### PR TITLE
fix: restore hard assertion in tier8 AMPLIHACK_HOME parity test

### DIFF
--- a/tests/parity/scenarios/tier8-env-vars.yaml
+++ b/tests/parity/scenarios/tier8-env-vars.yaml
@@ -169,24 +169,23 @@ cases:
       cat > "${SANDBOX_ROOT}/bin/claude" <<'SCRIPT'
       #!/usr/bin/env bash
       home_val="${AMPLIHACK_HOME:-<not-set>}"
-      # Write the raw value and validation result for inspection.
-      # Both CLIs should set AMPLIHACK_HOME to a path ending in .amplihack.
+      # Write the raw value for parity comparison
       printf '%s\n' "${home_val}" > "${SANDBOX_ROOT}/amplihack_home.txt"
+      # Hard assertion: AMPLIHACK_HOME must end with .amplihack
+      # Both Python and Rust CLIs must set this correctly
       if [[ "${home_val}" == *".amplihack" ]]; then
-        printf 'ok\n' > "${SANDBOX_ROOT}/amplihack_home_valid.txt"
+        exit 0
       else
-        printf 'invalid: %s\n' "${home_val}" > "${SANDBOX_ROOT}/amplihack_home_valid.txt"
+        printf 'AMPLIHACK_HOME not set or invalid: %s\n' "${home_val}" >&2
+        exit 1
       fi
-      # Always exit 0 — validation is checked via fs:amplihack_home_valid.txt
-      exit 0
       SCRIPT
       chmod +x "${SANDBOX_ROOT}/bin/claude"
     compare:
       - exit_code
-      - fs:amplihack_home_valid.txt
-    # Both CLIs should set AMPLIHACK_HOME to a path ending in .amplihack.
-    # The stub writes "ok" or "invalid: <value>" to amplihack_home_valid.txt.
-    # Comparing exit_code (both 0) and the validation file ensures parity.
+      - fs:amplihack_home.txt
+    # Both CLIs must set AMPLIHACK_HOME to a path ending in .amplihack.
+    # The stub exits 1 if the value is missing or invalid — no hiding failures.
 
   # ==========================================================================
   # CASE 5: Both AMPLIHACK_AGENT_BINARY and AMPLIHACK_HOME are set together.


### PR DESCRIPTION
## Summary
Reverts the lenient stub from PR #66 that always exited 0. The stub now exits 1 if AMPLIHACK_HOME is missing or invalid, which is the correct behavior — tests should fail when the feature doesn't work, not hide the failure.

This test will pass once the Python launcher is fixed (amplihack PR forthcoming) to set AMPLIHACK_HOME even when non-critical prerequisites are missing in non-interactive mode.

## Test plan
- [x] Test correctly FAILs when Python doesn't set AMPLIHACK_HOME
- [ ] Will PASS after Python launcher fix is merged

Generated with Claude Code