### PR TITLE
refactor(recipe): drop python3 session_tree fallback, use native subcommand

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -258,7 +258,7 @@ steps:
       # #283: replace python3 uuid with /proc/sys/kernel/random/uuid (POSIX)
       SESSION_ID=$(tr -d '-' < /proc/sys/kernel/random/uuid | head -c 8)
 
-      # #331: native Rust subcommand replaces python3 $TREE_SCRIPT register
+      # #248: native Rust subcommand for session tree registration
       if OUTPUT=$(amplihack session-tree register "$SESSION_ID" 2>&1); then
         # Output: "TREE_ID=abc123 DEPTH=0"
         TREE_ID=$(echo "$OUTPUT" | grep -oE 'TREE_ID=[A-Za-z0-9_-]+' | head -1 | cut -d= -f2)
@@ -940,7 +940,7 @@ steps:
       TREE_ID=${TREE_ID:-}
       STATUS=${STATUS:-}
 
-      # #331: native Rust subcommand replaces python3 $TREE_SCRIPT complete
+      # #248: native Rust subcommand for session tree completion
       if [ -n "$SESSION_ID" ] && [ "$STATUS" = "ok" ]; then
         AMPLIHACK_TREE_ID="$TREE_ID" amplihack session-tree complete "$SESSION_ID"
         echo "Session $SESSION_ID completed in tree $TREE_ID"


### PR DESCRIPTION
## Summary

Removes lingering `python3 $TREE_SCRIPT` references in comments within `amplifier-bundle/recipes/smart-orchestrator.yaml` so that **no** `TREE_SCRIPT` or python3 session_tree fallback paths remain in the recipe.

The recipe already invokes the native Rust `amplihack session-tree register|complete` subcommand (added in #339). This PR finishes the parity work by removing the now-stale comments that still referenced the legacy Python script. After this change, the validation check passes:

```
$ grep -c "python3.*TREE_SCRIPT\|python3 -m amplihack.runtime_assets" amplifier-bundle/recipes/smart-orchestrator.yaml
0
$ grep -c TREE_SCRIPT amplifier-bundle/recipes/smart-orchestrator.yaml
0
```

## Validation

- `cargo clippy --all-targets -- -D warnings` — passes
- `TMPDIR=/tmp cargo test` — passes (one pre-existing unrelated failure on main: `update::tests::should_not_skip_update_check_for_launch_subcommands`, not affected by this YAML-comment change)
- `grep -c "python3.*TREE_SCRIPT\|python3 -m amplihack.runtime_assets" amplifier-bundle/recipes/smart-orchestrator.yaml` = 0 ✅
- `grep -c TREE_SCRIPT amplifier-bundle/recipes/smart-orchestrator.yaml` = 0 ✅

## Refs

Refs #248
Builds on #339