### PR TITLE
feat(install): use bundled framework assets instead of upstream download (#254)

### DIFF
--- a/amplifier-bundle/tools/amplihack/install.sh
+++ b/amplifier-bundle/tools/amplihack/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Enhanced install script for dual-mode hook path management
-# if the AMPLIHACK_INSTALL_LOCATION variable is not set, default to https://github.com/rysweet/amplihack
-AMPLIHACK_INSTALL_LOCATION=${AMPLIHACK_INSTALL_LOCATION:-https://github.com/rysweet/amplihack}
+# Issue #254: default install source is now the amplihack-rs repo (which bundles framework assets)
+# if the AMPLIHACK_INSTALL_LOCATION variable is not set, default to https://github.com/rysweet/amplihack-rs
+AMPLIHACK_INSTALL_LOCATION=${AMPLIHACK_INSTALL_LOCATION:-https://github.com/rysweet/amplihack-rs}
 
 # clone the repository to a tmp local directory
 # make sure the dir does not exist first - exit if it does

--- a/amplifier-bundle/tools/amplihack/install_with_xpia.sh
+++ b/amplifier-bundle/tools/amplihack/install_with_xpia.sh
@@ -2,7 +2,8 @@
 # Enhanced install script with XPIA security hook integration
 # Fixes Issue #137: XPIA hooks not configured during installation
 
-AMPLIHACK_INSTALL_LOCATION=${AMPLIHACK_INSTALL_LOCATION:-https://github.com/rysweet/amplihack}
+# Issue #254: default install source is now the amplihack-rs repo
+AMPLIHACK_INSTALL_LOCATION=${AMPLIHACK_INSTALL_LOCATION:-https://github.com/rysweet/amplihack-rs}
 
 # Colors for output
 RED='\033[0;31m'

--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -53,7 +53,7 @@ pub(super) fn find_hooks_binary() -> Result<PathBuf> {
 
     bail!(
         "amplihack-hooks binary not found. Install it with:\n  \
-         cargo install --git https://github.com/rysweet/amplihack amplihack-hooks\n  \
+         cargo install --git https://github.com/rysweet/amplihack-rs amplihack-hooks\n  \
          or set AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH to its location."
     )
 }

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -1,4 +1,19 @@
-//! Repository cloning and archive extraction.
+//! Framework source resolution: bundled-first, with network fallback.
+//!
+//! As of issue #254 the framework assets are bundled inside the amplihack-rs
+//! source tree (`amplifier-bundle/`) and no longer fetched from the upstream
+//! `rysweet/amplihack` repository at install time.
+//!
+//! Resolution order:
+//! 1. **Compile-time workspace root** — the `CARGO_MANIFEST_DIR` embedded at
+//!    build time points two levels up to the workspace root that contains
+//!    `amplifier-bundle/` and (if present) a `.claude/` directory.
+//! 2. **`AMPLIHACK_HOME`** — user-configured override.
+//! 3. **Walk-up from executable** — walks parent directories looking for
+//!    `amplifier-bundle/`.
+//! 4. **`~/.amplihack`** — staged install location from a prior run.
+//! 5. **Network download** (legacy fallback) — `git clone` / tarball from
+//!    upstream, only attempted when none of the above yields a usable root.
 
 use super::types::{REPO_ARCHIVE_URL, REPO_GIT_URL};
 use crate::update::{extract_archive, http_get, validate_download_url};
@@ -8,12 +23,62 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
+/// Locate the bundled framework source from the amplihack-rs source tree.
+///
+/// Returns the repo root (the directory that contains `amplifier-bundle/`
+/// and — for a complete source checkout — `.claude/`) without any network
+/// access.  Returns `None` when the source tree is not reachable (e.g. the
+/// binary was installed via `cargo install` and the original checkout was
+/// deleted).
+pub(super) fn find_bundled_framework_root() -> Option<PathBuf> {
+    // 1. Compile-time workspace root
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf);
+    if let Some(ref root) = workspace_root
+        && root.join("amplifier-bundle").is_dir()
+    {
+        return Some(root.clone());
+    }
+
+    // 2. AMPLIHACK_HOME env var
+    if let Ok(home) = std::env::var("AMPLIHACK_HOME") {
+        let p = PathBuf::from(&home);
+        if p.join("amplifier-bundle").is_dir() {
+            return Some(p);
+        }
+    }
+
+    // 3. Walk up from executable
+    if let Ok(exe) = std::env::current_exe() {
+        let mut dir = exe.parent().map(Path::to_path_buf);
+        while let Some(d) = dir {
+            if d.join("amplifier-bundle").is_dir() {
+                return Some(d);
+            }
+            dir = d.parent().map(Path::to_path_buf);
+        }
+    }
+
+    // 4. ~/.amplihack (from prior staged install)
+    if let Ok(home) = std::env::var("HOME") {
+        let dot = PathBuf::from(home).join(".amplihack");
+        if dot.join("amplifier-bundle").is_dir() && dot.join(".claude").is_dir() {
+            return Some(dot);
+        }
+    }
+
+    None
+}
+
 /// Fetch the framework repository into `destination`.
+///
+/// **Deprecated path** — only reached when `find_bundled_framework_root()`
+/// returns `None` (source tree unavailable).
 ///
 /// Strategy (matches Python `amplihack install` behaviour):
 /// 1. If `git` is found on PATH, run `git clone --depth 1 <url> <dest>`.
-///    git writes "Cloning into '...'..." to stderr automatically.
-///    If the clone fails the error is propagated immediately (no fallback).
 /// 2. If `git` is NOT on PATH, fall back to HTTP tarball download.
 pub(super) fn download_and_extract_framework_repo(destination: &Path) -> Result<PathBuf> {
     if let Ok(git_path) = which_git() {
@@ -61,13 +126,6 @@ fn which_git() -> Result<PathBuf> {
 }
 
 /// Run `git clone --depth 1 <REPO_GIT_URL> <destination>`.
-///
-/// stderr is inherited so git's "Cloning into '...'" message reaches the
-/// terminal (parity with Python's `subprocess.check_call(["git", "clone", ...])`).
-///
-/// On failure, returns `CliExitError` with git's exit code so that the error
-/// message is clean (no extra Rust diagnostic on stderr — parity with Python
-/// which only prints to stdout on failure).
 fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
     let status = std::process::Command::new(git_path)
         .args([
@@ -83,11 +141,6 @@ fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
         .status()
         .with_context(|| format!("failed to spawn git clone for {REPO_GIT_URL}"))?;
     if !status.success() {
-        // Normalize to exit code 1 for parity with Python:
-        //   Python: CalledProcessError → print(f"Failed to install: {e}") to stdout + return 1
-        //   Rust:   CliExitError(1)    → std::process::exit(1), no extra stderr message
-        // Python always maps any git clone failure to exit 1 regardless of git's
-        // actual exit code.  Rust must match this behaviour.
         return Err(crate::command_error::exit_error(1));
     }
     Ok(())

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -14,7 +14,7 @@ mod types;
 mod tests;
 
 use binary::{deploy_binaries, find_hooks_binary};
-use clone::download_and_extract_framework_repo;
+use clone::{download_and_extract_framework_repo, find_bundled_framework_root};
 use directories::*;
 use filesystem::{all_rel_dirs, get_all_files_and_dirs};
 use hooks::ensure_object;
@@ -43,6 +43,19 @@ pub fn run_install(local: Option<PathBuf>) -> Result<()> {
         return local_install(&canonical);
     }
 
+    // Issue #254: prefer bundled framework assets from the amplihack-rs source
+    // tree.  Only fall back to network download when the local source tree is
+    // not reachable (e.g. binary installed via `cargo install` on a machine
+    // that doesn't have the checkout).
+    if let Some(bundled_root) = find_bundled_framework_root() {
+        println!(
+            "📦 Using bundled framework assets from {}",
+            bundled_root.display()
+        );
+        return local_install(&bundled_root);
+    }
+
+    println!("⚠️  Bundled framework source not found, falling back to network download...");
     let temp_dir = tempfile::tempdir().context("failed to create temp dir for install")?;
     let extracted_root = download_and_extract_framework_repo(temp_dir.path())?;
     local_install(&extracted_root)?;
@@ -60,22 +73,12 @@ pub(crate) fn ensure_framework_installed() -> Result<()> {
     let staging_dir = staging_claude_dir()?;
     let presence_bootstrap_needed =
         !staging_dir.exists() || !missing_framework_paths(&staging_dir)?.is_empty();
-    // Freshness check only runs when the presence check passes. A missing
-    // framework gets handled by the branch below; a stale-but-complete
-    // framework gets re-installed here.
-    let freshness_refresh_needed =
-        !presence_bootstrap_needed && crate::freshness::framework_needs_refresh();
+    // Issue #254: framework assets are now bundled in the amplihack-rs source
+    // tree.  The upstream freshness check against rysweet/amplihack is removed;
+    // framework updates are delivered via amplihack-rs binary updates instead.
     if presence_bootstrap_needed {
         println!("🔧 Bootstrapping amplihack framework assets...");
         run_install(None)?;
-    } else if freshness_refresh_needed {
-        println!("🔄 Refreshing amplihack framework assets (upstream has new commits) ...");
-        if let Err(err) = run_install(None) {
-            // A failed refresh is survivable — the staged framework is
-            // complete, just not on the latest commit.
-            eprintln!("⚠️  Framework refresh failed: {err:#}");
-            eprintln!("   Continuing with the existing staged framework.");
-        }
     }
 
     // Verify hooks are registered in settings.json — even after a fresh install.

--- a/crates/amplihack-cli/src/commands/install/types.rs
+++ b/crates/amplihack-cli/src/commands/install/types.rs
@@ -2,8 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Legacy upstream archive URL — only used as a network fallback when the
+/// bundled framework root cannot be resolved locally (issue #254).
 pub(super) const REPO_ARCHIVE_URL: &str =
     "https://github.com/rysweet/amplihack/archive/refs/heads/main.tar.gz";
+/// Legacy upstream git URL — only used as a network fallback (issue #254).
 pub(super) const REPO_GIT_URL: &str = "https://github.com/rysweet/amplihack";
 pub(super) const ESSENTIAL_DIRS: &[&str] = &[
     "agents/amplihack",

--- a/crates/amplihack-cli/src/freshness.rs
+++ b/crates/amplihack-cli/src/freshness.rs
@@ -1,22 +1,23 @@
-//! Upstream freshness checks for ancillary tooling and framework assets.
+//! Upstream freshness checks for ancillary tooling.
 //!
-//! The launcher's update path only keeps the amplihack binaries themselves
-//! up to date. Two other things can silently drift:
+//! The launcher's update path keeps the amplihack binaries themselves up to
+//! date.  One ancillary tool can silently drift:
 //!
 //! - `recipe-runner-rs`, installed via `cargo install --git`. Once present
 //!   it stays on whatever commit was current at install time.
-//! - The staged amplihack framework at `~/.amplihack/.claude/` — agents,
-//!   skills, commands, and hook specs sourced from `rysweet/amplihack`.
-//!   `ensure_framework_installed` only reinstalls when files are missing,
-//!   so a user who installed six months ago keeps using six-month-old
-//!   skills.
 //!
-//! This module adds optional, cooldown-gated freshness checks. Each check:
+//! **Framework assets** (agents, skills, commands, hook specs) are now bundled
+//! in the amplihack-rs source tree and delivered via binary updates (issue
+//! #254).  The former upstream freshness check against `rysweet/amplihack`
+//! has been removed.
+//!
+//! For the recipe-runner check, this module adds optional, cooldown-gated
+//! freshness checks:
 //!
 //! 1. Reads the installed SHA from a small JSON state file.
 //! 2. If the 24h cooldown has not expired, does nothing.
 //! 3. Otherwise fetches the upstream HEAD SHA via the GitHub commits API.
-//! 4. If the SHAs differ, runs the upgrade (cargo install / `amplihack install`).
+//! 4. If the SHAs differ, runs the upgrade (`cargo install`).
 //! 5. Records the new SHA + timestamp on success.
 //!
 //! Every step is best-effort — a network failure, rate-limit, or even a
@@ -239,76 +240,27 @@ fn install_recipe_runner_from_git() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Framework (rysweet/amplihack)
+// Framework (rysweet/amplihack) — DEPRECATED (issue #254)
 // ---------------------------------------------------------------------------
+//
+// Framework assets are now bundled in the amplihack-rs source tree and
+// delivered via binary updates.  The upstream freshness check against
+// `rysweet/amplihack` is no longer performed.  The public functions below
+// are kept as no-ops so that callers in `commands::install` continue to
+// compile without changes during the transition period.
 
-const FRAMEWORK_REPO: &str = "rysweet/amplihack";
-const FRAMEWORK_BRANCH: &str = "main";
+/// No-op.  Upstream SHA tracking is no longer used (issue #254).
+pub fn record_framework_installed_sha(_sha: &str) {}
 
-fn framework_state_path() -> Result<PathBuf> {
-    Ok(state_dir()?.join("framework.json"))
-}
-
-/// Record the upstream SHA that seeded the staged framework. Called after
-/// a successful `amplihack install` so the next freshness check has an
-/// anchor to diff against.
-pub fn record_framework_installed_sha(sha: &str) {
-    if sha.is_empty() {
-        return;
-    }
-    let Ok(path) = framework_state_path() else {
-        return;
-    };
-    let state = FreshnessState {
-        installed_sha: sha.to_string(),
-        checked_at: now_secs(),
-    };
-    if let Err(err) = state.write(&path) {
-        tracing::warn!(%err, "failed to record framework installed sha");
-    }
-}
-
-/// Best-effort fetch of the framework repo's current HEAD SHA. Returns
-/// `None` when the network is unavailable or rate-limited.
+/// Always returns `None`.  Upstream SHA fetching is no longer used (#254).
 pub fn current_framework_remote_sha() -> Option<String> {
-    fetch_branch_head_sha(FRAMEWORK_REPO, FRAMEWORK_BRANCH).ok()
+    None
 }
 
-/// Returns `true` when a freshness check would trigger a framework
-/// reinstall right now. Callers are expected to perform the reinstall
-/// themselves (to avoid a circular dependency between this module and
-/// `commands::install`) and then call `record_framework_installed_sha`.
-///
-/// Guarantees (per contract):
-/// - Returns `false` whenever freshness checks are disabled, the cooldown
-///   has not elapsed, or the remote SHA cannot be fetched. This makes the
-///   caller's decision path "trigger install only when we're certain the
-///   local copy is stale" — we never force-reinstall on uncertainty.
-/// - Updates the `checked_at` timestamp on every call so repeated launches
-///   don't bombard the GitHub API.
+/// Always returns `false`.  Framework freshness is now tied to the
+/// amplihack-rs binary version, not upstream rysweet/amplihack commits.
 pub fn framework_needs_refresh() -> bool {
-    if skip_freshness_checks() {
-        return false;
-    }
-    let Ok(path) = framework_state_path() else {
-        return false;
-    };
-    let mut state = FreshnessState::read(&path);
-    if state.is_in_cooldown() {
-        return false;
-    }
-    let remote = match current_framework_remote_sha() {
-        Some(sha) => sha,
-        None => {
-            state.checked_at = now_secs();
-            let _ = state.write(&path);
-            return false;
-        }
-    };
-    let stale = !state.installed_sha.is_empty() && state.installed_sha != remote;
-    state.checked_at = now_secs();
-    let _ = state.write(&path);
-    stale
+    false
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/concepts/idempotent-installation.md
+++ b/docs/concepts/idempotent-installation.md
@@ -53,21 +53,23 @@ Each install writes a fresh manifest, replacing the previous one. The manifest a
 
 ## Upgrading
 
-Running `amplihack install` after pulling a new version of the framework is the upgrade mechanism:
+Running `amplihack install` after updating the amplihack-rs binary is the upgrade mechanism. Framework assets are now bundled in the amplihack-rs source tree (issue #254), so updating the binary automatically updates the framework:
 
 ```sh
-# Pull latest framework
-cd ~/src/amplihack
-git pull
+# Update the binary (framework assets update automatically)
+cargo install --git https://github.com/rysweet/amplihack-rs amplihack-cli
 
 # Re-install to stage updated assets and update hook paths
-amplihack install --local ~/src/amplihack
+amplihack install
 ```
 
-Or to pull and install in one command:
+Or from a local checkout:
 
 ```sh
-amplihack install   # no --local: clones latest from GitHub
+cd ~/src/amplihack-rs
+git pull
+cargo build --release
+amplihack install --local .
 ```
 
 Hook command strings in `settings.json` are updated to point to the newly deployed binary.
@@ -79,7 +81,7 @@ The second run of `amplihack install` produces output identical to the first, bu
 ```
 ✓ Python 3.11.4 detected
 ✓ amplihack Python package detected
-✓ Cloning from https://github.com/rysweet/amplihack...
+✓ Using bundled framework assets...
 ✓ Updated amplihack → ~/.local/bin/amplihack
 ✓ Updated amplihack-hooks → ~/.local/bin/amplihack-hooks
 ✓ Staged framework assets (47 files, 12 directories)

--- a/docs/howto/local-install.md
+++ b/docs/howto/local-install.md
@@ -9,15 +9,15 @@ Use `amplihack install --local <PATH>` when you want to install from a local che
 | Air-gapped machine | `amplihack install --local /mnt/usb/amplihack` |
 | Testing a dev branch | `amplihack install --local ~/src/amplihack-dev` |
 | CI pipeline (pre-cloned) | `amplihack install --local $GITHUB_WORKSPACE` |
-| Normal first install | `amplihack install` (no flag, clones automatically) |
+| Normal first install | `amplihack install` (no flag, uses bundled assets) |
 
 ## Steps
 
 ### 1. Obtain a local checkout
 
 ```sh
-# Clone the repository
-git clone https://github.com/rysweet/amplihack ~/src/amplihack
+# Clone the repository (amplihack-rs bundles framework assets since #254)
+git clone https://github.com/rysweet/amplihack-rs ~/src/amplihack-rs
 
 # Or copy from another machine
 rsync -a user@remote:~/src/amplihack ~/src/amplihack
@@ -47,7 +47,7 @@ That local-checkout path is also the way to use the wrapper on platforms without
 published release archives yet, because the fallback build needs the Rust
 workspace and a local Rust toolchain.
 
-The `--local` flag skips the default GitHub archive download step and reads framework assets directly from your checkout. All other phases (optional legacy-Python probe, binary deployment, asset staging, hook wiring) run identically to a standard install.
+The `--local` flag explicitly specifies the framework source directory. Since issue #254, `amplihack install` (without `--local`) uses bundled framework assets from the amplihack-rs source tree instead of downloading from GitHub. The `--local` flag is still useful for testing a development branch or using a custom framework checkout. All other phases (binary deployment, asset staging, hook wiring) run identically.
 
 ### 3. Verify
 
@@ -75,7 +75,7 @@ The installer canonicalizes the root path before staging to prevent traversal ou
 
 ```sh
 # Check out the feature branch
-git clone --branch feat/bootstrap-parity https://github.com/rysweet/amplihack \
+git clone --branch feat/bootstrap-parity https://github.com/rysweet/amplihack-rs \
     ~/src/amplihack-bootstrap-test
 
 # Build the CLI from the same branch (if testing CLI changes)

--- a/docs/reference/install-command.md
+++ b/docs/reference/install-command.md
@@ -9,7 +9,9 @@ amplihack uninstall
 
 ## amplihack install
 
-Bootstraps the amplihack environment on the current machine. On first run, it performs full setup: obtains the framework source, deploys native binaries, stages framework assets, and registers Claude Code hooks. Subsequent runs are idempotent — they update existing registrations in place without duplication.
+Bootstraps the amplihack environment on the current machine. On first run, it performs full setup: locates the bundled framework source (or falls back to network download), deploys native binaries, stages framework assets, and registers Claude Code hooks. Subsequent runs are idempotent — they update existing registrations in place without duplication.
+
+Since issue #254, framework assets are bundled in the amplihack-rs source tree. The installer resolves the framework source in this order: (1) compile-time workspace root, (2) `AMPLIHACK_HOME`, (3) walk-up from executable, (4) `~/.amplihack`, (5) network download from upstream (legacy fallback).
 
 You can invoke the same command through the npm wrapper package when desired:
 
@@ -29,7 +31,7 @@ fall back to a source build.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--local <PATH>` | `PathBuf` | absent | Install from a local directory instead of cloning from GitHub. The path must exist, be a directory, and contain a `.claude` subdirectory (at `<PATH>/.claude` or `<PATH>/../.claude`). |
+| `--local <PATH>` | `PathBuf` | absent | Install from a specific local directory instead of using the bundled source. The path must exist, be a directory, and contain a `.claude` subdirectory (at `<PATH>/.claude` or `<PATH>/../.claude`). Without `--local`, the installer uses bundled framework assets from the amplihack-rs source tree. |
 
 ### Exit Codes
 
@@ -46,7 +48,7 @@ fall back to a source build.
 ```
 amplihack install
 │
-├── 1. GitHub archive OR --local path — obtain framework source
+├── 1. Bundled source, --local path, OR GitHub fallback — obtain framework source
 ├── 2. deploy_binaries()          — copy amplihack + amplihack-hooks (+ asset resolver when present) to ~/.local/bin
 ├── 3. copy framework assets      — stage .claude/ tree to ~/.amplihack/.claude/
 ├── 4. create_runtime_dirs()      — create runtime/ subdirs with 0o755 permissions
@@ -69,7 +71,7 @@ These variables are read during install. All are optional; the installer works w
 Successful install prints a phase-by-phase progress summary:
 
 ```
-✓ Downloaded framework archive from https://github.com/rysweet/amplihack
+✓ Using bundled framework assets from /path/to/amplihack-rs
 ✓ Deployed amplihack → ~/.local/bin/amplihack
 ✓ Deployed amplihack-hooks → ~/.local/bin/amplihack-hooks
 ✓ Deployed amplihack-asset-resolver → ~/.local/bin/amplihack-asset-resolver
@@ -142,7 +144,7 @@ The functions below are in `crates/amplihack-cli/src/commands/install.rs`.
 
 ### `run_install(local: Option<PathBuf>) -> Result<()>`
 
-Entry point called by the command dispatcher. Canonicalizes and validates `--local` path when provided. Delegates to `local_install()` directly (local mode) or after downloading and extracting the GitHub repository archive in native Rust (network mode).
+Entry point called by the command dispatcher. Canonicalizes and validates `--local` path when provided. Without `--local`, resolves the bundled framework root from the amplihack-rs source tree (compile-time path, `AMPLIHACK_HOME`, executable walk-up, `~/.amplihack`). Falls back to network download only when no local source is found.
 
 ### `run_uninstall() -> Result<()>`
 


### PR DESCRIPTION
## Summary

- **Stop downloading from upstream `rysweet/amplihack`** at install time. The installer now resolves framework assets locally using a 4-tier search: compile-time workspace root, `AMPLIHACK_HOME`, executable walk-up, `~/.amplihack`. Network download is kept as a legacy fallback only.
- **Remove upstream freshness check** from `freshness.rs` — framework updates are now delivered via amplihack-rs binary updates, not by polling `rysweet/amplihack` HEAD SHA.
- **Update shell scripts** (`install.sh`, `install_with_xpia.sh`) to default to `amplihack-rs` repo instead of upstream.
- **Update 3 docs** (install-command, local-install, idempotent-installation) to reflect the new bundled-first install flow.

### Follow-up needed (stage 2)

8 of the 12 ESSENTIAL_DIRS are not yet present in `amplifier-bundle/`: `agents/amplihack`, `commands/amplihack`, `workflow`, `templates`, `scenarios`, `docs`, `schemas`, `config`. These need to be copied from upstream into the source tree so the network fallback path is never triggered. This will be a separate PR.

## Test plan

- [x] `cargo clippy -p amplihack-cli --all-targets -- -D warnings` passes
- [x] `TMPDIR=/tmp cargo test -p amplihack-cli --lib` — 967 pass, 1 pre-existing failure (unrelated `update::tests::should_skip_update_check_for_update_related_args`)
- [ ] Manual: `amplihack install` from a fresh build uses local source without network access
- [ ] Manual: `amplihack install --local <path>` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)