### PR TITLE
docs: improve Rust-specific adaptations in wave 5 ported docs

### DIFF
--- a/docs/howto/ladybug-migration-guide.md
+++ b/docs/howto/ladybug-migration-guide.md
@@ -75,11 +75,23 @@ neither package is installed, the import raises `ImportError`.
 
 ### 4. Verify
 
+**amplihack-rs** (Rust):
+
 ```bash
-# Quick smoke test
+# Run the Rust graph store tests
+cargo test --package amplihack-memory -- ladybug
+
+# Or run the full test suite
+cargo test
+```
+
+**Upstream Python** (reference only):
+
+```bash
+# Quick smoke test (upstream Python)
 python3 -c "from amplihack.memory.ladybug_store import KuzuGraphStore; print('OK')"
 
-# Run graph store tests
+# Run graph store tests (upstream Python)
 pytest tests/test_graph_store.py -q
 ```
 

--- a/docs/howto/migration-worktree-support.md
+++ b/docs/howto/migration-worktree-support.md
@@ -55,24 +55,12 @@ cargo install amplihack
 
 ### Step 3: Verify Installation
 
-!!! note "Upstream Python verification"
-    The verification script below uses the upstream Python `amplihack` API.
-    In amplihack-rs the worktree utilities are built into the Rust binary
-    and do not require a separate Python import.
-
 ```bash
-# Check git_utils module exists (upstream Python API)
-python3 << 'EOF'
-try:
-    from amplihack.tools.amplihack.git_utils import (
-        is_worktree,
-        get_common_git_dir,
-        find_disabled_file
-    )
-    print("git_utils module installed")
-except ImportError as e:
-    print(f"git_utils not found: {e}")
-EOF
+# Verify amplihack-rs is installed and working
+amplihack --version
+
+# Run the built-in diagnostic
+amplihack doctor
 ```
 
 ### Step 4: Migrate State (Automatic)

--- a/docs/howto/power-steering-worktree-troubleshooting.md
+++ b/docs/howto/power-steering-worktree-troubleshooting.md
@@ -4,77 +4,72 @@
 
 Practical guide for fixing common Power Steering issues in git worktree environments.
 
-!!! note "Upstream Python Implementation"
-    The diagnostic scripts in this document reference the upstream Python implementation
-    of amplihack. They are preserved here as reference material for understanding the
-    Power Steering architecture. The amplihack-rs Rust implementation may use different
-    internal paths and APIs.
+!!! warning "Use `amplihack doctor` for Diagnostics"
+    The preferred diagnostic tool for amplihack-rs is `amplihack doctor`, which
+    reports worktree status, state directory health, and .disabled file locations.
+    The bash scripts below provide manual equivalents for environments where the
+    binary is not available.
 
 ## Quick Diagnosis
 
-Run this diagnostic command to check your Power Steering configuration:
+Run the built-in diagnostic command:
 
 ```bash
-python3 << 'EOF'
-import os
-import subprocess
-from pathlib import Path
+amplihack doctor
+```
 
-print("=== Power Steering Worktree Diagnostic ===\n")
+If the `amplihack` binary is not available, use this manual diagnostic:
+
+```bash
+echo "=== Power Steering Worktree Diagnostic ==="
 
 # Check if in git repo
-try:
-    subprocess.check_output(["git", "rev-parse", "--git-dir"], stderr=subprocess.DEVNULL)
-    print("✓ Git repository detected")
-except:
-    print("✗ Not a git repository")
-    exit(1)
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "✗ Not a git repository"; exit 1
+fi
+echo "✓ Git repository detected"
 
 # Check worktree status
-common_dir = subprocess.check_output(
-    ["git", "rev-parse", "--git-common-dir"], text=True
-).strip()
-git_dir = subprocess.check_output(
-    ["git", "rev-parse", "--git-dir"], text=True
-).strip()
+COMMON_DIR="$(git rev-parse --git-common-dir)"
+GIT_DIR="$(git rev-parse --git-dir)"
+COMMON_ABS="$(cd "$COMMON_DIR" && pwd)"
+GIT_ABS="$(cd "$GIT_DIR" && pwd)"
 
-is_worktree = os.path.abspath(common_dir) != os.path.abspath(git_dir)
-print(f"Worktree: {'Yes' if is_worktree else 'No'}")
-print(f"Common dir: {common_dir}")
-print(f"Git dir: {git_dir}")
+if [ "$COMMON_ABS" != "$GIT_ABS" ]; then
+    echo "Worktree: Yes"
+else
+    echo "Worktree: No"
+fi
+echo "Common dir: $COMMON_DIR"
+echo "Git dir: $GIT_DIR"
 
 # Check state directory
-state_dir = Path(common_dir) / ".claude" / "runtime" / "power-steering"
-print(f"\nState directory: {state_dir}")
-print(f"Exists: {state_dir.exists()}")
+STATE_DIR="$COMMON_DIR/.claude/runtime/power-steering"
+echo ""
+echo "State directory: $STATE_DIR"
+echo "Exists: $([ -d "$STATE_DIR" ] && echo 'true' || echo 'false')"
 
-if state_dir.exists():
-    counter_file = state_dir / "workflow_classification_block_counter.json"
-    print(f"Counter file: {counter_file}")
-    print(f"Exists: {counter_file.exists()}")
-    if counter_file.exists():
-        import json
-        with open(counter_file) as f:
-            print(f"Counter data: {json.load(f)}")
+COUNTER_FILE="$STATE_DIR/workflow_classification_block_counter.json"
+if [ -f "$COUNTER_FILE" ]; then
+    echo "Counter file: $COUNTER_FILE"
+    echo "Counter data: $(cat "$COUNTER_FILE")"
+fi
 
 # Check .disabled file
-disabled_locations = [
-    Path(".disabled"),
-    Path(common_dir) / ".claude" / "runtime" / "power-steering" / ".disabled",
-    Path(subprocess.check_output(
-        ["git", "rev-parse", "--show-toplevel"], text=True
-    ).strip()) / ".disabled"
-]
+echo ""
+echo ".disabled file locations:"
+for LOC in ".disabled" \
+           "$COMMON_DIR/.claude/runtime/power-steering/.disabled" \
+           "$(git rev-parse --show-toplevel)/.disabled"; do
+    if [ -f "$LOC" ]; then
+        echo "  ✓ $LOC → Power Steering disabled via this file"
+    else
+        echo "  ✗ $LOC"
+    fi
+done
 
-print("\n.disabled file locations:")
-for loc in disabled_locations:
-    exists = loc.exists()
-    print(f"  {'✓' if exists else '✗'} {loc}")
-    if exists:
-        print(f"    → Power Steering disabled via this file")
-
-print("\n=== Diagnostic Complete ===")
-EOF
+echo ""
+echo "=== Diagnostic Complete ==="
 ```
 
 ## Common Issues
@@ -91,20 +86,10 @@ EOF
 
 ```bash
 # Check if state directory exists
-python3 << 'EOF'
-import os
-import subprocess
-from pathlib import Path
-
-common_dir = subprocess.check_output(
-    ["git", "rev-parse", "--git-common-dir"], text=True
-).strip()
-state_dir = Path(common_dir) / ".claude" / "runtime" / "power-steering"
-
-print(f"State directory: {state_dir}")
-print(f"Exists: {state_dir.exists()}")
-print(f"Writable: {state_dir.exists() and os.access(state_dir, os.W_OK)}")
-EOF
+STATE_DIR="$(git rev-parse --git-common-dir)/.claude/runtime/power-steering"
+echo "State directory: $STATE_DIR"
+echo "Exists: $([ -d "$STATE_DIR" ] && echo 'true' || echo 'false')"
+echo "Writable: $([ -d "$STATE_DIR" ] && [ -w "$STATE_DIR" ] && echo 'true' || echo 'false')"
 ```
 
 **Solution 1: Create State Directory**
@@ -147,26 +132,23 @@ rm "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/"*.lock
 
 **Diagnosis**:
 
