### PR TITLE
feat(utils): add project_init, claude_md, and cleanup modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,11 @@ dependencies = [
 name = "amplihack-utils"
 version = "0.6.15"
 dependencies = [
+ "chrono",
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",

--- a/crates/amplihack-utils/Cargo.toml
+++ b/crates/amplihack-utils/Cargo.toml
@@ -12,6 +12,8 @@ regex = "1"
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { version = "1", features = ["process", "time", "rt"] }
+sha2 = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["process", "time", "rt", "macros"] }

--- a/crates/amplihack-utils/src/claude_md.rs
+++ b/crates/amplihack-utils/src/claude_md.rs
@@ -1,0 +1,390 @@
+//! `CLAUDE.md` preservation and version management.
+//!
+//! Ported from `amplihack/utils/claude_md_preserver.py`. Handles deployment
+//! and preservation of amplihack's `CLAUDE.md` with smart version detection,
+//! backup logic, and content hashing.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors produced by CLAUDE.md handling operations.
+#[derive(Debug, Error)]
+pub enum ClaudeMdError {
+    /// An I/O error occurred during file operations.
+    #[error("claude_md I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The source `CLAUDE.md` file could not be found.
+    #[error("source CLAUDE.md not found: {path}")]
+    SourceNotFound {
+        /// Path to the missing source.
+        path: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// Observed state of the `CLAUDE.md` file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaudeState {
+    /// No `CLAUDE.md` file exists in the target directory.
+    Missing,
+    /// The file contains the current amplihack version marker.
+    Default,
+    /// The file contains user-written content (no amplihack marker).
+    CustomClean,
+    /// The file is an older amplihack version.
+    CustomDirty,
+    /// The file state could not be determined (e.g. unreadable).
+    Unknown,
+}
+
+/// Desired handling behavior for `CLAUDE.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandleMode {
+    /// Preserve custom content by backing it up before overwriting.
+    Preserve,
+    /// Overwrite the file unconditionally.
+    Overwrite,
+    /// Merge amplihack content with existing user content.
+    Merge,
+}
+
+/// Action that was actually taken during handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionTaken {
+    /// Deployed a fresh `CLAUDE.md` (was missing).
+    Deployed,
+    /// Backed up existing content and replaced the file.
+    BackedUpAndReplaced,
+    /// No write was performed.
+    Skipped,
+    /// State was checked but no action was taken.
+    CheckOnly,
+}
+
+// ---------------------------------------------------------------------------
+// Result struct
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`handle_claude_md`] call.
+#[derive(Debug, Clone)]
+pub struct ClaudeHandlerResult {
+    /// What action was performed.
+    pub action: HandleMode,
+    /// SHA-256 hash of the written or existing content, if available.
+    pub content_hash: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Version marker prefix embedded in amplihack-managed `CLAUDE.md` files.
+const CLAUDE_VERSION_MARKER: &str = "<!-- amplihack-version:";
+
+/// Current version of the amplihack `CLAUDE.md` template.
+const CURRENT_VERSION: &str = "0.9.0";
+
+/// Start marker for preserved content sections inside `PROJECT.md`.
+const BEGIN_MARKER: &str = "<!-- BEGIN AMPLIHACK-PRESERVED-CONTENT";
+
+/// End marker for preserved content sections inside `PROJECT.md`.
+const END_MARKER: &str = "<!-- END AMPLIHACK-PRESERVED-CONTENT -->";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Compute a SHA-256 content hash, normalizing whitespace.
+///
+/// Trailing spaces on each line are stripped, and leading/trailing blank
+/// lines are removed before hashing. This ensures minor formatting changes
+/// do not alter the hash.
+///
+/// # Examples
+///
+/// ```
+/// use amplihack_utils::claude_md::compute_content_hash;
+///
+/// let h1 = compute_content_hash("hello\nworld\n");
+/// let h2 = compute_content_hash("hello  \nworld  \n\n");
+/// assert_eq!(h1, h2);
+/// ```
+pub fn compute_content_hash(content: &str) -> String {
+    let mut lines: Vec<&str> = content.lines().map(|l| l.trim_end()).collect();
+
+    // Strip leading blank lines.
+    while lines.first().is_some_and(|l| l.is_empty()) {
+        lines.remove(0);
+    }
+
+    // Strip trailing blank lines.
+    while lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+
+    let normalized = lines.join("\n");
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Detect the state of `CLAUDE.md` in `project_dir`.
+///
+/// Reads `CLAUDE.md` at the root of `project_dir` and classifies it based on
+/// the presence and version of the amplihack marker.
+///
+/// # Examples
+///
+/// ```no_run
+/// use amplihack_utils::claude_md::detect_claude_state;
+/// use std::path::Path;
+///
+/// let state = detect_claude_state(Path::new("/my/project"));
+/// ```
+pub fn detect_claude_state(project_dir: &Path) -> ClaudeState {
+    let md_path = project_dir.join("CLAUDE.md");
+
+    if !md_path.exists() {
+        return ClaudeState::Missing;
+    }
+
+    // Reject symlinks as a security precaution.
+    if md_path.is_symlink() {
+        tracing::warn!(path = %md_path.display(), "CLAUDE.md is a symlink — treating as custom");
+        return ClaudeState::CustomClean;
+    }
+
+    let content = match std::fs::read_to_string(&md_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(path = %md_path.display(), error = %e, "could not read CLAUDE.md");
+            return ClaudeState::Unknown;
+        }
+    };
+
+    parse_claude_state(&content)
+}
+
+/// Handle `CLAUDE.md` deployment/preservation in `target_dir`.
+///
+/// `source_claude` points to the canonical amplihack `CLAUDE.md` to deploy.
+///
+/// # Errors
+///
+/// Returns [`ClaudeMdError`] on I/O failures or if the source file is missing.
+///
+/// # Examples
+///
+/// ```no_run
+/// use amplihack_utils::claude_md::{handle_claude_md, HandleMode};
+/// use std::path::Path;
+///
+/// let result = handle_claude_md(
+///     Path::new("/amplihack/CLAUDE.md"),
+///     Path::new("/my/project"),
+///     HandleMode::Preserve,
+/// )?;
+/// # Ok::<(), amplihack_utils::claude_md::ClaudeMdError>(())
+/// ```
+pub fn handle_claude_md(
+    source_claude: &Path,
+    target_dir: &Path,
+    mode: HandleMode,
+) -> Result<ClaudeHandlerResult, ClaudeMdError> {
+    let state = detect_claude_state(target_dir);
+    let target_path = target_dir.join("CLAUDE.md");
+
+    match mode {
+        HandleMode::Overwrite => {
+            let source_content = read_source(source_claude)?;
+            let hash = compute_content_hash(&source_content);
+            write_claude_md(&target_path, &source_content)?;
+            Ok(ClaudeHandlerResult {
+                action: HandleMode::Overwrite,
+                content_hash: Some(hash),
+            })
+        }
+        HandleMode::Preserve => match state {
+            ClaudeState::Missing => {
+                let source_content = read_source(source_claude)?;
+                let hash = compute_content_hash(&source_content);
+                write_claude_md(&target_path, &source_content)?;
+                Ok(ClaudeHandlerResult {
+                    action: HandleMode::Preserve,
+                    content_hash: Some(hash),
+                })
+            }
+            ClaudeState::Default => {
+                // Already current — nothing to do.
+                let content = std::fs::read_to_string(&target_path)?;
+                Ok(ClaudeHandlerResult {
+                    action: HandleMode::Preserve,
+                    content_hash: Some(compute_content_hash(&content)),
+                })
+            }
+            ClaudeState::CustomDirty => {
+                // Outdated amplihack version — safe to replace.
+                let source_content = read_source(source_claude)?;
+                let hash = compute_content_hash(&source_content);
+                write_claude_md(&target_path, &source_content)?;
+                Ok(ClaudeHandlerResult {
+                    action: HandleMode::Preserve,
+                    content_hash: Some(hash),
+                })
+            }
+            ClaudeState::CustomClean | ClaudeState::Unknown => {
+                // User content — back up before replacing.
+                let existing = std::fs::read_to_string(&target_path).unwrap_or_default();
+                backup_to_preserved(target_dir, &existing)?;
+                backup_to_project_md(target_dir, &existing)?;
+
+                let source_content = read_source(source_claude)?;
+                let hash = compute_content_hash(&source_content);
+                write_claude_md(&target_path, &source_content)?;
+                Ok(ClaudeHandlerResult {
+                    action: HandleMode::Preserve,
+                    content_hash: Some(hash),
+                })
+            }
+        },
+        HandleMode::Merge => {
+            // Merge mode: append amplihack content below existing content.
+            let source_content = read_source(source_claude)?;
+            let existing = if target_path.is_file() {
+                std::fs::read_to_string(&target_path).unwrap_or_default()
+            } else {
+                String::new()
+            };
+
+            let merged = if existing.is_empty() {
+                source_content.clone()
+            } else {
+                format!("{existing}\n\n---\n\n{source_content}")
+            };
+
+            let hash = compute_content_hash(&merged);
+            write_claude_md(&target_path, &merged)?;
+            Ok(ClaudeHandlerResult {
+                action: HandleMode::Merge,
+                content_hash: Some(hash),
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Parse the content of a `CLAUDE.md` file and return its state.
+fn parse_claude_state(content: &str) -> ClaudeState {
+    // Look for the version marker.
+    let Some(marker_pos) = content.find(CLAUDE_VERSION_MARKER) else {
+        return ClaudeState::CustomClean;
+    };
+
+    let after_marker = &content[marker_pos + CLAUDE_VERSION_MARKER.len()..];
+    let version_end = match after_marker.find("-->") {
+        Some(pos) => pos,
+        None => return ClaudeState::CustomClean,
+    };
+
+    let version = after_marker[..version_end].trim();
+
+    if version == CURRENT_VERSION {
+        ClaudeState::Default
+    } else {
+        ClaudeState::CustomDirty
+    }
+}
+
+/// Read the source `CLAUDE.md` template file.
+fn read_source(source_claude: &Path) -> Result<String, ClaudeMdError> {
+    if !source_claude.is_file() {
+        return Err(ClaudeMdError::SourceNotFound {
+            path: source_claude.display().to_string(),
+        });
+    }
+    Ok(std::fs::read_to_string(source_claude)?)
+}
+
+/// Write content to a `CLAUDE.md` path, creating parent directories.
+fn write_claude_md(target: &Path, content: &str) -> Result<(), ClaudeMdError> {
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(target, content)?;
+    Ok(())
+}
+
+/// Create a `.preserved` backup of the existing `CLAUDE.md`.
+fn backup_to_preserved(target_dir: &Path, content: &str) -> Result<PathBuf, ClaudeMdError> {
+    let preserved_dir = target_dir.join(".claude").join("context");
+    std::fs::create_dir_all(&preserved_dir)?;
+
+    let preserved_path = preserved_dir.join("CLAUDE.md.preserved");
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    let header = format!(
+        "# Preserved CLAUDE.md content\n\
+         # Backed up: {timestamp}\n\
+         # This file was created by amplihack to preserve your custom CLAUDE.md\n\n"
+    );
+    let full = format!("{header}{content}");
+    std::fs::write(&preserved_path, full)?;
+
+    tracing::info!(path = %preserved_path.display(), "backed up CLAUDE.md to preserved file");
+    Ok(preserved_path)
+}
+
+/// Append preserved content as a marked section in `PROJECT.md`.
+fn backup_to_project_md(target_dir: &Path, content: &str) -> Result<PathBuf, ClaudeMdError> {
+    let project_md = target_dir
+        .join(".claude")
+        .join("context")
+        .join("PROJECT.md");
+    std::fs::create_dir_all(project_md.parent().expect("PROJECT.md has a parent dir"))?;
+
+    let timestamp = chrono::Utc::now().to_rfc3339();
+
+    if project_md.is_file() {
+        let existing = std::fs::read_to_string(&project_md)?;
+        // Idempotent: do not duplicate if already preserved.
+        if existing.contains(BEGIN_MARKER) {
+            tracing::debug!("PROJECT.md already contains preserved section — skipping");
+            return Ok(project_md);
+        }
+        let section = format!(
+            "\n\n---\n{BEGIN_MARKER} {timestamp} -->\n\
+             Preserved CLAUDE.md content:\n\n\
+             {content}\n\
+             {END_MARKER}\n---\n"
+        );
+        std::fs::write(&project_md, format!("{existing}{section}"))?;
+    } else {
+        let full = format!(
+            "# Project Context\n\n\
+             {BEGIN_MARKER} {timestamp} -->\n\
+             Preserved CLAUDE.md content:\n\n\
+             {content}\n\
+             {END_MARKER}\n"
+        );
+        std::fs::write(&project_md, full)?;
+    }
+
+    tracing::info!(path = %project_md.display(), "preserved CLAUDE.md content in PROJECT.md");
+    Ok(project_md)
+}
+
+#[cfg(test)]
+#[path = "tests/claude_md_tests.rs"]
+mod tests;

--- a/crates/amplihack-utils/src/cleanup.rs
+++ b/crates/amplihack-utils/src/cleanup.rs
@@ -1,0 +1,378 @@
+//! Cleanup registry and handler for tracked temporary paths.
+//!
+//! Ported from `amplihack/utils/cleanup_handler.py` and
+//! `amplihack/utils/cleanup_registry.py`. Provides a file-backed registry of
+//! paths created during a session and a handler that safely removes them on
+//! exit.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors produced by cleanup operations.
+#[derive(Debug, Error)]
+pub enum CleanupError {
+    /// An I/O error occurred during cleanup.
+    #[error("cleanup I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization/deserialization failure.
+    #[error("cleanup registry JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The registry has reached its capacity limit.
+    #[error("cleanup registry full (max {max} paths)")]
+    RegistryFull {
+        /// Maximum number of paths allowed.
+        max: usize,
+    },
+
+    /// A path failed security validation.
+    #[error("path validation failed for {path}: {reason}")]
+    ValidationFailed {
+        /// The offending path.
+        path: String,
+        /// Why validation failed.
+        reason: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum tracked paths (denial-of-service prevention).
+const MAX_TRACKED_PATHS: usize = 10_000;
+
+/// Default name for the on-disk registry file.
+const REGISTRY_FILENAME: &str = "amplihack-cleanup-registry.json";
+
+// ---------------------------------------------------------------------------
+// On-disk format
+// ---------------------------------------------------------------------------
+
+/// Serializable representation of the cleanup registry.
+#[derive(Debug, Serialize, Deserialize)]
+struct RegistryData {
+    session_id: String,
+    working_directory: String,
+    paths: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// CleanupRegistry
+// ---------------------------------------------------------------------------
+
+/// A file-backed registry that tracks paths created during a session for
+/// later cleanup.
+///
+/// Paths are stored in insertion order and cleaned deepest-first to safely
+/// handle nested directories.
+///
+/// # Examples
+///
+/// ```no_run
+/// use amplihack_utils::cleanup::CleanupRegistry;
+/// use std::path::Path;
+///
+/// let mut reg = CleanupRegistry::new(Path::new("/session/dir"))?;
+/// reg.register(Path::new("/session/dir/temp_file.txt"))?;
+/// reg.save()?;
+/// # Ok::<(), amplihack_utils::cleanup::CleanupError>(())
+/// ```
+#[derive(Debug)]
+pub struct CleanupRegistry {
+    /// Tracked paths in insertion order.
+    tracked_paths: Vec<PathBuf>,
+    /// Path to the on-disk registry JSON file.
+    registry_file: PathBuf,
+    /// Working directory used for path validation.
+    working_dir: PathBuf,
+    /// Session identifier.
+    session_id: String,
+}
+
+impl CleanupRegistry {
+    /// Create a new, empty registry stored in `registry_dir`.
+    ///
+    /// The session id is derived from the directory name. The registry file
+    /// is placed at `<registry_dir>/amplihack-cleanup-registry.json`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CleanupError::Io`] if the directory cannot be created.
+    pub fn new(registry_dir: &Path) -> Result<Self, CleanupError> {
+        std::fs::create_dir_all(registry_dir)?;
+
+        let session_id = registry_dir
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "default".to_owned());
+
+        Ok(Self {
+            tracked_paths: Vec::new(),
+            registry_file: registry_dir.join(REGISTRY_FILENAME),
+            working_dir: registry_dir.to_path_buf(),
+            session_id,
+        })
+    }
+
+    /// Register a path for later cleanup.
+    ///
+    /// The path is resolved to an absolute form. Duplicate paths are silently
+    /// ignored.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CleanupError::RegistryFull`] if the registry is at capacity.
+    pub fn register(&mut self, path: &Path) -> Result<(), CleanupError> {
+        if self.tracked_paths.len() >= MAX_TRACKED_PATHS {
+            return Err(CleanupError::RegistryFull {
+                max: MAX_TRACKED_PATHS,
+            });
+        }
+
+        let resolved = normalize_path(path);
+
+        if !self.tracked_paths.contains(&resolved) {
+            self.tracked_paths.push(resolved);
+        }
+
+        Ok(())
+    }
+
+    /// Return a slice of all tracked paths in insertion order.
+    pub fn get_tracked_paths(&self) -> &[PathBuf] {
+        &self.tracked_paths
+    }
+
+    /// Return tracked paths sorted deepest-first for safe deletion.
+    pub fn deletion_order(&self) -> Vec<PathBuf> {
+        let mut sorted = self.tracked_paths.clone();
+        sorted.sort_by(|a, b| {
+            let depth_a = a.components().count();
+            let depth_b = b.components().count();
+            depth_b.cmp(&depth_a)
+        });
+        sorted
+    }
+
+    /// Persist the registry to its JSON file on disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CleanupError`] on I/O or serialization failures.
+    pub fn save(&self) -> Result<(), CleanupError> {
+        let data = RegistryData {
+            session_id: self.session_id.clone(),
+            working_directory: self.working_dir.display().to_string(),
+            paths: self
+                .tracked_paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+        };
+
+        let json = serde_json::to_string_pretty(&data)?;
+
+        if let Some(parent) = self.registry_file.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        std::fs::write(&self.registry_file, json)?;
+
+        // Best-effort: restrict permissions on Unix.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            let _ = std::fs::set_permissions(&self.registry_file, perms);
+        }
+
+        Ok(())
+    }
+
+    /// Load a previously saved registry from `registry_dir`.
+    ///
+    /// Returns a fully populated [`CleanupRegistry`] with the paths that were
+    /// persisted. If the file does not exist or is malformed, returns an empty
+    /// registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CleanupError`] only on unexpected I/O errors (not
+    /// file-not-found).
+    pub fn load(registry_dir: &Path) -> Result<Self, CleanupError> {
+        let registry_file = registry_dir.join(REGISTRY_FILENAME);
+
+        if !registry_file.is_file() {
+            return Self::new(registry_dir);
+        }
+
+        // Validate permissions on Unix.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = std::fs::metadata(&registry_file)?;
+            let mode = meta.permissions().mode() & 0o777;
+            if mode & 0o077 != 0 {
+                tracing::warn!(
+                    path = %registry_file.display(),
+                    mode = format!("{mode:o}"),
+                    "cleanup registry has loose permissions"
+                );
+            }
+        }
+
+        let content = match std::fs::read_to_string(&registry_file) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Self::new(registry_dir);
+            }
+            Err(e) => return Err(CleanupError::Io(e)),
+        };
+
+        let data: RegistryData = match serde_json::from_str(&content) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(error = %e, "malformed cleanup registry — starting fresh");
+                return Self::new(registry_dir);
+            }
+        };
+
+        let tracked_paths: Vec<PathBuf> = data.paths.iter().map(PathBuf::from).collect();
+
+        Ok(Self {
+            tracked_paths,
+            registry_file,
+            working_dir: PathBuf::from(&data.working_directory),
+            session_id: data.session_id,
+        })
+    }
+
+    /// Remove all tracked paths and return the number of items cleaned.
+    ///
+    /// Paths are removed deepest-first. Symlinks, paths outside the working
+    /// directory, and non-existent paths are skipped with a warning.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CleanupError::Io`] only if the registry file itself cannot
+    /// be cleaned up. Individual path failures are logged but do not abort
+    /// the operation.
+    pub fn cleanup_all(&mut self) -> Result<usize, CleanupError> {
+        let ordered = self.deletion_order();
+        let mut cleaned = 0usize;
+
+        for path in &ordered {
+            if !path.exists() {
+                continue;
+            }
+
+            if let Err(reason) = validate_cleanup_path(path, &self.working_dir) {
+                tracing::warn!(path = %path.display(), %reason, "skipping invalid cleanup path");
+                continue;
+            }
+
+            // Double-check symlink status right before deletion (TOCTOU mitigation).
+            if path.is_symlink() {
+                tracing::warn!(path = %path.display(), "skipping symlink during cleanup");
+                continue;
+            }
+
+            let result = if path.is_dir() {
+                std::fs::remove_dir_all(path)
+            } else {
+                std::fs::remove_file(path)
+            };
+
+            match result {
+                Ok(()) => {
+                    tracing::debug!(path = %path.display(), "cleaned up");
+                    cleaned += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(path = %path.display(), error = %e, "failed to clean up path");
+                }
+            }
+        }
+
+        // Clean up the registry file itself.
+        if self.registry_file.is_file() {
+            let _ = std::fs::remove_file(&self.registry_file);
+        }
+
+        self.tracked_paths.clear();
+        Ok(cleaned)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Validate that a path is safe to delete.
+///
+/// Rejects symlinks and paths that escape the working directory.
+fn validate_cleanup_path(path: &Path, working_dir: &Path) -> Result<(), String> {
+    if path.is_symlink() {
+        return Err("path is a symlink".to_owned());
+    }
+
+    // Check containment: the path must be under the working directory.
+    let resolved = match path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => return Err(format!("canonicalize failed: {e}")),
+    };
+
+    let root = match working_dir.canonicalize() {
+        Ok(p) => p,
+        Err(e) => return Err(format!("working dir canonicalize failed: {e}")),
+    };
+
+    if !resolved.starts_with(&root) {
+        return Err(format!(
+            "path {} escapes working dir {}",
+            resolved.display(),
+            root.display()
+        ));
+    }
+
+    Ok(())
+}
+
+/// Normalize a path to an absolute form without requiring it to exist.
+///
+/// Uses `canonicalize()` when the path exists, otherwise falls back to
+/// joining with the current directory.
+fn normalize_path(path: &Path) -> PathBuf {
+    // Do NOT follow symlinks — we need to preserve symlink identity
+    // so cleanup_all can detect and skip them.
+    if path.is_symlink() {
+        return if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(path)
+        };
+    }
+    path.canonicalize().unwrap_or_else(|_| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(path)
+        }
+    })
+}
+
+#[cfg(test)]
+#[path = "tests/cleanup_tests.rs"]
+mod tests;

