### PR TITLE
fix(npm): resolve latest release tag at install time (#299)

### DIFF
--- a/npm/lib/bootstrap.js
+++ b/npm/lib/bootstrap.js
@@ -229,6 +229,38 @@ function download(url) {
   });
 }
 
+/**
+ * Resolve the latest published release tag for the configured GitHub repo.
+ *
+ * Returns the bare semver string (e.g. "0.7.63"). Falls back to the
+ * fallbackVersion parameter when the API call fails (offline, rate-limited,
+ * etc.) so installation degrades gracefully — only the freshness suffers.
+ *
+ * Honors AMPLIHACK_NPM_VERSION as an explicit override (set by users or CI
+ * who want a specific pinned version).
+ */
+async function resolveLatestReleaseTag(fallbackVersion) {
+  const explicit = process.env.AMPLIHACK_NPM_VERSION;
+  if (explicit) {
+    return explicit.replace(/^v/, '');
+  }
+  if (process.env.AMPLIHACK_NPM_NO_LATEST === '1') {
+    return fallbackVersion;
+  }
+  const url = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+  try {
+    const body = await download(url);
+    const data = JSON.parse(body.toString('utf8'));
+    const tag = typeof data.tag_name === 'string' ? data.tag_name.replace(/^v/, '') : '';
+    if (!/^\d+\.\d+\.\d+/.test(tag)) {
+      return fallbackVersion;
+    }
+    return tag;
+  } catch {
+    return fallbackVersion;
+  }
+}
+
 async function installFromRelease(version, installRoot) {
   const target = releaseTargetFor();
   if (!target) {
@@ -302,7 +334,14 @@ async function buildFromSource(root, installRoot) {
 }
 
 async function ensureNativeBinaries({ root, version }) {
-  const installRoot = cacheRoot(version);
+  // Resolve the freshest available release tag at install time. The
+  // package.json `version` field can drift behind the latest published
+  // release (the release workflow publishes new tags without rewriting
+  // package.json), so trusting `pkg.version` results in npx installs that
+  // ship a stale binary. Falling back to `version` keeps offline / API-
+  // rate-limited installs working.
+  const effectiveVersion = await resolveLatestReleaseTag(version);
+  const installRoot = cacheRoot(effectiveVersion);
   const binDir = path.join(installRoot, 'bin');
   const mainBinary = path.join(binDir, binaryFilename('amplihack'));
   const hooksBinary = path.join(binDir, binaryFilename('amplihack-hooks'));
@@ -323,7 +362,7 @@ async function ensureNativeBinaries({ root, version }) {
 
     if (!forceSource) {
       try {
-        await installFromRelease(version, installRoot);
+        await installFromRelease(effectiveVersion, installRoot);
         return { mainBinary, hooksBinary, installRoot };
       } catch (error) {
         errors.push(`release download failed: ${error.message}`);
@@ -371,6 +410,7 @@ module.exports = {
   parseChecksumHex,
   releaseTargetFor,
   releaseUrls,
+  resolveLatestReleaseTag,
   runAmplihack,
   validateDownloadUrl,
   verifyArchiveChecksum,

--- a/npm/test/bootstrap.test.js
+++ b/npm/test/bootstrap.test.js
@@ -17,6 +17,7 @@ const {
   parseChecksumHex,
   releaseTargetFor,
   releaseUrls,
+  resolveLatestReleaseTag,
   validateDownloadUrl,
   verifyArchiveChecksum,
 } = require('../lib/bootstrap');
@@ -118,4 +119,39 @@ test('package version stays aligned with Cargo workspace version', () => {
   const match = cargoToml.match(/\[workspace\.package\][\s\S]*?version = "([^"]+)"/u);
   assert.ok(match, 'workspace.package.version must exist');
   assert.equal(packageJson.version, match[1]);
+});
+
+test('resolveLatestReleaseTag honors AMPLIHACK_NPM_VERSION override', async () => {
+  const prev = process.env.AMPLIHACK_NPM_VERSION;
+  process.env.AMPLIHACK_NPM_VERSION = 'v9.9.9';
+  try {
+    const tag = await resolveLatestReleaseTag('0.0.1');
+    assert.equal(tag, '9.9.9', 'leading v stripped from override');
+  } finally {
+    if (prev === undefined) {
+      delete process.env.AMPLIHACK_NPM_VERSION;
+    } else {
+      process.env.AMPLIHACK_NPM_VERSION = prev;
+    }
+  }
+});
+
+test('resolveLatestReleaseTag falls back when network disabled', async () => {
+  const prev = process.env.AMPLIHACK_NPM_NO_LATEST;
+  const prevExplicit = process.env.AMPLIHACK_NPM_VERSION;
+  process.env.AMPLIHACK_NPM_NO_LATEST = '1';
+  delete process.env.AMPLIHACK_NPM_VERSION;
+  try {
+    const tag = await resolveLatestReleaseTag('1.2.3');
+    assert.equal(tag, '1.2.3');
+  } finally {
+    if (prev === undefined) {
+      delete process.env.AMPLIHACK_NPM_NO_LATEST;
+    } else {
+      process.env.AMPLIHACK_NPM_NO_LATEST = prev;
+    }
+    if (prevExplicit !== undefined) {
+      process.env.AMPLIHACK_NPM_VERSION = prevExplicit;
+    }
+  }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.7.21",
+  "version": "0.7.32",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Closes #299.

## Symptom

```
$ npx --yes --package=git+https://github.com/rysweet/amplihack-rs.git -- amplihack install
...
$ amplihack update
amplihack update (current: v0.7.21)
New version available: v0.7.21 -> v0.7.61
```

## Root cause

`npm/bin/amplihack.js` passes `pkg.version` (`0.7.21`) to `ensureNativeBinaries`, which downloads `amplihack-<target>.tar.gz` from `releases/download/v0.7.21/`. The release workflow publishes new tags without rewriting `package.json`, so the file drifts and every npx user gets a stale binary.

## Fix

1. **Runtime (primary):** new `resolveLatestReleaseTag(fallback)` queries `api.github.com/repos/<owner>/<repo>/releases/latest` and returns the bare tag. `ensureNativeBinaries` uses this as the effective install version. Falls back to `pkg.version` when the API call fails (offline, rate-limited, private), is opted out via `AMPLIHACK_NPM_NO_LATEST=1`, or returns an unexpected shape. Honors `AMPLIHACK_NPM_VERSION=<tag>` as an explicit pin.

2. **Alignment sync:** bumped `package.json` to `0.7.32` (current `Cargo.toml` `workspace.package.version`) so the existing alignment test passes and the offline fallback ships a current version.

## Tests
- New: `resolveLatestReleaseTag honors AMPLIHACK_NPM_VERSION override`
- New: `resolveLatestReleaseTag falls back when AMPLIHACK_NPM_NO_LATEST=1`
- Existing: alignment test now passes
- `node --test npm/test/*.test.js` 13/13 passed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>