### PR TITLE
docs: port Power Steering docs (wave 6, group 2) #420

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,20 @@
+# Features Documentation
+
+> [Home](../index.md) > Features
+
+This section documents amplihack-rs feature implementations.
+
+## Power Steering
+
+Intelligent guidance system that prevents common mistakes and ensures work completeness:
+
+- [Overview](power-steering/README.md)
+- [Architecture Refactor](power-steering/architecture-refactor.md)
+- [Configuration](power-steering/configuration.md)
+- [Customization Guide](power-steering/customization-guide.md)
+- [Worktree Support](power-steering/worktree-support.md)
+- [Troubleshooting](power-steering/troubleshooting.md)
+
+## Additional Features
+
+Additional feature documentation will be added as features are ported from upstream.

--- a/docs/features/power-steering/README.md
+++ b/docs/features/power-steering/README.md
@@ -1,0 +1,622 @@
+# Power-Steering Overview
+
+> [Home](../../index.md) > [Features](../README.md) > Power-Steering
+
+Intelligent session completion verification that prevents incomplete work and ensures quality.
+
+## What is Power-Steering?
+
+Power-Steering is an intelligent guidance system that validates session completeness before allowing Claude to conclude work. Think of it as a checklist enforcer that catches common mistakes:
+
+- ❌ Forgotten TODOs
+- ❌ Untested code
+- ❌ Missing documentation
+- ❌ Workflow shortcuts
+- ❌ Failing CI checks
+- ❌ Incomplete PR descriptions
+
+**Result**: Higher quality work, fewer review cycles, faster PR merges.
+
+---
+
+## Quick Start
+
+Power-Steering is enabled by default in amplihack. To customize behavior:
+
+1. **View current configuration**:
+
+   ```bash
+   cat .claude/tools/amplihack/considerations.yaml
+   ```
+
+2. **Customize considerations**: See [Customization Guide](customization-guide.md)
+
+3. **Configure merge preferences**: See [How-To: Merge Preferences](../../howto/power-steering-merge-preferences.md)
+
+---
+
+## How It Works
+
+### 21 Considerations
+
+Power-Steering checks 21 different aspects of your work across 6 categories:
+
+| Category               | Checks | Example                            |
+| ---------------------- | ------ | ---------------------------------- |
+| **Session Completion** | 3      | TODOs complete, objectives met     |
+| **Workflow Adherence** | 4      | DEFAULT_WORKFLOW followed          |
+| **Code Quality**       | 4      | Zero-BS compliance, no shortcuts   |
+| **Testing**            | 4      | Tests written and passing          |
+| **PR Content**         | 3      | Description complete, no pollution |
+| **CI/CD Status**       | 3      | Checks passing, PR mergeable       |
+
+Each consideration is either:
+
+- ✅ **Satisfied** - Check passed
+- ⚠️ **Warning** - Advisory, doesn't block
+- ❌ **Blocker** - Must fix before ending session
+
+### Validation Flow
+
+```
+[Work Complete Request]
+         |
+         v
+[Power-Steering Checker]
+         |
+         v
+[21 Considerations Evaluated]
+         |
+    All Pass?
+    /      \
+  YES       NO
+   |         |
+   v         v
+[Allow End] [Show Blockers]
+            [Suggest Fixes]
+```
+
+---
+
+## Key Features
+
+### 🔄 Auto-Re-enable on Startup (NEW)
+
+Power-Steering can be temporarily disabled when it blocks session completion. When you restart amplihack, you'll see a prompt to re-enable it.
+
+**Prompt behavior**:
+
+- Appears only when Power-Steering is disabled via `.disabled` file
+- Default answer: YES (re-enable)
+- 30-second timeout (auto-enables on timeout)
+- Worktree-aware (each worktree tracks its own state)
+
+```
+Power-Steering is currently disabled.
+Would you like to re-enable it? [Y/n] (30s timeout, defaults to YES):
+```
+
+**Response options**:
+
+- **YES** or timeout: Removes `.disabled` file, Power-Steering enabled
+- **NO**: Keeps Power-Steering disabled for this session
+
+**To permanently disable the re-enable prompt** (not recommended): Remove or rename `re_enable_prompt.py`
+
+**Note**: This disables the _re-enable prompt_, not power-steering itself. To disable power-steering, see [Troubleshooting: Disable Power-Steering](troubleshooting.md).
+
+**Learn more**: See [Troubleshooting: Disable Power-Steering](troubleshooting.md)
+
+### 🎯 Preference Awareness
+
+Power-Steering respects your USER_PREFERENCES.md settings, including the "NEVER Merge PRs Without Permission" preference.
+
+**With preference active**:
+
+- ✅ Stops at "PR ready + CI passing + awaiting approval"
+- ✅ No pressure to auto-merge
+- ✅ Respects manual review workflow
+
+**Learn more**: [How-To: Configure Merge Preferences](../../howto/power-steering-merge-preferences.md)
+
+### 📊 Evidence Collection
+
+Every check collects evidence to justify its result:
+
+```
+❌ CI Status: Checks failing
+
+Evidence:
+- gh pr view output: CI checks still running
+- Test suite: 3/15 tests failing
+- Linter: 2 errors in src/main.py
+```
+
+### 🔧 Customizable
+
+Modify considerations to match your workflow:
+
+- Enable/disable specific checks
+- Change severity levels (blocker ↔ warning)
+- Add custom team-specific considerations
+
+**See**: [Customization Guide](customization-guide.md)
+
+### 🛡️ Fail-Open Design
+
+If Power-Steering encounters errors, it defaults to safe behavior:
+
+- File read errors → skip check (don't block)
+- gh CLI errors → report as unsatisfied (require fix)
+- Regex errors → fall back to standard behavior
+
+**Principle**: Errors should never prevent valid work from completing.
+
+---
+
+## Benefits
+
+### Measurable Impact
+
+Based on usage data from amplihack development:
+
+| Metric                    | Improvement |
+| ------------------------- | ----------- |
+| Incomplete PRs            | **-30%**    |
+| Review cycles per PR      | **-20%**    |
+| CI failures on first push | **-15%**    |
+| Time to merge             | **-25%**    |
+| Forgotten TODOs           | **-90%**    |
+
+### Developer Experience
+
+**Without Power-Steering**:
+
+```
+Agent: I've completed the feature!
+[Creates PR with failing tests]
+[No documentation]
+[TODOs left in code]
+[Review cycle: 3 rounds]
+```
+
+**With Power-Steering**:
+
+```
+Agent: I believe I'm done.
+Power-Steering: Wait, 3 blockers:
+- 2 TODOs remain in src/main.py
+- No tests written
+- Documentation section incomplete
+
+Agent: [Fixes blockers]
+Power-Steering: All checks passed ✅
+[Creates complete PR]
+[Review cycle: 1 round]
+```
+
+---
+
+## Configuration
+
+### USER_PREFERENCES.md Integration
+
+Power-Steering reads `.claude/context/USER_PREFERENCES.md` to respect your workflow preferences.
+
+**Supported preferences**:
+
+| Preference                     | Impact                                     |
+| ------------------------------ | ------------------------------------------ |
+| NEVER Merge Without Permission | Stops at "PR ready", doesn't require merge |
+| Always Test Locally (Step 13)  | Enforces local testing requirement         |
+| No Direct Commits to Main      | Validates PR workflow used                 |
+
+**Add preferences**:
+
+```markdown
+### 2026-01-23 10:00:00
+
+**NEVER Merge PRs Without Explicit Permission**
+
+NEVER merge PRs or commit directly to main without explicit user permission.
+Always create PRs and wait for approval.
+```
+
+Power-Steering automatically detects and respects these preferences.
+
+### Consideration Categories
+
+**1. Session Completion & Progress**
+
+Ensures all planned work is complete:
+
+- ✅ All TODOs resolved or tracked
+- ✅ Session objectives met
+- ✅ Documentation updated
+
+**2. Workflow Process Adherence**
+
+Validates process compliance:
+
+- ✅ DEFAULT_WORKFLOW followed (if applicable)
+- ✅ Investigation results documented
+- ✅ All workflow steps completed
+
+**3. Code Quality & Philosophy Compliance**
+
+Enforces amplihack philosophy:
+
+- ✅ Zero-BS implementation (no stubs)
+- ✅ No shortcuts taken
+- ✅ Code follows brick & studs pattern
+
+**4. Testing & Local Validation**
+
+Verifies quality assurance:
+
+- ✅ Tests written (TDD approach)
+- ✅ All tests passing
+- ✅ Local testing completed (Step 13)
+- ✅ Interactive validation done
+
+**5. PR Content & Quality**
+
+Ensures PR completeness:
+
+- ✅ PR description is comprehensive
+- ✅ No root-level pollution (.DS_Store, etc.)
+- ✅ Related changes grouped properly
+
+**6. CI/CD & Mergeability Status**
+
+Validates deployment readiness:
+
+- ✅ CI checks passing
+- ✅ PR is mergeable (unless preference says otherwise)
+- ✅ No rebase needed
+- ✅ Pre-commit and CI checks aligned
+
+---
+
+## Advanced Usage
+
+### Custom Considerations
+
+Add team-specific checks to considerations.yaml:
+
+```yaml
+- id: security_review_completed
+  category: Code Quality & Philosophy Compliance
+  question: Has the security team reviewed this change?
+  description: Ensures security team sign-off for sensitive changes
+  severity: blocker
+  checker: generic # Uses keyword matching
+  enabled: true
+```
+
+**Learn more**: [Customization Guide](customization-guide.md)
+
+### Temporarily Disabling Power-Steering
+
+When Power-Steering blocks session completion, you can temporarily disable it:
+
+```bash
+# Disable for current session
+touch ~/.amplihack/.claude/runtime/power-steering/.disabled
+```
+
+**What happens next**:
+
+1. Power-Steering stops checking for remainder of session
+2. On next amplihack startup, re-enable prompt appears:
+   ```
+   Power-Steering is currently disabled.
+   Would you like to re-enable it? [Y/n] (30s timeout, defaults to YES):
+   ```
+3. Default behavior (YES or timeout) re-enables automatically
+
+**Worktree behavior**: Each git worktree tracks its own disabled state independently.
+
+**To resume checking immediately**:
+
+```bash
+# Re-enable Power-Steering
+rm ~/.amplihack/.claude/runtime/power-steering/.disabled
+```
+
+**Learn more**: See [Troubleshooting: Disable Power-Steering](troubleshooting.md)
+
+### Conditional Checks
+
+Some checks only apply in specific contexts:
+
+- DEFAULT_WORKFLOW checks → only when workflow active
+- Investigation checks → only during investigation sessions
+- PR checks → only when PR exists
+
+Power-Steering automatically detects context and enables/disables checks accordingly.
+
+### Integration with Workflows
+
+Power-Steering integrates seamlessly with amplihack workflows:
+
+```markdown
+# In DEFAULT_WORKFLOW.md
+
+## Step 21: Session Completion
+
+Power-Steering will now validate:
+
+- All workflow steps completed
+- Tests passing
+- Documentation updated
+- PR ready for review
+```
+
+No explicit calls needed - Power-Steering runs automatically when Claude attempts to end the session.
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**Problem**: Re-enable prompt not appearing on startup
+
+**Solution**:
+
+1. Verify `.disabled` file exists:
+   ```bash
+   ls -la ~/.amplihack/.claude/runtime/power-steering/.disabled
+   ```
+2. Check you're using CLI entry point (`cli.py` or `copilot.py`)
+3. Verify module exists: `src/amplihack/power_steering/re_enable_prompt.py`
+4. Check for errors in startup logs
+
+**Problem**: Prompt times out too quickly
+
+**Solution**: The 30-second timeout is hard-coded for safety (fail-open design). If you need more time, answer "n" and manually delete `.disabled` file when ready:
+
+```bash
+rm ~/.amplihack/.claude/runtime/power-steering/.disabled
+```
+
+**Problem**: Power-Steering blocks session end with false positive
+
+**Solution**:
+
+1. Review evidence provided
+2. Check if consideration is misconfigured
+3. Temporarily disable consideration if needed
+4. Report issue for investigation
+
+**Problem**: Preference not detected
+
+**Solution**:
+
+1. Check USER_PREFERENCES.md format
+2. Verify keywords present (see [Merge Preferences Guide](../../howto/power-steering-merge-preferences.md))
+3. Restart Claude session
+
+**Problem**: CI checks show as failing but they're passing
+
+**Solution**:
+
+```bash
+# Verify gh CLI authenticated
+gh auth status
+
+# Check PR status manually
+gh pr view --json statusCheckRollup
+
+# Ensure CI actually finished running
+```
+
+**More troubleshooting**: See [Power-Steering Troubleshooting](troubleshooting.md)
+
+---
+
+## Architecture
+
+### Components
+
+```
+.claude/tools/amplihack/
+├── hooks/
+│   ├── power_steering_checker/        # Modular checker package
+│   │   ├── __init__.py                # Public API re-exports
+│   │   ├── main_checker.py            # PowerSteeringChecker orchestration (1,217 lines)
+│   │   ├── considerations.py          # Dataclasses + ConsiderationsMixin
+│   │   ├── sdk_calls.py               # SdkCallsMixin + SDK integration
+│   │   ├── progress_tracking.py       # ProgressTrackingMixin + state I/O
+│   │   ├── result_formatting.py       # ResultFormattingMixin + output generation
+│   │   ├── checks_ci_pr.py            # CI/PR-specific checks
+│   │   ├── checks_docs.py             # Documentation checks
+│   │   ├── checks_quality.py          # Code quality checks
+│   │   ├── checks_workflow.py         # Workflow adherence checks
+│   │   ├── session_detection.py       # Session type detection
+│   │   ├── transcript_parser.py       # Transcript parsing (Claude Code + Copilot CLI)
+│   │   └── transcript_helpers.py      # Transcript utility functions
+│   ├── power_steering_state.py        # State management
+│   └── templates/
+│       └── power_steering_prompt.txt  # User-facing messages
+├── considerations.yaml                 # Configuration
+└── context/
+    └── USER_PREFERENCES.md            # User preferences
+```
+
+**Architecture Highlights**:
+
+- **Modular Design**: Split from monolithic 5,063-line file into 12 focused modules (largest: 1,217 lines)
+- **Backward Compatible**: All existing imports continue to work via `__init__.py` re-exports
+- **Copilot CLI Support**: Auto-detects and parses both Claude Code and GitHub Copilot CLI transcripts (real `events.jsonl` format)
+- **Import-Time Safe**: CLAUDECODE environment variable unset to prevent nested session errors in SDK calls
+- **Independently Testable**: 191 unit/integration tests (121 existing + 48 parser + 22 Copilot e2e)
+
+### Checker Methods
+
+| Method                       | Purpose                 | Evidence              |
+| ---------------------------- | ----------------------- | --------------------- |
+| `_check_todos_complete()`    | Find TODOs in code      | File scan results     |
+| `_check_ci_status()`         | Validate CI passing     | gh pr view output     |
+| `_check_pr_description()`    | Ensure PR complete      | PR body content       |
+| `_check_tests_passing()`     | Verify test success     | pytest output         |
+| `_check_workflow_complete()` | Validate workflow steps | Workflow step markers |
+
+**Generic checker**: For custom considerations, uses keyword extraction and transcript search.
+
+**Module Responsibilities**:
+
+- `considerations.py` — Data models + consideration loading/evaluation
+- `sdk_calls.py` — Claude SDK integration + parallel analysis + timeouts
+- `progress_tracking.py` — State persistence + redirect records + compaction
+- `result_formatting.py` — Text formatting + output generation
+- `main_checker.py` — Orchestration + public API
+
+See [power_steering_checker package README](README.md) for detailed module documentation.
+
+### State Management
+
+Power-Steering maintains minimal state:
+
+- Consideration results (cached for session)
+- Evidence collection (per check)
+- User preferences (read on each check)
+
+**No persistent state** - each session starts fresh.
+
+---
+
+## Best Practices
+
+### For Users
+
+1. **Trust the system**: If Power-Steering blocks, there's usually a good reason
+2. **Review evidence**: Don't just fix blindly - understand what's incomplete
+3. **Customize thoughtfully**: Too many blockers can be frustrating
+4. **Set preferences**: Configure USER_PREFERENCES.md to match your workflow
+
+### For Teams
+
+1. **Standard considerations**: Start with defaults, customize gradually
+2. **Team preferences**: Document team-wide preferences in onboarding
+3. **Regular review**: Periodically review consideration effectiveness
+4. **False positive tracking**: Track and fix false positive checks
+
+### For Agents
+
+1. **Don't fight it**: If Power-Steering blocks, fix the issues rather than arguing
+2. **Collect evidence**: Include evidence in responses to show compliance
+3. **Learn patterns**: Common blockers indicate areas for improvement
+4. **Respect preferences**: Always honor user-configured preferences
+
+---
+
+## Related Documentation
+
+### User Guides
+
+- [How-To: Configure Merge Preferences](../../howto/power-steering-merge-preferences.md) - Set up merge approval workflow
+- [Customization Guide](customization-guide.md) - Modify considerations
+- [Troubleshooting](troubleshooting.md) - Fix common issues
+
+### Technical References
+
+- [Technical Reference: Merge Preferences](../../reference/power-steering-merge-preferences.md) - Developer documentation
+- [Architecture Deep Dive](../../concepts/power-steering-compaction.md) - System design (coming soon)
+- [API Reference](../../reference/power-steering-checker-api.md) - Complete API docs (coming soon)
+
+### Related Features
+
+- [AUTO_MODE](../../concepts/auto-mode.md) - Autonomous execution with Power-Steering
+- [DEFAULT_WORKFLOW](../../concepts/default-workflow.md) - Structured development process
+- [USER_PREFERENCES](../../reference/profile-management.md) - Complete preferences reference
+
+---
+
+## Changelog
+
+### v0.10.0 (2026-03-07)
+
+**Refactored** (PR #2910):
+
+- **Modular Architecture**: Split monolithic `power_steering_checker.py` (5,063 lines) into 12 focused modules
+  - Largest module: `main_checker.py` at 1,217 lines (76% reduction)
+  - Improved maintainability and testability
+  - All existing imports remain backward compatible via `__init__.py` re-exports
+- **Copilot CLI Support**: Auto-detection and parsing of GitHub Copilot CLI transcripts
+  - Supports real `events.jsonl` format
+  - Verified against 5 real Copilot CLI sessions
+  - 48 new parser tests + 22 Copilot e2e tests
+- **SDK Integration Fix**: CLAUDECODE environment variable now properly unset to prevent nested session errors
+  - Affects all Claude SDK subprocess calls
+  - Applied to both `.claude/` and `amplifier-bundle/` copies
+
+**Testing**:
+
+- 191 unit/integration tests passing (121 existing + 48 parser + 22 Copilot e2e)
+- Quality audit cycle completed (3-agent validation)
+
+**Fixed** (PR #2887, #2886):
+
+- Bash template quoting in quality-audit-cycle (double-quote escaping issue)
+- JSON-as-commands execution in verify-fixes step
+
+### v0.9.2 (Planned)
+
+**Added**:
+
+- Preference awareness for "NEVER Merge Without Permission"
+- USER_PREFERENCES.md integration
+- Evidence-based validation
+
+**Improved**:
+
+- Fail-open error handling
+- gh CLI integration robustness
+
+### v0.9.1
+
+**Fixed**:
+
+- Infinite loop during session end
+- Stop hook exit hang (10-13s delay)
+
+**See**: [Migration Guide v0.9.1](migration-v0.9.1.md)
+
+---
+
+## FAQ
+
+**Q: Can I disable Power-Steering completely?**
+
+A: Not recommended, but you can disable individual considerations by setting `enabled: false` in considerations.yaml.
+
+**Q: Does Power-Steering slow down sessions?**
+
+A: Minimal impact (<2s for all checks). Network I/O (gh CLI) is the main overhead.
+
+**Q: What if I disagree with a blocker?**
+
+A: Review the evidence, customize the consideration if needed, or disable it temporarily. Provide feedback to improve detection logic.
+
+**Q: Does it work with GitHub and Azure DevOps?**
+
+A: Yes, uses platform-bridge for cross-platform compatibility. (Azure DevOps support coming soon)
+
+**Q: Can agents override Power-Steering?**
+
+A: No. Power-Steering is enforced at the system level. This is by design to prevent quality shortcuts.
+
+---
+
+## Support
+
+- **Issues**: Check [Troubleshooting](troubleshooting.md) first
+- **Bugs**: Report on [GitHub Issues](https://github.com/rysweet/amplihack/issues) with `power-steering` label
+- **Improvements**: Suggest new considerations or enhancements
+- **Questions**: Ask in discussions or open an issue
+
+---
+
+**Ready to customize?** Head to [Customization Guide](customization-guide.md) to configure Power-Steering for your workflow.

--- a/docs/features/power-steering/architecture-refactor.md
+++ b/docs/features/power-steering/architecture-refactor.md
@@ -1,0 +1,273 @@
+# Power-Steering Checker — Architecture Refactor
+
+> [Home](../../index.md) > [Features](../README.md) > [Power-Steering](README.md) > Architecture Refactor
+
+This document describes the split of `power_steering_checker.py` (5063 LOC) into the `power_steering_checker/` package, why each module boundary was drawn where it is, and how to work with the new structure.
+
+---
+
+## Why the Refactor
+
+The original `power_steering_checker.py` had grown to 5063 lines across a single file. This made it:
+
+- Difficult to navigate — unrelated concerns interleaved
+- Slow to test — any test had to import the entire module
+- Hard to reason about — import-time side effects not obviously scoped
+- Risky to modify — changes anywhere could affect anything
+
+The refactor splits the file along natural separation boundaries without changing any public behavior.
+
+---
+
+## Package Structure
+
+```
+hooks/power_steering_checker/
+├── __init__.py             # Re-exports; backward-compatible public API
+├── considerations.py       # Dataclasses + ConsiderationsMixin
+├── sdk_calls.py            # SdkCallsMixin + _timeout + optional SDK imports
+├── progress_tracking.py    # ProgressTrackingMixin + _write_with_retry + compaction
+├── result_formatting.py    # ResultFormattingMixin + turn-state imports
+└── main_checker.py         # PowerSteeringChecker + check_session + is_disabled
+```
+
+---
+
+## Module Boundaries
+
+### Why five modules, not six?
+
+An earlier design considered a shared `utils.py` for `_timeout` and `_write_with_retry`. This was rejected:
+
+- `_timeout` belongs in `sdk_calls.py` — it exists exclusively to wrap external subprocess/SDK calls
+- `_write_with_retry` belongs in `progress_tracking.py` — both call sites are in `ProgressTrackingMixin` methods
+
+Adding a utilities module would have required a circular-import-free design that complicated the dependency graph without providing any net benefit.
+
+### Dataclass placement
+
+All four dataclasses (`CheckerResult`, `ConsiderationAnalysis`, `PowerSteeringRedirect`, `PowerSteeringResult`) live in `considerations.py`. This is the stdlib-only module — no optional imports, no I/O, no side effects. Every other module can safely import from it without pulling in anything that might fail.
+
+### Availability flags
+
+Each flag lives in the module that owns its import:
+
+| Flag                   | Module              | Controls                            |
+| ---------------------- | ------------------- | ----------------------------------- |
+| `SDK_AVAILABLE`        | `sdk_calls`         | `claude_power_steering` integration |
+| `EVIDENCE_AVAILABLE`   | `sdk_calls`         | `completion_evidence` integration   |
+| `COMPACTION_AVAILABLE` | `progress_tracking` | `compaction_validator` integration  |
+| `TURN_STATE_AVAILABLE` | `result_formatting` | `power_steering_state` integration  |
+
+### Configurable constants placement
+
+Constants are placed in the module where their value is consumed:
+
+| Constant                         | Module              | Consumed by                               |
+| -------------------------------- | ------------------- | ----------------------------------------- |
+| `CHECKER_TIMEOUT`                | `sdk_calls`         | `_timeout()` calls inside `SdkCallsMixin` |
+| `PARALLEL_TIMEOUT`               | `sdk_calls`         | `asyncio.wait_for()` in parallel analysis |
+| `MAX_TRANSCRIPT_LINES`           | `main_checker`      | Transcript truncation in `check()`        |
+| `MAX_ASK_USER_QUESTIONS`         | `main_checker`      | AskUserQuestion count check               |
+| `MIN_TESTS_PASSED_THRESHOLD`     | `main_checker`      | Local testing check                       |
+| `DEFAULT_MAX_CONSECUTIVE_BLOCKS` | `result_formatting` | Fallback when TurnState unavailable       |
+
+---
+
+## Import Dependency Graph
+
+The dependency graph is strictly acyclic:
+
+```
+considerations.py       → stdlib only (dataclasses, typing, pathlib, ...)
+         ↑
+sdk_calls.py            → from .considerations import CheckerResult, ConsiderationAnalysis
+         ↑
+progress_tracking.py    → from .considerations import PowerSteeringResult, CheckerResult, ...
+         ↑
+result_formatting.py    → from .considerations import ConsiderationAnalysis, PowerSteeringResult
+         ↑
+main_checker.py         → from .considerations import (all)
+                        → from .sdk_calls import SDK_AVAILABLE, _timeout, SdkCallsMixin, ...
+                        → from .progress_tracking import ProgressTrackingMixin, _write_with_retry, ...
+                        → from .result_formatting import ResultFormattingMixin, ...
+         ↑
+__init__.py             → re-exports from all five modules
+```
+
+No module imports from a module that is at the same level or below in this chain.
+
+---
+
+## Backward Compatibility
+
+All imports that worked against the original `power_steering_checker.py` continue to work against the package `__init__.py`:
+
+```python
+# Before (single file)
+from power_steering_checker import PowerSteeringChecker
+from power_steering_checker import check_session, is_disabled
+from power_steering_checker import PowerSteeringResult, CheckerResult
+from power_steering_checker import SDK_AVAILABLE, _timeout
+
+# After (package) — identical, no changes needed
+from power_steering_checker import PowerSteeringChecker
+from power_steering_checker import check_session, is_disabled
+from power_steering_checker import PowerSteeringResult, CheckerResult
+from power_steering_checker import SDK_AVAILABLE, _timeout
+```
+
+Test files using `sys.path` insertion to import `power_steering_checker` continue to work because the package `__init__.py` re-exports all previously public symbols.
+
+---
+
+## Non-Functional Improvements
+
+The refactor also fixed the following issues that were unrelated to the module split:
+
+### Broad `except Exception` blocks
+
+All 19 `except Exception` blocks now:
+
+1. Capture the exception as `e`.
+2. Log at `WARNING` (or `ERROR` for two top-level fail-open catches) with `exc_info=True`.
+3. Never silently swallow exceptions.
+
+Before:
+
+```python
+except Exception:
+    pass  # Line 5020 — is_disabled() silent failure
+```
+
+After:
+
+```python
+except Exception as e:
+    logger.warning(
+        "PowerSteeringChecker creation failed, assuming not disabled: %s",
+        e,
+        exc_info=True,
+    )
+    return False
+```
+
+### Hardcoded literals replaced with named constants
+
+Six inline magic numbers replaced with configurable named constants:
+
+| Before                                                | After                            | Env Variable                     |
+| ----------------------------------------------------- | -------------------------------- | -------------------------------- |
+| `int(os.getenv("PSC_CHECKER_TIMEOUT", "25"))` inline  | `CHECKER_TIMEOUT`                | `PSC_CHECKER_TIMEOUT`            |
+| `int(os.getenv("PSC_PARALLEL_TIMEOUT", "60"))` inline | `PARALLEL_TIMEOUT`               | `PSC_PARALLEL_TIMEOUT`           |
+| Literal `50000`                                       | `MAX_TRANSCRIPT_LINES`           | `PSC_MAX_TRANSCRIPT_LINES`       |
+| Literal `3` (ask_user count)                          | `MAX_ASK_USER_QUESTIONS`         | `PSC_MAX_ASK_USER_QUESTIONS`     |
+| Literal `10` (tests threshold)                        | `MIN_TESTS_PASSED_THRESHOLD`     | `PSC_MIN_TESTS_PASSED_THRESHOLD` |
+| Literal `10` (consecutive blocks)                     | `DEFAULT_MAX_CONSECUTIVE_BLOCKS` | `PSC_MAX_CONSECUTIVE_BLOCKS`     |
+
+### Safe environment variable parsing
+
+All `PSC_*` variables are now parsed via `_env_int(name, default)` which logs a warning and returns the default if the value is non-numeric. This prevents a misconfigured environment from silently disabling the entire hook at import time.
+
+---
+
+## Security Improvements
+
+The refactor also addressed six security issues identified during analysis. See the [API Reference security section](../../reference/power-steering-checker-api.md#security) for complete details.
+
+| Issue                                  | Fix                                                                     |
+| -------------------------------------- | ----------------------------------------------------------------------- |
+| Session ID path traversal              | Regex validation `r'^[a-zA-Z0-9_\-]{1,128}$'` before path interpolation |
+| Non-numeric env vars crashing import   | `_env_int()` helper with fallback                                       |
+| Oversized JSON lines exhausting memory | 10 MB per-line size guard                                               |
+| Malformed compaction event paths       | `isinstance(str)` + non-empty check                                     |
+| Silent OSError swallowing              | Logged `WARNING` with `exc_info=True`                                   |
+| TOCTOU on semaphore creation           | Atomic `os.open(O_CREAT \| O_EXCL, 0o600)`                              |
+
+---
+
+## Working with the New Structure
+
+### Adding a method to an existing mixin
+
+1. Identify which module owns the concern (see Module Boundaries above).
+2. Add the method to the corresponding `*Mixin` class.
+3. If the method uses constants or imports from other modules, add them at the top of that module.
+4. No changes to `__init__.py` are needed for private methods.
+
+### Adding a new public symbol
+
+1. Implement in the appropriate module.
+2. Add the import to `__init__.py`.
+3. Add to `__all__` in `__init__.py`.
+
+### Adding a new configurable constant
+
+1. Place in the module where it is consumed (see Constants Placement above).
+2. Use the pattern:
+
+   ```python
+   MY_CONSTANT = int(os.getenv("PSC_MY_CONSTANT", "default_value"))
+   ```
+
+   Or, if the module already has `_env_int`:
+
+   ```python
+   MY_CONSTANT = _env_int("PSC_MY_CONSTANT", default_value)
+   ```
+
+3. Document in [Configuration Reference](../../reference/power-steering-checker-configuration.md).
+
+### Writing tests
+
+Each module can be tested in isolation by importing only that module. Tests that previously required the full `PowerSteeringChecker` class can now test individual mixins directly:
+
+```python
+# Test considerations logic without instantiating PowerSteeringChecker
+from power_steering_checker.considerations import ConsiderationsMixin
+
+class TestChecker(ConsiderationsMixin):
+    """Minimal test fixture."""
+    def __init__(self):
+        self.considerations = [...]
+
+checker = TestChecker()
+result = checker._classify_session(transcript_lines)
+assert result == "STANDARD"
+```
+
+---
+
+## Migration from Single-File to Package
+
+This section is for maintainers who need to understand how the split was performed, or who need to backport a change from an older single-file checkout.
+
+### File mapping
+
+| Original line range          | Destination module     |
+| ---------------------------- | ---------------------- |
+| Dataclasses (top)            | `considerations.py`    |
+| `ConsiderationsMixin`        | `considerations.py`    |
+| `_timeout()` context manager | `sdk_calls.py`         |
+| `SdkCallsMixin`              | `sdk_calls.py`         |
+| `_write_with_retry()`        | `progress_tracking.py` |
+| Compaction import block      | `progress_tracking.py` |
+| `ProgressTrackingMixin`      | `progress_tracking.py` |
+| `ResultFormattingMixin`      | `result_formatting.py` |
+| `PowerSteeringChecker` class | `main_checker.py`      |
+| `check_session()`            | `main_checker.py`      |
+| `is_disabled()`              | `main_checker.py`      |
+| `if __name__ == "__main__":` | `main_checker.py`      |
+
+### What was not moved
+
+Nothing was removed, renamed, or reordered beyond what is documented above. The logic is identical to the original file at the same version.
+
+---
+
+## Related Documentation
+
+- [API Reference](../../reference/power-steering-checker-api.md) — Public API
+- [Configuration Reference](../../reference/power-steering-checker-configuration.md) — Environment variables
+- [Power-Steering Overview](README.md) — Feature overview
+- [Troubleshooting](troubleshooting.md) — Common issues

--- a/docs/features/power-steering/changelog-v0.9.1.md
+++ b/docs/features/power-steering/changelog-v0.9.1.md
@@ -1,0 +1,257 @@
+# Power Steering v0.9.1 Changelog
+
+## Issue #1882: Infinite Loop Fix
+
+**Release Date:** 2025-12-17
+
+### Summary
+
+Fixed critical bug where power steering guidance got stuck in an infinite loop due to state persistence failures. The counter wouldn't increment, causing the same message to display repeatedly.
+
+### Problem
+
+Power steering's guidance counter failed to persist reliably:
+
+- Counter stayed at 0 even after incrementing
+- Same guidance message appeared on every tool call
+- State saves completed without error but data wasn't actually written
+- Cloud sync conflicts caused intermittent failures
+
+### Root Cause
+
+Three interconnected issues:
+
+1. **Non-atomic writes**: State saves didn't force disk flush, leaving data in OS buffer
+2. **No verification**: System assumed saves worked without confirming
+3. **No defensive validation**: Corrupted state data crashed the system instead of recovering
+
+### Solution
+
+Four-phase fix addressing all failure modes:
+
+#### Phase 1: Instrumentation
+
+Added structured diagnostic logging to understand failure patterns:
+
+```python
+# Diagnostic log entry example
+{
+    "timestamp": "2025-12-17T19:30:00Z",
+    "operation": "state_save",
+    "counter_before": 0,
+    "counter_after": 1,
+    "session_id": "20251217_193000",
+    "file_path": ".claude/runtime/power-steering/.../state.json",
+    "save_success": true,
+    "verification_success": true,
+    "retry_count": 0
+}
+```
+
+**Location:** `~/.amplihack/.claude/runtime/power-steering/{session_id}/diagnostic.jsonl`
+
+**Benefits:**
+
+- Traces state operations through save/load lifecycle
+- Captures counter transitions and verification results
+- Enables post-mortem analysis of failures
+
+#### Phase 2: Defensive Validation
+
+State validation after every load operation:
+
+```python
+def _validate_state(state: Dict) -> bool:
+    """Validate loaded state data"""
+    if not isinstance(state, dict):
+        return False
+
+    counter = state.get("consecutive_blocks", 0)
+    if not isinstance(counter, int) or counter < 0:
+        return False
+
+    session_id = state.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return False
+
+    return True
+```
+
+**Catches:**
+
+- Corrupted JSON data
+- Negative or null counter values
+- Missing or invalid session IDs
+
+**Recovery:**
+
+- Logs validation failure to diagnostics
+- Resets to safe default state
+- Continues operation without crashing
+
+#### Phase 3: Atomic Write Enhancement
+
+Three-layer reliability for state persistence:
+
+**Layer 1: fsync() force flush**
+
+```python
+with open(state_file, 'w') as f:
+    json.dump(state_data, f, indent=2)
+    f.flush()
+    os.fsync(f.fileno())  # Force disk write NOW
+```
+
+**Layer 2: Verification read**
+
+```python
+# Immediately read back what we wrote
+with open(state_file, 'r') as f:
+    verified_data = json.load(f)
+
+if verified_data != state_data:
+    # Save didn't work - try again
+    retry_with_backoff()
+```
+
+**Layer 3: Retry with exponential backoff**
+
+```python
+retry_delays = [0.1, 0.2, 0.4]  # Cloud sync tolerance
+for delay in retry_delays:
+    try:
+        atomic_write_with_fsync(state_file, data)
+        verify_read(state_file, data)
+        return  # Success!
+    except:
+        time.sleep(delay)
+```
+
+**Fallback:** Non-atomic write if atomic fails after retries
+
+#### Phase 4: User Visibility
+
+Made state persistence failures visible to users:
+
+**New diagnostic command:**
+
+```bash
+/amplihack:ps-diagnose
+```
+
+**Shows:**
+
+- Current state health
+- Counter value and increment history
+- Session ID consistency
+- Recent save/load operations
+- Detected failures and recovery actions
+
+**Error messages:**
+
+- "Power steering state save failed - counter may not persist"
+- "Corrupted state detected - resetting to defaults"
+- Clear guidance on when to file issues
+
+### Requirements Met
+
+| Requirement                         | Status | Evidence                            |
+| ----------------------------------- | ------ | ----------------------------------- |
+| REQ-1: Counter increments reliably  | ✅     | Atomic writes + verification read   |
+| REQ-2: Messages customized properly | ✅     | Check results integrated correctly  |
+| REQ-3: Atomic counter increment     | ✅     | fsync + retry logic                 |
+| REQ-4: Robust state management      | ✅     | Validation + recovery + diagnostics |
+
+### Testing
+
+**Test scenarios covered:**
+
+1. **Normal operation**: Counter increments, stops after first display
+2. **Cloud sync conflicts**: Retry logic handles delayed writes
+3. **Corrupted state**: Validation detects, resets, continues
+4. **Concurrent sessions**: Session ID prevents cross-contamination
+5. **File system full**: Graceful degradation with user notification
+
+**Results:** All scenarios pass with v0.9.1 fix.
+
+### Migration Notes
+
+**Automatic upgrade** - No action needed for users:
+
+- Existing state files remain compatible
+- New diagnostic logging starts automatically
+- Enhanced validation activates on next load
+
+**Breaking changes:** None
+
+**New files created:**
+
+- `~/.amplihack/.claude/runtime/power-steering/{session_id}/diagnostic.jsonl`
+
+**Performance impact:**
+
+- 1-2ms overhead per state save (negligible)
+- Retry logic only activates on failures
+
+### Files Changed
+
+- `~/.amplihack/.claude/tools/amplihack/hooks/power_steering_state.py`
+  - Added `fsync()` to state save
+  - Added verification read after save
+  - Added retry logic with exponential backoff
+  - Added defensive state validation
+  - Added diagnostic logging
+
+- `~/.amplihack/.claude/tools/amplihack/hooks/power_steering_checker.py`
+  - Enhanced message customization logic
+  - Integrated check results with guidance
+
+- `~/.amplihack/.claude/tools/amplihack/hooks/hook_processor.py`
+  - Added `/amplihack:ps-diagnose` command
+  - Integrated diagnostic reporting
+
+### Performance
+
+**Before fix:**
+
+- 70% failure rate on cloud-synced directories
+- Infinite loops requiring manual intervention
+- Average recovery time: 2-5 minutes (manual reset)
+
+**After fix:**
+
+- 99.5% success rate (0.5% graceful degradation)
+- Zero infinite loops
+- Average recovery time: 50ms (automatic)
+
+### Known Limitations
+
+1. **Concurrent sessions**: Still possible (though unlikely) for race conditions across multiple Claude Code instances
+2. **Network drives**: Very slow network drives may exceed retry timeout
+3. **Read-only filesystems**: State won't persist (graceful degradation)
+
+### Future Enhancements
+
+Potential improvements for future releases:
+
+1. **File locking**: Prevent concurrent session conflicts
+2. **Compression**: Reduce diagnostic log size
+3. **Metrics**: Track save success rate over time
+4. **Auto-cleanup**: Remove old diagnostic logs
+
+### Credits
+
+- **Issue reporter**: GitHub issue #1882
+- **Fix implemented**: v0.9.1 release
+- **Testing**: Simulated cloud sync conflicts, corruption scenarios
+
+### Related Issues
+
+- #1755: Multi-model validation patterns
+- #1785: AI-optimized workflows
+
+### References
+
+- [Power Steering Architecture](./architecture-refactor.md)
+- [Troubleshooting Guide](./troubleshooting.md)
+- [PATTERNS.md: File I/O with Cloud Sync Resilience](../../concepts/patterns.md)

--- a/docs/features/power-steering/configuration.md
+++ b/docs/features/power-steering/configuration.md
@@ -1,0 +1,679 @@
+# Power-Steering Configuration Guide
+
+> [Home](../../index.md) > [Features](../README.md) > [Power-Steering](README.md) > Configuration
+
+Complete guide to configuring Power-Steering for your workflow.
+
+## Quick Start
+
+Power-Steering configuration has two levels:
+
+1. **Considerations** (`.claude/tools/amplihack/considerations.yaml`) - What to check
+2. **Preferences** (`.claude/context/USER_PREFERENCES.md`) - How to behave
+
+---
+
+## Configuration Files
+
+### considerations.yaml
+
+**Location**: `.claude/tools/amplihack/considerations.yaml`
+
+**Purpose**: Define the 21 considerations that validate session completeness.
+
+**Format**:
+
+```yaml
+- id: unique_id
+  category: Category Name
+  question: What should we check?
+  description: Why this matters
+  severity: blocker # or warning
+  checker: method_name # or "generic"
+  enabled: true # or false
+```
+
+**See**: [Customization Guide](customization-guide.md) for detailed YAML syntax.
+
+### USER_PREFERENCES.md
+
+**Location**: `.claude/context/USER_PREFERENCES.md`
+
+**Purpose**: Define your workflow preferences that Power-Steering should respect.
+
+**Format**:
+
+```markdown
+### YYYY-MM-DD HH:MM:SS
+
+**Preference Title**
+
+Preference description and requirements.
+
+**Implementation Requirements** (optional):
+
+- Detailed requirements
+```
+
+---
+
+## Common Configurations
+
+### Configuration 1: Manual PR Approval
+
+**Use case**: You require manual review of all PRs before merge.
+
+**Setup**:
+
+Add to USER_PREFERENCES.md:
+
+```markdown
+### 2026-01-23 10:00:00
+
+**NEVER Merge PRs Without Explicit Permission**
+
+NEVER merge PRs or commit directly to main without explicit user permission.
+Always create PRs and wait for approval.
+```
+
+**Effect**: Power-Steering stops at "PR ready + CI passing", doesn't require merge.
+
+**Learn more**: [How-To: Merge Preferences](../../howto/power-steering-merge-preferences.md)
+
+### Configuration 2: Strict Local Testing
+
+**Use case**: Enforce local testing on every PR (no CI-only testing).
+
+**Setup**:
+
+Add to USER_PREFERENCES.md:
+
+```markdown
+### 2026-01-23 10:00:00
+
+**Step 13 Local Testing - NO EXCEPTIONS**
+
+EVERY PR MUST have local testing completed. Step 13 in DEFAULT_WORKFLOW.md
+is MANDATORY and cannot be skipped through rationalization.
+
+**Implementation Requirements:**
+
+- MUST execute at least 2 test scenarios (1 simple + 1 complex) locally
+- MUST document test results in PR description
+- MUST verify no regressions before committing
+```
+
+**Effect**: Power-Steering validates local testing evidence in PR description.
+
+### Configuration 3: Relaxed Workflow (Warnings Only)
+
+**Use case**: Less strict checking for exploratory or prototyping work.
+
+**Setup**:
+
+Modify considerations.yaml:
+
+```yaml
+# Change all blockers to warnings
+- id: tests_written
+  severity: warning # Changed from blocker
+
+- id: ci_status
+  severity: warning # Changed from blocker
+
+# Keep only critical blockers
+- id: zero_bs_compliance
+  severity: blocker # Keep as blocker
+```
+
+**Effect**: Power-Steering provides guidance but doesn't block session end.
+
+**Warning**: Use sparingly - reduces quality enforcement.
+
+### Configuration 4: Custom Team Requirements
+
+**Use case**: Add team-specific checks (security review, compliance, etc.).
+
+**Setup**:
+
+Add to considerations.yaml:
+
+```yaml
+- id: security_review
+  category: Code Quality & Philosophy Compliance
+  question: Has the security team reviewed this change for sensitive code?
+  description: Ensures security team sign-off for authentication, authorization, or data handling changes
+  severity: blocker
+  checker: generic # Uses keyword matching
+  enabled: true
+
+- id: compliance_checklist
+  category: Session Completion & Progress
+  question: Has the compliance checklist been completed for this feature?
+  description: Validates regulatory compliance requirements documented
+  severity: warning
+  checker: generic
+  enabled: true
+```
+
+**Effect**: Power-Steering checks for keywords like "security review", "compliance checklist" in session transcript.
+
+---
+
+## Preference Configuration
+
+### USER_PREFERENCES.md Format
+
+Power-Steering reads USER_PREFERENCES.md to detect workflow preferences.
+
+**Standard format**:
+
+```markdown
+### YYYY-MM-DD HH:MM:SS
+
+**Preference Title**
+
+Preference statement with MANDATORY keywords.
+
+**Implementation Requirements:**
+
+- Specific requirement 1
+- Specific requirement 2
+```
+
+### Supported Preferences
+
+| Preference                     | Keywords Required                       | Effect                     |
+| ------------------------------ | --------------------------------------- | -------------------------- |
+| Never Merge Without Permission | NEVER, Merge, PR, Without, Permission   | Stops at PR ready state    |
+| Always Test Locally            | Step 13, MANDATORY, Local Testing       | Enforces Step 13 evidence  |
+| No Direct Commits to Main      | NEVER, commit, main, without permission | Validates PR workflow used |
+
+### Adding New Preferences
+
+1. **Write preference** in USER_PREFERENCES.md with clear keywords
+2. **Test detection** by checking Power-Steering logs
+3. **Verify behavior** matches expectation
+4. **Document** in team onboarding
+
+**Example**:
+
+```markdown
+### 2026-01-23 10:00:00
+
+**Always Include Test Plan in PR Description**
+
+EVERY PR MUST include a "Test Plan" section describing manual testing performed.
+
+**Implementation Requirements:**
+
+- Test Plan section must exist in PR description
+- At least 2 test scenarios documented
+- Expected results specified
+```
+
+Future versions will support this preference automatically.
+
+---
+
+## Consideration Configuration
+
+### Enable/Disable Considerations
+
+**Disable a consideration**:
+
+```yaml
+- id: workflow_followed
+  enabled: false # Disabled
+```
+
+**Use cases**:
+
+- Temporarily disable during prototyping
+- Disable team-specific checks not relevant to your workflow
+- Troubleshoot false positives
+
+### Change Severity Levels
+
+**Convert blocker to warning**:
+
+```yaml
+- id: pr_description_complete
+  severity: warning # Changed from blocker
+```
+
+**Use cases**:
+
+- Less critical checks become advisory
+- Reduce friction during exploration
+- Gradual enforcement rollout
+
+**Warning**: Too many warnings reduce effectiveness.
+
+### Custom Checker Methods
+
+**Use specific checker** (requires code):
+
+```yaml
+- id: custom_check
+  checker: _check_custom_requirement
+```
+
+**Requirements**:
+
+- Method must exist in `power_steering_checker.py`
+- Method signature: `def _check_custom_requirement(self) -> CheckResult`
+- Returns `CheckResult` with satisfied, details, evidence
+
+**Use generic checker** (no code required):
+
+```yaml
+- id: custom_check
+  question: Has the custom requirement been documented in DOCS.md?
+  checker: generic
+```
+
+**How it works**:
+
+1. Extracts keywords from question: "custom", "requirement", "documented", "DOCS.md"
+2. Searches session transcript for keywords
+3. Returns satisfied if keywords found, unsatisfied otherwise
+
+### Custom Categories
+
+Add new category:
+
+```yaml
+- id: new_check
+  category: Custom Category Name
+  question: Custom check question?
+  description: What this checks
+  severity: blocker
+  checker: generic
+  enabled: true
+```
+
+Categories are free-form - use any name that makes sense for your team.
+
+---
+
+## Configuration Examples
+
+### Example 1: High-Quality Workflow
+
+**Goal**: Maximum quality enforcement, manual approval required.
+
+**considerations.yaml**:
+
+```yaml
+# All quality checks as blockers
+- id: zero_bs_compliance
+  severity: blocker
+
+- id: tests_written
+  severity: blocker
+
+- id: local_testing_completed
+  severity: blocker
+
+- id: pr_description_complete
+  severity: blocker
+
+- id: ci_status
+  severity: blocker
+```
+
+**USER_PREFERENCES.md**:
+
+```markdown
+**NEVER Merge PRs Without Explicit Permission**
+
+**Step 13 Local Testing - NO EXCEPTIONS**
+```
+
+**Result**: Strictest enforcement, highest quality PRs.
+
+### Example 2: Exploratory Workflow
+
+**Goal**: Guidance without blocking, fast iteration.
+
+**considerations.yaml**:
+
+```yaml
+# Most checks as warnings
+- id: tests_written
+  severity: warning
+
+- id: pr_description_complete
+  severity: warning
+
+# Keep only critical blockers
+- id: ci_status
+  severity: blocker # Still require CI passing
+```
+
+**USER_PREFERENCES.md**:
+
+```markdown
+# No additional preferences - use defaults
+```
+
+**Result**: Fast iteration with safety net for critical issues.
+
+### Example 3: Team Collaboration
+
+**Goal**: Team-specific requirements, balanced enforcement.
+
+**considerations.yaml**:
+
+```yaml
+# Standard checks as blockers
+- id: tests_written
+  severity: blocker
+
+- id: ci_status
+  severity: blocker
+
+# Custom team checks
+- id: design_review_completed
+  category: Session Completion & Progress
+  question: Has the design been reviewed by the architecture team?
+  description: Ensures architectural alignment for significant changes
+  severity: warning
+  checker: generic
+  enabled: true
+
+- id: api_contract_documented
+  category: PR Content & Quality
+  question: Is the API contract documented in the PR?
+  description: Validates API changes include contract documentation
+  severity: blocker
+  checker: generic
+  enabled: true
+```
+
+**USER_PREFERENCES.md**:
+
+```markdown
+**NEVER Merge PRs Without Explicit Permission**
+
+**API Changes Require Architecture Review**
+
+All API changes MUST be reviewed by architecture team before merge.
+```
+
+**Result**: Team-specific workflow with quality enforcement.
+
+---
+
+## Testing Configuration
+
+### Validate Preferences
+
+Test if preference detected:
+
+```bash
+# Check preference keywords present
+grep -i "never.*merge.*without.*permission" .claude/context/USER_PREFERENCES.md
+
+# Expected: Line matching the preference
+```
+
+### Test Considerations
+
+Run Power-Steering manually:
+
+```python
+# In Python REPL
+from amplihack.hooks.power_steering_checker import PowerSteeringChecker
+
+checker = PowerSteeringChecker()
+result = checker.check_consideration("ci_status")
+
+print(f"Satisfied: {result.satisfied}")
+print(f"Details: {result.details}")
+print(f"Evidence: {result.evidence}")
+```
+
+### Debug Logging
+
+Enable debug logging:
+
+```bash
+# Set environment variable
+export AMPLIHACK_LOG_LEVEL=DEBUG
+
+# Launch Claude
+amplihack claude
+```
+
+**Log output**:
+
+```
+DEBUG: Reading considerations.yaml
+DEBUG: Loaded 21 considerations
+DEBUG: Reading USER_PREFERENCES.md
+DEBUG: Detected preference: NEVER Merge Without Permission
+DEBUG: Using no-auto-merge CI check
+DEBUG: CI check satisfied (PR ready, awaiting user approval)
+```
+
+---
+
+## Configuration Best Practices
+
+### Start Conservative
+
+1. Use default considerations first
+2. Observe where friction occurs
+3. Customize gradually based on real usage
+4. Document why each change was made
+
+### Team Alignment
+
+1. **Document preferences**: Write team-specific preferences in onboarding docs
+2. **Review regularly**: Quarterly review of configuration effectiveness
+3. **Track metrics**: Monitor PR quality, review cycles, CI failures
+4. **Iterate**: Adjust based on data and feedback
+
+### Avoid Over-Configuration
+
+**Warning signs**:
+
+- Too many custom considerations (>30 total)
+- Everything is a blocker (reduces trust)
+- Everything is a warning (reduces effectiveness)
+- Complex detection logic (hard to maintain)
+
+**Better approach**:
+
+- Focus on 3-5 critical requirements per team
+- Balance blockers (5-10) and warnings (5-10)
+- Use generic checker for custom checks
+- Keep detection simple and clear
+
+---
+
+## Troubleshooting Configuration
+
+### Preference Not Detected
+
+**Diagnosis**:
+
+```bash
+# Check file exists
+ls -la .claude/context/USER_PREFERENCES.md
+
+# Check content
+cat .claude/context/USER_PREFERENCES.md
+```
+
+**Solutions**:
+
+1. Verify file location correct
+2. Check keywords present (see [Merge Preferences](../../howto/power-steering-merge-preferences.md))
+3. Restart Claude session (preferences read on initialization)
+
+### Consideration Not Running
+
+**Diagnosis**:
+
+Check enabled status:
+
+```bash
+# Search for consideration ID
+grep -A 5 "id: consideration_id" .claude/tools/amplihack/considerations.yaml
+```
+
+**Solutions**:
+
+1. Set `enabled: true`
+2. Verify YAML syntax valid (use YAML validator)
+3. Check checker method exists (if using specific checker)
+
+### False Positives
+
+**Diagnosis**:
+
+Review evidence:
+
+```
+❌ Check Failed: Tests not written
+
+Evidence:
+- No pytest output found
+- No test files in tests/ directory
+```
+
+**Solutions**:
+
+1. Fix the actual issue (write tests)
+2. If false positive, adjust detection logic
+3. Change severity to warning if check too strict
+4. Disable temporarily if blocking valid work
+
+---
+
+## Advanced Configuration
+
+### Conditional Checks
+
+Some considerations only apply in specific contexts:
+
+```yaml
+- id: workflow_followed
+  enabled_when: DEFAULT_WORKFLOW_ACTIVE
+  # Only checks if DEFAULT_WORKFLOW was used
+
+- id: investigation_documented
+  enabled_when: INVESTIGATION_SESSION
+  # Only checks during investigation sessions
+```
+
+**Note**: Context detection is automatic based on session transcript.
+
+### Precedence Rules
+
+Configuration precedence (highest to lowest):
+
+1. USER_PREFERENCES.md (user-specific)
+2. considerations.yaml (project-specific)
+3. Default considerations (framework defaults)
+
+**Example**:
+
+- Default: Require PR merge
+- USER_PREFERENCES.md: NEVER merge without permission
+- **Result**: Preference overrides default
+
+### Version Control
+
+**Recommendation**: Track configuration in git:
+
+```bash
+# Track considerations.yaml
+git add .claude/tools/amplihack/considerations.yaml
+
+# DO NOT track USER_PREFERENCES.md (personal)
+# Already in .gitignore
+```
+
+**Team workflow**:
+
+1. Standard considerations.yaml in repo
+2. Individual USER_PREFERENCES.md per developer
+3. Document standard preferences in onboarding
+
+---
+
+## Migration Guide
+
+### From No Configuration
+
+**Before**: Using default Power-Steering behavior
+
+**After**: Custom configuration
+
+**Steps**:
+
+1. Copy default considerations.yaml: `cp .claude/tools/amplihack/considerations.yaml.default .claude/tools/amplihack/considerations.yaml`
+2. Review each consideration, adjust as needed
+3. Add preferences to USER_PREFERENCES.md
+4. Test with a simple PR workflow
+5. Iterate based on feedback
+
+### From v0.9.1 to v0.10.0
+
+**Changes**:
+
+- Added: USER_PREFERENCES.md preference awareness
+- Added: Merge preference detection
+- No breaking changes to considerations.yaml
+
+**Migration**:
+
+1. Update Power-Steering code (automatic)
+2. Add preferences to USER_PREFERENCES.md (optional)
+3. Test merge preference behavior
+4. No configuration changes required
+
+---
+
+## Related Documentation
+
+### User Guides
+
+- [Power-Steering Overview](README.md) - Feature overview
+- [How-To: Merge Preferences](../../howto/power-steering-merge-preferences.md) - Configure merge approval
+- [Customization Guide](customization-guide.md) - Detailed YAML customization
+- [Troubleshooting](troubleshooting.md) - Fix common issues
+
+### Technical References
+
+- [Technical Reference: Merge Preferences](../../reference/power-steering-merge-preferences.md) - Developer docs
+- [considerations.yaml Schema](../../reference/power-steering-checker-configuration.md) - Complete YAML reference (coming soon)
+- [USER_PREFERENCES.md Reference](../../reference/profile-management.md) - Complete preferences reference
+
+---
+
+## FAQ
+
+**Q: Do I need to restart Claude after changing configuration?**
+
+A: considerations.yaml: No (loaded on each check). USER_PREFERENCES.md: Yes (read on session start).
+
+**Q: Can I have different configurations per project?**
+
+A: Yes. considerations.yaml is per-project. USER_PREFERENCES.md is per-project but can reference global preferences.
+
+**Q: What if my team uses Azure DevOps instead of GitHub?**
+
+A: Power-Steering uses platform-bridge for cross-platform support. Most checks work on both platforms.
+
+**Q: Can I disable Power-Steering for specific sessions?**
+
+A: Not recommended. Better to use warning-only severity for less critical checks.
+
+---
+
+**Ready to customize?** Start with [Customization Guide](customization-guide.md) for detailed YAML syntax and examples.

--- a/docs/features/power-steering/customization-guide.md
+++ b/docs/features/power-steering/customization-guide.md
@@ -1,0 +1,652 @@
+# How to Customize Power-Steering Mode
+
+This guide explains how to customize power-steering mode considerations to match your team's specific workflow and requirements.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Understanding Considerations](#understanding-considerations)
+3. [YAML File Format](#yaml-file-format)
+4. [Customization Examples](#customization-examples)
+5. [Adding Custom Considerations](#adding-custom-considerations)
+6. [Troubleshooting](#troubleshooting)
+
+## Overview
+
+Power-steering mode uses a YAML configuration file to define the 21 considerations that verify session completeness. You can:
+
+- **Modify existing considerations**: Change questions, severity, or enable/disable checks
+- **Add custom considerations**: Define team-specific requirements
+- **Use generic or specific checkers**: Simple keyword matching or dedicated analysis functions
+
+**Configuration File Location:**
+
+```
+.claude/tools/amplihack/considerations.yaml
+```
+
+## Understanding Considerations
+
+Each consideration checks a specific aspect of your work:
+
+### Consideration Structure
+
+```yaml
+- id: unique_identifier # Unique ID for this consideration
+  category: Category Name # One of 6 categories
+  question: Human-readable question? # Natural language prompt
+  description: What this checks # Detailed explanation
+  severity: blocker # "blocker" or "warning"
+  checker: method_name # Checker method or "generic"
+  enabled: true # true/false to enable/disable
+```
+
+### Categories
+
+1. **Session Completion & Progress** - TODOs, objectives, documentation
+2. **Workflow Process Adherence** - DEFAULT_WORKFLOW, investigations
+3. **Code Quality & Philosophy Compliance** - Zero-BS, no shortcuts
+4. **Testing & Local Validation** - Test execution, interactive testing
+5. **PR Content & Quality** - Description, related changes, root pollution
+6. **CI/CD & Mergeability Status** - CI passing, rebase, pre-commit/CI sync
+
+### Severity Levels
+
+- **blocker**: Blocks session end if check fails (red light)
+- **warning**: Advisory only, doesn't block (yellow light)
+
+### Checker Types
+
+- **Specific checker**: Named method like `_check_todos_complete`
+  - Uses sophisticated analysis logic
+  - Highly accurate for specific scenarios
+
+- **generic**: Simple keyword matching
+  - Extracts keywords from question
+  - Searches transcript for matches
+  - Defaults to satisfied (fail-open)
+  - Good for custom considerations
+
+## YAML File Format
+
+### Basic Structure
+
+The YAML file contains a list of consideration objects:
+
+```yaml
+# Comment lines start with #
+
+- id: first_consideration
+  category: Session Completion & Progress
+  question: Is the first thing done?
+  description: Checks if first thing completed
+  severity: blocker
+  checker: _check_first_thing
+  enabled: true
+
+- id: second_consideration
+  category: Code Quality & Philosophy Compliance
+  question: Is the second thing done?
+  description: Checks if second thing completed
+  severity: warning
+  checker: generic
+  enabled: true
+```
+
+### Required Fields
+
+All considerations MUST have these fields:
+
+1. `id` - Unique identifier (string)
+2. `category` - Category name (string)
+3. `question` - Human-readable question (string)
+4. `description` - What this checks (string)
+5. `severity` - Either "blocker" or "warning"
+6. `checker` - Method name or "generic"
+7. `enabled` - Boolean (true/false)
+
+### Validation Rules
+
+- **id**: Must be unique across all considerations
+- **severity**: Only "blocker" or "warning" allowed
+- **enabled**: Must be boolean (not "yes", "1", etc.)
+- **checker**: Must be valid method name or "generic"
+
+## Customization Examples
+
+### Example 1: Disable a Consideration
+
+To skip a check you don't need:
+
+```yaml
+- id: presentation_needed
+  category: Session Completion & Progress
+  question: Does work need presentation deck?
+  description: Detects high-impact work for stakeholders
+  severity: warning
+  checker: _check_presentation_needed
+  enabled: false # Changed from true to false
+```
+
+### Example 2: Change Severity
+
+Make a warning into a blocker (or vice versa):
+
+```yaml
+- id: documentation_updates
+  category: Session Completion & Progress
+  question: Were relevant documentation files updated?
+  description: Verifies README, docs reflect changes
+  severity: blocker # Changed from "warning" to "blocker"
+  checker: _check_documentation_updates
+  enabled: true
+```
+
+### Example 3: Modify Question Text
+
+Customize the prompt text:
+
+```yaml
+- id: local_testing
+  category: Testing & Local Validation
+  question: Did you run and verify all tests locally? # Customized
+  description: Verifies tests were executed and passed locally
+  severity: blocker
+  checker: _check_local_testing
+  enabled: true
+```
+
+### Example 4: Add Team-Specific Consideration
+
+Add a custom consideration with generic checker:
+
+```yaml
+# At the end of the file, add:
+
+- id: security_scan
+  category: Security & Compliance
+  question: Was security scanning performed?
+  description: Ensures security tools were run on code changes
+  severity: blocker
+  checker: generic # Uses simple keyword matching
+  enabled: true
+```
+
+### Example 5: Add Multiple Custom Checks
+
+```yaml
+# Custom security consideration
+- id: security_review
+  category: Security & Compliance
+  question: Was security review completed?
+  description: Verifies security team reviewed changes
+  severity: blocker
+  checker: generic
+  enabled: true
+
+# Custom performance consideration
+- id: performance_impact
+  category: Performance & Optimization
+  question: Was performance impact assessed?
+  description: Checks if performance implications were analyzed
+  severity: warning
+  checker: generic
+  enabled: true
+
+# Custom compliance consideration
+- id: gdpr_compliance
+  category: Legal & Compliance
+  question: Were GDPR requirements verified?
+  description: Ensures data privacy regulations followed
+  severity: blocker
+  checker: generic
+  enabled: true
+```
+
+## Adding Custom Considerations
+
+### Step 1: Identify the Requirement
+
+Ask yourself:
+
+- What should be checked before ending this session?
+- Is this a blocker or a warning?
+- Can I use the generic checker, or do I need custom logic?
+
+### Step 2: Write the YAML Entry
+
+Add to the end of `considerations.yaml`:
+
+```yaml
+# CUSTOM CONSIDERATIONS
+# Add team-specific checks below
+
+- id: my_custom_check
+  category: Custom Category
+  question: Is my custom requirement satisfied?
+  description: Checks for team-specific requirement
+  severity: blocker
+  checker: generic
+  enabled: true
+```
+
+### Step 3: Test the Consideration
+
+1. Save the YAML file
+2. Start a new session (changes take effect next session)
+3. Trigger the consideration by including relevant keywords in your work
+4. Verify the check appears in power-steering output
+
+### Step 4: Refine as Needed
+
+- Adjust severity if too strict/lenient
+- Modify question text for clarity
+- Disable if creating false positives
+
+## Generic Checker Behavior
+
+The generic checker is simple but effective:
+
+### How It Works
+
+1. **Extract keywords** from the question
+   - Removes common words ("is", "the", "are")
+   - Keeps meaningful terms (>3 characters)
+
+2. **Search transcript** for keywords
+   - Looks in user and assistant messages
+   - Case-insensitive matching
+
+3. **Default to satisfied** (fail-open)
+   - Avoids false positives
+   - Only flags if clear violation detected
+
+### Example: Generic Checker in Action
+
+```yaml
+question: Were security scans performed?
+# Keywords extracted: "security", "scans", "performed"
+# Searches transcript for these terms
+# If found: likely satisfied
+# If not found: may still be satisfied (fail-open)
+```
+
+### Limitations
+
+- **Simple keyword matching**: Not context-aware
+- **Fail-open default**: Conservative to avoid false positives
+- **No complex logic**: For sophisticated checks, use specific checkers
+
+### When to Use Generic
+
+✅ **Good for:**
+
+- Team-specific requirements
+- Workflow reminders
+- Documentation checks
+- Simple presence/absence checks
+
+❌ **Not good for:**
+
+- Complex logic (multiple conditions)
+- Code analysis (AST parsing)
+- Statistical analysis (coverage, performance)
+- External API checks
+
+## Available Specific Checkers
+
+These checkers have sophisticated logic built-in:
+
+### Session Completion
+
+- `_check_todos_complete` - All TodoWrite items completed
+- `_check_objective_completion` - Original user goal achieved
+- `_check_documentation_updates` - Docs updated with code changes
+- `_check_next_steps` - Follow-up tasks documented
+
+### Workflow & Process
+
+- `_check_dev_workflow_complete` - DEFAULT_WORKFLOW followed
+- `_check_investigation_docs` - Investigation findings captured
+- `_check_docs_organization` - Docs in correct directories
+
+### Code Quality
+
+- `_check_philosophy_compliance` - Zero-BS (no TODOs, stubs)
+- `_check_shortcuts` - No quality compromises
+- `_check_root_pollution` - No inappropriate root files
+
+### Testing
+
+- `_check_local_testing` - Tests executed and passed
+- `_check_interactive_testing` - Manual verification done
+
+### PR & CI/CD
+
+- `_check_ci_status` - CI checks passing
+- `_check_pr_description` - PR has summary and test plan
+- `_check_review_responses` - Review feedback addressed
+- `_check_branch_rebase` - Branch up to date with main
+- `_check_ci_precommit_mismatch` - CI and pre-commit aligned
+- `_check_unrelated_changes` - No scope creep
+
+### Miscellaneous
+
+- `_check_agent_unnecessary_questions` - Agent not asking obvious questions
+- `_check_tutorial_needed` - New features have examples
+- `_check_presentation_needed` - High-impact work has presentation
+
+## Troubleshooting
+
+### Problem: YAML File Not Loading
+
+**Symptoms:**
+
+- Warning in logs: "Considerations YAML not found"
+- Falls back to Phase 1 (5 checkers)
+
+**Solutions:**
+
+1. Verify file exists: `~/.amplihack/.claude/tools/amplihack/considerations.yaml`
+2. Check file permissions (must be readable)
+3. Look for typos in filename
+
+### Problem: YAML Parse Error
+
+**Symptoms:**
+
+- Error in logs: "Invalid YAML structure"
+- Falls back to Phase 1
+
+**Solutions:**
+
+1. Validate YAML syntax (use online validator)
+2. Check indentation (must use spaces, not tabs)
+3. Ensure all strings are properly quoted if needed
+4. Look for unmatched brackets or quotes
+
+### Problem: Consideration Not Running
+
+**Symptoms:**
+
+- Consideration defined but not appearing in results
+
+**Solutions:**
+
+1. Check `enabled: true` in YAML
+2. Verify not disabled in config file (`.power_steering_config`)
+3. Confirm consideration meets validation rules
+4. Check logs for validation errors
+
+### Problem: False Positives
+
+**Symptoms:**
+
+- Consideration fails when it shouldn't
+- Blocks sessions incorrectly
+
+**Solutions:**
+
+1. **For generic checkers:**
+   - Refine question keywords
+   - Consider changing to specific checker
+   - Change severity from "blocker" to "warning"
+
+2. **For specific checkers:**
+   - Review checker logic (may need code changes)
+   - Temporarily disable the consideration
+   - Report issue if checker has bugs
+
+### Problem: False Negatives
+
+**Symptoms:**
+
+- Consideration passes when it should fail
+- Doesn't catch issues
+
+**Solutions:**
+
+1. **For generic checkers:**
+   - Generic checkers are fail-open by default
+   - Consider implementing a specific checker
+   - Add more detailed keywords to question
+
+2. **For specific checkers:**
+   - Review checker heuristics
+   - May need to enhance checker logic
+
+### Problem: Too Many Blockers
+
+**Symptoms:**
+
+- Can't end session even when work is complete
+- Multiple false positives
+
+**Solutions:**
+
+1. Review severity levels - change blockers to warnings
+2. Disable non-critical considerations
+3. Adjust checker sensitivity
+4. Use `export AMPLIHACK_SKIP_POWER_STEERING=1` temporarily
+
+## Configuration File Reference
+
+### Minimal Valid Consideration
+
+```yaml
+- id: minimal
+  category: Test
+  question: Test?
+  description: Test
+  severity: warning
+  checker: generic
+  enabled: true
+```
+
+### Complete Example File
+
+```yaml
+# Power-Steering Considerations Configuration
+# See HOW_TO_CUSTOMIZE_POWER_STEERING.md for details
+
+# Session Completion
+- id: todos_complete
+  category: Session Completion & Progress
+  question: Were all TODO items completed?
+  description: Verifies all TodoWrite items are marked as completed
+  severity: blocker
+  checker: _check_todos_complete
+  enabled: true
+
+# Add more considerations...
+
+# CUSTOM CONSIDERATIONS
+- id: custom_team_check
+  category: Team Process
+  question: Was team process followed?
+  description: Team-specific requirement
+  severity: warning
+  checker: generic
+  enabled: true
+```
+
+### Validation Checklist
+
+Before saving your YAML file, verify:
+
+- ✅ Valid YAML syntax (no parse errors)
+- ✅ All required fields present
+- ✅ Unique IDs for all considerations
+- ✅ Severity is "blocker" or "warning"
+- ✅ Enabled is boolean (true/false)
+- ✅ Checker is valid method or "generic"
+- ✅ Proper indentation (2 spaces per level)
+
+## Best Practices
+
+### Do's
+
+✅ **Start conservative**: Begin with warnings, upgrade to blockers after testing
+✅ **Test incrementally**: Add one consideration at a time
+✅ **Use generic for simple checks**: Don't over-engineer
+✅ **Document custom considerations**: Add comments explaining why
+✅ **Review periodically**: Remove considerations that aren't useful
+✅ **Share with team**: Keep team's YAML in version control
+
+### Don'ts
+
+❌ **Don't block too aggressively**: Too many blockers frustrate users
+❌ **Don't skip testing**: Always test new considerations
+❌ **Don't forget to enable**: `enabled: false` means it won't run
+❌ **Don't ignore false positives**: Tune or disable problematic checks
+❌ **Don't use tabs**: YAML requires spaces for indentation
+❌ **Don't duplicate IDs**: Each consideration needs unique ID
+
+## Getting Help
+
+### Check Logs
+
+Power-steering logs are in:
+
+```
+.claude/runtime/power-steering/power_steering.log
+```
+
+Look for:
+
+- YAML loading messages
+- Validation errors
+- Checker execution details
+
+### Enable Debug Logging
+
+(Future enhancement - not yet implemented)
+
+### Disable Power-Steering
+
+Power-steering can be disabled using three control mechanisms (in priority order):
+
+```bash
+# Method 1: Runtime disable (highest priority)
+# Creates semaphore file to disable power-steering immediately
+mkdir -p .claude/runtime/power-steering && touch .claude/runtime/power-steering/.disabled
+
+# Method 2: Session disable (medium priority)
+# Affects sessions started after setting this variable
+export AMPLIHACK_SKIP_POWER_STEERING=1
+
+# Method 3: Startup disable (lowest priority)
+# Sets default behavior at startup - config file should be JSON
+echo '{"enabled": false}' > .claude/tools/amplihack/.power_steering_config
+```
+
+**To re-enable power-steering:**
+
+```bash
+# Remove the semaphore file
+rm .claude/runtime/power-steering/.disabled
+
+# Or unset the environment variable
+unset AMPLIHACK_SKIP_POWER_STEERING
+```
+
+### Report Issues
+
+If you find bugs in specific checkers or need help:
+
+1. Check existing documentation
+2. Review logs for error messages
+3. Create minimal reproduction case
+4. Report issue with YAML configuration and transcript excerpt
+
+## Advanced Topics
+
+### Creating Custom Specific Checkers
+
+For complex requirements, you may want to implement a custom specific checker.
+
+**Requirements:**
+
+- Python programming knowledge
+- Understanding of transcript structure
+- Ability to modify `power_steering_checker.py`
+
+**Steps:**
+
+1. Add method to `PowerSteeringChecker` class
+2. Method signature: `def _check_my_thing(self, transcript: List[Dict], session_id: str) -> bool`
+3. Return `True` if satisfied, `False` if failed
+4. Use fail-open error handling (catch exceptions, return True)
+5. Reference method in YAML: `checker: _check_my_thing`
+
+**Example:**
+
+```python
+def _check_custom_requirement(self, transcript: List[Dict], session_id: str) -> bool:
+    """Check custom team requirement.
+
+    Returns:
+        True if requirement met, False otherwise
+    """
+    try:
+        # Your custom logic here
+        requirement_met = False
+
+        for msg in transcript:
+            if msg.get("type") == "user":
+                content = str(msg.get("message", {}).get("content", ""))
+                if "custom keyword" in content.lower():
+                    requirement_met = True
+                    break
+
+        return requirement_met
+    except Exception:
+        # Fail-open: return True on any error
+        return True
+```
+
+### Performance Considerations
+
+- **YAML loading**: Happens once at initialization (< 50ms)
+- **Consideration analysis**: All checkers run sequentially
+- **Target**: < 5 seconds total for all 21 checkers
+- **Optimization**: Disable unused checkers to reduce overhead
+
+### Integration with CI/CD
+
+You can version control `considerations.yaml` for consistency:
+
+```bash
+# Add to git
+git add .claude/tools/amplihack/considerations.yaml
+git commit -m "Add team power-steering configuration"
+
+# Share with team
+git push origin main
+```
+
+Team members will automatically use the shared configuration.
+
+## Appendix: Complete Default Configuration
+
+The full default `considerations.yaml` with all 21 considerations is located at:
+
+```
+.claude/tools/amplihack/considerations.yaml
+```
+
+To restore defaults:
+
+```bash
+# Backup your customizations
+cp .claude/tools/amplihack/considerations.yaml considerations.yaml.backup
+
+# Restore from source
+# (Re-copy from original file or reinstall)
+```
+
+---
+
+**Version:** Phase 2 (v2.0)
+**Last Updated:** 2025
+**Author:** Power-Steering Mode Team

--- a/docs/features/power-steering/migration-v0.9.1.md
+++ b/docs/features/power-steering/migration-v0.9.1.md
@@ -1,0 +1,289 @@
+# Migration Guide: Power Steering v0.9.1
+
+Ahoy! This guide helps ye upgrade to power steering v0.9.1, which fixes the infinite loop bug.
+
+## Quick Summary
+
+**What changed:** Power steering state management be more robust
+**Who's affected:** All amplihack users
+**Action needed:** None (automatic upgrade)
+**Breaking changes:** None
+
+## Upgrade Process
+
+### Automatic Upgrade (Recommended)
+
+If ye're usin' the standard installation:
+
+```bash
+# PyPI installation
+cargo install amplihack-rs
+
+# uvx installation
+cargo install --force amplihack-rs
+
+# Verify version
+amplihack --version
+# Should show v0.9.1 or higher
+```
+
+That's it! No config changes needed.
+
+### Manual Upgrade
+
+If ye prefer manual updates:
+
+1. Update package:
+
+   ```bash
+   git pull origin main
+   cargo install --path .
+   ```
+
+2. Verify version:
+   ```bash
+   amplihack --version
+   ```
+
+## What Happens on Upgrade
+
+### Existing State Files
+
+**Preserved automatically:**
+
+- Existing `~/.amplihack/.claude/runtime/power-steering/*/state.json` files remain compatible
+- Counter values carry forward
+- Session IDs preserved
+
+**No migration needed** - the new code reads old state files just fine.
+
+### New Features
+
+**Automatically enabled after upgrade:**
+
+1. **Diagnostic logging**
+   - New logs appear at `~/.amplihack/.claude/runtime/power-steering/{session_id}/diagnostic.jsonl`
+   - Captures state operations automatically
+   - No configuration needed
+
+2. **Enhanced validation**
+   - State validation activates on next load
+   - Corrupted state automatically recovered
+   - No user action required
+
+3. **Atomic writes**
+   - fsync() enabled for all state saves
+   - Retry logic handles cloud sync automatically
+   - Transparent to users
+
+## Verifying the Upgrade
+
+### Test 1: Check Version
+
+```bash
+amplihack --version
+```
+
+Expected: `v0.9.1` or higher
+
+### Test 2: Run Diagnostic
+
+```bash
+# Start amplihack session
+amplihack
+
+# Run diagnostic command
+/amplihack:ps-diagnose
+```
+
+Expected output:
+
+```
+Power Steering Diagnostic Report
+Status: Healthy
+Counter: 0
+Session ID: 20251217_193000
+State file exists: Yes
+Recent operations: 3 successful saves, 0 failures
+```
+
+### Test 3: Verify Diagnostic Logs
+
+```bash
+# Check for diagnostic logs (should exist)
+ls .claude/runtime/power-steering/*/diagnostic.jsonl
+
+# View recent entries
+tail -5 .claude/runtime/power-steering/*/diagnostic.jsonl | jq
+```
+
+Expected: JSON entries showing state operations
+
+## Post-Upgrade Cleanup (Optional)
+
+If ye had issues with the old version, ye can clean up:
+
+### Remove Old Corrupted State
+
+```bash
+# Only if you had infinite loop issues
+rm -rf .claude/runtime/power-steering/
+```
+
+Next session will create fresh state.
+
+### Clear Old Logs (Optional)
+
+```bash
+# Only if you want to start fresh
+rm .claude/runtime/power-steering/*/power_steering.log
+```
+
+Diagnostic logs will accumulate over time - future versions will include auto-cleanup.
+
+## Rollback (If Needed)
+
+If ye encounter issues with v0.9.1, ye can rollback:
+
+```bash
+# Rollback to v0.9.0
+cargo install amplihack-rs==0.9.0
+
+# Or specific commit
+cargo install --git https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding@v0.9.0
+```
+
+**Please report issues** if ye need to rollback - helps us improve!
+
+## Known Migration Issues
+
+### Issue: Diagnostic logs grow large
+
+**Symptom:** `~/.amplihack/.claude/runtime/power-steering/*/diagnostic.jsonl` gets very large over time
+
+**Workaround:**
+
+```bash
+# Manual cleanup of old logs
+find .claude/runtime/power-steering -name "diagnostic.jsonl" -mtime +30 -delete
+```
+
+**Permanent fix:** Coming in v0.9.2 (auto-rotation)
+
+### Issue: Cloud sync conflicts during upgrade
+
+**Symptom:** State files fail to save immediately after upgrade
+
+**Cause:** Cloud services (Dropbox/iCloud) syncing old version
+
+**Solution:**
+
+1. Wait 1-2 minutes for sync to complete
+2. Retry operation
+3. Automatic retry logic will handle it
+
+## Configuration Changes
+
+### No Changes Required
+
+All configuration remains backward compatible:
+
+- `considerations.yaml` - No changes needed
+- Environment variables - Work as before
+- Semaphore files - Unchanged
+- `.power_steering_config` - Compatible
+
+### Optional Enhancements
+
+New configuration options available (all optional):
+
+```bash
+# Increase retry count for slow network drives
+export AMPLIHACK_PS_MAX_RETRIES=5
+
+# Enable debug logging
+export AMPLIHACK_PS_DEBUG=1
+
+# Custom diagnostic log location
+export AMPLIHACK_PS_DIAGNOSTIC_DIR=/custom/path
+```
+
+## Performance Impact
+
+Minimal performance changes:
+
+| Metric     | v0.9.0 | v0.9.1 | Change              |
+| ---------- | ------ | ------ | ------------------- |
+| State save | 0.5ms  | 1-2ms  | +1ms (fsync)        |
+| State load | 0.5ms  | 0.6ms  | +0.1ms (validation) |
+| Memory     | ~500B  | ~700B  | +200B (diagnostics) |
+
+**Total overhead:** < 2ms per operation (negligible)
+
+## Getting Help
+
+If ye encounter issues during upgrade:
+
+1. **Check version:**
+
+   ```bash
+   amplihack --version
+   ```
+
+2. **Run diagnostic:**
+
+   ```bash
+   /amplihack:ps-diagnose
+   ```
+
+3. **Check logs:**
+
+   ```bash
+   tail -50 .claude/runtime/power-steering/*/diagnostic.jsonl
+   ```
+
+4. **Report issue:**
+   - Include version number
+   - Diagnostic output
+   - Error messages
+   - What you were doing when it failed
+
+   Repository: https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues
+
+## FAQ
+
+**Q: Do I need to change my workflow?**
+A: Nope! Everything works the same, just more reliably.
+
+**Q: Will this fix my existing infinite loop?**
+A: Aye! Upgrade and the loop will stop.
+
+**Q: What about my custom checks?**
+A: All custom checks in `considerations.yaml` remain compatible.
+
+**Q: Can I downgrade if needed?**
+A: Aye, state files work with both versions.
+
+**Q: What's the disk space impact?**
+A: Diagnostic logs add ~10KB per session. We'll add auto-cleanup soon.
+
+**Q: Does this work with cloud-synced directories?**
+A: Better than before! Retry logic handles sync delays.
+
+## Related Documentation
+
+- [Changelog v0.9.1](./changelog-v0.9.1.md) - Complete release notes
+- [Troubleshooting](./troubleshooting.md) - Fix common issues
+- [Technical Reference](./configuration.md) - Implementation details
+- [Power Steering Overview](./README.md) - Main documentation
+
+## Success Stories
+
+After upgrading to v0.9.1:
+
+- 99.5% state persistence success rate (was 70%)
+- Zero infinite loops (was ~5% of sessions)
+- 50ms automatic recovery (was 2-5 min manual)
+- No reported regressions
+
+Fair winds and following seas with yer upgrade! 🏴‍☠️

--- a/docs/features/power-steering/migration-worktree-support.md
+++ b/docs/features/power-steering/migration-worktree-support.md
@@ -1,0 +1,322 @@
+# Migration Guide: Power Steering Worktree Support
+
+Guide for users upgrading from pre-worktree Power Steering to the worktree-aware version.
+
+## What's New
+
+Power Steering now includes full git worktree support with:
+
+1. **Shared state persistence** - Counter works across all worktrees
+2. **Multi-path .disabled detection** - Check current dir, shared dir, and project root
+3. **Hard maximum enforcement** - Automatic approval after 10 blocks
+4. **Clear error messages** - Actionable instructions for fixes
+
+## Do You Need to Migrate?
+
+Check if you're affected:
+
+```bash
+# Are you using git worktrees?
+git worktree list
+
+# If this shows multiple entries, you'll benefit from the upgrade
+```
+
+If you see multiple worktrees, the upgrade fixes:
+
+- Counter resetting in worktrees (now persists)
+- .disabled file not working (now checks multiple locations)
+- Potential infinite loops (now has hard maximum)
+
+## Migration Steps
+
+### Step 1: Backup Current State
+
+```bash
+# Backup existing counter (if in main repo)
+if [ -f .git/.claude/runtime/power-steering/workflow_classification_block_counter.json ]; then
+    cp .git/.claude/runtime/power-steering/workflow_classification_block_counter.json \
+       /tmp/power-steering-backup.json
+    echo "Backed up counter state"
+fi
+```
+
+### Step 2: Upgrade amplihack
+
+```bash
+# Pull latest changes
+git pull origin main
+
+# Or reinstall via uvx
+uvx --from git+https://github.com/rysweet/amplihack amplihack --reinstall
+```
+
+### Step 3: Verify Installation
+
+```bash
+# Check git_utils module exists
+python3 << 'EOF'
+try:
+    from amplihack.tools.amplihack.git_utils import (
+        is_worktree,
+        get_common_git_dir,
+        find_disabled_file
+    )
+    print("✓ git_utils module installed")
+except ImportError as e:
+    print(f"✗ git_utils not found: {e}")
+EOF
+```
+
+### Step 4: Migrate State (Automatic)
+
+The new version automatically handles state migration:
+
+**Before** (pre-worktree):
+
+```
+.git/.claude/runtime/power-steering/
+└── workflow_classification_block_counter.json
+```
+
+**After** (worktree-aware):
+
+```
+$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/
+└── workflow_classification_block_counter.json
+```
+
+In standard repos, these are the same location. No action required.
+
+### Step 5: Migrate .disabled Files
+
+If you had .disabled files in worktrees, move them to shared location:
+
+```bash
+# Check for .disabled files in worktrees
+git worktree list | awk '{print $1}' | while read worktree; do
+    if [ -f "$worktree/.disabled" ]; then
+        echo "Found .disabled in: $worktree"
+        # Move to shared location
+        touch "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+        echo "Migrated to shared location"
+        rm "$worktree/.disabled"
+    fi
+done
+```
+
+### Step 6: Test Worktree Functionality
+
+```bash
+# Create test worktree
+git worktree add /tmp/test-worktree-migration main
+
+# Test counter persistence
+cd /tmp/test-worktree-migration
+python3 << 'EOF'
+from amplihack.tools.amplihack.git_utils import get_common_git_dir
+from pathlib import Path
+import json
+
+common_dir = get_common_git_dir()
+counter_file = Path(common_dir) / ".claude" / "runtime" / "power-steering" / "workflow_classification_block_counter.json"
+
+# Write test counter
+counter_file.parent.mkdir(parents=True, exist_ok=True)
+counter_file.write_text(json.dumps({"count": 3}))
+
+print(f"Counter written to: {counter_file}")
+print(f"Count: {json.loads(counter_file.read_text())['count']}")
+EOF
+
+# Cleanup
+cd -
+git worktree remove /tmp/test-worktree-migration
+```
+
+## Configuration Changes
+
+### No Configuration Required
+
+The upgrade is **backward compatible**. No configuration changes needed.
+
+### Optional: Centralize .disabled File
+
+For worktree users, centralize .disabled file:
+
+```bash
+# Old: .disabled in each worktree (still works)
+# New: .disabled in shared location (recommended)
+
+# Create shared .disabled
+touch "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+
+# Remove individual worktree .disabled files
+git worktree list | awk '{print $1}' | while read worktree; do
+    rm -f "$worktree/.disabled"
+done
+```
+
+## Breaking Changes
+
+### None
+
+This release has **no breaking changes**. All existing functionality works identically.
+
+### Behavior Changes
+
+1. **Counter persists across worktrees** (previously reset)
+2. **.disabled file checked in 3 locations** (previously only CWD and root)
+3. **Hard maximum enforced** (new feature, prevents infinite loops)
+
+## Rollback Plan
+
+If you encounter issues, rollback to previous version:
+
+```bash
+# Restore from backup
+if [ -f /tmp/power-steering-backup.json ]; then
+    cp /tmp/power-steering-backup.json \
+       .git/.claude/runtime/power-steering/workflow_classification_block_counter.json
+fi
+
+# Revert amplihack
+git checkout <previous-version-tag>
+
+# Or reinstall specific version
+uvx --from git+https://github.com/rysweet/amplihack@<version> amplihack
+```
+
+## Verification Checklist
+
+After migration, verify these work:
+
+- [ ] Counter persists in main repo
+- [ ] Counter persists in worktrees
+- [ ] Counter shared across all worktrees
+- [ ] .disabled file works in current directory
+- [ ] .disabled file works in shared location
+- [ ] .disabled file works in project root
+- [ ] Hard maximum triggers after 10 blocks
+- [ ] Error messages are clear
+
+Run this verification script:
+
+```bash
+python3 << 'EOF'
+import subprocess
+from pathlib import Path
+import json
+
+print("=== Power Steering Migration Verification ===\n")
+
+# Test 1: Worktree detection
+from amplihack.tools.amplihack.git_utils import is_worktree, get_common_git_dir
+print(f"✓ Worktree detection: {is_worktree()}")
+print(f"✓ Common dir: {get_common_git_dir()}")
+
+# Test 2: State directory
+state_dir = Path(get_common_git_dir()) / ".claude" / "runtime" / "power-steering"
+state_dir.mkdir(parents=True, exist_ok=True)
+print(f"✓ State directory: {state_dir}")
+
+# Test 3: Counter persistence
+counter_file = state_dir / "workflow_classification_block_counter.json"
+counter_file.write_text(json.dumps({"count": 5}))
+assert json.loads(counter_file.read_text())["count"] == 5
+print(f"✓ Counter persistence works")
+
+# Test 4: .disabled detection
+from amplihack.tools.amplihack.git_utils import find_disabled_file
+test_disabled = state_dir / ".disabled"
+test_disabled.touch()
+assert find_disabled_file() is not None
+test_disabled.unlink()
+print(f"✓ .disabled detection works")
+
+print("\n=== All Tests Passed ===")
+EOF
+```
+
+## Common Migration Issues
+
+### Issue: Module Not Found
+
+**Symptom**: `ImportError: No module named 'amplihack.tools.amplihack.git_utils'`
+
+**Solution**: Reinstall amplihack
+
+```bash
+uvx --from git+https://github.com/rysweet/amplihack amplihack --reinstall
+```
+
+### Issue: Counter Not Migrating
+
+**Symptom**: Counter reset to 0 after upgrade
+
+**Solution**: Manually migrate counter
+
+```bash
+# Copy old counter to new location
+OLD_COUNTER=".git/.claude/runtime/power-steering/workflow_classification_block_counter.json"
+NEW_COUNTER="$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/workflow_classification_block_counter.json"
+
+if [ -f "$OLD_COUNTER" ] && [ "$OLD_COUNTER" != "$NEW_COUNTER" ]; then
+    mkdir -p "$(dirname "$NEW_COUNTER")"
+    cp "$OLD_COUNTER" "$NEW_COUNTER"
+    echo "Counter migrated"
+fi
+```
+
+### Issue: .disabled File Not Working
+
+**Symptom**: Created .disabled but Power Steering still blocks
+
+**Solution**: Check file location
+
+```bash
+# Verify .disabled file location
+python3 << 'EOF'
+from amplihack.tools.amplihack.git_utils import find_disabled_file
+result = find_disabled_file()
+if result:
+    print(f"Found: {result}")
+else:
+    print("Not found. Create in one of:")
+    print("  1. ./.disabled")
+    print("  2. $(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled")
+    print("  3. $(git rev-parse --show-toplevel)/.disabled")
+EOF
+```
+
+## Getting Help
+
+If you encounter migration issues:
+
+1. **Run diagnostic**: See [Troubleshooting Guide](../../howto/power-steering-worktree-troubleshooting.md)
+2. **Check logs**: `~/.claude/runtime/logs/power-steering-*.log`
+3. **File issue**: [GitHub Issues](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues)
+
+Include this diagnostic output:
+
+```bash
+# Generate diagnostic report
+python3 << 'EOF'
+import subprocess
+from amplihack.tools.amplihack.git_utils import is_worktree, get_common_git_dir, find_disabled_file
+
+print("=== Migration Diagnostic ===")
+print(f"amplihack version: {subprocess.check_output(['amplihack', '--version'], text=True).strip()}")
+print(f"Is worktree: {is_worktree()}")
+print(f"Common dir: {get_common_git_dir()}")
+print(f"Disabled file: {find_disabled_file()}")
+print("=== End Diagnostic ===")
+EOF
+```
+
+## Related Documentation
+
+- [Power Steering Worktree Support](./worktree-support.md) - Feature overview
+- [How to Troubleshoot Worktrees](../../howto/power-steering-worktree-troubleshooting.md) - Fix common issues
+- [Git Utils API Reference](../../reference/git-utils-api.md) - Technical documentation
+- [Power Steering Configuration](./configuration.md) - Configuration options

--- a/docs/features/power-steering/troubleshooting.md
+++ b/docs/features/power-steering/troubleshooting.md
@@ -1,0 +1,234 @@
+# Power Steering Troubleshooting
+
+Ahoy! This guide helps ye fix common power steering issues, particularly the infinite loop bug that was plaguing the system.
+
+## Quick Diagnosis
+
+If power steering seems stuck or repeatin' messages, run the diagnostic command:
+
+```bash
+/amplihack:ps-diagnose
+```
+
+This checks yer power steering state health and shows:
+
+- Current counter values
+- Session ID consistency
+- State file integrity
+- Recent save/load operations
+
+## Common Issues
+
+### Issue: Counter Not Incrementing (Infinite Loop)
+
+**Symptoms:**
+
+- Same guidance message appears repeatedly
+- Power steering never stops after first display
+- State counter stays at 0 or doesn't increment
+
+**Cause:**
+State persistence failures due to cloud sync conflicts, atomic write issues, or file system problems.
+
+**Solution (Fixed in v0.9.1+):**
+
+The fix includes:
+
+1. **Atomic writes with fsync**: Forces disk writes to complete
+2. **Retry logic**: Handles cloud sync delays automatically
+3. **Verification reads**: Confirms state was saved correctly
+4. **Defensive validation**: Catches corrupted state data
+
+**Check your version:**
+
+```bash
+amplihack --version
+```
+
+If ye're on v0.9.0 or earlier, upgrade:
+
+```bash
+cargo install amplihack-rs
+# or
+cargo install --force amplihack-rs
+```
+
+### Issue: State File Corruption
+
+**Symptoms:**
+
+- Power steering crashes with validation errors
+- Diagnostic shows "invalid state" warnings
+- Counter resets unexpectedly
+
+**Diagnosis:**
+
+```bash
+# Check diagnostic logs
+cat .claude/runtime/power-steering/*/diagnostic.jsonl | tail -20
+```
+
+Look fer:
+
+- `save_success: false` - Write failures
+- `load_success: false` - Read failures
+- `validation_failed: true` - Corrupted data
+
+**Solution:**
+
+The fix automatically handles corrupted state:
+
+1. Detects invalid counter values (negative or null)
+2. Logs corruption event to diagnostics
+3. Resets to safe default state
+4. Continues operation without crashing
+
+**Manual reset (if needed):**
+
+```bash
+# Remove corrupted state files
+rm .claude/runtime/power-steering/*/state.json
+```
+
+Power steering will create fresh state on next run.
+
+### Issue: Messages Not Customized
+
+**Symptoms:**
+
+- Generic messages appear instead of context-specific guidance
+- Check results not reflected in guidance text
+- All messages look identical
+
+**Cause (Pre-v0.9.1):**
+Message customization logic wasn't properly integrated with check results.
+
+**Solution (Fixed):**
+
+The fix ensures:
+
+1. Check results are captured accurately
+2. Messages are customized based on actual check outcomes
+3. Context-specific guidance appears at the right time
+
+**Verify the fix:**
+Trigger power steering in different contexts and observe message variations based on:
+
+- File modification status
+- Workflow compliance
+- Quality check results
+
+## Diagnostic Logs
+
+### Understanding Diagnostic Output
+
+Diagnostic logs be written to `~/.amplihack/.claude/runtime/power-steering/{session_id}/diagnostic.jsonl` with this structure:
+
+```json
+{
+  "timestamp": "2025-12-17T19:30:00Z",
+  "operation": "state_save",
+  "counter_before": 0,
+  "counter_after": 1,
+  "session_id": "20251217_193000",
+  "file_path": ".claude/runtime/power-steering/20251217_193000/state.json",
+  "save_success": true,
+  "verification_success": true,
+  "retry_count": 0
+}
+```
+
+**Key fields:**
+
+- `operation`: What happened (state_save, state_load, validation)
+- `counter_before/after`: Track counter changes
+- `save_success`: Whether write completed
+- `verification_success`: Whether verification read worked
+- `retry_count`: How many retries were needed
+
+### Common Log Patterns
+
+**Healthy operation:**
+
+```json
+{"operation": "state_save", "save_success": true, "verification_success": true, "retry_count": 0}
+{"operation": "state_load", "load_success": true, "validation_passed": true}
+```
+
+**Cloud sync retry (normal):**
+
+```json
+{ "operation": "state_save", "save_success": true, "retry_count": 2 }
+```
+
+**Corruption detected:**
+
+```json
+{"operation": "state_load", "load_success": true, "validation_failed": true, "reason": "negative_counter"}
+{"operation": "state_reset", "counter_reset_to": 0}
+```
+
+## Manual Recovery
+
+If automatic recovery doesn't work:
+
+### Step 1: Stop Claude Code
+
+Exit yer current session to prevent concurrent writes.
+
+### Step 2: Clear State
+
+```bash
+rm -rf .claude/runtime/power-steering/
+```
+
+### Step 3: Restart
+
+Start a fresh Claude Code session. Power steering will initialize cleanly.
+
+### Step 4: Verify
+
+```bash
+/amplihack:ps-diagnose
+```
+
+Should show fresh state with counter at 0.
+
+## Prevention
+
+The fix includes prevention measures, but ye can help:
+
+1. **Avoid concurrent sessions**: Don't run multiple Claude Code instances in the same repo
+2. **Wait fer cloud sync**: If usin' Dropbox/iCloud, let files sync before starting
+3. **Keep updated**: Always run latest amplihack version
+4. **Check diagnostics periodically**: Run `/amplihack:ps-diagnose` to catch issues early
+
+## Getting Help
+
+If issues persist after these steps:
+
+1. Capture diagnostic output:
+
+   ```bash
+   /amplihack:ps-diagnose > ps-diagnostic.txt
+   ```
+
+2. Gather logs:
+
+   ```bash
+   tar -czf ps-logs.tar.gz .claude/runtime/power-steering/
+   ```
+
+3. Create a GitHub issue with:
+   - amplihack version (`amplihack --version`)
+   - Diagnostic output
+   - Compressed logs
+   - Description of the problem
+
+Repository: https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues
+
+## Related Documentation
+
+- [Power Steering Overview](./README.md) - What power steering does
+- [Architecture](./architecture-refactor.md) - How the system works
+- [Configuration](./configuration.md) - Customization options

--- a/docs/features/power-steering/worktree-support.md
+++ b/docs/features/power-steering/worktree-support.md
@@ -1,0 +1,223 @@
+# Power Steering Worktree Support
+
+Power Steering now works seamlessly across git worktrees, providing consistent workflow validation and counter persistence regardless of where you work in your repository structure.
+
+## What Changed
+
+Previously, Power Steering had issues when working in git worktrees:
+
+- `.disabled` file detection failed (only checked current directory)
+- Block counters reset on every invocation (no shared state)
+- No hard maximum enforcement (potential infinite loops)
+- Confusing error messages
+
+These issues are now resolved. Power Steering works identically in worktrees and standard repositories.
+
+## Quick Start
+
+### Using Power Steering in Worktrees
+
+Power Steering automatically detects worktree environments and uses shared state directories. No configuration changes required.
+
+```bash
+# Create a worktree
+git worktree add ../feature-branch feature-branch
+
+# Work in the worktree
+cd ../feature-branch
+
+# Power Steering works normally
+# - Block counter persists across invocations
+# - .disabled file detection works from any location
+# - Hard maximum prevents infinite loops
+```
+
+### Disabling Power Steering
+
+Create a `.disabled` file in any of these locations (checked in order):
+
+1. **Current working directory**: `touch .disabled`
+2. **Shared Git directory**: `touch $(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled`
+3. **Project root**: `cd $(git rev-parse --show-toplevel) && touch .disabled`
+
+Power Steering checks all three locations automatically.
+
+```bash
+# Example: Disable from worktree
+cd /path/to/worktree
+touch .disabled
+
+# Or disable globally for all worktrees
+touch "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+```
+
+## Features
+
+### Worktree Detection
+
+Power Steering automatically detects git worktrees using `git rev-parse --git-common-dir`:
+
+```python
+from amplihack.tools.amplihack.git_utils import (
+    get_common_git_dir,
+    is_worktree
+)
+
+# Check if current directory is a worktree
+if is_worktree():
+    print("Working in a worktree")
+
+# Get shared Git directory
+common_dir = get_common_git_dir()
+# Returns: /path/to/main/repo/.git
+```
+
+### Shared State Persistence
+
+Counter state persists across all worktrees using a shared runtime directory:
+
+- **State location**: `$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/`
+- **Counter file**: `workflow_classification_block_counter.json`
+- **Shared across**: All worktrees and main repository
+
+```json
+{
+  "count": 3,
+  "last_updated": "2026-02-25T10:30:45Z",
+  "hard_maximum": 10
+}
+```
+
+### Hard Maximum Enforcement
+
+After 10 consecutive blocks, Power Steering automatically approves to prevent infinite loops:
+
+```
+POWER STEERING: Classification blocked 10 times (hard maximum reached)
+Automatically approving to prevent infinite loop.
+
+CRITICAL: This indicates a systematic problem.
+File an issue: https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues
+```
+
+### Multi-Path .disabled Check
+
+Power Steering checks three locations for the `.disabled` file:
+
+1. Current working directory (most convenient)
+2. Shared Git directory (affects all worktrees)
+3. Project root (backward compatible)
+
+```python
+# Example: Multi-path check
+from amplihack.tools.amplihack.git_utils import find_disabled_file
+
+disabled_file = find_disabled_file()
+if disabled_file:
+    print(f"Power Steering disabled via: {disabled_file}")
+```
+
+## Common Workflows
+
+### Working Across Multiple Worktrees
+
+```bash
+# Main branch
+cd /path/to/main-repo
+# Counter: 0
+
+# Create feature worktree
+git worktree add ../feature-a feature-a
+cd ../feature-a
+# Counter: 0 (shared state)
+
+# Block classification
+# Counter: 1 (persisted to shared location)
+
+# Switch to different worktree
+git worktree add ../feature-b feature-b
+cd ../feature-b
+# Counter: 1 (reads shared state)
+
+# Block again
+# Counter: 2 (updates shared state)
+```
+
+### Disabling Globally vs Locally
+
+```bash
+# Disable for current worktree only
+touch .disabled
+
+# Disable for all worktrees (main repo + all worktrees)
+touch "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+
+# Remove global disable
+rm "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/.disabled"
+```
+
+## Backward Compatibility
+
+Power Steering remains fully compatible with non-worktree repositories:
+
+- Standard repos use `.git/` directory normally
+- `.disabled` file still works in project root
+- Counter persistence works identically
+- No configuration changes required
+
+## Troubleshooting
+
+### Counter Not Persisting
+
+**Problem**: Block counter resets on every invocation
+
+**Solution**: Check shared state directory exists
+
+```bash
+# Verify shared directory
+echo "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/"
+
+# Create if missing
+mkdir -p "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/"
+```
+
+### .disabled File Not Detected
+
+**Problem**: Power Steering still blocks despite `.disabled` file
+
+**Solution**: Check file location
+
+```bash
+# Show all checked locations
+python3 << 'EOF'
+from amplihack.tools.amplihack.git_utils import find_disabled_file
+result = find_disabled_file()
+if result:
+    print(f"Found: {result}")
+else:
+    print("Not found in any checked location")
+EOF
+```
+
+### Hard Maximum Triggered
+
+**Problem**: Hit 10-block limit and auto-approved
+
+**Action**: This indicates a bug. File an issue with:
+
+1. Session logs showing repeated blocks
+2. Classification attempts and reasons
+3. Worktree configuration details
+
+**Temporary workaround**: Reset counter manually
+
+```bash
+rm "$(git rev-parse --git-common-dir)/.claude/runtime/power-steering/workflow_classification_block_counter.json"
+```
+
+## Related Documentation
+
+- [Power Steering Overview](./README.md) - Core concepts and philosophy
+- [Configuration Guide](./configuration.md) - Complete configuration options
+- [Troubleshooting Guide](./troubleshooting.md) - Fix common issues
+- [Migration Guide v0.9.1](./migration-v0.9.1.md) - Upgrade from earlier versions

--- a/docs/howto/power-steering-merge-preferences.md
+++ b/docs/howto/power-steering-merge-preferences.md
@@ -1,0 +1,273 @@
+# How to Configure Power-Steering PR Merge Preferences
+
+> [Home](../index.md) > [How-To Guides](./first-install.md) > Power-Steering Merge Preferences
+
+This guide explains how to configure Power-Steering to respect your PR merge approval preferences.
+
+## Quick Start
+
+If you want Power-Steering to stop at "PR ready + CI passing" without pressuring you to merge, add this to your `USER_PREFERENCES.md`:
+
+```markdown
+**NEVER Merge PRs or Commit Directly Without Explicit Permission**
+
+NEVER merge PRs or commit directly to main without explicit user permission.
+Always create PRs and wait for approval.
+```
+
+Power-Steering automatically detects this preference and treats "awaiting user approval" as a valid completion state.
+
+---
+
+## What This Feature Does
+
+Power-Steering's default behavior checks that PRs are merged as part of session completion. This can create pressure to auto-merge PRs even when you want manual approval.
+
+**With preference awareness enabled**, Power-Steering:
+
+- ✅ Recognizes "PR ready + CI passing + awaiting approval" as complete
+- ✅ Stops pressuring agents to auto-merge
+- ✅ Respects your workflow control preferences
+- ✅ Still validates all other completion criteria
+
+---
+
+## Configuration
+
+### Step 1: Check Your USER_PREFERENCES.md
+
+Power-Steering reads `.claude/context/USER_PREFERENCES.md` during each CI status check (lazy detection).
+
+Locate the merge permission section (typically around lines 214-227):
+
+```bash
+# View your preferences
+cat .claude/context/USER_PREFERENCES.md | grep -A 15 "NEVER Merge"
+```
+
+### Step 2: Verify Preference Format
+
+The preference must include specific keywords for detection:
+
+**Required keywords** (case-insensitive):
+
+- "NEVER" or "NEVER Merge"
+- "Without Permission" or "Without Explicit Permission"
+- "PR" or "Pull Request"
+
+**Example valid formats**:
+
+```markdown
+**NEVER Merge PRs Without Permission**
+
+**NEVER Merge PRs or Commit Directly Without Explicit Permission**
+
+**NEVER merge pull requests without explicit user permission**
+```
+
+All of these activate the preference awareness feature.
+
+### Step 3: Test the Configuration
+
+Create a test session to verify the behavior:
+
+```bash
+# Start a simple feature workflow
+amplihack claude
+
+# In the Claude session:
+# 1. Create a simple PR with passing CI
+# 2. Wait for Power-Steering to validate completion
+# 3. Verify it shows "PR ready + awaiting approval" as satisfied
+```
+
+**Expected output**:
+
+```
+✅ CI Status: PR is ready for review (checks passing, awaiting user approval)
+```
+
+---
+
+## How It Works
+
+### Detection Logic
+
+Power-Steering uses regex pattern matching to detect the preference:
+
+```python
+# Simplified detection logic
+pattern = r'NEVER.*(?:Merge|merge).*(?:PR|Pull Request).*(?:Without|without).*(?:Permission|permission)'
+
+if re.search(pattern, user_preferences_content, re.IGNORECASE | re.DOTALL):
+    # Preference detected - use no-auto-merge mode
+    return True
+```
+
+### Validation Behavior
+
+**With preference detected**:
+
+1. Reads PR status from git/gh CLI
+2. Checks if PR exists and is ready for review
+3. Validates CI checks are passing
+4. Returns ✅ satisfied without checking merge status
+
+**Without preference** (default):
+
+1. Performs standard CI status check
+2. Requires PR to be merged for completion
+3. Traditional Power-Steering behavior
+
+### Fail-Open Design
+
+If errors occur during preference detection, Power-Steering falls back to standard behavior:
+
+- File read errors → default behavior
+- Regex match errors → default behavior
+- PR status check errors → reports as unsatisfied
+
+This ensures robustness - errors never falsely mark sessions as complete.
+
+---
+
+## Use Cases
+
+### Use Case 1: Manual Code Review
+
+**Scenario**: You require manual review of all PRs before merge.
+
+**Solution**:
+
+```markdown
+**NEVER Merge PRs Without Explicit Permission**
+```
+
+**Result**: Power-Steering treats "PR ready + CI passing" as the goal state.
+
+### Use Case 2: Compliance Requirements
+
+**Scenario**: Company policy requires human approval for all merges.
+
+**Solution**: Same preference as Use Case 1.
+
+**Result**: Power-Steering aligns with compliance workflow.
+
+### Use Case 3: High-Stakes Changes
+
+**Scenario**: Working on critical infrastructure - want extra caution.
+
+**Solution**: Enable preference before starting work.
+
+**Result**: Power-Steering stops at "ready for review" for every PR in the session.
+
+---
+
+## Troubleshooting
+
+### Preference Not Detected
+
+**Problem**: Power-Steering still pressures to merge despite preference set.
+
+**Solutions**:
+
+1. **Check keyword format**:
+
+   ```bash
+   grep -i "never.*merge.*without.*permission" .claude/context/USER_PREFERENCES.md
+   ```
+
+   If no match, adjust wording to include required keywords.
+
+2. **Check file location**:
+
+   ```bash
+   ls -la .claude/context/USER_PREFERENCES.md
+   ```
+
+   File must exist at this path.
+
+3. **Changes take effect immediately**: Preference changes are detected on the next CI check—no restart needed.
+
+### False Positives
+
+**Problem**: Unrelated text triggers preference detection.
+
+**Solution**: The regex pattern is specific - requires all keywords. However, if false positives occur, ensure USER_PREFERENCES.md clearly separates sections with headings.
+
+### CI Status Check Fails
+
+**Problem**: Power-Steering reports CI status as unsatisfied even though checks passed.
+
+**Possible causes**:
+
+1. **PR not pushed**: Ensure `git push` completed successfully
+2. **CI still running**: Wait for checks to complete
+3. **gh CLI not authenticated**: Run `gh auth status`
+
+**Debug command**:
+
+```bash
+# Check PR status manually
+gh pr view --json statusCheckRollup,mergeable,state
+```
+
+---
+
+## Configuration Examples
+
+### Basic Setup
+
+**File**: `.claude/context/USER_PREFERENCES.md`
+
+```markdown
+### 2026-01-23 10:00:00
+
+**NEVER Merge PRs Without Explicit Permission**
+
+NEVER merge PRs or commit directly to main without explicit user permission.
+Always create PRs and wait for approval.
+```
+
+### With Additional Context
+
+```markdown
+### 2026-01-23 10:00:00
+
+**NEVER Merge PRs or Commit Directly Without Explicit Permission**
+
+NEVER merge PRs or commit directly to main without explicit user permission.
+Always create PRs and wait for approval. Only the first explicitly approved
+merge applies - subsequent PRs require separate approval.
+
+**Implementation Requirements:**
+
+- MUST create PR and wait for user to say "merge" or "please merge"
+- MUST ask for permission for EACH PR merge separately
+- MUST NOT assume "fix it all" means "merge everything automatically"
+```
+
+Both examples activate the preference awareness feature.
+
+---
+
+## Related Documentation
+
+- [Power-Steering Overview](../features/power-steering/README.md) - What is Power-Steering
+- [Power-Steering Configuration](../features/power-steering/configuration.md) - General configuration
+- [USER_PREFERENCES.md Guide](../reference/profile-management.md) - Complete preferences reference
+- [Power-Steering Technical Reference](../reference/power-steering-merge-preferences.md) - Developer documentation
+
+---
+
+## Next Steps
+
+After configuring merge preferences:
+
+1. **Test the workflow**: Create a test PR to verify behavior
+2. **Customize other preferences**: See [Power-Steering Configuration](../features/power-steering/configuration.md)
+3. **Review workflow compliance**: Check [DEFAULT_WORKFLOW.md](../concepts/default-workflow.md)
+
+---
+
+**Need help?** Check [Power-Steering Troubleshooting](../features/power-steering/troubleshooting.md) or [Discoveries](../concepts/patterns.md) for common issues.

--- a/docs/reference/power-steering-checker-api.md
+++ b/docs/reference/power-steering-checker-api.md
@@ -1,0 +1,384 @@
+# Power-Steering Checker — API Reference
+
+> [Home](../index.md) > [Reference](./power-steering-checker-api.md) > Power-Steering Checker API
+
+Complete API reference for the `power_steering_checker` package.
+
+---
+
+## Package Overview
+
+`power_steering_checker` is a Python package at:
+
+```
+.claude/tools/amplihack/hooks/power_steering_checker/
+```
+
+**Recent Refactoring (v0.10.0, 2026-03-07)**: Split from a monolithic 5,063-line `power_steering_checker.py` into 12 focused modules (largest: 1,217 lines). The refactoring includes:
+
+- Modular architecture with clear separation of concerns
+- Copilot CLI transcript support (auto-detects both Claude Code and GitHub Copilot CLI formats)
+- CLAUDECODE environment variable properly unset to prevent nested session errors
+- 191 tests passing (121 existing + 48 parser + 22 Copilot e2e)
+- Full backward compatibility via re-exporting `__init__.py`
+
+See the architecture refactor guide for module details.
+
+---
+
+## Public API (`__init__.py`)
+
+```python
+from power_steering_checker import (
+    # Main entry points
+    PowerSteeringChecker,
+    check_session,
+    is_disabled,
+
+    # Data classes
+    PowerSteeringResult,
+    CheckerResult,
+    ConsiderationAnalysis,
+    PowerSteeringRedirect,
+
+    # Feature flags (used by tests and integrations)
+    SDK_AVAILABLE,
+    _timeout,
+)
+```
+
+### `check_session(transcript_lines, session_id, project_root=None)`
+
+Module-level convenience wrapper. Creates a `PowerSteeringChecker` and calls `.check()`.
+
+**Parameters**
+
+| Name               | Type           | Description                                                 |
+| ------------------ | -------------- | ----------------------------------------------------------- |
+| `transcript_lines` | `list[str]`    | JSONL lines from the session transcript                     |
+| `session_id`       | `str`          | Session identifier (alphanumeric, `_`, `-`, max 128 chars)  |
+| `project_root`     | `Path \| None` | Project root; auto-detected from `.claude` marker if `None` |
+
+**Returns** `PowerSteeringResult`
+
+**Behavior**
+
+- Returns `decision="approve"` if all blocker considerations pass.
+- Returns `decision="block"` with `continuation_prompt` if any blocker fails.
+- Always returns a result; never raises (fail-open design).
+
+**Example**
+
+```python
+import sys
+from pathlib import Path
+from power_steering_checker import check_session
+
+lines = Path(".claude/runtime/transcript.jsonl").read_text().splitlines()
+result = check_session(lines, session_id="abc123")
+
+if result.decision == "block":
+    sys.stderr.write(result.continuation_prompt + "\n")
+    sys.exit(2)
+```
+
+---
+
+### `is_disabled(project_root=None)`
+
+Returns `True` if power-steering is currently disabled for the project.
+
+**Parameters**
+
+| Name           | Type           | Description                           |
+| -------------- | -------------- | ------------------------------------- |
+| `project_root` | `Path \| None` | Project root; auto-detected if `None` |
+
+**Returns** `bool`
+
+**Behavior**
+
+- Checks for a `.disabled` semaphore file in the runtime directory.
+- Returns `False` on any error (fail-open).
+- Logs a `WARNING` with stack trace if checker construction fails.
+
+**Example**
+
+```python
+from power_steering_checker import is_disabled
+
+if is_disabled():
+    sys.exit(0)  # Skip check; power-steering is disabled
+```
+
+---
+
+## `PowerSteeringChecker`
+
+Main orchestrator class. Inherits from four mixins:
+
+```
+ConsiderationsMixin   → loads YAML, classifies sessions, runs individual checks
+SdkCallsMixin         → parallel SDK analysis, timeout wrapper
+ProgressTrackingMixin → semaphore files, redirect records, compaction context
+ResultFormattingMixin → text output, continuation prompt generation
+```
+
+### Constructor
+
+```python
+checker = PowerSteeringChecker(project_root: Path | None = None)
+```
+
+Auto-detects `project_root` by walking up from `__file__` until a `.claude` directory is found (max 10 levels). Raises `ValueError` if not found.
+
+### `checker.check(transcript_lines, session_id)`
+
+Run all applicable considerations and return a decision.
+
+**Parameters**
+
+| Name               | Type        | Description                       |
+| ------------------ | ----------- | --------------------------------- |
+| `transcript_lines` | `list[str]` | Session transcript as JSONL lines |
+| `session_id`       | `str`       | Session identifier                |
+
+**Returns** `PowerSteeringResult`
+
+**Behavior**
+
+1. Validates `session_id` format (see Security section).
+2. Checks if already ran this session (idempotent via semaphore).
+3. Classifies session type (SIMPLE / STANDARD / COMPLEX).
+4. Runs all enabled considerations in parallel (up to `PARALLEL_TIMEOUT` seconds).
+5. Formats and returns result.
+
+---
+
+## Data Classes
+
+All data classes are defined in `considerations.py` and re-exported from `__init__.py`.
+
+### `PowerSteeringResult`
+
+Final decision from the checker.
+
+```python
+@dataclass
+class PowerSteeringResult:
+    decision: Literal["approve", "block"]
+    reasons: list[str]
+    continuation_prompt: str | None = None
+    summary: str | None = None
+    analysis: ConsiderationAnalysis | None = None
+    is_first_stop: bool = False
+    evidence_results: list = field(default_factory=list)
+    compaction_context: Any = None
+    considerations: list = field(default_factory=list)
+```
+
+| Field                 | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `decision`            | `"approve"` or `"block"`                                  |
+| `reasons`             | Human-readable reasons for the decision                   |
+| `continuation_prompt` | Injected into the hook output when `decision="block"`     |
+| `summary`             | One-line summary for logging                              |
+| `analysis`            | Full `ConsiderationAnalysis` for detailed inspection      |
+| `is_first_stop`       | `True` if this is the first block in the session          |
+| `evidence_results`    | Concrete evidence from Phase 1 checks                     |
+| `compaction_context`  | Compaction diagnostics (`CompactionContext` if available) |
+| `considerations`      | List of `CheckerResult` objects for visibility            |
+
+---
+
+### `CheckerResult`
+
+Result from a single consideration check.
+
+```python
+@dataclass
+class CheckerResult:
+    consideration_id: str
+    satisfied: bool
+    reason: str
+    severity: Literal["blocker", "warning"]
+    recovery_steps: list[str] = field(default_factory=list)
+    executed: bool = True
+```
+
+| Field              | Description                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| `consideration_id` | ID matching the entry in `considerations.yaml`                     |
+| `satisfied`        | `True` if the consideration was met                                |
+| `reason`           | Human-readable explanation                                         |
+| `severity`         | `"blocker"` blocks the session; `"warning"` is advisory            |
+| `recovery_steps`   | Ordered steps to resolve a failed check                            |
+| `executed`         | `False` if the check was skipped (not applicable for this session) |
+
+**Properties**
+
+```python
+result.id  # Alias for consideration_id (backward compatibility)
+```
+
+---
+
+### `ConsiderationAnalysis`
+
+Aggregate of all check results for a session.
+
+```python
+@dataclass
+class ConsiderationAnalysis:
+    results: dict[str, CheckerResult] = field(default_factory=dict)
+    failed_blockers: list[CheckerResult] = field(default_factory=list)
+    failed_warnings: list[CheckerResult] = field(default_factory=list)
+```
+
+**Properties**
+
+```python
+analysis.has_blockers  # True if any blocker failed
+```
+
+**Methods**
+
+```python
+analysis.add_result(result: CheckerResult) -> None
+# Adds result; automatically appends to failed_blockers or failed_warnings
+
+analysis.group_by_category() -> dict[str, list[CheckerResult]]
+# Groups failed considerations by display category
+```
+
+---
+
+### `PowerSteeringRedirect`
+
+Persistent record of a blocked session written to disk.
+
+```python
+@dataclass
+class PowerSteeringRedirect:
+    redirect_number: int
+    timestamp: str               # ISO 8601
+    failed_considerations: list[str]  # Consideration IDs
+    continuation_prompt: str
+    work_summary: str | None = None
+```
+
+---
+
+## Feature Flags
+
+These module-level booleans reflect whether optional dependencies are available. They are set at import time and do not change during execution.
+
+| Flag                   | Module              | Package Required        | Purpose                             |
+| ---------------------- | ------------------- | ----------------------- | ----------------------------------- |
+| `SDK_AVAILABLE`        | `sdk_calls`         | `claude_power_steering` | Enables SDK-based analysis          |
+| `EVIDENCE_AVAILABLE`   | `sdk_calls`         | `completion_evidence`   | Enables Phase 1 evidence collection |
+| `COMPACTION_AVAILABLE` | `progress_tracking` | `compaction_validator`  | Enables compaction event detection  |
+| `TURN_STATE_AVAILABLE` | `result_formatting` | `power_steering_state`  | Enables turn-aware state tracking   |
+
+```python
+from power_steering_checker import SDK_AVAILABLE
+
+if not SDK_AVAILABLE:
+    # Running in fallback heuristic mode
+    pass
+```
+
+---
+
+## `_timeout` Context Manager
+
+A SIGALRM-based timeout for wrapping external subprocess or SDK calls.
+
+```python
+from power_steering_checker import _timeout
+
+with _timeout(25):
+    result = subprocess.run(["gh", "pr", "view"], ...)
+```
+
+**Parameters**
+
+| Name      | Type  | Description                                      |
+| --------- | ----- | ------------------------------------------------ |
+| `seconds` | `int` | Maximum duration before `TimeoutError` is raised |
+
+**Raises** `TimeoutError` if the block exceeds `seconds`.
+
+**Note**: Uses `signal.SIGALRM` — only works on Unix-like systems. Windows is not supported.
+
+---
+
+## `_write_with_retry(filepath, data, mode, max_retries)`
+
+Retry-aware file writer that handles transient I/O errors from cloud-synced directories (iCloud, OneDrive, Dropbox).
+
+```python
+from power_steering_checker.progress_tracking import _write_with_retry
+
+_write_with_retry(Path("/some/file.json"), data='{"key": "val"}')
+```
+
+**Parameters**
+
+| Name          | Type   | Default | Description                             |
+| ------------- | ------ | ------- | --------------------------------------- |
+| `filepath`    | `Path` | —       | Destination path                        |
+| `data`        | `str`  | —       | Content to write                        |
+| `mode`        | `str`  | `"w"`   | `"w"` (overwrite) or `"a"` (append)     |
+| `max_retries` | `int`  | `3`     | Retry attempts with exponential backoff |
+
+**Raises** `OSError` after all retries exhausted.
+
+**Backoff**: Starts at 0.1s, doubles on each retry (0.1s → 0.2s → 0.4s).
+
+---
+
+## Security
+
+### Session ID Validation
+
+`session_id` is validated against `r'^[a-zA-Z0-9_\-]{1,128}$'` before being interpolated into filesystem paths. Inputs containing path separators (`.`, `/`, `\`) or control characters are rejected with a `WARNING` log and the check is skipped (fail-open).
+
+### Transcript Line Size Limit
+
+Each JSONL line read from the transcript is checked against `MAX_LINE_BYTES` (10 MB). Lines exceeding this limit are skipped with a `WARNING` log. This prevents memory exhaustion from pathological inputs.
+
+### Compaction Event Path Validation
+
+The `saved_transcript_path` field read from compaction events is validated with `isinstance(str)` and a non-empty check before use. Malformed entries are skipped with a `WARNING` log.
+
+### Semaphore File Creation
+
+Semaphore files (`.{session_id}_completed`) are created atomically using `os.open(O_CREAT | O_EXCL | O_WRONLY, 0o600)`. This eliminates the TOCTOU race window that existed with the previous two-step create-then-chmod approach.
+
+### Environment Variable Parsing
+
+All `PSC_*` environment variables are parsed through a `_env_int(name, default)` helper. Non-numeric values log a `WARNING` and fall back to the default, preventing silent hook failure at import time.
+
+---
+
+## Error Handling Policy
+
+| Scenario                           | Log Level                   | Behavior                                |
+| ---------------------------------- | --------------------------- | --------------------------------------- |
+| Unexpected error in `check()`      | `ERROR` + `exc_info=True`   | Fail-open: returns `decision="approve"` |
+| Parallel analysis failure          | `ERROR` + `exc_info=True`   | Fail-open: returns `decision="approve"` |
+| Individual consideration error     | `WARNING` + `exc_info=True` | Skip check; continue with others        |
+| `is_disabled()` construction error | `WARNING` + `exc_info=True` | Returns `False` (assume not disabled)   |
+| OSError on semaphore file          | `WARNING` + `exc_info=True` | Continue without semaphore              |
+| Invalid session ID                 | `WARNING`                   | Skip check; treat as not-already-ran    |
+| Oversized transcript line          | `WARNING`                   | Skip line; continue parsing             |
+
+---
+
+## Related Documentation
+
+- [Configuration Reference](power-steering-checker-configuration.md) — All `PSC_*` environment variables
+- [Architecture Refactor Guide](../features/power-steering/architecture-refactor.md) — Module split rationale
+- [Power-Steering Overview](../features/power-steering/README.md) — Feature overview
+- [Customization Guide](../features/power-steering/customization-guide.md) — considerations.yaml reference

--- a/docs/reference/power-steering-checker-configuration.md
+++ b/docs/reference/power-steering-checker-configuration.md
@@ -1,0 +1,236 @@
+# Power-Steering Checker — Configuration Reference
+
+> [Home](../index.md) > [Reference](../index.md) > Power-Steering Checker Configuration
+
+All runtime constants in the `power_steering_checker` package can be overridden with environment variables. This reference documents every variable, its default, the module that owns it, and the behavior when set to an invalid value.
+
+---
+
+## Quick Reference
+
+| Variable                         | Default | Module              | Description                                   |
+| -------------------------------- | ------- | ------------------- | --------------------------------------------- |
+| `PSC_CHECKER_TIMEOUT`            | `25`    | `sdk_calls`         | Per-consideration timeout (seconds)           |
+| `PSC_PARALLEL_TIMEOUT`           | `60`    | `sdk_calls`         | Total parallel execution budget (seconds)     |
+| `PSC_MAX_TRANSCRIPT_LINES`       | `50000` | `main_checker`      | Transcript size cap (lines)                   |
+| `PSC_MAX_ASK_USER_QUESTIONS`     | `3`     | `main_checker`      | AskUserQuestion call limit                    |
+| `PSC_MIN_TESTS_PASSED_THRESHOLD` | `10`    | `main_checker`      | Minimum passing tests                         |
+| `PSC_MAX_CONSECUTIVE_BLOCKS`     | `10`    | `result_formatting` | Consecutive block limit (turn-state fallback) |
+
+All variables are **optional**. Omitting them uses the default shown above.
+
+---
+
+## Timeout Variables
+
+### `PSC_CHECKER_TIMEOUT`
+
+**Default**: `25`
+**Module**: `sdk_calls.py` as `CHECKER_TIMEOUT`
+**Units**: seconds
+
+Per-consideration timeout. Each individual checker (e.g., `_check_ci_status`, `_check_todos_complete`) is allowed at most this many seconds to complete. If it exceeds the limit, a `TimeoutError` is raised and the check is treated as not-satisfied.
+
+**Timeout hierarchy**:
+
+```
+HOOK_TIMEOUT (120s)        ← hard limit imposed by Claude Code framework
+  └── PARALLEL_TIMEOUT (60s)  ← PSC_PARALLEL_TIMEOUT — total budget for all checks
+        └── CHECKER_TIMEOUT (25s) ← PSC_CHECKER_TIMEOUT — per-check budget
+```
+
+**Tuning guidelines**:
+
+| Situation                          | Recommended value |
+| ---------------------------------- | ----------------- |
+| Slow network (gh CLI latency > 5s) | `40`              |
+| CI environment with fast network   | `15`              |
+| Debug / local development          | `60`              |
+
+**Example**:
+
+```bash
+export PSC_CHECKER_TIMEOUT=40
+```
+
+---
+
+### `PSC_PARALLEL_TIMEOUT`
+
+**Default**: `60`
+**Module**: `sdk_calls.py` as `PARALLEL_TIMEOUT`
+**Units**: seconds
+
+Total execution budget for the parallel analysis phase. All 21 checks run concurrently; this timeout bounds the entire batch.
+
+Normal execution runs in 15–20 seconds. The 60-second default provides a buffer for slow network conditions while remaining safely under the 120-second hook timeout.
+
+**Constraint**: Must be less than the Claude Code hook timeout (120s).
+
+**Example**:
+
+```bash
+export PSC_PARALLEL_TIMEOUT=45
+```
+
+---
+
+## Transcript Variables
+
+### `PSC_MAX_TRANSCRIPT_LINES`
+
+**Default**: `50000`
+**Module**: `main_checker.py` as `MAX_TRANSCRIPT_LINES`
+**Units**: lines
+
+Maximum number of lines read from the session transcript. Lines beyond this limit are silently dropped. This prevents memory exhaustion when a very long session transcript is passed to the checker.
+
+**Security note**: In addition to this line count limit, each individual line is checked against a 10 MB per-line size limit (`MAX_LINE_BYTES` in `progress_tracking.py`). Both guards must be satisfied.
+
+**Example**:
+
+```bash
+# Reduce for memory-constrained environments
+export PSC_MAX_TRANSCRIPT_LINES=20000
+
+# Increase for very long sessions (ensure adequate RAM)
+export PSC_MAX_TRANSCRIPT_LINES=100000
+```
+
+---
+
+## Quality Threshold Variables
+
+### `PSC_MAX_ASK_USER_QUESTIONS`
+
+**Default**: `3`
+**Module**: `main_checker.py` as `MAX_ASK_USER_QUESTIONS`
+**Units**: count
+
+Maximum number of `AskUserQuestion` tool invocations before the checker flags the session as over-questioning. Sessions that repeatedly ask the user instead of executing are blocked.
+
+**Example**:
+
+```bash
+# Allow more questions in exploratory sessions
+export PSC_MAX_ASK_USER_QUESTIONS=5
+```
+
+---
+
+### `PSC_MIN_TESTS_PASSED_THRESHOLD`
+
+**Default**: `10`
+**Module**: `main_checker.py` as `MIN_TESTS_PASSED_THRESHOLD`
+**Units**: count
+
+Minimum number of test cases that must pass for the local testing check to be considered satisfied. Exists to distinguish meaningful test runs from trivial smoke tests.
+
+**Example**:
+
+```bash
+# Lower for projects with small test suites
+export PSC_MIN_TESTS_PASSED_THRESHOLD=3
+
+# Raise for large projects to ensure thorough test coverage
+export PSC_MIN_TESTS_PASSED_THRESHOLD=25
+```
+
+---
+
+### `PSC_MAX_CONSECUTIVE_BLOCKS`
+
+**Default**: `10`
+**Module**: `result_formatting.py` as `DEFAULT_MAX_CONSECUTIVE_BLOCKS`
+**Units**: count
+
+Fallback maximum consecutive block count used when `power_steering_state` is unavailable (`TURN_STATE_AVAILABLE=False`). When turn-state tracking is available, this constant is not used — the actual turn state value takes precedence.
+
+**Example**:
+
+```bash
+export PSC_MAX_CONSECUTIVE_BLOCKS=5
+```
+
+---
+
+## Invalid Value Behavior
+
+All `PSC_*` variables are parsed through the `_env_int(name, default)` helper. If a variable is set to a non-numeric string, the helper:
+
+1. Logs a `WARNING` with the variable name and the invalid value.
+2. Returns the default value.
+3. Continues — the hook is not disabled.
+
+**Example**:
+
+```bash
+export PSC_CHECKER_TIMEOUT=fast  # Non-numeric
+
+# Results in:
+# WARNING: PSC_CHECKER_TIMEOUT='fast' is not a valid integer; using default 25
+```
+
+This design ensures that a misconfigured environment variable never silently disables power-steering.
+
+---
+
+## Setting Variables
+
+### Per-Project (`.env` file)
+
+Not directly supported; use a shell wrapper or configure in your hook invocation.
+
+### In `settings.json` hook command
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PSC_CHECKER_TIMEOUT=40 PSC_PARALLEL_TIMEOUT=90 python .claude/tools/amplihack/hooks/stop_power_steering.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### In shell profile
+
+```bash
+# ~/.bashrc or ~/.zshrc
+export PSC_CHECKER_TIMEOUT=30
+export PSC_MAX_TRANSCRIPT_LINES=30000
+```
+
+### Per-Run (inline)
+
+```bash
+PSC_CHECKER_TIMEOUT=40 amplihack claude
+```
+
+---
+
+## Defaults Rationale
+
+| Variable                            | Default                                                                                                                         | Rationale |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `PSC_CHECKER_TIMEOUT=25`            | Per-check budget that exceeds `gh` CLI network latency (100–500ms) by a wide margin while leaving room for the parallel budget. |
+| `PSC_PARALLEL_TIMEOUT=60`           | Roughly 3× median execution time (15–20s), providing a buffer for slow checks without approaching the 120s hook limit.          |
+| `PSC_MAX_TRANSCRIPT_LINES=50000`    | Covers sessions up to ~50 hours of activity. At ~1 line/second average, 50k lines ≈ 14 hours.                                   |
+| `PSC_MAX_ASK_USER_QUESTIONS=3`      | Based on amplihack usage data: sessions asking more than 3 questions before executing tend to be stalling.                      |
+| `PSC_MIN_TESTS_PASSED_THRESHOLD=10` | Empirically derived: test suites with fewer than 10 passing tests rarely provide meaningful coverage evidence.                  |
+| `PSC_MAX_CONSECUTIVE_BLOCKS=10`     | Fallback only — the real threshold comes from `TurnStateManager` when available.                                                |
+
+---
+
+## Related Documentation
+
+- [API Reference](power-steering-checker-api.md) — Full package API
+- [Architecture Refactor Guide](../features/power-steering/architecture-refactor.md) — Module split and constant placement
+- [Troubleshooting](../features/power-steering/troubleshooting.md) — Common configuration issues

--- a/docs/reference/power-steering-file-locking.md
+++ b/docs/reference/power-steering-file-locking.md
@@ -1,0 +1,262 @@
+# Power Steering File Locking
+
+Technical reference for the file locking implementation that prevents race conditions in power-steering counter increments.
+
+## Problem Solved
+
+**Race Condition in Counter Increment**: Multiple concurrent stop hook invocations could read the same counter value, increment it independently, and write conflicting values. This caused the counter to reset unexpectedly (e.g., 5 → 0 instead of 5 → 6), triggering infinite power-steering loops.
+
+**Root Cause**: Lack of synchronization between read-modify-write operations on shared state file.
+
+## Solution Overview
+
+File locking using `fcntl.flock()` ensures atomic read-modify-write operations. Only one process can hold the lock at a time, preventing concurrent modifications.
+
+## Implementation
+
+### File Locking Protocol
+
+```python
+# [IMPLEMENTED] - Actual implementation
+import fcntl
+from contextlib import contextmanager
+
+@contextmanager
+def _acquire_file_lock(file_handle, timeout_seconds=2.0):
+    """Acquire exclusive lock with timeout."""
+    start_time = time.time()
+    lock_acquired = False
+
+    try:
+        while True:
+            try:
+                fcntl.flock(file_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                lock_acquired = True
+                break
+            except BlockingIOError:
+                if time.time() - start_time >= timeout_seconds:
+                    break  # Timeout - proceed without lock (fail-open)
+                time.sleep(0.05)  # Retry after 50ms
+
+        yield lock_acquired
+    finally:
+        if lock_acquired:
+            fcntl.flock(file_handle.fileno(), fcntl.LOCK_UN)
+
+# Usage with persistent lock file
+lock_file = state_file.parent / ".turn_state.lock"
+with open(lock_file, "a+") as lock_f:
+    with _acquire_file_lock(lock_f) as locked:
+        # Critical section: read-modify-write
+        state = load_state()
+        state.turn_count += 1
+        save_state(state, _skip_locking=True)
+```
+
+**Lock Type**: Exclusive (`LOCK_EX`) - Only one process can hold the lock.
+
+**Non-Blocking**: `LOCK_NB` flag attempts lock without waiting. If lock unavailable, raises `BlockingIOError`.
+
+**Timeout**: 2-second timeout prevents indefinite hangs. After timeout, operation fails open.
+
+**Automatic Release**: Lock released when file handle closes (via context manager).
+
+## Platform Support
+
+### Linux and macOS
+
+Full support via `fcntl.flock()`. Advisory locks work across all processes accessing the same file.
+
+### Windows
+
+Graceful degradation. Windows lacks `fcntl` module. Implementation uses try/except to detect platform:
+
+```python
+# [IMPLEMENTED] - Platform detection pattern
+try:
+    import fcntl
+    LOCKING_AVAILABLE = True
+except ImportError:
+    LOCKING_AVAILABLE = False
+    # Fall back to fail-open behavior
+
+# In TurnStateManager.__init__():
+if not LOCKING_AVAILABLE:
+    self.log("File locking unavailable (Windows) - operating in degraded mode")
+```
+
+On Windows, locking is skipped but operations continue. Race conditions remain possible but rare in practice.
+
+## Error Handling
+
+### Fail-Open Design
+
+All locking errors are non-fatal. System continues operation without locking rather than blocking users.
+
+**Lock Acquisition Timeout** (2s):
+
+- Log warning
+- Proceed without lock
+- State may be inconsistent but user not blocked
+
+**Lock Not Available** (`BlockingIOError`):
+
+- Another process holds lock
+- Wait briefly and retry
+- After max retries, proceed without lock
+
+**Platform Unsupported** (Windows):
+
+- Skip locking entirely
+- Proceed with atomic write (temp file + rename)
+- Log info message about degraded mode
+
+**File Permissions** (`PermissionError`):
+
+- Log error
+- Fall back to best-effort write
+- Don't block stop hook
+
+### Logging
+
+All lock operations logged to `.claude/runtime/power-steering/{session_id}/file_locking.log`:
+
+```jsonl
+{"event": "lock_acquired", "timestamp": "2026-01-27T10:30:45", "duration_ms": 15}
+{"event": "lock_timeout", "timestamp": "2026-01-27T10:30:47", "timeout_ms": 2000}
+{"event": "lock_unavailable", "timestamp": "2026-01-27T10:30:48", "retry": 1}
+```
+
+## Usage
+
+### Automatic Operation
+
+File locking operates transparently during counter increments. No user action required.
+
+```python
+# User perspective: Works the same with or without locking
+manager = TurnStateManager(project_root, session_id)
+state = manager.load_state()
+state = manager.increment_turn(state)
+manager.save_state(state)  # Locking happens here automatically
+```
+
+### Testing Lock Behavior
+
+Verify locking works correctly:
+
+```bash
+# Simulate concurrent writes
+python -c "
+from .claude.tools.amplihack.hooks.power_steering_state import TurnStateManager
+from pathlib import Path
+import threading
+
+def increment_counter(n):
+    manager = TurnStateManager(Path('.'), 'test_session')
+    for i in range(10):
+        state = manager.load_state()
+        state = manager.increment_turn(state)
+        manager.save_state(state)
+
+threads = [threading.Thread(target=increment_counter, args=(i,)) for i in range(5)]
+for t in threads: t.start()
+for t in threads: t.join()
+
+# Verify final count is 50 (5 threads × 10 increments)
+final = manager.load_state()
+assert final.turn_count == 50
+"
+```
+
+## Performance
+
+**Lock Overhead**: ~1-5ms per operation (negligible for stop hook).
+
+**Timeout Impact**: Only occurs under heavy concurrent load (rare in normal usage).
+
+**Windows Degradation**: No performance impact. Falls back to existing atomic write.
+
+## Debugging
+
+### Check Lock Status
+
+```bash
+# View lock log
+cat .claude/runtime/power-steering/*/file_locking.log | jq .
+
+# Monitor locks in real-time
+tail -f .claude/runtime/power-steering/*/file_locking.log
+```
+
+### Common Issues
+
+**"Lock timeout after 2000ms"**:
+
+- Another process holding lock too long
+- Check for hung processes: `ps aux | grep amplihack`
+- Increase timeout if necessary (edit `LOCK_TIMEOUT_MS`)
+
+**"Locking unavailable (Windows)"**:
+
+- Expected behavior on Windows
+- No action needed
+- Race conditions remain possible but rare
+
+**"Permission denied on lock file"**:
+
+- File permissions issue
+- Check `.claude/runtime/power-steering/` permissions
+- Run: `chmod -R u+rw .claude/runtime/`
+
+## Technical Details
+
+### Lock Scope
+
+**Advisory Locks**: Cooperative - all processes must use same locking protocol.
+
+**File-Level**: Lock applies to entire file, not individual records.
+
+**Process-Local**: Locks not inherited by child processes.
+
+### Lock Lifetime
+
+1. **Acquire**: `fcntl.flock(fd, LOCK_EX | LOCK_NB)` called when file opened
+2. **Hold**: Lock held during critical section (read-modify-write)
+3. **Release**: Lock automatically released when file closed or process exits
+
+### Concurrency Model
+
+```
+Process A                    Process B
+    |                            |
+    | open(state_file)           |
+    | flock(LOCK_EX)             |
+    | [LOCKED]                   |
+    |                            | open(state_file)
+    |                            | flock(LOCK_EX) [BLOCKED]
+    | read → modify → write      |
+    | close() [UNLOCK]           |
+    |                            | [LOCK ACQUIRED]
+    |                            | read → modify → write
+    |                            | close() [UNLOCK]
+```
+
+## Related
+
+- Issue #2155: Power steering infinite loop
+- [Power Steering State Management](../features/power-steering/README.md)
+- Stop Hook Implementation
+- Test Coverage (in test suite)
+
+## Metadata
+
+- **Status**: [IMPLEMENTED - Testing Complete]
+- **Issue**: #2155
+- **Platform**: Linux (full), macOS (full), Windows (degraded)
+- **Python Version**: 3.8+
+- **Dependencies**: Standard library only (`fcntl`, `json`, `os`, `time`, `contextlib`)
+- **Last Updated**: 2026-01-27
+- **Implementation**:
+  - `/home/azureuser/src/amplihack/worktrees/feat/issue-2155-power-steering-counter-race/.claude/tools/amplihack/hooks/power_steering_state.py`
+  - `/home/azureuser/src/amplihack/worktrees/feat/issue-2155-power-steering-counter-race/.claude/tools/amplihack/hooks/stop.py`

--- a/docs/reference/power-steering-merge-preferences.md
+++ b/docs/reference/power-steering-merge-preferences.md
@@ -1,0 +1,641 @@
+# Power-Steering Merge Preference Awareness - Technical Reference
+
+> [Home](../index.md) > [Reference](../index.md) > Power-Steering Merge Preferences
+
+Technical documentation for the Power-Steering merge preference awareness feature.
+
+## Overview
+
+Power-Steering respects the USER_PREFERENCES.md setting "NEVER Merge PRs Without Permission". When active, it treats "PR ready + CI passing + awaiting user approval" as a valid completion state, rather than requiring PR merge.
+
+**Key Components**:
+
+- Detection: `_user_prefers_no_auto_merge()` method
+- Validation: `_check_ci_status_no_auto_merge()` method
+- Integration: `_check_ci_status()` method modification
+- Location: `.claude/tools/amplihack/hooks/power_steering_checker.py`
+
+---
+
+## Architecture
+
+### Component Overview
+
+```
+[Power-Steering Checker]
+         |
+         v
+[_check_ci_status()] -----> reads USER_PREFERENCES.md
+         |
+         v
+[_user_prefers_no_auto_merge()] -----> regex detection
+         |
+    yes /   \ no
+       /     \
+      v       v
+[_check_ci_status_no_auto_merge()]  [standard CI check]
+      |                                      |
+      v                                      v
+"PR ready + CI passing"              "PR must be merged"
+```
+
+### Design Principles
+
+1. **Fail-Open**: Errors default to standard behavior, never falsely satisfy
+2. **Non-Invasive**: No changes to considerations.yaml required
+3. **User-Centric**: Respects explicit user preferences
+4. **Robust**: Handles missing files, regex errors, PR status failures
+
+---
+
+## API Reference
+
+### Detection Method
+
+```python
+def _user_prefers_no_auto_merge(self) -> bool:
+    """
+    Detect if user has set preference to never auto-merge PRs.
+
+    Reads USER_PREFERENCES.md and searches for the pattern:
+    "NEVER ... Merge ... PR ... Without ... Permission"
+
+    Returns:
+        bool: True if preference detected, False otherwise
+
+    Behavior:
+        - Case-insensitive regex matching
+        - Handles multiline preferences
+        - Fail-open: returns False on any error
+        - File path: .claude/context/USER_PREFERENCES.md
+
+    Examples:
+        Detected patterns:
+        - "NEVER Merge PRs Without Permission"
+        - "NEVER merge pull requests without explicit permission"
+        - "Never Merge PRs or Commit Without Explicit Permission"
+
+        Not detected:
+        - "Never commit without permission" (missing "merge" + "PR")
+        - "NEVER auto-merge" (missing "without permission")
+    """
+```
+
+**Implementation Notes**:
+
+- Regex pattern: `r'NEVER.*(?:Merge|merge).*(?:PR|Pull Request).*(?:Without|without).*(?:Permission|permission)'`
+- Uses `re.IGNORECASE` and `re.DOTALL` flags
+- Returns `False` on `FileNotFoundError`, `IOError`, `re.error`
+- Logs errors at WARNING level (does not raise)
+
+### Validation Method
+
+```python
+def _check_ci_status_no_auto_merge(self) -> CheckResult:
+    """
+    Validate CI status WITHOUT requiring PR merge.
+
+    Checks:
+        1. PR exists and is open
+        2. CI checks are passing
+        3. PR is ready for review (not draft)
+
+    Returns:
+        CheckResult: Satisfied if PR ready + CI passing, else Unsatisfied
+
+    Success Criteria:
+        - PR found via gh CLI
+        - PR state is "OPEN"
+        - CI status is "SUCCESS" or all checks passing
+        - Not in draft state
+
+    Failure Modes:
+        - No PR found → Unsatisfied ("No PR found")
+        - CI checks failing → Unsatisfied ("CI checks failing")
+        - gh CLI error → Unsatisfied (error message)
+
+    Example Success Output:
+        CheckResult(
+            satisfied=True,
+            details="PR #123 ready (CI passing, awaiting user approval)",
+            evidence=["gh pr view output"]
+        )
+    """
+```
+
+**Implementation Notes**:
+
+- Uses `gh pr view` to fetch PR status
+- Parses JSON response for `statusCheckRollup` and `state`
+- Does NOT check `mergeable` or `merged` status
+- Collects evidence: PR number, CI status, review state
+
+### Integration Method
+
+```python
+def _check_ci_status(self) -> CheckResult:
+    """
+    Check CI status with preference awareness.
+
+    Flow:
+        1. Call _user_prefers_no_auto_merge()
+        2. If True: call _check_ci_status_no_auto_merge()
+        3. If False: use standard CI check logic
+
+    Returns:
+        CheckResult: Result from appropriate checker method
+
+    Behavior:
+        - Transparent to caller
+        - No changes to CheckResult format
+        - Maintains backward compatibility
+    """
+```
+
+---
+
+## Data Structures
+
+### CheckResult
+
+```python
+@dataclass
+class CheckResult:
+    """Result of a Power-Steering consideration check."""
+
+    satisfied: bool
+    """Whether the check passed."""
+
+    details: str
+    """Human-readable explanation of result."""
+
+    evidence: List[str] = field(default_factory=list)
+    """Supporting evidence (command outputs, file contents)."""
+
+    error: Optional[str] = None
+    """Error message if check failed due to error."""
+```
+
+**Usage in Preference Awareness**:
+
+```python
+# Success case
+CheckResult(
+    satisfied=True,
+    details="PR #123 ready for review (CI passing, awaiting user approval)",
+    evidence=[
+        "gh pr view output",
+        "CI status: SUCCESS",
+        "Review state: APPROVED"
+    ]
+)
+
+# Failure case
+CheckResult(
+    satisfied=False,
+    details="CI checks still running",
+    evidence=["gh pr view output"],
+    error=None
+)
+
+# Error case
+CheckResult(
+    satisfied=False,
+    details="Failed to check PR status",
+    evidence=[],
+    error="gh CLI not authenticated"
+)
+```
+
+---
+
+## File Paths
+
+### USER_PREFERENCES.md
+
+**Location**: `.claude/context/USER_PREFERENCES.md`
+
+**Format**:
+
+```markdown
+### YYYY-MM-DD HH:MM:SS
+
+**Preference Title**
+
+Preference description. Must include keywords:
+
+- NEVER
+- Merge (or merge)
+- PR (or Pull Request)
+- Without (or without)
+- Permission (or permission)
+
+**Implementation Requirements** (optional):
+
+- Additional details
+```
+
+**Example**:
+
+```markdown
+### 2026-01-23 10:00:00
+
+**NEVER Merge PRs or Commit Directly Without Explicit Permission**
+
+NEVER merge PRs or commit directly to main without explicit user permission.
+Always create PRs and wait for approval. Only the first explicitly approved
+merge applies - subsequent PRs require separate approval.
+
+**Implementation Requirements:**
+
+- MUST create PR and wait for user to say "merge" or "please merge"
+- MUST ask for permission for EACH PR merge separately
+```
+
+### Power-Steering Checker
+
+**Location**: `.claude/tools/amplihack/hooks/power_steering_checker.py`
+
+**Class**: `PowerSteeringChecker`
+
+**Modified Methods**:
+
+- `_check_ci_status()` - Entry point, delegates based on preference
+- `_user_prefers_no_auto_merge()` - Detection logic (NEW)
+- `_check_ci_status_no_auto_merge()` - Validation logic (NEW)
+
+---
+
+## Integration Points
+
+### Lazy Detection Design
+
+Preference detection occurs **during each `_check_ci_status()` call**, not at initialization:
+
+```python
+# In _check_ci_status()
+if self._user_prefers_no_auto_merge():
+    return self._check_ci_status_no_auto_merge()
+else:
+    # Standard CI check logic
+    return self._check_ci_status_standard()
+```
+
+> **⚙️ Design Rationale: Lazy Detection**
+>
+> Power-Steering reads `USER_PREFERENCES.md` during each CI check rather than at initialization. This design provides:
+>
+> 1. **Zero Startup Overhead**: No file I/O during hook initialization
+> 2. **Dynamic Updates**: Preference changes take effect immediately without restart
+> 3. **Fail-Open Safety**: If `USER_PREFERENCES.md` is temporarily unavailable, the system continues with standard behavior
+> 4. **Resilience**: Detection errors never prevent CI validation
+>
+> The file read overhead (<1ms) is negligible compared to `gh` CLI network calls (100-500ms).
+
+**Key Behaviors**:
+
+- Preference state is NOT cached between checks
+- Changes to `USER_PREFERENCES.md` are detected on next check
+- No restart required when adding/removing preference
+- File read errors default to standard behavior (fail-open)
+
+### gh CLI Integration
+
+Uses GitHub CLI to fetch PR status:
+
+```bash
+# Command executed
+gh pr view --json state,statusCheckRollup,isDraft
+
+# Expected JSON response
+{
+  "state": "OPEN",
+  "isDraft": false,
+  "statusCheckRollup": [
+    {"state": "SUCCESS", "context": "ci/test"},
+    {"state": "SUCCESS", "context": "ci/lint"}
+  ]
+}
+```
+
+**Requirements**:
+
+- `gh` CLI installed and in PATH
+- Authenticated: `gh auth status` succeeds
+- Repository has GitHub remote configured
+
+**Fallback**: If `gh` CLI unavailable, check falls back to standard behavior.
+
+---
+
+## Error Handling
+
+### Error Scenarios
+
+| Error Type       | Trigger                      | Behavior                      | User Impact                       |
+| ---------------- | ---------------------------- | ----------------------------- | --------------------------------- |
+| File not found   | USER_PREFERENCES.md missing  | Return `False` from detection | Standard CI check runs            |
+| Read error       | Permission denied, I/O error | Return `False` from detection | Standard CI check runs            |
+| Regex error      | Invalid pattern (unlikely)   | Return `False` from detection | Standard CI check runs            |
+| gh CLI missing   | `gh` not in PATH             | Return unsatisfied            | User notified to install gh       |
+| gh CLI auth fail | Not authenticated            | Return unsatisfied            | User notified to run `gh auth`    |
+| PR not found     | No PR created yet            | Return unsatisfied            | Expected - user hasn't created PR |
+| CI checks fail   | Tests failing                | Return unsatisfied            | Expected - user must fix tests    |
+
+### Fail-Open Principle
+
+**Definition**: When in doubt, default to safe behavior that doesn't falsely satisfy checks.
+
+**Implementation**:
+
+```python
+try:
+    # Attempt preference detection
+    if self._user_prefers_no_auto_merge():
+        return self._check_ci_status_no_auto_merge()
+except Exception as e:
+    logger.warning(f"Error detecting merge preference: {e}")
+    # Fall through to standard behavior
+
+# Standard CI check (requires merge)
+return self._check_ci_status_standard()
+```
+
+**Rationale**:
+
+- Errors during detection should never prevent CI validation
+- Better to require merge when in doubt than skip validation
+- Preserves backward compatibility
+
+---
+
+## Testing
+
+### Unit Tests
+
+Test coverage for preference awareness:
+
+```python
+# test_power_steering_checker.py
+
+class TestMergePreferenceAwareness:
+    """Tests for USER_PREFERENCES merge preference detection."""
+
+    def test_preference_detected_standard_format(self):
+        """NEVER Merge PRs Without Permission detected."""
+
+    def test_preference_detected_verbose_format(self):
+        """NEVER merge pull requests without explicit user permission detected."""
+
+    def test_preference_not_detected_missing_keywords(self):
+        """Preference with missing keywords not detected."""
+
+    def test_preference_detection_file_not_found(self):
+        """Missing USER_PREFERENCES.md returns False."""
+
+    def test_ci_check_no_auto_merge_pr_ready(self):
+        """PR ready + CI passing returns satisfied."""
+
+    def test_ci_check_no_auto_merge_ci_failing(self):
+        """PR ready + CI failing returns unsatisfied."""
+
+    def test_ci_check_no_auto_merge_no_pr(self):
+        """No PR created returns unsatisfied."""
+
+    def test_ci_check_standard_behavior_without_preference(self):
+        """Standard behavior when preference not detected."""
+```
+
+### Integration Tests
+
+End-to-end validation:
+
+```python
+class TestMergePreferenceIntegration:
+    """Integration tests for merge preference workflow."""
+
+    def test_workflow_with_preference_stops_at_pr_ready(self):
+        """Workflow completes when PR ready (not merged)."""
+
+    def test_workflow_without_preference_requires_merge(self):
+        """Workflow requires merge when preference not set."""
+
+    def test_preference_change_during_session(self):
+        """Preference changes reflected in subsequent checks."""
+```
+
+### Manual Testing
+
+**Test Plan**:
+
+1. **Setup**: Create test repository with USER_PREFERENCES.md
+2. **Create PR**: Push code, create PR, wait for CI
+3. **Run Power-Steering**: Verify consideration check passes
+4. **Verify Evidence**: Check logs for "awaiting user approval" message
+5. **Remove Preference**: Comment out preference, verify standard behavior
+
+---
+
+## Performance Considerations
+
+### File I/O
+
+- `USER_PREFERENCES.md` read during each `_check_ci_status()` call (lazy detection)
+- Typical size: <10KB
+- Read overhead: <1ms
+- No caching between checks (enables dynamic preference changes)
+
+**Note**: Could cache preference state per session if file I/O becomes measurable overhead, but current design prioritizes dynamic updates.
+
+### Regex Performance
+
+- Pattern complexity: Medium (5 groups, quantifiers)
+- Typical input size: 1-100 lines
+- Match overhead: <1ms
+
+**Note**: Performance negligible compared to network I/O (gh CLI).
+
+### gh CLI Overhead
+
+- Network latency: 100-500ms (GitHub API)
+- Dominant performance factor
+- Unavoidable for accurate PR status
+
+---
+
+## Security Considerations
+
+### Input Validation
+
+**USER_PREFERENCES.md**:
+
+- File read with encoding='utf-8'
+- No code execution risk (text file only)
+- Regex matching is safe (no eval/exec)
+
+**gh CLI Output**:
+
+- JSON parsing with built-in `json` module
+- No shell injection (uses subprocess.run with list args)
+- Output sanitized before logging
+
+### Privilege Escalation
+
+**Risk**: None. Feature reads configuration, doesn't modify state.
+
+**Validation**:
+
+- No file writes
+- No git operations
+- No GitHub API mutations
+
+### Information Disclosure
+
+**Risk**: Low. Logs may contain PR numbers and status.
+
+**Mitigation**:
+
+- Logs written to `.claude/runtime/logs/` (gitignored)
+- No secrets logged (API tokens, passwords)
+- Evidence collection uses sanitized output
+
+---
+
+## Migration Guide
+
+### From Standard Behavior
+
+**Before** (standard Power-Steering):
+
+```yaml
+# considerations.yaml
+- id: ci_status
+  question: Are CI checks passing and PR merged?
+  checker: _check_ci_status
+```
+
+**After** (with preference awareness):
+
+```yaml
+# No changes to considerations.yaml required
+- id: ci_status
+  question: Are CI checks passing and PR merged?
+  checker: _check_ci_status # Now preference-aware
+```
+
+**Migration Steps**:
+
+1. Update Power-Steering code (already done)
+2. Add preference to `USER_PREFERENCES.md` (user action)
+3. **No restart needed** - changes detected on next CI check
+4. Verify behavior with test PR
+
+**Note**: If creating `USER_PREFERENCES.md` for the first time, restart Claude to ensure the file is accessible. Subsequent changes take effect immediately.
+
+---
+
+## Troubleshooting
+
+### Debug Logging
+
+Enable detailed logging:
+
+```python
+# In power_steering_checker.py
+logger.setLevel(logging.DEBUG)
+
+# Logs output
+DEBUG: Reading USER_PREFERENCES.md
+DEBUG: Preference pattern: NEVER.*Merge.*PR.*Without.*Permission
+DEBUG: Preference detected: True
+DEBUG: Using no-auto-merge CI check
+DEBUG: Executing: gh pr view --json state,statusCheckRollup,isDraft
+DEBUG: PR #123 state: OPEN, CI: SUCCESS
+INFO: CI check satisfied (PR ready, awaiting user approval)
+```
+
+### Common Issues
+
+**Issue**: Preference detected but CI check still fails
+
+**Diagnosis**:
+
+```bash
+# Check PR status manually
+gh pr view --json state,statusCheckRollup,isDraft
+
+# Expected output
+{
+  "state": "OPEN",
+  "statusCheckRollup": [{"state": "SUCCESS"}]
+}
+```
+
+**Solution**: Ensure CI checks actually passing, PR not in draft state.
+
+**Issue**: Preference not detected despite correct format
+
+**Diagnosis**:
+
+```bash
+# Check file exists and has correct content
+cat .claude/context/USER_PREFERENCES.md | grep -i "never.*merge.*without.*permission"
+```
+
+**Solution**:
+
+- Verify file location at `.claude/context/USER_PREFERENCES.md`
+- If file was just created, restart Claude session (first-time only)
+- If file already existed, changes take effect immediately on next check
+
+---
+
+## Related Documentation
+
+- [How-To: Configure Merge Preferences](../howto/power-steering-merge-preferences.md) - User guide
+- [Power-Steering Overview](../features/power-steering/README.md) - Feature overview
+- [Power-Steering Configuration](../features/power-steering/configuration.md) - General configuration
+- [USER_PREFERENCES.md Reference](../reference/profile-management.md) - Complete preferences documentation
+
+---
+
+## Changelog
+
+### v0.10.0 (Planned)
+
+**Added**:
+
+- `_user_prefers_no_auto_merge()` method for preference detection
+- `_check_ci_status_no_auto_merge()` method for no-merge validation
+- Preference-aware logic in `_check_ci_status()`
+
+**Changed**:
+
+- `_check_ci_status()` now respects USER_PREFERENCES.md merge setting
+
+**Technical Details**:
+
+- No breaking changes
+- Backward compatible with existing workflows
+- Fail-open design for robustness
+
+---
+
+## Future Enhancements
+
+### Planned Improvements
+
+1. **Caching**: Cache preference state per session to reduce file I/O
+2. **Configuration**: Add explicit toggle in considerations.yaml for preference awareness
+3. **Metrics**: Track preference usage and CI check success rates
+4. **Documentation**: Auto-detect preference format variations
+
+### Research Directions
+
+1. **Granular Preferences**: Per-PR merge preferences (e.g., "auto-merge bug fixes, manual for features")
+2. **Time-Based**: Preference inheritance from parent branch or project defaults
+3. **Team Policies**: Organization-wide merge preferences
+
+---
+
+**Questions?** Open an issue on [GitHub](https://github.com/rysweet/amplihack/issues) with the `power-steering` label.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Recipe Discovery Troubleshooting: howto/recipe-discovery-troubleshooting.md
       - Goal-Seeking Agent Tutorial: howto/goal-seeking-agent-tutorial.md
       - Token Sanitization: howto/token-sanitization.md
+      - Power Steering Merge Preferences: howto/power-steering-merge-preferences.md
       - Security Testing: howto/security-testing.md
   - Document-Driven Development:
       - Overview: document_driven_development/README.md
@@ -102,6 +103,18 @@ nav:
           - Common Pitfalls: document_driven_development/reference/common_pitfalls.md
           - FAQ: document_driven_development/reference/faq.md
           - Tips for Success: document_driven_development/reference/tips_for_success.md
+  - Features:
+      - Overview: features/README.md
+      - Power Steering:
+          - Overview: features/power-steering/README.md
+          - Architecture Refactor: features/power-steering/architecture-refactor.md
+          - Configuration: features/power-steering/configuration.md
+          - Customization Guide: features/power-steering/customization-guide.md
+          - "Changelog v0.9.1": features/power-steering/changelog-v0.9.1.md
+          - "Migration v0.9.1": features/power-steering/migration-v0.9.1.md
+          - Migration Worktree Support: features/power-steering/migration-worktree-support.md
+          - Troubleshooting: features/power-steering/troubleshooting.md
+          - Worktree Support: features/power-steering/worktree-support.md
   - Skills:
       - Migrate Session: skills/migrate.md
   - Reference:
@@ -137,6 +150,10 @@ nav:
       - Memory Extended API: reference/memory-extended-api.md
       - Plugin Directory Structure Fix: reference/plugin-directory-structure-fix.md
       - Power Steering Compaction API: reference/power-steering-compaction-api.md
+      - Power Steering Checker API: reference/power-steering-checker-api.md
+      - Power Steering Checker Configuration: reference/power-steering-checker-configuration.md
+      - Power Steering File Locking: reference/power-steering-file-locking.md
+      - Power Steering Merge Preferences: reference/power-steering-merge-preferences.md
       - Profile Management: reference/profile-management.md
       - Shell Command Hook: reference/shell-command-hook.md
       - Security Recommendations: reference/security-recommendations.md


### PR DESCRIPTION
## Summary

- Port 9 Power Steering feature docs, 4 reference docs, and 1 howto from upstream amplihack
- Create `docs/features/README.md` index page and Features nav section in mkdocs.yml
- Fix all broken cross-references to point at valid docs tree targets (`.claude/` paths replaced, `AUTO_MODE.md` -> `concepts/auto-mode.md`, etc.)
- Light-touch Rust adaptations (`pip install` -> `cargo install`, `uvx amplihack` -> `amplihack-rs`)

## Files added

**Feature docs** (9): `docs/features/power-steering/{README,architecture-refactor,changelog-v0.9.1,configuration,customization-guide,migration-v0.9.1,migration-worktree-support,troubleshooting,worktree-support}.md`

**Reference docs** (4): `docs/reference/power-steering-{checker-api,checker-configuration,file-locking,merge-preferences}.md`

**How-to** (1): `docs/howto/power-steering-merge-preferences.md`

**Index** (1): `docs/features/README.md`

## Test plan

- [x] `mkdocs build --strict` passes with zero warnings from new files
- [x] All cross-references verified to resolve to existing files
- [x] No secrets detected (grep for `sk-`, `AKIA`, `Bearer`, passwords)
- [x] Pre-existing docs untouched (`docs/howto/power-steering-worktree-troubleshooting.md`, `docs/reference/power-steering-compaction-api.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)