### PR TITLE
ci: cache install-smoke build to fix 20-min merge bottleneck (closes #353)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Share cache namespace with the native linux build in cross-compile,
+          # so once that job has populated the cache the install-smoke run
+          # hydrates instead of rebuilding the workspace from scratch.
+          key: x86_64-unknown-linux-gnu
       - name: Install from local checkout
         run: cargo install --path bins/amplihack --locked
       - name: Verify binary


### PR DESCRIPTION
The install-smoke job was the only one without `Swatinem/rust-cache@v2` and consistently took 20+ minutes — dominating every PR merge cycle. It was doing a clean release-mode `cargo install --path bins/amplihack --locked` of all 100+ workspace deps from zero on every run.

## Diagnosis

```
Lint & Format:           1m
Test:                    7m  (uses rust-cache)
Build x86_64-linux-gnu:  3m  (uses rust-cache)
Build aarch64-linux-gnu: 3m  (uses rust-cache)
Build *-darwin:          2m  (uses rust-cache)
Install Smoke Test:      20m ← no rust-cache, full release rebuild every run
```

## Fix

Add `Swatinem/rust-cache@v2` with `key: x86_64-unknown-linux-gnu` so the cache namespace is shared with the cross-compile matrix's native linux build. Once cross-compile populates the cache (already happens in ~3 min), install-smoke hydrates and only rebuilds changed crates.

## Expected outcome

- Cold cache (first run): ~same as before (~20 min)
- Warm cache (typical PR): 2-5 min, matching the other build jobs

PR #355 (the release fix that triggered this discovery) waited ~17 of its 20 min total CI time on install-smoke alone. With this change merged, future PRs should clear CI in 5-7 minutes total.

## Risk

Minimal — this adds the same caching action 4 other jobs already use successfully. Cache misses fall back to a fresh build (current behavior).

Closes #353.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>