--- a/crates/amplihack-utils/src/lib.rs
+++ b/crates/amplihack-utils/src/lib.rs
@@ -7,9 +7,15 @@
 //! - [`slugify`] — URL-safe slug generation with Unicode normalization
 //! - [`defensive`] — LLM response parsing, file I/O retry, prompt isolation
 //! - [`process`] — Cross-platform process management with timeout support
+//! - [`project_init`] — Project initialization and `PROJECT.md` management
+//! - [`claude_md`] — `CLAUDE.md` preservation and version management
+//! - [`cleanup`] — Cleanup registry and handler for tracked temporary paths
 
+pub mod claude_md;
+pub mod cleanup;
 pub mod defensive;
 pub mod process;
+pub mod project_init;
 pub mod slugify;
 
 // Re-export the most commonly used items at crate root.

--- a/crates/amplihack-utils/src/project_init.rs
+++ b/crates/amplihack-utils/src/project_init.rs
@@ -1,0 +1,316 @@
+//! Project initialization and `PROJECT.md` management.
+//!
+//! Ported from `amplihack/utils/project_initializer.py`. Detects the current
+//! state of a project's `PROJECT.md`, analyzes the project structure, and
+//! initializes or updates the file from a template.
+
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Errors produced by project initialization operations.
+#[derive(Debug, Error)]
+pub enum ProjectInitError {
+    /// An I/O error occurred reading or writing project files.
+    #[error("project init I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    /// The project directory does not exist.
+    #[error("project directory does not exist: {path}")]
+    DirNotFound { path: String },
+}
+
+/// Observed state of the `PROJECT.md` file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectState {
+    /// No `PROJECT.md` file exists.
+    Missing,
+    /// Contains amplihack-generated template markers.
+    Template,
+    /// Contains user-written content.
+    Custom,
+    /// Exists but is empty or unreadable.
+    Stale,
+}
+
+/// Desired initialization behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitMode {
+    /// Create if missing; leave existing user content alone.
+    Create,
+    /// Overwrite regardless of current state.
+    Update,
+    /// Report state only — never write.
+    Skip,
+}
+
+/// Action taken during initialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionTaken {
+    /// A new `PROJECT.md` was created.
+    Initialized,
+    /// An existing template file was regenerated.
+    Regenerated,
+    /// No write was performed.
+    Skipped,
+}
+
+/// Outcome of [`initialize_project_md`].
+#[derive(Debug, Clone)]
+pub struct InitResult {
+    /// What action was performed.
+    pub action: ActionTaken,
+    /// Path to `PROJECT.md`.
+    pub path: PathBuf,
+    /// Template applied, if any.
+    pub template_used: Option<String>,
+}
+
+/// High-level analysis of a project's structure.
+#[derive(Debug, Clone, Default)]
+pub struct ProjectAnalysis {
+    /// Inferred project name (directory stem).
+    pub name: String,
+    /// Programming languages detected via file extensions.
+    pub languages: Vec<String>,
+    /// Whether a `README.md` exists at the project root.
+    pub has_readme: bool,
+    /// First 500 characters of `README.md`, if present.
+    pub readme_preview: Option<String>,
+    /// Snippets from package manifest files (key = filename).
+    pub package_files: Vec<(String, String)>,
+}
+
+const AMPLIHACK_INDICATORS: &[&str] = &[
+    "Microsoft Hackathon 2025",
+    "Agentic Coding Framework",
+    "Building the tools that build the future",
+    "AI agents to accelerate software development",
+];
+const INDICATOR_THRESHOLD: usize = 2;
+const PROJECT_MD_REL: &str = ".claude/context/PROJECT.md";
+const PREVIEW_LIMIT: usize = 500;
+
+const PROJECT_MD_TEMPLATE: &str = "# {project_name}\n\n\
+    ## Description\n\n\
+    {project_description}\n\n\
+    ## Tech Stack\n\n\
+    {tech_stack}\n\n\
+    ## Getting Started\n\n\
+    <!-- Add setup instructions here -->\n\n\
+    ## Architecture\n\n\
+    <!-- Describe the high-level architecture -->\n";
+
+/// Detect the current state of `PROJECT.md` in `project_dir`.
+pub fn detect_project_state(project_dir: &Path) -> ProjectState {
+    let md_path = project_dir.join(PROJECT_MD_REL);
+    if !md_path.exists() {
+        return ProjectState::Missing;
+    }
+    let content = match std::fs::read_to_string(&md_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(path = %md_path.display(), error = %e, "could not read PROJECT.md");
+            return ProjectState::Stale;
+        }
+    };
+    if content.trim().is_empty() {
+        return ProjectState::Stale;
+    }
+    let lower = content.to_lowercase();
+    let hits = AMPLIHACK_INDICATORS
+        .iter()
+        .filter(|ind| lower.contains(&ind.to_lowercase()))
+        .count();
+    if hits >= INDICATOR_THRESHOLD {
+        ProjectState::Template
+    } else {
+        ProjectState::Custom
+    }
+}
+
+/// Analyze the structure of a project directory.
+pub fn analyze_project_structure(project_dir: &Path) -> ProjectAnalysis {
+    let name = project_dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "project".to_owned());
+    let languages = detect_languages(project_dir);
+    let has_readme = project_dir.join("README.md").is_file();
+    let readme_preview = read_preview(&project_dir.join("README.md"));
+    let manifests = ["pyproject.toml", "package.json", "Cargo.toml", "go.mod"];
+    let package_files = manifests
+        .iter()
+        .filter_map(|f| Some(((*f).to_owned(), read_preview(&project_dir.join(f))?)))
+        .collect();
+    ProjectAnalysis {
+        name,
+        languages,
+        has_readme,
+        readme_preview,
+        package_files,
+    }
+}
+
+/// Initialize or update `PROJECT.md` according to `mode`.
+///
+/// # Errors
+///
+/// Returns [`ProjectInitError`] on I/O failures or if `project_dir` is missing.
+pub fn initialize_project_md(
+    project_dir: &Path,
+    mode: InitMode,
+) -> Result<InitResult, ProjectInitError> {
+    if !project_dir.is_dir() {
+        return Err(ProjectInitError::DirNotFound {
+            path: project_dir.display().to_string(),
+        });
+    }
+    let md_path = project_dir.join(PROJECT_MD_REL);
+    let state = detect_project_state(project_dir);
+    if mode == InitMode::Skip {
+        return Ok(InitResult {
+            action: ActionTaken::Skipped,
+            path: md_path,
+            template_used: None,
+        });
+    }
+    if mode == InitMode::Create && matches!(state, ProjectState::Custom | ProjectState::Template) {
+        return Ok(InitResult {
+            action: ActionTaken::Skipped,
+            path: md_path,
+            template_used: None,
+        });
+    }
+    let analysis = analyze_project_structure(project_dir);
+    let content = generate_from_template(&analysis);
+    if md_path.is_file() {
+        std::fs::rename(&md_path, md_path.with_extension("md.bak"))?;
+    }
+    if let Some(parent) = md_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&md_path, &content)?;
+    let action = if state == ProjectState::Missing {
+        ActionTaken::Initialized
+    } else {
+        ActionTaken::Regenerated
+    };
+    Ok(InitResult {
+        action,
+        path: md_path,
+        template_used: Some("default".to_owned()),
+    })
+}
+
+fn detect_languages(project_dir: &Path) -> Vec<String> {
+    let checks: &[(&[&str], &str)] = &[
+        (&["py"], "Python"),
+        (&["js", "ts", "jsx", "tsx"], "JavaScript/TypeScript"),
+        (&["rs"], "Rust"),
+        (&["go"], "Go"),
+        (&["java", "kt"], "Java/Kotlin"),
+        (&["cs"], "C#"),
+        (&["cpp", "cc", "cxx", "h", "hpp"], "C/C++"),
+    ];
+    checks
+        .iter()
+        .filter(|(exts, _)| has_ext(project_dir, exts))
+        .map(|(_, lang)| (*lang).to_owned())
+        .collect()
+}
+
+fn has_ext(dir: &Path, extensions: &[&str]) -> bool {
+    let scan = |d: &Path| -> bool {
+        let Ok(entries) = std::fs::read_dir(d) else {
+            return false;
+        };
+        entries.flatten().any(|e| {
+            let p = e.path();
+            p.is_file()
+                && p.extension()
+                    .and_then(|x| x.to_str())
+                    .is_some_and(|x| extensions.iter().any(|e| e.eq_ignore_ascii_case(x)))
+        })
+    };
+    if scan(dir) {
+        return true;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|e| {
+        let p = e.path();
+        p.is_dir() && {
+            let n = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            !n.starts_with('.') && n != "node_modules" && n != "target" && scan(&p)
+        }
+    })
+}
+
+fn read_preview(path: &Path) -> Option<String> {
+    let c = std::fs::read_to_string(path).ok()?;
+    if c.is_empty() {
+        return None;
+    }
+    let end = c
+        .char_indices()
+        .nth(PREVIEW_LIMIT)
+        .map_or(c.len(), |(i, _)| i);
+    Some(c[..end].to_owned())
+}
+
+fn generate_from_template(analysis: &ProjectAnalysis) -> String {
+    let description = analysis
+        .readme_preview
+        .as_ref()
+        .map(|p| extract_description(p))
+        .unwrap_or_else(|| "<!-- Describe your project here -->".to_owned());
+    let tech_stack = if analysis.languages.is_empty() {
+        "<!-- List your tech stack here -->".to_owned()
+    } else {
+        let mut buf: String = analysis
+            .languages
+            .iter()
+            .map(|l| format!("- {l}\n"))
+            .collect();
+        buf.push_str("- <!-- Add frameworks, databases, etc. -->");
+        buf
+    };
+    PROJECT_MD_TEMPLATE
+        .replace("{project_name}", &analysis.name)
+        .replace("{project_description}", &description)
+        .replace("{tech_stack}", &tech_stack)
+}
+
+fn extract_description(preview: &str) -> String {
+    let mut lines: Vec<&str> = Vec::new();
+    for line in preview.lines() {
+        let t = line.trim();
+        if t.starts_with('#') {
+            if lines.is_empty() {
+                continue;
+            } else {
+                break;
+            }
+        }
+        if t.is_empty() {
+            if lines.is_empty() {
+                continue;
+            } else {
+                break;
+            }
+        }
+        lines.push(t);
+        if lines.len() >= 2 {
+            break;
+        }
+    }
+    if lines.is_empty() {
+        "<!-- Describe your project here -->".to_owned()
+    } else {
+        lines.join("\n")
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/project_init_tests.rs"]
+mod tests;

--- a/crates/amplihack-utils/src/tests/claude_md_tests.rs
+++ b/crates/amplihack-utils/src/tests/claude_md_tests.rs
@@ -1,0 +1,255 @@
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// compute_content_hash
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hash_is_deterministic() {
+    let h1 = compute_content_hash("hello world");
+    let h2 = compute_content_hash("hello world");
+    assert_eq!(h1, h2);
+}
+
+#[test]
+fn hash_normalizes_trailing_spaces() {
+    let h1 = compute_content_hash("hello\nworld\n");
+    let h2 = compute_content_hash("hello  \nworld  \n\n");
+    assert_eq!(h1, h2);
+}
+
+#[test]
+fn hash_strips_leading_trailing_blanks() {
+    let h1 = compute_content_hash("\n\nhello\n\n\n");
+    let h2 = compute_content_hash("hello");
+    assert_eq!(h1, h2);
+}
+
+#[test]
+fn hash_differs_for_different_content() {
+    let h1 = compute_content_hash("hello");
+    let h2 = compute_content_hash("world");
+    assert_ne!(h1, h2);
+}
+
+#[test]
+fn hash_is_hex_sha256() {
+    let h = compute_content_hash("test");
+    assert_eq!(h.len(), 64, "SHA-256 hex digest should be 64 chars");
+    assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+// ---------------------------------------------------------------------------
+// detect_claude_state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn detect_missing() {
+    let tmp = TempDir::new().expect("tempdir");
+    assert_eq!(detect_claude_state(tmp.path()), ClaudeState::Missing);
+}
+
+#[test]
+fn detect_current_version() {
+    let tmp = TempDir::new().expect("tempdir");
+    let content =
+        format!("# CLAUDE.md\n{CLAUDE_VERSION_MARKER} {CURRENT_VERSION} -->\nContent here.\n");
+    fs::write(tmp.path().join("CLAUDE.md"), &content).expect("write");
+    assert_eq!(detect_claude_state(tmp.path()), ClaudeState::Default);
+}
+
+#[test]
+fn detect_outdated_version() {
+    let tmp = TempDir::new().expect("tempdir");
+    let content = format!("# CLAUDE.md\n{CLAUDE_VERSION_MARKER} 0.1.0 -->\nOld content.\n");
+    fs::write(tmp.path().join("CLAUDE.md"), &content).expect("write");
+    assert_eq!(detect_claude_state(tmp.path()), ClaudeState::CustomDirty);
+}
+
+#[test]
+fn detect_custom_content_no_marker() {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::write(
+        tmp.path().join("CLAUDE.md"),
+        "# My custom CLAUDE.md\n\nDo things this way.\n",
+    )
+    .expect("write");
+    assert_eq!(detect_claude_state(tmp.path()), ClaudeState::CustomClean);
+}
+
+#[cfg(unix)]
+#[test]
+fn detect_symlink_as_custom() {
+    let tmp = TempDir::new().expect("tempdir");
+    let real_file = tmp.path().join("real_claude.md");
+    fs::write(&real_file, "content").expect("write");
+    std::os::unix::fs::symlink(&real_file, tmp.path().join("CLAUDE.md")).expect("symlink");
+    assert_eq!(detect_claude_state(tmp.path()), ClaudeState::CustomClean);
+}
+
+// ---------------------------------------------------------------------------
+// parse_claude_state (internal, tested via detect)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_no_marker() {
+    assert_eq!(
+        parse_claude_state("No markers here"),
+        ClaudeState::CustomClean
+    );
+}
+
+#[test]
+fn parse_malformed_marker() {
+    let content = format!("{CLAUDE_VERSION_MARKER} no closing tag");
+    assert_eq!(parse_claude_state(&content), ClaudeState::CustomClean);
+}
+
+// ---------------------------------------------------------------------------
+// handle_claude_md — Overwrite mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overwrite_deploys_to_empty_dir() {
+    let tmp = TempDir::new().expect("tempdir");
+    let source = tmp.path().join("source_claude.md");
+    fs::write(&source, "# Source CLAUDE.md\nContent.\n").expect("write");
+
+    let target = TempDir::new().expect("target tempdir");
+    let result = handle_claude_md(&source, target.path(), HandleMode::Overwrite).expect("handle");
+
+    assert_eq!(result.action, HandleMode::Overwrite);
+    assert!(result.content_hash.is_some());
+    assert!(target.path().join("CLAUDE.md").is_file());
+}
+
+#[test]
+fn overwrite_replaces_existing() {
+    let tmp = TempDir::new().expect("tempdir");
+    let source = tmp.path().join("source_claude.md");
+    fs::write(&source, "# New content\n").expect("write source");
+
+    let target = TempDir::new().expect("target tempdir");
+    fs::write(target.path().join("CLAUDE.md"), "# Old content\n").expect("write old");
+
+    let result = handle_claude_md(&source, target.path(), HandleMode::Overwrite).expect("handle");
+    assert_eq!(result.action, HandleMode::Overwrite);
+
+    let deployed = fs::read_to_string(target.path().join("CLAUDE.md")).expect("read");
+    assert!(deployed.contains("New content"));
+}
+
+// ---------------------------------------------------------------------------
+// handle_claude_md — Preserve mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn preserve_deploys_when_missing() {
+    let tmp = TempDir::new().expect("tempdir");
+    let source = tmp.path().join("source.md");
+    fs::write(&source, "# Source\n").expect("write");
+
+    let target = TempDir::new().expect("target");
+    let result = handle_claude_md(&source, target.path(), HandleMode::Preserve).expect("handle");
+    assert_eq!(result.action, HandleMode::Preserve);
+    assert!(target.path().join("CLAUDE.md").is_file());
+}
+
+#[test]
+fn preserve_backs_up_custom_content() {
+    let tmp = TempDir::new().expect("tempdir");
+    let source = tmp.path().join("source.md");
+    fs::write(&source, "# Amplihack source\n").expect("write source");
+
+    let target = TempDir::new().expect("target");
+    fs::write(
+        target.path().join("CLAUDE.md"),
+        "# My custom content\nDo not lose this.\n",
+    )
+    .expect("write custom");
+
+    let result = handle_claude_md(&source, target.path(), HandleMode::Preserve).expect("handle");
+    assert_eq!(result.action, HandleMode::Preserve);
+
+    // Backup files should exist.
+    let preserved = target.path().join(".claude/context/CLAUDE.md.preserved");
+    assert!(preserved.is_file(), "preserved backup should exist");
+
+    let preserved_content = fs::read_to_string(preserved).expect("read preserved");
+    assert!(preserved_content.contains("custom content"));
+
+    let project_md = target.path().join(".claude/context/PROJECT.md");
+    assert!(project_md.is_file(), "PROJECT.md backup should exist");
+}
+
+#[test]
+fn preserve_skips_when_current() {
+    let tmp = TempDir::new().expect("tempdir");
+    let source = tmp.path().join("source.md");
+    fs::write(&source, "# Source\n").expect("write source");
+
+    let target = TempDir::new().expect("target");
+    let versioned = format!("{CLAUDE_VERSION_MARKER} {CURRENT_VERSION} -->\n# Content\n");
+    fs::write(target.path().join("CLAUDE.md"), &versioned).expect("write versioned");
+
+    let result = handle_claude_md(&source, target.path(), HandleMode::Preserve).expect("handle");
+    assert_eq!(result.action, HandleMode::Preserve);
+    assert!(result.content_hash.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// handle_claude_md — Merge mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn merge_combines_content() {
+    let tmp = TempDir::new().expect("tempdir");
+    let source = tmp.path().join("source.md");
+    fs::write(&source, "# Amplihack section\n").expect("write source");
+
+    let target = TempDir::new().expect("target");
+    fs::write(target.path().join("CLAUDE.md"), "# Existing content\n").expect("write existing");
+
+    let result = handle_claude_md(&source, target.path(), HandleMode::Merge).expect("handle");
+    assert_eq!(result.action, HandleMode::Merge);
+
+    let content = fs::read_to_string(target.path().join("CLAUDE.md")).expect("read");
+    assert!(content.contains("Existing content"));
+    assert!(content.contains("Amplihack section"));
+    assert!(content.contains("---"), "separator should be present");
+}
+
+// ---------------------------------------------------------------------------
+// handle_claude_md — error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn handle_missing_source_errors() {
+    let target = TempDir::new().expect("target");
+    let result = handle_claude_md(
+        Path::new("/nonexistent/source.md"),
+        target.path(),
+        HandleMode::Overwrite,
+    );
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// backup_to_project_md idempotency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backup_to_project_md_is_idempotent() {
+    let tmp = TempDir::new().expect("tempdir");
+    backup_to_project_md(tmp.path(), "first backup").expect("first");
+    backup_to_project_md(tmp.path(), "second backup").expect("second");
+
+    let project_md = tmp.path().join(".claude/context/PROJECT.md");
+    let content = fs::read_to_string(project_md).expect("read");
+
+    // Should only contain one preserved section.
+    let count = content.matches(BEGIN_MARKER).count();
+    assert_eq!(count, 1, "should not duplicate preserved sections");
+}

