### PR TITLE
fix(orchestrator): replace python3 runtime_assets shell-out with native Rust subcommand

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -60,7 +60,7 @@ steps:
       elif ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
         ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' is not a git repository"
       fi
-      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
       if [ -z "$HELPER_PATH" ] || [ ! -f "$HELPER_PATH" ]; then
         ERRORS="${ERRORS}\n  ✗ Cannot find orch_helper.py — set AMPLIHACK_HOME to a valid amplihack root"
       fi
@@ -129,7 +129,7 @@ steps:
   - id: "parse-decomposition"
     type: "bash"
     command: |
-      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
       if [ ! -f "$HELPER_PATH" ]; then
           echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
           echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
@@ -180,7 +180,7 @@ steps:
   - id: "activate-workflow"
     type: "bash"
     command: |
-      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
       if [ ! -f "$HELPER_PATH" ]; then
           echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
           echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
@@ -192,7 +192,7 @@ steps:
       )
       TASK_TYPE={{task_type}}
       FORCE_SINGLE={{force_single_workstream}}
-      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
+      HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
@@ -271,7 +271,7 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type or task_type == ''"
     command: |
-      TREE_SCRIPT="$(python3 -m amplihack.runtime_assets session-tree-path 2>/dev/null || true)"
+      TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
       SESSION_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex[:8])")
 
       if [ -f "$TREE_SCRIPT" ]; then
@@ -434,7 +434,7 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and workstream_count != 1 and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
-      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
+      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
       if [ ! -f "$HELPER_PATH" ]; then
           echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
           echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
@@ -1001,8 +1001,8 @@ steps:
       {{session_info}}
       EOFSESSIONJSON
       )
-      TREE_SCRIPT="$(python3 -m amplihack.runtime_assets session-tree-path 2>/dev/null || true)"
-      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
+      TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
+      HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
       # Parse session fields and clear workflow semaphore in one Python subprocess.
       # Uses env vars instead of pipe+heredoc to avoid stdin conflict (issue #2581).
       export SESSION_JSON HOOKS_DIR

--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -319,6 +319,16 @@ pub enum Commands {
     /// Run system health checks
     Doctor,
 
+    /// Resolve a named bundle asset (helper-path, session-tree-path, hooks-dir)
+    /// or a relative path under amplifier-bundle/. Prints the resolved absolute
+    /// path on success, exits 1 if not found, exits 2 on invalid input.
+    /// Replaces `python3 -m amplihack.runtime_assets` in recipe shell steps.
+    #[command(name = "resolve-bundle-asset")]
+    ResolveBundleAsset {
+        /// Asset name (e.g. helper-path) or relative path starting with `amplifier-bundle/`
+        asset: String,
+    },
+
     /// Parallel workstream orchestrator (native Rust)
     Multitask {
         #[command(subcommand)]

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -308,6 +308,10 @@ pub fn dispatch(command: Commands) -> Result<()> {
         Commands::UvxHelp { find_path, info } => uvx_help::run_uvx_help(find_path, info),
         Commands::Completions { shell } => completions::run_completions(shell),
         Commands::Doctor => doctor::run_doctor(),
+        Commands::ResolveBundleAsset { asset } => {
+            let code = crate::resolve_bundle_asset::run_cli(&asset);
+            std::process::exit(code);
+        }
         Commands::Multitask { command } => dispatch_multitask(command),
     }
 }

--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -422,3 +422,86 @@ mod tests {
         assert_eq!(code, 0, "run_cli should return 0 when named asset found");
     }
 }
