### PR TITLE
docs(concepts): port upstream PHILOSOPHY, PATTERNS, TRUST, DEFAULT_WORKFLOW context

### DIFF
--- a/docs/concepts/default-workflow.md
+++ b/docs/concepts/default-workflow.md
@@ -1,0 +1,450 @@
+     here, and upstream there. Bundle-asset paths have been rewritten from
+     ~/.amplihack/.claude/... to amplifier-bundle/... to match amplihack-rs layout. -->
+
+---
+name: DEFAULT_WORKFLOW
+version: 1.1.0
+description: Standard 22-step workflow (Steps 0-21) for feature development, bug fixes, and refactoring
+steps: 22
+phases:
+  - requirements-clarification
+  - design
+  - implementation
+  - testing
+  - review
+  - merge
+success_criteria:
+  - "All steps completed"
+  - "PR is mergeable"
+  - "CI passes"
+  - "Philosophy compliant"
+philosophy_alignment:
+  - principle: Ruthless Simplicity
+    application: Each step has single clear purpose
+  - principle: Zero-BS Implementation
+    application: No stubs or placeholders in deliverables
+  - principle: Test-Driven Development
+    application: Write tests before implementation
+  - principle: Modular Design
+    application: Clean module boundaries enforced through workflow
+customizable: true
+---
+
+# Default Coding Workflow
+
+This file defines the default workflow for all non-trivial code changes.
+
+You can customize this workflow by editing this file.
+
+## How This Workflow Works
+
+**This workflow is the single source of truth for:**
+
+- The order of operations (steps must be followed sequentially)
+- Git workflow (branch, commit, push, PR process)
+- CI/CD integration points
+- Review and merge requirements
+
+## When This Workflow Applies
+
+This workflow should be followed for:
+
+- New features
+- Bug fixes
+- Refactoring
+- Any non-trivial code changes
+
+**Execution approach:**
+
+- Start with using the SlashCommand(amplihack:ultrathink) for any non-trivial task
+- The workflow defines the process; agents execute the work
+- Each step below leverages specialized agents whenever possible
+- UltraThink orchestrates parallel agent execution for maximum efficiency
+- When you customize this workflow, UltraThink adapts automatically
+
+## TodoWrite Best Practices
+
+When creating todos during workflow execution, reference the workflow steps directly:
+
+- Format: `Step N: [Step Name] - [Specific Action]`
+- This helps users track exactly which workflow step is active
+- Always show your full ToDo list
+- When you get to a particular step, you may always decide to break it down into smaller steps - this is preferred.
+
+- **Reference Step Numbers**: Include the workflow step number in todo content
+  - Example: `Step 1: Rewrite and Clarify Requirements - Use prompt-writer agent`
+  - Example: `Step 4: Research and Design - Use architect agent for solution design`
+
+- **Workstream Prefixes** (Optional): When running multiple workflows in parallel, prefix todos with workstream name
+  - Format: `[WORKSTREAM] Step N: Description`
+  - Example: `[PR1090 TASK] Step 1: Rewrite and Clarify Requirements`
+  - Example: `[FEATURE-X] Step 4: Research and Design - Use architect agent`
+  - This helps track which todos belong to which parallel workstream
+
+- **Be Specific**: Include the specific agent or action for each step
+  - Example: `Step 5: Implement the Solution - Use builder agent from specifications`
+
+- **Track Progress**: Users can see exactly which step is active (e.g., "Step 5 of 22")
+
+**Example Todo Structure (Single Workflow):**
+
+```
+Step 0: Workflow Preparation - Read workflow, create todos for ALL steps (0-21)
+Step 1: Prepare the Workspace - Check git status and fetch
+Step 2: Rewrite and Clarify Requirements - Use prompt-writer agent to clarify task
+Step 3: Create GitHub Issue - Define requirements and constraints using gh issue create
+Step 4: Setup Worktree and Branch - Create feat/issue-XXX branch in worktrees/
+Step 5: Research and Design - Use architect agent for solution design
+...
+Step 16: Review the PR - MANDATORY code review
+Step 17: Implement Review Feedback - MANDATORY
+...
+Step 21: Ensure PR is Mergeable - TASK COMPLETION POINT
+```
+
+**Example Todo Structure (Multiple Parallel Workflows):**
+
+```
+[PR1090 TASK] Step 0: Workflow Preparation - Create todos for ALL steps (0-21)
+[PR1090 TASK] Step 1: Prepare the Workspace - Check git status
+[PR1090 TASK] Step 2: Rewrite and Clarify Requirements - Use prompt-writer agent
+[FEATURE-X] Step 0: Workflow Preparation - Create todos for ALL steps (0-21)
+[FEATURE-X] Step 3: Setup Worktree and Branch - Create feat/issue-XXX branch
+[BUGFIX-Y] Step 16: Review the PR - MANDATORY code review
+...
+```
+
+This step-based structure helps users understand:
+
+- Exactly which workflow step is currently active
+- How many steps remain
+- What comes next in the workflow
+
+## The Workflow
+
+### Step 0: Workflow Preparation (MANDATORY - DO NOT SKIP)
+
+**CRITICAL: This step MUST be completed before ANY implementation work begins.**
+
+**Why This Step Exists:**
+
+Agents that skip workflow steps (especially mandatory review steps 10, 16-17) create quality issues and erode user trust. This step ensures agents track ALL steps from the start, preventing "completion bias" where agents feel done after implementation but before review.
+
+**Root Cause Prevention:**
+
+- **Completion Bias**: Agents often consider "PR created" as task completion
+- **Context Decay**: After heavy implementation, agents lose sight of remaining steps
+- **Autonomy Misapplication**: Being autonomous means making implementation decisions independently, NOT skipping mandatory process steps
+
+**Checklist:**
+
+- [ ] **Read this entire workflow file** - Understand all 22 steps (0-21) before starting
+- [ ] **Create TodoWrite entries for ALL steps (0-21)** using format: `Step N: [Step Name] - [Specific Action]`
+- [ ] **Mark each step complete ONLY when truly done** - No premature completion
+- [ ] **Task is NOT complete until Step 21 is marked complete**
+
+**Self-Verification:** Before proceeding to Step 1, confirm you have 22 todo items visible (Steps 0-21).
+
+**Anti-Pattern Prevention:**
+
+- ❌ DO NOT skip to implementation after reading requirements
+- ❌ DO NOT consider "PR created" as completion (Step 21 is the completion point)
+- ❌ DO NOT omit Steps 10, 16-17 (mandatory review steps)
+- ❌ DO NOT declare task complete with pending steps
+- ✅ DO create all step todos BEFORE starting any implementation
+- ✅ DO mark steps complete sequentially as you finish them
+- ✅ DO track every mandatory step in TodoWrite
+
+**Reference Issue:** This step was added after Issue #1607 identified workflow step skipping as a recurring problem.
+
+### Step 1: Prepare the Workspace
+
+**Prerequisite Check:** Verify Step 0 is complete - you should have 22 todos visible (Steps 0-21) before proceeding.
+
+- [ ] start with a clean local environment and make sure it is up to date (no unstashed changes, git fetch)
+
+### Step 2: Rewrite and Clarify Requirements
+
+- [ ] **FIRST: Identify explicit user requirements** that CANNOT be optimized away
+- [ ] **Always use** prompt-writer agent to clarify task requirements (includes automatic task classification)
+- [ ] **Use** analyzer agent to understand existing codebase context
+- [ ] **Use** ambiguity agent if requirements are unclear - employ other agents using Task() tool or Skills() using Skill tool as needed
+- [ ] Remove ambiguity from the task description - using your own best judgement to work autonomously and independently
+- [ ] Define clear success criteria
+- [ ] Document acceptance criteria
+- [ ] **CRITICAL: Pass explicit requirements to ALL subsequent agents**
+
+### Step 3: Create GitHub Issue
+
+- [ ] **Use** GitHub issue creation tool via agent
+- [ ] Create issue using `gh issue create`
+- [ ] Include clear problem description
+- [ ] Define requirements and constraints
+- [ ] Add success criteria
+- [ ] Assign appropriate labels
+
+### Step 4: Setup Worktree and Branch
+
+- [ ] **Always use** worktree-manager agent for worktree operations
+- [ ] Create new git worktree in `./worktrees/{branch-name}` for isolated development
+- [ ] Create branch with format: `feat/issue-{number}-{brief-description}` always branch from an up to date main unless specifically instructed otherwise.
+- [ ] Command: `git worktree add ./worktrees/{branch-name} -b {branch-name}`
+- [ ] Push branch to remote with tracking: `git push -u origin {branch-name}`
+- [ ] Switch to new worktree directory: `cd ./worktrees/{branch-name}`
+
+### Step 5: Research and Design
+
+**⚠️ INVESTIGATION-FIRST PATTERN**: If the existing codebase or system is unfamiliar/complex, consider running the Skills tool Skill(investigation-workflow) or ~.claude/workflow/INVESTIGATION_WORKFLOW.md FIRST, then return here to continue development. This is especially valuable when:
+
+- The codebase area is unfamiliar or poorly documented
+- The feature touches multiple complex subsystems
+- You need to understand existing patterns before designing new ones
+- The architecture or integration points are unclear
+
+After investigation completes, continue with these tasks:
+
+- [ ] check for any Skill tool Skills() that are applicable to this task and employ them
+- [ ] **Use** architect agent to design solution architecture
+- [ ] **Use** api-designer agent for API contracts (if applicable)
+- [ ] **Use** database agent for data model design (if applicable)
+- [ ] **Use** security agent to identify security requirements
+- [ ] use other subagents as appropriate if their expertise is applicable to the problem
+- [ ] **💡 TIP**: For diagnostic follow-up questions during research, consider `parallel agent investigation` (see `amplifier-bundle/CLAUDE.md` in the amplifier-bundle)
+- [ ] ask @zen-architect agent to review everything done so far and provide feedback
+- [ ] ask @architect agent to consider the feedback
+- [ ] Document module specifications
+- [ ] Create detailed implementation plan
+- [ ] Identify risks and dependencies
+
+### Step 6: Retcon Documentation Writing
+
+- [ ] ask @documentation-writer agent to retcon write the documentation for the finished feature as if it already exists - ie the documentation for the feature as we want it to be. Write ONLY the documentation, not the code.
+- [ ] ask the @architect agent to review the documentation to see if it aligns with their vision correctly or if it highlights any changes that should be made
+- [ ] ask @documentation-writer to make revisions based ont he architect's review
+
+### Step 7: Test Driven Development - Writing Tests First
+
+- [ ] Followingg the Test Driven Development methodology - use the tester agent to write failing tests (TDD approach) based upon the work done so far.
+
+### Step 8: Implement the Solution
+
+- [ ] **Always use** builder agent to implement from specifications, including considering the retcon'd documentation
+- [ ] **Use** integration agent for external service connections
+- [ ] Follow the architecture design, leverage appropriate skills with the Skill() tool as needed, handoff to other subagents if appropriate
+- [ ] Make failing tests pass iteratively
+- [ ] Ensure all requirements are met
+- [ ] Update documentation as needed
+
+### Step 9: Refactor and Simplify
+
+- [ ] **CRITICAL: Provide cleanup agent with original user requirements**
+- [ ] **Always use** cleanup agent for ruthless simplification WITHIN user constraints
+- [ ] **Use** optimizer agent for performance improvements
+- [ ] Remove unnecessary abstractions (that weren't explicitly requested)
+- [ ] Eliminate dead code (unless user explicitly wanted it)
+- [ ] Simplify complex logic (without violating user specifications)
+- [ ] Ensure single responsibility principle
+- [ ] Verify no placeholders remain - no stubs, no TODOs, no swallowed exceptions, no unimplemented functions - follow the zero-BS principle.
+- [ ] **VALIDATE: All explicit user requirements still preserved** and still adhering to `amplifier-bundle/context/PHILOSOPHY.md` and `amplifier-bundle/context/FORBIDDEN_PATTERNS.md`
+
+### Step 10: Review Pass Before Commit
+
+- [ ] **Always use** reviewer agent for comprehensive code review
+- [ ] **Use** security agent for security review
+- [ ] Check code quality and standards
+- [ ] Verify philosophy compliance with the philosophy-guardian agent
+- [ ] **Verify no Forbidden Pattern violations** — check against `amplifier-bundle/context/FORBIDDEN_PATTERNS.md` (error swallowing, silent fallbacks, data loss, shell anti-patterns, async misuse, config divergence, validation gaps, health check dishonesty)
+- [ ] Ensure adequate test coverage
+- [ ] Identify potential improvements
+- [ ] Ensure there are no TODOs, faked apis or faked data, stubs, or swallowed exceptions, no unimplemented functions - follow the zero-BS principle.
+- [ ] Ensure no Forbidden Pattern violations: no silent fallbacks, no `|| true`, no `>/dev/null 2>&1`, no fire-and-forget async, no unchecked HTTP responses, no log-only catches.
+
+### Step 11: Incorporate Any Review Feedback
+
+- [ ] Use the architect agent to assess the reviewer feedback and then handoff to the builder agent to implement any changes
+- [ ] Update documentation as needed
+
+### Step 12: Run Tests and Pre-commit Hooks
+
+- [ ] **Use** pre-commit-diagnostic agent if hooks fail
+- [ ] **💡 TIP**: For test failures, use `parallel investigation` (see `amplifier-bundle/CLAUDE.md` in the amplifier-bundle) to explore issues while continuing work
+- [ ] Run all unit tests
+- [ ] Execute `pre-commit run --all-files`
+- [ ] Fix any linting issues
+- [ ] Fix any formatting issues
+- [ ] Resolve type checking errors
+- [ ] Iterate until all checks pass
+
+### Step 13: Mandatory Local Testing (NOT in CI)
+
+**CRITICAL: Test all changes locally in realistic scenarios BEFORE committing.**
+Test like a user would use the feature - outside-in - not just unit tests.
+
+- [ ] **Test simple use cases** - Basic functionality verification
+- [ ] **Test complex use cases** - Edge cases and longer operations
+- [ ] **Test integration points** - External dependencies and APIs
+- [ ] **Verify no regressions** - Ensure existing functionality still works
+- [ ] **Document test results** - What was tested and results for the PR description (to be used in a moment) not in the repo
+- [ ] **RULE: Never commit without local testing**
+
+**Examples of required tests:**
+
+- If proxy changes: Test simple and long requests locally
+- If API changes: Test with real client requests
+- If CLI changes: Run actual commands with various options
+- If database changes: Test with actual data operations
+
+**Why this matters:**
+
+- CI checks can't catch all real-world issues
+- Local testing catches problems before they reach users
+- Faster feedback loop than waiting for CI
+- Prevents embarrassing failures after merge
+
+### Step 14: Commit and Push
+
+- [ ] Stage all changes
+- [ ] Write detailed commit message
+- [ ] Reference issue number in commit
+- [ ] Describe what changed and why
+- [ ] Push to remote branch
+- [ ] Verify push succeeded
+
+### Step 15: Open Pull Request as Draft
+
+- [ ] Create PR as DRAFT using `gh pr create --draft` (pipe through `| cat` for reliable output)
+- [ ] Link to the GitHub issue
+- [ ] Write comprehensive description
+- [ ] Include test plan and the rsults of any testing that you have already captured
+- [ ] Add screenshots if UI changes
+- [ ] Add "WIP" or "Draft" context to indicate work in progress
+- [ ] Request appropriate reviewers (optional - they can review draft)
+
+**Important**: When using `gh` commands, always pipe through `cat` to ensure output is displayed:
+
+```bash
+gh pr create --draft --title "..." --body "..." 2>&1 | cat
+```
+
+**Why Draft First:**
+
+- Allows review and feedback while still iterating
+- Signals the PR is not yet ready to merge
+- Enables CI checks to run early
+- Creates space for philosophy and quality checks before marking ready
+- Prevents premature merge while work continues
+
+This ensures you see success messages, error details, and PR URLs.
+
+### Step 16: Review the PR
+
+**⚠️ MANDATORY - DO NOT SKIP ⚠️**
+
+**REQUIRED FOR ALL PRs**
+
+- Quality gates exist for a reason - bypassing them introduces risk
+- Pattern of skipping reviews leads to technical debt accumulation
+
+**Review checklist:**
+
+- [ ] **Always use** reviewer agent for comprehensive code review
+- [ ] **Use** security agent for security review
+- [ ] Check code quality and standards
+- [ ] Verify philosophy compliance
+- [ ] **Verify no Forbidden Pattern violations** (FORBIDDEN_PATTERNS.md)
+- [ ] Ensure adequate test coverage
+- [ ] Post review comments on PR
+- [ ] Identify potential improvements
+- [ ] Ensure there are no TODOs, stubs, or swallowed exceptions, no unimplemented functions - follow the zero-BS principle.
+- [ ] Ensure no Forbidden Pattern violations: no silent fallbacks, no `|| true`, no `>/dev/null 2>&1`, no fire-and-forget async, no unchecked HTTP responses, no log-only catches.
+- [ ] Always Post the review as a comment on the PR
+
+### Step 17: Implement Review Feedback
+
+**⚠️ MANDATORY - DO NOT SKIP ⚠️**
+
+**REQUIRED FOR ALL PRs**
+
+- Unaddressed feedback means the review process was pointless and creates confusion about whether feedback was considered
+- Indicates disrespect for reviewer's time and expertise
+- May block PR merge indefinitely
+
+**Feedback implementation checklist:**
+
+- [ ] Review all feedback comments, think very carefully about each one and decide how to address it (or if you should disagree, explain why in a comment)
+- [ ] **Always use** builder agent to implement changes
+- [ ] **Use** relevant specialized agents for specific feedback
+- [ ] Address each review comment
+- [ ] Push updates to PR
+- [ ] Respond to review comments by posting replies as coments on the PR
+- [ ] Ensure all tests still pass
+- [ ] Ensure PR is still mergeable
+- [ ] Request re-review if needed
+
+### Step 18: Philosophy Compliance Check
+
+- [ ] **Always use** reviewer agent for final philosophy check
+- [ ] **Use** patterns agent to verify pattern compliance
+- [ ] Verify ruthless simplicity achieved
+- [ ] Confirm bricks & studs pattern followed
+- [ ] Ensure zero-BS implementation (no stubs, faked apis, swalloed exceptions, etc)
+- [ ] Verify all tests passing
+- [ ] Check documentation completeness and accuracy
+
+### Step 19: Final Cleanup and Verification
+
+- [ ] **CRITICAL: Provide cleanup agent with original user requirements AGAIN**
+- [ ] **Always use** cleanup agent for final quality pass
+- [ ] Review all changes for philosophy compliance WITHIN user constraints
+- [ ] Remove any temporary artifacts or test files (unless user wanted them)
+- [ ] Eliminate unnecessary complexity (that doesn't violate user requirements)
+- [ ] Verify module boundaries remain clean
+- [ ] Ensure zero dead code or stub implementations (unless explicitly requested)
+- [ ] **FINAL CHECK: All explicit user requirements preserved**
+- [ ] Ensure any cleanup agent changes get committed, validated by pre-commit, pushed to remote
+- [ ] Add a comment to the PR about any work the Cleanup agent did
+
+### Step 20: Convert PR to Ready for Review
+
+- [ ] Convert draft PR to ready-for-review using `gh pr ready`
+- [ ] Verify all previous steps completed
+- [ ] Ensure all review feedback has been addressed
+- [ ] Confirm philosophy compliance check passed
+- [ ] Add comment summarizing changes and readiness
+- [ ] Tag reviewers for final approval
+
+**Important**: Only convert to ready when:
+
+- All review feedback addressed
+- Philosophy compliance verified
+- You believe the PR is truly ready to merge
+- No known blockers remain
+
+```bash
+gh pr ready 2>&1 | cat
+```
+
+**Why This Step Matters:**
+
+- Signals transition from "work in progress" to "ready to merge"
+- Indicates you've completed all quality checks
+- Requests final approval from reviewers
+- Makes PR eligible for merge queue
+
+### Step 21: Ensure PR is Mergeable
+
+- [ ] Check CI status (all checks passing)
+- [ ] **Always use** ci-diagnostic-workflow agent if CI fails
+- [ ] **💡 TIP**: When investigating CI failures, use `parallel agent investigation` (see `amplifier-bundle/CLAUDE.md` in the amplifier-bundle) to explore logs and code simultaneously
+- [ ] Resolve any merge conflicts
+- [ ] Verify all review comments addressed, including check for any that showed up after marking the PR as ready
+- [ ] Confirm PR is approved
+- [ ] Notify that PR is ready to merge
+
+## Customization
+
+To customize this workflow:
+
+1. Edit this file to modify, add, or remove steps
+2. Save your changes
+3. The updated workflow will be used for future tasks

--- a/docs/concepts/patterns.md
+++ b/docs/concepts/patterns.md
@@ -1,0 +1,814 @@
+     here, and upstream there. Bundle-asset paths have been rewritten from
+     ~/.amplihack/.claude/... to amplifier-bundle/... to match amplihack-rs layout. -->
+
+# Development Patterns & Solutions
+
+This document captures proven patterns and solutions for clean design and robust development. It serves as a quick reference for recurring challenges.
+
+## Pattern Curation Philosophy
+
+This document maintains **14 foundational patterns** that apply across most amplihack development.
+
+**Patterns are kept when they:**
+
+1. Solve recurring problems (used 3+ times in real PRs)
+2. Apply broadly across multiple agent types and scenarios
+3. Represent non-obvious solutions with working code
+4. Prevent costly errors or enable critical capabilities
+
+**Patterns are removed when they:**
+
+- Become project-specific (better suited for PROJECT.md or DISCOVERIES.md)
+- Are one-time solutions (preserved in git history)
+- Are obvious applications of existing patterns
+- Haven't been referenced in 6+ months
+
+**Trust in Emergence**: Removed patterns can re-emerge when needed. See git history for context: `git log -p .claude/context/PATTERNS.md`
+
+**This refactoring (2024-11):** Reduced from 24 to 14 patterns (74% reduction) based on usage analysis and philosophy compliance. Removed patterns include: CI Failure Rapid Diagnosis, Incremental Processing, Configuration Single Source of Truth, Parallel Task Execution (covered in CLAUDE.md), Multi-Layer Security Sanitization, Reflection-Driven Self-Improvement, Unified Validation Flow, Modular User Visibility, and others that were either too specific or better documented elsewhere.
+
+## Core Architecture Patterns
+
+### Pattern: Bricks & Studs Module Design with Clear Public API
+
+> **Philosophy Reference**: See `amplifier-bundle/context/PHILOSOPHY.md` "The Brick Philosophy for AI Development" for the philosophical foundation of this pattern.
+
+**Challenge**: Modules become tightly coupled, making them hard to regenerate or replace.
+
+**Solution**: Design modules as self-contained "bricks" with clear "studs" (public API) defined via `__all__`.
+
+```python
+"""Module docstring documents philosophy and public API.
+
+Philosophy:
+- Single responsibility
+- Standard library only (when possible)
+- Self-contained and regeneratable
+
+Public API (the "studs"):
+    MainClass: Primary functionality
+    helper_function: Utility function
+    CONSTANT: Configuration value
+"""
+
+# ... implementation ...
+
+__all__ = ["MainClass", "helper_function", "CONSTANT"]
+```
+
+**Module Structure**:
+
+```
+module_name/
+├── __init__.py         # Public interface via __all__
+├── README.md          # Contract specification
+├── core.py           # Implementation
+├── tests/            # Test the contract
+└── examples/         # Working examples
+```
+
+**Key Points**:
+
+- Module docstring documents philosophy and public API
+- `__all__` defines the public interface explicitly
+- Standard library only for core utilities (avoid circular dependencies)
+- Tests verify the contract, not implementation details
+
+### Pattern: Zero-BS Implementation
+
+> **Philosophy Reference**: See `amplifier-bundle/context/PHILOSOPHY.md` "Zero-BS Implementations" section for the core principle behind this pattern.
+
+**Challenge**: Avoiding stub code and placeholders that serve no purpose.
+
+**Solution**: Every function must work or not exist.
+
+```python
+# BAD - Stub that does nothing
+def process_payment(amount):
+    # TODO: Implement Stripe integration
+    raise NotImplementedError("Coming soon")
+
+# GOOD - Working implementation
+def process_payment(amount, payments_file="payments.json"):
+    """Record payment locally - fully functional."""
+    payment = {
+        "amount": amount,
+        "timestamp": datetime.now().isoformat(),
+        "id": str(uuid.uuid4())
+    }
+
+    payments = []
+    if Path(payments_file).exists():
+        payments = json.loads(Path(payments_file).read_text())
+
+    payments.append(payment)
+    Path(payments_file).write_text(json.dumps(payments, indent=2))
+    return payment
+```
+
+**Key Points**:
+
+- Every function must work or not exist
+- Use files instead of external services initially
+- No TODOs without working code
+- Start simple, add complexity when needed
+
+## API & Integration Patterns
+
+### Pattern: API Validation Before Implementation
+
+**Challenge**: Invalid API calls cause immediate failures. Wrong model names, missing imports, or incorrect types lead to 20-30 min debug cycles.
+
+**Solution**: Validate APIs before implementation using official documentation.
+
+**Validation Checklist**:
+
+1. **Model/LLM APIs**: Check model name format, verify parameters, test minimal example
+2. **Imports/Libraries**: Verify module exists, check function signatures
+3. **Services/Config**: Verify endpoints, check response format
+4. **Error Handling**: Plan for rate limits, timeouts, specific error types
+
+```python
+# WRONG - assumptions without validation
+client = Anthropic()
+message = client.messages.create(
+    model="claude-3-5-sonnet-20241022",  # ❌ Not verified
+    max_tokens="1024",  # ❌ Wrong type
+    messages=[{"role": "user", "content": prompt}]
+)
+
+# RIGHT - validated against docs
+VALID_MODELS = ["claude-3-opus-20240229", "claude-3-sonnet-20241022"]
+model = "claude-3-sonnet-20241022"  # ✓ Verified
+max_tokens = 1024  # ✓ Correct type
+
+if model not in VALID_MODELS:
+    raise ValueError(f"Invalid model: {model}")
+
+try:
+    message = client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        messages=[{"role": "user", "content": prompt}]
+    )
+except Exception as e:
+    raise RuntimeError(f"API call failed: {e}")
+```
+
+**Key Points**:
+
+- 5-10 min validation prevents 20-30 min debug cycles
+- Use official documentation as source of truth
+- Test imports and minimal examples before full implementation
+
+### Pattern: Claude Code SDK Integration
+
+**Challenge**: Integrating Claude Code SDK requires proper environment setup and timeout handling.
+
+**Solution**:
+
+```python
+import asyncio
+from claude_code_sdk import ClaudeSDKClient, ClaudeCodeOptions
+
+async def extract_with_claude_sdk(prompt: str, timeout_seconds: int = 120):
+    """Extract using Claude Code SDK with proper timeout handling"""
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            async with ClaudeSDKClient(
+                options=ClaudeCodeOptions(
+                    system_prompt="Extract information...",
+                    max_turns=1,
+                )
+            ) as client:
+                await client.query(prompt)
+
+                response = ""
+                async for message in client.receive_response():
+                    if hasattr(message, "content"):
+                        content = getattr(message, "content", [])
+                        if isinstance(content, list):
+                            for block in content:
+                                if hasattr(block, "text"):
+                                    response += getattr(block, "text", "")
+                return response
+    except asyncio.TimeoutError:
+        print(f"Claude Code SDK timed out after {timeout_seconds} seconds")
+        return ""
+```
+
+**Key Points**:
+
+- 120-second timeout is optimal
+- SDK only works in Claude Code environment
+- Handle markdown in responses
+
+## Error Handling & Reliability Patterns
+
+### Pattern: Safe Subprocess Wrapper with Comprehensive Error Handling
+
+**Challenge**: Subprocess calls fail with cryptic error messages. Different error types need different user guidance.
+
+**Solution**: Create a safe subprocess wrapper with user-friendly, actionable error messages.
+
+```python
+def safe_subprocess_call(
+    cmd: List[str],
+    context: str,
+    timeout: Optional[int] = 30,
+) -> Tuple[int, str, str]:
+    """Safely execute subprocess with comprehensive error handling."""
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    except FileNotFoundError:
+        cmd_name = cmd[0] if cmd else "command"
+        error_msg = f"Command not found: {cmd_name}\n"
+        if context:
+            error_msg += f"Context: {context}\n"
+        error_msg += "Please ensure the tool is installed and in your PATH."
+        return 127, "", error_msg
+
+    except subprocess.TimeoutExpired:
+        cmd_name = cmd[0] if cmd else "command"
+        error_msg = f"Command timed out after {timeout}s: {cmd_name}\n"
+        if context:
+            error_msg += f"Context: {context}\n"
+        return 124, "", error_msg
+
+    except Exception as e:
+        cmd_name = cmd[0] if cmd else "command"
+        error_msg = f"Unexpected error running {cmd_name}: {str(e)}\n"
+        if context:
+            error_msg += f"Context: {context}\n"
+        return 1, "", error_msg
+```
+
+**Key Points**:
+
+- Standard exit codes (127 for command not found)
+- Context parameter is critical - always tell users what operation failed
+- User-friendly messages with actionable guidance
+- No exceptions propagate
+
+### Pattern: Fail-Fast Prerequisite Checking
+
+**Challenge**: Users start using a tool, get cryptic errors mid-workflow when dependencies are missing.
+
+**Solution**: Check all prerequisites at startup with clear, actionable error messages.
+
+```python
+@dataclass
+class ToolCheckResult:
+    tool: str
+    available: bool
+    path: Optional[str] = None
+    version: Optional[str] = None
+    error: Optional[str] = None
+
+class PrerequisiteChecker:
+    REQUIRED_TOOLS = {
+        "node": "--version",
+        "npm": "--version",
+        "uv": "--version",
+    }
+
+    def check_and_report(self) -> bool:
+        """Check prerequisites and print report if any are missing."""
+        result = self.check_all_prerequisites()
+
+        if result.all_available:
+            return True
+
+        print(self.format_missing_prerequisites(result.missing_tools))
+        return False
+
+class Launcher:
+    def prepare_launch(self) -> bool:
+        """Check prerequisites FIRST before any other operations"""
+        checker = PrerequisiteChecker()
+        if not checker.check_and_report():
+            return False
+        return self._setup_environment()
+```
+
+**Key Points**:
+
+- Check at entry point before any operations
+- Check all at once - show all issues
+- Structured results with dataclasses
+- Never auto-install - user control first
+
+### Pattern: Resilient Batch Processing
+
+**Challenge**: Processing large batches where individual items might fail.
+
+**Solution**:
+
+```python
+class ResilientProcessor:
+    async def process_batch(self, items):
+        results = {"succeeded": [], "failed": []}
+
+        for item in items:
+            try:
+                result = await self.process_item(item)
+                results["succeeded"].append(result)
+                self.save_results(results)  # Save after every item
+            except Exception as e:
+                results["failed"].append({
+                    "item": item,
+                    "error": str(e),
+                    "timestamp": datetime.now().isoformat()
+                })
+                continue  # Continue processing other items
+
+        return results
+```
+
+**Key Points**:
+
+- Save after every item - never lose progress
+- Continue on failure - don't let one failure stop the batch
+- Track failure reasons
+
+## Testing & Validation Patterns
+
+### Pattern: TDD Testing Pyramid for System Utilities
+
+**Challenge**: Testing system utilities that interact with external tools while maintaining fast execution.
+
+**Solution**: Follow testing pyramid with 60% unit tests, 30% integration tests, 10% E2E tests.
+
+```python
+"""Tests for module - TDD approach.
+
+Testing pyramid:
+- 60% Unit tests (fast, heavily mocked)
+- 30% Integration tests (multiple components)
+- 10% E2E tests (complete workflows)
+"""
+
+# UNIT TESTS (60%)
+class TestPlatformDetection:
+    def test_detect_macos(self):
+        with patch("platform.system", return_value="Darwin"):
+            checker = PrerequisiteChecker()
+            assert checker.platform == Platform.MACOS
+
+# INTEGRATION TESTS (30%)
+class TestPrerequisiteIntegration:
+    def test_full_check_workflow(self):
+        checker = PrerequisiteChecker()
+        with patch("shutil.which") as mock_which:
+            mock_which.side_effect = lambda x: f"/usr/bin/{x}"
+            result = checker.check_all_prerequisites()
+            assert result.all_available is True
+
+# E2E TESTS (10%)
+class TestEndToEnd:
+    def test_complete_workflow_with_guidance(self):
+        checker = PrerequisiteChecker()
+        result = checker.check_all_prerequisites()
+        message = checker.format_missing_prerequisites(result.missing_tools)
+        assert "prerequisite" in message.lower()
+```
+
+**Key Points**:
+
+- 60% unit tests for speed
+- Strategic mocking of external dependencies
+- E2E tests for complete workflows
+- All tests run in seconds
+
+## Environment & Platform Patterns
+
+### Pattern: Platform-Specific Installation Guidance
+
+**Challenge**: Users on different platforms need different installation commands.
+
+**Solution**: Detect platform automatically and provide exact installation commands.
+
+```python
+class Platform(Enum):
+    MACOS = "macos"
+    LINUX = "linux"
+    WSL = "wsl"
+    WINDOWS = "windows"
+
+class PrerequisiteChecker:
+    INSTALL_COMMANDS = {
+        Platform.MACOS: {
+            "node": "brew install node",
+            "git": "brew install git",
+        },
+        Platform.LINUX: {
+            "node": "# Ubuntu/Debian:\nsudo apt install nodejs\n# Fedora:\nsudo dnf install nodejs",
+        },
+    }
+
+    def get_install_command(self, tool: str) -> str:
+        platform_commands = self.INSTALL_COMMANDS.get(self.platform, {})
+        return platform_commands.get(tool, f"Please install {tool} manually")
+```
+
+**Key Points**:
+
+- Automatic platform detection (including WSL)
+- Multiple package managers for Linux
+- Documentation links for complex installations
+
+### Pattern: Graceful Environment Adaptation
+
+**Challenge**: Different behavior needed in different environments (UVX, normal, testing).
+
+**Solution**: Detect environment automatically and adapt through configuration objects.
+
+```python
+class EnvironmentAdapter:
+    def detect_environment(self) -> str:
+        if self._is_uvx_environment():
+            return "uvx"
+        elif self._is_testing_environment():
+            return "testing"
+        else:
+            return "normal"
+
+    def get_config(self) -> Dict[str, Any]:
+        env = self.detect_environment()
+        configs = {
+            "uvx": {"use_add_dir": True, "timeout_multiplier": 1.5},
+            "normal": {"use_add_dir": False, "timeout_multiplier": 1.0},
+            "testing": {"use_add_dir": False, "timeout_multiplier": 0.5},
+        }
+        config = configs.get(env, configs["normal"])
+        self._apply_env_overrides()  # Allow env variable overrides
+        return config
+```
+
+**Key Points**:
+
+- Automatic environment detection
+- Configuration objects over scattered conditionals
+- Environment variable overrides for customization
+
+## Performance & Optimization Patterns
+
+### Pattern: Intelligent Caching with Lifecycle Management
+
+**Challenge**: Expensive operations repeated unnecessarily, but naive caching leads to memory leaks.
+
+**Solution**: Smart caching with invalidation strategies.
+
+```python
+from functools import lru_cache
+import threading
+
+class SmartCache:
+    @lru_cache(maxsize=128)
+    def expensive_operation(self, input_data: str) -> str:
+        return self._compute_expensive_result(input_data)
+
+    def invalidate_cache(self) -> None:
+        with self._lock:
+            self.expensive_operation.cache_clear()
+
+    def get_cache_stats(self) -> Dict[str, Any]:
+        cache_info = self.expensive_operation.cache_info()
+        return {
+            "hits": cache_info.hits,
+            "misses": cache_info.misses,
+            "hit_rate": cache_info.hits / max(1, cache_info.hits + cache_info.misses)
+        }
+```
+
+**Key Points**:
+
+- lru_cache for automatic size management
+- Thread safety is essential
+- Provide invalidation methods
+- Track cache performance
+
+## File I/O & Async Patterns
+
+### Pattern: File I/O with Cloud Sync Resilience
+
+**Challenge**: File operations fail mysteriously when directories are synced with cloud services.
+
+**Solution**:
+
+```python
+def write_with_retry(filepath: Path, data: str, max_retries: int = 3):
+    """Write file with exponential backoff for cloud sync issues"""
+    retry_delay = 0.1
+
+    for attempt in range(max_retries):
+        try:
+            filepath.parent.mkdir(parents=True, exist_ok=True)
+            filepath.write_text(data)
+            return
+        except OSError as e:
+            if e.errno == 5 and attempt < max_retries - 1:
+                if attempt == 0:
+                    print("File I/O error - retrying. May be cloud sync issue.")
+                time.sleep(retry_delay)
+                retry_delay *= 2
+            else:
+                raise
+```
+
+**Key Points**:
+
+- Exponential backoff for cloud sync
+- Inform user about delays
+- Create parent directories
+
+### Pattern: System Metadata vs User Content Classification in Git Operations
+
+**Challenge**: Git-aware operations treat framework-generated metadata files (like `.version`, `.state`) as user content, causing false conflict warnings when files are auto-updated by the system.
+
+**Solution**: Explicitly categorize and filter system-generated files based on semantic purpose, not just directory structure.
+
+```python
+from pathlib import Path
+from typing import Set, List
+
+class GitAwareFileFilter:
+    """Distinguish system metadata from user content in git operations"""
+
+    # System-generated files that should never trigger conflicts
+    SYSTEM_METADATA = {
+        ".version",           # Framework version tracking
+        ".state",            # Runtime state
+        "settings.json",     # Auto-generated settings
+        "*.pyc",             # Compiled bytecode
+        "__pycache__",       # Python cache
+        ".pytest_cache",     # Test cache
+    }
+
+    def _filter_conflicts(
+        self, uncommitted_files: List[str], essential_dirs: List[str]
+    ) -> List[str]:
+        """Filter git status to exclude system metadata"""
+        conflicts = []
+        for file_path in uncommitted_files:
+            if file_path.startswith(".claude/"):
+                relative_path = file_path[8:]  # Strip ".claude/"
+
+                # Skip system-generated metadata - safe to overwrite
+                if relative_path in self.SYSTEM_METADATA:
+                    continue
+
+                # Check if file is in essential directories (user content)
+                for essential_dir in essential_dirs:
+                    if (
+                        relative_path.startswith(essential_dir + "/")
+                        or relative_path == essential_dir
+                    ):
+                        conflicts.append(file_path)
+                        break
+
+        return conflicts
+```
+
+**Usage in conflict detection**:
+
+```python
+class ConflictChecker:
+    def check_conflicts(self, source_dir: Path, essential_dirs: List[str]) -> List[Path]:
+        """Check for REAL conflicts - ignore system metadata"""
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, cwd=source_dir
+        )
+
+        uncommitted = self._parse_git_status(result.stdout)
+        user_changes = self._filter_conflicts(uncommitted, essential_dirs)
+
+        if user_changes:
+            raise ConflictError(
+                f"Uncommitted user content: {user_changes}\n"
+                f"(System metadata changes are normal and ignored)"
+            )
+```
+
+**Key Points**:
+
+- **Semantic categorization**: Filter by PURPOSE (system vs user), not location
+- **Root-level awareness**: Don't assume all root files are user content
+- **Clear error messages**: Tell users when conflicts are real vs system noise
+- **Philosophy alignment**: Ruthlessly simple - add explicit exclusion list
+- **Common pitfall**: Only checking subdirectories and missing root-level system files
+
+> **Origin**: Discovered investigating `.version` file causing false conflicts during UVX deployment. See DISCOVERIES.md (2025-12-01).
+
+### Pattern: Async Context Management
+
+**Challenge**: Nested asyncio event loops cause hangs.
+
+**Solution**: Design APIs to be fully async or fully sync, not both.
+
+```python
+# WRONG - Creates nested event loops
+class Service:
+    def process(self, data):
+        return asyncio.run(self._async_process(data))  # Creates new loop
+
+# RIGHT - Pure async throughout
+class Service:
+    async def process(self, data):
+        return await self._async_process(data)  # No new loop
+```
+
+**Key Points**:
+
+- Never mix sync/async APIs
+- Avoid asyncio.run() in libraries
+- Let caller manage the event loop
+
+## Documentation & Investigation Patterns
+
+### Pattern: Documentation Discovery Before Code Analysis
+
+**Challenge**: Agents dive into code without checking if documentation already explains the system.
+
+**Solution**: Always perform documentation discovery before code analysis.
+
+**Process**:
+
+1. Search for documentation files (README, ARCHITECTURE, docs/)
+2. Filter by relevance using keywords
+3. Read top 5 most relevant files
+4. Establish documentation baseline
+5. Use docs to guide code analysis
+
+```markdown
+Before analyzing [TOPIC], discover existing documentation:
+
+1. Glob: **/README.md, **/ARCHITECTURE.md, **/docs/**/\*.md
+2. Grep: Search for keywords related to TOPIC
+3. Read: Top 5 most relevant files
+4. Establish: What docs claim vs what exists
+5. Analyze: Verify code matches docs, identify gaps
+```
+
+**Key Points**:
+
+- Always discover docs first (30-second limit)
+- Identify doc/code discrepancies
+- Graceful degradation for missing docs
+
+## Decision-Making Patterns
+
+### Pattern: Cross-Domain Pattern Applicability Analysis
+
+**Challenge**: Teams import "industry best practices" from other domains without validating applicability, leading to unnecessary complexity.
+
+**Solution**: Five-phase framework for evaluating pattern adoption from other domains.
+
+**Phase 1: Threat Model Match**
+
+- Identify actual failure modes in YOUR system
+- Identify pattern's target failure modes
+- Verify failure modes match
+- If mismatch, REJECT pattern
+
+**Phase 2: Mechanism Appropriateness**
+
+- Does pattern assume adversarial nodes? (Usually wrong for AI agents)
+- Does pattern optimize for network communication? (Usually irrelevant for AI)
+- Does pattern solve YOUR domain's specific problem?
+
+**Phase 3: Complexity Justification**
+
+```
+Justified Complexity: Benefit Gain / Complexity Cost > 3.0
+```
+
+If ratio < 3.0, seek simpler alternatives.
+
+**Phase 4: Domain Validation**
+
+- Research pattern's origin domain
+- Verify target domain shares those characteristics
+- Check for successful applications in similar contexts
+
+**Phase 5: Alternative Exploration**
+
+- Can simpler mechanisms achieve same benefits?
+- Can you get 80% of benefit with 20% of complexity?
+
+**Key Points**:
+
+- Threat model mismatch is primary source of inappropriate pattern adoption
+- Distributed systems patterns rarely map to AI agent systems
+- "Industry best practice" without context validation is a red flag
+- Default to ruthless simplicity unless complexity clearly justified
+
+> **Origin**: Discovered evaluating PBZFT vs N-Version Programming. PBZFT would be 6-9x more complex with zero benefit. See DISCOVERIES.md (2025-10-20).
+
+## Multi-Model AI Patterns
+
+### Pattern: Multi-Model Validation Anti-Pattern (STOP Gates)
+
+**Challenge**: Validation checkpoints in AI guidance can trigger model-specific responses, helping one model while breaking another.
+
+**Problem**: STOP gates added to improve Opus caused Sonnet degradation:
+
+- Opus 4.5: STOP gates help (20/22 → 22/22 steps) ✅
+- Sonnet 4.5: STOP gates break (22/22 → 8/22 steps) ❌
+- Same text, opposite outcomes
+
+**Solution**: Remove validation checkpoints, use flow language instead.
+
+**Example - Bad (STOP Gates)**:
+
+```markdown
+## Step 1: Create GitHub Issue
+
+Create an issue for your feature.
+
+## STOP - Verify Issue Created
+
+Before proceeding to Step 2, confirm:
+
+- [ ] GitHub issue created
+- [ ] Issue number recorded
+
+Only proceed after verification complete.
+
+## Step 2: Create Branch
+
+...
+```
+
+**Example - Good (Flow Language)**:
+
+```markdown
+## Step 1: Create GitHub Issue
+
+Create an issue for your feature.
+
+## Step 2: Create Branch
+
+After creating the issue, create a feature branch...
+```
+
+**Why This Works**:
+
+- Provides clear structure without interruption points
+- Uses flow language ("After X, do Y") not interruption language ("STOP before Y")
+- Allows continuous autonomous execution
+- Works for both models
+
+**Empirical Evidence** (Issue #1755, 6/8 benchmarks complete):
+
+| Model  | With STOP Gates  | Without STOP Gates (V2)           |
+| ------ | ---------------- | --------------------------------- |
+| Sonnet | 8/22 steps (36%) | 22/22 steps (100%)                |
+| Opus   | 22/22 steps      | ~20/22 steps (maintains baseline) |
+
+**Performance Results**:
+
+- Sonnet V2: -16% cost improvement
+- Opus V2: -21% cost improvement
+- Removing gates IMPROVES performance (STOP Gate Paradox)
+
+**Key Points**:
+
+- Different models interpret "STOP" differently
+- Opus: Treats as checkpoint, proceeds
+- Sonnet: Treats as permission gate, asks user
+- High-salience language ("STOP", "MUST", ALL CAPS) risky
+- Always test multi-model before deploying guidance changes
+
+**When to Use Flow Language**:
+
+- "After X, proceed to Y" ✅
+- "When X completes, Y begins" ✅
+- "Following X, continue with Y" ✅
+
+**When to AVOID Interruption Language**:
+
+- "STOP before Y" ❌
+- "Only proceed after X" ❌
+- "Wait for confirmation before Y" ❌
+
+**Related**: Issue #1755, DISCOVERIES.md (2025-12-01)
+**Validation**: 75% complete (6/8 benchmarks), both models tested
+**Impact**: $20K-$406K annual savings from removing STOP gates
+
+---
+
+## Remember
+
+These patterns represent proven solutions from real development challenges:
+
+1. **Check this document first** - Don't reinvent solutions
+2. **Update when learning** - Keep patterns current
+3. **Include context** - Explain why, not just how
+4. **Show working code** - Examples should be copy-pasteable
+5. **Document gotchas** - Save others from the same pain

--- a/docs/concepts/philosophy.md
+++ b/docs/concepts/philosophy.md
@@ -1,0 +1,175 @@
+     here, and upstream there. Bundle-asset paths have been rewritten from
+     ~/.amplihack/.claude/... to amplifier-bundle/... to match amplihack-rs layout. -->
+
+# Development Philosophy
+
+This document outlines the core development philosophy that guides our approach to building software with AI assistance. It combines principles of ruthless simplicity with modular design for AI-powered development.
+
+## Core Philosophy
+
+### The Zen of Simple Code
+
+Our development philosophy embodies a Zen-like minimalism that values simplicity and clarity above all:
+
+- **Wabi-sabi philosophy**: Embracing simplicity and the essential. Each line serves a clear purpose without unnecessary embellishment.
+- **Occam's Razor thinking**: The solution should be as simple as possible, but no simpler.
+- **Trust in emergence**: Complex systems work best when built from simple, well-defined components that do one thing well.
+- **Present-moment focus**: The code handles what's needed now rather than anticipating every possible future scenario.
+- **Pragmatic trust**: We trust external systems enough to interact with them directly, handling failures as they occur rather than assuming they'll happen.
+
+### The Brick Philosophy for AI Development
+
+_"We provide the blueprint, and AI builds the product, one modular piece at a time."_
+
+Like a brick model, our software is built from small, clear modules. Each module is a self-contained "brick" of functionality with defined connectors (interfaces) to the rest of the system. Because these connection points are standard and stable, we can generate or regenerate any single module independently without breaking the whole.
+
+**Key concepts:**
+
+- **A brick** = Self-contained module with ONE clear responsibility
+- **A stud** = Public contract (functions, API, data model) others connect to
+- **Regeneratable** = Can be rebuilt from spec without breaking connections
+- **Isolated** = All code, tests, fixtures inside the module's folder
+
+## Core Design Principles
+
+### 1. Ruthless Simplicity
+
+- **KISS principle taken to heart**: Keep everything as simple as possible, but no simpler
+- **Minimize abstractions**: Every layer of abstraction must justify its existence
+- **Start minimal, grow as needed**: Begin with the simplest implementation that meets current needs
+- **Avoid future-proofing**: Don't build for hypothetical future requirements
+- **Question everything**: Regularly challenge complexity in the codebase
+
+### 2. Modular Architecture for AI
+
+- **Preserve key architectural patterns**: Clear module boundaries with defined contracts
+- **Simplify implementations**: Maintain pattern benefits with dramatically simpler code
+- **Scrappy but structured**: Lightweight implementations of solid architectural foundations
+- **End-to-end thinking**: Focus on complete flows rather than perfect components
+- **Regeneration-ready**: Every module can be rebuilt from its specification
+
+### 3. Zero-BS Implementations - Quality over Speed of Implementation
+
+- **Focus on quality**: Prioritize robust, well-tested implementations over quick fixes
+- **Avoid technical debt**: Don't sacrifice long-term maintainability for short-term gains
+- **Iterate with purpose**: Make incremental improvements that enhance quality
+- **No shortcuts**: Every function must work or not exist; no stubs or placeholders, no dead code, unimplemented functions, or TODOs in code
+- **Do not compromise**: Always choose quality over speed of implementation
+- **No faked APIs or mock implementations**: Implement real functionality from the start, do not create fake data or mock services (except in tests)
+- **No swallowed exceptions**: Handle errors transparently and ensure they are visible during development
+
+### 4. Library vs Custom Code
+
+Choosing between custom code and external libraries is a judgment call that evolves with requirements:
+
+#### When Custom Code Makes Sense
+
+- The need is simple and well-understood
+- You want code perfectly tuned to your exact requirements
+- Libraries would require significant "hacking" or workarounds
+- The problem is unique to your domain
+- You need full control over the implementation
+
+#### When Libraries Make Sense
+
+- They solve complex problems you'd rather not tackle (auth, crypto, video encoding)
+- They align well with your needs without major modifications
+- The problem is well-solved with mature, battle-tested solutions
+- Configuration alone can adapt them to your requirements
+- The complexity they handle far exceeds the integration cost
+
+#### Stay Flexible
+
+Keep library integration points minimal and isolated so you can switch approaches when needed. There's no shame in moving from custom to library or library to custom. Requirements change, understanding deepens, and the right answer today might not be the right answer tomorrow.
+
+## The Human-AI Partnership
+
+### Humans as Architects, AI as Builders
+
+In this approach, humans step back from being code mechanics and instead take on the role of architects and quality inspectors:
+
+- **Humans define**: Vision, specifications, contracts, and quality standards
+- **AI builds**: Code implementation according to specifications
+- **Humans validate**: Testing behavior, not reviewing every line of code
+- **AI regenerates**: Modules can be rebuilt when requirements change
+
+### Building in Parallel
+
+Our AI builders can spawn multiple versions of software in parallel:
+
+- Generate and test multiple variants of a feature simultaneously
+- Try different algorithms or approaches side by side
+- Build for multiple platforms from the same specifications
+- Learn from parallel experiments to refine specifications
+
+## Development Approach
+
+### Vertical Slices
+
+- Implement complete end-to-end functionality slices
+- Start with core user journeys
+- Get data flowing through all layers early
+- Add features horizontally only after core flows work
+
+### Iterative Implementation
+
+- 80/20 principle: Focus on high-value, low-effort features first
+- One working feature > multiple partial features
+- Validate with real usage before enhancing
+- Be willing to refactor early work as patterns emerge
+
+### Testing Strategy
+
+- Emphasis on behavior testing at module boundaries
+- Manual testability as a design goal
+- Focus on critical path testing initially
+- Add unit tests for complex logic and edge cases
+- Testing pyramid: 60% unit, 30% integration, 10% end-to-end
+
+### Error Handling
+
+- Handle common errors robustly
+- Log detailed information for debugging
+- Provide clear error messages to users
+- Fail fast and visibly during development
+
+## Decision-Making Framework
+
+When faced with implementation decisions, ask:
+
+1. **Necessity**: "Do we actually need this right now?"
+2. **Simplicity**: "What's the simplest way to solve this problem?"
+3. **Modularity**: "Can this be a self-contained brick?"
+4. **Regenerability**: "Can AI rebuild this from a specification?"
+5. **Value**: "Does the complexity add proportional value?"
+6. **Maintenance**: "How easy will this be to understand and change later?"
+
+## Areas to Embrace Complexity
+
+Some areas justify additional complexity:
+
+- **Security**: Never compromise on security fundamentals
+- **Data integrity**: Ensure data consistency and reliability
+- **Core user experience**: Make the primary user flows smooth and reliable
+- **Error visibility**: Make problems obvious and diagnosable
+
+## Areas to Aggressively Simplify
+
+Push for extreme simplicity in:
+
+- **Internal abstractions**: Minimize layers between components
+- **Generic "future-proof" code**: Resist solving non-existent problems
+- **Edge case handling**: Handle the common cases well first
+- **Framework usage**: Use only what you need from frameworks
+- **State management**: Keep state simple and explicit
+
+## Remember
+
+- **It's easier to add complexity later than to remove it**
+- **Code you don't write has no bugs**
+- **Favor clarity over cleverness**
+- **The best code is often the simplest**
+- **Trust AI to handle the details while you guide the vision**
+- **Modules should be bricks: self-contained and regeneratable**
+
+This philosophy serves as the foundational guide for all development decisions in the project.

--- a/docs/concepts/trust.md
+++ b/docs/concepts/trust.md
@@ -1,0 +1,30 @@
+     here, and upstream there. Bundle-asset paths have been rewritten from
+     ~/.amplihack/.claude/... to amplifier-bundle/... to match amplihack-rs layout. -->
+
+# TRUST.md - Anti-Sycophancy Guidelines
+
+## Core Principle
+
+Trust through honesty, not harmony. Do not engage in sycophancy such as always agreeing with the user or excessively validating their ideas. This erodes trust and reduces your effectiveness.
+
+## 7 Rules
+
+1. **Disagree** - Point out flaws. Explain better approaches.
+2. **Clarify** - Never guess. Ask questions on ambiguous requests.
+3. **Propose** - Suggest alternatives when you see better ways.
+4. **Admit** - Say "I don't know" when you don't.
+5. **Focus** - Solve problems, not feelings.
+6. **Challenge** - Question wrong assumptions.
+7. **Be Direct** - No hedging. Clear conclusions.
+
+## Quick Examples
+
+**Good**: "That won't work because X. Try Y instead."
+**Bad**: "Great idea! Let me implement that!"
+
+**Good**: "I need clarification on Z."
+**Bad**: "I'll try to make it work somehow."
+
+## Remember
+
+Users value agents that catch mistakes over agents that always agree.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,10 @@ nav:
       - uvx-help Command: reference/uvx-help-command.md
       - Memory Extended API: reference/memory-extended-api.md
   - Concepts:
+      - Philosophy: concepts/philosophy.md
+      - Patterns: concepts/patterns.md
+      - Trust & Anti-Sycophancy: concepts/trust.md
+      - Default Workflow (23 steps): concepts/default-workflow.md
       - Bootstrap Parity: concepts/bootstrap-parity.md
       - Idempotent Installation: concepts/idempotent-installation.md
       - cxx/cxx-build Contract: concepts/cxx-version-contract.md


### PR DESCRIPTION
Refs #420 (documentation parity audit)

## What

Ports four tightly-coupled foundational context documents from upstream `rysweet/amplihack` into `docs/concepts/`:

| Slug | Source upstream | Local path | Lines |
| ---- | --------------- | ---------- | ----- |
| `philosophy` | `docs/claude/context/PHILOSOPHY.md` | `docs/concepts/philosophy.md` | 175 |
| `patterns` | `docs/claude/context/PATTERNS.md` | `docs/concepts/patterns.md` | 814 |
| `trust` | `docs/claude/context/TRUST.md` | `docs/concepts/trust.md` | 30 |
| `default-workflow` | `docs/claude/workflow/DEFAULT_WORKFLOW.md` | `docs/concepts/default-workflow.md` | 450 |

All four are added to `mkdocs.yml` under the **Concepts** tab.

## Why bundled

The audit spec allows tightly-coupled multi-file sections to ship as one PR. These four documents are the agent operating doctrine and reference each other heavily (PHILOSOPHY's "Zero-BS" → PATTERNS' "Library vs Custom Code" → TRUST's "Anti-Sycophancy" → DEFAULT_WORKFLOW's 23 steps). Splitting them across four PRs would create artificial seams and merge-order coupling.

## Adaptations applied

1. Each file gains a 3-line HTML-comment attribution header at the top, naming the upstream source path and reminding maintainers to keep both sides in sync.
2. In `default-workflow.md`, all `~/.amplihack/.claude/<path>` references are rewritten to backtick-formatted `amplifier-bundle/<path>` references, matching the amplihack-rs runtime layout. The other three files had no such references.
3. No content was paraphrased or trimmed — the doctrine text is canonical and any changes belong upstream.

## CLI verification

This PR adds no CLI examples — it only ports prose documents. (The `default-workflow.md` text describes recipe-runner steps; the runner itself is documented in `docs/concepts/recipe-execution-flow.md` and `docs/reference/recipe-command.md` which already cover the verified `amplihack recipe` examples from PR #423.)

## mkdocs validation

```text
$ mkdocs build --strict
INFO    -  Doc file 'atlas/index.md' contains an unrecognized relative link 'cypher/', it was left as is.
INFO    -  Doc file 'concepts/amplihack-retirement-direction.md' contains an unrecognized relative link '../../.pm/', it was left as is.
INFO    -  Documentation built in ~2 seconds
exit: 0
```

The two `INFO` lines are pre-existing on `main` and unaffected by this PR. No `WARNING` or `ERROR` output.

## Diff scope

`docs/concepts/{philosophy,patterns,trust,default-workflow}.md` (created) + `mkdocs.yml` (4-line addition under the Concepts tab). No `.rs`, `Cargo.toml`, `crates/`, `bins/`, `recipes/`, `agents/`, `hooks/`, or workflow files are modified. Honors the docs-only constraint from #420.

## Audit-issue updates

After merge, the following audit rows in #420 will be flipped to `PORTED #<this-pr>`:

- `docs/claude/context/PHILOSOPHY.md`
- `docs/claude/context/PATTERNS.md`
- `docs/claude/context/TRUST.md`
- `docs/claude/workflow/DEFAULT_WORKFLOW.md`
