### PR TITLE
fix(recipes): bulletproof heredoc substitutions across workflow recipes

### DIFF
--- a/amplifier-bundle/recipes/consensus-workflow.yaml
+++ b/amplifier-bundle/recipes/consensus-workflow.yaml
@@ -578,10 +578,8 @@ steps:
       fi
 
       # Create branch name
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#311): use exported env var instead of fragile heredoc substitution
+      TASK_DESC="${TASK_DESCRIPTION:-}"
       TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g;s/^-//;s/-$//' | cut -c1-30 | sed 's/-$//')
       # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -139,12 +139,11 @@ steps:
       # FIX (issues #3045/#3076/#3117): unquoted heredoc for safe variable capture.
       # Unquoted heredoc allows Rust runner env-var expansion ($RECIPE_VAR_*).
       # Shell expansion is single-pass: expanded values are NOT re-processed.
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#311): use exported env var instead of template-substituted heredoc
+      # — bulletproof against any content (newlines, terminators, quotes).
+      TASK_DESC="${TASK_DESCRIPTION:-}"
       printf 'Task: %s\n' "$TASK_DESC"
-      printf 'Repository: %s\n' {{repo_path}}
+      printf 'Repository: %s\n' "${REPO_PATH:-{{repo_path}}}"
     output: "workflow_init"
 
   # ==========================================================================
@@ -302,18 +301,13 @@ steps:
       # The recipe runner performs {{variable}} substitution before bash executes,
       # so quoted delimiters are safe and correct.
       # Use unique delimiter unlikely to appear in user task descriptions.
-      TASK_DESC=$(cat <<'_AMPLIHACK_STEP03_TASK_EOF_'
-      {{task_description}}
-      _AMPLIHACK_STEP03_TASK_EOF_
-      )
+      # FIX (#311): use exported env vars instead of template-substituted heredocs.
+      TASK_DESC="${TASK_DESCRIPTION:-}"
       # Bash builtins replace tr|cut pipeline — avoids 2 subprocess spawns (matches step-16)
       ISSUE_TITLE="${TASK_DESC//$'\n'/ }"
       ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"
       ISSUE_TITLE="${ISSUE_TITLE:0:200}"
-      ISSUE_REQS=$(cat <<'_AMPLIHACK_STEP03_REQS_EOF_'
-      {{final_requirements}}
-      _AMPLIHACK_STEP03_REQS_EOF_
-      )
+      ISSUE_REQS="${FINAL_REQUIREMENTS:-}"
 
       # Idempotency Guard 1: Reuse issue referenced in task_description (#NNNN)
       # Mirrors step-16-create-draft-pr idempotency pattern (#3324).
@@ -374,22 +368,14 @@ steps:
     type: "bash"
     command: |
       # Extract issue number from the creation output.
-      # FIX (issue #3022): Use safe heredoc capture instead of echo {{variable}} to
-      # prevent shell metacharacter injection from issue body content.  Use head -1
-      # instead of tail -1 so the canonical URL (first match) wins — not a trailing
+      # FIX (#311): use exported env vars (ISSUE_CREATION, TASK_DESCRIPTION)
+      # instead of fragile template-substituted heredocs. The recipe runner
+      # exports every context key as an env var, immune to delimiter collisions
+      # and shell metacharacter injection regardless of content.
+      # Use head -1 so the canonical URL (first match) wins — not a trailing
       # noise number captured via 2>&1 in step-03a.
-      # EOFISSUECREATION delimiter is intentionally long/specific to prevent accidental
-      # collision with issue body text that might contain common delimiters like "EOF".
-      ISSUE_CREATION=$(cat <<'EOFISSUECREATION'
-      {{issue_creation}}
-      EOFISSUECREATION
-      )
-      # FIX (#4247): Capture task_description at top level (not inside if block)
-      # to avoid indented heredoc delimiters that bash cannot parse.
-      TASK_DESC_RAW=$(cat <<'EOFTASKDESC03B'
-      {{task_description}}
-      EOFTASKDESC03B
-      )
+      ISSUE_CREATION="${ISSUE_CREATION:-}"
+      TASK_DESC_RAW="${TASK_DESCRIPTION:-}"
       # FIX (#4233): Match both issue URLs (issues/NNN) and PR URLs (pull/NNN).
       # If the output is a PR URL, resolve the linked issue via gh pr view.
       EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
@@ -456,10 +442,7 @@ steps:
       # `$TREE_SCRIPT` or `$ORCH_SCRIPT` in their task text.
       # Security note: the sanitization pipeline (tr -cd 'a-z0-9-') strips all
       # shell metacharacters from the output, mitigating injection risk.
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      TASK_DESC="${TASK_DESCRIPTION:-}"
       TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-50 | sed 's/-$//')
       # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
@@ -1214,11 +1197,8 @@ steps:
       git add -A
       echo ""
       echo "--- Creating Commit ---"
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#311): use exported env var instead of fragile heredoc substitution
+      TASK_DESC="${TASK_DESCRIPTION:-}"
       COMMIT_TITLE=$(printf 'feat: %.72s' "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
       COMMIT_MSG=$(printf '%s\n\nImplements issue #%s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\nCloses #%s' "$COMMIT_TITLE" {{issue_number}} {{issue_number}})
       if [ -n "$(git diff --cached --name-only)" ]; then
@@ -1331,19 +1311,13 @@ steps:
       fi
 
       # Normal path: 1+ commits ahead, no existing PR — create the PR
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#311): use exported env var instead of fragile heredoc substitution
+      TASK_DESC="${TASK_DESCRIPTION:-}"
       # Bash builtins replace the `tr | cut` pipeline — avoids 2 subprocess spawns
       PR_TITLE="${TASK_DESC//$'\n'/ }"
       PR_TITLE="${PR_TITLE//$'\r'/ }"
       PR_TITLE="${PR_TITLE:0:200}"
-      PR_DESIGN=$(cat <<EOFDESIGN
-      {{design_spec}}
-      EOFDESIGN
-      )
+      PR_DESIGN="${DESIGN_SPEC:-}"
       PR_BODY=$(printf '## Summary\n%s\n\n## Issue\nCloses #%s\n\n## Changes\n%s\n\n## Testing\n- Unit tests added\n- Local testing completed\n- Pre-commit hooks pass\n\n## Checklist\n- [x] Tests pass\n- [x] Documentation updated\n- [x] No stubs or TODOs\n- [ ] Code review completed\n- [ ] Philosophy check passed\n\n---\n*This PR was created as a draft for review before merging.*\n' "$TASK_DESC" "$ISSUE_NUM" "$PR_DESIGN")
       # timeout 120: gh pr create contacts GitHub GraphQL API — cap wait to 2 minutes
       # 2>/dev/null: suppress gh stderr to prevent output contract corruption of pr_url
@@ -1752,14 +1726,8 @@ steps:
       # ARG_MAX guard: large template variables (philosophy_check, patterns_check)
       # are captured via heredoc and truncated to 1 KB summaries.  Echoing them
       # raw caused ARG_MAX overflow — see #3366 / b1f87112b.
-      PHIL_CHECK=$(cat <<'EOFPHILCHECK'
-      {{philosophy_check}}
-      EOFPHILCHECK
-      )
-      PAT_CHECK=$(cat <<'EOFPATCHECK'
-      {{patterns_check}}
-      EOFPATCHECK
-      )
+      PHIL_CHECK="${PHILOSOPHY_CHECK:-}"
+      PAT_CHECK="${PATTERNS_CHECK:-}"
       PHIL_SUMMARY=$(printf '%.1024s' "$PHIL_CHECK")
       PAT_SUMMARY=$(printf '%.1024s' "$PAT_CHECK")
 
@@ -1970,11 +1938,8 @@ steps:
       echo "PR Status:" && \
       gh pr view --json state,mergeable,reviews,statusCheckRollup && \
       echo "" && \
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      ) && \
+      # FIX (#311): use exported env var instead of fragile heredoc substitution
+      TASK_DESC="${TASK_DESCRIPTION:-}" && \
       printf '=== Task: %s ===\n' "$TASK_DESC" && \
       printf '=== Issue: #%s ===\n' {{issue_number}} && \
       printf '=== PR: %s ===\n' {{pr_url}} && \
@@ -1989,11 +1954,8 @@ steps:
     type: "bash"
     parse_json: true
     command: |
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#311): use exported env var instead of fragile heredoc substitution
+      TASK_DESC="${TASK_DESCRIPTION:-}"
       TASK_VAL=$(printf '%s' "$TASK_DESC")
       export TASK_VAL
       # {{issue_number}} and {{pr_url}} are system-generated integers/URLs —

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -142,11 +142,10 @@ steps:
   - id: "parse-decomposition"
     type: "bash"
     command: |
+      # FIX (#311): use exported env var instead of template-substituted heredoc.
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
-      {{decomposition_json}}
-      __DECOMP_EOF__
+      printf '%s' "${DECOMPOSITION_JSON:-}" > "$_DECOMP_TMPFILE"
       RAW_OBJ=$(amplihack orch helper extract-json < "$_DECOMP_TMPFILE")
       if [ "$RAW_OBJ" = "{}" ]; then
         cat <<'WARN' >&2
@@ -171,9 +170,7 @@ steps:
       # task description has strong development signals (file paths, "Add"+
       # path, PR mention, tests, multi-requirement), promote to Development.
       _TASK_TMPFILE=$(mktemp)
