### PR TITLE
fix: pass large recipe context via temp file to avoid E2BIG

### DIFF
--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -1,7 +1,13 @@
 use super::*;
 use crate::env_builder::{EnvBuilder, active_agent_binary};
+use std::io::Write as IoWrite;
 
 const STDERR_TAIL_LINES: usize = 5;
+
+/// Threshold in bytes for total `--set` argument size before we switch
+/// to passing context via a temp file. Well under the typical Linux
+/// ARG_MAX (~2MB) to leave room for env vars and other args.
+const CONTEXT_ARG_SIZE_THRESHOLD: usize = 128 * 1024;
 
 pub(super) fn execute_recipe_via_rust(
     recipe_path: &Path,
@@ -22,9 +28,9 @@ pub(super) fn execute_recipe_via_rust(
         command.arg("--dry-run");
     }
 
-    for (key, value) in context {
-        command.arg("--set").arg(format!("{key}={value}"));
-    }
+    // Pass context as a file when the total size would risk E2BIG (os error 7).
+    // The temp file is kept alive until command.output() completes.
+    let _context_file = pass_context(&mut command, context)?;
 
     EnvBuilder::new()
         .with_agent_binary(active_agent_binary())
@@ -56,6 +62,45 @@ pub(super) fn execute_recipe_via_rust(
     })?;
 
     Ok(parsed)
+}
+
+/// Pass context key-value pairs to the command. When total serialised size
+/// is small, uses `--set key=value` CLI args. When large, writes a JSON
+/// file and passes `--context-file <path>` to avoid E2BIG (issues #209, #211).
+///
+/// Returns an `Option<tempfile::NamedTempFile>` that must be kept alive
+/// until the child process has finished reading the file.
+pub(super) fn pass_context(
+    command: &mut Command,
+    context: &BTreeMap<String, String>,
+) -> Result<Option<tempfile::NamedTempFile>> {
+    if context.is_empty() {
+        return Ok(None);
+    }
+
+    let total_bytes: usize = context
+        .iter()
+        .map(|(k, v)| "--set".len() + k.len() + 1 + v.len())
+        .sum();
+
+    if total_bytes <= CONTEXT_ARG_SIZE_THRESHOLD {
+        for (key, value) in context {
+            command.arg("--set").arg(format!("{key}={value}"));
+        }
+        return Ok(None);
+    }
+
+    // Write context as JSON to a temp file.
+    let mut tmp =
+        tempfile::NamedTempFile::new().context("failed to create temp file for recipe context")?;
+    serde_json::to_writer(&mut tmp, context)
+        .context("failed to serialize recipe context to temp file")?;
+    tmp.flush()
+        .context("failed to flush recipe context temp file")?;
+
+    command.arg("--context-file").arg(tmp.path());
+
+    Ok(Some(tmp))
 }
 
 fn format_runner_failure_detail(status: &std::process::ExitStatus, stderr: &str) -> String {

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
@@ -296,6 +296,134 @@ fn test_execute_recipe_via_rust_reports_signal_kill_clearly() {
     );
 }
 
