### PR TITLE
fix(phase-bricks): declare worktree_setup outputs as required inputs (#414)

### DIFF
--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -16,6 +16,15 @@ recursion:
   max_depth: 6
   max_total_steps: 80
 
+# Required upstream outputs consumed by bash steps in this brick.
+# Documents the recipe-boundary contract; future compose-time validation
+# in amplihack-recipe-runner will hook here. See issue #414.
+inputs:
+  - name: worktree_setup.worktree_path
+    description: "Absolute path to the per-task worktree produced by workflow-worktree (step-04). Required by bash steps in step-20b-push-cleanup and step-21-pr-ready that cd into the worktree."
+  - name: repo_path
+    description: "Absolute path to the repository root. Required by step-22b-final-status that runs the final status report against the parent repo."
+
 context: {}
 
 steps:
@@ -53,10 +62,15 @@ steps:
   - id: "step-20b-push-cleanup"
     type: "bash"
     command: |
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
-      echo "=== Pushing Cleanup Changes ===" && \
-      git add -A && \
-      git diff --cached --quiet || (git commit -m "final cleanup pass" && git pull --rebase 2>/dev/null && git push) && \
+      set -euo pipefail
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-20b-push-cleanup requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      echo "=== Pushing Cleanup Changes ==="
+      git add -A
+      if ! git diff --cached --quiet; then
+        git commit -m "final cleanup pass"
+        git pull --rebase 2>/dev/null
+        git push
+      fi
       echo "=== Cleanup Complete ==="
     output: "cleanup_push_result"
 
@@ -138,15 +152,16 @@ steps:
   - id: "step-21-pr-ready"
     type: "bash"
     command: |
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
-      echo "=== Step 20: Converting PR to Ready ===" && \
-      echo "" && \
-      echo "--- Verifying All Steps Complete ---" && \
-      echo "" && \
-      echo "--- Converting PR to Ready ---" && \
-      gh pr ready && \
-      echo "" && \
-      echo "--- Adding Ready Comment ---" && \
+      set -euo pipefail
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-21-pr-ready requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      echo "=== Step 20: Converting PR to Ready ==="
+      echo ""
+      echo "--- Verifying All Steps Complete ---"
+      echo ""
+      echo "--- Converting PR to Ready ---"
+      gh pr ready
+      echo ""
+      echo "--- Adding Ready Comment ---"
       gh pr comment --body "## Ready for Final Review
 
       All workflow steps completed:
@@ -159,8 +174,8 @@ steps:
       - [x] Final cleanup complete
       - [x] Quality audit passed
 
-      Ready for merge approval." && \
-      echo "" && \
+      Ready for merge approval."
+      echo ""
       echo "=== PR Marked Ready ==="
     output: "pr_ready_result"
 
@@ -198,20 +213,21 @@ steps:
   - id: "step-22b-final-status"
     type: "bash"
     command: |
-      cd "$REPO_PATH" && \
-      echo "=== WORKFLOW COMPLETE ===" && \
-      echo "" && \
-      echo "PR Status:" && \
-      gh pr view --json state,mergeable,reviews,statusCheckRollup && \
-      echo "" && \
+      set -euo pipefail
+      cd "${REPO_PATH:?step-22b-final-status requires repo_path; ensure parent recipe propagated repo_path context}"
+      echo "=== WORKFLOW COMPLETE ==="
+      echo ""
+      echo "PR Status:"
+      gh pr view --json state,mergeable,reviews,statusCheckRollup
+      echo ""
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
-      TASK_DESC="$TASK_DESCRIPTION" && \
-      ISSUE_NUMBER="$ISSUE_NUMBER" && \
-      PR_URL="$PR_URL" && \
-      printf '=== Task: %s ===\n' "$TASK_DESC" && \
-      printf '=== Issue: #%s ===\n' "$ISSUE_NUMBER" && \
-      printf '=== PR: %s ===\n' "$PR_URL" && \
-      echo "" && \
+      TASK_DESC="$TASK_DESCRIPTION"
+      ISSUE_NUMBER="$ISSUE_NUMBER"
+      PR_URL="$PR_URL"
+      printf '=== Task: %s ===\n' "$TASK_DESC"
+      printf '=== Issue: #%s ===\n' "$ISSUE_NUMBER"
+      printf '=== PR: %s ===\n' "$PR_URL"
+      echo ""
       echo "All 23 workflow steps completed successfully."
     output: "final_status"
 

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -16,6 +16,13 @@ recursion:
   max_depth: 6
   max_total_steps: 80
 
+# Required upstream outputs consumed by bash steps in this brick.
+# Documents the recipe-boundary contract; future compose-time validation
+# in amplihack-recipe-runner will hook here. See issue #414.
+inputs:
+  - name: worktree_setup.worktree_path
+    description: "Absolute path to the per-task worktree produced by workflow-worktree (step-04). Required by bash steps in step-18c-push-feedback-changes and step-19c-zero-bs-verification that cd into the worktree."
+
 context: {}
 
 steps:
@@ -204,24 +211,26 @@ steps:
   - id: "step-18c-push-feedback-changes"
     type: "bash"
     command: |
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
-      echo "=== Pushing Review Feedback Changes ===" && \
-      git add -A && \
-      if [ -n "$(git diff --cached --name-only)" ]; then \
+      set -euo pipefail
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-18c-push-feedback-changes requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      echo "=== Pushing Review Feedback Changes ==="
+      git add -A
+      if [ -n "$(git diff --cached --name-only)" ]; then
         git commit -m "address review feedback
 
       - Implemented reviewer suggestions
       - Fixed identified issues
       - Updated per security review
-      - Addressed philosophy compliance items" ; \
-      else \
-        echo "WARNING: Nothing to commit - feedback changes already committed" ; \
-      fi && \
-      if git rev-list --count @{u}..HEAD 2>/dev/null | grep -qv '^0$'; then \
-        git pull --rebase 2>/dev/null && git push ; \
-      else \
-        echo "WARNING: Nothing to push - branch is up to date with remote" ; \
-      fi && \
+      - Addressed philosophy compliance items"
+      else
+        echo "WARNING: Nothing to commit - feedback changes already committed"
+      fi
+      if git rev-list --count @{u}..HEAD 2>/dev/null | grep -qv '^0$'; then
+        git pull --rebase 2>/dev/null
+        git push
+      else
+        echo "WARNING: Nothing to push - branch is up to date with remote"
+      fi
       echo "=== Changes Pushed ==="
     output: "feedback_push_result"
 
@@ -299,25 +308,26 @@ steps:
   - id: "step-19c-zero-bs-verification"
     type: "bash"
     command: |
-      echo "=== ZERO-BS VERIFICATION ===" && \
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" && \
-      echo "" && \
-      echo "Scanning for Zero-BS violations..." && \
-      echo "" && \
-      echo "--- Checking for TODO/FIXME comments ---" && \
-      (grep -r -E "(TODO|FIXME)" --include="*.py" --include="*.ts" --include="*.js" . 2>/dev/null || echo "None found") && \
-      echo "" && \
-      echo "--- Checking for stub indicators ---" && \
-      (grep -r -E "(NotImplementedError|raise NotImplemented|pass  # stub)" --include="*.py" . 2>/dev/null || echo "None found") && \
-      echo "" && \
-      echo "--- Checking for Forbidden Patterns ---" && \
-      echo "  Shell: || true, >/dev/null 2>&1, set +e" && \
-      (grep -rn "|| true\||| :\|>/dev/null 2>&1\|2>/dev/null\|&>/dev/null\|set +e" --include="*.sh" --include="*.bash" --include="Makefile" --include="Dockerfile" . 2>/dev/null || echo "  None found") && \
-      echo "  Python: bare except, except pass, return None in except" && \
-      (grep -rn "except:$\|except .*:.*pass$\|except.*:.*return None" --include="*.py" . 2>/dev/null || echo "  None found") && \
-      echo "  TypeScript/JS: empty catch, catch return undefined" && \
-      (grep -rn "catch.*{.*}$\|catch.*return undefined\|catch.*return \[\]" --include="*.ts" --include="*.js" . 2>/dev/null || echo "  None found") && \
-      echo "" && \
+      set -euo pipefail
+      echo "=== ZERO-BS VERIFICATION ==="
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-19c-zero-bs-verification requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      echo ""
+      echo "Scanning for Zero-BS violations..."
+      echo ""
+      echo "--- Checking for TODO/FIXME comments ---"
+      (grep -r -E "(TODO|FIXME)" --include="*.py" --include="*.ts" --include="*.js" . 2>/dev/null || echo "None found")
+      echo ""
+      echo "--- Checking for stub indicators ---"
+      (grep -r -E "(NotImplementedError|raise NotImplemented|pass  # stub)" --include="*.py" . 2>/dev/null || echo "None found")
+      echo ""
+      echo "--- Checking for Forbidden Patterns ---"
+      echo "  Shell: || true, >/dev/null 2>&1, set +e"
+      (grep -rn "|| true\||| :\|>/dev/null 2>&1\|2>/dev/null\|&>/dev/null\|set +e" --include="*.sh" --include="*.bash" --include="Makefile" --include="Dockerfile" . 2>/dev/null || echo "  None found")
+      echo "  Python: bare except, except pass, return None in except"
+      (grep -rn "except:$\|except .*:.*pass$\|except.*:.*return None" --include="*.py" . 2>/dev/null || echo "  None found")
+      echo "  TypeScript/JS: empty catch, catch return undefined"
+      (grep -rn "catch.*{.*}$\|catch.*return undefined\|catch.*return \[\]" --include="*.ts" --include="*.js" . 2>/dev/null || echo "  None found")
+      echo ""
       echo "=== Zero-BS Verification Complete ==="
     output: "zero_bs_check"
 

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -109,7 +109,7 @@ steps:
     condition: "goal_already_met != 'true'"
     command: |
       set -euo pipefail
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}"
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Step 15: Commit and Push ==="
       echo ""
       echo "--- Staging Changes ---"
@@ -177,7 +177,7 @@ steps:
     condition: "goal_already_met != 'true'"
     command: |
       set -euo pipefail
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}"
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-16 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Step 16: Creating Draft PR ===" >&2
 
       # FIX (#3324): Idempotency guard — detect pre-existing PRs before creating one

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -16,6 +16,15 @@ recursion:
   max_depth: 6
   max_total_steps: 80
 
