### PR TITLE
feat: resolve and set AMPLIHACK_HOME for subprocess asset resolution (WS3)

### DIFF
--- a/crates/amplihack-cli/src/commands/launch.rs
+++ b/crates/amplihack-cli/src/commands/launch.rs
@@ -59,6 +59,7 @@ pub fn run_launch(
         .with_amplihack_session_id()                                   // AMPLIHACK_SESSION_ID, AMPLIHACK_DEPTH
         .with_amplihack_vars()                                         // AMPLIHACK_RUST_RUNTIME, AMPLIHACK_VERSION, NODE_OPTIONS
         .with_agent_binary(tool)                                       // WS1: AMPLIHACK_AGENT_BINARY
+        .with_amplihack_home()                                         // WS3: AMPLIHACK_HOME
         .set_if(is_noninteractive(), "AMPLIHACK_NONINTERACTIVE", "1") // WS2: propagate flag
         .build();
 

--- a/crates/amplihack-cli/src/env_builder.rs
+++ b/crates/amplihack-cli/src/env_builder.rs
@@ -79,6 +79,85 @@ impl EnvBuilder {
         self.set("AMPLIHACK_AGENT_BINARY", tool)
     }
 
+    /// Resolve and set `AMPLIHACK_HOME` in the child environment.
+    ///
+    /// Resolution order:
+    /// 1. If `AMPLIHACK_HOME` is already set in the current environment → no-op.
+    /// 2. If `HOME` is set → use `$HOME/.amplihack`.
+    /// 3. If `std::env::current_exe()` succeeds → use the parent directory of
+    ///    the running executable.
+    /// 4. All attempts fail → return `self` unchanged (silent degradation).
+    ///
+    /// # Security (SEC-WS3-01/02/03)
+    ///
+    /// Paths containing `..` (parent directory) components are rejected with a
+    /// `tracing::warn!` and the variable is NOT set. This prevents an attacker
+    /// who controls `$HOME` from injecting traversal paths such as
+    /// `/tmp/../../etc`. Non-absolute paths are also rejected.
+    ///
+    /// Note: existence of the path is NOT checked — the consumer (recipe runner)
+    /// creates it on demand. Existence checks are avoided to keep this free of
+    /// filesystem side-effects and to work correctly in test environments.
+    pub fn with_amplihack_home(self) -> Self {
+        use std::path::{Component, Path, PathBuf};
+
+        /// Validate a candidate path and return it as a String if safe,
+        /// or `None` if it fails security checks (SEC-WS3-01/02).
+        fn validate_path(candidate: &Path) -> Option<String> {
+            // SEC-WS3-02: must be absolute.
+            if !candidate.is_absolute() {
+                tracing::warn!(
+                    path = %candidate.display(),
+                    "AMPLIHACK_HOME resolution produced a non-absolute path — skipping"
+                );
+                return None;
+            }
+            // SEC-WS3-01: reject any path containing '..' (ParentDir) components.
+            if candidate.components().any(|c| c == Component::ParentDir) {
+                tracing::warn!(
+                    path = %candidate.display(),
+                    "AMPLIHACK_HOME resolution produced a path with '..' components — skipping (SEC-WS3-01)"
+                );
+                return None;
+            }
+            Some(candidate.to_string_lossy().into_owned())
+        }
+
+        // Step 1: already set in environment — preserve it.
+        if let Ok(existing) = env::var("AMPLIHACK_HOME")
+            && !existing.is_empty()
+        {
+            return self.set("AMPLIHACK_HOME", existing);
+        }
+
+        // Step 2: derive from HOME env var → $HOME/.amplihack
+        if let Ok(home) = env::var("HOME")
+            && !home.is_empty()
+        {
+            let candidate = PathBuf::from(&home).join(".amplihack");
+            if let Some(value) = validate_path(&candidate) {
+                return self.set("AMPLIHACK_HOME", value);
+            }
+            // Path failed security check — do NOT fall through to exe-based
+            // strategy, as a poisoned HOME should not silently resolve to
+            // the binary directory (which may be controlled by the attacker).
+            return self;
+        }
+
+        // Step 3: fall back to the parent directory of the running executable.
+        if let Ok(exe) = env::current_exe()
+            && let Some(parent) = exe.parent()
+        {
+            let candidate = parent.to_path_buf();
+            if let Some(value) = validate_path(&candidate) {
+                return self.set("AMPLIHACK_HOME", value);
+            }
+        }
+
+        // Step 4: all strategies exhausted — return unchanged (SEC-WS3-03 silent).
+        self
+    }
+
     /// Add standard AMPLIHACK_* variables and NODE_OPTIONS.
     pub fn with_amplihack_vars(self) -> Self {
         // Merge NODE_OPTIONS: append if existing (and not already present), set fresh otherwise
@@ -177,6 +256,89 @@ mod tests {
                 "AMPLIHACK_AGENT_BINARY should be '{tool}'"
             );
         }
+    }
+
+    // ── WS3: with_amplihack_home ───────────────────────────────────────────────
+
+    /// WS3-1: with_amplihack_home should derive AMPLIHACK_HOME from HOME when
+    /// AMPLIHACK_HOME is not set.
+    #[test]
+    fn with_amplihack_home_sets_from_home() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        let temp = tempfile::tempdir().unwrap();
+        let prev_home = crate::test_support::set_home(temp.path());
+        let prev_amplihack_home = std::env::var_os("AMPLIHACK_HOME");
+        unsafe { std::env::remove_var("AMPLIHACK_HOME") };
+
+        let env = EnvBuilder::new().with_amplihack_home().build();
+
+        crate::test_support::restore_home(prev_home);
+        match prev_amplihack_home {
+            Some(v) => unsafe { std::env::set_var("AMPLIHACK_HOME", v) },
+            None => unsafe { std::env::remove_var("AMPLIHACK_HOME") },
+        }
+
+        let expected = temp.path().join(".amplihack");
+        assert_eq!(
+            env.get("AMPLIHACK_HOME").map(String::as_str),
+            Some(expected.to_str().unwrap()),
+            "AMPLIHACK_HOME should be <HOME>/.amplihack when unset"
+        );
+    }
+
+    /// WS3-2: with_amplihack_home must not overwrite an AMPLIHACK_HOME that is
+    /// already set in the process environment.
+    #[test]
+    fn with_amplihack_home_does_not_overwrite_existing() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        let custom = "/custom/path";
+        let prev = std::env::var_os("AMPLIHACK_HOME");
+        unsafe { std::env::set_var("AMPLIHACK_HOME", custom) };
+
+        let env = EnvBuilder::new().with_amplihack_home().build();
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("AMPLIHACK_HOME", v) },
+            None => unsafe { std::env::remove_var("AMPLIHACK_HOME") },
+        }
+
+        assert_eq!(
+            env.get("AMPLIHACK_HOME").map(String::as_str),
+            Some(custom),
+            "with_amplihack_home must preserve a pre-existing AMPLIHACK_HOME"
+        );
+    }
+
+    /// WS3-3 (SEC-WS3-01): with_amplihack_home must reject a HOME that contains
+    /// path traversal components (e.g. "..") and must NOT set AMPLIHACK_HOME.
+    #[test]
+    fn with_amplihack_home_rejects_traversal_path() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        let prev_home = crate::test_support::set_home(std::path::Path::new("/tmp/../../etc"));
+        let prev_amplihack_home = std::env::var_os("AMPLIHACK_HOME");
+        unsafe { std::env::remove_var("AMPLIHACK_HOME") };
+
+        let env = EnvBuilder::new().with_amplihack_home().build();
+
+        crate::test_support::restore_home(prev_home);
+        match prev_amplihack_home {
+            Some(v) => unsafe { std::env::set_var("AMPLIHACK_HOME", v) },
+            None => unsafe { std::env::remove_var("AMPLIHACK_HOME") },
+        }
+
+        assert!(
+            !env.contains_key("AMPLIHACK_HOME"),
+            "with_amplihack_home must not set AMPLIHACK_HOME when HOME contains path traversal"
+        );
     }
 
     // ── WS2: set_if ────────────────────────────────────────────────────────────

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,229 @@
+# Environment Variables — Reference
+
+All environment variables read or written by `amplihack` during a launch (`amplihack claude`, `amplihack copilot`, `amplihack codex`, `amplihack amplifier`).
+
+## Contents
+
+- [Variables set by amplihack](#variables-set-by-amplihack)
+  - [AMPLIHACK_AGENT_BINARY](#amplihack_agent_binary)
+  - [AMPLIHACK_HOME](#amplihack_home)
+  - [AMPLIHACK_NONINTERACTIVE](#amplihack_noninteractive)
+  - [AMPLIHACK_SESSION_ID](#amplihack_session_id)
+  - [AMPLIHACK_DEPTH](#amplihack_depth)
+  - [AMPLIHACK_RUST_RUNTIME](#amplihack_rust_runtime)
+  - [AMPLIHACK_VERSION](#amplihack_version)
+  - [NODE_OPTIONS](#node_options)
+- [Variables read by amplihack](#variables-read-by-amplihack)
+  - [HOME](#home)
+  - [AMPLIHACK_DEFAULT_MODEL](#amplihack_default_model)
+  - [UV_TOOL_BIN_DIR](#uv_tool_bin_dir)
+
+---
+
+## Variables set by amplihack
+
+These variables are injected into every child process launched by `amplihack`. They are not inherited from the parent shell; they are built fresh on each invocation.
+
+---
+
+### AMPLIHACK_AGENT_BINARY
+
+**Type:** string
+**Values:** `claude` | `copilot` | `codex` | `amplifier`
+**Set by:** `EnvBuilder::with_agent_binary()`
+
+Identifies which CLI binary was used to start the current session. Downstream consumers — the recipe runner, hooks, and sub-agents — read this variable to know which tool to invoke when they need to spawn a new AI session.
+
+```sh
+# Start a Claude session
+amplihack claude
+
+# Inside Claude Code hooks, the recipe runner sees:
+echo $AMPLIHACK_AGENT_BINARY
+# claude
+
+# Start a Copilot session
+amplihack copilot
+
+# Inside hooks:
+echo $AMPLIHACK_AGENT_BINARY
+# copilot
+```
+
+**Why it exists:** The recipe runner is agent-agnostic; it must call back into whatever tool launched it. Without this variable, the runner would have to guess the binary name or require manual configuration. See [Agent Binary Routing](../concepts/agent-binary-routing.md) for the full rationale.
+
+**Python parity:** Corresponds to `AMPLIHACK_AGENT_BINARY` set by the Python launcher in `amplihack/cli/launch.py`.
+
+---
+
+### AMPLIHACK_HOME
+
+**Type:** path
+**Example:** `/home/alice/.amplihack`
+**Set by:** `EnvBuilder::with_amplihack_home()`
+
+The root directory where amplihack stores framework assets, hooks, runtime state, and helper scripts. Recipe runner uses this to locate `.claude/tools/amplihack/` and related subdirectories without requiring hardcoded paths.
+
+**Resolution order (first match wins):**
+
+| Priority | Source | Example result |
+|----------|--------|----------------|
+| 1 | `AMPLIHACK_HOME` already set in environment | value is passed through unchanged |
+| 2 | `$HOME/.amplihack` | `/home/alice/.amplihack` |
+| 3 | Directory containing the `amplihack` binary | `/usr/local/bin/../amplihack` |
+| — | All above fail | variable is not set (silent degradation) |
+
+```sh
+# Override for a non-standard install location
+export AMPLIHACK_HOME=/opt/amplihack
+amplihack claude
+
+# Verify the value a subprocess receives
+AMPLIHACK_HOME=/opt/amplihack amplihack claude --print-env 2>&1 | grep AMPLIHACK_HOME
+# AMPLIHACK_HOME=/opt/amplihack
+```
+
+**Security note:** The resolved path is validated to be absolute and must not contain `..` path components. Paths that fail validation are silently dropped; a warning is emitted to the trace log.
+
+**Python parity:** Corresponds to `AMPLIHACK_HOME` propagation in the Python launcher.
+
+---
+
+### AMPLIHACK_NONINTERACTIVE
+
+**Type:** flag
+**Values:** `1` (non-interactive) — absence or any other value means interactive
+**Read by:** `util::is_noninteractive()`
+**Set by:** `EnvBuilder::set_if(is_noninteractive(), "AMPLIHACK_NONINTERACTIVE", "1")`
+
+Signals that the process is running in a non-interactive environment. When set to `1`, `amplihack` skips all interactive prompts and framework bootstrap guidance, preventing hangs in CI pipelines, pipes, and sandboxed environments.
+
+```sh
+# Run without interactive prompts (e.g. in CI)
+AMPLIHACK_NONINTERACTIVE=1 amplihack claude --print 'Fix the lint errors'
+
+# Pipe use also triggers non-interactive mode automatically (no TTY on stdin)
+echo 'Summarize this file' | amplihack claude --print -
+```
+
+**Detection logic:**
+
+Non-interactive mode is active when **either** condition is true:
+
+1. `AMPLIHACK_NONINTERACTIVE=1` is set in the environment
+2. `stdin` is not a TTY (detected via `std::io::IsTerminal`)
+
+Condition 2 covers pipe usage without requiring the caller to set the variable manually.
+
+**Effect on bootstrap:** When non-interactive mode is detected, `prepare_launcher()` returns immediately without running `check_required_tools()` or `ensure_framework_installed()`. The assumption is that CI environments are pre-provisioned and that interactive guidance output would be noise.
+
+**Propagation:** Once detected, `AMPLIHACK_NONINTERACTIVE=1` is written into the child process environment so that nested invocations (e.g. sub-agents spawned by hooks) also behave non-interactively.
+
+**Cross-language contract:** Only the value `"1"` triggers non-interactive mode. The strings `"true"`, `"yes"`, `"on"`, and `"TRUE"` are **not** recognised — this matches the Python launcher's behaviour.
+
+**Python parity:** Corresponds to `AMPLIHACK_NONINTERACTIVE` check in `amplihack/cli/launch.py` (Python PRs #3103, #3066).
+
+---
+
+### AMPLIHACK_SESSION_ID
+
+**Type:** string
+**Example:** `rs-1741872000-12345`
+**Set by:** `EnvBuilder::with_amplihack_session_id()`
+
+A correlation ID for the current session. Used in log output and by the nesting detector to identify recursive `amplihack` invocations. Reused unchanged if already set in the environment (i.e. a nested invocation inherits the session ID of its parent).
+
+Format: `rs-<unix_seconds>-<pid>`
+
+---
+
+### AMPLIHACK_DEPTH
+
+**Type:** integer string
+**Default:** `1`
+**Set by:** `EnvBuilder::with_amplihack_session_id()`
+
+Nesting depth of the current invocation. The root invocation receives `1`. Nested sessions (amplihack launched from within a Claude Code hook) inherit the value from the environment unchanged; the Python launcher increments it, but the Rust launcher propagates it as-is to match Python's observed behaviour for initial launches.
+
+---
+
+### AMPLIHACK_RUST_RUNTIME
+
+**Type:** flag
+**Value:** always `1`
+**Set by:** `EnvBuilder::with_amplihack_vars()`
+
+Indicates the session was started by the Rust CLI rather than the Python launcher. Hooks and recipe scripts can use this to branch on runtime differences.
+
+```sh
+# In a hook script
+if [ "$AMPLIHACK_RUST_RUNTIME" = "1" ]; then
+  # Rust-specific code path
+fi
+```
+
+---
+
+### AMPLIHACK_VERSION
+
+**Type:** semver string
+**Example:** `0.3.1`
+**Set by:** `EnvBuilder::with_amplihack_vars()`
+
+The version of the `amplihack-cli` crate that launched the session. Taken from `CARGO_PKG_VERSION` at compile time.
+
+---
+
+### NODE_OPTIONS
+
+**Type:** space-separated Node.js CLI flags
+**Set by:** `EnvBuilder::with_amplihack_vars()`
+
+`amplihack` injects `--max-old-space-size=32768` to raise the Node.js heap limit for Claude Code's large context operations. If `NODE_OPTIONS` is already set in the environment, `amplihack` appends the flag rather than replacing it, unless `--max-old-space-size=` is already present.
+
+---
+
+## Variables read by amplihack
+
+These variables influence `amplihack`'s behaviour but are not set by it.
+
+---
+
+### HOME
+
+**Required:** yes (for most operations)
+
+Standard Unix home directory. Used to resolve `~/.amplihack`, `~/.npm-global`, and shell profile paths.
+
+---
+
+### AMPLIHACK_DEFAULT_MODEL
+
+**Type:** string
+**Default:** `opus[1m]`
+**Used by:** `build_command()` in `launch.rs`
+
+The `--model` flag passed to the launched tool when the user has not specified one explicitly. Override to use a different model variant.
+
+```sh
+AMPLIHACK_DEFAULT_MODEL=sonnet amplihack claude
+# Passes: claude --model sonnet
+```
+
+---
+
+### UV_TOOL_BIN_DIR
+
+**Type:** path
+**Used by:** `bootstrap.rs` when installing `amplifier`
+
+Override the directory where `uv tool install` places the `amplifier` binary. Defaults to `~/.local/bin`.
+
+---
+
+## Related
+
+- [Agent Binary Routing](../concepts/agent-binary-routing.md) — Why `AMPLIHACK_AGENT_BINARY` exists and how recipe runner uses it
+- [Run amplihack in Non-interactive Mode](../howto/run-in-noninteractive-mode.md) — CI and pipe usage guide
+- [Bootstrap Parity](../concepts/bootstrap-parity.md) — How the Rust CLI matches the Python launcher's environment contract
+- [amplihack install](./install-command.md) — Variables read during installation


### PR DESCRIPTION
## Summary

Port from Python PR #3096 (rysweet/amplihack). Stacks on #52 (WS1) → #51 (WS2).

Recipes use dynamic asset resolution instead of hardcoded paths. This ensures recipe runner can always find helper scripts regardless of how the binary was invoked.

- **`env_builder.rs`**: Add `with_amplihack_home()` with a 4-step resolution chain:
  1. Preserve existing `AMPLIHACK_HOME` (no-op if already set)
  2. Use `$HOME/.amplihack` (most common case)
  3. Fall back to parent directory of running executable
  4. Silent no-op if all strategies fail (SEC-WS3-03)
  
  Security: rejects paths with `..` components (SEC-WS3-01) and non-absolute paths (SEC-WS3-02). Path existence is NOT checked to avoid filesystem side-effects.
- **`launch.rs`**: Wire `.with_amplihack_home()` into the env builder chain.
- **docs**: Add `docs/reference/environment-variables.md`.

## Parity Tests

3 new tests (WS3-1, WS3-2, WS3-3 security) — all pass.

## Step 13: Local Testing Results

### Scenario 1 — AMPLIHACK_HOME resolved from $HOME
Command: `cargo test --package amplihack-cli --lib -- with_amplihack_home`
Result: PASS
Output:
```
test env_builder::tests::with_amplihack_home_does_not_overwrite_existing ... ok
test env_builder::tests::with_amplihack_home_rejects_traversal_path ... ok
test env_builder::tests::with_amplihack_home_sets_from_home ... ok
test result: ok. 3 passed; 0 failed
```

### Scenario 2 — Full unit test suite (all 175 tests)
Command: `cargo test --package amplihack-cli --lib`
Result: PASS
Output: `test result: ok. 175 passed; 0 failed; 1 ignored`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Step 16b: Outside-In Testing Results

### Scenario 1 — AMPLIHACK_HOME fallback resolution when not pre-set
Command: `AMPLIHACK_NONINTERACTIVE=1 CLAUDECODE="" AMPLIHACK_HOME="" PATH="/tmp:$PATH" RUST_LOG=warn ./target/debug/amplihack copilot`
Branch: `feat/ws3-amplihack-home`
Result: PASS
Output:
```
AMPLIHACK_AGENT_BINARY=copilot
AMPLIHACK_HOME=/home/azureuser/.amplihack
AMPLIHACK_NONINTERACTIVE=1
AMPLIHACK_RUST_RUNTIME=1
```
- AMPLIHACK_HOME correctly resolved to $HOME/.amplihack when not pre-set

### Scenario 2 — AMPLIHACK_HOME no-op when already set
Command: `AMPLIHACK_NONINTERACTIVE=1 CLAUDECODE="" PATH="/tmp:$PATH" RUST_LOG=warn ./target/debug/amplihack claude`
(With AMPLIHACK_HOME already set to /home/azureuser/src/amploxy)
Result: PASS
Output:
```
AMPLIHACK_AGENT_BINARY=claude
AMPLIHACK_HOME=/home/azureuser/src/amploxy
AMPLIHACK_NONINTERACTIVE=1
AMPLIHACK_RUST_RUNTIME=1
```
- AMPLIHACK_HOME preserved existing value (no-op behavior confirmed)

### Unit Tests: 3 new tests pass
- `with_amplihack_home_sets_from_home` ✓
- `with_amplihack_home_does_not_overwrite_existing` ✓
- `with_amplihack_home_rejects_traversal_path` (SEC-WS3-01) ✓

Fix iterations: 0