### PR TITLE
feat: eliminate Python deps — port all tools to Rust, add eval crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Unreleased changes appear at the top under `[Unreleased]`.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **#277 (CRITICAL)**: Shell recipe steps now inject `HOME`, `PATH`,
+  `NONINTERACTIVE=1`, `DEBIAN_FRONTEND=noninteractive`, and `CI=true`
+  environment variables to prevent non-interactive shell hangs.
+
+- **#251 (CRITICAL)**: Agent recipe steps now receive working directory
+  context (path + file listing) in their prompt, preventing zero-change
+  outcomes when agents don't know where to write files.
+
+- **#257 (HIGH)**: `verify_sha256()` checksum download now uses
+  `http_get_with_retry()` with exponential backoff, preventing transient
+  502 errors from killing the update process.
+
+- **#249 (HIGH)**: `amplihack update` now calls `ensure_framework_installed()`
+  after binary replacement to re-stage assets (skills, recipes, hooks).
+  Failures are warned but do not abort the update.
+
+- **#254 (HIGH)**: Install URLs changed from Python repo
+  (`rysweet/amplihack`) to Rust repo (`rysweet/amplihack-rs`).
+  `find_framework_repo_root()` now accepts both `.claude/` and
+  `amplifier-bundle/` directory markers.
+
+- **#269 (MEDIUM)**: Workflow classifier OPS keywords changed from
+  single-word `"manage"` to multi-word phrases (`"manage infrastructure"`,
+  `"manage deployment"`, etc.). Added constructive-verb override: requests
+  containing OPS keywords + constructive verbs (add, create, build, etc.)
+  now correctly classify as DEFAULT.
+
+- **#280 (MEDIUM)**: QA team skill now includes repo-type detection table
+  for selecting the correct test command (`cargo test` for Rust,
+  `gadugi-test` for Node, `pytest` for Python).
+
+- **#242 (LOW)**: Added `validate_shell_prerequisites()` guard that checks
+  for known tools (python3, node, cargo, etc.) before shell step execution,
+  providing clear "tool not found" errors instead of cryptic failures.
+
+---
+
 ## [0.6.1] — 2026-03-16 — Test stability fixes
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
 name = "amplihack-cli"
 version = "0.7.32"
 dependencies = [
+ "amplihack-eval",
  "amplihack-hive",
  "amplihack-state",
  "amplihack-types",
@@ -179,6 +180,19 @@ dependencies = [
  "amplihack-workflows",
  "chrono",
  "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "amplihack-eval"
+version = "0.7.32"
+dependencies = [
+ "anyhow",
+ "chrono",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/amplihack-utils",
     "crates/amplihack-delegation",
     "crates/amplihack-agent-eval",
+    "crates/amplihack-eval",
     "crates/amplihack-agent-core",
     "crates/amplihack-domain-agents",
     "crates/amplihack-hive",
@@ -74,6 +75,7 @@ amplihack-safety = { path = "crates/amplihack-safety" }
 amplihack-utils = { path = "crates/amplihack-utils" }
 amplihack-delegation = { path = "crates/amplihack-delegation" }
 amplihack-agent-eval = { path = "crates/amplihack-agent-eval" }
+amplihack-eval = { path = "crates/amplihack-eval" }
 amplihack-agent-core = { path = "crates/amplihack-agent-core" }
 amplihack-domain-agents = { path = "crates/amplihack-domain-agents" }
 amplihack-hive = { path = "crates/amplihack-hive" }

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -1952,28 +1952,28 @@ steps:
       export ISSUE_VAL
       PR_VAL=$(printf '%s' {{pr_url}})
       export PR_VAL
-      python3 << 'PYEOF'
-      import json, os
-      print(json.dumps({
-          "workflow": "default-workflow",
-          "version": "2.0.0",
-          "task": os.environ.get("TASK_VAL", ""),
-          "issue_number": os.environ.get("ISSUE_VAL", ""),
-          "pr_url": os.environ.get("PR_VAL", ""),
-          "status": "complete",
-          "steps_completed": 23,
-          "phases_completed": [
-              "requirements-clarification", "design", "implementation",
-              "testing", "review", "merge"
-          ],
-          "mandatory_steps_completed": {
-              "step_0_preparation": True,
-              "step_14_version_bump": True,
-              "step_17_pr_review": True,
-              "step_18_implement_feedback": True
-          },
-          "philosophy_compliant": True,
-          "ready_to_merge": True
-      }, indent=2))
-      PYEOF
+      # Native bash JSON output (replaces python3 json.dumps)
+      cat <<EOJSON
+      {
+        "workflow": "default-workflow",
+        "version": "2.0.0",
+        "task": "${TASK_VAL}",
+        "issue_number": "${ISSUE_VAL}",
+        "pr_url": "${PR_VAL}",
+        "status": "complete",
+        "steps_completed": 23,
+        "phases_completed": [
+          "requirements-clarification", "design", "implementation",
+          "testing", "review", "merge"
+        ],
+        "mandatory_steps_completed": {
+          "step_0_preparation": true,
+          "step_14_version_bump": true,
+          "step_17_pr_review": true,
+          "step_18_implement_feedback": true
+        },
+        "philosophy_compliant": true,
+        "ready_to_merge": true
+      }
+      EOJSON
     output: "workflow_result"

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -53,9 +53,8 @@ steps:
       elif ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
         ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' is not a git repository"
       fi
-      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
-      if [ -z "$HELPER_PATH" ] || [ ! -f "$HELPER_PATH" ]; then
-        ERRORS="${ERRORS}\n  ✗ Cannot find orch_helper.py — set AMPLIHACK_HOME to a valid amplihack root"
+      if ! command -v amplihack >/dev/null 2>&1; then
+        ERRORS="${ERRORS}\n  ✗ amplihack binary not found — install via cargo install or uvx"
       fi
       if ! command -v recipe-runner-rs >/dev/null 2>&1 && [ ! -f "$HOME/.cargo/bin/recipe-runner-rs" ]; then
         ERRORS="${ERRORS}\n  ✗ recipe-runner-rs not found (run: cargo install --git https://github.com/rysweet/amplihack-recipe-runner)"
@@ -121,50 +120,16 @@ steps:
   - id: "parse-decomposition"
     type: "bash"
     command: |
-      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
-      _DECOMP_TMPFILE=$(mktemp)
-      trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
+      # Extract task_type from decomposition JSON using native Rust CLI
+      EXTRACTED=$(cat <<'__DECOMP_EOF__'
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export HELPER_PATH
-      python3 - <<'PYEOF'
-      import sys, json, os, importlib.util
-
-      helper_path = os.environ['HELPER_PATH']
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp_json = f.read()
-
-      spec = importlib.util.spec_from_file_location('orch_helper', helper_path)
-      h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
-      obj = h.extract_json(decomp_json)
-
-      if not obj:
-          msg = (
-              "\n"
-              "╔══════════════════════════════════════════════════════════════════╗\n"
-              "║  ERROR: decomposition JSON parse failed                         ║\n"
-              "║  The architect agent returned non-JSON prose instead of the     ║\n"
-              "║  expected structured plan.                                      ║\n"
-              "║                                                                 ║\n"
-              "║  Action: defaulting to task_type=Development so execution can   ║\n"
-              "║  continue. The adaptive strategy step will evaluate whether     ║\n"
-              "║  direct recipe invocation should be attempted.                  ║\n"
-              "╚══════════════════════════════════════════════════════════════════╝\n"
-          )
-          print(msg, file=sys.stderr)
-          # Do NOT print to stdout — stdout is captured as the output variable
-          # and box-drawing characters would corrupt downstream template substitution
-
-      task_type = h.normalise_type(obj.get("task_type", "Development"))
-      print(task_type)
-      PYEOF
+      )
+      TASK_TYPE_RAW=$(echo "$EXTRACTED" | amplihack orch-helper extract-json | amplihack orch-helper extract-json 2>/dev/null | head -1 || echo '{}')
+      # Extract task_type field, fall back to "Development"
+      RAW_TYPE=$(echo "$EXTRACTED" | amplihack orch-helper extract-json 2>/dev/null | sed -n 's/.*"task_type"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || echo "Development")
+      [ -z "$RAW_TYPE" ] && RAW_TYPE="Development"
+      echo "$RAW_TYPE" | amplihack orch-helper normalise-type
     output: "task_type"
 
   # activate-workflow: compute workstream_count, set workflow semaphore, announce.
@@ -172,71 +137,32 @@ steps:
   - id: "activate-workflow"
     type: "bash"
     command: |
-      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
-      DECOMP_JSON=$(cat <<EOFDECOMP
-      {{decomposition_json}}
-      EOFDECOMP
-      )
       TASK_TYPE={{task_type}}
       FORCE_SINGLE={{force_single_workstream}}
-      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
-      _DECOMP_TMPFILE=$(mktemp)
-      trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
+
+      # Extract workstream count from decomposition JSON using native Rust CLI
+      DECOMP_JSON=$(cat <<'__DECOMP_EOF__'
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export TASK_TYPE=$(printf '%s' {{task_type}})
-      export FORCE_SINGLE=$(printf '%s' "$FORCE_SINGLE")
-      export HELPER_PATH HOOKS_DIR
-      python3 - <<'PYEOF'
-      import os, sys, io, importlib.util
-
-      helper_path = os.environ['HELPER_PATH']
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp_json = f.read()
-      task_type = os.environ['TASK_TYPE']
-      hooks_dir = os.environ['HOOKS_DIR']
-      force_single = os.environ.get('FORCE_SINGLE', 'false').strip().lower() in ('true', '1')
-
-      # Compute workstream count from decomposition JSON
-      spec = importlib.util.spec_from_file_location('orch_helper', helper_path)
-      h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
-      obj = h.extract_json(decomp_json)
-      raw_count = max(1, len(obj.get("workstreams", [])))
+      )
+      EXTRACTED=$(echo "$DECOMP_JSON" | amplihack orch-helper extract-json 2>/dev/null || echo '{}')
+      # Count workstreams array length from extracted JSON
+      RAW_COUNT=$(echo "$EXTRACTED" | sed -n 's/.*"workstreams"[[:space:]]*:[[:space:]]*\[/\n/p' | tr ',' '\n' | grep -c '"name"' || echo 1)
+      [ "$RAW_COUNT" -lt 1 ] 2>/dev/null && RAW_COUNT=1
 
       # Enforce force_single_workstream override (fix #3130)
-      count = 1 if force_single else raw_count
+      FORCE_LOWER=$(echo "$FORCE_SINGLE" | tr '[:upper:]' '[:lower:]')
+      if [ "$FORCE_LOWER" = "true" ] || [ "$FORCE_LOWER" = "1" ]; then
+        if [ "$RAW_COUNT" -ne 1 ]; then
+          echo "[dev-orchestrator] force_single_workstream=true — overriding $RAW_COUNT workstreams to 1" >&2
+        fi
+        COUNT=1
+      else
+        COUNT=$RAW_COUNT
+      fi
 
-      # Set workflow-active semaphore so the hook skips injection during execution
-      # Redirect stdout during import to prevent pollution of captured output
-      _saved_stdout = sys.stdout
-      sys.stdout = io.StringIO()
-      try:
-          sys.path.insert(0, hooks_dir)
-          from dev_intent_router import set_workflow_active
-          set_workflow_active(task_type, count)
-      except Exception:
-          pass  # Hook may not exist in all environments
-      finally:
-          sys.stdout = _saved_stdout
-
-      # Announce classification to stderr (visible to user, not captured as output)
-      if force_single and raw_count != count:
-          print(f"[dev-orchestrator] force_single_workstream=true — overriding {raw_count} workstreams to 1", file=sys.stderr)
-      print(f"[dev-orchestrator] Classified as: {task_type} | Workstreams: {count} — starting execution...", file=sys.stderr)
-
-      # Output workstream count (captured by recipe runner).
-      # Use sys.stdout.write to avoid trailing newline — the recipe runner
-      # stores step output as-is, and a trailing '\n' breaks exact string
-      # comparisons in downstream conditions (fix #3570).
-      sys.stdout.write(str(count))
-      PYEOF
+      echo "[dev-orchestrator] Classified as: $TASK_TYPE | Workstreams: $COUNT — starting execution..." >&2
+      printf '%s' "$COUNT"
     output: "workstream_count"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -263,37 +189,22 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type or task_type == ''"
     command: |
-      TREE_SCRIPT="$(python3 -m amplihack.runtime_assets session-tree-path 2>/dev/null || true)"
-      SESSION_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex[:8])")
-
-      if [ -f "$TREE_SCRIPT" ]; then
-        # Register this session — atomic check+register under lock
-        if OUTPUT=$(python3 "$TREE_SCRIPT" register "$SESSION_ID" 2>&1); then
-          # Output: "TREE_ID=abc123 DEPTH=0"
-          TREE_ID=$(echo "$OUTPUT" | grep -oE 'TREE_ID=[A-Za-z0-9_-]+' | head -1 | cut -d= -f2)
-          DEPTH_STR=$(echo "$OUTPUT" | grep -oE 'DEPTH=[0-9]+' | head -1 | cut -d= -f2)
-          DEPTH_VAL=${DEPTH_STR:-0}
-          # Validate extracted values
-          if ! echo "$TREE_ID" | grep -qE '^[A-Za-z0-9_-]+$'; then
-            python3 -c "import json; print(json.dumps({'session_id': 'error', 'tree_id': 'error', 'depth': 0, 'status': 'registration_failed', 'error': 'invalid tree_id extracted'}))"
-            exit 0
-          fi
-          python3 -c "import sys,json; sid,tid,depth=sys.argv[1],sys.argv[2],int(sys.argv[3]); print(json.dumps({'session_id':sid,'tree_id':tid,'depth':depth,'status':'ok'}))" "$SESSION_ID" "$TREE_ID" "$DEPTH_VAL"
-        else
-          # Registration failed (capacity exceeded or depth limit) — encode structured error
-          echo "NOTE: Session registration failed — proceeding without recursion tracking." >&2
-          python3 -c "import json; print(json.dumps({'session_id': 'none', 'tree_id': 'none', 'depth': 0, 'status': 'registration_failed'}))"
+      # Register session using native Rust CLI (replaces python3 session_tree.py)
+      if OUTPUT=$(amplihack session-tree register 2>&1); then
+        # Output: "TREE_ID=abc123 DEPTH=0"
+        TREE_ID=$(echo "$OUTPUT" | grep -oE 'TREE_ID=[A-Za-z0-9_-]+' | head -1 | cut -d= -f2)
+        SESSION_ID=$(echo "$TREE_ID" | head -c8)  # use first 8 chars as session ID
+        DEPTH_STR=$(echo "$OUTPUT" | grep -oE 'DEPTH=[0-9]+' | head -1 | cut -d= -f2)
+        DEPTH_VAL=${DEPTH_STR:-0}
+        # Validate extracted values
+        if ! echo "$TREE_ID" | grep -qE '^[A-Za-z0-9_-]+$'; then
+          echo '{"session_id":"error","tree_id":"error","depth":0,"status":"registration_failed","error":"invalid tree_id extracted"}'
+          exit 0
         fi
+        printf '{"session_id":"%s","tree_id":"%s","depth":%d,"status":"ok"}' "$SESSION_ID" "$TREE_ID" "$DEPTH_VAL"
       else
-        # No session_tree.py — generate a tree_id from env or fresh uuid
-        TREE_ID=$(echo "${AMPLIHACK_TREE_ID:-}" | grep -E '^[A-Za-z0-9_-]+$' | head -1)
-        if [ -z "$TREE_ID" ]; then
-          TREE_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex[:8])")
-        fi
-        DEPTH_RAW="${AMPLIHACK_SESSION_DEPTH:-0}"
-        # Validate it's an integer (default to 0 if not)
-        DEPTH_VAL=$(echo "$DEPTH_RAW" | grep -E '^[0-9]+$' || echo '0')
-        python3 -c "import sys,json; sid,tid,depth=sys.argv[1],sys.argv[2],int(sys.argv[3]); print(json.dumps({'session_id':sid,'tree_id':tid,'depth':depth,'status':'no_tree_script'}))" "$SESSION_ID" "$TREE_ID" "$DEPTH_VAL"
+        echo "NOTE: Session registration failed — proceeding without recursion tracking." >&2
+        echo '{"session_id":"none","tree_id":"none","depth":0,"status":"registration_failed"}'
       fi
     output: "session_info"
 
@@ -407,42 +318,37 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and workstream_count != 1 and workstream_count != '1' and workstream_count != '' and 'ALLOWED' in recursion_guard and force_single_workstream != 'true'
     command: |
-      HELPER_PATH="$(python3 -m amplihack.runtime_assets helper-path 2>/dev/null || true)"
-      if [ ! -f "$HELPER_PATH" ]; then
-          echo "ERROR: orch_helper.py not found at: $HELPER_PATH" >&2
-          echo "Ensure amplihack is installed correctly, or set AMPLIHACK_HOME to a valid runtime root." >&2
-          exit 1
-      fi
-      _DECOMP_TMPFILE=$(mktemp)
-      trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
+      # Extract workstreams from decomposition JSON using native Rust CLI
+      DECOMP_JSON=$(cat <<'__DECOMP_EOF__'
       {{decomposition_json}}
       __DECOMP_EOF__
-      export DECOMP_TMPFILE="$_DECOMP_TMPFILE"
-      export HELPER_PATH
-      python3 - <<'PYEOF'
-      import json, os, re, tempfile, sys
-      sys.path.insert(0, os.path.dirname(os.environ['HELPER_PATH']))
-      import orch_helper
-      with open(os.environ['DECOMP_TMPFILE']) as f:
-          decomp = f.read()
-      obj = orch_helper.extract_json(decomp)
-      config = []
-      for i, ws in enumerate(obj.get("workstreams", [])):
-          name = ws.get("name", f"workstream-{i+1}")
-          slug = re.sub(r'[^a-z0-9-]', '-', name.lower())[:30].strip('-') or f"ws-{i+1}"
-          config.append({
-              "issue": "TBD",
-              "branch": f"feat/orch-{i+1}-{slug}",
-              "description": name,
-              "task": ws.get("description", name),
-              "recipe": ws.get("recipe", "default-workflow")
-          })
-      fd, p = tempfile.mkstemp(prefix="smart-orch-ws-", suffix=".json", dir="/tmp")
-      os.chmod(p, 0o600)
-      with os.fdopen(fd, "w") as f: json.dump(config, f, indent=2)
-      print(p)
-      PYEOF
+      )
+      EXTRACTED=$(echo "$DECOMP_JSON" | amplihack orch-helper extract-json 2>/dev/null || echo '{}')
+
+      # Generate workstreams config using jq-like processing in bash
+      WS_FILE=$(mktemp -p /tmp smart-orch-ws-XXXXXX.json)
+      chmod 600 "$WS_FILE"
+
+      # Parse workstreams from extracted JSON and build config
+      # Use amplihack orch-helper generate-workstream-config for the heavy lifting
+      echo "$EXTRACTED" | amplihack orch-helper generate-workstream-config > "$WS_FILE.raw" 2>/dev/null
+
+      # Transform the raw decomposition into multitask config format
+      # Extract workstreams array and reformat for the orchestrator
+      if command -v jq >/dev/null 2>&1; then
+        jq '[.workstreams // [] | to_entries[] | {
+          issue: "TBD",
+          branch: ("feat/orch-" + ((.key + 1) | tostring) + "-" + (.value.name // ("ws-" + ((.key + 1) | tostring))) | gsub("[^a-z0-9-]"; "-") | .[0:30]),
+          description: (.value.name // ("workstream-" + ((.key + 1) | tostring))),
+          task: (.value.description // .value.name // ""),
+          recipe: (.value.recipe // "default-workflow")
+        }]' "$WS_FILE.raw" > "$WS_FILE" 2>/dev/null
+      else
+        # Fallback: use the raw JSON directly (workstreams array)
+        cp "$WS_FILE.raw" "$WS_FILE"
+      fi
+      rm -f "$WS_FILE.raw"
+      echo "$WS_FILE"
     output: "workstreams_file"
 
   - id: "launch-parallel-round-1"
@@ -460,28 +366,13 @@ steps:
       {{session_info}}
       EOFSESSIONJSON
       )
-      # Parse tree_id, depth, and validate workstreams file in one Python subprocess.
-      # Uses env vars instead of pipe+heredoc to avoid stdin conflict (issue #2581).
-      export SESSION_JSON WS_FILE
-      read -r TREE_ID SESSION_DEPTH WS_COUNT_CHECK < <(python3 <<'PYEOF'
-      import os, json
-      try:
-          d = json.loads(os.environ.get('SESSION_JSON', '{}'))
-          tid = d.get('tree_id', '')
-          depth = d.get('depth', 0)
-      except Exception:
-          tid, depth = '', 0
-      ws_file = os.environ.get('WS_FILE', '')
-      ws_count = 0
-      if ws_file:
-          try:
-              with open(ws_file) as f:
-                  ws_count = len(json.load(f))
-          except Exception:
-              pass
-      print(tid, depth, ws_count)
-      PYEOF
-      )
+      # Parse tree_id, depth, and validate workstreams file using native tools
+      TREE_ID=$(echo "$SESSION_JSON" | sed -n 's/.*"tree_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+      SESSION_DEPTH=$(echo "$SESSION_JSON" | sed -n 's/.*"depth"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+      WS_COUNT_CHECK=0
+      if [ -n "$WS_FILE" ] && [ -f "$WS_FILE" ]; then
+        WS_COUNT_CHECK=$(grep -c '"branch"' "$WS_FILE" 2>/dev/null || echo 0)
+      fi
       TREE_ID=${TREE_ID:-}
       SESSION_DEPTH=${SESSION_DEPTH:-0}
       WS_COUNT_CHECK=${WS_COUNT_CHECK:-0}
@@ -505,36 +396,14 @@ steps:
       fi
       cd "$REPO_PATH"
 
-      # Resolve multitask orchestrator from AMPLIHACK_HOME, not from repo root.
-      # The orchestrator.py is an amplihack asset, not a repo file (#3762).
-      ORCH_SCRIPT=""
-      for candidate in \
-        "${AMPLIHACK_HOME:+$AMPLIHACK_HOME/.claude/skills/multitask/orchestrator.py}" \
-        "${HOME}/.amplihack/.claude/skills/multitask/orchestrator.py" \
-        "${HOME}/.copilot/skills/multitask/orchestrator.py" \
-        ".claude/skills/multitask/orchestrator.py"; do
-        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
-          ORCH_SCRIPT="$candidate"
-          break
-        fi
-      done
-      if [ -z "$ORCH_SCRIPT" ]; then
-        echo "ERROR: multitask orchestrator.py not found." >&2
-        echo "  Searched: AMPLIHACK_HOME/.claude/skills/multitask/orchestrator.py" >&2
-        echo "  Set AMPLIHACK_HOME or ensure amplihack is installed." >&2
-        emit_step_transition fail
-        exit 1
-      fi
-      echo "Selected orchestrator source: $ORCH_SCRIPT" >&2
-
-      echo "Launching parallel workstreams (tree: $TREE_ID, depth: $SESSION_DEPTH):"
+      echo "Launching parallel workstreams via native Rust orchestrator (tree: $TREE_ID, depth: $SESSION_DEPTH):"
       cat "$WS_FILE"
       echo "---"
       status=0
       AMPLIHACK_TREE_ID="$TREE_ID" AMPLIHACK_SESSION_DEPTH="$SESSION_DEPTH" \
         AMPLIHACK_PARENT_STEP="launch-parallel-round-1" \
         AMPLIHACK_REPO_PATH="$REPO_PATH" \
-        python3 -u "$ORCH_SCRIPT" "$WS_FILE" | tee /dev/stderr || status=$?
+        amplihack multitask run "$WS_FILE" 2>&1 | tee /dev/stderr || status=$?
       # Clean up workstreams file now, before this step's output inflates
       # the recipe context. Doing it here avoids the E2BIG error that
       # occurs when a later bash step inherits megabytes of env vars
@@ -958,36 +827,13 @@ steps:
       {{session_info}}
       EOFSESSIONJSON
       )
-      TREE_SCRIPT="$(python3 -m amplihack.runtime_assets session-tree-path 2>/dev/null || true)"
-      HOOKS_DIR="$(python3 -m amplihack.runtime_assets hooks-dir 2>/dev/null || true)"
-      # Parse session fields and clear workflow semaphore in one Python subprocess.
-      # Uses env vars instead of pipe+heredoc to avoid stdin conflict (issue #2581).
-      export SESSION_JSON HOOKS_DIR
-      read -r SESSION_ID TREE_ID STATUS < <(python3 <<'PYEOF'
-      import json, os, sys
-      try:
-          d = json.loads(os.environ.get('SESSION_JSON', '{}'))
-          sid, tid, status = d.get('session_id',''), d.get('tree_id',''), d.get('status','')
-      except Exception:
-          sid, tid, status = '', '', ''
-      # Clear workflow-active semaphore so the hook resumes injection
-      try:
-          hooks_dir = os.environ.get('HOOKS_DIR', '')
-          if hooks_dir:
-              sys.path.insert(0, hooks_dir)
-              from dev_intent_router import clear_workflow_active
-              clear_workflow_active()
-      except Exception:
-          pass
-      print(sid, tid, status)
-      PYEOF
-      )
-      SESSION_ID=${SESSION_ID:-}
-      TREE_ID=${TREE_ID:-}
-      STATUS=${STATUS:-}
+      # Parse session fields using native tools (replaces python3)
+      SESSION_ID=$(echo "$SESSION_JSON" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+      TREE_ID=$(echo "$SESSION_JSON" | sed -n 's/.*"tree_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+      STATUS=$(echo "$SESSION_JSON" | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 
-      if [ -n "$SESSION_ID" ] && [ "$STATUS" = "ok" ] && [ -f "$TREE_SCRIPT" ]; then
-        AMPLIHACK_TREE_ID="$TREE_ID" python3 "$TREE_SCRIPT" complete "$SESSION_ID"
+      if [ -n "$SESSION_ID" ] && [ "$STATUS" = "ok" ]; then
+        AMPLIHACK_TREE_ID="$TREE_ID" amplihack session-tree complete "$SESSION_ID"
         echo "Session $SESSION_ID completed in tree $TREE_ID"
       else
         echo "No session to complete (status: ${STATUS:-empty})"

--- a/amplifier-bundle/skills/qa-team/SKILL.md
+++ b/amplifier-bundle/skills/qa-team/SKILL.md
@@ -965,6 +965,34 @@ scenario:
 
 ## Framework Integration [LEVEL 2]
 
+### Repo-Type Detection — Test Command Selection
+
+Before running tests, detect the repository type and select the appropriate
+test command. This prevents failures when `gadugi-test` (Node/Electron tooling)
+is not available in non-Node repositories.
+
+| Marker file     | Repo type  | Test command                                   | Scenario validation                        |
+|-----------------|------------|------------------------------------------------|--------------------------------------------|
+| `Cargo.toml`    | Rust       | `cargo test` + `cargo clippy`                  | `tests/parity/scenarios/*.yaml`            |
+| `package.json`  | Node.js    | `gadugi-test run tests/agentic/*.yaml`         | `tests/agentic/*.yaml`                     |
+| `pyproject.toml`| Python     | `python -m pytest`                             | `tests/scenarios/*.feature`                |
+| *(fallback)*    | Unknown    | `gadugi-test run tests/agentic/*.yaml`         | *(gadugi-test default)*                    |
+
+**Detection logic** (apply in order, first match wins):
+
+```bash
+if [ -f Cargo.toml ]; then
+    cargo test --workspace
+    cargo clippy --workspace -- -D warnings
+elif [ -f package.json ]; then
+    gadugi-test run tests/agentic/*.yaml
+elif [ -f pyproject.toml ] || [ -f setup.py ]; then
+    python -m pytest
+else
+    gadugi-test run tests/agentic/*.yaml
+fi
+```
+
 ### Running Tests
 
 **Single test**:

--- a/crates/amplihack-agent-eval/src/long_horizon.rs
+++ b/crates/amplihack-agent-eval/src/long_horizon.rs
@@ -205,61 +205,70 @@ pub fn deterministic_grade(
     let answer_lower = actual_answer.to_lowercase();
     let mut scores = HashMap::new();
 
+    // Pre-lowercase rubric strings once (avoids re-lowercasing per dimension)
+    let keywords_lower: Vec<String> = rubric
+        .required_keywords
+        .iter()
+        .map(|kw| kw.to_lowercase())
+        .collect();
+    let paraphrases_lower: Vec<String> = rubric
+        .acceptable_paraphrases
+        .iter()
+        .map(|p| p.to_lowercase())
+        .collect();
+    let incorrect_lower: Vec<String> = rubric
+        .incorrect_patterns
+        .iter()
+        .map(|pat| pat.to_lowercase())
+        .collect();
+
+    // Pre-compute match counts (shared across dimensions)
+    let matched = keywords_lower
+        .iter()
+        .filter(|kw| answer_lower.contains(kw.as_str()))
+        .count();
+    let paraphrase_hits = paraphrases_lower
+        .iter()
+        .filter(|p| answer_lower.contains(p.as_str()))
+        .count();
+    let all_keywords_matched = !keywords_lower.is_empty() && matched == keywords_lower.len();
+    let has_full_correct = all_keywords_matched || paraphrase_hits > 0;
+    let found_incorrect = !incorrect_lower.is_empty()
+        && incorrect_lower
+            .iter()
+            .any(|pat| answer_lower.contains(pat.as_str()));
+
+    let mut ratio = if keywords_lower.is_empty() {
+        0.5
+    } else {
+        matched as f64 / keywords_lower.len() as f64
+    };
+    ratio = (ratio + paraphrase_hits as f64 * 0.25).min(1.0);
+
     for &dim in dimensions {
         if !DETERMINISTIC_DIMENSIONS.contains(&dim) {
             continue;
         }
 
-        // Keyword matching
-        let matched = rubric
-            .required_keywords
-            .iter()
-            .filter(|kw| answer_lower.contains(&kw.to_lowercase()))
-            .count();
-
-        let mut ratio = if rubric.required_keywords.is_empty() {
-            0.5
-        } else {
-            matched as f64 / rubric.required_keywords.len() as f64
-        };
-
-        // Paraphrase bonus
-        let paraphrase_hits = rubric
-            .acceptable_paraphrases
-            .iter()
-            .filter(|p| answer_lower.contains(&p.to_lowercase()))
-            .count();
-        ratio = (ratio + paraphrase_hits as f64 * 0.25).min(1.0);
-
         // Check incorrect patterns
-        let all_keywords_matched =
-            !rubric.required_keywords.is_empty() && matched == rubric.required_keywords.len();
-        let has_full_correct = all_keywords_matched || paraphrase_hits > 0;
-
-        if !rubric.incorrect_patterns.is_empty() && !has_full_correct {
-            let found_incorrect = rubric
-                .incorrect_patterns
-                .iter()
-                .any(|pat| answer_lower.contains(&pat.to_lowercase()));
-            if found_incorrect {
-                scores.insert(
-                    dim.to_string(),
-                    DimensionScore::new(
-                        dim,
-                        0.0,
-                        "Answer contains incorrect pattern without correct keywords",
-                    ),
-                );
-                continue;
-            }
+        if found_incorrect && !has_full_correct {
+            scores.insert(
+                dim.to_string(),
+                DimensionScore::new(
+                    dim,
+                    0.0,
+                    "Answer contains incorrect pattern without correct keywords",
+                ),
+            );
+            continue;
         }
 
         let mut reasoning_parts = Vec::new();
-        if !rubric.required_keywords.is_empty() {
+        if !keywords_lower.is_empty() {
             reasoning_parts.push(format!(
                 "Matched {}/{} required keywords",
                 matched,
-                rubric.required_keywords.len()
+                keywords_lower.len()
             ));
         }
         if paraphrase_hits > 0 {
@@ -339,46 +348,47 @@ pub fn multi_vote_grade(
 
     let mut result = Vec::new();
     for &dim in dimensions {
-        let mut vote_scores: Vec<f64> = Vec::new();
-        let mut reasonings: Vec<String> = Vec::new();
-        for grade_set in &grades {
+        // Collect (score, reasoning) pairs, deferring reasoning clone
+        let mut vote_entries: Vec<(f64, usize)> = Vec::new();
+        for (gi, grade_set) in grades.iter().enumerate() {
             if let Some(ds) = grade_set.iter().find(|d| d.dimension == dim) {
-                vote_scores.push(ds.score);
-                reasonings.push(ds.reasoning.clone());
+                vote_entries.push((ds.score, gi));
             }
         }
 
-        if vote_scores.is_empty() {
+        if vote_entries.is_empty() {
             result.push(DimensionScore::new(dim, 0.0, "Not graded"));
             continue;
         }
 
-        vote_scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        let median = if vote_scores.len().is_multiple_of(2) {
-            let mid = vote_scores.len() / 2;
-            (vote_scores[mid - 1] + vote_scores[mid]) / 2.0
+        vote_entries
+            .sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let n = vote_entries.len();
+        let median = if n.is_multiple_of(2) {
+            let mid = n / 2;
+            (vote_entries[mid - 1].0 + vote_entries[mid].0) / 2.0
         } else {
-            vote_scores[vote_scores.len() / 2]
+            vote_entries[n / 2].0
         };
 
-        // Pick reasoning closest to median
-        let best_idx = vote_scores
+        // Pick reasoning closest to median — only clone the one we need
+        let best_entry = vote_entries
             .iter()
-            .enumerate()
-            .min_by(|(_, a), (_, b)| {
-                ((**a) - median)
+            .min_by(|(a, _), (b, _)| {
+                (*a - median)
                     .abs()
-                    .partial_cmp(&((**b) - median).abs())
+                    .partial_cmp(&(*b - median).abs())
                     .unwrap_or(std::cmp::Ordering::Equal)
             })
-            .map(|(i, _)| i)
-            .unwrap_or(0);
+            .unwrap();
 
-        let reasoning = format!(
-            "{} [median of {} votes]",
-            reasonings.get(best_idx).cloned().unwrap_or_default(),
-            vote_scores.len()
-        );
+        let best_reasoning = grades[best_entry.1]
+            .iter()
+            .find(|d| d.dimension == dim)
+            .map(|d| d.reasoning.as_str())
+            .unwrap_or("");
+
+        let reasoning = format!("{best_reasoning} [median of {n} votes]");
 
         result.push(DimensionScore::new(dim, median, reasoning));
     }

--- a/crates/amplihack-agent-eval/src/long_horizon_multi_seed.rs
+++ b/crates/amplihack-agent-eval/src/long_horizon_multi_seed.rs
@@ -116,8 +116,8 @@ pub fn build_multi_seed_report(
     }
 
     // Compute per-question variance
-    let mut all_variances = Vec::new();
-    let mut noisy = Vec::new();
+    let mut all_variances = Vec::with_capacity(question_scores.len());
+    let mut noisy_indices = Vec::new();
 
     for (qid, seed_scores) in &question_scores {
         let (text, cat) = question_meta.get(qid).cloned().unwrap_or_default();
@@ -130,7 +130,10 @@ pub fn build_multi_seed_report(
         let std_val = safe_stddev(&values);
         let is_noisy = std_val > (NOISY_THRESHOLD_PP / 100.0);
 
-        let qv = QuestionVariance {
+        if is_noisy {
+            noisy_indices.push(all_variances.len());
+        }
+        all_variances.push(QuestionVariance {
             question_id: qid.clone(),
             question_text: text,
             category: cat,
@@ -138,13 +141,14 @@ pub fn build_multi_seed_report(
             mean_score: mean_val,
             stddev: std_val,
             is_noisy,
-        };
-
-        if is_noisy {
-            noisy.push(qv.clone());
-        }
-        all_variances.push(qv);
+        });
     }
+
+    // Build noisy list by cloning only flagged entries (avoids cloning every entry)
+    let noisy: Vec<QuestionVariance> = noisy_indices
+        .iter()
+        .map(|&i| all_variances[i].clone())
+        .collect();
 
     // Per-category stats
     let mut categories: HashMap<String, HashMap<u64, Vec<f64>>> = HashMap::new();

--- a/crates/amplihack-agent-eval/src/security_log/mod.rs
+++ b/crates/amplihack-agent-eval/src/security_log/mod.rs
@@ -142,10 +142,11 @@ pub struct SecurityGradeResult {
 /// Precision penalizes hallucinated campaign IDs.
 pub fn grade_answer(question: &SecurityQuestion, answer: &str) -> SecurityGradeResult {
     let answer_lower = answer.to_lowercase();
-    let mut matched = Vec::new();
+    let mut matched = Vec::with_capacity(question.required_keywords.len());
     let mut missing = Vec::new();
 
     for kw in &question.required_keywords {
+        // Keywords are typically short identifiers; lowercase once per keyword
         if answer_lower.contains(&kw.to_lowercase()) {
             matched.push(kw.clone());
         } else {
@@ -161,13 +162,13 @@ pub fn grade_answer(question: &SecurityQuestion, answer: &str) -> SecurityGradeR
     };
 
     // Precision: penalize hallucinated campaign IDs
-    let mut mentioned_camps = Vec::new();
+    let mut mentioned_camps = Vec::with_capacity(4);
     let mut start = 0;
     while let Some(pos) = answer[start..].find("CAMP-") {
         let abs_pos = start + pos;
         let end = (abs_pos + 16).min(answer.len());
         mentioned_camps.push(&answer[abs_pos..end]);
-        start = abs_pos + 1;
+        start = abs_pos + 5; // skip past "CAMP-" to avoid overlapping matches
     }
 
     let precision = if !mentioned_camps.is_empty() {
@@ -264,30 +265,42 @@ impl SecurityEvalReport {
             return report;
         }
 
-        let n = results.len() as f64;
-        report.overall_score = results.iter().map(|r| r.score).sum::<f64>() / n;
-        report.overall_precision = results.iter().map(|r| r.precision).sum::<f64>() / n;
-        report.overall_recall = results.iter().map(|r| r.recall).sum::<f64>() / n;
-        report.overall_f1 = results.iter().map(|r| r.f1).sum::<f64>() / n;
+        // Single-pass accumulation for overall and per-category metrics
+        let mut total_score = 0.0;
+        let mut total_precision = 0.0;
+        let mut total_recall = 0.0;
+        let mut total_f1 = 0.0;
+        let mut by_cat: HashMap<String, CategoryMetrics> = HashMap::new();
 
-        // By category
-        let mut by_cat: HashMap<String, Vec<&SecurityGradeResult>> = HashMap::new();
         for r in results {
-            by_cat.entry(r.category.clone()).or_default().push(r);
+            total_score += r.score;
+            total_precision += r.precision;
+            total_recall += r.recall;
+            total_f1 += r.f1;
+
+            let entry = by_cat.entry(r.category.clone()).or_default();
+            entry.score += r.score;
+            entry.precision += r.precision;
+            entry.recall += r.recall;
+            entry.f1 += r.f1;
+            entry.count += 1;
         }
-        for (cat, cat_results) in &by_cat {
-            let cn = cat_results.len() as f64;
-            report.category_scores.insert(
-                cat.clone(),
-                CategoryMetrics {
-                    score: cat_results.iter().map(|r| r.score).sum::<f64>() / cn,
-                    precision: cat_results.iter().map(|r| r.precision).sum::<f64>() / cn,
-                    recall: cat_results.iter().map(|r| r.recall).sum::<f64>() / cn,
-                    f1: cat_results.iter().map(|r| r.f1).sum::<f64>() / cn,
-                    count: cat_results.len(),
-                },
-            );
+
+        let n = results.len() as f64;
+        report.overall_score = total_score / n;
+        report.overall_precision = total_precision / n;
+        report.overall_recall = total_recall / n;
+        report.overall_f1 = total_f1 / n;
+
+        // Convert accumulated sums to averages
+        for metrics in by_cat.values_mut() {
+            let cn = metrics.count as f64;
+            metrics.score /= cn;
+            metrics.precision /= cn;
+            metrics.recall /= cn;
+            metrics.f1 /= cn;
         }
+        report.category_scores = by_cat;
 
         // By difficulty
         let mut by_diff: HashMap<String, Vec<&SecurityGradeResult>> = HashMap::new();

--- a/crates/amplihack-cli/Cargo.toml
+++ b/crates/amplihack-cli/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 amplihack-hive = { path = "../amplihack-hive" }
+amplihack-eval = { workspace = true }
 amplihack-types = { workspace = true }
 amplihack-state = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -4,7 +4,10 @@ use clap::Subcommand;
 use clap_complete::Shell;
 use std::path::PathBuf;
 
-use super::{MemoryCommands, ModeCommands, PluginCommands, QueryCodeCommands, RecipeCommands};
+use super::{
+    EvalCommands, LockCommands, MemoryCommands, ModeCommands, MultitaskCommands,
+    OrchHelperCommands, PluginCommands, QueryCodeCommands, RecipeCommands, SessionTreeCommands,
+};
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
@@ -315,4 +318,47 @@ pub enum Commands {
 
     /// Run system health checks
     Doctor,
+
+    /// Parallel workstream orchestration
+    Multitask {
+        #[command(subcommand)]
+        command: MultitaskCommands,
+    },
+
+    /// Lock/unlock continuous work mode
+    Lock {
+        #[command(subcommand)]
+        command: LockCommands,
+    },
+
+    /// Validate YAML frontmatter in markdown files
+    ValidateFrontmatter {
+        /// File to validate (validates all .md in cwd if omitted)
+        #[arg(long)]
+        file: Option<String>,
+    },
+
+    /// Session tree management for orchestration recursion prevention
+    SessionTree {
+        #[command(subcommand)]
+        command: SessionTreeCommands,
+    },
+
+    /// Orchestration helper functions (JSON extraction, type normalization)
+    OrchHelper {
+        #[command(subcommand)]
+        command: OrchHelperCommands,
+    },
+
+    /// Resolve a bundle asset path (internal use)
+    ResolveBundleAsset {
+        /// Asset name to resolve
+        asset: String,
+    },
+
+    /// Evaluation framework: run benchmarks, score results, generate reports
+    Eval {
+        #[command(subcommand)]
+        command: EvalCommands,
+    },
 }

--- a/crates/amplihack-cli/src/cli_subcommands.rs
+++ b/crates/amplihack-cli/src/cli_subcommands.rs
@@ -216,3 +216,123 @@ pub enum ModeCommands {
     /// Switch to local mode
     ToLocal,
 }
+
+#[derive(Subcommand, Debug)]
+pub enum LockCommands {
+    /// Enable continuous work mode
+    Lock {
+        /// Custom instruction for Claude
+        #[arg(short, long)]
+        message: Option<String>,
+    },
+    /// Disable continuous work mode
+    Unlock,
+    /// Check lock status
+    Check,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SessionTreeCommands {
+    /// Check if a new child session can be spawned
+    Check,
+    /// Register a session in the tree
+    Register {
+        /// Session identifier
+        session_id: Option<String>,
+        /// Parent session identifier
+        parent_id: Option<String>,
+    },
+    /// Mark a session as completed
+    Complete {
+        /// Session identifier
+        session_id: Option<String>,
+    },
+    /// Show tree status
+    Status {
+        /// Tree identifier (defaults to AMPLIHACK_TREE_ID env var)
+        tree_id: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum MultitaskCommands {
+    /// Run parallel workstreams from a config file
+    Run {
+        /// Path to workstreams JSON config
+        config: String,
+        /// Execution mode (recipe or classic)
+        #[arg(long, default_value = "")]
+        mode: String,
+        /// Recipe to use for each workstream
+        #[arg(long, default_value = "")]
+        recipe: String,
+        /// Maximum runtime in seconds
+        #[arg(long, default_value_t = 0)]
+        max_runtime: u64,
+        /// Timeout policy (interrupt-preserve or continue-preserve)
+        #[arg(long)]
+        timeout_policy: Option<String>,
+        /// Show what would be executed
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Clean up completed workstream directories
+    Cleanup {
+        /// Path to workstreams JSON config
+        config: String,
+        /// Show what would be removed
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show workstream status
+    Status {
+        /// Base directory for workstreams
+        #[arg(long)]
+        base_dir: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum OrchHelperCommands {
+    /// Extract first JSON object from LLM output on stdin
+    ExtractJson,
+    /// Normalise task type from stdin to: Q&A, Operations, Investigation, Development
+    NormaliseType,
+    /// Generate workstream config from decomposition JSON on stdin
+    GenerateWorkstreamConfig,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum EvalCommands {
+    /// Run a benchmark from a JSON config file and print results
+    Run {
+        /// Path to benchmark config JSON (or "-" to read from stdin)
+        #[arg(value_name = "CONFIG")]
+        config: String,
+        /// Output format
+        #[arg(short, long, default_value = "text", value_parser = ["text", "json"])]
+        format: String,
+        /// Pass threshold override in [0.0, 1.0]
+        #[arg(long)]
+        threshold: Option<f64>,
+    },
+    /// Compare two benchmark result JSON files (baseline vs candidate)
+    Compare {
+        /// Baseline result JSON file
+        baseline: String,
+        /// Candidate result JSON file
+        candidate: String,
+        /// Output format
+        #[arg(short, long, default_value = "text", value_parser = ["text", "json"])]
+        format: String,
+    },
+    /// Print a benchmark result JSON file in the requested format
+    Report {
+        /// Path to benchmark result JSON file (or "-" for stdin)
+        #[arg(value_name = "RESULT")]
+        result: String,
+        /// Output format
+        #[arg(short, long, default_value = "text", value_parser = ["text", "json"])]
+        format: String,
+    },
+}

--- a/crates/amplihack-cli/src/commands/auto_mode/tests.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/tests.rs
@@ -116,6 +116,11 @@ fn render_auto_session_argv_includes_auto_flags() {
 
 #[test]
 fn build_auto_command_propagates_launcher_environment() {
+    let _guard = crate::test_support::env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let prev_graph_db = std::env::var_os("AMPLIHACK_GRAPH_DB_PATH");
+    unsafe { std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH") };
     let dir = tempfile::tempdir().unwrap();
 
     let command = build_auto_command(
@@ -171,10 +176,20 @@ fn build_auto_command_propagates_launcher_environment() {
         Some("1"),
         "auto-mode sessions must set AMPLIHACK_AUTO_MODE=1 (Python parity)"
     );
+
+    match prev_graph_db {
+        Some(v) => unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", v) },
+        None => unsafe { std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH") },
+    }
 }
 
 #[test]
 fn build_auto_command_marks_staged_execution_context() {
+    let _guard = crate::test_support::env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let prev_graph_db = std::env::var_os("AMPLIHACK_GRAPH_DB_PATH");
+    unsafe { std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH") };
     let execution_dir = tempfile::tempdir().unwrap();
     let project_dir = tempfile::tempdir().unwrap();
 
@@ -220,6 +235,11 @@ fn build_auto_command_marks_staged_execution_context() {
                 .as_ref()
         )
     );
+
+    match prev_graph_db {
+        Some(v) => unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", v) },
+        None => unsafe { std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH") },
+    }
 }
 
 #[test]

--- a/crates/amplihack-cli/src/commands/eval/mod.rs
+++ b/crates/amplihack-cli/src/commands/eval/mod.rs
@@ -1,0 +1,146 @@
+//! `amplihack eval` subcommands.
+//!
+//! Wires the three public bricks in `amplihack-eval` to the CLI:
+//!
+//! * `run`    — execute a benchmark from a JSON config and print results.
+//! * `compare`— diff two benchmark result files (baseline vs. candidate).
+//! * `report` — pretty-print or re-serialise a saved result file.
+
+use amplihack_eval::{BenchmarkResult, Reporter, RunScore, Scorer, ScorerConfig};
+use anyhow::{Context, Result};
+use std::io::Read;
+
+// ─── public entry points ────────────────────────────────────────────────────
+
+/// `amplihack eval run <config> [--format text|json] [--threshold N]`
+pub fn run_eval_run(config_path: &str, format: &str, threshold: Option<f64>) -> Result<()> {
+    let raw = read_source(config_path).context("reading benchmark config")?;
+
+    // The config file is a BenchmarkResult in JSON form (cases pre-populated).
+    // This mirrors the Python eval framework where the runner records outcomes
+    // into a result object that is then passed to the scorer.
+    let mut result: BenchmarkResult =
+        serde_json::from_str(&raw).context("parsing benchmark config JSON")?;
+
+    // Ensure the result is finished (may already have finished_at set).
+    if result.finished_at.is_none() {
+        result.finish();
+    }
+
+    let config = match threshold {
+        Some(t) => ScorerConfig::with_threshold(t),
+        None => ScorerConfig::default(),
+    };
+    let score = Scorer::new(config).score(&result);
+
+    print_score(&score, format)?;
+
+    // Exit non-zero when the benchmark fails so scripts can detect failures.
+    if score.failed() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// `amplihack eval compare <baseline> <candidate> [--format text|json]`
+pub fn run_eval_compare(baseline_path: &str, candidate_path: &str, format: &str) -> Result<()> {
+    let baseline_score = load_score(baseline_path).context("loading baseline")?;
+    let candidate_score = load_score(candidate_path).context("loading candidate")?;
+
+    let scorer = Scorer::new(ScorerConfig::default());
+    let cmp = scorer.compare(&baseline_score, &candidate_score);
+
+    match format {
+        "json" => println!("{}", Reporter::comparison_json(&cmp)?),
+        _ => println!("{}", Reporter::comparison_text(&cmp)),
+    }
+    Ok(())
+}
+
+/// `amplihack eval report <result> [--format text|json]`
+pub fn run_eval_report(result_path: &str, format: &str) -> Result<()> {
+    let score = load_score(result_path).context("loading result")?;
+    print_score(&score, format)?;
+    Ok(())
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/// Read a file path or "-" for stdin.
+fn read_source(path: &str) -> Result<String> {
+    if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("reading stdin")?;
+        Ok(buf)
+    } else {
+        std::fs::read_to_string(path).with_context(|| format!("reading file '{path}'"))
+    }
+}
+
+/// Load a [`RunScore`] from a JSON file (or stdin with "-").
+fn load_score(path: &str) -> Result<RunScore> {
+    let raw = read_source(path)?;
+    serde_json::from_str(&raw).context("parsing RunScore JSON")
+}
+
+/// Print a [`RunScore`] in the requested format.
+fn print_score(score: &RunScore, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", Reporter::json(score)?),
+        _ => println!("{}", Reporter::text(score)),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use amplihack_eval::{BenchmarkResult, Scorer, ScorerConfig};
+    use std::io::Write;
+
+    fn write_temp_result(cases: &[(&str, bool, f64, u64)]) -> tempfile::NamedTempFile {
+        let mut r = BenchmarkResult::new("cli-test");
+        for &(id, passed, score, ms) in cases {
+            r.add_case(id, passed, score, ms);
+        }
+        r.finish();
+        let scorer = Scorer::new(ScorerConfig::default());
+        let score = scorer.score(&r);
+        let json = Reporter::json(&score).unwrap();
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn report_text_reads_file() {
+        let f = write_temp_result(&[("c1", true, 0.9, 5)]);
+        run_eval_report(f.path().to_str().unwrap(), "text").unwrap();
+    }
+
+    #[test]
+    fn report_json_reads_file() {
+        let f = write_temp_result(&[("c1", true, 0.9, 5)]);
+        run_eval_report(f.path().to_str().unwrap(), "json").unwrap();
+    }
+
+    #[test]
+    fn compare_two_files() {
+        let base = write_temp_result(&[("c1", false, 0.2, 5)]);
+        let cand = write_temp_result(&[("c1", true, 0.9, 5)]);
+        run_eval_compare(
+            base.path().to_str().unwrap(),
+            cand.path().to_str().unwrap(),
+            "text",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn load_score_missing_file_errors() {
+        let err = load_score("/no/such/file.json");
+        assert!(err.is_err());
+    }
+}

--- a/crates/amplihack-cli/src/commands/fleet/tests.rs
+++ b/crates/amplihack-cli/src/commands/fleet/tests.rs
@@ -41,6 +41,7 @@ fn native_reasoner_backend_propagates_shared_env_context() {
     let prev_depth = env::var_os("AMPLIHACK_SESSION_DEPTH");
     let prev_max_depth = env::var_os("AMPLIHACK_MAX_DEPTH");
     let prev_max_sessions = env::var_os("AMPLIHACK_MAX_SESSIONS");
+    let prev_graph_db = env::var_os("AMPLIHACK_GRAPH_DB_PATH");
     let previous_cwd = set_cwd(temp.path()).unwrap();
     unsafe {
         env::set_var("AMPLIHACK_HOME", &amplihack_home);
@@ -48,6 +49,7 @@ fn native_reasoner_backend_propagates_shared_env_context() {
         env::set_var("AMPLIHACK_SESSION_DEPTH", "2");
         env::set_var("AMPLIHACK_MAX_DEPTH", "4");
         env::set_var("AMPLIHACK_MAX_SESSIONS", "12");
+        env::remove_var("AMPLIHACK_GRAPH_DB_PATH");
     }
 
     let output = NativeReasonerBackend::Claude(reasoner)
@@ -60,6 +62,7 @@ fn native_reasoner_backend_propagates_shared_env_context() {
     restore_var("AMPLIHACK_SESSION_DEPTH", prev_depth);
     restore_var("AMPLIHACK_MAX_DEPTH", prev_max_depth);
     restore_var("AMPLIHACK_MAX_SESSIONS", prev_max_sessions);
+    restore_var("AMPLIHACK_GRAPH_DB_PATH", prev_graph_db);
 
     assert_eq!(
         output.trim(),

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -93,10 +93,16 @@ fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
     Ok(())
 }
 
+/// BFS search for the framework repo root.
+///
+/// Accepts directories containing either `.claude/` (Python repo layout) or
+/// `amplifier-bundle/` (Rust repo layout) as markers. This allows the install
+/// to work with both the legacy Python repo and the current Rust repo.
 pub(super) fn find_framework_repo_root(root: &Path) -> Result<PathBuf> {
+    let markers = [".claude", "amplifier-bundle"];
     let mut queue = VecDeque::from([root.to_path_buf()]);
     while let Some(dir) = queue.pop_front() {
-        if dir.join(".claude").is_dir() {
+        if markers.iter().any(|m| dir.join(m).is_dir()) {
             return Ok(dir);
         }
         for entry in
@@ -111,7 +117,8 @@ pub(super) fn find_framework_repo_root(root: &Path) -> Result<PathBuf> {
     }
 
     bail!(
-        "downloaded framework archive did not contain a repository root with .claude under {}",
+        "downloaded framework archive did not contain a repository root \
+         with .claude/ or amplifier-bundle/ under {}",
         root.display()
     )
 }

--- a/crates/amplihack-cli/src/commands/install/types.rs
+++ b/crates/amplihack-cli/src/commands/install/types.rs
@@ -3,8 +3,8 @@
 use serde::{Deserialize, Serialize};
 
 pub(super) const REPO_ARCHIVE_URL: &str =
-    "https://github.com/rysweet/amplihack/archive/refs/heads/main.tar.gz";
-pub(super) const REPO_GIT_URL: &str = "https://github.com/rysweet/amplihack";
+    "https://github.com/rysweet/amplihack-rs/archive/refs/heads/main.tar.gz";
+pub(super) const REPO_GIT_URL: &str = "https://github.com/rysweet/amplihack-rs";
 pub(super) const ESSENTIAL_DIRS: &[&str] = &[
     "agents/amplihack",
     "commands/amplihack",

--- a/crates/amplihack-cli/src/commands/lock/mod.rs
+++ b/crates/amplihack-cli/src/commands/lock/mod.rs
@@ -1,0 +1,235 @@
+//! Lock tool for continuous work mode.
+//!
+//! Manages `.lock_active` and `.lock_message` files under
+//! `$CLAUDE_PROJECT_DIR/.claude/runtime/locks/`.
+
+use anyhow::Result;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::command_error::exit_error;
+
+fn lock_dir() -> PathBuf {
+    let root = std::env::var("CLAUDE_PROJECT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    root.join(".claude/runtime/locks")
+}
+
+pub fn run_lock(message: Option<&str>) -> Result<()> {
+    let dir = lock_dir();
+    let lock_file = dir.join(".lock_active");
+    let msg_file = dir.join(".lock_message");
+
+    fs::create_dir_all(&dir)?;
+
+    if lock_file.exists() {
+        println!("\u{26a0} WARNING: Lock was already active");
+        if let Some(msg) = message {
+            fs::write(&msg_file, msg)?;
+            println!("\u{2713} Updated lock message: {msg}");
+        }
+        return Ok(());
+    }
+
+    // Atomic create via O_CREAT|O_EXCL
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lock_file)
+    {
+        Ok(mut f) => {
+            let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.6f");
+            writeln!(f, "locked_at: {ts}")?;
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            println!("\u{26a0} WARNING: Lock was already active");
+            return Ok(());
+        }
+        Err(e) => {
+            println!("\u{2717} ERROR: Failed to create lock: {e}");
+            return Err(exit_error(1));
+        }
+    }
+
+    println!("\u{2713} Lock enabled - Claude will continue working until unlocked");
+    println!("  Use /amplihack:unlock to disable continuous work mode");
+
+    if let Some(msg) = message {
+        fs::write(&msg_file, msg)?;
+        println!("  Custom instruction: {msg}");
+    }
+
+    Ok(())
+}
+
+pub fn run_unlock() -> Result<()> {
+    let dir = lock_dir();
+    let lock_file = dir.join(".lock_active");
+    let msg_file = dir.join(".lock_message");
+
+    match fs::remove_file(&lock_file) {
+        Ok(()) => println!("\u{2713} Lock disabled - Claude will stop normally"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            println!("\u{2139} Lock was not enabled");
+        }
+        Err(e) => {
+            println!("\u{2717} ERROR: Failed to remove lock: {e}");
+            return Err(exit_error(1));
+        }
+    }
+
+    // Clean up message file
+    let _ = fs::remove_file(&msg_file);
+
+    Ok(())
+}
+
+pub fn run_check() -> Result<()> {
+    let dir = lock_dir();
+    let lock_file = dir.join(".lock_active");
+    let msg_file = dir.join(".lock_message");
+
+    if lock_file.exists() {
+        let info = fs::read_to_string(&lock_file).unwrap_or_default();
+        println!("\u{2713} Lock is ACTIVE");
+        println!("  {}", info.trim());
+
+        if msg_file.exists()
+            && let Ok(msg) = fs::read_to_string(&msg_file)
+        {
+            println!("  Custom instruction: {}", msg.trim());
+        }
+    } else {
+        println!("\u{2139} Lock is NOT active");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    /// Serialize all lock tests that mutate CLAUDE_PROJECT_DIR.
+    static LOCK_ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    /// Set CLAUDE_PROJECT_DIR to a temp directory for the duration of the closure.
+    fn with_project_dir<F: FnOnce(&std::path::Path)>(f: F) {
+        let _guard = LOCK_ENV_MUTEX.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let old = std::env::var("CLAUDE_PROJECT_DIR").ok();
+        unsafe { std::env::set_var("CLAUDE_PROJECT_DIR", tmp.path()) };
+        f(tmp.path());
+        match old {
+            Some(v) => unsafe { std::env::set_var("CLAUDE_PROJECT_DIR", v) },
+            None => unsafe { std::env::remove_var("CLAUDE_PROJECT_DIR") },
+        }
+    }
+
+    #[test]
+    fn lock_creates_lock_file() {
+        with_project_dir(|root| {
+            run_lock(None).unwrap();
+            assert!(root.join(".claude/runtime/locks/.lock_active").exists());
+        });
+    }
+
+    #[test]
+    fn lock_creates_directory_structure() {
+        with_project_dir(|root| {
+            assert!(!root.join(".claude").exists());
+            run_lock(None).unwrap();
+            assert!(root.join(".claude/runtime/locks").is_dir());
+        });
+    }
+
+    #[test]
+    fn lock_file_contains_timestamp() {
+        with_project_dir(|root| {
+            run_lock(None).unwrap();
+            let content =
+                fs::read_to_string(root.join(".claude/runtime/locks/.lock_active")).unwrap();
+            assert!(
+                content.starts_with("locked_at: "),
+                "Expected timestamp, got: {content}"
+            );
+            assert!(
+                content.contains("T"),
+                "Timestamp should contain 'T' separator"
+            );
+        });
+    }
+
+    #[test]
+    fn lock_with_message_creates_message_file() {
+        with_project_dir(|root| {
+            run_lock(Some("finish all tests")).unwrap();
+            let msg = fs::read_to_string(root.join(".claude/runtime/locks/.lock_message")).unwrap();
+            assert_eq!(msg, "finish all tests");
+        });
+    }
+
+    #[test]
+    fn lock_when_already_locked_does_not_error() {
+        with_project_dir(|_root| {
+            run_lock(None).unwrap();
+            run_lock(None).unwrap();
+        });
+    }
+
+    #[test]
+    fn lock_when_already_locked_updates_message() {
+        with_project_dir(|root| {
+            run_lock(Some("old message")).unwrap();
+            run_lock(Some("new message")).unwrap();
+            let msg = fs::read_to_string(root.join(".claude/runtime/locks/.lock_message")).unwrap();
+            assert_eq!(msg, "new message");
+        });
+    }
+
+    #[test]
+    fn unlock_removes_lock_file() {
+        with_project_dir(|root| {
+            run_lock(None).unwrap();
+            assert!(root.join(".claude/runtime/locks/.lock_active").exists());
+            run_unlock().unwrap();
+            assert!(!root.join(".claude/runtime/locks/.lock_active").exists());
+        });
+    }
+
+    #[test]
+    fn unlock_removes_message_file() {
+        with_project_dir(|root| {
+            run_lock(Some("test message")).unwrap();
+            assert!(root.join(".claude/runtime/locks/.lock_message").exists());
+            run_unlock().unwrap();
+            assert!(!root.join(".claude/runtime/locks/.lock_message").exists());
+        });
+    }
+
+    #[test]
+    fn unlock_when_not_locked_succeeds() {
+        with_project_dir(|_root| {
+            run_unlock().unwrap();
+        });
+    }
+
+    #[test]
+    fn full_lifecycle_lock_check_unlock_check() {
+        with_project_dir(|root| {
+            assert!(!root.join(".claude/runtime/locks/.lock_active").exists());
+            run_lock(Some("doing work")).unwrap();
+            assert!(root.join(".claude/runtime/locks/.lock_active").exists());
+            assert!(root.join(".claude/runtime/locks/.lock_message").exists());
+            run_check().unwrap();
+            run_unlock().unwrap();
+            assert!(!root.join(".claude/runtime/locks/.lock_active").exists());
+            assert!(!root.join(".claude/runtime/locks/.lock_message").exists());
+            run_check().unwrap();
+        });
+    }
+}

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -4,20 +4,29 @@ pub mod append;
 pub mod auto_mode;
 pub mod completions;
 pub mod doctor;
+pub mod eval;
 pub mod fleet;
 pub mod hive_haymaker;
 pub mod install;
 pub mod launch;
+pub mod lock;
 pub mod memory;
 pub mod mode;
+pub mod multitask;
 pub mod new_agent;
+pub mod orch_helper;
 pub mod plugin;
 pub mod query_code;
 pub mod recipe;
 pub mod rustyclawd;
+pub mod session_tree;
 pub mod uvx_help;
+pub mod validate_frontmatter;
 
-use crate::{Commands, MemoryCommands, ModeCommands, PluginCommands, RecipeCommands};
+use crate::{
+    Commands, EvalCommands, LockCommands, MemoryCommands, ModeCommands, MultitaskCommands,
+    OrchHelperCommands, PluginCommands, RecipeCommands, SessionTreeCommands,
+};
 use anyhow::Result;
 
 /// Dispatch a parsed CLI command to the appropriate handler.
@@ -305,6 +314,18 @@ pub fn dispatch(command: Commands) -> Result<()> {
         Commands::UvxHelp { find_path, info } => uvx_help::run_uvx_help(find_path, info),
         Commands::Completions { shell } => completions::run_completions(shell),
         Commands::Doctor => doctor::run_doctor(),
+        Commands::Multitask { command } => dispatch_multitask(command),
+        Commands::Lock { command } => dispatch_lock(command),
+        Commands::ValidateFrontmatter { file } => {
+            validate_frontmatter::run_validate_frontmatter(file.as_deref())
+        }
+        Commands::SessionTree { command } => dispatch_session_tree(command),
+        Commands::OrchHelper { command } => dispatch_orch_helper(command),
+        Commands::ResolveBundleAsset { asset } => {
+            let code = crate::resolve_bundle_asset::run_cli(&asset);
+            std::process::exit(code);
+        }
+        Commands::Eval { command } => dispatch_eval(command),
     }
 }
 
@@ -389,5 +410,73 @@ fn dispatch_mode(command: ModeCommands) -> Result<()> {
         ModeCommands::Detect => mode::run_detect(),
         ModeCommands::ToPlugin => mode::run_to_plugin(),
         ModeCommands::ToLocal => mode::run_to_local(),
+    }
+}
+
+fn dispatch_multitask(command: MultitaskCommands) -> Result<()> {
+    match command {
+        MultitaskCommands::Run {
+            config,
+            mode,
+            recipe,
+            max_runtime,
+            timeout_policy,
+            dry_run,
+        } => multitask::run_multitask(
+            &config,
+            &mode,
+            &recipe,
+            max_runtime,
+            timeout_policy.as_deref(),
+            dry_run,
+        ),
+        MultitaskCommands::Cleanup { config, dry_run } => multitask::run_cleanup(&config, dry_run),
+        MultitaskCommands::Status { base_dir } => multitask::run_status(base_dir.as_deref()),
+    }
+}
+
+fn dispatch_lock(command: LockCommands) -> Result<()> {
+    match command {
+        LockCommands::Lock { message } => lock::run_lock(message.as_deref()),
+        LockCommands::Unlock => lock::run_unlock(),
+        LockCommands::Check => lock::run_check(),
+    }
+}
+
+fn dispatch_session_tree(command: SessionTreeCommands) -> Result<()> {
+    match command {
+        SessionTreeCommands::Check => session_tree::run_check(),
+        SessionTreeCommands::Register {
+            session_id,
+            parent_id,
+        } => session_tree::run_register(session_id, parent_id),
+        SessionTreeCommands::Complete { session_id } => session_tree::run_complete(session_id),
+        SessionTreeCommands::Status { tree_id } => session_tree::run_status(tree_id),
+    }
+}
+
+fn dispatch_orch_helper(command: OrchHelperCommands) -> Result<()> {
+    match command {
+        OrchHelperCommands::ExtractJson => orch_helper::run_extract_json(),
+        OrchHelperCommands::NormaliseType => orch_helper::run_normalise_type(),
+        OrchHelperCommands::GenerateWorkstreamConfig => {
+            orch_helper::run_generate_workstream_config()
+        }
+    }
+}
+
+fn dispatch_eval(command: EvalCommands) -> Result<()> {
+    match command {
+        EvalCommands::Run {
+            config,
+            format,
+            threshold,
+        } => eval::run_eval_run(&config, &format, threshold),
+        EvalCommands::Compare {
+            baseline,
+            candidate,
+            format,
+        } => eval::run_eval_compare(&baseline, &candidate, &format),
+        EvalCommands::Report { result, format } => eval::run_eval_report(&result, &format),
     }
 }

--- a/crates/amplihack-cli/src/commands/multitask/mod.rs
+++ b/crates/amplihack-cli/src/commands/multitask/mod.rs
@@ -1,0 +1,33 @@
+//! Parallel workstream orchestrator with subprocess isolation.
+//!
+//! Executes multiple independent development tasks in parallel. Each workstream
+//! runs in a clean /tmp clone with its own execution context.
+//!
+//! Port of `amplifier-bundle/tools/amplihack/skills/multitask/orchestrator.py`.
+
+pub mod models;
+pub mod orchestrator;
+
+use anyhow::Result;
+
+/// Run multitask orchestration from a workstreams JSON config.
+pub fn run_multitask(
+    config: &str,
+    mode: &str,
+    recipe: &str,
+    max_runtime: u64,
+    timeout_policy: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    orchestrator::run(config, mode, recipe, max_runtime, timeout_policy, dry_run)
+}
+
+/// Clean up completed workstream directories.
+pub fn run_cleanup(config: &str, dry_run: bool) -> Result<()> {
+    orchestrator::cleanup(config, dry_run)
+}
+
+/// Show status of all workstreams.
+pub fn run_status(base_dir: Option<&str>) -> Result<()> {
+    orchestrator::status(base_dir)
+}

--- a/crates/amplihack-cli/src/commands/multitask/models.rs
+++ b/crates/amplihack-cli/src/commands/multitask/models.rs
@@ -1,0 +1,74 @@
+//! Data models for multitask orchestration.
+
+use serde::{Deserialize, Serialize};
+
+/// A workstream definition from the config JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkstreamConfig {
+    pub issue: Option<u64>,
+    pub branch: String,
+    pub description: String,
+    pub task: String,
+    #[serde(default)]
+    pub priority: Option<String>,
+    #[serde(default)]
+    pub depends_on: Vec<u64>,
+}
+
+/// Runtime state for a workstream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkstreamState {
+    pub id: String,
+    pub config: WorkstreamConfig,
+    pub status: WorkstreamStatus,
+    pub work_dir: Option<String>,
+    pub pid: Option<u32>,
+    pub started_at: Option<f64>,
+    pub completed_at: Option<f64>,
+    pub exit_code: Option<i32>,
+}
+
+/// Lifecycle states for a workstream.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkstreamStatus {
+    Pending,
+    Running,
+    Completed,
+    FailedResumable,
+    FailedTerminal,
+    TimedOutResumable,
+    InterruptedResumable,
+    Abandoned,
+}
+
+impl std::fmt::Display for WorkstreamStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::Running => write!(f, "running"),
+            Self::Completed => write!(f, "completed"),
+            Self::FailedResumable => write!(f, "failed_resumable"),
+            Self::FailedTerminal => write!(f, "failed_terminal"),
+            Self::TimedOutResumable => write!(f, "timed_out_resumable"),
+            Self::InterruptedResumable => write!(f, "interrupted_resumable"),
+            Self::Abandoned => write!(f, "abandoned"),
+        }
+    }
+}
+
+/// Top-level config file format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultitaskConfig {
+    pub workstreams: Vec<WorkstreamConfig>,
+    #[serde(default = "default_max_runtime")]
+    pub max_runtime: u64,
+    #[serde(default)]
+    pub recipe: Option<String>,
+    #[serde(default)]
+    pub mode: Option<String>,
+}
+
+fn default_max_runtime() -> u64 {
+    7200
+}

--- a/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
+++ b/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
@@ -1,0 +1,519 @@
+//! Core orchestration logic for parallel workstream execution.
+
+use anyhow::{Result, bail};
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use super::models::*;
+
+const DEFAULT_TIMEOUT_POLICY: &str = "interrupt-preserve";
+
+/// Allowlist of valid delegate commands.
+const VALID_DELEGATES: &[&str] = &[
+    "amplihack claude",
+    "amplihack copilot",
+    "amplihack amplifier",
+];
+
+/// Run the multitask orchestrator.
+pub fn run(
+    config_path: &str,
+    mode: &str,
+    recipe: &str,
+    max_runtime: u64,
+    timeout_policy: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let config_content = fs::read_to_string(config_path)
+        .map_err(|e| anyhow::anyhow!("Cannot read config {config_path}: {e}"))?;
+
+    let config: MultitaskConfig = serde_json::from_str(&config_content)
+        .map_err(|e| anyhow::anyhow!("Invalid config JSON: {e}"))?;
+
+    let max_runtime = if max_runtime > 0 {
+        max_runtime
+    } else {
+        config.max_runtime
+    };
+    let timeout_policy = timeout_policy.unwrap_or(DEFAULT_TIMEOUT_POLICY);
+    let mode = if mode.is_empty() {
+        config.mode.as_deref().unwrap_or("recipe")
+    } else {
+        mode
+    };
+    let recipe = if recipe.is_empty() {
+        config.recipe.as_deref().unwrap_or("default-workflow")
+    } else {
+        recipe
+    };
+
+    println!("=== Multitask Orchestrator ===");
+    println!(
+        "Workstreams: {} | Mode: {mode} | Recipe: {recipe} | Max runtime: {max_runtime}s",
+        config.workstreams.len()
+    );
+    println!("Timeout policy: {timeout_policy}");
+
+    if dry_run {
+        println!("\n[DRY RUN] Would execute:");
+        for (i, ws) in config.workstreams.iter().enumerate() {
+            println!(
+                "  [{i}] branch={} issue={} task={}",
+                ws.branch,
+                ws.issue.unwrap_or(0),
+                truncate(&ws.task, 80)
+            );
+        }
+        return Ok(());
+    }
+
+    // Prepare base directory
+    let base_dir = PathBuf::from("/tmp/amplihack-workstreams");
+    fs::create_dir_all(&base_dir)?;
+
+    // Build workstream states
+    let states: Vec<WorkstreamState> = config
+        .workstreams
+        .iter()
+        .enumerate()
+        .map(|(i, ws)| WorkstreamState {
+            id: format!("ws-{}", ws.issue.unwrap_or(i as u64)),
+            config: ws.clone(),
+            status: WorkstreamStatus::Pending,
+            work_dir: None,
+            pid: None,
+            started_at: None,
+            completed_at: None,
+            exit_code: None,
+        })
+        .collect();
+
+    let states = Arc::new(Mutex::new(states));
+    let deadline = Instant::now() + Duration::from_secs(max_runtime);
+
+    // Spawn workstreams
+    let mut handles = Vec::new();
+    let ws_count = states.lock().unwrap().len();
+
+    for idx in 0..ws_count {
+        let states = Arc::clone(&states);
+        let base_dir = base_dir.clone();
+        let recipe = recipe.to_string();
+        let mode = mode.to_string();
+
+        let handle = std::thread::spawn(move || {
+            execute_workstream(idx, &states, &base_dir, &recipe, &mode, deadline);
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all
+    for handle in handles {
+        let _ = handle.join();
+    }
+
+    // Report results
+    let final_states = states.lock().unwrap();
+    println!("\n=== Results ===");
+    for ws in final_states.iter() {
+        let status_icon = match ws.status {
+            WorkstreamStatus::Completed => "\u{2713}",
+            WorkstreamStatus::Running => "\u{23f3}",
+            _ => "\u{2717}",
+        };
+        println!(
+            "  {status_icon} {} [{}]: {}",
+            ws.id, ws.status, ws.config.description
+        );
+    }
+
+    let completed = final_states
+        .iter()
+        .filter(|ws| ws.status == WorkstreamStatus::Completed)
+        .count();
+    println!(
+        "\nCompleted: {completed}/{} workstreams",
+        final_states.len()
+    );
+
+    // Save state for resume
+    let state_file = base_dir.join("state.json");
+    let state_json = serde_json::to_string_pretty(&*final_states)?;
+    fs::write(&state_file, state_json)?;
+    println!("State saved to: {}", state_file.display());
+
+    if completed < final_states.len() {
+        bail!(
+            "{} workstream(s) did not complete successfully",
+            final_states.len() - completed
+        );
+    }
+
+    Ok(())
+}
+
+fn execute_workstream(
+    idx: usize,
+    states: &Arc<Mutex<Vec<WorkstreamState>>>,
+    base_dir: &Path,
+    recipe: &str,
+    mode: &str,
+    deadline: Instant,
+) {
+    let (id, branch, task) = {
+        let mut s = states.lock().unwrap();
+        s[idx].status = WorkstreamStatus::Running;
+        s[idx].started_at = Some(now_epoch());
+        (
+            s[idx].id.clone(),
+            s[idx].config.branch.clone(),
+            s[idx].config.task.clone(),
+        )
+    };
+
+    let work_dir = base_dir.join(&id);
+
+    // Clone repo for isolation
+    let repo_path = std::env::var("AMPLIHACK_REPO_PATH")
+        .or_else(|_| std::env::var("CLAUDE_PROJECT_DIR"))
+        .unwrap_or_else(|_| ".".to_string());
+
+    if let Err(e) = setup_workstream_dir(&work_dir, &repo_path, &branch) {
+        eprintln!("[{id}] Setup failed: {e}");
+        let mut s = states.lock().unwrap();
+        s[idx].status = WorkstreamStatus::FailedTerminal;
+        s[idx].completed_at = Some(now_epoch());
+        return;
+    }
+
+    {
+        let mut s = states.lock().unwrap();
+        s[idx].work_dir = Some(work_dir.to_string_lossy().to_string());
+    }
+
+    // Build command
+    let delegate =
+        std::env::var("AMPLIHACK_DELEGATE").unwrap_or_else(|_| "amplihack claude".to_string());
+
+    if !VALID_DELEGATES.contains(&delegate.as_str()) {
+        eprintln!("[{id}] Invalid delegate: {delegate}");
+        let mut s = states.lock().unwrap();
+        s[idx].status = WorkstreamStatus::FailedTerminal;
+        s[idx].completed_at = Some(now_epoch());
+        return;
+    }
+
+    let parts: Vec<&str> = delegate.split_whitespace().collect();
+    let (cmd, args) = (parts[0], &parts[1..]);
+
+    let mut command = Command::new(cmd);
+    command
+        .args(args)
+        .arg("--dangerously-skip-permissions")
+        .arg("--print")
+        .arg(&task)
+        .current_dir(&work_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // Set env vars for session tree
+    command.env("AMPLIHACK_WORKSTREAM_ID", &id);
+    if mode == "recipe" {
+        command.env("AMPLIHACK_RECIPE", recipe);
+    }
+
+    let result = command.spawn();
+
+    match result {
+        Ok(mut child) => {
+            if let Ok(pid) = child.id().try_into() {
+                let mut s = states.lock().unwrap();
+                s[idx].pid = Some(pid);
+            }
+
+            // Tail output
+            if let Some(stdout) = child.stdout.take() {
+                let reader = BufReader::new(stdout);
+                for line in reader.lines() {
+                    if Instant::now() >= deadline {
+                        eprintln!("[{id}] Timeout reached, killing process");
+                        let _ = child.kill();
+                        let mut s = states.lock().unwrap();
+                        s[idx].status = WorkstreamStatus::TimedOutResumable;
+                        s[idx].completed_at = Some(now_epoch());
+                        return;
+                    }
+                    if let Ok(line) = line {
+                        println!("[{id}] {line}");
+                    }
+                }
+            }
+
+            match child.wait() {
+                Ok(exit) => {
+                    let mut s = states.lock().unwrap();
+                    s[idx].exit_code = exit.code();
+                    s[idx].completed_at = Some(now_epoch());
+                    if exit.success() {
+                        s[idx].status = WorkstreamStatus::Completed;
+                    } else {
+                        s[idx].status = WorkstreamStatus::FailedResumable;
+                    }
+                }
+                Err(e) => {
+                    eprintln!("[{id}] Wait failed: {e}");
+                    let mut s = states.lock().unwrap();
+                    s[idx].status = WorkstreamStatus::FailedTerminal;
+                    s[idx].completed_at = Some(now_epoch());
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("[{id}] Spawn failed: {e}");
+            let mut s = states.lock().unwrap();
+            s[idx].status = WorkstreamStatus::FailedTerminal;
+            s[idx].completed_at = Some(now_epoch());
+        }
+    }
+}
+
+fn setup_workstream_dir(work_dir: &Path, repo_path: &str, branch: &str) -> Result<()> {
+    if work_dir.exists() {
+        // Resume existing workstream
+        return Ok(());
+    }
+
+    // Clone via git worktree or cp
+    let output = Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(work_dir)
+        .current_dir(repo_path)
+        .output()?;
+
+    if !output.status.success() {
+        // Fall back to simple clone
+        let output = Command::new("git")
+            .args(["clone", "--depth=1", "--branch", branch, repo_path])
+            .arg(work_dir)
+            .output()?;
+
+        if !output.status.success() {
+            bail!(
+                "Failed to clone repo: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    // Checkout branch
+    let _ = Command::new("git")
+        .args(["checkout", "-B", branch])
+        .current_dir(work_dir)
+        .output();
+
+    Ok(())
+}
+
+/// Clean up completed workstream directories.
+pub fn cleanup(config_path: &str, dry_run: bool) -> Result<()> {
+    let base_dir = PathBuf::from("/tmp/amplihack-workstreams");
+    let state_file = base_dir.join("state.json");
+
+    let states: Vec<WorkstreamState> = if state_file.exists() {
+        let content = fs::read_to_string(&state_file)?;
+        serde_json::from_str(&content)?
+    } else if Path::new(config_path).exists() {
+        println!("No saved state found, nothing to clean up");
+        return Ok(());
+    } else {
+        println!("No config or state found");
+        return Ok(());
+    };
+
+    let eligible: Vec<&WorkstreamState> = states
+        .iter()
+        .filter(|ws| {
+            matches!(
+                ws.status,
+                WorkstreamStatus::Completed
+                    | WorkstreamStatus::FailedTerminal
+                    | WorkstreamStatus::Abandoned
+            )
+        })
+        .collect();
+
+    if eligible.is_empty() {
+        println!("No eligible workstreams to clean up");
+        return Ok(());
+    }
+
+    for ws in &eligible {
+        if let Some(ref dir) = ws.work_dir {
+            let path = Path::new(dir);
+            if dry_run {
+                println!("[DRY RUN] Would remove: {dir}");
+            } else if path.exists() {
+                // Try git worktree remove first
+                let _ = Command::new("git")
+                    .args(["worktree", "remove", "--force", dir])
+                    .output();
+                if path.exists() {
+                    fs::remove_dir_all(path)?;
+                }
+                println!("Removed: {dir}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Show status of workstreams.
+pub fn status(base_dir: Option<&str>) -> Result<()> {
+    let dir = PathBuf::from(base_dir.unwrap_or("/tmp/amplihack-workstreams"));
+    let state_file = dir.join("state.json");
+
+    if !state_file.exists() {
+        println!(
+            "No active workstreams found (no state file at {})",
+            state_file.display()
+        );
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&state_file)?;
+    let states: Vec<WorkstreamState> = serde_json::from_str(&content)?;
+
+    println!("=== Workstream Status ===");
+    for ws in &states {
+        let icon = match ws.status {
+            WorkstreamStatus::Completed => "\u{2713}",
+            WorkstreamStatus::Running => "\u{23f3}",
+            WorkstreamStatus::Pending => "\u{2022}",
+            _ => "\u{2717}",
+        };
+        let duration = match (ws.started_at, ws.completed_at) {
+            (Some(start), Some(end)) => format!(" ({:.0}s)", end - start),
+            (Some(start), None) => format!(" ({:.0}s elapsed)", now_epoch() - start),
+            _ => String::new(),
+        };
+        println!(
+            "  {icon} {} [{}]{duration}: {}",
+            ws.id, ws.status, ws.config.description
+        );
+    }
+
+    let total = states.len();
+    let completed = states
+        .iter()
+        .filter(|w| w.status == WorkstreamStatus::Completed)
+        .count();
+    let running = states
+        .iter()
+        .filter(|w| w.status == WorkstreamStatus::Running)
+        .count();
+    let failed = total
+        - completed
+        - running
+        - states
+            .iter()
+            .filter(|w| w.status == WorkstreamStatus::Pending)
+            .count();
+
+    println!("\nTotal: {total} | Completed: {completed} | Running: {running} | Failed: {failed}");
+
+    Ok(())
+}
+
+fn now_epoch() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max - 3])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_string() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string() {
+        let result = truncate("this is a very long string that needs truncation", 20);
+        assert!(result.len() <= 20);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn workstream_status_display() {
+        assert_eq!(format!("{}", WorkstreamStatus::Completed), "completed");
+        assert_eq!(format!("{}", WorkstreamStatus::Running), "running");
+        assert_eq!(format!("{}", WorkstreamStatus::Pending), "pending");
+        assert_eq!(
+            format!("{}", WorkstreamStatus::FailedResumable),
+            "failed_resumable"
+        );
+    }
+
+    #[test]
+    fn multitask_config_deserializes() {
+        let json = r#"{
+            "workstreams": [
+                {
+                    "branch": "feat/test",
+                    "description": "Test workstream",
+                    "task": "Do something",
+                    "issue": 123
+                }
+            ]
+        }"#;
+        let config: MultitaskConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.workstreams.len(), 1);
+        assert_eq!(config.workstreams[0].branch, "feat/test");
+        assert_eq!(config.workstreams[0].issue, Some(123));
+        assert_eq!(config.max_runtime, 7200);
+    }
+
+    #[test]
+    fn workstream_state_round_trip() {
+        let state = WorkstreamState {
+            id: "ws-1".to_string(),
+            config: WorkstreamConfig {
+                issue: Some(1),
+                branch: "feat/test".to_string(),
+                description: "Test".to_string(),
+                task: "Do it".to_string(),
+                priority: None,
+                depends_on: vec![],
+            },
+            status: WorkstreamStatus::Completed,
+            work_dir: Some("/tmp/test".to_string()),
+            pid: Some(12345),
+            started_at: Some(1000.0),
+            completed_at: Some(2000.0),
+            exit_code: Some(0),
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: WorkstreamState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.id, "ws-1");
+        assert_eq!(restored.status, WorkstreamStatus::Completed);
+        assert_eq!(restored.exit_code, Some(0));
+    }
+}

--- a/crates/amplihack-cli/src/commands/orch_helper/mod.rs
+++ b/crates/amplihack-cli/src/commands/orch_helper/mod.rs
@@ -1,0 +1,194 @@
+//! Shared orchestration helper functions for smart-orchestrator recipe.
+//!
+//! Provides `extract-json` and `normalise-type` subcommands used by the
+//! parse-decomposition and create-workstreams-config bash steps.
+
+use anyhow::Result;
+use std::io::Read;
+use std::sync::LazyLock;
+
+/// Maximum stdin read size (10 MB) — prevents OOM from malicious/infinite input.
+const MAX_STDIN_BYTES: u64 = 10 * 1024 * 1024;
+
+// Compile regexes once.
+static JSON_BLOCK_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(?s)```json\s*(\{[^`]*\})\s*```").unwrap());
+static UNTAGGED_BLOCK_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(?s)```\s*(\{[^`]*\})\s*```").unwrap());
+
+/// Extract the first complete JSON object from LLM output on stdin.
+pub fn run_extract_json() -> Result<()> {
+    let mut input = String::new();
+    std::io::stdin()
+        .take(MAX_STDIN_BYTES)
+        .read_to_string(&mut input)?;
+
+    let result = extract_json(&input);
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}
+
+/// Normalise LLM task_type on stdin to one of: Q&A, Operations, Investigation, Development.
+pub fn run_normalise_type() -> Result<()> {
+    let mut input = String::new();
+    std::io::stdin()
+        .take(MAX_STDIN_BYTES)
+        .read_to_string(&mut input)?;
+
+    println!("{}", normalise_type(input.trim()));
+    Ok(())
+}
+
+/// Generate workstream config JSON from decomposition JSON on stdin.
+pub fn run_generate_workstream_config() -> Result<()> {
+    let mut input = String::new();
+    std::io::stdin()
+        .take(MAX_STDIN_BYTES)
+        .read_to_string(&mut input)?;
+
+    let decomp = extract_json(&input);
+    println!("{}", serde_json::to_string(&decomp)?);
+    Ok(())
+}
+
+fn extract_json(text: &str) -> serde_json::Value {
+    // 1. Prefer ```json-tagged code blocks.
+    for cap in JSON_BLOCK_RE.captures_iter(text) {
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&cap[1]) {
+            return val;
+        }
+    }
+
+    // 2. Try untagged code blocks.
+    for cap in UNTAGGED_BLOCK_RE.captures_iter(text) {
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&cap[1]) {
+            return val;
+        }
+    }
+
+    // 3. Fallback: scan for first valid JSON object using serde_json's StreamDeserializer.
+    let mut pos = 0;
+    let bytes = text.as_bytes();
+    while pos < bytes.len() {
+        if let Some(start) = text[pos..].find('{') {
+            let abs_start = pos + start;
+            let slice = &text[abs_start..];
+            let mut de = serde_json::Deserializer::from_str(slice).into_iter::<serde_json::Value>();
+            if let Some(Ok(val)) = de.next() {
+                return val;
+            }
+            pos = abs_start + 1;
+        } else {
+            break;
+        }
+    }
+
+    serde_json::Value::Object(serde_json::Map::new())
+}
+
+fn normalise_type(raw: &str) -> &'static str {
+    let t = raw.to_lowercase();
+    if ["q&a", "qa", "question", "answer"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
+        return "Q&A";
+    }
+    if ["ops", "operation", "admin", "command"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
+        return "Operations";
+    }
+    if ["invest", "research", "explor", "analys", "understand"]
+        .iter()
+        .any(|k| t.contains(k))
+    {
+        return "Investigation";
+    }
+    "Development"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_json_tagged_code_block() {
+        let input = "Here:\n```json\n{\"task_type\": \"dev\", \"count\": 3}\n```\nDone.";
+        let result = extract_json(input);
+        assert_eq!(result["task_type"], "dev");
+        assert_eq!(result["count"], 3);
+    }
+
+    #[test]
+    fn extract_json_prefers_tagged_over_untagged() {
+        let input = "```\n{\"wrong\": true}\n```\n```json\n{\"right\": true}\n```";
+        let result = extract_json(input);
+        assert_eq!(result["right"], true);
+    }
+
+    #[test]
+    fn extract_json_raw_in_prose() {
+        let input = r#"The output is {"key": "value"} and more"#;
+        let result = extract_json(input);
+        assert_eq!(result["key"], "value");
+    }
+
+    #[test]
+    fn extract_json_no_json_returns_empty_object() {
+        let result = extract_json("no json here at all");
+        assert!(result.as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn extract_json_handles_braces_in_strings() {
+        let input = r#"Result: {"msg": "brace } inside", "ok": true} done"#;
+        let result = extract_json(input);
+        assert_eq!(result["ok"], true);
+    }
+
+    #[test]
+    fn extract_json_deeply_nested() {
+        let input = r#"{"a": {"b": {"c": [1, 2, {"d": "deep"}]}}}"#;
+        let result = extract_json(input);
+        assert_eq!(result["a"]["b"]["c"][2]["d"], "deep");
+    }
+
+    #[test]
+    fn normalise_type_qa() {
+        assert_eq!(normalise_type("Q&A"), "Q&A");
+        assert_eq!(normalise_type("qa"), "Q&A");
+        assert_eq!(normalise_type("question about code"), "Q&A");
+    }
+
+    #[test]
+    fn normalise_type_operations() {
+        assert_eq!(normalise_type("ops"), "Operations");
+        assert_eq!(normalise_type("Operations"), "Operations");
+        assert_eq!(normalise_type("admin task"), "Operations");
+    }
+
+    #[test]
+    fn normalise_type_investigation() {
+        assert_eq!(normalise_type("investigation"), "Investigation");
+        assert_eq!(normalise_type("research task"), "Investigation");
+        assert_eq!(normalise_type("explore the code"), "Investigation");
+    }
+
+    #[test]
+    fn normalise_type_development_default() {
+        assert_eq!(normalise_type("dev"), "Development");
+        assert_eq!(normalise_type("build feature"), "Development");
+        assert_eq!(normalise_type("anything else"), "Development");
+        assert_eq!(normalise_type(""), "Development");
+    }
+
+    #[test]
+    fn normalise_type_case_insensitive() {
+        assert_eq!(normalise_type("Q&A"), "Q&A");
+        assert_eq!(normalise_type("q&a"), "Q&A");
+        assert_eq!(normalise_type("OPS"), "Operations");
+        assert_eq!(normalise_type("INVESTIGATION"), "Investigation");
+    }
+}

--- a/crates/amplihack-cli/src/commands/session_tree/mod.rs
+++ b/crates/amplihack-cli/src/commands/session_tree/mod.rs
@@ -1,0 +1,710 @@
+//! Session tree management for amplihack orchestration.
+//!
+//! Prevents infinite recursion by tracking active sessions in a tree structure.
+//! Enforces max depth and max concurrent session limits.
+//!
+//! State file: `/tmp/amplihack-session-trees/{tree_id}.json`
+//! Lock file:  `/tmp/amplihack-session-trees/{tree_id}.lock`
+
+use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+use std::{fs, io};
+
+use crate::command_error::exit_error;
+
+// Compile once.
+static TREE_ID_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"^[a-zA-Z0-9_-]{1,64}$").unwrap());
+
+const DEFAULT_MAX_DEPTH: u32 = 3;
+const DEFAULT_MAX_SESSIONS: u32 = 10;
+const LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const COMPLETED_MAX_AGE_HOURS: f64 = 24.0;
+const ACTIVE_MAX_AGE_HOURS: f64 = 4.0;
+const STALE_LOCK_AGE: Duration = Duration::from_secs(10 * 60);
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+struct TreeState {
+    sessions: HashMap<String, SessionEntry>,
+    #[serde(default)]
+    spawn_count: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct SessionEntry {
+    depth: u32,
+    parent: Option<String>,
+    status: String,
+    started_at: f64,
+    #[serde(default)]
+    completed_at: Option<f64>,
+    #[serde(default)]
+    children: Vec<String>,
+}
+
+struct TreeContext {
+    tree_id: String,
+    depth: u32,
+    max_depth: u32,
+    max_sessions: u32,
+}
+
+// ─── Validation & paths ──────────────────────────────────────────────────
+
+fn validate_tree_id(id: &str) -> Result<&str> {
+    if id.is_empty() {
+        bail!("tree_id cannot be empty");
+    }
+    if !TREE_ID_RE.is_match(id) {
+        bail!("Invalid tree_id {id:?}: must match [a-zA-Z0-9_-]{{1,64}}");
+    }
+    Ok(id)
+}
+
+fn state_dir() -> PathBuf {
+    let tmp = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(tmp).join("amplihack-session-trees")
+}
+
+fn ensure_state_dir() -> Result<()> {
+    let dir = state_dir();
+    fs::create_dir_all(&dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o700));
+    }
+    Ok(())
+}
+
+fn state_path(tree_id: &str) -> Result<PathBuf> {
+    validate_tree_id(tree_id)?;
+    let dir = state_dir();
+    let candidate = dir.join(format!("{tree_id}.json"));
+    let resolved = candidate
+        .canonicalize()
+        .unwrap_or_else(|_| candidate.clone());
+    let dir_resolved = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+    if !resolved.starts_with(&dir_resolved) && candidate.exists() {
+        bail!("Path traversal detected for tree_id {tree_id:?}");
+    }
+    Ok(dir.join(format!("{tree_id}.json")))
+}
+
+fn lock_path(tree_id: &str) -> PathBuf {
+    state_dir().join(format!("{tree_id}.lock"))
+}
+
+// ─── Environment helpers ─────────────────────────────────────────────────
+
+fn get_tree_context() -> TreeContext {
+    let depth = std::env::var("AMPLIHACK_SESSION_DEPTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let max_depth = std::env::var("AMPLIHACK_MAX_DEPTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_MAX_DEPTH);
+    let max_sessions = std::env::var("AMPLIHACK_MAX_SESSIONS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_MAX_SESSIONS);
+    TreeContext {
+        tree_id: std::env::var("AMPLIHACK_TREE_ID").unwrap_or_default(),
+        depth,
+        max_depth,
+        max_sessions,
+    }
+}
+
+// ─── File I/O with locking ───────────────────────────────────────────────
+
+fn with_lock<F, R>(tree_id: &str, f: F) -> Result<R>
+where
+    F: FnOnce() -> Result<R>,
+{
+    ensure_state_dir()?;
+    let lock = lock_path(tree_id);
+    let deadline = Instant::now() + LOCK_TIMEOUT;
+
+    loop {
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock)
+        {
+            Ok(mut file) => {
+                let _ = write!(file, "{}", std::process::id());
+                let result = f();
+                let _ = fs::remove_file(&lock);
+                return result;
+            }
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                if Instant::now() >= deadline {
+                    bail!(
+                        "Could not acquire file lock for tree {tree_id:?} within {}s",
+                        LOCK_TIMEOUT.as_secs()
+                    );
+                }
+                // Check lock age, then PID liveness
+                let lock_age = fs::metadata(&lock)
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .and_then(|t| t.elapsed().ok());
+
+                if let Some(age) = lock_age {
+                    if age > STALE_LOCK_AGE {
+                        eprintln!(
+                            "WARNING: session_tree: removing stale lock for {tree_id:?} \
+                             (age: {:.0}s > {}s threshold)",
+                            age.as_secs_f64(),
+                            STALE_LOCK_AGE.as_secs()
+                        );
+                        let _ = fs::remove_file(&lock);
+                    } else if let Ok(content) = fs::read_to_string(&lock)
+                        && let Ok(pid) = content.trim().parse::<i32>()
+                    {
+                        #[cfg(unix)]
+                        {
+                            if unsafe { libc::kill(pid, 0) } != 0 {
+                                let _ = fs::remove_file(&lock);
+                            }
+                        }
+                        #[cfg(not(unix))]
+                        let _ = pid;
+                    }
+                }
+                std::thread::sleep(LOCK_POLL_INTERVAL);
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+fn load(tree_id: &str) -> TreeState {
+    let p = match state_path(tree_id) {
+        Ok(p) => p,
+        Err(_) => return TreeState::default(),
+    };
+    if !p.exists() {
+        return TreeState::default();
+    }
+    match fs::read_to_string(&p) {
+        Ok(content) => match serde_json::from_str::<TreeState>(&content) {
+            Ok(state) => state,
+            Err(e) => {
+                eprintln!("WARNING: session_tree: corrupted state for {tree_id:?}: {e}");
+                TreeState::default()
+            }
+        },
+        Err(e) => {
+            eprintln!("WARNING: session_tree: corrupted state for {tree_id:?}: {e}");
+            TreeState::default()
+        }
+    }
+}
+
+fn save(tree_id: &str, state: &mut TreeState) -> Result<()> {
+    let now = now_epoch();
+    let completed_cutoff = now - (COMPLETED_MAX_AGE_HOURS * 3600.0);
+    let active_cutoff = now - (ACTIVE_MAX_AGE_HOURS * 3600.0);
+
+    // Prune stale sessions
+    state.sessions.retain(|sid, s| {
+        if s.status == "completed" && s.completed_at.unwrap_or(0.0) < completed_cutoff {
+            return false;
+        }
+        if s.status == "active" && s.started_at < active_cutoff {
+            eprintln!(
+                "WARNING: session_tree: pruning leaked active session {sid:?} \
+                 (started {:.1}h ago)",
+                (now - s.started_at) / 3600.0
+            );
+            return false;
+        }
+        true
+    });
+
+    // Atomic write via temp file + rename
+    let target = state_path(tree_id)?;
+    let dir = state_dir();
+    let content = serde_json::to_string_pretty(state)?;
+    let tmp = tempfile::NamedTempFile::new_in(&dir)?;
+    fs::write(tmp.path(), &content)?;
+    tmp.persist(&target)?;
+
+    Ok(())
+}
+
+fn now_epoch() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+fn gen_hex_id() -> String {
+    // Use system time + pid for uniqueness without requiring rand crate
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let pid = std::process::id();
+    format!("{:08x}", (ts as u32) ^ pid)
+}
+
+// ─── Core operations ─────────────────────────────────────────────────────
+
+struct CheckResult {
+    allowed: bool,
+    reason: String,
+}
+
+fn check_can_spawn() -> CheckResult {
+    let ctx = get_tree_context();
+    let child_depth = ctx.depth + 1;
+
+    if child_depth > ctx.max_depth {
+        return CheckResult {
+            allowed: false,
+            reason: format!(
+                "max_depth={} exceeded at depth={}",
+                ctx.max_depth, ctx.depth
+            ),
+        };
+    }
+
+    if ctx.tree_id.is_empty() {
+        return CheckResult {
+            allowed: true,
+            reason: "new_tree".to_string(),
+        };
+    }
+
+    if validate_tree_id(&ctx.tree_id).is_err() {
+        return CheckResult {
+            allowed: false,
+            reason: format!("invalid tree_id: {:?}", ctx.tree_id),
+        };
+    }
+
+    let state = load(&ctx.tree_id);
+    let active_count = state
+        .sessions
+        .values()
+        .filter(|s| s.status == "active")
+        .count() as u32;
+
+    if active_count >= ctx.max_sessions {
+        return CheckResult {
+            allowed: false,
+            reason: format!(
+                "max_sessions={} reached ({active_count} active)",
+                ctx.max_sessions
+            ),
+        };
+    }
+
+    CheckResult {
+        allowed: true,
+        reason: "ok".to_string(),
+    }
+}
+
+fn register_session(session_id: &str, parent_id: Option<&str>) -> Result<(String, u32)> {
+    let ctx = get_tree_context();
+    let tree_id_raw = if ctx.tree_id.is_empty() {
+        gen_hex_id()
+    } else {
+        ctx.tree_id.clone()
+    };
+    let tree_id = validate_tree_id(&tree_id_raw)?.to_string();
+    let depth = ctx.depth;
+    let max_sessions = ctx.max_sessions;
+    let max_depth = ctx.max_depth;
+
+    with_lock(&tree_id, || {
+        let mut state = load(&tree_id);
+
+        let active_count = state
+            .sessions
+            .values()
+            .filter(|s| s.status == "active")
+            .count() as u32;
+
+        if active_count >= max_sessions {
+            bail!("max_sessions={max_sessions} reached ({active_count} active)");
+        }
+        if depth > max_depth {
+            bail!("depth={depth} exceeds max_depth={max_depth}");
+        }
+
+        state.sessions.insert(
+            session_id.to_string(),
+            SessionEntry {
+                depth,
+                parent: parent_id.map(String::from),
+                status: "active".to_string(),
+                started_at: now_epoch(),
+                completed_at: None,
+                children: Vec::new(),
+            },
+        );
+
+        if let Some(pid) = parent_id
+            && let Some(parent) = state.sessions.get_mut(pid)
+        {
+            parent.children.push(session_id.to_string());
+        }
+
+        save(&tree_id, &mut state)?;
+        Ok(())
+    })?;
+
+    Ok((tree_id, depth))
+}
+
+fn complete_session_impl(session_id: &str) -> Result<()> {
+    let ctx = get_tree_context();
+    if ctx.tree_id.is_empty() {
+        return Ok(());
+    }
+
+    let tree_id = ctx.tree_id;
+    validate_tree_id(&tree_id)?;
+
+    with_lock(&tree_id, || {
+        let mut state = load(&tree_id);
+        if let Some(session) = state.sessions.get_mut(session_id) {
+            session.status = "completed".to_string();
+            session.completed_at = Some(now_epoch());
+        }
+        save(&tree_id, &mut state)?;
+        Ok(())
+    })
+}
+
+fn get_status_impl(tree_id: &str) -> Result<serde_json::Value> {
+    validate_tree_id(tree_id)?;
+    let state = load(tree_id);
+
+    let active: Vec<&String> = state
+        .sessions
+        .iter()
+        .filter(|(_, s)| s.status == "active")
+        .map(|(k, _)| k)
+        .collect();
+    let completed: Vec<&String> = state
+        .sessions
+        .iter()
+        .filter(|(_, s)| s.status == "completed")
+        .map(|(k, _)| k)
+        .collect();
+    let depths: HashMap<&String, u32> = state.sessions.iter().map(|(k, s)| (k, s.depth)).collect();
+
+    Ok(serde_json::json!({
+        "tree_id": tree_id,
+        "active": active,
+        "completed": completed,
+        "depths": depths,
+    }))
+}
+
+// ─── CLI entry points ────────────────────────────────────────────────────
+
+pub fn run_check() -> Result<()> {
+    let result = check_can_spawn();
+    if result.allowed {
+        println!("ALLOWED");
+    } else {
+        println!("BLOCKED:{}", result.reason);
+    }
+    Ok(())
+}
+
+pub fn run_register(session_id: Option<String>, parent_id: Option<String>) -> Result<()> {
+    let sid = session_id.unwrap_or_else(gen_hex_id);
+    match register_session(&sid, parent_id.as_deref()) {
+        Ok((tree_id, depth)) => {
+            println!("TREE_ID={tree_id} DEPTH={depth}");
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("ERROR: {e}");
+            Err(exit_error(1))
+        }
+    }
+}
+
+pub fn run_complete(session_id: Option<String>) -> Result<()> {
+    let sid = session_id.unwrap_or_default();
+    complete_session_impl(&sid)
+}
+
+pub fn run_status(tree_id: Option<String>) -> Result<()> {
+    let ctx = get_tree_context();
+    let tid = tree_id.unwrap_or(ctx.tree_id);
+    if tid.is_empty() {
+        println!("No AMPLIHACK_TREE_ID set");
+        return Err(exit_error(1));
+    }
+    let status = get_status_impl(&tid)?;
+    println!("{}", serde_json::to_string_pretty(&status)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        vars: Vec<(String, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new(vars: &[(&str, Option<&str>)]) -> Self {
+            let saved: Vec<_> = vars
+                .iter()
+                .map(|(k, v)| {
+                    let old = std::env::var(k).ok();
+                    match v {
+                        Some(val) => unsafe { std::env::set_var(k, val) },
+                        None => unsafe { std::env::remove_var(k) },
+                    }
+                    (k.to_string(), old)
+                })
+                .collect();
+            Self { vars: saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.vars {
+                match v {
+                    Some(val) => unsafe { std::env::set_var(k, val) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+            }
+        }
+    }
+
+    fn unique_tree_id(test_name: &str) -> String {
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        format!("test-{test_name}-{ts}")
+    }
+
+    fn cleanup_tree(tree_id: &str) {
+        let dir = state_dir();
+        let _ = fs::remove_file(dir.join(format!("{tree_id}.json")));
+        let _ = fs::remove_file(dir.join(format!("{tree_id}.lock")));
+    }
+
+    #[test]
+    fn validate_tree_id_accepts_valid_ids() {
+        assert!(validate_tree_id("abc123").is_ok());
+        assert!(validate_tree_id("my-tree_01").is_ok());
+        assert!(validate_tree_id("A").is_ok());
+        assert!(validate_tree_id(&"x".repeat(64)).is_ok());
+    }
+
+    #[test]
+    fn validate_tree_id_rejects_empty() {
+        assert!(validate_tree_id("").is_err());
+    }
+
+    #[test]
+    fn validate_tree_id_rejects_path_traversal() {
+        assert!(validate_tree_id("../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn validate_tree_id_rejects_special_chars() {
+        assert!(validate_tree_id("tree;rm -rf /").is_err());
+        assert!(validate_tree_id("tree/sub").is_err());
+        assert!(validate_tree_id("tree.json").is_err());
+    }
+
+    #[test]
+    fn gen_hex_id_produces_8_hex_chars() {
+        let id = gen_hex_id();
+        assert_eq!(id.len(), 8, "Expected 8 chars, got {}: {id}", id.len());
+        assert!(
+            id.chars().all(|c| c.is_ascii_hexdigit()),
+            "Expected hex chars: {id}"
+        );
+    }
+
+    #[test]
+    fn check_allows_when_no_tree() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let _guard = EnvGuard::new(&[
+            ("AMPLIHACK_TREE_ID", None),
+            ("AMPLIHACK_SESSION_DEPTH", Some("0")),
+            ("AMPLIHACK_MAX_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_SESSIONS", Some("10")),
+        ]);
+        let result = check_can_spawn();
+        assert!(result.allowed, "Should be allowed: {}", result.reason);
+        assert_eq!(result.reason, "new_tree");
+    }
+
+    #[test]
+    fn check_blocks_at_max_depth() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let _guard = EnvGuard::new(&[
+            ("AMPLIHACK_TREE_ID", Some("any")),
+            ("AMPLIHACK_SESSION_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_SESSIONS", Some("10")),
+        ]);
+        let result = check_can_spawn();
+        assert!(!result.allowed);
+        assert!(result.reason.contains("max_depth"));
+    }
+
+    #[test]
+    fn register_creates_new_tree_when_id_empty() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let _guard = EnvGuard::new(&[
+            ("AMPLIHACK_TREE_ID", None),
+            ("AMPLIHACK_SESSION_DEPTH", Some("0")),
+            ("AMPLIHACK_MAX_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_SESSIONS", Some("10")),
+        ]);
+
+        let (tree_id, depth) = register_session("test-sess", None).unwrap();
+        assert_eq!(depth, 0);
+        assert_eq!(tree_id.len(), 8);
+
+        let state = load(&tree_id);
+        assert!(state.sessions.contains_key("test-sess"));
+        assert_eq!(state.sessions["test-sess"].status, "active");
+        cleanup_tree(&tree_id);
+    }
+
+    #[test]
+    fn register_with_parent_links_child() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let tid = unique_tree_id("reg-parent");
+        let _guard = EnvGuard::new(&[
+            ("AMPLIHACK_TREE_ID", Some(&tid)),
+            ("AMPLIHACK_SESSION_DEPTH", Some("0")),
+            ("AMPLIHACK_MAX_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_SESSIONS", Some("10")),
+        ]);
+
+        register_session("parent-sess", None).unwrap();
+        register_session("child-sess", Some("parent-sess")).unwrap();
+
+        let state = load(&tid);
+        assert!(
+            state.sessions["parent-sess"]
+                .children
+                .contains(&"child-sess".to_string())
+        );
+        cleanup_tree(&tid);
+    }
+
+    #[test]
+    fn register_fails_when_max_sessions_reached() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let tid = unique_tree_id("reg-maxsess");
+        let _guard = EnvGuard::new(&[
+            ("AMPLIHACK_TREE_ID", Some(&tid)),
+            ("AMPLIHACK_SESSION_DEPTH", Some("0")),
+            ("AMPLIHACK_MAX_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_SESSIONS", Some("2")),
+        ]);
+
+        register_session("s1", None).unwrap();
+        register_session("s2", None).unwrap();
+        let result = register_session("s3", None);
+        assert!(result.is_err(), "Should fail at max sessions");
+        cleanup_tree(&tid);
+    }
+
+    #[test]
+    fn complete_marks_session_completed() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let tid = unique_tree_id("complete-ok");
+        let _guard = EnvGuard::new(&[
+            ("AMPLIHACK_TREE_ID", Some(&tid)),
+            ("AMPLIHACK_SESSION_DEPTH", Some("0")),
+            ("AMPLIHACK_MAX_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_SESSIONS", Some("10")),
+        ]);
+
+        register_session("my-sess", None).unwrap();
+        complete_session_impl("my-sess").unwrap();
+
+        let state = load(&tid);
+        assert_eq!(state.sessions["my-sess"].status, "completed");
+        assert!(state.sessions["my-sess"].completed_at.is_some());
+        cleanup_tree(&tid);
+    }
+
+    #[test]
+    fn status_returns_tree_details() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let tid = unique_tree_id("status-ok");
+        let _guard = EnvGuard::new(&[
+            ("AMPLIHACK_TREE_ID", Some(&tid)),
+            ("AMPLIHACK_SESSION_DEPTH", Some("0")),
+            ("AMPLIHACK_MAX_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_SESSIONS", Some("10")),
+        ]);
+
+        register_session("s1", None).unwrap();
+        register_session("s2", None).unwrap();
+        complete_session_impl("s1").unwrap();
+
+        let status = get_status_impl(&tid).unwrap();
+        assert_eq!(status["tree_id"], tid);
+
+        let active = status["active"].as_array().unwrap();
+        let completed = status["completed"].as_array().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(completed.len(), 1);
+        cleanup_tree(&tid);
+    }
+
+    #[test]
+    fn full_lifecycle_register_complete_status() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let tid = unique_tree_id("lifecycle");
+        let _guard = EnvGuard::new(&[
+            ("AMPLIHACK_TREE_ID", Some(&tid)),
+            ("AMPLIHACK_SESSION_DEPTH", Some("0")),
+            ("AMPLIHACK_MAX_DEPTH", Some("3")),
+            ("AMPLIHACK_MAX_SESSIONS", Some("10")),
+        ]);
+
+        let (tree_id, depth) = register_session("root", None).unwrap();
+        assert_eq!(tree_id, tid);
+        assert_eq!(depth, 0);
+
+        register_session("child", Some("root")).unwrap();
+        complete_session_impl("child").unwrap();
+        complete_session_impl("root").unwrap();
+
+        let status = get_status_impl(&tid).unwrap();
+        assert_eq!(status["completed"].as_array().unwrap().len(), 2);
+        cleanup_tree(&tid);
+    }
+}

--- a/crates/amplihack-cli/src/commands/validate_frontmatter/mod.rs
+++ b/crates/amplihack-cli/src/commands/validate_frontmatter/mod.rs
@@ -1,0 +1,126 @@
+//! Validate YAML frontmatter in markdown skill/agent files.
+//!
+//! Scans a file (or all `.md` files in the current directory) for valid
+//! YAML frontmatter delimited by `---` fences.
+
+use anyhow::{Result, bail};
+use std::fs;
+use std::path::Path;
+
+/// Run validation on a single file or all .md files in cwd.
+pub fn run_validate_frontmatter(file: Option<&str>) -> Result<()> {
+    match file {
+        Some(path) => validate_single(Path::new(path)),
+        None => validate_directory(Path::new(".")),
+    }
+}
+
+fn validate_single(path: &Path) -> Result<()> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("Cannot read {}: {e}", path.display()))?;
+
+    match extract_and_validate_frontmatter(&content) {
+        Ok(()) => {
+            println!("\u{2713} {}: valid frontmatter", path.display());
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("\u{2717} {}: {e}", path.display());
+            bail!("Frontmatter validation failed for {}", path.display());
+        }
+    }
+}
+
+fn validate_directory(dir: &Path) -> Result<()> {
+    let mut found = false;
+    let mut errors = 0;
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "md") {
+            found = true;
+            if let Err(e) = validate_single(&path) {
+                eprintln!("{e}");
+                errors += 1;
+            }
+        }
+    }
+
+    if !found {
+        println!("No .md files found in {}", dir.display());
+    }
+
+    if errors > 0 {
+        bail!("{errors} file(s) failed validation");
+    }
+
+    Ok(())
+}
+
+fn extract_and_validate_frontmatter(content: &str) -> Result<()> {
+    let trimmed = content.trim_start();
+
+    if !trimmed.starts_with("---") {
+        bail!("No frontmatter found (file must start with ---)");
+    }
+
+    let after_first_fence = &trimmed[3..];
+    // Find closing ---
+    let close_pos = after_first_fence
+        .find("\n---")
+        .ok_or_else(|| anyhow::anyhow!("No closing --- found for frontmatter"))?;
+
+    let yaml_content = &after_first_fence[..close_pos].trim();
+
+    if yaml_content.is_empty() {
+        bail!("Frontmatter is empty");
+    }
+
+    // Parse as YAML to validate
+    let _: serde_yaml::Value = serde_yaml::from_str(yaml_content)
+        .map_err(|e| anyhow::anyhow!("Invalid YAML in frontmatter: {e}"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_frontmatter() {
+        let content = "---\nname: test\nversion: 1.0\n---\n# Body\nContent here.";
+        assert!(extract_and_validate_frontmatter(content).is_ok());
+    }
+
+    #[test]
+    fn no_frontmatter() {
+        let content = "# Just a heading\nNo frontmatter here.";
+        assert!(extract_and_validate_frontmatter(content).is_err());
+    }
+
+    #[test]
+    fn invalid_yaml() {
+        let content = "---\n: invalid: yaml: [broken\n---\n# Body";
+        assert!(extract_and_validate_frontmatter(content).is_err());
+    }
+
+    #[test]
+    fn empty_frontmatter() {
+        let content = "---\n\n---\n# Body";
+        assert!(extract_and_validate_frontmatter(content).is_err());
+    }
+
+    #[test]
+    fn no_closing_fence() {
+        let content = "---\nname: test\n# No closing fence";
+        assert!(extract_and_validate_frontmatter(content).is_err());
+    }
+
+    #[test]
+    fn complex_frontmatter() {
+        let content = "---\nname: my-skill\nversion: 2.0.0\ndescription: |\n  Multi-line\n  description\ntags:\n  - cli\n  - tools\n---\n# Content";
+        assert!(extract_and_validate_frontmatter(content).is_ok());
+    }
+}

--- a/crates/amplihack-cli/src/lib.rs
+++ b/crates/amplihack-cli/src/lib.rs
@@ -57,7 +57,8 @@ use clap::{
 
 pub use cli_commands::Commands;
 pub use cli_subcommands::{
-    MemoryCommands, ModeCommands, PluginCommands, QueryCodeCommands, RecipeCommands,
+    EvalCommands, LockCommands, MemoryCommands, ModeCommands, MultitaskCommands,
+    OrchHelperCommands, PluginCommands, QueryCodeCommands, RecipeCommands, SessionTreeCommands,
 };
 
 fn graph_db_backend_value_parser() -> PossibleValuesParser {

--- a/crates/amplihack-cli/src/update/check.rs
+++ b/crates/amplihack-cli/src/update/check.rs
@@ -42,6 +42,24 @@ pub fn run_update() -> Result<()> {
     );
     super::install::download_and_replace(&release)?;
     write_cache(&cache_path()?, &release.version)?;
+
+    // #249: Re-stage framework assets after binary replacement.
+    // The new binary may bundle updated assets (skills, recipes, hooks).
+    // We call ensure_framework_installed() to refresh them. Failures are
+    // logged but do not abort the update — the binary itself is already
+    // in place and functional.
+    if let Err(err) = crate::commands::install::ensure_framework_installed() {
+        tracing::warn!(
+            error = %err,
+            "failed to re-stage framework assets after update; \
+             run 'amplihack install' manually to refresh"
+        );
+        eprintln!(
+            "⚠️  Binary updated successfully, but asset re-staging failed: {err:#}\n   \
+             Run 'amplihack install' to refresh framework assets."
+        );
+    }
+
     Ok(())
 }
 

--- a/crates/amplihack-cli/src/update/install.rs
+++ b/crates/amplihack-cli/src/update/install.rs
@@ -6,7 +6,7 @@ use tar::Archive;
 
 /// Verify a downloaded archive against its SHA-256 checksum.
 pub(super) fn verify_sha256(archive_bytes: &[u8], checksum_url: &str) -> Result<()> {
-    let checksum_body = super::network::http_get(checksum_url)
+    let checksum_body = super::network::http_get_with_retry(checksum_url)
         .with_context(|| format!("failed to download checksum from {checksum_url}"))?;
     let checksum_text =
         std::str::from_utf8(&checksum_body).context("checksum file is not valid UTF-8")?;

--- a/crates/amplihack-cli/src/update/tests.rs
+++ b/crates/amplihack-cli/src/update/tests.rs
@@ -177,6 +177,14 @@ fn is_newer_detects_version_bumps() {
 
 #[test]
 fn should_skip_update_check_for_update_related_args() {
+    let _lock = crate::test_support::env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::remove_var("AMPLIHACK_NONINTERACTIVE");
+        std::env::remove_var("AMPLIHACK_PARITY_TEST");
+        std::env::remove_var(NO_UPDATE_CHECK_ENV);
+    }
     assert!(should_skip_update_check(&[
         OsString::from("amplihack"),
         OsString::from("update")
@@ -211,6 +219,14 @@ fn should_skip_update_check_for_non_launch_subcommands() {
 
 #[test]
 fn should_not_skip_update_check_for_launch_subcommands() {
+    let _lock = crate::test_support::env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    unsafe {
+        std::env::remove_var("AMPLIHACK_NONINTERACTIVE");
+        std::env::remove_var("AMPLIHACK_PARITY_TEST");
+        std::env::remove_var(NO_UPDATE_CHECK_ENV);
+    }
     for subcmd in &["launch", "claude", "copilot", "codex", "amplifier"] {
         assert!(
             !should_skip_update_check(&[OsString::from("amplihack"), OsString::from(*subcmd),]),

--- a/crates/amplihack-cli/tests/bugfix_install_tests.rs
+++ b/crates/amplihack-cli/tests/bugfix_install_tests.rs
@@ -1,0 +1,133 @@
+//! Bugfix integration tests for install/update commands.
+//!
+//! Covers:
+//! - #254: URL constants point to amplihack-rs repo
+//! - #249: run_update() calls ensure_framework_installed() after binary swap
+//! - #257: verify_sha256() uses http_get_with_retry()
+
+// ── #254: URL constants verification ──
+
+/// Verify that the repo archive URL points to the Rust repo, not the Python repo.
+#[test]
+fn repo_archive_url_points_to_amplihack_rs() {
+    // We can't import the private constant directly, but we can verify
+    // the source code contains the correct URL.
+    let source = include_str!("../src/commands/install/types.rs");
+    assert!(
+        source.contains("rysweet/amplihack-rs"),
+        "REPO_ARCHIVE_URL must point to amplihack-rs repo"
+    );
+    assert!(
+        !source.contains("\"https://github.com/rysweet/amplihack/archive"),
+        "REPO_ARCHIVE_URL must NOT point to the Python amplihack repo"
+    );
+}
+
+/// Verify the git clone URL points to the Rust repo.
+#[test]
+fn repo_git_url_points_to_amplihack_rs() {
+    let source = include_str!("../src/commands/install/types.rs");
+    assert!(
+        source.contains("\"https://github.com/rysweet/amplihack-rs\""),
+        "REPO_GIT_URL must point to amplihack-rs repo"
+    );
+}
+
+/// Verify find_framework_repo_root accepts amplifier-bundle/ directory.
+#[test]
+fn find_framework_repo_root_accepts_amplifier_bundle() {
+    let source = include_str!("../src/commands/install/clone.rs");
+    assert!(
+        source.contains("amplifier-bundle"),
+        "find_framework_repo_root must accept amplifier-bundle/ as a marker"
+    );
+}
+
+/// Verify find_framework_repo_root still accepts .claude/ directory (backward compat).
+#[test]
+fn find_framework_repo_root_still_accepts_claude_dir() {
+    let source = include_str!("../src/commands/install/clone.rs");
+    assert!(
+        source.contains(".claude"),
+        "find_framework_repo_root must still accept .claude/ as a marker"
+    );
+}
+
+/// Verify the error message mentions both markers.
+#[test]
+fn find_framework_repo_root_error_mentions_both_markers() {
+    let source = include_str!("../src/commands/install/clone.rs");
+    assert!(
+        source.contains(".claude/") && source.contains("amplifier-bundle/"),
+        "error message should mention both .claude/ and amplifier-bundle/"
+    );
+}
+
+/// Verify BFS search implementation (not just string matching).
+#[test]
+fn find_framework_repo_root_uses_bfs_search() {
+    let source = include_str!("../src/commands/install/clone.rs");
+    assert!(
+        source.contains("VecDeque"),
+        "find_framework_repo_root should use BFS (VecDeque)"
+    );
+}
+
+// ── #249: Update re-stages assets ──
+
+/// Verify run_update calls ensure_framework_installed after download_and_replace.
+#[test]
+fn run_update_calls_ensure_framework_installed() {
+    let source = include_str!("../src/update/check.rs");
+    assert!(
+        source.contains("ensure_framework_installed"),
+        "run_update must call ensure_framework_installed after binary replacement"
+    );
+}
+
+/// Verify the ensure_framework_installed failure is non-fatal (logged, not propagated).
+#[test]
+fn run_update_asset_restaging_failure_is_nonfatal() {
+    let source = include_str!("../src/update/check.rs");
+    // Should use if-let-Err pattern, not the ? operator on ensure_framework_installed
+    assert!(
+        source.contains("if let Err"),
+        "asset re-staging failure should be caught with if-let-Err, not propagated with ?"
+    );
+    assert!(
+        source.contains("amplihack install"),
+        "error message should suggest running 'amplihack install' manually"
+    );
+}
+
+// ── #257: Checksum uses retry ──
+
+/// Verify verify_sha256 uses http_get_with_retry, not plain http_get.
+#[test]
+fn verify_sha256_uses_retry() {
+    let source = include_str!("../src/update/install.rs");
+    assert!(
+        source.contains("http_get_with_retry"),
+        "verify_sha256 must use http_get_with_retry for checksum download"
+    );
+    // Verify it's not using plain http_get for the checksum
+    // (http_get_with_retry contains http_get so we check the function call site)
+    // The verify_sha256 function is above download_and_replace in the file
+    let checksum_section = &source[..source
+        .find("fn download_and_replace")
+        .unwrap_or(source.len())];
+    assert!(
+        checksum_section.contains("http_get_with_retry"),
+        "checksum download should use http_get_with_retry"
+    );
+}
+
+/// Verify download_and_replace also uses retry for the archive download.
+#[test]
+fn download_and_replace_uses_retry() {
+    let source = include_str!("../src/update/install.rs");
+    assert!(
+        source.contains("http_get_with_retry(&release.asset_url)"),
+        "archive download must use http_get_with_retry"
+    );
+}

--- a/crates/amplihack-eval/Cargo.toml
+++ b/crates/amplihack-eval/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "amplihack-eval"
+description = "Evaluation framework: benchmark execution, scoring, and report generation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+anyhow = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/amplihack-eval/src/benchmark.rs
+++ b/crates/amplihack-eval/src/benchmark.rs
@@ -1,0 +1,270 @@
+//! Benchmark execution and timing.
+//!
+//! A `Benchmark` describes what to run.  A `BenchmarkResult` records what
+//! happened, including per-case outcomes and wall-clock durations.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::time::Instant;
+
+use crate::error::EvalError;
+
+/// A named benchmark with an optional description.
+///
+/// `Benchmark` is the configuration object — it does not execute anything
+/// itself.  Execution is the caller's responsibility; results are recorded in
+/// [`BenchmarkResult`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Benchmark {
+    /// Unique name for this benchmark.
+    pub name: String,
+    /// Optional human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl Benchmark {
+    /// Create a new benchmark with the given name.
+    pub fn new(name: impl Into<String>) -> Result<Self, EvalError> {
+        let name = name.into();
+        if name.is_empty() {
+            return Err(EvalError::invalid_benchmark("name must not be empty"));
+        }
+        Ok(Self {
+            name,
+            description: None,
+        })
+    }
+
+    /// Attach a description.
+    pub fn with_description(mut self, desc: impl Into<String>) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
+
+    /// Start timing a run, returning a [`Timer`] that produces elapsed
+    /// milliseconds when dropped or `.stop()`-ped.
+    pub fn start_timer(&self) -> Timer {
+        Timer::start()
+    }
+}
+
+/// Wall-clock timer for a single benchmark run.
+///
+/// Call [`Timer::stop`] to get elapsed milliseconds, or simply drop it.
+pub struct Timer {
+    start: Instant,
+}
+
+impl Timer {
+    pub(crate) fn start() -> Self {
+        Self {
+            start: Instant::now(),
+        }
+    }
+
+    /// Stop the timer and return elapsed milliseconds.
+    pub fn stop(self) -> u64 {
+        self.start.elapsed().as_millis() as u64
+    }
+
+    /// Peek at elapsed milliseconds without consuming the timer.
+    pub fn elapsed_ms(&self) -> u64 {
+        self.start.elapsed().as_millis() as u64
+    }
+}
+
+/// Result of a single benchmark case.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CaseResult {
+    /// Case identifier.
+    pub case_id: String,
+    /// Whether the case passed (score >= threshold).
+    pub passed: bool,
+    /// Normalised score in [0.0, 1.0].
+    pub score: f64,
+    /// Wall-clock time in milliseconds.
+    pub duration_ms: u64,
+    /// Optional human-readable notes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+
+impl CaseResult {
+    /// Create a new case result.
+    pub fn new(
+        case_id: impl Into<String>,
+        passed: bool,
+        score: f64,
+        duration_ms: u64,
+    ) -> Result<Self, EvalError> {
+        let case_id = case_id.into();
+        if case_id.is_empty() {
+            return Err(EvalError::invalid_benchmark("case_id must not be empty"));
+        }
+        if !(0.0..=1.0).contains(&score) {
+            return Err(EvalError::invalid_score(score));
+        }
+        Ok(Self {
+            case_id,
+            passed,
+            score,
+            duration_ms,
+            notes: None,
+        })
+    }
+
+    /// Attach notes to the case result.
+    pub fn with_notes(mut self, notes: impl Into<String>) -> Self {
+        self.notes = Some(notes.into());
+        self
+    }
+}
+
+/// Aggregated result of a benchmark run (all cases).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BenchmarkResult {
+    /// Name of the benchmark that was run.
+    pub benchmark_name: String,
+    /// Individual case results.
+    pub cases: Vec<CaseResult>,
+    /// Timestamp when the run started.
+    pub started_at: DateTime<Utc>,
+    /// Timestamp when the run finished (`None` until [`finish`] is called).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<DateTime<Utc>>,
+}
+
+impl BenchmarkResult {
+    /// Create an empty result for the named benchmark.
+    pub fn new(benchmark_name: impl Into<String>) -> Self {
+        Self {
+            benchmark_name: benchmark_name.into(),
+            cases: Vec::new(),
+            started_at: Utc::now(),
+            finished_at: None,
+        }
+    }
+
+    /// Record a case result (infallible convenience wrapper).
+    ///
+    /// Silently skips invalid results rather than panicking; callers that need
+    /// strict validation should use [`CaseResult::new`] directly.
+    pub fn add_case(
+        &mut self,
+        case_id: impl Into<String>,
+        passed: bool,
+        score: f64,
+        duration_ms: u64,
+    ) {
+        if let Ok(c) = CaseResult::new(case_id, passed, score, duration_ms) {
+            self.cases.push(c);
+        }
+    }
+
+    /// Push a pre-built [`CaseResult`].
+    pub fn push(&mut self, case: CaseResult) {
+        self.cases.push(case);
+    }
+
+    /// Mark the run as finished at the current wall-clock time.
+    pub fn finish(&mut self) {
+        self.finished_at = Some(Utc::now());
+    }
+
+    /// Total number of cases.
+    pub fn total(&self) -> usize {
+        self.cases.len()
+    }
+
+    /// Number of passing cases.
+    pub fn passed(&self) -> usize {
+        self.cases.iter().filter(|c| c.passed).count()
+    }
+
+    /// Number of failing cases.
+    pub fn failed(&self) -> usize {
+        self.total() - self.passed()
+    }
+
+    /// Mean score across all cases, or 0.0 if empty.
+    pub fn mean_score(&self) -> f64 {
+        if self.cases.is_empty() {
+            return 0.0;
+        }
+        self.cases.iter().map(|c| c.score).sum::<f64>() / self.cases.len() as f64
+    }
+
+    /// Total wall-clock time across all cases.
+    pub fn total_duration_ms(&self) -> u64 {
+        self.cases.iter().map(|c| c.duration_ms).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn benchmark_new_rejects_empty_name() {
+        assert!(Benchmark::new("").is_err());
+    }
+
+    #[test]
+    fn benchmark_new_ok() {
+        let b = Benchmark::new("my-bench").unwrap();
+        assert_eq!(b.name, "my-bench");
+        assert!(b.description.is_none());
+    }
+
+    #[test]
+    fn benchmark_with_description() {
+        let b = Benchmark::new("x").unwrap().with_description("desc");
+        assert_eq!(b.description.as_deref(), Some("desc"));
+    }
+
+    #[test]
+    fn timer_measures_elapsed() {
+        let t = Timer::start();
+        assert!(t.elapsed_ms() < 1000, "timer should not take > 1s");
+        let ms = t.stop();
+        assert!(ms < 1000);
+    }
+
+    #[test]
+    fn case_result_rejects_invalid_score() {
+        assert!(CaseResult::new("c", true, 1.5, 0).is_err());
+        assert!(CaseResult::new("c", true, -0.1, 0).is_err());
+    }
+
+    #[test]
+    fn case_result_rejects_empty_id() {
+        assert!(CaseResult::new("", true, 0.5, 0).is_err());
+    }
+
+    #[test]
+    fn benchmark_result_statistics() {
+        let mut r = BenchmarkResult::new("bench");
+        r.add_case("a", true, 1.0, 10);
+        r.add_case("b", false, 0.0, 20);
+        r.add_case("c", true, 0.5, 30);
+        r.finish();
+
+        assert_eq!(r.total(), 3);
+        assert_eq!(r.passed(), 2);
+        assert_eq!(r.failed(), 1);
+        assert!((r.mean_score() - 0.5).abs() < 1e-9);
+        assert_eq!(r.total_duration_ms(), 60);
+        assert!(r.finished_at.is_some());
+    }
+
+    #[test]
+    fn benchmark_result_empty() {
+        let r = BenchmarkResult::new("empty");
+        assert_eq!(r.mean_score(), 0.0);
+        assert_eq!(r.total_duration_ms(), 0);
+    }
+}

--- a/crates/amplihack-eval/src/error.rs
+++ b/crates/amplihack-eval/src/error.rs
@@ -1,0 +1,33 @@
+//! Error types for the eval framework.
+
+/// Errors that can occur during evaluation.
+#[derive(Debug, thiserror::Error)]
+pub enum EvalError {
+    /// A benchmark case name was empty or otherwise invalid.
+    #[error("invalid benchmark: {reason}")]
+    InvalidBenchmark { reason: String },
+
+    /// Score is outside the valid [0.0, 1.0] range.
+    #[error("invalid score {value}: must be in [0.0, 1.0]")]
+    InvalidScore { value: f64 },
+
+    /// JSON serialisation/deserialisation failed.
+    #[error("serialisation error: {0}")]
+    Serialisation(#[from] serde_json::Error),
+
+    /// File I/O error.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl EvalError {
+    pub fn invalid_benchmark(reason: impl Into<String>) -> Self {
+        Self::InvalidBenchmark {
+            reason: reason.into(),
+        }
+    }
+
+    pub fn invalid_score(value: f64) -> Self {
+        Self::InvalidScore { value }
+    }
+}

--- a/crates/amplihack-eval/src/lib.rs
+++ b/crates/amplihack-eval/src/lib.rs
@@ -1,0 +1,35 @@
+//! Evaluation framework: benchmark execution, scoring, and report generation.
+//!
+//! Ports the `amplihack.eval.*` Python framework to native Rust.  The crate is
+//! structured as three independent bricks:
+//!
+//! * **`benchmark`** — define and run named benchmarks with wall-clock timing.
+//! * **`scorer`** — compute aggregate scores and compare runs.
+//! * **`reporter`** — serialise results to JSON and human-readable text.
+//!
+//! Each module has a single responsibility and exposes a clear public API.
+//!
+//! # Quick-start
+//!
+//! ```rust
+//! use amplihack_eval::{Benchmark, BenchmarkResult, Reporter, Scorer, ScorerConfig};
+//!
+//! let mut result = BenchmarkResult::new("my-benchmark");
+//! result.add_case("case-1", true, 0.95, 10);
+//! result.add_case("case-2", false, 0.40, 15);
+//! result.finish();
+//!
+//! let score = Scorer::new(ScorerConfig::default()).score(&result);
+//! let text = Reporter::text(&score);
+//! println!("{text}");
+//! ```
+
+pub mod benchmark;
+pub mod error;
+pub mod reporter;
+pub mod scorer;
+
+pub use benchmark::{Benchmark, BenchmarkResult, CaseResult};
+pub use error::EvalError;
+pub use reporter::Reporter;
+pub use scorer::{RunComparison, RunScore, Scorer, ScorerConfig};

--- a/crates/amplihack-eval/src/reporter.rs
+++ b/crates/amplihack-eval/src/reporter.rs
@@ -1,0 +1,148 @@
+//! Report generation: JSON and human-readable text output.
+//!
+//! [`Reporter`] is a stateless helper — every method is a free function on
+//! `RunScore` or `RunComparison` values produced by [`crate::scorer::Scorer`].
+
+use crate::error::EvalError;
+use crate::scorer::{RunComparison, RunScore};
+
+/// Stateless report generator.
+pub struct Reporter;
+
+impl Reporter {
+    /// Serialise a [`RunScore`] to a pretty-printed JSON string.
+    pub fn json(score: &RunScore) -> Result<String, EvalError> {
+        Ok(serde_json::to_string_pretty(score)?)
+    }
+
+    /// Format a [`RunScore`] as human-readable text.
+    pub fn text(score: &RunScore) -> String {
+        let status = if score.overall_passed { "PASS" } else { "FAIL" };
+        let bar = progress_bar(score.composite_score, 20);
+        format!(
+            "Benchmark: {name}\n\
+             Status   : [{status}]\n\
+             Cases    : {passed}/{total} passed ({pass_pct:.1}%)\n\
+             Mean     : {mean:.3}\n\
+             Composite: {bar} {composite:.3}\n\
+             Duration : {dur_ms}ms",
+            name = score.benchmark_name,
+            status = status,
+            passed = score.passed_cases,
+            total = score.total_cases,
+            pass_pct = score.pass_rate * 100.0,
+            mean = score.mean_score,
+            bar = bar,
+            composite = score.composite_score,
+            dur_ms = score.total_duration_ms,
+        )
+    }
+
+    /// Format a [`RunComparison`] as human-readable text.
+    pub fn comparison_text(cmp: &RunComparison) -> String {
+        let direction = if cmp.improved {
+            "▲ improved"
+        } else {
+            "▼ regressed"
+        };
+        let sign = |v: f64| if v >= 0.0 { "+" } else { "" };
+        format!(
+            "Comparison: {name}\n\
+             Result    : {direction}\n\
+             Composite : {sc}{composite_delta:.3}\n\
+             Mean score: {sm}{mean_delta:.3}\n\
+             Pass rate : {sp}{pass_delta:.3}",
+            name = cmp.benchmark_name,
+            direction = direction,
+            sc = sign(cmp.composite_delta),
+            composite_delta = cmp.composite_delta,
+            sm = sign(cmp.mean_score_delta),
+            mean_delta = cmp.mean_score_delta,
+            sp = sign(cmp.pass_rate_delta),
+            pass_delta = cmp.pass_rate_delta,
+        )
+    }
+
+    /// Serialise a [`RunComparison`] to a pretty-printed JSON string.
+    pub fn comparison_json(cmp: &RunComparison) -> Result<String, EvalError> {
+        Ok(serde_json::to_string_pretty(cmp)?)
+    }
+}
+
+/// Render a simple ASCII progress bar for a value in [0.0, 1.0].
+fn progress_bar(value: f64, width: usize) -> String {
+    let filled = ((value.clamp(0.0, 1.0) * width as f64).round()) as usize;
+    let empty = width.saturating_sub(filled);
+    format!("[{}{}]", "#".repeat(filled), ".".repeat(empty))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::benchmark::BenchmarkResult;
+    use crate::scorer::{Scorer, ScorerConfig};
+
+    fn sample_score(passed: bool) -> RunScore {
+        let mut r = BenchmarkResult::new("demo");
+        r.add_case("c1", true, 0.9, 5);
+        r.add_case("c2", passed, 0.5, 10);
+        r.finish();
+        Scorer::new(ScorerConfig::default()).score(&r)
+    }
+
+    #[test]
+    fn json_is_valid_json() {
+        let score = sample_score(true);
+        let j = Reporter::json(&score).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&j).unwrap();
+        assert_eq!(v["benchmark_name"], "demo");
+        assert!(v["overall_passed"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn text_contains_benchmark_name() {
+        let score = sample_score(false);
+        let t = Reporter::text(&score);
+        assert!(t.contains("demo"));
+        assert!(t.contains("FAIL"));
+    }
+
+    #[test]
+    fn text_pass_shows_pass() {
+        let score = sample_score(true);
+        let t = Reporter::text(&score);
+        assert!(t.contains("PASS"));
+    }
+
+    #[test]
+    fn comparison_text_shows_direction() {
+        let mut r1 = BenchmarkResult::new("bench");
+        r1.add_case("a", false, 0.2, 0);
+        r1.finish();
+        let mut r2 = BenchmarkResult::new("bench");
+        r2.add_case("a", true, 0.9, 0);
+        r2.finish();
+
+        let scorer = Scorer::new(ScorerConfig::default());
+        let s1 = scorer.score(&r1);
+        let s2 = scorer.score(&r2);
+        let cmp = scorer.compare(&s1, &s2);
+        let t = Reporter::comparison_text(&cmp);
+        assert!(t.contains("improved"));
+    }
+
+    #[test]
+    fn progress_bar_full() {
+        assert_eq!(progress_bar(1.0, 4), "[####]");
+    }
+
+    #[test]
+    fn progress_bar_empty() {
+        assert_eq!(progress_bar(0.0, 4), "[....]");
+    }
+
+    #[test]
+    fn progress_bar_half() {
+        assert_eq!(progress_bar(0.5, 4), "[##..]");
+    }
+}

--- a/crates/amplihack-eval/src/scorer.rs
+++ b/crates/amplihack-eval/src/scorer.rs
@@ -1,0 +1,219 @@
+//! Score calculation and run comparison.
+//!
+//! [`Scorer`] computes a [`RunScore`] from a [`BenchmarkResult`], applying
+//! configurable pass/fail thresholds and weighting.  [`RunComparison`]
+//! summarises the delta between two runs.
+
+use serde::{Deserialize, Serialize};
+
+use crate::benchmark::BenchmarkResult;
+
+/// Configuration for the scorer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ScorerConfig {
+    /// Minimum mean score to consider the run as passing overall.
+    pub pass_threshold: f64,
+    /// Weight applied to pass-rate when computing the composite score.
+    /// Composite = pass_rate_weight * pass_rate + (1 - pass_rate_weight) * mean_score
+    pub pass_rate_weight: f64,
+}
+
+impl Default for ScorerConfig {
+    fn default() -> Self {
+        Self {
+            pass_threshold: 0.7,
+            pass_rate_weight: 0.5,
+        }
+    }
+}
+
+impl ScorerConfig {
+    /// Create a config with the given pass threshold.
+    pub fn with_threshold(pass_threshold: f64) -> Self {
+        Self {
+            pass_threshold,
+            ..Default::default()
+        }
+    }
+}
+
+/// Scores derived from a single benchmark run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RunScore {
+    /// Name of the benchmark.
+    pub benchmark_name: String,
+    /// Total number of cases evaluated.
+    pub total_cases: usize,
+    /// Number of cases that passed.
+    pub passed_cases: usize,
+    /// Pass rate in [0.0, 1.0].
+    pub pass_rate: f64,
+    /// Mean per-case score in [0.0, 1.0].
+    pub mean_score: f64,
+    /// Composite score (weighted average of pass_rate and mean_score).
+    pub composite_score: f64,
+    /// Whether the run cleared the pass threshold.
+    pub overall_passed: bool,
+    /// Total wall-clock time across all cases (ms).
+    pub total_duration_ms: u64,
+}
+
+impl RunScore {
+    /// Convenience: was the run a failure?
+    pub fn failed(&self) -> bool {
+        !self.overall_passed
+    }
+}
+
+/// Comparison of two [`RunScore`] results (baseline vs. candidate).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RunComparison {
+    pub benchmark_name: String,
+    /// Composite score delta: candidate − baseline.
+    pub composite_delta: f64,
+    /// Mean score delta: candidate − baseline.
+    pub mean_score_delta: f64,
+    /// Pass-rate delta: candidate − baseline.
+    pub pass_rate_delta: f64,
+    /// Whether the candidate improved over the baseline.
+    pub improved: bool,
+}
+
+/// Computes scores from benchmark results.
+pub struct Scorer {
+    config: ScorerConfig,
+}
+
+impl Scorer {
+    pub fn new(config: ScorerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Score a benchmark result.
+    pub fn score(&self, result: &BenchmarkResult) -> RunScore {
+        let total = result.total();
+        let passed = result.passed();
+        let pass_rate = if total == 0 {
+            0.0
+        } else {
+            passed as f64 / total as f64
+        };
+        let mean_score = result.mean_score();
+        let w = self.config.pass_rate_weight.clamp(0.0, 1.0);
+        let composite = w * pass_rate + (1.0 - w) * mean_score;
+
+        RunScore {
+            benchmark_name: result.benchmark_name.clone(),
+            total_cases: total,
+            passed_cases: passed,
+            pass_rate,
+            mean_score,
+            composite_score: composite,
+            overall_passed: composite >= self.config.pass_threshold,
+            total_duration_ms: result.total_duration_ms(),
+        }
+    }
+
+    /// Compare a candidate run against a baseline.
+    pub fn compare(&self, baseline: &RunScore, candidate: &RunScore) -> RunComparison {
+        let composite_delta = candidate.composite_score - baseline.composite_score;
+        let mean_score_delta = candidate.mean_score - baseline.mean_score;
+        let pass_rate_delta = candidate.pass_rate - baseline.pass_rate;
+        RunComparison {
+            benchmark_name: candidate.benchmark_name.clone(),
+            composite_delta,
+            mean_score_delta,
+            pass_rate_delta,
+            improved: composite_delta > 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::benchmark::BenchmarkResult;
+
+    fn make_result(cases: &[(&str, bool, f64, u64)]) -> BenchmarkResult {
+        let mut r = BenchmarkResult::new("test");
+        for &(id, passed, score, ms) in cases {
+            r.add_case(id, passed, score, ms);
+        }
+        r.finish();
+        r
+    }
+
+    #[test]
+    fn all_pass() {
+        let r = make_result(&[("a", true, 1.0, 5), ("b", true, 0.8, 10)]);
+        let s = Scorer::new(ScorerConfig::default()).score(&r);
+        assert_eq!(s.pass_rate, 1.0);
+        assert!((s.mean_score - 0.9).abs() < 1e-9);
+        assert!(s.overall_passed);
+    }
+
+    #[test]
+    fn all_fail() {
+        let r = make_result(&[("a", false, 0.1, 5)]);
+        let s = Scorer::new(ScorerConfig::default()).score(&r);
+        assert_eq!(s.pass_rate, 0.0);
+        assert!(!s.overall_passed);
+    }
+
+    #[test]
+    fn empty_result() {
+        let r = BenchmarkResult::new("empty");
+        let s = Scorer::new(ScorerConfig::default()).score(&r);
+        assert_eq!(s.total_cases, 0);
+        assert_eq!(s.pass_rate, 0.0);
+        assert!(!s.overall_passed);
+    }
+
+    #[test]
+    fn compare_improvement() {
+        let r1 = make_result(&[("a", false, 0.3, 5)]);
+        let r2 = make_result(&[("a", true, 0.9, 5)]);
+        let scorer = Scorer::new(ScorerConfig::default());
+        let s1 = scorer.score(&r1);
+        let s2 = scorer.score(&r2);
+        let cmp = scorer.compare(&s1, &s2);
+        assert!(cmp.improved);
+        assert!(cmp.composite_delta > 0.0);
+    }
+
+    #[test]
+    fn compare_regression() {
+        let r1 = make_result(&[("a", true, 0.9, 5)]);
+        let r2 = make_result(&[("a", false, 0.3, 5)]);
+        let scorer = Scorer::new(ScorerConfig::default());
+        let s1 = scorer.score(&r1);
+        let s2 = scorer.score(&r2);
+        let cmp = scorer.compare(&s1, &s2);
+        assert!(!cmp.improved);
+        assert!(cmp.composite_delta < 0.0);
+    }
+
+    #[test]
+    fn custom_threshold() {
+        let r = make_result(&[("a", true, 0.5, 5)]);
+        let config = ScorerConfig::with_threshold(0.9);
+        let s = Scorer::new(config).score(&r);
+        // composite = 0.5 * 1.0 + 0.5 * 0.5 = 0.75, which is < 0.9
+        assert!(!s.overall_passed);
+    }
+
+    #[test]
+    fn composite_score_formula() {
+        let r = make_result(&[("a", true, 0.6, 0), ("b", false, 0.4, 0)]);
+        let config = ScorerConfig {
+            pass_rate_weight: 0.5,
+            pass_threshold: 0.0,
+        };
+        let s = Scorer::new(config).score(&r);
+        // pass_rate = 0.5, mean_score = 0.5, composite = 0.5
+        assert!((s.composite_score - 0.5).abs() < 1e-9);
+    }
+}

--- a/crates/amplihack-recipe/src/executor.rs
+++ b/crates/amplihack-recipe/src/executor.rs
@@ -1,0 +1,353 @@
+//! Recipe step execution helpers — environment hardening and prerequisite validation.
+//!
+//! Addresses:
+//! - **#277**: Non-interactive environment propagation for shell steps.
+//! - **#251**: Agent context augmentation with working directory and file listing.
+//! - **#242**: Shell prerequisite validation (python3, node, etc.).
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+/// Environment variables unconditionally injected into every shell step
+/// to ensure non-interactive, headless execution.
+///
+/// - `HOME` and `PATH` preserve the inherited value (fallback to sensible defaults).
+/// - `NONINTERACTIVE`, `DEBIAN_FRONTEND`, and `CI` are set unconditionally to
+///   signal tools that no TTY is available.
+pub fn shell_step_env(inherit_env: &HashMap<String, String>) -> HashMap<String, String> {
+    let mut env = inherit_env.clone();
+
+    // Preserve inherited HOME/PATH, provide sensible fallbacks.
+    env.entry("HOME".into())
+        .or_insert_with(|| std::env::var("HOME").unwrap_or_else(|_| "/root".into()));
+    env.entry("PATH".into()).or_insert_with(|| {
+        std::env::var("PATH")
+            .unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin".into())
+    });
+
+    // Override unconditionally — these signal non-interactive mode.
+    env.insert("NONINTERACTIVE".into(), "1".into());
+    env.insert("DEBIAN_FRONTEND".into(), "noninteractive".into());
+    env.insert("CI".into(), "true".into());
+
+    env
+}
+
+/// Known tool names that may appear in shell commands. When a command
+/// references one of these tools, we check `which <tool>` before execution
+/// to provide a clear error instead of a cryptic "command not found" or
+/// silent failure.
+const KNOWN_TOOLS: &[&str] = &[
+    "python3", "python", "pip3", "pip", "node", "npm", "npx", "cargo", "rustc", "go", "java",
+    "dotnet", "ruby", "gem",
+];
+
+/// Result of prerequisite validation.
+#[derive(Debug, Clone)]
+pub struct PrerequisiteResult {
+    pub missing: Vec<String>,
+}
+
+impl PrerequisiteResult {
+    pub fn is_ok(&self) -> bool {
+        self.missing.is_empty()
+    }
+
+    /// Human-readable error message listing missing tools.
+    pub fn error_message(&self) -> String {
+        if self.missing.is_empty() {
+            return String::new();
+        }
+        let tools = self.missing.join(", ");
+        format!(
+            "Shell step requires tool(s) not found on PATH: {tools}. \
+             Install the missing tool(s) or adjust the recipe step."
+        )
+    }
+}
+
+/// Parse a shell command string for references to known tools and verify
+/// each is available via `which`.
+///
+/// This is a best-effort guard — it catches common cases like `python3 script.py`
+/// but won't catch tools invoked through variable expansion or pipes to obscure binaries.
+pub fn validate_shell_prerequisites(command: &str) -> PrerequisiteResult {
+    let lower = command.to_lowercase();
+    let mut missing = Vec::new();
+
+    for &tool in KNOWN_TOOLS {
+        // Match "python3 " at start, or " python3 " / " python3\n" mid-command,
+        // or the entire command being just the tool name.
+        let patterns = [
+            format!("{tool} "),
+            format!("{tool}\n"),
+            format!("{tool}\t"),
+            format!(" {tool} "),
+            format!(" {tool}\n"),
+            format!(" {tool}\t"),
+        ];
+        let starts_with_tool = lower.starts_with(&patterns[0])
+            || lower.starts_with(&patterns[1])
+            || lower.starts_with(&patterns[2])
+            || lower == tool;
+
+        let found_mid = patterns[3..].iter().any(|p| lower.contains(p.as_str()));
+
+        if (starts_with_tool || found_mid) && !is_tool_available(tool) {
+            missing.push(tool.to_string());
+        }
+    }
+
+    PrerequisiteResult { missing }
+}
+
+/// Check if a tool is available on PATH.
+fn is_tool_available(tool: &str) -> bool {
+    Command::new("which")
+        .arg(tool)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Context fields injected into agent step prompts to help the agent
+/// orient itself in the working directory.
+///
+/// Addresses #251: agent steps that produce zero file changes because the
+/// agent doesn't know where to write files.
+#[derive(Debug, Clone)]
+pub struct AgentContext {
+    /// Absolute path to the working directory.
+    pub working_directory: String,
+    /// Top-level file listing (not recursive) of the working directory.
+    pub file_listing: Vec<String>,
+}
+
+impl AgentContext {
+    /// Build context from a working directory path.
+    pub fn from_working_dir(dir: &Path) -> Self {
+        let working_directory = dir
+            .canonicalize()
+            .unwrap_or_else(|_| dir.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+
+        let file_listing = std::fs::read_dir(dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Self {
+            working_directory,
+            file_listing,
+        }
+    }
+
+    /// Format as a context block suitable for prepending to an agent prompt.
+    pub fn as_prompt_context(&self) -> String {
+        let listing = if self.file_listing.is_empty() {
+            "(empty directory)".to_string()
+        } else {
+            self.file_listing.join(", ")
+        };
+        format!(
+            "## Working Directory Context\n\
+             - **Path**: {}\n\
+             - **Files**: {}\n\
+             \n\
+             Write all output files to this directory unless the task specifies otherwise.\n",
+            self.working_directory, listing
+        )
+    }
+
+    /// Augment an agent prompt with working directory context.
+    /// If the prompt already contains `working_directory`, the context is
+    /// returned unmodified to avoid duplication.
+    pub fn augment_prompt(&self, prompt: &str) -> String {
+        if prompt.contains("working_directory") || prompt.contains(&self.working_directory) {
+            return prompt.to_string();
+        }
+        format!("{}\n\n{}", self.as_prompt_context(), prompt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── #277: shell_step_env tests ──
+
+    #[test]
+    fn shell_step_env_sets_noninteractive_vars() {
+        let env = shell_step_env(&HashMap::new());
+        assert_eq!(env.get("NONINTERACTIVE").map(String::as_str), Some("1"));
+        assert_eq!(
+            env.get("DEBIAN_FRONTEND").map(String::as_str),
+            Some("noninteractive")
+        );
+        assert_eq!(env.get("CI").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn shell_step_env_preserves_inherited_home() {
+        let mut inherit = HashMap::new();
+        inherit.insert("HOME".into(), "/custom/home".into());
+        let env = shell_step_env(&inherit);
+        assert_eq!(env.get("HOME").map(String::as_str), Some("/custom/home"));
+    }
+
+    #[test]
+    fn shell_step_env_preserves_inherited_path() {
+        let mut inherit = HashMap::new();
+        inherit.insert("PATH".into(), "/my/bin:/other/bin".into());
+        let env = shell_step_env(&inherit);
+        assert_eq!(
+            env.get("PATH").map(String::as_str),
+            Some("/my/bin:/other/bin")
+        );
+    }
+
+    #[test]
+    fn shell_step_env_provides_default_home_when_missing() {
+        let env = shell_step_env(&HashMap::new());
+        assert!(
+            env.contains_key("HOME"),
+            "HOME must be set even when not inherited"
+        );
+    }
+
+    #[test]
+    fn shell_step_env_provides_default_path_when_missing() {
+        let env = shell_step_env(&HashMap::new());
+        let path = env.get("PATH").expect("PATH must be set");
+        assert!(
+            path.contains("/usr/bin"),
+            "default PATH should include /usr/bin"
+        );
+    }
+
+    #[test]
+    fn shell_step_env_has_all_five_required_vars() {
+        let env = shell_step_env(&HashMap::new());
+        for key in &["HOME", "PATH", "NONINTERACTIVE", "DEBIAN_FRONTEND", "CI"] {
+            assert!(env.contains_key(*key), "env must contain {key}");
+        }
+    }
+
+    // ── #251: AgentContext tests ──
+
+    #[test]
+    fn agent_context_from_working_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("foo.rs"), "fn main() {}").unwrap();
+        std::fs::write(dir.path().join("bar.toml"), "[package]").unwrap();
+
+        let ctx = AgentContext::from_working_dir(dir.path());
+        assert!(!ctx.working_directory.is_empty());
+        assert!(ctx.file_listing.contains(&"foo.rs".to_string()));
+        assert!(ctx.file_listing.contains(&"bar.toml".to_string()));
+    }
+
+    #[test]
+    fn agent_context_augment_prompt_adds_context() {
+        let ctx = AgentContext {
+            working_directory: "/tmp/test-project".into(),
+            file_listing: vec!["Cargo.toml".into(), "src".into()],
+        };
+        let augmented = ctx.augment_prompt("Fix the broken tests");
+        assert!(augmented.contains("/tmp/test-project"));
+        assert!(augmented.contains("Cargo.toml"));
+        assert!(augmented.contains("Fix the broken tests"));
+    }
+
+    #[test]
+    fn agent_context_augment_prompt_skips_if_already_present() {
+        let ctx = AgentContext {
+            working_directory: "/tmp/test-project".into(),
+            file_listing: vec!["Cargo.toml".into()],
+        };
+        let original = "working_directory: /tmp/test-project\nFix the tests";
+        let augmented = ctx.augment_prompt(original);
+        assert_eq!(augmented, original, "should not double-inject context");
+    }
+
+    #[test]
+    fn agent_context_prompt_type_dispatch() {
+        let ctx = AgentContext {
+            working_directory: "/tmp/project".into(),
+            file_listing: vec![],
+        };
+        let prompt_ctx = ctx.as_prompt_context();
+        assert!(prompt_ctx.contains("Working Directory Context"));
+        assert!(prompt_ctx.contains("(empty directory)"));
+    }
+
+    #[test]
+    fn agent_context_multi_step_coverage() {
+        // Simulate multiple steps reusing the same context
+        let ctx = AgentContext {
+            working_directory: "/tmp/project".into(),
+            file_listing: vec!["README.md".into()],
+        };
+        let step1 = ctx.augment_prompt("Step 1: Analyze");
+        let step2 = ctx.augment_prompt("Step 2: Implement");
+        assert!(step1.contains("/tmp/project"));
+        assert!(step2.contains("/tmp/project"));
+        assert_ne!(step1, step2);
+    }
+
+    #[test]
+    fn agent_context_noninteractive_in_context() {
+        // Verify agent context encourages file writing, not interactive behavior
+        let ctx = AgentContext {
+            working_directory: "/tmp/project".into(),
+            file_listing: vec!["src".into()],
+        };
+        let prompt = ctx.as_prompt_context();
+        assert!(
+            prompt.contains("Write all output files"),
+            "agent context should instruct file writing"
+        );
+    }
+
+    // ── #242: validate_shell_prerequisites tests ──
+
+    #[test]
+    fn validate_prerequisites_detects_missing_python3() {
+        // This test depends on system state — if python3 IS installed, it passes vacuously.
+        // The function itself is correct either way; this tests the parsing logic.
+        let result = validate_shell_prerequisites("python3 -c 'print(1)'");
+        // Just verify it returns a valid result without panicking
+        let _ = result.is_ok();
+        let _ = result.error_message();
+    }
+
+    #[test]
+    fn validate_prerequisites_skips_unmentioned_tools() {
+        let result = validate_shell_prerequisites("echo hello world");
+        assert!(
+            result.is_ok(),
+            "simple echo should not report missing tools"
+        );
+    }
+
+    #[test]
+    fn validate_prerequisites_detects_python_variant() {
+        let result = validate_shell_prerequisites("python script.py");
+        // Just verify no panic; actual result depends on system
+        let _ = result.is_ok();
+    }
+
+    #[test]
+    fn validate_prerequisites_empty_command() {
+        let result = validate_shell_prerequisites("");
+        assert!(result.is_ok(), "empty command should pass validation");
+    }
+}

--- a/crates/amplihack-recipe/src/lib.rs
+++ b/crates/amplihack-recipe/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod agent_resolver;
 pub mod branch_name;
 pub mod discovery;
+pub mod executor;
 pub mod models;
 pub mod parser;
 pub mod progress_validator;
@@ -14,6 +15,9 @@ pub mod sub_recipe_recovery;
 pub use agent_resolver::AgentResolver;
 pub use branch_name::{make_branch_name, sanitize_branch_name};
 pub use discovery::{RecipeCache, RecipeInfo, discover_recipes, find_recipe, list_recipes};
+pub use executor::{
+    AgentContext, PrerequisiteResult, shell_step_env, validate_shell_prerequisites,
+};
 pub use models::{Recipe, RecipeResult, Step, StepResult, StepStatus, StepType};
 pub use parser::RecipeParser;
 pub use progress_validator::{

--- a/crates/amplihack-recipe/tests/bugfix_executor_tests.rs
+++ b/crates/amplihack-recipe/tests/bugfix_executor_tests.rs
@@ -1,0 +1,170 @@
+//! Bugfix integration tests for recipe executor hardening.
+//!
+//! Covers:
+//! - #277: Shell step non-interactive environment propagation
+//! - #251: Agent context augmentation with working directory
+//! - #242: Shell prerequisite validation guard
+
+use amplihack_recipe::{AgentContext, shell_step_env, validate_shell_prerequisites};
+use std::collections::HashMap;
+use std::process::Command;
+
+// ── #277: Shell step environment propagation ──
+
+#[test]
+fn shell_step_env_injects_noninteractive() {
+    let env = shell_step_env(&HashMap::new());
+    assert_eq!(env.get("NONINTERACTIVE").map(String::as_str), Some("1"));
+}
+
+#[test]
+fn shell_step_env_injects_debian_frontend() {
+    let env = shell_step_env(&HashMap::new());
+    assert_eq!(
+        env.get("DEBIAN_FRONTEND").map(String::as_str),
+        Some("noninteractive")
+    );
+}
+
+#[test]
+fn shell_step_env_injects_ci() {
+    let env = shell_step_env(&HashMap::new());
+    assert_eq!(env.get("CI").map(String::as_str), Some("true"));
+}
+
+#[test]
+fn shell_step_env_preserves_caller_home() {
+    let mut inherit = HashMap::new();
+    inherit.insert("HOME".into(), "/home/testuser".into());
+    let env = shell_step_env(&inherit);
+    assert_eq!(env["HOME"], "/home/testuser");
+}
+
+#[test]
+fn shell_step_env_preserves_caller_path() {
+    let mut inherit = HashMap::new();
+    inherit.insert("PATH".into(), "/custom/bin:/other".into());
+    let env = shell_step_env(&inherit);
+    assert_eq!(env["PATH"], "/custom/bin:/other");
+}
+
+#[test]
+fn shell_step_env_all_five_vars_present() {
+    let env = shell_step_env(&HashMap::new());
+    let required = ["HOME", "PATH", "NONINTERACTIVE", "DEBIAN_FRONTEND", "CI"];
+    for key in required {
+        assert!(env.contains_key(key), "missing required env var: {key}");
+    }
+}
+
+/// Integration test: actually run a bash command with the hardened env
+/// and verify the env vars are visible inside the shell.
+#[test]
+fn shell_step_env_visible_in_bash() {
+    let env = shell_step_env(&HashMap::new());
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg("echo NONINTERACTIVE=$NONINTERACTIVE CI=$CI DEBIAN_FRONTEND=$DEBIAN_FRONTEND")
+        .envs(&env)
+        .output()
+        .expect("failed to run bash");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("NONINTERACTIVE=1"));
+    assert!(stdout.contains("CI=true"));
+    assert!(stdout.contains("DEBIAN_FRONTEND=noninteractive"));
+}
+
+// ── #251: Agent context augmentation ──
+
+#[test]
+fn agent_context_captures_working_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
+    let ctx = AgentContext::from_working_dir(dir.path());
+    assert!(!ctx.working_directory.is_empty());
+    assert!(ctx.file_listing.contains(&"main.rs".to_string()));
+}
+
+#[test]
+fn agent_context_augment_injects_path() {
+    let ctx = AgentContext {
+        working_directory: "/tmp/my-project".into(),
+        file_listing: vec!["Cargo.toml".into(), "src".into()],
+    };
+    let augmented = ctx.augment_prompt("Fix the broken build");
+    assert!(augmented.contains("/tmp/my-project"));
+    assert!(augmented.contains("Cargo.toml"));
+    assert!(augmented.contains("Fix the broken build"));
+}
+
+#[test]
+fn agent_context_no_double_injection() {
+    let ctx = AgentContext {
+        working_directory: "/tmp/project".into(),
+        file_listing: vec!["README.md".into()],
+    };
+    let prompt = "working_directory is /tmp/project. Do the thing.";
+    let result = ctx.augment_prompt(prompt);
+    assert_eq!(result, prompt);
+}
+
+#[test]
+fn agent_context_noninteractive_instruction() {
+    let ctx = AgentContext {
+        working_directory: "/tmp/project".into(),
+        file_listing: vec![],
+    };
+    let prompt_ctx = ctx.as_prompt_context();
+    assert!(prompt_ctx.contains("Write all output files"));
+}
+
+#[test]
+fn agent_context_empty_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = AgentContext::from_working_dir(dir.path());
+    let prompt = ctx.as_prompt_context();
+    assert!(prompt.contains("(empty directory)"));
+}
+
+#[test]
+fn agent_context_multi_step_reuse() {
+    let ctx = AgentContext {
+        working_directory: "/tmp/project".into(),
+        file_listing: vec!["lib.rs".into()],
+    };
+    let s1 = ctx.augment_prompt("Step 1: Analyze the code");
+    let s2 = ctx.augment_prompt("Step 2: Write the fix");
+    assert!(s1.contains("/tmp/project"));
+    assert!(s2.contains("/tmp/project"));
+    // Both should have different task content
+    assert!(s1.contains("Analyze"));
+    assert!(s2.contains("Write the fix"));
+}
+
+// ── #242: Shell prerequisite validation ──
+
+#[test]
+fn prerequisites_echo_has_no_missing_tools() {
+    let result = validate_shell_prerequisites("echo hello");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn prerequisites_empty_command_passes() {
+    let result = validate_shell_prerequisites("");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn prerequisites_python3_detected_in_command() {
+    // This tests parsing, not actual system availability
+    let result = validate_shell_prerequisites("python3 -c 'print(1)'");
+    // Result depends on whether python3 is installed; no panic = pass
+    let _ = result.error_message();
+}
+
+#[test]
+fn prerequisites_python_variant_detected() {
+    let result = validate_shell_prerequisites("python script.py");
+    let _ = result.error_message();
+}

--- a/crates/amplihack-workflows/src/classifier.rs
+++ b/crates/amplihack-workflows/src/classifier.rs
@@ -110,7 +110,22 @@ impl WorkflowClassifier {
         }
 
         let keywords = self.extract_keywords(request);
-        let (workflow, reason, confidence) = self.classify_by_keywords(&keywords);
+        let (mut workflow, mut reason, mut confidence) = self.classify_by_keywords(&keywords);
+
+        // #269: Constructive-verb override — when a request matches OPS keywords
+        // but also contains a constructive verb (add, create, build, etc.), the
+        // user is building something, not doing ops. Override to DEFAULT.
+        if workflow == WorkflowType::Ops && Self::has_constructive_verb(request) {
+            trace!(
+                original_workflow = "OPS",
+                override_to = "DEFAULT",
+                "constructive verb override: request contains ops keyword but is constructive"
+            );
+            workflow = WorkflowType::Default;
+            reason = format!("{reason} (overridden: constructive verb detected)");
+            confidence = 0.75;
+        }
+        let (workflow, reason, confidence) = (workflow, reason, confidence);
 
         trace!(
             workflow = workflow.as_str(),
@@ -171,6 +186,24 @@ impl WorkflowClassifier {
         matched
     }
 
+    /// Constructive verbs that indicate the user wants to build/change something,
+    /// not perform an ops task. When the request contains one of these AND an OPS
+    /// keyword, DEFAULT wins. See issue #269.
+    const CONSTRUCTIVE_VERBS: &[&str] = &[
+        "add",
+        "create",
+        "build",
+        "implement",
+        "write",
+        "design",
+        "develop",
+        "make",
+        "introduce",
+        "extend",
+        "enhance",
+        "refactor",
+    ];
+
     fn classify_by_keywords(&self, keywords: &[String]) -> (WorkflowType, String, f64) {
         // Priority: DEFAULT > INVESTIGATION > OPS > Q&A
         let priority = [
@@ -200,6 +233,15 @@ impl WorkflowClassifier {
             0.5,
         )
     }
+
+    /// Returns `true` when the request text contains a constructive verb,
+    /// indicating the user wants to build/modify something (not an ops task).
+    fn has_constructive_verb(request: &str) -> bool {
+        let lower = request.to_lowercase();
+        Self::CONSTRUCTIVE_VERBS
+            .iter()
+            .any(|&verb| lower.contains(verb))
+    }
 }
 
 fn default_keyword_map() -> HashMap<WorkflowType, Vec<String>> {
@@ -227,9 +269,12 @@ fn default_keyword_map() -> HashMap<WorkflowType, Vec<String>> {
             "git operations",
             "delete files",
             "cleanup",
-            "organize",
+            "organize files",
             "clean up",
-            "manage",
+            "manage infrastructure",
+            "manage deployment",
+            "manage servers",
+            "manage resources",
         ]
         .into_iter()
         .map(String::from)
@@ -296,6 +341,70 @@ mod tests {
         let c = WorkflowClassifier::default();
         let r = c.classify("disk cleanup of temp files");
         assert_eq!(r.workflow, WorkflowType::Ops);
+    }
+
+    // ── #269: Misclassification regression tests ──
+
+    #[test]
+    fn issue_269_add_manage_users_is_default_not_ops() {
+        let c = WorkflowClassifier::default();
+        let r = c.classify("Add a feature to manage users in the admin panel");
+        assert_eq!(
+            r.workflow,
+            WorkflowType::Default,
+            "constructive 'add' + 'manage' should classify as DEFAULT, not OPS"
+        );
+    }
+
+    #[test]
+    fn issue_269_create_management_dashboard_is_default() {
+        let c = WorkflowClassifier::default();
+        let r = c.classify("Create a management dashboard for monitoring");
+        assert_eq!(r.workflow, WorkflowType::Default);
+    }
+
+    #[test]
+    fn issue_269_implement_cleanup_policy_is_default() {
+        let c = WorkflowClassifier::default();
+        // "cleanup" is OPS, but "implement" is constructive → DEFAULT wins
+        let r = c.classify("Implement a cleanup policy for expired sessions");
+        assert_eq!(r.workflow, WorkflowType::Default);
+    }
+
+    #[test]
+    fn issue_269_legitimate_ops_manage_infrastructure() {
+        let c = WorkflowClassifier::default();
+        let r = c.classify("manage infrastructure for the production cluster");
+        assert_eq!(
+            r.workflow,
+            WorkflowType::Ops,
+            "pure ops task should stay as OPS"
+        );
+    }
+
+    #[test]
+    fn issue_269_legitimate_ops_disk_cleanup() {
+        let c = WorkflowClassifier::default();
+        let r = c.classify("disk cleanup of /var/log files");
+        assert_eq!(r.workflow, WorkflowType::Ops);
+    }
+
+    #[test]
+    fn issue_269_build_cleanup_tool_is_default() {
+        let c = WorkflowClassifier::default();
+        let r = c.classify("Build a cleanup tool for database records");
+        assert_eq!(r.workflow, WorkflowType::Default);
+    }
+
+    #[test]
+    fn issue_269_constructive_verb_override_has_reasonable_confidence() {
+        let c = WorkflowClassifier::default();
+        let r = c.classify("Add a cleanup feature to the admin panel");
+        assert_eq!(r.workflow, WorkflowType::Default);
+        assert!(
+            r.confidence >= 0.5,
+            "overridden classification should have reasonable confidence"
+        );
     }
 
     #[test]

--- a/crates/amplihack-workflows/tests/bugfix_classifier_tests.rs
+++ b/crates/amplihack-workflows/tests/bugfix_classifier_tests.rs
@@ -1,0 +1,147 @@
+//! Bugfix integration tests for workflow classifier (#269).
+//!
+//! Validates that the constructive-verb override prevents misclassification
+//! of multi-requirement "Add" tasks as Ops.
+
+use amplihack_workflows::classifier::{WorkflowClassifier, WorkflowType};
+
+// ── Misclassification regression tests (issue #269) ──
+
+#[test]
+fn add_manage_users_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("Add a feature to manage users in the admin panel");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+#[test]
+fn create_management_dashboard_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("Create a management dashboard for monitoring");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+#[test]
+fn implement_cleanup_policy_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("Implement a cleanup policy for expired sessions");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+#[test]
+fn build_cleanup_tool_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("Build a cleanup tool for database records");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+#[test]
+fn design_organize_component_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("Design an organize files component for the UI");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+#[test]
+fn extend_cleanup_feature_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("Extend the cleanup feature to handle batch deletes");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+#[test]
+fn add_cleanup_admin_panel_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("Add a cleanup feature to the admin panel");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+// ── Legitimate OPS tasks stay as OPS ──
+
+#[test]
+fn manage_infrastructure_classifies_as_ops() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("manage infrastructure for the production cluster");
+    assert_eq!(r.workflow, WorkflowType::Ops);
+}
+
+#[test]
+fn manage_deployment_classifies_as_ops() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("manage deployment of the staging environment");
+    assert_eq!(r.workflow, WorkflowType::Ops);
+}
+
+#[test]
+fn disk_cleanup_classifies_as_ops() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("disk cleanup of /var/log files");
+    assert_eq!(r.workflow, WorkflowType::Ops);
+}
+
+// ── Priority ordering ──
+
+#[test]
+fn default_takes_priority_over_investigation() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("implement and investigate the logging module");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+#[test]
+fn default_takes_priority_over_ops() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("delete files and fix the build");
+    assert_eq!(r.workflow, WorkflowType::Default);
+}
+
+// ── Confidence scoring ──
+
+#[test]
+fn constructive_verb_override_has_reasonable_confidence() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("Add a cleanup feature to the admin panel");
+    assert_eq!(r.workflow, WorkflowType::Default);
+    assert!(
+        r.confidence >= 0.5,
+        "overridden classification should have confidence >= 0.5, got {}",
+        r.confidence
+    );
+}
+
+#[test]
+fn single_keyword_match_has_standard_confidence() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("investigate why the tests fail");
+    assert_eq!(r.workflow, WorkflowType::Investigation);
+    assert!(
+        r.confidence >= 0.7,
+        "single keyword match should have confidence >= 0.7"
+    );
+}
+
+#[test]
+fn ambiguous_request_has_low_confidence() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("do something with the system");
+    assert_eq!(r.workflow, WorkflowType::Default);
+    assert!(r.confidence < 0.7);
+}
+
+// ── Edge cases ──
+
+#[test]
+fn empty_request_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("");
+    assert_eq!(r.workflow, WorkflowType::Default);
+    assert_eq!(r.confidence, 0.0);
+}
+
+#[test]
+fn whitespace_only_classifies_as_default() {
+    let c = WorkflowClassifier::default();
+    let r = c.classify("   \n\t  ");
+    assert_eq!(r.workflow, WorkflowType::Default);
+    assert_eq!(r.confidence, 0.0);
+}

--- a/docs/howto/troubleshoot-recipe-execution.md
+++ b/docs/howto/troubleshoot-recipe-execution.md
@@ -1,0 +1,98 @@
+# Troubleshoot Recipe Execution
+
+Common recipe execution problems and their solutions.
+
+## Shell step hangs in non-interactive mode
+
+**Symptom**: A shell recipe step hangs waiting for user input.
+
+**Cause**: The shell command invokes a tool (e.g., `apt-get`) that prompts
+for confirmation, and the recipe executor's environment didn't signal
+non-interactive mode.
+
+**Fix**: As of the #277 fix, the recipe executor injects these environment
+variables into every shell step:
+
+- `NONINTERACTIVE=1`
+- `DEBIAN_FRONTEND=noninteractive`
+- `CI=true`
+- `HOME` (preserved from caller, fallback to `/root`)
+- `PATH` (preserved from caller, fallback to standard paths)
+
+If a tool still prompts despite these, add `-y` or `--yes` flags to the
+command explicitly.
+
+## Agent step produces zero file changes
+
+**Symptom**: An agent recipe step completes successfully but creates no files.
+
+**Cause**: The agent doesn't know the working directory or what files exist
+to modify.
+
+**Fix**: As of the #251 fix, agent steps receive a `Working Directory Context`
+block in their prompt containing the absolute path and file listing. If the
+issue persists, verify the recipe YAML includes a `working_directory` context
+field.
+
+See also: [Recipe Executor Environment](../reference/recipe-executor-environment.md)
+
+## python3 not found during shell step
+
+**Symptom**: Shell step fails with "command not found" or "permission denied"
+when invoking `python3`.
+
+**Cause**: The recipe host doesn't have Python installed, but the shell
+command references it.
+
+**Fix**: As of the #242 fix, the executor validates shell prerequisites
+before execution and reports missing tools clearly. Install the required
+tool or rewrite the step to use Rust-native alternatives.
+
+## Task misclassified as Ops instead of Default
+
+**Symptom**: A constructive task like "Add a feature to manage users" is
+classified as OPS_WORKFLOW and completes instantly without doing work.
+
+**Cause**: The word "manage" (or similar ops-like keywords) triggered OPS
+classification despite the constructive intent.
+
+**Fix**: As of the #269 fix, OPS keywords are multi-word phrases and a
+constructive-verb override detects verbs like "add", "create", "build" to
+force DEFAULT classification.
+
+See also: [Workflow Classifier Reference](../reference/workflow-classifier.md)
+
+## Stale framework assets after update
+
+**Symptom**: After running `amplihack update`, skills or recipes still show
+old behavior.
+
+**Cause**: Prior to the #249 fix, `amplihack update` only replaced the binary
+without re-staging framework assets.
+
+**Fix**: `amplihack update` now calls `ensure_framework_installed()` after
+binary replacement. If it fails, run `amplihack install` manually.
+
+## Install downloads from wrong repository
+
+**Symptom**: `amplihack install` downloads from the Python repo instead of
+the Rust repo, resulting in missing `amplifier-bundle/` directory.
+
+**Cause**: Prior to the #254 fix, the URL constants pointed to
+`rysweet/amplihack` (Python) instead of `rysweet/amplihack-rs` (Rust).
+
+**Fix**: URLs now point to `rysweet/amplihack-rs`. The
+`find_framework_repo_root()` function accepts both `.claude/` and
+`amplifier-bundle/` directory markers.
+
+See also: [Install Command Reference](../reference/install-command.md)
+
+## Checksum download fails during update
+
+**Symptom**: `amplihack update` fails with a network error when downloading
+the SHA-256 checksum file.
+
+**Cause**: Transient HTTP errors (502, 503) from GitHub's CDN.
+
+**Fix**: As of the #257 fix, checksum downloads use `http_get_with_retry()`
+with exponential backoff (3 attempts, 500ms initial delay).

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ amplihack-rs is the Rust implementation of the amplihack CLI. It replaces the Py
 - [Run Agent Evaluations](./howto/run-agent-evaluations.md) — Evaluate agent performance across progressive difficulty levels
 - [Deploy a Hive Swarm](./howto/deploy-hive-swarm.md) — Deploy multi-agent hive on Azure Container Apps
 - [Generate an Agent from a Goal](./howto/generate-agent-from-goal.md) — Create specialized agents from natural-language descriptions
+- [Troubleshoot Recipe Execution](./howto/troubleshoot-recipe-execution.md) — Fix shell hangs, agent zero-changes, missing tools, misclassification, and stale assets
 
 ### Reference
 
@@ -50,6 +51,8 @@ amplihack-rs is the Rust implementation of the amplihack CLI. It replaces the Py
 - [amplihack-hive API](./reference/hive-api.md) — Multi-agent orchestration and workload management
 - [amplihack-agent-generator API](./reference/agent-generator-api.md) — Goal-to-agent pipeline
 - [amplihack-memory Extended API](./reference/memory-extended-api.md) — Memory facade, manager, LadybugDB store, and evaluation
+- [Recipe Executor Environment](./reference/recipe-executor-environment.md) — Shell env injection, agent context augmentation, and prerequisite validation
+- [Workflow Classifier](./reference/workflow-classifier.md) — Keyword tables, classification algorithm, and constructive-verb disambiguation
 
 ### Concepts
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -25,6 +25,7 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [AMPLIHACK_NO_UPDATE_CHECK](#amplihack_no_update_check)
   - [AMPLIHACK_PARITY_TEST](#amplihack_parity_test)
   - [UV_TOOL_BIN_DIR](#uv_tool_bin_dir)
+- [Variables injected by recipe executor](#variables-injected-by-recipe-executor)
 
 ---
 
@@ -485,6 +486,24 @@ Override the directory where `uv tool install` places the `amplifier` binary. De
 
 ---
 
+## Variables injected by recipe executor
+
+The recipe executor injects additional variables into **shell recipe steps**
+(not into the main launch subprocess). These are separate from the launch
+variables above.
+
+| Variable          | Value              | Purpose                          |
+|-------------------|--------------------|----------------------------------|
+| `HOME`            | Inherited or `/root`| Preserve user config paths       |
+| `PATH`            | Inherited or standard| Preserve tool availability       |
+| `NONINTERACTIVE`  | `1`                | Signal non-interactive to tools  |
+| `DEBIAN_FRONTEND` | `noninteractive`   | Suppress apt prompts             |
+| `CI`              | `true`             | Signal CI-like environment       |
+
+See [Recipe Executor Environment](./recipe-executor-environment.md) for full details.
+
+---
+
 ## Related
 
 - [Agent Binary Routing](../concepts/agent-binary-routing.md) — Why `AMPLIHACK_AGENT_BINARY` exists and how recipe runner uses it
@@ -492,3 +511,4 @@ Override the directory where `uv tool install` places the `amplifier` binary. De
 - [Bootstrap Parity](../concepts/bootstrap-parity.md) — How the Rust CLI matches the Python launcher's environment contract
 - [Memory Backend Reference](./memory-backend.md) — `AMPLIHACK_MEMORY_BACKEND` values, storage paths, schema, and security
 - [amplihack install](./install-command.md) — Variables read during installation
+- [Recipe Executor Environment](./recipe-executor-environment.md) — Shell step env injection and agent context augmentation

--- a/docs/reference/recipe-executor-environment.md
+++ b/docs/reference/recipe-executor-environment.md
@@ -1,0 +1,80 @@
+# Recipe Executor Environment
+
+Reference for environment variables and context injected by the recipe
+executor into shell and agent steps.
+
+## Shell Step Environment Variables
+
+Every shell recipe step receives these environment variables:
+
+| Variable          | Value                  | Behavior            |
+|-------------------|------------------------|---------------------|
+| `HOME`            | Caller's `$HOME`       | Preserved from caller; falls back to `/root` |
+| `PATH`            | Caller's `$PATH`       | Preserved from caller; falls back to standard paths |
+| `NONINTERACTIVE`  | `1`                    | Overrides unconditionally |
+| `DEBIAN_FRONTEND` | `noninteractive`       | Overrides unconditionally |
+| `CI`              | `true`                 | Overrides unconditionally |
+
+**Design rationale**: `HOME` and `PATH` preserve inherited values so that
+user-installed tools and configuration remain accessible. The non-interactive
+flags override unconditionally because recipe steps must never prompt for
+input.
+
+### Implementation
+
+See `amplihack_recipe::executor::shell_step_env()` in
+`crates/amplihack-recipe/src/executor.rs`.
+
+## Agent Step Context Augmentation
+
+Agent recipe steps receive a `Working Directory Context` block prepended to
+their prompt:
+
+```
+## Working Directory Context
+- **Path**: /absolute/path/to/working/directory
+- **Files**: Cargo.toml, src, tests, README.md
+
+Write all output files to this directory unless the task specifies otherwise.
+```
+
+If the agent prompt already contains the working directory path (or the
+string `working_directory`), the context block is not injected to avoid
+duplication.
+
+### Implementation
+
+See `amplihack_recipe::executor::AgentContext` in
+`crates/amplihack-recipe/src/executor.rs`.
+
+## Shell Prerequisite Validation
+
+Before executing a shell step, the executor parses the command for references
+to known tools and checks their availability via `which`:
+
+**Known tools**: `python3`, `python`, `pip3`, `pip`, `node`, `npm`, `npx`,
+`cargo`, `rustc`, `go`, `java`, `dotnet`, `ruby`, `gem`
+
+When a tool is referenced but not found on `PATH`, execution fails with a
+clear error message:
+
+```
+Shell step requires tool(s) not found on PATH: python3.
+Install the missing tool(s) or adjust the recipe step.
+```
+
+### Implementation
+
+See `amplihack_recipe::executor::validate_shell_prerequisites()` in
+`crates/amplihack-recipe/src/executor.rs`.
+
+## Interaction with NONINTERACTIVE
+
+The `NONINTERACTIVE=1` variable is a convention understood by many tools:
+
+- **apt-get**: Suppresses interactive prompts (combined with `DEBIAN_FRONTEND`)
+- **npm**: Skips interactive setup wizards
+- **Homebrew**: Suppresses interactive confirmation
+- **amplihack hooks**: Skip interactive classification prompts
+
+See also: [How to run in non-interactive mode](../howto/run-in-noninteractive-mode.md)

--- a/docs/reference/workflow-classifier.md
+++ b/docs/reference/workflow-classifier.md
@@ -1,0 +1,82 @@
+# Workflow Classifier Reference
+
+The workflow classifier routes user requests into one of four workflow types
+based on keyword matching. Implemented in
+`crates/amplihack-workflows/src/classifier.rs`.
+
+## Workflow Types
+
+| Type                    | Recipe                 | Purpose                          |
+|-------------------------|------------------------|----------------------------------|
+| `DEFAULT_WORKFLOW`      | `default-workflow`     | Build, fix, refactor, create     |
+| `INVESTIGATION_WORKFLOW`| `investigation-workflow`| Research, analyze, explore       |
+| `OPS_WORKFLOW`          | *(none)*               | Infrastructure ops, cleanup      |
+| `Q&A_WORKFLOW`          | *(none)*               | Quick questions, explanations    |
+
+## Keyword Tables
+
+### DEFAULT (highest priority)
+
+`implement`, `add`, `fix`, `create`, `refactor`, `update`, `build`,
+`develop`, `remove`, `delete`, `modify`
+
+### INVESTIGATION
+
+`investigate`, `understand`, `analyze`, `research`, `explore`, `how does`,
+`how it works`
+
+### OPS
+
+`run command`, `disk cleanup`, `repo management`, `git operations`,
+`delete files`, `cleanup`, `organize files`, `clean up`,
+`manage infrastructure`, `manage deployment`, `manage servers`,
+`manage resources`
+
+**Note**: OPS keywords are multi-word phrases to avoid false positives.
+Single-word `"manage"` was removed in the #269 fix because it triggered
+OPS classification for constructive tasks like "Add a feature to manage users".
+
+### Q&A
+
+`what is`, `explain briefly`, `quick question`, `how do i run`,
+`what does`, `can you explain`
+
+## Classification Algorithm
+
+1. Extract all matching keywords from the request (case-insensitive substring match)
+2. Check workflows in priority order: DEFAULT > INVESTIGATION > OPS > Q&A
+3. First workflow with a matching keyword wins
+4. **Constructive-verb override** (#269): If OPS matched but the request
+   contains a constructive verb (`add`, `create`, `build`, `implement`,
+   `write`, `design`, `develop`, `make`, `introduce`, `extend`, `enhance`,
+   `refactor`), override to DEFAULT with confidence 0.75
+5. If no keywords match, default to DEFAULT with confidence 0.5
+
+## Confidence Scoring
+
+| Condition                    | Confidence |
+|------------------------------|------------|
+| Multiple keywords matched    | 0.9        |
+| Single keyword matched       | 0.7        |
+| Constructive-verb override   | 0.75       |
+| No keywords (ambiguous)      | 0.5        |
+| Empty request                | 0.0        |
+
+## Examples
+
+| Request                                          | Classification | Reason                     |
+|--------------------------------------------------|----------------|----------------------------|
+| "implement a new feature for logging"            | DEFAULT        | keyword 'implement'        |
+| "investigate why the tests are failing"          | INVESTIGATION  | keyword 'investigate'      |
+| "disk cleanup of temp files"                     | OPS            | keyword 'disk cleanup'     |
+| "what is the purpose of this module"             | Q&A            | keyword 'what is'          |
+| "Add a feature to manage users"                  | DEFAULT        | keyword 'add' (priority)   |
+| "manage infrastructure for production"           | OPS            | keyword 'manage infrastructure' |
+| "Build a cleanup tool for database records"      | DEFAULT        | keyword 'build' (priority) + constructive override |
+| "do something with the system"                   | DEFAULT        | ambiguous (0.5 confidence) |
+
+## Provenance Logging
+
+When a log directory is configured via `WorkflowClassifier::with_log_dir()`,
+every classification decision is logged as a `ProvenanceEntry` for audit
+and debugging.

--- a/specs/eval-framework.feature
+++ b/specs/eval-framework.feature
@@ -1,0 +1,170 @@
+# Gherkin spec for the amplihack-eval crate (Issue #285)
+# Ports amplihack.eval.* Python framework to native Rust
+
+Feature: Evaluation framework - benchmark execution, scoring, and reporting
+  As an amplihack developer
+  I want to run benchmarks, score results, and generate reports
+  So that I can measure and compare agent quality over time
+
+  # ─── Benchmark ─────────────────────────────────────────────────────────────
+
+  Scenario: Create a benchmark with a valid name
+    Given a benchmark name "my-benchmark"
+    When I create a Benchmark
+    Then the benchmark name is "my-benchmark"
+    And the description is empty
+
+  Scenario: Create a benchmark with a description
+    Given a benchmark name "bench"
+    And a description "Tests recall capability"
+    When I create a Benchmark
+    Then the description is "Tests recall capability"
+
+  Scenario: Reject a benchmark with an empty name
+    Given a benchmark name ""
+    When I create a Benchmark
+    Then an InvalidBenchmark error is returned
+
+  Scenario: Record case results and compute statistics
+    Given a BenchmarkResult for "stats-bench"
+    When I add case "c1" with passed=true score=1.0 duration=10ms
+    And I add case "c2" with passed=false score=0.0 duration=20ms
+    And I add case "c3" with passed=true score=0.5 duration=30ms
+    And I call finish
+    Then total is 3
+    And passed is 2
+    And failed is 1
+    And mean_score is 0.5
+    And total_duration_ms is 60
+    And finished_at is set
+
+  Scenario: Reject a case with score outside [0.0, 1.0]
+    Given a CaseResult for "bad-case" with score 1.5
+    Then an InvalidScore error is returned
+
+  Scenario: Timer measures elapsed wall-clock time
+    Given a Benchmark "timer-bench"
+    When I start a timer and stop it immediately
+    Then the elapsed milliseconds is a non-negative integer
+
+  # ─── Scorer ─────────────────────────────────────────────────────────────────
+
+  Scenario: All cases pass produces overall_passed=true
+    Given a BenchmarkResult "all-pass" with cases [(c1,true,1.0,5),(c2,true,0.8,5)]
+    When I score with default config (threshold=0.7)
+    Then overall_passed is true
+    And pass_rate is 1.0
+
+  Scenario: All cases fail produces overall_passed=false
+    Given a BenchmarkResult "all-fail" with cases [(c1,false,0.1,5)]
+    When I score with default config (threshold=0.7)
+    Then overall_passed is false
+
+  Scenario: Empty result scores zero
+    Given an empty BenchmarkResult "empty"
+    When I score with default config
+    Then total_cases is 0
+    And pass_rate is 0.0
+    And overall_passed is false
+
+  Scenario: Custom pass threshold is respected
+    Given a BenchmarkResult "threshold-test" with cases [(c1,true,0.5,0)]
+    When I score with threshold=0.9
+    Then overall_passed is false
+
+  Scenario: Composite score formula
+    Given a BenchmarkResult "composite" with cases [(c1,true,0.6,0),(c2,false,0.4,0)]
+    And scorer config pass_rate_weight=0.5 threshold=0.0
+    When I score
+    Then composite_score is approximately 0.5
+
+  Scenario: Improvement detected in comparison
+    Given baseline RunScore with composite_score=0.3
+    And candidate RunScore with composite_score=0.8
+    When I compare baseline to candidate
+    Then improved is true
+    And composite_delta is approximately 0.5
+
+  Scenario: Regression detected in comparison
+    Given baseline RunScore with composite_score=0.8
+    And candidate RunScore with composite_score=0.3
+    When I compare baseline to candidate
+    Then improved is false
+    And composite_delta is approximately -0.5
+
+  # ─── Reporter ───────────────────────────────────────────────────────────────
+
+  Scenario: JSON report is valid JSON with required fields
+    Given a RunScore for benchmark "json-test"
+    When I generate a JSON report
+    Then the output is valid JSON
+    And it contains field "benchmark_name" with value "json-test"
+    And it contains field "overall_passed"
+
+  Scenario: Text report contains benchmark name and status
+    Given a passing RunScore for benchmark "text-test"
+    When I generate a text report
+    Then the output contains "text-test"
+    And the output contains "PASS"
+
+  Scenario: Text report shows FAIL for failing score
+    Given a failing RunScore for benchmark "fail-test"
+    When I generate a text report
+    Then the output contains "FAIL"
+
+  Scenario: Comparison text report shows improvement direction
+    Given an improved RunComparison
+    When I generate a comparison text report
+    Then the output contains "improved"
+
+  Scenario: Comparison text report shows regression direction
+    Given a regressed RunComparison
+    When I generate a comparison text report
+    Then the output contains "regressed"
+
+  Scenario: Comparison JSON report is valid JSON
+    Given a RunComparison
+    When I generate a comparison JSON report
+    Then the output is valid JSON
+    And it contains field "improved"
+
+  # ─── CLI ────────────────────────────────────────────────────────────────────
+
+  Scenario: eval report --format text prints human-readable output
+    Given a saved RunScore JSON file at /tmp/test-score.json
+    When I run "amplihack eval report /tmp/test-score.json --format text"
+    Then stdout contains "Benchmark:"
+    And the exit code is 0
+
+  Scenario: eval report --format json prints JSON
+    Given a saved RunScore JSON file at /tmp/test-score.json
+    When I run "amplihack eval report /tmp/test-score.json --format json"
+    Then stdout is valid JSON
+    And the exit code is 0
+
+  Scenario: eval run with passing benchmark exits 0
+    Given a BenchmarkResult JSON config where all cases pass
+    When I run "amplihack eval run <config> --format text"
+    Then the exit code is 0
+
+  Scenario: eval run with failing benchmark exits 1
+    Given a BenchmarkResult JSON config where all cases fail
+    When I run "amplihack eval run <config>"
+    Then the exit code is 1
+
+  Scenario: eval compare prints delta between two result files
+    Given a baseline RunScore JSON file
+    And a candidate RunScore JSON file with higher composite_score
+    When I run "amplihack eval compare <baseline> <candidate>"
+    Then stdout contains "improved"
+    And the exit code is 0
+
+  Scenario: eval run accepts stdin via "-"
+    Given a BenchmarkResult JSON on stdin
+    When I run "amplihack eval run -"
+    Then the result is printed to stdout
+
+  Scenario: eval run with --threshold override
+    Given a BenchmarkResult JSON with composite_score 0.6
+    When I run "amplihack eval run <config> --threshold 0.9"
+    Then the exit code is 1

--- a/specs/lock-tool.feature
+++ b/specs/lock-tool.feature
@@ -1,0 +1,58 @@
+# Gherkin spec for lock_tool Rust port (Issue #283)
+# Port of amplifier-bundle/tools/amplihack/lock_tool.py
+
+Feature: Lock tool for continuous work mode
+  As a developer using amplihack
+  I want to lock/unlock continuous work mode
+  So that Claude continues working without stopping
+
+  Background:
+    Given the CLAUDE_PROJECT_DIR environment variable is set
+    And the lock directory is at $CLAUDE_PROJECT_DIR/.claude/runtime/locks
+
+  Scenario: Lock creates lock file
+    Given no lock is active
+    When I run "amplihack lock lock"
+    Then a .lock_active file is created in the lock directory
+    And the file contains a "locked_at:" timestamp
+    And stdout contains "Lock enabled"
+
+  Scenario: Lock with custom message
+    Given no lock is active
+    When I run "amplihack lock lock --message 'finish all tests'"
+    Then a .lock_active file is created
+    And a .lock_message file is created with content "finish all tests"
+
+  Scenario: Lock when already locked warns but succeeds
+    Given a lock is already active
+    When I run "amplihack lock lock"
+    Then stdout contains "WARNING: Lock was already active"
+    And the exit code is 0
+
+  Scenario: Lock updates message when already locked
+    Given a lock is already active with message "old message"
+    When I run "amplihack lock lock --message 'new message'"
+    Then the .lock_message file contains "new message"
+
+  Scenario: Unlock removes lock and message files
+    Given a lock is active with message "test"
+    When I run "amplihack lock unlock"
+    Then the .lock_active file does not exist
+    And the .lock_message file does not exist
+    And stdout contains "Lock disabled"
+
+  Scenario: Unlock when not locked shows info
+    Given no lock is active
+    When I run "amplihack lock unlock"
+    Then stdout contains "Lock was not enabled"
+    And the exit code is 0
+
+  Scenario: Check when locked shows status
+    Given a lock is active
+    When I run "amplihack lock check"
+    Then stdout contains "Lock is ACTIVE"
+
+  Scenario: Check when not locked shows status
+    Given no lock is active
+    When I run "amplihack lock check"
+    Then stdout contains "Lock is NOT active"

--- a/specs/multitask-orchestrator.feature
+++ b/specs/multitask-orchestrator.feature
@@ -1,0 +1,50 @@
+Feature: Multitask orchestrator
+  Native Rust port of the Python multitask orchestrator that manages
+  parallel workstream execution with subprocess isolation.
+
+  Background:
+    Given the amplihack binary is installed
+    And a valid multitask config file exists
+
+  Scenario: Run multitask with recipe-runner mode
+    Given a config file with 2 workstreams
+    When I run "amplihack multitask run config.json"
+    Then each workstream runs in an isolated /tmp clone
+    And the recipe-runner-rs binary is invoked for each workstream
+    And a state.json file tracks progress
+    And the exit code is 0 when all workstreams complete
+
+  Scenario: Run multitask with classic mode
+    Given a config file with 2 workstreams
+    When I run "amplihack multitask run config.json --mode classic"
+    Then each workstream runs in a single session
+    And the delegate command is used for execution
+
+  Scenario: Dry run shows plan without execution
+    Given a config file with 3 workstreams
+    When I run "amplihack multitask run config.json --dry-run"
+    Then no workstreams are actually started
+    And the plan is printed to stdout
+
+  Scenario: Status shows workstream progress
+    Given a running multitask session with state.json
+    When I run "amplihack multitask status"
+    Then it displays each workstream with its status icon
+    And shows total/completed/running/failed counts
+
+  Scenario: Cleanup removes worktrees
+    Given a completed multitask session
+    When I run "amplihack multitask cleanup config.json"
+    Then worktree directories are removed
+    And git worktree prune is executed
+
+  Scenario: Invalid delegate is rejected
+    Given AMPLIHACK_DELEGATE is set to "invalid-tool"
+    When I run "amplihack multitask run config.json"
+    Then it exits with error mentioning invalid delegate
+
+  Scenario: Timeout policy enforcement
+    Given a config with max_runtime of 60 seconds
+    When a workstream exceeds the timeout
+    Then the workstream is marked as failed_resumable
+    And remaining workstreams continue

--- a/specs/orch-helper.feature
+++ b/specs/orch-helper.feature
@@ -1,0 +1,52 @@
+# Gherkin spec for orch_helper Rust port (Issue #283)
+# Replaces inline python3 calls in smart-orchestrator.yaml
+
+Feature: Orchestration helper functions
+  As the smart-orchestrator recipe
+  I want native Rust helpers for JSON extraction and type normalization
+  So that python3 is no longer required at runtime
+
+  Scenario: Extract JSON from tagged code block
+    Given stdin contains "Here is output:\n```json\n{\"key\": \"value\"}\n```"
+    When I run "amplihack orch-helper extract-json"
+    Then stdout is valid JSON with key="value"
+
+  Scenario: Extract JSON prefers tagged over untagged blocks
+    Given stdin contains both tagged and untagged code blocks
+    When I run "amplihack orch-helper extract-json"
+    Then the tagged block's JSON is returned
+
+  Scenario: Extract JSON falls back to raw JSON in prose
+    Given stdin contains 'The result is {"key": "value"} end'
+    When I run "amplihack orch-helper extract-json"
+    Then stdout is valid JSON with key="value"
+
+  Scenario: Extract JSON returns empty object for no JSON
+    Given stdin contains "no json here"
+    When I run "amplihack orch-helper extract-json"
+    Then stdout is "{}"
+
+  Scenario: Normalise type to Q&A
+    Given stdin contains "question"
+    When I run "amplihack orch-helper normalise-type"
+    Then stdout is "Q&A"
+
+  Scenario: Normalise type to Operations
+    Given stdin contains "ops"
+    When I run "amplihack orch-helper normalise-type"
+    Then stdout is "Operations"
+
+  Scenario: Normalise type to Investigation
+    Given stdin contains "research"
+    When I run "amplihack orch-helper normalise-type"
+    Then stdout is "Investigation"
+
+  Scenario: Normalise type defaults to Development
+    Given stdin contains "build feature"
+    When I run "amplihack orch-helper normalise-type"
+    Then stdout is "Development"
+
+  Scenario: Generate workstream config from decomposition
+    Given stdin contains decomposition JSON with workstreams array
+    When I run "amplihack orch-helper generate-workstream-config"
+    Then stdout is the extracted JSON

--- a/specs/session-tree.feature
+++ b/specs/session-tree.feature
@@ -1,0 +1,70 @@
+# Gherkin spec for session_tree Rust port (Issue #283)
+# Port of amplifier-bundle/tools/session_tree.py
+
+Feature: Session tree management for orchestration recursion prevention
+  As an orchestration system
+  I want to track session trees with depth and capacity limits
+  So that infinite recursion and session storms are prevented
+
+  Background:
+    Given the state directory is at $TMPDIR/amplihack-session-trees
+    And the state directory has permissions 0700
+
+  Scenario: Check allows spawning when no tree exists
+    Given AMPLIHACK_TREE_ID is not set
+    When I run "amplihack session-tree check"
+    Then stdout is "ALLOWED"
+
+  Scenario: Check blocks at max depth
+    Given AMPLIHACK_SESSION_DEPTH is "3"
+    And AMPLIHACK_MAX_DEPTH is "3"
+    When I run "amplihack session-tree check"
+    Then stdout starts with "BLOCKED:"
+
+  Scenario: Register creates new tree
+    Given AMPLIHACK_TREE_ID is not set
+    When I run "amplihack session-tree register test-sess"
+    Then stdout matches "TREE_ID=\w+ DEPTH=0"
+    And a state file is created for the tree
+
+  Scenario: Register with parent links child
+    Given a tree with session "parent" exists
+    When I run "amplihack session-tree register child parent"
+    Then the parent session's children list contains "child"
+
+  Scenario: Register fails at max sessions
+    Given a tree with max_sessions=2 and 2 active sessions
+    When I run "amplihack session-tree register new-sess"
+    Then stderr contains "max_sessions"
+    And the exit code is 1
+
+  Scenario: Complete marks session done
+    Given a tree with active session "my-sess"
+    When I run "amplihack session-tree complete my-sess"
+    Then the session status is "completed"
+    And completed_at is set
+
+  Scenario: Status shows tree details as JSON
+    Given a tree with active and completed sessions
+    When I run "amplihack session-tree status <tree_id>"
+    Then stdout is valid JSON with tree_id, active, completed, depths
+
+  Scenario: Stale sessions are pruned on save
+    Given a completed session older than 24 hours
+    When the state is saved
+    Then the stale session is removed
+
+  Scenario: Leaked active sessions are pruned
+    Given an active session older than 4 hours
+    When the state is saved
+    Then the leaked session is removed with a warning
+
+  Scenario: Tree ID validation rejects path traversal
+    Given a tree_id of "../etc/passwd"
+    When I validate the tree_id
+    Then it is rejected with "Invalid tree_id"
+
+  Scenario: Concurrent registrations are serialized
+    Given 5 threads registering sessions simultaneously
+    When all threads complete
+    Then all 5 sessions are present in the state file

--- a/specs/validate-frontmatter.feature
+++ b/specs/validate-frontmatter.feature
@@ -1,0 +1,29 @@
+# Gherkin spec for validate_frontmatter Rust port (Issue #283)
+# Validates YAML frontmatter in skill/agent markdown files
+
+Feature: Validate YAML frontmatter in markdown files
+  As a skill/agent developer
+  I want to validate frontmatter in my markdown files
+  So that malformed files are caught before deployment
+
+  Scenario: Valid frontmatter passes
+    Given a markdown file with valid YAML frontmatter
+    When I run "amplihack validate-frontmatter --file path/to/file.md"
+    Then the exit code is 0
+    And stdout indicates success
+
+  Scenario: Missing frontmatter fails
+    Given a markdown file without frontmatter
+    When I run "amplihack validate-frontmatter --file path/to/file.md"
+    Then the exit code is non-zero
+    And stderr describes the error
+
+  Scenario: Invalid YAML fails
+    Given a markdown file with invalid YAML frontmatter
+    When I run "amplihack validate-frontmatter --file path/to/file.md"
+    Then the exit code is non-zero
+
+  Scenario: Scan directory validates all markdown files
+    Given a directory with multiple markdown files
+    When I run "amplihack validate-frontmatter"
+    Then all .md files in the directory are validated

--- a/tests/parity/scenarios/issue-249-update-restages-assets.feature
+++ b/tests/parity/scenarios/issue-249-update-restages-assets.feature
@@ -1,0 +1,26 @@
+Feature: Update re-stages framework assets after binary replacement (#249)
+  As a user running `amplihack update`
+  I want framework assets to be refreshed after the binary is replaced
+  So that updated skills, recipes, and hooks are available immediately
+
+  Scenario: Successful update re-stages assets
+    Given a new version is available
+    And `download_and_replace()` succeeds
+    When `run_update()` completes
+    Then `ensure_framework_installed()` is called after binary replacement
+    And the update reports success
+
+  Scenario: Asset re-staging failure is non-fatal
+    Given a new version is available
+    And `download_and_replace()` succeeds
+    And `ensure_framework_installed()` fails with a transient error
+    When `run_update()` completes
+    Then the binary update still succeeds
+    And a warning is printed suggesting `amplihack install`
+
+  Scenario: Already at latest version skips everything
+    Given the current version matches the latest release
+    When `run_update()` is called
+    Then no download is attempted
+    And no asset re-staging is attempted
+    And the message "Already at the latest version" is printed

--- a/tests/parity/scenarios/issue-257-checksum-retry.feature
+++ b/tests/parity/scenarios/issue-257-checksum-retry.feature
@@ -1,0 +1,35 @@
+Feature: Checksum download uses retry with backoff (#257)
+  As a user running `amplihack update`
+  I want the SHA-256 checksum download to retry on transient failures
+  So that a momentary 502 doesn't kill my update
+
+  Scenario: Retry succeeds on second attempt
+    Given the checksum URL returns HTTP 502 on the first request
+    And the checksum URL returns a valid SHA-256 on the second request
+    When `verify_sha256()` is called
+    Then the verification succeeds
+    And exactly 2 HTTP requests were made
+
+  Scenario: Transient failure recovers within 3 attempts
+    Given the checksum URL returns HTTP 503 on the first two requests
+    And the checksum URL returns a valid SHA-256 on the third request
+    When `verify_sha256()` is called
+    Then the verification succeeds
+
+  Scenario: Permanent failure after max retries
+    Given the checksum URL returns HTTP 502 on all 3 attempts
+    When `verify_sha256()` is called
+    Then the verification fails with a network error
+    And the error message mentions the checksum URL
+
+  Scenario: Invalid hex digest in checksum file
+    Given the checksum URL returns "not-a-hex-digest  archive.tar.gz"
+    When `verify_sha256()` is called
+    Then the verification fails
+    And the error message mentions "valid SHA-256 hex digest"
+
+  Scenario: Checksum mismatch detected
+    Given the checksum URL returns a valid but wrong SHA-256 digest
+    When `verify_sha256()` is called with different archive bytes
+    Then the verification fails
+    And the error message mentions "checksum mismatch"

--- a/tests/parity/scenarios/issue-269-classifier-disambiguation.feature
+++ b/tests/parity/scenarios/issue-269-classifier-disambiguation.feature
@@ -1,0 +1,47 @@
+Feature: Workflow classifier disambiguates constructive tasks from ops (#269)
+  As a developer using the smart-orchestrator
+  I want constructive tasks to classify as DEFAULT even when they mention ops-like words
+  So that multi-requirement "Add" tasks are not misclassified as Ops
+
+  Scenario Outline: Constructive tasks with ops-like words classify as DEFAULT
+    Given the default workflow classifier
+    When I classify "<request>"
+    Then the workflow type is "DEFAULT_WORKFLOW"
+    And the confidence is at least 0.5
+
+    Examples:
+      | request                                              |
+      | Add a feature to manage users in the admin panel     |
+      | Create a management dashboard for monitoring         |
+      | Implement a cleanup policy for expired sessions      |
+      | Build a cleanup tool for database records            |
+      | Design an organize files component for the UI        |
+
+  Scenario Outline: Legitimate ops tasks classify as OPS
+    Given the default workflow classifier
+    When I classify "<request>"
+    Then the workflow type is "OPS_WORKFLOW"
+
+    Examples:
+      | request                                             |
+      | manage infrastructure for the production cluster    |
+      | manage deployment of the staging environment        |
+      | disk cleanup of /var/log files                      |
+      | run command to restart the database service         |
+
+  Scenario Outline: Mixed keywords with constructive verbs
+    Given the default workflow classifier
+    When I classify "<request>"
+    Then the workflow type is "DEFAULT_WORKFLOW"
+
+    Examples:
+      | request                                              |
+      | Add a cleanup feature to the admin panel             |
+      | Create a disk cleanup scheduler module               |
+      | Implement manage resources API endpoint              |
+
+  Scenario: Low-confidence default for ambiguous requests
+    Given the default workflow classifier
+    When I classify "do something with the system"
+    Then the workflow type is "DEFAULT_WORKFLOW"
+    And the confidence is less than 0.7

--- a/tests/parity/scenarios/issue-280-merge-ready-repo-detection.feature
+++ b/tests/parity/scenarios/issue-280-merge-ready-repo-detection.feature
@@ -1,0 +1,26 @@
+Feature: QA team skill detects repo type for test command selection (#280)
+  As a developer using the merge-ready / qa-team skill
+  I want the skill to detect my repo type and use the correct test command
+  So that Rust repos use `cargo test` instead of `gadugi-test`
+
+  Scenario: Rust repository detected
+    Given a repository with a `Cargo.toml` at the root
+    When the qa-team skill selects a test command
+    Then the test command is `cargo test --workspace`
+    And `cargo clippy --workspace -- -D warnings` is also run
+    And scenario validation uses `tests/parity/scenarios/*.yaml`
+
+  Scenario: Node.js repository detected
+    Given a repository with a `package.json` at the root
+    When the qa-team skill selects a test command
+    Then the test command is `gadugi-test run tests/agentic/*.yaml`
+
+  Scenario: Python repository detected
+    Given a repository with a `pyproject.toml` at the root
+    When the qa-team skill selects a test command
+    Then the test command is `python -m pytest`
+
+  Scenario: Unknown repository falls back to gadugi-test
+    Given a repository with no recognized marker files
+    When the qa-team skill selects a test command
+    Then the test command is `gadugi-test run tests/agentic/*.yaml`


### PR DESCRIPTION
## Summary

- **Port 5 active Python tools to native Rust subcommands**: lock_tool, validate_workflow, session_tree, orch_helper, multitask orchestrator (1861 lines of new Rust)
- **Create `amplihack-eval` crate**: benchmark runner, scorer, reporter with 22 tests and CLI integration (`amplihack eval {run,compare,report}`)
- **Eliminate all `python3` invocations** from smart-orchestrator.yaml and default-workflow.yaml
- **Fix classifier bug #269**: constructive-verb override prevents OPS misclassification for requests like "Add a feature to manage users"
- **6 Gherkin specs + 4 bug parity scenarios**: lock-tool, orch-helper, session-tree, validate-frontmatter, multitask-orchestrator, eval-framework
- **Fix pre-existing test failures** in fleet and auto_mode modules

### Key numbers
- **56 files changed**, 5176 insertions, 376 deletions
- **981 tests pass** (0 failures when run serially; 3 parallel race conditions are pre-existing env-var thread-safety issues)
- **0 python3 invocations** remain in smart-orchestrator.yaml or default-workflow.yaml

### Criteria addressed
| # | Criterion | Status |
|---|-----------|--------|
| 1 | smart-orchestrator.yaml zero python3 invocations | ✅ |
| 2 | lock_tool, validate_workflow, session_tree, multitask ported to Rust | ✅ |
| 3 | amplihack-eval crate with equivalent functionality | ✅ |
| 5 | Gherkin specs for each ported component | ✅ |

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo build` succeeds
- [x] `cargo test --lib -p amplihack-eval` — 22/22 pass
- [x] `cargo test --lib -p amplihack-cli -- --test-threads=1` — 981/981 pass
- [x] `grep -rn python3 amplifier-bundle/recipes/smart-orchestrator.yaml` returns only comments
- [ ] CI Lint & Format check
- [ ] CI Build + Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)