### PR TITLE
fix(release): unblock Windows build and mark releases as latest (closes #350)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,7 @@ jobs:
           name: "amplihack-rs v${{ needs.version-bump.outputs.version }}"
           files: release-assets/*
           generate_release_notes: true
+          make_latest: "true"
           body: |
             ## Install
 

--- a/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
+++ b/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
@@ -10,6 +10,7 @@ use chrono::Utc;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
+#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -932,13 +933,14 @@ fn tail_output(stdout: impl std::io::Read, log_file: &Path, issue_id: i64, max_l
     let reader = BufReader::new(stdout);
     let mut log_bytes_written: u64 = 0;
 
-    // Open log file with 0o600 permissions
-    let log_fd = fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(log_file);
+    // Open log file with 0o600 permissions on Unix, default permissions on Windows.
+    let log_fd = {
+        let mut opts = fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        opts.mode(0o600);
+        opts.open(log_file)
+    };
 
     let mut log_writer = log_fd.ok();
 
@@ -965,24 +967,31 @@ fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
         fs::create_dir_all(parent)?;
     }
     let tmp_path = path.with_extension("tmp");
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&tmp_path)?;
+    let mut file = {
+        let mut opts = fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        opts.mode(0o600);
+        opts.open(&tmp_path)?
+    };
     file.write_all(data)?;
     file.flush()?;
     fs::rename(&tmp_path, path)?;
     Ok(())
 }
 
-/// Set a file as executable (chmod +x).
+/// Set a file as executable (chmod +x). No-op on Windows.
+#[cfg(unix)]
 fn set_executable(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     let mut perms = fs::metadata(path)?.permissions();
     perms.set_mode(0o755);
     fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<()> {
     Ok(())
 }
 


### PR DESCRIPTION
Two bugs caused every release since v0.8.10 to silently fail:

1. **Windows build broken** in `multitask/orchestrator.rs` — uses Unix-only `OpenOptions::mode()` and `Permissions::set_mode()` without `#[cfg(unix)]` gates. PR #338 added the Windows release target but the `amplihack-cli` lib never actually compiled for `x86_64-pc-windows-msvc`. With `needs: [version-bump, build]` on the `release` job, one failing target blocks publishing.
2. **Releases not marked Latest** — `softprops/action-gh-release@v2` defaults to `make_latest: legacy` so v0.8.9 stayed pinned as Latest while tags v0.8.10–v0.8.19 piled up unpublished. `amplihack update` reports "already up to date" against the stale v0.8.9.

## Diagnosis trail

```
$ gh release list -L 30 --json tagName,isLatest -q '.[] | select(.tagName|startswith("v0.8"))'
v0.8.9  isLatest=true
v0.8.8 ... v0.7.70  (none Latest)

$ git ls-remote --tags origin 'v0.8.*'
... v0.8.18, v0.8.19  ← tags exist with NO release

$ gh run list --workflow=release.yml -L 10 --json conclusion
all 10 most recent runs: failure (Windows build error)
```

The Windows build error from the most recent failing run:
```
error[E0599]: no method named `mode` found for mutable reference `&mut std::fs::OpenOptions`
   --> crates\amplihack-cli\src\commands\multitask\orchestrator.rs:972:10

error[E0599]: no method named `set_mode` found for struct `Permissions`
   --> crates\amplihack-cli\src\commands\multitask\orchestrator.rs:984:11
```

## Changes

**`crates/amplihack-cli/src/commands/multitask/orchestrator.rs`:**
- Gate `use std::os::unix::fs::OpenOptionsExt;` with `#[cfg(unix)]`
- Gate the two `.mode(0o600)` calls (in `tail_output` and `atomic_write`) inside `#[cfg(unix)]` blocks. Windows tmp files get default ACLs, which is standard.
- Split `set_executable` into a unix impl (chmod 0o755) and a windows no-op. Windows uses file extensions for executability, not perm bits.

**`.github/workflows/release.yml`:**
- Add `make_latest: "true"` so each new release is marked Latest.

## Validation

- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` ✅
- `TMPDIR=/tmp cargo test -p amplihack-cli --lib commands::multitask` — 12/12 pass
- Pattern matches `set_script_permissions` in `install/filesystem.rs:283-295` which already compiles on Windows CI.

## Expected outcome after merge

Next push to main → version-bump computes v0.8.20 (since 19 is taken) → all 5 build targets succeed including Windows → release published → marked Latest → `amplihack update` works again.

Closes #350.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>