### PR TITLE
feat(utils): port plugin management system from Python

### DIFF
--- a/crates/amplihack-utils/src/lib.rs
+++ b/crates/amplihack-utils/src/lib.rs
@@ -15,6 +15,9 @@
 //! - [`worktree`] — Git worktree detection and shared runtime directory resolution
 //! - [`settings_generator`] — Plugin settings generation, merging, and writing
 //! - [`power_steering`] — Power-steering re-enable prompt with timeout
+//! - [`plugin_manifest`] — Plugin manifest types and validation
+//! - [`plugin_manager`] — Plugin installation, uninstallation, and path resolution
+//! - [`plugin_cli`] — CLI command handlers for plugin management
 
 pub mod claude_cli;
 pub mod claude_md;
@@ -22,6 +25,10 @@ pub mod cleanup;
 pub mod defensive;
 pub mod docker_detector;
 pub mod kb_types;
+pub mod plugin_cli;
+pub mod plugin_manifest;
+pub mod plugin_manager;
+pub(crate) mod plugin_manager_paths;
 pub mod plugin_verifier;
 pub mod power_steering;
 pub mod prerequisites;

--- a/crates/amplihack-utils/src/plugin_cli.rs
+++ b/crates/amplihack-utils/src/plugin_cli.rs
@@ -1,0 +1,192 @@
+//! CLI command handlers for plugin management.
+//!
+//! Ported from `amplihack/plugin_cli/cli_handlers.py` and
+//! `amplihack/plugin_cli/parser_setup.py`.
+//!
+//! Provides thin wrappers around [`PluginManager`] that print user-facing
+//! messages and return standard exit codes (0 = success, 1 = failure).
+
+use std::path::PathBuf;
+
+use crate::plugin_manager::PluginManager;
+use crate::plugin_verifier::PluginVerifier;
+
+// ---------------------------------------------------------------------------
+// Emoji / platform-aware indicators
+// ---------------------------------------------------------------------------
+
+/// Success indicator (emoji on Unix, text on Windows).
+const SUCCESS: &str = if cfg!(windows) { "[OK]" } else { "✅" };
+
+/// Failure indicator (emoji on Unix, text on Windows).
+const FAILURE: &str = if cfg!(windows) { "[ERROR]" } else { "❌" };
+
+// ---------------------------------------------------------------------------
+// CLI command handlers
+// ---------------------------------------------------------------------------
+
+/// Install a plugin from a git URL or local path.
+///
+/// - `source`: Git URL (`https://…`, `git@…`) or local directory path.
+/// - `force`: If `true`, overwrite an existing installation.
+/// - `plugin_root`: Optional override for the plugin install directory.
+///
+/// Returns `0` on success, `1` on failure.
+pub fn plugin_install_command(
+    source: &str,
+    force: bool,
+    plugin_root: Option<PathBuf>,
+) -> i32 {
+    let manager = PluginManager::new(plugin_root);
+    let result = manager.install(source, force);
+
+    if result.success {
+        println!("{SUCCESS} Plugin installed: {}", result.plugin_name);
+        println!("   Location: {}", result.installed_path.display());
+        println!("   {}", result.message);
+        0
+    } else {
+        println!("{FAILURE} Installation failed: {}", result.message);
+        1
+    }
+}
+
+/// Uninstall a plugin by name.
+///
+/// Returns `0` on success, `1` on failure.
+pub fn plugin_uninstall_command(
+    plugin_name: &str,
+    plugin_root: Option<PathBuf>,
+) -> i32 {
+    let manager = PluginManager::new(plugin_root);
+    let success = manager.uninstall(plugin_name);
+
+    if success {
+        println!("{SUCCESS} Plugin removed: {plugin_name}");
+        0
+    } else {
+        println!("{FAILURE} Failed to remove plugin: {plugin_name}");
+        println!("   Plugin may not be installed or removal failed");
+        1
+    }
+}
+
+/// Verify a plugin installation and discoverability.
+///
+/// Returns `0` if fully verified, `1` if any check fails.
+pub fn plugin_verify_command(plugin_name: &str) -> i32 {
+    let verifier = PluginVerifier::new(plugin_name);
+    let result = verifier.verify();
+
+    let status = |ok: bool| if ok { SUCCESS } else { FAILURE };
+
+    println!("Plugin: {plugin_name}");
+    println!("  Installed: {}", status(result.installed));
+    println!("  Discoverable: {}", status(result.discoverable));
+    println!("  Hooks loaded: {}", status(result.hooks_loaded));
+
+    if !result.success {
+        println!("\nDiagnostics:");
+        for issue in &result.issues {
+            println!("  - {issue}");
+        }
+    }
+
+    if result.success { 0 } else { 1 }
+}
+
+/// List all installed plugins and print them.
+///
+/// Returns `0` always (listing is informational).
+pub fn plugin_list_command(plugin_root: Option<PathBuf>) -> i32 {
+    let manager = PluginManager::new(plugin_root);
+    let plugins = manager.list_installed();
+
+    if plugins.is_empty() {
+        println!("No plugins installed.");
+    } else {
+        println!("Installed plugins:");
+        for name in &plugins {
+            println!("  - {name}");
+        }
+    }
+
+    0
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_plugin(root: &std::path::Path, name: &str) -> PathBuf {
+        let dir = root.join(name);
+        let manifest_dir = dir.join(".claude-plugin");
+        std::fs::create_dir_all(&manifest_dir).unwrap();
+        std::fs::write(
+            manifest_dir.join("plugin.json"),
+            r#"{"name":"test-plugin","version":"1.0.0","entry_point":"main.py"}"#,
+        )
+        .unwrap();
+        std::fs::write(dir.join("main.py"), "# entry").unwrap();
+        dir
+    }
+
+    #[test]
+    fn install_command_succeeds_with_valid_source() {
+        let tmp = TempDir::new().unwrap();
+        let source = create_test_plugin(tmp.path(), "test-plugin");
+        let install_dir = tmp.path().join("installed");
+
+        let code = plugin_install_command(
+            source.to_str().unwrap(),
+            false,
+            Some(install_dir.clone()),
+        );
+        assert_eq!(code, 0);
+        assert!(install_dir.join("test-plugin").exists());
+    }
+
+    #[test]
+    fn install_command_fails_with_bad_source() {
+        let code = plugin_install_command("/nonexistent", false, None);
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn uninstall_command_succeeds() {
+        let tmp = TempDir::new().unwrap();
+        let source = create_test_plugin(tmp.path(), "test-plugin");
+        let install_dir = tmp.path().join("installed");
+
+        plugin_install_command(
+            source.to_str().unwrap(),
+            false,
+            Some(install_dir.clone()),
+        );
+
+        let code = plugin_uninstall_command("test-plugin", Some(install_dir));
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn uninstall_command_fails_for_missing_plugin() {
+        let tmp = TempDir::new().unwrap();
+        let code = plugin_uninstall_command(
+            "ghost-plugin",
+            Some(tmp.path().join("plugins")),
+        );
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn list_command_returns_zero() {
+        let tmp = TempDir::new().unwrap();
+        let code = plugin_list_command(Some(tmp.path().join("plugins")));
+        assert_eq!(code, 0);
+    }
+}

--- a/crates/amplihack-utils/src/plugin_manager.rs
+++ b/crates/amplihack-utils/src/plugin_manager.rs
@@ -1,0 +1,358 @@
+//! Plugin manager: install, uninstall, list, and path resolution.
+//!
+//! Ported from `amplihack/plugin_manager/manager.py`.
+//!
+//! The [`PluginManager`] struct manages the full plugin lifecycle:
+//!
+//! - **Install** from a git URL or local directory path.
+//! - **Uninstall** by plugin name.
+//! - **List** all installed plugins.
+//! - **Resolve paths** in manifest dictionaries (with path-traversal detection).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::plugin_manifest::{is_valid_plugin_name, validate_manifest};
+use crate::plugin_manager_paths::{
+    copy_dir_recursive, extract_plugin_name_from_url, home_dir, resolve_paths_inner,
+    validate_path_safety,
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors produced by plugin manager operations.
+#[derive(Debug, Error)]
+pub enum PluginManagerError {
+    /// An I/O error occurred during plugin operations.
+    #[error("plugin I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization / deserialization failure.
+    #[error("plugin JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// A git clone command failed.
+    #[error("git clone failed (exit {code:?}): {stderr}")]
+    GitCloneFailed {
+        /// Exit code from git, if available.
+        code: Option<i32>,
+        /// Captured stderr.
+        stderr: String,
+    },
+
+    /// Path traversal was detected.
+    #[error("path traversal detected: {path} escapes {base}")]
+    PathTraversal {
+        /// The offending path.
+        path: String,
+        /// The base directory.
+        base: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Result of a plugin installation attempt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstallResult {
+    /// Whether installation succeeded.
+    pub success: bool,
+    /// Name of the plugin (extracted from URL or directory).
+    pub plugin_name: String,
+    /// Where the plugin was installed (empty path on failure).
+    pub installed_path: PathBuf,
+    /// Human-readable status message.
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
+// PluginManager
+// ---------------------------------------------------------------------------
+
+/// Manages plugin installation, validation, and removal.
+///
+/// # Example
+///
+/// ```no_run
+/// use amplihack_utils::plugin_manager::PluginManager;
+/// use std::path::PathBuf;
+///
+/// let mgr = PluginManager::new(Some(PathBuf::from("/my/plugins")));
+/// let result = mgr.install("/path/to/local-plugin", false);
+/// println!("{}", result.message);
+/// ```
+pub struct PluginManager {
+    plugin_root: PathBuf,
+    settings_path: PathBuf,
+}
+
+impl PluginManager {
+    /// Create a new `PluginManager`.
+    ///
+    /// If `plugin_root` is `None`, defaults to `~/.amplihack/.claude/plugins`.
+    pub fn new(plugin_root: Option<PathBuf>) -> Self {
+        let home = home_dir();
+        let plugin_root = plugin_root
+            .unwrap_or_else(|| home.join(".amplihack").join(".claude").join("plugins"));
+        let settings_path = home
+            .join(".config")
+            .join("claude-code")
+            .join("plugins.json");
+        Self { plugin_root, settings_path }
+    }
+
+    /// Create a manager with explicit paths (useful for testing).
+    pub fn with_paths(plugin_root: PathBuf, settings_path: PathBuf) -> Self {
+        Self { plugin_root, settings_path }
+    }
+
+    /// Root directory for installed plugins.
+    pub fn plugin_root(&self) -> &Path {
+        &self.plugin_root
+    }
+
+    /// Install a plugin from a git URL or local directory path.
+    ///
+    /// Git URLs start with `http://`, `https://`, or `git@`.
+    /// Set `force` to overwrite an existing installation.
+    pub fn install(&self, source: &str, force: bool) -> InstallResult {
+        if source.is_empty() {
+            return fail_result("", "Empty source provided");
+        }
+
+        let is_git = source.starts_with("http://")
+            || source.starts_with("https://")
+            || source.starts_with("git@");
+
+        if is_git {
+            self.install_from_git(source, force)
+        } else {
+            self.install_from_local(source, force)
+        }
+    }
+
+    fn install_from_git(&self, url: &str, force: bool) -> InstallResult {
+        let plugin_name = extract_plugin_name_from_url(url);
+
+        if !is_valid_plugin_name(&plugin_name) {
+            return fail_result(&plugin_name, "Invalid plugin name from URL");
+        }
+
+        let staging_root = self.plugin_root.join(".staging");
+        if let Err(e) = std::fs::create_dir_all(&staging_root) {
+            return fail_result(&plugin_name, &format!("Failed to create staging dir: {e}"));
+        }
+
+        let clone_target = staging_root.join(&plugin_name);
+        if clone_target.exists() {
+            let _ = std::fs::remove_dir_all(&clone_target);
+        }
+
+        let git_result = std::process::Command::new("git")
+            .args(["clone", url, &clone_target.to_string_lossy()])
+            .output();
+
+        let output = match git_result {
+            Ok(o) => o,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&staging_root);
+                return fail_result(&plugin_name, &format!("Failed to run git clone: {e}"));
+            }
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let _ = std::fs::remove_dir_all(&staging_root);
+            return fail_result(&plugin_name, &format!("Git clone failed: {stderr}"));
+        }
+
+        let result = self.finalize_install(&clone_target, &plugin_name, force);
+        let _ = std::fs::remove_dir_all(&staging_root);
+        result
+    }
+
+    fn install_from_local(&self, source: &str, force: bool) -> InstallResult {
+        let source_path = PathBuf::from(source);
+
+        if !source_path.is_dir() {
+            return fail_result("", &format!("Source must be a directory: {source}"));
+        }
+
+        let plugin_name = source_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        self.finalize_install(&source_path, &plugin_name, force)
+    }
+
+    fn finalize_install(
+        &self,
+        source_path: &Path,
+        plugin_name: &str,
+        force: bool,
+    ) -> InstallResult {
+        let manifest_path = source_path.join(".claude-plugin").join("plugin.json");
+
+        if !validate_path_safety(&manifest_path, source_path) {
+            return fail_result(plugin_name, "Manifest path traversal detected");
+        }
+
+        let validation = validate_manifest(&manifest_path);
+        if !validation.valid {
+            let msg = format!("Invalid manifest: {}", validation.errors.join(", "));
+            return fail_result(plugin_name, &msg);
+        }
+
+        let target_path = self.plugin_root.join(plugin_name);
+
+        if target_path.exists() && !force {
+            return InstallResult {
+                success: false,
+                plugin_name: plugin_name.to_string(),
+                installed_path: target_path,
+                message: format!(
+                    "Plugin already installed: {plugin_name} (use force=true to overwrite)"
+                ),
+            };
+        }
+
+        if target_path.exists()
+            && let Err(e) = std::fs::remove_dir_all(&target_path)
+        {
+            let msg = format!("Failed to remove existing plugin: {e}");
+            return fail_result(plugin_name, &msg);
+        }
+
+        if let Err(e) = std::fs::create_dir_all(&self.plugin_root) {
+            return fail_result(plugin_name, &format!("Failed to create plugin dir: {e}"));
+        }
+
+        if let Err(e) = copy_dir_recursive(source_path, &target_path) {
+            return fail_result(plugin_name, &format!("Failed to copy plugin files: {e}"));
+        }
+
+        if let Err(e) = self.register_plugin(plugin_name) {
+            return InstallResult {
+                success: false,
+                plugin_name: plugin_name.to_string(),
+                installed_path: target_path,
+                message: format!("Plugin copied but registration failed: {e}"),
+            };
+        }
+
+        InstallResult {
+            success: true,
+            plugin_name: plugin_name.to_string(),
+            installed_path: target_path,
+            message: format!("Plugin installed successfully: {plugin_name}"),
+        }
+    }
+
+    /// Remove an installed plugin by name.
+    ///
+    /// Returns `true` if the plugin was found and removed.
+    pub fn uninstall(&self, plugin_name: &str) -> bool {
+        let plugin_path = self.plugin_root.join(plugin_name);
+        if !plugin_path.exists() {
+            return false;
+        }
+        std::fs::remove_dir_all(&plugin_path).is_ok()
+    }
+
+    /// List all installed plugin names.
+    ///
+    /// Scans the plugin root for directories containing a manifest.
+    pub fn list_installed(&self) -> Vec<String> {
+        let mut plugins = Vec::new();
+        let entries = match std::fs::read_dir(&self.plugin_root) {
+            Ok(e) => e,
+            Err(_) => return plugins,
+        };
+        for entry in entries.flatten() {
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let manifest = entry.path().join(".claude-plugin").join("plugin.json");
+            if manifest.exists()
+                && let Some(name) = entry.file_name().to_str()
+            {
+                plugins.push(name.to_string());
+            }
+        }
+        plugins.sort();
+        plugins
+    }
+
+    /// Resolve relative paths in a manifest JSON map to absolute paths.
+    ///
+    /// Fields listed in [`PATH_FIELDS`](crate::plugin_manifest::PATH_FIELDS)
+    /// are resolved relative to `plugin_path` (or the plugin root if `None`).
+    pub fn resolve_paths(
+        &self,
+        manifest: &serde_json::Map<String, serde_json::Value>,
+        plugin_path: Option<&Path>,
+    ) -> Result<serde_json::Map<String, serde_json::Value>, PluginManagerError> {
+        let base = plugin_path.unwrap_or(&self.plugin_root);
+        resolve_paths_inner(manifest, base)
+    }
+
+    /// Register plugin name in the Claude Code settings file.
+    fn register_plugin(&self, plugin_name: &str) -> Result<(), PluginManagerError> {
+        if let Some(parent) = self.settings_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut settings: serde_json::Value = if self.settings_path.exists() {
+            let text = std::fs::read_to_string(&self.settings_path)?;
+            if text.trim().is_empty() {
+                serde_json::json!({})
+            } else {
+                serde_json::from_str(&text)?
+            }
+        } else {
+            serde_json::json!({})
+        };
+
+        let enabled = settings.as_object_mut().and_then(|o| {
+            o.entry("enabledPlugins")
+                .or_insert(serde_json::json!([]))
+                .as_array_mut()
+        });
+
+        if let Some(arr) = enabled {
+            let name_val = serde_json::Value::String(plugin_name.to_string());
+            if !arr.contains(&name_val) {
+                arr.push(name_val);
+            }
+        }
+
+        let text = serde_json::to_string_pretty(&settings)?;
+        std::fs::write(&self.settings_path, text)?;
+        Ok(())
+    }
+}
+
+/// Helper to construct a failure `InstallResult`.
+fn fail_result(plugin_name: &str, message: &str) -> InstallResult {
+    InstallResult {
+        success: false,
+        plugin_name: plugin_name.to_string(),
+        installed_path: PathBuf::new(),
+        message: message.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[path = "tests/plugin_manager_tests.rs"]
+mod tests;

--- a/crates/amplihack-utils/src/plugin_manager_paths.rs
+++ b/crates/amplihack-utils/src/plugin_manager_paths.rs
@@ -1,0 +1,149 @@
+//! Internal helpers for plugin manager path operations.
+//!
+//! Extracted from `plugin_manager` to keep modules under the 400-line limit.
+
+use std::path::{Path, PathBuf};
+
+use crate::plugin_manifest::PATH_FIELDS;
+use crate::plugin_manager::PluginManagerError;
+
+/// Validate that `path` stays under `base` after resolution (no traversal).
+pub fn validate_path_safety(path: &Path, base: &Path) -> bool {
+    let resolved_base = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
+
+    let resolved = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            let mut stack = Vec::new();
+            for component in path.components() {
+                match component {
+                    std::path::Component::ParentDir => {
+                        stack.pop();
+                    }
+                    std::path::Component::CurDir => {}
+                    std::path::Component::RootDir => {
+                        stack.clear();
+                        stack.push(std::ffi::OsStr::new("/"));
+                    }
+                    std::path::Component::Normal(c) => {
+                        stack.push(c);
+                    }
+                    std::path::Component::Prefix(p) => {
+                        stack.clear();
+                        stack.push(p.as_os_str());
+                    }
+                }
+            }
+            stack.iter().collect::<PathBuf>()
+        }
+    };
+
+    resolved.starts_with(&resolved_base)
+}
+
+/// Extract plugin name from a git URL.
+///
+/// Takes the last path segment and strips a trailing `.git` suffix.
+pub(crate) fn extract_plugin_name_from_url(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    let name = trimmed.rsplit('/').next().unwrap_or(trimmed);
+    name.strip_suffix(".git").unwrap_or(name).to_string()
+}
+
+/// Recursively copy a directory tree.
+pub(crate) fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolve paths in a JSON map, recursing into nested objects.
+pub(crate) fn resolve_paths_inner(
+    map: &serde_json::Map<String, serde_json::Value>,
+    base: &Path,
+) -> Result<serde_json::Map<String, serde_json::Value>, PluginManagerError> {
+    let mut resolved = serde_json::Map::new();
+
+    for (key, value) in map {
+        let is_path_field = PATH_FIELDS.contains(&key.as_str());
+
+        let new_val = if is_path_field {
+            match value {
+                serde_json::Value::String(s) => {
+                    let p = Path::new(s);
+                    if p.is_absolute() {
+                        value.clone()
+                    } else {
+                        let abs = base.join(p);
+                        if !validate_path_safety(&abs, base) {
+                            return Err(PluginManagerError::PathTraversal {
+                                path: abs.display().to_string(),
+                                base: base.display().to_string(),
+                            });
+                        }
+                        serde_json::Value::String(abs.to_string_lossy().to_string())
+                    }
+                }
+                serde_json::Value::Array(arr) => {
+                    let mut items = Vec::new();
+                    for item in arr {
+                        if let Some(s) = item.as_str() {
+                            let p = Path::new(s);
+                            if p.is_absolute() {
+                                items.push(serde_json::Value::String(s.to_string()));
+                            } else {
+                                let abs = base.join(p);
+                                if !validate_path_safety(&abs, base) {
+                                    return Err(PluginManagerError::PathTraversal {
+                                        path: abs.display().to_string(),
+                                        base: base.display().to_string(),
+                                    });
+                                }
+                                items.push(serde_json::Value::String(
+                                    abs.to_string_lossy().to_string(),
+                                ));
+                            }
+                        } else {
+                            items.push(item.clone());
+                        }
+                    }
+                    serde_json::Value::Array(items)
+                }
+                _ => value.clone(),
+            }
+        } else if let serde_json::Value::Object(nested) = value {
+            serde_json::Value::Object(resolve_paths_inner(nested, base)?)
+        } else {
+            value.clone()
+        };
+
+        resolved.insert(key.clone(), new_val);
+    }
+
+    Ok(resolved)
+}
+
+/// Resolve the user's home directory.
+pub(crate) fn home_dir() -> PathBuf {
+    #[cfg(unix)]
+    {
+        std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/"))
+    }
+    #[cfg(not(unix))]
+    {
+        std::env::var_os("USERPROFILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("C:\\"))
+    }
+}

--- a/crates/amplihack-utils/src/plugin_manifest.rs
+++ b/crates/amplihack-utils/src/plugin_manifest.rs
@@ -1,0 +1,354 @@
+//! Plugin manifest types and validation.
+//!
+//! Ported from `amplihack/plugin_manager/manager.py` (validation subset).
+//!
+//! Provides the [`PluginManifest`] type (deserialized from `plugin.json`)
+//! and [`validate_manifest`] for structural + semantic checks.
+
+use std::path::Path;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors produced by manifest operations.
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    /// An I/O error occurred reading the manifest file.
+    #[error("manifest I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The manifest file contains invalid JSON.
+    #[error("invalid JSON in manifest: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Regex patterns
+// ---------------------------------------------------------------------------
+
+/// Semantic version pattern: `major.minor.patch`.
+static VERSION_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\d+\.\d+\.\d+$").expect("VERSION_PATTERN regex is valid"));
+
+/// Plugin name pattern: lowercase letters, digits, hyphens.
+static NAME_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z0-9-]+$").expect("NAME_PATTERN regex is valid"));
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Required fields in a plugin manifest.
+const REQUIRED_FIELDS: &[&str] = &["name", "version", "entry_point"];
+
+/// Recommended (but optional) fields — triggers warnings when absent.
+const RECOMMENDED_FIELDS: &[&str] = &["description", "author"];
+
+/// Fields whose values should be resolved to absolute paths.
+pub const PATH_FIELDS: &[&str] = &["entry_point", "files", "cwd", "script", "path"];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// A deserialized `plugin.json` manifest.
+///
+/// Uses a loose schema so validation can produce detailed error messages
+/// rather than opaque deserialization failures.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PluginManifest {
+    /// Plugin name (lowercase, digits, hyphens).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Plugin version (semver `major.minor.patch`).
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Entry point file relative to the plugin root.
+    #[serde(default)]
+    pub entry_point: Option<String>,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Plugin author.
+    #[serde(default)]
+    pub author: Option<String>,
+    /// Additional files referenced by the plugin.
+    #[serde(default)]
+    pub files: Option<Vec<String>>,
+    /// Working directory override.
+    #[serde(default)]
+    pub cwd: Option<String>,
+    /// Script path.
+    #[serde(default)]
+    pub script: Option<String>,
+    /// Generic path field.
+    #[serde(default)]
+    pub path: Option<String>,
+    /// All other fields captured as a map.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Result of manifest validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationResult {
+    /// Whether the manifest passed all required checks.
+    pub valid: bool,
+    /// Hard errors that prevent installation.
+    pub errors: Vec<String>,
+    /// Non-fatal warnings (e.g. missing recommended fields).
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Load and deserialize a manifest file.
+pub fn load_manifest(manifest_path: &Path) -> Result<PluginManifest, ManifestError> {
+    let text = std::fs::read_to_string(manifest_path)?;
+    let manifest: PluginManifest = serde_json::from_str(&text)?;
+    Ok(manifest)
+}
+
+/// Validate a plugin manifest file on disk.
+///
+/// # Example
+///
+/// ```no_run
+/// use amplihack_utils::plugin_manifest::validate_manifest;
+/// use std::path::Path;
+///
+/// let result = validate_manifest(Path::new("/path/to/plugin.json"));
+/// if !result.valid {
+///     for err in &result.errors {
+///         eprintln!("  error: {err}");
+///     }
+/// }
+/// ```
+pub fn validate_manifest(manifest_path: &Path) -> ValidationResult {
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    if !manifest_path.exists() {
+        errors.push(format!("Manifest file not found: {}", manifest_path.display()));
+        return ValidationResult { valid: false, errors, warnings };
+    }
+
+    let text = match std::fs::read_to_string(manifest_path) {
+        Ok(t) => t,
+        Err(e) => {
+            errors.push(format!("Failed to read manifest: {e}"));
+            return ValidationResult { valid: false, errors, warnings };
+        }
+    };
+
+    let raw: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            errors.push(format!("Invalid JSON in manifest: {e}"));
+            return ValidationResult { valid: false, errors, warnings };
+        }
+    };
+
+    let obj = match raw.as_object() {
+        Some(o) => o,
+        None => {
+            errors.push("Manifest must be a JSON object".to_string());
+            return ValidationResult { valid: false, errors, warnings };
+        }
+    };
+
+    for &field in REQUIRED_FIELDS {
+        if !obj.contains_key(field) {
+            errors.push(format!("Missing required field: {field}"));
+        }
+    }
+
+    if let Some(ver) = obj.get("version").and_then(|v| v.as_str())
+        && !VERSION_PATTERN.is_match(ver)
+    {
+        errors.push(format!(
+            "Invalid version format: {ver} (expected semver like 1.0.0)"
+        ));
+    }
+
+    if let Some(name) = obj.get("name").and_then(|v| v.as_str())
+        && !NAME_PATTERN.is_match(name)
+    {
+        errors.push(format!(
+            "Invalid name format: {name} (must be lowercase letters, numbers, hyphens only)"
+        ));
+    }
+
+    for &field in RECOMMENDED_FIELDS {
+        if !obj.contains_key(field) {
+            warnings.push(format!("Missing recommended field: {field}"));
+        }
+    }
+
+    ValidationResult { valid: errors.is_empty(), errors, warnings }
+}
+
+/// Check whether a plugin name matches the required pattern.
+pub fn is_valid_plugin_name(name: &str) -> bool {
+    NAME_PATTERN.is_match(name)
+}
+
+/// Check whether a version string matches semver `major.minor.patch`.
+pub fn is_valid_version(version: &str) -> bool {
+    VERSION_PATTERN.is_match(version)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_manifest(dir: &Path, content: &str) -> std::path::PathBuf {
+        let path = dir.join("plugin.json");
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn valid_manifest() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"{"name":"my-plugin","version":"1.0.0","entry_point":"main.py"}"#,
+        );
+        let result = validate_manifest(&path);
+        assert!(result.valid);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn missing_required_fields() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(tmp.path(), r#"{"description":"test"}"#);
+        let result = validate_manifest(&path);
+        assert!(!result.valid);
+        assert_eq!(result.errors.len(), 3);
+    }
+
+    #[test]
+    fn invalid_version_format() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"{"name":"ok","version":"v1.0","entry_point":"main.py"}"#,
+        );
+        let result = validate_manifest(&path);
+        assert!(!result.valid);
+        assert!(result.errors.iter().any(|e| e.contains("Invalid version")));
+    }
+
+    #[test]
+    fn invalid_name_format() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"{"name":"My Plugin!","version":"1.0.0","entry_point":"main.py"}"#,
+        );
+        let result = validate_manifest(&path);
+        assert!(!result.valid);
+        assert!(result.errors.iter().any(|e| e.contains("Invalid name")));
+    }
+
+    #[test]
+    fn recommended_fields_produce_warnings() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"{"name":"ok","version":"1.0.0","entry_point":"main.py"}"#,
+        );
+        let result = validate_manifest(&path);
+        assert!(result.valid);
+        assert_eq!(result.warnings.len(), 2);
+    }
+
+    #[test]
+    fn nonexistent_file() {
+        let result = validate_manifest(Path::new("/nonexistent/plugin.json"));
+        assert!(!result.valid);
+        assert!(result.errors[0].contains("not found"));
+    }
+
+    #[test]
+    fn invalid_json() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(tmp.path(), "not json {{{");
+        let result = validate_manifest(&path);
+        assert!(!result.valid);
+        assert!(result.errors[0].contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn manifest_not_an_object() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(tmp.path(), r#"["array","not","object"]"#);
+        let result = validate_manifest(&path);
+        assert!(!result.valid);
+        assert!(result.errors[0].contains("JSON object"));
+    }
+
+    #[test]
+    fn name_validation_patterns() {
+        assert!(is_valid_plugin_name("my-plugin"));
+        assert!(is_valid_plugin_name("plugin123"));
+        assert!(is_valid_plugin_name("a"));
+        assert!(!is_valid_plugin_name("My Plugin"));
+        assert!(!is_valid_plugin_name("plugin_underscore"));
+        assert!(!is_valid_plugin_name(""));
+    }
+
+    #[test]
+    fn version_validation_patterns() {
+        assert!(is_valid_version("1.0.0"));
+        assert!(is_valid_version("0.0.1"));
+        assert!(is_valid_version("99.99.99"));
+        assert!(!is_valid_version("v1.0.0"));
+        assert!(!is_valid_version("1.0"));
+        assert!(!is_valid_version("1"));
+        assert!(!is_valid_version(""));
+    }
+
+    #[test]
+    fn load_manifest_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"{"name":"test","version":"2.0.0","entry_point":"run.sh","description":"A test","author":"dev"}"#,
+        );
+        let m = load_manifest(&path).unwrap();
+        assert_eq!(m.name.as_deref(), Some("test"));
+        assert_eq!(m.version.as_deref(), Some("2.0.0"));
+        assert_eq!(m.entry_point.as_deref(), Some("run.sh"));
+        assert_eq!(m.description.as_deref(), Some("A test"));
+        assert_eq!(m.author.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn full_manifest_with_extra_fields() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"{"name":"x","version":"1.0.0","entry_point":"e.py","extra_field":true}"#,
+        );
+        let result = validate_manifest(&path);
+        assert!(result.valid);
+        let m = load_manifest(&path).unwrap();
+        assert!(m.extra.contains_key("extra_field"));
+    }
+}

