### PR TITLE
feat: set AMPLIHACK_AGENT_BINARY in child process environment (WS1)

### DIFF
--- a/crates/amplihack-cli/src/commands/launch.rs
+++ b/crates/amplihack-cli/src/commands/launch.rs
@@ -56,6 +56,7 @@ pub fn run_launch(
     let env = EnvBuilder::new()
         .with_amplihack_session_id()
         .with_amplihack_vars()
+        .with_agent_binary(tool) // WS1: AMPLIHACK_AGENT_BINARY
         .build();
 
     // Build command

--- a/crates/amplihack-cli/src/env_builder.rs
+++ b/crates/amplihack-cli/src/env_builder.rs
@@ -45,6 +45,26 @@ impl EnvBuilder {
             .set("AMPLIHACK_DEPTH", depth)
     }
 
+    /// Set `AMPLIHACK_AGENT_BINARY` to the name of the CLI binary being launched.
+    ///
+    /// Downstream consumers (recipe runner, hooks) use this to determine which
+    /// agent binary to invoke. The value must be one of the four known tool names:
+    /// `claude`, `copilot`, `codex`, or `amplifier`.
+    ///
+    /// # Security (SEC-WS1-01)
+    ///
+    /// A `debug_assert!` validates the value in debug and test builds. The check
+    /// is compiled out in release builds — callers are responsible for passing a
+    /// valid tool name (controlled by `Commands` dispatch in `launch.rs`).
+    pub fn with_agent_binary(self, tool: impl Into<String>) -> Self {
+        let tool = tool.into();
+        debug_assert!(
+            matches!(tool.as_str(), "claude" | "copilot" | "codex" | "amplifier"),
+            "AMPLIHACK_AGENT_BINARY must be one of: claude, copilot, codex, amplifier; got: {tool}"
+        );
+        self.set("AMPLIHACK_AGENT_BINARY", tool)
+    }
+
     /// Add standard AMPLIHACK_* variables and NODE_OPTIONS.
     pub fn with_amplihack_vars(self) -> Self {
         // Merge NODE_OPTIONS: append if existing (and not already present), set fresh otherwise
@@ -128,6 +148,22 @@ fn generate_session_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── WS1: with_agent_binary ────────────────────────────────────────────────
+
+    /// WS1-1: with_agent_binary must insert AMPLIHACK_AGENT_BINARY for each
+    /// supported tool name.
+    #[test]
+    fn with_agent_binary_sets_env_var_for_all_tools() {
+        for tool in &["claude", "copilot", "codex", "amplifier"] {
+            let env = EnvBuilder::new().with_agent_binary(*tool).build();
+            assert_eq!(
+                env.get("AMPLIHACK_AGENT_BINARY").map(String::as_str),
+                Some(*tool),
+                "AMPLIHACK_AGENT_BINARY should be '{tool}'"
+            );
+        }
+    }
 
     #[test]
     fn empty_builder_produces_empty_map() {

--- a/docs/concepts/agent-binary-routing.md
+++ b/docs/concepts/agent-binary-routing.md
@@ -1,0 +1,24 @@
+# Agent Binary Routing (`AMPLIHACK_AGENT_BINARY`)
+
+## Overview
+
+When the amplihack Rust CLI launches a tool (Claude, Copilot, Codex, or Amplifier), it sets `AMPLIHACK_AGENT_BINARY` in the child process environment. This tells downstream consumers — recipe runner, hooks, shell completions — which agent binary initiated the session.
+
+## Rationale
+
+The Python launcher (PR #3100) set `AMPLIHACK_AGENT_BINARY` based on the invoked CLI entry point. This Rust port preserves that behaviour so the recipe runner and hook system can make routing decisions without inspecting `argv[0]`.
+
+## Values
+
+| Invoked CLI | `AMPLIHACK_AGENT_BINARY` |
+|-------------|--------------------------|
+| `amplihack claude` | `claude` |
+| `amplihack copilot` | `copilot` |
+| `amplihack codex` | `codex` |
+| `amplihack amplifier` | `amplifier` |
+
+## Implementation
+
+`EnvBuilder::with_agent_binary(tool)` in `crates/amplihack-cli/src/env_builder.rs` sets the variable. The value flows from the `Commands` dispatch in `lib.rs` → `run_launch()` in `launch.rs`.
+
+A `debug_assert!` validates the tool name in debug/test builds (SEC-WS1-01). Release builds trust the caller.


### PR DESCRIPTION
## Summary

Port from Python PR #3100 (rysweet/amplihack).

- Add `EnvBuilder::with_agent_binary(tool)` in `env_builder.rs` — sets `AMPLIHACK_AGENT_BINARY` in the child environment; `debug_assert!` validates the tool name (SEC-WS1-01)
- Wire `.with_agent_binary(tool)` into the env chain in `run_launch()` in `launch.rs`
- Add WS1-1 parity test: verifies all 4 tool names (`claude`, `copilot`, `codex`, `amplifier`) are set correctly
- Add `docs/concepts/agent-binary-routing.md` with design rationale

## Why

Recipe runner and hooks need to know which agent binary initiated the session. This variable lets them make routing decisions without inspecting `argv[0]`.

## Test plan

- [ ] `cargo test -p amplihack-cli --lib` passes (169 tests, 0 failures)
- [ ] `with_agent_binary_sets_env_var_for_all_tools` test verifies parity with Python behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)