### PR TITLE
feat(cli): port orch_helper.py and session_tree.py to native Rust subcommands

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -1984,28 +1984,29 @@ steps:
       export ISSUE_VAL
       PR_VAL=$(printf '%s' {{pr_url}})
       export PR_VAL
-      python3 << 'PYEOF'
-      import json, os
-      print(json.dumps({
-          "workflow": "default-workflow",
-          "version": "2.0.0",
-          "task": os.environ.get("TASK_VAL", ""),
-          "issue_number": os.environ.get("ISSUE_VAL", ""),
-          "pr_url": os.environ.get("PR_VAL", ""),
-          "status": "complete",
-          "steps_completed": 23,
-          "phases_completed": [
-              "requirements-clarification", "design", "implementation",
-              "testing", "review", "merge"
+      jq -n \
+        --arg task "$TASK_VAL" \
+        --arg issue "$ISSUE_VAL" \
+        --arg pr "$PR_VAL" \
+        '{
+          workflow: "default-workflow",
+          version: "2.0.0",
+          task: $task,
+          issue_number: $issue,
+          pr_url: $pr,
+          status: "complete",
+          steps_completed: 23,
+          phases_completed: [
+            "requirements-clarification", "design", "implementation",
+            "testing", "review", "merge"
           ],
-          "mandatory_steps_completed": {
-              "step_0_preparation": True,
-              "step_14_version_bump": True,
-              "step_17_pr_review": True,
-              "step_18_implement_feedback": True
+          mandatory_steps_completed: {
+            step_0_preparation: true,
+            step_14_version_bump: true,
+            step_17_pr_review: true,
+            step_18_implement_feedback: true
           },
-          "philosophy_compliant": True,
-          "ready_to_merge": True
-      }, indent=2))
-      PYEOF
+          philosophy_compliant: true,
+          ready_to_merge: true
+        }'
     output: "workflow_result"

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -129,50 +129,29 @@ steps:
   - id: "parse-decomposition"
     type: "bash"
     command: |
-      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export HELPER_PATH
-      python3 - <<'PYEOF'
-      import sys, json, os, importlib.util
+      # Extract JSON and get task_type field, then normalise it.
+      RAW_TYPE=$(amplihack orch-helper extract-json < "$_DECOMP_TMPFILE" | jq -r '.task_type // "Development"')
+      if [ "$RAW_TYPE" = "null" ] || [ -z "$RAW_TYPE" ]; then
+          cat >&2 <<'ERRBOX'
 
-      helper_path = os.environ['HELPER_PATH']
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp_json = f.read()
-
-      spec = importlib.util.spec_from_file_location('orch_helper', helper_path)
-      h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
-      obj = h.extract_json(decomp_json)
-
-      if not obj:
-          msg = (
-              "\n"
-              "╔══════════════════════════════════════════════════════════════════╗\n"
-              "║  ERROR: decomposition JSON parse failed                         ║\n"
-              "║  The architect agent returned non-JSON prose instead of the     ║\n"
-              "║  expected structured plan.                                      ║\n"
-              "║                                                                 ║\n"
-              "║  Action: defaulting to task_type=Development so execution can   ║\n"
-              "║  continue. The adaptive strategy step will evaluate whether     ║\n"
-              "║  direct recipe invocation should be attempted.                  ║\n"
-              "╚══════════════════════════════════════════════════════════════════╝\n"
-          )
-          print(msg, file=sys.stderr)
-          # Do NOT print to stdout — stdout is captured as the output variable
-          # and box-drawing characters would corrupt downstream template substitution
-
-      task_type = h.normalise_type(obj.get("task_type", "Development"))
-      print(task_type)
-      PYEOF
+      ╔══════════════════════════════════════════════════════════════════╗
+      ║  ERROR: decomposition JSON parse failed                         ║
+      ║  The architect agent returned non-JSON prose instead of the     ║
+      ║  expected structured plan.                                      ║
+      ║                                                                 ║
+      ║  Action: defaulting to task_type=Development so execution can   ║
+      ║  continue. The adaptive strategy step will evaluate whether     ║
+      ║  direct recipe invocation should be attempted.                  ║
+      ╚══════════════════════════════════════════════════════════════════╝
+      ERRBOX
+          RAW_TYPE="Development"
+      fi
+      echo "$RAW_TYPE" | amplihack orch-helper normalise-type
     output: "task_type"
 
   # activate-workflow: compute workstream_count, set workflow semaphore, announce.
@@ -180,16 +159,6 @@ steps:
   - id: "activate-workflow"
     type: "bash"
     command: |
-      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
-      DECOMP_JSON=$(cat <<EOFDECOMP
-      {{decomposition_json}}
-      EOFDECOMP
-      )
       TASK_TYPE={{task_type}}
       FORCE_SINGLE={{force_single_workstream}}
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
@@ -198,53 +167,40 @@ steps:
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export TASK_TYPE=$(printf '%s' {{task_type}})
-      export FORCE_SINGLE=$(printf '%s' "$FORCE_SINGLE")
-      export HELPER_PATH HOOKS_DIR
-      python3 - <<'PYEOF'
-      import os, sys, io, importlib.util
 
-      helper_path = os.environ['HELPER_PATH']
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp_json = f.read()
-      task_type = os.environ['TASK_TYPE']
-      hooks_dir = os.environ['HOOKS_DIR']
-      force_single = os.environ.get('FORCE_SINGLE', 'false').strip().lower() in ('true', '1')
-
-      # Compute workstream count from decomposition JSON
-      spec = importlib.util.spec_from_file_location('orch_helper', helper_path)
-      h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
-      obj = h.extract_json(decomp_json)
-      raw_count = max(1, len(obj.get("workstreams", [])))
+      # Compute workstream count from decomposition JSON using native Rust
+      RAW_COUNT=$(amplihack orch-helper extract-json < "$_DECOMP_TMPFILE" | jq '.workstreams | length // 0')
+      RAW_COUNT=$((RAW_COUNT > 0 ? RAW_COUNT : 1))
 
       # Enforce force_single_workstream override (fix #3130)
-      count = 1 if force_single else raw_count
+      FORCE_SINGLE_LOWER=$(printf '%s' "$FORCE_SINGLE" | tr '[:upper:]' '[:lower:]')
+      if [ "$FORCE_SINGLE_LOWER" = "true" ] || [ "$FORCE_SINGLE_LOWER" = "1" ]; then
+          COUNT=1
+          if [ "$RAW_COUNT" != "1" ]; then
+              echo "[dev-orchestrator] force_single_workstream=true — overriding $RAW_COUNT workstreams to 1" >&2
+          fi
+      else
+          COUNT=$RAW_COUNT
+      fi
 
       # Set workflow-active semaphore so the hook skips injection during execution
-      # Redirect stdout during import to prevent pollution of captured output
-      _saved_stdout = sys.stdout
-      sys.stdout = io.StringIO()
+      if [ -n "$HOOKS_DIR" ] && [ -f "$HOOKS_DIR/dev_intent_router.py" ]; then
+          python3 -c "
+      import sys; sys.path.insert(0, '$HOOKS_DIR')
       try:
-          sys.path.insert(0, hooks_dir)
           from dev_intent_router import set_workflow_active
-          set_workflow_active(task_type, count)
+          set_workflow_active('$TASK_TYPE', $COUNT)
       except Exception:
-          pass  # Hook may not exist in all environments
-      finally:
-          sys.stdout = _saved_stdout
+          pass
+      " 2>/dev/null || true
+      fi
 
       # Announce classification to stderr (visible to user, not captured as output)
-      if force_single and raw_count != count:
-          print(f"[dev-orchestrator] force_single_workstream=true — overriding {raw_count} workstreams to 1", file=sys.stderr)
-      print(f"[dev-orchestrator] Classified as: {task_type} | Workstreams: {count} — starting execution...", file=sys.stderr)
+      echo "[dev-orchestrator] Classified as: $TASK_TYPE | Workstreams: $COUNT — starting execution..." >&2
 
       # Output workstream count (captured by recipe runner).
-      # Use sys.stdout.write to avoid trailing newline — the recipe runner
-      # stores step output as-is, and a trailing '\n' breaks exact string
-      # comparisons in downstream conditions (fix #3570).
-      sys.stdout.write(str(count))
-      PYEOF
+      # Use printf to avoid trailing newline (fix #3570).
+      printf '%s' "$COUNT"
     output: "workstream_count"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -271,37 +227,24 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type or task_type == ''"
     command: |
-      TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
-      SESSION_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex[:8])")
+      SESSION_ID=$(amplihack orch-helper uuid)
 
