### PR TITLE
fix(#269): promote Operations→Development on strong dev signals

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -125,126 +125,78 @@ steps:
 
   # parse-decomposition: extract task_type from architect JSON output.
   # Outputs ONLY the canonical task_type string (e.g. "Development").
-  # Previously also extracted workstream_count here; that moved to activate-workflow.
+  # Uses native Rust `amplihack orch helper` (#270).
   - id: "parse-decomposition"
     type: "bash"
     command: |
-      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export HELPER_PATH
-      python3 - <<'PYEOF'
-      import sys, json, os, importlib.util
+      RAW_OBJ=$(amplihack orch helper extract-json < "$_DECOMP_TMPFILE")
+      if [ "$RAW_OBJ" = "{}" ]; then
+        cat <<'WARN' >&2
 
-      helper_path = os.environ['HELPER_PATH']
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp_json = f.read()
-
-      spec = importlib.util.spec_from_file_location('orch_helper', helper_path)
-      h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
-      obj = h.extract_json(decomp_json)
-
-      if not obj:
-          msg = (
-              "\n"
-              "╔══════════════════════════════════════════════════════════════════╗\n"
-              "║  ERROR: decomposition JSON parse failed                         ║\n"
-              "║  The architect agent returned non-JSON prose instead of the     ║\n"
-              "║  expected structured plan.                                      ║\n"
-              "║                                                                 ║\n"
-              "║  Action: defaulting to task_type=Development so execution can   ║\n"
-              "║  continue. The adaptive strategy step will evaluate whether     ║\n"
-              "║  direct recipe invocation should be attempted.                  ║\n"
-              "╚══════════════════════════════════════════════════════════════════╝\n"
-          )
-          print(msg, file=sys.stderr)
-          # Do NOT print to stdout — stdout is captured as the output variable
-          # and box-drawing characters would corrupt downstream template substitution
-
-      task_type = h.normalise_type(obj.get("task_type", "Development"))
-      print(task_type)
-      PYEOF
+      ╔══════════════════════════════════════════════════════════════════╗
+      ║  ERROR: decomposition JSON parse failed                         ║
+      ║  The architect agent returned non-JSON prose instead of the     ║
+      ║  expected structured plan.                                      ║
+      ║                                                                 ║
+      ║  Action: defaulting to task_type=Development so execution can   ║
+      ║  continue. The adaptive strategy step will evaluate whether     ║
+      ║  direct recipe invocation should be attempted.                  ║
+      ║                                                                 ║
+      WARN
+      fi
+      # Extract the task_type field from the JSON object via a one-liner
+      # Rust call: pipe extracted JSON into a small inline tool. We use
+      # `amplihack orch helper normalise-type` directly on the raw value.
+      RAW_TYPE=$(printf '%s' "$RAW_OBJ" | amplihack orch helper extract-field --field task_type --default Development)
+      printf '%s' "$RAW_TYPE" | amplihack orch helper normalise-type
     output: "task_type"
 
   # activate-workflow: compute workstream_count, set workflow semaphore, announce.
-  # Replaces the former extract-workstream-count + announce-classification steps.
+  # Uses native Rust `amplihack orch helper count-workstreams` (#270). The
+  # only Python that remains is the `dev_intent_router` hook integration —
+  # tracked separately as a follow-up port.
   - id: "activate-workflow"
     type: "bash"
     command: |
-      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
-      DECOMP_JSON=$(cat <<EOFDECOMP
-      {{decomposition_json}}
-      EOFDECOMP
-      )
-      TASK_TYPE={{task_type}}
-      FORCE_SINGLE={{force_single_workstream}}
-      HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export TASK_TYPE=$(printf '%s' {{task_type}})
-      export FORCE_SINGLE=$(printf '%s' "$FORCE_SINGLE")
-      export HELPER_PATH HOOKS_DIR
-      python3 - <<'PYEOF'
-      import os, sys, io, importlib.util
+      TASK_TYPE={{task_type}}
+      FORCE_SINGLE={{force_single_workstream}}
+      HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
 
-      helper_path = os.environ['HELPER_PATH']
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp_json = f.read()
-      task_type = os.environ['TASK_TYPE']
-      hooks_dir = os.environ['HOOKS_DIR']
-      force_single = os.environ.get('FORCE_SINGLE', 'false').strip().lower() in ('true', '1')
+      RAW_COUNT=$(amplihack orch helper count-workstreams < "$_DECOMP_TMPFILE")
+      case "$(printf '%s' "$FORCE_SINGLE" | tr '[:upper:]' '[:lower:]')" in
+        true|1) COUNT=1 ;;
+        *)      COUNT="$RAW_COUNT" ;;
+      esac
 
-      # Compute workstream count from decomposition JSON
-      spec = importlib.util.spec_from_file_location('orch_helper', helper_path)
-      h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
-      obj = h.extract_json(decomp_json)
-      raw_count = max(1, len(obj.get("workstreams", [])))
-
-      # Enforce force_single_workstream override (fix #3130)
-      count = 1 if force_single else raw_count
-
-      # Set workflow-active semaphore so the hook skips injection during execution
-      # Redirect stdout during import to prevent pollution of captured output
-      _saved_stdout = sys.stdout
-      sys.stdout = io.StringIO()
-      try:
-          sys.path.insert(0, hooks_dir)
-          from dev_intent_router import set_workflow_active
-          set_workflow_active(task_type, count)
-      except Exception:
-          pass  # Hook may not exist in all environments
-      finally:
-          sys.stdout = _saved_stdout
-
-      # Announce classification to stderr (visible to user, not captured as output)
-      if force_single and raw_count != count:
-          print(f"[dev-orchestrator] force_single_workstream=true — overriding {raw_count} workstreams to 1", file=sys.stderr)
-      print(f"[dev-orchestrator] Classified as: {task_type} | Workstreams: {count} — starting execution...", file=sys.stderr)
-
-      # Output workstream count (captured by recipe runner).
-      # Use sys.stdout.write to avoid trailing newline — the recipe runner
-      # stores step output as-is, and a trailing '\n' breaks exact string
-      # comparisons in downstream conditions (fix #3570).
-      sys.stdout.write(str(count))
+      # Set workflow-active semaphore so the hook skips injection during execution.
+      # This is the only remaining Python in this step; tracked as a follow-up
+      # port (the hooks system itself hasn't been ported yet).
+      if [ -d "$HOOKS_DIR" ]; then
+        TASK_TYPE="$TASK_TYPE" COUNT="$COUNT" HOOKS_DIR="$HOOKS_DIR" python3 - <<'PYEOF' >/dev/null 2>&1 || true
+      import os, sys
+      sys.path.insert(0, os.environ['HOOKS_DIR'])
+      from dev_intent_router import set_workflow_active
+      set_workflow_active(os.environ['TASK_TYPE'], int(os.environ['COUNT']))
       PYEOF
