### PR TITLE
feat(release): add Windows x86_64 to release matrix (#334)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,10 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-latest
             gnu_cross_toolchain: false
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            gnu_cross_toolchain: false
+            exe_suffix: ".exe"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -120,6 +124,7 @@ jobs:
 
       - name: Install GNU cross toolchain
         if: matrix.gnu_cross_toolchain
+        shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
@@ -137,15 +142,22 @@ jobs:
         # bake in whatever `CARGO_PKG_VERSION` happens to be in `Cargo.toml`,
         # which is the bug that caused the self-update prompt to loop forever
         # after a "successful" upgrade.
+        shell: bash
         env:
           AMPLIHACK_RELEASE_VERSION: ${{ needs.version-bump.outputs.version }}
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Package
+        # Use bash on every runner (Git Bash on windows-latest provides
+        # tar+sha256sum) so the .sha256 line format stays byte-identical
+        # across platforms — the npm wrapper's parseChecksumHex relies on
+        # the canonical "<hex>  <file>" sha256sum format. Do NOT switch
+        # this to certutil on Windows; its output is not parseable.
+        shell: bash
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/amplihack dist/ 2>/dev/null || true
-          cp target/${{ matrix.target }}/release/amplihack-hooks dist/ 2>/dev/null || true
+          cp target/${{ matrix.target }}/release/amplihack${{ matrix.exe_suffix }} dist/ 2>/dev/null || true
+          cp target/${{ matrix.target }}/release/amplihack-hooks${{ matrix.exe_suffix }} dist/ 2>/dev/null || true
           cd dist && tar czf ../amplihack-${{ matrix.target }}.tar.gz *
           cd .. && sha256sum amplihack-${{ matrix.target }}.tar.gz > amplihack-${{ matrix.target }}.tar.gz.sha256
 
@@ -207,6 +219,9 @@ jobs:
 
             # macOS ARM64 (Apple Silicon)
             curl -fsSL https://github.com/rysweet/amplihack-rs/releases/download/v${{ needs.version-bump.outputs.version }}/amplihack-aarch64-apple-darwin.tar.gz | tar xz -C ~/.local/bin/
+
+            # Windows x86_64 (PowerShell)
+            # iwr https://github.com/rysweet/amplihack-rs/releases/download/v${{ needs.version-bump.outputs.version }}/amplihack-x86_64-pc-windows-msvc.tar.gz -OutFile amplihack.tar.gz; tar xzf amplihack.tar.gz
             ```
 
             Or: `amplihack update`

--- a/crates/amplihack-cli/src/update/mod.rs
+++ b/crates/amplihack-cli/src/update/mod.rs
@@ -61,6 +61,8 @@ fn supported_release_target() -> Option<&'static str> {
         Some("x86_64-apple-darwin")
     } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
         Some("aarch64-apple-darwin")
+    } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        Some("x86_64-pc-windows-msvc")
     } else {
         None
     }
@@ -69,7 +71,7 @@ fn supported_release_target() -> Option<&'static str> {
 fn required_release_target() -> Result<&'static str> {
     supported_release_target().ok_or_else(|| {
         anyhow!(
-            "self-update is only supported on published release targets (linux/macos x86_64 and aarch64)"
+            "self-update is only supported on published release targets (linux/macos x86_64 and aarch64; windows x86_64)"
         )
     })
 }

--- a/crates/amplihack-cli/src/update/tests.rs
+++ b/crates/amplihack-cli/src/update/tests.rs
@@ -457,3 +457,51 @@ fn ensure_local_bin_on_shell_path_creates_export() {
         None => unsafe { std::env::remove_var("HOME") },
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #334: Windows x86_64 release support.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn release_target_table_covers_windows_x86_64() {
+    // The supported_release_target() function in mod.rs is hard-coded with
+    // cfg!() arms, so we can only directly observe the host's mapping. To
+    // assert the Windows arm exists without conditionally compiling the test
+    // away, we read the source and check the literal arm is present. This is
+    // a static guard — it fails any commit that drops the windows arm.
+    let src = include_str!("mod.rs");
+    assert!(
+        src.contains(r#"target_os = "windows", target_arch = "x86_64""#),
+        "supported_release_target() must include a windows/x86_64 arm",
+    );
+    assert!(
+        src.contains(r#"x86_64-pc-windows-msvc"#),
+        "supported_release_target() must map windows/x86_64 to x86_64-pc-windows-msvc",
+    );
+}
+
+#[test]
+fn binary_filename_appends_exe_on_windows() {
+    // binary_filename() uses cfg!(windows) so on non-Windows hosts it returns
+    // the bare name. Inspect the source to guarantee the .exe arm exists.
+    let src = include_str!("install.rs");
+    assert!(
+        src.contains(r#""amplihack" => "amplihack.exe""#),
+        "binary_filename() must append .exe to amplihack on windows",
+    );
+    assert!(
+        src.contains(r#""amplihack-hooks" => "amplihack-hooks.exe""#),
+        "binary_filename() must append .exe to amplihack-hooks on windows",
+    );
+}
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+#[test]
+fn windows_host_resolves_msvc_target() {
+    assert_eq!(supported_release_target(), Some("x86_64-pc-windows-msvc"));
+    assert_eq!(
+        expected_archive_name().unwrap(),
+        "amplihack-x86_64-pc-windows-msvc.tar.gz"
+    );
+    assert_eq!(binary_filename("amplihack"), "amplihack.exe");
+}

--- a/npm/lib/bootstrap.js
+++ b/npm/lib/bootstrap.js
@@ -38,6 +38,9 @@ function releaseTargetFor(platform = process.platform, arch = process.arch) {
   if (platform === 'darwin' && arch === 'arm64') {
     return 'aarch64-apple-darwin';
   }
+  if (platform === 'win32' && arch === 'x64') {
+    return 'x86_64-pc-windows-msvc';
+  }
   return null;
 }
 

--- a/npm/test/bootstrap.test.js
+++ b/npm/test/bootstrap.test.js
@@ -27,7 +27,18 @@ test('release target mapping matches published targets', () => {
   assert.equal(releaseTargetFor('linux', 'arm64'), 'aarch64-unknown-linux-gnu');
   assert.equal(releaseTargetFor('darwin', 'x64'), 'x86_64-apple-darwin');
   assert.equal(releaseTargetFor('darwin', 'arm64'), 'aarch64-apple-darwin');
-  assert.equal(releaseTargetFor('win32', 'x64'), null);
+  assert.equal(releaseTargetFor('win32', 'x64'), 'x86_64-pc-windows-msvc');
+  assert.equal(releaseTargetFor('win32', 'arm64'), null);
+  assert.equal(releaseTargetFor('freebsd', 'x64'), null);
+});
+
+test('windows release URL targets the canonical msvc artifact', () => {
+  const target = releaseTargetFor('win32', 'x64');
+  const urls = releaseUrls('1.2.3', target);
+  assert.equal(
+    urls.archiveUrl,
+    'https://github.com/rysweet/amplihack-rs/releases/download/v1.2.3/amplihack-x86_64-pc-windows-msvc.tar.gz',
+  );
 });
 
 test('binary filename adds .exe only on windows', () => {


### PR DESCRIPTION
## Summary

Closes #334. Windows users can now install amplihack via `npx amplihack`, `amplihack update`, and direct release-tarball download.

## Changes

- **release.yml**: new `windows-latest` matrix row for `x86_64-pc-windows-msvc`. `shell: bash` on every step so packaging emits byte-identical `tar.gz` and `sha256sum` output across runners. `certutil` is **not** used — its output is not parseable by the npm wrapper's `parseChecksumHex`.
- **update/mod.rs**: add windows/x86_64 arm to `supported_release_target()`.
- **bootstrap.js**: add `win32/x64` arm to `releaseTargetFor()`. Existing `binaryFilename` already handles the `.exe` suffix.
- Release notes include a PowerShell install snippet.
- 2 new Rust tests + 2 new Node tests pin the new platform mappings.

## Out of scope (follow-ups)

- Windows ARM64 (`win32 arm64` still returns `null`)
- Windows code-signing (.exe is unsigned)
- session-tree on Windows (unsupported this iteration)

## Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings   # clean
TMPDIR=/tmp cargo test -p amplihack-cli --lib -- update::tests  # baseline + new tests pass
cd npm && npm test                                            # 14/14
```

(Two pre-existing test failures in `update::tests::should_skip_update_check_*` are unrelated to this PR — verified by stashing changes and re-running on `origin/main`.)

Closes #334