### PR TITLE
docs(parity): port developer experience docs from upstream (#420)

### DIFF
--- a/docs/howto/create-your-own-tools.md
+++ b/docs/howto/create-your-own-tools.md
@@ -1,0 +1,128 @@
+# Create Your Own Tools
+
+**Type**: How-To (Task-Oriented)
+
+How to create new AI-powered tools with amplihack using metacognitive recipes.
+You describe **how the AI should think** — amplihack builds the solution.
+
+## Overview
+
+Tool creation follows 5 steps:
+
+1. **Identify a problem** — pick a task that is repetitive, complex, or time-consuming
+2. **Outline a metacognitive recipe** — describe the step-by-step thinking process
+3. **Use amplihack to build it** — launch creation with `/dev`
+4. **Refine and iterate** — test, give feedback, improve
+5. **Integrate** — use the tool, combine with others, contribute improvements
+
+## Step 1: Identify the Problem
+
+Choose a task you can describe clearly with a **concrete goal** and
+**measurable success criteria**. Examples:
+
+- Codebase analysis (find patterns across files)
+- Documentation generation (create docs from code)
+- Test coverage enhancement (identify untested paths)
+- Security audit (scan for common vulnerabilities)
+
+## Step 2: Formulate a Recipe
+
+Write down the approach an expert would take. Focus on **how to think**,
+not just what to do:
+
+### Break Into Steps
+
+Divide the problem into logical phases. Each step should be manageable:
+
+1. Analyze code structure
+2. Extract function signatures and docstrings
+3. Generate API reference
+4. Create usage examples
+5. Review for completeness
+
+!!! tip "Keep Steps Focused"
+    Avoid making one agent handle everything. Smaller, focused steps
+    improve reliability.
+
+### Add Checkpoints
+
+Build in review points: should the AI summarize findings before proceeding?
+Should it pause for user confirmation on ambiguous results?
+
+### Plan for Errors
+
+Include fallback plans:
+
+- "If analysis is incomplete, refine and retry"
+- "If no examples can be generated, explain why"
+
+## Step 3: Build with amplihack
+
+Launch tool creation:
+
+```
+/dev I want to create a tool called "API Documentation Generator".
+
+Goal: Analyze Python API code and generate comprehensive documentation.
+
+Steps:
+1. Scan directory for Python files with API endpoints
+2. Extract function signatures, docstrings, type hints
+3. Identify request/response models
+4. Generate markdown documentation with examples
+5. Validate all public endpoints are documented
+6. Offer draft for review and incorporate feedback
+```
+
+amplihack will:
+
+- Plan the architecture (architect agent)
+- Create code modules (builder agent)
+- Generate tests (tester agent)
+- Review for quality (reviewer agent)
+
+## Step 4: Refine and Iterate
+
+After initial generation:
+
+1. **Test the tool** on real data
+2. **Provide feedback** — describe what worked and what didn't
+3. **Iterate** — run `/dev` again with refinements
+4. **Validate** — ensure the tool handles edge cases
+
+## Step 5: Integrate
+
+### Place the Tool
+
+| Maturity      | Location                          |
+| ------------- | --------------------------------- |
+| Experimental  | `amplifier-bundle/ai_working/`    |
+| Production    | `amplifier-bundle/scenarios/`     |
+
+### Graduation Criteria
+
+Move from experimental to production when:
+
+- Proven value (2-3 successful uses)
+- Complete documentation
+- Comprehensive test coverage
+- Stability (no breaking changes for 1+ week)
+
+## Example: Code Quality Analyzer
+
+```
+/dev Create a "Code Quality Analyzer" tool that:
+
+1. Scans Rust source files for complexity metrics
+2. Identifies functions over 50 lines
+3. Flags deep nesting (>3 levels)
+4. Reports unused dependencies
+5. Generates a prioritized list of improvements
+6. Suggests specific refactoring for top 3 issues
+```
+
+## Related
+
+- [Developing amplihack](../howto/develop-amplihack.md) — local development setup
+- [Philosophy](../concepts/philosophy.md) — design principles guiding tool creation
+- [Create Custom Agent](../howto/create-custom-agent.md) — agent creation guide

--- a/docs/howto/develop-amplihack.md
+++ b/docs/howto/develop-amplihack.md
@@ -1,0 +1,152 @@
+# Developing amplihack
+
+**Type**: How-To (Task-Oriented)
+
+How to set up a local development environment for contributing to amplihack-rs.
+
+## Prerequisites
+
+- Rust toolchain (1.70+) via [rustup.rs](https://rustup.rs/)
+- Node.js 18+ and npm (for Claude Code CLI)
+- git 2.0+
+
+```bash
+# Verify prerequisites
+rustc --version && cargo --version && node --version && git --version
+```
+
+## Clone and Build
+
+```bash
+git clone https://github.com/rysweet/amplihack-rs.git
+cd amplihack-rs
+cargo build
+```
+
+## Run Tests
+
+```bash
+cargo test
+```
+
+## Project Structure
+
+| Directory            | Purpose                                      |
+| -------------------- | -------------------------------------------- |
+| `crates/`            | Rust crate workspace                         |
+| `crates/amplihack-cli/` | Main CLI binary                           |
+| `amplifier-bundle/`  | Framework assets (agents, recipes, commands)  |
+| `bridge/`            | Node.js bridge for Claude Code integration   |
+| `docs/`              | Documentation (mkdocs site)                  |
+| `tests/`             | Integration and end-to-end tests             |
+
+## Key Crates
+
+| Crate                  | Purpose                          |
+| ---------------------- | -------------------------------- |
+| `amplihack-cli`        | CLI argument parsing and routing |
+| `amplihack-core`       | Core types and utilities         |
+| `amplihack-agent-core` | Agent runtime and lifecycle      |
+| `amplihack-agent-eval` | Evaluation harness               |
+| `amplihack-memory`     | Memory backend                   |
+| `amplihack-recipes`    | Recipe runner                    |
+
+## Development Workflow
+
+### 1. Create a Feature Branch
+
+```bash
+git checkout -b feat/my-feature
+```
+
+### 2. Make Changes
+
+Edit Rust code in `crates/`, framework assets in `amplifier-bundle/`,
+or documentation in `docs/`.
+
+### 3. Format and Lint
+
+```bash
+cargo fmt --all
+cargo clippy -- -D warnings
+```
+
+### 4. Test
+
+```bash
+cargo test
+```
+
+### 5. Build Documentation (Optional)
+
+```bash
+pip install mkdocs-material  # one-time setup
+mkdocs build --strict
+```
+
+### 6. Commit and Push
+
+```bash
+git add <files>
+git commit -m "feat: description of change"
+git push -u origin feat/my-feature
+```
+
+### 7. Create Pull Request
+
+PRs require:
+
+- All CI checks passing (lint, test, build across 4 targets)
+- Documentation updates for user-facing changes
+- No regressions in existing tests
+
+## Common Tasks
+
+### Adding a CLI Subcommand
+
+1. Create a new module in `crates/amplihack-cli/src/commands/`
+2. Register it in `crates/amplihack-cli/src/commands/mod.rs`
+3. Add tests in the module's `tests/` subdirectory
+
+### Adding a Recipe
+
+1. Create a YAML file in `amplifier-bundle/recipes/`
+2. Define steps with `type: agent`, `type: shell`, or `type: sub_recipe`
+3. Test with `amplihack recipe run your-recipe.yaml`
+
+### Adding an Agent
+
+1. Create a markdown file in `amplifier-bundle/agents/`
+2. Define the agent's role, tools, and instructions
+3. Register in the appropriate directory (core, specialized, or workflows)
+
+## Troubleshooting
+
+### Build Failures
+
+```bash
+# Clean build artifacts and retry
+cargo clean && cargo build
+```
+
+### Test Failures
+
+```bash
+# Run a specific test with output
+cargo test test_name -- --nocapture
+```
+
+### Pre-commit Hook Issues
+
+The project uses pre-commit hooks. If they fail:
+
+```bash
+# Run hooks manually to see errors
+pre-commit run --all-files
+```
+
+## Related
+
+- [Prerequisites](../reference/prerequisites.md) — detailed tool installation
+- [Create Your Own Tools](../howto/create-your-own-tools.md) — building custom tools
+- [Code Review](../reference/code-review.md) — code review practices

--- a/docs/reference/code-review.md
+++ b/docs/reference/code-review.md
@@ -1,0 +1,116 @@
+# Code Review Practices
+
+**Type**: Reference (Information-Oriented)
+
+Code review practices and philosophy compliance checks for amplihack
+contributions.
+
+## Review Checklist
+
+### Philosophy Compliance
+
+| Principle              | Check                                              |
+| ---------------------- | -------------------------------------------------- |
+| Ruthless Simplicity    | No unnecessary abstractions or duplicated code     |
+| Zero-BS                | No stubs, TODOs, or placeholder implementations    |
+| Error Visibility       | All errors logged with context, no silent failures |
+| Regeneratable Modules  | No hardcoded paths or assumptions                  |
+| Present-Moment Focus   | Solves actual problems, not hypothetical ones      |
+
+### Code Quality
+
+- [ ] No duplicated code (extract helpers if needed)
+- [ ] Proper error handling with context
+- [ ] Type-safe (passes `cargo clippy -- -D warnings`)
+- [ ] Properly formatted (`cargo fmt --all`)
+- [ ] Tests cover new functionality
+- [ ] No hardcoded credentials or paths
+- [ ] Subprocess calls use arrays, not shell strings
+
+### Security
+
+- [ ] No hardcoded credentials
+- [ ] No injection vulnerabilities
+- [ ] Proper timeout handling
+- [ ] Secure error messages (no sensitive data leakage)
+- [ ] Subprocess inputs validated
+
+## Common Issues and Fixes
+
+### Code Duplication
+
+**Before** (3 copies of the same logic):
+
+```rust
+// In function A
+let result = process_input(input);
+if result.is_err() { log_error(&result); }
+
+// In function B — identical
+let result = process_input(input);
+if result.is_err() { log_error(&result); }
+```
+
+**After** (extracted helper):
+
+```rust
+fn process_and_log(input: &Input) -> Result<Output> {
+    let result = process_input(input)?;
+    Ok(result)
+}
+```
+
+### Missing Error Handling
+
+**Before** (silent failure):
+
+```rust
+let _ = subprocess.run(args);
+```
+
+**After** (visible error):
+
+```rust
+match subprocess.run(args) {
+    Ok(output) => output,
+    Err(e) => {
+        tracing::warn!("Subprocess failed: {e}");
+        return Err(e.into());
+    }
+}
+```
+
+### Incomplete Implementation
+
+**Before** (stub):
+
+```rust
+fn generate_summary() -> String {
+    todo!("implement later")
+}
+```
+
+**After** (complete or removed):
+
+```rust
+fn generate_summary(results: &[Result]) -> String {
+    format!("Completed {} tasks: {}", results.len(),
+        results.iter().filter(|r| r.is_ok()).count())
+}
+```
+
+## Review Workflow
+
+Code review happens at step 11 of the
+[Default Workflow](../concepts/default-workflow.md):
+
+1. **Self-review** — author checks against this checklist
+2. **Agent review** — reviewer agent checks philosophy compliance
+3. **CI validation** — automated lint, test, build checks
+4. **Merge** — after all checks pass
+
+## Related
+
+- [Philosophy](../concepts/philosophy.md) — design principles
+- [Developing amplihack](../howto/develop-amplihack.md) — development setup
+- [Default Workflow](../concepts/default-workflow.md) — the 23-step workflow

--- a/docs/reference/prerequisites.md
+++ b/docs/reference/prerequisites.md
@@ -1,0 +1,160 @@
+# Prerequisites
+
+**Type**: Reference (Information-Oriented)
+
+Detailed installation instructions for all tools required by amplihack-rs
+across different platforms.
+
+## Required Tools
+
+| Tool        | Min Version | Purpose                               |
+| ----------- | ----------- | ------------------------------------- |
+| **Rust**    | 1.70+       | Compiles and runs amplihack-rs        |
+| **Node.js** | v18+        | Runs Claude Code CLI                  |
+| **npm**     | (with Node) | Installs Claude Code CLI              |
+| **git**     | 2.0+        | Version control, worktrees, workflows |
+| **claude**  | latest      | Claude Code CLI (AI coding assistant) |
+
+## Quick Check
+
+```bash
+rustc --version && cargo --version && node --version && npm --version && git --version && echo "All prerequisites OK"
+```
+
+## Platform Installation
+
+### macOS
+
+```bash
+# Rust (via rustup)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Node.js and npm
+brew install node
+
+# git
+brew install git
+
+# Claude Code CLI
+npm install -g @anthropic-ai/claude-code
+```
+
+### Ubuntu / Debian
+
+```bash
+# Rust (via rustup)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Node.js 18+ (via NodeSource)
+curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+sudo apt install -y nodejs
+
+# git
+sudo apt install -y git
+
+# Claude Code CLI
+npm install -g @anthropic-ai/claude-code
+```
+
+### Fedora / RHEL
+
+```bash
+# Rust (via rustup)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Node.js and npm
+sudo dnf install nodejs npm
+
+# git
+sudo dnf install git
+
+# Claude Code CLI
+npm install -g @anthropic-ai/claude-code
+```
+
+### Windows (WSL2 Recommended)
+
+```bash
+# Install WSL2 first
+wsl --install
+
+# Then follow Ubuntu instructions above inside WSL2
+```
+
+For native Windows without WSL2, install:
+
+- Rust: [rustup-init.exe](https://rustup.rs/)
+- Node.js: [nodejs.org](https://nodejs.org/) (LTS installer)
+- git: [git-scm.com](https://git-scm.com/download/win)
+
+## Verification
+
+After installation, verify each tool:
+
+```bash
+rustc --version    # Should show 1.70+
+cargo --version    # Should show 1.70+
+node --version     # Should show v18+
+npm --version      # Should show 9+
+git --version      # Should show 2.0+
+```
+
+## Optional Tools
+
+| Tool           | Purpose                          | Install                    |
+| -------------- | -------------------------------- | -------------------------- |
+| `mkdocs`       | Build documentation site         | `pip install mkdocs-material` |
+| `pre-commit`   | Git pre-commit hooks             | `pip install pre-commit`   |
+| `gh`           | GitHub CLI for PR management     | `brew install gh` / `apt install gh` |
+| `cargo-audit`  | Security vulnerability scanning  | `cargo install cargo-audit` |
+
+## Post-Install: amplihack-rs
+
+```bash
+# Clone and build
+git clone https://github.com/rysweet/amplihack-rs.git
+cd amplihack-rs
+cargo build --release
+
+# Install
+cargo install --path crates/amplihack-cli
+
+# Verify
+amplihack --version
+```
+
+## Troubleshooting
+
+### Rust Build Errors
+
+```bash
+# Update Rust toolchain
+rustup update stable
+```
+
+### Node.js Version Too Old
+
+```bash
+# Check version
+node --version
+
+# If < 18, use nvm to install latest LTS
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+nvm install --lts
+```
+
+### Claude Code CLI Not Found
+
+```bash
+# Reinstall globally
+npm install -g @anthropic-ai/claude-code
+
+# Verify npm global bin is in PATH
+npm bin -g
+```
+
+## Related
+
+- [First-Time Install](../howto/first-install.md) — amplihack-rs installation guide
+- [Developing amplihack](../howto/develop-amplihack.md) — development environment setup
+- [Environment Variables](../reference/environment-variables.md) — configurable env vars

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,8 @@ nav:
       - Troubleshoot Worktree: howto/troubleshoot-worktree.md
       - Integrate Agent Memory: howto/integrate-agent-memory.md
       - Configure Hooks: howto/configure-hooks.md
+      - Develop amplihack: howto/develop-amplihack.md
+      - Create Your Own Tools: howto/create-your-own-tools.md
   - Skills:
       - Migrate Session: skills/migrate.md
   - Reference:
@@ -102,6 +104,8 @@ nav:
       - Security Recommendations: reference/security-recommendations.md
       - "Security Audit: Copilot CLI Flags": reference/security-audit-copilot-cli-flags.md
       - Eval Retrieval Methods: reference/eval-retrieval-reference.md
+      - Code Review Practices: reference/code-review.md
+      - Prerequisites: reference/prerequisites.md
   - Concepts:
       - Philosophy: concepts/philosophy.md
       - Patterns: concepts/patterns.md


### PR DESCRIPTION
## Summary

- Port 4 developer onboarding docs from upstream amplihack to amplihack-rs
  - `howto/develop-amplihack.md` — local development setup, project structure, dev workflow
  - `howto/create-your-own-tools.md` — creating custom tools with metacognitive recipes
  - `reference/code-review.md` — code review practices and philosophy compliance checks
  - `reference/prerequisites.md` — platform-specific prerequisite installation (macOS, Ubuntu, Fedora, Windows/WSL2)
- All 4 pages wired into `mkdocs.yml` nav under correct Diataxis sections
- `mkdocs build --strict` passes locally

Refs #420

## Test plan

- [x] `mkdocs build --strict` passes with zero errors
- [x] Diff restricted to `docs/**/*.md` and `mkdocs.yml`
- [x] No pre-existing docs modified or deleted
- [x] Nav entries placed under correct Diataxis sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)