### PR TITLE
feat: Phase 2 — Full CLI + Launcher Crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/amplihack-types",
     "crates/amplihack-state",
     "crates/amplihack-hooks",
+    "crates/amplihack-cli",
     "bins/amplihack",
     "bins/amplihack-hooks",
 ]
@@ -23,11 +24,15 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tempfile = "3"
 shell-words = "1"
+clap = { version = "4", features = ["derive"] }
+signal-hook = "0.3"
+libc = "0.2"
 
 # Workspace crate cross-references
 amplihack-types = { path = "crates/amplihack-types" }
 amplihack-state = { path = "crates/amplihack-state" }
 amplihack-hooks = { path = "crates/amplihack-hooks" }
+amplihack-cli = { path = "crates/amplihack-cli" }
 
 [profile.release]
 lto = true

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -13,8 +13,9 @@ path = "src/main.rs"
 amplihack-types = { workspace = true }
 amplihack-state = { workspace = true }
 amplihack-hooks = { workspace = true }
+amplihack-cli = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-clap = { version = "4", features = ["derive"] }
+clap = { workspace = true }

--- a/bins/amplihack/src/main.rs
+++ b/bins/amplihack/src/main.rs
@@ -1,47 +1,22 @@
 //! CLI binary for amplihack.
 //!
-//! Placeholder for Phase 2 — CLI + launcher implementation.
-//! Currently just provides version info and help.
+//! Entry point that parses CLI arguments via amplihack-cli
+//! and dispatches to the appropriate command handler.
 
+use amplihack_cli::Cli;
+use amplihack_cli::commands;
 use clap::Parser;
 
-/// amplihack CLI — Rust core runtime for deterministic infrastructure.
-#[derive(Parser, Debug)]
-#[command(name = "amplihack", version, about)]
-enum Cli {
-    /// Show version information.
-    Version,
-
-    /// Run hooks comparison (development tool).
-    #[command(subcommand)]
-    Hooks(HooksCmd),
-}
-
-#[derive(Parser, Debug)]
-enum HooksCmd {
-    /// Compare Python and Rust hook output for a given input.
-    Compare {
-        /// Path to the input JSON file.
-        #[arg(short, long)]
-        input: Option<String>,
-    },
-}
-
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_target(false)
+        .init();
+
     let cli = Cli::parse();
 
-    match cli {
-        Cli::Version => {
-            println!("amplihack-rs {}", env!("CARGO_PKG_VERSION"));
-        }
-        Cli::Hooks(cmd) => match cmd {
-            HooksCmd::Compare { input } => {
-                println!(
-                    "Hook comparison tool (input: {})",
-                    input.as_deref().unwrap_or("stdin")
-                );
-                println!("TODO: Implement in Phase 2");
-            }
-        },
+    if let Err(e) = commands::dispatch(cli.command) {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
     }
 }

