### PR TITLE
feat: Recipe system extensions — agent resolver, discovery, branch sanitization, recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "amplihack-recipe"
+version = "0.6.4"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "tempfile",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "amplihack-security"
 version = "0.6.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/amplihack-fleet",
     "crates/amplihack-memory",
     "crates/amplihack-launcher",
+    "crates/amplihack-recipe",
     "bins/amplihack",
     "bins/amplihack-asset-resolver",
     "bins/amplihack-hooks",
@@ -50,6 +51,7 @@ amplihack-cli = { path = "crates/amplihack-cli" }
 amplihack-fleet = { path = "crates/amplihack-fleet" }
 amplihack-memory = { path = "crates/amplihack-memory" }
 amplihack-launcher = { path = "crates/amplihack-launcher" }
+amplihack-recipe = { path = "crates/amplihack-recipe" }
 
 [profile.release]
 lto = true

--- a/crates/amplihack-recipe/Cargo.toml
+++ b/crates/amplihack-recipe/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "amplihack-recipe"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+sha2 = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/amplihack-recipe/src/agent_resolver.rs
+++ b/crates/amplihack-recipe/src/agent_resolver.rs
@@ -1,0 +1,200 @@
+//! Agent resolver — maps agent references to markdown content.
+//!
+//! Matches Python `amplihack/recipes/agent_resolver.py`:
+//! - Resolves `namespace:name` references (e.g. `amplihack:builder`)
+//! - Searches configurable list of directories
+//! - Path traversal prevention via safe-name regex
+
+use anyhow::{Context, Result, bail};
+use std::path::PathBuf;
+use tracing::debug;
+
+/// Error when an agent reference cannot be resolved.
+#[derive(Debug, thiserror::Error)]
+#[error("Agent '{agent_ref}' not found.{}", searched_msg(.searched))]
+pub struct AgentNotFoundError {
+    pub agent_ref: String,
+    pub searched: Vec<String>,
+}
+
+fn searched_msg(paths: &[String]) -> String {
+    if paths.is_empty() {
+        String::new()
+    } else {
+        format!(" Searched: {}", paths.join(", "))
+    }
+}
+
+/// Default search paths for agent definitions.
+fn default_search_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = home_dir() {
+        paths.push(home.join(".amplihack/.claude/agents"));
+    }
+    paths.push(PathBuf::from(".claude/agents"));
+    paths.push(PathBuf::from("amplifier-bundle/agents"));
+    paths.push(PathBuf::from("src/amplihack/amplifier-bundle/agents"));
+    paths.push(PathBuf::from("src/amplihack/.claude/agents"));
+    paths
+}
+
+/// Resolves `namespace:name` agent references to their markdown content.
+pub struct AgentResolver {
+    search_paths: Vec<PathBuf>,
+}
+
+impl AgentResolver {
+    pub fn new(search_paths: Option<Vec<PathBuf>>) -> Self {
+        Self {
+            search_paths: search_paths.unwrap_or_else(default_search_paths),
+        }
+    }
+
+    /// Resolve an agent reference to its markdown content.
+    ///
+    /// The reference format is `namespace:name` or `namespace:sub:name`.
+    /// Each segment is validated to prevent path traversal.
+    pub fn resolve(&self, agent_ref: &str) -> Result<String> {
+        let parts: Vec<&str> = agent_ref.split(':').collect();
+        if parts.is_empty() || parts.len() > 3 {
+            bail!("Invalid agent reference format: '{agent_ref}'");
+        }
+
+        // Validate each segment against path traversal
+        for part in &parts {
+            if !is_safe_name(part) {
+                bail!(
+                    "Invalid agent reference segment '{part}' in '{agent_ref}': \
+                     only alphanumeric, hyphens, and underscores allowed"
+                );
+            }
+        }
+
+        // Build relative path from reference parts
+        let relative = match parts.len() {
+            1 => format!("{}.md", parts[0]),
+            2 => format!("{}/{}.md", parts[0], parts[1]),
+            3 => format!("{}/{}/{}.md", parts[0], parts[1], parts[2]),
+            _ => unreachable!(),
+        };
+
+        let mut searched = Vec::new();
+        for search_dir in &self.search_paths {
+            let candidate = search_dir.join(&relative);
+            searched.push(candidate.display().to_string());
+            if candidate.is_file() {
+                debug!(path = %candidate.display(), "Resolved agent reference");
+                return std::fs::read_to_string(&candidate)
+                    .with_context(|| format!("failed to read agent file: {}", candidate.display()));
+            }
+        }
+
+        Err(AgentNotFoundError {
+            agent_ref: agent_ref.to_string(),
+            searched,
+        }
+        .into())
+    }
+
+    /// List all discoverable agent references.
+    pub fn list_agents(&self) -> Vec<String> {
+        let mut agents = Vec::new();
+        for search_dir in &self.search_paths {
+            if let Ok(entries) = std::fs::read_dir(search_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().is_some_and(|e| e == "md") {
+                        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                            agents.push(stem.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        agents.sort();
+        agents.dedup();
+        agents
+    }
+}
+
+/// Check if a name segment is safe (no path traversal).
+fn is_safe_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_name_validation() {
+        assert!(is_safe_name("builder"));
+        assert!(is_safe_name("core-architect"));
+        assert!(is_safe_name("my_agent"));
+        assert!(!is_safe_name(".."));
+        assert!(!is_safe_name("path/traversal"));
+        assert!(!is_safe_name(""));
+        assert!(!is_safe_name("has space"));
+    }
+
+    #[test]
+    fn resolve_single_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents_dir = dir.path().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("builder.md"), "# Builder Agent").unwrap();
+
+        let resolver = AgentResolver::new(Some(vec![agents_dir]));
+        let content = resolver.resolve("builder").unwrap();
+        assert_eq!(content, "# Builder Agent");
+    }
+
+    #[test]
+    fn resolve_two_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents_dir = dir.path().join("agents");
+        let ns_dir = agents_dir.join("amplihack");
+        std::fs::create_dir_all(&ns_dir).unwrap();
+        std::fs::write(ns_dir.join("builder.md"), "# amplihack Builder").unwrap();
+
+        let resolver = AgentResolver::new(Some(vec![agents_dir]));
+        let content = resolver.resolve("amplihack:builder").unwrap();
+        assert_eq!(content, "# amplihack Builder");
+    }
+
+    #[test]
+    fn resolve_rejects_path_traversal() {
+        let resolver = AgentResolver::new(Some(vec![]));
+        let result = resolver.resolve("../etc/passwd");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_returns_error_for_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolver = AgentResolver::new(Some(vec![dir.path().to_path_buf()]));
+        let result = resolver.resolve("nonexistent");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn list_agents_finds_md_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("builder.md"), "content").unwrap();
+        std::fs::write(dir.path().join("reviewer.md"), "content").unwrap();
+        std::fs::write(dir.path().join("not-agent.txt"), "content").unwrap();
+
+        let resolver = AgentResolver::new(Some(vec![dir.path().to_path_buf()]));
+        let agents = resolver.list_agents();
+        assert_eq!(agents, vec!["builder", "reviewer"]);
+    }
+}

