### PR TITLE
fix(quality-loop): handle gh issue comments as array

### DIFF
--- a/amplifier-bundle/recipes/quality-loop.yaml
+++ b/amplifier-bundle/recipes/quality-loop.yaml
@@ -205,7 +205,7 @@ steps:
         | jq '
           def n(l): (l // []) | map(.name);
           def score(i):
-            (n(i.labels)) as $L | (i.comments // 0) as $c
+            (n(i.labels)) as $L | ((i.comments // []) | length) as $c
             | (if any($L[]; . == "priority:high" or . == "P0" or . == "critical") then 100 else 0 end)
             + (if any($L[]; . == "priority:medium" or . == "P1") then 50 else 0 end)
             + (if any($L[]; . == "bug") then 30 else 0 end)
@@ -213,7 +213,7 @@ steps:
             + (if any($L[]; . == "good first issue" or . == "easy") then 20 else 0 end)
             + (if any($L[]; . == "epic" or . == "large") then -30 else 0 end)
             + ($c * 2);
-          { ranked: [ .[] | { number, title, labels: n(.labels), comments: (.comments // 0), score: score(.) } ] | sort_by(-.score) }'
+          { ranked: [ .[] | { number, title, labels: n(.labels), comments: ((.comments // []) | length), score: score(.) } ] | sort_by(-.score) }'
     output: "issue_survey"
   - id: "select-next-task"
     type: "bash"


### PR DESCRIPTION
## Bug
`survey-open-issues` failed at iter5 with:
```
jq: error (at <stdin>:1): array ([]) and number (2) cannot be multiplied
```

`gh issue list --json comments` returns the comments **array**, not a count, so `(.comments // 0) * 2` blows up when there are zero or more comments.

## Fix
Derive the count via `((.comments // []) | length)` both in the score() helper and in the projected output.

## Test
Verified locally:
```
gh issue list --author=@me --state=open --limit 100 --json number,title,labels,comments,createdAt,updatedAt | jq ...  # works
```

This unblocks the loop's survey→select→dispatch chain.