### PR TITLE
feat(retro): docs, .pm milestones, recipe hardening, dedup/flag-matrix specs (#96)

### DIFF
--- a/.pm/M1-orchestrator-stability.md
+++ b/.pm/M1-orchestrator-stability.md
@@ -1,0 +1,33 @@
+# M1: Orchestrator Stability
+
+Stabilize the smart-orchestrator and default-workflow recipes so that
+routine development tasks complete reliably without duplicate issues or
+silent failures.
+
+## Definition of Done
+
+- [ ] smart-orchestrator `file-routing-bug` step uses idempotency guards
+      (same two-guard pattern as default-workflow step-03)
+- [ ] Hollow-success detection thresholds validated against 10+ real
+      session transcripts
+- [ ] Adaptive recovery tested with forced routing gaps (all conditions
+      false)
+- [ ] No duplicate issues created when the same routing failure repeats
+      within 24 hours
+- [ ] Reflection rounds correctly distinguish PARTIAL from HOLLOW
+- [ ] Recursion guard logs are actionable (include tree ID and depth)
+- [ ] `detect-execution-gap` diagnostic banner includes recipe version
+- [ ] All changes covered by recipe-level integration tests
+
+## Deliverables
+
+| Deliverable | File | Type |
+|---|---|---|
+| Dedup guards in smart-orchestrator | `amplifier-bundle/recipes/smart-orchestrator.yaml` | Recipe fix |
+| Hollow-success test cases | `tests/recipes/` | Tests |
+| Issue dedup reference doc | `docs/reference/issue-dedup.md` | Documentation |
+| Recovery concept doc | `docs/concepts/smart-orchestrator-recovery.md` | Documentation |
+
+## Dependencies
+
+None. This milestone is self-contained.

--- a/.pm/M2-recipe-runner-consolidation.md
+++ b/.pm/M2-recipe-runner-consolidation.md
@@ -1,0 +1,37 @@
+# M2: Recipe Runner Consolidation
+
+Achieve full feature parity in `recipe-runner-rs` and remove the Python
+recipe runner fallback.
+
+## Definition of Done
+
+- [ ] All step types (`bash`, `agent`, `recipe`) supported by Rust runner
+- [ ] All 16 YAML recipes in `amplifier-bundle/recipes/` pass validation
+      with Rust runner
+- [ ] All 16 recipes execute successfully with Rust runner (no Python
+      fallback triggered)
+- [ ] `recipe_runner.py` deleted from `amplifier-bundle/tools/`
+- [ ] Freshness check in `freshness.rs` covers all supported platforms
+- [ ] No recipe references Python runner as a fallback
+
+## Gap Issues
+
+1. **Condition evaluation** — Rust runner's Jinja-like condition parser may
+   not cover all Python expressions used in existing recipes.
+2. **Timeout handling** — Python runner and Rust runner may differ in how
+   they signal timeouts to agent subprocesses.
+3. **Context variable escaping** — Multi-line values with special characters
+   may be handled differently between runners.
+
+## Deliverables
+
+| Deliverable | Location | Type |
+|---|---|---|
+| Step type parity | `recipe-runner-rs` repo | Code |
+| Recipe validation suite | `tests/recipes/` | Tests |
+| Python runner removal | `amplifier-bundle/tools/recipe_runner.py` | Deletion |
+| Architecture doc | `docs/concepts/recipe-runner-architecture.md` | Documentation |
+
+## Dependencies
+
+No hard dependency on M1, but M1's recipe fixes may surface runner gaps.

--- a/.pm/M3-bundled-python-winddown.md
+++ b/.pm/M3-bundled-python-winddown.md
@@ -1,0 +1,37 @@
+# M3: Bundled Python Winddown
+
+Eliminate all executable Python from `amplifier-bundle/tools/`, making
+the amplihack installation fully independent of a Python runtime.
+
+## Definition of Done
+
+- [ ] `session_tree.py` ported to Rust (module in `amplihack-cli` or
+      standalone binary)
+- [ ] Session tree state format (`/tmp/amplihack-session-trees/*.json`)
+      remains compatible
+- [ ] Memory discovery adapter migrated to Rust SQLite backend
+- [ ] Memory graph-DB adapter migrated or removed
+- [ ] All `amplifier-bundle/tools/*.py` files deleted or converted to
+      non-executable assets
+- [ ] `amplihack doctor` probe AC9 (validate-no-python) updated to scan
+      new module paths
+- [ ] `amplihack install` no longer checks for or requires Python
+- [ ] CI pipeline drops Python from build matrix
+- [ ] Integration tests confirm full operation without Python on PATH
+- [ ] Migration guide updated with winddown completion notice
+
+## Deliverables
+
+| Deliverable | Location | Type |
+|---|---|---|
+| Rust session tree | `crates/amplihack-cli/src/commands/session_tree/` | Code |
+| Memory adapter completion | `crates/amplihack-memory/` | Code |
+| Python file removal | `amplifier-bundle/tools/*.py` | Deletion |
+| AC9 probe update | `crates/amplihack-cli/src/commands/doctor/` | Code |
+| Retirement direction doc | `docs/concepts/amplihack-retirement-direction.md` | Documentation |
+
+## Dependencies
+
+- **Blocked on M2** — Recipe runner must be fully Rust before removing
+  Python runner.
+- Session tree port can proceed in parallel with M2.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,5 +373,3 @@ Use CONSENSUS_WORKFLOW for: ambiguous requirements, architectural changes, criti
 Use `/amplihack:customize` to view or modify (`set`, `show`, `reset`, `learn`).
 
 <!-- AMPLIHACK_CONTEXT_END -->
-
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplihack"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-core"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-memory",
  "async-trait",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-eval"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "serde",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-generator"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "serde",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-asset-resolver-bin"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-cli",
  "tracing",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-blarify"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-hive",
  "amplihack-state",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-context"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-delegation"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "globset",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-domain-agents"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-fleet"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hive"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-cli",
  "amplihack-security",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-launcher"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-memory"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "md-5",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-multilspy"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recipe"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recovery"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-remote"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-safety"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-security"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "once_cell",
  "regex",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-utils"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "libc",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-workflows"
-version = "0.7.33"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.33"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -718,23 +718,90 @@ steps:
       **Documentation:** {{final_documentation}}
       **Tests (must pass):** {{test_spec}}
 
-      Implement the solution following the design:
+      Implement the solution following the design.
 
-      **Rules:**
-      1. Follow the design closely
-      2. Make failing tests pass iteratively
-      3. NO stubs, TODOs, or placeholder code
-      4. NO swallowed exceptions
-      5. NO faked APIs or data
-      6. Clear error messages
-      7. Appropriate logging
+      **Rules (in order of authority):**
+      0. **The user's task description is authoritative.** If the existing code already
+         appears to satisfy the requirements, that is a SIGNAL THAT YOU MISREAD THE
+         TASK — re-read it more carefully and apply the requested change anyway. Do
+         NOT exit without modifying files unless the task is provably impossible
+         (e.g., contradicts laws of physics, references nonexistent platforms). A
+         "no-op" outcome must be explicitly justified in the output.
+      1. You MUST modify or create at least one file unless rule 0's "provably
+         impossible" exception applies. Reading code is not implementing.
+      2. Follow the design closely.
+      3. Make failing tests pass iteratively.
+      4. NO stubs, TODOs, or placeholder code.
+      5. NO swallowed exceptions.
+      6. NO faked APIs or data.
+      7. Clear error messages.
+      8. Appropriate logging.
 
-      **Output:**
-      - Complete implementation code (all files)
-      - File headers: `# File: path/to/file.py`
-      - Brief explanation of key decisions
-      - Any deviations from design (with justification)
+      **Self-verification before declaring done:**
+      - Run `git status` and `git diff --stat` in your working directory.
+      - If the diff is empty, you have NOT implemented anything. Re-read the task
+        and try again. Do not produce a final output until you have either (a)
+        written changes that show in `git diff`, or (b) determined the task is
+        provably impossible per rule 0.
+
+      **Output (structured — all sections required):**
+      - `Files modified:` — newline-separated list of paths you created or edited.
+        If empty, you must include a `No-op justification:` section explaining why
+        rule 0's "provably impossible" exception applies. Empty list with no
+        justification = workflow failure.
+      - `Diff summary:` — one line per file describing the change.
+      - Complete implementation code (all files), with `# File: path/to/file.py`
+        headers.
+      - Brief explanation of key decisions.
+      - Any deviations from design (with justification).
     output: "implementation"
+
+  - id: "step-08c-implementation-no-op-guard"
+    type: "bash"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    # Hard-fail early (before checkpoint, refactor, review) if step-08 declared
+    # success but reported zero file edits. This catches prompt-misalignment
+    # (issue #251 / amplihack-rs #251) closer to the root cause than the
+    # commit-stage hollow-success guard at step-15.
+    command: |
+      set -euo pipefail
+      IMPL="${IMPLEMENTATION:-}"
+      if [ -z "$IMPL" ]; then
+        echo "ERROR: step-08-implement produced no output." >&2
+        exit 1
+      fi
+      # Look for the structured "Files modified:" line.
+      FILES_LINE=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*Files modified:' || true)
+      JUSTIFICATION=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*No-op justification:' || true)
+      if [ -z "$FILES_LINE" ]; then
+        echo "WARNING: step-08-implement output is missing the required" >&2
+        echo "'Files modified:' section. The agent did not follow the structured" >&2
+        echo "output schema. Check the implementer prompt and output." >&2
+        # Soft-warn rather than hard-fail to remain backward-compatible with
+        # agents that ignore the schema. The git-diff guard below is the hard gate.
+      fi
+      # Check git diff in the worktree as the source of truth.
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$PWD}"
+      if ! git diff --quiet || ! git diff --cached --quiet || \
+         [ -n "$(git ls-files --others --exclude-standard)" ]; then
+        echo "step-08 produced file changes — guard passed."
+        exit 0
+      fi
+      if [ -n "$JUSTIFICATION" ]; then
+        echo "step-08 produced no file changes but declared a no-op justification:" >&2
+        echo "$JUSTIFICATION" >&2
+        echo "Allowing workflow to continue under rule 0 exception." >&2
+        exit 0
+      fi
+      echo "ERROR: step-08-implement claimed success but produced ZERO file changes" >&2
+      echo "and no 'No-op justification:' was provided. This is a hollow-success" >&2
+      echo "condition, almost certainly caused by prompt-misalignment — see" >&2
+      echo "https://github.com/rysweet/amplihack-rs/issues/251." >&2
+      echo "" >&2
+      echo "Working directory: $PWD" >&2
+      git --no-pager status >&2
+      exit 1
+    output: "implementation_noop_guard"
 
   - id: "step-08b-integration"
     agent: "amplihack:integration"

