### PR TITLE
docs: port Document-Driven Development docs (wave 6, group 1) #420

### DIFF
--- a/docs/document_driven_development/README.md
+++ b/docs/document_driven_development/README.md
@@ -1,0 +1,252 @@
+# Document-Driven Development (DDD)
+
+> [Home](../index.md) > Document-Driven Development
+
+**A systematic approach to building software where documentation leads, code follows, and AI assistance is maximized.**
+
+---
+
+## Quick Start
+
+**New to DDD?** Start here:
+
+1. [Overview](overview.md) - What is DDD and why use it
+2. [Core Concepts](core_concepts/) - Essential techniques
+3. [The Process](phases/) - Step-by-step phases
+4. [Reference](reference/) - Checklists and tips
+
+---
+
+## Using DDD with Slash Commands
+
+**The easiest way to execute the DDD workflow** is through numbered slash commands in Claude Code:
+
+```bash
+/ddd:0-help         # Complete guide and help
+/ddd:1-plan         # Phase 1: Planning & Design
+/ddd:2-docs         # Phase 2: Update All Non-Code Files
+/ddd:3-code-plan    # Phase 3: Plan Code Changes
+/ddd:4-code         # Phase 4: Implement & Verify
+/ddd:5-finish       # Phase 5: Wrap-Up & Cleanup
+
+# Utilities
+/ddd:prime          # Load all DDD context
+/ddd:status         # Check current progress
+```
+
+**Key Features**:
+
+- **Numbered for easy sequential use** - Just follow 1→2→3→4→5
+- **Stateful with artifacts** - Each phase creates files the next phase reads
+- **Optional arguments** - Run without args if continuing from previous phase
+- **Explicit authorization** - NO auto-commits, you control all git operations
+- **Iteration support** - Phases 2 and 4 stay active for back-and-forth until you're satisfied
+
+**Example Usage**:
+
+```bash
+# Start a new feature
+/ddd:1-plan Add JWT authentication with refresh tokens
+
+# Update docs (iterate until approved, then commit yourself)
+/ddd:2-docs
+
+# Plan code changes (review and approve)
+/ddd:3-code-plan
+
+# Implement and test (iterate until working)
+/ddd:4-code
+
+# Clean up and finalize
+/ddd:5-finish
+```
+
+All commands include comprehensive help and guide you through each phase. Run `/ddd:0-help` for complete documentation.
+
+---
+
+## Core Principle
+
+**"Documentation IS the specification. Code implements what documentation describes."**
+
+Traditional approach: Code → Docs (docs lag and drift, context poisoning)
+DDD approach: **Docs → Approval → Implementation** (docs lead, code follows, perfect sync)
+
+---
+
+## Philosophy Foundation
+
+Document-Driven Development builds on:
+
+- [PHILOSOPHY.md](../concepts/philosophy.md) - Ruthless simplicity and modular design principles
+
+Read this first to understand the underlying principles.
+
+---
+
+## The Process Flow
+
+```
+Phase 0: Planning & Alignment
+    ↓
+Phase 1: Documentation Retcon  ←─┐
+    ↓                             │
+Phase 2: Approval Gate            │ (iterate if needed)
+    ↓                             │
+    ├─────────────────────────────┘
+    ↓
+Phase 3: Implementation Planning
+    ↓
+Phase 4: Code Implementation
+    ↓
+Phase 5: Testing & Verification
+    ↓
+Phase 6: Cleanup & Push
+```
+
+---
+
+## Documentation Structure
+
+### [Overview](overview.md)
+
+What DDD is, why it works, and when to use it.
+
+### [Core Concepts](core_concepts/)
+
+Essential techniques used throughout the process:
+
+- [File Crawling](core_concepts/file_crawling.md) - Systematic file processing without context overload
+- [Context Poisoning](core_concepts/context_poisoning.md) - Understanding and preventing inconsistent information
+- [Retcon Writing](core_concepts/retcon_writing.md) - Writing docs as if feature already exists
+
+### [Phases](phases/)
+
+Detailed guides for each phase:
+
+- [Phase 0: Planning & Alignment](phases/00_planning_and_alignment.md)
+- [Phase 1: Documentation Retcon](phases/01_documentation_retcon.md)
+- [Phase 2: Approval Gate](phases/02_approval_gate.md)
+- [Phase 3: Implementation Planning](phases/03_implementation_planning.md)
+- [Phase 4: Code Implementation](phases/04_code_implementation.md)
+- [Phase 5: Testing & Verification](phases/05_testing_and_verification.md)
+- [Phase 6: Cleanup & Push](phases/06_cleanup_and_push.md)
+
+### [Reference](reference/)
+
+Practical resources:
+
+- [Checklists](reference/checklists.md) - Phase-by-phase verification checklists
+- [Tips for Success](reference/tips_for_success.md) - Best practices for humans and AI
+- [Common Pitfalls](reference/common_pitfalls.md) - What goes wrong and how to fix it
+- [FAQ](reference/faq.md) - Frequently asked questions
+
+---
+
+## Quick Reference
+
+### For AI Assistants
+
+**When starting a DDD cycle:**
+
+1. Load [overview.md](overview.md) to understand the process
+2. Load relevant phase docs as you work through each phase
+3. Reference [core concepts](core_concepts/) when using those techniques
+4. Use [checklists](reference/checklists.md) to verify completion
+
+**For specific modes:**
+
+- **Documentation Mode**: Load Phase 0, 1, 2 + file_crawling + context_poisoning + retcon_writing
+- **Implementation Mode**: Load Phase 3, 4, 5 + file_crawling
+- **Review Mode**: Load Phase 2, 5 + checklists
+
+### For Humans
+
+**Learning DDD:**
+
+1. Read [overview](overview.md) to understand the approach
+2. Skim [core concepts](core_concepts/) to know the techniques
+3. Refer to [phases](phases/) as you work through a cycle
+4. Use [reference](reference/) materials when needed
+
+**Using DDD:**
+
+- Follow [checklists](reference/checklists.md) to ensure nothing missed
+- Review [common pitfalls](reference/common_pitfalls.md) to avoid known issues
+- Check [FAQ](reference/faq.md) when questions arise
+
+---
+
+## Why Modular Structure?
+
+This documentation follows the same principles it teaches:
+
+**Maximum DRY**: Each concept lives in ONE place
+
+- File crawling technique: [core_concepts/file_crawling.md](core_concepts/file_crawling.md)
+- Context poisoning: [core_concepts/context_poisoning.md](core_concepts/context_poisoning.md)
+- Phase-specific guidance: [phases/](phases/)
+
+**Progressive Organization**: Start simple, drill down as needed
+
+- Overview → Core concepts → Detailed phases → Reference
+
+**Right-Sized Modules**: Each doc fits in context window
+
+- Typical doc: 200-400 lines
+- Self-contained but cross-referenced
+- Can be loaded selectively
+
+**AI-Optimized**: Load only what's needed for current mode
+
+- Documentation mode: Load docs about documentation phases
+- Implementation mode: Load docs about implementation phases
+- Review mode: Load docs about review and testing
+
+---
+
+## When to Use DDD
+
+✅ **Use DDD for:**
+
+- New features requiring multiple files
+- System redesigns or refactoring
+- API changes affecting documentation
+- Any change touching 10+ files
+- Cross-cutting concerns
+
+❌ **Don't use DDD for:**
+
+- Simple typo fixes
+- Single-file bug fixes
+- Emergency hotfixes
+- Trivial updates
+
+Use judgment: Lean toward DDD when uncertain. Process prevents expensive mistakes.
+
+---
+
+## Success Metrics
+
+You're doing DDD well when:
+
+- ✅ Documentation and code never diverge
+- ✅ Zero context poisoning incidents
+- ✅ Changes require minimal rework
+- ✅ AI tools make correct decisions
+- ✅ New developers understand from docs alone
+- ✅ Examples in docs all work
+
+---
+
+## Related Documentation
+
+**Philosophy:**
+
+- [PHILOSOPHY.md](../concepts/philosophy.md) - Ruthless simplicity and modular design principles
+
+---
+
+**Document Version**: 2.0
+**Last Updated**: 2025-10-25
+**Ported From**: microsoft/amplifier Document-Driven Development methodology

--- a/docs/document_driven_development/core_concepts/README.md
+++ b/docs/document_driven_development/core_concepts/README.md
@@ -1,0 +1,91 @@
+# Core Concepts
+
+**Essential techniques used throughout Document-Driven Development**
+
+---
+
+## Overview
+
+These core concepts are used repeatedly throughout the DDD process. Understanding them is essential for success.
+
+---
+
+## The Three Core Concepts
+
+### [File Crawling](file_crawling.md)
+
+**What**: Systematic processing of many files without context overload
+
+**Why**: AI cannot hold all files in context at once. File crawling provides external index + sequential processing.
+
+**When**: Processing 10+ files, documentation updates, code changes across modules
+
+**Key benefit**: 99.5% token reduction, guarantees every file processed
+
+### [Context Poisoning](context_poisoning.md)
+
+**What**: When AI loads inconsistent information leading to wrong decisions
+
+**Why**: Duplicate/stale/conflicting docs mislead AI tools
+
+**When**: Monitor always, prevent proactively, resolve when detected
+
+**Key benefit**: Eliminates root cause of AI making wrong decisions confidently
+
+### [Retcon Writing](retcon_writing.md)
+
+**What**: Writing documentation as if the feature already exists
+
+**Why**: Eliminates ambiguity about what's current vs future vs historical
+
+**When**: Phase 1 (Documentation Retcon), any doc updates
+
+**Key benefit**: Clear, unambiguous specifications for both humans and AI
+
+---
+
+## How They Work Together
+
+**File Crawling** enables systematic processing:
+
+- Prevents forgetting files
+- Efficient token usage
+- Clear progress tracking
+
+**Context Poisoning** prevention maintains quality:
+
+- Each concept in ONE place
+- No duplicate information
+- Always current, never stale
+
+**Retcon Writing** ensures clarity:
+
+- Write as if already implemented
+- No historical references
+- Single timeline (now)
+
+**Together**: Process many files systematically while preventing inconsistency and maintaining clarity.
+
+---
+
+## Quick Reference
+
+**For AI Assistants**:
+
+- Use file crawling for any 10+ file operation
+- Check for context poisoning when loading multiple sources
+- Apply retcon writing rules when updating docs
+
+**For Humans**:
+
+- File crawling: External checklist, process one at a time
+- Context poisoning: Delete duplicates, single source of truth
+- Retcon: Write present tense, as if already exists
+
+---
+
+## Related Documentation
+
+**Process**: [Phases](../phases/) - Where these concepts are applied
+**Reference**: [Checklists](../reference/checklists.md) - Verification steps
+**Return to**: [Main Index](../README.md)

