### PR TITLE
fix(executor): spill large bash steps to tempfile to avoid E2BIG

### DIFF
--- a/crates/amplihack-recipe/Cargo.toml
+++ b/crates/amplihack-recipe/Cargo.toml
@@ -13,6 +13,6 @@ tracing = { workspace = true }
 sha2 = { workspace = true }
 regex = "1"
 libc = { workspace = true }
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"

--- a/crates/amplihack-recipe/src/executor.rs
+++ b/crates/amplihack-recipe/src/executor.rs
@@ -17,10 +17,14 @@ use tracing::{debug, info, warn};
 /// Threshold above which a bash command body is spilled to a tempfile and
 /// executed as a script (`/bin/bash <path>`) instead of passed inline via
 /// `bash -c <body>`. Mirrors recipe-runner #80/#90: argv + env must fit in
-/// `ARG_MAX` (~128 KiB on Linux), and when smart-orchestrator final steps
-/// accumulate round results from many parallel workstreams the inlined
-/// script body alone can exceed this and fail with `Argument list too long
-/// (os error 7)`. 64 KiB leaves headroom for env vector + binary args.
+/// the kernel's `ARG_MAX` budget (currently 2 MiB on Linux ≥ 2.6.23, but as
+/// little as 128 KiB on older kernels and some other Unix variants). When
+/// smart-orchestrator final steps accumulate round results from many parallel
+/// workstreams, the inlined script body alone can exceed this and fail with
+/// `Argument list too long (os error 7)`. 64 KiB is a conservative threshold
+/// that leaves headroom for the env vector + binary args even on lower-bound
+/// systems, and is well clear of the per-step env budget defined inside
+/// `execute_shell_step`.
 const BASH_INLINE_LIMIT: usize = 64 * 1024;
 
 /// Wrap `body` in a `bash` `Command`, spilling to a tempfile when the body
@@ -38,9 +42,10 @@ fn build_bash_command(
             .with_context(|| "Failed to create tempfile for large bash step")?;
         tf.write_all(body.as_bytes())
             .with_context(|| "Failed to write large bash step to tempfile")?;
-        // Best-effort flush: close-on-drop will also flush, but explicit
-        // flush surfaces I/O errors before we attempt to spawn bash.
-        tf.flush().ok();
+        // Explicit flush so any I/O errors (disk full, quota exceeded, etc.)
+        // surface BEFORE we spawn bash against a possibly-truncated script.
+        tf.flush()
+            .with_context(|| "Failed to flush large bash step tempfile")?;
         let mut cmd = std::process::Command::new("/bin/bash");
         cmd.arg(tf.path());
         Ok((cmd, Some(tf)))

--- a/crates/amplihack-recipe/src/executor.rs
+++ b/crates/amplihack-recipe/src/executor.rs
@@ -10,8 +10,46 @@ use crate::sub_recipe_recovery::{FailureContext, SubRecipeRecovery};
 use crate::template::expand_template;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
+use std::io::Write;
 use std::time::Instant;
 use tracing::{debug, info, warn};
+
+/// Threshold above which a bash command body is spilled to a tempfile and
+/// executed as a script (`/bin/bash <path>`) instead of passed inline via
+/// `bash -c <body>`. Mirrors recipe-runner #80/#90: argv + env must fit in
+/// `ARG_MAX` (~128 KiB on Linux), and when smart-orchestrator final steps
+/// accumulate round results from many parallel workstreams the inlined
+/// script body alone can exceed this and fail with `Argument list too long
+/// (os error 7)`. 64 KiB leaves headroom for env vector + binary args.
+const BASH_INLINE_LIMIT: usize = 64 * 1024;
+
+/// Wrap `body` in a `bash` `Command`, spilling to a tempfile when the body
+/// exceeds [`BASH_INLINE_LIMIT`]. The returned `NamedTempFile` (when
+/// present) MUST outlive the spawned process — drop it only after the
+/// process has exited, otherwise the script file disappears mid-execution.
+fn build_bash_command(
+    body: &str,
+) -> Result<(std::process::Command, Option<tempfile::NamedTempFile>)> {
+    if body.len() > BASH_INLINE_LIMIT {
+        let mut tf = tempfile::Builder::new()
+            .prefix("recipe-bash-step-")
+            .suffix(".sh")
+            .tempfile()
+            .with_context(|| "Failed to create tempfile for large bash step")?;
+        tf.write_all(body.as_bytes())
+            .with_context(|| "Failed to write large bash step to tempfile")?;
+        // Best-effort flush: close-on-drop will also flush, but explicit
+        // flush surfaces I/O errors before we attempt to spawn bash.
+        tf.flush().ok();
+        let mut cmd = std::process::Command::new("/bin/bash");
+        cmd.arg(tf.path());
+        Ok((cmd, Some(tf)))
+    } else {
+        let mut cmd = std::process::Command::new("bash");
+        cmd.arg("-c").arg(body);
+        Ok((cmd, None))
+    }
+}
 
 /// Trait for executing agent steps. Implementors provide the actual agent
 /// invocation logic (e.g. spawning a Claude session).
@@ -344,8 +382,7 @@ impl<A: AgentBackend> RecipeExecutor<A> {
             ));
         }
 
