### PR TITLE
fix(launcher): tolerate empty/non-JSON recipe-runner output

### DIFF
--- a/crates/amplihack-cli/src/commands/recipe/mod.rs
+++ b/crates/amplihack-cli/src/commands/recipe/mod.rs
@@ -113,7 +113,7 @@ pub(crate) struct RecipeInfo {
     pub(crate) step_count: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct RecipeRunResult {
     pub(crate) recipe_name: String,
     pub(crate) success: bool,

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -46,23 +46,54 @@ pub(super) fn execute_recipe_via_rust(
         .context("failed to spawn recipe-runner-rs")?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let parsed: RecipeRunResult = serde_json::from_str(&stdout).map_err(|_| {
-        if output.status.success() {
-            anyhow::anyhow!(
-                "Rust recipe runner returned unparseable output (exit {}): {}",
-                exit_status_label(&output.status),
-                stdout.chars().take(500).collect::<String>()
-            )
-        } else {
-            anyhow::anyhow!(
-                "Rust recipe runner failed (exit {}): {}",
-                exit_status_label(&output.status),
-                format_runner_failure_detail(&output.status, &stderr)
-            )
-        }
-    })?;
 
-    Ok(parsed)
+    parse_recipe_output(&stdout, &stderr, output.status.success()).with_context(|| {
+        format!(
+            "recipe-runner-rs exited with {}",
+            exit_status_label(&output.status)
+        )
+    })
+}
+
+/// Pure parser for recipe-runner-rs subprocess output.
+///
+/// Behavior (issue #332):
+/// - Empty/whitespace-only stdout + success: returns a default `RecipeRunResult`
+///   with `success = true` (treats "ran but produced no JSON" as a no-op success).
+/// - Empty/whitespace-only stdout + failure: errors with the meaningful stderr
+///   tail surfaced so callers see the upstream cause.
+/// - Non-empty stdout: parses as JSON; on failure, errors with a bounded stdout
+///   preview (first 200 chars) and stderr tail in the `anyhow::Context`.
+///
+/// `RecipeRunResult` does not use `deny_unknown_fields`, so future
+/// recipe-runner-rs versions may add fields without breaking us.
+pub(super) fn parse_recipe_output(
+    stdout: &str,
+    stderr: &str,
+    exit_success: bool,
+) -> Result<RecipeRunResult> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        if exit_success {
+            return Ok(RecipeRunResult {
+                success: true,
+                ..RecipeRunResult::default()
+            });
+        }
+        anyhow::bail!(
+            "recipe-runner-rs produced no output and exited with failure\nstderr tail:\n{}",
+            meaningful_stderr_tail(stderr)
+        );
+    }
+
+    serde_json::from_str::<RecipeRunResult>(trimmed).with_context(|| {
+        let preview: String = trimmed.chars().take(200).collect();
+        format!(
+            "recipe-runner-rs produced non-JSON stdout (first 200 chars): {}\nstderr tail:\n{}",
+            preview,
+            meaningful_stderr_tail(stderr)
+        )
+    })
 }
 
 /// Pass context key-value pairs to the command. When total serialised size
@@ -104,33 +135,12 @@ pub(super) fn pass_context(
     Ok(Some(tmp))
 }
 
-fn format_runner_failure_detail(status: &std::process::ExitStatus, stderr: &str) -> String {
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::ExitStatusExt;
-
-        if let Some(signal) = status.signal() {
-            return format!(
-                "killed by signal {} ({}). The process was terminated externally before producing output.",
-                signal_name(signal),
-                signal
-            );
-        }
-    }
-
-    if stderr.is_empty() {
-        return "no stderr".to_string();
-    }
-
-    meaningful_stderr_tail(stderr)
-}
-
 fn exit_status_label(status: &std::process::ExitStatus) -> String {
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
         if let Some(signal) = status.signal() {
-            return format!("signal {signal}");
+            return format!("signal {} ({})", signal_name(signal), signal);
         }
     }
 