-      cat > "$_TASK_TMPFILE" <<__TASK_EOF__
-      {{task_description}}
-      __TASK_EOF__
+      printf '%s' "${TASK_DESCRIPTION:-}" > "$_TASK_TMPFILE"
       FINAL_TYPE=$(amplihack orch helper reclassify-task-type --current "$CANONICAL_TYPE" < "$_TASK_TMPFILE")
       rm -f "$_TASK_TMPFILE"
       if [ "$FINAL_TYPE" != "$CANONICAL_TYPE" ]; then
@@ -191,9 +188,7 @@ steps:
     command: |
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
-      {{decomposition_json}}
-      __DECOMP_EOF__
+      printf '%s' "${DECOMPOSITION_JSON:-}" > "$_DECOMP_TMPFILE"
       TASK_TYPE={{task_type}}
       FORCE_SINGLE={{force_single_workstream}}
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
@@ -352,10 +347,7 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type"
     command: |
-      SESSION_JSON=$(cat <<EOFSESSIONJSON
-      {{session_info}}
-      EOFSESSIONJSON
-      )
+      SESSION_JSON="${SESSION_INFO:-}"
       # Extract status using shell grep — no Python subprocess needed
       if echo "$SESSION_JSON" | grep -qE '"status" *: *"ok"'; then
         echo "ALLOWED"
@@ -418,9 +410,7 @@ steps:
     command: |
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
-      {{decomposition_json}}
-      __DECOMP_EOF__
+      printf '%s' "${DECOMPOSITION_JSON:-}" > "$_DECOMP_TMPFILE"
       amplihack orch helper build-workstreams-config < "$_DECOMP_TMPFILE"
     output: "workstreams_file"
 
@@ -435,10 +425,7 @@ steps:
       echo '{"transition":"step_started","step":"launch-parallel-round-1","timestamp":'$(date +%s)'}' >&2
       REPO_PATH={{repo_path}}
       WS_FILE={{workstreams_file}}
-      SESSION_JSON=$(cat <<EOFSESSIONJSON
-      {{session_info}}
-      EOFSESSIONJSON
-      )
+      SESSION_JSON="${SESSION_INFO:-}"
       # #283: parse tree_id, depth, and workstreams count using jq instead of
       # inline Python. jq is a standard CLI tool and removes a python3 heredoc.
       TREE_ID=$(printf '%s' "$SESSION_JSON" | jq -r '.tree_id // ""' 2>/dev/null || echo "")
@@ -596,7 +583,7 @@ steps:
       FORCE_SINGLE={{force_single_workstream}}
       GUARD={{recursion_guard}}
       RECIPE={{adaptive_recipe}}
-      TASK_DESC=$(printf '%s' {{task_description}})
+      TASK_DESC="${TASK_DESCRIPTION:-}"
 
       # Build diagnostic body
       BODY=$(cat <<EOFBODY
@@ -936,10 +923,7 @@ steps:
   - id: "complete-session"
     type: "bash"
     command: |
-      SESSION_JSON=$(cat <<EOFSESSIONJSON
-      {{session_info}}
-      EOFSESSIONJSON
-      )
+      SESSION_JSON="${SESSION_INFO:-}"
       TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
       # #283: parse session fields via jq instead of inline Python.


### PR DESCRIPTION
## Problem

Reported in user session: `step-03-create-issue` repeatedly fails with shell-quoting errors on long task descriptions. Investigation showed the failure mode applies to **19 sites** across 3 recipe files.

## Root Cause

The recipe-runner template engine (`crates/amplihack-recipe/src/template.rs`) does **literal text substitution** of `{{key}}` into the bash command. When that substitution lands inside a heredoc (`cat <<'EOFTASKDESC' ... EOFTASKDESC`), it breaks if the user content:

- Contains the literal heredoc terminator on a line by itself (closes early)
- Has unbalanced backslash continuations or embedded `\r`
- (For unquoted heredocs) contains `$VAR` refs that get expanded
- (At one site) gets passed through `printf '%s' {{task_description}}` unquoted — word-splits on whitespace

## Fix

The recipe runner already exports every context key as an env var (executor.rs:383-414, uppercased, dashes→underscores, 128KB per-value default). Replace fragile template-substituted heredocs with direct env var references — bulletproof regardless of input content.

| Recipe | Sites fixed |
|--------|-------------|
| default-workflow.yaml | 12 (steps 00, 03, 03b, 04, 15, 16, 19d, 22b, complete) |
| smart-orchestrator.yaml | 6 (parse-decomposition, activate-workflow, recursion-guard, launch-parallel, routing-gap, complete-session) |
| consensus-workflow.yaml | 1 (branch creation) |

## Validation

- YAML parses cleanly for all 3 recipes
- `cargo test -p amplihack-recipe --lib` → 152 passed
- Net 56 lines removed (simpler code)

## Risk

- Per-value env limit is 128KB (default). Task descriptions exceeding this would now produce empty `$TASK_DESCRIPTION` instead of the previous behavior of being silently embedded into broken shell. Failure mode is more visible.
- Tested with the recipe-runner unit tests; full e2e validation will happen on first `/dev` invocation post-merge.