### PR TITLE
feat(cli): port session_tree.py to native Rust as 'amplihack session-tree' (closes #331)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "clap_complete",
  "cxx-build",
  "flate2",
+ "fs4",
  "lbug",
  "libc",
  "lru",
@@ -140,6 +141,7 @@ dependencies = [
  "toml",
  "tracing",
  "ureq",
+ "uuid",
  "zip",
 ]
 
@@ -888,6 +890,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2544,6 +2556,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -250,41 +250,28 @@ steps:
     type: "bash"
     condition: "'Development' in task_type or 'Investigation' in task_type or task_type == ''"
     command: |
-      TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
       # #283: replace python3 uuid with /proc/sys/kernel/random/uuid (POSIX)
       SESSION_ID=$(tr -d '-' < /proc/sys/kernel/random/uuid | head -c 8)
 
-      if [ -f "$TREE_SCRIPT" ]; then
-        # Register this session — atomic check+register under lock
-        if OUTPUT=$(python3 "$TREE_SCRIPT" register "$SESSION_ID" 2>&1); then
-          # Output: "TREE_ID=abc123 DEPTH=0"
-          TREE_ID=$(echo "$OUTPUT" | grep -oE 'TREE_ID=[A-Za-z0-9_-]+' | head -1 | cut -d= -f2)
-          DEPTH_STR=$(echo "$OUTPUT" | grep -oE 'DEPTH=[0-9]+' | head -1 | cut -d= -f2)
-          DEPTH_VAL=${DEPTH_STR:-0}
-          # Validate extracted values
-          if ! echo "$TREE_ID" | grep -qE '^[A-Za-z0-9_-]+$'; then
-            # #283: replace python3 json with printf (inputs are fixed literals)
-            printf '{"session_id":"error","tree_id":"error","depth":0,"status":"registration_failed","error":"invalid tree_id extracted"}\n'
-            exit 0
-          fi
-          # #283: DEPTH_VAL is already validated as numeric above; SESSION_ID
-          # and TREE_ID are both constrained to [A-Za-z0-9_-], safe for JSON
-          printf '{"session_id":"%s","tree_id":"%s","depth":%d,"status":"ok"}\n' "$SESSION_ID" "$TREE_ID" "$DEPTH_VAL"
-        else
-          # Registration failed (capacity exceeded or depth limit) — encode structured error
-          echo "NOTE: Session registration failed — proceeding without recursion tracking." >&2
-          printf '{"session_id":"none","tree_id":"none","depth":0,"status":"registration_failed"}\n'
+      # #331: native Rust subcommand replaces python3 $TREE_SCRIPT register
+      if OUTPUT=$(amplihack session-tree register "$SESSION_ID" 2>&1); then
+        # Output: "TREE_ID=abc123 DEPTH=0"
+        TREE_ID=$(echo "$OUTPUT" | grep -oE 'TREE_ID=[A-Za-z0-9_-]+' | head -1 | cut -d= -f2)
+        DEPTH_STR=$(echo "$OUTPUT" | grep -oE 'DEPTH=[0-9]+' | head -1 | cut -d= -f2)
+        DEPTH_VAL=${DEPTH_STR:-0}
+        # Validate extracted values
+        if ! echo "$TREE_ID" | grep -qE '^[A-Za-z0-9_-]+$'; then
+          # #283: replace python3 json with printf (inputs are fixed literals)
+          printf '{"session_id":"error","tree_id":"error","depth":0,"status":"registration_failed","error":"invalid tree_id extracted"}\n'
+          exit 0
         fi
+        # #283: DEPTH_VAL is already validated as numeric above; SESSION_ID
+        # and TREE_ID are both constrained to [A-Za-z0-9_-], safe for JSON
+        printf '{"session_id":"%s","tree_id":"%s","depth":%d,"status":"ok"}\n' "$SESSION_ID" "$TREE_ID" "$DEPTH_VAL"
       else
-        # No session_tree.py — generate a tree_id from env or fresh uuid
-        TREE_ID=$(echo "${AMPLIHACK_TREE_ID:-}" | grep -E '^[A-Za-z0-9_-]+$' | head -1)
-        if [ -z "$TREE_ID" ]; then
-          TREE_ID=$(tr -d '-' < /proc/sys/kernel/random/uuid | head -c 8)
-        fi
-        DEPTH_RAW="${AMPLIHACK_SESSION_DEPTH:-0}"
-        # Validate it's an integer (default to 0 if not)
-        DEPTH_VAL=$(echo "$DEPTH_RAW" | grep -E '^[0-9]+$' || echo '0')
-        printf '{"session_id":"%s","tree_id":"%s","depth":%d,"status":"no_tree_script"}\n' "$SESSION_ID" "$TREE_ID" "$DEPTH_VAL"
+        # Registration failed (capacity exceeded or depth limit) — encode structured error
+        echo "NOTE: Session registration failed — proceeding without recursion tracking." >&2
+        printf '{"session_id":"none","tree_id":"none","depth":0,"status":"registration_failed"}\n'
       fi
     output: "session_info"
 
@@ -935,7 +922,6 @@ steps:
     command: |
       # FIX (#469/#311): Use env var — safe against injection and word-splitting.
       SESSION_JSON="$SESSION_INFO"
-      TREE_SCRIPT="$(amplihack resolve-bundle-asset session-tree-path 2>/dev/null || true)"
       HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir 2>/dev/null || true)"
       # #283: parse session fields via jq instead of inline Python.
       SESSION_ID=$(printf '%s' "$SESSION_JSON" | jq -r '.session_id // ""' 2>/dev/null || echo "")
