### PR TITLE
docs(parity): port security documentation from upstream (#420)

### DIFF
--- a/docs/concepts/security-context-preservation.md
+++ b/docs/concepts/security-context-preservation.md
@@ -1,0 +1,116 @@
+# Security: Context Preservation Protection
+
+**Type**: Explanation (Understanding-Oriented)
+
+Comprehensive security enhancements in the context preservation system,
+protecting against regex denial-of-service (ReDoS) attacks and input validation
+vulnerabilities.
+
+## Vulnerabilities Addressed
+
+### Regex Denial-of-Service (ReDoS)
+
+Unvalidated user input processed through regex operations can cause exponential
+backtracking, leading to application hang or crash. All regex-heavy parsing
+methods (`_parse_requirements`, `_parse_constraints`, `_parse_success_criteria`,
+`_parse_target`, `get_latest_session_id`) now use timeout-protected wrappers.
+
+### Input Size Attacks
+
+Unlimited input size could cause memory exhaustion. Protection:
+
+- Maximum input size: 50 KB
+- Maximum line length: 1,000 characters
+- Early validation before processing
+
+### Input Injection
+
+Malicious content in user input could be stored and executed. Protection:
+
+- Unicode normalization (NFKC)
+- Character whitelist filtering
+- HTML escaping in output
+- Content sanitization
+
+## Security Architecture
+
+### SecurityConfig
+
+Centralized limits:
+
+| Parameter          | Value   | Purpose                    |
+| ------------------ | ------- | -------------------------- |
+| `MAX_INPUT_SIZE`   | 50 KB   | Maximum input              |
+| `MAX_LINE_LENGTH`  | 1,000   | Maximum line length        |
+| `MAX_SENTENCES`    | 100     | Maximum sentences          |
+| `MAX_BULLETS`      | 20      | Maximum bullet points      |
+| `MAX_REQUIREMENTS` | 10      | Maximum requirements       |
+| `MAX_CONSTRAINTS`  | 5       | Maximum constraints        |
+| `MAX_CRITERIA`     | 5       | Maximum success criteria   |
+| `REGEX_TIMEOUT`    | 1.0 s   | Regex operation timeout    |
+
+### SecurityValidator
+
+Safe wrappers for all regex operations:
+
+- `validate_input_size()` — enforces size limits
+- `sanitize_input()` — applies whitelist filtering
+- `safe_regex_finditer()` — timeout-protected finditer
+- `safe_regex_search()` — timeout-protected search
+- `safe_regex_findall()` — timeout-protected findall
+- `safe_split()` — timeout-protected split
+
+## Protection Mechanisms
+
+### Timeout Protection
+
+SIGALRM-based timeouts (Unix/Linux/macOS) with graceful fallback for Windows.
+Each regex operation has a 1-second maximum.
+
+### Input Sanitization
+
+Character whitelist approach: only alphanumerics, whitespace, punctuation, and
+common symbols are allowed. Unicode is normalized via NFKC before filtering.
+
+### Result Limiting
+
+All operations cap the number of results returned, preventing memory exhaustion
+from large result sets.
+
+### Fail-Safe Error Handling
+
+Operations fail securely with fallback responses. Security errors never expose
+system internals.
+
+```
+# Example fail-safe pattern:
+except (RegexTimeoutError, Exception):
+    # Secure fallback without exposing error details
+    requirements.append("[Requirements extraction failed - manual review needed]")
+```
+
+## Security Principles Applied
+
+| Principle                  | Implementation                            |
+| -------------------------- | ----------------------------------------- |
+| **Defense in Depth**       | Input validation + sanitization + timeout + limits |
+| **Least Privilege**        | Minimal allowed character set             |
+| **Fail Secure**            | Default deny on validation failure        |
+| **Input Validation**       | Server-side, whitelist over blacklist     |
+
+## amplihack-rs Considerations
+
+In the Rust port, equivalent protections are implemented using:
+
+- `regex` crate with built-in backtracking limits (no ReDoS by default)
+- Input size validation at deserialization boundaries
+- `serde` field-level size constraints
+- Rust's ownership model prevents many injection classes
+
+The upstream Python protections documented here inform the Rust implementation's
+threat model even where Rust provides stronger defaults.
+
+## Related
+
+- [Security Recommendations](../reference/security-recommendations.md) — operational security checklist
+- [Security Audit: Copilot CLI Flags](../reference/security-audit-copilot-cli-flags.md) — review of flag isolation

--- a/docs/reference/security-audit-copilot-cli-flags.md
+++ b/docs/reference/security-audit-copilot-cli-flags.md
@@ -1,0 +1,81 @@
+# Security Audit: Copilot CLI Flags Fix
+
+**Type**: Reference (Information-Oriented)
+
+Security review of the Copilot CLI flag isolation changes that ensure correct
+permission flags are selected based on the active agent binary.
+
+## Scope
+
+- `smart-orchestrator.yaml` — classify-and-decompose step conditionally selects
+  CLI flags based on `$AGENT_BIN`
+- `claude_process.py` — `_build_command()` selects permission flags based on
+  delegate type
+- `auto_mode.py` — `_run_sdk_subprocess()` routes flags per agent binary
+
+**Verdict**: APPROVED
+
+## Security Checklist
+
+| Area                         | Status | Notes                                                |
+| ---------------------------- | ------ | ---------------------------------------------------- |
+| Input validation             | PASS   | Env vars validated; unknown binaries raise error     |
+| Output encoding              | PASS   | No user content reflected unsanitized                |
+| Authentication/authorization | N/A    | No auth changes                                      |
+| Sensitive data handling      | PASS   | Session tokens stripped before subprocess invocation  |
+| No hardcoded secrets         | PASS   | Clean                                                |
+| Error messages               | PASS   | Emit binary name and exit code only; no stack traces |
+
+## Findings
+
+### FINDING 1 (MEDIUM): Copilot branch soft constraint
+
+Claude branch uses `--disallowed-tools` (runtime-enforced tool blocklist).
+Copilot branch uses `--allow-all-tools` with a prompt-injected constraint.
+Prompt constraints are *soft* — the model can still invoke tools.
+
+**Risk**: LOW. The classify step is a single-turn invocation. Even if the model
+ignores the constraint, the subprocess exits after one turn.
+
+**Mitigation**: Copilot CLI does not support `--disallowed-tools`. This is the
+best available approach.
+
+### FINDING 2 (LOW): `$AGENT_BIN` glob matching breadth
+
+Any binary path containing `copilot` or `codex` matches. An attacker who
+controls `AMPLIHACK_AGENT_BINARY` already has shell access, making this
+non-exploitable.
+
+### FINDING 3 (LOW): Session limit overrides via environment
+
+`_get_positive_int_env()` allows raising `max_total_api_calls` and
+`max_session_duration` via env vars. Validation correctly rejects non-positive
+and non-integer values with warnings, falling back to safe defaults.
+
+### FINDING 4 (POSITIVE): Unknown agent binary fails loudly
+
+Unknown agent binaries raise `RuntimeError` immediately rather than silently
+degrading with wrong flags. This follows the fail-secure principle.
+
+### FINDING 5 (POSITIVE): Branch name validation
+
+Branch names are validated against `[^a-zA-Z0-9/_.-]` before use in CLI
+commands, preventing argument injection via exotic branch names.
+
+## Test Coverage
+
+- 21 tests validate YAML case-statement flag isolation
+- 8 tests validate Python subprocess flag routing, timeouts, and
+  unknown-binary rejection
+- All 29 tests passing
+
+## Conclusion
+
+No blocking security issues. The implementation follows defense-in-depth:
+runtime-enforced restrictions where available (Claude), prompt-level constraints
+as fallback (Copilot), and fail-loud behavior for unknown binaries.
+
+## Related
+
+- [Security Recommendations](../reference/security-recommendations.md) — operational security checklist
+- [Security Context Preservation](../concepts/security-context-preservation.md) — input validation protections

--- a/docs/reference/security-recommendations.md
+++ b/docs/reference/security-recommendations.md
@@ -1,0 +1,83 @@
+# Security Recommendations
+
+**Type**: Reference (Information-Oriented)
+
+Operational security checklist and recommendations for amplihack deployments.
+
+## Critical Issues
+
+### 1. API Key Exposure (HIGH)
+
+Never hard-code API keys in configuration files. Use environment variables:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # Claude API
+export OPENAI_API_KEY="sk-..."          # OpenAI API (if using Copilot)
+```
+
+!!! danger "Never Commit Keys"
+    If a key appears in a config file or source code, rotate it immediately.
+
+### 2. Tool Calling Configuration
+
+Default secure settings:
+
+| Setting                              | Default | Purpose                     |
+| ------------------------------------ | ------- | --------------------------- |
+| `ENFORCE_ONE_TOOL_CALL_PER_RESPONSE` | `true`  | Limit concurrent tool calls |
+| `AMPLIHACK_TOOL_RETRY_ATTEMPTS`      | `3`     | Retry limit                 |
+
+For complex workflows requiring multiple parallel tool calls:
+
+```bash
+export ENFORCE_ONE_TOOL_CALL_PER_RESPONSE=false
+export AMPLIHACK_TOOL_RETRY_ATTEMPTS=5
+export ENABLE_TOOL_FALLBACK=true
+```
+
+### 3. Supply Chain Security
+
+The `litellm` dependency was removed from upstream amplihack due to a PyPI
+supply chain attack. amplihack-rs avoids this class of risk by using direct
+API integrations via Rust crates with `cargo audit` verification.
+
+Run supply chain checks:
+
+```bash
+cargo audit          # Check for known vulnerabilities
+cargo deny check     # License and advisory checks
+```
+
+### 4. File Logging Security
+
+The logging subsystem enforces:
+
+- Localhost-only binding (no remote access)
+- Credential sanitization in log output
+- Connection limits
+- Proper file permissions (`0600` for logs containing session data)
+
+## Implementation Priority
+
+| Priority      | Action                                         |
+| ------------- | ---------------------------------------------- |
+| **Immediate** | Ensure no API keys in source or config files   |
+| **High**      | Review tool calling limits for your workflow    |
+| **Medium**    | Run `cargo audit` in CI                        |
+| **Low**       | Add audit logging for tool executions          |
+
+## Compliance Status
+
+| Area                        | Status    |
+| --------------------------- | --------- |
+| Log streaming security      | Compliant |
+| Tool calling error handling | Compliant |
+| Localhost binding           | Compliant |
+| API key management          | Review    |
+| Tool execution limits       | Tunable   |
+
+## Related
+
+- [Security Context Preservation](../concepts/security-context-preservation.md) — ReDoS and input validation protections
+- [Security Audit: Copilot CLI Flags](../reference/security-audit-copilot-cli-flags.md) — flag isolation review
+- [Environment Variables](../reference/environment-variables.md) — all configurable env vars

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,8 @@ nav:
       - Memory Extended API: reference/memory-extended-api.md
       - Power Steering Compaction API: reference/power-steering-compaction-api.md
       - Shell Command Hook: reference/shell-command-hook.md
+      - Security Recommendations: reference/security-recommendations.md
+      - "Security Audit: Copilot CLI Flags": reference/security-audit-copilot-cli-flags.md
   - Concepts:
       - Philosophy: concepts/philosophy.md
       - Patterns: concepts/patterns.md
@@ -128,6 +130,7 @@ nav:
       - Agent Memory Architecture: concepts/agent-memory-architecture.md
       - Power Steering Compaction: concepts/power-steering-compaction.md
       - Hooks Comparison: concepts/hooks-comparison.md
+      - Security Context Preservation: concepts/security-context-preservation.md
   - Code Atlas:
       - Overview: atlas/index.md
       - "Layer 1: Repo Surface": atlas/repo-surface/README.md


### PR DESCRIPTION
## Summary

- Port 3 security-related docs from upstream amplihack to amplihack-rs
  - `concepts/security-context-preservation.md` — ReDoS and input validation protections
  - `reference/security-recommendations.md` — operational security checklist
  - `reference/security-audit-copilot-cli-flags.md` — Copilot CLI flag isolation review
- All 3 pages wired into `mkdocs.yml` nav under correct Diataxis sections
- `mkdocs build --strict` passes locally

Refs #420

## Test plan

- [x] `mkdocs build --strict` passes with zero errors
- [x] Diff restricted to `docs/**/*.md` and `mkdocs.yml`
- [x] No pre-existing docs modified or deleted
- [x] Nav entries placed under correct Diataxis sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)