### PR TITLE
feat(skills): port multi-language code-visualizer scripts/tests from amplihack #4480

### DIFF
--- a/amplifier-bundle/skills/code-visualizer/README.md
+++ b/amplifier-bundle/skills/code-visualizer/README.md
@@ -1,97 +1,164 @@
 # Code Visualizer
 
-Auto-generates and maintains visual code flow diagrams from Python module analysis.
+Auto-generates and maintains visual code flow diagrams from **multi-language**
+module analysis. Supports **Python, TypeScript/JavaScript, Rust, and Go** out
+of the box, with a brick-style architecture that makes adding a new language
+a single-file change.
 
 ## Quick Start
 
-Simply describe what you want:
+```bash
+# Generate one mermaid diagram per detected language, plus a combined view
+python amplifier-bundle/skills/code-visualizer/scripts/visualizer.py . \
+    --output docs/diagrams --combined
+```
+
+Or just describe what you want:
 
 ```
-Generate a code flow diagram for the auth module
+Generate code flow diagrams for this repo
 ```
 
 ```
 Check if my architecture diagrams are up to date
 ```
 
-```
-Show what architecture changes this PR introduces
-```
-
 ## Features
 
-### Auto-Generation
+### Multi-Language Auto-Detection
 
-Analyzes Python imports and generates mermaid diagrams:
+The dispatcher walks the target path, buckets files by extension, and routes
+each language to its own analyzer:
+
+| Language              | Extensions                                   |
+| --------------------- | -------------------------------------------- |
+| Python                | `.py`                                        |
+| TypeScript/JavaScript | `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` |
+| Rust                  | `.rs`                                        |
+| Go                    | `.go`                                        |
+
+Mixed-language repos produce one diagram per detected language plus an
+optional `--combined` mermaid view with one `subgraph` per language.
+
+### Auto-Generated Diagrams
 
 ```mermaid
 flowchart TD
-    main[main.py] --> auth[auth/]
-    main --> api[api/]
-    auth --> models[models.py]
+    main_py["main.py"] --> auth_py["auth.py"]
+    main_py --> api_py["api.py"]
+    auth_py --> models_py["models.py"]
 ```
 
 ### Staleness Detection
 
-Warns when diagrams become out of sync with code:
+Walks all source files matching detected languages' extensions and compares
+max-mtime against the diagram mtime — works the same way for every supported
+language.
 
 ```
-STALE: README.md diagram (last updated: Jan 1, code changed: Jan 15)
-Missing: new_module.py, api/v2.py
+STALE: docs/diagrams/architecture-python.mmd (sources newer than diagram)
+FRESH: docs/diagrams/architecture-typescript.mmd
 ```
-
-### PR Impact Analysis
-
-Shows architecture changes in pull requests:
-
-- New modules added
-- Changed dependencies
-- Deleted relationships
 
 ## How It Works
 
-1. **Analyze**: Parse Python files for imports and classes
-2. **Generate**: Create mermaid diagrams from relationships (delegates to mermaid-diagram-generator)
-3. **Monitor**: Compare timestamps to detect staleness
-4. **Report**: Provide freshness status and recommendations
+1. **Dispatch**: Detect languages by file extension, skipping `IGNORE_DIRS`
+   (`.git`, `node_modules`, `.venv`, `dist`, `build`, `target`, …) and
+   symlinks.
+2. **Analyze**: Per-language analyzers (`python_analyzer`, `ts_analyzer`,
+   `rust_analyzer`, `go_analyzer`) each expose a single `normalize(paths) ->
+Graph` entry point.
+3. **Render**: A language-blind renderer turns each `Graph` into mermaid.
+4. **Monitor**: A generalized staleness detector compares max-mtime across
+   matching extensions.
 
-## Skill Architecture
+## Architecture
 
 ```
 code-visualizer
-├── Analyzes: Python AST for imports/classes
-├── Detects: Stale diagrams via timestamps
-└── Delegates to:
-    ├── mermaid-diagram-generator (syntax)
-    └── visualization-architect (complex diagrams)
+├── scripts/
+│   ├── graph.py              # Node / Edge / Graph dataclasses (data contract)
+│   ├── dispatcher.py         # Language detection + routing
+│   ├── python_analyzer.py    # ast-based
+│   ├── ts_analyzer.py        # regex-based (.ts/.tsx/.js/.jsx/.mjs/.cjs)
+│   ├── rust_analyzer.py      # regex-based
+│   ├── go_analyzer.py        # regex-based
+│   ├── mermaid_renderer.py   # language-blind
+│   ├── staleness.py
+│   └── visualizer.py         # CLI
+└── tests/
 ```
 
-## Limitations (Important)
+Each analyzer is a self-contained brick. **No shared inheritance.** The only
+coupling is the `Graph` data contract.
 
-- **Staleness is timestamp-based**: 70-80% accuracy, false positives common
-- **Python-only**: No TypeScript/JS/Rust support
-- **Static analysis**: Dynamic imports not detected
-- **Import-centric**: Internal logic changes invisible
+## CLI
 
-See SKILL.md for complete limitations and accuracy expectations.
+```
+python visualizer.py <path> [--output DIR] [--basename NAME]
+                            [--check-staleness] [--combined]
+```
+
+Outputs:
+
+- `<basename>-python.mmd`
+- `<basename>-typescript.mmd`
+- `<basename>-rust.mmd`
+- `<basename>-go.mmd`
+- `<basename>-combined.mmd` (with `--combined`)
+
+Files are only written for languages actually detected.
+
+## Adding a New Language
+
+1. Create `scripts/<lang>_analyzer.py` exposing
+   `normalize(paths) -> Graph`.
+2. Register the extension(s) and module name in `dispatcher.LANGUAGES`.
+3. Add `tests/test_<lang>_analyzer.py`.
+
+That's the entire change. The renderer, staleness detector, and CLI consume
+the language-blind `Graph` and need no modification. See **Extending** in
+`SKILL.md` for the full recipe.
+
+## Limitations
+
+- **Static heuristics**: Regex-based extraction for TS/JS/Rust/Go covers
+  common forms; some edge syntax is documented in source.
+- **Import-centric**: Edges are imports/uses only. No call graphs.
+- **External imports**: Rendered as ghost target nodes; not resolved.
+- **Cross-language edges**: Out of MVP scope; combined view is per-subgraph.
+- **Shell scripts**: Not first-class; ignored.
+
+See `SKILL.md` for the full limitation list and security model.
+
+## Testing
+
+```bash
+pytest amplifier-bundle/skills/code-visualizer/tests -q
+```
+
+The skill ships unit tests for each analyzer, the dispatcher, the renderer,
+and the staleness detector, plus a smoke test that runs the dispatcher
+against the repo root and asserts non-empty mermaid output for both Python
+and TypeScript/JavaScript.
 
 ## Philosophy Alignment
 
-| Principle               | How This Skill Follows It                                           |
-| ----------------------- | ------------------------------------------------------------------- |
-| **Ruthless Simplicity** | Timestamp-based staleness is "good enough" for 90% of cases         |
-| **Zero-BS**             | Real AST parsing, no mock data, honest about limitations            |
-| **Modular Design**      | Single brick, delegates diagram syntax to mermaid-diagram-generator |
+| Principle               | How v2.0 follows it                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------- |
+| **Ruthless Simplicity** | Stdlib-only. Regex over tree-sitter. Max-mtime over semantic diff.                  |
+| **Zero-BS**             | Real parsers; honest about regex edge cases.                                        |
+| **Modular Design**      | Each analyzer is a brick with one `normalize()` stud.                               |
+| **Brick Composition**   | Renderer / dispatcher / staleness are independent bricks sharing only the contract. |
 
 ## Integration
 
 Works with:
 
-- `mermaid-diagram-generator` skill for diagram syntax
+- `mermaid-diagram-generator` skill for diagram syntax helpers
 - `visualization-architect` agent for complex diagrams
-- PR review workflow for impact analysis
 
 ## Dependencies
 
-- **Required**: mermaid-diagram-generator skill
-- **Recommended**: Python 3.8+, Git for enhanced staleness detection
+- **Required**: Python 3.11+ (stdlib only).
+- **Optional**: `mermaid-diagram-generator` skill for advanced styling.

--- a/amplifier-bundle/skills/code-visualizer/SKILL.md
+++ b/amplifier-bundle/skills/code-visualizer/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: code-visualizer
-version: 1.1.0
+version: 2.0.0
 description: |
