### PR TITLE
docs(parity): port eval documentation from upstream (#420)

### DIFF
--- a/docs/concepts/eval-grading-improvements.md
+++ b/docs/concepts/eval-grading-improvements.md
@@ -1,0 +1,121 @@
+# Eval Grading Improvements
+
+**Type**: Explanation (Understanding-Oriented)
+
+How grader false negatives were fixed and advanced retrieval strategies
+implemented to improve evaluation accuracy.
+
+## The Problem: Grader False Negatives
+
+Consider this example:
+
+- **Question**: "What is the current project budget?"
+- **Expected**: "$1.4M"
+- **Agent answer**: "The budget increased from $1.2M to $1.4M"
+
+The agent's answer is correct ($1.4M is present), but a naive grader penalizes it
+because the historical value $1.2M matches an "incorrect pattern." This is a
+**false negative** — correct answers scored as wrong.
+
+### Root Cause
+
+The grader checked for incorrect patterns WITHOUT first verifying that the
+correct answer was present:
+
+```python
+# BUGGY: penalizes even when correct answer IS present
+if any(pattern in answer.lower() for pattern in incorrect_patterns):
+    score = 0.0
+```
+
+## The Fix: Correct-First Grading
+
+Only apply incorrect pattern penalties when the correct keywords are NOT present:
+
+```python
+def _deterministic_grade(answer: str, rubric: GradingRubric) -> float:
+    answer_lower = answer.lower()
+
+    # Check if correct keywords are present FIRST
+    has_correct = any(
+        keyword.lower() in answer_lower
+        for keyword in rubric.correct_keywords
+    )
+
+    # Only penalize incorrect patterns if correct answer is MISSING
+    if not has_correct:
+        for pattern in rubric.incorrect_patterns:
+            if pattern.lower() in answer_lower:
+                return 0.0
+
+    # Grade based on keyword match ratio
+    matches = sum(
+        1 for keyword in rubric.correct_keywords
+        if keyword.lower() in answer_lower
+    )
+    return matches / len(rubric.correct_keywords)
+```
+
+### Key Insight
+
+An answer containing both historical and current values should score based on
+whether the **current** (correct) value is present — not penalized for also
+mentioning the historical value.
+
+## Entity-Linked Retrieval
+
+Standard context-based search misses questions targeting structured entity IDs
+(e.g., `INC-2024-089`, `CVE-2024-12345`). Entity-linked retrieval extracts these
+IDs and searches across ALL contexts.
+
+### How It Works
+
+1. Extract entity IDs from question using regex patterns
+2. For each entity ID, search ALL memory contexts (not just the current one)
+3. Aggregate and deduplicate retrieved facts
+4. Return enriched fact list
+
+### Supported Entity ID Patterns
+
+| Pattern          | Example        | Use Case                    |
+| ---------------- | -------------- | --------------------------- |
+| `INC-YYYY-NNN`  | INC-2024-089   | Security incidents, outages |
+| `CVE-YYYY-NNNNN`| CVE-2024-12345 | Vulnerability tracking      |
+| `PROJ-NNN`      | PROJ-456       | Project management          |
+| `SRV-NNN`       | SRV-789        | Infrastructure inventory    |
+
+## Multi-Entity Retrieval
+
+For questions requiring multi-hop reasoning across multiple entities:
+
+1. Identify all named entities in the question
+2. Retrieve facts for each entity independently
+3. Combine with context overlap detection
+4. Support cross-entity relationship traversal
+
+This handles questions like "Compare the response times of INC-2024-089 and
+INC-2024-102" where facts about both incidents must be retrieved.
+
+## Results
+
+These improvements increased evaluation accuracy:
+
+- Overall: 96.0% to 97.8% (+1.8%)
+- Temporal evolution: 86.6% to 99.8% (+13.2%)
+- Security log analysis: 88% to 100% (+12%)
+- 9 categories reached 100% accuracy
+
+## Best Practices
+
+1. **Deterministic before semantic** — Check for exact/pattern matches first;
+   fall back to LLM grading only for ambiguous cases
+2. **Correct-first logic** — Always check for correct answers before penalizing
+   for incorrect patterns
+3. **Cross-context retrieval** — For structured IDs, search all contexts,
+   not just the current one
+4. **Multi-vote grading** — Use 3+ grading votes and take the median
+
+## Related
+
+- [Eval System Architecture](../concepts/eval-system-architecture.md) — full evaluation system overview
+- [Eval Retrieval Reference](../reference/eval-retrieval-reference.md) — retrieval method specifications

--- a/docs/concepts/eval-system-architecture.md
+++ b/docs/concepts/eval-system-architecture.md
@@ -1,0 +1,172 @@
+# Eval System Architecture
+
+**Type**: Explanation (Understanding-Oriented)
+
+Comprehensive guide to the evaluation and self-improvement infrastructure for
+goal-seeking agents. Covers the progressive test suite (L1-L12), long-horizon
+memory testing, multi-SDK evaluation, and the self-improvement loop.
+
+## Overview
+
+The eval system is a multi-layered framework that tests agent learning and
+reasoning capabilities across 12 progressively harder levels. It supports
+multiple SDK implementations, includes a self-improvement loop with patch
+proposer and reviewer voting, and provides domain-specific evaluation for
+specialized agents.
+
+## Architecture
+
+```
++------------------------------------------------------------------+
+|                    EVALUATION ENTRY POINTS                         |
++------------------------------------------------------------------+
+|                                                                    |
+|  progressive_test_suite     sdk_eval_loop       run_domain_evals  |
+|  (L1-L12 single/parallel)  (multi-SDK loop)    (domain agents)   |
+|                                                                    |
+|  self_improve/runner        long_horizon_memory                   |
+|  (closed-loop improvement)  (1000-turn stress test, 12 blocks)   |
+|                                                                    |
++------------------------------------------------------------------+
+                        |                |
+                        v                v
++------------------------------------------------------------------+
+|                    CORE EVAL PIPELINE                              |
++------------------------------------------------------------------+
+|                                                                    |
+|  1. DATA LAYER              2. AGENT LAYER                        |
+|  - test_levels (L1-L12)     - subprocess isolation                |
+|  - TestArticle/Question     - learning phase                      |
+|  - long_horizon_data        - testing phase                       |
+|    (12-block generation)    - SDK routing                         |
+|                                                                    |
+|  3. GRADING LAYER                                                 |
+|  - LLM semantic grading     - metacognition grading               |
+|  - multi-vote scoring       - level-specific rubrics              |
+|  - deterministic fallback   - 4-dimension scoring                 |
+|                                                                    |
++------------------------------------------------------------------+
+                        |
+                        v
++------------------------------------------------------------------+
+|                    ANALYSIS & IMPROVEMENT                          |
++------------------------------------------------------------------+
+|                                                                    |
+|  error_analyzer (10 failure modes)                                |
+|  patch_proposer (LLM-generated diffs)                             |
+|  reviewer_voting (3-perspective review)                           |
+|                                                                    |
+|  EVAL -> ANALYZE -> PROPOSE -> CHALLENGE -> VOTE ->               |
+|    APPLY -> RE-EVAL -> DECIDE                                     |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Progressive Test Suite (L1-L12)
+
+| Level | Name                     | Description                           |
+| ----- | ------------------------ | ------------------------------------- |
+| L1    | Direct Recall            | Single source direct recall           |
+| L2    | Multi-Source Synthesis   | Combine facts across sources          |
+| L3    | Temporal Reasoning       | Track changes over time               |
+| L4    | Procedural Learning      | Learn and apply procedures            |
+| L5    | Contradiction Handling   | Resolve conflicting information       |
+| L6    | Incremental Learning     | Accumulate knowledge over time        |
+| L7    | Teacher-Student Transfer | Teach learned knowledge to another    |
+| L8    | Analogical Reasoning     | Apply patterns to novel domains       |
+| L9    | Meta-Cognitive           | Reason about own knowledge gaps       |
+| L10   | Adversarial              | Resist misleading information         |
+| L11   | Long-Range Dependencies  | Connect distant facts                 |
+| L12   | Open-Ended Synthesis     | Generate novel insights               |
+
+Each level runs in a separate subprocess with its own memory database,
+preventing cross-level contamination.
+
+## Long-Horizon Memory Testing
+
+Stress tests agent memory across 1,000 turns using 12 information blocks
+(including security domain). Measures retention, update handling, and retrieval
+accuracy at scale.
+
+## Self-Improvement Loop
+
+An 8-stage cycle per iteration:
+
+1. **EVAL** — Run evaluation to get per-category scores
+2. **ANALYZE** — Identify worst-performing category
+3. **PROPOSE** — Generate unified diff with hypothesis and expected impact
+4. **CHALLENGE** — Devil's advocate arguments against the patch
+5. **VOTE** — Three reviewer perspectives (quality, regression, simplicity)
+6. **APPLY** — If accepted, apply patch and commit
+7. **RE-EVAL** — Run evaluation again to measure impact
+8. **DECIDE** — If regression > 5% on any category, auto-revert; if net improvement >= 2%, keep
+
+`PatchHistory` tracks all applied, reverted, and rejected patches to prevent
+repeating failed fixes.
+
+## Error Analysis Taxonomy
+
+| Failure Mode               | Description                    |
+| -------------------------- | ------------------------------ |
+| retrieval_insufficient     | Not enough facts retrieved     |
+| temporal_ordering_wrong    | Wrong temporal arithmetic      |
+| intent_misclassification   | Wrong intent detection         |
+| fact_extraction_incomplete | Missing facts in memory        |
+| synthesis_hallucination    | Invented information           |
+| update_not_applied         | Used outdated data             |
+| contradiction_undetected   | Missed conflicting sources     |
+| procedural_ordering_lost   | Steps out of sequence          |
+| teaching_coverage_gap      | Student not taught key facts   |
+| counterfactual_refusal     | Refused hypothetical reasoning |
+
+## General Capability Evaluation
+
+Beyond memory, 5 general-purpose capabilities are evaluated:
+
+| Eval Type                   | What It Tests                              | Scenarios |
+| --------------------------- | ------------------------------------------ | --------- |
+| Tool Use Efficiency         | Correct tool selection, chaining, economy  | 4         |
+| Planning                    | Multi-step task decomposition              | 3         |
+| Reasoning Under Uncertainty | Handling incomplete/conflicting evidence    | 3         |
+| Cross-Domain Transfer       | Applying patterns to new domains           | 2         |
+| Collaborative Task          | Multi-agent delegation and synthesis       | 2         |
+
+## Key Design Decisions
+
+1. **Subprocess Isolation** — Each eval level runs in a separate subprocess with
+   its own memory database, preventing cross-level contamination and ensuring
+   reproducibility.
+
+2. **LLM-Based Grading** — Uses semantic grading rather than exact-match scoring,
+   handling equivalences like "26 medals" vs "twenty-six medals" and partial credit.
+
+3. **Multi-Vote Grading** — Each answer is graded 3 times independently; the
+   median reduces noise on ambiguous answers.
+
+4. **3-Run Medians** — Single runs are unreliable due to LLM stochasticity.
+   Running 3 times and taking median scores gives stable results.
+
+## amplihack-rs Integration
+
+In amplihack-rs, the eval system is accessed via:
+
+```bash
+# Run progressive test suite
+amplihack agent-eval --levels L1,L2,L3
+
+# Run with specific SDK
+amplihack agent-eval --sdk mini --output-dir ./eval-results
+```
+
+The `crates/amplihack-agent-eval/` crate provides the Rust evaluation harness,
+while the Python eval scripts in `amplifier-bundle/` handle LLM-based grading.
+
+See [Evaluation Framework](../concepts/eval-framework.md) for the high-level
+framework overview and [Run Agent Evaluations](../howto/run-agent-evaluations.md)
+for step-by-step instructions.
+
+## Related
+
+- [Eval Grading Improvements](../concepts/eval-grading-improvements.md) — fixing grader false negatives
+- [Eval Retrieval Reference](../reference/eval-retrieval-reference.md) — retrieval method specifications
+- [Evaluation Framework](../concepts/eval-framework.md) — high-level framework overview

--- a/docs/reference/eval-retrieval-reference.md
+++ b/docs/reference/eval-retrieval-reference.md
@@ -1,0 +1,147 @@
+# Eval Retrieval Methods Reference
+
+**Type**: Reference (Information-Oriented)
+
+Specifications for retrieval methods in the amplihack evaluation system.
+These methods improve fact retrieval accuracy for structured entity IDs and
+multi-hop reasoning questions.
+
+## Method Comparison
+
+| Method                     | Use Case              | Multi-Entity | Complexity                        |
+| -------------------------- | --------------------- | ------------ | --------------------------------- |
+| `_entity_linked_retrieval` | Structured entity IDs | No           | O(n x e) where n=facts, e=entities |
+| `_multi_entity_retrieval`  | Multi-hop reasoning   | Yes          | O(n x e x k) where k=facts/entity  |
+| `_standard_retrieval`      | General questions     | No           | O(n)                              |
+
+## Entity-Linked Retrieval
+
+### Signature
+
+```python
+def _entity_linked_retrieval(
+    self,
+    question: str,
+    limit_per_entity: int = 10
+) -> list[Fact]:
+```
+
+**Parameters:**
+
+| Parameter          | Type | Default | Description                     |
+| ------------------ | ---- | ------- | ------------------------------- |
+| `question`         | str  | —       | Question text with entity IDs   |
+| `limit_per_entity` | int  | 10      | Max facts retrieved per entity  |
+
+**Returns:** Deduplicated list of facts containing the entity IDs.
+
+### Supported Entity ID Patterns
+
+| Pattern            | Regex                          | Example        |
+| ------------------ | ------------------------------ | -------------- |
+| Incident           | `INC-\d{4}-\d{3}`             | INC-2024-089   |
+| CVE                | `CVE-\d{4}-\d{4,5}`           | CVE-2024-12345 |
+| Project            | `PROJ-\d{3}`                   | PROJ-456       |
+| Server             | `SRV-\d{3}`                    | SRV-789        |
+
+### Algorithm
+
+1. Extract entity IDs from question using regex patterns
+2. For each entity ID:
+   - Search memory for facts containing the entity ID text
+   - Search across ALL contexts (not limited to single context)
+   - Retrieve up to `limit_per_entity` facts
+3. Aggregate all retrieved facts
+4. Deduplicate based on fact ID
+5. Return deduplicated fact list
+
+### When to Use
+
+- Question contains structured identifiers (INC-, CVE-, PROJ-, SRV-)
+- Standard retrieval misses because the ID is not in the current context
+- Facts about the entity are distributed across multiple learning sessions
+
+## Multi-Entity Retrieval
+
+### Signature
+
+```python
+def _multi_entity_retrieval(
+    self,
+    question: str,
+    limit_per_entity: int = 5
+) -> list[Fact]:
+```
+
+**Parameters:**
+
+| Parameter          | Type | Default | Description                     |
+| ------------------ | ---- | ------- | ------------------------------- |
+| `question`         | str  | —       | Question with multiple entities |
+| `limit_per_entity` | int  | 5       | Max facts retrieved per entity  |
+
+**Returns:** Combined fact list from all identified entities.
+
+### Algorithm
+
+1. Identify all named entities in the question
+2. For each entity:
+   - Perform independent fact retrieval
+   - Include cross-context results
+3. Combine results with overlap detection
+4. Return merged fact list
+
+### When to Use
+
+- Question requires comparing or relating multiple entities
+- Multi-hop reasoning where facts from separate entities must be combined
+- Example: "Compare the response times of INC-2024-089 and INC-2024-102"
+
+## Standard Retrieval
+
+### Signature
+
+```python
+def _standard_retrieval(
+    self,
+    question: str,
+    context: str | None = None,
+    limit: int = 10
+) -> list[Fact]:
+```
+
+**Parameters:**
+
+| Parameter | Type         | Default | Description              |
+| --------- | ------------ | ------- | ------------------------ |
+| `question` | str         | —       | Question text            |
+| `context` | str or None  | None    | Optional context filter  |
+| `limit`   | int          | 10      | Max facts to retrieve    |
+
+**Returns:** Facts matching the question within the specified context.
+
+### When to Use
+
+- General questions without structured entity IDs
+- Single-context retrieval is sufficient
+- Default retrieval path when no special patterns detected
+
+## Retrieval Strategy Selection
+
+The system automatically selects the retrieval method:
+
+```
+1. Check question for structured entity IDs (INC-, CVE-, PROJ-, SRV-)
+   -> If found: use entity_linked_retrieval
+
+2. Check if question references multiple named entities
+   -> If yes: use multi_entity_retrieval
+
+3. Default: use standard_retrieval
+```
+
+## Related
+
+- [Eval System Architecture](../concepts/eval-system-architecture.md) — full system overview
+- [Eval Grading Improvements](../concepts/eval-grading-improvements.md) — grading fix details
+- [Evaluation Framework](../concepts/eval-framework.md) — high-level framework concepts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - Shell Command Hook: reference/shell-command-hook.md
       - Security Recommendations: reference/security-recommendations.md
       - "Security Audit: Copilot CLI Flags": reference/security-audit-copilot-cli-flags.md
+      - Eval Retrieval Methods: reference/eval-retrieval-reference.md
   - Concepts:
       - Philosophy: concepts/philosophy.md
       - Patterns: concepts/patterns.md
@@ -131,6 +132,8 @@ nav:
       - Power Steering Compaction: concepts/power-steering-compaction.md
       - Hooks Comparison: concepts/hooks-comparison.md
       - Security Context Preservation: concepts/security-context-preservation.md
+      - Eval System Architecture: concepts/eval-system-architecture.md
+      - Eval Grading Improvements: concepts/eval-grading-improvements.md
   - Code Atlas:
       - Overview: atlas/index.md
       - "Layer 1: Repo Surface": atlas/repo-surface/README.md


### PR DESCRIPTION
## Summary

- Port 3 eval-related docs from upstream amplihack to amplihack-rs
  - `concepts/eval-system-architecture.md` — full evaluation system architecture (L1-L12, self-improvement loop)
  - `concepts/eval-grading-improvements.md` — grading false negative fixes and retrieval strategies
  - `reference/eval-retrieval-reference.md` — retrieval method specifications (entity-linked, multi-entity, standard)
- All 3 pages wired into `mkdocs.yml` nav under correct Diataxis sections
- `mkdocs build --strict` passes locally

Refs #420

## Test plan

- [x] `mkdocs build --strict` passes with zero errors
- [x] Diff restricted to `docs/**/*.md` and `mkdocs.yml`
- [x] No pre-existing docs modified or deleted
- [x] Nav entries placed under correct Diataxis sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)