### PR TITLE
fix(update): use http_get_with_retry for checksum download

### DIFF
--- a/crates/amplihack-cli/src/update/install.rs
+++ b/crates/amplihack-cli/src/update/install.rs
@@ -8,7 +8,7 @@ use tar::Archive;
 
 /// Verify a downloaded archive against its SHA-256 checksum.
 pub(super) fn verify_sha256(archive_bytes: &[u8], checksum_url: &str) -> Result<()> {
-    let checksum_body = super::network::http_get(checksum_url)
+    let checksum_body = super::network::http_get_with_retry(checksum_url)
         .with_context(|| format!("failed to download checksum from {checksum_url}"))?;
     let checksum_text =
         std::str::from_utf8(&checksum_body).context("checksum file is not valid UTF-8")?;

--- a/crates/amplihack-cli/src/update/network.rs
+++ b/crates/amplihack-cli/src/update/network.rs
@@ -82,6 +82,10 @@ pub(super) fn github_error_message(status: u16, url: &str) -> String {
             "GitHub rate limit exceeded for {url}. \
             Please wait a few minutes before retrying."
         ),
+        500..=599 => format!(
+            "Transient server error ({status}) from {url}. \
+            The request will be retried automatically."
+        ),
         _ => format!("HTTP {status} from {url}"),
     }
 }

--- a/crates/amplihack-cli/src/update/tests.rs
+++ b/crates/amplihack-cli/src/update/tests.rs
@@ -135,6 +135,21 @@ fn github_error_message_contains_actionable_advice() {
 }
 
 #[test]
+fn github_error_message_5xx_indicates_transient() {
+    for status in [500u16, 502, 503, 504] {
+        let msg = github_error_message(status, "https://api.github.com/test");
+        assert!(
+            msg.contains("Transient server error"),
+            "expected transient-error message for {status}, got: {msg}"
+        );
+        assert!(
+            msg.contains("retried automatically"),
+            "expected retry hint for {status}, got: {msg}"
+        );
+    }
+}
+
+#[test]
 fn validate_download_url_accepts_allowed_hosts() {
     assert!(validate_download_url("https://api.github.com/repos/x/y/releases/latest").is_ok());
     assert!(validate_download_url("https://github.com/x/y/releases/download/v1/x.tar.gz").is_ok());


### PR DESCRIPTION
## Summary
- Switch `verify_sha256` checksum download from `http_get` (no retry) to `http_get_with_retry` so transient 5xx errors during checksum fetch no longer abort the entire update
- Extend `github_error_message` to return a human-readable "Transient server error (5xx), retrying..." hint for 500-599 status codes
- Add unit test covering the new 5xx message branch

Fixes #257

## Test plan
- [x] `cargo clippy -p amplihack-cli --all-targets -- -D warnings` passes clean
- [x] New test `github_error_message_5xx_indicates_transient` passes
- [x] All pre-existing tests unaffected (3 flaky env-var-race failures confirmed pre-existing on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)