@@ -138,6 +148,18 @@ fn exit_status_label(status: &std::process::ExitStatus) -> String {
         .code()
         .map(|code| code.to_string())
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(unix)]
+fn signal_name(signal: i32) -> &'static str {
+    match signal {
+        2 => "SIGINT",
+        6 => "SIGABRT",
+        9 => "SIGKILL",
+        11 => "SIGSEGV",
+        15 => "SIGTERM",
+        _ => "signal",
+    }
 }
 
 pub(super) fn meaningful_stderr_tail(stderr: &str) -> String {
@@ -170,16 +192,4 @@ pub(super) fn meaningful_stderr_tail(stderr: &str) -> String {
     };
 
     selected.into_iter().rev().collect::<Vec<_>>().join("\n")
-}
-
-#[cfg(unix)]
-fn signal_name(signal: i32) -> &'static str {
-    match signal {
-        2 => "SIGINT",
-        6 => "SIGABRT",
-        9 => "SIGKILL",
-        11 => "SIGSEGV",
-        15 => "SIGTERM",
-        _ => "signal",
-    }
 }

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
@@ -258,11 +258,14 @@ fn test_execute_recipe_via_rust_reports_nonzero_exit_with_stderr() {
     }
 
     let error = result.expect_err("nonzero runner exit must return an error");
+    let chain = format!("{error:?}");
     assert!(
-        error
-            .to_string()
-            .contains("Rust recipe runner failed (exit 2): runner exploded"),
-        "nonzero exit must surface stderr clearly. Got: {error}"
+        chain.contains("exited with 2"),
+        "nonzero exit must surface exit code clearly. Got: {chain}"
+    );
+    assert!(
+        chain.contains("runner exploded"),
+        "nonzero exit must surface stderr tail in error chain. Got: {chain}"
     );
 }
 
@@ -445,4 +448,120 @@ fn which_recipe_runner_available() -> bool {
         }
     }
     false
