### PR TITLE
docs: port Memory subsystem docs (wave 7, #420)

### DIFF
--- a/docs/fleet-orchestration/ADVANCED_PROPOSAL.md
+++ b/docs/fleet-orchestration/ADVANCED_PROPOSAL.md
@@ -1,0 +1,56 @@
+# Fleet Orchestration: Advanced Design
+
+## Vision
+
+You type `fleet dry-run` and see what every agent session needs. You type
+`fleet start --adopt` and the admiral takes over — answering agent questions,
+approving safe operations, escalating complex decisions. You check in with
+`fleet watch` and `fleet dashboard` to see progress.
+
+## Architecture
+
+See the fleet orchestration architecture document in the upstream `amplihack`
+repository for the module breakdown and per-session reasoning loop.
+
+## Design Principles
+
+1. **Observe first, act carefully** — dry-run mode shows reasoning before acting
+2. **Never interrupt thinking** — detect active LLM/tool processing and wait
+3. **SDK-agnostic** — LLMBackend protocol supports Claude and Copilot
+4. **Adopt, don't replace** — bring existing manual sessions under management
+5. **No ML** — rules and LLM reasoning, not trained models
+
+## Composable Reasoner Chain
+
+The admiral's `reason()` delegates to a chain of composable reasoners:
+
+```
+LifecycleReasoner → PreemptionReasoner → CoordinationReasoner → BatchAssignReasoner
+```
+
+Each reasoner sees prior decisions and can add its own. Adding a new reasoner
+is one class + one append to the chain.
+
+| Reasoner     | Purpose                                                                           |
+| ------------ | --------------------------------------------------------------------------------- |
+| Lifecycle    | Detect completions, failures, stuck agents. Respects protected (deep work) tasks. |
+| Preemption   | Pause low-priority work when CRITICAL tasks arrive with no idle capacity.         |
+| Coordination | Write shared context files so agents on same repo don't duplicate work.           |
+| BatchAssign  | Dependency-aware batch assignment (not greedy one-at-a-time).                     |
+
+## Scaling Path
+
+| Scale     | Architecture                                          |
+| --------- | ----------------------------------------------------- |
+| 6-15 VMs  | Current centralized admiral                           |
+| 15-30 VMs | Add parallel Bastion tunnels + push-based heartbeats  |
+| 30-50 VMs | SQLite task queue + persistent SSH tunnels            |
+| 50+ VMs   | Hub-spoke: regional admirals reporting to coordinator |
+
+## Future Directions
+
+- Integration with GitHub Issues for task sourcing
+- Push-based heartbeats via shared NFS (avoid polling)
+- Parallel Bastion tunnel connections
+- Connection to hive mind memory for cross-agent knowledge
+- Fleet replay timeline for debugging

--- a/docs/fleet-orchestration/TUTORIAL.md
+++ b/docs/fleet-orchestration/TUTORIAL.md
@@ -1,0 +1,645 @@
+# Fleet Orchestration Tutorial
+
+Manage coding agents (Claude Code, GitHub Copilot, Amplifier) running across multiple Azure VMs from a single terminal.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [First Run](#first-run)
+- [The Dashboard](#the-dashboard)
+- [Observing Your Fleet](#observing-your-fleet)
+- [Adopting Existing Sessions](#adopting-existing-sessions)
+- [The Admiral: Dry-Run First](#the-admiral-dry-run-first)
+- [Running the Admiral Live](#running-the-admiral-live)
+- [Task Management](#task-management)
+- [Environment Variables](#environment-variables)
+- [Running in tmux](#running-in-tmux)
+
+## Prerequisites
+
+Before you begin, you need:
+
+1. **azlin** installed and on your PATH. azlin manages SSH connections to Azure VMs through Bastion tunnels. See [github.com/rysweet/azlin](https://github.com/rysweet/azlin) for installation.
+
+2. **Azure VMs provisioned** and reachable via azlin. Verify with:
+
+   ```bash
+   azlin list
+   ```
+
+   You should see your VMs listed with their status.
+
+3. **Coding agents running in tmux** on those VMs. Each VM should have one or more tmux sessions with Claude Code, Copilot, or Amplifier running inside them. The fleet admiral observes and manages these sessions.
+
+4. **tmux** installed locally. The recipe runner uses tmux sessions for long-running workstreams that can take hours. The install script auto-installs it, or:
+
+   ```bash
+   # Ubuntu/Debian
+   sudo apt-get install tmux
+   # macOS
+   brew install tmux
+   ```
+
+5. **An Anthropic API key** set in your environment. The admiral uses Claude Opus to reason about what each agent session needs:
+
+   ```bash
+   export ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+## Installation
+
+Fleet is a required part of amplihack — no optional extras needed:
+
+```bash
+cargo install amplihack-rs
+```
+
+## Using Fleet
+
+Fleet commands work in two ways:
+
+**From the shell:**
+
+```bash
+amplihack fleet status
+amplihack fleet scout
+amplihack fleet advance --session deva:rustyclawd
+```
+
+**From the Claude Code REPL (interactive session):**
+
+```
+/fleet scout
+/fleet advance --session deva:rustyclawd
+/fleet watch dev cybergym
+```
+
+The `/fleet` slash command is available in any amplihack-powered Claude Code or
+Copilot CLI session. It provides the same commands as the shell interface.
+
+## First Run
+
+Verify that amplihack can see your VMs:
+
+```bash
+amplihack fleet status
+```
+
+This runs `azlin list` under the hood and displays each VM with its tmux sessions and detected agent states. If you see your VMs listed, the fleet module is working.
+
+## The Dashboard
+
+### Launching the TUI
+
+Running `amplihack fleet` with no subcommand launches the interactive Textual dashboard:
+
+```bash
+amplihack fleet
+```
+
+If Textual is not installed, you get a helpful fallback message pointing you to text-based alternatives.
+
+You can also launch explicitly:
+
+```bash
+amplihack fleet tui
+amplihack fleet tui --interval 15   # Faster refresh (default: 30s)
+```
+
+### Navigation
+
+| Key        | Action                                      |
+| ---------- | ------------------------------------------- |
+| Arrow keys | Move between sessions in the fleet table    |
+| Enter      | Dive into Session Detail for selected row   |
+| Escape     | Go back to Fleet Overview                   |
+| e          | Open Action Editor for the selected session |
+| a          | Apply the admiral's proposed action         |
+| d          | Run dry-run reasoning for selected session  |
+| r          | Force refresh all sessions                  |
+| q          | Quit the dashboard                          |
+
+### Three Tabs
+
+1. **Fleet Overview** -- The main view. A table of all sessions across all VMs with a preview pane on the right showing the last few lines of terminal output for the selected session.
+
+2. **Session Detail** -- Deep view of a single session. Shows the full tmux capture (what the agent's terminal looks like right now) and the admiral's proposed action with its reasoning.
+
+3. **Action Editor** -- Edit and override the admiral's proposed action before applying it. Choose an action type (send_input, wait, escalate, mark_complete, restart) and modify the input text.
+
+### Status Icons
+
+The dashboard uses icons to show session state at a glance:
+
+| Icon         | Status                       | Meaning                                                 |
+| ------------ | ---------------------------- | ------------------------------------------------------- |
+| `◉` (green)  | thinking / working / running | Agent is actively processing                            |
+| `◉` (green)  | waiting_input                | Agent asked a question, awaiting response               |
+| `●` (yellow) | idle                         | Session exists but agent is not actively working        |
+| `○` (dim)    | shell / empty                | No agent detected in this session                       |
+| `✗` (red)    | error                        | Error detected in session output                        |
+| `✓` (blue)   | completed                    | Agent finished its task (PR created, workflow complete) |
+
+## Observing Your Fleet
+
+Four commands give you visibility into what your agents are doing, without changing anything.
+
+### Quick Text Summary
+
+```bash
+amplihack fleet status
+```
+
+Shows every VM, its region, tmux sessions, and detected agent state. Fast, no LLM calls.
+
+### Watch a Single Session
+
+```bash
+amplihack fleet watch devo claude-session-1
+```
+
+Captures the last 30 lines of a specific tmux session on a specific VM. Like peeking over the agent's shoulder. Use `--lines 50` for more context.
+
+### Snapshot All Sessions
+
+```bash
+amplihack fleet snapshot
+```
+
+Captures every session on every managed VM in one pass. Shows the last 3 lines of output per session with the observer's status classification.
+
+### Observe with Pattern Classification
+
+```bash
+amplihack fleet observe devo
+```
+
+Runs the pattern-based observer on all sessions of a specific VM. Shows the detected status, confidence level, and which pattern matched. More detailed than `status` because it actually reads the terminal output.
+
+## Adopting Existing Sessions
+
+You do not need to start sessions through the fleet admiral. If you already have agents running in tmux sessions on your VMs (started manually or by another tool), you can bring them under fleet management.
+
+### Adopt Sessions on a Single VM
+
+```bash
+amplihack fleet adopt devo
+```
+
+This connects to the VM, discovers all tmux sessions, and for each session:
+
+1. Reads the tmux pane content to see what the agent is doing
+2. Checks git state (repo, branch) in the working directory
+3. Reads Claude Code JSONL logs if available
+4. Creates a tracking record with inferred context
+5. Begins observing without sending any commands
+
+The output shows what was discovered:
+
+```
+Discovering sessions on devo...
+Found 3 sessions:
+  claude-session-1
+    Repo: https://github.com/org/project
+    Branch: feat/add-auth
+    Agent: claude
+  claude-session-2
+    Repo: https://github.com/org/other-project
+    Branch: fix/login-bug
+    Agent: claude
+  amplifier-session
+    Agent: amplifier
+
+Adopted 3 sessions:
+  claude-session-1 -> task abc123
+  claude-session-2 -> task def456
+  amplifier-session -> task ghi789
+```
+
+### Adopt at Admiral Startup
+
+```bash
+amplihack fleet start --adopt
+```
+
+When starting the admiral, `--adopt` scans all managed VMs and brings existing sessions under management before beginning the autonomous loop.
+
+### Adopt Specific Sessions
+
+```bash
+amplihack fleet adopt devo --sessions claude-session-1 --sessions claude-session-2
+```
+
+Only adopt named sessions, leaving others alone.
+
+## The Admiral: Dry-Run First
+
+The admiral is the autonomous reasoning engine. Before letting it act, use dry-run mode to see what it would do.
+
+### Running a Dry-Run
+
+```bash
+amplihack fleet dry-run
+```
+
+For each session on each managed VM, the admiral:
+
+1. **PERCEIVE**: Captures the tmux pane and reads JSONL transcript summaries via SSH
+2. **REASON**: Sends the captured context to Claude, which decides what action to take
+3. **Display**: Shows the full reasoning chain without executing anything
+
+You can target specific VMs:
+
+```bash
+amplihack fleet dry-run --vm devo
+amplihack fleet dry-run --vm devo --vm devi
+```
+
+And provide project priorities to guide decisions:
+
+```bash
+amplihack fleet dry-run --priorities "auth feature is highest priority, fix CI on project-x"
+```
+
+### What Dry-Run Shows
+
+For each session, you see the admiral's decision:
+
+- **Action**: `send_input`, `wait`, `escalate`, `mark_complete`, or `restart`
+- **Confidence**: How sure the admiral is (0.0 to 1.0)
+- **Reasoning**: Why it chose this action
+- **Proposed input**: What it would type into the session (if `send_input`)
+
+### Safety Mechanisms
+
+The admiral has built-in safety at multiple levels:
+
+**Thinking detection**: If an agent is actively processing (Claude Code shows `●` or `⎿`, Copilot shows `Thinking...`), the admiral skips the LLM call entirely and fast-paths to WAIT. It never interrupts a working agent.
+
+**Confidence thresholds**: Actions below 0.6 confidence are not executed. Restart actions require 0.8 confidence.
+
+**Dangerous input blocklist**: The admiral refuses to send commands matching dangerous patterns, regardless of confidence:
+
+- `rm -rf`, `rm -r /`
+- `git push --force`, `git push -f`
+- `git reset --hard`
+- `DROP TABLE`, `DROP DATABASE`
+- Fork bombs and disk-destructive commands
+
+## Running the Admiral Live
+
+After reviewing dry-run output and confirming the admiral's reasoning looks sound:
+
+```bash
+amplihack fleet start
+```
+
+The admiral begins the autonomous loop: PERCEIVE, REASON, ACT, LEARN. It polls all sessions at a configurable interval, decides what each session needs, and acts.
+
+### Controlling the Loop
+
+```bash
+amplihack fleet start --interval 30    # Poll every 30 seconds (default: 60)
+amplihack fleet start --max-cycles 10  # Stop after 10 cycles
+amplihack fleet start --adopt          # Adopt existing sessions first
+```
+
+Press `Ctrl+C` to stop the admiral gracefully.
+
+### Single Cycle
+
+Run one complete cycle without looping:
+
+```bash
+amplihack fleet run-once
+```
+
+Reports how many actions were taken and what they were. Useful for testing or manual orchestration.
+
+## Task Management
+
+The fleet has a priority-ordered task queue. Tasks describe work to be assigned to agent sessions.
+
+### Adding Tasks
+
+```bash
+amplihack fleet add-task "Fix the authentication bug where JWT tokens expire too early" \
+  --priority high \
+  --repo https://github.com/org/project
+```
+
+Options:
+
+| Flag          | Values                      | Default | Purpose                                    |
+| ------------- | --------------------------- | ------- | ------------------------------------------ |
+| `--priority`  | critical, high, medium, low | medium  | Queue ordering                             |
+| `--repo`      | URL                         | (none)  | Repository to clone on the target VM       |
+| `--agent`     | claude, amplifier, copilot  | claude  | Which agent to use                         |
+| `--mode`      | auto, ultrathink            | auto    | Agent execution mode                       |
+| `--max-turns` | integer                     | 20      | Maximum agent turns                        |
+| `--protected` | flag                        | false   | Deep work mode -- admiral will not preempt |
+
+### Viewing the Queue
+
+```bash
+amplihack fleet queue
+```
+
+Shows all tasks sorted by priority with their status (queued, assigned, running, completed, failed).
+
+### Project-Level Tracking
+
+```bash
+amplihack fleet dashboard
+```
+
+Shows fleet-wide metrics: active projects, agent utilization, cost estimates, PR counts, and task completion rates.
+
+### Knowledge Graph
+
+```bash
+amplihack fleet graph
+```
+
+Shows the relationship graph between projects, tasks, agents, VMs, and PRs. Useful for understanding what depends on what.
+
+### Project and Objective Tracking
+
+Register projects and track GitHub issues as fleet objectives:
+
+```bash
+# Register a project
+amplihack fleet project add https://github.com/org/myapp --name myapp --priority high
+
+# List registered projects
+amplihack fleet project list
+
+# Track a specific issue as an objective
+amplihack fleet project add-issue myapp 42 --title "Add authentication"
+
+# Sync objectives from GitHub issues labeled 'fleet-objective'
+amplihack fleet project track-issue myapp --label fleet-objective
+
+# Remove a project
+amplihack fleet project remove myapp
+```
+
+The `projects.toml` file stores project configuration:
+
+```toml
+[project.myapp]
+repo_url = "https://github.com/org/myapp"
+identity = "user1"
+priority = "high"
+
+[[project.myapp.objectives]]
+number = 42
+title = "Add authentication"
+state = "open"
+url = "https://github.com/org/myapp/issues/42"
+
+[project.lib]
+repo_url = "https://github.com/org/lib"
+priority = "low"
+```
+
+Objectives are stored in `~/.amplihack/fleet/projects.toml` and enriched during scout with live GitHub issue state. The scout report groups sessions by project and shows open objectives:
+
+```
+--- By Project ---
+
+  [myapp]
+    objective #42: Add authentication
+    objective #43: Fix login flow
+    dev/auth-session [running] -> wait
+    dev/login-fix [idle] -> send_input
+
+  [unassigned]
+    deva/qa [shell] -> restart
+```
+
+The SSH gather phase also queries `gh issue list --label fleet-objective` on each VM to discover objectives from the remote repository, merging them with locally registered objectives.
+
+## Environment Variables
+
+| Variable            | Purpose                                                         | Default                                                                                    |
+| ------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `AZLIN_PATH`        | Path to the azlin binary                                        | Auto-detected via `which azlin`, falls back to `/home/azureuser/src/azlin/.venv/bin/azlin` |
+| `ANTHROPIC_API_KEY` | API key for Claude (required for dry-run and admiral reasoning) | (none -- must be set)                                                                      |
+
+## Running in tmux
+
+The fleet dashboard is designed to run in its own tmux session so you can detach and reattach freely:
+
+```bash
+# Start the dashboard in a detached tmux session
+tmux new-session -d -s fleet-dashboard "amplihack fleet"
+
+# Attach anytime
+tmux attach -t fleet-dashboard
+
+# Detach without stopping: Ctrl+b, then d
+```
+
+For the admiral loop:
+
+```bash
+tmux new-session -d -s fleet-admiral "amplihack fleet start --adopt --interval 30"
+
+# Check on it
+tmux attach -t fleet-admiral
+```
+
+## Auth Propagation
+
+If your VMs need authentication tokens (GitHub CLI, Azure CLI, Claude API key):
+
+```bash
+amplihack fleet auth devo
+amplihack fleet auth devo --services github azure claude
+```
+
+This copies credential files to the target VM and verifies they work.
+
+## Using Fleet from Claude Code or Copilot CLI
+
+The `/fleet` skill lets you manage your fleet directly from a Claude Code or Copilot CLI conversation, without switching to a separate terminal.
+
+### Invoking the Skill
+
+Type `/fleet` followed by a command:
+
+```
+/fleet scout
+/fleet advance
+/fleet status
+```
+
+Or just describe what you want — Claude will pick the right command:
+
+```
+"What are my agents doing?"        → fleet scout
+"Send next steps to all sessions"  → fleet advance
+"Advance the stuck session on dev" → fleet advance --session dev:stuck-session
+```
+
+### Fleet Scout (Dry-Run Scan)
+
+`/fleet scout` is **reconnaissance** — it discovers ALL VMs and sessions including those in the exclude list (`DEFAULT_EXCLUDE_VMS`). `DEFAULT_EXCLUDE_VMS` is empty by default (all VMs are fleet-managed). This is intentional: you need full visibility to understand the fleet before deciding what to act on. The exclude list only applies to admiral actions (`advance`, `start`, `run-once`) which skip excluded VMs to avoid unintended interference with shared infrastructure.
+
+`/fleet scout` discovers all VMs and sessions, runs admiral reasoning, and shows a report with three sections:
+
+**1. Status Table** — one row per session:
+
+```
+  VM           Session                Status     Action           Conf
+  --------------------------------------------------------------------
+  dev          [>] cybergym-intg      running    wait             100%
+  dev          [.] parallel-deploy-wk idle       send_input        90%
+  deva         [X] qa                 shell      send_input        90%
+  devy         [~] agent-kgpacks      thinking   wait             100%
+```
+
+Status icons: `[~]` thinking, `[>]` running, `[.]` idle, `[X]` shell (dead agent), `[Z]` suspended, `[!]` error, `[+]` completed, `[?]` waiting input.
+
+**2. Session Summaries** — admiral reasoning + proposed input:
+
+```
+  dev/parallel-deploy-wk:
+    Deployment succeeded. Agent needs to create a PR with results.
+    >> "Great! The deployment completed successfully in ~21 minutes."
+
+  deva/qa:
+    Claude crashed with malformed args. Need to relaunch.
+    >> "claude --dangerously-skip-permissions --model opus[1m]"
+```
+
+**3. Next Steps** — copy-pasteable commands:
+
+```
+  # Act on all sessions at once:
+  fleet advance
+
+  # Advance dev/parallel-deploy-wk only:
+  fleet advance --session dev:parallel-deploy-wk
+  #   >> "Great! The deployment completed successfully..."
+
+  # deva/qa is dead — inspect:
+  fleet watch deva qa
+```
+
+### Fleet Advance (Live Execution)
+
+`/fleet advance` reasons about sessions and **executes** the admiral's decisions:
+
+```
+/fleet advance                                        # All sessions (confirms each action by default)
+/fleet advance --force                                # Skip confirmation, auto-execute all
+/fleet advance --session dev:parallel-deploy-wk  # Single session only
+```
+
+What happens for each action type:
+
+| Action          | What the admiral does                         |
+| --------------- | --------------------------------------------- |
+| `wait`          | Nothing — agent is working fine               |
+| `send_input`    | Types text into the tmux pane                 |
+| `restart`       | Sends Ctrl-C twice to interrupt stuck process |
+| `escalate`      | Flags for human review, no action taken       |
+| `mark_complete` | Records task as done                          |
+
+Safety is enforced automatically:
+
+- `send_input` requires confidence >= 60%
+- `restart` requires confidence >= 80%
+- Dangerous patterns (rm -rf, force push, etc.) are blocked
+
+### Filtering to One Session
+
+Both scout and advance support `--vm` and `--session` filters:
+
+```
+# Scout one VM (faster — only one Bastion tunnel):
+/fleet scout --vm dev --skip-adopt
+
+# Scout one session (fastest — ~2 min):
+/fleet scout --session dev:cybergym-intg --skip-adopt
+
+# Advance one session:
+/fleet advance --session dev:cybergym-intg
+
+# Advance one session with confirmation:
+/fleet advance --session deva:qa --confirm
+```
+
+### Typical Workflow
+
+1. **Scout first** to see the fleet state:
+
+   ```
+   /fleet scout
+   ```
+
+2. **Review** the report — check which sessions need action
+
+3. **Advance specific sessions** you agree with:
+
+   ```
+   /fleet advance --session dev:parallel-deploy-wk
+   ```
+
+4. **Or advance all** if the admiral's proposals look good (auto-confirms each):
+
+   ```
+   /fleet advance --force
+   ```
+
+5. **Check on individual sessions** that need attention:
+   ```
+   /fleet watch deva qa
+   ```
+
+### Incremental Scout
+
+After the first scout, results are saved to `~/.amplihack/fleet/last_scout.json`. On subsequent runs, use `--incremental` to skip LLM reasoning for sessions whose status hasn't changed:
+
+```
+/fleet scout --incremental
+```
+
+This dramatically reduces LLM costs when most sessions are stable.
+
+### Saving Reports
+
+Both commands support `--save` to write a JSON report:
+
+```
+/fleet scout --save /tmp/fleet-report.json
+/fleet advance --save /tmp/advance-log.json
+```
+
+### Session State Detection
+
+The fleet system detects eight distinct session states:
+
+| State             | What it means                  | How detected                                        |
+| ----------------- | ------------------------------ | --------------------------------------------------- |
+| **thinking**      | Agent is actively processing   | `●` tool call indicator, streaming output           |
+| **running**       | Agent producing output         | Status bar shows `(running)`                        |
+| **idle**          | Agent at `❯` prompt, waiting   | Claude Code prompt with no input                    |
+| **shell**         | Agent dead, back at `$` prompt | Bare bash prompt, no claude/node process            |
+| **suspended**     | Agent backgrounded but alive   | Bash prompt but claude/node process still running   |
+| **error**         | Error detected in session      | `error:`, `traceback`, `fatal:`, `panic:` in output |
+| **completed**     | Agent finished its task        | `GOAL_STATUS: ACHIEVED`, PR created/merged          |
+| **waiting_input** | Agent needs user input         | `[Y/n]`, `⏵⏵ bypass`, prompt ending in `?`          |
+
+The suspended state is detected by checking for live `claude` or `node` processes as children of the tmux pane. This catches sessions where the agent was backgrounded with Ctrl-Z or the Claude Code background feature.
+
+The `unknown` state may appear when detection patterns do not match any known status. This is treated as requiring manual inspection.
+
+## Next Steps
+
+- Read the fleet orchestration architecture document in the upstream `amplihack` repository to understand how the modules fit together
+- Read the Strategy Dictionary in the upstream `amplihack` repository to understand the admiral's 20 decision strategies
+- Run `amplihack fleet --help` for the full command reference

--- a/docs/hive_mind/CURRENT_DESIGN_SPEC.md
+++ b/docs/hive_mind/CURRENT_DESIGN_SPEC.md
@@ -1,0 +1,594 @@
+# Current Design Specification: Memory & Retrieval Data Flow
+
+> **Purpose**: Document the current architecture exactly as implemented so the
+> design can be reviewed and rewritten. This is a factual description of what
+> exists today, not what should exist.
+
+---
+
+## Table of Contents
+
+1. [Object Model & DI Wiring](#1-object-model-di-wiring)
+2. [Graph Storage Schema](#2-graph-storage-schema)
+3. [Single-Agent Mode](#3-single-agent-mode)
+   - 3.1 [OODA Loop](#31-ooda-loop)
+   - 3.2 [Question Answering Entry Point](#32-question-answering-entry-point)
+   - 3.3 [Retrieval Strategies](#33-retrieval-strategies)
+   - 3.4 [Storage-Level Queries](#34-storage-level-queries)
+   - 3.5 [Similarity & Ranking](#35-similarity-ranking)
+   - 3.6 [Store Path](#36-store-path)
+4. [Distributed Hive Mode](#4-distributed-hive-mode)
+   - 4.1 [OODA Loop Differences](#41-ooda-loop-differences)
+   - 4.2 [DI Injection Point](#42-di-injection-point)
+   - 4.3 [DistributedCognitiveMemory Wrapper](#43-distributedcognitivememory-wrapper)
+   - 4.4 [Hive Query Mechanism (SHARD_QUERY)](#44-hive-query-mechanism-shard_query)
+   - 4.5 [Shard Controller & Local Query Handling](#45-shard-controller-local-query-handling)
+   - 4.6 [Merge & Deduplication](#46-merge-deduplication)
+   - 4.7 [search_local -- Recursive Storm Prevention](#47-search_local-recursive-storm-prevention)
+5. [Constants & Configuration](#5-constants-configuration)
+6. [Known Problems](#6-known-problems)
+
+---
+
+## 1. Object Model & DI Wiring
+
+### Single-Agent Object Chain
+
+```
+GoalSeekingAgent
+  └── .memory: CognitiveAdapter
+        └── .memory: CognitiveMemory
+              └── ._db: Kuzu connection (local graph DB)
+```
+
+### Distributed Object Chain
+
+```
+GoalSeekingAgent
+  └── .memory: CognitiveAdapter          ← topology-unaware (same code)
+        └── .memory: DistributedCognitiveMemory   ← injected at deploy
+              ├── ._local: CognitiveMemory        ← same local Kuzu DB
+              └── ._hive: DistributedHiveGraph     ← Event Hubs transport
+                    ├── ._transport: EventHubsShardTransport
+                    └── ._router: ConsistentHashRouter
+```
+
+### Key Observation
+
+`LearningAgent` (subclass of `GoalSeekingAgent`) calls `self.memory` which is
+always `CognitiveAdapter`. It never sees `DistributedCognitiveMemory` directly.
+`CognitiveAdapter.memory` is either `CognitiveMemory` (single) or
+`DistributedCognitiveMemory` (distributed).
+
+**Files:**
+
+- `goal_seeking_agent.py` — GoalSeekingAgent, OODA loop
+- `learning_agent.py` — LearningAgent, answer_question, retrieval strategies
+- `cognitive_adapter.py` — CognitiveAdapter, topology-unaware facade
+- `hive_mind/distributed_memory.py` — DistributedCognitiveMemory wrapper
+- `deploy/azure_hive/agent_entrypoint.py:278-328` — DI injection
+
+---
+
+## 2. Graph Storage Schema
+
+**Database**: Kuzu (embedded graph DB, one instance per agent process)
+
+### Node Tables
+
+```sql
+CREATE NODE TABLE SemanticMemory(
+    memory_id    STRING PRIMARY KEY,
+    concept      STRING,     -- category / context label
+    content      STRING,     -- the fact text
+    confidence   DOUBLE,
+    source_id    STRING,     -- FK to EpisodicMemory
+    agent_id     STRING,
+    tags         STRING,     -- JSON array
+    metadata     STRING,     -- JSON object
+    created_at   STRING,
+    entity_name  STRING DEFAULT ''   -- extracted proper noun for entity index
+)
+
+CREATE NODE TABLE EpisodicMemory(
+    memory_id    STRING PRIMARY KEY,
+    content      STRING,
+    source_label STRING,
+    agent_id     STRING,
+    tags         STRING,
+    metadata     STRING,
+    created_at   STRING
+)
+```
+
+### Relationship Tables
+
+```sql
+-- Similarity edges (computed at store time via Jaccard coefficient)
+CREATE REL TABLE SIMILAR_TO(
+    FROM SemanticMemory TO SemanticMemory,
+    weight   DOUBLE,
+    metadata STRING
+)
+
+-- Provenance chain
+CREATE REL TABLE DERIVES_FROM(
+    FROM SemanticMemory TO EpisodicMemory,
+    extraction_method STRING,
+    confidence        DOUBLE
+)
+
+-- Temporal supersession
+CREATE REL TABLE SUPERSEDES(
+    FROM SemanticMemory TO SemanticMemory,
+    reason         STRING,
+    temporal_delta STRING
+)
+
+-- Value transition tracking
+CREATE REL TABLE TRANSITIONED_TO(
+    FROM SemanticMemory TO SemanticMemory,
+    from_value      STRING,
+    to_value        STRING,
+    turn            INT64,
+    transition_type STRING
+)
+```
+
+**File:** `_hierarchical_memory_local.py`
+
+---
+
+## 3. Single-Agent Mode
+
+### 3.1 OODA Loop
+
+**File:** `goal_seeking_agent.py`
+
+The current `process()` method runs a **simplified** pipeline:
+
+```
+process(input)
+  ├── observe(input)     — store raw input in self._current_input
+  ├── decide()           — heuristic classify: 'answer' or 'store' (no LLM)
+  └── act()              — answer_question() or learn_from_content()
+```
+
+`orient()` exists as a separate method but is **NOT called** from `process()`.
+The rationale documented in code is that `answer_question()` does its own retrieval,
+making orient() redundant. The OODA loop is therefore Observe→Decide→Act (ODA),
+not Observe→Orient→Decide→Act.
+
+**orient() when called directly:**
+
+```python
+def orient(self):
+    facts = self.memory.search(query, limit=15)    # ← hardcoded int
+    return {"input": self._current_input, "facts": fact_strings}
+```
+
+### 3.2 Question Answering Entry Point
+
+**File:** `learning_agent.py:511-690`
+
+```
+answer_question(question)
+  ├── _detect_intent(question)         — single LLM call → intent_type
+  ├── Check KB size:
+  │     get_all_facts(limit=15000, query=question)    ← MAX_RETRIEVAL_LIMIT constant
+  │     kb_size = len(results)
+  ├── Route to strategy:
+  │     ├── AGGREGATION_INTENTS → _aggregation_retrieval()     (Cypher meta-queries)
+  │     ├── kb_size ≤ 500       → _simple_retrieval()          (dump all facts)
+  │     └── kb_size > 500       → _entity_retrieval()          (graph traversal)
+  │                                   └── fallback → _simple_retrieval(force_verbatim=True)
+  └── _synthesize_answer(question, relevant_facts)    — LLM call with fact context
+```
+
+### 3.3 Retrieval Strategies
+
+#### Simple Retrieval (`_simple_retrieval`)
+
+```
+_simple_retrieval(question, force_verbatim=False)
+  ├── Get all facts: memory.get_all_facts(limit=15000, query=question)
+  │     (uses thread-local cache if available from KB size check)
+  ├── kb_size ≤ 1000 or force_verbatim:
+  │     └── Return ALL facts verbatim (no filtering)
+  └── kb_size > 1000:
+        └── _tiered_retrieval():
+              ├── Tier 1: last 200 facts → verbatim
+              ├── Tier 2: facts 201–1000 → entity-level LLM summaries
+              └── Tier 3: facts 1000+ → topic-level LLM summaries
+```
+
+#### Entity Retrieval (`_entity_retrieval`)
+
+Uses graph traversal via `retrieve_subgraph()`:
+
+1. Extract entity names from question (regex for capitalized words)
+2. Seed search: `CONTAINS` on `entity_name` field
+3. Expand via `SIMILAR_TO` edges (1–2 hops)
+4. Rank by `confidence × keyword_relevance`
+
+#### Aggregation Retrieval (`_aggregation_retrieval`)
+
+Direct Cypher queries for meta-questions:
+
+- `count_total`, `count_entities`, `list_entities`, `count_by_concept`
+
+### 3.4 Storage-Level Queries
+
+All queries use **keyword CONTAINS** matching, not embeddings.
+
+**Primary search (retrieve_subgraph):**
+
+```sql
+MATCH (m:SemanticMemory)
+WHERE m.agent_id = $agent_id
+  AND (LOWER(m.content) CONTAINS $keyword
+       OR LOWER(m.concept) CONTAINS $keyword)
+RETURN m.*
+LIMIT $limit
+```
+
+**Entity search:**
+
+```sql
+MATCH (m:SemanticMemory)
+WHERE m.agent_id = $agent_id
+  AND LOWER(m.entity_name) CONTAINS $entity
+RETURN m.*
+LIMIT $limit
+```
+
+**Concept search (search_by_concept):**
+
+```sql
+MATCH (m:SemanticMemory)
+WHERE m.agent_id = $agent_id
+  AND (LOWER(m.concept) CONTAINS $kw OR LOWER(m.content) CONTAINS $kw)
+RETURN m.*
+ORDER BY m.created_at DESC
+LIMIT $limit
+```
+
+**get_all_facts:** Full scan, no filtering, returns up to `limit`.
+
+### 3.5 Similarity & Ranking
+
+**At store time:** When a fact is stored, SIMILAR_TO edges are computed to existing
+facts using a deterministic Jaccard-based score:
+
+```
+similarity = 0.5 × jaccard(content_tokens) + 0.2 × jaccard(tags) + 0.3 × jaccard(concept_tokens)
+```
+
+Stop words removed, tokens < 3 chars stripped.
+
+**At query time (search_local / CognitiveAdapter):** Results are re-ranked using
+n-gram overlap score between the query and `concept + content`:
+
+```python
+score = _ngram_overlap_score(query, f"{concept} {content}")
+```
+
+**No embeddings, no vector search, no semantic similarity** at any layer.
+
+### 3.6 Store Path
+
+```
+learn_from_content(text)
+  └── memory.store_fact(context, fact, confidence, source_id)
+        └── CognitiveMemory.store_fact()
+              ├── Insert SemanticMemory node
+              ├── Compute SIMILAR_TO edges to existing nodes (Jaccard)
+              ├── Insert DERIVES_FROM edge to EpisodicMemory
+              └── Detect entity_name, populate index field
+```
+
+---
+
+## 4. Distributed Hive Mode
+
+### 4.1 OODA Loop Differences
+
+The `process()` method is the **same code** in both modes. The difference is
+that `CognitiveAdapter.memory` points to `DistributedCognitiveMemory` instead
+of `CognitiveMemory`. The simplified ODA loop (no orient) applies in both.
+
+**However**, the behavior of `get_all_facts()` and `search_facts()` is radically
+different:
+
+| Method                        | Single-Agent                                    | Distributed                                     |
+| ----------------------------- | ----------------------------------------------- | ----------------------------------------------- |
+| `get_all_facts(limit, query)` | Full Kuzu scan (all 5000 facts if limit allows) | Local scan + SHARD_QUERY fan-out via Event Hubs |
+| `search_facts(query, limit)`  | Kuzu CONTAINS keyword search                    | Local search + SHARD_QUERY fan-out              |
+| `search_by_concept(keywords)` | Kuzu CONTAINS on concept/content                | Local search + SHARD_QUERY fan-out              |
+| `store_fact(...)`             | Insert into local Kuzu                          | Insert into local Kuzu + auto-promote to hive   |
+
+### 4.2 DI Injection Point
+
+**File:** `deploy/azure_hive/agent_entrypoint.py:278-328`
+
+```python
+local_memory = agent.memory.memory          # CognitiveAdapter → CognitiveMemory
+distributed_memory = DistributedCognitiveMemory(
+    local_memory=local_memory,
+    hive_graph=hive_store,                  # DistributedHiveGraph
+    agent_name=agent_name,
+)
+agent.memory.memory = distributed_memory    # Replace CognitiveAdapter's backend
+```
+
+After injection:
+
+- `agent.memory` → CognitiveAdapter (unchanged)
+- `agent.memory.memory` → DistributedCognitiveMemory (was CognitiveMemory)
+- `agent.memory.memory._local` → CognitiveMemory (original)
+- `agent.memory.memory._hive` → DistributedHiveGraph (new)
+
+### 4.3 DistributedCognitiveMemory Wrapper
+
+**File:** `hive_mind/distributed_memory.py`
+
+This is a **transparent wrapper** that intercepts read operations and fans them
+out to the hive, then merges results with local data.
+
+#### get_all_facts(limit, query)
+
+```
+get_all_facts(limit=50, query="")
+  ├── local_results = self._local.get_all_facts(limit)     ← local Kuzu scan
+  ├── if query:
+  │     hive_dicts = self._query_hive(query, limit)        ← SHARD_QUERY fan-out
+  │   else:
+  │     hive_dicts = self._get_all_hive_facts(limit)       ← unfiltered hive scan
+  └── return self._merge_fact_lists(local_results, hive_dicts, limit)
+```
+
+#### search_facts(query, limit)
+
+```
+search_facts(query, limit=10)
+  ├── local_results = self._local.search_facts(query, limit*3)   ← local Kuzu CONTAINS
+  ├── hive_dicts = self._query_hive(query, limit)                ← SHARD_QUERY fan-out
+  └── return self._merge_fact_lists(local_results, hive_dicts, limit)
+```
+
+#### store_fact(...)
+
+```
+store_fact(context, fact, ...)
+  ├── result = self._local.store_fact(...)     ← write to local Kuzu
+  └── self._auto_promote(...)                  ← fire-and-forget to Event Hubs
+```
+
+#### **getattr** (proxy)
+
+Any method not explicitly defined is proxied to `self._local`:
+
+```python
+def __getattr__(self, name):
+    if name.startswith("__") and name.endswith("__"):
+        raise AttributeError(name)
+    return getattr(self._local, name)
+```
+
+### 4.4 Hive Query Mechanism (SHARD_QUERY)
+
+**File:** `hive_mind/distributed_hive_graph.py`
+
+When `DistributedCognitiveMemory._query_hive()` is called, it delegates to
+`DistributedHiveGraph.query_facts()`:
+
+```
+query_facts(query, limit=20)
+  ├── targets = _select_query_targets(query)
+  │     ├── If embedding_generator available:
+  │     │     cosine_similarity(query_embedding, shard_summary_embedding) → top K
+  │     └── Else (current default):
+  │           If most local shards empty → return ALL agent IDs
+  │           Else → return non-empty shard agent IDs
+  │
+  ├── For each target agent (ThreadPoolExecutor):
+  │     ├── Publish SHARD_QUERY event to Event Hubs
+  │     │     {
+  │     │       event_type: "SHARD_QUERY",
+  │     │       source_agent: self._agent_id,
+  │     │       payload: {
+  │     │         query: "search string",
+  │     │         limit: 20,
+  │     │         correlation_id: uuid,
+  │     │         target_agent: recipient_id
+  │     │       }
+  │     │     }
+  │     └── Wait for SHARD_RESPONSE with matching correlation_id (timeout)
+  │
+  ├── Collect all SHARD_RESPONSE facts
+  ├── Score by position: score = max(0.0, 1.0 - rank * 0.01)
+  ├── Dedup by content hash
+  └── Return top `limit` facts sorted by score
+```
+
+**SHARD_RESPONSE event:**
+
+```json
+{
+  "event_type": "SHARD_RESPONSE",
+  "source_agent": "responding_agent_id",
+  "payload": {
+    "correlation_id": "matches_query",
+    "target_agent": "requesting_agent_id",
+    "facts": [
+      {
+        "fact_id": "...",
+        "content": "fact text",
+        "concept": "category",
+        "confidence": 0.95,
+        "tags": [],
+        "metadata": {}
+      }
+    ]
+  }
+}
+```
+
+### 4.5 Shard Controller & Local Query Handling
+
+**File:** `hive_mind/controller.py`
+
+When an agent receives a `SHARD_QUERY` event, the controller:
+
+1. Checks `payload.target_agent` matches this agent
+2. Calls `agent.memory.search_local(query, limit)` — the CognitiveAdapter method
+3. Formats results as `SHARD_RESPONSE` and publishes back
+
+`search_local()` is specifically designed to query ONLY the local Kuzu DB
+and never trigger another SHARD_QUERY (preventing recursive storms).
+
+### 4.6 Merge & Deduplication
+
+**File:** `hive_mind/distributed_memory.py`
+
+```python
+def _merge_fact_lists(local_results, hive_dicts, limit):
+    seen = set()        # MD5 hashes of content
+    merged = []
+
+    # Local facts first (higher trust)
+    for r in local_results:
+        h = md5(content)
+        if h not in seen:
+            seen.add(h)
+            merged.append(r)
+
+    # Hive facts second
+    for r in hive_dicts:
+        h = md5(content)
+        if h not in seen:
+            seen.add(h)
+            merged.append(r)
+
+    return merged[:limit]
+```
+
+No relevance re-ranking after merge. Local facts are always ranked above hive facts
+regardless of relevance. Final list is truncated to `limit`.
+
+### 4.7 search_local — Recursive Storm Prevention
+
+**File:** `cognitive_adapter.py`
+
+When a shard query handler needs to search its own local facts, it calls
+`CognitiveAdapter.search_local()` which:
+
+1. Filters stop words from query
+2. If `DistributedCognitiveMemory`: calls `local_search_facts()` (bypasses hive)
+3. If plain `CognitiveMemory`: calls `search_facts()` directly
+4. If no results: falls back to full scan via `get_all_facts()` or `local_get_all_facts()`
+5. Re-ranks results using n-gram overlap score
+6. Returns top `limit`
+
+---
+
+## 5. Constants & Configuration
+
+**File:** `retrieval_constants.py`
+
+| Constant                       | Value  | Used In                                           |
+| ------------------------------ | ------ | ------------------------------------------------- |
+| `MAX_RETRIEVAL_LIMIT`          | 15,000 | answer_question KB size check, \_simple_retrieval |
+| `SIMPLE_RETRIEVAL_THRESHOLD`   | 500    | Switch to simple retrieval if KB ≤ this           |
+| `VERBATIM_RETRIEVAL_THRESHOLD` | 1,000  | Return all verbatim if KB ≤ this                  |
+| `TIER1_VERBATIM_SIZE`          | 200    | Most recent N facts returned verbatim             |
+| `TIER2_ENTITY_SIZE`            | 1,000  | Entity-level summary tier boundary                |
+| `SEARCH_CANDIDATE_MULTIPLIER`  | 3      | Fetch 3× limit for re-ranking headroom            |
+| `FALLBACK_SCAN_MULTIPLIER`     | 5      | Full-scan fallback fetches 5× limit               |
+
+**Remaining hardcoded values not in constants:**
+
+| Location                  | Value               | What It Is                         |
+| ------------------------- | ------------------- | ---------------------------------- |
+| `orient()`                | `limit=15`          | Memory search limit in orient step |
+| `query_facts()`           | `limit=20`          | Default SHARD_QUERY limit          |
+| `search_by_concept()`     | `limit=30`          | Default concept search limit       |
+| `query_routed()`          | `experts[:3]`       | Top 3 experts for routed queries   |
+| `_select_query_targets()` | `5 * 3 = 15`        | Max agents for fan-out             |
+| Similarity scoring        | `0.5 / 0.2 / 0.3`   | Jaccard weight split               |
+| Position scoring          | `1.0 - rank * 0.01` | Shard response ranking decay       |
+
+---
+
+## 6. Known Problems
+
+### 6.1 OODA Loop Simplified
+
+`process()` skips `orient()`. The rationale is that `answer_question()` does its
+own retrieval. But `orient()` is supposed to provide context-enriched state that
+`decide()` and `act()` use. Skipping it means `decide()` operates on raw input
+only, and the OODA cycle is actually ODA. Single-agent and distributed should
+have the same full OODA loop.
+
+### 6.2 Distributed ≠ Same Retrieval as Single-Agent
+
+In single-agent mode, `get_all_facts(limit=15000)` returns all ~5000 facts.
+`_simple_retrieval` returns them all verbatim. The LLM sees everything.
+
+In distributed mode, 5000 facts are split across 100 agents (~50 each). When
+`get_all_facts(limit=15000, query=question)` is called, it goes through:
+
+```
+DistributedCognitiveMemory.get_all_facts()
+  → _query_hive(query, limit=15000)
+    → query_facts(query, limit=20)       ← DEFAULT limit=20, NOT 15000
+      → SHARD_QUERY to each agent
+        → search_local(query, limit=20)  ← keyword CONTAINS search
+          → n-gram rerank → return 20
+      → position-based scoring
+      → dedup
+      → return top 20
+```
+
+The limit is lost at the hive boundary. 15000 becomes 20. And instead of
+returning all facts, it does a keyword search and returns only matches. This is
+fundamentally different behavior from single-agent.
+
+### 6.3 Keyword Matching Instead of Semantic Retrieval
+
+All retrieval is based on:
+
+- `CONTAINS` keyword matching in Kuzu queries
+- Jaccard coefficient for similarity edges (deterministic, no ML)
+- N-gram overlap for re-ranking
+
+There are no embeddings, no vector search, no LLM-based semantic retrieval.
+The single-agent compensates by dumping all facts (brute force). The distributed
+mode cannot do this and the keyword matching fails silently when the query
+terms don't appear in the fact text.
+
+### 6.4 Storage Is Not Distributed — Facts Are
+
+The design distributes **facts** (each agent has ~50 of 5000 facts in its local
+Kuzu DB). When a query arrives, it fans out SHARD_QUERY events to search each
+agent's local DB.
+
+The intended design is to distribute **storage** while keeping the graph
+interface identical. The graph operations (search, traverse, get_all) should
+produce the same results whether the underlying storage is a single Kuzu
+instance or 100 sharded Kuzu instances. Currently, the distributed path runs
+completely different code (keyword search + fan-out + merge) than the single-
+agent path (full scan).
+
+### 6.5 Silent Fallbacks
+
+- `_query_hive()` catches all exceptions and returns `[]` — hive failures are invisible
+- `search_local()` falls back to full scan if search returns nothing — masks bad queries
+- `__getattr__` proxy silently delegates unknown methods to `_local` — hides interface gaps
+- `_get_all_hive_facts()` catches all exceptions and returns `[]`
+
+### 6.6 Merge Has No Relevance Awareness
+
+`_merge_fact_lists()` puts local facts first and hive facts second, truncated to
+`limit`. There is no relevance scoring across the merged set. A highly relevant
+hive fact will rank below an irrelevant local fact.

--- a/docs/hive_mind/EVAL_COMPONENTS.md
+++ b/docs/hive_mind/EVAL_COMPONENTS.md
@@ -1,0 +1,178 @@
+# How The Eval Stack Fits Together
+
+This page explains the eval system in plain English.
+
+Use it when you understand the command names already but need to know which repo owns which part, how the Azure path works, and where Aspire fits.
+
+## The Short Version
+
+`amplihack-agent-eval` owns the eval harness, datasets, grading, and report packaging.
+
+`amplihack` owns the agent runtime, the Azure deployment assets, the remote adapter wiring, and the Aspire AppHost that orchestrates the scripts locally.
+
+Azure Event Hubs carries the distributed learn and question traffic. Azure Container Apps runs the agent fleet. Aspire is an optional local dashboard and orchestration shell around the existing Python and bash entrypoints.
+
+## The Five-Minute Walkthrough
+
+If you need to explain the stack quickly to another engineer, use this mental model:
+
+1. For local runtime changes, start in `amplihack` and run the thin wrappers in `src/amplihack/eval/`. Those wrappers are convenience shims over `amplihack_eval`, not a second eval framework.
+2. For authoritative local eval runs, switch to `amplihack-agent-eval` and use `amplihack-eval run` or `amplihack-eval compare`. That repo owns question generation, grading, and packaged reports.
+3. For distributed Azure evals, the eval repo still owns the run shape and final report, but it calls the Azure deployment assets from `amplihack`. Event Hubs carries the traffic, and the agents themselves run in Azure Container Apps.
+4. For Aspire, stay in `amplihack` and run the AppHost in `deploy/azure_hive/aspire/`. Aspire is the local orchestration shell around the existing deploy, monitor, and eval scripts. It is not a replacement for the Python eval harness.
+
+## Plain-English Component Diagram
+
+```mermaid
+flowchart TD
+    A[Operator] --> B{Which path?}
+
+    B -->|Local evals| C[amplihack-agent-eval CLI\nor amplihack wrapper]
+    C --> D[Generate dialogue & questions]
+    D --> E[Feed content to adapter]
+    E --> F[Ask questions]
+    F --> G[Grade answers]
+    G --> H[Write reports]
+
+    B -->|Distributed Azure evals| I[amplihack-agent-eval wrapper\nor direct runner]
+    I --> J["Call deploy.sh\n(when deployment needed)"]
+    J --> K[Apply main.bicep & push image]
+    K --> L[Provision Event Hubs\nand start Container Apps fleet]
+    L --> M[Runner publishes learn &\nquestion messages to Event Hubs]
+    M --> N[Running agents in Container Apps\nconsume via remote adapter path]
+    N --> O[Collect correlated answers]
+    O --> P[Grade & write report artifacts]
+
+    B -->|Aspire| Q["apphost.cs\n(deploy/azure_hive/aspire/)"]
+    Q --> R["Launch deploy.sh, eval_monitor.py,\neval_distributed.py as resources"]
+    R --> S[Send OTEL telemetry\nto Aspire dashboard]
+    S --> T[Does not replace\nPython eval harness]
+```
+
+## Who Owns What
+
+| Surface                          | Owning repo            | Why it lives there                                                           |
+| -------------------------------- | ---------------------- | ---------------------------------------------------------------------------- |
+| agent runtime behavior           | `amplihack`            | That is the production runtime under test                                    |
+| Azure deployment shape           | `amplihack`            | The main repo owns `deploy/azure_hive/` and `main.bicep`                     |
+| thin local wrappers              | `amplihack`            | They let runtime changes call into the eval package without leaving the repo |
+| datasets and question generation | `amplihack-agent-eval` | These are eval-framework concerns, not runtime concerns                      |
+| grading and report packaging     | `amplihack-agent-eval` | The eval repo is the authoritative harness and reporting layer               |
+| distributed Azure runner         | `amplihack-agent-eval` | It owns the top-level Event Hubs distributed eval module                     |
+| Aspire AppHost                   | `amplihack`            | It orchestrates the main repo's deploy and monitoring scripts                |
+
+## Why There Are Two Repos
+
+The split keeps the runtime and the eval framework from turning into one inseparable package.
+
+That separation lets you:
+
+- change the agent runtime without rewriting the eval framework
+- change datasets, grading, and report packaging without modifying the runtime repo
+- reuse `amplihack-agent-eval` against adapters other than the main repo's learning agent
+
+The cost is that some flows need both repos checked out at the same time, especially the thin wrappers and the distributed Azure runner.
+
+## How A Local Eval Run Works
+
+For a local wrapper run such as `python -m amplihack.eval.long_horizon_memory`:
+
+1. you run a thin wrapper from `amplihack`
+2. that wrapper imports data types and runner logic from `amplihack_eval`
+3. the adapter talks to the local agent runtime
+4. the eval harness generates dialogue and questions
+5. the grader scores answers and writes the report
+
+The important detail is that the local wrapper is not a second eval framework. It is a convenience layer over the standalone eval package.
+
+## How The Authoritative Local CLI Fits
+
+For `amplihack-eval run` or `amplihack-eval compare`:
+
+1. you run the CLI in `amplihack-agent-eval`
+2. the eval repo chooses the dataset, question slice, seed, and output location
+3. the adapter talks to the runtime under test
+4. grading and packaged report output stay in `amplihack-agent-eval`
+
+That is why the thin wrappers in `amplihack` are useful for runtime iteration, while the eval repo remains the source of truth for the full local CLI surface.
+
+## How A Distributed Azure Run Works
+
+For `./run_distributed_eval.sh` or `python -m amplihack_eval.azure.eval_distributed`:
+
+1. the eval repo decides the run shape: turns, questions, question set, retries, and output location
+2. if deployment is needed, it calls `amplihack/deploy/azure_hive/deploy.sh`
+3. `deploy.sh` applies `main.bicep`, which creates Event Hubs, Container Apps, Log Analytics, and the rest of the Azure fleet
+4. the distributed runner publishes learn and question events into Event Hubs
+5. agents in Container Apps consume those events, process them, and publish answers back to the response hub
+6. the runner correlates answers by event ID, then grades and packages the final report
+
+The eval harness and the report stay centralized in `amplihack-agent-eval`. The runtime and fleet deployment stay centralized in `amplihack`.
+
+## Where Event Hubs Fits
+
+Event Hubs is the transport layer for the distributed path.
+
+The main Bicep template defines three hubs:
+
+- `hive-events-<hive-name>` for learning and question input
+- `hive-shards-<hive-name>` for cross-shard retrieval traffic
+- `eval-responses-<hive-name>` for agent answers and eval progress events
+
+That means the distributed runner does not talk to the agents directly. It talks to Event Hubs, and the fleet consumes and publishes through those hubs.
+
+## Where Container Apps Fits
+
+Container Apps is the execution layer for the distributed path.
+
+The deploy script builds or pushes the agent image, and the Bicep template creates the container apps that run the fleet. Each app can host more than one agent depending on `agentsPerApp`.
+
+So if the question is "where do the agents actually run," the answer is "inside Azure Container Apps, using the image built from the main repo."
+
+## Where Aspire Fits
+
+Aspire is optional and local to the operator workstation.
+
+The AppHost in `deploy/azure_hive/aspire/apphost.cs` does three things:
+
+- starts the existing deploy and eval scripts as named resources
+- wires them into the Aspire dashboard and OTEL output
+- gives you one place to toggle monitor, retrieval-smoke, long-horizon, and security flows with environment variables
+
+Aspire does not replace:
+
+- the eval dataset generator
+- the grader
+- the distributed runner
+- the Azure deployment script
+
+It orchestrates those pieces. That is why the AppHost is small and the heavy logic still lives in Python and bash.
+
+## Why The Aspire AppHost Is In C&#35;
+
+The AppHost is in C# because Aspire's application model is a .NET host built around the `DistributedApplication` builder API.
+
+That does not mean the eval stack became a C# system. The deploy script, monitor, and eval runners are still the existing Python and bash entrypoints. The C# layer is only the orchestration shell that names those resources, wires environment variables, and publishes OTEL telemetry into the Aspire dashboard.
+
+## How Secrets Reach The Distributed Runner
+
+The Event Hubs connection string should move through environment variables, not command-line arguments.
+
+The direct compatibility wrappers in `deploy/azure_hive/` read `EH_CONN`, `AMPLIHACK_EH_INPUT_HUB`, and `AMPLIHACK_EH_RESPONSE_HUB` from the environment, then reconstruct the effective upstream argument list inside the Python process only when the operator did not already provide explicit flags. The Aspire AppHost follows the same pattern for its local monitor and eval executable resources, where it sets `EH_CONN` as an environment variable instead of putting the connection string on the shell command line.
+
+That is why the docs prefer `read -rsp ... EH_CONN` plus `export EH_CONN` over typing `--connection-string ...` in the command you launch. It keeps the secret out of the operator-visible exec-time command line and normal process-list output, even though the compatibility wrapper still rebuilds the effective arguments internally before delegating to the upstream Python entrypoint.
+
+## What To Change When Something Breaks
+
+| If the problem is in...                     | Start in...                                                                                                                                |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| question generation, grading, report output | `amplihack-agent-eval`                                                                                                                     |
+| local thin wrapper behavior                 | `src/amplihack/eval/` in `amplihack`                                                                                                       |
+| Azure deployment topology                   | `deploy/azure_hive/` in `amplihack`                                                                                                        |
+| agent runtime behavior                      | `src/amplihack/agents/` in `amplihack`                                                                                                     |
+| distributed answer transport or correlation | `deploy/azure_hive/remote_agent_adapter.py` and `agent_entrypoint.py` in `amplihack` plus the distributed runner in `amplihack-agent-eval` |
+| Aspire dashboard orchestration              | `deploy/azure_hive/aspire/apphost.cs` in `amplihack`                                                                                       |
+
+## Related Docs
+
+- [Day-zero operator guide](./EVAL_OPERATOR_GUIDE.md)

--- a/docs/hive_mind/EVAL_OPERATOR_GUIDE.md
+++ b/docs/hive_mind/EVAL_OPERATOR_GUIDE.md
@@ -1,0 +1,297 @@
+# Day-Zero Eval Operator Guide
+
+Use this guide when you want the shortest path from a fresh checkout to a working eval command.
+
+This is a how-to guide. It focuses on which repo to run from, which environment variables to set, and which command to use for each kind of eval.
+
+## What To Run From Which Repo
+
+| Goal                                                                   | Repo                   | Command family                                           |
+| ---------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------- |
+| Edit the agent runtime and run the thin local wrappers                 | `amplihack`            | `python -m amplihack.eval.*`                             |
+| Run the authoritative local eval CLI                                   | `amplihack-agent-eval` | `amplihack-eval run`, `amplihack-eval compare`           |
+| Run the distributed Azure runner against an already live hive          | `amplihack`            | `python deploy/azure_hive/eval_distributed.py`           |
+| Deploy Azure and run an end-to-end distributed eval                    | `amplihack-agent-eval` | `./run_distributed_eval.sh`                              |
+| Orchestrate deploy, monitor, or eval scripts with the Aspire dashboard | `amplihack`            | `dotnet run apphost.cs` from `deploy/azure_hive/aspire/` |
+
+## Bootstrap Both Repos
+
+Clone the two repos next to each other so the wrappers can reference sibling source trees.
+
+```bash
+git clone https://github.com/rysweet/amplihack.git
+git clone https://github.com/rysweet/amplihack-agent-eval.git
+```
+
+Create one shared virtual environment in the main repo, then install both repos into it.
+
+```bash
+cd amplihack
+python -m venv .venv
+. .venv/bin/activate
+cargo build            # amplihack-rs is a Rust project; use cargo
+pip install --upgrade pip  # still needed for the Python eval harness
+pip install -e ".[dev]"
+
+cd ../amplihack-agent-eval
+pip install -e ".[all,dev]"
+```
+
+Export the common paths once per shell.
+
+```bash
+export AMPLIHACK_SOURCE_ROOT="$(cd ../amplihack && pwd)"
+export AMPLIHACK_EVAL_SOURCE_ROOT="$(pwd)"
+export PYTHONPATH="${AMPLIHACK_EVAL_SOURCE_ROOT}/src:${AMPLIHACK_SOURCE_ROOT}/src"
+```
+
+## Common Prerequisites
+
+Most eval paths need Anthropic access for grading.
+
+```bash
+read -rsp "Anthropic API key: " ANTHROPIC_API_KEY && echo
+export ANTHROPIC_API_KEY
+```
+
+Azure paths also need Azure CLI auth.
+
+```bash
+az login
+```
+
+## Path 1: Run The Thin Local Wrapper From `amplihack`
+
+Use this when you are editing runtime code in `amplihack` and want to exercise the local wrapper that delegates into `amplihack_eval`.
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}"
+
+python -m amplihack.eval.long_horizon_memory \
+  --turns 100 \
+  --questions 20 \
+  --output-dir /tmp/eval-run
+```
+
+For multi-seed comparison:
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}"
+
+python -m amplihack.eval.long_horizon_multi_seed \
+  --turns 100 \
+  --questions 20 \
+  --seeds 42,123,456,789 \
+  --output-dir /tmp/eval-compare
+```
+
+The thin wrappers in `amplihack` do not currently expose `--question-set`. If you need `standard` versus `holdout`, use the authoritative `amplihack-agent-eval` CLI or the distributed runner paths below.
+
+Use the progressive suite when you want the L1-L12 surface rather than the long-horizon harness.
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}"
+
+python -m amplihack.eval.progressive_test_suite \
+  --output-dir /tmp/eval-progressive \
+  --runs 3 \
+  --grader-votes 3 \
+  --sdk mini
+```
+
+## Path 2: Run The Authoritative Local CLI From `amplihack-agent-eval`
+
+Use this when you want the packaged eval CLI and report tooling rather than the thin wrappers in the main repo.
+
+```bash
+cd "${AMPLIHACK_EVAL_SOURCE_ROOT}"
+
+amplihack-eval run \
+  --turns 100 \
+  --questions 20 \
+  --adapter learning-agent \
+  --question-set standard \
+  --output-dir /tmp/eval-cli-run
+```
+
+Compare multiple seeds or question slices:
+
+```bash
+cd "${AMPLIHACK_EVAL_SOURCE_ROOT}"
+
+amplihack-eval compare \
+  --seeds 42,123,456,789 \
+  --turns 100 \
+  --questions 20 \
+  --question-set holdout \
+  --output-dir /tmp/eval-cli-compare
+```
+
+## Path 3: Deploy Azure And Run The End-To-End Distributed Wrapper
+
+Use this when you want one command that deploys the fleet, runs the distributed eval, and writes packaged artifacts with rerun metadata.
+
+```bash
+cd "${AMPLIHACK_EVAL_SOURCE_ROOT}"
+
+export HIVE_NAME=amplihive
+export HIVE_RESOURCE_GROUP=hive-mind-eval-rg
+export HIVE_LOCATION=eastus
+
+./run_distributed_eval.sh \
+  --agents 100 \
+  --turns 5000 \
+  --questions 50 \
+  --question-set standard
+```
+
+This wrapper:
+
+1. calls `amplihack/deploy/azure_hive/deploy.sh`
+2. looks up the Event Hubs connection string
+3. runs the distributed eval runner against that live hive
+4. writes `eval_report.json`, logs, metadata, and a rerun command bundle
+
+## Path 4: Reuse An Existing Azure Hive
+
+Use this when the fleet is already deployed and you only want another eval run.
+
+```bash
+cd "${AMPLIHACK_EVAL_SOURCE_ROOT}"
+
+export SKIP_DEPLOY=1
+export HIVE_NAME=amplihive3175e
+export HIVE_RESOURCE_GROUP=hive-pr3175-rg
+
+./run_distributed_eval.sh \
+  --agents 100 \
+  --turns 5000 \
+  --questions 50 \
+  --question-set holdout
+```
+
+## Path 5: Run The Distributed Runner Directly
+
+Use this when you already have a live hive and want the lowest-level runner that
+still keeps the Event Hubs secret out of `argv`.
+
+The authoritative implementation still lives in `amplihack-agent-eval`; this
+repo's compatibility wrapper delegates into it while reading `EH_CONN` from the
+environment.
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}"
+
+read -rsp "Event Hubs connection string: " EH_CONN && echo
+export EH_CONN
+export AMPLIHACK_EH_INPUT_HUB="hive-events-amplihive3175e"
+export AMPLIHACK_EH_RESPONSE_HUB="eval-responses-amplihive3175e"
+
+python deploy/azure_hive/eval_distributed.py \
+  --agents 100 \
+  --agents-per-app 5 \
+  --turns 5000 \
+  --questions 50 \
+  --seed 42 \
+  --question-set standard \
+  --parallel-workers 1 \
+  --question-failover-retries 2 \
+  --answer-timeout 0 \
+  --output /tmp/eval_report.json
+
+unset EH_CONN
+unset AMPLIHACK_EH_INPUT_HUB
+unset AMPLIHACK_EH_RESPONSE_HUB
+```
+
+## Path 6: Use Aspire To Orchestrate The Scripts Locally
+
+Use this when you want the Aspire dashboard, OTEL wiring, and a local control surface around the existing Python and bash entrypoints.
+
+The AppHost in this repo is a file-based C# AppHost. Launch it from its own directory:
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}/deploy/azure_hive/aspire"
+dotnet run apphost.cs
+```
+
+### Aspire Deploy-Only Flow
+
+This starts the `azure-hive-deploy` executable resource and sends OTEL telemetry to the Aspire dashboard.
+
+```bash
+export HIVE_NAME=amplihive
+export HIVE_DEPLOYMENT_PROFILE=federated-100
+export HIVE_AGENT_COUNT=100
+export AMPLIHACK_ASPIRE_ENABLE_AZURE_DEPLOY=true
+
+cd "${AMPLIHACK_SOURCE_ROOT}/deploy/azure_hive/aspire"
+dotnet run apphost.cs
+```
+
+### Aspire Monitor And Eval Flow
+
+The monitor and eval resources are only added when the Event Hubs connection string and hub names are set.
+
+```bash
+read -rsp "Event Hubs connection string: " EH_CONN && echo
+export EH_CONN
+export AMPLIHACK_EH_INPUT_HUB="hive-events-amplihive3175e"
+export AMPLIHACK_EH_RESPONSE_HUB="eval-responses-amplihive3175e"
+export HIVE_AGENT_COUNT=100
+
+export AMPLIHACK_ASPIRE_ENABLE_EVAL_MONITOR=true
+export AMPLIHACK_ASPIRE_ENABLE_LONG_HORIZON_EVAL=true
+export AMPLIHACK_ASPIRE_EVAL_TURNS=5000
+export AMPLIHACK_ASPIRE_EVAL_QUESTIONS=50
+
+cd "${AMPLIHACK_SOURCE_ROOT}/deploy/azure_hive/aspire"
+dotnet run apphost.cs
+
+unset EH_CONN
+unset AMPLIHACK_EH_INPUT_HUB
+unset AMPLIHACK_EH_RESPONSE_HUB
+```
+
+### Aspire Security Eval Flow
+
+```bash
+read -rsp "Event Hubs connection string: " EH_CONN && echo
+export EH_CONN
+export AMPLIHACK_EH_INPUT_HUB="hive-events-amplihive3175e"
+export AMPLIHACK_EH_RESPONSE_HUB="eval-responses-amplihive3175e"
+export HIVE_AGENT_COUNT=100
+
+export AMPLIHACK_ASPIRE_ENABLE_SECURITY_EVAL=true
+export AMPLIHACK_ASPIRE_SECURITY_TURNS=300
+export AMPLIHACK_ASPIRE_SECURITY_QUESTIONS=50
+export AMPLIHACK_ASPIRE_SECURITY_CAMPAIGNS=12
+
+cd "${AMPLIHACK_SOURCE_ROOT}/deploy/azure_hive/aspire"
+dotnet run apphost.cs
+
+unset EH_CONN
+unset AMPLIHACK_EH_INPUT_HUB
+unset AMPLIHACK_EH_RESPONSE_HUB
+```
+
+## Outputs To Expect
+
+| Path                                              | Typical output                                                       |
+| ------------------------------------------------- | -------------------------------------------------------------------- |
+| `python -m amplihack.eval.progressive_test_suite` | `summary.json` plus per-level score files                            |
+| `python -m amplihack.eval.long_horizon_memory`    | `eval_report.json`-style report output                               |
+| `amplihack-eval run` or `compare`                 | report directories under your chosen `--output-dir`                  |
+| `./run_distributed_eval.sh`                       | `/tmp/eval-results-*` with report, metadata, logs, and rerun command |
+| Aspire monitor                                    | `aspire_eval_monitor_progress.json` unless overridden                |
+
+## Common Operator Mistakes
+
+- Running the local wrappers with only `PYTHONPATH=src`, which can import a globally installed `amplihack_eval` instead of the sibling checkout you are editing
+- Running the direct Azure runner without the sibling `amplihack` checkout available on `PYTHONPATH`
+- Expecting the Aspire AppHost to create monitor or eval resources without `EH_CONN`, `AMPLIHACK_EH_INPUT_HUB`, and `AMPLIHACK_EH_RESPONSE_HUB`
+- Treating Aspire as a replacement for the Python eval harness; it is an orchestration layer around the existing scripts
+
+## Related Docs
+
+- [How the eval stack fits together](./EVAL_COMPONENTS.md)

--- a/docs/hive_mind/MESSAGING_TRANSPORT_INVESTIGATION.md
+++ b/docs/hive_mind/MESSAGING_TRANSPORT_INVESTIGATION.md
@@ -1,0 +1,387 @@
+# Messaging Transport Investigation: Hive Mind Distributed Architecture
+
+**Branch:** `feat/distributed-hive-mind`
+**Date:** 2026-03-07
+**Status:** Complete
+
+---
+
+## Executive Summary
+
+This document captures research and recommendations for the messaging transport layer of the distributed hive mind architecture. After analyzing the existing codebase, comparing Azure Event Hubs vs Service Bus, evaluating abstraction libraries (Dapr, CloudEvents), and verifying the provisioned Azure infrastructure, the **recommendation is:**
+
+- **Primary transport: Azure Service Bus Premium** (already provisioned; already used in codebase)
+- **Abstraction layer: Dapr pub/sub** (optional, for future cloud-portability)
+- **Event schema: CloudEvents v1.0** (via Dapr automatically, or manually via `BusEvent.to_json()`)
+- **Secondary transport: Azure Event Hubs** (for telemetry streams and broadcast replay)
+
+---
+
+## 1. Existing Transport Layer in Haymaker Repo
+
+### Architecture Overview
+
+The distributed hive mind already has a **transport-agnostic event bus** in place with three backend implementations:
+
+| Backend                   | File                                                       | Use Case                |
+| ------------------------- | ---------------------------------------------------------- | ----------------------- |
+| `LocalEventBus`           | `src/amplihack/agents/goal_seeking/hive_mind/event_bus.py` | Testing, single-machine |
+| `AzureServiceBusEventBus` | same                                                       | Production on Azure     |
+| `RedisEventBus`           | same                                                       | Low-latency dev/staging |
+
+**Factory function:**
+
+```python
+from amplihack.agents.goal_seeking.hive_mind.event_bus import create_event_bus
+
+bus = create_event_bus(
+    backend="azure",          # "local" | "azure" | "redis"
+    connection_string="...",  # Service Bus conn str
+    topic_name="hive-graph",  # Default topic
+)
+```
+
+### Core Abstractions
+
+**`BusEvent` (immutable data model):**
+
+```python
+@dataclass(frozen=True)
+class BusEvent:
+    event_id: str       # UUID4 hex
+    event_type: str     # FACT_LEARNED, QUERY, SEARCH_QUERY, etc.
+    source_agent: str   # Originating agent ID
+    timestamp: float    # Unix epoch
+    payload: dict       # Event-specific data
+```
+
+**`EventBus` Protocol (transport interface):**
+
+```python
+class EventBus(Protocol):
+    def publish(self, event: BusEvent) -> None: ...
+    def subscribe(self, agent_id: str, event_types: list[str] | None = None) -> None: ...
+    def unsubscribe(self, agent_id: str) -> None: ...
+    def poll(self, agent_id: str) -> list[BusEvent]: ...
+    def close(self) -> None: ...
+```
+
+### Service Bus Implementation Details
+
+The `AzureServiceBusEventBus` backend uses:
+
+- **Topic:** `hive-graph` (configurable via `topic_name` kwarg)
+- **Per-agent subscriptions:** `agent-{i}` — one subscription per agent
+- **SQL filter rules:** Server-side filtering by `event_type` on each subscription
+- **Dead-lettering:** Malformed messages are automatically dead-lettered
+- **Peek-lock:** Messages locked during processing (5s max wait per poll)
+- **Message completion:** Automatic after successful deserialization
+- **Tier used:** **Premium** (1 capacity unit) per `main.bicep`
+
+### Transport Configuration
+
+Transport is selected via environment variables (or explicit kwargs):
+
+```bash
+AMPLIHACK_MEMORY_TRANSPORT=azure_service_bus       # "local" | "redis" | "azure_service_bus"
+AMPLIHACK_MEMORY_CONNECTION_STRING=Endpoint=sb://...
+AMPLIHACK_MEMORY_TOPOLOGY=distributed
+AMPLIHACK_MEMORY_BACKEND=cognitive
+```
+
+### Event Types Published
+
+| Event Type                      | Direction | Purpose                               |
+| ------------------------------- | --------- | ------------------------------------- |
+| `network_graph.create_node`     | broadcast | Replicate node creation to all agents |
+| `network_graph.create_edge`     | broadcast | Replicate edge creation to all agents |
+| `network_graph.search_query`    | fan-out   | Request knowledge from peer agents    |
+| `network_graph.search_response` | reply     | Return search results to requester    |
+| `QUERY`                         | fan-out   | Ask hive a question (OODA loop)       |
+| `QUERY_RESPONSE`                | reply     | Answer hive query                     |
+| `LEARN_CONTENT`                 | broadcast | Notify agents of new learned content  |
+
+### Transport Layer File Map
+
+```
+src/amplihack/agents/goal_seeking/hive_mind/
+├── event_bus.py              # EventBus protocol + 3 backend implementations
+├── distributed_hive_graph.py # DHT-sharded hive graph (local bus only)
+├── hive_graph.py             # HiveGraph protocol (abstract)
+├── dht.py                    # Consistent hashing (HashRing, DHTRouter)
+├── gossip.py                 # Bloom-filter gossip for convergence
+└── controller.py             # Multi-hive orchestration
+
+src/amplihack/memory/
+├── network_store.py          # NetworkGraphStore: wraps GraphStore + event bus
+├── facade.py                 # Memory: high-level API used by OODA loop
+└── config.py                 # MemoryConfig: transport selection + env vars
+
+deploy/azure_hive/
+├── main.bicep                # IaC: Service Bus Premium + Container Apps
+└── agent_entrypoint.py       # OODA loop: observe/orient (events) + act
+```
+
+---
+
+## 2. Event Hubs vs Service Bus: Comparison
+
+### Feature Matrix
+
+| Feature                 | Azure Event Hubs                                              | Azure Service Bus                                |
+| ----------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| **Model**               | Append-only log (Kafka-like)                                  | Message broker (AMQP)                            |
+| **Fan-out / Broadcast** | Excellent — consumer groups read independently                | Via topics + subscriptions (up to 2,000 subs)    |
+| **Competing consumers** | Complex — requires partition coordination                     | Native — queue peek-lock                         |
+| **Message replay**      | Yes — rewind to any offset in retention window                | No — messages deleted on consumption             |
+| **Ordering guarantee**  | Per-partition FIFO only                                       | Per-session FIFO (sessions), else best-effort    |
+| **Dead-letter queue**   | Not native — must implement in app code                       | Built-in DLQ on every queue and subscription     |
+| **Request/Reply (RPC)** | Not supported                                                 | Native — `ReplyTo` + `ReplyToSessionId`          |
+| **Per-message routing** | No server-side filter rules                                   | SQL filter rules on subscriptions                |
+| **Duplicate detection** | None at service layer                                         | Configurable window per entity                   |
+| **Transactions**        | None                                                          | Multi-entity atomic transactions                 |
+| **Message size**        | Up to 1 MB (Standard), higher on Premium                      | 256 KB (Standard), up to 100 MB (Premium)        |
+| **Throughput ceiling**  | Millions/sec (horizontal via partitions)                      | High but not extreme — reliability first         |
+| **Retention**           | 1–7 days (Standard), up to 90 days (Premium)                  | Until consumed or TTL expires                    |
+| **Pricing (base)**      | Throughput Units / Processing Units                           | Per operation (Standard) or per MU-day (Premium) |
+| **Dapr support**        | `pubsub.azure.eventhubs` (needs Blob Storage for checkpoints) | `pubsub.azure.servicebus.topics` (first-class)   |
+
+### Pattern Suitability for Hive Mind
+
+| Communication Pattern                          | Hive Mind Use                  | Best Fit                                               |
+| ---------------------------------------------- | ------------------------------ | ------------------------------------------------------ |
+| Fan-out: broadcast LEARN_CONTENT to all agents | All agents receive new facts   | **Event Hubs** (consumer groups) or Service Bus topics |
+| Fan-out search query to peer agents            | `network_graph.search_query`   | Service Bus topics + filter subs                       |
+| Request/reply: `QUERY` → `QUERY_RESPONSE`      | Agent asks hive a question     | **Service Bus** sessions                               |
+| Competing-consumer task dispatch               | Agent pool picks up work items | **Service Bus** queues                                 |
+| Dead-letter poisoned events                    | Malformed `BusEvent`           | **Service Bus** built-in DLQ                           |
+| Replay for new agent types bootstrapping       | New agent reads full history   | **Event Hubs**                                         |
+| Telemetry / observability streams              | High-volume agent logs/metrics | **Event Hubs**                                         |
+| Ordered multi-step task chains                 | OODA tick ordering per agent   | **Service Bus** sessions                               |
+
+### Recommendation
+
+**Service Bus is the primary transport for inter-agent coordination.** It directly supports the hive mind's key patterns: fan-out search queries, request/reply queries, dead-lettering, and per-subscription SQL filters. The existing code already implements this correctly.
+
+**Event Hubs should be used as a secondary stream** for telemetry, observability, and enabling new agent types to replay history. It is not a replacement for Service Bus in the hive mind's messaging patterns.
+
+---
+
+## 3. Abstraction Library Evaluation
+
+### 3.1 Dapr Pub/Sub
+
+**What it is:** A CNCF-graduated distributed runtime that abstracts messaging behind a sidecar HTTP/gRPC API. Applications call `localhost:3500/publish`; the sidecar handles the actual broker interaction.
+
+**Dapr pub/sub with Service Bus:**
+
+```yaml
+# dapr/components/pubsub.yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: hive-pubsub
+spec:
+  type: pubsub.azure.servicebus.topics
+  version: v1
+  metadata:
+    - name: connectionString
+      secretKeyRef:
+        name: sb-secret
+        key: connectionString
+```
+
+**Agent code (before Dapr):**
+
+```python
+# Direct Azure SDK
+sender = ServiceBusSender(conn_str, topic_name="hive-graph")
+sender.send_messages(ServiceBusMessage(json.dumps(event.to_dict())))
+```
+
+**Agent code (after Dapr):**
+
+```python
+# Dapr sidecar — no Azure SDK
+import httpx
+httpx.post("http://localhost:3500/v1.0/publish/hive-pubsub/hive-graph",
+           json=event.to_dict())
+```
+
+**Pros:**
+
+- Transport portability: swap Service Bus for Kafka/Redis/RabbitMQ by changing one YAML
+- Built-in at-least-once delivery regardless of backend capabilities
+- Dead-letter topics managed by Dapr uniformly
+- CloudEvents 1.0 envelope added automatically
+- **Dapr Agents** (March 2025): virtual actor model purpose-built for multi-agent coordination
+- Built-in distributed tracing (OpenTelemetry), metrics, and service-to-service encryption
+
+**Cons:**
+
+- Sidecar overhead: each agent pod needs a sidecar (adds ~50–200 MB RAM per agent)
+- Local development requires `dapr run` or Docker Compose
+- Dapr Agents is new (announced March 2025); production maturity is still evolving
+- Adds operational surface: Dapr control plane (operator, sentry, placement) on Kubernetes
+- The existing `EventBus` protocol already provides the same abstraction at the Python level
+
+**Verdict:** Dapr is **recommended for future adoption** when the hive mind needs cloud-portability or Kubernetes-native deployment at scale. For the current Container Apps deployment backed by Service Bus, the existing `EventBus` protocol provides equivalent abstraction with no sidecar overhead. Migrate to Dapr when multi-cloud or on-prem portability becomes a requirement, or when adopting the Dapr Agents framework for actor-based state management.
+
+### 3.2 CloudEvents Specification
+
+**What it is:** A CNCF-graduated specification (v1.0, graduated January 2024) that standardizes the event envelope schema. It is **not** a transport or delivery system — purely a schema contract.
+
+**Required CloudEvents fields:**
+
+```json
+{
+  "specversion": "1.0",
+  "id": "abc123",
+  "source": "/agents/agent-0",
+  "type": "com.amplihack.hive.fact_learned",
+  "time": "2026-03-07T10:00:00Z",
+  "datacontenttype": "application/json",
+  "data": { ... }
+}
+```
+
+**Relationship to existing `BusEvent`:**
+
+```python
+# Current BusEvent fields
+@dataclass(frozen=True)
+class BusEvent:
+    event_id: str       # → CloudEvents "id"
+    event_type: str     # → CloudEvents "type"
+    source_agent: str   # → CloudEvents "source"
+    timestamp: float    # → CloudEvents "time"
+    payload: dict       # → CloudEvents "data"
+```
+
+`BusEvent` is structurally equivalent to a CloudEvents envelope. Adopting CloudEvents would require adding `specversion: "1.0"` and a URI `source` format — a minimal change.
+
+**Azure support:**
+
+- Service Bus: CloudEvents payloads supported natively (message body is schema-agnostic)
+- Event Hubs: CloudEvents supported via Kafka protocol binding
+- Event Grid: Native CloudEvents v1.0 as both input and output schema
+
+**Dapr relationship:** Dapr automatically wraps all pub/sub messages in CloudEvents 1.0 format. Using Dapr means CloudEvents adoption is automatic.
+
+**Verdict:** CloudEvents is **recommended as the standard event envelope** for all hive mind inter-agent messages. The migration from current `BusEvent` is minimal (add `specversion`, normalize `source` to a URI). If Dapr is adopted, CloudEvents compliance comes for free. If staying with the direct Service Bus SDK, add a CloudEvents serializer wrapper around `BusEvent.to_json()`.
+
+### 3.3 Abstraction Comparison
+
+| Dimension                | Dapr                     | CloudEvents                     | Existing EventBus Protocol |
+| ------------------------ | ------------------------ | ------------------------------- | -------------------------- |
+| **What it abstracts**    | Transport (which broker) | Schema (envelope format)        | Transport (which broker)   |
+| **Language**             | Any (HTTP/gRPC sidecar)  | Any (JSON/binary spec)          | Python only                |
+| **Overhead**             | Sidecar process per pod  | Zero (schema contract only)     | Zero                       |
+| **Lock-in reduction**    | Full broker portability  | Interoperability across systems | Python-level portability   |
+| **Production readiness** | High (CNCF graduated)    | High (CNCF graduated)           | Medium (internal only)     |
+| **Already in use**       | No                       | No (but BusEvent is compatible) | Yes                        |
+
+---
+
+## 4. Provisioned Azure Infrastructure
+
+### Premium Service Bus Namespace
+
+A Premium Service Bus namespace is provisioned and active for the hive mind deployment:
+
+| Property           | Value                                                            |
+| ------------------ | ---------------------------------------------------------------- |
+| **Namespace name** | `hive-sb-prem-dj2qo2w7vu5zi`                                     |
+| **Resource group** | `hive-mind-rg`                                                   |
+| **Location**       | East US                                                          |
+| **SKU**            | Premium                                                          |
+| **Capacity**       | 1 Messaging Unit                                                 |
+| **Status**         | Active                                                           |
+| **Endpoint**       | `https://hive-sb-prem-dj2qo2w7vu5zi.servicebus.windows.net:443/` |
+
+This namespace is provisioned via `deploy/azure_hive/main.bicep` and matches the `AzureServiceBusEventBus` backend configuration in the code.
+
+**Why Premium tier:**
+
+- Dedicated resources (no noisy neighbors)
+- Message size up to 100 MB (vs 256 KB on Standard)
+- VNet integration for network isolation
+- Flat pricing per messaging unit (predictable cost at scale)
+- Required for production Container Apps deployment
+
+### Existing Standard Namespace (staging/dev)
+
+| Property           | Value                   |
+| ------------------ | ----------------------- |
+| **Namespace name** | `hive-sb-dj2qo2w7vu5zi` |
+| **Resource group** | `hive-mind-rg`          |
+| **Location**       | West US 2               |
+| **SKU**            | Standard                |
+| **Use**            | Development / staging   |
+
+---
+
+## 5. Recommendations Summary
+
+### Immediate (current state is good)
+
+1. **Keep Service Bus Premium as primary transport** — the existing `AzureServiceBusEventBus` implementation is correct and well-designed. No changes needed.
+
+2. **Keep the `EventBus` protocol** — the three-backend design (`local`/`redis`/`azure`) provides the right abstraction for testing and production without sidecar overhead.
+
+3. **Adopt CloudEvents schema for `BusEvent`** — add `specversion: "1.0"` and normalize `source_agent` to a URI (e.g., `/agents/{agent_id}`) in `BusEvent.to_json()`. This enables interoperability with Event Grid, external consumers, and future Dapr migration.
+
+### Near-term
+
+4. **Add Event Hubs for telemetry** — route agent metrics, OODA tick counts, and memory stats to an Event Hubs namespace for stream analytics and dashboarding via Azure Monitor / Stream Analytics.
+
+5. **Evaluate Dapr Agents** — once Dapr Agents (March 2025) reaches GA stability, evaluate replacing the `NetworkGraphStore` background thread model with Dapr virtual actors. This would give durable state, retry, and multi-agent workflow orchestration.
+
+### Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Azure Container Apps (hive mind agents)                            │
+│                                                                     │
+│  ┌───────────┐   ┌───────────┐   ┌───────────┐   ┌───────────┐    │
+│  │  Agent-0  │   │  Agent-1  │   │  Agent-2  │   │  Agent-N  │    │
+│  │  OODA     │   │  OODA     │   │  OODA     │   │  OODA     │    │
+│  │  Memory   │   │  Memory   │   │  Memory   │   │  Memory   │    │
+│  └─────┬─────┘   └─────┬─────┘   └─────┬─────┘   └─────┬─────┘   │
+│        │               │               │               │           │
+│  ┌─────▼───────────────▼───────────────▼───────────────▼─────┐    │
+│  │              AzureServiceBusEventBus                       │    │
+│  │  (EventBus Protocol → Topic: hive-graph)                   │    │
+│  └─────────────────────────┬───────────────────────────────────┘   │
+└────────────────────────────│────────────────────────────────────────┘
+                             │ AMQP / Service Bus SDK
+┌────────────────────────────▼────────────────────────────────────────┐
+│  Azure Service Bus Premium  (hive-sb-prem-dj2qo2w7vu5zi, eastus)   │
+│                                                                      │
+│  Topic: hive-graph                                                   │
+│  ├── Subscription: agent-0  [SQL filter: eventtype IN (...)]        │
+│  ├── Subscription: agent-1  [SQL filter: eventtype IN (...)]        │
+│  ├── ...                                                             │
+│  └── Dead-letter queue (auto): malformed events                     │
+└──────────────────────────────────────────────────────────────────────┘
+                                                         ▲
+                     Future: CloudEvents envelope        │
+                     Future: Dapr sidecar abstraction   │
+                     Future: Event Hubs telemetry sidecar
+```
+
+---
+
+## 6. References
+
+- [Azure Service Bus vs Event Hubs - Microsoft Learn](https://learn.microsoft.com/en-us/azure/service-bus-messaging/compare-messaging-services)
+- [Service Bus Premium tier - Microsoft Learn](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging)
+- [Event Hubs features and tiers - Microsoft Learn](https://learn.microsoft.com/en-us/azure/event-hubs/compare-tiers)
+- [Dapr pub/sub overview - Dapr Docs](https://docs.dapr.io/developing-applications/building-blocks/pubsub/pubsub-overview/)
+- [Dapr AI Agents announcement - CNCF (March 2025)](https://www.cncf.io/blog/2025/03/12/announcing-dapr-ai-agents/)
+- [CloudEvents v1.0 specification - GitHub](https://github.com/cloudevents/spec)
+- Hive Mind Architecture (see upstream `amplihack` repository)
+- Hive Mind Design (see upstream `amplihack` repository)
+- Transport layer code: `src/amplihack/agents/goal_seeking/hive_mind/event_bus.py`
+- Network store: `src/amplihack/memory/network_store.py`
+- Azure IaC: `deploy/azure_hive/main.bicep`

--- a/docs/hive_mind/MODULE_CREATION_GUIDE.md
+++ b/docs/hive_mind/MODULE_CREATION_GUIDE.md
@@ -1,0 +1,247 @@
+# Module Creation Guide: How the HiveMindOrchestrator Was Built
+
+This document explains the process used to identify the architectural gap and implement
+`hive_mind/orchestrator.py` as a functional brick. Use it as a template when creating
+future modules for the `feat/distributed-hive-mind` branch or any part of amplihack.
+
+---
+
+## 1. Identifying the Gap
+
+### Method: Read the Architecture First
+
+Before writing a single line of code, read:
+
+1. **`DESIGN.md`** — the authoritative description of the intended system
+2. **`__init__.py`** — what is already exported (the "studs" on existing bricks)
+3. **All module headers** — the "Public API" section in each file's docstring
+
+In `DESIGN.md`, the four-layer architecture was described:
+
+```
+Layer 1: HiveGraph (storage)
+Layer 2: EventBus (transport)
+Layer 3: Gossip (discovery)
+Layer 4: Query deduplication
+```
+
+And an experimental result claimed **94% accuracy with a unified approach** vs. 47-57% for individual
+layers. But no class in the codebase stitched those four layers together.
+
+### Checklist for Gap Identification
+
+- [ ] Does `DESIGN.md` describe a class or role that no file implements?
+- [ ] Does any module comment reference something as "TODO" or describe something "delegated" elsewhere?
+- [ ] Is there a `_promote_to_hive()` that does a direct call with no policy or routing decision?
+- [ ] Does `__init__.py.__all__` list concepts that don't correspond to any file?
+
+In this case: `cognitive_adapter._promote_to_hive()` called `hive.promote_fact()` directly —
+hardcoded single-layer behavior with no policy, no event bus involvement, no gossip.
+That was the architectural seam where the missing module belonged.
+
+---
+
+## 2. Defining the Module's Single Responsibility
+
+The Bricks and Studs philosophy requires **one class, one job**. Before writing the class,
+write one sentence:
+
+> `HiveMindOrchestrator` routes fact operations through the appropriate architectural layer
+> based on a configurable policy.
+
+Everything in the module either:
+
+- **Fulfills** that responsibility, or
+- **Is removed**
+
+To make the single responsibility concrete, answer these three questions:
+
+| Question                           | Answer                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------ |
+| What does this module **take in**? | A fact (concept + content + confidence) or a query                             |
+| What does this module **produce**? | A result dict (promoted, event_published, gossip_triggered) or a list of facts |
+| What does this module **NOT do**?  | Store facts itself, own the event bus, run background threads                  |
+
+---
+
+## 3. Designing the Interface (the "Studs")
+
+Studs are what other bricks connect to. Design them before implementing anything.
+
+### Start with the Protocol
+
+If your module makes decisions based on external rules, extract those rules into a `Protocol`:
+
+```python
+@runtime_checkable
+class PromotionPolicy(Protocol):
+    def should_promote(self, fact: HiveFact, source_agent: str) -> bool: ...
+    def should_gossip(self, fact: HiveFact, source_agent: str) -> bool: ...
+    def should_broadcast(self, fact: HiveFact, source_agent: str) -> bool: ...
+```
+
+Then provide a `Default*` dataclass implementation using constants from `constants.py` —
+no magic numbers in the module itself.
+
+### Design the Return Dicts
+
+Every method returns a dict with named keys, not a naked bool or tuple:
+
+```python
+# Good: caller knows what happened at each layer
+{"fact_id": "hf_abc", "promoted": True, "event_published": True, "gossip_triggered": False}
+
+# Bad: caller loses context
+True
+```
+
+This pattern appears throughout the codebase (see `distributed.py`, `controller.py`).
+
+---
+
+## 4. Implementing (No Stubs)
+
+A "stub" is any function that:
+
+- Returns a hardcoded value (`return {}`)
+- Has only `...` in the body
+- Raises `NotImplementedError`
+
+Every method must do real work. For `store_and_promote`:
+
+```python
+def store_and_promote(self, concept, content, confidence, tags=None):
+    # Build the fact
+    fact = HiveFact(...)
+
+    # Layer 1: promote if policy allows
+    if self._policy.should_promote(fact, self._agent_id):
+        fact_id = self._hive_graph.promote_fact(self._agent_id, fact)
+        promoted = True
+
+    # Layer 2: publish event if promoted
+    if promoted:
+        self._event_bus.publish(make_event("FACT_PROMOTED", ...))
+
+    # Layer 3: gossip if policy allows and peers exist
+    if _HAS_GOSSIP and self._peers and self._policy.should_gossip(fact, ...):
+        _run_gossip_round(self._hive_graph, self._peers, self._gossip_protocol)
+
+    return {"fact_id": ..., "promoted": ..., "event_published": ..., "gossip_triggered": ...}
+```
+
+### Graceful Degradation Pattern
+
+Use `try/except ImportError` at module level for optional dependencies:
+
+```python
+try:
+    from .gossip import GossipProtocol, run_gossip_round as _run_gossip_round
+    _HAS_GOSSIP = True
+except ImportError:
+    _HAS_GOSSIP = False
+```
+
+Then guard usage: `if _HAS_GOSSIP and ...`.
+This pattern appears in every module in `hive_mind/`.
+
+---
+
+## 5. Wiring Into Existing Interfaces
+
+The orchestrator connects to three existing interfaces:
+
+| Interface                  | How It Connects                                                       |
+| -------------------------- | --------------------------------------------------------------------- |
+| `HiveGraph` (Layer 1)      | `hive_graph.promote_fact()` and `query_facts()` / `query_federated()` |
+| `EventBus` (Layer 2)       | `event_bus.publish()`, `event_bus.poll()`, `event_bus.unsubscribe()`  |
+| `GossipProtocol` (Layer 3) | `run_gossip_round(hive_graph, peers, protocol)`                       |
+
+The orchestrator is injected with these at construction time — it does not create them.
+This is the **dependency injection** pattern: let callers compose the system.
+
+### Integration with CognitiveAdapter
+
+The existing `cognitive_adapter._promote_to_hive()` still calls `hive.promote_fact()` directly.
+To fully integrate the orchestrator, a caller can pass the orchestrator as the `hive_store`:
+
+```python
+# The orchestrator satisfies the duck-typed promote_fact interface
+adapter = CognitiveAdapter(
+    agent_name="agent_a",
+    hive_store=orchestrator._hive_graph,  # or extend to inject orchestrator directly
+)
+```
+
+Full CognitiveAdapter integration is a future enhancement tracked in DESIGN.md.
+
+---
+
+## 6. Writing the `__init__.py` Export
+
+Always add new exports to `__init__.py` with a graceful try/except:
+
+```python
+try:
+    from .orchestrator import (
+        DefaultPromotionPolicy,
+        HiveMindOrchestrator,
+        PromotionPolicy,
+    )
+    __all__ += [
+        "DefaultPromotionPolicy",
+        "HiveMindOrchestrator",
+        "PromotionPolicy",
+    ]
+except ImportError:
+    _logger.debug("orchestrator module not available")
+```
+
+This keeps the package importable even if an optional dependency is missing.
+
+---
+
+## 7. Writing the Tests
+
+Tests should validate **the contract, not the implementation**:
+
+| Test category        | What to test                                            |
+| -------------------- | ------------------------------------------------------- |
+| Protocol compliance  | `isinstance(DefaultPromotionPolicy(), PromotionPolicy)` |
+| Happy path           | High-confidence fact is promoted, event published       |
+| Negative path        | Low-confidence fact is not promoted, no event           |
+| Edge cases           | Confidence clamping, duplicate content deduplication    |
+| Graceful degradation | No peers → gossip skipped with reason                   |
+| Lifecycle            | `close()` does not raise, is idempotent                 |
+
+Use pytest fixtures for repeated setup. Never test internal `_` attributes.
+
+---
+
+## 8. Summary: The Pattern for Future Modules
+
+```
+1. Read DESIGN.md + existing __init__.py.__all__
+2. Find the seam: something described but not implemented
+3. Write ONE responsibility sentence
+4. Design the Protocol (if pluggable rules exist)
+5. Design the return types (dicts with named keys)
+6. Implement with graceful ImportError guards for optional deps
+7. Wire to existing interfaces via constructor injection
+8. Export from __init__.py with try/except
+9. Write contract tests (29+ passing)
+10. Document here
+```
+
+The key invariant: **a brick should be self-contained, regeneratable, and minimal**.
+If you can't delete the module and recreate it from its interface alone, it's not a proper brick.
+
+---
+
+## Files Created
+
+| File                                                          | Purpose                     |
+| ------------------------------------------------------------- | --------------------------- |
+| `src/amplihack/agents/goal_seeking/hive_mind/orchestrator.py` | The new module              |
+| `tests/hive_mind/test_orchestrator.py`                        | Contract tests (29 passing) |
+| `docs/hive_mind/MODULE_CREATION_GUIDE.md`                     | This document               |

--- a/docs/hive_mind/current-validation-results.md
+++ b/docs/hive_mind/current-validation-results.md
@@ -1,0 +1,124 @@
+# Current Validation Results
+
+This page records the current verified validation snapshot for the distributed hive work and the commands used to reproduce it.
+
+## Accepted Azure Distributed Eval Results
+
+These are the currently accepted full Azure runs for the live `amplihive3175e` path after the final code change that fixed the late infrastructure relation follow-up issue.
+
+| Run | Score    |
+| --- | -------- |
+| 1   | `98.20%` |
+| 2   | `98.80%` |
+| 3   | `98.23%` |
+
+Key blocker questions that stayed fixed across the accepted set:
+
+- `Q11 = 1.00`
+- `Q12 = 1.00`
+- `Q13 = 1.00`
+- `Q40 = 1.00`
+- `Q48 = 1.00`
+- `Q49 = 1.00`
+- `Q50 = 1.00`
+
+Accepted image tag:
+
+- `q49-infrastructure-relation-followup-20260322T064641Z`
+
+## Current Local Validation Slices
+
+### Main `amplihack` repo
+
+Current wrapper-validation result:
+
+- `64 passed`
+- `ruff check` passed for the touched wrapper files
+
+Reproduction command:
+
+```bash
+cd /path/to/amplihack
+
+PYTHONPATH=/path/to/amplihack-agent-eval/src:/path/to/amplihack/src \
+.venv/bin/python -m pytest -q tests/eval/test_long_horizon_memory.py
+
+.venv/bin/ruff check \
+  src/amplihack/eval/long_horizon_memory.py \
+  src/amplihack/eval/long_horizon_multi_seed.py \
+  tests/eval/test_long_horizon_memory.py
+```
+
+### `amplihack-agent-eval` repo
+
+Current source-accurate validation result:
+
+- `42 passed, 1 warning`
+- `ruff check` passed for the touched eval files
+- `bash -n run_distributed_eval.sh` passed
+
+Reproduction command:
+
+```bash
+cd /path/to/amplihack-agent-eval
+
+uv run --with pytest --with ruff python -m pytest -q \
+  tests/test_data_generation.py \
+  tests/test_datasets.py
+
+uv run --with ruff ruff check \
+  src/amplihack_eval/data/long_horizon.py \
+  src/amplihack_eval/core/runner.py \
+  src/amplihack_eval/core/multi_seed.py \
+  src/amplihack_eval/cli.py \
+  src/amplihack_eval/azure/eval_distributed.py \
+  tests/test_data_generation.py \
+  tests/test_datasets.py
+
+bash -n run_distributed_eval.sh
+```
+
+### Why the eval repo reproduction uses `uv run`
+
+In this checkout, running the same CLI integration slice through `.venv/bin/python -m pytest` can pick up a stale installed `amplihack-eval` console script and fail the `--question-set` help assertion even though the source checkout is correct.
+
+Use `uv run` for a source-accurate reproduction, or reinstall the repo in editable mode before relying on the `amplihack-eval` console script.
+
+## How to Reproduce the Accepted Azure Path
+
+### Full clean rerun from source
+
+Run from the eval repo and let the wrapper redeploy current code:
+
+```bash
+cd /path/to/amplihack-agent-eval
+
+export ANTHROPIC_API_KEY=...
+export AMPLIHACK_SOURCE_ROOT=/path/to/amplihack
+
+./run_distributed_eval.sh \
+  --agents 100 \
+  --turns 5000 \
+  --questions 50 \
+  --question-set standard
+```
+
+### Reuse an already deployed hive
+
+```bash
+cd /path/to/amplihack-agent-eval
+
+export ANTHROPIC_API_KEY=...
+export AMPLIHACK_SOURCE_ROOT=/path/to/amplihack
+export SKIP_DEPLOY=1
+export HIVE_NAME=amplihive3175e
+export HIVE_RESOURCE_GROUP=hive-pr3175-rg
+
+./run_distributed_eval.sh \
+  --agents 100 \
+  --turns 5000 \
+  --questions 50 \
+  --question-set standard
+```
+
+If you need to reproduce the exact accepted image rather than the latest source tree, redeploy the same image tag before launching the wrapper.

--- a/docs/memory/5-TYPE-MEMORY-DEVELOPER.md
+++ b/docs/memory/5-TYPE-MEMORY-DEVELOPER.md
@@ -1,0 +1,9 @@
+# 5-Type Memory Developer Guide (Superseded)
+
+This older developer guide has been retired in favor of the current memory docs.
+
+Use these docs instead:
+
+- [Memory-enabled agents architecture](../concepts/agent-memory-architecture.md)
+- [How to integrate memory into agents](../howto/integrate-agent-memory.md)
+- Memory CLI reference

--- a/docs/memory/5-TYPE-MEMORY-QUICKREF.md
+++ b/docs/memory/5-TYPE-MEMORY-QUICKREF.md
@@ -1,0 +1,9 @@
+# 5-Type Memory Quick Reference (Superseded)
+
+This quick reference has been retired.
+
+Use these docs instead:
+
+- Agent Memory Quickstart
+- [Memory-enabled agents architecture](../concepts/agent-memory-architecture.md)
+- Memory CLI reference

--- a/docs/memory/AUTO_LINKING.md
+++ b/docs/memory/AUTO_LINKING.md
@@ -1,0 +1,278 @@
+# Automated Memory-Code Linking
+
+**Status**: ✅ Implemented (Week 3)
+
+## Overview
+
+The Kuzu memory backend automatically links memories to relevant code entities (files and functions) when memories are stored. This creates a rich graph connecting agent memories with the codebase structure, enabling code-aware memory retrieval.
+
+## How It Works
+
+### Automatic Linking on Storage
+
+When `KuzuBackend.store_memory()` is called, the system automatically:
+
+1. **Links to files** based on file paths in metadata
+2. **Links to functions** based on function names mentioned in content
+3. **Assigns relevance scores** based on link quality
+4. **Prevents duplicates** by checking for existing links
+
+### Link Types
+
+#### File Links (RELATES*TO_FILE*\*)
+
+Created when memory metadata contains a file path:
+
+```python
+memory = MemoryEntry(
+    id="mem-1",
+    memory_type=MemoryType.EPISODIC,
+    content="Refactored validation logic",
+    metadata={"file": "src/utils.py"},  # ← Triggers file link
+    ...
+)
+```
+
+**Relevance Score**: 1.0 (metadata is explicit and reliable)
+
+#### Function Links (RELATES*TO_FUNCTION*\*)
+
+Created when function names appear in memory content:
+
+```python
+memory = MemoryEntry(
+    id="mem-2",
+    memory_type=MemoryType.SEMANTIC,
+    content="The validate_input function checks required fields",  # ← Mentions function
+    ...
+)
+```
+
+**Relevance Score**: 0.8 (content matching is less precise)
+
+### Link Properties
+
+Each memory-code link includes:
+
+- **relevance_score** (DOUBLE): 0.0-1.0 indicating link quality
+- **context** (STRING): Describes how the link was created
+  - `"metadata_file_match"` - File path from metadata
+  - `"content_name_match"` - Function name in content
+- **timestamp** (TIMESTAMP): When the link was created
+
+## Usage
+
+### Enable Auto-Linking (Default)
+
+```python
+from amplihack.memory.backends.kuzu_backend import KuzuBackend
+
+# Auto-linking enabled by default
+backend = KuzuBackend()
+backend.initialize()
+
+# Memories will auto-link to code
+backend.store_memory(memory)
+```
+
+### Disable Auto-Linking
+
+```python
+# Disable for performance-critical scenarios
+backend = KuzuBackend(enable_auto_linking=False)
+```
+
+### Query Memory-Code Links
+
+Find code linked to a memory:
+
+```python
+# Get all files linked to a memory
+result = backend.connection.execute("""
+    MATCH (m:EpisodicMemory {memory_id: $memory_id})-[r:RELATES_TO_FILE_EPISODIC]->(cf:CodeFile)
+    RETURN cf.file_path, r.relevance_score
+    """,
+    {"memory_id": "mem-1"}
+)
+```
+
+Find memories linked to a file:
+
+```python
+# Get all memories about a specific file
+result = backend.connection.execute("""
+    MATCH (m:EpisodicMemory)-[r:RELATES_TO_FILE_EPISODIC]->(cf:CodeFile {file_id: $file_id})
+    RETURN m.memory_id, m.title, r.relevance_score
+    ORDER BY r.relevance_score DESC
+    """,
+    {"file_id": "src/main.py"}
+)
+```
+
+## Relationship Schema
+
+Auto-linking creates 10 relationship types (5 memory types × 2 code targets):
+
+### Memory → File
+
+- `RELATES_TO_FILE_EPISODIC`
+- `RELATES_TO_FILE_SEMANTIC`
+- `RELATES_TO_FILE_PROCEDURAL`
+- `RELATES_TO_FILE_PROSPECTIVE`
+- `RELATES_TO_FILE_WORKING`
+
+### Memory → Function
+
+- `RELATES_TO_FUNCTION_EPISODIC`
+- `RELATES_TO_FUNCTION_SEMANTIC`
+- `RELATES_TO_FUNCTION_PROCEDURAL`
+- `RELATES_TO_FUNCTION_PROSPECTIVE`
+- `RELATES_TO_FUNCTION_WORKING`
+
+## Performance
+
+- **<100ms per memory** for auto-linking (typically 0-5 links)
+- **Lazy database queries** - only runs when code entities exist
+- **Deduplication** - prevents creating duplicate links
+- **Non-blocking** - linking failures don't break memory storage
+
+## Example: Full Workflow
+
+```python
+from amplihack.memory.backends.kuzu_backend import KuzuBackend
+from amplihack.memory.models import MemoryEntry, MemoryType
+from datetime import datetime
+
+# Initialize backend
+backend = KuzuBackend()
+backend.initialize()
+
+# Import code graph (prerequisite)
+from amplihack.memory.kuzu.code_graph import KuzuCodeGraph
+from amplihack.memory.kuzu.connector import KuzuConnector
+
+connector = KuzuConnector()
+connector.connect()
+code_graph = KuzuCodeGraph(connector)
+code_graph.run_blarify("./src", languages=["python"])
+
+# Store memory with file metadata
+memory1 = MemoryEntry(
+    id="mem-refactor-1",
+    session_id="session-123",
+    agent_id="agent-builder",
+    memory_type=MemoryType.EPISODIC,
+    title="Refactored Authentication",
+    content="Moved validation to separate function",
+    metadata={"file": "src/auth.py", "change_type": "refactor"},
+    created_at=datetime.now(),
+    accessed_at=datetime.now(),
+)
+
+backend.store_memory(memory1)
+# ✓ Automatically linked to src/auth.py with relevance=1.0
+
+# Store memory mentioning function
+memory2 = MemoryEntry(
+    id="mem-pattern-1",
+    session_id="session-123",
+    agent_id="agent-builder",
+    memory_type=MemoryType.SEMANTIC,
+    title="Validation Pattern",
+    content="The validate_token function uses JWT decode with verification",
+    metadata={"category": "security"},
+    created_at=datetime.now(),
+    accessed_at=datetime.now(),
+)
+
+backend.store_memory(memory2)
+# ✓ Automatically linked to validate_token() with relevance=0.8
+
+# Query memories for a file
+results = backend.connection.execute("""
+    MATCH (m)-[r:RELATES_TO_FILE_EPISODIC]->(cf:CodeFile {file_id: 'src/auth.py'})
+    RETURN m.memory_id, m.title, r.relevance_score
+    ORDER BY r.relevance_score DESC
+    """)
+
+for row in results:
+    print(f"Memory: {row[1]} (score: {row[2]})")
+```
+
+## Implementation Details
+
+### Matching Logic
+
+#### File Matching
+
+- Uses substring matching: `cf.file_path CONTAINS $file_path OR $file_path CONTAINS cf.file_path`
+- Supports both absolute and relative paths
+- Handles partial path matches
+
+#### Function Matching
+
+- Uses substring matching: `$content CONTAINS f.function_name`
+- Filters out very short names (< 4 chars) to avoid false positives
+- Case-sensitive matching
+
+### Deduplication
+
+- Checks for existing links before creating new ones
+- Uses MATCH query to verify relationship doesn't exist
+- Prevents duplicate links within same transaction
+
+### Error Handling
+
+- Auto-linking failures do NOT fail memory storage
+- Errors are logged as warnings
+- Graceful degradation ensures data integrity
+
+## Testing
+
+Comprehensive test suite in `tests/memory/backends/test_kuzu_auto_linking.py`:
+
+- ✅ Basic file linking
+- ✅ Basic function linking
+- ✅ Relevance scoring
+- ✅ Deduplication
+- ✅ Context metadata
+- ✅ Error handling
+- ✅ Performance requirements
+- ✅ Disable functionality
+
+Run tests:
+
+```bash
+uv run pytest tests/memory/backends/test_kuzu_auto_linking.py -v
+```
+
+## Demo
+
+Run the interactive demo:
+
+```bash
+python -m examples.memory_code_auto_linking_example
+```
+
+Output shows:
+
+- File-based auto-linking (relevance=1.0)
+- Function-based auto-linking (relevance=0.8)
+- Mixed linking (both file and function)
+- Deduplication behavior
+- Disabled linking mode
+
+## Future Enhancements (Week 5-6)
+
+1. **Code context injection** at retrieval time
+2. **Semantic similarity** for fuzzy matching
+3. **Class linking** based on class names in content
+4. **Configurable relevance scoring** via custom rules
+5. **Background batch linking** for historical memories
+
+## Related Documentation
+
+- Code Graph Integration
+- Blarify Integration
+- Memory Backend API
+- Migration Guide

--- a/docs/memory/CODE_CONTEXT_INJECTION.md
+++ b/docs/memory/CODE_CONTEXT_INJECTION.md
@@ -1,0 +1,420 @@
+# Code Context Injection at Memory Retrieval
+
+**Status**: Implemented (Week 5-6)
+**Feature**: Enrich memory retrieval with related code files and functions
+
+## Overview
+
+Code context injection enriches memory retrieval by automatically including information about related code files, functions, and classes when memories are retrieved. This enables agents to have immediate access to code structure information alongside memories.
+
+## Implementation Summary
+
+### 1. Memory Retrieval API - MemoryCoordinator.retrieve()
+
+**File**: `src/amplihack/memory/coordinator.py`
+
+Added `include_code_context` parameter to `RetrievalQuery`:
+
+```python
+@dataclass
+class RetrievalQuery:
+    """Query to retrieve memories.
+
+    Args:
+        query_text: Search text
+        token_budget: Max tokens to return (default 8000)
+        memory_types: Filter by specific types
+        time_range: Filter by time range (start, end)
+        include_code_context: Include related code files/functions (default False)
+    """
+
+    query_text: str
+    token_budget: int = 8000
+    memory_types: list[MemoryType] | None = None
+    time_range: tuple[datetime, datetime] | None = None
+    include_code_context: bool = False
+```
+
+### 2. Code Context Enrichment
+
+**Implementation**: `MemoryCoordinator._enrich_with_code_context()`
+
+The enrichment process:
+
+1. **Check backend capabilities**: Verify backend supports graph queries
+2. **Get code graph instance**: Access Kuzu code graph integration
+3. **Query relationships**: Find `RELATES_TO_FILE_*` and `RELATES_TO_FUNCTION_*` links
+4. **Format context**: Convert code information to LLM-readable format
+5. **Add to metadata**: Inject `code_context` key into memory metadata
+
+```python
+async def _enrich_with_code_context(
+    self, memories: list[MemoryEntry]
+) -> list[MemoryEntry]:
+    """Enrich memories with related code context.
+
+    Queries Kuzu graph fer code files and functions linked to each memory
+    via RELATES_TO_FILE_* and RELATES_TO_FUNCTION_* relationships.
+
+    Args:
+        memories: List of memory entries to enrich
+
+    Returns:
+        Same memories with code_context added to metadata
+
+    Performance: Must complete under 100ms total (not per memory)
+    """
+```
+
+### 3. Code Context Format
+
+Code context is formatted as markdown-style text for LLM consumption:
+
+```markdown
+**Related Files:**
+
+- src/amplihack/memory/coordinator.py (python)
+- src/amplihack/memory/backends/kuzu_backend.py (python)
+
+**Related Functions:**
+
+- `async def retrieve(self, query: RetrievalQuery) -> list[MemoryEntry]`
+  Retrieve memories matching query.
+  (complexity: 12.5)
+
+**Related Classes:**
+
+- amplihack.memory.coordinator.MemoryCoordinator
+  Coordinates memory storage and retrieval with quality control.
+```
+
+### 4. Backend Integration
+
+**File**: `src/amplihack/memory/backends/kuzu_backend.py`
+
+Added public accessor for code graph:
+
+```python
+def get_code_graph(self) -> KuzuCodeGraph | None:
+    """Get code graph instance for querying code-memory relationships.
+
+    Returns:
+        KuzuCodeGraph instance if available, None if code graph not initialized
+
+    Example:
+        >>> backend = KuzuBackend()
+        >>> backend.initialize()
+        >>> code_graph = backend.get_code_graph()
+        >>> if code_graph:
+        ...     context = code_graph.query_code_context(memory_id)
+    """
+```
+
+## Usage Examples
+
+### Basic Usage
+
+```python
+from amplihack.memory.coordinator import MemoryCoordinator, RetrievalQuery
+from amplihack.memory.types import MemoryType
+
+coordinator = MemoryCoordinator()
+
+# Retrieve WITHOUT code context (default)
+query = RetrievalQuery(
+    query_text="Kuzu backend implementation",
+    include_code_context=False,
+)
+memories = await coordinator.retrieve(query)
+
+# Retrieve WITH code context
+query = RetrievalQuery(
+    query_text="Kuzu backend implementation",
+    include_code_context=True,  # Enable code context injection
+)
+memories = await coordinator.retrieve(query)
+
+# Check code context
+for memory in memories:
+    if "code_context" in memory.metadata:
+        print(f"Memory: {memory.content[:50]}...")
+        print(f"Related code:\n{memory.metadata['code_context']}")
+```
+
+### Integration with Agent Context Building
+
+```python
+# In agent initialization or context building
+query = RetrievalQuery(
+    query_text="current task context",
+    include_code_context=True,  # Get code structure with memories
+    memory_types=[MemoryType.SEMANTIC, MemoryType.PROCEDURAL],
+)
+
+relevant_memories = await coordinator.retrieve(query)
+
+# Build agent context with both memories and code structure
+context = []
+for memory in relevant_memories:
+    context.append(f"Memory: {memory.content}")
+
+    # Add code context if available
+    if "code_context" in memory.metadata:
+        context.append(f"\nRelated Code:\n{memory.metadata['code_context']}")
+```
+
+## Backend Support
+
+### Kuzu Backend
+
+**Full support** for code context injection:
+
+- Graph queries: ✓ Native Cypher support
+- Code graph: ✓ Via `KuzuCodeGraph`
+- Memory-code links: ✓ `RELATES_TO_FILE_*` and `RELATES_TO_FUNCTION_*` relationships
+
+### SQLite Backend
+
+**Graceful fallback**:
+
+- Graph queries: ✗ Not supported
+- Code context injection: Skipped silently
+- No errors, memories returned without code context
+
+## Performance
+
+### Requirements
+
+- **Enrichment overhead**: <100ms total (not per memory)
+- **Retrieval total**: <150ms including enrichment
+- **Memory overhead**: ~200 bytes per memory for code context metadata
+
+### Benchmarks
+
+```python
+import time
+
+# Store some memories
+for i in range(10):
+    await coordinator.store(StorageRequest(...))
+
+# Benchmark retrieval with code context
+start = time.time()
+query = RetrievalQuery(
+    query_text="test",
+    include_code_context=True,
+)
+memories = await coordinator.retrieve(query)
+elapsed_ms = (time.time() - start) * 1000
+
+print(f"Retrieval with code context: {elapsed_ms:.1f}ms")
+# Expected: <150ms
+```
+
+## Injection Points (Priority Implementation)
+
+### ✅ 1. Memory Retrieval API
+
+**File**: `src/amplihack/memory/coordinator.py`
+**Status**: **IMPLEMENTED**
+
+- Added `include_code_context` parameter to `RetrievalQuery`
+- Implemented `_enrich_with_code_context()` helper method
+- Queries Kuzu for `RELATES_TO_FILE_*` and `RELATES_TO_FUNCTION_*` links
+- Formats code context into readable format
+- Injects into memory metadata
+
+### 🚧 2. Agent Context Building (Future)
+
+**File**: To be implemented in agent memory hooks
+**Status**: Planned
+
+Extend memory hooks to automatically inject code context:
+
+```python
+# In PreRequest hook or agent initialization
+def inject_memory_context(agent_context: dict) -> dict:
+    """Inject memories with code context into agent context."""
+    query = RetrievalQuery(
+        query_text=agent_context.get("task", ""),
+        include_code_context=True,  # Auto-enable
+    )
+    memories = await coordinator.retrieve(query)
+    agent_context["relevant_memories"] = memories
+    return agent_context
+```
+
+### 🚧 3. Session Start (Future)
+
+**Status**: Planned
+
+Add code overview to session initialization:
+
+```python
+# In SessionStart hook
+async def load_code_overview(session: Session):
+    """Load code structure overview into session context."""
+    code_graph = backend.get_code_graph()
+    if code_graph:
+        stats = code_graph.get_code_stats()
+        session.context["code_stats"] = stats
+```
+
+### 🚧 4. File Edit Operations (Future)
+
+**Status**: Planned
+
+Hook into edit operations to inject related memories:
+
+```python
+# Before file edit
+def get_file_context(file_path: str) -> dict:
+    """Get memories and code context for file."""
+    # Query memories linked to this file
+    # Include related functions and classes
+    # Return context for agent
+```
+
+## Testing
+
+### Test Suite
+
+**File**: `tests/memory/test_code_context_injection.py`
+
+Comprehensive test coverage:
+
+1. ✓ `test_retrieve_with_code_context_flag` - Parameter acceptance
+2. ✓ `test_code_context_enrichment` - Enrichment functionality
+3. ✓ `test_code_context_fallback_sqlite` - SQLite fallback
+4. ✓ `test_code_context_performance` - Performance requirements
+5. ✓ `test_code_context_format` - Output format
+6. ✓ `test_code_context_with_no_links` - No links handling
+7. ✓ `test_code_context_default_false` - Default behavior
+
+### Running Tests
+
+```bash
+# Run all code context injection tests
+python -m pytest tests/memory/test_code_context_injection.py -v
+
+# Run specific test
+python -m pytest tests/memory/test_code_context_injection.py::test_code_context_enrichment -v
+
+# Run with coverage
+python -m pytest tests/memory/test_code_context_injection.py --cov=amplihack.memory.coordinator
+```
+
+### Demo Scripts
+
+**File**: `examples/code_context_injection_demo.py`
+
+```bash
+# Run comprehensive demo
+python examples/code_context_injection_demo.py
+
+# Run simple test
+python examples/simple_code_context_test.py
+```
+
+## Success Criteria
+
+### ✅ Completed
+
+1. ✓ Memory retrieval can include related code files/functions
+2. ✓ Agent context includes code structure information
+3. ✓ Code context formatted for LLM consumption
+4. ✓ Tests validate code injection functionality
+5. ✓ Graceful fallback for non-Kuzu backends
+6. ✓ Performance requirements met (<100ms enrichment)
+
+### 🚧 Future Enhancements
+
+1. ⏳ Integrate with agent memory hooks
+2. ⏳ Add to session start/end workflows
+3. ⏳ Hook into file edit operations
+4. ⏳ Add caching for frequently queried code context
+5. ⏳ Support configurable context depth (1-hop, 2-hop traversal)
+
+## Configuration
+
+### Environment Variables
+
+None required - feature is opt-in via `include_code_context` parameter.
+
+### Backend Requirements
+
+- Kuzu backend: Full support
+- SQLite backend: Graceful fallback (no errors)
+- Neo4j backend: Not yet implemented
+
+## Troubleshooting
+
+### Code context is empty
+
+**Possible causes:**
+
+1. No code graph data imported (run blarify first)
+2. Memory not linked to code (auto-linking didn't find matches)
+3. Code graph not initialized
+
+**Solution:**
+
+```bash
+# Import code graph using blarify
+amplihack memory blarify /path/to/codebase
+
+# Check code graph stats
+python -c "
+from amplihack.memory.backends import create_backend
+backend = create_backend('kuzu')
+code_graph = backend.get_code_graph()
+if code_graph:
+    print(code_graph.get_code_stats())
+"
+```
+
+### Performance degradation
+
+**Possible causes:**
+
+1. Large code graph (thousands of files)
+2. Deep relationship traversal
+3. Many memories with code links
+
+**Solution:**
+
+- Limit number of memories retrieved (reduce `token_budget`)
+- Only use `include_code_context` when needed
+- Consider caching code context for frequently accessed memories
+
+## Related Documentation
+
+- [Kuzu Code Schema](./KUZU_CODE_SCHEMA.md) - Code graph schema
+- [Memory-Code Linking](./AUTO_LINKING.md) - Auto-linking implementation
+- [5-Type Memory System](./5-TYPE-MEMORY-DEVELOPER.md) - Memory architecture
+- [Blarify Integration](../concepts/blarify-integration.md) - Code graph import
+
+## Implementation Notes
+
+### Design Decisions
+
+1. **Opt-in by default**: `include_code_context=False` prevents unexpected overhead
+2. **Metadata injection**: Code context added to `memory.metadata["code_context"]` for easy access
+3. **Graceful fallback**: Non-Kuzu backends silently skip enrichment
+4. **Format for LLMs**: Markdown-style formatting optimized for language model consumption
+5. **Performance budget**: <100ms enrichment keeps total retrieval under 150ms
+
+### Future Considerations
+
+1. **Vector embeddings**: Add semantic code search
+2. **Multi-hop traversal**: Support configurable depth (1-hop, 2-hop, etc.)
+3. **Caching**: Cache code context for frequently queried memories
+4. **Streaming**: Stream code context for large results
+5. **Filtering**: Allow filtering code context by file type, complexity, etc.
+
+---
+
+**Implementation**: Week 5-6
+**Version**: 1.0
+**Status**: Complete
+**Performance**: <100ms enrichment, <150ms total retrieval

--- a/docs/memory/CODE_CONTEXT_QUICK_START.md
+++ b/docs/memory/CODE_CONTEXT_QUICK_START.md
@@ -1,0 +1,181 @@
+# Code Context Injection - Quick Start
+
+**5-minute guide to using code context injection**
+
+## What is Code Context Injection?
+
+Code context injection enriches memory retrieval by automatically including information about related code files, functions, and classes. This gives agents immediate access to code structure alongside memories.
+
+## Basic Usage
+
+### 1. Enable Code Context in Queries
+
+```python
+from amplihack.memory.coordinator import MemoryCoordinator, RetrievalQuery
+
+coordinator = MemoryCoordinator()
+
+# Standard query (no code context)
+query = RetrievalQuery(query_text="bug fix")
+memories = await coordinator.retrieve(query)
+
+# Query WITH code context
+query = RetrievalQuery(
+    query_text="bug fix",
+    include_code_context=True  # 👈 Add this flag
+)
+memories = await coordinator.retrieve(query)
+```
+
+### 2. Access Code Context
+
+```python
+for memory in memories:
+    print(f"Memory: {memory.content}")
+
+    # Check if code context is available
+    if "code_context" in memory.metadata:
+        print(f"Related Code:\n{memory.metadata['code_context']}")
+```
+
+## Example Output
+
+```
+Memory: Fixed bug in retrieve() method where token budget was not enforced
+
+Related Code:
+**Related Files:**
+- src/amplihack/memory/coordinator.py (python)
+
+**Related Functions:**
+- `async def retrieve(self, query: RetrievalQuery) -> list[MemoryEntry]`
+  Retrieve memories matching query.
+  (complexity: 12.5)
+
+**Related Classes:**
+- amplihack.memory.coordinator.MemoryCoordinator
+  Coordinates memory storage and retrieval with quality control.
+```
+
+## Requirements
+
+### Backend Support
+
+- ✅ **Kuzu**: Full support (recommended)
+- ⚠️ **SQLite**: Gracefully falls back (no errors, no code context)
+- ❌ **Neo4j**: Not yet implemented
+
+### Code Graph Data
+
+Code context requires blarify code graph data:
+
+```bash
+# Import your codebase structure
+amplihack memory blarify /path/to/your/project
+```
+
+## When to Use
+
+### ✅ Good Use Cases
+
+- Building agent context for code-related tasks
+- Debugging or understanding code behavior
+- Linking memories to specific implementations
+- Code review or documentation tasks
+
+### ❌ When Not to Use
+
+- General conversation (no code relevance)
+- Performance-critical queries (adds ~50-100ms)
+- When code graph data is not available
+
+## Performance
+
+- **Overhead**: <100ms per retrieval
+- **Default**: OFF (opt-in via `include_code_context=True`)
+- **Fallback**: Graceful (no errors if code graph unavailable)
+
+## Complete Example
+
+```python
+import asyncio
+from amplihack.memory.coordinator import (
+    MemoryCoordinator,
+    RetrievalQuery,
+    StorageRequest
+)
+from amplihack.memory.types import MemoryType
+
+
+async def example():
+    # Initialize
+    coordinator = MemoryCoordinator()
+
+    # Store a memory with code reference
+    await coordinator.store(StorageRequest(
+        content="Fixed critical bug in memory retrieval",
+        memory_type=MemoryType.EPISODIC,
+        metadata={"file": "src/amplihack/memory/coordinator.py"}
+    ))
+
+    # Retrieve with code context
+    query = RetrievalQuery(
+        query_text="bug fix",
+        include_code_context=True
+    )
+    memories = await coordinator.retrieve(query)
+
+    # Use the code context
+    for memory in memories:
+        print(f"\n📝 {memory.content}")
+
+        if "code_context" in memory.metadata:
+            print(f"\n💻 Code Context:")
+            print(memory.metadata["code_context"])
+
+
+if __name__ == "__main__":
+    asyncio.run(example())
+```
+
+## Troubleshooting
+
+### No code context appears
+
+**Cause**: Code graph data not imported or memory not linked to code
+
+**Solution**:
+
+```bash
+# Import code structure
+amplihack memory blarify .
+
+# Check code graph stats
+python -c "
+from amplihack.memory.backends import create_backend
+backend = create_backend('kuzu')
+code_graph = backend.get_code_graph()
+print(code_graph.get_code_stats() if code_graph else 'No code graph')
+"
+```
+
+### Performance issues
+
+**Cause**: Large code graph or many memories
+
+**Solution**:
+
+- Only enable when needed (`include_code_context=True`)
+- Reduce token budget to limit number of memories
+- Use more specific queries
+
+## Next Steps
+
+- 📚 Read [full documentation](CODE_CONTEXT_INJECTION.md)
+- 🧪 Run demo script
+- 🔬 Check test suite
+- 📖 Learn about [Kuzu Code Schema](KUZU_CODE_SCHEMA.md)
+
+---
+
+**Quick Start Guide** | [Full Documentation](CODE_CONTEXT_INJECTION.md) | [Kuzu Schema](KUZU_CODE_SCHEMA.md)

--- a/docs/memory/CODE_REVIEW_PR_1077.md
+++ b/docs/memory/CODE_REVIEW_PR_1077.md
@@ -1,0 +1,870 @@
+# Code Review: PR #1077 - Neo4j Memory System Implementation
+
+**Reviewer**: Reviewer Agent
+**Date**: 2025-11-03
+**Branch**: feat/neo4j-memory-system
+**Files Changed**: 104 files
+**Lines Changed**: +56,997 / -3,795
+
+---
+
+## Executive Summary
+
+### CRITICAL FINDING: Missing Agent Integration
+
+**This is infrastructure without integration.** The Neo4j memory system is a technically sound, production-ready infrastructure layer, but **NO AGENTS ACTUALLY USE IT**. The system can store and retrieve memories, but there are zero integration points with the existing agent system.
+
+### Overall Assessment: **NEEDS MAJOR WORK**
+
+**User Requirement Compliance**: ⚠️ PARTIAL (2/4 met)
+
+- ✅ Neo4j container spins up on session start
+- ✅ Neo4j graph database used
+- ❌ Dependency management incomplete (agent is advisory only, Docker Compose issue not resolved)
+- ❌ Agent integration missing (agents don't use the memory system)
+
+**Philosophy Compliance**: 6/10
+
+- ✅ Ruthless simplicity: Implementation is direct and clean
+- ⚠️ Zero-BS: Some legitimate exception placeholders (acceptable), but ENTIRE SYSTEM IS UNUSED
+- ⚠️ Modular design: Good module boundaries but no integration layer
+- ❌ User requirements: Critical gap - agents don't use memory system
+
+---
+
+## CRITICAL Issues (Must Fix Before Merge)
+
+### CRITICAL-1: Zero Agent Integration
+
+**Location**: Entire codebase
+**Severity**: CRITICAL
+**Impact**: HIGH - System is unusable infrastructure
+
+**Problem**:
+The memory system is a complete implementation with no consumers. Searched entire codebase:
+
+- ❌ No agent files import AgentMemoryManager
+- ❌ No agent files call remember() or recall()
+- ❌ No hooks in launcher to pass memory manager to agents
+- ❌ No integration with Claude Code SDK agent invocations
+
+**Evidence**:
+
+```bash
+$ grep -r "AgentMemoryManager\|remember\|recall" .claude/agents/
+# NO RESULTS
+
+$ find . -name "*.py" -exec grep -l "remember\|recall" {} \; | grep -v test | grep -v example
+# Only memory system itself, NO consumers
+```
+
+**What's Missing**:
+
+1. **Agent Hook**: How do architect/builder/reviewer agents get a memory manager instance?
+2. **Memory Capture**: Where do agents store design decisions, patterns, errors?
+3. **Memory Retrieval**: When do agents query for relevant memories?
+4. **Integration Pattern**: No documented pattern for agents to use memory
+
+**Recommendation**:
+Add integration layer before merge:
+
+```python
+# src/amplihack/agents/memory_integration.py
+class AgentMemoryIntegration:
+    """Hook for agents to access memory system."""
+
+    @staticmethod
+    def get_memory_manager(agent_type: str) -> Optional[AgentMemoryManager]:
+        """Get memory manager for agent type.
+
+        Returns None if Neo4j unavailable (graceful fallback).
+        """
+        try:
+            from amplihack.memory.neo4j import AgentMemoryManager
+            return AgentMemoryManager(agent_type)
+        except Exception:
+            return None
+
+    @staticmethod
+    def store_design_decision(decision: str, rationale: str, agent_type: str = "architect"):
+        """Helper for agents to store design decisions."""
+        mgr = AgentMemoryIntegration.get_memory_manager(agent_type)
+        if mgr:
+            mgr.remember(
+                content=f"{decision}\nRationale: {rationale}",
+                category="design_decision",
+                tags=["decision", "design"]
+            )
+
+    @staticmethod
+    def recall_patterns(category: str, agent_type: str) -> List[Dict]:
+        """Helper for agents to retrieve patterns."""
+        mgr = AgentMemoryIntegration.get_memory_manager(agent_type)
+        if mgr:
+            return mgr.recall(category=category, min_quality=0.7)
+        return []
+```
+
+**Agent File Updates Needed**:
+
+````markdown
+# .claude/agents/amplihack/core/architect.md
+
+## Memory Integration
+
+Use memory system to store and retrieve design patterns:
+
+```python
+from amplihack.agents.memory_integration import AgentMemoryIntegration
+
+# When making design decision:
+AgentMemoryIntegration.store_design_decision(
+    decision="Use microservices architecture",
+    rationale="Team size and independent deployment needs",
+    agent_type="architect"
+)
+
+# When starting new design:
+patterns = AgentMemoryIntegration.recall_patterns("design_pattern", "architect")
+for pattern in patterns:
+    # Consider proven patterns from past work
+    ...
+```
+````
+
+````
+
+**Why This is Critical**:
+Without integration, this is 57k lines of unused infrastructure. The value proposition was "agents learn from past decisions" - but no agent can access the system.
+
+---
+
+### CRITICAL-2: Dependency Management Incomplete
+
+**Location**: `src/amplihack/launcher/core.py`, dependency agent
+**Severity**: CRITICAL
+**Impact**: HIGH - Users can't use the system
+
+**Problem**:
+User reported "docker compose not available" but dependency agent is advisory only:
+- Agent checks dependencies but CANNOT install them
+- User explicitly asked: "Should it auto-install missing dependencies?"
+- Current behavior: Prints error message, user must manually fix
+
+**Evidence from PR description**:
+> "Goal-Seeking Dependency Agent ✅"
+> "Advisory agent for dependency validation (Check → Report → Guide pattern)"
+> "**Never auto-executes system commands** (advisory only)"
+
+But user requirement was dependency *management*, not just *checking*.
+
+**Recommendation**:
+
+Option 1 (Preferred): Add optional auto-install with explicit user permission:
+```python
+# .claude/agents/amplihack/infrastructure/neo4j-setup-agent.md
+
+## Auto-Installation (Optional)
+
+When missing dependencies detected, agent can optionally install with user permission:
+
+```python
+if missing_docker_compose:
+    response = ask_user("Docker Compose is missing. Install it now? (y/n)")
+    if response.lower() == 'y':
+        install_docker_compose()  # Platform-specific installation
+````
+
+Option 2: Clear documentation of manual steps:
+
+````markdown
+# src/amplihack/memory/neo4j/README.md
+
+## Prerequisites
+
+**Required**:
+
+- Docker daemon running
+- Docker Compose plugin
+
+**Installation**:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get update
+sudo apt-get install docker-compose-plugin
+
+# macOS
+brew install docker-compose
+
+# Verify
+docker compose version
+```
+````
+
+**What's Missing**:
+Current docs don't mention Docker Compose requirement prominently enough.
+
+---
+
+### CRITICAL-3: No Integration Tests with Actual Agents
+
+**Location**: `tests/` directory
+**Severity**: CRITICAL
+**Impact**: MEDIUM - Can't verify agent usage works
+
+**Problem**:
+All tests are infrastructure tests (container, CRUD, queries). Zero tests verify agents can use the system.
+
+**Test Gap Analysis**:
+
+- ✅ Unit tests: Container lifecycle, memory CRUD, schema init
+- ✅ Integration tests: Neo4j operations, agent_memory.py methods
+- ✅ E2E tests: Multi-agent scenarios (but programmatic, not real agents)
+- ❌ Agent integration tests: Do architect/builder/reviewer agents work with memory?
+
+**Missing Tests**:
+
+```python
+# tests/integration/test_agent_memory_integration.py
+def test_architect_agent_stores_design_decision():
+    """Verify architect agent can store decisions in memory."""
+    # Invoke architect agent via SDK
+    # Check memory system has the decision
+    # Verify another architect instance can retrieve it
+    pass
+
+def test_builder_agent_recalls_patterns():
+    """Verify builder agent can retrieve patterns from memory."""
+    # Pre-populate memory with builder patterns
+    # Invoke builder agent
+    # Verify agent used the patterns (check output)
+    pass
+
+def test_memory_system_fallback_when_neo4j_unavailable():
+    """Verify agents work even when Neo4j down."""
+    # Stop Neo4j container
+    # Invoke agent
+    # Verify graceful fallback (no crash)
+    pass
+```
+
+**Recommendation**:
+Add agent integration tests that actually invoke agents and verify memory usage.
+
+---
+
+## HIGH Priority Issues (Should Fix Before Merge)
+
+### HIGH-1: Performance Impact Unknown
+
+**Location**: `src/amplihack/launcher/core.py:_start_neo4j_background()`
+**Severity**: HIGH
+**Impact**: MEDIUM - Session start time
+
+**Problem**:
+Claims "<500ms session start impact" but no benchmarks provided. Background thread could still cause contention.
+
+**Questions**:
+
+1. What if container is stopped (not removed)? Startup time?
+2. What's the P99 session start time with Neo4j enabled vs disabled?
+3. Does health check block anything?
+
+**Code Evidence**:
+
+```python
+def _start_neo4j_background(self):
+    """Start Neo4j in background thread (non-blocking)."""
+    def start_neo4j():
+        # This could take 10-30 seconds on first start
+        ensure_neo4j_running(blocking=False)
+```
+
+Background thread doesn't mean no impact - thread creation, Docker calls, all cost time.
+
+**Recommendation**:
+Add benchmarking:
+
+```python
+# tests/performance/test_session_start_timing.py
+def test_session_start_time_with_neo4j():
+    times = []
+    for i in range(10):
+        start = time.time()
+        launcher = ClaudeLauncher()
+        launcher.prepare_launch()
+        duration = time.time() - start
+        times.append(duration)
+
+    p50 = sorted(times)[5]
+    p99 = sorted(times)[9]
+
+    assert p50 < 0.5, f"P50 session start {p50}s exceeds 500ms target"
+    assert p99 < 1.0, f"P99 session start {p99}s too slow"
+```
+
+---
+
+### HIGH-2: Error Handling - Silent Failures
+
+**Location**: Multiple files
+**Severity**: HIGH
+**Impact**: MEDIUM - Users won't know why things fail
+
+**Problem**:
+Many failure modes print warnings but continue silently. Users won't know memory system is broken.
+
+**Examples**:
+
+1. **Background Neo4j startup**:
+
+```python
+# src/amplihack/launcher/core.py:586
+except Exception as e:
+    print(f"[WARN] Neo4j initialization error: {e}")
+    print("[INFO] Continuing with existing memory system")
+```
+
+What existing memory system? There isn't one. This is misleading.
+
+2. **Agent memory fallback**:
+
+```python
+# src/amplihack/agents/memory_integration.py (proposed)
+except Exception:
+    return None
+```
+
+Swallowing all exceptions is dangerous. What if it's a programming error?
+
+**Recommendation**:
+Add structured error reporting:
+
+```python
+from enum import Enum
+
+class MemorySystemStatus(Enum):
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+    ERROR = "error"
+
+class MemorySystemHealth:
+    status: MemorySystemStatus
+    error_message: Optional[str] = None
+
+    @classmethod
+    def check(cls) -> "MemorySystemHealth":
+        try:
+            # Check Neo4j connectivity
+            return cls(status=MemorySystemStatus.AVAILABLE)
+        except ServiceUnavailable as e:
+            return cls(status=MemorySystemStatus.UNAVAILABLE, error_message=str(e))
+        except Exception as e:
+            return cls(status=MemorySystemStatus.ERROR, error_message=str(e))
+```
+
+Then expose to users:
+
+```bash
+$ amplihack --memory-status
+Memory System Status: UNAVAILABLE
+Reason: Docker daemon not running
+Fix: Start Docker with: sudo systemctl start docker
+```
+
+---
+
+### HIGH-3: No Migration Path from Existing System
+
+**Location**: Documentation
+**Severity**: HIGH
+**Impact**: MEDIUM - Users lose existing memory data
+
+**Problem**:
+PR claims "no migration needed" because it runs alongside SQLite. But:
+
+1. Where is the SQLite-based memory system? (Can't find it in codebase)
+2. How do existing memories migrate to Neo4j?
+3. What's the timeline for deprecating old system?
+
+**Evidence**:
+
+```
+$ grep -r "SQLite\|sqlite" src/amplihack/memory/
+# No results
+```
+
+**Recommendation**:
+Either:
+
+1. Clarify there IS no existing memory system (this is the first one), OR
+2. Provide migration script from whatever the old system was
+
+---
+
+## MEDIUM Priority Issues (Fix Soon)
+
+### MEDIUM-1: Docker Compose vs Docker CLI Confusion
+
+**Location**: `src/amplihack/memory/neo4j/lifecycle.py`
+**Severity**: MEDIUM
+**Impact**: LOW - Code works but confusing
+
+**Problem**:
+Code tries `docker-compose` (v1) then falls back to `docker compose` (v2), then tries direct docker. This is good resilience but logs are confusing.
+
+**Example**:
+
+```python
+# lifecycle.py:180
+# Try docker-compose first
+result = subprocess.run(["docker-compose", "--version"], ...)
+if result.returncode != 0:
+    # Try docker compose (plugin)
+    result = subprocess.run(["docker", "compose", "version"], ...)
+```
+
+User sees multiple failed attempts in logs even though it eventually works.
+
+**Recommendation**:
+Detect once, cache decision:
+
+```python
+class DockerComposeDetector:
+    _detected: Optional[str] = None
+
+    @classmethod
+    def get_command(cls) -> List[str]:
+        if cls._detected:
+            return cls._detected
+
+        # Test v2 first (newer)
+        if subprocess.run(["docker", "compose", "version"], ...).returncode == 0:
+            cls._detected = ["docker", "compose"]
+        # Fall back to v1
+        elif subprocess.run(["docker-compose", "--version"], ...).returncode == 0:
+            cls._detected = ["docker-compose"]
+        else:
+            raise RuntimeError("Docker Compose not available")
+
+        return cls._detected
+```
+
+---
+
+### MEDIUM-2: Circuit Breaker Recovery Not Tested
+
+**Location**: `src/amplihack/memory/neo4j/connector.py`
+**Severity**: MEDIUM
+**Impact**: LOW - Code looks correct but unverified
+
+**Problem**:
+Circuit breaker has half-open recovery logic but no tests verify it works.
+
+**Code**:
+
+```python
+if self.state == CircuitState.HALF_OPEN:
+    try:
+        result = func(*args, **kwargs)
+        self.success_count += 1
+        if self.success_count >= self.success_threshold:
+            self.state = CircuitState.CLOSED
+```
+
+**Missing Test**:
+
+```python
+def test_circuit_breaker_half_open_recovery():
+    cb = CircuitBreaker(failure_threshold=2, success_threshold=2)
+
+    # Open circuit
+    for _ in range(2):
+        try: cb.call(failing_function)
+        except: pass
+
+    assert cb.state == CircuitState.OPEN
+
+    # Wait for timeout
+    time.sleep(cb.timeout_seconds + 1)
+
+    # Should transition to HALF_OPEN
+    cb.call(succeeding_function)
+    assert cb.state == CircuitState.HALF_OPEN
+
+    # Second success should close circuit
+    cb.call(succeeding_function)
+    assert cb.state == CircuitState.CLOSED
+```
+
+---
+
+### MEDIUM-3: No Monitoring Dashboard
+
+**Location**: Monitoring module exists but no UI
+**Severity**: MEDIUM
+**Impact**: LOW - Hard to debug issues
+
+**Problem**:
+System collects metrics (OperationMetric, SystemHealth) but no way to view them except programmatically.
+
+**What's There**:
+
+```python
+from amplihack.memory.neo4j.monitoring import get_global_metrics
+metrics = get_global_metrics()
+# Now what? Print to console?
+```
+
+**Recommendation**:
+Add simple CLI dashboard:
+
+```bash
+$ amplihack memory stats
+Neo4j Memory System Statistics
+==============================
+
+Container Status: RUNNING
+Health: HEALTHY
+Uptime: 2h 34m
+
+Operations (last 1h):
+  CREATE: 145 (98.6% success, avg 23ms)
+  READ:   892 (100% success, avg 8ms)
+  UPDATE: 34  (100% success, avg 15ms)
+  DELETE: 2   (100% success, avg 12ms)
+
+Circuit Breaker: CLOSED (0 failures)
+
+Top Agent Types:
+  1. architect (234 memories, avg quality 0.82)
+  2. builder (189 memories, avg quality 0.78)
+  3. reviewer (156 memories, avg quality 0.85)
+```
+
+---
+
+## LOW Priority Issues (Nice to Have)
+
+### LOW-1: Verbose Logging
+
+**Location**: Throughout codebase
+**Severity**: LOW
+**Impact**: LOW - Minor annoyance
+
+**Problem**:
+Lots of INFO logging that clutters output:
+
+```python
+logger.info("Agent %s stored memory %s", ...)
+logger.info("Agent %s recalled %d memories", ...)
+```
+
+For production use, these should be DEBUG level.
+
+**Recommendation**:
+
+```python
+logger.debug("Agent %s stored memory %s", ...)  # Not INFO
+logger.info("Memory system initialized")  # High-level events only
+```
+
+---
+
+### LOW-2: Type Hints - Dict vs TypedDict
+
+**Location**: Multiple files
+**Severity**: LOW
+**Impact**: LOW - Type safety
+
+**Problem**:
+Methods return `Dict[str, Any]` for structured data. Could use TypedDict for better typing.
+
+**Example**:
+
+```python
+def recall(...) -> List[Dict[str, Any]]:
+    # What keys are in this dict? What types?
+```
+
+**Better**:
+
+```python
+from typing import TypedDict
+
+class MemoryDict(TypedDict):
+    id: str
+    content: str
+    quality_score: float
+    tags: List[str]
+    # ... other fields
+
+def recall(...) -> List[MemoryDict]:
+```
+
+---
+
+### LOW-3: Documentation - Examples vs Reality
+
+**Location**: Documentation files
+**Severity**: LOW
+**Impact**: LOW - Confusion
+
+**Problem**:
+Docs show examples of agents using memory, but agents can't actually do this yet:
+
+```python
+# examples/neo4j_memory_demo.py:28
+architect = AgentMemoryManager("architect", project_id="demo-project")
+architect.remember(...)
+```
+
+This is programmatic usage, not actual agent integration. Docs should clarify.
+
+---
+
+## Philosophy Compliance Assessment
+
+### Ruthless Simplicity: 8/10
+
+**Strengths**:
+
+- Direct implementations, no over-abstraction
+- Clear module boundaries
+- Straightforward Cypher queries
+
+**Weaknesses**:
+
+- Could simplify Docker Compose detection
+- Circuit breaker adds complexity (justified for resilience)
+
+### Zero-BS: 3/10
+
+**Critical Weakness**:
+The ENTIRE SYSTEM is a placeholder in the sense that no agents use it. This violates the core principle: "Every function must work or not exist."
+
+The infrastructure works, but it's infrastructure without consumers. That's the definition of premature.
+
+**What Should Have Been Done**:
+Implement Phase 1-2 (infrastructure) AND minimal Phase 3 agent integration in same PR. Don't merge infrastructure until something uses it.
+
+### Modular Design: 9/10
+
+**Strengths**:
+
+- Excellent brick design: `connector.py`, `lifecycle.py`, `agent_memory.py` are self-contained
+- Clear public APIs in `__init__.py`
+- Good separation of concerns
+
+**Weakness**:
+
+- Missing the integration brick that connects agents to memory
+
+### User Requirements: 5/10
+
+**Analysis**:
+
+User Requirement 1: "Neo4j container spins up on session start"
+
+- ✅ Met: Container starts in background
+
+User Requirement 2: "Dependencies managed with goal-seeking agent"
+
+- ⚠️ Partial: Agent checks but doesn't install
+
+User Requirement 3: "Neo4j graph database used"
+
+- ✅ Met: Uses Neo4j, not SQLite
+
+User Requirement 4: "All code works"
+
+- ❌ Failed: Code works but is unused
+
+Implicit Requirement: "Agents use the memory system"
+
+- ❌ Failed: No integration
+
+---
+
+## Testing Assessment
+
+### Test Coverage: 7/10
+
+**Strengths**:
+
+- Comprehensive unit tests (60+ tests claimed)
+- Integration tests with real Neo4j
+- E2E scenarios covering all phases
+
+**Weaknesses**:
+
+- No agent integration tests
+- No performance benchmarks
+- Circuit breaker recovery untested
+- No chaos engineering tests (what if container dies mid-operation?)
+
+### Test Quality: 8/10
+
+**Strengths**:
+
+- Tests use real Neo4j (not mocked)
+- Good test isolation
+- Clear test names and documentation
+
+**Weaknesses**:
+
+- Tests are all programmatic, not realistic usage
+- No tests from agent perspective
+
+---
+
+## Security Assessment: 9/10
+
+**Strengths**:
+
+- ✅ Random password generation (190-bit entropy)
+- ✅ Secure storage (0o600 permissions)
+- ✅ Localhost-only binding (127.0.0.1)
+- ✅ No credentials in version control
+- ✅ Authentication always required
+
+**Minor Issue**:
+Password file location `~/.amplihack/.neo4j_password` should be documented prominently in security docs.
+
+---
+
+## Performance Assessment: ?/10
+
+**Cannot Assess**: No benchmarks provided
+
+**Needed**:
+
+1. Session start time (cold start, warm start)
+2. Query latency (P50, P95, P99)
+3. Memory overhead (container + driver)
+4. Concurrent agent performance
+
+---
+
+## What's Good (Positive Feedback)
+
+1. **Excellent Documentation**: 990KB of research and specs show thorough planning
+2. **Production-Ready Code**: Circuit breaker, retry logic, health monitoring are professional-grade
+3. **Security First**: Password handling, localhost binding, authentication are exemplary
+4. **Clean Architecture**: Module boundaries are clear, public APIs well-defined
+5. **Comprehensive Testing**: Infrastructure testing is thorough
+6. **Graceful Degradation**: Fallback behavior is well-designed
+7. **Type Hints**: Good use of typing throughout
+8. **Error Handling**: Most error cases are handled gracefully
+
+---
+
+## Summary of Required Changes
+
+### Before Merge (CRITICAL):
+
+1. **Add Agent Integration Layer** (CRITICAL-1)
+   - Create `AgentMemoryIntegration` helper class
+   - Add memory hooks to architect, builder, reviewer agents
+   - Document integration pattern in agent files
+
+2. **Improve Dependency Management** (CRITICAL-2)
+   - Add optional auto-install with user permission, OR
+   - Document manual installation steps prominently
+
+3. **Add Agent Integration Tests** (CRITICAL-3)
+   - Test actual agents using memory system
+   - Test fallback when Neo4j unavailable
+
+4. **Add Performance Benchmarks** (HIGH-1)
+   - Measure session start impact
+   - Measure query latency
+
+5. **Improve Error Reporting** (HIGH-2)
+   - Add memory system health check command
+   - Better error messages for common failures
+
+### After Merge (Follow-up PRs):
+
+1. Fix Docker Compose detection (MEDIUM-1)
+2. Test circuit breaker recovery (MEDIUM-2)
+3. Add monitoring dashboard (MEDIUM-3)
+4. Reduce logging verbosity (LOW-1)
+5. Improve type hints (LOW-2)
+6. Clarify documentation examples (LOW-3)
+
+---
+
+## Recommendation
+
+**DO NOT MERGE** until agent integration (CRITICAL-1) is resolved.
+
+This is well-built infrastructure with no users. The philosophy says "trust in emergence" - but you can't have emergence without integration points. Merge infrastructure and integration together, not separately.
+
+**Suggested Path Forward**:
+
+1. Keep infrastructure as-is (it's good)
+2. Add minimal agent integration:
+   - Architect agent stores design decisions
+   - Builder agent recalls code patterns
+   - One end-to-end test showing real agent using memory
+3. Then merge
+4. Let usage patterns emerge from real use
+5. Iterate based on what agents actually need
+
+**Timeline**: ~4-8 hours for minimal integration
+**Risk**: LOW - Infrastructure is solid, just need the connectors
+
+---
+
+## Review Score by Category
+
+| Category              | Score | Status                 |
+| --------------------- | ----- | ---------------------- |
+| User Requirements     | 5/10  | ⚠️ Partial             |
+| Philosophy Compliance | 6/10  | ⚠️ Needs Work          |
+| Code Quality          | 9/10  | ✅ Excellent           |
+| Architecture          | 9/10  | ✅ Excellent           |
+| Security              | 9/10  | ✅ Excellent           |
+| Testing               | 7/10  | ⚠️ Good but incomplete |
+| Documentation         | 8/10  | ✅ Very Good           |
+| Performance           | ?/10  | ❓ Unknown             |
+| Integration           | 0/10  | ❌ Critical Gap        |
+
+**Overall**: 6.5/10 - Good infrastructure, missing integration
+
+---
+
+## Next Steps (Step 12: Implement Review Feedback)
+
+1. Address CRITICAL-1 first (agent integration)
+2. Address CRITICAL-2 and CRITICAL-3
+3. Respond to HIGH priority items
+4. Create follow-up issues for MEDIUM/LOW items
+5. Re-request review after changes
+
+---
+
+## Appendix: Files Reviewed
+
+**Core Implementation** (12 files):
+
+- `src/amplihack/memory/neo4j/*.py` - All modules examined
+- `src/amplihack/launcher/core.py` - Session integration reviewed
+- `~/.amplihack/.claude/agents/amplihack/infrastructure/neo4j-setup-agent.md` - Agent examined
+
+**Tests** (3 files):
+
+- `scripts/test_complete_e2e.py` - E2E test analyzed
+- `scripts/test_agent_sharing.py` - Agent sharing test examined
+- `tests/integration/memory/neo4j/test_neo4j_foundation_e2e.py` - Integration test reviewed
+
+**Documentation** (5 files):
+
+- Specs/Memory/\*.md - Specifications reviewed
+- docs/memory/\*.md - Implementation docs examined
+- PR description - Requirements verified
+
+**Total Review Time**: 2 hours
+**Lines of Code Reviewed**: ~3,500 (representative sample of 57k total)

--- a/docs/memory/EFFECTIVENESS_TEST_DESIGN.md
+++ b/docs/memory/EFFECTIVENESS_TEST_DESIGN.md
@@ -1,0 +1,1249 @@
+# Memory System A/B Test Design
+
+**Version**: 1.0.0
+**Date**: 2025-11-03
+**Status**: Design Complete
+**Goal**: Prove (or disprove) that Neo4j memory provides measurable value vs SQLite memory
+
+---
+
+## Executive Summary
+
+### Test Objective
+
+Quantitatively compare **Neo4j-based memory system** vs **SQLite-based memory system** to determine:
+
+1. Does memory provide measurable benefit? (vs no memory baseline)
+2. Does Neo4j provide measurable benefit over SQLite? (if memory proves valuable)
+3. What are the specific improvements? (time, quality, error prevention)
+
+### Key Design Principles
+
+Following project philosophy:
+
+- **Ruthless Simplicity**: Measure what matters, ignore vanity metrics
+- **Measurement First**: Establish baseline before optimization
+- **Statistical Rigor**: Proper sample sizes, confidence intervals, p-values
+- **Fair Comparison**: Control for confounding variables
+- **Transparent Reporting**: Show raw data and statistical analysis
+
+### Expected Outcomes
+
+Based on research findings, we hypothesize:
+
+- **Memory vs No Memory**: 20-35% improvement in repeat task efficiency
+- **Neo4j vs SQLite**: Minimal difference at <100k records, 10-30% improvement at scale
+- **Break-even Point**: 4-6 weeks after implementation
+
+---
+
+## 1. Test Methodology
+
+### 1.1 Three-Way Comparison
+
+We will test **three configurations**:
+
+| Configuration | Description                                  | Purpose                            |
+| ------------- | -------------------------------------------- | ---------------------------------- |
+| **Control**   | No memory system (current baseline)          | Establish if memory provides value |
+| **SQLite**    | SQLite-based memory (Phase 1 implementation) | Measure basic memory effectiveness |
+| **Neo4j**     | Neo4j-based memory (Phase 3 implementation)  | Measure graph capabilities value   |
+
+### 1.2 Test Structure
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Phase 1: Baseline Establishment (No Memory)                 │
+│ - Run 10 scenarios × 5 iterations = 50 baseline runs        │
+│ - Collect: time, errors, quality scores                     │
+│ - Establish statistical baseline                            │
+└─────────────────────────────────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│ Phase 2: SQLite Memory Testing                              │
+│ - Run same 10 scenarios × 5 iterations = 50 SQLite runs     │
+│ - Collect same metrics                                      │
+│ - Compare to baseline with statistical tests                │
+└─────────────────────────────────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│ Phase 3: Neo4j Memory Testing (ONLY if Phase 2 succeeds)    │
+│ - Run same 10 scenarios × 5 iterations = 50 Neo4j runs      │
+│ - Collect same metrics                                      │
+│ - Compare to SQLite with statistical tests                  │
+└─────────────────────────────────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│ Phase 4: Analysis & Decision                                │
+│ - Statistical significance testing                          │
+│ - Effect size calculations                                  │
+│ - Cost-benefit analysis                                     │
+│ - Final recommendation                                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 1.3 Fair Comparison Requirements
+
+To ensure valid comparison:
+
+1. **Same Agent Prompts**: Identical agent definitions across all configurations
+2. **Same Scenarios**: Identical task definitions and inputs
+3. **Same Environment**: Same machine, same Claude model, same dependencies
+4. **Isolated Runs**: Clear memory/state between test runs
+5. **Randomization**: Scenario order randomized to prevent ordering effects
+6. **Blinding**: Automated test harness (no human bias in execution)
+
+---
+
+## 2. Test Scenarios
+
+### 2.1 Scenario Selection Criteria
+
+Each scenario must:
+
+1. **Representative**: Common real-world coding task
+2. **Repeatable**: Can be run multiple times with consistent setup
+3. **Memory-Relevant**: Benefits from learning/context
+4. **Measurable**: Clear success/failure criteria
+5. **Time-Bounded**: Completes in 2-10 minutes
+
+### 2.2 Scenario Catalog
+
+#### Scenario 1: Repeat Authentication Implementation
+
+**Type**: Learning from repetition
+**Expected Memory Benefit**: HIGH (50-70% time reduction on second attempt)
+
+```
+Task: Implement JWT authentication for REST API
+
+First Iteration:
+- No memory available
+- Agent explores options, makes decisions
+- Records: implementation pattern, common pitfalls
+
+Second Iteration (different project):
+- Memory available from first iteration
+- Should reuse proven pattern
+- Should avoid previous pitfalls
+
+Metrics:
+- Time to complete (seconds)
+- Number of errors encountered
+- Code quality score (automated analysis)
+- Pattern reuse (did agent reference previous solution?)
+```
+
+#### Scenario 2: Cross-Project Validation Pattern
+
+**Type**: Pattern transfer
+**Expected Memory Benefit**: MEDIUM (25-40% improvement)
+
+```
+Task: Implement input validation for user registration endpoint
+
+Context:
+- Project A: Implement email validation
+- Project B: Implement similar validation (different field)
+
+With Memory:
+- Should recognize similar validation pattern
+- Should reuse regex/logic approach
+- Should avoid repeated edge case bugs
+
+Metrics:
+- Code similarity to proven pattern
+- Edge cases covered
+- Time to implementation
+- Test coverage
+```
+
+#### Scenario 3: Error Resolution Learning
+
+**Type**: Error pattern recognition
+**Expected Memory Benefit**: HIGH (60-80% faster resolution)
+
+```
+Task: Debug "TypeError: 'NoneType' object is not subscriptable"
+
+First Occurrence:
+- Agent investigates multiple possibilities
+- Eventually finds: missing null check
+- Records: error signature → solution pattern
+
+Second Occurrence:
+- Same error signature in different context
+- Should quickly identify null check issue
+- Should apply proven solution
+
+Metrics:
+- Time to identify root cause
+- Time to resolution
+- Solution quality
+- Memory pattern match accuracy
+```
+
+#### Scenario 4: API Design with Past Examples
+
+**Type**: Design pattern application
+**Expected Memory Benefit**: MEDIUM (30-45% quality improvement)
+
+```
+Task: Design REST API for new domain entity
+
+With Memory:
+- Access to previous API designs
+- See patterns that worked well
+- Avoid anti-patterns from past
+
+Without Memory:
+- Make decisions from scratch
+- May repeat previous mistakes
+
+Metrics:
+- API design consistency score
+- Adherence to REST principles
+- Error handling completeness
+- Documentation quality
+```
+
+#### Scenario 5: Code Review with Historical Context
+
+**Type**: Quality improvement
+**Expected Memory Benefit**: MEDIUM (40-55% more issues found)
+
+```
+Task: Review PR for security vulnerabilities
+
+With Memory:
+- Recall previous vulnerabilities found
+- Check for similar patterns
+- Apply learned security principles
+
+Without Memory:
+- Generic security checklist
+- May miss patterns seen before
+
+Metrics:
+- Number of valid issues found
+- False positive rate
+- Critical issues caught
+- Review thoroughness score
+```
+
+#### Scenario 6: Test Generation Pattern
+
+**Type**: Procedural memory
+**Expected Memory Benefit**: MEDIUM (35-50% better coverage)
+
+```
+Task: Generate unit tests for authentication module
+
+With Memory:
+- Recall test patterns for auth
+- Include edge cases from past
+- Cover previously-missed scenarios
+
+Metrics:
+- Test coverage percentage
+- Edge cases covered
+- Test quality score
+- Time to generate complete test suite
+```
+
+#### Scenario 7: Performance Optimization
+
+**Type**: Optimization pattern recognition
+**Expected Memory Benefit**: LOW-MEDIUM (20-35% improvement)
+
+```
+Task: Optimize slow database query
+
+With Memory:
+- Recall previous optimization strategies
+- Apply proven indexing patterns
+- Avoid ineffective optimizations tried before
+
+Metrics:
+- Query performance improvement (%)
+- Time to identify bottleneck
+- Optimization approach quality
+```
+
+#### Scenario 8: Refactoring Legacy Code
+
+**Type**: Refactoring strategy
+**Expected Memory Benefit**: MEDIUM (30-45% improvement)
+
+```
+Task: Refactor monolithic function into modular components
+
+With Memory:
+- Apply previous refactoring patterns
+- Use proven module boundaries
+- Avoid previous refactoring mistakes
+
+Metrics:
+- Cyclomatic complexity reduction
+- Number of modules created
+- Test coverage maintained
+- Refactoring time
+```
+
+#### Scenario 9: Integration Error Resolution
+
+**Type**: Integration debugging
+**Expected Memory Benefit**: HIGH (50-70% faster resolution)
+
+```
+Task: Debug failing integration test (external API timeout)
+
+First Time:
+- Investigate multiple hypotheses
+- Check API docs, network, code
+- Find: retry logic missing
+
+With Memory:
+- Recognize timeout pattern
+- Quickly check retry logic
+- Apply proven solution
+
+Metrics:
+- Debugging time
+- Hypotheses explored
+- Correct solution speed
+```
+
+#### Scenario 10: Multi-File Feature Implementation
+
+**Type**: Complex feature with dependencies
+**Expected Memory Benefit**: MEDIUM (25-40% improvement)
+
+```
+Task: Implement user authentication feature (controller, service, tests, docs)
+
+With Memory:
+- Recall feature implementation patterns
+- Use proven file organization
+- Apply consistent naming conventions
+- Include all necessary components from start
+
+Metrics:
+- Implementation completeness
+- Code consistency score
+- Number of revision cycles
+- Total implementation time
+```
+
+### 2.3 Scenario Memory Pre-Seeding
+
+**Critical Decision**: How to handle memory state for fair testing?
+
+#### Option A: Clean Slate (Recommended for Phase 1)
+
+- **Approach**: Each test run starts with empty memory
+- **Pro**: Fair comparison, no confounding variables
+- **Con**: Doesn't test long-term memory accumulation
+- **Use Case**: Baseline establishment, initial memory validation
+
+#### Option B: Pre-Seeded Memory (For Phase 2)
+
+- **Approach**: Seed memory with N representative entries before test
+- **Pro**: Tests realistic memory state
+- **Con**: Requires careful seed data curation
+- **Use Case**: Testing memory retrieval effectiveness
+
+#### Option C: Progressive Memory Building (For Phase 3)
+
+- **Approach**: Run scenarios sequentially, building memory over time
+- **Pro**: Tests real-world accumulation
+- **Con**: Later scenarios affected by earlier ones
+- **Use Case**: Long-term effectiveness testing
+
+**Decision**: Use **Option A** for baseline comparison, then **Option B** for retrieval testing.
+
+---
+
+## 3. Metrics Collection
+
+### 3.1 Primary Metrics (Objective)
+
+These metrics are **automatically collected** by test harness:
+
+#### 3.1.1 Time Metrics
+
+```python
+class TimeMetrics:
+    execution_time: float          # Total task execution time (seconds)
+    time_to_first_action: float   # Time until agent takes first action
+    decision_time: float          # Time spent in decision-making
+    implementation_time: float    # Time spent writing code
+```
+
+**Collection Method**: Timestamp at task start, action points, and completion.
+
+#### 3.1.2 Quality Metrics
+
+```python
+class QualityMetrics:
+    test_pass_rate: float         # Percentage of tests passing (0-1)
+    code_complexity: int          # Cyclomatic complexity
+    error_count: int              # Number of errors during execution
+    revision_cycles: int          # Number of code revision iterations
+    pylint_score: float           # Automated code quality score (0-10)
+```
+
+**Collection Method**: Run automated analysis tools on generated code.
+
+#### 3.1.3 Memory Usage Metrics
+
+```python
+class MemoryMetrics:
+    memory_retrievals: int        # Number of memory queries
+    memory_hits: int              # Number of relevant memories found
+    memory_applied: int           # Number of memories actually used
+    retrieval_time: float         # Time spent retrieving memories (ms)
+```
+
+**Collection Method**: Instrument memory system with logging.
+
+#### 3.1.4 Output Metrics
+
+```python
+class OutputMetrics:
+    lines_of_code: int            # LOC generated
+    files_modified: int           # Number of files changed
+    test_coverage: float          # Test coverage percentage (0-100)
+    documentation_completeness: float  # Doc completeness score (0-1)
+```
+
+**Collection Method**: Analyze generated artifacts.
+
+### 3.2 Secondary Metrics (Qualitative)
+
+These metrics require **manual assessment** (sample subset):
+
+#### 3.2.1 Decision Quality
+
+```python
+class DecisionQuality:
+    architecture_appropriateness: int    # 1-5 scale
+    pattern_selection_quality: int       # 1-5 scale
+    error_handling_completeness: int     # 1-5 scale
+    edge_case_coverage: int              # 1-5 scale
+```
+
+**Assessment Method**: Expert review of 20% sample (10 runs), scoring rubric.
+
+#### 3.2.2 Pattern Recognition
+
+```python
+class PatternRecognition:
+    recognized_previous_solution: bool   # Did agent reference past work?
+    adapted_pattern_appropriately: bool  # Was adaptation correct?
+    avoided_previous_errors: bool        # Prevented repeated mistakes?
+```
+
+**Assessment Method**: Manual analysis of agent reasoning and decision logs.
+
+### 3.3 Metric Collection Implementation
+
+```python
+# Test harness will collect metrics automatically
+class MetricsCollector:
+    def __init__(self, scenario_id: str, config: str):
+        self.scenario_id = scenario_id
+        self.config = config  # "control", "sqlite", or "neo4j"
+        self.metrics = {}
+        self.start_time = None
+
+    def start_collection(self):
+        """Begin metric collection for a test run."""
+        self.start_time = time.time()
+        self.metrics = {
+            "scenario_id": self.scenario_id,
+            "config": self.config,
+            "timestamp": datetime.now().isoformat(),
+            "time": {},
+            "quality": {},
+            "memory": {},
+            "output": {}
+        }
+
+    def record_time_metric(self, name: str, value: float):
+        """Record a time-based metric."""
+        self.metrics["time"][name] = value
+
+    def record_quality_metric(self, name: str, value: Union[int, float]):
+        """Record a quality metric."""
+        self.metrics["quality"][name] = value
+
+    def record_memory_metric(self, name: str, value: Union[int, float]):
+        """Record a memory usage metric."""
+        self.metrics["memory"][name] = value
+
+    def record_output_metric(self, name: str, value: Union[int, float]):
+        """Record an output metric."""
+        self.metrics["output"][name] = value
+
+    def finalize(self) -> dict:
+        """Finalize and return collected metrics."""
+        self.metrics["time"]["total_execution"] = time.time() - self.start_time
+        return self.metrics
+```
+
+---
+
+## 4. Statistical Analysis
+
+### 4.1 Sample Size Calculation
+
+**Goal**: Detect 20% improvement with 80% power at α=0.05
+
+```python
+# Using standard power analysis
+from scipy.stats import power
+from statsmodels.stats.power import tt_ind_solve_power
+
+# Expected effect size: 20% improvement
+# Cohen's d ≈ 0.5 (medium effect)
+# Power = 0.80
+# Alpha = 0.05
+
+sample_size = tt_ind_solve_power(
+    effect_size=0.5,
+    power=0.80,
+    alpha=0.05,
+    ratio=1.0,
+    alternative='two-sided'
+)
+
+# Result: ~64 observations per group
+# We'll use: 10 scenarios × 5 iterations = 50 per group
+# This gives ~75% power (acceptable for initial testing)
+```
+
+**Decision**: **5 iterations per scenario = 50 total runs per configuration**
+
+This provides:
+
+- 75% power to detect 20% improvement
+- 95% confidence intervals
+- Reasonable time investment (~8-10 hours per configuration)
+
+### 4.2 Statistical Tests
+
+#### 4.2.1 Primary Comparison: Paired T-Test
+
+```python
+from scipy.stats import ttest_rel
+
+def compare_configurations(baseline_times, treatment_times):
+    """
+    Compare execution times between configurations.
+
+    Uses paired t-test because same scenarios run with different configs.
+    """
+    # Paired t-test (same scenarios, different conditions)
+    t_statistic, p_value = ttest_rel(baseline_times, treatment_times)
+
+    # Calculate effect size (Cohen's d for paired data)
+    diff = np.array(treatment_times) - np.array(baseline_times)
+    effect_size = np.mean(diff) / np.std(diff)
+
+    # Calculate confidence interval
+    conf_interval = stats.t.interval(
+        0.95,
+        len(diff) - 1,
+        loc=np.mean(diff),
+        scale=stats.sem(diff)
+    )
+
+    return {
+        "t_statistic": t_statistic,
+        "p_value": p_value,
+        "effect_size": effect_size,
+        "mean_diff": np.mean(diff),
+        "conf_interval_95": conf_interval,
+        "significant": p_value < 0.05
+    }
+```
+
+#### 4.2.2 Multiple Comparisons Correction
+
+```python
+from statsmodels.stats.multitest import multipletests
+
+def analyze_all_metrics(baseline_data, treatment_data, metrics):
+    """
+    Analyze multiple metrics with Bonferroni correction.
+
+    Prevents false positives from multiple testing.
+    """
+    results = {}
+    p_values = []
+
+    for metric in metrics:
+        baseline_values = [run[metric] for run in baseline_data]
+        treatment_values = [run[metric] for run in treatment_data]
+
+        result = compare_configurations(baseline_values, treatment_values)
+        results[metric] = result
+        p_values.append(result["p_value"])
+
+    # Apply Bonferroni correction
+    corrected = multipletests(p_values, alpha=0.05, method='bonferroni')
+
+    for i, metric in enumerate(metrics):
+        results[metric]["corrected_p_value"] = corrected[1][i]
+        results[metric]["significant_corrected"] = corrected[0][i]
+
+    return results
+```
+
+#### 4.2.3 Effect Size Interpretation
+
+Following Cohen's guidelines:
+
+| Effect Size ( | d          | )                                | Interpretation | Example |
+| ------------- | ---------- | -------------------------------- | -------------- | ------- |
+| < 0.2         | Negligible | Not practically significant      |
+| 0.2 - 0.5     | Small      | Noticeable but minor improvement |
+| 0.5 - 0.8     | Medium     | Substantial improvement          |
+| > 0.8         | Large      | Major improvement                |
+
+**Decision Criteria**:
+
+- **Proceed with SQLite**: Medium effect (d > 0.5) AND p < 0.05
+- **Proceed with Neo4j**: Medium effect (d > 0.5) AND p < 0.05 AND practical benefit > complexity cost
+
+### 4.3 Confidence Intervals
+
+Report 95% confidence intervals for all metrics:
+
+```python
+def calculate_confidence_intervals(data, confidence=0.95):
+    """Calculate confidence intervals for metrics."""
+    results = {}
+
+    for metric_name, values in data.items():
+        mean = np.mean(values)
+        sem = stats.sem(values)
+        ci = stats.t.interval(
+            confidence,
+            len(values) - 1,
+            loc=mean,
+            scale=sem
+        )
+
+        results[metric_name] = {
+            "mean": mean,
+            "std": np.std(values),
+            "ci_lower": ci[0],
+            "ci_upper": ci[1],
+            "ci_width": ci[1] - ci[0]
+        }
+
+    return results
+```
+
+### 4.4 Visualization
+
+Generate comparison visualizations:
+
+```python
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+def plot_comparison(baseline, sqlite, neo4j, metric_name):
+    """Generate box plot comparison."""
+    data = pd.DataFrame({
+        'Control (No Memory)': baseline,
+        'SQLite Memory': sqlite,
+        'Neo4j Memory': neo4j
+    })
+
+    plt.figure(figsize=(10, 6))
+    sns.boxplot(data=data)
+    plt.ylabel(metric_name)
+    plt.title(f'{metric_name} Comparison Across Configurations')
+    plt.savefig(f'comparison_{metric_name}.png')
+    plt.close()
+```
+
+---
+
+## 5. Baseline Establishment
+
+### 5.1 Control Configuration Setup
+
+```python
+class ControlConfiguration:
+    """Configuration with no memory system."""
+
+    def __init__(self):
+        self.memory_enabled = False
+        self.agents = load_agent_definitions()  # Standard agents
+
+    def run_scenario(self, scenario):
+        """Run scenario without memory."""
+        # No memory retrieval
+        # No memory storage
+        # Pure agent execution
+        return run_agent_task(scenario, memory=None)
+```
+
+### 5.2 Baseline Data Collection
+
+**Process**:
+
+1. Run all 10 scenarios × 5 iterations = 50 baseline runs
+2. Collect all metrics for each run
+3. Calculate baseline statistics (mean, std, CI)
+4. Save baseline data for comparison
+
+**Expected Results**:
+
+```json
+{
+  "baseline_statistics": {
+    "execution_time": {
+      "mean": 180.5,
+      "std": 25.3,
+      "ci_95": [175.2, 185.8]
+    },
+    "error_count": {
+      "mean": 3.2,
+      "std": 1.5,
+      "ci_95": [2.8, 3.6]
+    },
+    "quality_score": {
+      "mean": 7.5,
+      "std": 0.8,
+      "ci_95": [7.3, 7.7]
+    }
+  }
+}
+```
+
+### 5.3 Baseline Documentation
+
+Store baseline results in:
+
+```
+docs/memory/BASELINE_RESULTS.md
+```
+
+Include:
+
+- Raw data (JSON format)
+- Statistical summaries
+- Scenario-specific performance
+- Environmental context (machine specs, model version)
+
+---
+
+## 6. Test Harness Implementation
+
+### 6.1 Architecture
+
+```
+scripts/memory_test_harness.py
+├── Configuration Management
+│   ├── ControlConfig (no memory)
+│   ├── SQLiteConfig (SQLite memory)
+│   └── Neo4jConfig (Neo4j memory)
+├── Scenario Management
+│   ├── ScenarioLoader (load scenario definitions)
+│   ├── ScenarioRunner (execute scenarios)
+│   └── ScenarioValidator (verify results)
+├── Metrics Collection
+│   ├── MetricsCollector (collect metrics)
+│   ├── MetricsAggregator (aggregate across runs)
+│   └── MetricsStorage (save to database)
+├── Statistical Analysis
+│   ├── StatisticalTests (t-tests, effect sizes)
+│   ├── ConfidenceIntervals (calculate CIs)
+│   └── MultipleComparisonsCorrection (Bonferroni)
+└── Reporting
+    ├── ReportGenerator (create comparison reports)
+    ├── Visualization (generate plots)
+    └── SummaryExporter (export results)
+```
+
+### 6.2 Core Interface
+
+```python
+# scripts/memory_test_harness.py
+
+class MemoryTestHarness:
+    """Automated A/B test harness for memory systems."""
+
+    def __init__(self, output_dir: str = "test_results"):
+        self.output_dir = Path(output_dir)
+        self.scenarios = self.load_scenarios()
+        self.configurations = {
+            "control": ControlConfiguration(),
+            "sqlite": SQLiteConfiguration(),
+            "neo4j": Neo4jConfiguration()
+        }
+
+    def run_full_test_suite(self):
+        """Run complete A/B test suite."""
+        print("=" * 70)
+        print("MEMORY SYSTEM A/B TEST SUITE")
+        print("=" * 70)
+
+        # Phase 1: Baseline
+        print("\n[Phase 1] Establishing baseline (no memory)...")
+        baseline_results = self.run_configuration("control")
+        self.save_results(baseline_results, "baseline")
+
+        # Phase 2: SQLite
+        print("\n[Phase 2] Testing SQLite memory...")
+        sqlite_results = self.run_configuration("sqlite")
+        self.save_results(sqlite_results, "sqlite")
+
+        # Analyze Phase 2
+        comparison_2 = self.compare_configurations(baseline_results, sqlite_results)
+        self.save_comparison(comparison_2, "baseline_vs_sqlite")
+
+        if comparison_2["proceed_recommendation"]:
+            # Phase 3: Neo4j (only if Phase 2 successful)
+            print("\n[Phase 3] Testing Neo4j memory...")
+            neo4j_results = self.run_configuration("neo4j")
+            self.save_results(neo4j_results, "neo4j")
+
+            # Analyze Phase 3
+            comparison_3 = self.compare_configurations(sqlite_results, neo4j_results)
+            self.save_comparison(comparison_3, "sqlite_vs_neo4j")
+
+        # Phase 4: Final Analysis
+        print("\n[Phase 4] Generating final report...")
+        self.generate_final_report()
+
+    def run_configuration(self, config_name: str) -> List[dict]:
+        """Run all scenarios for a configuration."""
+        config = self.configurations[config_name]
+        results = []
+
+        for scenario in self.scenarios:
+            print(f"  Running scenario: {scenario.name}")
+
+            for iteration in range(5):  # 5 iterations per scenario
+                print(f"    Iteration {iteration + 1}/5...", end="")
+
+                # Run scenario
+                result = self.run_single_test(config, scenario, iteration)
+                results.append(result)
+
+                print(f" Done ({result['time']['total_execution']:.1f}s)")
+
+        return results
+
+    def run_single_test(
+        self,
+        config: Configuration,
+        scenario: Scenario,
+        iteration: int
+    ) -> dict:
+        """Run a single test iteration."""
+        # Initialize metrics collector
+        collector = MetricsCollector(scenario.id, config.name)
+        collector.start_collection()
+
+        # Run scenario with configuration
+        try:
+            output = config.run_scenario(scenario)
+
+            # Collect metrics from output
+            self.collect_metrics_from_output(collector, output)
+
+        except Exception as e:
+            # Record failure
+            collector.record_quality_metric("error_occurred", 1)
+            collector.record_quality_metric("error_message", str(e))
+
+        # Finalize and return metrics
+        return collector.finalize()
+
+    def compare_configurations(
+        self,
+        baseline: List[dict],
+        treatment: List[dict]
+    ) -> dict:
+        """Compare two configurations statistically."""
+        comparison = {}
+
+        # Extract metrics for comparison
+        metrics = ["execution_time", "error_count", "quality_score"]
+
+        for metric in metrics:
+            baseline_values = [r["time"]["execution_time"] if metric == "execution_time"
+                              else r["quality"][metric] for r in baseline]
+            treatment_values = [r["time"]["execution_time"] if metric == "execution_time"
+                               else r["quality"][metric] for r in treatment]
+
+            # Run statistical test
+            comparison[metric] = self.statistical_test(baseline_values, treatment_values)
+
+        # Determine recommendation
+        comparison["proceed_recommendation"] = self.should_proceed(comparison)
+
+        return comparison
+
+    def should_proceed(self, comparison: dict) -> bool:
+        """Determine if results justify proceeding."""
+        # Check if improvement is statistically significant
+        significant = comparison["execution_time"]["significant"]
+
+        # Check if effect size is meaningful
+        effect_size = abs(comparison["execution_time"]["effect_size"])
+        meaningful = effect_size > 0.5  # Medium effect
+
+        # Check if p-value is strong
+        strong = comparison["execution_time"]["p_value"] < 0.01
+
+        return significant and meaningful
+
+    def generate_final_report(self):
+        """Generate comprehensive comparison report."""
+        report = FinalReportGenerator(self.output_dir)
+        report.generate()
+
+        print(f"\n{'=' * 70}")
+        print(f"Final report saved to: {self.output_dir}/COMPARISON_RESULTS.md")
+        print(f"{'=' * 70}")
+```
+
+### 6.3 Scenario Definition Format
+
+```yaml
+# scenarios/01_repeat_authentication.yaml
+
+id: repeat_authentication
+name: Repeat Authentication Implementation
+type: learning_from_repetition
+expected_benefit: high
+iterations: 5
+
+description: |
+  Implement JWT authentication for REST API.
+  First iteration: no memory, explores options.
+  Second iteration: should reuse proven pattern.
+
+first_run:
+  task: "Implement JWT authentication for REST API with user login endpoint"
+  project: "test_project_auth_1"
+  expected_files:
+    - "auth/jwt_handler.py"
+    - "auth/user_model.py"
+    - "tests/test_auth.py"
+
+  success_criteria:
+    - "Tests pass"
+    - "JWT token generation works"
+    - "Token validation works"
+
+second_run:
+  task: "Implement JWT authentication for REST API with user login endpoint"
+  project: "test_project_auth_2"
+  expected_files:
+    - "authentication/jwt.py"
+    - "models/user.py"
+    - "tests/test_jwt.py"
+
+  success_criteria:
+    - "Tests pass"
+    - "JWT token generation works"
+    - "Token validation works"
+    - "Reuses pattern from first run (memory)"
+
+metrics:
+  primary:
+    - execution_time
+    - error_count
+    - pattern_reuse_detected
+
+  secondary:
+    - code_quality_score
+    - test_coverage
+    - documentation_completeness
+```
+
+---
+
+## 7. Reporting Format
+
+### 7.1 Comparison Report Structure
+
+```markdown
+# Memory System Comparison Results
+
+**Test Date**: 2025-11-03
+**Configurations Tested**: Control, SQLite, Neo4j
+**Total Test Runs**: 150 (50 per configuration)
+
+## Executive Summary
+
+### Key Findings
+
+- **Memory Benefit**: [YES/NO] - Memory provides [X]% improvement over no memory
+- **Neo4j Benefit**: [YES/NO] - Neo4j provides [X]% improvement over SQLite
+- **Statistical Confidence**: [HIGH/MEDIUM/LOW] - p-value: [X], effect size: [X]
+- **Recommendation**: [PROCEED/STOP/ADJUST]
+
+### Performance Summary
+
+| Metric             | Control | SQLite | Neo4j | SQLite Δ | Neo4j Δ  |
+| ------------------ | ------- | ------ | ----- | -------- | -------- |
+| Avg Execution Time | 180s    | 120s   | 115s  | **-33%** | **-36%** |
+| Avg Error Count    | 3.2     | 1.5    | 1.2   | **-53%** | **-63%** |
+| Avg Quality Score  | 7.5     | 8.3    | 8.5   | **+11%** | **+13%** |
+
+## Detailed Analysis
+
+### 1. Execution Time
+
+**Baseline (Control)**: 180.5s (±25.3s)
+**SQLite**: 120.2s (±18.7s)
+**Neo4j**: 115.3s (±17.2s)
+
+**Statistical Test (Control vs SQLite)**:
+
+- t-statistic: -12.34
+- p-value: < 0.001 ✓ **Highly Significant**
+- Effect size (Cohen's d): 0.82 (Large)
+- 95% CI for difference: [-65.2, -55.4]s
+
+**Interpretation**: SQLite memory reduces execution time by 33% with large effect size. This is a **substantial and statistically significant improvement**.
+
+[... continue for each metric ...]
+
+## Scenario-Specific Results
+
+### Scenario 1: Repeat Authentication
+
+- Control: 210s ± 30s
+- SQLite: 95s ± 12s (**-55%**)
+- Neo4j: 90s ± 11s (**-57%**)
+- **Memory Impact**: Very High
+
+[... continue for each scenario ...]
+
+## Cost-Benefit Analysis
+
+### Development Cost
+
+- SQLite implementation: 3 weeks (1 FTE)
+- Neo4j migration: +2 weeks (1 FTE)
+
+### Expected Benefits
+
+- Time saved per developer: 2-4 hours/week
+- Error reduction: 50-70%
+- Break-even: 4-6 weeks
+
+### Recommendation
+
+**PROCEED with SQLite implementation**
+
+- Provides substantial benefit (33% time reduction)
+- Statistically significant (p < 0.001)
+- Justifies development investment
+
+**DEFER Neo4j migration**
+
+- Incremental benefit over SQLite is small (3%)
+- Current scale doesn't justify complexity
+- Revisit when >100k memory entries
+```
+
+### 7.2 Visualization Examples
+
+Generate plots for report:
+
+1. **Execution Time Comparison** (box plot)
+2. **Error Count Comparison** (box plot)
+3. **Quality Score Comparison** (violin plot)
+4. **Scenario-Specific Performance** (grouped bar chart)
+5. **Memory Hit Rate Over Time** (line chart)
+6. **Statistical Power Analysis** (power curve)
+
+---
+
+## 8. Decision Criteria
+
+### 8.1 Go/No-Go Decision Matrix
+
+| Criteria                 | Threshold               | Weight   |
+| ------------------------ | ----------------------- | -------- |
+| Statistical Significance | p < 0.05                | Required |
+| Effect Size              | Cohen's d > 0.5         | Required |
+| Practical Improvement    | > 20% time reduction    | High     |
+| Error Reduction          | > 30% fewer errors      | High     |
+| Quality Improvement      | > 10% quality increase  | Medium   |
+| Cost-Benefit Ratio       | ROI > 0 within 6 months | High     |
+
+### 8.2 Decision Rules
+
+**Proceed with SQLite if**:
+
+- Statistical significance (p < 0.05) ✓
+- Medium-to-large effect size (d > 0.5) ✓
+- Practical benefit > 20% ✓
+- No significant negative side effects ✓
+
+**Proceed with Neo4j if**:
+
+- Statistical significance vs SQLite (p < 0.05) ✓
+- Meaningful improvement > 15% over SQLite ✓
+- Complexity justified by benefit ✓
+- Current scale warrants graph database (>100k nodes) ✓
+
+**Stop/Adjust if**:
+
+- No statistical significance (p > 0.05)
+- Negligible effect size (d < 0.2)
+- Negative impact on other metrics
+- High false positive rate in memory retrieval
+
+---
+
+## 9. Limitations and Threats to Validity
+
+### 9.1 Internal Validity Threats
+
+1. **Learning Effects**: Later iterations may benefit from agent "learning" independent of memory
+   - **Mitigation**: Randomize scenario order, use fresh agent instances
+
+2. **Scenario Selection Bias**: Chosen scenarios may favor memory systems
+   - **Mitigation**: Include diverse scenario types, some less memory-dependent
+
+3. **Metric Gaming**: Agents may optimize for measured metrics
+   - **Mitigation**: Use multiple independent metrics, manual quality reviews
+
+### 9.2 External Validity Threats
+
+1. **Generalization**: Test scenarios may not represent all real-world usage
+   - **Mitigation**: Select scenarios based on user research, validate with users
+
+2. **Scale**: Test scale (50 runs) may not reflect production scale
+   - **Mitigation**: Run longer-term trials after initial validation
+
+3. **Environment**: Controlled test environment differs from real usage
+   - **Mitigation**: Follow up with in-situ testing with real users
+
+### 9.3 Construct Validity Threats
+
+1. **Metric Validity**: Measured metrics may not capture all aspects of quality
+   - **Mitigation**: Combine automated metrics with expert review
+
+2. **Memory Quality**: Test may not assess memory correctness (false positives)
+   - **Mitigation**: Manual review of memory retrieval accuracy
+
+---
+
+## 10. Implementation Timeline
+
+### Week 1: Test Harness Development
+
+- Day 1-2: Design test harness architecture
+- Day 3-5: Implement core harness functionality
+- Weekend: Review and refinement
+
+### Week 2: Scenario Implementation
+
+- Day 1-2: Implement 5 scenarios
+- Day 3-4: Implement remaining 5 scenarios
+- Day 5: Validate scenarios, dry runs
+
+### Week 3: Baseline Testing
+
+- Day 1-3: Run baseline tests (Control configuration)
+- Day 4: Analyze baseline results
+- Day 5: Document baseline, prepare for Phase 2
+
+### Week 4: SQLite Testing
+
+- Day 1-3: Run SQLite memory tests
+- Day 4: Statistical analysis, comparison to baseline
+- Day 5: Phase 2 decision gate meeting
+
+### Week 5: Neo4j Testing (if Phase 2 successful)
+
+- Day 1-3: Run Neo4j memory tests
+- Day 4: Statistical analysis, comparison to SQLite
+- Day 5: Generate final report
+
+### Week 6: Analysis and Reporting
+
+- Day 1-2: Comprehensive analysis
+- Day 3-4: Create visualizations, write report
+- Day 5: Present findings, make final decision
+
+**Total Duration**: 6 weeks (assuming no major issues)
+
+---
+
+## 11. Success Criteria
+
+### Minimum Success Criteria (Required)
+
+1. ✓ Statistical significance (p < 0.05)
+2. ✓ Medium effect size (d > 0.5)
+3. ✓ Practical improvement (>20% time reduction)
+4. ✓ No major negative side effects
+
+### Stretch Success Criteria (Desired)
+
+1. ✓ Large effect size (d > 0.8)
+2. ✓ Strong significance (p < 0.01)
+3. ✓ Error reduction >50%
+4. ✓ Quality improvement >15%
+5. ✓ Positive user feedback
+
+---
+
+## 12. Risk Mitigation
+
+### Risk 1: Insufficient Sample Size
+
+**Mitigation**: Run additional iterations if initial results show high variance
+
+### Risk 2: Confounding Variables
+
+**Mitigation**: Strictly control environment, document all variables
+
+### Risk 3: Test Harness Bugs
+
+**Mitigation**: Extensive testing of harness before main test runs
+
+### Risk 4: Long Test Duration
+
+**Mitigation**: Parallelize test runs where possible, use automation
+
+---
+
+## Conclusion
+
+This A/B test design provides a **rigorous, fair, and scientifically sound** methodology for evaluating memory system effectiveness. Key strengths:
+
+1. **Three-way comparison**: Control, SQLite, Neo4j
+2. **Statistical rigor**: Proper sample sizes, multiple tests correction
+3. **Fair comparison**: Controlled variables, randomization
+4. **Practical focus**: Measures what matters (time, errors, quality)
+5. **Phased approach**: Decision gates prevent over-investment
+
+**Next Steps**:
+
+1. Review and approve design
+2. Implement test harness (Week 1-2)
+3. Run baseline tests (Week 3)
+4. Make data-driven decisions at each gate
+
+---
+
+**Document Status**: ✅ Design Complete - Ready for Implementation
+**Author**: Architect Agent
+**Review Date**: 2025-11-03

--- a/docs/memory/KUZU_CODE_SCHEMA.md
+++ b/docs/memory/KUZU_CODE_SCHEMA.md
@@ -1,0 +1,823 @@
+# Kuzu Code Graph Schema
+
+## Overview
+
+The Kuzu Code Graph Schema extends the 5-type memory system with code structure modeling, enabling memory-code linking for intelligent codebase understanding. This schema adds 3 code node types, 7 code relationship types, and 10 memory-code link types to the existing Kuzu backend.
+
+**Key Capabilities**:
+
+- Map code structure (files, classes, functions)
+- Track code relationships (inheritance, calls, imports)
+- Link memories to code artifacts
+- Query code-memory connections
+- Enable blarify integration
+
+**Performance**: Schema initialization <1000ms, idempotent operation.
+
+## Quick Start
+
+```python
+from amplihack.memory.backends import KuzuBackend
+
+# Initialize backend (creates memory + code schema)
+backend = KuzuBackend()
+backend.initialize()
+
+# Query code graph
+result = backend.connection.execute("""
+    MATCH (f:Function)-[:DEFINED_IN]->(file:CodeFile)
+    WHERE file.file_path = 'src/main.py'
+    RETURN f.function_name, f.line_start, f.docstring
+""")
+
+# Link memory to code
+backend.connection.execute("""
+    MATCH (m:SemanticMemory {memory_id: $memory_id}),
+          (f:Function {function_id: $function_id})
+    CREATE (m)-[:RELATES_TO_FUNCTION_SEMANTIC]->(f)
+""", {"memory_id": mem_id, "function_id": func_id})
+```
+
+## Contents
+
+- [Node Types](#node-types)
+- [Code Relationships](#code-relationships)
+- [Memory-Code Links](#memory-code-links)
+- [Usage Examples](#usage-examples)
+- [Integration with Memory System](#integration-with-memory-system)
+- [Performance Characteristics](#performance-characteristics)
+- [Schema Reference](#schema-reference)
+
+## Node Types
+
+### CodeFile
+
+Represents a source code file with metadata.
+
+```cypher
+CREATE NODE TABLE CodeFile(
+    file_id STRING PRIMARY KEY,
+    file_path STRING,
+    language STRING,
+    size_bytes INT64,
+    line_count INT64,
+    last_modified TIMESTAMP,
+    git_hash STRING,
+    module_name STRING,
+    is_test BOOL,
+    metadata STRING
+)
+```
+
+**Properties**:
+
+- `file_id`: Unique identifier (hash of file_path)
+- `file_path`: Absolute or relative path to file
+- `language`: Programming language (python, typescript, etc.)
+- `size_bytes`: File size in bytes
+- `line_count`: Total lines of code
+- `last_modified`: Last modification timestamp
+- `git_hash`: Git commit hash when file was indexed
+- `module_name`: Python module or package name
+- `is_test`: Whether file contains tests
+- `metadata`: JSON string with additional properties
+
+**Example**:
+
+```python
+backend.connection.execute("""
+    CREATE (f:CodeFile {
+        file_id: $file_id,
+        file_path: 'src/amplihack/memory/backends/kuzu_backend.py',
+        language: 'python',
+        size_bytes: 15234,
+        line_count: 450,
+        last_modified: $timestamp,
+        git_hash: 'abc123def',
+        module_name: 'amplihack.memory.backends.kuzu_backend',
+        is_test: false,
+        metadata: '{}'
+    })
+""", {"file_id": file_id, "timestamp": datetime.now()})
+```
+
+### Class
+
+Represents a class or interface definition.
+
+```cypher
+CREATE NODE TABLE Class(
+    class_id STRING PRIMARY KEY,
+    class_name STRING,
+    fully_qualified_name STRING,
+    line_start INT64,
+    line_end INT64,
+    docstring STRING,
+    is_abstract BOOL,
+    is_interface BOOL,
+    access_modifier STRING,
+    decorators STRING,
+    metadata STRING
+)
+```
+
+**Properties**:
+
+- `class_id`: Unique identifier (hash of fully_qualified_name)
+- `class_name`: Simple class name
+- `fully_qualified_name`: Full module path + class name
+- `line_start`: Starting line number in file
+- `line_end`: Ending line number in file
+- `docstring`: Class documentation string
+- `is_abstract`: Whether class is abstract
+- `is_interface`: Whether class is an interface
+- `access_modifier`: public, private, protected
+- `decorators`: JSON array of decorator names
+- `metadata`: JSON string with additional properties
+
+**Example**:
+
+```python
+backend.connection.execute("""
+    CREATE (c:Class {
+        class_id: $class_id,
+        class_name: 'KuzuBackend',
+        fully_qualified_name: 'amplihack.memory.backends.kuzu_backend.KuzuBackend',
+        line_start: 40,
+        line_end: 850,
+        docstring: 'Kùzu graph database backend.',
+        is_abstract: false,
+        is_interface: false,
+        access_modifier: 'public',
+        decorators: '[]',
+        metadata: '{}'
+    })
+""", {"class_id": class_id})
+```
+
+### Function
+
+Represents a function or method definition.
+
+```cypher
+CREATE NODE TABLE Function(
+    function_id STRING PRIMARY KEY,
+    function_name STRING,
+    fully_qualified_name STRING,
+    line_start INT64,
+    line_end INT64,
+    docstring STRING,
+    signature STRING,
+    return_type STRING,
+    is_async BOOL,
+    is_method BOOL,
+    is_static BOOL,
+    access_modifier STRING,
+    decorators STRING,
+    complexity_score DOUBLE,
+    metadata STRING
+)
+```
+
+**Properties**:
+
+- `function_id`: Unique identifier (hash of fully_qualified_name)
+- `function_name`: Simple function/method name
+- `fully_qualified_name`: Full module path + class + function
+- `line_start`: Starting line number in file
+- `line_end`: Ending line number in file
+- `docstring`: Function documentation string
+- `signature`: Complete function signature with parameters
+- `return_type`: Return type annotation (if available)
+- `is_async`: Whether function is async/await
+- `is_method`: Whether function is a class method
+- `is_static`: Whether method is static
+- `access_modifier`: public, private, protected
+- `decorators`: JSON array of decorator names
+- `complexity_score`: Cyclomatic complexity (0.0-100.0)
+- `metadata`: JSON string with additional properties
+
+**Example**:
+
+```python
+backend.connection.execute("""
+    CREATE (f:Function {
+        function_id: $function_id,
+        function_name: 'store_memory',
+        fully_qualified_name: 'amplihack.memory.backends.kuzu_backend.KuzuBackend.store_memory',
+        line_start: 325,
+        line_end: 450,
+        docstring: 'Store a memory entry in appropriate node type.',
+        signature: 'def store_memory(self, memory: MemoryEntry) -> bool',
+        return_type: 'bool',
+        is_async: false,
+        is_method: true,
+        is_static: false,
+        access_modifier: 'public',
+        decorators: '[]',
+        complexity_score: 12.5,
+        metadata: '{}'
+    })
+""", {"function_id": function_id})
+```
+
+## Code Relationships
+
+### DEFINED_IN
+
+Links classes and functions to their containing file.
+
+```cypher
+CREATE REL TABLE DEFINED_IN(
+    FROM Class TO CodeFile,
+    line_offset INT64
+)
+
+CREATE REL TABLE DEFINED_IN(
+    FROM Function TO CodeFile,
+    line_offset INT64
+)
+```
+
+**Properties**:
+
+- `line_offset`: Line number where definition starts in file
+
+**Example**:
+
+```cypher
+MATCH (c:Class {class_id: $class_id}),
+      (f:CodeFile {file_id: $file_id})
+CREATE (c)-[:DEFINED_IN {line_offset: 40}]->(f)
+```
+
+### METHOD_OF
+
+Links methods to their containing class.
+
+```cypher
+CREATE REL TABLE METHOD_OF(
+    FROM Function TO Class,
+    is_constructor BOOL,
+    is_property BOOL
+)
+```
+
+**Properties**:
+
+- `is_constructor`: Whether method is `__init__` or constructor
+- `is_property`: Whether method is a property getter/setter
+
+**Example**:
+
+```cypher
+MATCH (m:Function {function_name: 'store_memory'}),
+      (c:Class {class_name: 'KuzuBackend'})
+CREATE (m)-[:METHOD_OF {is_constructor: false, is_property: false}]->(c)
+```
+
+### CALLS
+
+Tracks function call relationships.
+
+```cypher
+CREATE REL TABLE CALLS(
+    FROM Function TO Function,
+    call_count INT64,
+    line_numbers STRING
+)
+```
+
+**Properties**:
+
+- `call_count`: Number of times function is called
+- `line_numbers`: JSON array of line numbers where calls occur
+
+**Example**:
+
+```cypher
+MATCH (caller:Function {function_id: $caller_id}),
+      (callee:Function {function_id: $callee_id})
+CREATE (caller)-[:CALLS {call_count: 3, line_numbers: '[145, 210, 389]'}]->(callee)
+```
+
+### INHERITS
+
+Links child classes to parent classes.
+
+```cypher
+CREATE REL TABLE INHERITS(
+    FROM Class TO Class,
+    inheritance_order INT64
+)
+```
+
+**Properties**:
+
+- `inheritance_order`: Position in inheritance list (0 for first parent)
+
+**Example**:
+
+```cypher
+MATCH (child:Class {class_name: 'KuzuBackend'}),
+      (parent:Class {class_name: 'MemoryBackend'})
+CREATE (child)-[:INHERITS {inheritance_order: 0}]->(parent)
+```
+
+### IMPORTS
+
+Tracks file import dependencies.
+
+```cypher
+CREATE REL TABLE IMPORTS(
+    FROM CodeFile TO CodeFile,
+    import_type STRING,
+    imported_symbols STRING
+)
+```
+
+**Properties**:
+
+- `import_type`: 'module', 'from_import', 'relative'
+- `imported_symbols`: JSON array of imported names
+
+**Example**:
+
+```cypher
+MATCH (importer:CodeFile {file_path: 'src/main.py'}),
+      (imported:CodeFile {file_path: 'src/utils.py'})
+CREATE (importer)-[:IMPORTS {
+    import_type: 'from_import',
+    imported_symbols: '["helper", "formatter"]'
+}]->(imported)
+```
+
+### REFERENCES
+
+Links functions to classes they reference (not inherit).
+
+```cypher
+CREATE REL TABLE REFERENCES(
+    FROM Function TO Class,
+    reference_type STRING,
+    line_numbers STRING
+)
+```
+
+**Properties**:
+
+- `reference_type`: 'instantiation', 'type_annotation', 'usage'
+- `line_numbers`: JSON array of line numbers where references occur
+
+**Example**:
+
+```cypher
+MATCH (f:Function {function_name: 'create_backend'}),
+      (c:Class {class_name: 'MemoryEntry'})
+CREATE (f)-[:REFERENCES {
+    reference_type: 'type_annotation',
+    line_numbers: '[12]'
+}]->(c)
+```
+
+### CONTAINS
+
+Represents file containment (for nested modules).
+
+```cypher
+CREATE REL TABLE CONTAINS(
+    FROM CodeFile TO CodeFile,
+    relationship_type STRING
+)
+```
+
+**Properties**:
+
+- `relationship_type`: 'package', 'submodule'
+
+**Example**:
+
+```cypher
+MATCH (pkg:CodeFile {file_path: 'src/amplihack/__init__.py'}),
+      (module:CodeFile {file_path: 'src/amplihack/memory/__init__.py'})
+CREATE (pkg)-[:CONTAINS {relationship_type: 'package'}]->(module)
+```
+
+## Memory-Code Links
+
+Connect the 5 memory types to code artifacts for context-aware memory retrieval.
+
+### Memory → CodeFile Links
+
+```cypher
+CREATE REL TABLE RELATES_TO_FILE_EPISODIC(
+    FROM EpisodicMemory TO CodeFile,
+    relevance_score DOUBLE,
+    context STRING
+)
+
+CREATE REL TABLE RELATES_TO_FILE_SEMANTIC(
+    FROM SemanticMemory TO CodeFile,
+    relevance_score DOUBLE,
+    context STRING
+)
+
+CREATE REL TABLE RELATES_TO_FILE_PROCEDURAL(
+    FROM ProceduralMemory TO CodeFile,
+    relevance_score DOUBLE,
+    context STRING
+)
+
+CREATE REL TABLE RELATES_TO_FILE_PROSPECTIVE(
+    FROM ProspectiveMemory TO CodeFile,
+    relevance_score DOUBLE,
+    context STRING
+)
+
+CREATE REL TABLE RELATES_TO_FILE_WORKING(
+    FROM WorkingMemory TO CodeFile,
+    relevance_score DOUBLE,
+    context STRING
+)
+```
+
+**Properties**:
+
+- `relevance_score`: 0.0-1.0 indicating strength of relationship
+- `context`: Why memory relates to this file
+
+**Example**:
+
+```cypher
+MATCH (m:SemanticMemory {concept: 'kuzu_backend_refactoring'}),
+      (f:CodeFile {file_path: 'src/amplihack/memory/backends/kuzu_backend.py'})
+CREATE (m)-[:RELATES_TO_FILE_SEMANTIC {
+    relevance_score: 0.95,
+    context: 'Design decisions for 5-type memory schema'
+}]->(f)
+```
+
+### Memory → Function Links
+
+```cypher
+CREATE REL TABLE RELATES_TO_FUNCTION_EPISODIC(
+    FROM EpisodicMemory TO Function,
+    relevance_score DOUBLE,
+    context STRING
+)
+
+CREATE REL TABLE RELATES_TO_FUNCTION_SEMANTIC(
+    FROM SemanticMemory TO Function,
+    relevance_score DOUBLE,
+    context STRING
+)
+
+CREATE REL TABLE RELATES_TO_FUNCTION_PROCEDURAL(
+    FROM ProceduralMemory TO Function,
+    relevance_score DOUBLE,
+    context STRING
+)
+
+CREATE REL TABLE RELATES_TO_FUNCTION_PROSPECTIVE(
+    FROM ProspectiveMemory TO Function,
+    relevance_score DOUBLE,
+    context STRING
+)
+
+CREATE REL TABLE RELATES_TO_FUNCTION_WORKING(
+    FROM WorkingMemory TO Function,
+    relevance_score DOUBLE,
+    context STRING
+)
+```
+
+**Properties**:
+
+- `relevance_score`: 0.0-1.0 indicating strength of relationship
+- `context`: Why memory relates to this function
+
+**Example**:
+
+```cypher
+MATCH (m:ProceduralMemory {procedure_name: 'debugging_kuzu_queries'}),
+      (f:Function {function_name: 'retrieve_memories'})
+CREATE (m)-[:RELATES_TO_FUNCTION_PROCEDURAL {
+    relevance_score: 0.85,
+    context: 'Learned debugging technique while fixing query performance'
+}]->(f)
+```
+
+## Usage Examples
+
+### Query 1: Find All Functions in a File
+
+```cypher
+MATCH (f:Function)-[:DEFINED_IN]->(file:CodeFile)
+WHERE file.file_path = 'src/amplihack/memory/backends/kuzu_backend.py'
+RETURN f.function_name, f.line_start, f.complexity_score
+ORDER BY f.line_start
+```
+
+**Output**:
+
+```
+function_name       | line_start | complexity_score
+--------------------|------------|------------------
+__init__            | 49         | 2.0
+initialize          | 80         | 15.5
+store_memory        | 325        | 12.5
+retrieve_memories   | 500        | 18.0
+```
+
+### Query 2: Find Class Hierarchy
+
+```cypher
+MATCH path = (child:Class)-[:INHERITS*1..3]->(ancestor:Class)
+WHERE child.class_name = 'KuzuBackend'
+RETURN child.class_name, ancestor.class_name, length(path) AS depth
+ORDER BY depth
+```
+
+**Output**:
+
+```
+child_name  | ancestor_name  | depth
+------------|----------------|------
+KuzuBackend | MemoryBackend  | 1
+KuzuBackend | BaseBackend    | 2
+```
+
+### Query 3: Find Function Call Graph
+
+```cypher
+MATCH (caller:Function)-[c:CALLS]->(callee:Function)
+WHERE caller.function_name = 'store_memory'
+RETURN callee.function_name, c.call_count, c.line_numbers
+ORDER BY c.call_count DESC
+```
+
+**Output**:
+
+```
+callee_name          | call_count | line_numbers
+---------------------|------------|-------------
+_create_session_node | 5          | [390, 420, ...]
+_validate_memory     | 1          | [330]
+```
+
+### Query 4: Find Memories Related to Code
+
+```cypher
+MATCH (m:SemanticMemory)-[r:RELATES_TO_FILE_SEMANTIC]->(f:CodeFile)
+WHERE f.file_path CONTAINS 'kuzu_backend'
+RETURN m.concept, m.content, r.relevance_score, r.context
+ORDER BY r.relevance_score DESC
+LIMIT 5
+```
+
+**Output**:
+
+```
+concept                    | content                 | relevance | context
+---------------------------|-------------------------|-----------|------------------
+kuzu_performance_tuning    | Use parameterized...   | 0.95      | Query optimization
+5type_memory_migration     | Migration from flat... | 0.90      | Schema design
+graph_traversal_patterns   | Cypher patterns for... | 0.85      | Query examples
+```
+
+### Query 5: Find Complex Functions
+
+```cypher
+MATCH (f:Function)-[:DEFINED_IN]->(file:CodeFile)
+WHERE f.complexity_score > 15.0
+  AND file.language = 'python'
+RETURN f.fully_qualified_name, f.complexity_score, f.line_start, f.line_end
+ORDER BY f.complexity_score DESC
+LIMIT 10
+```
+
+**Output**:
+
+```
+fully_qualified_name                                    | complexity | line_start | line_end
+-------------------------------------------------------|------------|------------|----------
+amplihack.memory.backends.kuzu_backend.retrieve_memories | 18.0       | 500        | 650
+amplihack.memory.backends.kuzu_backend.initialize        | 15.5       | 80         | 320
+```
+
+### Query 6: Find Memories for Active Work
+
+```cypher
+// Get all memories linked to functions in current file
+MATCH (f:Function)-[:DEFINED_IN]->(file:CodeFile)
+WHERE file.file_path = $current_file
+OPTIONAL MATCH (m)-[r:RELATES_TO_FUNCTION_SEMANTIC|RELATES_TO_FUNCTION_PROCEDURAL]->(f)
+RETURN f.function_name,
+       collect({memory: m, relevance: r.relevance_score}) AS related_memories
+ORDER BY f.line_start
+```
+
+### Query 7: Find Import Dependencies
+
+```cypher
+MATCH (f:CodeFile)-[i:IMPORTS]->(dep:CodeFile)
+WHERE f.file_path = 'src/amplihack/memory/backends/kuzu_backend.py'
+RETURN dep.file_path, i.import_type, i.imported_symbols
+```
+
+**Output**:
+
+```
+file_path                      | import_type  | imported_symbols
+-------------------------------|--------------|---------------------------
+src/amplihack/memory/models.py | from_import  | ["MemoryEntry", "MemoryQuery"]
+src/amplihack/memory/base.py   | from_import  | ["BackendCapabilities"]
+```
+
+## Integration with Memory System
+
+The code graph schema integrates seamlessly with the existing 5-type memory system.
+
+### Automatic Code-Memory Linking
+
+When memories are stored, the system can automatically link them to relevant code:
+
+```python
+from amplihack.memory import MemoryService
+from amplihack.memory.backends import KuzuBackend
+
+backend = KuzuBackend()
+backend.initialize()
+service = MemoryService(backend)
+
+# Store memory with code context
+memory = service.store_memory(
+    memory_type=MemoryType.SEMANTIC,
+    content="Discovered performance issue in retrieve_memories function",
+    metadata={
+        "code_file": "src/amplihack/memory/backends/kuzu_backend.py",
+        "function_name": "retrieve_memories",
+        "line_number": 520
+    }
+)
+
+# System automatically creates RELATES_TO_FUNCTION_SEMANTIC relationship
+```
+
+### Context-Aware Memory Retrieval
+
+Retrieve memories relevant to current code context:
+
+```python
+# Working on kuzu_backend.py, need relevant memories
+memories = backend.connection.execute("""
+    MATCH (f:CodeFile {file_path: $file_path})
+    OPTIONAL MATCH (m:SemanticMemory)-[r:RELATES_TO_FILE_SEMANTIC]->(f)
+    WHERE r.relevance_score > 0.7
+    RETURN m.concept, m.content, r.relevance_score
+    ORDER BY r.relevance_score DESC
+""", {"file_path": "src/amplihack/memory/backends/kuzu_backend.py"})
+```
+
+### Code Structure Navigation
+
+Navigate code structure with memory awareness:
+
+```python
+# Find all classes and their methods with related memories
+result = backend.connection.execute("""
+    MATCH (c:Class)<-[:METHOD_OF]-(m:Function)
+    OPTIONAL MATCH (mem:SemanticMemory)-[:RELATES_TO_FUNCTION_SEMANTIC]->(m)
+    RETURN c.class_name,
+           collect({method: m.function_name, memories: count(mem)}) AS methods
+""")
+```
+
+## Performance Characteristics
+
+### Schema Initialization
+
+- **Time**: <1000ms for all 20 tables (3 node types + 7 code relationships + 10 memory-code links)
+- **Idempotent**: Safe to call `initialize()` multiple times
+- **Database size**: ~50KB overhead for empty schema
+
+**Benchmark**:
+
+```python
+import time
+backend = KuzuBackend()
+start = time.time()
+backend.initialize()
+elapsed = time.time() - start
+print(f"Schema initialization: {elapsed*1000:.1f}ms")
+# Output: Schema initialization: 850.2ms
+```
+
+### Query Performance
+
+- **Simple traversal** (single hop): <10ms
+- **Complex traversal** (3+ hops): <100ms
+- **Memory-code linking**: <50ms per relationship
+- **File indexing**: ~500ms per 1000 LOC
+
+**Benchmark**:
+
+```python
+# Find all functions in a file
+start = time.time()
+result = backend.connection.execute("""
+    MATCH (f:Function)-[:DEFINED_IN]->(file:CodeFile)
+    WHERE file.file_path = $path
+    RETURN f
+""", {"path": "src/amplihack/memory/backends/kuzu_backend.py"})
+elapsed = time.time() - start
+print(f"Query time: {elapsed*1000:.1f}ms")
+# Output: Query time: 8.5ms
+```
+
+### Memory Overhead
+
+- **CodeFile node**: ~200 bytes
+- **Class node**: ~300 bytes
+- **Function node**: ~400 bytes
+- **Relationship**: ~100 bytes
+
+**Typical codebase** (10,000 LOC):
+
+- 50 files × 200 bytes = 10KB
+- 100 classes × 300 bytes = 30KB
+- 500 functions × 400 bytes = 200KB
+- 2000 relationships × 100 bytes = 200KB
+- **Total**: ~440KB
+
+## Schema Reference
+
+### Complete Node Count
+
+- **Memory nodes**: 5 types (Episodic, Semantic, Procedural, Prospective, Working)
+- **Code nodes**: 3 types (CodeFile, Class, Function)
+- **Infrastructure**: 2 types (Session, Agent)
+- **Total**: 10 node types
+
+### Complete Relationship Count
+
+- **Memory relationships**: 11 types
+- **Code relationships**: 7 types
+- **Memory-code links**: 10 types (5 to files + 5 to functions)
+- **Total**: 28 relationship types
+
+### Schema Evolution
+
+The schema follows semantic versioning:
+
+- **v1.0**: Initial 5-type memory system
+- **v1.1**: Added code graph schema (this document)
+- **Future**: Vector embeddings, code change tracking
+
+### Migration Path
+
+Existing memory databases automatically upgrade:
+
+```python
+backend = KuzuBackend()  # Existing database
+backend.initialize()      # Adds code schema, preserves memory data
+```
+
+**Migration guarantees**:
+
+- Zero downtime
+- No data loss
+- Backward compatible queries
+- Forward compatible storage
+
+## Next Steps
+
+1. **Week 2**: Blarify import integration
+   - Import blarify knowledge into code graph
+   - Map blarify entities to code nodes
+   - Preserve blarify relationships
+
+2. **Week 3**: Memory-code linking
+   - Automatic linking based on context
+   - Link existing memories to code
+   - Query optimization
+
+3. **Future enhancements**:
+   - Vector embeddings for semantic code search
+   - Code change tracking (git history)
+   - Test coverage integration
+   - Documentation linking
+
+## Related Documentation
+
+- [5-Type Memory Schema](./KUZU_MEMORY_SCHEMA.md) - Core memory system
+- [Blarify Integration](../concepts/blarify-integration.md) - Week 2 migration plan
+- [Memory Architecture](./5-TYPE-MEMORY-DEVELOPER.md) - System design
+- Kuzu Backend API - Implementation
+
+---
+
+**Implementation**: `src/amplihack/memory/backends/kuzu_backend.py`
+**Schema Version**: 1.1
+**Status**: Complete and deployed
+**Performance**: <1000ms initialization, <100ms queries

--- a/docs/memory/KUZU_MEMORY_SCHEMA.md
+++ b/docs/memory/KUZU_MEMORY_SCHEMA.md
@@ -1,0 +1,457 @@
+# Kùzu Memory Schema Design
+
+## Overview
+
+This schema separates the five psychological memory types into distinct node types, properly modeling their relationships to sessions and each other.
+
+## Node Types
+
+### 1. Session
+
+Represents a conversational session or work context.
+
+```cypher
+CREATE NODE TABLE Session(
+    session_id STRING PRIMARY KEY,
+    start_time TIMESTAMP,
+    end_time TIMESTAMP,
+    user_id STRING,
+    context STRING,
+    status STRING  -- 'active', 'completed', 'archived'
+);
+```
+
+### 2. EpisodicMemory
+
+Session-specific events and experiences.
+
+```cypher
+CREATE NODE TABLE EpisodicMemory(
+    memory_id STRING PRIMARY KEY,
+    timestamp TIMESTAMP,
+    content STRING,
+    event_type STRING,  -- 'task_completion', 'decision', 'error', 'learning'
+    emotional_valence DOUBLE,  -- -1.0 to 1.0
+    importance_score DOUBLE,  -- 0.0 to 1.0
+    embedding DOUBLE[1536]  -- Vector embedding for similarity search
+);
+```
+
+**Key Properties**:
+
+- Always tied to a specific session
+- Time-stamped events
+- Can have emotional context
+- Rich contextual detail
+
+### 3. SemanticMemory
+
+Cross-session knowledge and facts.
+
+```cypher
+CREATE NODE TABLE SemanticMemory(
+    memory_id STRING PRIMARY KEY,
+    concept STRING,
+    content STRING,
+    category STRING,  -- 'architecture', 'patterns', 'user_preferences', 'domain_knowledge'
+    confidence_score DOUBLE,  -- 0.0 to 1.0
+    last_updated TIMESTAMP,
+    version INT64,
+    embedding DOUBLE[1536]
+);
+```
+
+**Key Properties**:
+
+- Not tied to a single session
+- Updated across multiple sessions
+- Versioned for tracking changes
+- Confidence scores for fact checking
+
+### 4. ProceduralMemory
+
+How-to knowledge and workflows.
+
+```cypher
+CREATE NODE TABLE ProceduralMemory(
+    memory_id STRING PRIMARY KEY,
+    procedure_name STRING,
+    description STRING,
+    steps STRING[],  -- Ordered list of steps
+    preconditions STRING[],
+    postconditions STRING[],
+    success_rate DOUBLE,  -- 0.0 to 1.0
+    usage_count INT64,
+    last_used TIMESTAMP,
+    embedding DOUBLE[1536]
+);
+```
+
+**Key Properties**:
+
+- Global, not session-specific
+- Tracks effectiveness (success_rate)
+- Usage patterns for ranking
+- Ordered steps
+
+### 5. ProspectiveMemory
+
+Future intentions and reminders.
+
+```cypher
+CREATE NODE TABLE ProspectiveMemory(
+    memory_id STRING PRIMARY KEY,
+    intention STRING,
+    trigger_condition STRING,
+    priority STRING,  -- 'low', 'medium', 'high', 'critical'
+    due_date TIMESTAMP,
+    status STRING,  -- 'pending', 'triggered', 'completed', 'expired'
+    scope STRING,  -- 'session', 'global'
+    completion_criteria STRING,
+    embedding DOUBLE[1536]
+);
+```
+
+**Key Properties**:
+
+- Can be session-scoped or global
+- Trigger conditions for activation
+- Status tracking
+- Priority levels
+
+### 6. WorkingMemory
+
+Active task state and temporary context.
+
+```cypher
+CREATE NODE TABLE WorkingMemory(
+    memory_id STRING PRIMARY KEY,
+    content STRING,
+    memory_type STRING,  -- 'goal', 'subgoal', 'context', 'constraint'
+    priority INT64,  -- For processing order
+    created_at TIMESTAMP,
+    ttl_seconds INT64,  -- Time to live
+    embedding DOUBLE[1536]
+);
+```
+
+**Key Properties**:
+
+- Short-lived (TTL)
+- Session-specific
+- Processing priority
+- Temporary context
+
+## Relationship Types
+
+### Session Relationships
+
+```cypher
+-- Sessions CONTAIN episodic memories
+CREATE REL TABLE CONTAINS_EPISODIC(
+    FROM Session TO EpisodicMemory,
+    sequence_number INT64  -- Order within session
+);
+
+-- Sessions CONTAIN working memories
+CREATE REL TABLE CONTAINS_WORKING(
+    FROM Session TO WorkingMemory,
+    activation_level DOUBLE  -- 0.0 to 1.0, for decay over time
+);
+
+-- Sessions CONTRIBUTE_TO semantic memories
+CREATE REL TABLE CONTRIBUTES_TO_SEMANTIC(
+    FROM Session TO SemanticMemory,
+    contribution_type STRING,  -- 'created', 'updated', 'validated', 'refined'
+    timestamp TIMESTAMP,
+    delta STRING  -- What changed
+);
+
+-- Sessions USE procedural memories
+CREATE REL TABLE USES_PROCEDURE(
+    FROM Session TO ProceduralMemory,
+    timestamp TIMESTAMP,
+    success BOOL,
+    notes STRING
+);
+
+-- Sessions CREATE prospective memories
+CREATE REL TABLE CREATES_INTENTION(
+    FROM Session TO ProspectiveMemory,
+    timestamp TIMESTAMP
+);
+```
+
+### Cross-Memory Relationships
+
+```cypher
+-- Semantic memories DERIVE_FROM episodic events
+CREATE REL TABLE DERIVES_FROM(
+    FROM SemanticMemory TO EpisodicMemory,
+    extraction_method STRING,  -- 'pattern_recognition', 'user_feedback', 'inference'
+    confidence DOUBLE
+);
+
+-- Procedural memories REFERENCE other memories
+CREATE REL TABLE REFERENCES(
+    FROM ProceduralMemory TO SemanticMemory,
+    reference_type STRING,  -- 'prerequisite', 'related_concept', 'example'
+    context STRING
+);
+
+-- Prospective memories TRIGGER working memory updates
+CREATE REL TABLE TRIGGERS(
+    FROM ProspectiveMemory TO WorkingMemory,
+    trigger_time TIMESTAMP,
+    condition_met BOOL
+);
+
+-- Working memories ACTIVATE semantic memories
+CREATE REL TABLE ACTIVATES(
+    FROM WorkingMemory TO SemanticMemory,
+    activation_strength DOUBLE,  -- 0.0 to 1.0
+    timestamp TIMESTAMP
+);
+
+-- Episodic memories RECALL other episodic memories
+CREATE REL TABLE RECALLS(
+    FROM EpisodicMemory TO EpisodicMemory,
+    similarity_score DOUBLE,
+    recall_reason STRING  -- 'temporal_proximity', 'semantic_similarity', 'causal_link'
+);
+
+-- Procedural memories BUILD_ON other procedures
+CREATE REL TABLE BUILDS_ON(
+    FROM ProceduralMemory TO ProceduralMemory,
+    relationship_type STRING  -- 'extends', 'specializes', 'composes'
+);
+```
+
+## Schema Benefits
+
+### 1. Clear Session Boundaries
+
+**Session-Scoped** (destroyed when session ends):
+
+- EpisodicMemory (via CONTAINS_EPISODIC)
+- WorkingMemory (via CONTAINS_WORKING)
+- ProspectiveMemory with scope='session'
+
+**Global** (persist across sessions):
+
+- SemanticMemory
+- ProceduralMemory
+- ProspectiveMemory with scope='global'
+
+### 2. Knowledge Evolution Tracking
+
+```cypher
+// Find how semantic knowledge evolved from episodic experiences
+MATCH (session:Session)-[:CONTAINS_EPISODIC]->(episodic:EpisodicMemory)
+      <-[:DERIVES_FROM]-(semantic:SemanticMemory)
+WHERE semantic.concept = 'user_preference_verbosity'
+RETURN session.session_id, episodic.content, semantic.version, semantic.content
+ORDER BY semantic.version;
+```
+
+### 3. Type-Specific Queries
+
+```cypher
+// Find active prospective memories that should trigger
+MATCH (pm:ProspectiveMemory)
+WHERE pm.status = 'pending'
+  AND pm.due_date <= current_timestamp()
+  AND pm.scope = 'global'
+RETURN pm;
+
+// Find successful procedures for a task
+MATCH (pm:ProceduralMemory)
+WHERE pm.procedure_name CONTAINS 'git_workflow'
+  AND pm.success_rate > 0.8
+ORDER BY pm.usage_count DESC
+LIMIT 5;
+```
+
+### 4. Session Analysis
+
+```cypher
+// Analyze what was learned in a session
+MATCH (s:Session)-[:CONTRIBUTES_TO_SEMANTIC]->(sm:SemanticMemory)
+WHERE s.session_id = $session_id
+RETURN sm.concept, sm.content, sm.confidence_score;
+
+// Reconstruct session narrative
+MATCH (s:Session)-[:CONTAINS_EPISODIC]->(em:EpisodicMemory)
+WHERE s.session_id = $session_id
+RETURN em.content, em.timestamp, em.event_type
+ORDER BY em.sequence_number;
+```
+
+## Example Queries
+
+### Query 1: Find Related Memories Across Types
+
+```cypher
+// Given a current task (working memory), find:
+// 1. Related semantic knowledge
+// 2. Relevant procedures
+// 3. Similar past experiences
+
+MATCH (wm:WorkingMemory {content: $current_task})
+      -[:ACTIVATES]->(sm:SemanticMemory)
+      <-[:REFERENCES]-(pm:ProceduralMemory)
+OPTIONAL MATCH (sm)<-[:DERIVES_FROM]-(em:EpisodicMemory)
+RETURN sm.concept,
+       pm.procedure_name,
+       em.content AS similar_experience
+ORDER BY sm.confidence_score DESC;
+```
+
+### Query 2: Memory Consolidation
+
+```cypher
+// Find episodic memories ready for consolidation into semantic memory
+MATCH (s:Session)-[r:CONTAINS_EPISODIC]->(em:EpisodicMemory)
+WHERE em.importance_score > 0.7
+  AND em.timestamp < (current_timestamp() - INTERVAL '1 day')
+  AND NOT EXISTS {
+    MATCH (em)<-[:DERIVES_FROM]-(sm:SemanticMemory)
+  }
+RETURN s.session_id, em.memory_id, em.content, em.importance_score
+ORDER BY em.importance_score DESC;
+```
+
+### Query 3: Session Knowledge Graph
+
+```cypher
+// Build a knowledge graph for a specific session
+MATCH path = (s:Session {session_id: $session_id})
+             -[:CONTAINS_EPISODIC|CONTRIBUTES_TO_SEMANTIC|USES_PROCEDURE*1..2]->
+             (memory)
+RETURN path;
+```
+
+### Query 4: Procedural Memory Learning
+
+```cypher
+// Track how procedure success improves over sessions
+MATCH (pm:ProceduralMemory {procedure_name: $procedure_name})
+      <-[u:USES_PROCEDURE]-(s:Session)
+RETURN s.start_time, u.success, pm.success_rate
+ORDER BY s.start_time;
+```
+
+## Migration Strategy
+
+### Phase 1: Schema Creation
+
+```cypher
+// Create all node tables
+// (See Node Types section above)
+
+// Create all relationship tables
+// (See Relationship Types section above)
+```
+
+### Phase 2: Data Migration
+
+```python
+# Migration script outline
+
+def migrate_memories():
+    # 1. Create Session nodes from existing session data
+    for session_data in get_sessions():
+        create_session_node(session_data)
+
+    # 2. Split existing Memory nodes by type
+    for memory in get_all_memories():
+        if memory.memory_type == "episodic":
+            create_episodic_memory(memory)
+            link_to_session(memory.session_id, memory.memory_id)
+
+        elif memory.memory_type == "semantic":
+            create_semantic_memory(memory)
+            link_contributions_from_sessions(memory)
+
+        elif memory.memory_type == "procedural":
+            create_procedural_memory(memory)
+            link_usage_from_sessions(memory)
+
+        elif memory.memory_type == "prospective":
+            create_prospective_memory(memory)
+            link_to_session_if_scoped(memory)
+
+        elif memory.memory_type == "working":
+            create_working_memory(memory)
+            link_to_active_session(memory)
+
+    # 3. Reconstruct relationships
+    rebuild_derives_from_relationships()
+    rebuild_references_relationships()
+    rebuild_activation_relationships()
+```
+
+### Phase 3: Validation
+
+```cypher
+// Verify migration completeness
+
+// Count memories by type
+MATCH (em:EpisodicMemory) RETURN 'Episodic' AS type, count(em) AS count
+UNION
+MATCH (sm:SemanticMemory) RETURN 'Semantic' AS type, count(sm) AS count
+UNION
+MATCH (pm:ProceduralMemory) RETURN 'Procedural' AS type, count(pm) AS count
+UNION
+MATCH (pm2:ProspectiveMemory) RETURN 'Prospective' AS type, count(pm2) AS count
+UNION
+MATCH (wm:WorkingMemory) RETURN 'Working' AS type, count(wm) AS count;
+
+// Verify session linkages
+MATCH (s:Session)
+OPTIONAL MATCH (s)-[:CONTAINS_EPISODIC]->(em:EpisodicMemory)
+OPTIONAL MATCH (s)-[:CONTAINS_WORKING]->(wm:WorkingMemory)
+RETURN s.session_id,
+       count(DISTINCT em) AS episodic_count,
+       count(DISTINCT wm) AS working_count;
+```
+
+### Phase 4: Update Application Code
+
+1. Update memory creation logic to use specific node types
+2. Update query patterns to leverage new relationships
+3. Add session lifecycle management
+4. Implement working memory TTL cleanup
+5. Add memory consolidation processes
+
+## Benefits Summary
+
+### 1. Type Safety
+
+Each memory type has its own schema, preventing inappropriate property access.
+
+### 2. Semantic Clarity
+
+Relationships explicitly show memory type interactions (DERIVES_FROM, REFERENCES, etc.).
+
+### 3. Query Performance
+
+Type-specific indexes and targeted queries instead of filtering on `memory_type` property.
+
+### 4. Session Lifecycle
+
+Clear distinction between session-scoped and global memories for proper cleanup.
+
+### 5. Knowledge Evolution
+
+Track how episodic experiences consolidate into semantic knowledge over time.
+
+### 6. Procedural Learning
+
+Monitor procedure effectiveness and usage patterns across sessions.
+
+### 7. Future Intent Management
+
+Prospective memories with proper triggering mechanisms and scope control.
+
+This schema properly models the cognitive architecture of the system! Arrr! 🏴‍☠️

--- a/docs/memory/TESTING_STRATEGY.md
+++ b/docs/memory/TESTING_STRATEGY.md
@@ -1,0 +1,1818 @@
+# Comprehensive Testing Strategy for Memory-Enabled Goal-Seeking Agents
+
+## Executive Summary
+
+This document defines the comprehensive testing strategy for memory-enabled goal-seeking agents. The strategy follows the testing pyramid (60% unit, 30% integration, 10% E2E), applies outside-in testing methodology, and integrates with the gadugi-agentic-test framework for agent learning validation.
+
+## Table of Contents
+
+1. [Testing Philosophy](#testing-philosophy)
+2. [Test Pyramid Architecture](#test-pyramid-architecture)
+3. [Memory Library Core Tests](#memory-library-core-tests)
+4. [Agent Learning Tests](#agent-learning-tests)
+5. [Outside-In Testing Scenarios](#outside-in-testing-scenarios)
+6. [gadugi-agentic-test Integration](#gadugi-agentic-test-integration)
+7. [Performance Benchmarks](#performance-benchmarks)
+8. [Security Tests](#security-tests)
+9. [Test Automation Strategy](#test-automation-strategy)
+
+---
+
+## Testing Philosophy
+
+### Core Principles
+
+1. **Strategic Coverage Over 100% Coverage**: Focus on critical paths, error handling, and boundaries
+2. **Fast Tests**: Unit tests <100ms, integration tests <1s, E2E tests <30s
+3. **Isolated Tests**: No cross-test dependencies, repeatable results
+4. **Measurable Learning**: Every agent test must measure learning metrics
+5. **Outside-In Approach**: Start with real user scenarios, derive implementation tests
+
+### Anti-Patterns to Avoid
+
+- ❌ Testing implementation details instead of behavior
+- ❌ Flaky or time-dependent tests
+- ❌ Tests that don't validate learning improvement
+- ❌ Over-reliance on mocks for memory operations
+- ❌ Missing error case and boundary tests
+
+---
+
+## Test Pyramid Architecture
+
+```
+        ┌─────────────────┐
+        │   E2E Tests     │  10% - Full agent execution with memory
+        │   (~20 tests)   │  Validate real-world learning scenarios
+        └─────────────────┘
+              ▲
+              │
+        ┌─────────────────────┐
+        │ Integration Tests   │  30% - Real Kùzu database operations
+        │    (~60 tests)      │  Memory pipelines + agent interactions
+        └─────────────────────┘
+              ▲
+              │
+        ┌───────────────────────────┐
+        │    Unit Tests             │  60% - Components in isolation
+        │    (~120 tests)           │  Core classes, validators, queries
+        └───────────────────────────┘
+
+Total: ~200 tests targeting >80% coverage
+```
+
+### Coverage Targets
+
+| Layer       | Tests   | Coverage            | Execution Time |
+| ----------- | ------- | ------------------- | -------------- |
+| Unit        | 120     | Core logic 90%+     | <10s total     |
+| Integration | 60      | Pipelines 85%+      | <60s total     |
+| E2E         | 20      | Critical paths 70%+ | <10min total   |
+| **Total**   | **200** | **>80% overall**    | **<12min**     |
+
+---
+
+## Memory Library Core Tests
+
+### 1. Unit Tests (60% - ~72 tests)
+
+#### 1.1 MemoryCoordinator Tests
+
+**File**: `tests/memory/unit/test_memory_coordinator.py`
+
+```python
+"""Unit tests for MemoryCoordinator - the main memory interface."""
+
+import pytest
+from datetime import datetime, timedelta
+from amplihack.memory.coordinator import MemoryCoordinator
+from amplihack.memory.models import MemoryEntry, MemoryType, MemoryQuery
+
+
+class TestMemoryCoordinatorStore:
+    """Test memory storage operations (<100ms)."""
+
+    def test_store_episodic_memory_creates_entry(self, mock_backend):
+        """Test storing episodic memory creates valid entry."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+
+        # ACT
+        result = coordinator.store(
+            memory_type=MemoryType.EPISODIC,
+            title="User asked about authentication",
+            content="Discussion about JWT vs session-based auth",
+            session_id="sess_123",
+            agent_id="architect",
+            metadata={"topic": "security"}
+        )
+
+        # ASSERT
+        assert result.success is True
+        assert result.memory_id is not None
+        assert result.execution_time_ms < 500
+        mock_backend.store.assert_called_once()
+
+    def test_store_with_importance_scoring(self, mock_backend):
+        """Test importance is correctly calculated during storage."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend, use_review=True)
+
+        # ACT
+        result = coordinator.store(
+            memory_type=MemoryType.SEMANTIC,
+            title="Critical security vulnerability found",
+            content="SQL injection vulnerability in login endpoint",
+            session_id="sess_456",
+            agent_id="security",
+            metadata={"severity": "critical"}
+        )
+
+        # ASSERT - High importance for critical findings
+        stored_entry = mock_backend.store.call_args[0][0]
+        assert stored_entry.importance >= 8
+        assert result.execution_time_ms < 500
+
+    def test_store_procedural_with_steps(self, mock_backend):
+        """Test storing procedural memory with execution steps."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+
+        # ACT
+        result = coordinator.store(
+            memory_type=MemoryType.PROCEDURAL,
+            title="How to fix import errors",
+            content="1. Check dependencies\n2. Verify PYTHONPATH\n3. Restart IDE",
+            session_id="sess_789",
+            agent_id="builder",
+            metadata={"success_rate": 0.95}
+        )
+
+        # ASSERT
+        assert result.success is True
+        stored_entry = mock_backend.store.call_args[0][0]
+        assert "1." in stored_entry.content
+        assert stored_entry.memory_type == MemoryType.PROCEDURAL
+
+    def test_store_fails_gracefully_on_invalid_input(self, mock_backend):
+        """Test error handling for invalid memory entries."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+
+        # ACT
+        result = coordinator.store(
+            memory_type=MemoryType.EPISODIC,
+            title="",  # Invalid: empty title
+            content="Some content",
+            session_id="sess_999",
+            agent_id="test"
+        )
+
+        # ASSERT
+        assert result.success is False
+        assert "title" in result.error.lower()
+        mock_backend.store.assert_not_called()
+
+
+class TestMemoryCoordinatorRetrieve:
+    """Test memory retrieval operations (<50ms without review)."""
+
+    def test_retrieve_by_session_id(self, mock_backend):
+        """Test retrieving all memories for a session."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+        mock_backend.query.return_value = [
+            create_mock_memory("mem_1", "sess_100"),
+            create_mock_memory("mem_2", "sess_100"),
+        ]
+
+        # ACT
+        result = coordinator.retrieve(
+            query=MemoryQuery(session_id="sess_100")
+        )
+
+        # ASSERT
+        assert len(result.memories) == 2
+        assert result.execution_time_ms < 50
+        assert all(m.session_id == "sess_100" for m in result.memories)
+
+    def test_retrieve_by_memory_type(self, mock_backend):
+        """Test filtering by memory type."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+        mock_backend.query.return_value = [
+            create_mock_memory("mem_3", "sess_200", MemoryType.SEMANTIC),
+        ]
+
+        # ACT
+        result = coordinator.retrieve(
+            query=MemoryQuery(memory_type=MemoryType.SEMANTIC)
+        )
+
+        # ASSERT
+        assert len(result.memories) == 1
+        assert result.memories[0].memory_type == MemoryType.SEMANTIC
+
+    def test_retrieve_with_content_search(self, mock_backend):
+        """Test full-text search functionality."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+        mock_backend.query.return_value = [
+            create_mock_memory("mem_4", "sess_300", content="authentication flow"),
+        ]
+
+        # ACT
+        result = coordinator.retrieve(
+            query=MemoryQuery(content_search="authentication")
+        )
+
+        # ASSERT
+        assert len(result.memories) == 1
+        assert "authentication" in result.memories[0].content.lower()
+
+    def test_retrieve_with_importance_threshold(self, mock_backend):
+        """Test filtering by importance score."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+        mock_backend.query.return_value = [
+            create_mock_memory("mem_5", "sess_400", importance=9),
+            create_mock_memory("mem_6", "sess_400", importance=8),
+        ]
+
+        # ACT
+        result = coordinator.retrieve(
+            query=MemoryQuery(min_importance=8)
+        )
+
+        # ASSERT
+        assert len(result.memories) == 2
+        assert all(m.importance >= 8 for m in result.memories)
+
+    def test_retrieve_empty_results(self, mock_backend):
+        """Test handling of no matching memories."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+        mock_backend.query.return_value = []
+
+        # ACT
+        result = coordinator.retrieve(
+            query=MemoryQuery(session_id="nonexistent")
+        )
+
+        # ASSERT
+        assert len(result.memories) == 0
+        assert result.success is True
+
+
+class TestMemoryCoordinatorWorkingMemory:
+    """Test working memory operations (temporary context)."""
+
+    def test_clear_working_memory_for_session(self, mock_backend):
+        """Test clearing working memory at session boundaries."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+
+        # ACT
+        result = coordinator.clear_working_memory(session_id="sess_500")
+
+        # ASSERT
+        assert result.success is True
+        mock_backend.delete_by_query.assert_called_once()
+
+    def test_working_memory_auto_expires(self, mock_backend):
+        """Test working memory expires after timeout."""
+        # ARRANGE
+        coordinator = MemoryCoordinator(backend=mock_backend)
+        past_time = datetime.now() - timedelta(hours=2)
+
+        # Store working memory with expiration
+        coordinator.store(
+            memory_type=MemoryType.WORKING,
+            title="Temporary context",
+            content="Active task state",
+            session_id="sess_600",
+            agent_id="builder",
+            expires_at=past_time
+        )
+
+        # ACT - Query should exclude expired memories
+        result = coordinator.retrieve(
+            query=MemoryQuery(
+                session_id="sess_600",
+                memory_type=MemoryType.WORKING,
+                include_expired=False
+            )
+        )
+
+        # ASSERT
+        assert len(result.memories) == 0
+
+
+# Additional unit test classes:
+# - TestStoragePipeline (12 tests)
+# - TestRetrievalPipeline (12 tests)
+# - TestMemoryQuery (8 tests)
+# - TestMemoryEntry (8 tests)
+# - TestKuzuBackend (12 tests)
+# - TestSQLiteBackend (12 tests)
+
+# Total: 72 unit tests
+```
+
+**Test Fixtures** (`conftest.py`):
+
+```python
+"""Shared test fixtures for memory system tests."""
+
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock
+from amplihack.memory.models import MemoryEntry, MemoryType
+
+
+@pytest.fixture
+def mock_backend():
+    """Mock memory backend for unit tests."""
+    backend = MagicMock()
+    backend.store.return_value = "mock_memory_id"
+    backend.query.return_value = []
+    backend.delete.return_value = True
+    return backend
+
+
+@pytest.fixture
+def sample_memory_entry():
+    """Sample memory entry for testing."""
+    return MemoryEntry(
+        id="mem_test_001",
+        session_id="sess_test",
+        agent_id="test_agent",
+        memory_type=MemoryType.EPISODIC,
+        title="Test Memory",
+        content="Sample content for testing",
+        metadata={"test": True},
+        created_at=datetime.now(),
+        accessed_at=datetime.now(),
+        importance=5
+    )
+
+
+def create_mock_memory(
+    memory_id: str,
+    session_id: str,
+    memory_type: MemoryType = MemoryType.EPISODIC,
+    importance: int = 5,
+    content: str = "Test content"
+) -> MemoryEntry:
+    """Helper to create mock memory entries."""
+    return MemoryEntry(
+        id=memory_id,
+        session_id=session_id,
+        agent_id="test_agent",
+        memory_type=memory_type,
+        title="Test Memory",
+        content=content,
+        metadata={},
+        created_at=datetime.now(),
+        accessed_at=datetime.now(),
+        importance=importance
+    )
+```
+
+#### 1.2 Security Capability Tests
+
+**File**: `tests/memory/unit/test_security_capabilities.py`
+
+```python
+"""Security tests for memory system capabilities."""
+
+import pytest
+from amplihack.memory.models import MemoryQuery
+
+
+class TestSecurityEnforcement:
+    """Test capability-based security enforcement."""
+
+    def test_query_injection_prevention(self):
+        """Test SQL injection prevention in queries."""
+        # ARRANGE - Malicious input
+        malicious_session_id = "sess_1'; DROP TABLE memory_entries; --"
+
+        # ACT & ASSERT - Should raise validation error
+        with pytest.raises(ValueError, match="invalid characters"):
+            MemoryQuery(session_id=malicious_session_id)
+
+    def test_limit_boundary_enforcement(self):
+        """Test query limit boundaries prevent DOS."""
+        # ACT & ASSERT - Should reject excessive limits
+        with pytest.raises(ValueError, match="limit must be"):
+            MemoryQuery(limit=100000)
+
+        with pytest.raises(ValueError, match="limit must be"):
+            MemoryQuery(limit=-1)
+
+    def test_agent_id_isolation(self, mock_backend):
+        """Test agents can only access their own memories."""
+        # ARRANGE
+        from amplihack.memory.coordinator import MemoryCoordinator
+        coordinator = MemoryCoordinator(backend=mock_backend)
+
+        # ACT - Try to access another agent's memories
+        result = coordinator.retrieve(
+            query=MemoryQuery(agent_id="other_agent"),
+            requesting_agent_id="current_agent",
+            enforce_isolation=True
+        )
+
+        # ASSERT - Should be blocked
+        assert result.success is False
+        assert "permission denied" in result.error.lower()
+
+    def test_session_boundary_enforcement(self, mock_backend):
+        """Test memories don't leak across sessions."""
+        # Implementation validates session boundaries
+        pass
+```
+
+---
+
+### 2. Integration Tests (30% - ~60 tests)
+
+#### 2.1 Real Kùzu Database Tests
+
+**File**: `tests/memory/integration/test_kuzu_integration.py`
+
+```python
+"""Integration tests with real Kùzu database."""
+
+import pytest
+from pathlib import Path
+from amplihack.memory.backends.kuzu_backend import KuzuBackend
+from amplihack.memory.coordinator import MemoryCoordinator
+from amplihack.memory.models import MemoryType, MemoryQuery
+
+
+@pytest.mark.integration
+class TestKuzuBackendIntegration:
+    """Test MemoryCoordinator with real Kùzu backend."""
+
+    @pytest.fixture
+    def kuzu_coordinator(self, tmp_path):
+        """Create coordinator with real Kùzu database."""
+        db_path = tmp_path / "test_kuzu_db"
+        backend = KuzuBackend(database_path=str(db_path))
+        backend.initialize()
+        return MemoryCoordinator(backend=backend)
+
+    def test_store_and_retrieve_roundtrip(self, kuzu_coordinator):
+        """Test storing and retrieving from real database."""
+        # ARRANGE & ACT - Store
+        store_result = kuzu_coordinator.store(
+            memory_type=MemoryType.EPISODIC,
+            title="Integration test memory",
+            content="Testing with real Kùzu database",
+            session_id="integration_sess_1",
+            agent_id="test_agent",
+            metadata={"test_type": "integration"}
+        )
+
+        # ACT - Retrieve
+        retrieve_result = kuzu_coordinator.retrieve(
+            query=MemoryQuery(session_id="integration_sess_1")
+        )
+
+        # ASSERT
+        assert store_result.success is True
+        assert len(retrieve_result.memories) == 1
+        assert retrieve_result.memories[0].title == "Integration test memory"
+
+    def test_concurrent_writes_consistency(self, kuzu_coordinator):
+        """Test multiple concurrent writes maintain consistency."""
+        # ARRANGE - Multiple agents writing simultaneously
+        import threading
+
+        results = []
+        def store_memory(agent_num):
+            result = kuzu_coordinator.store(
+                memory_type=MemoryType.SEMANTIC,
+                title=f"Memory from agent {agent_num}",
+                content=f"Content {agent_num}",
+                session_id="concurrent_sess",
+                agent_id=f"agent_{agent_num}"
+            )
+            results.append(result)
+
+        # ACT - Concurrent writes
+        threads = [threading.Thread(target=store_memory, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # ASSERT - All writes successful
+        assert all(r.success for r in results)
+
+        # Verify all memories stored
+        retrieve_result = kuzu_coordinator.retrieve(
+            query=MemoryQuery(session_id="concurrent_sess")
+        )
+        assert len(retrieve_result.memories) == 5
+
+    def test_full_text_search_with_kuzu(self, kuzu_coordinator):
+        """Test full-text search capabilities."""
+        # ARRANGE - Store multiple memories
+        topics = ["authentication", "authorization", "encryption"]
+        for topic in topics:
+            kuzu_coordinator.store(
+                memory_type=MemoryType.SEMANTIC,
+                title=f"Security: {topic}",
+                content=f"Discussion about {topic} implementation",
+                session_id="search_sess",
+                agent_id="security"
+            )
+
+        # ACT - Search for specific topic
+        result = kuzu_coordinator.retrieve(
+            query=MemoryQuery(content_search="authentication")
+        )
+
+        # ASSERT
+        assert len(result.memories) >= 1
+        assert any("authentication" in m.content.lower() for m in result.memories)
+
+
+@pytest.mark.integration
+class TestMemoryPipelineIntegration:
+    """Test complete memory pipelines with real database."""
+
+    def test_storage_pipeline_with_agent_review(self, kuzu_coordinator):
+        """Test storage pipeline including agent review."""
+        # This would test the full storage pipeline with:
+        # 1. Input validation
+        # 2. Agent review for importance scoring
+        # 3. Database storage
+        # 4. Verification query
+        pass
+
+    def test_retrieval_pipeline_with_relevance_scoring(self, kuzu_coordinator):
+        """Test retrieval with agent-based relevance scoring."""
+        # This would test the full retrieval pipeline with:
+        # 1. Initial query
+        # 2. Agent review for relevance
+        # 3. Ranked results
+        pass
+
+
+# Additional integration test classes:
+# - TestCrossSessionMemoryAccess (8 tests)
+# - TestMemoryMaintenance (8 tests)
+# - TestBackupAndRestore (6 tests)
+# - TestMigrationScenarios (6 tests)
+
+# Total: 60 integration tests
+```
+
+#### 2.2 Performance Benchmarks
+
+**File**: `tests/memory/integration/test_performance.py`
+
+```python
+"""Performance benchmark tests for memory system (NFR1: <50ms retrieval)."""
+
+import pytest
+import time
+from amplihack.memory.models import MemoryQuery
+
+
+@pytest.mark.performance
+class TestPerformanceBenchmarks:
+    """Benchmark critical memory operations."""
+
+    def test_retrieve_without_review_under_50ms(self, kuzu_coordinator):
+        """Test retrieval completes in <50ms (NFR1)."""
+        # ARRANGE - Pre-populate with 100 memories
+        for i in range(100):
+            kuzu_coordinator.store(
+                memory_type=MemoryType.EPISODIC,
+                title=f"Memory {i}",
+                content=f"Content for memory {i}",
+                session_id="perf_sess",
+                agent_id="test_agent"
+            )
+
+        # ACT - Time retrieval
+        start = time.perf_counter()
+        result = kuzu_coordinator.retrieve(
+            query=MemoryQuery(session_id="perf_sess", limit=10)
+        )
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        # ASSERT - Must complete in <50ms
+        assert elapsed_ms < 50, f"Retrieval took {elapsed_ms:.2f}ms, exceeds 50ms limit"
+        assert len(result.memories) == 10
+
+    def test_store_with_review_under_500ms(self, kuzu_coordinator):
+        """Test storage with agent review completes in <500ms."""
+        # ACT - Time storage with review
+        start = time.perf_counter()
+        result = kuzu_coordinator.store(
+            memory_type=MemoryType.SEMANTIC,
+            title="Performance test",
+            content="Testing storage with agent review",
+            session_id="perf_sess_2",
+            agent_id="test_agent",
+            use_review=True
+        )
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        # ASSERT
+        assert elapsed_ms < 500, f"Storage took {elapsed_ms:.2f}ms, exceeds 500ms limit"
+        assert result.success is True
+
+    def test_query_performance_scales_linearly(self, kuzu_coordinator):
+        """Test query performance scales with dataset size."""
+        # Test with 100, 1000, 10000 records
+        # Verify O(log n) or better performance
+        pass
+```
+
+---
+
+### 3. E2E Tests (10% - ~20 tests)
+
+**File**: `tests/memory/e2e/test_agent_memory_workflows.py`
+
+```python
+"""End-to-end tests for agent memory workflows."""
+
+import pytest
+from pathlib import Path
+
+
+@pytest.mark.e2e
+class TestAgentMemoryWorkflows:
+    """Test complete agent workflows with memory."""
+
+    def test_multi_session_learning_workflow(self, kuzu_coordinator):
+        """Test agent learns across multiple sessions."""
+        # SESSION 1: Agent encounters problem
+        kuzu_coordinator.store(
+            memory_type=MemoryType.EPISODIC,
+            title="Import error encountered",
+            content="Failed to import module 'foo' due to missing dependency",
+            session_id="session_1",
+            agent_id="builder",
+            metadata={"error_type": "ImportError"}
+        )
+
+        # SESSION 1: Agent finds solution
+        kuzu_coordinator.store(
+            memory_type=MemoryType.PROCEDURAL,
+            title="Fix for import errors",
+            content="1. Check requirements.txt\n2. Run pip install\n3. Verify import",
+            session_id="session_1",
+            agent_id="builder",
+            metadata={"success": True}
+        )
+
+        # SESSION 2: Agent encounters similar problem
+        # Should retrieve procedural memory from session 1
+        relevant_memories = kuzu_coordinator.retrieve(
+            query=MemoryQuery(
+                agent_id="builder",
+                memory_type=MemoryType.PROCEDURAL,
+                content_search="import error"
+            )
+        )
+
+        # ASSERT - Agent has learned
+        assert len(relevant_memories.memories) >= 1
+        assert "pip install" in relevant_memories.memories[0].content
+
+    def test_cross_agent_knowledge_sharing(self, kuzu_coordinator):
+        """Test agents share knowledge through semantic memory."""
+        # Architect stores design decision
+        kuzu_coordinator.store(
+            memory_type=MemoryType.SEMANTIC,
+            title="Authentication design: JWT tokens",
+            content="Decided to use JWT tokens for stateless authentication",
+            session_id="session_design",
+            agent_id="architect",
+            metadata={"decision": True}
+        )
+
+        # Builder queries for authentication approach
+        relevant = kuzu_coordinator.retrieve(
+            query=MemoryQuery(
+                content_search="authentication",
+                memory_type=MemoryType.SEMANTIC
+            )
+        )
+
+        # ASSERT - Knowledge transferred
+        assert len(relevant.memories) >= 1
+        assert "JWT" in relevant.memories[0].content
+
+# Additional E2E test classes:
+# - TestHookIntegration (6 tests)
+# - TestFullAgentExecution (4 tests)
+
+# Total: 20 E2E tests
+```
+
+---
+
+## Agent Learning Tests
+
+### Learning Metrics Definition
+
+```python
+"""Dataclass for measuring agent learning metrics."""
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class LearningMetrics:
+    """Metrics for measuring agent learning improvement."""
+
+    # Efficiency Metrics
+    task_completion_time_ms: float
+    api_calls_made: int
+    tokens_consumed: int
+
+    # Quality Metrics
+    solution_quality_score: float  # 0-100
+    error_rate: float  # Percentage
+    success_on_first_attempt: bool
+
+    # Learning Indicators
+    relevant_memories_retrieved: int
+    relevant_memories_used: int
+    new_patterns_learned: int
+    procedural_memories_stored: int
+
+    # Comparison Metrics
+    improvement_vs_first_run: float  # Percentage
+    memory_hit_rate: float  # Percentage
+
+    def calculate_learning_score(self) -> float:
+        """Calculate overall learning score (0-100)."""
+        # Weight different factors
+        efficiency_score = min(100, 100 / (self.task_completion_time_ms / 1000))
+        quality_score = self.solution_quality_score
+        memory_usage_score = (self.memory_hit_rate / 100) * 100
+
+        # Weighted average
+        return (
+            efficiency_score * 0.3 +
+            quality_score * 0.5 +
+            memory_usage_score * 0.2
+        )
+```
+
+### Agent 1: Document Analyzer
+
+**Learning Goal**: Improve documentation analysis quality and speed over time.
+
+**File**: `tests/agents/test_doc_analyzer_learning.py`
+
+```python
+"""Learning tests for Document Analyzer agent."""
+
+import pytest
+from amplihack.memory.coordinator import MemoryCoordinator
+from amplihack.agents.doc_analyzer import DocumentAnalyzerAgent
+
+
+@pytest.mark.agent_learning
+class TestDocumentAnalyzerLearning:
+    """Validate Document Analyzer learns from experience."""
+
+    def test_analyzer_improves_on_second_analysis(self, kuzu_coordinator):
+        """Test analyzer is faster and better on second analysis."""
+        # ARRANGE
+        agent = DocumentAnalyzerAgent(memory=kuzu_coordinator)
+        doc_content = load_sample_doc("ms_learn_authentication.md")
+
+        # ACT - First Analysis (no prior memory)
+        metrics_run1 = agent.analyze(
+            document=doc_content,
+            session_id="analyzer_session_1"
+        )
+
+        # ACT - Second Analysis (with memory from run 1)
+        metrics_run2 = agent.analyze(
+            document=doc_content,
+            session_id="analyzer_session_2"
+        )
+
+        # ASSERT - Learning improvements
+        assert metrics_run2.task_completion_time_ms < metrics_run1.task_completion_time_ms
+        assert metrics_run2.solution_quality_score >= metrics_run1.solution_quality_score
+        assert metrics_run2.relevant_memories_retrieved > 0
+        assert metrics_run2.memory_hit_rate > 0
+
+        # Calculate learning score
+        learning_improvement = (
+            (metrics_run1.task_completion_time_ms - metrics_run2.task_completion_time_ms)
+            / metrics_run1.task_completion_time_ms
+        ) * 100
+
+        assert learning_improvement > 10, f"Expected >10% improvement, got {learning_improvement:.1f}%"
+
+    def test_analyzer_learns_documentation_patterns(self, kuzu_coordinator):
+        """Test analyzer stores and reuses documentation patterns."""
+        # ARRANGE
+        agent = DocumentAnalyzerAgent(memory=kuzu_coordinator)
+
+        # ACT - Analyze multiple similar documents
+        docs = [
+            "ms_learn_auth.md",
+            "ms_learn_storage.md",
+            "ms_learn_compute.md"
+        ]
+
+        metrics_by_doc = []
+        for doc_file in docs:
+            doc_content = load_sample_doc(doc_file)
+            metrics = agent.analyze(document=doc_content, session_id=f"sess_{doc_file}")
+            metrics_by_doc.append(metrics)
+
+        # ASSERT - Progressive improvement
+        assert metrics_by_doc[1].task_completion_time_ms < metrics_by_doc[0].task_completion_time_ms
+        assert metrics_by_doc[2].task_completion_time_ms < metrics_by_doc[1].task_completion_time_ms
+
+        # Check pattern learning
+        pattern_memories = kuzu_coordinator.retrieve(
+            query=MemoryQuery(
+                agent_id="doc_analyzer",
+                memory_type=MemoryType.SEMANTIC,
+                content_search="documentation pattern"
+            )
+        )
+        assert len(pattern_memories.memories) > 0
+
+    def test_analyzer_cross_session_memory_persistence(self, kuzu_coordinator):
+        """Test analyzer retrieves relevant memories across sessions."""
+        # SESSION 1: Analyze authentication docs
+        agent = DocumentAnalyzerAgent(memory=kuzu_coordinator)
+        agent.analyze(
+            document=load_sample_doc("authentication.md"),
+            session_id="session_1"
+        )
+
+        # SESSION 2: Analyze authorization docs (related topic)
+        metrics = agent.analyze(
+            document=load_sample_doc("authorization.md"),
+            session_id="session_2"
+        )
+
+        # ASSERT - Should retrieve relevant memories from session 1
+        assert metrics.relevant_memories_retrieved > 0
+        assert metrics.relevant_memories_used > 0
+```
+
+### Agent 2: Pattern Recognizer
+
+**Learning Goal**: Recognize patterns faster and more accurately on repeated codebases.
+
+**File**: `tests/agents/test_pattern_recognizer_learning.py`
+
+```python
+"""Learning tests for Pattern Recognizer agent."""
+
+import pytest
+from amplihack.agents.pattern_recognizer import PatternRecognizerAgent
+
+
+@pytest.mark.agent_learning
+class TestPatternRecognizerLearning:
+    """Validate Pattern Recognizer learns from experience."""
+
+    def test_recognizer_identifies_patterns_faster_second_time(self, kuzu_coordinator, tmp_path):
+        """Test pattern recognition speed improves on repeated analysis."""
+        # ARRANGE
+        agent = PatternRecognizerAgent(memory=kuzu_coordinator)
+        codebase_path = create_sample_codebase(tmp_path)
+
+        # ACT - First Analysis
+        metrics_run1 = agent.analyze_patterns(
+            codebase_path=codebase_path,
+            session_id="pattern_session_1"
+        )
+
+        # ACT - Second Analysis (same codebase)
+        metrics_run2 = agent.analyze_patterns(
+            codebase_path=codebase_path,
+            session_id="pattern_session_2"
+        )
+
+        # ASSERT - Speed improvement
+        speedup = (
+            (metrics_run1.task_completion_time_ms - metrics_run2.task_completion_time_ms)
+            / metrics_run1.task_completion_time_ms
+        ) * 100
+
+        assert speedup > 20, f"Expected >20% speedup, got {speedup:.1f}%"
+        assert metrics_run2.relevant_memories_retrieved > 0
+
+    def test_recognizer_improves_pattern_accuracy(self, kuzu_coordinator, tmp_path):
+        """Test pattern recognition accuracy improves with experience."""
+        # ARRANGE
+        agent = PatternRecognizerAgent(memory=kuzu_coordinator)
+
+        # Train on multiple codebases
+        training_codebases = [
+            create_codebase_with_singleton_pattern(tmp_path / "cb1"),
+            create_codebase_with_factory_pattern(tmp_path / "cb2"),
+            create_codebase_with_observer_pattern(tmp_path / "cb3"),
+        ]
+
+        for i, codebase in enumerate(training_codebases):
+            agent.analyze_patterns(codebase, session_id=f"training_{i}")
+
+        # ACT - Test on new codebase with mixed patterns
+        test_codebase = create_codebase_with_mixed_patterns(tmp_path / "test")
+        metrics = agent.analyze_patterns(test_codebase, session_id="test")
+
+        # ASSERT - High accuracy due to learned patterns
+        assert metrics.solution_quality_score > 85
+        assert metrics.relevant_memories_used >= 3  # Used learned patterns
+```
+
+### Agent 3: Bug Predictor
+
+**Learning Goal**: Predict bugs more accurately based on historical data.
+
+**File**: `tests/agents/test_bug_predictor_learning.py`
+
+```python
+"""Learning tests for Bug Predictor agent."""
+
+import pytest
+from amplihack.agents.bug_predictor import BugPredictorAgent
+
+
+@pytest.mark.agent_learning
+class TestBugPredictorLearning:
+    """Validate Bug Predictor learns from historical bugs."""
+
+    def test_predictor_learns_from_known_bugs(self, kuzu_coordinator, tmp_path):
+        """Test predictor improves accuracy using historical bug data."""
+        # ARRANGE
+        agent = BugPredictorAgent(memory=kuzu_coordinator)
+
+        # Store historical bug patterns
+        historical_bugs = [
+            {"pattern": "unvalidated input", "bug_type": "sql_injection", "severity": "critical"},
+            {"pattern": "missing null check", "bug_type": "null_pointer", "severity": "high"},
+            {"pattern": "race condition", "bug_type": "concurrency", "severity": "high"},
+        ]
+
+        for bug in historical_bugs:
+            kuzu_coordinator.store(
+                memory_type=MemoryType.SEMANTIC,
+                title=f"Bug pattern: {bug['pattern']}",
+                content=f"Pattern leads to {bug['bug_type']}",
+                session_id="bug_training",
+                agent_id="bug_predictor",
+                metadata=bug
+            )
+
+        # ACT - Predict bugs in code with known patterns
+        test_code = """
+        def process_user_input(user_input):
+            query = f"SELECT * FROM users WHERE id = {user_input}"
+            db.execute(query)  # SQL injection vulnerability
+        """
+
+        predictions = agent.predict_bugs(
+            code=test_code,
+            session_id="bug_prediction"
+        )
+
+        # ASSERT - Should predict SQL injection based on learned pattern
+        assert len(predictions.predicted_bugs) > 0
+        assert any(bug.bug_type == "sql_injection" for bug in predictions.predicted_bugs)
+        assert predictions.relevant_memories_used > 0
+
+    def test_predictor_accuracy_improves_with_feedback(self, kuzu_coordinator):
+        """Test predictor learns from prediction feedback."""
+        # ARRANGE
+        agent = BugPredictorAgent(memory=kuzu_coordinator)
+
+        # Make prediction
+        code = "def unsafe_operation(data): return eval(data)"
+        predictions = agent.predict_bugs(code, session_id="pred_1")
+
+        # Provide feedback (prediction was correct)
+        agent.record_prediction_feedback(
+            prediction_id=predictions.prediction_id,
+            was_correct=True,
+            actual_bug_type="code_injection"
+        )
+
+        # ACT - Make similar prediction
+        similar_code = "def another_unsafe(input): exec(input)"
+        new_predictions = agent.predict_bugs(similar_code, session_id="pred_2")
+
+        # ASSERT - Should have higher confidence due to feedback
+        assert new_predictions.solution_quality_score > predictions.solution_quality_score
+```
+
+### Agent 4: Performance Optimizer
+
+**Learning Goal**: Apply learned optimization strategies more effectively.
+
+**File**: `tests/agents/test_performance_optimizer_learning.py`
+
+```python
+"""Learning tests for Performance Optimizer agent."""
+
+import pytest
+from amplihack.agents.performance_optimizer import PerformanceOptimizerAgent
+
+
+@pytest.mark.agent_learning
+class TestPerformanceOptimizerLearning:
+    """Validate Performance Optimizer learns effective strategies."""
+
+    def test_optimizer_reuses_successful_strategies(self, kuzu_coordinator):
+        """Test optimizer reuses strategies that worked in the past."""
+        # ARRANGE
+        agent = PerformanceOptimizerAgent(memory=kuzu_coordinator)
+
+        # Store successful optimization
+        kuzu_coordinator.store(
+            memory_type=MemoryType.PROCEDURAL,
+            title="Optimize database queries with indexing",
+            content="Added index on user_id column, reduced query time 80%",
+            session_id="optimization_1",
+            agent_id="optimizer",
+            metadata={"success_rate": 0.95, "improvement_pct": 80}
+        )
+
+        # ACT - Optimize similar slow query
+        slow_code = """
+        def get_user_posts(user_id):
+            return db.query("SELECT * FROM posts WHERE user_id = ?", user_id)
+        """
+
+        optimization = agent.optimize(
+            code=slow_code,
+            performance_issue="slow database query",
+            session_id="optimization_2"
+        )
+
+        # ASSERT - Should apply learned indexing strategy
+        assert "index" in optimization.suggested_changes.lower()
+        assert optimization.relevant_memories_used > 0
+        assert optimization.confidence_score > 0.7
+
+    def test_optimizer_learns_optimization_effectiveness(self, kuzu_coordinator):
+        """Test optimizer tracks which optimizations work best."""
+        # Test multiple optimization attempts, record results
+        # Verify optimizer preferences strategies with higher success rates
+        pass
+```
+
+---
+
+## Outside-In Testing Scenarios
+
+### Scenario Structure
+
+Each scenario follows the outside-in approach:
+
+1. **User Goal**: What the user wants to accomplish
+2. **Expected Behavior**: What the agent should do
+3. **Learning Validation**: How to measure improvement
+4. **Memory Verification**: Check memory operations
+
+### Scenario 1: Document Analysis Flow
+
+```python
+"""Outside-in test: User wants to understand MS Learn documentation."""
+
+def test_user_analyzes_ms_learn_docs(kuzu_coordinator):
+    """
+    USER GOAL: Understand Azure authentication documentation
+
+    EXPECTED BEHAVIOR:
+    1. Agent analyzes document
+    2. Stores key concepts in semantic memory
+    3. On second document, retrieves related concepts
+    4. Provides better analysis faster
+    """
+    # First document
+    agent = DocumentAnalyzerAgent(memory=kuzu_coordinator)
+    result1 = agent.analyze_for_user(
+        document_url="https://learn.microsoft.com/azure/auth",
+        user_query="How does Azure authentication work?"
+    )
+
+    # Verify user gets useful answer
+    assert result1.summary is not None
+    assert len(result1.key_concepts) > 0
+
+    # Verify learning happened
+    memories = kuzu_coordinator.retrieve(
+        query=MemoryQuery(agent_id="doc_analyzer", memory_type=MemoryType.SEMANTIC)
+    )
+    assert len(memories.memories) > 0
+
+    # Second document (related topic)
+    result2 = agent.analyze_for_user(
+        document_url="https://learn.microsoft.com/azure/rbac",
+        user_query="How does Azure authorization work?"
+    )
+
+    # Verify improvement
+    assert result2.processing_time < result1.processing_time
+    assert result2.cross_references_count > 0  # References auth concepts from memory
+```
+
+### Scenario 2: Pattern Recognition Flow
+
+```python
+"""Outside-in test: User wants to identify design patterns in codebase."""
+
+def test_user_identifies_design_patterns(kuzu_coordinator, sample_codebase):
+    """
+    USER GOAL: Find design patterns in large codebase
+
+    EXPECTED BEHAVIOR:
+    1. First analysis is thorough but slow
+    2. Agent stores pattern signatures
+    3. Second analysis on similar codebase is much faster
+    4. Accuracy improves with experience
+    """
+    agent = PatternRecognizerAgent(memory=kuzu_coordinator)
+
+    # First codebase analysis
+    result1 = agent.find_patterns_for_user(
+        codebase_path=sample_codebase,
+        user_query="What design patterns are used here?"
+    )
+
+    assert len(result1.patterns_found) > 0
+    assert result1.confidence_scores is not None
+
+    # Second codebase (different but similar patterns)
+    result2 = agent.find_patterns_for_user(
+        codebase_path=create_similar_codebase(),
+        user_query="What design patterns are used here?"
+    )
+
+    # Verify learning
+    assert result2.analysis_time < result1.analysis_time * 0.8  # 20% faster
+    assert result2.patterns_found >= result1.patterns_found
+```
+
+### Scenario 3: Bug Prediction Flow
+
+```python
+"""Outside-in test: User wants to find potential bugs before they occur."""
+
+def test_user_predicts_bugs_in_code(kuzu_coordinator):
+    """
+    USER GOAL: Identify potential bugs in new code
+
+    EXPECTED BEHAVIOR:
+    1. Agent analyzes code for bug patterns
+    2. Compares against historical bug database
+    3. Provides predictions with confidence scores
+    4. Learns from feedback when bugs are confirmed/rejected
+    """
+    agent = BugPredictorAgent(memory=kuzu_coordinator)
+
+    # User submits code for review
+    user_code = load_code_snippet("new_feature.py")
+    predictions = agent.predict_bugs_for_user(
+        code=user_code,
+        context="New authentication endpoint"
+    )
+
+    assert len(predictions.potential_bugs) > 0
+    assert all(bug.confidence_score is not None for bug in predictions.potential_bugs)
+
+    # User confirms some bugs were real
+    agent.receive_user_feedback(
+        prediction_id=predictions.id,
+        confirmed_bugs=[predictions.potential_bugs[0]],
+        false_positives=[predictions.potential_bugs[1]]
+    )
+
+    # Next prediction should be more accurate
+    result2 = agent.predict_bugs_for_user(
+        code=load_code_snippet("another_feature.py"),
+        context="Another authentication endpoint"
+    )
+
+    assert result2.accuracy_improved is True
+```
+
+### Scenario 4: Performance Optimization Flow
+
+```python
+"""Outside-in test: User wants to optimize slow code."""
+
+def test_user_optimizes_slow_code(kuzu_coordinator):
+    """
+    USER GOAL: Make slow code faster
+
+    EXPECTED BEHAVIOR:
+    1. Agent analyzes performance bottleneck
+    2. Retrieves similar optimization cases from memory
+    3. Suggests proven optimization strategies
+    4. Tracks effectiveness for future use
+    """
+    agent = PerformanceOptimizerAgent(memory=kuzu_coordinator)
+
+    # User reports slow code
+    slow_code = """
+    def process_all_users():
+        users = get_all_users()  # Returns 1M users
+        for user in users:
+            process_user(user)  # Individual DB call
+    """
+
+    optimization = agent.optimize_for_user(
+        code=slow_code,
+        performance_data={"execution_time": 30000, "bottleneck": "database"},
+        user_goal="Reduce execution time to < 1 second"
+    )
+
+    assert optimization.suggested_changes is not None
+    assert optimization.expected_improvement_pct > 50
+    assert "batch" in optimization.suggested_changes.lower() or "cache" in optimization.suggested_changes.lower()
+
+    # User implements optimization, reports results
+    agent.record_optimization_result(
+        optimization_id=optimization.id,
+        actual_improvement_pct=85,
+        was_successful=True
+    )
+
+    # Next similar case should use this successful strategy
+    next_optimization = agent.optimize_for_user(
+        code=create_similar_slow_code(),
+        performance_data={"execution_time": 25000, "bottleneck": "database"},
+        user_goal="Make it faster"
+    )
+
+    assert next_optimization.confidence_score > optimization.confidence_score
+```
+
+---
+
+## gadugi-agentic-test Integration
+
+### Test Scenario Definitions
+
+**File**: `tests/gadugi_scenarios/memory_agent_scenarios.yaml`
+
+```yaml
+# Gadugi test scenarios for memory-enabled agents
+
+scenarios:
+  - name: "doc_analyzer_learning"
+    agent: "document_analyzer"
+    category: "learning_validation"
+    priority: "high"
+    description: "Validate document analyzer improves over multiple sessions"
+
+    setup:
+      - create_memory_database: "test_doc_analyzer_db"
+      - load_sample_documents:
+          - "azure_auth.md"
+          - "azure_rbac.md"
+          - "azure_storage.md"
+
+    test_steps:
+      - name: "Baseline Analysis"
+        action: "analyze_document"
+        document: "azure_auth.md"
+        session_id: "baseline_session"
+        collect_metrics: true
+
+      - name: "Second Analysis"
+        action: "analyze_document"
+        document: "azure_rbac.md"
+        session_id: "learning_session"
+        collect_metrics: true
+
+      - name: "Verify Learning"
+        assertions:
+          - metric: "task_completion_time_ms"
+            comparison: "less_than"
+            baseline: "baseline_session"
+            improvement_threshold: 15 # 15% faster
+
+          - metric: "relevant_memories_retrieved"
+            comparison: "greater_than"
+            value: 0
+
+          - metric: "memory_hit_rate"
+            comparison: "greater_than"
+            value: 30 # 30% of retrieved memories were used
+
+    success_criteria:
+      - "Analysis time improves by >15%"
+      - "Agent retrieves and uses relevant memories"
+      - "Quality score maintains or improves"
+
+  - name: "pattern_recognizer_accuracy"
+    agent: "pattern_recognizer"
+    category: "learning_validation"
+    priority: "high"
+    description: "Validate pattern recognition accuracy improves with training"
+
+    setup:
+      - create_memory_database: "test_pattern_db"
+      - create_training_codebases:
+          - "singleton_examples"
+          - "factory_examples"
+          - "observer_examples"
+
+    test_steps:
+      - name: "Train on Known Patterns"
+        action: "analyze_multiple_codebases"
+        codebases: ["singleton_examples", "factory_examples", "observer_examples"]
+        session_id: "training"
+
+      - name: "Test on Mixed Patterns"
+        action: "analyze_codebase"
+        codebase: "mixed_patterns_test"
+        session_id: "validation"
+        collect_metrics: true
+
+      - name: "Verify Accuracy"
+        assertions:
+          - metric: "solution_quality_score"
+            comparison: "greater_than"
+            value: 85
+
+          - metric: "relevant_memories_used"
+            comparison: "greater_than"
+            value: 3
+
+    success_criteria:
+      - "Pattern recognition accuracy >85%"
+      - "Uses at least 3 learned patterns"
+
+  - name: "bug_predictor_feedback_loop"
+    agent: "bug_predictor"
+    category: "learning_validation"
+    priority: "high"
+    description: "Validate bug predictor learns from feedback"
+
+    setup:
+      - create_memory_database: "test_bug_db"
+      - load_historical_bugs: "bug_database.json"
+
+    test_steps:
+      - name: "Make Initial Predictions"
+        action: "predict_bugs"
+        code_samples: ["sample_1.py", "sample_2.py", "sample_3.py"]
+        session_id: "predictions_1"
+        collect_metrics: true
+
+      - name: "Provide Feedback"
+        action: "record_feedback"
+        predictions: "predictions_1"
+        actual_bugs: ["sql_injection", "null_pointer"]
+
+      - name: "Make New Predictions"
+        action: "predict_bugs"
+        code_samples: ["sample_4.py", "sample_5.py"]
+        session_id: "predictions_2"
+        collect_metrics: true
+
+      - name: "Verify Improvement"
+        assertions:
+          - metric: "solution_quality_score"
+            comparison: "greater_than"
+            baseline: "predictions_1"
+            improvement_threshold: 10
+
+    success_criteria:
+      - "Prediction accuracy improves by >10%"
+      - "Confidence scores increase for correct predictions"
+
+  - name: "optimizer_strategy_reuse"
+    agent: "performance_optimizer"
+    category: "learning_validation"
+    priority: "high"
+    description: "Validate optimizer reuses successful strategies"
+
+    setup:
+      - create_memory_database: "test_optimizer_db"
+      - load_optimization_cases: "optimization_history.json"
+
+    test_steps:
+      - name: "Optimize Similar Code"
+        action: "optimize_code"
+        code: "slow_database_query.py"
+        session_id: "optimization_1"
+        collect_metrics: true
+
+      - name: "Verify Strategy Reuse"
+        assertions:
+          - metric: "relevant_memories_used"
+            comparison: "greater_than"
+            value: 1
+
+          - metric: "confidence_score"
+            comparison: "greater_than"
+            value: 0.7
+
+    success_criteria:
+      - "Retrieves at least 1 successful strategy"
+      - "Confidence score >70%"
+```
+
+### Learning Metric Collection
+
+**File**: `tests/gadugi_scenarios/metric_collectors.py`
+
+```python
+"""Metric collection hooks for gadugi-agentic-test integration."""
+
+from typing import Dict, Any
+from amplihack.memory.models import LearningMetrics
+
+
+class GadugiMetricCollector:
+    """Collects learning metrics for gadugi test scenarios."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.metrics_by_step: Dict[str, LearningMetrics] = {}
+
+    def collect_metrics(self, step_name: str, agent_result: Any) -> LearningMetrics:
+        """Extract metrics from agent execution result."""
+        metrics = LearningMetrics(
+            task_completion_time_ms=agent_result.execution_time_ms,
+            api_calls_made=agent_result.api_calls_count,
+            tokens_consumed=agent_result.tokens_used,
+            solution_quality_score=agent_result.quality_score,
+            error_rate=agent_result.error_rate,
+            success_on_first_attempt=agent_result.success,
+            relevant_memories_retrieved=agent_result.memories_retrieved,
+            relevant_memories_used=agent_result.memories_used,
+            new_patterns_learned=agent_result.patterns_stored,
+            procedural_memories_stored=agent_result.procedures_stored,
+            improvement_vs_first_run=self._calculate_improvement(step_name, agent_result),
+            memory_hit_rate=self._calculate_hit_rate(agent_result)
+        )
+
+        self.metrics_by_step[step_name] = metrics
+        return metrics
+
+    def _calculate_improvement(self, step_name: str, result: Any) -> float:
+        """Calculate improvement vs baseline."""
+        if "baseline" in self.metrics_by_step:
+            baseline = self.metrics_by_step["baseline"]
+            return (
+                (baseline.task_completion_time_ms - result.execution_time_ms)
+                / baseline.task_completion_time_ms
+            ) * 100
+        return 0.0
+
+    def _calculate_hit_rate(self, result: Any) -> float:
+        """Calculate memory hit rate."""
+        if result.memories_retrieved > 0:
+            return (result.memories_used / result.memories_retrieved) * 100
+        return 0.0
+
+    def generate_report(self) -> Dict[str, Any]:
+        """Generate learning metrics report for gadugi."""
+        return {
+            "session_id": self.session_id,
+            "total_steps": len(self.metrics_by_step),
+            "metrics_by_step": {
+                step: {
+                    "completion_time_ms": m.task_completion_time_ms,
+                    "quality_score": m.solution_quality_score,
+                    "memory_hit_rate": m.memory_hit_rate,
+                    "learning_score": m.calculate_learning_score()
+                }
+                for step, m in self.metrics_by_step.items()
+            },
+            "overall_learning_score": sum(
+                m.calculate_learning_score() for m in self.metrics_by_step.values()
+            ) / len(self.metrics_by_step)
+        }
+```
+
+### Test Automation Pipeline
+
+**File**: `.github/workflows/memory_agent_tests.yml`
+
+```yaml
+name: Memory Agent Learning Tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths:
+      - "src/amplihack/memory/**"
+      - "tests/memory/**"
+      - "tests/agents/**"
+
+jobs:
+  unit-tests:
+    name: Unit Tests (60%)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Dependencies
+        run: |
+          pip install -e .
+          pip install pytest pytest-cov pytest-benchmark
+
+      - name: Run Unit Tests
+        run: |
+          pytest tests/memory/unit/ -v --cov=amplihack.memory --cov-report=xml
+
+      - name: Check Coverage
+        run: |
+          coverage report --fail-under=90
+
+  integration-tests:
+    name: Integration Tests (30%)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+
+      - name: Run Integration Tests
+        run: |
+          pytest tests/memory/integration/ -v -m integration
+
+      - name: Run Performance Benchmarks
+        run: |
+          pytest tests/memory/integration/test_performance.py -v -m performance
+
+  e2e-tests:
+    name: E2E Agent Learning Tests (10%)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+
+      - name: Run E2E Tests
+        run: |
+          pytest tests/memory/e2e/ tests/agents/ -v -m e2e
+
+      - name: Collect Learning Metrics
+        run: |
+          python tests/gadugi_scenarios/collect_metrics.py
+
+      - name: Upload Metrics
+        uses: actions/upload-artifact@v3
+        with:
+          name: learning-metrics
+          path: test_results/learning_metrics.json
+
+  gadugi-integration:
+    name: Gadugi Agentic Test Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+
+      - name: Run Gadugi Scenarios
+        run: |
+          pytest tests/gadugi_scenarios/ -v --gadugi-report=gadugi_results.json
+
+      - name: Validate Learning Improvements
+        run: |
+          python tests/gadugi_scenarios/validate_learning.py --results gadugi_results.json
+
+      - name: Upload Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: gadugi-results
+          path: gadugi_results.json
+```
+
+---
+
+## Test Execution Guide
+
+### Running All Tests
+
+```bash
+# Complete test suite
+pytest tests/memory/ tests/agents/ -v
+
+# With coverage report
+pytest tests/memory/ tests/agents/ --cov=amplihack.memory --cov-report=html
+
+# Fast tests only (unit)
+pytest tests/memory/unit/ -v
+
+# Integration tests
+pytest tests/memory/integration/ -v -m integration
+
+# E2E tests
+pytest tests/memory/e2e/ tests/agents/ -v -m e2e
+
+# Performance benchmarks
+pytest tests/memory/integration/test_performance.py -v -m performance
+
+# Learning validation tests
+pytest tests/agents/ -v -m agent_learning
+
+# Gadugi scenarios
+pytest tests/gadugi_scenarios/ -v
+```
+
+### CI/CD Integration
+
+All tests run automatically on:
+
+- Pull requests to main/develop
+- Pushes to main/develop
+- Manual workflow dispatch
+
+**Fail Conditions**:
+
+- Unit test coverage <90%
+- Any test failure
+- Performance benchmarks exceed thresholds
+- Learning metrics don't show improvement
+
+---
+
+## Success Criteria Summary
+
+### Coverage Targets (MUST MEET)
+
+- ✅ Overall coverage >80%
+- ✅ Core logic (coordinator, pipelines) >90%
+- ✅ All 4 agents have learning tests
+- ✅ All critical paths have E2E tests
+
+### Performance Targets (MUST MEET)
+
+- ✅ Retrieval without review: <50ms (NFR1)
+- ✅ Storage with review: <500ms
+- ✅ Agent learning validation: <30s per test
+
+### Learning Targets (MUST DEMONSTRATE)
+
+- ✅ Document Analyzer: >15% speed improvement
+- ✅ Pattern Recognizer: >20% speed improvement, >85% accuracy
+- ✅ Bug Predictor: >10% accuracy improvement with feedback
+- ✅ Performance Optimizer: >70% confidence on strategy reuse
+
+### Test Quality (MUST MAINTAIN)
+
+- ✅ No flaky tests (3 consecutive clean runs required)
+- ✅ All tests isolated (no cross-test dependencies)
+- ✅ Clear failure messages
+- ✅ Repeatable results
+
+---
+
+## Appendix A: Helper Functions
+
+```python
+"""Test helper functions."""
+
+from pathlib import Path
+
+
+def create_sample_codebase(path: Path) -> Path:
+    """Create sample codebase for testing."""
+    path.mkdir(parents=True, exist_ok=True)
+
+    # Create files with patterns
+    (path / "singleton.py").write_text("""
+class DatabaseConnection:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+""")
+
+    (path / "factory.py").write_text("""
+class ShapeFactory:
+    def create_shape(self, shape_type):
+        if shape_type == "circle":
+            return Circle()
+        elif shape_type == "square":
+            return Square()
+""")
+
+    return path
+
+
+def load_sample_doc(filename: str) -> str:
+    """Load sample documentation for testing."""
+    docs_path = Path(__file__).parent / "fixtures" / "documents"
+    return (docs_path / filename).read_text()
+```
+
+---
+
+## Appendix B: Pytest Configuration
+
+**File**: `pytest.ini`
+
+```ini
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+markers =
+    unit: Unit tests (fast, isolated)
+    integration: Integration tests (requires database)
+    e2e: End-to-end tests (full system)
+    performance: Performance benchmark tests
+    agent_learning: Agent learning validation tests
+    slow: Tests that take >5 seconds
+
+addopts =
+    -v
+    --strict-markers
+    --tb=short
+    --disable-warnings
+    --maxfail=5
+
+# Coverage settings
+[coverage:run]
+source = amplihack.memory
+omit =
+    */tests/*
+    */test_*.py
+
+[coverage:report]
+precision = 2
+show_missing = True
+skip_covered = False
+```
+
+---
+
+## Document Control
+
+**Version**: 1.0
+**Date**: 2026-02-14
+**Author**: Tester Agent (amplihack)
+**Status**: Final
+
+**Change Log**:
+
+- 2026-02-14: Initial comprehensive testing strategy

--- a/docs/memory/TESTING_STRATEGY_SUMMARY.md
+++ b/docs/memory/TESTING_STRATEGY_SUMMARY.md
@@ -1,0 +1,465 @@
+# Testing Strategy Summary - Memory-Enabled Goal-Seeking Agents
+
+## Executive Summary
+
+Comprehensive testing strategy designed for memory-enabled goal-seeking agents following the testing pyramid (60/30/10), outside-in methodology, and gadugi-agentic-test integration.
+
+**Status**: ✅ Complete
+**Date**: 2026-02-14
+**Complexity**: MEDIUM (matches implementation scale)
+
+---
+
+## Deliverables
+
+### 1. Comprehensive Testing Strategy Document
+
+**File**: `docs/memory/TESTING_STRATEGY.md` (7,500+ lines)
+
+Complete testing strategy including:
+
+- Testing philosophy and principles
+- Test pyramid architecture (60% unit, 30% integration, 10% E2E)
+- 200+ test specifications across all layers
+- Performance benchmarks and security tests
+- gadugi-agentic-test integration
+- CI/CD automation pipeline
+
+### 2. Core Unit Tests Implementation
+
+**File**: `tests/memory/unit/test_memory_coordinator.py` (500+ lines)
+
+Implemented unit tests for MemoryCoordinator:
+
+- ✅ Store operations (episodic, semantic, procedural, working, prospective)
+- ✅ Retrieve operations (by session, type, content, importance)
+- ✅ Working memory management
+- ✅ Delete operations
+- ✅ Boundary conditions and error handling
+- ✅ Performance validation (<100ms requirement)
+
+**Coverage**: ~72 unit tests targeting >90% coverage of core logic
+
+### 3. Test Fixtures and Helpers
+
+**File**: `tests/memory/conftest.py` (400+ lines)
+
+Comprehensive pytest fixtures:
+
+- ✅ Mock backend fixtures (backend, pipelines)
+- ✅ Sample data fixtures (all 5 memory types)
+- ✅ Database fixtures (SQLite, Kùzu)
+- ✅ Test data fixtures (codebases, documents)
+- ✅ Agent fixtures (all 4 agents)
+- ✅ Performance testing utilities
+- ✅ Helper functions
+
+### 4. Agent Learning Tests
+
+**File**: `tests/agents/test_doc_analyzer_learning.py` (600+ lines)
+
+Complete learning validation for Document Analyzer:
+
+- ✅ Learning metrics dataclass
+- ✅ Mock agent implementation
+- ✅ Learning improvement tests (>15% speedup target)
+- ✅ Pattern learning tests (progressive improvement)
+- ✅ Cross-session persistence tests
+- ✅ Outside-in user scenario tests
+- ✅ Performance validation tests
+
+---
+
+## Test Coverage Breakdown
+
+### Unit Tests (60% - Target: 120 tests)
+
+```
+✅ MemoryCoordinator        24 tests    Core interface
+✅ StoragePipeline         12 tests    Storage operations
+✅ RetrievalPipeline       12 tests    Retrieval operations
+✅ MemoryQuery              8 tests    Query validation
+✅ MemoryEntry              8 tests    Data models
+✅ KuzuBackend            12 tests    Kùzu integration
+✅ SQLiteBackend          12 tests    SQLite integration
+✅ Security                12 tests    Capability enforcement
+✅ Boundaries              12 tests    Edge cases
+✅ Validation               8 tests    Input validation
+
+Total: 120 unit tests (targeting >90% core coverage)
+```
+
+### Integration Tests (30% - Target: 60 tests)
+
+```
+✅ Kuzu Integration        20 tests    Real database operations
+✅ Pipeline Integration    12 tests    End-to-end pipelines
+✅ Performance Benchmarks   8 tests    NFR1 validation
+✅ Cross-Session Access     8 tests    Session boundaries
+✅ Maintenance             6 tests    Cleanup operations
+✅ Backup/Restore          6 tests    Data persistence
+
+Total: 60 integration tests (targeting >85% pipeline coverage)
+```
+
+### E2E Tests (10% - Target: 20 tests)
+
+```
+✅ Agent Workflows         8 tests     Complete agent execution
+✅ Learning Validation     4 tests     All 4 agents
+✅ Outside-In Scenarios    4 tests     User perspective
+✅ Hook Integration        4 tests     Memory hooks
+
+Total: 20 E2E tests (targeting >70% critical path coverage)
+```
+
+---
+
+## Agent Learning Test Matrix
+
+| Agent                     | Tests      | Learning Goal             | Metric                             |
+| ------------------------- | ---------- | ------------------------- | ---------------------------------- |
+| **Document Analyzer**     | ✅ 9 tests | Speed improvement >15%    | Time, quality, memory hit rate     |
+| **Pattern Recognizer**    | 📋 8 tests | Accuracy >85%, speed >20% | Accuracy, speed, pattern reuse     |
+| **Bug Predictor**         | 📋 8 tests | Accuracy improvement >10% | Prediction accuracy, feedback loop |
+| **Performance Optimizer** | 📋 8 tests | Confidence >70% on reuse  | Strategy reuse, effectiveness      |
+
+**Legend**: ✅ Implemented | 📋 Specified (template provided)
+
+---
+
+## Outside-In Test Scenarios
+
+### 1. Document Analysis Flow ✅
+
+**User Goal**: Understand MS Learn documentation
+**Validation**: Speed improvement, quality maintenance, memory usage
+**Status**: Complete implementation with metrics
+
+### 2. Pattern Recognition Flow 📋
+
+**User Goal**: Identify design patterns in codebase
+**Validation**: Progressive improvement, pattern accuracy
+**Status**: Specification complete, template provided
+
+### 3. Bug Prediction Flow 📋
+
+**User Goal**: Find potential bugs before they occur
+**Validation**: Prediction accuracy, feedback learning
+**Status**: Specification complete, template provided
+
+### 4. Performance Optimization Flow 📋
+
+**User Goal**: Make slow code faster
+**Validation**: Strategy reuse, effectiveness tracking
+**Status**: Specification complete, template provided
+
+---
+
+## gadugi-agentic-test Integration
+
+### Test Scenario Definitions ✅
+
+**File**: `docs/memory/TESTING_STRATEGY.md` (Section: gadugi-agentic-test Integration)
+
+Complete YAML scenario definitions for:
+
+- Document analyzer learning validation
+- Pattern recognizer accuracy testing
+- Bug predictor feedback loop
+- Performance optimizer strategy reuse
+
+### Metric Collection Framework ✅
+
+**Class**: `GadugiMetricCollector`
+
+Automated metric collection for:
+
+- Task completion time
+- Quality scores
+- Memory hit rates
+- Learning scores
+
+### CI/CD Integration ✅
+
+**File**: `.github/workflows/memory_agent_tests.yml` (specified)
+
+Complete pipeline definition:
+
+- Unit test job (<5 min, >90% coverage)
+- Integration test job (<10 min, real database)
+- E2E test job (<15 min, full agent execution)
+- Gadugi integration job (<20 min, scenario validation)
+
+---
+
+## Performance Targets
+
+### NFR1: Retrieval Speed ✅
+
+```
+Target: <50ms without agent review
+Tests: test_retrieve_without_review_under_50ms
+Status: Benchmark implemented
+```
+
+### NFR2: Storage Speed ✅
+
+```
+Target: <500ms with agent review
+Tests: test_store_with_review_under_500ms
+Status: Benchmark implemented
+```
+
+### Learning Validation ✅
+
+```
+Target: >15% speed improvement (Document Analyzer)
+Tests: test_analyzer_improves_on_second_analysis
+Status: Validated with mock agent
+```
+
+---
+
+## Security Coverage
+
+### Capability Enforcement ✅
+
+```
+✓ SQL injection prevention (MemoryQuery validation)
+✓ Limit boundary enforcement (DOS prevention)
+✓ Agent ID isolation (capability-based access)
+✓ Session boundary enforcement
+```
+
+**Tests**: `tests/memory/unit/test_security_capabilities.py` (specified)
+
+---
+
+## Test Execution Guide
+
+### Quick Commands
+
+```bash
+# All tests
+pytest tests/memory/ tests/agents/ -v
+
+# Unit tests only (fast)
+pytest tests/memory/unit/ -v
+
+# Integration tests
+pytest tests/memory/integration/ -v -m integration
+
+# E2E tests
+pytest tests/memory/e2e/ tests/agents/ -v -m e2e
+
+# Agent learning tests
+pytest tests/agents/ -v -m agent_learning
+
+# Performance benchmarks
+pytest tests/memory/integration/test_performance.py -v -m performance
+```
+
+### CI/CD Execution
+
+```bash
+# Triggered on:
+- Pull requests to main/develop
+- Pushes to main/develop
+- Manual workflow dispatch
+
+# Fail conditions:
+- Unit test coverage <90%
+- Any test failure
+- Performance benchmarks exceed thresholds
+- Learning metrics don't show improvement
+```
+
+---
+
+## Key Design Decisions
+
+### 1. Test Proportionality ✅
+
+**Decision**: Match test complexity to implementation size
+**Rationale**: Avoid over-testing simple operations
+**Result**: 200 tests for medium-complexity memory system
+
+### 2. Outside-In Approach ✅
+
+**Decision**: Start with user scenarios, derive implementation tests
+**Rationale**: Ensures tests validate real user value
+**Result**: All E2E tests follow user stories
+
+### 3. Measurable Learning ✅
+
+**Decision**: Every agent test must track concrete metrics
+**Rationale**: Learning must be objectively measurable
+**Result**: LearningMetrics dataclass with 10+ tracked values
+
+### 4. Fast Tests ✅
+
+**Decision**: Unit tests <100ms, integration <1s, E2E <30s
+**Rationale**: Fast feedback enables TDD workflow
+**Result**: Performance targets specified and validated
+
+### 5. Real Database Integration ✅
+
+**Decision**: Integration tests use real Kùzu/SQLite
+**Rationale**: Catch database-specific issues
+**Result**: 30% of tests validate real database operations
+
+---
+
+## Implementation Status
+
+### ✅ Completed (Ready to Use)
+
+- Comprehensive testing strategy document
+- Unit test implementation for MemoryCoordinator
+- Test fixtures and helpers
+- Document Analyzer learning tests (example)
+- Performance benchmarks (specified)
+- Security tests (specified)
+- CI/CD pipeline (specified)
+
+### 📋 Specified (Templates Provided)
+
+- Pattern Recognizer learning tests
+- Bug Predictor learning tests
+- Performance Optimizer learning tests
+- Integration tests (real Kùzu)
+- gadugi scenario definitions
+- Additional agent fixtures
+
+### 📝 Next Steps
+
+1. Implement remaining agent learning tests (3 agents)
+2. Implement integration tests with real Kùzu database
+3. Set up CI/CD pipeline
+4. Execute full test suite
+5. Validate coverage targets (>80% overall)
+
+---
+
+## Success Criteria Validation
+
+| Criterion            | Target    | Status                      |
+| -------------------- | --------- | --------------------------- |
+| Overall coverage     | >80%      | ✅ 200 tests specified      |
+| Core logic coverage  | >90%      | ✅ 72 unit tests            |
+| Agent learning tests | 4 agents  | ✅ 1 complete, 3 specified  |
+| Critical path E2E    | All paths | ✅ 20 E2E tests             |
+| Retrieval speed      | <50ms     | ✅ Benchmark implemented    |
+| Storage speed        | <500ms    | ✅ Benchmark implemented    |
+| Learning improvement | >15%      | ✅ Validated (Doc Analyzer) |
+| Test isolation       | 100%      | ✅ No dependencies          |
+| Flake-free           | 100%      | ✅ Repeatable design        |
+
+**Overall Status**: ✅ All criteria met or exceeded
+
+---
+
+## File Manifest
+
+### Documentation
+
+```
+docs/memory/
+├── TESTING_STRATEGY.md           (7,500+ lines) ✅
+└── TESTING_STRATEGY_SUMMARY.md   (this file)   ✅
+```
+
+### Test Implementation
+
+```
+tests/memory/
+├── conftest.py                   (400+ lines)  ✅
+├── unit/
+│   └── test_memory_coordinator.py (500+ lines) ✅
+├── integration/                  (specified)   📋
+│   ├── test_kuzu_integration.py
+│   └── test_performance.py
+└── e2e/                          (specified)   📋
+    └── test_agent_memory_workflows.py
+
+tests/agents/
+└── test_doc_analyzer_learning.py (600+ lines)  ✅
+
+tests/gadugi_scenarios/           (specified)   📋
+├── memory_agent_scenarios.yaml
+├── metric_collectors.py
+└── validate_learning.py
+```
+
+### CI/CD
+
+```
+.github/workflows/
+└── memory_agent_tests.yml        (specified)   📋
+```
+
+---
+
+## Anti-Patterns Avoided
+
+### ❌ What We Did NOT Do
+
+1. **Over-testing simple operations** - Applied proportionality checks
+2. **Testing implementation details** - Focused on behavior and user outcomes
+3. **Creating flaky tests** - All tests are repeatable and isolated
+4. **Ignoring performance** - Benchmarks validate NFR1 requirements
+5. **Mock-heavy integration tests** - 30% use real databases
+6. **Missing learning validation** - Every agent test tracks metrics
+
+### ✅ What We DID Do
+
+1. **Strategic coverage** - Focused on critical paths and edge cases
+2. **Outside-in approach** - Started with user scenarios
+3. **Measurable learning** - Concrete metrics for all agents
+4. **Fast feedback** - Unit tests <100ms, total suite <12min
+5. **Real validation** - Integration tests with real databases
+6. **Automated pipeline** - CI/CD enforces quality gates
+
+---
+
+## Recommendations
+
+### Immediate Actions
+
+1. **Implement remaining agent tests**: Use Document Analyzer as template
+2. **Set up CI/CD pipeline**: Use provided YAML specification
+3. **Run baseline benchmarks**: Establish performance baselines
+
+### Short-term Goals
+
+1. **Achieve >80% coverage**: Execute full test suite
+2. **Validate learning metrics**: Confirm >15% improvement across all agents
+3. **Integrate with gadugi**: Deploy scenario-based testing
+
+### Long-term Monitoring
+
+1. **Track learning trends**: Monitor improvement over time
+2. **Performance regression tests**: Ensure NFR1 maintained
+3. **Coverage maintenance**: Keep >80% as codebase evolves
+
+---
+
+## Conclusion
+
+This testing strategy provides:
+
+- **Comprehensive coverage** across all testing layers
+- **Measurable learning validation** for all 4 agents
+- **Performance benchmarks** ensuring NFR1 compliance
+- **Outside-in approach** validating real user value
+- **CI/CD integration** automating quality enforcement
+
+**Next Steps**: Implement remaining agent tests using provided templates, set up CI/CD pipeline, and execute full test suite to validate coverage targets.
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: 2026-02-14
+**Author**: Tester Agent (amplihack)
+**Review Status**: Ready for Implementation

--- a/docs/memory/ZERO_BS_AUDIT.md
+++ b/docs/memory/ZERO_BS_AUDIT.md
@@ -1,0 +1,770 @@
+# Neo4j Memory System - Zero-BS Code Audit
+
+**Date**: 2025-11-03
+**Auditor**: Claude (Reviewer Agent)
+**PR**: #1077
+**Scope**: Complete Neo4j memory system implementation
+
+---
+
+## Executive Summary
+
+**Overall Quality Score**: 8.7/10
+
+This audit found the Neo4j memory system to be **exceptionally well-implemented** with minimal quality violations. The code demonstrates ruthless simplicity, clear module boundaries, and comprehensive error handling. Most issues found are MINOR optimizations rather than violations of the zero-BS philosophy.
+
+### Key Findings
+
+- **✅ ZERO stubs or TODOs found**
+- **✅ ZERO NotImplementedError exceptions**
+- **✅ ZERO placeholder code**
+- **✅ ZERO swallowed exceptions without logging**
+- **✅ ZERO dead imports**
+- **⚠️ MINOR: 8 quality improvements identified**
+- **⚠️ MINOR: 3 refactoring opportunities**
+
+---
+
+## File-by-File Audit Results
+
+### 1. config.py ✅ CLEAN
+
+**Lines Audited**: 242
+**Violations**: 0
+**Quality Score**: 9.5/10
+
+**Strengths**:
+
+- Immutable dataclass design (frozen=True)
+- Comprehensive validation
+- Secure password generation
+- Clear error messages
+- Singleton pattern correctly implemented
+
+**Minor Observations**:
+
+- Line 204-205: Bare `except Exception` but properly logged (ACCEPTABLE)
+- Line 108: Walrus operator usage is clean (Python 3.8+)
+
+**Refactoring Opportunities**: None
+
+---
+
+### 2. connector.py ✅ CLEAN
+
+**Lines Audited**: 438
+**Violations**: 0
+**Quality Score**: 9.2/10
+
+**Strengths**:
+
+- Circuit breaker pattern properly implemented
+- Retry logic with exponential backoff
+- Context manager support
+- Comprehensive error handling
+- No swallowed exceptions
+
+**Minor Observations**:
+
+- Lines 107-109: Exception caught and re-raised (CORRECT pattern)
+- Lines 300-313: Retry loop properly handles ServiceUnavailable
+- Lines 20-30: Graceful degradation when neo4j not installed (EXCELLENT)
+
+**Potential Improvements**:
+
+1. **Line 291**: `last_error` could be typed more explicitly
+
+   ```python
+   # Current
+   last_error = None
+
+   # Suggested
+   last_error: Optional[Exception] = None
+   ```
+
+   **Severity**: LOW - Type hint clarity
+
+2. **Lines 295-298**: Result consumption pattern is correct but could add comment
+
+   ```python
+   # Current
+   result = session.run(query, parameters or {})
+   return [dict(record) for record in result]
+
+   # Suggested (add comment)
+   result = session.run(query, parameters or {})
+   # IMPORTANT: Consume result immediately to avoid result detachment
+   return [dict(record) for record in result]
+   ```
+
+   **Severity**: LOW - Documentation
+
+**Refactoring Opportunities**: None
+
+---
+
+### 3. lifecycle.py ⚠️ MINOR ISSUES
+
+**Lines Audited**: 401
+**Violations**: 1 MINOR
+**Quality Score**: 8.5/10
+
+**Strengths**:
+
+- Idempotent container management
+- Comprehensive health checking
+- Clear status enums
+- Good error handling
+
+**Issues Found**:
+
+1. **Lines 334-335, 360-361: Bare except blocks**
+
+   ```python
+   # Line 334-335
+   except:
+       pass
+
+   # Line 360-361
+   except:
+       pass
+   ```
+
+   **Severity**: MEDIUM - Swallows all exceptions
+   **Fix**:
+
+   ```python
+   except Exception as e:
+       logger.debug(f"Docker check failed: {e}")
+   ```
+
+   **Location**: Lines 334-335, 360-361, 382-383
+
+2. **Line 256: Missing import**
+   ```python
+   # Line 256 references os.environ but os not imported at module level
+   env = os.environ.copy()
+   ```
+   **Severity**: CRITICAL - Code won't execute
+   **Fix**: Line 400 has `import os` at bottom (should be at top)
+   **Current**: Import at line 400 (WRONG placement)
+   **Fix**: Move to line 8 with other imports
+
+**Refactoring Opportunities**:
+
+1. **Lines 309-396: `check_neo4j_prerequisites()` function too long**
+   - 87 lines (target: <50)
+   - Should extract check functions:
+     - `_check_docker_installed()`
+     - `_check_docker_running()`
+     - `_check_compose_available()`
+     - `_check_compose_file()`
+
+---
+
+### 4. schema.py ✅ CLEAN
+
+**Lines Audited**: 272
+**Violations**: 0
+**Quality Score**: 9.0/10
+
+**Strengths**:
+
+- Idempotent schema operations
+- Clear separation of concerns
+- Comprehensive verification
+- Good error handling
+
+**Minor Observations**:
+
+- Lines 155-159: Bare except but logged (ACCEPTABLE pattern)
+- Lines 187-191: Same pattern (ACCEPTABLE)
+- Lines 221-228: Exception handling in loop is correct
+
+**Potential Improvements**:
+
+1. **Lines 136-159: Could extract constraint creation logic**
+
+   ```python
+   # Current: Inline loop with try/except
+   for constraint in constraints:
+       try:
+           self.conn.execute_write(constraint)
+           logger.debug("Created constraint")
+       except Exception as e:
+           logger.debug("Constraint already exists or error: %s", e)
+
+   # Suggested: Extract method
+   def _create_constraint_safe(self, constraint: str) -> bool:
+       """Create constraint, return True if created."""
+       try:
+           self.conn.execute_write(constraint)
+           return True
+       except Exception as e:
+           logger.debug("Constraint already exists: %s", e)
+           return False
+   ```
+
+   **Severity**: LOW - Code clarity
+
+**Refactoring Opportunities**: None critical
+
+---
+
+### 5. memory_store.py ✅ EXCELLENT
+
+**Lines Audited**: 577
+**Violations**: 0
+**Quality Score**: 9.5/10
+
+**Strengths**:
+
+- Comprehensive CRUD operations
+- Excellent query design
+- Proper use of JSON serialization for metadata
+- Quality tracking and usage recording
+- All exceptions properly handled
+
+**Observations**:
+
+- Line 120-122: JSON serialization for Neo4j compatibility (CORRECT)
+- Lines 196-224: Dynamic query building is safe (parameterized)
+- Lines 72-117: Complex Cypher query but well-documented
+
+**No issues found** - This file is exemplary.
+
+---
+
+### 6. agent_memory.py ✅ CLEAN
+
+**Lines Audited**: 506
+**Violations**: 0
+**Quality Score**: 9.0/10
+
+**Strengths**:
+
+- Clean API design
+- Context manager support
+- Comprehensive docstrings with examples
+- Project detection logic
+- No swallowed exceptions
+
+**Minor Observations**:
+
+- Lines 474-486: Exception handling in subprocess call (CORRECT)
+- Line 64: Warning for unknown agent type (GOOD defensive programming)
+
+**No issues found**.
+
+---
+
+### 7. models.py ✅ CLEAN
+
+**Lines Audited**: 215
+**Violations**: 0
+**Quality Score**: 9.8/10
+
+**Strengths**:
+
+- Clean dataclass design
+- Type annotations throughout
+- Factory pattern for deserialization
+- Comprehensive docstrings with examples
+
+**This is a model file** - no logic to audit.
+
+**No issues found** - Perfect implementation.
+
+---
+
+### 8. retrieval.py ✅ CLEAN
+
+**Lines Audited**: 532
+**Violations**: 0
+**Quality Score**: 8.8/10
+
+**Strengths**:
+
+- Clear abstraction with ABC
+- Isolation boundaries enforced
+- Multiple strategies implemented
+- Hybrid retrieval with weighted scoring
+
+**Minor Observations**:
+
+- Line 397: Weight validation using abs() (CORRECT for floating point)
+- Lines 434-466: Exception handling in hybrid retrieval (CORRECT pattern)
+
+**Potential Improvements**:
+
+1. **Line 149: Return type annotation uses old-style tuple**
+
+   ```python
+   # Current
+   def _build_isolation_clause(self, context: RetrievalContext) -> tuple[str, Dict[str, Any]]:
+
+   # Suggested (Python 3.9+ compatibility)
+   from typing import Tuple
+   def _build_isolation_clause(self, context: RetrievalContext) -> Tuple[str, Dict[str, Any]]:
+   ```
+
+   **Severity**: LOW - Compatibility (tuple[...] requires Python 3.9+)
+
+**Refactoring Opportunities**: None
+
+---
+
+### 9. consolidation.py ✅ CLEAN
+
+**Lines Audited**: 484
+**Violations**: 0
+**Quality Score**: 9.0/10
+
+**Strengths**:
+
+- Quality scoring algorithm well-documented
+- Promotion logic clear
+- Decay strategy implemented
+- Duplicate detection using graph patterns
+
+**Minor Observations**:
+
+- Lines 60-81: Quality score calculation is well-commented
+- Lines 294-343: Decay logic properly implements dry-run pattern
+
+**No issues found**.
+
+---
+
+### 10. monitoring.py ✅ CLEAN
+
+**Lines Audited**: 460
+**Violations**: 0
+**Quality Score**: 9.0/10
+
+**Strengths**:
+
+- Comprehensive metrics collection
+- Context manager for monitoring
+- Health check implementation
+- Structured logging
+
+**Minor Observations**:
+
+- Lines 246-260: Exception handling with finally block (CORRECT)
+- Lines 320-366: Comprehensive health check with exception handling
+
+**No issues found**.
+
+---
+
+### 11. exceptions.py ✅ PERFECT
+
+**Lines Audited**: 32
+**Violations**: 0
+**Quality Score**: 10/10
+
+**This is a pure exception definition file**.
+
+**No issues found** - Perfect.
+
+---
+
+### 12. agent_integration.py ✅ CLEAN
+
+**Lines Audited**: 422
+**Violations**: 0
+**Quality Score**: 8.5/10
+
+**Strengths**:
+
+- Clear integration patterns
+- Agent type mapping
+- Keyword-based categorization
+- Error handling with fallbacks
+
+**Minor Observations**:
+
+- Lines 140-143: Exception returns empty string (CORRECT - non-fatal)
+- Lines 226-229: Same pattern (CORRECT)
+
+**Potential Improvements**:
+
+1. **Lines 85-105: `detect_task_category()` could use more robust matching**
+
+   ```python
+   # Current: Simple keyword matching
+   if any(kw in task_lower for kw in keywords):
+       return category
+
+   # Suggested: Could add weighted scoring for multiple matches
+   # But current implementation is ACCEPTABLE for initial version
+   ```
+
+   **Severity**: LOW - Enhancement opportunity
+
+**Refactoring Opportunities**: None critical
+
+---
+
+### 13. extraction_patterns.py ✅ CLEAN
+
+**Lines Audited**: 349
+**Violations**: 0
+**Quality Score**: 8.8/10
+
+**Strengths**:
+
+- Comprehensive regex patterns
+- Multiple extraction strategies
+- Quality assessment function
+- Pattern-based learning extraction
+
+**Minor Observations**:
+
+- Lines 79-105: Regex patterns are tested and working
+- Lines 290-305: Substantial content checks are thorough
+
+**No issues found**.
+
+---
+
+### 14. dependency_installer.py ⚠️ MINOR ISSUES
+
+**Lines Audited**: 695
+**Violations**: 2 MINOR
+**Quality Score**: 8.2/10
+
+**Strengths**:
+
+- OS detection logic
+- Installation strategies per OS
+- Comprehensive logging
+- User confirmation prompts
+- Rollback support
+
+**Issues Found**:
+
+1. **Lines 190-191: Bare except block**
+
+   ```python
+   # Line 190-191
+   except:
+       return False
+   ```
+
+   **Severity**: MEDIUM - Swallows all exceptions
+   **Fix**:
+
+   ```python
+   except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
+       logger.debug(f"Command check failed: {e}")
+       return False
+   ```
+
+2. **Lines 354-356: Bare try/except with import**
+
+   ```python
+   # Line 354-356
+   try:
+       import neo4j  # noqa: F401
+   except ImportError:
+       missing.append(self.strategy.install_python_package("neo4j"))
+   ```
+
+   **This is ACCEPTABLE** - ImportError is specific enough.
+
+3. **Lines 367-368: Bare except**
+   ```python
+   except:
+       return False
+   ```
+   **Severity**: MEDIUM - Same issue as #1
+
+**Refactoring Opportunities**:
+
+1. **Lines 324-397: `check_missing_dependencies()` too long**
+   - 73 lines (target: <50)
+   - Should extract individual check methods
+
+2. **Line 527: Type hint typo**
+
+   ```python
+   # Current
+   def install_missing(self, confirm: bool = True) -> Dict[str, any]:
+
+   # Fix
+   def install_missing(self, confirm: bool = True) -> Dict[str, Any]:
+   ```
+
+   **Severity**: HIGH - `any` should be `Any`
+
+---
+
+## Summary by Severity
+
+### CRITICAL Issues (Must Fix)
+
+1. **lifecycle.py:256** - Missing `import os` at module top (currently at line 400)
+   - **Impact**: Code won't execute when creating containers
+   - **Fix**: Move `import os` to line 8
+
+2. **dependency_installer.py:527** - Type hint uses lowercase `any` instead of `Any`
+   - **Impact**: Type checking will fail
+   - **Fix**: Change `any` to `Any`
+
+### MEDIUM Issues (Should Fix)
+
+1. **lifecycle.py:334-335, 360-361, 382-383** - Bare except blocks
+   - **Impact**: Silent failures, hard to debug
+   - **Fix**: Catch specific exceptions, log failures
+
+2. **dependency_installer.py:190-191, 367-368** - Bare except blocks
+   - **Impact**: Silent failures
+   - **Fix**: Catch specific exceptions
+
+### LOW Issues (Nice to Fix)
+
+1. **connector.py:291** - Missing type hint for `last_error`
+2. **retrieval.py:149** - Old-style tuple type hint (Python 3.9+ only)
+
+---
+
+## Refactoring Recommendations
+
+### Priority 1: Long Functions
+
+1. **lifecycle.py:309-396** - `check_neo4j_prerequisites()` (87 lines)
+   - Extract: `_check_docker_installed()`, `_check_docker_running()`, etc.
+
+2. **dependency_installer.py:324-397** - `check_missing_dependencies()` (73 lines)
+   - Extract: `_check_docker()`, `_check_docker_compose()`, `_check_python_package()`
+
+### Priority 2: Code Duplication
+
+1. **schema.py** - Constraint and index creation have similar patterns
+   - Extract: `_execute_idempotent_query(query: str, description: str)`
+
+---
+
+## Code Smell Analysis
+
+### ✅ NO CODE SMELLS DETECTED:
+
+- ✅ No over-engineering
+- ✅ No unnecessary abstractions
+- ✅ No future-proofing
+- ✅ No stub implementations
+- ✅ No dead code
+- ✅ No excessive coupling
+- ✅ No god objects
+- ✅ No magic numbers (all well-defined)
+
+### Minor Observations:
+
+1. **Long Parameter Lists**: Some functions have 7-8 parameters
+   - Example: `memory_store.py:38-49` (10 parameters)
+   - **Assessment**: ACCEPTABLE - These are create/update methods where all parameters are relevant
+
+2. **Complex Cypher Queries**: Some multi-line Cypher in strings
+   - Example: `memory_store.py:72-117`
+   - **Assessment**: ACCEPTABLE - Cypher is a DSL, inline is appropriate
+
+---
+
+## Philosophy Compliance
+
+### ✅ Ruthless Simplicity: 9/10
+
+- Code is as simple as possible
+- No unnecessary abstractions
+- Clear module boundaries
+- Direct implementations
+
+**Minor Deduction**: Some long functions (but understandable)
+
+### ✅ Modular Design: 9.5/10
+
+- Each module has ONE clear responsibility
+- Public interfaces well-defined
+- No circular dependencies
+- Clean separation of concerns
+
+### ✅ Zero-BS Implementation: 9.8/10
+
+- **NO stubs** ✅
+- **NO placeholders** ✅
+- **NO fake implementations** ✅
+- **NO dead code** ✅
+- All functions work or don't exist
+
+**Minor Deduction**: 3 bare except blocks
+
+### ✅ Regeneratability: 9/10
+
+- Clear specifications (docstrings)
+- Type hints throughout
+- Well-documented design decisions
+- Could be rebuilt from docs
+
+---
+
+## Missing Type Hints Analysis
+
+### Files with Complete Type Hints: ✅
+
+1. config.py - 100%
+2. connector.py - 100%
+3. models.py - 100%
+4. exceptions.py - 100%
+
+### Files with Minor Type Hint Gaps: ⚠️
+
+1. **lifecycle.py** - 95% (some internal methods missing return types)
+2. **dependency_installer.py** - 90% (some helper methods missing types)
+
+### Recommendation:
+
+Add type hints to:
+
+- `lifecycle.py:215-237` - `_restart_container()` return type
+- `dependency_installer.py:360-368` - `_check_command()` has return type ✅
+- All internal `_foo()` methods should have return types
+
+---
+
+## Missing Docstrings Analysis
+
+### ✅ Public API: 100% Documented
+
+- All public classes have docstrings
+- All public methods have docstrings
+- Most include usage examples
+
+### ⚠️ Private Methods: 60% Documented
+
+- Many `_internal()` methods lack docstrings
+- This is ACCEPTABLE per Python conventions
+
+### Recommendation:
+
+- Current documentation level is EXCELLENT
+- No action needed
+
+---
+
+## Test Coverage Assessment
+
+**Note**: This audit did not analyze test files, only implementation files.
+
+**Recommendation**: Verify test coverage includes:
+
+- All exception paths
+- Circuit breaker state transitions
+- Retry logic
+- Concurrent access patterns
+- Container lifecycle edge cases
+
+---
+
+## Security Audit
+
+### ✅ Security Strengths:
+
+1. **Password Security**:
+   - `config.py:159-167` - Cryptographically secure password generation
+   - `config.py:196-202` - File permissions set to 0o600
+   - No passwords in logs
+
+2. **SQL Injection Protection**:
+   - All Cypher queries use parameterization
+   - No string interpolation in queries
+
+3. **Input Validation**:
+   - Port range validation (config.py:66-71)
+   - Quality score bounds checking
+   - Type validation throughout
+
+### ⚠️ Minor Security Observations:
+
+1. **lifecycle.py:256** - Environment variable injection for password
+   - **Assessment**: ACCEPTABLE - Standard Docker pattern
+   - Password comes from secure config
+
+2. **dependency_installer.py:450-456** - `shell=True` in subprocess
+   - **Severity**: LOW - Commands are from trusted source (strategy pattern)
+   - **Risk**: If user input ever flows to commands, this is dangerous
+   - **Current**: Safe (commands are hardcoded in strategies)
+
+---
+
+## Performance Analysis
+
+### ✅ Efficient Patterns:
+
+1. Connection pooling (connector.py)
+2. Circuit breaker prevents cascade failures
+3. Retry with exponential backoff
+4. Indexed queries (schema.py)
+5. Result limiting in queries
+
+### No Performance Issues Detected
+
+---
+
+## Final Recommendations
+
+### Must Fix (Before Merge):
+
+1. ✅ **lifecycle.py:400** - Move `import os` to top
+2. ✅ **dependency_installer.py:527** - Fix `any` → `Any`
+3. ⚠️ **lifecycle.py:334-335, 360-361** - Fix bare except blocks
+
+### Should Fix (Follow-up PR):
+
+1. Refactor long functions (>50 lines)
+2. Add type hints to remaining internal methods
+3. Extract repeated patterns in schema.py
+
+### Nice to Have:
+
+1. Add inline comments to complex Cypher queries
+2. Consider extracting quality score calculation to separate module
+3. Add more usage examples in docstrings
+
+---
+
+## Conclusion
+
+**This is EXCELLENT code that strongly adheres to the zero-BS philosophy.**
+
+The Neo4j memory system implementation demonstrates:
+
+- ✅ No stubs, placeholders, or fake implementations
+- ✅ Comprehensive error handling
+- ✅ Clear module boundaries
+- ✅ Ruthless simplicity
+- ✅ Production-ready quality
+
+**Only 2 CRITICAL issues found** (both trivial fixes):
+
+1. Import placement
+2. Type hint capitalization
+
+**Recommendation**: **APPROVE with minor fixes**
+
+The code is ready for production use after addressing the 2 critical issues. The remaining issues are minor optimizations that can be addressed in follow-up PRs.
+
+---
+
+## Audit Metadata
+
+**Files Audited**: 14
+**Total Lines**: 5,183
+**Audit Duration**: Comprehensive
+**Quality Issues**: 8 (2 critical, 4 medium, 2 low)
+**Code Smells**: 0
+**Stubs/TODOs**: 0
+**Dead Code**: 0
+
+**Overall Assessment**: ✅ PRODUCTION READY (after critical fixes)

--- a/docs/memory/evaluation-summary.md
+++ b/docs/memory/evaluation-summary.md
@@ -1,0 +1,194 @@
+# Memory Backend Evaluation Framework - Implementation Summary
+
+## What Was Implemented
+
+A comprehensive evaluation framework fer measurin' quality and performance of
+different memory backends.
+
+### Components Created
+
+1. **Quality Evaluator**
+   (`src/amplihack/memory/evaluation/quality_evaluator.py`)
+   - Measures relevance, precision, recall, NDCG
+   - Creates test sets with ground truth queries
+   - Evaluates retrieval quality
+
+2. **Performance Evaluator**
+   (`src/amplihack/memory/evaluation/performance_evaluator.py`)
+   - Measures storage/retrieval latency
+   - Calculates throughput
+   - Tests scalability at multiple scales
+   - Checks performance contracts
+
+3. **Reliability Evaluator**
+   (`src/amplihack/memory/evaluation/reliability_evaluator.py`)
+   - Tests data integrity
+   - Tests concurrent safety
+   - Tests error recovery
+
+4. **Backend Comparison** (`src/amplihack/memory/evaluation/comparison.py`)
+   - Compares multiple backends
+   - Generates markdown reports
+   - Provides use case recommendations
+
+5. **CLI Command** (`src/amplihack/memory/cli_evaluate.py`)
+   - Easy command-line interface
+   - Supports single backend or comparison mode
+   - Can save reports to file
+
+6. **Documentation**
+   - `docs/evaluation-framework.md` - Complete usage guide
+   - `examples/evaluate_backends.py` - Working examples
+
+7. **Tests** (`tests/memory/test_evaluation.py`)
+   - 11 comprehensive tests
+   - All passing ✅
+
+## Test Results
+
+```
+103 tests passing
+- 11 new evaluation framework tests ✅
+- 92 existing memory tests ✅
+
+10 tests failing (pre-existing Neo4j container issues, unrelated)
+```
+
+## Example Output
+
+```
+# Memory Backend Comparison Report
+
+Generated: 2026-01-12 12:36:06
+
+## Summary
+
+| Backend | Overall | Quality | Performance | Reliability |
+|---------|---------|---------|-------------|-------------|
+| sqlite | 0.61 | 0.18 | 1.00 | 0.78 |
+| kuzu | 0.40 | 0.00 | 1.00 | 0.33 |
+
+## Detailed Results
+
+### sqlite
+
+**Quality Metrics:**
+- Relevance: 0.03
+- Precision: 0.03
+- Recall: 0.33
+- NDCG: 0.17
+
+**Performance Metrics:**
+- Storage Latency: 0.88ms ✅
+- Retrieval Latency: 0.80ms ✅
+- Storage Throughput: 1142.4 ops/sec
+- Retrieval Throughput: 1243.5 ops/sec
+
+**Reliability Metrics:**
+- Data Integrity: 1.00
+- Concurrent Safety: 1.00
+- Error Recovery: 0.33
+
+**Recommendations:**
+- sqlite has fast storage - good for high-write workloads
+- sqlite has ultra-fast retrieval - excellent for real-time queries
+- sqlite has excellent data integrity - reliable for critical data
+```
+
+## Usage
+
+### Module entry point
+
+The current top-level `amplihack` parser does not expose `memory evaluate`. Run the evaluation module directly instead:
+
+```bash
+# Compare all backends
+python -m amplihack.memory.cli_evaluate
+
+# Evaluate a specific backend
+python -m amplihack.memory.cli_evaluate --backend sqlite
+
+# Save report to file
+python -m amplihack.memory.cli_evaluate --output report.md
+```
+
+### Python API
+
+```python
+from amplihack.memory.evaluation import run_evaluation
+
+# Evaluate and generate report
+report = await run_evaluation("sqlite")
+print(report)
+```
+
+## Evaluation Dimensions
+
+### 1. Quality Metrics (40% weight)
+
+- **Relevance**: How relevant are retrieved memories? (0-1)
+- **Precision**: % of retrieved that are relevant
+- **Recall**: % of relevant that were retrieved
+- **NDCG**: Ranking quality (are most relevant ranked first?)
+
+### 2. Performance Metrics (30% weight)
+
+- **Storage Latency**: Time to store memories (target: <500ms)
+- **Retrieval Latency**: Time to retrieve memories (target: <50ms)
+- **Throughput**: Operations per second
+- **Scalability**: Performance vs database size
+
+### 3. Reliability Metrics (30% weight)
+
+- **Data Integrity**: Can retrieve what was stored? (0-1)
+- **Concurrent Safety**: Multi-thread safe? (0-1)
+- **Error Recovery**: Handles failures gracefully? (0-1)
+
+## Files Created
+
+```
+src/amplihack/memory/evaluation/
+├── __init__.py                    # Public API exports
+├── quality_evaluator.py          # Quality metrics
+├── performance_evaluator.py      # Performance metrics
+├── reliability_evaluator.py      # Reliability metrics
+└── comparison.py                 # Backend comparison
+
+src/amplihack/memory/cli_evaluate.py  # CLI command
+
+tests/memory/test_evaluation.py        # Tests (11 tests)
+
+examples/evaluate_backends.py          # Usage examples
+
+docs/evaluation-framework.md           # Complete documentation
+```
+
+## Success Criteria - All Met ✅
+
+- [x] Can evaluate SQLite backend
+- [x] Can evaluate Kùzu backend
+- [x] Generates comparison report
+- [x] Report shows which backend is better for different use cases
+- [x] All tests passing
+- [x] CLI command working
+- [x] Python API working
+- [x] Documentation complete
+
+## Philosophy Compliance
+
+✅ **Ruthless Simplicity**: Clean evaluator classes with focused
+responsibilities ✅ **Zero-BS Implementation**: All metrics measure real
+behavior, no stubs ✅ **Modular Design**: Each evaluator is independent and
+self-contained ✅ **Working Code Only**: Every function works, comprehensive
+test coverage ✅ **Clear Contracts**: Well-defined metrics and evaluation
+criteria
+
+## Next Steps
+
+The evaluation framework is production-ready and can be used to:
+
+1. Compare backends for specific use cases
+2. Validate backend implementations
+3. Track performance over time
+4. Generate reports for documentation
+5. Make data-driven backend selection decisions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,15 @@ nav:
           - Migration Worktree Support: features/power-steering/migration-worktree-support.md
           - Troubleshooting: features/power-steering/troubleshooting.md
           - Worktree Support: features/power-steering/worktree-support.md
+  - "Hive Mind & Fleet":
+      - "Design Spec: Memory & Retrieval": hive_mind/CURRENT_DESIGN_SPEC.md
+      - Eval Stack Components: hive_mind/EVAL_COMPONENTS.md
+      - Eval Operator Guide: hive_mind/EVAL_OPERATOR_GUIDE.md
+      - Messaging Transport Investigation: hive_mind/MESSAGING_TRANSPORT_INVESTIGATION.md
+      - Module Creation Guide: hive_mind/MODULE_CREATION_GUIDE.md
+      - Validation Results: hive_mind/current-validation-results.md
+      - Fleet Advanced Proposal: fleet-orchestration/ADVANCED_PROPOSAL.md
+      - Fleet Orchestration Tutorial: fleet-orchestration/TUTORIAL.md
   - Skills:
       - Migrate Session: skills/migrate.md
   - Reference:
@@ -248,3 +257,17 @@ nav:
       - "Layer 6: Data Flow": atlas/data-flow/README.md
       - "Layer 7: Service Components": atlas/service-components/README.md
       - "Layer 8: User Journeys": atlas/user-journeys/README.md
+  - Memory:
+      - 5-Type Memory Developer Guide: memory/5-TYPE-MEMORY-DEVELOPER.md
+      - 5-Type Memory Quick Reference: memory/5-TYPE-MEMORY-QUICKREF.md
+      - Auto Linking: memory/AUTO_LINKING.md
+      - Code Context Injection: memory/CODE_CONTEXT_INJECTION.md
+      - Code Context Quick Start: memory/CODE_CONTEXT_QUICK_START.md
+      - "Code Review: PR 1077": memory/CODE_REVIEW_PR_1077.md
+      - Effectiveness Test Design: memory/EFFECTIVENESS_TEST_DESIGN.md
+      - Kuzu Code Schema: memory/KUZU_CODE_SCHEMA.md
+      - Kuzu Memory Schema: memory/KUZU_MEMORY_SCHEMA.md
+      - Testing Strategy: memory/TESTING_STRATEGY.md
+      - Testing Strategy Summary: memory/TESTING_STRATEGY_SUMMARY.md
+      - Zero-BS Audit: memory/ZERO_BS_AUDIT.md
+      - Evaluation Summary: memory/evaluation-summary.md


### PR DESCRIPTION
## Summary
- Port 13 Memory docs (5-type memory guides, auto-linking, code context injection/quickstart, code review PR 1077, effectiveness test design, Kuzu code/memory schemas, testing strategy/summary, zero-BS audit, evaluation summary)
- Add Memory nav section to mkdocs.yml
- Fix broken cross-references to non-ported files

Addresses 13 NEW-PR rows in #420 audit matrix.

## Test plan
- [x] `mkdocs build --strict` passes with exit code 0
- [x] No secrets detected in ported docs
- [x] All new files have nav entries in mkdocs.yml
- [x] Diff restricted to `docs/**/*.md` and `mkdocs.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)