### PR TITLE
test(recipe-runner): pin shell-step env inheritance (regression for #268)

### DIFF
--- a/crates/amplihack-recipe/src/executor.rs
+++ b/crates/amplihack-recipe/src/executor.rs
@@ -714,4 +714,46 @@ steps:
         assert_eq!(merged.get("b").unwrap(), "3");
         assert_eq!(merged.get("c").unwrap(), "4");
     }
+
+    /// Regression for #268 (closed not-reproducible): the recipe runner must
+    /// inherit the parent process environment when launching `bash` steps, so
+    /// users can pass things like `PYTHONPATH` or arbitrary custom env vars
+    /// from their shell into the recipe. Rust's `Command` inherits by default;
+    /// this test pins that behavior so we don't accidentally introduce
+    /// `env_clear()` / `env_remove()` in `execute_shell_step`.
+    #[test]
+    fn shell_step_inherits_parent_env_vars() {
+        // SAFETY: env vars are set/removed in a single-threaded test.
+        let key = "AMPLIHACK_INHERIT_PROBE_268";
+        let value = "propagated-from-parent";
+        unsafe {
+            std::env::set_var(key, value);
+        }
+
+        let yaml = format!(
+            r#"
+name: env-inherit-probe
+steps:
+  - id: probe
+    type: shell
+    command: 'printf "%s" "${}"'
+"#,
+            key
+        );
+        let recipe = crate::parser::RecipeParser::new().parse(&yaml).unwrap();
+        let executor = RecipeExecutor::new(ExecutorConfig::default(), DryRunAgentBackend);
+        let result = executor.execute(&recipe, HashMap::new()).unwrap();
+
+        unsafe {
+            std::env::remove_var(key);
+        }
+
+        assert!(result.success, "recipe should succeed");
+        assert_eq!(result.step_results[0].status, StepStatus::Succeeded);
+        assert_eq!(
+            result.step_results[0].output.as_deref(),
+            Some(value),
+            "shell step did not inherit parent env var (regression for #268)"
+        );
+    }
 }

--- a/crates/amplihack-recipe/src/executor.rs
+++ b/crates/amplihack-recipe/src/executor.rs
@@ -723,12 +723,27 @@ steps:
     /// `env_clear()` / `env_remove()` in `execute_shell_step`.
     #[test]
     fn shell_step_inherits_parent_env_vars() {
-        // SAFETY: env vars are set/removed in a single-threaded test.
+        // RAII guard so the env var is removed even if an assertion or
+        // executor call panics — env vars are process-global and cargo runs
+        // tests in parallel, so a leak would contaminate sibling tests.
+        struct EnvGuard(&'static str);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                // SAFETY: removing a var we set; no other thread observes
+                // this unique key.
+                unsafe {
+                    std::env::remove_var(self.0);
+                }
+            }
+        }
+
         let key = "AMPLIHACK_INHERIT_PROBE_268";
         let value = "propagated-from-parent";
+        // SAFETY: unique key, no concurrent reader of this name.
         unsafe {
             std::env::set_var(key, value);
         }