-  Auto-generates code flow diagrams from Python module analysis.
+  Auto-generates code flow diagrams from multi-language module analysis.
   Detects when architecture diagrams become stale (code changed, diagram didn't).
-  Use when: creating new modules, reviewing PRs for architecture impact, or checking diagram freshness.
+  Supports Python, TypeScript/JavaScript, Rust, and Go out of the box.
+  Use when: creating new modules, reviewing PRs for architecture impact, or
+  checking diagram freshness across polyglot repositories.
   Generates mermaid diagrams showing imports, dependencies, and module relationships.
 invokes:
   skills:
@@ -17,562 +19,399 @@ invokes:
 
 ## Purpose
 
-Automatically generate and maintain visual code flow diagrams. This skill analyzes Python module structure, detects import relationships, and generates mermaid diagrams. It also monitors for staleness when code changes but diagrams don't.
+Automatically generate and maintain visual code flow diagrams across multiple
+programming languages. The skill auto-detects which languages are present in a
+target path, analyzes each one with a dedicated analyzer, and emits one
+mermaid diagram per language plus an optional combined high-level view. It
+also detects when committed diagrams are stale relative to the source they
+describe.
 
-## Philosophy Alignment
+## What's New in 2.0.0
 
-This skill embodies amplihack's core philosophy:
+- **Multi-language support**: Python, TypeScript/JavaScript, Rust, and Go.
+- **Language dispatcher**: Detects languages by file extension and routes to
+  per-language analyzers.
+- **Language-blind renderer**: A single mermaid renderer consumes a normalized
+  graph; the renderer never inspects language semantics.
+- **One diagram per language** plus an optional `--combined` view that places
+  each language in its own mermaid `subgraph`.
+- **Generalized staleness**: Walks all source files matching detected
+  languages' extensions and compares max-mtime against the diagram mtime.
+- **Brick-style architecture**: Each language analyzer is a self-contained
+  module that exposes a single `normalize()` function. No shared inheritance.
 
-### Ruthless Simplicity
+## Supported Languages
 
-- **Single responsibility**: Visualize code structure - nothing more
-- **Minimal dependencies**: Uses only Python AST for analysis, delegates diagram syntax to mermaid-diagram-generator
-- **No over-engineering**: Timestamp-based staleness is simple and "good enough" for 90% of cases
+| Language              | Extensions                                   | Analyzer          | Parser | Notes                                                            |
+| --------------------- | -------------------------------------------- | ----------------- | ------ | ---------------------------------------------------------------- |
+| Python                | `.py`                                        | `python_analyzer` | `ast`  | Extracts `import` and `from … import …`.                         |
+| TypeScript/JavaScript | `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` | `ts_analyzer`     | regex  | Extracts `import … from`, `require(...)`, dynamic `import(...)`. |
+| Rust                  | `.rs`                                        | `rust_analyzer`   | regex  | Extracts `use crate::…`, `use super::…`, `mod …`.                |
+| Go                    | `.go`                                        | `go_analyzer`     | regex  | Extracts single and grouped `import` declarations.               |
 
-### Zero-BS Implementation
+Languages outside this table are skipped silently. See **Extending** below to
+add new ones.
 
-- **Real analysis**: Actually parses Python AST to extract imports - no mock data
-- **Honest limitations**: Staleness detection is timestamp-based, not semantic (see Limitations section)
-- **Working code**: All algorithms shown are functional, not pseudocode
-
-### Modular Design (Bricks & Studs)
-
-- **This skill is one brick**: Code analysis and staleness detection
-- **Delegates to other bricks**: mermaid-diagram-generator for syntax, visualization-architect for complex diagrams
-- **Clear studs (public contract)**: Analyze modules, generate diagrams, check freshness
-
-## Skill Delegation Architecture
+## Architecture
 
 ```
-code-visualizer (this skill)
-├── Responsibilities:
-│   ├── Python module analysis (AST parsing)
-│   ├── Import relationship extraction
-│   ├── Staleness detection (timestamp-based)
-│   └── Orchestration of diagram generation
-│
-└── Delegates to:
-    ├── mermaid-diagram-generator skill
-    │   ├── Mermaid syntax generation
-    │   ├── Diagram formatting and styling
-    │   └── Markdown embedding
-    │
-    └── visualization-architect agent
-        ├── Complex multi-level architecture
-        ├── ASCII art alternatives
-        └── Cross-module dependency graphs
+amplifier-bundle/skills/code-visualizer/
+├── SKILL.md
+├── README.md
+└── scripts/
+    ├── __init__.py
+    ├── graph.py              # Normalized data contract (Node, Edge, Graph)
+    ├── python_analyzer.py    # normalize(paths) -> Graph
+    ├── ts_analyzer.py        # normalize(paths) -> Graph
+    ├── rust_analyzer.py      # normalize(paths) -> Graph
+    ├── go_analyzer.py        # normalize(paths) -> Graph
+    ├── dispatcher.py         # detect languages, route, return dict[lang, Graph]
+    ├── mermaid_renderer.py   # render(graph) / render_combined(graphs)
+    ├── staleness.py          # is_stale(target, diagram, languages)
+    └── visualizer.py         # CLI entry point
 ```
 
-**Invocation Pattern:**
+### Data Contract (`graph.py`)
 
 ```python
-# code-visualizer analyzes code structure
-modules = analyze_python_modules("src/")
-relationships = extract_import_relationships(modules)
+@dataclass(frozen=True)
+class Node:
+    id: str           # mermaid-safe identifier
+    label: str        # human-readable label (e.g. "src/auth/oauth.py")
+    language: str     # "python" | "typescript" | "rust" | "go"
+    file_path: str    # absolute path on disk
 
-# Then delegates to mermaid-diagram-generator for syntax
-Skill(skill="mermaid-diagram-generator")
-# Provide: Module relationships, diagram type (flowchart/class), styling preferences
-# Receive: Valid mermaid syntax ready for embedding
+@dataclass(frozen=True)
+class Edge:
+    src: str          # Node.id of source
+    dst: str          # Node.id of destination
+    kind: str         # "import" | "require" | "use" | "mod" | "dynamic_import"
 
-# For complex architectures, delegates to visualization-architect
-Task(subagent_type="visualization-architect", prompt="Create multi-level diagram for...")
+@dataclass(frozen=True)
+class Graph:
+    language: str
+    nodes: tuple[Node, ...]
+    edges: tuple[Edge, ...]
 ```
 
-## When to Use This Skill
+Analyzers may **import** these dataclasses but must not inherit from any
+shared class. The data contract is the only coupling.
 
-- **New Module Creation**: Auto-generate architecture diagram for new modules
-- **PR Reviews**: Show architecture impact of proposed changes
-- **Staleness Detection**: Check if existing diagrams reflect current code
-- **Dependency Analysis**: Visualize import relationships
-- **Refactoring**: Understand module dependencies before changes
+### Per-Language Analyzers
+
+Each analyzer is a self-contained brick exposing exactly one entry point:
+
+```python
+def normalize(paths: Iterable[Path]) -> Graph: ...
+```
+
+The function:
+
+1. Reads each file with `encoding="utf-8", errors="ignore"`.
+2. Skips files larger than ~5 MB.
+3. Wraps parsing in `try/except` and skips files that fail to parse.
+4. Returns a `Graph` whose `language` field matches the analyzer.
+
+### Dispatcher
+
+The dispatcher uses a registry that maps language name → extensions + module
+name (string). It loads analyzers lazily via `importlib.import_module` so
+adding a new language never requires touching the dispatcher's import
+statements.
+
+```python
+from scripts.dispatcher import analyze
+
+graphs: dict[str, Graph] = analyze(target_path)
+# {"python": Graph(...), "typescript": Graph(...)}
+```
+
+The dispatcher:
+
+- Walks `target_path` with `os.walk(..., followlinks=False)`.
+- Skips `IGNORE_DIRS` (`.git`, `node_modules`, `.venv`, `venv`, `__pycache__`,
+  `dist`, `build`, `target`, `.mypy_cache`, `.pytest_cache`, `.tox`).
+- Buckets files by extension into language groups.
+- Calls each language's `normalize()` with its file list.
+- Returns a `dict[language_name, Graph]` for languages that produced any
+  files.
+
+### Mermaid Renderer
+
+The renderer is language-blind:
+
+```python
+from scripts.mermaid_renderer import render, render_combined
+
+per_language: str = render(graph)            # one diagram for one language
+combined: str = render_combined(graphs)      # one diagram, one subgraph/lang
+```
+
+Node IDs are sanitized (`[^A-Za-z0-9_] -> _`) and labels with quotes are
+escaped to prevent diagram-syntax injection.
+
+### Staleness Detection
+
+```python
+from scripts.staleness import is_stale
+
+stale = is_stale(
+    target_path=Path("src/"),
+    diagram_path=Path("docs/architecture-python.mmd"),
+    languages=["python"],
+)
+```
+
+Returns `True` if any source file with a matching language extension has an
+mtime newer than `diagram_path`. Generalizes the previous Python-only
+behavior.
+
+## CLI
+
+The skill ships a single executable: `scripts/visualizer.py`.
+
+```
+python visualizer.py <path> [--output DIR] [--basename NAME]
+                            [--check-staleness] [--combined]
+```
+
+| Flag                | Default        | Purpose                                                               |
+| ------------------- | -------------- | --------------------------------------------------------------------- |
+| `<path>`            | _required_     | Directory to analyze. Must exist and be a directory.                  |
+| `--output DIR`      | `./diagrams`   | Output directory for `.mmd` files.                                    |
+| `--basename NAME`   | `architecture` | Filename stem. Validated against `^[A-Za-z0-9._-]+$`.                 |
+| `--check-staleness` | off            | Print staleness report for existing diagrams; exit non-zero if stale. |
+| `--combined`        | off            | Also write `<basename>-combined.mmd` containing all languages.        |
+
+### Output Files
+
+| File                                          | Contents                                               |
+| --------------------------------------------- | ------------------------------------------------------ |
+| `<basename>-python.mmd`                       | Mermaid diagram for Python modules and their imports.  |
+| `<basename>-typescript.mmd`                   | Mermaid diagram for TS/JS files and their imports.     |
+| `<basename>-rust.mmd`                         | Mermaid diagram for Rust modules and `use` edges.      |
+| `<basename>-go.mmd`                           | Mermaid diagram for Go packages and `import` edges.    |
+| `<basename>-combined.mmd` (with `--combined`) | One diagram with one `subgraph` per detected language. |
+
+Files are only written for languages that were actually detected.
 
 ## Quick Start
 
-### Generate Diagram for Module
+### Generate diagrams for a polyglot repo
 
-```
-User: Generate a code flow diagram for the authentication module
-```
-
-### Check Diagram Freshness
-
-```
-User: Are my architecture diagrams up to date?
+```bash
+python amplifier-bundle/skills/code-visualizer/scripts/visualizer.py . \
+    --output docs/diagrams --combined
 ```
 
-### Show PR Impact
+Output (for this repo, which contains Python and JS):
 
 ```
-User: What architecture changes does this PR introduce?
+docs/diagrams/architecture-python.mmd
+docs/diagrams/architecture-typescript.mmd
+docs/diagrams/architecture-combined.mmd
 ```
 
-## Core Capabilities
+### Check freshness in CI
 
-### 1. Module Analysis
-
-Analyzes Python files to extract:
-
-- Import statements (internal and external)
-- Class definitions and inheritance
-- Function exports (`__all__`)
-- Module dependencies
-
-### 2. Diagram Generation
-
-Creates mermaid diagrams showing:
-
-- Module relationships (flowchart)
-- Class hierarchies (class diagram)
-- Data flow between components
-- Dependency graphs
-
-### 3. Staleness Detection
-
-Compares:
-
-- File modification timestamps
-- Git history for changes
-- Diagram content vs actual code structure
-- Missing modules in diagrams
-
-## Analysis Process
-
-### Step 1: Discover Modules
-
-```python
-# Scan target directory for Python modules
-modules = glob("**/*.py")
-packages = identify_packages(modules)
+```bash
+python amplifier-bundle/skills/code-visualizer/scripts/visualizer.py src/ \
+    --output docs/diagrams --check-staleness
+# exits 1 if any per-language diagram is older than its source set
 ```
 
-### Step 2: Extract Relationships
+### Generate for a single language
 
-For each module:
+Provide a path that only contains files of one language; the dispatcher will
+detect a single language and emit a single `.mmd`:
 
-1. Parse import statements
-2. Identify local vs external imports
-3. Build dependency graph
-4. Detect circular dependencies
+```bash
+python visualizer.py src/auth/      # Python-only -> architecture-python.mmd
+```
 
-### Step 3: Generate Diagram
+## Auto-Detection Rules
+
+1. The dispatcher walks `<path>`, skipping `IGNORE_DIRS` and symlinks.
+2. Files are bucketed by extension into one of the supported languages.
+3. A language is "detected" if at least one file matches.
+4. Each detected language is analyzed independently.
+5. With `--combined`, the renderer composes one mermaid diagram with one
+   `subgraph` per detected language. Cross-language edges are not inferred in
+   the MVP.
+
+## Example Output
+
+For a repo with:
+
+- `src/api.py` importing `src/auth.py`
+- `web/index.ts` importing `web/utils.ts`
+
+`architecture-python.mmd`:
 
 ```mermaid
 flowchart TD
-    subgraph core["Core Modules"]
-        auth[auth.py]
-        users[users.py]
-        api[api.py]
-    end
-
-    subgraph utils["Utilities"]
-        helpers[helpers.py]
-        validators[validators.py]
-    end
-
-    api --> auth
-    api --> users
-    auth --> helpers
-    users --> validators
+    src_api_py["src/api.py"]
+    src_auth_py["src/auth.py"]
+    src_api_py --> src_auth_py
 ```
 
-### Step 4: Check Freshness
-
-Compare diagram timestamps with source files:
-
-- Diagram older than sources = STALE
-- Missing modules in diagram = INCOMPLETE
-- Extra modules in diagram = OUTDATED
-
-## Diagram Types
-
-### Module Dependency Graph
-
-Best for: Showing import relationships between files
-
-```mermaid
-flowchart LR
-    main[main.py] --> auth[auth/]
-    main --> api[api/]
-    auth --> models[models.py]
-    api --> auth
-```
-
-### Class Hierarchy
-
-Best for: Showing inheritance and composition
-
-```mermaid
-classDiagram
-    class BaseService {
-        +process()
-    }
-    class AuthService {
-        +login()
-        +logout()
-    }
-    BaseService <|-- AuthService
-```
-
-### Data Flow
-
-Best for: Showing how data moves through system
+`architecture-typescript.mmd`:
 
 ```mermaid
 flowchart TD
-    Request[HTTP Request] --> Validate{Validate}
-    Validate -->|Valid| Process[Process]
-    Validate -->|Invalid| Error[Return Error]
-    Process --> Response[HTTP Response]
+    web_index_ts["web/index.ts"]
+    web_utils_ts["web/utils.ts"]
+    web_index_ts --> web_utils_ts
 ```
 
-## Staleness Detection
-
-### How It Works
-
-1. **Find Diagrams**: Locate mermaid diagrams in README.md, ARCHITECTURE.md
-2. **Extract Modules**: Parse diagram for referenced modules
-3. **Compare**: Check if all current modules are represented
-4. **Report**: Generate freshness report
-
-### Freshness Report Format
-
-```markdown
-## Diagram Freshness Report
-
-### Status: STALE
-
-**Diagrams Checked**: 3
-**Fresh**: 1
-**Stale**: 2
-
-### Details
-
-| File         | Last Updated | Code Changed | Status |
-| ------------ | ------------ | ------------ | ------ |
-| README.md    | 2025-01-01   | 2025-01-15   | STALE  |
-| docs/ARCH.md | 2025-01-10   | 2025-01-10   | FRESH  |
-
-### Missing from Diagrams
-
-- `new_module.py` (added 2025-01-12)
-- `api/v2.py` (added 2025-01-14)
-
-### Recommended Actions
-
-1. Update README.md architecture diagram
-2. Add new_module.py to dependency graph
-```
-
-## PR Architecture Impact
-
-### What It Shows
-
-For a given PR or set of changes:
-
-1. New modules/files added
-2. Changed import relationships
-3. Deleted dependencies
-4. Modified class hierarchies
-
-### Impact Diagram
+`architecture-combined.mmd`:
 
 ```mermaid
 flowchart TD
-    subgraph added["New"]
-        style added fill:#90EE90
-        new_api[api/v2.py]
+    subgraph python ["python"]
+        src_api_py["src/api.py"]
+        src_auth_py["src/auth.py"]
+        src_api_py --> src_auth_py
     end
-
-    subgraph modified["Modified"]
-        style modified fill:#FFE4B5
-        auth[auth.py]
+    subgraph typescript ["typescript"]
+        web_index_ts["web/index.ts"]
+        web_utils_ts["web/utils.ts"]
+        web_index_ts --> web_utils_ts
     end
-
-    subgraph existing["Unchanged"]
-        users[users.py]
-        models[models.py]
-    end
-
-    new_api --> auth
-    auth --> models
-    users --> models
 ```
 
-## Integration with Other Skills
+> Note: the renderer emits the `subgraph <id> ["<label>"]` form (space
+> between id and bracketed label), which is the Mermaid-documented syntax
+> accepted across recent Mermaid versions. `test_mermaid_renderer.py` pins
+> the exact emitted form.
 
-### Mermaid Diagram Generator
+## Extending: Adding a New Language
 
-This skill uses `mermaid-diagram-generator` for:
+The skill follows the brick philosophy: a new language is a new self-contained
+module. There is **no base class to subclass**.
 
-- Syntax generation
-- Diagram formatting
-- Embedding in markdown
+1. Create `scripts/<lang>_analyzer.py` with the entry point:
 
-### Visualization Architect Agent
+   ```python
+   from collections.abc import Iterable
+   from pathlib import Path
+   from graph import Edge, Graph, Node  # sibling import; works under `python visualizer.py`
 
-Delegates to `visualization-architect` for:
+   def normalize(paths: Iterable[Path]) -> Graph:
+       nodes: list[Node] = []
+       edges: list[Edge] = []
+       for p in paths:
+           # parse file, append nodes/edges
+           ...
+       return Graph(language="<lang>", nodes=tuple(nodes), edges=tuple(edges))
+   ```
 
-- Complex architecture visualization
-- ASCII art alternatives
-- Multi-level diagrams
+2. Register the language in `scripts/dispatcher.py`:
 
-## Usage Examples
+   ```python
+   LANGUAGES = {
+       "python":     {"exts": {".py"},                          "module": "python_analyzer"},
+       "typescript": {"exts": {".ts", ".tsx", ".js", ".jsx",
+                               ".mjs", ".cjs"},                 "module": "ts_analyzer"},
+       "rust":       {"exts": {".rs"},                          "module": "rust_analyzer"},
+       "go":         {"exts": {".go"},                          "module": "go_analyzer"},
+       # add here:
+       "<lang>":     {"exts": {".ext"},                         "module": "<lang>_analyzer"},
+   }
+   ```
 
-### Example 1: New Module Diagram
+3. Add `tests/test_<lang>_analyzer.py` with `tmp_path` fixtures asserting
+   nodes and edges produced by representative source snippets.
 
-```
-User: I just created a new payment module. Generate an architecture diagram.
+4. Update the **Supported Languages** table above.
 
-Claude:
-1. Analyzes payment/ directory
-2. Extracts imports and dependencies
-3. Generates mermaid flowchart
-4. Suggests where to embed (README.md)
-```
+That's it. The renderer, dispatcher routing, staleness detector, and CLI all
+work without further changes because they consume the language-blind `Graph`
+data contract.
 
-### Example 2: Check Staleness
+## Testing
 
-```
-User: Are my diagrams up to date?
+Tests live under `amplifier-bundle/skills/code-visualizer/tests/` and run via
+`pytest`. The skill registers its `tests/` directory in the repo's
+`pytest.ini` `testpaths` so CI picks them up automatically.
 
-Claude:
-1. Finds all mermaid diagrams in docs
-2. Compares with current codebase
-3. Reports stale diagrams
-4. Lists missing modules
-5. Suggests updates
-```
+Test files:
 
-### Example 3: PR Impact
+| File                       | Purpose                                                              |
+| -------------------------- | -------------------------------------------------------------------- |
+| `test_python_analyzer.py`  | AST-driven import extraction; verifies edges for `import`/`from`.    |
+| `test_ts_analyzer.py`      | `import`/`require`/dynamic `import()`; type-only and relative paths. |
+| `test_dispatcher.py`       | Mixed-language fixture; verifies correct routing per extension.      |
+| `test_mermaid_renderer.py` | Empty graphs, non-empty graphs, ID/label sanitization.               |
+| `test_staleness.py`        | Mtime comparison across multiple language extensions.                |
+| `test_smoke_repo.py`       | Runs dispatcher against the repo root; asserts non-empty mermaid     |
+|                            | for both Python and TypeScript/JavaScript.                           |
 
-```
-User: Show architecture impact of this PR
+Run only the skill's tests:
 
-Claude:
-1. Gets changed files from PR
-2. Identifies new/modified/deleted modules
-3. Generates impact diagram
-4. Highlights dependency changes
-```
-
-## Detection Algorithms
-
-### Import Analysis
-
-```python
-# Extract imports from Python file
-import ast
-
-def extract_imports(file_path):
-    """Extract import statements from Python file."""
-    tree = ast.parse(Path(file_path).read_text())
-    imports = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                imports.append(alias.name)
-        elif isinstance(node, ast.ImportFrom):
-            if node.module:
-                imports.append(node.module)
-    return imports
+```bash
+pytest amplifier-bundle/skills/code-visualizer/tests -q
 ```
 
-### Staleness Check
+## Security Considerations
 
-```python
-def check_staleness(diagram_file, source_dir):
-    """Check if diagram is stale compared to source."""
-    diagram_mtime = Path(diagram_file).stat().st_mtime
-
-    for source in Path(source_dir).rglob("*.py"):
-        if source.stat().st_mtime > diagram_mtime:
-            return True, source  # Stale
-
-    return False, None  # Fresh
-```
-
-## Best Practices
-
-### When to Update Diagrams
-
-1. **New modules**: Add to dependency graph
-2. **Changed imports**: Update relationships
-3. **Deleted files**: Remove from diagrams
-4. **Architectural changes**: Regenerate completely
-
-### Diagram Placement
-
-| Diagram Type          | Recommended Location |
-| --------------------- | -------------------- |
-| Module overview       | README.md            |
-| Detailed architecture | docs/ARCHITECTURE.md |
-| Package structure     | package/README.md    |
-| API flow              | api/README.md        |
-
-### Naming Conventions
-
-````markdown
-## Architecture
-
-<!-- code-visualizer:auto-generated -->
-<!-- last-updated: 2025-01-15 -->
-<!-- source-hash: abc123 -->
-
-```mermaid
-flowchart TD
-    ...
-```
-````
-
-## Success Criteria
-
-A good visualization:
-
-- [ ] Shows all current modules
-- [ ] Reflects actual import relationships
-- [ ] Uses appropriate diagram type
-- [ ] Placed in discoverable location
-- [ ] Includes freshness metadata
-- [ ] Clear and not overcrowded
+- **No code execution**: Analyzers only parse source. No `exec`/`eval`/
+  subprocess on analyzed files.
+- **Path validation**: `<path>` and `--output` are resolved with
+  `Path.resolve()` and rejected if non-existent or non-directory.
+- **Filename validation**: `--basename` must match `^[A-Za-z0-9._-]+$`.
+- **Symlink safety**: `os.walk(..., followlinks=False)` plus `IGNORE_DIRS`
+  prevents loops and escape.
+- **Bounded reads**: Per-file size cap (~5 MB); UTF-8 decode with
+  `errors="ignore"`.
+- **Bounded regex**: Anchored, no nested quantifiers; protects against ReDoS.
+- **Mermaid sanitization**: Node IDs strip non-`[A-Za-z0-9_]`; labels with
+  embedded quotes are escaped.
+- **Stdlib-only**: Zero third-party runtime dependencies; no supply-chain
+  surface.
+- **Output containment**: Writes are constrained to the resolved `--output`
+  directory; source content is never logged.
 
 ## Limitations
 
-**IMPORTANT**: Understand these limitations before relying on this skill:
+- **Static heuristics**: Regex-based extraction for TS/JS/Rust/Go misses some
+  edge syntax (TS type-only imports across multiple lines, Rust nested
+  `use {a, b::c}`, Go cgo blocks). Documented per analyzer in source.
+- **No call graphs**: Edges are import/use only. Runtime/dynamic imports
+  beyond `import("...")`/`__import__` are not modeled.
+- **External imports**: Rendered as ghost target nodes inline; not resolved to
+  real files.
+- **Combined view**: Cross-language edges are out of MVP scope.
+- **Shell scripts**: Not first-class; `.sh` files are ignored.
+- **Compiler-grade accuracy**: Not a goal. The skill optimizes for "useful
+  diagram in seconds" over "perfect AST."
 
-### Staleness Detection Limitations
+## Philosophy Alignment
 
-1. **Timestamp-based, not semantic**: Detection compares file modification times, not actual code changes
-   - A file touched but not meaningfully changed will trigger "stale"
-   - Reformatting code triggers false positives
-   - Git operations that update mtime trigger false positives
+| Principle               | How v2.0 follows it                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| **Ruthless Simplicity** | Stdlib-only; regex over tree-sitter; max-mtime over semantic diff.                   |
+| **Zero-BS**             | Real parsers (`ast` for Python, regex for others). Limitations documented honestly.  |
+| **Modular Design**      | Each analyzer is a brick with a single `normalize()` stud. No inheritance.           |
+| **Brick Composition**   | Renderer/dispatcher/staleness are independent bricks reusing only the data contract. |
 
-2. **Cannot detect logic changes**: Adding a function that doesn't change imports won't be detected
-   - Internal refactoring within a module is invisible
-   - Changes to function signatures not reflected
-   - New class methods added without import changes won't show
+## Migration from 1.x
 
-3. **Import-centric view**: Only tracks import relationships
-   - Runtime dependencies (dependency injection) not detected
-   - Configuration-based connections invisible
-   - Duck typing relationships not captured
+The 1.x skill was Python-only. Forward-compatibility notes (verify against
+your actual 1.x integration before relying on them):
 
-### Scope Limitations
-
-1. **Python-only**: Currently only analyzes Python files
-   - No TypeScript, JavaScript, Rust, Go support
-   - Multi-language projects partially covered
-
-2. **Static analysis only**: No runtime information
-   - Dynamic imports (`__import__`, `importlib`) not detected
-   - Conditional imports may be missed
-   - Plugin architectures not fully represented
-
-3. **Single-project scope**: Cannot analyze cross-repository dependencies
-   - External package internals not shown
-   - Monorepo relationships require manual configuration
-
-### Accuracy Expectations
-
-| Scenario                      | Accuracy | Notes                       |
-| ----------------------------- | -------- | --------------------------- |
-| New module detection          | 95%+     | Reliable for Python modules |
-| Import relationship mapping   | 90%+     | Misses dynamic imports      |
-| Staleness detection           | 70-80%   | False positives common      |
-| Circular dependency detection | 85%+     | May miss complex cycles     |
-| Class hierarchy extraction    | 85%+     | Mixins can be tricky        |
-
-### When NOT to Use This Skill
-
-- **Security-critical dependency audits**: Use proper security scanning tools
-- **Runtime dependency analysis**: Use profilers or dynamic analysis tools
-- **Cross-language projects**: Manual analysis may be more accurate
-- **Heavily dynamic codebases**: Plugin architectures, metaprogramming
-
-## Dependencies
-
-This skill requires:
-
-1. **mermaid-diagram-generator skill**: Must be available for diagram syntax generation
-2. **Python 3.8+**: For AST parsing features used
-3. **Git (optional)**: For enhanced staleness detection using git history
-
-If mermaid-diagram-generator is unavailable, this skill will provide raw relationship data but cannot generate embedded diagrams.
-
-## PR Review Integration
-
-### How Diagrams Appear in PRs
-
-When reviewing PRs, this skill generates impact diagrams that can be added to PR descriptions:
-
-**PR Description Template:**
-
-````markdown
-## Architecture Impact
-
-<!-- Generated by code-visualizer -->
-
-### Changed Dependencies
-
-```mermaid
-flowchart LR
-    subgraph changed["Modified Modules"]
-        style changed fill:#FFE4B5
-        auth[auth/service.py]
-        api[api/routes.py]
-    end
-
-    subgraph added["New Modules"]
-        style added fill:#90EE90
-        oauth[auth/oauth.py]
-    end
-
-    subgraph unchanged["Existing"]
-        models[models/user.py]
-        db[db/connection.py]
-    end
-
-    oauth --> auth
-    auth --> models
-    api --> auth
-    api --> db
-```
-
-### Impact Summary
-
-- **New modules**: 1 (oauth.py)
-- **Modified modules**: 2 (auth/service.py, api/routes.py)
-- **New dependencies**: oauth.py -> auth/service.py
-- **Diagrams to update**: README.md (STALE)
-````
-
-### CI Integration Example
-
-Add to `.github/workflows/pr-review.yml`:
-
-```yaml
-- name: Check Diagram Staleness
-  run: |
-    # Claude Code analyzes and reports
-    # Outputs: STALE diagrams that need updating
-    # Generates: Suggested diagram updates
-```
-
-### Reviewer Workflow
-
-1. **PR opened** -> code-visualizer generates impact diagram
-2. **Reviewer sees** -> Visual diff of architecture changes
-3. **Staleness check** -> Warns if existing diagrams need updates
-4. **Action items** -> Lists diagrams requiring manual update
+1. Diagrams previously named `<basename>.mmd` are now
+   `<basename>-python.mmd`. Update any references in `README.md` /
+   `ARCHITECTURE.md`.
+2. Staleness reports now include a per-language breakdown. CI scripts that
+   parsed the old single-line output should be updated to handle multiple
+   languages.
+3. Any direct Python helper used in 1.x is superseded by
+   `dispatcher.analyze(path)` returning a `dict[language, Graph]`. Callers
+   that only want Python can use `dispatcher.analyze(path)["python"]`.
 
 ## Remember
 
-This skill automates what developers often forget:
-
-- Keeping diagrams in sync with code
-- Documenting architecture changes
-- Understanding dependency impacts
-
-The goal is diagrams that stay fresh automatically.
-
-**But remember the limitations**: Staleness detection is approximate. When accuracy matters, verify manually.
+The skill automates what developers forget across all four supported
+languages: keeping diagrams in sync with code. It's not a compiler; it's a
+fast, honest, multi-language snapshot.

--- a/amplifier-bundle/skills/code-visualizer/scripts/dispatcher.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/dispatcher.py
@@ -43,6 +43,8 @@ IGNORE_DIRS = frozenset(
         ".mypy_cache",
         ".pytest_cache",
         ".ruff_cache",
+        "worktrees",  # amplihack worktree pool — scanning these duplicates source files
+        ".amplihack-worktrees",
     }
 )
 

--- a/amplifier-bundle/skills/code-visualizer/scripts/dispatcher.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/dispatcher.py
@@ -1,0 +1,107 @@
+"""Language dispatcher: scan a path, group files by language, route to analyzers.
+
+Loads each language's analyzer via `importlib` (string module name in the
+registry) so the dispatcher has no compile-time dependency on any specific
+analyzer module.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path as _Path
+
+_HERE = _Path(__file__).resolve().parent
+if str(_HERE) not in _sys.path:
+    _sys.path.insert(0, str(_HERE))
+
+import importlib
+import logging
+import os
+from pathlib import Path
+
+from graph import Graph
+
+LOG = logging.getLogger(__name__)
+
+# Directories never traversed.
+IGNORE_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "env",
+        ".tox",
+        "dist",
+        "build",
+        "target",  # rust build dir
+        ".next",
+        ".cache",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+    }
+)
+
+# language name -> (analyzer module name, set of extensions)
+LANGUAGES: dict[str, tuple[str, frozenset[str]]] = {
+    "python": ("python_analyzer", frozenset({".py"})),
+    "typescript": (
+        "ts_analyzer",
+        frozenset({".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"}),
+    ),
+    "rust": ("rust_analyzer", frozenset({".rs"})),
+    "go": ("go_analyzer", frozenset({".go"})),
+}
+
+
+def _ext_to_language(ext: str) -> str | None:
+    for lang, (_mod, exts) in LANGUAGES.items():
+        if ext in exts:
+            return lang
+    return None
+
+
+def _scan(root: Path) -> dict[str, list[Path]]:
+    by_lang: dict[str, list[Path]] = {}
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        # Filter ignored dirs in place.
+        dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS]
+        for name in filenames:
+            ext = os.path.splitext(name)[1].lower()
+            lang = _ext_to_language(ext)
+            if lang is None:
+                continue
+            by_lang.setdefault(lang, []).append(Path(dirpath) / name)
+    return by_lang
+
+
+def analyze(target: Path | str) -> dict[str, Graph]:
+    """Detect languages under `target`, run each analyzer, return graphs.
+
+    Raises ValueError if `target` does not exist or is not a directory.
+    """
+    path = Path(target)
+    if not path.exists():
+        raise FileNotFoundError(f"target path does not exist: {path}")
+    if not path.is_dir():
+        raise NotADirectoryError(f"target is not a directory: {path}")
+
+    by_lang = _scan(path)
+    result: dict[str, Graph] = {}
+    for lang, files in by_lang.items():
+        mod_name, _exts = LANGUAGES[lang]
+        try:
+            module = importlib.import_module(mod_name)
+        except ImportError as exc:
+            LOG.error("could not load analyzer %s: %s", mod_name, exc)
+            continue
+        normalize = getattr(module, "normalize", None)
+        if normalize is None:
+            LOG.error("analyzer %s missing normalize()", mod_name)
+            continue
+        result[lang] = normalize(files)
+    return result

--- a/amplifier-bundle/skills/code-visualizer/scripts/go_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/go_analyzer.py
@@ -1,0 +1,73 @@
+"""Go package import graph analyzer.
+
+Handles single `import "fmt"` and grouped `import ( … )` blocks (with
+optional aliases). Self-contained brick: exposes exactly one entry point,
+`normalize()`.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path as _Path
+
+_HERE = _Path(__file__).resolve().parent
+if str(_HERE) not in _sys.path:
+    _sys.path.insert(0, str(_HERE))
+
+import logging
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+from graph import Edge, Graph, Node
+
+LOG = logging.getLogger(__name__)
+MAX_BYTES = 5 * 1024 * 1024
+
+_RE_SINGLE = re.compile(
+    r"""^\s*import\s+(?:[A-Za-z_]\w{0,100}\s+)?["]([^"\n]{1,500})["]""",
+    re.MULTILINE,
+)
+_RE_BLOCK = re.compile(r"import\s*\(([^)]{0,5000})\)", re.DOTALL)
+_RE_BLOCK_ITEM = re.compile(
+    r"""(?:[A-Za-z_]\w{0,100}\s+)?["]([^"\n]{1,500})["]""",
+)
+
+
+def _read(path: Path) -> str:
+    try:
+        if path.stat().st_size > MAX_BYTES:
+            LOG.warning("skipping %s: exceeds %d bytes", path, MAX_BYTES)
+            return ""
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError as exc:
+        LOG.warning("could not read %s: %s", path, exc)
+        return ""
+
+
+def normalize(paths: Iterable[Path]) -> Graph:
+    nodes: list[Node] = []
+    edges: list[Edge] = []
+    seen: set[str] = set()
+
+    for raw in paths:
+        path = Path(raw)
+        if not path.is_file():
+            continue
+        text = _read(path)
+        if not text:
+            continue
+
+        src_id = path.stem
+        if src_id not in seen:
+            nodes.append(Node(id=src_id, label=src_id, language="go", file_path=str(path)))
+            seen.add(src_id)
+
+        for spec in _RE_SINGLE.findall(text):
+            edges.append(Edge(src=src_id, dst=spec, kind="import"))
+
+        for block in _RE_BLOCK.findall(text):
+            for spec in _RE_BLOCK_ITEM.findall(block):
+                edges.append(Edge(src=src_id, dst=spec, kind="import"))
+
+    return Graph(language="go", nodes=nodes, edges=edges)

--- a/amplifier-bundle/skills/code-visualizer/scripts/go_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/go_analyzer.py
@@ -19,7 +19,7 @@ import re
 from collections.abc import Iterable
 from pathlib import Path
 
-from graph import Edge, Graph, Node
+from graph import Edge, Graph, Node, common_root, make_node_id
 
 LOG = logging.getLogger(__name__)
 MAX_BYTES = 5 * 1024 * 1024
@@ -50,17 +50,20 @@ def normalize(paths: Iterable[Path]) -> Graph:
     edges: list[Edge] = []
     seen: set[str] = set()
 
-    for raw in paths:
-        path = Path(raw)
+    materialised = [Path(p) for p in paths]
+    root = common_root(materialised)
+
+    for path in materialised:
         if not path.is_file():
             continue
         text = _read(path)
         if not text:
             continue
 
-        src_id = path.stem
+        # Repo-relative id keeps `main.go` in different packages distinct (#363).
+        src_id = make_node_id(path, root)
         if src_id not in seen:
-            nodes.append(Node(id=src_id, label=src_id, language="go", file_path=str(path)))
+            nodes.append(Node(id=src_id, label=path.stem, language="go", file_path=str(path)))
             seen.add(src_id)
 
         for spec in _RE_SINGLE.findall(text):

--- a/amplifier-bundle/skills/code-visualizer/scripts/graph.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/graph.py
@@ -7,7 +7,10 @@ from one another.
 
 from __future__ import annotations
 
+import os
+from collections.abc import Iterable
 from dataclasses import dataclass, field
+from pathlib import Path
 
 
 @dataclass
@@ -30,3 +33,44 @@ class Graph:
     language: str
     nodes: list[Node] = field(default_factory=list)
     edges: list[Edge] = field(default_factory=list)
+
+
+def common_root(paths: Iterable[Path]) -> Path | None:
+    """Return the longest common parent directory of `paths`, or None for empty input.
+
+    Used by analyzers to build collision-free, repo-relative node ids
+    (e.g. so two `mod.rs` files in different crates do not collapse into
+    one graph node — see #363 / COE feedback).
+    """
+    materialised = [p.resolve() for p in paths if p is not None]
+    if not materialised:
+        return None
+    if len(materialised) == 1:
+        # Use the file's parent so the relative path keeps the basename.
+        return materialised[0].parent
+    common = os.path.commonpath([str(p) for p in materialised])
+    return Path(common)
+
+
+def make_node_id(path: Path, root: Path | None) -> str:
+    """Build a unique node id for `path` relative to `root`.
+
+    Falls back to the absolute path (with separators normalised) when no
+    root is available. The id is always unique for a given input path
+    (no two distinct files collide), in contrast to `path.stem`.
+    """
+    p = Path(path).resolve()
+    if root is not None:
+        try:
+            rel = p.relative_to(root)
+        except ValueError:
+            rel = p
+    else:
+        rel = p
+    # Mermaid-safe: replace path separators with `/` (already canonical)
+    # and drop the suffix from the trailing component to keep ids readable
+    # while still unique (the directory prefix carries the disambiguation).
+    parts = list(rel.parts)
+    if parts:
+        parts[-1] = Path(parts[-1]).stem
+    return "/".join(parts) if parts else p.stem

--- a/amplifier-bundle/skills/code-visualizer/scripts/graph.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/graph.py
@@ -1,0 +1,32 @@
+"""Language-blind graph data contract used by all analyzers and the renderer.
+
+Brick philosophy: this module defines plain dataclasses (a *data contract*),
+not a base class. Analyzers may import these dataclasses but MUST NOT inherit
+from one another.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Node:
+    id: str
+    label: str
+    language: str
+    file_path: str
+
+
+@dataclass
+class Edge:
+    src: str
+    dst: str
+    kind: str
+
+
+@dataclass
+class Graph:
+    language: str
+    nodes: list[Node] = field(default_factory=list)
+    edges: list[Edge] = field(default_factory=list)

--- a/amplifier-bundle/skills/code-visualizer/scripts/mermaid_renderer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/mermaid_renderer.py
@@ -1,0 +1,111 @@
+"""Mermaid renderer: converts a normalized Graph into mermaid syntax.
+
+Language-blind: only inspects Node/Edge/Graph dataclasses, never branches on
+the `language` field for syntax decisions.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path as _Path
+
+_HERE = _Path(__file__).resolve().parent
+if str(_HERE) not in _sys.path:
+    _sys.path.insert(0, str(_HERE))
+
+import re
+
+from graph import Graph
+
+_SAFE_ID = re.compile(r"[^A-Za-z0-9_]")
+
+
+def _sanitize_id(raw: str) -> str:
+    """Mermaid identifier: alnum + underscore, must not start with digit."""
+    cleaned = _SAFE_ID.sub("_", raw)
+    if not cleaned:
+        cleaned = "n"
+    if cleaned[0].isdigit():
+        cleaned = "n_" + cleaned
+    return cleaned
+
+
+def _escape_label(raw: str) -> str:
+    return raw.replace('"', '\\"').replace("\n", " ")
+
+
+def _node_ids_for(graph: Graph) -> tuple[dict[str, str], list[tuple[str, str, str]]]:
+    """Return (raw_id -> safe_id, list of (safe_id, label, raw_id) for declarations)."""
+    raw_ids: list[str] = []
+    seen: set[str] = set()
+    for n in graph.nodes:
+        if n.id not in seen:
+            raw_ids.append(n.id)
+            seen.add(n.id)
+    for e in graph.edges:
+        for rid in (e.src, e.dst):
+            if rid not in seen:
+                raw_ids.append(rid)
+                seen.add(rid)
+
+    mapping: dict[str, str] = {}
+    used: set[str] = set()
+    decls: list[tuple[str, str, str]] = []
+    for raw in raw_ids:
+        safe = _sanitize_id(raw)
+        base = safe
+        i = 1
+        while safe in used:
+            i += 1
+            safe = f"{base}_{i}"
+        used.add(safe)
+        mapping[raw] = safe
+        decls.append((safe, raw, raw))  # safe_id, label, original_raw
+    return mapping, decls
+
+
+def render(graph: Graph) -> str:
+    """Render a single-language Graph as a mermaid `graph LR` diagram."""
+    lines: list[str] = ["graph LR"]
+    mapping, decls = _node_ids_for(graph)
+
+    if not decls:
+        # Always emit at least one comment so output is non-empty/parseable.
+        lines.append(f"    %% no nodes for language={graph.language}")
+        return "\n".join(lines) + "\n"
+
+    for safe, label, _raw in decls:
+        lines.append(f'    {safe}["{_escape_label(label)}"]')
+
+    for e in graph.edges:
+        s = mapping.get(e.src) or _sanitize_id(e.src)
+        d = mapping.get(e.dst) or _sanitize_id(e.dst)
+        lines.append(f"    {s} --> {d}")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_combined(graphs: dict[str, Graph]) -> str:
+    """Render multiple language graphs as one mermaid diagram with subgraphs."""
+    lines: list[str] = ["graph LR"]
+    if not graphs:
+        lines.append("    %% no graphs to render")
+        return "\n".join(lines) + "\n"
+
+    # Per-language id namespacing to avoid collisions across languages.
+    for lang, graph in graphs.items():
+        safe_lang = _sanitize_id(lang)
+        lines.append(f'    subgraph {safe_lang} ["{_escape_label(lang)}"]')
+        mapping, decls = _node_ids_for(graph)
+        prefixed: dict[str, str] = {}
+        for safe, label, raw in decls:
+            ns_safe = f"{safe_lang}_{safe}"
+            prefixed[raw] = ns_safe
+            lines.append(f'        {ns_safe}["{_escape_label(label)}"]')
+        for e in graph.edges:
+            s = prefixed.get(e.src) or f"{safe_lang}_{_sanitize_id(e.src)}"
+            d = prefixed.get(e.dst) or f"{safe_lang}_{_sanitize_id(e.dst)}"
+            lines.append(f"        {s} --> {d}")
+        lines.append("    end")
+
+    return "\n".join(lines) + "\n"

--- a/amplifier-bundle/skills/code-visualizer/scripts/python_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/python_analyzer.py
@@ -1,0 +1,92 @@
+"""Python import graph analyzer.
+
+Uses the standard library `ast` module to extract `import` and `from … import`
+statements. Each source file becomes a node identified by its dotted module
+path (best-effort) or filename stem; each import becomes an edge.
+
+Self-contained brick: exposes exactly one entry point, `normalize()`. No
+inheritance from or to any other analyzer.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path as _Path
+
+_HERE = _Path(__file__).resolve().parent
+if str(_HERE) not in _sys.path:
+    _sys.path.insert(0, str(_HERE))
+
+import ast
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+from graph import Edge, Graph, Node
+
+LOG = logging.getLogger(__name__)
+MAX_BYTES = 5 * 1024 * 1024  # per-file safety cap
+
+
+def _module_id(path: Path) -> str:
+    """Best-effort dotted module id from a path.
+
+    Walks up while sibling __init__.py files exist; otherwise uses the stem.
+    """
+    parts: list[str] = [path.stem]
+    parent = path.parent
+    while (parent / "__init__.py").exists():
+        parts.append(parent.name)
+        if parent.parent == parent:
+            break
+        parent = parent.parent
+    return ".".join(reversed(parts))
+
+
+def _read(path: Path) -> str:
+    try:
+        if path.stat().st_size > MAX_BYTES:
+            LOG.warning("skipping %s: exceeds %d bytes", path, MAX_BYTES)
+            return ""
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError as exc:
+        LOG.warning("could not read %s: %s", path, exc)
+        return ""
+
+
+def normalize(paths: Iterable[Path]) -> Graph:
+    """Build a normalized Graph from Python source files."""
+    nodes: list[Node] = []
+    edges: list[Edge] = []
+    seen_node_ids: set[str] = set()
+
+    for raw in paths:
+        path = Path(raw)
+        if not path.is_file():
+            continue
+        text = _read(path)
+        try:
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError as exc:
+            LOG.info("skipping unparseable %s: %s", path, exc)
+            continue
+
+        src_id = _module_id(path)
+        if src_id not in seen_node_ids:
+            nodes.append(Node(id=src_id, label=src_id, language="python", file_path=str(path)))
+            seen_node_ids.add(src_id)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    edges.append(Edge(src=src_id, dst=alias.name, kind="import"))
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if node.level and not module:
+                    # Pure relative import like `from . import x` — record names
+                    for alias in node.names:
+                        edges.append(Edge(src=src_id, dst=alias.name, kind="import"))
+                else:
+                    edges.append(Edge(src=src_id, dst=module, kind="import"))
+
+    return Graph(language="python", nodes=nodes, edges=edges)

--- a/amplifier-bundle/skills/code-visualizer/scripts/rust_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/rust_analyzer.py
@@ -18,7 +18,7 @@ import re
 from collections.abc import Iterable
 from pathlib import Path
 
-from graph import Edge, Graph, Node
+from graph import Edge, Graph, Node, common_root, make_node_id
 
 LOG = logging.getLogger(__name__)
 MAX_BYTES = 5 * 1024 * 1024
@@ -43,17 +43,21 @@ def normalize(paths: Iterable[Path]) -> Graph:
     edges: list[Edge] = []
     seen: set[str] = set()
 
-    for raw in paths:
-        path = Path(raw)
+    materialised = [Path(p) for p in paths]
+    root = common_root(materialised)
+
+    for path in materialised:
         if not path.is_file():
             continue
         text = _read(path)
         if not text:
             continue
 
-        src_id = path.stem
+        # Repo-relative id keeps `mod.rs` in two different crates distinct
+        # (#363). Label stays as the stem for readability.
+        src_id = make_node_id(path, root)
         if src_id not in seen:
-            nodes.append(Node(id=src_id, label=src_id, language="rust", file_path=str(path)))
+            nodes.append(Node(id=src_id, label=path.stem, language="rust", file_path=str(path)))
             seen.add(src_id)
 
         for spec in _RE_USE.findall(text):

--- a/amplifier-bundle/skills/code-visualizer/scripts/rust_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/rust_analyzer.py
@@ -1,0 +1,64 @@
+"""Rust module graph analyzer.
+
+Extracts `use …;` and `mod …;` statements via bounded regex. Self-contained
+brick: exposes exactly one entry point, `normalize()`.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path as _Path
+
+_HERE = _Path(__file__).resolve().parent
+if str(_HERE) not in _sys.path:
+    _sys.path.insert(0, str(_HERE))
+
+import logging
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+from graph import Edge, Graph, Node
+
+LOG = logging.getLogger(__name__)
+MAX_BYTES = 5 * 1024 * 1024
+
+_RE_USE = re.compile(r"^\s*use\s+([A-Za-z_][\w:]{0,500});", re.MULTILINE)
+_RE_MOD = re.compile(r"^\s*(?:pub\s+)?mod\s+([A-Za-z_]\w{0,200})\s*;", re.MULTILINE)
+
+
+def _read(path: Path) -> str:
+    try:
+        if path.stat().st_size > MAX_BYTES:
+            LOG.warning("skipping %s: exceeds %d bytes", path, MAX_BYTES)
+            return ""
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError as exc:
+        LOG.warning("could not read %s: %s", path, exc)
+        return ""
+
+
+def normalize(paths: Iterable[Path]) -> Graph:
+    nodes: list[Node] = []
+    edges: list[Edge] = []
+    seen: set[str] = set()
+
+    for raw in paths:
+        path = Path(raw)
+        if not path.is_file():
+            continue
+        text = _read(path)
+        if not text:
+            continue
+
+        src_id = path.stem
+        if src_id not in seen:
+            nodes.append(Node(id=src_id, label=src_id, language="rust", file_path=str(path)))
+            seen.add(src_id)
+
+        for spec in _RE_USE.findall(text):
+            edges.append(Edge(src=src_id, dst=spec, kind="use"))
+        for name in _RE_MOD.findall(text):
+            edges.append(Edge(src=src_id, dst=name, kind="mod"))
+
+    return Graph(language="rust", nodes=nodes, edges=edges)

--- a/amplifier-bundle/skills/code-visualizer/scripts/staleness.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/staleness.py
@@ -1,0 +1,72 @@
+"""Staleness detection: compare a diagram's mtime to the max source mtime."""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path as _Path
+
+_HERE = _Path(__file__).resolve().parent
+if str(_HERE) not in _sys.path:
+    _sys.path.insert(0, str(_HERE))
+
+import importlib
+import os
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def _dispatcher_constants() -> tuple[frozenset[str], dict]:
+    """Lazily import the sibling dispatcher module to avoid hard top-level dep."""
+    mod = importlib.import_module("dispatcher")
+    return mod.IGNORE_DIRS, mod.LANGUAGES
+
+
+def _extensions_for(languages: Iterable[str]) -> set[str]:
+    _ignore, lang_table = _dispatcher_constants()
+    exts: set[str] = set()
+    for lang in languages:
+        if lang in lang_table:
+            _mod, lang_exts = lang_table[lang]
+            exts.update(lang_exts)
+    return exts
+
+
+def _max_source_mtime(root: Path, extensions: set[str]) -> float | None:
+    ignore_dirs, _lang_table = _dispatcher_constants()
+    latest: float | None = None
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
+        for name in filenames:
+            ext = os.path.splitext(name)[1].lower()
+            if ext not in extensions:
+                continue
+            try:
+                m = (Path(dirpath) / name).stat().st_mtime
+            except OSError:
+                continue
+            if latest is None or m > latest:
+                latest = m
+    return latest
+
+
+def is_stale(target: Path | str, diagram: Path | str, languages: Iterable[str]) -> bool:
+    """Return True if any source file is newer than the diagram (or diagram missing)."""
+    target_path = Path(target)
+    diagram_path = Path(diagram)
+
+    if not diagram_path.exists():
+        return True
+
+    try:
+        diagram_mtime = diagram_path.stat().st_mtime
+    except OSError:
+        return True
+
+    extensions = _extensions_for(languages)
+    if not extensions:
+        return False
+
+    latest = _max_source_mtime(target_path, extensions)
+    if latest is None:
+        return False
+    return latest > diagram_mtime

--- a/amplifier-bundle/skills/code-visualizer/scripts/ts_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/ts_analyzer.py
@@ -24,7 +24,7 @@ import re
 from collections.abc import Iterable
 from pathlib import Path
 
-from graph import Edge, Graph, Node
+from graph import Edge, Graph, Node, common_root, make_node_id
 
 LOG = logging.getLogger(__name__)
 MAX_BYTES = 5 * 1024 * 1024
@@ -62,17 +62,20 @@ def normalize(paths: Iterable[Path]) -> Graph:
     edges: list[Edge] = []
     seen: set[str] = set()
 
-    for raw in paths:
-        path = Path(raw)
+    materialised = [Path(p) for p in paths]
+    root = common_root(materialised)
+
+    for path in materialised:
         if not path.is_file():
             continue
         text = _read(path)
         if not text:
             continue
 
-        src_id = path.stem
+        # Repo-relative id keeps `index.ts` in different packages distinct (#363).
+        src_id = make_node_id(path, root)
         if src_id not in seen:
-            nodes.append(Node(id=src_id, label=src_id, language="typescript", file_path=str(path)))
+            nodes.append(Node(id=src_id, label=path.stem, language="typescript", file_path=str(path)))
             seen.add(src_id)
 
         specs: list[str] = []

--- a/amplifier-bundle/skills/code-visualizer/scripts/ts_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/ts_analyzer.py
@@ -1,0 +1,85 @@
+"""TypeScript / JavaScript import graph analyzer.
+
+Handles `.ts/.tsx/.js/.jsx/.mjs/.cjs`. Uses bounded regex (no nested
+quantifiers) to extract three forms:
+
+1. ESM static:  `import … from '<spec>'`
+2. CommonJS:    `require('<spec>')`
+3. Dynamic:     `import('<spec>')`
+
+Self-contained brick: exposes exactly one entry point, `normalize()`.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+from pathlib import Path as _Path
+
+_HERE = _Path(__file__).resolve().parent
+if str(_HERE) not in _sys.path:
+    _sys.path.insert(0, str(_HERE))
+
+import logging
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+from graph import Edge, Graph, Node
+
+LOG = logging.getLogger(__name__)
+MAX_BYTES = 5 * 1024 * 1024
+
+# Bounded patterns, anchored on quote pair, no catastrophic backtracking.
+_RE_IMPORT_FROM = re.compile(
+    r"""import\s+[^'";]{0,500}?from\s*['"]([^'"\n]{1,500})['"]""",
+    re.MULTILINE,
+)
+_RE_IMPORT_BARE = re.compile(
+    r"""(?:^|[^.\w])import\s*['"]([^'"\n]{1,500})['"]""",
+    re.MULTILINE,
+)
+_RE_REQUIRE = re.compile(
+    r"""require\s*\(\s*['"]([^'"\n]{1,500})['"]\s*\)""",
+)
+_RE_DYNAMIC = re.compile(
+    r"""(?:^|[^.\w])import\s*\(\s*['"]([^'"\n]{1,500})['"]\s*\)""",
+)
+
+
+def _read(path: Path) -> str:
+    try:
+        if path.stat().st_size > MAX_BYTES:
+            LOG.warning("skipping %s: exceeds %d bytes", path, MAX_BYTES)
+            return ""
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError as exc:
+        LOG.warning("could not read %s: %s", path, exc)
+        return ""
+
+
+def normalize(paths: Iterable[Path]) -> Graph:
+    nodes: list[Node] = []
+    edges: list[Edge] = []
+    seen: set[str] = set()
+
+    for raw in paths:
+        path = Path(raw)
+        if not path.is_file():
+            continue
+        text = _read(path)
+        if not text:
+            continue
+
+        src_id = path.stem
+        if src_id not in seen:
+            nodes.append(Node(id=src_id, label=src_id, language="typescript", file_path=str(path)))
+            seen.add(src_id)
+
+        specs: list[str] = []
+        for pat in (_RE_IMPORT_FROM, _RE_IMPORT_BARE, _RE_REQUIRE, _RE_DYNAMIC):
+            specs.extend(pat.findall(text))
+
+        for spec in specs:
+            edges.append(Edge(src=src_id, dst=spec, kind="import"))
+
+    return Graph(language="typescript", nodes=nodes, edges=edges)

--- a/amplifier-bundle/skills/code-visualizer/scripts/visualizer.py
+++ b/amplifier-bundle/skills/code-visualizer/scripts/visualizer.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""CLI entry point: produce per-language mermaid diagrams for a target path.
+
+Usage:
+    visualizer.py <path> [--output DIR] [--basename NAME]
+                  [--combined] [--check-staleness]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Make sibling modules importable when invoked as a script.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from dispatcher import analyze
+from mermaid_renderer import render, render_combined
+from staleness import is_stale
+
+_BASENAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="visualizer",
+        description="Generate mermaid diagrams of imports/dependencies per language.",
+    )
+    p.add_argument("path", help="Target source directory to scan.")
+    p.add_argument(
+        "--output",
+        default=".",
+        help="Directory to write .mmd files into (default: current directory).",
+    )
+    p.add_argument(
+        "--basename",
+        default="diagram",
+        help="Base filename for output (default: 'diagram'). "
+        "Final files are <basename>-<language>.mmd.",
+    )
+    p.add_argument(
+        "--combined",
+        action="store_true",
+        help="Also emit a <basename>-combined.mmd with one subgraph per language.",
+    )
+    p.add_argument(
+        "--check-staleness",
+        action="store_true",
+        help="Only check whether existing diagrams are stale; exit 1 if stale.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    if not _BASENAME_RE.match(args.basename):
+        print(
+            f"error: --basename must match {_BASENAME_RE.pattern}; got {args.basename!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    target = Path(args.path).resolve()
+    if not target.exists():
+        print(f"error: path does not exist: {target}", file=sys.stderr)
+        return 2
+    if not target.is_dir():
+        print(f"error: path is not a directory: {target}", file=sys.stderr)
+        return 2
+
+    output_dir = Path(args.output).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    graphs = analyze(target)
+
+    if args.check_staleness:
+        any_stale = False
+        for lang in graphs:
+            diag = output_dir / f"{args.basename}-{lang}.mmd"
+            if is_stale(target, diag, [lang]):
+                print(f"stale: {diag}")
+                any_stale = True
+        return 1 if any_stale else 0
+
+    for lang, graph in graphs.items():
+        out = output_dir / f"{args.basename}-{lang}.mmd"
+        out.write_text(render(graph), encoding="utf-8")
+        print(f"wrote {out}")
+
+    if args.combined:
+        combined = output_dir / f"{args.basename}-combined.mmd"
+        combined.write_text(render_combined(graphs), encoding="utf-8")
+        print(f"wrote {combined}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/amplifier-bundle/skills/code-visualizer/tests/conftest.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Make sibling `scripts/` package importable for tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/amplifier-bundle/skills/code-visualizer/tests/test_dispatcher.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_dispatcher.py
@@ -1,0 +1,69 @@
+"""Tests for dispatcher: language detection, routing, ignore dirs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write(p: Path, text: str = "") -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_dispatcher_routes_by_extension(tmp_path: Path):
+    from dispatcher import analyze
+
+    _write(tmp_path / "a.py", "import os\n")
+    _write(tmp_path / "b.ts", "import x from './y';\n")
+    _write(tmp_path / "c.go", 'package main\nimport "fmt"\n')
+    _write(tmp_path / "d.rs", "use std::io;\n")
+
+    result = analyze(tmp_path)
+    # result is a dict[language_name, Graph]
+    assert "python" in result
+    assert "typescript" in result
+    assert "go" in result
+    assert "rust" in result
+    for lang, g in result.items():
+        assert g.language == lang
+
+
+def test_dispatcher_ignores_common_dirs(tmp_path: Path):
+    from dispatcher import analyze
+
+    _write(tmp_path / "real.py", "import os\n")
+    _write(tmp_path / "node_modules" / "junk.ts", "import x from 'y';\n")
+    _write(tmp_path / ".git" / "stuff.py", "import gone\n")
+    _write(tmp_path / "__pycache__" / "x.py", "import nope\n")
+    _write(tmp_path / "dist" / "out.js", "require('z');\n")
+
+    result = analyze(tmp_path)
+    py = result.get("python")
+    assert py is not None
+    # Only the real one
+    file_paths = {n.file_path for n in py.nodes}
+    assert any("real.py" in fp for fp in file_paths)
+    assert not any("__pycache__" in fp for fp in file_paths)
+    assert not any(".git" in fp for fp in file_paths)
+    # node_modules should be excluded entirely
+    ts = result.get("typescript")
+    if ts is not None:
+        assert not any("node_modules" in n.file_path for n in ts.nodes)
+
+
+def test_dispatcher_returns_empty_for_unsupported(tmp_path: Path):
+    from dispatcher import analyze
+
+    _write(tmp_path / "doc.md", "hello")
+    _write(tmp_path / "config.toml", "x = 1")
+    result = analyze(tmp_path)
+    assert result == {} or all(len(g.nodes) == 0 for g in result.values())
+
+
+def test_dispatcher_rejects_nonexistent_path(tmp_path: Path):
+    import pytest as _pytest
+    from dispatcher import analyze
+
+    with _pytest.raises((FileNotFoundError, ValueError, NotADirectoryError)):
+        analyze(tmp_path / "does-not-exist")

--- a/amplifier-bundle/skills/code-visualizer/tests/test_go_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_go_analyzer.py
@@ -1,0 +1,50 @@
+"""Tests for go_analyzer.normalize()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write(p: Path, text: str) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_single_import(tmp_path: Path):
+    from go_analyzer import normalize
+
+    f = _write(tmp_path / "a.go", 'package main\n\nimport "fmt"\n')
+    g = normalize([f])
+    assert g.language == "go"
+    dsts = {e.dst for e in g.edges}
+    assert any("fmt" in d for d in dsts)
+
+
+def test_grouped_import_block(tmp_path: Path):
+    from go_analyzer import normalize
+
+    f = _write(
+        tmp_path / "b.go",
+        """package main
+
+import (
+    "fmt"
+    "os"
+    alias "github.com/user/repo/pkg"
+)
+""",
+    )
+    g = normalize([f])
+    dsts = {e.dst for e in g.edges}
+    assert any("fmt" in d for d in dsts)
+    assert any("os" in d for d in dsts)
+    assert any("github.com/user/repo/pkg" in d for d in dsts)
+
+
+def test_empty(tmp_path: Path):
+    from go_analyzer import normalize
+
+    g = normalize([])
+    assert g.language == "go"
+    assert g.edges == []

--- a/amplifier-bundle/skills/code-visualizer/tests/test_graph.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_graph.py
@@ -1,0 +1,65 @@
+"""Contract tests for the language-blind Graph data structure."""
+
+from __future__ import annotations
+
+
+def test_node_is_dataclass_with_required_fields():
+    from graph import Node
+
+    n = Node(id="a.b", label="a.b", language="python", file_path="a/b.py")
+    assert n.id == "a.b"
+    assert n.label == "a.b"
+    assert n.language == "python"
+    assert n.file_path == "a/b.py"
+
+
+def test_edge_is_dataclass_with_required_fields():
+    from graph import Edge
+
+    e = Edge(src="a", dst="b", kind="import")
+    assert e.src == "a"
+    assert e.dst == "b"
+    assert e.kind == "import"
+
+
+def test_graph_holds_language_nodes_and_edges():
+    from graph import Edge, Graph, Node
+
+    g = Graph(
+        language="python",
+        nodes=[Node(id="a", label="a", language="python", file_path="a.py")],
+        edges=[Edge(src="a", dst="b", kind="import")],
+    )
+    assert g.language == "python"
+    assert len(g.nodes) == 1
+    assert len(g.edges) == 1
+
+
+def test_graph_no_inheritance_among_analyzers():
+    """Brick philosophy: analyzers must NOT subclass each other."""
+    import go_analyzer
+    import python_analyzer
+    import rust_analyzer
+    import ts_analyzer
+
+    for mod in (python_analyzer, ts_analyzer, rust_analyzer, go_analyzer):
+        assert hasattr(mod, "normalize"), f"{mod.__name__} must expose normalize()"
+
+    # No analyzer module should define a class that another analyzer inherits from.
+    import inspect
+
+    classes = []
+    for mod in (python_analyzer, ts_analyzer, rust_analyzer, go_analyzer):
+        for _name, cls in inspect.getmembers(mod, inspect.isclass):
+            if cls.__module__ == mod.__name__:
+                classes.append(cls)
+
+    for cls in classes:
+        bases = [b for b in cls.__mro__[1:] if b is not object]
+        for base in bases:
+            assert base.__module__ not in {
+                "python_analyzer",
+                "ts_analyzer",
+                "rust_analyzer",
+                "go_analyzer",
+            }, f"{cls} inherits from analyzer base {base}"

--- a/amplifier-bundle/skills/code-visualizer/tests/test_mermaid_renderer.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_mermaid_renderer.py
@@ -1,0 +1,76 @@
+"""Tests for mermaid_renderer: language-blind rendering and combined view."""
+
+from __future__ import annotations
+
+
+def _make_graph(language: str, edges: list[tuple[str, str]]):
+    from graph import Edge, Graph, Node
+
+    nodes_set = set()
+    for s, d in edges:
+        nodes_set.add(s)
+        nodes_set.add(d)
+    nodes = [Node(id=n, label=n, language=language, file_path=f"{n}.x") for n in sorted(nodes_set)]
+    es = [Edge(src=s, dst=d, kind="import") for s, d in edges]
+    return Graph(language=language, nodes=nodes, edges=es)
+
+
+def test_render_empty_graph_returns_string():
+    from graph import Graph
+    from mermaid_renderer import render
+
+    out = render(Graph(language="python", nodes=[], edges=[]))
+    assert isinstance(out, str)
+    assert out.strip() != ""
+    # Must declare a graph type
+    assert "graph" in out.lower() or "flowchart" in out.lower()
+
+
+def test_render_includes_edges():
+    from mermaid_renderer import render
+
+    g = _make_graph("python", [("a", "b"), ("b", "c")])
+    out = render(g)
+    assert "-->" in out
+    # both edges represented
+    assert out.count("-->") >= 2
+
+
+def test_render_sanitizes_node_ids():
+    from mermaid_renderer import render
+
+    g = _make_graph("typescript", [("./foo-bar", "@scope/pkg")])
+    out = render(g)
+    # No raw '@' or unescaped '/' as a bare identifier — sanitized form should appear
+    # We just check the output is non-empty and contains an edge arrow.
+    assert "-->" in out
+    # The ids should be sanitized to valid mermaid identifiers (alnum/underscore)
+    # Check that we don't emit bare '@scope/pkg' as the identifier on the LHS of [
+    for line in out.splitlines():
+        # mermaid id syntax: `id["label"]` — the id (before [) must be sanitized
+        if "[" in line and "]" in line:
+            ident = line.split("[", 1)[0].strip().split()[-1]
+            assert all(ch.isalnum() or ch == "_" for ch in ident), f"bad id: {ident!r}"
+
+
+def test_render_combined_uses_subgraph_per_language():
+    from mermaid_renderer import render_combined
+
+    graphs = {
+        "python": _make_graph("python", [("a", "b")]),
+        "typescript": _make_graph("typescript", [("x", "y")]),
+    }
+    out = render_combined(graphs)
+    assert "subgraph" in out
+    # one subgraph per language
+    assert out.lower().count("subgraph") >= 2
+    assert "python" in out
+    assert "typescript" in out
+
+
+def test_render_combined_empty():
+    from mermaid_renderer import render_combined
+
+    out = render_combined({})
+    assert isinstance(out, str)
+    assert out.strip() != ""

--- a/amplifier-bundle/skills/code-visualizer/tests/test_python_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_python_analyzer.py
@@ -1,0 +1,58 @@
+"""Tests for python_analyzer.normalize()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write(p: Path, text: str) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_normalize_extracts_simple_imports(tmp_path: Path):
+    from python_analyzer import normalize
+
+    a = _write(tmp_path / "pkg" / "a.py", "import os\nimport pkg.b\n")
+    b = _write(tmp_path / "pkg" / "b.py", "x = 1\n")
+    _write(tmp_path / "pkg" / "__init__.py", "")
+
+    g = normalize([a, b])
+    assert g.language == "python"
+    node_ids = {n.id for n in g.nodes}
+    # a and b at minimum
+    assert any(nid.endswith("a") for nid in node_ids)
+    assert any(nid.endswith("b") for nid in node_ids)
+
+    # edge a -> pkg.b (or b)
+    pairs = {(e.src, e.dst) for e in g.edges}
+    assert any(src.endswith("a") and ("b" in dst) for src, dst in pairs)
+
+
+def test_normalize_extracts_from_imports(tmp_path: Path):
+    from python_analyzer import normalize
+
+    f = _write(tmp_path / "m.py", "from collections import OrderedDict\nfrom .sib import x\n")
+    g = normalize([f])
+    dsts = {e.dst for e in g.edges}
+    assert any("collections" in d for d in dsts)
+
+
+def test_normalize_skips_unparseable(tmp_path: Path):
+    from python_analyzer import normalize
+
+    bad = _write(tmp_path / "bad.py", "def (((( syntax error\n")
+    good = _write(tmp_path / "good.py", "import json\n")
+    g = normalize([bad, good])
+    # Should not raise; should still return graph with json edge
+    assert any("json" in e.dst for e in g.edges)
+
+
+def test_normalize_empty_input_returns_empty_graph():
+    from python_analyzer import normalize
+
+    g = normalize([])
+    assert g.language == "python"
+    assert g.nodes == []
+    assert g.edges == []

--- a/amplifier-bundle/skills/code-visualizer/tests/test_rust_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_rust_analyzer.py
@@ -38,3 +38,19 @@ def test_empty(tmp_path: Path):
     g = normalize([])
     assert g.language == "rust"
     assert g.edges == []
+
+
+def test_no_node_id_collision_across_crates(tmp_path: Path):
+    """#363: two `mod.rs` files in different crates must not share a node id."""
+    from rust_analyzer import normalize
+
+    a = _write(tmp_path / "crate_a" / "src" / "mod.rs", "use foo::bar;\n")
+    b = _write(tmp_path / "crate_b" / "src" / "mod.rs", "use baz::qux;\n")
+
+    g = normalize([a, b])
+    ids = [n.id for n in g.nodes]
+    assert len(ids) == 2, f"expected 2 distinct nodes, got {ids}"
+    assert len(set(ids)) == 2, f"node ids collided: {ids}"
+    # Labels may repeat (display name) — only ids must be unique.
+    labels = {n.label for n in g.nodes}
+    assert "mod" in labels

--- a/amplifier-bundle/skills/code-visualizer/tests/test_rust_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_rust_analyzer.py
@@ -1,0 +1,40 @@
+"""Tests for rust_analyzer.normalize()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write(p: Path, text: str) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_use_statements(tmp_path: Path):
+    from rust_analyzer import normalize
+
+    f = _write(
+        tmp_path / "src" / "main.rs",
+        """
+use std::collections::HashMap;
+use crate::utils::helper;
+use super::sibling;
+mod local;
+""",
+    )
+    g = normalize([f])
+    assert g.language == "rust"
+    dsts = {e.dst for e in g.edges}
+    assert any("std" in d or "HashMap" in d or "collections" in d for d in dsts)
+    assert any("utils" in d or "helper" in d for d in dsts)
+    assert any("sibling" in d for d in dsts)
+    assert any("local" in d for d in dsts)
+
+
+def test_empty(tmp_path: Path):
+    from rust_analyzer import normalize
+
+    g = normalize([])
+    assert g.language == "rust"
+    assert g.edges == []

--- a/amplifier-bundle/skills/code-visualizer/tests/test_smoke_repo.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_smoke_repo.py
@@ -1,0 +1,30 @@
+"""Smoke test: run dispatcher against the amplihack repo root.
+
+Asserts that we get non-empty mermaid output for languages this repo actually
+contains from the supported set (Python and JS/TS). Rust/Go are tolerated as
+absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_dispatcher_against_repo_root():
+    from dispatcher import analyze
+    from mermaid_renderer import render
+
+    assert REPO_ROOT.exists(), f"repo root missing: {REPO_ROOT}"
+    result = analyze(REPO_ROOT)
+
+    assert "python" in result, f"expected python in result; got {sorted(result)}"
+    py_mermaid = render(result["python"])
+    assert py_mermaid.strip() != ""
+    assert "-->" in py_mermaid  # has at least one edge
+
+    # JS/TS may or may not be present depending on repo contents
+    if "typescript" in result and result["typescript"].nodes:
+        ts_mermaid = render(result["typescript"])
+        assert ts_mermaid.strip() != ""

--- a/amplifier-bundle/skills/code-visualizer/tests/test_staleness.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_staleness.py
@@ -1,0 +1,54 @@
+"""Tests for staleness detection: max-mtime over source files vs diagram mtime."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+
+def _write(p: Path, text: str = "") -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_diagram_missing_is_stale(tmp_path: Path):
+    from staleness import is_stale
+
+    _write(tmp_path / "a.py", "import os\n")
+    diagram = tmp_path / "diagram.mmd"
+    assert is_stale(tmp_path, diagram, ["python"]) is True
+
+
+def test_diagram_newer_than_sources_is_fresh(tmp_path: Path):
+    from staleness import is_stale
+
+    src = _write(tmp_path / "a.py", "x=1\n")
+    old = time.time() - 100
+    os.utime(src, (old, old))
+    diagram = _write(tmp_path / "d.mmd", "graph LR\n")
+    # diagram mtime is now > old
+    assert is_stale(tmp_path, diagram, ["python"]) is False
+
+
+def test_source_newer_than_diagram_is_stale(tmp_path: Path):
+    from staleness import is_stale
+
+    diagram = _write(tmp_path / "d.mmd", "graph LR\n")
+    old = time.time() - 100
+    os.utime(diagram, (old, old))
+    _write(tmp_path / "a.py", "x=2\n")  # new mtime
+    assert is_stale(tmp_path, diagram, ["python"]) is True
+
+
+def test_only_listed_languages_considered(tmp_path: Path):
+    from staleness import is_stale
+
+    diagram = _write(tmp_path / "d.mmd", "graph LR\n")
+    old = time.time() - 100
+    os.utime(diagram, (old, old))
+    # Only a JS file is newer; if we ask about python only, should be fresh
+    _write(tmp_path / "a.js", "require('x');\n")
+    assert is_stale(tmp_path, diagram, ["python"]) is False
+    assert is_stale(tmp_path, diagram, ["typescript"]) is True

--- a/amplifier-bundle/skills/code-visualizer/tests/test_ts_analyzer.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_ts_analyzer.py
@@ -1,0 +1,68 @@
+"""Tests for ts_analyzer.normalize() — handles .ts/.tsx/.js/.jsx/.mjs/.cjs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write(p: Path, text: str) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_es_module_static_imports(tmp_path: Path):
+    from ts_analyzer import normalize
+
+    f = _write(
+        tmp_path / "src" / "a.ts",
+        """
+import { foo } from './b';
+import bar from "./c";
+import * as ns from 'lodash';
+""",
+    )
+    g = normalize([f])
+    assert g.language == "typescript"
+    dsts = {e.dst for e in g.edges}
+    assert any("b" in d for d in dsts)
+    assert any("c" in d for d in dsts)
+    assert any("lodash" in d for d in dsts)
+
+
+def test_commonjs_require(tmp_path: Path):
+    from ts_analyzer import normalize
+
+    f = _write(tmp_path / "x.js", "const fs = require('fs');\nconst u = require('./util');\n")
+    g = normalize([f])
+    dsts = {e.dst for e in g.edges}
+    assert any("fs" in d for d in dsts)
+    assert any("util" in d for d in dsts)
+
+
+def test_dynamic_import(tmp_path: Path):
+    from ts_analyzer import normalize
+
+    f = _write(tmp_path / "y.mjs", "const m = await import('./lazy');\n")
+    g = normalize([f])
+    dsts = {e.dst for e in g.edges}
+    assert any("lazy" in d for d in dsts)
+
+
+def test_tsx_jsx_supported(tmp_path: Path):
+    from ts_analyzer import normalize
+
+    a = _write(tmp_path / "a.tsx", "import React from 'react';\n")
+    b = _write(tmp_path / "b.jsx", "import x from './x';\n")
+    g = normalize([a, b])
+    dsts = {e.dst for e in g.edges}
+    assert any("react" in d for d in dsts)
+    assert any("x" in d for d in dsts)
+
+
+def test_empty_input(tmp_path: Path):
+    from ts_analyzer import normalize
+
+    g = normalize([])
+    assert g.language == "typescript"
+    assert g.edges == []

--- a/amplifier-bundle/skills/code-visualizer/tests/test_visualizer_cli.py
+++ b/amplifier-bundle/skills/code-visualizer/tests/test_visualizer_cli.py
@@ -1,0 +1,86 @@
+"""Tests for the visualizer.py CLI entry point."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "visualizer.py"
+
+
+def _write(p: Path, text: str) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_cli_produces_per_language_files(tmp_path: Path):
+    src = tmp_path / "src"
+    out = tmp_path / "out"
+    out.mkdir()
+    _write(src / "a.py", "import os\n")
+    _write(src / "b.ts", "import x from './y';\n")
+
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), str(src), "--output", str(out), "--basename", "diagram"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert r.returncode == 0, r.stderr
+    files = {p.name for p in out.iterdir()}
+    assert "diagram-python.mmd" in files
+    assert "diagram-typescript.mmd" in files
+    for f in files:
+        assert (out / f).read_text().strip() != ""
+
+
+def test_cli_combined_flag_produces_combined_file(tmp_path: Path):
+    src = tmp_path / "src"
+    out = tmp_path / "out"
+    out.mkdir()
+    _write(src / "a.py", "import os\n")
+    _write(src / "b.ts", "import x from './y';\n")
+
+    r = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(src),
+            "--output",
+            str(out),
+            "--basename",
+            "diagram",
+            "--combined",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert r.returncode == 0, r.stderr
+    assert (out / "diagram-combined.mmd").exists()
+    assert (out / "diagram-combined.mmd").read_text().strip() != ""
+
+
+def test_cli_rejects_bad_basename(tmp_path: Path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _write(src / "a.py", "x=1\n")
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), str(src), "--basename", "../evil"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert r.returncode != 0
+
+
+def test_cli_rejects_nonexistent_path(tmp_path: Path):
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), str(tmp_path / "nope")],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert r.returncode != 0


### PR DESCRIPTION
Restores parity: amplihack-rs had only the docs for the code-visualizer skill while rysweet/amplihack #4480 just merged with the full multi-language implementation. This PR ports scripts/ + tests/ + updates SKILL.md/README.md to 2.0.0.

## Languages supported
Python, TypeScript/JavaScript, Rust, Go (via brick-style per-language analyzers + a dispatcher that routes by file extension).

## Validation (dogfooded on this repo)
```
$ python3 -m pytest amplifier-bundle/skills/code-visualizer/tests/ -q
36 passed in 9.58s

$ python3 amplifier-bundle/skills/code-visualizer/scripts/visualizer.py \
    crates/amplihack-cli/src --output /tmp/codeviz-rs \
    --basename amplihack-cli --combined
wrote /tmp/codeviz-rs/amplihack-cli-rust.mmd        (52KB)
wrote /tmp/codeviz-rs/amplihack-cli-combined.mmd    (68KB)
```

## Why this matters
Skills shipped with amplihack-rs need to actually work, not just have docs. The legacy amplihack repo had the implementation; without this port, anyone invoking the skill via amplihack-rs gets a broken reference.

Closes the parity gap from #4480.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>