### PR TITLE
fix(npm): invert cache fast-path so npx serves freshest binary (#333)

### DIFF
--- a/npm/lib/bootstrap.js
+++ b/npm/lib/bootstrap.js
@@ -20,6 +20,10 @@ const ALLOWED_DOWNLOAD_PREFIXES = [
 const INSTALL_LOCK_FILE = '.install-lock';
 const INSTALL_LOCK_TIMEOUT_MS = 120000;
 const INSTALL_LOCK_POLL_MS = 200;
+const LATEST_TAG_CACHE_FILE = '.latest-tag.json';
+const LATEST_TAG_CACHE_SCHEMA = 1;
+const DEFAULT_LATEST_TAG_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const TAG_REGEX = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/u;
 
 function binaryFilename(name, platform = process.platform) {
   return platform === 'win32' ? `${name}.exe` : name;
@@ -60,6 +64,94 @@ function cacheRoot(version, platform = process.platform, arch = process.arch) {
     return path.resolve(explicit);
   }
   return path.join(os.homedir(), '.cache', 'amplihack', 'npm-wrapper', version, `${platform}-${arch}`);
+}
+
+/**
+ * Directory where shared (cross-version) wrapper state lives, including the
+ * latest-tag cache. Located one level above the per-version cacheRoot so it
+ * survives `npx` reinstalls that swap pkg.version. Honors the same
+ * AMPLIHACK_NPM_WRAPPER_CACHE override as cacheRoot for test isolation.
+ */
+function cacheStateRoot() {
+  const explicit = process.env.AMPLIHACK_NPM_WRAPPER_CACHE;
+  if (explicit) {
+    return path.resolve(explicit);
+  }
+  return path.join(os.homedir(), '.cache', 'amplihack', 'npm-wrapper');
+}
+
+function latestTagCachePath() {
+  return path.join(cacheStateRoot(), LATEST_TAG_CACHE_FILE);
+}
+
+function latestTagTtlMs() {
+  const raw = process.env.AMPLIHACK_NPM_LATEST_TTL_MS;
+  if (raw === undefined || raw === '') {
+    return DEFAULT_LATEST_TAG_TTL_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_LATEST_TAG_TTL_MS;
+  }
+  return parsed;
+}
+
+function readLatestTagCache(now = Date.now()) {
+  const ttl = latestTagTtlMs();
+  if (ttl === 0) {
+    return null;
+  }
+  let raw;
+  try {
+    raw = fs.readFileSync(latestTagCachePath(), 'utf8');
+  } catch {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+  if (parsed.schema !== LATEST_TAG_CACHE_SCHEMA) {
+    return null;
+  }
+  if (typeof parsed.tag !== 'string' || !TAG_REGEX.test(parsed.tag)) {
+    return null;
+  }
+  if (typeof parsed.fetched_at !== 'number' || !Number.isFinite(parsed.fetched_at)) {
+    return null;
+  }
+  if (now - parsed.fetched_at > ttl) {
+    return null;
+  }
+  return parsed.tag;
+}
+
+function writeLatestTagCache(tag, now = Date.now()) {
+  if (latestTagTtlMs() === 0) {
+    return;
+  }
+  if (typeof tag !== 'string' || !TAG_REGEX.test(tag)) {
+    return;
+  }
+  const dir = cacheStateRoot();
+  const file = latestTagCachePath();
+  const tmp = `${file}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(tmp, JSON.stringify({
+      schema: LATEST_TAG_CACHE_SCHEMA,
+      tag,
+      fetched_at: now,
+    }));
+    fs.renameSync(tmp, file);
+  } catch {
+    try { fs.unlinkSync(tmp); } catch { /* ignore */ }
+  }
 }
 
 function hasLocalCargoWorkspace(root) {
@@ -247,16 +339,28 @@ async function resolveLatestReleaseTag(fallbackVersion) {
   if (process.env.AMPLIHACK_NPM_NO_LATEST === '1') {
     return fallbackVersion;
   }
+  // Check TTL cache before hitting the network.
+  const cached = readLatestTagCache();
+  if (cached) {
+    return cached;
+  }
   const url = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
   try {
     const body = await download(url);
     const data = JSON.parse(body.toString('utf8'));
     const tag = typeof data.tag_name === 'string' ? data.tag_name.replace(/^v/, '') : '';
-    if (!/^\d+\.\d+\.\d+/.test(tag)) {
+    if (!TAG_REGEX.test(tag)) {
+      // Network response was unparseable: fall back without poisoning the cache.
+      process.stderr.write(`amplihack: could not parse latest release tag, using fallback v${fallbackVersion}\n`);
       return fallbackVersion;
     }
+    writeLatestTagCache(tag);
     return tag;
-  } catch {
+  } catch (error) {
+    // Network failure: fall back to pkg.version. Do NOT write to cache so the
+    // next call retries. Warn once so the user knows the version may be stale.
+    const reason = error && error.message ? error.message : 'unknown error';
+    process.stderr.write(`amplihack: failed to resolve latest release (${reason}); using fallback v${fallbackVersion}\n`);
     return fallbackVersion;
   }
 }
@@ -334,23 +438,16 @@ async function buildFromSource(root, installRoot) {
 }
 
 async function ensureNativeBinaries({ root, version }) {
-  // Fast path: check the package.json version cache first to avoid a
-  // network round-trip when binaries are already installed. The GitHub API
-  // call is deferred until we know the local cache is stale.
-  const knownRoot = cacheRoot(version);
-  const knownBinDir = path.join(knownRoot, 'bin');
-  const knownMain = path.join(knownBinDir, binaryFilename('amplihack'));
-  const knownHooks = path.join(knownBinDir, binaryFilename('amplihack-hooks'));
-  if (fs.existsSync(knownMain) && fs.existsSync(knownHooks)) {
-    return { mainBinary: knownMain, hooksBinary: knownHooks, installRoot: knownRoot };
-  }
-
-  // Cache miss — resolve the freshest available release tag. The
-  // package.json `version` field can drift behind the latest published
-  // release (the release workflow publishes new tags without rewriting
-  // package.json), so trusting `pkg.version` results in npx installs that
-  // ship a stale binary. Falling back to `version` keeps offline / API-
-  // rate-limited installs working.
+  // Resolve the latest published release tag first. The package.json `version`
+  // field can drift behind the latest published release (the release workflow
+  // publishes new tags without rewriting package.json), so trusting
+  // `pkg.version` as the cache key results in npx installs serving stale
+  // binaries even after a new release ships (issue #333).
+  //
+  // resolveLatestReleaseTag is cheap when the TTL cache is warm (no network
+  // call), so this runs in milliseconds on repeat invocations. On cache miss
+  // it makes one GitHub API call, with graceful fallback to `version` on
+  // network failure.
   const effectiveVersion = await resolveLatestReleaseTag(version);
   const installRoot = cacheRoot(effectiveVersion);
   const binDir = path.join(installRoot, 'bin');
@@ -412,17 +509,21 @@ module.exports = {
   acquireInstallLock,
   binaryFilename,
   cacheRoot,
+  cacheStateRoot,
   copyFileAtomic,
   ensureNativeBinaries,
   findBinary,
   hasLocalCargoWorkspace,
   installFromRelease,
+  latestTagCachePath,
   packageRoot,
   parseChecksumHex,
+  readLatestTagCache,
   releaseTargetFor,
   releaseUrls,
   resolveLatestReleaseTag,
   runAmplihack,
   validateDownloadUrl,
   verifyArchiveChecksum,
+  writeLatestTagCache,
 };

--- a/npm/test/bootstrap.test.js
+++ b/npm/test/bootstrap.test.js
@@ -10,16 +10,20 @@ const { setTimeout: delay } = require('node:timers/promises');
 const {
   acquireInstallLock,
   binaryFilename,
+  cacheStateRoot,
   copyFileAtomic,
   findBinary,
   hasLocalCargoWorkspace,
+  latestTagCachePath,
   packageRoot,
   parseChecksumHex,
+  readLatestTagCache,
   releaseTargetFor,
   releaseUrls,
   resolveLatestReleaseTag,
   validateDownloadUrl,
   verifyArchiveChecksum,
+  writeLatestTagCache,
 } = require('../lib/bootstrap');
 
 test('release target mapping matches published targets', () => {
@@ -155,3 +159,104 @@ test('resolveLatestReleaseTag falls back when network disabled', async () => {
     }
   }
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #333: TTL cache for latest release tag.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function withIsolatedCache(testFn) {
+  return async (t) => {
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'amplihack-tagcache-'));
+    const prevCache = process.env.AMPLIHACK_NPM_WRAPPER_CACHE;
+    const prevVersion = process.env.AMPLIHACK_NPM_VERSION;
+    const prevNoLatest = process.env.AMPLIHACK_NPM_NO_LATEST;
+    const prevTtl = process.env.AMPLIHACK_NPM_LATEST_TTL_MS;
+    process.env.AMPLIHACK_NPM_WRAPPER_CACHE = tempDir;
+    delete process.env.AMPLIHACK_NPM_VERSION;
+    delete process.env.AMPLIHACK_NPM_NO_LATEST;
+    delete process.env.AMPLIHACK_NPM_LATEST_TTL_MS;
+    try {
+      await testFn(t, tempDir);
+    } finally {
+      if (prevCache === undefined) delete process.env.AMPLIHACK_NPM_WRAPPER_CACHE;
+      else process.env.AMPLIHACK_NPM_WRAPPER_CACHE = prevCache;
+      if (prevVersion === undefined) delete process.env.AMPLIHACK_NPM_VERSION;
+      else process.env.AMPLIHACK_NPM_VERSION = prevVersion;
+      if (prevNoLatest === undefined) delete process.env.AMPLIHACK_NPM_NO_LATEST;
+      else process.env.AMPLIHACK_NPM_NO_LATEST = prevNoLatest;
+      if (prevTtl === undefined) delete process.env.AMPLIHACK_NPM_LATEST_TTL_MS;
+      else process.env.AMPLIHACK_NPM_LATEST_TTL_MS = prevTtl;
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+    }
+  };
+}
+
+test('latest-tag cache lives in cacheStateRoot, not per-version cacheRoot', withIsolatedCache(async () => {
+  const expected = path.join(cacheStateRoot(), '.latest-tag.json');
+  assert.equal(latestTagCachePath(), expected);
+}));
+
+test('readLatestTagCache returns null when cache file is missing', withIsolatedCache(async () => {
+  assert.equal(readLatestTagCache(), null);
+}));
+
+test('writeLatestTagCache + readLatestTagCache roundtrip a valid tag', withIsolatedCache(async () => {
+  writeLatestTagCache('1.2.3', 1_000_000);
+  assert.equal(readLatestTagCache(1_000_000), '1.2.3');
+}));
+
+test('readLatestTagCache returns null after TTL expiry', withIsolatedCache(async () => {
+  process.env.AMPLIHACK_NPM_LATEST_TTL_MS = '60000';
+  writeLatestTagCache('1.2.3', 1_000_000);
+  assert.equal(readLatestTagCache(1_000_000), '1.2.3');
+  assert.equal(readLatestTagCache(1_000_000 + 60_001), null);
+}));
+
+test('TTL=0 disables the cache entirely', withIsolatedCache(async () => {
+  process.env.AMPLIHACK_NPM_LATEST_TTL_MS = '0';
+  writeLatestTagCache('1.2.3', 1_000_000);
+  assert.equal(readLatestTagCache(1_000_000), null);
+}));
+
+test('readLatestTagCache rejects corrupt JSON without throwing', withIsolatedCache(async (_, tempDir) => {
+  await fs.promises.writeFile(latestTagCachePath(), 'this is not json{{{');
+  assert.equal(readLatestTagCache(), null);
+}));
+
+test('readLatestTagCache rejects unknown schema versions', withIsolatedCache(async () => {
+  await fs.promises.writeFile(latestTagCachePath(), JSON.stringify({
+    schema: 99,
+    tag: '1.2.3',
+    fetched_at: Date.now(),
+  }));
+  assert.equal(readLatestTagCache(), null);
+}));
+
+test('writeLatestTagCache rejects malformed tags', withIsolatedCache(async () => {
+  writeLatestTagCache('not-a-version', 1_000_000);
+  assert.equal(fs.existsSync(latestTagCachePath()), false);
+}));
+
+test('AMPLIHACK_NPM_NO_LATEST=1 bypasses cache and returns fallback', withIsolatedCache(async () => {
+  // Even with a fresh cache entry, the env var override must win.
+  writeLatestTagCache('9.9.9', Date.now());
+  process.env.AMPLIHACK_NPM_NO_LATEST = '1';
+  const tag = await resolveLatestReleaseTag('1.2.3');
+  assert.equal(tag, '1.2.3');
+}));
+
+test('AMPLIHACK_NPM_VERSION override beats both cache and AMPLIHACK_NPM_NO_LATEST', withIsolatedCache(async () => {
+  writeLatestTagCache('9.9.9', Date.now());
+  process.env.AMPLIHACK_NPM_NO_LATEST = '1';
+  process.env.AMPLIHACK_NPM_VERSION = 'v7.7.7';
+  const tag = await resolveLatestReleaseTag('1.2.3');
+  assert.equal(tag, '7.7.7');
+}));
+
+test('resolveLatestReleaseTag returns cached tag without network call', withIsolatedCache(async () => {
+  // Pre-populate cache; if resolveLatestReleaseTag tried the network here it
+  // would hit api.github.com — but the cache should short-circuit first.
+  writeLatestTagCache('5.6.7', Date.now());
+  const tag = await resolveLatestReleaseTag('1.2.3');
+  assert.equal(tag, '5.6.7');
+}));


### PR DESCRIPTION
## Summary

Fix #333 — `npx amplihack` was serving stale binaries because `ensureNativeBinaries()` short-circuited on `existsSync(cacheRoot(pkg.version))` before `resolveLatestReleaseTag()` could ever run.

## Changes

- `ensureNativeBinaries` now resolves the latest release tag **first**, then checks the cache at the resolved version's path.
- New TTL-cached lookup at `~/.cache/amplihack/npm-wrapper/.latest-tag.json` (default 6h, schema-versioned). Survives per-version cacheRoot churn.
- Network-failure fallback to `pkg.version` is preserved; failures emit a stderr warning and **never** poison the cache.
- New tunable: `AMPLIHACK_NPM_LATEST_TTL_MS` (`0` disables cache).
- All existing escape hatches honored: `AMPLIHACK_NPM_VERSION` (pin) > `AMPLIHACK_NPM_NO_LATEST=1` (bypass).

## Tests

- 24 tests pass (13 baseline + 11 new).
- Covers cache miss/hit/expiry, TTL=0 disable, env precedence, corrupt JSON, unknown schema, malformed tags, and offline path.

```
cd npm && npm test
# tests 24, pass 24, fail 0
```

Closes #333