--- a/amplifier-bundle/skills/qa-team/examples/electron/multi-window-coordination.yaml
+++ b/amplifier-bundle/skills/qa-team/examples/electron/multi-window-coordination.yaml
@@ -215,7 +215,7 @@ scenario:
     # Test Case 10: Verify Other Windows Unaffected
     - action: window_action
       window: 1
-      action: focus
+      sub_action: focus
 
     - action: verify_element
       selector: ".chat-active"

--- a/crates/amplihack-cli/src/commands/launch/tests_command.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_command.rs
@@ -355,6 +355,52 @@ fn copilot_skips_allow_all_when_env_opt_out() {
     });
 }
 
+/// Copilot is NOT Claude-compatible, so even when skip_permissions=true the
+/// `--dangerously-skip-permissions` flag MUST NOT appear.  This locks the
+/// `is_claude_compatible` whitelist against accidental expansion.
+#[test]
+fn copilot_does_not_get_skip_permissions_even_when_requested() {
+    with_uvx_detection_disabled(|| {
+        let binary = BinaryInfo {
+            name: "copilot".to_string(),
+            path: PathBuf::from("/usr/bin/copilot"),
+            version: None,
+        };
+        let cmd = build_command(&binary, false, false, true, &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            !args.iter().any(|a| a == "--dangerously-skip-permissions"),
+            "copilot must never receive --dangerously-skip-permissions, \
+             even when skip_permissions=true; got {args:?}"
+        );
+    });
+}
+
+/// Same invariant as copilot: Codex is NOT Claude-compatible.
+#[test]
+fn codex_does_not_get_skip_permissions_even_when_requested() {
+    with_uvx_detection_disabled(|| {
+        let binary = BinaryInfo {
+            name: "codex".to_string(),
+            path: PathBuf::from("/usr/bin/codex"),
+            version: None,
+        };
+        let cmd = build_command(&binary, false, false, true, &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            !args.iter().any(|a| a == "--dangerously-skip-permissions"),
+            "codex must never receive --dangerously-skip-permissions, \
+             even when skip_permissions=true; got {args:?}"
+        );
+    });
+}
+
 #[test]
 fn claude_does_not_get_allow_all_injected() {
     with_uvx_detection_disabled(|| {

--- a/crates/amplihack-recipe/src/condition_eval.rs
+++ b/crates/amplihack-recipe/src/condition_eval.rs
@@ -124,13 +124,16 @@ impl Value {
         }
     }
 
-    fn as_str(&self) -> String {
+    /// Returns a borrowed string representation when possible, or an owned
+    /// `Cow` for non-string variants. Avoids heap allocation for the common
+    /// `Value::Str` case (equality checks, containment tests).
+    fn as_str(&self) -> std::borrow::Cow<'_, str> {
         match self {
-            Value::Str(s) => s.clone(),
-            Value::Int(n) => n.to_string(),
-            Value::Bool(b) => b.to_string(),
-            Value::List(_) => "<list>".to_string(),
-            Value::None => String::new(),
+            Value::Str(s) => std::borrow::Cow::Borrowed(s),
+            Value::Int(n) => std::borrow::Cow::Owned(n.to_string()),
+            Value::Bool(b) => std::borrow::Cow::Owned(b.to_string()),
+            Value::List(_) => std::borrow::Cow::Borrowed("<list>"),
+            Value::None => std::borrow::Cow::Borrowed(""),
         }
     }
 
@@ -138,9 +141,12 @@ impl Value {
         match self {
             Value::Str(haystack) => {
                 let needle_str = needle.as_str();
-                haystack.contains(&needle_str)
+                haystack.contains(&*needle_str)
             }
-            Value::List(items) => items.iter().any(|item| item.as_str() == needle.as_str()),
+            Value::List(items) => {
+                let needle_str = needle.as_str();
+                items.iter().any(|item| item.as_str() == needle_str)
+            }
             _ => false,
         }
     }
@@ -177,12 +183,14 @@ enum Token {
 
 fn tokenize(input: &str) -> Result<Vec<Token>, ConditionError> {
     let mut tokens = Vec::new();
-    let chars: Vec<char> = input.chars().collect();
-    let len = chars.len();
+    // Work directly on byte slices — all grammar tokens are ASCII, so byte
+    // indexing is safe and avoids the heap allocation of `chars().collect()`.
+    let bytes = input.as_bytes();
+    let len = bytes.len();
     let mut i = 0;
 
     while i < len {
-        let ch = chars[i];
+        let ch = bytes[i];
 
         if ch.is_ascii_whitespace() {
             i += 1;
@@ -191,24 +199,23 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ConditionError> {
 
         // Two-character operators
         if i + 1 < len {
-            let two = &input[i..i + 2];
-            match two {
-                "==" => {
+            match (ch, bytes[i + 1]) {
+                (b'=', b'=') => {
                     tokens.push(Token::Eq);
                     i += 2;
                     continue;
                 }
-                "!=" => {
+                (b'!', b'=') => {
                     tokens.push(Token::Ne);
                     i += 2;
                     continue;
                 }
-                ">=" => {
+                (b'>', b'=') => {
                     tokens.push(Token::Ge);
                     i += 2;
                     continue;
                 }
-                "<=" => {
+                (b'<', b'=') => {
                     tokens.push(Token::Le);
                     i += 2;
                     continue;
@@ -218,42 +225,42 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ConditionError> {
         }
 
         match ch {
-            '>' => {
+            b'>' => {
                 tokens.push(Token::Gt);
                 i += 1;
                 continue;
             }
-            '<' => {
+            b'<' => {
                 tokens.push(Token::Lt);
                 i += 1;
                 continue;
             }
-            '(' => {
+            b'(' => {
                 tokens.push(Token::LParen);
                 i += 1;
                 continue;
             }
-            ')' => {
+            b')' => {
                 tokens.push(Token::RParen);
                 i += 1;
                 continue;
             }
-            '[' => {
+            b'[' => {
                 tokens.push(Token::LBracket);
                 i += 1;
                 continue;
             }
-            ']' => {
+            b']' => {
                 tokens.push(Token::RBracket);
                 i += 1;
                 continue;
             }
-            ',' => {
+            b',' => {
                 tokens.push(Token::Comma);
                 i += 1;
                 continue;
             }
-            '.' => {
+            b'.' => {
                 tokens.push(Token::Dot);
                 i += 1;
                 continue;
@@ -262,11 +269,13 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ConditionError> {
         }
 
         // String literals
-        if ch == '\'' || ch == '"' {
+        if ch == b'\'' || ch == b'"' {
             let quote = ch;
             i += 1;
             let start = i;
-            while i < len && chars[i] != quote {
+            while i < len && bytes[i] != quote {
+                // Non-ASCII bytes inside string literals are fine — we just
+                // scan for the closing quote byte, which is always ASCII.
                 i += 1;
             }
             if i >= len {
@@ -274,7 +283,10 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ConditionError> {
                     "unterminated string literal starting at position {start}"
                 )));
             }
-            let s: String = chars[start..i].iter().collect();
+            // SAFETY: `start..i` boundaries were advanced byte-by-byte from
+            // a valid UTF-8 `&str` and the quote byte is ASCII, so the
+            // interior slice is valid UTF-8.
+            let s = input[start..i].to_string();
             tokens.push(Token::Str(s));
             i += 1;
             continue;
@@ -283,10 +295,10 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ConditionError> {
         // Numbers
         if ch.is_ascii_digit() {
             let start = i;
-            while i < len && chars[i].is_ascii_digit() {
+            while i < len && bytes[i].is_ascii_digit() {
                 i += 1;
             }
-            let num_str: String = chars[start..i].iter().collect();
+            let num_str = &input[start..i];
             let n: i64 = num_str
                 .parse()
                 .map_err(|_| ConditionError::Parse(format!("invalid integer: {num_str}")))?;
@@ -295,20 +307,20 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ConditionError> {
         }
 
         // Identifiers and keywords
-        if ch.is_ascii_alphanumeric() || ch == '_' {
+        if ch.is_ascii_alphanumeric() || ch == b'_' {
             let start = i;
-            while i < len && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+            while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
                 i += 1;
             }
-            let word: String = chars[start..i].iter().collect();
-            let tok = match word.as_str() {
+            let word = &input[start..i];
+            let tok = match word {
                 "and" => Token::And,
                 "or" => Token::Or,
                 "not" => Token::Not,
                 "in" => Token::In,
                 "true" | "True" => Token::True,
                 "false" | "False" => Token::False,
-                _ => Token::Ident(word),
+                _ => Token::Ident(word.to_string()),
             };
             tokens.push(tok);
             continue;
@@ -317,7 +329,8 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ConditionError> {
         // Special: &amp; in YAML gets decoded to & — handle & in identifiers
         // like 'Q&A' which appear as string literals, not bare identifiers.
         return Err(ConditionError::Parse(format!(
-            "unexpected character: '{ch}' at position {i}"
+            "unexpected character: '{}' at position {i}",
+            ch as char
         )));
     }
 

--- a/crates/amplihack-recipe/src/executor.rs
+++ b/crates/amplihack-recipe/src/executor.rs
@@ -490,16 +490,26 @@ impl<A: AgentBackend> RecipeExecutor<A> {
 
         // Augment context with working directory and non-interactive flag so
         // the agent knows where to read/write files (fix #251).
-        let mut augmented = context.clone();
-        augmented
-            .entry("working_directory".to_string())
-            .or_insert_with(|| self.config.working_dir.clone());
-        augmented
-            .entry("NONINTERACTIVE".to_string())
-            .or_insert_with(|| "1".to_string());
-
-        self.agent_backend
-            .run_agent(agent_ref, &expanded, &augmented)
+        // Only clone when we actually need to insert missing keys to avoid
+        // a full HashMap clone on every agent step.
+        let needs_wd = !context.contains_key("working_directory");
+        let needs_ni = !context.contains_key("NONINTERACTIVE");
+        if needs_wd || needs_ni {
+            let mut augmented = context.clone();
+            if needs_wd {
+                augmented.insert(
+                    "working_directory".to_string(),
+                    self.config.working_dir.clone(),
+                );
+            }
+            if needs_ni {
+                augmented.insert("NONINTERACTIVE".to_string(), "1".to_string());
+            }
+            self.agent_backend
+                .run_agent(agent_ref, &expanded, &augmented)
+        } else {
+            self.agent_backend.run_agent(agent_ref, &expanded, context)
+        }
     }
 
     fn execute_sub_recipe_step(

--- a/crates/amplihack-utils/src/knowledge_builder.rs
+++ b/crates/amplihack-utils/src/knowledge_builder.rs
@@ -195,9 +195,9 @@ where
 
     /// Execute the complete Socratic knowledge-building workflow.
     ///
-    /// 1. Generate questions  
-    /// 2. Answer questions  
-    /// 3. Generate artefacts  
+    /// 1. Generate questions
+    /// 2. Answer questions
+    /// 3. Generate artefacts
     ///
     /// Returns the output directory on success.
     ///

--- a/docs/concepts/agentic-step-patterns.md
+++ b/docs/concepts/agentic-step-patterns.md
@@ -1,0 +1,181 @@
+# Agentic Step Patterns
+
+When to use `bash`, `agent`, and `recipe` step types in YAML recipes,
+and how to write effective agent prompts.
+
+## Contents
+
+- [Decision rule](#decision-rule)
+- [Step types](#step-types)
+- [When to use each type](#when-to-use-each-type)
+- [Prompt writing guide](#prompt-writing-guide)
+- [Anti-patterns](#anti-patterns)
+- [Example recipe sequence](#example-recipe-sequence)
+
+---
+
+## Decision rule
+
+**Default to `agent` steps.** Use `bash` only for deterministic operations
+(git commands, file checks, API calls with known output). Use `recipe` to
+compose larger workflows from smaller ones.
+
+The reasoning: agent steps handle ambiguity, adapt to unexpected input, and
+produce richer output. Bash steps are brittle when the output format or
+error conditions vary.
+
+## Step types
+
+| Type | Executor | Output | Timeout default |
+|---|---|---|---|
+| `bash` | Shell subprocess | stdout captured to `output` key | 120s |
+| `agent` | Claude/Copilot session | Full response captured to `output` key | `default_step_timeout` (recipe-level) |
+| `recipe` | Nested recipe-runner-rs invocation | Final context from sub-recipe | Inherits from sub-recipe |
+
+## When to use each type
+
+### `bash` — Deterministic, verifiable operations
+
+Use when:
+- Running `git` commands (branch, commit, push, status)
+- Checking file existence or reading structured output
+- Calling APIs with predictable JSON responses (`gh issue view`)
+- Setting up environment (mkdir, export, install)
+
+```yaml
+- id: "create-branch"
+  type: "bash"
+  command: |
+    cd "$REPO_PATH"
+    git checkout -b "feat/$BRANCH_NAME" 2>/dev/null || git checkout "feat/$BRANCH_NAME"
+  output: "branch_result"
+```
+
+### `agent` — Reasoning, analysis, generation
+
+Use when:
+- Analyzing requirements or code
+- Generating code, tests, or documentation
+- Making design decisions
+- Evaluating quality or correctness
+- Anything requiring natural language understanding
+
+```yaml
+- id: "design-solution"
+  type: "agent"
+  timeout_seconds: 300
+  prompt: |
+    Design an implementation for the following requirement.
+
+    **Task**: {{task_description}}
+    **Requirements**: {{final_requirements}}
+    **Constraints**: Rust codebase, must maintain backward compatibility.
+
+    Output a concrete file-by-file implementation plan.
+  output: "design"
+```
+
+### `recipe` — Workflow composition
+
+Use when:
+- A step is itself a multi-step workflow (e.g., running `default-workflow`
+  from within `smart-orchestrator`)
+- Reusing an existing recipe as a building block
+- Isolating a complex sub-task with its own context
+
+```yaml
+- id: "run-default-workflow"
+  type: "recipe"
+  recipe: "default-workflow"
+  context:
+    task_description: "{{task_description}}"
+    repo_path: "{{repo_path}}"
+```
+
+## Prompt writing guide
+
+Agent steps live or die by their prompts. Follow these rules:
+
+### 1. State the goal, not the process
+
+```yaml
+# Good: what to achieve
+prompt: "Identify all public functions in {{file_path}} that lack test coverage."
+
+# Bad: how to do it
+prompt: "Read the file, then grep for fn, then check if tests exist..."
+```
+
+### 2. Provide full context via interpolation
+
+Every `{{variable}}` referenced must be a context key populated by a prior
+step. Never assume the agent remembers prior steps — each agent session
+starts fresh.
+
+### 3. Specify output format when downstream steps parse it
+
+```yaml
+prompt: |
+    Classify this task.
+    Respond with EXACTLY one line: `Development` or `Investigation` or `Q&A`.
+output: "task_type"
+```
+
+### 4. Set appropriate timeouts
+
+Agent steps that spawn full Claude sessions can exceed the default timeout.
+The `smart-orchestrator.yaml` sets `default_step_timeout: 300` (5 minutes)
+for this reason.
+
+## Anti-patterns
+
+| Anti-pattern | Problem | Fix |
+|---|---|---|
+| Bash step that parses natural language | Fragile regex on free-form text | Use an agent step |
+| Agent step for `git checkout` | Wastes tokens on deterministic work | Use a bash step |
+| Agent prompt without context vars | Agent has no information to work with | Interpolate `{{variables}}` |
+| Nested recipe without forwarding context | Sub-recipe runs with empty context | Pass required context explicitly |
+| No timeout on agent step | Hangs indefinitely on slow sessions | Set `timeout_seconds` |
+
+## Example recipe sequence
+
+From `default-workflow.yaml`, a typical sequence mixing all three types:
+
+```yaml
+steps:
+  # 1. Bash: create GitHub issue (deterministic API call)
+  - id: "create-issue"
+    type: "bash"
+    command: "gh issue create --title '...' --body '...'"
+    output: "issue_url"
+
+  # 2. Agent: design the solution (reasoning required)
+  - id: "design"
+    type: "agent"
+    prompt: "Design implementation for: {{task_description}}"
+    output: "design_spec"
+
+  # 3. Agent: implement the code (generation required)
+  - id: "implement"
+    type: "agent"
+    prompt: "Implement the design: {{design_spec}}"
+    output: "implementation"
+
+  # 4. Bash: run tests (deterministic command)
+  - id: "test"
+    type: "bash"
+    command: "cargo test 2>&1"
+    output: "test_results"
+
+  # 5. Agent: evaluate results (judgment required)
+  - id: "review"
+    type: "agent"
+    prompt: "Review test results: {{test_results}}"
+    output: "review"
+```
+
+## Related
+
+- [Recipe Execution Flow](./recipe-execution-flow.md) — How the runner processes steps
+- [amplihack recipe](../reference/recipe-command.md) — CLI reference for recipe commands
+- [Recipe Runner Architecture](./recipe-runner-architecture.md) — Why the runner is external

--- a/docs/concepts/amplihack-retirement-direction.md
+++ b/docs/concepts/amplihack-retirement-direction.md
@@ -1,0 +1,109 @@
+# amplihack Python Retirement Direction
+
+The strategic direction for migrating bundled Python components to Rust,
+eliminating the Python runtime dependency.
+
+## Contents
+
+- [Migration status](#migration-status)
+- [What moves where](#what-moves-where)
+- [Compatibility guarantees](#compatibility-guarantees)
+- [Milestones](#milestones)
+
+---
+
+## Migration status
+
+| Component | Python location | Rust status | Notes |
+|---|---|---|---|
+| CLI entry point | `amplifier-bundle/amplihack` | ✅ Complete | `amplihack-cli` crate |
+| Install/uninstall | `amplifier-bundle/tools/installer.py` | ✅ Complete | `commands/install/` |
+| Hook registration | `amplifier-bundle/tools/hooks.py` | ✅ Complete | `commands/install/hooks.rs` |
+| Binary resolution | `amplifier-bundle/tools/binary_finder.py` | ✅ Complete | `binary_finder.rs` |
+| Recipe runner | `amplifier-bundle/tools/recipe_runner.py` | ⚠️ Partial | `recipe-runner-rs` (separate repo) |
+| Session tree | `amplifier-bundle/tools/session_tree.py` | ❌ Not started | Still Python-only |
+| Memory/discoveries | `amplifier-bundle/tools/memory/` | ⚠️ Partial | SQLite backend in Rust, graph DB pending |
+| Code graph (SCIP) | `amplifier-bundle/tools/blarify/` | ✅ Complete | LadybugDB via `amplihack-memory` crate |
+| Fleet dashboard | N/A | ✅ Native Rust | No Python predecessor |
+| Agent framework | N/A | ✅ Native Rust | `amplihack-agent-*` crates |
+
+**Legend**: ✅ = Rust implementation is production-ready. ⚠️ = Partial
+migration, both implementations coexist. ❌ = Not started.
+
+## What moves where
+
+### Stays in `amplifier-bundle/` (non-code assets)
+
+These are configuration and content files, not executable code:
+
+- YAML recipes (`recipes/*.yaml`)
+- Agent definitions (`agents/amplihack/*.md`)
+- Skill definitions (`skills/`)
+- Context files (`context/*.md`)
+- Templates (`templates/`)
+
+### Moves to Rust crates
+
+- **Recipe execution** → `recipe-runner-rs` (external binary)
+- **Session tree management** → proposed: new module in `amplihack-cli`
+- **Memory adapters** → `amplihack-memory` crate (in progress)
+
+### Deleted when migration completes
+
+- `amplifier-bundle/tools/recipe_runner.py` — replaced by `recipe-runner-rs`
+- `amplifier-bundle/tools/session_tree.py` — replaced by Rust module
+- `amplifier-bundle/tools/binary_finder.py` — already replaced
+- Python `__pycache__` directories and `.pyc` files
+
+## Compatibility guarantees
+
+1. **Recipe YAML format is stable.** Recipes written for the Python runner
+   must work with the Rust runner without modification.
+
+2. **Context variable names are stable.** Steps reference variables like
+   `{{task_description}}` — these names cannot change.
+
+3. **CLI interface is stable.** `amplihack recipe run <name> --context k=v`
+   works identically regardless of which runner executes it.
+
+4. **Environment variables are stable.** All `AMPLIHACK_*` env vars
+   documented in the [Environment Variables](../reference/environment-variables.md)
+   reference retain their semantics.
+
+## Milestones
+
+### M1: Orchestrator Stability
+
+Stabilize the smart-orchestrator and default-workflow recipes. No Python
+migration work — purely recipe-level fixes.
+
+- Issue dedup guards in smart-orchestrator
+- Adaptive recovery hardening
+- Hollow-success detection tuning
+
+### M2: Recipe Runner Consolidation
+
+Achieve full feature parity in `recipe-runner-rs` and remove the Python
+fallback.
+
+- Port remaining step types
+- Validate all recipes against Rust runner
+- Remove `recipe_runner.py`
+
+### M3: Bundled Python Winddown
+
+Eliminate all executable Python from `amplifier-bundle/tools/`.
+
+- Port `session_tree.py` to Rust
+- Complete memory adapter migration
+- Remove Python runtime requirement from install
+- Update `validate-no-python` probe (AC9) to cover new modules
+- Blocked on: M2 completion
+
+See the [.pm/ milestone files](../../.pm/) for detailed acceptance criteria.
+
+## Related
+
+- [Recipe Runner Architecture](./recipe-runner-architecture.md) — Why the runner is external
+- [Migrate from Python](../howto/migrate-from-python.md) — User-facing migration guide
+- [Bootstrap Parity](./bootstrap-parity.md) — Why Rust replicates the Python install flow

--- a/docs/concepts/recipe-runner-architecture.md
+++ b/docs/concepts/recipe-runner-architecture.md
@@ -1,0 +1,129 @@
+# Recipe Runner Architecture
+
+Why the recipe runner is an external binary, how amplihack-rs locates and
+invokes it, and what the consolidation plan means for the codebase.
+
+## Contents
+
+- [Why external](#why-external)
+- [Binary resolution](#binary-resolution)
+- [Invocation contract](#invocation-contract)
+- [Data flow](#data-flow)
+- [What amplihack-rs does NOT do](#what-amplihack-rs-does-not-do)
+- [The Python runner: why it still exists](#the-python-runner-why-it-still-exists)
+- [Consolidation direction](#consolidation-direction)
+
+---
+
+## Why external
+
+The recipe runner (`recipe-runner-rs`) is a separate Rust binary maintained
+in its own repository (`rysweet/amplihack-recipe-runner`). This separation
+exists because:
+
+1. **Independent release cadence** — Recipe execution semantics change more
+   frequently than CLI behavior.
+2. **Build isolation** — The runner has different dependencies (YAML parsing,
+   step execution, agent spawning) that would bloat the CLI.
+3. **Replaceability** — The CLI treats the runner as a black box behind a
+   stable CLI interface.
+
+## Binary resolution
+
+amplihack-rs resolves the runner binary at launch time using `freshness.rs`:
+
+```
+$PATH lookup for `recipe-runner-rs`
+       │
+       ├── found → check freshness against GitHub HEAD
+       │              │
+       │              ├── up-to-date → use it
+       │              └── stale → `cargo install --git` to upgrade
+       │
+       └── not found → `cargo install --git` to install
+```
+
+The freshness check compares the locally installed commit SHA against the
+remote `main` branch HEAD, throttled by a cooldown file at
+`~/.amplihack/state/recipe_runner.json`.
+
+Source: `crates/amplihack-cli/src/freshness.rs`, lines 108–176.
+
+## Invocation contract
+
+amplihack-rs invokes the runner as a subprocess:
+
+```
+amplihack recipe run <recipe-name> \
+    --context key1=value1 \
+    --context key2=value2
+```
+
+The runner:
+1. Resolves the recipe YAML from the search path
+2. Validates schema and step dependencies
+3. Executes steps sequentially, threading context variables between them
+4. Returns exit code 0 on success, 1 on failure
+
+## Data flow
+
+```
+┌─────────────┐     CLI args      ┌──────────────────┐
+│ amplihack   │──────────────────▶│ recipe-runner-rs  │
+│ (CLI)       │                   │ (external binary) │
+└─────────────┘                   └──────────────────┘
+                                         │
+                              ┌──────────┼──────────┐
+                              ▼          ▼          ▼
+                         ┌────────┐ ┌────────┐ ┌────────┐
+                         │ bash   │ │ agent  │ │ recipe │
+                         │ step   │ │ step   │ │ step   │
+                         └────────┘ └────────┘ └────────┘
+```
+
+Context variables flow forward: each step's `output` key becomes available
+to subsequent steps via `{{variable_name}}` interpolation.
+
+## What amplihack-rs does NOT do
+
+- **Does not parse recipes** — YAML parsing is the runner's responsibility.
+- **Does not execute steps** — Step dispatch (bash/agent/recipe) is handled
+  by the runner.
+- **Does not manage step state** — Context threading, condition evaluation,
+  and output capture are runner internals.
+- **Does not embed the runner** — There is no compiled-in recipe execution
+  engine.
+
+amplihack-rs is responsible for: binary resolution, freshness checks,
+argument forwarding, and exit code propagation.
+
+## The Python runner: why it still exists
+
+A Python-based recipe runner (`amplifier-bundle/tools/recipe_runner.py`)
+predates the Rust implementation. Both runners coexist because:
+
+- **Legacy recipes** may depend on Python-specific behavior not yet ported.
+- **The `amplifier-bundle`** still ships Python utilities that some recipes
+  reference.
+- **Migration is incomplete** — Not all step types have Rust equivalents.
+
+The Rust runner is the default for new recipes. The Python runner is a
+fallback, not a parallel production system.
+
+## Consolidation direction
+
+The goal is a single Rust recipe runner. Consolidation requires:
+
+1. **Porting remaining step types** from Python to Rust
+2. **Removing Python-specific recipe shims** in `amplifier-bundle/tools/`
+3. **Validating all recipes** against the Rust runner exclusively
+4. **Deleting the Python runner** once no recipe depends on it
+
+See [amplihack Retirement Direction](./amplihack-retirement-direction.md)
+for the broader Python winddown timeline.
+
+## Related
+
+- [amplihack recipe](../reference/recipe-command.md) — CLI reference for the `recipe` subcommand
+- [Recipe Execution Flow](./recipe-execution-flow.md) — Step-by-step execution semantics
+- [Recipe Executor Environment](../reference/recipe-executor-environment.md) — Environment variables for recipe steps

--- a/docs/concepts/smart-orchestrator-recovery.md
+++ b/docs/concepts/smart-orchestrator-recovery.md
@@ -1,0 +1,146 @@
+# Smart-Orchestrator Recovery
+
+How the smart-orchestrator detects failures, recovers via adaptive
+strategies, and avoids false positives through hollow-success detection.
+
+## Contents
+
+- [Failure taxonomy](#failure-taxonomy)
+- [Recovery pipeline](#recovery-pipeline)
+- [Hollow-success detection](#hollow-success-detection)
+- [Issue dedup integration](#issue-dedup-integration)
+- [Recursion guard](#recursion-guard)
+- [Goal status values](#goal-status-values)
+
+---
+
+## Failure taxonomy
+
+The smart-orchestrator (`smart-orchestrator.yaml`) encounters seven failure
+modes during execution:
+
+| Mode | Cause | Detection |
+|---|---|---|
+| **Routing gap** | All execution conditions evaluate to false | `round_1_result` is empty after all execution steps |
+| **Agent timeout** | Claude/Copilot session exceeds `timeout_seconds` | Runner kills subprocess, step returns error |
+| **Bash failure** | Shell step exits non-zero | `set -euo pipefail` propagates to runner |
+| **Recipe failure** | Nested recipe returns exit code 1 | Runner captures sub-recipe exit |
+| **Hollow success** | Agent completes but produces no real work | Reflection step detects empty artifacts |
+| **Recursion limit** | Session depth exceeds `AMPLIHACK_MAX_DEPTH` | Session tree blocks spawn |
+| **Infrastructure** | `gh` unavailable, auth expired, disk full | Various — often detected by bash guard steps |
+
+## Recovery pipeline
+
+Recovery proceeds through four stages, implemented across multiple recipe
+steps:
+
+### Stage 1: Detect execution gap
+
+Step `detect-execution-gap` fires when the task type is Development or
+Investigation but `round_1_result` is empty:
+
+```yaml
+condition: |
+  ('Development' in task_type or 'Investigation' in task_type) and not round_1_result
+```
+
+This step:
+1. Logs a diagnostic banner to stderr
+2. Determines the appropriate fallback recipe (`default-workflow` or
+   `investigation-workflow`) based on task type
+3. Sets `adaptive_recipe` context variable
+
+### Stage 2: File infrastructure bug
+
+Step `file-routing-bug` runs when `adaptive_recipe` is non-empty. It:
+1. Assembles diagnostic context (task type, workstream count, environment)
+2. Attempts to create a GitHub issue labeled `bug`
+3. Falls back to writing a local diagnostic file if `gh` is unavailable
+
+```yaml
+condition: |
+  adaptive_recipe and adaptive_recipe != ''
+```
+
+### Stage 3: Execute adaptive strategy
+
+Two conditional steps attempt direct recipe invocation:
+
+- `adaptive-execute-development` → runs `default-workflow` recipe
+- `adaptive-execute-investigation` → runs `investigation-workflow` recipe
+
+These bypass the normal routing logic entirely, providing a last-resort
+execution path.
+
+### Stage 4: Reflect with context
+
+The reflection step (Phase 3 in the orchestrator) receives `adaptive_recipe`
+and `infra_error_details` as context. It factors the adaptive strategy into
+its goal evaluation, noting what failed and what recovery was applied.
+
+## Hollow-success detection
+
+The reflection step distinguishes real results from hollow successes. A
+result is hollow when **all three** conditions are true:
+
+1. The agent explicitly states it cannot access the codebase or files
+2. No concrete code changes, findings, or artifacts are described
+3. The output contains no file paths, diffs, test results, or code
+   references
+
+**The reflection step must NOT flag hollow when:**
+
+- Results are partial but real (use `PARTIAL` instead)
+- Some criteria are met but not others
+- The agent produced specific findings, even if brief
+- The task was investigative and concrete conclusions were reached
+
+This distinction prevents false infrastructure failures when agents produce
+legitimate but minimal output.
+
+## Issue dedup integration
+
+Currently, the `file-routing-bug` step creates issues with **no dedup
+guards**. Each routing failure files a new issue regardless of whether an
+identical one exists. This is the primary source of duplicate issue noise.
+
+The [Issue Deduplication](../reference/issue-dedup.md) reference documents
+both the existing `default-workflow` guards (which the smart-orchestrator
+lacks) and the proposed Rust-side fingerprint dedup that would cover both
+recipes.
+
+## Recursion guard
+
+The smart-orchestrator respects session tree limits to prevent infinite
+sub-orchestration:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AMPLIHACK_TREE_ID` | (auto) | Shared tree ID for the session |
+| `AMPLIHACK_SESSION_DEPTH` | `0` | Current nesting depth |
+| `AMPLIHACK_MAX_DEPTH` | `3` | Maximum allowed depth |
+| `AMPLIHACK_MAX_SESSIONS` | `10` | Maximum concurrent sessions |
+
+When depth reaches the limit, the orchestrator blocks sub-workstream
+spawning and falls back to single-session execution. Session state is
+tracked in `/tmp/amplihack-session-trees/{tree_id}.json`.
+
+## Goal status values
+
+The reflection step ends with exactly one status:
+
+| Status | Meaning | Next action |
+|---|---|---|
+| `ACHIEVED` | All criteria met with evidence | Proceed to summary |
+| `PARTIAL -- [what's missing]` | Some criteria met | Trigger round 2 |
+| `NOT_ACHIEVED -- [reason]` | No criteria met | Trigger round 2 |
+| `HOLLOW -- [what was empty]` | Agent ran but produced nothing | Flag infrastructure issue |
+
+The orchestrator runs up to 3 rounds (configurable) before accepting the
+best result.
+
+## Related
+
+- [Issue Deduplication](../reference/issue-dedup.md) — Dedup guards and proposed fingerprint system
+- [Recipe Execution Flow](./recipe-execution-flow.md) — Step-by-step execution semantics
+- [Recipe Runner Architecture](./recipe-runner-architecture.md) — External binary model

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,8 @@ amplihack-rs is the Rust implementation of the amplihack CLI. It replaces the Py
 - [amplihack recipe](./reference/recipe-command.md) — Full CLI reference for `recipe list`, `recipe show`, `recipe validate`, and `recipe run`
 - [Recipe Executor Environment](./reference/recipe-executor-environment.md) — Environment variables, prerequisite checks, and context propagation for recipe steps
 - [Workflow Classifier](./reference/workflow-classifier.md) — Keyword tables, classification algorithm, and constructive-verb disambiguation
+- [Issue Deduplication](./reference/issue-dedup.md) — Idempotency guards, dedup decision tree, and proposed fingerprint algorithm for avoiding duplicate GitHub issues
+- [Launch Flag Matrix](./reference/flag-matrix.md) — Per-tool capability matrix for `--dangerously-skip-permissions`, `--model`, `--allow-all`, and proposed type-safe refactoring
 - [Parity Test Scenarios](./reference/parity-test-scenarios.md) — Every parity tier file, its test cases, and expected Python↔Rust divergence
 - [amplihack index-code and index-scip](./reference/memory-index-command.md) — Full CLI reference for code-graph ingestion commands
 - [amplihack query-code](./reference/query-code-command.md) — Full CLI reference for querying the native LadybugDB code-graph
@@ -73,6 +75,10 @@ amplihack-rs is the Rust implementation of the amplihack CLI. It replaces the Py
 - [Evaluation Framework](./concepts/eval-framework.md) — Progressive L1–L12 evaluation, graders, and self-improvement
 - [Hive Orchestration](./concepts/hive-orchestration.md) — Multi-agent swarm deployment, events, and workload management
 - [Goal Agent Generator](./concepts/agent-generator.md) — Four-stage pipeline: analyze → plan → synthesize → assemble
+- [Recipe Runner Architecture](./concepts/recipe-runner-architecture.md) — Why the runner is an external binary, resolution logic, invocation contract, and Python coexistence
+- [Agentic Step Patterns](./concepts/agentic-step-patterns.md) — Decision rules for bash vs agent vs recipe step types, prompt writing guide, and anti-patterns
+- [Smart-Orchestrator Recovery](./concepts/smart-orchestrator-recovery.md) — Failure taxonomy, four-stage recovery pipeline, hollow-success detection, and goal status values
+- [amplihack Retirement Direction](./concepts/amplihack-retirement-direction.md) — Python-to-Rust migration status, compatibility guarantees, and milestone tracking
 
 ## Quick Start
 

--- a/docs/reference/flag-matrix.md
+++ b/docs/reference/flag-matrix.md
@@ -1,0 +1,158 @@
+# Launch Flag Matrix — Reference
+
+How `amplihack` builds the subprocess command line for each supported AI
+tool. Covers `--dangerously-skip-permissions`, `--model`, `--allow-all`,
+and extra-args passthrough.
+
+## Contents
+
+- [Current implementation](#current-implementation)
+- [Capability matrix](#capability-matrix)
+- [Flag injection rules](#flag-injection-rules)
+- [Proposed design: type-safe refactoring](#proposed-design-type-safe-refactoring)
+- [Related](#related)
+
+---
+
+## Current implementation
+
+Flag logic lives in `crates/amplihack-cli/src/commands/launch/command.rs`.
+The current approach uses ad-hoc string matching and standalone functions
+rather than a unified type system.
+
+### Tool identification
+
+Claude-compatible tools are identified by a `matches!` expression:
+
+```rust
+// command.rs, line 43
+let is_claude_compatible = matches!(
+    binary.name.as_str(),
+    "claude" | "rusty" | "rustyclawd" | "amplifier"
+);
+```
+
+### Copilot `--allow-all` injection
+
+A standalone function determines whether to inject `--allow-all` for
+Copilot:
+
+```rust
+// command.rs, line 87
+pub(crate) fn should_inject_copilot_allow_all(extra_args: &[String]) -> bool {
+    if std::env::var("AMPLIHACK_COPILOT_NO_ALLOW_ALL").as_deref() == Ok("1") {
+        return false;
+    }
+    let already_present = extra_args.iter().any(|a| {
+        a == "--allow-all"
+            || a == "--allow-all-tools"
+            || a == "--allow-all-paths"
+            || a == "--allow-all-urls"
+    });
+    !already_present
+}
+```
+
+## Capability matrix
+
+Current behavior, derived from `command.rs`:
+
+| Flag | claude | rusty | rustyclawd | amplifier | copilot | codex |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| `--dangerously-skip-permissions` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `--model` (auto-inject) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `--allow-all` (auto-inject) | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| `--resume` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `--continue` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `--plugin-dir` (UVX only) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `--add-dir` (UVX only) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Extra args passthrough | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+### Override environment variables
+
+| Variable | Effect |
+|---|---|
+| `AMPLIHACK_DEFAULT_MODEL` | Override the default model (default: `opus[1m]`) |
+| `AMPLIHACK_COPILOT_NO_ALLOW_ALL` | Set to `1` to suppress `--allow-all` injection for Copilot |
+
+## Flag injection rules
+
+1. **`--dangerously-skip-permissions`**: Injected only when the user passes
+   `--skip-permissions` AND the tool is Claude-compatible. Never injected
+   by default (SEC-2).
+
+2. **`--model`**: Injected for Claude-compatible tools unless the user
+   already supplied `--model` in extra args. Defaults to `opus[1m]` or
+   the value of `AMPLIHACK_DEFAULT_MODEL`.
+
+3. **`--allow-all`**: Injected only for `copilot` unless suppressed by env
+   var or the user already provided any `--allow-all*` flag.
+
+4. **UVX plugin args**: `--plugin-dir` and `--add-dir` are injected only
+   for `claude` when running in a UVX deployment.
+
+5. **Extra args**: All remaining arguments are passed through unchanged,
+   appended after injected flags.
+
+## Proposed design: type-safe refactoring
+
+The following types are **design specifications for future implementation**.
+They do not exist in the current codebase.
+
+### `AgentBinary` enum
+
+```rust
+// Proposed — not yet implemented
+pub enum AgentBinary {
+    Claude,
+    Rusty,
+    RustyClawd,
+    Amplifier,
+    Copilot,
+    Codex,
+}
+
+impl AgentBinary {
+    pub fn from_name(name: &str) -> Option<Self> { /* ... */ }
+    pub fn is_claude_compatible(&self) -> bool { /* ... */ }
+    pub fn supports_flag(&self, flag: Flag) -> bool { /* ... */ }
+}
+```
+
+### `FlagSet` struct
+
+```rust
+// Proposed — not yet implemented
+pub struct FlagSet {
+    flags: Vec<Flag>,
+}
+
+impl FlagSet {
+    /// Build the correct flag set for a given binary + user options.
+    pub fn for_binary(binary: &AgentBinary, opts: &LaunchOpts) -> Self { /* ... */ }
+
+    /// Append flags to a Command.
+    pub fn apply(&self, cmd: &mut Command) { /* ... */ }
+}
+```
+
+The goal is to replace the scattered `if`/`matches!` logic with a single
+matrix lookup, making it impossible to add a new tool without specifying
+its full flag capabilities.
+
+### Test table (proposed)
+
+| Test case | Input | Expected flags |
+|---|---|---|
+| Claude default | `claude`, no extra args | `--model opus[1m]` |
+| Claude skip-perms | `claude`, `--skip-permissions` | `--dangerously-skip-permissions --model opus[1m]` |
+| Copilot default | `copilot`, no extra args | `--allow-all` |
+| Copilot suppressed | `copilot`, `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` | (no flags) |
+| Codex default | `codex`, no extra args | (no flags) |
+| User model override | `claude`, `--model sonnet` | `--model sonnet` (no duplicate) |
+
+## Related
+
+- [Launch Flag Injection](./launch-flag-injection.md) — Detailed reference for the existing injection logic
+- [Environment Variables](./environment-variables.md) — All env vars read by amplihack
+- [Agent Binary Routing](../concepts/agent-binary-routing.md) — How `AMPLIHACK_AGENT_BINARY` routes callbacks

--- a/docs/reference/issue-dedup.md
+++ b/docs/reference/issue-dedup.md
@@ -1,0 +1,155 @@
+# Issue Deduplication — Reference
+
+How amplihack recipes avoid creating duplicate GitHub issues when the same
+task runs more than once.
+
+## Contents
+
+- [Current implementation](#current-implementation)
+- [Guard 1: Reference extraction](#guard-1-reference-extraction)
+- [Guard 2: Title search](#guard-2-title-search)
+- [smart-orchestrator gap](#smart-orchestrator-gap)
+- [Proposed design: Rust-side dedup](#proposed-design-rust-side-dedup)
+- [Configuration](#configuration)
+
+---
+
+## Current implementation
+
+The `default-workflow.yaml` recipe (step `step-03-create-issue`) uses a
+two-guard idempotency pattern implemented entirely in Bash. Both guards
+run before any `gh issue create` call.
+
+```
+task_description
+       │
+       ▼
+┌──────────────┐    match    ┌──────────────┐   exists   ┌──────────┐
+│ Extract #NNN │───────────▶│ gh issue view │──────────▶│ Reuse    │
+│ from text    │            │ $REF_ISSUE    │           │ (exit 0) │
+└──────────────┘            └──────────────┘           └──────────┘
+       │ no match                   │ not found
+       ▼                            ▼
+┌──────────────┐    found    ┌──────────┐
+│ gh issue list│───────────▶│ Reuse    │
+│ --search     │            │ (exit 0) │
+└──────────────┘            └──────────┘
+       │ not found
+       ▼
+┌──────────────┐
+│ gh issue     │
+│ create       │
+└──────────────┘
+```
+
+## Guard 1: Reference extraction
+
+Extracts an issue number from the `task_description` context variable using
+a Bash regex match on `#([0-9]+)`.
+
+```bash
+# From default-workflow.yaml, step-03-create-issue
+if [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then
+    REF_ISSUE_NUM="${BASH_REMATCH[1]}"
+fi
+```
+
+If a number is extracted, the guard verifies the issue exists via
+`gh issue view "$REF_ISSUE_NUM"`. When the issue exists, its URL is printed
+and the step exits with code 0, skipping creation entirely.
+
+**Defense-in-depth**: A secondary check rejects non-numeric values before
+interpolating into the `gh` command.
+
+## Guard 2: Title search
+
+When Guard 1 does not match (no `#NNN` in the task description) or the
+referenced issue does not exist, Guard 2 searches open issues by title:
+
+```bash
+SEARCH_QUERY="${ISSUE_TITLE:0:100}"
+FOUND_URL=$(timeout 60 gh issue list --state open \
+    --search "$SEARCH_QUERY" --json url --jq '.[0].url // ""' 2>/dev/null || echo '')
+```
+
+This matches the first 100 characters of the issue title. If a matching
+open issue is found, its URL is reused.
+
+**Limitation**: Title search uses GitHub's search API, which is fuzzy.
+Unrelated issues with similar titles can cause false positives.
+
+## smart-orchestrator gap
+
+The `smart-orchestrator.yaml` recipe creates issues in its
+`file-routing-bug` step (line ~627) with **no dedup guards at all**:
+
+```bash
+ISSUE_URL=$(gh issue create \
+    --title "smart-orchestrator routing gap: ..." \
+    --body "$BODY" \
+    --label "bug" 2>/dev/null) || true
+```
+
+This is the primary source of duplicate issue noise. Each routing failure
+files a new issue regardless of whether an identical one already exists.
+
+## Proposed design: Rust-side dedup
+
+The following types are **design specifications for future implementation**,
+not existing code.
+
+### `IssueClient` trait
+
+```rust
+// Proposed — not yet implemented
+pub trait IssueClient: Send + Sync {
+    /// Search for an existing issue by content fingerprint.
+    fn find_by_fingerprint(&self, fingerprint: &str) -> Result<Option<IssueRef>>;
+
+    /// Add a comment to an existing issue instead of creating a new one.
+    fn add_comment(&self, issue: u64, body: &str) -> Result<()>;
+
+    /// Create a new issue. Returns the issue URL.
+    fn create(&self, title: &str, body: &str, labels: &[&str]) -> Result<String>;
+}
+```
+
+### Fingerprint algorithm
+
+The proposed fingerprint hashes the normalized issue title and the `bug`
+label to produce a deterministic key. Same-day duplicates append a comment;
+next-day duplicates create a rollup issue referencing the original.
+
+### `GhCliClient` and `MockIssueClient`
+
+- `GhCliClient`: Production implementation that shells out to `gh`.
+- `MockIssueClient`: Test double that records calls in a `Vec<Call>`.
+
+### Decision tree (proposed)
+
+| Condition | Action |
+|---|---|
+| Fingerprint matches open issue, same calendar day | Append comment |
+| Fingerprint matches open issue, different day | Create rollup referencing original |
+| No fingerprint match | Create new issue |
+
+## Configuration
+
+### Environment variables (existing)
+
+| Variable | Default | Description |
+|---|---|---|
+| `GH_TOKEN` / `GITHUB_TOKEN` | (required) | GitHub CLI authentication |
+
+### Environment variables (proposed)
+
+| Variable | Default | Description |
+|---|---|---|
+| `AMPLIHACK_ISSUE_DEDUP` | `1` | Enable (`1`) or disable (`0`) fingerprint dedup |
+| `AMPLIHACK_ISSUE_DEDUP_WINDOW` | `86400` | Seconds within which duplicates are commented, not created |
+
+## Related
+
+- [amplihack recipe](./recipe-command.md) — CLI reference for recipe execution
+- [Recipe Execution Flow](../concepts/recipe-execution-flow.md) — How recipe steps run
+- [Smart-Orchestrator Recovery](../concepts/smart-orchestrator-recovery.md) — Failure handling that triggers issue creation

--- a/docs/reference/query-code-command.md
+++ b/docs/reference/query-code-command.md
@@ -96,7 +96,7 @@ Code context for memory 'mem-query':
   Files:
     - src/example/module.py [python] (10 bytes)
   Functions:
-    - helper :: 
+    - helper ::
   Classes: none
 ```
 

--- a/docs/reference/recipe-command.md
+++ b/docs/reference/recipe-command.md
@@ -419,9 +419,28 @@ amplihack recipe run recipe.yaml -c task_description="..."
 
 ---
 
+## Failure modes
+
+Recipe execution can fail at multiple levels. For diagnosis:
+
+| Failure | Symptom | See |
+|---|---|---|
+| Runner binary missing | `recipe-runner-rs: command not found` | [Recipe search path](#recipe-search-path) and [Binary Resolution](./binary-resolution.md) |
+| Step timeout | Step killed after `timeout_seconds` | [Recipe Executor Environment](./recipe-executor-environment.md) |
+| Routing gap (no step runs) | Empty result after execution phase | [Smart-Orchestrator Recovery](../concepts/smart-orchestrator-recovery.md) |
+| Duplicate issues filed | Repeated `gh issue create` on retries | [Issue Deduplication](./issue-dedup.md) |
+| Condition parse error | `condition` field uses unsupported expression | [Agentic Step Patterns](../concepts/agentic-step-patterns.md) |
+| Context variable missing | `{{var}}` renders as empty string | [Context variables](#context-variables) |
+
+For general troubleshooting, see [Troubleshoot Recipe Execution Failures](../howto/troubleshoot-recipe-execution.md).
+
+---
+
 ## Related
 
 - [Run a Recipe End-to-End](../howto/run-a-recipe.md) — Step-by-step guide to executing recipes
 - [Environment Variables](./environment-variables.md) — `AMPLIHACK_CONTEXT_*`, `AMPLIHACK_TASK_DESCRIPTION`, `RECIPE_RUNNER_RS_PATH`
 - [Parity Test Scenarios](./parity-test-scenarios.md) — `tier4-recipe-run.yaml` test cases
 - [Agent Binary Routing](../concepts/agent-binary-routing.md) — How `AMPLIHACK_AGENT_BINARY` affects recipe step execution
+- [Recipe Runner Architecture](../concepts/recipe-runner-architecture.md) — Why the runner is an external binary
+- [Agentic Step Patterns](../concepts/agentic-step-patterns.md) — When to use bash vs agent vs recipe steps

--- a/npm/lib/bootstrap.js
+++ b/npm/lib/bootstrap.js
@@ -334,7 +334,18 @@ async function buildFromSource(root, installRoot) {
 }
 
 async function ensureNativeBinaries({ root, version }) {
-  // Resolve the freshest available release tag at install time. The
+  // Fast path: check the package.json version cache first to avoid a
+  // network round-trip when binaries are already installed. The GitHub API
+  // call is deferred until we know the local cache is stale.
+  const knownRoot = cacheRoot(version);
+  const knownBinDir = path.join(knownRoot, 'bin');
+  const knownMain = path.join(knownBinDir, binaryFilename('amplihack'));
+  const knownHooks = path.join(knownBinDir, binaryFilename('amplihack-hooks'));
+  if (fs.existsSync(knownMain) && fs.existsSync(knownHooks)) {
+    return { mainBinary: knownMain, hooksBinary: knownHooks, installRoot: knownRoot };
+  }
+
+  // Cache miss — resolve the freshest available release tag. The
   // package.json `version` field can drift behind the latest published
   // release (the release workflow publishes new tags without rewriting
   // package.json), so trusting `pkg.version` results in npx installs that

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.7.32",
+  "version": "0.8.0",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {

--- a/tests/integration/doc_code_drift_test.rs
+++ b/tests/integration/doc_code_drift_test.rs
@@ -141,14 +141,14 @@ mod launch_flag_injection {
                         .skip(i)
                         .take(5)
                         .find(|l| l.contains("claude --") || l.starts_with("# →"));
-                    if let Some(spawned) = spawned_line {
-                        if !context.contains("--skip-permissions") {
-                            assert!(
-                                !spawned.contains("--dangerously-skip-permissions"),
-                                "Line {}: bare `amplihack claude` must NOT inject --dangerously-skip-permissions.\nContext:\n{context}",
-                                i + 1
-                            );
-                        }
+                    if let Some(spawned) = spawned_line
+                        && !context.contains("--skip-permissions")
+                    {
+                        assert!(
+                            !spawned.contains("--dangerously-skip-permissions"),
+                            "Line {}: bare `amplihack claude` must NOT inject --dangerously-skip-permissions.\nContext:\n{context}",
+                            i + 1
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Closes #96.

Delivers retro recommendations R1, R2 (specs), R4, R5, R6 from the /pm-architect 30-day review.

## What's in here

**R1 — Issue dedup design**: docs/reference/issue-dedup.md (hash-based dedup spec for orchestrator-filed issues). Implementation lands separately.

**R2 — Recipe-runner consolidation prep**:
- crates/amplihack-recipe/src/{executor,condition_eval}.rs hardening (carries forward fork-only fixes)
- .pm/M2-recipe-runner-consolidation.md milestone tracker
- Gap issues already filed upstream: rysweet/amplihack-recipe-runner#99 (progress validator), #100 (sub-recipe recovery), #101 (env-protection + tempfile spill)

**R3 — Step-08 prompt** (separate PR #322, already merged)

**R4 — Copilot/Claude flag matrix**: docs/reference/flag-matrix.md

**R5 — Docs blitz**:
- docs/concepts/agentic-step-patterns.md
- docs/concepts/amplihack-retirement-direction.md (strategic frame: amplihack-rs is the future)
- docs/concepts/recipe-runner-architecture.md
- docs/concepts/smart-orchestrator-recovery.md
- docs/reference/recipe-command.md
- docs/index.md TOC updates

**R6 — .pm/ milestone structure**:
- .pm/M1-orchestrator-stability.md
- .pm/M2-recipe-runner-consolidation.md
- .pm/M3-bundled-python-winddown.md

**Plus**:
- npm/lib/bootstrap.js: cache fast-path to avoid GitHub API round-trip when binaries already installed
- crates/amplihack-cli launch tests command additions
- amplifier-bundle/recipes/default-workflow.yaml refinements
- Version bump 0.7.33 → 0.8.0
- tests/integration/doc_code_drift_test.rs: clippy collapsible_if fix

## Provenance

This PR was produced by smart-orchestrator (recipe-runner-rs) running R1+R2+R4+R5+R6 as a single development workstream. The recipe completed all 32 steps through step-14-bump-version; step-15-commit-push was blocked by the pre-existing #87 (build_publish_validation_scope.py missing) and a clippy autofix that needed to be applied. Recovery: applied the clippy fix, squashed the WIP commits into this single feat commit, pushed.

## Test Plan

CI runs: cargo fmt/clippy/test on the workspace. Locally verified clippy clean with `cargo clippy --workspace --all-targets -- -D warnings`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>