--- a/crates/amplihack-recipe/src/branch_name.rs
+++ b/crates/amplihack-recipe/src/branch_name.rs
@@ -1,0 +1,188 @@
+//! Branch name sanitization for git worktrees.
+//!
+//! Matches the sanitization pipeline from Python's
+//! `tests/test_branch_name_sanitization.py` and
+//! `default-workflow.yaml` step-04-setup-worktree:
+//!
+//! 1. Replace newlines with spaces
+//! 2. Strip leading/trailing whitespace
+//! 3. Lowercase
+//! 4. Replace invalid chars with hyphens
+//! 5. Collapse consecutive hyphens
+//! 6. Truncate to 60 chars
+//! 7. Strip trailing hyphens/dots
+
+/// Maximum length for a sanitized branch name.
+const MAX_BRANCH_LEN: usize = 60;
+
+/// Sanitize a task description into a valid git branch name.
+///
+/// Reproduces the exact pipeline from default-workflow.yaml step-04.
+pub fn sanitize_branch_name(task_desc: &str) -> String {
+    // 1. Replace newlines/carriage returns with spaces
+    let s = task_desc.replace(['\n', '\r'], " ");
+
+    // 2. Strip leading/trailing whitespace
+    let s = s.trim();
+
+    // 3. Lowercase
+    let s = s.to_lowercase();
+
+    // 4. Replace invalid git ref chars with hyphens
+    let s: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '.' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    // 5. Collapse consecutive hyphens
+    let mut result = String::with_capacity(s.len());
+    let mut prev_hyphen = false;
+    for c in s.chars() {
+        if c == '-' {
+            if !prev_hyphen {
+                result.push('-');
+            }
+            prev_hyphen = true;
+        } else {
+            result.push(c);
+            prev_hyphen = false;
+        }
+    }
+
+    // 6. Truncate to MAX_BRANCH_LEN
+    let result = if result.len() > MAX_BRANCH_LEN {
+        result[..MAX_BRANCH_LEN].to_string()
+    } else {
+        result
+    };
+
+    // 7. Strip trailing hyphens and dots
+    result.trim_end_matches(['-', '.']).to_string()
+}
+
+/// Create a full branch name with prefix.
+pub fn make_branch_name(prefix: &str, task_desc: &str) -> String {
+    let sanitized = sanitize_branch_name(task_desc);
+    if sanitized.is_empty() {
+        format!("{prefix}/unnamed")
+    } else {
+        format!("{prefix}/{sanitized}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_description() {
+        assert_eq!(
+            sanitize_branch_name("Fix the login bug"),
+            "fix-the-login-bug"
+        );
+    }
+
+    #[test]
+    fn multiline_description() {
+        assert_eq!(
+            sanitize_branch_name("Fix the\nlogin bug\nplease"),
+            "fix-the-login-bug-please"
+        );
+    }
+
+    #[test]
+    fn special_characters() {
+        assert_eq!(
+            sanitize_branch_name("feat: add @user/auth (v2)"),
+            "feat-add-user-auth-v2"
+        );
+    }
+
+    #[test]
+    fn consecutive_hyphens_collapsed() {
+        assert_eq!(
+            sanitize_branch_name("a --- b --- c"),
+            "a-b-c"
+        );
+    }
+
+    #[test]
+    fn long_description_truncated() {
+        let long = "a".repeat(100);
+        let result = sanitize_branch_name(&long);
+        assert!(result.len() <= MAX_BRANCH_LEN);
+    }
+
+    #[test]
+    fn trailing_hyphens_stripped() {
+        assert_eq!(
+            sanitize_branch_name("fix trailing---"),
+            "fix-trailing"
+        );
+    }
+
+    #[test]
+    fn trailing_dots_stripped() {
+        assert_eq!(
+            sanitize_branch_name("version 1.0."),
+            "version-1.0"
+        );
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(sanitize_branch_name(""), "");
+    }
+
+    #[test]
+    fn whitespace_only() {
+        assert_eq!(sanitize_branch_name("   "), "");
+    }
+
+    #[test]
+    fn unicode_replaced() {
+        assert_eq!(
+            sanitize_branch_name("日本語テスト"),
+            ""  // all non-ascii → hyphens → collapsed → stripped
+        );
+    }
+
+    #[test]
+    fn make_branch_name_with_prefix() {
+        assert_eq!(
+            make_branch_name("feat", "Add user auth"),
+            "feat/add-user-auth"
+        );
+    }
+
+    #[test]
+    fn make_branch_name_empty_desc() {
+        assert_eq!(
+            make_branch_name("fix", ""),
+            "fix/unnamed"
+        );
+    }
+
+    #[test]
+    fn preserves_dots_and_underscores() {
+        assert_eq!(
+            sanitize_branch_name("v1.0_release"),
+            "v1.0_release"
+        );
+    }
+
+    #[test]
+    fn truncation_respects_trailing_strip() {
+        // 60 chars ending in hyphens should be stripped
+        let desc = format!("{}---", "x".repeat(58));
+        let result = sanitize_branch_name(&desc);
+        assert!(!result.ends_with('-'));
+        assert!(result.len() <= MAX_BRANCH_LEN);
+    }
+}

--- a/crates/amplihack-recipe/src/discovery.rs
+++ b/crates/amplihack-recipe/src/discovery.rs
@@ -1,0 +1,335 @@
+//! Recipe discovery — find, list, and cache recipe YAML files.
+//!
+//! Matches Python `amplihack/recipes/discovery.py`:
+//! - Search-path priority: package → global → local
+//! - Recipe metadata extraction from YAML front matter
+//! - Content hashing for change detection
+//! - Qualified keys (search_dir:name) and bare names
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tracing::{debug, warn};
+
+/// Metadata for a discovered recipe.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RecipeInfo {
+    pub name: String,
+    pub path: PathBuf,
+    pub version: Option<String>,
+    pub description: Option<String>,
+    pub content_hash: String,
+    pub qualified_key: String,
+}
+
+/// Cache of discovered recipes with qualified and bare name lookup.
+pub struct RecipeCache {
+    by_qualified: HashMap<String, RecipeInfo>,
+    bare_to_qualified: HashMap<String, String>,
+}
+
+impl RecipeCache {
+    pub fn new() -> Self {
+        Self {
+            by_qualified: HashMap::new(),
+            bare_to_qualified: HashMap::new(),
+        }
+    }
+
+    fn register(&mut self, info: RecipeInfo) {
+        let bare = info.name.clone();
+        let qualified = info.qualified_key.clone();
+        self.bare_to_qualified
+            .entry(bare)
+            .or_insert_with(|| qualified.clone());
+        self.by_qualified.insert(qualified, info);
+    }
+
+    /// Look up by qualified key or bare name.
+    pub fn get(&self, key: &str) -> Option<&RecipeInfo> {
+        self.by_qualified
+            .get(key)
+            .or_else(|| {
+                self.bare_to_qualified
+                    .get(key)
+                    .and_then(|qk| self.by_qualified.get(qk))
+            })
+    }
+
+    pub fn contains(&self, key: &str) -> bool {
+        self.get(key).is_some()
+    }
+
+    /// All qualified keys.
+    pub fn qualified_keys(&self) -> Vec<&str> {
+        self.by_qualified.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Map of bare names to their first qualified key.
+    pub fn bare_name_map(&self) -> &HashMap<String, String> {
+        &self.bare_to_qualified
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_qualified.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_qualified.is_empty()
+    }
+}
+
+impl Default for RecipeCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Default search directories for recipes, in priority order.
+pub fn default_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = home_dir() {
+        dirs.push(home.join(".amplihack/.claude/recipes"));
+    }
+    // AMPLIHACK_HOME-relative
+    if let Ok(ah) = std::env::var("AMPLIHACK_HOME") {
+        let ah = PathBuf::from(ah);
+        dirs.push(ah.join("amplifier-bundle/recipes"));
+        dirs.push(ah.join(".claude/recipes"));
+    }
+    dirs.push(PathBuf::from("amplifier-bundle/recipes"));
+    dirs.push(PathBuf::from("src/amplihack/amplifier-bundle/recipes"));
+    dirs.push(PathBuf::from(".claude/recipes"));
+    dirs
+}
+
+/// Discover all recipes in the given search directories.
+pub fn discover_recipes(search_dirs: &[PathBuf]) -> RecipeCache {
+    let mut cache = RecipeCache::new();
+    for dir in search_dirs {
+        if !dir.is_dir() {
+            continue;
+        }
+        debug!(dir = %dir.display(), "Scanning for recipes");
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if is_recipe_file(&path) {
+                    if let Some(info) = load_recipe_info(&path, dir) {
+                        cache.register(info);
+                    }
+                }
+            }
+        }
+    }
+    debug!(count = cache.len(), "Recipes discovered");
+    cache
+}
+
+/// List all discoverable recipes.
+pub fn list_recipes(search_dirs: Option<&[PathBuf]>) -> Vec<RecipeInfo> {
+    let default = default_search_dirs();
+    let dirs = search_dirs.unwrap_or(&default);
+    let cache = discover_recipes(dirs);
+    let mut recipes: Vec<RecipeInfo> = cache.by_qualified.into_values().collect();
+    recipes.sort_by(|a, b| a.name.cmp(&b.name));
+    recipes
+}
+
+/// Find a specific recipe by name.
+pub fn find_recipe(name: &str, search_dirs: Option<&[PathBuf]>) -> Option<PathBuf> {
+    let default = default_search_dirs();
+    let dirs = search_dirs.unwrap_or(&default);
+    for dir in dirs {
+        if !dir.is_dir() {
+            continue;
+        }
+        for ext in &["yaml", "yml"] {
+            let candidate = dir.join(format!("{name}.{ext}"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Verify global recipe installation.
+pub fn verify_global_installation() -> VerifyResult {
+    let dirs = default_search_dirs();
+    let found_dirs: Vec<_> = dirs.iter().filter(|d| d.is_dir()).cloned().collect();
+    let cache = discover_recipes(&found_dirs);
+    VerifyResult {
+        search_dirs_checked: dirs.len(),
+        search_dirs_found: found_dirs.len(),
+        recipes_found: cache.len(),
+        recipe_names: cache.qualified_keys().iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+/// Result of global installation verification.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct VerifyResult {
+    pub search_dirs_checked: usize,
+    pub search_dirs_found: usize,
+    pub recipes_found: usize,
+    pub recipe_names: Vec<String>,
+}
+
+/// Compute content hash for change detection.
+pub fn file_hash(path: &Path) -> Result<String> {
+    let content = std::fs::read(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&content);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn load_recipe_info(path: &Path, search_dir: &Path) -> Option<RecipeInfo> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let name = path.file_stem()?.to_str()?.to_string();
+    let qualified_key = qualified_key(search_dir, &name);
+    let content_hash = {
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_bytes());
+        format!("{:x}", hasher.finalize())
+    };
+
+    // Extract version and description from YAML
+    let (version, description) = match serde_yaml::from_str::<serde_yaml::Value>(&content) {
+        Ok(doc) => {
+            let version = doc
+                .get("version")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let description = doc
+                .get("description")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            (version, description)
+        }
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "Failed to parse recipe YAML");
+            (None, None)
+        }
+    };
+
+    Some(RecipeInfo {
+        name,
+        path: path.to_path_buf(),
+        version,
+        description,
+        content_hash,
+        qualified_key,
+    })
+}
+
+fn qualified_key(search_dir: &Path, name: &str) -> String {
+    let dir_name = search_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+    format!("{dir_name}:{name}")
+}
+
+fn is_recipe_file(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .extension()
+            .is_some_and(|e| e == "yaml" || e == "yml")
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_finds_yaml_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("test-recipe.yaml"),
+            "name: test\nversion: '1.0'\ndescription: A test recipe\nsteps: []",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("not-recipe.txt"), "ignored").unwrap();
+
+        let cache = discover_recipes(&[dir.path().to_path_buf()]);
+        assert_eq!(cache.len(), 1);
+        assert!(cache.contains("test-recipe"));
+    }
+
+    #[test]
+    fn qualified_and_bare_lookup() {
+        let dir = tempfile::tempdir().unwrap();
+        let recipes = dir.path().join("recipes");
+        std::fs::create_dir_all(&recipes).unwrap();
+        std::fs::write(recipes.join("my-recipe.yaml"), "name: my-recipe\nsteps: []").unwrap();
+
+        let cache = discover_recipes(&[recipes.clone()]);
+        let qualified = cache.qualified_keys();
+        assert_eq!(qualified.len(), 1);
+        assert!(qualified[0].contains("my-recipe"));
+
+        // Bare name lookup
+        assert!(cache.get("my-recipe").is_some());
+    }
+
+    #[test]
+    fn find_recipe_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("default-workflow.yaml"), "steps: []").unwrap();
+        let found = find_recipe("default-workflow", Some(&[dir.path().to_path_buf()]));
+        assert!(found.is_some());
+        assert!(find_recipe("nonexistent", Some(&[dir.path().to_path_buf()])).is_none());
+    }
+
+    #[test]
+    fn file_hash_deterministic() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.yaml");
+        std::fs::write(&file, "content: hello").unwrap();
+        let h1 = file_hash(&file).unwrap();
+        let h2 = file_hash(&file).unwrap();
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64); // SHA-256 hex
+    }
+
+    #[test]
+    fn verify_result_serializes() {
+        let result = VerifyResult {
+            search_dirs_checked: 5,
+            search_dirs_found: 2,
+            recipes_found: 3,
+            recipe_names: vec!["a".into(), "b".into()],
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["recipes_found"], 3);
+    }
+
+    #[test]
+    fn recipe_info_extracts_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("smart.yaml"),
+            "version: '2.0'\ndescription: Smart orchestrator\nsteps: []",
+        )
+        .unwrap();
+        let cache = discover_recipes(&[dir.path().to_path_buf()]);
+        let info = cache.get("smart").unwrap();
+        assert_eq!(info.version.as_deref(), Some("2.0"));
+        assert_eq!(info.description.as_deref(), Some("Smart orchestrator"));
+    }
+
+    #[test]
+    fn empty_cache() {
+        let cache = RecipeCache::new();
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+        assert!(cache.get("anything").is_none());
+    }
+}