--- a/crates/amplihack-utils/src/tests/plugin_manager_tests.rs
+++ b/crates/amplihack-utils/src/tests/plugin_manager_tests.rs
@@ -1,0 +1,300 @@
+use super::*;
+use crate::plugin_manager_paths::{extract_plugin_name_from_url, validate_path_safety};
+use tempfile::TempDir;
+
+/// Create a minimal valid plugin directory.
+fn create_plugin_dir(root: &Path, name: &str) -> PathBuf {
+    let dir = root.join(name);
+    let manifest_dir = dir.join(".claude-plugin");
+    std::fs::create_dir_all(&manifest_dir).unwrap();
+    std::fs::write(
+        manifest_dir.join("plugin.json"),
+        r#"{"name":"test-plugin","version":"1.0.0","entry_point":"main.py"}"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("main.py"), "# entry point").unwrap();
+    dir
+}
+
+#[test]
+fn install_from_local_path() {
+    let tmp = TempDir::new().unwrap();
+    let source = create_plugin_dir(tmp.path(), "test-plugin");
+    let install_root = tmp.path().join("installed");
+    let settings = tmp.path().join("settings.json");
+
+    let mgr = PluginManager::with_paths(install_root.clone(), settings);
+    let result = mgr.install(source.to_str().unwrap(), false);
+
+    assert!(result.success, "install failed: {}", result.message);
+    assert_eq!(result.plugin_name, "test-plugin");
+    assert!(install_root.join("test-plugin").exists());
+    assert!(install_root.join("test-plugin").join("main.py").exists());
+}
+
+#[test]
+fn install_rejects_nonexistent_source() {
+    let tmp = TempDir::new().unwrap();
+    let mgr = PluginManager::with_paths(
+        tmp.path().join("plugins"),
+        tmp.path().join("settings.json"),
+    );
+    let result = mgr.install("/nonexistent/path", false);
+    assert!(!result.success);
+    assert!(result.message.contains("must be a directory"));
+}
+
+#[test]
+fn install_rejects_empty_source() {
+    let tmp = TempDir::new().unwrap();
+    let mgr = PluginManager::with_paths(
+        tmp.path().join("plugins"),
+        tmp.path().join("settings.json"),
+    );
+    let result = mgr.install("", false);
+    assert!(!result.success);
+    assert!(result.message.contains("Empty source"));
+}
+
+#[test]
+fn install_rejects_duplicate_without_force() {
+    let tmp = TempDir::new().unwrap();
+    let source = create_plugin_dir(tmp.path(), "test-plugin");
+    let install_root = tmp.path().join("installed");
+    let settings = tmp.path().join("settings.json");
+
+    let mgr = PluginManager::with_paths(install_root, settings);
+    let r1 = mgr.install(source.to_str().unwrap(), false);
+    assert!(r1.success);
+
+    let r2 = mgr.install(source.to_str().unwrap(), false);
+    assert!(!r2.success);
+    assert!(r2.message.contains("already installed"));
+}
+
+#[test]
+fn install_force_overwrites_existing() {
+    let tmp = TempDir::new().unwrap();
+    let source = create_plugin_dir(tmp.path(), "test-plugin");
+    let install_root = tmp.path().join("installed");
+    let settings = tmp.path().join("settings.json");
+
+    let mgr = PluginManager::with_paths(install_root, settings);
+    let r1 = mgr.install(source.to_str().unwrap(), false);
+    assert!(r1.success);
+
+    let r2 = mgr.install(source.to_str().unwrap(), true);
+    assert!(r2.success, "force install failed: {}", r2.message);
+}
+
+#[test]
+fn uninstall_removes_plugin() {
+    let tmp = TempDir::new().unwrap();
+    let source = create_plugin_dir(tmp.path(), "test-plugin");
+    let install_root = tmp.path().join("installed");
+    let settings = tmp.path().join("settings.json");
+
+    let mgr = PluginManager::with_paths(install_root.clone(), settings);
+    mgr.install(source.to_str().unwrap(), false);
+
+    assert!(mgr.uninstall("test-plugin"));
+    assert!(!install_root.join("test-plugin").exists());
+}
+
+#[test]
+fn uninstall_returns_false_for_missing_plugin() {
+    let tmp = TempDir::new().unwrap();
+    let mgr = PluginManager::with_paths(
+        tmp.path().join("plugins"),
+        tmp.path().join("settings.json"),
+    );
+    assert!(!mgr.uninstall("no-such-plugin"));
+}
+
+#[test]
+fn list_installed_finds_valid_plugins() {
+    let tmp = TempDir::new().unwrap();
+    let install_root = tmp.path().join("plugins");
+
+    create_plugin_dir(&install_root, "alpha-plugin");
+    create_plugin_dir(&install_root, "beta-plugin");
+
+    std::fs::create_dir_all(install_root.join("not-a-plugin")).unwrap();
+
+    let mgr =
+        PluginManager::with_paths(install_root, tmp.path().join("settings.json"));
+    let list = mgr.list_installed();
+    assert_eq!(list, vec!["alpha-plugin", "beta-plugin"]);
+}
+
+#[test]
+fn list_installed_empty_when_no_plugins() {
+    let tmp = TempDir::new().unwrap();
+    let mgr = PluginManager::with_paths(
+        tmp.path().join("plugins"),
+        tmp.path().join("settings.json"),
+    );
+    assert!(mgr.list_installed().is_empty());
+}
+
+#[test]
+fn resolve_paths_makes_relative_absolute() {
+    let tmp = TempDir::new().unwrap();
+    let base = tmp.path().join("plugin");
+    std::fs::create_dir_all(&base).unwrap();
+
+    let mgr = PluginManager::with_paths(
+        tmp.path().join("plugins"),
+        tmp.path().join("settings.json"),
+    );
+
+    let mut manifest = serde_json::Map::new();
+    manifest.insert(
+        "entry_point".to_string(),
+        serde_json::Value::String("src/main.py".to_string()),
+    );
+    manifest.insert(
+        "name".to_string(),
+        serde_json::Value::String("my-plugin".to_string()),
+    );
+
+    let resolved = mgr.resolve_paths(&manifest, Some(&base)).unwrap();
+    let ep = resolved["entry_point"].as_str().unwrap();
+    assert!(ep.starts_with(base.to_str().unwrap()));
+    assert!(ep.ends_with("src/main.py"));
+    assert_eq!(resolved["name"].as_str().unwrap(), "my-plugin");
+}
+
+#[test]
+fn resolve_paths_preserves_absolute() {
+    let tmp = TempDir::new().unwrap();
+    let mgr = PluginManager::with_paths(
+        tmp.path().join("plugins"),
+        tmp.path().join("settings.json"),
+    );
+
+    let mut manifest = serde_json::Map::new();
+    manifest.insert(
+        "entry_point".to_string(),
+        serde_json::Value::String("/absolute/path/main.py".to_string()),
+    );
+
+    let resolved = mgr.resolve_paths(&manifest, None).unwrap();
+    assert_eq!(
+        resolved["entry_point"].as_str().unwrap(),
+        "/absolute/path/main.py"
+    );
+}
+
+#[test]
+fn resolve_paths_handles_arrays() {
+    let tmp = TempDir::new().unwrap();
+    let base = tmp.path().join("plugin");
+    std::fs::create_dir_all(&base).unwrap();
+
+    let mgr = PluginManager::with_paths(
+        tmp.path().join("plugins"),
+        tmp.path().join("settings.json"),
+    );
+
+    let mut manifest = serde_json::Map::new();
+    manifest.insert(
+        "files".to_string(),
+        serde_json::json!(["src/a.py", "/abs/b.py"]),
+    );
+
+    let resolved = mgr.resolve_paths(&manifest, Some(&base)).unwrap();
+    let files = resolved["files"].as_array().unwrap();
+    assert!(files[0].as_str().unwrap().ends_with("src/a.py"));
+    assert_eq!(files[1].as_str().unwrap(), "/abs/b.py");
+}
+
+#[test]
+fn resolve_paths_recurses_into_nested_objects() {
+    let tmp = TempDir::new().unwrap();
+    let base = tmp.path().join("plugin");
+    std::fs::create_dir_all(&base).unwrap();
+
+    let mgr = PluginManager::with_paths(
+        tmp.path().join("plugins"),
+        tmp.path().join("settings.json"),
+    );
+
+    let mut manifest = serde_json::Map::new();
+    let mut nested = serde_json::Map::new();
+    nested.insert(
+        "script".to_string(),
+        serde_json::Value::String("run.sh".to_string()),
+    );
+    manifest.insert("hooks".to_string(), serde_json::Value::Object(nested));
+
+    let resolved = mgr.resolve_paths(&manifest, Some(&base)).unwrap();
+    let script = resolved["hooks"]["script"].as_str().unwrap();
+    assert!(script.starts_with(base.to_str().unwrap()));
+}
+
+#[test]
+fn extract_name_from_git_url() {
+    assert_eq!(
+        extract_plugin_name_from_url("https://github.com/org/my-plugin.git"),
+        "my-plugin"
+    );
+    assert_eq!(
+        extract_plugin_name_from_url("https://github.com/org/my-plugin"),
+        "my-plugin"
+    );
+    assert_eq!(
+        extract_plugin_name_from_url("git@github.com:org/cool-plugin.git"),
+        "cool-plugin"
+    );
+    assert_eq!(
+        extract_plugin_name_from_url("https://github.com/org/plugin/"),
+        "plugin"
+    );
+}
+
+#[test]
+fn validate_path_safety_accepts_children() {
+    let tmp = TempDir::new().unwrap();
+    let base = tmp.path();
+    let child = base.join("subdir").join("file.txt");
+    assert!(validate_path_safety(&child, base));
+}
+
+#[test]
+fn validate_path_safety_rejects_traversal() {
+    let tmp = TempDir::new().unwrap();
+    let base = tmp.path().join("plugin");
+    std::fs::create_dir_all(&base).unwrap();
+    let escaped = base.join("..").join("..").join("etc").join("passwd");
+    assert!(!validate_path_safety(&escaped, &base));
+}
+
+#[test]
+fn register_plugin_creates_settings_file() {
+    let tmp = TempDir::new().unwrap();
+    let settings = tmp.path().join("config").join("plugins.json");
+    let mgr = PluginManager::with_paths(tmp.path().join("plugins"), settings.clone());
+
+    mgr.register_plugin("my-plugin").unwrap();
+
+    let text = std::fs::read_to_string(&settings).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let arr = val["enabledPlugins"].as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0].as_str().unwrap(), "my-plugin");
+}
+
+#[test]
+fn register_plugin_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let settings = tmp.path().join("plugins.json");
+    let mgr = PluginManager::with_paths(tmp.path().join("plugins"), settings.clone());
+
+    mgr.register_plugin("x").unwrap();
+    mgr.register_plugin("x").unwrap();
+
+    let text = std::fs::read_to_string(&settings).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(val["enabledPlugins"].as_array().unwrap().len(), 1);
+}