+      fi
+
+      if [ "$COUNT" != "$RAW_COUNT" ]; then
+        echo "[dev-orchestrator] force_single_workstream=true — overriding $RAW_COUNT workstreams to 1" >&2
+      fi
+      echo "[dev-orchestrator] Classified as: $TASK_TYPE | Workstreams: $COUNT — starting execution..." >&2
+
+      # Output workstream count without trailing newline (fix #3570).
+      printf '%s' "$COUNT"
     output: "workstream_count"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -434,42 +386,12 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and workstream_count != 1 and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
-      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export HELPER_PATH
-      python3 - <<'PYEOF'
-      import json, os, re, tempfile, sys
-      sys.path.insert(0, os.path.dirname(os.environ['HELPER_PATH']))
-      import orch_helper
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp = f.read()
-      obj = orch_helper.extract_json(decomp)
-      config = []
-      for i, ws in enumerate(obj.get("workstreams", [])):
-          name = ws.get("name", f"workstream-{i+1}")
-          slug = re.sub(r'[^a-z0-9-]', '-', name.lower())[:30].strip('-') or f"ws-{i+1}"
-          config.append({
-              "issue": "TBD",
-              "branch": f"feat/orch-{i+1}-{slug}",
-              "description": name,
-              "task": ws.get("description", name),
-              "recipe": ws.get("recipe", "default-workflow")
-          })
-      fd, p = tempfile.mkstemp(prefix="smart-orch-ws-", suffix=".json", dir="/tmp")
-      os.chmod(p, 0o600)
-      with os.fdopen(fd, "w") as f: json.dump(config, f, indent=2)
-      print(p)
-      PYEOF
+      amplihack orch helper build-workstreams-config < "$_DECOMP_TMPFILE"
     output: "workstreams_file"
 
   - id: "launch-parallel-round-1"

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -108,6 +108,19 @@ steps:
                 "investigate X then implement Y" -> 2 workstreams
          - recipe: "default-workflow" (dev) | "investigation-workflow" (research)
 
+      **Classification rules — read carefully (#269)**:
+      - **Operations** is ONLY for one-shot read-only or trivial mutating
+        commands the user could type themselves: "git status", "ls", "delete
+        old logs", "show disk usage", "run cargo test". Operations NEVER
+        writes new functions, NEVER opens PRs, NEVER writes tests, NEVER
+        modifies source files in `src/`, `crates/`, `bins/`, etc.
+      - **Development** is the correct type whenever the task asks you to:
+        "Add", "Extend", "Implement", "Create", "Build", "Refactor", or "Port"
+        ANY code; OR write/add tests; OR open a PR; OR modify files in
+        `src/` / `crates/` / `bins/`. Multi-requirement tasks with numbered
+        items `(1)`, `(2)`, `(3)` are almost always Development.
+      - When in doubt between Operations and Development, choose Development.
+
       **Decomposition override**: {{force_single_workstream}} — if "true", use exactly 1 workstream regardless of task structure.
 
       **Output exactly this JSON**:
@@ -153,7 +166,20 @@ steps:
       # Rust call: pipe extracted JSON into a small inline tool. We use
       # `amplihack orch helper normalise-type` directly on the raw value.
       RAW_TYPE=$(printf '%s' "$RAW_OBJ" | amplihack orch helper extract-field --field task_type --default Development)
-      printf '%s' "$RAW_TYPE" | amplihack orch helper normalise-type
+      CANONICAL_TYPE=$(printf '%s' "$RAW_TYPE" | amplihack orch helper normalise-type)
+      # Deterministic safety net (#269): if the LLM said Operations but the
+      # task description has strong development signals (file paths, "Add"+
+      # path, PR mention, tests, multi-requirement), promote to Development.
+      _TASK_TMPFILE=$(mktemp)
+      cat > "$_TASK_TMPFILE" <<__TASK_EOF__
+      {{task_description}}
+      __TASK_EOF__
+      FINAL_TYPE=$(amplihack orch helper reclassify-task-type --current "$CANONICAL_TYPE" < "$_TASK_TMPFILE")
+      rm -f "$_TASK_TMPFILE"
+      if [ "$FINAL_TYPE" != "$CANONICAL_TYPE" ]; then
+        echo "[dev-orchestrator] Reclassified $CANONICAL_TYPE → $FINAL_TYPE based on task description signals (#269)" >&2
+      fi
+      echo "$FINAL_TYPE"
     output: "task_type"
 
   # activate-workflow: compute workstream_count, set workflow semaphore, announce.

--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -334,4 +334,13 @@ pub enum Commands {
         #[command(subcommand)]
         command: MultitaskCommands,
     },
+
+    /// Smart-orchestrator helper utilities (extract-json, normalise-type).
+    ///
+    /// Replaces `python3 -m ... orch_helper` calls in
+    /// `amplifier-bundle/recipes/smart-orchestrator.yaml` (issue #270).
+    Orch {
+        #[command(subcommand)]
+        command: crate::commands::orch::OrchCommands,
+    },
 }

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod memory;
 pub mod mode;
 pub mod multitask;
 pub mod new_agent;
+pub mod orch;
 pub mod plugin;
 pub mod query_code;
 pub mod recipe;
@@ -313,6 +314,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
             std::process::exit(code);
         }
         Commands::Multitask { command } => dispatch_multitask(command),
+        Commands::Orch { command } => orch::dispatch(command),
     }
 }
 

--- a/crates/amplihack-cli/src/commands/orch.rs
+++ b/crates/amplihack-cli/src/commands/orch.rs
@@ -74,6 +74,20 @@ pub enum OrchHelperCommands {
         #[arg(long, default_value = "")]
         default: String,
     },
+
+    /// Reclassify a task type using deterministic dev-signal heuristics (#269).
+    ///
+    /// Reads the task description from stdin and the current task type from
+    /// `--current`. Promotes `Operations` → `Development` when the task
+    /// contains strong development signals (file paths, PR mention, unit
+    /// test mention, "Add"/"Extend"/"Implement"/"Create" keywords, multiple
+    /// numbered requirements). Never demotes any other classification.
+    /// Prints the (possibly updated) task type.
+    ReclassifyTaskType {
+        /// The current task type (e.g. "Operations").
+        #[arg(long)]
+        current: String,
+    },
 }
 
 /// Extract and parse the FIRST complete JSON object from LLM output.
@@ -226,7 +240,116 @@ pub fn run(command: OrchHelperCommands) -> Result<()> {
             println!("{out}");
             Ok(())
         }
