### PR TITLE
fix(workflow): goal-already-met short-circuit + cross-repo + cap (COE)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -824,21 +824,42 @@ steps:
         exit 0
       fi
       # closedByPullRequestsReferences items DO NOT carry .state; we must
-      # fetch each PR's mergedAt explicitly. (Verified live; documented in
-      # PR #367 cohort review.)
-      CLOSING_PR_NUMS=$(gh issue view "$ISSUE_NUM" \
+      # fetch each PR's mergedAt explicitly. Capture (number, owner/repo)
+      # pairs so cross-repo closing PRs are looked up in the correct repo
+      # rather than silently misresolved against the current repo (COE
+      # cohort review #2, REAL_BUG #2).
+      CLOSING_PR_REFS=$(gh issue view "$ISSUE_NUM" \
         --json closedByPullRequestsReferences \
-        --jq '[.closedByPullRequestsReferences[]?.number] | join(" ")' \
+        --jq '[.closedByPullRequestsReferences[]? | "\(.number) \(.repository.owner.login)/\(.repository.name)"] | join("\n")' \
         2>/dev/null || true)
-      for PR_NUM in $CLOSING_PR_NUMS; do
-        PR_MERGED=$(gh pr view "$PR_NUM" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+      # Cap the fan-out (DESIGN_RISK #3): an issue with hundreds of linked
+      # PRs would otherwise serially walk the GitHub API and chew rate
+      # limit; the typical real case is 1-2 PRs.
+      MAX_PROBE=10
+      probed=0
+      while IFS= read -r ref; do
+        [ -z "$ref" ] && continue
+        probed=$((probed + 1))
+        if [ "$probed" -gt "$MAX_PROBE" ]; then
+          echo "WARN: hit MAX_PROBE=${MAX_PROBE} linked-PR cap; assuming goal not met." >&2
+          break
+        fi
+        PR_NUM=$(printf '%s' "$ref" | awk '{print $1}')
+        PR_REPO=$(printf '%s' "$ref" | awk '{print $2}')
+        # Cap each gh call at 30s to prevent stalling the whole workflow on
+        # a slow API response (DESIGN_RISK #3).
+        if [ -n "$PR_REPO" ] && [ "$PR_REPO" != "/" ]; then
+          PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --repo "$PR_REPO" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+        else
+          PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+        fi
         if [ -n "$PR_MERGED" ] && [ "$PR_MERGED" != "null" ]; then
-          echo "INFO: issue #${ISSUE_NUM} is already CLOSED by merged PR #${PR_NUM}." >&2
-          echo "  Short-circuiting steps 07/08/08c — goal already met (#368)." >&2
+          echo "INFO: issue #${ISSUE_NUM} is already CLOSED by merged PR ${PR_REPO}#${PR_NUM}." >&2
+          echo "  Short-circuiting steps 07/08/08c/08b/09-16b — goal already met (#368)." >&2
           echo "true"
           exit 0
         fi
-      done
+      done <<< "$CLOSING_PR_REFS"
       echo "false"
     output: "goal_already_met"
 
@@ -972,20 +993,32 @@ steps:
         ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null || true)
         if [ "$ISSUE_STATE" = "CLOSED" ]; then
           # closedByPullRequestsReferences items DO NOT carry .state.
-          # Fetch PR numbers, then probe each PR's mergedAt explicitly.
-          CLOSING_PR_NUMS=$(gh issue view "$ISSUE_NUM" \
+          # Fetch (number, owner/repo) pairs so cross-repo PRs are looked
+          # up correctly (COE cohort review #2).
+          CLOSING_PR_REFS=$(gh issue view "$ISSUE_NUM" \
             --json closedByPullRequestsReferences \
-            --jq '[.closedByPullRequestsReferences[]?.number] | join(" ")' \
+            --jq '[.closedByPullRequestsReferences[]? | "\(.number) \(.repository.owner.login)/\(.repository.name)"] | join("\n")' \
             2>/dev/null || true)
+          MAX_PROBE=10
+          probed=0
           MERGED_FOUND=0
-          for PR_NUM in $CLOSING_PR_NUMS; do
-            PR_MERGED=$(gh pr view "$PR_NUM" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+          while IFS= read -r ref; do
+            [ -z "$ref" ] && continue
+            probed=$((probed + 1))
+            if [ "$probed" -gt "$MAX_PROBE" ]; then break; fi
+            PR_NUM=$(printf '%s' "$ref" | awk '{print $1}')
+            PR_REPO=$(printf '%s' "$ref" | awk '{print $2}')
+            if [ -n "$PR_REPO" ] && [ "$PR_REPO" != "/" ]; then
+              PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --repo "$PR_REPO" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+            else
+              PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+            fi
             # mergedAt is null for unmerged PRs and a timestamp string for merged ones.
             if [ -n "$PR_MERGED" ] && [ "$PR_MERGED" != "null" ]; then
               MERGED_FOUND=1
               break
             fi
-          done
+          done <<< "$CLOSING_PR_REFS"
           if [ "$MERGED_FOUND" -eq 1 ]; then
             echo "INFO: step-08-implement produced no file changes, but issue" >&2
             echo "  #${ISSUE_NUM} is already CLOSED by a merged pull request." >&2
@@ -1007,7 +1040,7 @@ steps:
 
   - id: "step-08b-integration"
     agent: "amplihack:integration"
-    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
     prompt: |
       # Step 8b: External Service Integration
 
@@ -1054,6 +1087,7 @@ steps:
   # ==========================================================================
   - id: "step-09-refactor"
     agent: "amplihack:cleanup"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 9: Refactor and Simplify
 
@@ -1082,6 +1116,7 @@ steps:
 
   - id: "step-09b-optimize"
     agent: "amplihack:optimizer"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 9b: Performance Optimization
 
@@ -1102,6 +1137,7 @@ steps:
   # ==========================================================================
   - id: "step-10-pre-commit-review"
     agent: "amplihack:reviewer"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 10: Review Pass Before Commit
 
@@ -1133,6 +1169,7 @@ steps:
 
   - id: "step-10b-security-review"
     agent: "amplihack:security"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 10b: Security Review
 
@@ -1152,6 +1189,7 @@ steps:
 
   - id: "step-10c-philosophy-check"
     agent: "amplihack:philosophy-guardian"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 10c: Philosophy Compliance Check
 
@@ -1173,6 +1211,7 @@ steps:
   # ==========================================================================
   - id: "step-11-incorporate-feedback"
     agent: "amplihack:architect"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 11: Assess Review Feedback
 
@@ -1190,6 +1229,7 @@ steps:
 
   - id: "step-11b-implement-feedback"
     agent: "amplihack:builder"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 11b: Implement Review Feedback
 
@@ -1234,6 +1274,7 @@ steps:
   # ==========================================================================
   - id: "step-12-run-precommit"
     agent: "amplihack:pre-commit-diagnostic"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 12: Run Tests and Pre-commit Hooks
 
@@ -1271,6 +1312,7 @@ steps:
   # ==========================================================================
   - id: "step-13-local-testing"
     agent: "amplihack:builder"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 13: Mandatory Outside-In Testing (CANNOT BE SKIPPED)
 
@@ -1353,6 +1395,7 @@ steps:
   # ==========================================================================
   - id: "step-14-bump-version"
     agent: "amplihack:architect"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 14: Bump Version in pyproject.toml (MANDATORY - DO NOT SKIP)
 
@@ -1437,6 +1480,7 @@ steps:
   # ==========================================================================
   - id: "step-15-commit-push"
     type: "bash"
+    condition: "goal_already_met != 'true'"
     command: |
       set -euo pipefail
       cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}"
@@ -1504,6 +1548,7 @@ steps:
   # ==========================================================================
   - id: "step-16-create-draft-pr"
     type: "bash"
+    condition: "goal_already_met != 'true'"
     command: |
       set -euo pipefail
       cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}"
@@ -1591,6 +1636,7 @@ steps:
   # ==========================================================================
   - id: "step-16b-outside-in-fix-loop"
     agent: "amplihack:builder"
+    condition: "goal_already_met != 'true'"
     prompt: |
       # Step 16b: Outside-In Testing and Fix Loop (MANDATORY)
 

--- a/amplifier-bundle/tools/test_default_workflow_fixes.py
+++ b/amplifier-bundle/tools/test_default_workflow_fixes.py
@@ -1581,6 +1581,85 @@ class TestGoalAlreadyMetProbe(unittest.TestCase):
         finally:
             shutil.rmtree(bindir, ignore_errors=True)
 
+    def test_cross_repo_closing_pr_uses_explicit_repo_flag(self):
+        """
+        COE finding (cohort #2): closedByPullRequestsReferences may point at
+        a PR in a different repo. The probe must pass `--repo owner/name`
+        when looking up that PR, otherwise it queries the current repo and
+        either silently misses (false negative) or worse, reads the wrong
+        PR with the same number.
+        """
+        # Stub records the args it sees so we can assert --repo was passed.
+        bindir = tempfile.mkdtemp()
+        try:
+            log = Path(bindir) / "calls.log"
+            gh_script = (
+                "#!/bin/bash\n"
+                f'echo "$*" >> {log}\n'
+                'if [[ "$*" == *"issue view"*"--jq .state"* ]]; then echo CLOSED; exit 0; fi\n'
+                'if [[ "$*" == *"issue view"*closedByPullRequestsReferences* ]]; then\n'
+                # Return one cross-repo PR ref: number=42, repo=upstream/other
+                '  echo "42 upstream/other"; exit 0\n'
+                'fi\n'
+                'if [[ "$*" == *"pr view 42"*"--repo upstream/other"*"--jq .mergedAt"* ]]; then\n'
+                '  echo "2026-01-01T00:00:00Z"; exit 0\n'
+                'fi\n'
+                # If --repo was NOT passed, return null so the test fails loudly.
+                'if [[ "$*" == *"pr view 42"*"--jq .mergedAt"* ]]; then echo null; exit 0; fi\n'
+                "exit 1\n"
+            )
+            Path(bindir, "gh").write_text(gh_script)
+            os.chmod(Path(bindir, "gh"), 0o755)
+            env = {
+                "PATH": f"{bindir}:{os.environ['PATH']}",
+                "ISSUE_NUMBER": "999",
+            }
+            self._run_probe(env, expect="true")
+            calls = log.read_text()
+            self.assertIn("--repo upstream/other", calls,
+                          f"probe must pass --repo for cross-repo PR. calls:\n{calls}")
+        finally:
+            shutil.rmtree(bindir, ignore_errors=True)
+
+    def test_caps_fan_out_at_max_probe(self):
+        """
+        DESIGN_RISK (cohort #2): an issue with many linked PRs must not
+        chew through the rate limit; cap is MAX_PROBE=10. After the cap,
+        the probe falls through to "false" rather than continuing to walk.
+        """
+        bindir = tempfile.mkdtemp()
+        try:
+            log = Path(bindir) / "calls.log"
+            # Generate 20 unmerged PR refs.
+            refs = "\\n".join(f"{i} owner/repo" for i in range(1, 21))
+            gh_script = (
+                "#!/bin/bash\n"
+                f'echo "$*" >> {log}\n'
+                'if [[ "$*" == *"issue view"*"--jq .state"* ]]; then echo CLOSED; exit 0; fi\n'
+                'if [[ "$*" == *"issue view"*closedByPullRequestsReferences* ]]; then\n'
+                f'  printf "{refs}\\n"; exit 0\n'
+                'fi\n'
+                # All PRs unmerged.
+                'if [[ "$*" == *"pr view"*"--jq .mergedAt"* ]]; then echo null; exit 0; fi\n'
+                "exit 1\n"
+            )
+            Path(bindir, "gh").write_text(gh_script)
+            os.chmod(Path(bindir, "gh"), 0o755)
+            env = {
+                "PATH": f"{bindir}:{os.environ['PATH']}",
+                "ISSUE_NUMBER": "999",
+            }
+            self._run_probe(env, expect="false")
+            # Count pr-view calls — must be at most 10 (the cap).
+            calls = log.read_text()
+            pr_view_calls = sum(1 for line in calls.splitlines() if "pr view" in line)
+            self.assertLessEqual(
+                pr_view_calls, 10,
+                f"probe walked {pr_view_calls} PRs; cap is 10. calls:\n{calls}",
+            )
+        finally:
+            shutil.rmtree(bindir, ignore_errors=True)
+
 
 # ===========================================================================
 


### PR DESCRIPTION
## Context
Cohort #2 COE review of #369 (which closed #368) caught two real bugs and one design risk in the goal-already-met probe.

## Bugs fixed

### REAL_BUG #1 — short-circuit was incomplete
`step-06d` set `goal_already_met='true'` and gated 07/08/08c, but **steps 08b, 09, 09b, 10*, 11*, 12, 13, 14, 15, 16, 16b still ran unconditionally**. Result: a duplicate-issue round would bump version, commit nothing-but-the-bump, and open a nonsense PR.

Fix: gate all 14 downstream write/agent steps on `goal_already_met != 'true'`.

### REAL_BUG #2 — cross-repo closing PRs misresolved
`step-06d` and `step-08c` noop-guard discarded repository identity from `closedByPullRequestsReferences` and called `gh pr view N` without `--repo`. An issue closed by a PR in a different repo would either silently miss or inspect a same-numbered PR in the current repo.

Fix: capture `(number, owner/repo)` pairs in the jq filter and pass `--repo` to `gh pr view`.

### DESIGN_RISK #3 — unbounded fan-out
Loop walked every linked PR with no cap and no per-call timeout.

Fix: `MAX_PROBE=10` and `timeout 30 gh pr view ...` per call.

## Tests
- `test_cross_repo_closing_pr_uses_explicit_repo_flag` — asserts `--repo upstream/other` was passed when the ref points cross-repo
- `test_caps_fan_out_at_max_probe` — stub returns 20 unmerged PR refs; asserts probe makes ≤10 `pr view` calls
- All 14 existing tests still pass

Refs #368.