-        let mut cmd = std::process::Command::new("bash");
-        cmd.arg("-c").arg(&expanded);
+        let (mut cmd, _script_file) = build_bash_command(&expanded)?;
         cmd.current_dir(&self.config.working_dir);
 
         // Ensure a sane non-interactive environment (fix #277).
@@ -416,6 +453,9 @@ impl<A: AgentBackend> RecipeExecutor<A> {
         let output = cmd
             .output()
             .with_context(|| format!("Failed to execute shell step '{}'", step.id))?;
+        // _script_file (if Some) is dropped here, after bash has exited —
+        // moving the drop earlier would yank the script file mid-execution.
+        drop(_script_file);
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -494,12 +534,12 @@ impl<A: AgentBackend> RecipeExecutor<A> {
         // Checkpoint steps run their command (typically git commit) if present
         if let Some(ref command) = step.command {
             let expanded = expand_template(command, context);
-            let output = std::process::Command::new("bash")
-                .arg("-c")
-                .arg(&expanded)
+            let (mut cmd, _script_file) = build_bash_command(&expanded)?;
+            let output = cmd
                 .current_dir(&self.config.working_dir)
                 .output()
                 .with_context(|| format!("Checkpoint step '{}' failed", step.id))?;
+            drop(_script_file);
 
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             if output.status.success() {
@@ -938,6 +978,69 @@ steps:
             result.step_results[0].output.as_deref(),
             Some(value),
             "shell step did not inherit parent env var (regression for #268)"
+        );
+    }
+
+    // ---- BASH_INLINE_LIMIT spill (mirrors recipe-runner #80/#90) ----
+
+    #[test]
+    fn build_bash_command_inline_for_small_body() {
+        let body = "echo hi";
+        let (cmd, tf) = build_bash_command(body).unwrap();
+        assert!(tf.is_none(), "small body should NOT spill to tempfile");
+        let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0], "-c");
+        assert_eq!(args[1], body);
+    }
+
+    #[test]
+    fn build_bash_command_spills_for_oversized_body() {
+        // Body > BASH_INLINE_LIMIT must use the file-backed form.
+        let big = "a".repeat(64 * 1024 + 1);
+        let (cmd, tf) = build_bash_command(&big).unwrap();
+        let tf = tf.expect("oversized body must spill to tempfile");
+        let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
+        // Single arg = the script path; no `-c` form.
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0], tf.path().as_os_str());
+        // Tempfile actually contains the body.
+        let on_disk = std::fs::read_to_string(tf.path()).unwrap();
+        assert_eq!(on_disk.len(), big.len());
+    }
+
+    #[test]
+    fn shell_step_executes_oversized_body_via_tempfile() {
+        // End-to-end: a shell step whose body is > 64 KiB must execute
+        // successfully (would fail with `Argument list too long` if we
+        // still used `bash -c`).
+        let mut padding = String::with_capacity(80 * 1024);
+        for i in 0..1300 {
+            padding.push_str(&format!(
+                "# padding {i:04} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+            ));
+        }
+        padding.push_str("printf SPILL_OK\n");
+        assert!(padding.len() > 64 * 1024);
+
+        let yaml = "
+name: spill-test
+steps:
+  - id: big
+    type: shell
+    command: 'placeholder'
+"
+        .to_string();
+        let mut recipe = crate::parser::RecipeParser::new().parse(&yaml).unwrap();
+        recipe.steps[0].command = Some(padding);
+
+        let executor = RecipeExecutor::new(ExecutorConfig::default(), DryRunAgentBackend);
+        let result = executor.execute(&recipe, HashMap::new()).unwrap();
+        assert!(result.success, "oversized shell step failed: {result:?}");
+        let out = result.step_results[0].output.as_deref().unwrap_or("");
+        assert!(
+            out.contains("SPILL_OK"),
+            "oversized shell step did not run; output={out:?}"
         );
     }
 }

--- a/docs/concepts/recipe-execution-flow.md
+++ b/docs/concepts/recipe-execution-flow.md
@@ -57,7 +57,9 @@ The executor applies two layers of defensive configuration before running any st
 
 ### Shell steps
 
-Every `bash -c` subprocess receives `HOME`, `PATH`, `NONINTERACTIVE=1`, `DEBIAN_FRONTEND=noninteractive`, and `CI=true` in its environment. These values are injected unconditionally — recipe steps are automated and must never prompt for input.
+Every shell subprocess receives `HOME`, `PATH`, `NONINTERACTIVE=1`, `DEBIAN_FRONTEND=noninteractive`, and `CI=true` in its environment. These values are injected unconditionally — recipe steps are automated and must never prompt for input.
+
+Command bodies up to 64 KiB are passed inline via `bash -c <body>`. Larger bodies are written to a tempfile and executed as `bash <path>` to avoid `Argument list too long (E2BIG)` from kernel `ARG_MAX` (~128 KiB on Linux). Both paths receive identical environment, working directory, and stdio handling; only the argv shape differs.
 
 If the shell command references `python3` or `python `, the executor runs a pre-flight `python3 --version` check and aborts the step immediately if Python is unavailable.
 


### PR DESCRIPTION
## Summary

Ports recipe-runner [#80/#90](https://github.com/rysweet/amplihack-recipe-runner/pull/90) to the amplihack-rs native Rust executor. When a shell or checkpoint step's expanded command body exceeds 64 KiB, write it to a `tempfile::NamedTempFile` and execute as a script file (`/bin/bash <path>`) instead of inline (`bash -c <body>`).

## Problem

`smart-orchestrator` final infrastructure steps (`cleanup-helper`, `complete-session`) deterministically fail at the OS exec layer with:

```
Argument list too long (os error 7)
```

Root cause: `execute_shell_step` invokes `bash -c <expanded>`, so the entire script body sits in a single `argv` element. After several parallel workstreams accumulate round-results, the inlined script body alone can exceed kernel `ARG_MAX` (2 MiB on Linux ≥ 2.6.23, 128 KiB on older systems and some other Unix variants) — even though context env vars are already capped via the #224 budget logic.

## Fix

Shared `build_bash_command` helper:

```rust
const BASH_INLINE_LIMIT: usize = 64 * 1024;
fn build_bash_command(body: &str) -> Result<(Command, Option<NamedTempFile>)>
```

- Body ≤ 64 KiB → `bash -c <body>` (unchanged, fast path)
- Body > 64 KiB → write to `tempfile::NamedTempFile`, return `/bin/bash <path>`

Used in both `execute_shell_step` and `execute_checkpoint_step`. The tempfile is held alongside the Command and explicitly dropped *after* `output()` returns, so the script file isn't yanked mid-execution.

64 KiB is conservative — it leaves headroom for the env vector + binary args even on lower-bound systems where `ARG_MAX` is only 128 KiB.

## Tests (3 new)

- `build_bash_command_inline_for_small_body` — under threshold uses `-c`
- `build_bash_command_spills_for_oversized_body` — over threshold writes to disk
- `shell_step_executes_oversized_body_via_tempfile` — end-to-end via `RecipeExecutor` with a ~80 KiB script

## Cargo.toml

Promotes `tempfile` from `[dev-dependencies]` to `[dependencies]` (was already pulled in transitively for tests).

## Docs

- `docs/concepts/recipe-execution-flow.md` updated to document the inline vs. spill paths and clarify both receive identical environment, working directory, and stdio handling.

## Verification

```
$ TMPDIR=/tmp cargo test -p amplihack-recipe --lib
test result: ok. 155 passed; 0 failed; 0 ignored

$ cargo clippy -p amplihack-recipe --tests -- -D warnings
(clean)
```

## Related

- recipe-runner PR rysweet/amplihack-recipe-runner#90 (source of fix)
- recipe-runner issue rysweet/amplihack-recipe-runner#80 (reproduction)
- amplihack-rs issue rysweet/amplihack-rs#321 (pre-existing checkpoint env-var gap, surfaced during this PR's audit — see Quality-audit section)

## Out of scope

- No recipe YAML changes.
- Doesn't change the `#224` env-budget logic — that limits *env* size, this limits *argv*.
- Pre-existing env-var divergence between `execute_shell_step` and `execute_checkpoint_step` (filed separately as #321) — this PR does not introduce or worsen that divergence; it merely refactored both call sites to share `build_bash_command`.

---

## Merge readiness

### QA-team evidence

- This PR ships executor-internal logic (bash command spawn shape) with no user-facing CLI/API change. End-to-end behaviour is exercised by the in-tree test `shell_step_executes_oversized_body_via_tempfile`, which constructs a real `RecipeExecutor`, runs an ~80 KiB shell step through `execute_shell_step`, and asserts both the spill code path and the resulting stdout/exit-code.
- Validation: `TMPDIR=/tmp cargo test -p amplihack-recipe --lib` → `155 passed; 0 failed`.
- Full repo CI exercises the executor through real recipe runs (Install Smoke Test, Test); see `gh pr checks 319`.

### Documentation

- User-facing docs impact: **yes** — `docs/concepts/recipe-execution-flow.md` previously asserted that "every `bash -c` subprocess receives …", which is no longer accurate. Updated to document both inline and tempfile paths and clarify they receive identical env/cwd/stdio.
- Updated docs: `docs/concepts/recipe-execution-flow.md` (lines 60-63 in the new revision).
- Changed surfaces reviewed: `crates/amplihack-recipe/src/executor.rs`, `crates/amplihack-recipe/Cargo.toml`, `docs/concepts/recipe-execution-flow.md`.

### Quality-audit

- **Cycle 1**: `code-review` agent ran 8-point verification (tempfile lifetime, permissions, cross-platform, threshold sizing, error propagation, partial writes, env preservation, test triggering). Findings:
  - (Medium, fixable) `tf.flush().ok()` silently discarded I/O errors despite a comment claiming it "surfaces" them. Fix: replaced with `tf.flush().with_context(|| …)?` so disk-full / quota errors abort cleanly instead of feeding bash a truncated script.
  - (Medium, fixable) `BASH_INLINE_LIMIT` doc comment incorrectly stated `ARG_MAX (~128 KiB)`. Modern Linux (≥ 2.6.23) is 2 MiB. Fix: rewrote comment to be accurate and explain the conservative-threshold rationale.
  - (High, **pre-existing**) `execute_checkpoint_step` doesn't inject HOME/PATH/NONINTERACTIVE/CI env vars or per-step context env vars like `execute_shell_step` does. **Filed as rysweet/amplihack-rs#321** with full reproduction. Kept out of scope to keep this port surgical.
- **Cycle 2**: Re-ran the same `code-review` agent on the post-fix state. Verdict: **"No findings — convergence achieved."** Verified both fixes are correct, complete, regression-free; both call sites correctly drop the tempfile post-`output()`; error message is actionable.
- Convergence summary: 2 cycles. Final cycle ended with **zero critical/high findings and zero medium correctness/security findings introduced by this PR**. The pre-existing High finding is tracked in #321.

### CI

- Result: see `gh pr checks 319` — all checks green at merge time on the latest commit (`6a5b4b5`).
- Skipped checks: `Release`, `scan`, `deploy` (workflow conditionals).
- Flaky reruns: none.

### Scope

- Files reviewed: `gh pr diff 319 --name-only` → 3 files: `crates/amplihack-recipe/src/executor.rs`, `crates/amplihack-recipe/Cargo.toml`, `docs/concepts/recipe-execution-flow.md`.
- Unrelated changes: **none**.

### Verdict

- Merge-ready: **yes**
- Remaining blockers: **none**
