### PR TITLE
fix(cli): resolve AMPLIHACK_GRAPH_DB path against HOME instead of cwd

### DIFF
--- a/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
@@ -156,9 +156,13 @@ fn test_execute_recipe_via_rust_propagates_asset_resolver_env() {
             amplihack_home.to_string_lossy().into_owned()
         ))
     );
+    let expected_graph = temp.path().join(".amplihack").join("graph_db");
     assert_eq!(
         result.context.get("graph"),
-        Some(&JsonValue::String("/custom/graph".to_string()))
+        Some(&JsonValue::String(
+            expected_graph.to_string_lossy().into_owned()
+        )),
+        "explicit project_root (temp dir) must win over inherited AMPLIHACK_GRAPH_DB_PATH (issue #250)"
     );
     assert_eq!(
         result.context.get("legacy_graph_alias"),

--- a/crates/amplihack-cli/src/env_builder/builder.rs
+++ b/crates/amplihack-cli/src/env_builder/builder.rs
@@ -1,7 +1,7 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::helpers::{
@@ -128,61 +128,16 @@ impl EnvBuilder {
 
     /// Set the backend-neutral code-graph DB path for child processes.
     ///
-    /// Prefer an existing backend-neutral `AMPLIHACK_GRAPH_DB_PATH`, then accept
-    /// a legacy `AMPLIHACK_KUZU_DB_PATH` as input-only compatibility. Child
-    /// processes receive `AMPLIHACK_GRAPH_DB_PATH` and have the legacy alias
-    /// explicitly removed so the neutral contract is what propagates forward.
+    /// The explicit `project_root` argument is authoritative — it always wins
+    /// over any inherited `AMPLIHACK_GRAPH_DB_PATH` / `AMPLIHACK_KUZU_DB_PATH`
+    /// in the parent environment (issue #250). The legacy alias is unset so
+    /// only the neutral contract propagates forward.
     pub fn with_project_graph_db(self, project_root: &Path) -> Result<Self> {
         debug_assert!(
             project_root.is_absolute(),
             "project_root must be an absolute path; got: {}",
             project_root.display()
         );
-        fn validate_graph_db_path(candidate: &str, env_var: &str) -> Result<String> {
-            let path = Path::new(candidate);
-            if !path.is_absolute() {
-                bail!(
-                    "invalid {env_var} override: graph DB path must be absolute: {}",
-                    path.display()
-                );
-            }
-            if path
-                .components()
-                .any(|component| matches!(component, Component::ParentDir))
-            {
-                bail!(
-                    "invalid {env_var} override: graph DB path must not contain parent traversal: {}",
-                    path.display()
-                );
-            }
-            for blocked in [Path::new("/proc"), Path::new("/sys"), Path::new("/dev")] {
-                if path.starts_with(blocked) {
-                    bail!(
-                        "invalid {env_var} override: graph DB path uses blocked prefix {}: {}",
-                        blocked.display(),
-                        path.display()
-                    );
-                }
-            }
-            Ok(candidate.to_string())
-        }
-
-        if let Ok(existing) = env::var("AMPLIHACK_GRAPH_DB_PATH")
-            && !existing.is_empty()
-        {
-            let existing = validate_graph_db_path(&existing, "AMPLIHACK_GRAPH_DB_PATH")?;
-            return Ok(self
-                .unset("AMPLIHACK_KUZU_DB_PATH")
-                .set("AMPLIHACK_GRAPH_DB_PATH", existing));
-        }
-        if let Ok(existing) = env::var("AMPLIHACK_KUZU_DB_PATH")
-            && !existing.is_empty()
-        {
-            let existing = validate_graph_db_path(&existing, "AMPLIHACK_KUZU_DB_PATH")?;
-            return Ok(self
-                .unset("AMPLIHACK_KUZU_DB_PATH")
-                .set("AMPLIHACK_GRAPH_DB_PATH", existing));
-        }
 
         let path = project_root.join(".amplihack").join("graph_db");
         let path = path.to_string_lossy().into_owned();

--- a/crates/amplihack-cli/src/env_builder/tests_builder.rs
+++ b/crates/amplihack-cli/src/env_builder/tests_builder.rs
@@ -69,8 +69,10 @@ fn with_project_graph_db_sets_project_local_path() {
     assert_eq!(env.get("AMPLIHACK_KUZU_DB_PATH").map(String::as_str), None);
 }
 
+/// Issue #250: explicit `project_root` is authoritative — an inherited
+/// `AMPLIHACK_KUZU_DB_PATH` legacy alias must NOT override the derived path.
 #[test]
-fn with_project_graph_db_preserves_existing_override() {
+fn with_project_graph_db_ignores_inherited_legacy_kuzu_alias() {
     let _guard = cwd_env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -94,18 +96,20 @@ fn with_project_graph_db_preserves_existing_override() {
         None => unsafe { std::env::remove_var("AMPLIHACK_KUZU_DB_PATH") },
     }
 
+    let expected = temp.path().join(".amplihack").join("graph_db");
     assert_eq!(
         env.get("AMPLIHACK_GRAPH_DB_PATH").map(String::as_str),
-        Some("/custom/legacy-graph-alias")
+        Some(expected.to_str().unwrap()),
+        "explicit project_root must win over inherited AMPLIHACK_KUZU_DB_PATH"
     );
     assert_eq!(env.get("AMPLIHACK_KUZU_DB_PATH").map(String::as_str), None);
 }
 
-/// I77-ENV-GRAPH-ONLY: When only AMPLIHACK_GRAPH_DB_PATH is set,
-/// with_project_graph_db() must preserve the backend-neutral name and avoid
-/// re-emitting the legacy Kuzu alias into child process overrides.
+/// Issue #250: explicit `project_root` is authoritative — an inherited
+/// `AMPLIHACK_GRAPH_DB_PATH` must NOT override the derived path. Legacy
+/// alias is still removed so only the neutral contract propagates.
 #[test]
-fn with_project_graph_db_preserves_graph_db_env_without_emitting_legacy_alias() {
+fn with_project_graph_db_ignores_inherited_graph_db_env() {
     let _guard = cwd_env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -129,10 +133,11 @@ fn with_project_graph_db_preserves_graph_db_env_without_emitting_legacy_alias() 
         None => unsafe { std::env::remove_var("AMPLIHACK_KUZU_DB_PATH") },
     }
 
+    let expected = temp.path().join(".amplihack").join("graph_db");
     assert_eq!(
         env.get("AMPLIHACK_GRAPH_DB_PATH").map(String::as_str),
-        Some("/custom/graph-only"),
-        "AMPLIHACK_GRAPH_DB_PATH must be preserved from the process environment"
+        Some(expected.to_str().unwrap()),
+        "explicit project_root must win over inherited AMPLIHACK_GRAPH_DB_PATH"
     );
     assert_eq!(
         env.get("AMPLIHACK_KUZU_DB_PATH").map(String::as_str),
@@ -141,8 +146,10 @@ fn with_project_graph_db_preserves_graph_db_env_without_emitting_legacy_alias() 
     );
 }
 
+/// Issue #250: when both legacy and neutral envs are set in the parent process,
+/// the explicit `project_root` still wins; the legacy alias is unset.
 #[test]
-fn with_project_graph_db_prefers_backend_neutral_override() {
+fn with_project_graph_db_ignores_both_inherited_envs() {
     let _guard = cwd_env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -166,27 +173,44 @@ fn with_project_graph_db_prefers_backend_neutral_override() {
         None => unsafe { std::env::remove_var("AMPLIHACK_KUZU_DB_PATH") },
     }
 
+    let expected = temp.path().join(".amplihack").join("graph_db");
     assert_eq!(
         env.get("AMPLIHACK_GRAPH_DB_PATH").map(String::as_str),
-        Some("/custom/graph")
+        Some(expected.to_str().unwrap()),
+        "explicit project_root must win over both inherited envs"
     );
     assert_eq!(env.get("AMPLIHACK_KUZU_DB_PATH").map(String::as_str), None);
 }
 
+/// Issue #250: bogus inherited env values (relative, /proc-prefixed, traversal)
+/// are ignored entirely — `with_project_graph_db` never reads them, so they
+/// can never cause errors or leak into child processes.
 #[test]
-fn with_project_graph_db_rejects_relative_graph_override() {
+fn with_project_graph_db_ignores_bogus_inherited_envs() {
     let _guard = cwd_env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let temp = tempfile::tempdir().unwrap();
     let prev_graph = std::env::var_os("AMPLIHACK_GRAPH_DB_PATH");
     let prev = std::env::var_os("AMPLIHACK_KUZU_DB_PATH");
-    unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", "relative/graph_db") };
-    unsafe { std::env::remove_var("AMPLIHACK_KUZU_DB_PATH") };
 
-    let error = EnvBuilder::new()
-        .with_project_graph_db(temp.path())
-        .unwrap_err();
+    for bogus in &["relative/graph_db", "/proc/1/mem", "/tmp/../etc/shadow"] {
+        unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", bogus) };
+        unsafe { std::env::set_var("AMPLIHACK_KUZU_DB_PATH", bogus) };
+
+        let env = EnvBuilder::new()
+            .with_project_graph_db(temp.path())
+            .expect("bogus inherited env must NOT cause an error")
+            .build();
+
+        let expected = temp.path().join(".amplihack").join("graph_db");
+        assert_eq!(
+            env.get("AMPLIHACK_GRAPH_DB_PATH").map(String::as_str),
+            Some(expected.to_str().unwrap()),
+            "bogus inherited env {bogus:?} must not leak into child override"
+        );
+        assert_eq!(env.get("AMPLIHACK_KUZU_DB_PATH").map(String::as_str), None);
+    }
 
     match prev_graph {
         Some(v) => unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", v) },
@@ -196,68 +220,6 @@ fn with_project_graph_db_rejects_relative_graph_override() {
         Some(v) => unsafe { std::env::set_var("AMPLIHACK_KUZU_DB_PATH", v) },
         None => unsafe { std::env::remove_var("AMPLIHACK_KUZU_DB_PATH") },
     }
-
-    let rendered = format!("{error:#}");
-    assert!(rendered.contains("invalid AMPLIHACK_GRAPH_DB_PATH override"));
-    assert!(rendered.contains("graph DB path must be absolute"));
-}
-
-#[test]
-fn with_project_graph_db_rejects_proc_prefixed_graph_override() {
-    let _guard = cwd_env_lock()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let temp = tempfile::tempdir().unwrap();
-    let prev_graph = std::env::var_os("AMPLIHACK_GRAPH_DB_PATH");
-    let prev = std::env::var_os("AMPLIHACK_KUZU_DB_PATH");
-    unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", "/proc/1/mem") };
-    unsafe { std::env::remove_var("AMPLIHACK_KUZU_DB_PATH") };
-
-    let error = EnvBuilder::new()
-        .with_project_graph_db(temp.path())
-        .unwrap_err();
-
-    match prev_graph {
-        Some(v) => unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", v) },
-        None => unsafe { std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH") },
-    }
-    match prev {
-        Some(v) => unsafe { std::env::set_var("AMPLIHACK_KUZU_DB_PATH", v) },
-        None => unsafe { std::env::remove_var("AMPLIHACK_KUZU_DB_PATH") },
-    }
-
-    let rendered = format!("{error:#}");
-    assert!(rendered.contains("invalid AMPLIHACK_GRAPH_DB_PATH override"));
-    assert!(rendered.contains("blocked prefix /proc"));
-}
-
-#[test]
-fn with_project_graph_db_invalid_graph_override_does_not_fall_through_to_kuzu_alias() {
-    let _guard = cwd_env_lock()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let temp = tempfile::tempdir().unwrap();
-    let prev_graph = std::env::var_os("AMPLIHACK_GRAPH_DB_PATH");
-    let prev = std::env::var_os("AMPLIHACK_KUZU_DB_PATH");
-    unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", "/tmp/../etc/shadow") };
-    unsafe { std::env::set_var("AMPLIHACK_KUZU_DB_PATH", "/custom/legacy-graph-alias") };
-
-    let error = EnvBuilder::new()
-        .with_project_graph_db(temp.path())
-        .unwrap_err();
-
-    match prev_graph {
-        Some(v) => unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", v) },
-        None => unsafe { std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH") },
-    }
-    match prev {
-        Some(v) => unsafe { std::env::set_var("AMPLIHACK_KUZU_DB_PATH", v) },
-        None => unsafe { std::env::remove_var("AMPLIHACK_KUZU_DB_PATH") },
-    }
-
-    let rendered = format!("{error:#}");
-    assert!(rendered.contains("invalid AMPLIHACK_GRAPH_DB_PATH override"));
-    assert!(rendered.contains("/tmp/../etc/shadow"));
 }
 
 #[test]
@@ -295,11 +257,12 @@ fn apply_to_command_translates_kuzu_alias_to_graph_db_path_and_removes_kuzu_var(
             )
         })
         .collect();
+    let expected = temp.path().join(".amplihack").join("graph_db");
     assert_eq!(
         envs.get("AMPLIHACK_GRAPH_DB_PATH")
             .and_then(|value| value.as_deref()),
-        Some("/inherited/legacy"),
-        "Legacy KUZU_DB_PATH must be translated to GRAPH_DB_PATH in child env"
+        Some(expected.to_str().unwrap()),
+        "explicit project_root must win; inherited KUZU_DB_PATH is ignored (issue #250)"
     );
     assert_eq!(
         envs.get("AMPLIHACK_KUZU_DB_PATH")

--- a/crates/amplihack-cli/src/update/tests.rs
+++ b/crates/amplihack-cli/src/update/tests.rs
@@ -428,7 +428,13 @@ fn shell_profile_path_unknown() {
 fn ensure_local_bin_on_shell_path_creates_export() {
     use crate::commands::install::paths::ensure_local_bin_on_shell_path;
     let tmp = tempfile::TempDir::new().unwrap();
-    let _lock = crate::test_support::env_lock();
+    // Use home_env_lock so we serialize with HOME-reading tests like
+    // test_resolve_binary_path_expands_tilde_to_home_dir.
+    let _lock = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let prev_home = std::env::var_os("HOME");
+    let prev_shell = std::env::var_os("SHELL");
     unsafe { std::env::set_var("HOME", tmp.path().as_os_str()) };
     unsafe { std::env::set_var("SHELL", "/bin/bash") };
     ensure_local_bin_on_shell_path().unwrap();
@@ -442,6 +448,12 @@ fn ensure_local_bin_on_shell_path_creates_export() {
     let content2 = std::fs::read_to_string(tmp.path().join(".bashrc")).unwrap();
     let count = content2.matches("export PATH").count();
     assert_eq!(count, 1, "should not duplicate the export line");
-    unsafe { std::env::remove_var("SHELL") };
-    unsafe { std::env::remove_var("HOME") };
+    match prev_shell {
+        Some(v) => unsafe { std::env::set_var("SHELL", v) },
+        None => unsafe { std::env::remove_var("SHELL") },
+    }
+    match prev_home {
+        Some(v) => unsafe { std::env::set_var("HOME", v) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
 }

--- a/crates/amplihack-cli/tests/bugfix_install_tests.rs
+++ b/crates/amplihack-cli/tests/bugfix_install_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify:
 //! - #254: REPO_ARCHIVE_URL and REPO_GIT_URL point to amplihack-rs;
-//!         find_framework_repo_root() accepts `amplifier-bundle/` marker
+//!   find_framework_repo_root() accepts `amplifier-bundle/` marker
 //! - #249: run_update() calls ensure_framework_installed() after binary swap
 //! - #257: verify_sha256() uses http_get_with_retry() (tested via contract)
 


### PR DESCRIPTION
Closes #250

## Problem

\`with_project_graph_db()\` consulted inherited \`AMPLIHACK_GRAPH_DB_PATH\` and \`AMPLIHACK_KUZU_DB_PATH\` env vars and let them override the explicit \`project_root\` argument. This made staged execution contexts (\`auto_mode\`, \`fleet\`) unable to anchor the graph DB under \`HOME/.amplihack/graph_db\` when an inherited env was present, breaking 3 tests:

- \`build_auto_command_marks_staged_execution_context\`
- \`build_auto_command_propagates_launcher_environment\`
- \`native_reasoner_backend_propagates_shared_env_context\`

## Fix

Make the explicit \`project_root\` authoritative — it always wins, the legacy alias is unset, and bogus inherited values can never leak into child overrides or surface as validation errors. The env-var short-circuit (lines 170-185) is removed; the function now always derives the path from \`project_root.join(\".amplihack\").join(\"graph_db\")\`.

## Test changes

- Updated \`env_builder/tests_builder.rs\` to assert the new contract (explicit project_root wins; inherited envs are ignored). Replaces 5 tests that asserted the old "env wins" behavior with 4 tests asserting the new "project_root wins" contract.
- Updated \`commands/recipe/run/tests_execute.rs\` to expect the derived path instead of the inherited \`/custom/graph\` value.
- Fixed pre-existing test isolation bug in \`update/tests.rs\`: \`ensure_local_bin_on_shell_path_creates_export\` removed \`HOME\` without restoring it, racing against \`test_resolve_binary_path_expands_tilde_to_home_dir\` which reads HOME under \`home_env_lock\`. Now uses \`home_env_lock\` and saves/restores HOME.
- Fixed pre-existing rust-1.93 \`doc-overindented-list-items\` lint in \`tests/bugfix_install_tests.rs\` (was blocking clippy verification).

## Verification

\`\`\`
cargo clippy -p amplihack-cli --all-targets -- -D warnings  # clean
TMPDIR=/tmp cargo test -p amplihack-cli --lib               # 1003/1003 passing
\`\`\`

The 3 previously-failing tests from #250 (\`build_auto_command_*\`, \`native_reasoner_backend_*\`) now pass.