### PR TITLE
docs: port tutorial docs (wave 6, group 3) #420

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,20 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Tutorials:
+      - Amplihack Tutorial: tutorials/amplihack-tutorial.md
+      - Goal-Seeking Agent Generator: tutorials/GOAL_SEEKING_AGENT_TUTORIAL.md
+      - Code Atlas Getting Started: tutorials/code-atlas-getting-started.md
+      - Copilot Parity Control Plane: tutorials/copilot-parity-control-plane.md
+      - Dev Orchestrator Getting Started: tutorials/dev-orchestrator-tutorial.md
+      - Your First Docs Site: tutorials/first-docs-site.md
+      - Hive Mind Getting Started: tutorials/hive-mind-getting-started.md
+      - Hive Mind Tutorial: tutorials/hive-mind-tutorial.md
+      - LearningAgent Refactor Walkthrough: tutorials/learning-agent-refactor-tutorial.md
+      - Memory-Enabled Agents Getting Started: tutorials/memory-enabled-agents-getting-started.md
+      - Platform Bridge Quickstart: tutorials/platform-bridge-quickstart.md
+      - Resumable Workstream Timeouts: tutorials/resumable-workstream-timeouts.md
+      - Session-Start Workflow Classification: tutorials/session-start-workflow-classification.md
   - How-To Guides:
       - First-Time Install: howto/first-install.md
       - Install from Local Repo: howto/local-install.md
@@ -234,17 +248,3 @@ nav:
       - "Layer 6: Data Flow": atlas/data-flow/README.md
       - "Layer 7: Service Components": atlas/service-components/README.md
       - "Layer 8: User Journeys": atlas/user-journeys/README.md
-  - Tutorials:
-      - amplihack Tutorial: tutorials/amplihack-tutorial.md
-      - Goal-Seeking Agent Tutorial: tutorials/GOAL_SEEKING_AGENT_TUTORIAL.md
-      - Code Atlas Getting Started: tutorials/code-atlas-getting-started.md
-      - Copilot Parity Control Plane: tutorials/copilot-parity-control-plane.md
-      - Dev Orchestrator Tutorial: tutorials/dev-orchestrator-tutorial.md
-      - First Docs Site: tutorials/first-docs-site.md
-      - Hive Mind Getting Started: tutorials/hive-mind-getting-started.md
-      - Hive Mind Tutorial: tutorials/hive-mind-tutorial.md
-      - Learning Agent Refactor: tutorials/learning-agent-refactor-tutorial.md
-      - Memory-Enabled Agents: tutorials/memory-enabled-agents-getting-started.md
-      - Platform Bridge Quickstart: tutorials/platform-bridge-quickstart.md
-      - Resumable Workstream Timeouts: tutorials/resumable-workstream-timeouts.md
-      - Session Start Workflow: tutorials/session-start-workflow-classification.md


### PR DESCRIPTION
## Summary

- Move Tutorials nav section from bottom of mkdocs.yml to between Home and How-To Guides, as specified for the documentation parity effort
- Improve nav entry names for better discoverability (e.g., "Dev Orchestrator Getting Started" instead of "Dev Orchestrator Tutorial")
- Tutorial files were already ported in #462; this PR corrects the nav ordering

Note: The 11 tutorial files and their Rust adaptations (cargo install, fixed cross-references, removed broken links to non-existent docs) were ported in PR #462. This PR handles the nav reordering that was missed.

## Test plan

- [x] `mkdocs build --strict` passes with zero warnings from tutorial files
- [x] Tutorials section appears between Home and How-To Guides in nav
- [x] All 13 tutorial entries present (11 new + 2 pre-existing hive-mind)

Wave 6 — Group 3 of 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)