-!!! note "Upstream Python API"
-    The following script uses `amplihack.tools.amplihack.git_utils` from the upstream
-    Python implementation. In amplihack-rs, equivalent functionality is provided by
-    the Rust crate internals.
-
 ```bash
-# Check which locations are being checked
-python3 << 'EOF'
-from amplihack.tools.amplihack.git_utils import find_disabled_file
-
-result = find_disabled_file()
-if result:
-    print(f"Found .disabled at: {result}")
-else:
-    print("No .disabled file found")
-    print("\nChecked locations:")
-    print("1. Current directory: ./.disabled")
-    print("2. Shared runtime: <common-dir>/.claude/runtime/power-steering/.disabled")
-    print("3. Project root: <root>/.disabled")
-EOF
+# Check which .disabled file locations exist
+COMMON_DIR="$(git rev-parse --git-common-dir)"
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+FOUND=0
+for LOC in ".disabled" \
+           "$COMMON_DIR/.claude/runtime/power-steering/.disabled" \
+           "$ROOT_DIR/.disabled"; do
+    if [ -f "$LOC" ]; then
+        echo "Found .disabled at: $LOC"
+        FOUND=1
+    fi
+done
+if [ "$FOUND" -eq 0 ]; then
+    echo "No .disabled file found"
+    echo "Checked: ./.disabled, $COMMON_DIR/.claude/runtime/power-steering/.disabled, $ROOT_DIR/.disabled"
+fi
 ```
 
 **Solution 1: Create in Correct Location**
@@ -305,27 +287,17 @@ Reset block counter to start fresh:
 rm "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/workflow_classification_block_counter.json"
 
 # Reset with confirmation
-python3 << 'EOF'
-import subprocess
-import json
-from pathlib import Path
-
-common_dir = subprocess.check_output(
-    ["git", "rev-parse", "--git-common-dir"], text=True
-).strip()
-counter_file = Path(common_dir) / ".claude" / "runtime" / "power-steering" / "workflow_classification_block_counter.json"
-
-if counter_file.exists():
-    with open(counter_file) as f:
-        current = json.load(f)
-    print(f"Current count: {current.get('count', 0)}")
-    response = input("Reset to 0? (y/n): ")
-    if response.lower() == 'y':
-        counter_file.unlink()
-        print("Counter reset")
-else:
-    print("No counter file found")
-EOF
+COUNTER="$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/workflow_classification_block_counter.json"
+if [ -f "$COUNTER" ]; then
+    echo "Current data: $(cat "$COUNTER")"
+    read -p "Reset to 0? (y/n): " REPLY
+    if [ "$REPLY" = "y" ]; then
+        rm "$COUNTER"
+        echo "Counter reset"
+    fi
+else
+    echo "No counter file found"
+fi
 ```
 
 ## Checking Shared State Location
@@ -334,41 +306,31 @@ Verify where Power Steering stores shared state:
 
 ```bash
 # Show state directory
-python3 << 'EOF'
-import subprocess
-from pathlib import Path
+STATE_DIR="$(git rev-parse --git-common-dir)/.claude/runtime/power-steering"
+echo "State directory: $STATE_DIR"
+echo "Full path: $(cd "$STATE_DIR" 2>/dev/null && pwd || echo '(does not exist)')"
 
-common_dir = subprocess.check_output(
-    ["git", "rev-parse", "--git-common-dir"], text=True
-).strip()
-state_dir = Path(common_dir) / ".claude" / "runtime" / "power-steering"
-
-print(f"State directory: {state_dir}")
-print(f"Full path: {state_dir.resolve()}")
-
-if state_dir.exists():
-    print("\nContents:")
-    for item in state_dir.iterdir():
-        print(f"  {item.name}")
-EOF
+if [ -d "$STATE_DIR" ]; then
+    echo ""
+    echo "Contents:"
+    ls -1 "$STATE_DIR"
+fi
 ```
 
 ## Verifying Worktree Detection
 
-!!! note "Upstream Python API"
-    The following script uses `amplihack.tools.amplihack.git_utils` from the upstream
-    Python implementation.
-
-Test if amplihack correctly detects worktrees:
+Test if the current directory is a git worktree:
 
 ```bash
 # Test worktree detection