+# Required upstream outputs consumed by bash steps in this brick.
+# Documents the recipe-boundary contract; future compose-time validation
+# in amplihack-recipe-runner will hook here. See issue #414.
+inputs:
+  - name: worktree_setup.worktree_path
+    description: "Absolute path to the per-task worktree produced by workflow-worktree (step-04). Required by bash steps that cd into the worktree (step-15, step-16)."
+  - name: repo_path
+    description: "Absolute path to the repository root. Provided by parent recipe context."
+
 context: {}
 
 steps:

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -16,6 +16,13 @@ recursion:
   max_depth: 6
   max_total_steps: 80
 
+# Required upstream outputs consumed by bash steps in this brick.
+# Documents the recipe-boundary contract; future compose-time validation
+# in amplihack-recipe-runner will hook here. See issue #414.
+inputs:
+  - name: worktree_setup.worktree_path
+    description: "Absolute path to the per-task worktree produced by workflow-worktree (step-04). Required by the checkpoint bash step (step-11b-implement-feedback) that cd into the worktree."
+
 context: {}
 
 steps:
@@ -187,19 +194,20 @@ steps:
     type: "bash"
     max_env_value_bytes: 65536
     command: |
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:-$REPO_PATH}" 2>/dev/null || cd "$REPO_PATH" && \
-      echo "=== Checkpoint: Staging Review Feedback ===" && \
-      git add -A && \
-      STAGED=$(git diff --cached --name-only) && \
-      if [ -n "$STAGED" ]; then \
+      set -euo pipefail
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-11b-implement-feedback requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      echo "=== Checkpoint: Staging Review Feedback ==="
+      git add -A
+      STAGED=$(git diff --cached --name-only)
+      if [ -n "$STAGED" ]; then
         git commit -m "wip: checkpoint after review feedback (steps 10-11)
 
       Automatic checkpoint to preserve review-addressed changes.
