### PR TITLE
ci: fix linux arm64 release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,19 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             cross: false
+            gnu_cross_toolchain: false
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-latest
-            cross: true
+            cross: false
+            gnu_cross_toolchain: true
           - target: x86_64-apple-darwin
             runner: macos-latest
             cross: false
+            gnu_cross_toolchain: false
           - target: aarch64-apple-darwin
             runner: macos-latest
             cross: false
+            gnu_cross_toolchain: false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -62,7 +66,22 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      # Install cross for Linux ARM64
+      - name: Install GNU cross toolchain
+        if: matrix.gnu_cross_toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Configure GNU cross toolchain
+        if: matrix.gnu_cross_toolchain
+        run: |
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> "$GITHUB_ENV"
+          echo "AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> "$GITHUB_ENV"
+
+      # Install cross when a target really needs the container image
       - name: Install cross
         if: matrix.cross
         run: cargo install cross --locked

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -28,15 +28,19 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             cross: false
+            gnu_cross_toolchain: false
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-latest
-            cross: true
+            cross: false
+            gnu_cross_toolchain: true
           - target: x86_64-apple-darwin
             runner: macos-latest
             cross: false
+            gnu_cross_toolchain: false
           - target: aarch64-apple-darwin
             runner: macos-latest
             cross: false
+            gnu_cross_toolchain: false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -45,6 +49,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: snapshot-${{ matrix.target }}
+
+      - name: Install GNU cross toolchain
+        if: matrix.gnu_cross_toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Configure GNU cross toolchain
+        if: matrix.gnu_cross_toolchain
+        run: |
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> "$GITHUB_ENV"
+          echo "AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> "$GITHUB_ENV"
 
       - name: Install cross
         if: matrix.cross

--- a/CONTRIBUTING_RUST.md
+++ b/CONTRIBUTING_RUST.md
@@ -5,7 +5,7 @@ Rust core runtime for amplihack deterministic infrastructure.
 ## Prerequisites
 
 - **Rust** 2024 edition (1.85+): `rustup update stable`
-- **cross** (for ARM64 Linux): `cargo install cross --locked`
+- **GNU cross toolchain** (for ARM64 Linux): `sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu`
 - **Python 3.11+** with amplihack installed (for SDK bridge tests)
 
 ## Build & Test
@@ -102,7 +102,11 @@ tests/
 cargo build --release
 
 # Linux ARM64
-cross build --release --target aarch64-unknown-linux-gnu
+rustup target add aarch64-unknown-linux-gnu
+CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+cargo build --release --target aarch64-unknown-linux-gnu
 
 # macOS (from macOS host)
 rustup target add aarch64-apple-darwin


### PR DESCRIPTION
## Summary
- stop using the stale `cross` container for `aarch64-unknown-linux-gnu`
- install and configure Ubuntu's modern GNU AArch64 toolchain for both CI and snapshot release builds
- update the Rust contributing guide to match the working Linux ARM64 build path

## Why
The previous matrix used a `cross` image with GCC 5.4, which fails while building `kuzu` because it requires C++20 support. This broke both the normal CI matrix and the new snapshot-release workflow.

## Validation
- `python3` YAML parse for `.github/workflows/ci.yml`
- `python3` YAML parse for `.github/workflows/publish-snapshot.yml`
