### PR TITLE
feat: add native Rust multitask subcommand

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -56,6 +56,10 @@ context:
   # Workstream name for parallel workflows (optional)
   workstream: ""
 
+  # Resume support: set to a checkpoint ID to skip steps already completed.
+  # Valid values: "", "checkpoint-after-implementation", "checkpoint-after-review-feedback"
+  resume_checkpoint: ""
+
   # Outputs populated during execution
   clarified_requirements: ""
   issue_number: ""
@@ -709,6 +713,7 @@ steps:
   # ==========================================================================
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -738,6 +743,7 @@ steps:
   # ==========================================================================
   - id: "step-08-implement"
     agent: "amplihack:builder"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -767,6 +773,7 @@ steps:
 
   - id: "step-08b-integration"
     agent: "amplihack:integration"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8b: External Service Integration
 
@@ -787,6 +794,7 @@ steps:
   # --------------------------------------------------------------------------
   - id: "checkpoint-after-implementation"
     type: "bash"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     # FIX (#4231): Limit env var size to prevent E2BIG when prior steps
     # (implementation, test_spec, design_spec) produce large outputs.
     max_env_value_bytes: 65536

--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -4,7 +4,7 @@ use clap::Subcommand;
 use clap_complete::Shell;
 use std::path::PathBuf;
 
-use super::{MemoryCommands, ModeCommands, PluginCommands, QueryCodeCommands, RecipeCommands};
+use super::{MemoryCommands, ModeCommands, MultitaskCommands, PluginCommands, QueryCodeCommands, RecipeCommands};
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
@@ -315,4 +315,10 @@ pub enum Commands {
 
     /// Run system health checks
     Doctor,
+
+    /// Parallel workstream orchestrator (native Rust)
+    Multitask {
+        #[command(subcommand)]
+        command: MultitaskCommands,
+    },
 }

--- a/crates/amplihack-cli/src/cli_subcommands.rs
+++ b/crates/amplihack-cli/src/cli_subcommands.rs
@@ -216,3 +216,41 @@ pub enum ModeCommands {
     /// Switch to local mode
     ToLocal,
 }
+
+#[derive(Subcommand, Debug)]
+pub enum MultitaskCommands {
+    /// Run parallel workstreams from a JSON config file
+    Run {
+        /// Path to workstreams JSON config file
+        config: String,
+        /// Execution mode
+        #[arg(long, default_value = "recipe", value_parser = ["recipe", "classic"])]
+        mode: String,
+        /// Recipe name for recipe mode
+        #[arg(long, default_value = "default-workflow")]
+        recipe: String,
+        /// Override workstream runtime budget in seconds
+        #[arg(long = "max-runtime")]
+        max_runtime: Option<u64>,
+        /// Timeout policy for active workstreams
+        #[arg(long = "timeout-policy", value_parser = ["interrupt-preserve", "continue-preserve"])]
+        timeout_policy: Option<String>,
+        /// Show what would be executed without launching
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Clean up workstreams with merged PRs
+    Cleanup {
+        /// Path to workstreams JSON config file
+        config: String,
+        /// Show what would be deleted without deleting
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show status of existing workstreams
+    Status {
+        /// Base directory for workstream artifacts
+        #[arg(long = "base-dir")]
+        base_dir: Option<String>,
+    },
+}

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod install;
 pub mod launch;
 pub mod memory;
 pub mod mode;
+pub mod multitask;
 pub mod new_agent;
 pub mod plugin;
 pub mod query_code;
@@ -17,7 +18,7 @@ pub mod recipe;
 pub mod rustyclawd;
 pub mod uvx_help;
 
-use crate::{Commands, MemoryCommands, ModeCommands, PluginCommands, RecipeCommands};
+use crate::{Commands, MemoryCommands, ModeCommands, MultitaskCommands, PluginCommands, RecipeCommands};
 use anyhow::Result;
 
 /// Dispatch a parsed CLI command to the appropriate handler.
@@ -305,6 +306,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
         Commands::UvxHelp { find_path, info } => uvx_help::run_uvx_help(find_path, info),
         Commands::Completions { shell } => completions::run_completions(shell),
         Commands::Doctor => doctor::run_doctor(),
+        Commands::Multitask { command } => dispatch_multitask(command),
     }
 }
 
@@ -389,5 +391,27 @@ fn dispatch_mode(command: ModeCommands) -> Result<()> {
         ModeCommands::Detect => mode::run_detect(),
         ModeCommands::ToPlugin => mode::run_to_plugin(),
         ModeCommands::ToLocal => mode::run_to_local(),
+    }
+}
+
+fn dispatch_multitask(command: MultitaskCommands) -> Result<()> {
+    match command {
+        MultitaskCommands::Run {
+            config,
+            mode,
+            recipe,
+            max_runtime,
+            timeout_policy,
+            dry_run,
+        } => multitask::run_multitask(
+            &config,
+            &mode,
+            &recipe,
+            max_runtime,
+            timeout_policy.as_deref(),
+            dry_run,
+        ),
+        MultitaskCommands::Cleanup { config, dry_run } => multitask::run_cleanup(&config, dry_run),
+        MultitaskCommands::Status { base_dir } => multitask::run_status(base_dir.as_deref()),
     }
 }

--- a/crates/amplihack-cli/src/commands/multitask/mod.rs
+++ b/crates/amplihack-cli/src/commands/multitask/mod.rs
@@ -1,0 +1,147 @@
+//! Native parallel workstream orchestrator (port of `multitask/orchestrator.py`).
+//!
+//! Executes multiple independent development workstreams in parallel, each in
+//! its own subprocess with isolated working directories. Supports recipe-based
+//! and classic execution modes, per-workstream timeout budgets, state
+//! persistence for resumption, and automatic cleanup of completed workstreams.
+
+mod models;
+mod orchestrator;
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Run parallel workstreams from a JSON config file.
+pub fn run_multitask(
+    config_path: &str,
+    mode: &str,
+    recipe: &str,
+    max_runtime: Option<u64>,
+    timeout_policy: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let config_text = std::fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read config file: {config_path}"))?;
+
+    let items: Vec<models::WorkstreamConfig> = serde_json::from_str(&config_text)
+        .with_context(|| format!("Failed to parse config file: {config_path}"))?;
+
+    if items.is_empty() {
+        eprintln!("No workstreams defined in {config_path}");
+        return Ok(());
+    }
+
+    let repo_url = detect_repo_url();
+
+    let mut orch = orchestrator::ParallelOrchestrator::new(&repo_url, mode);
+
+    if let Some(max_rt) = max_runtime {
+        orch.set_default_max_runtime(max_rt);
+    }
+    if let Some(policy) = timeout_policy {
+        orch.set_default_timeout_policy(policy);
+    }
+
+    orch.setup()?;
+
+    for item in &items {
+        orch.add(item, recipe)?;
+    }
+
+    if dry_run {
+        println!("Dry-run: {} workstreams would be launched", items.len());
+        for item in &items {
+            println!("  [{}] {} (recipe: {})", item.issue, item.description_or_default(), item.recipe.as_deref().unwrap_or(recipe));
+        }
+        return Ok(());
+    }
+
+    // Install signal handler for graceful shutdown
+    let running = orch.running_flag();
+    let r = running.clone();
+    ctrlc_flag(&r);
+
+    orch.launch_all()?;
+    orch.monitor(running)?;
+    let report = orch.report();
+    println!("{report}");
+
+    Ok(())
+}
+
+/// Clean up workstreams with merged PRs.
+pub fn run_cleanup(config_path: &str, dry_run: bool) -> Result<()> {
+    let repo_url = detect_repo_url();
+    let orch = orchestrator::ParallelOrchestrator::new(&repo_url, "recipe");
+    orch.cleanup_merged(config_path, dry_run)
+}
+
+/// Show status of existing workstreams.
+pub fn run_status(base_dir: Option<&str>) -> Result<()> {
+    let base = base_dir
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| orchestrator::default_base_dir());
+    let state_dir = Path::new(&base).join("state");
+
+    if !state_dir.exists() {
+        println!("No workstream state directory found at {}", state_dir.display());
+        return Ok(());
+    }
+
+    let mut found = false;
+    for entry in std::fs::read_dir(&state_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "json")
+            && !path.file_name().is_some_and(|n| n.to_string_lossy().contains(".progress."))
+        {
+            match std::fs::read_to_string(&path) {
+                Ok(text) => {
+                    if let Ok(state) = serde_json::from_str::<serde_json::Value>(&text) {
+                        let issue = state.get("issue").and_then(|v| v.as_i64()).unwrap_or(0);
+                        let lifecycle = state.get("lifecycle_state").and_then(|v| v.as_str()).unwrap_or("unknown");
+                        let step = state.get("current_step").and_then(|v| v.as_str()).unwrap_or("unknown");
+                        let branch = state.get("branch").and_then(|v| v.as_str()).unwrap_or("");
+                        println!("[{issue}] {lifecycle:20} step={step:30} branch={branch}");
+                        found = true;
+                    }
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+
+    if !found {
+        println!("No workstream state files found.");
+    }
+
+    Ok(())
+}
+
+fn detect_repo_url() -> String {
+    std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            std::env::var("AMPLIHACK_REPO_PATH")
+                .unwrap_or_else(|_| {
+                    let cwd = std::env::current_dir()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_else(|_| ".".to_string());
+                    eprintln!("WARNING: No git remote 'origin'; using local path: {cwd}");
+                    cwd
+                })
+        })
+}
+
+fn ctrlc_flag(flag: &std::sync::Arc<std::sync::atomic::AtomicBool>) {
+    let f = flag.clone();
+    // Best-effort: if signal registration fails, Ctrl-C will kill the process
+    // immediately instead of triggering graceful shutdown.
+    let _ = signal_hook::flag::register(signal_hook::consts::SIGINT, f);
+}

