### PR TITLE
fix(release): use git tags as version-bump source of truth (#359)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compute next version from tags
@@ -40,19 +41,24 @@ jobs:
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT}"
 
-          # Find latest release tag to determine next patch
-          LATEST_TAG=$(gh release list --limit 50 --json tagName --jq '.[].tagName' \
-            | grep -E "^v${MAJOR}\.${MINOR}\.[0-9]+$" \
-            | sort -t. -k3 -n -r \
-            | head -1 || true)
+          # Find latest tag in the v${MAJOR}.${MINOR}.x series.
+          #
+          # Source of truth is `git tag --list` (the tag namespace) rather than
+          # `gh release list`. When release publishing fails (e.g. a build leg
+          # broke), tags advance but releases don't — `gh release list` then
+          # returns stale data and the next run computes a colliding patch
+          # number, falling back to the `while git rev-parse` bump loop.
+          # Reading from git tags eliminates that drift entirely. (#359)
+          LATEST_PATCH=$(git tag --list "v${MAJOR}.${MINOR}.*" \
+            | sed -n "s/^v${MAJOR}\.${MINOR}\.\([0-9]\+\)$/\1/p" \
+            | sort -n | tail -1)
 
-          if [ -n "${LATEST_TAG}" ]; then
-            LATEST_PATCH=$(echo "${LATEST_TAG}" | sed "s/^v${MAJOR}\.${MINOR}\.\([0-9]*\)/\1/")
+          if [ -n "${LATEST_PATCH}" ]; then
             NEW_PATCH=$((LATEST_PATCH + 1))
-            echo "Latest release: ${LATEST_TAG} → next patch: ${NEW_PATCH}"
+            echo "Latest tag: v${MAJOR}.${MINOR}.${LATEST_PATCH} → next patch: ${NEW_PATCH}"
           else
             NEW_PATCH="${PATCH}"
-            echo "No prior v${MAJOR}.${MINOR}.x release found"
+            echo "No prior v${MAJOR}.${MINOR}.x tag found"
           fi
 
           HEAD_SHA=$(git rev-parse HEAD)


### PR DESCRIPTION
Fixes #359.

## Problem
When release publishing failed silently (as it did from v0.8.10 → v0.8.22), the version-bump logic kept reading `gh release list` (which only sees PUBLISHED releases). Stale published data → colliding patch numbers → spin in the `while git rev-parse` bump loop one tag at a time.

## Fix
Read from `git tag --list 'v${MAJOR}.${MINOR}.*'` instead. Tags are pushed unconditionally before build/release steps and survive build failures.

Also added explicit `fetch-tags: true` to checkout (belt + suspenders).

## Validation
Against current repo state (v0.8.x latest is v0.8.23 — correctly published):
- New logic: proposes `v0.8.24` ✅
- Old logic on a failed-publish day would have proposed v0.8.10 (stale) and looped through 14 already-existing tags before settling.

The post-loop `while git rev-parse` guard is kept as a safety net for concurrent-run races, but should never fire in normal operation now.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>