### PR TITLE
fix: use tag-based versioning for auto-release (fixes branch protection)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # ── Auto-bump patch version on every push to main ─────────────────────
+  # ── Determine next version and create tag ─────────────────────────────
+  # Tag-based versioning: reads base version from Cargo.toml, increments
+  # patch from the latest release tag, and creates a lightweight tag.
+  # No commit to main required — works with branch protection.
   version-bump:
     name: Auto-bump version
     runs-on: ubuntu-latest
@@ -27,13 +30,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump patch version
+      - name: Compute next version from tags
         id: bump
         run: |
           set -euo pipefail
 
           CURRENT=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-          echo "Current version: ${CURRENT}"
+          echo "Cargo.toml version: ${CURRENT}"
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT}"
 
@@ -53,31 +56,27 @@ jobs:
           fi
 
           NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+          HEAD_SHA=$(git rev-parse HEAD)
 
-          if [ "${NEW_VERSION}" = "${CURRENT}" ]; then
-            echo "Version already at ${CURRENT} — no bump needed"
-            echo "version=${CURRENT}" >> "$GITHUB_OUTPUT"
-            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          # Check if this exact commit already has a release tag
+          EXISTING=$(git tag --points-at HEAD | grep -E "^v${MAJOR}\.${MINOR}\." || true)
+          if [ -n "${EXISTING}" ]; then
+            echo "Commit already tagged: ${EXISTING} — skipping"
+            echo "version=${EXISTING#v}" >> "$GITHUB_OUTPUT"
+            echo "sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Bumping: ${CURRENT} → ${NEW_VERSION}"
+          echo "Tagging: v${NEW_VERSION} at ${HEAD_SHA}"
 
-          # Update Cargo.toml workspace version
-          sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW_VERSION}\"/" Cargo.toml
-
-          # Regenerate lockfile
-          cargo generate-lockfile 2>/dev/null || true
-
-          # Commit and push
+          # Create and push a lightweight tag (no commit to main needed)
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock
-          git commit -m "chore: auto-bump version ${CURRENT} → ${NEW_VERSION} [skip ci]"
-          git push
+          git tag "v${NEW_VERSION}" "${HEAD_SHA}"
+          git push origin "v${NEW_VERSION}"
 
           echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

The auto-release workflow has been broken since branch protection was enabled on `main`. The `GITHUB_TOKEN` cannot push commits to protected branches (GH006 error), so the version-bump step fails every time.

This means **no binary releases have been published** since v0.7.32, despite 7+ PRs being merged.

## Root Cause

The workflow was committing a Cargo.toml version bump to `main` and pushing — but `GITHUB_TOKEN` doesn't have permission to bypass branch protection rules.

## Solution

Switch to **tag-based versioning** that doesn't require pushing commits:

1. Read base version from `Cargo.toml` 
2. Find latest release tag to compute next patch number
3. Create and push a **lightweight tag** (tags bypass branch protection)
4. Build binaries from the tagged commit
5. Create GitHub Release with artifacts

No commit to `main` needed. The version in `Cargo.toml` serves as the base version; release tags are the source of truth.

## Verification

After merge, the workflow will trigger on the merge commit and should:
- Compute v0.7.33 as the next version
- Tag the commit
- Build 4 binary targets
- Create a GitHub Release with artifacts

Closes #213