### PR TITLE
fix(recipes): propagate worktree_setup + add allow_no_op opt-out (#425, #412)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -66,6 +66,19 @@ context:
   issue_number: ""
   branch_name: ""
   worktree_path: ""
+  # Issue #425: nested-recipe context propagation for the worktree-setup
+  # output object and the orchestration opt-out flag.
+  #
+  # `worktree_setup` mirrors the workflow-worktree (step-04) output object
+  # so the recipe-runner threads it across nested recipe boundaries
+  # (smart-execute-routing -> default-workflow -> workflow-tdd, where step-08c
+  # reads ${WORKTREE_SETUP_WORKTREE_PATH}).
+  #
+  # `allow_no_op` opts orchestration / docs-only / audit / meta tasks out of
+  # the step-08c hollow-success guard. Defaults to false; smart-classify-route
+  # flips it to true when classification permits no working-tree edits.
+  worktree_setup: ""
+  allow_no_op: false
   design_spec: ""
   documentation: ""
   test_spec: ""

--- a/amplifier-bundle/recipes/smart-classify-route.yaml
+++ b/amplifier-bundle/recipes/smart-classify-route.yaml
@@ -218,6 +218,33 @@ steps:
     output: "force_single_workstream"
 
   # ─────────────────────────────────────────────────────────────────────────
+  # Issue #425: emit `allow_no_op` so step-08c (workflow-tdd) skips its
+  # hollow-success guard for orchestration / docs-only / audit / meta tasks.
+  #
+  # Allowlist (case-insensitive substring match against task_description):
+  #   audit, docs-only, orchestration, meta
+  # Default: false. Step-08c uses STRICT equality with the literal "true",
+  # so coerced values (1, yes, on, True) cannot accidentally bypass the
+  # guard for code-producing classifications.
+  # ─────────────────────────────────────────────────────────────────────────
+  - id: "materialize-allow-no-op"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      _TASK_LC=$(printf '%s' "${TASK_DESCRIPTION:-}" | tr '[:upper:]' '[:lower:]')
+      _ALLOW="false"
+      case "$_TASK_LC" in
+        *audit*|*docs-only*|*"docs only"*|*orchestration*|*meta-task*|*"meta task"*)
+          _ALLOW="true"
+          ;;
+      esac
+      if [ "$_ALLOW" = "true" ]; then
+        echo "[dev-orchestrator] allow_no_op=true (orchestration / docs-only / audit / meta classification — issue #425)" >&2
+      fi
+      printf '%s' "$_ALLOW"
+    output: "allow_no_op"
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Setup: register this session in the session tree (atomic check+register)
   # Runs for Development and Investigation tasks before any workstream spawning.
   # session_info output format: JSON {"session_id":..,"tree_id":..,"depth":..,"status":..}
@@ -251,4 +278,3 @@ steps:
         printf '{"session_id":"none","tree_id":"none","depth":0,"status":"registration_failed"}\n'
       fi
     output: "session_info"
-

--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -121,6 +121,13 @@ steps:
     condition: |
       'Development' in task_type and ((workstream_count == 1 or workstream_count == '1' or workstream_count == '') or force_single_workstream == 'true')
     recipe: "default-workflow"
+    # Issue #425: explicitly forward worktree_setup and allow_no_op so the
+    # recipe-runner threads them across the smart-execute-routing ->
+    # default-workflow -> workflow-tdd boundary. task_description and
+    # repo_path continue to flow via automatic merging in _execute_sub_recipe().
+    context:
+      worktree_setup: "{{worktree_setup}}"
+      allow_no_op: "{{allow_no_op}}"
     # No explicit context needed: task_description and repo_path flow through
     # from the parent smart-orchestrator context automatically via context merging
     # in _execute_sub_recipe().
@@ -228,6 +235,11 @@ steps:
     condition: |
       'Development' in task_type and 'BLOCKED' in recursion_guard and workstream_count != 1 and workstream_count != '1' and workstream_count != ''
     recipe: "default-workflow"
+    # Issue #425: forward worktree_setup and allow_no_op (see execute-single-
+    # round-1-development for rationale).
+    context:
+      worktree_setup: "{{worktree_setup}}"
+      allow_no_op: "{{allow_no_op}}"
     # No explicit context needed: task_description and repo_path flow through
     # from the parent smart-orchestrator context automatically.
     output: "round_1_result"
@@ -358,6 +370,12 @@ steps:
     condition: |
       adaptive_recipe == 'default-workflow'
     recipe: "default-workflow"
+    # Issue #425: forward worktree_setup and allow_no_op for adaptive recovery
+    # path so orchestration tasks routed through adaptive recovery still get
+    # the opt-out flag and worktree setup output object.
+    context:
+      worktree_setup: "{{worktree_setup}}"
+      allow_no_op: "{{allow_no_op}}"
     output: "round_1_result"
 
   - id: "adaptive-execute-investigation"
@@ -380,4 +398,3 @@ steps:
       rm -f /tmp/smart-orch-ws-*.json 2>/dev/null || true
       echo "ok"
     output: "cleanup_status"
-

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -113,6 +113,37 @@ steps:
         echo "ERROR: step-08-implement produced no output." >&2
         exit 1
       fi
+      # ----------------------------------------------------------------------
+      # Issue #425: orchestration opt-out.
+      #
+      # Some smart-orchestrator routes (audit, docs-only, orchestration, meta)
+      # legitimately produce no working-tree edits — their "implementation"
+      # is filing GitHub issues, opening child PRs, or coordinating downstream
+      # work. For those classifications the hollow-success guard below is a
+      # FALSE POSITIVE and must be skipped.
+      #
+      # Two opt-out mechanisms (precedence: sentinel > flag):
+      #   1. Sentinel match in implementer output. Canonical bytes (em-dash
+      #      U+2014, exact match via grep -F): "No files modified — orchestration task"
+      #   2. ALLOW_NO_OP context flag, strict equality "true" only. We refuse
+      #      to coerce 1 / yes / on / True so callers cannot accidentally
+      #      bypass the guard with shell-style truthiness.
+      #
+      # These checks MUST run BEFORE the `cd` so orchestration tasks pass
+      # even if WORKTREE_SETUP_WORKTREE_PATH is unset (orchestration mode
+      # may skip worktree setup entirely).
+      # ----------------------------------------------------------------------
+      _ORCH_SENTINEL='No files modified — orchestration task'
+      if printf '%s' "$IMPL" | grep -qF -- "$_ORCH_SENTINEL"; then
+        echo "INFO: step-08c orchestration opt-out — sentinel matched (issue #425)." >&2
+        echo "  Skipping hollow-success guard for orchestration / docs-only task." >&2
+        exit 0
+      fi
+      if [ "${ALLOW_NO_OP:-false}" = "true" ]; then
+        echo "INFO: step-08c orchestration opt-out — ALLOW_NO_OP=true (issue #425)." >&2
+        echo "  Skipping hollow-success guard; classification permits no working-tree edits." >&2
+        exit 0
+      fi
       # Look for the structured "Files modified:" line.
       FILES_LINE=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*Files modified:' || true)
       JUSTIFICATION=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*No-op justification:' || true)

--- a/amplifier-bundle/tools/test_default_workflow_fixes.py
+++ b/amplifier-bundle/tools/test_default_workflow_fixes.py
@@ -1956,5 +1956,468 @@ class TestWorktreePathFailLoudInTddRecipe(unittest.TestCase):
         )
 
 
+# ===========================================================================
+# Issues #425 + #412: orchestration opt-out + sibling-recipe fail-loud audit
+# ===========================================================================
+#
+# Issue #425: when smart-orchestrator routes a docs-only / audit /
+# orchestration meta-task whose "implementation" is filing GitHub issues +
+# opening child PRs (no working-tree edits), step-08c fails twice:
+#   1. WARNING about missing 'Files modified:' section.
+#   2. step-08c bails because WORKTREE_SETUP_WORKTREE_PATH is unset (the
+#      :? diagnostic from #410 firing — root cause is propagation gap at
+#      the smart-execute-routing -> default-workflow -> workflow-tdd
+#      composer boundary).
+#
+# Issue #412: same silent-fallback pattern (`${WORKTREE_*:-…}`) that #410
+# fixed in workflow-tdd / workflow-publish still exists in 4 sibling
+# recipes (workflow-finalize ×2, workflow-pr-review ×2,
+# workflow-refactor-review ×1 with a triple fallback chain).
+#
+# Fix: (A) propagate `worktree_setup` and `allow_no_op` through composers;
+# (B) add an opt-out path to step-08c (sentinel + ALLOW_NO_OP flag);
+# (C) convert the 5 remaining silent fallbacks to fail-loud `:?`.
+#
+# These tests are RED until the YAML changes are in place.
+
+_DEFAULT_WORKFLOW_YAML = _RECIPES_DIR / "default-workflow.yaml"
+_SMART_EXECUTE_ROUTING_YAML = _RECIPES_DIR / "smart-execute-routing.yaml"
+_SMART_CLASSIFY_ROUTE_YAML = _RECIPES_DIR / "smart-classify-route.yaml"
+_WORKFLOW_FINALIZE_YAML = _RECIPES_DIR / "workflow-finalize.yaml"
+_WORKFLOW_PR_REVIEW_YAML = _RECIPES_DIR / "workflow-pr-review.yaml"
+_WORKFLOW_REFACTOR_REVIEW_YAML = _RECIPES_DIR / "workflow-refactor-review.yaml"
+_WORKFLOW_PUBLISH_YAML = _RECIPES_DIR / "workflow-publish.yaml"
+
+# Canonical opt-out sentinel — exact bytes (em-dash U+2014).
+_ORCHESTRATION_SENTINEL = "No files modified \u2014 orchestration task"
+
+
+def _scrubbed_env(**overrides) -> dict:
+    """Build a minimal env with no inherited secrets (security contract).
+
+    Per design spec section A8: must use env -i + explicit allowlist (PATH,
+    HOME, plus test-specific vars). Never os.environ.copy().
+    """
+    base = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        # Avoid bash spitting locale warnings on minimal CI images.
+        "LC_ALL": "C",
+    }
+    base.update(overrides)
+    return base
+
+
+def _init_git_repo(path: str) -> None:
+    """Initialize a minimal git repo with one commit so `git diff` works."""
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t",
+         "init", "-q", "-b", "main", path],
+        check=True,
+    )
+    Path(path, "README.md").write_text("# init\n")
+    subprocess.run(
+        ["git", "-C", path, "-c", "user.name=t", "-c", "user.email=t@t",
+         "add", "README.md"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", path, "-c", "user.name=t", "-c", "user.email=t@t",
+         "commit", "-q", "-m", "init"],
+        check=True,
+    )
+
+
+class TestNoopGuardOrchestrationOptOut(unittest.TestCase):
+    """Issue #425: step-08c must allow orchestration / docs-only tasks
+    that legitimately produce no working-tree edits to pass.
+
+    Opt-out precedence (per design spec A2):
+      1. Sentinel match in IMPLEMENTATION output → exit 0
+      2. ALLOW_NO_OP=="true" (strict equality) → exit 0
+      3. Existing no-op-justification path → exit 0
+      4. Existing closed-PR / goal-already-met path → exit 0
+      5. Otherwise → fail loud (hollow-success guard preserved).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.step_cmd = _extract_step_command(
+            _WORKFLOW_TDD_YAML, "step-08c-implementation-no-op-guard"
+        )
+
+    def test_sentinel_opt_out_exits_zero_with_no_diff(self):
+        """When the implementer emits the canonical sentinel and there are
+        no working-tree edits, step-08c MUST exit 0 (orchestration task)."""
+        with tempfile.TemporaryDirectory() as repo:
+            _init_git_repo(repo)
+            impl = (
+                "Implementation summary:\n"
+                f"{_ORCHESTRATION_SENTINEL}\n"
+                "Filed issues: #1, #2, #3\n"
+                "Opened PRs: #100, #101\n"
+            )
+            env = _scrubbed_env(
+                REPO_PATH=repo,
+                WORKTREE_SETUP_WORKTREE_PATH=repo,
+                IMPLEMENTATION=impl,
+            )
+            r = subprocess.run(
+                ["bash", "-c", self.step_cmd],
+                capture_output=True, text=True, env=env, cwd=repo,
+            )
+            self.assertEqual(
+                r.returncode, 0,
+                "Sentinel-only opt-out must exit 0.\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}",
+            )
+
+    def test_allow_no_op_flag_opt_out_exits_zero_with_no_diff(self):
+        """When ALLOW_NO_OP=true and there are no edits, step-08c MUST
+        exit 0 even if the sentinel is absent."""
+        with tempfile.TemporaryDirectory() as repo:
+            _init_git_repo(repo)
+            env = _scrubbed_env(
+                REPO_PATH=repo,
+                WORKTREE_SETUP_WORKTREE_PATH=repo,
+                IMPLEMENTATION="Files modified: (none)\nOrchestration only.\n",
+                ALLOW_NO_OP="true",
+            )
+            r = subprocess.run(
+                ["bash", "-c", self.step_cmd],
+                capture_output=True, text=True, env=env, cwd=repo,
+            )
+            self.assertEqual(
+                r.returncode, 0,
+                "ALLOW_NO_OP=true opt-out must exit 0.\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}",
+            )
+
+    def test_both_sentinel_and_flag_exits_zero(self):
+        """Both opt-out paths together must still exit 0 (idempotent)."""
+        with tempfile.TemporaryDirectory() as repo:
+            _init_git_repo(repo)
+            env = _scrubbed_env(
+                REPO_PATH=repo,
+                WORKTREE_SETUP_WORKTREE_PATH=repo,
+                IMPLEMENTATION=f"X\n{_ORCHESTRATION_SENTINEL}\nY\n",
+                ALLOW_NO_OP="true",
+            )
+            r = subprocess.run(
+                ["bash", "-c", self.step_cmd],
+                capture_output=True, text=True, env=env, cwd=repo,
+            )
+            self.assertEqual(
+                r.returncode, 0,
+                "Belt-and-suspenders opt-out must exit 0.\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}",
+            )
+
+    def test_no_opt_out_no_diff_no_justification_fails_loud(self):
+        """Genuine hollow-success (no opt-out, no edits, no justification)
+        MUST still fail loud — the original hollow-success guard is intact."""
+        with tempfile.TemporaryDirectory() as repo:
+            _init_git_repo(repo)
+            env = _scrubbed_env(
+                REPO_PATH=repo,
+                WORKTREE_SETUP_WORKTREE_PATH=repo,
+                IMPLEMENTATION="Files modified: (none)\n",
+                # No ALLOW_NO_OP, no sentinel, no justification, no ISSUE_NUMBER.
+            )
+            r = subprocess.run(
+                ["bash", "-c", self.step_cmd],
+                capture_output=True, text=True, env=env, cwd=repo,
+            )
+            self.assertNotEqual(
+                r.returncode, 0,
+                "Genuine hollow success must still fail loud.\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}",
+            )
+            self.assertIn("hollow-success", r.stderr.lower() + r.stdout.lower())
+
+    def test_allow_no_op_strict_boolean_rejects_yes(self):
+        """ALLOW_NO_OP=yes / 1 / on / True MUST NOT trigger opt-out.
+        Only the literal string 'true' (lowercase) is accepted (security
+        contract: avoid coercion surprises)."""
+        for val in ("yes", "1", "on", "True", "TRUE"):
+            with self.subTest(allow_no_op=val):
+                with tempfile.TemporaryDirectory() as repo:
+                    _init_git_repo(repo)
+                    env = _scrubbed_env(
+                        REPO_PATH=repo,
+                        WORKTREE_SETUP_WORKTREE_PATH=repo,
+                        IMPLEMENTATION="Files modified: (none)\n",
+                        ALLOW_NO_OP=val,
+                    )
+                    r = subprocess.run(
+                        ["bash", "-c", self.step_cmd],
+                        capture_output=True, text=True, env=env, cwd=repo,
+                    )
+                    self.assertNotEqual(
+                        r.returncode, 0,
+                        f"ALLOW_NO_OP={val!r} must NOT trigger opt-out "
+                        "(only literal 'true' accepted).\n"
+                        f"stdout: {r.stdout}\nstderr: {r.stderr}",
+                    )
+
+    def test_real_diff_passes_regardless_of_flag(self):
+        """When the worktree contains real edits, step-08c passes via the
+        existing git-diff path (no opt-out needed)."""
+        with tempfile.TemporaryDirectory() as repo:
+            _init_git_repo(repo)
+            Path(repo, "new_file.txt").write_text("real work\n")
+            env = _scrubbed_env(
+                REPO_PATH=repo,
+                WORKTREE_SETUP_WORKTREE_PATH=repo,
+                IMPLEMENTATION="Files modified: new_file.txt\n",
+            )
+            r = subprocess.run(
+                ["bash", "-c", self.step_cmd],
+                capture_output=True, text=True, env=env, cwd=repo,
+            )
+            self.assertEqual(
+                r.returncode, 0,
+                "Real edits must pass via existing diff path.\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}",
+            )
+
+
+class TestFailLoudWorktreePath425(unittest.TestCase):
+    """Issue #425: step-08c MUST fail loud with a step-id-tagged diagnostic
+    when WORKTREE_SETUP_WORKTREE_PATH is genuinely missing AND no opt-out
+    is requested. The diagnostic must mention 'step-08c' and
+    'worktree_setup.worktree_path'.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.step_cmd = _extract_step_command(
+            _WORKFLOW_TDD_YAML, "step-08c-implementation-no-op-guard"
+        )
+
+    def test_missing_worktree_path_fails_loud_with_step_id(self):
+        with tempfile.TemporaryDirectory() as repo:
+            _init_git_repo(repo)
+            env = _scrubbed_env(
+                REPO_PATH=repo,
+                IMPLEMENTATION="Files modified: foo.py\n",
+                # WORKTREE_SETUP_WORKTREE_PATH deliberately UNSET.
+                # No opt-out: must fail loud.
+            )
+            r = subprocess.run(
+                ["bash", "-c", self.step_cmd],
+                capture_output=True, text=True, env=env, cwd=repo,
+            )
+            self.assertNotEqual(
+                r.returncode, 0,
+                "Missing WORKTREE_SETUP_WORKTREE_PATH must fail loud.\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}",
+            )
+            self.assertIn(
+                "step-08c requires worktree_setup.worktree_path",
+                r.stderr,
+                "Diagnostic must reference 'step-08c requires "
+                "worktree_setup.worktree_path' so reviewers can trace the "
+                "propagation gap to the composer boundary.\n"
+                f"stderr: {r.stderr}",
+            )
+
+    def test_missing_worktree_does_not_fail_when_orchestration_opt_out(self):
+        """If orchestration opt-out fires BEFORE the cd, missing worktree
+        path should not cause step-08c to fail. (Opt-out paths must not
+        depend on the worktree being set up.)"""
+        with tempfile.TemporaryDirectory() as repo:
+            env = _scrubbed_env(
+                REPO_PATH=repo,
+                IMPLEMENTATION=f"{_ORCHESTRATION_SENTINEL}\n",
+                ALLOW_NO_OP="true",
+                # WORKTREE_SETUP_WORKTREE_PATH deliberately UNSET.
+            )
+            r = subprocess.run(
+                ["bash", "-c", self.step_cmd],
+                capture_output=True, text=True, env=env, cwd=repo,
+            )
+            self.assertEqual(
+                r.returncode, 0,
+                "Orchestration opt-out must short-circuit before the cd "
+                "so missing worktree path is acceptable for orchestration "
+                "tasks.\nstdout: {r.stdout}\nstderr: {r.stderr}",
+            )
+
+
+class TestComposerPropagatesContext425(unittest.TestCase):
+    """Issue #425 root cause A: composers must declare and forward
+    `worktree_setup` and `allow_no_op` so the recipe-runner threads them
+    across nested-recipe boundaries.
+    """
+
+    def test_default_workflow_declares_worktree_setup_in_context(self):
+        text = _DEFAULT_WORKFLOW_YAML.read_text()
+        self.assertRegex(
+            text,
+            r"(?m)^\s*worktree_setup\s*:",
+            "default-workflow.yaml `context:` block must declare "
+            "`worktree_setup: \"\"` so the runner threads it from "
+            "smart-execute-routing into workflow-tdd.",
+        )
+
+    def test_default_workflow_declares_allow_no_op_in_context(self):
+        text = _DEFAULT_WORKFLOW_YAML.read_text()
+        self.assertRegex(
+            text,
+            r"(?m)^\s*allow_no_op\s*:",
+            "default-workflow.yaml `context:` block must declare "
+            "`allow_no_op: false` so orchestration tasks can flip it to true.",
+        )
+
+    def test_smart_execute_routing_forwards_worktree_setup(self):
+        if not _SMART_EXECUTE_ROUTING_YAML.exists():
+            self.skipTest(f"{_SMART_EXECUTE_ROUTING_YAML} not present in this branch.")
+        text = _SMART_EXECUTE_ROUTING_YAML.read_text()
+        self.assertIn(
+            "worktree_setup",
+            text,
+            "smart-execute-routing.yaml must reference `worktree_setup` "
+            "in its sub-recipe context to forward it to default-workflow.",
+        )
+
+    def test_smart_execute_routing_forwards_allow_no_op(self):
+        if not _SMART_EXECUTE_ROUTING_YAML.exists():
+            self.skipTest(f"{_SMART_EXECUTE_ROUTING_YAML} not present in this branch.")
+        text = _SMART_EXECUTE_ROUTING_YAML.read_text()
+        self.assertIn(
+            "allow_no_op",
+            text,
+            "smart-execute-routing.yaml must forward `allow_no_op` to "
+            "default-workflow context so the flag propagates end-to-end.",
+        )
+
+    def test_smart_classify_route_emits_allow_no_op(self):
+        if not _SMART_CLASSIFY_ROUTE_YAML.exists():
+            self.skipTest(f"{_SMART_CLASSIFY_ROUTE_YAML} not present in this branch.")
+        text = _SMART_CLASSIFY_ROUTE_YAML.read_text()
+        self.assertIn(
+            "allow_no_op",
+            text,
+            "smart-classify-route.yaml must emit `allow_no_op` (true for "
+            "audit/docs-only/orchestration/meta classifications, else false).",
+        )
+
+
+class TestSiblingRecipesFailLoud412(unittest.TestCase):
+    """Issue #412: the 4 sibling recipes that still use `${WORKTREE_*:-…}`
+    silent fallback must be converted to fail-loud `:?` form.
+
+    Targets:
+      - workflow-finalize.yaml (L56, L141)
+      - workflow-pr-review.yaml (L207, L303)
+      - workflow-refactor-review.yaml (L190 — triple-fallback chain)
+      - workflow-publish.yaml (audit pass; should already be clean post-#413)
+    """
+
+    SILENT_FALLBACK_RE = re.compile(r"\$\{WORKTREE_[A-Z_]*:-")
+
+    def _scan(self, path: Path) -> list[str]:
+        offenders = []
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            # Allow informational echo lines that intentionally use :-(unset).
+            if "(unset)" in line:
+                continue
+            if self.SILENT_FALLBACK_RE.search(line):
+                offenders.append(f"  L{lineno}: {line.strip()}")
+        return offenders
+
+    def test_workflow_finalize_no_silent_fallback(self):
+        offenders = self._scan(_WORKFLOW_FINALIZE_YAML)
+        self.assertEqual(
+            offenders, [],
+            "workflow-finalize.yaml must use ${VAR:?diagnostic} fail-loud "
+            "form for WORKTREE_* paths (issue #412):\n" + "\n".join(offenders),
+        )
+
+    def test_workflow_pr_review_no_silent_fallback(self):
+        offenders = self._scan(_WORKFLOW_PR_REVIEW_YAML)
+        self.assertEqual(
+            offenders, [],
+            "workflow-pr-review.yaml must use ${VAR:?diagnostic} fail-loud "
+            "form for WORKTREE_* paths (issue #412):\n" + "\n".join(offenders),
+        )
+
+    def test_workflow_refactor_review_no_silent_fallback(self):
+        offenders = self._scan(_WORKFLOW_REFACTOR_REVIEW_YAML)
+        self.assertEqual(
+            offenders, [],
+            "workflow-refactor-review.yaml must use ${VAR:?diagnostic} "
+            "fail-loud form for WORKTREE_* paths (issue #412):\n"
+            + "\n".join(offenders),
+        )
+
+    def test_workflow_refactor_review_no_triple_fallback_chain(self):
+        text = _WORKFLOW_REFACTOR_REVIEW_YAML.read_text()
+        self.assertNotIn(
+            '2>/dev/null || cd "$REPO_PATH"',
+            text,
+            "workflow-refactor-review.yaml L190 must not use the triple-"
+            "fallback `cd \"${WORKTREE_*:-$REPO_PATH}\" 2>/dev/null || "
+            "cd \"$REPO_PATH\"` chain. Replace with single :? fail-loud.",
+        )
+
+    def test_workflow_publish_no_silent_fallback(self):
+        """Per design spec A3: publish should already be clean from #413.
+        This test guards against regression."""
+        offenders = self._scan(_WORKFLOW_PUBLISH_YAML)
+        self.assertEqual(
+            offenders, [],
+            "workflow-publish.yaml regression: silent fallback re-introduced.\n"
+            + "\n".join(offenders),
+        )
+
+    def test_finalize_uses_fail_loud_at_known_sites(self):
+        text = _WORKFLOW_FINALIZE_YAML.read_text()
+        count = text.count("${WORKTREE_SETUP_WORKTREE_PATH:?")
+        self.assertGreaterEqual(
+            count, 2,
+            "workflow-finalize.yaml must contain at least two "
+            "${WORKTREE_SETUP_WORKTREE_PATH:?...} sites (was L56 and L141).",
+        )
+
+    def test_pr_review_uses_fail_loud_at_known_sites(self):
+        text = _WORKFLOW_PR_REVIEW_YAML.read_text()
+        count = text.count("${WORKTREE_SETUP_WORKTREE_PATH:?")
+        self.assertGreaterEqual(
+            count, 2,
+            "workflow-pr-review.yaml must contain at least two "
+            "${WORKTREE_SETUP_WORKTREE_PATH:?...} sites (was L207 and L303).",
+        )
+
+    def test_refactor_review_uses_fail_loud(self):
+        text = _WORKFLOW_REFACTOR_REVIEW_YAML.read_text()
+        self.assertIn(
+            "${WORKTREE_SETUP_WORKTREE_PATH:?",
+            text,
+            "workflow-refactor-review.yaml must use fail-loud :? form "
+            "(was triple-fallback at L190).",
+        )
+
+    def test_diagnostics_reference_workflow_worktree(self):
+        """All :? diagnostics in the converted recipes should mention the
+        producing step (workflow-worktree / step-04) per Zero-BS contract."""
+        for path in (
+            _WORKFLOW_FINALIZE_YAML,
+            _WORKFLOW_PR_REVIEW_YAML,
+            _WORKFLOW_REFACTOR_REVIEW_YAML,
+        ):
+            text = path.read_text()
+            for m in re.finditer(
+                r"\$\{WORKTREE_SETUP_WORKTREE_PATH:\?([^}]+)\}", text
+            ):
+                diag = m.group(1)
+                self.assertIn(
+                    "worktree", diag.lower(),
+                    f"{path.name}: diagnostic must mention 'worktree'. "
+                    f"Got: {diag!r}",
+                )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/integration/smart_orchestrator_decomposition_test.rs
+++ b/tests/integration/smart_orchestrator_decomposition_test.rs
@@ -27,6 +27,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "parse-decomposition",
     "activate-workflow",
     "materialize-force-single-workstream",
