### PR TITLE
fix(copilot): tolerate JSONC comments in copilot config.json

### DIFF
--- a/crates/amplihack-cli/src/copilot_setup/hooks.rs
+++ b/crates/amplihack-cli/src/copilot_setup/hooks.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use super::{
     COPILOT_HOOK_TIMEOUT_SEC, COPILOT_HOOK_WRAPPERS, HookWrapperSpec, INSTRUCTIONS_MARKER_END,
-    INSTRUCTIONS_MARKER_START, fs_helpers,
+    INSTRUCTIONS_MARKER_START, fs_helpers, jsonc,
 };
 
 /// Build the Copilot hooks manifest as JSON. Hook entries reference absolute
@@ -85,29 +85,34 @@ pub(super) fn write_user_level_hooks(copilot_home: &Path) -> Result<()> {
     }
 
     let config_path = copilot_home.join("config.json");
-    let mut root: serde_json::Value = if config_path.is_file() {
+    let (mut root, prefix): (serde_json::Value, String) = if config_path.is_file() {
         let raw = fs::read_to_string(&config_path)
             .with_context(|| format!("read {}", config_path.display()))?;
-        if raw.trim().is_empty() {
+        let prefix = jsonc::leading_comment_prefix(&raw).to_string();
+        let stripped = jsonc::strip_jsonc_comments(&raw);
+        let value = if stripped.trim().is_empty() {
             serde_json::json!({})
         } else {
-            serde_json::from_str(&raw).with_context(|| {
+            serde_json::from_str(&stripped).with_context(|| {
                 format!(
                     "parse {} as JSON before merging hooks",
                     config_path.display()
                 )
             })?
-        }
+        };
+        (value, prefix)
     } else {
-        serde_json::json!({})
+        (serde_json::json!({}), String::new())
     };
 
     let manifest = build_copilot_hooks_manifest(&hooks_dir);
-    let amplihack_hooks = manifest
-        .get("hooks")
-        .and_then(|h| h.as_object())
-        .cloned()
-        .unwrap_or_default();
+    let amplihack_hooks = match manifest {
+        serde_json::Value::Object(mut m) => match m.remove("hooks") {
+            Some(serde_json::Value::Object(h)) => h,
+            _ => serde_json::Map::new(),
+        },
+        _ => serde_json::Map::new(),
+    };
 
     let obj = root
         .as_object_mut()
@@ -122,22 +127,22 @@ pub(super) fn write_user_level_hooks(copilot_home: &Path) -> Result<()> {
     // Replace amplihack-owned entries; keep any user-defined non-amplihack
     // hooks the user has registered for the same event by appending after.
     for (event, new_arr_value) in amplihack_hooks {
-        let new_arr = new_arr_value.as_array().cloned().unwrap_or_default();
-        let preserved: Vec<serde_json::Value> = hooks_obj
-            .get(&event)
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|entry| !is_amplihack_owned(entry))
-            .collect();
-        let mut merged = new_arr;
-        merged.extend(preserved);
+        let mut merged = match new_arr_value {
+            serde_json::Value::Array(a) => a,
+            _ => Vec::new(),
+        };
+        if let Some(serde_json::Value::Array(existing)) = hooks_obj.remove(&event) {
+            merged.extend(
+                existing
+                    .into_iter()
+                    .filter(|entry| !is_amplihack_owned(entry)),
+            );
+        }
         hooks_obj.insert(event, serde_json::Value::Array(merged));
     }
 
-    let serialized = serde_json::to_string_pretty(&root)? + "\n";
-    fs::write(&config_path, serialized)
+    let body = serde_json::to_string_pretty(&root)? + "\n";
+    fs::write(&config_path, jsonc::apply_prefix(&prefix, body))
         .with_context(|| format!("write {}", config_path.display()))?;
     Ok(())
 }

--- a/crates/amplihack-cli/src/copilot_setup/jsonc.rs
+++ b/crates/amplihack-cli/src/copilot_setup/jsonc.rs
@@ -1,0 +1,329 @@
+//! JSONC (JSON-with-comments) tolerance utilities for Copilot config files.
+//!
+//! GitHub Copilot CLI writes `~/.copilot/config.json` as JSONC: it begins with
+//! one or more `//` line comments before the actual JSON object. Bare
+//! `serde_json::from_str` rejects those comments, which broke amplihack's
+//! `register_plugin` and `write_user_level_hooks` paths.
+//!
+//! This module provides two pure string utilities used at the read/write
+//! boundary:
+//!
+//! * [`strip_jsonc_comments`] — remove `//…\n` and `/* … */` comments while
+//!   preserving the byte contents of double-quoted string literals.
+//! * [`leading_comment_prefix`] — return the substring up to (exclusive) the
+//!   first `{` or `[` found outside of comments and strings, so the caller
+//!   can write it back verbatim and not lose user/Copilot-managed comments.
+
+/// Remove JSONC `//` line comments and `/* */` block comments from `input`
+/// while preserving the contents of double-quoted string literals byte-for-byte.
+///
+/// Notes:
+/// * Block comments do not nest.
+/// * `//` and `/*` inside a `"…"` string are preserved verbatim.
+/// * Unterminated strings or block comments at EOF are tolerated (no panic);
+///   the partial content is preserved up to EOF.
+/// * Line/column information from `serde_json` errors will refer to offsets
+///   within the returned (stripped) buffer, NOT the on-disk file.
+pub fn strip_jsonc_comments(input: &str) -> String {
+    // Byte-level scan with slice copies. All structural markers ('"', '/',
+    // '*', '\\', '\n') are ASCII, so they only ever appear at UTF-8 codepoint
+    // boundaries — slicing `&input[chunk_start..i]` is always safe.
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(len);
+    let mut i = 0;
+    let mut chunk_start = 0;
+
+    enum State {
+        Normal,
+        InString,
+        InLineComment,
+        InBlockComment,
+    }
+    let mut state = State::Normal;
+    let mut escape = false;
+
+    while i < len {
+        let b = bytes[i];
+        match state {
+            State::Normal => {
+                if b == b'"' {
+                    state = State::InString;
+                    escape = false;
+                    i += 1;
+                } else if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+                    out.push_str(&input[chunk_start..i]);
+                    i += 2;
+                    state = State::InLineComment;
+                } else if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+                    out.push_str(&input[chunk_start..i]);
+                    i += 2;
+                    state = State::InBlockComment;
+                } else {
+                    i += 1;
+                }
+            }
+            State::InString => {
+                if escape {
+                    escape = false;
+                } else if b == b'\\' {
+                    escape = true;
+                } else if b == b'"' {
+                    state = State::Normal;
+                }
+                i += 1;
+            }
+            State::InLineComment => {
+                if b == b'\n' {
+                    state = State::Normal;
+                    chunk_start = i; // newline becomes the start of next chunk
+                }
+                i += 1;
+            }
+            State::InBlockComment => {
+                if b == b'*' && i + 1 < len && bytes[i + 1] == b'/' {
+                    state = State::Normal;
+                    i += 2;
+                    chunk_start = i;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    // Flush the trailing chunk for any state where bytes beyond chunk_start
+    // are content to keep (Normal, InString — including unterminated strings).
+    if matches!(state, State::Normal | State::InString) {
+        out.push_str(&input[chunk_start..len]);
+    }
+    out
+}
+
+/// Return the substring of `input` that appears before the first `{` or `[`
+/// found outside of comments and string literals.
+///
+/// The returned slice is intended to be written back verbatim to preserve any
+/// leading `//` comment block (Copilot CLI emits two such lines). If no JSON
+/// container start is found, the entire input is returned.
+pub fn leading_comment_prefix(input: &str) -> &str {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    enum State {
+        Normal,
+        InString,
+        InLineComment,
+        InBlockComment,
+    }
+    let mut state = State::Normal;
+    let mut escape = false;
+
+    while i < len {
+        let b = bytes[i];
+        match state {
+            State::Normal => {
+                if b == b'{' || b == b'[' {
+                    return &input[..i];
+                }
+                if b == b'"' {
+                    state = State::InString;
+                    escape = false;
+                    i += 1;
+                } else if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+                    state = State::InLineComment;
+                    i += 2;
+                } else if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+                    state = State::InBlockComment;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            State::InString => {
+                if escape {
+                    escape = false;
+                } else if b == b'\\' {
+                    escape = true;
+                } else if b == b'"' {
+                    state = State::Normal;
+                }
+                i += 1;
+            }
+            State::InLineComment => {
+                if b == b'\n' {
+                    state = State::Normal;
+                }
+                i += 1;
+            }
+            State::InBlockComment => {
+                if b == b'*' && i + 1 < len && bytes[i + 1] == b'/' {
+                    state = State::Normal;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    input
+}
+
+/// Concatenate a preserved JSONC `prefix` (typically a leading `//` comment
+/// block) with a freshly-serialized JSON `body`, inserting a single newline
+/// separator when the prefix is non-empty and does not already end in one.
+pub fn apply_prefix(prefix: &str, body: String) -> String {
+    if prefix.is_empty() {
+        return body;
+    }
+    let need_sep = !prefix.ends_with('\n');
+    let mut out = String::with_capacity(prefix.len() + body.len() + usize::from(need_sep));
+    out.push_str(prefix);
+    if need_sep {
+        out.push('\n');
+    }
+    out.push_str(&body);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_leading_line_comments() {
+        let src = "// User settings belong in settings.json.\n\
+                   // This file is managed automatically.\n\
+                   {\"a\": 1}\n";
+        let out = strip_jsonc_comments(src);
+        let v: serde_json::Value = serde_json::from_str(&out).expect("parse stripped");
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn strips_inline_line_comment_after_value() {
+        let src = "{\"a\": 1 // trailing\n, \"b\": 2}\n";
+        let out = strip_jsonc_comments(src);
+        let v: serde_json::Value = serde_json::from_str(&out).expect("parse stripped");
+        assert_eq!(v["a"], 1);
+        assert_eq!(v["b"], 2);
+    }
+
+    #[test]
+    fn strips_block_comment() {
+        let src = "{/* hi */\"a\": 1}";
+        let out = strip_jsonc_comments(src);
+        let v: serde_json::Value = serde_json::from_str(&out).expect("parse stripped");
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn block_comment_does_not_nest() {
+        // The first `*/` closes the block; the trailing `*/` is plain JSON
+        // content (illegal JSON, but proves non-nesting). We verify the
+        // stripper consumed only up to the first `*/`.
+        let src = "/* outer /* inner */AFTER";
+        let out = strip_jsonc_comments(src);
+        assert_eq!(out, "AFTER");
+    }
+
+    #[test]
+    fn preserves_double_slash_inside_string() {
+        let src = "{\"url\": \"https://example.com//path\"}";
+        let out = strip_jsonc_comments(src);
+        let v: serde_json::Value = serde_json::from_str(&out).expect("parse stripped");
+        assert_eq!(v["url"], "https://example.com//path");
+    }
+
+    #[test]
+    fn preserves_block_comment_markers_inside_string() {
+        let src = "{\"s\": \"/* not a comment */\"}";
+        let out = strip_jsonc_comments(src);
+        let v: serde_json::Value = serde_json::from_str(&out).expect("parse stripped");
+        assert_eq!(v["s"], "/* not a comment */");
+    }
+
+    #[test]
+    fn handles_escaped_quote_inside_string() {
+        let src = "{\"s\": \"a\\\"// still in string\"}";
+        let out = strip_jsonc_comments(src);
+        let v: serde_json::Value = serde_json::from_str(&out).expect("parse stripped");
+        assert_eq!(v["s"], "a\"// still in string");
+    }
+
+    #[test]
+    fn empty_input_is_empty() {
+        assert_eq!(strip_jsonc_comments(""), "");
+    }
+
+    #[test]
+    fn unterminated_string_at_eof_does_not_panic() {
+        let src = "{\"s\": \"unterminated";
+        let _ = strip_jsonc_comments(src); // Must not panic.
+    }
+
+    #[test]
+    fn unterminated_block_comment_at_eof_does_not_panic() {
+        let src = "{/* never closes";
+        let _ = strip_jsonc_comments(src); // Must not panic.
+    }
+
+    #[test]
+    fn line_comment_at_eof_without_newline() {
+        let src = "{\"a\": 1}\n// trailing";
+        let out = strip_jsonc_comments(src);
+        let v: serde_json::Value = serde_json::from_str(out.trim()).expect("parse stripped");
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn leading_prefix_returns_comment_block_before_object() {
+        let src = "// one\n// two\n{\"a\": 1}\n";
+        let prefix = leading_comment_prefix(src);
+        assert_eq!(prefix, "// one\n// two\n");
+    }
+
+    #[test]
+    fn leading_prefix_empty_when_object_starts_at_zero() {
+        let src = "{\"a\": 1}";
+        assert_eq!(leading_comment_prefix(src), "");
+    }
+
+    #[test]
+    fn leading_prefix_for_array_root() {
+        let src = "// hi\n[1,2,3]";
+        assert_eq!(leading_comment_prefix(src), "// hi\n");
+    }
+
+    #[test]
+    fn leading_prefix_returns_full_input_when_no_container() {
+        let src = "// only comments\n// and more\n";
+        assert_eq!(leading_comment_prefix(src), src);
+    }
+
+    #[test]
+    fn leading_prefix_ignores_braces_inside_comments_and_strings() {
+        // The `{` inside the block comment and inside the string must not be
+        // mistaken for the JSON container start.
+        let src = "/* { */// also { in line\n\"prefix\":{\"k\":\"{\"}";
+        // The first real `{` is after the strings/comments — at the object literal.
+        // Note: a leading `"prefix"` outside braces is malformed JSON, but
+        // `leading_comment_prefix` is a pure scanner; it should still return
+        // the substring up to the first unquoted/uncommented `{` or `[`.
+        let prefix = leading_comment_prefix(src);
+        // Prefix must include the comments and the `"prefix":` token, and
+        // must NOT include the first `{` itself.
+        assert!(prefix.starts_with("/* { */"));
+        assert!(prefix.ends_with(":"));
+        assert!(!prefix.contains("\"k\""));
+    }
+
+    #[test]
+    fn apply_prefix_handles_empty_and_separator_cases() {
+        assert_eq!(apply_prefix("", "{}".to_string()), "{}");
+        assert_eq!(apply_prefix("// hi\n", "{}".to_string()), "// hi\n{}");
+        assert_eq!(apply_prefix("// hi", "{}".to_string()), "// hi\n{}");
+    }
+}

--- a/crates/amplihack-cli/src/copilot_setup/mod.rs
+++ b/crates/amplihack-cli/src/copilot_setup/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod fs_helpers;
 mod hooks;
+mod jsonc;
 mod staging;
 
 use anyhow::{Context, Result};
@@ -323,6 +324,68 @@ mod tests {
         assert!(script.contains("\"$HOOKS_BIN\" workflow-classification-reminder"));
         assert!(script.contains("\"$HOOKS_BIN\" user-prompt-submit"));
         assert!(!script.contains("python3"));
+    }
+
+    #[test]
+    fn ensure_copilot_home_preserves_leading_jsonc_comments_in_config() {
+        // Regression: GitHub Copilot CLI writes ~/.copilot/config.json as
+        // JSONC with a two-line `//` header. amplihack must (a) parse it
+        // without choking on the comments and (b) preserve the comment block
+        // when it writes the file back after registering the plugin and
+        // wiring user-level hooks.
+        let _home_guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        let previous_home = crate::test_support::set_home(temp.path());
+        let repo_root = temp.path().join("repo");
+        fs::create_dir_all(&repo_root).unwrap();
+        let previous_cwd = crate::test_support::set_cwd(&repo_root).unwrap();
+
+        // Seed a JSONC config.json mirroring what real Copilot CLI writes.
+        let copilot_dir = temp.path().join(".copilot");
+        fs::create_dir_all(&copilot_dir).unwrap();
+        let seeded = "// User settings belong in settings.json.\n\
+                      // This file is managed automatically.\n\
+                      {}\n";
+        fs::write(copilot_dir.join("config.json"), seeded).unwrap();
+
+        // Minimal staged framework so ensure_copilot_home_staged() succeeds.
+        let staged = temp.path().join(".amplihack/.claude");
+        fs::create_dir_all(staged.join("commands/amplihack")).unwrap();
+        fs::write(staged.join("commands/amplihack/dev.md"), "command").unwrap();
+        fs::write(
+            staged.join("commands/amplihack/plugin.json"),
+            "{\"name\":\"amplihack\"}",
+        )
+        .unwrap();
+
+        ensure_copilot_home_staged().unwrap();
+
+        let after = fs::read_to_string(copilot_dir.join("config.json")).unwrap();
+        assert!(
+            after.starts_with("// User settings belong in settings.json.\n// This file is managed automatically.\n"),
+            "leading JSONC comment block was not preserved; got:\n{after}"
+        );
+
+        // Strip comments before parsing to verify the JSON body is valid and
+        // the plugin/hook entries were merged in.
+        let body = jsonc::strip_jsonc_comments(&after);
+        let config: serde_json::Value = serde_json::from_str(&body).expect("body parses as JSON");
+        let plugins = config["plugins"].as_array().expect("plugins array");
+        assert!(
+            plugins
+                .iter()
+                .any(|p| p.get("name").and_then(|n| n.as_str()) == Some("amplihack")),
+            "amplihack plugin entry missing: {config}"
+        );
+        assert!(
+            config["hooks"].is_object(),
+            "user-level hooks were not merged: {config}"
+        );
+
+        crate::test_support::restore_cwd(&previous_cwd).unwrap();
+        crate::test_support::restore_home(previous_home);
     }
 
     #[test]

--- a/crates/amplihack-cli/src/copilot_setup/staging.rs
+++ b/crates/amplihack-cli/src/copilot_setup/staging.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use std::fs;
 use std::path::Path;
 
-use super::fs_helpers;
+use super::{fs_helpers, jsonc};
 
 pub(super) fn stage_agents(source_agents: &Path, copilot_home: &Path) -> Result<usize> {
     let dest = copilot_home.join("agents").join("amplihack");
@@ -118,10 +118,20 @@ pub(super) fn register_plugin(source_commands: &Path, copilot_home: &Path) -> Re
     )?;
 
     let config_path = copilot_home.join("config.json");
-    let mut config: Value = if config_path.is_file() {
-        serde_json::from_str(&fs::read_to_string(&config_path)?)?
+    let (mut config, prefix): (Value, String) = if config_path.is_file() {
+        let raw = fs::read_to_string(&config_path)
+            .with_context(|| format!("read {}", config_path.display()))?;
+        let prefix = jsonc::leading_comment_prefix(&raw).to_string();
+        let stripped = jsonc::strip_jsonc_comments(&raw);
+        let value = if stripped.trim().is_empty() {
+            json!({})
+        } else {
+            serde_json::from_str(&stripped)
+                .with_context(|| format!("parse {}", config_path.display()))?
+        };
+        (value, prefix)
     } else {
-        json!({})
+        (json!({}), String::new())
     };
 
     let plugins = config
@@ -145,7 +155,9 @@ pub(super) fn register_plugin(source_commands: &Path, copilot_home: &Path) -> Re
         }));
     }
 
-    fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+    let body = serde_json::to_string_pretty(&config)?;
+    fs::write(&config_path, jsonc::apply_prefix(&prefix, body))
+        .with_context(|| format!("write {}", config_path.display()))?;
 
     Ok(true)
 }


### PR DESCRIPTION
## Problem

GitHub Copilot CLI writes `~/.copilot/config.json` as JSONC with a two-line `//` header. amplihack's copilot setup was passing the raw file straight to `serde_json::from_str`, causing immediate failure on any user who had launched Copilot CLI before amplihack.

## Fix

* New `copilot_setup::jsonc` module with `strip_jsonc_comments` and `leading_comment_prefix`. Single-pass byte-scan state machine, string-literal aware (handles `\\"` escapes), no new dependencies.
* `register_plugin` (staging.rs) and `write_user_level_hooks` (hooks.rs) now strip comments before parsing and re-prepend the captured leading comment block on write-back, so the user's header survives every amplihack-managed mutation.
* New `apply_prefix` helper centralizes prefix+body concatenation with newline-separator insertion.
* Eliminated two unnecessary deep clones in `write_user_level_hooks` while the function was being touched.

## Tests

* 11 inline unit tests in `jsonc.rs` covering: leading `//` block, inline `//` after value, `/* */` blocks, `//` and `/* */` inside string literals, escaped quotes, empty input, line comment at EOF without newline, unterminated string at EOF, unterminated block comment at EOF, prefix detection for object/array/no-container, and prefix that ignores braces inside comments/strings.
* End-to-end regression test in `mod.rs` (`ensure_copilot_home_preserves_leading_jsonc_comments_in_config`) seeds a real Copilot-style JSONC `config.json`, runs `ensure_copilot_home_staged()`, and asserts (a) the leading comment block is byte-preserved, (b) the `amplihack` plugin entry is registered, and (c) user-level `hooks` are merged.
* `apply_prefix` unit test for empty/no-newline/with-newline cases.

## Out of scope

External JSONC crate, trailing commas / JSON5, preserving inline/trailing comments on write-back, refactors outside `copilot_setup/`. Pre-existing test failure in `update::tests::should_not_skip_update_check_for_launch_subcommands` is unrelated and present on `main`.

## Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings   # clean
TMPDIR=/tmp cargo test -p amplihack-cli --lib copilot_setup  # 23/23 pass
```