### PR TITLE
refactor(self-improvement-loop): graceful-skip optional python eval module (closes #248)

### DIFF
--- a/amplifier-bundle/recipes/self-improvement-loop.yaml
+++ b/amplifier-bundle/recipes/self-improvement-loop.yaml
@@ -89,12 +89,33 @@ steps:
       echo "Output: {{output_dir}}/baseline"
       echo ""
 
+      # Probe for python + amplihack.eval.progressive_test_suite (refs #248).
+      # Mirrors the graceful-skip pattern from sdk-comparison.yaml (PR #347):
+      # if neither python3 nor python provides the optional module, emit a
+      # `[skip]` warning to stderr, a synthetic JSON payload to stdout, and
+      # exit 0 so the recipe stays runnable in pure-Rust environments.
+      PY=""
+      for cand in python3 python; do
+        if command -v "$cand" >/dev/null 2>&1; then
+          if PYTHONPATH=src "$cand" -c 'import amplihack.eval.progressive_test_suite' >/dev/null 2>&1; then
+            PY="$cand"
+            break
+          fi
+        fi
+      done
+
+      if [ -z "$PY" ]; then
+        echo "[skip] amplihack.eval.progressive_test_suite not available; skipping run-baseline-eval" >&2
+        echo '{"skipped":true,"reason":"amplihack.eval.progressive_test_suite not installed; step skipped"}'
+        exit 0
+      fi
+
       LEVELS_ARGS=""
       for level in {{levels}}; do
         LEVELS_ARGS="$LEVELS_ARGS $level"
       done
 
-      PYTHONPATH=src python -m amplihack.eval.progressive_test_suite \
+      PYTHONPATH=src "$PY" -m amplihack.eval.progressive_test_suite \
         --output-dir "{{output_dir}}/baseline" \
         --agent-name "{{agent_name}}_baseline_$(date +%s)" \
         --sdk "{{sdk}}" \
@@ -311,12 +332,30 @@ steps:
         exit 0
       fi
 
+      # Probe for python + amplihack.eval.progressive_test_suite (refs #248).
+      # Same graceful-skip pattern as run-baseline-eval / PR #347.
+      PY=""
+      for cand in python3 python; do
+        if command -v "$cand" >/dev/null 2>&1; then
+          if PYTHONPATH=src "$cand" -c 'import amplihack.eval.progressive_test_suite' >/dev/null 2>&1; then
+            PY="$cand"
+            break
+          fi
+        fi
+      done
+
+      if [ -z "$PY" ]; then
+        echo "[skip] amplihack.eval.progressive_test_suite not available; skipping re-eval-affected" >&2
+        echo '{"skipped":true,"reason":"amplihack.eval.progressive_test_suite not installed; step skipped"}'
+        exit 0
+      fi
+
       LEVELS_ARGS=""
       for level in {{levels}}; do
         LEVELS_ARGS="$LEVELS_ARGS $level"
       done
 
-      PYTHONPATH=src python -m amplihack.eval.progressive_test_suite \
+      PYTHONPATH=src "$PY" -m amplihack.eval.progressive_test_suite \
         --output-dir "{{output_dir}}/re_eval" \
         --agent-name "{{agent_name}}_reeval_$(date +%s)" \
         --sdk "{{sdk}}" \


### PR DESCRIPTION
## Summary

Final parity step for #248: wrap the two remaining bare `PYTHONPATH=src python -m amplihack.eval.progressive_test_suite` invocations in `amplifier-bundle/recipes/self-improvement-loop.yaml` (`run-baseline-eval` at L97, `re-eval-affected` at L319) with the same graceful-skip pattern that PR #347 applied to `sdk-comparison.yaml`.

## Pattern (mirrors #347)

Each step now:
1. Probes `python3` then `python` for availability.
2. For each candidate, verifies `amplihack.eval.progressive_test_suite` is importable.
3. On absence: emits `[skip] ...` to **stderr**, a synthetic JSON `{"skipped":true,"reason":"..."}` to **stdout**, and exits `0` — keeping the recipe runnable in pure-Rust environments.
4. On presence: runs the original command via `"$PY"`.

## Audit of remaining `python` references in `amplifier-bundle/recipes/`

After this change, `grep -n python amplifier-bundle/recipes/` only matches:
- Markdown ```python``` code blocks inside agent prompts.
- The existing graceful probes in `sdk-comparison.yaml` (PR #347) and now `self-improvement-loop.yaml`.
- Prose / template variable names in `oxidizer-workflow.yaml` (e.g. `{{python_package_path}}`).
- A pytest invocation in `consensus-workflow.yaml` — out of scope per #248.
- A documentation example in a markdown code block inside `guide.yaml`.

No remaining bare-execution python invocations of `amplihack.eval.*` modules exist.

## Validation

- YAML parses (`yaml.safe_load`) ✅
- `bash -n` on both extracted command bodies ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `TMPDIR=/tmp cargo test` — 1061 pass; 2 pre-existing unrelated failures in `amplihack-cli::update::tests` (verified to also fail on `main` before this change).

Closes #248.
