### PR TITLE
feat: auto-release pipeline + v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,188 @@
+name: Auto Release
+
+# Trigger on merge to main (push) — creates a release if version changed.
+# Also supports manual dispatch for ad-hoc releases.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type (patch/minor/major) — only for manual trigger"
+        required: false
+        default: "patch"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Step 1: Detect if the workspace version changed vs the latest release tag.
+  detect-version:
+    name: Detect version change
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+      tag: ${{ steps.check.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need tags
+
+      - name: Check if version changed
+        id: check
+        run: |
+          # Get version from Cargo.toml
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          # Check if this tag already exists
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — no release needed"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag ${TAG} does not exist — will release"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Step 2: Build release binaries for all platforms
+  build:
+    name: Build ${{ matrix.target }}
+    needs: detect-version
+    if: needs.detect-version.outputs.should_release == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            cross: false
+            gnu_cross_toolchain: false
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-latest
+            cross: false
+            gnu_cross_toolchain: true
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            cross: false
+            gnu_cross_toolchain: false
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            cross: false
+            gnu_cross_toolchain: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Install GNU cross toolchain
+        if: matrix.gnu_cross_toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Configure GNU cross toolchain
+        if: matrix.gnu_cross_toolchain
+        run: |
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> "$GITHUB_ENV"
+          echo "AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> "$GITHUB_ENV"
+
+      - name: Build release
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/amplihack dist/ 2>/dev/null || true
+          cp target/${{ matrix.target }}/release/amplihack-hooks dist/ 2>/dev/null || true
+          cd dist
+          tar czf ../amplihack-${{ matrix.target }}.tar.gz *
+          cd ..
+          sha256sum amplihack-${{ matrix.target }}.tar.gz > amplihack-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: amplihack-${{ matrix.target }}
+          path: |
+            amplihack-${{ matrix.target }}.tar.gz
+            amplihack-${{ matrix.target }}.tar.gz.sha256
+          if-no-files-found: error
+
+  # Step 3: Create the release with tag and upload all artifacts
+  release:
+    name: Create Release
+    needs: [detect-version, build]
+    if: needs.detect-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ needs.detect-version.outputs.tag }}" -m "Release ${{ needs.detect-version.outputs.tag }}"
+          git push origin "${{ needs.detect-version.outputs.tag }}"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect release assets
+        run: |
+          mkdir -p release-assets
+          find artifacts -name '*.tar.gz' -exec cp {} release-assets/ \;
+          find artifacts -name '*.sha256' -exec cp {} release-assets/ \;
+          ls -la release-assets/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.detect-version.outputs.tag }}
+          name: "amplihack-rs ${{ needs.detect-version.outputs.tag }}"
+          files: release-assets/*
+          generate_release_notes: true
+          body: |
+            ## Installation
+
+            Download the binary for your platform and extract:
+
+            ```bash
+            # Linux x86_64
+            curl -fsSL https://github.com/rysweet/amplihack-rs/releases/download/${{ needs.detect-version.outputs.tag }}/amplihack-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.local/bin/
+
+            # Linux ARM64
+            curl -fsSL https://github.com/rysweet/amplihack-rs/releases/download/${{ needs.detect-version.outputs.tag }}/amplihack-aarch64-unknown-linux-gnu.tar.gz | tar xz -C ~/.local/bin/
+
+            # macOS x86_64
+            curl -fsSL https://github.com/rysweet/amplihack-rs/releases/download/${{ needs.detect-version.outputs.tag }}/amplihack-x86_64-apple-darwin.tar.gz | tar xz -C ~/.local/bin/
+
+            # macOS ARM64 (Apple Silicon)
+            curl -fsSL https://github.com/rysweet/amplihack-rs/releases/download/${{ needs.detect-version.outputs.tag }}/amplihack-aarch64-apple-darwin.tar.gz | tar xz -C ~/.local/bin/
+            ```
+
+            Or update an existing installation:
+            ```bash
+            amplihack update
+            ```
+
+            ## SHA256 Checksums
+
+            Verify your download:
+            ```bash
+            sha256sum -c amplihack-<target>.tar.gz.sha256
+            ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "amplihack-state",
  "amplihack-types",
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "amplihack-state",
  "amplihack-types",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -266,7 +266,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -300,12 +311,13 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.138"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4b7522f539fe056f1d6fc8577d8ab731451f6f33a89b1e5912e22b76c553e7"
+checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
- "codespan-reporting",
+ "codespan-reporting 0.13.1",
+ "indexmap",
  "proc-macro2",
  "quote",
  "scratch",
@@ -319,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f01e92ab4ce9fd4d16e3bb11b158d98cbdcca803c1417aa43130a6526fbf208"
 dependencies = [
  "clap",
- "codespan-reporting",
+ "codespan-reporting 0.11.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -1194,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -1357,6 +1369,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bump the workspace version in Cargo.toml and commit.
+# Usage: ./scripts/bump-version.sh [patch|minor|major]
+#
+# The auto-release workflow detects version changes on push to main
+# and creates a GitHub release automatically.
+
+BUMP_TYPE="${1:-patch}"
+CARGO_TOML="Cargo.toml"
+
+# Get current version
+CURRENT=$(grep '^version' "$CARGO_TOML" | head -1 | sed 's/version = "\(.*\)"/\1/')
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+case "$BUMP_TYPE" in
+  patch) PATCH=$((PATCH + 1)) ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  *) echo "Usage: $0 [patch|minor|major]"; exit 1 ;;
+esac
+
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+echo "Bumping version: ${CURRENT} → ${NEW_VERSION}"
+
+# Update Cargo.toml
+sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW_VERSION}\"/" "$CARGO_TOML"
+
+# Update Cargo.lock
+cargo generate-lockfile 2>/dev/null || true
+
+echo "Updated ${CARGO_TOML} to ${NEW_VERSION}"
+echo ""
+echo "Next steps:"
+echo "  git add Cargo.toml Cargo.lock"
+echo "  git commit -m 'chore: bump version to ${NEW_VERSION}'"
+echo "  git push origin main"
+echo ""
+echo "The auto-release workflow will create v${NEW_VERSION} on push."


### PR DESCRIPTION
## Summary

- Add `release.yml` workflow: auto-creates GitHub releases when workspace version changes on push to main
- Add `scripts/bump-version.sh` for easy version bumping
- Bump version from 0.1.0 to 0.2.0 to trigger first release

## How it works

1. Every push to main, the workflow checks if the version in `Cargo.toml` has a corresponding git tag
2. If not, it builds release binaries for 4 platforms, creates SHA256 checksums, tags the commit, and creates a GitHub Release
3. `amplihack update` can then download the latest release

## To release a new version

```bash
./scripts/bump-version.sh patch  # 0.2.0 → 0.2.1
git add Cargo.toml Cargo.lock
git commit -m "chore: bump version to 0.2.1"
git push origin main
# Release created automatically
```

## Test plan

- [x] Workflow syntax validated
- [x] Version detection logic tested locally
- [x] cargo build succeeds with new version
- [x] SHA256 checksums included in release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)