### PR TITLE
fix(install,launch): same-path skip (#302), atomic binary deploy (#304), copilot --allow-all default (#303)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -95,6 +95,8 @@ pub(super) fn validate_hook_command_string(cmd: &str) -> Result<()> {
 /// Emits a PATH advisory if `~/.local/bin` is not in `$PATH`.
 /// Returns the list of deployed paths for the manifest.
 pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
+    use super::filesystem::deploy_binary;
+
     let home = home_dir()?;
     let local_bin = home.join(".local").join("bin");
     fs::create_dir_all(&local_bin)
@@ -102,44 +104,25 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
 
     let hooks_src = find_hooks_binary()?;
     let hooks_dst = local_bin.join("amplihack-hooks");
-
-    fs::copy(&hooks_src, &hooks_dst).with_context(|| {
+    deploy_binary(&hooks_src, &hooks_dst).with_context(|| {
         format!(
-            "failed to copy {} to {}",
+            "failed to deploy {} to {}",
             hooks_src.display(),
             hooks_dst.display()
         )
     })?;
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&hooks_dst, std::fs::Permissions::from_mode(0o755))
-            .with_context(|| format!("failed to chmod {}", hooks_dst.display()))?;
-    }
-
     let mut deployed = vec![hooks_dst.clone()];
 
-    // Also copy self (the amplihack binary) if it differs from the destination
+    // Also copy self (the amplihack binary) if it differs from the destination.
+    // Uses atomic rename-then-replace (issue #304) so it succeeds even when the
+    // destination is the currently-running binary.
     if let Ok(self_exe) = std::env::current_exe() {
         let self_dst = local_bin.join("amplihack");
         if self_exe != self_dst {
-            fs::copy(&self_exe, &self_dst).with_context(|| {
-                format!("failed to copy amplihack binary to {}", self_dst.display())
+            deploy_binary(&self_exe, &self_dst).with_context(|| {
+                format!("failed to deploy amplihack binary to {}", self_dst.display())
             })?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                if let Err(e) =
-                    fs::set_permissions(&self_dst, std::fs::Permissions::from_mode(0o755))
-                {
-                    tracing::warn!(
-                        "failed to set executable bit on {}: {}",
-                        self_dst.display(),
-                        e
-                    );
-                }
-            }
             deployed.push(self_dst);
         }
 
@@ -151,19 +134,13 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
         if let Some(resolver_src) = resolver_src {
             let resolver_dst = local_bin.join("amplihack-asset-resolver");
             if resolver_src != resolver_dst {
-                fs::copy(&resolver_src, &resolver_dst).with_context(|| {
+                deploy_binary(&resolver_src, &resolver_dst).with_context(|| {
                     format!(
-                        "failed to copy {} to {}",
+                        "failed to deploy {} to {}",
                         resolver_src.display(),
                         resolver_dst.display()
                     )
                 })?;
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    fs::set_permissions(&resolver_dst, std::fs::Permissions::from_mode(0o755))
-                        .with_context(|| format!("failed to chmod {}", resolver_dst.display()))?;
-                }
                 deployed.push(resolver_dst);
             }
         }

--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -121,7 +121,10 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
         let self_dst = local_bin.join("amplihack");
         if self_exe != self_dst {
             deploy_binary(&self_exe, &self_dst).with_context(|| {
-                format!("failed to deploy amplihack binary to {}", self_dst.display())
+                format!(
+                    "failed to deploy amplihack binary to {}",
+                    self_dst.display()
+                )
             })?;
             deployed.push(self_dst);
         }

--- a/crates/amplihack-cli/src/commands/install/filesystem.rs
+++ b/crates/amplihack-cli/src/commands/install/filesystem.rs
@@ -56,8 +56,7 @@ pub(super) fn deploy_binary(src: &Path, dst: &Path) -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
         if let Err(e) = fs::set_permissions(&temp_path, std::fs::Permissions::from_mode(0o755)) {
             let _ = fs::remove_file(&temp_path);
-            return Err(e)
-                .with_context(|| format!("failed to chmod {}", temp_path.display()));
+            return Err(e).with_context(|| format!("failed to chmod {}", temp_path.display()));
         }
     }
 

--- a/crates/amplihack-cli/src/commands/install/filesystem.rs
+++ b/crates/amplihack-cli/src/commands/install/filesystem.rs
@@ -5,6 +5,89 @@ use std::collections::{BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// Atomically deploy a binary from `src` to `dst` using rename-then-replace.
+///
+/// Linux returns `ETXTBSY` (errno 26) if you try `fs::copy` over a binary that
+/// is currently being executed (issue #304). The fix is to write the new bytes
+/// to a sibling tempfile and `rename(2)` it over the destination — `rename`
+/// swaps the inode rather than overwriting the busy text segment, so it works
+/// even if the target binary is currently running.
+///
+/// Behavior:
+/// - If `src` and `dst` resolve to the same file, returns `Ok(())` (no-op).
+/// - On Unix, sets the destination mode to `0o755` before rename so the
+///   replacement is atomically visible as executable.
+/// - On `EXDEV` (cross-filesystem rename), falls back to a copy-then-rename
+///   inside the destination filesystem.
+pub(super) fn deploy_binary(src: &Path, dst: &Path) -> Result<()> {
+    // Same-file no-op (issue #302).
+    if let (Ok(s), Ok(d)) = (src.canonicalize(), dst.canonicalize())
+        && s == d
+    {
+        return Ok(());
+    }
+
+    let dst_dir = dst
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("destination has no parent: {}", dst.display()))?;
+    fs::create_dir_all(dst_dir)
+        .with_context(|| format!("failed to create {}", dst_dir.display()))?;
+
+    let dst_name = dst
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow::anyhow!("destination has no file name: {}", dst.display()))?;
+    let temp_name = format!(".{}.new.{}", dst_name, std::process::id());
+    let temp_path = dst_dir.join(&temp_name);
+
+    // Best-effort cleanup of any leftover temp from a prior failed run.
+    let _ = fs::remove_file(&temp_path);
+
+    fs::copy(src, &temp_path).with_context(|| {
+        format!(
+            "failed to copy {} to {}",
+            src.display(),
+            temp_path.display()
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) = fs::set_permissions(&temp_path, std::fs::Permissions::from_mode(0o755)) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(e)
+                .with_context(|| format!("failed to chmod {}", temp_path.display()));
+        }
+    }
+
+    if let Err(rename_err) = fs::rename(&temp_path, dst) {
+        // EXDEV (cross-device link): rename fails across filesystems. Fall back
+        // to a direct copy, but only after cleaning up the temp file.
+        let is_exdev = rename_err.raw_os_error() == Some(libc::EXDEV);
+        let _ = fs::remove_file(&temp_path);
+        if is_exdev {
+            fs::copy(src, dst).with_context(|| {
+                format!(
+                    "failed to copy {} to {} (cross-device fallback)",
+                    src.display(),
+                    dst.display()
+                )
+            })?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = fs::set_permissions(dst, std::fs::Permissions::from_mode(0o755));
+            }
+        } else {
+            return Err(rename_err)
+                .with_context(|| format!("failed to rename to {}", dst.display()));
+        }
+    }
+
+    Ok(())
+}
+
 pub(super) fn all_rel_dirs(claude_dir: &Path) -> Result<BTreeSet<String>> {
     let mut result = BTreeSet::new();
     if !claude_dir.exists() {
@@ -125,14 +208,18 @@ fn is_excluded_file(name: &std::ffi::OsStr) -> bool {
 /// `__pycache__` directories and `.pyc`/`.pyo` files are excluded.
 /// Broken symlinks are removed during traversal.
 pub(super) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
-    // Same-path guard: bail if source and destination resolve to the same location.
+    // Same-path guard (issue #302): if source and destination resolve to the
+    // same location, this is a legitimate re-stage-after-update workflow
+    // (`amplihack install` from `~/.amplihack` when target is `~/.amplihack/.claude`).
+    // Skip the copy and return Ok rather than bailing.
     if let (Ok(src_canon), Ok(dst_canon)) = (src.canonicalize(), dst.canonicalize())
         && src_canon == dst_canon
     {
-        anyhow::bail!(
-            "source and destination are the same path: {}",
+        println!(
+            "  ↩️  Skipping {}: source and destination are identical",
             src_canon.display()
         );
+        return Ok(());
     }
 
     fs::create_dir_all(dst).with_context(|| format!("failed to create {}", dst.display()))?;
@@ -154,6 +241,13 @@ pub(super) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
             copy_dir_recursive(&source, &target)?;
         } else if kind.is_file() {
             if is_excluded_file(&file_name) {
+                continue;
+            }
+            // Per-file same-path guard: protects against the case where the
+            // top-level dirs differ but a recursed subdirectory aliases back.
+            if let (Ok(s), Ok(t)) = (source.canonicalize(), target.canonicalize())
+                && s == t
+            {
                 continue;
             }
             fs::copy(&source, &target).with_context(|| {

--- a/crates/amplihack-cli/src/commands/install/tests/deploy_binary_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/deploy_binary_tests.rs
@@ -69,11 +69,10 @@ fn deploy_binary_cleans_up_temp_on_success() {
     let leftovers: Vec<_> = fs::read_dir(tmp.path())
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .contains(".new.")
-        })
+        .filter(|e| e.file_name().to_string_lossy().contains(".new."))
         .collect();
-    assert!(leftovers.is_empty(), "no temp files should remain: {leftovers:?}");
+    assert!(
+        leftovers.is_empty(),
+        "no temp files should remain: {leftovers:?}"
+    );
 }

--- a/crates/amplihack-cli/src/commands/install/tests/deploy_binary_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/deploy_binary_tests.rs
@@ -1,0 +1,79 @@
+//! Tests for `deploy_binary` — atomic rename-then-replace pattern that fixes
+//! issue #304 (ETXTBSY when overwriting the running amplihack binary).
+
+use super::super::filesystem::deploy_binary;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn deploy_binary_replaces_existing_target() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("src-binary");
+    let dst = tmp.path().join("dst-binary");
+    fs::write(&src, b"new bytes").unwrap();
+    fs::write(&dst, b"old bytes").unwrap();
+
+    deploy_binary(&src, &dst).expect("deploy_binary");
+    assert_eq!(fs::read(&dst).unwrap(), b"new bytes");
+}
+
+#[test]
+fn deploy_binary_creates_missing_destination() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("src-binary");
+    let dst = tmp.path().join("dst-binary");
+    fs::write(&src, b"hello").unwrap();
+
+    deploy_binary(&src, &dst).expect("deploy_binary");
+    assert_eq!(fs::read(&dst).unwrap(), b"hello");
+}
+
+#[test]
+#[cfg(unix)]
+fn deploy_binary_sets_executable_mode() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("src-binary");
+    let dst = tmp.path().join("dst-binary");
+    fs::write(&src, b"data").unwrap();
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+
+    deploy_binary(&src, &dst).expect("deploy_binary");
+    let mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o755, "destination should be 0o755");
+}
+
+#[test]
+fn deploy_binary_same_path_is_noop() {
+    // Issue #302 / #304 interaction: when src and dst resolve to the same
+    // file, deploy_binary returns Ok without touching the file. This guards
+    // the legitimate re-stage-after-update workflow when src == dst.
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("self");
+    fs::write(&path, b"self bytes").unwrap();
+
+    deploy_binary(&path, &path).expect("same-path deploy_binary");
+    assert_eq!(fs::read(&path).unwrap(), b"self bytes");
+}
+
+#[test]
+fn deploy_binary_cleans_up_temp_on_success() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::write(&src, b"x").unwrap();
+
+    deploy_binary(&src, &dst).unwrap();
+
+    // No leftover .new.* siblings in dst directory.
+    let leftovers: Vec<_> = fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .contains(".new.")
+        })
+        .collect();
+    assert!(leftovers.is_empty(), "no temp files should remain: {leftovers:?}");
+}

