### PR TITLE
fix(install): stage amplifier-bundle from local checkout source (closes #341)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -4,15 +4,25 @@
 //! source tree (`amplifier-bundle/`) and no longer fetched from the upstream
 //! `rysweet/amplihack` repository at install time.
 //!
-//! Resolution order:
-//! 1. **Compile-time workspace root** — the `CARGO_MANIFEST_DIR` embedded at
+//! Resolution order (fix #341 — prefer the user's actual checkout over any
+//! baked-at-build-time path):
+//! 1. **`AMPLIHACK_HOME`** — explicit user-configured override (highest
+//!    priority).
+//! 2. **CWD walk-up** — walks parent directories of the current working
+//!    directory looking for `amplifier-bundle/`. This is the path that
+//!    correctly identifies "the checkout the user is installing from" when
+//!    they invoke `amplihack install` from inside a clone, even if the
+//!    binary was built elsewhere.
+//! 3. **Walk-up from executable** — walks parent directories of
+//!    `current_exe()` looking for `amplifier-bundle/` (in-tree dev binary
+//!    under `target/`).
+//! 4. **Compile-time workspace root** — the `CARGO_MANIFEST_DIR` embedded at
 //!    build time points two levels up to the workspace root that contains
-//!    `amplifier-bundle/` and (if present) a `.claude/` directory.
-//! 2. **`AMPLIHACK_HOME`** — user-configured override.
-//! 3. **Walk-up from executable** — walks parent directories looking for
-//!    `amplifier-bundle/`.
-//! 4. **`~/.amplihack`** — staged install location from a prior run.
-//! 5. **Network download** (legacy fallback) — `git clone` / tarball from
+//!    `amplifier-bundle/`. Only meaningful for `cargo run`-style invocations
+//!    from the workspace itself; demoted because for an installed binary it
+//!    pins the bundle to whatever was on disk at compile time (issue #341).
+//! 5. **`~/.amplihack`** — staged install location from a prior run.
+//! 6. **Network download** (legacy fallback) — `git clone` / tarball from
 //!    upstream, only attempted when none of the above yields a usable root.
 
 use super::types::{REPO_ARCHIVE_URL, REPO_GIT_URL};
@@ -31,18 +41,7 @@ use std::process::Stdio;
 /// binary was installed via `cargo install` and the original checkout was
 /// deleted).
 pub(super) fn find_bundled_framework_root() -> Option<PathBuf> {
-    // 1. Compile-time workspace root
-    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf);
-    if let Some(ref root) = workspace_root
-        && root.join("amplifier-bundle").is_dir()
-    {
-        return Some(root.clone());
-    }
-
-    // 2. AMPLIHACK_HOME env var
+    // 1. AMPLIHACK_HOME env var — explicit user override
     if let Ok(home) = std::env::var("AMPLIHACK_HOME") {
         let p = PathBuf::from(&home);
         if p.join("amplifier-bundle").is_dir() {
@@ -50,7 +49,18 @@ pub(super) fn find_bundled_framework_root() -> Option<PathBuf> {
         }
     }
 
-    // 3. Walk up from executable
+    // 2. CWD walk-up — the checkout the user is installing from (fix #341)
+    if let Ok(cwd) = std::env::current_dir() {
+        let mut dir: Option<PathBuf> = Some(cwd);
+        while let Some(d) = dir {
+            if d.join("amplifier-bundle").is_dir() {
+                return Some(d);
+            }
+            dir = d.parent().map(Path::to_path_buf);
+        }
+    }
+
+    // 3. Walk up from executable (in-tree dev binary under `target/`)
     if let Ok(exe) = std::env::current_exe() {
         let mut dir = exe.parent().map(Path::to_path_buf);
         while let Some(d) = dir {
@@ -61,7 +71,20 @@ pub(super) fn find_bundled_framework_root() -> Option<PathBuf> {
         }
     }
 
-    // 4. ~/.amplihack (from prior staged install)
+    // 4. Compile-time workspace root (only meaningful for `cargo run` from
+    //    the workspace; demoted because for installed binaries it pins the
+    //    bundle to whatever was on disk at build time — issue #341).
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf);
+    if let Some(ref root) = workspace_root
+        && root.join("amplifier-bundle").is_dir()
+    {
+        return Some(root.clone());
+    }
+
+    // 5. ~/.amplihack (from prior staged install)
     if let Ok(home) = std::env::var("HOME") {
         let dot = PathBuf::from(home).join(".amplihack");
         if dot.join("amplifier-bundle").is_dir() && dot.join(".claude").is_dir() {

--- a/crates/amplihack-cli/tests/bugfix_341_install_freshness.rs
+++ b/crates/amplihack-cli/tests/bugfix_341_install_freshness.rs
@@ -1,0 +1,240 @@
+//! TDD test for issue #341: `amplihack install` must stage the
+//! `amplifier-bundle/` from the local checkout the user is installing from,
+//! not from a stale/baked source (e.g. the workspace `CARGO_MANIFEST_DIR`).
+//!
+//! Scenario this guards against:
+//!  - User clones amplihack-rs at HEAD where `recipes/smart-orchestrator.yaml`
+//!    contains 0 references to the legacy Python entrypoint
+//!    (`python3 -m amplihack.runtime_assets`).
+//!  - User runs `amplihack install` from inside that checkout.
+//!  - Expected: `~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml`
+//!    also contains 0 such references (i.e. is a byte-faithful copy of the
+//!    checkout's source file).
+//!
+//! ## Process-level invariants
+//!
+//! This test mutates `HOME`, `CWD`, `AMPLIHACK_HOME`, and
+//! `AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH`. Each integration test binary is a
+//! separate process, but Rust's default test harness runs `#[test]` fns on
+//! multiple threads within that process. We therefore (a) only define a single
+//! test in this file, and (b) serialize via a `OnceLock<Mutex<()>>` for
+//! defensive consistency with sibling test files.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use amplihack_cli::commands::install::run_install;
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Walk up from `CARGO_MANIFEST_DIR` (the amplihack-cli crate dir) to the
+/// workspace root that contains the real `amplifier-bundle/`.
+fn workspace_root() -> PathBuf {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut cur: &Path = &crate_dir;
+    loop {
+        if cur.join("amplifier-bundle").is_dir() && cur.join("Cargo.toml").is_file() {
+            return cur.to_path_buf();
+        }
+        cur = cur
+            .parent()
+            .expect("walked above filesystem root looking for workspace");
+    }
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let ty = entry.file_type().unwrap();
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir_all(&from, &to);
+        } else if ty.is_symlink() {
+            // Resolve symlinks to their target contents (good enough for asset
+            // copying in tests).
+            if let Ok(target_meta) = fs::metadata(&from)
+                && target_meta.is_dir()
+            {
+                copy_dir_all(&from, &to);
+                continue;
+            }
+            let _ = fs::copy(&from, &to);
+        } else {
+            fs::copy(&from, &to).unwrap();
+        }
+    }
+}
+
+/// Writes a minimal executable stub at `dir/amplihack-hooks` (mode 0700) and
+/// returns its path. Content is padded > 1024 bytes to satisfy
+/// `deploy_binaries`' sanity-check.
+fn write_stub_hooks_binary(dir: &Path) -> PathBuf {
+    let path = dir.join("amplihack-hooks");
+    let content = format!("#!/bin/sh\nexit 0\n{}\n", "x".repeat(1100));
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    path
+}
+
+const STALE_MARKER: &str = "python3 -m amplihack.runtime_assets";
+/// Sentinel string injected into the fake checkout's smart-orchestrator.yaml.
+/// Its presence in the staged file proves the install used the CWD checkout
+/// rather than the workspace `CARGO_MANIFEST_DIR` bundle.
+const CHECKOUT_SENTINEL: &str = "# bugfix-341-checkout-sentinel-7f3e9a1b\n";
+
+#[test]
+fn install_stages_amplifier_bundle_from_local_checkout_not_stale_source() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // ----- Set up a fake "user checkout" tempdir containing a real bundle copy
+    let checkout = tempfile::tempdir().expect("create checkout tempdir");
+    let workspace = workspace_root();
+    copy_dir_all(
+        &workspace.join("amplifier-bundle"),
+        &checkout.path().join("amplifier-bundle"),
+    );
+    // Fabricate a minimal `.claude/` skeleton with the ESSENTIAL_DIRS the
+    // installer expects. The workspace itself doesn't contain these (its
+    // assets live under `amplifier-bundle/`), so we create empty stubs to
+    // get past the install's "no directories copied" failure mode. The
+    // amplifier-bundle staging — which is what #341 is about — runs
+    // independently of these.
+    let claude = checkout.path().join(".claude");
+    for dir in [
+        "agents/amplihack",
+        "commands/amplihack",
+        "tools/amplihack",
+        "tools/xpia",
+        "context",
+        "workflow",
+        "skills",
+        "templates",
+        "scenarios",
+        "docs",
+        "schemas",
+        "config",
+    ] {
+        fs::create_dir_all(claude.join(dir)).unwrap();
+        // Drop a placeholder file so the dir is non-empty (some copy code
+        // skips empty dirs).
+        fs::write(claude.join(dir).join(".keep"), "").unwrap();
+    }
+    fs::write(claude.join("tools/statusline.sh"), "#!/bin/sh\necho hi\n").unwrap();
+    fs::write(claude.join("AMPLIHACK.md"), "framework\n").unwrap();
+    fs::write(claude.join("settings.json"), "{}\n").unwrap();
+    fs::write(checkout.path().join("CLAUDE.md"), "root\n").unwrap();
+
+    // Inject sentinel into the checkout's smart-orchestrator.yaml so we can
+    // prove which source the install consumed.
+    let checkout_yaml = checkout
+        .path()
+        .join("amplifier-bundle/recipes/smart-orchestrator.yaml");
+    let original = fs::read_to_string(&checkout_yaml).expect("read checkout yaml");
+    fs::write(&checkout_yaml, format!("{original}\n{CHECKOUT_SENTINEL}")).unwrap();
+
+    // Preconditions: the checkout source must have 0 stale-marker lines.
+    let pre_count = original
+        .lines()
+        .filter(|l| l.contains(STALE_MARKER))
+        .count();
+    assert_eq!(
+        pre_count, 0,
+        "precondition: checkout source must have 0 stale '{STALE_MARKER}' refs; \
+         found {pre_count}. Update the workspace amplifier-bundle source."
+    );
+
+    // ----- Set HOME to a tempdir so install stages into an isolated location
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let bin_dir = home.path().join("stub_bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let hooks_stub = write_stub_hooks_binary(&bin_dir);
+
+    let prev_home = std::env::var_os("HOME");
+    let prev_amplihack_home = std::env::var_os("AMPLIHACK_HOME");
+    let prev_hooks = std::env::var_os("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH");
+    let prev_cwd = std::env::current_dir().ok();
+
+    // SAFETY: env mutation is gated by `env_lock()` above. Each integration
+    // test binary is its own process; this file defines a single test.
+    unsafe {
+        std::env::set_var("HOME", home.path());
+        std::env::remove_var("AMPLIHACK_HOME");
+        std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", &hooks_stub);
+    }
+    std::env::set_current_dir(checkout.path()).expect("chdir into checkout");
+
+    // ----- Act: install from the (CWD) checkout
+    let install_result = run_install(None);
+
+    // ----- Capture assertions before restoring env so a panic on restore
+    //       doesn't mask the real failure.
+    let staged_yaml = home
+        .path()
+        .join(".amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml");
+    let staged_exists = staged_yaml.is_file();
+    let staged_contents = if staged_exists {
+        Some(fs::read_to_string(&staged_yaml).expect("read staged yaml"))
+    } else {
+        None
+    };
+
+    // ----- Restore env
+    if let Some(d) = prev_cwd {
+        let _ = std::env::set_current_dir(d);
+    }
+    unsafe {
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match prev_amplihack_home {
+            Some(v) => std::env::set_var("AMPLIHACK_HOME", v),
+            None => std::env::remove_var("AMPLIHACK_HOME"),
+        }
+        match prev_hooks {
+            Some(v) => std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", v),
+            None => std::env::remove_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH"),
+        }
+    }
+
+    // ----- Now check the captured state
+    install_result.expect("run_install must succeed");
+    assert!(
+        staged_exists,
+        "smart-orchestrator.yaml must be staged at ~/.amplihack/amplifier-bundle/recipes/"
+    );
+    let staged = staged_contents.unwrap();
+
+    // R2 / #341: the staged file must contain 0 lines with the legacy Python
+    // entrypoint, mirroring `grep -c "python3 -m amplihack.runtime_assets"`.
+    let stale_count = staged.lines().filter(|l| l.contains(STALE_MARKER)).count();
+    assert_eq!(
+        stale_count, 0,
+        "issue #341 regression: staged smart-orchestrator.yaml contains \
+         {stale_count} stale '{STALE_MARKER}' line(s); install must stage \
+         from the local checkout's source (which has 0)."
+    );
+
+    // Provenance check: the staged file must contain the sentinel we wrote
+    // into the CWD checkout. If this fails, install consumed a different
+    // bundle source (e.g. CARGO_MANIFEST_DIR workspace) and #341 is not
+    // actually fixed even if the stale-count happens to be 0.
+    assert!(
+        staged.contains(CHECKOUT_SENTINEL.trim_end()),
+        "staged smart-orchestrator.yaml does not contain the CWD-checkout \
+         sentinel — install consumed a different bundle source than the \
+         local checkout (issue #341 not fixed)."
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #341 — `amplihack install` now stages `amplifier-bundle/` from the user's checkout rather than from a stale snapshot baked in at compile time via `CARGO_MANIFEST_DIR`.

## Root Cause


## Fix

Reorder resolution to:

1. `AMPLIHACK_HOME` — explicit user override
2. **CWD walk-up** — the checkout the user is installing from (NEW)
3. `current_exe()` walk-up — in-tree dev binary under `target/`
4. `CARGO_MANIFEST_DIR` — compile-time workspace root (demoted)
5. `~/.amplihack` — prior staged install

The `is_dir("amplifier-bundle")` guard is preserved on every branch (trust boundary against malicious `AMPLIHACK_HOME`).

## Test

New integration test `crates/amplihack-cli/tests/bugfix_341_install_freshness.rs`:

- Builds a tempdir checkout containing a real copy of `amplifier-bundle/`
- Injects a unique sentinel into `recipes/smart-orchestrator.yaml`
- Sets `HOME` to a tempdir, `chdir`s into the checkout, and runs `run_install`
- Asserts (a) staged file contains the sentinel (provenance: install consumed the CWD checkout), and (b) `grep -c 'python3 -m amplihack.runtime_assets'` on the staged file is `0` (freshness regression guard)

## Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings   # clean
TMPDIR=/tmp cargo test -p amplihack-cli --test bugfix_341_install_freshness   # 1 passed
TMPDIR=/tmp cargo test -p amplihack-cli --lib   # 1061 passed; 2 pre-existing failures on main (update::tests, unrelated)
```

Closes #341