### PR TITLE
feat(retro): R1 issue-dedup + R4 flag-matrix implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "shell-words",
  "tempfile",
  "tracing",

--- a/crates/amplihack-hooks/Cargo.toml
+++ b/crates/amplihack-hooks/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 shell-words = { workspace = true }
 regex = "1"
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/amplihack-hooks/src/issue_dedup.rs
+++ b/crates/amplihack-hooks/src/issue_dedup.rs
@@ -1,0 +1,492 @@
+//! R1: Issue dedup module — fingerprint-based GitHub issue deduplication.
+//!
+//! Provides trait-abstracted GitHub issue management to prevent duplicate issue
+//! filing by the orchestrator auto-filer. Uses SHA-256 fingerprints keyed on
+//! `(error_class, day)` to decide whether to create a new issue, append a
+//! comment to an existing one, or create a daily rollup.
+
+use sha2::{Digest, Sha256};
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Fingerprint
+// ---------------------------------------------------------------------------
+
+/// A 12-char hex fingerprint derived from error class fields.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Fingerprint(pub String);
+
+impl Fingerprint {
+    /// Build fingerprint from error class components.
+    /// Matches the `make_signature_id` pattern in `amplihack-recovery::stage2`.
+    pub fn from_error_class(error_type: &str, headline: &str, location: &str) -> Self {
+        let canonical = format!("{error_type}|{headline}|{location}");
+        let hash = Sha256::digest(canonical.as_bytes());
+        let hex: String = hash[..6].iter().map(|b| format!("{b:02x}")).collect();
+        Self(hex)
+    }
+
+    /// Build the full dedup key combining fingerprint + date.
+    pub fn dedup_key(&self, date_ymd: &str) -> String {
+        format!("{}:{}", self.0, date_ymd)
+    }
+}
+
+impl fmt::Display for Fingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Issue search result
+// ---------------------------------------------------------------------------
+
+/// Represents a found GitHub issue matching a fingerprint search.
+#[derive(Clone, Debug)]
+pub struct FoundIssue {
+    pub number: u64,
+    pub title: String,
+    pub created_date: String, // YYYY-MM-DD
+    pub is_open: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Dedup decision
+// ---------------------------------------------------------------------------
+
+/// The action the dedup logic decided to take.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DedupAction {
+    /// No matching issue exists today — create a new one.
+    CreateNew,
+    /// An open issue with the same fingerprint was created today — append a comment.
+    AppendComment { issue_number: u64 },
+    /// Open issues exist from prior days — create a new daily issue that cross-references them.
+    CreateDailyRollup { prior_issue_numbers: Vec<u64> },
+}
+
+// ---------------------------------------------------------------------------
+// IssueClient trait
+// ---------------------------------------------------------------------------
+
+/// Abstraction over GitHub issue operations (real impl shells out to `gh`).
+pub trait IssueClient {
+    /// Search for open issues containing the fingerprint marker.
+    fn search_issues_by_fingerprint(
+        &self,
+        repo: &str,
+        fingerprint: &Fingerprint,
+    ) -> Result<Vec<FoundIssue>, String>;
+
+    /// Create a new issue. Returns issue number.
+    fn create_issue(
+        &self,
+        repo: &str,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+    ) -> Result<u64, String>;
+
+    /// Append a comment to an existing issue.
+    fn add_comment(&self, repo: &str, issue_number: u64, body: &str) -> Result<(), String>;
+}
+
+// ---------------------------------------------------------------------------
+// Core dedup logic
+// ---------------------------------------------------------------------------
+
+/// Determine what action to take given the current date and search results.
+pub fn decide_action(
+    matching_issues: &[FoundIssue],
+    today: &str, // YYYY-MM-DD
+) -> DedupAction {
+    // Filter to open issues only
+    let open_issues: Vec<&FoundIssue> = matching_issues.iter().filter(|i| i.is_open).collect();
+
+    if open_issues.is_empty() {
+        return DedupAction::CreateNew;
+    }
+
+    // Check if any open issue was created today
+    let todays_issues: Vec<&FoundIssue> = open_issues
+        .iter()
+        .filter(|i| i.created_date == today)
+        .copied()
+        .collect();
+
+    if let Some(issue) = todays_issues.first() {
+        return DedupAction::AppendComment {
+            issue_number: issue.number,
+        };
+    }
+
+    // Open issues exist but none from today — daily rollup
+    let prior_numbers: Vec<u64> = open_issues.iter().map(|i| i.number).collect();
+    DedupAction::CreateDailyRollup {
+        prior_issue_numbers: prior_numbers,
+    }
+}
+
+/// Execute the full dedup workflow: search, decide, act.
+pub fn file_or_dedup(
+    client: &dyn IssueClient,
+    repo: &str,
+    fingerprint: &Fingerprint,
+    today: &str,
+    error_title: &str,
+    error_body: &str,
+) -> Result<DedupAction, String> {
+    let matches = client.search_issues_by_fingerprint(repo, fingerprint)?;
+    let action = decide_action(&matches, today);
+
+    match &action {
+        DedupAction::CreateNew => {
+            let body_with_marker = format!(
+                "{error_body}\n\n<!-- amplihack-fingerprint:{} -->",
+                fingerprint
+            );
+            client.create_issue(repo, error_title, &body_with_marker, &["auto-filed"])?;
+        }
+        DedupAction::AppendComment { issue_number } => {
+            let comment = format!("**Duplicate occurrence** ({})\n\n{}", today, error_body);
+            client.add_comment(repo, *issue_number, &comment)?;
+        }
+        DedupAction::CreateDailyRollup {
+            prior_issue_numbers,
+        } => {
+            let refs: Vec<String> = prior_issue_numbers
+                .iter()
+                .map(|n| format!("#{n}"))
+                .collect();
+            let rollup_body = format!(
+                "**Daily rollup** for {today}\n\nPrior issues: {}\n\n{error_body}\n\n<!-- amplihack-fingerprint:{} -->",
+                refs.join(", "),
+                fingerprint
+            );
+            client.create_issue(
+                repo,
+                &format!("[Rollup {today}] {error_title}"),
+                &rollup_body,
+                &["auto-filed"],
+            )?;
+        }
+    }
+
+    Ok(action)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    // -----------------------------------------------------------------------
+    // Mock IssueClient
+    // -----------------------------------------------------------------------
+
+    #[derive(Default)]
+    struct MockIssueClient {
+        /// Pre-loaded search results keyed by fingerprint string.
+        search_results: HashMap<String, Vec<FoundIssue>>,
+        /// Track created issues: (title, body, labels)
+        created_issues: RefCell<Vec<(String, String, Vec<String>)>>,
+        /// Track appended comments: (issue_number, body)
+        appended_comments: RefCell<Vec<(u64, String)>>,
+        /// Next issue number to return from create.
+        next_issue_number: RefCell<u64>,
+    }
+
+    impl MockIssueClient {
+        fn with_search_results(mut self, fp: &Fingerprint, issues: Vec<FoundIssue>) -> Self {
+            self.search_results.insert(fp.0.clone(), issues);
+            self
+        }
+    }
+
+    impl IssueClient for MockIssueClient {
+        fn search_issues_by_fingerprint(
+            &self,
+            _repo: &str,
+            fingerprint: &Fingerprint,
+        ) -> Result<Vec<FoundIssue>, String> {
+            Ok(self
+                .search_results
+                .get(&fingerprint.0)
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn create_issue(
+            &self,
+            _repo: &str,
+            title: &str,
+            body: &str,
+            labels: &[&str],
+        ) -> Result<u64, String> {
+            let num = {
+                let mut n = self.next_issue_number.borrow_mut();
+                *n += 1;
+                *n
+            };
+            self.created_issues.borrow_mut().push((
+                title.to_string(),
+                body.to_string(),
+                labels.iter().map(|s| s.to_string()).collect(),
+            ));
+            Ok(num)
+        }
+
+        fn add_comment(&self, _repo: &str, issue_number: u64, body: &str) -> Result<(), String> {
+            self.appended_comments
+                .borrow_mut()
+                .push((issue_number, body.to_string()));
+            Ok(())
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Fingerprint tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fingerprint_is_12_hex_chars() {
+        let fp = Fingerprint::from_error_class("ImportError", "no module foo", "src/main.py");
+        assert_eq!(fp.0.len(), 12, "fingerprint must be 12 hex chars");
+        assert!(fp.0.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn fingerprint_deterministic() {
+        let fp1 = Fingerprint::from_error_class("TypeError", "expected int", "lib.rs:42");
+        let fp2 = Fingerprint::from_error_class("TypeError", "expected int", "lib.rs:42");
+        assert_eq!(fp1, fp2);
+    }
+
+    #[test]
+    fn fingerprint_differs_for_different_errors() {
+        let fp1 = Fingerprint::from_error_class("TypeError", "expected int", "lib.rs:42");
+        let fp2 = Fingerprint::from_error_class("ValueError", "expected int", "lib.rs:42");
+        assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn dedup_key_format() {
+        let fp = Fingerprint::from_error_class("Err", "msg", "loc");
+        let key = fp.dedup_key("2026-04-23");
+        assert!(key.contains("2026-04-23"));
+        assert!(key.starts_with(&fp.0));
+    }
+
+    // -----------------------------------------------------------------------
+    // decide_action tests — the 3 code paths
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn decide_create_new_when_no_matches() {
+        let action = decide_action(&[], "2026-04-23");
+        assert_eq!(action, DedupAction::CreateNew);
+    }
+
+    #[test]
+    fn decide_create_new_when_only_closed_issues() {
+        let issues = vec![FoundIssue {
+            number: 10,
+            title: "old".into(),
+            created_date: "2026-04-23".into(),
+            is_open: false,
+        }];
+        let action = decide_action(&issues, "2026-04-23");
+        assert_eq!(action, DedupAction::CreateNew);
+    }
+
+    #[test]
+    fn decide_append_comment_when_open_issue_exists_today() {
+        let issues = vec![FoundIssue {
+            number: 42,
+            title: "existing".into(),
+            created_date: "2026-04-23".into(),
+            is_open: true,
+        }];
+        let action = decide_action(&issues, "2026-04-23");
+        assert_eq!(action, DedupAction::AppendComment { issue_number: 42 });
+    }
+
+    #[test]
+    fn decide_daily_rollup_when_open_issues_from_prior_days() {
+        let issues = vec![
+            FoundIssue {
+                number: 10,
+                title: "day1".into(),
+                created_date: "2026-04-21".into(),
+                is_open: true,
+            },
+            FoundIssue {
+                number: 20,
+                title: "day2".into(),
+                created_date: "2026-04-22".into(),
+                is_open: true,
+            },
+        ];
+        let action = decide_action(&issues, "2026-04-23");
+        assert_eq!(
+            action,
+            DedupAction::CreateDailyRollup {
+                prior_issue_numbers: vec![10, 20],
+            }
+        );
+    }
+
+    #[test]
+    fn decide_prefers_today_append_over_rollup() {
+        // Mix of today + prior day open issues → should append to today's
+        let issues = vec![
+            FoundIssue {
+                number: 10,
+                title: "yesterday".into(),
+                created_date: "2026-04-22".into(),
+                is_open: true,
+            },
+            FoundIssue {
+                number: 42,
+                title: "today".into(),
+                created_date: "2026-04-23".into(),
+                is_open: true,
+            },
+        ];
+        let action = decide_action(&issues, "2026-04-23");
+        assert_eq!(action, DedupAction::AppendComment { issue_number: 42 });
+    }
+
+    // -----------------------------------------------------------------------
+    // file_or_dedup integration tests with mock
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn file_or_dedup_creates_issue_with_fingerprint_marker() {
+        let fp = Fingerprint::from_error_class("TestError", "boom", "test.rs:1");
+        let client = MockIssueClient::default();
+
+        let action = file_or_dedup(
+            &client,
+            "rysweet/amplihack-rs",
+            &fp,
+            "2026-04-23",
+            "TestError: boom",
+            "Stack trace here",
+        )
+        .unwrap();
+
+        assert_eq!(action, DedupAction::CreateNew);
+        let created = client.created_issues.borrow();
+        assert_eq!(created.len(), 1);
+        assert!(created[0].1.contains("amplihack-fingerprint:"));
+        assert!(created[0].2.contains(&"auto-filed".to_string()));
+    }
+
+    #[test]
+    fn file_or_dedup_appends_comment_on_today_match() {
+        let fp = Fingerprint::from_error_class("TestError", "boom", "test.rs:1");
+        let client = MockIssueClient::default().with_search_results(
+            &fp,
+            vec![FoundIssue {
+                number: 99,
+                title: "existing".into(),
+                created_date: "2026-04-23".into(),
+                is_open: true,
+            }],
+        );
+
+        let action = file_or_dedup(
+            &client,
+            "rysweet/amplihack-rs",
+            &fp,
+            "2026-04-23",
+            "TestError: boom",
+            "Another occurrence",
+        )
+        .unwrap();
+
+        assert_eq!(action, DedupAction::AppendComment { issue_number: 99 });
+        let comments = client.appended_comments.borrow();
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].0, 99);
+        assert!(comments[0].1.contains("Duplicate occurrence"));
+    }
+
+    #[test]
+    fn file_or_dedup_creates_rollup_with_cross_references() {
+        let fp = Fingerprint::from_error_class("TestError", "boom", "test.rs:1");
+        let client = MockIssueClient::default().with_search_results(
+            &fp,
+            vec![FoundIssue {
+                number: 50,
+                title: "old".into(),
+                created_date: "2026-04-20".into(),
+                is_open: true,
+            }],
+        );
+
+        let action = file_or_dedup(
+            &client,
+            "rysweet/amplihack-rs",
+            &fp,
+            "2026-04-23",
+            "TestError: boom",
+            "Details",
+        )
+        .unwrap();
+
+        assert_eq!(
+            action,
+            DedupAction::CreateDailyRollup {
+                prior_issue_numbers: vec![50],
+            }
+        );
+        let created = client.created_issues.borrow();
+        assert_eq!(created.len(), 1);
+        assert!(created[0].0.contains("Rollup"));
+        assert!(created[0].1.contains("#50"));
+    }
+
+    #[test]
+    fn file_or_dedup_propagates_search_error() {
+        struct FailingClient;
+        impl IssueClient for FailingClient {
+            fn search_issues_by_fingerprint(
+                &self,
+                _repo: &str,
+                _fingerprint: &Fingerprint,
+            ) -> Result<Vec<FoundIssue>, String> {
+                Err("gh: not found".into())
+            }
+            fn create_issue(
+                &self,
+                _repo: &str,
+                _title: &str,
+                _body: &str,
+                _labels: &[&str],
+            ) -> Result<u64, String> {
+                unreachable!()
+            }
+            fn add_comment(
+                &self,
+                _repo: &str,
+                _issue_number: u64,
+                _body: &str,
+            ) -> Result<(), String> {
+                unreachable!()
+            }
+        }
+
+        let fp = Fingerprint::from_error_class("E", "h", "l");
+        let result = file_or_dedup(&FailingClient, "repo", &fp, "2026-04-23", "t", "b");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("gh: not found"));
+    }
+}

--- a/crates/amplihack-hooks/src/lib.rs
+++ b/crates/amplihack-hooks/src/lib.rs
@@ -28,6 +28,9 @@ pub mod user_prompt;
 /// Workflow classification reminder hook: injects topic-boundary routing guidance.
 pub mod workflow_classification;
 
+/// Fingerprint-based GitHub issue deduplication (R1).
+pub mod issue_dedup;
+
 /// Copilot stop handler utilities (continuation, lock cleanup, decision log).
 pub mod copilot_stop_handler;
 /// Hook file installation verification.

--- a/crates/amplihack-launcher/src/flag_matrix.rs
+++ b/crates/amplihack-launcher/src/flag_matrix.rs
@@ -1,0 +1,277 @@
+//! R4: Single source-of-truth flag matrix for agent binary nested-flag deltas.
+//!
+//! Maps per-binary capabilities and flags so that command builders can consult
+//! a canonical matrix instead of scattering flag knowledge across modules.
+
+// ---------------------------------------------------------------------------
+// Agent binary enum
+// ---------------------------------------------------------------------------
+
+/// The supported agent binaries that amplihack can launch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AgentBinary {
+    Claude,
+    Copilot,
+    Codex,
+}
+
+impl AgentBinary {
+    /// Returns the env var value used for `AMPLIHACK_AGENT_BINARY`.
+    pub fn env_value(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Copilot => "copilot",
+            Self::Codex => "codex",
+        }
+    }
+}
+
+impl std::fmt::Display for AgentBinary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.env_value())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FlagSet — the canonical flag collection for a binary
+// ---------------------------------------------------------------------------
+
+/// Canonical set of flags and capabilities for an agent binary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FlagSet {
+    /// Binary type this flag set is for.
+    pub binary: AgentBinary,
+    /// Supports `--append-system-prompt <path>`.
+    pub supports_append_prompt: bool,
+    /// Supports `--add-dir <path>`.
+    pub supports_add_dir: bool,
+    /// Supports `--model <name>`.
+    pub supports_model: bool,
+    /// Supports `--dangerously-skip-permissions`.
+    pub supports_skip_permissions: bool,
+    /// Supports `--resume` / `--continue`.
+    pub supports_resume: bool,
+    /// Supports `--print` (non-interactive mode).
+    pub supports_print: bool,
+    /// Supports `--allow-all-tools` (Copilot-specific).
+    pub supports_allow_all_tools: bool,
+    /// The env var name set to identify the agent binary in nested sessions.
+    pub agent_binary_env: &'static str,
+}
+
+// ---------------------------------------------------------------------------
+// Matrix lookup
+// ---------------------------------------------------------------------------
+
+/// Return the canonical `FlagSet` for a given agent binary.
+pub fn flags_for(binary: AgentBinary) -> FlagSet {
+    match binary {
+        AgentBinary::Claude => FlagSet {
+            binary: AgentBinary::Claude,
+            supports_append_prompt: true,
+            supports_add_dir: true,
+            supports_model: true,
+            supports_skip_permissions: true,
+            supports_resume: true,
+            supports_print: true,
+            supports_allow_all_tools: false,
+            agent_binary_env: "AMPLIHACK_AGENT_BINARY",
+        },
+        AgentBinary::Copilot => FlagSet {
+            binary: AgentBinary::Copilot,
+            supports_append_prompt: false,
+            supports_add_dir: false,
+            supports_model: true,
+            supports_skip_permissions: false,
+            supports_resume: false,
+            supports_print: false,
+            supports_allow_all_tools: true,
+            agent_binary_env: "AMPLIHACK_AGENT_BINARY",
+        },
+        AgentBinary::Codex => FlagSet {
+            binary: AgentBinary::Codex,
+            supports_append_prompt: false,
+            supports_add_dir: false,
+            supports_model: false,
+            supports_skip_permissions: false,
+            supports_resume: false,
+            supports_print: false,
+            supports_allow_all_tools: false,
+            agent_binary_env: "AMPLIHACK_AGENT_BINARY",
+        },
+    }
+}
+
+/// All known agent binaries.
+pub const ALL_BINARIES: &[AgentBinary] = &[
+    AgentBinary::Claude,
+    AgentBinary::Copilot,
+    AgentBinary::Codex,
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Basic matrix correctness
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn claude_supports_append_prompt() {
+        let flags = flags_for(AgentBinary::Claude);
+        assert!(flags.supports_append_prompt);
+    }
+
+    #[test]
+    fn claude_supports_add_dir() {
+        let flags = flags_for(AgentBinary::Claude);
+        assert!(flags.supports_add_dir);
+    }
+
+    #[test]
+    fn claude_supports_print() {
+        let flags = flags_for(AgentBinary::Claude);
+        assert!(flags.supports_print);
+    }
+
+    #[test]
+    fn claude_does_not_support_allow_all_tools() {
+        let flags = flags_for(AgentBinary::Claude);
+        assert!(!flags.supports_allow_all_tools);
+    }
+
+    #[test]
+    fn copilot_supports_allow_all_tools() {
+        let flags = flags_for(AgentBinary::Copilot);
+        assert!(flags.supports_allow_all_tools);
+    }
+
+    #[test]
+    fn copilot_does_not_support_append_prompt() {
+        let flags = flags_for(AgentBinary::Copilot);
+        assert!(!flags.supports_append_prompt);
+    }
+
+    #[test]
+    fn copilot_does_not_support_print() {
+        let flags = flags_for(AgentBinary::Copilot);
+        assert!(!flags.supports_print);
+    }
+
+    #[test]
+    fn codex_is_minimal_flags() {
+        let flags = flags_for(AgentBinary::Codex);
+        assert!(!flags.supports_append_prompt);
+        assert!(!flags.supports_add_dir);
+        assert!(!flags.supports_model);
+        assert!(!flags.supports_skip_permissions);
+        assert!(!flags.supports_resume);
+        assert!(!flags.supports_print);
+        assert!(!flags.supports_allow_all_tools);
+    }
+
+    // -----------------------------------------------------------------------
+    // Agent binary env value
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn all_binaries_share_same_env_var_name() {
+        for binary in ALL_BINARIES {
+            let flags = flags_for(*binary);
+            assert_eq!(flags.agent_binary_env, "AMPLIHACK_AGENT_BINARY");
+        }
+    }
+
+    #[test]
+    fn agent_binary_env_values_are_distinct() {
+        let values: Vec<&str> = ALL_BINARIES.iter().map(|b| b.env_value()).collect();
+        let unique: std::collections::HashSet<&&str> = values.iter().collect();
+        assert_eq!(values.len(), unique.len(), "env values must be unique");
+    }
+
+    #[test]
+    fn claude_env_value_is_claude() {
+        assert_eq!(AgentBinary::Claude.env_value(), "claude");
+    }
+
+    #[test]
+    fn copilot_env_value_is_copilot() {
+        assert_eq!(AgentBinary::Copilot.env_value(), "copilot");
+    }
+
+    #[test]
+    fn codex_env_value_is_codex() {
+        assert_eq!(AgentBinary::Codex.env_value(), "codex");
+    }
+
+    // -----------------------------------------------------------------------
+    // Matrix consistency — every binary returns the correct binary field
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn flagset_binary_field_matches_input() {
+        for binary in ALL_BINARIES {
+            let flags = flags_for(*binary);
+            assert_eq!(flags.binary, *binary);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested flag propagation assertions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn claude_nested_flags_include_resume() {
+        let flags = flags_for(AgentBinary::Claude);
+        assert!(
+            flags.supports_resume,
+            "Claude must support --resume for session continuation"
+        );
+    }
+
+    #[test]
+    fn claude_nested_flags_include_model() {
+        let flags = flags_for(AgentBinary::Claude);
+        assert!(
+            flags.supports_model,
+            "Claude must support --model for model selection"
+        );
+    }
+
+    #[test]
+    fn copilot_nested_flags_include_model() {
+        let flags = flags_for(AgentBinary::Copilot);
+        assert!(flags.supports_model, "Copilot must support --model");
+    }
+
+    #[test]
+    fn claude_nested_flags_include_skip_permissions() {
+        let flags = flags_for(AgentBinary::Claude);
+        assert!(flags.supports_skip_permissions);
+    }
+
+    // -----------------------------------------------------------------------
+    // Display / formatting
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn agent_binary_display() {
+        assert_eq!(format!("{}", AgentBinary::Claude), "claude");
+        assert_eq!(format!("{}", AgentBinary::Copilot), "copilot");
+        assert_eq!(format!("{}", AgentBinary::Codex), "codex");
+    }
+
+    // -----------------------------------------------------------------------
+    // ALL_BINARIES completeness
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn all_binaries_contains_three_variants() {
+        assert_eq!(ALL_BINARIES.len(), 3);
+    }
+}

--- a/crates/amplihack-launcher/src/lib.rs
+++ b/crates/amplihack-launcher/src/lib.rs
@@ -21,6 +21,7 @@ pub mod copilot_auto_install;
 pub mod copilot_launcher;
 pub mod copilot_mcp;
 pub mod copilot_staging;
+pub mod flag_matrix;
 pub mod fork_manager;
 pub mod json_logger;
 pub mod launcher_core;


### PR DESCRIPTION
Follow-up to #323 adding the two library modules produced by the retro orchestrator run that were left as untracked working-tree files during recovery.

## R1 — amplihack-hooks::issue_dedup

Fingerprint-based dedup for orchestrator-filed issues (spec: docs/reference/issue-dedup.md).

- `Fingerprint::from_error_class(error_type, headline, location)` — SHA-256 over canonical `error_type|headline|location`, first 12 hex chars.
- `dedup_key(date_ymd)` — combines fingerprint + YYYY-MM-DD.
- `file_or_dedup()` — decides between creating a new issue, appending a comment to today's match, or creating a daily rollup.
- GitHub operations abstracted through an `IssueOps` trait so tests use a fake.
- 13 passing unit tests.

## R4 — amplihack-launcher::flag_matrix

Single source-of-truth for per-binary CLI flag capabilities (spec: docs/reference/flag-matrix.md).

- `AgentBinary` enum: Claude / Copilot / Codex with `env_value()`.
- `FlagSet` capturing supports_print / supports_append_prompt / supports_allow_all_tools / nested_flags.
- 20 passing unit tests.

## Status

Both modules are standalone library code; they're not yet consumed by any caller. Follow-up PRs will:
- migrate the orchestrator's issue-filer to call `file_or_dedup()`
- migrate `strategies.rs` / `copilot_launcher.rs` to consult `flag_matrix` instead of hard-coding flags

## Test Plan

```
cargo clippy -p amplihack-hooks -p amplihack-launcher --tests -- -D warnings
TMPDIR=/tmp cargo test -p amplihack-hooks issue_dedup
TMPDIR=/tmp cargo test -p amplihack-launcher flag_matrix
```

All 33 tests pass locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>