### PR TITLE
fix(smart-orchestrator): negative anchors + path-existence check to prevent scope drift (#381)

### DIFF
--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -126,6 +126,12 @@ steps:
         items `(1)`, `(2)`, `(3)` are almost always Development.
       - When in doubt between Operations and Development, choose Development.
 
+      **Scope anchors (#381)**:
+      - The repository is whatever `repo_path` resolves to. Do NOT invent file paths from project names mentioned in conversational context.
+      - If the task description names a specific file path (e.g., `amplifier-bundle/recipes/quality-loop.yaml`), the workstream description MUST cite that exact path verbatim.
+      - Do NOT propose writes to directories that do not exist in `repo_path`.
+      - If the task names a project unfamiliar to you (e.g., "Simard", "Foo"), do NOT translate file paths through that name. The repository's directory structure is the only source of truth.
+
       **Decomposition override**: {{force_single_workstream}} — if "true", use exactly 1 workstream regardless of task structure.
 
       **Output exactly this JSON**:
@@ -184,6 +190,36 @@ steps:
       fi
       echo "$FINAL_TYPE"
     output: "task_type"
+
+  # verify-decomposition-paths (#381): fail-fast if the decomposition references
+  # file paths whose parent directory does not exist in repo_path. This blocks
+  # scope-drift bugs where the architect invents paths from conversational
+  # context (e.g., a phantom 'Simard' project's src/self_improve/cycle.rs).
+  # Gated to Development/Investigation — Q&A and Operations have no workstreams.
+  - id: "verify-decomposition-paths"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      if [ "$TASK_TYPE" != "Development" ] && [ "$TASK_TYPE" != "Investigation" ]; then
+        echo "[verify-decomposition-paths] task_type=$TASK_TYPE — skipping (no workstreams to verify)."
+        exit 0
+      fi
+      cd "$REPO_PATH"
+      TRACKED_DIRS=$(git ls-files | xargs -n1 dirname | sort -u)
+      CANDIDATES=$(printf '%s' "$DECOMPOSITION_JSON" \
+        | jq -r '.workstreams[].description' \
+        | grep -oE '[A-Za-z0-9_./-]+\.(rs|ya?ml|toml|md|py|sh|json)' \
+        | sort -u || true)
+      for P in $CANDIDATES; do
+        case "$P" in */*) ;; *) continue ;; esac
+        PARENT=$(dirname "$P")
+        if [ "$PARENT" = "." ]; then continue; fi
+        if printf '%s\n' "$TRACKED_DIRS" | grep -qxF "$PARENT"; then continue; fi
+        if [ -d "$PARENT" ]; then continue; fi
+        echo "ERROR: planned path '$P' has no parent directory in repo." >&2
+        exit 1
+      done
+      echo "[verify-decomposition-paths] OK — all candidate paths have valid parent directories."
 
   # activate-workflow: compute workstream_count, set workflow semaphore, announce.
   # Uses native Rust `amplihack orch helper count-workstreams` (#270). The


### PR DESCRIPTION
## Summary

Fixes scope-drift in smart-orchestrator's classify-and-decompose step where verbose task descriptions referencing concepts from prior conversational context (e.g., a project name 'Simard') would cause the architect agent to invent file paths that do not exist in `repo_path`. Canonical reproduction: PR #380, which created `src/self_improve/cycle.rs`, a `simard-improve-step` binary, and `gym_*` modules in amplihack-rs, where none of those directories or projects exist. The user's task explicitly named amplihack-rs files (`amplifier-bundle/recipes/quality-loop.yaml`).

## Changes

Single file: `amplifier-bundle/recipes/smart-orchestrator.yaml` (959 → 995 lines, +36).

### 1. Prompt anchors in `classify-and-decompose`
Adds a 'Scope anchors (#381)' block to the architect prompt before the 'Decomposition override' line:
- Repository is whatever `repo_path` resolves to — do not invent paths from conversational context.
- If the task names a specific file path, the workstream description must cite that exact path verbatim.
- Do not propose writes to directories that do not exist in `repo_path`.
- Do not translate file paths through unfamiliar project names ('Simard', 'Foo' named explicitly).

### 2. New `verify-decomposition-paths` bash step
Inserted between `parse-decomposition` and `activate-workflow`. Runtime guard that:
- Skips for Q&A / Operations (no workstreams to verify).
- Extracts file-path candidates from `.workstreams[].description` (tokens that contain a `/` AND end in `.rs|.ya?ml|.toml|.md|.py|.sh|.json`) — version strings like `1.0.42` and bare filenames like `Cargo.toml` are filtered out by design.
- For each candidate, checks the parent directory against (a) git ls-files dirnames and (b) on-disk dirs. Fails fast with `ERROR: planned path '<P>' has no parent directory in repo.` on first miss.

Preserves `set -euo pipefail`, uses env-var form (`$REPO_PATH`, `$DECOMPOSITION_JSON`, `$TASK_TYPE`) per #393 / #395 conventions. `|| true` only on the candidate-extraction pipeline (empty match is legitimate). #396 fix untouched.

## Acceptance

1. ✅ Prompt has explicit negative anchors against phantom paths and unfamiliar project names.
2. ✅ Verification step exits non-zero when planned path lacks parent directory in repo.
3. ✅ Quality-loop task → workstream targeting `amplifier-bundle/recipes/quality-loop.yaml` (exists, passes); phantom Simard paths (`src/self_improve/cycle.rs`) → check fails.
4. ✅ File grew by 36 lines, within budget.

Closes #381