### PR TITLE
docs: port logging and benchmarking docs from upstream

### DIFF
--- a/docs/concepts/native-binary-trace-logging.md
+++ b/docs/concepts/native-binary-trace-logging.md
@@ -1,0 +1,224 @@
+# Native Binary Trace Logging
+
+**Complete documentation for the native binary with optional trace logging**
+
+!!! note "Rust Port"
+    amplihack-rs is already a native binary built in Rust. The trace logging
+    system described here is integrated directly into the Rust binary using
+    the `tracing` crate, providing zero-cost abstractions when logging is
+    disabled.
+
+## Overview
+
+amplihack uses Anthropic's native Claude binary with optional JSONL trace
+logging. This provides excellent performance, zero external dependencies, and
+enhanced security.
+
+## Key Improvements
+
+- **No NPM dependency**: Uses native Claude binary directly
+- **Optional by default**: Trace logging disabled by default, zero overhead when off
+- **High performance**: <0.1ms overhead when disabled, <10ms when enabled
+- **Automatic security**: TokenSanitizer removes API keys and secrets automatically
+- **Session-scoped logs**: JSONL files organized by session in `.claude/runtime/amplihack-traces/`
+- **Direct API integration**: Automatic request/response capture via callbacks
+
+### Performance
+
+| Metric | Native Binary |
+|---|---|
+| Overhead (disabled) | <0.1ms |
+| Overhead (enabled) | <10ms |
+| NPM dependency | None |
+| Default state | Disabled |
+| Security | Automatic |
+
+## Quick Start
+
+### Enable Trace Logging
+
+Trace logging is **disabled by default**. Enable it when needed:
+
+```bash
+# Enable for single session
+AMPLIHACK_TRACE_LOGGING=true amplihack
+
+# Enable permanently
+export AMPLIHACK_TRACE_LOGGING=true
+echo 'export AMPLIHACK_TRACE_LOGGING=true' >> ~/.bashrc
+
+# Launch amplihack
+amplihack
+```
+
+### View Traces
+
+```bash
+# List trace files
+ls -lh .claude/runtime/amplihack-traces/
+
+# View latest trace
+tail -f .claude/runtime/amplihack-traces/trace_*.jsonl | jq .
+
+# Analyze token usage
+cat .claude/runtime/amplihack-traces/*.jsonl | \
+  jq -s '[.[] | select(.response.usage != null) | .response.usage] |
+         {calls: length, total_tokens: map(.total_tokens) | add}'
+```
+
+## Documentation Map
+
+### For Users
+
+1. **Feature Overview**
+   - What is trace logging and why use it
+   - Common scenarios and use cases
+   - Quick start guide
+   - Security considerations
+
+2. **How-To Guide**
+   - Enable/disable trace logging
+   - Analyze traces with jq
+   - Monitor token usage
+   - Archive traces for compliance
+   - Export to CSV
+
+### For Developers
+
+3. **Developer Reference**
+   - Architecture overview
+   - Module reference (TraceLogger, TokenSanitizer, etc.)
+   - Trace entry schema
+   - Performance characteristics
+   - Extension points
+
+### For Troubleshooting
+
+4. **Troubleshooting Guide**
+   - No trace files created
+   - Malformed JSONL entries
+   - Sensitive data in traces
+   - High disk usage
+   - Performance degradation
+   - Permission errors
+
+## Common Use Cases
+
+### Debug Unexpected Responses
+
+```bash
+# Enable trace logging
+export AMPLIHACK_TRACE_LOGGING=true
+
+# Run session that shows unexpected behavior
+amplihack
+# ... reproduce issue ...
+exit
+
+# Analyze the conversation
+cat .claude/runtime/amplihack-traces/trace_*.jsonl | \
+  jq 'select(.event=="request" or .event=="response")'
+```
+
+### Monitor Token Usage
+
+```bash
+cat .claude/runtime/amplihack-traces/*.jsonl | \
+  jq -s '[.[] | select(.response.usage != null) | .response.usage] |
+         {total_calls: length,
+          total_prompt: map(.prompt_tokens) | add,
+          total_completion: map(.completion_tokens) | add,
+          total_tokens: map(.total_tokens) | add}'
+```
+
+### Compliance Audit Trail
+
+```bash
+# Enable permanent trace logging
+export AMPLIHACK_TRACE_LOGGING=true
+
+# Archive daily
+mkdir -p ~/amplihack-audit/$(date +%Y%m%d)
+cp .claude/runtime/amplihack-traces/*.jsonl ~/amplihack-audit/$(date +%Y%m%d)/
+
+# Generate compliance report
+cat ~/amplihack-audit/*/*.jsonl | \
+  jq -r '[.timestamp, .session_id, .event] | @csv' > audit-report.csv
+```
+
+## Architecture
+
+### Component Diagram
+
+```
+amplihack Session
+       │
+       ▼
+API Callback Manager
+       │
+       ▼
+TraceLogger
+  (checks AMPLIHACK_TRACE_LOGGING)
+       │
+       ▼
+TokenSanitizer
+  (removes API keys, secrets)
+       │
+       ▼
+JSONL Writer
+  (.claude/runtime/amplihack-traces/)
+```
+
+### File Structure
+
+```
+.claude/runtime/amplihack-traces/
+├── trace_20260122_143022_a3f9d8.jsonl
+├── trace_20260122_151345_b4e2f1.jsonl
+└── trace_20260123_090015_c5f3a2.jsonl
+
+File naming: trace_YYYYMMDD_HHMMSS_SESSION.jsonl
+```
+
+### Trace Entry Format
+
+Each trace file contains JSONL (newline-delimited JSON):
+
+```jsonl
+{"timestamp":"2026-01-22T14:30:22.451Z","session_id":"a3f9d8","event":"request","request":{...}}
+{"timestamp":"2026-01-22T14:30:23.102Z","session_id":"a3f9d8","event":"response","response":{...}}
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AMPLIHACK_TRACE_LOGGING` | `false` | Enable/disable trace logging |
+| `AMPLIHACK_TRACE_DIR` | `.claude/runtime/amplihack-traces/` | Trace output directory |
+| `AMPLIHACK_TRACE_MAX_SIZE` | `100MB` | Maximum trace file size |
+| `AMPLIHACK_TRACE_SANITIZE` | `true` | Auto-sanitize sensitive tokens |
+
+## Security
+
+### Automatic Token Sanitization
+
+The TokenSanitizer automatically removes sensitive data from traces:
+
+| Token Type | Pattern | Replacement |
+|---|---|---|
+| GitHub tokens | `gho_*`, `ghp_*` | `[REDACTED-GITHUB-TOKEN]` |
+| OpenAI keys | `sk-*` | `[REDACTED-OPENAI-KEY]` |
+| Anthropic keys | `sk-ant-*` | `[REDACTED-ANTHROPIC-KEY]` |
+| Bearer tokens | `Bearer <token>` | `[REDACTED-BEARER-TOKEN]` |
+| JWT tokens | `eyJ*.eyJ*.*` | `[REDACTED-JWT-TOKEN]` |
+
+See [Security Recommendations](../reference/security-recommendations.md) for
+full security guidance.
+
+## Related Documentation
+
+- [JSON Logging](../reference/json-logging.md) — structured auto-mode event logging
+- [Benchmarking](../reference/benchmarking.md) — performance measurement with eval-recipes
+- [Security Recommendations](../reference/security-recommendations.md) — security best practices