-python3 << 'EOF'
-from amplihack.tools.amplihack.git_utils import is_worktree, get_common_git_dir
-
-print(f"Is worktree: {is_worktree()}")
-print(f"Common git dir: {get_common_git_dir()}")
-EOF
+COMMON_ABS="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
+GIT_ABS="$(cd "$(git rev-parse --git-dir)" && pwd)"
+if [ "$COMMON_ABS" != "$GIT_ABS" ]; then
+    echo "Is worktree: true"
+else
+    echo "Is worktree: false"
+fi
+echo "Common git dir: $COMMON_ABS"
 ```
 
 ## Debugging Classification Blocks
@@ -388,104 +350,78 @@ tail -f ~/.claude/runtime/logs/power-steering-*.log
 
 ## Test Power Steering After Fixes
 
-!!! note "Upstream Python API"
-    The following test scripts use `amplihack.tools.amplihack.git_utils` from the
-    upstream Python implementation.
-
 Verify Power Steering works correctly:
 
 ```bash
 # Test 1: Counter persistence
-python3 << 'EOF'
-from amplihack.tools.amplihack.git_utils import get_common_git_dir
-from pathlib import Path
-import json
-
-common_dir = get_common_git_dir()
-counter_file = Path(common_dir) / ".claude" / "runtime" / "power-steering" / "workflow_classification_block_counter.json"
-
-# Write test counter
-counter_file.parent.mkdir(parents=True, exist_ok=True)
-counter_file.write_text(json.dumps({"count": 5}))
-
-# Read back
-data = json.loads(counter_file.read_text())
-assert data["count"] == 5, "Counter not persisted"
-print("✓ Counter persistence works")
-EOF
+STATE_DIR="$(git rev-parse --git-common-dir)/.claude/runtime/power-steering"
+mkdir -p "$STATE_DIR"
+echo '{"count": 5}' > "$STATE_DIR/workflow_classification_block_counter.json"
+READBACK="$(cat "$STATE_DIR/workflow_classification_block_counter.json")"
+echo "$READBACK" | grep -q '"count": 5' && echo "✓ Counter persistence works" || echo "✗ Counter not persisted"
 
 # Test 2: .disabled detection
-touch "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
-python3 << 'EOF'
-from amplihack.tools.amplihack.git_utils import find_disabled_file
-assert find_disabled_file() is not None, ".disabled not detected"
-print("✓ .disabled detection works")
-EOF
-rm "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+touch "$STATE_DIR/.disabled"
+[ -f "$STATE_DIR/.disabled" ] && echo "✓ .disabled detection works" || echo "✗ .disabled not detected"
+rm "$STATE_DIR/.disabled"
 
 # Test 3: Worktree detection
-python3 << 'EOF'
-from amplihack.tools.amplihack.git_utils import is_worktree
-print(f"✓ Worktree detection: {is_worktree()}")
-EOF
+COMMON_ABS="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
+GIT_ABS="$(cd "$(git rev-parse --git-dir)" && pwd)"
+if [ "$COMMON_ABS" != "$GIT_ABS" ]; then
+    echo "✓ Worktree detection: true"
+else
+    echo "✓ Worktree detection: false (standard repo)"
+fi
 ```
 
 ## Reporting Issues
 
 When filing issues, include this diagnostic output:
 
-!!! note "Upstream Python API"
-    The following diagnostic script uses `amplihack.tools.amplihack.git_utils` from
-    the upstream Python implementation. For amplihack-rs, include output from
-    `amplihack doctor` instead.
-
 ```bash
-# Collect diagnostic information
-python3 << 'EOF' > /tmp/power-steering-diagnostic.txt
-import os
-import subprocess
-import json
-from pathlib import Path
+# Preferred: use amplihack doctor
+amplihack doctor > /tmp/power-steering-diagnostic.txt 2>&1
 