--- a/crates/amplihack-recipe/src/lib.rs
+++ b/crates/amplihack-recipe/src/lib.rs
@@ -1,0 +1,15 @@
+//! amplihack-recipe: Recipe system extensions for parity with Python.
+//!
+//! Provides agent resolution, recipe discovery/caching, branch name
+//! sanitization, and sub-recipe recovery — filling gaps between the
+//! existing Rust recipe runner and the Python recipe subsystem.
+
+pub mod agent_resolver;
+pub mod branch_name;
+pub mod discovery;
+pub mod sub_recipe_recovery;
+
+pub use agent_resolver::AgentResolver;
+pub use branch_name::{make_branch_name, sanitize_branch_name};
+pub use discovery::{RecipeCache, RecipeInfo, discover_recipes, find_recipe, list_recipes};
+pub use sub_recipe_recovery::{FailureClass, FailureContext, RecoveryResult, SubRecipeRecovery};

--- a/crates/amplihack-recipe/src/sub_recipe_recovery.rs
+++ b/crates/amplihack-recipe/src/sub_recipe_recovery.rs
@@ -1,0 +1,307 @@
+//! Sub-recipe recovery — agentic error recovery for nested recipe failures.
+//!
+//! Matches Python `amplihack/recipes/tests/test_sub_recipe_recovery.py`:
+//! - When a sub-recipe step fails, attempt agent-based recovery
+//! - Classify failures as recoverable vs unrecoverable
+//! - Preserve error context from both original and recovery attempts
+//! - Limit recovery attempts to prevent infinite loops
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// Maximum recovery attempts before giving up.
+const MAX_RECOVERY_ATTEMPTS: u32 = 2;
+
+/// Classification of a sub-recipe failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FailureClass {
+    /// The failure can potentially be recovered by an agent.
+    Recoverable,
+    /// The failure is permanent (e.g., missing dependency, auth error).
+    Unrecoverable,
+    /// Unknown — attempt recovery once then give up.
+    Unknown,
+}
+
+/// Context about a failed sub-recipe execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureContext {
+    pub recipe_name: String,
+    pub step_id: String,
+    pub error_message: String,
+    pub exit_code: Option<i32>,
+    pub failure_class: FailureClass,
+    pub attempt: u32,
+}
+
+/// Result of a recovery attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecoveryResult {
+    pub recovered: bool,
+    pub output: String,
+    pub attempt: u32,
+    pub strategy: String,
+}
+
+/// Manages sub-recipe error recovery.
+pub struct SubRecipeRecovery {
+    max_attempts: u32,
+}
+
+impl SubRecipeRecovery {
+    pub fn new() -> Self {
+        Self {
+            max_attempts: MAX_RECOVERY_ATTEMPTS,
+        }
+    }
+
+    pub fn with_max_attempts(max_attempts: u32) -> Self {
+        Self { max_attempts }
+    }
+
+    /// Classify a failure to determine if recovery should be attempted.
+    pub fn classify_failure(&self, error: &str, exit_code: Option<i32>) -> FailureClass {
+        let error_lower = error.to_lowercase();
+
+        // Unrecoverable patterns
+        let unrecoverable = [
+            "permission denied",
+            "authentication failed",
+            "not found: 404",
+            "out of memory",
+            "disk full",
+            "unrecoverable",
+            "fatal:",
+            "cannot find module",
+        ];
+        if unrecoverable.iter().any(|p| error_lower.contains(p)) {
+            return FailureClass::Unrecoverable;
+        }
+
+        // Exit codes that indicate unrecoverable issues
+        if matches!(exit_code, Some(126) | Some(127) | Some(137)) {
+            return FailureClass::Unrecoverable;
+        }
+
+        // Recoverable patterns
+        let recoverable = [
+            "test failed",
+            "compilation error",
+            "syntax error",
+            "lint error",
+            "type error",
+            "assertion failed",
+            "command exited with code 1",
+        ];
+        if recoverable.iter().any(|p| error_lower.contains(p)) {
+            return FailureClass::Recoverable;
+        }
+
+        FailureClass::Unknown
+    }
+
+    /// Check if recovery should be attempted.
+    pub fn should_attempt_recovery(&self, ctx: &FailureContext) -> bool {
+        if ctx.attempt >= self.max_attempts {
+            warn!(
+                recipe = ctx.recipe_name,
+                attempt = ctx.attempt,
+                "Max recovery attempts reached"
+            );
+            return false;
+        }
+        ctx.failure_class != FailureClass::Unrecoverable
+    }
+
+    /// Build a recovery prompt for the agent.
+    pub fn build_recovery_prompt(&self, ctx: &FailureContext) -> String {
+        format!(
+            "Sub-recipe '{}' failed at step '{}' (attempt {}/{}).\n\n\
+             Error: {}\n\n\
+             Please analyze the failure and attempt to fix the issue. \
+             If the issue is unrecoverable, respond with UNRECOVERABLE.",
+            ctx.recipe_name,
+            ctx.step_id,
+            ctx.attempt + 1,
+            self.max_attempts,
+            ctx.error_message,
+        )
+    }
+
+    /// Parse the agent's recovery response.
+    pub fn parse_recovery_response(&self, response: &str, attempt: u32) -> RecoveryResult {
+        let response_lower = response.to_lowercase();
+        if response_lower.contains("unrecoverable") {
+            return RecoveryResult {
+                recovered: false,
+                output: response.to_string(),
+                attempt,
+                strategy: "agent_declared_unrecoverable".into(),
+            };
+        }
+        // If the agent provided a response without UNRECOVERABLE, consider it recovered
+        RecoveryResult {
+            recovered: !response.trim().is_empty(),
+            output: response.to_string(),
+            attempt,
+            strategy: "agent_recovery".into(),
+        }
+    }
+}
+
+impl Default for SubRecipeRecovery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_unrecoverable_patterns() {
+        let r = SubRecipeRecovery::new();
+        assert_eq!(
+            r.classify_failure("Permission denied: /root/.ssh", None),
+            FailureClass::Unrecoverable
+        );
+        assert_eq!(
+            r.classify_failure("Fatal: could not read", None),
+            FailureClass::Unrecoverable
+        );
+        assert_eq!(
+            r.classify_failure("something", Some(127)),
+            FailureClass::Unrecoverable
+        );
+    }
+
+    #[test]
+    fn classify_recoverable_patterns() {
+        let r = SubRecipeRecovery::new();
+        assert_eq!(
+            r.classify_failure("Test failed: 3 assertions", None),
+            FailureClass::Recoverable
+        );
+        assert_eq!(
+            r.classify_failure("Compilation error in main.rs", None),
+            FailureClass::Recoverable
+        );
+        assert_eq!(
+            r.classify_failure("command exited with code 1", None),
+            FailureClass::Recoverable
+        );
+    }
+
+    #[test]
+    fn classify_unknown() {
+        let r = SubRecipeRecovery::new();
+        assert_eq!(
+            r.classify_failure("something unexpected happened", None),
+            FailureClass::Unknown
+        );
+    }
+
+    #[test]
+    fn should_attempt_recovery() {
+        let r = SubRecipeRecovery::new();
+        let ctx = FailureContext {
+            recipe_name: "test".into(),
+            step_id: "s1".into(),
+            error_message: "test failed".into(),
+            exit_code: Some(1),
+            failure_class: FailureClass::Recoverable,
+            attempt: 0,
+        };
+        assert!(r.should_attempt_recovery(&ctx));
+    }
+
+    #[test]
+    fn should_not_recover_unrecoverable() {
+        let r = SubRecipeRecovery::new();
+        let ctx = FailureContext {
+            recipe_name: "test".into(),
+            step_id: "s1".into(),
+            error_message: "perm denied".into(),
+            exit_code: None,
+            failure_class: FailureClass::Unrecoverable,
+            attempt: 0,
+        };
+        assert!(!r.should_attempt_recovery(&ctx));
+    }
+
+    #[test]
+    fn should_not_recover_max_attempts() {
+        let r = SubRecipeRecovery::new();
+        let ctx = FailureContext {
+            recipe_name: "test".into(),
+            step_id: "s1".into(),
+            error_message: "test failed".into(),
+            exit_code: None,
+            failure_class: FailureClass::Recoverable,
+            attempt: 2,
+        };
+        assert!(!r.should_attempt_recovery(&ctx));
+    }
+
+    #[test]
+    fn recovery_prompt_includes_context() {
+        let r = SubRecipeRecovery::new();
+        let ctx = FailureContext {
+            recipe_name: "default-workflow".into(),
+            step_id: "step-05".into(),
+            error_message: "cargo test failed".into(),
+            exit_code: Some(1),
+            failure_class: FailureClass::Recoverable,
+            attempt: 0,
+        };
+        let prompt = r.build_recovery_prompt(&ctx);
+        assert!(prompt.contains("default-workflow"));
+        assert!(prompt.contains("step-05"));
+        assert!(prompt.contains("cargo test failed"));
+        assert!(prompt.contains("1/2"));
+    }
+
+    #[test]
+    fn parse_unrecoverable_response() {
+        let r = SubRecipeRecovery::new();
+        let result = r.parse_recovery_response(
+            "This is UNRECOVERABLE - missing external dependency",
+            0,
+        );
+        assert!(!result.recovered);
+        assert_eq!(result.strategy, "agent_declared_unrecoverable");
+    }
+
+    #[test]
+    fn parse_successful_recovery() {
+        let r = SubRecipeRecovery::new();
+        let result = r.parse_recovery_response(
+            "Fixed the compilation error by adding missing import",
+            0,
+        );
+        assert!(result.recovered);
+        assert_eq!(result.strategy, "agent_recovery");
+    }
+
+    #[test]
+    fn parse_empty_response_not_recovered() {
+        let r = SubRecipeRecovery::new();
+        let result = r.parse_recovery_response("", 0);
+        assert!(!result.recovered);
+    }
+
+    #[test]
+    fn custom_max_attempts() {
+        let r = SubRecipeRecovery::with_max_attempts(5);
+        let ctx = FailureContext {
+            recipe_name: "test".into(),
+            step_id: "s1".into(),
+            error_message: "failed".into(),
+            exit_code: None,
+            failure_class: FailureClass::Recoverable,
+            attempt: 4,
+        };
+        assert!(r.should_attempt_recovery(&ctx));
+    }
+}


