### PR TITLE
feat(workflow): support targeting existing PR branch via context (closes #342)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "clap",
  "libc",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/amplifier-bundle/recipes/consensus-workflow.yaml
+++ b/amplifier-bundle/recipes/consensus-workflow.yaml
@@ -70,6 +70,12 @@ recursion:
 context:
   # Description of the task
   task_description: ""
+
+  # Issue #342: target an existing PR branch instead of deriving a new one.
+  # MIRROR: keep in sync with default-workflow.yaml. See its context block
+  # for the full security/precedence contract.
+  existing_branch: ""
+  pr_number: ""
 context_validation:
   task_description: "nonempty"
   repo_path: "git_repo"
@@ -566,6 +572,65 @@ steps:
       # NOTE: This pipeline mirrors default-workflow.yaml step-04-setup-worktree with a
       # 30-char limit (vs 50). Keep both in sync on security patches. See Issue #2952.
       # FIX (issue #3041): Use heredoc instead of single-quote wrapping.
+
+      # ========================================================================
+      # MIRROR (#342): Existing-branch / PR targeting path.
+      # When EXISTING_BRANCH or PR_NUMBER is set, reuse the named branch instead
+      # of deriving a slug. EXISTING_BRANCH wins on tie (WARNING to stderr).
+      # Keep in sync with default-workflow.yaml step-04-setup-worktree.
+      # ========================================================================
+      EXISTING_BRANCH="${EXISTING_BRANCH:-}"
+      PR_NUMBER="${PR_NUMBER:-}"
+      if [ -n "$EXISTING_BRANCH" ] || [ -n "$PR_NUMBER" ]; then
+        if [ -n "$EXISTING_BRANCH" ] && [ -n "$PR_NUMBER" ]; then
+          echo "WARNING: both 'existing_branch' and 'pr_number' set — using existing_branch ('$EXISTING_BRANCH'), ignoring pr_number ('$PR_NUMBER')." >&2
+        fi
+        if [ -n "$EXISTING_BRANCH" ]; then
+          BRANCH_NAME="$EXISTING_BRANCH"
+        else
+          # SECURITY: PR_NUMBER must be a positive integer before passing to gh.
+          if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "ERROR: pr_number '$PR_NUMBER' is not a valid positive integer (arg-injection guard)." >&2
+            exit 1
+          fi
+          if ! command -v gh >/dev/null 2>&1; then
+            echo "ERROR: pr_number is set but the 'gh' CLI is not on PATH." >&2
+            exit 1
+          fi
+          BRANCH_NAME="$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName 2>/dev/null || true)"
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "ERROR: 'gh pr view $PR_NUMBER' returned no branch name." >&2
+            exit 1
+          fi
+        fi
+        # SECURITY: validate (or re-validate) branch name via authoritative checker.
+        if ! git check-ref-format --branch "$BRANCH_NAME" >/dev/null 2>&1; then
+          echo "ERROR: branch name '$BRANCH_NAME' is invalid (git check-ref-format rejection)." >&2
+          exit 1
+        fi
+        echo "INFO: Targeting existing branch '$BRANCH_NAME' (issue #342 path)." >&2
+        git fetch origin "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" >&2 2>/dev/null || true
+        WORKTREE_PATH="$WORKTREE_DIR/$BRANCH_NAME"
+        EXISTING_WT="$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH_NAME" '
+          $1=="worktree" { wt=$2 }
+          $1=="branch" && $2==b { print wt; exit }
+        ')"
+        if [ -n "$EXISTING_WT" ]; then
+          WORKTREE_PATH="$EXISTING_WT"
+        elif [ "$(git symbolic-ref --short HEAD 2>/dev/null || true)" = "$BRANCH_NAME" ]; then
+          WORKTREE_PATH="$(pwd)"
+        elif git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+          git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+        elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+          git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+        else
+          echo "ERROR: branch '$BRANCH_NAME' not found locally or on origin." >&2
+          exit 1
+        fi
+        printf '{"branch_name": "%s", "worktree_path": "%s", "commands_executed": ["existing-branch path #342"], "setup_complete": true}\n' \
+          "$BRANCH_NAME" "$WORKTREE_PATH"
+        exit 0
+      fi
 
       # --- Bootstrap detection (same pattern as #3603 fix in default-workflow) ---
       # Detect whether origin remote and origin/main exist. New repos (first commit,

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -53,6 +53,19 @@ context:
   # Branch name prefix (default: feat)
   branch_prefix: "feat"
 
+  # Issue #342: target an existing PR branch instead of deriving a new one.
+  # When set, step-04-setup-worktree skips slug derivation and reuses the
+  # named branch. Empty string => legacy behaviour (derive a new branch).
+  # SECURITY: validated via `git check-ref-format --branch` before any use.
+  existing_branch: ""
+
+  # Issue #342: alternative to existing_branch — resolve a PR number to its
+  # head branch via `gh pr view <N> --json headRefName -q .headRefName`.
+  # Empty string => legacy behaviour. Must be a positive integer (regex-validated
+  # before invoking gh; the gh response is re-validated through check-ref-format).
+  # Precedence: if both are set, `existing_branch` wins and a WARNING is emitted.
+  pr_number: ""
+
   # Workstream name for parallel workflows (optional)
   workstream: ""
 
@@ -411,6 +424,116 @@ steps:
 
       echo "=== Step 4: Creating Worktree and Branch ===" >&2
       echo "" >&2
+
+      # ========================================================================
+      # NEW (#342): Existing-branch / PR targeting path.
+      # When EXISTING_BRANCH or PR_NUMBER is set, reuse an existing branch
+      # instead of deriving a slug from TASK_DESCRIPTION. EXISTING_BRANCH wins
+      # when both are set (a WARNING is emitted to stderr).
+      #
+      # MIRROR: consensus-workflow.yaml step3-setup-worktree must keep the same
+      # validation gates and resolution algorithm. Do not patch one without the
+      # other. The Python parity test in
+      # amplifier-bundle/tools/test_default_workflow_fixes.py guards drift.
+      # ========================================================================
+      EXISTING_BRANCH="${EXISTING_BRANCH:-}"
+      PR_NUMBER="${PR_NUMBER:-}"
+
+      if [ -n "$EXISTING_BRANCH" ] || [ -n "$PR_NUMBER" ]; then
+        # Precedence: existing_branch wins on tie.
+        if [ -n "$EXISTING_BRANCH" ] && [ -n "$PR_NUMBER" ]; then
+          echo "WARNING: both 'existing_branch' and 'pr_number' set — using existing_branch ('$EXISTING_BRANCH'), ignoring pr_number ('$PR_NUMBER')." >&2
+        fi
+
+        if [ -n "$EXISTING_BRANCH" ]; then
+          BRANCH_NAME="$EXISTING_BRANCH"
+        else
+          # SECURITY: PR_NUMBER must be a positive integer before passing to gh.
+          # Rejects arg-injection like '342 --repo evil/x', '-1', or '$(rm)'.
+          if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "ERROR: pr_number '$PR_NUMBER' is not a valid positive integer (arg-injection guard)." >&2
+            exit 1
+          fi
+          if ! command -v gh >/dev/null 2>&1; then
+            echo "ERROR: pr_number is set but the 'gh' CLI is not on PATH." >&2
+            exit 1
+          fi
+          # gh stderr suppressed to avoid leaking auth/token diagnostics; we
+          # surface a sanitized error instead.
+          BRANCH_NAME="$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName 2>/dev/null || true)"
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "ERROR: 'gh pr view $PR_NUMBER' returned no branch name (PR not found, no auth, or gh failure)." >&2
+            exit 1
+          fi
+        fi
+
+        # SECURITY: validate the branch name with the authoritative git ref
+        # checker BEFORE using it in any path or git invocation. This rejects
+        # '..', leading '-', shell metachars, and control chars. Re-applied
+        # to gh output so we never trust an upstream API response.
+        if ! git check-ref-format --branch "$BRANCH_NAME" >/dev/null 2>&1; then
+          echo "ERROR: branch name '$BRANCH_NAME' is invalid (git check-ref-format rejection)." >&2
+          exit 1
+        fi
+
+        echo "INFO: Targeting existing branch '$BRANCH_NAME' (issue #342 path)." >&2
+
+        # Best-effort fetch so remote-only branches resolve. Explicit refspec
+        # creates the local remote-tracking ref. Branch name is validated above.
+        git fetch origin "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" >&2 2>/dev/null || true
+
+        # Resolve worktree path:
+        #   (a) reuse if a worktree already exists for the branch
+        #   (b) else use REPO_PATH if it is itself checked out on the branch
+        #   (c) else attach a new worktree at REPO_PATH/worktrees/<branch>
+        WORKTREE_PATH=""
+        EXISTING_WT="$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH_NAME" '
+          $1=="worktree" { wt=$2 }
+          $1=="branch" && $2==b { print wt; exit }
+        ')"
+        if [ -n "$EXISTING_WT" ]; then
+          WORKTREE_PATH="$EXISTING_WT"
+          echo "INFO: Reusing existing worktree at '$WORKTREE_PATH'." >&2
+        else
+          HEAD_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+          if [ "$HEAD_BRANCH" = "$BRANCH_NAME" ]; then
+            WORKTREE_PATH="$REPO_PATH"
+            echo "INFO: Caller already on branch '$BRANCH_NAME'; using REPO_PATH as worktree." >&2
+          else
+            # SECURITY: WORKTREE_PATH construction is safe because BRANCH_NAME
+            # has passed git check-ref-format above (rejects .., leading -, etc.).
+            WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+            if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+              # Local branch exists: attach without -b (safe re-attach).
+              git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+            elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+              # Remote-only: create local tracking branch on attach.
+              git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+            else
+              echo "ERROR: branch '$BRANCH_NAME' not found locally or on origin." >&2
+              exit 1
+            fi
+          fi
+        fi
+
+        # When reusing an existing branch, `created=false` reflects that the
+        # branch was not created by this step (its worktree may be new).
+        CREATED=false
+
+        # Push/upstream best-effort (idempotent on existing PR branches).
+        git -C "$WORKTREE_PATH" push origin "$BRANCH_NAME" > /dev/null 2>&1 || true
+        git -C "$WORKTREE_PATH" branch --set-upstream-to="origin/${BRANCH_NAME}" "$BRANCH_NAME" > /dev/null 2>&1 || true
+
+        echo "" >&2
+        echo "=== Worktree Setup Complete (existing-branch path) ===" >&2
+
+        # Stdout reserved for the JSON contract; all human-readable lines go to stderr.
+        # NOTE: printf (not heredoc) — heredoc terminator must be at column 0 after
+        # YAML strips block indent, which conflicts with the indented if-block here.
+        printf '{"worktree_path": "%s", "branch_name": "%s", "created": %s}\n' \
+          "$WORKTREE_PATH" "$BRANCH_NAME" "$CREATED"
+        exit 0
+      fi
 
       # Fetch latest refs
       git fetch origin main >&2

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -17,6 +17,11 @@ default_step_timeout: 300
 context:
   task_description: ""
   repo_path: "."
+  # Issue #342: target an existing PR branch in sub-recipes.
+  # Propagated automatically to default-workflow / consensus-workflow via
+  # context-merging. Empty strings preserve legacy behaviour.
+  existing_branch: ""
+  pr_number: ""
   decomposition_json: ""
   session_id: ""
   tree_id: ""

--- a/amplifier-bundle/tools/test_default_workflow_fixes.py
+++ b/amplifier-bundle/tools/test_default_workflow_fixes.py
@@ -1089,6 +1089,166 @@ class TestStep16CreateDraftPR(unittest.TestCase):
 
 
 # ===========================================================================
+# ISSUE #342: existing_branch / pr_number context vars (parity layer)
+# ===========================================================================
+#
+# These tests are written FIRST (TDD red). They MUST fail until the
+# corresponding YAML changes land in step-04-setup-worktree:
+#
+#   * EXISTING_BRANCH=""     → legacy slug derivation (created=true)  [BL-002 unchanged]
+#   * EXISTING_BRANCH=<name> → reuse existing branch (created=false), no `branch -b`
+#   * EXISTING_BRANCH invalid → fail check-ref-format
+#   * PR_NUMBER=<N>          → resolve via `gh pr view`, then take reuse path
+#   * PR_NUMBER non-numeric  → fail before invoking gh
+#   * Both vars set          → existing_branch wins, WARNING on stderr
+#
+# A Rust integration test in tests/integration/existing_branch_context_test.rs
+# enforces the same contract; this Python layer prevents drift between
+# default-workflow.yaml and consensus-workflow.yaml and provides a fast
+# stdlib-only check developers can run without `cargo test`.
+
+
+def _run_step4_with_env(
+    raw_cmd: str,
+    repo_path: str,
+    env_overrides: dict,
+    extra_path: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Run the YAML-extracted step-04 bash with explicit env vars (issue #342)."""
+    env = os.environ.copy()
+    env.setdefault("REPO_PATH", repo_path)
+    env.setdefault("BRANCH_PREFIX", "feat")
+    env.setdefault("ISSUE_NUMBER", "342")
+    env.setdefault("TASK_DESCRIPTION", "issue 342 existing branch")
+    env.setdefault("EXISTING_BRANCH", "")
+    env.setdefault("PR_NUMBER", "")
+    env.update(env_overrides)
+    if extra_path:
+        env["PATH"] = f"{extra_path}:{env.get('PATH', '/usr/bin:/bin')}"
+    return subprocess.run(
+        ["bash", "-c", raw_cmd],
+        capture_output=True,
+        text=True,
+        cwd=repo_path,
+        env=env,
+    )
+
+
+def _make_gh_shim(tmpdir: str, branch_name: str) -> str:
+    """Write a `gh` PATH shim that emits `branch_name` for `pr view`."""
+    p = Path(tmpdir) / "gh"
+    p.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then\n'
+        f"  printf '%s' '{branch_name}'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 2\n"
+    )
+    p.chmod(0o755)
+    return tmpdir
+
+
+class TestIssue342ExistingBranchContext(unittest.TestCase):
+    """Parity tests for issue #342 — existing_branch / pr_number context vars."""
+
+    def setUp(self):
+        self.origin_dir = tempfile.mkdtemp(prefix="iss342_origin_")
+        subprocess.run(
+            ["git", "init", "--bare", "-b", "main", self.origin_dir],
+            check=True,
+            capture_output=True,
+        )
+        self.repo_dir = tempfile.mkdtemp(prefix="iss342_repo_")
+        _git("init", "-b", "main", cwd=self.repo_dir)
+        _git("config", "user.email", "test@test", cwd=self.repo_dir)
+        _git("config", "user.name", "test", cwd=self.repo_dir)
+        _git("remote", "add", "origin", self.origin_dir, cwd=self.repo_dir)
+        Path(self.repo_dir, "README.md").write_text("init\n")
+        _git("add", "README.md", cwd=self.repo_dir)
+        _git("commit", "-m", "init", cwd=self.repo_dir)
+        _git("push", "-u", "origin", "HEAD:main", cwd=self.repo_dir)
+        self.shim_dir = tempfile.mkdtemp(prefix="iss342_shim_")
+        self.raw_cmd = _extract_step_command(_WORKFLOW_YAML, "step-04-setup-worktree")
+
+    def tearDown(self):
+        subprocess.run(["git", "worktree", "prune"], cwd=self.repo_dir, capture_output=True)
+        shutil.rmtree(self.origin_dir, ignore_errors=True)
+        shutil.rmtree(self.repo_dir, ignore_errors=True)
+        shutil.rmtree(self.shim_dir, ignore_errors=True)
+
+    def test_existing_branch_empty_preserves_legacy_behaviour(self):
+        """EXISTING_BRANCH='' must take the legacy slug path (BL-002 unchanged)."""
+        r = _run_step4_with_env(self.raw_cmd, self.repo_dir, {})
+        self.assertEqual(r.returncode, 0, f"stderr:\n{r.stderr}")
+        out = json.loads(r.stdout[r.stdout.index("{"):])
+        self.assertTrue(out["created"], f"legacy path must emit created=true; got {out}")
+        self.assertTrue(
+            out["branch_name"].startswith("feat/issue-342-"),
+            f"legacy slug must derive from TASK_DESCRIPTION; got {out['branch_name']}",
+        )
+
+    def test_existing_branch_local_is_reused(self):
+        """Local branch listed in EXISTING_BRANCH is reused (created=false)."""
+        _git("branch", "feat/already-here", "main", cwd=self.repo_dir)
+        r = _run_step4_with_env(
+            self.raw_cmd, self.repo_dir, {"EXISTING_BRANCH": "feat/already-here"}
+        )
+        self.assertEqual(r.returncode, 0, f"stderr:\n{r.stderr}")
+        out = json.loads(r.stdout[r.stdout.index("{"):])
+        self.assertEqual(out["branch_name"], "feat/already-here")
+        self.assertFalse(out["created"], f"reuse path must emit created=false; got {out}")
+
+    def test_existing_branch_invalid_ref_rejected(self):
+        """Invalid ref name must fail check-ref-format gate."""
+        r = _run_step4_with_env(
+            self.raw_cmd, self.repo_dir, {"EXISTING_BRANCH": "invalid..name"}
+        )
+        self.assertNotEqual(r.returncode, 0, f"stdout:\n{r.stdout}")
+
+    def test_pr_number_resolves_via_gh_shim(self):
+        """PR_NUMBER must resolve to a branch via `gh pr view`."""
+        _git("branch", "feat/pr-resolved", "main", cwd=self.repo_dir)
+        _make_gh_shim(self.shim_dir, "feat/pr-resolved")
+        r = _run_step4_with_env(
+            self.raw_cmd,
+            self.repo_dir,
+            {"PR_NUMBER": "342"},
+            extra_path=self.shim_dir,
+        )
+        self.assertEqual(r.returncode, 0, f"stderr:\n{r.stderr}")
+        out = json.loads(r.stdout[r.stdout.index("{"):])
+        self.assertEqual(out["branch_name"], "feat/pr-resolved")
+        self.assertFalse(out["created"])
+
+    def test_pr_number_non_numeric_rejected(self):
+        """Non-numeric PR_NUMBER must fail BEFORE invoking gh (arg-injection guard)."""
+        r = _run_step4_with_env(
+            self.raw_cmd, self.repo_dir, {"PR_NUMBER": "342 --repo evil/x"}
+        )
+        self.assertNotEqual(r.returncode, 0, f"stdout:\n{r.stdout}")
+
+    def test_both_vars_set_existing_branch_wins_with_warning(self):
+        """When both vars are set, EXISTING_BRANCH wins; precedence WARNING on stderr."""
+        _git("branch", "feat/wins", "main", cwd=self.repo_dir)
+        _make_gh_shim(self.shim_dir, "feat/loses")
+        r = _run_step4_with_env(
+            self.raw_cmd,
+            self.repo_dir,
+            {"EXISTING_BRANCH": "feat/wins", "PR_NUMBER": "342"},
+            extra_path=self.shim_dir,
+        )
+        self.assertEqual(r.returncode, 0, f"stderr:\n{r.stderr}")
+        out = json.loads(r.stdout[r.stdout.index("{"):])
+        self.assertEqual(out["branch_name"], "feat/wins")
+        sl = r.stderr.lower()
+        self.assertTrue(
+            "warning" in sl and "existing_branch" in sl,
+            f"precedence WARNING missing on stderr:\n{r.stderr}",
+        )
+
+
+# ===========================================================================
 # Entry point
 # ===========================================================================
 

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -28,6 +28,7 @@ clap = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 libc = { workspace = true }
 
@@ -97,6 +98,15 @@ path = "../../tests/integration/kuzu_path_notice_test.rs"
 [[test]]
 name = "cli_golden"
 path = "../../tests/integration/cli_golden_tests.rs"
+
+# Issue #342: Targeting existing PR branch via context (existing_branch / pr_number).
+# Verifies step-04-setup-worktree (default-workflow.yaml) and step3-setup-worktree
+# (consensus-workflow.yaml) skip branch creation when an existing branch is supplied,
+# resolve pr_number via `gh`, validate inputs against shell/path injection, and
+# preserve byte-identical legacy behaviour when both vars are empty.
+[[test]]
+name = "existing_branch_context"
+path = "../../tests/integration/existing_branch_context_test.rs"
 
 # Issue #259: Documentation-vs-code drift detection tests.
 # Verify docs match source code for flag injection, completions,

--- a/tests/integration/existing_branch_context_test.rs
+++ b/tests/integration/existing_branch_context_test.rs
@@ -59,10 +59,8 @@ fn smart_orchestrator_yaml() -> PathBuf {
 
 /// Load a recipe YAML and return the parsed serde_yaml::Value.
 fn load_recipe(path: &Path) -> Value {
-    let text =
-        fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-    serde_yaml::from_str(&text)
-        .unwrap_or_else(|e| panic!("parse {} as YAML: {e}", path.display()))
+    let text = fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {} as YAML: {e}", path.display()))
 }
 
 /// Find a step by id under `steps:` and return its `command:` body.
@@ -137,7 +135,10 @@ impl GitFixture {
         let repo = TempDir::new().expect("repo tempdir");
         let rp = repo.path().to_path_buf();
         git(&rp, &["init", "-b", "main"]);
-        git(&rp, &["remote", "add", "origin", origin.path().to_str().unwrap()]);
+        git(
+            &rp,
+            &["remote", "add", "origin", origin.path().to_str().unwrap()],
+        );
         fs::write(rp.join("README.md"), "init\n").unwrap();
         git(&rp, &["add", "README.md"]);
         git(&rp, &["commit", "-m", "init"]);
@@ -257,8 +258,7 @@ fn parse_json(stdout: &str) -> serde_json::Value {
         panic!("no closing brace in stdout:\n{stdout}");
     });
     let candidate = &slice[..=end];
-    serde_json::from_str(candidate)
-        .unwrap_or_else(|e| panic!("invalid JSON {candidate:?}: {e}"))
+    serde_json::from_str(candidate).unwrap_or_else(|e| panic!("invalid JSON {candidate:?}: {e}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -336,7 +336,10 @@ fn consensus_workflow_declares_pr_number_context_var() {
 // ---------------------------------------------------------------------------
 
 fn step04_body() -> String {
-    extract_step_body(&load_recipe(&default_workflow_yaml()), "step-04-setup-worktree")
+    extract_step_body(
+        &load_recipe(&default_workflow_yaml()),
+        "step-04-setup-worktree",
+    )
 }
 
 fn base_env(fix: &GitFixture) -> HashMap<&'static str, String> {
@@ -344,7 +347,10 @@ fn base_env(fix: &GitFixture) -> HashMap<&'static str, String> {
     env.insert("REPO_PATH", fix.repo_path.to_string_lossy().into_owned());
     env.insert("BRANCH_PREFIX", "feat".to_owned());
     env.insert("ISSUE_NUMBER", "342".to_owned());
-    env.insert("TASK_DESCRIPTION", "issue 342 existing branch context".to_owned());
+    env.insert(
+        "TASK_DESCRIPTION",
+        "issue 342 existing branch context".to_owned(),
+    );
     env.insert("EXISTING_BRANCH", String::new());
     env.insert("PR_NUMBER", String::new());
     env
@@ -358,7 +364,11 @@ fn case1_empty_existing_branch_preserves_legacy_behaviour() {
     let env = base_env(&fix);
 
     let r = run_bash(&body, &env, &fix.repo_path);
-    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    assert_eq!(
+        r.status, 0,
+        "step exited {} stderr=\n{}",
+        r.status, r.stderr
+    );
     let json = parse_json(&r.stdout);
     assert_eq!(json["created"], serde_json::Value::Bool(true));
     let bn = json["branch_name"].as_str().unwrap();
@@ -381,7 +391,11 @@ fn case2_existing_local_branch_reused_without_creating() {
     env.insert("GIT_TRACE", "1".to_owned());
 
     let r = run_bash(&body, &env, &fix.repo_path);
-    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    assert_eq!(
+        r.status, 0,
+        "step exited {} stderr=\n{}",
+        r.status, r.stderr
+    );
     let json = parse_json(&r.stdout);
     assert_eq!(
         json["branch_name"].as_str().unwrap(),
@@ -409,7 +423,11 @@ fn case3_remote_only_branch_fetched_and_attached() {
     env.insert("GIT_TRACE", "1".to_owned());
 
     let r = run_bash(&body, &env, &fix.repo_path);
-    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    assert_eq!(
+        r.status, 0,
+        "step exited {} stderr=\n{}",
+        r.status, r.stderr
+    );
     let json = parse_json(&r.stdout);
     assert_eq!(
         json["branch_name"].as_str().unwrap(),
@@ -417,7 +435,10 @@ fn case3_remote_only_branch_fetched_and_attached() {
         "branch_name must equal existing_branch"
     );
     let wp = json["worktree_path"].as_str().unwrap();
-    assert!(Path::new(wp).is_dir(), "worktree path must exist on disk: {wp}");
+    assert!(
+        Path::new(wp).is_dir(),
+        "worktree path must exist on disk: {wp}"
+    );
     assert!(
         !r.stderr.contains("branch -b"),
         "remote-only attach must not use `git branch -b`. stderr=\n{}",
@@ -443,7 +464,11 @@ fn case5_pr_number_resolves_via_gh_shim() {
     env.insert("PATH", path);
 
     let r = run_bash(&body, &env, &fix.repo_path);
-    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    assert_eq!(
+        r.status, 0,
+        "step exited {} stderr=\n{}",
+        r.status, r.stderr
+    );
     let json = parse_json(&r.stdout);
     assert_eq!(json["branch_name"].as_str().unwrap(), "feat/pr-resolved");
     assert_eq!(json["created"], serde_json::Value::Bool(false));
@@ -470,7 +495,11 @@ fn case6_both_set_existing_branch_wins_with_warning() {
     env.insert("PATH", path);
 
     let r = run_bash(&body, &env, &fix.repo_path);
-    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    assert_eq!(
+        r.status, 0,
+        "step exited {} stderr=\n{}",
+        r.status, r.stderr
+    );
     let json = parse_json(&r.stdout);
     assert_eq!(json["branch_name"].as_str().unwrap(), "feat/wins");
     let warn_lc = r.stderr.to_lowercase();
@@ -494,7 +523,11 @@ fn sec_case_invalid_ref_name_rejected() {
     env.insert("EXISTING_BRANCH", "invalid..name".to_owned());
 
     let r = run_bash(&body, &env, &fix.repo_path);
-    assert_ne!(r.status, 0, "must reject invalid ref names; stdout=\n{}", r.stdout);
+    assert_ne!(
+        r.status, 0,
+        "must reject invalid ref names; stdout=\n{}",
+        r.stdout
+    );
     let s = r.stderr.to_lowercase();
     assert!(
         s.contains("check-ref-format") || s.contains("invalid"),
@@ -521,7 +554,10 @@ fn sec_case_shell_metachar_rejected() {
     let fix = GitFixture::new();
     let body = step04_body();
     let mut env = base_env(&fix);
-    env.insert("EXISTING_BRANCH", "feat/$(touch /tmp/pwn-issue-342)".to_owned());
+    env.insert(
+        "EXISTING_BRANCH",
+        "feat/$(touch /tmp/pwn-issue-342)".to_owned(),
+    );
 
     let r = run_bash(&body, &env, &fix.repo_path);
     assert_ne!(r.status, 0, "shell metachars must be rejected");
@@ -566,7 +602,10 @@ fn sec_case_pr_number_leading_dash_rejected() {
     env.insert("PR_NUMBER", "-1".to_owned());
 
     let r = run_bash(&body, &env, &fix.repo_path);
-    assert_ne!(r.status, 0, "negative/leading-dash PR_NUMBER must be rejected");
+    assert_ne!(
+        r.status, 0,
+        "negative/leading-dash PR_NUMBER must be rejected"
+    );
 }
 
 /// Security: malicious `gh` response (invalid ref) is re-validated and rejected.

--- a/tests/integration/existing_branch_context_test.rs
+++ b/tests/integration/existing_branch_context_test.rs
@@ -1,0 +1,596 @@
+//! Integration tests for issue #342 — targeting an existing PR branch via context.
+//!
+//! These tests are written FIRST (TDD red), against the current `default-workflow.yaml`
+//! and `consensus-workflow.yaml`. They MUST fail until step 9 implementation lands:
+//!
+//!   * `default-workflow.yaml` declares `existing_branch` and `pr_number` context vars
+//!     and `step-04-setup-worktree` skips branch creation when `existing_branch` is set.
+//!   * `consensus-workflow.yaml` mirrors the same behaviour in `step3-setup-worktree`.
+//!   * `smart-orchestrator.yaml` declares both vars so they propagate to sub-recipes.
+//!
+//! Test strategy (mirrors `amplifier-bundle/tools/test_default_workflow_fixes.py`):
+//!   * Parse the recipe YAML with `serde_yaml` to extract the `command:` block of the
+//!     worktree-setup step (or the prompt body for the consensus agent step).
+//!   * Drive that block as a `bash -c` subprocess against a real tempdir git repo
+//!     with a bare local origin — no network, no mocking of git.
+//!   * Mock `gh` via a PATH shim for the `pr_number` resolution path.
+//!   * Cover **6 functional cases** + **7 security cases** as enumerated in the
+//!     design spec (D2/D4 in EXISTING_BRANCH_CONTEXT.md §7).
+//!
+//! Stdout contract preserved: `{"worktree_path","branch_name","created"}` JSON only;
+//! all human-readable lines (INFO/WARNING/ERROR) go to stderr.
+
+#![allow(clippy::too_many_lines)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_yaml::Value;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Repo / recipe paths
+// ---------------------------------------------------------------------------
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // bins/amplihack -> bins
+    p.pop(); // bins -> workspace root
+    p
+}
+
+fn default_workflow_yaml() -> PathBuf {
+    workspace_root().join("amplifier-bundle/recipes/default-workflow.yaml")
+}
+
+fn consensus_workflow_yaml() -> PathBuf {
+    workspace_root().join("amplifier-bundle/recipes/consensus-workflow.yaml")
+}
+
+fn smart_orchestrator_yaml() -> PathBuf {
+    workspace_root().join("amplifier-bundle/recipes/smart-orchestrator.yaml")
+}
+
+// ---------------------------------------------------------------------------
+// Recipe parsing helpers
+// ---------------------------------------------------------------------------
+
+/// Load a recipe YAML and return the parsed serde_yaml::Value.
+fn load_recipe(path: &Path) -> Value {
+    let text =
+        fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text)
+        .unwrap_or_else(|e| panic!("parse {} as YAML: {e}", path.display()))
+}
+
+/// Find a step by id under `steps:` and return its `command:` body.
+/// For agent-typed steps without a `command:` field, returns the `prompt:` body.
+fn extract_step_body(recipe: &Value, step_id: &str) -> String {
+    let steps = recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("recipe must have a top-level 'steps' sequence");
+
+    for step in steps {
+        let id = step.get("id").and_then(Value::as_str).unwrap_or("");
+        if id == step_id {
+            if let Some(cmd) = step.get("command").and_then(Value::as_str) {
+                return cmd.to_owned();
+            }
+            if let Some(prompt) = step.get("prompt").and_then(Value::as_str) {
+                return prompt.to_owned();
+            }
+            panic!("step '{step_id}' has neither 'command:' nor 'prompt:' body");
+        }
+    }
+    panic!("step '{step_id}' not found in recipe");
+}
+
+/// Return the recipe's `context:` map.
+fn context_keys(recipe: &Value) -> Vec<String> {
+    let ctx = recipe
+        .get("context")
+        .and_then(Value::as_mapping)
+        .expect("recipe must have a top-level 'context' mapping");
+    ctx.keys()
+        .filter_map(|k| k.as_str().map(str::to_owned))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Git fixture
+// ---------------------------------------------------------------------------
+
+struct GitFixture {
+    _origin: TempDir,
+    _repo: TempDir,
+    repo_path: PathBuf,
+}
+
+fn git(cwd: &Path, args: &[&str]) -> Output {
+    let out = Command::new("git")
+        .args(["-c", "user.email=test@test", "-c", "user.name=test"])
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    out
+}
+
+impl GitFixture {
+    fn new() -> Self {
+        let origin = TempDir::new().expect("origin tempdir");
+        Command::new("git")
+            .args(["init", "--bare", "-b", "main"])
+            .arg(origin.path())
+            .output()
+            .expect("git init --bare");
+
+        let repo = TempDir::new().expect("repo tempdir");
+        let rp = repo.path().to_path_buf();
+        git(&rp, &["init", "-b", "main"]);
+        git(&rp, &["remote", "add", "origin", origin.path().to_str().unwrap()]);
+        fs::write(rp.join("README.md"), "init\n").unwrap();
+        git(&rp, &["add", "README.md"]);
+        git(&rp, &["commit", "-m", "init"]);
+        git(&rp, &["push", "-u", "origin", "HEAD:main"]);
+        // Ensure local 'main' tracks origin/main
+        let _ = Command::new("git")
+            .args(["branch", "--set-upstream-to=origin/main", "main"])
+            .current_dir(&rp)
+            .output();
+
+        Self {
+            _origin: origin,
+            _repo: repo,
+            repo_path: rp,
+        }
+    }
+
+    fn create_local_branch(&self, name: &str) {
+        git(&self.repo_path, &["branch", name, "main"]);
+    }
+
+    fn create_remote_only_branch(&self, name: &str) {
+        // Create on origin without leaving a local ref behind.
+        git(&self.repo_path, &["branch", name, "main"]);
+        git(&self.repo_path, &["push", "origin", name]);
+        git(&self.repo_path, &["branch", "-D", name]);
+        // Drop the local remote-tracking ref so the branch truly is "remote-only"
+        // from the recipe's point of view until it fetches.
+        let _ = Command::new("git")
+            .args(["update-ref", "-d", &format!("refs/remotes/origin/{name}")])
+            .current_dir(&self.repo_path)
+            .output();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// gh PATH shim (for pr_number tests)
+// ---------------------------------------------------------------------------
+
+/// Build a temp dir containing an executable `gh` shim that emits the given
+/// branch name when invoked as `gh pr view <N> --json headRefName -q .headRefName`.
+fn gh_shim(branch_name: &str) -> TempDir {
+    let dir = TempDir::new().expect("gh shim tempdir");
+    let script = format!(
+        "#!/usr/bin/env bash\n\
+         # Test shim — only the headRefName lookup is supported.\n\
+         if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n\
+           printf '%s' '{branch_name}'\n\
+           exit 0\n\
+         fi\n\
+         echo 'gh shim: unsupported invocation' >&2\n\
+         exit 2\n",
+    );
+    let p = dir.path().join("gh");
+    fs::write(&p, script).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = fs::metadata(&p).unwrap().permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(&p, perm).unwrap();
+    }
+    dir
+}
+
+/// Build a malicious gh shim that emits an invalid/dangerous branch name.
+fn gh_shim_malicious(payload: &str) -> TempDir {
+    gh_shim(payload)
+}
+
+// ---------------------------------------------------------------------------
+// Bash runner
+// ---------------------------------------------------------------------------
+
+struct RunResult {
+    status: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_bash(script: &str, env: &HashMap<&str, String>, cwd: &Path) -> RunResult {
+    let mut cmd = Command::new("bash");
+    cmd.arg("-c").arg(script).current_dir(cwd);
+    // Start from a clean env so PATH shims are deterministic.
+    cmd.env_clear();
+    // Preserve a minimal baseline.
+    if let Some(home) = std::env::var_os("HOME") {
+        cmd.env("HOME", home);
+    }
+    let path = env
+        .get("PATH")
+        .cloned()
+        .unwrap_or_else(|| std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".into()));
+    cmd.env("PATH", path);
+    for (k, v) in env {
+        if *k == "PATH" {
+            continue;
+        }
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("spawn bash");
+    RunResult {
+        status: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+fn parse_json(stdout: &str) -> serde_json::Value {
+    // The recipe heredoc may emit leading whitespace per YAML block-scalar
+    // indentation; locate the first '{'.
+    let start = stdout.find('{').unwrap_or_else(|| {
+        panic!("no JSON object in stdout:\n{stdout}");
+    });
+    let slice = &stdout[start..];
+    let end = slice.rfind('}').unwrap_or_else(|| {
+        panic!("no closing brace in stdout:\n{stdout}");
+    });
+    let candidate = &slice[..=end];
+    serde_json::from_str(candidate)
+        .unwrap_or_else(|e| panic!("invalid JSON {candidate:?}: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Default-workflow context-var declaration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_workflow_declares_existing_branch_context_var() {
+    let recipe = load_recipe(&default_workflow_yaml());
+    let keys = context_keys(&recipe);
+    assert!(
+        keys.iter().any(|k| k == "existing_branch"),
+        "default-workflow.yaml must declare 'existing_branch' in its context block. \
+         Found keys: {keys:?}"
+    );
+}
+
+#[test]
+fn default_workflow_declares_pr_number_context_var() {
+    let recipe = load_recipe(&default_workflow_yaml());
+    let keys = context_keys(&recipe);
+    assert!(
+        keys.iter().any(|k| k == "pr_number"),
+        "default-workflow.yaml must declare 'pr_number' in its context block. \
+         Found keys: {keys:?}"
+    );
+}
+
+#[test]
+fn smart_orchestrator_declares_existing_branch_context_var() {
+    let recipe = load_recipe(&smart_orchestrator_yaml());
+    let keys = context_keys(&recipe);
+    assert!(
+        keys.iter().any(|k| k == "existing_branch"),
+        "smart-orchestrator.yaml must declare 'existing_branch' so it propagates to sub-recipes. \
+         Found keys: {keys:?}"
+    );
+}
+
+#[test]
+fn smart_orchestrator_declares_pr_number_context_var() {
+    let recipe = load_recipe(&smart_orchestrator_yaml());
+    let keys = context_keys(&recipe);
+    assert!(
+        keys.iter().any(|k| k == "pr_number"),
+        "smart-orchestrator.yaml must declare 'pr_number' so it propagates to sub-recipes. \
+         Found keys: {keys:?}"
+    );
+}
+
+#[test]
+fn consensus_workflow_declares_existing_branch_context_var() {
+    let recipe = load_recipe(&consensus_workflow_yaml());
+    let keys = context_keys(&recipe);
+    assert!(
+        keys.iter().any(|k| k == "existing_branch"),
+        "consensus-workflow.yaml must declare 'existing_branch' in its context block. \
+         Found keys: {keys:?}"
+    );
+}
+
+#[test]
+fn consensus_workflow_declares_pr_number_context_var() {
+    let recipe = load_recipe(&consensus_workflow_yaml());
+    let keys = context_keys(&recipe);
+    assert!(
+        keys.iter().any(|k| k == "pr_number"),
+        "consensus-workflow.yaml must declare 'pr_number' in its context block. \
+         Found keys: {keys:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Functional cases — drive step-04-setup-worktree directly
+// ---------------------------------------------------------------------------
+
+fn step04_body() -> String {
+    extract_step_body(&load_recipe(&default_workflow_yaml()), "step-04-setup-worktree")
+}
+
+fn base_env(fix: &GitFixture) -> HashMap<&'static str, String> {
+    let mut env = HashMap::new();
+    env.insert("REPO_PATH", fix.repo_path.to_string_lossy().into_owned());
+    env.insert("BRANCH_PREFIX", "feat".to_owned());
+    env.insert("ISSUE_NUMBER", "342".to_owned());
+    env.insert("TASK_DESCRIPTION", "issue 342 existing branch context".to_owned());
+    env.insert("EXISTING_BRANCH", String::new());
+    env.insert("PR_NUMBER", String::new());
+    env
+}
+
+/// Case 1 (functional): empty existing_branch — current behaviour preserved (created=true).
+#[test]
+fn case1_empty_existing_branch_preserves_legacy_behaviour() {
+    let fix = GitFixture::new();
+    let body = step04_body();
+    let env = base_env(&fix);
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    let json = parse_json(&r.stdout);
+    assert_eq!(json["created"], serde_json::Value::Bool(true));
+    let bn = json["branch_name"].as_str().unwrap();
+    assert!(
+        bn.starts_with("feat/issue-342-"),
+        "legacy slug derivation must run when existing_branch is empty; got {bn}"
+    );
+}
+
+/// Case 2 (functional): existing_branch points at a local branch — reuse, created=false,
+/// no `git branch -b` invocation.
+#[test]
+fn case2_existing_local_branch_reused_without_creating() {
+    let fix = GitFixture::new();
+    fix.create_local_branch("feat/pre-existing");
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("EXISTING_BRANCH", "feat/pre-existing".to_owned());
+    // Surface git invocations so we can assert no `branch -b` happens.
+    env.insert("GIT_TRACE", "1".to_owned());
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    let json = parse_json(&r.stdout);
+    assert_eq!(
+        json["branch_name"].as_str().unwrap(),
+        "feat/pre-existing",
+        "branch_name must equal existing_branch"
+    );
+    assert_eq!(json["created"], serde_json::Value::Bool(false));
+    assert!(
+        !r.stderr.contains("branch -b") && !r.stderr.contains("worktree add -b"),
+        "must not invoke `git branch -b` or `git worktree add -b` on reuse path. \
+         GIT_TRACE stderr:\n{}",
+        r.stderr
+    );
+}
+
+/// Case 3 (functional): existing_branch is remote-only — fetched, worktree created,
+/// created=true, still no `git branch -b` (worktree resolves remote ref).
+#[test]
+fn case3_remote_only_branch_fetched_and_attached() {
+    let fix = GitFixture::new();
+    fix.create_remote_only_branch("feat/remote-only");
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("EXISTING_BRANCH", "feat/remote-only".to_owned());
+    env.insert("GIT_TRACE", "1".to_owned());
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    let json = parse_json(&r.stdout);
+    assert_eq!(
+        json["branch_name"].as_str().unwrap(),
+        "feat/remote-only",
+        "branch_name must equal existing_branch"
+    );
+    let wp = json["worktree_path"].as_str().unwrap();
+    assert!(Path::new(wp).is_dir(), "worktree path must exist on disk: {wp}");
+    assert!(
+        !r.stderr.contains("branch -b"),
+        "remote-only attach must not use `git branch -b`. stderr=\n{}",
+        r.stderr
+    );
+}
+
+/// Case 5 (functional): pr_number resolves to a branch via the gh shim.
+#[test]
+fn case5_pr_number_resolves_via_gh_shim() {
+    let fix = GitFixture::new();
+    fix.create_local_branch("feat/pr-resolved");
+    let shim = gh_shim("feat/pr-resolved");
+
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("PR_NUMBER", "342".to_owned());
+    let path = format!(
+        "{}:{}",
+        shim.path().display(),
+        std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".into())
+    );
+    env.insert("PATH", path);
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    let json = parse_json(&r.stdout);
+    assert_eq!(json["branch_name"].as_str().unwrap(), "feat/pr-resolved");
+    assert_eq!(json["created"], serde_json::Value::Bool(false));
+}
+
+/// Case 6 (functional): when both vars are set, existing_branch wins and a warning
+/// is emitted to stderr (precedence rule per design D1).
+#[test]
+fn case6_both_set_existing_branch_wins_with_warning() {
+    let fix = GitFixture::new();
+    fix.create_local_branch("feat/wins");
+    // gh shim returns a *different* branch — must NOT be selected.
+    let shim = gh_shim("feat/loses");
+
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("EXISTING_BRANCH", "feat/wins".to_owned());
+    env.insert("PR_NUMBER", "342".to_owned());
+    let path = format!(
+        "{}:{}",
+        shim.path().display(),
+        std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".into())
+    );
+    env.insert("PATH", path);
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_eq!(r.status, 0, "step exited {} stderr=\n{}", r.status, r.stderr);
+    let json = parse_json(&r.stdout);
+    assert_eq!(json["branch_name"].as_str().unwrap(), "feat/wins");
+    let warn_lc = r.stderr.to_lowercase();
+    assert!(
+        warn_lc.contains("warning") && warn_lc.contains("existing_branch"),
+        "must emit a precedence WARNING on stderr; got:\n{}",
+        r.stderr
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Security cases
+// ---------------------------------------------------------------------------
+
+/// Case 4 (security): invalid branch name (`..`) must be rejected via check-ref-format.
+#[test]
+fn sec_case_invalid_ref_name_rejected() {
+    let fix = GitFixture::new();
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("EXISTING_BRANCH", "invalid..name".to_owned());
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_ne!(r.status, 0, "must reject invalid ref names; stdout=\n{}", r.stdout);
+    let s = r.stderr.to_lowercase();
+    assert!(
+        s.contains("check-ref-format") || s.contains("invalid"),
+        "must reference check-ref-format or 'invalid' in error; got:\n{}",
+        r.stderr
+    );
+}
+
+/// Security: leading-dash branch name (flag injection) rejected.
+#[test]
+fn sec_case_leading_dash_rejected() {
+    let fix = GitFixture::new();
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("EXISTING_BRANCH", "-rf".to_owned());
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_ne!(r.status, 0, "leading-dash branch name must be rejected");
+}
+
+/// Security: shell metachar in branch name rejected.
+#[test]
+fn sec_case_shell_metachar_rejected() {
+    let fix = GitFixture::new();
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("EXISTING_BRANCH", "feat/$(touch /tmp/pwn-issue-342)".to_owned());
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_ne!(r.status, 0, "shell metachars must be rejected");
+    assert!(
+        !Path::new("/tmp/pwn-issue-342").exists(),
+        "command substitution payload must not execute"
+    );
+}
+
+/// Security: path-traversal branch name rejected.
+#[test]
+fn sec_case_path_traversal_rejected() {
+    let fix = GitFixture::new();
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("EXISTING_BRANCH", "../../etc/passwd".to_owned());
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_ne!(r.status, 0, "path-traversal branch name must be rejected");
+}
+
+/// Security: PR_NUMBER non-numeric (arg injection) rejected before reaching gh.
+#[test]
+fn sec_case_pr_number_non_numeric_rejected() {
+    let fix = GitFixture::new();
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("PR_NUMBER", "342 --repo evil/x".to_owned());
+    // Intentionally do not install a gh shim — the input must be rejected
+    // BEFORE any gh invocation.
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_ne!(r.status, 0, "non-numeric PR_NUMBER must be rejected");
+}
+
+/// Security: PR_NUMBER leading-dash arg-injection rejected.
+#[test]
+fn sec_case_pr_number_leading_dash_rejected() {
+    let fix = GitFixture::new();
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("PR_NUMBER", "-1".to_owned());
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_ne!(r.status, 0, "negative/leading-dash PR_NUMBER must be rejected");
+}
+
+/// Security: malicious `gh` response (invalid ref) is re-validated and rejected.
+/// The recipe must NOT trust the upstream API response — it must run the same
+/// `check-ref-format` gate on whatever `gh` emits.
+#[test]
+fn sec_case_malicious_gh_response_rejected() {
+    let fix = GitFixture::new();
+    let shim = gh_shim_malicious("../../etc/passwd");
+
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("PR_NUMBER", "342".to_owned());
+    let path = format!(
+        "{}:{}",
+        shim.path().display(),
+        std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".into())
+    );
+    env.insert("PATH", path);
+
+    let r = run_bash(&body, &env, &fix.repo_path);
+    assert_ne!(
+        r.status, 0,
+        "malicious gh response must be re-validated and rejected; stdout=\n{}",
+        r.stdout
+    );
+}


### PR DESCRIPTION
## Summary

Closes #342.

Adds two optional context variables — `existing_branch` and `pr_number` — to `default-workflow.yaml`, `smart-orchestrator.yaml`, and `consensus-workflow.yaml` so that follow-up orchestrator rounds can target an **existing PR branch** instead of deriving a new slug from `task_description`. When both vars are empty (the default), behaviour is byte-identical to today's recipe (BL-002 idempotency preserved).

## Context-variable contract

| Var | Type | Default | Semantics |
|---|---|---|---|
| `existing_branch` | string | `""` | Reuse this branch verbatim; skip slug derivation. |
| `pr_number` | string (positive integer) | `""` | Resolve via `gh pr view <N> --json headRefName -q .headRefName`. |

**Precedence:** if both are set, `existing_branch` wins and a `WARNING` is emitted to stderr (stdout reserved for the JSON contract).

## step-04-setup-worktree changes

When either variable is set:

1. **Validation gates** (security):
   - `PR_NUMBER` must match `^[1-9][0-9]*$` *before* invoking `gh` (rejects arg-injection like `342 --repo evil/x`, `-1`, `$(rm)`).
   - `gh` response is **re-validated** through `git check-ref-format --branch` so an upstream API result can never bypass the gate.
   - `EXISTING_BRANCH` is validated through the same `check-ref-format` gate.
2. **Fetch** the branch with an explicit refspec so remote-only branches resolve.
3. **Worktree resolution:**
   - If a worktree already exists for the branch → reuse it, `created=false`.
   - Else if `$REPO_PATH` is itself checked out on the branch → use `$REPO_PATH`, `created=false`.
   - Else `git worktree add` under `$REPO_PATH/worktrees/<branch>` (no `-b` for local branches; `--track -b` for remote-only).
4. **JSON contract preserved verbatim** so steps 12/15/16 continue to consume `worktree_setup.worktree_path` unchanged: `{"worktree_path", "branch_name", "created"}`.

The legacy slug-derivation block is **byte-identical** when `EXISTING_BRANCH` and `PR_NUMBER` are both empty.

## Mirroring

`consensus-workflow.yaml` step3-setup-worktree mirrors the same validation gates and resolution algorithm. Both files carry a `# MIRROR:` comment to flag drift in future PRs. A Python parity test enforces the contract at the YAML layer.

## Tests

* **Rust integration** (`tests/integration/existing_branch_context_test.rs`, 596 lines):
  - 6 context-var declaration assertions across all three recipes.
  - 5 functional cases: empty (legacy), local reuse, remote-only fetch, PR resolution, precedence + WARNING.
  - 7 security cases: invalid ref, leading-dash, shell metachars, path traversal, non-numeric PR_NUMBER, leading-dash PR_NUMBER, malicious gh response.
  - **18/18 pass.**
* **Python parity** (`amplifier-bundle/tools/test_default_workflow_fixes.py::TestIssue342ExistingBranchContext`, 6 cases): **6/6 pass.**

## Validation gates

```
cargo clippy --all-targets -- -D warnings   # clean
TMPDIR=/tmp cargo test                       # 1062/1063 pass; the single failure
                                              # (amplihack-cli update::tests) is pre-existing
                                              # on main and unrelated to this PR.
```

## Acceptance criteria

- [x] `existing_branch` and `pr_number` declared in default-workflow.yaml
- [x] step-04-setup-worktree skips slug derivation when either is set
- [x] PR_NUMBER resolves via `gh pr view` with arg-injection guard
- [x] Sibling recipes (`consensus-workflow.yaml`) mirror the logic
- [x] smart-orchestrator.yaml propagates the context vars
- [x] Regression tests at both Rust and Python layers
- [x] Backward compatibility: empty vars => byte-identical legacy behaviour
- [x] cargo clippy --all-targets -- -D warnings clean

## Out of scope

Issues #248 (remove Python from amplifier-bundle recipes) and #285 (port 77 bundled python tools) are not touched in this PR.