-      if [ -f "$TREE_SCRIPT" ]; then
-        # Register this session — atomic check+register under lock
-        if OUTPUT=$(python3 "$TREE_SCRIPT" register "$SESSION_ID" 2>&1); then
-          # Output: "TREE_ID=abc123 DEPTH=0"
-          TREE_ID=$(echo "$OUTPUT" | grep -oE 'TREE_ID=[A-Za-z0-9_-]+' | head -1 | cut -d= -f2)
-          DEPTH_STR=$(echo "$OUTPUT" | grep -oE 'DEPTH=[0-9]+' | head -1 | cut -d= -f2)
-          DEPTH_VAL=${DEPTH_STR:-0}
-          # Validate extracted values
-          if ! echo "$TREE_ID" | grep -qE '^[A-Za-z0-9_-]+$'; then
-            python3 -c "import json; print(json.dumps({'session_id': 'error', 'tree_id': 'error', 'depth': 0, 'status': 'registration_failed', 'error': 'invalid tree_id extracted'}))"
-            exit 0
-          fi
-          python3 -c "import sys,json; sid,tid,depth=sys.argv[1],sys.argv[2],int(sys.argv[3]); print(json.dumps({'session_id':sid,'tree_id':tid,'depth':depth,'status':'ok'}))" "$SESSION_ID" "$TREE_ID" "$DEPTH_VAL"
-        else
-          # Registration failed (capacity exceeded or depth limit) — encode structured error
-          echo "NOTE: Session registration failed — proceeding without recursion tracking." >&2
-          python3 -c "import json; print(json.dumps({'session_id': 'none', 'tree_id': 'none', 'depth': 0, 'status': 'registration_failed'}))"
+      # Register this session via native Rust session-tree — atomic check+register under lock
+      if OUTPUT=$(amplihack session-tree register "$SESSION_ID" 2>&1); then
+        # Output: "TREE_ID=abc123 DEPTH=0"
+        TREE_ID=$(echo "$OUTPUT" | grep -oE 'TREE_ID=[A-Za-z0-9_-]+' | head -1 | cut -d= -f2)
+        DEPTH_STR=$(echo "$OUTPUT" | grep -oE 'DEPTH=[0-9]+' | head -1 | cut -d= -f2)
+        DEPTH_VAL=${DEPTH_STR:-0}
+        # Validate extracted values
+        if ! echo "$TREE_ID" | grep -qE '^[A-Za-z0-9_-]+$'; then
+          amplihack orch-helper json-output session_id=error tree_id=error depth=0 status=registration_failed error="invalid tree_id extracted"
+          exit 0
         fi
+        amplihack orch-helper json-output session_id="$SESSION_ID" tree_id="$TREE_ID" depth="$DEPTH_VAL" status=ok
       else
-        # No session_tree.py — generate a tree_id from env or fresh uuid
-        TREE_ID=$(echo "${AMPLIHACK_TREE_ID:-}" | grep -E '^[A-Za-z0-9_-]+$' | head -1)
-        if [ -z "$TREE_ID" ]; then
-          TREE_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex[:8])")
-        fi
-        DEPTH_RAW="${AMPLIHACK_SESSION_DEPTH:-0}"
-        # Validate it's an integer (default to 0 if not)
-        DEPTH_VAL=$(echo "$DEPTH_RAW" | grep -E '^[0-9]+$' || echo '0')
-        python3 -c "import sys,json; sid,tid,depth=sys.argv[1],sys.argv[2],int(sys.argv[3]); print(json.dumps({'session_id':sid,'tree_id':tid,'depth':depth,'status':'no_tree_script'}))" "$SESSION_ID" "$TREE_ID" "$DEPTH_VAL"
+        # Registration failed (capacity exceeded or depth limit) — encode structured error
+        echo "NOTE: Session registration failed — proceeding without recursion tracking." >&2
+        amplihack orch-helper json-output session_id=none tree_id=none depth=0 status=registration_failed
       fi
     output: "session_info"
 
@@ -434,42 +377,13 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and workstream_count != 1 and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
-      HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export HELPER_PATH
-      python3 - <<'PYEOF'
-      import json, os, re, tempfile, sys
-      sys.path.insert(0, os.path.dirname(os.environ['HELPER_PATH']))
-      import orch_helper
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp = f.read()
-      obj = orch_helper.extract_json(decomp)
-      config = []
-      for i, ws in enumerate(obj.get("workstreams", [])):
-          name = ws.get("name", f"workstream-{i+1}")
-          slug = re.sub(r'[^a-z0-9-]', '-', name.lower())[:30].strip('-') or f"ws-{i+1}"
-          config.append({
-              "issue": "TBD",
-              "branch": f"feat/orch-{i+1}-{slug}",
-              "description": name,
-              "task": ws.get("description", name),
-              "recipe": ws.get("recipe", "default-workflow")
-          })
-      fd, p = tempfile.mkstemp(prefix="smart-orch-ws-", suffix=".json", dir="/tmp")
-      os.chmod(p, 0o600)
-      with os.fdopen(fd, "w") as f: json.dump(config, f, indent=2)
-      print(p)
-      PYEOF
+      # Native Rust replacement for Python workstream config generation
+      amplihack orch-helper create-workstreams-config --input "$_DECOMP_TMPFILE"
     output: "workstreams_file"
 
   - id: "launch-parallel-round-1"
@@ -487,81 +401,40 @@ steps:
       {{session_info}}
       EOFSESSIONJSON
       )
