### PR TITLE
fix(quality-loop): capture new PR from sub-recipe output not gh pr list timing (#387)

### DIFF
--- a/amplifier-bundle/recipes/quality-loop.yaml
+++ b/amplifier-bundle/recipes/quality-loop.yaml
@@ -298,12 +298,11 @@ steps:
     command: |
       set -euo pipefail
       IFS=$'\n\t'
-      REPO="{{repo_path}}"
-      cd "$REPO"
-      NEW_PR="$(gh pr list --author=@me --state=open --limit 5 \
-        --json number,createdAt | jq -r 'sort_by(.createdAt) | reverse | .[0].number // empty')"
-      [[ "$NEW_PR" =~ ^[0-9]+$ ]] || { echo "capture-new-pr: could not determine new PR number ('$NEW_PR')" >&2; exit 1; }
-      printf '%s' "$NEW_PR"
+      PR_URL={{implement_result.pr_url}}
+      [[ -n "$PR_URL" ]] || { echo "capture-new-pr: implement_result.pr_url is empty; sub-recipe did not produce a PR URL" >&2; exit 1; }
+      pr_number=$(printf '%s' "$PR_URL" | sed -E 's@.*/pull/([0-9]+).*@\1@')
+      [[ "$pr_number" =~ ^[0-9]+$ ]] || { echo "capture-new-pr: could not parse PR number from URL '$PR_URL'" >&2; exit 1; }
+      printf '%s' "$pr_number"
     output: "new_pr_number"
   - id: "quality-audit"
     type: "bash"


### PR DESCRIPTION
## Summary

Replaces the timing-based heuristic in the `capture-new-pr` step of `quality-loop.yaml` with structural extraction from the dispatched `default-workflow` sub-recipe's declared `pr_url` output.

## Defect (Issue #387)

Previously `capture-new-pr` ran:
```
gh pr list --author=@me --state=open --limit 5 --json number,createdAt | jq ...
```
and returned the newest PR. Under concurrent loop execution (or any unrelated PR activity from the same user), this could capture the wrong PR.

## Fix

`default-workflow` already declares a top-level `pr_url` output. The dispatch step `implement-via-default-workflow` binds its result to `implement_result`. So we read `{{implement_result.pr_url}}` directly:

```yaml
command: |
  set -euo pipefail
  IFS=$'\\n\\t'
  PR_URL={{implement_result.pr_url}}
  [[ -n "$PR_URL" ]] || { echo "capture-new-pr: implement_result.pr_url is empty; sub-recipe did not produce a PR URL" >&2; exit 1; }
  pr_number=$(printf '%s' "$PR_URL" | sed -E 's@.*/pull/([0-9]+).*@\\1@')
  [[ "$pr_number" =~ ^[0-9]+$ ]] || { echo "capture-new-pr: could not parse PR number from URL '$PR_URL'" >&2; exit 1; }
  printf '%s' "$pr_number"
```

## Guarantees

- No silent fallbacks: empty or unparseable URL → exit 1 with stderr diagnostic.
- No regression of #393: `{{implement_result.pr_url}}` is **bare** (no surrounding single quotes); render_shell already double-quotes the env-var ref.
- File still <=500 lines (now 497).
- `set -euo pipefail` preserved.
- Downstream contract preserved: `output: "new_pr_number"` still emits the numeric PR ID consumed by `quality-audit`.

Closes #387