### PR TITLE
docs: port goal-seeking agent docs from upstream

### DIFF
--- a/docs/concepts/goal-seeking-agents.md
+++ b/docs/concepts/goal-seeking-agents.md
@@ -1,0 +1,423 @@
+# Goal-Seeking Agents
+
+A complete guide to generating, evaluating, and iterating on autonomous learning
+agents in amplihack.
+
+!!! note "Rust Port"
+    In amplihack-rs, the goal-seeking agent system is orchestrated through the
+    Rust CLI (`amplihack new`) and the agent framework crates. The underlying
+    LLM interaction follows the same SDK-agnostic design as upstream.
+
+---
+
+## Table of Contents
+
+- [What Are Goal-Seeking Agents?](#what-are-goal-seeking-agents)
+- [Quick Start](#quick-start)
+- [Generating Agents](#generating-agents)
+- [Agent Capabilities](#agent-capabilities)
+- [Architecture](#architecture)
+- [Multi-Agent Architecture](#multi-agent-architecture)
+- [Evaluating Agents](#evaluating-agents)
+- [Iterating on Agents](#iterating-on-agents)
+- [Domain Agents](#domain-agents)
+- [Reference](#reference)
+
+---
+
+## What Are Goal-Seeking Agents?
+
+Goal-seeking agents are autonomous programs that pursue objectives by learning,
+reasoning, and taking actions. Unlike static scripts that follow a fixed
+sequence, these agents:
+
+1. **Learn** — Extract facts from content and store them in persistent memory.
+2. **Remember** — Search, verify, and organize knowledge across sessions.
+3. **Teach** — Explain what they know to other agents (or humans) through multi-turn dialogue.
+4. **Apply** — Use stored knowledge and tools to solve new problems.
+
+The system provides a single `GoalSeekingAgent` base class that works
+identically across four different SDK backends (Copilot, Claude, Microsoft Agent
+Framework, and a lightweight mini-framework). You write your agent logic once;
+the SDK handles the underlying LLM calls, tool registration, and agent loop.
+
+**Core design**: The `GoalSeekingAgent` ABC defines the interface. All SDK
+implementations delegate learning and answering to a shared `LearningAgent`
+instance, which contains the eval intelligence: LLM-based fact extraction,
+intent detection, retrieval strategy selection, and answer synthesis.
+
+### Related Contributor Docs
+
+<!-- TODO: link when ported -->
+- Understanding the LearningAgent module architecture
+- LearningAgent module reference
+- How to maintain and extend the refactored LearningAgent
+
+---
+
+## Quick Start
+
+Generate and run a learning agent in under 5 minutes.
+
+### 1. Write a goal prompt
+
+Create a file describing what your agent should do:
+
+```bash
+cat > my_goal.md << 'EOF'
+# Goal: Learn and Teach Python Testing
+
+Learn best practices for Python testing (pytest, mocking, fixtures)
+and be able to teach them to junior developers.
+
+## Constraints
+- Focus on pytest ecosystem
+- Keep explanations beginner-friendly
+
+## Success Criteria
+- Can explain pytest fixtures with examples
+- Can describe when to use mocking vs integration tests
+- Can generate a test plan for a given module
+EOF
+```
+
+### 2. Generate the agent
+
+```bash
+amplihack new --file my_goal.md --enable-memory --verbose
+```
+
+This produces a standalone agent directory:
+
+```
+goal_agents/learn-and-teach-python-testing/
+  main.py              # Entry point
+  README.md            # Agent documentation
+  prompt.md            # Original goal
+  agent_config.json    # Configuration
+  .claude/
+    agents/            # Matched skills
+    context/
+      goal.json        # Structured goal definition
+      execution_plan.json
+  logs/                # Runtime logs
+```
+
+### 3. Run the agent
+
+```bash
+cd goal_agents/learn-and-teach-python-testing
+python main.py
+```
+
+### 4. Use the Python API directly
+
+```python
+# Upstream Python API (reference only)
+from amplihack.agents.goal_seeking.sdk_adapters.factory import create_agent
+
+agent = create_agent(
+    name="my-learner",
+    sdk="mini",
+    instructions="You are a learning agent that acquires knowledge from content.",
+    enable_memory=True,
+)
+
+agent.learn_from_content("React 20.1 was released in January 2026 with 47 new features.")
+answer = agent.answer_question("When was React 20.1 released?")
+print(answer)
+
+agent.close()
+```
+
+---
+
+## Generating Agents
+
+### The `amplihack new` Command
+
+The generator takes a natural language prompt file and produces a complete,
+runnable agent directory.
+
+**Pipeline stages:**
+
+```
+prompt.md
+  │
+  ▼
+[1] Prompt Analysis     → GoalDefinition
+  │
+  ▼
+[2] Objective Planning  → ExecutionPlan
+  │
+  ▼
+[3] Skill Synthesis     → List[SkillDefinition]
+  │
+  ▼
+[4] Agent Assembly      → GoalAgentBundle
+  │
+  ▼
+[5] Packaging           → Standalone directory
+```
+
+### Command Options
+
+| Option | Short | Description | Default |
+|---|---|---|---|
+| `--file` | `-f` | Path to prompt.md file (required) | — |
+| `--output` | `-o` | Output directory | `./goal_agents` |
+| `--name` | `-n` | Custom agent name | Auto-generated |
+| `--skills-dir` | | Custom skills directory | `~/.amplihack/.claude/agents/amplihack` |
+| `--verbose` | `-v` | Show detailed output | Off |
+| `--enable-memory` | | Enable persistent memory | Off |
+| `--sdk` | | SDK backend | `copilot` |
+| `--multi-agent` | | Enable multi-agent architecture | Off |
+| `--enable-spawning` | | Enable dynamic sub-agent creation | Off |
+
+### Prompt Format
+
+The generator accepts free-form markdown, but this structure produces the best
+results:
+
+```markdown
+# Goal: <Primary objective in one sentence>
+
+<Detailed description>
+
+## Constraints
+- Time limits, resource restrictions, scope boundaries
+
+## Success Criteria
+- Measurable outcomes that define "done"
+
+## Context
+- Background information, domain knowledge
+```
+
+---
+
+## Agent Capabilities
+
+### Learning
+
+Agents extract facts from content and store them in persistent memory using
+LLM-powered fact extraction (not simple keyword matching).
+
+**Process:**
+
+1. Content is passed to `learn_from_content()`
+2. Temporal metadata is detected from the content
+3. In hierarchical mode, an episode node is stored for provenance
+4. The LLM extracts individual facts with confidence scores and tags
+5. Facts are stored in the graph database with temporal metadata
+6. A summary concept map is generated for knowledge organization
+
+### Memory
+
+Agents use the memory system for persistent knowledge storage:
+
+- **Graph database** — Embedded graph DB, no external server required
+- **Hierarchical memory** — Facts can supersede older facts via SUPERSEDES edges
+- **Entity-centric indexing** — O(1) entity lookup via `entity_name` tags
+- **Similarity search** — Keyword-boosted reranking
+- **Cross-session persistence** — Knowledge survives between runs
+- **Temporal metadata** — Tracks when facts were learned and source dates
+
+**Seven learning tools are registered automatically:**
+
+| Tool | Category | Description |
+|---|---|---|
+| `learn_from_content` | learning | Extract and store facts from text |
+| `search_memory` | memory | Query stored knowledge by keyword/topic |
+| `explain_knowledge` | teaching | Generate a topic explanation from stored facts |
+| `find_knowledge_gaps` | learning | Identify what is unknown about a topic |
+| `verify_fact` | applying | Check if a claim is consistent with stored knowledge |
+| `store_fact` | memory | Directly store a fact with context and confidence |
+| `get_memory_summary` | memory | Get statistics about what the agent knows |
+
+### Answering Questions (Retrieval Cascade)
+
+The `answer_question()` method uses a multi-step retrieval cascade:
+
+1. **Intent detection** — Classifies the question into one of 9 intent types
+2. **Retrieval strategy selection** — Entity-centric, simple+rerank, or Cypher aggregation
+3. **Math pre-computation** — Extracts numbers and evaluates expressions safely
+4. **Category-specific synthesis** — LLM prompt varies by intent type
+5. **Math validation** — Checks arithmetic correctness
+6. **Temporal code generation** — Code-based retrieval for temporal questions
+
+### Teaching
+
+The teaching system implements multi-turn dialogue between teacher and student
+agents with **separate memory databases**. Knowledge transfer happens only
+through conversation.
+
+**Teaching strategy (informed by learning theory):**
+
+1. **Advance Organizer** (Ausubel) — Structured overview
+2. **Elaborative Interrogation** — Clarifying questions
+3. **Scaffolding** (Vygotsky) — Adapted explanation level
+4. **Self-Explanation** (Chi 1994) — Student summarizes understanding
+5. **Reciprocal Teaching** (Palincsar & Brown) — Student teaches back
+6. **Feynman Technique** — Every 5 exchanges, student teaches the material
+
+---
+
+## Architecture
+
+### System Design
+
+```
+User Interface
+  amplihack new --file goal.md --sdk copilot
+                    │
+                    ▼
+      GoalSeekingAgent ABC (base)
+      ├── learn_from_content()
+      ├── answer_question()
+      ├── form_goal(intent)
+      ├── run(task, max_turns)
+      └── close()
+           │
+    ┌──────┼──────────┬────────┐
+    ▼      ▼          ▼        ▼
+ Copilot  Claude   Microsoft  Mini
+  SDK     Agent     Agent    Framework
+  SDK     SDK     Framework
+    └──────┼──────────┘────────┘
+           ▼
+   Shared LearningAgent Core
+   ├── fact extraction
+   ├── intent detection
+   ├── retrieval strategies
+   └── synthesis prompts
+           │
+           ▼
+     Memory Library
+   ├── Graph DB
+   ├── Hierarchical memory
+   └── Entity-centric indexing
+```
+
+---
+
+## Multi-Agent Architecture
+
+When `--multi-agent` is enabled, the generator creates a team of specialized
+agents:
+
+| Role | Responsibility |
+|---|---|
+| **Coordinator** | Decomposes goals, assigns tasks, tracks progress |
+| **Researcher** | Gathers information from content and external sources |
+| **Analyzer** | Processes and synthesizes gathered information |
+| **Writer** | Produces final outputs (reports, code, documentation) |
+
+---
+
+## Evaluating Agents
+
+### Progressive Evaluation Levels
+
+Agents are evaluated on a 12-level progressive scale:
+
+| Level | Name | What It Tests |
+|---|---|---|
+| L1 | Smoke | Agent starts and responds |
+| L2 | Learning | Can extract and store facts |
+| L3 | Recall | Can answer simple questions from memory |
+| L4 | Synthesis | Can combine facts from multiple sources |
+| L5 | Teaching | Can explain concepts to others |
+| L6 | Temporal | Can reason about time-ordered events |
+| L7 | Math | Can perform arithmetic on extracted numbers |
+| L8 | Contradiction | Can detect conflicting information |
+| L9 | Causal | Can reason about cause and effect |
+| L10 | Meta-memory | Can answer questions about its own knowledge |
+| L11 | Multi-agent | Can coordinate with other agents |
+| L12 | Self-improvement | Can identify and fix its own weaknesses |
+
+### Running Evaluations
+
+```bash
+# Run all levels
+amplihack eval --agent-dir goal_agents/my-agent/
+
+# Run specific level
+amplihack eval --agent-dir goal_agents/my-agent/ --level L3
+
+# Run with detailed output
+amplihack eval --agent-dir goal_agents/my-agent/ --verbose
+```
+
+---
+
+## Iterating on Agents
+
+### Self-Improvement Loop
+
+The self-improvement loop follows the EVAL → ANALYZE → RESEARCH → IMPROVE →
+RE-EVAL → DECIDE cycle:
+
+1. **EVAL**: Run evaluation suite, get baseline scores
+2. **ANALYZE**: Identify weakest eval levels
+3. **RESEARCH**: Generate hypotheses for improvement with evidence and counter-arguments
+4. **IMPROVE**: Apply targeted improvements
+5. **RE-EVAL**: Run evaluations again
+6. **DECIDE**: Auto-commit if net improvement ≥ +2%, revert if regression > 5%
+
+```bash
+# Run self-improvement loop
+amplihack improve --agent-dir goal_agents/my-agent/ --max-iterations 5
+```
+
+---
+
+## Domain Agents
+
+Pre-built domain agents for common use cases:
+
+| Agent | Domain | Purpose |
+|---|---|---|
+| `security-scanner` | Security | Vulnerability detection and assessment |
+| `dependency-auditor` | DevOps | Package dependency analysis |
+| `api-doc-generator` | Documentation | API documentation from code |
+| `test-coverage-analyzer` | Testing | Test gap identification |
+| `pr-manager` | GitHub | Pull request management |
+| `aks-sre` | Infrastructure | AKS reliability engineering |
+
+See [Goal Agent Generator](agent-generator.md) for the generation system and
+[Agent Lifecycle](agent-lifecycle.md) for lifecycle management.
+
+---
+
+## Reference
+
+### GoalSeekingAgent Interface
+
+```python
+# Upstream Python API (reference only)
+class GoalSeekingAgent(ABC):
+    def learn_from_content(self, content: str) -> dict[str, Any]: ...
+    def answer_question(self, question: str) -> str: ...
+    async def run(self, task: str, max_turns: int = 10) -> AgentResult: ...
+    def form_goal(self, user_intent: str) -> Goal: ...
+    def get_memory_stats(self) -> dict[str, Any]: ...
+    def close(self) -> None: ...
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AMPLIHACK_AGENT_SDK` | `copilot` | Default SDK backend |
+| `AMPLIHACK_AGENT_MEMORY` | `false` | Enable persistent memory |
+| `AMPLIHACK_AGENT_VERBOSE` | `false` | Detailed agent output |
+| `AMPLIHACK_AGENT_MAX_TURNS` | `10` | Maximum agent turns |
+
+## Related Documentation
+
+- [Goal Agent Generator](agent-generator.md) — generation pipeline
+- [Agent Lifecycle](agent-lifecycle.md) — lifecycle management
+- [Evaluation Framework](eval-framework.md) — evaluation system
+- [Goal-Seeking Agent Tutorial](../howto/goal-seeking-agent-tutorial.md) — step-by-step guide
+- [Example Goal Prompts](../reference/goal-agent-example-prompt.md) — prompt templates

--- a/docs/howto/goal-seeking-agent-tutorial.md
+++ b/docs/howto/goal-seeking-agent-tutorial.md
@@ -1,0 +1,315 @@
+# Goal-Seeking Agent Generator Tutorial
+
+A step-by-step guide to generating, evaluating, and iterating on autonomous
+learning agents in amplihack.
+
+!!! note "Rust Port"
+    In amplihack-rs, the generator CLI is `amplihack new`. The tutorial
+    steps are the same; only the installation and binary invocation differ.
+
+---
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Your First Agent](#2-your-first-agent)
+3. [SDK Selection Guide](#3-sdk-selection-guide)
+4. [Multi-Agent Architecture](#4-multi-agent-architecture)
+5. [Running Evaluations](#5-running-evaluations)
+6. [Understanding Eval Levels](#6-understanding-eval-levels)
+7. [Self-Improvement Loop](#7-self-improvement-loop)
+8. [Troubleshooting](#troubleshooting)
+
+---
+
+## 1. Introduction
+
+### What Is a Goal-Seeking Agent?
+
+A goal-seeking agent is an autonomous program that pursues an objective by
+**learning**, **remembering**, **teaching**, and **applying** knowledge. Unlike
+a static script that follows a fixed sequence, these agents adapt and improve.
+
+### Architecture
+
+The generator pipeline has five stages:
+
+```
+Prompt (.md)
+    │
+    ▼
+PromptAnalyzer → GoalDefinition
+    │
+    ▼
+ObjectivePlanner → ExecutionPlan
+    │
+    ▼
+SkillSynthesizer → Skills + SDK Tools
+    │
+    ▼
+AgentAssembler → GoalAgentBundle
+    │
+    ▼
+GoalAgentPackager → /goal_agents/<name>/
+```
+
+1. **Analyze**: Extract goal, domain, constraints from markdown
+2. **Plan**: Break goal into phases with capabilities
+3. **Synthesize**: Match skills and SDK-native tools
+4. **Assemble**: Build the agent bundle with config and metadata
+5. **Package**: Write to disk as a runnable project
+
+### The GoalSeekingAgent Interface
+
+Every generated agent implements the same interface regardless of SDK:
+
+```python
+# Upstream Python API (reference only)
+class GoalSeekingAgent(ABC):
+    def learn_from_content(self, content: str) -> dict[str, Any]: ...
+    def answer_question(self, question: str) -> str: ...
+    async def run(self, task: str, max_turns: int = 10) -> AgentResult: ...
+    def form_goal(self, user_intent: str) -> Goal: ...
+    def get_memory_stats(self) -> dict[str, Any]: ...
+    def close(self) -> None: ...
+```
+
+Write your agent logic once; swap SDKs freely.
+
+---
+
+## 2. Your First Agent
+
+### Step 1: Write a Prompt File
+
+Create `my_goal.md`:
+
+```markdown
+# Goal: Learn and Summarize Python Best Practices
+
+## Objective
+Build an agent that reads Python style guides and can answer
+questions about best practices.
+
+## Domain
+software-engineering
+
+## Constraints
+- Focus on PEP-8 and type-hinting
+- Keep answers concise
+
+## Success Criteria
+- Can explain PEP-8 naming conventions
+- Can describe when to use type hints
+```
+
+The prompt file requires four sections: **Goal/Objective**, **Domain**,
+**Constraints**, and **Success Criteria**.
+
+### Step 2: Generate the Agent
+
+```bash
+amplihack new --file my_goal.md
+```
+
+With custom output directory and name:
+
+```bash
+amplihack new --file my_goal.md --name python-coach --output ./agents
+```
+
+### Step 3: Run the Agent
+
+```bash
+cd goal_agents/python-coach
+python main.py
+```
+
+### What Happens Under the Hood
+
+1. `PromptAnalyzer` parses `my_goal.md` and extracts goal, domain, constraints
+2. `ObjectivePlanner` creates an `ExecutionPlan` with phases
+3. `SkillSynthesizer` matches skills from `.claude/agents/amplihack/`
+4. `AgentAssembler` builds the `GoalAgentBundle`
+5. `GoalAgentPackager` writes files to disk
+
+---
+
+## 3. SDK Selection Guide
+
+Choose an SDK based on your needs:
+
+| SDK | LLM | Best For | Native Tools |
+|---|---|---|---|
+| `copilot` | GPT-4.1 | GitHub integration, file ops | file, git, web |
+| `claude` | Claude Sonnet | Code analysis, writing | bash, read, write, grep |
+| `microsoft` | GPT-4o | Enterprise, session mgmt | FunctionTool |
+| `mini` | Any (via API) | Lightweight, testing | Learning tools only |
+
+### Using a Specific SDK
+
+```bash
+# Generate with Claude SDK
+amplihack new --file my_goal.md --sdk claude
+
+# Generate with Copilot SDK
+amplihack new --file my_goal.md --sdk copilot
+
+# Generate with Mini framework (lightweight)
+amplihack new --file my_goal.md --sdk mini
+```
+
+---
+
+## 4. Multi-Agent Architecture
+
+Enable multi-agent mode for complex goals:
+
+```bash
+amplihack new --file my_goal.md --multi-agent
+```
+
+This generates a team of specialized agents:
+
+| Role | Responsibility |
+|---|---|
+| **Coordinator** | Decomposes goals, assigns tasks |
+| **Researcher** | Gathers information |
+| **Analyzer** | Processes and synthesizes |
+| **Writer** | Produces final outputs |
+
+### Agent Spawning
+
+Enable dynamic sub-agent creation:
+
+```bash
+amplihack new --file my_goal.md --multi-agent --enable-spawning
+```
+
+With spawning, the coordinator can create new specialized agents at runtime
+based on the task requirements.
+
+---
+
+## 5. Running Evaluations
+
+### Basic Evaluation
+
+```bash
+# Run all evaluation levels
+amplihack eval --agent-dir goal_agents/my-agent/
+
+# Run specific level
+amplihack eval --agent-dir goal_agents/my-agent/ --level L3
+
+# Run with detailed output
+amplihack eval --agent-dir goal_agents/my-agent/ --verbose
+```
+
+### Evaluation Output
+
+```
+Evaluation Results for: python-coach
+═══════════════════════════════════
+
+L1  Smoke .............. PASS  (1.2s)
+L2  Learning ........... PASS  (3.4s)
+L3  Recall ............. PASS  (2.1s)
+L4  Synthesis .......... PASS  (4.5s)
+L5  Teaching ........... FAIL  (5.2s)
+    └─ Could not explain pytest fixtures with examples
+L6  Temporal ........... SKIP  (depends on L5)
+
+Overall: 4/6 passed (66.7%)
+```
+
+---
+
+## 6. Understanding Eval Levels
+
+| Level | Name | What It Tests | Pass Criteria |
+|---|---|---|---|
+| L1 | Smoke | Agent starts and responds | Returns non-empty response |
+| L2 | Learning | Can extract and store facts | ≥ 1 fact stored |
+| L3 | Recall | Can answer simple questions | Correct answer from memory |
+| L4 | Synthesis | Combines facts from multiple sources | Multi-source answer |
+| L5 | Teaching | Can explain concepts | Clear, accurate explanation |
+| L6 | Temporal | Reasons about time-ordered events | Correct temporal ordering |
+| L7 | Math | Performs arithmetic on extracted numbers | Correct computation |
+| L8 | Contradiction | Detects conflicting information | Identifies conflict |
+| L9 | Causal | Reasons about cause and effect | Correct causal chain |
+| L10 | Meta-memory | Answers questions about its knowledge | Accurate self-assessment |
+| L11 | Multi-agent | Coordinates with other agents | Successful delegation |
+| L12 | Self-improvement | Identifies and fixes weaknesses | Score improvement |
+
+---
+
+## 7. Self-Improvement Loop
+
+The self-improvement loop automatically iterates on agent quality:
+
+```bash
+amplihack improve --agent-dir goal_agents/my-agent/ --max-iterations 5
+```
+
+### Cycle
+
+1. **EVAL**: Run evaluation suite, get baseline scores
+2. **ANALYZE**: Identify weakest eval levels
+3. **RESEARCH**: Generate hypotheses for improvement
+4. **IMPROVE**: Apply targeted improvements
+5. **RE-EVAL**: Run evaluations again
+6. **DECIDE**: Auto-commit if improvement ≥ +2%, revert if regression > 5%
+
+### Example Output
+
+```
+Iteration 1/5
+  Baseline: L5=FAIL (teaching)
+  Hypothesis: Add structured example templates to teaching prompts
+  Applying improvement...
+  Re-eval: L5=PASS ✓ (+8.3% overall improvement)
+  Decision: COMMIT (net gain +8.3%, no regression)
+
+Iteration 2/5
+  All levels passing. No further improvements needed.
+  Final score: 12/12 (100%)
+```
+
+---
+
+## Troubleshooting
+
+### Agent fails to start
+
+- Check that the SDK is installed and API keys are configured
+- Verify the agent directory contains `main.py` and `agent_config.json`
+- Check logs in `goal_agents/<name>/logs/`
+
+### Low evaluation scores
+
+- Review the goal prompt for clarity and specificity
+- Ensure constraints are realistic
+- Try a different SDK (Claude tends to be better for code-heavy tasks)
+
+### Memory issues
+
+- Verify memory is enabled: `--enable-memory`
+- Check that the graph database is accessible
+- Look for memory errors in agent logs
+
+### Generation fails
+
+- Validate the prompt file has all required sections
+- Check that the skills directory exists
+- Try with `--verbose` for detailed error output
+
+---
+
+## Related Documentation
+
+- [Goal-Seeking Agents](../concepts/goal-seeking-agents.md) — concept overview
+- [Goal Agent Generator](../concepts/agent-generator.md) — generation pipeline
+- [Example Goal Prompts](../reference/goal-agent-example-prompt.md) — prompt templates
+- [Evaluation Framework](../concepts/eval-framework.md) — evaluation system
+- [Benchmarking](../reference/benchmarking.md) — performance measurement

--- a/docs/reference/goal-agent-example-prompt.md
+++ b/docs/reference/goal-agent-example-prompt.md
@@ -1,0 +1,112 @@
+# Example Goal Prompt
+
+A template for creating goal-seeking agent prompts with the `amplihack new`
+command.
+
+## Template
+
+```markdown
+# Goal: <Primary objective in one sentence>
+
+<Detailed description of what the agent should accomplish>
+
+## Objective
+<Specific, measurable objective>
+
+## Domain
+<Domain area: software-engineering, security, documentation, etc.>
+
+## Constraints
+- <Time limits>
+- <Resource restrictions>
+- <Scope boundaries>
+
+## Success Criteria
+- <Measurable outcome 1>
+- <Measurable outcome 2>
+- <Measurable outcome 3>
+
+## Context
+<Background information, domain knowledge, related systems>
+
+## Technical Requirements
+- <Specific tool or API integrations>
+- <Language or framework requirements>
+- <Output format specifications>
+```
+
+## Example: Code Review Agent
+
+```markdown
+# Goal: Automate Code Review Process
+
+Create an autonomous agent that reviews pull requests and provides feedback.
+
+## Objective
+
+Build a system that:
+
+- Analyzes code changes in pull requests
+- Detects common issues and anti-patterns
+- Generates constructive feedback
+- Posts review comments automatically
+
+## Domain
+
+Automation and code quality
+
+## Constraints
+
+- Must complete review within 15 minutes
+- Should not modify code directly
+- Must respect existing code style
+- Cannot access production systems
+
+## Success Criteria
+
+- All pull requests reviewed within SLA
+- At least 80% of common issues detected
+- Review comments are actionable and helpful
+- No false positives on style violations
+- Team satisfaction with review quality
+
+## Technical Requirements
+
+- Integrate with GitHub API
+- Support multiple programming languages
+- Generate reports in markdown format
+- Track review metrics over time
+
+## Context
+
+This agent will help reduce code review bottlenecks and improve code quality
+by providing fast, consistent, automated feedback on common issues, allowing
+human reviewers to focus on architecture and business logic.
+```
+
+## Usage
+
+```bash
+# Generate from prompt file
+amplihack new --file code_review_goal.md --enable-memory --verbose
+
+# With specific SDK
+amplihack new --file code_review_goal.md --sdk claude --name pr-reviewer
+
+# With multi-agent architecture
+amplihack new --file code_review_goal.md --multi-agent --enable-spawning
+```
+
+## Tips for Effective Prompts
+
+1. **Be specific**: "Review Rust code for unsafe blocks" > "Review code"
+2. **Measurable criteria**: "Detect 80% of issues" > "Find bugs"
+3. **Clear constraints**: List what the agent should NOT do
+4. **Context matters**: Explain why the agent exists and how it fits in
+5. **Domain specification**: Helps the generator select appropriate skills
+
+## Related Documentation
+
+- [Goal-Seeking Agents](../concepts/goal-seeking-agents.md) — concept overview
+- [Goal-Seeking Agent Tutorial](../howto/goal-seeking-agent-tutorial.md) — step-by-step guide
+- [Goal Agent Generator](../concepts/agent-generator.md) — generation pipeline

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Create Your Own Tools: howto/create-your-own-tools.md
       - Recipe CLI Examples: howto/recipe-cli-examples.md
       - Recipe Discovery Troubleshooting: howto/recipe-discovery-troubleshooting.md
+      - Goal-Seeking Agent Tutorial: howto/goal-seeking-agent-tutorial.md
       - Token Sanitization: howto/token-sanitization.md
       - Security Testing: howto/security-testing.md
   - Skills:
@@ -113,6 +114,7 @@ nav:
       - Benchmarking: reference/benchmarking.md
       - Recipe Quick Reference: reference/recipe-quick-reference.md
       - Security API Reference: reference/security-api.md
+      - Goal Agent Example Prompt: reference/goal-agent-example-prompt.md
       - Code Review Practices: reference/code-review.md
       - Prerequisites: reference/prerequisites.md
   - Concepts:
@@ -153,6 +155,7 @@ nav:
       - Documentation Knowledge Graph: concepts/documentation-knowledge-graph.md
       - External Knowledge Integration: concepts/external-knowledge-integration.md
       - Native Binary Trace Logging: concepts/native-binary-trace-logging.md
+      - Goal-Seeking Agents: concepts/goal-seeking-agents.md
   - Code Atlas:
       - Overview: atlas/index.md
       - "Layer 1: Repo Surface": atlas/repo-surface/README.md


### PR DESCRIPTION
## Summary
- Port 3 upstream goal-seeking agent docs (#420)
- `docs/GOAL_SEEKING_AGENTS.md` → `docs/concepts/goal-seeking-agents.md`
- `docs/tutorials/GOAL_SEEKING_AGENT_TUTORIAL.md` → `docs/howto/goal-seeking-agent-tutorial.md`
- `docs/examples/goal_agent_generator/example_goal_prompt.md` → `docs/reference/goal-agent-example-prompt.md`

## Test plan
- [x] `mkdocs build --strict` passes locally
- [x] Diff contains only `docs/**/*.md` and `mkdocs.yml`
- [x] Nav entries added under correct Diátaxis sections
- [x] Cross-links to existing agent docs verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #420