### PR TITLE
fix(default-workflow): replace python3 JSON emission with jq (refs #242)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -2010,28 +2010,31 @@ steps:
       export ISSUE_VAL
       PR_VAL="$PR_URL"
       export PR_VAL
-      python3 << 'PYEOF'
-      import json, os
-      print(json.dumps({
-          "workflow": "default-workflow",
-          "version": "2.0.0",
-          "task": os.environ.get("TASK_VAL", ""),
-          "issue_number": os.environ.get("ISSUE_VAL", ""),
-          "pr_url": os.environ.get("PR_VAL", ""),
-          "status": "complete",
-          "steps_completed": 23,
-          "phases_completed": [
-              "requirements-clarification", "design", "implementation",
-              "testing", "review", "merge"
+      # Pure jq — no Python dependency (#242).
+      # jq -n constructs the object; --arg passes env vars in safely (no quoting hazards).
+      jq -n \
+        --arg task "${TASK_VAL}" \
+        --arg issue "${ISSUE_VAL}" \
+        --arg pr "${PR_VAL}" \
+        '{
+          workflow: "default-workflow",
+          version: "2.0.0",
+          task: $task,
+          issue_number: $issue,
+          pr_url: $pr,
+          status: "complete",
+          steps_completed: 23,
+          phases_completed: [
+            "requirements-clarification", "design", "implementation",
+            "testing", "review", "merge"
           ],
-          "mandatory_steps_completed": {
-              "step_0_preparation": True,
-              "step_14_version_bump": True,
-              "step_17_pr_review": True,
-              "step_18_implement_feedback": True
+          mandatory_steps_completed: {
+            step_0_preparation: true,
+            step_14_version_bump: true,
+            step_17_pr_review: true,
+            step_18_implement_feedback: true
           },
-          "philosophy_compliant": True,
-          "ready_to_merge": True
-      }, indent=2))
-      PYEOF
+          philosophy_compliant: true,
+          ready_to_merge: true
+        }'
     output: "workflow_result"


### PR DESCRIPTION
## Summary
First concrete win toward #242 (recipes must not depend on Python). Step-23 of default-workflow.yaml was using a `python3 << PYEOF` heredoc to construct a literal JSON object — a textbook case for `jq`, which is already required by other recipe steps.

## Change
```diff
- python3 << 'PYEOF'
- import json, os
- print(json.dumps({...}, indent=2))
- PYEOF
+ jq -n --arg task ... --arg issue ... --arg pr ... '{...}'
```

## Validation
- `yaml.safe_load(open(...))` — yaml structure preserved
- `jq -n` output matches python3 output byte-for-byte (same inputs → same JSON)
- `--arg` quotes env vars safely (no shell injection risk)

## Followup
This is one Python invocation removed. The full audit (filed as separate issue) catalogs ~20 more in oxidizer-workflow.yaml, quality-audit-cycle.yaml, and elsewhere.

Refs #242

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>