### PR TITLE
docs: port migration guides from upstream (wave 5)

### DIFF
--- a/docs/howto/ladybug-migration-guide.md
+++ b/docs/howto/ladybug-migration-guide.md
@@ -1,0 +1,158 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Migrating KuzuGraphStore from kuzu to ladybug
+
+## What Changed
+
+The `KuzuGraphStore` class moved from `amplihack.memory.kuzu_store` to
+`amplihack.memory.ladybug_store`. The underlying graph engine changed from
+[kuzu](https://kuzudb.com/) to [ladybug](https://github.com/kuzudb/ladybug),
+Kuzu's next-generation embedded graph database.
+
+The class name (`KuzuGraphStore`) and its public API are **unchanged**.
+
+!!! note "Upstream Python API reference"
+    The import paths, installation commands, and code snippets in this guide
+    refer to the **upstream Python amplihack** implementation. The architectural
+    concepts (ladybug vs kuzu migration, locking, read-only mode) apply equally
+    to amplihack-rs, but the Rust crate uses its own native bindings.
+
+### Why ladybug?
+
+Ladybug is the successor to kuzu. It ships the same Cypher query engine with
+improvements to concurrent access, string handling, and packaging. The amplihack
+upgrade adds `fcntl.flock` serialization so multiple processes (e.g., parallel
+agent workstreams) can safely share a single database directory.
+
+## Who Needs to Migrate
+
+| You are... | Action required |
+|---|---|
+| Using `amplihack memory tree` / `export` / `import` CLI | None -- transparent |
+| Importing `from amplihack.memory import KuzuGraphStore` | None -- still works |
+| Importing `from amplihack.memory.kuzu_store import ...` | Update import path |
+| Running tests that mock `kuzu_store` internals | Update mock paths |
+| Calling `KuzuGraphStore(db_path=...)` | None -- API unchanged |
+
+## Migration Steps
+
+### 1. Update direct imports
+
+```python
+# Before
+from amplihack.memory.kuzu_store import KuzuGraphStore
+
+# After
+from amplihack.memory.ladybug_store import KuzuGraphStore
+```
+
+The package-level import still works without changes:
+
+```python
+from amplihack.memory import KuzuGraphStore  # no change needed
+```
+
+### 2. Install ladybug
+
+```bash
+uv add ladybug
+# or
+pip install ladybug
+```
+
+A graceful fallback to `import kuzu` exists during the transition period. If
+neither package is installed, the import raises `ImportError`.
+
+### 3. Update mock/patch targets in tests
+
+```python
+# Before
+@mock.patch("amplihack.memory.kuzu_store.ladybug.Database")
+
+# After
+@mock.patch("amplihack.memory.ladybug_store.ladybug.Database")
+```
+
+### 4. Verify
+
+```bash
+# Quick smoke test
+python3 -c "from amplihack.memory.ladybug_store import KuzuGraphStore; print('OK')"
+
+# Run graph store tests
+pytest tests/test_graph_store.py -q
+```
+
+## New Features
+
+### Read-only mode
+
+Open a database for read-only access with a shared lock:
+
+```python
+store = KuzuGraphStore(db_path="~/.amplihack/memory.db", read_only=True)
+nodes = store.query_nodes("Session", filters={"status": "completed"})
+store.close()
+```
+
+Read-only mode acquires `LOCK_SH` (shared) instead of `LOCK_EX` (exclusive),
+allowing concurrent readers.
+
+### flock serialization
+
+All `Database()` creation is now serialized through `fcntl.flock` on a sidecar
+`.lock` file next to the database directory. This prevents corruption when
+multiple agent processes access the same graph store.
+
+| Scenario | Lock type | Concurrent access |
+|---|---|---|
+| Normal open | `LOCK_EX` (exclusive) | One writer at a time |
+| `read_only=True` | `LOCK_SH` (shared) | Multiple readers |
+| Lock timeout (30s) | Raises `TimeoutError` | Caller retries or fails |
+
+The lock is released when `close()` is called or the process exits.
+
+### Cypher identifier validation
+
+All table names, relationship types, and property keys interpolated into Cypher
+queries are validated against `^[a-zA-Z_][a-zA-Z0-9_]*$`. Invalid identifiers
+raise `ValueError` immediately, preventing Cypher injection.
+
+## Unchanged Behavior
+
+- `KuzuGraphStore` class name
+- Constructor signature: `db_path`, `buffer_pool_size`, `max_db_size`
+- All public methods: `create_node`, `get_node`, `update_node`, `delete_node`,
+  `query_nodes`, `search_nodes`, `create_edge`, `get_edges`, `delete_edge`,
+  `ensure_table`, `ensure_rel_table`, `export_nodes`, `export_edges`,
+  `import_nodes`, `import_edges`, `get_all_node_ids`, `close`
+- Thread safety via `threading.RLock`
+- In-memory mode (`db_path=None`)
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/amplihack/memory/ladybug_store.py` | **New** -- replaces `kuzu_store.py` |
+| `src/amplihack/memory/kuzu_store.py` | **Deleted** |
+| `src/amplihack/memory/__init__.py` | Import path updated |
+| `src/amplihack/memory/facade.py` | 2 lazy imports updated |
+| `src/amplihack/memory/distributed_store.py` | 1 lazy import updated |
+| `src/amplihack/memory/cli_visualize.py` | 2 docstring references updated |
+| `tests/test_graph_store.py` | Import path updated |
+| `tests/memory/test_cli_visualize.py` | Import path updated |
+| `tests/memory/test_code_context_injection.py` | Import path updated |
+
+## Out of Scope
+
+These modules still use `kuzu` directly and are **not** affected:
+
+- `src/amplihack/memory/kuzu/` -- Code-graph indexing subsystem
+- `src/amplihack/memory/backends/kuzu_backend.py` -- Separate backend for the
+  5-type memory system
+
+## Related
+
+- [Memory Backend](../reference/memory-backend.md)
+- [Memory Architecture](../concepts/memory-backend-architecture.md)
+- [Migrate Memory Backend](migrate-memory-backend.md)

--- a/docs/howto/migration-guide.md
+++ b/docs/howto/migration-guide.md
@@ -1,0 +1,549 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Migration Guide: Per-Project to Plugin
+
+Guide for migrating from per-project `~/.amplihack/.claude/` installations to the global plugin architecture.
+
+## Overview
+
+This guide helps you transition from copying `~/.amplihack/.claude/` into each project to using the global plugin at `~/.amplihack/.claude/`.
+
+**Command note:** This guide uses `amplihack claude` in examples. `amplihack launch` still works as a compatibility alias, but `claude` is the preferred explicit command in user-facing docs.
+
+**Migration Path:**
+
+```
+Before (Per-Project)              After (Plugin)
+─────────────────────             ──────────────
+~/project1/.claude/    ────┐
+~/project2/.claude/    ────┼────▶  ~/.amplihack/.claude/
+~/project3/.claude/    ────┘          (single installation)
+```
+
+## Benefits of Plugin Mode
+
+### Automatic Updates
+
+- Plugin updates affect all projects instantly
+- No need to copy `~/.amplihack/.claude/` to each project
+- Always use latest agents and commands
+
+### Consistent Behavior
+
+- Same workflow across all projects
+- Standardized agent responses
+- Predictable hook behavior
+
+### Simplified Management
+
+- One location for all customizations
+- Easier to track changes
+- Simpler backup and version control
+
+### Disk Space Savings
+
+- One `~/.amplihack/.claude/` directory instead of N copies
+- 50MB saved per project (typical)
+- Example: 10 projects = 500MB saved
+
+## When to Migrate
+
+### Recommended Cases
+
+**Migrate to Plugin When:**
+
+- You work on multiple projects
+- You want automatic updates across all projects
+- You use standard amplihack without customizations
+- You want zero-configuration setup
+
+**Example Workflow:**
+
+```bash
+# Install plugin once
+amplihack plugin install
+
+# All projects use plugin automatically
+cd ~/project1 && amplihack claude  # Uses plugin
+cd ~/project2 && amplihack claude  # Uses same plugin
+cd ~/project3 && amplihack claude  # Still uses plugin
+```
+
+### Keep Per-Project Mode
+
+**Stay Per-Project When:**
+
+- You need project-specific agent customizations
+- You want to pin amplihack version for stability
+- You are experimenting with custom workflows
+- You need different configurations per project
+
+**Example Workflow:**
+
+```bash
+# Each project has own .claude/
+cd ~/project1 && amplihack claude  # Uses project1/.claude/
+cd ~/project2 && amplihack claude  # Uses project2/.claude/
+```
+
+## Migration Methods
+
+### Method 1: Clean Migration (Recommended)
+
+Complete migration to plugin with cleanup of old installations.
+
+**Steps:**
+
+1. **Verify No Custom Modifications**
+
+```bash
+cd ~/project
+amplihack mode status
+```
+
+Check for custom files in `~/.amplihack/.claude/` (agents, commands, skills you added).
+
+2. **Install Plugin**
+
+```bash
+amplihack plugin install https://github.com/rysweet/amplihack
+```
+
+Output:
+
+```
+Plugin installed: amplihack
+   Location: /home/user/.amplihack/.claude/
+   Plugin is ready for use!
+```
+
+3. **Migrate Project**
+
+```bash
+cd ~/project
+amplihack mode migrate-to-plugin
+```
+
+Output:
+
+```
+Removing local .claude/ from /home/user/project
+Migration complete. Project now uses plugin.
+```
+
+4. **Verify Migration**
+
+```bash
+amplihack mode status
+```
+
+Output:
+
+```
+Current mode: plugin
+  Using: /home/user/.amplihack/.claude
+```
+
+5. **Repeat for Each Project**
+
+```bash
+cd ~/project2
+amplihack mode migrate-to-plugin
+
+cd ~/project3
+amplihack mode migrate-to-plugin
+```
+
+### Method 2: Gradual Migration
+
+Migrate projects one at a time, testing each before proceeding.
+
+**Steps:**
+
+1. **Install Plugin**
+
+```bash
+amplihack plugin install
+```
+
+2. **Test with New Project First**
+
+```bash
+cd ~/new-test-project
+# No .claude/ directory here
+amplihack claude
+```
+
+Plugin is used automatically (no local `~/.amplihack/.claude/` exists).
+
+3. **Migrate Low-Risk Project**
+
+```bash
+cd ~/simple-project
+amplihack mode migrate-to-plugin
+```
+
+4. **Test Thoroughly**
+
+```bash
+# Run typical workflow
+amplihack claude -- -p "implement simple feature"
+
+# Verify agents work
+# Verify commands work
+# Verify hooks execute
+```
+
+5. **Migrate Remaining Projects**
+
+Once satisfied, migrate others:
+
+```bash
+cd ~/important-project
+amplihack mode migrate-to-plugin
+```
+
+### Method 3: Hybrid Mode
+
+Keep plugin for most projects, local `~/.amplihack/.claude/` for specific ones.
+
+**Use Case**: 90% of projects use plugin, but one project needs custom agents.
+
+**Steps:**
+
+1. **Install Plugin**
+
+```bash
+amplihack plugin install
+```
+
+2. **Migrate Standard Projects**
+
+```bash
+cd ~/standard-project1
+amplihack mode migrate-to-plugin
+
+cd ~/standard-project2
+amplihack mode migrate-to-plugin
+```
+
+3. **Keep Custom Project Unchanged**
+
+```bash
+cd ~/custom-project
+# Leave .claude/ directory intact
+amplihack claude  # Uses local .claude/ (precedence)
+```
+
+**Mode Detection:**
+
+- Projects without `~/.amplihack/.claude/` use plugin
+- Projects with `~/.amplihack/.claude/` use local (override)
+
+## Preserving Customizations
+
+If you have custom agents, commands, or skills in `~/.amplihack/.claude/`, preserve them before migrating.
+
+### Backup Custom Files
+
+```bash
+cd ~/project
+
+# List custom files
+find .claude -type f -name "*.md" -o -name "*.py" | grep -E "(agents|commands|skills)"
+
+# Create backup
+mkdir -p ~/amplihack-customizations/$(basename $(pwd))
+cp -r .claude/agents/custom-agent.md ~/amplihack-customizations/$(basename $(pwd))/
+cp -r .claude/commands/custom-command/ ~/amplihack-customizations/$(basename $(pwd))/
+```
+
+### Move Customizations to Plugin
+
+After installing plugin, add your custom content:
+
+```bash
+# Copy custom agent to plugin
+cp ~/amplihack-customizations/project1/custom-agent.md \
+   ~/.amplihack/.claude/agents/amplihack/specialized/
+
+# Copy custom command to plugin
+cp -r ~/amplihack-customizations/project1/custom-command \
+      ~/.amplihack/.claude/commands/amplihack/
+
+# Now available in ALL projects
+```
+
+### Alternative: Keep Project-Specific Customizations
+
+If customizations are specific to one project:
+
+```bash
+# Don't migrate this project
+cd ~/custom-project
+# Keep .claude/ directory
+
+# Plugin used for other projects
+cd ~/standard-project
+amplihack mode migrate-to-plugin
+```
+
+## Reverting Migration
+
+To go back to per-project mode:
+
+```bash
+cd ~/project
+amplihack mode migrate-to-local
+```
+
+Output:
+
+```
+Creating local .claude/ from plugin
+Migration complete. Project now uses local .claude/
+You can now customize .claude/ for this project.
+```
+
+**Result**: Project has own `~/.amplihack/.claude/` copy (local precedence).
+
+## Verification Steps
+
+After migration, verify everything works:
+
+### 1. Check Mode
+
+```bash
+amplihack mode status
+```
+
+Expected output:
+
+```
+Current mode: plugin
+  Using: /home/user/.amplihack/.claude
+```
+
+### 2. Verify Plugin Verification
+
+```bash
+amplihack plugin verify amplihack
+```
+
+Expected output:
+
+```
+Plugin: amplihack
+  Installed: yes
+  Discoverable: yes
+  Hooks loaded: yes
+```
+
+### 3. Test Workflow
+
+```bash
+cd ~/project
+amplihack claude -- -p "analyze src/file.py"
+```
+
+Verify:
+
+- [ ] Commands available (`/dev`, `/analyze`)
+- [ ] Agents load correctly
+- [ ] Hooks execute (session start, prompt wrap)
+- [ ] Workflow runs as expected
+
+### 4. Test Across Multiple Projects
+
+```bash
+cd ~/project1
+amplihack claude -- -p "quick test"
+
+cd ~/project2
+amplihack claude -- -p "quick test"
+```
+
+Both should use same plugin.
+
+## Troubleshooting
+
+### Migration Fails with Custom Files
+
+**Symptom**:
+
+```
+Warning: Local .claude/ has custom files:
+  - agents/my-custom-agent.md
+  - commands/my-command/
+
+These will be lost. Backup first or use --preserve-custom
+```
+
+**Solution**:
+
+1. Backup custom files (see "Preserving Customizations")
+2. Migrate: `amplihack mode migrate-to-plugin`
+3. Add custom files to plugin manually
+
+### Plugin Not Found After Migration
+
+**Symptom**:
+
+```
+Current mode: none
+  No .claude installation found
+```
+
+**Diagnosis**:
+
+```bash
+amplihack plugin verify amplihack
+```
+
+**Solution**:
+
+```bash
+# Reinstall plugin
+amplihack plugin install https://github.com/rysweet/amplihack
+
+# Verify
+amplihack plugin verify amplihack
+```
+
+### Local .claude/ Still Used After Migration
+
+**Symptom**: Project still uses local `~/.amplihack/.claude/` after migration.
+
+**Diagnosis**:
+
+```bash
+ls -la .claude/  # Directory still exists
+```
+
+**Solution**:
+
+```bash
+# Migration didn't complete - try again
+amplihack mode migrate-to-plugin --force
+```
+
+### Want to Undo Migration
+
+**Symptom**: Migrated but want per-project mode back.
+
+**Solution**:
+
+```bash
+# Revert to local mode
+amplihack mode migrate-to-local
+
+# Verify
+amplihack mode status
+# Output: Current mode: local
+```
+
+## Best Practices
+
+### 1. Test Before Full Migration
+
+```bash
+# Install plugin
+amplihack plugin install
+
+# Test with one low-risk project
+cd ~/test-project
+amplihack mode migrate-to-plugin
+
+# Verify everything works
+# Then migrate others
+```
+
+### 2. Backup Custom Content
+
+```bash
+# Before migration
+tar -czf ~/amplihack-backup-$(date +%Y%m%d).tar.gz \
+  ~/.claude/ \
+  ~/project1/.claude/ \
+  ~/project2/.claude/
+```
+
+### 3. Document Project-Specific Needs
+
+Create `PROJECT.md` in each project:
+
+```markdown
+## Amplihack Mode
+
+This project uses: **plugin mode**
+
+Reason: Standard workflow, no custom agents
+
+Migration date: 2025-01-17
+```
+
+### 4. Update .gitignore
+
+If you previously committed `~/.amplihack/.claude/` to git:
+
+```bash
+# Add to .gitignore
+echo ".claude/" >> .gitignore
+
+# Remove from git
+git rm -r --cached .claude/
+git commit -m "Remove .claude/ (now using plugin)"
+```
+
+## Migration Checklist
+
+Use this checklist for each project:
+
+```markdown
+## Project: [NAME]
+
+- [ ] Verify no custom content in .claude/
+- [ ] Backup .claude/ if customs exist
+- [ ] Install plugin: `amplihack plugin install`
+- [ ] Migrate: `amplihack mode migrate-to-plugin`
+- [ ] Verify: `amplihack mode status`
+- [ ] Test workflow: Basic command execution
+- [ ] Test agents: Run typical tasks
+- [ ] Update .gitignore (if needed)
+- [ ] Document in PROJECT.md
+```
+
+## FAQs
+
+**Q: Can I use both plugin and local .claude/ simultaneously?**
+
+A: Yes, local `~/.amplihack/.claude/` takes precedence. Plugin is used as fallback when no local installation exists.
+
+**Q: What happens to my customizations?**
+
+A: They are lost unless backed up. See "Preserving Customizations" section.
+
+**Q: Can I migrate back to per-project mode?**
+
+A: Yes, run `amplihack mode migrate-to-local` in any project.
+
+**Q: How do I update the plugin?**
+
+A: Reinstall: `amplihack plugin install --force https://github.com/rysweet/amplihack`
+
+**Q: Does migration affect git history?**
+
+A: No, unless you committed `~/.amplihack/.claude/` to git. If so, remove it from git after migration.
+
+**Q: What if migration fails?**
+
+A: Run `amplihack mode migrate-to-plugin --force` or reinstall plugin first.
+
+## Next Steps
+
+After successful migration:
+
+1. **Customize Plugin** (optional): Add project-agnostic custom agents to `~/.amplihack/.claude/agents/`
+2. **Update Documentation**: Note migration in project README
+3. **Monitor Performance**: Verify plugin works across all projects
+4. **Report Issues**: File issues at <https://github.com/rysweet/amplihack-rs/issues>

--- a/docs/howto/migration-worktree-support.md
+++ b/docs/howto/migration-worktree-support.md
@@ -1,0 +1,235 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Migration Guide: Power Steering Worktree Support
+
+Guide for users upgrading from pre-worktree Power Steering to the worktree-aware version.
+
+## What's New
+
+Power Steering now includes full git worktree support with:
+
+1. **Shared state persistence** - Counter works across all worktrees
+2. **Multi-path .disabled detection** - Check current dir, shared dir, and project root
+3. **Hard maximum enforcement** - Automatic approval after 10 blocks
+4. **Clear error messages** - Actionable instructions for fixes
+
+## Do You Need to Migrate?
+
+Check if you are affected:
+
+```bash
+# Are you using git worktrees?
+git worktree list
+
+# If this shows multiple entries, you'll benefit from the upgrade
+```
+
+If you see multiple worktrees, the upgrade fixes:
+
+- Counter resetting in worktrees (now persists)
+- .disabled file not working (now checks multiple locations)
+- Potential infinite loops (now has hard maximum)
+
+## Migration Steps
+
+### Step 1: Backup Current State
+
+```bash
+# Backup existing counter (if in main repo)
+if [ -f .git/.claude/runtime/power-steering/workflow_classification_block_counter.json ]; then
+    cp .git/.claude/runtime/power-steering/workflow_classification_block_counter.json \
+       /tmp/power-steering-backup.json
+    echo "Backed up counter state"
+fi
+```
+
+### Step 2: Upgrade amplihack
+
+```bash
+# Pull latest changes
+git pull origin main
+
+# Or reinstall
+cargo install amplihack
+```
+
+### Step 3: Verify Installation
+
+!!! note "Upstream Python verification"
+    The verification script below uses the upstream Python `amplihack` API.
+    In amplihack-rs the worktree utilities are built into the Rust binary
+    and do not require a separate Python import.
+
+```bash
+# Check git_utils module exists (upstream Python API)
+python3 << 'EOF'
+try:
+    from amplihack.tools.amplihack.git_utils import (
+        is_worktree,
+        get_common_git_dir,
+        find_disabled_file
+    )
+    print("git_utils module installed")
+except ImportError as e:
+    print(f"git_utils not found: {e}")
+EOF
+```
+
+### Step 4: Migrate State (Automatic)
+
+The new version automatically handles state migration:
+
+**Before** (pre-worktree):
+
+```
+.git/.claude/runtime/power-steering/
+└── workflow_classification_block_counter.json
+```
+
+**After** (worktree-aware):
+
+```
+$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/
+└── workflow_classification_block_counter.json
+```
+
+In standard repos, these are the same location. No action required.
+
+### Step 5: Migrate .disabled Files
+
+If you had .disabled files in worktrees, move them to shared location:
+
+```bash
+# Check for .disabled files in worktrees
+git worktree list | awk '{print $1}' | while read worktree; do
+    if [ -f "$worktree/.disabled" ]; then
+        echo "Found .disabled in: $worktree"
+        # Move to shared location
+        touch "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+        echo "Migrated to shared location"
+        rm "$worktree/.disabled"
+    fi
+done
+```
+
+### Step 6: Test Worktree Functionality
+
+```bash
+# Create test worktree
+git worktree add /tmp/test-worktree-migration main
+
+# Test counter persistence
+cd /tmp/test-worktree-migration
+
+# Verify the common git dir resolves correctly
+git rev-parse --git-common-dir
+
+# Cleanup
+cd -
+git worktree remove /tmp/test-worktree-migration
+```
+
+## Configuration Changes
+
+### No Configuration Required
+
+The upgrade is **backward compatible**. No configuration changes needed.
+
+### Optional: Centralize .disabled File
+
+For worktree users, centralize .disabled file:
+
+```bash
+# Old: .disabled in each worktree (still works)
+# New: .disabled in shared location (recommended)
+
+# Create shared .disabled
+touch "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+
+# Remove individual worktree .disabled files
+git worktree list | awk '{print $1}' | while read worktree; do
+    rm -f "$worktree/.disabled"
+done
+```
+
+## Breaking Changes
+
+### None
+
+This release has **no breaking changes**. All existing functionality works identically.
+
+### Behavior Changes
+
+1. **Counter persists across worktrees** (previously reset)
+2. **.disabled file checked in 3 locations** (previously only CWD and root)
+3. **Hard maximum enforced** (new feature, prevents infinite loops)
+
+## Rollback Plan
+
+If you encounter issues, rollback to previous version:
+
+```bash
+# Restore from backup
+if [ -f /tmp/power-steering-backup.json ]; then
+    cp /tmp/power-steering-backup.json \
+       .git/.claude/runtime/power-steering/workflow_classification_block_counter.json
+fi
+
+# Revert amplihack to a previous version
+cargo install amplihack --version <previous-version>
+```
+
+## Verification Checklist
+
+After migration, verify these work:
+
+- [ ] Counter persists in main repo
+- [ ] Counter persists in worktrees
+- [ ] Counter shared across all worktrees
+- [ ] .disabled file works in current directory
+- [ ] .disabled file works in shared location
+- [ ] .disabled file works in project root
+- [ ] Hard maximum triggers after 10 blocks
+- [ ] Error messages are clear
+
+## Common Migration Issues
+
+### Issue: Counter Not Migrating
+
+**Symptom**: Counter reset to 0 after upgrade
+
+**Solution**: Manually migrate counter
+
+```bash
+# Copy old counter to new location
+OLD_COUNTER=".git/.claude/runtime/power-steering/workflow_classification_block_counter.json"
+NEW_COUNTER="$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/workflow_classification_block_counter.json"
+
+if [ -f "$OLD_COUNTER" ] && [ "$OLD_COUNTER" != "$NEW_COUNTER" ]; then
+    mkdir -p "$(dirname "$NEW_COUNTER")"
+    cp "$OLD_COUNTER" "$NEW_COUNTER"
+    echo "Counter migrated"
+fi
+```
+
+### Issue: .disabled File Not Working
+
+**Symptom**: Created .disabled but Power Steering still blocks
+
+**Solution**: Check file location. The .disabled file should be in one of:
+
+1. `./.disabled` (current directory)
+2. `$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled` (shared location)
+3. `$(git rev-parse --show-toplevel)/.disabled` (project root)
+
+## Getting Help
+
+If you encounter migration issues:
+
+1. **Check logs**: `~/.claude/runtime/logs/power-steering-*.log`
+2. **File issue**: [GitHub Issues](https://github.com/rysweet/amplihack-rs/issues)
+
+## Related Documentation
+
+- [Worktree Support](../concepts/worktree-support.md) - Feature overview
+- [Troubleshoot Worktree](troubleshoot-worktree.md) - Fix common issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,9 @@ nav:
       - Install from Local Repo: howto/local-install.md
       - Uninstall: howto/uninstall.md
       - Migrate from Python: howto/migrate-from-python.md
+      - Ladybug Migration: howto/ladybug-migration-guide.md
+      - Migration Guide: howto/migration-guide.md
+      - Migration Worktree Support: howto/migration-worktree-support.md
       - Enable Shell Completions: howto/enable-shell-completions.md
       - Non-interactive Mode: howto/run-in-noninteractive-mode.md
       - Manage Update Checks: howto/manage-tool-update-checks.md


### PR DESCRIPTION
## Summary

- Ports `MIGRATION_GUIDE.md` into `docs/howto/migration-guide.md` with all pirate-speak converted to standard English
- Ports `LADYBUG_MIGRATION_GUIDE.md` into `docs/howto/ladybug-migration-guide.md` with upstream Python code marked as reference
- Ports `migration-worktree-support.md` into `docs/howto/migration-worktree-support.md` with `uvx` install commands replaced by `cargo install`
- Adds all three entries to `mkdocs.yml` nav (alphabetically in How-To Guides)

Part of #420

## Test plan

- [x] `mkdocs build --strict` passes
- [ ] Verify rendered pages display correctly
- [ ] Cross-references to existing docs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>