### PR TITLE
fix(release): gate remaining libc Unix calls in multitask (followup #355)

### DIFF
--- a/crates/amplihack-cli/src/commands/multitask/models.rs
+++ b/crates/amplihack-cli/src/commands/multitask/models.rs
@@ -134,9 +134,19 @@ impl Workstream {
 
     #[allow(dead_code)]
     pub fn is_running(&self) -> bool {
-        if let Some(pid) = self.pid {
+        let Some(pid) = self.pid else {
+            return false;
+        };
+        #[cfg(unix)]
+        {
             unsafe { libc::kill(pid as i32, 0) == 0 }
-        } else {
+        }
+        #[cfg(not(unix))]
+        {
+            // Windows fallback: assume not running unless we have a tighter
+            // signal. The orchestrator does not currently rely on this on
+            // Windows; if it ever does, port to OpenProcess + GetExitCodeProcess.
+            let _ = pid;
             false
         }
     }

--- a/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
+++ b/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
@@ -816,23 +816,33 @@ export AMPLIHACK_MAX_SESSIONS='{max_sessions}'
     }
 
     fn check_disk_space(&self, min_free_gb: f64) -> Result<()> {
-        // Use statvfs to check available space
-        let path_cstr = std::ffi::CString::new(self.base_dir.to_string_lossy().as_bytes())?;
-        unsafe {
-            let mut stat: libc::statvfs = std::mem::zeroed();
-            if libc::statvfs(path_cstr.as_ptr(), &mut stat) == 0 {
-                // macOS `statvfs` uses `u32` fields; Linux uses `u64`. Cast
-                // both so the multiplication type-checks on every target.
-                #[allow(clippy::unnecessary_cast)]
-                let free_bytes = (stat.f_bavail as u64) * (stat.f_frsize as u64);
-                let free_gb = free_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
-                if free_gb < min_free_gb {
-                    bail!(
-                        "Insufficient disk space: {free_gb:.1}GB free, need {min_free_gb}GB minimum"
-                    );
+        #[cfg(unix)]
+        {
+            // Use statvfs to check available space
+            let path_cstr = std::ffi::CString::new(self.base_dir.to_string_lossy().as_bytes())?;
+            unsafe {
+                let mut stat: libc::statvfs = std::mem::zeroed();
+                if libc::statvfs(path_cstr.as_ptr(), &mut stat) == 0 {
+                    // macOS `statvfs` uses `u32` fields; Linux uses `u64`. Cast
+                    // both so the multiplication type-checks on every target.
+                    #[allow(clippy::unnecessary_cast)]
+                    let free_bytes = (stat.f_bavail as u64) * (stat.f_frsize as u64);
+                    let free_gb = free_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+                    if free_gb < min_free_gb {
+                        bail!(
+                            "Insufficient disk space: {free_gb:.1}GB free, need {min_free_gb}GB minimum"
+                        );
+                    }
+                    debug!("Disk space check: {free_gb:.1}GB available");
                 }
-                debug!("Disk space check: {free_gb:.1}GB available");
             }
+        }
+        #[cfg(not(unix))]
+        {
+            // Windows: skip the precondition check. multitask is not yet
+            // wired into Windows release flows; if/when it is, port via
+            // GetDiskFreeSpaceExW. Silently passing is safer than failing.
+            let _ = min_free_gb;
         }
         Ok(())
     }


### PR DESCRIPTION
Followup to #355 — PR #355 fixed the `OpenOptionsExt` usage but the Windows release build is **still** failing on two more unguarded `libc` calls in `multitask`. v0.8.20, v0.8.21, v0.8.22 are all tagged but unpublished as a result.

## Errors observed in CI on main (post-#355)

```
error[E0425]: cannot find function `kill` in crate `libc`
  crates/amplihack-cli/src/commands/multitask/models.rs:138

error[E0425]: cannot find type `statvfs` in crate `libc`
error[E0425]: cannot find function `statvfs` in crate `libc`
  crates/amplihack-cli/src/commands/multitask/orchestrator.rs:822-823
```

## Fix

Both follow the canonical pattern at `nesting/helpers.rs:95-115` and `commands/memory/indexing_job.rs:33-44`:
- Body in `#[cfg(unix)]` block
- `#[cfg(not(unix))]` no-op fallback (`false` / `Ok(())`)
- Inline note pointing at the Win32 equivalents (`OpenProcess` + `GetExitCodeProcess`, `GetDiskFreeSpaceExW`)

## Validation

```
cargo clippy -p amplihack-cli --all-targets -- -D warnings    PASS
```

Cross-compile to `x86_64-pc-windows-gnu` blocked locally by the `lbug` cmake/mingw issue — must be validated by CI on MSVC.

## Why this audit was missed in #355

I grepped `OpenOptionsExt` and `Permissions` for the first round but did not enumerate `libc::` calls. Tracking issue #350 should be expanded with a regression check (clippy lint `unused_unsafe` plus `#[cfg(unix)] cargo check --target x86_64-pc-windows-gnu` step in CI) — separate PR.

Refs #350.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>