### PR TITLE
fix(workflow): pre-flight 'goal already met' probe (#368)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -797,11 +797,57 @@ steps:
     output: "final_documentation"
 
   # ==========================================================================
+  # STEP 6d: PRE-FLIGHT "GOAL ALREADY MET" PROBE (#368)
+  # ==========================================================================
+  # Detect whether the linked GitHub issue is already CLOSED by a merged PR
+  # *before* paying for tests + implementation. When the goal is already met
+  # this short-circuits steps 07/08/08c, saving ~30min of agent runtime per
+  # round (typical case: a previous orchestrator round shipped the fix and
+  # this round was queued as a duplicate).
+  #
+  # Defensive: if `gh` is missing, ISSUE_NUMBER is unset, or any probe call
+  # fails, we set goal_already_met="false" and let the workflow proceed
+  # normally — never short-circuit on uncertainty.
+  - id: "step-06d-goal-already-met-probe"
+    type: "bash"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    command: |
+      set -euo pipefail
+      ISSUE_NUM="${ISSUE_NUMBER:-}"
+      if [ -z "$ISSUE_NUM" ] || ! command -v gh >/dev/null 2>&1; then
+        echo "false"
+        exit 0
+      fi
+      ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null || true)
+      if [ "$ISSUE_STATE" != "CLOSED" ]; then
+        echo "false"
+        exit 0
+      fi
+      # closedByPullRequestsReferences items DO NOT carry .state; we must
+      # fetch each PR's mergedAt explicitly. (Verified live; documented in
+      # PR #367 cohort review.)
+      CLOSING_PR_NUMS=$(gh issue view "$ISSUE_NUM" \
+        --json closedByPullRequestsReferences \
+        --jq '[.closedByPullRequestsReferences[]?.number] | join(" ")' \
+        2>/dev/null || true)
+      for PR_NUM in $CLOSING_PR_NUMS; do
+        PR_MERGED=$(gh pr view "$PR_NUM" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+        if [ -n "$PR_MERGED" ] && [ "$PR_MERGED" != "null" ]; then
+          echo "INFO: issue #${ISSUE_NUM} is already CLOSED by merged PR #${PR_NUM}." >&2
+          echo "  Short-circuiting steps 07/08/08c — goal already met (#368)." >&2
+          echo "true"
+          exit 0
+        fi
+      done
+      echo "false"
+    output: "goal_already_met"
+
+  # ==========================================================================
   # STEP 7: TDD - WRITE TESTS FIRST
   # ==========================================================================
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
-    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -831,7 +877,7 @@ steps:
   # ==========================================================================
   - id: "step-08-implement"
     agent: "amplihack:builder"
-    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -881,7 +927,7 @@ steps:
 
   - id: "step-08c-implementation-no-op-guard"
     type: "bash"
-    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
     # Hard-fail early (before checkpoint, refactor, review) if step-08 declared
     # success but reported zero file edits. This catches prompt-misalignment
     # (issue #251 / amplihack-rs #251) closer to the root cause than the

--- a/amplifier-bundle/tools/test_default_workflow_fixes.py
+++ b/amplifier-bundle/tools/test_default_workflow_fixes.py
@@ -1473,6 +1473,115 @@ class TestNoopGuardPreExisting(unittest.TestCase):
             shutil.rmtree(bindir, ignore_errors=True)
 
 
+class TestGoalAlreadyMetProbe(unittest.TestCase):
+    """
+    Regression tests for issue #368.
+
+    The pre-flight `step-06d-goal-already-met-probe` short-circuits steps
+    07/08/08c when the linked GitHub issue is already closed by a merged
+    PR — saving ~30min of agent runtime per duplicate round vs relying on
+    the post-implement noop-guard (#360).
+
+    Contract:
+      stdout MUST be exactly "true\n" or "false\n" (consumed by step
+      conditions `goal_already_met != 'true'`); never crash.
+    """
+
+    def _run_probe(self, env: dict, *, expect: str) -> subprocess.CompletedProcess:
+        raw = _extract_step_command(_WORKFLOW_YAML, "step-06d-goal-already-met-probe")
+        r = subprocess.run(
+            ["bash", "-c", raw], capture_output=True, text=True, env=env,
+        )
+        self.assertEqual(r.returncode, 0, f"probe must never fail-hard. stderr={r.stderr}")
+        self.assertEqual(
+            r.stdout.strip(), expect,
+            f"probe stdout mismatch: expected {expect!r}, got {r.stdout!r}\n"
+            f"stderr: {r.stderr}",
+        )
+        return r
+
+    def _gh_stub(self, script: str) -> tuple[str, dict]:
+        bindir = tempfile.mkdtemp()
+        Path(bindir, "gh").write_text(script)
+        os.chmod(Path(bindir, "gh"), 0o755)
+        env = {
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "ISSUE_NUMBER": "999",
+        }
+        return bindir, env
+
+    def test_returns_true_when_issue_closed_by_merged_pr(self):
+        gh_stub = (
+            "#!/bin/bash\n"
+            'if [[ "$*" == *"issue view"*"--jq .state"* ]]; then echo CLOSED; exit 0; fi\n'
+            'if [[ "$*" == *"issue view"*closedByPullRequestsReferences* ]]; then echo 999; exit 0; fi\n'
+            'if [[ "$*" == *"pr view"*"--jq .mergedAt"* ]]; then echo "2026-01-01T00:00:00Z"; exit 0; fi\n'
+            "exit 1\n"
+        )
+        bindir, env = self._gh_stub(gh_stub)
+        try:
+            r = self._run_probe(env, expect="true")
+            self.assertIn("goal already met", r.stderr)
+        finally:
+            shutil.rmtree(bindir, ignore_errors=True)
+
+    def test_returns_false_when_issue_open(self):
+        gh_stub = (
+            "#!/bin/bash\n"
+            'if [[ "$*" == *"issue view"*"--jq .state"* ]]; then echo OPEN; exit 0; fi\n'
+            "exit 1\n"
+        )
+        bindir, env = self._gh_stub(gh_stub)
+        try:
+            self._run_probe(env, expect="false")
+        finally:
+            shutil.rmtree(bindir, ignore_errors=True)
+
+    def test_returns_false_when_closed_but_no_pr_merged(self):
+        gh_stub = (
+            "#!/bin/bash\n"
+            'if [[ "$*" == *"issue view"*"--jq .state"* ]]; then echo CLOSED; exit 0; fi\n'
+            'if [[ "$*" == *"issue view"*closedByPullRequestsReferences* ]]; then echo 999; exit 0; fi\n'
+            'if [[ "$*" == *"pr view"*"--jq .mergedAt"* ]]; then echo null; exit 0; fi\n'
+            "exit 1\n"
+        )
+        bindir, env = self._gh_stub(gh_stub)
+        try:
+            self._run_probe(env, expect="false")
+        finally:
+            shutil.rmtree(bindir, ignore_errors=True)
+
+    def test_returns_false_when_issue_number_unset(self):
+        # No ISSUE_NUMBER → defensive default to "false" (run normally).
+        env = {"PATH": os.environ["PATH"]}
+        self._run_probe(env, expect="false")
+
+    def test_returns_false_when_gh_missing(self):
+        # PATH without gh → defensive default to "false".
+        # Use a tempdir as PATH so bash itself remains available via the
+        # absolute interpreter; ensure no `gh` binary is present there.
+        bindir = tempfile.mkdtemp()
+        try:
+            env = {"PATH": bindir, "ISSUE_NUMBER": "999"}
+            raw = _extract_step_command(_WORKFLOW_YAML, "step-06d-goal-already-met-probe")
+            r = subprocess.run(
+                ["/bin/bash", "-c", raw], capture_output=True, text=True, env=env,
+            )
+            self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
+            self.assertEqual(r.stdout.strip(), "false")
+        finally:
+            shutil.rmtree(bindir, ignore_errors=True)
+
+    def test_returns_false_when_gh_call_errors(self):
+        # gh exits 1 (e.g. rate-limited or auth fail) → "false", never crash.
+        gh_stub = "#!/bin/bash\nexit 1\n"
+        bindir, env = self._gh_stub(gh_stub)
+        try:
+            self._run_probe(env, expect="false")
+        finally:
+            shutil.rmtree(bindir, ignore_errors=True)
+
+
 # ===========================================================================
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #368.

## Problem
After #367 we detect goal-already-met **post-implementation** in step-08c, which limits damage to 'wasted agent time + clean exit'. But we still pay for tester (#step-07) + implementer (#step-08) agents — typically ~30 min — before realising the goal was already shipped by a previous round.

## Fix
Add **step-06d-goal-already-met-probe** *before* step-07-write-tests. When the linked GitHub issue is already CLOSED by a merged PR, output 'true' on stdout and gate steps 07/08/08c via condition `goal_already_met != 'true'`.

## Behaviour contract
- stdout is exactly `true` or `false`
- never fails-hard (defensive default to `false` on any error)
- skips probe entirely when `ISSUE_NUMBER` unset or `gh` missing

## Implementation notes
- Reuses the verified-live schema work from #367 — `closedByPullRequestsReferences` items have no `.state` field, so we fetch each PR's `mergedAt` explicitly via `gh pr view N`.

## Tests
- New `TestGoalAlreadyMetProbe` × 6 covering true-path, open issue, closed-but-no-merged-PR, missing ISSUE_NUMBER, missing gh binary, and gh-call-errors.
- All 12 workflow regression tests pass.

## Manual validation
```
$ python3 -m pytest amplifier-bundle/tools/test_default_workflow_fixes.py \
    -k 'GoalAlreadyMet or NoopGuard or WorktreePathFallback' -q
............ 12 passed
```