### PR TITLE
fix(default-workflow): step-04 SIGPIPE — read git worktree list before piping to awk (#397)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -487,7 +487,12 @@ steps:
         #   (b) else use REPO_PATH if it is itself checked out on the branch
         #   (c) else attach a new worktree at REPO_PATH/worktrees/<branch>
         WORKTREE_PATH=""
-        EXISTING_WT="$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH_NAME" '
+        # Buffer git output into a variable before piping to awk. Without this,
+        # awk's early `exit` closes the pipe and `git worktree list --porcelain`
+        # is killed by SIGPIPE, causing the pipeline to return 141 under
+        # `set -euo pipefail`. See issue #397.
+        WT_LIST="$(git worktree list --porcelain)"
+        EXISTING_WT="$(printf '%s\n' "$WT_LIST" | awk -v b="refs/heads/$BRANCH_NAME" '
           $1=="worktree" { wt=$2 }
           $1=="branch" && $2==b { print wt; exit }
         ')"


### PR DESCRIPTION
## Summary

Fixes step-04-setup-worktree exiting 141 (SIGPIPE) when invoked against an existing branch.

## Root cause

The pipeline:

```bash
EXISTING_WT="$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH_NAME" '
  $1=="worktree" { wt=$2 }
  $1=="branch" && $2==b { print wt; exit }
')"
```

runs under `set -euo pipefail`. When awk hits its early `exit`, it closes the pipe, `git worktree list --porcelain` is killed by SIGPIPE, and the pipeline returns 141 — failing the entire step.

## Fix

Buffer the git output into a variable first, then feed it through a `printf | awk` pipeline. The producer (printf in a subshell) fully writes its output before awk's exit, eliminating the SIGPIPE race.

```bash
WT_LIST="$(git worktree list --porcelain)"
EXISTING_WT="$(printf '%s\n' "$WT_LIST" | awk -v b="refs/heads/$BRANCH_NAME" '
  $1=="worktree" { wt=$2 }
  $1=="branch" && $2==b { print wt; exit }
')"
```

## Verification

- `grep -n 'git.*|.*awk' amplifier-bundle/recipes/default-workflow.yaml` → no matches
- `set -euo pipefail` preserved in the touched shell block
- No `|| true` or `2>/dev/null` introduced (zero-BS philosophy)
- Single-file, single-commit change

Closes #397.