### PR TITLE
feat: set AMPLIHACK_AGENT_BINARY in child process environment (WS1)

### DIFF
--- a/crates/amplihack-cli/src/commands/launch.rs
+++ b/crates/amplihack-cli/src/commands/launch.rs
@@ -58,6 +58,7 @@ pub fn run_launch(
     let env = EnvBuilder::new()
         .with_amplihack_session_id()                                   // AMPLIHACK_SESSION_ID, AMPLIHACK_DEPTH
         .with_amplihack_vars()                                         // AMPLIHACK_RUST_RUNTIME, AMPLIHACK_VERSION, NODE_OPTIONS
+        .with_agent_binary(tool)                                       // WS1: AMPLIHACK_AGENT_BINARY
         .set_if(is_noninteractive(), "AMPLIHACK_NONINTERACTIVE", "1") // WS2: propagate flag
         .build();
 

--- a/crates/amplihack-cli/src/env_builder.rs
+++ b/crates/amplihack-cli/src/env_builder.rs
@@ -59,6 +59,26 @@ impl EnvBuilder {
         if condition { self.set(key, value) } else { self }
     }
 
+    /// Set `AMPLIHACK_AGENT_BINARY` to the name of the CLI binary being launched.
+    ///
+    /// Downstream consumers (recipe runner, hooks) use this to determine which
+    /// agent binary to invoke. The value must be one of the four known tool names:
+    /// `claude`, `copilot`, `codex`, or `amplifier`.
+    ///
+    /// # Security (SEC-WS1-01)
+    ///
+    /// A `debug_assert!` validates the value in debug and test builds. The check
+    /// is compiled out in release builds — callers are responsible for passing a
+    /// valid tool name (controlled by `Commands` dispatch in `launch.rs`).
+    pub fn with_agent_binary(self, tool: impl Into<String>) -> Self {
+        let tool = tool.into();
+        debug_assert!(
+            matches!(tool.as_str(), "claude" | "copilot" | "codex" | "amplifier"),
+            "AMPLIHACK_AGENT_BINARY must be one of: claude, copilot, codex, amplifier; got: {tool}"
+        );
+        self.set("AMPLIHACK_AGENT_BINARY", tool)
+    }
+
     /// Add standard AMPLIHACK_* variables and NODE_OPTIONS.
     pub fn with_amplihack_vars(self) -> Self {
         // Merge NODE_OPTIONS: append if existing (and not already present), set fresh otherwise
@@ -142,6 +162,22 @@ fn generate_session_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── WS1: with_agent_binary ────────────────────────────────────────────────
+
+    /// WS1-1: with_agent_binary must insert AMPLIHACK_AGENT_BINARY for each
+    /// supported tool name.
+    #[test]
+    fn with_agent_binary_sets_env_var_for_all_tools() {
+        for tool in &["claude", "copilot", "codex", "amplifier"] {
+            let env = EnvBuilder::new().with_agent_binary(*tool).build();
+            assert_eq!(
+                env.get("AMPLIHACK_AGENT_BINARY").map(String::as_str),
+                Some(*tool),
+                "AMPLIHACK_AGENT_BINARY should be '{tool}'"
+            );
+        }
+    }
 
     // ── WS2: set_if ────────────────────────────────────────────────────────────
 

--- a/docs/concepts/agent-binary-routing.md
+++ b/docs/concepts/agent-binary-routing.md
@@ -1,0 +1,105 @@
+# Agent Binary Routing
+
+`amplihack` supports four AI backends — `claude`, `copilot`, `codex`, and `amplifier` — each launched via the same `amplihack <tool>` pattern. This document explains how downstream components (recipe runner, hooks, sub-agents) know which backend is active, and why this matters.
+
+## Contents
+
+- [The problem](#the-problem)
+- [The solution: AMPLIHACK_AGENT_BINARY](#the-solution-amplihack_agent_binary)
+- [How it propagates](#how-it-propagates)
+- [Consumers](#consumers)
+  - [Recipe runner](#recipe-runner)
+  - [Hooks](#hooks)
+  - [Sub-agents](#sub-agents)
+- [Supported values](#supported-values)
+- [Related](#related)
+
+## The problem
+
+The recipe runner is a shell-level orchestrator that executes multi-step workflows by spawning new AI sessions. It does not know — and should not hardcode — which AI tool the user started with. If a user invokes `amplihack copilot` and triggers a recipe that spawns a follow-up session, that session must also use `copilot`, not `claude`.
+
+Before `AMPLIHACK_AGENT_BINARY` was propagated, components were forced to:
+
+- Hardcode `claude` (breaking Copilot and Codex users)
+- Require an explicit configuration setting (error-prone and redundant)
+- Inspect `$0` or try to detect the active binary at runtime (fragile)
+
+## The solution: AMPLIHACK_AGENT_BINARY
+
+When `amplihack` launches any tool, it writes the tool name into the child process environment as `AMPLIHACK_AGENT_BINARY`. Every subprocess — the AI tool itself, hooks, recipe steps — inherits this variable and can use it to spawn the correct binary without any additional configuration.
+
+```sh
+# User invokes:
+amplihack claude
+
+# Child process environment contains:
+AMPLIHACK_AGENT_BINARY=claude
+
+# User invokes:
+amplihack copilot
+
+# Child process environment contains:
+AMPLIHACK_AGENT_BINARY=copilot
+```
+
+The value is always one of the four known tool names. It is set unconditionally on every launch — there is no fallback or default value that could mask a misconfiguration.
+
+## How it propagates
+
+The Rust CLI sets `AMPLIHACK_AGENT_BINARY` inside `EnvBuilder::with_agent_binary()`, called as part of the env build chain in `launch.rs`:
+
+```rust
+let env = EnvBuilder::new()
+    .with_amplihack_session_id()
+    .with_amplihack_vars()
+    .with_agent_binary(tool)         // sets AMPLIHACK_AGENT_BINARY
+    .with_amplihack_home()
+    .set_if(is_noninteractive(), "AMPLIHACK_NONINTERACTIVE", "1")
+    .build();
+```
+
+`tool` is the string passed to `run_launch()` by the CLI dispatcher — it is always the exact name of the subcommand the user invoked.
+
+## Consumers
+
+### Recipe runner
+
+The recipe runner reads `AMPLIHACK_AGENT_BINARY` to decide which binary to call when launching a new AI session as part of a workflow step.
+
+```sh
+# Inside a recipe step script:
+${AMPLIHACK_AGENT_BINARY} --print "${PROMPT}" --model "${MODEL}"
+# Equivalent to: claude --print "..." or copilot --print "..." depending on which tool was used
+```
+
+### Hooks
+
+Claude Code hooks run as subprocesses of the AI tool. They inherit the full environment, including `AMPLIHACK_AGENT_BINARY`. A hook that needs to spawn a continuation session uses this variable:
+
+```sh
+# In a PostToolUse hook
+if [ "$AMPLIHACK_AGENT_BINARY" = "claude" ]; then
+  # Claude-specific post-processing
+  claude --print "Review the output of the tool call"
+fi
+```
+
+### Sub-agents
+
+Agents spawned by the recipe runner or by hooks inherit `AMPLIHACK_AGENT_BINARY` automatically because it is part of the process environment. No explicit passing is required.
+
+## Supported values
+
+| Value | Tool | Installed by |
+|-------|------|-------------|
+| `claude` | Anthropic Claude Code | npm: `@anthropic-ai/claude-code` |
+| `copilot` | GitHub Copilot CLI | npm: `@github/copilot` |
+| `codex` | OpenAI Codex CLI | npm: `@openai/codex-cli` |
+| `amplifier` | Microsoft Amplifier | uv: `git+https://github.com/microsoft/amplifier` |
+
+No other values are valid. The Rust implementation uses a `debug_assert!` in `with_agent_binary()` that panics on unexpected values in debug and test builds, making misuse visible early in development.
+
+## Related
+
+- [Environment Variables](../reference/environment-variables.md#amplihack_agent_binary) — Full reference for `AMPLIHACK_AGENT_BINARY`
+- [Bootstrap Parity](./bootstrap-parity.md) — Full Python/Rust parity contract for the launcher environment


### PR DESCRIPTION
## Summary

Port from Python PR #3100 (rysweet/amplihack). Stacks on #51 (WS2).

The Python launcher sets `AMPLIHACK_AGENT_BINARY` based on which CLI is invoked (`claude`, `copilot`, `codex`, `amplifier`). Recipe runner and hooks use this to know which agent binary to call downstream.

- **`env_builder.rs`**: Add `with_agent_binary(tool)` method that sets `AMPLIHACK_AGENT_BINARY`. Validates tool name with `debug_assert!` in debug/test builds (SEC-WS1-01). Compiled out in release — callers control the value via `Commands` dispatch.
- **`launch.rs`**: Wire `.with_agent_binary(tool)` into the env builder chain. Tool name flows from `Commands` dispatch in `lib.rs`.
- **docs**: Add `docs/concepts/agent-binary-routing.md`.

## Parity Tests

1 new test (WS1-1) verifying all 4 tool names — passes.

## Step 13: Local Testing Results

### Scenario 1 — AMPLIHACK_AGENT_BINARY set for all tools
Command: `cargo test --package amplihack-cli --lib -- with_agent_binary`
Result: PASS
Output:
```
test env_builder::tests::with_agent_binary_sets_env_var_for_all_tools ... ok
test result: ok. 1 passed; 0 failed
```

### Scenario 2 — Binary integration smoke test
Command: `AMPLIHACK_NONINTERACTIVE=1 amplihack version`
Result: PASS
Output: `amplihack-rs 0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)