### PR TITLE
docs: port security deep-dive docs from upstream

### DIFF
--- a/docs/howto/security-testing.md
+++ b/docs/howto/security-testing.md
@@ -1,0 +1,218 @@
+# Security Testing Guide
+
+How to test security features in amplihack, including token sanitization, input
+validation, and file permissions.
+
+!!! note "Rust Port"
+    In amplihack-rs, security tests use standard Rust testing with `cargo test`.
+    The upstream Python test patterns translate directly to Rust `#[test]`
+    functions. The testing pyramid ratios (60/30/10) remain the same.
+
+## Testing Pyramid
+
+Security tests follow the 60/30/10 testing pyramid:
+
+- **60% Unit Tests**: Fast, isolated, heavily mocked
+- **30% Integration Tests**: Multiple components, real scenarios
+- **10% E2E Tests**: Complete workflows, minimal mocking
+
+### Why This Distribution?
+
+1. **Unit tests (60%)**: Catch bugs early, run in milliseconds
+2. **Integration tests (30%)**: Verify component interactions
+3. **E2E tests (10%)**: Validate complete user workflows
+
+## Running Security Tests
+
+### All Security Tests
+
+```bash
+# Rust tests
+cargo test --package amplihack-security -- --nocapture
+
+# With coverage (requires cargo-tarpaulin)
+cargo tarpaulin --packages amplihack-security --out Html
+```
+
+### Upstream Python Tests (reference only)
+
+```bash
+# From project root
+pytest tests/ -k "security or sanitiz" -v
+
+# Run with coverage
+pytest tests/ -k "security or sanitiz" \
+  --cov=amplihack.tracing.token_sanitizer \
+  --cov-report=term-missing
+```
+
+### Specific Test Categories
+
+```bash
+# Unit tests only (fast)
+cargo test --package amplihack-security -- token_pattern
+cargo test --package amplihack-security -- string_sanitization
+
+# Integration tests
+cargo test --package amplihack-security -- real_error_scenarios
+
+# E2E tests
+cargo test --package amplihack-security -- end_to_end
+```
+
+### Continuous Integration
+
+Security tests run automatically on:
+
+- Every commit to main branch
+- Every pull request
+- Pre-commit hooks (optional)
+
+## Writing Security Tests
+
+### Test Structure (Rust)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Unit tests (60%)
+    #[test]
+    fn test_github_token_detection() {
+        let sanitizer = TokenSanitizer::new();
+        assert!(sanitizer.contains_token("gho_1234567890abcdefghij"));
+        assert!(!sanitizer.contains_token("github oauth token"));
+        assert!(!sanitizer.contains_token("gho_short")); // Too short
+    }
+
+    // Integration tests (30%)
+    #[test]
+    fn test_sanitize_github_api_error() {
+        let sanitizer = TokenSanitizer::new();
+        let error_msg = r#"
+            HTTP 401 Unauthorized
+            Authorization: Bearer gho_1234567890abcdefghij
+            Response: {"message": "Bad credentials"}
+        "#;
+
+        let result = sanitizer.sanitize(error_msg);
+        assert!(!result.contains("gho_1234567890abcdefghij"));
+        assert!(result.contains("[REDACTED-GITHUB-TOKEN]"));
+        assert!(result.contains("Bad credentials"));
+    }
+
+    // E2E tests (10%)
+    #[test]
+    fn test_complete_sanitization_workflow() {
+        // Test complete user journey
+        let sanitizer = TokenSanitizer::new();
+        let report = generate_error_report_with_tokens();
+        let sanitized = sanitizer.sanitize(&report);
+        assert!(!sanitizer.contains_token(&sanitized));
+    }
+}
+```
+
+### Test Structure (Upstream Python, reference only)
+
+```python
+"""Tests for [feature] security.
+
+Testing pyramid:
+- 60% Unit tests (fast, heavily mocked)
+- 30% Integration tests (multiple components)
+- 10% E2E tests (complete workflows)
+"""
+
+import pytest
+from amplihack.tracing.token_sanitizer import TokenSanitizer
+
+# Unit tests (60%)
+class TestBasicFunctionality:
+    def test_specific_behavior(self):
+        sanitizer = TokenSanitizer()
+        result = sanitizer.sanitize("test input")
+        assert result == "expected output"
+
+# Integration tests (30%)
+class TestRealScenarios:
+    def test_real_world_case(self):
+        pass
+
+# E2E tests (10%)
+class TestCompleteWorkflows:
+    def test_full_workflow(self):
+        pass
+```
+
+## Test Coverage Requirements
+
+| Category | Minimum Coverage |
+|---|---|
+| Token detection patterns | 100% |
+| Sanitization logic | 95% |
+| Edge cases | 90% |
+| Integration scenarios | 85% |
+| Overall security module | 90% |
+
+## Common Test Patterns
+
+### Boundary Testing
+
+```rust
+#[test]
+fn test_token_boundaries() {
+    let sanitizer = TokenSanitizer::new();
+
+    // Minimum length tokens
+    assert!(!sanitizer.contains_token("gho_12345"));      // Too short
+    assert!(sanitizer.contains_token("gho_123456"));       // Minimum valid
+
+    // Maximum length tokens
+    let long_token = format!("gho_{}", "a".repeat(100));
+    assert!(sanitizer.contains_token(&long_token));
+
+    // Tokens at string boundaries
+    assert!(sanitizer.contains_token("gho_123456"));       // Start
+    assert!(sanitizer.contains_token("text gho_123456"));  // Middle
+    assert!(sanitizer.contains_token("gho_123456 text"));  // End
+}
+```
+
+### Multi-Token Testing
+
+```rust
+#[test]
+fn test_multiple_tokens_in_one_string() {
+    let sanitizer = TokenSanitizer::new();
+    let input = "GitHub: gho_abc123xyz, OpenAI: sk-abc123xyz456";
+    let result = sanitizer.sanitize(input);
+
+    assert!(result.contains("[REDACTED-GITHUB-TOKEN]"));
+    assert!(result.contains("[REDACTED-OPENAI-KEY]"));
+    assert!(!result.contains("gho_abc123xyz"));
+    assert!(!result.contains("sk-abc123xyz456"));
+}
+```
+
+### Negative Testing
+
+```rust
+#[test]
+fn test_no_false_positives() {
+    let sanitizer = TokenSanitizer::new();
+
+    // Should NOT be redacted
+    assert!(!sanitizer.contains_token("ghost_writer"));
+    assert!(!sanitizer.contains_token("skeleton_key"));
+    assert!(!sanitizer.contains_token("just plain text"));
+    assert!(!sanitizer.contains_token("gho_short"));
+}
+```
+
+## Related Documentation
+
+- [Token Sanitization Guide](token-sanitization.md) — usage guide
+- [Security API Reference](../reference/security-api.md) — complete API docs
+- [Security Recommendations](../reference/security-recommendations.md) — best practices

--- a/docs/howto/token-sanitization.md
+++ b/docs/howto/token-sanitization.md
@@ -1,0 +1,184 @@
+# Token Sanitization Guide
+
+Prevent token exposure in logs, errors, and debug output with automatic
+sanitization.
+
+!!! note "Rust Port"
+    In amplihack-rs, token sanitization is implemented in the
+    `amplihack-security` crate using compiled regex patterns. The Rust
+    implementation provides the same detection coverage as the upstream
+    Python `TokenSanitizer` with lower overhead.
+
+## Quick Start
+
+```python
+# Upstream Python API (reference only)
+from amplihack.utils.token_sanitizer import TokenSanitizer
+
+sanitizer = TokenSanitizer()
+
+error_msg = "Authentication failed with token: gho_abc123xyz"
+safe_msg = sanitizer.sanitize(error_msg)
+print(safe_msg)
+# Output: "Authentication failed with token: [REDACTED-GITHUB-TOKEN]"
+```
+
+## What Gets Sanitized
+
+TokenSanitizer detects and redacts these token types:
+
+| Token Type | Pattern | Redaction Marker |
+|---|---|---|
+| GitHub tokens | `gho_*`, `ghp_*`, `ghs_*`, `ghu_*`, `ghr_*` | `[REDACTED-GITHUB-TOKEN]` |
+| OpenAI keys | `sk-*`, `sk-proj-*` | `[REDACTED-OPENAI-KEY]` |
+| Anthropic keys | `sk-ant-*` | `[REDACTED-ANTHROPIC-KEY]` |
+| Bearer tokens | `Bearer <token>` | `[REDACTED-BEARER-TOKEN]` |
+| JWT tokens | `eyJ*.eyJ*.*` | `[REDACTED-JWT-TOKEN]` |
+| Azure keys | `azure-key-*` | `[REDACTED-AZURE-KEY]` |
+| Azure connections | `DefaultEndpointsProtocol=...` | `[REDACTED-AZURE-CONNECTION]` |
+
+## Common Use Cases
+
+### Sanitizing API Errors
+
+When API calls fail, error messages often contain authentication tokens:
+
+```python
+# Upstream Python API (reference only)
+sanitizer = TokenSanitizer()
+
+try:
+    response = github_api.chat_completion(token="gho_abc123xyz")
+except Exception as e:
+    safe_error = sanitizer.sanitize(str(e))
+    logger.error(f"API call failed: {safe_error}")
+```
+
+### Sanitizing Configuration Dumps
+
+When debugging configuration, sanitize before printing:
+
+```python
+# Upstream Python API (reference only)
+config = {
+    "github_token": "gho_1234567890abcdefghij",
+    "openai_key": "sk-proj-abc123xyz",
+    "endpoint": "https://api.github.com"
+}
+
+sanitizer = TokenSanitizer()
+safe_config = sanitizer.sanitize(config)
+print(safe_config)
+# Output: {'github_token': '[REDACTED-GITHUB-TOKEN]',
+#          'openai_key': '[REDACTED-OPENAI-KEY]',
+#          'endpoint': 'https://api.github.com'}
+```
+
+### Sanitizing Log Files
+
+Process existing log files to remove tokens:
+
+```python
+# Upstream Python API (reference only)
+from pathlib import Path
+
+sanitizer = TokenSanitizer()
+log_file = Path("debug.log")
+
+content = log_file.read_text()
+sanitized = sanitizer.sanitize(content)
+log_file.write_text(sanitized)
+```
+
+## Integration Examples
+
+### Logging Wrapper
+
+Create a logging wrapper that auto-sanitizes:
+
+```python
+# Upstream Python API (reference only)
+import logging
+
+class SanitizingLogger:
+    def __init__(self, name: str):
+        self.logger = logging.getLogger(name)
+        self.sanitizer = TokenSanitizer()
+
+    def debug(self, msg: str, *args, **kwargs):
+        self.logger.debug(self.sanitizer.sanitize(msg), *args, **kwargs)
+
+    def error(self, msg: str, *args, **kwargs):
+        self.logger.error(self.sanitizer.sanitize(msg), *args, **kwargs)
+
+# Usage
+logger = SanitizingLogger(__name__)
+logger.debug(f"Token: {github_token}")  # Automatically sanitized
+```
+
+### Rust Integration
+
+In amplihack-rs, token sanitization is automatic in the tracing pipeline:
+
+```rust
+// Token sanitization happens transparently in the tracing subscriber
+// No manual calls needed in most cases
+use tracing::info;
+
+info!("Processing request with auth header");
+// Any tokens in the span context are automatically redacted in log output
+```
+
+## Performance
+
+TokenSanitizer is optimized for production use:
+
+| Operation | Latency |
+|---|---|
+| Simple strings | < 1ms |
+| Small dicts | < 1ms |
+| 1000 strings | < 1 second total |
+| Compiled regex | Patterns compiled once at initialization |
+
+## Troubleshooting
+
+### False Positives
+
+If legitimate data is redacted:
+
+- Check if your data resembles a token pattern
+- Use allowlists for known-safe patterns
+- Consider restructuring data to avoid token-like values
+
+### Performance Issues
+
+If sanitization is slow:
+
+1. **Profile token density**: Check before sanitizing
+
+    ```python
+    if sanitizer.contains_token(text):
+        text = sanitizer.sanitize(text)
+    ```
+
+2. **Reduce nested depth**: Very deep nesting (10+ levels) impacts performance
+3. **Batch processing**: Process in chunks for huge datasets
+
+## Best Practices
+
+1. **Sanitize at boundaries**: Sanitize data when it crosses trust boundaries (logging, errors, API responses)
+2. **Don't sanitize business logic**: Only sanitize for output/logging, not internal processing
+3. **Use in exception handlers**: Always sanitize exceptions before displaying
+4. **Test with real tokens**: Use actual token formats in tests (with pragma comments)
+5. **Check before expensive operations**: Use `contains_token()` before deep sanitization
+
+## Related Documentation
+
+- [Security API Reference](../reference/security-api.md) — complete API documentation
+- [Security Testing Guide](security-testing.md) — how to test security features
+- [Security Recommendations](../reference/security-recommendations.md) — security best practices
+
+---
+
+**Remember**: TokenSanitizer protects against accidental token exposure. It is
+not a replacement for proper secret management, secure storage, or encryption.

--- a/docs/reference/security-api.md
+++ b/docs/reference/security-api.md
@@ -1,0 +1,259 @@
+# Security API Reference
+
+Complete reference for the token sanitizer module.
+
+!!! note "Rust Port"
+    In amplihack-rs, the token sanitizer is implemented in the
+    `amplihack-security` crate. The Rust API mirrors the upstream Python
+    `TokenSanitizer` class with idiomatic Rust patterns.
+
+## TokenSanitizer
+
+### Overview
+
+TokenSanitizer detects and redacts sensitive tokens from strings and data
+structures. Designed for production use with < 1ms performance for typical
+operations.
+
+**Philosophy**:
+
+- Single responsibility: Token detection and sanitization
+- Zero-BS: Fully functional with no stubs
+- Performance-first: Compiled regex, minimal overhead
+
+### Rust API
+
+```rust
+use amplihack_security::TokenSanitizer;
+
+let sanitizer = TokenSanitizer::new();
+
+// Check for tokens
+assert!(sanitizer.contains_token("gho_abc123xyz"));
+
+// Sanitize a string
+let result = sanitizer.sanitize("Token: gho_abc123xyz");
+assert_eq!(result, "Token: [REDACTED-GITHUB-TOKEN]");
+```
+
+### Upstream Python API (reference only)
+
+```python
+from amplihack.tracing.token_sanitizer import TokenSanitizer
+
+sanitizer = TokenSanitizer()
+```
+
+---
+
+### `new()` / `TokenSanitizer()`
+
+Create a new TokenSanitizer instance with compiled regex patterns.
+
+**Rust:**
+
+```rust
+let sanitizer = TokenSanitizer::new();
+```
+
+**Python (upstream):**
+
+```python
+sanitizer = TokenSanitizer()
+```
+
+**Thread Safety**: Yes — patterns are immutable after initialization.
+
+**Performance**: O(1) — patterns compiled once.
+
+---
+
+### `contains_token`
+
+Check if text contains any sensitive tokens.
+
+**Rust:**
+
+```rust
+fn contains_token(&self, text: &str) -> bool
+```
+
+**Python (upstream):**
+
+```python
+def contains_token(self, text: str) -> bool
+```
+
+**Arguments**:
+
+- `text`: Text to check for tokens
+
+**Returns**: `true` if tokens detected, `false` otherwise
+
+**Example:**
+
+```rust
+let sanitizer = TokenSanitizer::new();
+
+assert!(sanitizer.contains_token("gho_abc123xyz"));     // true
+assert!(!sanitizer.contains_token("no tokens here"));    // false
+```
+
+**Performance**: O(n) where n is text length
+
+- Average: < 0.1ms for 1KB text
+- Worst case: < 0.5ms for 10KB text
+
+---
+
+### `sanitize`
+
+Sanitize tokens from a string. Returns a new string with tokens redacted.
+
+**Rust:**
+
+```rust
+fn sanitize(&self, text: &str) -> String
+```
+
+**Python (upstream):**
+
+```python
+def sanitize(self, data: Any) -> Any
+```
+
+!!! note
+    The Python version recursively processes strings, dicts, and lists.
+    The Rust version operates on `&str` — use iterators for collections.
+
+**Arguments**:
+
+- `text`: Text to sanitize
+
+**Returns**: New string with tokens redacted
+
+**Examples:**
+
+**String sanitization:**
+
+```rust
+let sanitizer = TokenSanitizer::new();
+
+let result = sanitizer.sanitize("Token: gho_abc123xyz");
+assert_eq!(result, "Token: [REDACTED-GITHUB-TOKEN]");
+```
+
+**Multiple tokens:**
+
+```rust
+let input = "GitHub: gho_abc123, OpenAI: sk-abc123456789";
+let result = sanitizer.sanitize(input);
+assert!(result.contains("[REDACTED-GITHUB-TOKEN]"));
+assert!(result.contains("[REDACTED-OPENAI-KEY]"));
+```
+
+**Performance**:
+
+- Strings: O(n) where n is string length
+- Average: < 1ms for typical data
+
+---
+
+## Token Patterns
+
+All patterns are compiled at initialization time and immutable thereafter.
+
+### Supported Token Types
+
+#### GitHub Tokens
+
+**Prefixes**: `gho_`, `ghp_`, `ghs_`, `ghu_`, `ghr_`
+
+**Pattern**: `gh[opsuhr]_[A-Za-z0-9]{6,100}`
+
+**Replacement**: `[REDACTED-GITHUB-TOKEN]`
+
+**Examples**:
+
+| Input | Matched? |
+|---|---|
+| `gho_1234567890abcdefghij` | ✓ Yes |
+| `ghp_1234567890abcdefghij` | ✓ Yes |
+| `gho_short` | ✗ No (< 6 chars after prefix) |
+| `ghost_writer` | ✗ No (not a valid prefix) |
+
+#### OpenAI Keys
+
+**Prefixes**: `sk-`, `sk-proj-`
+
+**Pattern**: `sk-(?:proj-)?[A-Za-z0-9]{10,100}`
+
+**Replacement**: `[REDACTED-OPENAI-KEY]`
+
+#### Anthropic Keys
+
+**Prefix**: `sk-ant-`
+
+**Pattern**: `sk-ant-[A-Za-z0-9]{10,100}`
+
+**Replacement**: `[REDACTED-ANTHROPIC-KEY]`
+
+#### Bearer Tokens
+
+**Pattern**: `Bearer\s+[A-Za-z0-9._~+/=-]{10,}`
+
+**Replacement**: `[REDACTED-BEARER-TOKEN]`
+
+#### JWT Tokens
+
+**Pattern**: `eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`
+
+**Replacement**: `[REDACTED-JWT-TOKEN]`
+
+#### Azure Keys
+
+**Pattern**: `azure-key-[A-Za-z0-9]{10,}`
+
+**Replacement**: `[REDACTED-AZURE-KEY]`
+
+#### Azure Connection Strings
+
+**Pattern**: `DefaultEndpointsProtocol=https?;[^\s]{10,}`
+
+**Replacement**: `[REDACTED-AZURE-CONNECTION]`
+
+---
+
+## Performance Characteristics
+
+### Benchmarks
+
+| Operation | Input Size | Latency |
+|---|---|---|
+| `contains_token` | 100 bytes (no token) | 0.02ms |
+| `contains_token` | 1 KB (with token) | 0.08ms |
+| `sanitize` | 100 bytes (1 token) | 0.05ms |
+| `sanitize` | 1 KB (3 tokens) | 0.15ms |
+| `sanitize` | 10 KB (10 tokens) | 0.8ms |
+| Init (`new()`) | — | 0.5ms |
+
+### Memory Usage
+
+- Per instance: ~2KB (compiled regex patterns)
+- Per sanitization: O(n) temporary allocation for output string
+- Patterns: Shared across all operations, immutable
+
+### Thread Safety
+
+TokenSanitizer is fully thread-safe:
+
+- All methods are `&self` (read-only)
+- No internal mutation after initialization
+- Safe to share across threads via `Arc<TokenSanitizer>`
+
+## Related Documentation
+
+- [Token Sanitization Guide](../howto/token-sanitization.md) — usage guide
+- [Security Testing Guide](../howto/security-testing.md) — testing patterns
+- [Security Recommendations](security-recommendations.md) — best practices
+- [Security Context Preservation](../concepts/security-context-preservation.md) — context security

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,8 @@ nav:
       - Create Your Own Tools: howto/create-your-own-tools.md
       - Recipe CLI Examples: howto/recipe-cli-examples.md
       - Recipe Discovery Troubleshooting: howto/recipe-discovery-troubleshooting.md
+      - Token Sanitization: howto/token-sanitization.md
+      - Security Testing: howto/security-testing.md
   - Skills:
       - Migrate Session: skills/migrate.md
   - Reference:
@@ -110,6 +112,7 @@ nav:
       - JSON Logging: reference/json-logging.md
       - Benchmarking: reference/benchmarking.md
       - Recipe Quick Reference: reference/recipe-quick-reference.md
+      - Security API Reference: reference/security-api.md
       - Code Review Practices: reference/code-review.md
       - Prerequisites: reference/prerequisites.md
   - Concepts:


### PR DESCRIPTION
## Summary
- Port 3 upstream security deep-dive docs (#420)
- `docs/security/TOKEN_SANITIZATION_GUIDE.md` → `docs/howto/token-sanitization.md`
- `docs/security/SECURITY_TESTING_GUIDE.md` → `docs/howto/security-testing.md`
- `docs/security/SECURITY_API_REFERENCE.md` → `docs/reference/security-api.md`

## Test plan
- [x] `mkdocs build --strict` passes locally
- [x] Diff contains only `docs/**/*.md` and `mkdocs.yml`
- [x] Nav entries added under correct Diátaxis sections
- [x] Rust API examples included alongside upstream Python reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #420