### PR TITLE
fix: add same-path guard to copy_dir_recursive to prevent self-copy crash

### DIFF
--- a/crates/amplihack-cli/src/auto_stager.rs
+++ b/crates/amplihack-cli/src/auto_stager.rs
@@ -101,6 +101,19 @@ fn copy_claude_directory(source: &Path, dest: &Path) -> Result<()> {
 }
 
 fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<()> {
+    // Guard: skip copy when source and dest resolve to the same directory.
+    // Prevents infinite recursion / SameFileError (see issue #4296).
+    if let (Ok(canon_src), Ok(canon_dst)) = (source.canonicalize(), dest.canonicalize()) {
+        if canon_src == canon_dst {
+            tracing::warn!(
+                src = %source.display(),
+                dst = %dest.display(),
+                "skipping copy: source and destination are the same path"
+            );
+            return Ok(());
+        }
+    }
+
     fs::create_dir_all(dest).with_context(|| format!("failed to create {}", dest.display()))?;
     for entry in
         fs::read_dir(source).with_context(|| format!("failed to read {}", source.display()))?
@@ -194,5 +207,17 @@ mod tests {
                 .to_string_lossy()
                 .contains("___unsafe")
         );
+    }
+
+    #[test]
+    fn copy_dir_recursive_same_path_returns_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("data");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "content").unwrap();
+
+        copy_dir_recursive(&dir, &dir).unwrap();
+
+        assert_eq!(fs::read_to_string(dir.join("file.txt")).unwrap(), "content");
     }
 }

--- a/crates/amplihack-cli/src/commands/mode/migration.rs
+++ b/crates/amplihack-cli/src/commands/mode/migration.rs
@@ -177,6 +177,18 @@ fn confirm(input: &mut impl BufRead, out: &mut impl Write) -> Result<bool> {
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    // Guard: skip copy when source and dest resolve to the same directory (issue #4296).
+    if let (Ok(canon_src), Ok(canon_dst)) = (src.canonicalize(), dst.canonicalize()) {
+        if canon_src == canon_dst {
+            tracing::warn!(
+                src = %src.display(),
+                dst = %dst.display(),
+                "skipping copy: source and destination are the same path"
+            );
+            return Ok(());
+        }
+    }
+
     fs::create_dir_all(dst)
         .with_context(|| format!("failed to create directory {}", dst.display()))?;
 
@@ -203,4 +215,21 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copy_dir_recursive_same_path_returns_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("data");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "content").unwrap();
+
+        copy_dir_recursive(&dir, &dir).unwrap();
+
+        assert_eq!(fs::read_to_string(dir.join("file.txt")).unwrap(), "content");
+    }
 }

--- a/crates/amplihack-context/src/migration.rs
+++ b/crates/amplihack-context/src/migration.rs
@@ -151,6 +151,11 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     // Guard: skip copy when source and dest resolve to the same directory (issue #4296).
     if let (Ok(canon_src), Ok(canon_dst)) = (src.canonicalize(), dst.canonicalize()) {
         if canon_src == canon_dst {
+            tracing::warn!(
+                src = %src.display(),
+                dst = %dst.display(),
+                "skipping copy: source and destination are the same path"
+            );
             return Ok(());
         }
     }

--- a/crates/amplihack-context/src/migration.rs
+++ b/crates/amplihack-context/src/migration.rs
@@ -148,6 +148,13 @@ fn dirs_path() -> Option<PathBuf> {
 
 /// Recursively copy a directory tree from `src` to `dst`.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    // Guard: skip copy when source and dest resolve to the same directory (issue #4296).
+    if let (Ok(canon_src), Ok(canon_dst)) = (src.canonicalize(), dst.canonicalize()) {
+        if canon_src == canon_dst {
+            return Ok(());
+        }
+    }
+
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
@@ -239,5 +246,17 @@ mod tests {
         assert!(!info.can_migrate_to_local); // local already exists
         assert!(info.local_path.is_some());
         assert!(info.plugin_path.is_some());
+    }
+
+    #[test]
+    fn copy_dir_recursive_same_path_returns_ok() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("data");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "content").unwrap();
+
+        copy_dir_recursive(&dir, &dir).unwrap();
+
+        assert_eq!(fs::read_to_string(dir.join("file.txt")).unwrap(), "content");
     }
 }

--- a/crates/amplihack-launcher/src/auto_stager.rs
+++ b/crates/amplihack-launcher/src/auto_stager.rs
@@ -91,6 +91,18 @@ fn copy_claude_directory(source: &Path, dest: &Path) {
 
 /// Recursively copy a directory, skipping symlinks.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    // Guard: skip copy when source and dest resolve to the same directory (issue #4296).
+    if let (Ok(canon_src), Ok(canon_dst)) = (src.canonicalize(), dst.canonicalize()) {
+        if canon_src == canon_dst {
+            tracing::warn!(
+                src = %src.display(),
+                dst = %dst.display(),
+                "skipping copy: source and destination are the same path"
+            );
+            return Ok(());
+        }
+    }
+
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
@@ -191,5 +203,17 @@ mod tests {
             fs::read_to_string(dst.join("sub").join("b.txt")).unwrap(),
             "world"
         );
+    }
+
+    #[test]
+    fn copy_dir_recursive_same_path_returns_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("data");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "content").unwrap();
+
+        copy_dir_recursive(&dir, &dir).unwrap();
+
+        assert_eq!(fs::read_to_string(dir.join("file.txt")).unwrap(), "content");
     }
 }