--- a/docs/reference/benchmarking.md
+++ b/docs/reference/benchmarking.md
@@ -1,0 +1,166 @@
+# Benchmarking amplihack with eval-recipes
+
+Complete guide for running Microsoft's eval-recipes benchmarks to measure
+amplihack performance.
+
+!!! note "Rust Port"
+    The eval-recipes benchmarking system works with both the upstream Python
+    amplihack and amplihack-rs. When benchmarking amplihack-rs, the agent
+    config uses the Rust binary directly.
+
+## Quick Start
+
+```bash
+# 1. Clone eval-recipes
+git clone https://github.com/microsoft/eval-recipes.git ~/eval-recipes
+cd ~/eval-recipes
+
+# 2. Copy agent configs
+cp -r /path/to/amplihack/.claude/agents/eval-recipes/* data/agents/
+
+# 3. Set API key
+echo "ANTHROPIC_API_KEY=sk-ant-..." > .env
+
+# 4. Run benchmark
+uv run scripts/run_benchmarks.py \
+  --agent-filter "name=amplihack" \
+  --task-filter "name=linkedin_drafting" \
+  --num-trials 1
+```
+
+## Available Agents
+
+| Agent | Description |
+|---|---|
+| `amplihack` | Baseline amplihack with full context and workflow orchestration |
+| `claude_code` | Vanilla Claude Code for baseline comparison |
+| `amplihack_pr1443_v2` | amplihack with task classification fix (+36.5 point improvement) |
+
+## Common Tasks
+
+```bash
+# LinkedIn drafting (complex tool creation)
+--task-filter "name=linkedin_drafting"
+
+# Email drafting (CLI tool creation)
+--task-filter "name=email_drafting"
+
+# Multiple tasks
+--task-filter "name=linkedin_drafting,email_drafting"
+```
+
+## Command Reference
+
+### Basic Run
+
+```bash
+uv run scripts/run_benchmarks.py \
+  --agent-filter "name=AGENT_NAME" \
+  --task-filter "name=TASK_NAME" \
+  --num-trials 1
+```
+
+### With Reports
+
+```bash
+uv run scripts/run_benchmarks.py \
+  --agent-filter "name=amplihack" \
+  --task-filter "name=linkedin_drafting" \
+  --num-trials 3 \
+  --generate-reports
+```
+
+### Compare Multiple Agents
+
+```bash
+uv run scripts/run_benchmarks.py \
+  --agent-filter "name=amplihack,claude_code" \
+  --task-filter "name=linkedin_drafting" \
+  --num-trials 1
+```
+
+## Results Location
+
+Results saved to: `~/eval-recipes/.benchmark_results/YYYY-MM-DD_HH-MM-SS/`
+
+```bash
+# Find latest score
+find .benchmark_results -name "score.txt" -newer /tmp/test_start -exec cat {} \;
+
+# View failure report
+find .benchmark_results -name "FAILURE_REPORT*.md" | tail -1 | xargs less
+
+# View HTML report
+open .benchmark_results/latest/benchmark_report.html
+```
+
+## Testing a PR Branch
+
+To test a specific PR branch:
+
+1. Create new agent config in `~/eval-recipes/data/agents/amplihack_prXXXX/`
+2. Update `install.dockerfile`:
+
+    ```dockerfile
+    RUN git clone -b BRANCH_NAME --single-branch --depth 1 \
+        https://github.com/rysweet/amplihack-rs.git /tmp/amplihack && \
+        cp /tmp/amplihack/target/release/amplihack /usr/local/bin/ && \
+        rm -rf /tmp/amplihack
+    ```
+
+3. Run:
+
+    ```bash
+    uv run scripts/run_benchmarks.py \
+      --agent-filter "name=amplihack_prXXXX" \
+      --task-filter "name=TASK"
+    ```
+
+## Proven Results
+
+**PR #1443 Validation** (2025-11-19):
+
+| Metric | Score |
+|---|---|
+| Baseline (main) | 6.5/100 (created skill instead of tool) |
+| With fix (PR #1443 V2) | 43.0/100 (created executable tool) |
+| **Improvement** | **+36.5 points** proven via actual benchmark |
+
+## Timing Expectations
+
+| Phase | Duration |
+|---|---|
+| Docker build | ~60 seconds |
+| Task execution | 5–15 minutes |
+| Test scoring | 8–12 minutes |
+| **Total** | **15–25 minutes per task** |
+
+## Troubleshooting
+
+**"command not found: amplihack"**
+
+- Agent config uses wrong command template
+- Should use: `IS_SANDBOX=1 claude -p "{{task_instructions}}"` not `amplihack claude`
+
+**Import errors in generated code**
+
+- This is expected — eval tests both architecture and execution
+- Architecture scores (30%) award partial credit for good design
+- Execution scores (70%) require working code
+
+**Docker build fails**
+
+- Check Dockerfile syntax matches base.dockerfile patterns
+- Do not add `RUN apt-get install` (causes errors)
+- Use existing Claude Code from base image
+
+## References
+
+- **eval-recipes**: <https://github.com/microsoft/eval-recipes>
+- **Agent configs**: `~/.amplihack/.claude/agents/eval-recipes/` in amplihack repo
+
+## Related Documentation
+
+- [Eval System Architecture](../concepts/eval-system-architecture.md) — evaluation framework design
+- [Eval Grading Improvements](../concepts/eval-grading-improvements.md) — grading rubric details
+- [Eval Retrieval Methods](eval-retrieval-reference.md) — retrieval strategy reference

--- a/docs/reference/json-logging.md
+++ b/docs/reference/json-logging.md
@@ -1,0 +1,222 @@
+# Structured JSON Logging for Auto-Mode
+
+## Overview
+
+Auto-mode includes structured JSONL (JSON Lines) logging alongside the existing
+text logs. This provides machine-readable event data for programmatic analysis,
+monitoring, and debugging.
+
+!!! note "Rust Port"
+    In amplihack-rs, auto-mode logging uses the same JSONL format. The Rust
+    implementation uses `tracing` with `tracing-subscriber` for structured
+    output, writing to the same log directory structure.
+
+## Log File Location
+
+The structured log is written to:
+
+```
+.claude/runtime/logs/<session_id>/auto.jsonl
+```
+
+Where `<session_id>` is the unique identifier for the auto-mode session
+(e.g., `auto_claude_1234567890`).
+
+## Event Schema
+
+Each line in `auto.jsonl` is a standalone JSON object with the following base
+structure:
+
+```json
+{
+  "timestamp": "2026-01-20T00:14:09.680139+00:00",
+  "level": "INFO",
+  "event": "turn_start",
+  ...
+}
+```
+
+### Common Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | ISO 8601 | Timestamp with timezone (UTC) |
+| `level` | string | Log level (`INFO`, `WARNING`, `ERROR`) |
+| `event` | string | Event type (see below) |
+
+### Event Types
+
+#### 1. `turn_start`
+
+Logged at the beginning of each turn.
+
+```json
+{
+  "timestamp": "2026-01-20T00:14:09.680139+00:00",
+  "level": "INFO",
+  "event": "turn_start",
+  "turn": 1,
+  "phase": "clarifying",
+  "max_turns": 20
+}
+```
+
+Fields:
+
+- `turn`: Current turn number (1-indexed)
+- `phase`: Current phase (`clarifying`, `planning`, `executing`, `evaluating`, `summarizing`)
+- `max_turns`: Maximum turns configured for the session
+
+#### 2. `turn_complete`
+
+Logged when a turn finishes execution.
+
+```json
+{
+  "timestamp": "2026-01-20T00:14:11.815309+00:00",
+  "level": "INFO",
+  "event": "turn_complete",
+  "turn": 1,
+  "duration_sec": 23.42,
+  "success": true
+}
+```
+
+Fields:
+
+- `turn`: Turn number that completed
+- `duration_sec`: Duration of the turn in seconds (rounded to 2 decimal places)
+- `success`: Boolean indicating if the turn succeeded (exit code 0)
+
+#### 3. `agent_invoked`
+
+Logged when an agent or tool is invoked during execution.
+
+```json
+{
+  "timestamp": "2026-01-20T00:15:32.480478+00:00",
+  "level": "INFO",
+  "event": "agent_invoked",
+  "agent": "TodoWrite",
+  "turn": 5
+}
+```
+
+Fields:
+
+- `agent`: Name of the agent/tool invoked
+- `turn`: Turn number during which the agent was invoked
+
+#### 4. `error`
+
+Logged when an error occurs during execution.
+
+```json
+{
+  "timestamp": "2026-01-20T00:20:15.680583+00:00",
+  "level": "ERROR",
+  "event": "error",
+  "turn": 4,
+  "error_type": "timeout",
+  "message": "Turn 4 timed out after 600.0s"
+}
+```
+
+Fields:
+
+- `turn`: Turn number when the error occurred
+- `error_type`: Type of error (e.g., `timeout`, `ValueError`)
+- `message`: Human-readable error message
+
+## Usage Examples
+
+### Reading Events with Python
+
+```python
+import json
+from pathlib import Path
+
+log_file = Path(".claude/runtime/logs/auto_claude_1234567890/auto.jsonl")
+
+with open(log_file) as f:
+    events = [json.loads(line) for line in f]
+
+# Filter by event type
+turn_starts = [e for e in events if e["event"] == "turn_start"]
+errors = [e for e in events if e["event"] == "error"]
+
+# Calculate total duration
+turn_completes = [e for e in events if e["event"] == "turn_complete"]
+total_duration = sum(e["duration_sec"] for e in turn_completes)
+```
+
+### Analyzing with jq
+
+```bash
+# Count events by type
+cat auto.jsonl | jq -s 'group_by(.event) | map({event: .[0].event, count: length})'
+
+# Get all errors
+cat auto.jsonl | jq 'select(.event == "error")'
+
+# Calculate average turn duration
+cat auto.jsonl | jq -s '[.[] | select(.event == "turn_complete") | .duration_sec] | add / length'
+
+# List all agents invoked
+cat auto.jsonl | jq -s '[.[] | select(.event == "agent_invoked") | .agent] | unique'
+```
+
+### Monitoring Session Progress
+
+```python
+import json
+from pathlib import Path
+
+def monitor_session(log_file: Path):
+    """Monitor auto-mode session progress in real-time."""
+    current_turn = 0
+    total_duration = 0.0
+
+    with open(log_file) as f:
+        for line in f:
+            event = json.loads(line)
+
+            if event["event"] == "turn_start":
+                current_turn = event["turn"]
+                print(f"Turn {current_turn}/{event['max_turns']} ({event['phase']})")
+
+            elif event["event"] == "turn_complete":
+                total_duration += event["duration_sec"]
+                status = "✓" if event["success"] else "✗"
+                print(f"  {status} Completed in {event['duration_sec']}s")
+
+            elif event["event"] == "agent_invoked":
+                print(f"  → Agent: {event['agent']}")
+
+            elif event["event"] == "error":
+                print(f"  ✗ ERROR: {event['message']}")
+
+    print(f"\nTotal duration: {total_duration:.2f}s")
+```
+
+## Benefits
+
+1. **Programmatic Analysis**: Parse events with standard JSON tools
+2. **Monitoring**: Track session progress and performance metrics
+3. **Debugging**: Quickly identify errors and bottlenecks
+4. **Metrics Collection**: Calculate turn durations, success rates, agent usage
+5. **Integration**: Easy to integrate with log aggregation systems (Splunk, ELK, etc.)
+
+## Implementation Details
+
+- Events are written immediately (not buffered) for real-time monitoring
+- File I/O errors are logged to stderr but do not crash the session
+- Uses UTC timestamps for consistency across timezones
+- JSONL format allows easy streaming and appending
+- Each event is self-contained (no dependencies on previous events)
+
+## Related Documentation
+
+- Native Binary Trace Logging — trace-level logging for the native binary
+<!-- TODO: link when ported --> <!-- docs/features/trace-logging.md -->
+- Auto Mode — auto-mode concept overview

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,8 @@ nav:
       - "Security Audit: Copilot CLI Flags": reference/security-audit-copilot-cli-flags.md
       - Eval Retrieval Methods: reference/eval-retrieval-reference.md
       - Doc Graph Quick Reference: reference/doc-graph-quick-reference.md
+      - JSON Logging: reference/json-logging.md
+      - Benchmarking: reference/benchmarking.md
       - Code Review Practices: reference/code-review.md
       - Prerequisites: reference/prerequisites.md
   - Concepts:
@@ -144,6 +146,7 @@ nav:
       - Recipe Resilience: concepts/recipe-resilience.md
       - Documentation Knowledge Graph: concepts/documentation-knowledge-graph.md
       - External Knowledge Integration: concepts/external-knowledge-integration.md
+      - Native Binary Trace Logging: concepts/native-binary-trace-logging.md
   - Code Atlas:
       - Overview: atlas/index.md
       - "Layer 1: Repo Surface": atlas/repo-surface/README.md


### PR DESCRIPTION
## Summary
- Port 3 upstream docs for logging and benchmarking (#420)
- `docs/json_logging.md` → `docs/reference/json-logging.md`
- `docs/NATIVE_BINARY_TRACE_LOGGING.md` → `docs/concepts/native-binary-trace-logging.md`
- `docs/BENCHMARKING.md` → `docs/reference/benchmarking.md`

## Test plan
- [x] `mkdocs build --strict` passes locally
- [x] Diff contains only `docs/**/*.md` and `mkdocs.yml`
- [x] Nav entries added under correct Diátaxis sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #420