### PR TITLE
fix(copilot): emit valid hook manifest, stage user-level hooks (#306)

### DIFF
--- a/crates/amplihack-cli/src/copilot_setup/hooks.rs
+++ b/crates/amplihack-cli/src/copilot_setup/hooks.rs
@@ -7,16 +7,39 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use super::{
-    COPILOT_HOOK_WRAPPERS, COPILOT_HOOKS_MANIFEST, HookWrapperSpec, INSTRUCTIONS_MARKER_END,
+    COPILOT_HOOK_TIMEOUT_SEC, COPILOT_HOOK_WRAPPERS, HookWrapperSpec, INSTRUCTIONS_MARKER_END,
     INSTRUCTIONS_MARKER_START, fs_helpers,
 };
+
+/// Build the Copilot hooks manifest as JSON. Hook entries reference absolute
+/// paths to the staged bash wrappers under `<repo>/.github/hooks/`.
+pub(super) fn build_copilot_hooks_manifest(hooks_dir: &Path) -> serde_json::Value {
+    let mut hooks = serde_json::Map::new();
+    for spec in COPILOT_HOOK_WRAPPERS {
+        let bash_path = hooks_dir.join(spec.hook_name);
+        let entry = serde_json::json!({
+            "type": "command",
+            "bash": bash_path.to_string_lossy(),
+            "timeoutSec": COPILOT_HOOK_TIMEOUT_SEC,
+        });
+        hooks.insert(spec.copilot_event.to_string(), serde_json::json!([entry]));
+    }
+    serde_json::json!({
+        "version": 1,
+        "hooks": hooks,
+    })
+}
 
 pub(super) fn stage_repo_hooks(repo_root: &Path) -> Result<usize> {
     let hooks_dir = repo_root.join(".github").join("hooks");
     fs::create_dir_all(&hooks_dir)?;
 
+    let manifest = build_copilot_hooks_manifest(&hooks_dir);
     let manifest_dest = hooks_dir.join("amplihack-hooks.json");
-    fs::write(&manifest_dest, COPILOT_HOOKS_MANIFEST)?;
+    fs::write(
+        &manifest_dest,
+        serde_json::to_string_pretty(&manifest)? + "\n",
+    )?;
 
     let mut count = 1; // manifest itself
 
@@ -37,6 +60,99 @@ pub(super) fn stage_repo_hooks(repo_root: &Path) -> Result<usize> {
     count += 1;
 
     Ok(count)
+}
+
+/// Merge an amplihack hooks block into `~/.copilot/config.json` so that hooks
+/// fire regardless of which directory Copilot is launched from. Existing
+/// non-amplihack hook entries are preserved; amplihack-owned entries (those
+/// whose `bash` path resolves under `~/.amplihack` or whose `_amplihack`
+/// marker is set) are replaced atomically.
+pub(super) fn write_user_level_hooks(copilot_home: &Path) -> Result<()> {
+    // We point the user-level hooks at the staged framework directory so the
+    // hook wrappers work irrespective of which repo Copilot opens. The
+    // wrappers themselves resolve `amplihack-hooks` from PATH or the standard
+    // install locations, so they degrade gracefully if the binary is missing.
+    let hooks_dir = copilot_home.join(".github").join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+
+    // Materialize the wrappers under ~/.copilot/.github/hooks/ so their bash
+    // paths resolve absolutely on disk.
+    for spec in COPILOT_HOOK_WRAPPERS {
+        let dest = hooks_dir.join(spec.hook_name);
+        let script = build_wrapper_script(spec);
+        fs::write(&dest, &script)?;
+        set_executable(&dest)?;
+    }
+
+    let config_path = copilot_home.join("config.json");
+    let mut root: serde_json::Value = if config_path.is_file() {
+        let raw = fs::read_to_string(&config_path)
+            .with_context(|| format!("read {}", config_path.display()))?;
+        if raw.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&raw).with_context(|| {
+                format!("parse {} as JSON before merging hooks", config_path.display())
+            })?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    let manifest = build_copilot_hooks_manifest(&hooks_dir);
+    let amplihack_hooks = manifest
+        .get("hooks")
+        .and_then(|h| h.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    let obj = root
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("config.json root is not a JSON object"))?;
+    let hooks_entry = obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    let hooks_obj = hooks_entry
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("config.json `hooks` is not a JSON object"))?;
+
+    // Replace amplihack-owned entries; keep any user-defined non-amplihack
+    // hooks the user has registered for the same event by appending after.
+    for (event, new_arr_value) in amplihack_hooks {
+        let new_arr = new_arr_value.as_array().cloned().unwrap_or_default();
+        let preserved: Vec<serde_json::Value> = hooks_obj
+            .get(&event)
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|entry| !is_amplihack_owned(entry))
+            .collect();
+        let mut merged = new_arr;
+        merged.extend(preserved);
+        hooks_obj.insert(event, serde_json::Value::Array(merged));
+    }
+
+    let serialized = serde_json::to_string_pretty(&root)? + "\n";
+    fs::write(&config_path, serialized)
+        .with_context(|| format!("write {}", config_path.display()))?;
+    Ok(())
+}
+
+fn is_amplihack_owned(entry: &serde_json::Value) -> bool {
+    let bash = entry
+        .get("bash")
+        .and_then(|v| v.as_str())
+        .or_else(|| entry.get("command").and_then(|v| v.as_str()))
+        .unwrap_or("");
+    bash.contains(".amplihack")
+        || bash.contains("/.copilot/.github/hooks/")
+        || bash.contains("/.github/hooks/session-start")
+        || bash.contains("/.github/hooks/user-prompt-submit")
+        || bash.contains("/.github/hooks/pre-tool-use")
+        || bash.contains("/.github/hooks/post-tool-use")
+        || bash.contains("/.github/hooks/pre-compact")
+        || bash.contains("/.github/hooks/stop")
 }
 
 pub(super) fn generate_copilot_instructions(copilot_home: &Path) -> Result<()> {

--- a/crates/amplihack-cli/src/copilot_setup/hooks.rs
+++ b/crates/amplihack-cli/src/copilot_setup/hooks.rs
@@ -92,7 +92,10 @@ pub(super) fn write_user_level_hooks(copilot_home: &Path) -> Result<()> {
             serde_json::json!({})
         } else {
             serde_json::from_str(&raw).with_context(|| {
-                format!("parse {} as JSON before merging hooks", config_path.display())
+                format!(
+                    "parse {} as JSON before merging hooks",
+                    config_path.display()
+                )
             })?
         }
     } else {

--- a/crates/amplihack-cli/src/copilot_setup/mod.rs
+++ b/crates/amplihack-cli/src/copilot_setup/mod.rs
@@ -10,46 +10,56 @@ use std::path::PathBuf;
 
 #[cfg(test)]
 use hooks::{build_wrapper_script, error_wrapper_script, replace_or_append_section};
-use hooks::{generate_copilot_instructions, stage_repo_hooks};
+use hooks::{generate_copilot_instructions, stage_repo_hooks, write_user_level_hooks};
 use staging::{register_plugin, stage_agents, stage_command_docs, stage_directory, stage_skills};
 
 const INSTRUCTIONS_MARKER_START: &str = "<!-- AMPLIHACK_INSTRUCTIONS_START -->";
 const INSTRUCTIONS_MARKER_END: &str = "<!-- AMPLIHACK_INSTRUCTIONS_END -->";
-const COPILOT_HOOKS_MANIFEST: &str = r#"{
-  "hooks": {
-    "session-start": [".github/hooks/session-start"],
-    "user-prompt-submit": [".github/hooks/user-prompt-submit"],
-    "post-tool-use": [".github/hooks/post-tool-use"],
-    "pre-compact": [".github/hooks/pre-compact"],
-    "stop": [".github/hooks/stop"]
-  }
-}
-"#;
+
+/// Default hook timeout in seconds. Hooks that exceed this are killed by Copilot.
+const COPILOT_HOOK_TIMEOUT_SEC: u32 = 30;
 
 struct HookWrapperSpec {
+    /// File name of the bash wrapper script under `.github/hooks/`.
     hook_name: &'static str,
+    /// Copilot CLI camelCase event name (matches schema in copilot app.js
+    /// `fWr` set: sessionStart, sessionEnd, userPromptSubmitted, preToolUse,
+    /// postToolUse, postToolUseFailure, errorOccurred, agentStop,
+    /// subagentStop, subagentStart, preCompact, permissionRequest,
+    /// notification).
+    copilot_event: &'static str,
     subcommands: &'static [&'static str],
 }
 
 const COPILOT_HOOK_WRAPPERS: &[HookWrapperSpec] = &[
     HookWrapperSpec {
         hook_name: "session-start",
+        copilot_event: "sessionStart",
         subcommands: &["session-start"],
     },
     HookWrapperSpec {
         hook_name: "user-prompt-submit",
+        copilot_event: "userPromptSubmitted",
         subcommands: &["workflow-classification-reminder", "user-prompt-submit"],
     },
     HookWrapperSpec {
+        hook_name: "pre-tool-use",
+        copilot_event: "preToolUse",
+        subcommands: &["pre-tool-use"],
+    },
+    HookWrapperSpec {
         hook_name: "post-tool-use",
+        copilot_event: "postToolUse",
         subcommands: &["post-tool-use"],
     },
     HookWrapperSpec {
         hook_name: "pre-compact",
+        copilot_event: "preCompact",
         subcommands: &["pre-compact"],
     },
     HookWrapperSpec {
         hook_name: "stop",
+        copilot_event: "agentStop",
         subcommands: &["stop"],
     },
 ];
@@ -85,7 +95,23 @@ pub fn ensure_copilot_home_staged() -> Result<()> {
     generate_copilot_instructions(&copilot_home)?;
 
     if let Ok(cwd) = std::env::current_dir() {
-        let _ = stage_repo_hooks(&cwd);
+        match stage_repo_hooks(&cwd) {
+            Ok(count) => {
+                tracing::debug!("staged {count} copilot hook file(s) into {}", cwd.display());
+            }
+            Err(err) => {
+                eprintln!(
+                    "⚠️  Failed to stage Copilot hooks into {}: {err}",
+                    cwd.display()
+                );
+            }
+        }
+    }
+
+    // Also stage hooks at the user level so they fire regardless of the
+    // current working directory at Copilot launch time.
+    if let Err(err) = write_user_level_hooks(&copilot_home) {
+        eprintln!("⚠️  Failed to write user-level Copilot hooks: {err}");
     }
 
     Ok(())
@@ -174,17 +200,84 @@ mod tests {
                 .exists()
         );
         assert!(repo_root.join(".github/hooks/session-start").exists());
+        assert!(repo_root.join(".github/hooks/pre-tool-use").exists());
         assert!(
             repo_root
                 .join(".github/hooks/amplihack-hooks.json")
                 .exists()
         );
 
-        let config = fs::read_to_string(temp.path().join(".copilot/config.json")).unwrap();
-        assert!(config.contains("\"name\": \"amplihack\""));
+        // Verify the staged manifest uses Copilot's camelCase event names
+        // and the documented entry schema (so Copilot doesn't ignore them).
+        let manifest_raw =
+            fs::read_to_string(repo_root.join(".github/hooks/amplihack-hooks.json")).unwrap();
+        let manifest: serde_json::Value = serde_json::from_str(&manifest_raw).unwrap();
+        assert_eq!(manifest["version"], 1);
+        let hooks_obj = manifest["hooks"].as_object().expect("hooks is object");
+        for event in [
+            "sessionStart",
+            "userPromptSubmitted",
+            "preToolUse",
+            "postToolUse",
+            "preCompact",
+            "agentStop",
+        ] {
+            let arr = hooks_obj
+                .get(event)
+                .unwrap_or_else(|| panic!("missing hook event {event}"))
+                .as_array()
+                .expect("event is array");
+            assert!(!arr.is_empty(), "event {event} has no entries");
+            let entry = &arr[0];
+            assert_eq!(entry["type"], "command", "{event} entry type");
+            assert!(
+                entry["bash"].as_str().unwrap_or("").contains(event_basename(event)),
+                "{event} bash path mismatch: {entry}"
+            );
+            assert!(
+                entry["timeoutSec"].as_u64().is_some(),
+                "{event} missing timeoutSec"
+            );
+        }
+        // None of our event names should be the legacy kebab-case form.
+        for legacy in ["session-start", "user-prompt-submit", "post-tool-use", "stop"] {
+            assert!(
+                !hooks_obj.contains_key(legacy),
+                "legacy event name leaked: {legacy}"
+            );
+        }
+
+        // User-level hooks should be wired into ~/.copilot/config.json so they
+        // fire regardless of cwd.
+        let copilot_config_raw =
+            fs::read_to_string(temp.path().join(".copilot/config.json")).unwrap();
+        let copilot_config: serde_json::Value = serde_json::from_str(&copilot_config_raw).unwrap();
+        let user_hooks = copilot_config["hooks"]
+            .as_object()
+            .expect("user-level hooks present");
+        assert!(user_hooks.contains_key("sessionStart"));
+        assert!(user_hooks.contains_key("preToolUse"));
+        assert!(
+            temp.path()
+                .join(".copilot/.github/hooks/session-start")
+                .exists()
+        );
+        assert!(copilot_config_raw.contains("\"name\": \"amplihack\""));
 
         crate::test_support::restore_cwd(&previous_cwd).unwrap();
         crate::test_support::restore_home(previous_home);
+    }
+
+    fn event_basename(event: &str) -> &'static str {
+        match event {
+            "sessionStart" => "session-start",
+            "userPromptSubmitted" => "user-prompt-submit",
+            "preToolUse" => "pre-tool-use",
+            "postToolUse" => "post-tool-use",
+            "preCompact" => "pre-compact",
+            "agentStop" => "stop",
+            _ => "",
+        }
     }
 
     #[test]
@@ -202,6 +295,7 @@ mod tests {
     fn build_wrapper_script_uses_binary_subcommand_for_single_hook() {
         let script = build_wrapper_script(&HookWrapperSpec {
             hook_name: "session-start",
+            copilot_event: "sessionStart",
             subcommands: &["session-start"],
         });
 
@@ -214,6 +308,7 @@ mod tests {
     fn build_wrapper_script_uses_multiple_binary_subcommands() {
         let script = build_wrapper_script(&HookWrapperSpec {
             hook_name: "user-prompt-submit",
+            copilot_event: "userPromptSubmitted",
             subcommands: &["workflow-classification-reminder", "user-prompt-submit"],
         });
 

--- a/crates/amplihack-cli/src/copilot_setup/mod.rs
+++ b/crates/amplihack-cli/src/copilot_setup/mod.rs
@@ -231,7 +231,10 @@ mod tests {
             let entry = &arr[0];
             assert_eq!(entry["type"], "command", "{event} entry type");
             assert!(
-                entry["bash"].as_str().unwrap_or("").contains(event_basename(event)),
+                entry["bash"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains(event_basename(event)),
                 "{event} bash path mismatch: {entry}"
             );
             assert!(
@@ -240,7 +243,12 @@ mod tests {
             );
         }
         // None of our event names should be the legacy kebab-case form.
-        for legacy in ["session-start", "user-prompt-submit", "post-tool-use", "stop"] {
+        for legacy in [
+            "session-start",
+            "user-prompt-submit",
+            "post-tool-use",
+            "stop",
+        ] {
             assert!(
                 !hooks_obj.contains_key(legacy),
                 "legacy event name leaked: {legacy}"


### PR DESCRIPTION
Closes #306.

## Confirmed bug: zero amplihack hooks were firing under Copilot CLI

After investigation, **five stacked bugs** kept every amplihack hook from running under Copilot CLI:

1. **Wrong event names** — emitted `session-start`, `post-tool-use`, `stop`, etc. Copilot 1.0.33 (`fWr` set in `~/.copilot/pkg/.../app.js`) only knows camelCase: `sessionStart`, `userPromptSubmitted`, `preToolUse`, `postToolUse`, `preCompact`, `agentStop`. Copilot logs `Ignoring unknown hook event(s) in <file>: ...` and skips them.
2. **Wrong entry shape** — values were file-path strings; Copilot expects `{type:"command", bash|powershell|command, cwd?, env?, timeoutSec?, _vsCodeCompat?}`. Zod schema rejects strings.
3. **Missing `pre-tool-use`** in `COPILOT_HOOK_WRAPPERS` — even after fixing the schema, no `preToolUse` wrapper ever shipped.
4. **Hooks only staged into launch-time cwd, errors swallowed** — `let _ = stage_repo_hooks(&cwd)`. If user opened Copilot without `amplihack launch`, nothing was wired.
5. **No user-level fallback** — Copilot reads `~/.copilot/config.json`'s `hooks` field, but we never wrote there.

## Fix

- Replace hard-coded `COPILOT_HOOKS_MANIFEST` with a JSON builder that emits the documented schema with absolute bash paths and `timeoutSec: 30`.
- Add `copilot_event: &'static str` to `HookWrapperSpec` (camelCase Copilot event name) and the missing `pre-tool-use` wrapper.
- New `write_user_level_hooks()` stages wrappers under `~/.copilot/.github/hooks/` and merges hook block into `~/.copilot/config.json`. Preserves existing non-amplihack user-defined entries.

## Tests

Updated `ensure_copilot_home_stages_assets_and_plugin` to assert:
- Manifest `version: 1`, all six camelCase events present
- Each entry has `type:"command"`, absolute `bash` ending in correct wrapper basename, `timeoutSec`
- Legacy kebab-case event names do NOT appear
- `~/.copilot/config.json` has the hook block under `hooks`
- Wrappers materialized under `~/.copilot/.github/hooks/`

## Validation

- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` clean
- `TMPDIR=/tmp cargo test -p amplihack-cli --lib` 1003 passed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>