### PR TITLE
feat(plugin): add resolve_manifest_paths for relative path resolution

### DIFF
--- a/crates/amplihack-cli/src/commands/plugin/helpers.rs
+++ b/crates/amplihack-cli/src/commands/plugin/helpers.rs
@@ -164,3 +164,51 @@ pub(super) fn is_valid_plugin_name(value: &str) -> bool {
             .chars()
             .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
 }
+
+/// Fields in a plugin manifest whose values are file-system paths that may
+/// need to be resolved relative to the plugin root directory.
+const PATH_FIELDS: &[&str] = &["entry_point", "files", "cwd", "script", "path"];
+
+/// Resolve relative paths in a plugin manifest to absolute paths.
+///
+/// Walks the manifest JSON value and, for every key listed in [`PATH_FIELDS`],
+/// converts relative path strings (or lists of path strings) into absolute
+/// paths anchored at `plugin_root`.  Nested objects are handled recursively.
+///
+/// Absolute paths are left unchanged.
+pub(super) fn resolve_manifest_paths(manifest: &mut serde_json::Value, plugin_root: &Path) {
+    if let Some(obj) = manifest.as_object_mut() {
+        resolve_object_paths(obj, plugin_root);
+    }
+}
+
+/// Recursively resolve path fields inside a JSON object.
+fn resolve_object_paths(obj: &mut serde_json::Map<String, serde_json::Value>, plugin_root: &Path) {
+    for (key, value) in obj.iter_mut() {
+        let is_path_field = PATH_FIELDS.iter().any(|&f| f == key);
+
+        if is_path_field {
+            match value {
+                serde_json::Value::String(s) => {
+                    let p = Path::new(s.as_str());
+                    if !p.is_absolute() {
+                        *s = plugin_root.join(p).to_string_lossy().into_owned();
+                    }
+                }
+                serde_json::Value::Array(arr) => {
+                    for item in arr.iter_mut() {
+                        if let serde_json::Value::String(s) = item {
+                            let p = Path::new(s.as_str());
+                            if !p.is_absolute() {
+                                *s = plugin_root.join(p).to_string_lossy().into_owned();
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        } else if let serde_json::Value::Object(nested) = value {
+            resolve_object_paths(nested, plugin_root);
+        }
+    }
+}

--- a/crates/amplihack-cli/src/commands/plugin/tests.rs
+++ b/crates/amplihack-cli/src/commands/plugin/tests.rs
@@ -1,5 +1,6 @@
 use super::helpers::{
     copy_dir_recursive, is_valid_plugin_name, is_valid_semver, plugin_name_from_git_url,
+    resolve_manifest_paths,
 };
 use super::manager::PluginManager;
 use super::verifier::PluginVerifier;
@@ -144,4 +145,93 @@ fn plugin_name_validation_matches_python_pattern() {
     assert!(is_valid_plugin_name("demo-plugin1"));
     assert!(!is_valid_plugin_name("Demo"));
     assert!(!is_valid_plugin_name("../demo"));
+}
+
+#[test]
+fn resolve_manifest_paths_converts_relative_string_fields() {
+    let root = Path::new("/plugins/demo");
+    let mut manifest = serde_json::json!({
+        "name": "demo",
+        "entry_point": "main.py",
+        "cwd": "src",
+        "script": "run.sh",
+        "path": "lib/bin",
+    });
+    resolve_manifest_paths(&mut manifest, root);
+    assert_eq!(manifest["entry_point"], "/plugins/demo/main.py");
+    assert_eq!(manifest["cwd"], "/plugins/demo/src");
+    assert_eq!(manifest["script"], "/plugins/demo/run.sh");
+    assert_eq!(manifest["path"], "/plugins/demo/lib/bin");
+    // Non-path fields are untouched
+    assert_eq!(manifest["name"], "demo");
+}
+
+#[test]
+fn resolve_manifest_paths_preserves_absolute_paths() {
+    let root = Path::new("/plugins/demo");
+    let mut manifest = serde_json::json!({
+        "entry_point": "/usr/bin/python",
+        "script": "/opt/run.sh",
+    });
+    resolve_manifest_paths(&mut manifest, root);
+    assert_eq!(manifest["entry_point"], "/usr/bin/python");
+    assert_eq!(manifest["script"], "/opt/run.sh");
+}
+
+#[test]
+fn resolve_manifest_paths_handles_path_lists() {
+    let root = Path::new("/plugins/demo");
+    let mut manifest = serde_json::json!({
+        "files": ["a.py", "/abs/b.py", "sub/c.py"],
+    });
+    resolve_manifest_paths(&mut manifest, root);
+    let files = manifest["files"].as_array().unwrap();
+    assert_eq!(files[0], "/plugins/demo/a.py");
+    assert_eq!(files[1], "/abs/b.py");
+    assert_eq!(files[2], "/plugins/demo/sub/c.py");
+}
+
+#[test]
+fn resolve_manifest_paths_recurses_into_nested_objects() {
+    let root = Path::new("/plugins/demo");
+    let mut manifest = serde_json::json!({
+        "name": "demo",
+        "hooks": {
+            "entry_point": "hooks/main.py",
+            "nested": {
+                "script": "deep/run.sh",
+            }
+        }
+    });
+    resolve_manifest_paths(&mut manifest, root);
+    assert_eq!(
+        manifest["hooks"]["entry_point"],
+        "/plugins/demo/hooks/main.py"
+    );
+    assert_eq!(
+        manifest["hooks"]["nested"]["script"],
+        "/plugins/demo/deep/run.sh"
+    );
+}
+
+#[test]
+fn resolve_manifest_paths_ignores_non_path_fields() {
+    let root = Path::new("/plugins/demo");
+    let mut manifest = serde_json::json!({
+        "name": "demo",
+        "version": "1.0.0",
+        "description": "relative/looking/but/not/a/path",
+    });
+    let original = manifest.clone();
+    resolve_manifest_paths(&mut manifest, root);
+    assert_eq!(manifest, original);
+}
+
+#[test]
+fn resolve_manifest_paths_noop_on_non_object() {
+    let root = Path::new("/plugins/demo");
+    let mut manifest = serde_json::json!("just a string");
+    let original = manifest.clone();
+    resolve_manifest_paths(&mut manifest, root);
+    assert_eq!(manifest, original);
 }


### PR DESCRIPTION
## Summary

Ports the Python `resolve_paths()` function to Rust, completing the plugin manager port.

## Changes

- **`helpers.rs`**: Added `resolve_manifest_paths()` and private helper `resolve_object_paths()`
- **`tests.rs`**: Added 6 tests covering string fields, absolute path preservation, path lists, nested objects, non-path field passthrough, and non-object input

## Behavior

For each key in `PATH_FIELDS` (`entry_point`, `files`, `cwd`, `script`, `path`):
- **String values**: relative paths are joined with `plugin_root`; absolute paths are unchanged
- **Array values**: each string element is resolved individually
- **Nested objects**: recursed into for any non-path-field object values

## Validation

- `cargo fmt` ✅
- `cargo clippy` — no new warnings (2 expected dead_code notes since function is not yet wired into call sites)
- `cargo test -p amplihack-cli` — all 6 new tests pass; 759/760 total pass (1 pre-existing failure in tilde expansion test)
- Both modified files under 400 lines (helpers: 214, tests: 237)