### PR TITLE
fix: correct amplihack-delegation integration tests

### DIFF
--- a/crates/amplihack-delegation/tests/models_test.rs
+++ b/crates/amplihack-delegation/tests/models_test.rs
@@ -1,156 +1,130 @@
-use amplihack_delegation::{
-    DelegationStatus, EvidenceItem, EvidenceType, MetaDelegationResult, ScenarioCategory,
-    SubprocessResult,
-};
-use serde_json::json;
+use amplihack_delegation::models::*;
+use chrono::Utc;
 
 #[test]
 fn delegation_status_display() {
-    assert_eq!(DelegationStatus::Pending.to_string(), "Pending");
-    assert_eq!(DelegationStatus::Running.to_string(), "Running");
-    assert_eq!(DelegationStatus::Completed.to_string(), "Completed");
-    assert_eq!(DelegationStatus::Failed.to_string(), "Failed");
+    assert_eq!(DelegationStatus::Success.to_string(), "SUCCESS");
+    assert_eq!(DelegationStatus::Partial.to_string(), "PARTIAL");
+    assert_eq!(DelegationStatus::Failure.to_string(), "FAILURE");
 }
 
 #[test]
-fn serde_roundtrip() {
-    let result = MetaDelegationResult {
-        delegated_to: "test_persona".into(),
-        status: DelegationStatus::Completed,
-        result: "test_result".into(),
-    };
-
-    let json = serde_json::to_string(&result).unwrap();
-    let deserialized: MetaDelegationResult = serde_json::from_str(&json).unwrap();
-
-    assert_eq!(deserialized.delegated_to, "test_persona");
-    assert_eq!(deserialized.status, DelegationStatus::Completed);
-    assert_eq!(deserialized.result, "test_result");
+fn delegation_status_serde_roundtrip() {
+    let json = serde_json::to_string(&DelegationStatus::Success).unwrap();
+    assert_eq!(json, r#""SUCCESS""#);
+    let back: DelegationStatus = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, DelegationStatus::Success);
 }
 
 #[test]
 fn evidence_type_display() {
-    assert_eq!(EvidenceType::TestPassed.to_string(), "TestPassed");
-    assert_eq!(EvidenceType::LogEntry.to_string(), "LogEntry");
-    assert_eq!(EvidenceType::CodeReview.to_string(), "CodeReview");
-    assert_eq!(EvidenceType::Performance.to_string(), "Performance");
+    assert_eq!(EvidenceType::CodeFile.to_string(), "code_file");
+    assert_eq!(
+        EvidenceType::ArchitectureDoc.to_string(),
+        "architecture_doc"
+    );
 }
 
 #[test]
 fn subprocess_result_success_and_crashed() {
-    let success = SubprocessResult {
+    let ok = SubprocessResult {
         exit_code: 0,
-        stdout: "output".into(),
-        stderr: "".into(),
+        stdout: String::new(),
+        stderr: String::new(),
+        duration_secs: 1.0,
+        subprocess_pid: 42,
+        timed_out: false,
+        orphans_cleaned: 0,
     };
-    assert!(success.success());
+    assert!(ok.success());
+    assert!(!ok.crashed());
 
-    let failed = SubprocessResult {
-        exit_code: 1,
-        stdout: "".into(),
-        stderr: "error".into(),
+    let timed_out = SubprocessResult {
+        timed_out: true,
+        ..ok.clone()
     };
-    assert!(!failed.success());
+    assert!(!timed_out.success());
 
     let crashed = SubprocessResult {
-        exit_code: -1,
-        stdout: "".into(),
-        stderr: "crash".into(),
+        exit_code: -9,
+        ..ok
     };
-    assert!(!crashed.success());
+    assert!(crashed.crashed());
 }
 
 #[test]
 fn evaluation_result_clamps_score() {
-    use amplihack_delegation::EvaluationResult;
-
-    let result = EvaluationResult {
-        score: 150,
-        passed: true,
-    };
-    assert_eq!(result.clamped_score(), 100);
-
-    let result = EvaluationResult {
-        score: 75,
-        passed: true,
-    };
-    assert_eq!(result.clamped_score(), 75);
-
-    let result = EvaluationResult {
-        score: -10,
-        passed: false,
-    };
-    assert_eq!(result.clamped_score(), 0);
+    let r = EvaluationResult::new(150, String::new(), vec![], vec![], 0);
+    assert_eq!(r.score, 100);
 }
 
 #[test]
 fn evaluation_result_status_thresholds() {
-    use amplihack_delegation::EvaluationResult;
-
-    let high = EvaluationResult {
-        score: 85,
-        passed: true,
-    };
-    assert_eq!(high.status(), "Excellent");
-
-    let medium = EvaluationResult {
-        score: 65,
-        passed: true,
-    };
-    assert_eq!(medium.status(), "Good");
-
-    let low = EvaluationResult {
-        score: 45,
-        passed: true,
-    };
-    assert_eq!(low.status(), "Acceptable");
-
-    let failed = EvaluationResult {
-        score: 20,
-        passed: false,
-    };
-    assert_eq!(failed.status(), "Failed");
+    assert_eq!(
+        EvaluationResult::new(80, String::new(), vec![], vec![], 0).status(),
+        DelegationStatus::Success
+    );
+    assert_eq!(
+        EvaluationResult::new(50, String::new(), vec![], vec![], 0).status(),
+        DelegationStatus::Partial
+    );
+    assert_eq!(
+        EvaluationResult::new(49, String::new(), vec![], vec![], 0).status(),
+        DelegationStatus::Failure
+    );
 }
 
 #[test]
 fn meta_delegation_result_json_roundtrip() {
-    let original = MetaDelegationResult {
-        delegated_to: "architect".into(),
-        status: DelegationStatus::Completed,
-        result: r#"{"feedback": "well structured"}"#.into(),
+    let result = MetaDelegationResult {
+        status: DelegationStatus::Success,
+        success_score: 95,
+        evidence: vec![],
+        execution_log: "all good".into(),
+        duration_secs: 10.5,
+        persona_used: "guide".into(),
+        platform_used: "claude-code".into(),
+        failure_reason: None,
+        partial_completion_notes: None,
+        subprocess_pid: Some(1234),
+        test_scenarios: None,
     };
-
-    let json_str = serde_json::to_string(&original).unwrap();
-    let parsed: MetaDelegationResult = serde_json::from_str(&json_str).unwrap();
-
-    assert_eq!(parsed.delegated_to, original.delegated_to);
-    assert_eq!(parsed.status, original.status);
-    assert_eq!(parsed.result, original.result);
+    let json = result.to_json().unwrap();
+    let back = MetaDelegationResult::from_json(&json).unwrap();
+    assert_eq!(back.success_score, 95);
+    assert_eq!(back.status, DelegationStatus::Success);
 }
 
 #[test]
 fn get_evidence_by_type_filters() {
-    let items = vec![
-        EvidenceItem {
-            evidence_type: EvidenceType::TestPassed,
-            content: "test 1 passed".into(),
-        },
-        EvidenceItem {
-            evidence_type: EvidenceType::LogEntry,
-            content: "log line".into(),
-        },
-        EvidenceItem {
-            evidence_type: EvidenceType::TestPassed,
-            content: "test 2 passed".into(),
-        },
-    ];
-
-    let test_items: Vec<_> = items
-        .iter()
-        .filter(|e| e.evidence_type == EvidenceType::TestPassed)
-        .collect();
-
-    assert_eq!(test_items.len(), 2);
-    assert_eq!(test_items[0].content, "test 1 passed");
-    assert_eq!(test_items[1].content, "test 2 passed");
+    let item = EvidenceItem {
+        evidence_type: EvidenceType::TestFile,
+        path: "test_main.py".into(),
+        content: String::new(),
+        excerpt: String::new(),
+        size_bytes: 100,
+        timestamp: Utc::now(),
+        metadata: Default::default(),
+    };
+    let result = MetaDelegationResult {
+        status: DelegationStatus::Success,
+        success_score: 90,
+        evidence: vec![item],
+        execution_log: String::new(),
+        duration_secs: 1.0,
+        persona_used: "guide".into(),
+        platform_used: "claude-code".into(),
+        failure_reason: None,
+        partial_completion_notes: None,
+        subprocess_pid: None,
+        test_scenarios: None,
+    };
+    assert_eq!(
+        result.get_evidence_by_type(&EvidenceType::TestFile).len(),
+        1
+    );
+    assert_eq!(
+        result.get_evidence_by_type(&EvidenceType::CodeFile).len(),
+        0
+    );
 }

--- a/crates/amplihack-delegation/tests/scenario_test.rs
+++ b/crates/amplihack-delegation/tests/scenario_test.rs
@@ -1,83 +1,90 @@
-use amplihack_delegation::{ScenarioCategory, ScenarioGenerator};
+use amplihack_delegation::{ScenarioCategory, ScenarioGenerator, TestScenario};
 
-#[test]
-fn generates_minimum() {
-    let generator = ScenarioGenerator::new("build a todo app");
-    let scenarios = generator.generate(1);
-    assert!(!scenarios.is_empty());
-    assert_eq!(scenarios[0].goal, "build a todo app");
+fn make_gen() -> ScenarioGenerator {
+    ScenarioGenerator::new()
 }
 
 #[test]
-fn api_more() {
-    let generator = ScenarioGenerator::new("build rest api");
-    let scenarios = generator.generate(2);
-    assert!(scenarios.len() >= 1);
+fn generates_minimum_scenarios_for_generic_goal() {
+    let s = make_gen().generate_scenarios("build a CLI tool", "it works");
+    assert!(s.len() >= 6, "expected >= 6, got {}", s.len());
+}
+
+#[test]
+fn api_goal_produces_more_scenarios() {
+    let generic = make_gen().generate_scenarios("build a tool", "works");
+    let api = make_gen().generate_scenarios("build a REST API endpoint", "returns JSON");
+    assert!(api.len() > generic.len());
+}
+
+#[test]
+fn auth_goal_includes_security_scenarios() {
+    let s = make_gen().generate_scenarios("implement JWT authentication", "login returns token");
+    let n = s
+        .iter()
+        .filter(|x| x.category == ScenarioCategory::Security)
+        .count();
+    assert!(n >= 3, "expected >= 3 security, got {n}");
+}
+
+#[test]
+fn performance_goal_includes_performance_scenarios() {
+    let s = make_gen().generate_scenarios("optimize performance of search", "handles load");
+    let n = s
+        .iter()
+        .filter(|x| x.category == ScenarioCategory::Performance)
+        .count();
+    assert!(n >= 1);
+}
+
+#[test]
+fn pagination_goal_includes_zero_results() {
+    let s = make_gen().generate_scenarios("implement paginated list endpoint", "returns page");
+    assert!(s.iter().any(|x| x.name == "Pagination with zero results"));
+}
+
+#[test]
+fn all_scenarios_have_required_fields() {
+    let s = make_gen().generate_scenarios("build auth API endpoint", "secure JWT login");
+    for x in &s {
+        assert!(!x.name.is_empty());
+        assert!(!x.steps.is_empty());
+        assert!(["high", "medium", "low"].contains(&x.priority.as_str()));
+    }
+}
+
+#[test]
+fn integration_always_present() {
+    let s = make_gen().generate_scenarios("anything", "something");
     assert!(
-        scenarios
-            .iter()
-            .any(|s| s.category == ScenarioCategory::API)
+        s.iter()
+            .any(|x| x.category == ScenarioCategory::Integration)
     );
 }
 
 #[test]
-fn auth_security() {
-    let generator = ScenarioGenerator::new("jwt authentication");
-    let scenarios = generator.generate(1);
-    assert!(!scenarios.is_empty());
-    assert_eq!(scenarios[0].category, ScenarioCategory::AuthSecurity);
+fn error_handling_always_has_missing_data() {
+    let s = make_gen().generate_scenarios("do stuff", "it works");
+    assert!(
+        s.iter()
+            .any(|x| x.name == "Missing required data is rejected")
+    );
 }
 
 #[test]
-fn performance() {
-    let generator = ScenarioGenerator::new("performance testing");
-    let scenarios = generator.generate(1);
-    assert!(!scenarios.is_empty());
-    assert_eq!(scenarios[0].category, ScenarioCategory::Performance);
-}
-
-#[test]
-fn pagination_zero() {
-    let generator = ScenarioGenerator::new("build list page");
-    let scenarios = generator.generate(0);
-    assert_eq!(scenarios.len(), 0);
-}
-
-#[test]
-fn required_fields() {
-    let generator = ScenarioGenerator::new("test goal");
-    let scenarios = generator.generate(1);
-    assert!(!scenarios.is_empty());
-    let scenario = &scenarios[0];
-    assert!(!scenario.goal.is_empty());
-    assert!(!scenario.test_steps.is_empty());
-    assert!(!scenario.expected_outcome.is_empty());
-    assert!(!scenario.priority.is_empty());
-    assert!(!scenario.tags.is_empty());
-}
-
-#[test]
-fn integration_always() {
-    let generator = ScenarioGenerator::new("any goal");
-    let scenarios = generator.generate(1);
-    assert!(!scenarios.is_empty());
-    assert!(scenarios[0].tags.contains(&"integration".into()));
-}
-
-#[test]
-fn missing_data() {
-    let generator = ScenarioGenerator::new("");
-    let scenarios = generator.generate(1);
-    assert!(!scenarios.is_empty());
-}
-
-#[test]
-fn serde_roundtrip() {
-    let generator = ScenarioGenerator::new("test");
-    let scenarios = generator.generate(1);
-    if !scenarios.is_empty() {
-        let json = serde_json::to_string(&scenarios[0]).unwrap();
-        let deserialized = serde_json::from_str(&json).expect("Failed to deserialize scenario");
-        assert_eq!(scenarios[0].goal, deserialized.goal);
-    }
+fn scenario_serde_roundtrip() {
+    let scenario = TestScenario {
+        name: "test".into(),
+        category: ScenarioCategory::HappyPath,
+        description: "desc".into(),
+        preconditions: vec!["pre".into()],
+        steps: vec!["step".into()],
+        expected_outcome: "pass".into(),
+        priority: "high".into(),
+        tags: vec!["tag".into()],
+    };
+    let json = serde_json::to_string(&scenario).unwrap();
+    let back: TestScenario = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.name, "test");
+    assert_eq!(back.category, ScenarioCategory::HappyPath);
 }


### PR DESCRIPTION
## Summary
Fix integration tests for the amplihack-delegation crate that were merged with incorrect API usage in PR #135.

## Changes
- **tests/models_test.rs**: Rewritten to use correct field names and types from `models.rs` (DelegationStatus, EvidenceType, SubprocessResult, EvaluationResult, MetaDelegationResult, EvidenceItem)
- **tests/scenario_test.rs**: Rewritten to use correct `ScenarioGenerator::generate_scenarios()` API with proper assertions

## Test Results
- 28 unit tests (error, persona, state_machine)
- 8 integration tests (models)
- 9 integration tests (scenarios)
- **Total: 45 tests passing**

## Verification
```
cargo fmt -p amplihack-delegation  # clean
cargo clippy -p amplihack-delegation -- -D warnings  # clean
cargo test -p amplihack-delegation  # 45 tests pass
```

All source modules under 400 lines. No `unwrap()` in library code. All public items documented.