### PR TITLE
fix(default-workflow): step-08c no-op-guard inspects worktree HEAD not orchestrator CWD (#379)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -1031,13 +1031,47 @@ steps:
         # Soft-warn rather than hard-fail to remain backward-compatible with
         # agents that ignore the schema. The git-diff guard below is the hard gate.
       fi
-      # Check git diff in the worktree as the source of truth.
-      : "${WORKTREE_SETUP_WORKTREE_PATH:?WORKTREE_SETUP_WORKTREE_PATH is required (set by step-04-setup-worktree). If this step ran without it, step-04 was skipped — fix the upstream gap rather than substituting a default (philosophy: no silent fallbacks).}"
-      cd "$WORKTREE_SETUP_WORKTREE_PATH"
-      if ! git diff --quiet || ! git diff --cached --quiet || \
-         [ -n "$(git ls-files --others --exclude-standard)" ]; then
-        echo "step-08 produced file changes — guard passed."
+      # Check git state in the WORKTREE as the source of truth.
+      #
+      # Issue #379: step-08 (the implementer) commits inside the feature
+      # worktree at $WORKTREE_SETUP_WORKTREE_PATH. After it commits, the
+      # working tree is clean — so a working-tree-only check falsely aborts
+      # even though worktree HEAD has advanced and CI on the pushed branch
+      # is green (repro: PR #378). Inspect committed changes too, scoped via
+      # `git -C "$WORKTREE_PATH"` rather than the orchestrator's CWD.
+      WORKTREE_PATH="${WORKTREE_SETUP_WORKTREE_PATH:-}"
+      if [ -z "$WORKTREE_PATH" ]; then
+        echo "[step-08c][warn] WORKTREE_SETUP_WORKTREE_PATH is unset; falling" >&2
+        echo "[step-08c][warn] back to orchestrator CWD ($PWD). step-04 should" >&2
+        echo "[step-08c][warn] normally populate worktree_path. See #379." >&2
+        WORKTREE_PATH="."
+      fi
+      # 1) Uncommitted work in the worktree.
+      if ! git -C "$WORKTREE_PATH" diff --quiet || \
+         ! git -C "$WORKTREE_PATH" diff --cached --quiet || \
+         [ -n "$(git -C "$WORKTREE_PATH" ls-files --others --exclude-standard)" ]; then
+        echo "step-08 produced uncommitted file changes in $WORKTREE_PATH — guard passed."
         exit 0
+      fi
+      # 2) Committed work in the worktree (issue #379). Resolve a base ref
+      #    so we count only commits introduced on this branch. Prefer
+      #    origin/main..HEAD; fall back to HEAD~1..HEAD only if needed.
+      BASE_REF=""
+      if git -C "$WORKTREE_PATH" rev-parse --verify --quiet origin/main >/dev/null; then
+        BASE_REF=$(git -C "$WORKTREE_PATH" merge-base HEAD origin/main)
+      elif git -C "$WORKTREE_PATH" rev-parse --verify --quiet HEAD~1 >/dev/null; then
+        BASE_REF="HEAD~1"
+      fi
+      if [ -n "$BASE_REF" ]; then
+        NEW_COMMITS=$(git -C "$WORKTREE_PATH" log --oneline "${BASE_REF}..HEAD" | wc -l | tr -d ' ')
+        if [ "$NEW_COMMITS" -gt 0 ]; then
+          DIFF_STAT=$(git -C "$WORKTREE_PATH" diff --stat "${BASE_REF}..HEAD")
+          if [ -n "$DIFF_STAT" ]; then
+            echo "step-08 produced ${NEW_COMMITS} commit(s) in worktree $WORKTREE_PATH (vs ${BASE_REF}) — guard passed."
+            printf '%s\n' "$DIFF_STAT"
+            exit 0
+          fi
+        fi
       fi
       if [ -n "$JUSTIFICATION" ]; then
         echo "step-08 produced no file changes but declared a no-op justification:" >&2
@@ -1095,8 +1129,8 @@ steps:
       echo "condition, almost certainly caused by prompt-misalignment — see" >&2
       echo "https://github.com/rysweet/amplihack-rs/issues/251." >&2
       echo "" >&2
-      echo "Working directory: $PWD" >&2
-      git --no-pager status >&2
+      echo "Worktree path: $WORKTREE_PATH (orchestrator CWD: $PWD)" >&2
+      git -C "$WORKTREE_PATH" --no-pager status >&2
       exit 1
     output: "implementation_noop_guard"
 


### PR DESCRIPTION
## Summary

Fixes #379. The `step-08c-implementation-no-op-guard` in `amplifier-bundle/recipes/default-workflow.yaml` previously inspected only working-tree state inside the feature worktree (`git diff` / `--cached` / `ls-files --others`). When step-08 (the implementer) **commits** its changes inside the worktree, the working tree is clean post-commit — so the guard reported "ZERO file changes" and aborted the workflow even though:

- The worktree HEAD had advanced with real commits.
- The branch was pushed and CI was green (repro: PR #378; same false-positive blocked iter4 quality-loop drive-red on PR #377).

The orchestrator's CWD never sees those commits because they live on the feature branch in the worktree, not on the orchestrator's main HEAD.

## Fix

- All diff/log inspection is now scoped to the worktree via `git -C "$WORKTREE_PATH"`.
- Added a committed-changes check using `origin/main..HEAD` (with `HEAD~1..HEAD` fallback when origin/main isn't resolvable) — counts new commits and verifies non-empty diff stat.
- Working-tree check preserved for the pre-commit case (back-compat).
- When `WORKTREE_SETUP_WORKTREE_PATH` is unset (legacy callers without step-04 worktree setup), emit a clear `[step-08c][warn]` line and fall back to inspecting the orchestrator CWD instead of hard-failing.

## Constraints honored

- `set -euo pipefail` preserved.
- No `|| true`, no `2>/dev/null` introduced on diff/log checks (fail-loud).
- Genuine no-op (no commits + clean worktree + no justification + no merged-PR for the issue) STILL triggers the guard and aborts.
- Single file modified; single commit.

## Test plan

- YAML parses (`python3 -c "yaml.safe_load(...)"`).
- Extracted bash command passes `bash -n` syntax check.
- Logic walkthrough:
  - Implementer commits in worktree → step 1 (working tree clean) skipped → step 2 finds N≥1 new commits with non-empty diff → exit 0 ✅
  - Implementer makes no commits, no edits → step 1 skipped → step 2 finds 0 new commits (origin/main..HEAD is empty) → falls through to no-op-justification + issue-merged checks → aborts as before ✅
  - Implementer leaves staged/untracked files (no commit) → step 1 fires → exit 0 ✅
  - WORKTREE_SETUP_WORKTREE_PATH unset → warning emitted, falls back to CWD inspection ✅

Closes #379.