--- a/crates/amplihack-cli/Cargo.toml
+++ b/crates/amplihack-cli/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "amplihack-cli"
+description = "CLI command parsing, launcher, and process management for amplihack"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+amplihack-types = { workspace = true }
+amplihack-state = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+libc = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+signal-hook = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/amplihack-cli/src/binary_finder.rs
+++ b/crates/amplihack-cli/src/binary_finder.rs
@@ -1,0 +1,230 @@
+//! Binary finder — locates tool binaries (claude, copilot, codex, amplifier) in PATH.
+//!
+//! Uses `which`-style lookup with version verification. No fallbacks:
+//! if the binary isn't found, we error out.
+
+use anyhow::{Result, bail};
+use std::collections::HashSet;
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Metadata about a discovered binary.
+#[derive(Debug, Clone)]
+pub struct BinaryInfo {
+    /// Tool name (e.g., "claude").
+    pub name: String,
+    /// Absolute path to the binary.
+    pub path: PathBuf,
+    /// Version string if available.
+    pub version: Option<String>,
+}
+
+/// Finds tool binaries on the system PATH.
+pub struct BinaryFinder;
+
+impl BinaryFinder {
+    /// Find a tool binary by name.
+    ///
+    /// Search order:
+    /// 1. `AMPLIHACK_{TOOL}_BINARY_PATH` env var (exact override)
+    /// 2. PATH search for known binary names
+    ///
+    /// Errors if the binary is not found. No fallbacks.
+    pub fn find(tool: &str) -> Result<BinaryInfo> {
+        let tool_upper = tool.to_uppercase();
+
+        // Check explicit override env var
+        let env_key = format!("AMPLIHACK_{tool_upper}_BINARY_PATH");
+        if let Ok(explicit_path) = env::var(&env_key) {
+            let path = PathBuf::from(&explicit_path);
+            if path.exists() {
+                let version = detect_version(&path);
+                return Ok(BinaryInfo {
+                    name: tool.to_string(),
+                    path,
+                    version,
+                });
+            }
+            bail!("{env_key}={explicit_path} does not exist");
+        }
+
+        // Search PATH for known binary names
+        let candidates = binary_candidates(tool);
+        let path_dirs = search_path_dirs();
+
+        for candidate in &candidates {
+            for dir in &path_dirs {
+                let full_path = dir.join(candidate);
+                if full_path.is_file() && is_executable(&full_path) {
+                    let version = detect_version(&full_path);
+                    return Ok(BinaryInfo {
+                        name: tool.to_string(),
+                        path: full_path,
+                        version,
+                    });
+                }
+            }
+        }
+
+        bail!(
+            "binary for '{tool}' not found in PATH (searched for: {})",
+            candidates.join(", ")
+        );
+    }
+
+    /// List all tool binaries found in PATH (for diagnostics).
+    pub fn find_all(tool: &str) -> Vec<BinaryInfo> {
+        let candidates = binary_candidates(tool);
+        let path_dirs = search_path_dirs();
+        let mut results = Vec::new();
+
+        for candidate in &candidates {
+            for dir in &path_dirs {
+                let full_path = dir.join(candidate);
+                if full_path.is_file() && is_executable(&full_path) {
+                    let version = detect_version(&full_path);
+                    results.push(BinaryInfo {
+                        name: tool.to_string(),
+                        path: full_path,
+                        version,
+                    });
+                }
+            }
+        }
+
+        results
+    }
+}
+
+/// Return candidate binary names for a tool.
+fn binary_candidates(tool: &str) -> Vec<String> {
+    match tool {
+        "claude" => vec!["rustyclawd".to_string(), "claude".to_string()],
+        "copilot" => vec!["copilot".to_string()],
+        "codex" => vec!["codex".to_string()],
+        "amplifier" => vec!["amplifier".to_string()],
+        other => vec![other.to_string()],
+    }
+}
+
+/// Collect PATH directories into a de-duplicated, ordered Vec.
+fn search_path_dirs() -> Vec<PathBuf> {
+    let path_var = env::var("PATH").unwrap_or_default();
+    let mut seen = HashSet::new();
+    let mut dirs = Vec::new();
+
+    for entry in env::split_paths(&path_var) {
+        if seen.insert(entry.clone()) {
+            dirs.push(entry);
+        }
+    }
+
+    dirs
+}
+
+/// Run `binary --version` and extract a version string.
+fn detect_version(path: &Path) -> Option<String> {
+    let output = Command::new(path).arg("--version").output().ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Extract version-like string: first line, or the part after the last space.
+    let first_line = stdout.lines().next()?.trim();
+    Some(first_line.to_string())
+}
+
+/// Check if a path is executable (Unix: has execute bit).
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_candidates_claude() {
+        let candidates = binary_candidates("claude");
+        assert!(candidates.contains(&"rustyclawd".to_string()));
+        assert!(candidates.contains(&"claude".to_string()));
+    }
+
+    #[test]
+    fn binary_candidates_unknown_tool() {
+        let candidates = binary_candidates("newtool");
+        assert_eq!(candidates, vec!["newtool"]);
+    }
+
+    #[test]
+    fn search_path_dirs_deduplicates() {
+        // PATH deduplication is deterministic
+        let dirs = search_path_dirs();
+        let unique: HashSet<_> = dirs.iter().collect();
+        assert_eq!(dirs.len(), unique.len());
+    }
+
+    #[test]
+    fn find_echo_binary() {
+        // `echo` should be findable on any Unix system
+        let result = BinaryFinder::find("echo");
+        if let Ok(info) = result {
+            assert!(info.path.exists());
+            assert_eq!(info.name, "echo");
+        }
+        // If not found (unlikely), that's fine for a test
+    }
+
+    #[test]
+    fn find_nonexistent_binary_errors() {
+        let result = BinaryFinder::find("definitely_not_a_real_binary_xyz_123");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn explicit_env_override() {
+        // Set an explicit override pointing to /bin/echo
+        let echo_path = if Path::new("/usr/bin/echo").exists() {
+            "/usr/bin/echo"
+        } else if Path::new("/bin/echo").exists() {
+            "/bin/echo"
+        } else {
+            return; // Skip test if echo not found
+        };
+
+        // SAFETY: Test-only env var manipulation; test runner serializes tests by default.
+        unsafe { env::set_var("AMPLIHACK_TESTTOOL_BINARY_PATH", echo_path) };
+        let result = BinaryFinder::find("testtool");
+        unsafe { env::remove_var("AMPLIHACK_TESTTOOL_BINARY_PATH") };
+
+        let info = result.unwrap();
+        assert_eq!(info.path, PathBuf::from(echo_path));
+    }
+
+    #[test]
+    fn explicit_env_override_nonexistent_errors() {
+        // SAFETY: Test-only env var manipulation; test runner serializes tests by default.
+        unsafe {
+            env::set_var(
+                "AMPLIHACK_BADTOOL_BINARY_PATH",
+                "/nonexistent/path/to/binary",
+            );
+        }
+        let result = BinaryFinder::find("badtool");
+        unsafe { env::remove_var("AMPLIHACK_BADTOOL_BINARY_PATH") };
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/amplihack-cli/src/commands/install.rs
+++ b/crates/amplihack-cli/src/commands/install.rs
@@ -1,0 +1,57 @@
+//! Install and uninstall commands.
+//!
+//! These delegate to `python -m amplihack.cli install/uninstall` for now,
+//! since the full install logic lives in Python.
+
+use anyhow::{Context, Result};
+use std::process::Command;
+
+/// Run `amplihack install` via Python.
+pub fn run_install() -> Result<()> {
+    delegate_to_python(&["install"])
+}
+
+/// Run `amplihack uninstall` via Python.
+pub fn run_uninstall() -> Result<()> {
+    delegate_to_python(&["uninstall"])
+}
+
+fn delegate_to_python(args: &[&str]) -> Result<()> {
+    let status = Command::new("python3")
+        .arg("-m")
+        .arg("amplihack.cli")
+        .args(args)
+        .status()
+        .context("failed to spawn python3 -m amplihack.cli")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "python3 -m amplihack.cli {} exited with status {}",
+            args.join(" "),
+            status
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delegate_to_python_constructs_correct_command() {
+        // Verify argument assembly (we can't run the actual Python command in tests,
+        // but we can verify the function doesn't panic with missing args).
+        let result = Command::new("python3")
+            .arg("-m")
+            .arg("amplihack.cli")
+            .arg("--help")
+            .output();
+        // If python3 is available, the command should at least execute.
+        // If not, the test is a no-op (CI might not have amplihack installed).
+        if let Ok(output) = result {
+            // --help should exit 0 or 2 (argparse), not crash
+            assert!(output.status.code().is_some());
+        }
+    }
+}

--- a/crates/amplihack-cli/src/commands/launch.rs
+++ b/crates/amplihack-cli/src/commands/launch.rs
@@ -1,0 +1,146 @@
+//! Launch commands for Claude, Copilot, Codex, and Amplifier.
+//!
+//! Builds the environment, finds the binary, checks nesting, and spawns
+//! a `ManagedChild` with signal forwarding.
+
+use crate::binary_finder::{BinaryFinder, BinaryInfo};
+use crate::env_builder::EnvBuilder;
+use crate::launcher::ManagedChild;
+use crate::nesting::NestingDetector;
+use crate::signals;
+use anyhow::{Context, Result};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+/// Launch a tool binary (claude, copilot, codex, amplifier).
+pub fn run_launch(
+    tool: &str,
+    resume: bool,
+    continue_session: bool,
+    extra_args: Vec<String>,
+) -> Result<()> {
+    // Check nesting
+    let nesting = NestingDetector::detect();
+    match &nesting {
+        crate::nesting::NestingResult::Nested {
+            session_id, depth, ..
+        } => {
+            tracing::warn!(
+                session_id,
+                depth,
+                "nested amplihack session detected — launching anyway"
+            );
+        }
+        crate::nesting::NestingResult::StaleSession { session_id } => {
+            tracing::info!(session_id, "stale session detected, ignoring");
+        }
+        crate::nesting::NestingResult::NotNested => {}
+    }
+
+    // Find binary
+    let binary = BinaryFinder::find(tool)
+        .with_context(|| format!("could not find '{tool}' binary in PATH"))?;
+
+    tracing::info!(
+        binary = %binary.path.display(),
+        version = binary.version.as_deref().unwrap_or("unknown"),
+        "launching {tool}"
+    );
+
+    // Build environment
+    let env = EnvBuilder::new()
+        .with_amplihack_session_id()
+        .with_amplihack_vars()
+        .build();
+
+    // Build command
+    let mut cmd = build_command(&binary, resume, continue_session, &extra_args);
+    cmd.envs(env);
+
+    // Register signal handlers
+    let shutdown = signals::register_handlers()?;
+
+    // Spawn child in its own process group
+    let mut child = ManagedChild::spawn(cmd)?;
+
+    // Wait for child or signal
+    let exit_code = wait_for_child_or_signal(&mut child, &shutdown)?;
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+fn build_command(
+    binary: &BinaryInfo,
+    resume: bool,
+    continue_session: bool,
+    extra_args: &[String],
+) -> Command {
+    let mut cmd = Command::new(&binary.path);
+    if resume {
+        cmd.arg("--resume");
+    }
+    if continue_session {
+        cmd.arg("--continue");
+    }
+    cmd.args(extra_args);
+    cmd
+}
+
+fn wait_for_child_or_signal(
+    child: &mut ManagedChild,
+    shutdown: &Arc<std::sync::atomic::AtomicBool>,
+) -> Result<i32> {
+    loop {
+        // Check if we received a shutdown signal
+        if shutdown.load(Ordering::Relaxed) {
+            tracing::info!("shutdown signal received, terminating child process");
+            // ManagedChild::drop handles graceful shutdown
+            return Ok(130); // standard SIGINT exit code
+        }
+
+        // Check if child has exited
+        match child.try_wait()? {
+            Some(status) => {
+                return Ok(status.code().unwrap_or(1));
+            }
+            None => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn build_command_basic() {
+        let binary = BinaryInfo {
+            name: "claude".to_string(),
+            path: PathBuf::from("/usr/bin/claude"),
+            version: Some("1.0.0".to_string()),
+        };
+        let cmd = build_command(&binary, false, false, &[]);
+        assert_eq!(cmd.get_program(), "/usr/bin/claude");
+        assert_eq!(cmd.get_args().count(), 0);
+    }
+
+    #[test]
+    fn build_command_with_flags() {
+        let binary = BinaryInfo {
+            name: "claude".to_string(),
+            path: PathBuf::from("/usr/bin/claude"),
+            version: None,
+        };
+        let extra = vec!["--model".to_string(), "opus".to_string()];
+        let cmd = build_command(&binary, true, true, &extra);
+        let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
+        assert_eq!(args, &["--resume", "--continue", "--model", "opus"]);
+    }
+}

--- a/crates/amplihack-cli/src/commands/memory.rs
+++ b/crates/amplihack-cli/src/commands/memory.rs
@@ -1,0 +1,42 @@
+//! Memory commands — delegated to Python.
+
+use anyhow::{Context, Result};
+use std::process::Command;
+
+fn delegate(args: &[&str]) -> Result<()> {
+    let status = Command::new("python3")
+        .arg("-m")
+        .arg("amplihack.cli")
+        .arg("memory")
+        .args(args)
+        .status()
+        .context("failed to spawn python3 -m amplihack.cli memory")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "amplihack memory {} exited with status {}",
+            args.join(" "),
+            status
+        );
+    }
+    Ok(())
+}
+
+pub fn run_tree() -> Result<()> {
+    delegate(&["tree"])
+}
+
+pub fn run_export(output: Option<&str>) -> Result<()> {
+    match output {
+        Some(path) => delegate(&["export", "--output", path]),
+        None => delegate(&["export"]),
+    }
+}
+
+pub fn run_import(file: &str) -> Result<()> {
+    delegate(&["import", file])
+}
+
+pub fn run_clean() -> Result<()> {
+    delegate(&["clean"])
+}

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -1,0 +1,71 @@
+//! Command dispatch for all CLI subcommands.
+
+pub mod install;
+pub mod launch;
+pub mod memory;
+pub mod mode;
+pub mod plugin;
+pub mod recipe;
+
+use crate::{Commands, MemoryCommands, ModeCommands, PluginCommands, RecipeCommands};
+use anyhow::Result;
+
+/// Dispatch a parsed CLI command to the appropriate handler.
+pub fn dispatch(command: Commands) -> Result<()> {
+    match command {
+        Commands::Install => install::run_install(),
+        Commands::Uninstall => install::run_uninstall(),
+        Commands::Launch {
+            resume,
+            continue_session,
+            claude_args,
+        } => launch::run_launch("claude", resume, continue_session, claude_args),
+        Commands::Claude { claude_args } => launch::run_launch("claude", false, false, claude_args),
+        Commands::Copilot { args } => launch::run_launch("copilot", false, false, args),
+        Commands::Codex { args } => launch::run_launch("codex", false, false, args),
+        Commands::Amplifier { args } => launch::run_launch("amplifier", false, false, args),
+        Commands::Plugin { command } => dispatch_plugin(command),
+        Commands::Memory { command } => dispatch_memory(command),
+        Commands::Recipe { command } => dispatch_recipe(command),
+        Commands::Mode { command } => dispatch_mode(command),
+        Commands::Version => {
+            println!("amplihack-rs {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+    }
+}
+
+fn dispatch_plugin(command: PluginCommands) -> Result<()> {
+    match command {
+        PluginCommands::Install { name } => plugin::run_install(&name),
+        PluginCommands::Uninstall { name } => plugin::run_uninstall(&name),
+        PluginCommands::Link { path } => plugin::run_link(&path),
+        PluginCommands::Verify => plugin::run_verify(),
+    }
+}
+
+fn dispatch_memory(command: MemoryCommands) -> Result<()> {
+    match command {
+        MemoryCommands::Tree => memory::run_tree(),
+        MemoryCommands::Export { output } => memory::run_export(output.as_deref()),
+        MemoryCommands::Import { file } => memory::run_import(&file),
+        MemoryCommands::Clean => memory::run_clean(),
+    }
+}
+
+fn dispatch_recipe(command: RecipeCommands) -> Result<()> {
+    match command {
+        RecipeCommands::Run { name, args } => recipe::run_recipe(&name, &args),
+        RecipeCommands::List => recipe::run_list(),
+        RecipeCommands::Validate { file } => recipe::run_validate(&file),
+        RecipeCommands::Show { name } => recipe::run_show(&name),
+    }
+}
+
+fn dispatch_mode(command: ModeCommands) -> Result<()> {
+    match command {
+        ModeCommands::Detect => mode::run_detect(),
+        ModeCommands::ToPlugin => mode::run_to_plugin(),
+        ModeCommands::ToLocal => mode::run_to_local(),
+    }
+}

--- a/crates/amplihack-cli/src/commands/mode.rs
+++ b/crates/amplihack-cli/src/commands/mode.rs
@@ -1,0 +1,35 @@
+//! Mode commands — delegated to Python.
+
+use anyhow::{Context, Result};
+use std::process::Command;
+
+fn delegate(args: &[&str]) -> Result<()> {
+    let status = Command::new("python3")
+        .arg("-m")
+        .arg("amplihack.cli")
+        .arg("mode")
+        .args(args)
+        .status()
+        .context("failed to spawn python3 -m amplihack.cli mode")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "amplihack mode {} exited with status {}",
+            args.join(" "),
+            status
+        );
+    }
+    Ok(())
+}
+
+pub fn run_detect() -> Result<()> {
+    delegate(&["detect"])
+}
+
+pub fn run_to_plugin() -> Result<()> {
+    delegate(&["to-plugin"])
+}
+
+pub fn run_to_local() -> Result<()> {
+    delegate(&["to-local"])
+}

--- a/crates/amplihack-cli/src/commands/plugin.rs
+++ b/crates/amplihack-cli/src/commands/plugin.rs
@@ -1,0 +1,39 @@
+//! Plugin commands — delegated to Python.
+
+use anyhow::{Context, Result};
+use std::process::Command;
+
+fn delegate(args: &[&str]) -> Result<()> {
+    let status = Command::new("python3")
+        .arg("-m")
+        .arg("amplihack.cli")
+        .arg("plugin")
+        .args(args)
+        .status()
+        .context("failed to spawn python3 -m amplihack.cli plugin")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "amplihack plugin {} exited with status {}",
+            args.join(" "),
+            status
+        );
+    }
+    Ok(())
+}
+
+pub fn run_install(name: &str) -> Result<()> {
+    delegate(&["install", name])
+}
+
+pub fn run_uninstall(name: &str) -> Result<()> {
+    delegate(&["uninstall", name])
+}
+
+pub fn run_link(path: &str) -> Result<()> {
+    delegate(&["link", path])
+}
+
+pub fn run_verify() -> Result<()> {
+    delegate(&["verify"])
+}

--- a/crates/amplihack-cli/src/commands/recipe.rs
+++ b/crates/amplihack-cli/src/commands/recipe.rs
@@ -1,0 +1,42 @@
+//! Recipe commands — delegated to Python.
+
+use anyhow::{Context, Result};
+use std::process::Command;
+
+fn delegate(args: &[&str]) -> Result<()> {
+    let status = Command::new("python3")
+        .arg("-m")
+        .arg("amplihack.cli")
+        .arg("recipe")
+        .args(args)
+        .status()
+        .context("failed to spawn python3 -m amplihack.cli recipe")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "amplihack recipe {} exited with status {}",
+            args.join(" "),
+            status
+        );
+    }
+    Ok(())
+}
+
+pub fn run_recipe(name: &str, args: &[String]) -> Result<()> {
+    let mut cmd_args = vec!["run", name];
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    cmd_args.extend(arg_refs);
+    delegate(&cmd_args)
+}
+
+pub fn run_list() -> Result<()> {
+    delegate(&["list"])
+}
+
+pub fn run_validate(file: &str) -> Result<()> {
+    delegate(&["validate", file])
+}
+
+pub fn run_show(name: &str) -> Result<()> {
+    delegate(&["show", name])
+}

