### PR TITLE
feat(default-workflow): decompose 3098-LOC monolith into 9 composable phase bricks (≤400 LOC each)

### DIFF
--- a/amplifier-bundle/recipes/_recipe_manifest.json
+++ b/amplifier-bundle/recipes/_recipe_manifest.json
@@ -4,7 +4,7 @@
   "code-atlas": "086c4299a3fd331d",
   "consensus-workflow": "79baac1a8e0cef8b",
   "debate-workflow": "cf667901c45b498b",
-  "default-workflow": "80b323714dce8123",
+  "default-workflow": "3ab0c0868df4cdf9",
   "guide": "3a317f9f004c1ddb",
   "investigation-explore": "a56fbb3ff6df9812",
   "investigation-prep": "64d4d26702bcb4f3",
@@ -18,5 +18,14 @@
   "sdk-comparison": "a4ead8f91eb1e93a",
   "self-improvement-loop": "f9fe001854a0742b",
   "smart-orchestrator": "d471df6ad3564969",
-  "verification-workflow": "5227881f37c97325"
+  "verification-workflow": "5227881f37c97325",
+  "workflow-design": "5f9e2b0a27b06f55",
+  "workflow-finalize": "824c5bc6245b2231",
+  "workflow-pr-review": "64a08e62308ae9d1",
+  "workflow-precommit-test": "6862b817b8c65b8f",
+  "workflow-prep": "3e1dfe776ced6d26",
+  "workflow-publish": "250aae725873ae9f",
+  "workflow-refactor-review": "ad94b72c16cecd5d",
+  "workflow-tdd": "4a8574462bc30532",
+  "workflow-worktree": "6ed477c9530e4426"
 }

