### PR TITLE
docs(parity): port auto-mode and recipe resilience docs (#420)

### DIFF
--- a/docs/concepts/auto-mode.md
+++ b/docs/concepts/auto-mode.md
@@ -1,0 +1,114 @@
+# Auto Mode
+
+**Type**: Explanation (Understanding-Oriented)
+
+Auto mode enables autonomous agentic loops with Claude Code or GitHub Copilot
+CLI, allowing AI to work through multi-turn workflows with minimal human
+intervention.
+
+## Overview
+
+Auto mode orchestrates an intelligent loop that:
+
+1. Clarifies objectives with measurable evaluation criteria
+2. Creates detailed execution plans identifying parallel opportunities
+3. Executes plans autonomously through multiple turns
+4. Evaluates progress after each turn
+5. Continues until objective achieved or max turns reached
+6. Provides comprehensive summary of work completed
+
+## Usage
+
+### With Claude Code
+
+```bash
+# Basic auto mode
+amplihack claude --auto -- -p "implement user authentication"
+
+# With custom max turns
+amplihack claude --auto --max-turns 20 -- -p "refactor the API module"
+```
+
+### With GitHub Copilot CLI
+
+```bash
+# Basic auto mode
+amplihack copilot --auto -- -p "add logging to all services"
+
+# With custom max turns
+amplihack copilot --auto --max-turns 15 -- -p "implement feature X"
+```
+
+## How It Works
+
+### Turn 1: Objective Clarification
+
+Auto mode transforms your prompt into a clear objective with evaluation criteria.
+
+- **Input**: Your prompt
+- **Output**: Clear objective statement + measurable evaluation criteria
+
+### Turn 2: Planning
+
+Creates a detailed execution plan, identifying:
+
+- Sequential steps
+- Parallel opportunities
+- Dependencies between tasks
+
+### Turns 3-N: Execution
+
+Each turn:
+
+1. Executes the next step in the plan
+2. Evaluates progress against criteria
+3. Adjusts plan if needed
+4. Continues or terminates
+
+### Final Turn: Summary
+
+Provides:
+
+- Work completed
+- Files changed
+- Evaluation results against criteria
+- Remaining work (if any)
+
+## Session Limits
+
+Auto mode enforces safety limits to prevent runaway sessions:
+
+| Limit                  | Default | Override Env Var              |
+| ---------------------- | ------- | ----------------------------- |
+| Max turns              | 10      | `--max-turns` flag            |
+| Max API calls          | 100     | `AMPLIHACK_MAX_API_CALLS`     |
+| Max session duration   | 30 min  | `AMPLIHACK_MAX_SESSION_DURATION` |
+
+Limit overrides are validated: non-positive or non-integer values fall back
+to safe defaults with a warning.
+
+## Platform Differences
+
+| Feature              | Claude Code          | Copilot CLI         |
+| -------------------- | -------------------- | ------------------- |
+| Context injection    | Full (hook-based)    | File-based (AGENTS.md) |
+| Tool restriction     | `--disallowed-tools` | Prompt constraint   |
+| Multi-turn support   | Native               | Via subprocess loop |
+
+## amplihack-rs Integration
+
+In amplihack-rs, auto mode is invoked through the unified CLI:
+
+```bash
+amplihack claude --auto --max-turns 10 -- -p "task description"
+```
+
+The Rust binary handles argument parsing, agent binary resolution, and
+subprocess management. See [Automode Safety](../concepts/automode-safety.md)
+for critical safety guidelines.
+
+## Related
+
+- [Automode Safety](../concepts/automode-safety.md) — critical safety guide for auto mode
+- [Recipe Resilience](../concepts/recipe-resilience.md) — how recipes self-heal on failure
+- [Recipe Execution Flow](../concepts/recipe-execution-flow.md) — how recipes execute

--- a/docs/concepts/automode-safety.md
+++ b/docs/concepts/automode-safety.md
@@ -1,0 +1,122 @@
+# Automode Safety Guide
+
+**Type**: Explanation (Understanding-Oriented)
+
+!!! danger "Critical"
+    Automode works in the current directory and can conflict with active sessions.
+    Read this guide before using auto mode.
+
+## The Problem
+
+When you launch `amplihack claude --auto` from within an active Claude Code session:
+
+- Automode tries to stage files in the same `.claude/` directory
+- Conflicts with existing structure
+- Can overwrite uncommitted changes
+- Results in: `OSError: Directory not empty`
+- **Risk: Data loss**
+
+## Safe Usage Patterns
+
+### Option 1: Git Worktrees (Recommended)
+
+For parallel automode sessions:
+
+```bash
+# Commit current work first
+git add -A && git commit -m "checkpoint: before automode"
+
+# Create worktrees for each task
+git worktree add ./worktrees/automode-task1 -b automode-task1
+git worktree add ./worktrees/automode-task2 -b automode-task2
+
+# Launch from worktrees (isolated environments)
+cd ./worktrees/automode-task1
+amplihack claude --auto --max-turns 10 -- -p "task 1 description"
+```
+
+**Benefits**: Complete isolation, no file conflicts, can run in parallel.
+
+### Option 2: Commit First
+
+For single automode sessions:
+
+```bash
+# Save current work
+git add -A && git commit -m "WIP: before automode"
+
+# Launch automode
+amplihack claude --auto --max-turns 10 -- -p "task description"
+
+# If issues occur, rollback
+git reset HEAD~1
+```
+
+### Option 3: Separate Clone
+
+For experimental usage:
+
+```bash
+git clone <repo-url> ~/automode-workspace
+cd ~/automode-workspace
+amplihack claude --auto --max-turns 10 -- -p "task"
+```
+
+## What NOT To Do
+
+| Dangerous Action | Risk |
+| ---------------- | ---- |
+| Launch from active session with uncommitted work | Lost changes, conflicts |
+| Multiple automode in same directory | File staging conflicts, crashes |
+
+## Pre-Flight Checklist
+
+Before launching automode:
+
+- [ ] All important changes are committed
+- [ ] OR using a git worktree
+- [ ] OR in a separate clone
+- [ ] Understand automode will modify `.claude/` directory
+- [ ] Have recovery plan if things go wrong
+
+## Recovery
+
+If automode crashes and changes are lost:
+
+```bash
+# Check git reflog for lost commits
+git reflog
+
+# Check for stashes
+git stash list
+
+# Restore to last good state
+git reset --hard HEAD
+```
+
+## Recommended Parallel Workflow
+
+```bash
+# 1. Commit current state
+git add -A && git commit -m "checkpoint"
+
+# 2. Create worktrees
+for i in {1..3}; do
+  git worktree add ./worktrees/automode-$i -b automode-$i
+done
+
+# 3. Launch in background
+(cd ./worktrees/automode-1 && amplihack claude --auto --max-turns 10 -- -p "task 1") &
+(cd ./worktrees/automode-2 && amplihack claude --auto --max-turns 10 -- -p "task 2") &
+(cd ./worktrees/automode-3 && amplihack claude --auto --max-turns 10 -- -p "task 3") &
+wait
+
+# 4. Review results, cleanup
+git worktree remove ./worktrees/automode-{1..3}
+```
+
+## Related
+
+- [Auto Mode](../concepts/auto-mode.md) — auto mode overview and usage
+- [Worktree Support](../concepts/worktree-support.md) — worktree management in amplihack-rs
+- [Troubleshoot Worktree](../howto/troubleshoot-worktree.md) — worktree troubleshooting

--- a/docs/concepts/recipe-resilience.md
+++ b/docs/concepts/recipe-resilience.md
@@ -1,0 +1,122 @@
+# Recipe Resilience: Branch Sanitization & Sub-Recipe Recovery
+
+**Type**: Explanation (Understanding-Oriented)
+
+Two resilience improvements to the amplihack recipe runner: branch name
+sanitization and sub-recipe agentic recovery.
+
+## Branch Name Sanitization
+
+### Problem
+
+`step-04-setup-worktree` creates a git worktree using a branch name derived
+from `task_description`. Raw multi-line task descriptions (common when pasting
+from issue bodies) produce invalid branch names:
+
+```
+fatal: 'fix login bug\nwith oauth' is not a valid branch name
+```
+
+### Solution: Sanitization Pipeline
+
+The task description passes through a sanitization pipeline:
+
+```
+newlines -> spaces
+-> strip whitespace
+-> lowercase
+-> replace invalid chars with hyphens
+-> collapse consecutive hyphens
+-> truncate to 60 characters
+-> strip trailing hyphens/dots
+-> validate with git check-ref-format --branch
+-> fallback if invalid
+```
+
+### Examples
+
+| Input                                        | Branch Slug                                 |
+| -------------------------------------------- | ------------------------------------------- |
+| `Fix login bug`                              | `fix-login-bug`                             |
+| `Fix authentication bug\nThis affects oauth` | `fix-authentication-bug-this-affects-oauth`  |
+| `Add User Authentication`                    | `add-user-authentication`                   |
+| `fix: auth/login (oauth2)`                   | `fix-auth-login-oauth2`                     |
+| 120 'a' characters                           | truncated to 60 chars                       |
+| `!@#$%^&*()`                                 | fallback: `{prefix}/issue-{n}-task`         |
+
+### Fallback
+
+If the sanitized slug is empty or fails `git check-ref-format`, the branch
+name falls back to `{prefix}/issue-{issue_number}-task`.
+
+### Security
+
+The `task_description` is always passed via a named environment variable
+(`$TASK_DESC`), never interpolated into the shell command string, preventing
+shell injection.
+
+## Sub-Recipe Agentic Recovery
+
+### Problem
+
+When a sub-recipe step failed, `RecipeRunner._execute_sub_recipe()` raised
+`StepExecutionError` immediately. The entire workflow halted with no recovery
+opportunity, even for transient failures.
+
+### Solution: Recovery Agent Dispatch
+
+On sub-recipe failure, the runner invokes `_attempt_agent_recovery()` before
+raising. The recovery agent receives full failure context and can either
+complete the work or signal the failure as unrecoverable.
+
+### Recovery Flow
+
+```
+sub-recipe fails
+    |
+    v
+_attempt_agent_recovery()
+    |
+    +-- no adapter -----------> return None (no recovery)
+    +-- adapter raises -------> return None (log warning)
+    +-- empty response -------> return None
+    +-- "UNRECOVERABLE" ------> return None (log warning)
+    +-- non-empty response ---> return recovery_output (success)
+```
+
+### Recovery Prompt
+
+The recovery agent receives:
+
+- Sub-recipe name
+- Names of failed steps
+- Original error message
+- First 500 characters of partial outputs
+- Redacted context summary (up to 20 keys, 80 chars each)
+
+### Signaling Unrecoverable Failures
+
+The recovery agent includes `UNRECOVERABLE` in its response:
+
+```
+UNRECOVERABLE: the test environment requires Docker which is not installed
+```
+
+Any other non-empty response is treated as successful recovery.
+
+### Security
+
+- `partial_outputs` truncated to 500 characters before prompt construction
+- Context keys matching `token`, `secret`, `password`, `key` are redacted
+- Uses existing adapter credentials (no new auth surface)
+
+## Configuration
+
+Neither feature introduces new configuration knobs. Branch sanitization and
+recovery are always active.
+
+## Related
+
+- [Auto Mode](../concepts/auto-mode.md) — autonomous agentic loop documentation
+- [Recipe Execution Flow](../concepts/recipe-execution-flow.md) — how recipes execute
+- [Run a Recipe](../howto/run-a-recipe.md) — step-by-step recipe usage

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,9 @@ nav:
       - Security Context Preservation: concepts/security-context-preservation.md
       - Eval System Architecture: concepts/eval-system-architecture.md
       - Eval Grading Improvements: concepts/eval-grading-improvements.md
+      - Auto Mode: concepts/auto-mode.md
+      - Automode Safety: concepts/automode-safety.md
+      - Recipe Resilience: concepts/recipe-resilience.md
   - Code Atlas:
       - Overview: atlas/index.md
       - "Layer 1: Repo Surface": atlas/repo-surface/README.md


### PR DESCRIPTION
## Summary

- Port 3 operational robustness docs from upstream amplihack to amplihack-rs
  - `concepts/auto-mode.md` — autonomous agentic loop documentation
  - `concepts/automode-safety.md` — safety guide (worktree isolation, pre-flight checklist)
  - `concepts/recipe-resilience.md` — branch name sanitization and sub-recipe agentic recovery
- All 3 pages wired into `mkdocs.yml` nav under Concepts
- `mkdocs build --strict` passes locally

Refs #420

## Test plan

- [x] `mkdocs build --strict` passes with zero errors
- [x] Diff restricted to `docs/**/*.md` and `mkdocs.yml`
- [x] No pre-existing docs modified or deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)