### PR TITLE
fix(quality-loop): drop outer single quotes around {{pr_survey}} so render_shell env-var ref expands (#393)

### DIFF
--- a/amplifier-bundle/recipes/quality-loop.yaml
+++ b/amplifier-bundle/recipes/quality-loop.yaml
@@ -102,7 +102,7 @@ steps:
       REPO="{{repo_path}}"
       cd "$REPO"
       ADMIN_MERGE="{{admin_merge}}"
-      GREEN_JSON="$(printf '%s' '{{pr_survey}}' | jq -c '.green')"
+      GREEN_JSON="$(printf '%s' {{pr_survey}} | jq -c '.green')"
       MERGED=()
       SKIPPED=()
       COUNT=0
@@ -144,7 +144,7 @@ steps:
     command: |
       set -euo pipefail
       IFS=$'\n\t'
-      printf '%s' '{{pr_survey}}' \
+      printf '%s' {{pr_survey}} \
         | jq -r '
           [ .stale[] | "  - PR #\(.number): \(.title) (updated \(.updatedAt))" ]
           | (["triage-stale-prs:"] + .) | join("\n")'
@@ -157,7 +157,7 @@ steps:
       IFS=$'\n\t'
       REPO="{{repo_path}}"
       cd "$REPO"
-      RED_JSON="$(printf '%s' '{{pr_survey}}' | jq -c '.red')"
+      RED_JSON="$(printf '%s' {{pr_survey}} | jq -c '.red')"
       DISPATCHED=()
       COUNT=0
       CAP=10
@@ -476,7 +476,7 @@ steps:
       DESIGN_LINE="$(verdict_line "{{coe_design}}")"
       AUDIT_LINE="$(verdict_line "{{audit_verdict_out}}")"
       DIFF_LINE="$(verdict_line "{{coe_diff_out}}")"
-      STALE_REMAINING="$(printf '%s' '{{pr_survey}}' | jq '[.stale[].number]')"
+      STALE_REMAINING="$(printf '%s' {{pr_survey}} | jq '[.stale[].number]')"
       jq -n \
         --arg merged "$MERGED" \
         --arg dispatched "$DISPATCHED" \


### PR DESCRIPTION
## Summary

Fixes #393. The `quality-loop` recipe wrapped `{{pr_survey}}` in outer single quotes at 4 call sites. The recipe runner's `render_shell` substitutes `{{var}}` outside heredocs with `"$RECIPE_VAR_var"` (already double-quoted). The outer single quotes literalized the env-var reference, so `jq` received the literal text `$RECIPE_VAR_pr_survey` instead of the JSON, failing with `Cannot index string with string "green"`.

## Change

Surgical removal of outer single quotes around `{{pr_survey}}` at lines 105, 147, 160, 479 of `amplifier-bundle/recipes/quality-loop.yaml`. Nothing else touched.

## Verification

- `grep -c "'{{pr_survey}}'" amplifier-bundle/recipes/quality-loop.yaml` → `0`
- `wc -l` → `498` (unchanged, ≤500)
- `git diff --stat` → 1 file, 4 insertions(+), 4 deletions(-)
- `set -euo pipefail` and `IFS=$'\n\t'` preserved on every bash step
- No `|| true`, no `2>/dev/null`, no `${VAR:-default}` introduced
- `survey-open-prs` step unchanged

## Security

No new inputs, privileges, or secrets. Post-fix substitution relies on render_shell's double-quoted env-var expansion (no word-splitting / glob / metacharacter risk). `pr_survey` originates from trusted internal `gh pr list` JSON; `jq` parses (does not eval).

Closes #393
