### PR TITLE
Add repo hygiene: pre-commit, rustfmt.toml, CONTRIBUTING.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt --all --check
+        entry: cargo fmt --all --check
+        language: system
+        pass_filenames: false
+        files: '(\.rs|Cargo\.toml|Cargo\.lock)$'
+
+      - id: cargo-clippy
+        name: cargo clippy -- -D warnings
+        entry: cargo clippy -- -D warnings
+        language: system
+        pass_filenames: false
+        files: '(\.rs|Cargo\.toml|Cargo\.lock)$'
+
+      - id: cargo-test
+        name: cargo test (workspace, skip heavy)
+        entry: bash -c 'cargo test --workspace --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu'
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        files: '(\.rs|Cargo\.toml|Cargo\.lock)$'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to amplihack-rs
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Rust | 1.85+ | Core development (edition 2024) |
+| pre-commit | latest | Git hooks for formatting, linting, testing |
+
+## Setup
+
+```bash
+git clone https://github.com/rysweet/amplihack-rs.git
+cd amplihack-rs
+cargo build
+cargo test --workspace --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu
+pip install pre-commit
+pre-commit install
+```
+
+## Pre-commit hooks
+
+Each commit automatically runs:
+
+- **`cargo fmt --all`** — formatting check
+- **`cargo clippy -- -D warnings`** — lint with zero warnings
+- Standard hooks: trailing-whitespace, end-of-file-fixer, check-yaml, check-toml, check-merge-conflict
+
+On `pre-push`, the full workspace test suite runs (skipping heavy integration tests).
+
+## Testing
+
+```bash
+# Fast: skip kuzu C++ build and fleet probes
+cargo test --workspace --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu
+
+# Single crate
+cargo test -p amplihack-cli
+cargo test -p amplihack-hooks
+
+# Coverage
+cargo llvm-cov --lib --workspace --skip fleet_probe --skip kuzu
+```
+
+## Pull request process
+
+1. Create a feature branch from `main`
+2. Ensure `cargo fmt`, `cargo clippy -- -D warnings`, and tests pass
+3. All PRs must pass the **merge-criteria** skill before merge
+4. All PRs must have a **quality-audit** cycle (3+ rounds)
+5. Squash merge preferred
+
+## Code standards
+
+- All modules < 400 lines
+- Test coverage ≥ 70%
+- All public items documented with `///` doc comments
+- No `unwrap()` in library code — use `?` or explicit error handling
+- No deferred technical debt

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+max_width = 100


### PR DESCRIPTION
## Summary

Adds gold standard repo hygiene matching other amplihack ecosystem repos (xpia-defender, recipe-runner, memory-lib).

### Added
- **`.pre-commit-config.yaml`**: pre-commit-hooks v6.0.0 (merge-conflict, trailing-whitespace, end-of-file, yaml, toml, large files) + local cargo fmt/clippy/test hooks
- **`rustfmt.toml`**: edition 2024, max_width 100
- **`CONTRIBUTING.md`**: Prerequisites, setup, testing commands, PR process, code standards

### Why
Previously amplihack-rs was the only ecosystem repo without pre-commit hooks or a CONTRIBUTING guide. This aligns it with the template used for amplihack-traits, amplihack-xpia-defender, and amplihack-recipe-runner.

### Testing
- No code changes — config files only
- CI will validate the workflow file syntax