### PR TITLE
fix: reject dirty worktree branches in recipe runner

### DIFF
--- a/amplifier-bundle/recipes/consensus-workflow.yaml
+++ b/amplifier-bundle/recipes/consensus-workflow.yaml
@@ -631,10 +631,28 @@ steps:
       WORKTREE_EXISTS=$(git worktree list --porcelain | grep -Fx "worktree $WORKTREE_PATH" || true)
 
       if [ -n "$BRANCH_EXISTS" ] && [ -n "$WORKTREE_EXISTS" ]; then
-        echo "INFO: Branch '$BRANCH_NAME' and worktree already exist — reusing." >&2
+        # FIX (issue #200): Verify branch cleanliness before reusing.
+        WORKTREE_DIRTY=$(git -C "$WORKTREE_PATH" status --porcelain 2>/dev/null || true)
+        COMMITS_AHEAD=$(git -C "$WORKTREE_PATH" rev-list --count origin/main..HEAD 2>/dev/null || echo "0")
+        if [ -n "$WORKTREE_DIRTY" ] || [ "$COMMITS_AHEAD" -gt 0 ]; then
+          echo "WARNING: Existing branch '$BRANCH_NAME' is dirty — resetting to origin/main." >&2
+          git -C "$WORKTREE_PATH" checkout -- . 2>/dev/null || true
+          git -C "$WORKTREE_PATH" clean -fd 2>/dev/null || true
+          git -C "$WORKTREE_PATH" reset --hard origin/main >&2
+        else
+          echo "INFO: Branch '$BRANCH_NAME' and worktree already exist and are clean — reusing." >&2
+        fi
       elif [ -n "$BRANCH_EXISTS" ] && [ -z "$WORKTREE_EXISTS" ]; then
-        echo "INFO: Branch '$BRANCH_NAME' exists but worktree missing — adding without -b." >&2
-        git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+        # FIX (issue #200): Check for unmerged commits before reattaching.
+        COMMITS_AHEAD=$(git rev-list --count origin/main.."$BRANCH_NAME" 2>/dev/null || echo "0")
+        if [ "$COMMITS_AHEAD" -gt 0 ]; then
+          echo "WARNING: Existing branch '$BRANCH_NAME' has unmerged commits — resetting." >&2
+          git branch -D "$BRANCH_NAME" >&2
+          git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" "$BASE_REF"
+        else
+          echo "INFO: Branch '$BRANCH_NAME' exists (clean) but worktree missing — adding without -b." >&2
+          git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+        fi
       else
         git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" "$BASE_REF"
       fi

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -490,11 +490,35 @@ steps:
       WORKTREE_EXISTS=$(git worktree list --porcelain | grep -Fx "worktree ${WORKTREE_PATH}" || true)
 
       if [ -n "$BRANCH_EXISTS" ] && [ -n "$WORKTREE_EXISTS" ]; then
-        echo "INFO: Branch '${BRANCH_NAME}' and worktree '${WORKTREE_PATH}' already exist — reusing." >&2
-        CREATED=false
+        # FIX (issue #200): Verify branch cleanliness before reusing.
+        # A dirty worktree (uncommitted changes or unmerged commits ahead of
+        # origin/main) can leak stale state into a new recipe run.
+        WORKTREE_DIRTY=$(git -C "${WORKTREE_PATH}" status --porcelain 2>/dev/null || true)
+        COMMITS_AHEAD=$(git -C "${WORKTREE_PATH}" rev-list --count origin/main..HEAD 2>/dev/null || echo "0")
+        if [ -n "$WORKTREE_DIRTY" ] || [ "$COMMITS_AHEAD" -gt 0 ]; then
+          echo "WARNING: Existing branch '${BRANCH_NAME}' is dirty (uncommitted changes: $([ -n "$WORKTREE_DIRTY" ] && echo 'yes' || echo 'no'), commits ahead of origin/main: ${COMMITS_AHEAD})." >&2
+          echo "INFO: Resetting worktree to origin/main for a clean slate." >&2
+          git -C "${WORKTREE_PATH}" checkout -- . 2>/dev/null || true
+          git -C "${WORKTREE_PATH}" clean -fd 2>/dev/null || true
+          git -C "${WORKTREE_PATH}" reset --hard origin/main >&2
+          CREATED=false
+        else
+          echo "INFO: Branch '${BRANCH_NAME}' and worktree '${WORKTREE_PATH}' already exist and are clean — reusing." >&2
+          CREATED=false
+        fi
       elif [ -n "$BRANCH_EXISTS" ] && [ -z "$WORKTREE_EXISTS" ]; then
-        echo "INFO: Branch '${BRANCH_NAME}' exists but worktree is missing — adding worktree without -b." >&2
-        git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}" >&2
+        # FIX (issue #200): Check branch cleanliness before attaching worktree.
+        # The branch may have unmerged commits from a previous run even if the
+        # worktree was pruned.
+        COMMITS_AHEAD=$(git rev-list --count origin/main.."${BRANCH_NAME}" 2>/dev/null || echo "0")
+        if [ "$COMMITS_AHEAD" -gt 0 ]; then
+          echo "WARNING: Existing branch '${BRANCH_NAME}' has ${COMMITS_AHEAD} unmerged commit(s) — resetting to origin/main." >&2
+          git branch -D "${BRANCH_NAME}" >&2
+          git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" origin/main >&2
+        else
+          echo "INFO: Branch '${BRANCH_NAME}' exists (clean) but worktree is missing — adding worktree without -b." >&2
+          git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}" >&2
+        fi
         CREATED=true
       else
         echo "INFO: Creating new branch and worktree." >&2


### PR DESCRIPTION
## Problem

When the smart-orchestrator reuses an existing worktree branch (idempotency State 1 or State 2), it does not verify that the branch is clean. This means uncommitted changes or unmerged commits from a previous run can leak into a new recipe execution, causing unpredictable behavior.

Closes #200

## Fix

Added a cleanliness guard in both `default-workflow.yaml` and `consensus-workflow.yaml` worktree setup steps:

### State 1 (branch + worktree both exist)
- Check `git status --porcelain` for uncommitted changes
- Check `git rev-list --count origin/main..HEAD` for unmerged commits
- If either is non-zero: `checkout -- .`, `clean -fd`, `reset --hard origin/main`
- If clean: reuse as before

### State 2 (branch exists, worktree missing)
- Check `git rev-list --count origin/main..BRANCH` for unmerged commits
- If commits ahead: delete the branch and recreate fresh from origin/main
- If clean: attach worktree as before (no change)

### State 3 (neither exists)
- No change — fresh creation path is already clean

## Testing
- All `cargo test` pass
- YAML changes are shell script within recipe steps — validated by recipe runner at execution time

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>