-      Saved before running pre-commit hooks and tests." && \
-        echo "Checkpoint commit created with $(wc -l <<< "$STAGED") file(s)" ; \
-      else \
-        echo "No changes to checkpoint" ; \
-      fi && \
+      Saved before running pre-commit hooks and tests."
+        echo "Checkpoint commit created with $(wc -l <<< "$STAGED") file(s)"
+      else
+        echo "No changes to checkpoint"
+      fi
       echo "=== Checkpoint Complete ==="
     output: "review_checkpoint"
 

--- a/tests/issue_413_fail_loud_worktree.sh
+++ b/tests/issue_413_fail_loud_worktree.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Tests for Issue #413: workflow-publish.yaml must fail loud when
+# WORKTREE_SETUP_WORKTREE_PATH is unset, instead of silently falling back to
+# $REPO_PATH.
+#
+# These tests validate:
+#   1. The two target lines (112 and 180) use ${VAR:?diagnostic} form.
+#   2. No silent fallback ${VAR:-$REPO_PATH} remains in execution paths.
+#   3. The diagnostic strings reference the correct step (15 / 16) and source.
+#   4. Manual reproduction with `unset` produces the diagnostic on stderr and
+#      a non-zero exit, never executing the cd.
+#   5. Diagnostic echo lines (informational ${VAR:-(unset)}) are preserved.
+#   6. YAML remains parseable.
+#
+# Run: bash tests/issue_413_fail_loud_worktree.sh
+# Expected before fix: FAIL. Expected after fix: PASS.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FILE="$REPO_ROOT/amplifier-bundle/recipes/workflow-publish.yaml"
+
+fail=0
+pass=0
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        echo "PASS: $desc"
+        pass=$((pass+1))
+    else
+        echo "FAIL: $desc"
+        echo "      condition: $cond"
+        fail=$((fail+1))
+    fi
+}
+
+echo "=== Issue #413 TDD tests ==="
+echo "Target file: $FILE"
+echo
+
+# --- Test 1: file exists ----------------------------------------------------
+assert "workflow-publish.yaml exists" "[ -f '$FILE' ]"
+
+# --- Test 2: no silent fallback for WORKTREE_SETUP_WORKTREE_PATH ------------
+silent_count=$(grep -c 'WORKTREE_SETUP_WORKTREE_PATH:-\$REPO_PATH' "$FILE" || true)
+assert "no '\${WORKTREE_SETUP_WORKTREE_PATH:-\$REPO_PATH}' remains (found=$silent_count)" \
+    "[ '$silent_count' = '0' ]"
+
+# --- Test 3: fail-loud form present at exactly two execution sites ----------
+fail_loud_count=$(grep -c 'WORKTREE_SETUP_WORKTREE_PATH:?' "$FILE" || true)
+assert "exactly two '\${WORKTREE_SETUP_WORKTREE_PATH:?...}' execution sites (found=$fail_loud_count)" \
+    "[ '$fail_loud_count' = '2' ]"
+
+# --- Test 4: step-15 diagnostic references step-15 and step-04 source -------
+assert "step-15 diagnostic references step-15 and workflow-worktree" \
+    "grep -q 'step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree)' '$FILE'"
+
+# --- Test 5: step-16 diagnostic references step-16 and step-04 source -------
+assert "step-16 diagnostic references step-16 and workflow-worktree" \
+    "grep -q 'step-16 requires worktree_setup.worktree_path from step-04 (workflow-worktree)' '$FILE'"
+
+# --- Test 6: cd uses quoted expansion (no bare $VAR) ------------------------
+bare_cd=$(grep -cE 'cd \$WORKTREE_SETUP_WORKTREE_PATH' "$FILE" || true)
+assert "no bare unquoted 'cd \$WORKTREE_SETUP_WORKTREE_PATH'" "[ '$bare_cd' = '0' ]"
+
+# --- Test 7: diagnostic echo lines preserved (informational) ----------------
+# These two are intentionally NOT changed (they are log output, not exec paths).
+assert "informational echo with WORKTREE_SETUP_WORKTREE_PATH:-(unset) preserved" \
+    "grep -q 'WORKTREE_SETUP_WORKTREE_PATH:-(unset)' '$FILE'"
+
+# --- Test 8: set -euo pipefail present in both step blocks ------------------
+# :? requires errexit to abort the recipe step.
+step15_block=$(awk '/id: "step-15-commit-push"/,/id: "step-16-create-draft-pr"/' "$FILE")
+assert "step-15 block has 'set -euo pipefail'" \
+    "echo \"\$step15_block\" | grep -q 'set -euo pipefail'"
+
+step16_block=$(awk '/id: "step-16-create-draft-pr"/,/^  - id:/' "$FILE" | tail -n +2 | awk 'NR==1{print; next} /^  - id:/{exit} {print}')
+# Fallback simpler check: just grep within a window after step-16 marker.
+assert "step-16 block has 'set -euo pipefail'" \
+    "awk '/id: \"step-16-create-draft-pr\"/{f=1} f' '$FILE' | head -20 | grep -q 'set -euo pipefail'"
+
+# --- Test 9: YAML parses cleanly --------------------------------------------
+if command -v python3 >/dev/null 2>&1; then
+    if python3 -c "import yaml" 2>/dev/null; then
+        assert "YAML parses with yaml.safe_load" \
+            "python3 -c 'import yaml; yaml.safe_load(open(\"$FILE\"))'"
+    else
+        echo "SKIP: PyYAML not available"
+    fi
+else
+    echo "SKIP: python3 not available"
+fi
+
+# --- Test 10: runtime fail-loud reproduction --------------------------------
+# Validates the actual shell semantics of the diagnostic form used in the file.
+diag='step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs'
+out=$(unset WORKTREE_SETUP_WORKTREE_PATH; bash -c 'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?'"$diag"'}"' 2>&1)
+rc=$?
+assert "fail-loud reproduction exits non-zero" "[ '$rc' != '0' ]"
+assert "fail-loud reproduction emits step-15 diagnostic on stderr" \
+    "echo \"\$out\" | grep -q 'step-15 requires worktree_setup.worktree_path'"
+
+# --- Test 11: success path unchanged when var is set ------------------------
+tmpdir=$(mktemp -d)
+WORKTREE_SETUP_WORKTREE_PATH="$tmpdir" bash -c \
+    'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?should-not-fire}" && pwd' \
+    >/dev/null
+rc=$?
+rm -rf "$tmpdir"
+assert "success path: cd succeeds when WORKTREE_SETUP_WORKTREE_PATH is set" "[ '$rc' = '0' ]"
+
+# --- Summary ----------------------------------------------------------------
+echo
+echo "=== Summary: $pass passed, $fail failed ==="
+exit "$fail"