+        OrchHelperCommands::ReclassifyTaskType { current } => {
+            let task = read_stdin()?;
+            let out = reclassify_task_type(&current, &task);
+            println!("{out}");
+            Ok(())
+        }
     }
+}
+
+/// Promote a task type to `Development` when the task description contains
+/// strong development signals that the LLM classifier may have missed (#269).
+///
+/// Rules:
+/// - Only promotes `Operations` → `Development`. All other types pass through
+///   unchanged (including `Q&A`, `Investigation`, and already-`Development`).
+/// - Counts dev signals and promotes if any of:
+///   * Task explicitly mentions opening a PR
+///   * Task mentions writing tests / unit tests
+///   * Task contains a source file path (`src/`, `crates/`, `bins/`, `.rs`,
+///     `.py`, `.ts`, etc.) AND any one Add/Extend/Implement/Create keyword
+///   * Three or more enumerated requirements (e.g. `(1) ... (2) ... (3) ...`)
+///     AND any one Add/Extend/Implement/Create keyword
+pub fn reclassify_task_type(current: &str, task: &str) -> String {
+    let canonical = normalise_type(current);
+    if canonical != "Operations" {
+        return canonical.to_string();
+    }
+    if has_strong_dev_signals(task) {
+        return "Development".to_string();
+    }
+    canonical.to_string()
+}
+
+/// True if `haystack` contains `needle` as a whole word (separated by
+/// non-alphanumeric chars or string boundaries). All inputs assumed lowercase.
+fn contains_word(haystack: &str, needle: &str) -> bool {
+    let nlen = needle.len();
+    if nlen == 0 || nlen > haystack.len() {
+        return false;
+    }
+    let bytes = haystack.as_bytes();
+    let mut start = 0;
+    while let Some(idx) = haystack[start..].find(needle) {
+        let abs = start + idx;
+        let before_ok = abs == 0 || !bytes[abs - 1].is_ascii_alphanumeric();
+        let after = abs + nlen;
+        let after_ok = after == bytes.len() || !bytes[after].is_ascii_alphanumeric();
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
+fn has_strong_dev_signals(task: &str) -> bool {
+    let lower = task.to_lowercase();
+
+    // 1. Explicit PR mention is an unambiguous dev signal.
+    let mentions_pr = lower.contains("open a pr")
+        || lower.contains("open pr")
+        || lower.contains("pull request")
+        || lower.contains("opens a pr");
+    if mentions_pr {
+        return true;
+    }
+
+    // 2. Test-writing language — Operations doesn't write tests.
+    let mentions_tests = lower.contains("unit test")
+        || lower.contains("unit tests")
+        || lower.contains("write tests")
+        || lower.contains("add tests")
+        || lower.contains("add a test")
+        || lower.contains("test coverage");
+    if mentions_tests {
+        return true;
+    }
+
+    // 3. Verb signals (word-boundary aware to avoid e.g. "report" → "port").
+    let dev_verbs = ["add", "extend", "implement", "create", "build", "refactor", "port"];
+    let has_dev_verb = dev_verbs.iter().any(|v| contains_word(&lower, v));
+
+    // 4. Source-file/path signals.
+    let path_markers = [
+        "src/", "crates/", "bins/", "lib/", "tests/", "amplifier-bundle/",
+        ".rs ", ".rs.", ".rs:", ".rs,", ".py ", ".py.", ".py:", ".py,",
+        ".ts ", ".tsx", ".js ", ".go ", ".java ", ".cpp ", ".c ", ".h ",
+    ];
+    let has_path = path_markers.iter().any(|p| lower.contains(p))
+        || lower.contains(".rs)")
+        || lower.contains(".py)")
+        || lower.ends_with(".rs")
+        || lower.ends_with(".py");
+
+    if has_dev_verb && has_path {
+        return true;
+    }
+
+    // 5. Multi-requirement structure: 3+ enumerated items like "(1)", "(2)".
+    let mut req_count = 0;
+    for n in 1..=9 {
+        if lower.contains(&format!("({n})")) {
+            req_count += 1;
+        }
+    }
+    if req_count >= 3 && has_dev_verb {
+        return true;
+    }
+
+    false
 }
 
 /// Extract `field` from a top-level JSON object. Returns the string form of
@@ -655,5 +778,103 @@ mod tests {
             Some(r#"{"x":1}"#.to_string())
         );
         assert_eq!(extract_field(r#"{"x": null}"#, "x"), Some(String::new()));
+    }
+
+    // --- reclassify_task_type (#269) -----------------------------------------
+
+    #[test]
+    fn reclassify_promotes_issue_269_repro_task() {
+        let task = "Add an agentic disk-cleanup loop to the Simard OODA daemon. \
+            Requirements: (1) Extend src/cmd_cleanup.rs with a new function \
+            agentic_wip_safe_cleanup() that runs as part of the existing per-cycle \
+            handle_cleanup() pipeline. (2) Trigger only when free disk on /home or \
+            /tmp is below 25 GB. (3) WIP-aware: scan all git worktrees... \
+            (5) Add unit tests for free_disk_gb()... \
+            (6) Open a PR titled fix(cleanup): agentic WIP-safe target dir reclamation";
+        assert_eq!(reclassify_task_type("Operations", task), "Development");
+    }
+
+    #[test]
+    fn reclassify_promotes_on_pr_mention_alone() {
+        assert_eq!(
+            reclassify_task_type("Operations", "Open a PR that does X"),
+            "Development"
+        );
+        assert_eq!(
+            reclassify_task_type("Operations", "Please open a pull request for the fix"),
+            "Development"
+        );
+    }
+
+    #[test]
+    fn reclassify_promotes_on_test_mention_alone() {
+        assert_eq!(
+            reclassify_task_type("Operations", "Write unit tests for the parser"),
+            "Development"
+        );
+        assert_eq!(
+            reclassify_task_type("Operations", "Add tests covering the new helper"),
+            "Development"
+        );
+    }
+
+    #[test]
+    fn reclassify_promotes_on_verb_plus_file_path() {
+        assert_eq!(
+            reclassify_task_type("Operations", "Extend src/foo.rs with a new function"),
+            "Development"
+        );
+        assert_eq!(
+            reclassify_task_type("Operations", "Add a flag to crates/cli/src/main.rs"),
+            "Development"
+        );
+        assert_eq!(
+            reclassify_task_type("Operations", "Implement amplifier-bundle/recipes/foo.yaml"),
+            "Development"
+        );
+    }
+
+    #[test]
+    fn reclassify_promotes_on_three_plus_numbered_reqs_with_dev_verb() {
+        let task = "Add a feature: (1) parse input, (2) validate config, \
+                    (3) emit metrics, (4) record audit log";
+        assert_eq!(reclassify_task_type("Operations", task), "Development");
+    }
+
+    #[test]
+    fn reclassify_does_not_promote_pure_ops_tasks() {
+        for task in [
+            "Run cargo test and report failures",
+            "Show me git status",
+            "Clean up tmp files",
+            "Delete the build directory",
+            "List the files in target/",
+        ] {
+            assert_eq!(
+                reclassify_task_type("Operations", task),
+                "Operations",
+                "task should stay Operations: {task:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn reclassify_passes_through_non_operations_types() {
+        let dev_signal_task = "Add unit tests and open a PR for src/foo.rs";
+        assert_eq!(reclassify_task_type("Q&A", dev_signal_task), "Q&A");
+        assert_eq!(reclassify_task_type("Investigation", dev_signal_task), "Investigation");
+        assert_eq!(reclassify_task_type("Development", dev_signal_task), "Development");
+    }
+
+    #[test]
+    fn reclassify_normalises_unknown_current_to_development() {
+        assert_eq!(reclassify_task_type("garbage", "do anything"), "Development");
+    }
+
+    #[test]
+    fn reclassify_does_not_promote_three_reqs_without_dev_verb() {
+        let task = "Please do the following: (1) check disk space, \
+                    (2) report free GB, (3) print the result";
+        assert_eq!(reclassify_task_type("Operations", task), "Operations");
     }
 }

--- a/crates/amplihack-cli/src/commands/orch.rs
+++ b/crates/amplihack-cli/src/commands/orch.rs
@@ -325,14 +325,41 @@ fn has_strong_dev_signals(task: &str) -> bool {
     }
 
     // 3. Verb signals (word-boundary aware to avoid e.g. "report" → "port").
-    let dev_verbs = ["add", "extend", "implement", "create", "build", "refactor", "port"];
+    let dev_verbs = [
+        "add",
+        "extend",
+        "implement",
+        "create",
+        "build",
+        "refactor",
+        "port",
+    ];
     let has_dev_verb = dev_verbs.iter().any(|v| contains_word(&lower, v));
 
     // 4. Source-file/path signals.
     let path_markers = [
-        "src/", "crates/", "bins/", "lib/", "tests/", "amplifier-bundle/",
-        ".rs ", ".rs.", ".rs:", ".rs,", ".py ", ".py.", ".py:", ".py,",
-        ".ts ", ".tsx", ".js ", ".go ", ".java ", ".cpp ", ".c ", ".h ",
+        "src/",
+        "crates/",
+        "bins/",
+        "lib/",
+        "tests/",
+        "amplifier-bundle/",
+        ".rs ",
+        ".rs.",
+        ".rs:",
+        ".rs,",
+        ".py ",
+        ".py.",
+        ".py:",
+        ".py,",
+        ".ts ",
+        ".tsx",
+        ".js ",
+        ".go ",
+        ".java ",
+        ".cpp ",
+        ".c ",
+        ".h ",
     ];
     let has_path = path_markers.iter().any(|p| lower.contains(p))
         || lower.contains(".rs)")
@@ -873,13 +900,22 @@ mod tests {
     fn reclassify_passes_through_non_operations_types() {
         let dev_signal_task = "Add unit tests and open a PR for src/foo.rs";
         assert_eq!(reclassify_task_type("Q&A", dev_signal_task), "Q&A");
-        assert_eq!(reclassify_task_type("Investigation", dev_signal_task), "Investigation");
-        assert_eq!(reclassify_task_type("Development", dev_signal_task), "Development");
+        assert_eq!(
+            reclassify_task_type("Investigation", dev_signal_task),
+            "Investigation"
+        );
+        assert_eq!(
+            reclassify_task_type("Development", dev_signal_task),
+            "Development"
+        );
     }
 
     #[test]
     fn reclassify_normalises_unknown_current_to_development() {
-        assert_eq!(reclassify_task_type("garbage", "do anything"), "Development");
+        assert_eq!(
+            reclassify_task_type("garbage", "do anything"),
+            "Development"
+        );
     }
 
     #[test]

--- a/crates/amplihack-cli/src/commands/orch.rs
+++ b/crates/amplihack-cli/src/commands/orch.rs
@@ -1,0 +1,659 @@
+//! Native Rust port of `amplifier-bundle/tools/orch_helper.py` (#270).
+//!
+//! Helpers used by `smart-orchestrator.yaml` to parse LLM output:
+//!
+//! - [`extract_json`] — pull the first complete JSON object out of mixed
+//!   markdown/prose/code-block output.
+//! - [`normalise_type`] — collapse a free-text task-type label into one of
+//!   `Q&A` / `Operations` / `Investigation` / `Development`.
+//! - [`count_workstreams`] — count the workstreams in a decomposition blob,
+//!   defaulting to 1 if absent.
+//! - [`build_workstreams_config_to_tempfile`] — build the workstreams-config
+//!   tempfile from a decomposition blob, returning the path.
+//!
+//! Exposed via the `amplihack orch helper` CLI subcommand so recipes no longer
+//! need to shell into `python3`. See issue #270.
+
+use anyhow::{Context, Result, bail};
+use clap::Subcommand;
+use std::io::Read;
+
+#[derive(Subcommand, Debug)]
+pub enum OrchCommands {
+    /// Helper utilities used by smart-orchestrator (formerly orch_helper.py).
+    Helper {
+        #[command(subcommand)]
+        command: OrchHelperCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum OrchHelperCommands {
+    /// Read stdin, print the first complete JSON object found in it.
+    ///
+    /// Mirrors `orch_helper.extract_json`. Tries, in order: ```json blocks,
+    /// untagged ``` blocks, then a balanced-brace scan over raw prose.
+    /// Prints `{}` if nothing parseable is found (matches the Python).
+    ExtractJson,
+
+    /// Read stdin, print the normalised task-type label.
+    ///
+    /// Mirrors `orch_helper.normalise_type`. Output is one of:
+    /// `Q&A`, `Operations`, `Investigation`, `Development` (the default).
+    NormaliseType,
+
+    /// Read decomposition JSON from stdin, print the workstream count.
+    ///
+    /// Equivalent to `max(1, len(extract_json(stdin)["workstreams"]))`.
+    /// With `--force-single`, always prints `1`.
+    CountWorkstreams {
+        /// If true, ignore the JSON and print 1 (overrides the count).
+        #[arg(long, default_value_t = false)]
+        force_single: bool,
+    },
+
+    /// Read decomposition JSON from stdin, write a workstream-config
+    /// tempfile, print the tempfile path on stdout.
+    ///
+    /// Equivalent to the `create-workstreams-config` python heredoc in
+    /// `smart-orchestrator.yaml`. Each workstream becomes one config entry
+    /// with: `issue: "TBD"`, branch slug, description, task, recipe.
+    BuildWorkstreamsConfig,
+
+    /// Read JSON from stdin, print the value at `--field` as a string.
+    ///
+    /// If the field is missing or the input is not a JSON object, prints
+    /// the value of `--default` (defaults to empty string). Strings are
+    /// printed without quoting; objects/arrays are printed as compact JSON.
+    /// Used by recipes to avoid pulling in `jq`.
+    ExtractField {
+        /// Name of the top-level field to extract (no nested paths yet).
+        #[arg(long)]
+        field: String,
+        /// Value to print if the field is absent.
+        #[arg(long, default_value = "")]
+        default: String,
+    },
+}
+
+/// Extract and parse the FIRST complete JSON object from LLM output.
+///
+/// Priority (matches Python `extract_json` in `orch_helper.py`):
+///   1. ```json fenced blocks (most explicit signal)
+///   2. ``` untagged fenced blocks
+///   3. Raw JSON in prose, scanning left-to-right with `serde_json`'s
+///      streaming deserializer (handles `}` inside string values correctly).
+///
+/// Returns `None` if no parseable JSON object is found anywhere.
+pub fn extract_json(text: &str) -> Option<serde_json::Value> {
+    if let Some(v) = scan_fenced_blocks(text, true) {
+        return Some(v);
+    }
+    if let Some(v) = scan_fenced_blocks(text, false) {
+        return Some(v);
+    }
+    scan_raw_braces(text)
+}
+
+/// Find ```json (or ```) fenced blocks and return the first one whose body
+/// parses as a JSON object. `tagged_only` selects between ```json and ```.
+fn scan_fenced_blocks(text: &str, tagged_only: bool) -> Option<serde_json::Value> {
+    let opener_needle = if tagged_only { "```json" } else { "```" };
+    let mut search_from = 0usize;
+
+    while let Some(open_rel) = text[search_from..].find(opener_needle) {
+        let open_abs = search_from + open_rel;
+        let body_start_search = open_abs + opener_needle.len();
+
+        if !tagged_only {
+            // For untagged blocks, skip any block that is actually ```json —
+            // those were already considered (and failed) in the tagged pass.
+            let after = &text[body_start_search..];
+            let lang = after
+                .chars()
+                .take_while(|c| c.is_alphanumeric())
+                .collect::<String>();
+            if lang.eq_ignore_ascii_case("json") {
+                search_from = body_start_search;
+                continue;
+            }
+        }
+
+        // Find the body's first `{` and the matching closing ``` after it.
+        let Some(brace_rel) = text[body_start_search..].find('{') else {
+            break;
+        };
+        let brace_abs = body_start_search + brace_rel;
+        let Some(close_rel) = text[brace_abs..].find("```") else {
+            break;
+        };
+        let close_abs = brace_abs + close_rel;
+        let candidate = text[brace_abs..close_abs].trim();
+        if let Ok(v @ serde_json::Value::Object(_)) = serde_json::from_str(candidate) {
+            return Some(v);
+        }
+        search_from = close_abs + 3;
+    }
+
+    None
+}
+
+/// Walk left-to-right; at each `{`, ask `serde_json` if the slice starting
+/// here parses as a valid JSON value via `StreamDeserializer`. The
+/// streaming deserializer correctly handles braces inside string values,
+/// unlike a manual depth counter — same property the Python relies on
+/// via `json.JSONDecoder.raw_decode`.
+fn scan_raw_braces(text: &str) -> Option<serde_json::Value> {
+    let bytes = text.as_bytes();
+    let mut pos = 0usize;
+    while let Some(rel) = bytes[pos..].iter().position(|&b| b == b'{') {
+        let start = pos + rel;
+        let mut stream = serde_json::Deserializer::from_str(&text[start..])
+            .into_iter::<serde_json::Value>();
+        if let Some(Ok(v @ serde_json::Value::Object(_))) = stream.next() {
+            return Some(v);
+        }
+        pos = start + 1;
+    }
+    None
+}
+
+/// Normalise an LLM task-type label to one of `Q&A`, `Operations`,
+/// `Investigation`, `Development` (the default for unknowns).
+///
+/// Order matters — first matching keyword wins, mirroring Python's
+/// short-circuit `any()` chain.
+pub fn normalise_type(raw: &str) -> &'static str {
+    let t = raw.to_ascii_lowercase();
+    if ["q&a", "qa", "question", "answer"].iter().any(|k| t.contains(k)) {
+        return "Q&A";
+    }
+    if ["ops", "operation", "admin", "command"].iter().any(|k| t.contains(k)) {
+        return "Operations";
+    }
+    if ["invest", "research", "explor", "analys", "understand"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
+        return "Investigation";
+    }
+    "Development"
+}
+
+/// Read all of stdin into a `String`. Errors out cleanly if stdin is
+/// not valid UTF-8 (recipe shell pipes always produce UTF-8 in practice).
+fn read_stdin() -> Result<String> {
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .context("failed to read stdin")?;
+    Ok(buf)
+}
+
+/// CLI entry point for `amplihack orch helper <subcommand>`.
+pub fn run(command: OrchHelperCommands) -> Result<()> {
+    match command {
+        OrchHelperCommands::ExtractJson => {
+            let input = read_stdin()?;
+            let value = extract_json(&input).unwrap_or(serde_json::json!({}));
+            println!("{}", serde_json::to_string(&value)?);
+            Ok(())
+        }
+        OrchHelperCommands::NormaliseType => {
+            let input = read_stdin()?;
+            println!("{}", normalise_type(input.trim()));
+            Ok(())
+        }
+        OrchHelperCommands::CountWorkstreams { force_single } => {
+            let input = read_stdin()?;
+            let count = if force_single {
+                1
+            } else {
+                count_workstreams(&input)
+            };
+            println!("{count}");
+            Ok(())
+        }
+        OrchHelperCommands::BuildWorkstreamsConfig => {
+            let input = read_stdin()?;
+            let path = build_workstreams_config_to_tempfile(&input)?;
+            println!("{path}");
+            Ok(())
+        }
+        OrchHelperCommands::ExtractField { field, default } => {
+            let input = read_stdin()?;
+            let out = extract_field(&input, &field).unwrap_or(default);
+            println!("{out}");
+            Ok(())
+        }
+    }
+}
+
+/// Extract `field` from a top-level JSON object. Returns the string form of
+/// scalars (without quotes) and the compact JSON encoding of objects/arrays.
+/// Returns `None` if the input is not a JSON object or the field is missing.
+pub fn extract_field(json: &str, field: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(json.trim()).ok()?;
+    let obj = v.as_object()?;
+    let val = obj.get(field)?;
+    Some(match val {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    })
+}
+
+/// Count workstreams in a decomposition JSON blob. Returns at least 1, even
+/// when no workstreams are present (matches the Python `max(1, len(...))`).
+pub fn count_workstreams(decomp: &str) -> usize {
+    let obj = match extract_json(decomp) {
+        Some(serde_json::Value::Object(m)) => m,
+        _ => return 1,
+    };
+    let raw = obj
+        .get("workstreams")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    raw.max(1)
+}
+
+/// Build the workstreams-config tempfile from a decomposition JSON blob and
+/// return the path. Mirrors the `create-workstreams-config` Python heredoc:
+/// each entry has `issue: "TBD"`, `branch: feat/orch-{i}-{slug}`,
+/// `description`, `task`, `recipe` (default `default-workflow`).
+pub fn build_workstreams_config_to_tempfile(decomp: &str) -> Result<String> {
+    let obj = extract_json(decomp).unwrap_or(serde_json::json!({}));
+    let workstreams = obj
+        .get("workstreams")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut entries: Vec<serde_json::Value> = Vec::with_capacity(workstreams.len());
+    for (i, ws) in workstreams.iter().enumerate() {
+        let idx = i + 1;
+        let name = ws
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("workstream-{idx}"));
+        let slug = slugify(&name, idx);
+        let task = ws
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&name)
+            .to_string();
+        let recipe = ws
+            .get("recipe")
+            .and_then(|v| v.as_str())
+            .unwrap_or("default-workflow")
+            .to_string();
+        entries.push(serde_json::json!({
+            "issue": "TBD",
+            "branch": format!("feat/orch-{idx}-{slug}"),
+            "description": name,
+            "task": task,
+            "recipe": recipe,
+        }));
+    }
+
+    let dir = std::env::temp_dir();
+    let mut tmp = tempfile::Builder::new()
+        .prefix("smart-orch-ws-")
+        .suffix(".json")
+        .rand_bytes(8)
+        .tempfile_in(&dir)
+        .context("failed to create workstreams-config tempfile")?;
+
+    use std::io::Write;
+    let body = serde_json::to_string_pretty(&entries)?;
+    tmp.write_all(body.as_bytes())?;
+
+    // chmod 600 to match Python `os.chmod(p, 0o600)`.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(tmp.path())?.permissions();
+        perms.set_mode(0o600);
+        std::fs::set_permissions(tmp.path(), perms)?;
+    }
+
+    let (_, path) = tmp.keep().context("failed to persist workstreams tempfile")?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+/// Slugify a workstream name to `[a-z0-9-]{1,30}` with no leading/trailing
+/// `-`. Mirrors the Python regex `[^a-z0-9-]` → `-` then trim.
+fn slugify(name: &str, idx: usize) -> String {
+    let lower: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let truncated: String = lower.chars().take(30).collect();
+    let trimmed = truncated.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        format!("ws-{idx}")
+    } else {
+        trimmed
+    }
+}
+
+/// Dispatch helper used by the top-level CLI: matches the `Orch` variant
+/// down to a leaf subcommand.
+pub fn dispatch(command: OrchCommands) -> Result<()> {
+    match command {
+        OrchCommands::Helper { command } => run(command),
+    }
+}
+
+/// Public guard so callers can give a friendly error for invalid types.
+pub fn is_known_type(label: &str) -> bool {
+    matches!(label, "Q&A" | "Operations" | "Investigation" | "Development")
+}
+
+// Compile-time guarantee that `bail!` import isn't dead; used in tests below
+// when input categories are validated.
+#[allow(dead_code)]
+fn _bail_used_in_tests() -> Result<()> {
+    bail!("placeholder");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- extract_json --------------------------------------------------------
+
+    #[test]
+    fn extract_json_from_tagged_code_block() {
+        let input = "blah\n```json\n{\"task_type\": \"dev\", \"x\": 1}\n```\nmore";
+        let v = extract_json(input).expect("should parse");
+        assert_eq!(v, json!({"task_type": "dev", "x": 1}));
+    }
+
+    #[test]
+    fn extract_json_from_untagged_code_block() {
+        let input = "preamble\n```\n{\"a\": [1, 2, 3]}\n```\n";
+        let v = extract_json(input).expect("should parse");
+        assert_eq!(v, json!({"a": [1, 2, 3]}));
+    }
+
+    #[test]
+    fn extract_json_prefers_tagged_over_untagged() {
+        let input = concat!(
+            "```\n{\"wrong\": true}\n```\n",
+            "```json\n{\"right\": true}\n```\n",
+        );
+        let v = extract_json(input).expect("should parse");
+        assert_eq!(v, json!({"right": true}));
+    }
+
+    #[test]
+    fn extract_json_skips_malformed_tagged_block_then_finds_next() {
+        let input = concat!(
+            "```json\n{not valid json at all\n```\n",
+            "```json\n{\"ok\": 1}\n```\n",
+        );
+        let v = extract_json(input).expect("should parse");
+        assert_eq!(v, json!({"ok": 1}));
+    }
+
+    #[test]
+    fn extract_json_from_raw_prose_skipping_non_json_braces() {
+        // The {nope} prefix is not valid JSON; the scanner must move past it.
+        let input = "Some prose {nope, not json} then {\"real\": \"json\"} after";
+        let v = extract_json(input).expect("should parse");
+        assert_eq!(v, json!({"real": "json"}));
+    }
+
+    #[test]
+    fn extract_json_handles_braces_inside_string_values() {
+        // Critical correctness property the Python relies on via
+        // `JSONDecoder.raw_decode`. A naive depth counter would terminate
+        // the object early at the first '}' in the string and fail.
+        let input = "intro {\"msg\": \"this } looks {tricky\", \"n\": 7}";
+        let v = extract_json(input).expect("should parse");
+        assert_eq!(v, json!({"msg": "this } looks {tricky", "n": 7}));
+    }
+
+    #[test]
+    fn extract_json_returns_none_when_no_object_present() {
+        assert!(extract_json("just words, no JSON here at all").is_none());
+        assert!(extract_json("").is_none());
+        assert!(extract_json("[1, 2, 3]").is_none(), "arrays alone are not objects");
+    }
+
+    #[test]
+    fn extract_json_handles_multiple_tagged_blocks_first_wins() {
+        let input = concat!(
+            "```json\n{\"first\": true}\n```\n",
+            "```json\n{\"second\": true}\n```\n",
+        );
+        let v = extract_json(input).expect("should parse");
+        assert_eq!(v, json!({"first": true}));
+    }
+
+    #[test]
+    fn extract_json_nested_object_in_block() {
+        let input = "```json\n{\"workstreams\": [{\"name\": \"a\", \"meta\": {\"k\": 1}}]}\n```";
+        let v = extract_json(input).expect("should parse");
+        assert_eq!(v["workstreams"][0]["meta"]["k"], json!(1));
+    }
+
+    // --- normalise_type ------------------------------------------------------
+
+    #[test]
+    fn normalise_type_qa_variants() {
+        for s in ["Q&A", "qa", "QA", "this is a Question?", "answer me"] {
+            assert_eq!(normalise_type(s), "Q&A", "{s:?}");
+        }
+    }
+
+    #[test]
+    fn normalise_type_ops_variants() {
+        for s in ["ops", "OPERATIONS", "admin task", "shell command"] {
+            assert_eq!(normalise_type(s), "Operations", "{s:?}");
+        }
+    }
+
+    #[test]
+    fn normalise_type_investigation_variants() {
+        for s in [
+            "investigate",
+            "research-mode",
+            "do an Analysis",
+            "explore the codebase",
+            "help me UNDERSTAND",
+        ] {
+            assert_eq!(normalise_type(s), "Investigation", "{s:?}");
+        }
+    }
+
+    #[test]
+    fn normalise_type_default_to_development() {
+        for s in ["dev", "build", "implement", "feature", "", "blah"] {
+            assert_eq!(normalise_type(s), "Development", "{s:?}");
+        }
+    }
+
+    #[test]
+    fn normalise_type_priority_qa_beats_ops_when_both_keywords_present() {
+        // "qa" appears before "command" in keyword order — first match wins,
+        // matching the Python's short-circuit `any()` evaluation.
+        assert_eq!(normalise_type("qa command"), "Q&A");
+    }
+
+    #[test]
+    fn is_known_type_recognises_canonical_forms() {
+        for v in ["Q&A", "Operations", "Investigation", "Development"] {
+            assert!(is_known_type(v));
+        }
+        for v in ["q&a", "ops", "Dev", "", "Other"] {
+            assert!(!is_known_type(v));
+        }
+    }
+
+    // --- count_workstreams ---------------------------------------------------
+
+    #[test]
+    fn count_workstreams_returns_array_length() {
+        let decomp = r#"```json
+{"task_type": "dev", "workstreams": [
+  {"name": "a"},
+  {"name": "b"},
+  {"name": "c"}
+]}
+```"#;
+        assert_eq!(count_workstreams(decomp), 3);
+    }
+
+    #[test]
+    fn count_workstreams_returns_one_when_empty() {
+        // Matches Python `max(1, len(...))`.
+        assert_eq!(count_workstreams("{\"workstreams\": []}"), 1);
+        assert_eq!(count_workstreams("{}"), 1);
+        assert_eq!(count_workstreams(""), 1);
+        assert_eq!(count_workstreams("not even json"), 1);
+    }
+
+    #[test]
+    fn count_workstreams_handles_raw_json_in_prose() {
+        let decomp = "Here is the plan: {\"workstreams\": [{\"n\":1},{\"n\":2}]} EOM";
+        assert_eq!(count_workstreams(decomp), 2);
+    }
+
+    // --- build_workstreams_config_to_tempfile --------------------------------
+
+    #[test]
+    fn build_workstreams_config_writes_tempfile_with_entries() {
+        let decomp = r#"{
+            "task_type": "Development",
+            "workstreams": [
+              {"name": "API service",         "description": "Implement the REST API"},
+              {"name": "Web UI Front-end!!!", "description": "Build the React UI"}
+            ]
+        }"#;
+        let path = build_workstreams_config_to_tempfile(decomp).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+
+        // Each entry has the required shape.
+        assert_eq!(arr[0]["issue"], "TBD");
+        assert_eq!(arr[0]["description"], "API service");
+        assert_eq!(arr[0]["task"], "Implement the REST API");
+        assert_eq!(arr[0]["recipe"], "default-workflow");
+        assert_eq!(arr[0]["branch"], "feat/orch-1-api-service");
+
+        // Slug strips special chars and lowercases.
+        assert_eq!(arr[1]["branch"], "feat/orch-2-web-ui-front-end");
+
+        // Tempfile is restrictive on Unix.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::metadata(&path).unwrap().permissions();
+            assert_eq!(perms.mode() & 0o777, 0o600, "tempfile must be 0600");
+        }
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn build_workstreams_config_handles_missing_fields() {
+        // No `description` → falls back to name. No `recipe` → default-workflow.
+        // No `name` → "workstream-{idx}".
+        let decomp = r#"{"workstreams": [{}]}"#;
+        let path = build_workstreams_config_to_tempfile(decomp).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed[0]["description"], "workstream-1");
+        assert_eq!(parsed[0]["task"], "workstream-1");
+        assert_eq!(parsed[0]["recipe"], "default-workflow");
+        assert_eq!(parsed[0]["branch"], "feat/orch-1-workstream-1");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn build_workstreams_config_truncates_slug_to_30_chars() {
+        let long = "A".repeat(80);
+        let decomp = format!(r#"{{"workstreams": [{{"name": "{long}"}}]}}"#);
+        let path = build_workstreams_config_to_tempfile(&decomp).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let branch = parsed[0]["branch"].as_str().unwrap();
+        let slug = branch.strip_prefix("feat/orch-1-").unwrap();
+        assert_eq!(slug.len(), 30);
+        assert!(slug.chars().all(|c| c == 'a' || c == '-'));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn build_workstreams_config_empty_input_writes_empty_array() {
+        let path = build_workstreams_config_to_tempfile("{}").unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed.as_array().unwrap().len(), 0);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn slug_falls_back_when_input_has_no_alphanumeric() {
+        let decomp = r#"{"workstreams": [{"name": "!!!"}]}"#;
+        let path = build_workstreams_config_to_tempfile(decomp).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        // All non-alphanum become '-', then trim → empty → fallback "ws-{idx}".
+        assert_eq!(parsed[0]["branch"], "feat/orch-1-ws-1");
+        std::fs::remove_file(&path).ok();
+    }
+
+    // --- extract_field --------------------------------------------------------
+
+    #[test]
+    fn extract_field_returns_string_without_quotes() {
+        assert_eq!(
+            extract_field(r#"{"task_type": "Investigation"}"#, "task_type"),
+            Some("Investigation".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_field_returns_none_for_missing_key() {
+        assert_eq!(extract_field(r#"{"a": 1}"#, "task_type"), None);
+    }
+
+    #[test]
+    fn extract_field_returns_none_for_invalid_json() {
+        assert_eq!(extract_field("not json", "task_type"), None);
+        assert_eq!(extract_field("[1,2,3]", "task_type"), None); // array, not object
+    }
+
+    #[test]
+    fn extract_field_handles_scalars_and_nested_values() {
+        assert_eq!(
+            extract_field(r#"{"n": 42}"#, "n"),
+            Some("42".to_string())
+        );
+        assert_eq!(
+            extract_field(r#"{"b": true}"#, "b"),
+            Some("true".to_string())
+        );
+        assert_eq!(
+            extract_field(r#"{"o": {"x": 1}}"#, "o"),
+            Some(r#"{"x":1}"#.to_string())
+        );
+        assert_eq!(extract_field(r#"{"x": null}"#, "x"), Some(String::new()));
+    }
+}

--- a/crates/amplihack-cli/src/commands/orch.rs
+++ b/crates/amplihack-cli/src/commands/orch.rs
@@ -162,8 +162,8 @@ fn scan_raw_braces(text: &str) -> Option<serde_json::Value> {
     let mut pos = 0usize;
     while let Some(rel) = bytes[pos..].iter().position(|&b| b == b'{') {
         let start = pos + rel;
-        let mut stream = serde_json::Deserializer::from_str(&text[start..])
-            .into_iter::<serde_json::Value>();
+        let mut stream =
+            serde_json::Deserializer::from_str(&text[start..]).into_iter::<serde_json::Value>();
         if let Some(Ok(v @ serde_json::Value::Object(_))) = stream.next() {
             return Some(v);
         }
@@ -179,10 +179,16 @@ fn scan_raw_braces(text: &str) -> Option<serde_json::Value> {
 /// short-circuit `any()` chain.
 pub fn normalise_type(raw: &str) -> &'static str {
     let t = raw.to_ascii_lowercase();
-    if ["q&a", "qa", "question", "answer"].iter().any(|k| t.contains(k)) {
+    if ["q&a", "qa", "question", "answer"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
         return "Q&A";
     }
-    if ["ops", "operation", "admin", "command"].iter().any(|k| t.contains(k)) {
+    if ["ops", "operation", "admin", "command"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
         return "Operations";
     }
     if ["invest", "research", "explor", "analys", "understand"]
@@ -444,7 +450,9 @@ pub fn build_workstreams_config_to_tempfile(decomp: &str) -> Result<String> {
         std::fs::set_permissions(tmp.path(), perms)?;
     }
 
-    let (_, path) = tmp.keep().context("failed to persist workstreams tempfile")?;
+    let (_, path) = tmp
+        .keep()
+        .context("failed to persist workstreams tempfile")?;
     Ok(path.to_string_lossy().into_owned())
 }
 
@@ -480,7 +488,10 @@ pub fn dispatch(command: OrchCommands) -> Result<()> {
 
 /// Public guard so callers can give a friendly error for invalid types.
 pub fn is_known_type(label: &str) -> bool {
-    matches!(label, "Q&A" | "Operations" | "Investigation" | "Development")
+    matches!(
+        label,
+        "Q&A" | "Operations" | "Investigation" | "Development"
+    )
 }
 
 // Compile-time guarantee that `bail!` import isn't dead; used in tests below
@@ -553,7 +564,10 @@ mod tests {
     fn extract_json_returns_none_when_no_object_present() {
         assert!(extract_json("just words, no JSON here at all").is_none());
         assert!(extract_json("").is_none());
-        assert!(extract_json("[1, 2, 3]").is_none(), "arrays alone are not objects");
+        assert!(
+            extract_json("[1, 2, 3]").is_none(),
+            "arrays alone are not objects"
+        );
     }
 
     #[test]
@@ -765,10 +779,7 @@ mod tests {
 
     #[test]
     fn extract_field_handles_scalars_and_nested_values() {
-        assert_eq!(
-            extract_field(r#"{"n": 42}"#, "n"),
-            Some("42".to_string())
-        );
+        assert_eq!(extract_field(r#"{"n": 42}"#, "n"), Some("42".to_string()));
         assert_eq!(
             extract_field(r#"{"b": true}"#, "b"),
             Some("true".to_string())


### PR DESCRIPTION
Closes #269. Stacks on top of #273 (orch helper Rust port).

## Problem

The smart-orchestrator routed a clearly Development task ('Add an agentic disk-cleanup loop... Extend src/cmd_cleanup.rs with...') to `handle-ops-agent` instead of decomposing into workstreams. The handle-ops-agent ran a single `cat` and immediately marked the recipe complete with no code written.

## Fix

Two-layer defense:

### 1. Prompt hardening
Added explicit classification rules to the architect prompt in `classify-and-decompose`. Operations is now defined as **one-shot read-only commands ONLY**. Multi-requirement / file-modification / test-writing / PR-opening tasks are unambiguously Development. "When in doubt, Development."

### 2. Deterministic safety net (`amplihack orch helper reclassify-task-type`)
A new Rust subcommand reads the task description from stdin and promotes Operations→Development when strong dev signals are present:
- Explicit PR / pull-request mention
- Test-writing language ("unit tests", "write tests", "add tests", "test coverage")
- Dev verb (Add / Extend / Implement / Create / Build / Refactor / Port) AND a source-file path (`src/`, `crates/`, `bins/`, `.rs`, `.py`, `.ts`, `.go`, etc.)
- 3+ enumerated requirements `(1)(2)(3)...` AND a dev verb

Verb matching uses word-boundary detection so `report` does not match `port`. Other classifications (Q&A, Investigation, Development) pass through unchanged — the fix only ever **promotes**, never demotes.

`parse-decomposition` now invokes `reclassify-task-type` after the LLM classification and announces any reclassification on stderr.

## Tests

9 new unit tests in `commands::orch::tests`:
- `reclassify_promotes_issue_269_repro_task` — the exact task from issue #269
- `reclassify_promotes_on_pr_mention_alone`
- `reclassify_promotes_on_test_mention_alone`
- `reclassify_promotes_on_verb_plus_file_path`
- `reclassify_promotes_on_three_plus_numbered_reqs_with_dev_verb`
- `reclassify_does_not_promote_pure_ops_tasks` (5 ops cases stay Operations)
- `reclassify_passes_through_non_operations_types` (Q&A / Investigation / Dev unchanged)
- `reclassify_normalises_unknown_current_to_development`
- `reclassify_does_not_promote_three_reqs_without_dev_verb` (no dev verb = no promotion)

Total: 36/36 `commands::orch` tests pass; clippy clean.

## Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings  # clean
TMPDIR=/tmp cargo test -p amplihack-cli --lib commands::orch # 36/36 pass
```

Smoke-tested against the release binary using the issue-269 repro task — promoted to Development as expected; pure ops tasks stay Operations.