### PR TITLE
fix(quality-loop): drop parse_json on survey-open-prs so downstream jq receives raw JSON (#393)

### DIFF
--- a/amplifier-bundle/recipes/quality-loop.yaml
+++ b/amplifier-bundle/recipes/quality-loop.yaml
@@ -72,7 +72,6 @@ steps:
     output: "refresh_status"
   - id: "survey-open-prs"
     type: "bash"
-    parse_json: true
     command: |
       set -euo pipefail
       IFS=$'\n\t'


### PR DESCRIPTION
## Summary

Removes `parse_json: true` from the `survey-open-prs` step in `amplifier-bundle/recipes/quality-loop.yaml`.

## Defect

When `parse_json: true` is set, the recipe runner parses the `jq` stdout into a structured value and then re-serializes it as a JSON string literal on `{{pr_survey}}` substitution. The four downstream consumers use:

```bash
printf '%s' '{{pr_survey}}' | jq -c '.green'
```

…and fail with `jq: error … Cannot index string with string "green"` because they receive a JSON-encoded string instead of a raw JSON object.

## Fix

Single-line deletion. The raw `jq` stdout is already valid JSON text and is now substituted verbatim, so downstream `jq` pipelines work as intended.

## Verification

- `wc -l` → 498 (≤500 budget)
- `yaml.safe_load` → OK
- `git diff --stat` → 1 file, 1 deletion
- All four downstream consumers (`drive-green-prs-to-merge`, `triage-stale-prs`, `drive-red-prs-to-fix`, `update-plan`) unchanged; they already use the `printf '%s' '{{pr_survey}}' | jq` pattern that requires raw JSON.

Closes #393