--- a/docs/concepts/same-path-copy-guard.md
+++ b/docs/concepts/same-path-copy-guard.md
@@ -1,0 +1,97 @@
+# Same-Path Copy Guard
+
+Every `copy_dir_recursive` function in amplihack-rs includes a same-path
+guard that prevents self-copy when source and destination resolve to the
+same filesystem path.
+
+## Problem
+
+When `AMPLIHACK_HOME` points at the source checkout itself—or when a
+symlink causes two seemingly-different paths to converge—a recursive
+directory copy would either:
+
+1. Enter infinite recursion (copying into itself)
+2. Corrupt files by overwriting them mid-read
+3. Panic with an OS-level "same file" error
+
+This scenario occurs during local development (`AMPLIHACK_HOME=.`),
+symlinked installs, and CI pipelines that reuse the checkout directory
+as the install target.
+
+## Solution
+
+Before copying, each function canonicalizes both paths and compares them:
+
+```rust
+if let (Ok(canon_src), Ok(canon_dst)) = (source.canonicalize(), dest.canonicalize()) {
+    if canon_src == canon_dst {
+        tracing::warn!(
+            src = %source.display(),
+            dst = %dest.display(),
+            "skipping copy: source and destination are the same path"
+        );
+        return Ok(());
+    }
+}
+```
+
+### Design Decisions
+
+| Decision | Rationale |
+| --- | --- |
+| `canonicalize()` over raw path comparison | Resolves symlinks, `..`, and relative segments so aliased paths are detected |
+| `if let` with fallthrough | `canonicalize()` fails on broken symlinks or permission errors; falling through to the normal copy is the safe default |
+| `return Ok(())` (not `Err`) | Same-path is not an error—it means the content is already in place |
+| `tracing::warn!` | Visible in logs for debugging without halting execution |
+
+### TOCTOU Consideration
+
+There is a time-of-check-to-time-of-use (TOCTOU) window between the
+`canonicalize()` check and the actual `fs::copy` / `fs::create_dir_all`
+calls. This is accepted because:
+
+- Both paths are controlled by the same user/process
+- The guard protects against *configuration* mistakes, not adversarial races
+- Eliminating the window would require holding file locks across the entire
+  copy, which is disproportionate to the risk
+
+## Affected Functions
+
+| Crate | File | Function |
+| --- | --- | --- |
+| `amplihack-cli` | `src/auto_stager.rs` | `copy_dir_recursive` |
+| `amplihack-launcher` | `src/auto_stager.rs` | `copy_dir_recursive` |
+| `amplihack-context` | `src/migration.rs` | `copy_dir_recursive` |
+| `amplihack-cli` | `src/commands/mode/migration.rs` | `copy_dir_recursive` |
+
+Each function has an inline `#[test]` that creates a `tempdir`, and
+verifies the function returns `Ok(())` without copying when source and
+destination are identical:
+
+```rust
+#[test]
+fn copy_dir_recursive_same_path_returns_ok() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(dir.join("file.txt"), "hello").unwrap();
+    let result = copy_dir_recursive(dir, dir);
+    assert!(result.is_ok());
+}
+```
+
+## Python Equivalent
+
+The Python installer (`amplihack/install.py`) has the same guard using
+`os.path.samefile()`, which compares device and inode numbers:
+
+```python
+if os.path.exists(target_dir) and os.path.samefile(source_dir, target_dir):
+    print(f"  ⚠️  Skipping {dir_path}: source and target are the same path")
+    continue
+```
+
+## Related
+
+- [Issue #4296](https://github.com/rysweet/amplihack/issues/4296)
+- [Python fix PR #4297](https://github.com/rysweet/amplihack/pull/4297)
+- [Rust fix PR #201](https://github.com/rysweet/amplihack-rs/pull/201)

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ amplihack-rs is the Rust implementation of the amplihack CLI. It replaces the Py
 - [Evaluation Framework](./concepts/eval-framework.md) — Progressive L1–L12 evaluation, graders, and self-improvement
 - [Hive Orchestration](./concepts/hive-orchestration.md) — Multi-agent swarm deployment, events, and workload management
 - [Goal Agent Generator](./concepts/agent-generator.md) — Four-stage pipeline: analyze → plan → synthesize → assemble
+- [Same-Path Copy Guard](./concepts/same-path-copy-guard.md) — How `copy_dir_recursive` detects and skips self-copy when source and destination resolve to the same path
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

When source and destination resolve to the same directory (e.g. when `AMPLIHACK_HOME` points at the source tree), `copy_dir_recursive()` would enter infinite recursion or corrupt files.

## Changes

Added a `canonicalize`-based same-path guard at the top of all four `copy_dir_recursive` functions. When both paths exist and canonicalize to the same location, the function returns `Ok(())` early with a tracing warning.

### Files modified:
- `crates/amplihack-cli/src/auto_stager.rs` — guard + test
- `crates/amplihack-launcher/src/auto_stager.rs` — guard + test
- `crates/amplihack-context/src/migration.rs` — guard + test
- `crates/amplihack-cli/src/commands/mode/migration.rs` — guard + test module

## Testing

```
cargo test --lib -p amplihack-cli -- copy_dir_recursive_same_path     # 2 passed
cargo test --lib -p amplihack-launcher -- copy_dir_recursive_same_path # 1 passed
cargo test --lib -p amplihack-context -- copy_dir_recursive_same_path  # 1 passed
```

Fixes rysweet/amplihack#4296