--- a/tests/issue_414_fail_loud_phase_bricks.sh
+++ b/tests/issue_414_fail_loud_phase_bricks.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Tests for Issue #414: phase-brick recipes must declare worktree-setup outputs
+# as required inputs and fail loudly when WORKTREE_SETUP_WORKTREE_PATH /
+# REPO_PATH are unset, instead of silently falling back.
+#
+# Mirrors tests/issue_413_fail_loud_worktree.sh.
+#
+# Validates (per spec):
+#   A. No `${VAR:-...}` fallback on required worktree/repo context vars.
+#   B. `${VAR:?...}` form present at expected count per file.
+#   C. Diagnostic strings reference the step-id, the upstream output, and
+#      the literal "worktree-setup".
+#   D. Top-level `inputs:` block declared in each affected file.
+#   E. PyYAML safe_load parses each file AND the `inputs` block conforms to
+#      schema: list of dicts each with `name` (str) + `description` (str).
+#   F. Runtime negative reproduction per hardened step:
+#        - exits non-zero
+#        - diagnostic appears on stderr (not stdout)
+#        - re-grep for `:-` fallback patterns is empty (runtime invariant)
+#        - negative-grep for `eval` and unquoted `cd $WORKTREE...` to lock
+#          safety properties going forward.
+#
+# Run: bash tests/issue_414_fail_loud_phase_bricks.sh
+# Expected before fix: FAIL. Expected after fix: PASS.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RECIPES_DIR="$REPO_ROOT/amplifier-bundle/recipes"
+
+FINALIZE="$RECIPES_DIR/workflow-finalize.yaml"
+PR_REVIEW="$RECIPES_DIR/workflow-pr-review.yaml"
+REFACTOR="$RECIPES_DIR/workflow-refactor-review.yaml"
+PUBLISH="$RECIPES_DIR/workflow-publish.yaml"
+
+ALL_FILES=("$FINALIZE" "$PR_REVIEW" "$REFACTOR" "$PUBLISH")
+
+fail=0
+pass=0
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        echo "PASS: $desc"
+        pass=$((pass+1))
+    else
+        echo "FAIL: $desc"
+        echo "      condition: $cond"
+        fail=$((fail+1))
+    fi
+}
+
+echo "=== Issue #414 TDD tests ==="
+echo
+
+# --- Pre: files exist -------------------------------------------------------
+for f in "${ALL_FILES[@]}"; do
+    assert "exists: $(basename "$f")" "[ -f '$f' ]"
+done
+
+# ----------------------------------------------------------------------------
+# Section A — No `:-` fallback on required vars in any of the 4 files.
+# ----------------------------------------------------------------------------
+echo
+echo "--- Section A: no ':-' fallback on required vars ---"
+for f in "${ALL_FILES[@]}"; do
+    n_wt=$(grep -c 'WORKTREE_SETUP_WORKTREE_PATH:-\$REPO_PATH' "$f" || true)
+    assert "no \${WORKTREE_SETUP_WORKTREE_PATH:-\$REPO_PATH} in $(basename "$f") (found=$n_wt)" \
+        "[ '$n_wt' = '0' ]"
+done
+
+# REPO_PATH must not appear bare in workflow-finalize.yaml step-22b cd context
+bare_repo=$(grep -cE '^\s*cd \$REPO_PATH' "$FINALIZE" || true)
+assert "no bare 'cd \$REPO_PATH' in workflow-finalize.yaml (found=$bare_repo)" \
+    "[ '$bare_repo' = '0' ]"
+
+# Negative-grep: no `eval` on protected vars in any affected file
+for f in "${ALL_FILES[@]}"; do
+    n_eval=$(grep -cE 'eval[[:space:]]+["$]?(WORKTREE_SETUP_WORKTREE_PATH|REPO_PATH)' "$f" || true)
+    assert "no 'eval' on protected vars in $(basename "$f") (found=$n_eval)" \
+        "[ '$n_eval' = '0' ]"
+done
+
+# Negative-grep: no unquoted `cd $WORKTREE_SETUP_WORKTREE_PATH` anywhere
+for f in "${ALL_FILES[@]}"; do
+    n_bare=$(grep -cE 'cd \$WORKTREE_SETUP_WORKTREE_PATH' "$f" || true)
+    assert "no unquoted 'cd \$WORKTREE_SETUP_WORKTREE_PATH' in $(basename "$f") (found=$n_bare)" \
+        "[ '$n_bare' = '0' ]"
+done
+
+# ----------------------------------------------------------------------------
+# Section B — `:?` form present at expected count per file.
+# ----------------------------------------------------------------------------
+echo
+echo "--- Section B: ':?' hardening counts ---"
+
+# workflow-finalize.yaml: 2 WORKTREE_SETUP_WORKTREE_PATH:?  +  1 REPO_PATH:?
+n=$(grep -c 'WORKTREE_SETUP_WORKTREE_PATH:?' "$FINALIZE" || true)
+assert "workflow-finalize: 2 \${WORKTREE_SETUP_WORKTREE_PATH:?} (found=$n)" "[ '$n' = '2' ]"
+n=$(grep -c 'REPO_PATH:?' "$FINALIZE" || true)
+assert "workflow-finalize: >=1 \${REPO_PATH:?} (found=$n)" "[ '$n' -ge '1' ]"
+
+# workflow-pr-review.yaml: 2 WORKTREE_SETUP_WORKTREE_PATH:?
+n=$(grep -c 'WORKTREE_SETUP_WORKTREE_PATH:?' "$PR_REVIEW" || true)
+assert "workflow-pr-review: 2 \${WORKTREE_SETUP_WORKTREE_PATH:?} (found=$n)" "[ '$n' = '2' ]"
+
+# workflow-refactor-review.yaml: 1 WORKTREE_SETUP_WORKTREE_PATH:?
+n=$(grep -c 'WORKTREE_SETUP_WORKTREE_PATH:?' "$REFACTOR" || true)
+assert "workflow-refactor-review: 1 \${WORKTREE_SETUP_WORKTREE_PATH:?} (found=$n)" "[ '$n' = '1' ]"
+
+# workflow-publish.yaml: 2 WORKTREE_SETUP_WORKTREE_PATH:? (unchanged from #413)
+n=$(grep -c 'WORKTREE_SETUP_WORKTREE_PATH:?' "$PUBLISH" || true)
+assert "workflow-publish: 2 \${WORKTREE_SETUP_WORKTREE_PATH:?} (preserved from #413; found=$n)" \
+    "[ '$n' = '2' ]"
+
+# Refactor-review must drop the 2>/dev/null + || cd fallback
+n=$(grep -cE 'WORKTREE_SETUP_WORKTREE_PATH.*2>/dev/null.*cd "\$REPO_PATH"' "$REFACTOR" || true)
+assert "workflow-refactor-review: '2>/dev/null || cd \$REPO_PATH' fallback removed (found=$n)" \
+    "[ '$n' = '0' ]"
+
+# ----------------------------------------------------------------------------
+# Section C — Diagnostic strings reference step-id + upstream output + worktree-setup.
+# ----------------------------------------------------------------------------
+echo
+echo "--- Section C: diagnostic strings ---"
+
+# workflow-finalize.yaml — three hardened steps
+for step in step-20b-push-cleanup step-21-pr-ready step-22b-final-status; do
+    assert "workflow-finalize: diagnostic mentions $step" \
+        "grep -q '$step requires' '$FINALIZE'"
+done
+assert "workflow-finalize: diagnostics mention 'worktree-setup'" \
+    "[ \"\$(grep -c 'ensure parent recipe ran worktree-setup' '$FINALIZE')\" -ge '2' ]"
+assert "workflow-finalize: step-22b diagnostic mentions repo_path" \
+    "grep -q 'step-22b-final-status requires repo_path' '$FINALIZE'"
+
+# workflow-pr-review.yaml — two hardened steps
+for step in step-18c-push-feedback-changes step-19c-zero-bs-verification; do
+    assert "workflow-pr-review: diagnostic mentions $step" \
+        "grep -q '$step requires worktree_setup.worktree_path' '$PR_REVIEW'"
+done
+assert "workflow-pr-review: diagnostics mention 'worktree-setup'" \
+    "[ \"\$(grep -c 'ensure parent recipe ran worktree-setup' '$PR_REVIEW')\" -ge '2' ]"
+
+# workflow-refactor-review.yaml — one hardened step
+assert "workflow-refactor-review: diagnostic mentions step-11b-implement-feedback" \
+    "grep -q 'step-11b-implement-feedback requires worktree_setup.worktree_path' '$REFACTOR'"
+assert "workflow-refactor-review: diagnostic mentions 'worktree-setup'" \
+    "grep -q 'ensure parent recipe ran worktree-setup' '$REFACTOR'"
+
+# ----------------------------------------------------------------------------
+# Section D — Top-level `inputs:` block declared in each file.
+# ----------------------------------------------------------------------------
+echo
+echo "--- Section D: top-level inputs: blocks ---"
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+    for f in "${ALL_FILES[@]}"; do
+        assert "$(basename "$f"): top-level 'inputs:' block present" \
+            "python3 -c \"import yaml,sys; d=yaml.safe_load(open('$f')); sys.exit(0 if isinstance(d.get('inputs'), list) and len(d['inputs'])>=1 else 1)\""
+    done
+
+    # finalize + publish must declare both worktree_setup.worktree_path and repo_path
+    for f in "$FINALIZE" "$PUBLISH"; do
+        assert "$(basename "$f"): inputs declares worktree_setup.worktree_path AND repo_path" \
+            "python3 -c \"import yaml,sys; d=yaml.safe_load(open('$f')); names={i['name'] for i in d.get('inputs',[])}; sys.exit(0 if {'worktree_setup.worktree_path','repo_path'}.issubset(names) else 1)\""
+    done
+
+    # pr-review + refactor-review must declare worktree_setup.worktree_path
+    for f in "$PR_REVIEW" "$REFACTOR"; do
+        assert "$(basename "$f"): inputs declares worktree_setup.worktree_path" \
+            "python3 -c \"import yaml,sys; d=yaml.safe_load(open('$f')); names={i['name'] for i in d.get('inputs',[])}; sys.exit(0 if 'worktree_setup.worktree_path' in names else 1)\""
+    done
+else
+    echo "SKIP: python3+PyYAML not available — Section D"
+fi
+
+# ----------------------------------------------------------------------------
+# Section E — PyYAML safe_load + inputs schema.
+# ----------------------------------------------------------------------------
+echo
+echo "--- Section E: PyYAML safe_load + schema ---"
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+    for f in "${ALL_FILES[@]}"; do
+        assert "$(basename "$f"): yaml.safe_load succeeds" \
+            "python3 -c 'import yaml; yaml.safe_load(open(\"$f\"))'"
+        assert "$(basename "$f"): inputs schema = list of {name:str, description:str}" \
+            "python3 -c \"import yaml,sys; d=yaml.safe_load(open('$f')); inp=d.get('inputs',[]); ok=isinstance(inp,list) and all(isinstance(x,dict) and isinstance(x.get('name'),str) and isinstance(x.get('description'),str) for x in inp); sys.exit(0 if ok else 1)\""
+    done
+else
+    echo "SKIP: python3+PyYAML not available — Section E"
+fi
+
+# ----------------------------------------------------------------------------
+# Section F — Runtime negative reproduction per hardened step.
+# ----------------------------------------------------------------------------
+echo
+echo "--- Section F: runtime negative reproductions ---"
+
+TMPWORK="$(mktemp -d)"
+trap 'rm -rf "$TMPWORK"' EXIT
+
+run_negative() {
+    # $1 = test description, $2 = diagnostic substring, $3 = bash body
+    local desc="$1"
+    local needle="$2"
+    local body="$3"
+
+    local stdout_file="$TMPWORK/stdout.$$"
+    local stderr_file="$TMPWORK/stderr.$$"
+
+    env -i PATH=/usr/bin:/bin TMPDIR="$TMPWORK" bash -c "$body" \
+        >"$stdout_file" 2>"$stderr_file"
+    local rc=$?
+
+    assert "$desc: exits non-zero" "[ '$rc' != '0' ]"
+    assert "$desc: diagnostic on stderr" "grep -q '$needle' '$stderr_file'"
+    assert "$desc: diagnostic NOT on stdout (stderr discipline)" \
+        "! grep -q '$needle' '$stdout_file'"
+}
+
+# step-20b-push-cleanup
+run_negative \
+    "workflow-finalize.step-20b-push-cleanup" \
+    "step-20b-push-cleanup requires worktree_setup.worktree_path" \
+    'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-20b-push-cleanup requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"'
+
+# step-21-pr-ready
+run_negative \
+    "workflow-finalize.step-21-pr-ready" \
+    "step-21-pr-ready requires worktree_setup.worktree_path" \
+    'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-21-pr-ready requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"'
+
+# step-22b-final-status (REPO_PATH)
+run_negative \
+    "workflow-finalize.step-22b-final-status" \
+    "step-22b-final-status requires repo_path" \
+    'set -euo pipefail; cd "${REPO_PATH:?step-22b-final-status requires repo_path; ensure parent recipe propagated repo_path context}"'
+
+# step-18c-push-feedback-changes
+run_negative \
+    "workflow-pr-review.step-18c-push-feedback-changes" \
+    "step-18c-push-feedback-changes requires worktree_setup.worktree_path" \
+    'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-18c-push-feedback-changes requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"'
+
+# step-19c-zero-bs-verification
+run_negative \
+    "workflow-pr-review.step-19c-zero-bs-verification" \
+    "step-19c-zero-bs-verification requires worktree_setup.worktree_path" \
+    'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-19c-zero-bs-verification requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"'
+
+# step-11b-implement-feedback
+run_negative \
+    "workflow-refactor-review.step-11b-implement-feedback" \
+    "step-11b-implement-feedback requires worktree_setup.worktree_path" \
+    'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-11b-implement-feedback requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"'
+
+# Positive control: when var is set, success path works
+ok_dir="$(mktemp -d -p "$TMPWORK")"
+env -i PATH=/usr/bin:/bin WORKTREE_SETUP_WORKTREE_PATH="$ok_dir" \
+    bash -c 'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?should-not-fire}" && pwd' \
+    >/dev/null 2>&1
+rc=$?
+assert "positive control: success path when var is set" "[ '$rc' = '0' ]"
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo
+echo "=== Summary: $pass passed, $fail failed ==="
+exit "$fail"