--- a/crates/amplihack-utils/src/tests/cleanup_tests.rs
+++ b/crates/amplihack-utils/src/tests/cleanup_tests.rs
@@ -1,0 +1,253 @@
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// CleanupRegistry::new
+// ---------------------------------------------------------------------------
+
+#[test]
+fn new_creates_directory() {
+    let tmp = TempDir::new().expect("tempdir");
+    let reg_dir = tmp.path().join("subdir");
+    let reg = CleanupRegistry::new(&reg_dir).expect("new");
+    assert!(reg_dir.is_dir());
+    assert!(reg.get_tracked_paths().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// register
+// ---------------------------------------------------------------------------
+
+#[test]
+fn register_adds_path() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut reg = CleanupRegistry::new(tmp.path()).expect("new");
+
+    let file = tmp.path().join("test.txt");
+    fs::write(&file, "data").expect("write");
+
+    reg.register(&file).expect("register");
+    assert_eq!(reg.get_tracked_paths().len(), 1);
+}
+
+#[test]
+fn register_deduplicates() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut reg = CleanupRegistry::new(tmp.path()).expect("new");
+
+    let file = tmp.path().join("test.txt");
+    fs::write(&file, "data").expect("write");
+
+    reg.register(&file).expect("first");
+    reg.register(&file).expect("second");
+    assert_eq!(reg.get_tracked_paths().len(), 1);
+}
+
+#[test]
+fn register_rejects_when_full() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut reg = CleanupRegistry::new(tmp.path()).expect("new");
+
+    // Fill up with unique paths (they don't need to exist for registration).
+    for i in 0..MAX_TRACKED_PATHS {
+        reg.tracked_paths.push(PathBuf::from(format!("/fake/{i}")));
+    }
+
+    let result = reg.register(Path::new("/fake/overflow"));
+    assert!(result.is_err());
+    if let Err(CleanupError::RegistryFull { max }) = result {
+        assert_eq!(max, MAX_TRACKED_PATHS);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// deletion_order
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deletion_order_is_deepest_first() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut reg = CleanupRegistry::new(tmp.path()).expect("new");
+
+    reg.tracked_paths.push(PathBuf::from("/a"));
+    reg.tracked_paths.push(PathBuf::from("/a/b/c"));
+    reg.tracked_paths.push(PathBuf::from("/a/b"));
+
+    let order = reg.deletion_order();
+    assert_eq!(order[0], PathBuf::from("/a/b/c"));
+    assert_eq!(order[1], PathBuf::from("/a/b"));
+    assert_eq!(order[2], PathBuf::from("/a"));
+}
+
+// ---------------------------------------------------------------------------
+// save / load round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn save_and_load_round_trip() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut reg = CleanupRegistry::new(tmp.path()).expect("new");
+
+    let file1 = tmp.path().join("file1.txt");
+    let file2 = tmp.path().join("file2.txt");
+    fs::write(&file1, "a").expect("write");
+    fs::write(&file2, "b").expect("write");
+
+    reg.register(&file1).expect("reg1");
+    reg.register(&file2).expect("reg2");
+    reg.save().expect("save");
+
+    // Verify file exists.
+    assert!(tmp.path().join(REGISTRY_FILENAME).is_file());
+
+    // Load and verify.
+    let loaded = CleanupRegistry::load(tmp.path()).expect("load");
+    assert_eq!(loaded.get_tracked_paths().len(), 2);
+    assert_eq!(loaded.session_id, reg.session_id);
+}
+
+#[test]
+fn load_nonexistent_returns_empty() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fresh_dir = tmp.path().join("empty");
+    let loaded = CleanupRegistry::load(&fresh_dir).expect("load");
+    assert!(loaded.get_tracked_paths().is_empty());
+}
+
+#[test]
+fn load_malformed_json_returns_empty() {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::write(tmp.path().join(REGISTRY_FILENAME), "NOT JSON!!!").expect("write");
+
+    let loaded = CleanupRegistry::load(tmp.path()).expect("load");
+    assert!(loaded.get_tracked_paths().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// cleanup_all
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cleanup_removes_files() {
+    let tmp = TempDir::new().expect("tempdir");
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).expect("mkdir");
+
+    let mut reg = CleanupRegistry::new(&work).expect("new");
+
+    let f1 = work.join("temp1.txt");
+    let f2 = work.join("temp2.txt");
+    fs::write(&f1, "a").expect("write");
+    fs::write(&f2, "b").expect("write");
+
+    reg.register(&f1).expect("reg");
+    reg.register(&f2).expect("reg");
+
+    let cleaned = reg.cleanup_all().expect("cleanup");
+    assert_eq!(cleaned, 2);
+    assert!(!f1.exists());
+    assert!(!f2.exists());
+    assert!(reg.get_tracked_paths().is_empty());
+}
+
+#[test]
+fn cleanup_removes_directories() {
+    let tmp = TempDir::new().expect("tempdir");
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).expect("mkdir");
+
+    let mut reg = CleanupRegistry::new(&work).expect("new");
+
+    let subdir = work.join("subdir");
+    fs::create_dir_all(&subdir).expect("mkdir");
+    fs::write(subdir.join("inner.txt"), "x").expect("write");
+
+    reg.register(&subdir).expect("reg");
+
+    let cleaned = reg.cleanup_all().expect("cleanup");
+    assert_eq!(cleaned, 1);
+    assert!(!subdir.exists());
+}
+
+#[test]
+fn cleanup_skips_nonexistent_paths() {
+    let tmp = TempDir::new().expect("tempdir");
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).expect("mkdir");
+
+    let mut reg = CleanupRegistry::new(&work).expect("new");
+    reg.tracked_paths.push(work.join("does_not_exist.txt"));
+
+    let cleaned = reg.cleanup_all().expect("cleanup");
+    assert_eq!(cleaned, 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn cleanup_skips_symlinks() {
+    let tmp = TempDir::new().expect("tempdir");
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).expect("mkdir");
+
+    let mut reg = CleanupRegistry::new(&work).expect("new");
+
+    let real = work.join("real.txt");
+    fs::write(&real, "data").expect("write");
+    let link = work.join("link.txt");
+    std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+    reg.register(&link).expect("reg");
+
+    let cleaned = reg.cleanup_all().expect("cleanup");
+    assert_eq!(cleaned, 0, "symlinks should be skipped");
+    assert!(real.exists(), "real file should still exist");
+}
+
+// ---------------------------------------------------------------------------
+// validate_cleanup_path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_accepts_contained_path() {
+    let tmp = TempDir::new().expect("tempdir");
+    let file = tmp.path().join("test.txt");
+    fs::write(&file, "x").expect("write");
+
+    assert!(validate_cleanup_path(&file, tmp.path()).is_ok());
+}
+
+#[test]
+fn validate_rejects_escaped_path() {
+    let tmp = TempDir::new().expect("tempdir");
+    let work = tmp.path().join("work");
+    fs::create_dir_all(&work).expect("mkdir");
+
+    // Create a file outside the working directory.
+    let outside = tmp.path().join("outside.txt");
+    fs::write(&outside, "x").expect("write");
+
+    assert!(validate_cleanup_path(&outside, &work).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// save permissions (Unix only)
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn save_sets_restrictive_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let mut reg = CleanupRegistry::new(tmp.path()).expect("new");
+
+    let file = tmp.path().join("test.txt");
+    fs::write(&file, "x").expect("write");
+    reg.register(&file).expect("reg");
+    reg.save().expect("save");
+
+    let reg_file = tmp.path().join(REGISTRY_FILENAME);
+    let mode = fs::metadata(&reg_file).expect("meta").permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "registry file should be owner-only");
+}

