### PR TITLE
fix(docs): wire mkdocs --strict into PR CI, fix all broken links/anchors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,11 @@ on:
       - 'mkdocs.yml'
       - 'README.md'
       - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -34,6 +39,7 @@ jobs:
           path: site
 
   deploy:
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 *.pyc
 *.pyo
 worktrees/
+site/
 
 # Amplihack runtime directories (auto-generated)
 .claude/logs/

--- a/docs/howto/manage-tool-update-checks.md
+++ b/docs/howto/manage-tool-update-checks.md
@@ -3,8 +3,7 @@
 > **Scope of this guide**: This guide covers pre-launch npm tool update notices
 > only — the check that runs before `claude`, `copilot`, or `codex` is invoked.
 > For the separate `amplihack` binary self-update system (GitHub release
-> downloads with SHA-256 verification), see
-> [Update the amplihack Binary](../reference/update.md).
+> downloads with SHA-256 verification), see the `amplihack update` subcommand.
 
 Before launching `claude`, `copilot`, or `codex`, `amplihack` checks whether a
 newer version of the npm-distributed tool is available. When an update is found,
@@ -263,4 +262,4 @@ visible text.
 - [Run amplihack in Non-interactive Mode](./run-in-noninteractive-mode.md) — Full CI and pipeline guide
 - [Environment Variables](../reference/environment-variables.md) — `AMPLIHACK_NONINTERACTIVE`, `AMPLIHACK_PARITY_TEST`, and `AMPLIHACK_NO_UPDATE_CHECK` reference
 - [Launch Flag Injection](../reference/launch-flag-injection.md) — How `amplihack` builds the subprocess command line
-- [amplihack launch](../reference/launch-command.md) — Full CLI reference for launch subcommands
+- [Launch Flag Injection](../reference/launch-flag-injection.md) — How `amplihack` builds the subprocess command line for launch subcommands

--- a/docs/howto/resolve-kuzu-linker-errors.md
+++ b/docs/howto/resolve-kuzu-linker-errors.md
@@ -161,6 +161,6 @@ The root cause is in the lbug crate's `Cargo.toml`, which specifies `cxx-build =
 ## Related
 
 - [The cxx/cxx-build Version Contract](../concepts/cxx-version-contract.md) — Why the versions must match
