### PR TITLE
fix: install/path issues (#225, #228, #229)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -188,16 +188,58 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
         && let Some(on_path) = find_binary("amplihack")
         && on_path != *amplihack_dst
     {
-        println!(
-            "  ⚠️  `amplihack` currently resolves to {} instead of the Rust binary at {}.",
-            on_path.display(),
-            amplihack_dst.display()
-        );
-        println!(
-            "     Use {} directly for the Rust CLI, or move ~/.local/bin ahead of older amplihack installs.",
-            amplihack_dst.display()
-        );
+        let is_python = is_python_script(&on_path);
+        if is_python {
+            println!(
+                "  ⚠️  A Python `amplihack` script at {} shadows the Rust binary at {}.",
+                on_path.display(),
+                amplihack_dst.display()
+            );
+            println!(
+                "     The Python script will intercept `amplihack` commands, preventing the Rust CLI from running."
+            );
+            println!("     To fix, do one of the following:");
+            println!(
+                "       1. Remove the Python script:  rm {}",
+                on_path.display()
+            );
+            println!(
+                "       2. Reorder PATH so ~/.local/bin comes first:  export PATH=\"$HOME/.local/bin:$PATH\""
+            );
+            println!(
+                "       3. Uninstall the Python package:  pip uninstall amplihack"
+            );
+        } else {
+            println!(
+                "  ⚠️  `amplihack` currently resolves to {} instead of the Rust binary at {}.",
+                on_path.display(),
+                amplihack_dst.display()
+            );
+            println!(
+                "     Use {} directly for the Rust CLI, or move ~/.local/bin ahead of older amplihack installs.",
+                amplihack_dst.display()
+            );
+        }
     }
 
     Ok(deployed)
+}
+
+/// Check whether a file is a Python script (shebang or .py extension).
+fn is_python_script(path: &std::path::Path) -> bool {
+    if path.extension().and_then(|e| e.to_str()) == Some("py") {
+        return true;
+    }
+    // Read the first line to check for a Python shebang
+    if let Ok(content) = std::fs::read(path) {
+        if let Some(first_line) = content
+            .split(|&b| b == b'\n')
+            .next()
+            .and_then(|line| std::str::from_utf8(line).ok())
+        {
+            return first_line.starts_with("#!")
+                && (first_line.contains("python") || first_line.contains("Python"));
+        }
+    }
+    false
 }

