### PR TITLE
docs: port blarify architecture, git-utils API, and recipe runner audit (wave 5)

### DIFF
--- a/docs/concepts/blarify-architecture.md
+++ b/docs/concepts/blarify-architecture.md
@@ -1,0 +1,474 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Blarify Code Graph Architecture
+
+Visual representation of the blarify integration with LadybugDB/Kuzu embedded database.
+
+!!! note "Related Documentation"
+    - [Blarify Integration](blarify-integration.md) — concept overview of the blarify code-graph integration
+    - [Blarify Quickstart](../howto/blarify-quickstart.md) — hands-on guide to indexing a project
+    - [LadybugDB Code Graph](kuzu-code-graph.md) — the Kuzu-backed graph store used by amplihack-rs
+
+## System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         CODEBASE                                 │
+│  (Python, JavaScript, TypeScript, Ruby, Go, C#)                 │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         │ vendored blarify with KuzuManager
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                  TEMPORARY KUZU DATABASE                         │
+│  (blarify uses KuzuManager to analyze and store)                │
+│  - Nodes: FILE, CLASS, FUNCTION                                  │
+│  - Relationships: CONTAINS, CALLS, REFERENCES                    │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         │ Export to JSON
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    BLARIFY OUTPUT (JSON)                         │
+│  - Files (path, language, LOC)                                  │
+│  - Classes (name, docstring, line_number)                       │
+│  - Functions (name, params, complexity)                         │
+│  - Relationships (CALLS, INHERITS, CONTAINS)                    │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         │ KuzuCodeGraph.import_blarify_output()
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   KUZU EMBEDDED DATABASE                         │
+│                 (amplihack-rs main database)                     │
+│                                                                  │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  CODE GRAPH                                              │   │
+│  │                                                          │   │
+│  │  (:CodeFile {file_path, language, size_bytes})         │   │
+│  │       ▲                                                  │   │
+│  │       │ DEFINED_IN, CLASS_DEFINED_IN                     │   │
+│  │  (:CodeClass {class_name, docstring})                   │   │
+│  │       ▲                                                  │   │
+│  │       │ METHOD_OF                                        │   │
+│  │  (:CodeFunction {function_name, params, complexity})    │   │
+│  │       │                                                  │   │
+│  │       │ CALLS                                            │   │
+│  │       ▼                                                  │   │
+│  │  (:CodeFunction)                                         │   │
+│  └──────────────────────┬───────────────────────────────────┘   │
+│                         │                                        │
+│                         │ RELATES_TO_FILE                        │
+│                         │ RELATES_TO_FUNCTION                    │
+│                         │                                        │
+│  ┌──────────────────────▼───────────────────────────────────┐   │
+│  │  MEMORY GRAPH (Existing)                                 │   │
+│  │                                                          │   │
+│  │  (:Memory {content, agent_type, category})              │   │
+│  │       │                                                  │   │
+│  │       │ HAS_MEMORY                                       │   │
+│  │       ▼                                                  │   │
+│  │  (:AgentType {name, description})                       │   │
+│  │       │                                                  │   │
+│  │       │ SCOPED_TO                                        │   │
+│  │       ▼                                                  │   │
+│  │  (:Project {id, name})                                   │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Data Flow
+
+### Import Flow
+
+```
+1. USER RUNS IMPORT
+   │
+   ▼
+2. run_blarify()
+   │ - Executes: blarify analyze <codebase>
+   │ - Generates: code_graph.json
+   │
+   ▼
+3. BlarifyIntegration.initialize_code_schema()
+   │ - Creates constraints (unique paths/ids)
+   │ - Creates indexes (performance)
+   │
+   ▼
+4. BlarifyIntegration.import_blarify_output()
+   │ - Imports files → (:CodeFile)
+   │ - Imports classes → (:Class)
+   │ - Imports functions → (:Function)
+   │ - Creates relationships (DEFINED_IN, METHOD_OF, CALLS)
+   │
+   ▼
+5. BlarifyIntegration.link_code_to_memories()
+   │ - Finds memories with file references
+   │ - Creates (:Memory)-[:RELATES_TO_FILE]->(:CodeFile)
+   │ - Finds memories mentioning functions
+   │ - Creates (:Memory)-[:RELATES_TO_FUNCTION]->(:Function)
+   │
+   ▼
+6. COMPLETE - Code and memory graphs connected
+```
+
+### Query Flow
+
+```
+USER QUERIES MEMORY
+   │
+   ▼
+BlarifyIntegration.query_code_context(memory_id)
+   │
+   ├─> Find related files
+   │   MATCH (m:Memory)-[:RELATES_TO_FILE]->(cf:CodeFile)
+   │
+   ├─> Find related functions
+   │   MATCH (m:Memory)-[:RELATES_TO_FUNCTION]->(f:Function)
+   │
+   └─> Find related classes
+       MATCH (f)-[:METHOD_OF]->(c:Class)
+   │
+   ▼
+RETURN {
+  files: [...],
+  functions: [...],
+  classes: [...]
+}
+```
+
+## Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      BLARIFY INTEGRATION                         │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────┐    │
+│  │  code_graph.py (650 lines)                             │    │
+│  │                                                         │    │
+│  │  class BlarifyIntegration:                             │    │
+│  │    - initialize_code_schema()                          │    │
+│  │    - import_blarify_output()                           │    │
+│  │    - link_code_to_memories()                           │    │
+│  │    - query_code_context()                              │    │
+│  │    - get_code_stats()                                  │    │
+│  │    - incremental_update()                              │    │
+│  │                                                         │    │
+│  │  def run_blarify():                                    │    │
+│  │    - Executes blarify CLI                              │    │
+│  │    - Generates JSON output                             │    │
+│  └─────────────────┬───────────────────────────────────────┘    │
+│                    │                                            │
+│                    │ uses                                        │
+│                    ▼                                            │
+│  ┌────────────────────────────────────────────────────────┐    │
+│  │  KuzuConnector (LadybugDB)                             │    │
+│  │    - execute_query()                                   │    │
+│  │    - execute_write()                                   │    │
+│  │    - Circuit breaker                                   │    │
+│  │    - Retry logic                                       │    │
+│  └────────────────────────────────────────────────────────┘    │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                        CLI TOOLS                                 │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────┐    │
+│  │  import_codebase_to_neo4j.py (250 lines)              │    │
+│  │    - Runs blarify                                      │    │
+│  │    - Imports to Kuzu                                   │    │
+│  │    - Links to memories                                 │    │
+│  │    - Reports statistics                                │    │
+│  └────────────────────────────────────────────────────────┘    │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────┐    │
+│  │  test_blarify_integration.py (350 lines)              │    │
+│  │    - Creates sample data                               │    │
+│  │    - Tests all features                                │    │
+│  │    - Validates integration                             │    │
+│  └────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Relationship Types
+
+### Code-to-Code Relationships
+
+```
+(:Function)-[:DEFINED_IN]->(:CodeFile)
+   - Function belongs to file
+
+(:Function)-[:METHOD_OF]->(:Class)
+   - Function is method of class
+
+(:Class)-[:DEFINED_IN]->(:CodeFile)
+   - Class belongs to file
+
+(:Function)-[:CALLS]->(:Function)
+   - Function calls another function
+
+(:Class)-[:INHERITS]->(:Class)
+   - Class inherits from parent
+
+(:CodeFile)-[:IMPORTS {symbol, alias}]->(:CodeFile)
+   - File imports from another file
+
+(:CodeFile)-[:BELONGS_TO_PROJECT]->(:Project)
+   - File belongs to project (optional)
+```
+
+### Code-to-Memory Relationships
+
+```
+(:Memory)-[:RELATES_TO_FILE]->(:CodeFile)
+   - Memory references file
+   - Created when memory.metadata contains file path
+
+(:Memory)-[:RELATES_TO_FUNCTION]->(:Function)
+   - Memory references function
+   - Created when memory.content mentions function name
+```
+
+### Memory-to-Memory Relationships (Existing)
+
+```
+(:Memory)<-[:HAS_MEMORY]-(:AgentType)
+   - Agent type owns memory
+
+(:Memory)-[:SCOPED_TO]->(:Project)
+   - Memory scoped to project
+
+(:Memory)-[:SCOPED_TO {scope_type: "universal"}]->(:AgentType)
+   - Memory is universal (not project-specific)
+```
+
+## Query Patterns
+
+### Pattern 1: Find Code for Memory
+
+```cypher
+MATCH (m:Memory {id: $memory_id})
+OPTIONAL MATCH (m)-[:RELATES_TO_FILE]->(cf:CodeFile)
+OPTIONAL MATCH (m)-[:RELATES_TO_FUNCTION]->(f:Function)
+RETURN m, cf, f
+```
+
+### Pattern 2: Find Memories for Code
+
+```cypher
+MATCH (cf:CodeFile {path: $file_path})
+OPTIONAL MATCH (cf)<-[:RELATES_TO_FILE]-(m:Memory)
+RETURN m
+```
+
+### Pattern 3: Traverse Call Graph
+
+```cypher
+MATCH path = (start:Function {name: $start_name})-[:CALLS*1..3]->(end:Function)
+RETURN path
+```
+
+### Pattern 4: Find Complex Functions
+
+```cypher
+MATCH (f:Function)
+WHERE f.complexity > 10
+OPTIONAL MATCH (f)<-[:RELATES_TO_FUNCTION]-(m:Memory)
+RETURN f.name, f.complexity,
+       CASE WHEN m IS NULL THEN 'No docs' ELSE m.content END
+ORDER BY f.complexity DESC
+```
+
+### Pattern 5: Code Change Impact
+
+```cypher
+MATCH (cf:CodeFile)
+WHERE cf.last_modified > $timestamp
+MATCH (cf)<-[:DEFINED_IN]-(f:Function)
+OPTIONAL MATCH (f)<-[:RELATES_TO_FUNCTION]-(m:Memory)
+RETURN cf.path, f.name, collect(m.content) as affected_memories
+```
+
+## Schema Constraints and Indexes
+
+### Constraints (Uniqueness)
+
+```cypher
+// Code constraints
+CREATE CONSTRAINT code_file_path IF NOT EXISTS
+FOR (cf:CodeFile) REQUIRE cf.path IS UNIQUE
+
+CREATE CONSTRAINT class_id IF NOT EXISTS
+FOR (c:Class) REQUIRE c.id IS UNIQUE
+
+CREATE CONSTRAINT function_id IF NOT EXISTS
+FOR (f:Function) REQUIRE f.id IS UNIQUE
+
+// Memory constraints (existing)
+CREATE CONSTRAINT memory_id IF NOT EXISTS
+FOR (m:Memory) REQUIRE m.id IS UNIQUE
+```
+
+### Indexes (Performance)
+
+```cypher
+// Code indexes
+CREATE INDEX code_file_language IF NOT EXISTS
+FOR (cf:CodeFile) ON (cf.language)
+
+CREATE INDEX class_name IF NOT EXISTS
+FOR (c:Class) ON (c.name)
+
+CREATE INDEX function_name IF NOT EXISTS
+FOR (f:Function) ON (f.name)
+
+// Memory indexes (existing)
+CREATE INDEX memory_type IF NOT EXISTS
+FOR (m:Memory) ON (m.memory_type)
+```
+
+## Performance Considerations
+
+### Import Performance
+
+```
+Blarify Analysis:
+  - With SCIP: O(n) where n = files, ~2 seconds for 1000 files
+  - Without SCIP: O(n²) slower, ~10 minutes for 1000 files
+
+Kuzu Import:
+  - Batch operations: O(n) linear scaling
+  - Indexes speed lookups: O(log n)
+  - ~30 seconds for 1000 files regardless
+
+Memory Linking:
+  - Pattern matching: O(n*m) where n=memories, m=code
+  - Optimized with indexes: O(n log m)
+  - ~10 seconds for 1000 memories × 1000 files
+```
+
+### Query Performance
+
+```
+Single Memory Context:
+  - Index lookup: O(1)
+  - Relationship traversal: O(degree)
+  - Typical: < 10ms
+
+Code Graph Traversal:
+  - BFS/DFS: O(V + E) where V=nodes, E=edges
+  - Max depth limited (default: 2)
+  - Typical: < 100ms
+
+Full Text Search:
+  - String matching: O(n) on content
+  - Can add full-text index for O(log n)
+  - Typical: < 500ms
+```
+
+## Extension Points
+
+!!! info "Upstream Python API Reference"
+    The code examples in this section show the upstream Python API from
+    `amplihack.tools.amplihack.code_graph`. amplihack-rs implements equivalent
+    functionality in Rust via the `amplihack-memory` crate. The Cypher query
+    patterns remain the same regardless of host language.
+
+### Adding New Node Types
+
+```python
+def _import_custom_nodes(self, nodes: List[Dict]) -> int:
+    query = """
+    UNWIND $nodes as node
+    MERGE (n:CustomNode {id: node.id})
+    SET n.property = node.property
+    RETURN count(n) as count
+    """
+    result = self.conn.execute_write(query, {"nodes": nodes})
+    return result[0]["count"]
+```
+
+### Adding New Relationships
+
+```python
+def _create_custom_relationship(self, source_id: str, target_id: str) -> int:
+    query = """
+    MATCH (source {id: $source_id})
+    MATCH (target {id: $target_id})
+    MERGE (source)-[r:CUSTOM_REL]->(target)
+    RETURN count(r) as count
+    """
+    result = self.conn.execute_write(query, params)
+    return result[0]["count"]
+```
+
+### Custom Linking Logic
+
+```python
+def link_custom_pattern(self, pattern: str) -> int:
+    query = """
+    MATCH (m:Memory)
+    WHERE m.content CONTAINS $pattern
+    MATCH (cf:CodeFile)
+    WHERE cf.path CONTAINS $pattern
+    MERGE (m)-[r:CUSTOM_LINK]->(cf)
+    RETURN count(r) as count
+    """
+    result = self.conn.execute_write(query, {"pattern": pattern})
+    return result[0]["count"]
+```
+
+## Security Considerations
+
+1. **SQL Injection Prevention**: All queries use parameterized statements
+2. **Path Validation**: File paths sanitized before storage
+3. **Access Control**: Kuzu database authentication where applicable
+4. **Data Isolation**: Project-level scoping supported
+5. **Circuit Breaker**: Prevents cascading failures
+
+## Monitoring
+
+### Key Metrics
+
+```python
+# Import metrics
+counts = integration.import_blarify_output(path)
+# Track: files, classes, functions, relationships
+
+# Link metrics
+link_count = integration.link_code_to_memories()
+# Track: number of code-memory relationships created
+
+# Query metrics
+stats = integration.get_code_stats()
+# Track: total nodes, relationships, query performance
+```
+
+### Health Checks
+
+```python
+# Connection health
+if conn.verify_connectivity():
+    print("✓ Kuzu healthy")
+
+# Schema health
+if integration.initialize_code_schema():
+    print("✓ Schema valid")
+
+# Data health
+stats = integration.get_code_stats()
+if stats["file_count"] > 0:
+    print("✓ Data present")
+```
+
+---
+
+**Architecture designed for**:
+
+- Scale: 10K+ files, 100K+ functions
+- Performance: Sub-second queries
+- Extensibility: Easy to add new node/relationship types
+- Reliability: Circuit breaker, retries, error handling
+- Maintainability: Clear separation of concerns

--- a/docs/reference/git-utils-api.md
+++ b/docs/reference/git-utils-api.md
@@ -1,0 +1,466 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Git Utilities API Reference
+
+!!! note "Upstream Python API Reference"
+    This document describes the upstream Python `amplihack.tools.amplihack.git_utils`
+    module. amplihack-rs implements equivalent functionality in Rust (see
+    `crates/amplihack-cli/src/git/`). The function signatures, behaviors, and
+    patterns documented here serve as the reference specification for the Rust
+    implementation.
+
+Technical documentation for `amplihack.tools.amplihack.git_utils` module providing git worktree detection and shared directory utilities.
+
+## Overview
+
+The `git_utils` module provides utilities for detecting git worktrees and finding shared directories across worktree configurations. These functions enable Power Steering and other tools to work correctly in both standard repositories and worktree environments.
+
+## Installation
+
+The module is included in amplihack core:
+
+```python
+from amplihack.tools.amplihack.git_utils import (
+    is_worktree,
+    get_common_git_dir,
+    find_disabled_file
+)
+```
+
+## Functions
+
+### is_worktree
+
+```python
+def is_worktree(cwd: Optional[str] = None) -> bool
+```
+
+Detect if the current directory is a git worktree.
+
+**Parameters**:
+
+- `cwd` (Optional[str]): Working directory to check. Defaults to `os.getcwd()`.
+
+**Returns**: `bool` - `True` if working in a worktree, `False` otherwise.
+
+**How It Works**:
+
+- Runs `git rev-parse --git-common-dir` and `git rev-parse --git-dir`
+- Compares resolved paths
+- If paths differ, directory is a worktree
+- If paths match, directory is standard repo or main repo
+
+**Example**:
+
+```python
+from amplihack.tools.amplihack.git_utils import is_worktree
+
+# Check current directory
+if is_worktree():
+    print("Working in a worktree")
+else:
+    print("Working in standard repo")
+
+# Check specific directory
+if is_worktree("/path/to/worktree"):
+    print("Path is a worktree")
+```
+
+**Error Handling**:
+
+```python
+# Non-git directory
+is_worktree("/tmp/not-a-repo")  # Returns False
+
+# Permission denied
+is_worktree("/root/restricted")  # Returns False
+```
+
+### get_common_git_dir
+
+```python
+def get_common_git_dir(cwd: Optional[str] = None) -> str
+```
+
+Get the common git directory shared across all worktrees.
+
+**Parameters**:
+
+- `cwd` (Optional[str]): Working directory. Defaults to `os.getcwd()`.
+
+**Returns**: `str` - Absolute path to common git directory.
+
+**How It Works**:
+
+- Runs `git rev-parse --git-common-dir`
+- Resolves to absolute path
+- In standard repos: Returns `.git/`
+- In worktrees: Returns main repo's `.git/`
+
+**Example**:
+
+```python
+from amplihack.tools.amplihack.git_utils import get_common_git_dir
+
+# Standard repo
+common_dir = get_common_git_dir()
+# Returns: /path/to/repo/.git
+
+# Worktree
+common_dir = get_common_git_dir("/path/to/worktree")
+# Returns: /path/to/main-repo/.git
+```
+
+**Use Cases**:
+
+```python
+# Store shared state
+import os
+from amplihack.tools.amplihack.git_utils import get_common_git_dir
+
+common_dir = get_common_git_dir()
+state_dir = os.path.join(common_dir, ".claude/runtime/power-steering/")
+os.makedirs(state_dir, exist_ok=True)
+
+# Write counter
+counter_file = os.path.join(state_dir, "counter.json")
+with open(counter_file, "w") as f:
+    json.dump({"count": 5}, f)
+```
+
+**Error Handling**:
+
+```python
+# Non-git directory
+try:
+    common_dir = get_common_git_dir("/tmp/not-a-repo")
+except subprocess.CalledProcessError:
+    print("Not a git repository")
+```
+
+### find_disabled_file
+
+```python
+def find_disabled_file(cwd: Optional[str] = None) -> Optional[str]
+```
+
+Find `.disabled` file in multiple locations (worktree-aware).
+
+**Parameters**:
+
+- `cwd` (Optional[str]): Working directory. Defaults to `os.getcwd()`.
+
+**Returns**: `Optional[str]` - Absolute path to `.disabled` file if found, `None` otherwise.
+
+**Search Order**:
+
+1. Current working directory: `{cwd}/.disabled`
+2. Shared runtime directory: `{common_git_dir}/.claude/runtime/power-steering/.disabled`
+3. Project root: `{project_root}/.disabled`
+
+**Example**:
+
+```python
+from amplihack.tools.amplihack.git_utils import find_disabled_file
+
+# Check if Power Steering is disabled
+disabled_file = find_disabled_file()
+if disabled_file:
+    print(f"Power Steering disabled via: {disabled_file}")
+else:
+    print("Power Steering enabled")
+```
+
+**Creating .disabled Files**:
+
+```bash
+# Local disable (current worktree only)
+touch .disabled
+
+# Global disable (all worktrees)
+touch "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+
+# Root disable (backward compatible)
+cd "$(git rev-parse --show-toplevel)"
+touch .disabled
+```
+
+**Use Cases**:
+
+```python
+# Conditional execution based on .disabled file
+from amplihack.tools.amplihack.git_utils import find_disabled_file
+
+def should_run_power_steering() -> bool:
+    """Check if Power Steering should run."""
+    return find_disabled_file() is None
+
+if should_run_power_steering():
+    # Run Power Steering
+    pass
+else:
+    # Skip Power Steering
+    print("Power Steering disabled")
+```
+
+## Shared State Pattern
+
+Recommended pattern for storing shared state across worktrees:
+
+```python
+import os
+import json
+from pathlib import Path
+from amplihack.tools.amplihack.git_utils import get_common_git_dir
+
+def get_state_directory() -> Path:
+    """Get shared state directory for tool."""
+    common_dir = get_common_git_dir()
+    state_dir = Path(common_dir) / ".claude" / "runtime" / "my-tool"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+def load_state() -> dict:
+    """Load state from shared directory."""
+    state_file = get_state_directory() / "state.json"
+    if state_file.exists():
+        return json.loads(state_file.read_text())
+    return {}
+
+def save_state(state: dict) -> None:
+    """Save state to shared directory."""
+    state_file = get_state_directory() / "state.json"
+    state_file.write_text(json.dumps(state, indent=2))
+```
+
+## Implementation Details
+
+### Worktree Detection Algorithm
+
+```python
+def is_worktree(cwd: Optional[str] = None) -> bool:
+    """
+    Algorithm:
+    1. Run: git rev-parse --git-common-dir
+    2. Run: git rev-parse --git-dir
+    3. Resolve both to absolute paths
+    4. Compare:
+       - Same path → Standard repo or main repo
+       - Different paths → Worktree
+    """
+    common_dir = subprocess.check_output(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=cwd,
+        text=True
+    ).strip()
+
+    git_dir = subprocess.check_output(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=cwd,
+        text=True
+    ).strip()
+
+    return os.path.abspath(common_dir) != os.path.abspath(git_dir)
+```
+
+### Directory Structure
+
+Standard repository:
+
+```
+repo/.git/
+├── config
+├── objects/
+└── refs/
+```
+
+Worktree configuration:
+
+```
+main-repo/.git/           # Common git directory
+├── config
+├── objects/              # Shared objects
+├── refs/                 # Shared refs
+├── worktrees/
+│   └── feature-branch/
+│       ├── gitdir        # Points to worktree .git
+│       └── HEAD          # Worktree-specific HEAD
+└── .claude/
+    └── runtime/
+        └── power-steering/
+            └── counter.json  # Shared state
+
+worktree-dir/.git         # File containing: gitdir: /path/to/main-repo/.git/worktrees/feature-branch
+```
+
+### Common Directory Resolution
+
+```python
+# Standard repo
+os.getcwd()                    # /path/to/repo
+git rev-parse --git-dir        # .git
+git rev-parse --git-common-dir # .git
+→ Common: /path/to/repo/.git
+
+# Worktree
+os.getcwd()                    # /path/to/worktree
+git rev-parse --git-dir        # /path/to/main/.git/worktrees/feature
+git rev-parse --git-common-dir # /path/to/main/.git
+→ Common: /path/to/main/.git
+```
+
+## Error Handling
+
+### Non-Git Directory
+
+```python
+from amplihack.tools.amplihack.git_utils import is_worktree, get_common_git_dir
+
+# is_worktree returns False
+is_worktree("/tmp/not-a-repo")  # False
+
+# get_common_git_dir raises exception
+try:
+    get_common_git_dir("/tmp/not-a-repo")
+except subprocess.CalledProcessError as e:
+    print(f"Not a git repository: {e}")
+```
+
+### Permission Errors
+
+```python
+# Handle permission errors
+import os
+from amplihack.tools.amplihack.git_utils import find_disabled_file
+
+try:
+    disabled = find_disabled_file()
+except PermissionError:
+    print("Permission denied checking .disabled file")
+    disabled = None
+```
+
+### Git Command Failures
+
+```python
+# Graceful degradation
+from amplihack.tools.amplihack.git_utils import get_common_git_dir
+
+try:
+    common_dir = get_common_git_dir()
+except Exception:
+    # Fallback to current directory
+    common_dir = ".git"
+```
+
+## Testing
+
+### Unit Tests
+
+```python
+import unittest
+from unittest.mock import patch, MagicMock
+from amplihack.tools.amplihack.git_utils import is_worktree
+
+class TestGitUtils(unittest.TestCase):
+    @patch('subprocess.check_output')
+    def test_is_worktree_standard_repo(self, mock_check_output):
+        """Test standard repository detection."""
+        mock_check_output.return_value = b'/repo/.git\n'
+        self.assertFalse(is_worktree())
+
+    @patch('subprocess.check_output')
+    def test_is_worktree_detects_worktree(self, mock_check_output):
+        """Test worktree detection."""
+        mock_check_output.side_effect = [
+            b'/main/.git\n',         # --git-common-dir
+            b'/main/.git/worktrees/feature\n'  # --git-dir
+        ]
+        self.assertTrue(is_worktree())
+```
+
+### Integration Tests
+
+```bash
+# Test worktree detection
+git worktree add ../test-worktree feature
+cd ../test-worktree
+
+python3 << 'EOF'
+from amplihack.tools.amplihack.git_utils import is_worktree, get_common_git_dir
+assert is_worktree(), "Should detect worktree"
+print(f"Common dir: {get_common_git_dir()}")
+EOF
+```
+
+## Performance
+
+### Benchmarks
+
+| Function               | Standard Repo | Worktree | Overhead      |
+| ---------------------- | ------------- | -------- | ------------- |
+| `is_worktree()`        | ~2ms          | ~2ms     | < 0.1%        |
+| `get_common_git_dir()` | ~1ms          | ~1ms     | < 0.1%        |
+| `find_disabled_file()` | ~3ms          | ~5ms     | 3 file checks |
+
+### Caching
+
+For performance-critical code, cache results:
+
+```python
+from functools import lru_cache
+from amplihack.tools.amplihack.git_utils import get_common_git_dir
+
+@lru_cache(maxsize=1)
+def get_cached_common_dir() -> str:
+    """Cache common git directory (doesn't change during execution)."""
+    return get_common_git_dir()
+```
+
+## Migration Guide
+
+### Upgrading from Pre-Worktree Code
+
+**Before** (broken in worktrees):
+
+```python
+# Hardcoded .git directory
+state_dir = ".git/.claude/runtime/power-steering/"
+```
+
+**After** (works in worktrees):
+
+```python
+# Use git_utils
+from amplihack.tools.amplihack.git_utils import get_common_git_dir
+import os
+
+common_dir = get_common_git_dir()
+state_dir = os.path.join(common_dir, ".claude/runtime/power-steering/")
+```
+
+### Updating .disabled Checks
+
+**Before** (only checks CWD):
+
+```python
+# Only checks current directory
+if os.path.exists(".disabled"):
+    return
+```
+
+**After** (checks multiple locations):
+
+```python
+# Checks CWD, shared dir, and project root
+from amplihack.tools.amplihack.git_utils import find_disabled_file
+
+if find_disabled_file():
+    return
+```
+
+## Related Documentation
+
+- [Worktree Support](../concepts/worktree-support.md) — concept overview of worktree integration
+- [Power Steering Compaction](../concepts/power-steering-compaction.md) — compaction strategies for power steering
+- [Git Worktree Documentation](https://git-scm.com/docs/git-worktree) — official git docs

--- a/docs/reference/recipe-runner-audit.md
+++ b/docs/reference/recipe-runner-audit.md
@@ -1,0 +1,429 @@
+<!-- Ported from upstream amplihack. Rust-specific adaptations applied where applicable. -->
+
+# Recipe Runner Infrastructure: Quality & Robustness Audit
+
+!!! info "Upstream Audit Report"
+    This is a reference audit of the recipe runner infrastructure. File paths
+    reference the upstream Python source. Findings about the Rust binary
+    (`recipe-runner-rs`) are directly relevant to amplihack-rs. The Python
+    wrapper findings document the upstream execution model that amplihack-rs
+    replaces with native Rust execution.
+
+**Date**: 2026-03-27
+**Scope**: Recipe runner observability, condition evaluation, error recovery, YAML quality, smart-orchestrator routing
+**Issues**: #3676, #3677, #3678, #3679
+
+---
+
+## Executive Summary
+
+This audit examines five areas of the recipe runner infrastructure. **31 findings** were identified across 4 severity levels. The most critical issues are: (1) failure diagnostics are nearly invisible due to stderr filtering and empty error fields, (2) condition expressions silently evaluate incorrectly due to boolean coercion bugs, (3) no resume-from-step capability means late failures waste hours of work, and (4) 173 recipe steps rely on fragile type inference.
+
+| Severity    | Count | Key Theme                                                |
+| ----------- | ----- | -------------------------------------------------------- |
+| Critical    | 8     | Silent failures, data loss, broken chains                |
+| High        | 11    | Observability gaps, type mismatches, missing checkpoints |
+| Medium      | 9     | Missing validation, implicit behaviors                   |
+| Low         | 3     | Cosmetic, documentation                                  |
+
+---
+
+## Table of Contents
+
+1. [Runner Observability](#1-runner-observability)
+2. [Condition Expression Robustness](#2-condition-expression-robustness)
+3. [Error Recovery & Checkpoint Resilience](#3-error-recovery-checkpoint-resilience)
+4. [Recipe YAML Quality](#4-recipe-yaml-quality)
+5. [Smart-Orchestrator Routing](#5-smart-orchestrator-routing)
+6. [Consolidated Findings](#6-consolidated-findings)
+7. [Prioritized Remediation Plan](#7-prioritized-remediation-plan)
+
+---
+
+## 1. Runner Observability
+
+### Architecture
+
+The recipe runner uses a Rust binary (`recipe-runner-rs`) as the execution engine with a Python wrapper (`src/amplihack/recipes/rust_runner_execution.py`). Two execution modes exist:
+
+| Mode             | Default? | Buffering        | Live Output  | Progress File                    |
+| ---------------- | -------- | ---------------- | ------------ | -------------------------------- |
+| `progress=False` | **Yes**  | Full block       | None         | None                             |
+| `progress=True`  | No       | Line (bufsize=1) | stderr relay | `/tmp/amplihack-progress-*.json` |
+
+**Process flow**: Python → `subprocess.Popen/run` → Rust binary → agent processes
+
+### Findings
+
+#### F-OBS-1: Default progress disabled (Critical)
+
+- **File**: `src/amplihack/recipes/__init__.py:91`
+- **Issue**: `progress: bool = False` is the default. Most callers get fully-buffered, non-streamed execution with zero visibility until completion.
+- **Impact**: First indication of failure is when the process exits. No intermediate output.
+- **Fix**: Default to `progress=True` when stderr is a TTY: `progress = kwargs.get('progress', sys.stderr.isatty())`
+
+#### F-OBS-2: Failure diagnostics are empty (Critical)
+
+- **File**: `src/amplihack/recipes/rust_runner_execution.py:267-291`
+- **Issue**: When a step fails, Python relies entirely on the Rust binary's `error` field in JSON. If the Rust binary returns `error: ""`, the user sees nothing useful. This is exactly what happened when `clarify-ambiguities` failed in Round 1 — zero diagnostic output.
+- **Impact**: Users cannot diagnose step failures without manual log inspection.
+- **Fix**: Collect all non-progress stderr as diagnostic context. Show last 100 lines, not 5.
+
+#### F-OBS-3: Stderr filtering discards diagnostic info (High)
+
+- **File**: `src/amplihack/recipes/rust_runner_execution.py:270-272`
+- **Issue**: `_meaningful_stderr_tail()` filters lines starting with `[agent]`, `▶`, `✓`, `⊘`, `✗`. Agent debug output is lost. Only last 5 lines survive.
+- **Fix**: Collect all stderr separately; filter only progress markers for display.
+
+#### F-OBS-4: No timeout or deadlock detection (High)
+
+- **File**: `src/amplihack/recipes/rust_runner_execution.py:118, 232`
+- **Issue**: `process.wait()` blocks indefinitely. No mechanism to kill hung processes.
+- **Fix**: Add `timeout` parameter (default 3600s) to `subprocess.run` and `process.wait`.
+
+#### F-OBS-5: Progress file missing total_steps (Medium)
+
+- **File**: `src/amplihack/recipes/rust_runner_execution.py:192-199`
+- **Issue**: `total_steps=0` hardcoded. External tools cannot show "step 3 of 8".
+- **Fix**: Parse recipe YAML for step count before execution; pass to progress file.
+
+#### F-OBS-6: No heartbeat mechanism (High)
+
+- **Issue**: If a step is stuck but not producing output, no indicator is updated. Progress file goes stale.
+- **Fix**: Timer-based progress writes every 5 seconds.
+
+#### F-OBS-7: Output memory limit unenforced (Medium)
+
+- **File**: `src/amplihack/recipes/rust_runner.py:41`
+- **Issue**: `MAX_BINARY_OUTPUT_BYTES = 10MB` constant defined but never checked in non-progress mode.
+- **Fix**: Enforce with defensive read loop.
+
+---
+
+## 2. Condition Expression Robustness
+
+### Evaluator Architecture
+
+Conditions are evaluated using Python `simpleeval.EvalWithCompoundTypes` (NOT Rust).
+
+- **File**: `src/amplihack/recipes/models.py:56-82`
+- **Type coercion**: `True` → `'true'` (string), `False` → `'false'` (string)
+- **Exception handling**: Any exception → returns `True` (step EXECUTES)
+
+### Inventory
+
+**39 total conditions** found across 10 recipe YAML files:
+
+- 38% Safe, 54% Fragile, 8% Risk
+
+| Recipe                      | Safe | Fragile | Risk |
+| --------------------------- | ---- | ------- | ---- |
+| auto-workflow.yaml          | 4    | 0       | 0    |
+| code-atlas.yaml             | 1    | 9       | 0    |
+| consensus-workflow.yaml     | 1    | 5       | 0    |
+| investigation-workflow.yaml | 2    | 0       | 2    |
+| smart-orchestrator.yaml     | 3    | 2       | 0    |
+| Others (5 files)            | 4    | 5       | 1    |
+
+### Findings
+
+#### F-COND-1: Boolean literal comparisons silently fail (Critical)
+
+- **Affected**: 11 conditions across code-atlas (9), consensus-workflow (2), qa-workflow (2)
+- **Issue**: `bug_hunt == True` fails because coercion converts `True` to `'true'` (string). `'true' == True` → `False`. Steps that should run are silently skipped.
+- **Fix**: Replace `X == True` with `X == 'true'` or bare `X` (truthy check).
+
+#### F-COND-2: Exception-on-eval returns True — masks bugs (Critical)
+
+- **File**: `src/amplihack/recipes/models.py:56-82`
+- **Issue**: If condition evaluation raises ANY exception (NameError, KeyError, AttributeError), returns `True`. Steps execute when they shouldn't, masking real bugs.
+- **Fix**: Log the exception; consider defaulting to `False` (fail-closed) or requiring explicit handling.
+
+#### F-COND-3: Deep nested attribute access without null checks (High)
+
+- **Affected**: 3 conditions in investigation-workflow, n-version-workflow
+- **Example**: `strategy.parallel_deployment.specialist_agent` — if `parallel_deployment` is `None`, raises `AttributeError` → caught by F-COND-2 → returns `True` → step runs when it shouldn't.
+- **Fix**: Add defensive chains or support safe navigation operator.
+
+#### F-COND-4: String literal comparisons fragile to type changes (Medium)
+
+- **Affected**: 4 conditions in consensus-workflow, oxidizer-workflow, long-horizon-memory-eval
+- **Example**: `is_critical_code == 'false'` — works with current coercion but breaks if context provides a boolean.
+- **Fix**: Standardize on `str(var).strip() == 'expected'` pattern (as smart-orchestrator does).
+
+#### F-COND-5: Security is solid (Info)
+
+- Verified by tests in `tests/gadugi/test_simpleeval_scenarios.py`
+- Code injection via `__import__`, `open()`, `__class__` all blocked.
+
+---
+
+## 3. Error Recovery & Checkpoint Resilience
+
+### Checkpoint Inventory
+
+The default-workflow has exactly **3 git-based checkpoints** across 23 steps:
+
+| Phase           | After Step | Commit Message                          | What's Saved         |
+| --------------- | ---------- | --------------------------------------- | -------------------- |
+| Implementation  | 7-8        | `wip: checkpoint after implementation`  | Tests & code         |
+| Review Feedback | 10-11      | `wip: checkpoint after review feedback` | Review fixes         |
+| Main Commit     | 15         | `feat: <task summary>`                  | Final implementation |
+
+**No checkpoints exist after steps 13 (testing), 18 (feedback), or 20 (cleanup).**
+
+### Findings
+
+#### F-ERR-1: No resume-from-step capability (Critical)
+
+- **Issue**: After a step 15+ failure (2+ hours of work), the entire workflow must restart from step 0. Context dict is ephemeral — no state serialization.
+- **Impact**: Hours of agent work (design, implementation, review) are lost on late failures.
+- **Fix**: Serialize context dict to disk after each step; add `--resume-from-step N` CLI flag.
+
+#### F-ERR-2: Step 13 "CANNOT BE SKIPPED" label has no enforcement mechanism (High)
+
+- **File**: `amplifier-bundle/recipes/default-workflow.yaml:961`
+- **Issue**: Step 13 (outside-in testing) is labeled "CANNOT BE SKIPPED" in the prompt text, but has no `condition` or `depends_on` field enforcing this. The label is advisory only. Step 17a (compliance gate) validates `local_testing_gate` output and fails if step 13 produced no output — creating an implicit but fragile coupling.
+- **Fix**: Add explicit `required: true` metadata or a validation step that halts the workflow if step 13 is skipped.
+
+#### F-ERR-3: Only 40% of workflow has checkpoint coverage (High)
+
+- **Issue**: Steps 13-22 (testing, review, feedback, cleanup) have no checkpoints. Failure at step 19 loses all step 18 work.
+- **Fix**: Add checkpoints after steps 13 and 18.
+
+#### F-ERR-4: Non-idempotent steps have no safety documentation (High)
+
+- **Issue**: Steps 8, 9, 11, 18, 20 are non-idempotent (code modification). Operators might manually re-run and corrupt state. No documentation of safe retry points.
+- **Fix**: Add `idempotent: true|false` metadata to recipe YAML steps.
+
+#### F-ERR-5: Investigation round-2 recovery uses wrong agent type (High)
+
+- **Issue**: If `clarify-ambiguities` (ambiguity agent) fails in round 1, round 2 invokes the builder agent. Builder cannot resolve semantic ambiguities.
+- **Fix**: Round 2 should re-invoke the failed agent's type, not default to builder.
+
+#### F-ERR-6: Soft failures (gh, push) are opaque (Medium)
+
+- **Issue**: Steps 3, 16, 21 silently continue if `gh` is unavailable. Operators don't know if PR was created.
+- **Fix**: Add explicit `continue_on_error: true` with warning output.
+
+#### F-ERR-7: `clarify-ambiguities` failure analysis (Medium)
+
+- **File**: `amplifier-bundle/recipes/investigation-workflow.yaml:144-180`
+- **Issue**: When this step fails, `parse_json: true` causes validation failure. Downstream steps receive empty `{{ambiguity_resolution}}`. The recipe reports FAILED with zero diagnostic detail (see F-OBS-2).
+
+---
+
+## 4. Recipe YAML Quality
+
+### Findings
+
+#### F-YAML-1: 173 steps missing explicit `type` field (Critical)
+
+- **Affected**: All 14 recipe YAML files (consensus: 52, default: 36, n-version: 20, others: 65)
+- **Issue**: Steps rely on type inference via `RecipeParser` (parser.py:270-296). Field typos silently misclassify: `agent_name` instead of `agent` → interpreted as BASH.
+- **Fix**: Add `type: "agent"` or `type: "bash"` explicitly to all steps. Add validation warning for missing type.
+
+#### F-YAML-2: 13 agent steps missing `output` field in code-atlas.yaml (Critical)
+
+- **Issue**: Agent output not captured → downstream `{{step-OUTPUT}}` references are undefined → silent data loss. Affects `build-layers-1-4`, `verify-all-layers`, all bug-hunt steps, and more.
+- **Fix**: Add `output:` field to all 13 affected steps.
+
+#### F-YAML-3: No JSON schema for recipe validation (Medium)
+
+- **Issue**: `_recipe_manifest.json` contains only name→ID mappings. No formal schema for step fields, types, constraints.
+- **Fix**: Create JSON Schema; validate at parse time.
+
+#### F-YAML-4: No pre-commit linting for recipes (Medium)
+
+- **Issue**: Recipes only validated at runtime when executed. No CI gate catches YAML issues before commit.
+- **Fix**: Add pre-commit hook and CI step.
+
+#### F-YAML-5: 19 context variables with empty defaults in smart-orchestrator (Medium)
+
+- **File**: `amplifier-bundle/recipes/smart-orchestrator.yaml:9-30`
+- **Issue**: Required variables like `task_description` default to `""`. Steps fail silently if not provided.
+- **Fix**: Mark required variables; validate at recipe start.
+
+#### F-YAML-6: 10 conditional bash steps missing error handling (Medium)
+
+- **Issue**: When condition is false and step is skipped, output variable is undefined. Downstream steps that reference it may fail.
+
+---
+
+## 5. Smart-Orchestrator Routing
+
+### Routing Flow
+
+```
+PHASE 1: SETUP
+├─ setup-session → session_info
+├─ classify-and-decompose (agent) → decomposition_json
+├─ parse-decomposition (bash) → task_type, workstream_count
+├─ activate-workflow (bash) → workstream_count
+└─ materialize-force-single → force_single_workstream
+
+PHASE 2: ROUTING DECISION
+├─ IF Q&A          → handle-qa (agent)
+├─ ELIF Operations → handle-ops-agent (agent)
+├─ ELIF Dev/Investigation:
+│  ├─ IF recursion_guard ALLOWED:
+│  │  ├─ IF single workstream → execute-single-round-1
+│  │  └─ ELIF multi workstream → launch-parallel-round-1
+│  └─ FALLBACK:
+│     ├─ detect-execution-gap → adaptive_recipe
+│     ├─ file-routing-bug (GitHub issue)
+│     └─ adaptive-execute → round_1_result
+
+PHASE 3: REFLECTION → reflect-round-1/2/3/final
+PHASE 4: VALIDATION → validate + summarize
+PHASE 5: TEARDOWN → complete-session
+```
+
+### Findings
+
+#### F-ROUTE-1: Multiple JSON blocks use first — may be wrong (Critical)
+
+- **File**: `amplifier-bundle/tools/orch_helper.py:14-56`
+- **Issue**: `extract_json()` takes the first JSON block found. If an agent produces an initial analysis then a revised one, the wrong (first) block is used.
+- **Fix**: Use last JSON block, or validate expected schema and pick best match.
+
+#### F-ROUTE-2: Zero-workstream escalation is silent (Medium)
+
+- **Issue**: `max(1, len([]))` silently converts 0 workstreams to 1. Safe but implicit.
+- **Fix**: Log when escalation happens.
+
+#### F-ROUTE-3: Malformed JSON defaults to empty object (Medium)
+
+- **Issue**: If no valid JSON found, returns `{}`. `task_type` defaults to `"Development"`. Graceful but may route incorrectly.
+- **Fix**: Add explicit error reporting when decomposition produces no valid JSON.
+
+#### F-ROUTE-4: Adaptive fallback is robust (Good)
+
+- `detect-execution-gap` + `file-routing-bug` + `adaptive-execute` is well-designed.
+
+#### F-ROUTE-5: Workstream field validation is adequate (Good)
+
+- Missing optional fields handled gracefully with defaults.
+
+---
+
+## 6. Consolidated Findings
+
+### Critical (8)
+
+| ID        | Area          | Finding                         | Impact                              |
+| --------- | ------------- | ------------------------------- | ----------------------------------- |
+| F-OBS-1   | Observability | Default progress disabled       | Zero visibility during execution    |
+| F-OBS-2   | Observability | Failure diagnostics empty       | Cannot diagnose step failures       |
+| F-COND-1  | Conditions    | Boolean literal `== True` fails | 11 conditions silently wrong        |
+| F-COND-2  | Conditions    | Exception-on-eval returns True  | Steps run when they shouldn't       |
+| F-ERR-1   | Recovery      | No resume-from-step             | Hours of work lost on late failures |
+| F-YAML-1  | YAML Quality  | 173 steps missing explicit type | Silent type misclassification       |
+| F-YAML-2  | YAML Quality  | 13 agent steps missing output   | Broken downstream chains            |
+| F-ROUTE-1 | Routing       | Multiple JSON blocks use first  | Wrong decomposition silently used   |
+
+### High (11)
+
+| ID       | Area          | Finding                                   |
+| -------- | ------------- | ----------------------------------------- |
+| F-OBS-3  | Observability | Stderr filtering discards diagnostic info |
+| F-OBS-4  | Observability | No timeout or deadlock detection          |
+| F-OBS-6  | Observability | No heartbeat mechanism                    |
+| F-COND-3 | Conditions    | Deep nested access without null checks    |
+| F-ERR-2  | Recovery      | Step 13 "CANNOT BE SKIPPED" unenforced    |
+| F-ERR-3  | Recovery      | Only 40% checkpoint coverage              |
+| F-ERR-4  | Recovery      | Non-idempotent steps undocumented         |
+| F-ERR-5  | Recovery      | Round-2 uses wrong agent type             |
+
+### Medium (9)
+
+| ID       | Area          | Finding                                       |
+| -------- | ------------- | --------------------------------------------- |
+| F-OBS-5  | Observability | Progress file missing total_steps             |
+| F-OBS-7  | Observability | Output memory limit unenforced                |
+| F-COND-4 | Conditions    | String literal comparisons fragile            |
+| F-ERR-6  | Recovery      | Soft failures opaque                          |
+| F-ERR-7  | Recovery      | clarify-ambiguities failure opaque            |
+| F-YAML-3 | YAML Quality  | No JSON schema                                |
+| F-YAML-4 | YAML Quality  | No pre-commit linting                         |
+| F-YAML-5 | YAML Quality  | 19 empty context defaults                     |
+| F-YAML-6 | YAML Quality  | Conditional bash steps missing error handling |
+
+### Low/Info (3)
+
+| ID        | Area       | Finding                              |
+| --------- | ---------- | ------------------------------------ |
+| F-COND-5  | Conditions | Security evaluation is solid         |
+| F-ROUTE-4 | Routing    | Adaptive fallback is robust          |
+| F-ROUTE-5 | Routing    | Workstream field validation adequate |
+
+---
+
+## 7. Prioritized Remediation Plan
+
+### P0 — Immediate (1-2 days)
+
+| #   | Action                                                                                | Effort | Findings         |
+| --- | ------------------------------------------------------------------------------------- | ------ | ---------------- |
+| 1   | Fix 11 boolean literal conditions: replace `X == True` with `X == 'true'` or bare `X` | 30 min | F-COND-1         |
+| 2   | Add `output:` field to 13 agent steps in code-atlas.yaml                              | 30 min | F-YAML-2         |
+| 3   | Change exception-on-eval from `return True` to `return False` + log warning           | 1 hr   | F-COND-2         |
+| 4   | Add `required: true` enforcement for step 13 or pre-step validation gate              | 1 hr   | F-ERR-2          |
+| 5   | Increase stderr diagnostic tail from 5 to 100 lines; stop filtering `[agent]` lines   | 30 min | F-OBS-2, F-OBS-3 |
+| 6   | Fix `extract_json()` to use last JSON block instead of first                          | 30 min | F-ROUTE-1        |
+| 7   | Add explicit `continue_on_error: true` to steps 3, 16, 21                             | 15 min | F-ERR-6          |
+
+### P1 — Short-term (1-2 weeks)
+
+| #   | Action                                                             | Effort | Findings |
+| --- | ------------------------------------------------------------------ | ------ | -------- |
+| 8   | Default `progress=True` when stderr is a TTY                       | 1 hr   | F-OBS-1  |
+| 9   | Add subprocess timeout (default 3600s)                             | 2 hr   | F-OBS-4  |
+| 10  | Add 2 more checkpoints: after steps 13 and 18                      | 2 hr   | F-ERR-3  |
+| 11  | Add `type: "agent"` explicitly to 173 steps                        | 3 hr   | F-YAML-1 |
+| 12  | Standardize conditions on `str(var).strip() == 'expected'` pattern | 2 hr   | F-COND-4 |
+| 13  | Add defensive null checks to 3 deep-nested conditions              | 1 hr   | F-COND-3 |
+| 14  | Fix investigation round-2 to re-invoke correct agent type          | 2 hr   | F-ERR-5  |
+
+### P2 — Medium-term (1 month)
+
+| #   | Action                                                      | Effort | Findings |
+| --- | ----------------------------------------------------------- | ------ | -------- |
+| 15  | Implement heartbeat mechanism (timer-based progress writes) | 4 hr   | F-OBS-6  |
+| 16  | Add `total_steps` to progress file from recipe metadata     | 2 hr   | F-OBS-5  |
+| 17  | Create JSON Schema for recipe YAML validation               | 8 hr   | F-YAML-3 |
+| 18  | Add pre-commit hook for recipe validation                   | 4 hr   | F-YAML-4 |
+| 19  | Add `idempotent: true/false` metadata to recipe steps       | 4 hr   | F-ERR-4  |
+| 20  | Serialize context dict to disk per step (resume prototype)  | 8 hr   | F-ERR-1  |
+
+### P3 — Long-term (next quarter)
+
+| #   | Action                                                    | Effort  | Findings |
+| --- | --------------------------------------------------------- | ------- | -------- |
+| 21  | Full resume-from-step implementation                      | 2 weeks | F-ERR-1  |
+| 22  | Enforce output memory limit                               | 2 hr    | F-OBS-7  |
+| 23  | Pre-flight context validation (check required vars exist) | 4 hr    | F-YAML-5 |
+| 24  | Support safe navigation in conditions (`strategy?.field`) | 1 week  | F-COND-3 |
+
+---
+
+## Key Files Referenced
+
+!!! note "Upstream File Paths"
+    The file paths below refer to the upstream Python amplihack repository.
+    amplihack-rs replaces the Python wrapper layer with native Rust execution in
+    `crates/amplihack-cli/src/commands/recipe/`.
+
+| Component                         | File                                                   |
+| --------------------------------- | ------------------------------------------------------ |
+| Public API                        | `src/amplihack/recipes/__init__.py`                    |
+| Rust runner wrapper               | `src/amplihack/recipes/rust_runner.py`                 |
+| Execution logic                   | `src/amplihack/recipes/rust_runner_execution.py`       |
+| Data models / Condition evaluator | `src/amplihack/recipes/models.py`                      |
+| Recipe parser                     | `src/amplihack/recipes/parser.py`                      |
+| Orchestrator helper               | `amplifier-bundle/tools/orch_helper.py`                |
+| Default workflow                  | `amplifier-bundle/recipes/default-workflow.yaml`       |
+| Smart orchestrator                | `amplifier-bundle/recipes/smart-orchestrator.yaml`     |
+| Investigation workflow            | `amplifier-bundle/recipes/investigation-workflow.yaml` |
+| Code atlas workflow               | `amplifier-bundle/recipes/code-atlas.yaml`             |
+| Simpleeval security tests         | `tests/gadugi/test_simpleeval_scenarios.py`            |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,7 +124,9 @@ nav:
       - JSON Logging: reference/json-logging.md
       - Benchmarking: reference/benchmarking.md
       - Recipe Quick Reference: reference/recipe-quick-reference.md
+      - Recipe Runner Audit: reference/recipe-runner-audit.md
       - Security API Reference: reference/security-api.md
+      - Git Utils API: reference/git-utils-api.md
       - Goal Agent Example Prompt: reference/goal-agent-example-prompt.md
       - Code Review Practices: reference/code-review.md
       - Prerequisites: reference/prerequisites.md
@@ -153,6 +155,7 @@ nav:
       - Goal Agent Generator: concepts/agent-generator.md
       - Hive Mind (Distributed): concepts/hive-mind-distributed.md
       - Agent Bundle Generator: concepts/agent-bundle-generator.md
+      - Blarify Architecture: concepts/blarify-architecture.md
       - Blarify Integration: concepts/blarify-integration.md
       - Worktree Support: concepts/worktree-support.md
       - Workspace Pattern: concepts/workspace-pattern.md


### PR DESCRIPTION
## Summary

- Port `docs/blarify_architecture.md` → `docs/concepts/blarify-architecture.md` (blarify + Kuzu architecture diagrams, adapted Neo4j refs to LadybugDB/Kuzu)
- Port `docs/git-utils-api.md` → `docs/reference/git-utils-api.md` (Python git_utils API reference with admonition noting Rust equivalent)
- Port `docs/audits/recipe-runner-quality-robustness-audit.md` → `docs/reference/recipe-runner-audit.md` (31-finding quality audit, recipe-runner-rs findings directly relevant)
- Updated mkdocs.yml nav entries in Concepts and Reference sections

This is PR 6 of 6 in wave 5 documentation parity.

Part of #420

## Test plan

- [x] `mkdocs build --strict` passes with no errors
- [x] Cross-references to existing docs verified (blarify-integration.md, blarify-quickstart.md, worktree-support.md, etc.)
- [x] All three files have HTML comment header and appropriate admonitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)