+    "materialize-allow-no-op",
     "setup-session",
     "handle-qa",
     "handle-ops-agent",

--- a/tests/issue_412_fail_loud_other_recipes.sh
+++ b/tests/issue_412_fail_loud_other_recipes.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Tests for Issue #412: the four sibling recipes that still use the
+# `${WORKTREE_*:-…}` silent-fallback pattern (which #413 already fixed in
+# workflow-publish.yaml) must be converted to fail-loud `${VAR:?…}` form
+# per the Zero-BS contract.
+#
+# Targets (lines from current main, may shift after fix):
+#   - workflow-finalize.yaml         L56, L141
+#   - workflow-pr-review.yaml        L207, L303
+#   - workflow-refactor-review.yaml  L190 (triple-fallback chain)
+#   - workflow-publish.yaml          regression guard (already clean post-#413)
+#
+# These tests validate:
+#   1. No `${WORKTREE_*:-…}` execution-path silent fallback remains in any
+#      of the four recipes (informational `:-(unset)` echoes are exempt).
+#   2. Each `cd "${WORKTREE_*:?…}"` diagnostic references workflow-worktree.
+#   3. The infamous `2>/dev/null || cd "$REPO_PATH"` chain is gone from
+#      workflow-refactor-review.yaml.
+#   4. Each recipe still has `set -euo pipefail` somewhere in the modified
+#      blocks (so :? actually aborts the step).
+#   5. Each recipe parses cleanly as YAML.
+#   6. Runtime semantics: a stripped `cd "${WORKTREE_SETUP_WORKTREE_PATH:?…}"`
+#      with the env var unset exits non-zero and surfaces the diagnostic.
+#
+# Run: bash tests/issue_412_fail_loud_other_recipes.sh
+# Expected before fix: FAIL. Expected after fix: PASS.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RECIPES_DIR="$REPO_ROOT/amplifier-bundle/recipes"
+
+FINALIZE="$RECIPES_DIR/workflow-finalize.yaml"
+PR_REVIEW="$RECIPES_DIR/workflow-pr-review.yaml"
+REFACTOR_REVIEW="$RECIPES_DIR/workflow-refactor-review.yaml"
+PUBLISH="$RECIPES_DIR/workflow-publish.yaml"
+
+ALL_TARGETS=("$FINALIZE" "$PR_REVIEW" "$REFACTOR_REVIEW" "$PUBLISH")
+
+fail=0
+pass=0
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        echo "PASS: $desc"
+        pass=$((pass+1))
+    else
+        echo "FAIL: $desc"
+        echo "      condition: $cond"
+        fail=$((fail+1))
+    fi
+}
+
+echo "=== Issue #412 TDD tests ==="
+echo "Target dir: $RECIPES_DIR"
+echo
+
+# --- Test 1: all target files exist -----------------------------------------
+for f in "${ALL_TARGETS[@]}"; do
+    assert "$(basename "$f") exists" "[ -f '$f' ]"
+done
+
+# --- Test 2: no `${WORKTREE_*:-…}` silent fallback in any execution path ----
+# Informational echo lines that intentionally use `:-(unset)` are exempt.
+for f in "${ALL_TARGETS[@]}"; do
+    name=$(basename "$f")
+    silent_count=$(grep -nE '\$\{WORKTREE_[A-Z_]*:-' "$f" | grep -v '(unset)' | wc -l | tr -d ' ')
+    if [ "$silent_count" != "0" ]; then
+        echo "      offending lines in $name:"
+        grep -nE '\$\{WORKTREE_[A-Z_]*:-' "$f" | grep -v '(unset)' | sed 's/^/        /'
+    fi
+    assert "no '\${WORKTREE_*:-…}' execution-path fallback in $name (found=$silent_count)" \
+        "[ '$silent_count' = '0' ]"
+done
+
+# --- Test 3: known-fixed sites use :? fail-loud form -------------------------
+finalize_failloud=$(grep -c '\${WORKTREE_SETUP_WORKTREE_PATH:?' "$FINALIZE" || true)
+assert "workflow-finalize.yaml has at least 2 \${WORKTREE_SETUP_WORKTREE_PATH:?...} sites (found=$finalize_failloud)" \
+    "[ '$finalize_failloud' -ge '2' ]"
+
+pr_review_failloud=$(grep -c '\${WORKTREE_SETUP_WORKTREE_PATH:?' "$PR_REVIEW" || true)
+assert "workflow-pr-review.yaml has at least 2 \${WORKTREE_SETUP_WORKTREE_PATH:?...} sites (found=$pr_review_failloud)" \
+    "[ '$pr_review_failloud' -ge '2' ]"
+
+refactor_failloud=$(grep -c '\${WORKTREE_SETUP_WORKTREE_PATH:?' "$REFACTOR_REVIEW" || true)
+assert "workflow-refactor-review.yaml has at least 1 \${WORKTREE_SETUP_WORKTREE_PATH:?...} site (found=$refactor_failloud)" \
+    "[ '$refactor_failloud' -ge '1' ]"
+
+# --- Test 4: triple-fallback chain removed from refactor-review --------------
+triple=$(grep -c '2>/dev/null || cd "\$REPO_PATH"' "$REFACTOR_REVIEW" || true)
+assert "workflow-refactor-review.yaml: triple-fallback chain removed (found=$triple)" \
+    "[ '$triple' = '0' ]"
+
+# --- Test 5: diagnostics reference workflow-worktree -------------------------
+for f in "$FINALIZE" "$PR_REVIEW" "$REFACTOR_REVIEW"; do
+    name=$(basename "$f")
+    # Every :? diagnostic should mention 'worktree' so the reviewer can
+    # trace the missing producer.
+    bad_diag=$(grep -oE '\$\{WORKTREE_SETUP_WORKTREE_PATH:\?[^}]+\}' "$f" \
+               | grep -vci 'worktree' || true)
+    assert "$name: every :? diagnostic mentions 'worktree' (bad=$bad_diag)" \
+        "[ '$bad_diag' = '0' ]"
+done
+
+# --- Test 6: bare `cd $WORKTREE_*` (unquoted) absent -------------------------
+for f in "${ALL_TARGETS[@]}"; do
+    name=$(basename "$f")
+    bare=$(grep -cE 'cd \$WORKTREE_' "$f" || true)
+    assert "no bare unquoted 'cd \$WORKTREE_*' in $name (found=$bare)" \
+        "[ '$bare' = '0' ]"
+done
+
+# --- Test 7: each modified file still has `set -euo pipefail` ----------------
+for f in "${ALL_TARGETS[@]}"; do
+    name=$(basename "$f")
+    has=$(grep -c 'set -euo pipefail' "$f" || true)
+    assert "$name retains 'set -euo pipefail' (count=$has)" \
+        "[ '$has' -ge '1' ]"
+done
+
+# --- Test 8: YAML parses cleanly --------------------------------------------
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+    for f in "${ALL_TARGETS[@]}"; do
+        name=$(basename "$f")
+        assert "$name parses with yaml.safe_load" \
+            "python3 -c 'import yaml; yaml.safe_load(open(\"$f\"))'"
+    done
+else
+    echo "SKIP: python3 + PyYAML not available, skipping YAML parse checks"
+fi
+
+# --- Test 9: runtime fail-loud reproduction (semantic guard) -----------------
+diag='step-XX requires worktree_setup.worktree_path from workflow-worktree; ensure parent recipe ran worktree-setup and propagated outputs'
+out=$(unset WORKTREE_SETUP_WORKTREE_PATH; bash -c 'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?'"$diag"'}"' 2>&1)
+rc=$?
+assert "fail-loud reproduction exits non-zero" "[ '$rc' != '0' ]"
+assert "fail-loud reproduction emits diagnostic mentioning workflow-worktree" \
+    "echo \"\$out\" | grep -q 'workflow-worktree'"
+
+# --- Test 10: success path unchanged when var is set ------------------------
+tmpdir=$(mktemp -d)
+WORKTREE_SETUP_WORKTREE_PATH="$tmpdir" bash -c \
+    'set -euo pipefail; cd "${WORKTREE_SETUP_WORKTREE_PATH:?should-not-fire}" && pwd' \
+    >/dev/null
+rc=$?
+rm -rf "$tmpdir"
+assert "success path: cd succeeds when WORKTREE_SETUP_WORKTREE_PATH is set" "[ '$rc' = '0' ]"
+
+# --- Summary ----------------------------------------------------------------
+echo
+echo "=== Summary: $pass passed, $fail failed ==="
+exit "$fail"


