### PR TITLE
feat: expand shadow parity harness with 4 new cases (#39)

### DIFF
--- a/tests/parity/shadow_harness.py
+++ b/tests/parity/shadow_harness.py
@@ -429,6 +429,36 @@ EOF
         "argv": ["plugin", "verify", "nonexistent"],
         "compare": ["stdout", "stderr", "exit_code"],
     },
+    # ── WS5: New parity cases (issue #39) ──────────────────────────────────
+    # Install — local mode, idempotent.  exit_code only; stdout/stderr differ
+    # across environments (paths, Python versions, package state).
+    {
+        "name": "shadow-install-local",
+        "category": "install",
+        "argv": ["install", "--local"],
+        "compare": ["exit_code"],
+    },
+    # Uninstall — local mode.  exit_code only; same rationale as install.
+    {
+        "name": "shadow-uninstall-local",
+        "category": "uninstall",
+        "argv": ["uninstall", "--local"],
+        "compare": ["exit_code"],
+    },
+    # Plugin list (distinct from verify-missing which tests error paths).
+    {
+        "name": "shadow-plugin-list",
+        "category": "plugin",
+        "argv": ["plugin", "list"],
+        "compare": ["exit_code"],
+    },
+    # Memory status — lightweight query that does not require a running session.
+    {
+        "name": "shadow-memory-status",
+        "category": "memory",
+        "argv": ["memory", "status", "--backend", "sqlite"],
+        "compare": ["exit_code"],
+    },
 ]
 
 


### PR DESCRIPTION
## Summary

Add 4 new entries to `SHADOW_CASES` in `tests/parity/shadow_harness.py` covering previously untested command categories:

| Case | Category | Command | Compare |
|------|----------|---------|---------|
| `shadow-install-local` | install | `install --local` | exit_code |
| `shadow-uninstall-local` | uninstall | `uninstall --local` | exit_code |
| `shadow-plugin-list` | plugin | `plugin list` | exit_code |
| `shadow-memory-status` | memory | `memory status --backend sqlite` | exit_code |

All 4 cases use `exit_code`-only comparison to avoid environment-specific stdout differences while still catching command dispatch regressions between the Python and Rust implementations.

## Test plan

- [ ] `python tests/parity/shadow_harness.py` runs without error
- [ ] All 4 new cases appear in the case list
- [ ] Existing cases unaffected

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)