@@ -949,8 +935,9 @@ steps:
       TREE_ID=${TREE_ID:-}
       STATUS=${STATUS:-}
 
-      if [ -n "$SESSION_ID" ] && [ "$STATUS" = "ok" ] && [ -f "$TREE_SCRIPT" ]; then
-        AMPLIHACK_TREE_ID="$TREE_ID" python3 "$TREE_SCRIPT" complete "$SESSION_ID"
+      # #331: native Rust subcommand replaces python3 $TREE_SCRIPT complete
+      if [ -n "$SESSION_ID" ] && [ "$STATUS" = "ok" ]; then
+        AMPLIHACK_TREE_ID="$TREE_ID" amplihack session-tree complete "$SESSION_ID"
         echo "Session $SESSION_ID completed in tree $TREE_ID"
       else
         echo "No session to complete (status: ${STATUS:-empty})"

--- a/crates/amplihack-cli/Cargo.toml
+++ b/crates/amplihack-cli/Cargo.toml
@@ -37,6 +37,8 @@ lbug = "0.15.3"
 rusqlite = { version = "0.38.0", features = ["bundled"] }
 prost = "0.13"
 lru = { workspace = true }
+fs4 = { version = "0.13", features = ["sync"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -343,4 +343,15 @@ pub enum Commands {
         #[command(subcommand)]
         command: crate::commands::orch::OrchCommands,
     },
+
+    /// Session-tree management (atomic recursion / fan-out tracking).
+    ///
+    /// Native Rust port of `amplifier-bundle/tools/session_tree.py`.
+    /// Replaces `python3 $TREE_SCRIPT register|complete` invocations in
+    /// `amplifier-bundle/recipes/smart-orchestrator.yaml` (issue #331).
+    #[command(name = "session-tree")]
+    SessionTree {
+        #[command(subcommand)]
+        command: crate::commands::session_tree::SessionTreeCommands,
+    },
 }

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod plugin;
 pub mod query_code;
 pub mod recipe;
 pub mod rustyclawd;
+pub mod session_tree;
 pub mod uvx_help;
 
 use crate::{
@@ -315,6 +316,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
         }
         Commands::Multitask { command } => dispatch_multitask(command),
         Commands::Orch { command } => orch::dispatch(command),
+        Commands::SessionTree { command } => session_tree::run(command),
     }
 }
 

