### PR TITLE
docs(parity): port LadybugDB & memory tree docs from upstream (#420)

### DIFF
--- a/docs/concepts/five-type-memory.md
+++ b/docs/concepts/five-type-memory.md
@@ -1,0 +1,46 @@
+# Five-Type Memory (Superseded)
+
+> Ported from upstream `rysweet/amplihack:docs/memory/5-TYPE-MEMORY-GUIDE.md`.
+> The upstream page exists only as a redirect to current memory docs; the
+> redirect is preserved here for amplihack-rs users who follow links from
+> older READMEs or external references.
+>
+> **See also:** [Memory Backend Architecture](./memory-backend-architecture.md) ·
+> [Memory Tree](./memory-tree.md) ·
+> [Agent Memory Quickstart](../howto/agent-memory-quickstart.md)
+
+This older guide described an automatic 5-type memory flow with hook behavior
+and backend assumptions that are **not** the current source of truth for
+amplihack-rs.
+
+## Use These Docs Instead
+
+- [Agent Memory Quickstart](../howto/agent-memory-quickstart.md)
+- [Memory Backend Architecture](./memory-backend-architecture.md)
+- [Memory Backend Reference](../reference/memory-backend.md)
+- [LadybugDB Reference](../reference/ladybug-reference.md)
+- [Memory Tree](./memory-tree.md)
+
+## Why This Page Was Retired
+
+The current docs separate two concerns that the 5-type guide conflated:
+
+- **The in-repo CLI memory backend** — exposed by the `amplihack memory`
+  subcommands (`tree`, `export`, `import`, `clean`) and backed by either
+  SQLite or LadybugDB. See
+  [Memory Backend Architecture](./memory-backend-architecture.md).
+- **The generated `amplihack new --enable-memory` scaffold** — a standalone
+  goal-agent package that ships its own local `./memory/` directory and its
+  own backend selection. See
+  [Agent Memory Quickstart](../howto/agent-memory-quickstart.md).
+
+The older automatic-hook narrative and backend performance claims from the
+previous version of this page should not be treated as the current user
+guide.
+
+> **About the name.** "Five-type memory" refers to the original taxonomy of
+> `conversation`, `decision`, `pattern`, `context`, and `learning`. A sixth
+> type, `artifact`, was added later for binary or large-payload entries; the
+> page name is preserved for compatibility with older external links. All six
+> values are accepted by `amplihack memory tree --type` for backwards
+> compatibility — see [Memory Tree](./memory-tree.md) for the supported list.

--- a/docs/concepts/memory-tree.md
+++ b/docs/concepts/memory-tree.md
@@ -1,0 +1,108 @@
+# Memory Tree
+
+> Ported from upstream `rysweet/amplihack:docs/memory/MEMORY_TREE_VISUALIZATION.md`.
+> Concepts preserved verbatim; CLI invocations are unchanged because
+> `amplihack memory tree` is a CLI surface shared between the Python and Rust
+> implementations.
+>
+> **See also:** [Memory Backend Architecture](./memory-backend-architecture.md) ·
+> [Agent Memory Quickstart](../howto/agent-memory-quickstart.md) ·
+> [Memory Backend Reference](../reference/memory-backend.md)
+
+This page documents the current `amplihack memory tree` command.
+
+## Overview
+
+`amplihack memory tree` renders the repo's top-level session memory graph
+using the amplihack memory database — a SQLite store at
+`~/.amplihack/memory.db` by default, or a LadybugDB graph store when the
+graph backend is selected (see
+[Memory Backend Architecture](./memory-backend-architecture.md)).
+
+It is a graph view over the top-level CLI/session memory store. It is **not**
+a live view into a generated goal-agent's local `./memory/` directory.
+
+## Mental Model
+
+The memory tree is a hierarchy with three levels:
+
+1. **Root** — the memory database itself (one per `~/.amplihack/` install,
+   plus per-bundle databases when `amplihack new --enable-memory` is used).
+2. **Sessions** — each top-level session (CLI run, recipe execution, or
+   long-lived agent loop) is a node under the root.
+3. **Memory items** — individual entries (learnings, decisions, patterns,
+   conversations, contexts, artifacts) attached to a session.
+
+Edges between memory items express provenance and relationships (for example,
+a `learning` derived from a `pattern`, or an `artifact` produced by a
+`decision`). The tree view collapses these edges into a parent/child view
+suitable for human inspection.
+
+## Usage
+
+### Basic command
+
+```sh
+amplihack memory tree
+```
+
+### Filter by session
+
+```sh
+amplihack memory tree --session Session-2026-01-12
+```
+
+### Filter by memory-item type
+
+```sh
+amplihack memory tree --type learning
+amplihack memory tree --type pattern
+```
+
+The current parser accepts these legacy type names:
+
+- `conversation`
+- `decision`
+- `pattern`
+- `context`
+- `learning`
+- `artifact`
+
+### Limit depth
+
+```sh
+amplihack memory tree --depth 3
+```
+
+## Supported Options
+
+```sh
+amplihack memory tree [--session SESSION] [--type TYPE] [--depth N]
+```
+
+There is no supported top-level `--backend` flag on `memory tree` in the
+current parser. The backend is selected by the same environment variables and
+config that drive every other `amplihack memory` subcommand — see
+[Memory Backend Reference](../reference/memory-backend.md).
+
+## Output Shape
+
+The command renders a tree of the current session graph, grouped by session
+and memory item metadata. The exact styling may change, but the current
+command is intended for human inspection rather than machine parsing. For
+machine-readable output, use `amplihack memory export`.
+
+## Related Commands
+
+- `amplihack memory export` / `amplihack memory import` — agent-local
+  hierarchical memory transfer.
+- `amplihack new --enable-memory` — generated agent scaffolds with a local
+  `./memory/` directory.
+
+## Related Docs
+
+- [Agent Memory Quickstart](../howto/agent-memory-quickstart.md)
+- [Memory Backend Reference](../reference/memory-backend.md)
+- [Memory Backend Architecture](./memory-backend-architecture.md)
+- [LadybugDB Reference](../reference/ladybug-reference.md)
+- [Five-Type Memory](./five-type-memory.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ amplihack-rs is the Rust implementation of the amplihack CLI. It replaces the Py
 - [amplihack-hive API](./reference/hive-api.md) — Multi-agent orchestration and workload management
 - [amplihack-agent-generator API](./reference/agent-generator-api.md) — Goal-to-agent pipeline
 - [amplihack-memory Extended API](./reference/memory-extended-api.md) — Memory facade, manager, LadybugDB store, and evaluation
+- [LadybugDB Reference](./reference/ladybug-reference.md) — `lbug` crate API surface: schema, node/edge CRUD, querying, import/export, concurrency, and security
 
 ### Concepts
 
@@ -80,6 +81,8 @@ amplihack-rs is the Rust implementation of the amplihack CLI. It replaces the Py
 - [Agentic Step Patterns](./concepts/agentic-step-patterns.md) — Decision rules for bash vs agent vs recipe step types, prompt writing guide, and anti-patterns
 - [Smart-Orchestrator Recovery](./concepts/smart-orchestrator-recovery.md) — Failure taxonomy, four-stage recovery pipeline, hollow-success detection, and goal status values
 - [amplihack Retirement Direction](./concepts/amplihack-retirement-direction.md) — Python-to-Rust migration status, compatibility guarantees, and milestone tracking
+- [Memory Tree](./concepts/memory-tree.md) — Mental model and CLI surface for the `amplihack memory tree` command
+- [Five-Type Memory (Superseded)](./concepts/five-type-memory.md) — Redirect from the legacy 5-type memory guide to current memory documentation
 
 ## Quick Start
 

--- a/docs/reference/ladybug-reference.md
+++ b/docs/reference/ladybug-reference.md
@@ -1,0 +1,415 @@
+# LadybugDB Reference
+
+> Ported from upstream `rysweet/amplihack:docs/memory/LADYBUG_GRAPH_STORE.md`.
+> Concepts and Cypher patterns preserved; install/import snippets and call
+> sites adapted for the Rust `lbug` crate (the LadybugDB binding, formerly
+> Kuzu) used by amplihack-rs in
+> `crates/amplihack-cli/src/commands/memory/backend/graph_db/`.
+>
+> **See also:** [LadybugDB Code Graph](../concepts/kuzu-code-graph.md) ·
+> [Memory Backend](./memory-backend.md) ·
+> [Memory Backend Architecture](../concepts/memory-backend-architecture.md)
+
+This page documents the **Cypher patterns** that amplihack-rs uses against the
+LadybugDB graph store, together with the small, stable Rust API exposed by the
+`lbug` crate. Unlike the upstream Python wrapper (`KuzuGraphStore`), the Rust
+binding has no node/edge wrapper class: every operation is expressed as
+parameterised Cypher executed through `Connection::prepare` plus
+`Connection::execute`, or fired-and-forgotten through `Connection::query`.
+
+## Add the dependency
+
+Pin the `lbug` crate to the same version used in `crates/amplihack-cli/Cargo.toml`:
+
+```toml
+# Cargo.toml
+[dependencies]
+lbug = "0.15.3"
+```
+
+Or, from the command line:
+
+```sh
+cargo add lbug@0.15.3
+```
+
+## Import
+
+Import `lbug` directly. amplihack-rs does **not** re-export the `lbug` types
+on its public API — `GraphDbConnection`, `GraphDbDatabase`,
+`GraphDbSystemConfig`, and `GraphDbValue` in
+`amplihack_cli::commands::memory::backend::graph_db` are `pub(crate)` aliases
+used only inside the `amplihack-cli` crate (see
+[`graph_db/mod.rs`](https://github.com/rysweet/amplihack-rs/blob/main/crates/amplihack-cli/src/commands/memory/backend/graph_db/mod.rs)).
+
+```rust
+use lbug::{Connection, Database, SystemConfig, Value};
+```
+
+The functions amplihack-rs exposes for graph-backend callers are:
+
+| Item                            | Visibility | Purpose                                           |
+| ------------------------------- | ---------- | ------------------------------------------------- |
+| `init_graph_backend_schema`     | `pub`      | Create the full node/relationship schema.         |
+| `list_graph_sessions_from_conn` | `pub`      | List all `Session` rows as `SessionSummary`s.     |
+| `graph_rows`                    | `pub`      | Run a parameterised Cypher and collect rows.      |
+
+All other operations are written inline as Cypher and executed through `lbug`
+directly.
+
+## Open a database
+
+Construct a `Database` with `SystemConfig::default()`, then a `Connection`:
+
+```rust
+use lbug::{Connection, Database, SystemConfig};
+use std::path::Path;
+
+let db = Database::new(Path::new("/data/graph"), SystemConfig::default())?;
+let conn = Connection::new(&db)?;
+```
+
+This matches every call site in amplihack-rs (see
+[`handle.rs`](https://github.com/rysweet/amplihack-rs/blob/main/crates/amplihack-cli/src/commands/memory/backend/graph_db/handle.rs)
+`open_graph_db_at_path` and `connect_graph_db`).
+
+`SystemConfig` ships with tuning defaults from the `lbug` crate. amplihack-rs
+does not customise them; if you need to tune buffer-pool size, read-only mode,
+or other parameters, consult the lbug 0.15.3 release for the supported builder
+methods. Treat any tuning as crate-version-specific.
+
+## Run Cypher
+
+There are three call patterns in amplihack-rs, all routed through `lbug`:
+
+### 1. Fire-and-forget DDL via `query`
+
+Use `Connection::query` for statements with no parameters whose result you
+discard (typical for `CREATE NODE TABLE` / `CREATE REL TABLE`):
+
+```rust
+conn.query(
+    "CREATE NODE TABLE IF NOT EXISTS Session (
+         session_id    STRING PRIMARY KEY,
+         start_time    TIMESTAMP,
+         status        STRING,
+         metadata      STRING
+     )",
+)?;
+```
+
+### 2. Parameterised reads via `prepare` + `execute`
+
+`Connection::execute` takes a **mutable** prepared statement; the result is
+iterable and is materialised with `.collect()`:
+
+```rust
+let mut stmt = conn.prepare(
+    "MATCH (s:Session {session_id: $session_id}) RETURN s.status",
+)?;
+let rows: Vec<Vec<Value>> = conn
+    .execute(&mut stmt, vec![
+        ("session_id", Value::String(session_id.clone())),
+    ])?
+    .collect();
+```
+
+amplihack-rs wraps this pattern in `graph_rows` (see
+[`values.rs`](https://github.com/rysweet/amplihack-rs/blob/main/crates/amplihack-cli/src/commands/memory/backend/graph_db/values.rs)):
+
+```rust
+use amplihack_cli::commands::memory::backend::graph_db::{graph_rows, GraphDbValue};
+
+let rows = graph_rows(
+    &conn,
+    "MATCH (s:Session {session_id: $session_id}) RETURN s.status",
+    vec![("session_id", GraphDbValue::String(session_id.clone()))],
+)?;
+```
+
+### 3. Parameterised writes via `prepare` + `execute`
+
+Identical shape; the iterator is typically discarded:
+
+```rust
+let mut stmt = conn.prepare(
+    "CREATE (s:Session {
+         session_id: $session_id,
+         start_time: $start_time,
+         status:     $status,
+         metadata:   $metadata
+     })",
+)?;
+conn.execute(&mut stmt, vec![
+    ("session_id", Value::String(session_id.clone())),
+    ("start_time", Value::Timestamp(now)),
+    ("status",     Value::String("active".to_string())),
+    ("metadata",   Value::String("{}".to_string())),
+])?;
+```
+
+> **Note.** `execute` requires `&mut stmt`. Passing `&stmt` will not compile.
+> See `learning.rs:51,73,115,130` and `values.rs:14-15` for verified call
+> sites.
+
+## Schema
+
+amplihack-rs defines its full schema in
+[`schema.rs`](https://github.com/rysweet/amplihack-rs/blob/main/crates/amplihack-cli/src/commands/memory/backend/graph_db/schema.rs)
+and applies it through:
+
+```rust
+use amplihack_cli::commands::memory::backend::graph_db::init_graph_backend_schema;
+
+init_graph_backend_schema(&conn)?;
+```
+
+If you want to define your own node table, use `CREATE NODE TABLE IF NOT
+EXISTS` with `STRING PRIMARY KEY`:
+
+```rust
+conn.query(
+    "CREATE NODE TABLE IF NOT EXISTS Session (
+         session_id    STRING PRIMARY KEY,
+         start_time    TIMESTAMP,
+         status        STRING,
+         metadata      STRING
+     )",
+)?;
+```
+
+For a relationship table:
+
+```rust
+conn.query(
+    "CREATE REL TABLE IF NOT EXISTS CONTRIBUTES_TO_SEMANTIC (
+         FROM Session TO SemanticMemory,
+         contribution_type STRING,
+         timestamp         TIMESTAMP,
+         delta             STRING
+     )",
+)?;
+```
+
+## Node CRUD (Cypher)
+
+### Create
+
+```rust
+let mut stmt = conn.prepare(
+    "CREATE (s:Session {session_id: $session_id, start_time: $start_time, status: $status})",
+)?;
+conn.execute(&mut stmt, vec![
+    ("session_id", Value::String(session_id.clone())),
+    ("start_time", Value::Timestamp(now)),
+    ("status",     Value::String("active".to_string())),
+])?;
+```
+
+### Read
+
+```rust
+let mut stmt = conn.prepare("MATCH (s:Session {session_id: $session_id}) RETURN s")?;
+let rows: Vec<Vec<Value>> = conn
+    .execute(&mut stmt, vec![("session_id", Value::String(session_id))])?
+    .collect();
+```
+
+### Update
+
+```rust
+let mut stmt = conn.prepare(
+    "MATCH (s:Session {session_id: $session_id}) SET s.status = $status",
+)?;
+conn.execute(&mut stmt, vec![
+    ("session_id", Value::String(session_id)),
+    ("status",     Value::String("done".to_string())),
+])?;
+```
+
+### Delete
+
+```rust
+let mut stmt = conn.prepare("MATCH (s:Session {session_id: $session_id}) DELETE s")?;
+conn.execute(&mut stmt, vec![("session_id", Value::String(session_id))])?;
+```
+
+## Querying
+
+### Filtered reads
+
+```rust
+let mut stmt = conn.prepare(
+    "MATCH (s:Session) WHERE s.status = $status RETURN s LIMIT $limit",
+)?;
+let rows: Vec<Vec<Value>> = conn
+    .execute(&mut stmt, vec![
+        ("status", Value::String("active".to_string())),
+        ("limit",  Value::Int64(10)),
+    ])?
+    .collect();
+```
+
+amplihack-rs exposes a higher-level helper `list_graph_sessions_from_conn` for
+the `Session` table specifically — see
+[`queries.rs`](https://github.com/rysweet/amplihack-rs/blob/main/crates/amplihack-cli/src/commands/memory/backend/graph_db/queries.rs).
+
+### Keyword search
+
+amplihack-rs builds keyword search at the application layer: it splits search
+text into up to 6 meaningful tokens (length ≥ 3, stop words removed) and
+matches any token against the relevant `STRING` columns using `CONTAINS()`.
+
+```rust
+let mut stmt = conn.prepare(
+    "MATCH (m:SemanticMemory)
+     WHERE m.content CONTAINS $term OR m.concept CONTAINS $term
+     RETURN m LIMIT $limit",
+)?;
+let rows: Vec<Vec<Value>> = conn
+    .execute(&mut stmt, vec![
+        ("term",  Value::String("authentication".to_string())),
+        ("limit", Value::Int64(5)),
+    ])?
+    .collect();
+```
+
+## Edges (Cypher)
+
+### Create
+
+```rust
+let mut stmt = conn.prepare(
+    "MATCH (s:Session {session_id: $session_id}),
+           (m:SemanticMemory {memory_id: $memory_id})
+     CREATE (s)-[:CONTRIBUTES_TO_SEMANTIC {
+         contribution_type: $contribution_type,
+         timestamp:         $timestamp,
+         delta:             $delta
+     }]->(m)",
+)?;
+conn.execute(&mut stmt, vec![
+    ("session_id",        Value::String(session_id)),
+    ("memory_id",         Value::String(memory_id)),
+    ("contribution_type", Value::String("created".to_string())),
+    ("timestamp",         Value::Timestamp(now)),
+    ("delta",             Value::String("initial_creation".to_string())),
+])?;
+```
+
+### Traverse
+
+Direction is controlled by the Cypher pattern: `(n)-[r]->()` (outgoing),
+`()-[r]->(n)` (incoming), or `(n)-[r]-()` (both).
+
+```rust
+let mut stmt = conn.prepare(
+    "MATCH (s:Session {session_id: $session_id})-[r]->(other) RETURN s, r, other",
+)?;
+let rows: Vec<Vec<Value>> = conn
+    .execute(&mut stmt, vec![("session_id", Value::String(session_id))])?
+    .collect();
+```
+
+### Delete
+
+```rust
+let mut stmt = conn.prepare(
+    "MATCH (a {session_id: $from})-[r:CONTRIBUTES_TO_SEMANTIC]->(b {memory_id: $to}) DELETE r",
+)?;
+conn.execute(&mut stmt, vec![
+    ("from", Value::String(from_id)),
+    ("to",   Value::String(to_id)),
+])?;
+```
+
+## Bulk Import / Export
+
+amplihack-rs does not ship a bulk import/export wrapper at the Rust API
+surface; the upstream Python `KuzuGraphStore` `export_nodes` /
+`import_nodes` / `export_edges` / `import_edges` helpers are implemented in
+the application layer using the same primitives:
+
+```rust
+// Export all nodes as (label, id, properties)
+let mut stmt = conn.prepare(
+    "MATCH (n) RETURN labels(n)[0], n.session_id, properties(n)",
+)?;
+let rows: Vec<Vec<Value>> = conn.execute(&mut stmt, vec![])?.collect();
+```
+
+```rust
+// Idempotent re-import via MERGE
+let mut stmt = conn.prepare(
+    "MERGE (s:Session {session_id: $session_id}) SET s += $props",
+)?;
+for (id, props) in nodes {
+    conn.execute(&mut stmt, vec![
+        ("session_id", Value::String(id)),
+        ("props",      props),
+    ])?;
+}
+```
+
+`MERGE` gives idempotent upsert semantics on the primary key, so re-importing
+the same export is a no-op.
+
+## Lifecycle
+
+`Connection` and `Database` are released by `Drop`. In Rust this happens at
+scope exit; for deterministic release, scope the `Database` in a block or
+call `drop(db)` explicitly:
+
+```rust
+{
+    let db = Database::new(path, SystemConfig::default())?;
+    let conn = Connection::new(&db)?;
+    // ... do work ...
+} // db and conn are dropped here
+```
+
+amplihack-rs encapsulates this lifetime in `GraphDbHandle::with_conn`, which
+opens a fresh `Connection` for the duration of the closure (see
+[`handle.rs`](https://github.com/rysweet/amplihack-rs/blob/main/crates/amplihack-cli/src/commands/memory/backend/graph_db/handle.rs)).
+
+## Concurrency
+
+`GraphDbHandle` is `Send + Sync` and synchronises in-process access by
+opening a `Connection` per call. Cross-process safety is delegated to
+`lbug`/LadybugDB's own locking; consult the upstream LadybugDB documentation
+for the lock-mode matrix and timeouts. amplihack-rs surfaces any failure to
+acquire the lock as an `anyhow::Error`.
+
+## Security
+
+- All Cypher executed against user input uses `$param` binding via
+  `Connection::prepare` + `Connection::execute`. There is no string
+  interpolation of values.
+- Identifier validation (table names, relationship types, property keys
+  interpolated into Cypher) is the caller's responsibility. amplihack-rs
+  validates against `^[a-zA-Z_][a-zA-Z0-9_]*$` before composing any
+  identifier into a Cypher string.
+
+## Environment variables and CLI flags
+
+amplihack-rs currently honours the **legacy `KUZU_*` names** for the database
+path. The `LADYBUG_*` rename is planned but not yet implemented in this repo.
+
+| Variable / flag           | Status                | Purpose                                                                                  |
+| ------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
+| `AMPLIHACK_KUZU_DB_PATH`  | Current (legacy name) | Path to the LadybugDB graph database. Read in `graph_db/resolve.rs`.                     |
+| `--kuzu-path` (CLI flag)  | Current (legacy name) | Override the database path on the CLI. Hidden flag; defined in `cli_commands.rs`.        |
+| `--backend kuzu`          | Current               | Selects the graph-backed memory backend (`Backend::Kuzu`).                               |
+
+Source: `crates/amplihack-cli/src/commands/memory/backend/graph_db/resolve.rs`
+and `crates/amplihack-cli/src/cli_commands.rs`. New `LADYBUG_*` aliases will
+be added when the CLI surface is renamed; this page will be updated at that
+time.
+
+## Related
+
+- [LadybugDB Code Graph](../concepts/kuzu-code-graph.md)
+- [Memory Backend Architecture](../concepts/memory-backend-architecture.md)
+- [Memory Backend](./memory-backend.md)
+- [Memory Tree](../concepts/memory-tree.md)
+- [Five-Type Memory](../concepts/five-type-memory.md)

--- a/scripts/test_docs_parity_batch_c.sh
+++ b/scripts/test_docs_parity_batch_c.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Test suite for Issue #420 Doc Parity Batch C.
+#
+# Validates the contract for ported LadybugDB / memory-tree docs:
+#  - required files exist at correct Diataxis paths with kebab-case names
+#  - hard-fail content checks pass (no Python-only fences, pip install,
+#    `import kuzu` remnants, or leaked secrets)
+#  - docs/index.md links the three new docs
+#  - all internal "See also" links resolve
+#  - lbug crate version reference (if any) matches workspace pin (0.15.3)
+#  - KUZU_* env-var references appear only as legacy alias notes
+#
+# Exit non-zero on any failure. Run from repo root or the worktree root.
+
+set -u
+
+DOCS_DIR="${DOCS_DIR:-docs}"
+INDEX="$DOCS_DIR/index.md"
+PORTED=(
+  "$DOCS_DIR/reference/ladybug-reference.md"
+  "$DOCS_DIR/concepts/memory-tree.md"
+  "$DOCS_DIR/concepts/five-type-memory.md"
+)
+
+pass=0
+fail=0
+report() {
+  local status="$1" msg="$2"
+  if [[ "$status" == "PASS" ]]; then
+    printf '  \033[32mPASS\033[0m %s\n' "$msg"
+    pass=$((pass + 1))
+  else
+    printf '  \033[31mFAIL\033[0m %s\n' "$msg"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "==> [1/7] Required files exist"
+for f in "${PORTED[@]}"; do
+  if [[ -f "$f" && -s "$f" ]]; then
+    report PASS "exists and non-empty: $f"
+  else
+    report FAIL "missing or empty: $f"
+  fi
+done
+
+echo "==> [2/7] Filenames are kebab-case"
+for f in "${PORTED[@]}"; do
+  base="$(basename "$f" .md)"
+  if [[ "$base" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+    report PASS "kebab-case: $base"
+  else
+    report FAIL "not kebab-case: $base"
+  fi
+done
+
+echo "==> [3/7] Hard-fail content checks (no Python-only verbatim, no secrets)"
+for f in "${PORTED[@]}"; do
+  [[ -f "$f" ]] || continue
+  if grep -Eq '^```(python|py)\s*$' "$f"; then
+    report FAIL "python code fence in $f"
+  else
+    report PASS "no python fence: $f"
+  fi
+  if grep -Eq 'pip install' "$f"; then
+    report FAIL "pip install reference in $f"
+  else
+    report PASS "no pip install: $f"
+  fi
+  if grep -Eq '^[[:space:]]*import[[:space:]]+kuzu\b' "$f"; then
+    report FAIL "import kuzu remnant in $f"
+  else
+    report PASS "no import kuzu: $f"
+  fi
+  if grep -Eq 'ghp_[A-Za-z0-9]{20,}|sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|BEGIN PRIVATE KEY' "$f"; then
+    report FAIL "possible secret in $f"
+  else
+    report PASS "no secret pattern: $f"
+  fi
+done
+
+echo "==> [4/7] docs/index.md links every ported doc"
+if [[ -f "$INDEX" ]]; then
+  for f in "${PORTED[@]}"; do
+    rel="${f#$DOCS_DIR/}"
+    if grep -Fq "$rel" "$INDEX"; then
+      report PASS "index links $rel"
+    else
+      report FAIL "index missing link to $rel"
+    fi
+  done
+else
+  report FAIL "missing $INDEX"
+fi
+
+echo "==> [5/7] Internal links resolve"
+for f in "${PORTED[@]}"; do
+  [[ -f "$f" ]] || continue
+  # Extract markdown link targets that look like local relative paths.
+  while IFS= read -r target; do
+    [[ -z "$target" ]] && continue
+    # Strip optional #anchor.
+    path="${target%%#*}"
+    [[ -z "$path" ]] && continue   # pure-anchor link, skip
+    # Resolve relative to the file's directory.
+    dir="$(dirname "$f")"
+    abs="$(cd "$dir" && cd "$(dirname "$path")" 2>/dev/null && pwd)/$(basename "$path")"
+    if [[ -e "$abs" ]]; then
+      report PASS "link ok in $(basename "$f"): $target"
+    else
+      report FAIL "broken link in $f: $target"
+    fi
+  done < <(grep -oE '\]\(\.{1,2}/[^)]+\)' "$f" | sed -E 's/^\]\(//; s/\)$//')
+done
+
+echo "==> [6/7] lbug version pin (when referenced) matches workspace (0.15.3)"
+for f in "${PORTED[@]}"; do
+  [[ -f "$f" ]] || continue
+  if grep -Eq 'lbug[[:space:]]*=' "$f"; then
+    if grep -Eq 'lbug[[:space:]]*=[[:space:]]*"0\.15\.3"' "$f"; then
+      report PASS "lbug pin correct in $(basename "$f")"
+    else
+      report FAIL "lbug version mismatch in $f (expected 0.15.3)"
+    fi
+  else
+    report PASS "no lbug version reference in $(basename "$f") (skipped)"
+  fi
+done
+
+echo "==> [7/7] KUZU_* env-vars appear only as legacy alias notes"
+for f in "${PORTED[@]}"; do
+  [[ -f "$f" ]] || continue
+  if grep -Eq 'KUZU_[A-Z_]+' "$f"; then
+    # Each line mentioning KUZU_ must also mention "legacy" or "alias" within
+    # 2 lines of context, or be inside a table row that contains those words.
+    bad=$(grep -nE 'KUZU_[A-Z_]+' "$f" | while IFS=: read -r line _; do
+      ctx=$(awk -v L="$line" 'NR>=L-2 && NR<=L+2' "$f")
+      if echo "$ctx" | grep -Eqi 'legacy|alias|deprecated|preserved|compat'; then
+        :
+      else
+        echo "line $line"
+      fi
+    done)
+    if [[ -z "$bad" ]]; then
+      report PASS "KUZU_* references annotated in $(basename "$f")"
+    else
+      report FAIL "KUZU_* not annotated as legacy in $f: $bad"
+    fi
+  else
+    report PASS "no KUZU_* references in $(basename "$f") (skipped)"
+  fi
+done
+
+echo
+echo "==> Summary: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Refs #420

## Summary

Ports LadybugDB and memory-related documentation from upstream `rysweet/amplihack`,
adapting Python/Kuzu API examples to the Rust `lbug` crate (formerly Kuzu).

## PORTED (3 files)

| Target (this repo) | Source (upstream) | Diataxis |
|---|---|---|
| `docs/reference/ladybug-reference.md` | `docs/memory/LADYBUG_GRAPH_STORE.md` | Reference |
| `docs/concepts/memory-tree.md` | `docs/memory/MEMORY_TREE_VISUALIZATION.md` | Concepts |
| `docs/concepts/five-type-memory.md` | `docs/memory/5-TYPE-MEMORY-GUIDE.md` | Concepts |

### Adaptation rules applied

- `pip install kuzu` → `cargo add lbug` (pinned to workspace `0.15.3`)
- `import kuzu` → `use lbug::{Database, SystemConfig};` (verified against `crates/amplihack-cli/src/commands/memory/backend/graph_db/mod.rs`)
- `KUZU_*` env vars retained as **legacy alias** notes only (current code uses `--kuzu-path` / `AMPLIHACK_KUZU_DB_PATH`; rename to `LADYBUG_*` is planned)
- Concepts/architecture preserved verbatim; only install/import/code snippets adapted
- "See also" links added to existing related docs to avoid duplication

## OMIT-py (2 files — no upstream analog)

| Spec-named file | Justification |
|---|---|
| `LADYBUG_GETTING_STARTED.md` | No matching file exists upstream at `rysweet/amplihack/docs/memory/`. Closest content already covered by `docs/reference/ladybug-reference.md` (this PR) and existing `docs/howto/memory-backend.md`. |
| `LADYBUG_TROUBLESHOOTING.md` | No matching file exists upstream. Troubleshooting concerns are Python-stack specific (kuzu install errors, Python venv); the Rust `lbug` crate is statically linked, eliminating the failure modes documented upstream. |

## Other changes

- `docs/index.md` — added 1 Reference link + 2 Concepts links
- `scripts/test_docs_parity_batch_c.sh` — 56-check regression suite covering: file existence, kebab-case naming, no Python/secret leakage, index links, internal link resolution, lbug version pin, and KUZU_* legacy framing

## Test plan

```bash
./scripts/test_docs_parity_batch_c.sh
# ==> Summary: 56 passed, 0 failed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
