### PR TITLE
fix(install): stage amplifier-bundle on every install (#243)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/directories.rs
+++ b/crates/amplihack-cli/src/commands/install/directories.rs
@@ -167,9 +167,7 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
     let source_bundle = repo_root.join("amplifier-bundle");
     if !source_bundle.is_dir() {
         println!("  ⚠️  Warning: amplifier-bundle not found in source, skipping");
-        println!(
-            "     dev-orchestrator recipe execution will be unavailable on this install"
-        );
+        println!("     dev-orchestrator recipe execution will be unavailable on this install");
         return Ok(false);
     }
 
@@ -191,7 +189,10 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
     }
 
     copy_dir_recursive(&source_bundle, &target_bundle)?;
-    println!("  ✅ Staged amplifier-bundle to {}", target_bundle.display());
+    println!(
+        "  ✅ Staged amplifier-bundle to {}",
+        target_bundle.display()
+    );
     Ok(true)
 }
 

--- a/crates/amplihack-cli/src/commands/install/directories.rs
+++ b/crates/amplihack-cli/src/commands/install/directories.rs
@@ -160,35 +160,102 @@ pub(super) fn prune_legacy_amplihack_hook_assets(claude_dir: &Path) -> Result<us
 /// skill's `AMPLIHACK_HOME` auto-detection that walks for an
 /// `amplifier-bundle/` folder) both succeed.
 ///
-/// Returns `Ok(true)` if the bundle was staged, `Ok(false)` if the source
-/// repo did not contain an `amplifier-bundle/` directory (warned but not
-/// fatal — older source layouts may lack it).
+/// Returns `Ok(true)` if the bundle was staged. Returns an error if the
+/// source repo lacks an `amplifier-bundle/` directory, since
+/// [`super::settings::missing_framework_paths`] treats the bundle's recipes
+/// and `tools/orch_helper.py` as required framework assets — a missing
+/// source bundle would cause every subsequent launcher boot to attempt
+/// (and fail) a re-install in a tight loop.
+///
+/// The copy is performed via a temp-dir + atomic-rename pattern so a failed
+/// mid-flight copy never destroys an existing working bundle.
+///
+/// The source `amplifier-bundle/` root must be a real directory; symlinked
+/// roots are rejected to prevent a malicious local repo from copying an
+/// arbitrary readable directory into the user's staging area.
 pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Result<bool> {
     let source_bundle = repo_root.join("amplifier-bundle");
-    if !source_bundle.is_dir() {
-        println!("  ⚠️  Warning: amplifier-bundle not found in source, skipping");
-        println!("     dev-orchestrator recipe execution will be unavailable on this install");
-        return Ok(false);
+    let source_meta = fs::symlink_metadata(&source_bundle).with_context(|| {
+        format!(
+            "amplifier-bundle not found at {} — required for dev-orchestrator \
+             recipe execution (#243)",
+            source_bundle.display()
+        )
+    })?;
+    if source_meta.file_type().is_symlink() {
+        anyhow::bail!(
+            "refusing to stage amplifier-bundle from symlinked source root at {} \
+             — bundle root must be a real directory (#243)",
+            source_bundle.display()
+        );
+    }
+    if !source_meta.is_dir() {
+        anyhow::bail!(
+            "amplifier-bundle source at {} is not a directory",
+            source_bundle.display()
+        );
     }
 
     let target_bundle = claude_dir
         .parent()
         .context("staging .claude dir missing parent")?
         .join("amplifier-bundle");
-    if target_bundle.exists() {
-        fs::remove_dir_all(&target_bundle).with_context(|| {
-            format!(
-                "failed to remove stale amplifier-bundle at {}",
-                target_bundle.display()
-            )
-        })?;
-    }
     if let Some(parent) = target_bundle.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
-    copy_dir_recursive(&source_bundle, &target_bundle)?;
+    // Atomic replacement: copy into sibling temp dir first, then swap.
+    // If the copy fails, the existing bundle remains intact — this matters
+    // because `ensure_framework_installed` swallows refresh errors and
+    // expects the previous staged framework to still be usable.
+    let staging_temp = target_bundle.with_extension("staging");
+    if staging_temp.exists() {
+        fs::remove_dir_all(&staging_temp).with_context(|| {
+            format!(
+                "failed to clean stale staging dir {}",
+                staging_temp.display()
+            )
+        })?;
+    }
+    copy_dir_recursive(&source_bundle, &staging_temp).with_context(|| {
+        format!(
+            "failed to copy amplifier-bundle into staging dir {}",
+            staging_temp.display()
+        )
+    })?;
+
+    if target_bundle.exists() {
+        let backup = target_bundle.with_extension("old");
+        if backup.exists() {
+            fs::remove_dir_all(&backup).ok();
+        }
+        fs::rename(&target_bundle, &backup).with_context(|| {
+            format!(
+                "failed to back up existing amplifier-bundle at {}",
+                target_bundle.display()
+            )
+        })?;
+        if let Err(err) = fs::rename(&staging_temp, &target_bundle) {
+            // Roll the previous bundle back into place so the install isn't bricked.
+            let _ = fs::rename(&backup, &target_bundle);
+            return Err(err).with_context(|| {
+                format!(
+                    "failed to swap new amplifier-bundle into {}",
+                    target_bundle.display()
+                )
+            });
+        }
+        let _ = fs::remove_dir_all(&backup);
+    } else {
+        fs::rename(&staging_temp, &target_bundle).with_context(|| {
+            format!(
+                "failed to move new amplifier-bundle into {}",
+                target_bundle.display()
+            )
+        })?;
+    }
+
     println!(
         "  ✅ Staged amplifier-bundle to {}",
         target_bundle.display()

--- a/crates/amplihack-cli/src/commands/install/directories.rs
+++ b/crates/amplihack-cli/src/commands/install/directories.rs
@@ -146,6 +146,55 @@ pub(super) fn prune_legacy_amplihack_hook_assets(claude_dir: &Path) -> Result<us
     Ok(removed)
 }
 
+/// Stage the `amplifier-bundle/` tree from the source repo into
+/// `~/.amplihack/amplifier-bundle/`.
+///
+/// The dev-orchestrator skill's mandatory execution path
+/// (`amplihack recipe run smart-orchestrator`) is unreachable without these
+/// recipes (`smart-orchestrator.yaml`, `default-workflow.yaml`,
+/// `investigation-workflow.yaml`) and the `tools/orch_helper.py` referenced
+/// by the parse-decomposition step. See issue #243.
+///
+/// The bundle is copied to `~/.amplihack/amplifier-bundle/` so the recipe
+/// runner's `AMPLIHACK_HOME/amplifier-bundle/recipes` lookup (and the
+/// skill's `AMPLIHACK_HOME` auto-detection that walks for an
+/// `amplifier-bundle/` folder) both succeed.
+///
+/// Returns `Ok(true)` if the bundle was staged, `Ok(false)` if the source
+/// repo did not contain an `amplifier-bundle/` directory (warned but not
+/// fatal — older source layouts may lack it).
+pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Result<bool> {
+    let source_bundle = repo_root.join("amplifier-bundle");
+    if !source_bundle.is_dir() {
+        println!("  ⚠️  Warning: amplifier-bundle not found in source, skipping");
+        println!(
+            "     dev-orchestrator recipe execution will be unavailable on this install"
+        );
+        return Ok(false);
+    }
+
+    let target_bundle = claude_dir
+        .parent()
+        .context("staging .claude dir missing parent")?
+        .join("amplifier-bundle");
+    if target_bundle.exists() {
+        fs::remove_dir_all(&target_bundle).with_context(|| {
+            format!(
+                "failed to remove stale amplifier-bundle at {}",
+                target_bundle.display()
+            )
+        })?;
+    }
+    if let Some(parent) = target_bundle.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    copy_dir_recursive(&source_bundle, &target_bundle)?;
+    println!("  ✅ Staged amplifier-bundle to {}", target_bundle.display());
+    Ok(true)
+}
+
 pub(super) fn initialize_project_md(claude_dir: &Path) -> Result<()> {
     let project_md = claude_dir.join("context").join("PROJECT.md");
     if let Some(parent) = project_md.parent() {

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -200,6 +200,29 @@ pub fn run_uninstall() -> Result<()> {
         }
     }
 
+    // Issue #243: amplifier-bundle is staged at ~/.amplihack/amplifier-bundle/
+    // (sibling of the .claude staging dir). Remove it on uninstall so a stale
+    // bundle does not remain after the framework is removed.
+    if let Some(staging_root) = claude_dir.parent() {
+        let bundle = staging_root.join("amplifier-bundle");
+        if bundle.exists() {
+            match fs::remove_dir_all(&bundle) {
+                Ok(()) => {
+                    removed_any = true;
+                    removed_dirs += 1;
+                    println!("  🗑️  Removed amplifier-bundle at {}", bundle.display());
+                }
+                Err(error) => {
+                    println!(
+                        "  ⚠️  Could not remove amplifier-bundle at {}: {}",
+                        bundle.display(),
+                        error
+                    );
+                }
+            }
+        }
+    }
+
     // Phase 3: remove binaries listed in manifest
     for binary_path in &manifest.binaries {
         let p = PathBuf::from(binary_path);
@@ -329,6 +352,10 @@ fn local_install(repo_root: &Path) -> Result<()> {
     }
 
     println!();
+    println!("📦 Staging amplifier-bundle (recipes, modules, tools):");
+    let bundle_staged = copy_amplifier_bundle(repo_root, &claude_dir)?;
+
+    println!();
     println!("📝 Initializing PROJECT.md:");
     initialize_project_md(&claude_dir)?;
 
@@ -409,7 +436,7 @@ fn local_install(repo_root: &Path) -> Result<()> {
 
     println!();
     println!("============================================================");
-    if settings_ok && hooks_ok && !copied_dirs.is_empty() {
+    if settings_ok && hooks_ok && !copied_dirs.is_empty() && bundle_staged {
         println!("✅ Amplihack installation completed successfully!");
         println!();
         println!("📍 Installed to: {}", claude_dir.display());
@@ -418,6 +445,7 @@ fn local_install(repo_root: &Path) -> Result<()> {
         for dir in &copied_dirs {
             println!("   • {dir}");
         }
+        println!("   • amplifier-bundle (recipes, modules, tools)");
         println!();
         println!("🎯 Features enabled:");
         println!("   • Session start hook");
@@ -425,6 +453,7 @@ fn local_install(repo_root: &Path) -> Result<()> {
         println!("   • Post-tool-use hook");
         println!("   • Pre-compact hook");
         println!("   • Runtime logging and metrics");
+        println!("   • dev-orchestrator recipe execution");
         println!();
         println!("💡 To uninstall: amplihack uninstall");
     } else {
@@ -437,6 +466,12 @@ fn local_install(repo_root: &Path) -> Result<()> {
         }
         if copied_dirs.is_empty() {
             println!("   • No directories were copied");
+        }
+        if !bundle_staged {
+            println!(
+                "   • amplifier-bundle was not staged — dev-orchestrator recipe \
+                 execution will be unavailable (see issue #243)"
+            );
         }
         println!();
         println!("💡 You may need to manually verify the installation");

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -203,22 +203,21 @@ pub fn run_uninstall() -> Result<()> {
     // Issue #243: amplifier-bundle is staged at ~/.amplihack/amplifier-bundle/
     // (sibling of the .claude staging dir). Remove it on uninstall so a stale
     // bundle does not remain after the framework is removed.
-    if let Some(staging_root) = claude_dir.parent() {
-        let bundle = staging_root.join("amplifier-bundle");
-        if bundle.exists() {
-            match fs::remove_dir_all(&bundle) {
-                Ok(()) => {
-                    removed_any = true;
-                    removed_dirs += 1;
-                    println!("  🗑️  Removed amplifier-bundle at {}", bundle.display());
-                }
-                Err(error) => {
-                    println!(
-                        "  ⚠️  Could not remove amplifier-bundle at {}: {}",
-                        bundle.display(),
-                        error
-                    );
-                }
+    if let Ok(bundle) = staging_amplifier_bundle_dir()
+        && bundle.exists()
+    {
+        match fs::remove_dir_all(&bundle) {
+            Ok(()) => {
+                removed_any = true;
+                removed_dirs += 1;
+                println!("  🗑️  Removed amplifier-bundle at {}", bundle.display());
+            }
+            Err(error) => {
+                println!(
+                    "  ⚠️  Could not remove amplifier-bundle at {}: {}",
+                    bundle.display(),
+                    error
+                );
             }
         }
     }
@@ -353,7 +352,7 @@ fn local_install(repo_root: &Path) -> Result<()> {
 
     println!();
     println!("📦 Staging amplifier-bundle (recipes, modules, tools):");
-    let bundle_staged = copy_amplifier_bundle(repo_root, &claude_dir)?;
+    copy_amplifier_bundle(repo_root, &claude_dir)?;
 
     println!();
     println!("📝 Initializing PROJECT.md:");
@@ -436,7 +435,7 @@ fn local_install(repo_root: &Path) -> Result<()> {
 
     println!();
     println!("============================================================");
-    if settings_ok && hooks_ok && !copied_dirs.is_empty() && bundle_staged {
+    if settings_ok && hooks_ok && !copied_dirs.is_empty() {
         println!("✅ Amplihack installation completed successfully!");
         println!();
         println!("📍 Installed to: {}", claude_dir.display());
@@ -466,12 +465,6 @@ fn local_install(repo_root: &Path) -> Result<()> {
         }
         if copied_dirs.is_empty() {
             println!("   • No directories were copied");
-        }
-        if !bundle_staged {
-            println!(
-                "   • amplifier-bundle was not staged — dev-orchestrator recipe \
-                 execution will be unavailable (see issue #243)"
-            );
         }
         println!();
         println!("💡 You may need to manually verify the installation");

--- a/crates/amplihack-cli/src/commands/install/paths.rs
+++ b/crates/amplihack-cli/src/commands/install/paths.rs
@@ -55,7 +55,6 @@ pub(super) fn staging_claude_dir() -> Result<PathBuf> {
 /// `smart-orchestrator`, `default-workflow`, and `investigation-workflow`
 /// recipes, plus `tools/orch_helper.py` — without it, the dev-orchestrator's
 /// "REQUIRED" execution path is unreachable on a fresh install.
-#[allow(dead_code)]
 pub(super) fn staging_amplifier_bundle_dir() -> Result<PathBuf> {
     Ok(home_dir()?.join(".amplihack").join("amplifier-bundle"))
 }

--- a/crates/amplihack-cli/src/commands/install/paths.rs
+++ b/crates/amplihack-cli/src/commands/install/paths.rs
@@ -47,6 +47,19 @@ pub(super) fn staging_claude_dir() -> Result<PathBuf> {
     Ok(home_dir()?.join(".amplihack").join(".claude"))
 }
 
+/// Staged location for the `amplifier-bundle/` tree.
+///
+/// The dev-orchestrator skill, recipe runner, and parse-decomposition tooling
+/// all expect `AMPLIHACK_HOME/amplifier-bundle/` to exist (where
+/// `AMPLIHACK_HOME` defaults to `~/.amplihack`). The bundle ships the
+/// `smart-orchestrator`, `default-workflow`, and `investigation-workflow`
+/// recipes, plus `tools/orch_helper.py` — without it, the dev-orchestrator's
+/// "REQUIRED" execution path is unreachable on a fresh install.
+#[allow(dead_code)]
+pub(super) fn staging_amplifier_bundle_dir() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".amplihack").join("amplifier-bundle"))
+}
+
 pub(super) fn global_settings_path() -> Result<PathBuf> {
     Ok(global_claude_dir()?.join("settings.json"))
 }

--- a/crates/amplihack-cli/src/commands/install/settings.rs
+++ b/crates/amplihack-cli/src/commands/install/settings.rs
@@ -313,12 +313,34 @@ pub(super) fn missing_framework_paths(claude_dir: &Path) -> Result<Vec<String>> 
             missing.push(format!("{file} (expected at {})", path.display()));
         }
     }
-    let claude_md = claude_dir
+    let staging_root = claude_dir
         .parent()
-        .context("staging .claude dir missing parent")?
-        .join("CLAUDE.md");
+        .context("staging .claude dir missing parent")?;
+    let claude_md = staging_root.join("CLAUDE.md");
     if !claude_md.exists() {
         missing.push(format!("CLAUDE.md (expected at {})", claude_md.display()));
     }
+
+    // Issue #243: amplifier-bundle MUST be staged on every startup. Without
+    // these recipe yamls and `tools/orch_helper.py`, the dev-orchestrator
+    // skill's required execution path (`amplihack recipe run smart-orchestrator`)
+    // is unreachable.
+    let bundle_dir = staging_root.join("amplifier-bundle");
+    let required_bundle_paths: &[&str] = &[
+        "recipes/smart-orchestrator.yaml",
+        "recipes/default-workflow.yaml",
+        "recipes/investigation-workflow.yaml",
+        "tools/orch_helper.py",
+    ];
+    for rel in required_bundle_paths {
+        let path = bundle_dir.join(rel);
+        if !path.exists() {
+            missing.push(format!(
+                "amplifier-bundle/{rel} (expected at {})",
+                path.display()
+            ));
+        }
+    }
+
     Ok(missing)
 }

--- a/crates/amplihack-cli/src/commands/install/tests/helpers.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/helpers.rs
@@ -16,6 +16,24 @@ pub(super) fn create_source_repo(root: &Path) {
     fs::write(root.join(".claude/tools/statusline.sh"), "echo hi\n").unwrap();
     fs::write(root.join(".claude/AMPLIHACK.md"), "framework\n").unwrap();
     fs::write(root.join("CLAUDE.md"), "root\n").unwrap();
+
+    // Issue #243: source repos must ship `amplifier-bundle/` so the install
+    // can stage recipes + orch_helper.py for dev-orchestrator.
+    let bundle = root.join("amplifier-bundle");
+    fs::create_dir_all(bundle.join("recipes")).unwrap();
+    fs::create_dir_all(bundle.join("tools")).unwrap();
+    for recipe in [
+        "smart-orchestrator.yaml",
+        "default-workflow.yaml",
+        "investigation-workflow.yaml",
+    ] {
+        fs::write(
+            bundle.join("recipes").join(recipe),
+            "name: test-recipe\nsteps: []\n",
+        )
+        .unwrap();
+    }
+    fs::write(bundle.join("tools/orch_helper.py"), "# stub\n").unwrap();
 }
 
 pub(super) fn create_minimal_staged_assets(root: &Path) {
@@ -26,6 +44,23 @@ pub(super) fn create_minimal_staged_assets(root: &Path) {
     fs::write(claude_dir.join("tools/statusline.sh"), "echo hi\n").unwrap();
     fs::write(claude_dir.join("AMPLIHACK.md"), "framework\n").unwrap();
     fs::write(root.join(".amplihack/CLAUDE.md"), "root\n").unwrap();
+
+    // Issue #243: staged amplifier-bundle is now part of the presence check.
+    let bundle = root.join(".amplihack/amplifier-bundle");
+    fs::create_dir_all(bundle.join("recipes")).unwrap();
+    fs::create_dir_all(bundle.join("tools")).unwrap();
+    for recipe in [
+        "smart-orchestrator.yaml",
+        "default-workflow.yaml",
+        "investigation-workflow.yaml",
+    ] {
+        fs::write(
+            bundle.join("recipes").join(recipe),
+            "name: test-recipe\nsteps: []\n",
+        )
+        .unwrap();
+    }
+    fs::write(bundle.join("tools/orch_helper.py"), "# stub\n").unwrap();
 }
 
 /// Creates an executable stub at `dir/name` (755 perms on Unix).

--- a/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
@@ -3,6 +3,122 @@ use super::*;
 use std::fs;
 
 #[test]
+fn local_install_stages_amplifier_bundle_for_dev_orchestrator() {
+    // Issue #243: the dev-orchestrator skill's required execution path
+    // (`amplihack recipe run smart-orchestrator`) is unreachable unless
+    // amplihack install stages the amplifier-bundle (recipes + orch_helper.py)
+    // to ~/.amplihack/amplifier-bundle/.
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    let bin_dir = temp.path().join("stub_bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let hooks_stub = create_exe_stub(&bin_dir, "amplihack-hooks");
+
+    let prev_hooks = std::env::var_os("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH");
+    let prev_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", &hooks_stub);
+        let new_path = format!(
+            "{}:{}",
+            bin_dir.display(),
+            prev_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        );
+        std::env::set_var("PATH", &new_path);
+    }
+
+    create_source_repo(temp.path());
+    local_install(temp.path()).unwrap();
+
+    if let Some(v) = prev_hooks {
+        unsafe { std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", v) };
+    } else {
+        unsafe { std::env::remove_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH") };
+    }
+    if let Some(v) = prev_path {
+        unsafe { std::env::set_var("PATH", v) };
+    }
+    crate::test_support::restore_home(previous);
+
+    let bundle = temp.path().join(".amplihack/amplifier-bundle");
+    assert!(
+        bundle.is_dir(),
+        "amplifier-bundle must be staged at ~/.amplihack/amplifier-bundle/ after install"
+    );
+    for recipe in [
+        "recipes/smart-orchestrator.yaml",
+        "recipes/default-workflow.yaml",
+        "recipes/investigation-workflow.yaml",
+    ] {
+        assert!(
+            bundle.join(recipe).is_file(),
+            "{recipe} must be staged so dev-orchestrator can execute it"
+        );
+    }
+    assert!(
+        bundle.join("tools/orch_helper.py").is_file(),
+        "tools/orch_helper.py must be staged so parse-decomposition can run"
+    );
+
+    // The presence check used by ensure_framework_installed must now treat
+    // a missing bundle as a reason to re-install on next launch.
+    let staging_claude = temp.path().join(".amplihack/.claude");
+    assert!(
+        settings::missing_framework_paths(&staging_claude)
+            .unwrap()
+            .is_empty(),
+        "fully-staged install must report no missing framework paths"
+    );
+    fs::remove_dir_all(&bundle).unwrap();
+    let missing = settings::missing_framework_paths(&staging_claude).unwrap();
+    assert!(
+        missing
+            .iter()
+            .any(|m| m.contains("amplifier-bundle/recipes/smart-orchestrator.yaml")),
+        "missing amplifier-bundle must be reported by presence check (issue #243), got: {missing:?}"
+    );
+}
+
+#[test]
+fn uninstall_removes_staged_amplifier_bundle() {
+    // Issue #243 follow-up: uninstall must clean up the staged bundle so
+    // a stale tree does not linger after the framework is removed.
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    fs::create_dir_all(temp.path().join(".amplihack/.claude/install")).unwrap();
+    let bundle = temp.path().join(".amplihack/amplifier-bundle/recipes");
+    fs::create_dir_all(&bundle).unwrap();
+    fs::write(bundle.join("smart-orchestrator.yaml"), "x\n").unwrap();
+    let manifest = InstallManifest::default();
+    manifest::write_manifest(
+        &temp
+            .path()
+            .join(".amplihack/.claude/install/amplihack-manifest.json"),
+        &manifest,
+    )
+    .unwrap();
+
+    run_uninstall().unwrap();
+
+    assert!(
+        !temp.path().join(".amplihack/amplifier-bundle").exists(),
+        "uninstall must remove ~/.amplihack/amplifier-bundle/"
+    );
+
+    crate::test_support::restore_home(previous);
+}
+
+#[test]
 fn local_install_writes_manifest() {
     let _guard = crate::test_support::home_env_lock()
         .lock()

--- a/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
@@ -577,3 +577,113 @@ fn read_manifest_accepts_valid_relative_paths() {
         result.err()
     );
 }
+
+#[test]
+fn copy_amplifier_bundle_errors_when_source_missing() {
+    // Issue #243: missing source bundle must be a hard error during install,
+    // because missing_framework_paths() now treats the bundle as required —
+    // a silent skip would cause an infinite re-install loop on every launcher
+    // boot.
+    let temp = tempfile::tempdir().unwrap();
+    let repo_root = temp.path().join("repo-without-bundle");
+    let claude_dir = temp.path().join(".amplihack/.claude");
+    fs::create_dir_all(&repo_root).unwrap();
+    fs::create_dir_all(&claude_dir).unwrap();
+
+    let result = directories::copy_amplifier_bundle(&repo_root, &claude_dir);
+
+    assert!(
+        result.is_err(),
+        "missing source amplifier-bundle must error, not silently warn"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("amplifier-bundle"),
+        "error must mention amplifier-bundle, got: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn copy_amplifier_bundle_rejects_symlinked_source_root() {
+    // Defense-in-depth: a malicious local repo could symlink amplifier-bundle/
+    // at an arbitrary readable directory and have it copied into the user's
+    // staging area. The bundle root must be a real directory.
+    let temp = tempfile::tempdir().unwrap();
+    let repo_root = temp.path().join("repo");
+    fs::create_dir_all(&repo_root).unwrap();
+    let claude_dir = temp.path().join(".amplihack/.claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+
+    let elsewhere = temp.path().join("evil");
+    fs::create_dir_all(&elsewhere).unwrap();
+    fs::write(elsewhere.join("secret.txt"), "private").unwrap();
+    std::os::unix::fs::symlink(&elsewhere, repo_root.join("amplifier-bundle")).unwrap();
+
+    let result = directories::copy_amplifier_bundle(&repo_root, &claude_dir);
+
+    assert!(
+        result.is_err(),
+        "symlinked amplifier-bundle root must be rejected"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("symlink"),
+        "error must mention symlink rejection, got: {err}"
+    );
+    assert!(
+        !claude_dir
+            .parent()
+            .unwrap()
+            .join("amplifier-bundle")
+            .exists(),
+        "no bundle must have been staged from the symlinked source"
+    );
+}
+
+#[test]
+fn copy_amplifier_bundle_replaces_existing_atomically() {
+    // The copy must use a temp-dir + rename pattern so a failed mid-flight
+    // refresh never destroys an existing working bundle. Verify both the
+    // happy path (new content replaces old) and that no leftover staging
+    // dirs remain in the parent.
+    let temp = tempfile::tempdir().unwrap();
+    let repo_root = temp.path().join("repo");
+    let claude_dir = temp.path().join(".amplihack/.claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+
+    let bundle_src = repo_root.join("amplifier-bundle");
+    fs::create_dir_all(bundle_src.join("recipes")).unwrap();
+    fs::write(bundle_src.join("recipes/smart-orchestrator.yaml"), "v1\n").unwrap();
+    directories::copy_amplifier_bundle(&repo_root, &claude_dir).unwrap();
+
+    let staged = temp.path().join(".amplihack/amplifier-bundle");
+    assert_eq!(
+        fs::read_to_string(staged.join("recipes/smart-orchestrator.yaml")).unwrap(),
+        "v1\n"
+    );
+
+    fs::write(bundle_src.join("recipes/smart-orchestrator.yaml"), "v2\n").unwrap();
+    fs::write(bundle_src.join("recipes/new-recipe.yaml"), "fresh\n").unwrap();
+    directories::copy_amplifier_bundle(&repo_root, &claude_dir).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(staged.join("recipes/smart-orchestrator.yaml")).unwrap(),
+        "v2\n",
+        "re-install must replace existing content"
+    );
+    assert!(
+        staged.join("recipes/new-recipe.yaml").is_file(),
+        "re-install must add new files from the source"
+    );
+
+    let parent = temp.path().join(".amplihack");
+    assert!(
+        !parent.join("amplifier-bundle.staging").exists(),
+        "no staging temp dir must remain after a successful install"
+    );
+    assert!(
+        !parent.join("amplifier-bundle.old").exists(),
+        "no backup dir must remain after a successful install"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #243. The dev-orchestrator skill's REQUIRED execution path (`amplihack recipe run smart-orchestrator`) was unreachable on a fresh install because `amplihack install` only staged `.claude/` — it never copied the `amplifier-bundle/` tree that ships the workflow recipes (`smart-orchestrator.yaml`, `default-workflow.yaml`, `investigation-workflow.yaml`) and `tools/orch_helper.py`.

## Changes

- **Stage `amplifier-bundle/`** from the source repo to `~/.amplihack/amplifier-bundle/` during `local_install`. This satisfies both the recipe runner's `AMPLIHACK_HOME/amplifier-bundle/recipes` lookup (`recipe/resolve.rs`) and the dev-orchestrator skill's `AMPLIHACK_HOME` auto-detection.
- **Treat the bundle as a required framework asset** — `missing_framework_paths` now reports the four critical bundle files (3 recipes + `orch_helper.py`) as missing if absent, so the next `ensure_framework_installed` call (every launcher boot) triggers a re-install. This closes the "critical files MUST be staged every startup" loop.
- **Atomic replacement** — bundle is copied into a sibling `amplifier-bundle.staging` temp dir, then renamed into place. On failure the previous bundle is rolled back from a `.old` backup so a failed refresh never bricks an existing working install.
- **Hard error on missing source bundle** — install fails fast (instead of silently warning) when the source repo lacks `amplifier-bundle/`, matching the contract `missing_framework_paths` enforces and preventing infinite re-install loops.
- **Symlinked source root rejected** — `amplifier-bundle/` must be a real directory; symlinked roots are refused so a malicious local repo can't copy arbitrary readable directories into the user's staging area.
- **Removed on uninstall** — `~/.amplihack/amplifier-bundle/` is cleaned up via the new `staging_amplifier_bundle_dir()` helper.

## Quality-Audit Evidence

A multi-pass quality audit (rubber-duck) was run on the diff and surfaced 2 HIGH + 2 MEDIUM findings:

| Severity | Finding | Resolution |
|---|---|---|
| HIGH | Non-atomic replacement could brick install on failed refresh | Fixed: temp-dir + atomic rename + rollback (`directories.rs`) |
| HIGH | Install warned on missing bundle but `missing_framework_paths` required it (infinite loop) | Fixed: missing source bundle now hard-errors (`directories.rs`) |
| MEDIUM | `is_dir()` followed symlinks at the bundle root | Fixed: `symlink_metadata()` + symlink rejection (`directories.rs`) |
| MEDIUM | Failure-path test coverage thin | Fixed: 3 new tests (missing source, symlink, atomic re-install) |
| LOW | `staging_amplifier_bundle_dir()` helper unused | Fixed: now used by uninstall path (`mod.rs`) |

Final cycle: clean (zero remaining HIGH/critical findings).

## Test Plan

- `local_install_stages_amplifier_bundle_for_dev_orchestrator` — asserts all 3 recipes + `orch_helper.py` land at `~/.amplihack/amplifier-bundle/` after install, and `missing_framework_paths` reports the bundle as missing when removed.
- `uninstall_removes_staged_amplifier_bundle` — asserts the bundle dir is cleaned up.
- `copy_amplifier_bundle_errors_when_source_missing` — asserts hard-error (not warn) when source repo lacks `amplifier-bundle/`.
- `copy_amplifier_bundle_rejects_symlinked_source_root` (Unix) — asserts symlinked source roots are refused and no bundle is staged.
- `copy_amplifier_bundle_replaces_existing_atomically` — asserts re-install over existing content swaps cleanly with no leftover `.staging` or `.old` directories.
- Updated `create_source_repo` and `create_minimal_staged_assets` test helpers so existing tests satisfy the new presence check.
- All 69 install-module tests pass; `cargo clippy -p amplihack-cli --all-targets -- -D warnings` clean.
- Pre-existing failures (`build_auto_command_*`, `native_reasoner_backend_*` — graph_db path resolution) confirmed not caused by this change (reproduce on prior commit `11fad89`).

## Merge-Ready Verdict

- **CI**: ✅ all 8 active checks green (Lint & Format, Test, Install Smoke Test, 4 Build matrix targets, GitGuardian); 2 skipped (`scan`, `Release` — both intentional/conditional)
- **Scope**: ✅ all 4 changed files under `crates/amplihack-cli/src/commands/install/`
- **Quality-audit**: ✅ rubber-duck multi-pass review; final cycle clean
- **Docs**: not-applicable — no public API/CLI/config surface added; install warning text changes are user-facing console output (covered by tests)
- **PR description evidence**: ✅ this update

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
