### PR TITLE
fix(recipe): preserve absolute repo root for runner context

### DIFF
--- a/crates/amplihack-cli/src/commands/recipe/run.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run.rs
@@ -163,7 +163,9 @@ fn execute_recipe_via_rust(
         .arg("--output-format")
         .arg("json")
         .arg("-C")
-        .arg(working_dir);
+        .arg(working_dir)
+        .current_dir(working_dir)
+        .env("AMPLIHACK_ORIGINAL_CWD", working_dir);
 
     if dry_run {
         command.arg("--dry-run");
@@ -1182,6 +1184,85 @@ steps:
         assert_eq!(
             result.context.get("agent_binary"),
             Some(&JsonValue::String("copilot".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_execute_recipe_via_rust_sets_runner_cwd_and_original_cwd_env() {
+        let _home_guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _cwd_guard = crate::test_support::cwd_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let ambient_dir = temp.path().join("ambient-cwd");
+        let project_dir = temp.path().join("project-root");
+        let wrong_original = temp.path().join("wrong-original");
+        let runner = temp.path().join("recipe-runner-rs");
+        let amplihack_home = temp.path().join("amplihack-home");
+        std::fs::create_dir_all(&ambient_dir).expect("failed to create ambient cwd");
+        std::fs::create_dir_all(&project_dir).expect("failed to create project dir");
+        std::fs::create_dir_all(&wrong_original).expect("failed to create wrong original dir");
+        std::fs::create_dir_all(&amplihack_home).expect("failed to create amplihack home");
+
+        std::fs::write(
+            &runner,
+            "#!/bin/sh\npwd_value=\"$(pwd)\"\ncat <<EOF\n{\"recipe_name\":\"env-probe\",\"success\":true,\"step_results\":[],\"context\":{\"pwd\":\"$pwd_value\",\"original_cwd\":\"$AMPLIHACK_ORIGINAL_CWD\"}}\nEOF\n",
+        )
+        .expect("failed to write runner stub");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&runner, std::fs::Permissions::from_mode(0o755))
+                .expect("failed to chmod runner");
+        }
+
+        let recipe = temp.path().join("recipe.yaml");
+        std::fs::write(
+            &recipe,
+            "name: env-probe\nsteps:\n  - id: step-1\n    type: bash\n    command: echo ok\n",
+        )
+        .expect("failed to write recipe");
+
+        let prev_cwd = crate::test_support::set_cwd(&ambient_dir).expect("failed to set cwd");
+        let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+        let prev_home = std::env::var_os("AMPLIHACK_HOME");
+        let prev_original_cwd = std::env::var_os("AMPLIHACK_ORIGINAL_CWD");
+        unsafe {
+            std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+            std::env::set_var("AMPLIHACK_HOME", &amplihack_home);
+            std::env::set_var("AMPLIHACK_ORIGINAL_CWD", &wrong_original);
+        }
+
+        let result = execute_recipe_via_rust(&recipe, &BTreeMap::new(), true, &project_dir)
+            .expect("recipe run must succeed");
+
+        crate::test_support::restore_cwd(&prev_cwd).expect("failed to restore cwd");
+        match prev_runner {
+            Some(value) => unsafe { std::env::set_var("RECIPE_RUNNER_RS_PATH", value) },
+            None => unsafe { std::env::remove_var("RECIPE_RUNNER_RS_PATH") },
+        }
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("AMPLIHACK_HOME", value) },
+            None => unsafe { std::env::remove_var("AMPLIHACK_HOME") },
+        }
+        match prev_original_cwd {
+            Some(value) => unsafe { std::env::set_var("AMPLIHACK_ORIGINAL_CWD", value) },
+            None => unsafe { std::env::remove_var("AMPLIHACK_ORIGINAL_CWD") },
+        }
+
+        let expected = JsonValue::String(project_dir.to_string_lossy().into_owned());
+        assert_eq!(
+            result.context.get("pwd"),
+            Some(&expected),
+            "recipe runner child process must execute from the validated working directory, not the ambient cwd"
+        );
+        assert_eq!(
+            result.context.get("original_cwd"),
+            Some(&expected),
+            "recipe runner child process must export AMPLIHACK_ORIGINAL_CWD as the validated working directory"
         );
     }
 


### PR DESCRIPTION
## Summary
- preserve the absolute validated working directory as inferred `repo_path` for `amplihack recipe run`
- run the spawned `recipe-runner-rs` process from that validated working directory
- export `AMPLIHACK_ORIGINAL_CWD` to the same validated repo root so nested launches keep the intended workspace instead of inheriting ambient or temp-step cwd state
- add focused regressions for repo-path inference, env override precedence, runner cwd propagation, and original-cwd propagation

## Why
Open workflow issues `#107`, `#108`, and `#109` describe nested workflow steps losing the target repository root and operating from temp directories. This PR tightens the Rust CLI side of that boundary in two ways:

1. when `repo_path` is required but not explicitly provided, inference now uses the validated absolute working directory instead of `.`
2. when the CLI spawns `recipe-runner-rs`, it now sets both the child process cwd and `AMPLIHACK_ORIGINAL_CWD` to that validated working directory

That preserves the intended repo root across the runner handoff and matches the downstream launch logic that already prefers `AMPLIHACK_ORIGINAL_CWD` when present.

## Validation
- `cargo test -p amplihack-cli commands::recipe::run -- --nocapture`
  - result: `26 passed, 0 failed, 1 ignored`
- `cargo test -p amplihack-cli build_command_prefers_original_cwd_for_staged_uvx_launches -- --nocapture`
  - result: `1 passed, 0 failed`
- repeated on a fresh clean worktree replay to avoid unrelated staged-file contamination

## Notes
- This is a narrow issue-77 / workflow-context slice, not the full Python-elimination completion.
- It should be evaluated as part of the broader workflow-context bug family tracked by `#107`, `#108`, and `#109`.
