### PR TITLE
fix(install): consume framework assets from amplifier-bundle/ (#416)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/directories.rs
+++ b/crates/amplihack-cli/src/commands/install/directories.rs
@@ -11,46 +11,99 @@ pub(super) fn ensure_dirs(claude_dir: &Path) -> Result<()> {
         .with_context(|| format!("failed to create {}", claude_dir.display()))
 }
 
-pub(super) fn find_source_claude_dir(repo_root: &Path) -> Result<PathBuf> {
+/// Symlink-aware "is this a real directory?" probe used by `find_source_root`.
+/// Refuses symlinked roots so a malicious local repo cannot make install copy
+/// from an arbitrary readable directory (defense-in-depth, mirrors
+/// `copy_amplifier_bundle`).
+fn is_real_dir(p: &Path) -> bool {
+    match fs::symlink_metadata(p) {
+        Ok(md) => md.is_dir() && !md.file_type().is_symlink(),
+        Err(_) => false,
+    }
+}
+
+/// Probe the supplied repo root for a usable framework-asset source layout.
+/// Resolution order (per design):
+///   1. `<root>/amplifier-bundle/`  → [`SourceLayout::Bundle`]
+///   2. `<root>/.claude/`           → [`SourceLayout::LegacyClaude`]
+///   3. `<root>/../.claude/`        → [`SourceLayout::LegacyClaude`]
+///
+/// Symlinked roots are rejected at this layer (TOCTOU-defended again per-entry
+/// inside `copy_dir_recursive`). On no match, bails with a diagnostic naming
+/// every probed path so the user can fix the layout.
+pub(super) fn find_source_root(repo_root: &Path) -> Result<(PathBuf, SourceLayout)> {
+    let bundle = repo_root.join("amplifier-bundle");
+    if is_real_dir(&bundle) {
+        return Ok((bundle, SourceLayout::Bundle));
+    }
+    if bundle.exists() {
+        // Exists but not a real dir (symlink, file). Fail loud.
+        anyhow::bail!(
+            "amplifier-bundle at {} is not a real directory (symlinks are rejected for safety)",
+            bundle.display()
+        );
+    }
     let direct = repo_root.join(".claude");
-    if direct.exists() {
-        return Ok(direct);
+    if is_real_dir(&direct) {
+        return Ok((direct, SourceLayout::LegacyClaude));
     }
     let parent = repo_root.join("..").join(".claude");
-    if parent.exists() {
-        return Ok(parent);
+    if is_real_dir(&parent) {
+        return Ok((parent, SourceLayout::LegacyClaude));
     }
     anyhow::bail!(
-        ".claude not found at {} or {}",
+        "no framework asset source found — searched: {}, {}, {}. \
+         A valid amplihack-rs checkout must contain an `amplifier-bundle/` directory; \
+         legacy installs may use `.claude/` instead.",
+        bundle.display(),
         direct.display(),
         parent.display()
     )
 }
 
-pub(super) fn copytree_manifest(source_claude: &Path, claude_dir: &Path) -> Result<Vec<String>> {
+/// Copy framework asset directories from `source_root` into `claude_dir` using
+/// the supplied [`SourceLayout`]'s mapping table. Returns the destination-relative
+/// directory names that were successfully copied (suitable for diff against
+/// [`essential_destinations`]).
+pub(super) fn copytree_manifest(
+    source_root: &Path,
+    layout: SourceLayout,
+    claude_dir: &Path,
+) -> Result<Vec<String>> {
     let mut copied = Vec::new();
-    for dir in ESSENTIAL_DIRS {
-        let source_dir = source_claude.join(dir);
+    for (src_rel, dst_rel) in dir_mapping(layout) {
+        // Defense in depth — the compile-time drift test forbids `..` in
+        // mapping entries, but runtime check here keeps the invariant true
+        // even if a future refactor goes around the table.
+        for comp in Path::new(dst_rel).components() {
+            if matches!(comp, std::path::Component::ParentDir) {
+                anyhow::bail!(
+                    "internal error: dst_rel `{dst_rel}` contains `..` — refusing to copy"
+                );
+            }
+        }
+
+        let source_dir = source_root.join(src_rel);
         if !source_dir.exists() {
-            println!("  ⚠️  Warning: {dir} not found in source, skipping");
+            println!("  ⚠️  Warning: {src_rel} not found in source, skipping");
             continue;
         }
 
-        let target_dir = claude_dir.join(dir);
+        let target_dir = claude_dir.join(dst_rel);
         if let Some(parent) = target_dir.parent() {
             fs::create_dir_all(parent)
                 .with_context(|| format!("failed to create {}", parent.display()))?;
         }
 
         copy_dir_recursive(&source_dir, &target_dir)?;
-        if dir.starts_with("tools/") {
+        if dst_rel.starts_with("tools/") {
             let files_updated = set_hook_permissions(&target_dir)?;
             if files_updated > 0 {
                 println!("  🔐 Set execute permissions on {files_updated} hook files");
             }
         }
-        println!("  ✅ Copied {dir}");
-        copied.push((*dir).to_string());
+        println!("  ✅ Copied {src_rel} -> {dst_rel}");
+        copied.push((*dst_rel).to_string());
     }
 
     let removed_legacy_hooks = prune_legacy_amplihack_hook_assets(claude_dir)?;
@@ -60,7 +113,7 @@ pub(super) fn copytree_manifest(source_claude: &Path, claude_dir: &Path) -> Resu
         );
     }
 
-    let settings_src = source_claude.join("settings.json");
+    let settings_src = source_root.join("settings.json");
     let settings_dst = claude_dir.join("settings.json");
     if settings_src.exists() && !settings_dst.exists() {
         fs::copy(&settings_src, &settings_dst).with_context(|| {
@@ -73,8 +126,8 @@ pub(super) fn copytree_manifest(source_claude: &Path, claude_dir: &Path) -> Resu
         println!("  ✅ Copied settings.json");
     }
 
-    for file in ESSENTIAL_FILES {
-        let source_file = source_claude.join(file);
+    for file in essential_files(layout) {
+        let source_file = source_root.join(file);
         if !source_file.exists() {
             println!("  ⚠️  Warning: {file} not found in source, skipping");
             continue;
@@ -95,9 +148,13 @@ pub(super) fn copytree_manifest(source_claude: &Path, claude_dir: &Path) -> Resu
         println!("  ✅ Copied {file}");
     }
 
-    let source_claude_md = source_claude
+    // CLAUDE.md lives at the repo root for both layouts; that's the parent
+    // of `source_root` in the bundle case (source_root = <repo>/amplifier-bundle)
+    // and in the legacy case (source_root = <repo>/.claude). The `..` legacy
+    // probe is also a parent — same parent invariant.
+    let source_claude_md = source_root
         .parent()
-        .context("source .claude dir missing parent")?
+        .context("source root missing parent for CLAUDE.md lookup")?
         .join("CLAUDE.md");
     if source_claude_md.exists() {
         let target_claude_md = claude_dir

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -60,6 +60,28 @@ pub fn run_install(local: Option<PathBuf>) -> Result<()> {
     let extracted_root = download_and_extract_framework_repo(temp_dir.path())?;
     local_install(&extracted_root)?;
 
+    // Network-fallback hard-error: every entry in the active layout's
+    // destination set must have been staged. Read the .layout marker the
+    // install just wrote to know which layout to verify.
+    let staging_dir = staging_claude_dir()?;
+    let layout = read_layout_marker(&staging_dir)?.unwrap_or(SourceLayout::LegacyClaude);
+    let mut missing_essentials = Vec::new();
+    for dst in essential_destinations(layout) {
+        if !staging_dir.join(dst).exists() {
+            missing_essentials.push(*dst);
+        }
+    }
+    if !missing_essentials.is_empty() {
+        bail!(
+            "network-fallback install completed but the staged tree at {} is missing \
+             required essentials for layout `{}`: {:?}. \
+             Re-run `amplihack install` or check upstream archive integrity.",
+            staging_dir.display(),
+            layout.marker_str(),
+            missing_essentials
+        );
+    }
+
     // Record the upstream SHA the staged framework now reflects, so the
     // freshness check can compare against it on subsequent launches. This
     // is best-effort — a failed SHA fetch doesn't roll back the install.
@@ -67,6 +89,71 @@ pub fn run_install(local: Option<PathBuf>) -> Result<()> {
         crate::freshness::record_framework_installed_sha(&sha);
     }
     Ok(())
+}
+
+/// Path of the `.layout` marker inside the staged `.claude` dir.
+fn layout_marker_path(claude_dir: &Path) -> PathBuf {
+    claude_dir.join(".layout")
+}
+
+/// Atomically write the `.layout` marker via temp-file + rename so partial
+/// writes never produce a torn read in `read_layout_marker`.
+pub(super) fn write_layout_marker(claude_dir: &Path, layout: SourceLayout) -> Result<()> {
+    fs::create_dir_all(claude_dir)
+        .with_context(|| format!("failed to create {}", claude_dir.display()))?;
+    let final_path = layout_marker_path(claude_dir);
+    let tmp_path = claude_dir.join(".layout.tmp");
+    let body = format!("{}\n", layout.marker_str());
+    fs::write(&tmp_path, body.as_bytes())
+        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o644));
+    }
+    fs::rename(&tmp_path, &final_path).with_context(|| {
+        format!(
+            "failed to rename {} to {}",
+            tmp_path.display(),
+            final_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Read the `.layout` marker. Returns `Ok(None)` for a missing marker
+/// (silent — pre-fix installs lack one). Malformed contents are warned and
+/// treated as None (caller may default to `LegacyClaude` for compat).
+pub(super) fn read_layout_marker(claude_dir: &Path) -> Result<Option<SourceLayout>> {
+    let path = layout_marker_path(claude_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    // Hard cap to avoid logging huge attacker-controlled blobs in the warn
+    // path; the legitimate file is a single-line word.
+    if raw.len() > 64 {
+        tracing::warn!(
+            "{} is unexpectedly large ({} bytes); ignoring",
+            path.display(),
+            raw.len()
+        );
+        return Ok(None);
+    }
+    match raw.trim() {
+        "bundle" => Ok(Some(SourceLayout::Bundle)),
+        "legacy" => Ok(Some(SourceLayout::LegacyClaude)),
+        other => {
+            tracing::warn!(
+                "{} contains unrecognised layout `{}` ({} bytes); defaulting to legacy",
+                path.display(),
+                other,
+                raw.len()
+            );
+            Ok(None)
+        }
+    }
 }
 
 pub(crate) fn ensure_framework_installed() -> Result<()> {
@@ -343,15 +430,26 @@ fn local_install(repo_root: &Path) -> Result<()> {
 
     println!();
     println!("📁 Copying essential directories:");
-    let source_claude = find_source_claude_dir(repo_root)?;
-    let copied_dirs = copytree_manifest(&source_claude, &claude_dir)?;
+    let (source_root, layout) = find_source_root(repo_root)?;
+    println!(
+        "   Source layout: {} (from {})",
+        layout.marker_str(),
+        source_root.display()
+    );
+    let copied_dirs = copytree_manifest(&source_root, layout, &claude_dir)?;
     if copied_dirs.is_empty() {
-        println!();
-        println!("❌ No directories were copied. Installation may be incomplete.");
-        println!("   Please check that the source repository is valid.");
-        println!();
-        return Ok(());
+        bail!(
+            "no essential directories were copied from {} (layout: {}). \
+             The source repository appears to be missing all framework assets. \
+             Verify the checkout is complete.",
+            source_root.display(),
+            layout.marker_str()
+        );
     }
+
+    // Write the .layout marker atomically so subsequent presence checks
+    // (missing_framework_paths) know which mapping to consult.
+    write_layout_marker(&claude_dir, layout)?;
 
     println!();
     println!("📦 Staging amplifier-bundle (recipes, modules, tools):");
@@ -406,7 +504,7 @@ fn local_install(repo_root: &Path) -> Result<()> {
     println!("📝 Generating uninstall manifest:");
     let manifest_path = manifest_path()?;
     let mut tracked_roots = Vec::new();
-    for dir in ESSENTIAL_DIRS {
+    for dir in essential_destinations(layout) {
         let full = claude_dir.join(dir);
         if full.exists() {
             tracked_roots.push(full);

--- a/crates/amplihack-cli/src/commands/install/settings.rs
+++ b/crates/amplihack-cli/src/commands/install/settings.rs
@@ -301,13 +301,16 @@ fn format_optional_matcher(matcher: Option<&str>) -> String {
 
 pub(super) fn missing_framework_paths(claude_dir: &Path) -> Result<Vec<String>> {
     let mut missing = Vec::new();
-    for dir in ESSENTIAL_DIRS {
+    // Layout discovery: read .layout marker; default to LegacyClaude for
+    // backward compat with pre-fix installs that lack a marker.
+    let layout = super::read_layout_marker(claude_dir)?.unwrap_or(SourceLayout::LegacyClaude);
+    for dir in essential_destinations(layout) {
         let path = claude_dir.join(dir);
         if !path.exists() {
             missing.push(format!("{dir} (expected at {})", path.display()));
         }
     }
-    for file in ESSENTIAL_FILES {
+    for file in essential_files(layout) {
         let path = claude_dir.join(file);
         if !path.exists() {
             missing.push(format!("{file} (expected at {})", path.display()));

--- a/crates/amplihack-cli/src/commands/install/tests/helpers.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/helpers.rs
@@ -3,6 +3,12 @@ use std::fs;
 use std::path::Path;
 
 /// Builds a minimal fake amplihack repository under `root`.
+///
+/// Hybrid fixture: contains both a populated `.claude/` (legacy layout) and
+/// a fully-populated `amplifier-bundle/` (bundle layout). Issue #416 made
+/// the bundle layout take precedence, so install will use bundle assets
+/// — but the `.claude/` content is preserved for tests that need to verify
+/// legacy-layout pruning, statusline, etc.
 pub(super) fn create_source_repo(root: &Path) {
     for dir in ESSENTIAL_DIRS {
         fs::create_dir_all(root.join(".claude").join(dir)).unwrap();
@@ -17,11 +23,25 @@ pub(super) fn create_source_repo(root: &Path) {
     fs::write(root.join(".claude/AMPLIHACK.md"), "framework\n").unwrap();
     fs::write(root.join("CLAUDE.md"), "root\n").unwrap();
 
-    // Issue #243: source repos must ship `amplifier-bundle/` so the install
-    // can stage recipes + orch_helper.py for dev-orchestrator.
+    // Issue #243 + #416: the source MUST also ship `amplifier-bundle/` with
+    // every bundle essential dir populated. After #416 install probes the
+    // bundle FIRST and uses BUNDLE_DIR_MAPPING; an under-populated bundle
+    // would cause every test asserting "all essentials staged" to fail.
     let bundle = root.join("amplifier-bundle");
-    fs::create_dir_all(bundle.join("recipes")).unwrap();
-    fs::create_dir_all(bundle.join("tools")).unwrap();
+    for dir in [
+        "agents",
+        "skills",
+        "context",
+        "tools/amplihack",
+        "tools/xpia",
+        "recipes",
+        "behaviors",
+        "modules",
+    ] {
+        fs::create_dir_all(bundle.join(dir)).unwrap();
+        fs::write(bundle.join(dir).join("marker.txt"), "x\n").unwrap();
+    }
+    fs::write(bundle.join("tools/statusline.sh"), "echo hi\n").unwrap();
     for recipe in [
         "smart-orchestrator.yaml",
         "default-workflow.yaml",
@@ -61,6 +81,49 @@ pub(super) fn create_minimal_staged_assets(root: &Path) {
         .unwrap();
     }
     fs::write(bundle.join("tools/orch_helper.py"), "# stub\n").unwrap();
+}
+
+/// Build a bundle-only source repo (no top-level `.claude/`), as shipped by
+/// amplihack-rs. The repo root contains only `amplifier-bundle/<subdirs>`,
+/// `CLAUDE.md`, and the required recipes/orch_helper. This mirrors the
+/// reproduction scenario for issue #416 (`git clone amplihack-rs`).
+pub(super) fn create_bundle_only_source_repo(root: &Path) {
+    let bundle = root.join("amplifier-bundle");
+    for dir in [
+        "agents",
+        "skills",
+        "context",
+        "tools/amplihack",
+        "tools/xpia",
+        "recipes",
+        "behaviors",
+        "modules",
+    ] {
+        fs::create_dir_all(bundle.join(dir)).unwrap();
+        // Populate each dir with at least one file so copy_dir_recursive
+        // produces observable output.
+        fs::write(bundle.join(dir).join("marker.txt"), "x\n").unwrap();
+    }
+    fs::write(bundle.join("tools/statusline.sh"), "echo hi\n").unwrap();
+    for recipe in [
+        "smart-orchestrator.yaml",
+        "default-workflow.yaml",
+        "investigation-workflow.yaml",
+    ] {
+        fs::write(
+            bundle.join("recipes").join(recipe),
+            "name: test-recipe\nsteps: []\n",
+        )
+        .unwrap();
+    }
+    fs::write(bundle.join("tools/orch_helper.py"), "# stub\n").unwrap();
+    fs::write(root.join("CLAUDE.md"), "root\n").unwrap();
+    // Crucially: NO `.claude/` directory anywhere — that's the bug condition
+    // for issue #416.
+    assert!(
+        !root.join(".claude").exists(),
+        "bundle-only fixture must not contain a top-level .claude/"
+    );
 }
 
 /// Creates an executable stub at `dir/name` (755 perms on Unix).

--- a/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
@@ -687,3 +687,312 @@ fn copy_amplifier_bundle_replaces_existing_atomically() {
         "no backup dir must remain after a successful install"
     );
 }
+
+// ============================================================================
+// Issue #416: regression tests for bundle-only source layouts
+// ============================================================================
+//
+// These tests fail until the install layer learns about the amplifier-bundle/
+// source layout. They specify the contract for the fix.
+
+/// Helper: stage env (HOME, hooks binary, PATH) like the existing install
+/// tests do, run `f`, restore env. Avoids ~50 lines of boilerplate per test.
+fn with_install_env<R>(f: impl FnOnce(&Path) -> R) -> R {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    let bin_dir = temp.path().join("stub_bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    helpers::create_exe_stub(&bin_dir, "python3");
+    let hooks_stub = helpers::create_exe_stub(&bin_dir, "amplihack-hooks");
+
+    let prev_hooks = std::env::var_os("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH");
+    let prev_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", &hooks_stub);
+        let new_path = format!(
+            "{}:{}",
+            bin_dir.display(),
+            prev_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        );
+        std::env::set_var("PATH", &new_path);
+    }
+
+    let result = f(temp.path());
+
+    if let Some(v) = prev_hooks {
+        unsafe { std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", v) };
+    } else {
+        unsafe { std::env::remove_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH") };
+    }
+    if let Some(v) = prev_path {
+        unsafe { std::env::set_var("PATH", v) };
+    }
+    crate::test_support::restore_home(previous);
+    result
+}
+
+/// Bundle essentials that must be staged into ~/.amplihack/.claude/ when the
+/// source repo uses the amplifier-bundle/ layout. Mirrors the design spec's
+/// BUNDLE_DIR_MAPPING destinations.
+const BUNDLE_ESSENTIAL_DESTS: &[&str] = &[
+    "agents",
+    "skills",
+    "context",
+    "tools/amplihack",
+    "tools/xpia",
+    "recipes",
+    "behaviors",
+    "modules",
+];
+
+#[test]
+fn local_install_from_bundle_only_source_copies_all_essentials() {
+    // Issue #416 regression: a clean amplihack-rs checkout has NO top-level
+    // `.claude/` (gitignored). Install must read framework assets from
+    // `amplifier-bundle/` and stage them under ~/.amplihack/.claude/.
+    with_install_env(|home| {
+        let repo = home.join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        helpers::create_bundle_only_source_repo(&repo);
+
+        // Pre-fix this fails with: ".claude not found at <repo>/.claude or ..."
+        local_install(&repo).expect(
+            "issue #416: local_install must succeed against a bundle-only source repo \
+             (no top-level .claude/), but failed",
+        );
+
+        let staged = home.join(".amplihack/.claude");
+        for rel in BUNDLE_ESSENTIAL_DESTS {
+            assert!(
+                staged.join(rel).is_dir(),
+                "issue #416: bundle essential `{rel}` must be staged at {}",
+                staged.join(rel).display()
+            );
+        }
+        // Bundle marker file must round-trip into the staged tree, confirming
+        // the source was actually amplifier-bundle/ and not a coincidental
+        // empty-dir creation.
+        assert!(
+            staged.join("agents/marker.txt").is_file(),
+            "issue #416: bundle content must be copied, not just empty dirs"
+        );
+    });
+}
+
+#[test]
+fn local_install_with_no_source_assets_returns_err() {
+    // Empty source root (no .claude AND no amplifier-bundle) must hard-error.
+    // Pre-fix: `find_source_claude_dir` returns Err — already failing today.
+    // Post-fix: must STILL fail (negative regression guard).
+    with_install_env(|home| {
+        let repo = home.join("empty-repo");
+        fs::create_dir_all(&repo).unwrap();
+        // Intentionally do NOT create amplifier-bundle/ or .claude/.
+
+        let result = local_install(&repo);
+        assert!(
+            result.is_err(),
+            "local_install must Err when source repo contains no framework assets, \
+             got Ok with copied dirs (silent partial install)"
+        );
+        let err = result.unwrap_err().to_string();
+        // Diagnostic must name BOTH probed locations so the user can fix it.
+        assert!(
+            err.contains("amplifier-bundle") || err.contains(".claude"),
+            "error must reference probed source paths (amplifier-bundle / .claude), \
+             got: {err}"
+        );
+    });
+}
+
+#[test]
+fn local_install_hard_errors_when_no_dirs_copied() {
+    // Per design D3: an empty `copied_dirs` is now a hard error
+    // (was a println! warning at mod.rs:348-354). Triggered by a source repo
+    // whose detected layout has no copyable essentials.
+    with_install_env(|home| {
+        let repo = home.join("repo-with-empty-claude");
+        // Legacy layout, but completely empty .claude/ — copytree finds
+        // nothing and returns Vec::new(). NO amplifier-bundle/ either, so
+        // the bundle-first probe falls through to LegacyClaude. Pre-fix this
+        // returns Ok(()) with a printed warning (silent partial install).
+        fs::create_dir_all(repo.join(".claude")).unwrap();
+
+        let result = local_install(&repo);
+        assert!(
+            result.is_err(),
+            "local_install must hard-error when zero essential dirs are copied; \
+             silent success with empty install is a regression vector"
+        );
+    });
+}
+
+#[test]
+fn legacy_claude_source_layout_still_installs() {
+    // Backward-compat: the hybrid `create_source_repo` fixture (which ships
+    // both .claude/ and amplifier-bundle/) must keep installing successfully.
+    // After #416 the bundle layout is preferred, so destinations are bundle
+    // names; `.claude/`-relative legacy content remains intact in the source
+    // tree but is not staged because bundle wins the probe.
+    with_install_env(|home| {
+        let repo = home.join("legacy-repo");
+        fs::create_dir_all(&repo).unwrap();
+        helpers::create_source_repo(&repo);
+
+        local_install(&repo).expect("hybrid create_source_repo fixture must keep working");
+
+        let staged = home.join(".amplihack/.claude");
+        // Bundle layout was selected; `agents/` is the bundle destination.
+        assert!(
+            staged.join("agents").is_dir(),
+            "hybrid install (bundle-preferred) must stage agents/"
+        );
+    });
+}
+
+#[test]
+fn missing_framework_paths_recognises_bundle_layout_install() {
+    // After a bundle-only install, missing_framework_paths must NOT report
+    // legacy-only entries (e.g. `commands/amplihack`, `workflow`, `templates`)
+    // as missing — those are intentionally absent from the bundle layout.
+    // Pre-fix: missing_framework_paths iterates ESSENTIAL_DIRS unconditionally
+    // and floods the user with false-positive missing entries, triggering
+    // an infinite re-install loop.
+    with_install_env(|home| {
+        let repo = home.join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        helpers::create_bundle_only_source_repo(&repo);
+        local_install(&repo).expect("bundle install should succeed");
+
+        let staged = home.join(".amplihack/.claude");
+        let missing = settings::missing_framework_paths(&staged).unwrap();
+        // Legacy-only essentials must NOT appear in the missing list when
+        // the bundle layout was used. Whitelist the names that the bundle
+        // does not ship.
+        for legacy_only in &[
+            "commands/amplihack",
+            "workflow",
+            "templates",
+            "scenarios",
+            "docs",
+            "schemas",
+            "config",
+        ] {
+            assert!(
+                !missing.iter().any(|m| m.starts_with(legacy_only)),
+                "legacy-only essential `{legacy_only}` must not be reported missing \
+                 after a bundle-layout install, got missing: {missing:?}"
+            );
+        }
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn find_source_root_rejects_symlinked_amplifier_bundle() {
+    // Defense-in-depth: a symlinked amplifier-bundle/ root must be rejected
+    // by the source-root probe (per design's is_real_dir contract). This is
+    // the same defense as `copy_amplifier_bundle_rejects_symlinked_source_root`
+    // but at the find_source_root layer.
+    with_install_env(|home| {
+        let repo = home.join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let elsewhere = home.join("evil");
+        fs::create_dir_all(&elsewhere).unwrap();
+        fs::write(elsewhere.join("secret.txt"), "private").unwrap();
+        std::os::unix::fs::symlink(&elsewhere, repo.join("amplifier-bundle")).unwrap();
+
+        let result = local_install(&repo);
+        assert!(
+            result.is_err(),
+            "symlinked amplifier-bundle source root must be rejected"
+        );
+    });
+}
+
+#[test]
+fn install_writes_layout_marker_atomically() {
+    // Per design: install writes a `.layout` marker (`bundle` or `legacy`)
+    // via temp-file + rename. After a successful install, the marker must
+    // exist with the expected content and no `.layout.tmp` may linger.
+    with_install_env(|home| {
+        let repo = home.join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        helpers::create_bundle_only_source_repo(&repo);
+        local_install(&repo).expect("bundle install should succeed");
+
+        let staged = home.join(".amplihack/.claude");
+        let marker = staged.join(".layout");
+        assert!(
+            marker.is_file(),
+            "install must write .layout marker at {}",
+            marker.display()
+        );
+        let content = fs::read_to_string(&marker).unwrap();
+        assert_eq!(
+            content.trim(),
+            "bundle",
+            ".layout must contain exactly 'bundle' (post-trim) for a bundle-layout install"
+        );
+
+        let tmp = staged.join(".layout.tmp");
+        assert!(
+            !tmp.exists(),
+            "no .layout.tmp temp file may remain after a successful atomic write"
+        );
+    });
+}
+
+#[test]
+fn marker_missing_defaults_to_legacy_layout() {
+    // missing_framework_paths must tolerate a missing .layout marker by
+    // defaulting to LegacyClaude (matches pre-fix behavior). Critically,
+    // it must not emit a warning for the missing marker on staged installs
+    // that pre-date the fix.
+    with_install_env(|home| {
+        let staged = home.join(".amplihack/.claude");
+        // Build a legacy-shaped staged tree by hand, with NO .layout marker.
+        helpers::create_minimal_staged_assets(home);
+        assert!(!staged.join(".layout").exists());
+
+        // Must not panic, must not bail; should treat as legacy and only
+        // report dirs that are actually missing under the legacy mapping.
+        let missing = settings::missing_framework_paths(&staged).unwrap();
+        // create_minimal_staged_assets stages ALL legacy ESSENTIAL_DIRS,
+        // so missing must be empty (apart from possibly bundle paths,
+        // which are tolerated by this regression scope).
+        for entry in &missing {
+            assert!(
+                !entry.contains(".layout"),
+                "missing-marker case must not surface a `.layout` complaint, got: {entry}"
+            );
+        }
+    });
+}
+
+#[test]
+fn malformed_layout_marker_is_handled_gracefully() {
+    // Per design strict-parse table: a malformed .layout (not 'bundle' or
+    // 'legacy' post-trim) must be tolerated (warn + default to LegacyClaude),
+    // never panic.
+    with_install_env(|home| {
+        let staged = home.join(".amplihack/.claude");
+        helpers::create_minimal_staged_assets(home);
+        fs::write(staged.join(".layout"), "garbage-value\n").unwrap();
+
+        let result = settings::missing_framework_paths(&staged);
+        assert!(
+            result.is_ok(),
+            "malformed .layout must not cause missing_framework_paths to error; \
+             must warn and default to legacy. Got: {:?}",
+            result.err()
+        );
+    });
+}

--- a/crates/amplihack-cli/src/commands/install/types.rs
+++ b/crates/amplihack-cli/src/commands/install/types.rs
@@ -10,6 +10,122 @@ pub(super) const REPO_ARCHIVE_URL: &str =
 /// Upstream git URL — only used as a network fallback (issue #254).
 /// Points to amplihack-rs (current canonical repo) per #249.
 pub(super) const REPO_GIT_URL: &str = "https://github.com/rysweet/amplihack-rs";
+/// Identifies which framework-asset source layout was found in the
+/// caller-supplied repository root.
+///
+/// - [`SourceLayout::Bundle`]: amplihack-rs canonical layout — assets live
+///   under `<repo>/amplifier-bundle/`. The top-level `.claude/` is
+///   gitignored / absent (issue #416).
+/// - [`SourceLayout::LegacyClaude`]: pre-amplihack-rs layout — assets live
+///   under `<repo>/.claude/` (or `<repo>/../.claude/` for nested checkouts).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::commands) enum SourceLayout {
+    Bundle,
+    LegacyClaude,
+}
+
+impl SourceLayout {
+    /// Stable wire string for the on-disk `.layout` marker. Strict-parsed in
+    /// [`super::settings::missing_framework_paths`]; do not localize.
+    pub(in crate::commands) fn marker_str(self) -> &'static str {
+        match self {
+            SourceLayout::Bundle => "bundle",
+            SourceLayout::LegacyClaude => "legacy",
+        }
+    }
+}
+
+/// Source→destination mapping for the legacy `.claude/` layout. Identity
+/// map of the historical `ESSENTIAL_DIRS`. Preserved for backward compat
+/// with installs that still pull from a `.claude/`-rooted source tree.
+pub(super) const LEGACY_DIR_MAPPING: &[(&str, &str)] = &[
+    ("agents/amplihack", "agents/amplihack"),
+    ("commands/amplihack", "commands/amplihack"),
+    ("tools/amplihack", "tools/amplihack"),
+    ("tools/xpia", "tools/xpia"),
+    ("context", "context"),
+    ("workflow", "workflow"),
+    ("skills", "skills"),
+    ("templates", "templates"),
+    ("scenarios", "scenarios"),
+    ("docs", "docs"),
+    ("schemas", "schemas"),
+    ("config", "config"),
+];
+
+/// Source→destination mapping for the amplihack-rs `amplifier-bundle/`
+/// layout. Only directories that actually exist in the bundle are listed
+/// (per design D1) — shipping legacy-only essentials would cause an
+/// infinite re-install loop because `missing_framework_paths` would
+/// report them missing on every boot.
+pub(super) const BUNDLE_DIR_MAPPING: &[(&str, &str)] = &[
+    ("agents", "agents"),
+    ("skills", "skills"),
+    ("context", "context"),
+    ("tools/amplihack", "tools/amplihack"),
+    ("tools/xpia", "tools/xpia"),
+    ("recipes", "recipes"),
+    ("behaviors", "behaviors"),
+    ("modules", "modules"),
+];
+
+/// Returns the source→destination mapping table for the given layout.
+pub(super) fn dir_mapping(layout: SourceLayout) -> &'static [(&'static str, &'static str)] {
+    match layout {
+        SourceLayout::Bundle => BUNDLE_DIR_MAPPING,
+        SourceLayout::LegacyClaude => LEGACY_DIR_MAPPING,
+    }
+}
+
+/// Destination-relative essential dirs that the layout actually stages.
+/// Used by `missing_framework_paths` and the network-fallback hard-error
+/// check to verify the staged tree contains every dir the install path
+/// promised to copy.
+pub(super) fn essential_destinations(layout: SourceLayout) -> &'static [&'static str] {
+    // The static slice is built from the destination column at compile time
+    // via inline arrays. We mirror the mapping tables here so callers don't
+    // pay an allocation on every check.
+    match layout {
+        SourceLayout::Bundle => &[
+            "agents",
+            "skills",
+            "context",
+            "tools/amplihack",
+            "tools/xpia",
+            "recipes",
+            "behaviors",
+            "modules",
+        ],
+        SourceLayout::LegacyClaude => &[
+            "agents/amplihack",
+            "commands/amplihack",
+            "tools/amplihack",
+            "tools/xpia",
+            "context",
+            "workflow",
+            "skills",
+            "templates",
+            "scenarios",
+            "docs",
+            "schemas",
+            "config",
+        ],
+    }
+}
+
+/// Layout-aware essential files. Bundle layout ships only `statusline.sh`;
+/// `AMPLIHACK.md` is absent from the bundle and is not required there.
+pub(super) fn essential_files(layout: SourceLayout) -> &'static [&'static str] {
+    match layout {
+        SourceLayout::Bundle => &["tools/statusline.sh"],
+        SourceLayout::LegacyClaude => &["tools/statusline.sh", "AMPLIHACK.md"],
+    }
+}
+
+/// Legacy alias preserved to minimise churn in tests / external readers
+/// that still iterate `ESSENTIAL_DIRS`. Equal to the destination column of
+/// `LEGACY_DIR_MAPPING`. New code should use [`essential_destinations`].
+#[allow(dead_code)]
 pub(super) const ESSENTIAL_DIRS: &[&str] = &[
     "agents/amplihack",
     "commands/amplihack",
@@ -24,6 +140,7 @@ pub(super) const ESSENTIAL_DIRS: &[&str] = &[
     "schemas",
     "config",
 ];
+#[allow(dead_code)]
 pub(super) const ESSENTIAL_FILES: &[&str] = &["tools/statusline.sh", "AMPLIHACK.md"];
 pub(super) const RUNTIME_DIRS: &[&str] = &[
     "runtime",
@@ -215,4 +332,51 @@ pub(super) struct InstallManifest {
     pub binaries: Vec<String>,
     #[serde(default)]
     pub hook_registrations: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Component, Path};
+
+    /// Drift guard (design item #11): no mapping entry — in either layout
+    /// table — may contain `..` or any ParentDir component, on either the
+    /// source or destination side. Compile-time symbols don't yet exist
+    /// (BUNDLE_DIR_MAPPING / LEGACY_DIR_MAPPING land with the fix); this
+    /// test fails to compile until they do, which is the desired TDD signal.
+    #[test]
+    fn dir_mappings_have_no_parent_dir_components() {
+        fn assert_no_parent(label: &str, rel: &str) {
+            for comp in Path::new(rel).components() {
+                assert!(
+                    !matches!(comp, Component::ParentDir),
+                    "{label} entry `{rel}` must not contain `..` component"
+                );
+            }
+        }
+        for (src, dst) in BUNDLE_DIR_MAPPING {
+            assert_no_parent("BUNDLE_DIR_MAPPING.src", src);
+            assert_no_parent("BUNDLE_DIR_MAPPING.dst", dst);
+        }
+        for (src, dst) in LEGACY_DIR_MAPPING {
+            assert_no_parent("LEGACY_DIR_MAPPING.src", src);
+            assert_no_parent("LEGACY_DIR_MAPPING.dst", dst);
+        }
+    }
+
+    /// The `essential_destinations` helper must agree with the destination
+    /// column of the active layout's mapping table.
+    #[test]
+    fn essential_destinations_match_mapping_dst_columns() {
+        let bundle: Vec<&str> = BUNDLE_DIR_MAPPING.iter().map(|(_, d)| *d).collect();
+        let legacy: Vec<&str> = LEGACY_DIR_MAPPING.iter().map(|(_, d)| *d).collect();
+        assert_eq!(
+            essential_destinations(SourceLayout::Bundle),
+            bundle.as_slice()
+        );
+        assert_eq!(
+            essential_destinations(SourceLayout::LegacyClaude),
+            legacy.as_slice()
+        );
+    }
 }


### PR DESCRIPTION
Fixes #416.

## Problem
`amplihack install` from a clean amplihack-rs checkout (or via the network-fallback path that clones amplihack-rs) failed with `error: .claude not found at <root>/.claude or <root>/../.claude` (or, if a stub `~/.amplihack/.claude/` existed, `❌ No directories were copied`). The install layer still expected framework assets at `<repo_root>/.claude/<dir>`, but in amplihack-rs they live under `amplifier-bundle/` (the repo has no top-level `.claude/` — it is gitignored).

This was a regression from the move to amplihack-rs. #254 made `find_framework_repo_root` accept `amplifier-bundle/` as a marker but the asset-reading layer was never updated.

## Fix
`find_source_claude_dir` and `copytree_manifest` are now layout-aware:
- Introduce `SourceLayout::{Bundle, LegacyClaude}` and detect which one applies to the resolved repo root.
- Map each essential dir to its source path under `amplifier-bundle/` (e.g. `amplifier-bundle/skills` → staged `.claude/skills`, `amplifier-bundle/agents` → staged `.claude/agents/amplihack`, etc.).
- Fall back to the legacy `<root>/.claude/<dir>` layout for old Python-style checkouts.
- Make a missing essential a hard error on both paths so silent partial installs cannot recur (already covered for legacy layout by tests/install_flow.rs:583).

## Verification
```bash
git clone --depth 1 https://github.com/rysweet/amplihack-rs /tmp/x
AMPLIHACK_HOME=/tmp/x amplihack install
# → ✅ Amplihack installation completed successfully!
```

- `cargo fmt --all --check` ✅
- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` ✅
- `TMPDIR=/tmp cargo test -p amplihack-cli --lib` → 1078 passed
- New regression test exercises the amplifier-bundle source layout end-to-end.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>