### PR TITLE
feat(condition): support bracket access in condition expressions

### DIFF
--- a/crates/amplihack-recipe/src/condition_eval.rs
+++ b/crates/amplihack-recipe/src/condition_eval.rs
@@ -6,12 +6,16 @@
 //! - Integer literals: `1`, `42`
 //! - Identifiers (context variables): `task_type`, `round_1_result`
 //! - Dot access: `obj.field.subfield`
+//! - Bracket access: `obj['key']`, `items[0]` (string-key or integer-index;
+//!   flattened into the dot-access lookup key, so `obj['k']` is equivalent
+//!   to `obj.k` against the flat string context map)
 //! - Boolean operators: `and`, `or`, `not`
 //! - Comparison: `==`, `!=`, `>=`, `<=`, `>`, `<`
 //! - Containment: `'x' in var`, `'x' not in var`
 //! - List literals: `['a', 'b', 'c']`
 //! - Parenthesized groups: `(expr)`
-//! - Function calls: `int(x)`
+//! - Function calls: `int(x)` (postfix `.field` / `['k']` / `[i]` chains
+//!   are honored on call arguments via the shared primary parser)
 //! - Truthiness: bare identifiers are truthy if non-empty and not `"false"`
 
 use std::collections::HashMap;
@@ -525,23 +529,55 @@ fn parse_primary(
             let name = name.clone();
             *pos += 1;
 
-            // Dot-access: ident.field.subfield
+            // Postfix accessor chain: `.field`, `['key']`, `[index]`.
+            // String-key and integer-index bracket access flatten into the
+            // dot-access lookup key (mirrors recipe-runner #71/#92 semantics
+            // adapted to amplihack-rs's flat string context model), so
+            // `obj['confirmed_count']` is looked up as `obj.confirmed_count`.
             let mut lookup_key = name.clone();
-            while *pos < tokens.len() && tokens[*pos] == Token::Dot {
-                *pos += 1;
-                if *pos >= tokens.len() {
-                    return Err(ConditionError::Parse(
-                        "expected identifier after '.'".to_string(),
-                    ));
-                }
-                if let Token::Ident(field) = &tokens[*pos] {
-                    lookup_key = format!("{lookup_key}.{field}");
+            loop {
+                if *pos < tokens.len() && tokens[*pos] == Token::Dot {
                     *pos += 1;
+                    if *pos >= tokens.len() {
+                        return Err(ConditionError::Parse(
+                            "expected identifier after '.'".to_string(),
+                        ));
+                    }
+                    if let Token::Ident(field) = &tokens[*pos] {
+                        lookup_key = format!("{lookup_key}.{field}");
+                        *pos += 1;
+                    } else {
+                        return Err(ConditionError::Parse(format!(
+                            "expected identifier after '.', got {:?}",
+                            tokens[*pos]
+                        )));
+                    }
+                } else if *pos < tokens.len() && tokens[*pos] == Token::LBracket {
+                    *pos += 1;
+                    if *pos >= tokens.len() {
+                        return Err(ConditionError::Parse(
+                            "unexpected end of expression after '['".to_string(),
+                        ));
+                    }
+                    let key = match &tokens[*pos] {
+                        Token::Str(s) => s.clone(),
+                        Token::Int(n) => n.to_string(),
+                        other => {
+                            return Err(ConditionError::Parse(format!(
+                                "expected string or integer key inside '[...]', got {other:?}"
+                            )));
+                        }
+                    };
+                    *pos += 1;
+                    if *pos >= tokens.len() || tokens[*pos] != Token::RBracket {
+                        return Err(ConditionError::Parse(
+                            "expected ']' after subscript key".to_string(),
+                        ));
+                    }
+                    *pos += 1;
+                    lookup_key = format!("{lookup_key}.{key}");
                 } else {
-                    return Err(ConditionError::Parse(format!(
-                        "expected identifier after '.', got {:?}",
-                        tokens[*pos]
-                    )));
+                    break;
                 }
             }
 
@@ -897,5 +933,83 @@ mod tests {
     fn complex_condition_with_dot_and_equality() {
         let c = ctx(&[("initial_requirements.requires_debate", "true")]);
         assert!(evaluate_condition("initial_requirements.requires_debate == 'true'", &c).unwrap());
+    }
+
+    // -- Bracket access (mirrors recipe-runner #71/#92) --
+
+    #[test]
+    fn bracket_access_string_key() {
+        let c = ctx(&[("validated_findings.confirmed_count", "3")]);
+        assert!(evaluate_condition("int(validated_findings['confirmed_count']) > 0", &c).unwrap());
+    }
+
+    #[test]
+    fn bracket_access_missing_key_is_falsy() {
+        let c = ctx(&[("validated_findings.rejected_count", "1")]);
+        assert!(!evaluate_condition("validated_findings['confirmed_count']", &c).unwrap());
+    }
+
+    #[test]
+    fn bracket_access_integer_index() {
+        let c = ctx(&[("items.0", "alpha")]);
+        assert!(evaluate_condition("items[0] == 'alpha'", &c).unwrap());
+    }
+
+    #[test]
+    fn bracket_access_chains_with_dot() {
+        // obj.a['b'] flattens to obj.a.b
+        let c = ctx(&[("obj.a.b", "v")]);
+        assert!(evaluate_condition("obj.a['b'] == 'v'", &c).unwrap());
+        // obj['a'].b flattens to obj.a.b
+        assert!(evaluate_condition("obj['a'].b == 'v'", &c).unwrap());
+    }
+
+    #[test]
+    fn bracket_access_inside_function_arg() {
+        // Postfix bracket on a function/method call argument must parse.
+        // Mirrors recipe-runner #92 regression
+        // (`obj.contains(items['key'])`-style usage).
+        let c = ctx(&[("validated_findings.confirmed_count", "5")]);
+        assert!(evaluate_condition("int(validated_findings['confirmed_count']) >= 5", &c).unwrap());
+    }
+
+    #[test]
+    fn bracket_access_quality_audit_pattern() {
+        // Real condition shape from quality-audit-cycle.yaml:
+        // `validated_findings and validated_findings['confirmed_count'] > 0`
+        let c = ctx(&[
+            ("validated_findings", "{\"confirmed_count\":3}"),
+            ("validated_findings.confirmed_count", "3"),
+        ]);
+        assert!(
+            evaluate_condition(
+                "validated_findings and int(validated_findings['confirmed_count']) > 0",
+                &c,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn bracket_access_validate_only() {
+        // Validation path (lenient mode) must accept the syntax.
+        assert!(validate_condition("obj['k'] == 'v'").is_ok());
+        assert!(validate_condition("int(obj['k']) > 0").is_ok());
+        assert!(validate_condition("items[0]").is_ok());
+        assert!(validate_condition("a.b['c'].d['e']").is_ok());
+    }
+
+    #[test]
+    fn bracket_access_invalid_key_errors() {
+        // Bare identifier inside brackets is not a valid key (must be string
+        // literal or integer).
+        let c = HashMap::new();
+        assert!(evaluate_condition("obj[bad]", &c).is_err());
+    }
+
+    #[test]
+    fn bracket_access_missing_close_errors() {
+        let c = HashMap::new();
+        assert!(evaluate_condition("obj['k'", &c).is_err());
     }
 }

--- a/crates/amplihack-recipe/src/condition_eval.rs
+++ b/crates/amplihack-recipe/src/condition_eval.rs
@@ -965,6 +965,23 @@ mod tests {
     }
 
     #[test]
+    fn bracket_access_consecutive_brackets() {
+        // obj['a']['b'] must flatten the same as obj.a.b — verifies the
+        // accessor loop iterates correctly over multiple bracket terms.
+        let c = ctx(&[("obj.a.b", "v")]);
+        assert!(evaluate_condition("obj['a']['b'] == 'v'", &c).unwrap());
+    }
+
+    #[test]
+    fn bracket_access_key_containing_dot() {
+        // obj['a.b'] flattens to lookup key obj.a.b — same as obj.a.b and
+        // obj['a']['b']. Documents that dotted keys are NOT round-tripped
+        // through the flat HashMap context (matches existing dot-access).
+        let c = ctx(&[("obj.a.b", "v")]);
+        assert!(evaluate_condition("obj['a.b'] == 'v'", &c).unwrap());
+    }
+
+    #[test]
     fn bracket_access_inside_function_arg() {
         // Postfix bracket on a function/method call argument must parse.
         // Mirrors recipe-runner #92 regression


### PR DESCRIPTION
## Summary

Ports postfix bracket-access (`obj['k']`, `items[0]`) to amplihack-rs's recipe condition parser. Mirrors recipe-runner [#71](https://github.com/rysweet/amplihack-recipe-runner/pull/71) (primary-position bracket access) and [#92](https://github.com/rysweet/amplihack-recipe-runner/pull/92) (bracket-access inside call arguments).

## Why

amplihack-rs ships its own Rust recipe runner (`crates/amplihack-recipe/`) — independent of the Python `amplihack-recipe-runner`. Cross-ecosystem audit found the Rust parser only supported `.field` and `(arg)` postfix, so any ported recipe using bracket access (e.g. `validated_findings['confirmed_count']` from `quality-audit-cycle.yaml`) failed at runtime with `Parse error: unexpected token: LBracket`.

## Approach

amplihack-rs uses a flat `HashMap<String, String>` context (vs. recipe-runner's nested `serde_json::Value`). To preserve parity without a context-model rewrite, bracket access flattens into the existing dot-access lookup key:

| Expression | Lookup key |
|---|---|
| `obj['confirmed_count']` | `obj.confirmed_count` |
| `items[0]` | `items.0` |
| `obj['a']['b']` | `obj.a.b` |
| `obj['a.b']` | `obj.a.b` (dot-key flattened — matches existing dot-access) |
| `obj.a['b'].c['d']` | `obj.a.b.c.d` |

Postfix bracket and dot can chain freely, in any order. Because the change lives in `parse_primary`, it's automatically honored inside function/method call arguments (e.g. `int(obj['k']) > 0`) — no separate `parse_or_value` plumbing needed.

## Tests

11 tests covering:
- string-key, integer-index, missing-key falsy, dot+bracket chains
- consecutive `[…][…]` brackets and dotted-string keys (cycle-2 audit additions)
- bracket-access inside function call arguments
- the real `quality-audit-cycle.yaml` condition shape
- validation-only path
- error cases (invalid key token, unclosed bracket)

```
$ TMPDIR=/tmp cargo test -p amplihack-recipe --lib
test result: ok. 163 passed; 0 failed; 0 ignored

$ cargo clippy -p amplihack-recipe --tests -- -D warnings
(clean)
```

## Related

- recipe-runner PR rysweet/amplihack-recipe-runner#71 (introduced bracket access)
- recipe-runner PR rysweet/amplihack-recipe-runner#92 (bracket access inside call args)
- amplihack issue rysweet/amplihack#4398
- amplihack-rs issue rysweet/amplihack-rs#313

## Out of scope

- No recipe YAML changes. Stock amplihack-rs recipes don't yet use bracket access; this fix is forward-compatible for any port from amplihack/recipe-runner that does.
- No context-model change (still flat `HashMap<String, String>`).
- No tokenizer escape-sequence support inside string keys (`obj['a\'b']`). Not introduced by this PR; users can already use alternating quote styles. Filed for future consideration if a use case arises.

---

## Merge readiness

### QA-team evidence

- This PR ships pure library logic (recipe condition expression parser) with no user-facing CLI/API surface change. The corresponding gadugi-test category for amplihack-rs is `tests/outside-in/scenario*-*.yaml` (CLI-level scenarios); no scenario maps to "the recipe condition parser supports bracket access" because that surface is internal.
- Behavioural coverage is provided by **11 in-tree unit tests** (`condition_eval::tests::bracket_access_*`) including the real `quality-audit-cycle.yaml` condition shape.
- Validation: `TMPDIR=/tmp cargo test -p amplihack-recipe --lib` → `163 passed; 0 failed`.

### Documentation

- User-facing docs impact: **no**. The condition expression grammar is not exposed in any of the docs (`docs/reference/recipe-command.md` only lists `condition` as a string field; no grammar reference page exists). The change is additive and forward-compatible — existing recipe conditions continue to parse identically.
- Changed surfaces reviewed: `crates/amplihack-recipe/src/condition_eval.rs` (internal library). No CLI behaviour, no config schema, no env-var contract changes.

### Quality-audit

- **Cycle 1**: `code-review` agent ran a focused 5-point verification (parser edge cases, security, test coverage). Initial three medium-severity concerns surfaced: (a) `int(x)['key']` accessor on call result, (b) escape sequences in string keys, (c) coverage gap on consecutive brackets / dotted keys. After re-evaluation by the same reviewer:
  - (a) is correct behaviour (function results are Values, not accessors) and is implicitly covered by the existing parser error path.
  - (b) is consistent with the existing tokenizer (no escapes); users can use alternating quote styles. Not a regression.
  - (c) was an actionable test-coverage gap.
- **Cycle 2**: Added 2 regression tests addressing (c) (`bracket_access_consecutive_brackets`, `bracket_access_key_containing_dot`). Re-ran lint + test → clean. Final cycle ended with **zero critical/high findings and zero medium correctness/security findings**.
- Convergence summary: 2 cycles. The single remaining concern (escape sequences) is documented under "Out of scope" as a forward-looking enhancement.

### CI

- Result: see `gh pr checks 318` — all checks green at merge time.
- Skipped checks: `Release` / `scan` (workflow conditionals on tag pushes / scheduled scans), `Atlas PR Impact Check` and `Check skill/agent drift` are advisory-only and merge regardless.
- Flaky reruns: none.

### Scope

- Files reviewed: `gh pr diff 318 --name-only` → exactly one file (`crates/amplihack-recipe/src/condition_eval.rs`).
- Unrelated changes: **none**.

### Verdict

- Merge-ready: **yes**
- Remaining blockers: **none**
