### PR TITLE
feat: Context detection — launcher, mode, path resolver, LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "amplihack-context"
+version = "0.6.4"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "amplihack-fleet"
 version = "0.6.4"
 dependencies = [
@@ -352,7 +364,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/amplihack-launcher",
     "crates/amplihack-recipe",
     "crates/amplihack-safety",
+    "crates/amplihack-context",
     "bins/amplihack",
     "bins/amplihack-asset-resolver",
     "bins/amplihack-hooks",

--- a/crates/amplihack-context/Cargo.toml
+++ b/crates/amplihack-context/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "amplihack-context"
+description = "Adaptive context detection, mode resolution, and LSP configuration"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { version = "0.4", features = ["serde"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/amplihack-context/src/launcher_detector.rs
+++ b/crates/amplihack-context/src/launcher_detector.rs
@@ -1,0 +1,223 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Launcher identity for adaptive hook injection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LauncherType {
+    Claude,
+    Copilot,
+    Unknown,
+}
+
+/// Persisted launcher context written by the bootstrap layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LauncherContext {
+    pub launcher_type: LauncherType,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub environment: Option<String>,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Reads/writes `.claude/runtime/launcher_context.json` to detect
+/// which agent launcher (Claude Code, Copilot, etc.) started the session.
+pub struct LauncherDetector {
+    context_path: PathBuf,
+}
+
+impl LauncherDetector {
+    pub fn new(project_dir: &Path) -> Self {
+        Self {
+            context_path: project_dir.join(".claude/runtime/launcher_context.json"),
+        }
+    }
+
+    /// Detect the current launcher, returning `Unknown` when the file is
+    /// missing or stale (> 24 h).
+    pub fn detect(&self) -> LauncherType {
+        match self.read_context() {
+            Ok(ctx) => {
+                if self.is_stale_ctx(&ctx, 24) {
+                    tracing::debug!("launcher context is stale");
+                    LauncherType::Unknown
+                } else {
+                    ctx.launcher_type
+                }
+            }
+            Err(_) => LauncherType::Unknown,
+        }
+    }
+
+    /// Persist a new launcher context to disk.
+    pub fn write_context(
+        &self,
+        launcher_type: LauncherType,
+        command: Option<String>,
+        environment: Option<String>,
+    ) -> Result<()> {
+        let ctx = LauncherContext {
+            launcher_type,
+            command,
+            environment,
+            timestamp: Utc::now(),
+        };
+        if let Some(parent) = self.context_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create dir: {}", parent.display()))?;
+        }
+        let json = serde_json::to_string_pretty(&ctx)?;
+        std::fs::write(&self.context_path, json)
+            .with_context(|| format!("write: {}", self.context_path.display()))?;
+        Ok(())
+    }
+
+    /// Whether the persisted context is older than `max_age_hours`.
+    pub fn is_stale(&self, max_age_hours: i64) -> bool {
+        match self.read_context() {
+            Ok(ctx) => self.is_stale_ctx(&ctx, max_age_hours),
+            Err(_) => true,
+        }
+    }
+
+    /// Remove the context file.
+    pub fn cleanup(&self) -> Result<()> {
+        if self.context_path.exists() {
+            std::fs::remove_file(&self.context_path)?;
+        }
+        Ok(())
+    }
+
+    /// Return the on-disk path for inspection/testing.
+    pub fn context_path(&self) -> &Path {
+        &self.context_path
+    }
+
+    fn read_context(&self) -> Result<LauncherContext> {
+        let content = std::fs::read_to_string(&self.context_path)?;
+        let ctx: LauncherContext = serde_json::from_str(&content)?;
+        Ok(ctx)
+    }
+
+    fn is_stale_ctx(&self, ctx: &LauncherContext, max_age_hours: i64) -> bool {
+        let age = Utc::now() - ctx.timestamp;
+        age.num_hours() >= max_age_hours
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, LauncherDetector) {
+        let dir = TempDir::new().unwrap();
+        let det = LauncherDetector::new(dir.path());
+        (dir, det)
+    }
+
+    #[test]
+    fn detect_unknown_when_no_file() {
+        let (_dir, det) = setup();
+        assert_eq!(det.detect(), LauncherType::Unknown);
+    }
+
+    #[test]
+    fn detect_claude_after_write() {
+        let (_dir, det) = setup();
+        det.write_context(LauncherType::Claude, Some("claude".into()), None)
+            .unwrap();
+        assert_eq!(det.detect(), LauncherType::Claude);
+    }
+
+    #[test]
+    fn detect_copilot_after_write() {
+        let (_dir, det) = setup();
+        det.write_context(LauncherType::Copilot, None, Some("vscode".into()))
+            .unwrap();
+        assert_eq!(det.detect(), LauncherType::Copilot);
+    }
+
+    #[test]
+    fn write_context_creates_directories() {
+        let (_dir, det) = setup();
+        assert!(!det.context_path().exists());
+        det.write_context(LauncherType::Claude, None, None).unwrap();
+        assert!(det.context_path().exists());
+    }
+
+    #[test]
+    fn is_stale_returns_true_when_no_file() {
+        let (_dir, det) = setup();
+        assert!(det.is_stale(24));
+    }
+
+    #[test]
+    fn is_stale_returns_false_for_fresh_context() {
+        let (_dir, det) = setup();
+        det.write_context(LauncherType::Claude, None, None).unwrap();
+        assert!(!det.is_stale(24));
+    }
+
+    #[test]
+    fn is_stale_returns_true_for_zero_max_age() {
+        let (_dir, det) = setup();
+        det.write_context(LauncherType::Claude, None, None).unwrap();
+        // max_age_hours=0 means anything >= 0 hours old is stale
+        assert!(det.is_stale(0));
+    }
+
+    #[test]
+    fn detect_stale_context_returns_unknown() {
+        let (_dir, det) = setup();
+        // Write a context with a timestamp far in the past
+        let ctx = LauncherContext {
+            launcher_type: LauncherType::Claude,
+            command: None,
+            environment: None,
+            timestamp: Utc::now() - chrono::Duration::hours(48),
+        };
+        std::fs::create_dir_all(det.context_path().parent().unwrap()).unwrap();
+        std::fs::write(
+            det.context_path(),
+            serde_json::to_string_pretty(&ctx).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(det.detect(), LauncherType::Unknown);
+    }
+
+    #[test]
+    fn cleanup_removes_file() {
+        let (_dir, det) = setup();
+        det.write_context(LauncherType::Claude, None, None).unwrap();
+        assert!(det.context_path().exists());
+        det.cleanup().unwrap();
+        assert!(!det.context_path().exists());
+    }
+
+    #[test]
+    fn cleanup_noop_when_missing() {
+        let (_dir, det) = setup();
+        det.cleanup().unwrap(); // should not error
+    }
+
+    #[test]
+    fn roundtrip_serialization() {
+        let (_dir, det) = setup();
+        det.write_context(
+            LauncherType::Copilot,
+            Some("copilot-cli".into()),
+            Some("terminal".into()),
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(det.context_path()).unwrap();
+        let ctx: LauncherContext = serde_json::from_str(&raw).unwrap();
+        assert_eq!(ctx.launcher_type, LauncherType::Copilot);
+        assert_eq!(ctx.command.as_deref(), Some("copilot-cli"));
+        assert_eq!(ctx.environment.as_deref(), Some("terminal"));
+    }
+}

--- a/crates/amplihack-context/src/lib.rs
+++ b/crates/amplihack-context/src/lib.rs
@@ -1,0 +1,13 @@
+//! Adaptive context detection, mode resolution, path handling, and LSP configuration.
+
+pub mod launcher_detector;
+pub mod strategies;
+pub mod mode_detector;
+pub mod path_resolver;
+pub mod lsp_detector;
+
+pub use launcher_detector::{LauncherDetector, LauncherType, LauncherContext};
+pub use strategies::{HookStrategy, ClaudeStrategy, CopilotStrategy};
+pub use mode_detector::{ClaudeMode, ModeDetector};
+pub use path_resolver::PathResolver;
+pub use lsp_detector::LSPDetector;

--- a/crates/amplihack-context/src/lsp_detector.rs
+++ b/crates/amplihack-context/src/lsp_detector.rs
@@ -1,0 +1,274 @@
+use std::path::Path;
+
+use serde_json::{json, Value};
+
+struct LanguagePattern {
+    id: &'static str,
+    extensions: &'static [&'static str],
+}
+
+const LANGUAGE_PATTERNS: &[LanguagePattern] = &[
+    LanguagePattern {
+        id: "py",
+        extensions: &["*.py"],
+    },
+    LanguagePattern {
+        id: "js",
+        extensions: &["*.js", "*.jsx"],
+    },
+    LanguagePattern {
+        id: "ts",
+        extensions: &["*.ts", "*.tsx"],
+    },
+    LanguagePattern {
+        id: "rs",
+        extensions: &["*.rs"],
+    },
+    LanguagePattern {
+        id: "go",
+        extensions: &["*.go"],
+    },
+];
+
+const IGNORED_DIRS: &[&str] = &[
+    "node_modules",
+    ".git",
+    "venv",
+    "__pycache__",
+    "target",
+    ".venv",
+    "dist",
+    "build",
+];
+
+/// Maximum directory depth to recurse when scanning for source files.
+const MAX_SCAN_DEPTH: usize = 5;
+
+/// Detects project languages and generates LSP server configurations.
+pub struct LSPDetector;
+
+impl LSPDetector {
+    /// Walk `project_path` and return the set of detected language IDs.
+    pub fn detect_languages(project_path: &Path) -> Vec<String> {
+        LANGUAGE_PATTERNS
+            .iter()
+            .filter(|lp| Self::has_files(project_path, lp.extensions, 0))
+            .map(|lp| lp.id.to_string())
+            .collect()
+    }
+
+    /// Build an `{ "lsp_servers": { … } }` config for the given language
+    /// IDs.
+    pub fn generate_lsp_config(languages: &[String]) -> Value {
+        let mut servers = serde_json::Map::new();
+        for lang in languages {
+            if let Some(cfg) = Self::lsp_config_for(lang) {
+                servers.insert(lang.clone(), cfg);
+            }
+        }
+        json!({ "lsp_servers": servers })
+    }
+
+    /// Shallow-merge `lsp_config` into `existing` (top-level keys only).
+    pub fn update_settings(existing: &Value, lsp_config: &Value) -> Value {
+        let mut merged = existing.clone();
+        if let (Some(base), Some(new)) = (merged.as_object_mut(), lsp_config.as_object()) {
+            for (k, v) in new {
+                base.insert(k.clone(), v.clone());
+            }
+        }
+        merged
+    }
+
+    // -- internal --------------------------------------------------------
+
+    fn has_files(dir: &Path, patterns: &[&str], depth: usize) -> bool {
+        if depth > MAX_SCAN_DEPTH {
+            return false;
+        }
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(_) => return false,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+
+            if path.is_dir() {
+                if IGNORED_DIRS.contains(&name_str.as_ref()) {
+                    continue;
+                }
+                if Self::has_files(&path, patterns, depth + 1) {
+                    return true;
+                }
+            } else if patterns.iter().any(|p| matches_glob(p, &name_str)) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn lsp_config_for(language: &str) -> Option<Value> {
+        Some(match language {
+            "py" => json!({
+                "command": ["pyright-langserver", "--stdio"],
+                "languages": ["python"]
+            }),
+            "js" | "ts" => json!({
+                "command": ["typescript-language-server", "--stdio"],
+                "languages": ["javascript", "typescript"]
+            }),
+            "rs" => json!({
+                "command": ["rust-analyzer"],
+                "languages": ["rust"]
+            }),
+            "go" => json!({
+                "command": ["gopls"],
+                "languages": ["go"]
+            }),
+            _ => return None,
+        })
+    }
+}
+
+/// Trivial glob: only supports `*.ext` patterns.
+fn matches_glob(pattern: &str, filename: &str) -> bool {
+    match pattern.strip_prefix("*.") {
+        Some(ext) => filename.ends_with(&format!(".{ext}")),
+        None => filename == pattern,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn project_with_files(files: &[&str]) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        for f in files {
+            let path = dir.path().join(f);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&path, "// stub").unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn detect_python() {
+        let dir = project_with_files(&["app.py"]);
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(langs.contains(&"py".to_string()));
+    }
+
+    #[test]
+    fn detect_rust() {
+        let dir = project_with_files(&["src/main.rs"]);
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(langs.contains(&"rs".to_string()));
+    }
+
+    #[test]
+    fn detect_javascript() {
+        let dir = project_with_files(&["index.js"]);
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(langs.contains(&"js".to_string()));
+    }
+
+    #[test]
+    fn detect_typescript_tsx() {
+        let dir = project_with_files(&["src/App.tsx"]);
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(langs.contains(&"ts".to_string()));
+    }
+
+    #[test]
+    fn detect_go() {
+        let dir = project_with_files(&["main.go"]);
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(langs.contains(&"go".to_string()));
+    }
+
+    #[test]
+    fn detect_no_languages_in_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(langs.is_empty());
+    }
+
+    #[test]
+    fn detect_multiple_languages() {
+        let dir = project_with_files(&["main.py", "lib.rs", "app.go"]);
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(langs.contains(&"py".to_string()));
+        assert!(langs.contains(&"rs".to_string()));
+        assert!(langs.contains(&"go".to_string()));
+    }
+
+    #[test]
+    fn ignored_dirs_are_skipped() {
+        let dir = project_with_files(&["node_modules/dep/index.js"]);
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(!langs.contains(&"js".to_string()));
+    }
+
+    #[test]
+    fn ignored_dirs_target() {
+        let dir = project_with_files(&["target/debug/build.rs"]);
+        let langs = LSPDetector::detect_languages(dir.path());
+        assert!(!langs.contains(&"rs".to_string()));
+    }
+
+    #[test]
+    fn generate_config_python() {
+        let config = LSPDetector::generate_lsp_config(&["py".to_string()]);
+        let servers = &config["lsp_servers"];
+        assert!(servers["py"]["command"].is_array());
+    }
+
+    #[test]
+    fn generate_config_empty() {
+        let config = LSPDetector::generate_lsp_config(&[]);
+        let servers = config["lsp_servers"].as_object().unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn generate_config_unknown_language_skipped() {
+        let config = LSPDetector::generate_lsp_config(&["brainfuck".to_string()]);
+        let servers = config["lsp_servers"].as_object().unwrap();
+        assert!(!servers.contains_key("brainfuck"));
+    }
+
+    #[test]
+    fn update_settings_merges() {
+        let existing = json!({ "editor": "vim", "lsp_servers": {} });
+        let lsp = json!({ "lsp_servers": { "py": { "command": ["pyright"] } } });
+        let merged = LSPDetector::update_settings(&existing, &lsp);
+        assert_eq!(merged["editor"], "vim");
+        assert!(merged["lsp_servers"]["py"].is_object());
+    }
+
+    #[test]
+    fn update_settings_overwrites_key() {
+        let existing = json!({ "lsp_servers": { "py": "old" } });
+        let lsp = json!({ "lsp_servers": { "py": "new" } });
+        let merged = LSPDetector::update_settings(&existing, &lsp);
+        assert_eq!(merged["lsp_servers"]["py"], "new");
+    }
+
+    #[test]
+    fn matches_glob_extension() {
+        assert!(matches_glob("*.rs", "main.rs"));
+        assert!(!matches_glob("*.rs", "main.py"));
+    }
+
+    #[test]
+    fn matches_glob_exact() {
+        assert!(matches_glob("Makefile", "Makefile"));
+        assert!(!matches_glob("Makefile", "makefile"));
+    }
+}

--- a/crates/amplihack-context/src/mode_detector.rs
+++ b/crates/amplihack-context/src/mode_detector.rs
@@ -1,0 +1,189 @@
+use std::path::{Path, PathBuf};
+
+/// Installation mode for the amplihack Claude integration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaudeMode {
+    /// `.claude/` exists in the project with all essential directories.
+    Local,
+    /// `~/.amplihack/.claude/` contains a plugin manifest.
+    Plugin,
+    /// No installation detected.
+    None,
+}
+
+/// Essential sub-directories that must all exist under `.claude/` for a
+/// local installation to be recognised.
+const ESSENTIAL_DIRS: &[&str] = &["agents", "commands", "skills", "tools"];
+
+/// Detects the amplihack installation mode for a project.
+pub struct ModeDetector;
+
+impl ModeDetector {
+    /// Detect mode with precedence: env-override → Local → Plugin → None.
+    pub fn detect(project_dir: &Path) -> ClaudeMode {
+        if let Ok(mode) = std::env::var("AMPLIHACK_MODE") {
+            match mode.to_lowercase().as_str() {
+                "local" => return ClaudeMode::Local,
+                "plugin" => return ClaudeMode::Plugin,
+                "none" => return ClaudeMode::None,
+                other => tracing::warn!("unknown AMPLIHACK_MODE value: {other}"),
+            }
+        }
+
+        if Self::has_local_installation(project_dir) {
+            ClaudeMode::Local
+        } else if Self::has_plugin_installation() {
+            ClaudeMode::Plugin
+        } else {
+            ClaudeMode::None
+        }
+    }
+
+    /// Check whether `project_dir/.claude/` exists with all essential
+    /// sub-directories.
+    pub fn has_local_installation(project_dir: &Path) -> bool {
+        let claude_dir = project_dir.join(".claude");
+        claude_dir.is_dir()
+            && ESSENTIAL_DIRS
+                .iter()
+                .all(|d| claude_dir.join(d).is_dir())
+    }
+
+    /// Check whether `~/.amplihack/.claude/` contains a plugin manifest.
+    pub fn has_plugin_installation() -> bool {
+        home_dir()
+            .map(|h| {
+                let plugin = h.join(".amplihack/.claude");
+                plugin.is_dir() && plugin.join("plugin_manifest.json").exists()
+            })
+            .unwrap_or(false)
+    }
+
+    /// Return the `.claude` directory for a given mode, if any.
+    pub fn get_claude_dir(mode: &ClaudeMode, project_dir: &Path) -> Option<PathBuf> {
+        match mode {
+            ClaudeMode::Local => Some(project_dir.join(".claude")),
+            ClaudeMode::Plugin => home_dir().map(|h| h.join(".amplihack/.claude")),
+            ClaudeMode::None => None,
+        }
+    }
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_local_installation(base: &Path) {
+        let claude = base.join(".claude");
+        for d in ESSENTIAL_DIRS {
+            std::fs::create_dir_all(claude.join(d)).unwrap();
+        }
+    }
+
+    #[test]
+    fn detect_none_when_empty() {
+        let dir = TempDir::new().unwrap();
+        // Ensure env override is not set for this test
+        let mode = ModeDetector::detect(dir.path());
+        // May be None or Plugin depending on host; at minimum it's not Local
+        assert_ne!(mode, ClaudeMode::Local);
+    }
+
+    #[test]
+    fn detect_local_when_essential_dirs_present() {
+        let dir = TempDir::new().unwrap();
+        create_local_installation(dir.path());
+        // Temporarily override to avoid plugin detection interfering
+        unsafe { std::env::remove_var("AMPLIHACK_MODE") };
+        let mode = ModeDetector::detect(dir.path());
+        assert_eq!(mode, ClaudeMode::Local);
+    }
+
+    #[test]
+    fn has_local_false_without_claude_dir() {
+        let dir = TempDir::new().unwrap();
+        assert!(!ModeDetector::has_local_installation(dir.path()));
+    }
+
+    #[test]
+    fn has_local_false_with_partial_dirs() {
+        let dir = TempDir::new().unwrap();
+        let claude = dir.path().join(".claude");
+        std::fs::create_dir_all(claude.join("agents")).unwrap();
+        std::fs::create_dir_all(claude.join("commands")).unwrap();
+        // Missing skills and tools
+        assert!(!ModeDetector::has_local_installation(dir.path()));
+    }
+
+    #[test]
+    fn has_local_true_with_all_dirs() {
+        let dir = TempDir::new().unwrap();
+        create_local_installation(dir.path());
+        assert!(ModeDetector::has_local_installation(dir.path()));
+    }
+
+    #[test]
+    fn env_override_local() {
+        let dir = TempDir::new().unwrap();
+        unsafe { std::env::set_var("AMPLIHACK_MODE", "local") };
+        let mode = ModeDetector::detect(dir.path());
+        unsafe { std::env::remove_var("AMPLIHACK_MODE") };
+        assert_eq!(mode, ClaudeMode::Local);
+    }
+
+    #[test]
+    fn env_override_plugin() {
+        let dir = TempDir::new().unwrap();
+        unsafe { std::env::set_var("AMPLIHACK_MODE", "plugin") };
+        let mode = ModeDetector::detect(dir.path());
+        unsafe { std::env::remove_var("AMPLIHACK_MODE") };
+        assert_eq!(mode, ClaudeMode::Plugin);
+    }
+
+    #[test]
+    fn env_override_none() {
+        let dir = TempDir::new().unwrap();
+        create_local_installation(dir.path());
+        unsafe { std::env::set_var("AMPLIHACK_MODE", "none") };
+        let mode = ModeDetector::detect(dir.path());
+        unsafe { std::env::remove_var("AMPLIHACK_MODE") };
+        assert_eq!(mode, ClaudeMode::None);
+    }
+
+    #[test]
+    fn env_override_unknown_falls_through() {
+        let dir = TempDir::new().unwrap();
+        unsafe { std::env::set_var("AMPLIHACK_MODE", "bogus") };
+        // Should fall through to normal detection (not Local)
+        let mode = ModeDetector::detect(dir.path());
+        unsafe { std::env::remove_var("AMPLIHACK_MODE") };
+        assert_ne!(mode, ClaudeMode::Local);
+    }
+
+    #[test]
+    fn get_claude_dir_local() {
+        let dir = TempDir::new().unwrap();
+        let result = ModeDetector::get_claude_dir(&ClaudeMode::Local, dir.path());
+        assert_eq!(result, Some(dir.path().join(".claude")));
+    }
+
+    #[test]
+    fn get_claude_dir_none() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(ModeDetector::get_claude_dir(&ClaudeMode::None, dir.path()), None);
+    }
+
+    #[test]
+    fn get_claude_dir_plugin() {
+        let result = ModeDetector::get_claude_dir(&ClaudeMode::Plugin, Path::new("/unused"));
+        // Should be Some(HOME/.amplihack/.claude) when HOME is set
+        if std::env::var("HOME").is_ok() {
+            assert!(result.is_some());
+        }
+    }
+}

--- a/crates/amplihack-context/src/path_resolver.rs
+++ b/crates/amplihack-context/src/path_resolver.rs
@@ -1,0 +1,190 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+/// Known JSON keys that hold filesystem paths.
+const PATH_FIELDS: &[&str] = &[
+    "path",
+    "cwd",
+    "script",
+    "entry_point",
+    "file",
+    "files",
+    "absolute",
+    "relative",
+];
+
+/// Resolves `~`-prefixed and relative paths against a plugin root.
+pub struct PathResolver;
+
+impl PathResolver {
+    /// Expand `~`, then resolve relative paths against `plugin_root`.
+    /// Absolute paths are returned unchanged.
+    pub fn resolve(path_str: &str, plugin_root: &Path) -> String {
+        if path_str.is_empty() {
+            return path_str.to_string();
+        }
+
+        let expanded = if path_str.starts_with("~/") {
+            match std::env::var("HOME") {
+                Ok(home) => format!("{home}{}", &path_str[1..]),
+                Err(_) => path_str.to_string(),
+            }
+        } else if path_str == "~" {
+            std::env::var("HOME").unwrap_or_else(|_| path_str.to_string())
+        } else {
+            path_str.to_string()
+        };
+
+        if Path::new(&expanded).is_absolute() {
+            return expanded;
+        }
+
+        plugin_root
+            .join(&expanded)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Recursively walk a JSON value and resolve every string in a
+    /// recognised path field.
+    pub fn resolve_map(data: &Value, plugin_root: &Path) -> Value {
+        let fields: HashSet<&str> = PATH_FIELDS.iter().copied().collect();
+        Self::walk(data, plugin_root, &fields)
+    }
+
+    /// Return `PLUGIN_ROOT` env var or fall back to `~/.amplihack/.claude`.
+    pub fn get_plugin_root() -> PathBuf {
+        if let Ok(root) = std::env::var("PLUGIN_ROOT") {
+            return PathBuf::from(root);
+        }
+        std::env::var("HOME")
+            .map(|h| PathBuf::from(h).join(".amplihack/.claude"))
+            .unwrap_or_else(|_| PathBuf::from(".amplihack/.claude"))
+    }
+
+    fn walk(data: &Value, root: &Path, fields: &HashSet<&str>) -> Value {
+        match data {
+            Value::Object(map) => {
+                let mut out = serde_json::Map::new();
+                for (key, val) in map {
+                    let resolved = if fields.contains(key.as_str()) {
+                        Self::resolve_field(val, root, fields)
+                    } else {
+                        Self::walk(val, root, fields)
+                    };
+                    out.insert(key.clone(), resolved);
+                }
+                Value::Object(out)
+            }
+            Value::Array(arr) => {
+                Value::Array(arr.iter().map(|v| Self::walk(v, root, fields)).collect())
+            }
+            other => other.clone(),
+        }
+    }
+
+    fn resolve_field(val: &Value, root: &Path, fields: &HashSet<&str>) -> Value {
+        match val {
+            Value::String(s) => Value::String(Self::resolve(s, root)),
+            Value::Array(arr) => Value::Array(
+                arr.iter()
+                    .map(|v| match v {
+                        Value::String(s) => Value::String(Self::resolve(s, root)),
+                        other => Self::walk(other, root, fields),
+                    })
+                    .collect(),
+            ),
+            other => Self::walk(other, root, fields),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::path::Path;
+
+    #[test]
+    fn resolve_absolute_unchanged() {
+        let result = PathResolver::resolve("/usr/bin/foo", Path::new("/root"));
+        assert_eq!(result, "/usr/bin/foo");
+    }
+
+    #[test]
+    fn resolve_tilde() {
+        let home = std::env::var("HOME").unwrap();
+        let result = PathResolver::resolve("~/docs/x.txt", Path::new("/root"));
+        assert_eq!(result, format!("{home}/docs/x.txt"));
+    }
+
+    #[test]
+    fn resolve_bare_tilde() {
+        let home = std::env::var("HOME").unwrap();
+        let result = PathResolver::resolve("~", Path::new("/root"));
+        assert_eq!(result, home);
+    }
+
+    #[test]
+    fn resolve_relative_to_plugin_root() {
+        let result = PathResolver::resolve("src/main.rs", Path::new("/project"));
+        assert_eq!(result, "/project/src/main.rs");
+    }
+
+    #[test]
+    fn resolve_empty_string() {
+        let result = PathResolver::resolve("", Path::new("/root"));
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn resolve_map_resolves_path_fields() {
+        let data = json!({
+            "path": "src/lib.rs",
+            "name": "mylib",
+            "cwd": "~/work"
+        });
+        let home = std::env::var("HOME").unwrap();
+        let resolved = PathResolver::resolve_map(&data, Path::new("/project"));
+        assert_eq!(resolved["path"], "/project/src/lib.rs");
+        assert_eq!(resolved["name"], "mylib"); // not a path field
+        assert_eq!(resolved["cwd"], format!("{home}/work"));
+    }
+
+    #[test]
+    fn resolve_map_handles_nested_objects() {
+        let data = json!({
+            "outer": {
+                "file": "readme.md"
+            }
+        });
+        let resolved = PathResolver::resolve_map(&data, Path::new("/root"));
+        assert_eq!(resolved["outer"]["file"], "/root/readme.md");
+    }
+
+    #[test]
+    fn resolve_map_handles_array_of_paths() {
+        let data = json!({ "files": ["a.rs", "b.rs"] });
+        let resolved = PathResolver::resolve_map(&data, Path::new("/root"));
+        assert_eq!(resolved["files"][0], "/root/a.rs");
+        assert_eq!(resolved["files"][1], "/root/b.rs");
+    }
+
+    #[test]
+    fn get_plugin_root_uses_env() {
+        unsafe { std::env::set_var("PLUGIN_ROOT", "/custom/root") };
+        let root = PathResolver::get_plugin_root();
+        unsafe { std::env::remove_var("PLUGIN_ROOT") };
+        assert_eq!(root, PathBuf::from("/custom/root"));
+    }
+
+    #[test]
+    fn get_plugin_root_fallback() {
+        unsafe { std::env::remove_var("PLUGIN_ROOT") };
+        let root = PathResolver::get_plugin_root();
+        // Should contain .amplihack/.claude
+        assert!(root.to_string_lossy().contains(".amplihack/.claude"));
+    }
+}

--- a/crates/amplihack-context/src/strategies.rs
+++ b/crates/amplihack-context/src/strategies.rs
@@ -1,0 +1,285 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+
+// ── Trait ──────────────────────────────────────────────────────────────
+
+/// Strategy for injecting context into a specific agent launcher.
+pub trait HookStrategy {
+    /// Inject context and return the serialized payload that was written.
+    fn inject_context(&self, context: &str) -> Result<String>;
+    /// Remove any injected context artefacts.
+    fn cleanup(&self) -> Result<()>;
+    /// Called when the session stops.
+    fn handle_stop(&self) -> Result<()> {
+        self.cleanup()
+    }
+    fn pre_tool_use(&self, _tool_name: &str) -> Result<()> {
+        Ok(())
+    }
+    fn post_tool_use(&self, _tool_name: &str) -> Result<()> {
+        Ok(())
+    }
+    fn user_prompt_submit(&self, _prompt: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+// ── Claude ─────────────────────────────────────────────────────────────
+
+/// Writes context as JSON to `.claude/runtime/hook_context.json`.
+pub struct ClaudeStrategy {
+    context_path: PathBuf,
+}
+
+impl ClaudeStrategy {
+    pub fn new(project_dir: &Path) -> Self {
+        Self {
+            context_path: project_dir.join(".claude/runtime/hook_context.json"),
+        }
+    }
+
+    pub fn context_path(&self) -> &Path {
+        &self.context_path
+    }
+}
+
+impl HookStrategy for ClaudeStrategy {
+    fn inject_context(&self, context: &str) -> Result<String> {
+        if let Some(parent) = self.context_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let payload = serde_json::json!({ "context": context });
+        let json_str = serde_json::to_string_pretty(&payload)?;
+        std::fs::write(&self.context_path, &json_str)?;
+        Ok(json_str)
+    }
+
+    fn cleanup(&self) -> Result<()> {
+        if self.context_path.exists() {
+            std::fs::remove_file(&self.context_path)?;
+        }
+        Ok(())
+    }
+}
+
+// ── Copilot ────────────────────────────────────────────────────────────
+
+const MARKER_START: &str = "<!-- AMPLIHACK_CONTEXT_START -->";
+const MARKER_END: &str = "<!-- AMPLIHACK_CONTEXT_END -->";
+/// 10 MB hard limit.
+const MAX_CONTEXT_SIZE: usize = 10 * 1024 * 1024;
+
+/// Injects context into `AGENTS.md` at the repository root, delimited by
+/// marker comments so repeated injections replace rather than append.
+pub struct CopilotStrategy {
+    agents_path: PathBuf,
+}
+
+impl CopilotStrategy {
+    pub fn new(project_dir: &Path) -> Self {
+        Self {
+            agents_path: project_dir.join("AGENTS.md"),
+        }
+    }
+
+    pub fn agents_path(&self) -> &Path {
+        &self.agents_path
+    }
+}
+
+impl HookStrategy for CopilotStrategy {
+    fn inject_context(&self, context: &str) -> Result<String> {
+        if context.len() > MAX_CONTEXT_SIZE {
+            bail!(
+                "context exceeds maximum size of {} bytes ({} given)",
+                MAX_CONTEXT_SIZE,
+                context.len()
+            );
+        }
+
+        let marked = format!("{MARKER_START}\n{context}\n{MARKER_END}");
+
+        let existing = if self.agents_path.exists() {
+            std::fs::read_to_string(&self.agents_path)?
+        } else {
+            String::new()
+        };
+
+        let new_content = if let (Some(s), Some(e)) =
+            (existing.find(MARKER_START), existing.find(MARKER_END))
+        {
+            let end = e + MARKER_END.len();
+            format!("{}{marked}{}", &existing[..s], &existing[end..])
+        } else if existing.is_empty() {
+            marked.clone()
+        } else {
+            format!("{}\n\n{marked}", existing.trim_end())
+        };
+
+        std::fs::write(&self.agents_path, &new_content)?;
+        Ok(marked)
+    }
+
+    fn cleanup(&self) -> Result<()> {
+        if !self.agents_path.exists() {
+            return Ok(());
+        }
+        let content = std::fs::read_to_string(&self.agents_path)?;
+        if let (Some(s), Some(e)) = (content.find(MARKER_START), content.find(MARKER_END)) {
+            let end = e + MARKER_END.len();
+            let mut cleaned = format!("{}{}", &content[..s], &content[end..]);
+            while cleaned.contains("\n\n\n") {
+                cleaned = cleaned.replace("\n\n\n", "\n\n");
+            }
+            let cleaned = cleaned.trim().to_string();
+            if cleaned.is_empty() {
+                std::fs::remove_file(&self.agents_path)?;
+            } else {
+                std::fs::write(&self.agents_path, &cleaned)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // -- Claude ----------------------------------------------------------
+
+    #[test]
+    fn claude_inject_writes_json() {
+        let dir = TempDir::new().unwrap();
+        let strat = ClaudeStrategy::new(dir.path());
+        let result = strat.inject_context("hello world").unwrap();
+        assert!(result.contains("hello world"));
+        let on_disk = std::fs::read_to_string(strat.context_path()).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&on_disk).unwrap();
+        assert_eq!(val["context"], "hello world");
+    }
+
+    #[test]
+    fn claude_inject_creates_parent_dirs() {
+        let dir = TempDir::new().unwrap();
+        let strat = ClaudeStrategy::new(dir.path());
+        strat.inject_context("x").unwrap();
+        assert!(strat.context_path().exists());
+    }
+
+    #[test]
+    fn claude_cleanup_removes_file() {
+        let dir = TempDir::new().unwrap();
+        let strat = ClaudeStrategy::new(dir.path());
+        strat.inject_context("data").unwrap();
+        strat.cleanup().unwrap();
+        assert!(!strat.context_path().exists());
+    }
+
+    #[test]
+    fn claude_cleanup_noop_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let strat = ClaudeStrategy::new(dir.path());
+        strat.cleanup().unwrap();
+    }
+
+    #[test]
+    fn claude_handle_stop_cleans_up() {
+        let dir = TempDir::new().unwrap();
+        let strat = ClaudeStrategy::new(dir.path());
+        strat.inject_context("ctx").unwrap();
+        strat.handle_stop().unwrap();
+        assert!(!strat.context_path().exists());
+    }
+
+    // -- Copilot ---------------------------------------------------------
+
+    #[test]
+    fn copilot_inject_creates_agents_md() {
+        let dir = TempDir::new().unwrap();
+        let strat = CopilotStrategy::new(dir.path());
+        let result = strat.inject_context("my context").unwrap();
+        assert!(result.contains(MARKER_START));
+        assert!(result.contains(MARKER_END));
+        assert!(result.contains("my context"));
+        let on_disk = std::fs::read_to_string(strat.agents_path()).unwrap();
+        assert!(on_disk.contains("my context"));
+    }
+
+    #[test]
+    fn copilot_inject_replaces_existing_markers() {
+        let dir = TempDir::new().unwrap();
+        let strat = CopilotStrategy::new(dir.path());
+        strat.inject_context("first").unwrap();
+        strat.inject_context("second").unwrap();
+        let on_disk = std::fs::read_to_string(strat.agents_path()).unwrap();
+        assert!(!on_disk.contains("first"));
+        assert!(on_disk.contains("second"));
+        // Only one pair of markers
+        assert_eq!(on_disk.matches(MARKER_START).count(), 1);
+    }
+
+    #[test]
+    fn copilot_inject_appends_to_existing_content() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("AGENTS.md"), "# Agents\n\nExisting.").unwrap();
+        let strat = CopilotStrategy::new(dir.path());
+        strat.inject_context("new ctx").unwrap();
+        let on_disk = std::fs::read_to_string(strat.agents_path()).unwrap();
+        assert!(on_disk.starts_with("# Agents"));
+        assert!(on_disk.contains("new ctx"));
+    }
+
+    #[test]
+    fn copilot_cleanup_removes_markers() {
+        let dir = TempDir::new().unwrap();
+        let strat = CopilotStrategy::new(dir.path());
+        std::fs::write(
+            strat.agents_path(),
+            format!("# Title\n\n{MARKER_START}\nctx\n{MARKER_END}\n\nFooter"),
+        )
+        .unwrap();
+        strat.cleanup().unwrap();
+        let on_disk = std::fs::read_to_string(strat.agents_path()).unwrap();
+        assert!(!on_disk.contains(MARKER_START));
+        assert!(on_disk.contains("# Title"));
+        assert!(on_disk.contains("Footer"));
+    }
+
+    #[test]
+    fn copilot_cleanup_removes_file_when_only_markers() {
+        let dir = TempDir::new().unwrap();
+        let strat = CopilotStrategy::new(dir.path());
+        strat.inject_context("solo").unwrap();
+        strat.cleanup().unwrap();
+        assert!(!strat.agents_path().exists());
+    }
+
+    #[test]
+    fn copilot_cleanup_noop_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let strat = CopilotStrategy::new(dir.path());
+        strat.cleanup().unwrap();
+    }
+
+    #[test]
+    fn copilot_rejects_oversized_context() {
+        let dir = TempDir::new().unwrap();
+        let strat = CopilotStrategy::new(dir.path());
+        let huge = "x".repeat(MAX_CONTEXT_SIZE + 1);
+        assert!(strat.inject_context(&huge).is_err());
+    }
+
+    #[test]
+    fn copilot_markers_are_present_in_output() {
+        let dir = TempDir::new().unwrap();
+        let strat = CopilotStrategy::new(dir.path());
+        let result = strat.inject_context("payload").unwrap();
+        assert!(result.starts_with(MARKER_START));
+        assert!(result.ends_with(MARKER_END));
+    }
+}


### PR DESCRIPTION
## Summary

New `amplihack-context` crate implementing 4 Python utility modules for environment detection.

## Modules

### LauncherDetector (launcher_detector.rs, 223 lines)
- Detects Claude Code vs Copilot CLI from `.claude/runtime/launcher_context.json`
- Staleness tracking (24h threshold)
- Context write/cleanup

### Injection Strategies (strategies.rs, 285 lines)
- `HookStrategy` trait for launcher-specific context injection
- `ClaudeStrategy`: JSON-based context via `.claude/runtime/hook_context.json`
- `CopilotStrategy`: Markdown markers in `AGENTS.md`, 10MB size limit

### Mode Detector (mode_detector.rs, 189 lines)
- `ClaudeMode` enum: Local / Plugin / None
- Precedence: Local > Plugin > None
- `AMPLIHACK_MODE` env var override
- Essential directory validation (agents, commands, skills, tools)

### Path Resolver (path_resolver.rs, 190 lines)
- Tilde expansion, relative-to-absolute resolution
- Recursive map walking for path fields
- Plugin root detection via `PLUGIN_ROOT` env

### LSP Detector (lsp_detector.rs, 274 lines)
- Language detection (Python, JS, TS, Rust, Go) via file patterns
- LSP server config generation per language
- Settings.json merging for MCP servers

## Verification
- ✅ 62 tests pass
- ✅ All 6 files under 400 lines (max: 285)
- ✅ Clean build