--- a/crates/amplihack-cli/src/commands/multitask/models.rs
+++ b/crates/amplihack-cli/src/commands/multitask/models.rs
@@ -1,0 +1,201 @@
+//! Data models for the parallel workstream orchestrator.
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+use std::time::Instant;
+
+/// Regex for sanitizing IDs to filesystem-safe strings.
+static SAFE_ID_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[^a-zA-Z0-9_-]").unwrap());
+
+/// Sanitize an identifier for use in filesystem paths.
+pub fn sanitize_id(raw: &str) -> String {
+    SAFE_ID_RE.replace_all(raw, "_").to_string()
+}
+
+/// Default max runtime for workstreams (2 hours).
+pub const DEFAULT_MAX_RUNTIME: u64 = 7200;
+
+/// Timeout policy: interrupt the subprocess and preserve state.
+pub const INTERRUPT_PRESERVE_TIMEOUT_POLICY: &str = "interrupt-preserve";
+/// Timeout policy: mark timed-out but let the subprocess continue.
+pub const CONTINUE_PRESERVE_TIMEOUT_POLICY: &str = "continue-preserve";
+/// Default timeout policy.
+pub const DEFAULT_TIMEOUT_POLICY: &str = INTERRUPT_PRESERVE_TIMEOUT_POLICY;
+
+/// Lifecycle states that can be resumed.
+#[allow(dead_code)]
+pub const RESUMABLE_STATES: &[&str] = &[
+    "failed_resumable",
+    "timed_out_resumable",
+    "interrupted_resumable",
+];
+
+/// Lifecycle states eligible for cleanup.
+pub const CLEANUP_ELIGIBLE_STATES: &[&str] = &["completed", "failed_terminal", "abandoned"];
+
+/// JSON config entry for a workstream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkstreamConfig {
+    pub issue: serde_json::Value,
+    pub branch: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub task: String,
+    #[serde(default)]
+    pub recipe: Option<String>,
+    #[serde(default)]
+    pub max_runtime: Option<u64>,
+    #[serde(default)]
+    pub timeout_policy: Option<String>,
+}
+
+impl WorkstreamConfig {
+    pub fn issue_id(&self) -> i64 {
+        match &self.issue {
+            serde_json::Value::Number(n) => n.as_i64().unwrap_or(0),
+            serde_json::Value::String(s) => s.parse().unwrap_or(0),
+            _ => 0,
+        }
+    }
+
+    pub fn description_or_default(&self) -> String {
+        self.description
+            .clone()
+            .unwrap_or_else(|| format!("Issue #{}", self.issue_id()))
+    }
+}
+
+/// Runtime state for a single workstream.
+#[derive(Debug)]
+pub struct Workstream {
+    pub issue: i64,
+    pub branch: String,
+    pub description: String,
+    pub task: String,
+    pub recipe: String,
+    pub work_dir: PathBuf,
+    pub log_file: PathBuf,
+    pub state_file: PathBuf,
+    pub progress_file: PathBuf,
+    pub pid: Option<u32>,
+    pub start_time: Option<Instant>,
+    pub end_time: Option<Instant>,
+    pub exit_code: Option<i32>,
+    pub lifecycle_state: String,
+    pub cleanup_eligible: bool,
+    pub worktree_path: String,
+    pub checkpoint_id: String,
+    pub last_step: String,
+    pub attempt: u32,
+    pub timeout_policy: String,
+    pub max_runtime: u64,
+    pub resume_checkpoint: String,
+}
+
+impl Workstream {
+    pub fn new(
+        issue: i64,
+        branch: String,
+        description: String,
+        task: String,
+        recipe: String,
+        base_dir: &PathBuf,
+        state_dir: &PathBuf,
+    ) -> Self {
+        let safe_id = sanitize_id(&issue.to_string());
+        Self {
+            issue,
+            branch,
+            description,
+            task,
+            recipe,
+            work_dir: base_dir.join(format!("ws-{issue}")),
+            log_file: base_dir.join(format!("log-{safe_id}.txt")),
+            state_file: state_dir.join(format!("ws-{safe_id}.json")),
+            progress_file: state_dir.join(format!("ws-{safe_id}.progress.json")),
+            pid: None,
+            start_time: None,
+            end_time: None,
+            exit_code: None,
+            lifecycle_state: "pending".to_string(),
+            cleanup_eligible: false,
+            worktree_path: String::new(),
+            checkpoint_id: String::new(),
+            last_step: String::new(),
+            attempt: 0,
+            timeout_policy: DEFAULT_TIMEOUT_POLICY.to_string(),
+            max_runtime: DEFAULT_MAX_RUNTIME,
+            resume_checkpoint: String::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_running(&self) -> bool {
+        if let Some(pid) = self.pid {
+            unsafe { libc::kill(pid as i32, 0) == 0 }
+        } else {
+            false
+        }
+    }
+
+    pub fn runtime_seconds(&self) -> Option<f64> {
+        self.start_time.map(|start| {
+            let end = self.end_time.unwrap_or_else(Instant::now);
+            end.duration_since(start).as_secs_f64()
+        })
+    }
+
+    pub fn derive_cleanup_eligible(lifecycle_state: &str) -> bool {
+        CLEANUP_ELIGIBLE_STATES.contains(&lifecycle_state)
+    }
+}
+
+/// Persisted state for a workstream (JSON on disk).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PersistedState {
+    #[serde(default)]
+    pub issue: i64,
+    #[serde(default)]
+    pub branch: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub task: String,
+    #[serde(default)]
+    pub recipe: String,
+    #[serde(default)]
+    pub lifecycle_state: String,
+    #[serde(default)]
+    pub cleanup_eligible: bool,
+    #[serde(default)]
+    pub attempt: u32,
+    #[serde(default)]
+    pub last_pid: Option<u32>,
+    #[serde(default)]
+    pub last_exit_code: Option<i32>,
+    #[serde(default)]
+    pub current_step: String,
+    #[serde(default)]
+    pub checkpoint_id: String,
+    #[serde(default)]
+    pub work_dir: String,
+    #[serde(default)]
+    pub worktree_path: String,
+    #[serde(default)]
+    pub log_file: String,
+    #[serde(default)]
+    pub progress_sidecar: String,
+    #[serde(default)]
+    pub max_runtime: Option<u64>,
+    #[serde(default)]
+    pub timeout_policy: Option<String>,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+    #[serde(default)]
+    pub resume_context: Option<HashMap<String, serde_json::Value>>,
+}

--- a/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
+++ b/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
@@ -1,0 +1,1113 @@
+//! Core orchestrator logic for parallel workstream execution.
+//!
+//! Port of `multitask/orchestrator.py` — manages workstream lifecycle,
+//! subprocess spawning, output tailing, timeout enforcement, state persistence,
+//! and reporting.
+
+use super::models::*;
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+use tracing::{debug, warn};
+
+/// Default base directory for workstream artifacts.
+pub fn default_base_dir() -> String {
+    format!(
+        "{}/amplihack-workstreams",
+        std::env::temp_dir().to_string_lossy()
+    )
+}
+
+/// Valid delegate commands for subprocess execution.
+const VALID_DELEGATES: &[&str] = &[
+    "amplihack claude",
+    "amplihack copilot",
+    "amplihack amplifier",
+];
+
+pub struct ParallelOrchestrator {
+    repo_url: String,
+    base_dir: PathBuf,
+    state_dir: PathBuf,
+    mode: String,
+    workstreams: Vec<Workstream>,
+    processes: HashMap<i64, Arc<Mutex<Option<Child>>>>,
+    cleaned_up: std::collections::HashSet<i64>,
+    freed_bytes: u64,
+    default_max_runtime: u64,
+    default_timeout_policy: String,
+    default_branch: Option<String>,
+}
+
+impl ParallelOrchestrator {
+    pub fn new(repo_url: &str, mode: &str) -> Self {
+        Self {
+            repo_url: repo_url.to_string(),
+            base_dir: PathBuf::from(default_base_dir()),
+            state_dir: PathBuf::from(default_base_dir()).join("state"),
+            mode: mode.to_string(),
+            workstreams: Vec::new(),
+            processes: HashMap::new(),
+            cleaned_up: std::collections::HashSet::new(),
+            freed_bytes: 0,
+            default_max_runtime: DEFAULT_MAX_RUNTIME,
+            default_timeout_policy: DEFAULT_TIMEOUT_POLICY.to_string(),
+            default_branch: None,
+        }
+    }
+
+    pub fn set_default_max_runtime(&mut self, max_runtime: u64) {
+        self.default_max_runtime = max_runtime;
+    }
+
+    pub fn set_default_timeout_policy(&mut self, policy: &str) {
+        if policy == INTERRUPT_PRESERVE_TIMEOUT_POLICY
+            || policy == CONTINUE_PRESERVE_TIMEOUT_POLICY
+        {
+            self.default_timeout_policy = policy.to_string();
+        } else {
+            warn!(
+                "Invalid timeout policy {policy:?}; using default {DEFAULT_TIMEOUT_POLICY:?}"
+            );
+        }
+    }
+
+    pub fn running_flag(&self) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(true))
+    }
+
+    pub fn setup(&self) -> Result<()> {
+        fs::create_dir_all(&self.base_dir)
+            .with_context(|| format!("Failed to create base dir: {}", self.base_dir.display()))?;
+        fs::create_dir_all(&self.state_dir).with_context(|| {
+            format!("Failed to create state dir: {}", self.state_dir.display())
+        })?;
+
+        // Check disk space
+        self.check_disk_space(5.0)?;
+        Ok(())
+    }
+
+    pub fn add(&mut self, config: &WorkstreamConfig, default_recipe: &str) -> Result<()> {
+        let issue = config.issue_id();
+        if issue <= 0 {
+            bail!("Invalid issue number: {}", config.issue);
+        }
+
+        let recipe = config
+            .recipe
+            .as_deref()
+            .unwrap_or(default_recipe)
+            .to_string();
+
+        let mut ws = Workstream::new(
+            issue,
+            config.branch.clone(),
+            config.description_or_default(),
+            config.task.clone(),
+            recipe,
+            &self.base_dir,
+            &self.state_dir,
+        );
+
+        // Apply runtime overrides
+        ws.max_runtime = config.max_runtime.unwrap_or(self.default_max_runtime);
+        ws.timeout_policy = config
+            .timeout_policy
+            .clone()
+            .unwrap_or_else(|| self.default_timeout_policy.clone());
+
+        // Load any saved state
+        let saved = load_state(&ws.state_file);
+        if let Some(ref state) = saved {
+            self.apply_saved_state(&mut ws, state);
+        }
+
+        let reuse_existing =
+            saved.is_some() && !ws.cleanup_eligible && ws.work_dir.exists();
+
+        if !reuse_existing && ws.work_dir.exists() {
+            let _ = fs::remove_dir_all(&ws.work_dir);
+        }
+
+        let default_branch = self.resolve_default_branch();
+
+        if reuse_existing {
+            println!("[{}] Reusing preserved work dir {}", issue, ws.work_dir.display());
+        } else {
+            println!(
+                "[{}] Cloning default branch '{}' from remote...",
+                issue, default_branch
+            );
+            let status = Command::new("git")
+                .args([
+                    "clone",
+                    "--depth=1",
+                    &format!("--branch={default_branch}"),
+                    &self.repo_url,
+                    &ws.work_dir.to_string_lossy(),
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .with_context(|| format!("[{issue}] Failed to spawn git clone"))?;
+
+            if !status.success() {
+                bail!("[{issue}] git clone failed with exit code {}", status);
+            }
+        }
+
+        fs::create_dir_all(&ws.work_dir)?;
+
+        // Write execution files
+        if self.mode == "recipe" {
+            self.write_recipe_launcher(&ws)?;
+        } else {
+            self.write_classic_launcher(&ws)?;
+        }
+
+        persist_state(&ws)?;
+        self.workstreams.push(ws);
+        Ok(())
+    }
+
+    pub fn launch_all(&mut self) -> Result<()> {
+        let delegate = self.detect_delegate();
+        let count = self.workstreams.len();
+
+        for i in 0..count {
+            self.launch_workstream(i, &delegate)?;
+        }
+
+        println!(
+            "\n{count} workstreams launched in parallel ({} mode)",
+            self.mode
+        );
+        Ok(())
+    }
+
+    fn launch_workstream(&mut self, idx: usize, delegate: &str) -> Result<()> {
+        let ws = &mut self.workstreams[idx];
+        let issue = ws.issue;
+
+        let mut env_vars: HashMap<String, String> = std::env::vars().collect();
+        env_vars.insert("AMPLIHACK_DELEGATE".to_string(), delegate.to_string());
+
+        let run_sh = ws.work_dir.join("run.sh");
+        let child = Command::new("bash")
+            .arg(&run_sh)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .current_dir(&ws.work_dir)
+            .envs(&env_vars)
+            .spawn()
+            .with_context(|| format!("[{issue}] Failed to launch workstream"))?;
+
+        ws.pid = Some(child.id());
+        ws.start_time = Some(Instant::now());
+        ws.end_time = None;
+        ws.exit_code = None;
+        ws.lifecycle_state = "running".to_string();
+        ws.cleanup_eligible = false;
+        ws.attempt += 1;
+
+        println!("[{issue}] Launched PID {} ({} mode)", child.id(), self.mode);
+
+        let child_arc = Arc::new(Mutex::new(Some(child)));
+        self.processes.insert(issue, child_arc.clone());
+
+        // Spawn output tailing thread
+        let log_file = ws.log_file.clone();
+        let max_log_bytes: u64 = std::env::var("AMPLIHACK_MAX_LOG_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(100 * 1024 * 1024);
+
+        thread::spawn(move || {
+            let mut child_guard = child_arc.lock().unwrap();
+            if let Some(ref mut child) = *child_guard {
+                if let Some(stdout) = child.stdout.take() {
+                    drop(child_guard);
+                    tail_output(stdout, &log_file, issue, max_log_bytes);
+                }
+            }
+        });
+
+        persist_state(&self.workstreams[idx])?;
+        Ok(())
+    }
+
+    pub fn monitor(&mut self, running: Arc<AtomicBool>) -> Result<()> {
+        let check_interval = Duration::from_secs(10);
+        let start = Instant::now();
+
+        while running.load(Ordering::Relaxed) {
+            // Enforce per-workstream timeouts
+            self.enforce_timeouts();
+
+            let status = self.get_status();
+            let elapsed = start.elapsed().as_secs();
+            let now = Utc::now().format("%H:%M:%S");
+
+            println!(
+                "\n[{now}] Status (elapsed: {elapsed}s):\n  \
+                 Running:   {} {:?}\n  \
+                 Completed: {} {:?}\n  \
+                 Failed:    {} {:?}",
+                status.running.len(),
+                status.running,
+                status.completed.len(),
+                status.completed,
+                status.failed.len(),
+                status.failed,
+            );
+
+            // Emit JSONL heartbeat to stderr
+            let heartbeat = serde_json::json!({
+                "type": "heartbeat",
+                "ts": Utc::now().timestamp_millis() as f64 / 1000.0,
+                "elapsed_s": elapsed,
+                "summary": {
+                    "running": status.running.len(),
+                    "completed": status.completed.len(),
+                    "failed": status.failed.len(),
+                    "total": self.workstreams.len(),
+                },
+            });
+            eprintln!("{}", serde_json::to_string(&heartbeat).unwrap_or_default());
+
+            // Auto-cleanup completed workstream directories
+            for ws in &self.workstreams {
+                if !self.cleaned_up.contains(&ws.issue) && ws.exit_code.is_some() {
+                    if Workstream::derive_cleanup_eligible(&ws.lifecycle_state) {
+                        self.cleanup_workstream_dir(ws);
+                    }
+                }
+            }
+
+            if status.running.is_empty() {
+                break;
+            }
+
+            thread::sleep(check_interval);
+        }
+
+        // If interrupted, terminate remaining
+        if !running.load(Ordering::Relaxed) {
+            println!("\nInterrupted! Cleaning up workstreams...");
+            self.cleanup_running();
+        }
+
+        Ok(())
+    }
+
+    pub fn report(&self) -> String {
+        let mut lines = vec![
+            String::new(),
+            "=".repeat(70),
+            "PARALLEL WORKSTREAM REPORT".to_string(),
+            format!("Mode: {}", self.mode),
+            "=".repeat(70),
+        ];
+
+        let mut succeeded = 0u32;
+        let mut failed = 0u32;
+
+        for ws in &self.workstreams {
+            let runtime = ws
+                .runtime_seconds()
+                .map(|s| format!("{s:.0}s"))
+                .unwrap_or_else(|| "N/A".to_string());
+
+            let status = if ws.exit_code == Some(0) {
+                succeeded += 1;
+                "OK".to_string()
+            } else {
+                failed += 1;
+                format!(
+                    "FAILED (exit {})",
+                    ws.exit_code.map(|c| c.to_string()).unwrap_or_else(|| "?".to_string())
+                )
+            };
+
+            lines.push(format!("\n[{}] {}", ws.issue, ws.description));
+            lines.push(format!("  Branch:    {}", ws.branch));
+            lines.push(format!("  Status:    {status}"));
+            lines.push(format!("  Lifecycle: {}", ws.lifecycle_state));
+            lines.push(format!("  Runtime:   {runtime}"));
+            lines.push(format!(
+                "  Checkpoint: {}",
+                if ws.checkpoint_id.is_empty() { "n/a" } else { &ws.checkpoint_id }
+            ));
+            lines.push(format!(
+                "  Worktree: {}",
+                if ws.worktree_path.is_empty() { "n/a" } else { &ws.worktree_path }
+            ));
+            lines.push(format!("  Log:       {}", ws.log_file.display()));
+            lines.push(format!("  Cleanup eligible: {}", ws.cleanup_eligible));
+        }
+
+        let freed_gb = self.freed_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+        lines.push(String::new());
+        lines.push("-".repeat(70));
+        lines.push(format!(
+            "Total: {} | Succeeded: {succeeded} | Failed: {failed}",
+            self.workstreams.len()
+        ));
+        lines.push(String::new());
+        lines.push("DISK MANAGEMENT:".to_string());
+        lines.push(format!(
+            "  Auto-cleaned: {} workstream dirs ({freed_gb:.2}GB freed)",
+            self.cleaned_up.len()
+        ));
+        lines.push(format!(
+            "  Log files preserved at: {}/log-*.txt",
+            self.base_dir.display()
+        ));
+        lines.push("=".repeat(70));
+
+        let report_text = lines.join("\n");
+
+        // Write report to file
+        let report_file = self.base_dir.join("REPORT.md");
+        if let Err(e) = fs::write(&report_file, &report_text) {
+            warn!("Failed to write report to {}: {e}", report_file.display());
+        } else {
+            println!("Report saved to: {}", report_file.display());
+        }
+
+        report_text
+    }
+
+    pub fn cleanup_merged(&self, config_path: &str, dry_run: bool) -> Result<()> {
+        let config_text = fs::read_to_string(config_path)
+            .with_context(|| format!("Failed to read config: {config_path}"))?;
+        let items: Vec<WorkstreamConfig> = serde_json::from_str(&config_text)?;
+
+        let mut deleted_count = 0u32;
+        let mut freed_bytes = 0u64;
+
+        for item in &items {
+            let issue = item.issue_id();
+            let safe_id = sanitize_id(&issue.to_string());
+            let work_dir = self.base_dir.join(format!("ws-{issue}"));
+            let state_file = self.state_dir.join(format!("ws-{safe_id}.json"));
+
+            // Check if PR is merged via gh CLI
+            let is_merged = Command::new("gh")
+                .args(["pr", "view", &item.branch, "--json", "state", "-q", ".state"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .is_some_and(|s| s.trim() == "MERGED");
+
+            if !is_merged {
+                continue;
+            }
+
+            if work_dir.exists() {
+                let dir_size = dir_size_bytes(&work_dir);
+                if dry_run {
+                    println!(
+                        "[{issue}] Would delete work dir ({:.0}MB)",
+                        dir_size as f64 / (1024.0 * 1024.0)
+                    );
+                } else {
+                    let _ = fs::remove_dir_all(&work_dir);
+                    let _ = fs::remove_file(&state_file);
+                    println!(
+                        "[{issue}] Deleted work dir ({:.0}MB freed)",
+                        dir_size as f64 / (1024.0 * 1024.0)
+                    );
+                }
+                freed_bytes += dir_size;
+                deleted_count += 1;
+            }
+        }
+
+        let freed_gb = freed_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+        println!(
+            "\n{}Summary:\n  Workstreams {}deleted: {deleted_count}\n  Disk space {}freed: {freed_gb:.2}GB",
+            if dry_run { "DRY RUN " } else { "" },
+            if dry_run { "would be " } else { "" },
+            if dry_run { "would be " } else { "" },
+        );
+
+        if dry_run && deleted_count > 0 {
+            println!("\nRun without --dry-run to actually delete these workstreams.");
+        }
+
+        Ok(())
+    }
+
+    // --- Private helpers ---
+
+    fn get_status(&mut self) -> WorkstreamStatus {
+        let mut status = WorkstreamStatus::default();
+
+        for ws in &mut self.workstreams {
+            let proc = self.processes.get(&ws.issue);
+
+            let maybe_code = proc.and_then(|arc| {
+                let mut guard = arc.lock().unwrap();
+                guard.as_mut().and_then(|child| child.try_wait().ok().flatten().map(|s| s.code().unwrap_or(-1)))
+            });
+
+            if let Some(code) = maybe_code {
+                finalize_workstream(ws, code);
+                if ws.lifecycle_state == "completed" {
+                    status.completed.push(ws.issue);
+                } else {
+                    status.failed.push(ws.issue);
+                }
+            } else if proc.is_some() && ws.exit_code.is_none() {
+                ws.lifecycle_state = "running".to_string();
+                status.running.push(ws.issue);
+            } else if ws.exit_code == Some(0) || ws.lifecycle_state == "completed" {
+                status.completed.push(ws.issue);
+            } else {
+                status.failed.push(ws.issue);
+            }
+        }
+
+        status
+    }
+
+    fn enforce_timeouts(&mut self) {
+        for ws in &mut self.workstreams {
+            if ws.lifecycle_state != "running" {
+                continue;
+            }
+            let Some(start) = ws.start_time else {
+                continue;
+            };
+            let elapsed = start.elapsed().as_secs();
+            if elapsed < ws.max_runtime {
+                continue;
+            }
+
+            let issue = ws.issue;
+            println!(
+                "[{issue}] Timed out after {}s, marking timed_out_resumable",
+                ws.max_runtime
+            );
+
+            if ws.timeout_policy == INTERRUPT_PRESERVE_TIMEOUT_POLICY {
+                if let Some(proc_arc) = self.processes.get(&issue) {
+                    let mut guard = proc_arc.lock().unwrap();
+                    if let Some(ref mut child) = *guard {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                    }
+                }
+            }
+
+            ws.lifecycle_state = "timed_out_resumable".to_string();
+            ws.end_time = Some(Instant::now());
+            let _ = persist_state(ws);
+        }
+    }
+
+    fn cleanup_running(&mut self) {
+        for ws in &mut self.workstreams {
+            if ws.lifecycle_state != "running" {
+                continue;
+            }
+            let issue = ws.issue;
+            if let Some(proc_arc) = self.processes.get(&issue) {
+                let mut guard = proc_arc.lock().unwrap();
+                if let Some(ref mut child) = *guard {
+                    println!("[{issue}] Terminating PID {}...", ws.pid.unwrap_or(0));
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+            }
+            ws.lifecycle_state = "interrupted_resumable".to_string();
+            ws.end_time = Some(Instant::now());
+            let _ = persist_state(ws);
+        }
+    }
+
+    fn cleanup_workstream_dir(&self, ws: &Workstream) {
+        if !ws.work_dir.exists() {
+            return;
+        }
+        let dir_size = dir_size_bytes(&ws.work_dir);
+        let _ = fs::remove_dir_all(&ws.work_dir);
+        let freed_mb = dir_size as f64 / (1024.0 * 1024.0);
+        println!(
+            "[{}] Cleaned up work dir ({freed_mb:.0}MB freed, log preserved at {})",
+            ws.issue,
+            ws.log_file.display()
+        );
+    }
+
+    fn detect_delegate(&self) -> String {
+        if let Ok(delegate) = std::env::var("AMPLIHACK_DELEGATE") {
+            if VALID_DELEGATES.contains(&delegate.as_str()) {
+                return delegate;
+            }
+            warn!(
+                "AMPLIHACK_DELEGATE={delegate:?} is not valid. Using default."
+            );
+        }
+        // Default to claude
+        "amplihack claude".to_string()
+    }
+
+    fn resolve_default_branch(&mut self) -> String {
+        if let Some(ref branch) = self.default_branch {
+            return branch.clone();
+        }
+
+        let branch = Command::new("git")
+            .args(["ls-remote", "--symref", &self.repo_url, "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .and_then(|out| {
+                out.lines()
+                    .find(|l| l.starts_with("ref: refs/heads/"))
+                    .and_then(|l| l.strip_prefix("ref: refs/heads/"))
+                    .and_then(|l| l.split('\t').next())
+                    .map(|s| s.trim().to_string())
+            })
+            .unwrap_or_else(|| "main".to_string());
+
+        self.default_branch = Some(branch.clone());
+        branch
+    }
+
+    fn write_recipe_launcher(&self, ws: &Workstream) -> Result<()> {
+        let resume_context = self.build_resume_context(ws);
+        let safe_recipe = serde_json::to_string(&ws.recipe)?;
+        let safe_context = serde_json::to_string(&resume_context)?;
+
+        let launcher_py = ws.work_dir.join("launcher.py");
+        let launcher_content = format!(
+            r#"#!/usr/bin/env python3
+"""Workstream launcher - Rust recipe runner execution."""
+import sys
+import json
+import logging
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parent
+src_path = repo_root / "src"
+if src_path.exists():
+    sys.path.insert(0, str(src_path))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
+try:
+    from amplihack.recipes import run_recipe_by_name
+except ImportError:
+    print("ERROR: amplihack package not importable.")
+    sys.exit(2)
+
+user_context = json.loads({safe_context})
+result = run_recipe_by_name(
+    {safe_recipe},
+    user_context=user_context,
+    progress=True,
+)
+
+print()
+print("=" * 60)
+print("RECIPE EXECUTION RESULTS")
+print("=" * 60)
+for sr in result.step_results:
+    print(f"  [{{sr.status.value:>9}}] {{sr.step_id}}")
+print(f"\nOverall: {{'SUCCESS' if result.success else 'FAILED'}}")
+sys.exit(0 if result.success else 1)
+"#
+        );
+        fs::write(&launcher_py, launcher_content)?;
+        set_executable(&launcher_py)?;
+
+        let depth: u32 = std::env::var("AMPLIHACK_SESSION_DEPTH")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let tree_id = std::env::var("AMPLIHACK_TREE_ID")
+            .unwrap_or_else(|_| format!("{:08x}", rand_u32()));
+        let max_depth = std::env::var("AMPLIHACK_MAX_DEPTH").unwrap_or_else(|_| "3".to_string());
+        let max_sessions =
+            std::env::var("AMPLIHACK_MAX_SESSIONS").unwrap_or_else(|_| "10".to_string());
+        let delegate = self.detect_delegate();
+
+        let run_sh = ws.work_dir.join("run.sh");
+        let run_content = format!(
+            r#"#!/bin/bash
+cd '{work_dir}'
+export AMPLIHACK_TREE_ID='{tree_id}'
+export AMPLIHACK_SESSION_DEPTH='{depth}'
+export AMPLIHACK_MAX_DEPTH='{max_depth}'
+export AMPLIHACK_MAX_SESSIONS='{max_sessions}'
+export AMPLIHACK_DELEGATE='{delegate}'
+export AMPLIHACK_WORKSTREAM_ISSUE='{issue}'
+export AMPLIHACK_WORKSTREAM_PROGRESS_FILE='{progress_file}'
+export AMPLIHACK_WORKSTREAM_STATE_FILE='{state_file}'
+export AMPLIHACK_WORKTREE_PATH='{worktree_path}'
+exec python3 -u launcher.py
+"#,
+            work_dir = ws.work_dir.display(),
+            depth = depth + 1,
+            issue = ws.issue,
+            progress_file = ws.progress_file.display(),
+            state_file = ws.state_file.display(),
+            worktree_path = ws.worktree_path,
+        );
+        fs::write(&run_sh, run_content)?;
+        set_executable(&run_sh)?;
+
+        Ok(())
+    }
+
+    fn write_classic_launcher(&self, ws: &Workstream) -> Result<()> {
+        let task_md = ws.work_dir.join("TASK.md");
+        fs::write(
+            &task_md,
+            format!(
+                "# Issue #{}\n\n{}\n\nFollow DEFAULT_WORKFLOW.md autonomously. \
+                 NO QUESTIONS. Work through Steps 0-22. Create PR when complete.",
+                ws.issue, ws.task
+            ),
+        )?;
+
+        let depth: u32 = std::env::var("AMPLIHACK_SESSION_DEPTH")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let tree_id = std::env::var("AMPLIHACK_TREE_ID")
+            .unwrap_or_else(|_| format!("{:08x}", rand_u32()));
+        let max_depth = std::env::var("AMPLIHACK_MAX_DEPTH").unwrap_or_else(|_| "3".to_string());
+        let max_sessions =
+            std::env::var("AMPLIHACK_MAX_SESSIONS").unwrap_or_else(|_| "10".to_string());
+        let delegate = self.detect_delegate();
+
+        let run_sh = ws.work_dir.join("run.sh");
+        let run_content = format!(
+            r#"#!/bin/bash
+cd '{work_dir}'
+export AMPLIHACK_TREE_ID='{tree_id}'
+export AMPLIHACK_SESSION_DEPTH='{depth}'
+export AMPLIHACK_MAX_DEPTH='{max_depth}'
+export AMPLIHACK_MAX_SESSIONS='{max_sessions}'
+{delegate} --subprocess-safe -- -p "@TASK.md Execute task autonomously following DEFAULT_WORKFLOW.md. NO QUESTIONS. Work through all steps. Create PR when complete."
+"#,
+            work_dir = ws.work_dir.display(),
+            depth = depth + 1,
+        );
+        fs::write(&run_sh, run_content)?;
+        set_executable(&run_sh)?;
+
+        Ok(())
+    }
+
+    fn build_resume_context(&self, ws: &Workstream) -> HashMap<String, serde_json::Value> {
+        let mut ctx = HashMap::new();
+        ctx.insert(
+            "task_description".to_string(),
+            serde_json::Value::String(ws.task.clone()),
+        );
+        ctx.insert(
+            "repo_path".to_string(),
+            serde_json::Value::String(".".to_string()),
+        );
+        ctx.insert(
+            "issue_number".to_string(),
+            serde_json::json!(ws.issue),
+        );
+        ctx.insert(
+            "workstream_state_file".to_string(),
+            serde_json::Value::String(ws.state_file.to_string_lossy().to_string()),
+        );
+        ctx.insert(
+            "workstream_progress_file".to_string(),
+            serde_json::Value::String(ws.progress_file.to_string_lossy().to_string()),
+        );
+        if !ws.resume_checkpoint.is_empty() {
+            ctx.insert(
+                "resume_checkpoint".to_string(),
+                serde_json::Value::String(ws.resume_checkpoint.clone()),
+            );
+        }
+        if !ws.worktree_path.is_empty() {
+            ctx.insert(
+                "worktree_setup".to_string(),
+                serde_json::json!({
+                    "worktree_path": ws.worktree_path,
+                    "branch_name": ws.branch,
+                    "created": false,
+                }),
+            );
+        }
+        ctx
+    }
+
+    fn apply_saved_state(&self, ws: &mut Workstream, state: &PersistedState) {
+        if !state.branch.is_empty() {
+            ws.branch = state.branch.clone();
+        }
+        if !state.description.is_empty() {
+            ws.description = state.description.clone();
+        }
+        if !state.lifecycle_state.is_empty() {
+            ws.lifecycle_state = state.lifecycle_state.clone();
+        }
+        ws.cleanup_eligible = state.cleanup_eligible
+            || Workstream::derive_cleanup_eligible(&ws.lifecycle_state);
+        if !state.worktree_path.is_empty() {
+            ws.worktree_path = state.worktree_path.clone();
+        }
+        if !state.checkpoint_id.is_empty() {
+            ws.checkpoint_id = state.checkpoint_id.clone();
+            ws.resume_checkpoint = state.checkpoint_id.clone();
+        }
+        if !state.current_step.is_empty() {
+            ws.last_step = state.current_step.clone();
+        }
+        ws.attempt = state.attempt;
+        if let Some(max_rt) = state.max_runtime {
+            ws.max_runtime = max_rt;
+        }
+        if let Some(ref policy) = state.timeout_policy {
+            ws.timeout_policy = policy.clone();
+        }
+        ws.pid = state.last_pid;
+        if let Some(code) = state.last_exit_code {
+            ws.exit_code = Some(code);
+        }
+    }
+
+    fn check_disk_space(&self, min_free_gb: f64) -> Result<()> {
+        // Use statvfs to check available space
+        let path_cstr = std::ffi::CString::new(self.base_dir.to_string_lossy().as_bytes())?;
+        unsafe {
+            let mut stat: libc::statvfs = std::mem::zeroed();
+            if libc::statvfs(path_cstr.as_ptr(), &mut stat) == 0 {
+                let free_bytes = stat.f_bavail as u64 * stat.f_frsize as u64;
+                let free_gb = free_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+                if free_gb < min_free_gb {
+                    bail!(
+                        "Insufficient disk space: {free_gb:.1}GB free, need {min_free_gb}GB minimum"
+                    );
+                }
+                debug!("Disk space check: {free_gb:.1}GB available");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Status snapshot for all workstreams.
+#[derive(Default)]
+struct WorkstreamStatus {
+    running: Vec<i64>,
+    completed: Vec<i64>,
+    failed: Vec<i64>,
+}
+
+/// Finalize a workstream after its process exits.
+fn finalize_workstream(ws: &mut Workstream, exit_code: i32) {
+    if ws.end_time.is_none() {
+        ws.end_time = Some(Instant::now());
+    }
+    ws.exit_code = Some(exit_code);
+
+    if ws.lifecycle_state == "interrupted_resumable"
+        || (ws.lifecycle_state == "timed_out_resumable"
+            && ws.timeout_policy == INTERRUPT_PRESERVE_TIMEOUT_POLICY)
+    {
+        let _ = persist_state(ws);
+        return;
+    }
+
+    if exit_code == 0 {
+        ws.lifecycle_state = "completed".to_string();
+    } else if !ws.checkpoint_id.is_empty() {
+        ws.lifecycle_state = "failed_resumable".to_string();
+    } else {
+        ws.lifecycle_state = "failed_terminal".to_string();
+    }
+    ws.cleanup_eligible = Workstream::derive_cleanup_eligible(&ws.lifecycle_state);
+    let _ = persist_state(ws);
+}
+
+/// Load persisted state from a JSON file.
+fn load_state(state_file: &Path) -> Option<PersistedState> {
+    fs::read_to_string(state_file)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+}
+
+/// Persist workstream state to its JSON state file.
+fn persist_state(ws: &Workstream) -> Result<()> {
+    let now = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+    let existing = load_state(&ws.state_file);
+    let created_at = existing
+        .as_ref()
+        .and_then(|s| {
+            if s.created_at.is_empty() {
+                None
+            } else {
+                Some(s.created_at.clone())
+            }
+        })
+        .unwrap_or_else(|| now.clone());
+
+    let state = PersistedState {
+        issue: ws.issue,
+        branch: ws.branch.clone(),
+        description: ws.description.clone(),
+        task: ws.task.clone(),
+        recipe: ws.recipe.clone(),
+        lifecycle_state: ws.lifecycle_state.clone(),
+        cleanup_eligible: ws.cleanup_eligible,
+        attempt: ws.attempt,
+        last_pid: ws.pid,
+        last_exit_code: ws.exit_code,
+        current_step: if ws.last_step.is_empty() {
+            "unknown".to_string()
+        } else {
+            ws.last_step.clone()
+        },
+        checkpoint_id: ws.checkpoint_id.clone(),
+        work_dir: ws.work_dir.to_string_lossy().to_string(),
+        worktree_path: ws.worktree_path.clone(),
+        log_file: ws.log_file.to_string_lossy().to_string(),
+        progress_sidecar: ws.progress_file.to_string_lossy().to_string(),
+        max_runtime: Some(ws.max_runtime),
+        timeout_policy: Some(ws.timeout_policy.clone()),
+        created_at,
+        updated_at: now,
+        resume_context: existing.and_then(|s| s.resume_context),
+    };
+
+    let json = serde_json::to_string_pretty(&state)?;
+    atomic_write(&ws.state_file, json.as_bytes())?;
+    Ok(())
+}
+
+/// Tail subprocess output to a log file and prefixed stdout.
+fn tail_output(stdout: impl std::io::Read, log_file: &Path, issue_id: i64, max_log_bytes: u64) {
+    let reader = BufReader::new(stdout);
+    let mut log_bytes_written: u64 = 0;
+
+    // Open log file with 0o600 permissions
+    let log_fd = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(log_file);
+
+    let mut log_writer = log_fd.ok();
+
+    for line in reader.lines() {
+        let Ok(line) = line else { break };
+        let line_bytes = line.len() as u64 + 1; // +1 for newline
+
+        if log_bytes_written < max_log_bytes {
+            if log_bytes_written + line_bytes <= max_log_bytes {
+                if let Some(ref mut w) = log_writer {
+                    let _ = writeln!(w, "{line}");
+                    let _ = w.flush();
+                }
+                log_bytes_written += line_bytes;
+            }
+        }
+
+        // Prefix output to stdout
+        println!("[ws:{issue_id}] {line}");
+    }
+}
+
+/// Atomically write data to a file (write to tmp, then rename).
+fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp_path = path.with_extension("tmp");
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&tmp_path)?;
+    file.write_all(data)?;
+    file.flush()?;
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+/// Set a file as executable (chmod +x).
+fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+/// Calculate total size of a directory tree.
+fn dir_size_bytes(path: &Path) -> u64 {
+    let mut total = 0u64;
+    if let Ok(entries) = fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                total += entry.metadata().map(|m| m.len()).unwrap_or(0);
+            } else if path.is_dir() {
+                total += dir_size_bytes(&path);
+            }
+        }
+    }
+    total
+}
+
+/// Simple pseudo-random u32 using time-based seed (no external crate needed).
+fn rand_u32() -> u32 {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    (now.as_nanos() & 0xFFFF_FFFF) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_id() {
+        assert_eq!(sanitize_id("123"), "123");
+        assert_eq!(sanitize_id("hello-world"), "hello-world");
+        assert_eq!(sanitize_id("path/../../etc"), "path_______etc");
+        assert_eq!(sanitize_id("a b c"), "a_b_c");
+    }
+
+    #[test]
+    fn test_workstream_config_parsing() {
+        let json = r#"[
+            {
+                "issue": 42,
+                "branch": "feat/test",
+                "description": "Test workstream",
+                "task": "Do something",
+                "recipe": "default-workflow"
+            }
+        ]"#;
+        let configs: Vec<WorkstreamConfig> = serde_json::from_str(json).unwrap();
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].issue_id(), 42);
+        assert_eq!(configs[0].branch, "feat/test");
+        assert_eq!(configs[0].description_or_default(), "Test workstream");
+    }
+
+    #[test]
+    fn test_workstream_config_string_issue() {
+        let json = r#"[{"issue": "99", "branch": "b", "task": "t"}]"#;
+        let configs: Vec<WorkstreamConfig> = serde_json::from_str(json).unwrap();
+        assert_eq!(configs[0].issue_id(), 99);
+    }
+
+    #[test]
+    fn test_workstream_config_default_description() {
+        let json = r#"[{"issue": 7, "branch": "b", "task": "t"}]"#;
+        let configs: Vec<WorkstreamConfig> = serde_json::from_str(json).unwrap();
+        assert_eq!(configs[0].description_or_default(), "Issue #7");
+    }
+
+    #[test]
+    fn test_persisted_state_roundtrip() {
+        let state = PersistedState {
+            issue: 42,
+            branch: "feat/test".to_string(),
+            lifecycle_state: "completed".to_string(),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: PersistedState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.issue, 42);
+        assert_eq!(parsed.branch, "feat/test");
+        assert_eq!(parsed.lifecycle_state, "completed");
+    }
+
+    #[test]
+    fn test_derive_cleanup_eligible() {
+        assert!(Workstream::derive_cleanup_eligible("completed"));
+        assert!(Workstream::derive_cleanup_eligible("failed_terminal"));
+        assert!(Workstream::derive_cleanup_eligible("abandoned"));
+        assert!(!Workstream::derive_cleanup_eligible("running"));
+        assert!(!Workstream::derive_cleanup_eligible("pending"));
+        assert!(!Workstream::derive_cleanup_eligible("failed_resumable"));
+    }
+
+    #[test]
+    fn test_default_constants() {
+        assert_eq!(DEFAULT_MAX_RUNTIME, 7200);
+        assert_eq!(DEFAULT_TIMEOUT_POLICY, "interrupt-preserve");
+    }
+
+    #[test]
+    fn test_valid_delegates() {
+        assert!(VALID_DELEGATES.contains(&"amplihack claude"));
+        assert!(VALID_DELEGATES.contains(&"amplihack copilot"));
+        assert!(VALID_DELEGATES.contains(&"amplihack amplifier"));
+        assert!(!VALID_DELEGATES.contains(&"rm -rf /"));
+    }
+
+    #[test]
+    fn test_orchestrator_construction() {
+        let orch = ParallelOrchestrator::new("https://github.com/test/repo", "recipe");
+        assert_eq!(orch.mode, "recipe");
+        assert_eq!(orch.default_max_runtime, DEFAULT_MAX_RUNTIME);
+        assert!(orch.workstreams.is_empty());
+    }
+
+    #[test]
+    fn test_set_timeout_policy() {
+        let mut orch = ParallelOrchestrator::new(".", "recipe");
+        orch.set_default_timeout_policy("continue-preserve");
+        assert_eq!(orch.default_timeout_policy, "continue-preserve");
+
+        // Invalid policy should be rejected
+        orch.set_default_timeout_policy("invalid-policy");
+        assert_eq!(orch.default_timeout_policy, "continue-preserve");
+    }
+
+    #[test]
+    fn test_atomic_write() {
+        let dir = std::env::temp_dir().join("amplihack-test-atomic-write");
+        let _ = fs::create_dir_all(&dir);
+        let file = dir.join("test.json");
+        atomic_write(&file, b"hello world").unwrap();
+        assert_eq!(fs::read_to_string(&file).unwrap(), "hello world");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_report_empty() {
+        let orch = ParallelOrchestrator::new(".", "recipe");
+        let report = orch.report();
+        assert!(report.contains("PARALLEL WORKSTREAM REPORT"));
+        assert!(report.contains("Mode: recipe"));
+        assert!(report.contains("Total: 0 | Succeeded: 0 | Failed: 0"));
+    }
+}

--- a/crates/amplihack-cli/src/lib.rs
+++ b/crates/amplihack-cli/src/lib.rs
@@ -57,7 +57,7 @@ use clap::{
 
 pub use cli_commands::Commands;
 pub use cli_subcommands::{
-    MemoryCommands, ModeCommands, PluginCommands, QueryCodeCommands, RecipeCommands,
+    MemoryCommands, ModeCommands, MultitaskCommands, PluginCommands, QueryCodeCommands, RecipeCommands,
 };
 
 fn graph_db_backend_value_parser() -> PossibleValuesParser {

--- a/crates/amplihack-recipe/tests/recipe_integration_tests.rs
+++ b/crates/amplihack-recipe/tests/recipe_integration_tests.rs
@@ -276,6 +276,36 @@ fn condition_eval_smart_orchestrator_patterns() {
 }
 
 #[test]
+fn condition_eval_resume_checkpoint_compat() {
+    // Issue #222: resume_checkpoint conditions must use != instead of
+    // `not in [...]` list syntax to remain compatible with older
+    // recipe-runner binaries that lack LBracket support.
+    use amplihack_recipe::evaluate_condition;
+    use std::collections::HashMap;
+
+    let cond = "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'";
+
+    // Empty resume_checkpoint → condition true (step should run)
+    let mut ctx = HashMap::new();
+    ctx.insert("resume_checkpoint".to_string(), "".to_string());
+    assert!(evaluate_condition(cond, &ctx).unwrap());
+
+    // Matching first checkpoint → condition false (step should skip)
+    ctx.insert(
+        "resume_checkpoint".to_string(),
+        "checkpoint-after-implementation".to_string(),
+    );
+    assert!(!evaluate_condition(cond, &ctx).unwrap());
+
+    // Matching second checkpoint → condition false (step should skip)
+    ctx.insert(
+        "resume_checkpoint".to_string(),
+        "checkpoint-after-review-feedback".to_string(),
+    );
+    assert!(!evaluate_condition(cond, &ctx).unwrap());
+}
+
+#[test]
 fn all_recipe_conditions_are_valid() {
     use amplihack_recipe::validate_condition;
 

--- a/crates/amplihack-utils/src/bundle_generator.rs
+++ b/crates/amplihack-utils/src/bundle_generator.rs
@@ -1,0 +1,1111 @@
+//! Agent Bundle Generator.
+//!
+//! Ported from `amplihack/bundle_generator/`.
+//!
+//! Provides types, error handling, and the core API for generating, testing,
+//! and packaging AI agent bundles from natural language descriptions.
+//!
+//! ## Architecture
+//!
+//! The pipeline stages mirror the Python implementation:
+//!
+//! 1. **Parsing** — analyse natural language prompts ([`PromptParser`])
+//! 2. **Extraction** — extract intent and requirements ([`IntentExtractor`])
+//! 3. **Generation** — create agent content ([`AgentGenerator`])
+//! 4. **Building** — assemble bundles ([`BundleBuilder`])
+//! 5. **Packaging** — produce distributable packages ([`FilesystemPackager`])
+//! 6. **Distribution** — publish to GitHub ([`GitHubDistributor`])
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Error hierarchy
+// ---------------------------------------------------------------------------
+
+/// Errors from bundle generator operations.
+#[derive(Debug, Error)]
+pub enum BundleGeneratorError {
+    /// Prompt parsing failed.
+    #[error("[PARSING_FAILED] {message}")]
+    Parsing {
+        /// Human-readable description.
+        message: String,
+        /// Fragment of the prompt that caused the issue.
+        prompt_fragment: Option<String>,
+        /// Character position.
+        position: Option<usize>,
+    },
+
+    /// Intent extraction failed.
+    #[error("[EXTRACTION_FAILED] {message}")]
+    Extraction {
+        /// Human-readable description.
+        message: String,
+        /// Terms that could not be interpreted.
+        ambiguous_terms: Vec<String>,
+        /// Extraction confidence (0.0–1.0).
+        confidence: Option<f64>,
+    },
+
+    /// Agent content generation failed.
+    #[error("[GENERATION_FAILED] {message}")]
+    Generation {
+        /// Human-readable description.
+        message: String,
+        /// Name of the agent being generated.
+        agent_name: Option<String>,
+        /// Pipeline stage that failed.
+        stage: Option<String>,
+    },
+
+    /// Bundle validation failed.
+    #[error("[VALIDATION_FAILED] {message}")]
+    Validation {
+        /// Human-readable description.
+        message: String,
+        /// Validation category.
+        validation_type: String,
+        /// Individual failures.
+        failures: Vec<String>,
+    },
+
+    /// Bundle packaging failed.
+    #[error("[PACKAGING_FAILED] {message}")]
+    Packaging {
+        /// Human-readable description.
+        message: String,
+        /// Target format.
+        format: Option<String>,
+        /// File path involved.
+        path: Option<String>,
+    },
+
+    /// Distribution failed.
+    #[error("[DISTRIBUTION_FAILED] {message}")]
+    Distribution {
+        /// Human-readable description.
+        message: String,
+        /// Target platform.
+        platform: Option<String>,
+        /// HTTP status code, if applicable.
+        http_status: Option<u16>,
+    },
+
+    /// I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON error.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl BundleGeneratorError {
+    /// Suggested recovery action for this error.
+    pub fn recovery_suggestion(&self) -> &str {
+        match self {
+            Self::Parsing { .. } => {
+                "Check prompt syntax and structure. Ensure clear agent descriptions."
+            }
+            Self::Extraction { .. } => {
+                "Provide clearer agent requirements. Use specific action verbs and clear role definitions."
+            }
+            Self::Generation { .. } => {
+                "Try simplifying agent requirements or generating agents individually."
+            }
+            Self::Validation { .. } => {
+                "Review validation failures and correct the identified issues."
+            }
+            Self::Packaging { .. } => {
+                "Check file permissions and available disk space."
+            }
+            Self::Distribution { .. } => {
+                "Check network connectivity and authentication. Verify repository permissions."
+            }
+            Self::Io(_) | Self::Json(_) => "Check file system state and retry.",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Data models
+// ---------------------------------------------------------------------------
+
+/// Result of parsing a natural language prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParsedPrompt {
+    /// Original prompt text.
+    pub raw_prompt: String,
+    /// Tokenised words.
+    pub tokens: Vec<String>,
+    /// Sentence segments.
+    pub sentences: Vec<String>,
+    /// Key phrases extracted from the prompt.
+    pub key_phrases: Vec<String>,
+    /// Named entities grouped by type.
+    pub entities: HashMap<String, Vec<String>>,
+    /// Parsing confidence (0.0–1.0).
+    pub confidence: f64,
+    /// Arbitrary metadata.
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl ParsedPrompt {
+    /// Validate the parsed prompt.
+    pub fn validate(&self) -> Result<(), BundleGeneratorError> {
+        if !(0.0..=1.0).contains(&self.confidence) {
+            return Err(BundleGeneratorError::Parsing {
+                message: format!(
+                    "Confidence must be between 0 and 1, got {}",
+                    self.confidence
+                ),
+                prompt_fragment: None,
+                position: None,
+            });
+        }
+        if self.raw_prompt.trim().is_empty() {
+            return Err(BundleGeneratorError::Parsing {
+                message: "Raw prompt cannot be empty".into(),
+                prompt_fragment: None,
+                position: None,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Action to perform with the bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BundleAction {
+    /// Create new agents.
+    Create,
+    /// Modify existing agents.
+    Modify,
+    /// Combine multiple agents.
+    Combine,
+    /// Specialise an agent for a domain.
+    Specialize,
+}
+
+/// Complexity tier for a bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Complexity {
+    /// Minimal configuration.
+    Simple,
+    /// Standard multi-agent bundle.
+    Standard,
+    /// Complex multi-agent bundle with dependencies.
+    Advanced,
+}
+
+/// Agent type classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentType {
+    /// Core infrastructure agent.
+    Core,
+    /// Domain-specific agent.
+    Specialized,
+    /// Workflow orchestration agent.
+    Workflow,
+}
+
+/// Requirements for a single agent within a bundle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRequirement {
+    /// Agent name (alphanumeric + hyphens/underscores).
+    pub name: String,
+    /// Role description.
+    pub role: String,
+    /// Purpose statement.
+    pub purpose: String,
+    /// List of capabilities.
+    pub capabilities: Vec<String>,
+    /// Constraints on the agent.
+    #[serde(default)]
+    pub constraints: Vec<String>,
+    /// Suggested type.
+    #[serde(default = "default_agent_type")]
+    pub suggested_type: AgentType,
+    /// Dependencies on other agents.
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    /// Priority (0 = highest).
+    #[serde(default)]
+    pub priority: u32,
+}
+
+fn default_agent_type() -> AgentType {
+    AgentType::Specialized
+}
+
+impl AgentRequirement {
+    /// Validate the agent requirement.
+    pub fn validate(&self) -> Result<(), BundleGeneratorError> {
+        let clean = self.name.replace(['-', '_'], "");
+        if !clean.chars().all(|c| c.is_alphanumeric()) {
+            return Err(BundleGeneratorError::Validation {
+                message: format!(
+                    "Agent name must be alphanumeric with hyphens/underscores: {}",
+                    self.name
+                ),
+                validation_type: "agent_name".into(),
+                failures: vec![self.name.clone()],
+            });
+        }
+        if self.capabilities.is_empty() {
+            return Err(BundleGeneratorError::Validation {
+                message: format!("Agent {} must have at least one capability", self.name),
+                validation_type: "capabilities".into(),
+                failures: vec![],
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Extracted intent from a parsed prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedIntent {
+    /// Action to perform.
+    pub action: BundleAction,
+    /// Domain (e.g. "security", "data-processing").
+    pub domain: String,
+    /// Number of agents to generate.
+    pub agent_count: usize,
+    /// Per-agent requirements.
+    pub agent_requirements: Vec<AgentRequirement>,
+    /// Complexity tier.
+    pub complexity: Complexity,
+    /// Global constraints.
+    pub constraints: Vec<String>,
+    /// Global dependencies.
+    pub dependencies: Vec<String>,
+    /// Extraction confidence (0.0–1.0).
+    pub confidence: f64,
+}
+
+impl ExtractedIntent {
+    /// Validate the extracted intent.
+    pub fn validate(&self) -> Result<(), BundleGeneratorError> {
+        if self.agent_count == 0 {
+            return Err(BundleGeneratorError::Extraction {
+                message: "Must have at least one agent".into(),
+                ambiguous_terms: vec![],
+                confidence: Some(self.confidence),
+            });
+        }
+        if self.agent_count > 10 {
+            return Err(BundleGeneratorError::Extraction {
+                message: "Maximum 10 agents per bundle".into(),
+                ambiguous_terms: vec![],
+                confidence: Some(self.confidence),
+            });
+        }
+        if self.agent_requirements.is_empty() {
+            return Err(BundleGeneratorError::Extraction {
+                message: "Must have at least one agent requirement".into(),
+                ambiguous_terms: vec![],
+                confidence: Some(self.confidence),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// A generated agent with content and metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneratedAgent {
+    /// Unique identifier.
+    pub id: String,
+    /// Agent name.
+    pub name: String,
+    /// Agent type.
+    #[serde(rename = "type")]
+    pub agent_type: AgentType,
+    /// Role description.
+    pub role: String,
+    /// Short description.
+    pub description: String,
+    /// Markdown content (agent definition).
+    pub content: String,
+    /// LLM model to use ("inherit" = use parent).
+    #[serde(default = "default_model")]
+    pub model: String,
+    /// Capabilities list.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// Dependencies on other agents.
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    /// Test file contents.
+    #[serde(default)]
+    pub tests: Vec<String>,
+    /// Additional documentation.
+    #[serde(default)]
+    pub documentation: String,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Time spent generating this agent.
+    #[serde(default)]
+    pub generation_time_seconds: f64,
+}
+
+fn default_model() -> String {
+    "inherit".into()
+}
+
+impl GeneratedAgent {
+    /// Estimated file size in KiB.
+    pub fn file_size_kb(&self) -> f64 {
+        self.content.len() as f64 / 1024.0
+    }
+}
+
+/// A complete bundle of agents ready for packaging.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentBundle {
+    /// Unique identifier.
+    pub id: String,
+    /// Bundle name (3–50 characters).
+    pub name: String,
+    /// Semantic version.
+    #[serde(default = "default_version")]
+    pub version: String,
+    /// Short description.
+    #[serde(default)]
+    pub description: String,
+    /// Agents in this bundle.
+    pub agents: Vec<GeneratedAgent>,
+    /// Arbitrary manifest data.
+    #[serde(default)]
+    pub manifest: HashMap<String, serde_json::Value>,
+    /// Arbitrary metadata.
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Bundle status.
+    #[serde(default = "default_status")]
+    pub status: BundleStatus,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Last update timestamp.
+    pub updated_at: DateTime<Utc>,
+}
+
+fn default_version() -> String {
+    "1.0.0".into()
+}
+
+/// Status of a bundle in the pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BundleStatus {
+    /// Awaiting processing.
+    Pending,
+    /// Currently being generated.
+    Processing,
+    /// Ready for packaging/distribution.
+    Ready,
+    /// Generation failed.
+    Failed,
+}
+
+fn default_status() -> BundleStatus {
+    BundleStatus::Pending
+}
+
+impl AgentBundle {
+    /// Validate the bundle.
+    pub fn validate(&self) -> Result<(), BundleGeneratorError> {
+        if self.name.is_empty() {
+            return Err(BundleGeneratorError::Validation {
+                message: "Bundle must have a name".into(),
+                validation_type: "bundle_name".into(),
+                failures: vec![],
+            });
+        }
+        if self.name.len() < 3 || self.name.len() > 50 {
+            return Err(BundleGeneratorError::Validation {
+                message: "Bundle name must be 3-50 characters".into(),
+                validation_type: "bundle_name".into(),
+                failures: vec![self.name.clone()],
+            });
+        }
+        if self.agents.is_empty() {
+            return Err(BundleGeneratorError::Validation {
+                message: "Bundle must contain at least one agent".into(),
+                validation_type: "agent_count".into(),
+                failures: vec![],
+            });
+        }
+        Ok(())
+    }
+
+    /// Number of agents in the bundle.
+    pub fn agent_count(&self) -> usize {
+        self.agents.len()
+    }
+
+    /// Total estimated size in KiB.
+    pub fn total_size_kb(&self) -> f64 {
+        self.agents.iter().map(|a| a.file_size_kb()).sum()
+    }
+}
+
+/// Package format for distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageFormat {
+    /// Gzipped tar archive.
+    #[serde(rename = "tar.gz")]
+    TarGz,
+    /// Zip archive.
+    Zip,
+    /// Plain directory.
+    Directory,
+    /// UVX package.
+    Uvx,
+}
+
+/// A packaged bundle ready for distribution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackagedBundle {
+    /// The underlying bundle.
+    pub bundle: AgentBundle,
+    /// Path to the package on disk.
+    pub package_path: PathBuf,
+    /// Package format.
+    pub format: PackageFormat,
+    /// Checksum of the package file.
+    #[serde(default)]
+    pub checksum: String,
+    /// Package size in bytes.
+    #[serde(default)]
+    pub size_bytes: u64,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Distribution platform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DistributionPlatform {
+    /// GitHub repository.
+    Github,
+    /// PyPI registry.
+    Pypi,
+    /// Local filesystem.
+    Local,
+}
+
+/// Result of distributing a bundle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DistributionResult {
+    /// Whether distribution succeeded.
+    pub success: bool,
+    /// Target platform.
+    pub platform: DistributionPlatform,
+    /// URL of the published package.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Repository identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    /// Branch name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    /// Commit SHA.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    /// Release tag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_tag: Option<String>,
+    /// Errors encountered.
+    #[serde(default)]
+    pub errors: Vec<String>,
+    /// Warnings encountered.
+    #[serde(default)]
+    pub warnings: Vec<String>,
+    /// Time spent distributing (seconds).
+    #[serde(default)]
+    pub distribution_time_seconds: f64,
+}
+
+impl DistributionResult {
+    /// Whether the result contains errors.
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Whether the result contains warnings.
+    pub fn has_warnings(&self) -> bool {
+        !self.warnings.is_empty()
+    }
+}
+
+/// Result of testing an agent or bundle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestResult {
+    /// What was tested.
+    pub test_type: TestType,
+    /// Name of the test target.
+    pub target_name: String,
+    /// Whether all tests passed.
+    pub passed: bool,
+    /// Total test count.
+    #[serde(default)]
+    pub test_count: usize,
+    /// Passed tests.
+    #[serde(default)]
+    pub passed_count: usize,
+    /// Failed tests.
+    #[serde(default)]
+    pub failed_count: usize,
+    /// Skipped tests.
+    #[serde(default)]
+    pub skipped_count: usize,
+    /// Execution duration (seconds).
+    #[serde(default)]
+    pub duration_seconds: f64,
+    /// Test coverage percentage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub coverage_percent: Option<f64>,
+}
+
+/// Type of test being run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TestType {
+    /// Single agent test.
+    Agent,
+    /// Full bundle test.
+    Bundle,
+    /// Integration test.
+    Integration,
+}
+
+impl TestResult {
+    /// Test success rate (0.0–1.0).
+    pub fn success_rate(&self) -> f64 {
+        if self.test_count == 0 {
+            return 0.0;
+        }
+        self.passed_count as f64 / self.test_count as f64
+    }
+}
+
+/// Metrics for a bundle generation run.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GenerationMetrics {
+    /// Total elapsed time (seconds).
+    pub total_time_seconds: f64,
+    /// Time spent parsing (seconds).
+    pub parsing_time: f64,
+    /// Time spent on extraction (seconds).
+    pub extraction_time: f64,
+    /// Time spent generating content (seconds).
+    pub generation_time: f64,
+    /// Time spent on validation (seconds).
+    pub validation_time: f64,
+    /// Time spent packaging (seconds).
+    pub packaging_time: f64,
+    /// Number of agents generated.
+    pub agent_count: usize,
+    /// Total content size (KiB).
+    pub total_size_kb: f64,
+    /// Peak memory usage (MiB).
+    pub memory_peak_mb: f64,
+}
+
+impl GenerationMetrics {
+    /// Average generation time per agent.
+    pub fn average_agent_time(&self) -> f64 {
+        if self.agent_count == 0 {
+            return 0.0;
+        }
+        self.generation_time / self.agent_count as f64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline traits
+// ---------------------------------------------------------------------------
+
+/// Parses natural language prompts into structured representations.
+pub trait PromptParser: Send + Sync {
+    /// Parse a raw prompt string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BundleGeneratorError::Parsing`] on invalid input.
+    fn parse(&self, prompt: &str) -> Result<ParsedPrompt, BundleGeneratorError>;
+}
+
+/// Extracts structured intent from a parsed prompt.
+pub trait IntentExtractor: Send + Sync {
+    /// Extract intent from a parsed prompt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BundleGeneratorError::Extraction`] on ambiguous input.
+    fn extract(&self, parsed: &ParsedPrompt) -> Result<ExtractedIntent, BundleGeneratorError>;
+}
+
+/// Generates agent content from requirements.
+pub trait AgentGenerator: Send + Sync {
+    /// Generate an agent from a requirement specification.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BundleGeneratorError::Generation`] if content creation fails.
+    fn generate(
+        &self,
+        requirement: &AgentRequirement,
+        context: &ExtractedIntent,
+    ) -> Result<GeneratedAgent, BundleGeneratorError>;
+}
+
+/// Assembles generated agents into a bundle.
+pub trait BundleBuilder: Send + Sync {
+    /// Build a bundle from generated agents.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BundleGeneratorError::Validation`] if the bundle is invalid.
+    fn build(
+        &self,
+        name: &str,
+        agents: Vec<GeneratedAgent>,
+        intent: &ExtractedIntent,
+    ) -> Result<AgentBundle, BundleGeneratorError>;
+}
+
+// ---------------------------------------------------------------------------
+// FilesystemPackager
+// ---------------------------------------------------------------------------
+
+/// Unsafe system directories that must not be used as output targets.
+const UNSAFE_PATHS: &[&str] = &["/", "/etc", "/usr", "/bin", "/sbin", "/sys", "/proc", "/dev"];
+
+/// Creates complete filesystem packages for agent bundles.
+///
+/// Orchestrates writing agents, documentation, configuration, and scripts
+/// to a target directory.
+pub struct FilesystemPackager {
+    output_dir: PathBuf,
+}
+
+impl FilesystemPackager {
+    /// Create a new packager targeting `output_dir`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BundleGeneratorError::Packaging`] if the path points to a
+    /// system directory.
+    pub fn new(output_dir: impl Into<PathBuf>) -> Result<Self, BundleGeneratorError> {
+        let output_dir = output_dir.into();
+        validate_output_dir(&output_dir)?;
+        Ok(Self { output_dir })
+    }
+
+    /// Create a complete filesystem package for a bundle.
+    ///
+    /// Creates:
+    /// - `agents/` — agent markdown files
+    /// - `tests/` — test files
+    /// - `docs/` — documentation
+    /// - `config/` — configuration
+    /// - `manifest.json` — bundle metadata
+    /// - `README.md`
+    ///
+    /// Returns the path to the created package directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BundleGeneratorError::Packaging`] on I/O failures.
+    pub fn create_package(
+        &self,
+        bundle: &AgentBundle,
+        _options: Option<&HashMap<String, serde_json::Value>>,
+    ) -> Result<PathBuf, BundleGeneratorError> {
+        let package_name = format!("{}-{}", bundle.name, bundle.version);
+        let package_path = self.output_dir.join(&package_name);
+
+        // Create directory structure.
+        for subdir in &["agents", "tests", "docs", "config"] {
+            std::fs::create_dir_all(package_path.join(subdir))?;
+        }
+
+        // Write agent files.
+        for agent in &bundle.agents {
+            let agent_file = package_path.join("agents").join(format!("{}.md", agent.name));
+            std::fs::write(&agent_file, &agent.content)?;
+        }
+
+        // Write manifest.
+        let manifest_path = package_path.join("manifest.json");
+        let manifest_json = serde_json::to_string_pretty(bundle)?;
+        std::fs::write(&manifest_path, manifest_json)?;
+
+        // Write README.
+        let readme = format!(
+            "# {}\n\n{}\n\n## Agents\n\n{}\n",
+            bundle.name,
+            bundle.description,
+            bundle
+                .agents
+                .iter()
+                .map(|a| format!("- **{}**: {}", a.name, a.description))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        std::fs::write(package_path.join("README.md"), readme)?;
+
+        Ok(package_path)
+    }
+}
+
+/// Validate that `output_dir` is not a system directory.
+fn validate_output_dir(path: &Path) -> Result<(), BundleGeneratorError> {
+    let resolved = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf());
+    let resolved_str = resolved.to_string_lossy();
+
+    for &unsafe_path in UNSAFE_PATHS {
+        if resolved_str == unsafe_path {
+            return Err(BundleGeneratorError::Packaging {
+                message: format!(
+                    "Cannot write to system directory: {resolved_str}. \
+                     Choose a user directory for output."
+                ),
+                format: None,
+                path: Some(resolved_str.into_owned()),
+            });
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// GitHubDistributor (stub)
+// ---------------------------------------------------------------------------
+
+/// Distributes agent bundles to GitHub repositories.
+///
+/// TODO: implement `create_repository`, `push_bundle`, `create_release`
+pub struct GitHubDistributor {
+    /// GitHub personal access token.
+    _token: String,
+}
+
+impl GitHubDistributor {
+    /// Create a new distributor with a GitHub token.
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            _token: token.into(),
+        }
+    }
+
+    /// Distribute a packaged bundle to GitHub.
+    ///
+    /// TODO: implement GitHub API calls for repository creation, push, and release.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BundleGeneratorError::Distribution`] on failure.
+    pub fn distribute(
+        &self,
+        _bundle: &PackagedBundle,
+        _repo_name: &str,
+    ) -> Result<DistributionResult, BundleGeneratorError> {
+        // TODO: implement GitHub API integration
+        Err(BundleGeneratorError::Distribution {
+            message: "GitHub distribution not yet implemented".into(),
+            platform: Some("github".into()),
+            http_status: None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parsed_prompt_validation_empty() {
+        let p = ParsedPrompt {
+            raw_prompt: "   ".into(),
+            tokens: vec![],
+            sentences: vec![],
+            key_phrases: vec![],
+            entities: HashMap::new(),
+            confidence: 0.5,
+            metadata: HashMap::new(),
+        };
+        assert!(p.validate().is_err());
+    }
+
+    #[test]
+    fn parsed_prompt_validation_bad_confidence() {
+        let p = ParsedPrompt {
+            raw_prompt: "create an agent".into(),
+            tokens: vec!["create".into()],
+            sentences: vec!["create an agent".into()],
+            key_phrases: vec![],
+            entities: HashMap::new(),
+            confidence: 1.5,
+            metadata: HashMap::new(),
+        };
+        assert!(p.validate().is_err());
+    }
+
+    #[test]
+    fn parsed_prompt_validation_ok() {
+        let p = ParsedPrompt {
+            raw_prompt: "create an agent".into(),
+            tokens: vec!["create".into(), "an".into(), "agent".into()],
+            sentences: vec!["create an agent".into()],
+            key_phrases: vec!["agent".into()],
+            entities: HashMap::new(),
+            confidence: 0.9,
+            metadata: HashMap::new(),
+        };
+        assert!(p.validate().is_ok());
+    }
+
+    #[test]
+    fn agent_requirement_validation() {
+        let req = AgentRequirement {
+            name: "my-agent".into(),
+            role: "tester".into(),
+            purpose: "testing".into(),
+            capabilities: vec!["test".into()],
+            constraints: vec![],
+            suggested_type: AgentType::Specialized,
+            dependencies: vec![],
+            priority: 0,
+        };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn agent_requirement_empty_capabilities() {
+        let req = AgentRequirement {
+            name: "my-agent".into(),
+            role: "tester".into(),
+            purpose: "testing".into(),
+            capabilities: vec![],
+            constraints: vec![],
+            suggested_type: AgentType::Specialized,
+            dependencies: vec![],
+            priority: 0,
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn extracted_intent_zero_agents() {
+        let intent = ExtractedIntent {
+            action: BundleAction::Create,
+            domain: "security".into(),
+            agent_count: 0,
+            agent_requirements: vec![],
+            complexity: Complexity::Simple,
+            constraints: vec![],
+            dependencies: vec![],
+            confidence: 0.8,
+        };
+        assert!(intent.validate().is_err());
+    }
+
+    #[test]
+    fn extracted_intent_too_many_agents() {
+        let intent = ExtractedIntent {
+            action: BundleAction::Create,
+            domain: "security".into(),
+            agent_count: 11,
+            agent_requirements: vec![AgentRequirement {
+                name: "a".into(),
+                role: "r".into(),
+                purpose: "p".into(),
+                capabilities: vec!["c".into()],
+                constraints: vec![],
+                suggested_type: AgentType::Core,
+                dependencies: vec![],
+                priority: 0,
+            }],
+            complexity: Complexity::Advanced,
+            constraints: vec![],
+            dependencies: vec![],
+            confidence: 0.8,
+        };
+        assert!(intent.validate().is_err());
+    }
+
+    #[test]
+    fn bundle_validation_empty_name() {
+        let bundle = AgentBundle {
+            id: "test-id".into(),
+            name: String::new(),
+            version: "1.0.0".into(),
+            description: String::new(),
+            agents: vec![],
+            manifest: HashMap::new(),
+            metadata: HashMap::new(),
+            status: BundleStatus::Pending,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        assert!(bundle.validate().is_err());
+    }
+
+    #[test]
+    fn bundle_validation_no_agents() {
+        let bundle = AgentBundle {
+            id: "test-id".into(),
+            name: "my-bundle".into(),
+            version: "1.0.0".into(),
+            description: String::new(),
+            agents: vec![],
+            manifest: HashMap::new(),
+            metadata: HashMap::new(),
+            status: BundleStatus::Pending,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        assert!(bundle.validate().is_err());
+    }
+
+    #[test]
+    fn generation_metrics_average() {
+        let m = GenerationMetrics {
+            generation_time: 10.0,
+            agent_count: 5,
+            ..Default::default()
+        };
+        assert!((m.average_agent_time() - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn generation_metrics_zero_agents() {
+        let m = GenerationMetrics::default();
+        assert!((m.average_agent_time()).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_result_success_rate() {
+        let r = TestResult {
+            test_type: TestType::Bundle,
+            target_name: "my-bundle".into(),
+            passed: true,
+            test_count: 10,
+            passed_count: 8,
+            failed_count: 2,
+            skipped_count: 0,
+            duration_seconds: 1.0,
+            coverage_percent: None,
+        };
+        assert!((r.success_rate() - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn distribution_result_flags() {
+        let r = DistributionResult {
+            success: true,
+            platform: DistributionPlatform::Github,
+            url: Some("https://github.com/test/repo".into()),
+            repository: Some("test/repo".into()),
+            branch: None,
+            commit_sha: None,
+            release_tag: None,
+            errors: vec![],
+            warnings: vec!["check license".into()],
+            distribution_time_seconds: 0.0,
+        };
+        assert!(!r.has_errors());
+        assert!(r.has_warnings());
+    }
+
+    #[test]
+    fn validate_output_dir_rejects_root() {
+        let result = validate_output_dir(Path::new("/"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn generated_agent_file_size() {
+        let agent = GeneratedAgent {
+            id: "id".into(),
+            name: "test".into(),
+            agent_type: AgentType::Specialized,
+            role: "tester".into(),
+            description: "test agent".into(),
+            content: "x".repeat(1024),
+            model: "inherit".into(),
+            capabilities: vec![],
+            dependencies: vec![],
+            tests: vec![],
+            documentation: String::new(),
+            created_at: Utc::now(),
+            generation_time_seconds: 0.0,
+        };
+        assert!((agent.file_size_kb() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn error_recovery_suggestions() {
+        let err = BundleGeneratorError::Parsing {
+            message: "bad".into(),
+            prompt_fragment: None,
+            position: None,
+        };
+        assert!(!err.recovery_suggestion().is_empty());
+    }
+
+    #[test]
+    fn bundle_serde_roundtrip() {
+        let bundle = AgentBundle {
+            id: "test-id".into(),
+            name: "test-bundle".into(),
+            version: "1.0.0".into(),
+            description: "A test bundle".into(),
+            agents: vec![GeneratedAgent {
+                id: "agent-1".into(),
+                name: "test-agent".into(),
+                agent_type: AgentType::Core,
+                role: "tester".into(),
+                description: "tests things".into(),
+                content: "# Test Agent\n\nContent here.".repeat(10),
+                model: "inherit".into(),
+                capabilities: vec!["testing".into()],
+                dependencies: vec![],
+                tests: vec![],
+                documentation: String::new(),
+                created_at: Utc::now(),
+                generation_time_seconds: 1.5,
+            }],
+            manifest: HashMap::new(),
+            metadata: HashMap::new(),
+            status: BundleStatus::Ready,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&bundle).unwrap();
+        let deserialized: AgentBundle = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.name, bundle.name);
+        assert_eq!(deserialized.agents.len(), 1);
+    }
+}

--- a/crates/amplihack-utils/src/docker_manager.rs
+++ b/crates/amplihack-utils/src/docker_manager.rs
@@ -1,0 +1,278 @@
+//! Docker container manager for amplihack execution.
+//!
+//! Ported from `amplihack/docker/manager.py`.
+//!
+//! Provides [`DockerManager`] which builds Docker images and runs amplihack
+//! commands inside containers with security restrictions and resource limits.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use regex::Regex;
+use tracing::{debug, error, info, warn};
+
+use crate::docker_detector::DockerDetector;
+
+/// Default Docker image name.
+const IMAGE_NAME: &str = "amplihack:latest";
+
+/// Manages Docker containers for amplihack execution.
+pub struct DockerManager;
+
+impl DockerManager {
+    /// Build the Docker image if it does not already exist.
+    ///
+    /// Looks for a `Dockerfile` relative to `project_root`. Returns `true` on
+    /// success (including when the image already exists).
+    pub fn build_image(project_root: &Path) -> bool {
+        if !DockerDetector::is_running() {
+            error!("Docker is not running");
+            return false;
+        }
+
+        if DockerDetector::check_image_exists(IMAGE_NAME) {
+            debug!("Docker image already exists: {IMAGE_NAME}");
+            return true;
+        }
+
+        info!("Building Docker image: {IMAGE_NAME}");
+
+        let dockerfile = project_root.join("Dockerfile");
+        if !dockerfile.exists() {
+            error!("Dockerfile not found at {}", dockerfile.display());
+            return false;
+        }
+
+        match Command::new("docker")
+            .args([
+                "build",
+                "-t",
+                IMAGE_NAME,
+                "-f",
+                &dockerfile.to_string_lossy(),
+                &project_root.to_string_lossy(),
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .status()
+        {
+            Ok(status) if status.success() => {
+                info!("Successfully built Docker image: {IMAGE_NAME}");
+                true
+            }
+            Ok(_) => {
+                error!("Docker build failed");
+                false
+            }
+            Err(e) => {
+                error!("Error running docker build: {e}");
+                false
+            }
+        }
+    }
+
+    /// Run an amplihack command inside a Docker container.
+    ///
+    /// Mounts `cwd` (or the current directory) as `/workspace`, forwards
+    /// relevant environment variables, and applies security constraints.
+    ///
+    /// Returns the container's exit code, or `1` on launch failure.
+    pub fn run_command(args: &[&str], cwd: Option<&Path>) -> i32 {
+        if !DockerDetector::is_running() {
+            error!("Docker is not running");
+            return 1;
+        }
+
+        let work_dir = match cwd {
+            Some(p) => p.to_path_buf(),
+            None => std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        };
+        let work_dir = work_dir
+            .canonicalize()
+            .unwrap_or_else(|_| work_dir.clone());
+
+        let mut docker_cmd = vec![
+            "run".to_string(),
+            "--rm".into(),
+            "--interactive".into(),
+            // Security options
+            "--security-opt".into(),
+            "no-new-privileges".into(),
+            // Resource limits
+            "--memory".into(),
+            "4g".into(),
+            "--cpus".into(),
+            "2".into(),
+        ];
+
+        // Run as current user (Unix only).
+        #[cfg(unix)]
+        {
+            let uid = unsafe { libc::getuid() };
+            let gid = unsafe { libc::getgid() };
+            docker_cmd.push("--user".into());
+            docker_cmd.push(format!("{uid}:{gid}"));
+        }
+
+        // Mount workspace.
+        docker_cmd.push("-v".into());
+        docker_cmd.push(format!("{}:/workspace", work_dir.display()));
+        docker_cmd.push("-w".into());
+        docker_cmd.push("/workspace".into());
+
+        // Forward validated environment variables.
+        for (key, value) in get_env_vars() {
+            docker_cmd.push("-e".into());
+            docker_cmd.push(format!("{key}={value}"));
+        }
+
+        // Image and arguments.
+        docker_cmd.push(IMAGE_NAME.into());
+        docker_cmd.extend(args.iter().map(|s| (*s).to_string()));
+
+        debug!("Running Docker command: docker {}", docker_cmd.join(" "));
+
+        match Command::new("docker")
+            .args(&docker_cmd)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+        {
+            Ok(status) => status.code().unwrap_or(1),
+            Err(e) => {
+                error!("Error running Docker container: {e}");
+                1
+            }
+        }
+    }
+
+    /// Check whether Docker should be used for this session.
+    ///
+    /// Delegates to [`DockerDetector::should_use_docker`].
+    pub fn should_use_docker() -> bool {
+        DockerDetector::should_use_docker()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Environment variable handling
+// ---------------------------------------------------------------------------
+
+/// Sanitise an environment variable value by removing control characters.
+fn sanitize_env_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|&c| {
+            // Keep printable chars plus newline and tab.
+            c >= ' ' || c == '\n' || c == '\t'
+        })
+        .collect()
+}
+
+/// Validate an API key against known provider patterns.
+fn validate_api_key(key_name: &str, value: &str) -> bool {
+    if value.len() < 10 {
+        return false;
+    }
+
+    match key_name {
+        "ANTHROPIC_API_KEY" | "OPENAI_API_KEY" => {
+            Regex::new(r"^sk-[a-zA-Z0-9\-_]+$")
+                .map(|re| re.is_match(value))
+                .unwrap_or(false)
+        }
+        "GITHUB_TOKEN" | "GH_TOKEN" => {
+            let prefixed = Regex::new(r"^(ghp_|ghs_|github_pat_|gho_|ghu_)[a-zA-Z0-9_]+$")
+                .map(|re| re.is_match(value))
+                .unwrap_or(false);
+            let classic = Regex::new(r"^[a-f0-9]{40}$")
+                .map(|re| re.is_match(value))
+                .unwrap_or(false);
+            prefixed || classic
+        }
+        _ => {
+            Regex::new(r"^[a-zA-Z0-9\-_./+=]+$")
+                .map(|re| re.is_match(value))
+                .unwrap_or(false)
+        }
+    }
+}
+
+/// Collect environment variables to forward into the container.
+fn get_env_vars() -> Vec<(String, String)> {
+    let mut vars = Vec::new();
+
+    // API keys with validation.
+    for key in ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GITHUB_TOKEN", "GH_TOKEN"] {
+        if let Ok(value) = std::env::var(key) {
+            let sanitized = sanitize_env_value(&value);
+            if validate_api_key(key, &sanitized) {
+                vars.push((key.into(), sanitized));
+            } else {
+                warn!("Invalid format for {key}, skipping");
+            }
+        }
+    }
+
+    // AMPLIHACK_* variables (except the Docker trigger).
+    for (key, value) in std::env::vars() {
+        if key.starts_with("AMPLIHACK_") && key != "AMPLIHACK_USE_DOCKER" {
+            vars.push((key, sanitize_env_value(&value)));
+        }
+    }
+
+    // Terminal settings.
+    if let Ok(term) = std::env::var("TERM") {
+        vars.push(("TERM".into(), sanitize_env_value(&term)));
+    }
+
+    vars
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_removes_control_chars() {
+        let input = "hello\x00world\x01\ttab\nnewline";
+        let result = sanitize_env_value(input);
+        assert_eq!(result, "helloworld\ttab\nnewline");
+    }
+
+    #[test]
+    fn validate_anthropic_key() {
+        assert!(validate_api_key("ANTHROPIC_API_KEY", "sk-ant-api03-abcdef1234567890"));
+        assert!(!validate_api_key("ANTHROPIC_API_KEY", "invalid"));
+        assert!(!validate_api_key("ANTHROPIC_API_KEY", "short"));
+    }
+
+    #[test]
+    fn validate_github_token_prefixed() {
+        assert!(validate_api_key("GITHUB_TOKEN", "ghp_1234567890abcdef1234567890abcdef12345678"));
+        assert!(validate_api_key("GITHUB_TOKEN", "ghs_1234567890abcdef"));
+        assert!(validate_api_key("GITHUB_TOKEN", "github_pat_1234567890abcdef"));
+    }
+
+    #[test]
+    fn validate_github_token_classic() {
+        assert!(validate_api_key("GITHUB_TOKEN", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"));
+    }
+
+    #[test]
+    fn validate_unknown_key() {
+        assert!(validate_api_key("CUSTOM_KEY", "some-valid_key.value/+=="));
+        assert!(!validate_api_key("CUSTOM_KEY", "has spaces!"));
+    }
+
+    #[test]
+    fn should_use_docker_false_by_default() {
+        // In test env without AMPLIHACK_USE_DOCKER, should return false.
+        assert!(!DockerManager::should_use_docker());
+    }
+}

--- a/crates/amplihack-utils/src/lib.rs
+++ b/crates/amplihack-utils/src/lib.rs
@@ -21,12 +21,16 @@
 //! - [`simple_tui`] — Simple TUI testing framework with gadugi and subprocess fallback
 //! - [`knowledge_builder`] — Knowledge Builder orchestrator (Socratic method pipeline)
 //! - [`llm_client`] — SDK launcher detection and LLM completion routing
+//! - [`bundle_generator`] — Agent bundle generation, packaging, and distribution
+//! - [`docker_manager`] — Docker container management for isolated execution
 
+pub mod bundle_generator;
 pub mod claude_cli;
 pub mod claude_md;
 pub mod cleanup;
 pub mod defensive;
 pub mod docker_detector;
+pub mod docker_manager;
 pub mod hook_merge;
 pub mod kb_types;
 pub mod knowledge_builder;


### PR DESCRIPTION
## Summary

Port of `multitask/orchestrator.py` to a native Rust subcommand in the CLI crate.

Closes #220

## Changes

Adds three subcommands under `amplihack multitask`:

- **`run`** — Launch parallel workstreams from a JSON config file
- **`cleanup`** — Remove workstream artifacts for merged PRs
- **`status`** — Show lifecycle state of existing workstreams

### Key features ported from Python:
- Parallel workstream execution via subprocess isolation (each ws gets a cloned repo + launcher script)
- Recipe-based and classic execution modes
- Per-workstream timeout budgets (`interrupt-preserve` / `continue-preserve` policies)
- State persistence (JSON) for workstream resumption across runs
- Automatic cleanup of completed workstream directories to free disk
- JSONL heartbeat events on stderr for machine-readable monitoring
- Signal handling (SIGINT) for graceful shutdown
- Log file tailing with size caps and `[ws:ID]` prefix
- Disk space checks (statvfs) before launching

### Architecture
- `commands/multitask/mod.rs` — CLI entry points and dispatch
- `commands/multitask/models.rs` — Data types (`WorkstreamConfig`, `Workstream`, `PersistedState`)
- `commands/multitask/orchestrator.rs` — Core orchestrator logic + 12 unit tests

## Testing

```
cargo check     # clean, no warnings
cargo test -p amplihack-cli -- multitask  # 12 tests pass
```