### PR TITLE
fix(auto-mode): use --allow-all for copilot non-interactive (#277)

### DIFF
--- a/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
@@ -214,8 +214,15 @@ pub(super) fn build_tool_passthrough_args(
         AutoModeTool::Copilot => {
             // Strip Claude-only flags from Copilot invocations (PR #4142).
             args = strip_claude_only_flags(args);
-            if !args.iter().any(|arg| arg == "--allow-all-tools") {
-                args.push("--allow-all-tools".to_string());
+            // #277: use `--allow-all` (tools + paths + urls) in non-interactive
+            // mode. `--allow-all-tools` alone permits the tools but keeps the
+            // path-allowlist gate in effect, which causes shell commands to
+            // fail with "could not request permission from user" when the
+            // worktree is outside an explicitly-added directory.
+            let has_allow_all = args.iter().any(|a| a == "--allow-all");
+            let has_allow_all_tools = args.iter().any(|a| a == "--allow-all-tools");
+            if !has_allow_all && !has_allow_all_tools {
+                args.push("--allow-all".to_string());
             }
             if !args.iter().any(|arg| arg == "--add-dir") {
                 args.push("--add-dir".to_string());

--- a/crates/amplihack-cli/src/commands/auto_mode/tests.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/tests.rs
@@ -85,7 +85,7 @@ fn build_tool_passthrough_args_matches_codex_and_copilot_contracts() {
     let copilot = build_tool_passthrough_args(AutoModeTool::Copilot, &[], "add logging");
     assert_eq!(
         copilot,
-        vec!["--allow-all-tools", "--add-dir", "/", "-p", "add logging"]
+        vec!["--allow-all", "--add-dir", "/", "-p", "add logging"]
     );
 }
 
@@ -268,7 +268,7 @@ fn copilot_strips_claude_only_flags_from_passthrough() {
     assert!(!args.contains(&"--disallowed-tools".to_string()));
     assert!(!args.contains(&"Bash,Write".to_string()));
     assert!(args.contains(&"--model".to_string()));
-    assert!(args.contains(&"--allow-all-tools".to_string()));
+    assert!(args.contains(&"--allow-all".to_string()));
 }
 
 #[test]
@@ -285,5 +285,5 @@ fn copilot_strips_equals_style_claude_flags() {
             .any(|a| a.starts_with("--dangerously-skip-permissions"))
     );
     assert!(!args.iter().any(|a| a.starts_with("--disallowed-tools")));
-    assert!(args.contains(&"--allow-all-tools".to_string()));
+    assert!(args.contains(&"--allow-all".to_string()));
 }


### PR DESCRIPTION
Closes #277 (for auto-mode path).

## Problem

In non-interactive copilot (`-p`) mode, `--allow-all-tools` alone lets tools *run* but keeps the file-path allowlist gate in effect. Shell commands that stat/read/write paths outside the `--add-dir` tree fail with:

```
Permission denied and could not request permission from user
```

This is the root cause of hollow-success runs in `default-workflow` / `smart-orchestrator` on the copilot binary.

## Fix

Switch `build_tool_passthrough_args(AutoModeTool::Copilot, ...)` from `--allow-all-tools` to `--allow-all` — the latter is equivalent to `--allow-all-tools --allow-all-paths --allow-all-urls` (per `copilot --help`). This grants tool permission **and** disables path verification, closing the hollow-success hole.

Safety: if the caller already passed `--allow-all-tools` or `--allow-all` in passthrough args, neither is added again (no duplicate flags).

## Scope

This fixes the **auto-mode** copilot launcher in amplihack-cli. The external `recipe-runner-rs` binary has its own copilot invocation path; tracking that there (if needed) will require upstream changes.

## Verification

- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` — clean
- `cargo test -p amplihack-cli --lib commands::auto_mode` — 14/14 pass