### PR DESCRIPTION
## Summary

Ports the plugin management system from Python to Rust in the `amplihack-utils` crate.

### New modules

| Module | Lines | Description |
|--------|-------|-------------|
| `plugin_manifest` | 354 | Manifest types (`PluginManifest`), validation (`validate_manifest`), name/version checking |
| `plugin_manager` | 358 | `PluginManager` struct: install (git/local), uninstall, list, resolve_paths |
| `plugin_manager_paths` | 149 | Extracted path helpers: traversal detection, recursive copy, path resolution |
| `plugin_cli` | 192 | CLI wrappers: install, uninstall, verify, list commands with exit codes |

### Ported from
- `amplihack/plugin_manager/manager.py` (~410 lines)
- `amplihack/plugin_cli/cli_handlers.py` (~97 lines)
- `amplihack/plugin_cli/parser_setup.py` (~75 lines)

### Quality checklist
- [x] All modules under 400 lines
- [x] All public items documented
- [x] No `unwrap()` in library code
- [x] 35 tests total (12 manifest + 18 manager + 5 CLI)
- [x] Clippy clean: `cargo clippy -p amplihack-utils -- -D warnings`
- [x] All tests pass: `cargo test -p amplihack-utils` (258 total)

### Key design decisions
- Split `plugin_manager` into core + `plugin_manager_paths` helper to stay under 400-line limit
- Manager tests in separate `tests/plugin_manager_tests.rs` following existing crate pattern
- `validate_path_safety` uses component-based normalization for non-existent paths
- `register_plugin` handles empty/missing settings files gracefully
- Git clone uses staging directory under plugin root for same-filesystem copy