### PR TITLE
Bulletproof recipe heredoc substitutions: the recipe runner template engine (crates/amplihack-recipe/src/template.rs) does literal text substitution of {{key}} into bash commands. When this lands insi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplihack"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-core"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-memory",
  "async-trait",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-eval"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "chrono",
  "serde",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-generator"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "chrono",
  "serde",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-asset-resolver-bin"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-cli",
  "tracing",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-blarify"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-hive",
  "amplihack-state",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-context"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-delegation"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "chrono",
  "globset",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-domain-agents"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-fleet"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "serde",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hive"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-cli",
  "amplihack-security",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-launcher"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-memory"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "md-5",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-multilspy"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recipe"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "libc",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recovery"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-remote"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-safety"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "serde",
  "serde_json",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-security"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "once_cell",
  "regex",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "serde",
  "serde_json",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-utils"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "chrono",
  "libc",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-workflows"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "chrono",
  "serde",
@@ -532,9 +532,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -569,9 +569,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -621,18 +621,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -847,9 +847,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -983,6 +983,12 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1134,12 +1140,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1176,9 +1182,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1213,15 +1219,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
@@ -1381,9 +1387,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -1574,9 +1580,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1612,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -1712,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -1736,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1932,9 +1938,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -2081,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2222,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -2312,9 +2318,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2367,11 +2373,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2380,14 +2386,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2398,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2408,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2421,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2468,14 +2474,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2647,6 +2653,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.32"
+version = "0.7.33"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/amplifier-bundle/recipes/consensus-workflow.yaml
+++ b/amplifier-bundle/recipes/consensus-workflow.yaml
@@ -111,13 +111,13 @@ steps:
     type: "bash"
     command: |
       ERRORS=""
-      REPO="{{repo_path}}"
+      REPO="$REPO_PATH"
       if [ ! -d "$REPO" ]; then
         ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' does not exist"
       elif ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
         ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' is not a git repository"
       fi
-      if [ -z "{{task_description}}" ]; then
+      if [ -z "$TASK_DESCRIPTION" ]; then
         ERRORS="${ERRORS}\n  ✗ task_description is empty"
       fi
       if [ -n "$ERRORS" ]; then
@@ -495,17 +495,17 @@ steps:
     type: "bash"
     command: |
       # Create GitHub issue from consensus requirements
-      echo "Creating GitHub issue for: {{task_description}}"
+      echo "Creating GitHub issue for: $TASK_DESCRIPTION"
 
-      # FIX (#469): Assign template vars to shell vars first — avoids heredoc delimiter collision.
-      _TASK_DESC="{{task_description}}"
-      _REQS_EXPLICIT="{{final_requirements.explicit_requirements}}"
-      _REQS_SUCCESS="{{final_requirements.success_criteria}}"
-      _REQS_CONSTRAINTS="{{final_requirements.constraints}}"
-      _REQS_MECHANISM="{{final_requirements.consensus_mechanism_used}}"
-      _REQS_AGENTS="{{final_requirements.agents_involved}}"
-      _REQS_CONFIDENCE="{{final_requirements.confidence_level}}"
-      _CRITICALITY="{{criticality}}"
+      # FIX (#311): Use env vars — safe against injection and word-splitting.
+      _TASK_DESC="$TASK_DESCRIPTION"
+      _REQS_EXPLICIT="$FINAL_REQUIREMENTS_EXPLICIT_REQUIREMENTS"
+      _REQS_SUCCESS="$FINAL_REQUIREMENTS_SUCCESS_CRITERIA"
+      _REQS_CONSTRAINTS="$FINAL_REQUIREMENTS_CONSTRAINTS"
+      _REQS_MECHANISM="$FINAL_REQUIREMENTS_CONSENSUS_MECHANISM_USED"
+      _REQS_AGENTS="$FINAL_REQUIREMENTS_AGENTS_INVOLVED"
+      _REQS_CONFIDENCE="$FINAL_REQUIREMENTS_CONFIDENCE_LEVEL"
+      _CRITICALITY="$CRITICALITY"
       # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
       ISSUE_BODY=$(cat <<ISSUE_EOF
       ## Task Description
@@ -586,8 +586,8 @@ steps:
         BASE_REF="HEAD"
       fi
 
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC="{{task_description}}"
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
       TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g;s/^-//;s/-$//' | cut -c1-30 | sed 's/-$//')
       # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
@@ -632,7 +632,7 @@ steps:
       fi
 
       # Idempotency guard (mirrors default-workflow three-state check)
-      WORKTREE_PATH="{{worktree_dir}}/$BRANCH_NAME"
+      WORKTREE_PATH="$WORKTREE_DIR/$BRANCH_NAME"
       BRANCH_EXISTS=$(git branch --list "$BRANCH_NAME")
       WORKTREE_EXISTS=$(git worktree list --porcelain | grep -Fx "worktree $WORKTREE_PATH" || true)
 
@@ -1654,11 +1654,11 @@ steps:
       # Stage all changes
       git add -A
 
-      # FIX (#469): Assign template vars to shell vars — avoids heredoc delimiter collision.
-      _TASK_DESC="{{task_description}}"
-      _REQS_SUMMARY="{{final_requirements.task_summary}}"
-      _IS_CRITICAL="{{is_critical_code}}"
-      _ISSUE_NUM="{{issue_number}}"
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      _TASK_DESC="$TASK_DESCRIPTION"
+      _REQS_SUMMARY="$FINAL_REQUIREMENTS_TASK_SUMMARY"
+      _IS_CRITICAL="$IS_CRITICAL_CODE"
+      _ISSUE_NUM="$ISSUE_NUMBER"
       SHORT_DESC=$(printf '%s' "$_TASK_DESC" | tr '\n\r' ' ' | cut -c1-72)
       # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
       COMMIT_MSG=$(cat <<COMMIT_EOF
@@ -1705,14 +1705,14 @@ steps:
     command: |
       echo "Creating pull request..."
 
-      # FIX (#469): Assign template vars to shell vars — avoids heredoc delimiter collision.
-      _TASK_DESC="{{task_description}}"
-      _REQS_EXPLICIT="{{final_requirements.explicit_requirements}}"
-      _REQS_MECHANISM="{{final_requirements.consensus_mechanism_used}}"
-      _IS_CRITICAL="{{is_critical_code}}"
-      _TDD_TOTAL="{{tdd_tests.total_tests}}"
-      _LOCAL_PASSED="{{local_testing.all_scenarios_passed}}"
-      _ISSUE_NUM="{{issue_number}}"
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      _TASK_DESC="$TASK_DESCRIPTION"
+      _REQS_EXPLICIT="$FINAL_REQUIREMENTS_EXPLICIT_REQUIREMENTS"
+      _REQS_MECHANISM="$FINAL_REQUIREMENTS_CONSENSUS_MECHANISM_USED"
+      _IS_CRITICAL="$IS_CRITICAL_CODE"
+      _TDD_TOTAL="$TDD_TESTS_TOTAL_TESTS"
+      _LOCAL_PASSED="$LOCAL_TESTING_ALL_SCENARIOS_PASSED"
+      _ISSUE_NUM="$ISSUE_NUMBER"
       # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
       PR_BODY=$(cat <<PR_EOF
       ## Description
@@ -2387,19 +2387,19 @@ steps:
     type: "bash"
     parse_json: true
     command: |
-      # FIX (#469): Use jq --arg for safe JSON construction — no heredoc delimiter collision.
+      # FIX (#469/#311): Use jq --arg with "$ENV_VAR" — safe against injection and word-splitting.
       jq -n \
-        --arg task {{task_description}} \
-        --arg criticality {{criticality}} \
-        --arg gate1 {{final_requirements.consensus_mechanism_used}} \
-        --arg gate2 {{design_consensus.consensus_achieved}} \
-        --arg gate3 {{is_critical_code}} \
-        --arg gate4 {{refactoring_consensus.unanimous_approval}} \
-        --arg gate5 {{pr_review_consensus.unanimous_approval}} \
-        --arg gate6 {{philosophy_consensus.unanimous_philosophy_approval}} \
-        --arg gate7 {{final_consensus.final_unanimous_approval}} \
-        --arg final_approval {{final_consensus.production_ready}} \
-        --arg pr_ready {{final_consensus.pr_approved_for_merge}} \
+        --arg task "$TASK_DESCRIPTION" \
+        --arg criticality "$CRITICALITY" \
+        --arg gate1 "$FINAL_REQUIREMENTS_CONSENSUS_MECHANISM_USED" \
+        --arg gate2 "$DESIGN_CONSENSUS_CONSENSUS_ACHIEVED" \
+        --arg gate3 "$IS_CRITICAL_CODE" \
+        --arg gate4 "$REFACTORING_CONSENSUS_UNANIMOUS_APPROVAL" \
+        --arg gate5 "$PR_REVIEW_CONSENSUS_UNANIMOUS_APPROVAL" \
+        --arg gate6 "$PHILOSOPHY_CONSENSUS_UNANIMOUS_PHILOSOPHY_APPROVAL" \
+        --arg gate7 "$FINAL_CONSENSUS_FINAL_UNANIMOUS_APPROVAL" \
+        --arg final_approval "$FINAL_CONSENSUS_PRODUCTION_READY" \
+        --arg pr_ready "$FINAL_CONSENSUS_PR_APPROVED_FOR_MERGE" \
         '{
           workflow: "consensus-workflow",
           version: "2.0.0",

--- a/amplifier-bundle/recipes/consensus-workflow.yaml
+++ b/amplifier-bundle/recipes/consensus-workflow.yaml
@@ -497,36 +497,45 @@ steps:
       # Create GitHub issue from consensus requirements
       echo "Creating GitHub issue for: {{task_description}}"
 
-      # Format issue body
-      ISSUE_BODY=$(cat << 'ISSUE_EOF'
+      # FIX (#469): Assign template vars to shell vars first — avoids heredoc delimiter collision.
+      _TASK_DESC={{task_description}}
+      _REQS_EXPLICIT={{final_requirements.explicit_requirements}}
+      _REQS_SUCCESS={{final_requirements.success_criteria}}
+      _REQS_CONSTRAINTS={{final_requirements.constraints}}
+      _REQS_MECHANISM={{final_requirements.consensus_mechanism_used}}
+      _REQS_AGENTS={{final_requirements.agents_involved}}
+      _REQS_CONFIDENCE={{final_requirements.confidence_level}}
+      _CRITICALITY={{criticality}}
+      # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
+      ISSUE_BODY=$(cat <<ISSUE_EOF
       ## Task Description
-      {{task_description}}
+      $_TASK_DESC
 
       ## Requirements (Consensus-Validated)
-      {{final_requirements.explicit_requirements}}
+      $_REQS_EXPLICIT
 
       ## Success Criteria
-      {{final_requirements.success_criteria}}
+      $_REQS_SUCCESS
 
       ## Constraints
-      {{final_requirements.constraints}}
+      $_REQS_CONSTRAINTS
 
       ## Consensus Process
-      - Mechanism Used: {{final_requirements.consensus_mechanism_used}}
-      - Agents Involved: {{final_requirements.agents_involved}}
-      - Confidence: {{final_requirements.confidence_level}}
+      - Mechanism Used: $_REQS_MECHANISM
+      - Agents Involved: $_REQS_AGENTS
+      - Confidence: $_REQS_CONFIDENCE
 
       ---
-      Labels: consensus-validated, {{criticality}}
+      Labels: consensus-validated, $_CRITICALITY
       ISSUE_EOF
       )
 
       # Create issue (truncate title to 200 chars)
-      ISSUE_TITLE=$(printf '%s' {{task_description}} | tr '\n\r' ' ' | cut -c1-200)
+      ISSUE_TITLE=$(printf '%s' "$_TASK_DESC" | tr '\n\r' ' ' | cut -c1-200)
       gh issue create \
         --title "$ISSUE_TITLE" \
         --body "$ISSUE_BODY" \
-        --label "consensus,{{criticality}}" 2>/dev/null || echo "Issue creation skipped (no gh CLI or not in repo)"
+        --label "consensus,$_CRITICALITY" 2>/dev/null || echo "Issue creation skipped (no gh CLI or not in repo)"
 
       echo '{"issue_created": true, "step": "step2-create-issue"}'
     output: "issue_creation"
@@ -577,11 +586,8 @@ steps:
         BASE_REF="HEAD"
       fi
 
-      # Create branch name
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      TASK_DESC={{task_description}}
       TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g;s/^-//;s/-$//' | cut -c1-30 | sed 's/-$//')
       # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
@@ -1648,22 +1654,27 @@ steps:
       # Stage all changes
       git add -A
 
-      # Create commit message (truncate title to 72 chars for git convention)
-      SHORT_DESC=$(printf '%s' {{task_description}} | tr '\n\r' ' ' | cut -c1-72)
-      COMMIT_MSG=$(cat << COMMIT_EOF
+      # FIX (#469): Assign template vars to shell vars — avoids heredoc delimiter collision.
+      _TASK_DESC={{task_description}}
+      _REQS_SUMMARY={{final_requirements.task_summary}}
+      _IS_CRITICAL={{is_critical_code}}
+      _ISSUE_NUM={{issue_number}}
+      SHORT_DESC=$(printf '%s' "$_TASK_DESC" | tr '\n\r' ' ' | cut -c1-72)
+      # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
+      COMMIT_MSG=$(cat <<COMMIT_EOF
       feat: ${SHORT_DESC}
 
-      Implements {{final_requirements.task_summary}}
+      Implements $_REQS_SUMMARY
 
       Consensus Mechanisms Used:
       - Multi-Agent Debate: Requirements clarification
       - Multi-Agent Debate: Architecture design
-      - N-Version Programming: {{is_critical_code}}
+      - N-Version Programming: $_IS_CRITICAL
       - Expert Panel: Refactoring review
 
       Requirements validated by consensus process.
 
-      Resolves #{{issue_number}}
+      Resolves #$_ISSUE_NUM
       COMMIT_EOF
       )
 
@@ -1694,12 +1705,21 @@ steps:
     command: |
       echo "Creating pull request..."
 
-      PR_BODY=$(cat << 'PR_EOF'
+      # FIX (#469): Assign template vars to shell vars — avoids heredoc delimiter collision.
+      _TASK_DESC={{task_description}}
+      _REQS_EXPLICIT={{final_requirements.explicit_requirements}}
+      _REQS_MECHANISM={{final_requirements.consensus_mechanism_used}}
+      _IS_CRITICAL={{is_critical_code}}
+      _TDD_TOTAL={{tdd_tests.total_tests}}
+      _LOCAL_PASSED={{local_testing.all_scenarios_passed}}
+      _ISSUE_NUM={{issue_number}}
+      # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
+      PR_BODY=$(cat <<PR_EOF
       ## Description
-      {{task_description}}
+      $_TASK_DESC
 
       ## Requirements (Consensus-Validated)
-      {{final_requirements.explicit_requirements}}
+      $_REQS_EXPLICIT
 
       ## Design Decisions
       Architecture consensus achieved with:
@@ -1708,14 +1728,14 @@ steps:
       - All conflicts resolved with documented rationale
 
       ## Consensus Mechanisms Applied
-      - [x] Multi-Agent Debate: Requirements ({{final_requirements.consensus_mechanism_used}})
+      - [x] Multi-Agent Debate: Requirements ($_REQS_MECHANISM)
       - [x] Multi-Agent Debate: Architecture design
-      - [x] N-Version Programming: {{is_critical_code}}
+      - [x] N-Version Programming: $_IS_CRITICAL
       - [x] Expert Panel: Refactoring review
 
       ## Test Plan
-      - Unit tests: {{tdd_tests.total_tests}} tests
-      - Local testing: {{local_testing.all_scenarios_passed}}
+      - Unit tests: $_TDD_TOTAL tests
+      - Local testing: $_LOCAL_PASSED
       - Coverage: All requirements mapped to tests
 
       ## Checklist
@@ -1725,14 +1745,14 @@ steps:
       - [x] Local testing completed
       - [x] No stubs/TODOs/placeholders
 
-      Resolves #{{issue_number}}
+      Resolves #$_ISSUE_NUM
 
       ---
       Label: consensus-validated
       PR_EOF
       )
 
-      PR_TITLE=$(printf '%s' {{task_description}} | tr '\n\r' ' ' | cut -c1-200)
+      PR_TITLE=$(printf '%s' "$_TASK_DESC" | tr '\n\r' ' ' | cut -c1-200)
       PR_CREATED=false
       if git remote get-url origin >/dev/null 2>&1; then
         if gh pr create \
@@ -2367,30 +2387,41 @@ steps:
     type: "bash"
     parse_json: true
     command: |
-      cat << 'EOF'
-      {
-        "workflow": "consensus-workflow",
-        "version": "2.0.0",
-        "task": "{{task_description}}",
-        "criticality": "{{criticality}}",
-        "status": "complete",
-        "consensus_gates_completed": {
-          "gate1_requirements_debate": "{{final_requirements.consensus_mechanism_used}}",
-          "gate2_design_debate": "{{design_consensus.consensus_achieved}}",
-          "gate3_n_version": "{{is_critical_code}}",
-          "gate4_refactoring_panel": "{{refactoring_consensus.unanimous_approval}}",
-          "gate5_pr_review_panel": "{{pr_review_consensus.unanimous_approval}}",
-          "gate6_philosophy_panel": "{{philosophy_consensus.unanimous_philosophy_approval}}",
-          "gate7_final_quality_panel": "{{final_consensus.final_unanimous_approval}}"
-        },
-        "agents_involved": [
-          "prompt-writer", "analyzer", "architect", "security", "api-designer",
-          "database", "tester", "worktree-manager", "builder", "cleanup",
-          "optimizer", "reviewer", "patterns", "pre-commit-diagnostic",
-          "ci-diagnostic-workflow", "philosophy-guardian"
-        ],
-        "final_approval": "{{final_consensus.production_ready}}",
-        "pr_ready_to_merge": "{{final_consensus.pr_approved_for_merge}}"
-      }
-      EOF
+      # FIX (#469): Use jq --arg for safe JSON construction — no heredoc delimiter collision.
+      jq -n \
+        --arg task {{task_description}} \
+        --arg criticality {{criticality}} \
+        --arg gate1 {{final_requirements.consensus_mechanism_used}} \
+        --arg gate2 {{design_consensus.consensus_achieved}} \
+        --arg gate3 {{is_critical_code}} \
+        --arg gate4 {{refactoring_consensus.unanimous_approval}} \
+        --arg gate5 {{pr_review_consensus.unanimous_approval}} \
+        --arg gate6 {{philosophy_consensus.unanimous_philosophy_approval}} \
+        --arg gate7 {{final_consensus.final_unanimous_approval}} \
+        --arg final_approval {{final_consensus.production_ready}} \
+        --arg pr_ready {{final_consensus.pr_approved_for_merge}} \
+        '{
+          workflow: "consensus-workflow",
+          version: "2.0.0",
+          task: $task,
+          criticality: $criticality,
+          status: "complete",
+          consensus_gates_completed: {
+            gate1_requirements_debate: $gate1,
+            gate2_design_debate: $gate2,
+            gate3_n_version: $gate3,
+            gate4_refactoring_panel: $gate4,
+            gate5_pr_review_panel: $gate5,
+            gate6_philosophy_panel: $gate6,
+            gate7_final_quality_panel: $gate7
+          },
+          agents_involved: [
+            "prompt-writer", "analyzer", "architect", "security", "api-designer",
+            "database", "tester", "worktree-manager", "builder", "cleanup",
+            "optimizer", "reviewer", "patterns", "pre-commit-diagnostic",
+            "ci-diagnostic-workflow", "philosophy-guardian"
+          ],
+          final_approval: $final_approval,
+          pr_ready_to_merge: $pr_ready
+        }'
     output: "workflow_result"

--- a/amplifier-bundle/recipes/consensus-workflow.yaml
+++ b/amplifier-bundle/recipes/consensus-workflow.yaml
@@ -498,14 +498,14 @@ steps:
       echo "Creating GitHub issue for: {{task_description}}"
 
       # FIX (#469): Assign template vars to shell vars first — avoids heredoc delimiter collision.
-      _TASK_DESC={{task_description}}
-      _REQS_EXPLICIT={{final_requirements.explicit_requirements}}
-      _REQS_SUCCESS={{final_requirements.success_criteria}}
-      _REQS_CONSTRAINTS={{final_requirements.constraints}}
-      _REQS_MECHANISM={{final_requirements.consensus_mechanism_used}}
-      _REQS_AGENTS={{final_requirements.agents_involved}}
-      _REQS_CONFIDENCE={{final_requirements.confidence_level}}
-      _CRITICALITY={{criticality}}
+      _TASK_DESC="{{task_description}}"
+      _REQS_EXPLICIT="{{final_requirements.explicit_requirements}}"
+      _REQS_SUCCESS="{{final_requirements.success_criteria}}"
+      _REQS_CONSTRAINTS="{{final_requirements.constraints}}"
+      _REQS_MECHANISM="{{final_requirements.consensus_mechanism_used}}"
+      _REQS_AGENTS="{{final_requirements.agents_involved}}"
+      _REQS_CONFIDENCE="{{final_requirements.confidence_level}}"
+      _CRITICALITY="{{criticality}}"
       # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
       ISSUE_BODY=$(cat <<ISSUE_EOF
       ## Task Description
@@ -587,7 +587,7 @@ steps:
       fi
 
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC={{task_description}}
+      TASK_DESC="{{task_description}}"
       TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g;s/^-//;s/-$//' | cut -c1-30 | sed 's/-$//')
       # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
@@ -1655,10 +1655,10 @@ steps:
       git add -A
 
       # FIX (#469): Assign template vars to shell vars — avoids heredoc delimiter collision.
-      _TASK_DESC={{task_description}}
-      _REQS_SUMMARY={{final_requirements.task_summary}}
-      _IS_CRITICAL={{is_critical_code}}
-      _ISSUE_NUM={{issue_number}}
+      _TASK_DESC="{{task_description}}"
+      _REQS_SUMMARY="{{final_requirements.task_summary}}"
+      _IS_CRITICAL="{{is_critical_code}}"
+      _ISSUE_NUM="{{issue_number}}"
       SHORT_DESC=$(printf '%s' "$_TASK_DESC" | tr '\n\r' ' ' | cut -c1-72)
       # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
       COMMIT_MSG=$(cat <<COMMIT_EOF
@@ -1706,13 +1706,13 @@ steps:
       echo "Creating pull request..."
 
       # FIX (#469): Assign template vars to shell vars — avoids heredoc delimiter collision.
-      _TASK_DESC={{task_description}}
-      _REQS_EXPLICIT={{final_requirements.explicit_requirements}}
-      _REQS_MECHANISM={{final_requirements.consensus_mechanism_used}}
-      _IS_CRITICAL={{is_critical_code}}
-      _TDD_TOTAL={{tdd_tests.total_tests}}
-      _LOCAL_PASSED={{local_testing.all_scenarios_passed}}
-      _ISSUE_NUM={{issue_number}}
+      _TASK_DESC="{{task_description}}"
+      _REQS_EXPLICIT="{{final_requirements.explicit_requirements}}"
+      _REQS_MECHANISM="{{final_requirements.consensus_mechanism_used}}"
+      _IS_CRITICAL="{{is_critical_code}}"
+      _TDD_TOTAL="{{tdd_tests.total_tests}}"
+      _LOCAL_PASSED="{{local_testing.all_scenarios_passed}}"
+      _ISSUE_NUM="{{issue_number}}"
       # NOTE: Unquoted heredoc — $VAR expansion runs with invoking user's privileges (no escalation).
       PR_BODY=$(cat <<PR_EOF
       ## Description

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -137,7 +137,7 @@ steps:
       echo "  Step 22: Ensure PR Mergeable"
       echo ""
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC={{task_description}}
+      TASK_DESC="{{task_description}}"
       printf 'Task: %s\n' "$TASK_DESC"
       printf 'Repository: %s\n' {{repo_path}}
     output: "workflow_init"
@@ -293,12 +293,12 @@ steps:
       echo "=== Step 3: Creating GitHub Issue ===" >&2
 
       # FIX (#469): Direct assignment — immune to heredoc delimiter collision.
-      TASK_DESC={{task_description}}
+      TASK_DESC="{{task_description}}"
       # Bash builtins replace tr|cut pipeline — avoids 2 subprocess spawns (matches step-16)
       ISSUE_TITLE="${TASK_DESC//$'\n'/ }"
       ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"
       ISSUE_TITLE="${ISSUE_TITLE:0:200}"
-      ISSUE_REQS={{final_requirements}}
+      ISSUE_REQS="{{final_requirements}}"
 
       # Idempotency Guard 1: Reuse issue referenced in task_description (#NNNN)
       # Mirrors step-16-create-draft-pr idempotency pattern (#3324).
@@ -360,8 +360,8 @@ steps:
     command: |
       # Extract issue number from the creation output.
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      ISSUE_CREATION={{issue_creation}}
-      TASK_DESC_RAW={{task_description}}
+      ISSUE_CREATION="{{issue_creation}}"
+      TASK_DESC_RAW="{{task_description}}"
       # FIX (#4233): Match both issue URLs (issues/NNN) and PR URLs (pull/NNN).
       # If the output is a PR URL, resolve the linked issue via gh pr view.
       EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
@@ -422,7 +422,7 @@ steps:
       # Generate branch name from task description.
       # FIX (#469): Direct assignment — immune to heredoc delimiter collision.
       # Sanitization pipeline (tr -cd 'a-z0-9-') strips all shell metacharacters.
-      TASK_DESC={{task_description}}
+      TASK_DESC="{{task_description}}"
       TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-50 | sed 's/-$//')
       # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
@@ -1178,8 +1178,8 @@ steps:
       echo ""
       echo "--- Creating Commit ---"
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC={{task_description}}
-      ISSUE_NUMBER={{issue_number}}
+      TASK_DESC="{{task_description}}"
+      ISSUE_NUMBER="{{issue_number}}"
       COMMIT_TITLE=$(printf 'feat: %.72s' "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
       COMMIT_MSG=$(printf '%s\n\nImplements issue #%s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\nCloses #%s' "$COMMIT_TITLE" "$ISSUE_NUMBER" "$ISSUE_NUMBER")
       if [ -n "$(git diff --cached --name-only)" ]; then
@@ -1293,8 +1293,8 @@ steps:
 
       # Normal path: 1+ commits ahead, no existing PR — create the PR
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC={{task_description}}
-      PR_DESIGN={{design_spec}}
+      TASK_DESC="{{task_description}}"
+      PR_DESIGN="{{design_spec}}"
       # Bash builtins replace the `tr | cut` pipeline — avoids 2 subprocess spawns
       PR_TITLE="${TASK_DESC//$'\n'/ }"
       PR_TITLE="${PR_TITLE//$'\r'/ }"
@@ -1408,7 +1408,7 @@ steps:
     command: |
       echo "=== Step 17a: Step 13 Compliance Verification ===" && \
       echo "" && \
-      GATE_OUTPUT={{local_testing_gate}} && \
+      GATE_OUTPUT="{{local_testing_gate}}" && \
       if [ -z "$GATE_OUTPUT" ] || [ "$GATE_OUTPUT" = "''" ]; then \
         echo "COMPLIANCE FAILURE: Step 13 (outside-in testing) produced no output." && \
         echo "" && \
@@ -1706,8 +1706,8 @@ steps:
     command: |
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
       # ARG_MAX guard: truncated to 1 KB summaries below (#3366 / b1f87112b).
-      PHIL_CHECK={{philosophy_check}}
-      PAT_CHECK={{patterns_check}}
+      PHIL_CHECK="{{philosophy_check}}"
+      PAT_CHECK="{{patterns_check}}"
       PHIL_SUMMARY=$(printf '%.1024s' "$PHIL_CHECK")
       PAT_SUMMARY=$(printf '%.1024s' "$PAT_CHECK")
 
@@ -1919,9 +1919,9 @@ steps:
       gh pr view --json state,mergeable,reviews,statusCheckRollup && \
       echo "" && \
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC={{task_description}} && \
-      ISSUE_NUMBER={{issue_number}} && \
-      PR_URL={{pr_url}} && \
+      TASK_DESC="{{task_description}}" && \
+      ISSUE_NUMBER="{{issue_number}}" && \
+      PR_URL="{{pr_url}}" && \
       printf '=== Task: %s ===\n' "$TASK_DESC" && \
       printf '=== Issue: #%s ===\n' "$ISSUE_NUMBER" && \
       printf '=== PR: %s ===\n' "$PR_URL" && \
@@ -1937,11 +1937,11 @@ steps:
     parse_json: true
     command: |
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_VAL={{task_description}}
+      TASK_VAL="{{task_description}}"
       export TASK_VAL
-      ISSUE_VAL={{issue_number}}
+      ISSUE_VAL="{{issue_number}}"
       export ISSUE_VAL
-      PR_VAL={{pr_url}}
+      PR_VAL="{{pr_url}}"
       export PR_VAL
       python3 << 'PYEOF'
       import json, os

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -136,10 +136,10 @@ steps:
       echo "  Step 21: Convert PR to Ready"
       echo "  Step 22: Ensure PR Mergeable"
       echo ""
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC="{{task_description}}"
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
       printf 'Task: %s\n' "$TASK_DESC"
-      printf 'Repository: %s\n' {{repo_path}}
+      printf 'Repository: %s\n' "$REPO_PATH"
     output: "workflow_init"
 
   # ==========================================================================
@@ -150,7 +150,7 @@ steps:
   - id: "step-01-prepare-workspace"
     type: "bash"
     command: |
-      cd {{repo_path}} && \
+      cd "$REPO_PATH" && \
       echo "=== Step 1: Preparing Workspace ===" && \
       echo "" && \
       echo "Current directory: $(pwd)" && \
@@ -289,16 +289,16 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
-      cd "{{repo_path}}"
+      cd "$REPO_PATH"
       echo "=== Step 3: Creating GitHub Issue ===" >&2
 
-      # FIX (#469): Direct assignment — immune to heredoc delimiter collision.
-      TASK_DESC="{{task_description}}"
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
       # Bash builtins replace tr|cut pipeline — avoids 2 subprocess spawns (matches step-16)
       ISSUE_TITLE="${TASK_DESC//$'\n'/ }"
       ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"
       ISSUE_TITLE="${ISSUE_TITLE:0:200}"
-      ISSUE_REQS="{{final_requirements}}"
+      ISSUE_REQS="$FINAL_REQUIREMENTS"
 
       # Idempotency Guard 1: Reuse issue referenced in task_description (#NNNN)
       # Mirrors step-16-create-draft-pr idempotency pattern (#3324).
@@ -359,9 +359,9 @@ steps:
     type: "bash"
     command: |
       # Extract issue number from the creation output.
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      ISSUE_CREATION="{{issue_creation}}"
-      TASK_DESC_RAW="{{task_description}}"
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      ISSUE_CREATION="$ISSUE_CREATION"
+      TASK_DESC_RAW="$TASK_DESCRIPTION"
       # FIX (#4233): Match both issue URLs (issues/NNN) and PR URLs (pull/NNN).
       # If the output is a PR URL, resolve the linked issue via gh pr view.
       EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
@@ -403,11 +403,11 @@ steps:
     command: |
       set -euo pipefail
       # Guard: fail-fast if repo_path does not exist (prevents path traversal, catches misconfiguration).
-      if [ ! -d "{{repo_path}}" ]; then
-        echo "ERROR: repo_path '{{repo_path}}' does not exist or is not a directory" >&2
+      if [ ! -d "$REPO_PATH" ]; then
+        echo "ERROR: repo_path '$REPO_PATH' does not exist or is not a directory" >&2
         exit 1
       fi
-      cd {{repo_path}}
+      cd "$REPO_PATH"
 
       echo "=== Step 4: Creating Worktree and Branch ===" >&2
       echo "" >&2
@@ -420,28 +420,28 @@ steps:
       # update consensus-workflow.yaml in the same commit. See Issue #2952 for context.
       #
       # Generate branch name from task description.
-      # FIX (#469): Direct assignment — immune to heredoc delimiter collision.
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
       # Sanitization pipeline (tr -cd 'a-z0-9-') strips all shell metacharacters.
-      TASK_DESC="{{task_description}}"
+      TASK_DESC="$TASK_DESCRIPTION"
       TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-50 | sed 's/-$//')
       # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
       if [ -z "$TASK_SLUG" ]; then
         echo "WARNING: task_description produced an empty slug — falling back to task-unnamed" >&2
         # FIX (issue #3023 / BL-002 fallback hardening): Use hardcoded 'feat/' prefix rather
-        # than {{branch_prefix}} to prevent injection via an invalid or malicious branch_prefix
+        # than $BRANCH_PREFIX to prevent injection via an invalid or malicious branch_prefix
         # value (e.g. '; rm -rf /' or '../../etc'). The prefix is not user-configurable in
         # the fallback path; configurable prefix only applies when a valid slug exists.
         BRANCH_NAME="feat/task-unnamed-$(date +%s)"
       else
-        BRANCH_NAME="{{branch_prefix}}/issue-{{issue_number}}-${TASK_SLUG}"
+        BRANCH_NAME="${BRANCH_PREFIX}/issue-${ISSUE_NUMBER}-${TASK_SLUG}"
         # Validate with authoritative git ref checker; fall back to safe unique name on failure
         if ! git check-ref-format --branch "${BRANCH_NAME}" >/dev/null 2>&1; then
           echo "WARNING: derived branch name '${BRANCH_NAME}' is invalid — falling back to task-unnamed" >&2
           BRANCH_NAME="feat/task-unnamed-$(date +%s)"
         fi
       fi
-      WORKTREE_PATH="{{repo_path}}/worktrees/${BRANCH_NAME}"
+      WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
 
       echo "Branch: ${BRANCH_NAME}" >&2
       echo "Worktree: ${WORKTREE_PATH}" >&2
@@ -764,7 +764,7 @@ steps:
     # (implementation, test_spec, design_spec) produce large outputs.
     max_env_value_bytes: 65536
     command: |
-      cd {{worktree_setup.worktree_path}} 2>/dev/null || cd {{repo_path}} && \
+      cd "$WORKTREE_SETUP_WORKTREE_PATH" 2>/dev/null || cd "$REPO_PATH" && \
       echo "=== Checkpoint: Staging Implementation ===" && \
       git add -A && \
       STAGED=$(git diff --cached --name-only) && \
@@ -944,7 +944,7 @@ steps:
     type: "bash"
     max_env_value_bytes: 65536
     command: |
-      cd {{worktree_setup.worktree_path}} 2>/dev/null || cd {{repo_path}} && \
+      cd "$WORKTREE_SETUP_WORKTREE_PATH" 2>/dev/null || cd "$REPO_PATH" && \
       echo "=== Checkpoint: Staging Review Feedback ===" && \
       git add -A && \
       STAGED=$(git diff --cached --name-only) && \
@@ -1170,16 +1170,16 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
-      cd "{{worktree_setup.worktree_path}}"
+      cd "$WORKTREE_SETUP_WORKTREE_PATH"
       echo "=== Step 15: Commit and Push ==="
       echo ""
       echo "--- Staging Changes ---"
       git add -A
       echo ""
       echo "--- Creating Commit ---"
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC="{{task_description}}"
-      ISSUE_NUMBER="{{issue_number}}"
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
+      ISSUE_NUMBER="$ISSUE_NUMBER"
       COMMIT_TITLE=$(printf 'feat: %.72s' "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
       COMMIT_MSG=$(printf '%s\n\nImplements issue #%s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\nCloses #%s' "$COMMIT_TITLE" "$ISSUE_NUMBER" "$ISSUE_NUMBER")
       if [ -n "$(git diff --cached --name-only)" ]; then
@@ -1194,14 +1194,14 @@ steps:
           ALT_WORKTREE_COMMITS=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
         fi
         if [ "$ALT_WORKTREE_COMMITS" -gt 0 ]; then
-          echo "INFO: Nothing staged in {{worktree_setup.worktree_path}}, but the" >&2
+          echo "INFO: Nothing staged in $WORKTREE_SETUP_WORKTREE_PATH, but the" >&2
           echo "current branch '$CURRENT_BRANCH' is $ALT_WORKTREE_COMMITS commit(s) ahead of" >&2
           echo "its upstream. The agent likely committed via an alternate worktree on" >&2
           echo "the same branch; treating as success." >&2
           git --no-pager log --oneline -"$ALT_WORKTREE_COMMITS" >&2
         else
           echo "ERROR: Nothing staged to commit. The implementation step may have written files" >&2
-          echo "outside the worktree ({{worktree_setup.worktree_path}}), or no code changes were produced." >&2
+          echo "outside the worktree ($WORKTREE_SETUP_WORKTREE_PATH), or no code changes were produced." >&2
           echo "This is a hollow-success condition — the workflow completed structurally but" >&2
           echo "produced no git artifacts. Check that agents created files in the worktree," >&2
           echo "not in AMPLIHACK_HOME or other locations." >&2
@@ -1237,7 +1237,7 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
-      cd "{{worktree_setup.worktree_path}}"
+      cd "$WORKTREE_SETUP_WORKTREE_PATH"
       echo "=== Step 16: Creating Draft PR ===" >&2
 
       # FIX (#3324): Idempotency guard — detect pre-existing PRs before creating one
@@ -1245,7 +1245,7 @@ steps:
       # Root cause: step-09-refactor may create PR on a different branch, leaving
       # the worktree branch with 0 commits ahead of main.
       CURRENT_BRANCH=$(git branch --show-current)
-      ISSUE_NUM="{{issue_number}}"
+      ISSUE_NUM="$ISSUE_NUMBER"
 
       # SECURITY: Validate ISSUE_NUM is numeric before interpolating into jq regex
       # Without this, a non-numeric value could inject into the jq test() filter.
@@ -1292,9 +1292,9 @@ steps:
       fi
 
       # Normal path: 1+ commits ahead, no existing PR — create the PR
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC="{{task_description}}"
-      PR_DESIGN="{{design_spec}}"
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
+      PR_DESIGN="$DESIGN_SPEC"
       # Bash builtins replace the `tr | cut` pipeline — avoids 2 subprocess spawns
       PR_TITLE="${TASK_DESC//$'\n'/ }"
       PR_TITLE="${PR_TITLE//$'\r'/ }"
@@ -1408,7 +1408,7 @@ steps:
     command: |
       echo "=== Step 17a: Step 13 Compliance Verification ===" && \
       echo "" && \
-      GATE_OUTPUT="{{local_testing_gate}}" && \
+      GATE_OUTPUT="$LOCAL_TESTING_GATE" && \
       if [ -z "$GATE_OUTPUT" ] || [ "$GATE_OUTPUT" = "''" ]; then \
         echo "COMPLIANCE FAILURE: Step 13 (outside-in testing) produced no output." && \
         echo "" && \
@@ -1584,7 +1584,7 @@ steps:
   - id: "step-18c-push-feedback-changes"
     type: "bash"
     command: |
-      cd {{worktree_setup.worktree_path}} && \
+      cd "$WORKTREE_SETUP_WORKTREE_PATH" && \
       echo "=== Pushing Review Feedback Changes ===" && \
       git add -A && \
       if [ -n "$(git diff --cached --name-only)" ]; then \
@@ -1680,7 +1680,7 @@ steps:
     type: "bash"
     command: |
       echo "=== ZERO-BS VERIFICATION ===" && \
-      cd {{worktree_setup.worktree_path}} && \
+      cd "$WORKTREE_SETUP_WORKTREE_PATH" && \
       echo "" && \
       echo "Scanning for Zero-BS violations..." && \
       echo "" && \
@@ -1704,10 +1704,10 @@ steps:
   - id: "step-19d-verification-gate"
     type: "bash"
     command: |
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
       # ARG_MAX guard: truncated to 1 KB summaries below (#3366 / b1f87112b).
-      PHIL_CHECK="{{philosophy_check}}"
-      PAT_CHECK="{{patterns_check}}"
+      PHIL_CHECK="$PHILOSOPHY_CHECK"
+      PAT_CHECK="$PATTERNS_CHECK"
       PHIL_SUMMARY=$(printf '%.1024s' "$PHIL_CHECK")
       PAT_SUMMARY=$(printf '%.1024s' "$PAT_CHECK")
 
@@ -1767,7 +1767,7 @@ steps:
   - id: "step-20b-push-cleanup"
     type: "bash"
     command: |
-      cd {{worktree_setup.worktree_path}} && \
+      cd "$WORKTREE_SETUP_WORKTREE_PATH" && \
       echo "=== Pushing Cleanup Changes ===" && \
       git add -A && \
       git diff --cached --quiet || (git commit -m "final cleanup pass" && git pull --rebase 2>/dev/null && git push) && \
@@ -1852,7 +1852,7 @@ steps:
   - id: "step-21-pr-ready"
     type: "bash"
     command: |
-      cd {{worktree_setup.worktree_path}} && \
+      cd "$WORKTREE_SETUP_WORKTREE_PATH" && \
       echo "=== Step 20: Converting PR to Ready ===" && \
       echo "" && \
       echo "--- Verifying All Steps Complete ---" && \
@@ -1912,16 +1912,16 @@ steps:
   - id: "step-22b-final-status"
     type: "bash"
     command: |
-      cd {{repo_path}} && \
+      cd "$REPO_PATH" && \
       echo "=== WORKFLOW COMPLETE ===" && \
       echo "" && \
       echo "PR Status:" && \
       gh pr view --json state,mergeable,reviews,statusCheckRollup && \
       echo "" && \
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_DESC="{{task_description}}" && \
-      ISSUE_NUMBER="{{issue_number}}" && \
-      PR_URL="{{pr_url}}" && \
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION" && \
+      ISSUE_NUMBER="$ISSUE_NUMBER" && \
+      PR_URL="$PR_URL" && \
       printf '=== Task: %s ===\n' "$TASK_DESC" && \
       printf '=== Issue: #%s ===\n' "$ISSUE_NUMBER" && \
       printf '=== PR: %s ===\n' "$PR_URL" && \
@@ -1936,12 +1936,12 @@ steps:
     type: "bash"
     parse_json: true
     command: |
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      TASK_VAL="{{task_description}}"
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_VAL="$TASK_DESCRIPTION"
       export TASK_VAL
-      ISSUE_VAL="{{issue_number}}"
+      ISSUE_VAL="$ISSUE_NUMBER"
       export ISSUE_VAL
-      PR_VAL="{{pr_url}}"
+      PR_VAL="$PR_URL"
       export PR_VAL
       python3 << 'PYEOF'
       import json, os

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -136,13 +136,8 @@ steps:
       echo "  Step 21: Convert PR to Ready"
       echo "  Step 22: Ensure PR Mergeable"
       echo ""
-      # FIX (issues #3045/#3076/#3117): unquoted heredoc for safe variable capture.
-      # Unquoted heredoc allows Rust runner env-var expansion ($RECIPE_VAR_*).
-      # Shell expansion is single-pass: expanded values are NOT re-processed.
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      TASK_DESC={{task_description}}
       printf 'Task: %s\n' "$TASK_DESC"
       printf 'Repository: %s\n' {{repo_path}}
     output: "workflow_init"
@@ -297,23 +292,13 @@ steps:
       cd "{{repo_path}}"
       echo "=== Step 3: Creating GitHub Issue ===" >&2
 
-      # FIX (#4221): Use quoted heredoc (<<'DELIM') to prevent bash from expanding
-      # $(), backticks, or other shell metacharacters in template-substituted content.
-      # The recipe runner performs {{variable}} substitution before bash executes,
-      # so quoted delimiters are safe and correct.
-      # Use unique delimiter unlikely to appear in user task descriptions.
-      TASK_DESC=$(cat <<'_AMPLIHACK_STEP03_TASK_EOF_'
-      {{task_description}}
-      _AMPLIHACK_STEP03_TASK_EOF_
-      )
+      # FIX (#469): Direct assignment — immune to heredoc delimiter collision.
+      TASK_DESC={{task_description}}
       # Bash builtins replace tr|cut pipeline — avoids 2 subprocess spawns (matches step-16)
       ISSUE_TITLE="${TASK_DESC//$'\n'/ }"
       ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"
       ISSUE_TITLE="${ISSUE_TITLE:0:200}"
-      ISSUE_REQS=$(cat <<'_AMPLIHACK_STEP03_REQS_EOF_'
-      {{final_requirements}}
-      _AMPLIHACK_STEP03_REQS_EOF_
-      )
+      ISSUE_REQS={{final_requirements}}
 
       # Idempotency Guard 1: Reuse issue referenced in task_description (#NNNN)
       # Mirrors step-16-create-draft-pr idempotency pattern (#3324).
@@ -374,22 +359,9 @@ steps:
     type: "bash"
     command: |
       # Extract issue number from the creation output.
-      # FIX (issue #3022): Use safe heredoc capture instead of echo {{variable}} to
-      # prevent shell metacharacter injection from issue body content.  Use head -1
-      # instead of tail -1 so the canonical URL (first match) wins — not a trailing
-      # noise number captured via 2>&1 in step-03a.
-      # EOFISSUECREATION delimiter is intentionally long/specific to prevent accidental
-      # collision with issue body text that might contain common delimiters like "EOF".
-      ISSUE_CREATION=$(cat <<'EOFISSUECREATION'
-      {{issue_creation}}
-      EOFISSUECREATION
-      )
-      # FIX (#4247): Capture task_description at top level (not inside if block)
-      # to avoid indented heredoc delimiters that bash cannot parse.
-      TASK_DESC_RAW=$(cat <<'EOFTASKDESC03B'
-      {{task_description}}
-      EOFTASKDESC03B
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      ISSUE_CREATION={{issue_creation}}
+      TASK_DESC_RAW={{task_description}}
       # FIX (#4233): Match both issue URLs (issues/NNN) and PR URLs (pull/NNN).
       # If the output is a PR URL, resolve the linked issue via gh pr view.
       EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
@@ -448,18 +420,9 @@ steps:
       # update consensus-workflow.yaml in the same commit. See Issue #2952 for context.
       #
       # Generate branch name from task description.
-      # FIX (issue #3087 / #301): Template substitution of {{task_description}}
-      # happens BEFORE the bash script runs — so a single-quoted heredoc is
-      # correct here and safer. An UNQUOTED heredoc would re-interpret any
-      # `$NAME` literals in the task description as bash variables, which
-      # with `set -u` aborts the step when the user mentions things like
-      # `$TREE_SCRIPT` or `$ORCH_SCRIPT` in their task text.
-      # Security note: the sanitization pipeline (tr -cd 'a-z0-9-') strips all
-      # shell metacharacters from the output, mitigating injection risk.
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#469): Direct assignment — immune to heredoc delimiter collision.
+      # Sanitization pipeline (tr -cd 'a-z0-9-') strips all shell metacharacters.
+      TASK_DESC={{task_description}}
       TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-50 | sed 's/-$//')
       # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
@@ -1214,13 +1177,11 @@ steps:
       git add -A
       echo ""
       echo "--- Creating Commit ---"
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      TASK_DESC={{task_description}}
+      ISSUE_NUMBER={{issue_number}}
       COMMIT_TITLE=$(printf 'feat: %.72s' "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
-      COMMIT_MSG=$(printf '%s\n\nImplements issue #%s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\nCloses #%s' "$COMMIT_TITLE" {{issue_number}} {{issue_number}})
+      COMMIT_MSG=$(printf '%s\n\nImplements issue #%s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\nCloses #%s' "$COMMIT_TITLE" "$ISSUE_NUMBER" "$ISSUE_NUMBER")
       if [ -n "$(git diff --cached --name-only)" ]; then
         git commit -m "$COMMIT_MSG"
       else
@@ -1331,19 +1292,13 @@ steps:
       fi
 
       # Normal path: 1+ commits ahead, no existing PR — create the PR
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      TASK_DESC={{task_description}}
+      PR_DESIGN={{design_spec}}
       # Bash builtins replace the `tr | cut` pipeline — avoids 2 subprocess spawns
       PR_TITLE="${TASK_DESC//$'\n'/ }"
       PR_TITLE="${PR_TITLE//$'\r'/ }"
       PR_TITLE="${PR_TITLE:0:200}"
-      PR_DESIGN=$(cat <<EOFDESIGN
-      {{design_spec}}
-      EOFDESIGN
-      )
       PR_BODY=$(printf '## Summary\n%s\n\n## Issue\nCloses #%s\n\n## Changes\n%s\n\n## Testing\n- Unit tests added\n- Local testing completed\n- Pre-commit hooks pass\n\n## Checklist\n- [x] Tests pass\n- [x] Documentation updated\n- [x] No stubs or TODOs\n- [ ] Code review completed\n- [ ] Philosophy check passed\n\n---\n*This PR was created as a draft for review before merging.*\n' "$TASK_DESC" "$ISSUE_NUM" "$PR_DESIGN")
       # timeout 120: gh pr create contacts GitHub GraphQL API — cap wait to 2 minutes
       # 2>/dev/null: suppress gh stderr to prevent output contract corruption of pr_url
@@ -1749,17 +1704,10 @@ steps:
   - id: "step-19d-verification-gate"
     type: "bash"
     command: |
-      # ARG_MAX guard: large template variables (philosophy_check, patterns_check)
-      # are captured via heredoc and truncated to 1 KB summaries.  Echoing them
-      # raw caused ARG_MAX overflow — see #3366 / b1f87112b.
-      PHIL_CHECK=$(cat <<'EOFPHILCHECK'
-      {{philosophy_check}}
-      EOFPHILCHECK
-      )
-      PAT_CHECK=$(cat <<'EOFPATCHECK'
-      {{patterns_check}}
-      EOFPATCHECK
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      # ARG_MAX guard: truncated to 1 KB summaries below (#3366 / b1f87112b).
+      PHIL_CHECK={{philosophy_check}}
+      PAT_CHECK={{patterns_check}}
       PHIL_SUMMARY=$(printf '%.1024s' "$PHIL_CHECK")
       PAT_SUMMARY=$(printf '%.1024s' "$PAT_CHECK")
 
@@ -1970,14 +1918,13 @@ steps:
       echo "PR Status:" && \
       gh pr view --json state,mergeable,reviews,statusCheckRollup && \
       echo "" && \
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      ) && \
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      TASK_DESC={{task_description}} && \
+      ISSUE_NUMBER={{issue_number}} && \
+      PR_URL={{pr_url}} && \
       printf '=== Task: %s ===\n' "$TASK_DESC" && \
-      printf '=== Issue: #%s ===\n' {{issue_number}} && \
-      printf '=== PR: %s ===\n' {{pr_url}} && \
+      printf '=== Issue: #%s ===\n' "$ISSUE_NUMBER" && \
+      printf '=== PR: %s ===\n' "$PR_URL" && \
       echo "" && \
       echo "All 23 workflow steps completed successfully."
     output: "final_status"
@@ -1989,18 +1936,12 @@ steps:
     type: "bash"
     parse_json: true
     command: |
-      # FIX (#3045/#3076/#3117): unquoted heredoc — safe variable capture
-      TASK_DESC=$(cat <<'EOFTASKDESC'
-      {{task_description}}
-      EOFTASKDESC
-      )
-      TASK_VAL=$(printf '%s' "$TASK_DESC")
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      TASK_VAL={{task_description}}
       export TASK_VAL
-      # {{issue_number}} and {{pr_url}} are system-generated integers/URLs —
-      # no user-controlled metacharacters possible; heredoc not required.
-      ISSUE_VAL=$(printf '%s' {{issue_number}})
+      ISSUE_VAL={{issue_number}}
       export ISSUE_VAL
-      PR_VAL=$(printf '%s' {{pr_url}})
+      PR_VAL={{pr_url}}
       export PR_VAL
       python3 << 'PYEOF'
       import json, os

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -144,9 +144,8 @@ steps:
     command: |
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
-      {{decomposition_json}}
-      __DECOMP_EOF__
+      # FIX (heredoc-bulletproof): use env var — no heredoc needed.
+      printf '%s' "$DECOMPOSITION_JSON" > "$_DECOMP_TMPFILE"
       RAW_OBJ=$(amplihack orch helper extract-json < "$_DECOMP_TMPFILE")
       if [ "$RAW_OBJ" = "{}" ]; then
         cat <<'WARN' >&2
@@ -171,9 +170,8 @@ steps:
       # task description has strong development signals (file paths, "Add"+
       # path, PR mention, tests, multi-requirement), promote to Development.
       _TASK_TMPFILE=$(mktemp)
-      cat > "$_TASK_TMPFILE" <<__TASK_EOF__
-      {{task_description}}
-      __TASK_EOF__
+      # FIX (heredoc-bulletproof): use env var — no heredoc needed.
+      printf '%s' "$TASK_DESCRIPTION" > "$_TASK_TMPFILE"
       FINAL_TYPE=$(amplihack orch helper reclassify-task-type --current "$CANONICAL_TYPE" < "$_TASK_TMPFILE")
       rm -f "$_TASK_TMPFILE"
       if [ "$FINAL_TYPE" != "$CANONICAL_TYPE" ]; then
@@ -191,9 +189,8 @@ steps:
     command: |
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
-      {{decomposition_json}}
-      __DECOMP_EOF__
+      # FIX (heredoc-bulletproof): use env var — no heredoc needed.
+      printf '%s' "$DECOMPOSITION_JSON" > "$_DECOMP_TMPFILE"
       TASK_TYPE="{{task_type}}"
       FORCE_SINGLE="{{force_single_workstream}}"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
@@ -416,9 +413,8 @@ steps:
     command: |
       _DECOMP_TMPFILE=$(mktemp)
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
-      cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
-      {{decomposition_json}}
-      __DECOMP_EOF__
+      # FIX (heredoc-bulletproof): use env var — no heredoc needed.
+      printf '%s' "$DECOMPOSITION_JSON" > "$_DECOMP_TMPFILE"
       amplihack orch helper build-workstreams-config < "$_DECOMP_TMPFILE"
     output: "workstreams_file"
 

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -352,10 +352,8 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type"
     command: |
-      SESSION_JSON=$(cat <<EOFSESSIONJSON
-      {{session_info}}
-      EOFSESSIONJSON
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      SESSION_JSON={{session_info}}
       # Extract status using shell grep — no Python subprocess needed
       if echo "$SESSION_JSON" | grep -qE '"status" *: *"ok"'; then
         echo "ALLOWED"
@@ -435,10 +433,8 @@ steps:
       echo '{"transition":"step_started","step":"launch-parallel-round-1","timestamp":'$(date +%s)'}' >&2
       REPO_PATH={{repo_path}}
       WS_FILE={{workstreams_file}}
-      SESSION_JSON=$(cat <<EOFSESSIONJSON
-      {{session_info}}
-      EOFSESSIONJSON
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      SESSION_JSON={{session_info}}
       # #283: parse tree_id, depth, and workstreams count using jq instead of
       # inline Python. jq is a standard CLI tool and removes a python3 heredoc.
       TREE_ID=$(printf '%s' "$SESSION_JSON" | jq -r '.tree_id // ""' 2>/dev/null || echo "")
@@ -596,7 +592,8 @@ steps:
       FORCE_SINGLE={{force_single_workstream}}
       GUARD={{recursion_guard}}
       RECIPE={{adaptive_recipe}}
-      TASK_DESC=$(printf '%s' {{task_description}})
+      # FIX (#469): Direct assignment — avoids word-split on unquoted {{task_description}}.
+      TASK_DESC={{task_description}}
 
       # Build diagnostic body
       BODY=$(cat <<EOFBODY
@@ -936,10 +933,8 @@ steps:
   - id: "complete-session"
     type: "bash"
     command: |
-      SESSION_JSON=$(cat <<EOFSESSIONJSON
-      {{session_info}}
-      EOFSESSIONJSON
-      )
+      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
+      SESSION_JSON={{session_info}}
       TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
       # #283: parse session fields via jq instead of inline Python.

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -50,8 +50,8 @@ steps:
     type: "bash"
     command: |
       ERRORS=""
-      REPO="{{repo_path}}"
-      TASK="{{task_description}}"
+      REPO="$REPO_PATH"
+      TASK="$TASK_DESCRIPTION"
       if [ -z "$TASK" ]; then
         ERRORS="${ERRORS}\n  ✗ task_description is empty"
       fi
@@ -191,8 +191,8 @@ steps:
       trap 'rm -f "$_DECOMP_TMPFILE"' EXIT
       # FIX (heredoc-bulletproof): use env var — no heredoc needed.
       printf '%s' "$DECOMPOSITION_JSON" > "$_DECOMP_TMPFILE"
-      TASK_TYPE="{{task_type}}"
-      FORCE_SINGLE="{{force_single_workstream}}"
+      TASK_TYPE="$TASK_TYPE"
+      FORCE_SINGLE="$FORCE_SINGLE_WORKSTREAM"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
 
       RAW_COUNT=$(amplihack orch helper count-workstreams < "$_DECOMP_TMPFILE")
@@ -228,12 +228,12 @@ steps:
   # The Rust runner's --set flag updates template variables ({{...}}) but
   # the condition evaluator only sees step outputs and initial context.
   # This step bridges the gap by echoing the context value to stdout.
-  # NOTE: Use bare {{var}} — single-quoted '{{var}}' prevents expansion.
+  # NOTE: Use "$ENV_VAR" — safe against word-splitting and injection.
   # ─────────────────────────────────────────────────────────────────────────
   - id: "materialize-force-single-workstream"
     type: "bash"
     command: |
-      printf '%s' {{force_single_workstream}}
+      printf '%s' "$FORCE_SINGLE_WORKSTREAM"
     output: "force_single_workstream"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -330,7 +330,7 @@ steps:
     type: "bash"
     condition: "'Operations' in task_type"
     command: |
-      cd "{{repo_path}}" 2>/dev/null || true
+      cd "$REPO_PATH" 2>/dev/null || true
       CHANGED=$(git diff --name-only 2>/dev/null | head -1)
       UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null | head -1)
       if [ -n "$CHANGED" ] || [ -n "$UNTRACKED" ]; then
@@ -349,8 +349,8 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type"
     command: |
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      SESSION_JSON="{{session_info}}"
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      SESSION_JSON="$SESSION_INFO"
       # Extract status using shell grep — no Python subprocess needed
       if echo "$SESSION_JSON" | grep -qE '"status" *: *"ok"'; then
         echo "ALLOWED"
@@ -427,10 +427,10 @@ steps:
       set -o pipefail
       # Emit step-transition marker for progress tracking (#3625)
       echo '{"transition":"step_started","step":"launch-parallel-round-1","timestamp":'$(date +%s)'}' >&2
-      REPO_PATH="{{repo_path}}"
-      WS_FILE="{{workstreams_file}}"
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      SESSION_JSON="{{session_info}}"
+      REPO_PATH="$REPO_PATH"
+      WS_FILE="$WORKSTREAMS_FILE"
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      SESSION_JSON="$SESSION_INFO"
       # #283: parse tree_id, depth, and workstreams count using jq instead of
       # inline Python. jq is a standard CLI tool and removes a python3 heredoc.
       TREE_ID=$(printf '%s' "$SESSION_JSON" | jq -r '.tree_id // ""' 2>/dev/null || echo "")
@@ -545,10 +545,10 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and not round_1_result
     command: |
-      TASK_TYPE="{{task_type}}"
-      WS_COUNT="{{workstream_count}}"
-      FORCE_SINGLE="{{force_single_workstream}}"
-      GUARD="{{recursion_guard}}"
+      TASK_TYPE="$TASK_TYPE"
+      WS_COUNT="$WORKSTREAM_COUNT"
+      FORCE_SINGLE="$FORCE_SINGLE_WORKSTREAM"
+      GUARD="$RECURSION_GUARD"
 
       cat >&2 <<ERRMSG
 
@@ -583,13 +583,13 @@ steps:
     condition: |
       adaptive_recipe and adaptive_recipe != ''
     command: |
-      TASK_TYPE="{{task_type}}"
-      WS_COUNT="{{workstream_count}}"
-      FORCE_SINGLE="{{force_single_workstream}}"
-      GUARD="{{recursion_guard}}"
-      RECIPE="{{adaptive_recipe}}"
-      # FIX (#469): Direct assignment — avoids word-split on unquoted {{task_description}}.
-      TASK_DESC="{{task_description}}"
+      TASK_TYPE="$TASK_TYPE"
+      WS_COUNT="$WORKSTREAM_COUNT"
+      FORCE_SINGLE="$FORCE_SINGLE_WORKSTREAM"
+      GUARD="$RECURSION_GUARD"
+      RECIPE="$ADAPTIVE_RECIPE"
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
 
       # Build diagnostic body
       BODY=$(cat <<EOFBODY
@@ -929,8 +929,8 @@ steps:
   - id: "complete-session"
     type: "bash"
     command: |
-      # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      SESSION_JSON="{{session_info}}"
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      SESSION_JSON="$SESSION_INFO"
       TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
       # #283: parse session fields via jq instead of inline Python.

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -194,8 +194,8 @@ steps:
       cat > "$_DECOMP_TMPFILE" <<__DECOMP_EOF__
       {{decomposition_json}}
       __DECOMP_EOF__
-      TASK_TYPE={{task_type}}
-      FORCE_SINGLE={{force_single_workstream}}
+      TASK_TYPE="{{task_type}}"
+      FORCE_SINGLE="{{force_single_workstream}}"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
 
       RAW_COUNT=$(amplihack orch helper count-workstreams < "$_DECOMP_TMPFILE")
@@ -353,7 +353,7 @@ steps:
     condition: "'Development' in task_type or 'Investigation' in task_type"
     command: |
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      SESSION_JSON={{session_info}}
+      SESSION_JSON="{{session_info}}"
       # Extract status using shell grep — no Python subprocess needed
       if echo "$SESSION_JSON" | grep -qE '"status" *: *"ok"'; then
         echo "ALLOWED"
@@ -431,10 +431,10 @@ steps:
       set -o pipefail
       # Emit step-transition marker for progress tracking (#3625)
       echo '{"transition":"step_started","step":"launch-parallel-round-1","timestamp":'$(date +%s)'}' >&2
-      REPO_PATH={{repo_path}}
-      WS_FILE={{workstreams_file}}
+      REPO_PATH="{{repo_path}}"
+      WS_FILE="{{workstreams_file}}"
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      SESSION_JSON={{session_info}}
+      SESSION_JSON="{{session_info}}"
       # #283: parse tree_id, depth, and workstreams count using jq instead of
       # inline Python. jq is a standard CLI tool and removes a python3 heredoc.
       TREE_ID=$(printf '%s' "$SESSION_JSON" | jq -r '.tree_id // ""' 2>/dev/null || echo "")
@@ -549,10 +549,10 @@ steps:
     condition: |
       ('Development' in task_type or 'Investigation' in task_type) and not round_1_result
     command: |
-      TASK_TYPE={{task_type}}
-      WS_COUNT={{workstream_count}}
-      FORCE_SINGLE={{force_single_workstream}}
-      GUARD={{recursion_guard}}
+      TASK_TYPE="{{task_type}}"
+      WS_COUNT="{{workstream_count}}"
+      FORCE_SINGLE="{{force_single_workstream}}"
+      GUARD="{{recursion_guard}}"
 
       cat >&2 <<ERRMSG
 
@@ -587,13 +587,13 @@ steps:
     condition: |
       adaptive_recipe and adaptive_recipe != ''
     command: |
-      TASK_TYPE={{task_type}}
-      WS_COUNT={{workstream_count}}
-      FORCE_SINGLE={{force_single_workstream}}
-      GUARD={{recursion_guard}}
-      RECIPE={{adaptive_recipe}}
+      TASK_TYPE="{{task_type}}"
+      WS_COUNT="{{workstream_count}}"
+      FORCE_SINGLE="{{force_single_workstream}}"
+      GUARD="{{recursion_guard}}"
+      RECIPE="{{adaptive_recipe}}"
       # FIX (#469): Direct assignment — avoids word-split on unquoted {{task_description}}.
-      TASK_DESC={{task_description}}
+      TASK_DESC="{{task_description}}"
 
       # Build diagnostic body
       BODY=$(cat <<EOFBODY
@@ -934,7 +934,7 @@ steps:
     type: "bash"
     command: |
       # FIX (#469): Direct assignment — no heredoc delimiter collision risk.
-      SESSION_JSON={{session_info}}
+      SESSION_JSON="{{session_info}}"
       TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
       # #283: parse session fields via jq instead of inline Python.


### PR DESCRIPTION


## Step 16b: Outside-In Testing Results

### Scenario 1 — Heredoc template var detection in bash command blocks
Command: Python YAML parser + regex scan across all 3 recipe files (145 steps total)
Result: **FAIL → PASS** (after fix)
Output: Found 4 remaining `{{...}}` template vars inside heredocs in `smart-orchestrator.yaml` steps: `parse-decomposition` (×2), `activate-workflow`, `create-workstreams-config`. Fixed by replacing `cat > file <<__DELIM__` heredoc patterns with `printf '%s' "$ENV_VAR" > file`.

### Scenario 2 — cargo test -p amplihack-recipe (lib + integration)
Command: `cargo test -p amplihack-recipe`
Result: **PASS**
Output: 14/14 tests passed including `parse_smart_orchestrator_recipe`, `parse_default_workflow_recipe`, `all_bash_steps_have_valid_syntax`, `all_recipe_conditions_are_valid`

### Scenario 3 — YAML parse validation
Command: `yaml.safe_load()` on all 3 recipe files
Result: **PASS**
Output: All files parse correctly (56 + 29 + 60 steps)

### Scenario 4 — Word-split risk detection
Command: Regex scan for `$(printf %s {{var}})` patterns in all bash command blocks
Result: **PASS**
Output: No unquoted word-split risks found

Fix iterations: 1 (fixed 4 missed heredoc sites in smart-orchestrator.yaml)