--- a/crates/amplihack-cli/src/commands/install/tests/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/mod.rs
@@ -1,9 +1,11 @@
 use super::*;
 
 mod binary_tests;
+mod deploy_binary_tests;
 mod helpers;
 mod hook_specs;
 mod install_flow;
+mod same_path_tests;
 mod settings_tests;
 mod uninstall_tests;
 mod wrapper_tests;

--- a/crates/amplihack-cli/src/commands/install/tests/same_path_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/same_path_tests.rs
@@ -1,0 +1,33 @@
+//! Tests for the same-path skip behavior in `copy_dir_recursive` (issue #302).
+
+use super::super::filesystem::copy_dir_recursive;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn copy_dir_recursive_skips_same_path() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("d");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("file"), b"contents").unwrap();
+
+    // Same path on both sides — must succeed (no error) and leave file intact.
+    copy_dir_recursive(&dir, &dir).expect("same-path copy should be a no-op");
+    assert_eq!(fs::read(dir.join("file")).unwrap(), b"contents");
+}
+
+#[test]
+fn copy_dir_recursive_copies_distinct_paths_normally() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("a"), b"hello").unwrap();
+    fs::create_dir_all(src.join("nested")).unwrap();
+    fs::write(src.join("nested").join("b"), b"world").unwrap();
+
+    copy_dir_recursive(&src, &dst).expect("distinct-path copy");
+
+    assert_eq!(fs::read(dst.join("a")).unwrap(), b"hello");
+    assert_eq!(fs::read(dst.join("nested").join("b")).unwrap(), b"world");
+}