+}
+
+// -------------------------------------------------------------------------
+// parse_recipe_output — pure parser unit tests (issue #332)
+// -------------------------------------------------------------------------
+
+/// Empty stdout + exit success: must return a default RecipeRunResult with
+/// success = true, not an error. This resolves issue #332 where
+/// recipe-runner-rs producing no output crashed the launcher.
+#[test]
+fn parse_empty_stdout_success_returns_default_with_success_true() {
+    let result =
+        execute::parse_recipe_output("", "", true).expect("empty stdout on success must not error");
+    assert!(result.success, "success flag must be true on empty+success");
+    assert_eq!(
+        result.recipe_name, "",
+        "default recipe_name is empty string"
+    );
+    assert!(result.step_results.is_empty(), "no step results expected");
+    assert!(result.context.is_empty(), "no context expected");
+}
+
+/// Empty stdout + exit failure: must error with stderr tail surfaced
+/// in the message so callers can diagnose upstream failures.
+#[test]
+fn parse_empty_stdout_failure_errors_with_stderr_tail() {
+    let stderr = "warm-up line\nERROR: recipe-runner crashed\nbacktrace omitted";
+    let err = execute::parse_recipe_output("", stderr, false)
+        .expect_err("empty stdout on failure must error");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("ERROR: recipe-runner crashed"),
+        "stderr tail must appear in error chain, got: {msg}"
+    );
+}
+
+/// Plain (non-JSON) text on stdout must error with context that includes
+/// a stdout preview so users can see what was actually returned.
+#[test]
+fn parse_plain_text_stdout_errors_with_context() {
+    let stdout = "this is not JSON, just a plain text line";
+    let err =
+        execute::parse_recipe_output(stdout, "", true).expect_err("plain text stdout must error");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("plain text"),
+        "stdout preview must appear in error context, got: {msg}"
+    );
+}
+
+/// Malformed JSON on stdout must error with context (truncated preview
+/// + stderr tail) so the user sees the bad payload.
+#[test]
+fn parse_malformed_json_errors_with_context() {
+    let stdout = r#"{"recipe_name": "x", "success": tru"#; // truncated
+    let stderr = "stderr-marker-xyz";
+    let err =
+        execute::parse_recipe_output(stdout, stderr, true).expect_err("malformed JSON must error");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("recipe_name") || msg.contains("success"),
+        "stdout preview must appear in error, got: {msg}"
+    );
+    assert!(
+        msg.contains("stderr-marker-xyz"),
+        "stderr tail must appear in error, got: {msg}"
+    );
+}
+
+/// Valid JSON must parse successfully into RecipeRunResult.
+#[test]
+fn parse_valid_json_succeeds() {
+    let stdout = r#"{
+        "recipe_name": "demo",
+        "success": true,
+        "step_results": [
+            {"step_id": "s1", "status": "ok", "output": "hello", "error": ""}
+        ],
+        "context": {"k": "v"}
+    }"#;
+    let result = execute::parse_recipe_output(stdout, "", true).expect("valid JSON must parse");
+    assert_eq!(result.recipe_name, "demo");
+    assert!(result.success);
+    assert_eq!(result.step_results.len(), 1);
+    assert_eq!(result.step_results[0].step_id, "s1");
+    assert_eq!(
+        result.context.get("k").and_then(serde_json::Value::as_str),
+        Some("v")
+    );
+}
+
+/// Valid JSON with extra/unknown top-level fields must still parse —
+/// serde ignores unknown fields by default and we rely on that contract
+/// for forward compatibility with future recipe-runner-rs versions.
+#[test]
+fn parse_valid_json_with_unknown_fields_succeeds() {
+    let stdout = r#"{
+        "recipe_name": "demo",
+        "success": true,
+        "step_results": [],
+        "context": {},
+        "future_field_xyz": 42,
+        "another_unknown": {"nested": "value"}
+    }"#;
+    let result = execute::parse_recipe_output(stdout, "", true)
+        .expect("unknown fields must be ignored, not rejected");
+    assert_eq!(result.recipe_name, "demo");
+    assert!(result.success);
+}
+
+/// Whitespace-only stdout (e.g. trailing newline) must be treated as empty.
+#[test]
+fn parse_whitespace_only_stdout_success_returns_default() {
+    let result = execute::parse_recipe_output("   \n\t  \n", "", true)
+        .expect("whitespace-only stdout on success must not error");
+    assert!(result.success);
 }


### PR DESCRIPTION
## Summary

Resolves issue #332 where `recipe-runner-rs` producing empty or non-JSON stdout (e.g. immediately after a `cargo install`/`cargo update` with no JSON yet emitted) caused the launcher to fail with the cryptic `expected value at line 1 column 1` error.

## Changes

- **`crates/amplihack-cli/src/commands/recipe/mod.rs`** — Derive `Default` on `RecipeRunResult` to support the empty-stdout-success path.
- **`crates/amplihack-cli/src/commands/recipe/run/execute.rs`** — Extract a pure `parse_recipe_output(stdout, stderr, exit_success) -> Result<RecipeRunResult>` helper:
  - Empty/whitespace stdout + success → default `RecipeRunResult { success: true }`
  - Empty/whitespace stdout + failure → `anyhow::bail` with stderr tail surfaced
  - Non-empty stdout → `serde_json` parse with bounded preview (first 200 chars) + stderr tail surfaced via `anyhow::Context` on failure
- Refactor `execute_recipe_via_rust` to delegate parsing to the helper and wrap the result with the exit-status label as outer context.
- Use `signal_name` in `exit_status_label` so SIGTERM is shown symbolically.
- **`crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs`** — Add 7 unit tests covering: empty + success, empty + failure, plain text, malformed JSON, valid JSON, valid JSON with unknown fields (forward-compat), and whitespace-only stdout.

## Test Plan

```
cargo clippy -p amplihack-launcher -p amplihack-cli --all-targets -- -D warnings   # clean
TMPDIR=/tmp cargo test -p amplihack-launcher -p amplihack-cli --lib                # 280 launcher + 48 recipe tests pass
```

The two pre-existing `update::tests::should_*` failures observed locally are unrelated to this change (they fail on `main` as well).

Closes #332

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>