### PR TITLE
fix(workflow): guard WORKTREE_SETUP_WORKTREE_PATH with safe fallback (#362)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -954,7 +954,7 @@ steps:
     # (implementation, test_spec, design_spec) produce large outputs.
     max_env_value_bytes: 65536
     command: |
-      cd "$WORKTREE_SETUP_WORKTREE_PATH" 2>/dev/null || cd "$REPO_PATH" && \
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" 2>/dev/null || cd "$REPO_PATH" && \
       echo "=== Checkpoint: Staging Implementation ===" && \
       git add -A && \
       STAGED=$(git diff --cached --name-only) && \
@@ -1134,7 +1134,7 @@ steps:
     type: "bash"
     max_env_value_bytes: 65536
     command: |
-      cd "$WORKTREE_SETUP_WORKTREE_PATH" 2>/dev/null || cd "$REPO_PATH" && \
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" 2>/dev/null || cd "$REPO_PATH" && \
       echo "=== Checkpoint: Staging Review Feedback ===" && \
       git add -A && \
       STAGED=$(git diff --cached --name-only) && \
@@ -1360,7 +1360,7 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
-      cd "$WORKTREE_SETUP_WORKTREE_PATH"
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}"
       echo "=== Step 15: Commit and Push ==="
       echo ""
       echo "--- Staging Changes ---"
@@ -1384,14 +1384,14 @@ steps:
           ALT_WORKTREE_COMMITS=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
         fi
         if [ "$ALT_WORKTREE_COMMITS" -gt 0 ]; then
-          echo "INFO: Nothing staged in $WORKTREE_SETUP_WORKTREE_PATH, but the" >&2
+          echo "INFO: Nothing staged in ${WORKTREE_SETUP_WORKTREE_PATH:-(unset)}, but the" >&2
           echo "current branch '$CURRENT_BRANCH' is $ALT_WORKTREE_COMMITS commit(s) ahead of" >&2
           echo "its upstream. The agent likely committed via an alternate worktree on" >&2
           echo "the same branch; treating as success." >&2
           git --no-pager log --oneline -"$ALT_WORKTREE_COMMITS" >&2
         else
           echo "ERROR: Nothing staged to commit. The implementation step may have written files" >&2
-          echo "outside the worktree ($WORKTREE_SETUP_WORKTREE_PATH), or no code changes were produced." >&2
+          echo "outside the worktree (${WORKTREE_SETUP_WORKTREE_PATH:-(unset)}), or no code changes were produced." >&2
           echo "This is a hollow-success condition — the workflow completed structurally but" >&2
           echo "produced no git artifacts. Check that agents created files in the worktree," >&2
           echo "not in AMPLIHACK_HOME or other locations." >&2
@@ -1427,7 +1427,7 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
-      cd "$WORKTREE_SETUP_WORKTREE_PATH"
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}"
       echo "=== Step 16: Creating Draft PR ===" >&2
 
       # FIX (#3324): Idempotency guard — detect pre-existing PRs before creating one
@@ -1774,7 +1774,7 @@ steps:
   - id: "step-18c-push-feedback-changes"
     type: "bash"
     command: |
-      cd "$WORKTREE_SETUP_WORKTREE_PATH" && \
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
       echo "=== Pushing Review Feedback Changes ===" && \
       git add -A && \
       if [ -n "$(git diff --cached --name-only)" ]; then \
@@ -1870,7 +1870,7 @@ steps:
     type: "bash"
     command: |
       echo "=== ZERO-BS VERIFICATION ===" && \
-      cd "$WORKTREE_SETUP_WORKTREE_PATH" && \
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
       echo "" && \
       echo "Scanning for Zero-BS violations..." && \
       echo "" && \
@@ -1957,7 +1957,7 @@ steps:
   - id: "step-20b-push-cleanup"
     type: "bash"
     command: |
-      cd "$WORKTREE_SETUP_WORKTREE_PATH" && \
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
       echo "=== Pushing Cleanup Changes ===" && \
       git add -A && \
       git diff --cached --quiet || (git commit -m "final cleanup pass" && git pull --rebase 2>/dev/null && git push) && \
@@ -2042,7 +2042,7 @@ steps:
   - id: "step-21-pr-ready"
     type: "bash"
     command: |
-      cd "$WORKTREE_SETUP_WORKTREE_PATH" && \
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
       echo "=== Step 20: Converting PR to Ready ===" && \
       echo "" && \
       echo "--- Verifying All Steps Complete ---" && \

--- a/amplifier-bundle/tools/test_default_workflow_fixes.py
+++ b/amplifier-bundle/tools/test_default_workflow_fixes.py
@@ -1249,6 +1249,90 @@ class TestIssue342ExistingBranchContext(unittest.TestCase):
 
 
 # ===========================================================================