+
+#[cfg(test)]
+mod cli_dispatch_tests {
+    //! Verify the `amplihack resolve-bundle-asset <asset>` clap subcommand
+    //! parses correctly and that recipes don't regress to the old
+    //! `python3 -m amplihack.runtime_assets ...` invocation.
+    use crate::{Cli, Commands};
+    use clap::Parser;
+
+    #[test]
+    fn parses_named_asset_argument() {
+        let cli =
+            Cli::try_parse_from(["amplihack", "resolve-bundle-asset", "helper-path"]).unwrap();
+        match cli.command {
+            Commands::ResolveBundleAsset { asset } => assert_eq!(asset, "helper-path"),
+            other => panic!("expected ResolveBundleAsset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_relative_path_argument() {
+        let cli = Cli::try_parse_from([
+            "amplihack",
+            "resolve-bundle-asset",
+            "amplifier-bundle/tools/orch_helper.py",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::ResolveBundleAsset { asset } => {
+                assert_eq!(asset, "amplifier-bundle/tools/orch_helper.py")
+            }
+            other => panic!("expected ResolveBundleAsset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_missing_argument() {
+        let result = Cli::try_parse_from(["amplihack", "resolve-bundle-asset"]);
+        assert!(
+            result.is_err(),
+            "missing asset argument should be a parse error"
+        );
+    }
+
+    #[test]
+    fn recipes_do_not_invoke_python_runtime_assets() {
+        // Regression guard for the bug where smart-orchestrator preflight
+        // failed because `python3 -m amplihack.runtime_assets` is not
+        // available on machines that only have the Rust binary installed.
+        // Recipes must use `amplihack resolve-bundle-asset` instead.
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let recipes_dir = manifest
+            .join("..")
+            .join("..")
+            .join("amplifier-bundle")
+            .join("recipes");
+        if !recipes_dir.is_dir() {
+            // Crate may be built outside the workspace (e.g., crates.io
+            // packaging); recipes only exist in the source repo.
+            eprintln!(
+                "skipping: recipes dir not found at {}",
+                recipes_dir.display()
+            );
+            return;
+        }
+        let mut offenders = Vec::new();
+        for entry in std::fs::read_dir(&recipes_dir).unwrap().flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("yaml") {
+                continue;
+            }
+            let body = std::fs::read_to_string(&path).unwrap();
+            if body.contains("python3 -m amplihack.runtime_assets") {
+                offenders.push(path.display().to_string());
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "recipes still invoke the legacy Python runtime_assets module \
+             instead of `amplihack resolve-bundle-asset`: {offenders:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Bug

Colleague reported smart-orchestrator preflight failing with `orch_helper.py not found in AMPLIHACK_HOME` on a fresh azlin VM, even though PR #244 staged `amplifier-bundle/` correctly. Root cause: every recipe step that needed to find a bundled asset shelled out to:

```bash
python3 -m amplihack.runtime_assets <name>
```

That module ships only with the **legacy Python** `amplihack` package, which most users no longer install. With only the Rust binary present, the command returns empty and the helper-path check fails.

A working Rust port (`resolve_bundle_asset::run_cli`) had already shipped in this crate but was **never wired into the main `amplihack` binary**. The standalone `amplihack-asset-resolver` bin existed but isn't published in releases either.

## Fix

1. **New CLI subcommand**: `amplihack resolve-bundle-asset <asset>` — wraps the existing Rust `run_cli` and prints the resolved absolute path. Returns 0 on success, 1 if not found, 2 on invalid input.
2. **Recipe migration**: replaced all 8 `python3 -m amplihack.runtime_assets …` invocations in `smart-orchestrator.yaml` with `amplihack resolve-bundle-asset …`.
3. **Tests** (4 new):
   - 3 clap parsing tests for the new subcommand
   - **Regression guard** that scans `amplifier-bundle/recipes/*.yaml` for `python3 -m amplihack.runtime_assets` and fails the build if any recipe regresses

## Scope note (no-python mandate)

The recipe still embeds Python heredocs for JSON extraction (`orch_helper.extract_json`) and session-tree registration. Those need their own Rust subcommands and will be migrated in follow-up PRs. This PR fixes the **immediate preflight bug class** by eliminating the asset-lookup Python dependency, which is the one that breaks installs.

## Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings   # clean
TMPDIR=/tmp cargo test -p amplihack-cli --lib                # 968 passed; 0 failed (+4 new)
amplihack resolve-bundle-asset helper-path                   # prints orch_helper.py path
```
