### PR TITLE
feat: simard-self-improve-cycle recipe (Phase 1 Simard rebuild)

### DIFF
--- a/amplifier-bundle/recipes/simard-self-improve-cycle.yaml
+++ b/amplifier-bundle/recipes/simard-self-improve-cycle.yaml
@@ -1,0 +1,228 @@
+name: "simard-self-improve-cycle"
+description: "Simard self-improvement cycle expressed as a deterministic agentic workflow. Replaces run_improvement_cycle() in src/self_improve/cycle.rs."
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["simard", "self-improve", "rebuild", "recipes-first"]
+
+# SIMARD_SELF_IMPROVE_CYCLE
+#
+# This recipe is the **deterministic agentic** rewrite of Simard's
+# `self_improve::cycle::run_improvement_cycle` and the proposal-loop driver
+# in `self_improve_executor::executor::run_autonomous_improvement`.
+#
+# Architecture pivot: orchestration in YAML; primitives in Rust.
+# Non-LLM phases (eval, analyze, decide) shell out to a small Rust helper
+# binary (`simard-improve-step`) that re-uses the existing functions in
+# `src/self_improve/` and `src/gym_*`. LLM phases (generate-patch, review)
+# become explicit agentic recipe steps invoking copilot/claude.
+#
+# Preserved quality gates from the Rust loop:
+#   - Pillar 11 fail-fast on gym evaluation errors
+#   - Weak-dimension detection with deficit sort + target-dimension override
+#   - "no proposed changes -> Revert" early exit
+#   - Regression detection on every dimension (tier-1/2/3 severity)
+#   - Philosophy review (PHILOSOPHY_REVIEW string) applied to every patch
+#   - Stop on critical review findings or commit failures
+#
+# Inputs (recipe context):
+#   workspace_path     (string, required)  -- repo to improve in canary
+#   suite_id           (string, required)  -- gym suite to evaluate against
+#   proposal           (string, required)  -- the improvement proposal text
+#   weak_threshold     (float,  default 0.7)
+#   target_dimension   (string, optional)  -- if set, only consider this dim weak
+#   helper_bin         (string, default "simard-improve-step")
+#
+# Outputs (final cycle JSON):
+#   cycle_json         (string)  -- a serialized ImprovementCycle struct,
+#                                    byte-equivalent to the Rust path output
+
+recursion:
+  max_depth: 4
+  max_total_steps: 20
+
+context:
+  workspace_path: "."
+  suite_id: "default"
+  proposal: ""
+  weak_threshold: 0.7
+  target_dimension: ""
+  helper_bin: "simard-improve-step"
+
+steps:
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 1: Eval -- establish baseline (Pillar 11 fail-fast)
+  # ────────────────────────────────────────────────────────────────────────
+  - id: "eval-baseline"
+    type: "bash"
+    command: |
+      {{helper_bin}} eval \
+        --workspace "{{workspace_path}}" \
+        --suite-id "{{suite_id}}"
+    on_error: "fail"
+    outputs:
+      - name: "baseline_score_json"
+        from: "stdout"
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 2: Analyze -- find weak dimensions (sorted by deficit)
+  # ────────────────────────────────────────────────────────────────────────
+  - id: "analyze-weak-dimensions"
+    type: "bash"
+    command: |
+      {{helper_bin}} analyze \
+        --baseline-json '{{baseline_score_json}}' \
+        --weak-threshold {{weak_threshold}} \
+        --target-dimension "{{target_dimension}}"
+    on_error: "fail"
+    outputs:
+      - name: "weak_dimensions_json"
+        from: "stdout"
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 3: Research -- if no proposal, short-circuit to Revert
+  # ────────────────────────────────────────────────────────────────────────
+  - id: "research-check-proposal"
+    type: "bash"
+    command: |
+      if [ -z "{{proposal}}" ] || [ "{{proposal}}" = '""' ]; then
+        echo "REVERT_NO_PROPOSAL"
+      else
+        echo "CONTINUE"
+      fi
+    outputs:
+      - name: "research_decision"
+        from: "stdout"
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 4a: Improve -- agent generates a patch from the proposal
+  # ────────────────────────────────────────────────────────────────────────
+  # This is the moment the LLM enters the loop. Today the equivalent is
+  # `generate_patch()` calling `plan_objective()` with an LLM session
+  # opened from inside Rust. Hoisting this into an explicit recipe step
+  # makes the prompt visible, tunable, and instrumentable -- it stops
+  # being a hidden coupling between Rust and the model.
+  - id: "generate-patch"
+    type: "agent"
+    condition: "{{research_decision}} == 'CONTINUE'"
+    agent: "{{agent_binary | default('copilot')}}"
+    prompt: |
+      You are working in the Simard self-improvement loop. Generate a minimal,
+      surgical patch that implements the following improvement proposal.
+
+      PROPOSAL:
+      {{proposal}}
+
+      WEAK DIMENSIONS (highest deficit first):
+      {{weak_dimensions_json}}
+
+      WORKSPACE: {{workspace_path}}
+
+      Constraints (hard):
+      - Each module must remain ≤ 400 lines after the change
+      - No panics in library code (return SimardResult)
+      - Clippy clean
+      - Every public function tested
+      - Preserve existing behavior unless the proposal explicitly changes it
+
+      Output ONLY the unified diff (one or more `diff --git` blocks).
+      Do not include prose, explanation, or fences. The output is parsed by
+      the next step and applied with `git apply`.
+    outputs:
+      - name: "patch_diff"
+        from: "stdout"
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 4b: Review -- agent reviews the patch against PHILOSOPHY
+  # ────────────────────────────────────────────────────────────────────────
+  - id: "review-patch"
+    type: "agent"
+    condition: "{{research_decision}} == 'CONTINUE'"
+    agent: "{{agent_binary | default('copilot')}}"
+    prompt: |
+      You are the Simard philosophy reviewer. Evaluate this patch.
+
+      PHILOSOPHY (mandatory):
+      Ruthless simplicity. No unnecessary abstractions. Modules under 400
+      lines. Every public function tested. Clippy clean. No panics in
+      library code.
+
+      PATCH:
+      {{patch_diff}}
+
+      Output STRICT JSON of the form:
+      {
+        "findings": [
+          {"severity": "critical|major|minor", "message": "...", "file": "..."}
+        ],
+        "should_commit": true|false
+      }
+
+      `should_commit` must be `false` if any finding has severity "critical".
+      No prose, no fences -- only the JSON object.
+    outputs:
+      - name: "review_json"
+        from: "stdout"
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 4c: Apply or rollback (deterministic, Rust)
+  # ────────────────────────────────────────────────────────────────────────
+  - id: "apply-or-rollback"
+    type: "bash"
+    condition: "{{research_decision}} == 'CONTINUE'"
+    command: |
+      {{helper_bin}} apply-or-rollback \
+        --workspace "{{workspace_path}}" \
+        --review-json '{{review_json}}' \
+        --patch-stdin <<'PATCHEOF'
+      {{patch_diff}}
+      PATCHEOF
+    outputs:
+      - name: "apply_result_json"
+        from: "stdout"
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 5: ReEval -- re-run gym suite
+  # ────────────────────────────────────────────────────────────────────────
+  - id: "reeval"
+    type: "bash"
+    condition: "{{research_decision}} == 'CONTINUE'"
+    command: |
+      {{helper_bin}} eval \
+        --workspace "{{workspace_path}}" \
+        --suite-id "{{suite_id}}"
+    on_error: "fail"
+    outputs:
+      - name: "post_score_json"
+        from: "stdout"
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 6: Decide -- compare baseline vs post, accept or revert
+  # ────────────────────────────────────────────────────────────────────────
+  - id: "decide"
+    type: "bash"
+    command: |
+      {{helper_bin}} decide \
+        --baseline-json '{{baseline_score_json}}' \
+        --post-json '{{post_score_json | default("null")}}' \
+        --weak-dimensions-json '{{weak_dimensions_json}}' \
+        --proposal "{{proposal}}" \
+        --research-decision "{{research_decision}}" \
+        --apply-result-json '{{apply_result_json | default("null")}}' \
+        --target-dimension "{{target_dimension}}"
+    on_error: "fail"
+    outputs:
+      - name: "cycle_json"
+        from: "stdout"
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Phase 7: Output -- the serialized ImprovementCycle, ready for stdout
+  # consumption by the thin Rust driver. Byte-equivalent to what
+  # `run_improvement_cycle()` returns today.
+  # ────────────────────────────────────────────────────────────────────────
+  - id: "emit-cycle"
+    type: "bash"
+    command: |
+      printf '%s\n' '{{cycle_json}}'
+    outputs:
+      - name: "final_cycle"
+        from: "stdout"


### PR DESCRIPTION
First recipe in the Simard recipes-first rebuild. Replaces the 6-phase Rust orchestration in src/self_improve/cycle.rs with 8 declarative steps (eval/analyze/research-check/generate-patch[agent]/review-patch[agent]/apply-or-rollback/reeval/decide/emit-cycle).

Conditions short-circuit downstream phases when no proposal is generated. on_error: fail enforces Pillar 11 on deterministic phases.

Companion PR: rysweet/Simard#TBD (feat/recipe-self-improve-pattern) adds:
- simard-improve-step helper bin (deterministic phases via JSON I/O)
- simard-self-improve-recipe thin driver
- 3 parity tests proving recipe path ≡ Rust path for deterministic phases

Validated with `amplihack recipe validate`.

This is Phase 1 of the architectural pivot mandated by the user: every Rust orchestration loop in Simard becomes a YAML recipe, with thin Rust bins handling deterministic primitives. Phases 2-4 will tackle engineer_loop (8337 LOC), ooda_loop, and finally remove redundant Rust orchestration.