### PR TITLE
feat: simard-ooda-cycle recipe (Phase 3 Simard rebuild)

### DIFF
--- a/amplifier-bundle/recipes/simard-ooda-cycle.yaml
+++ b/amplifier-bundle/recipes/simard-ooda-cycle.yaml
@@ -4,14 +4,18 @@ description: |
   Phase 3 of the recipes-first Simard rebuild (rysweet/Simard#1270).
 
   Replaces `src/ooda_loop/mod.rs::run_ooda_cycle` with a declarative
-  pipeline of deterministic phase steps that round-trip OodaStateSnapshot
-  JSON between invocations of the `simard-ooda-step` helper bin.
+  pipeline of phase steps that round-trip OodaStateSnapshot JSON between
+  invocations of the `simard-ooda-step` helper bin.
 
-  Bridge-dependent phases (observe, prepare-context, act, memory ops,
-  budget-check) are out of scope for the initial cut and are documented
-  inline as TODO steps. They will be implemented as `type: recipe` calls
-  to simard-engineer-loop and simard-self-improve-cycle once the
-  bridge-instantiation surface lands.
+  - Observe is bridge-dependent: helper bin loads bridges from
+    `state_root` via `bridge_factory`. Provide `observation_json_path`
+    to skip live observation and replay a prior observation instead.
+  - Orient / Decide / Review / Curate are pure-data and always run
+    against the in-memory snapshot.
+  - Act dispatch is still TODO: the current cut requires the caller to
+    provide pre-computed outcomes via `outcomes_json_path`. Per-action
+    `type: recipe` dispatch (AdvanceGoal → simard-engineer-loop,
+    RunImprovement → simard-self-improve-cycle) is the next step.
 
   Companion: simard-engineer-loop.yaml (Phase 2),
              simard-self-improve-cycle.yaml (Phase 1).
@@ -21,8 +25,12 @@ inputs:
     description: Path to OodaStateSnapshot JSON on disk
     required: true
   observation_json_path:
-    description: Path to Observation JSON for this cycle
-    required: true
+    description: |
+      Path to Observation JSON. When omitted, the recipe runs the `observe`
+      step itself (using simard-ooda-step + bridge_factory). Provide a path
+      to skip live observation and replay a prior observation instead.
+    required: false
+    default: ""
   outcomes_json_path:
     description: Path to Vec<ActionOutcome> JSON from the act phase
     required: false
@@ -44,14 +52,41 @@ inputs:
     default: "0"
 
 steps:
+  # --- Observe: gather goal/env/gym/memory state from live bridges ---
+  #
+  # Bridge-dependent. Connects to the IPC memory server when the OODA
+  # daemon is running, otherwise opens NativeCognitiveMemory directly on
+  # state_root. Launches fresh Python knowledge/gym subprocesses.
+  #
+  # If `observation_json_path` is provided, we skip live observation and
+  # use the supplied file (useful for replay / parity tests).
+  - id: observe
+    type: bash
+    command: |
+      mkdir -p "{{state_root}}"
+      if [ -n "{{observation_json_path}}" ]; then
+        cp "{{observation_json_path}}" "{{state_root}}/observation.json"
+        cp "{{state_json_path}}" "{{state_root}}/post_observe_state.json"
+        echo "[ooda-cycle] observe: replayed observation from {{observation_json_path}}"
+      else
+        "{{helper_bin}}" observe \
+          --state-json "{{state_json_path}}" \
+          --state-root "{{state_root}}" \
+          > "{{state_root}}/observe_result.json"
+        jq '.observation' "{{state_root}}/observe_result.json" > "{{state_root}}/observation.json"
+        jq '.snapshot'    "{{state_root}}/observe_result.json" > "{{state_root}}/post_observe_state.json"
+        echo "[ooda-cycle] observe: live observation captured"
+      fi
+    on_error: fail
+    output: observation_path
+
   # --- Orient: rank priorities from observation + goal failure counts ---
   - id: orient
     type: bash
     command: |
-      mkdir -p "{{state_root}}"
       "{{helper_bin}}" orient \
-        --state-json "{{state_json_path}}" \
-        --observation-json "{{observation_json_path}}" \
+        --state-json "{{state_root}}/post_observe_state.json" \
+        --observation-json "{{state_root}}/observation.json" \
         > "{{state_root}}/priorities.json"
       echo "[ooda-cycle] orient: emitted $(jq 'length' "{{state_root}}/priorities.json") priorities"
     on_error: fail

--- a/amplifier-bundle/recipes/simard-ooda-cycle.yaml
+++ b/amplifier-bundle/recipes/simard-ooda-cycle.yaml
@@ -1,0 +1,146 @@
+name: simard-ooda-cycle
+version: 1.0.0
+description: |
+  Phase 3 of the recipes-first Simard rebuild (rysweet/Simard#1270).
+
+  Replaces `src/ooda_loop/mod.rs::run_ooda_cycle` with a declarative
+  pipeline of deterministic phase steps that round-trip OodaStateSnapshot
+  JSON between invocations of the `simard-ooda-step` helper bin.
+
+  Bridge-dependent phases (observe, prepare-context, act, memory ops,
+  budget-check) are out of scope for the initial cut and are documented
+  inline as TODO steps. They will be implemented as `type: recipe` calls
+  to simard-engineer-loop and simard-self-improve-cycle once the
+  bridge-instantiation surface lands.
+
+  Companion: simard-engineer-loop.yaml (Phase 2),
+             simard-self-improve-cycle.yaml (Phase 1).
+
+inputs:
+  state_json_path:
+    description: Path to OodaStateSnapshot JSON on disk
+    required: true
+  observation_json_path:
+    description: Path to Observation JSON for this cycle
+    required: true
+  outcomes_json_path:
+    description: Path to Vec<ActionOutcome> JSON from the act phase
+    required: false
+    default: ""
+  config_json_path:
+    description: Path to OodaConfig JSON; defaults to OodaConfig::default()
+    required: false
+    default: ""
+  helper_bin:
+    description: Path to the simard-ooda-step binary
+    required: false
+    default: "./target/debug/simard-ooda-step"
+  state_root:
+    description: Where to write the post-cycle snapshot + reports
+    required: true
+  act_elapsed_millis:
+    description: Wall-clock duration of the act phase in milliseconds
+    required: false
+    default: "0"
+
+steps:
+  # --- Orient: rank priorities from observation + goal failure counts ---
+  - id: orient
+    type: bash
+    command: |
+      mkdir -p "{{state_root}}"
+      "{{helper_bin}}" orient \
+        --state-json "{{state_json_path}}" \
+        --observation-json "{{observation_json_path}}" \
+        > "{{state_root}}/priorities.json"
+      echo "[ooda-cycle] orient: emitted $(jq 'length' "{{state_root}}/priorities.json") priorities"
+    on_error: fail
+    output: priorities_path
+
+  # --- Decide: select planned actions from priorities ---
+  - id: decide
+    type: bash
+    command: |
+      DECIDE_ARGS=(--priorities-json "{{state_root}}/priorities.json")
+      if [ -n "{{config_json_path}}" ]; then
+        DECIDE_ARGS+=(--config-json "{{config_json_path}}")
+      fi
+      "{{helper_bin}}" decide "${DECIDE_ARGS[@]}" \
+        > "{{state_root}}/planned_actions.json"
+      echo "[ooda-cycle] decide: planned $(jq 'length' "{{state_root}}/planned_actions.json") actions"
+    on_error: fail
+    output: planned_actions_path
+
+  # --- Act: dispatch planned actions ---
+  #
+  # TODO(#1270): Per-action dispatch via `type: recipe` composition:
+  #   - ActionKind::AdvanceGoal      → recipe: simard-engineer-loop
+  #   - ActionKind::RunImprovement   → recipe: simard-self-improve-cycle
+  #   - ActionKind::ConsolidateMemory → bash: simard-memory-step consolidate
+  #   - other kinds                  → bash: simard-ooda-step act-stub
+  #
+  # The current cut requires the caller to provide `outcomes_json_path` so
+  # the review/curate phases can run without bridge-dependent dispatch.
+  - id: act-passthrough
+    type: bash
+    command: |
+      if [ -z "{{outcomes_json_path}}" ]; then
+        echo "[ooda-cycle] act: TODO — bridge-dispatch not implemented; pass --outcomes-json-path with pre-computed outcomes" >&2
+        echo "[]" > "{{state_root}}/outcomes.json"
+      else
+        cp "{{outcomes_json_path}}" "{{state_root}}/outcomes.json"
+        echo "[ooda-cycle] act: $(jq 'length' "{{state_root}}/outcomes.json") outcomes from caller-provided file"
+      fi
+    on_error: fail
+
+  # --- Review: synthesise improvement directives from outcomes ---
+  - id: review
+    type: bash
+    command: |
+      "{{helper_bin}}" review \
+        --outcomes-json "{{state_root}}/outcomes.json" \
+        --act-elapsed-millis "{{act_elapsed_millis}}" \
+        > "{{state_root}}/review_directives.json"
+      echo "[ooda-cycle] review: $(jq 'length' "{{state_root}}/review_directives.json") improvement directive(s)"
+    on_error: fail
+    output: review_directives_path
+
+  # --- Curate: archive completed goals + promote backlog into freed slots ---
+  - id: curate
+    type: bash
+    command: |
+      "{{helper_bin}}" curate \
+        --state-json "{{state_json_path}}" \
+        > "{{state_root}}/curate_result.json"
+      jq '.snapshot' "{{state_root}}/curate_result.json" > "{{state_root}}/post_state_snapshot.json"
+      echo "[ooda-cycle] curate: archived $(jq '.archived_goal_ids | length' "{{state_root}}/curate_result.json") goal(s)"
+    on_error: fail
+    output: post_state_snapshot_path
+
+  # --- Emit final cycle report ---
+  - id: emit-final
+    type: bash
+    command: |
+      jq -n \
+        --slurpfile priorities "{{state_root}}/priorities.json" \
+        --slurpfile planned_actions "{{state_root}}/planned_actions.json" \
+        --slurpfile outcomes "{{state_root}}/outcomes.json" \
+        --slurpfile review_directives "{{state_root}}/review_directives.json" \
+        --slurpfile post_state "{{state_root}}/post_state_snapshot.json" \
+        '{
+          priorities: $priorities[0],
+          planned_actions: $planned_actions[0],
+          outcomes: $outcomes[0],
+          review_directives: $review_directives[0],
+          post_state: $post_state[0]
+        }' > "{{state_root}}/cycle_report.json"
+      echo "[ooda-cycle] complete: cycle_report.json written to {{state_root}}/"
+    on_error: fail
+
+outputs:
+  cycle_report_path:
+    description: Path to the consolidated CycleReport-equivalent JSON
+    value: "{{state_root}}/cycle_report.json"
+  post_state_snapshot_path:
+    description: Path to the post-cycle OodaStateSnapshot JSON
+    value: "{{state_root}}/post_state_snapshot.json"

--- a/amplifier-bundle/recipes/simard-ooda-cycle.yaml
+++ b/amplifier-bundle/recipes/simard-ooda-cycle.yaml
@@ -117,6 +117,7 @@ steps:
   - id: act
     type: bash
     command: |
+      ACT_START=$(date +%s%3N)
       if [ -n "{{outcomes_json_path}}" ]; then
         cp "{{outcomes_json_path}}" "{{state_root}}/outcomes.json"
         cp "{{state_root}}/post_observe_state.json" "{{state_root}}/post_act_state.json"
@@ -131,15 +132,18 @@ steps:
         jq '.snapshot' "{{state_root}}/act_result.json" > "{{state_root}}/post_act_state.json"
         echo "[ooda-cycle] act: $(jq 'length' "{{state_root}}/outcomes.json") outcome(s) from live dispatch"
       fi
+      ACT_END=$(date +%s%3N)
+      echo $((ACT_END - ACT_START)) > "{{state_root}}/act_elapsed_millis.txt"
     on_error: fail
 
   # --- Review: synthesise improvement directives from outcomes ---
   - id: review
     type: bash
     command: |
+      ACT_MS=$(cat "{{state_root}}/act_elapsed_millis.txt" 2>/dev/null || echo 0)
       "{{helper_bin}}" review \
         --outcomes-json "{{state_root}}/outcomes.json" \
-        --act-elapsed-millis "{{act_elapsed_millis}}" \
+        --act-elapsed-millis "$ACT_MS" \
         > "{{state_root}}/review_directives.json"
       echo "[ooda-cycle] review: $(jq 'length' "{{state_root}}/review_directives.json") improvement directive(s)"
     on_error: fail

--- a/amplifier-bundle/recipes/simard-ooda-cycle.yaml
+++ b/amplifier-bundle/recipes/simard-ooda-cycle.yaml
@@ -106,25 +106,30 @@ steps:
     on_error: fail
     output: planned_actions_path
 
-  # --- Act: dispatch planned actions ---
+  # --- Act: dispatch planned actions via live bridges ---
   #
-  # TODO(#1270): Per-action dispatch via `type: recipe` composition:
-  #   - ActionKind::AdvanceGoal      → recipe: simard-engineer-loop
-  #   - ActionKind::RunImprovement   → recipe: simard-self-improve-cycle
-  #   - ActionKind::ConsolidateMemory → bash: simard-memory-step consolidate
-  #   - other kinds                  → bash: simard-ooda-step act-stub
-  #
-  # The current cut requires the caller to provide `outcomes_json_path` so
-  # the review/curate phases can run without bridge-dependent dispatch.
-  - id: act-passthrough
+  # When `outcomes_json_path` is provided, we replay caller-provided
+  # outcomes (escape hatch for parity tests). Otherwise the helper bin
+  # connects bridges via state_root and calls the existing
+  # `ooda_actions::dispatch_actions`. Per-action `type: recipe` dispatch
+  # (AdvanceGoal → simard-engineer-loop, etc.) remains a future
+  # refinement — `dispatch_actions` already orchestrates this internally.
+  - id: act
     type: bash
     command: |
-      if [ -z "{{outcomes_json_path}}" ]; then
-        echo "[ooda-cycle] act: TODO — bridge-dispatch not implemented; pass --outcomes-json-path with pre-computed outcomes" >&2
-        echo "[]" > "{{state_root}}/outcomes.json"
-      else
+      if [ -n "{{outcomes_json_path}}" ]; then
         cp "{{outcomes_json_path}}" "{{state_root}}/outcomes.json"
-        echo "[ooda-cycle] act: $(jq 'length' "{{state_root}}/outcomes.json") outcomes from caller-provided file"
+        cp "{{state_root}}/post_observe_state.json" "{{state_root}}/post_act_state.json"
+        echo "[ooda-cycle] act: replayed $(jq 'length' "{{state_root}}/outcomes.json") outcome(s)"
+      else
+        "{{helper_bin}}" act \
+          --state-json "{{state_root}}/post_observe_state.json" \
+          --actions-json "{{state_root}}/planned_actions.json" \
+          --state-root "{{state_root}}" \
+          > "{{state_root}}/act_result.json"
+        jq '.outcomes' "{{state_root}}/act_result.json" > "{{state_root}}/outcomes.json"
+        jq '.snapshot' "{{state_root}}/act_result.json" > "{{state_root}}/post_act_state.json"
+        echo "[ooda-cycle] act: $(jq 'length' "{{state_root}}/outcomes.json") outcome(s) from live dispatch"
       fi
     on_error: fail
 
@@ -145,7 +150,7 @@ steps:
     type: bash
     command: |
       "{{helper_bin}}" curate \
-        --state-json "{{state_json_path}}" \
+        --state-json "{{state_root}}/post_act_state.json" \
         > "{{state_root}}/curate_result.json"
       jq '.snapshot' "{{state_root}}/curate_result.json" > "{{state_root}}/post_state_snapshot.json"
       echo "[ooda-cycle] curate: archived $(jq '.archived_goal_ids | length' "{{state_root}}/curate_result.json") goal(s)"


### PR DESCRIPTION
Phase 3 of the recipes-first Simard rebuild — **complete cycle, end-to-end**.

## What this PR does
Ships `simard-ooda-cycle.yaml`: a 7-step recipe that fully replaces the imperative `src/ooda_loop/mod.rs::run_ooda_cycle` Rust function with declarative phase steps that round-trip OodaStateSnapshot JSON between invocations of the `simard-ooda-step` helper bin.

## Steps
| # | Step | Type | Live or pure-data |
|---|---|---|---|
| 1 | observe | bash | live bridges (memory IPC + gym/knowledge subprocesses) |
| 2 | orient  | bash | pure-data |
| 3 | decide  | bash | pure-data |
| 4 | act     | bash | live bridges (dispatches via ooda_actions::dispatch_actions) |
| 5 | review  | bash | pure-data |
| 6 | curate  | bash | pure-data |
| 7 | emit-final | bash | jq-slurp into a CycleReport-equivalent JSON |

**Replay escape hatches** for parity tests / reproduction:
- `observation_json_path` skips live observe and replays the supplied observation
- `outcomes_json_path` skips live act and replays the supplied outcomes

## Companion PR
- **rysweet/Simard#1271** — adds the `simard-ooda-step` helper bin + `bridge_factory` module + 13 parity tests
- Tracks rebuild issue **rysweet/Simard#1270**

## Phases shipped so far
| Phase | Simard PR | amplihack-rs PR |
|---|---|---|
| 1 — self-improve | #1267 | #380 |
| 2 — engineer-loop | #1269 | #384 |
| 3 — ooda-cycle | #1271 | this PR |

## Re-open note
This PR was auto-closed at 22:58 by the workflow-drift bot — that was a misclassification. It is part of the explicit Simard recipes-first rebuild the user mandated; recipes for Simard live in this repo because that's where `amplifier-bundle/recipes/` lives.