--- a/crates/amplihack-cli/src/env_builder.rs
+++ b/crates/amplihack-cli/src/env_builder.rs
@@ -1,0 +1,182 @@
+//! Type-safe environment builder for launching child processes.
+//!
+//! Constructs the environment variables needed by launched tools,
+//! including AMPLIHACK_* vars and PATH augmentation. Uses set-based
+//! PATH deduplication instead of error-prone substring matching.
+
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::path::PathBuf;
+
+/// Builder for constructing the environment passed to child processes.
+#[derive(Debug)]
+pub struct EnvBuilder {
+    vars: HashMap<String, String>,
+    path_prepend: Vec<PathBuf>,
+}
+
+impl EnvBuilder {
+    pub fn new() -> Self {
+        Self {
+            vars: HashMap::new(),
+            path_prepend: Vec::new(),
+        }
+    }
+
+    /// Set a specific environment variable.
+    pub fn set(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.vars.insert(key.into(), value.into());
+        self
+    }
+
+    /// Prepend a directory to PATH (deduplicated).
+    pub fn prepend_path(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.path_prepend.push(dir.into());
+        self
+    }
+
+    /// Add AMPLIHACK_SESSION_ID (generate a new one if not already set).
+    pub fn with_amplihack_session_id(self) -> Self {
+        let session_id = env::var("AMPLIHACK_SESSION_ID").unwrap_or_else(|_| generate_session_id());
+        let depth: u32 = env::var("AMPLIHACK_DEPTH")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+
+        self.set("AMPLIHACK_SESSION_ID", session_id)
+            .set("AMPLIHACK_DEPTH", (depth + 1).to_string())
+    }
+
+    /// Add standard AMPLIHACK_* variables.
+    pub fn with_amplihack_vars(self) -> Self {
+        self.set("AMPLIHACK_RUST_RUNTIME", "1")
+            .set("AMPLIHACK_VERSION", env!("CARGO_PKG_VERSION"))
+    }
+
+    /// Build the final environment as key-value pairs.
+    ///
+    /// The returned map includes only the variables explicitly set via this builder,
+    /// plus the augmented PATH. The child process inherits the rest from the parent.
+    pub fn build(self) -> HashMap<String, String> {
+        let mut result = self.vars;
+
+        // Build augmented PATH
+        if !self.path_prepend.is_empty() {
+            let current_path = env::var("PATH").unwrap_or_default();
+            let new_path = build_path(&self.path_prepend, &current_path);
+            result.insert("PATH".to_string(), new_path);
+        }
+
+        result
+    }
+}
+
+impl Default for EnvBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Build a PATH string by prepending directories and deduplicating.
+fn build_path(prepend: &[PathBuf], current: &str) -> String {
+    let mut seen = HashSet::new();
+    let mut parts = Vec::new();
+
+    // Prepend entries first (higher priority)
+    for dir in prepend {
+        let s = dir.to_string_lossy().to_string();
+        if seen.insert(s.clone()) {
+            parts.push(s);
+        }
+    }
+
+    // Then existing PATH entries
+    for entry in env::split_paths(current) {
+        let s = entry.to_string_lossy().to_string();
+        if seen.insert(s.clone()) {
+            parts.push(s);
+        }
+    }
+
+    env::join_paths(parts.iter().map(|s| s.as_str()))
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default()
+}
+
+/// Generate a simple session ID (timestamp + PID).
+fn generate_session_id() -> String {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("rs-{}-{}", ts, std::process::id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_builder_produces_empty_map() {
+        let env = EnvBuilder::new().build();
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn set_adds_variable() {
+        let env = EnvBuilder::new()
+            .set("FOO", "bar")
+            .set("BAZ", "qux")
+            .build();
+        assert_eq!(env.get("FOO").unwrap(), "bar");
+        assert_eq!(env.get("BAZ").unwrap(), "qux");
+    }
+
+    #[test]
+    fn prepend_path_deduplicates() {
+        let env = EnvBuilder::new()
+            .prepend_path("/opt/bin")
+            .prepend_path("/opt/bin") // duplicate
+            .build();
+
+        let path = env.get("PATH").unwrap();
+        let count = path.matches("/opt/bin").count();
+        assert_eq!(count, 1, "PATH should not contain duplicates");
+    }
+
+    #[test]
+    fn with_amplihack_session_id_sets_vars() {
+        let env = EnvBuilder::new().with_amplihack_session_id().build();
+        assert!(env.contains_key("AMPLIHACK_SESSION_ID"));
+        assert!(env.contains_key("AMPLIHACK_DEPTH"));
+    }
+
+    #[test]
+    fn with_amplihack_vars_sets_runtime_flag() {
+        let env = EnvBuilder::new().with_amplihack_vars().build();
+        assert_eq!(env.get("AMPLIHACK_RUST_RUNTIME").unwrap(), "1");
+        assert!(env.contains_key("AMPLIHACK_VERSION"));
+    }
+
+    #[test]
+    fn generate_session_id_format() {
+        let id = generate_session_id();
+        assert!(
+            id.starts_with("rs-"),
+            "session ID should start with 'rs-': {id}"
+        );
+    }
+
+    #[test]
+    fn build_path_preserves_order() {
+        let path = build_path(
+            &[PathBuf::from("/first"), PathBuf::from("/second")],
+            "/third:/fourth",
+        );
+        let parts: Vec<&str> = path.split(':').collect();
+        assert_eq!(parts[0], "/first");
+        assert_eq!(parts[1], "/second");
+        assert_eq!(parts[2], "/third");
+        assert_eq!(parts[3], "/fourth");
+    }
+}

--- a/crates/amplihack-cli/src/launcher.rs
+++ b/crates/amplihack-cli/src/launcher.rs
@@ -1,0 +1,165 @@
+//! Process launcher with managed child and graceful shutdown.
+//!
+//! `ManagedChild` wraps `std::process::Child` with a bounded `Drop`
+//! implementation that sends SIGTERM, waits up to 3 seconds, then
+//! sends SIGKILL.
+
+use anyhow::{Context, Result};
+use std::process::{Child, Command, ExitStatus};
+use std::time::{Duration, Instant};
+
+/// A child process wrapper with graceful shutdown on drop.
+///
+/// On drop:
+/// 1. If the child already exited, do nothing.
+/// 2. Send SIGTERM (Unix) or kill (Windows).
+/// 3. Wait up to 3 seconds for graceful exit.
+/// 4. If still alive, SIGKILL + wait.
+pub struct ManagedChild {
+    child: Child,
+}
+
+impl ManagedChild {
+    /// Spawn a command in its own process group (Unix: setpgid).
+    pub fn spawn(mut cmd: Command) -> Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            // SAFETY: setpgid(0, 0) is async-signal-safe and called pre-exec
+            // to place the child in its own process group, preventing the parent's
+            // SIGINT from reaching the child directly.
+            unsafe {
+                cmd.pre_exec(|| {
+                    libc::setpgid(0, 0);
+                    Ok(())
+                });
+            }
+        }
+
+        let child = cmd.spawn().context("failed to spawn child process")?;
+        tracing::debug!(pid = child.id(), "spawned managed child");
+        Ok(Self { child })
+    }
+
+    /// Non-blocking check: has the child exited?
+    pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+        self.child
+            .try_wait()
+            .context("failed to check child status")
+    }
+
+    /// Blocking wait until child exits.
+    pub fn wait(&mut self) -> Result<ExitStatus> {
+        self.child.wait().context("failed to wait for child")
+    }
+
+    /// Get the child's PID.
+    pub fn id(&self) -> u32 {
+        self.child.id()
+    }
+
+    /// Explicitly terminate the child (SIGTERM → wait → SIGKILL).
+    pub fn terminate(&mut self) {
+        self.graceful_shutdown();
+    }
+
+    fn graceful_shutdown(&mut self) {
+        // Already exited?
+        if matches!(self.child.try_wait(), Ok(Some(_))) {
+            return;
+        }
+
+        // Send SIGTERM
+        #[cfg(unix)]
+        {
+            // SAFETY: We're sending a standard signal to a process we own.
+            // The PID is valid because try_wait() above confirmed the child is still running.
+            unsafe {
+                libc::kill(self.child.id() as i32, libc::SIGTERM);
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = self.child.kill();
+        }
+
+        // Wait up to 3 seconds for graceful exit
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline {
+            if matches!(self.child.try_wait(), Ok(Some(_))) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // Force kill
+        tracing::warn!(
+            pid = self.child.id(),
+            "child did not exit gracefully, sending SIGKILL"
+        );
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for ManagedChild {
+    fn drop(&mut self) {
+        self.graceful_shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_and_wait_for_exit() {
+        let cmd = Command::new("echo");
+        let mut child = ManagedChild::spawn(cmd).unwrap();
+        let status = child.wait().unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    fn try_wait_returns_none_while_running() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("10");
+        let mut child = ManagedChild::spawn(cmd).unwrap();
+
+        // Should not have exited yet
+        let result = child.try_wait().unwrap();
+        assert!(result.is_none());
+
+        // Drop will clean up (SIGTERM → SIGKILL)
+    }
+
+    #[test]
+    fn drop_terminates_running_process() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("60");
+        let child = ManagedChild::spawn(cmd).unwrap();
+        let pid = child.id();
+
+        // Drop the child — should terminate it
+        drop(child);
+
+        // Verify process is gone (on Unix)
+        #[cfg(unix)]
+        {
+            // SAFETY: Sending signal 0 to check if a process exists is a standard
+            // POSIX pattern and is safe for any PID value.
+            let result = unsafe { libc::kill(pid as i32, 0) };
+            assert_eq!(result, -1, "process should be dead after drop");
+        }
+    }
+
+    #[test]
+    fn managed_child_id() {
+        let cmd = Command::new("sleep");
+        let mut cmd = cmd;
+        cmd.arg("0.1");
+        let child = ManagedChild::spawn(cmd).unwrap();
+        assert!(child.id() > 0);
+    }
+}

--- a/crates/amplihack-cli/src/lib.rs
+++ b/crates/amplihack-cli/src/lib.rs
@@ -1,0 +1,167 @@
+//! CLI command parsing, launcher, and process management for amplihack.
+//!
+//! This crate provides the full CLI experience: argument parsing via clap derive,
+//! binary discovery, environment construction, process management with signal
+//! handling, and nesting detection.
+
+pub mod binary_finder;
+pub mod commands;
+pub mod env_builder;
+pub mod launcher;
+pub mod nesting;
+pub mod settings_manager;
+pub mod signals;
+
+use clap::{Parser, Subcommand};
+
+/// amplihack CLI — Rust core runtime.
+#[derive(Parser, Debug)]
+#[command(
+    name = "amplihack",
+    version,
+    about = "amplihack CLI — Rust core runtime"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Install amplihack agents and tools to ~/.claude
+    Install,
+    /// Remove amplihack agents and tools
+    Uninstall,
+    /// Launch Claude Code
+    Launch {
+        /// Resume the previous session
+        #[arg(long)]
+        resume: bool,
+        /// Continue the previous session
+        #[arg(long)]
+        continue_session: bool,
+        /// Extra args passed to claude
+        #[arg(trailing_var_arg = true)]
+        claude_args: Vec<String>,
+    },
+    /// Launch Claude Code (alias)
+    Claude {
+        /// Extra args passed to claude
+        #[arg(trailing_var_arg = true)]
+        claude_args: Vec<String>,
+    },
+    /// Launch GitHub Copilot CLI
+    Copilot {
+        /// Extra args passed to copilot
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+    /// Launch OpenAI Codex CLI
+    Codex {
+        /// Extra args passed to codex
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+    /// Launch Amplifier
+    Amplifier {
+        /// Extra args passed to amplifier
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+    /// Plugin management
+    Plugin {
+        #[command(subcommand)]
+        command: PluginCommands,
+    },
+    /// Memory system commands
+    Memory {
+        #[command(subcommand)]
+        command: MemoryCommands,
+    },
+    /// Recipe management
+    Recipe {
+        #[command(subcommand)]
+        command: RecipeCommands,
+    },
+    /// Mode management
+    Mode {
+        #[command(subcommand)]
+        command: ModeCommands,
+    },
+    /// Show version information
+    Version,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PluginCommands {
+    /// Install a plugin
+    Install {
+        /// Plugin name or path
+        name: String,
+    },
+    /// Uninstall a plugin
+    Uninstall {
+        /// Plugin name
+        name: String,
+    },
+    /// Link a local plugin for development
+    Link {
+        /// Path to the plugin directory
+        path: String,
+    },
+    /// Verify installed plugins
+    Verify,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum MemoryCommands {
+    /// Show memory tree
+    Tree,
+    /// Export memory to file
+    Export {
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+    },
+    /// Import memory from file
+    Import {
+        /// Input file path
+        file: String,
+    },
+    /// Clean stale memory entries
+    Clean,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RecipeCommands {
+    /// Run a recipe
+    Run {
+        /// Recipe name
+        name: String,
+        /// Extra args passed to the recipe
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+    /// List available recipes
+    List,
+    /// Validate a recipe file
+    Validate {
+        /// Recipe file path
+        file: String,
+    },
+    /// Show recipe details
+    Show {
+        /// Recipe name
+        name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ModeCommands {
+    /// Detect current mode
+    Detect,
+    /// Switch to plugin mode
+    ToPlugin,
+    /// Switch to local mode
+    ToLocal,
+}

--- a/crates/amplihack-cli/src/nesting.rs
+++ b/crates/amplihack-cli/src/nesting.rs
@@ -1,0 +1,265 @@
+//! Nesting detection — prevents accidental recursive amplihack sessions.
+//!
+//! Detection strategy:
+//! 1. Primary: Check `AMPLIHACK_SESSION_ID` env var — if set, we're nested.
+//! 2. Secondary: Check session file with PID + timestamp in `~/.claude/runtime/`.
+//! 3. Stale detection: If holder PID is dead AND session is >1h old, consider stale.
+
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Result of nesting detection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NestingResult {
+    /// Not inside another amplihack session.
+    NotNested,
+    /// Inside an existing amplihack session.
+    Nested {
+        /// The parent session's ID.
+        session_id: String,
+        /// Nesting depth (1 = first nested, 2 = doubly nested, etc.).
+        depth: u32,
+    },
+    /// A session file exists but the holder process is dead and session is stale.
+    StaleSession {
+        /// The stale session's ID.
+        session_id: String,
+    },
+}
+
+/// Session file format stored in `~/.claude/runtime/session.json`.
+#[derive(Debug, Serialize, Deserialize)]
+struct SessionFile {
+    session_id: String,
+    pid: u32,
+    timestamp: u64,
+}
+
+const SESSION_FILE_NAME: &str = "session.json";
+const STALE_THRESHOLD: Duration = Duration::from_secs(3600); // 1 hour
+
+/// Detects whether we are inside a nested amplihack session.
+pub struct NestingDetector;
+
+impl NestingDetector {
+    /// Detect nesting state.
+    pub fn detect() -> NestingResult {
+        // Primary: Check env var
+        if let Ok(session_id) = env::var("AMPLIHACK_SESSION_ID") {
+            let depth: u32 = env::var("AMPLIHACK_DEPTH")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(1);
+            return NestingResult::Nested { session_id, depth };
+        }
+
+        // Secondary: Check session file
+        if let Some(session_path) = session_file_path()
+            && let Ok(content) = std::fs::read_to_string(&session_path)
+            && let Ok(session) = serde_json::from_str::<SessionFile>(&content)
+        {
+            if is_process_alive(session.pid) {
+                return NestingResult::Nested {
+                    session_id: session.session_id,
+                    depth: 1,
+                };
+            }
+
+            // Process is dead — check staleness
+            if is_stale(session.timestamp) {
+                return NestingResult::StaleSession {
+                    session_id: session.session_id,
+                };
+            }
+
+            // Process dead but session is recent — assume nested
+            // (might have just crashed)
+            return NestingResult::Nested {
+                session_id: session.session_id,
+                depth: 1,
+            };
+        }
+
+        NestingResult::NotNested
+    }
+
+    /// Write a session file to claim the current session.
+    pub fn claim_session(session_id: &str) -> anyhow::Result<()> {
+        let session_path = session_file_path()
+            .ok_or_else(|| anyhow::anyhow!("could not determine HOME directory"))?;
+
+        if let Some(parent) = session_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let session = SessionFile {
+            session_id: session_id.to_string(),
+            pid: std::process::id(),
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        };
+
+        let content = serde_json::to_string_pretty(&session)?;
+        std::fs::write(&session_path, content)?;
+        Ok(())
+    }
+
+    /// Remove the session file (on clean exit).
+    pub fn release_session() {
+        if let Some(session_path) = session_file_path() {
+            let _ = std::fs::remove_file(session_path);
+        }
+    }
+}
+
+fn session_file_path() -> Option<PathBuf> {
+    env::var("HOME").ok().map(|h| {
+        PathBuf::from(h)
+            .join(".claude")
+            .join("runtime")
+            .join(SESSION_FILE_NAME)
+    })
+}
+
+/// Check if a process with the given PID is alive.
+#[cfg(unix)]
+fn is_process_alive(pid: u32) -> bool {
+    // SAFETY: kill(pid, 0) is a standard POSIX signal-safe way to check if
+    // a process exists without actually sending a signal.
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn is_process_alive(_pid: u32) -> bool {
+    // On non-Unix, assume alive (conservative)
+    true
+}
+
+fn is_stale(timestamp: u64) -> bool {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    now.saturating_sub(timestamp) > STALE_THRESHOLD.as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_nested_when_no_env_var() {
+        // SAFETY: Test-only env var manipulation; test runner serializes tests by default.
+        unsafe {
+            env::remove_var("AMPLIHACK_SESSION_ID");
+            env::remove_var("AMPLIHACK_DEPTH");
+        }
+
+        // Without a session file, should be NotNested
+        // (This test may report Nested if there's an actual session file,
+        // but in a clean test environment it should be NotNested.)
+        let result = NestingDetector::detect();
+        // We accept both NotNested and StaleSession in test environments
+        assert!(
+            matches!(
+                result,
+                NestingResult::NotNested | NestingResult::StaleSession { .. }
+            ),
+            "expected NotNested or StaleSession without env var, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn nested_when_env_var_set() {
+        // SAFETY: Test-only env var manipulation; test runner serializes tests by default.
+        unsafe {
+            env::set_var("AMPLIHACK_SESSION_ID", "test-session-123");
+            env::set_var("AMPLIHACK_DEPTH", "2");
+        }
+
+        let result = NestingDetector::detect();
+
+        // SAFETY: Cleanup after test.
+        unsafe {
+            env::remove_var("AMPLIHACK_SESSION_ID");
+            env::remove_var("AMPLIHACK_DEPTH");
+        }
+
+        assert!(matches!(
+            result,
+            NestingResult::Nested {
+                ref session_id,
+                depth: 2
+            } if session_id == "test-session-123"
+        ));
+    }
+
+    #[test]
+    fn is_stale_old_timestamp() {
+        let two_hours_ago = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - 7200;
+        assert!(is_stale(two_hours_ago));
+    }
+
+    #[test]
+    fn is_not_stale_recent_timestamp() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(!is_stale(now));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn current_process_is_alive() {
+        assert!(is_process_alive(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dead_process_is_not_alive() {
+        // PID 99999999 is almost certainly not alive
+        assert!(!is_process_alive(99_999_999));
+    }
+
+    #[test]
+    fn claim_and_release_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_path = dir
+            .path()
+            .join(".claude")
+            .join("runtime")
+            .join(SESSION_FILE_NAME);
+
+        // Override HOME for this test
+        let original_home = env::var("HOME").ok();
+        // SAFETY: Test-only env var manipulation; test runner serializes tests by default.
+        unsafe { env::set_var("HOME", dir.path()) };
+
+        NestingDetector::claim_session("test-claim").unwrap();
+        assert!(session_path.exists());
+
+        let content: SessionFile =
+            serde_json::from_str(&std::fs::read_to_string(&session_path).unwrap()).unwrap();
+        assert_eq!(content.session_id, "test-claim");
+        assert_eq!(content.pid, std::process::id());
+
+        NestingDetector::release_session();
+        assert!(!session_path.exists());
+
+        // Restore HOME
+        // SAFETY: Restoring original env var.
+        if let Some(home) = original_home {
+            unsafe { env::set_var("HOME", home) };
+        }
+    }
+}

--- a/crates/amplihack-cli/src/settings_manager.rs
+++ b/crates/amplihack-cli/src/settings_manager.rs
@@ -1,0 +1,171 @@
+//! Atomic settings.json CRUD using `AtomicJsonFile` from amplihack-state.
+//!
+//! Provides a high-level interface for reading and writing amplihack settings
+//! (both global `~/.claude/settings.json` and project-local `.claude/settings.json`).
+
+use amplihack_state::AtomicJsonFile;
+use amplihack_types::{ProjectDirs, Settings};
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+/// Manages settings.json files for amplihack.
+pub struct SettingsManager {
+    global: AtomicJsonFile,
+    local: Option<AtomicJsonFile>,
+}
+
+impl SettingsManager {
+    /// Create a settings manager for the global settings only.
+    pub fn global_only() -> Result<Self> {
+        let global_path = global_settings_path()
+            .context("could not determine global settings path (HOME not set)")?;
+        Ok(Self {
+            global: AtomicJsonFile::new(global_path),
+            local: None,
+        })
+    }
+
+    /// Create a settings manager for both global and project-local settings.
+    pub fn with_project(project_dirs: &ProjectDirs) -> Result<Self> {
+        let global_path = global_settings_path()
+            .context("could not determine global settings path (HOME not set)")?;
+        let local_path = project_dirs.claude.join("settings.json");
+        Ok(Self {
+            global: AtomicJsonFile::new(global_path),
+            local: Some(AtomicJsonFile::new(local_path)),
+        })
+    }
+
+    /// Read global settings. Returns default if file doesn't exist.
+    pub fn read_global(&self) -> Result<Settings> {
+        self.global
+            .read_or_default()
+            .context("failed to read global settings")
+    }
+
+    /// Read project-local settings. Returns default if file doesn't exist.
+    pub fn read_local(&self) -> Result<Option<Settings>> {
+        match &self.local {
+            Some(local) => local.read().context("failed to read local settings"),
+            None => Ok(None),
+        }
+    }
+
+    /// Write global settings atomically.
+    pub fn write_global(&self, settings: &Settings) -> Result<()> {
+        self.global
+            .write(settings)
+            .context("failed to write global settings")
+    }
+
+    /// Write project-local settings atomically.
+    pub fn write_local(&self, settings: &Settings) -> Result<()> {
+        let local = self
+            .local
+            .as_ref()
+            .context("no project-local settings configured")?;
+        local
+            .write(settings)
+            .context("failed to write local settings")
+    }
+
+    /// Update global settings with a mutation function.
+    pub fn update_global<F>(&self, f: F) -> Result<Settings>
+    where
+        F: FnOnce(&mut Settings),
+    {
+        self.global
+            .update(f)
+            .context("failed to update global settings")
+    }
+
+    /// Return the global settings file path.
+    pub fn global_path(&self) -> &std::path::Path {
+        self.global.path()
+    }
+}
+
+fn global_settings_path() -> Option<PathBuf> {
+    ProjectDirs::global_settings()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_global_returns_default_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = AtomicJsonFile::new(dir.path().join("settings.json"));
+        let mgr = SettingsManager {
+            global: file,
+            local: None,
+        };
+        let settings = mgr.read_global().unwrap();
+        assert!(settings.hooks.is_empty());
+    }
+
+    #[test]
+    fn write_and_read_global_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = AtomicJsonFile::new(dir.path().join("settings.json"));
+        let mgr = SettingsManager {
+            global: file,
+            local: None,
+        };
+
+        let mut settings = Settings::default();
+        settings
+            .extra
+            .insert("test_key".to_string(), serde_json::json!("test_value"));
+        mgr.write_global(&settings).unwrap();
+
+        let read = mgr.read_global().unwrap();
+        assert_eq!(read.extra.get("test_key").unwrap(), "test_value");
+    }
+
+    #[test]
+    fn update_global_modifies_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = AtomicJsonFile::new(dir.path().join("settings.json"));
+        let mgr = SettingsManager {
+            global: file,
+            local: None,
+        };
+
+        let result = mgr
+            .update_global(|s| {
+                s.extra
+                    .insert("updated".to_string(), serde_json::json!(true));
+            })
+            .unwrap();
+        assert_eq!(result.extra.get("updated").unwrap(), true);
+    }
+
+    #[test]
+    fn read_local_returns_none_without_project() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = AtomicJsonFile::new(dir.path().join("settings.json"));
+        let mgr = SettingsManager {
+            global: file,
+            local: None,
+        };
+        assert!(mgr.read_local().unwrap().is_none());
+    }
+
+    #[test]
+    fn local_settings_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let global_file = AtomicJsonFile::new(dir.path().join("global.json"));
+        let local_file = AtomicJsonFile::new(dir.path().join("local.json"));
+        let mgr = SettingsManager {
+            global: global_file,
+            local: Some(local_file),
+        };
+
+        let settings = Settings::default();
+        mgr.write_local(&settings).unwrap();
+        let read = mgr.read_local().unwrap();
+        assert!(read.is_some());
+    }
+}

--- a/crates/amplihack-cli/src/signals.rs
+++ b/crates/amplihack-cli/src/signals.rs
@@ -1,0 +1,61 @@
+//! Signal handling for the CLI launcher.
+//!
+//! Registers handlers for SIGINT, SIGTERM, and SIGHUP that set an
+//! `AtomicBool` flag, allowing the main loop to detect shutdown requests.
+
+use anyhow::{Context, Result};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+/// Register signal handlers that set a shared `AtomicBool` on shutdown signals.
+///
+/// Returns the `AtomicBool` that will be set to `true` when any of
+/// SIGINT, SIGTERM, or SIGHUP is received.
+pub fn register_handlers() -> Result<Arc<AtomicBool>> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    #[cfg(unix)]
+    {
+        for sig in [
+            signal_hook::consts::SIGINT,
+            signal_hook::consts::SIGTERM,
+            signal_hook::consts::SIGHUP,
+        ] {
+            signal_hook::flag::register(sig, Arc::clone(&shutdown))
+                .with_context(|| format!("failed to register signal handler for signal {sig}"))?;
+        }
+    }
+
+    Ok(shutdown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn register_handlers_creates_false_flag() {
+        let shutdown = register_handlers().unwrap();
+        assert!(!shutdown.load(Ordering::Relaxed));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_sets_flag() {
+        let shutdown = register_handlers().unwrap();
+        assert!(!shutdown.load(Ordering::Relaxed));
+
+        // Send ourselves SIGTERM
+        // SAFETY: Sending SIGTERM to our own process is safe and a standard
+        // pattern for testing signal handlers.
+        unsafe {
+            libc::kill(libc::getpid(), libc::SIGTERM);
+        }
+
+        // Give the signal handler a moment
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        assert!(shutdown.load(Ordering::Relaxed));
+    }
+}


### PR DESCRIPTION
## Phase 2: CLI + Launcher + Nesting Detection

### What's new

Adds the `amplihack-cli` crate with complete CLI command parsing, process launcher, and nesting detection.

### Phase 2a: CLI command parsing (clap derive)
- Full `Cli` struct with all subcommands: Install, Uninstall, Launch, Claude, Copilot, Codex, Amplifier, Plugin, Memory, Recipe, Mode, Version
- Sub-enums: PluginCommands, MemoryCommands, RecipeCommands, ModeCommands
- Python delegation via `python3 -m amplihack.cli` for memory/recipe/plugin/mode
- Command dispatch module routing parsed args to handlers

### Phase 2b: Launcher + process management
- **ManagedChild**: `std::process::Child` wrapper with bounded Drop (SIGTERM → 3s wait → SIGKILL)
- **Signal handling**: SIGINT/SIGTERM/SIGHUP → AtomicBool via signal-hook
- **Process groups**: setpgid via libc to prevent double-SIGINT
- **BinaryFinder**: PATH search with env override (`AMPLIHACK_{TOOL}_BINARY_PATH`), version detection
- **EnvBuilder**: Type-safe PATH construction with set-based deduplication
- **SettingsManager**: Atomic settings.json CRUD via AtomicJsonFile

### Phase 2c: Nesting detection
- Primary: `AMPLIHACK_SESSION_ID` env var check
- Secondary: Session file (PID + timestamp) in `~/.claude/runtime/`
- Stale detection: dead PID + >1h old = stale (ignored)
- Session claim/release lifecycle

### Crate structure
```
crates/amplihack-cli/
├── Cargo.toml
└── src/
    ├── lib.rs              (Cli/Commands/sub-enums)
    ├── commands/
    │   ├── mod.rs           (dispatch)
    │   ├── launch.rs        (Launch/Claude/Copilot/Codex/Amplifier)
    │   ├── install.rs       (Install/Uninstall → Python)
    │   ├── plugin.rs        (Plugin → Python)
    │   ├── memory.rs        (Memory → Python)
    │   ├── recipe.rs        (Recipe → Python)
    │   └── mode.rs          (Mode → Python)
    ├── launcher.rs          (ManagedChild + bounded Drop)
    ├── signals.rs           (SIGINT/SIGTERM/SIGHUP handling)
    ├── binary_finder.rs     (PATH search + version detection)
    ├── env_builder.rs       (type-safe env construction)
    ├── nesting.rs           (NestingDetector + session files)
    └── settings_manager.rs  (atomic settings.json CRUD)
```

### Testing
- 35 new tests across all modules
- All 156 workspace tests pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

### Workspace changes
- Added `crates/amplihack-cli` to workspace members
- Added workspace deps: clap, signal-hook, libc
- Updated `bins/amplihack` to use amplihack-cli for CLI parsing