### PR TITLE
fix(env_builder): detect parent agent runtime in active_agent_binary (#441)

### DIFF
--- a/crates/amplihack-cli/src/env_builder/helpers.rs
+++ b/crates/amplihack-cli/src/env_builder/helpers.rs
@@ -2,16 +2,60 @@ use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 
-pub fn active_agent_binary() -> String {
-    match env::var("AMPLIHACK_AGENT_BINARY") {
-        Ok(value) if !value.trim().is_empty() => value,
-        _ => {
-            tracing::warn!(
-                "AMPLIHACK_AGENT_BINARY not set; defaulting to 'claude'. This usually means a subprocess was launched outside the amplihack CLI dispatcher."
-            );
-            "claude".to_string()
+const CLAUDE_PREFIX: &str = "CLAUDE_CODE_";
+const CODEX_PREFIX: &str = "CODEX_";
+
+fn env_nonempty(key: &str) -> bool {
+    matches!(env::var(key), Ok(v) if !v.trim().is_empty())
+}
+
+fn any_prefix_nonempty(prefix: &str) -> bool {
+    for (k, v) in env::vars_os() {
+        let Some(k) = k.to_str() else { continue };
+        if k.starts_with(prefix)
+            && let Some(v) = v.to_str()
+            && !v.trim().is_empty()
+        {
+            return true;
         }
     }
+    false
+}
+
+/// Resolves which agent binary identifier the current process is operating under.
+///
+/// Detection priority:
+/// 1. `AMPLIHACK_AGENT_BINARY` (non-empty after trim) — explicit override.
+/// 2. `COPILOT_AGENT_SESSION_ID` (non-empty) → `"copilot"`.
+/// 3. `CLAUDECODE` or any `CLAUDE_CODE_*` env var (non-empty) → `"claude"`.
+/// 4. `CODEX_HOME` or any `CODEX_*` env var (non-empty) → `"codex"`.
+/// 5. Fallback → emit a warning and return `"claude"`.
+///
+/// The override value is **untrusted user input** — callers must allowlist or
+/// otherwise validate it before using it as a `Command::new` target.
+pub fn active_agent_binary() -> String {
+    if let Ok(value) = env::var("AMPLIHACK_AGENT_BINARY")
+        && !value.trim().is_empty()
+    {
+        return value;
+    }
+
+    if env_nonempty("COPILOT_AGENT_SESSION_ID") {
+        return "copilot".to_string();
+    }
+
+    if env_nonempty("CLAUDECODE") || any_prefix_nonempty(CLAUDE_PREFIX) {
+        return "claude".to_string();
+    }
+
+    if env_nonempty("CODEX_HOME") || any_prefix_nonempty(CODEX_PREFIX) {
+        return "codex".to_string();
+    }
+
+    tracing::warn!(
+        "AMPLIHACK_AGENT_BINARY not set; defaulting to 'claude'. This usually means a subprocess was launched outside the amplihack CLI dispatcher."
+    );
+    "claude".to_string()
 }
 
 pub(super) fn find_asset_resolver_binary() -> Option<PathBuf> {

--- a/crates/amplihack-cli/src/env_builder/tests_builder.rs
+++ b/crates/amplihack-cli/src/env_builder/tests_builder.rs
@@ -354,3 +354,185 @@ fn with_amplihack_home_rejects_traversal_path() {
         "with_amplihack_home must not set AMPLIHACK_HOME when HOME contains path traversal"
     );
 }
+
+// ── Issue #441: active_agent_binary parent-runtime detection ──────────────
+//
+// These tests serialize all mutations to the detection-relevant env vars
+// via a single mutex, snapshot every relevant key on entry, scrub them, run
+// the assertion, then restore originals on drop (RAII).
+
+use std::sync::Mutex;
+
+static AGENT_BINARY_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const TRACKED_EXACT: &[&str] = &[
+    "AMPLIHACK_AGENT_BINARY",
+    "COPILOT_AGENT_SESSION_ID",
+    "CLAUDECODE",
+    "CODEX_HOME",
+];
+
+const TRACKED_PREFIXES: &[&str] = &["CLAUDE_CODE_", "CODEX_"];
+
+struct EnvSnapshot {
+    saved: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+}
+
+impl EnvSnapshot {
+    /// Snapshot every detection-relevant env var, then remove them all.
+    fn scrub_all() -> Self {
+        let mut saved = Vec::new();
+        let mut keys: Vec<std::ffi::OsString> = Vec::new();
+        for k in TRACKED_EXACT {
+            keys.push(std::ffi::OsString::from(k));
+        }
+        for (k, _v) in env::vars_os() {
+            let k_lossy = k.to_string_lossy();
+            for prefix in TRACKED_PREFIXES {
+                if k_lossy.starts_with(prefix) && !keys.iter().any(|existing| existing == &k) {
+                    keys.push(k.clone());
+                    break;
+                }
+            }
+        }
+        for k in keys {
+            if let Some(v) = env::var_os(&k) {
+                saved.push((k.clone(), v));
+            }
+            unsafe { env::remove_var(&k) };
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for EnvSnapshot {
+    fn drop(&mut self) {
+        // Remove anything we may have set during the test, then restore.
+        for k in TRACKED_EXACT {
+            unsafe { env::remove_var(k) };
+        }
+        // We cannot enumerate test-set prefixed keys reliably; clear any
+        // tracked keys that were saved + any that exist now matching prefix.
+        let current: Vec<std::ffi::OsString> = env::vars_os().map(|(k, _)| k).collect();
+        for k in current {
+            let k_lossy = k.to_string_lossy();
+            for prefix in TRACKED_PREFIXES {
+                if k_lossy.starts_with(prefix) {
+                    unsafe { env::remove_var(&k) };
+                    break;
+                }
+            }
+        }
+        for (k, v) in &self.saved {
+            unsafe { env::set_var(k, v) };
+        }
+    }
+}
+
+fn lock_agent_env() -> std::sync::MutexGuard<'static, ()> {
+    AGENT_BINARY_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+}
+
+/// Issue #441: explicit AMPLIHACK_AGENT_BINARY override beats any runtime
+/// signal — including when copilot/claude/codex env vars are also present.
+#[test]
+fn override_wins_over_runtime_signals() {
+    let _guard = lock_agent_env();
+    let _snap = EnvSnapshot::scrub_all();
+
+    unsafe { env::set_var("AMPLIHACK_AGENT_BINARY", "custom") };
+    unsafe { env::set_var("COPILOT_AGENT_SESSION_ID", "abc123") };
+    unsafe { env::set_var("CLAUDECODE", "1") };
+    unsafe { env::set_var("CODEX_HOME", "/x") };
+
+    assert_eq!(active_agent_binary(), "custom");
+}
+
+/// Issue #441: COPILOT_AGENT_SESSION_ID alone -> "copilot".
+#[test]
+fn detects_copilot_via_session_id() {
+    let _guard = lock_agent_env();
+    let _snap = EnvSnapshot::scrub_all();
+
+    unsafe { env::set_var("COPILOT_AGENT_SESSION_ID", "session-xyz") };
+
+    assert_eq!(active_agent_binary(), "copilot");
+}
+
+/// Issue #441: CLAUDECODE set OR any CLAUDE_CODE_* prefix set -> "claude".
+#[test]
+fn detects_claude_via_claudecode_or_prefix() {
+    // Sub-case 1: CLAUDECODE exact match
+    {
+        let _guard = lock_agent_env();
+        let _snap = EnvSnapshot::scrub_all();
+        unsafe { env::set_var("CLAUDECODE", "1") };
+        assert_eq!(
+            active_agent_binary(),
+            "claude",
+            "CLAUDECODE should select claude"
+        );
+    }
+    // Sub-case 2: CLAUDE_CODE_* prefix match
+    {
+        let _guard = lock_agent_env();
+        let _snap = EnvSnapshot::scrub_all();
+        unsafe { env::set_var("CLAUDE_CODE_SESSION", "x") };
+        assert_eq!(
+            active_agent_binary(),
+            "claude",
+            "CLAUDE_CODE_* prefix should select claude"
+        );
+    }
+}
+
+/// Issue #441: CODEX_HOME set OR any CODEX_* prefix set -> "codex".
+#[test]
+fn detects_codex_via_home_or_prefix() {
+    // Sub-case 1: CODEX_HOME exact match
+    {
+        let _guard = lock_agent_env();
+        let _snap = EnvSnapshot::scrub_all();
+        unsafe { env::set_var("CODEX_HOME", "/opt/codex") };
+        assert_eq!(
+            active_agent_binary(),
+            "codex",
+            "CODEX_HOME should select codex"
+        );
+    }
+    // Sub-case 2: CODEX_* prefix match (not CODEX_HOME)
+    {
+        let _guard = lock_agent_env();
+        let _snap = EnvSnapshot::scrub_all();
+        unsafe { env::set_var("CODEX_SESSION_ID", "x") };
+        assert_eq!(
+            active_agent_binary(),
+            "codex",
+            "CODEX_* prefix should select codex"
+        );
+    }
+}
+
+/// Issue #441: when no detection vars are set, fall back to "claude" with warn.
+#[test]
+fn fallback_when_nothing_set() {
+    let _guard = lock_agent_env();
+    let _snap = EnvSnapshot::scrub_all();
+
+    assert_eq!(active_agent_binary(), "claude");
+}
+
+/// Issue #441: empty/whitespace-only override is treated as "not set" and
+/// detection logic proceeds (here: copilot via session id).
+#[test]
+fn empty_override_falls_through_to_detection() {
+    let _guard = lock_agent_env();
+    let _snap = EnvSnapshot::scrub_all();
+
+    unsafe { env::set_var("AMPLIHACK_AGENT_BINARY", "   ") };
+    unsafe { env::set_var("COPILOT_AGENT_SESSION_ID", "session") };
+
+    assert_eq!(active_agent_binary(), "copilot");
+}

--- a/docs/reference/active-agent-binary.md
+++ b/docs/reference/active-agent-binary.md
@@ -1,0 +1,152 @@
+# `active_agent_binary()` — Parent Agent Runtime Detection
+
+## Overview
+
+`active_agent_binary()` returns the identifier of the agent binary that the current `amplihack-cli` process should treat as its "active" runtime. As of #441, it auto-detects the parent agent runtime from well-known environment variables instead of unconditionally returning `"claude"`.
+
+This means that when `amplihack-cli` is invoked from inside a Copilot CLI, Claude Code, or Codex session, nested workflow steps stay on the caller's runtime without requiring the user to set `AMPLIHACK_AGENT_BINARY` manually.
+
+**Module:** `amplihack_cli::env_builder::helpers`
+**Signature:** `pub fn active_agent_binary() -> String`
+
+## Detection Priority
+
+The function evaluates the following sources in order and returns on the first match. A value is considered "set" only if it is present **and** non-empty after trimming whitespace.
+
+| # | Source                                                       | Returned identifier                  |
+| - | ------------------------------------------------------------ | ------------------------------------ |
+| 1 | `AMPLIHACK_AGENT_BINARY` (explicit override)                 | the override value, verbatim (after trim check) |
+| 2 | `COPILOT_AGENT_SESSION_ID`                                   | `"copilot"`                          |
+| 3 | `CLAUDECODE` **or** any env var starting with `CLAUDE_CODE_` | `"claude"`                           |
+| 4 | `CODEX_HOME` **or** any env var starting with `CODEX_`       | `"codex"`                            |
+| 5 | (none of the above)                                          | `"claude"` + a `tracing::warn!` log  |
+
+Empty or whitespace-only values are treated as "not set" at every level, including the override. For example, `AMPLIHACK_AGENT_BINARY=""` and `AMPLIHACK_AGENT_BINARY="   "` are both treated as unset and detection proceeds to step 2.
+
+### Prefix-match scope
+
+The `CLAUDE_CODE_` and `CODEX_` prefix scans iterate `std::env::vars_os()` and match **any** variable whose name starts with the given prefix:
+
+- `CLAUDE_CODE_*` matches `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_SSE_PORT`, etc. It does **not** match the bare `CLAUDE_*` namespace — `CLAUDE_API_KEY` will not trigger Claude detection.
+- `CODEX_*` matches every variable starting with `CODEX_`. `CODEX_HOME` is one such match; any other `CODEX_*` variable also triggers detection. The explicit `CODEX_HOME` check is a fast path, not an exclusion.
+
+## Usage
+
+```rust
+use amplihack_cli::env_builder::helpers::active_agent_binary;
+
+let binary = active_agent_binary();
+tracing::info!(%binary, "dispatching nested workflow on detected runtime");
+```
+
+The returned string is an **identifier**, not a path. Callers that need to launch the binary should resolve it through their existing platform allowlist (e.g. the launcher's binary resolver), never pass it directly to `Command::new`. The two existing in-tree consumers (`execute.rs` and `rust_trial.rs`) use the return value purely as an identifier passed to the platform binary resolver.
+
+## Examples
+
+### Inside Copilot CLI
+
+```bash
+# Copilot CLI sets COPILOT_AGENT_SESSION_ID for every nested process.
+$ env | grep COPILOT_AGENT_SESSION_ID
+COPILOT_AGENT_SESSION_ID=abc123
+
+$ amplihack recipe run smart-orchestrator -c task_description="..."
+# active_agent_binary() -> "copilot"
+```
+
+### Inside Claude Code
+
+```bash
+$ env | grep -E '^(CLAUDECODE|CLAUDE_CODE_)'
+CLAUDECODE=1
+CLAUDE_CODE_ENTRYPOINT=cli
+
+$ amplihack recipe run default-workflow ...
+# active_agent_binary() -> "claude"
+```
+
+Note that only the `CLAUDE_CODE_` prefix is scanned. A value such as `CLAUDE_API_KEY` would not trigger Claude detection on its own.
+
+### Inside Codex
+
+```bash
+$ env | grep ^CODEX_
+CODEX_HOME=/home/me/.codex
+
+$ amplihack recipe run investigation-workflow ...
+# active_agent_binary() -> "codex"
+```
+
+### Explicit override (highest priority)
+
+```bash
+$ AMPLIHACK_AGENT_BINARY=copilot amplihack ...
+# active_agent_binary() -> "copilot"  (regardless of any other detection signals)
+```
+
+### Empty override falls through to detection
+
+```bash
+$ AMPLIHACK_AGENT_BINARY="   " COPILOT_AGENT_SESSION_ID=abc amplihack ...
+# active_agent_binary() -> "copilot"  (whitespace-only override is treated as unset)
+```
+
+### No runtime detected (fallback)
+
+```bash
+$ env -i amplihack ...
+# active_agent_binary() -> "claude"
+# WARN: AMPLIHACK_AGENT_BINARY not set; defaulting to 'claude'. ...
+```
+
+## Configuration Reference
+
+| Variable                    | Effect                                                       | Notes                                  |
+| --------------------------- | ------------------------------------------------------------ | -------------------------------------- |
+| `AMPLIHACK_AGENT_BINARY`    | Forces the returned identifier to this exact value           | Highest priority. Untrusted; callers must allowlist before exec. Empty/whitespace-only values fall through to detection. |
+| `COPILOT_AGENT_SESSION_ID`  | Presence selects `"copilot"`                                 | Set automatically by Copilot CLI       |
+| `CLAUDECODE`                | Presence selects `"claude"`                                  | Set automatically by Claude Code       |
+| `CLAUDE_CODE_*` (any)       | Presence of any matching var selects `"claude"`              | Strict prefix `CLAUDE_CODE_`. Bare `CLAUDE_*` does **not** match. |
+| `CODEX_HOME`                | Presence selects `"codex"`                                   | Set automatically by Codex             |
+| `CODEX_*` (any)             | Presence of any matching var selects `"codex"`               | Prefix `CODEX_`. `CODEX_HOME` is one such match; any other `CODEX_*` var also triggers detection. |
+
+All checks ignore values that are empty or whitespace-only.
+
+## Security Notes
+
+- `AMPLIHACK_AGENT_BINARY` is **untrusted user input**. `active_agent_binary()` returns it verbatim; do not pass the value directly to `Command::new` or shell. Resolve through your platform's binary allowlist.
+- The function never logs env var **values**, only detection outcomes (and only on the fallback branch).
+- Prefix scans iterate `std::env::vars_os()` once per call; cost is O(n) in env size — negligible for typical usage. Cache the result if invoked in a hot path.
+- No new dependencies are introduced.
+
+## Behavior Change Summary (#441)
+
+| Scenario                                               | Before #441           | After #441                                                 |
+| ------------------------------------------------------ | --------------------- | ---------------------------------------------------------- |
+| Run from Copilot CLI, no override                      | `"claude"` + warn     | `"copilot"`                                                |
+| Run from Claude Code, no override                      | `"claude"` + warn     | `"claude"` (no warn)                                       |
+| Run from Codex, no override                            | `"claude"` + warn     | `"codex"`                                                  |
+| `AMPLIHACK_AGENT_BINARY=foo` set                       | `"foo"`               | `"foo"` (unchanged)                                        |
+| `AMPLIHACK_AGENT_BINARY=""` (or whitespace) set        | `"claude"` + warn     | Falls through to runtime detection (or fallback + warn)    |
+| No detection vars and no override                      | `"claude"` + warn     | `"claude"` + warn (unchanged; warn message preserved verbatim) |
+
+The fallback warn message is preserved verbatim from the pre-#441 implementation so that existing log scrapers and alerts continue to match.
+
+## Testing
+
+Unit tests live in `crates/amplihack-cli/src/env_builder/tests_builder.rs` and cover all branches:
+
+- `override_wins_over_runtime_signals`
+- `detects_copilot_via_session_id`
+- `detects_claude_via_claudecode_or_prefix`
+- `detects_codex_via_home_or_prefix`
+- `fallback_when_nothing_set`
+
+Tests are standard `#[test]` functions. They serialize on a module-local `AGENT_BINARY_ENV_LOCK: Mutex<()>` and use a RAII `EnvSnapshot` guard that scrubs all detection-relevant variables (`AMPLIHACK_AGENT_BINARY`, `COPILOT_AGENT_SESSION_ID`, `CLAUDECODE`, `CODEX_HOME`, plus any `CLAUDE_CODE_*` / `CODEX_*` discovered at runtime) and restores the originals on drop. The mutex makes parallel `cargo test` execution safe.
+
+Run locally:
+
+```bash
+cargo clippy -p amplihack-cli --all-targets -- -D warnings
+TMPDIR=/tmp cargo test -p amplihack-cli --lib
+```


### PR DESCRIPTION
## Summary

Fixes #441.

When `AMPLIHACK_AGENT_BINARY` is unset, `active_agent_binary()` now detects the parent agent runtime via well-known env vars before falling back to `'claude'` with a warning. This prevents nested workflow agents from silently misreporting their runtime when launched outside the amplihack CLI dispatcher.

## Detection priority

1. `AMPLIHACK_AGENT_BINARY` (non-empty after trim) — explicit override (existing).
2. `COPILOT_AGENT_SESSION_ID` (non-empty) → `"copilot"`.
3. `CLAUDECODE` or any `CLAUDE_CODE_*` (non-empty) → `"claude"`.
4. `CODEX_HOME` or any `CODEX_*` (non-empty) → `"codex"`.
5. Fallback → emit existing warn verbatim and return `"claude"`.

Empty / whitespace-only values are treated as "not set" (consistent with the existing override check).

## Tests

Six tests in `crates/amplihack-cli/src/env_builder/tests_builder.rs` cover every branch:

- `override_wins_over_runtime_signals`
- `detects_copilot_via_session_id`
- `detects_claude_via_claudecode_or_prefix` (covers exact match + prefix)
- `detects_codex_via_home_or_prefix` (covers exact match + prefix)
- `fallback_when_nothing_set`
- `empty_override_falls_through_to_detection`

Tests share an `AGENT_BINARY_ENV_LOCK` mutex and an `EnvSnapshot` RAII guard that scrubs and restores all detection-relevant env vars (including `CLAUDE_CODE_*` / `CODEX_*` prefix keys discovered at runtime), so they are safe under `cargo test` parallelism.

## Consumer verification

Verified that downstream consumers (`commands/launch/execute.rs`, `commands/rust_trial.rs`) treat the return value as an **identifier** (used for branching, env propagation, telemetry) — not as a `Command::new` target. So the override-injection surface is unchanged by this PR.

## Validation

- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` ✅
- `TMPDIR=/tmp cargo test -p amplihack-cli --lib env_builder` → 32 passed, 0 failed ✅
- `pre-commit run` (cargo fmt + clippy) ✅
- Two pre-existing failures in `update::tests` are environment-dependent (`AMPLIHACK_NONINTERACTIVE=1` in CI/dev shell) and reproduce on `main` — unrelated to this change.

## Files changed

- `crates/amplihack-cli/src/env_builder/helpers.rs` — detection logic + rustdoc
- `crates/amplihack-cli/src/env_builder/tests_builder.rs` — 6 new tests + env-snapshot infra
- `docs/reference/active-agent-binary.md` — new reference doc

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