+        let _guard = EnvGuard(key);
 
         let yaml = format!(
             r#"
@@ -743,10 +758,6 @@ steps:
         let recipe = crate::parser::RecipeParser::new().parse(&yaml).unwrap();
         let executor = RecipeExecutor::new(ExecutorConfig::default(), DryRunAgentBackend);
         let result = executor.execute(&recipe, HashMap::new()).unwrap();
-
-        unsafe {
-            std::env::remove_var(key);
-        }
 
         assert!(result.success, "recipe should succeed");
         assert_eq!(result.step_results[0].status, StepStatus::Succeeded);


### PR DESCRIPTION
## Summary

Pin the shell-step env-inheritance behavior of the Rust recipe-runner with a regression test, so we can never silently break it.

## Background

Issue #268 (closed not-reproducible) claimed the Rust recipe-runner strips `PYTHONPATH` from `shell`/`bash` steps, breaking smart-orchestrator's preflight. I disproved that claim empirically (see #268 comment) — `std::process::Command` inherits the parent env by default, and `execute_shell_step` (`crates/amplihack-recipe/src/executor.rs:329`) does not call `env_clear()` / `env_remove()`. PYTHONPATH and arbitrary custom env vars propagate fine.

The colleague's actual failure was an asset-staging / older-binary issue (already tracked by #243/#249), not env propagation.

## What this PR does

Adds `shell_step_inherits_parent_env_vars` to `crates/amplihack-recipe/src/executor.rs`. The test:

1. Sets a unique env var in the parent process (RAII guard ensures cleanup on panic).
2. Runs a one-step shell-type recipe whose command is `printf "%s" "$VAR"`.
3. Asserts the step output equals the parent value.

If a future refactor introduces `cmd.env_clear()` or `cmd.env_remove("PYTHONPATH")`, this test will fail and surface the regression immediately.

## Merge readiness

### QA-team evidence

`gadugi-test` is for Electron applications and is not applicable to this Rust CLI. The executable QA artifact for this PR **is the cargo unit test it adds** — a test-as-scenario that locks in the externally-observable behavior the issue alleged was broken.

- Scenario file: `crates/amplihack-recipe/src/executor.rs` (`shell_step_inherits_parent_env_vars`)
- Validation command: `cargo clippy -p amplihack-recipe --tests -- -D warnings`
- Validation result: passed (clean)
- Run command: `TMPDIR=/tmp cargo test -p amplihack-recipe --lib`
- Run target: local
- Run result: **149/149 passed** (the new regression test passes; no prior tests regressed)
- Evidence: see verification block below

### Documentation

- User-facing docs impact: no
- Updated docs: none
- Rationale: change is purely a test addition to internal recipe-executor module (`crates/amplihack-recipe/src/executor.rs`); no public API, no CLI flag, no config schema, no user-visible behavior change. Test pins existing behavior rather than introducing it.

### Quality-audit

- Cycle 1: code-review found High-severity finding — env var would leak on panic before cleanup line, contaminating sibling tests. Fix applied: introduced `EnvGuard` Drop type so removal is RAII-guaranteed on every exit path.
- Cycle 2: code-review flagged hypothetical parallel-thread race on the unique key. Reviewed: cargo runs different test functions in parallel threads, but each test function runs once per binary invocation, and the unique key `AMPLIHACK_INHERIT_PROBE_268` is referenced by no other test in the repo. Pattern matches established convention (40+ other tests use the same `set_var`/`remove_var` style). No code change needed.
- Cycle 3: code-review returned **CLEAN**. RAII pattern correct, key truly unique, conventions followed.
- Final clean cycle: 3 (zero critical/high, zero medium correctness/security)
- Fixes followed default-workflow: yes (small, focused commit; tests pass; clippy clean; fmt clean)
- Convergence summary: reached clean state in 3 cycles after one substantive fix.

### CI

- Checks command: `gh pr checks 271`
- Result: all green / skipped (verified before final push; new push triggers re-run)
- Skipped checks: `Invisible Character Scan` (conditional), `scan` (path-filter), `deploy` (path-filter)
- Flaky reruns performed: none
- Real failures fixed: none on this PR

### Scope

- Changed files: `crates/amplihack-recipe/src/executor.rs` (test-only addition, ~57 lines)
- Unrelated changes: none

### Verdict

- Merge-ready: **yes** (pending CI re-run on latest commit and external reviewer approval per branch protection)
- Remaining blockers: external reviewer approval required (branch protection prevents author self-approval); branch protection / 1-reviewer requirement is project-level, not a PR defect.

## Verification

```
TMPDIR=/tmp cargo test -p amplihack-recipe --lib    # 149/149 pass
cargo clippy -p amplihack-recipe --tests -- -D warnings   # clean
cargo fmt --check                                          # clean
```

Refs #268.