### PR DESCRIPTION
## Summary
Adds the `amplihack-recipe` crate filling gaps between the Rust recipe runner and the Python recipe subsystem.

## What's Implemented

### AgentResolver (`agent_resolver.rs`, 200 lines)
- Resolves `namespace:name` references to markdown content
- Path traversal prevention via safe-name regex
- Configurable search paths (home, .claude, amplifier-bundle)
- Agent listing/discovery

### Recipe Discovery (`discovery.rs`, 335 lines)
- Find, list, and cache recipe YAML files
- Search-path priority (package → global → local)
- Content hashing (SHA-256) for change detection
- Qualified keys (`search_dir:name`) and bare name lookup
- Global installation verification

### Branch Name Sanitization (`branch_name.rs`, 188 lines)
- 7-step pipeline matching default-workflow.yaml step-04
- Newlines → spaces → trim → lowercase → invalid chars → collapse → truncate → strip
- Max 60 characters, valid git branch names

### Sub-Recipe Recovery (`sub_recipe_recovery.rs`, 307 lines)
- Classifies failures: recoverable (test/compile errors) vs unrecoverable (auth/disk)
- Recovery prompt generation with context
- Agent response parsing (UNRECOVERABLE detection)
- Max attempt enforcement (default 2)

## Python Parity
Matches these Python modules:
- `recipes/agent_resolver.py`
- `recipes/discovery.py`
- `recipes/tests/test_branch_name_sanitization.py`
- `recipes/tests/test_sub_recipe_recovery.py`

## Quality
- **38 tests** covering all paths
- **All files under 400 lines** (largest: 335)
- **Full workspace build passes**
- 1045 lines total

Partial close of #111