### PR TITLE
fix(cli/tests): isolate graph_db env vars in auto_mode and fleet tests

### DIFF
--- a/crates/amplihack-cli/src/commands/auto_mode/tests.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/tests.rs
@@ -4,6 +4,7 @@ use super::helpers::{
 };
 use super::run::render_auto_session_argv;
 use super::*;
+use crate::test_support::{ClearedGraphDbEnv, env_lock};
 use std::collections::HashMap;
 
 #[test]
@@ -116,6 +117,10 @@ fn render_auto_session_argv_includes_auto_flags() {
 
 #[test]
 fn build_auto_command_propagates_launcher_environment() {
+    let _env_guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _graph_guard = ClearedGraphDbEnv::new();
     let dir = tempfile::tempdir().unwrap();
 
     let command = build_auto_command(
@@ -175,6 +180,10 @@ fn build_auto_command_propagates_launcher_environment() {
 
 #[test]
 fn build_auto_command_marks_staged_execution_context() {
+    let _env_guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _graph_guard = ClearedGraphDbEnv::new();
     let execution_dir = tempfile::tempdir().unwrap();
     let project_dir = tempfile::tempdir().unwrap();
 

--- a/crates/amplihack-cli/src/commands/fleet/tests.rs
+++ b/crates/amplihack-cli/src/commands/fleet/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::command_error;
-use crate::test_support::{home_env_lock, restore_cwd, set_cwd};
+use crate::test_support::{ClearedGraphDbEnv, home_env_lock, restore_cwd, set_cwd};
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 
@@ -27,6 +27,7 @@ fn native_reasoner_backend_propagates_shared_env_context() {
     let _home_guard = home_env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _graph_guard = ClearedGraphDbEnv::new();
     let temp = tempfile::tempdir().unwrap();
     let reasoner = temp.path().join("claude");
     let amplihack_home = temp.path().join("amplihack-home");

--- a/crates/amplihack-cli/src/test_support.rs
+++ b/crates/amplihack-cli/src/test_support.rs
@@ -45,3 +45,48 @@ pub(crate) fn set_cwd(path: &Path) -> std::io::Result<std::path::PathBuf> {
 pub(crate) fn restore_cwd(previous: &Path) -> std::io::Result<()> {
     std::env::set_current_dir(previous)
 }
+
+/// RAII guard that clears `AMPLIHACK_GRAPH_DB_PATH` and `AMPLIHACK_KUZU_DB_PATH`
+/// for the duration of a test and restores the previous values on drop.
+///
+/// `EnvBuilder::with_project_graph_db` reads these env vars first and falls
+/// back to a project-derived path only when neither is set. Tests that assert
+/// against the project-derived path therefore must clear any ambient values
+/// the developer's shell or CI runner may have set, otherwise the leaking
+/// value wins and the assertion fails. Acquire the `env_lock()` before
+/// constructing this guard so concurrent tests don't observe the cleared
+/// state.
+pub(crate) struct ClearedGraphDbEnv {
+    previous_graph: Option<std::ffi::OsString>,
+    previous_kuzu: Option<std::ffi::OsString>,
+}
+
+impl ClearedGraphDbEnv {
+    pub(crate) fn new() -> Self {
+        let previous_graph = std::env::var_os("AMPLIHACK_GRAPH_DB_PATH");
+        let previous_kuzu = std::env::var_os("AMPLIHACK_KUZU_DB_PATH");
+        unsafe {
+            std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH");
+            std::env::remove_var("AMPLIHACK_KUZU_DB_PATH");
+        }
+        Self {
+            previous_graph,
+            previous_kuzu,
+        }
+    }
+}
+
+impl Drop for ClearedGraphDbEnv {
+    fn drop(&mut self) {
+        unsafe {
+            match self.previous_graph.take() {
+                Some(value) => std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", value),
+                None => std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH"),
+            }
+            match self.previous_kuzu.take() {
+                Some(value) => std::env::set_var("AMPLIHACK_KUZU_DB_PATH", value),
+                None => std::env::remove_var("AMPLIHACK_KUZU_DB_PATH"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three tests in `amplihack-cli` were failing locally for any developer whose shell exports `AMPLIHACK_GRAPH_DB_PATH` (a very common configuration). CI passes because CI doesn't set the var. This was the source of the 'pre-existing failures' user observed.

### Root cause

`EnvBuilder::with_project_graph_db` (env_builder/builder.rs:170-187) reads `AMPLIHACK_GRAPH_DB_PATH` and `AMPLIHACK_KUZU_DB_PATH` from the process env first, and only falls back to `$project_root/.amplihack/graph_db` when both are unset. **Production behavior is correct** — env vars are meant to override the default.

The bug was in the **tests**: they assert the project-derived path but never clear leaking ambient values.

### Fix

Add a `ClearedGraphDbEnv` RAII guard in `test_support.rs` that saves, clears, and restores both env vars on drop. Apply it (alongside the existing env_lock mutex for thread safety) to:

- `commands::auto_mode::tests::build_auto_command_propagates_launcher_environment`
- `commands::auto_mode::tests::build_auto_command_marks_staged_execution_context`
- `commands::fleet::tests::native_reasoner_backend_propagates_shared_env_context`

### Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings   # clean
TMPDIR=/tmp AMPLIHACK_GRAPH_DB_PATH=/some/path cargo test -p amplihack-cli --lib
# 964 passed; 0 failed   (was 3 failed before this PR)
```

### Scope

Test-only change. No production code modified. No behavior change.