--- a/crates/amplihack-cli/src/commands/launch/command.rs
+++ b/crates/amplihack-cli/src/commands/launch/command.rs
@@ -66,8 +66,35 @@ pub(super) fn build_command_for_dir(
     if continue_session {
         cmd.arg("--continue");
     }
+
+    // Inject --allow-all for Copilot by default (issue #303). Copilot's
+    // `--allow-all` is shorthand for `--allow-all-tools + --allow-all-paths +
+    // --allow-all-urls`. Without it, Copilot prompts for tool/path/url
+    // permission on its first action, which blocks unattended orchestrator
+    // loops launched by amplihack. Skip injection if the user already set any
+    // allow-all-* flag, or if AMPLIHACK_COPILOT_NO_ALLOW_ALL=1.
+    if binary.name == "copilot" && should_inject_copilot_allow_all(extra_args) {
+        cmd.arg("--allow-all");
+    }
+
     cmd.args(extra_args);
     cmd
+}
+
+/// Decide whether `amplihack` should inject `--allow-all` into a Copilot
+/// invocation. Returns false if the user already supplied any allow-all-*
+/// flag, or if the `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` env var is set.
+pub(crate) fn should_inject_copilot_allow_all(extra_args: &[String]) -> bool {
+    if std::env::var("AMPLIHACK_COPILOT_NO_ALLOW_ALL").as_deref() == Ok("1") {
+        return false;
+    }
+    let already_present = extra_args.iter().any(|a| {
+        a == "--allow-all"
+            || a == "--allow-all-tools"
+            || a == "--allow-all-paths"
+            || a == "--allow-all-urls"
+    });
+    !already_present
 }
 
 fn inject_uvx_plugin_args(

--- a/crates/amplihack-cli/src/commands/launch/tests_command.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_command.rs
@@ -274,3 +274,86 @@ fn build_command_without_skip_permissions_and_with_flags() {
         assert_eq!(args, &["--resume", "--continue", "--model", "opus"]);
     });
 }
+
+#[test]
+fn copilot_gets_allow_all_injected_by_default() {
+    // Issue #303: amplihack should pass --allow-all to copilot by default so
+    // unattended orchestrator loops are not blocked by tool/path/url prompts.
+    with_uvx_detection_disabled(|| {
+        // Clear the opt-out env var in case the test environment has it set.
+        // Safety: tests in this file are serialized via home_env_lock().
+        unsafe { std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL"); }
+        let binary = BinaryInfo {
+            name: "copilot".to_string(),
+            path: PathBuf::from("/usr/bin/copilot"),
+            version: None,
+        };
+        let cmd = build_command(&binary, false, false, false, &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            args.iter().any(|a| a == "--allow-all"),
+            "copilot launch must include --allow-all by default; got {args:?}"
+        );
+    });
+}
+
+#[test]
+fn copilot_skips_allow_all_when_user_sets_one() {
+    with_uvx_detection_disabled(|| {
+        unsafe { std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL"); }
+        let binary = BinaryInfo {
+            name: "copilot".to_string(),
+            path: PathBuf::from("/usr/bin/copilot"),
+            version: None,
+        };
+        // User already passed --allow-all-tools; we must NOT inject another flag.
+        let extra = vec!["--allow-all-tools".to_string()];
+        let cmd = build_command(&binary, false, false, false, &extra);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        let allow_all_count = args.iter().filter(|a| a.as_str() == "--allow-all").count();
+        assert_eq!(allow_all_count, 0, "should not inject --allow-all when user supplied --allow-all-tools; got {args:?}");
+    });
+}
+
+#[test]
+fn copilot_skips_allow_all_when_env_opt_out() {
+    with_uvx_detection_disabled(|| {
+        // Safety: serialized via home_env_lock(); restored at end.
+        unsafe { std::env::set_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL", "1"); }
+        let binary = BinaryInfo {
+            name: "copilot".to_string(),
+            path: PathBuf::from("/usr/bin/copilot"),
+            version: None,
+        };
+        let cmd = build_command(&binary, false, false, false, &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        unsafe { std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL"); }
+        assert!(!args.iter().any(|a| a == "--allow-all"), "opt-out must suppress allow-all; got {args:?}");
+    });
+}
+
+#[test]
+fn claude_does_not_get_allow_all_injected() {
+    with_uvx_detection_disabled(|| {
+        let binary = BinaryInfo {
+            name: "claude".to_string(),
+            path: PathBuf::from("/usr/bin/claude"),
+            version: None,
+        };
+        let cmd = build_command(&binary, false, false, false, &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert!(!args.iter().any(|a| a == "--allow-all"), "non-copilot tools must not get --allow-all; got {args:?}");
+    });
+}

--- a/crates/amplihack-cli/src/commands/launch/tests_command.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_command.rs
@@ -282,7 +282,9 @@ fn copilot_gets_allow_all_injected_by_default() {
     with_uvx_detection_disabled(|| {
         // Clear the opt-out env var in case the test environment has it set.
         // Safety: tests in this file are serialized via home_env_lock().
-        unsafe { std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL"); }
+        unsafe {
+            std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+        }
         let binary = BinaryInfo {
             name: "copilot".to_string(),
             path: PathBuf::from("/usr/bin/copilot"),
@@ -303,7 +305,9 @@ fn copilot_gets_allow_all_injected_by_default() {
 #[test]
 fn copilot_skips_allow_all_when_user_sets_one() {
     with_uvx_detection_disabled(|| {
-        unsafe { std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL"); }
+        unsafe {
+            std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+        }
         let binary = BinaryInfo {
             name: "copilot".to_string(),
             path: PathBuf::from("/usr/bin/copilot"),
@@ -317,7 +321,10 @@ fn copilot_skips_allow_all_when_user_sets_one() {
             .map(|s| s.to_string_lossy().into_owned())
             .collect();
         let allow_all_count = args.iter().filter(|a| a.as_str() == "--allow-all").count();
-        assert_eq!(allow_all_count, 0, "should not inject --allow-all when user supplied --allow-all-tools; got {args:?}");
+        assert_eq!(
+            allow_all_count, 0,
+            "should not inject --allow-all when user supplied --allow-all-tools; got {args:?}"
+        );
     });
 }
 
@@ -325,7 +332,9 @@ fn copilot_skips_allow_all_when_user_sets_one() {
 fn copilot_skips_allow_all_when_env_opt_out() {
     with_uvx_detection_disabled(|| {
         // Safety: serialized via home_env_lock(); restored at end.
-        unsafe { std::env::set_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL", "1"); }
+        unsafe {
+            std::env::set_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL", "1");
+        }
         let binary = BinaryInfo {
             name: "copilot".to_string(),
             path: PathBuf::from("/usr/bin/copilot"),
@@ -336,8 +345,13 @@ fn copilot_skips_allow_all_when_env_opt_out() {
             .get_args()
             .map(|s| s.to_string_lossy().into_owned())
             .collect();
-        unsafe { std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL"); }
-        assert!(!args.iter().any(|a| a == "--allow-all"), "opt-out must suppress allow-all; got {args:?}");
+        unsafe {
+            std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+        }
+        assert!(
+            !args.iter().any(|a| a == "--allow-all"),
+            "opt-out must suppress allow-all; got {args:?}"
+        );
     });
 }
 
@@ -354,6 +368,9 @@ fn claude_does_not_get_allow_all_injected() {
             .get_args()
             .map(|s| s.to_string_lossy().into_owned())
             .collect();
-        assert!(!args.iter().any(|a| a == "--allow-all"), "non-copilot tools must not get --allow-all; got {args:?}");
+        assert!(
+            !args.iter().any(|a| a == "--allow-all"),
+            "non-copilot tools must not get --allow-all; got {args:?}"
+        );
     });
 }


### PR DESCRIPTION
Closes #302, #303, #304.

## Three install-time / launch-time robustness fixes

### #302 — install: 'source and destination are the same path'

`amplihack install` after `amplihack update` (with both source bundle and target under `~/.amplihack`) bailed out at the first directory copy. The same-path guard in `copy_dir_recursive` now **skips and logs** instead of erroring. Added a per-file same-path guard for the recurse-into-aliased-subdir case.

### #304 — install: 'Text file busy' (ETXTBSY) on running binary

`std::fs::copy` over a running binary returns ETXTBSY on Linux. New helper `deploy_binary(src, dst)`:
1. Writes new bytes to `<dst_dir>/.<dst_name>.new.<pid>`.
2. `chmod 0o755` on the temp.
3. `fs::rename` over the destination — swaps the inode, works on live binaries.
4. EXDEV fallback to `fs::copy` for cross-filesystem destinations.

Replaces all 3 `fs::copy + chmod` blocks in `install/binary.rs`.

### #303 — launch: copilot --allow-all by default

`amplihack launch copilot` (and every nested orchestrator launch path) inherited Copilot's default permission gates → first action prompts for tool/path/url permission → unattended runs hang. Now injects `--allow-all` for copilot **unless** any of `--allow-all`, `--allow-all-tools`, `--allow-all-paths`, `--allow-all-urls` is already in the user args, or `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` is set. Generalizes auto-mode behavior from PR #297 (issue #277) to all launch sites.

## Validation

- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` — clean
- `TMPDIR=/tmp cargo test -p amplihack-cli --lib commands::{install,launch}` — 126 passed
- 11 new unit tests covering each fix

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>