### PR TITLE
fix: add explicit timeouts to smart-orchestrator agent steps (#210)

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -8,6 +8,12 @@ version: "1.5.0"
 author: "Amplihack Team"
 tags: ["orchestration", "routing", "parallel", "auto-classify", "goal-seeking"]
 
+# Agent steps launch full Claude sessions (including plugin installation)
+# which can easily exceed the recipe-runner's built-in 60s default.
+# Set a 5-minute recipe-level default so steps without an explicit
+# timeout_seconds still get adequate time.  Fixes #210.
+default_step_timeout: 300
+
 context:
   task_description: ""
   repo_path: "."
@@ -75,6 +81,7 @@ steps:
 
   - id: "classify-and-decompose"
     type: "agent"
+    timeout_seconds: 300
     agent: "amplihack:core:architect"
     prompt: |
       === [RECIPE PROGRESS] Step: classify-and-decompose ===
@@ -303,6 +310,7 @@ steps:
 
   - id: "handle-qa"
     type: "agent"
+    timeout_seconds: 300
     condition: "'Q&A' in task_type"
     agent: "amplihack:core:analyzer"
     prompt: |
@@ -323,6 +331,7 @@ steps:
 
   - id: "handle-ops-agent"
     type: "agent"
+    timeout_seconds: 300
     condition: "'Operations' in task_type"
     agent: "amplihack:core:builder"
     prompt: |
@@ -718,6 +727,7 @@ steps:
 
   - id: "reflect-round-1"
     type: "agent"
+    timeout_seconds: 300
     condition: |
       'Q&A' not in task_type and 'Operations' not in task_type and round_1_result
     agent: "amplihack:core:reviewer"
@@ -761,6 +771,7 @@ steps:
 
   - id: "execute-round-2"
     type: "agent"
+    timeout_seconds: 600
     condition: |
       reflection_1 and ('PARTIAL' in reflection_1 or 'NOT_ACHIEVED' in reflection_1 or 'HOLLOW' in reflection_1)
     agent: "amplihack:core:builder"
@@ -778,6 +789,7 @@ steps:
 
   - id: "reflect-round-2"
     type: "agent"
+    timeout_seconds: 300
     condition: |
       round_2_result and ('PARTIAL' in reflection_1 or 'NOT_ACHIEVED' in reflection_1)
     agent: "amplihack:core:reviewer"
@@ -796,6 +808,7 @@ steps:
 
   - id: "execute-round-3"
     type: "agent"
+    timeout_seconds: 600
     condition: |
       reflection_2 and ('PARTIAL' in reflection_2 or 'NOT_ACHIEVED' in reflection_2)
     agent: "amplihack:core:builder"
@@ -813,6 +826,7 @@ steps:
 
   - id: "reflect-final"
     type: "agent"
+    timeout_seconds: 300
     condition: "'Q&A' not in task_type and 'Operations' not in task_type and round_1_result"
     agent: "amplihack:core:reviewer"
     prompt: |
@@ -846,6 +860,7 @@ steps:
 
   - id: "validate-outside-in-testing"
     type: "agent"
+    timeout_seconds: 300
     condition: "'Q&A' not in task_type and 'Operations' not in task_type and 'Development' in task_type and round_1_result"
     agent: "amplihack:core:reviewer"
     prompt: |
@@ -919,6 +934,7 @@ steps:
 
   - id: "summarize"
     type: "agent"
+    timeout_seconds: 300
     condition: "'Q&A' not in task_type and 'Operations' not in task_type and round_1_result"
     agent: "amplihack:core:architect"
     prompt: |

--- a/crates/amplihack-recipe/src/models.rs
+++ b/crates/amplihack-recipe/src/models.rs
@@ -139,6 +139,12 @@ impl Step {
         self.max_env_value_bytes
             .unwrap_or(Self::DEFAULT_MAX_ENV_BYTES)
     }
+
+    /// Returns the effective timeout for this step, falling back to
+    /// `recipe_default` if the step has no explicit timeout.
+    pub fn effective_timeout(&self, recipe_default: Option<u64>) -> Option<u64> {
+        self.timeout_seconds.or(recipe_default)
+    }
 }
 
 /// A complete recipe definition.
@@ -154,6 +160,11 @@ pub struct Recipe {
     pub context: HashMap<String, serde_json::Value>,
     #[serde(default)]
     pub on_failure: Option<String>,
+    /// Default timeout (seconds) applied to steps that don't specify their own.
+    /// When set, the recipe runner should use this value instead of its
+    /// built-in default for any step with `timeout_seconds: None`.
+    #[serde(default)]
+    pub default_step_timeout: Option<u64>,
 }
 
 fn default_version() -> String {
@@ -169,6 +180,7 @@ impl Recipe {
             steps,
             context: HashMap::new(),
             on_failure: None,
+            default_step_timeout: None,
         }
     }
 


### PR DESCRIPTION
## Problem

The `reflect-round-1` step in the smart-orchestrator recipe fails because agent steps launch full Claude sessions (including `claude plugin install amplihack`), which regularly exceeds the recipe runner's built-in 60-second default timeout. This causes the step to be killed, discarding successful parallel round results.

## Root Cause

All 10 agent steps in `smart-orchestrator.yaml` had no explicit `timeout_seconds`, so the recipe runner applied its 60s default — insufficient for agent startup + plugin installation + actual work.

## Fix

**Recipe YAML** (`amplifier-bundle/recipes/smart-orchestrator.yaml`):
- Add `timeout_seconds: 300` (5 min) to all review/reflect/classify/summarize agent steps
- Add `timeout_seconds: 600` (10 min) to execution agent steps (`execute-round-2`, `execute-round-3`) which do implementation work
- Add `default_step_timeout: 300` at recipe level as a safety net for any future steps

**Rust model** (`crates/amplihack-recipe/src/models.rs`):
- Add `default_step_timeout: Option<u64>` field to `Recipe` struct
- Add `Step::effective_timeout()` helper that falls back to recipe default
- Parser already supported `default_step_timeout` extraction

## Testing

- All 13 recipe crate tests pass (including `parse_smart_orchestrator_recipe`)
- `cargo fmt --check` clean
- `cargo clippy -p amplihack-recipe -- -D warnings` clean

Closes #210