-      # Parse tree_id, depth, and validate workstreams file in one Python subprocess.
-      # Uses env vars instead of pipe+heredoc to avoid stdin conflict (issue #2581).
-      export SESSION_JSON WS_FILE
-      read -r TREE_ID SESSION_DEPTH WS_COUNT_CHECK < <(python3 <<'PYEOF'
-      import os, json
-      try:
-          d = json.loads(os.environ.get('SESSION_JSON', '{}'))
-          tid = d.get('tree_id', '')
-          depth = d.get('depth', 0)
-      except Exception:
-          tid, depth = '', 0
-      ws_file = os.environ.get('WS_FILE', '')
-      ws_count = 0
-      if ws_file:
-          try:
-              with open(ws_file) as f:
-                  ws_count = len(json.load(f))
-          except Exception:
-              pass
-      print(tid, depth, ws_count)
-      PYEOF
-      )
-      TREE_ID=${TREE_ID:-}
-      SESSION_DEPTH=${SESSION_DEPTH:-0}
-      WS_COUNT_CHECK=${WS_COUNT_CHECK:-0}
+      # Parse tree_id, depth from session JSON using jq (replaces Python subprocess)
+      TREE_ID=$(echo "$SESSION_JSON" | jq -r '.tree_id // ""' 2>/dev/null || echo "")
+      SESSION_DEPTH=$(echo "$SESSION_JSON" | jq -r '.depth // 0' 2>/dev/null || echo "0")
+      # Validate workstreams file
+      WS_COUNT_CHECK=0
+      if [ -n "$WS_FILE" ] && [ -f "$WS_FILE" ]; then
+        WS_COUNT_CHECK=$(jq 'length' "$WS_FILE" 2>/dev/null || echo "0")
+      fi
 
       if [ -z "$WS_FILE" ] || [ ! -f "$WS_FILE" ]; then
         echo "ERROR: workstreams_file is missing or empty. create-workstreams-config may have failed." >&2
-        emit_step_transition fail
         exit 1
       fi
 
       if [ "$WS_COUNT_CHECK" = "0" ]; then
         echo "ERROR: workstreams config has 0 entries — decomposition may have failed." >&2
-        emit_step_transition fail
         exit 1
       fi
 
       if [ ! -d "$REPO_PATH" ]; then
         echo "ERROR: repo_path does not exist: $REPO_PATH" >&2
-        emit_step_transition fail
         exit 1
       fi
       cd "$REPO_PATH"
-
-      # Resolve multitask orchestrator from AMPLIHACK_HOME, not from repo root.
-      # The orchestrator.py is an amplihack asset, not a repo file (#3762).
-      ORCH_SCRIPT=""
-      for candidate in \
-        "${AMPLIHACK_HOME:+$AMPLIHACK_HOME/.claude/skills/multitask/orchestrator.py}" \
-        "${HOME}/.amplihack/.claude/skills/multitask/orchestrator.py" \
-        "${HOME}/.copilot/skills/multitask/orchestrator.py" \
-        ".claude/skills/multitask/orchestrator.py"; do
-        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
-          ORCH_SCRIPT="$candidate"
-          break
-        fi
-      done
-      if [ -z "$ORCH_SCRIPT" ]; then
-        echo "ERROR: multitask orchestrator.py not found." >&2
-        echo "  Searched: AMPLIHACK_HOME/.claude/skills/multitask/orchestrator.py" >&2
-        echo "  Set AMPLIHACK_HOME or ensure amplihack is installed." >&2
-        emit_step_transition fail
-        exit 1
-      fi
-      echo "Selected orchestrator source: $ORCH_SCRIPT" >&2
 
       echo "Launching parallel workstreams (tree: $TREE_ID, depth: $SESSION_DEPTH):"
       cat "$WS_FILE"
       echo "---"
       status=0
+      # Use native Rust multitask orchestrator instead of Python orchestrator.py
       AMPLIHACK_TREE_ID="$TREE_ID" AMPLIHACK_SESSION_DEPTH="$SESSION_DEPTH" \
         AMPLIHACK_PARENT_STEP="launch-parallel-round-1" \
         AMPLIHACK_REPO_PATH="$REPO_PATH" \
-        python3 -u "$ORCH_SCRIPT" "$WS_FILE" | tee /dev/stderr || status=$?
+        amplihack multitask run "$WS_FILE" | tee /dev/stderr || status=$?
       # Clean up workstreams file now, before this step's output inflates
       # the recipe context. Doing it here avoids the E2BIG error that
       # occurs when a later bash step inherits megabytes of env vars
@@ -1001,36 +874,26 @@ steps:
       {{session_info}}
       EOFSESSIONJSON
       )
-      TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
-      # Parse session fields and clear workflow semaphore in one Python subprocess.
-      # Uses env vars instead of pipe+heredoc to avoid stdin conflict (issue #2581).
-      export SESSION_JSON HOOKS_DIR
-      read -r SESSION_ID TREE_ID STATUS < <(python3 <<'PYEOF'
-      import json, os, sys
-      try:
-          d = json.loads(os.environ.get('SESSION_JSON', '{}'))
-          sid, tid, status = d.get('session_id',''), d.get('tree_id',''), d.get('status','')
-      except Exception:
-          sid, tid, status = '', '', ''
+      # Parse session fields using jq (replaces Python subprocess)
+      SESSION_ID=$(echo "$SESSION_JSON" | jq -r '.session_id // ""' 2>/dev/null || echo "")
+      TREE_ID=$(echo "$SESSION_JSON" | jq -r '.tree_id // ""' 2>/dev/null || echo "")
+      STATUS=$(echo "$SESSION_JSON" | jq -r '.status // ""' 2>/dev/null || echo "")
+
       # Clear workflow-active semaphore so the hook resumes injection
+      if [ -n "$HOOKS_DIR" ] && [ -f "$HOOKS_DIR/dev_intent_router.py" ]; then
+          python3 -c "
+      import sys; sys.path.insert(0, '$HOOKS_DIR')
       try:
-          hooks_dir = os.environ.get('HOOKS_DIR', '')
-          if hooks_dir:
-              sys.path.insert(0, hooks_dir)
-              from dev_intent_router import clear_workflow_active
-              clear_workflow_active()
+          from dev_intent_router import clear_workflow_active
+          clear_workflow_active()
       except Exception:
           pass
-      print(sid, tid, status)
-      PYEOF
-      )
-      SESSION_ID=${SESSION_ID:-}
-      TREE_ID=${TREE_ID:-}
-      STATUS=${STATUS:-}
+      " 2>/dev/null || true
+      fi
 
-      if [ -n "$SESSION_ID" ] && [ "$STATUS" = "ok" ] && [ -f "$TREE_SCRIPT" ]; then
-        AMPLIHACK_TREE_ID="$TREE_ID" python3 "$TREE_SCRIPT" complete "$SESSION_ID"
+      if [ -n "$SESSION_ID" ] && [ "$STATUS" = "ok" ]; then
+        AMPLIHACK_TREE_ID="$TREE_ID" amplihack session-tree complete "$SESSION_ID"
         echo "Session $SESSION_ID completed in tree $TREE_ID"
       else
         echo "No session to complete (status: ${STATUS:-empty})"

--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -5,8 +5,8 @@ use clap_complete::Shell;
 use std::path::PathBuf;
 
 use super::{
-    MemoryCommands, ModeCommands, MultitaskCommands, PluginCommands, QueryCodeCommands,
-    RecipeCommands,
+    MemoryCommands, ModeCommands, MultitaskCommands, OrchestratorHelperCommands, PluginCommands,
+    QueryCodeCommands, RecipeCommands, SessionTreeCommands,
 };
 
 #[derive(Subcommand, Debug)]