### PR DESCRIPTION
Fixes #425. Closes #412.

## Problem
`smart-orchestrator` consistently failed at `step-08c-implementation-no-op-guard` for docs-only / audit / orchestration meta-tasks with two coupled bugs:

1. `workflow-worktree` (step-04) completed but its `worktree_setup` output never reached step-08c — `$WORKTREE_SETUP_WORKTREE_PATH` was unset and the fail-loud guard fired.
2. The hollow-success guard rejected legitimate orchestration tasks whose 'implementation' is filing GitHub issues / opening child PRs (no working-tree edits to declare).

This blocked all multi-PR audit / parity / orchestration loops (reproduced live during the docs-parity work that produced #423 and #424).

## Fix
- `default-workflow.yaml`: declare `worktree_setup` and `allow_no_op` as first-class context inputs.
- `smart-classify-route.yaml`: detect orchestration / docs-only / audit / meta classifications via case-insensitive substring match and emit `allow_no_op=true`. Strict equality with literal 'true' — no truthy coercion.
- `smart-execute-routing.yaml`: explicitly forward `worktree_setup` + `allow_no_op` across all three sub-recipe entry points (round-1, round-1-blocked, adaptive recovery).
- `workflow-tdd.yaml`: skip the hollow-success guard when `allow_no_op == 'true'` (strict equality).

## Tests
- `tests/issue_412_fail_loud_other_recipes.sh` — 30 assertions validating fail-loud `:?` patterns and YAML parse-cleanliness across the 4 recipes from #412 (already migrated in prior work; this prevents regression).
- `amplifier-bundle/tools/test_default_workflow_fixes.py` — +22 tests exercising propagation and opt-out paths (all passing).

24 pre-existing errors in the python test file are unrelated to this PR (step-04 was moved out into `workflow-worktree.yaml` in earlier work; those tests need updating in a separate PR).

## Verification
`bash tests/issue_412_fail_loud_other_recipes.sh` → 30 passed, 0 failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>