-print("=== Power Steering Diagnostic Report ===\n")
+# Fallback: manual bash diagnostic
+{
+echo "=== Power Steering Diagnostic Report ==="
+echo ""
+echo "Git Configuration:"
+echo "  Common dir: $(git rev-parse --git-common-dir)"
+echo "  Git dir: $(git rev-parse --git-dir)"
+echo "  Root: $(git rev-parse --show-toplevel)"
 
-# Git info
-print("Git Configuration:")
-print(f"  Common dir: {subprocess.check_output(['git', 'rev-parse', '--git-common-dir'], text=True).strip()}")
-print(f"  Git dir: {subprocess.check_output(['git', 'rev-parse', '--git-dir'], text=True).strip()}")
-print(f"  Root: {subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], text=True).strip()}")
+COMMON_ABS="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
+GIT_ABS="$(cd "$(git rev-parse --git-dir)" && pwd)"
+echo ""
+echo "Worktree Status:"
+[ "$COMMON_ABS" != "$GIT_ABS" ] && echo "  Is worktree: true" || echo "  Is worktree: false"
+echo "  Common dir: $COMMON_ABS"
 
-# Worktree status
-from amplihack.tools.amplihack.git_utils import is_worktree, get_common_git_dir
-print(f"\nWorktree Status:")
-print(f"  Is worktree: {is_worktree()}")
-print(f"  Common dir: {get_common_git_dir()}")
+STATE_DIR="$COMMON_ABS/.claude/runtime/power-steering"
+echo ""
+echo "State Directory:"
+echo "  Path: $STATE_DIR"
+echo "  Exists: $([ -d "$STATE_DIR" ] && echo 'true' || echo 'false')"
+echo "  Writable: $([ -d "$STATE_DIR" ] && [ -w "$STATE_DIR" ] && echo 'true' || echo 'false')"
 
-# State directory
-state_dir = Path(get_common_git_dir()) / ".claude" / "runtime" / "power-steering"
-print(f"\nState Directory:")
-print(f"  Path: {state_dir}")
-print(f"  Exists: {state_dir.exists()}")
-print(f"  Writable: {state_dir.exists() and os.access(state_dir, os.W_OK)}")
+COUNTER="$STATE_DIR/workflow_classification_block_counter.json"
+echo ""
+echo "Counter File:"
+echo "  Path: $COUNTER"
+echo "  Exists: $([ -f "$COUNTER" ] && echo 'true' || echo 'false')"
+[ -f "$COUNTER" ] && echo "  Contents: $(cat "$COUNTER")"
 
-# Counter file
-counter_file = state_dir / "workflow_classification_block_counter.json"
-print(f"\nCounter File:")
-print(f"  Path: {counter_file}")
-print(f"  Exists: {counter_file.exists()}")
-if counter_file.exists():
-    print(f"  Contents: {counter_file.read_text()}")
+echo ""
+echo ".disabled File:"
+for LOC in ".disabled" "$STATE_DIR/.disabled" "$(git rev-parse --show-toplevel)/.disabled"; do
+    [ -f "$LOC" ] && echo "  Found: $LOC"
+done
 
-# .disabled file
-from amplihack.tools.amplihack.git_utils import find_disabled_file
-disabled = find_disabled_file()
-print(f"\n.disabled File:")
-print(f"  Found: {disabled is not None}")
-if disabled:
-    print(f"  Location: {disabled}")
-
-print("\n=== End Diagnostic Report ===")
-EOF
+echo ""
+echo "=== End Diagnostic Report ==="
+} > /tmp/power-steering-diagnostic.txt
 
 cat /tmp/power-steering-diagnostic.txt
 ```

--- a/docs/reference/copilot-cli.md
+++ b/docs/reference/copilot-cli.md
@@ -439,10 +439,10 @@ gh copilot suggest --context .github/commands/analyze.md \
 
 Each hook is a **bash wrapper** that calls a **Python implementation**:
 
-!!! note "Upstream Python Implementation"
-    The hook examples below show the upstream Python implementation pattern.
-    amplihack-rs uses Rust-native hooks where applicable. See
-    [hook specifications](hook-specifications.md) and
+!!! note "Upstream Python hook pattern"
+    The bash+Python hook implementation below describes the **upstream Python
+    amplihack** pattern. amplihack-rs uses Rust-native hooks where applicable.
+    See [hook specifications](hook-specifications.md) and
     [configure hooks](../howto/configure-hooks.md) for the Rust approach.
 
 **Bash Wrapper** (`.github/hooks/pre-commit`):
@@ -1034,6 +1034,11 @@ amplihack install
 ```
 
 ## Testing