@@ -333,5 +333,19 @@ pub enum Commands {
     Multitask {
         #[command(subcommand)]
         command: MultitaskCommands,
+    },
+
+    /// Orchestrator helper utilities (native Rust replacement for orch_helper.py)
+    #[command(name = "orch-helper")]
+    OrchestratorHelper {
+        #[command(subcommand)]
+        command: OrchestratorHelperCommands,
+    },
+
+    /// Session tree management for orchestration recursion control
+    #[command(name = "session-tree")]
+    SessionTree {
+        #[command(subcommand)]
+        command: SessionTreeCommands,
     },
 }

--- a/crates/amplihack-cli/src/cli_subcommands.rs
+++ b/crates/amplihack-cli/src/cli_subcommands.rs
@@ -218,6 +218,54 @@ pub enum ModeCommands {
 }
 
 #[derive(Subcommand, Debug)]
+pub enum OrchestratorHelperCommands {
+    /// Extract first JSON object from stdin (prints {} on failure)
+    #[command(name = "extract-json")]
+    ExtractJson,
+    /// Normalise a task type string to: Q&A | Operations | Investigation | Development
+    #[command(name = "normalise-type")]
+    NormaliseType,
+    /// Build workstream config JSON from decomposition JSON file
+    #[command(name = "create-workstreams-config")]
+    CreateWorkstreamsConfig {
+        /// Path to decomposition JSON file
+        #[arg(long)]
+        input: String,
+    },
+    /// Print 8-char hex UUID to stdout
+    Uuid,
+    /// Build JSON object from key=value positional args and print to stdout
+    #[command(name = "json-output")]
+    JsonOutput {
+        /// key=value pairs
+        pairs: Vec<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SessionTreeCommands {
+    /// Advisory check if a new child session can be spawned
+    Check,
+    /// Register a session in the tree atomically
+    Register {
+        /// Session identifier
+        session_id: String,
+        /// Optional parent session identifier
+        parent_id: Option<String>,
+    },
+    /// Mark a session as completed
+    Complete {
+        /// Session identifier to mark completed
+        session_id: String,
+    },
+    /// Show tree status as JSON
+    Status {
+        /// Tree ID (defaults to AMPLIHACK_TREE_ID env var)
+        tree_id: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 pub enum MultitaskCommands {
     /// Run parallel workstreams from a JSON config file
     Run {

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -12,7 +12,9 @@ pub mod memory;
 pub mod mode;
 pub mod multitask;
 pub mod new_agent;
+pub mod orch_helper;
 pub mod plugin;
+pub mod session_tree;
 pub mod query_code;
 pub mod recipe;
 pub mod rustyclawd;
@@ -313,6 +315,8 @@ pub fn dispatch(command: Commands) -> Result<()> {
             std::process::exit(code);
         }
         Commands::Multitask { command } => dispatch_multitask(command),
+        Commands::OrchestratorHelper { command } => orch_helper::dispatch(command),
+        Commands::SessionTree { command } => session_tree::run_session_tree(command),
     }
 }
 

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -14,10 +14,10 @@ pub mod multitask;
 pub mod new_agent;
 pub mod orch_helper;
 pub mod plugin;
-pub mod session_tree;
 pub mod query_code;
 pub mod recipe;
 pub mod rustyclawd;
+pub mod session_tree;
 pub mod uvx_help;
 
 use crate::{

--- a/crates/amplihack-cli/src/commands/orch_helper/mod.rs
+++ b/crates/amplihack-cli/src/commands/orch_helper/mod.rs
@@ -1,0 +1,383 @@
+//! Native Rust replacement for `amplifier-bundle/tools/orch_helper.py`.
+//!
+//! Provides subcommands used by the smart-orchestrator recipe:
+//!   - `extract-json`  — extract first JSON object from LLM output on stdin
+//!   - `normalise-type` — normalise a task type string to a canonical label
+//!   - `create-workstreams-config` — build workstream config from decomposition JSON
+//!   - `uuid` — print 8-char hex identifier
+//!   - `json-output` — build JSON object from key=value CLI args
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use serde_json::Value;
+use std::io::Read as _;
+
+use crate::OrchestratorHelperCommands;
+
+/// Dispatch an `orch-helper` subcommand.
+pub fn dispatch(command: OrchestratorHelperCommands) -> Result<()> {
+    match command {
+        OrchestratorHelperCommands::ExtractJson => run_extract_json(),
+        OrchestratorHelperCommands::NormaliseType => run_normalise_type(),
+        OrchestratorHelperCommands::CreateWorkstreamsConfig { input } => {
+            run_create_workstreams_config(&input)
+        }
+        OrchestratorHelperCommands::Uuid => run_uuid(),
+        OrchestratorHelperCommands::JsonOutput { pairs } => run_json_output(&pairs),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// extract-json
+// ---------------------------------------------------------------------------
+
+/// Read stdin, extract the first valid JSON object, print it to stdout.
+/// Prints `{}` on failure.
+fn run_extract_json() -> Result<()> {
+    let mut text = String::new();
+    std::io::stdin()
+        .read_to_string(&mut text)
+        .context("Failed to read stdin")?;
+
+    let obj = extract_json(&text);
+    println!(
+        "{}",
+        serde_json::to_string(&obj).unwrap_or_else(|_| "{}".to_string())
+    );
+    Ok(())
+}
+
+/// Extract and parse the first complete JSON object from LLM output.
+///
+/// Priority:
+/// 1. ```json-tagged code blocks
+/// 2. Untagged ``` code blocks
+/// 3. Raw JSON in prose (try parsing from each `{`)
+fn extract_json(text: &str) -> Value {
+    // 1. ```json-tagged code blocks
+    let json_block_re = Regex::new(r"(?s)```json\s*(\{[^`]*\})\s*```").unwrap();
+    for cap in json_block_re.captures_iter(text) {
+        if let Some(m) = cap.get(1) {
+            if let Ok(v) = serde_json::from_str::<Value>(m.as_str()) {
+                if v.is_object() {
+                    return v;
+                }
+            }
+        }
+    }
+
+    // 2. Untagged code blocks
+    let untagged_re = Regex::new(r"(?s)```\s*(\{[^`]*\})\s*```").unwrap();
+    for cap in untagged_re.captures_iter(text) {
+        if let Some(m) = cap.get(1) {
+            if let Ok(v) = serde_json::from_str::<Value>(m.as_str()) {
+                if v.is_object() {
+                    return v;
+                }
+            }
+        }
+    }
+
+    // 3. Fallback: scan for first valid JSON object starting at each `{`.
+    // Use serde_json::Deserializer::from_str to handle } inside string values.
+    let mut pos = 0;
+    let bytes = text.as_bytes();
+    while pos < bytes.len() {
+        if let Some(offset) = text[pos..].find('{') {
+            let start = pos + offset;
+            let slice = &text[start..];
+            let mut stream = serde_json::Deserializer::from_str(slice).into_iter::<Value>();
+            if let Some(Ok(v)) = stream.next() {
+                if v.is_object() {
+                    return v;
+                }
+            }
+            pos = start + 1;
+        } else {
+            break;
+        }
+    }
+
+    Value::Object(serde_json::Map::new())
+}
+
+// ---------------------------------------------------------------------------
+// normalise-type
+// ---------------------------------------------------------------------------
+
+fn run_normalise_type() -> Result<()> {
+    let mut text = String::new();
+    std::io::stdin()
+        .read_to_string(&mut text)
+        .context("Failed to read stdin")?;
+    println!("{}", normalise_type(text.trim()));
+    Ok(())
+}
+
+/// Normalise LLM task_type to one of: Q&A, Operations, Investigation, Development.
+fn normalise_type(raw: &str) -> &'static str {
+    let t = raw.to_lowercase();
+    if ["q&a", "qa", "question", "answer"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
+        return "Q&A";
+    }
+    if ["ops", "operation", "admin", "command"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
+        return "Operations";
+    }
+    if ["invest", "research", "explor", "analys", "understand"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
+        return "Investigation";
+    }
+    "Development"
+}
+
+// ---------------------------------------------------------------------------
+// create-workstreams-config
+// ---------------------------------------------------------------------------
+
+fn run_create_workstreams_config(input_path: &str) -> Result<()> {
+    let raw = std::fs::read_to_string(input_path)
+        .with_context(|| format!("Failed to read input file: {input_path}"))?;
+
+    let obj = extract_json(&raw);
+
+    let workstreams = obj
+        .get("workstreams")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut config: Vec<Value> = Vec::new();
+    for (i, ws) in workstreams.iter().enumerate() {
+        let name = ws
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&format!("workstream-{}", i + 1))
+            .to_string();
+
+        let slug = make_slug(&name, i);
+
+        let description = ws
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&name)
+            .to_string();
+
+        let recipe = ws
+            .get("recipe")
+            .and_then(|v| v.as_str())
+            .unwrap_or("default-workflow")
+            .to_string();
+
+        config.push(serde_json::json!({
+            "issue": "TBD",
+            "branch": format!("feat/orch-{}-{}", i + 1, slug),
+            "description": name,
+            "task": description,
+            "recipe": recipe,
+        }));
+    }
+
+    // Write to a temp file with the expected prefix/suffix.
+    let tmp_dir = std::path::Path::new("/tmp");
+    let tmp = tempfile::Builder::new()
+        .prefix("smart-orch-ws-")
+        .suffix(".json")
+        .tempfile_in(tmp_dir)
+        .context("Failed to create temp file")?;
+
+    // Set permissions to 0o600.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    let json_str = serde_json::to_string_pretty(&config)?;
+    std::fs::write(tmp.path(), &json_str)?;
+
+    // Persist the temp file (prevent deletion on drop).
+    let path = tmp.into_temp_path().keep()?;
+    println!("{}", path.display());
+    Ok(())
+}
+
+/// Generate a slug from a workstream name: lowercase, non-[a-z0-9-] replaced
+/// with '-', truncated to 30 chars, leading/trailing '-' stripped.
+fn make_slug(name: &str, index: usize) -> String {
+    let lowered = name.to_lowercase();
+    let slug: String = lowered
+        .chars()
+        .map(|c| {
+            if c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    let truncated = if slug.len() > 30 {
+        &slug[..30]
+    } else {
+        &slug
+    };
+
+    let trimmed = truncated.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        format!("ws-{}", index + 1)
+    } else {
+        trimmed
+    }
+}
+
+// ---------------------------------------------------------------------------
+// uuid
+// ---------------------------------------------------------------------------
+
+fn run_uuid() -> Result<()> {
+    // Read 4 random bytes from /dev/urandom and format as 8-char hex.
+    let mut buf = [0u8; 4];
+    let mut f =
+        std::fs::File::open("/dev/urandom").context("Failed to open /dev/urandom for UUID")?;
+    std::io::Read::read_exact(&mut f, &mut buf).context("Failed to read from /dev/urandom")?;
+    println!("{}", hex_encode(&buf));
+    Ok(())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+// ---------------------------------------------------------------------------
+// json-output
+// ---------------------------------------------------------------------------
+
+fn run_json_output(pairs: &[String]) -> Result<()> {
+    let mut map = serde_json::Map::new();
+    for pair in pairs {
+        if let Some((key, value)) = pair.split_once('=') {
+            map.insert(key.to_string(), Value::String(value.to_string()));
+        } else {
+            anyhow::bail!("Invalid key=value pair: {pair}");
+        }
+    }
+    println!("{}", serde_json::to_string(&Value::Object(map))?);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_json_tagged_block() {
+        let input = r#"Here is the result:
+```json
+{"task_type": "Development", "count": 1}
+```
+Done."#;
+        let v = extract_json(input);
+        assert_eq!(v["task_type"], "Development");
+        assert_eq!(v["count"], 1);
+    }
+
+    #[test]
+    fn test_extract_json_untagged_block() {
+        let input = r#"Result:
+```
+{"foo": "bar"}
+```"#;
+        let v = extract_json(input);
+        assert_eq!(v["foo"], "bar");
+    }
+
+    #[test]
+    fn test_extract_json_raw_prose() {
+        let input = r#"The answer is {"key": "value"} and more text."#;
+        let v = extract_json(input);
+        assert_eq!(v["key"], "value");
+    }
+
+    #[test]
+    fn test_extract_json_empty_fallback() {
+        let input = "No JSON here at all";
+        let v = extract_json(input);
+        assert!(v.as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_extract_json_with_braces_in_strings() {
+        let input = r#"{"msg": "use { and } in text", "ok": true}"#;
+        let v = extract_json(input);
+        assert_eq!(v["msg"], "use { and } in text");
+        assert_eq!(v["ok"], true);
+    }
+
+    #[test]
+    fn test_normalise_type_qa() {
+        assert_eq!(normalise_type("Q&A"), "Q&A");
+        assert_eq!(normalise_type("qa"), "Q&A");
+        assert_eq!(normalise_type("question about X"), "Q&A");
+    }
+
+    #[test]
+    fn test_normalise_type_operations() {
+        assert_eq!(normalise_type("Operations"), "Operations");
+        assert_eq!(normalise_type("admin task"), "Operations");
+    }
+
+    #[test]
+    fn test_normalise_type_investigation() {
+        assert_eq!(normalise_type("Investigation"), "Investigation");
+        assert_eq!(normalise_type("research topic"), "Investigation");
+        assert_eq!(normalise_type("explore the code"), "Investigation");
+    }
+
+    #[test]
+    fn test_normalise_type_development() {
+        assert_eq!(normalise_type("Development"), "Development");
+        assert_eq!(normalise_type("implement feature"), "Development");
+        assert_eq!(normalise_type("random text"), "Development");
+    }
+
+    #[test]
+    fn test_make_slug() {
+        assert_eq!(make_slug("Add Auth System", 0), "add-auth-system");
+        assert_eq!(make_slug("Hello World!!!", 0), "hello-world");
+        assert_eq!(make_slug("---", 2), "ws-3");
+        // Truncation
+        let long = "a".repeat(50);
+        assert_eq!(make_slug(&long, 0).len(), 30);
+    }
+
+    #[test]
+    fn test_hex_encode() {
+        assert_eq!(hex_encode(&[0x0a, 0xff, 0x00, 0x42]), "0aff0042");
+    }
+
+    #[test]
+    fn test_extract_json_tagged_block_priority() {
+        // Tagged block should take priority over untagged
+        let input = r#"
+```
+{"wrong": true}
+```
+```json
+{"right": true}
+```"#;
+        let v = extract_json(input);
+        assert_eq!(v["right"], true);
+    }
+}

--- a/crates/amplihack-cli/src/commands/orch_helper/mod.rs
+++ b/crates/amplihack-cli/src/commands/orch_helper/mod.rs
@@ -224,11 +224,7 @@ fn make_slug(name: &str, index: usize) -> String {
         })
         .collect();
 
-    let truncated = if slug.len() > 30 {
-        &slug[..30]
-    } else {
-        &slug
-    };
+    let truncated = if slug.len() > 30 { &slug[..30] } else { &slug };
 
     let trimmed = truncated.trim_matches('-').to_string();
     if trimmed.is_empty() {

--- a/crates/amplihack-cli/src/commands/session_tree/mod.rs
+++ b/crates/amplihack-cli/src/commands/session_tree/mod.rs
@@ -165,8 +165,8 @@ struct FileLock {
 impl FileLock {
     fn acquire(tree_id: &str) -> Result<Self> {
         let path = lock_path(tree_id)?;
-        let deadline = std::time::Instant::now()
-            + std::time::Duration::from_secs_f64(LOCK_TIMEOUT_SECS);
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs_f64(LOCK_TIMEOUT_SECS);
         let pid = std::process::id();
 
         loop {
@@ -186,8 +186,7 @@ impl FileLock {
                     if let Ok(content) = fs::read_to_string(&path) {
                         if let Ok(holder_pid) = content.trim().parse::<i32>() {
                             // kill(pid, 0) checks if process exists
-                            let alive =
-                                unsafe { libc::kill(holder_pid, 0) } == 0;
+                            let alive = unsafe { libc::kill(holder_pid, 0) } == 0;
                             if !alive {
                                 // Stale lock — remove it
                                 let _ = fs::remove_file(&path);
@@ -369,10 +368,7 @@ fn check_can_spawn() -> (bool, String, u32, u32) {
     (true, "ok".to_string(), active_count, depth)
 }
 
-fn register_session(
-    session_id: &str,
-    parent_id: Option<&str>,
-) -> Result<(String, u32)> {
+fn register_session(session_id: &str, parent_id: Option<&str>) -> Result<(String, u32)> {
     let ctx = get_tree_context();
     let tree_id = if ctx.tree_id.is_empty() {
         generate_short_id()
@@ -395,9 +391,7 @@ fn register_session(
         .count() as u32;
 
     if active_count >= max_sessions {
-        bail!(
-            "max_sessions={max_sessions} reached ({active_count} active)"
-        );
+        bail!("max_sessions={max_sessions} reached ({active_count} active)");
     }
     if depth > max_depth {
         bail!("depth={depth} exceeds max_depth={max_depth}");
@@ -411,9 +405,7 @@ fn register_session(
         completed_at: 0.0,
         children: Vec::new(),
     };
-    state
-        .sessions
-        .insert(session_id.to_string(), entry);
+    state.sessions.insert(session_id.to_string(), entry);
 
     if let Some(pid) = parent_id {
         if let Some(parent) = state.sessions.get_mut(pid) {
@@ -493,26 +485,23 @@ pub fn run_session_tree(command: SessionTreeCommands) -> Result<()> {
         SessionTreeCommands::Register {
             session_id,
             parent_id,
-        } => {
-            match register_session(&session_id, parent_id.as_deref()) {
-                Ok((tree_id, depth)) => {
-                    println!("TREE_ID={tree_id} DEPTH={depth}");
-                    Ok(())
-                }
-                Err(e) => {
-                    eprintln!("ERROR: {e}");
-                    std::process::exit(1);
-                }
+        } => match register_session(&session_id, parent_id.as_deref()) {
+            Ok((tree_id, depth)) => {
+                println!("TREE_ID={tree_id} DEPTH={depth}");
+                Ok(())
             }
-        }
+            Err(e) => {
+                eprintln!("ERROR: {e}");
+                std::process::exit(1);
+            }
+        },
         SessionTreeCommands::Complete { session_id } => {
             complete_session(&session_id)?;
             Ok(())
         }
         SessionTreeCommands::Status { tree_id } => {
-            let tid = tree_id.unwrap_or_else(|| {
-                std::env::var("AMPLIHACK_TREE_ID").unwrap_or_default()
-            });
+            let tid =
+                tree_id.unwrap_or_else(|| std::env::var("AMPLIHACK_TREE_ID").unwrap_or_default());
             if tid.is_empty() {
                 eprintln!("No AMPLIHACK_TREE_ID set");
                 std::process::exit(1);

--- a/crates/amplihack-cli/src/commands/session_tree/mod.rs
+++ b/crates/amplihack-cli/src/commands/session_tree/mod.rs
@@ -1,0 +1,525 @@
+//! Session tree management for amplihack orchestration.
+//!
+//! Prevents infinite recursion by tracking active sessions in a tree structure.
+//! Enforces max depth and max concurrent session limits.
+//!
+//! Replaces `amplifier-bundle/tools/session_tree.py`.
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::SessionTreeCommands;
+
+const DEFAULT_MAX_DEPTH: u32 = 3;
+const DEFAULT_MAX_SESSIONS: u32 = 10;
+/// Reserved for future `increment-spawn` subcommand.
+#[allow(dead_code)]
+const DEFAULT_MAX_TREE_SPAWNS: u32 = 50;
+const LOCK_TIMEOUT_SECS: f64 = 10.0;
+const LOCK_SPIN_MS: u64 = 50;
+const COMPLETED_MAX_AGE_HOURS: f64 = 24.0;
+const ACTIVE_MAX_AGE_HOURS: f64 = 4.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State model
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct SessionEntry {
+    depth: u32,
+    parent: Option<String>,
+    status: String,
+    started_at: f64,
+    #[serde(default)]
+    completed_at: f64,
+    #[serde(default)]
+    children: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct TreeState {
+    sessions: HashMap<String, SessionEntry>,
+    #[serde(default)]
+    spawn_count: u32,
+}
+
+impl Default for TreeState {
+    fn default() -> Self {
+        Self {
+            sessions: HashMap::new(),
+            spawn_count: 0,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Environment context
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct TreeContext {
+    tree_id: String,
+    depth: u32,
+    max_depth: u32,
+    max_sessions: u32,
+}
+
+fn get_tree_context() -> TreeContext {
+    let depth = std::env::var("AMPLIHACK_SESSION_DEPTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let max_depth = std::env::var("AMPLIHACK_MAX_DEPTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_MAX_DEPTH);
+    let max_sessions = std::env::var("AMPLIHACK_MAX_SESSIONS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_MAX_SESSIONS);
+    let tree_id = std::env::var("AMPLIHACK_TREE_ID").unwrap_or_default();
+
+    TreeContext {
+        tree_id,
+        depth,
+        max_depth,
+        max_sessions,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Paths & validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn state_dir() -> PathBuf {
+    let base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(base).join("amplihack-session-trees")
+}
+
+fn validate_tree_id(tree_id: &str) -> Result<()> {
+    if tree_id.is_empty() {
+        bail!("tree_id cannot be empty");
+    }
+    let re = Regex::new(r"^[a-zA-Z0-9_-]{1,64}$").unwrap();
+    if !re.is_match(tree_id) {
+        bail!(
+            "Invalid tree_id {:?}: must match [a-zA-Z0-9_-]{{1,64}}",
+            tree_id
+        );
+    }
+    Ok(())
+}
+
+fn ensure_state_dir() -> Result<()> {
+    let dir = state_dir();
+    if !dir.exists() {
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("Failed to create state dir: {}", dir.display()))?;
+        // Best-effort chmod 0o700
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o700));
+        }
+    }
+    Ok(())
+}
+
+fn state_path(tree_id: &str) -> Result<PathBuf> {
+    validate_tree_id(tree_id)?;
+    ensure_state_dir()?;
+    let dir = state_dir();
+    let candidate = dir.join(format!("{tree_id}.json"));
+    // Path traversal guard: resolve and verify prefix
+    let resolved = candidate
+        .canonicalize()
+        .unwrap_or_else(|_| candidate.clone());
+    let dir_resolved = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+    if !resolved.starts_with(&dir_resolved) && candidate != dir.join(format!("{tree_id}.json")) {
+        bail!("Path traversal detected for tree_id {:?}", tree_id);
+    }
+    Ok(dir.join(format!("{tree_id}.json")))
+}
+
+fn lock_path(tree_id: &str) -> Result<PathBuf> {
+    validate_tree_id(tree_id)?;
+    ensure_state_dir()?;
+    Ok(state_dir().join(format!("{tree_id}.lock")))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// File-based locking (O_EXCL cross-process mutex with stale PID detection)
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct FileLock {
+    path: PathBuf,
+}
+
+impl FileLock {
+    fn acquire(tree_id: &str) -> Result<Self> {
+        let path = lock_path(tree_id)?;
+        let deadline = std::time::Instant::now()
+            + std::time::Duration::from_secs_f64(LOCK_TIMEOUT_SECS);
+        let pid = std::process::id();
+
+        loop {
+            // Try O_CREAT | O_EXCL | O_WRONLY
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&path)
+            {
+                Ok(mut f) => {
+                    let _ = write!(f, "{pid}");
+                    return Ok(FileLock { path });
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // Check if lock holder is alive
+                    if let Ok(content) = fs::read_to_string(&path) {
+                        if let Ok(holder_pid) = content.trim().parse::<i32>() {
+                            // kill(pid, 0) checks if process exists
+                            let alive =
+                                unsafe { libc::kill(holder_pid, 0) } == 0;
+                            if !alive {
+                                // Stale lock — remove it
+                                let _ = fs::remove_file(&path);
+                            }
+                        }
+                        // If content is not a valid PID, just wait
+                    }
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!("Failed to create lock file: {}", path.display())
+                    });
+                }
+            }
+
+            if std::time::Instant::now() >= deadline {
+                bail!(
+                    "Could not acquire file lock for tree {:?} within {LOCK_TIMEOUT_SECS}s",
+                    tree_id
+                );
+            }
+            std::thread::sleep(std::time::Duration::from_millis(LOCK_SPIN_MS));
+        }
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State I/O
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn now_epoch() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+fn load_state(tree_id: &str) -> TreeState {
+    let path = match state_path(tree_id) {
+        Ok(p) => p,
+        Err(_) => return TreeState::default(),
+    };
+    if !path.exists() {
+        return TreeState::default();
+    }
+    match fs::read_to_string(&path) {
+        Ok(text) => match serde_json::from_str::<TreeState>(&text) {
+            Ok(state) => state,
+            Err(e) => {
+                eprintln!(
+                    "WARNING: session_tree: corrupted state for {:?}: {e}",
+                    tree_id
+                );
+                TreeState::default()
+            }
+        },
+        Err(e) => {
+            eprintln!(
+                "WARNING: session_tree: corrupted state for {:?}: {e}",
+                tree_id
+            );
+            TreeState::default()
+        }
+    }
+}
+
+fn save_state(tree_id: &str, state: &mut TreeState) -> Result<()> {
+    let now = now_epoch();
+    let completed_cutoff = now - (COMPLETED_MAX_AGE_HOURS * 3600.0);
+    let active_cutoff = now - (ACTIVE_MAX_AGE_HOURS * 3600.0);
+
+    // Prune stale sessions
+    state.sessions.retain(|sid, s| {
+        if s.status == "completed" && s.completed_at < completed_cutoff {
+            return false;
+        }
+        if s.status == "active" && s.started_at < active_cutoff {
+            let age_hours = (now - s.started_at) / 3600.0;
+            eprintln!(
+                "WARNING: session_tree: pruning leaked active session {:?} (started {age_hours:.1}h ago)",
+                sid
+            );
+            return false;
+        }
+        true
+    });
+
+    // Atomic write via temp file + rename
+    let target = state_path(tree_id)?;
+    let dir = state_dir();
+    let content = serde_json::to_string_pretty(state)?;
+
+    let tmp = tempfile::NamedTempFile::new_in(&dir)
+        .with_context(|| format!("Failed to create temp file in {}", dir.display()))?;
+    fs::write(tmp.path(), &content)?;
+    // persist() does rename
+    tmp.persist(&target)
+        .with_context(|| format!("Failed to persist state to {}", target.display()))?;
+
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ID generation (replaces uuid.uuid4().hex[:8])
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn generate_short_id() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let pid = std::process::id();
+    let mut hasher = Sha256::new();
+    hasher.update(now.as_nanos().to_le_bytes());
+    hasher.update(pid.to_le_bytes());
+    // Mix in a pointer to a stack variable for extra entropy
+    let stack_var: u8 = 0;
+    let addr = &stack_var as *const u8 as usize;
+    hasher.update(addr.to_le_bytes());
+    let hash = hasher.finalize();
+    // 8 hex chars (4 bytes)
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}",
+        hash[0], hash[1], hash[2], hash[3]
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core operations
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn check_can_spawn() -> (bool, String, u32, u32) {
+    let ctx = get_tree_context();
+    let tree_id = &ctx.tree_id;
+    let depth = ctx.depth;
+    let max_depth = ctx.max_depth;
+    let max_sessions = ctx.max_sessions;
+    let child_depth = depth + 1;
+
+    if child_depth > max_depth {
+        return (
+            false,
+            format!("max_depth={max_depth} exceeded at depth={depth}"),
+            0,
+            depth,
+        );
+    }
+
+    if tree_id.is_empty() {
+        // Root session creating first tree — always allowed
+        return (true, "new_tree".to_string(), 0, 0);
+    }
+
+    if validate_tree_id(tree_id).is_err() {
+        return (false, "invalid_tree_id".to_string(), 0, depth);
+    }
+
+    let state = load_state(tree_id);
+    let active_count = state
+        .sessions
+        .values()
+        .filter(|s| s.status == "active")
+        .count() as u32;
+
+    if active_count >= max_sessions {
+        return (
+            false,
+            format!("max_sessions={max_sessions} reached ({active_count} active)"),
+            active_count,
+            depth,
+        );
+    }
+
+    (true, "ok".to_string(), active_count, depth)
+}
+
+fn register_session(
+    session_id: &str,
+    parent_id: Option<&str>,
+) -> Result<(String, u32)> {
+    let ctx = get_tree_context();
+    let tree_id = if ctx.tree_id.is_empty() {
+        generate_short_id()
+    } else {
+        ctx.tree_id.clone()
+    };
+    validate_tree_id(&tree_id)?;
+    let depth = ctx.depth;
+    let max_sessions = ctx.max_sessions;
+    let max_depth = ctx.max_depth;
+
+    let _lock = FileLock::acquire(&tree_id)?;
+    let mut state = load_state(&tree_id);
+
+    // Atomic capacity and depth check
+    let active_count = state
+        .sessions
+        .values()
+        .filter(|s| s.status == "active")
+        .count() as u32;
+
+    if active_count >= max_sessions {
+        bail!(
+            "max_sessions={max_sessions} reached ({active_count} active)"
+        );
+    }
+    if depth > max_depth {
+        bail!("depth={depth} exceeds max_depth={max_depth}");
+    }
+
+    let entry = SessionEntry {
+        depth,
+        parent: parent_id.map(|s| s.to_string()),
+        status: "active".to_string(),
+        started_at: now_epoch(),
+        completed_at: 0.0,
+        children: Vec::new(),
+    };
+    state
+        .sessions
+        .insert(session_id.to_string(), entry);
+
+    if let Some(pid) = parent_id {
+        if let Some(parent) = state.sessions.get_mut(pid) {
+            parent.children.push(session_id.to_string());
+        }
+    }
+
+    save_state(&tree_id, &mut state)?;
+    Ok((tree_id, depth))
+}
+
+fn complete_session(session_id: &str) -> Result<()> {
+    let ctx = get_tree_context();
+    let tree_id = &ctx.tree_id;
+    if tree_id.is_empty() {
+        return Ok(());
+    }
+    validate_tree_id(tree_id)?;
+
+    let _lock = FileLock::acquire(tree_id)?;
+    let mut state = load_state(tree_id);
+
+    if let Some(session) = state.sessions.get_mut(session_id) {
+        session.status = "completed".to_string();
+        session.completed_at = now_epoch();
+    }
+
+    save_state(tree_id, &mut state)?;
+    Ok(())
+}
+
+fn get_status(tree_id: &str) -> Result<serde_json::Value> {
+    validate_tree_id(tree_id)?;
+    let state = load_state(tree_id);
+
+    let active: Vec<&String> = state
+        .sessions
+        .iter()
+        .filter(|(_, s)| s.status == "active")
+        .map(|(sid, _)| sid)
+        .collect();
+    let completed: Vec<&String> = state
+        .sessions
+        .iter()
+        .filter(|(_, s)| s.status == "completed")
+        .map(|(sid, _)| sid)
+        .collect();
+    let depths: HashMap<&String, u32> = state
+        .sessions
+        .iter()
+        .map(|(sid, s)| (sid, s.depth))
+        .collect();
+
+    Ok(serde_json::json!({
+        "tree_id": tree_id,
+        "active": active,
+        "completed": completed,
+        "depths": depths,
+    }))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI dispatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub fn run_session_tree(command: SessionTreeCommands) -> Result<()> {
+    match command {
+        SessionTreeCommands::Check => {
+            let (allowed, reason, _active, _depth) = check_can_spawn();
+            if allowed {
+                println!("ALLOWED");
+            } else {
+                println!("BLOCKED:{reason}");
+            }
+            Ok(())
+        }
+        SessionTreeCommands::Register {
+            session_id,
+            parent_id,
+        } => {
+            match register_session(&session_id, parent_id.as_deref()) {
+                Ok((tree_id, depth)) => {
+                    println!("TREE_ID={tree_id} DEPTH={depth}");
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("ERROR: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        SessionTreeCommands::Complete { session_id } => {
+            complete_session(&session_id)?;
+            Ok(())
+        }
+        SessionTreeCommands::Status { tree_id } => {
+            let tid = tree_id.unwrap_or_else(|| {
+                std::env::var("AMPLIHACK_TREE_ID").unwrap_or_default()
+            });
+            if tid.is_empty() {
+                eprintln!("No AMPLIHACK_TREE_ID set");
+                std::process::exit(1);
+            }
+            let status = get_status(&tid)?;
+            println!("{}", serde_json::to_string_pretty(&status)?);
+            Ok(())
+        }
+    }
+}

--- a/crates/amplihack-cli/src/lib.rs
+++ b/crates/amplihack-cli/src/lib.rs
@@ -77,8 +77,8 @@ pub const VERSION: &str = match option_env!("AMPLIHACK_RELEASE_VERSION") {
 
 pub use cli_commands::Commands;
 pub use cli_subcommands::{
-    MemoryCommands, ModeCommands, MultitaskCommands, PluginCommands, QueryCodeCommands,
-    RecipeCommands,
+    MemoryCommands, ModeCommands, MultitaskCommands, OrchestratorHelperCommands, PluginCommands,
+    QueryCodeCommands, RecipeCommands, SessionTreeCommands,
 };
 
 fn graph_db_backend_value_parser() -> PossibleValuesParser {


### PR DESCRIPTION
## Summary
- Add `amplihack orch-helper` subcommand (5 subcommands: extract-json, normalise-type, create-workstreams-config, uuid, json-output) replacing Python `orch_helper.py`
- Add `amplihack session-tree` subcommand (4 subcommands: check, register, complete, status) replacing Python `session_tree.py`
- Replace 12 of 14 python3 invocations in `smart-orchestrator.yaml` with native Rust/jq equivalents
- Replace 1 python3 invocation in `default-workflow.yaml` with jq
- 12 new unit tests for orch-helper, all passing

### Python invocation reduction
| File | Before | After | Remaining |
|------|--------|-------|-----------|
| smart-orchestrator.yaml | 13 | 2 | Optional workflow hook calls (set/clear_workflow_active) |
| default-workflow.yaml | 1 | 0 | None |

### New CLI subcommands
```
amplihack orch-helper extract-json              # Extract first JSON from LLM output (stdin)
amplihack orch-helper normalise-type            # Normalize task type string (stdin)
amplihack orch-helper create-workstreams-config # Generate workstream config from decomposition
amplihack orch-helper uuid                      # Generate 8-char hex identifier
amplihack orch-helper json-output key=val ...   # Build JSON from key=value pairs
amplihack session-tree check                    # Advisory spawn check
amplihack session-tree register <id>            # Register session atomically
amplihack session-tree complete <id>            # Mark session completed
amplihack session-tree status [tree_id]         # Show tree status
```

Closes #283. Partially addresses #284, #285.

## Test plan
- [x] `cargo check --lib -p amplihack-cli` compiles clean
- [x] `cargo test -p amplihack-cli -- orch_helper` — 12/12 tests pass
- [x] `cargo test -p amplihack-cli` — 978/980 pass (2 pre-existing failures in update::tests)
- [x] Manual testing of all new subcommands with real input
- [ ] End-to-end: run `/dev` with updated smart-orchestrator.yaml to verify orchestration works

🤖 Generated with [Claude Code](https://claude.com/claude-code)