### PR DESCRIPTION
## Summary

Issue #414: harden the four phase-brick recipes that consume `worktree_setup` outputs so they fail loudly with a diagnostic when `WORKTREE_SETUP_WORKTREE_PATH` or `REPO_PATH` is unset, instead of silently falling back. Adds a top-level `inputs:` block to each brick to document the recipe-boundary contract and serve as a forward-compat hook for compose-time validation.

Builds on #413 (workflow-publish fail-loud) — extends the same pattern to the remaining 4 phase bricks.

## Changes

| File | Hardened steps | Inputs declared |
| --- | --- | --- |
| `workflow-finalize.yaml` | step-20b-push-cleanup, step-21-pr-ready (`WORKTREE_SETUP_WORKTREE_PATH:?`), step-22b-final-status (`REPO_PATH:?`) | worktree_setup.worktree_path, repo_path |
| `workflow-pr-review.yaml` | step-18c-push-feedback-changes, step-19c-zero-bs-verification | worktree_setup.worktree_path |
| `workflow-refactor-review.yaml` | checkpoint-after-review-feedback (drops `2>/dev/null \|\| cd $REPO_PATH` fallback) | worktree_setup.worktree_path |
| `workflow-publish.yaml` | (unchanged from #413) | worktree_setup.worktree_path, repo_path |

Each hardened step gains `set -euo pipefail` so the `:?` parameter expansion actually exits the step on unbound var.

## Diagnostic format

Matches #411 / #413 precedent:

```
<step-id> requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs
```

## Test

`tests/issue_414_fail_loud_phase_bricks.sh` — 68 assertions covering:

- Section A — no `${VAR:-$REPO_PATH}` fallback on required vars
- Section B — expected `:?` count per file
- Section C — diagnostic strings reference step-id + upstream output + "worktree-setup"
- Section D — top-level `inputs:` block present
- Section E — `yaml.safe_load` parses every file; `inputs:` schema is list-of-dict
- Section F — runtime negative reproduction per hardened step (exits non-zero, diagnostic on stderr)

`=== Summary: 68 passed, 0 failed ===`

## Gates

- `cargo clippy --all-targets -- -D warnings` ✅
- `bash tests/issue_414_fail_loud_phase_bricks.sh` ✅ (68/68)
- `TMPDIR=/tmp cargo test` — 1065 passed, 2 pre-existing failures in `amplihack-cli update::tests` (unrelated; tests not modified by this PR)

## Rationale for skipping compose-time validation in this repo

Acceptance criterion #3 of issue #414 explicitly permits skipping compose-time validation if documented. The runner crate lives in a separate repository (`amplihack-recipe-runner`), not in `amplihack-rs`. The top-level `inputs:` block remains valuable as documentation and as a forward-compat hook. A follow-up issue will be filed against `amplihack-recipe-runner` to track compose-time validation.

## Deferred (out-of-scope) cleanups

These `2>/dev/null` instances were intentionally **not** modified to keep the diff scoped:

- `workflow-pr-review.yaml` audit-scan greps (lines ~317-328) — `grep ... 2>/dev/null || echo "None found"` idioms
- Git-op suppressions on `git pull --rebase 2>/dev/null` and `git rev-list --count @{u}..HEAD 2>/dev/null`

Should be revisited in a dedicated forbidden-pattern sweep.

Fixes #414

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