--- a/crates/amplihack-cli/src/commands/session_tree/mod.rs
+++ b/crates/amplihack-cli/src/commands/session_tree/mod.rs
@@ -1,0 +1,401 @@
+//! `amplihack session-tree` — native Rust port of `session_tree.py`.
+//!
+//! Tracks active orchestration sessions in a tree structure to bound
+//! recursion depth and concurrent fan-out. The `register`, `complete`,
+//! `status`, and `check` subcommands match the byte-exact stdout contract
+//! consumed by `amplifier-bundle/recipes/smart-orchestrator.yaml`.
+//!
+//! Stdout contract (one line per command, no trailing whitespace except `\n`):
+//! * `register` → `TREE_ID=<tree_id> DEPTH=<n>\n` (exit 0) or nothing on
+//!   registration failure (exit 1, with the reason on stderr)
+//! * `complete` → no stdout (exit 0)
+//! * `status`   → JSON object, multiline (pretty) (exit 0)
+//! * `check`    → `ALLOWED\n` (exit 0) or `BLOCKED:<reason>\n` (exit 2)
+//!
+//! Diagnostic output goes to stderr via `eprintln!` to keep stdout
+//! parser-friendly.
+
+pub mod state;
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use serde_json::json;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use state::{
+    DEFAULT_MAX_DEPTH, DEFAULT_MAX_SESSIONS, MAX_DEPTH_CEILING, SessionEntry, SessionStatus,
+    load_state, save_state, state_dir, state_path_in, validate_tree_id, with_locked_tree,
+};
+
+/// `amplihack session-tree <subcommand>`
+#[derive(Subcommand, Debug)]
+pub enum SessionTreeCommands {
+    /// Register a session in the current tree.
+    Register {
+        /// Session ID to register. If omitted, a random 8-hex-char id is generated.
+        session_id: Option<String>,
+        /// Optional parent session ID.
+        parent_id: Option<String>,
+    },
+    /// Mark a session as completed.
+    Complete {
+        /// Session ID to mark complete.
+        session_id: String,
+    },
+    /// Print a JSON status summary for the current tree.
+    Status {
+        /// Tree ID (defaults to $AMPLIHACK_TREE_ID).
+        tree_id: Option<String>,
+    },
+    /// Check whether a new child session can be spawned. Exit 0 + stdout
+    /// "ALLOWED" if allowed, exit 2 + stdout "BLOCKED:<reason>" if not.
+    Check,
+}
+
+#[derive(Debug, Clone)]
+struct TreeContext {
+    tree_id: Option<String>,
+    depth: u32,
+    max_depth: u32,
+    max_sessions: u32,
+}
+
+fn tree_context() -> TreeContext {
+    let tree_id = std::env::var("AMPLIHACK_TREE_ID")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let depth = std::env::var("AMPLIHACK_SESSION_DEPTH")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(0);
+    let max_depth = std::env::var("AMPLIHACK_MAX_DEPTH")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(DEFAULT_MAX_DEPTH)
+        .min(MAX_DEPTH_CEILING);
+    let max_sessions = std::env::var("AMPLIHACK_MAX_SESSIONS")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(DEFAULT_MAX_SESSIONS);
+    TreeContext {
+        tree_id,
+        depth,
+        max_depth,
+        max_sessions,
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn random_id() -> String {
+    uuid::Uuid::new_v4().simple().to_string()[..8].to_string()
+}
+
+/// Public entry point dispatched from `commands::dispatch`.
+pub fn run(cmd: SessionTreeCommands) -> Result<()> {
+    let ctx = tree_context();
+    match cmd {
+        SessionTreeCommands::Register {
+            session_id,
+            parent_id,
+        } => run_register(ctx, session_id, parent_id),
+        SessionTreeCommands::Complete { session_id } => run_complete(ctx, &session_id),
+        SessionTreeCommands::Status { tree_id } => run_status(ctx, tree_id),
+        SessionTreeCommands::Check => run_check(ctx),
+    }
+}
+
+fn run_register(
+    ctx: TreeContext,
+    session_id: Option<String>,
+    parent_id: Option<String>,
+) -> Result<()> {
+    let session_id = session_id.unwrap_or_else(random_id);
+    validate_tree_id(&session_id).context("invalid session_id")?;
+    if let Some(p) = parent_id.as_deref() {
+        validate_tree_id(p).context("invalid parent_id")?;
+    }
+    let tree_id = match ctx.tree_id.clone() {
+        Some(id) => {
+            validate_tree_id(&id).context("invalid AMPLIHACK_TREE_ID")?;
+            id
+        }
+        None => random_id(),
+    };
+
+    let dir = state_dir()?;
+    let max_sessions = ctx.max_sessions;
+    let max_depth = ctx.max_depth;
+    let depth = ctx.depth;
+    let parent_id_clone = parent_id.clone();
+    let session_id_clone = session_id.clone();
+
+    let outcome: Result<()> = with_locked_tree(&dir, &tree_id, move |path| {
+        let mut state = load_state(path)?;
+        let active = state.active_count();
+        if active >= max_sessions {
+            anyhow::bail!("max_sessions={max_sessions} reached ({active} active)");
+        }
+        if depth > max_depth {
+            anyhow::bail!("depth={depth} exceeds max_depth={max_depth}");
+        }
+        let entry = SessionEntry {
+            depth,
+            parent: parent_id_clone.clone(),
+            status: SessionStatus::Active,
+            started_at: now_secs(),
+            completed_at: None,
+            children: vec![],
+        };
+        state.sessions.insert(session_id_clone.clone(), entry);
+        if let Some(pid) = parent_id_clone.as_ref()
+            && let Some(parent_entry) = state.sessions.get_mut(pid)
+            && !parent_entry.children.contains(&session_id_clone)
+        {
+            parent_entry.children.push(session_id_clone.clone());
+        }
+        save_state(path, state)
+    });
+
+    match outcome {
+        Ok(()) => {
+            // Byte-exact stdout contract consumed by smart-orchestrator.yaml.
+            println!("TREE_ID={tree_id} DEPTH={depth}");
+            Ok(())
+        }
+        Err(err) => {
+            eprintln!("ERROR: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run_complete(ctx: TreeContext, session_id: &str) -> Result<()> {
+    validate_tree_id(session_id).context("invalid session_id")?;
+    let Some(tree_id) = ctx.tree_id.clone() else {
+        // Nothing to complete without a tree — keep parity with Python (silent no-op).
+        return Ok(());
+    };
+    validate_tree_id(&tree_id).context("invalid AMPLIHACK_TREE_ID")?;
+    let dir = state_dir()?;
+    let session_id_owned = session_id.to_string();
+    with_locked_tree(&dir, &tree_id, move |path| {
+        let mut state = load_state(path)?;
+        if let Some(entry) = state.sessions.get_mut(&session_id_owned) {
+            entry.status = SessionStatus::Completed;
+            entry.completed_at = Some(now_secs());
+        }
+        save_state(path, state)
+    })?;
+    Ok(())
+}
+
+fn run_status(ctx: TreeContext, tree_id_arg: Option<String>) -> Result<()> {
+    let tree_id = match tree_id_arg.or(ctx.tree_id) {
+        Some(t) => t,
+        None => {
+            println!("No AMPLIHACK_TREE_ID set");
+            std::process::exit(1);
+        }
+    };
+    validate_tree_id(&tree_id)?;
+    let dir = state_dir()?;
+    let path = state_path_in(&dir, &tree_id)?;
+    let state = load_state(&path)?;
+    let depths: serde_json::Map<String, serde_json::Value> = state
+        .sessions
+        .iter()
+        .map(|(k, v)| (k.clone(), json!(v.depth)))
+        .collect();
+    let payload = json!({
+        "tree_id": tree_id,
+        "active": state.active_ids(),
+        "completed": state.completed_ids(),
+        "depths": depths,
+    });
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+    Ok(())
+}
+
+fn run_check(ctx: TreeContext) -> Result<()> {
+    let child_depth = ctx.depth.saturating_add(1);
+    if child_depth > ctx.max_depth {
+        println!(
+            "BLOCKED:max_depth={} exceeded at depth={}",
+            ctx.max_depth, ctx.depth
+        );
+        std::process::exit(2);
+    }
+    let Some(tree_id) = ctx.tree_id.clone() else {
+        // Root session creating a brand-new tree — always allowed.
+        println!("ALLOWED");
+        return Ok(());
+    };
+    validate_tree_id(&tree_id)?;
+    let dir = state_dir()?;
+    let path = state_path_in(&dir, &tree_id)?;
+    let state = load_state(&path)?;
+    let active = state.active_count();
+    if active >= ctx.max_sessions {
+        println!(
+            "BLOCKED:max_sessions={} reached ({} active)",
+            ctx.max_sessions, active
+        );
+        std::process::exit(2);
+    }
+    println!("ALLOWED");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::state::TreeState;
+    use super::*;
+    use serial_test_lock::SerialLock;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    // Module-private serial lock — TMPDIR mutation must not race other tests.
+    mod serial_test_lock {
+        use std::sync::OnceLock;
+        use std::sync::{Mutex, MutexGuard};
+        pub struct SerialLock;
+        impl SerialLock {
+            pub fn acquire() -> MutexGuard<'static, ()> {
+                static LK: OnceLock<Mutex<()>> = OnceLock::new();
+                LK.get_or_init(|| Mutex::new(()))
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+            }
+        }
+    }
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn isolated_env() -> (TempDir, std::sync::MutexGuard<'static, ()>) {
+        let g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // Anchor to /tmp directly; do NOT mutate the global TMPDIR — other
+        // crate tests anchor `TempDir::new()` against it concurrently.
+        let td = TempDir::new_in("/tmp").unwrap();
+        unsafe {
+            std::env::set_var("AMPLIHACK_SESSION_TREE_DIR", td.path().join("trees"));
+            std::env::remove_var("AMPLIHACK_TREE_ID");
+            std::env::remove_var("AMPLIHACK_SESSION_DEPTH");
+            std::env::remove_var("AMPLIHACK_MAX_DEPTH");
+            std::env::remove_var("AMPLIHACK_MAX_SESSIONS");
+        }
+        (td, g)
+    }
+
+    #[test]
+    fn register_root_creates_tree_and_writes_state() {
+        let _serial = SerialLock::acquire();
+        let (_td, _env) = isolated_env();
+        let ctx = tree_context();
+        // Pre-set tree_id so the test is deterministic.
+        let tree_id = "regroot".to_string();
+        unsafe {
+            std::env::set_var("AMPLIHACK_TREE_ID", &tree_id);
+        }
+        let ctx = TreeContext {
+            tree_id: Some(tree_id.clone()),
+            ..ctx
+        };
+
+        // Inline of run_register's body (cannot easily call run_register
+        // because it prints to stdout and we're testing state shape).
+        let dir = state_dir().unwrap();
+        with_locked_tree(&dir, &tree_id, |path| {
+            let mut state = load_state(path).unwrap();
+            state.sessions.insert(
+                "s1".into(),
+                SessionEntry {
+                    depth: ctx.depth,
+                    parent: None,
+                    status: SessionStatus::Active,
+                    started_at: now_secs(),
+                    completed_at: None,
+                    children: vec![],
+                },
+            );
+            save_state(path, state)
+        })
+        .unwrap();
+        let state = load_state(&state_path_in(&dir, &tree_id).unwrap()).unwrap();
+        assert!(state.sessions.contains_key("s1"));
+    }
+
+    #[test]
+    fn check_at_max_depth_blocks() {
+        let _serial = SerialLock::acquire();
+        let (_td, _env) = isolated_env();
+        unsafe {
+            std::env::set_var("AMPLIHACK_SESSION_DEPTH", "3");
+            std::env::set_var("AMPLIHACK_MAX_DEPTH", "3");
+        }
+        let ctx = tree_context();
+        // child_depth = 4 > max_depth = 3 → BLOCKED.
+        assert_eq!(ctx.depth.saturating_add(1), 4);
+        assert!(ctx.depth.saturating_add(1) > ctx.max_depth);
+    }
+
+    #[test]
+    fn check_below_max_depth_allows_when_no_tree() {
+        let _serial = SerialLock::acquire();
+        let (_td, _env) = isolated_env();
+        unsafe {
+            std::env::set_var("AMPLIHACK_SESSION_DEPTH", "0");
+            std::env::set_var("AMPLIHACK_MAX_DEPTH", "3");
+        }
+        let ctx = tree_context();
+        assert!(ctx.depth.saturating_add(1) <= ctx.max_depth);
+        assert!(ctx.tree_id.is_none());
+    }
+
+    #[test]
+    fn complete_marks_session_done() {
+        let _serial = SerialLock::acquire();
+        let (_td, _env) = isolated_env();
+        let tree_id = "comp".to_string();
+        let dir = state_dir().unwrap();
+        with_locked_tree(&dir, &tree_id, |path| {
+            let mut state = TreeState::default();
+            state.sessions.insert(
+                "x".into(),
+                SessionEntry {
+                    depth: 0,
+                    parent: None,
+                    status: SessionStatus::Active,
+                    started_at: now_secs(),
+                    completed_at: None,
+                    children: vec![],
+                },
+            );
+            save_state(path, state)
+        })
+        .unwrap();
+        unsafe {
+            std::env::set_var("AMPLIHACK_TREE_ID", &tree_id);
+        }
+        let ctx = tree_context();
+        run_complete(ctx, "x").unwrap();
+        let state = load_state(&state_path_in(&dir, &tree_id).unwrap()).unwrap();
+        assert_eq!(state.sessions["x"].status, SessionStatus::Completed);
+        assert!(state.sessions["x"].completed_at.is_some());
+    }
+
+    #[test]
+    fn random_id_format_is_8_lower_hex() {
+        let id = random_id();
+        assert_eq!(id.len(), 8);
+        assert!(
+            id.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+    }
+}

--- a/crates/amplihack-cli/src/commands/session_tree/state.rs
+++ b/crates/amplihack-cli/src/commands/session_tree/state.rs
@@ -1,0 +1,541 @@
+//! On-disk session-tree state management.
+//!
+//! The session-tree state is kept under `$TMPDIR/amplihack-session-trees/`,
+//! one JSON file per tree (`{tree_id}.json`). Concurrent access is serialised
+//! via two layers of locking:
+//!
+//! * an intra-process [`std::sync::Mutex`] keyed by tree_id, so threads in
+//!   the same process cannot race each other while holding the file lock
+//!   (file lock semantics on POSIX are per-process, not per-thread)
+//! * a cross-process exclusive file lock acquired via [`fs4`] on a sidecar
+//!   `{tree_id}.lock` file
+//!
+//! All state writes go through `with_locked_tree` to guarantee atomic
+//! check-then-write semantics. State files are written atomically via
+//! tmpfile + rename.
+
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::fs::Permissions;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, anyhow, bail};
+use fs4::fs_std::FileExt;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+/// Directory name (under `TMPDIR` or `/tmp`) where tree state files live.
+const STATE_DIR_NAME: &str = "amplihack-session-trees";
+
+/// Maximum permitted size of a single tree state file (1 MiB). Protects
+/// against pathological growth or a malicious actor planting a huge file
+/// before we can read it.
+const MAX_STATE_FILE_BYTES: u64 = 1024 * 1024;
+
+/// Default maximum recursion depth (root = depth 0).
+pub const DEFAULT_MAX_DEPTH: u32 = 3;
+
+/// Default cap on simultaneously-active sessions per tree.
+pub const DEFAULT_MAX_SESSIONS: u32 = 10;
+
+/// Hard ceiling on `max_depth` to prevent fork-bomb-style misconfiguration.
+pub const MAX_DEPTH_CEILING: u32 = 32;
+
+/// Stale-pruning thresholds (matches the original Python contract).
+const COMPLETED_MAX_AGE_SECS: u64 = 24 * 60 * 60;
+const ACTIVE_MAX_AGE_SECS: u64 = 4 * 60 * 60;
+
+fn tree_id_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^[A-Za-z0-9_-]{1,64}$").expect("tree_id regex compiles"))
+}
+
+/// Validate a tree_id (or session_id, which uses the same alphabet).
+///
+/// Returns the input on success. Rejects anything that could be used for
+/// path traversal or shell injection.
+pub fn validate_tree_id(id: &str) -> Result<&str> {
+    if id.is_empty() {
+        bail!("tree_id cannot be empty");
+    }
+    if !tree_id_regex().is_match(id) {
+        bail!("invalid tree_id {id:?}: must match [A-Za-z0-9_-]{{1,64}}");
+    }
+    Ok(id)
+}
+
+/// Resolve the state directory, creating it with mode 0700 if necessary.
+pub fn state_dir() -> Result<PathBuf> {
+    // `AMPLIHACK_SESSION_TREE_DIR` is an internal override (used by tests and
+    // anyone who wants to relocate state without disturbing the global TMPDIR).
+    // Production callers should leave it unset; the recipe reads/writes via
+    // the same `amplihack session-tree` binary, so the env-var contract stays
+    // self-consistent across parent and child processes.
+    let dir = if let Some(explicit) = std::env::var_os("AMPLIHACK_SESSION_TREE_DIR") {
+        PathBuf::from(explicit)
+    } else {
+        let base = std::env::var_os("TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        base.join(STATE_DIR_NAME)
+    };
+    fs::create_dir_all(&dir)
+        .with_context(|| format!("failed to create state dir {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        // Best-effort 0700; ignore if we don't own the directory.
+        let _ = fs::set_permissions(&dir, Permissions::from_mode(0o700));
+    }
+    Ok(dir)
+}
+
+/// Compute the path to a tree's state file under the given directory.
+///
+/// Validates the tree_id and verifies that the resolved path stays under
+/// `dir` (defence-in-depth — the regex already excludes `/` and `..`).
+pub fn state_path_in(dir: &Path, tree_id: &str) -> Result<PathBuf> {
+    validate_tree_id(tree_id)?;
+    let candidate = dir.join(format!("{tree_id}.json"));
+    let canonical_dir = fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+    if let Some(parent) = candidate.parent() {
+        let canonical_parent = fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
+        if canonical_parent != canonical_dir {
+            bail!("path traversal detected for tree_id {tree_id:?}");
+        }
+    }
+    Ok(candidate)
+}
+
+fn lock_path_in(dir: &Path, tree_id: &str) -> Result<PathBuf> {
+    validate_tree_id(tree_id)?;
+    Ok(dir.join(format!("{tree_id}.lock")))
+}
+
+/// Status of a single session within a tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionStatus {
+    Active,
+    Completed,
+}
+
+/// One session entry in the tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionEntry {
+    pub depth: u32,
+    pub parent: Option<String>,
+    pub status: SessionStatus,
+    pub started_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<u64>,
+    #[serde(default)]
+    pub children: Vec<String>,
+}
+
+/// Full on-disk shape of a tree's state file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TreeState {
+    #[serde(default)]
+    pub sessions: HashMap<String, SessionEntry>,
+}
+
+impl TreeState {
+    pub fn active_count(&self) -> u32 {
+        self.sessions
+            .values()
+            .filter(|s| s.status == SessionStatus::Active)
+            .count() as u32
+    }
+
+    pub fn active_ids(&self) -> Vec<String> {
+        let mut v: Vec<_> = self
+            .sessions
+            .iter()
+            .filter(|(_, s)| s.status == SessionStatus::Active)
+            .map(|(k, _)| k.clone())
+            .collect();
+        v.sort();
+        v
+    }
+
+    pub fn completed_ids(&self) -> Vec<String> {
+        let mut v: Vec<_> = self
+            .sessions
+            .iter()
+            .filter(|(_, s)| s.status == SessionStatus::Completed)
+            .map(|(k, _)| k.clone())
+            .collect();
+        v.sort();
+        v
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Load (or initialise) the state for one tree. Caps the read at 1 MiB and
+/// degrades to an empty state on JSON parse failure (logged via tracing).
+pub fn load_state(path: &Path) -> Result<TreeState> {
+    if !path.exists() {
+        return Ok(TreeState::default());
+    }
+    let metadata =
+        fs::metadata(path).with_context(|| format!("failed to stat {}", path.display()))?;
+    if metadata.len() > MAX_STATE_FILE_BYTES {
+        tracing::warn!(
+            path = %path.display(),
+            len = metadata.len(),
+            "session_tree state file exceeds {MAX_STATE_FILE_BYTES} bytes; treating as empty"
+        );
+        return Ok(TreeState::default());
+    }
+    let mut opts = OpenOptions::new();
+    opts.read(true);
+    #[cfg(unix)]
+    {
+        // O_NOFOLLOW + O_CLOEXEC defeat symlink TOCTOU on shared /tmp.
+        opts.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = opts
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    let mut buf = String::new();
+    file.read_to_string(&mut buf)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    match serde_json::from_str::<TreeState>(&buf) {
+        Ok(state) => Ok(state),
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "session_tree state file is corrupt; treating as empty"
+            );
+            Ok(TreeState::default())
+        }
+    }
+}
+
+/// Atomically write state to disk via tmpfile + rename. Sets mode 0600 on
+/// the destination (Unix). Prunes stale completed and leaked-active
+/// sessions before writing.
+pub fn save_state(path: &Path, mut state: TreeState) -> Result<()> {
+    prune_stale(&mut state);
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("state path has no parent: {}", path.display()))?;
+    let file_stem = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow!("state path has no file name: {}", path.display()))?;
+    let tmp = parent.join(format!(".{file_stem}.tmp.{}", std::process::id()));
+
+    let mut opts = OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        opts.mode(0o600);
+        opts.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let payload =
+        serde_json::to_string_pretty(&state).with_context(|| "failed to serialise tree state")?;
+    {
+        let mut tmp_file = opts
+            .open(&tmp)
+            .with_context(|| format!("failed to create temp file {}", tmp.display()))?;
+        tmp_file
+            .write_all(payload.as_bytes())
+            .with_context(|| format!("failed to write {}", tmp.display()))?;
+        tmp_file
+            .sync_all()
+            .with_context(|| format!("failed to fsync {}", tmp.display()))?;
+    }
+    fs::rename(&tmp, path)
+        .with_context(|| format!("failed to rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+fn prune_stale(state: &mut TreeState) {
+    let now = now_secs();
+    let completed_cutoff = now.saturating_sub(COMPLETED_MAX_AGE_SECS);
+    let active_cutoff = now.saturating_sub(ACTIVE_MAX_AGE_SECS);
+    state.sessions.retain(|sid, entry| match entry.status {
+        SessionStatus::Completed => {
+            let when = entry.completed_at.unwrap_or(0);
+            if when < completed_cutoff {
+                tracing::debug!(session = %sid, "pruning stale completed session");
+                false
+            } else {
+                true
+            }
+        }
+        SessionStatus::Active => {
+            if entry.started_at < active_cutoff {
+                tracing::warn!(
+                    session = %sid,
+                    "pruning leaked active session (started {} secs ago)",
+                    now.saturating_sub(entry.started_at)
+                );
+                false
+            } else {
+                true
+            }
+        }
+    });
+}
+
+fn process_lock_for(tree_id: &str) -> &'static Mutex<()> {
+    use std::sync::Mutex as StdMutex;
+    static LOCKS: OnceLock<StdMutex<HashMap<String, &'static Mutex<()>>>> = OnceLock::new();
+    let map = LOCKS.get_or_init(|| StdMutex::new(HashMap::new()));
+    let mut guard = map.lock().expect("session_tree process-lock map poisoned");
+    if let Some(existing) = guard.get(tree_id) {
+        return existing;
+    }
+    let leaked: &'static Mutex<()> = Box::leak(Box::new(Mutex::new(())));
+    guard.insert(tree_id.to_string(), leaked);
+    leaked
+}
+
+/// Run `op` while holding both an intra-process lock and a cross-process
+/// exclusive file lock for `tree_id`. The lock is released when this
+/// function returns.
+pub fn with_locked_tree<F, T>(dir: &Path, tree_id: &str, op: F) -> Result<T>
+where
+    F: FnOnce(&Path) -> Result<T>,
+{
+    validate_tree_id(tree_id)?;
+    let _process_guard = process_lock_for(tree_id)
+        .lock()
+        .map_err(|_| anyhow!("intra-process lock for tree {tree_id:?} poisoned"))?;
+
+    let lock_path = lock_path_in(dir, tree_id)?;
+    let mut opts = OpenOptions::new();
+    opts.write(true).create(true).truncate(false).read(true);
+    #[cfg(unix)]
+    {
+        opts.mode(0o600);
+        opts.custom_flags(libc::O_CLOEXEC);
+    }
+    let lock_file: File = opts
+        .open(&lock_path)
+        .with_context(|| format!("failed to open lock file {}", lock_path.display()))?;
+    FileExt::lock_exclusive(&lock_file)
+        .with_context(|| format!("failed to acquire lock on {}", lock_path.display()))?;
+
+    let result = op(&state_path_in(dir, tree_id)?);
+
+    // Best-effort unlock; the kernel will release on drop regardless.
+    let _ = FileExt::unlock(&lock_file);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+    use tempfile::TempDir;
+
+    fn temp_state_dir() -> (TempDir, PathBuf) {
+        let td = TempDir::new_in("/tmp").expect("tempdir");
+        let p = td.path().to_path_buf();
+        (td, p)
+    }
+
+    #[test]
+    fn validate_accepts_valid_ids() {
+        assert!(validate_tree_id("abc123").is_ok());
+        assert!(validate_tree_id("AB_cd-EF").is_ok());
+        assert!(validate_tree_id(&"a".repeat(64)).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_path_traversal() {
+        assert!(validate_tree_id("").is_err());
+        assert!(validate_tree_id("..").is_err());
+        assert!(validate_tree_id("a/b").is_err());
+        assert!(validate_tree_id("a.b").is_err());
+        assert!(validate_tree_id(&"a".repeat(65)).is_err());
+        assert!(validate_tree_id("../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn state_path_lives_under_dir() {
+        let (_td, dir) = temp_state_dir();
+        let p = state_path_in(&dir, "tree1").unwrap();
+        assert_eq!(p, dir.join("tree1.json"));
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let (_td, dir) = temp_state_dir();
+        let path = state_path_in(&dir, "rt").unwrap();
+        let mut state = TreeState::default();
+        state.sessions.insert(
+            "s1".into(),
+            SessionEntry {
+                depth: 0,
+                parent: None,
+                status: SessionStatus::Active,
+                started_at: now_secs(),
+                completed_at: None,
+                children: vec![],
+            },
+        );
+        save_state(&path, state).unwrap();
+        let loaded = load_state(&path).unwrap();
+        assert!(loaded.sessions.contains_key("s1"));
+        assert_eq!(loaded.active_count(), 1);
+    }
+
+    #[test]
+    fn load_missing_returns_default() {
+        let (_td, dir) = temp_state_dir();
+        let path = dir.join("missing.json");
+        let state = load_state(&path).unwrap();
+        assert!(state.sessions.is_empty());
+    }
+
+    #[test]
+    fn load_corrupt_returns_default() {
+        let (_td, dir) = temp_state_dir();
+        let path = state_path_in(&dir, "corrupt").unwrap();
+        fs::write(&path, "not json{{{").unwrap();
+        let state = load_state(&path).unwrap();
+        assert!(state.sessions.is_empty());
+    }
+
+    #[test]
+    fn load_oversized_file_returns_default() {
+        let (_td, dir) = temp_state_dir();
+        let path = state_path_in(&dir, "big").unwrap();
+        let big = "x".repeat((MAX_STATE_FILE_BYTES + 1) as usize);
+        fs::write(&path, big).unwrap();
+        let state = load_state(&path).unwrap();
+        assert!(state.sessions.is_empty());
+    }
+
+    #[test]
+    fn save_writes_atomically_no_temp_leftover() {
+        let (_td, dir) = temp_state_dir();
+        let path = state_path_in(&dir, "atomic").unwrap();
+        save_state(&path, TreeState::default()).unwrap();
+        let leftovers: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "found temp leftovers: {leftovers:?}");
+    }
+
+    #[test]
+    fn prune_drops_stale_completed_and_leaked_active() {
+        let mut state = TreeState::default();
+        let stale_completed_at = now_secs().saturating_sub(COMPLETED_MAX_AGE_SECS + 60);
+        let stale_active_at = now_secs().saturating_sub(ACTIVE_MAX_AGE_SECS + 60);
+        state.sessions.insert(
+            "stale_completed".into(),
+            SessionEntry {
+                depth: 0,
+                parent: None,
+                status: SessionStatus::Completed,
+                started_at: stale_completed_at,
+                completed_at: Some(stale_completed_at),
+                children: vec![],
+            },
+        );
+        state.sessions.insert(
+            "stale_active".into(),
+            SessionEntry {
+                depth: 0,
+                parent: None,
+                status: SessionStatus::Active,
+                started_at: stale_active_at,
+                completed_at: None,
+                children: vec![],
+            },
+        );
+        state.sessions.insert(
+            "fresh".into(),
+            SessionEntry {
+                depth: 0,
+                parent: None,
+                status: SessionStatus::Active,
+                started_at: now_secs(),
+                completed_at: None,
+                children: vec![],
+            },
+        );
+        prune_stale(&mut state);
+        assert_eq!(state.sessions.len(), 1);
+        assert!(state.sessions.contains_key("fresh"));
+    }
+
+    #[test]
+    fn concurrent_register_no_lost_updates() {
+        // 16 threads each register one unique session under the same tree.
+        // Lost updates would manifest as fewer than 16 sessions on disk.
+        let (_td, dir) = temp_state_dir();
+        let dir = Arc::new(dir);
+        let mut handles = vec![];
+        for i in 0..16 {
+            let dir = Arc::clone(&dir);
+            handles.push(thread::spawn(move || {
+                with_locked_tree(&dir, "concur", |path| {
+                    let mut state = load_state(path)?;
+                    state.sessions.insert(
+                        format!("s{i}"),
+                        SessionEntry {
+                            depth: 0,
+                            parent: None,
+                            status: SessionStatus::Active,
+                            started_at: now_secs(),
+                            completed_at: None,
+                            children: vec![],
+                        },
+                    );
+                    save_state(path, state)
+                })
+                .unwrap();
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let state = load_state(&state_path_in(&dir, "concur").unwrap()).unwrap();
+        assert_eq!(
+            state.sessions.len(),
+            16,
+            "expected 16 sessions, got {}",
+            state.sessions.len()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn state_dir_has_restrictive_permissions() {
+        let td = TempDir::new_in("/tmp").unwrap();
+        // Set the session-tree-specific override; do NOT mutate global TMPDIR
+        // because other parallel tests anchor `TempDir::new()` against it.
+        unsafe {
+            std::env::set_var("AMPLIHACK_SESSION_TREE_DIR", td.path().join("trees"));
+        }
+        let dir = state_dir().unwrap();
+        let mode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "state dir mode should be 0700, got {mode:o}");
+        unsafe {
+            std::env::remove_var("AMPLIHACK_SESSION_TREE_DIR");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the last bundled-tool `python3` invocations in `amplifier-bundle/recipes/smart-orchestrator.yaml` (lines 259 and 953) with a native Rust subcommand: `amplihack session-tree {register|complete|status|check}`.

The Python helper at `amplifier-bundle/tools/session_tree.py` and the matching `session-tree-path` entry in `runtime_assets.rs` remain in place for one release as a shim for any out-of-tree callers (per design spec).

Closes #331.

## Subcommand surface (byte-for-byte parity with the Python contract)

| Subcommand | Stdout | Exit |
|---|---|---|
| `register` | `TREE_ID=<id> DEPTH=<n>\n` | 0 |
| `complete` | (none) | 0 |
| `status`   | JSON | 0 |
| `check`    | `ALLOWED\n` or `BLOCKED:<reason>\n` | 0 / **2** |

`check` exits **2** on BLOCKED so the recipe can distinguish depth-blocked from generic failure (exit 1).

## State management

- State at `$TMPDIR/amplihack-session-trees/<tree_id>.json` (overridable via `AMPLIHACK_SESSION_TREE_DIR`, used by tests so they don't disturb the global TMPDIR).
- `tree_id` validated against `^[A-Za-z0-9_-]{1,64}$` plus a canonicalize-under-state-dir defence-in-depth check.
- Per-process `std::sync::Mutex` interned per `tree_id`, plus an `fs4` cross-process exclusive lock on a sidecar `.lock` file.
- Atomic writes via tmp + rename; mode 0700 dir, 0600 files; reads capped at 1 MiB; opened with `O_NOFOLLOW|O_CLOEXEC` on Unix.
- Pruning: completed sessions >24h and active sessions >4h dropped on every save (matches Python parity).

## Tests (16 new)

- `tree_id` validation (incl. path-traversal rejection)
- Atomic save/load roundtrip; corrupt/missing/oversized -> default
- 16-thread concurrent register: no lost updates
- Pruning of stale completed and leaked active sessions
- Unix mode 0700 on state directory
- `register`/`complete`/`status`/`check` stdout contract + exit codes
- BLOCKED `check` returns exit code 2

## Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings   # PASS
TMPDIR=/tmp cargo test -p amplihack-cli --lib                # 1052 pass
```

The 2 remaining failures (`update::tests::should_*_update_check_*`) are pre-existing and present on `origin/main` — unrelated to this PR (also flagged in #338).

## Companion PRs

- #337 — fix(npm): cache-key bug serving stale binaries (closes #333, P0)
- #338 — feat(release): add windows-x86_64 to release matrix (closes #334)

Together these close the three highest-leverage parity gaps for amplihack-rs replacing legacy amplihack.