+// -------------------------------------------------------------------------
+// pass_context — unit tests for E2BIG mitigation (issues #209, #211)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_pass_context_uses_args_for_small_payloads() {
+    let mut context = BTreeMap::new();
+    context.insert("key1".to_string(), "value1".to_string());
+    context.insert("key2".to_string(), "value2".to_string());
+
+    let mut command = Command::new("echo");
+    let tmp = execute::pass_context(&mut command, &context).unwrap();
+
+    // Small payloads should not produce a temp file.
+    assert!(
+        tmp.is_none(),
+        "small context should use CLI args, not a file"
+    );
+}
+
+#[test]
+fn test_pass_context_uses_file_for_large_payloads() {
+    let mut context = BTreeMap::new();
+    // Create a payload well over the 128KB threshold.
+    let big_value = "x".repeat(200 * 1024);
+    context.insert("task_description".to_string(), big_value.clone());
+
+    let mut command = Command::new("echo");
+    let tmp = execute::pass_context(&mut command, &context).unwrap();
+
+    assert!(tmp.is_some(), "large context must use a temp file");
+
+    // Verify the temp file contains valid JSON with the context.
+    let file = tmp.unwrap();
+    let content = std::fs::read_to_string(file.path()).unwrap();
+    let parsed: BTreeMap<String, String> = serde_json::from_str(&content).unwrap();
+    assert_eq!(
+        parsed.get("task_description").map(String::as_str),
+        Some(big_value.as_str())
+    );
+}
+
+#[test]
+fn test_pass_context_empty_returns_none() {
+    let context = BTreeMap::new();
+    let mut command = Command::new("echo");
+    let tmp = execute::pass_context(&mut command, &context).unwrap();
+    assert!(tmp.is_none());
+}
+
+#[test]
+#[cfg(unix)]
+fn test_large_context_does_not_hit_e2big() {
+    // End-to-end: run a stub binary with a context value larger than typical
+    // ARG_MAX. The binary reads --context-file and echoes success.
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+
+    // Stub: if --context-file is present, cat it and report success.
+    // Otherwise report the --set args count.
+    std::fs::write(
+        &runner,
+        r#"#!/bin/sh
+CONTEXT_FILE=""
+for arg in "$@"; do
+    if [ "$prev" = "--context-file" ]; then
+        CONTEXT_FILE="$arg"
+    fi
+    prev="$arg"
+done
+if [ -n "$CONTEXT_FILE" ]; then
+    # Verify the file exists and is valid JSON
+    python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(json.dumps({'recipe_name':'large-ctx','success':True,'step_results':[],'context':{'got_file':'true','keys':str(len(d))}}))" "$CONTEXT_FILE"
+else
+    echo '{"recipe_name":"large-ctx","success":true,"step_results":[],"context":{"got_file":"false"}}'
+fi
+"#,
+    )
+    .expect("failed to write runner stub");
+
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&runner, std::fs::Permissions::from_mode(0o755))
+            .expect("failed to chmod runner");
+    }
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: large-ctx\nsteps: []\n").expect("failed to write recipe");
+
+    let amplihack_home = temp.path().join("amplihack-home");
+    std::fs::create_dir_all(&amplihack_home).unwrap();
+
+    let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+    let prev_home = std::env::var_os("AMPLIHACK_HOME");
+    unsafe {
+        std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+        std::env::set_var("AMPLIHACK_HOME", &amplihack_home);
+    }
+
+    // Context of ~256KB — would exceed ARG_MAX on many systems.
+    let mut context = BTreeMap::new();
+    context.insert("task_description".to_string(), "x".repeat(256 * 1024));
+
+    let result = execute::execute_recipe_via_rust(&recipe, &context, true, temp.path());
+
+    match prev_runner {
+        Some(v) => unsafe { std::env::set_var("RECIPE_RUNNER_RS_PATH", v) },
+        None => unsafe { std::env::remove_var("RECIPE_RUNNER_RS_PATH") },
+    }
+    match prev_home {
+        Some(v) => unsafe { std::env::set_var("AMPLIHACK_HOME", v) },
+        None => unsafe { std::env::remove_var("AMPLIHACK_HOME") },
+    }
+
+    let run_result =
+        result.expect("execute_recipe_via_rust must not fail with E2BIG for large context");
+    assert_eq!(run_result.recipe_name, "large-ctx");
+    assert!(run_result.success);
+    assert_eq!(
+        run_result.context.get("got_file"),
+        Some(&serde_json::json!("true")),
+        "large context must be passed via --context-file, not --set args"
+    );
+}
+
 /// Returns true if recipe-runner-rs appears to be available on this system.
 fn which_recipe_runner_available() -> bool {
     if let Ok(p) = std::env::var("RECIPE_RUNNER_RS_PATH")


### PR DESCRIPTION
## Fixes #211, #209

**Problem:** `complete-session` (and any recipe run) crashes with `Argument list too long (os error 7)` when context values exceed the OS ARG_MAX limit (~128KB-2MB). Large `task_description` or session data passed as `--set key=value` CLI args triggers E2BIG.

**Solution:** Add a `pass_context()` helper in `execute.rs` that:
- Measures total context arg size before spawning the subprocess
- For small contexts (≤128KB): uses `--set key=value` args as before (zero overhead)
- For large contexts (>128KB): writes JSON to a temp file and passes `--context-file <path>`
- Temp file lifetime is tied to `command.output()` completion via RAII

**Tests added:**
- `test_pass_context_uses_args_for_small_payloads` — verifies no temp file for small data
- `test_pass_context_uses_file_for_large_payloads` — verifies temp file creation + content
- `test_pass_context_empty_returns_none` — edge case
- `test_large_context_does_not_hit_e2big` — E2E with 256KB context and stub binary

All `cargo fmt` and `cargo clippy -- -D warnings` clean.