--- a/crates/amplihack-cli/src/commands/install/filesystem.rs
+++ b/crates/amplihack-cli/src/commands/install/filesystem.rs
@@ -123,6 +123,7 @@ fn is_excluded_file(name: &std::ffi::OsStr) -> bool {
 /// Copy a directory recursively, skipping symlinks with a warning.
 /// Device files, sockets, and FIFOs are skipped silently.
 /// `__pycache__` directories and `.pyc`/`.pyo` files are excluded.
+/// Broken symlinks are removed during traversal.
 pub(super) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     // Same-path guard: bail if source and destination resolve to the same location.
     if let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
@@ -196,6 +197,61 @@ pub(super) fn set_script_permissions(path: &Path) -> Result<()> {
         perms.set_mode(perms.mode() | 0o110);
         fs::set_permissions(path, perms)
             .with_context(|| format!("failed to chmod {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Remove broken symlinks from a directory tree.
+///
+/// Walks the directory non-recursively by default (set `recursive` for deep scan).
+/// Returns the number of broken symlinks removed.
+pub(super) fn clean_broken_symlinks(dir: &Path, recursive: bool) -> Result<usize> {
+    let mut removed = 0usize;
+    if !dir.exists() {
+        return Ok(0);
+    }
+    clean_broken_symlinks_inner(dir, recursive, &mut removed, 0)?;
+    Ok(removed)
+}
+
+fn clean_broken_symlinks_inner(
+    dir: &Path,
+    recursive: bool,
+    removed: &mut usize,
+    depth: usize,
+) -> Result<()> {
+    if depth > MAX_WALK_DEPTH {
+        return Ok(());
+    }
+    let entries =
+        fs::read_dir(dir).with_context(|| format!("failed to read dir {}", dir.display()))?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let meta = match path.symlink_metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_symlink() {
+            // Check if the symlink target exists (broken = target missing)
+            if !path.exists() {
+                match fs::remove_file(&path) {
+                    Ok(()) => {
+                        println!("  🗑️  Removed broken symlink: {}", path.display());
+                        *removed += 1;
+                    }
+                    Err(e) => {
+                        println!(
+                            "  ⚠️  Could not remove broken symlink {}: {}",
+                            path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        } else if recursive && meta.is_dir() {
+            clean_broken_symlinks_inner(&path, recursive, removed, depth + 1)?;
+        }
     }
     Ok(())
 }

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -316,6 +316,23 @@ fn local_install(repo_root: &Path) -> Result<()> {
     create_runtime_dirs(&claude_dir)?;
 
     println!();
+    println!("🧹 Cleaning broken symlinks:");
+    let broken_count = filesystem::clean_broken_symlinks(&claude_dir, true)?;
+    if broken_count > 0 {
+        println!("   Removed {broken_count} broken symlink(s)");
+    } else {
+        println!("   No broken symlinks found");
+    }
+    // Also clean broken symlinks in ~/.local/bin (stale gadugi-test, etc.)
+    if let Ok(home) = paths::home_dir() {
+        let local_bin = home.join(".local").join("bin");
+        let local_broken = filesystem::clean_broken_symlinks(&local_bin, false)?;
+        if local_broken > 0 {
+            println!("   Removed {local_broken} broken symlink(s) from ~/.local/bin");
+        }
+    }
+
+    println!();
     println!("⚙️  Configuring settings.json:");
     let (settings_ok, registered_events) =
         ensure_settings_json(&claude_dir, timestamp, &hooks_bin)?;

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -37,6 +37,7 @@ pub(super) fn execute_recipe_via_rust(
         .with_session_tree_context()
         .with_amplihack_home()
         .with_asset_resolver()
+        .with_python_sanitization()
         .with_project_graph_db(working_dir)?
         .apply_to_command(&mut command);
 

--- a/crates/amplihack-cli/src/env_builder/builder.rs
+++ b/crates/amplihack-cli/src/env_builder/builder.rs
@@ -5,8 +5,9 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use super::helpers::{
-    build_path, find_asset_resolver_binary, generate_session_id, resolve_session_tree_depth,
-    resolve_session_tree_id, session_tree_context_present,
+    build_path, find_asset_resolver_binary, generate_session_id, is_file_python_script,
+    is_python_amplihack_path, resolve_session_tree_depth, resolve_session_tree_id,
+    session_tree_context_present,
 };
 
 /// Builder for constructing the environment passed to child processes.
@@ -289,6 +290,68 @@ impl EnvBuilder {
                 "AMPLIHACK_ASSET_RESOLVER",
                 path.to_string_lossy().into_owned(),
             );
+        }
+
+        self
+    }
+
+    /// Sanitize the child process environment to prevent re-entry into the
+    /// Python amplihack stack.
+    ///
+    /// When agent subprocesses are spawned by the Rust recipe runner, they may
+    /// inherit PATH/PYTHONPATH entries that cause them to pick up the Python
+    /// `amplihack` package instead of the Rust binary. This method:
+    ///
+    /// 1. Removes PYTHONPATH entries containing `amplihack` (but not `amplihack-rs`)
+    /// 2. Filters PATH entries that contain a Python `amplihack` script that would
+    ///    shadow the Rust binary
+    /// 3. Unsets `PYTHONSTARTUP` if it references amplihack
+    pub fn with_python_sanitization(mut self) -> Self {
+        // Sanitize PYTHONPATH: remove entries referencing Python amplihack
+        if let Ok(pythonpath) = env::var("PYTHONPATH") {
+            let filtered: Vec<&str> = pythonpath
+                .split(':')
+                .filter(|entry| !is_python_amplihack_path(entry))
+                .collect();
+            if filtered.is_empty() {
+                self.removed_vars.insert("PYTHONPATH".to_string());
+            } else {
+                let cleaned = filtered.join(":");
+                if cleaned != pythonpath {
+                    self = self.set("PYTHONPATH", cleaned);
+                }
+            }
+        }
+
+        // Sanitize PYTHONSTARTUP if it references amplihack
+        if let Ok(startup) = env::var("PYTHONSTARTUP") {
+            if startup.contains("amplihack") && !startup.contains("amplihack-rs") {
+                self.removed_vars.insert("PYTHONSTARTUP".to_string());
+            }
+        }
+
+        // Filter PATH: remove directories containing a Python amplihack that
+        // would shadow the Rust binary. We mark dirs for removal if they contain
+        // an `amplihack` file that is a Python script (not an ELF binary).
+        if let Ok(path_var) = env::var("PATH") {
+            let filtered: Vec<&str> = path_var
+                .split(':')
+                .filter(|dir| {
+                    if dir.is_empty() {
+                        return true;
+                    }
+                    let candidate = Path::new(dir).join("amplihack");
+                    if !candidate.is_file() {
+                        return true; // no amplihack binary here, keep dir
+                    }
+                    // Keep the dir if the amplihack binary is NOT a Python script
+                    !is_file_python_script(&candidate)
+                })
+                .collect();
+            let cleaned = filtered.join(":");
+            if cleaned != path_var {
+                self = self.set("PATH", cleaned);
+            }
         }
 
         self

--- a/crates/amplihack-cli/src/env_builder/helpers.rs
+++ b/crates/amplihack-cli/src/env_builder/helpers.rs
@@ -127,3 +127,38 @@ pub(super) fn resolve_session_tree_depth(increment: bool) -> String {
     };
     depth.to_string()
 }
+
+/// Check whether a PATH/PYTHONPATH entry looks like it references the Python
+/// amplihack package (not amplihack-rs).
+pub(super) fn is_python_amplihack_path(entry: &str) -> bool {
+    if entry.is_empty() {
+        return false;
+    }
+    // Match paths containing amplihack that aren't amplihack-rs
+    let lower = entry.to_lowercase();
+    (lower.contains("amplihack") && !lower.contains("amplihack-rs") && !lower.contains("amplihack_rs"))
+        // Also catch pip/site-packages installs
+        || (lower.contains("site-packages") && lower.contains("amplihack"))
+}
+
+/// Check whether a file is a Python script by reading its shebang or checking extension.
+pub(super) fn is_file_python_script(path: &std::path::Path) -> bool {
+    if path.extension().and_then(|e| e.to_str()) == Some("py") {
+        return true;
+    }
+    // Read just enough bytes to check for a Python shebang
+    if let Ok(file) = std::fs::File::open(path) {
+        use std::io::Read;
+        let mut buf = [0u8; 128];
+        let mut reader = std::io::BufReader::new(file);
+        if let Ok(n) = reader.read(&mut buf) {
+            if let Ok(first_line) = std::str::from_utf8(&buf[..n]) {
+                if let Some(line) = first_line.lines().next() {
+                    return line.starts_with("#!")
+                        && (line.contains("python") || line.contains("Python"));
+                }
+            }
+        }
+    }
+    false
+}

--- a/crates/amplihack-utils/src/simple_tui_types.rs
+++ b/crates/amplihack-utils/src/simple_tui_types.rs
@@ -119,9 +119,36 @@ pub fn is_ci_environment() -> bool {
 /// Check whether the `gadugi-test` binary is reachable through `npx`.
 ///
 /// Returns `false` in CI environments to avoid hanging on auto-install prompts.
+/// Also detects stale/broken npx cache entries that would cause runtime failures.
 pub fn check_gadugi_available() -> bool {
     if is_ci_environment() {
         return false;
+    }
+
+    // Check for broken gadugi-test symlinks in the npx cache before probing.
+    // Stale cache entries can cause npx to report success while the binary
+    // is actually unreachable (issue #229).
+    if let Ok(home) = std::env::var("HOME") {
+        let npx_cache = std::path::PathBuf::from(&home).join(".npm").join("_npx");
+        if npx_cache.is_dir() {
+            if let Ok(entries) = std::fs::read_dir(&npx_cache) {
+                for entry in entries.flatten() {
+                    let gadugi_bin = entry
+                        .path()
+                        .join("node_modules")
+                        .join(".bin")
+                        .join("gadugi-test");
+                    // Check for broken symlink: symlink_metadata succeeds but
+                    // the target doesn't exist
+                    if let Ok(meta) = gadugi_bin.symlink_metadata() {
+                        if meta.file_type().is_symlink() && !gadugi_bin.exists() {
+                            // Remove the broken symlink silently
+                            let _ = std::fs::remove_file(&gadugi_bin);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // Verify npx itself is available.


### PR DESCRIPTION
## Summary

Fixes three related install/path issues:

### #225 — Python amplihack shadows Rust binary on PATH
- Enhanced `deploy_binaries()` to detect when a Python `amplihack` script shadows the Rust binary
- Reads file shebang to distinguish Python scripts from ELF binaries
- Provides specific remediation: remove script, reorder PATH, or pip uninstall

### #228 — Recipe runner subprocess tree re-enters Python amplihack stack
- Added `with_python_sanitization()` method to `EnvBuilder`
- Removes PYTHONPATH entries referencing Python amplihack (not amplihack-rs)
- Filters PATH directories containing Python amplihack scripts
- Unsets PYTHONSTARTUP if it references amplihack
- Applied in `execute_recipe_via_rust()` before spawning child processes

### #229 — Stale broken gadugi-test symlink in npm-packages cache
- Added `clean_broken_symlinks()` to install filesystem module
- Install now cleans broken symlinks in `~/.amplihack/.claude` and `~/.local/bin`
- Hardened `check_gadugi_available()` to detect and remove stale gadugi-test symlinks in npx cache

## Testing
- `cargo check` passes
- `cargo test --lib -p amplihack-cli` — all tests pass
- `cargo test --lib -p amplihack-utils` — all tests pass

Closes #225, closes #228, closes #229