### PR TITLE
fix: session_count filename parity with Python

### DIFF
--- a/crates/amplihack-hooks/src/stop/power_steering.rs
+++ b/crates/amplihack-hooks/src/stop/power_steering.rs
@@ -44,7 +44,7 @@ pub fn check(
     let ps_dir = dirs.session_power_steering(session_id);
     fs::create_dir_all(&ps_dir)?;
 
-    let counter = AtomicCounter::new(ps_dir.join("session_count.json"));
+    let counter = AtomicCounter::new(ps_dir.join("session_count"));
     let count = counter.increment()?;
 
     // First stop: always approve (let power steering checker handle on subsequent stops).


### PR DESCRIPTION
Fixes audit v2 cycle 2 finding C2-001: Rust power_steering.rs used `session_count.json` but Python uses `session_count` (no extension). Mismatch broke cross-engine counter visibility.