### PR TITLE
docs: port recipe system guides from upstream

### DIFF
--- a/docs/howto/recipe-cli-examples.md
+++ b/docs/howto/recipe-cli-examples.md
@@ -1,0 +1,270 @@
+# Recipe CLI Examples
+
+Real-world examples showing how to use the `amplihack recipe` CLI commands in
+different development scenarios.
+
+## Contents
+
+- [Development Scenarios](#development-scenarios)
+- [Testing Scenarios](#testing-scenarios)
+- [CI/CD Integration](#cicd-integration)
+- [Custom Recipe Development](#custom-recipe-development)
+
+## Development Scenarios
+
+### Implement a New Feature
+
+**Scenario**: Add JWT authentication to an API using the full 22-step workflow.
+
+```bash
+amplihack recipe run default-workflow \
+  --context '{
+    "task_description": "Add JWT authentication to REST API with token refresh",
+    "repo_path": "/home/user/api-server",
+    "branch_name": "feat/jwt-auth"
+  }'
+```
+
+**What happens**:
+
+1. Creates branch `feat/jwt-auth`
+2. Clarifies requirements (prompt-writer agent)
+3. Designs architecture (architect agent)
+4. Writes failing tests (tester agent)
+5. Implements code (builder agent)
+6. Reviews code (reviewer agent)
+7. Runs tests and CI
+8. Creates pull request
+9. Merges to main (after CI passes)
+
+**Expected duration**: 15–25 minutes
+
+### Quick Bug Fix
+
+**Scenario**: Fix a null pointer exception in production code.
+
+```bash
+amplihack recipe run quick-fix \
+  --context '{
+    "task_description": "Fix NullPointerException in UserProfileHandler.getAvatar() when user has no avatar set",
+    "repo_path": ".",
+    "branch_name": "fix/avatar-null-check"
+  }'
+```
+
+**What happens**:
+
+1. Analyzes the bug location and root cause
+2. Generates and applies fix
+3. Runs existing tests
+4. Commits changes with descriptive message
+
+**Expected duration**: 2–5 minutes
+
+### Investigate Unknown Codebase
+
+**Scenario**: Understand how authentication works in a legacy system.
+
+```bash
+amplihack recipe run investigation \
+  --context '{
+    "task_description": "How does the authentication and session management system work?",
+    "repo_path": "/home/user/legacy-app",
+    "focus_area": "src/auth/"
+  }'
+```
+
+**What happens**:
+
+1. Maps code structure in `src/auth/`
+2. Traces data flow through authentication
+3. Identifies session storage mechanism
+4. Documents findings in markdown
+5. Generates architecture diagram
+
+**Output files**:
+
+- `docs/INVESTIGATION_auth-system-<timestamp>.md`
+- `docs/diagrams/auth-flow.mermaid`
+
+**Expected duration**: 10–15 minutes
+
+### Refactor Legacy Code
+
+**Scenario**: Refactor a monolithic function into smaller, testable units.
+
+```bash
+amplihack recipe run refactor \
+  --context '{
+    "task_description": "Refactor process_order() function — split into smaller functions with single responsibilities",
+    "repo_path": ".",
+    "target_file": "src/service/order_service.rs",
+    "branch_name": "refactor/order-service"
+  }'
+```
+
+**What happens**:
+
+1. Analyzes current code structure
+2. Proposes refactoring plan (shows before/after)
+3. Writes tests for existing behavior
+4. Applies refactoring incrementally
+5. Verifies tests still pass after each step
+6. Reviews for regressions
+
+**Expected duration**: 8–12 minutes
+
+## Testing Scenarios
+
+### Run Only Verification Steps
+
+**Scenario**: Code is already implemented, just need to verify tests and CI.
+
+```bash
+amplihack recipe run verification-workflow \
+  --context '{"repo_path": "."}'
+```
+
+**What happens**:
+
+1. Runs test suite
+2. Checks code coverage
+3. Runs linting/formatting
+4. Builds project
+5. Generates verification report
+
+**Expected duration**: 3–6 minutes
+
+### Validate Recipe Before Running
+
+**Scenario**: Created a custom recipe, want to verify it is correct.
+
+```bash
+# First validate the YAML
+amplihack recipe validate ~/.amplihack/.claude/recipes/my-api-workflow.yaml
+```
+
+**Expected output**:
+
+```
+Validating my-api-workflow.yaml...
+  [OK] Valid YAML syntax
+  [OK] Required fields present (name, steps)
+  [OK] All step IDs unique
+  [OK] Template variables resolve against context
+  [OK] Agent references valid (api-designer, builder, tester)
+  [OK] No circular dependencies
+
+Recipe "my-api-workflow" is valid (7 steps)
+```
+
+**Then dry-run**:
+
+```bash
+amplihack recipe run my-api-workflow --dry-run \
+  --context '{"endpoint": "/api/users", "repo_path": "."}'
+```
+
+**Expected output**:
+
+```
+[DRY RUN] my-api-workflow (7 steps)
+[Step 1/7] design-api (agent: api-designer)
+  Would run agent: amplihack:api-designer
+[Step 2/7] generate-openapi (type: bash)
+  Would execute: generate_openapi
+...
+No changes made (dry run mode)
+```
+
+## CI/CD Integration
+
+### GitHub Actions Workflow
+
+```yaml
+name: Recipe Verification
+on: [push, pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install amplihack
+        run: cargo install amplihack
+      - name: Run verification
+        run: |
+          amplihack recipe run verification-workflow \
+            --context repo_path="." \
+            --context branch_name="${{ github.ref_name }}"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+### Exit Code Handling
+
+```bash
+amplihack recipe run verification-workflow \
+  --context repo_path="." \
+  --context branch_name="main"
+
+case $? in
+  0) echo "✓ All checks passed" ;;
+  1) echo "✗ Validation failed" ;;
+  2) echo "✗ Missing context" ;;
+  3) echo "✗ Step failed" ;;
+  *) echo "✗ Unknown error" ;;
+esac
+```
+
+### Save Execution Log
+
+```bash
+amplihack recipe run default-workflow \
+  --context task_description="Deploy to staging" \
+  --output execution-log.json
+```
+
+## Custom Recipe Development
+
+### Create a Custom Recipe
+
+```yaml
+# ~/.amplihack/.claude/recipes/my-workflow.yaml
+name: my-workflow
+description: Custom workflow for my team
+steps:
+  - id: analyze
+    type: agent
+    agent: analyzer
+    prompt: "Analyze {{focus_area}} for issues"
+  - id: fix
+    type: agent
+    agent: builder
+    prompt: "Fix issues found in analysis"
+    depends_on: [analyze]
+  - id: test
+    type: bash
+    command: "cargo test"
+    depends_on: [fix]
+```
+
+### Test the Custom Recipe
+
+```bash
+# Validate
+amplihack recipe validate my-workflow.yaml
+
+# Dry run
+amplihack recipe run my-workflow --dry-run --context focus_area="src/"
+
+# Real run
+amplihack recipe run my-workflow --context focus_area="src/"
+```
+
+## Related Documentation
+
+- [Recipe Quick Reference](../reference/recipe-quick-reference.md) — CLI cheat sheet
+- [Recipe Execution Flow](../concepts/recipe-execution-flow.md) — execution internals
+- [Recipe Resilience](../concepts/recipe-resilience.md) — error handling
+- [Recipe Discovery Troubleshooting](recipe-discovery-troubleshooting.md) — fixing discovery

--- a/docs/howto/recipe-discovery-troubleshooting.md
+++ b/docs/howto/recipe-discovery-troubleshooting.md
@@ -1,0 +1,137 @@
+# Recipe Discovery Troubleshooting
+
+## Overview
+
+Recipe Runner includes enhanced discovery diagnostics to help troubleshoot
+recipe loading issues, especially in subprocess isolation environments like
+`/tmp` clones.
+
+## Features
+
+### Global-First Search Priority
+
+Recipes are discovered in this priority order:
+
+1. **Installed Package Path** — `site-packages/amplihack/amplifier-bundle/recipes/` (for installed amplihack)
+2. **Repository Root** — repo-root `amplifier-bundle/recipes/` (for editable installs)
+3. **Global Installation** — `~/.amplihack/.claude/recipes/` (user-installed recipes)
+4. **CWD Bundle** — `amplifier-bundle/recipes/` (CWD-relative, legacy compatibility)
+5. **CWD Source** — `src/amplihack/amplifier-bundle/recipes/` (CWD-relative, development)
+6. **Project-local** — `.claude/recipes/` (project-specific recipes, can override)
+
+!!! note "Rust Port"
+    In amplihack-rs, the Rust binary embeds bundled recipes at compile time.
+    The global installation path (`~/.amplihack/.claude/recipes/`) and
+    project-local path (`.claude/recipes/`) still apply for user overrides.
+
+**Why this matters**: When amplihack is installed and you run from any
+directory, the installed path (1) is the only reliable location for bundled
+recipes. CWD-relative paths (4, 5) only work when running from the amplihack
+repo directory.
+
+### Debug Logging
+
+Enable debug logging to see exactly which paths are searched:
+
+```bash
+AMPLIHACK_VERBOSE=1 amplihack recipe list
+```
+
+**Output shows**:
+
+- Each directory searched
+- Whether directories exist
+- Which recipes are found in each location
+- Total recipe count
+
+### Installation Verification
+
+Check if global recipes are properly installed:
+
+```bash
+amplihack recipe list --long
+```
+
+If the list is empty, verify that `~/.amplihack/.claude/recipes/` contains
+recipe YAML files.
+
+## Common Issues
+
+### Issue: "No recipes discovered" when running from different directory
+
+**Symptom**: `amplihack recipe list` returns empty when running from a project
+other than amplihack's own repo.
+
+**Cause**: Discovery used only CWD-relative paths in earlier versions.
+
+**Solution**: Upgrade to amplihack >= 0.9.0 which includes absolute package
+paths in discovery.
+
+### Issue: "No recipes discovered" in /tmp clone
+
+**Symptom**: `amplihack recipe list` returns empty in subprocess isolation.
+
+**Cause**: Global recipes not installed at `~/.amplihack/.claude/recipes/`.
+
+**Solution**: Verify global installation exists:
+
+```bash
+ls ~/.amplihack/.claude/recipes/*.yaml 2>/dev/null || echo "No global recipes found"
+```
+
+If missing, re-run the amplihack installer:
+
+```bash
+amplihack install
+```
+
+### Issue: Wrong recipe version loaded
+
+**Symptom**: Unexpected recipe behavior — a local override shadows the bundled
+version.
+
+**Cause**: Local recipe in `.claude/recipes/` overriding global recipe with
+same name.
+
+**Solution**: Enable verbose logging to see which path won:
+
+```bash
+AMPLIHACK_VERBOSE=1 amplihack recipe show <recipe-name>
+```
+
+### Issue: Recipe not found after pip install
+
+**Symptom**: `amplihack recipe run default-workflow` fails with "recipe not
+found" after `pip install amplihack`.
+
+**Cause**: The package path is not in the search order (pre-0.9.0).
+
+**Solution**: Upgrade or manually copy recipes:
+
+```bash
+# Copy bundled recipes to global location
+cp -r $(python -c "import amplihack; print(amplihack.__path__[0])")/amplifier-bundle/recipes/* \
+  ~/.amplihack/.claude/recipes/
+```
+
+## Version History
+
+### Version 0.9.0 (March 2026)
+
+- Recipe discovery now includes installed package path
+- Absolute paths resolved via compile-time embedding work for all installs
+- Recipes discoverable from any working directory
+- Added package-relative and repo-root search paths
+
+### Version 0.5.32
+
+- Recipe discovery now works in `/tmp` clones
+- Global recipes prioritized for subprocess isolation
+- Debug logging added for troubleshooting
+
+## Related Documentation
+
+- [Recipe Quick Reference](../reference/recipe-quick-reference.md) — CLI cheat sheet
+- [Recipe CLI Examples](recipe-cli-examples.md) — real-world usage
+- [Recipe Execution Flow](../concepts/recipe-execution-flow.md) — how recipes execute
+- [Recipe Resilience](../concepts/recipe-resilience.md) — error handling in recipes

--- a/docs/reference/recipe-quick-reference.md
+++ b/docs/reference/recipe-quick-reference.md
@@ -1,0 +1,229 @@
+# Recipe CLI Quick Reference
+
+One-page cheat sheet for the `amplihack recipe` CLI commands.
+
+!!! note "Rust Port"
+    In amplihack-rs, recipe commands are accessed via `amplihack recipe`.
+    The Rust implementation provides identical CLI semantics to the upstream
+    Python version.
+
+## Core Commands
+
+```bash
+# List recipes
+amplihack recipe list                     # All recipes
+amplihack recipe list --long              # With details
+amplihack recipe list --format json       # JSON output
+
+# Run recipe
+amplihack recipe run <recipe> --context '{"key": "value"}'
+amplihack recipe run <recipe> --context-file context.json
+amplihack recipe run <recipe> --dry-run   # Preview only
+
+# Validate recipe
+amplihack recipe validate <file>          # Check syntax/structure
+amplihack recipe validate <file> --strict # Warnings as errors
+
+# Show recipe details
+amplihack recipe show <recipe>            # Full details
+amplihack recipe show <recipe> --format json
+amplihack recipe show <recipe> --steps-only
+```
+
+## Common Recipes
+
+| Recipe | Steps | Purpose |
+|---|---|---|
+| `default-workflow` | 22 | Full development (requirements → merge) |
+| `quick-fix` | 4 | Fast bug fixes |
+| `investigation` | 6 | Understand existing code |
+| `code-review` | 5 | Multi-perspective review |
+| `security-audit` | 7 | Security analysis |
+| `verification-workflow` | 8 | Post-implementation testing |
+
+## Context Variables
+
+Pass runtime values using key=value format:
+
+```bash
+--context task_description="Add auth" --context repo_path="."
+--context-file config.json
+```
+
+Common variables:
+
+| Variable | Description | Default |
+|---|---|---|
+| `task_description` | What to implement | (usually required) |
+| `repo_path` | Repository root | `.` |
+| `branch_name` | Git branch override | — |
+| `pr_number` | Pull request number | — |
+| `focus_area` | Directory to analyze | — |
+
+### Variable Substitution
+
+Use `{{var_name}}` in recipe YAML to reference context variables. The runner
+automatically normalises quoting — write `{{var}}` directly without wrapping in
+quotes:
+
+```yaml
+# Correct — runner handles quoting automatically
+command: echo {{task_description}}
+command: git checkout -b {{branch_name}}
+
+# Also accepted — runner strips the extra quotes
+command: echo "{{task_description}}"
+```
+
+## Run Options
+
+```bash
+--dry-run                  # Preview without executing
+--adapter <name>           # Force adapter: claude, copilot, cli
+--resume-from <step>       # Resume from step ID
+--stop-at <step>           # Stop after step ID
+--output <file>            # Save execution log
+--interactive              # Approve each step
+--verbose, -v              # Detailed output
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Validation failed or recipe not found |
+| 2 | Missing context variable |
+| 3 | Step execution failed |
+| 4 | Agent not found |
+| 5 | Adapter not available |
+| 130 | User interrupted (Ctrl+C) |
+
+## Environment Variables
+
+```bash
+export AMPLIHACK_RECIPE_PATH="/custom/recipes:/team/recipes"
+export AMPLIHACK_ADAPTER=copilot
+export AMPLIHACK_VERBOSE=1
+export AMPLIHACK_DRY_RUN=1
+export AMPLIHACK_AGENT_BINARY=copilot
+```
+
+### `AMPLIHACK_AGENT_BINARY`
+
+Sets the agent binary used for all subprocess orchestration. Defaults to
+`claude` with a warning if unset.
+
+```bash
+# Use GitHub Copilot as the orchestration agent
+export AMPLIHACK_AGENT_BINARY=copilot
+
+# Use a fully-qualified path
+export AMPLIHACK_AGENT_BINARY=/usr/local/bin/my-agent
+```
+
+This makes amplihack agent-agnostic: `amplihack <command>` will use the
+configured binary for all agent subprocess calls (skills, recipes,
+orchestrator).
+
+## Quick Examples
+
+### Development Workflow
+
+```bash
+# Full feature implementation
+amplihack recipe run default-workflow \
+  --context task_description="Add JWT auth" \
+  --context repo_path="."
+
+# Fast bug fix
+amplihack recipe run quick-fix \
+  --context task_description="Fix null pointer in UserService"
+
+# Code investigation
+amplihack recipe run investigation \
+  --context task_description="How does auth work?" \
+  --context focus_area="src/auth/"
+```
+
+### Testing & Validation
+
+```bash
+# Validate before running
+amplihack recipe validate my-recipe.yaml
+
+# Preview execution
+amplihack recipe run my-recipe --dry-run \
+  --context target="src/api"
+
+# Run verification suite
+amplihack recipe run verification-workflow \
+  --context repo_path="."
+```
+
+### CI/CD Integration
+
+```bash
+# Check exit code
+amplihack recipe run verification-workflow \
+  --context repo_path="." \
+  --context branch_name="main"
+if [ $? -eq 0 ]; then
+  echo "Tests passed"
+fi
+
+# Save execution log
+amplihack recipe run default-workflow \
+  --context task_description="Deploy to staging" \
+  --output execution-log.json
+```
+
+## Recipe Discovery
+
+Recipes discovered from (in priority order):
+
+1. `amplifier-bundle/recipes/` — Bundled recipes
+2. `src/amplihack/amplifier-bundle/recipes/` — Package recipes
+3. `~/.amplihack/.claude/recipes/` — User recipes
+4. `.claude/recipes/` — Project recipes
+5. `$AMPLIHACK_RECIPE_PATH` — Custom paths
+
+Later paths override earlier ones.
+
+## Adapter Selection
+
+Auto-detected based on available CLIs:
+
+1. Claude Agent SDK (if `claude` CLI found)
+2. GitHub Copilot SDK (if `copilot` CLI found)
+3. CLI subprocess (fallback, always available)
+
+Override with `--adapter <name>`.
+
+## Common Patterns
+
+### Resume after failure
+
+```bash
+# Initial run fails at step 15
+amplihack recipe run default-workflow \
+  --context task_description="Add auth" \
+  --resume-from step-15
+```
+
+### Stop-and-inspect
+
+```bash
+# Run up to implementation step
+amplihack recipe run default-workflow \
+  --context task_description="Add auth" \
+  --stop-at step-10
+```
+
+## Related Documentation
+
+- [recipe Command](recipe-command.md) — full command reference
+- [Recipe Execution Flow](../concepts/recipe-execution-flow.md) — how recipes execute
+- [Recipe Resilience](../concepts/recipe-resilience.md) — error handling in recipes
+- [Recipe CLI Examples](../howto/recipe-cli-examples.md) — real-world usage examples
+- [Recipe Discovery Troubleshooting](../howto/recipe-discovery-troubleshooting.md) — fixing discovery issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,8 @@ nav:
       - Configure Hooks: howto/configure-hooks.md
       - Develop amplihack: howto/develop-amplihack.md
       - Create Your Own Tools: howto/create-your-own-tools.md
+      - Recipe CLI Examples: howto/recipe-cli-examples.md
+      - Recipe Discovery Troubleshooting: howto/recipe-discovery-troubleshooting.md
   - Skills:
       - Migrate Session: skills/migrate.md
   - Reference:
@@ -107,6 +109,7 @@ nav:
       - Doc Graph Quick Reference: reference/doc-graph-quick-reference.md
       - JSON Logging: reference/json-logging.md
       - Benchmarking: reference/benchmarking.md
+      - Recipe Quick Reference: reference/recipe-quick-reference.md
       - Code Review Practices: reference/code-review.md
       - Prerequisites: reference/prerequisites.md
   - Concepts:


### PR DESCRIPTION
## Summary
- Port 3 upstream recipe system docs (#420)
- `docs/recipes/quick-reference.md` → `docs/reference/recipe-quick-reference.md`
- `docs/recipes/cli-examples.md` → `docs/howto/recipe-cli-examples.md`
- `docs/recipes/recipe-discovery-troubleshooting.md` → `docs/howto/recipe-discovery-troubleshooting.md`

## Test plan
- [x] `mkdocs build --strict` passes locally
- [x] Diff contains only `docs/**/*.md` and `mkdocs.yml`
- [x] Nav entries added under correct Diátaxis sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #420