### PR TITLE
fix: launch tests complete in <1s (was 90s+ / hanging)

### DIFF
--- a/crates/amplihack-cli/src/commands/launch/mod.rs
+++ b/crates/amplihack-cli/src/commands/launch/mod.rs
@@ -248,7 +248,7 @@ fn wait_for_child_or_signal(
         // Check if we received a shutdown signal
         if shutdown.load(Ordering::Relaxed) {
             tracing::info!("shutdown signal received, terminating child process");
-            // ManagedChild::drop handles graceful shutdown
+            child.terminate();
             return Ok(0); // match Python behavior: exit 0 on SIGINT
         }
 

--- a/crates/amplihack-cli/src/commands/launch/tests_launch.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_launch.rs
@@ -118,6 +118,11 @@ fn test_subprocess_safe_preserves_existing_node_options() {
     let home = tempfile::tempdir().unwrap();
     let original_home = set_home(home.path());
     fs::create_dir_all(home.path().join(".amplihack")).unwrap();
+    fs::write(
+        home.path().join(".amplihack/config"),
+        r#"{"node_options_consent":true,"node_options_limit_mb":32768}"#,
+    )
+    .unwrap();
     let previous_node_options = std::env::var_os("NODE_OPTIONS");
     unsafe { std::env::set_var("NODE_OPTIONS", "--trace-warnings") };
 
@@ -146,6 +151,11 @@ fn test_subprocess_safe_without_parent_still_applies_memory_config() {
     let home = tempfile::tempdir().unwrap();
     let original_home = set_home(home.path());
     fs::create_dir_all(home.path().join(".amplihack")).unwrap();
+    fs::write(
+        home.path().join(".amplihack/config"),
+        r#"{"node_options_consent":true,"node_options_limit_mb":32768}"#,
+    )
+    .unwrap();
     let previous_node_options = std::env::var_os("NODE_OPTIONS");
     unsafe { std::env::remove_var("NODE_OPTIONS") };
 
@@ -178,6 +188,11 @@ fn test_normal_launch_applies_smart_node_options() {
     let home = tempfile::tempdir().unwrap();
     let original_home = set_home(home.path());
     fs::create_dir_all(home.path().join(".amplihack")).unwrap();
+    fs::write(
+        home.path().join(".amplihack/config"),
+        r#"{"node_options_consent":true,"node_options_limit_mb":32768}"#,
+    )
+    .unwrap();
     let previous_node_options = std::env::var_os("NODE_OPTIONS");
     unsafe { std::env::remove_var("NODE_OPTIONS") };
 


### PR DESCRIPTION
Two root causes:

1. **Missing child.terminate()**: wait_for_child_or_signal returned without killing the child process on shutdown, causing drop() to block 3+ seconds.

2. **30s prompt timeout in tests**: Tests called resolve_launch_node_options without pre-seeded config, triggering a 30-second stdin poll timeout each.

Result: 15 tests pass in 0.21s (was 90s+ or indefinite hang).