### PR TITLE
docs: fix 8 broken links, mkdocs --strict on PRs, untrack site/ (#259)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: Docs
 
 on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - '.github/workflows/docs.yml'
   push:
     branches: [main]
     paths:
@@ -35,6 +41,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ index.scip
 .amplihack/
 logs/
 outputs/
+site/

--- a/docs/howto/manage-tool-update-checks.md
+++ b/docs/howto/manage-tool-update-checks.md
@@ -4,7 +4,7 @@
 > only — the check that runs before `claude`, `copilot`, or `codex` is invoked.
 > For the separate `amplihack` binary self-update system (GitHub release
 > downloads with SHA-256 verification), see
-> [Update the amplihack Binary](../reference/update.md).
+> [Update the amplihack Binary](https://github.com/rysweet/amplihack-rs/blob/main/crates/amplihack-cli/src/update/install.rs).
 
 Before launching `claude`, `copilot`, or `codex`, `amplihack` checks whether a
 newer version of the npm-distributed tool is available. When an update is found,
@@ -263,4 +263,4 @@ visible text.
 - [Run amplihack in Non-interactive Mode](./run-in-noninteractive-mode.md) — Full CI and pipeline guide
 - [Environment Variables](../reference/environment-variables.md) — `AMPLIHACK_NONINTERACTIVE`, `AMPLIHACK_PARITY_TEST`, and `AMPLIHACK_NO_UPDATE_CHECK` reference
 - [Launch Flag Injection](../reference/launch-flag-injection.md) — How `amplihack` builds the subprocess command line
-- [amplihack launch](../reference/launch-command.md) — Full CLI reference for launch subcommands
+- [amplihack launch](../reference/launch-flag-injection.md) — Launch flag injection reference for launch subcommands

--- a/docs/howto/resolve-kuzu-linker-errors.md
+++ b/docs/howto/resolve-kuzu-linker-errors.md
@@ -161,6 +161,6 @@ The root cause is in the lbug crate's `Cargo.toml`, which specifies `cxx-build =
 ## Related
 
 - [The cxx/cxx-build Version Contract](../concepts/cxx-version-contract.md) — Why the versions must match
-- [CONTRIBUTING_RUST.md](../../CONTRIBUTING_RUST.md) — Build and test commands
+- [CONTRIBUTING_RUST.md](https://github.com/rysweet/amplihack-rs/blob/main/CONTRIBUTING_RUST.md) — Build and test commands
 - [GitHub Issue #35](https://github.com/rysweet/amplihack-rs/issues/35) — Original report and investigation
 - [GitHub PR #43](https://github.com/rysweet/amplihack-rs/pull/43) — The fix

--- a/docs/howto/run-fleet-scout-and-advance.md
+++ b/docs/howto/run-fleet-scout-and-advance.md
@@ -10,7 +10,7 @@ opening a separate terminal for each VM.
 - [Prerequisites](#prerequisites)
 - [Run a scout report](#run-a-scout-report)
 - [Advance sessions interactively](#advance-sessions-interactively)
-- [Automate advance with --force](#automate-advance-with---force)
+- [Automate advance with --force](#automate-advance-with-force)
 - [Save reports to disk](#save-reports-to-disk)
 - [Use incremental scouting](#use-incremental-scouting)
 - [Target a single VM or session](#target-a-single-vm-or-session)

--- a/docs/howto/validate-no-python.md
+++ b/docs/howto/validate-no-python.md
@@ -134,5 +134,5 @@ before it. If you want to validate the release binary, pass `--release`:
 ## Related
 
 - [No-Python Compliance (AC9)](../concepts/kuzu-code-graph.md#security-model) — why this matters
-- [`scripts/probe-no-python.sh`](../../scripts/probe-no-python.sh) — the probe script itself
-- [Parity Test Scenarios](./parity-test-scenarios.md) — full parity test matrix
+- [`scripts/probe-no-python.sh`](https://github.com/rysweet/amplihack-rs/blob/main/scripts/probe-no-python.sh) — the probe script itself
+- [Parity Test Scenarios](../reference/parity-test-scenarios.md) — full parity test matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,5 +89,5 @@ amplihack uninstall
 
 ## Related
 
-- [README](../README.md) — Architecture overview and design principles
-- [CONTRIBUTING_RUST.md](../CONTRIBUTING_RUST.md) — Developer setup, build targets, test harness
+- [README](https://github.com/rysweet/amplihack-rs/blob/main/README.md) — Architecture overview and design principles
+- [CONTRIBUTING_RUST.md](https://github.com/rysweet/amplihack-rs/blob/main/CONTRIBUTING_RUST.md) — Developer setup, build targets, test harness

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -9,7 +9,7 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [AMPLIHACK_ASSET_RESOLVER](#amplihack_asset_resolver)
   - [AMPLIHACK_HOME](#amplihack_home)
   - [AMPLIHACK_GRAPH_DB_PATH](#amplihack_graph_db_path)
-  - [AMPLIHACK_KUZU_DB_PATH](#amplihack_kuzu_db_path-legacy-alias)
+  - [AMPLIHACK_KUZU_DB_PATH](#amplihack_kuzu_db_path-backward-compatible-alias)
   - [AMPLIHACK_NONINTERACTIVE](#amplihack_noninteractive)
   - [AMPLIHACK_SESSION_ID](#amplihack_session_id)
   - [AMPLIHACK_DEPTH](#amplihack_depth)

--- a/docs/reference/launch-flag-injection.md
+++ b/docs/reference/launch-flag-injection.md
@@ -9,9 +9,9 @@ can override the defaults.
 ## Contents
 
 - [Injected flags overview](#injected-flags-overview)
-- [--dangerously-skip-permissions](#--dangerously-skip-permissions)
-- [--model](#--model)
-- [--resume and --continue](#--resume-and---continue)
+- [--dangerously-skip-permissions](#dangerously-skip-permissions)
+- [--model](#model)
+- [--resume and --continue](#resume-and-continue)
 - [Extra args passthrough](#extra-args-passthrough)
 - [Complete command-line assembly](#complete-command-line-assembly)
 - [Python launcher parity](#python-launcher-parity)
@@ -30,7 +30,7 @@ can override the defaults.
 
 ---
 
-## --dangerously-skip-permissions
+## --dangerously-skip-permissions { #dangerously-skip-permissions }
 
 `amplihack` passes `--dangerously-skip-permissions` to the tool subprocess only
 when **both** conditions are met:
@@ -75,7 +75,7 @@ may behave differently. Verify Python launcher behavior independently.
 
 ---
 
-## --model
+## --model { #model }
 
 `amplihack` injects `--model <value>` into the subprocess command line to set
 the AI model variant used for the session. This flag is only injected for
@@ -154,7 +154,7 @@ Examples that work at time of writing:
 
 ---
 
-## --resume and --continue
+## --resume and --continue { #resume-and-continue }
 
 These flags are passed through only when the user explicitly requests them on
 the `launch` subcommand. They are never injected automatically.

--- a/docs/reference/parity-test-scenarios.md
+++ b/docs/reference/parity-test-scenarios.md
@@ -15,19 +15,19 @@ and what behaviour each tier validates.
   - [Comparison targets](#comparison-targets)
   - [Environment variable expansion](#environment-variable-expansion)
 - [Tier files](#tier-files)
-  - [tier1.yaml — Mode detection](#tier1yaml--mode-detection)
-  - [tier2-install.yaml — Install command](#tier2-installyaml--install-command)
-  - [tier2-plugin.yaml — Plugin command](#tier2-pluginyaml--plugin-command)
-  - [tier3-memory.yaml — Memory command](#tier3-memoryyaml--memory-command)
-  - [tier4-recipe-run.yaml — Recipe run](#tier4-recipe-runyaml--recipe-run)
-  - [tier5-e2e.yaml — End-to-end launch](#tier5-e2eyaml--end-to-end-launch)
-  - [tier5-gap-tests.yaml — Known gaps](#tier5-gap-testsyaml--known-gaps)
-  - [tier5-launcher.yaml — Launcher flags](#tier5-launcheryaml--launcher-flags)
-  - [tier5-live-recipe.yaml — Live recipe execution](#tier5-live-recipeyaml--live-recipe-execution)
-  - [tier5-malformed-yaml.yaml — Error handling](#tier5-malformed-yamalyaml--error-handling)
-  - [tier6-qa-bugfixes.yaml — QA regressions](#tier6-qa-bugfixesyaml--qa-regressions)
-  - [tier7-launcher-parity.yaml — Launcher gaps](#tier7-launcher-parityyaml--launcher-gaps)
-  - [tier8-env-vars.yaml — Environment variable injection](#tier8-env-varsyaml--environment-variable-injection)
+  - [tier1.yaml — Mode detection](#tier1yaml-mode-detection)
+  - [tier2-install.yaml — Install command](#tier2-installyaml-install-command)
+  - [tier2-plugin.yaml — Plugin command](#tier2-pluginyaml-plugin-command)
+  - [tier3-memory.yaml — Memory command](#tier3-memoryyaml-memory-command)
+  - [tier4-recipe-run.yaml — Recipe run](#tier4-recipe-runyaml-recipe-run)
+  - [tier5-e2e.yaml — End-to-end launch](#tier5-e2eyaml-end-to-end-launch)
+  - [tier5-gap-tests.yaml — Known gaps](#tier5-gap-testsyaml-known-gaps)
+  - [tier5-launcher.yaml — Launcher flags](#tier5-launcheryaml-launcher-flags)
+  - [tier5-live-recipe.yaml — Live recipe execution](#tier5-live-recipeyaml-live-recipe-execution)
+  - [tier5-malformed-yaml.yaml — Error handling](#tier5-malformed-yamlyaml-error-handling)
+  - [tier6-qa-bugfixes.yaml — QA regressions](#tier6-qa-bugfixesyaml-qa-regressions)
+  - [tier7-launcher-parity.yaml — Launcher gaps](#tier7-launcher-parityyaml-launcher-gaps)
+  - [tier8-env-vars.yaml — Environment variable injection](#tier8-env-varsyaml-environment-variable-injection)
 - [Related](#related)
 
 ---
@@ -283,7 +283,7 @@ python tests/parity/validate_cli_parity.py \
 
 ## Related
 
-- [validate_cli_parity.py](../../tests/parity/validate_cli_parity.py) — Harness source
+- [validate_cli_parity.py](https://github.com/rysweet/amplihack-rs/blob/main/tests/parity/validate_cli_parity.py) — Harness source
 - [Environment Variables](./environment-variables.md) — Reference for all variables injected during launch
 - [Agent Binary Routing](../concepts/agent-binary-routing.md) — Why `AMPLIHACK_AGENT_BINARY` exists
 - [Bootstrap Parity](../concepts/bootstrap-parity.md) — Design principles behind Python↔Rust parity

--- a/docs/reference/signal-handling.md
+++ b/docs/reference/signal-handling.md
@@ -8,7 +8,7 @@ in each case.
 
 - [Signal handler registration](#signal-handler-registration)
 - [Exit code contract](#exit-code-contract)
-  - [SIGINT — Ctrl-C](#sigint--ctrl-c)
+  - [SIGINT — Ctrl-C](#sigint-ctrl-c)
   - [Normal child exit](#normal-child-exit)
   - [Signal-killed child (no exit code)](#signal-killed-child-no-exit-code)
 - [Python launcher parity](#python-launcher-parity)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
 
 markdown_extensions:
   - admonition
+  - attr_list
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.tabbed:


### PR DESCRIPTION
## Summary

Fixes Part A of #259.

- Convert broken doc links to repo files into absolute GitHub URLs (README, CONTRIBUTING_RUST, scripts/probe-no-python.sh, tests/parity/validate_cli_parity.py).
- Fix incorrect relative paths in two how-to docs.
- Add `site/` to `.gitignore` (mkdocs build output should not be committed) and untrack any previously committed `site/` files.
- Extend `.github/workflows/docs.yml` to run `mkdocs build --strict` on PRs that touch docs/, only deploy on push to main.

## Verification

```
$ rm -rf site && mkdocs build --strict
INFO    -  Documentation built in 3.15 seconds   # exit 0, no WARNING
```

## Note

The original ws-261 agent worked on this but its commit was rejected by pre-commit's `check-added-large-files` hook because it accidentally committed `site/` (mkdocs output >500KB per file). Branch was lost. This PR redoes the work the right way (gitignore site/ first, then build).

Closes part A of #259.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>