+class TestWorktreePathFallback(unittest.TestCase):
+    """
+    Regression test for issue #362.
+
+    Bug: default-workflow.yaml steps that consume WORKTREE_SETUP_WORKTREE_PATH
+    used a bare reference (`$VAR`) under `set -euo pipefail`. When the BLOCKED
+    fallback path (or any code path that skips step-04-setup-worktree) runs
+    those steps, `set -u` aborts at variable expansion BEFORE any `cd … || cd
+    $REPO_PATH` fallback can take effect.
+
+    Fix: every consumer must use `${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}`
+    (or `:-(unset)` for echo).
+
+    This test asserts no bare `$WORKTREE_SETUP_WORKTREE_PATH` reference remains
+    in default-workflow.yaml, so any future bare reuse fails CI immediately.
+    """
+
+    def test_no_bare_worktree_path_references(self):
+        text = _WORKFLOW_YAML.read_text()
+        bare_refs: list[tuple[int, str]] = []
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            # Find $WORKTREE_SETUP_WORKTREE_PATH that is NOT inside ${...:-...}
+            # i.e., a literal `$WORKTREE_SETUP_WORKTREE_PATH` not preceded by `{`.
+            # Acceptable: ${WORKTREE_SETUP_WORKTREE_PATH:-...}
+            # Unacceptable: $WORKTREE_SETUP_WORKTREE_PATH (bare)
+            if "$WORKTREE_SETUP_WORKTREE_PATH" in line and "${WORKTREE_SETUP_WORKTREE_PATH" not in line:
+                bare_refs.append((lineno, line.rstrip()))
+        self.assertEqual(
+            bare_refs,
+            [],
+            "Bare $WORKTREE_SETUP_WORKTREE_PATH references found — these will\n"
+            "abort `set -u` when the var is unset (see issue #362).\n"
+            "Use ${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH} (or :-(unset) for echo).\n"
+            f"Offenders:\n" + "\n".join(f"  L{n}: {l}" for n, l in bare_refs),
+        )
+
+    def test_step15_runs_under_set_u_with_unset_worktree_path(self):
+        """
+        End-to-end: extract step-15-commit-push command, invoke it in a temp
+        git repo with WORKTREE_SETUP_WORKTREE_PATH UNSET. Before the fix, it
+        aborts at line 1 with `unbound variable`. After the fix, it falls
+        through to REPO_PATH and reaches the staging logic.
+        """
+        raw_cmd = _extract_step_command(_WORKFLOW_YAML, "step-15-commit-push")
+        tmp = tempfile.mkdtemp()
+        try:
+            subprocess.run(
+                ["git", "-c", "user.name=test", "-c", "user.email=t@t",
+                 "init", "-q", "-b", "main", tmp],
+                check=True,
+            )
+            # Make at least one commit so HEAD exists.
+            (Path(tmp) / "README.md").write_text("hi\n")
+            subprocess.run(["git", "-C", tmp, "add", "-A"], check=True)
+            subprocess.run(
+                ["git", "-C", tmp, "-c", "user.name=test", "-c", "user.email=t@t",
+                 "commit", "-q", "-m", "init"],
+                check=True,
+            )
+            env = {
+                "PATH": os.environ["PATH"],
+                "REPO_PATH": tmp,
+                "TASK_DESCRIPTION": "test",
+                "ISSUE_NUMBER": "0",
+                # WORKTREE_SETUP_WORKTREE_PATH deliberately unset.
+            }
+            result = subprocess.run(
+                ["bash", "-c", raw_cmd],
+                capture_output=True, text=True, env=env, cwd=tmp,
+            )
+            # Must NOT abort with unbound variable. Either succeeds (nothing to
+            # commit → exits via hollow-success branch which is fine for this test
+            # since upstream isn't configured), or exits 1 with a meaningful
+            # diagnostic — but never with "unbound variable".
+            self.assertNotIn(
+                "unbound variable",
+                result.stderr,
+                f"set -u aborted on bare WORKTREE_SETUP_WORKTREE_PATH:\n{result.stderr}",
+            )
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+# ===========================================================================
 # Entry point
 # ===========================================================================
 


### PR DESCRIPTION
Fixes #362.

## Problem
\`default-workflow.yaml\` step-15-commit-push (and 9 other consumers) had bare \`\$WORKTREE_SETUP_WORKTREE_PATH\` references under \`set -euo pipefail\`. When the orchestrator routes through the BLOCKED fallback path (or any path that skips step-04-setup-worktree's output propagation), the step aborts at variable expansion with \`unbound variable\` — BEFORE any \`|| cd \$REPO_PATH\` fallback gets a chance.

This is the inverse of #251 (hollow success). The audit recipe's underlying work succeeded — 6 PRs landed — but its self-assessment marked the run FAILED.

## Fix
All 10 bare references now use \`\${WORKTREE_SETUP_WORKTREE_PATH:-\$REPO_PATH}\` (matching the existing pattern at line 907). Echo statements use \`\${...:-(unset)}\` for informative diagnostics.

## Tests
- \`test_no_bare_worktree_path_references\` — yaml-level guard, fails CI on any future regression.
- \`test_step15_runs_under_set_u_with_unset_worktree_path\` — invokes the actual step command in a temp git repo with the var unset; asserts no \"unbound variable\".

Both pass. The 3 unrelated pre-existing test failures (\`test_yaml_step03b_*\`, \`test_yaml_step04_second_run_exits_zero\`) reproduce identically on main without this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>