### PR TITLE
fix: exclude __pycache__ from staging copy and add same-path guard

### DIFF
--- a/crates/amplihack-agent-generator/src/update_manager.rs
+++ b/crates/amplihack-agent-generator/src/update_manager.rs
@@ -224,13 +224,40 @@ fn detect_modified_files(
 }
 
 fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    // Same-path guard.
+    if let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
+        && src_canon == dst_canon
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "source and destination are the same path: {}",
+                src_canon.display()
+            ),
+        ));
+    }
+
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
-        let dest = dst.join(entry.file_name());
+        let file_name = entry.file_name();
+        let dest = dst.join(&file_name);
         if entry.file_type()?.is_dir() {
+            if matches!(
+                file_name.to_str(),
+                Some("__pycache__" | ".pytest_cache" | "node_modules")
+            ) {
+                continue;
+            }
             copy_dir_all(&entry.path(), &dest)?;
         } else {
+            if file_name
+                .to_str()
+                .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
             fs::copy(entry.path(), &dest)?;
         }
     }

--- a/crates/amplihack-cli/src/auto_stager.rs
+++ b/crates/amplihack-cli/src/auto_stager.rs
@@ -100,7 +100,32 @@ fn copy_claude_directory(source: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Returns `true` for directory names that should be excluded from staging copies.
+fn is_excluded_dir(name: &std::ffi::OsStr) -> bool {
+    matches!(
+        name.to_str(),
+        Some("__pycache__" | ".pytest_cache" | "node_modules")
+    )
+}
+
+/// Returns `true` for file extensions that should be excluded from staging copies.
+fn is_excluded_file(name: &std::ffi::OsStr) -> bool {
+    name.to_str()
+        .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+        .unwrap_or(false)
+}
+
 fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<()> {
+    // Same-path guard: bail if source and destination resolve to the same location.
+    if let (Ok(src_canon), Ok(dst_canon)) = (source.canonicalize(), dest.canonicalize())
+        && src_canon == dst_canon
+    {
+        anyhow::bail!(
+            "source and destination are the same path: {}",
+            src_canon.display()
+        );
+    }
+
     fs::create_dir_all(dest).with_context(|| format!("failed to create {}", dest.display()))?;
     for entry in
         fs::read_dir(source).with_context(|| format!("failed to read {}", source.display()))?
@@ -108,6 +133,7 @@ fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<()> {
         let entry =
             entry.with_context(|| format!("failed to read entry in {}", source.display()))?;
         let entry_path = entry.path();
+        let file_name = entry.file_name();
         let metadata = symlink_metadata(&entry_path)?;
         if metadata.file_type().is_symlink() {
             tracing::warn!(
@@ -117,10 +143,16 @@ fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<()> {
             continue;
         }
 
-        let destination = dest.join(entry.file_name());
+        let destination = dest.join(&file_name);
         if metadata.is_dir() {
+            if is_excluded_dir(&file_name) {
+                continue;
+            }
             copy_dir_recursive(&entry_path, &destination)?;
         } else if metadata.is_file() {
+            if is_excluded_file(&file_name) {
+                continue;
+            }
             fs::copy(&entry_path, &destination).with_context(|| {
                 format!(
                     "failed to copy staged asset {} -> {}",
@@ -193,6 +225,59 @@ mod tests {
                 .unwrap()
                 .to_string_lossy()
                 .contains("___unsafe")
+        );
+    }
+
+    #[test]
+    fn stage_for_nested_execution_skips_pycache() {
+        let project = tempfile::tempdir().unwrap();
+        let source_claude = project.path().join(".claude");
+        let agents_dir = source_claude.join("agents");
+        let pycache = agents_dir.join("__pycache__");
+        fs::create_dir_all(&pycache).unwrap();
+        fs::write(agents_dir.join("agent.md"), "agent").unwrap();
+        fs::write(agents_dir.join("helper.pyc"), "bytecode").unwrap();
+        fs::write(pycache.join("agent.cpython-312.pyc"), "cached").unwrap();
+
+        let result =
+            AutoStager::stage_for_nested_execution(project.path(), "pycache-test").unwrap();
+
+        assert!(
+            result
+                .staged_claude
+                .join("agents")
+                .join("agent.md")
+                .exists()
+        );
+        assert!(
+            !result
+                .staged_claude
+                .join("agents")
+                .join("__pycache__")
+                .exists()
+        );
+        assert!(
+            !result
+                .staged_claude
+                .join("agents")
+                .join("helper.pyc")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn copy_dir_recursive_rejects_same_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("dir");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "data").unwrap();
+
+        let result = copy_dir_recursive(&dir, &dir);
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("same"),
+            "expected same-path error, got: {err_msg}"
         );
     }
 }

--- a/crates/amplihack-cli/src/commands/install/filesystem.rs
+++ b/crates/amplihack-cli/src/commands/install/filesystem.rs
@@ -105,14 +105,41 @@ pub(super) fn walk_all(root: &Path) -> Result<Vec<PathBuf>> {
     walk_bounded(root, |_| true)
 }
 
+/// Returns `true` for directory names that should be excluded from copy operations.
+fn is_excluded_dir(name: &std::ffi::OsStr) -> bool {
+    matches!(
+        name.to_str(),
+        Some("__pycache__" | ".pytest_cache" | "node_modules")
+    )
+}
+
+/// Returns `true` for file extensions that should be excluded from copy operations.
+fn is_excluded_file(name: &std::ffi::OsStr) -> bool {
+    name.to_str()
+        .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+        .unwrap_or(false)
+}
+
 /// Copy a directory recursively, skipping symlinks with a warning.
 /// Device files, sockets, and FIFOs are skipped silently.
+/// `__pycache__` directories and `.pyc`/`.pyo` files are excluded.
 pub(super) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    // Same-path guard: bail if source and destination resolve to the same location.
+    if let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
+        && src_canon == dst_canon
+    {
+        anyhow::bail!(
+            "source and destination are the same path: {}",
+            src_canon.display()
+        );
+    }
+
     fs::create_dir_all(dst).with_context(|| format!("failed to create {}", dst.display()))?;
     for entry in fs::read_dir(src).with_context(|| format!("failed to read {}", src.display()))? {
         let entry = entry?;
         let source = entry.path();
-        let target = dst.join(entry.file_name());
+        let file_name = entry.file_name();
+        let target = dst.join(&file_name);
         // Use entry.file_type() — symlink-safe (does not follow symlinks)
         let kind = entry.file_type()?;
         if kind.is_symlink() {
@@ -120,8 +147,14 @@ pub(super) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
             println!("  ⚠️  Skipping symlink: {}", source.display());
             continue;
         } else if kind.is_dir() {
+            if is_excluded_dir(&file_name) {
+                continue;
+            }
             copy_dir_recursive(&source, &target)?;
         } else if kind.is_file() {
+            if is_excluded_file(&file_name) {
+                continue;
+            }
             fs::copy(&source, &target).with_context(|| {
                 format!(
                     "failed to copy {} to {}",

--- a/crates/amplihack-cli/src/commands/memory/transfer/paths.rs
+++ b/crates/amplihack-cli/src/commands/memory/transfer/paths.rs
@@ -131,6 +131,18 @@ fn copy_dir_recursive_inner(
             src.display()
         );
     }
+
+    // Same-path guard at the top level.
+    if depth == 0
+        && let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
+        && src_canon == dst_canon
+    {
+        anyhow::bail!(
+            "source and destination are the same path: {}",
+            src_canon.display()
+        );
+    }
+
     fs::create_dir_all(dst)?;
     let canonical = src.canonicalize().unwrap_or_else(|_| src.to_path_buf());
     if !seen.insert(canonical) {
@@ -139,15 +151,29 @@ fn copy_dir_recursive_inner(
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let kind = entry.file_type()?;
+        let file_name = entry.file_name();
         let from = entry.path();
-        let to = dst.join(entry.file_name());
+        let to = dst.join(&file_name);
         if kind.is_symlink() {
             // Skip symlinks with a warning to prevent directory traversal attacks
             println!("  Skipping symlink: {}", from.display());
             continue;
         } else if kind.is_dir() {
+            if matches!(
+                file_name.to_str(),
+                Some("__pycache__" | ".pytest_cache" | "node_modules")
+            ) {
+                continue;
+            }
             copy_dir_recursive_inner(&from, &to, depth + 1, seen)?;
         } else if kind.is_file() {
+            if file_name
+                .to_str()
+                .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
             ensure_parent_dir(&to)?;
             fs::copy(&from, &to)?;
         }

--- a/crates/amplihack-cli/src/commands/memory/transfer/sqlite_backend/import_helpers.rs
+++ b/crates/amplihack-cli/src/commands/memory/transfer/sqlite_backend/import_helpers.rs
@@ -269,11 +269,22 @@ pub(super) fn get_existing_ids(conn: &SqliteConnection, agent_name: &str) -> Res
 }
 
 pub(super) fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
+    // Same-path guard.
+    if let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
+        && src_canon == dst_canon
+    {
+        anyhow::bail!(
+            "source and destination are the same path: {}",
+            src_canon.display()
+        );
+    }
+
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let from = entry.path();
-        let to = dst.join(entry.file_name());
+        let file_name = entry.file_name();
+        let to = dst.join(&file_name);
         let file_type = entry.file_type()?;
         // Skip symlinks to prevent directory-traversal attacks, mirroring the
         // behaviour of copy_dir_recursive_inner in the graph-db backend.
@@ -282,8 +293,21 @@ pub(super) fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> Result<(
             continue;
         }
         if file_type.is_dir() {
+            if matches!(
+                file_name.to_str(),
+                Some("__pycache__" | ".pytest_cache" | "node_modules")
+            ) {
+                continue;
+            }
             copy_dir(&from, &to)?;
         } else {
+            if file_name
+                .to_str()
+                .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
             fs::copy(&from, &to)?;
         }
     }

--- a/crates/amplihack-cli/src/commands/mode/migration.rs
+++ b/crates/amplihack-cli/src/commands/mode/migration.rs
@@ -177,21 +177,45 @@ fn confirm(input: &mut impl BufRead, out: &mut impl Write) -> Result<bool> {
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    // Same-path guard: bail if source and destination resolve to the same location.
+    if let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
+        && src_canon == dst_canon
+    {
+        anyhow::bail!(
+            "source and destination are the same path: {}",
+            src_canon.display()
+        );
+    }
+
     fs::create_dir_all(dst)
         .with_context(|| format!("failed to create directory {}", dst.display()))?;
 
     for entry in fs::read_dir(src).with_context(|| format!("failed to read {}", src.display()))? {
         let entry = entry?;
         let source_path = entry.path();
-        let target_path = dst.join(entry.file_name());
+        let file_name = entry.file_name();
+        let target_path = dst.join(&file_name);
         let file_type = entry.file_type()?;
 
         if file_type.is_symlink() {
             tracing::debug!("Skipping symlink: {}", source_path.display());
             continue;
         } else if file_type.is_dir() {
+            if matches!(
+                file_name.to_str(),
+                Some("__pycache__" | ".pytest_cache" | "node_modules")
+            ) {
+                continue;
+            }
             copy_dir_recursive(&source_path, &target_path)?;
         } else if file_type.is_file() {
+            if file_name
+                .to_str()
+                .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
             fs::copy(&source_path, &target_path).with_context(|| {
                 format!(
                     "failed to copy {} to {}",

--- a/crates/amplihack-cli/src/commands/new_agent/packager.rs
+++ b/crates/amplihack-cli/src/commands/new_agent/packager.rs
@@ -282,16 +282,40 @@ pub fn into_packaged_bundle(
 
 /// Recursively copy a directory tree.
 pub(super) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), BundleError> {
+    // Same-path guard.
+    if let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
+        && src_canon == dst_canon
+    {
+        return Err(pkg_err(format!(
+            "source and destination are the same path: {}",
+            src_canon.display()
+        )));
+    }
+
     fs::create_dir_all(dst).map_err(|e| pkg_err(format!("mkdir {}: {e}", dst.display())))?;
     for entry in fs::read_dir(src).map_err(|e| pkg_err(format!("read {}: {e}", src.display())))? {
         let entry = entry.map_err(|e| pkg_err(format!("entry: {e}")))?;
         let ft = entry
             .file_type()
             .map_err(|e| pkg_err(format!("ftype: {e}")))?;
-        let target = dst.join(entry.file_name());
+        let file_name = entry.file_name();
+        let target = dst.join(&file_name);
         if ft.is_dir() {
+            if matches!(
+                file_name.to_str(),
+                Some("__pycache__" | ".pytest_cache" | "node_modules")
+            ) {
+                continue;
+            }
             copy_dir_recursive(&entry.path(), &target)?;
         } else {
+            if file_name
+                .to_str()
+                .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
             fs::copy(entry.path(), &target).map_err(|e| pkg_err(format!("copy: {e}")))?;
         }
     }

--- a/crates/amplihack-cli/src/commands/plugin/helpers.rs
+++ b/crates/amplihack-cli/src/commands/plugin/helpers.rs
@@ -4,6 +4,15 @@ pub(super) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     let src_root = src
         .canonicalize()
         .with_context(|| format!("failed to resolve source root {}", src.display()))?;
+    // Same-path guard.
+    if let Ok(dst_canon) = dst.canonicalize()
+        && src_root == dst_canon
+    {
+        anyhow::bail!(
+            "source and destination are the same path: {}",
+            src_root.display()
+        );
+    }
     copy_dir_recursive_inner(src, dst, &src_root)
 }
 
@@ -12,11 +21,25 @@ fn copy_dir_recursive_inner(src: &Path, dst: &Path, src_root: &Path) -> Result<(
     for entry in fs::read_dir(src).with_context(|| format!("failed to read {}", src.display()))? {
         let entry = entry?;
         let source = entry.path();
-        let target = dst.join(entry.file_name());
+        let file_name = entry.file_name();
+        let target = dst.join(&file_name);
         let kind = entry.file_type()?;
         if kind.is_dir() {
+            if matches!(
+                file_name.to_str(),
+                Some("__pycache__" | ".pytest_cache" | "node_modules")
+            ) {
+                continue;
+            }
             copy_dir_recursive_inner(&source, &target, src_root)?;
         } else if kind.is_file() {
+            if file_name
+                .to_str()
+                .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
             fs::copy(&source, &target).with_context(|| {
                 format!(
                     "failed to copy {} to {}",

--- a/crates/amplihack-launcher/src/auto_stager.rs
+++ b/crates/amplihack-launcher/src/auto_stager.rs
@@ -89,18 +89,53 @@ fn copy_claude_directory(source: &Path, dest: &Path) {
     }
 }
 
-/// Recursively copy a directory, skipping symlinks.
+/// Returns `true` for directory names that should be excluded from staging copies.
+fn is_excluded_dir(name: &std::ffi::OsStr) -> bool {
+    matches!(
+        name.to_str(),
+        Some("__pycache__" | ".pytest_cache" | "node_modules")
+    )
+}
+
+/// Returns `true` for file extensions that should be excluded from staging copies.
+fn is_excluded_file(name: &std::ffi::OsStr) -> bool {
+    name.to_str()
+        .map(|s| s.ends_with(".pyc") || s.ends_with(".pyo"))
+        .unwrap_or(false)
+}
+
+/// Recursively copy a directory, skipping symlinks, `__pycache__`, and `.pyc` files.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    // Same-path guard: bail if source and destination resolve to the same location.
+    if let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
+        && src_canon == dst_canon
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "source and destination are the same path: {}",
+                src_canon.display()
+            ),
+        ));
+    }
+
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
-        let dest_path = dst.join(entry.file_name());
+        let file_name = entry.file_name();
+        let dest_path = dst.join(&file_name);
         if ty.is_symlink() {
             continue;
         } else if ty.is_dir() {
+            if is_excluded_dir(&file_name) {
+                continue;
+            }
             copy_dir_recursive(&entry.path(), &dest_path)?;
         } else {
+            if is_excluded_file(&file_name) {
+                continue;
+            }
             fs::copy(entry.path(), &dest_path)?;
         }
     }
@@ -190,6 +225,40 @@ mod tests {
         assert_eq!(
             fs::read_to_string(dst.join("sub").join("b.txt")).unwrap(),
             "world"
+        );
+    }
+
+    #[test]
+    fn copy_dir_recursive_skips_pycache_and_pyc() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let pycache = src.join("__pycache__");
+        fs::create_dir_all(&pycache).unwrap();
+        fs::write(src.join("main.py"), "print('hi')").unwrap();
+        fs::write(src.join("module.pyc"), "bytecode").unwrap();
+        fs::write(pycache.join("main.cpython-312.pyc"), "cached").unwrap();
+
+        let dst = tmp.path().join("dst");
+        copy_dir_recursive(&src, &dst).unwrap();
+
+        assert!(dst.join("main.py").exists());
+        assert!(!dst.join("__pycache__").exists());
+        assert!(!dst.join("module.pyc").exists());
+    }
+
+    #[test]
+    fn copy_dir_recursive_rejects_same_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("dir");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "data").unwrap();
+
+        let result = copy_dir_recursive(&dir, &dir);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("same"),
+            "expected same-path error, got: {err_msg}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #199

All copy_dir_recursive implementations now:
1. Exclude __pycache__/, .pytest_cache/, node_modules/ directories
2. Exclude .pyc/.pyo files
3. Add same-path guard (source == dest check)

9 files changed across 3 crates. 3 new tests added. All existing tests pass.