### PR TITLE
fix(quality-loop): use gh pr list-supported --json fields; per-PR fork-guard via gh pr view (#391)

### DIFF
--- a/amplifier-bundle/recipes/quality-loop.yaml
+++ b/amplifier-bundle/recipes/quality-loop.yaml
@@ -79,7 +79,7 @@ steps:
       REPO="{{repo_path}}"
       cd "$REPO"
       gh pr list --author=@me --state=open --limit 50 \
-        --json number,title,headRefName,mergeable,isDraft,authorAssociation,headRepositoryOwner,baseRepositoryOwner,statusCheckRollup,updatedAt \
+        --json number,title,headRefName,mergeable,isDraft,statusCheckRollup,updatedAt \
         | jq '
           def classify(p):
             (p.statusCheckRollup // []) as $c
@@ -118,9 +118,8 @@ steps:
         if ! [[ "$NUM" =~ ^[0-9]+$ ]]; then
           echo "drive-green-prs-to-merge: invalid PR number '$NUM'" >&2; exit 1
         fi
-        ASSOC="$(printf '%s' "$pr" | jq -r '.authorAssociation')"
-        HEAD_OWNER="$(printf '%s' "$pr" | jq -r '.headRepositoryOwner.login // ""')"
-        BASE_OWNER="$(printf '%s' "$pr" | jq -r '.baseRepositoryOwner.login // ""')"
+        PR_META="$(gh pr view "$NUM" --json authorAssociation,headRepositoryOwner,baseRepositoryOwner)"
+        IFS=$'\t' read -r ASSOC HEAD_OWNER BASE_OWNER <<<"$(printf '%s' "$PR_META" | jq -r '[.authorAssociation,(.headRepositoryOwner.login // ""),(.baseRepositoryOwner.login // "")] | @tsv')"
         case "$ASSOC" in
           OWNER|MEMBER|COLLABORATOR) ;;
           *) SKIPPED+=("$NUM:assoc=$ASSOC"); continue ;;


### PR DESCRIPTION
Closes #391

The survey-open-prs step requested authorAssociation, headRepositoryOwner, and baseRepositoryOwner from 'gh pr list --json', but those fields are only supported by 'gh pr view --json'. The recipe failed immediately with 'Unknown JSON field: authorAssociation'.

Changes (single file: amplifier-bundle/recipes/quality-loop.yaml):

1. survey-open-prs: trim gh pr list --json to the 7 supported fields: number,title,headRefName,mergeable,isDraft,statusCheckRollup,updatedAt.
2. drive-green-prs-to-merge: fetch fork-guard metadata per-PR via gh pr view inside the merge loop, before the merge attempt. Skip semantics preserved verbatim (skip if association not in {OWNER,MEMBER,COLLABORATOR} or head/base owners differ).

Invariants preserved:
- set -euo pipefail + IFS on every bash step
- No silent fallbacks (no || true, no 2>/dev/null, no set +e, no defaults on guard verdicts)
- File is 499 lines (within 500 cap)
- YAML parses cleanly
- pr_survey schema unchanged