### PR TITLE
fix(investigation-workflow): seed investigation_question from task_description (closes #256)

### DIFF
--- a/amplifier-bundle/recipes/investigation-workflow.yaml
+++ b/amplifier-bundle/recipes/investigation-workflow.yaml
@@ -102,6 +102,32 @@ steps:
     output: "preflight_status"
 
   # ==========================================================================
+  # NORMALIZE QUESTION
+  # When this recipe is launched from smart-orchestrator's multitask path or
+  # any other caller that forwards `task_description` but not
+  # `investigation_question`, promote `task_description` so downstream prompts
+  # have a non-empty question. Without this, every deep-dive agent receives
+  # the literal empty default and reports "no investigation question was
+  # provided", producing hollow success (recipe exits 0 but no real
+  # investigation occurs). An explicitly-supplied `investigation_question`
+  # is preserved unchanged.
+  #
+  # Mirrors amplihack PR #4444 — adapted for amplihack-rs's executor, which
+  # exposes context vars as uppercase env vars (e.g. `task_description` →
+  # `TASK_DESCRIPTION`) without the Python recipe-runner's `RECIPE_VAR_`
+  # prefix. The `output:` key overwrites the empty default in place.
+  # ==========================================================================
+  - id: "normalize-question"
+    type: "bash"
+    command: |
+      if [ -z "${INVESTIGATION_QUESTION:-}" ] && [ -n "${TASK_DESCRIPTION:-}" ]; then
+        printf '%s' "${TASK_DESCRIPTION}"
+      else
+        printf '%s' "${INVESTIGATION_QUESTION:-}"
+      fi
+    output: "investigation_question"
+
+  # ==========================================================================
   # INITIALIZATION: Track start time for efficiency metrics
   # ==========================================================================
   - id: "init-tracking"


### PR DESCRIPTION
## Summary

Ports amplihack [PR #4444](https://github.com/rysweet/amplihack/pull/4444) — adapted for amplihack-rs's native Rust executor. Closes #256.

## Problem

`investigation-workflow` exits with `Status: ✓ Success` while every deep-dive agent reports
"no investigation question was provided" — a hollow-success failure mode.

**Reproduction**: invoke `smart-orchestrator` with any investigation task. The multitask path
forwards `task_description`, `repo_path`, `issue_number`, etc., but does **not** set
`investigation_question`. The investigation recipe declares `investigation_question: ""` as
its sole question variable and uses `{{investigation_question}}` in 30+ template substitutions,
so every spawned agent receives the empty literal.

## Fix

Add a `normalize-question` bash step immediately after `preflight-validation`:

```yaml
- id: "normalize-question"
  type: "bash"
  command: |
    if [ -z "${INVESTIGATION_QUESTION:-}" ] && [ -n "${TASK_DESCRIPTION:-}" ]; then
      printf '%s' "${TASK_DESCRIPTION}"
    else
      printf '%s' "${INVESTIGATION_QUESTION:-}"
    fi
  output: "investigation_question"
```

`output: "investigation_question"` overwrites the empty default in place (verified against
`crates/amplihack-recipe/src/executor.rs:185-194`, the #226 output-key fix).

## Adaptation from amplihack PR #4444

The Python recipe-runner exposes context vars with a `RECIPE_VAR_` prefix; amplihack-rs's
executor exposes them as plain uppercase env vars (`task_description` → `TASK_DESCRIPTION`).
Variable names adapted accordingly. Step semantics and `output` key handling are identical.

## Why recipe-local instead of orchestrator-side?

A recipe-local fix handles **all** callers in one place — single workstream, parallel multitask,
direct `amplihack recipe run` invocation — without coupling the orchestrator to recipe-specific
input variable names.

## Verification

```
$ python3 -c "import yaml; yaml.safe_load(open('amplifier-bundle/recipes/investigation-workflow.yaml'))"
(parses cleanly)

$ TMPDIR=/tmp cargo test -p amplihack-recipe --lib parse
(all 21 parser tests pass)
```

The output-key overwrite path is exercised by the existing `#226` regression test.

## Related

- amplihack PR rysweet/amplihack#4444 (source of fix)
- amplihack-rs issue rysweet/amplihack-rs#256 (hollow-success symptom)
- Simard rysweet/Simard#1152 (downstream impact)

---

## Merge readiness

### QA-team evidence

- This PR is a **YAML-only** recipe change (one workflow file). Behaviour is testable end-to-end by running `amplihack recipe run investigation-workflow -c task_description="…"`. Coverage relies on:
  - YAML syntactic validity (asserted via `python3 -c "import yaml; yaml.safe_load(...)"` and the in-tree recipe-parser tests)
  - The existing `#226` output-key overwrite regression test in `crates/amplihack-recipe/src/executor.rs` (proves the `output: investigation_question` mechanism overwrites the empty default the way this fix relies on)
- The corresponding gadugi-test category for amplihack-rs is `tests/outside-in/scenario*-*.yaml` (CLI-level scenarios). No existing scenario covers the investigation workflow, so writing a new gadugi scenario would require standing up a new investigation harness — out of scope for a one-line YAML fix that mirrors a merged-and-validated amplihack PR.
- Validation: `cargo test -p amplihack-recipe --lib parse` → all 21 parser tests pass.

### Documentation

- User-facing docs impact: **no**. `investigation_question` is an internal recipe input variable, not a user-facing CLI flag or config key. Users continue to invoke the workflow exactly as before via `task_description`.
- Changed surfaces reviewed: `amplifier-bundle/recipes/investigation-workflow.yaml` only. No CLI command, no documented input variable, no config key changes.

### Quality-audit

- **Cycle 1**: `code-review` agent ran a 7-point verification (env-var naming, step ordering, output-key semantics, printf safety, set-e behaviour, condition/resume handling, YAML schema). Initial concern (Medium) on printf+template interaction was raised, then **withdrawn on re-evaluation** when the agent confirmed the bash uses env vars (not template-expansion `{{…}}`), so context values are read safely from the environment and `printf '%s'` correctly preserves them. Final verdict: **"No significant issues found in the reviewed changes."**
- Convergence summary: 1 cycle was sufficient — the agent independently re-checked its initial concern and confirmed it was a false positive. Final cycle ended with **zero findings**.

### CI

- Result: see `gh pr checks 320` — all checks green.
- Skipped checks: `Release`, `scan` (workflow conditionals).
- Flaky reruns: none.

### Scope

- Files reviewed: `gh pr diff 320 --name-only` → exactly one file (`amplifier-bundle/recipes/investigation-workflow.yaml`).
- Unrelated changes: **none**.

### Verdict

- Merge-ready: **yes**
- Remaining blockers: **none**
