### PR TITLE
docs: port build infrastructure reference docs (wave 5)

### DIFF
--- a/docs/reference/kuzu-test-configuration.md
+++ b/docs/reference/kuzu-test-configuration.md
@@ -1,0 +1,130 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Kuzu Test Configuration
+
+!!! note "Upstream Python Testing Patterns"
+    This document describes test isolation patterns used in the upstream Python
+    amplihack project for the `kuzu` graph database dependency. It is preserved
+    here for reference. In amplihack-rs, LadybugDB (the Rust-native graph layer)
+    replaces the Python kuzu bindings — see
+    [LadybugDB Code Graph](../concepts/kuzu-code-graph.md) and
+    [Resolve LadybugDB Linker Errors](../howto/resolve-kuzu-linker-errors.md)
+    for Rust-specific guidance.
+
+The upstream `amplihack` test suite includes tests that import `kuzu` — a C++
+graph database with a Python binding. In environments where `kuzu` is not
+installed (e.g., CI without cmake, containers), these tests skip gracefully
+rather than hang or error.
+
+This document explains the approved isolation mechanism and the root cause that
+was fixed.
+
+## Contents
+
+- [How kuzu tests skip gracefully](#how-kuzu-tests-skip-gracefully)
+- [Root cause: package shadowing bug](#root-cause-package-shadowing-bug)
+- [Which test files are guarded](#which-test-files-are-guarded)
+- [Verify the skip works](#verify-the-skip-works)
+- [Related](#related)
+
+---
+
+## How kuzu tests skip gracefully
+
+Each kuzu-specific test file has `pytest.importorskip("kuzu")` near the top:
+
+```python
+import pytest
+
+pytest.importorskip("kuzu")  # skips entire module if kuzu not installed
+
+from src.amplihack.memory.backends.kuzu_backend import KuzuBackend
+```
+
+When `kuzu` is not installed, `pytest.importorskip` raises `Skipped` during
+collection, and the entire module is skipped cleanly — no error, no hang.
+
+This is the standard pytest pattern for optional-dependency tests and requires
+no environment variables or conftest configuration.
+
+> **Note:** PR #3110, which proposed an `AMPLIHACK_SKIP_KUZU_TESTS` environment
+> variable guard in `conftest.py`, was rejected. The `pytest.importorskip`
+> approach in individual files is simpler, more portable, and follows standard
+> pytest conventions.
+
+---
+
+## Root cause: package shadowing bug
+
+The original hang was caused by `tests/memory/kuzu/__init__.py` existing.
+
+**How it happened:**
+
+1. `tests/memory/kuzu/__init__.py` made `tests/memory/kuzu/` a Python package.
+2. pytest's default (prepend) import mode added `tests/memory/` to `sys.path`
+   when collecting files from that directory.
+3. `import kuzu` in `kuzu_backend.py` resolved to `tests/memory/kuzu/` (the
+   test package) instead of the installed PyPI `kuzu` package.
+4. The test package had no `Database` attribute → `AttributeError` at collection
+   time, causing hangs.
+
+**The fix:** `tests/memory/kuzu/__init__.py` and
+`tests/memory/kuzu/indexing/__init__.py` were deleted. Without `__init__.py`,
+pytest adds `tests/memory/kuzu/` itself (not `tests/memory/`) to `sys.path`,
+and there is no `kuzu` package name to shadow there.
+
+---
+
+## Which test files are guarded
+
+All kuzu-specific test files carry `pytest.importorskip("kuzu")`:
+
+| File                                                   | Notes                                               |
+| ------------------------------------------------------ | --------------------------------------------------- |
+| `tests/memory/backends/test_kuzu_session_isolation.py` | Guard placed before module-level KuzuBackend import |
+| `tests/memory/backends/test_kuzu_schema_redesign.py`   |                                                     |
+| `tests/memory/backends/test_kuzu_code_schema.py`       |                                                     |
+| `tests/memory/backends/test_kuzu_auto_linking.py`      |                                                     |
+| `tests/memory/kuzu/test_kuzu_connector.py`             |                                                     |
+| `tests/unit/memory/test_kuzu_retry.py`                 |                                                     |
+
+The guard coverage is verified by `tests/test_kuzu_skip_guard.py` (WS4 tests).
+
+---
+
+## Verify the skip works
+
+When kuzu is installed, all tests collect and run normally:
+
+```sh
+pytest --collect-only -q tests/memory/backends/test_kuzu_session_isolation.py
+```
+
+To simulate a missing kuzu installation, temporarily rename the package and
+confirm the module is skipped (not errored):
+
+```sh
+pytest --collect-only -q tests/memory/backends/test_kuzu_schema_redesign.py
+# With kuzu absent: "1 skipped" not "ERROR"
+```
+
+Collection time for all kuzu tests must be under 10 seconds:
+
+```sh
+time pytest --collect-only -q tests/memory/ tests/unit/memory/
+```
+
+---
+
+## Related
+
+- [LadybugDB Code Graph](../concepts/kuzu-code-graph.md) — Rust-native graph layer in amplihack-rs
+- [Resolve LadybugDB Linker Errors](../howto/resolve-kuzu-linker-errors.md) — Troubleshooting LadybugDB builds
+- [Ladybug Migration](../howto/ladybug-migration-guide.md) — `kuzu_store` → `ladybug_store` upgrade guide
+- [pytest importorskip docs](https://docs.pytest.org/en/stable/reference/pytest.html#pytest.importorskip) — upstream library documentation
+- [kuzu Python bindings](https://docs.kuzudb.com/client-apis/python/) — upstream library
+
+> **Note:** The `KuzuGraphStore` class (in `amplihack.memory.ladybug_store`)
+> now imports `ladybug` with a fallback to `kuzu`. The backend-level test files
+> listed above still test `kuzu_backend.py` which imports `kuzu` directly — those
+> are separate from the `KuzuGraphStore` migration.

--- a/docs/reference/oxidizer.md
+++ b/docs/reference/oxidizer.md
@@ -1,0 +1,208 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Oxidizer Workflow
+
+The Oxidizer workflow automates Python-to-Rust migration through iterative
+convergence loops. It treats the Python codebase as the living specification
+and produces a fully-tested Rust equivalent with zero-tolerance parity
+validation.
+
+!!! tip "Directly relevant to amplihack-rs"
+    The Oxidizer is the workflow that produced amplihack-rs itself. The phases,
+    zero-tolerance policy, and Effective Rust compliance sections below are the
+    specification that all ported Rust code must satisfy.
+
+## Overview
+
+Oxidizer is a recipe-driven workflow that:
+
+- Analyzes the Python codebase (AST, dependencies, types, public API)
+- Ensures complete test coverage before any porting begins
+- Scaffolds a Rust project with the correct structure
+- Ports tests first, then implementation module-by-module
+- Runs quality and degradation audits on every iteration
+- Loops until 100% feature parity is achieved
+
+## Quick Start
+
+```bash
+recipe-runner-rs amplifier-bundle/recipes/oxidizer-workflow.yaml \
+  --set python_package_path=src/mypackage \
+  --set rust_target_path=rust/mypackage \
+  --set rust_repo_name=my-rust-crate \
+  --set rust_repo_org=myorg
+```
+
+## Required Context Variables
+
+| Variable              | Description                           | Example                   |
+| --------------------- | ------------------------------------- | ------------------------- |
+| `python_package_path` | Path to the Python package to migrate | `src/amplihack/recipes`   |
+| `rust_target_path`    | Where to create the Rust project      | `rust/recipe-runner`      |
+| `rust_repo_name`      | GitHub repository name for the output | `amplihack-recipe-runner` |
+| `rust_repo_org`       | GitHub org or user                    | `rysweet`                 |
+
+## Workflow Phases
+
+### Phase 1: Analysis
+
+Performs comprehensive analysis of the Python codebase:
+
+- AST analysis of every module
+- Dependency graph mapping
+- Type inference for function signatures
+- Public API surface extraction
+- Migration priority ordering (leaf modules first)
+
+### Phase 1B: Test Completeness Gate
+
+**This gate blocks all further progress until test coverage is sufficient.**
+
+1. Measures current Python test coverage
+2. Identifies untested code paths
+3. Writes missing tests
+4. Re-verifies coverage
+5. If coverage is still insufficient → **workflow stops**
+
+### Phase 2: Scaffolding
+
+Creates the Rust project structure:
+
+- `cargo init` with appropriate dependencies
+- Module structure mirroring the Python package
+- CI configuration (clippy, fmt, test)
+- README and documentation scaffolding
+
+### Phase 3: Test Extraction
+
+Ports Python tests to Rust before any implementation:
+
+- Converts pytest fixtures to Rust test helpers
+- Maps Python assertions to Rust equivalents
+- Runs a quality audit on extracted tests
+- Tests are expected to fail at this point (no implementation yet)
+
+### Phase 4-6: Iterative Convergence
+
+Each iteration processes one module:
+
+```
+┌─────────────────────────────────────────────┐
+│  Select next module (priority order)         │
+│  ↓                                           │
+│  Implement module in Rust                    │
+│  ↓                                           │
+│  Compare: feature matrix diff vs Python      │
+│  ↓                                           │
+│  Quality gate: clippy + fmt + test           │
+│  ↓                                           │
+│  Silent degradation audit                    │
+│  ↓                                           │
+│  Fix any degradation found                   │
+│  ↓                                           │
+│  Convergence check                           │
+│  ↓                                           │
+│  < 100% parity? → loop again                 │
+│  = 100% parity? → done                       │
+└─────────────────────────────────────────────┘
+```
+
+The recipe unrolls 5 explicit loop iterations. The `max_depth: 8` recursion
+setting allows sub-recipes to recurse further if needed. The `max_iterations`
+context variable (default: 30) provides an upper bound.
+
+## Zero-Tolerance Policy
+
+The oxidizer enforces strict standards:
+
+- **No partial convergence** — `allow_partial_convergence` is `false`
+- **Parity target is 100%** — anything less loops again
+- **Silent degradation audit** — catches lossy type conversions, missing error
+  variants, dropped edge cases, and behavioral differences
+- **Unsafe code audit** — flags every `unsafe` block as a critical finding;
+  requires elimination or justification with safety comments and Miri testing
+- **Quality gate** — `cargo clippy -- -D warnings`, `cargo fmt --check`, full
+  test suite must pass
+
+## Effective Rust Compliance
+
+All generated Rust code follows the [Effective Rust](https://effective-rust.com/)
+guide. Key rules enforced on every iteration:
+
+### Types (Items 1-6)
+
+- Use `enum` with data fields — make invalid states unrepresentable
+- `Option<T>` for optional values, never sentinel values
+- `Result<T, E>` for fallible ops, never panic on expected errors
+- Newtype pattern for domain semantics (`struct Miles(f64)`)
+- `From`/`Into` conversions over `as` casts
+- `thiserror` for library errors, `anyhow` for applications
+
+### Unsafe (Item 16)
+
+- `#![deny(unsafe_code)]` in lib.rs by default
+- If FFI requires `unsafe`: isolate in wrapper, add safety comments, run Miri
+- See <https://effective-rust.com/unsafe.html>
+
+### Parallelism (Item 17)
+
+- Prefer channels over shared state
+- `Arc<Mutex<T>>` with small lock scopes, single-lock grouping
+- Never invoke closures or return `MutexGuard` with locks held
+- See <https://effective-rust.com/deadlock.html>
+
+### Tooling (Items 29, 31, 32)
+
+- `cargo clippy -- -D warnings`, `cargo fmt`, `cargo doc`
+- `rust-toolchain.toml` for reproducible CI builds
+- `cargo-deny` for license/advisory checks, `cargo-udeps` for unused deps
+- See <https://effective-rust.com/use-tools.html>
+
+## Using via Python API
+
+!!! note "Upstream Python API"
+    The example below uses the upstream Python `run_recipe_by_name` API from
+    the original amplihack project. In amplihack-rs, invoke the oxidizer recipe
+    via the `recipe-runner-rs` CLI as shown in [Quick Start](#quick-start).
+
+```python
+from amplihack.recipes import run_recipe_by_name
+
+result = run_recipe_by_name(
+    "oxidizer-workflow",
+    user_context={
+        "python_package_path": "src/mypackage",
+        "rust_target_path": "rust/mypackage",
+        "rust_repo_name": "my-rust-crate",
+        "rust_repo_org": "myorg",
+    },
+)
+
+if result.success:
+    print("Migration complete — 100% parity achieved")
+else:
+    for sr in result.step_results:
+        if sr.error:
+            print(f"  {sr.step_id}: {sr.error}")
+```
+
+## Recipe Location
+
+The oxidizer recipe lives at:
+
+```
+amplifier-bundle/recipes/oxidizer-workflow.yaml
+```
+
+## Customization
+
+Override any context variable with `--set`:
+
+```bash
+recipe-runner-rs amplifier-bundle/recipes/oxidizer-workflow.yaml \
+  --set max_iterations=50 \
+  --set parity_target=100
+```
+
+The recipe is designed to be used as-is for most migrations. For specialized
+needs, copy the recipe and modify the agent prompts in each phase.

--- a/docs/reference/plugin-directory-structure-fix.md
+++ b/docs/reference/plugin-directory-structure-fix.md
@@ -1,0 +1,448 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Plugin Directory Structure Fix for UVX Discovery
+
+!!! note "Upstream Python Build System Reference"
+    This document describes the upstream Python/UVX wheel packaging build system
+    used by the original amplihack project. It is preserved here for historical
+    reference and to explain the architecture that amplihack-rs intentionally
+    diverges from. The Rust binary distribution model in amplihack-rs does not
+    use Python wheels or UVX — see [Binary Resolution](binary-resolution.md)
+    for the current distribution approach.
+
+**Feature**: Automatic plugin directory inclusion in wheel builds for Claude Code plugin discovery
+
+**Status**: Implemented and working (upstream Python project)
+
+**Last Updated**: 2026-02-04
+
+---
+
+## What This Fix Does
+
+When you install amplihack via UVX from GitHub, Claude Code now automatically discovers the plugin because the build system includes all necessary directories in the wheel package.
+
+**Before this fix**:
+
+- `uvx --from git+https://github.com/user/amplihack amplihack` installed the package
+- Claude Code couldn't find commands, skills, or agents
+- Plugin manifest existed but pointed to missing directories
+
+**After this fix**:
+
+- Same UVX command installs package WITH plugin directories
+- Claude Code discovers all 24 commands, 73 skills, and 38 agents
+- Everything works immediately, no manual setup required
+
+## How It Works
+
+### Build-Time Directory Copying
+
+The build system (`build_hooks.py`) automatically copies plugin directories from the repository root into the package **during wheel build**, before setuptools packages everything.
+
+**Copied directories**:
+
+1. `.claude/commands/` → `src/amplihack/.claude/commands/`
+2. `.claude/skills/` → `src/amplihack/.claude/skills/`
+3. `.claude/agents/` → `src/amplihack/.claude/agents/`
+4. `.claude-plugin/` → `src/amplihack/.claude-plugin/` (manifest)
+5. `.github/` → `src/amplihack/.github/` (Copilot CLI integration)
+6. `amplifier-bundle/` → `src/amplihack/amplifier-bundle/` (Amplifier support)
+7. `AMPLIHACK.md` → `src/amplihack/AMPLIHACK.md` (framework instructions)
+
+**Why this works**:
+
+- Python wheel packages only include files **inside** Python packages
+- Repository root directories (`.claude/`, `.github/`) are **outside** `src/amplihack/`
+- Copying them **into** the package makes them part of the wheel
+- UVX extracts the wheel → directories appear in installed package location
+- Claude Code reads plugin manifest → finds directories → loads plugins
+
+### Symlink Preservation
+
+The build system preserves symlinks within copied directories using `shutil.copytree(symlinks=True)`.
+
+**Why symlinks matter**:
+
+- `.github/agents/amplihack` → `.claude/agents/amplihack` (symlink)
+- Maintains zero-duplication architecture
+- Single source of truth for agent definitions
+- Without `symlinks=True`, build fails on symlink copying
+
+### Automatic Cleanup
+
+After building the wheel, `build_hooks.py` removes copied directories from `src/amplihack/` to keep the repository clean.
+
+**Cleanup guarantees**:
+
+- Runs even if build fails (using `try/finally`)
+- Removes all 7 copied items
+- Repository state unchanged after build
+
+## Technical Implementation
+
+### Build Hook Architecture
+
+```python
+# pyproject.toml
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "build_hooks"
+backend-path = ["."]
+```
+
+This configuration tells Python build tools to use `build_hooks.py` as the custom build backend instead of standard setuptools.
+
+### Copy Process
+
+```
+Build starts
+    ↓
+1. _copy_claude_directory()                    # Copy .claude/ with symlinks=True
+2. _copy_plugin_manifest()                     # Copy .claude-plugin/
+3. _copy_github_directory()                    # Copy .github/ with symlinks=True
+4. _copy_bundle_directory()                    # Copy amplifier-bundle/ with symlinks=True
+5. _copy_amplihack_md()                        # Copy AMPLIHACK.md
+6. _copy_plugin_discoverable_directories()     # Copy commands/, skills/, agents/
+    ↓
+setuptools builds wheel (includes copied directories)
+    ↓
+7. _cleanup_claude_directory()                 # Remove src/amplihack/.claude/
+8. _cleanup_plugin_manifest()                  # Remove src/amplihack/.claude-plugin/
+9. _cleanup_github_directory()                 # Remove src/amplihack/.github/
+10. _cleanup_bundle_directory()                # Remove src/amplihack/amplifier-bundle/
+11. _cleanup_amplihack_md()                    # Remove src/amplihack/AMPLIHACK.md
+12. _cleanup_plugin_discoverable_directories() # Remove commands/, skills/, agents/
+    ↓
+Build complete, repository clean
+```
+
+### Package Data Declaration
+
+```python
+# pyproject.toml
+[tool.setuptools.package-data]
+amplihack = [
+    ".claude/**/*",              # All .claude/ contents
+    ".claude/**/.gitkeep",       # Preserve empty directories
+    ".claude/**/.*",             # Hidden files (config files, not .version)
+    ".claude-plugin/**/*",       # Plugin manifest
+    "amplifier-bundle/**/*",     # Amplifier support
+    "AMPLIHACK.md",              # Framework instructions
+]
+```
+
+**Note on .github/ omission**: The `.github/` directory is copied by build hooks for symlink preservation, but NOT declared in package-data because:
+
+- **Editable installs**: When installed with `pip install -e .`, the repository root is already in the Python path, making `.github/` accessible via symlinks
+- **Wheel installs**: `.github/` IS included in wheels (build hooks copy it), but setuptools auto-includes it because it contains Python-accessible content
+- **Result**: `.github/` works in both installation modes without explicit package-data declaration
+
+This tells setuptools to include these directories in the wheel **after** build hooks copy them into the package.
+
+## Ignore Pattern Rationale
+
+### Why Files Are Excluded from Wheels
+
+The build system uses `ignore_patterns()` to exclude specific files/directories from copied content:
+
+```python
+ignore = ignore_patterns(
+    "*.pyc", "__pycache__", "*.pyo", "*.pyd",  # Python bytecode
+    ".git", ".gitignore", ".gitattributes",    # Git metadata
+    "*.log", "*.tmp", ".DS_Store",             # Runtime/system files
+    "node_modules", ".env", ".venv"            # Dependencies/secrets
+)
+```
+
+**Security reasons**:
+
+- `.env` files contain secrets (API keys, tokens)
+- `.git` directory may expose sensitive history
+- `.venv` includes local-specific Python environments
+
+**Size reasons**:
+
+- `node_modules/` can be hundreds of MB
+- `__pycache__/` bytecode is regenerated on first run
+- `.git` directory adds significant unnecessary weight
+
+**Distribution cleanliness**:
+
+- Runtime logs (`.log`, `.tmp`) are machine-specific
+- System files (`.DS_Store`) are platform-specific
+- Bytecode files (`.pyc`, `.pyo`) are Python version-specific
+
+**Result**: Wheels contain only essential source files, reducing size from ~100MB to ~25MB while maintaining full functionality.
+
+## Editable Install Behavior
+
+When installed with `pip install -e .`, the build hooks **do NOT run**. This is correct and intentional:
+
+- **Development workflow**: Repository root remains intact with `.claude/` at root level
+- **Symlink access**: `.github/` symlinks to `.claude/` work naturally
+- **No cleanup needed**: No temporary copies in `src/amplihack/`
+- **Fast iteration**: No build step required for code changes
+
+**Production vs Development**:
+
+| Mode | Command | Build Hooks | Directory Location | Use Case |
+|------|---------|-------------|-------------------|----------|
+| **Editable** | `pip install -e .` | Not run | Repository root | Development |
+| **Wheel** | `python -m build` | Run | Inside package | Distribution |
+
+## Verification Steps
+
+### 1. Verify Build Includes Directories
+
+```bash
+# Build wheel
+python -m build --wheel
+
+# Check wheel contents
+unzip -l dist/amplihack-*.whl | grep -E "(\.claude|\.github|amplifier-bundle|AMPLIHACK)"
+```
+
+**Expected output**:
+
+```
+amplihack/.claude/commands/
+amplihack/.claude/skills/
+amplihack/.claude/agents/
+amplihack/.claude-plugin/plugin.json
+amplihack/.github/agents/amplihack -> ../../.claude/agents/amplihack  (symlink)
+amplihack/.github/skills/amplihack -> ../../.claude/skills/amplihack  (symlink)
+amplihack/amplifier-bundle/
+amplihack/AMPLIHACK.md
+```
+
+**Note**: Symlinks appear as regular entries in zip listings but preserve their symlink nature when extracted.
+
+### 2. Verify UVX Installation
+
+```bash
+# Install from GitHub via UVX
+uvx --from git+https://github.com/rysweet/amplihack amplihack --help
+
+# Check plugin discovery
+amplihack claude  # Launch Claude Code with amplihack plugin
+```
+
+**In Claude Code session**:
+
+```
+Type: /help
+```
+
+**Expected result**: All 24 commands listed (including `/ultrathink`, `/analyze`, `/improve`, `/fix`, DDD commands, fault tolerance commands)
+
+### 3. Verify Directory Locations
+
+```bash
+# Find UVX cache location
+ls ~/.cache/uv/archive-*/amplihack/.claude/
+
+# Check commands directory
+ls ~/.cache/uv/archive-*/amplihack/.claude/commands/
+
+# Check skills directory
+ls ~/.cache/uv/archive-*/amplihack/.claude/skills/
+
+# Check agents directory
+ls ~/.cache/uv/archive-*/amplihack/.claude/agents/amplihack/
+```
+
+**Expected**: All directories present with full contents.
+
+### 4. Test Plugin Functionality
+
+```bash
+# Launch Claude Code with plugin
+amplihack claude
+
+# In Claude Code, test a command
+/ultrathink "Analyze the build_hooks.py file"
+```
+
+**Expected**: UltraThink command executes successfully, orchestrating agents.
+
+## User-Visible Changes
+
+**None**. This is a transparent build system fix.
+
+Users continue to:
+
+1. Run `uvx --from git+https://github.com/user/amplihack amplihack`
+2. Launch their preferred tool (`amplihack claude`, `amplihack amplifier`, etc.)
+3. Access all commands, skills, and agents immediately
+
+The **only** difference: it now **works** when installed via UVX from GitHub.
+
+## Troubleshooting
+
+### Build Fails: "shutil.Error: [Errno 2] No such file"
+
+**Problem**: Source directories don't exist in repository.
+
+**Solution**: Verify repository structure:
+
+```bash
+ls -la .claude/ .claude-plugin/ .github/ amplifier-bundle/
+```
+
+All directories should exist. If missing, clone repository correctly:
+
+```bash
+git clone --recurse-submodules https://github.com/rysweet/amplihack
+```
+
+### Build Fails: "symlink points to invalid target"
+
+**Problem**: Symlinks broken in repository.
+
+**Solution**: Check symlink targets:
+
+```bash
+ls -la .github/agents/
+# Should show: amplihack -> ../../.claude/agents/amplihack
+
+ls -la .github/skills/
+# Should show: amplihack -> ../../.claude/skills/amplihack
+```
+
+Fix broken symlinks:
+
+```bash
+cd .github/agents/
+ln -sf ../../.claude/agents/amplihack amplihack
+```
+
+### Plugin Not Discovered After UVX Install
+
+**Problem**: Claude Code can't find plugin.
+
+**Diagnosis**:
+
+```bash
+# Check wheel contents
+unzip -l dist/amplihack-*.whl | grep ".claude-plugin/plugin.json"
+
+# If missing, build failed to include directories
+```
+
+**Solution**: Rebuild wheel:
+
+```bash
+rm -rf dist/ build/ src/amplihack.egg-info/
+python -m build --wheel
+```
+
+### Directories Remain in src/amplihack/ After Build
+
+**Problem**: Cleanup didn't run.
+
+**Cause**: Build hook crashed before cleanup.
+
+**Solution**: Manual cleanup:
+
+```bash
+rm -rf src/amplihack/.claude/
+rm -rf src/amplihack/.claude-plugin/
+rm -rf src/amplihack/.github/
+rm -rf src/amplihack/amplifier-bundle/
+rm -f src/amplihack/AMPLIHACK.md
+```
+
+## Integration with Existing Systems
+
+### Compatibility with Per-Project Staging
+
+This fix **only** affects UVX installations. Per-project staging (`~/.amplihack/.claude/`) remains unchanged.
+
+**Per-project mode** (Microsoft Amplifier, GitHub Copilot CLI, Codex):
+
+```bash
+amplihack amplifier  # Stages files to project-local ~/.amplihack/.claude/
+```
+
+**Plugin mode** (Claude Code only):
+
+```bash
+amplihack claude  # Uses plugin discovery from UVX-installed package
+```
+
+### Compatibility with Development Mode
+
+When developing amplihack, install in editable mode:
+
+```bash
+pip install -e .
+```
+
+Build hooks **do not run** in editable mode. Directories remain at repository root, which is correct for development. See **Editable Install Behavior** section above for detailed comparison.
+
+## Performance Considerations
+
+### Build Time Impact
+
+**Copying overhead**: +2-5 seconds per build
+
+- `.claude/` directory: ~50MB, 1000+ files
+- Copy operation: ~2 seconds on SSD
+- Cleanup operation: ~1 second
+- Total build time increase: minimal (< 10%)
+
+### Wheel Size Impact
+
+**Size increase**: +10MB per wheel
+
+- `.claude/` compressed: ~5MB
+- `.github/` compressed: ~2MB
+- `amplifier-bundle/` compressed: ~3MB
+- Total wheel size: ~25MB (was ~15MB)
+
+**Trade-off**: Acceptable increase for complete plugin functionality.
+
+## Related Documentation
+
+- [Binary Resolution](binary-resolution.md) — How amplihack-rs distributes binaries (replaces UVX/wheel approach)
+- [Install Command](install-command.md) — amplihack-rs installation reference
+- [Install Manifest](install-manifest.md) — Manifest-driven installation in amplihack-rs
+
+## Maintenance Notes
+
+### When to Update This Fix
+
+**Update build_hooks.py if**:
+
+- Adding new plugin directories (e.g., `.claude/templates/`)
+- Changing symlink structure in `.github/`
+- Modifying ignore patterns for runtime files
+
+**Update pyproject.toml if**:
+
+- Changing package data patterns
+- Adding new directories to include
+
+### Testing Strategy
+
+**Before each release**:
+
+1. Build wheel: `python -m build --wheel`
+2. Check contents: `unzip -l dist/amplihack-*.whl`
+3. Test UVX install: `uvx --from dist/amplihack-*.whl amplihack claude`
+4. Verify plugin discovery: Launch Claude Code, run `/help`
+
+**Automated tests**:
+
+- `tests/test_uvx_packaging.py` — Verifies wheel contents
+- CI builds wheels on every commit
+- Release workflow publishes to PyPI with verified wheels
+
+---
+
+## Summary
+
+The plugin directory structure fix enables zero-configuration Claude Code plugin discovery for UVX-based GitHub installations. The build system automatically includes all plugin directories in wheels, preserves symlinks, and cleans up afterward. Users experience no changes in workflow — everything just works.
+
+**Key benefit**: Install once from GitHub, use everywhere, no manual setup.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Launch Flag Injection: reference/launch-flag-injection.md
       - Signal Handling: reference/signal-handling.md
       - recipe Command: reference/recipe-command.md
+      - Oxidizer: reference/oxidizer.md
       - Parity Test Scenarios: reference/parity-test-scenarios.md
       - memory index Command: reference/memory-index-command.md
       - query-code Command: reference/query-code-command.md
@@ -99,6 +100,7 @@ nav:
       - RustyClawd Command: reference/rustyclawd-command.md
       - fleet Command: reference/fleet-command.md
       - multitask Command: reference/multitask-command.md
+      - Kuzu Test Configuration: reference/kuzu-test-configuration.md
       - Memory Backend: reference/memory-backend.md
       - doctor Command: reference/doctor-command.md
       - Agent Configuration: reference/agent-configuration.md
@@ -109,6 +111,7 @@ nav:
       - agent-generator API: reference/agent-generator-api.md
       - uvx-help Command: reference/uvx-help-command.md
       - Memory Extended API: reference/memory-extended-api.md
+      - Plugin Directory Structure Fix: reference/plugin-directory-structure-fix.md
       - Power Steering Compaction API: reference/power-steering-compaction-api.md
       - Shell Command Hook: reference/shell-command-hook.md
       - Security Recommendations: reference/security-recommendations.md


### PR DESCRIPTION
## Summary

- Ports `OXIDIZER.md` → `docs/reference/oxidizer.md` (Python-to-Rust migration workflow spec — directly relevant to amplihack-rs)
- Ports `KUZU_TEST_CONFIGURATION.md` → `docs/reference/kuzu-test-configuration.md` (upstream Python test isolation patterns for kuzu)
- Ports `build_system/plugin-directory-structure-fix.md` → `docs/reference/plugin-directory-structure-fix.md` (upstream UVX/wheel packaging reference)

All files adapted with HTML comment headers, admonitions noting upstream vs Rust-native context, and fixed cross-references to existing amplihack-rs docs.

Part of #420

## Test plan

- [x] `mkdocs build --strict` passes
- [ ] CI passes
- [ ] Verify rendered pages in GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)