### PR TITLE
fix(cli): expose multitask-orchestrator as a named asset (unblocks parallel workflows)

### DIFF
--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -320,7 +320,10 @@ mod tests {
             .lock()
             .unwrap_or_else(|p| p.into_inner());
         let temp = tempfile::tempdir().unwrap();
-        make_named_asset_file(temp.path(), "amplifier-bundle/skills/multitask/orchestrator.py");
+        make_named_asset_file(
+            temp.path(),
+            "amplifier-bundle/skills/multitask/orchestrator.py",
+        );
 
         let prev_home = crate::test_support::set_home(temp.path());
         let prev = env::var_os("AMPLIHACK_HOME");
@@ -362,7 +365,10 @@ mod tests {
         }
         crate::test_support::restore_home(prev_home);
 
-        assert_eq!(exit, 0, "expected resolve-bundle-asset multitask-orchestrator to succeed");
+        assert_eq!(
+            exit, 0,
+            "expected resolve-bundle-asset multitask-orchestrator to succeed"
+        );
     }
 
     #[test]

--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -25,6 +25,18 @@ const NAMED_ASSETS: &[(&str, &[&str])] = &[
             "amplifier-bundle/tools/amplihack/hooks",
         ],
     ),
+    // FIX (rysweet/amplihack-rs#283/#248): expose the multitask-orchestrator
+    // script under a stable named-asset key so smart-orchestrator's
+    // launch-parallel-round-1 step can resolve it via the Rust CLI instead of
+    // the legacy `python3 -m amplihack.runtime_assets multitask-orchestrator`
+    // shim. The candidate paths mirror those in `runtime_assets::asset_relative_paths`.
+    (
+        "multitask-orchestrator",
+        &[
+            ".claude/skills/multitask/orchestrator.py",
+            "amplifier-bundle/skills/multitask/orchestrator.py",
+        ],
+    ),
 ];
 
 pub fn validate_relative_path(relative_path: &str) -> Result<()> {
@@ -300,6 +312,57 @@ mod tests {
             "expected session_tree.py path, got {:?}",
             resolved
         );
+    }
+
+    #[test]
+    fn resolve_named_asset_multitask_orchestrator_uses_amplihack_home() {
+        let _home_guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        make_named_asset_file(temp.path(), "amplifier-bundle/skills/multitask/orchestrator.py");
+
+        let prev_home = crate::test_support::set_home(temp.path());
+        let prev = env::var_os("AMPLIHACK_HOME");
+        unsafe { env::set_var("AMPLIHACK_HOME", temp.path()) };
+
+        let result = resolve_named_asset("multitask-orchestrator");
+
+        match prev {
+            Some(v) => unsafe { env::set_var("AMPLIHACK_HOME", v) },
+            None => unsafe { env::remove_var("AMPLIHACK_HOME") },
+        }
+        crate::test_support::restore_home(prev_home);
+
+        let resolved = result.unwrap();
+        assert!(
+            resolved.ends_with("amplifier-bundle/skills/multitask/orchestrator.py"),
+            "expected multitask orchestrator.py path, got {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn run_cli_resolves_multitask_orchestrator_named_asset() {
+        let _home_guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        make_named_asset_file(temp.path(), ".claude/skills/multitask/orchestrator.py");
+
+        let prev_home = crate::test_support::set_home(temp.path());
+        let prev = env::var_os("AMPLIHACK_HOME");
+        unsafe { env::set_var("AMPLIHACK_HOME", temp.path()) };
+
+        let exit = run_cli("multitask-orchestrator");
+
+        match prev {
+            Some(v) => unsafe { env::set_var("AMPLIHACK_HOME", v) },
+            None => unsafe { env::remove_var("AMPLIHACK_HOME") },
+        }
+        crate::test_support::restore_home(prev_home);
+
+        assert_eq!(exit, 0, "expected resolve-bundle-asset multitask-orchestrator to succeed");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`smart-orchestrator`'s `launch-parallel-round-1` step calls:

```
amplihack resolve-bundle-asset multitask-orchestrator
```

This fails with `ERROR: Path must start with 'amplifier-bundle/'` because the
CLI subcommand consults `NAMED_ASSETS` in `resolve_bundle_asset/mod.rs`, which
only contained 3 entries (`helper-path`, `session-tree-path`, `hooks-dir`).
PR #315 added `multitask-orchestrator` to `runtime_assets::asset_relative_paths()`,
but that map is an internal Rust API never consulted by the CLI subcommand.

**Impact:** ANY recipe with parallel workstreams fails at the multitask launch
step. This was observed during a session driving multiple issues to merge —
several smart-orchestrator runs all hit this same wall.

## Fix

Add `multitask-orchestrator` to `NAMED_ASSETS` with both candidate paths
mirroring `runtime_assets`:
- `.claude/skills/multitask/orchestrator.py`
- `amplifier-bundle/skills/multitask/orchestrator.py`

## Tests

Three regression tests added (all pass):
- `resolve_named_asset_multitask_orchestrator_uses_amplihack_home` — direct API
- `run_cli_resolves_multitask_orchestrator_named_asset` — full CLI dispatch
- Pre-existing `recipes_do_not_invoke_python_runtime_assets` continues to pass

## Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings  # clean
TMPDIR=/tmp cargo test -p amplihack-cli --lib resolve_bundle_asset  # 19 passed
```

This is a surgical infrastructure fix submitted directly per the dev-orchestrator
skill's adaptive-strategy guidance — `smart-orchestrator` cannot run multi-workstream
flows until this lands, so wrapping the fix in another smart-orchestrator run would
deadlock.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>