--- a/crates/amplihack-utils/src/tests/project_init_tests.rs
+++ b/crates/amplihack-utils/src/tests/project_init_tests.rs
@@ -1,0 +1,234 @@
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// detect_project_state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn detect_missing_project_md() {
+    let tmp = TempDir::new().expect("tempdir");
+    assert_eq!(detect_project_state(tmp.path()), ProjectState::Missing);
+}
+
+#[test]
+fn detect_custom_project_md() {
+    let tmp = TempDir::new().expect("tempdir");
+    let ctx = tmp.path().join(".claude").join("context");
+    fs::create_dir_all(&ctx).expect("mkdir");
+    fs::write(
+        ctx.join("PROJECT.md"),
+        "# My Custom Project\n\nDescription here.\n",
+    )
+    .expect("write");
+    assert_eq!(detect_project_state(tmp.path()), ProjectState::Custom);
+}
+
+#[test]
+fn detect_template_project_md() {
+    let tmp = TempDir::new().expect("tempdir");
+    let ctx = tmp.path().join(".claude").join("context");
+    fs::create_dir_all(&ctx).expect("mkdir");
+    let content = "\
+# Project\n\
+\n\
+Microsoft Hackathon 2025\n\
+Agentic Coding Framework\n\
+Building the tools that build the future\n\
+";
+    fs::write(ctx.join("PROJECT.md"), content).expect("write");
+    assert_eq!(detect_project_state(tmp.path()), ProjectState::Template);
+}
+
+#[test]
+fn detect_stale_empty_project_md() {
+    let tmp = TempDir::new().expect("tempdir");
+    let ctx = tmp.path().join(".claude").join("context");
+    fs::create_dir_all(&ctx).expect("mkdir");
+    fs::write(ctx.join("PROJECT.md"), "   \n  \n").expect("write");
+    assert_eq!(detect_project_state(tmp.path()), ProjectState::Stale);
+}
+
+// ---------------------------------------------------------------------------
+// analyze_project_structure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn analyze_detects_rust_language() {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::write(tmp.path().join("main.rs"), "fn main() {}").expect("write");
+
+    let analysis = analyze_project_structure(tmp.path());
+    assert!(analysis.languages.contains(&"Rust".to_owned()));
+}
+
+#[test]
+fn analyze_detects_python_in_subdirectory() {
+    let tmp = TempDir::new().expect("tempdir");
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).expect("mkdir");
+    fs::write(src.join("app.py"), "pass").expect("write");
+
+    let analysis = analyze_project_structure(tmp.path());
+    assert!(analysis.languages.contains(&"Python".to_owned()));
+}
+
+#[test]
+fn analyze_reads_readme_preview() {
+    let tmp = TempDir::new().expect("tempdir");
+    let readme_text = "# My Project\n\nA short description.\n";
+    fs::write(tmp.path().join("README.md"), readme_text).expect("write");
+
+    let analysis = analyze_project_structure(tmp.path());
+    assert!(analysis.has_readme);
+    assert!(analysis.readme_preview.is_some());
+    assert!(
+        analysis
+            .readme_preview
+            .as_ref()
+            .map_or(false, |p| p.contains("short description"))
+    );
+}
+
+#[test]
+fn analyze_collects_package_files() {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = \"test\"").expect("write");
+
+    let analysis = analyze_project_structure(tmp.path());
+    assert!(
+        analysis
+            .package_files
+            .iter()
+            .any(|(name, _)| name == "Cargo.toml")
+    );
+}
+
+#[test]
+fn analyze_no_files() {
+    let tmp = TempDir::new().expect("tempdir");
+    let analysis = analyze_project_structure(tmp.path());
+    assert!(analysis.languages.is_empty());
+    assert!(!analysis.has_readme);
+}
+
+// ---------------------------------------------------------------------------
+// initialize_project_md
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_creates_project_md_when_missing() {
+    let tmp = TempDir::new().expect("tempdir");
+    let result = initialize_project_md(tmp.path(), InitMode::Create).expect("init");
+
+    assert_eq!(result.action, ActionTaken::Initialized);
+    assert!(result.path.is_file());
+    assert!(result.template_used.is_some());
+}
+
+#[test]
+fn init_skip_mode_never_writes() {
+    let tmp = TempDir::new().expect("tempdir");
+    let result = initialize_project_md(tmp.path(), InitMode::Skip).expect("init");
+
+    assert_eq!(result.action, ActionTaken::Skipped);
+    assert!(!result.path.is_file());
+}
+
+#[test]
+fn init_create_does_not_overwrite_custom() {
+    let tmp = TempDir::new().expect("tempdir");
+    let ctx = tmp.path().join(".claude").join("context");
+    fs::create_dir_all(&ctx).expect("mkdir");
+    fs::write(ctx.join("PROJECT.md"), "# Custom project\n").expect("write");
+
+    let result = initialize_project_md(tmp.path(), InitMode::Create).expect("init");
+    assert_eq!(result.action, ActionTaken::Skipped);
+
+    let content = fs::read_to_string(ctx.join("PROJECT.md")).expect("read");
+    assert!(content.contains("Custom project"));
+}
+
+#[test]
+fn init_update_overwrites_custom() {
+    let tmp = TempDir::new().expect("tempdir");
+    let ctx = tmp.path().join(".claude").join("context");
+    fs::create_dir_all(&ctx).expect("mkdir");
+    fs::write(ctx.join("PROJECT.md"), "# Custom project\n").expect("write");
+
+    let result = initialize_project_md(tmp.path(), InitMode::Update).expect("init");
+    assert_eq!(result.action, ActionTaken::Regenerated);
+    assert!(
+        ctx.join("PROJECT.md.bak").is_file(),
+        "backup should be created"
+    );
+}
+
+#[test]
+fn init_errors_on_nonexistent_dir() {
+    let result = initialize_project_md(Path::new("/nonexistent/path"), InitMode::Create);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// generate_from_template (via initialize)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generated_content_includes_project_name() {
+    let tmp = TempDir::new().expect("tempdir");
+    initialize_project_md(tmp.path(), InitMode::Create).expect("init");
+
+    let md_path = tmp.path().join(".claude/context/PROJECT.md");
+    let content = fs::read_to_string(md_path).expect("read");
+    // The project name should be the tmpdir basename.
+    assert!(content.starts_with('#'));
+}
+
+#[test]
+fn generated_content_includes_detected_languages() {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::write(tmp.path().join("main.rs"), "fn main() {}").expect("write");
+
+    initialize_project_md(tmp.path(), InitMode::Create).expect("init");
+
+    let md_path = tmp.path().join(".claude/context/PROJECT.md");
+    let content = fs::read_to_string(md_path).expect("read");
+    assert!(content.contains("Rust"));
+}
+
+// ---------------------------------------------------------------------------
+// extract_description
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extract_description_from_readme() {
+    let preview = "# My Project\n\nA great library for testing.\nSecond line.\n\n## Features\n";
+    let desc = extract_description(preview);
+    assert!(desc.contains("great library"));
+    assert!(!desc.contains("Features"));
+}
+
+#[test]
+fn extract_description_placeholder_on_empty() {
+    let desc = extract_description("#Title\n\n");
+    assert!(desc.contains("Describe your project"));
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indicator_matching_is_case_insensitive() {
+    let tmp = TempDir::new().expect("tempdir");
+    let ctx = tmp.path().join(".claude").join("context");
+    fs::create_dir_all(&ctx).expect("mkdir");
+    fs::write(
+        ctx.join("PROJECT.md"),
+        "microsoft hackathon 2025\nagentic coding framework\n",
+    )
+    .expect("write");
+    assert_eq!(detect_project_state(tmp.path()), ProjectState::Template);
+}


### PR DESCRIPTION
## Summary

Port three Python modules to Rust for the `amplihack-utils` crate:

### New Modules

- **`project_init`** (316 lines): PROJECT.md state detection, project structure analysis, and template-based initialization. Ported from `project_initializer.py`.
- **`claude_md`** (390 lines): CLAUDE.md version detection, SHA-256 content hashing, preservation with backup to PROJECT.md. Ported from `claude_md_preserver.py`.
- **`cleanup`** (378 lines): File-backed cleanup registry with JSON persistence, deepest-first deletion order, path validation, and TOCTOU symlink mitigation. Ported from `cleanup_handler.py` + `cleanup_registry.py`.

### Changes

- 3 new source files in `crates/amplihack-utils/src/`
- 3 new test files in `crates/amplihack-utils/src/tests/`
- Updated `lib.rs` with module declarations
- Added `sha2` and `chrono` workspace dependencies to `Cargo.toml`

### Quality

- All modules under 400 lines
- No `unwrap()` in library code
- All public items documented
- 113 unit tests + 11 doc tests passing
- `cargo clippy -D warnings` clean