### PR TITLE
fix(cli): expose multitask-orchestrator via resolve-bundle-asset (#283)

### DIFF
--- a/crates/amplihack-cli/src/runtime_assets.rs
+++ b/crates/amplihack-cli/src/runtime_assets.rs
@@ -27,6 +27,16 @@ pub fn asset_relative_paths() -> HashMap<&'static str, Vec<&'static str>> {
             "amplifier-bundle/tools/amplihack/hooks",
         ],
     );
+    // FIX (rysweet/amplihack-rs#283/#248): expose the multitask-orchestrator
+    // script so smart-orchestrator.yaml can drop its remaining
+    // `python3 -m amplihack.runtime_assets multitask-orchestrator` shim.
+    m.insert(
+        "multitask-orchestrator",
+        vec![
+            ".claude/skills/multitask/orchestrator.py",
+            "amplifier-bundle/skills/multitask/orchestrator.py",
+        ],
+    );
     m
 }
 
@@ -160,6 +170,16 @@ mod tests {
         assert!(paths.contains_key("helper-path"));
         assert!(paths.contains_key("session-tree-path"));
         assert!(paths.contains_key("hooks-dir"));
+        assert!(paths.contains_key("multitask-orchestrator"));
+    }
+
+    #[test]
+    fn multitask_orchestrator_has_two_candidates() {
+        let paths = asset_relative_paths();
+        let orch = &paths["multitask-orchestrator"];
+        assert_eq!(orch.len(), 2);
+        assert!(orch[0].contains(".claude/skills/multitask"));
+        assert!(orch[1].contains("amplifier-bundle/skills/multitask"));
     }
 
     #[test]


### PR DESCRIPTION
Refs #283 #248

## Problem
`smart-orchestrator.yaml` still has `python3 -m amplihack.runtime_assets multitask-orchestrator` calls because the Rust `amplihack resolve-bundle-asset` subcommand did not know the `multitask-orchestrator` key. This blocks removing python3 from the recipe runtime path.

## Fix
Add the `multitask-orchestrator` key to `asset_relative_paths()` with the same two candidate paths the Python implementation searched:
- `.claude/skills/multitask/orchestrator.py`
- `amplifier-bundle/skills/multitask/orchestrator.py`

Plus a regression test mirroring `hooks_dir_has_two_candidates`.

## Test plan
- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` — clean
- `TMPDIR=/tmp cargo test -p amplihack-cli --lib` — 1015 passed (was 1014, +1 new test)

## Follow-up
Once this lands and ships in a release, a follow-up PR in rysweet/amplihack will replace the 10 `python3 -m amplihack.runtime_assets X` call sites in `smart-orchestrator.yaml` with `amplihack resolve-bundle-asset X`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>