--- a/amplifier-bundle/recipes/workflow-design.yaml
+++ b/amplifier-bundle/recipes/workflow-design.yaml
@@ -1,0 +1,245 @@
+name: "workflow-design"
+description: "Phase 2: architecture, API/DB/security design, docs (05-06d)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "design", "architecture"]
+
+# workflow-design: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  - id: "step-05-architecture"
+    agent: "amplihack:architect"
+    prompt: |
+      # Step 5: Research and Design - Architecture
+
+      **Task:** {{task_description}}
+      **Requirements:** {{final_requirements}}
+      **Codebase Analysis:** {{codebase_analysis}}
+      **Worktree:** {{worktree_setup}}
+
+      Design the solution architecture:
+
+      1. Identify components involved
+      2. Define module boundaries
+      3. Plan implementation approach
+      4. Document module specifications
+      5. Identify risks and dependencies
+
+      Consider the INVESTIGATION-FIRST PATTERN if the codebase is unfamiliar.
+
+      Output a comprehensive design specification.
+    output: "architecture_design"
+
+  - id: "step-05b-api-design"
+    agent: "amplihack:api-designer"
+    prompt: |
+      # Step 5b: API Design (if applicable)
+
+      **Architecture:** {{architecture_design}}
+      **Requirements:** {{final_requirements}}
+
+      Design API contracts:
+      - Endpoint definitions
+      - Request/response schemas
+      - Error handling patterns
+      - Versioning strategy
+
+      Skip if no API work is required.
+    output: "api_design"
+
+  - id: "step-05c-database-design"
+    agent: "amplihack:database"
+    prompt: |
+      # Step 5c: Database Design (if applicable)
+
+      **Architecture:** {{architecture_design}}
+      **Requirements:** {{final_requirements}}
+
+      Design data model:
+      - Schema definitions
+      - Migrations needed
+      - Indexes and constraints
+      - Data relationships
+
+      Skip if no database work is required.
+    output: "database_design"
+
+  - id: "step-05d-security-review"
+    agent: "amplihack:security"
+    prompt: |
+      # Step 5d: Security Requirements Review
+
+      **Architecture:** {{architecture_design}}
+      **Requirements:** {{final_requirements}}
+      **API Design:** {{api_design}}
+      **Database Design:** {{database_design}}
+
+      Identify security requirements:
+      - Authentication/authorization needs
+      - Input validation requirements
+      - Data protection considerations
+      - Security risks and mitigations
+
+      Provide security guidelines for implementation.
+    output: "security_requirements"
+
+  - id: "step-05e-design-consolidation"
+    agent: "amplihack:architect"
+    prompt: |
+      # Step 5e: Design Consolidation
+
+      **Architecture:** {{architecture_design}}
+      **API Design:** {{api_design}}
+      **Database Design:** {{database_design}}
+      **Security Requirements:** {{security_requirements}}
+
+      Consolidate all design inputs into a final implementation plan:
+
+      ```json
+      {
+        "components": [{"name": "...", "action": "create/modify", "purpose": "..."}],
+        "files_to_change": ["list of file paths"],
+        "new_files": ["files to create"],
+        "test_files": ["test files to create/modify"],
+        "implementation_order": ["ordered steps"],
+        "risks": ["potential issues"],
+        "security_considerations": ["security notes"]
+      }
+      ```
+    output: "design_spec"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 6: RETCON DOCUMENTATION WRITING
+  # ==========================================================================
+  - id: "step-06-documentation"
+    agent: "amplihack:documentation-writer"
+    prompt: |
+      # Step 6: Retcon Documentation Writing
+
+      **Task:** {{task_description}}
+      **Requirements:** {{final_requirements}}
+      **Design Specification:** {{design_spec}}
+
+      Write documentation for the feature AS IF IT ALREADY EXISTS.
+      This is "retcon" documentation - describing the finished state.
+
+      Write ONLY the documentation, NOT the code:
+      - Usage documentation
+      - API documentation (if applicable)
+      - Configuration documentation
+      - Examples and tutorials
+
+      This documentation serves as the specification for implementation.
+    output: "documentation"
+
+  - id: "step-06b-documentation-review"
+    agent: "amplihack:architect"
+    prompt: |
+      # Step 6b: Documentation Review
+
+      **Design Specification:** {{design_spec}}
+      **Documentation:** {{documentation}}
+
+      Review the documentation to verify:
+      1. Aligns with the architectural vision
+      2. Accurately describes intended behavior
+      3. Highlights any changes needed to the design
+
+      Provide feedback for documentation refinement.
+    output: "doc_review_feedback"
+
+  - id: "step-06c-documentation-refinement"
+    agent: "amplihack:documentation-writer"
+    prompt: |
+      # Step 6c: Documentation Refinement
+
+      **Original Documentation:** {{documentation}}
+      **Architect Feedback:** {{doc_review_feedback}}
+
+      Revise the documentation based on the architect's review.
+      Ensure it accurately represents the feature we will build.
+    output: "final_documentation"
+
+  # ==========================================================================
+  # STEP 6d: PRE-FLIGHT "GOAL ALREADY MET" PROBE (#368)
+  # ==========================================================================
+  # Detect whether the linked GitHub issue is already CLOSED by a merged PR
+  # *before* paying for tests + implementation. When the goal is already met
+  # this short-circuits steps 07/08/08c, saving ~30min of agent runtime per
+  # round (typical case: a previous orchestrator round shipped the fix and
+  # this round was queued as a duplicate).
+  #
+  # Defensive: if `gh` is missing, ISSUE_NUMBER is unset, or any probe call
+  # fails, we set goal_already_met="false" and let the workflow proceed
+  # normally — never short-circuit on uncertainty.
+  - id: "step-06d-goal-already-met-probe"
+    type: "bash"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    command: |
+      set -euo pipefail
+      ISSUE_NUM="${ISSUE_NUMBER:-}"
+      if [ -z "$ISSUE_NUM" ] || ! command -v gh >/dev/null 2>&1; then
+        echo "false"
+        exit 0
+      fi
+      ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null || true)
+      if [ "$ISSUE_STATE" != "CLOSED" ]; then
+        echo "false"
+        exit 0
+      fi
+      # closedByPullRequestsReferences items DO NOT carry .state; we must
+      # fetch each PR's mergedAt explicitly. Capture (number, owner/repo)
+      # pairs so cross-repo closing PRs are looked up in the correct repo
+      # rather than silently misresolved against the current repo (COE
+      # cohort review #2, REAL_BUG #2).
+      CLOSING_PR_REFS=$(gh issue view "$ISSUE_NUM" \
+        --json closedByPullRequestsReferences \
+        --jq '[.closedByPullRequestsReferences[]? | "\(.number) \(.repository.owner.login)/\(.repository.name)"] | join("\n")' \
+        2>/dev/null || true)
+      # Cap the fan-out (DESIGN_RISK #3): an issue with hundreds of linked
+      # PRs would otherwise serially walk the GitHub API and chew rate
+      # limit; the typical real case is 1-2 PRs.
+      MAX_PROBE=10
+      probed=0
+      while IFS= read -r ref; do
+        [ -z "$ref" ] && continue
+        probed=$((probed + 1))
+        if [ "$probed" -gt "$MAX_PROBE" ]; then
+          echo "WARN: hit MAX_PROBE=${MAX_PROBE} linked-PR cap; assuming goal not met." >&2
+          break
+        fi
+        PR_NUM=$(printf '%s' "$ref" | awk '{print $1}')
+        PR_REPO=$(printf '%s' "$ref" | awk '{print $2}')
+        # Cap each gh call at 30s to prevent stalling the whole workflow on
+        # a slow API response (DESIGN_RISK #3).
+        if [ -n "$PR_REPO" ] && [ "$PR_REPO" != "/" ]; then
+          PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --repo "$PR_REPO" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+        else
+          PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+        fi
+        if [ -n "$PR_MERGED" ] && [ "$PR_MERGED" != "null" ]; then
+          echo "INFO: issue #${ISSUE_NUM} is already CLOSED by merged PR ${PR_REPO}#${PR_NUM}." >&2
+          echo "  Short-circuiting steps 07/08/08c/08b/09-16b — goal already met (#368)." >&2
+          echo "true"
+          exit 0
+        fi
+      done <<< "$CLOSING_PR_REFS"
+      echo "false"
+    output: "goal_already_met"
+
+  # ==========================================================================
+  # STEP 7: TDD - WRITE TESTS FIRST
+  # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -1,0 +1,259 @@
+name: "workflow-finalize"
+description: "Phase 8: cleanup, quality audit, mergeable, complete (20-22b)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "cleanup", "merge"]
+
+# workflow-finalize: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  - id: "step-20-final-cleanup"
+    agent: "amplihack:cleanup"
+    prompt: |
+      # Step 20: Final Cleanup and Verification
+
+      **CRITICAL:** Original user requirements:
+      {{final_requirements}}
+
+      **Implementation:** {{pr_feedback_changes}}
+      **Philosophy Check:** {{philosophy_check}}
+      **Patterns Check:** {{patterns_check}}
+
+      Final quality pass:
+
+      1. Review all changes for philosophy compliance WITHIN user constraints
+      2. Review all changes for Forbidden Pattern violations (FORBIDDEN_PATTERNS.md)
+      3. Remove temporary artifacts or test files (unless user wanted them)
+      4. Eliminate unnecessary complexity (without violating requirements)
+      5. Verify module boundaries remain clean
+      6. Ensure zero dead code or stub implementations
+
+      **PR Cleanliness Final Check:**
+      - [ ] Full diff review - all changes intentional
+      - [ ] No temporary patterns (test_*.py, temp_*.js, etc.)
+      - [ ] No debugging code
+      - [ ] Documentation audit passed
+      - [ ] Git hygiene verified
+
+      **FINAL CHECK:** All explicit user requirements preserved.
+    output: "final_cleanup"
+
+  - id: "step-20b-push-cleanup"
+    type: "bash"
+    command: |
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
+      echo "=== Pushing Cleanup Changes ===" && \
+      git add -A && \
+      git diff --cached --quiet || (git commit -m "final cleanup pass" && git pull --rebase 2>/dev/null && git push) && \
+      echo "=== Cleanup Complete ==="
+    output: "cleanup_push_result"
+
+  # ==========================================================================
+  # STEP 20c: QUALITY AUDIT LOOP
+  # Runs quality-audit-cycle: seek → multi-agent validate → fix → recurse.
+  # Minimum 3 iterations with escalating depth. Continues if >3 medium or
+  # any high/critical severity findings remain after cycle 3.
+  # Placed AFTER philosophy compliance and cleanup, BEFORE marking PR ready.
+  # Added per issues #2805, #2809, #2810.
+  # ==========================================================================
+  - id: "step-20c-quality-audit"
+    agent: "amplihack:core:reviewer"
+    prompt: |
+      # Step 20c: Quality Audit Loop
+
+      **Requirements:** {{final_requirements}}
+      **PR URL:** {{pr_url}}
+      **Repository:** {{repo_path}}
+
+      Run a comprehensive, iterative quality audit on all files changed in
+      this PR. This step follows the quality-audit-cycle recipe (v3.0).
+
+      NOTE: When recipe-in-recipe support is available (see issue #2821),
+      this step should use `type: "recipe"` with `recipe: "quality-audit-cycle"`.
+      Until then, execute the audit inline following these instructions.
+
+      ## Execution: Run 3+ Audit Cycles
+
+      For each cycle (minimum 3, maximum 6):
+
+      ### A. SEEK — Scan changed files for issues in 9 categories:
+      1. Security (hardcoded secrets, missing input validation)
+      2. Reliability (missing timeouts, bare except clauses)
+      3. Dead Code (unused imports, unreachable branches)
+      4. Test Gaps (files without tests, tests without assertions)
+      5. Doc Gaps (public functions without docstrings)
+      6. Silent Fallbacks (except:pass, broad catches returning defaults)
+      7. Error Swallowing (catch blocks with no logging/re-raise)
+      8. Structural Issues (files >500 LOC, functions >50 lines, nesting >4)
+      9. Documentation (point-in-time content, unprofessional tone like
+         pirate speak "fer"/"ye"/"arr", quality/correctness vs code)
+
+      Escalate depth each cycle: cycle 1 = broad scan, cycle 2 = deeper,
+      cycle 3+ = challenge assumptions, examine module interactions.
+
+      ### B. VALIDATE — For each finding, verify by reading actual code.
+      Deploy 3 independent validation perspectives:
+      - Technical merits check
+      - Skeptical verification (assume findings are wrong until proven)
+      - Adversarial review (look for reasons the finding is incorrect)
+      A finding is confirmed only if ≥2 perspectives agree.
+
+      ### C. FIX — Fix all confirmed findings:
+      1. Understand the finding and its context
+      2. Write or update tests that verify the fix
+      3. Implement the minimal fix
+      4. Run tests to verify nothing is broken
+
+      ### D. DECIDE — Continue or stop:
+      - Below cycle 3: always continue
+      - At cycle 3+: stop if ≤3 medium findings and no high/critical
+      - At cycle 6: always stop (safety valve)
+
+      ## After All Cycles: Self-Improvement
+
+      Step back and ask: "How else would you improve this code?"
+      Look for systemic issues, architectural improvements, and patterns
+      the audit missed. Fix any CRITICAL improvements found.
+
+      **Output:** "QUALITY AUDIT: CLEAN" if final cycle has no confirmed
+      findings, otherwise list remaining findings and fixes applied.
+    output: "quality_audit_results"
+
+  # ==========================================================================
+  # STEP 21: CONVERT PR TO READY FOR REVIEW
+  # Convert draft PR to ready-for-review.
+  # ==========================================================================
+  - id: "step-21-pr-ready"
+    type: "bash"
+    command: |
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
+      echo "=== Step 20: Converting PR to Ready ===" && \
+      echo "" && \
+      echo "--- Verifying All Steps Complete ---" && \
+      echo "" && \
+      echo "--- Converting PR to Ready ---" && \
+      gh pr ready && \
+      echo "" && \
+      echo "--- Adding Ready Comment ---" && \
+      gh pr comment --body "## Ready for Final Review
+
+      All workflow steps completed:
+      - [x] Requirements clarified
+      - [x] Design approved
+      - [x] Implementation complete
+      - [x] Tests passing
+      - [x] Code review addressed
+      - [x] Philosophy compliance verified
+      - [x] Final cleanup complete
+      - [x] Quality audit passed
+
+      Ready for merge approval." && \
+      echo "" && \
+      echo "=== PR Marked Ready ==="
+    output: "pr_ready_result"
+
+  # ==========================================================================
+  # STEP 22: ENSURE PR IS MERGEABLE
+  # ==========================================================================
+  - id: "step-22-ensure-mergeable"
+    agent: "amplihack:ci-diagnostic-workflow"
+    prompt: |
+      # Step 21: Ensure PR is Mergeable (TASK COMPLETION POINT)
+
+      **PR URL:** {{pr_url}}
+      **Repository:** {{repo_path}}
+
+      Final verification that PR is ready to merge:
+
+      **Checklist:**
+      - [ ] CI status - all checks passing
+      - [ ] No merge conflicts
+      - [ ] All review comments addressed
+      - [ ] PR is approved
+
+      **Actions:**
+      1. Check CI status
+      2. If CI fails, diagnose and fix
+      3. Resolve any merge conflicts
+      4. Verify all review comments addressed (including any that appeared after marking ready)
+      5. Confirm PR is approved
+      6. Notify that PR is ready to merge
+
+      **THIS IS THE TASK COMPLETION POINT**
+      Task is complete when this step passes.
+    output: "ci_status"
+
+  - id: "step-22b-final-status"
+    type: "bash"
+    command: |
+      cd "$REPO_PATH" && \
+      echo "=== WORKFLOW COMPLETE ===" && \
+      echo "" && \
+      echo "PR Status:" && \
+      gh pr view --json state,mergeable,reviews,statusCheckRollup && \
+      echo "" && \
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION" && \
+      ISSUE_NUMBER="$ISSUE_NUMBER" && \
+      PR_URL="$PR_URL" && \
+      printf '=== Task: %s ===\n' "$TASK_DESC" && \
+      printf '=== Issue: #%s ===\n' "$ISSUE_NUMBER" && \
+      printf '=== PR: %s ===\n' "$PR_URL" && \
+      echo "" && \
+      echo "All 23 workflow steps completed successfully."
+    output: "final_status"
+
+  # ==========================================================================
+  # FINAL OUTPUT
+  # ==========================================================================
+  - id: "workflow-complete"
+    type: "bash"
+    parse_json: true
+    command: |
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_VAL="$TASK_DESCRIPTION"
+      export TASK_VAL
+      ISSUE_VAL="$ISSUE_NUMBER"
+      export ISSUE_VAL
+      PR_VAL="$PR_URL"
+      export PR_VAL
+      # Pure jq — no Python dependency (#242).
+      # jq -n constructs the object; --arg passes env vars in safely (no quoting hazards).
+      jq -n \
+        --arg task "${TASK_VAL}" \
+        --arg issue "${ISSUE_VAL}" \
+        --arg pr "${PR_VAL}" \
+        '{
+          workflow: "default-workflow",
+          version: "2.0.0",
+          task: $task,
+          issue_number: $issue,
+          pr_url: $pr,
+          status: "complete",
+          steps_completed: 23,
+          phases_completed: [
+            "requirements-clarification", "design", "implementation",
+            "testing", "review", "merge"
+          ],
+          mandatory_steps_completed: {
+            step_0_preparation: true,
+            step_14_version_bump: true,
+            step_17_pr_review: true,
+            step_18_implement_feedback: true
+          },
+          philosophy_compliant: true,
+          ready_to_merge: true
+        }'
+    output: "workflow_result"

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -1,0 +1,355 @@
+name: "workflow-pr-review"
+description: "Phase 7: PR review cycle — compliance, reviewer, gates (17a-19d)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "review", "pr"]
+
+# workflow-pr-review: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  - id: "step-17a-compliance-verification"
+    type: "bash"
+    # FIX (#2925): Previously this step only echoed instructions without
+    # checking anything — it was a no-op that never enforced step-13 completion.
+    # Now it reads local_testing_gate (step-13 output) and FAILS hard if the
+    # gate is empty, blocking the review phase until testing is done.
+    command: |
+      echo "=== Step 17a: Step 13 Compliance Verification ===" && \
+      echo "" && \
+      GATE_OUTPUT="$LOCAL_TESTING_GATE" && \
+      if [ -z "$GATE_OUTPUT" ] || [ "$GATE_OUTPUT" = "''" ]; then \
+        echo "COMPLIANCE FAILURE: Step 13 (outside-in testing) produced no output." && \
+        echo "" && \
+        echo "The outside-in testing step (step-13-local-testing) must be completed" && \
+        echo "before the PR review phase can begin." && \
+        echo "" && \
+        echo "Required: Invoke the qa-team skill (outside-in-testing alias also works) and document at least" && \
+        echo "2 test scenarios in the PR description under 'Step 13: Local Testing Results'." && \
+        exit 1 ; \
+      fi && \
+      echo "Compliance check: local_testing_gate is populated." && \
+      echo "" && \
+      echo "Verify PR description contains 'Step 13: Local Testing Results' section" && \
+      echo "with actual test execution evidence (not just planning)." && \
+      echo "" && \
+      echo "=== Compliance Check PASSED ==="
+    output: "step_13_compliance_check"
+
+  - id: "step-17b-reviewer-agent"
+    agent: "amplihack:reviewer"
+    prompt: |
+      # Step 17b: Comprehensive Code Review (MANDATORY)
+
+      **PR URL:** {{pr_url}}
+      **Requirements:** {{final_requirements}}
+      **Implementation:** {{review_feedback}}
+
+      **REQUIRED FOR ALL PRs** - Quality gates exist for a reason.
+
+      **Review Checklist:**
+      - [ ] Code quality and standards
+      - [ ] Test coverage adequate
+      - [ ] No TODOs, stubs, or swallowed exceptions
+      - [ ] No unimplemented functions
+      - [ ] Logic correctness
+      - [ ] Edge case handling
+
+      **Actions:**
+      1. Perform comprehensive code review
+      2. Identify issues and improvements
+      3. **POST review comments on PR** (this is required evidence)
+
+      **Output:** Structured review findings AND confirmation that review was posted to PR.
+    output: "pr_review"
+
+  - id: "step-17c-security-review"
+    agent: "amplihack:security"
+    prompt: |
+      # Step 17c: Security Review (MANDATORY)
+
+      **PR URL:** {{pr_url}}
+      **Implementation:** {{review_feedback}}
+      **Previous Review:** {{pr_review}}
+
+      Security review of the PR:
+      - [ ] Verify all security requirements met
+      - [ ] Check for any new vulnerabilities
+      - [ ] Confirm sensitive data handling
+      - [ ] Review authentication/authorization if applicable
+      - [ ] Check for injection vulnerabilities
+
+      **Actions:**
+      1. Perform security analysis
+      2. **POST security findings as PR comments** (this is required evidence)
+
+      **Output:** Security review findings AND confirmation that review was posted to PR.
+    output: "pr_security_review"
+
+  - id: "step-17d-philosophy-guardian"
+    agent: "amplihack:philosophy-guardian"
+    prompt: |
+      # Step 17d: Philosophy Guardian Review (MANDATORY)
+
+      **PR URL:** {{pr_url}}
+      **Implementation:** {{review_feedback}}
+      **Code Review:** {{pr_review}}
+
+      Philosophy compliance review:
+      - [ ] Ruthless simplicity achieved
+      - [ ] Bricks & studs pattern followed
+      - [ ] Zero-BS implementation (no stubs, faked APIs, swallowed exceptions)
+      - [ ] No over-engineering
+      - [ ] Clean module boundaries
+
+      **Actions:**
+      1. Verify philosophy compliance
+      2. **POST philosophy check as PR comment** (this is required evidence)
+
+      **Output:** Philosophy compliance status AND confirmation that review was posted to PR.
+    output: "pr_philosophy_review"
+
+  - id: "step-17e-address-blocking-issues"
+    agent: "amplihack:builder"
+    prompt: |
+      # Step 17e: Address Blocking Issues (MANDATORY)
+
+      **PR Review:** {{pr_review}}
+      **Security Review:** {{pr_security_review}}
+      **Philosophy Review:** {{pr_philosophy_review}}
+
+      Review all findings from Steps 16a-16d and address any blocking issues:
+
+      1. Identify blocking issues from each review
+      2. Implement fixes for each blocking issue
+      3. If issues found, re-run applicable reviews after fixing
+
+      **Output:** Summary of blocking issues found and how they were addressed.
+      If no blocking issues, state "No blocking issues found."
+    output: "blocking_issues_addressed"
+
+  - id: "step-17f-verification-gate"
+    type: "bash"
+    command: |
+      echo "=== STEP 17 VERIFICATION GATE ===" && \
+      echo "" && \
+      echo "Before proceeding, verify ALL of the following:" && \
+      echo "" && \
+      echo "  ✓ Did I invoke the REVIEWER agent? → Yes (output captured)" && \
+      echo "  ✓ Did I invoke the SECURITY agent? → Yes (output captured)" && \
+      echo "  ✓ Did I invoke the PHILOSOPHY-GUARDIAN agent? → Yes (output captured)" && \
+      echo "  ✓ Did I check for FORBIDDEN PATTERN violations? → Yes" && \
+      echo "  ✓ Are all three reviews POSTED to the PR as comments?" && \
+      echo "  ✓ All blocking issues have been addressed?" && \
+      echo "" && \
+      echo "If any verification fails, STOP and complete the missing step." && \
+      echo "" && \
+      echo "=== GATE PASSED - Proceed to Step 18 ==="
+    output: "step_17_gate_status"
+
+  # ==========================================================================
+  # STEP 18: IMPLEMENT REVIEW FEEDBACK (MANDATORY - DO NOT SKIP)
+  # Granular sub-steps to ensure thorough feedback implementation.
+  # ==========================================================================
+  - id: "step-18a-analyze-feedback"
+    agent: "amplihack:architect"
+    prompt: |
+      # Step 18a: Analyze Review Feedback (MANDATORY)
+
+      **PR Review:** {{pr_review}}
+      **Security Review:** {{pr_security_review}}
+      **Philosophy Review:** {{pr_philosophy_review}}
+
+      Analyze ALL feedback from Step 16 reviews:
+      1. Categorize each item: blocking issues vs. suggestions vs. questions
+      2. Prioritize blocking issues first
+      3. Create action plan for addressing each item
+
+      **Output:** Structured analysis of all feedback with action plan.
+    output: "feedback_analysis"
+
+  - id: "step-18b-implement-feedback"
+    agent: "amplihack:builder"
+    prompt: |
+      # Step 18b: Implement Review Feedback (MANDATORY)
+
+      **Feedback Analysis:** {{feedback_analysis}}
+      **PR Review:** {{pr_review}}
+      **Security Review:** {{pr_security_review}}
+      **Philosophy Review:** {{pr_philosophy_review}}
+      **Current Implementation:** {{review_feedback}}
+
+      **REQUIRED FOR ALL PRs** - Unaddressed feedback means the review was pointless.
+
+      **Checklist:**
+      - [ ] Address EVERY blocking issue
+      - [ ] Address suggestions where appropriate
+      - [ ] For disagreements, document reasoning
+      - [ ] Ensure changes don't introduce new issues
+
+      **Output:** Updated implementation with summary of changes for each feedback item.
+    output: "pr_feedback_changes"
+
+  - id: "step-18c-push-feedback-changes"
+    type: "bash"
+    command: |
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
+      echo "=== Pushing Review Feedback Changes ===" && \
+      git add -A && \
+      if [ -n "$(git diff --cached --name-only)" ]; then \
+        git commit -m "address review feedback
+
+      - Implemented reviewer suggestions
+      - Fixed identified issues
+      - Updated per security review
+      - Addressed philosophy compliance items" ; \
+      else \
+        echo "WARNING: Nothing to commit - feedback changes already committed" ; \
+      fi && \
+      if git rev-list --count @{u}..HEAD 2>/dev/null | grep -qv '^0$'; then \
+        git pull --rebase 2>/dev/null && git push ; \
+      else \
+        echo "WARNING: Nothing to push - branch is up to date with remote" ; \
+      fi && \
+      echo "=== Changes Pushed ==="
+    output: "feedback_push_result"
+
+  - id: "step-18d-respond-to-comments"
+    type: "bash"
+    command: |
+      echo "=== Responding to Review Comments ===" && \
+      echo "" && \
+      echo "Post responses to each review comment on the PR explaining:" && \
+      echo "  - What was done to address the feedback" && \
+      echo "  - Any disagreements with reasoning" && \
+      echo "" && \
+      echo "Use: gh pr comment <pr_number> --body 'Response text'" && \
+      echo "" && \
+      echo "=== Comment Responses Complete ==="
+    output: "comment_responses"
+
+  - id: "step-18e-verification-gate"
+    type: "bash"
+    command: |
+      echo "=== STEP 18 VERIFICATION GATE ===" && \
+      echo "" && \
+      echo "Before proceeding, verify ALL of the following:" && \
+      echo "" && \
+      echo "  ✓ Did I address EVERY feedback comment (not just some)?" && \
+      echo "  ✓ Did I respond to each comment on the PR?" && \
+      echo "  ✓ Did I use the builder agent for implementation changes?" && \
+      echo "  ✓ Are all tests still passing?" && \
+      echo "" && \
+      echo "If any verification fails, STOP and complete the missing step." && \
+      echo "" && \
+      echo "=== GATE PASSED - Proceed to Step 19 ==="
+    output: "step_18_gate_status"
+
+  # ==========================================================================
+  # STEP 19: PHILOSOPHY COMPLIANCE CHECK
+  # Granular sub-steps with verification gate to prevent completion bias.
+  # ==========================================================================
+  - id: "step-19a-philosophy-check"
+    agent: "amplihack:reviewer"
+    prompt: |
+      # Step 19a: Philosophy Compliance Review (MANDATORY)
+
+      **Implementation:** {{pr_feedback_changes}}
+      **Requirements:** {{final_requirements}}
+
+      Philosophy compliance verification:
+      - [ ] Ruthless simplicity achieved
+      - [ ] No over-engineering or unnecessary complexity
+      - [ ] Implementation aligns with project philosophy
+      - [ ] No Forbidden Pattern violations (FORBIDDEN_PATTERNS.md): no error swallowing, no silent fallbacks, no data loss, no shell anti-patterns (|| true, >/dev/null), no async misuse, no config divergence, no validation gaps
+      - [ ] All tests passing
+      - [ ] Documentation complete and accurate
+
+      **Output:** Detailed philosophy compliance findings.
+    output: "philosophy_check"
+
+  - id: "step-19b-patterns-check"
+    agent: "amplihack:patterns"
+    prompt: |
+      # Step 19b: Pattern Compliance Review (MANDATORY)
+
+      **Implementation:** {{pr_feedback_changes}}
+
+      Pattern compliance verification:
+      - [ ] Design patterns used correctly
+      - [ ] Architectural patterns followed
+      - [ ] Code organization patterns maintained
+      - [ ] No anti-patterns introduced
+      - [ ] No Forbidden Patterns (error swallowing, silent fallbacks, || true, >/dev/null, fire-and-forget async, unchecked HTTP responses, log-only catches)
+
+      **Output:** Pattern compliance findings with any violations.
+    output: "patterns_check"
+
+  - id: "step-19c-zero-bs-verification"
+    type: "bash"
+    command: |
+      echo "=== ZERO-BS VERIFICATION ===" && \
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
+      echo "" && \
+      echo "Scanning for Zero-BS violations..." && \
+      echo "" && \
+      echo "--- Checking for TODO/FIXME comments ---" && \
+      (grep -r -E "(TODO|FIXME)" --include="*.py" --include="*.ts" --include="*.js" . 2>/dev/null || echo "None found") && \
+      echo "" && \
+      echo "--- Checking for stub indicators ---" && \
+      (grep -r -E "(NotImplementedError|raise NotImplemented|pass  # stub)" --include="*.py" . 2>/dev/null || echo "None found") && \
+      echo "" && \
+      echo "--- Checking for Forbidden Patterns ---" && \
+      echo "  Shell: || true, >/dev/null 2>&1, set +e" && \
+      (grep -rn "|| true\||| :\|>/dev/null 2>&1\|2>/dev/null\|&>/dev/null\|set +e" --include="*.sh" --include="*.bash" --include="Makefile" --include="Dockerfile" . 2>/dev/null || echo "  None found") && \
+      echo "  Python: bare except, except pass, return None in except" && \
+      (grep -rn "except:$\|except .*:.*pass$\|except.*:.*return None" --include="*.py" . 2>/dev/null || echo "  None found") && \
+      echo "  TypeScript/JS: empty catch, catch return undefined" && \
+      (grep -rn "catch.*{.*}$\|catch.*return undefined\|catch.*return \[\]" --include="*.ts" --include="*.js" . 2>/dev/null || echo "  None found") && \
+      echo "" && \
+      echo "=== Zero-BS Verification Complete ==="
+    output: "zero_bs_check"
+
+  - id: "step-19d-verification-gate"
+    type: "bash"
+    command: |
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      # ARG_MAX guard: truncated to 1 KB summaries below (#3366 / b1f87112b).
+      PHIL_CHECK="$PHILOSOPHY_CHECK"
+      PAT_CHECK="$PATTERNS_CHECK"
+      PHIL_SUMMARY=$(printf '%.1024s' "$PHIL_CHECK")
+      PAT_SUMMARY=$(printf '%.1024s' "$PAT_CHECK")
+
+      echo "=== STEP 19 VERIFICATION GATE ==="
+      echo ""
+      echo "Before proceeding, verify ALL of the following:"
+      echo ""
+      echo "  ✓ Did I invoke the REVIEWER agent for philosophy check?"
+      echo "  ✓ Did I invoke the PATTERNS agent?"
+      echo "  ✓ Did I complete the zero-BS verification?"
+      echo "  ✓ Did I check for Forbidden Pattern violations?"
+      echo "  ✓ Are all findings documented?"
+      echo "  ✓ Any issues found have been addressed?"
+      echo ""
+      echo "Philosophy check (first 1KB): $PHIL_SUMMARY"
+      echo "Patterns check (first 1KB): $PAT_SUMMARY"
+      echo ""
+      echo "If any verification fails, STOP and complete the missing step."
+      echo ""
+      echo "=== GATE PASSED - Proceed to Step 20 ==="
+    output: "step_19_gate_status"
+
+  # ==========================================================================
+  # STEP 20: FINAL CLEANUP AND VERIFICATION
+  # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-precommit-test.yaml
+++ b/amplifier-bundle/recipes/workflow-precommit-test.yaml
@@ -1,0 +1,142 @@
+name: "workflow-precommit-test"
+description: "Phase 5: pre-commit hooks + local testing (12-13)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "testing", "quality"]
+
+# workflow-precommit-test: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  - id: "step-12-run-precommit"
+    agent: "amplihack:pre-commit-diagnostic"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 12: Run Tests and Pre-commit Hooks
+
+      **Worktree:** {{worktree_setup}}
+      **Implementation:** {{review_feedback}}
+
+      Execute pre-commit validation:
+
+      1. **Check hooks installed:**
+         ```bash
+         test -f .pre-commit-config.yaml && echo "Config found"
+         test -f "$(git rev-parse --git-path hooks/pre-commit)" && echo "Hooks installed"
+         ```
+
+      2. **Install if needed:** `pre-commit install`
+
+      3. **Run all checks:**
+         ```bash
+         pre-commit run --all-files
+         pytest
+         ```
+
+      4. **Fix any issues:**
+         - Linting issues
+         - Formatting issues
+         - Type checking errors
+
+      Iterate until all checks pass. Report results.
+    output: "precommit_results"
+
+  # ==========================================================================
+  # STEP 13: MANDATORY OUTSIDE-IN TESTING
+  # Use the qa-team skill (outside-in-testing alias supported) to test this PR as a user would from
+  # the PR branch. No bash echo — the agent must actually execute the tests.
+  # ==========================================================================
+  - id: "step-13-local-testing"
+    agent: "amplihack:builder"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 13: Mandatory Outside-In Testing (CANNOT BE SKIPPED)
+
+      **Task:** {{task_description}}
+      **Repository:** {{repo_path}}
+      **Branch:** Run `git branch --show-current` to get the current branch name.
+
+      You MUST perform outside-in testing using the `qa-team` skill (`outside-in-testing` remains an alias)
+      to verify this change as a real user would — from the PR branch, not just
+      the working directory.
+
+      ## Required Actions
+
+      1. **Get the current branch name:**
+         ```bash
+         git branch --show-current
+         ```
+
+      2. **Get the remote URL (for uvx testing):**
+         ```bash
+         git remote get-url origin
+         ```
+
+      3. **Invoke the `qa-team` skill** to generate and execute
+         agentic outside-in tests for this change. Pass the PR branch name and
+         repository URL so tests run against the actual branch:
+         ```
+         Skill(skill="qa-team")
+         ```
+
+      4. **Execute at least 2 test scenarios:**
+         - **Scenario 1 (simple):** Test the most basic user-facing behaviour
+           introduced or changed by this PR.
+         - **Scenario 2 (complex):** Test an edge case, a longer operation, or
+           an integration point affected by this PR.
+
+         Test from the PR branch using the pattern:
+         ```bash
+         uvx --from git+<remote-url>@<branch-name> amplihack <command>
+         ```
+
+      5. **Document results** — write the following section into the PR
+         description (you will paste it in Step 16 when creating the PR):
+
+         ```
+         ## Step 13: Local Testing Results
+
+         ### Scenario 1 — <brief description>
+         Command: `uvx --from git+...@<branch> amplihack <command>`
+         Result: PASS / FAIL
+         Output: <key output lines>
+
+         ### Scenario 2 — <brief description>
+         Command: `uvx --from git+...@<branch> amplihack <command>`
+         Result: PASS / FAIL
+         Output: <key output lines>
+         ```
+
+      ## What Counts as Testing
+
+      - Running the actual changed code with test inputs via `uvx --from git+...`
+      - Verifying error messages, output format, and user experience
+      - Checking that existing functionality still works (regression check)
+
+      ## What Does NOT Count
+
+      - Planning tests without executing them
+      - CI/CD checks only (local execution required IN ADDITION)
+      - Assuming "documentation can't be tested"
+
+      Report the full test output and confirm both scenarios passed (or document
+      any failures with root cause analysis).
+    output: "local_testing_gate"
+
+  # ==========================================================================
+  # STEP 14: BUMP VERSION IN PYPROJECT.TOML (MANDATORY - DO NOT SKIP)
+  # Before committing, bump version to reflect change type.
+  # CI will block PRs that don't bump version.
+  # Git tags are auto-created on merge matching the version.
+  # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -1,0 +1,335 @@
+name: "workflow-prep"
+description: "Phase 1a: requirements + issue creation (steps 00-03b)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "prep", "requirements"]
+
+# workflow-prep: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  # ==========================================================================
+  # STEP 0: WORKFLOW PREPARATION (MANDATORY - DO NOT SKIP)
+  # Creates tracking structure for all 23 workflow steps.
+  # CRITICAL: Must complete before ANY implementation work begins.
+  # Prevents "completion bias" - ensures mandatory review steps (0, 14, 17-18) not skipped.
+  # ==========================================================================
+  - id: "step-00-workflow-preparation"
+    type: "bash"
+    command: |
+      echo "=== WORKFLOW PREPARATION COMPLETE ==="
+      echo ""
+      echo "23-Step Workflow Initialized (with granular sub-steps for Steps 17-19):"
+      echo "  Step 0: Workflow Preparation - CURRENT"
+      echo "  Step 1: Prepare Workspace"
+      echo "  Step 2: Rewrite/Clarify Requirements"
+      echo "  Step 3: Create GitHub Issue"
+      echo "  Step 4: Setup Worktree/Branch"
+      echo "  Step 5: Research and Design"
+      echo "  Step 6: Retcon Documentation"
+      echo "  Step 7: TDD - Write Tests First"
+      echo "  Step 8: Implement Solution"
+      echo "  Step 9: Refactor and Simplify"
+      echo "  Step 10: Review Before Commit"
+      echo "  Step 11: Incorporate Feedback"
+      echo "  Step 12: Run Pre-commit Hooks"
+      echo "  Step 13: Mandatory Local Testing"
+      echo "  Step 14: Bump Version (MANDATORY)"
+      echo "  Step 15: Commit and Push"
+      echo "  Step 16: Open PR as Draft"
+      echo "  Step 17: Review the PR (MANDATORY - 6 sub-steps with verification gate)"
+      echo "    17a: Step 13 Compliance Verification"
+      echo "    17b: Comprehensive Code Review (reviewer agent)"
+      echo "    17c: Security Review (security agent)"
+      echo "    17d: Philosophy Guardian Review (philosophy-guardian agent)"
+      echo "    17e: Address Blocking Issues (builder agent)"
+      echo "    17f: Verification Gate"
+      echo "  Step 18: Implement Review Feedback (MANDATORY - 5 sub-steps with verification gate)"
+      echo "    18a: Analyze Feedback"
+      echo "    18b: Implement Feedback (builder agent)"
+      echo "    18c: Push Changes"
+      echo "    18d: Respond to Comments"
+      echo "    18e: Verification Gate"
+      echo "  Step 19: Philosophy Compliance Check (4 sub-steps with verification gate)"
+      echo "    19a: Philosophy Review (reviewer agent)"
+      echo "    19b: Pattern Check (patterns agent)"
+      echo "    19c: Zero-BS Verification"
+      echo "    19d: Verification Gate"
+      echo "  Step 20: Final Cleanup"
+      echo "  Step 20c: Quality Audit Loop (3+ cycles, multi-agent validation)"
+      echo "  Step 21: Convert PR to Ready"
+      echo "  Step 22: Ensure PR Mergeable"
+      echo ""
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
+      printf 'Task: %s\n' "$TASK_DESC"
+      printf 'Repository: %s\n' "$REPO_PATH"
+    output: "workflow_init"
+
+  # ==========================================================================
+  # STEP 1: PREPARE THE WORKSPACE
+  # Ensure a clean local environment that is up to date.
+  # Actions: verify no unstashed changes, git fetch, check git status
+  # ==========================================================================
+  - id: "step-01-prepare-workspace"
+    type: "bash"
+    command: |
+      cd "$REPO_PATH" && \
+      echo "=== Step 1: Preparing Workspace ===" && \
+      echo "" && \
+      echo "Current directory: $(pwd)" && \
+      echo "" && \
+      echo "--- Git Status ---" && \
+      git status && \
+      echo "" && \
+      echo "--- Fetching Latest ---" && \
+      git fetch --all && \
+      echo "" && \
+      echo "--- Current Branch ---" && \
+      git branch --show-current && \
+      echo "" && \
+      echo "=== Workspace Prepared ==="
+    output: "workspace_status"
+
+  # ==========================================================================
+  # STEP 2: REWRITE AND CLARIFY REQUIREMENTS
+  # ==========================================================================
+  - id: "step-02-clarify-requirements"
+    agent: "amplihack:prompt-writer"
+    prompt: |
+      # Step 2: Rewrite and Clarify Requirements
+
+      **Task Description:** {{task_description}}
+      **Initial Requirements:** {{requirements}}
+
+      Your role is to clarify and structure the task requirements.
+
+      **Actions Required:**
+      1. Identify explicit user requirements that CANNOT be optimized away
+      2. Remove ambiguity from the task description
+      3. Define clear success criteria
+      4. Document acceptance criteria
+
+      **Output Format:**
+      ```json
+      {
+        "task_summary": "one-line clear summary",
+        "explicit_requirements": ["list of must-have features"],
+        "acceptance_criteria": ["how to verify completion"],
+        "out_of_scope": ["what this does NOT include"],
+        "assumptions": ["assumptions being made"],
+        "questions_resolved": ["clarifications made autonomously"],
+        "estimated_complexity": "low/medium/high",
+        "classification": "feature/bugfix/refactor/other"
+      }
+      ```
+
+      Use your best judgment to work autonomously. Pass explicit requirements to ALL subsequent agents.
+    output: "clarified_requirements"
+    parse_json: true
+
+  - id: "step-02b-analyze-codebase"
+    agent: "amplihack:architect"
+    prompt: |
+      # Step 2b: Analyze Existing Codebase Context
+
+      **Task:** {{task_description}}
+      **Clarified Requirements:** {{clarified_requirements}}
+      **Repository:** {{repo_path}}
+
+      ## IMPORTANT: Emit progress markers throughout this analysis
+
+      This step runs under a watchdog that times out if no output is seen for
+      60+ seconds. You MUST emit a progress line before each major exploration
+      phase so the recipe runner can see activity. Use this format:
+
+      ```
+      ## Progress: [Phase name] — [brief description]
+      ```
+
+      ## Exploration Phases
+
+      Work through these phases in order, emitting a progress marker before each:
+
+      **Phase 1 — Project structure**
+      Print: `## Progress: Phase 1/4 — Scanning project structure`
+      Use Glob to identify top-level layout, key config files (pyproject.toml,
+      package.json, Cargo.toml, etc.), and source directory organization.
+
+      **Phase 2 — Relevant code paths**
+      Print: `## Progress: Phase 2/4 — Searching for task-relevant code`
+      Use Grep to find code related to the task: relevant class/function names,
+      imports, config keys, and patterns mentioned in the requirements.
+
+      **Phase 3 — Dependencies and integration points**
+      Print: `## Progress: Phase 3/4 — Analyzing dependencies and interfaces`
+      Read key files (imports, interfaces, config) to understand how components
+      connect. Identify external dependencies relevant to the task.
+
+      **Phase 4 — Synthesis**
+      Print: `## Progress: Phase 4/4 — Synthesizing findings`
+      Compile findings into a structured summary.
+
+      ## Output
+
+      Provide a codebase context summary covering:
+      1. Relevant existing code and patterns
+      2. Files that will likely need modification
+      3. Dependencies and integration points
+      4. Potential conflicts or considerations
+
+      Use glob and grep to explore the codebase. Avoid web searches.
+    output: "codebase_analysis"
+
+  - id: "step-02c-resolve-ambiguity"
+    agent: "amplihack:ambiguity"
+    prompt: |
+      # Step 2c: Resolve Any Remaining Ambiguity
+
+      **Task:** {{task_description}}
+      **Clarified Requirements:** {{clarified_requirements}}
+      **Codebase Analysis:** {{codebase_analysis}}
+
+      Review for any remaining ambiguity in the requirements.
+
+      If ambiguity exists:
+      - Resolve it using best judgment
+      - Document the decisions made
+      - Explain rationale
+
+      If no ambiguity:
+      - Confirm requirements are clear
+      - Proceed with confidence
+
+      Output final, unambiguous requirements ready for design phase.
+    output: "final_requirements"
+
+  # ==========================================================================
+  # STEP 3: CREATE GITHUB ISSUE
+  # Create a GitHub issue documenting the task with problem description,
+  # requirements, constraints, success criteria, and appropriate labels.
+  # ==========================================================================
+  - id: "step-03-create-issue"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      cd "$REPO_PATH"
+      echo "=== Step 3: Creating GitHub Issue ===" >&2
+
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
+      # Bash builtins replace tr|cut pipeline — avoids 2 subprocess spawns (matches step-16)
+      ISSUE_TITLE="${TASK_DESC//$'\n'/ }"
+      ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"
+      ISSUE_TITLE="${ISSUE_TITLE:0:200}"
+      ISSUE_REQS="$FINAL_REQUIREMENTS"
+
+      # Idempotency Guard 1: Reuse issue referenced in task_description (#NNNN)
+      # Mirrors step-16-create-draft-pr idempotency pattern (#3324).
+      # Bash regex replaces printf|grep|head|tr pipeline — avoids 4 subprocess spawns
+      if [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then
+          REF_ISSUE_NUM="${BASH_REMATCH[1]}"
+      else
+          REF_ISSUE_NUM=""
+      fi
+      # Defense-in-depth: validate numeric before interpolating into gh command
+      if [ -n "$REF_ISSUE_NUM" ] && ! [[ "$REF_ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+          echo "WARN: Extracted issue reference is not numeric: $REF_ISSUE_NUM — skipping guard 1" >&2
+          REF_ISSUE_NUM=""
+      fi
+      if [ -n "$REF_ISSUE_NUM" ]; then
+          echo "INFO: task_description references issue #$REF_ISSUE_NUM — verifying it exists" >&2
+          EXISTING_URL=$(timeout 60 gh issue view "$REF_ISSUE_NUM" --json url --jq '.url // ""' 2>/dev/null || echo '')
+          if [ -n "$EXISTING_URL" ]; then
+              echo "INFO: Reusing existing issue #$REF_ISSUE_NUM — skipping creation" >&2
+              printf '%s\n' "$EXISTING_URL"
+              exit 0
+          fi
+          echo "WARN: Referenced issue #$REF_ISSUE_NUM not found — will search or create" >&2
+      fi
+
+      # Idempotency Guard 2: Search open issues for similar title
+      SEARCH_QUERY="${ISSUE_TITLE:0:100}"
+      if [ -n "$SEARCH_QUERY" ]; then
+          echo "INFO: Searching open issues for similar title" >&2
+          FOUND_URL=$(timeout 60 gh issue list --state open --search "$SEARCH_QUERY" --json url --jq '.[0].url // ""' 2>/dev/null || echo '')
+          if [ -n "$FOUND_URL" ]; then
+              echo "INFO: Found existing open issue matching title — skipping creation" >&2
+              printf '%s\n' "$FOUND_URL"
+              exit 0
+          fi
+          echo "INFO: No matching open issue found — proceeding to create" >&2
+      fi
+
+      # Normal path: create a new issue
+      ISSUE_BODY=$(printf '## Task Description\n%s\n\n## Requirements\n%s\n\n## Acceptance Criteria\n- [ ] All explicit requirements met\n- [ ] Tests passing\n- [ ] Philosophy compliant\n- [ ] Documentation updated\n\n## Classification\nGenerated via default-workflow recipe\n' "$TASK_DESC" "$ISSUE_REQS")
+      LABEL_NAME="workflow:default"
+      if ! gh label list --limit 1000 2>/dev/null | grep -qw "$LABEL_NAME"; then
+        gh label create "$LABEL_NAME" \
+          --color "0366d6" \
+          --description "Created by default-workflow recipe" 2>/dev/null || true
+      fi
+      gh issue create \
+        --title "$ISSUE_TITLE" \
+        --body "$ISSUE_BODY" \
+        --label "$LABEL_NAME" 2>&1 || \
+      gh issue create \
+        --title "$ISSUE_TITLE" \
+        --body "$ISSUE_BODY"
+    output: "issue_creation"
+    parse_json: false
+
+  - id: "step-03b-extract-issue-number"
+    type: "bash"
+    command: |
+      # Extract issue number from the creation output.
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      ISSUE_CREATION="$ISSUE_CREATION"
+      TASK_DESC_RAW="$TASK_DESCRIPTION"
+      # FIX (#4233): Match both issue URLs (issues/NNN) and PR URLs (pull/NNN).
+      # If the output is a PR URL, resolve the linked issue via gh pr view.
+      EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
+      if [ -z "$EXTRACTED" ]; then
+        # Try PR URL — step-03 may have returned a PR URL if reusing an existing PR
+        PR_NUMBER=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
+        if [ -n "$PR_NUMBER" ]; then
+          echo "INFO: step-03b found PR URL (not issue URL) — resolving linked issue from PR #$PR_NUMBER" >&2
+          EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo '')
+          # If no linked issue, use the PR number as the issue number
+          # (downstream steps can handle PR-only workflows)
+          if [ -z "$EXTRACTED" ]; then
+            echo "INFO: PR #$PR_NUMBER has no linked issue — using PR number as reference" >&2
+            EXTRACTED="$PR_NUMBER"
+          fi
+        fi
+      fi
+      if [ -z "$EXTRACTED" ]; then
+        # Last resort: scan for bare #NNNN references in the task description
+        EXTRACTED=$(printf '%s' "$TASK_DESC_RAW" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | head -1)
+      fi
+      if [ -z "$EXTRACTED" ]; then
+        echo "ERROR: step-03b failed to extract issue number from issue_creation output." >&2
+        echo "Raw issue_creation output was:" >&2
+        printf '%s\n' "$ISSUE_CREATION" >&2
+        echo "This means step-03a (create-issue) likely failed or returned unexpected output." >&2
+        echo "Downstream steps (commit, PR) will fail without a valid issue number." >&2
+        exit 1
+      fi
+      printf '%s' "$EXTRACTED"
+    output: "issue_number"
+
+  # ==========================================================================
+  # STEP 4: SETUP WORKTREE AND BRANCH
+  # Creates isolated worktree and outputs structured JSON for subsequent steps.
+  # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -1,0 +1,342 @@
+name: "workflow-publish"
+description: "Phase 6: bump + commit + push + draft PR + outside-in (14-16b)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "version", "pr"]
+
+# workflow-publish: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  - id: "step-14-bump-version"
+    agent: "amplihack:architect"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 14: Bump Version in pyproject.toml (MANDATORY - DO NOT SKIP)
+
+      **⚠️ MANDATORY - DO NOT SKIP ⚠️**
+
+      **REQUIRED FOR ALL PRs**
+
+      Before committing changes to git history, bump the version number in `pyproject.toml` to reflect the nature of your changes.
+
+      **Task:** {{task_description}}
+      **Repository:** {{repo_path}}
+
+      **Actions Required:**
+
+      1. **Review changes:** Run `git diff main...HEAD` to see all changes
+      2. **Classify change type:** Determine if this is PATCH, MINOR, or MAJOR
+      3. **Read current version:** Check `pyproject.toml` line 8
+      4. **Bump version appropriately:**
+         - **PATCH** (0.2.0 → 0.2.1): Bug fixes, documentation, minor improvements
+         - **MINOR** (0.2.0 → 0.3.0): New features, backward-compatible changes
+         - **MAJOR** (0.2.0 → 1.0.0): Breaking changes, major architecture changes
+      5. **Edit pyproject.toml:** Update the version line
+      6. **Verify:** Confirm the new version is correct
+
+      **Classification Examples:**
+
+      | Change Type | Example | Version Bump |
+      |-------------|---------|--------------|
+      | Bug fix | Fix authentication error handling | PATCH |
+      | Documentation | Update README with new examples | PATCH |
+      | New feature | Add auto-update check mechanism | MINOR |
+      | API change | Modify function signature (backward-compatible) | MINOR |
+      | Breaking change | Remove deprecated API | MAJOR |
+      | Refactor | Internal cleanup, no behavior change | PATCH |
+
+      **Commands to execute:**
+      ```bash
+      cd {{repo_path}}
+
+      # Show changes
+      git diff main...HEAD --stat
+
+      # Read current version
+      CURRENT_VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
+      echo "Current version: $CURRENT_VERSION"
+
+      # Based on your classification, determine new version
+      # For PATCH: increment last number (0.2.0 → 0.2.1)
+      # For MINOR: increment middle, reset last (0.2.0 → 0.3.0)
+      # For MAJOR: increment first, reset others (0.2.0 → 1.0.0)
+
+      # Edit the file with new version
+      # sed -i 's/version = "X.Y.Z"/version = "NEW.VERSION"/' pyproject.toml
+
+      # Verify
+      grep -E '^version = ' pyproject.toml | head -1
+      ```
+
+      **Output JSON:**
+      ```json
+      {
+        "current_version": "X.Y.Z",
+        "new_version": "A.B.C",
+        "change_classification": "PATCH|MINOR|MAJOR",
+        "rationale": "explanation of why this version bump",
+        "changes_summary": "brief summary of what changed"
+      }
+      ```
+
+      **CI Enforcement:**
+      - PR will be blocked if version not bumped
+      - CI creates git tag (e.g., `v0.3.0`) on merge to main
+      - Tags enable `uv tool upgrade amplihack` to work correctly
+
+      **Important:** Version bump happens BEFORE commit (Step 15), so it's included in the main implementation commit.
+    output: "version_bump"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 15: COMMIT AND PUSH
+  # Stage all changes, write detailed commit message, and push.
+  # ==========================================================================
+  - id: "step-15-commit-push"
+    type: "bash"
+    condition: "goal_already_met != 'true'"
+    command: |
+      set -euo pipefail
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}"
+      echo "=== Step 15: Commit and Push ==="
+      echo ""
+      echo "--- Staging Changes ---"
+      git add -A
+      echo ""
+      echo "--- Creating Commit ---"
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
+      ISSUE_NUMBER="$ISSUE_NUMBER"
+      COMMIT_TITLE=$(printf 'feat: %.72s' "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
+      COMMIT_MSG=$(printf '%s\n\nImplements issue #%s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\nCloses #%s' "$COMMIT_TITLE" "$ISSUE_NUMBER" "$ISSUE_NUMBER")
+      if [ -n "$(git diff --cached --name-only)" ]; then
+        git commit -m "$COMMIT_MSG"
+      else
+        # FIX (#282): hollow-success false-positive when agent worked in an
+        # alternate worktree. Check if the current branch has new commits
+        # in any other worktree before declaring hollow success.
+        CURRENT_BRANCH=$(git branch --show-current)
+        ALT_WORKTREE_COMMITS=0
+        if [ -n "$CURRENT_BRANCH" ] && git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+          ALT_WORKTREE_COMMITS=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+        fi
+        if [ "$ALT_WORKTREE_COMMITS" -gt 0 ]; then
+          echo "INFO: Nothing staged in ${WORKTREE_SETUP_WORKTREE_PATH:-(unset)}, but the" >&2
+          echo "current branch '$CURRENT_BRANCH' is $ALT_WORKTREE_COMMITS commit(s) ahead of" >&2
+          echo "its upstream. The agent likely committed via an alternate worktree on" >&2
+          echo "the same branch; treating as success." >&2
+          git --no-pager log --oneline -"$ALT_WORKTREE_COMMITS" >&2
+        else
+          echo "ERROR: Nothing staged to commit. The implementation step may have written files" >&2
+          echo "outside the worktree (${WORKTREE_SETUP_WORKTREE_PATH:-(unset)}), or no code changes were produced." >&2
+          echo "This is a hollow-success condition — the workflow completed structurally but" >&2
+          echo "produced no git artifacts. Check that agents created files in the worktree," >&2
+          echo "not in AMPLIHACK_HOME or other locations." >&2
+          git --no-pager status >&2
+          exit 1
+        fi
+      fi
+      echo ""
+      echo "--- Pushing to Remote ---"
+      # REL-002: Detect missing upstream tracking branch before rev-list
+      if ! git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+        echo "WARNING: No upstream tracking branch configured — skipping push" >&2
+        exit 0
+      fi
+      COMMITS_AHEAD=$(git rev-list --count @{u}..HEAD)
+      if [ "$COMMITS_AHEAD" -ne 0 ]; then
+        # REL-001: No stderr suppression on rebase — surface conflict diagnostics
+        # Split into separate statements so set -e catches rebase failures
+        git pull --rebase
+        git push
+      else
+        echo "WARNING: Nothing to push - branch is up to date with remote"
+      fi
+      echo ""
+      echo "=== Commit and Push Complete ==="
+    output: "commit_result"
+
+  # ==========================================================================
+  # STEP 16: OPEN PULL REQUEST AS DRAFT
+  # Create a draft PR with comprehensive description.
+  # ==========================================================================
+  - id: "step-16-create-draft-pr"
+    type: "bash"
+    condition: "goal_already_met != 'true'"
+    command: |
+      set -euo pipefail
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}"
+      echo "=== Step 16: Creating Draft PR ===" >&2
+
+      # FIX (#3324): Idempotency guard — detect pre-existing PRs before creating one
+      # Prevents: "GraphQL: No commits between main and feat/issue-XXXX" error
+      # Root cause: step-09-refactor may create PR on a different branch, leaving
+      # the worktree branch with 0 commits ahead of main.
+      CURRENT_BRANCH=$(git branch --show-current)
+      ISSUE_NUM="$ISSUE_NUMBER"
+
+      # SECURITY: Validate ISSUE_NUM is numeric before interpolating into jq regex
+      # Without this, a non-numeric value could inject into the jq test() filter.
+      if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+          echo "ERROR: issue_number is not numeric: $ISSUE_NUM" >&2
+          exit 1
+      fi
+
+      # Check 1: Is there already a PR on the exact current branch?
+      # timeout 60: prevents hanging indefinitely if GitHub API is unresponsive
+      # REL-003: 2>/dev/null || echo '' is intentional resilience — gh pr list stderr
+      # is noisy (auth warnings, API rate limits) and failure here should not block
+      # the workflow; an empty result simply means "no existing PR found".
+      EXISTING_PR=$(timeout 60 gh pr list --head "$CURRENT_BRANCH" --json url --jq '.[0].url // ""' 2>/dev/null || echo '')
+
+      # Check 2: If not, look for a PR on any branch matching the issue number pattern
+      # (handles case where step-09-refactor created PR on fix/issue-XXXX-* branch)
+      if [ -z "$EXISTING_PR" ]; then
+          EXISTING_PR=$(timeout 60 gh pr list --json url,headRefName --jq "[.[] | select(.headRefName | test(\"issue-$ISSUE_NUM\"))] | .[0].url // \"\""  2>/dev/null || echo '')
+      fi
+
+      # If a PR exists: skip creation, output existing URL to stdout, exit SUCCESS
+      if [ -n "$EXISTING_PR" ]; then
+          echo "INFO: PR already exists — skipping creation" >&2
+          echo "Existing PR: $EXISTING_PR" >&2
+          printf '%s\n' "$EXISTING_PR"
+          exit 0
+      fi
+
+      # Check 3: How many commits are ahead of origin/main?
+      # NOTE: base branch is confirmed as 'main' (error message says "between main and feat/...")
+      # Use arithmetic -eq (not string ==) to handle whitespace-padded output on some platforms
+      COMMITS_AHEAD=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo "0")
+
+      if [ "$COMMITS_AHEAD" -eq 0 ]; then
+          echo "ERROR: 0 commits ahead of main and no related PR found for issue-$ISSUE_NUM." >&2
+          echo "This is a hollow-success condition: the workflow ran but produced no commits." >&2
+          echo "Possible causes:" >&2
+          echo "  1. step-15-commit-push failed silently (check commit_result output)" >&2
+          echo "  2. Implementation agents wrote files outside the worktree" >&2
+          echo "  3. Work was done on a different branch" >&2
+          git --no-pager log --oneline -5 >&2
+          exit 1
+      fi
+
+      # Normal path: 1+ commits ahead, no existing PR — create the PR
+      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
+      TASK_DESC="$TASK_DESCRIPTION"
+      PR_DESIGN="$DESIGN_SPEC"
+      # Bash builtins replace the `tr | cut` pipeline — avoids 2 subprocess spawns
+      PR_TITLE="${TASK_DESC//$'\n'/ }"
+      PR_TITLE="${PR_TITLE//$'\r'/ }"
+      PR_TITLE="${PR_TITLE:0:200}"
+      PR_BODY=$(printf '## Summary\n%s\n\n## Issue\nCloses #%s\n\n## Changes\n%s\n\n## Testing\n- Unit tests added\n- Local testing completed\n- Pre-commit hooks pass\n\n## Checklist\n- [x] Tests pass\n- [x] Documentation updated\n- [x] No stubs or TODOs\n- [ ] Code review completed\n- [ ] Philosophy check passed\n\n---\n*This PR was created as a draft for review before merging.*\n' "$TASK_DESC" "$ISSUE_NUM" "$PR_DESIGN")
+      # timeout 120: gh pr create contacts GitHub GraphQL API — cap wait to 2 minutes
+      # 2>/dev/null: suppress gh stderr to prevent output contract corruption of pr_url
+      timeout 120 gh pr create --draft \
+        --title "$PR_TITLE" \
+        --body "$PR_BODY" 2>/dev/null || {
+          STATUS=$?
+          if [ "$STATUS" -eq 124 ]; then
+              echo "ERROR: gh pr create timed out after 120s — GitHub API may be unavailable" >&2
+          else
+              echo "ERROR: gh pr create failed (exit $STATUS) — PR may already exist for this branch or GitHub API is unavailable" >&2
+          fi
+          exit "$STATUS"
+      }
+    output: "pr_url"
+
+  # ==========================================================================
+  # STEP 16b: OUTSIDE-IN TESTING AND FIX LOOP
+  # After the PR is open, run outside-in tests from the PR branch.
+  # If failures are found, fix them and re-test in a loop until all pass.
+  # ==========================================================================
+  - id: "step-16b-outside-in-fix-loop"
+    agent: "amplihack:builder"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 16b: Outside-In Testing and Fix Loop (MANDATORY)
+
+      The PR is now open. You MUST test the change as a user would FROM THE PR BRANCH
+      and fix any problems found before proceeding to review.
+
+      **Task:** {{task_description}}
+      **PR URL:** {{pr_url}}
+      **Branch:** Run `git branch --show-current` to get branch name.
+      **Remote:** Run `git remote get-url origin` for the repo URL.
+
+      ## Required Actions
+
+      ### Phase 1: Run Outside-In Tests
+
+      Use the `qa-team` skill to test from the PR branch (`outside-in-testing` alias also works):
+
+      ```
+      Skill(skill="qa-team")
+      ```
+
+      Test using the PR branch:
+      ```bash
+      uvx --from git+<remote-url>@<branch-name> amplihack <command>
+      ```
+
+      Run at minimum:
+      1. **Simple scenario**: Basic user-facing behavior this PR changes
+      2. **Complex scenario**: Edge case or integration point affected
+
+      ### Phase 2: Fix Loop (if failures found)
+
+      If any test fails:
+
+      1. **Diagnose** the root cause from the test output
+      2. **Fix** the code in the current branch
+      3. **Commit and push** the fix:
+         ```bash
+         git add -A && git commit -m "fix: <describe the fix found during outside-in testing>"
+         git pull --rebase && git push
+         ```
+      4. **Re-run** the outside-in tests from the updated branch
+      5. **Repeat** until all tests pass (max 3 fix iterations)
+
+      If failures persist after 3 iterations, document them clearly and continue —
+      blocking is not acceptable, but honest documentation is required.
+
+      ### Phase 3: Update PR Description
+
+      After all tests pass (or after 3 iterations), update the PR description with
+      a "Step 16b: Outside-In Testing Results" section:
+
+      ```bash
+      gh pr edit {{pr_url}} --body "$(gh pr view {{pr_url}} --json body -q .body)
+
+      ## Step 16b: Outside-In Testing Results
+
+      ### Scenario 1 — <description>
+      Command: \`uvx --from git+...@<branch> amplihack <command>\`
+      Result: PASS
+      Output: <key output>
+
+      ### Scenario 2 — <description>
+      Command: \`uvx --from git+...@<branch> amplihack <command>\`
+      Result: PASS
+      Output: <key output>
+
+      Fix iterations: 0 (or N if fixes were required)
+      "
+      ```
+    output: "outside_in_fix_loop_results"
+
+  # ==========================================================================
+  # STEP 17: REVIEW THE PR (MANDATORY - DO NOT SKIP)
+  # Granular sub-steps with verification gates to prevent completion bias.
+  # Each sub-step invokes a specific agent and requires evidence.
+  # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -1,0 +1,208 @@
+name: "workflow-refactor-review"
+description: "Phase 4: refactor + 3 pre-commit reviews + feedback (09-11b)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "refactor", "review"]
+
+# workflow-refactor-review: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  - id: "step-09-refactor"
+    agent: "amplihack:cleanup"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 9: Refactor and Simplify
+
+      **CRITICAL:** User requirements that CANNOT be removed:
+      {{final_requirements}}
+
+      **Implementation to refactor:** {{implementation}}
+      **Integration code:** {{integration_code}}
+
+      Apply ruthless simplification WITHIN user constraints:
+
+      1. Remove unnecessary abstractions (not explicitly requested)
+      2. Eliminate dead code (unless user wanted it)
+      3. Simplify complex logic (without violating specs)
+      4. Ensure single responsibility principle
+      5. Verify no placeholders remain
+
+      **Zero-BS Checklist:**
+      - [ ] No stubs
+      - [ ] No TODOs
+      - [ ] No swallowed exceptions
+      - [ ] No unimplemented functions
+
+      **VALIDATE:** All explicit user requirements still preserved.
+    output: "refactored_code"
+
+  - id: "step-09b-optimize"
+    agent: "amplihack:optimizer"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 9b: Performance Optimization
+
+      **Refactored Code:** {{refactored_code}}
+      **Requirements:** {{final_requirements}}
+
+      Review for performance improvements:
+      - Algorithm efficiency
+      - Resource usage
+      - Caching opportunities
+      - Unnecessary operations
+
+      Apply optimizations without sacrificing clarity or correctness.
+    output: "optimized_code"
+
+  # ==========================================================================
+  # STEP 10: REVIEW PASS BEFORE COMMIT
+  # ==========================================================================
+  - id: "step-10-pre-commit-review"
+    agent: "amplihack:reviewer"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 10: Review Pass Before Commit
+
+      **Requirements:** {{final_requirements}}
+      **Design:** {{design_spec}}
+      **Implementation:** {{optimized_code}}
+      **Tests:** {{test_spec}}
+
+      Comprehensive code review before committing:
+
+      **Checklist:**
+      - [ ] Meets all requirements
+      - [ ] Follows the design
+      - [ ] No stubs/TODOs/placeholders
+      - [ ] Proper error handling
+      - [ ] Adequate test coverage
+      - [ ] Code is as simple as possible
+      - [ ] Clear naming and documentation
+      - [ ] No debugging code (console.log, print, breakpoint)
+      - [ ] No temporary files
+
+      **PR Cleanliness Check:**
+      - [ ] All changes directly related to issue
+      - [ ] No experimental code
+      - [ ] No "while I'm here" improvements
+
+      Provide review summary with issues and recommendations.
+    output: "pre_commit_review"
+
+  - id: "step-10b-security-review"
+    agent: "amplihack:security"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 10b: Security Review
+
+      **Implementation:** {{optimized_code}}
+      **Security Requirements:** {{security_requirements}}
+
+      Security review checklist:
+      - [ ] Input validation
+      - [ ] Output encoding
+      - [ ] Authentication/authorization
+      - [ ] Sensitive data handling
+      - [ ] No hardcoded secrets
+      - [ ] Proper error messages (no info leakage)
+
+      Report any security issues found.
+    output: "security_review"
+
+  - id: "step-10c-philosophy-check"
+    agent: "amplihack:philosophy-guardian"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 10c: Philosophy Compliance Check
+
+      **Implementation:** {{optimized_code}}
+      **Review:** {{pre_commit_review}}
+      **Security Review:** {{security_review}}
+
+      Verify philosophy compliance:
+      - Ruthless Simplicity: Is this as simple as possible?
+      - Zero-BS: No stubs, faked data, swallowed exceptions?
+      - Modular Design: Clean boundaries?
+      - Test-Driven: Adequate coverage?
+
+      Report any philosophy violations.
+    output: "philosophy_review"
+
+  # ==========================================================================
+  # STEP 11: INCORPORATE REVIEW FEEDBACK
+  # ==========================================================================
+  - id: "step-11-incorporate-feedback"
+    agent: "amplihack:architect"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 11: Assess Review Feedback
+
+      **Pre-Commit Review:** {{pre_commit_review}}
+      **Security Review:** {{security_review}}
+      **Philosophy Review:** {{philosophy_review}}
+
+      Assess all review feedback and determine:
+      1. What changes are required?
+      2. Priority of changes
+      3. Implementation approach
+
+      Provide guidance for the builder agent.
+    output: "feedback_assessment"
+
+  - id: "step-11b-implement-feedback"
+    agent: "amplihack:builder"
+    condition: "goal_already_met != 'true'"
+    prompt: |
+      # Step 11b: Implement Review Feedback
+
+      **Current Code:** {{optimized_code}}
+      **Feedback Assessment:** {{feedback_assessment}}
+      **Reviews:**
+      - Pre-commit: {{pre_commit_review}}
+      - Security: {{security_review}}
+      - Philosophy: {{philosophy_review}}
+
+      Implement all required changes from the reviews.
+      Update documentation as needed.
+
+      Output the updated implementation.
+    output: "review_feedback"
+
+  # --------------------------------------------------------------------------
+  # CHECKPOINT: Stage review feedback changes before pre-commit hooks
+  # --------------------------------------------------------------------------
+  - id: "checkpoint-after-review-feedback"
+    type: "bash"
+    max_env_value_bytes: 65536
+    command: |
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" 2>/dev/null || cd "$REPO_PATH" && \
+      echo "=== Checkpoint: Staging Review Feedback ===" && \
+      git add -A && \
+      STAGED=$(git diff --cached --name-only) && \
+      if [ -n "$STAGED" ]; then \
+        git commit -m "wip: checkpoint after review feedback (steps 10-11)
+
+      Automatic checkpoint to preserve review-addressed changes.
+      Saved before running pre-commit hooks and tests." && \
+        echo "Checkpoint commit created with $(wc -l <<< "$STAGED") file(s)" ; \
+      else \
+        echo "No changes to checkpoint" ; \
+      fi && \
+      echo "=== Checkpoint Complete ==="
+    output: "review_checkpoint"
+
+  # ==========================================================================
+  # STEP 12: RUN TESTS AND PRE-COMMIT HOOKS
+  # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -1,0 +1,240 @@
+name: "workflow-tdd"
+description: "Phase 3: TDD — tests, implement, no-op guard (07-08c)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "tdd", "implementation"]
+
+# workflow-tdd: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  - id: "step-07-write-tests"
+    agent: "amplihack:tester"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
+    prompt: |
+      # Step 7: TDD - Write Tests First
+
+      **Task:** {{task_description}}
+      **Requirements:** {{final_requirements}}
+      **Design Specification:** {{design_spec}}
+      **Documentation:** {{final_documentation}}
+
+      Following Test-Driven Development methodology:
+
+      Write FAILING tests that specify the expected behavior:
+      - Unit tests for each component
+      - Integration tests for workflows
+      - Edge case tests
+      - Error handling tests
+
+      These tests should:
+      - Define the contract for the implementation
+      - Fail initially (code doesn't exist yet)
+      - Pass once implementation is complete
+
+      Output test files with clear file path headers.
+    output: "test_spec"
+
+  # ==========================================================================
+  # STEP 8: IMPLEMENT THE SOLUTION
+  # ==========================================================================
+  - id: "step-08-implement"
+    agent: "amplihack:builder"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
+    prompt: |
+      # Step 8: Implement the Solution
+
+      **Task:** {{task_description}}
+      **Requirements:** {{final_requirements}}
+      **Design Specification:** {{design_spec}}
+      **Documentation:** {{final_documentation}}
+      **Tests (must pass):** {{test_spec}}
+
+      Implement the solution following the design.
+
+      **Rules (in order of authority):**
+      0. **The user's task description is authoritative.** If the existing code already
+         appears to satisfy the requirements, that is a SIGNAL THAT YOU MISREAD THE
+         TASK — re-read it more carefully and apply the requested change anyway. Do
+         NOT exit without modifying files unless the task is provably impossible
+         (e.g., contradicts laws of physics, references nonexistent platforms). A
+         "no-op" outcome must be explicitly justified in the output.
+      1. You MUST modify or create at least one file unless rule 0's "provably
+         impossible" exception applies. Reading code is not implementing.
+      2. Follow the design closely.
+      3. Make failing tests pass iteratively.
+      4. NO stubs, TODOs, or placeholder code.
+      5. NO swallowed exceptions.
+      6. NO faked APIs or data.
+      7. Clear error messages.
+      8. Appropriate logging.
+
+      **Self-verification before declaring done:**
+      - Run `git status` and `git diff --stat` in your working directory.
+      - If the diff is empty, you have NOT implemented anything. Re-read the task
+        and try again. Do not produce a final output until you have either (a)
+        written changes that show in `git diff`, or (b) determined the task is
+        provably impossible per rule 0.
+
+      **Output (structured — all sections required):**
+      - `Files modified:` — newline-separated list of paths you created or edited.
+        If empty, you must include a `No-op justification:` section explaining why
+        rule 0's "provably impossible" exception applies. Empty list with no
+        justification = workflow failure.
+      - `Diff summary:` — one line per file describing the change.
+      - Complete implementation code (all files), with `# File: path/to/file.py`
+        headers.
+      - Brief explanation of key decisions.
+      - Any deviations from design (with justification).
+    output: "implementation"
+
+  - id: "step-08c-implementation-no-op-guard"
+    type: "bash"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
+    # Hard-fail early (before checkpoint, refactor, review) if step-08 declared
+    # success but reported zero file edits. This catches prompt-misalignment
+    # (issue #251 / amplihack-rs #251) closer to the root cause than the
+    # commit-stage hollow-success guard at step-15.
+    command: |
+      set -euo pipefail
+      IMPL="${IMPLEMENTATION:-}"
+      if [ -z "$IMPL" ]; then
+        echo "ERROR: step-08-implement produced no output." >&2
+        exit 1
+      fi
+      # Look for the structured "Files modified:" line.
+      FILES_LINE=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*Files modified:' || true)
+      JUSTIFICATION=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*No-op justification:' || true)
+      if [ -z "$FILES_LINE" ]; then
+        echo "WARNING: step-08-implement output is missing the required" >&2
+        echo "'Files modified:' section. The agent did not follow the structured" >&2
+        echo "output schema. Check the implementer prompt and output." >&2
+        # Soft-warn rather than hard-fail to remain backward-compatible with
+        # agents that ignore the schema. The git-diff guard below is the hard gate.
+      fi
+      # Check git diff in the worktree as the source of truth.
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$PWD}"
+      if ! git diff --quiet || ! git diff --cached --quiet || \
+         [ -n "$(git ls-files --others --exclude-standard)" ]; then
+        echo "step-08 produced file changes — guard passed."
+        exit 0
+      fi
+      if [ -n "$JUSTIFICATION" ]; then
+        echo "step-08 produced no file changes but declared a no-op justification:" >&2
+        echo "$JUSTIFICATION" >&2
+        echo "Allowing workflow to continue under rule 0 exception." >&2
+        exit 0
+      fi
+      # Issue #360: detect "goal already met" — the desired change is already
+      # in main (e.g., a previous orchestrator round merged it) before treating
+      # this as a hollow-success failure. Probe the linked GitHub issue: if it
+      # is closed by a merged PR, exit 0 with a "pre-existing" marker rather
+      # than failing the round.
+      ISSUE_NUM="${ISSUE_NUMBER:-}"
+      if [ -n "$ISSUE_NUM" ] && command -v gh >/dev/null 2>&1; then
+        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null || true)
+        if [ "$ISSUE_STATE" = "CLOSED" ]; then
+          # closedByPullRequestsReferences items DO NOT carry .state.
+          # Fetch (number, owner/repo) pairs so cross-repo PRs are looked
+          # up correctly (COE cohort review #2).
+          CLOSING_PR_REFS=$(gh issue view "$ISSUE_NUM" \
+            --json closedByPullRequestsReferences \
+            --jq '[.closedByPullRequestsReferences[]? | "\(.number) \(.repository.owner.login)/\(.repository.name)"] | join("\n")' \
+            2>/dev/null || true)
+          MAX_PROBE=10
+          probed=0
+          MERGED_FOUND=0
+          while IFS= read -r ref; do
+            [ -z "$ref" ] && continue
+            probed=$((probed + 1))
+            if [ "$probed" -gt "$MAX_PROBE" ]; then break; fi
+            PR_NUM=$(printf '%s' "$ref" | awk '{print $1}')
+            PR_REPO=$(printf '%s' "$ref" | awk '{print $2}')
+            if [ -n "$PR_REPO" ] && [ "$PR_REPO" != "/" ]; then
+              PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --repo "$PR_REPO" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+            else
+              PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
+            fi
+            # mergedAt is null for unmerged PRs and a timestamp string for merged ones.
+            if [ -n "$PR_MERGED" ] && [ "$PR_MERGED" != "null" ]; then
+              MERGED_FOUND=1
+              break
+            fi
+          done <<< "$CLOSING_PR_REFS"
+          if [ "$MERGED_FOUND" -eq 1 ]; then
+            echo "INFO: step-08-implement produced no file changes, but issue" >&2
+            echo "  #${ISSUE_NUM} is already CLOSED by a merged pull request." >&2
+            echo "  This is a 'goal already met' (#360) — not a hollow success." >&2
+            echo "  Treating as pre-existing success and continuing." >&2
+            exit 0
+          fi
+        fi
+      fi
+      echo "ERROR: step-08-implement claimed success but produced ZERO file changes" >&2
+      echo "and no 'No-op justification:' was provided. This is a hollow-success" >&2
+      echo "condition, almost certainly caused by prompt-misalignment — see" >&2
+      echo "https://github.com/rysweet/amplihack-rs/issues/251." >&2
+      echo "" >&2
+      echo "Working directory: $PWD" >&2
+      git --no-pager status >&2
+      exit 1
+    output: "implementation_noop_guard"
+
+  - id: "step-08b-integration"
+    agent: "amplihack:integration"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
+    prompt: |
+      # Step 8b: External Service Integration
+
+      **Implementation:** {{implementation}}
+      **Design Specification:** {{design_spec}}
+
+      Handle external service connections:
+      - API client implementations
+      - Service adapters
+      - Error handling for external calls
+      - Retry logic and resilience
+
+      Skip if no external integrations are required.
+    output: "integration_code"
+
+  # --------------------------------------------------------------------------
+  # CHECKPOINT: Stage implementation work to prevent loss if later steps fail
+  # --------------------------------------------------------------------------
+  - id: "checkpoint-after-implementation"
+    type: "bash"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    # FIX (#4231): Limit env var size to prevent E2BIG when prior steps
+    # (implementation, test_spec, design_spec) produce large outputs.
+    max_env_value_bytes: 65536
+    command: |
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" 2>/dev/null || cd "$REPO_PATH" && \
+      echo "=== Checkpoint: Staging Implementation ===" && \
+      git add -A && \
+      STAGED=$(git diff --cached --name-only) && \
+      if [ -n "$STAGED" ]; then \
+        git commit -m "wip: checkpoint after implementation (steps 7-8)
+
+      Automatic checkpoint to preserve work in progress.
+      Tests and implementation saved before refactoring phase." && \
+        echo "Checkpoint commit created with $(wc -l <<< "$STAGED") file(s)" ; \
+      else \
+        echo "No changes to checkpoint" ; \
+      fi && \
+      echo "=== Checkpoint Complete ==="
+    output: "impl_checkpoint"
+
+  # ==========================================================================
+  # STEP 9: REFACTOR AND SIMPLIFY
+  # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -1,0 +1,252 @@
+name: "workflow-worktree"
+description: "Phase 1b: worktree / branch setup (step 04)"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "prep", "worktree", "git"]
+
+# workflow-worktree: extracted from default-workflow.yaml as a composable phase brick.
+#
+# Preserves every original step verbatim — the layered review steps the LLM
+# converges through must remain intact. Context flows in from the parent
+# workflow via recipe-runner's automatic context-merging in
+# `_execute_sub_recipe()`; outputs declared by these steps propagate back to
+# the parent and are visible to subsequent phase recipes.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context: {}
+
+steps:
+  - id: "step-04-setup-worktree"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      # Guard: fail-fast if repo_path does not exist (prevents path traversal, catches misconfiguration).
+      if [ ! -d "$REPO_PATH" ]; then
+        echo "ERROR: repo_path '$REPO_PATH' does not exist or is not a directory" >&2
+        exit 1
+      fi
+      cd "$REPO_PATH"
+
+      echo "=== Step 4: Creating Worktree and Branch ===" >&2
+      echo "" >&2
+
+      # ========================================================================
+      # NEW (#342): Existing-branch / PR targeting path.
+      # When EXISTING_BRANCH or PR_NUMBER is set, reuse an existing branch
+      # instead of deriving a slug from TASK_DESCRIPTION. EXISTING_BRANCH wins
+      # when both are set (a WARNING is emitted to stderr).
+      #
+      # MIRROR: consensus-workflow.yaml step3-setup-worktree must keep the same
+      # validation gates and resolution algorithm. Do not patch one without the
+      # other. The Python parity test in
+      # amplifier-bundle/tools/test_default_workflow_fixes.py guards drift.
+      # ========================================================================
+      EXISTING_BRANCH="${EXISTING_BRANCH:-}"
+      PR_NUMBER="${PR_NUMBER:-}"
+
+      if [ -n "$EXISTING_BRANCH" ] || [ -n "$PR_NUMBER" ]; then
+        # Precedence: existing_branch wins on tie.
+        if [ -n "$EXISTING_BRANCH" ] && [ -n "$PR_NUMBER" ]; then
+          echo "WARNING: both 'existing_branch' and 'pr_number' set — using existing_branch ('$EXISTING_BRANCH'), ignoring pr_number ('$PR_NUMBER')." >&2
+        fi
+
+        if [ -n "$EXISTING_BRANCH" ]; then
+          BRANCH_NAME="$EXISTING_BRANCH"
+        else
+          # SECURITY: PR_NUMBER must be a positive integer before passing to gh.
+          # Rejects arg-injection like '342 --repo evil/x', '-1', or '$(rm)'.
+          if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "ERROR: pr_number '$PR_NUMBER' is not a valid positive integer (arg-injection guard)." >&2
+            exit 1
+          fi
+          if ! command -v gh >/dev/null 2>&1; then
+            echo "ERROR: pr_number is set but the 'gh' CLI is not on PATH." >&2
+            exit 1
+          fi
+          # gh stderr suppressed to avoid leaking auth/token diagnostics; we
+          # surface a sanitized error instead.
+          BRANCH_NAME="$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName 2>/dev/null || true)"
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "ERROR: 'gh pr view $PR_NUMBER' returned no branch name (PR not found, no auth, or gh failure)." >&2
+            exit 1
+          fi
+        fi
+
+        # SECURITY: validate the branch name with the authoritative git ref
+        # checker BEFORE using it in any path or git invocation. This rejects
+        # '..', leading '-', shell metachars, and control chars. Re-applied
+        # to gh output so we never trust an upstream API response.
+        if ! git check-ref-format --branch "$BRANCH_NAME" >/dev/null 2>&1; then
+          echo "ERROR: branch name '$BRANCH_NAME' is invalid (git check-ref-format rejection)." >&2
+          exit 1
+        fi
+
+        echo "INFO: Targeting existing branch '$BRANCH_NAME' (issue #342 path)." >&2
+
+        # Best-effort fetch so remote-only branches resolve. Explicit refspec
+        # creates the local remote-tracking ref. Branch name is validated above.
+        git fetch origin "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" >&2 2>/dev/null || true
+
+        # Resolve worktree path:
+        #   (a) reuse if a worktree already exists for the branch
+        #   (b) else use REPO_PATH if it is itself checked out on the branch
+        #   (c) else attach a new worktree at REPO_PATH/worktrees/<branch>
+        WORKTREE_PATH=""
+        EXISTING_WT="$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH_NAME" '
+          $1=="worktree" { wt=$2 }
+          $1=="branch" && $2==b { print wt; exit }
+        ')"
+        if [ -n "$EXISTING_WT" ]; then
+          WORKTREE_PATH="$EXISTING_WT"
+          echo "INFO: Reusing existing worktree at '$WORKTREE_PATH'." >&2
+        else
+          HEAD_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+          if [ "$HEAD_BRANCH" = "$BRANCH_NAME" ]; then
+            WORKTREE_PATH="$REPO_PATH"
+            echo "INFO: Caller already on branch '$BRANCH_NAME'; using REPO_PATH as worktree." >&2
+          else
+            # SECURITY: WORKTREE_PATH construction is safe because BRANCH_NAME
+            # has passed git check-ref-format above (rejects .., leading -, etc.).
+            WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+            if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+              # Local branch exists: attach without -b (safe re-attach).
+              git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+            elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+              # Remote-only: create local tracking branch on attach.
+              git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+            else
+              echo "ERROR: branch '$BRANCH_NAME' not found locally or on origin." >&2
+              exit 1
+            fi
+          fi
+        fi
+
+        # When reusing an existing branch, `created=false` reflects that the
+        # branch was not created by this step (its worktree may be new).
+        CREATED=false
+
+        # Push/upstream best-effort (idempotent on existing PR branches).
+        git -C "$WORKTREE_PATH" push origin "$BRANCH_NAME" > /dev/null 2>&1 || true
+        git -C "$WORKTREE_PATH" branch --set-upstream-to="origin/${BRANCH_NAME}" "$BRANCH_NAME" > /dev/null 2>&1 || true
+
+        echo "" >&2
+        echo "=== Worktree Setup Complete (existing-branch path) ===" >&2
+
+        # Stdout reserved for the JSON contract; all human-readable lines go to stderr.
+        # NOTE: printf (not heredoc) — heredoc terminator must be at column 0 after
+        # YAML strips block indent, which conflicts with the indented if-block here.
+        printf '{"worktree_path": "%s", "branch_name": "%s", "created": %s}\n' \
+          "$WORKTREE_PATH" "$BRANCH_NAME" "$CREATED"
+        exit 0
+      fi
+
+      # Fetch latest refs
+      git fetch origin main >&2
+
+      # NOTE: This slug pipeline is duplicated in consensus-workflow.yaml step3-setup-worktree
+      # with a 30-char limit instead of 50. If you update this pipeline (e.g. security patch),
+      # update consensus-workflow.yaml in the same commit. See Issue #2952 for context.
+      #
+      # Generate branch name from task description.
+      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      # Sanitization pipeline (tr -cd 'a-z0-9-') strips all shell metacharacters.
+      TASK_DESC="$TASK_DESCRIPTION"
+      TASK_SLUG=$(printf '%s' "$TASK_DESC" | tr '\n\r' '  ' | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-50 | sed 's/-$//')
+      # Guard: empty slug (blank/all-symbol input) produces a trailing-hyphen branch that
+      # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
+      if [ -z "$TASK_SLUG" ]; then
+        echo "WARNING: task_description produced an empty slug — falling back to task-unnamed" >&2
+        # FIX (issue #3023 / BL-002 fallback hardening): Use hardcoded 'feat/' prefix rather
+        # than $BRANCH_PREFIX to prevent injection via an invalid or malicious branch_prefix
+        # value (e.g. '; rm -rf /' or '../../etc'). The prefix is not user-configurable in
+        # the fallback path; configurable prefix only applies when a valid slug exists.
+        BRANCH_NAME="feat/task-unnamed-$(date +%s)"
+      else
+        BRANCH_NAME="${BRANCH_PREFIX}/issue-${ISSUE_NUMBER}-${TASK_SLUG}"
+        # Validate with authoritative git ref checker; fall back to safe unique name on failure
+        if ! git check-ref-format --branch "${BRANCH_NAME}" >/dev/null 2>&1; then
+          echo "WARNING: derived branch name '${BRANCH_NAME}' is invalid — falling back to task-unnamed" >&2
+          BRANCH_NAME="feat/task-unnamed-$(date +%s)"
+        fi
+      fi
+      WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+
+      echo "Branch: ${BRANCH_NAME}" >&2
+      echo "Worktree: ${WORKTREE_PATH}" >&2
+      echo "" >&2
+
+      # --- Idempotency: detect existing branch and/or worktree ---
+      # FIX (issue #3023 / BL-002): Three-state guard makes re-runs safe.
+      # State 1: branch + worktree both exist → reuse silently, emit created=false
+      # State 2: branch exists but worktree missing → add worktree without -b
+      # State 3: neither exists → full create path (original behaviour)
+      #
+      # Security note: grep -F is required (not -E/-P) so that filesystem path
+      # characters (., +, *) in WORKTREE_PATH are not interpreted as regex metacharacters.
+      BRANCH_EXISTS=$(git branch --list "${BRANCH_NAME}")
+      WORKTREE_EXISTS=$(git worktree list --porcelain | grep -Fx "worktree ${WORKTREE_PATH}" || true)
+
+      if [ -n "$BRANCH_EXISTS" ] && [ -n "$WORKTREE_EXISTS" ]; then
+        # FIX (issue #200): Verify branch cleanliness before reusing.
+        # A dirty worktree (uncommitted changes or unmerged commits ahead of
+        # origin/main) can leak stale state into a new recipe run.
+        WORKTREE_DIRTY=$(git -C "${WORKTREE_PATH}" status --porcelain 2>/dev/null || true)
+        COMMITS_AHEAD=$(git -C "${WORKTREE_PATH}" rev-list --count origin/main..HEAD 2>/dev/null || echo "0")
+        if [ -n "$WORKTREE_DIRTY" ] || [ "$COMMITS_AHEAD" -gt 0 ]; then
+          echo "WARNING: Existing branch '${BRANCH_NAME}' is dirty (uncommitted changes: $([ -n "$WORKTREE_DIRTY" ] && echo 'yes' || echo 'no'), commits ahead of origin/main: ${COMMITS_AHEAD})." >&2
+          echo "INFO: Resetting worktree to origin/main for a clean slate." >&2
+          git -C "${WORKTREE_PATH}" checkout -- . 2>/dev/null || true
+          git -C "${WORKTREE_PATH}" clean -fd 2>/dev/null || true
+          git -C "${WORKTREE_PATH}" reset --hard origin/main >&2
+          CREATED=false
+        else
+          echo "INFO: Branch '${BRANCH_NAME}' and worktree '${WORKTREE_PATH}' already exist and are clean — reusing." >&2
+          CREATED=false
+        fi
+      elif [ -n "$BRANCH_EXISTS" ] && [ -z "$WORKTREE_EXISTS" ]; then
+        # FIX (issue #200): Check branch cleanliness before attaching worktree.
+        # The branch may have unmerged commits from a previous run even if the
+        # worktree was pruned.
+        COMMITS_AHEAD=$(git rev-list --count origin/main.."${BRANCH_NAME}" 2>/dev/null || echo "0")
+        if [ "$COMMITS_AHEAD" -gt 0 ]; then
+          echo "WARNING: Existing branch '${BRANCH_NAME}' has ${COMMITS_AHEAD} unmerged commit(s) — resetting to origin/main." >&2
+          git branch -D "${BRANCH_NAME}" >&2
+          git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" origin/main >&2
+        else
+          echo "INFO: Branch '${BRANCH_NAME}' exists (clean) but worktree is missing — adding worktree without -b." >&2
+          git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}" >&2
+        fi
+        CREATED=true
+      else
+        echo "INFO: Creating new branch and worktree." >&2
+        git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" origin/main >&2
+        CREATED=true
+      fi
+
+      # Push branch to remote with tracking (idempotent).
+      # NOTE: Push failures are suppressed here and surface at step-16 PR creation.
+      # This allows idempotent re-runs where the remote branch already exists.
+      git -C "${WORKTREE_PATH}" push origin "${BRANCH_NAME}" > /dev/null 2>&1 || true
+      git -C "${WORKTREE_PATH}" branch --set-upstream-to="origin/${BRANCH_NAME}" "${BRANCH_NAME}" > /dev/null 2>&1 || true
+
+      echo "" >&2
+      echo "=== Worktree Setup Complete ===" >&2
+
+      # Output structured JSON for subsequent steps.
+      # created=false signals that an existing worktree was reused (diagnostic for re-runs).
+      cat << EOF
+      {
+        "worktree_path": "${WORKTREE_PATH}",
+        "branch_name": "${BRANCH_NAME}",
+        "created": ${CREATED}
+      }
+      EOF
+    output: "worktree_setup"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 5: RESEARCH AND DESIGN
+  # ==========================================================================

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -67,6 +67,15 @@ path = "../../tests/integration/recipe_e2e_test.rs"
 name = "no_python_probe"
 path = "../../tests/integration/no_python_probe_test.rs"
 
+# Default-workflow decomposition parity tests.
+# Locks the v3 contract: composer calls 9 phase sub-recipes, every original
+# step ID is preserved in order, no duplicates, every brick stays under 400
+# LOC, and mandatory steps (0/14/17/18) remain present. Pure structural,
+# no recipe-runner needed.
+[[test]]
+name = "default_workflow_decomposition"
+path = "../../tests/integration/default_workflow_decomposition_test.rs"
+
 # Issue #78 / v0.5.0: Fleet local dashboard probe tests (TC-09 through TC-12).
 # These tests validate the local session management dashboard:
 #   TC-09: fleet --help exits 0

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -49,10 +49,9 @@ fn recipes_dir() -> PathBuf {
 
 fn load(name: &str) -> Recipe {
     let path = recipes_dir().join(format!("{name}.yaml"));
-    let text = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-    serde_yaml::from_str(&text)
-        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 }
 
 /// The expected step inventory of `default-workflow`, in execution order, as
@@ -181,10 +180,7 @@ fn every_phase_subrecipe_loads_and_has_steps() {
     for name in PHASE_RECIPES {
         let r = load(name);
         assert_eq!(&r.name, name, "recipe.name must match filename");
-        assert!(
-            !r.steps.is_empty(),
-            "{name} must declare at least one step"
-        );
+        assert!(!r.steps.is_empty(), "{name} must declare at least one step");
     }
 }
 
@@ -232,7 +228,10 @@ fn no_duplicate_step_ids_across_subrecipes() {
 fn every_phase_subrecipe_under_400_lines() {
     const LIMIT: usize = 400;
     let mut violations: Vec<(String, usize)> = Vec::new();
-    for name in PHASE_RECIPES.iter().chain(std::iter::once(&"default-workflow")) {
+    for name in PHASE_RECIPES
+        .iter()
+        .chain(std::iter::once(&"default-workflow"))
+    {
         let path = recipes_dir().join(format!("{name}.yaml"));
         let lines = std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -1,0 +1,270 @@
+//! Default-workflow decomposition parity tests.
+//!
+//! `default-workflow.yaml` was decomposed (v3.0.0) from a 3098-line monolith
+//! into a thin composer that calls 9 phase sub-recipes:
+//!
+//!   workflow-prep, workflow-worktree, workflow-design, workflow-tdd,
+//!   workflow-refactor-review, workflow-precommit-test, workflow-publish,
+//!   workflow-pr-review, workflow-finalize
+//!
+//! Every original step prompt is preserved verbatim — the user's stated
+//! design constraint is that the LLM converges on correct behaviour through
+//! many recursive review layers, so no layer may be silently dropped.
+//!
+//! These tests lock the contract: if a future edit drops a step or reorders
+//! the inventory or breaks the brick budget (≤400 LOC per sub-recipe), CI
+//! fails before the regression ships.
+//!
+//! The tests deliberately do NOT exercise the recipe runner end-to-end (that
+//! is `recipe_e2e_test.rs`'s job). They are pure structural assertions on
+//! YAML content, fast, and have no external dependencies.
+
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct Recipe {
+    name: String,
+    #[serde(default)]
+    steps: Vec<Step>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Step {
+    id: String,
+    #[serde(rename = "type", default)]
+    step_type: Option<String>,
+    #[serde(default)]
+    recipe: Option<String>,
+}
+
+fn recipes_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("amplifier-bundle")
+        .join("recipes")
+}
+
+fn load(name: &str) -> Recipe {
+    let path = recipes_dir().join(format!("{name}.yaml"));
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text)
+        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+/// The expected step inventory of `default-workflow`, in execution order, as
+/// of the v2 -> v3 decomposition. This is the contract every PR must preserve.
+///
+/// If you intentionally add or remove a step, update this list AND adjust the
+/// owning sub-recipe; the test then verifies you didn't accidentally lose any
+/// other step in the same change.
+const EXPECTED_STEP_INVENTORY: &[&str] = &[
+    // Phase 1a: workflow-prep (steps 00-03b)
+    "step-00-workflow-preparation",
+    "step-01-prepare-workspace",
+    "step-02-clarify-requirements",
+    "step-02b-analyze-codebase",
+    "step-02c-resolve-ambiguity",
+    "step-03-create-issue",
+    "step-03b-extract-issue-number",
+    // Phase 1b: workflow-worktree (step 04)
+    "step-04-setup-worktree",
+    // Phase 2: workflow-design (steps 05-06d)
+    "step-05-architecture",
+    "step-05b-api-design",
+    "step-05c-database-design",
+    "step-05d-security-review",
+    "step-05e-design-consolidation",
+    "step-06-documentation",
+    "step-06b-documentation-review",
+    "step-06c-documentation-refinement",
+    "step-06d-goal-already-met-probe",
+    // Phase 3: workflow-tdd (steps 07-08c)
+    "step-07-write-tests",
+    "step-08-implement",
+    "step-08c-implementation-no-op-guard",
+    "step-08b-integration",
+    "checkpoint-after-implementation",
+    // Phase 4: workflow-refactor-review (steps 09-11b)
+    "step-09-refactor",
+    "step-09b-optimize",
+    "step-10-pre-commit-review",
+    "step-10b-security-review",
+    "step-10c-philosophy-check",
+    "step-11-incorporate-feedback",
+    "step-11b-implement-feedback",
+    "checkpoint-after-review-feedback",
+    // Phase 5: workflow-precommit-test (steps 12-13)
+    "step-12-run-precommit",
+    "step-13-local-testing",
+    // Phase 6: workflow-publish (steps 14-16b)
+    "step-14-bump-version",
+    "step-15-commit-push",
+    "step-16-create-draft-pr",
+    "step-16b-outside-in-fix-loop",
+    // Phase 7: workflow-pr-review (steps 17a-19d)
+    "step-17a-compliance-verification",
+    "step-17b-reviewer-agent",
+    "step-17c-security-review",
+    "step-17d-philosophy-guardian",
+    "step-17e-address-blocking-issues",
+    "step-17f-verification-gate",
+    "step-18a-analyze-feedback",
+    "step-18b-implement-feedback",
+    "step-18c-push-feedback-changes",
+    "step-18d-respond-to-comments",
+    "step-18e-verification-gate",
+    "step-19a-philosophy-check",
+    "step-19b-patterns-check",
+    "step-19c-zero-bs-verification",
+    "step-19d-verification-gate",
+    // Phase 8: workflow-finalize (steps 20-22b + complete)
+    "step-20-final-cleanup",
+    "step-20b-push-cleanup",
+    "step-20c-quality-audit",
+    "step-21-pr-ready",
+    "step-22-ensure-mergeable",
+    "step-22b-final-status",
+    "workflow-complete",
+];
+
+const PHASE_RECIPES: &[&str] = &[
+    "workflow-prep",
+    "workflow-worktree",
+    "workflow-design",
+    "workflow-tdd",
+    "workflow-refactor-review",
+    "workflow-precommit-test",
+    "workflow-publish",
+    "workflow-pr-review",
+    "workflow-finalize",
+];
+
+/// The composer must call exactly the 9 phase sub-recipes, in order, and
+/// declare nothing else.
+#[test]
+fn composer_calls_nine_phase_subrecipes_in_order() {
+    let composer = load("default-workflow");
+    assert_eq!(composer.name, "default-workflow");
+    assert_eq!(
+        composer.steps.len(),
+        PHASE_RECIPES.len(),
+        "composer must have exactly {} sub-recipe calls; found {}",
+        PHASE_RECIPES.len(),
+        composer.steps.len()
+    );
+    for (i, (step, expected)) in composer.steps.iter().zip(PHASE_RECIPES).enumerate() {
+        assert_eq!(
+            step.step_type.as_deref(),
+            Some("recipe"),
+            "composer step {i} must be type=recipe"
+        );
+        assert_eq!(
+            step.recipe.as_deref(),
+            Some(*expected),
+            "composer step {i} must call recipe '{expected}'; got {:?}",
+            step.recipe
+        );
+        assert_eq!(
+            step.id, *expected,
+            "composer step id should match recipe name for traceability"
+        );
+    }
+}
+
+/// Every phase sub-recipe must parse and have a non-empty step list.
+#[test]
+fn every_phase_subrecipe_loads_and_has_steps() {
+    for name in PHASE_RECIPES {
+        let r = load(name);
+        assert_eq!(&r.name, name, "recipe.name must match filename");
+        assert!(
+            !r.steps.is_empty(),
+            "{name} must declare at least one step"
+        );
+    }
+}
+
+/// Concatenating the steps of all 9 phase sub-recipes (in composer order) must
+/// reproduce the original 58-step inventory in the original order.
+#[test]
+fn composed_step_inventory_matches_expected_in_order() {
+    let mut composed: Vec<String> = Vec::new();
+    for name in PHASE_RECIPES {
+        let r = load(name);
+        composed.extend(r.steps.iter().map(|s| s.id.clone()));
+    }
+    let expected: Vec<&str> = EXPECTED_STEP_INVENTORY.to_vec();
+    assert_eq!(
+        composed.len(),
+        expected.len(),
+        "composed inventory has {} steps, expected {}",
+        composed.len(),
+        expected.len()
+    );
+    for (i, (c, e)) in composed.iter().zip(&expected).enumerate() {
+        assert_eq!(c, e, "step #{i}: composed has '{c}', expected '{e}'");
+    }
+}
+
+/// No step ID may appear twice anywhere across the decomposition. Duplicates
+/// would silently shadow context outputs.
+#[test]
+fn no_duplicate_step_ids_across_subrecipes() {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut dups: Vec<String> = Vec::new();
+    for name in PHASE_RECIPES {
+        for step in load(name).steps {
+            if !seen.insert(step.id.clone()) {
+                dups.push(step.id);
+            }
+        }
+    }
+    assert!(dups.is_empty(), "duplicate step IDs found: {dups:?}");
+}
+
+/// Brick rule: every phase sub-recipe must be ≤ 400 lines. The composer is
+/// already tiny by construction; checking it too costs nothing.
+#[test]
+fn every_phase_subrecipe_under_400_lines() {
+    const LIMIT: usize = 400;
+    let mut violations: Vec<(String, usize)> = Vec::new();
+    for name in PHASE_RECIPES.iter().chain(std::iter::once(&"default-workflow")) {
+        let path = recipes_dir().join(format!("{name}.yaml"));
+        let lines = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+            .lines()
+            .count();
+        if lines > LIMIT {
+            violations.push((name.to_string(), lines));
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "brick rule violation (>{LIMIT} LOC): {violations:?}"
+    );
+}
+
+/// MANDATORY steps from the v2 contract (0, 14, 17, 18) must remain present.
+/// Listed explicitly so a regression that drops a mandatory gate is loud.
+#[test]
+fn mandatory_steps_still_present() {
+    let composed: HashSet<String> = PHASE_RECIPES
+        .iter()
+        .flat_map(|name| load(name).steps.into_iter().map(|s| s.id))
+        .collect();
+    for required in [
+        "step-00-workflow-preparation",
+        "step-14-bump-version",
+        "step-17a-compliance-verification",
+        "step-18a-analyze-feedback",
+    ] {
+        assert!(
+            composed.contains(required),
+            "MANDATORY step '{required}' missing from decomposed workflow"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`default-workflow.yaml` was 3098 LOC, 58 steps — the single hardest recipe to read, edit, or review. v3 keeps the **identical 23-step contract** but extracts each phase into its own sub-recipe brick.

| Brick | Steps | LOC |
|---|---|---|
| workflow-prep | 00–03b | 335 |
| workflow-worktree | 04 | 252 |
| workflow-design | 05–06d | 245 |
| workflow-tdd | 07–08c | 240 |
| workflow-refactor-review | 09–11b | 208 |
| workflow-precommit-test | 12–13 | 142 |
| workflow-publish | 14–16b | 342 |
| workflow-pr-review | 17a–19d | 355 |
| workflow-finalize | 20–22b + complete | 259 |
| **default-workflow** (composer) | calls all 9 | **98** |

All 9 sub-recipes and the composer fit the 400-LOC brick budget.

## Preserved verbatim

Every original step prompt, condition, output declaration, and ordering is byte-for-byte identical to v2. The user's design constraint:

> *the LLM is often wrong the first several times it does something and it is through many layers of recursion that it converges on more correct results... do not lose the fidelity of its many layers - that is what yields better results*

So no review layer, TDD step, security gate, philosophy check, zero-bs verification, or feedback round was dropped or merged. They were sliced into the brick they belong to and are still executed in identical order.

## Context flow

Sub-recipes have empty `context: {}` blocks. Inputs flow in from the parent default-workflow context via recipe-runner's automatic context-merging in `_execute_sub_recipe()`. Outputs declared by steps inside a sub-recipe propagate back into the parent context and become inputs for subsequent phase recipes — e.g. `workflow-design`'s `design_spec` output is visible to `workflow-tdd`'s step-07 prompt via `{{design_spec}}` substitution.

## Tests (`tests/integration/default_workflow_decomposition_test.rs`)

6 fast structural tests, all green:

- `composer_calls_nine_phase_subrecipes_in_order`
- `every_phase_subrecipe_loads_and_has_steps`
- `composed_step_inventory_matches_expected_in_order` — hard-coded expected list of all 58 step IDs
- `no_duplicate_step_ids_across_subrecipes`
- `every_phase_subrecipe_under_400_lines` — locks the brick rule into CI
- `mandatory_steps_still_present` — explicit assertion for steps 0/14/17/18

If a future edit drops a step, reorders the inventory, duplicates an ID, or pushes a brick over 400 LOC, CI fails before the regression ships.

## Migration / backward compat

The composer is still named `default-workflow`. All existing invocations from smart-orchestrator, `/dev`, and downstream recipes continue to work unchanged. The Rust resolver finds it by name in `amplifier-bundle/recipes/`; no manifest hash check is enforced at runtime, but `_recipe_manifest.json` is regenerated for cleanliness.

## Companion PR

#372 (separate, smaller) strengthens the TDD step prompt itself with formal-spec / property-based / error-set / trace-matrix language. That edit lives in `workflow-tdd.yaml` after both PRs land.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>