--- a/docs/document_driven_development/core_concepts/context_poisoning.md
+++ b/docs/document_driven_development/core_concepts/context_poisoning.md
@@ -1,0 +1,512 @@
+# Context Poisoning
+
+**Understanding and preventing inconsistent information that misleads AI tools**
+
+---
+
+## What is Context Poisoning?
+
+**Context poisoning** occurs when AI tools load inconsistent or conflicting information from the codebase, leading to wrong decisions and implementations.
+
+**Metaphor**: Imagine a chef following multiple recipes for the same dish that contradict each other on ingredients and temperatures. The dish will fail. Same with code - AI following contradictory "recipes" (documentation) produces broken implementations.
+
+---
+
+## Why It's Critical
+
+When AI tools load context for a task, they may:
+
+- Load stale doc instead of current one
+- Load conflicting docs and guess wrong
+- Not know which source is authoritative
+- Combine information incorrectly
+- Make wrong decisions confidently
+
+**Real-world impact**:
+
+- Wasted hours implementing wrong design
+- Bugs from mixing incompatible approaches
+- Rework when conflicts discovered later
+- User confusion when docs contradict
+- Loss of trust in documentation
+
+---
+
+## Common Sources
+
+### 1. Duplicate Documentation
+
+Same concept described differently in multiple files
+
+**Example**:
+
+- `docs/USER_GUIDE.md`: "Workflows configure your environment"
+- `docs/API.md`: "Profiles define capability sets"
+
+**Impact**: AI doesn't know if "workflow" == "profile" or they're different
+
+### 2. Stale Documentation
+
+Docs don't match current code
+
+**Example**:
+
+- Docs: "Use `amplifier setup` to configure"
+- Code: Only `amplifier init` works
+
+**Impact**: AI generates code using removed command
+
+### 3. Inconsistent Terminology
+
+Multiple terms for same concept
+
+**Example**:
+
+- README: "workflow"
+- USER_GUIDE: "profile"
+- API: "capability set"
+
+**Impact**: AI confused about canonical term
+
+### 4. Partial Updates
+
+Updated some files but not others
+
+**Example**:
+
+- Updated README with new flags (`--model`)
+- Forgot to update COMMAND_REFERENCE
+- COMMAND_REFERENCE now has wrong syntax
+
+**Impact**: AI uses outdated syntax from COMMAND_REFERENCE
+
+### 5. Historical References
+
+Old approaches mentioned alongside new
+
+**Example**:
+
+```markdown
+Previously, use `setup`. Now use `init`.
+For now, both work.
+```
+
+**Impact**: AI implements BOTH, doesn't know which is current
+
+---
+
+## Real Example from Practice
+
+**Context poisoning caught live during development**:
+
+### What Happened
+
+1. Created `docs/COMMAND_REFERENCE.md` with command syntax
+2. Updated `README.md` with new provider-specific flags (`--model`, `--deployment`)
+3. `COMMAND_REFERENCE.md` now out of sync - doesn't show new flags
+4. Future AI loads outdated syntax from `COMMAND_REFERENCE.md`
+5. AI generates code using old syntax without required flags
+
+### The Cost
+
+- Bugs in generated code
+- User confusion (docs say one thing, code requires another)
+- Rework needed to fix
+- Lost trust in documentation
+
+### The Fix
+
+- **Deleted** `COMMAND_REFERENCE.md` entirely
+- Moved unique content to `USER_ONBOARDING.md#quick-reference`
+- Single source of truth restored
+
+### The Lesson
+
+**Even small duplication causes immediate problems. If file exists, it will drift.**
+
+---
+
+## Types of Context Poisoning
+
+### Type 1: Terminology Conflicts
+
+```markdown
+# docs/USER_GUIDE.md
+
+Use workflows to configure environment.
+Run: amplifier workflow apply dev
+
+# docs/API.md
+
+Profiles define capability sets.
+Run: amplifier profile use dev
+
+# POISON: Are "workflow" and "profile" the same? Different?
+```
+
+### Type 2: Behavioral Conflicts
+
+```markdown
+# docs/USER_GUIDE.md
+
+The --model flag is optional. Defaults to claude-sonnet-4-5.
+
+# docs/API.md
+
+The --model flag is required. Command fails without it.
+
+# POISON: Is --model required or optional?
+```
+
+### Type 3: Example Conflicts
+
+```markdown
+# README.md
+
+amplifier provider use anthropic
+
+# docs/USER_GUIDE.md
+
+amplifier provider use anthropic --model claude-opus-4
+
+# POISON: Which example is correct?
+```
+
+### Type 4: Historical References
+
+```markdown
+# docs/MIGRATION.md
+
+Previously, use `amplifier setup`.
+Now, use `amplifier init` instead.
+The old `setup` command still works.
+
+# POISON: Should AI implement setup, init, or both?
+```
+
+### Type 5: Scope Conflicts
+
+```markdown
+# docs/ARCHITECTURE.md
+
+Provider configuration is immutable per session.
+
+# docs/USER_GUIDE.md
+
+Use --local flag to override provider per project.
+
+# POISON: Is provider immutable or overridable?
+```
+
+---
+
+## Prevention Strategies
+
+### 1. Maximum DRY (Don't Repeat Yourself)
+
+**Rule**: Each concept lives in exactly ONE place.
+
+**Good organization**:
+
+- ✅ Command syntax → `docs/USER_ONBOARDING.md#quick-reference`
+- ✅ Architecture → `docs/ARCHITECTURE.md`
+- ✅ API reference → `docs/API.md`
+
+**Cross-reference, don't duplicate**:
+
+```markdown
+For command syntax, see [USER_ONBOARDING.md#quick-reference](...)
+
+NOT: Duplicating all command syntax inline
+```
+
+### 2. Aggressive Deletion
+
+When you find duplication:
+
+1. Identify which doc is canonical
+2. **Delete** the duplicate entirely (don't update it)
+3. Update cross-references to canonical source
+
+**Why delete vs. update?**
+
+- Prevents future divergence
+- If it exists, it will drift
+- Deletion is permanent elimination
+
+**Example**:
+
+```bash
+# Found duplication: COMMAND_GUIDE.md duplicates USER_ONBOARDING.md
+
+# Delete duplicate
+rm docs/COMMAND_GUIDE.md
+
+# Update cross-references
+sed -i 's/COMMAND_GUIDE\.md/USER_ONBOARDING.md#commands/g' docs/*.md
+
+# Verify gone
+grep -r "COMMAND_GUIDE" docs/  # Should find nothing
+```
+
+### 3. Retcon, Don't Evolve
+
+**BAD** (creates poison):
+
+```markdown
+Previously, use `amplifier setup`.
+As of version 2.0, use `amplifier init`.
+In future, `setup` will be removed.
+For now, both work.
+```
+
+**GOOD** (clean retcon):
+
+````markdown
+## Provider Configuration
+
+Configure your provider:
+
+```bash
+amplifier init
+```
+````
+
+Historical info belongs in git history and CHANGELOG, not docs.
+
+See [Retcon Writing](retcon_writing.md) for details.
+
+### 4. Systematic Global Updates
+
+When terminology changes:
+
+```bash
+# 1. Global replace (first pass only)
+find docs/ -name "*.md" -exec sed -i 's/\bworkflow\b/profile/g' {} +
+
+# 2. STILL review each file individually
+# Global replace is helper, not solution
+
+# 3. Verify
+grep -rn "\bworkflow\b" docs/  # Should be zero or intentional
+
+# 4. Commit together
+git commit -am "docs: Standardize terminology: workflow → profile"
+```
+
+### 5. Catch During File Processing
+
+When using [file crawling](file_crawling.md), check each file for conflicts.
+
+**If detected**: PAUSE, collect all instances, ask human for resolution.
+
+See [Phase 1: Step 6](../phases/01_documentation_retcon.md#step-6-detecting-and-resolving-conflicts) for details.
+
+---
+
+## Detection and Resolution
+
+### During Documentation Phase
+
+**Watch for**:
+
+- Conflicting definitions
+- Duplicate content
+- Inconsistent examples
+- Historical baggage
+
+**Action**: PAUSE, collect all instances, get human guidance
+
+### During Implementation Phase
+
+**Watch for AI saying**:
+
+- "I see from COMMAND_REFERENCE.md that..." (when that file was deleted)
+- "According to the old approach..." (no old approaches should be documented)
+- "Both X and Y are valid..." (when only Y should be documented)
+- "The docs are inconsistent about..." (PAUSE, fix docs)
+
+**Action**: PAUSE immediately, document conflict, ask user
+
+### Resolution Pattern
+
+```markdown
+# CONFLICT DETECTED - User guidance needed
+
+## Issue
+
+[Describe what conflicts]
+
+## Instances
+
+1. file1.md:42: says X
+2. file2.md:15: says Y
+3. file3.md:8: says Z
+
+## Analysis
+
+[What's most common, what matches code, etc.]
+
+## Suggested Resolutions
+
+Option A: [description]
+
+- Pro: [benefits]
+- Con: [drawbacks]
+
+Option B: [description]
+
+- Pro: [benefits]
+- Con: [drawbacks]
+
+## Recommendation
+
+[AI's suggestion with reasoning]
+
+Please advise which resolution to apply.
+```
+
+**Wait for human decision**, then apply systematically.
+
+---
+
+## Prevention Checklist
+
+Before committing any documentation:
+
+- [ ] No duplicate concepts across files
+- [ ] Consistent terminology throughout
+- [ ] No historical references (use retcon)
+- [ ] All cross-references point to existing content
+- [ ] Each doc has clear, non-overlapping scope
+- [ ] Examples all work (test them)
+- [ ] No "old way" and "new way" both shown
+- [ ] Version numbers removed (docs always current)
+
+---
+
+## Measuring Context Poisoning
+
+### Healthy Codebase (No Poisoning)
+
+✅ `grep -r "duplicate-term" docs/` returns single canonical location
+✅ AI tools make correct assumptions consistently
+✅ New contributors understand system from docs alone
+✅ Examples all work when copy-pasted
+✅ No "which docs are current?" questions
+
+### Warning Signs (Poisoning Present)
+
+❌ Multiple files define same concept
+❌ AI implements wrong approach confidently
+❌ Contributors ask "which is right?"
+❌ Examples don't work
+❌ Frequent questions about terminology
+
+---
+
+## Real-World Examples
+
+### Example 1: Command Reference Duplication
+
+**Setup**:
+
+- Created COMMAND_REFERENCE.md with all command syntax
+- README.md also documents commands
+
+**What happened**:
+
+- Updated README with new flags
+- Forgot COMMAND_REFERENCE
+- Future AI loaded COMMAND_REFERENCE (wrong syntax)
+
+**Fix**: Deleted COMMAND_REFERENCE entirely
+
+### Example 2: Terminology Inconsistency
+
+**Setup**:
+
+- Some docs say "workflow"
+- Some docs say "profile"
+- Some docs say "capability set"
+
+**What happened**:
+
+- AI confused about canonical term
+- Generated code mixing terms
+- User confused reading docs
+
+**Fix**: Chose "profile" as canonical, global replace + individual review
+
+### Example 3: Historical References
+
+**Setup**:
+
+- Docs mentioned both old `setup` and new `init` commands
+- Said "both work for now"
+
+**What happened**:
+
+- AI implemented both commands
+- Maintained old approach unnecessarily
+- More code to maintain
+
+**Fix**: Retconned docs to show only `init`, removed historical references
+
+---
+
+## Quick Reference
+
+### Detection
+
+**Ask yourself**:
+
+- Can same information be found in multiple places?
+- Are there multiple terms for same concept?
+- Do docs reference "old" vs "new" approaches?
+- Do examples conflict with each other?
+
+**If yes to any**: Context poisoning present
+
+### Prevention
+
+**Core rules**:
+
+1. Each concept in ONE place only
+2. Delete duplicates (don't update)
+3. Use retcon (not evolution)
+4. Consistent terminology everywhere
+5. Test all examples work
+
+### Resolution
+
+**When detected**:
+
+1. PAUSE all work
+2. Collect all instances
+3. Present to human with options
+4. Wait for decision
+5. Apply resolution systematically
+6. Verify with grep
+
+---
+
+## Integration with DDD
+
+Context poisoning prevention is built into every phase:
+
+- **[Phase 0](../phases/00_planning_and_alignment.md)**: Check docs during reconnaissance
+- **[Phase 1](../phases/01_documentation_retcon.md)**: Enforce maximum DRY
+- **[Phase 2](../phases/02_approval_gate.md)**: Human catches inconsistencies
+- **[Phase 4](../phases/04_code_implementation.md)**: Pause when docs conflict
+- **[Phase 5](../phases/05_testing_and_verification.md)**: Examples reveal conflicts
+
+**Result**: Context poisoning prevented by design, not by luck.
+
+---
+
+**Return to**: [Core Concepts](README.md) | [Main Index](../README.md)
+
+**Related**: [File Crawling](file_crawling.md) | [Retcon Writing](retcon_writing.md)
+
+**See Also**: [Phase 1 Step 4](../phases/01_documentation_retcon.md#step-4-maximum-dry-enforcement)

--- a/docs/document_driven_development/core_concepts/file_crawling.md
+++ b/docs/document_driven_development/core_concepts/file_crawling.md
@@ -1,0 +1,299 @@
+# File Crawling Technique
+
+**Systematic processing of many files without context overload**
+
+---
+
+## What is File Crawling?
+
+File crawling is a technique for processing large numbers of files systematically using an external index and sequential processing. It solves the fundamental problem that AI cannot hold all files in context at once.
+
+**Core pattern**: External checklist → Process one file → Mark complete → Repeat
+
+---
+
+## The Problem It Solves
+
+### AI Limitations
+
+AI assistants have critical limitations:
+
+- **Limited context window** - Cannot hold 100+ files at once
+- **Attention degradation** - Misses files in large lists
+- **Memory limitations** - Forgets files between iterations
+- **False confidence** - Thinks it remembers but doesn't
+
+**Real example**: AI shown list of 100 files. AI processes first 20, then forgets about the rest. Returns saying "all done" but 80 files untouched.
+
+### Traditional Approach Fails
+
+```bash
+# BAD: Try to hold all files in context
+files = [file1, file2, file3, ... file100]
+for file in files:  # AI will forget most of these
+  process(file)
+```
+
+**What happens**:
+
+- AI loads all 100 filenames (1000+ tokens each iteration)
+- Can only focus on ~20 files before attention degrades
+- Forgets remaining 80 files
+- Returns confidently saying "all done"
+- Human discovers 80 files untouched
+
+---
+
+## The Solution: External Index + Sequential Processing
+
+### Core Pattern
+
+```bash
+# 1. Generate external checklist
+find . -name "*.md" > /tmp/checklist.txt
+sed -i 's/^/[ ] /' /tmp/checklist.txt
+
+# 2. Process loop - AI reads only ONE line at a time
+while [ $(grep -c "^\[ \]" /tmp/checklist.txt) -gt 0 ]; do
+  # Get next uncompleted file (5-10 tokens)
+  NEXT=$(grep -m1 "^\[ \]" /tmp/checklist.txt | sed 's/\[ \] //')
+
+  # Process this ONE file completely
+  # - AI reads full file
+  # - AI makes all needed changes
+  # - AI verifies changes
+
+  # Mark complete (in-place edit)
+  sed -i "s|\[ \] $NEXT|[x] $NEXT|" /tmp/checklist.txt
+done
+
+# 3. Cleanup
+rm /tmp/checklist.txt
+```
+
+---
+
+## Why It Works
+
+### Token Efficiency
+
+**Without file crawling**: 100 iterations × 2,000 tokens = 200,000 tokens wasted
+
+**With file crawling**: 100 iterations × 10 tokens = 1,000 tokens
+
+**Savings**: 199,000 tokens (99.5% reduction)
+
+### Key Benefits
+
+1. **No forgetting** - Files tracked externally, not in AI memory
+2. **Clear progress** - Visual `[x]` marks show what's done
+3. **Resumable** - Can stop and restart without losing place
+4. **Systematic** - Guarantees every file processed exactly once
+5. **Verifiable** - Human can check progress anytime
+
+---
+
+## When to Use File Crawling
+
+### ✅ Use When:
+
+- Processing 10+ files systematically
+- Each file requires similar updates
+- Need clear progress visibility
+- Want resumability
+- Working across multiple turns
+
+### ✅ Common in DDD:
+
+- **Phase 1**: Processing all documentation files
+- **Phase 3**: Code reconnaissance across modules
+- **Phase 4**: Implementing changes across files
+- **Phase 5**: Testing all documented examples
+
+---
+
+## Step-by-Step Guide
+
+### Step 1: Generate File Index
+
+```bash
+# Find all files to process
+find . -type f \( -name "*.md" -o -name "*.py" \) \
+  ! -path "*/.git/*" ! -path "*/.venv/*" \
+  > /tmp/files_to_process.txt
+
+# Convert to checklist format
+sed 's/^/[ ] /' /tmp/files_to_process.txt > /tmp/checklist.txt
+
+# Show AI the checklist once
+cat /tmp/checklist.txt
+```
+
+### Step 2: Sequential Processing
+
+```bash
+# AI executes this pattern
+while [ $(grep -c "^\[ \]" /tmp/checklist.txt) -gt 0 ]; do
+  # Get next (minimal tokens)
+  NEXT=$(grep -m1 "^\[ \]" /tmp/checklist.txt | sed 's/\[ \] //')
+
+  echo "Processing: $NEXT"
+
+  # AI reads this ONE file COMPLETELY
+  # AI makes ALL needed changes
+  # AI verifies changes worked
+
+  # Mark complete ONLY after full review
+  sed -i "s|\[ \] $NEXT|[x] $NEXT|" /tmp/checklist.txt
+
+  # Optional: Show progress every 10 files
+  if [ $((counter % 10)) -eq 0 ]; then
+    DONE=$(grep -c "^\[x\]" /tmp/checklist.txt)
+    TOTAL=$(wc -l < /tmp/checklist.txt)
+    echo "Progress: $DONE/$TOTAL files"
+  fi
+  counter=$((counter + 1))
+done
+```
+
+### Step 3: Verify and Cleanup
+
+```bash
+# Verify all files processed
+REMAINING=$(grep -c "^\[ \]" /tmp/checklist.txt)
+if [ $REMAINING -gt 0 ]; then
+  echo "WARNING: $REMAINING files not processed"
+  grep "^\[ \]" /tmp/checklist.txt
+else
+  echo "✓ All files processed"
+fi
+
+# Cleanup
+rm /tmp/checklist.txt /tmp/files_to_process.txt
+```
+
+---
+
+## Common Mistakes to Avoid
+
+### ❌ Loading Entire Checklist into Context
+
+```bash
+# BAD: All 100 files in context
+for file in $(cat /tmp/checklist.txt); do
+  # Won't work
+done
+
+# GOOD: Only next file
+NEXT=$(grep -m1 "^\[ \]" /tmp/checklist.txt | sed 's/\[ \] //')
+```
+
+### ❌ Marking Complete Without Full Review
+
+```bash
+# BAD: Mark all complete after global replace
+sed -i 's/old/new/g' docs/*.md
+sed -i 's/^\[ \]/[x]/' /tmp/checklist.txt  # All marked!
+
+# GOOD: Mark after individual review
+# Read file → Make changes → Verify → Mark complete
+```
+
+**Why this matters**: Global replacements miss files and context. Each file needs individual attention.
+
+### ❌ Processing Multiple Files Per Iteration
+
+```bash
+# BAD: Process 5 at once
+NEXT_5=$(grep -m5 "^\[ \]" /tmp/checklist.txt)
+
+# GOOD: One at a time
+NEXT=$(grep -m1 "^\[ \]" /tmp/checklist.txt)
+```
+
+---
+
+## Advanced Techniques
+
+### Filtered Crawling
+
+```bash
+# Only files mentioning "provider"
+grep -rl "provider" docs/ | \
+  grep -v ".git" | \
+  sed 's/^/[ ] /' > /tmp/provider_docs.txt
+```
+
+### Priority Ordering
+
+```bash
+# Manual priority
+cat > /tmp/ordered.txt << 'EOF'
+[ ] README.md              # Highest priority
+[ ] docs/USER_GUIDE.md     # User-facing
+[ ] docs/API.md            # Developer-facing
+EOF
+
+# Or by size (smaller first)
+find docs/ -name "*.md" -exec wc -l {} + | \
+  sort -n | awk '{print $2}' | sed 's/^/[ ] /' > /tmp/by_size.txt
+```
+
+---
+
+## Integration with DDD Process
+
+File crawling is used throughout:
+
+- **[Phase 1](../phases/01_documentation_retcon.md)**: Documentation file processing
+- **[Phase 4](../phases/04_code_implementation.md)**: Code file implementation
+- **[Phase 5](../phases/05_testing_and_verification.md)**: Testing documented examples
+
+---
+
+## Tips for Success
+
+### For AI Assistants
+
+1. Always use file crawling for 10+ files
+2. Process one file at a time
+3. Read complete file before changes
+4. Mark complete honestly
+5. Show progress periodically
+
+### For Humans
+
+1. Check progress: `grep "^\[x\]" /tmp/checklist.txt | wc -l`
+2. Interrupt safely - resume from checklist
+3. Verify completion before proceeding
+4. Review checklist files
+
+---
+
+## Quick Reference
+
+```bash
+# Standard Pattern
+
+# 1. Generate index
+find . -name "*.md" > /tmp/files.txt
+sed 's/^/[ ] /' /tmp/files.txt > /tmp/checklist.txt
+
+# 2. Process loop
+while [ $(grep -c "^\[ \]" /tmp/checklist.txt) -gt 0 ]; do
+  NEXT=$(grep -m1 "^\[ \]" /tmp/checklist.txt | sed 's/\[ \] //')
+  # Process $NEXT completely
+  sed -i "s|\[ \] $NEXT|[x] $NEXT|" /tmp/checklist.txt
+done
+
+# 3. Cleanup
+rm /tmp/checklist.txt /tmp/files.txt
+```
+
+---
+
+**Return to**: [Core Concepts](README.md) | [Main Index](../README.md)
+
+**Related**: [Context Poisoning](context_poisoning.md) | [Retcon Writing](retcon_writing.md)
+
+**See Also**: [Phase 1](../phases/01_documentation_retcon.md) | [Phase 4](../phases/04_code_implementation.md)

--- a/docs/document_driven_development/core_concepts/retcon_writing.md
+++ b/docs/document_driven_development/core_concepts/retcon_writing.md
@@ -1,0 +1,450 @@
+# Retcon Writing
+
+**Writing documentation as if the feature already exists**
+
+---
+
+## What is Retcon Writing?
+
+**Retcon** (retroactive continuity) means writing documentation as if the new feature already exists and always worked this way. No historical references, no "will be implemented," just pure present-tense description of how it works.
+
+**Purpose**: Eliminate ambiguity about what's current, what's planned, and what's historical.
+
+---
+
+## Why Retcon Writing Matters
+
+### The Problem with Traditional Documentation
+
+**Traditional approach**:
+
+```markdown
+## Provider Configuration (Updated 2025-01-15)
+
+Previously, providers were configured using `amplifier setup`.
+This approach has been deprecated as of version 2.0.
+
+Now, use `amplifier init` instead.
+
+In a future release, `setup` will be removed entirely.
+
+For now, both work, but we recommend using `init`.
+```
+
+**What's wrong**:
+
+- AI doesn't know which approach is current
+- Mix of past, present, and future
+- Unclear if `setup` still works
+- Version numbers add confusion
+- Multiple timelines create ambiguity
+
+**Result**: AI might implement `setup`, or `init`, or both. Wrong decision made confidently.
+
+### The Retcon Solution
+
+**Retcon approach**:
+
+````markdown
+## Provider Configuration
+
+Configure your provider using the init wizard:
+
+```bash
+amplifier init
+```
+````
+
+The wizard guides you through provider selection and configuration.
+
+````
+
+**What's right**:
+- Single timeline: NOW
+- Clear current approach
+- No version confusion
+- No historical baggage
+- Unambiguous for AI and humans
+
+**Result**: AI knows exactly what to implement. Humans know exactly how to use it.
+
+---
+
+## Retcon Writing Rules
+
+### DO:
+
+✅ **Write in present tense** - "The system does X" not "will do X"
+
+✅ **Write as if always existed** - Describe current reality only
+
+✅ **Show actual commands** - Examples that work right now
+
+✅ **Use canonical terminology** - No invented names
+
+✅ **Document all complexity** - Be honest about what's required
+
+✅ **Focus on now** - Not past, not future, just now
+
+### DON'T:
+
+❌ **"This will change to X"** - Write as if X is reality
+
+❌ **"Coming soon" or "planned"** - Only document what you're implementing
+
+❌ **Migration notes in main docs** - Belongs in CHANGELOG or git history
+
+❌ **Historical references** - "Used to work this way"
+
+❌ **Version numbers in docs** - Docs are always current
+
+❌ **Future-proofing** - Document what exists, not what might
+
+❌ **Transition language** - "Now use init instead of setup"
+
+---
+
+## Examples
+
+### Example 1: Command Syntax
+
+**BAD** (traditional):
+```markdown
+## Setup Command (Deprecated)
+
+The `amplifier setup` command was used in v1.0 to configure providers.
+
+As of v2.0, this is deprecated. Use `amplifier init` instead.
+
+Example (old way - don't use):
+amplifier setup
+
+Example (new way - recommended):
+amplifier init
+````
+
+**GOOD** (retcon):
+
+````markdown
+## Initial Configuration
+
+Configure Amplifier on first use:
+
+```bash
+amplifier init
+```
+````
+
+The init wizard guides you through provider and profile selection.
+
+````
+
+### Example 2: Configuration Files
+
+**BAD** (traditional):
+```markdown
+## Settings Files
+
+Previously, settings were stored in `~/.amplifier/config.json`.
+
+In v2.0, we migrated to YAML format for better readability.
+
+Old location (deprecated): `~/.amplifier/config.json`
+New location: `~/.amplifier/settings.yaml`
+
+If you're upgrading from v1.0, run `amplifier migrate` to convert your settings.
+````
+
+**GOOD** (retcon):
+
+```markdown
+## Settings Files
+
+Amplifier stores settings in YAML format:
+
+- `~/.amplifier/settings.yaml` - User-global settings
+- `.amplifier/settings.yaml` - Project settings
+- `.amplifier/settings.local.yaml` - Local overrides (gitignored)
+```
+
+### Example 3: API Changes
+
+**BAD** (traditional):
+
+```markdown
+## Profile Management
+
+The profile API changed in v2.0:
+
+Old API (v1.0):
+amplifier profile apply dev
+
+New API (v2.0):
+amplifier profile use dev
+
+We kept `apply` as an alias for backward compatibility,
+but `use` is now the preferred command.
+```
+
+**GOOD** (retcon):
+
+````markdown
+## Profile Management
+
+Activate a profile:
+
+```bash
+amplifier profile use dev
+```
+````
+
+This loads the profile's capability set and makes it active.
+
+````
+
+---
+
+## Where Historical Information Goes
+
+**Retcon main docs**, but preserve history where appropriate:
+
+### CHANGELOG.md
+
+```markdown
+# Changelog
+
+## [2.0.0] - 2025-01-15
+
+### Changed
+- Profile activation: `amplifier profile apply` → `amplifier profile use`
+- Configuration format: JSON → YAML
+- Setup command: `amplifier setup` → `amplifier init`
+
+### Migration
+Run `amplifier migrate` to update v1.0 settings to v2.0 format.
+````
+
+### Git Commit Messages
+
+```bash
+git commit -m "refactor: Replace setup command with init
+
+Replaces `amplifier setup` with `amplifier init`.
+
+BREAKING CHANGE: `amplifier setup` has been removed.
+Users should use `amplifier init` instead.
+
+Migration: Manual update required for existing users."
+```
+
+### Migration Guides (If Necessary)
+
+````markdown
+# Migration Guide: v1.0 → v2.0
+
+## For Existing Users
+
+If upgrading from v1.0:
+
+1. Run migration tool:
+   ```bash
+   amplifier migrate
+   ```
+````
+
+2. Verify settings:
+   ```bash
+   amplifier config show
+   ```
+
+## What Changed
+
+- Command: `setup` → `init`
+- Config format: JSON → YAML
+- Profile activation: `apply` → `use`
+
+````
+
+**Key point**: Migration info goes in dedicated migration docs, CHANGELOG, and git history. NOT in main user-facing documentation.
+
+---
+
+## Benefits of Retcon Writing
+
+### 1. Eliminates Ambiguity
+
+**Single timeline**: Documentation describes ONE reality (current state)
+
+**AI benefit**: No confusion about what to implement
+
+**Human benefit**: No confusion about how to use it
+
+### 2. Prevents Context Poisoning
+
+**No mixed timelines**: Can't load "old approach" by mistake
+
+**No version confusion**: Docs are always current
+
+**Clear specification**: AI knows exactly what to build
+
+### 3. Cleaner Documentation
+
+**Shorter**: No historical baggage
+
+**Focused**: Just how it works now
+
+**Maintainable**: One timeline to maintain
+
+### 4. Better User Experience
+
+**Users don't care about history**: They want to know how it works now
+
+**Clear examples**: Commands that actually work
+
+**No confusion**: Single approach shown
+
+---
+
+## Common Mistakes
+
+### Mistake 1: Apologetic Language
+
+**BAD**:
+```markdown
+The new approach is better because it's simpler and more intuitive.
+We apologize for the inconvenience of changing the command.
+````
+
+**GOOD**:
+
+````markdown
+Configure Amplifier:
+
+```bash
+amplifier init
+```
+````
+
+````
+
+**Why**: Apologies imply something else was standard. Just describe how it works.
+
+### Mistake 2: Transition Warnings
+
+**BAD**:
+```markdown
+Note: If you're used to the old `setup` command, you'll need to
+learn the new `init` command instead. The syntax is different.
+````
+
+**GOOD**:
+
+````markdown
+Initialize Amplifier configuration:
+
+```bash
+amplifier init
+```
+````
+
+````
+
+**Why**: Assumes users know old way. New users don't. Just describe current way.
+
+### Mistake 3: Version Numbers in Headers
+
+**BAD**:
+```markdown
+## Profile Management (v2.0+)
+
+New in version 2.0: Profile management commands
+````
+
+**GOOD**:
+
+```markdown
+## Profile Management
+
+Manage capability profiles:
+```
+
+**Why**: Docs are always current. Version numbers add noise.
+
+---
+
+## When NOT to Retcon
+
+### Keep History When:
+
+1. **CHANGELOG.md** - Explicitly about changes over time
+2. **Migration guides** - Purpose is to document transition
+3. **Git history** - Commit messages and history
+4. **ADRs** (if used) - Architecture decision records
+
+### Retcon Everywhere Else:
+
+- Main README
+- User guides
+- API documentation
+- Architecture docs
+- Examples and tutorials
+
+---
+
+## Integration with DDD
+
+Retcon writing is applied throughout:
+
+- **[Phase 1](../phases/01_documentation_retcon.md)**: All documentation updates use retcon
+- **[Phase 2](../phases/02_approval_gate.md)**: Review checks for non-retcon language
+- **[Phase 4](../phases/04_code_implementation.md)**: Code implements current state only
+
+---
+
+## Quick Reference
+
+### Retcon Writing Checklist
+
+Before committing documentation:
+
+- [ ] All present tense ("system does X")
+- [ ] No "will" or "planned" language
+- [ ] No historical references ("used to")
+- [ ] No version numbers in main content
+- [ ] No transition language ("now use X instead of Y")
+- [ ] No backward compatibility notes in main docs
+- [ ] Examples work with current code
+
+### Quick Fixes
+
+**Find non-retcon language**:
+
+```bash
+# Check for future tense
+grep -rn "will be\|coming soon\|planned" docs/
+
+# Check for historical references
+grep -rn "previously\|used to\|old way\|new way" docs/
+
+# Check for version numbers
+grep -rn "v[0-9]\|version [0-9]" docs/
+
+# Check for transition language
+grep -rn "instead of\|rather than\|no longer" docs/
+```
+
+**Fix systematically**:
+
+```bash
+# Remove identified issues
+# Rewrite in present tense
+# Describe only current state
+```
+
+---
+
+**Return to**: [Core Concepts](README.md) | [Main Index](../README.md)
+
+**Related**: [File Crawling](file_crawling.md) | [Context Poisoning](context_poisoning.md)
+
+**See Also**: [Phase 1 Step 3](../phases/01_documentation_retcon.md#step-3-retcon-writing-rules)

--- a/docs/document_driven_development/overview.md
+++ b/docs/document_driven_development/overview.md
@@ -1,0 +1,471 @@
+# Document-Driven Development: Overview
+
+**Understanding the core principle and why it works**
+
+---
+
+## What is Document-Driven Development?
+
+Document-Driven Development (DDD) is a systematic approach where:
+
+1. **Documentation comes first** - You design and document the system before writing code
+2. **Documentation IS the specification** - Code must match what docs describe exactly
+3. **Approval gate** - Human reviews and approves design before implementation
+4. **Implementation follows docs** - Code implements what documentation promises
+5. **Testing verifies docs** - Tests ensure code matches documentation
+
+**Core Principle**: "Documentation IS the specification. Code implements what documentation describes."
+
+---
+
+## The Traditional Problem
+
+**Traditional approach**: Code → Docs
+
+What happens:
+
+- Docs written after code (if at all)
+- Docs lag behind code changes
+- Docs and code diverge over time
+- AI tools load stale/conflicting docs
+- Context poisoning leads to wrong implementations
+- Bugs from misunderstanding requirements
+
+**Result**: Documentation becomes untrustworthy. Developers stop reading docs. More bugs.
+
+---
+
+## The DDD Solution
+
+**DDD approach**: Docs → Approval → Implementation
+
+What happens:
+
+- Design captured in docs first
+- Human reviews and approves design
+- **Only then** write code
+- Code matches docs exactly
+- Tests verify code matches docs
+- Docs and code never diverge
+
+**Result**: Documentation is always correct. Single source of truth. Fewer bugs.
+
+---
+
+## Why This Works (Especially for AI)
+
+### 1. Prevents Context Poisoning
+
+**Context poisoning** = AI loads inconsistent information, makes wrong decisions
+
+**How DDD prevents it**:
+
+- Single source of truth for each concept
+- No duplicate documentation
+- No stale docs (updated before code)
+- Clear, unambiguous specifications
+
+### 2. Clear Contracts First
+
+**Problem**: Implementation complexity obscures design intent
+
+**How DDD helps**:
+
+- Docs define interfaces before implementation
+- Contracts clear before complexity added
+- Easier to review design than code
+- Cheaper to fix design than implementation
+
+### 3. Reviewable Design
+
+**Problem**: Design flaws discovered after expensive implementation
+
+**How DDD helps**:
+
+- Design reviewed at approval gate
+- Catch flaws before coding
+- Iterate on docs (cheap) not code (expensive)
+- Human judgment applied early
+
+### 4. AI-Optimized
+
+**Problem**: AI tools rely on docs for context
+
+**How DDD helps**:
+
+- Docs always current
+- No conflicting information
+- Clear specifications
+- AI can't guess wrong (spec is clear)
+
+### 5. No Drift
+
+**Problem**: Docs and code slowly diverge over time
+
+**How DDD helps**:
+
+- Docs come first, so can't lag
+- If code needs to differ, update docs first
+- Always in sync by design
+- Drift is impossible
+
+### 6. Modular Alignment
+
+**Problem**: Unclear module boundaries and interfaces
+
+**How DDD helps**:
+
+- Docs define "studs" (interfaces) first
+- Then build "bricks" (implementations)
+- Clear contracts between modules
+- Regeneratable from specs
+
+### 7. Human Judgment Preserved
+
+**Problem**: Critical decisions made during coding under pressure
+
+**How DDD helps**:
+
+- Design decisions at planning phase
+- Time to think through trade-offs
+- Expert review before commitment
+- Better decisions
+
+---
+
+## Philosophy Foundation
+
+DDD builds on these principles:
+
+### From [PHILOSOPHY.md](../concepts/philosophy.md)
+
+**Ruthless Simplicity**:
+
+- Start minimal, grow as needed
+- Avoid future-proofing
+- Question every abstraction
+- Clear over clever
+
+**Applied in DDD**:
+
+- Simple docs easier to maintain
+- No speculative features in docs
+- Each doc has one clear purpose
+- Progressive organization
+
+**Bricks and Studs**:
+
+- Self-contained modules
+- Clear interfaces (studs)
+- Regeneratable from spec
+- Human architects, AI builds
+
+**Applied in DDD**:
+
+- Docs define interfaces (studs)
+- Code implements modules (bricks)
+- Can regenerate from docs
+- Human reviews design, AI implements
+
+---
+
+## The Complete Process
+
+```
+Phase 0: Planning & Alignment
+    ↓
+    • Problem framing
+    • Reconnaissance
+    • Proposals and iteration
+    • Shared understanding
+    ↓
+Phase 1: Documentation Retcon
+    ↓
+    • Update ALL docs to target state
+    • Write as if already exists
+    • Maximum DRY enforcement
+    • Progressive organization
+    ↓
+Phase 2: Approval Gate ←─────┐
+    ↓                         │
+    • Human reviews design    │
+    • Iterate until right     │ (iterate if needed)
+    • THEN commit docs        │
+    ↓                         │
+    ├─────────────────────────┘
+    ↓
+Phase 3: Implementation Planning
+    ↓
+    • Code reconnaissance
+    • Detailed plan
+    • Right-sizing check
+    ↓
+Phase 4: Code Implementation
+    ↓
+    • Code matches docs exactly
+    • Load full context
+    • Commit incrementally
+    ↓
+Phase 5: Testing & Verification
+    ↓
+    • Test documented behaviors
+    • Test as user would
+    • AI is QA entity
+    ↓
+Phase 6: Cleanup & Push
+    ↓
+    • Remove temporary files
+    • Final verification
+    • Push to remote
+```
+
+---
+
+## When to Use DDD
+
+### ✅ Use DDD For
+
+**Large changes**:
+
+- New features requiring multiple files
+- System redesigns or refactoring
+- API changes affecting documentation
+- Any change touching 10+ files
+- Cross-cutting concerns
+
+**High-stakes work**:
+
+- User-facing features
+- Breaking changes
+- Complex integrations
+- Architecture decisions
+
+**Collaborative work**:
+
+- Multiple developers involved
+- Need clear specification
+- External review required
+
+### ❌ Don't Use DDD For
+
+**Simple changes**:
+
+- Typo fixes
+- Single-file bug fixes
+- Trivial updates
+- Documentation-only changes
+
+**Emergency situations**:
+
+- Production hotfixes
+- Critical security patches
+- System down scenarios
+
+**When uncertain**: Lean toward using DDD. Process prevents expensive mistakes.
+
+---
+
+## Key Benefits
+
+### Prevents Expensive Mistakes
+
+- Catch design flaws before implementation
+- Review is cheap, rework is expensive
+- Philosophy compliance checked early
+- Human judgment applied at right time
+
+### Eliminates Context Poisoning
+
+- Single source of truth
+- No duplicate documentation
+- No stale information
+- Clear, unambiguous specs
+
+### Optimizes AI Collaboration
+
+- AI has clear specifications
+- No guessing from unclear docs
+- Can regenerate from spec
+- Systematic file processing
+
+### Maintains Quality
+
+- Documentation always correct
+- Code matches documentation
+- Examples always work
+- New developers understand from docs
+
+### Reduces Bugs
+
+- Fewer misunderstandings
+- Clear requirements
+- Tested against spec
+- Integration verified
+
+---
+
+## Success Criteria
+
+You're doing DDD well when:
+
+**Documentation Quality**:
+
+- ✅ Docs and code never diverge
+- ✅ Zero context poisoning incidents
+- ✅ Examples all work when copy-pasted
+- ✅ New developers understand from docs alone
+
+**Process Quality**:
+
+- ✅ Changes require minimal rework
+- ✅ Design flaws caught at approval gate
+- ✅ Philosophy principles naturally followed
+- ✅ Git history is clean (no thrashing)
+
+**AI Collaboration**:
+
+- ✅ AI tools make correct decisions consistently
+- ✅ No "wrong approach implemented confidently"
+- ✅ Can regenerate modules from specs
+
+**Team Impact**:
+
+- ✅ Implementation time decreases (better specs)
+- ✅ Bug rate decreases (fewer misunderstandings)
+- ✅ Questions about features, not "which docs are right?"
+
+---
+
+## What Makes DDD Different
+
+### Not Just "Write Docs First"
+
+DDD is more than writing documentation before code:
+
+**Traditional "docs first"**:
+
+- Write docs
+- Write code
+- Docs drift over time
+- No systematic process
+
+**DDD**:
+
+- Systematic process with phases
+- Approval gate before implementation
+- Specific techniques (file crawling, retcon, etc.)
+- Built-in prevention of drift
+- AI-optimized workflow
+
+### Not Just "Spec-Driven Development"
+
+DDD differs from traditional spec-driven development:
+
+**Traditional specs**:
+
+- Often separate from user docs
+- Written in formal specification language
+- Rarely updated after initial write
+- Developers don't read them
+
+**DDD**:
+
+- User docs ARE the specs
+- Written in clear human language
+- Always current (updated first)
+- Single source of truth
+- Developers AND AI use them
+
+---
+
+## Learning Path
+
+**If you're new to DDD**:
+
+1. **Understand the principles** (this document)
+   - Why docs first matters
+   - How context poisoning happens
+   - What the process flow is
+
+2. **Learn the core techniques** ([core_concepts/](core_concepts/))
+   - [File Crawling](core_concepts/file_crawling.md) - Processing many files systematically
+   - [Context Poisoning](core_concepts/context_poisoning.md) - Understanding and prevention
+   - [Retcon Writing](core_concepts/retcon_writing.md) - Writing as if already exists
+
+3. **Practice with small project**
+   - Follow [phase guides](phases/) step by step
+   - Use [checklists](reference/checklists.md) to verify completion
+   - Learn from [common pitfalls](reference/common_pitfalls.md)
+
+4. **Apply to real work**
+   - Start with medium-sized feature
+   - Reference [tips for success](reference/tips_for_success.md)
+   - Use [FAQ](reference/faq.md) when questions arise
+
+**If you're an AI assistant**:
+
+1. **Load overview** (this document) to understand the process
+2. **Load relevant phase docs** as you work through each phase
+3. **Reference core concepts** when using those techniques
+4. **Use checklists** to verify completion
+5. **Follow tips** for AI assistants in each phase
+
+---
+
+## Common Misconceptions
+
+### "This is too much process"
+
+**Reality**: Process prevents expensive rework. An hour in planning saves days of coding wrong thing.
+
+### "We don't have time for this"
+
+**Reality**: You don't have time NOT to do this. Rework from misunderstanding costs far more than upfront clarity.
+
+### "Our docs are already good"
+
+**Reality**: If docs and code can diverge, they will. DDD makes divergence impossible by design.
+
+### "AI doesn't need perfect docs"
+
+**Reality**: AI makes wrong decisions confidently when docs conflict. Context poisoning is real and expensive.
+
+### "This only works for big projects"
+
+**Reality**: Works at any scale. Small projects benefit from clarity. Large projects require it.
+
+---
+
+## Next Steps
+
+**Ready to start?**
+
+1. **Read core concepts**: [core_concepts/](core_concepts/)
+   - Essential techniques you'll use throughout
+
+2. **Follow the process**: [phases/](phases/)
+   - Start with Phase 0: Planning & Alignment
+   - Work through each phase systematically
+
+3. **Use reference materials**: [reference/](reference/)
+   - Checklists to verify completion
+   - Tips to avoid common mistakes
+   - FAQ for quick answers
+
+**Have questions?** See [FAQ](reference/faq.md) or [common pitfalls](reference/common_pitfalls.md).
+
+---
+
+## Related Resources
+
+**Philosophy Foundation**:
+
+- [PHILOSOPHY.md](../concepts/philosophy.md) - Ruthless simplicity and modular design principles
+
+**Return to**: [Main Index](README.md)
+
+---
+
+**Document Version**: 2.0
+**Last Updated**: 2025-10-25
+**Ported From**: microsoft/amplifier Document-Driven Development methodology

--- a/docs/document_driven_development/phases/00_planning_and_alignment.md
+++ b/docs/document_driven_development/phases/00_planning_and_alignment.md
@@ -1,0 +1,120 @@
+# Phase 0: Planning & Alignment
+
+> [Home](../../index.md) > [Document-Driven Development](../README.md) > [Phases](README.md) > Phase 0
+
+**Achieve shared understanding between human and AI before any work begins**
+
+---
+
+## Goal
+
+Establish clear, shared understanding of what will be built before touching any files.
+
+**Why critical**: Misaligned understanding is expensive. An hour in planning saves days of rework.
+
+---
+
+## The Steps
+
+### Step 1: Problem Framing
+
+**Human presents**:
+
+- High-level problem or requirement
+- Scope and constraints
+- Success criteria
+- Relevant context
+
+**Be explicit**: Don't assume AI knows your context.
+
+### Step 2: Reconnaissance
+
+**AI performs reconnaissance**:
+
+- "What's the current state of X in the codebase?"
+- "What files would be affected?"
+- "What patterns exist to follow?"
+
+**Use [file crawling](../core_concepts/file_crawling.md) if large scope**.
+
+### Step 3: Brainstorming & Proposals
+
+**AI generates 2-3 options**:
+
+- Different approaches
+- Trade-offs for each
+- Complexity assessment
+- Philosophy alignment
+
+**Iterate together**:
+
+- Human injects domain knowledge
+- AI identifies technical constraints
+- Discuss and refine
+
+### Step 4: Shared Understanding Check
+
+**Verification**:
+
+- Ask AI to articulate the plan back
+- Does AI's explanation match your mental model?
+- Are there any gaps or misunderstandings?
+
+**Red flag**: If explanation doesn't match expectations, keep iterating.
+
+### Step 5: Capture the Plan
+
+**For within-turn work**:
+
+- AI uses TodoWrite to track steps
+- System enforces completion
+- AI can modify as discoveries made
+
+**For multi-turn work**:
+
+- Create file in `ai_working/` directory
+- Track phases and blockers
+- Update as work progresses
+- Clean up when done
+
+**Why**: AI is "easily distracted and forgetful." External tracking keeps focus.
+
+---
+
+## Output of Phase 0
+
+When complete:
+
+- ✅ Shared mental model established
+- ✅ Plan captured (TodoWrite or ai_working/ file)
+- ✅ Reconnaissance complete
+- ✅ Trade-offs understood
+- ✅ Philosophy alignment verified
+- ✅ Human explicitly approves proceeding
+
+**Ready for**: [Phase 1: Documentation Retcon](01_documentation_retcon.md)
+
+---
+
+## Tips
+
+**For Humans**:
+
+- Be patient - get this right before proceeding
+- Challenge AI's assumptions
+- Provide clear direction
+- Approve explicitly when aligned
+
+**For AI**:
+
+- Show your reconnaissance findings
+- Present multiple options
+- Be honest about trade-offs
+- Ask clarifying questions
+- Don't proceed without alignment
+
+---
+
+**Return to**: [Phases](README.md) | [Main Index](../README.md)
+
+**Next Phase**: [Phase 1: Documentation Retcon](01_documentation_retcon.md)

--- a/docs/document_driven_development/phases/01_documentation_retcon.md
+++ b/docs/document_driven_development/phases/01_documentation_retcon.md
@@ -1,0 +1,588 @@
+# Phase 1: Documentation Retcon
+
+> [Home](../../index.md) > [Document-Driven Development](../README.md) > [Phases](README.md) > Phase 1
+
+**Update ALL documentation to describe the target state as if it already exists**
+
+---
+
+## Goal
+
+Update every piece of documentation to reflect the target state using [retcon writing](../core_concepts/retcon_writing.md). Write as if the feature already exists and always worked this way.
+
+**Critical**: Do NOT commit documentation yet. Iterate with human feedback until approved in Phase 2.
+
+---
+
+## Why Retcon First?
+
+**Why documentation before code**:
+
+- Design flaws cheaper to fix in docs than code
+- Clear specification before implementation complexity
+- Human reviews design before expensive coding
+- Prevents implementing wrong thing
+
+**Why retcon style**:
+
+- Eliminates ambiguity (single timeline: NOW)
+- Prevents [context poisoning](../core_concepts/context_poisoning.md)
+- Clear for both AI and humans
+- No historical confusion
+
+---
+
+## Overview of Steps
+
+```
+Step 1: Generate File Index
+    ↓
+Step 2: Sequential File Processing (file crawling)
+    ↓
+Step 3: Apply Retcon Writing Rules
+    ↓
+Step 4: Enforce Maximum DRY
+    ↓
+Step 5: Global Replacements (helper only)
+    ↓
+Step 6: Detect and Resolve Conflicts
+    ↓
+Step 7: Progressive Organization
+    ↓
+Step 8: Verification Pass
+    ↓
+Ready for Phase 2 (Approval)
+```
+
+---
+
+## Step 1: Generate File Index
+
+Use [file crawling technique](../core_concepts/file_crawling.md) for systematic processing.
+
+```bash
+# Find all non-code files to update
+find . -type f \
+  \( -name "*.md" -o -name "*.yaml" -o -name "*.toml" \) \
+  ! -path "*/.git/*" \
+  ! -path "*/.venv/*" \
+  ! -path "*/node_modules/*" \
+  > /tmp/docs_to_process.txt
+
+# Convert to checklist format
+sed 's/^/[ ] /' /tmp/docs_to_process.txt > /tmp/docs_checklist.txt
+
+# Show checklist (once)
+cat /tmp/docs_checklist.txt
+```
+
+**Why external file**: Tracks files outside AI's limited context. Saves 99.5% tokens.
+
+---
+
+## Step 2: Sequential File Processing
+
+Process files ONE AT A TIME using [file crawling](../core_concepts/file_crawling.md#step-by-step-guide):
+
+```bash
+# Processing loop
+while [ $(grep -c "^\[ \]" /tmp/docs_checklist.txt) -gt 0 ]; do
+  # Get next uncompleted file (minimal tokens)
+  NEXT=$(grep -m1 "^\[ \]" /tmp/docs_checklist.txt | sed 's/\[ \] //')
+
+  echo "Processing: $NEXT"
+
+  # AI reads this ONE file COMPLETELY
+  # AI reviews ENTIRE file content
+  # AI makes ALL needed updates
+  # AI verifies changes
+
+  # Mark complete ONLY after full individual review
+  sed -i "s|\[ \] $NEXT|[x] $NEXT|" /tmp/docs_checklist.txt
+
+  # Show progress periodically
+  if [ $((counter % 10)) -eq 0 ]; then
+    DONE=$(grep -c "^\[x\]" /tmp/docs_checklist.txt)
+    TOTAL=$(wc -l < /tmp/docs_checklist.txt)
+    echo "Progress: $DONE/$TOTAL files"
+  fi
+  counter=$((counter + 1))
+done
+```
+
+**For each file**:
+
+1. **Read ENTIRE file** - Full content, no skimming
+2. **Review in context** - Understand file's purpose and scope
+3. **Decide action**:
+   - Update to target state (retcon)
+   - Delete if duplicates another doc
+   - Move if wrong location
+   - Skip if already correct
+4. **Apply changes** - Edit, delete, or move
+5. **Mark complete** - Only after thorough review
+
+**⚠️ ANTI-PATTERN**: Do NOT mark complete based on global replacements alone. Each file needs individual attention.
+
+---
+
+## Step 3: Apply Retcon Writing Rules
+
+For each file being updated, follow [retcon writing rules](../core_concepts/retcon_writing.md#retcon-writing-rules):
+
+### DO:
+
+✅ Write in **present tense**: "The system does X"
+✅ Write as if **always existed**: Current reality only
+✅ Show **actual commands**: Examples that work now
+✅ Use **canonical terminology**: No invented names
+✅ **Document all complexity**: Be honest about requirements
+
+### DON'T:
+
+❌ "This will change to X"
+❌ "Coming soon" or "planned"
+❌ Migration notes in main docs
+❌ Historical references ("used to")
+❌ Version numbers in content
+❌ Future-proofing
+
+**Why**: See [Why Retcon Writing Matters](../core_concepts/retcon_writing.md#why-retcon-writing-matters)
+
+---
+
+## Step 4: Enforce Maximum DRY
+
+**Rule**: Each concept lives in exactly ONE place. Zero duplication.
+
+**Why critical**: Duplication causes [context poisoning](../core_concepts/context_poisoning.md). When one doc updates and another doesn't, AI loads inconsistent information.
+
+### Finding Duplication
+
+While processing files, ask:
+
+- Does this content exist in another file?
+- Is this concept already documented elsewhere?
+- Am I duplicating another doc's scope?
+
+### Resolving Duplication
+
+**If found**:
+
+1. Identify which doc is canonical
+2. **Delete** the duplicate entirely (don't update it)
+3. Update cross-references to canonical source
+
+**Example**:
+
+```bash
+# Found: COMMAND_GUIDE.md duplicates USER_ONBOARDING.md
+
+# Delete duplicate
+rm docs/COMMAND_GUIDE.md
+
+# Update cross-references
+sed -i 's/COMMAND_GUIDE\.md/USER_ONBOARDING.md#commands/g' docs/*.md
+
+# Verify deletion
+grep -r "COMMAND_GUIDE" docs/  # Should find nothing
+```
+
+**Why delete vs. update**: If it exists, it will drift. Deletion is permanent elimination.
+
+---
+
+## Step 5: Global Replacements (Use with Extreme Caution)
+
+Global replacements can help with terminology changes, but **are NOT a substitute for individual review**.
+
+### How to Use Correctly
+
+```bash
+# 1. Run global replacement as FIRST PASS
+sed -i 's/profile apply/profile use/g' docs/*.md
+sed -i 's/\bworkflow\b/profile/g' docs/*.md
+
+# 2. STILL review each file individually (Step 2)
+# Global replace is helper, not solution
+
+# 3. Verify worked correctly
+grep -rn "profile apply" docs/  # Should be zero
+grep -rn "\bworkflow\b" docs/   # Check each hit for context
+```
+
+### ⚠️ CRITICAL WARNING - ANTI-PATTERN
+
+**Global replacements cause context poisoning when used as completion marker.**
+
+**Problems**:
+
+1. **Inconsistent formatting** - Misses variations
+2. **Context-inappropriate** - Replaces wrong instances
+3. **False confidence** - Files marked done without review
+
+**Example of what goes wrong**:
+
+```markdown
+# File 1: "Use `profile apply`" → Caught by replace
+
+# File 2: "run profile-apply command" → Missed (hyphenated)
+
+# File 3: "applying profiles" → Missed (verb form)
+
+# Developer marks files "done" after global replace
+
+# Files 2 and 3 still have old terminology
+
+# Context poisoning introduced
+```
+
+**Correct approach**:
+
+- Use as helper for first pass
+- Still review EVERY file individually
+- Verify replacement worked in context
+- Make additional file-specific changes
+- Mark complete only after full review
+
+See [Common Pitfall #3](../reference/common_pitfalls.md#pitfall-3-global-replacements-as-completion) for more.
+
+---
+
+## Step 6: Detect and Resolve Conflicts
+
+**If AI detects drift/inconsistency/conflicts between files**:
+
+### ⚠️ PAUSE IMMEDIATELY
+
+Do NOT continue. Do NOT fix without human guidance.
+
+### Conflict Detection Pattern
+
+```markdown
+# AI detects while processing:
+
+File 1 (docs/USER_GUIDE.md): calls it "workflow"
+File 2 (docs/API.md): calls it "profile"
+File 3 (docs/TUTORIAL.md): calls it "capability set"
+
+# AI SHOULD PAUSE
+```
+
+### What AI Should Do
+
+1. **Stop processing** - Don't mark more files complete
+2. **Collect all instances** - Document every conflict
+3. **Present to human** with analysis and options:
+
+```markdown
+# CONFLICT DETECTED - User guidance needed
+
+## Issue
+
+Inconsistent terminology found across documentation
+
+## Instances
+
+1. docs/USER_GUIDE.md:42: "workflow"
+2. docs/API.md:15: "profile"
+3. docs/TUTORIAL.md:8: "capability set"
+4. README.md:25: uses both "workflow" and "profile"
+
+## Analysis
+
+- "profile" appears 47 times across 12 files
+- "workflow" appears 23 times across 8 files
+- "capability set" appears 3 times across 2 files
+
+## Suggested Resolutions
+
+Option A: Standardize on "profile"
+
+- Pro: Most common, matches code
+- Con: May confuse users familiar with "workflow"
+
+Option B: Standardize on "capability set"
+
+- Pro: More descriptive
+- Con: More verbose
+
+Option C: Define relationship, keep both
+
+- Pro: Accommodates existing usage
+- Con: Maintains ambiguity, risks context poisoning
+
+## Recommendation
+
+Option A - standardize on "profile" as canonical term
+
+Please advise which resolution to apply.
+```
+
+4. **Wait for human decision**
+5. **Apply resolution systematically** across all files
+6. **Resume processing**
+
+**Conflicts include**:
+
+- Terminology (different words for same concept)
+- Technical approaches (incompatible methods)
+- Scope (unclear boundaries)
+- Examples (code that contradicts)
+
+**Why this matters**: Only human has full context to decide correctly. AI guessing introduces new context poisoning.
+
+---
+
+## Step 7: Progressive Documentation Organization
+
+**Principle**: Organize for progressive understanding, not information dump.
+
+### Documentation Hierarchy
+
+```
+README.md (Entry Point)
+├─ Introduction (what is this?)
+├─ Quick Start (working in 90 seconds)
+├─ Key Concepts (3-5 ideas, brief)
+└─ Next Steps (where to learn more)
+   ├─ → User Guide (detailed usage)
+   ├─ → Developer Guide (contributing)
+   ├─ → API Reference (technical)
+   └─ → Architecture (system design)
+```
+
+### Top-Level README Principles
+
+✅ **Focus on awareness, not completeness** - "These things exist, find them here"
+✅ **Progressive reveal** - Simple → detailed
+✅ **Audience-appropriate** - Tailor to primary users
+✅ **Action-oriented** - What can I do now?
+
+❌ **Don't duplicate entire guides inline**
+❌ **Don't compress to cryptic bullets**
+❌ **Don't optimize for AI at expense of humans**
+❌ **Don't mix all audience levels together**
+
+### Example: Well-Organized README
+
+````markdown
+## Quick Start
+
+### Step 1: Install (30 seconds)
+
+```bash
+curl -sSL https://install.sh | sh
+```
+
+### Step 2: Run (60 seconds)
+
+```bash
+myapp init
+myapp run
+```
+
+**First time?** The init wizard guides you. [See detailed setup →](docs/USER_GUIDE.md#setup)
+
+---
+
+## Core Concepts
+
+**Profiles** - Capability sets. [Learn more →](docs/PROFILES.md)
+**Providers** - Infrastructure backends. [Learn more →](docs/PROVIDERS.md)
+**Modules** - Pluggable functionality. [Browse modules →](docs/MODULES.md)
+
+---
+
+## Next Steps
+
+**For users**: [User Guide](docs/USER_GUIDE.md)
+**For developers**: [Developer Guide](docs/DEVELOPER_GUIDE.md)
+**For architects**: [Architecture](docs/ARCHITECTURE.md)
+
+````
+
+### Audience-Specific Organization
+
+**End-user applications**:
+- README focuses on user experience
+- Developer docs separate, linked from bottom
+
+**Developer tools/libraries**:
+- README focuses on developer quick start
+- API reference prominent
+
+**Platform/infrastructure**:
+- README introduces capabilities
+- Multiple audience paths clearly separated
+
+### Balance Clarity and Conciseness
+
+✅ **GOOD**: "Profiles define capability sets. Use `amplifier profile use dev` to activate the development profile."
+
+❌ **TOO COMPRESSED**: "Profiles=caps. Use: amp prof use dev"
+
+❌ **TOO VERBOSE**: "Profiles are comprehensive modular capability aggregation configurations..."
+
+**Remember**: Documents are for humans first. AI can parse anything. Humans need clarity and flow.
+
+---
+
+## Step 8: Verification Pass
+
+Before considering Phase 1 complete (but still NOT committing):
+
+### Verification Checklist
+
+- [ ] **Broken links check** - All cross-references work
+- [ ] **Terminology consistency** - No old terms remain
+- [ ] **Zero duplication** - Each concept in ONE place
+- [ ] **Examples validity** - Commands use correct syntax
+- [ ] **Philosophy compliance** - Follows IMPLEMENTATION_PHILOSOPHY.md and MODULAR_DESIGN_PHILOSOPHY.md
+- [ ] **Human readability** - New person can understand
+
+### Verification Commands
+
+```bash
+# Check for old terminology
+grep -rn "old-term" docs/  # Should return zero
+
+# Check for duplicate concepts
+grep -rn "concept definition" docs/  # Single canonical location
+
+# Verify historical references removed
+grep -rn "previously\|used to\|old way" docs/  # Should be zero
+
+# Check for future tense
+grep -rn "will be\|coming soon" docs/  # Should be zero
+````
+
+---
+
+## Common Issues and Fixes
+
+### Issue: Files Missed During Processing
+
+**Symptom**: Some files not in checklist, got skipped
+
+**Fix**:
+
+```bash
+# Regenerate checklist with better filters
+find . -type f -name "*.md" \
+  ! -path "*/.git/*" \
+  ! -path "*/.venv/*" \
+  ! -path "*/node_modules/*" \
+  ! -path "*/__pycache__/*" \
+  > /tmp/complete_docs_list.txt
+
+# Compare with what was processed
+diff /tmp/docs_to_process.txt /tmp/complete_docs_list.txt
+
+# Process missed files
+```
+
+### Issue: Duplicate Content Found Late
+
+**Symptom**: Found duplication after processing many files
+
+**Fix**:
+
+1. Identify canonical source
+2. Delete duplicate file
+3. Update all cross-references
+4. Re-process files that referenced duplicate
+5. Verify with grep
+
+### Issue: Inconsistent Terminology After Global Replace
+
+**Symptom**: Some files still have old terms
+
+**Fix**:
+
+1. Find all remaining instances: `grep -rn "old-term" docs/`
+2. Review each in context (might be intentional)
+3. Fix individually
+4. Update checklist for affected files
+
+---
+
+## Integration with Core Concepts
+
+This phase relies heavily on core concepts:
+
+**[File Crawling](../core_concepts/file_crawling.md)**:
+
+- Step 1: Generate index
+- Step 2: Sequential processing
+- Prevents forgetting files
+
+**[Context Poisoning](../core_concepts/context_poisoning.md)**:
+
+- Step 4: Enforce maximum DRY
+- Step 6: Detect and resolve conflicts
+- Prevents inconsistent information
+
+**[Retcon Writing](../core_concepts/retcon_writing.md)**:
+
+- Step 3: Apply writing rules
+- Step 7: Progressive organization
+- Eliminates timeline ambiguity
+
+---
+
+## Output of Phase 1
+
+When complete:
+
+- ✅ All documentation describes target state
+- ✅ Retcon writing style used throughout
+- ✅ Maximum DRY enforced (no duplication)
+- ✅ Progressive organization applied
+- ✅ Verification pass complete
+- ✅ All files in checklist marked `[x]`
+- ⚠️ **NOT committed yet** - awaiting approval
+- ⚠️ **NOT pushed** - Phase 2 next
+
+**Ready for**: [Phase 2: Approval Gate](02_approval_gate.md)
+
+---
+
+## Tips for Success
+
+### For AI Assistants
+
+1. **Use file crawling** - Don't try to hold all files in context
+2. **Read complete files** - No skimming
+3. **Apply retcon rules strictly** - Present tense, as if already exists
+4. **PAUSE on conflicts** - Never guess at resolution
+5. **Mark complete honestly** - Only after full individual review
+6. **Show progress** - Keep human informed
+
+### For Humans
+
+1. **Monitor progress** - Check checklist files periodically
+2. **Don't commit yet** - Wait for Phase 2 approval
+3. **Review samples** - Spot-check files during processing
+4. **Provide clear decisions** - When AI pauses for conflicts
+
+---
+
+## Next Phase
+
+**When Phase 1 complete**: [Phase 2: Approval Gate](02_approval_gate.md)
+
+**Before proceeding**:
+
+- All files processed
+- No remaining `[ ]` in checklist
+- Verification pass complete
+- Ready for human review
+
+---
+
+**Return to**: [Phases](README.md) | [Main Index](../README.md)
+
+**Prerequisites**: [Phase 0: Planning & Alignment](00_planning_and_alignment.md)
+
+**Core Techniques**: [File Crawling](../core_concepts/file_crawling.md) | [Context Poisoning](../core_concepts/context_poisoning.md) | [Retcon Writing](../core_concepts/retcon_writing.md)

--- a/docs/document_driven_development/phases/02_approval_gate.md
+++ b/docs/document_driven_development/phases/02_approval_gate.md
@@ -1,0 +1,136 @@
+# Phase 2: Approval Gate
+
+> [Home](../../index.md) > [Document-Driven Development](../README.md) > [Phases](README.md) > Phase 2
+
+**Human reviews and approves design. Iterate until right. THEN commit.**
+
+---
+
+## Goal
+
+Human reviews and approves the design as expressed in documentation. Iterate with AI until design is correct. Only then commit documentation.
+
+**Why this gate is critical**: Last checkpoint before expensive implementation. Design flaws caught here save days of rework. Committing before approval thrashes git log with wrong commits.
+
+---
+
+## The Process
+
+### Review Checklist
+
+Human reviews uncommitted documentation:
+
+- [ ] Design is correct and complete
+- [ ] Terminology is accurate and canonical
+- [ ] Complexity captured honestly
+- [ ] Examples are realistic and will work
+- [ ] Philosophy principles followed
+- [ ] No duplication or [context poisoning](../core_concepts/context_poisoning.md) sources
+- [ ] Progressive organization makes sense
+- [ ] Human-readable and clear
+
+### Review Questions
+
+**Ask yourself**:
+
+- Can I understand this without reading code?
+- Would this guide someone to build the right thing?
+- Are examples realistic? Will they work?
+- Is anything over-complex?
+- Is anything missing?
+- Does this align with project philosophy?
+
+---
+
+## Iteration Cycle
+
+### If Issues Found
+
+1. **Provide feedback** to AI
+2. **AI fixes issues** in documentation
+3. **Return to Phase 1** for affected files
+4. **Return to review**
+5. **Do NOT commit** - keep iterating
+
+**Iterate until right** - No commits during iteration.
+
+**Why**: Prevents git log thrashing with wrong versions.
+
+### If Approved
+
+1. **Explicitly approve**: "This looks good, proceed to implementation"
+2. **AI commits documentation**:
+
+```bash
+git add docs/ README.md *.md
+git commit -m "docs: Complete [feature name] documentation retcon
+
+- Updated all docs to reflect target state
+- Deleted duplicate documentation (DRY principle)
+- Fixed terminology: [old] → [new]
+- Organized for progressive learning
+
+Following Document-Driven Development approach.
+Documentation is specification - code implementation follows.
+
+Reviewed and approved by: [human name]"
+```
+
+3. **Documentation is now the specification**
+4. **No code changes without doc changes from this point**
+
+---
+
+## Why Wait Until Approval
+
+**Prevents**:
+
+- Git log thrashing with wrong commits
+- Implementing against flawed design
+- Wasted iteration time
+
+**Ensures**:
+
+- Clean git history (only approved designs)
+- Design is right before implementation
+- Documentation remains authoritative
+
+---
+
+## Output of Phase 2
+
+When complete:
+
+- ✅ Documentation reviewed by human
+- ✅ Design approved
+- ✅ **Documentation committed** (with approval note)
+- ✅ Specification locked
+- ⚠️ **NOT pushed yet** - implementation next
+
+**Ready for**: [Phase 3: Implementation Planning](03_implementation_planning.md)
+
+---
+
+## Tips
+
+**For Humans**:
+
+- Review thoroughly - cheapest checkpoint
+- Iterate until right before approving
+- Be specific about what needs changing
+- Approve explicitly when satisfied
+
+**For AI**:
+
+- Don't commit until explicit approval
+- Apply feedback systematically
+- Return to Phase 1 process for fixes
+- Wait patiently for approval
+
+---
+
+**Return to**: [Phases](README.md) | [Main Index](../README.md)
+
+**Prerequisites**: [Phase 1: Documentation Retcon](01_documentation_retcon.md)
+
+**Next Phase**: [Phase 3: Implementation Planning](03_implementation_planning.md)

--- a/docs/document_driven_development/phases/03_implementation_planning.md
+++ b/docs/document_driven_development/phases/03_implementation_planning.md
@@ -1,0 +1,128 @@
+# Phase 3: Implementation Planning
+
+> [Home](../../index.md) > [Document-Driven Development](../README.md) > [Phases](README.md) > Phase 3
+
+**Create detailed plan for making code match documentation exactly**
+
+---
+
+## Goal
+
+Create comprehensive plan showing how code will match documentation. Understand full scope before coding.
+
+**Why plan first**: Reveals dependencies, complexity, proper sequencing. Prevents mid-implementation surprises.
+
+---
+
+## The Steps
+
+### Step 1: Code Reconnaissance
+
+Use [file crawling](../core_concepts/file_crawling.md) to understand current state:
+
+```bash
+# Generate index of code files
+find amplifier-core amplifier-app-cli -type f -name "*.py" \
+  ! -path "*/__pycache__/*" ! -path "*/.venv/*" \
+  > /tmp/code_files.txt
+
+# Process systematically
+# For each file: read, understand, note changes needed
+```
+
+**If conflicts detected** between docs and code:
+
+**⚠️ PAUSE**: Present to human with options. See [context poisoning detection](../core_concepts/context_poisoning.md#detection-and-resolution).
+
+### Step 2: Create Implementation Specification
+
+Document exactly what needs to change:
+
+```markdown
+# Implementation Plan - [Feature Name]
+
+## Current State
+
+- ✅ What exists and works
+- ❌ What's missing
+- ⚠️ What needs modification
+
+## Changes Required
+
+### Core Classes
+
+**File**: path/to/file.py
+**Purpose**: What it does
+**Methods**: List of methods
+**Dependencies**: What it needs
+**Estimated lines**: ~150
+**Philosophy check**: Mechanism/policy alignment
+
+[... detailed breakdown ...]
+
+## Dependencies Between Changes
+
+1. X depends on Y (build Y first)
+2. Z requires X and Y (build last)
+
+## Proper Sequencing
+
+Phase 1: Core classes (foundation)
+Phase 2: Commands (builds on core)
+Phase 3: Tests (validates)
+
+## Complexity Check
+
+- New abstractions: 2
+- Justification: Why needed
+- Alternative: What else considered
+- Why chosen: Reasoning
+
+## Estimated Effort
+
+- Component A: 2-3 hours
+- Component B: 1-2 hours
+  Total: 8-11 hours, +850 lines
+
+## Philosophy Compliance
+
+- ✅ Ruthless simplicity
+- ✅ Bricks and studs
+- ✅ Right-sized modules
+```
+
+### Step 3: Right-Sizing Check
+
+Each chunk should:
+
+- ✅ Fit in AI context window (~4000-8000 lines)
+- ✅ Have clear boundaries
+- ✅ Be independently testable
+- ✅ Be regeneratable from spec
+
+**If too large**: Break into smaller modules with clear interfaces.
+
+---
+
+## Output of Phase 3
+
+When complete:
+
+- ✅ Detailed implementation plan documented
+- ✅ Work properly right-sized
+- ✅ Dependencies identified
+- ✅ Sequencing determined
+- ✅ Conflicts resolved
+- ✅ Philosophy alignment verified
+
+**Ready for**: [Phase 4: Code Implementation](04_code_implementation.md)
+
+---
+
+**Return to**: [Phases](README.md) | [Main Index](../README.md)
+
+**Prerequisites**: [Phase 2: Approval Gate](02_approval_gate.md)
+
+**Core Techniques**: [File Crawling](../core_concepts/file_crawling.md)
+
+**Philosophy**: [MODULAR_DESIGN_PHILOSOPHY.md](../../concepts/philosophy.md)

--- a/docs/document_driven_development/phases/04_code_implementation.md
+++ b/docs/document_driven_development/phases/04_code_implementation.md
@@ -1,0 +1,39 @@
+# Phase 4: Code Implementation
+
+> [Home](../../index.md) > [Document-Driven Development](../README.md) > [Phases](README.md) > Phase 4
+
+**Make code match documentation exactly**
+
+---
+
+## Goal
+
+Implement code that matches documentation specification exactly. Code follows docs, not the other way around.
+
+**Philosophy reminder**: If implementation needs to differ, update docs first (with approval).
+
+---
+
+## General Principles
+
+1. **Code follows docs exactly** - No deviation without doc update
+2. **Load full context first** - Read all related files before coding
+3. **Implement in phases** - Smaller chunks, test as you go
+4. **Use [file crawling](../core_concepts/file_crawling.md)** - For large changes
+5. **PAUSE on conflicts** - Don't guess, ask user
+6. **Commit incrementally** - Logical feature groupings
+
+---
+
+## File Crawling for Code Changes
+
+For large-scale changes:
+
+```bash
+# Generate code file index
+cat > /tmp/code_to_implement.txt << 'EOF'
+[ ] amplifier-core/amplifier_core/config/provider_manager.py
+[ ] amplifier-core/amplifier_core/config/module_manager.py
+[ ] amplifier-app-cli/amplifier_app_cli/commands/init.py
+[ ] amplifier-app-cli/amplifier_app_cli/commands/provider.py
+```

--- a/docs/document_driven_development/phases/05_testing_and_verification.md
+++ b/docs/document_driven_development/phases/05_testing_and_verification.md
@@ -1,0 +1,751 @@
+# Phase 5: Testing & Verification
+
+> [Home](../../index.md) > [Document-Driven Development](../README.md) > [Phases](README.md) > Phase 5
+
+**Verify code matches documentation specification and works as users will use it**
+
+---
+
+## Goal
+
+Verify that code matches documentation specification through two critical layers:
+
+1. **Test documented behaviors** - Does code do what docs promise?
+2. **Test as actual user** - Does it work the way users will use it?
+
+**Philosophy**: Test what docs promise. If docs say it works, it must work. AI is the QA entity before human review.
+
+---
+
+## Why Two Testing Layers?
+
+### Code-Based Tests (Traditional)
+
+**What they verify**:
+
+- Implementation details
+- Unit logic correctness
+- Integration points
+- Edge cases
+
+**What they miss**:
+
+- Confusing UX
+- Broken end-to-end workflows
+- Unclear output messages
+- Real-world usage patterns
+
+### User Testing (Critical Addition)
+
+**What it verifies**:
+
+- Actual user experience
+- End-to-end workflows
+- Output clarity
+- Integration with real environment
+- Behavior matches documentation
+
+**What it catches**:
+
+- Commands that technically work but are confusing
+- Output that's correct but unclear
+- Workflows broken end-to-end
+- Integration issues between components
+- Real scenarios not covered by unit tests
+
+**Together**: Comprehensive verification of both implementation AND experience.
+
+---
+
+## Overview of Steps
+
+```
+Step 1: Test Against Specification
+    ↓
+Step 2: Systematic Testing (file crawling)
+    ↓
+Step 3: Test As User Would (CRITICAL)
+    ↓
+Step 4: Create User Testing Report
+    ↓
+Step 5: Handle Mismatches
+    ↓
+Step 6: Code-Based Test Verification
+    ↓
+Ready for Phase 6 (Cleanup & Push)
+```
+
+---
+
+## Step 1: Test Against Specification
+
+For each documented behavior, verify it works:
+
+1. **Find the doc** - Where is this behavior described?
+2. **Extract the example** - What command/code does doc show?
+3. **Run the example** - Does it actually work?
+4. **Verify output** - Does it match what docs say?
+5. **Test edge cases** - Error handling, invalid inputs
+
+**Example**:
+
+```bash
+# From docs/USER_ONBOARDING.md:45
+amplifier provider use anthropic --model claude-opus-4 --local
+
+# Run it
+$ amplifier provider use anthropic --model claude-opus-4 --local
+
+# Verify output matches docs
+Expected: "✓ Provider configured: anthropic (claude-opus-4)"
+Actual: [must match]
+
+# Verify behavior
+$ amplifier provider current
+Expected: Shows anthropic with claude-opus-4
+Actual: [must match]
+```
+
+---
+
+## Step 2: Systematic Testing with File Crawling
+
+Use [file crawling](../core_concepts/file_crawling.md) for comprehensive testing:
+
+```bash
+# Generate test checklist from documentation
+cat > /tmp/test_checklist.txt << 'EOF'
+[ ] Test: README.md Quick Start flow
+[ ] Test: USER_ONBOARDING.md provider use command
+[ ] Test: USER_ONBOARDING.md provider list command
+[ ] Test: USER_ONBOARDING.md profile use with --local
+[ ] Test: API.md provider configuration examples
+[ ] Test: Error handling for missing API key
+[ ] Test: Error handling for invalid provider
+EOF
+
+# Process each test
+while [ $(grep -c "^\[ \]" /tmp/test_checklist.txt) -gt 0 ]; do
+  NEXT=$(grep -m1 "^\[ \]" /tmp/test_checklist.txt | sed 's/\[ \] Test: //')
+
+  echo "Testing: $NEXT"
+
+  # AI runs this test:
+  # 1. Extract example from doc
+  # 2. Run it
+  # 3. Verify output
+  # 4. Pass/fail
+
+  sed -i "s|\[ \] Test: $NEXT|[x] Test: $NEXT|" /tmp/test_checklist.txt
+done
+```
+
+---
+
+## Step 3: Test As User Would (CRITICAL)
+
+**This is AI's QA role** - Before handing to human, AI must test as actual user.
+
+### Why This Matters
+
+**Code-based tests verify**: Implementation details
+**User testing verifies**: Actual experience
+
+**What user testing catches**:
+
+- Commands that work but are confusing
+- Output that's correct but unclear
+- Workflows broken end-to-end
+- Integration issues
+- Real-world scenarios not in unit tests
+
+### Testing Approach
+
+**Identify user scenarios from documentation**:
+
+- What are the main use cases?
+- What does Quick Start promise?
+- What workflows are documented?
+
+**Actually run the tool as user would**:
+
+- Not just unit tests
+- Not mocked environment
+- Real CLI commands
+- Real user workflows
+
+**Observe everything**:
+
+- Command output (clear? correct?)
+- Logs generated (any errors/warnings?)
+- State changes (files created/modified correctly?)
+- Artifacts produced (as expected?)
+- System behavior (performance? responsiveness?)
+
+**Verify expectations**:
+
+- Does behavior match documentation?
+- Would a user be confused?
+- Are error messages helpful?
+- Does workflow feel smooth?
+
+### Example User Testing Session
+
+```markdown
+# User Testing Session - Provider Management Feature
+
+## Test Environment
+
+- OS: Ubuntu 22.04
+- Python: 3.11.5
+- Fresh install: Yes
+
+## Scenario 1: First-time setup with Anthropic
+
+**Documentation reference**: README.md Quick Start
+
+**Steps (as user would do)**:
+
+1. Install: `uvx --from git+https://...@next amplifier`
+2. Run: `amplifier`
+3. Follow init wizard prompts
+
+**Observations**:
+
+- ✅ Init wizard appeared automatically
+- ✅ Provider selection clear (1-4 options)
+- ✅ API key prompt clear with link
+- ✅ Model selection presented options
+- ✅ Profile selection clear
+- ✅ Success message displayed
+- ✅ Chat started immediately after
+
+**Output examined**:
+```
+
+Welcome to Amplifier!
+
+First time? Let's get you set up.
+
+Provider? [1] Anthropic [2] OpenAI [3] Azure OpenAI [4] Ollama: 1
+API key: ••••••••
+Get one: https://console.anthropic.com/settings/keys
+✓ Saved to ~/.amplifier/keys.env
+
+Model? [1] claude-sonnet-4-5 [2] claude-opus-4 [3] custom: 1
+✓ Using claude-sonnet-4-5
+
+Profile? [1] dev [2] base [3] full: 1
+✓ Activated profile: dev
+
+Ready! Starting chat...
+
+```
+
+**Artifacts checked**:
+- ✅ `~/.amplifier/keys.env` created with ANTHROPIC_API_KEY
+- ✅ `.amplifier/settings.local.yaml` created with provider config
+- ✅ Profile 'dev' activated correctly
+
+**Behavior assessment**:
+- ✅ Matches documentation exactly
+- ✅ User experience smooth, no confusion
+- ✅ Error handling clear (tested with invalid input)
+
+## Scenario 2: Switching providers mid-project
+
+**Documentation reference**: USER_ONBOARDING.md Provider Management
+
+**Steps (as user would do)**:
+1. Check current: `amplifier provider current`
+2. Switch: `amplifier provider use openai --model gpt-4o --local`
+3. Verify: `amplifier provider current`
+4. Test: `amplifier run "test message"`
+
+**Observations**:
+- ✅ Current command shows provider clearly
+- ✅ Switch command accepted
+- ⚠️ Warning shown: OpenAI key not found
+- ✅ Helpful error message with next steps
+- ❌ **BUG FOUND**: Chat tried to use OpenAI without key, crashed
+
+**Output examined**:
+```
+
+$ amplifier provider current
+Current provider: anthropic (claude-sonnet-4-5)
+Scope: local
+
+$ amplifier provider use openai --model gpt-4o --local
+⚠️ OpenAI API key not found
+Run: amplifier init
+Or set: OPENAI_API_KEY in ~/.amplifier/keys.env
+✓ Provider configured: openai (gpt-4o)
+
+$ amplifier run "test"
+Error: OpenAI API key not found
+Set OPENAI_API_KEY environment variable
+
+```
+
+**Behavior assessment**:
+- ✅ Warning appropriate
+- ❌ **CRITICAL**: Crash is bad UX
+- 📝 **RECOMMENDATION**: Add validation before allowing provider switch
+
+## Scenario 3: Smoke tests (integration points)
+
+**Areas not directly changed but should still work**:
+
+Profile management:
+- ✅ `amplifier profile list` works
+- ✅ `amplifier profile current` shows active
+- ✅ `amplifier profile use base` switches correctly
+
+Module management:
+- ✅ `amplifier module list` works
+- ✅ `amplifier module show tool-bash` shows details
+
+Chat functionality:
+- ✅ `amplifier` starts chat with configured provider
+- ✅ Sending message works, gets response
+- ✅ `/status` command shows provider info
+
+**Assessment**: Integration points intact, no regressions detected
+```
+
+### What to Test
+
+**Changed areas** (thorough):
+
+- All new commands
+- All modified workflows
+- All updated behaviors
+- Provider-specific paths
+- Scope variations
+
+**Integration points** (smoke test):
+
+- Related features still work
+- No regressions introduced
+- Cross-cutting scenarios function
+- Existing workflows intact
+
+**Edge cases**:
+
+- Invalid inputs
+- Missing configuration
+- Error scenarios
+- Boundary conditions
+
+---
+
+## Step 4: Create User Testing Report
+
+### Report Template
+
+Save detailed findings to `ai_working/user_testing_report.md`:
+
+```markdown
+# User Testing Report - [Feature Name]
+
+## Test Environment
+
+- OS: [operating system]
+- Python: [version]
+- Fresh install: [yes/no]
+
+## Scenarios Tested
+
+### Scenario 1: [Name]
+
+**Documentation reference**: [file:section]
+
+**Steps (as user would do)**:
+
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+**Observations**:
+
+- ✅ [What worked]
+- ⚠️ [Warnings/concerns]
+- ❌ [What failed]
+
+**Output examined**:
+```
+
+[Actual command output]
+
+```
+
+**Artifacts checked**:
+- ✅ [Files created correctly]
+- ✅ [State persisted correctly]
+
+**Behavior assessment**:
+- ✅ Matches documentation: [yes/no]
+- ✅ User experience smooth: [yes/no]
+- 📝 Recommendations: [any improvements]
+
+[... additional scenarios ...]
+
+## Issues Found
+
+### Critical
+1. **[Issue name]**
+   - Severity: High
+   - Impact: [description]
+   - Recommendation: [fix or workaround]
+
+### Minor
+[List minor issues]
+
+### Improvements
+[Suggested improvements not blocking]
+
+## Test Coverage Assessment
+
+### Thoroughly tested
+- ✅ [Main feature areas]
+- ✅ [All providers/variations]
+
+### Smoke tested
+- ✅ [Integration points]
+- ✅ [Existing features]
+
+### Not tested
+- ℹ️ [Out of scope items]
+```
+
+### Present Summary to Human
+
+```markdown
+# User Testing Complete
+
+## Summary
+
+- Tested 3 main scenarios + smoke tests
+- Found 1 critical issue (provider switch validation)
+- 0 minor issues
+- All documented behaviors work correctly
+
+## Issues Requiring Action
+
+### Critical: Provider switch without API key crashes
+
+When user switches provider but doesn't have API key configured,
+chat attempts to use provider anyway and crashes.
+
+**Recommendation**: Add validation to prevent switch until key
+configured, or gracefully degrade with clear error.
+
+## Detailed Report
+
+See: ai_working/user_testing_report.md
+
+## Recommended Smoke Tests for You (~12 minutes)
+
+As actual user of the tool, try these scenarios:
+
+1. **Fresh setup flow** (5 minutes)
+   - Delete `~/.amplifier/` and `.amplifier/`
+   - Run `amplifier` and go through init wizard
+   - Verify it feels smooth and clear
+
+2. **Provider switching** (2 minutes)
+   - Try switching between providers you have keys for
+   - Check that chat actually uses new provider
+   - Verify `amplifier provider current` is accurate
+
+3. **Azure OpenAI** (if available) (3 minutes)
+   - Run init with Azure OpenAI option
+   - Verify endpoint/deployment flow makes sense
+   - Test Azure CLI auth if available
+
+4. **Error scenarios** (2 minutes)
+   - Try provider without API key (should fail gracefully)
+   - Try invalid provider name (should show helpful error)
+   - Try malformed endpoint (should validate)
+
+These test main flows and integration points without requiring
+deep technical knowledge. Run as you would naturally use the tool.
+```
+
+**Key points**:
+
+- High-level summary for quick understanding
+- Critical issues highlighted
+- Link to detailed report for depth
+- Recommended smoke tests described as user would run them
+- NOT code snippets, actual tool usage
+
+---
+
+## Step 5: Handle Mismatches
+
+### When Tests Reveal Problems
+
+**Option A: Code is wrong**
+
+```markdown
+# Test failed: provider use command
+
+Expected (from docs): "✓ Provider configured: anthropic"
+Actual: "Error: model is required"
+
+Analysis: Code requires --model but docs say it's optional
+
+Resolution: Fix code to match docs (model should be optional
+with sensible default)
+```
+
+**Action**: Fix code to match documentation
+
+**Option B: Docs are wrong**
+
+```markdown
+# Test failed: provider list command
+
+Expected (from docs): Shows 4 providers
+Actual: Shows 3 providers (missing Ollama)
+
+Analysis: Docs mention Ollama but it's not implemented
+
+Resolution: Either implement Ollama OR update docs to remove it
+This requires returning to Phase 1 to fix documentation.
+```
+
+**Action**: PAUSE, propose doc fix to user, get approval, return to Phase 1
+
+**Option C: Design was wrong**
+
+```markdown
+# Test failed: profile use command
+
+Expected (from docs): amplifier profile use dev --local
+Actual: Command doesn't accept --local flag
+
+Analysis: Realized during implementation that --local doesn't
+make sense for profiles (profiles are session-level)
+
+Resolution: Design discussion needed with human
+```
+
+**Action**: PAUSE, document issue, get human guidance
+
+### Critical Rule
+
+**Documentation remains source of truth**:
+
+- If docs are wrong, fix docs first
+- Get approval on doc changes
+- Then update code to match
+- Never let them diverge
+
+### Updating Documentation When Needed
+
+**If implementation reveals documentation was wrong**:
+
+1. **Stop testing**
+2. **Document what's wrong and why**
+3. **Propose fix to user**
+4. **Get approval**
+5. **Return to Phase 1** - Fix documentation
+6. **Update implementation to match corrected docs**
+7. **Resume testing**
+
+---
+
+## Step 6: Code-Based Test Verification
+
+**In addition to user testing**, verify code-based tests pass:
+
+```bash
+# Run all tests
+make test
+
+# Run all checks (lint, format, type check)
+make check
+
+# Both must pass before proceeding
+```
+
+**What code tests verify**:
+
+- Unit tests: Logic correctness
+- Integration tests: Component interaction
+- Type checking: Type safety
+- Linting: Code quality
+- Formatting: Style consistency
+
+**Philosophy compliance** (from [IMPLEMENTATION_PHILOSOPHY.md](../../concepts/philosophy.md)):
+
+- Test real bugs, not code inspection
+- Test runtime invariants
+- Test edge cases
+- Don't test obvious things
+
+---
+
+## Completion Checklist
+
+Before considering Phase 5 complete:
+
+- [ ] All documented examples tested and working
+- [ ] **User testing complete** (AI tested as actual user)
+- [ ] **User testing report created** (detailed in ai_working/)
+- [ ] **Recommended smoke tests provided** (for human to run)
+- [ ] Error handling tested (invalid inputs, edge cases)
+- [ ] Output matches documentation descriptions
+- [ ] Cross-cutting scenarios tested
+- [ ] Performance acceptable (no obvious bottlenecks)
+- [ ] All code-based tests passing: `make test`
+- [ ] All checks passing: `make check`
+- [ ] **Critical issues resolved** or documented for user
+- [ ] Documentation updated if mismatches found
+
+---
+
+## Output of Phase 5
+
+When complete:
+
+- ✅ All documented behaviors verified working
+- ✅ Tested as user would use it
+- ✅ Comprehensive user testing report created
+- ✅ Recommendations for human smoke tests provided
+- ✅ All code-based tests passing
+- ✅ Critical issues resolved or documented
+- ✅ Docs updated if needed (with approval)
+
+**Ready for**: [Phase 6: Cleanup & Push](06_cleanup_and_push.md)
+
+---
+
+## Real-World Example: Detailed User Testing
+
+This example shows what thorough user testing looks like:
+
+### Scenario: Provider Configuration Feature
+
+**Test environment setup**:
+
+```bash
+# Fresh environment
+rm -rf ~/.amplifier .amplifier
+
+# Verify clean state
+ls ~/.amplifier  # Should not exist
+```
+
+**Test execution**:
+
+```bash
+# Run as user would
+$ amplifier
+
+# Follow wizard
+Provider? [1] Anthropic [2] OpenAI [3] Azure OpenAI [4] Ollama: 1
+[... following prompts ...]
+
+# Test provider switching
+$ amplifier provider use openai --model gpt-4o --local
+$ amplifier provider current
+
+# Test error scenarios
+$ amplifier provider use invalid-provider
+$ amplifier provider use anthropic  # Missing required flag
+```
+
+**Observations documented**:
+
+- What output appeared
+- What files were created/modified
+- What warnings/errors shown
+- How behavior matched docs
+- What felt confusing
+- What worked well
+
+**Issues found**:
+
+- Critical: Provider switch without key crashes
+- Minor: Warning message could be clearer
+- Improvement: Consider `amplifier provider test` command
+
+**Assessment**:
+
+- 90% matches documentation
+- 1 critical bug found and documented
+- User experience mostly smooth
+- Recommendations provided
+
+**Result**: Detailed report in `ai_working/user_testing_report.md` with summary for human.
+
+---
+
+## Tips for Success
+
+### For AI Assistants
+
+1. **Actually run the tool** - Don't just read code
+2. **Test as real user** - Follow documented workflows
+3. **Observe everything** - Output, logs, state, artifacts
+4. **Document thoroughly** - What worked, what didn't
+5. **Be honest about issues** - Don't hide problems
+6. **Provide recommendations** - Suggest fixes or improvements
+7. **Guide human testing** - Recommend scenarios to verify
+
+### For Humans
+
+1. **Review user testing report** - AI's findings are valuable
+2. **Run recommended smoke tests** - Quick verification
+3. **Test edge cases AI might miss** - Domain expertise
+4. **Verify on different environment** - AI tested on one environment
+5. **Trust but verify** - AI is good QA, but not perfect
+
+---
+
+## Common Issues
+
+### Issue: AI only runs unit tests
+
+**Problem**: AI runs `make test` and considers testing done
+
+**Fix**: Explicitly ask AI to "test as user would use it" - actual CLI commands, real workflows
+
+### Issue: Mocked testing instead of real
+
+**Problem**: AI creates mock environment instead of testing real tool
+
+**Fix**: Specify "real environment, not mocked" - actual installation, actual commands
+
+### Issue: No user testing report
+
+**Problem**: AI tests but doesn't document findings
+
+**Fix**: Require detailed report in ai_working/ with summary and recommendations
+
+---
+
+## Next Phase
+
+**When Phase 5 complete**: [Phase 6: Cleanup & Push](06_cleanup_and_push.md)
+
+**Before proceeding**:
+
+- All tests passing (code and user)
+- User testing report created
+- Critical issues resolved
+- Ready for final cleanup
+
+---
+
+**Return to**: [Phases](README.md) | [Main Index](../README.md)
+
+**Prerequisites**: [Phase 4: Code Implementation](04_code_implementation.md)
+
+**Core Techniques**: [File Crawling](../core_concepts/file_crawling.md)
+
+**Philosophy**: [IMPLEMENTATION_PHILOSOPHY.md](../../concepts/philosophy.md)

--- a/docs/document_driven_development/phases/06_cleanup_and_push.md
+++ b/docs/document_driven_development/phases/06_cleanup_and_push.md
@@ -1,0 +1,160 @@
+# Phase 6: Cleanup & Push
+
+> [Home](../../index.md) > [Document-Driven Development](../README.md) > [Phases](README.md) > Phase 6
+
+**Remove temporary files, verify completeness, push changes**
+
+---
+
+## Goal
+
+Clean up temporary artifacts, perform final verification, and push clean, complete work to remote.
+
+---
+
+## The Steps
+
+### Step 1: Cleanup Temporary Files
+
+```bash
+# Remove file crawling indexes
+rm /tmp/docs_checklist.txt
+rm /tmp/docs_to_process.txt
+rm /tmp/code_to_implement.txt
+rm /tmp/test_checklist.txt
+
+# Review ai_working/ directory
+ls -la ai_working/
+
+# Archive valuable reports
+mkdir -p ai_working/archive/$(date +%Y-%m-%d)-feature-name
+mv ai_working/user_testing_report.md ai_working/archive/.../
+
+# Delete pure working files
+rm ai_working/implementation_tracking.md
+```
+
+**Generally**: Don't commit `ai_working/` unless files are broadly valuable.
+
+### Step 2: Final Verification
+
+Before pushing:
+
+- [ ] All todos complete
+- [ ] All tests passing: `make test`
+- [ ] All checks passing: `make check`
+- [ ] Documentation and code in perfect sync
+- [ ] No temporary/debug code
+- [ ] No debugging print() statements
+- [ ] Commit messages clear
+- [ ] No uncommitted changes: `git status` clean
+- [ ] Philosophy principles followed
+
+**Philosophy verification**:
+
+```markdown
+## IMPLEMENTATION_PHILOSOPHY.md
+
+- ✅ Ruthless simplicity
+- ✅ Minimal implementation
+- ✅ Clear over clever
+
+## MODULAR_DESIGN_PHILOSOPHY.md
+
+- ✅ Bricks and studs (clear interfaces)
+- ✅ Regeneratable from spec
+- ✅ Self-contained modules
+```
+
+### Step 3: Push Changes
+
+```bash
+# Review all commits
+git log origin/main..HEAD --oneline
+
+# Verify branch
+git branch --show-current
+
+# Push
+git push origin <branch-name>
+```
+
+---
+
+## PR Description Template
+
+If pushing triggers PR creation:
+
+```markdown
+# [Feature Name]
+
+## Summary
+
+Implements [feature] as specified in documentation.
+
+## Documentation
+
+- [docs/USER_ONBOARDING.md](link) - User guide
+- [docs/API.md](link) - Technical reference
+- [README.md](link) - Quick start updated
+
+## Implementation
+
+- Added [key components]
+- Updated [modified areas]
+- Comprehensive tests
+
+## Testing
+
+### Code Tests
+
+- ✅ Unit tests: 45 tests, 100% coverage
+- ✅ Integration tests: End-to-end verified
+- ✅ All checks passing
+
+### User Testing (AI QA)
+
+- ✅ Tested 3 main scenarios as actual user
+- ✅ Smoke tested integration points
+- ✅ 1 critical issue found and fixed
+- ✅ Report: ai_working/archive/.../user_testing_report.md
+
+### Recommended Human Verification (~12 minutes)
+
+- Fresh setup flow
+- Provider switching
+- Error handling
+
+## Philosophy Compliance
+
+- ✅ Ruthless simplicity
+- ✅ Modular design
+- ✅ Documentation-driven
+- ✅ Context-poison-free
+
+## Breaking Changes
+
+None - additive functionality
+```
+
+---
+
+## Output of Phase 6
+
+When complete:
+
+- ✅ Temporary files cleaned
+- ✅ Final verification complete
+- ✅ All tests and checks passing
+- ✅ Documentation and code in perfect sync
+- ✅ Clean git history
+- ✅ Pushed to remote
+- ✅ Ready for human review
+
+**DDD Cycle Complete!**
+
+---
+
+**Return to**: [Phases](README.md) | [Main Index](../README.md)
+
+**Prerequisites**: [Phase 5: Testing & Verification](05_testing_and_verification.md)

--- a/docs/document_driven_development/phases/README.md
+++ b/docs/document_driven_development/phases/README.md
@@ -1,0 +1,41 @@
+# Process Phases
+
+**Step-by-step guides for each phase of Document-Driven Development**
+
+---
+
+## The Process Flow
+
+```
+Phase 0: Planning & Alignment → Shared understanding
+    ↓
+Phase 1: Documentation Retcon → All docs updated
+    ↓
+Phase 2: Approval Gate ←────┐
+    ↓                        │ Iterate until right
+    ├─────────────────────────┘
+    ↓
+Phase 3: Implementation Planning → Detailed plan
+    ↓
+Phase 4: Code Implementation → Code matches docs
+    ↓
+Phase 5: Testing & Verification → Verify matches docs
+    ↓
+Phase 6: Cleanup & Push → Clean and push
+```
+
+---
+
+## Phase Guides
+
+- [Phase 0: Planning & Alignment](00_planning_and_alignment.md) - Achieve shared understanding
+- [Phase 1: Documentation Retcon](01_documentation_retcon.md) - Update all docs to target state
+- [Phase 2: Approval Gate](02_approval_gate.md) - Human review and iteration
+- [Phase 3: Implementation Planning](03_implementation_planning.md) - Create detailed plan
+- [Phase 4: Code Implementation](04_code_implementation.md) - Code matches docs
+- [Phase 5: Testing & Verification](05_testing_and_verification.md) - Test as user would
+- [Phase 6: Cleanup & Push](06_cleanup_and_push.md) - Finalize and push
+
+---
+
+Return to [Main Index](../README.md)

--- a/docs/document_driven_development/reference/README.md
+++ b/docs/document_driven_development/reference/README.md
@@ -1,0 +1,27 @@
+# Reference Materials
+
+**Practical resources for Document-Driven Development**
+
+---
+
+## Available Resources
+
+### [Checklists](checklists.md)
+
+Phase-by-phase verification checklists. Use these to ensure nothing is missed.
+
+### [Tips for Success](tips_for_success.md)
+
+Best practices for humans and AI assistants.
+
+### [Common Pitfalls](common_pitfalls.md)
+
+What goes wrong, how to recognize it, and how to fix it.
+
+### [FAQ](faq.md)
+
+Frequently asked questions with clear answers.
+
+---
+
+Return to [Main Index](../README.md)

--- a/docs/document_driven_development/reference/checklists.md
+++ b/docs/document_driven_development/reference/checklists.md
@@ -1,0 +1,207 @@
+# Checklists
+
+**Phase-by-phase verification checklists for Document-Driven Development**
+
+---
+
+## Overview
+
+Use these checklists to verify completion of each phase. Check off items as you complete them to ensure nothing is missed.
+
+---
+
+## Phase 0: Planning & Alignment
+
+- [ ] Problem clearly framed with scope and success criteria
+- [ ] Reconnaissance complete ([file crawling](../core_concepts/file_crawling.md) if large)
+- [ ] Multiple proposals considered (2-3 options)
+- [ ] Trade-offs discussed openly
+- [ ] Shared understanding achieved and verified
+- [ ] AI can articulate plan back accurately
+- [ ] Master plan captured (TodoWrite or ai_working/ file)
+- [ ] Philosophy alignment verified
+- [ ] **User explicitly approves proceeding**
+
+**Ready for**: [Phase 1](../phases/01_documentation_retcon.md)
+
+---
+
+## Phase 1: Documentation Retcon
+
+- [ ] File index generated programmatically
+- [ ] [File crawling](../core_concepts/file_crawling.md) approach used systematically
+- [ ] Each file processed individually (not batch marked)
+- [ ] Full file content read before changes
+- [ ] [Retcon writing rules](../core_concepts/retcon_writing.md) followed strictly
+- [ ] Maximum DRY enforced (duplicates deleted)
+- [ ] Global replacements used as helper only (not substitute)
+- [ ] Conflicts detected and resolved (if any)
+- [ ] Progressive organization applied
+- [ ] Verification pass complete
+- [ ] **NOT committed yet** - ready for approval
+- [ ] All files in checklist marked `[x]`
+
+**Ready for**: [Phase 2](../phases/02_approval_gate.md)
+
+---
+
+## Phase 2: Approval Gate
+
+- [ ] Human reviewed all documentation
+- [ ] Design verified correct and complete
+- [ ] Terminology verified accurate and canonical
+- [ ] Complexity captured honestly
+- [ ] Examples verified realistic and correct
+- [ ] Philosophy compliance confirmed
+- [ ] No duplication or [context poisoning](../core_concepts/context_poisoning.md) sources
+- [ ] Progressive organization makes sense
+- [ ] Human-readable and clear
+- [ ] **Iterate with human until approved**
+- [ ] User explicitly approves: "proceed to implementation"
+- [ ] **NOW commit documentation** with approval note
+- [ ] **NOT pushed yet** - implementation next
+
+**Ready for**: [Phase 3](../phases/03_implementation_planning.md)
+
+---
+
+## Phase 3: Implementation Planning
+
+- [ ] Code reconnaissance complete ([file crawling](../core_concepts/file_crawling.md))
+- [ ] Conflicts between docs and code resolved
+- [ ] Implementation plan documented in detail
+- [ ] Work properly right-sized (fits in context window)
+- [ ] Dependencies identified
+- [ ] Proper sequencing determined
+- [ ] Complexity check performed
+- [ ] Effort estimated
+- [ ] Philosophy alignment verified
+
+**Ready for**: [Phase 4](../phases/04_code_implementation.md)
+
+---
+
+## Phase 4: Code Implementation
+
+- [ ] [File crawling](../core_concepts/file_crawling.md) approach used for large changes
+- [ ] Full context loaded before each subtask
+- [ ] Related docs, code, and tests read first
+- [ ] Conflicts detected and paused on (if any)
+- [ ] Code matches docs exactly
+- [ ] No deviation without doc update first
+- [ ] Changes committed incrementally by logical feature
+- [ ] Clear commit messages
+- [ ] All implementation checklist items marked complete
+
+**Ready for**: [Phase 5](../phases/05_testing_and_verification.md)
+
+---
+
+## Phase 5: Testing & Verification
+
+- [ ] All documented examples tested
+- [ ] Examples work when copy-pasted
+- [ ] **User testing complete** (AI tested as actual user)
+- [ ] **User testing report created** (detailed in ai_working/)
+- [ ] **Recommended smoke tests provided** (for human)
+- [ ] Output matches documentation descriptions
+- [ ] Error handling tested (invalid inputs, edge cases)
+- [ ] Cross-cutting scenarios tested
+- [ ] All code-based tests passing: `make test`
+- [ ] All checks passing: `make check`
+- [ ] Performance acceptable
+- [ ] **Critical issues resolved** or documented
+- [ ] Docs updated if mismatches found (with approval)
+
+**Ready for**: [Phase 6](../phases/06_cleanup_and_push.md)
+
+---
+
+## Phase 6: Cleanup & Push
+
+- [ ] Temporary files removed or archived
+- [ ] ai_working/ reviewed and cleaned
+- [ ] All tests passing
+- [ ] All checks passing
+- [ ] Documentation and code in perfect sync
+- [ ] No temporary/debug code
+- [ ] Commit messages clear
+- [ ] Philosophy principles followed throughout
+- [ ] Final verification complete
+- [ ] **Changes pushed to remote**
+
+**DDD Cycle Complete!**
+
+---
+
+## Quick Verification Commands
+
+### Check Documentation Consistency
+
+```bash
+# No old terminology
+grep -rn "old-term" docs/
+
+# No historical references
+grep -rn "previously\|used to\|old way" docs/
+
+# No future tense
+grep -rn "will be\|coming soon" docs/
+
+# No duplicate concepts
+grep -rn "concept definition" docs/  # Should be single location
+```
+
+### Check Implementation Quality
+
+```bash
+# Run tests
+make test
+
+# Run checks
+make check
+
+# Verify no debug code
+grep -rn "print(\|console.log\|debugger" --include="*.py" --include="*.js"
+
+# Check git status
+git status  # Should be clean
+```
+
+### Check Context Poisoning
+
+```bash
+# No duplicate documentation
+# Each concept in ONE place
+
+# Verify with:
+grep -r "term-to-check" docs/  # Should return single canonical location
+```
+
+---
+
+## Master Checklist (All Phases)
+
+Use this for complete DDD cycle verification:
+
+**Planning**: Phase 0 complete
+**Documentation**: Phase 1 complete, Phase 2 approved & committed
+**Implementation**: Phase 3 planned, Phase 4 implemented & committed
+**Verification**: Phase 5 tested (user + code)
+**Completion**: Phase 6 cleaned & pushed
+
+**Success criteria**:
+
+- ✅ Documentation and code never diverged
+- ✅ Zero context poisoning
+- ✅ All tests passing
+- ✅ Clean git history
+- ✅ Philosophy principles followed
+- ✅ User testing complete
+- ✅ Ready for human review
+
+---
+
+**Return to**: [Reference](README.md) | [Main Index](../README.md)
+
+**See Also**: [Tips for Success](tips_for_success.md) | [Common Pitfalls](common_pitfalls.md)

--- a/docs/document_driven_development/reference/common_pitfalls.md
+++ b/docs/document_driven_development/reference/common_pitfalls.md
@@ -1,0 +1,442 @@
+# Common Pitfalls
+
+**What goes wrong, how to recognize it, and how to fix it**
+
+---
+
+## Overview
+
+These are the most common mistakes made when using Document-Driven Development, along with practical guidance for recognizing and recovering from them.
+
+---
+
+## Pitfall 1: Skipping Planning Phase
+
+### The Problem
+
+Diving straight into documentation without achieving shared understanding first.
+
+### What Happens
+
+- AI implements different design than you envisioned
+- Wasted effort on wrong approach
+- Major rework needed after approval
+- Frustration on both sides
+
+### Warning Signs
+
+- User says "that's not what I meant" after doc retcon
+- AI's explanation doesn't match your mental model
+- Proposals seem off-base or missing key points
+
+### How to Recover
+
+```markdown
+# If caught after documentation started:
+
+1. STOP immediately
+2. Return to [Phase 0](../phases/00_planning_and_alignment.md)
+3. Re-establish shared understanding
+4. Get clear approval on correct design
+5. Start Phase 1 over with correct design
+```
+
+### Prevention
+
+- Be patient in Phase 0
+- Iterate on proposals until aligned
+- Ask AI to articulate plan back
+- Approve explicitly when aligned
+
+**Better 2 hours in Phase 0 than 2 days of rework.**
+
+---
+
+## Pitfall 2: Trying to Hold Everything in Context
+
+### The Problem
+
+AI tries to process all files at once without [file crawling](../core_concepts/file_crawling.md).
+
+### What Happens
+
+- Attention degradation - misses files in large lists
+- Token waste - loading unnecessary content
+- False confidence - AI thinks it processed all
+- Incomplete work - many files actually skipped
+- [Context poisoning](../core_concepts/context_poisoning.md) from missing updates
+
+### Warning Signs
+
+- AI says "processed all 100 files" but shows work on only 20
+- Files marked complete without individual review
+- Global replacements used as completion marker
+- User finds untouched files after "completion"
+
+### How to Recover
+
+```bash
+# Check what was actually done
+grep "^\[x\]" /tmp/checklist.txt  # What AI marked complete
+git diff --name-only  # What actually changed
+
+# Reset incomplete items
+sed -i 's/^\[x\] \(.*\.md\)$/[ ] \1/' /tmp/checklist.txt
+
+# Manually mark only verified-complete files
+# Resume with file crawling
+```
+
+### Prevention
+
+- Use [file crawling](../core_concepts/file_crawling.md) for 10+ files
+- Process one file at a time
+- Verify checklist shows all `[x]` before proceeding
+
+---
+
+## Pitfall 3: Global Replacements as Completion
+
+### The Problem
+
+Run global find/replace, mark all files "done" without individual review.
+
+### What Happens
+
+- Replacements miss inconsistently-formatted instances
+- Replacements change wrong instances (context-inappropriate)
+- File-specific changes never made
+- [Context poisoning](../core_concepts/context_poisoning.md) from inconsistent updates
+- False confidence - files marked complete but incomplete
+
+### Warning Signs
+
+- AI runs `sed -i 's/old/new/g'` then marks files done
+- No individual file review performed
+- Files "completed" in seconds (too fast)
+- Specific changes from plan not visible in diffs
+
+### How to Recover
+
+```bash
+# Verify what global replace caught
+grep -rn "old-term" docs/  # Should be zero if replace worked
+
+# If results remain, understand why:
+# - Different formatting?
+# - Context-appropriate use?
+# - Pattern wrong?
+
+# Unmark all files
+sed -i 's/^\[x\]/[ ]/' /tmp/checklist.txt
+
+# Resume with individual review
+# Read each file completely
+# Verify replace worked correctly
+# Make additional changes needed
+# Mark complete only after full review
+```
+
+### Prevention
+
+- Global replace is HELPER only, not solution
+- Always review every file individually
+- Mark complete only after full review
+- Use verification grep to check results
+
+**See**: [Phase 1 Step 5](../phases/01_documentation_retcon.md#step-5-global-replacements-use-with-extreme-caution)
+
+---
+
+## Pitfall 4: Implementation Before Approval
+
+### The Problem
+
+Starting code while docs still under review.
+
+### What Happens
+
+- Code implements wrong or incomplete spec
+- Rework when docs corrected
+- Wasted implementation effort
+- Confusion about what's authoritative
+
+### Warning Signs
+
+- AI working on code during Phase 1 or 2
+- Implementation happening while user commenting on docs
+- "I'll just start the easy parts" mentality
+
+### How to Recover
+
+```markdown
+# If code started too early:
+
+1. STOP all implementation
+2. Return to Phase 2
+3. Fix documentation per user feedback
+4. Get explicit approval
+5. Review code against corrected docs
+6. Update or rewrite code to match
+7. Resume only after alignment
+```
+
+### Prevention
+
+- Hard gate at Phase 2 approval
+- No code until explicit approval
+- User says "approved, proceed to implementation"
+- [Phase 2](../phases/02_approval_gate.md) checklist complete
+
+---
+
+## Pitfall 5: Not Loading Full Context for Subtasks
+
+### The Problem
+
+Implement feature without reading related code, patterns, or tests.
+
+### What Happens
+
+- Breaks existing patterns
+- Inconsistent code style
+- Misses edge cases already handled
+- Reinvents existing solutions
+- [Context poisoning](../core_concepts/context_poisoning.md) when new code conflicts with old
+
+### Warning Signs
+
+- AI implements without reading related files
+- New code doesn't match existing patterns
+- Edge cases not handled
+- Duplicates existing functionality
+
+### How to Recover
+
+```markdown
+# If caught after implementation:
+
+1. Read SettingsManager and ProfileManager
+2. Read tests to understand patterns
+3. Identify where new code diverges
+4. Refactor to match established patterns
+5. Update tests to match existing style
+```
+
+### Prevention
+
+- Always load full context before implementation
+- Read: spec from docs, related code, existing tests
+- Check for conflicts before coding
+- Follow [Phase 4](../phases/04_code_implementation.md#loading-full-context-critical) guidance
+
+---
+
+## Pitfall 6: Documentation Drifts During Implementation
+
+### The Problem
+
+Discover implementation needs to differ, change code but not docs.
+
+### What Happens
+
+- Docs and code out of sync immediately
+- [Context poisoning](../core_concepts/context_poisoning.md) - future AI reads wrong spec
+- Users follow docs, get unexpected behavior
+- Lost benefit of documentation-driven approach
+
+### Warning Signs
+
+- Implementation doesn't match docs
+- AI says "docs were wrong, fixed code"
+- Examples in docs don't work with implementation
+- User says "docs say X but it does Y"
+
+### How to Recover
+
+```markdown
+# If drift detected:
+
+## Situation
+
+Implemented provider use. Testing revealed --model should be
+optional with defaults, but docs say it's required.
+
+## Action - DO NOT just change code!
+
+1. PAUSE implementation
+2. Document the mismatch
+3. Propose doc fix to user
+4. Get approval
+5. Return to Phase 1 - fix documentation
+6. Update code to match corrected docs
+7. Resume testing
+```
+
+### Prevention
+
+- Documentation remains source of truth always
+- If code needs to differ, update docs first (with approval)
+- Never Code → "close enough to docs"
+- Test against docs to catch drift early
+
+---
+
+## Pitfall 7: Ignoring Conflict Detection
+
+### The Problem
+
+AI detects conflicts but continues anyway, guessing at resolution.
+
+### What Happens
+
+- Wrong resolution applied
+- Conflict spreads to more files
+- User discovers conflict later (expensive)
+- More [context poisoning](../core_concepts/context_poisoning.md) introduced
+
+### Warning Signs
+
+- AI says "found conflict, choosing option A"
+- AI continues despite detecting inconsistency
+- No user consultation when sources conflict
+
+### How to Recover
+
+```markdown
+# If AI continued past conflict:
+
+1. Identify all files AI changed
+2. Undo: git reset --hard HEAD~N
+3. Return to conflict point
+4. Present conflict properly to user
+5. Get user decision
+6. Apply correct resolution systematically
+7. Resume work
+```
+
+### Prevention
+
+- Hard rule: PAUSE on ANY conflict
+- Only human decides resolution
+- AI detects and proposes, never decides
+- See [conflict resolution pattern](../core_concepts/context_poisoning.md#detection-and-resolution)
+
+---
+
+## Pitfall 8: Skipping User Testing
+
+### The Problem
+
+AI runs unit tests but doesn't test as actual user would.
+
+### What Happens
+
+- Misses UX issues
+- Misses workflow problems
+- Misses integration issues
+- Issues discovered only during human review
+
+### Warning Signs
+
+- AI only runs `make test`
+- No user testing report created
+- No recommended smoke tests for human
+- Testing section mentions only unit tests
+
+### How to Recover
+
+```markdown
+# Before proceeding to Phase 6:
+
+1. Return to Phase 5 Step 3
+2. Actually run the tool as user would
+3. Test main scenarios from documentation
+4. Create detailed user testing report
+5. Provide recommended smoke tests
+6. Fix any issues found
+```
+
+### Prevention
+
+- Explicitly require user testing
+- Ask for detailed report in ai_working/
+- Expect recommendations for human testing
+- See [Phase 5 Step 3](../phases/05_testing_and_verification.md#step-3-test-as-user-would-critical)
+
+---
+
+## Pitfall 9: Committing Before Approval
+
+### The Problem
+
+Committing documentation changes during iteration before human approval.
+
+### What Happens
+
+- Git log thrashed with wrong versions
+- Multiple "oops, undo that" commits
+- Harder to track what was actually decided
+- Git history is context poisoning source
+
+### Warning Signs
+
+- Multiple commits during Phase 1
+- Commit messages like "fix docs again"
+- Git log shows iteration history
+
+### How to Recover
+
+```bash
+# If already committed wrong versions:
+
+# Soft reset to before documentation commits
+git reset --soft HEAD~N
+
+# All changes now unstaged
+# Fix documentation with user feedback
+# Get approval
+# Make SINGLE commit with approved docs
+```
+
+### Prevention
+
+- Do NOT commit during Phase 1
+- Iterate until approved in Phase 2
+- THEN commit once with approval
+- See [Phase 2](../phases/02_approval_gate.md)
+
+---
+
+## Quick Reference: Recovery Patterns
+
+### Conflict Detected
+
+1. STOP all work
+2. Collect all instances
+3. Present to human with options
+4. Wait for decision
+5. Apply systematically
+6. Resume
+
+### Files Missed
+
+1. Regenerate checklist
+2. Compare with original
+3. Process missed files
+4. Verify all complete
+
+### Implementation Doesn't Match Docs
+
+1. PAUSE
+2. Propose doc update to human
+3. Get approval
+4. Fix docs (Phase 1)
+5. Update code to match
+6. Resume
+
+---
+
+**Return to**: [Reference](README.md) | [Main Index](../README.md)
+
+**See Also**: [Tips for Success](tips_for_success.md) | [FAQ](faq.md) | [Checklists](checklists.md)

--- a/docs/document_driven_development/reference/faq.md
+++ b/docs/document_driven_development/reference/faq.md
@@ -1,0 +1,133 @@
+# Frequently Asked Questions
+
+**Quick answers to common questions about Document-Driven Development**
+
+---
+
+## Process Questions
+
+**Q: What if implementation reveals the design was wrong?**
+
+A: Stop immediately. Fix documentation first. Propose change to user. Get approval. Update approved spec. Then update code to match. Documentation remains source of truth throughout.
+
+---
+
+**Q: Can I skip the approval gate for small changes?**
+
+A: Use judgment. Typo fixes: no gate needed. Design changes, new features, refactoring: always gate. When in doubt, get approval. Gates are cheap, rework is expensive.
+
+---
+
+**Q: Should I commit during documentation iteration?**
+
+A: No. Iterate with human until approved, THEN commit. This prevents git log thrashing with wrong versions. Clean git history prevents another form of context poisoning.
+
+---
+
+**Q: How do I handle backward compatibility?**
+
+A: Don't document it in main docs. Code can maintain backward compat internally, but docs describe only current state. Use [retcon writing](../core_concepts/retcon_writing.md) - write as if the new way always existed. Migration notes belong in CHANGELOG or git history.
+
+---
+
+**Q: What if I have hundreds of files to process?**
+
+A: Use [file crawling technique](../core_concepts/file_crawling.md). Process one at a time. Token efficient, resumable, guarantees completion. Exactly what it's designed for.
+
+---
+
+## Context Poisoning Questions
+
+**Q: How do I know if duplication is bad?**
+
+A: Ask: "If I update this content in one place, would I need to update it in another?" If yes, it's duplication. Delete one, keep only canonical source.
+
+See [context poisoning](../core_concepts/context_poisoning.md).
+
+---
+
+**Q: Should I delete or update duplicate docs?**
+
+A: **Delete**. If it exists, it will drift. Updating fixes it once, but drift will return. Deletion is permanent elimination.
+
+---
+
+**Q: What if global replacement changes wrong instances?**
+
+A: This is why global replacement alone is insufficient. Always review each file individually after global replace. Verify replacement worked correctly in context. Mark complete only after verification.
+
+See [Phase 1 Step 5](../phases/01_documentation_retcon.md#step-5-global-replacements-use-with-extreme-caution).
+
+---
+
+## AI Collaboration Questions
+
+**Q: What if AI forgets to use TodoWrite?**
+
+A: Remind it. The todo list is critical for complex tasks. AI should proactively create it at start of any multi-step work within a turn. If work spans multiple turns with user interaction, use `ai_working/` files instead.
+
+---
+
+**Q: How do I know if AI detected a conflict?**
+
+A: AI should explicitly PAUSE and present conflict with options. If AI continues despite mentioning inconsistency, stop it and ask for proper conflict resolution pattern.
+
+---
+
+**Q: Can AI make decisions about conflicts?**
+
+A: No. Only human has full context. AI should detect, collect instances, propose options, and wait for decision. Never guess.
+
+---
+
+## Testing Questions
+
+**Q: How important is "test as user" phase?**
+
+A: Critical. Code tests verify implementation. User testing verifies experience. This catches issues unit tests miss: confusing UX, broken workflows, unclear output. AI should be QA before human review.
+
+See [Phase 5 Step 3](../phases/05_testing_and_verification.md#step-3-test-as-user-would-critical).
+
+---
+
+**Q: What should user testing reports include?**
+
+A: Scenarios tested, observations (output, logs, behavior, state), issues found (with severity), recommendations for human smoke tests. Be specific. Include enough detail for understanding without re-testing everything.
+
+---
+
+## Documentation Questions
+
+**Q: How do I handle third-party library documentation?**
+
+A: Don't duplicate it. Link to official docs. Document only _your_ usage patterns, integration points, and project-specific conventions.
+
+---
+
+**Q: How do I know if documentation organization is progressive enough?**
+
+A: Test: Can a new person start at README and progressively drill down? Can they stop at any level with complete understanding of that level? If they must jump around to understand basics, organization needs work.
+
+---
+
+**Q: What if I detect conflicts during implementation?**
+
+A: PAUSE. Don't fix docs or code without guidance. Collect evidence, present to user with options. User decides. If docs need fixing, return to Phase 1. If code needs fixing, fix code to match docs.
+
+---
+
+**Q: Is it really worth all this process for small changes?**
+
+A: Use judgment. Small isolated changes (typo, small refactor): less process fine. Anything touching multiple files, changing interfaces, or affecting users: process saves time by catching issues early. Lean toward more process when uncertain.
+
+---
+
+## Related Documentation
+
+- [Common Pitfalls](common_pitfalls.md) - What goes wrong and how to fix it
+- [Tips for Success](tips_for_success.md) - Best practices
+- [Checklists](checklists.md) - Verification steps
+
+---
+
+**Return to**: [Reference](README.md) | [Main Index](../README.md)

--- a/docs/document_driven_development/reference/tips_for_success.md
+++ b/docs/document_driven_development/reference/tips_for_success.md
@@ -1,0 +1,150 @@
+# Tips for Success
+
+**Best practices for humans and AI assistants using Document-Driven Development**
+
+---
+
+## For Humans
+
+### Planning Phase (Phase 0)
+
+1. **Be patient** - Get shared understanding right before any work
+2. **Challenge assumptions** - AI doesn't know your context
+3. **Provide clear direction** - Be explicit about success criteria
+4. **Approve explicitly** - Don't assume alignment
+
+### Documentation Phase (Phase 1-2)
+
+5. **Review docs thoroughly** - Cheapest checkpoint for catching issues
+6. **Iterate until right** - Don't approve until actually right
+7. **Insist on DRY** - Delete duplicates aggressively
+8. **Don't commit before approval** - Prevents git thrashing
+
+### Implementation Phase (Phase 3-4)
+
+9. **Trust the process** - Resist urge to code before docs approved
+10. **Provide clear decisions** - When AI pauses for conflicts
+11. **Question over-complexity** - Challenge deviations from simplicity
+
+### Testing Phase (Phase 5)
+
+12. **Review user testing reports** - AI's findings are valuable
+13. **Run recommended smoke tests** - Quick verification as actual user
+14. **Test on your environment** - AI tested on one environment
+15. **Trust but verify** - AI is good QA, not perfect
+
+---
+
+## For AI Assistants
+
+### General Principles
+
+1. **Use TodoWrite religiously** - Track all multi-step work
+2. **Be honest about limitations** - Say "I don't know" rather than guess
+3. **Show your work** - Explain reasoning, not just results
+4. **Ask early** - Better to clarify than implement wrong
+
+### File Processing
+
+5. **Use [file crawling](../core_concepts/file_crawling.md) for 10+ files** - Don't try to hold all in context
+6. **Process one file at a time** - No shortcuts, no batching
+7. **Read complete files** - No skimming before changes
+8. **Mark complete honestly** - Only after full individual review
+9. **Show progress periodically** - Keep human informed
+
+### Documentation
+
+10. **Follow [retcon writing](../core_concepts/retcon_writing.md) strictly** - Write as if already exists
+11. **PAUSE on conflicts** - Never guess, always ask
+12. **Delete duplicates** - Suggest deletion, not update
+13. **Global replacements are helpers** - Never substitutes for review
+
+### Implementation
+
+14. **Load full context first** - Read all related files before coding
+15. **PAUSE when docs conflict** - Don't proceed with inconsistency
+16. **Code matches docs exactly** - No deviation without doc update
+17. **Commit incrementally** - Don't wait for everything complete
+
+### Testing
+
+18. **Test as actual user** - Not just unit tests
+19. **Document thoroughly** - Create detailed user testing reports
+20. **Be honest about issues** - Don't hide problems found
+21. **Guide human testing** - Recommend specific scenarios
+
+---
+
+## Universal Tips
+
+### For Both Humans and AI
+
+**Communication**:
+
+- Be explicit and clear
+- Ask when uncertain
+- Confirm understanding
+- Document decisions
+
+**Quality**:
+
+- Follow [philosophy principles](../../concepts/philosophy.md)
+- Verify against [checklists](checklists.md)
+- Test thoroughly
+- Iterate until right
+
+**Efficiency**:
+
+- Use systematic approaches ([file crawling](../core_concepts/file_crawling.md))
+- Catch issues early (approval gates)
+- Don't skip steps
+- Trust the process
+
+---
+
+## Red Flags to Watch For
+
+**For Humans**:
+
+- ❌ AI says "done" but you suspect files missed
+- ❌ AI doesn't pause when you see conflicts
+- ❌ AI marks files complete after global replace only
+- ❌ AI proceeding without shared understanding
+
+**For AI**:
+
+- ❌ Human seems confused by your explanation
+- ❌ You found conflicts but continued anyway
+- ❌ You marked files done without reading them
+- ❌ You're guessing at resolutions
+
+**If any red flags**: STOP and address before continuing.
+
+---
+
+## Success Patterns
+
+### Healthy Collaboration
+
+✅ Clear back-and-forth in planning
+✅ AI pauses appropriately for conflicts
+✅ Human provides clear decisions
+✅ Both aligned on approach
+✅ Systematic progress visible
+✅ Issues caught early
+✅ Quality maintained throughout
+
+### Efficient Process
+
+✅ File crawling used for large sets
+✅ One file at a time processing
+✅ Progress visible and trackable
+✅ Conflicts resolved before continuing
+✅ Documentation approved before implementation
+✅ Testing thorough (code + user)
+
+---
+
+**Return to**: [Reference](README.md) | [Main Index](../README.md)
+
+**See Also**: [Common Pitfalls](common_pitfalls.md) | [FAQ](faq.md) | [Checklists](checklists.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,29 @@ nav:
       - Goal-Seeking Agent Tutorial: howto/goal-seeking-agent-tutorial.md
       - Token Sanitization: howto/token-sanitization.md
       - Security Testing: howto/security-testing.md
+  - Document-Driven Development:
+      - Overview: document_driven_development/README.md
+      - DDD in Depth: document_driven_development/overview.md
+      - Core Concepts:
+          - Index: document_driven_development/core_concepts/README.md
+          - Context Poisoning: document_driven_development/core_concepts/context_poisoning.md
+          - File Crawling: document_driven_development/core_concepts/file_crawling.md
+          - Retcon Writing: document_driven_development/core_concepts/retcon_writing.md
+      - Phases:
+          - Index: document_driven_development/phases/README.md
+          - "Phase 0: Planning & Alignment": document_driven_development/phases/00_planning_and_alignment.md
+          - "Phase 1: Documentation Retcon": document_driven_development/phases/01_documentation_retcon.md
+          - "Phase 2: Approval Gate": document_driven_development/phases/02_approval_gate.md
+          - "Phase 3: Implementation Planning": document_driven_development/phases/03_implementation_planning.md
+          - "Phase 4: Code Implementation": document_driven_development/phases/04_code_implementation.md
+          - "Phase 5: Testing & Verification": document_driven_development/phases/05_testing_and_verification.md
+          - "Phase 6: Cleanup & Push": document_driven_development/phases/06_cleanup_and_push.md
+      - Reference:
+          - Index: document_driven_development/reference/README.md
+          - Checklists: document_driven_development/reference/checklists.md
+          - Common Pitfalls: document_driven_development/reference/common_pitfalls.md
+          - FAQ: document_driven_development/reference/faq.md
+          - Tips for Success: document_driven_development/reference/tips_for_success.md
   - Skills:
       - Migrate Session: skills/migrate.md
   - Reference:


### PR DESCRIPTION
## Summary
- Port 19 DDD documentation files from upstream amplihack into `docs/document_driven_development/`
- Covers core concepts (context poisoning, file crawling, retcon writing), all 7 phases, and reference material
- Adds Document-Driven Development nav section to mkdocs.yml
- Light-touch Rust adaptations applied; internal PHILOSOPHY.md links rewritten to `concepts/philosophy.md`

## Test plan
- [x] `mkdocs build --strict` passes with zero warnings
- [x] All 19 new files present in nav
- [x] No secrets in ported content
- [x] Existing docs untouched

Wave 6 — Group 1 of 6 for #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)