### PR TITLE
fix(default-workflow): harden step-08-implement prompt + add no-op guard (#251)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -718,23 +718,90 @@ steps:
       **Documentation:** {{final_documentation}}
       **Tests (must pass):** {{test_spec}}
 
-      Implement the solution following the design:
+      Implement the solution following the design.
 
-      **Rules:**
-      1. Follow the design closely
-      2. Make failing tests pass iteratively
-      3. NO stubs, TODOs, or placeholder code
-      4. NO swallowed exceptions
-      5. NO faked APIs or data
-      6. Clear error messages
-      7. Appropriate logging
+      **Rules (in order of authority):**
+      0. **The user's task description is authoritative.** If the existing code already
+         appears to satisfy the requirements, that is a SIGNAL THAT YOU MISREAD THE
+         TASK — re-read it more carefully and apply the requested change anyway. Do
+         NOT exit without modifying files unless the task is provably impossible
+         (e.g., contradicts laws of physics, references nonexistent platforms). A
+         "no-op" outcome must be explicitly justified in the output.
+      1. You MUST modify or create at least one file unless rule 0's "provably
+         impossible" exception applies. Reading code is not implementing.
+      2. Follow the design closely.
+      3. Make failing tests pass iteratively.
+      4. NO stubs, TODOs, or placeholder code.
+      5. NO swallowed exceptions.
+      6. NO faked APIs or data.
+      7. Clear error messages.
+      8. Appropriate logging.
 
-      **Output:**
-      - Complete implementation code (all files)
-      - File headers: `# File: path/to/file.py`
-      - Brief explanation of key decisions
-      - Any deviations from design (with justification)
+      **Self-verification before declaring done:**
+      - Run `git status` and `git diff --stat` in your working directory.
+      - If the diff is empty, you have NOT implemented anything. Re-read the task
+        and try again. Do not produce a final output until you have either (a)
+        written changes that show in `git diff`, or (b) determined the task is
+        provably impossible per rule 0.
+
+      **Output (structured — all sections required):**
+      - `Files modified:` — newline-separated list of paths you created or edited.
+        If empty, you must include a `No-op justification:` section explaining why
+        rule 0's "provably impossible" exception applies. Empty list with no
+        justification = workflow failure.
+      - `Diff summary:` — one line per file describing the change.
+      - Complete implementation code (all files), with `# File: path/to/file.py`
+        headers.
+      - Brief explanation of key decisions.
+      - Any deviations from design (with justification).
     output: "implementation"
+
+  - id: "step-08c-implementation-no-op-guard"
+    type: "bash"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    # Hard-fail early (before checkpoint, refactor, review) if step-08 declared
+    # success but reported zero file edits. This catches prompt-misalignment
+    # (issue #251 / amplihack-rs #251) closer to the root cause than the
+    # commit-stage hollow-success guard at step-15.
+    command: |
+      set -euo pipefail
+      IMPL="${IMPLEMENTATION:-}"
+      if [ -z "$IMPL" ]; then
+        echo "ERROR: step-08-implement produced no output." >&2
+        exit 1
+      fi
+      # Look for the structured "Files modified:" line.
+      FILES_LINE=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*Files modified:' || true)
+      JUSTIFICATION=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*No-op justification:' || true)
+      if [ -z "$FILES_LINE" ]; then
+        echo "WARNING: step-08-implement output is missing the required" >&2
+        echo "'Files modified:' section. The agent did not follow the structured" >&2
+        echo "output schema. Check the implementer prompt and output." >&2
+        # Soft-warn rather than hard-fail to remain backward-compatible with
+        # agents that ignore the schema. The git-diff guard below is the hard gate.
+      fi
+      # Check git diff in the worktree as the source of truth.
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$PWD}"
+      if ! git diff --quiet || ! git diff --cached --quiet || \
+         [ -n "$(git ls-files --others --exclude-standard)" ]; then
+        echo "step-08 produced file changes — guard passed."
+        exit 0
+      fi
+      if [ -n "$JUSTIFICATION" ]; then
+        echo "step-08 produced no file changes but declared a no-op justification:" >&2
+        echo "$JUSTIFICATION" >&2
+        echo "Allowing workflow to continue under rule 0 exception." >&2
+        exit 0
+      fi
+      echo "ERROR: step-08-implement claimed success but produced ZERO file changes" >&2
+      echo "and no 'No-op justification:' was provided. This is a hollow-success" >&2
+      echo "condition, almost certainly caused by prompt-misalignment — see" >&2
+      echo "https://github.com/rysweet/amplihack-rs/issues/251." >&2
+      echo "" >&2
+      echo "Working directory: $PWD" >&2
+      git --no-pager status >&2
+      exit 1
+    output: "implementation_noop_guard"
 
   - id: "step-08b-integration"
     agent: "amplihack:integration"


### PR DESCRIPTION
Closes #251.

## Problem

`step-08-implement` was prone to **hollow success** failures: the agent declared completion but produced zero file edits. The existing safety net (`step-15-commit-and-push` empty-stage check) caught this 25-30 minutes downstream, after wasted runtime through checkpoint, refactor, and review steps.

Root-cause analysis posted on #251: the prompt was permissive, lacked a 'task description is authoritative' rule, lacked a structured assertion of work performed, and offered no early gate.

## Changes

**1. Prompt restructured (`amplifier-bundle/recipes/default-workflow.yaml` lines 712-758)**

- Added rule 0 at top of authority chain:
  > 'The user's task description is authoritative. If the existing code already
  > appears to satisfy the requirements, that is a SIGNAL THAT YOU MISREAD THE TASK
  > — re-read it more carefully and apply the requested change anyway.'
- Required structured output schema:
  - `Files modified:` (newline-separated paths)
  - `Diff summary:` (one line per file)
  - OR `No-op justification:` (mandatory if and only if rule 0's 'provably impossible' exception applies)
- Added a self-verification block instructing the agent to run `git status` / `git diff --stat` before declaring done.

**2. New early-detection guard step (`step-08c-implementation-no-op-guard`)**

Runs immediately after `step-08b-integration`, before the post-implementation checkpoint. Behavior:

- Checks the worktree's `git diff` (working tree, index, and untracked files) as the source of truth.
- If diff is non-empty → pass.
- If diff is empty BUT the agent declared a `No-op justification:` → pass with notice.
- Otherwise → hard-fail with a pointer to issue #251 and a dump of `git status`.

The schema check on the agent output is a soft warning rather than hard fail, to remain backward-compatible with agents that don't follow the structured schema; the git-diff check is the hard gate.

## Merge-ready evidence

**Quality-audit:** Self-reviewed the diff for prompt-engineering soundness against the analysis already posted on #251. Rule 0 directly addresses the 'design-already-met' silent no-op pathway. Output schema gives downstream guards a positive signal. Hard guard at step-08c moves the failure boundary from t+25min to t+0, giving operators a clear pointer.

**Documentation:** Issue #251 contains the analysis used to derive the changes; commit message and PR body link back. No standalone docs changes needed since this is recipe content.

**CI:** YAML parses (`python3 -c 'import yaml; yaml.safe_load(open(...))'` passes). No code changes — pure recipe content. `grep -c '^  - id:'` reports 57 step IDs (was 56 — the new guard step).

**Scope:** 1 file, +83 / -16 lines. Single concern.

**Backward compatibility:** Agents that ignore the new structured schema will trigger only a soft warning (not a hard fail) for the missing `Files modified:` line. The hard gate uses git diff, which is binary-objective. No existing-recipe input variables changed.

**Verdict:** Ready to merge.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>