### PR TITLE
fix(tests): point step04_body at workflow-worktree.yaml after #404 (Fixes #407)

### DIFF
--- a/tests/integration/existing_branch_context_test.rs
+++ b/tests/integration/existing_branch_context_test.rs
@@ -45,6 +45,10 @@ fn default_workflow_yaml() -> PathBuf {
     workspace_root().join("amplifier-bundle/recipes/default-workflow.yaml")
 }
 
+fn workflow_worktree_yaml() -> PathBuf {
+    workspace_root().join("amplifier-bundle/recipes/workflow-worktree.yaml")
+}
+
 fn consensus_workflow_yaml() -> PathBuf {
     workspace_root().join("amplifier-bundle/recipes/consensus-workflow.yaml")
 }
@@ -337,7 +341,7 @@ fn consensus_workflow_declares_pr_number_context_var() {
 
 fn step04_body() -> String {
     extract_step_body(
-        &load_recipe(&default_workflow_yaml()),
+        &load_recipe(&workflow_worktree_yaml()),
         "step-04-setup-worktree",
     )
 }


### PR DESCRIPTION
## Summary

Fixes #407 — 8 failing test cases (actually 12 sharing same root cause) in `tests/integration/existing_branch_context_test.rs`.

## Root Cause

PR #404 decomposed the monolithic workflow and relocated `step-04-setup-worktree` from `default-workflow.yaml` to `workflow-worktree.yaml`. The test helper `step04_body()` still loaded from `default-workflow.yaml`, so `extract_step_body` panicked when looking up the moved step ID.

## Fix

Test-only change:
- Add `workflow_worktree_yaml()` path helper alongside `default_workflow_yaml()`
- Switch `step04_body()` to load from `workflow-worktree.yaml`
- Context-declaration tests still load `default-workflow.yaml` (context vars remain at workflow scope)

No production code, recipe YAML, or Cargo.toml changes.

## Verification

```
TMPDIR=/tmp cargo test -p amplihack --test existing_branch_context  # 18/18 green
cargo clippy --workspace --all-targets -- -D warnings                # clean
```

Pre-existing unrelated failures in `amplihack-cli update::tests` exist on main and are out of scope.

Fixes #407