-- [CONTRIBUTING_RUST.md](../../CONTRIBUTING_RUST.md) — Build and test commands
+- [CONTRIBUTING_RUST.md](https://github.com/rysweet/amplihack-rs/blob/main/CONTRIBUTING_RUST.md) — Build and test commands
 - [GitHub Issue #35](https://github.com/rysweet/amplihack-rs/issues/35) — Original report and investigation
 - [GitHub PR #43](https://github.com/rysweet/amplihack-rs/pull/43) — The fix

--- a/docs/howto/run-fleet-scout-and-advance.md
+++ b/docs/howto/run-fleet-scout-and-advance.md
@@ -10,7 +10,7 @@ opening a separate terminal for each VM.
 - [Prerequisites](#prerequisites)
 - [Run a scout report](#run-a-scout-report)
 - [Advance sessions interactively](#advance-sessions-interactively)
-- [Automate advance with --force](#automate-advance-with---force)
+- [Automate advance with --force](#automate-advance-with-force)
 - [Save reports to disk](#save-reports-to-disk)
 - [Use incremental scouting](#use-incremental-scouting)
 - [Target a single VM or session](#target-a-single-vm-or-session)

--- a/docs/howto/validate-no-python.md
+++ b/docs/howto/validate-no-python.md
@@ -134,5 +134,5 @@ before it. If you want to validate the release binary, pass `--release`:
 ## Related
 
 - [No-Python Compliance (AC9)](../concepts/kuzu-code-graph.md#security-model) — why this matters
-- [`scripts/probe-no-python.sh`](../../scripts/probe-no-python.sh) — the probe script itself
-- [Parity Test Scenarios](./parity-test-scenarios.md) — full parity test matrix
+- [`scripts/probe-no-python.sh`](https://github.com/rysweet/amplihack-rs/blob/main/scripts/probe-no-python.sh) — the probe script itself
+- [Parity Test Scenarios](../reference/parity-test-scenarios.md) — full parity test matrix

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,5 +89,5 @@ amplihack uninstall
 
 ## Related
 
-- [README](../README.md) — Architecture overview and design principles
-- [CONTRIBUTING_RUST.md](../CONTRIBUTING_RUST.md) — Developer setup, build targets, test harness
+- [README](https://github.com/rysweet/amplihack-rs/blob/main/README.md) — Architecture overview and design principles
+- [CONTRIBUTING_RUST.md](https://github.com/rysweet/amplihack-rs/blob/main/CONTRIBUTING_RUST.md) — Developer setup, build targets, test harness

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -9,7 +9,7 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [AMPLIHACK_ASSET_RESOLVER](#amplihack_asset_resolver)
   - [AMPLIHACK_HOME](#amplihack_home)
   - [AMPLIHACK_GRAPH_DB_PATH](#amplihack_graph_db_path)
-  - [AMPLIHACK_KUZU_DB_PATH](#amplihack_kuzu_db_path-legacy-alias)
+  - [AMPLIHACK_KUZU_DB_PATH](#amplihack_kuzu_db_path-backward-compatible-alias)
   - [AMPLIHACK_NONINTERACTIVE](#amplihack_noninteractive)
   - [AMPLIHACK_SESSION_ID](#amplihack_session_id)
   - [AMPLIHACK_DEPTH](#amplihack_depth)

--- a/docs/reference/launch-flag-injection.md
+++ b/docs/reference/launch-flag-injection.md
@@ -9,9 +9,9 @@ can override the defaults.
 ## Contents
 
 - [Injected flags overview](#injected-flags-overview)
-- [--dangerously-skip-permissions](#--dangerously-skip-permissions)
-- [--model](#--model)
-- [--resume and --continue](#--resume-and---continue)
+- [--dangerously-skip-permissions](#-dangerously-skip-permissions)
+- [--model](#-model)
+- [--resume and --continue](#-resume-and-continue)
 - [Extra args passthrough](#extra-args-passthrough)
 - [Complete command-line assembly](#complete-command-line-assembly)
 - [Python launcher parity](#python-launcher-parity)

--- a/docs/reference/parity-test-scenarios.md
+++ b/docs/reference/parity-test-scenarios.md
@@ -15,19 +15,19 @@ and what behaviour each tier validates.
   - [Comparison targets](#comparison-targets)
   - [Environment variable expansion](#environment-variable-expansion)
 - [Tier files](#tier-files)
-  - [tier1.yaml — Mode detection](#tier1yaml--mode-detection)
-  - [tier2-install.yaml — Install command](#tier2-installyaml--install-command)
-  - [tier2-plugin.yaml — Plugin command](#tier2-pluginyaml--plugin-command)
-  - [tier3-memory.yaml — Memory command](#tier3-memoryyaml--memory-command)
-  - [tier4-recipe-run.yaml — Recipe run](#tier4-recipe-runyaml--recipe-run)
-  - [tier5-e2e.yaml — End-to-end launch](#tier5-e2eyaml--end-to-end-launch)
-  - [tier5-gap-tests.yaml — Known gaps](#tier5-gap-testsyaml--known-gaps)
-  - [tier5-launcher.yaml — Launcher flags](#tier5-launcheryaml--launcher-flags)
-  - [tier5-live-recipe.yaml — Live recipe execution](#tier5-live-recipeyaml--live-recipe-execution)
-  - [tier5-malformed-yaml.yaml — Error handling](#tier5-malformed-yamalyaml--error-handling)
-  - [tier6-qa-bugfixes.yaml — QA regressions](#tier6-qa-bugfixesyaml--qa-regressions)
-  - [tier7-launcher-parity.yaml — Launcher gaps](#tier7-launcher-parityyaml--launcher-gaps)
-  - [tier8-env-vars.yaml — Environment variable injection](#tier8-env-varsyaml--environment-variable-injection)
+  - [tier1.yaml — Mode detection](#tier1yaml-mode-detection)
+  - [tier2-install.yaml — Install command](#tier2-installyaml-install-command)
+  - [tier2-plugin.yaml — Plugin command](#tier2-pluginyaml-plugin-command)
+  - [tier3-memory.yaml — Memory command](#tier3-memoryyaml-memory-command)
+  - [tier4-recipe-run.yaml — Recipe run](#tier4-recipe-runyaml-recipe-run)
+  - [tier5-e2e.yaml — End-to-end launch](#tier5-e2eyaml-end-to-end-launch)
+  - [tier5-gap-tests.yaml — Known gaps](#tier5-gap-testsyaml-known-gaps)
+  - [tier5-launcher.yaml — Launcher flags](#tier5-launcheryaml-launcher-flags)
+  - [tier5-live-recipe.yaml — Live recipe execution](#tier5-live-recipeyaml-live-recipe-execution)
+  - [tier5-malformed-yaml.yaml — Error handling](#tier5-malformed-yamlyaml-error-handling)
+  - [tier6-qa-bugfixes.yaml — QA regressions](#tier6-qa-bugfixesyaml-qa-regressions)
+  - [tier7-launcher-parity.yaml — Launcher gaps](#tier7-launcher-parityyaml-launcher-gaps)
+  - [tier8-env-vars.yaml — Environment variable injection](#tier8-env-varsyaml-environment-variable-injection)
 - [Related](#related)
 
 ---
@@ -283,7 +283,7 @@ python tests/parity/validate_cli_parity.py \
 
 ## Related
 
-- [validate_cli_parity.py](../../tests/parity/validate_cli_parity.py) — Harness source
+- [validate_cli_parity.py](https://github.com/rysweet/amplihack-rs/blob/main/tests/parity/validate_cli_parity.py) — Harness source
 - [Environment Variables](./environment-variables.md) — Reference for all variables injected during launch
 - [Agent Binary Routing](../concepts/agent-binary-routing.md) — Why `AMPLIHACK_AGENT_BINARY` exists
 - [Bootstrap Parity](../concepts/bootstrap-parity.md) — Design principles behind Python↔Rust parity

--- a/docs/reference/signal-handling.md
+++ b/docs/reference/signal-handling.md
@@ -8,7 +8,7 @@ in each case.
 
 - [Signal handler registration](#signal-handler-registration)
 - [Exit code contract](#exit-code-contract)
-  - [SIGINT — Ctrl-C](#sigint--ctrl-c)
+  - [SIGINT — Ctrl-C](#sigint-ctrl-c)
   - [Normal child exit](#normal-child-exit)
   - [Signal-killed child (no exit code)](#signal-killed-child-no-exit-code)
 - [Python launcher parity](#python-launcher-parity)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
 
 markdown_extensions:
   - admonition
+  - attr_list
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.tabbed:


### PR DESCRIPTION
## Summary

- Adds `pull_request` trigger to `.github/workflows/docs.yml` so `mkdocs build --strict` runs on every PR touching `docs/**` or `mkdocs.yml`; gates the deploy job to push-to-main only
- Fixes all 8 broken-link warnings (relative paths to repo-root files like `README.md`, `CONTRIBUTING_RUST.md`, `scripts/`, `tests/` replaced with absolute GitHub URLs; dead refs to `update.md` and `launch-command.md` removed)
- Fixes all 17 broken-anchor warnings (em-dash headings generate single-hyphen slugs, leading `--` stripped to `-`, TOC entry mismatches corrected)
- Enables `attr_list` markdown extension for explicit `{#anchor-id}` support
- Adds `site/` to `.gitignore`

`mkdocs build --strict` now passes with zero warnings.

Closes #259 (part A)

## Test plan

- [x] `mkdocs build --strict` passes locally with zero warnings
- [ ] Docs CI workflow triggers on this PR and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)