+
+!!! note "Upstream Python test commands"
+    The `pytest` commands in the Copilot CLI Transcript Support section above
+    reference the upstream Python test suite. For amplihack-rs, use `cargo test`
+    to run the Rust test suite.
 
 ### Running Tests
 

--- a/docs/reference/git-utils-api.md
+++ b/docs/reference/git-utils-api.md
@@ -2,12 +2,30 @@
 
 # Git Utilities API Reference
 
-!!! note "Upstream Python API Reference"
+!!! warning "Not Directly Callable in amplihack-rs"
     This document describes the upstream Python `amplihack.tools.amplihack.git_utils`
-    module. amplihack-rs implements equivalent functionality in Rust (see
-    `crates/amplihack-cli/src/git/`). The function signatures, behaviors, and
-    patterns documented here serve as the reference specification for the Rust
-    implementation.
+    module. **Python imports shown below do not work in amplihack-rs.** The Rust
+    implementation lives in `crates/amplihack-cli/src/git/` and is accessed via
+    the `amplihack doctor` CLI command or the Rust API directly.
+
+## Rust Equivalents
+
+amplihack-rs provides equivalent functionality through native Rust functions:
+
+```rust
+// crates/amplihack-cli/src/git/worktree.rs
+pub fn is_worktree(cwd: Option<&Path>) -> Result<bool>;
+pub fn get_common_git_dir(cwd: Option<&Path>) -> Result<PathBuf>;
+pub fn find_disabled_file(cwd: Option<&Path>) -> Result<Option<PathBuf>>;
+```
+
+Access via CLI:
+
+```bash
+amplihack doctor          # Reports worktree status, state dir, .disabled files
+```
+
+## Upstream Python API (Reference Specification)
 
 Technical documentation for `amplihack.tools.amplihack.git_utils` module providing git worktree detection and shared directory utilities.
 
@@ -17,9 +35,12 @@ The `git_utils` module provides utilities for detecting git worktrees and findin
 
 ## Installation
 
-The module is included in amplihack core:
+!!! note "Upstream Python imports — not available in amplihack-rs"
+
+The module is included in upstream amplihack core:
 
 ```python
+# Upstream Python signature — Rust equivalent: git::is_worktree()
 from amplihack.tools.amplihack.git_utils import (
     is_worktree,
     get_common_git_dir,
@@ -32,6 +53,7 @@ from amplihack.tools.amplihack.git_utils import (
 ### is_worktree
 
 ```python
+# Upstream Python signature — Rust equivalent: git::is_worktree()
 def is_worktree(cwd: Optional[str] = None) -> bool
 ```
 
@@ -79,6 +101,7 @@ is_worktree("/root/restricted")  # Returns False
 ### get_common_git_dir
 
 ```python
+# Upstream Python signature — Rust equivalent: git::get_common_git_dir()
 def get_common_git_dir(cwd: Optional[str] = None) -> str
 ```
 
@@ -141,6 +164,7 @@ except subprocess.CalledProcessError:
 ### find_disabled_file
 
 ```python
+# Upstream Python signature — Rust equivalent: git::find_disabled_file()
 def find_disabled_file(cwd: Optional[str] = None) -> Optional[str]
 ```
 


### PR DESCRIPTION
## Summary

- Replace Python diagnostic scripts with bash equivalents in `power-steering-worktree-troubleshooting.md`
- Add `amplihack doctor` as the preferred diagnostic tool throughout worktree docs
- Add Rust equivalent function signatures (`git::is_worktree()`, etc.) to `git-utils-api.md`
- Upgrade Python API admonitions from `note` to `warning` in high-severity files
- Split verification steps into amplihack-rs (cargo test) and upstream Python (reference only) in `ladybug-migration-guide.md`
- Replace Python verification with `amplihack --version` / `amplihack doctor` in `migration-worktree-support.md`
- Add upstream Python hook pattern admonitions in `copilot-cli.md`

Ref: #420 (wave 5 quality pass)

## Test plan

- [x] `mkdocs build --strict` passes clean
- [ ] CI green
- [ ] No internal link breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)