### PR TITLE
docs: port Hive Mind & Fleet docs (wave 6, group 4) #420

### DIFF
--- a/docs/fleet-orchestration/ADVANCED_PROPOSAL.md
+++ b/docs/fleet-orchestration/ADVANCED_PROPOSAL.md
@@ -1,0 +1,56 @@
+# Fleet Orchestration: Advanced Design
+
+## Vision
+
+You type `fleet dry-run` and see what every agent session needs. You type
+`fleet start --adopt` and the admiral takes over — answering agent questions,
+approving safe operations, escalating complex decisions. You check in with
+`fleet watch` and `fleet dashboard` to see progress.
+
+## Architecture
+
+See the fleet orchestration architecture document in the upstream `amplihack`
+repository for the module breakdown and per-session reasoning loop.
+
+## Design Principles
+
+1. **Observe first, act carefully** — dry-run mode shows reasoning before acting
+2. **Never interrupt thinking** — detect active LLM/tool processing and wait
+3. **SDK-agnostic** — LLMBackend protocol supports Claude and Copilot
+4. **Adopt, don't replace** — bring existing manual sessions under management
+5. **No ML** — rules and LLM reasoning, not trained models
+
+## Composable Reasoner Chain
+
+The admiral's `reason()` delegates to a chain of composable reasoners:
+
+```
+LifecycleReasoner → PreemptionReasoner → CoordinationReasoner → BatchAssignReasoner
+```
+
+Each reasoner sees prior decisions and can add its own. Adding a new reasoner
+is one class + one append to the chain.
+
+| Reasoner     | Purpose                                                                           |
+| ------------ | --------------------------------------------------------------------------------- |
+| Lifecycle    | Detect completions, failures, stuck agents. Respects protected (deep work) tasks. |
+| Preemption   | Pause low-priority work when CRITICAL tasks arrive with no idle capacity.         |
+| Coordination | Write shared context files so agents on same repo don't duplicate work.           |
+| BatchAssign  | Dependency-aware batch assignment (not greedy one-at-a-time).                     |
+
+## Scaling Path
+
+| Scale     | Architecture                                          |
+| --------- | ----------------------------------------------------- |
+| 6-15 VMs  | Current centralized admiral                           |
+| 15-30 VMs | Add parallel Bastion tunnels + push-based heartbeats  |
+| 30-50 VMs | SQLite task queue + persistent SSH tunnels            |
+| 50+ VMs   | Hub-spoke: regional admirals reporting to coordinator |
+
+## Future Directions
+
+- Integration with GitHub Issues for task sourcing
+- Push-based heartbeats via shared NFS (avoid polling)
+- Parallel Bastion tunnel connections
+- Connection to hive mind memory for cross-agent knowledge
+- Fleet replay timeline for debugging

--- a/docs/fleet-orchestration/TUTORIAL.md
+++ b/docs/fleet-orchestration/TUTORIAL.md
@@ -1,0 +1,645 @@
+# Fleet Orchestration Tutorial
+
+Manage coding agents (Claude Code, GitHub Copilot, Amplifier) running across multiple Azure VMs from a single terminal.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [First Run](#first-run)
+- [The Dashboard](#the-dashboard)
+- [Observing Your Fleet](#observing-your-fleet)
+- [Adopting Existing Sessions](#adopting-existing-sessions)
+- [The Admiral: Dry-Run First](#the-admiral-dry-run-first)
+- [Running the Admiral Live](#running-the-admiral-live)
+- [Task Management](#task-management)
+- [Environment Variables](#environment-variables)
+- [Running in tmux](#running-in-tmux)
+
+## Prerequisites
+
+Before you begin, you need:
+
+1. **azlin** installed and on your PATH. azlin manages SSH connections to Azure VMs through Bastion tunnels. See [github.com/rysweet/azlin](https://github.com/rysweet/azlin) for installation.
+
+2. **Azure VMs provisioned** and reachable via azlin. Verify with:
+
+   ```bash
+   azlin list
+   ```
+
+   You should see your VMs listed with their status.
+
+3. **Coding agents running in tmux** on those VMs. Each VM should have one or more tmux sessions with Claude Code, Copilot, or Amplifier running inside them. The fleet admiral observes and manages these sessions.
+
+4. **tmux** installed locally. The recipe runner uses tmux sessions for long-running workstreams that can take hours. The install script auto-installs it, or:
+
+   ```bash
+   # Ubuntu/Debian
+   sudo apt-get install tmux
+   # macOS
+   brew install tmux
+   ```
+
+5. **An Anthropic API key** set in your environment. The admiral uses Claude Opus to reason about what each agent session needs:
+
+   ```bash
+   export ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+## Installation
+
+Fleet is a required part of amplihack — no optional extras needed:
+
+```bash
+cargo install amplihack-rs
+```
+
+## Using Fleet
+
+Fleet commands work in two ways:
+
+**From the shell:**
+
+```bash
+amplihack fleet status
+amplihack fleet scout
+amplihack fleet advance --session deva:rustyclawd
+```
+
+**From the Claude Code REPL (interactive session):**
+
+```
+/fleet scout
+/fleet advance --session deva:rustyclawd
+/fleet watch dev cybergym
+```
+
+The `/fleet` slash command is available in any amplihack-powered Claude Code or
+Copilot CLI session. It provides the same commands as the shell interface.
+
+## First Run
+
+Verify that amplihack can see your VMs:
+
+```bash
+amplihack fleet status
+```
+
+This runs `azlin list` under the hood and displays each VM with its tmux sessions and detected agent states. If you see your VMs listed, the fleet module is working.
+
+## The Dashboard
+
+### Launching the TUI
+
+Running `amplihack fleet` with no subcommand launches the interactive Textual dashboard:
+
+```bash
+amplihack fleet
+```
+
+If Textual is not installed, you get a helpful fallback message pointing you to text-based alternatives.
+
+You can also launch explicitly:
+
+```bash
+amplihack fleet tui
+amplihack fleet tui --interval 15   # Faster refresh (default: 30s)
+```
+
+### Navigation
+
+| Key        | Action                                      |
+| ---------- | ------------------------------------------- |
+| Arrow keys | Move between sessions in the fleet table    |
+| Enter      | Dive into Session Detail for selected row   |
+| Escape     | Go back to Fleet Overview                   |
+| e          | Open Action Editor for the selected session |
+| a          | Apply the admiral's proposed action         |
+| d          | Run dry-run reasoning for selected session  |
+| r          | Force refresh all sessions                  |
+| q          | Quit the dashboard                          |
+
+### Three Tabs
+
+1. **Fleet Overview** -- The main view. A table of all sessions across all VMs with a preview pane on the right showing the last few lines of terminal output for the selected session.
+
+2. **Session Detail** -- Deep view of a single session. Shows the full tmux capture (what the agent's terminal looks like right now) and the admiral's proposed action with its reasoning.
+
+3. **Action Editor** -- Edit and override the admiral's proposed action before applying it. Choose an action type (send_input, wait, escalate, mark_complete, restart) and modify the input text.
+
+### Status Icons
+
+The dashboard uses icons to show session state at a glance:
+
+| Icon         | Status                       | Meaning                                                 |
+| ------------ | ---------------------------- | ------------------------------------------------------- |
+| `◉` (green)  | thinking / working / running | Agent is actively processing                            |
+| `◉` (green)  | waiting_input                | Agent asked a question, awaiting response               |
+| `●` (yellow) | idle                         | Session exists but agent is not actively working        |
+| `○` (dim)    | shell / empty                | No agent detected in this session                       |
+| `✗` (red)    | error                        | Error detected in session output                        |
+| `✓` (blue)   | completed                    | Agent finished its task (PR created, workflow complete) |
+
+## Observing Your Fleet
+
+Four commands give you visibility into what your agents are doing, without changing anything.
+
+### Quick Text Summary
+
+```bash
+amplihack fleet status
+```
+
+Shows every VM, its region, tmux sessions, and detected agent state. Fast, no LLM calls.
+
+### Watch a Single Session
+
+```bash
+amplihack fleet watch devo claude-session-1
+```
+
+Captures the last 30 lines of a specific tmux session on a specific VM. Like peeking over the agent's shoulder. Use `--lines 50` for more context.
+
+### Snapshot All Sessions
+
+```bash
+amplihack fleet snapshot
+```
+
+Captures every session on every managed VM in one pass. Shows the last 3 lines of output per session with the observer's status classification.
+
+### Observe with Pattern Classification
+
+```bash
+amplihack fleet observe devo
+```
+
+Runs the pattern-based observer on all sessions of a specific VM. Shows the detected status, confidence level, and which pattern matched. More detailed than `status` because it actually reads the terminal output.
+
+## Adopting Existing Sessions
+
+You do not need to start sessions through the fleet admiral. If you already have agents running in tmux sessions on your VMs (started manually or by another tool), you can bring them under fleet management.
+
+### Adopt Sessions on a Single VM
+
+```bash
+amplihack fleet adopt devo
+```
+
+This connects to the VM, discovers all tmux sessions, and for each session:
+
+1. Reads the tmux pane content to see what the agent is doing
+2. Checks git state (repo, branch) in the working directory
+3. Reads Claude Code JSONL logs if available
+4. Creates a tracking record with inferred context
+5. Begins observing without sending any commands
+
+The output shows what was discovered:
+
+```
+Discovering sessions on devo...
+Found 3 sessions:
+  claude-session-1
+    Repo: https://github.com/org/project
+    Branch: feat/add-auth
+    Agent: claude
+  claude-session-2
+    Repo: https://github.com/org/other-project
+    Branch: fix/login-bug
+    Agent: claude
+  amplifier-session
+    Agent: amplifier
+
+Adopted 3 sessions:
+  claude-session-1 -> task abc123
+  claude-session-2 -> task def456
+  amplifier-session -> task ghi789
+```
+
+### Adopt at Admiral Startup
+
+```bash
+amplihack fleet start --adopt
+```
+
+When starting the admiral, `--adopt` scans all managed VMs and brings existing sessions under management before beginning the autonomous loop.
+
+### Adopt Specific Sessions
+
+```bash
+amplihack fleet adopt devo --sessions claude-session-1 --sessions claude-session-2
+```
+
+Only adopt named sessions, leaving others alone.
+
+## The Admiral: Dry-Run First
+
+The admiral is the autonomous reasoning engine. Before letting it act, use dry-run mode to see what it would do.
+
+### Running a Dry-Run
+
+```bash
+amplihack fleet dry-run
+```
+
+For each session on each managed VM, the admiral:
+
+1. **PERCEIVE**: Captures the tmux pane and reads JSONL transcript summaries via SSH
+2. **REASON**: Sends the captured context to Claude, which decides what action to take
+3. **Display**: Shows the full reasoning chain without executing anything
+
+You can target specific VMs:
+
+```bash
+amplihack fleet dry-run --vm devo
+amplihack fleet dry-run --vm devo --vm devi
+```
+
+And provide project priorities to guide decisions:
+
+```bash
+amplihack fleet dry-run --priorities "auth feature is highest priority, fix CI on project-x"
+```
+
+### What Dry-Run Shows
+
+For each session, you see the admiral's decision:
+
+- **Action**: `send_input`, `wait`, `escalate`, `mark_complete`, or `restart`
+- **Confidence**: How sure the admiral is (0.0 to 1.0)
+- **Reasoning**: Why it chose this action
+- **Proposed input**: What it would type into the session (if `send_input`)
+
+### Safety Mechanisms
+
+The admiral has built-in safety at multiple levels:
+
+**Thinking detection**: If an agent is actively processing (Claude Code shows `●` or `⎿`, Copilot shows `Thinking...`), the admiral skips the LLM call entirely and fast-paths to WAIT. It never interrupts a working agent.
+
+**Confidence thresholds**: Actions below 0.6 confidence are not executed. Restart actions require 0.8 confidence.
+
+**Dangerous input blocklist**: The admiral refuses to send commands matching dangerous patterns, regardless of confidence:
+
+- `rm -rf`, `rm -r /`
+- `git push --force`, `git push -f`
+- `git reset --hard`
+- `DROP TABLE`, `DROP DATABASE`
+- Fork bombs and disk-destructive commands
+
+## Running the Admiral Live
+
+After reviewing dry-run output and confirming the admiral's reasoning looks sound:
+
+```bash
+amplihack fleet start
+```
+
+The admiral begins the autonomous loop: PERCEIVE, REASON, ACT, LEARN. It polls all sessions at a configurable interval, decides what each session needs, and acts.
+
+### Controlling the Loop
+
+```bash
+amplihack fleet start --interval 30    # Poll every 30 seconds (default: 60)
+amplihack fleet start --max-cycles 10  # Stop after 10 cycles
+amplihack fleet start --adopt          # Adopt existing sessions first
+```
+
+Press `Ctrl+C` to stop the admiral gracefully.
+
+### Single Cycle
+
+Run one complete cycle without looping:
+
+```bash
+amplihack fleet run-once
+```
+
+Reports how many actions were taken and what they were. Useful for testing or manual orchestration.
+
+## Task Management
+
+The fleet has a priority-ordered task queue. Tasks describe work to be assigned to agent sessions.
+
+### Adding Tasks
+
+```bash
+amplihack fleet add-task "Fix the authentication bug where JWT tokens expire too early" \
+  --priority high \
+  --repo https://github.com/org/project
+```
+
+Options:
+
+| Flag          | Values                      | Default | Purpose                                    |
+| ------------- | --------------------------- | ------- | ------------------------------------------ |
+| `--priority`  | critical, high, medium, low | medium  | Queue ordering                             |
+| `--repo`      | URL                         | (none)  | Repository to clone on the target VM       |
+| `--agent`     | claude, amplifier, copilot  | claude  | Which agent to use                         |
+| `--mode`      | auto, ultrathink            | auto    | Agent execution mode                       |
+| `--max-turns` | integer                     | 20      | Maximum agent turns                        |
+| `--protected` | flag                        | false   | Deep work mode -- admiral will not preempt |
+
+### Viewing the Queue
+
+```bash
+amplihack fleet queue
+```
+
+Shows all tasks sorted by priority with their status (queued, assigned, running, completed, failed).
+
+### Project-Level Tracking
+
+```bash
+amplihack fleet dashboard
+```
+
+Shows fleet-wide metrics: active projects, agent utilization, cost estimates, PR counts, and task completion rates.
+
+### Knowledge Graph
+
+```bash
+amplihack fleet graph
+```
+
+Shows the relationship graph between projects, tasks, agents, VMs, and PRs. Useful for understanding what depends on what.
+
+### Project and Objective Tracking
+
+Register projects and track GitHub issues as fleet objectives:
+
+```bash
+# Register a project
+amplihack fleet project add https://github.com/org/myapp --name myapp --priority high
+
+# List registered projects
+amplihack fleet project list
+
+# Track a specific issue as an objective
+amplihack fleet project add-issue myapp 42 --title "Add authentication"
+
+# Sync objectives from GitHub issues labeled 'fleet-objective'
+amplihack fleet project track-issue myapp --label fleet-objective
+
+# Remove a project
+amplihack fleet project remove myapp
+```
+
+The `projects.toml` file stores project configuration:
+
+```toml
+[project.myapp]
+repo_url = "https://github.com/org/myapp"
+identity = "user1"
+priority = "high"
+
+[[project.myapp.objectives]]
+number = 42
+title = "Add authentication"
+state = "open"
+url = "https://github.com/org/myapp/issues/42"
+
+[project.lib]
+repo_url = "https://github.com/org/lib"
+priority = "low"
+```
+
+Objectives are stored in `~/.amplihack/fleet/projects.toml` and enriched during scout with live GitHub issue state. The scout report groups sessions by project and shows open objectives:
+
+```
+--- By Project ---
+
+  [myapp]
+    objective #42: Add authentication
+    objective #43: Fix login flow
+    dev/auth-session [running] -> wait
+    dev/login-fix [idle] -> send_input
+
+  [unassigned]
+    deva/qa [shell] -> restart
+```
+
+The SSH gather phase also queries `gh issue list --label fleet-objective` on each VM to discover objectives from the remote repository, merging them with locally registered objectives.
+
+## Environment Variables
+
+| Variable            | Purpose                                                         | Default                                                                                    |
+| ------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `AZLIN_PATH`        | Path to the azlin binary                                        | Auto-detected via `which azlin`, falls back to `/home/azureuser/src/azlin/.venv/bin/azlin` |
+| `ANTHROPIC_API_KEY` | API key for Claude (required for dry-run and admiral reasoning) | (none -- must be set)                                                                      |
+
+## Running in tmux
+
+The fleet dashboard is designed to run in its own tmux session so you can detach and reattach freely:
+
+```bash
+# Start the dashboard in a detached tmux session
+tmux new-session -d -s fleet-dashboard "amplihack fleet"
+
+# Attach anytime
+tmux attach -t fleet-dashboard
+
+# Detach without stopping: Ctrl+b, then d
+```
+
+For the admiral loop:
+
+```bash
+tmux new-session -d -s fleet-admiral "amplihack fleet start --adopt --interval 30"
+
+# Check on it
+tmux attach -t fleet-admiral
+```
+
+## Auth Propagation
+
+If your VMs need authentication tokens (GitHub CLI, Azure CLI, Claude API key):
+
+```bash
+amplihack fleet auth devo
+amplihack fleet auth devo --services github azure claude
+```
+
+This copies credential files to the target VM and verifies they work.
+
+## Using Fleet from Claude Code or Copilot CLI
+
+The `/fleet` skill lets you manage your fleet directly from a Claude Code or Copilot CLI conversation, without switching to a separate terminal.
+
+### Invoking the Skill
+
+Type `/fleet` followed by a command:
+
+```
+/fleet scout
+/fleet advance
+/fleet status
+```
+
+Or just describe what you want — Claude will pick the right command:
+
+```
+"What are my agents doing?"        → fleet scout
+"Send next steps to all sessions"  → fleet advance
+"Advance the stuck session on dev" → fleet advance --session dev:stuck-session
+```
+
+### Fleet Scout (Dry-Run Scan)
+
+`/fleet scout` is **reconnaissance** — it discovers ALL VMs and sessions including those in the exclude list (`DEFAULT_EXCLUDE_VMS`). `DEFAULT_EXCLUDE_VMS` is empty by default (all VMs are fleet-managed). This is intentional: you need full visibility to understand the fleet before deciding what to act on. The exclude list only applies to admiral actions (`advance`, `start`, `run-once`) which skip excluded VMs to avoid unintended interference with shared infrastructure.
+
+`/fleet scout` discovers all VMs and sessions, runs admiral reasoning, and shows a report with three sections:
+
+**1. Status Table** — one row per session:
+
+```
+  VM           Session                Status     Action           Conf
+  --------------------------------------------------------------------
+  dev          [>] cybergym-intg      running    wait             100%
+  dev          [.] parallel-deploy-wk idle       send_input        90%
+  deva         [X] qa                 shell      send_input        90%
+  devy         [~] agent-kgpacks      thinking   wait             100%
+```
+
+Status icons: `[~]` thinking, `[>]` running, `[.]` idle, `[X]` shell (dead agent), `[Z]` suspended, `[!]` error, `[+]` completed, `[?]` waiting input.
+
+**2. Session Summaries** — admiral reasoning + proposed input:
+
+```
+  dev/parallel-deploy-wk:
+    Deployment succeeded. Agent needs to create a PR with results.
+    >> "Great! The deployment completed successfully in ~21 minutes."
+
+  deva/qa:
+    Claude crashed with malformed args. Need to relaunch.
+    >> "claude --dangerously-skip-permissions --model opus[1m]"
+```
+
+**3. Next Steps** — copy-pasteable commands:
+
+```
+  # Act on all sessions at once:
+  fleet advance
+
+  # Advance dev/parallel-deploy-wk only:
+  fleet advance --session dev:parallel-deploy-wk
+  #   >> "Great! The deployment completed successfully..."
+
+  # deva/qa is dead — inspect:
+  fleet watch deva qa
+```
+
+### Fleet Advance (Live Execution)
+
+`/fleet advance` reasons about sessions and **executes** the admiral's decisions:
+
+```
+/fleet advance                                        # All sessions (confirms each action by default)
+/fleet advance --force                                # Skip confirmation, auto-execute all
+/fleet advance --session dev:parallel-deploy-wk  # Single session only
+```
+
+What happens for each action type:
+
+| Action          | What the admiral does                         |
+| --------------- | --------------------------------------------- |
+| `wait`          | Nothing — agent is working fine               |
+| `send_input`    | Types text into the tmux pane                 |
+| `restart`       | Sends Ctrl-C twice to interrupt stuck process |
+| `escalate`      | Flags for human review, no action taken       |
+| `mark_complete` | Records task as done                          |
+
+Safety is enforced automatically:
+
+- `send_input` requires confidence >= 60%
+- `restart` requires confidence >= 80%
+- Dangerous patterns (rm -rf, force push, etc.) are blocked
+
+### Filtering to One Session
+
+Both scout and advance support `--vm` and `--session` filters:
+
+```
+# Scout one VM (faster — only one Bastion tunnel):
+/fleet scout --vm dev --skip-adopt
+
+# Scout one session (fastest — ~2 min):
+/fleet scout --session dev:cybergym-intg --skip-adopt
+
+# Advance one session:
+/fleet advance --session dev:cybergym-intg
+
+# Advance one session with confirmation:
+/fleet advance --session deva:qa --confirm
+```
+
+### Typical Workflow
+
+1. **Scout first** to see the fleet state:
+
+   ```
+   /fleet scout
+   ```
+
+2. **Review** the report — check which sessions need action
+
+3. **Advance specific sessions** you agree with:
+
+   ```
+   /fleet advance --session dev:parallel-deploy-wk
+   ```
+
+4. **Or advance all** if the admiral's proposals look good (auto-confirms each):
+
+   ```
+   /fleet advance --force
+   ```
+
+5. **Check on individual sessions** that need attention:
+   ```
+   /fleet watch deva qa
+   ```
+
+### Incremental Scout
+
+After the first scout, results are saved to `~/.amplihack/fleet/last_scout.json`. On subsequent runs, use `--incremental` to skip LLM reasoning for sessions whose status hasn't changed:
+
+```
+/fleet scout --incremental
+```
+
+This dramatically reduces LLM costs when most sessions are stable.
+
+### Saving Reports
+
+Both commands support `--save` to write a JSON report:
+
+```
+/fleet scout --save /tmp/fleet-report.json
+/fleet advance --save /tmp/advance-log.json
+```
+
+### Session State Detection
+
+The fleet system detects eight distinct session states:
+
+| State             | What it means                  | How detected                                        |
+| ----------------- | ------------------------------ | --------------------------------------------------- |
+| **thinking**      | Agent is actively processing   | `●` tool call indicator, streaming output           |
+| **running**       | Agent producing output         | Status bar shows `(running)`                        |
+| **idle**          | Agent at `❯` prompt, waiting   | Claude Code prompt with no input                    |
+| **shell**         | Agent dead, back at `$` prompt | Bare bash prompt, no claude/node process            |
+| **suspended**     | Agent backgrounded but alive   | Bash prompt but claude/node process still running   |
+| **error**         | Error detected in session      | `error:`, `traceback`, `fatal:`, `panic:` in output |
+| **completed**     | Agent finished its task        | `GOAL_STATUS: ACHIEVED`, PR created/merged          |
+| **waiting_input** | Agent needs user input         | `[Y/n]`, `⏵⏵ bypass`, prompt ending in `?`          |
+
+The suspended state is detected by checking for live `claude` or `node` processes as children of the tmux pane. This catches sessions where the agent was backgrounded with Ctrl-Z or the Claude Code background feature.
+
+The `unknown` state may appear when detection patterns do not match any known status. This is treated as requiring manual inspection.
+
+## Next Steps
+
+- Read the fleet orchestration architecture document in the upstream `amplihack` repository to understand how the modules fit together
+- Read the Strategy Dictionary in the upstream `amplihack` repository to understand the admiral's 20 decision strategies
+- Run `amplihack fleet --help` for the full command reference

--- a/docs/hive_mind/CURRENT_DESIGN_SPEC.md
+++ b/docs/hive_mind/CURRENT_DESIGN_SPEC.md
@@ -1,0 +1,594 @@
+# Current Design Specification: Memory & Retrieval Data Flow
+
+> **Purpose**: Document the current architecture exactly as implemented so the
+> design can be reviewed and rewritten. This is a factual description of what
+> exists today, not what should exist.
+
+---
+
+## Table of Contents
+
+1. [Object Model & DI Wiring](#1-object-model-di-wiring)
+2. [Graph Storage Schema](#2-graph-storage-schema)
+3. [Single-Agent Mode](#3-single-agent-mode)
+   - 3.1 [OODA Loop](#31-ooda-loop)
+   - 3.2 [Question Answering Entry Point](#32-question-answering-entry-point)
+   - 3.3 [Retrieval Strategies](#33-retrieval-strategies)
+   - 3.4 [Storage-Level Queries](#34-storage-level-queries)
+   - 3.5 [Similarity & Ranking](#35-similarity-ranking)
+   - 3.6 [Store Path](#36-store-path)
+4. [Distributed Hive Mode](#4-distributed-hive-mode)
+   - 4.1 [OODA Loop Differences](#41-ooda-loop-differences)
+   - 4.2 [DI Injection Point](#42-di-injection-point)
+   - 4.3 [DistributedCognitiveMemory Wrapper](#43-distributedcognitivememory-wrapper)
+   - 4.4 [Hive Query Mechanism (SHARD_QUERY)](#44-hive-query-mechanism-shard_query)
+   - 4.5 [Shard Controller & Local Query Handling](#45-shard-controller-local-query-handling)
+   - 4.6 [Merge & Deduplication](#46-merge-deduplication)
+   - 4.7 [search_local -- Recursive Storm Prevention](#47-search_local-recursive-storm-prevention)
+5. [Constants & Configuration](#5-constants-configuration)
+6. [Known Problems](#6-known-problems)
+
+---
+
+## 1. Object Model & DI Wiring
+
+### Single-Agent Object Chain
+
+```
+GoalSeekingAgent
+  └── .memory: CognitiveAdapter
+        └── .memory: CognitiveMemory
+              └── ._db: Kuzu connection (local graph DB)
+```
+
+### Distributed Object Chain
+
+```
+GoalSeekingAgent
+  └── .memory: CognitiveAdapter          ← topology-unaware (same code)
+        └── .memory: DistributedCognitiveMemory   ← injected at deploy
+              ├── ._local: CognitiveMemory        ← same local Kuzu DB
+              └── ._hive: DistributedHiveGraph     ← Event Hubs transport
+                    ├── ._transport: EventHubsShardTransport
+                    └── ._router: ConsistentHashRouter
+```
+
+### Key Observation
+
+`LearningAgent` (subclass of `GoalSeekingAgent`) calls `self.memory` which is
+always `CognitiveAdapter`. It never sees `DistributedCognitiveMemory` directly.
+`CognitiveAdapter.memory` is either `CognitiveMemory` (single) or
+`DistributedCognitiveMemory` (distributed).
+
+**Files:**
+
+- `goal_seeking_agent.py` — GoalSeekingAgent, OODA loop
+- `learning_agent.py` — LearningAgent, answer_question, retrieval strategies
+- `cognitive_adapter.py` — CognitiveAdapter, topology-unaware facade
+- `hive_mind/distributed_memory.py` — DistributedCognitiveMemory wrapper
+- `deploy/azure_hive/agent_entrypoint.py:278-328` — DI injection
+
+---
+
+## 2. Graph Storage Schema
+
+**Database**: Kuzu (embedded graph DB, one instance per agent process)
+
+### Node Tables
+
+```sql
+CREATE NODE TABLE SemanticMemory(
+    memory_id    STRING PRIMARY KEY,
+    concept      STRING,     -- category / context label
+    content      STRING,     -- the fact text
+    confidence   DOUBLE,
+    source_id    STRING,     -- FK to EpisodicMemory
+    agent_id     STRING,
+    tags         STRING,     -- JSON array
+    metadata     STRING,     -- JSON object
+    created_at   STRING,
+    entity_name  STRING DEFAULT ''   -- extracted proper noun for entity index
+)
+
+CREATE NODE TABLE EpisodicMemory(
+    memory_id    STRING PRIMARY KEY,
+    content      STRING,
+    source_label STRING,
+    agent_id     STRING,
+    tags         STRING,
+    metadata     STRING,
+    created_at   STRING
+)
+```
+
+### Relationship Tables
+
+```sql
+-- Similarity edges (computed at store time via Jaccard coefficient)
+CREATE REL TABLE SIMILAR_TO(
+    FROM SemanticMemory TO SemanticMemory,
+    weight   DOUBLE,
+    metadata STRING
+)
+
+-- Provenance chain
+CREATE REL TABLE DERIVES_FROM(
+    FROM SemanticMemory TO EpisodicMemory,
+    extraction_method STRING,
+    confidence        DOUBLE
+)
+
+-- Temporal supersession
+CREATE REL TABLE SUPERSEDES(
+    FROM SemanticMemory TO SemanticMemory,
+    reason         STRING,
+    temporal_delta STRING
+)
+
+-- Value transition tracking
+CREATE REL TABLE TRANSITIONED_TO(
+    FROM SemanticMemory TO SemanticMemory,
+    from_value      STRING,
+    to_value        STRING,
+    turn            INT64,
+    transition_type STRING
+)
+```
+
+**File:** `_hierarchical_memory_local.py`
+
+---
+
+## 3. Single-Agent Mode
+
+### 3.1 OODA Loop
+
+**File:** `goal_seeking_agent.py`
+
+The current `process()` method runs a **simplified** pipeline:
+
+```
+process(input)
+  ├── observe(input)     — store raw input in self._current_input
+  ├── decide()           — heuristic classify: 'answer' or 'store' (no LLM)
+  └── act()              — answer_question() or learn_from_content()
+```
+
+`orient()` exists as a separate method but is **NOT called** from `process()`.
+The rationale documented in code is that `answer_question()` does its own retrieval,
+making orient() redundant. The OODA loop is therefore Observe→Decide→Act (ODA),
+not Observe→Orient→Decide→Act.
+
+**orient() when called directly:**
+
+```python
+def orient(self):
+    facts = self.memory.search(query, limit=15)    # ← hardcoded int
+    return {"input": self._current_input, "facts": fact_strings}
+```
+
+### 3.2 Question Answering Entry Point
+
+**File:** `learning_agent.py:511-690`
+
+```
+answer_question(question)
+  ├── _detect_intent(question)         — single LLM call → intent_type
+  ├── Check KB size:
+  │     get_all_facts(limit=15000, query=question)    ← MAX_RETRIEVAL_LIMIT constant
+  │     kb_size = len(results)
+  ├── Route to strategy:
+  │     ├── AGGREGATION_INTENTS → _aggregation_retrieval()     (Cypher meta-queries)
+  │     ├── kb_size ≤ 500       → _simple_retrieval()          (dump all facts)
+  │     └── kb_size > 500       → _entity_retrieval()          (graph traversal)
+  │                                   └── fallback → _simple_retrieval(force_verbatim=True)
+  └── _synthesize_answer(question, relevant_facts)    — LLM call with fact context
+```
+
+### 3.3 Retrieval Strategies
+
+#### Simple Retrieval (`_simple_retrieval`)
+
+```
+_simple_retrieval(question, force_verbatim=False)
+  ├── Get all facts: memory.get_all_facts(limit=15000, query=question)
+  │     (uses thread-local cache if available from KB size check)
+  ├── kb_size ≤ 1000 or force_verbatim:
+  │     └── Return ALL facts verbatim (no filtering)
+  └── kb_size > 1000:
+        └── _tiered_retrieval():
+              ├── Tier 1: last 200 facts → verbatim
+              ├── Tier 2: facts 201–1000 → entity-level LLM summaries
+              └── Tier 3: facts 1000+ → topic-level LLM summaries
+```
+
+#### Entity Retrieval (`_entity_retrieval`)
+
+Uses graph traversal via `retrieve_subgraph()`:
+
+1. Extract entity names from question (regex for capitalized words)
+2. Seed search: `CONTAINS` on `entity_name` field
+3. Expand via `SIMILAR_TO` edges (1–2 hops)
+4. Rank by `confidence × keyword_relevance`
+
+#### Aggregation Retrieval (`_aggregation_retrieval`)
+
+Direct Cypher queries for meta-questions:
+
+- `count_total`, `count_entities`, `list_entities`, `count_by_concept`
+
+### 3.4 Storage-Level Queries
+
+All queries use **keyword CONTAINS** matching, not embeddings.
+
+**Primary search (retrieve_subgraph):**
+
+```sql
+MATCH (m:SemanticMemory)
+WHERE m.agent_id = $agent_id
+  AND (LOWER(m.content) CONTAINS $keyword
+       OR LOWER(m.concept) CONTAINS $keyword)
+RETURN m.*
+LIMIT $limit
+```
+
+**Entity search:**
+
+```sql
+MATCH (m:SemanticMemory)
+WHERE m.agent_id = $agent_id
+  AND LOWER(m.entity_name) CONTAINS $entity
+RETURN m.*
+LIMIT $limit
+```
+
+**Concept search (search_by_concept):**
+
+```sql
+MATCH (m:SemanticMemory)
+WHERE m.agent_id = $agent_id
+  AND (LOWER(m.concept) CONTAINS $kw OR LOWER(m.content) CONTAINS $kw)
+RETURN m.*
+ORDER BY m.created_at DESC
+LIMIT $limit
+```
+
+**get_all_facts:** Full scan, no filtering, returns up to `limit`.
+
+### 3.5 Similarity & Ranking
+
+**At store time:** When a fact is stored, SIMILAR_TO edges are computed to existing
+facts using a deterministic Jaccard-based score:
+
+```
+similarity = 0.5 × jaccard(content_tokens) + 0.2 × jaccard(tags) + 0.3 × jaccard(concept_tokens)
+```
+
+Stop words removed, tokens < 3 chars stripped.
+
+**At query time (search_local / CognitiveAdapter):** Results are re-ranked using
+n-gram overlap score between the query and `concept + content`:
+
+```python
+score = _ngram_overlap_score(query, f"{concept} {content}")
+```
+
+**No embeddings, no vector search, no semantic similarity** at any layer.
+
+### 3.6 Store Path
+
+```
+learn_from_content(text)
+  └── memory.store_fact(context, fact, confidence, source_id)
+        └── CognitiveMemory.store_fact()
+              ├── Insert SemanticMemory node
+              ├── Compute SIMILAR_TO edges to existing nodes (Jaccard)
+              ├── Insert DERIVES_FROM edge to EpisodicMemory
+              └── Detect entity_name, populate index field
+```
+
+---
+
+## 4. Distributed Hive Mode
+
+### 4.1 OODA Loop Differences
+
+The `process()` method is the **same code** in both modes. The difference is
+that `CognitiveAdapter.memory` points to `DistributedCognitiveMemory` instead
+of `CognitiveMemory`. The simplified ODA loop (no orient) applies in both.
+
+**However**, the behavior of `get_all_facts()` and `search_facts()` is radically
+different:
+
+| Method                        | Single-Agent                                    | Distributed                                     |
+| ----------------------------- | ----------------------------------------------- | ----------------------------------------------- |
+| `get_all_facts(limit, query)` | Full Kuzu scan (all 5000 facts if limit allows) | Local scan + SHARD_QUERY fan-out via Event Hubs |
+| `search_facts(query, limit)`  | Kuzu CONTAINS keyword search                    | Local search + SHARD_QUERY fan-out              |
+| `search_by_concept(keywords)` | Kuzu CONTAINS on concept/content                | Local search + SHARD_QUERY fan-out              |
+| `store_fact(...)`             | Insert into local Kuzu                          | Insert into local Kuzu + auto-promote to hive   |
+
+### 4.2 DI Injection Point
+
+**File:** `deploy/azure_hive/agent_entrypoint.py:278-328`
+
+```python
+local_memory = agent.memory.memory          # CognitiveAdapter → CognitiveMemory
+distributed_memory = DistributedCognitiveMemory(
+    local_memory=local_memory,
+    hive_graph=hive_store,                  # DistributedHiveGraph
+    agent_name=agent_name,
+)
+agent.memory.memory = distributed_memory    # Replace CognitiveAdapter's backend
+```
+
+After injection:
+
+- `agent.memory` → CognitiveAdapter (unchanged)
+- `agent.memory.memory` → DistributedCognitiveMemory (was CognitiveMemory)
+- `agent.memory.memory._local` → CognitiveMemory (original)
+- `agent.memory.memory._hive` → DistributedHiveGraph (new)
+
+### 4.3 DistributedCognitiveMemory Wrapper
+
+**File:** `hive_mind/distributed_memory.py`
+
+This is a **transparent wrapper** that intercepts read operations and fans them
+out to the hive, then merges results with local data.
+
+#### get_all_facts(limit, query)
+
+```
+get_all_facts(limit=50, query="")
+  ├── local_results = self._local.get_all_facts(limit)     ← local Kuzu scan
+  ├── if query:
+  │     hive_dicts = self._query_hive(query, limit)        ← SHARD_QUERY fan-out
+  │   else:
+  │     hive_dicts = self._get_all_hive_facts(limit)       ← unfiltered hive scan
+  └── return self._merge_fact_lists(local_results, hive_dicts, limit)
+```
+
+#### search_facts(query, limit)
+
+```
+search_facts(query, limit=10)
+  ├── local_results = self._local.search_facts(query, limit*3)   ← local Kuzu CONTAINS
+  ├── hive_dicts = self._query_hive(query, limit)                ← SHARD_QUERY fan-out
+  └── return self._merge_fact_lists(local_results, hive_dicts, limit)
+```
+
+#### store_fact(...)
+
+```
+store_fact(context, fact, ...)
+  ├── result = self._local.store_fact(...)     ← write to local Kuzu
+  └── self._auto_promote(...)                  ← fire-and-forget to Event Hubs
+```
+
+#### **getattr** (proxy)
+
+Any method not explicitly defined is proxied to `self._local`:
+
+```python
+def __getattr__(self, name):
+    if name.startswith("__") and name.endswith("__"):
+        raise AttributeError(name)
+    return getattr(self._local, name)
+```
+
+### 4.4 Hive Query Mechanism (SHARD_QUERY)
+
+**File:** `hive_mind/distributed_hive_graph.py`
+
+When `DistributedCognitiveMemory._query_hive()` is called, it delegates to
+`DistributedHiveGraph.query_facts()`:
+
+```
+query_facts(query, limit=20)
+  ├── targets = _select_query_targets(query)
+  │     ├── If embedding_generator available:
+  │     │     cosine_similarity(query_embedding, shard_summary_embedding) → top K
+  │     └── Else (current default):
+  │           If most local shards empty → return ALL agent IDs
+  │           Else → return non-empty shard agent IDs
+  │
+  ├── For each target agent (ThreadPoolExecutor):
+  │     ├── Publish SHARD_QUERY event to Event Hubs
+  │     │     {
+  │     │       event_type: "SHARD_QUERY",
+  │     │       source_agent: self._agent_id,
+  │     │       payload: {
+  │     │         query: "search string",
+  │     │         limit: 20,
+  │     │         correlation_id: uuid,
+  │     │         target_agent: recipient_id
+  │     │       }
+  │     │     }
+  │     └── Wait for SHARD_RESPONSE with matching correlation_id (timeout)
+  │
+  ├── Collect all SHARD_RESPONSE facts
+  ├── Score by position: score = max(0.0, 1.0 - rank * 0.01)
+  ├── Dedup by content hash
+  └── Return top `limit` facts sorted by score
+```
+
+**SHARD_RESPONSE event:**
+
+```json
+{
+  "event_type": "SHARD_RESPONSE",
+  "source_agent": "responding_agent_id",
+  "payload": {
+    "correlation_id": "matches_query",
+    "target_agent": "requesting_agent_id",
+    "facts": [
+      {
+        "fact_id": "...",
+        "content": "fact text",
+        "concept": "category",
+        "confidence": 0.95,
+        "tags": [],
+        "metadata": {}
+      }
+    ]
+  }
+}
+```
+
+### 4.5 Shard Controller & Local Query Handling
+
+**File:** `hive_mind/controller.py`
+
+When an agent receives a `SHARD_QUERY` event, the controller:
+
+1. Checks `payload.target_agent` matches this agent
+2. Calls `agent.memory.search_local(query, limit)` — the CognitiveAdapter method
+3. Formats results as `SHARD_RESPONSE` and publishes back
+
+`search_local()` is specifically designed to query ONLY the local Kuzu DB
+and never trigger another SHARD_QUERY (preventing recursive storms).
+
+### 4.6 Merge & Deduplication
+
+**File:** `hive_mind/distributed_memory.py`
+
+```python
+def _merge_fact_lists(local_results, hive_dicts, limit):
+    seen = set()        # MD5 hashes of content
+    merged = []
+
+    # Local facts first (higher trust)
+    for r in local_results:
+        h = md5(content)
+        if h not in seen:
+            seen.add(h)
+            merged.append(r)
+
+    # Hive facts second
+    for r in hive_dicts:
+        h = md5(content)
+        if h not in seen:
+            seen.add(h)
+            merged.append(r)
+
+    return merged[:limit]
+```
+
+No relevance re-ranking after merge. Local facts are always ranked above hive facts
+regardless of relevance. Final list is truncated to `limit`.
+
+### 4.7 search_local -- Recursive Storm Prevention
+
+**File:** `cognitive_adapter.py`
+
+When a shard query handler needs to search its own local facts, it calls
+`CognitiveAdapter.search_local()` which:
+
+1. Filters stop words from query
+2. If `DistributedCognitiveMemory`: calls `local_search_facts()` (bypasses hive)
+3. If plain `CognitiveMemory`: calls `search_facts()` directly
+4. If no results: falls back to full scan via `get_all_facts()` or `local_get_all_facts()`
+5. Re-ranks results using n-gram overlap score
+6. Returns top `limit`
+
+---
+
+## 5. Constants & Configuration
+
+**File:** `retrieval_constants.py`
+
+| Constant                       | Value  | Used In                                           |
+| ------------------------------ | ------ | ------------------------------------------------- |
+| `MAX_RETRIEVAL_LIMIT`          | 15,000 | answer_question KB size check, \_simple_retrieval |
+| `SIMPLE_RETRIEVAL_THRESHOLD`   | 500    | Switch to simple retrieval if KB ≤ this           |
+| `VERBATIM_RETRIEVAL_THRESHOLD` | 1,000  | Return all verbatim if KB ≤ this                  |
+| `TIER1_VERBATIM_SIZE`          | 200    | Most recent N facts returned verbatim             |
+| `TIER2_ENTITY_SIZE`            | 1,000  | Entity-level summary tier boundary                |
+| `SEARCH_CANDIDATE_MULTIPLIER`  | 3      | Fetch 3× limit for re-ranking headroom            |
+| `FALLBACK_SCAN_MULTIPLIER`     | 5      | Full-scan fallback fetches 5× limit               |
+
+**Remaining hardcoded values not in constants:**
+
+| Location                  | Value               | What It Is                         |
+| ------------------------- | ------------------- | ---------------------------------- |
+| `orient()`                | `limit=15`          | Memory search limit in orient step |
+| `query_facts()`           | `limit=20`          | Default SHARD_QUERY limit          |
+| `search_by_concept()`     | `limit=30`          | Default concept search limit       |
+| `query_routed()`          | `experts[:3]`       | Top 3 experts for routed queries   |
+| `_select_query_targets()` | `5 * 3 = 15`        | Max agents for fan-out             |
+| Similarity scoring        | `0.5 / 0.2 / 0.3`   | Jaccard weight split               |
+| Position scoring          | `1.0 - rank * 0.01` | Shard response ranking decay       |
+
+---
+
+## 6. Known Problems
+
+### 6.1 OODA Loop Simplified
+
+`process()` skips `orient()`. The rationale is that `answer_question()` does its
+own retrieval. But `orient()` is supposed to provide context-enriched state that
+`decide()` and `act()` use. Skipping it means `decide()` operates on raw input
+only, and the OODA cycle is actually ODA. Single-agent and distributed should
+have the same full OODA loop.
+
+### 6.2 Distributed ≠ Same Retrieval as Single-Agent
+
+In single-agent mode, `get_all_facts(limit=15000)` returns all ~5000 facts.
+`_simple_retrieval` returns them all verbatim. The LLM sees everything.
+
+In distributed mode, 5000 facts are split across 100 agents (~50 each). When
+`get_all_facts(limit=15000, query=question)` is called, it goes through:
+
+```
+DistributedCognitiveMemory.get_all_facts()
+  → _query_hive(query, limit=15000)
+    → query_facts(query, limit=20)       ← DEFAULT limit=20, NOT 15000
+      → SHARD_QUERY to each agent
+        → search_local(query, limit=20)  ← keyword CONTAINS search
+          → n-gram rerank → return 20
+      → position-based scoring
+      → dedup
+      → return top 20
+```
+
+The limit is lost at the hive boundary. 15000 becomes 20. And instead of
+returning all facts, it does a keyword search and returns only matches. This is
+fundamentally different behavior from single-agent.
+
+### 6.3 Keyword Matching Instead of Semantic Retrieval
+
+All retrieval is based on:
+
+- `CONTAINS` keyword matching in Kuzu queries
+- Jaccard coefficient for similarity edges (deterministic, no ML)
+- N-gram overlap for re-ranking
+
+There are no embeddings, no vector search, no LLM-based semantic retrieval.
+The single-agent compensates by dumping all facts (brute force). The distributed
+mode cannot do this and the keyword matching fails silently when the query
+terms don't appear in the fact text.
+
+### 6.4 Storage Is Not Distributed — Facts Are
+
+The design distributes **facts** (each agent has ~50 of 5000 facts in its local
+Kuzu DB). When a query arrives, it fans out SHARD_QUERY events to search each
+agent's local DB.
+
+The intended design is to distribute **storage** while keeping the graph
+interface identical. The graph operations (search, traverse, get_all) should
+produce the same results whether the underlying storage is a single Kuzu
+instance or 100 sharded Kuzu instances. Currently, the distributed path runs
+completely different code (keyword search + fan-out + merge) than the single-
+agent path (full scan).
+
+### 6.5 Silent Fallbacks
+
+- `_query_hive()` catches all exceptions and returns `[]` — hive failures are invisible
+- `search_local()` falls back to full scan if search returns nothing — masks bad queries
+- `__getattr__` proxy silently delegates unknown methods to `_local` — hides interface gaps
+- `_get_all_hive_facts()` catches all exceptions and returns `[]`
+
+### 6.6 Merge Has No Relevance Awareness
+
+`_merge_fact_lists()` puts local facts first and hive facts second, truncated to
+`limit`. There is no relevance scoring across the merged set. A highly relevant
+hive fact will rank below an irrelevant local fact.

--- a/docs/hive_mind/EVAL_COMPONENTS.md
+++ b/docs/hive_mind/EVAL_COMPONENTS.md
@@ -1,0 +1,178 @@
+# How The Eval Stack Fits Together
+
+This page explains the eval system in plain English.
+
+Use it when you understand the command names already but need to know which repo owns which part, how the Azure path works, and where Aspire fits.
+
+## The Short Version
+
+`amplihack-agent-eval` owns the eval harness, datasets, grading, and report packaging.
+
+`amplihack` owns the agent runtime, the Azure deployment assets, the remote adapter wiring, and the Aspire AppHost that orchestrates the scripts locally.
+
+Azure Event Hubs carries the distributed learn and question traffic. Azure Container Apps runs the agent fleet. Aspire is an optional local dashboard and orchestration shell around the existing Python and bash entrypoints.
+
+## The Five-Minute Walkthrough
+
+If you need to explain the stack quickly to another engineer, use this mental model:
+
+1. For local runtime changes, start in `amplihack` and run the thin wrappers in `src/amplihack/eval/`. Those wrappers are convenience shims over `amplihack_eval`, not a second eval framework.
+2. For authoritative local eval runs, switch to `amplihack-agent-eval` and use `amplihack-eval run` or `amplihack-eval compare`. That repo owns question generation, grading, and packaged reports.
+3. For distributed Azure evals, the eval repo still owns the run shape and final report, but it calls the Azure deployment assets from `amplihack`. Event Hubs carries the traffic, and the agents themselves run in Azure Container Apps.
+4. For Aspire, stay in `amplihack` and run the AppHost in `deploy/azure_hive/aspire/`. Aspire is the local orchestration shell around the existing deploy, monitor, and eval scripts. It is not a replacement for the Python eval harness.
+
+## Plain-English Component Diagram
+
+```mermaid
+flowchart TD
+    A[Operator] --> B{Which path?}
+
+    B -->|Local evals| C[amplihack-agent-eval CLI\nor amplihack wrapper]
+    C --> D[Generate dialogue & questions]
+    D --> E[Feed content to adapter]
+    E --> F[Ask questions]
+    F --> G[Grade answers]
+    G --> H[Write reports]
+
+    B -->|Distributed Azure evals| I[amplihack-agent-eval wrapper\nor direct runner]
+    I --> J["Call deploy.sh\n(when deployment needed)"]
+    J --> K[Apply main.bicep & push image]
+    K --> L[Provision Event Hubs\nand start Container Apps fleet]
+    L --> M[Runner publishes learn &\nquestion messages to Event Hubs]
+    M --> N[Running agents in Container Apps\nconsume via remote adapter path]
+    N --> O[Collect correlated answers]
+    O --> P[Grade & write report artifacts]
+
+    B -->|Aspire| Q["apphost.cs\n(deploy/azure_hive/aspire/)"]
+    Q --> R["Launch deploy.sh, eval_monitor.py,\neval_distributed.py as resources"]
+    R --> S[Send OTEL telemetry\nto Aspire dashboard]
+    S --> T[Does not replace\nPython eval harness]
+```
+
+## Who Owns What
+
+| Surface                          | Owning repo            | Why it lives there                                                           |
+| -------------------------------- | ---------------------- | ---------------------------------------------------------------------------- |
+| agent runtime behavior           | `amplihack`            | That is the production runtime under test                                    |
+| Azure deployment shape           | `amplihack`            | The main repo owns `deploy/azure_hive/` and `main.bicep`                     |
+| thin local wrappers              | `amplihack`            | They let runtime changes call into the eval package without leaving the repo |
+| datasets and question generation | `amplihack-agent-eval` | These are eval-framework concerns, not runtime concerns                      |
+| grading and report packaging     | `amplihack-agent-eval` | The eval repo is the authoritative harness and reporting layer               |
+| distributed Azure runner         | `amplihack-agent-eval` | It owns the top-level Event Hubs distributed eval module                     |
+| Aspire AppHost                   | `amplihack`            | It orchestrates the main repo's deploy and monitoring scripts                |
+
+## Why There Are Two Repos
+
+The split keeps the runtime and the eval framework from turning into one inseparable package.
+
+That separation lets you:
+
+- change the agent runtime without rewriting the eval framework
+- change datasets, grading, and report packaging without modifying the runtime repo
+- reuse `amplihack-agent-eval` against adapters other than the main repo's learning agent
+
+The cost is that some flows need both repos checked out at the same time, especially the thin wrappers and the distributed Azure runner.
+
+## How A Local Eval Run Works
+
+For a local wrapper run such as `python -m amplihack.eval.long_horizon_memory`:
+
+1. you run a thin wrapper from `amplihack`
+2. that wrapper imports data types and runner logic from `amplihack_eval`
+3. the adapter talks to the local agent runtime
+4. the eval harness generates dialogue and questions
+5. the grader scores answers and writes the report
+
+The important detail is that the local wrapper is not a second eval framework. It is a convenience layer over the standalone eval package.
+
+## How The Authoritative Local CLI Fits
+
+For `amplihack-eval run` or `amplihack-eval compare`:
+
+1. you run the CLI in `amplihack-agent-eval`
+2. the eval repo chooses the dataset, question slice, seed, and output location
+3. the adapter talks to the runtime under test
+4. grading and packaged report output stay in `amplihack-agent-eval`
+
+That is why the thin wrappers in `amplihack` are useful for runtime iteration, while the eval repo remains the source of truth for the full local CLI surface.
+
+## How A Distributed Azure Run Works
+
+For `./run_distributed_eval.sh` or `python -m amplihack_eval.azure.eval_distributed`:
+
+1. the eval repo decides the run shape: turns, questions, question set, retries, and output location
+2. if deployment is needed, it calls `amplihack/deploy/azure_hive/deploy.sh`
+3. `deploy.sh` applies `main.bicep`, which creates Event Hubs, Container Apps, Log Analytics, and the rest of the Azure fleet
+4. the distributed runner publishes learn and question events into Event Hubs
+5. agents in Container Apps consume those events, process them, and publish answers back to the response hub
+6. the runner correlates answers by event ID, then grades and packages the final report
+
+The eval harness and the report stay centralized in `amplihack-agent-eval`. The runtime and fleet deployment stay centralized in `amplihack`.
+
+## Where Event Hubs Fits
+
+Event Hubs is the transport layer for the distributed path.
+
+The main Bicep template defines three hubs:
+
+- `hive-events-<hive-name>` for learning and question input
+- `hive-shards-<hive-name>` for cross-shard retrieval traffic
+- `eval-responses-<hive-name>` for agent answers and eval progress events
+
+That means the distributed runner does not talk to the agents directly. It talks to Event Hubs, and the fleet consumes and publishes through those hubs.
+
+## Where Container Apps Fits
+
+Container Apps is the execution layer for the distributed path.
+
+The deploy script builds or pushes the agent image, and the Bicep template creates the container apps that run the fleet. Each app can host more than one agent depending on `agentsPerApp`.
+
+So if the question is "where do the agents actually run," the answer is "inside Azure Container Apps, using the image built from the main repo."
+
+## Where Aspire Fits
+
+Aspire is optional and local to the operator workstation.
+
+The AppHost in `deploy/azure_hive/aspire/apphost.cs` does three things:
+
+- starts the existing deploy and eval scripts as named resources
+- wires them into the Aspire dashboard and OTEL output
+- gives you one place to toggle monitor, retrieval-smoke, long-horizon, and security flows with environment variables
+
+Aspire does not replace:
+
+- the eval dataset generator
+- the grader
+- the distributed runner
+- the Azure deployment script
+
+It orchestrates those pieces. That is why the AppHost is small and the heavy logic still lives in Python and bash.
+
+## Why The Aspire AppHost Is In C&#35;
+
+The AppHost is in C# because Aspire's application model is a .NET host built around the `DistributedApplication` builder API.
+
+That does not mean the eval stack became a C# system. The deploy script, monitor, and eval runners are still the existing Python and bash entrypoints. The C# layer is only the orchestration shell that names those resources, wires environment variables, and publishes OTEL telemetry into the Aspire dashboard.
+
+## How Secrets Reach The Distributed Runner
+
+The Event Hubs connection string should move through environment variables, not command-line arguments.
+
+The direct compatibility wrappers in `deploy/azure_hive/` read `EH_CONN`, `AMPLIHACK_EH_INPUT_HUB`, and `AMPLIHACK_EH_RESPONSE_HUB` from the environment, then reconstruct the effective upstream argument list inside the Python process only when the operator did not already provide explicit flags. The Aspire AppHost follows the same pattern for its local monitor and eval executable resources, where it sets `EH_CONN` as an environment variable instead of putting the connection string on the shell command line.
+
+That is why the docs prefer `read -rsp ... EH_CONN` plus `export EH_CONN` over typing `--connection-string ...` in the command you launch. It keeps the secret out of the operator-visible exec-time command line and normal process-list output, even though the compatibility wrapper still rebuilds the effective arguments internally before delegating to the upstream Python entrypoint.
+
+## What To Change When Something Breaks
+
+| If the problem is in...                     | Start in...                                                                                                                                |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| question generation, grading, report output | `amplihack-agent-eval`                                                                                                                     |
+| local thin wrapper behavior                 | `src/amplihack/eval/` in `amplihack`                                                                                                       |
+| Azure deployment topology                   | `deploy/azure_hive/` in `amplihack`                                                                                                        |
+| agent runtime behavior                      | `src/amplihack/agents/` in `amplihack`                                                                                                     |
+| distributed answer transport or correlation | `deploy/azure_hive/remote_agent_adapter.py` and `agent_entrypoint.py` in `amplihack` plus the distributed runner in `amplihack-agent-eval` |
+| Aspire dashboard orchestration              | `deploy/azure_hive/aspire/apphost.cs` in `amplihack`                                                                                       |
+
+## Related Docs
+
+- [Day-zero operator guide](./EVAL_OPERATOR_GUIDE.md)

--- a/docs/hive_mind/EVAL_OPERATOR_GUIDE.md
+++ b/docs/hive_mind/EVAL_OPERATOR_GUIDE.md
@@ -1,0 +1,297 @@
+# Day-Zero Eval Operator Guide
+
+Use this guide when you want the shortest path from a fresh checkout to a working eval command.
+
+This is a how-to guide. It focuses on which repo to run from, which environment variables to set, and which command to use for each kind of eval.
+
+## What To Run From Which Repo
+
+| Goal                                                                   | Repo                   | Command family                                           |
+| ---------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------- |
+| Edit the agent runtime and run the thin local wrappers                 | `amplihack`            | `python -m amplihack.eval.*`                             |
+| Run the authoritative local eval CLI                                   | `amplihack-agent-eval` | `amplihack-eval run`, `amplihack-eval compare`           |
+| Run the distributed Azure runner against an already live hive          | `amplihack`            | `python deploy/azure_hive/eval_distributed.py`           |
+| Deploy Azure and run an end-to-end distributed eval                    | `amplihack-agent-eval` | `./run_distributed_eval.sh`                              |
+| Orchestrate deploy, monitor, or eval scripts with the Aspire dashboard | `amplihack`            | `dotnet run apphost.cs` from `deploy/azure_hive/aspire/` |
+
+## Bootstrap Both Repos
+
+Clone the two repos next to each other so the wrappers can reference sibling source trees.
+
+```bash
+git clone https://github.com/rysweet/amplihack.git
+git clone https://github.com/rysweet/amplihack-agent-eval.git
+```
+
+Create one shared virtual environment in the main repo, then install both repos into it.
+
+```bash
+cd amplihack
+python -m venv .venv
+. .venv/bin/activate
+cargo build            # amplihack-rs is a Rust project; use cargo
+pip install --upgrade pip  # still needed for the Python eval harness
+pip install -e ".[dev]"
+
+cd ../amplihack-agent-eval
+pip install -e ".[all,dev]"
+```
+
+Export the common paths once per shell.
+
+```bash
+export AMPLIHACK_SOURCE_ROOT="$(cd ../amplihack && pwd)"
+export AMPLIHACK_EVAL_SOURCE_ROOT="$(pwd)"
+export PYTHONPATH="${AMPLIHACK_EVAL_SOURCE_ROOT}/src:${AMPLIHACK_SOURCE_ROOT}/src"
+```
+
+## Common Prerequisites
+
+Most eval paths need Anthropic access for grading.
+
+```bash
+read -rsp "Anthropic API key: " ANTHROPIC_API_KEY && echo
+export ANTHROPIC_API_KEY
+```
+
+Azure paths also need Azure CLI auth.
+
+```bash
+az login
+```
+
+## Path 1: Run The Thin Local Wrapper From `amplihack`
+
+Use this when you are editing runtime code in `amplihack` and want to exercise the local wrapper that delegates into `amplihack_eval`.
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}"
+
+python -m amplihack.eval.long_horizon_memory \
+  --turns 100 \
+  --questions 20 \
+  --output-dir /tmp/eval-run
+```
+
+For multi-seed comparison:
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}"
+
+python -m amplihack.eval.long_horizon_multi_seed \
+  --turns 100 \
+  --questions 20 \
+  --seeds 42,123,456,789 \
+  --output-dir /tmp/eval-compare
+```
+
+The thin wrappers in `amplihack` do not currently expose `--question-set`. If you need `standard` versus `holdout`, use the authoritative `amplihack-agent-eval` CLI or the distributed runner paths below.
+
+Use the progressive suite when you want the L1-L12 surface rather than the long-horizon harness.
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}"
+
+python -m amplihack.eval.progressive_test_suite \
+  --output-dir /tmp/eval-progressive \
+  --runs 3 \
+  --grader-votes 3 \
+  --sdk mini
+```
+
+## Path 2: Run The Authoritative Local CLI From `amplihack-agent-eval`
+
+Use this when you want the packaged eval CLI and report tooling rather than the thin wrappers in the main repo.
+
+```bash
+cd "${AMPLIHACK_EVAL_SOURCE_ROOT}"
+
+amplihack-eval run \
+  --turns 100 \
+  --questions 20 \
+  --adapter learning-agent \
+  --question-set standard \
+  --output-dir /tmp/eval-cli-run
+```
+
+Compare multiple seeds or question slices:
+
+```bash
+cd "${AMPLIHACK_EVAL_SOURCE_ROOT}"
+
+amplihack-eval compare \
+  --seeds 42,123,456,789 \
+  --turns 100 \
+  --questions 20 \
+  --question-set holdout \
+  --output-dir /tmp/eval-cli-compare
+```
+
+## Path 3: Deploy Azure And Run The End-To-End Distributed Wrapper
+
+Use this when you want one command that deploys the fleet, runs the distributed eval, and writes packaged artifacts with rerun metadata.
+
+```bash
+cd "${AMPLIHACK_EVAL_SOURCE_ROOT}"
+
+export HIVE_NAME=amplihive
+export HIVE_RESOURCE_GROUP=hive-mind-eval-rg
+export HIVE_LOCATION=eastus
+
+./run_distributed_eval.sh \
+  --agents 100 \
+  --turns 5000 \
+  --questions 50 \
+  --question-set standard
+```
+
+This wrapper:
+
+1. calls `amplihack/deploy/azure_hive/deploy.sh`
+2. looks up the Event Hubs connection string
+3. runs the distributed eval runner against that live hive
+4. writes `eval_report.json`, logs, metadata, and a rerun command bundle
+
+## Path 4: Reuse An Existing Azure Hive
+
+Use this when the fleet is already deployed and you only want another eval run.
+
+```bash
+cd "${AMPLIHACK_EVAL_SOURCE_ROOT}"
+
+export SKIP_DEPLOY=1
+export HIVE_NAME=amplihive3175e
+export HIVE_RESOURCE_GROUP=hive-pr3175-rg
+
+./run_distributed_eval.sh \
+  --agents 100 \
+  --turns 5000 \
+  --questions 50 \
+  --question-set holdout
+```
+
+## Path 5: Run The Distributed Runner Directly
+
+Use this when you already have a live hive and want the lowest-level runner that
+still keeps the Event Hubs secret out of `argv`.
+
+The authoritative implementation still lives in `amplihack-agent-eval`; this
+repo's compatibility wrapper delegates into it while reading `EH_CONN` from the
+environment.
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}"
+
+read -rsp "Event Hubs connection string: " EH_CONN && echo
+export EH_CONN
+export AMPLIHACK_EH_INPUT_HUB="hive-events-amplihive3175e"
+export AMPLIHACK_EH_RESPONSE_HUB="eval-responses-amplihive3175e"
+
+python deploy/azure_hive/eval_distributed.py \
+  --agents 100 \
+  --agents-per-app 5 \
+  --turns 5000 \
+  --questions 50 \
+  --seed 42 \
+  --question-set standard \
+  --parallel-workers 1 \
+  --question-failover-retries 2 \
+  --answer-timeout 0 \
+  --output /tmp/eval_report.json
+
+unset EH_CONN
+unset AMPLIHACK_EH_INPUT_HUB
+unset AMPLIHACK_EH_RESPONSE_HUB
+```
+
+## Path 6: Use Aspire To Orchestrate The Scripts Locally
+
+Use this when you want the Aspire dashboard, OTEL wiring, and a local control surface around the existing Python and bash entrypoints.
+
+The AppHost in this repo is a file-based C# AppHost. Launch it from its own directory:
+
+```bash
+cd "${AMPLIHACK_SOURCE_ROOT}/deploy/azure_hive/aspire"
+dotnet run apphost.cs
+```
+
+### Aspire Deploy-Only Flow
+
+This starts the `azure-hive-deploy` executable resource and sends OTEL telemetry to the Aspire dashboard.
+
+```bash
+export HIVE_NAME=amplihive
+export HIVE_DEPLOYMENT_PROFILE=federated-100
+export HIVE_AGENT_COUNT=100
+export AMPLIHACK_ASPIRE_ENABLE_AZURE_DEPLOY=true
+
+cd "${AMPLIHACK_SOURCE_ROOT}/deploy/azure_hive/aspire"
+dotnet run apphost.cs
+```
+
+### Aspire Monitor And Eval Flow
+
+The monitor and eval resources are only added when the Event Hubs connection string and hub names are set.
+
+```bash
+read -rsp "Event Hubs connection string: " EH_CONN && echo
+export EH_CONN
+export AMPLIHACK_EH_INPUT_HUB="hive-events-amplihive3175e"
+export AMPLIHACK_EH_RESPONSE_HUB="eval-responses-amplihive3175e"
+export HIVE_AGENT_COUNT=100
+
+export AMPLIHACK_ASPIRE_ENABLE_EVAL_MONITOR=true
+export AMPLIHACK_ASPIRE_ENABLE_LONG_HORIZON_EVAL=true
+export AMPLIHACK_ASPIRE_EVAL_TURNS=5000
+export AMPLIHACK_ASPIRE_EVAL_QUESTIONS=50
+
+cd "${AMPLIHACK_SOURCE_ROOT}/deploy/azure_hive/aspire"
+dotnet run apphost.cs
+
+unset EH_CONN
+unset AMPLIHACK_EH_INPUT_HUB
+unset AMPLIHACK_EH_RESPONSE_HUB
+```
+
+### Aspire Security Eval Flow
+
+```bash
+read -rsp "Event Hubs connection string: " EH_CONN && echo
+export EH_CONN
+export AMPLIHACK_EH_INPUT_HUB="hive-events-amplihive3175e"
+export AMPLIHACK_EH_RESPONSE_HUB="eval-responses-amplihive3175e"
+export HIVE_AGENT_COUNT=100
+
+export AMPLIHACK_ASPIRE_ENABLE_SECURITY_EVAL=true
+export AMPLIHACK_ASPIRE_SECURITY_TURNS=300
+export AMPLIHACK_ASPIRE_SECURITY_QUESTIONS=50
+export AMPLIHACK_ASPIRE_SECURITY_CAMPAIGNS=12
+
+cd "${AMPLIHACK_SOURCE_ROOT}/deploy/azure_hive/aspire"
+dotnet run apphost.cs
+
+unset EH_CONN
+unset AMPLIHACK_EH_INPUT_HUB
+unset AMPLIHACK_EH_RESPONSE_HUB
+```
+
+## Outputs To Expect
+
+| Path                                              | Typical output                                                       |
+| ------------------------------------------------- | -------------------------------------------------------------------- |
+| `python -m amplihack.eval.progressive_test_suite` | `summary.json` plus per-level score files                            |
+| `python -m amplihack.eval.long_horizon_memory`    | `eval_report.json`-style report output                               |
+| `amplihack-eval run` or `compare`                 | report directories under your chosen `--output-dir`                  |
+| `./run_distributed_eval.sh`                       | `/tmp/eval-results-*` with report, metadata, logs, and rerun command |
+| Aspire monitor                                    | `aspire_eval_monitor_progress.json` unless overridden                |
+
+## Common Operator Mistakes
+
+- Running the local wrappers with only `PYTHONPATH=src`, which can import a globally installed `amplihack_eval` instead of the sibling checkout you are editing
+- Running the direct Azure runner without the sibling `amplihack` checkout available on `PYTHONPATH`
+- Expecting the Aspire AppHost to create monitor or eval resources without `EH_CONN`, `AMPLIHACK_EH_INPUT_HUB`, and `AMPLIHACK_EH_RESPONSE_HUB`
+- Treating Aspire as a replacement for the Python eval harness; it is an orchestration layer around the existing scripts
+
+## Related Docs
+
+- [How the eval stack fits together](./EVAL_COMPONENTS.md)

--- a/docs/hive_mind/MESSAGING_TRANSPORT_INVESTIGATION.md
+++ b/docs/hive_mind/MESSAGING_TRANSPORT_INVESTIGATION.md
@@ -1,0 +1,387 @@
+# Messaging Transport Investigation: Hive Mind Distributed Architecture
+
+**Branch:** `feat/distributed-hive-mind`
+**Date:** 2026-03-07
+**Status:** Complete
+
+---
+
+## Executive Summary
+
+This document captures research and recommendations for the messaging transport layer of the distributed hive mind architecture. After analyzing the existing codebase, comparing Azure Event Hubs vs Service Bus, evaluating abstraction libraries (Dapr, CloudEvents), and verifying the provisioned Azure infrastructure, the **recommendation is:**
+
+- **Primary transport: Azure Service Bus Premium** (already provisioned; already used in codebase)
+- **Abstraction layer: Dapr pub/sub** (optional, for future cloud-portability)
+- **Event schema: CloudEvents v1.0** (via Dapr automatically, or manually via `BusEvent.to_json()`)
+- **Secondary transport: Azure Event Hubs** (for telemetry streams and broadcast replay)
+
+---
+
+## 1. Existing Transport Layer in Haymaker Repo
+
+### Architecture Overview
+
+The distributed hive mind already has a **transport-agnostic event bus** in place with three backend implementations:
+
+| Backend                   | File                                                       | Use Case                |
+| ------------------------- | ---------------------------------------------------------- | ----------------------- |
+| `LocalEventBus`           | `src/amplihack/agents/goal_seeking/hive_mind/event_bus.py` | Testing, single-machine |
+| `AzureServiceBusEventBus` | same                                                       | Production on Azure     |
+| `RedisEventBus`           | same                                                       | Low-latency dev/staging |
+
+**Factory function:**
+
+```python
+from amplihack.agents.goal_seeking.hive_mind.event_bus import create_event_bus
+
+bus = create_event_bus(
+    backend="azure",          # "local" | "azure" | "redis"
+    connection_string="...",  # Service Bus conn str
+    topic_name="hive-graph",  # Default topic
+)
+```
+
+### Core Abstractions
+
+**`BusEvent` (immutable data model):**
+
+```python
+@dataclass(frozen=True)
+class BusEvent:
+    event_id: str       # UUID4 hex
+    event_type: str     # FACT_LEARNED, QUERY, SEARCH_QUERY, etc.
+    source_agent: str   # Originating agent ID
+    timestamp: float    # Unix epoch
+    payload: dict       # Event-specific data
+```
+
+**`EventBus` Protocol (transport interface):**
+
+```python
+class EventBus(Protocol):
+    def publish(self, event: BusEvent) -> None: ...
+    def subscribe(self, agent_id: str, event_types: list[str] | None = None) -> None: ...
+    def unsubscribe(self, agent_id: str) -> None: ...
+    def poll(self, agent_id: str) -> list[BusEvent]: ...
+    def close(self) -> None: ...
+```
+
+### Service Bus Implementation Details
+
+The `AzureServiceBusEventBus` backend uses:
+
+- **Topic:** `hive-graph` (configurable via `topic_name` kwarg)
+- **Per-agent subscriptions:** `agent-{i}` — one subscription per agent
+- **SQL filter rules:** Server-side filtering by `event_type` on each subscription
+- **Dead-lettering:** Malformed messages are automatically dead-lettered
+- **Peek-lock:** Messages locked during processing (5s max wait per poll)
+- **Message completion:** Automatic after successful deserialization
+- **Tier used:** **Premium** (1 capacity unit) per `main.bicep`
+
+### Transport Configuration
+
+Transport is selected via environment variables (or explicit kwargs):
+
+```bash
+AMPLIHACK_MEMORY_TRANSPORT=azure_service_bus       # "local" | "redis" | "azure_service_bus"
+AMPLIHACK_MEMORY_CONNECTION_STRING=Endpoint=sb://...
+AMPLIHACK_MEMORY_TOPOLOGY=distributed
+AMPLIHACK_MEMORY_BACKEND=cognitive
+```
+
+### Event Types Published
+
+| Event Type                      | Direction | Purpose                               |
+| ------------------------------- | --------- | ------------------------------------- |
+| `network_graph.create_node`     | broadcast | Replicate node creation to all agents |
+| `network_graph.create_edge`     | broadcast | Replicate edge creation to all agents |
+| `network_graph.search_query`    | fan-out   | Request knowledge from peer agents    |
+| `network_graph.search_response` | reply     | Return search results to requester    |
+| `QUERY`                         | fan-out   | Ask hive a question (OODA loop)       |
+| `QUERY_RESPONSE`                | reply     | Answer hive query                     |
+| `LEARN_CONTENT`                 | broadcast | Notify agents of new learned content  |
+
+### Transport Layer File Map
+
+```
+src/amplihack/agents/goal_seeking/hive_mind/
+├── event_bus.py              # EventBus protocol + 3 backend implementations
+├── distributed_hive_graph.py # DHT-sharded hive graph (local bus only)
+├── hive_graph.py             # HiveGraph protocol (abstract)
+├── dht.py                    # Consistent hashing (HashRing, DHTRouter)
+├── gossip.py                 # Bloom-filter gossip for convergence
+└── controller.py             # Multi-hive orchestration
+
+src/amplihack/memory/
+├── network_store.py          # NetworkGraphStore: wraps GraphStore + event bus
+├── facade.py                 # Memory: high-level API used by OODA loop
+└── config.py                 # MemoryConfig: transport selection + env vars
+
+deploy/azure_hive/
+├── main.bicep                # IaC: Service Bus Premium + Container Apps
+└── agent_entrypoint.py       # OODA loop: observe/orient (events) + act
+```
+
+---
+
+## 2. Event Hubs vs Service Bus: Comparison
+
+### Feature Matrix
+
+| Feature                 | Azure Event Hubs                                              | Azure Service Bus                                |
+| ----------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| **Model**               | Append-only log (Kafka-like)                                  | Message broker (AMQP)                            |
+| **Fan-out / Broadcast** | Excellent — consumer groups read independently                | Via topics + subscriptions (up to 2,000 subs)    |
+| **Competing consumers** | Complex — requires partition coordination                     | Native — queue peek-lock                         |
+| **Message replay**      | Yes — rewind to any offset in retention window                | No — messages deleted on consumption             |
+| **Ordering guarantee**  | Per-partition FIFO only                                       | Per-session FIFO (sessions), else best-effort    |
+| **Dead-letter queue**   | Not native — must implement in app code                       | Built-in DLQ on every queue and subscription     |
+| **Request/Reply (RPC)** | Not supported                                                 | Native — `ReplyTo` + `ReplyToSessionId`          |
+| **Per-message routing** | No server-side filter rules                                   | SQL filter rules on subscriptions                |
+| **Duplicate detection** | None at service layer                                         | Configurable window per entity                   |
+| **Transactions**        | None                                                          | Multi-entity atomic transactions                 |
+| **Message size**        | Up to 1 MB (Standard), higher on Premium                      | 256 KB (Standard), up to 100 MB (Premium)        |
+| **Throughput ceiling**  | Millions/sec (horizontal via partitions)                      | High but not extreme — reliability first         |
+| **Retention**           | 1–7 days (Standard), up to 90 days (Premium)                  | Until consumed or TTL expires                    |
+| **Pricing (base)**      | Throughput Units / Processing Units                           | Per operation (Standard) or per MU-day (Premium) |
+| **Dapr support**        | `pubsub.azure.eventhubs` (needs Blob Storage for checkpoints) | `pubsub.azure.servicebus.topics` (first-class)   |
+
+### Pattern Suitability for Hive Mind
+
+| Communication Pattern                          | Hive Mind Use                  | Best Fit                                               |
+| ---------------------------------------------- | ------------------------------ | ------------------------------------------------------ |
+| Fan-out: broadcast LEARN_CONTENT to all agents | All agents receive new facts   | **Event Hubs** (consumer groups) or Service Bus topics |
+| Fan-out search query to peer agents            | `network_graph.search_query`   | Service Bus topics + filter subs                       |
+| Request/reply: `QUERY` → `QUERY_RESPONSE`      | Agent asks hive a question     | **Service Bus** sessions                               |
+| Competing-consumer task dispatch               | Agent pool picks up work items | **Service Bus** queues                                 |
+| Dead-letter poisoned events                    | Malformed `BusEvent`           | **Service Bus** built-in DLQ                           |
+| Replay for new agent types bootstrapping       | New agent reads full history   | **Event Hubs**                                         |
+| Telemetry / observability streams              | High-volume agent logs/metrics | **Event Hubs**                                         |
+| Ordered multi-step task chains                 | OODA tick ordering per agent   | **Service Bus** sessions                               |
+
+### Recommendation
+
+**Service Bus is the primary transport for inter-agent coordination.** It directly supports the hive mind's key patterns: fan-out search queries, request/reply queries, dead-lettering, and per-subscription SQL filters. The existing code already implements this correctly.
+
+**Event Hubs should be used as a secondary stream** for telemetry, observability, and enabling new agent types to replay history. It is not a replacement for Service Bus in the hive mind's messaging patterns.
+
+---
+
+## 3. Abstraction Library Evaluation
+
+### 3.1 Dapr Pub/Sub
+
+**What it is:** A CNCF-graduated distributed runtime that abstracts messaging behind a sidecar HTTP/gRPC API. Applications call `localhost:3500/publish`; the sidecar handles the actual broker interaction.
+
+**Dapr pub/sub with Service Bus:**
+
+```yaml
+# dapr/components/pubsub.yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: hive-pubsub
+spec:
+  type: pubsub.azure.servicebus.topics
+  version: v1
+  metadata:
+    - name: connectionString
+      secretKeyRef:
+        name: sb-secret
+        key: connectionString
+```
+
+**Agent code (before Dapr):**
+
+```python
+# Direct Azure SDK
+sender = ServiceBusSender(conn_str, topic_name="hive-graph")
+sender.send_messages(ServiceBusMessage(json.dumps(event.to_dict())))
+```
+
+**Agent code (after Dapr):**
+
+```python
+# Dapr sidecar — no Azure SDK
+import httpx
+httpx.post("http://localhost:3500/v1.0/publish/hive-pubsub/hive-graph",
+           json=event.to_dict())
+```
+
+**Pros:**
+
+- Transport portability: swap Service Bus for Kafka/Redis/RabbitMQ by changing one YAML
+- Built-in at-least-once delivery regardless of backend capabilities
+- Dead-letter topics managed by Dapr uniformly
+- CloudEvents 1.0 envelope added automatically
+- **Dapr Agents** (March 2025): virtual actor model purpose-built for multi-agent coordination
+- Built-in distributed tracing (OpenTelemetry), metrics, and service-to-service encryption
+
+**Cons:**
+
+- Sidecar overhead: each agent pod needs a sidecar (adds ~50–200 MB RAM per agent)
+- Local development requires `dapr run` or Docker Compose
+- Dapr Agents is new (announced March 2025); production maturity is still evolving
+- Adds operational surface: Dapr control plane (operator, sentry, placement) on Kubernetes
+- The existing `EventBus` protocol already provides the same abstraction at the Python level
+
+**Verdict:** Dapr is **recommended for future adoption** when the hive mind needs cloud-portability or Kubernetes-native deployment at scale. For the current Container Apps deployment backed by Service Bus, the existing `EventBus` protocol provides equivalent abstraction with no sidecar overhead. Migrate to Dapr when multi-cloud or on-prem portability becomes a requirement, or when adopting the Dapr Agents framework for actor-based state management.
+
+### 3.2 CloudEvents Specification
+
+**What it is:** A CNCF-graduated specification (v1.0, graduated January 2024) that standardizes the event envelope schema. It is **not** a transport or delivery system — purely a schema contract.
+
+**Required CloudEvents fields:**
+
+```json
+{
+  "specversion": "1.0",
+  "id": "abc123",
+  "source": "/agents/agent-0",
+  "type": "com.amplihack.hive.fact_learned",
+  "time": "2026-03-07T10:00:00Z",
+  "datacontenttype": "application/json",
+  "data": { ... }
+}
+```
+
+**Relationship to existing `BusEvent`:**
+
+```python
+# Current BusEvent fields
+@dataclass(frozen=True)
+class BusEvent:
+    event_id: str       # → CloudEvents "id"
+    event_type: str     # → CloudEvents "type"
+    source_agent: str   # → CloudEvents "source"
+    timestamp: float    # → CloudEvents "time"
+    payload: dict       # → CloudEvents "data"
+```
+
+`BusEvent` is structurally equivalent to a CloudEvents envelope. Adopting CloudEvents would require adding `specversion: "1.0"` and a URI `source` format — a minimal change.
+
+**Azure support:**
+
+- Service Bus: CloudEvents payloads supported natively (message body is schema-agnostic)
+- Event Hubs: CloudEvents supported via Kafka protocol binding
+- Event Grid: Native CloudEvents v1.0 as both input and output schema
+
+**Dapr relationship:** Dapr automatically wraps all pub/sub messages in CloudEvents 1.0 format. Using Dapr means CloudEvents adoption is automatic.
+
+**Verdict:** CloudEvents is **recommended as the standard event envelope** for all hive mind inter-agent messages. The migration from current `BusEvent` is minimal (add `specversion`, normalize `source` to a URI). If Dapr is adopted, CloudEvents compliance comes for free. If staying with the direct Service Bus SDK, add a CloudEvents serializer wrapper around `BusEvent.to_json()`.
+
+### 3.3 Abstraction Comparison
+
+| Dimension                | Dapr                     | CloudEvents                     | Existing EventBus Protocol |
+| ------------------------ | ------------------------ | ------------------------------- | -------------------------- |
+| **What it abstracts**    | Transport (which broker) | Schema (envelope format)        | Transport (which broker)   |
+| **Language**             | Any (HTTP/gRPC sidecar)  | Any (JSON/binary spec)          | Python only                |
+| **Overhead**             | Sidecar process per pod  | Zero (schema contract only)     | Zero                       |
+| **Lock-in reduction**    | Full broker portability  | Interoperability across systems | Python-level portability   |
+| **Production readiness** | High (CNCF graduated)    | High (CNCF graduated)           | Medium (internal only)     |
+| **Already in use**       | No                       | No (but BusEvent is compatible) | Yes                        |
+
+---
+
+## 4. Provisioned Azure Infrastructure
+
+### Premium Service Bus Namespace
+
+A Premium Service Bus namespace is provisioned and active for the hive mind deployment:
+
+| Property           | Value                                                            |
+| ------------------ | ---------------------------------------------------------------- |
+| **Namespace name** | `hive-sb-prem-dj2qo2w7vu5zi`                                     |
+| **Resource group** | `hive-mind-rg`                                                   |
+| **Location**       | East US                                                          |
+| **SKU**            | Premium                                                          |
+| **Capacity**       | 1 Messaging Unit                                                 |
+| **Status**         | Active                                                           |
+| **Endpoint**       | `https://hive-sb-prem-dj2qo2w7vu5zi.servicebus.windows.net:443/` |
+
+This namespace is provisioned via `deploy/azure_hive/main.bicep` and matches the `AzureServiceBusEventBus` backend configuration in the code.
+
+**Why Premium tier:**
+
+- Dedicated resources (no noisy neighbors)
+- Message size up to 100 MB (vs 256 KB on Standard)
+- VNet integration for network isolation
+- Flat pricing per messaging unit (predictable cost at scale)
+- Required for production Container Apps deployment
+
+### Existing Standard Namespace (staging/dev)
+
+| Property           | Value                   |
+| ------------------ | ----------------------- |
+| **Namespace name** | `hive-sb-dj2qo2w7vu5zi` |
+| **Resource group** | `hive-mind-rg`          |
+| **Location**       | West US 2               |
+| **SKU**            | Standard                |
+| **Use**            | Development / staging   |
+
+---
+
+## 5. Recommendations Summary
+
+### Immediate (current state is good)
+
+1. **Keep Service Bus Premium as primary transport** — the existing `AzureServiceBusEventBus` implementation is correct and well-designed. No changes needed.
+
+2. **Keep the `EventBus` protocol** — the three-backend design (`local`/`redis`/`azure`) provides the right abstraction for testing and production without sidecar overhead.
+
+3. **Adopt CloudEvents schema for `BusEvent`** — add `specversion: "1.0"` and normalize `source_agent` to a URI (e.g., `/agents/{agent_id}`) in `BusEvent.to_json()`. This enables interoperability with Event Grid, external consumers, and future Dapr migration.
+
+### Near-term
+
+4. **Add Event Hubs for telemetry** — route agent metrics, OODA tick counts, and memory stats to an Event Hubs namespace for stream analytics and dashboarding via Azure Monitor / Stream Analytics.
+
+5. **Evaluate Dapr Agents** — once Dapr Agents (March 2025) reaches GA stability, evaluate replacing the `NetworkGraphStore` background thread model with Dapr virtual actors. This would give durable state, retry, and multi-agent workflow orchestration.
+
+### Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Azure Container Apps (hive mind agents)                            │
+│                                                                     │
+│  ┌───────────┐   ┌───────────┐   ┌───────────┐   ┌───────────┐    │
+│  │  Agent-0  │   │  Agent-1  │   │  Agent-2  │   │  Agent-N  │    │
+│  │  OODA     │   │  OODA     │   │  OODA     │   │  OODA     │    │
+│  │  Memory   │   │  Memory   │   │  Memory   │   │  Memory   │    │
+│  └─────┬─────┘   └─────┬─────┘   └─────┬─────┘   └─────┬─────┘   │
+│        │               │               │               │           │
+│  ┌─────▼───────────────▼───────────────▼───────────────▼─────┐    │
+│  │              AzureServiceBusEventBus                       │    │
+│  │  (EventBus Protocol → Topic: hive-graph)                   │    │
+│  └─────────────────────────┬───────────────────────────────────┘   │
+└────────────────────────────│────────────────────────────────────────┘
+                             │ AMQP / Service Bus SDK
+┌────────────────────────────▼────────────────────────────────────────┐
+│  Azure Service Bus Premium  (hive-sb-prem-dj2qo2w7vu5zi, eastus)   │
+│                                                                      │
+│  Topic: hive-graph                                                   │
+│  ├── Subscription: agent-0  [SQL filter: eventtype IN (...)]        │
+│  ├── Subscription: agent-1  [SQL filter: eventtype IN (...)]        │
+│  ├── ...                                                             │
+│  └── Dead-letter queue (auto): malformed events                     │
+└──────────────────────────────────────────────────────────────────────┘
+                                                         ▲
+                     Future: CloudEvents envelope        │
+                     Future: Dapr sidecar abstraction   │
+                     Future: Event Hubs telemetry sidecar
+```
+
+---
+
+## 6. References
+
+- [Azure Service Bus vs Event Hubs - Microsoft Learn](https://learn.microsoft.com/en-us/azure/service-bus-messaging/compare-messaging-services)
+- [Service Bus Premium tier - Microsoft Learn](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging)
+- [Event Hubs features and tiers - Microsoft Learn](https://learn.microsoft.com/en-us/azure/event-hubs/compare-tiers)
+- [Dapr pub/sub overview - Dapr Docs](https://docs.dapr.io/developing-applications/building-blocks/pubsub/pubsub-overview/)
+- [Dapr AI Agents announcement - CNCF (March 2025)](https://www.cncf.io/blog/2025/03/12/announcing-dapr-ai-agents/)
+- [CloudEvents v1.0 specification - GitHub](https://github.com/cloudevents/spec)
+- Hive Mind Architecture (see upstream `amplihack` repository)
+- Hive Mind Design (see upstream `amplihack` repository)
+- Transport layer code: `src/amplihack/agents/goal_seeking/hive_mind/event_bus.py`
+- Network store: `src/amplihack/memory/network_store.py`
+- Azure IaC: `deploy/azure_hive/main.bicep`

--- a/docs/hive_mind/MODULE_CREATION_GUIDE.md
+++ b/docs/hive_mind/MODULE_CREATION_GUIDE.md
@@ -1,0 +1,247 @@
+# Module Creation Guide: How the HiveMindOrchestrator Was Built
+
+This document explains the process used to identify the architectural gap and implement
+`hive_mind/orchestrator.py` as a functional brick. Use it as a template when creating
+future modules for the `feat/distributed-hive-mind` branch or any part of amplihack.
+
+---
+
+## 1. Identifying the Gap
+
+### Method: Read the Architecture First
+
+Before writing a single line of code, read:
+
+1. **`DESIGN.md`** — the authoritative description of the intended system
+2. **`__init__.py`** — what is already exported (the "studs" on existing bricks)
+3. **All module headers** — the "Public API" section in each file's docstring
+
+In `DESIGN.md`, the four-layer architecture was described:
+
+```
+Layer 1: HiveGraph (storage)
+Layer 2: EventBus (transport)
+Layer 3: Gossip (discovery)
+Layer 4: Query deduplication
+```
+
+And an experimental result claimed **94% accuracy with a unified approach** vs. 47-57% for individual
+layers. But no class in the codebase stitched those four layers together.
+
+### Checklist for Gap Identification
+
+- [ ] Does `DESIGN.md` describe a class or role that no file implements?
+- [ ] Does any module comment reference something as "TODO" or describe something "delegated" elsewhere?
+- [ ] Is there a `_promote_to_hive()` that does a direct call with no policy or routing decision?
+- [ ] Does `__init__.py.__all__` list concepts that don't correspond to any file?
+
+In this case: `cognitive_adapter._promote_to_hive()` called `hive.promote_fact()` directly —
+hardcoded single-layer behavior with no policy, no event bus involvement, no gossip.
+That was the architectural seam where the missing module belonged.
+
+---
+
+## 2. Defining the Module's Single Responsibility
+
+The Bricks and Studs philosophy requires **one class, one job**. Before writing the class,
+write one sentence:
+
+> `HiveMindOrchestrator` routes fact operations through the appropriate architectural layer
+> based on a configurable policy.
+
+Everything in the module either:
+
+- **Fulfills** that responsibility, or
+- **Is removed**
+
+To make the single responsibility concrete, answer these three questions:
+
+| Question                           | Answer                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------ |
+| What does this module **take in**? | A fact (concept + content + confidence) or a query                             |
+| What does this module **produce**? | A result dict (promoted, event_published, gossip_triggered) or a list of facts |
+| What does this module **NOT do**?  | Store facts itself, own the event bus, run background threads                  |
+
+---
+
+## 3. Designing the Interface (the "Studs")
+
+Studs are what other bricks connect to. Design them before implementing anything.
+
+### Start with the Protocol
+
+If your module makes decisions based on external rules, extract those rules into a `Protocol`:
+
+```python
+@runtime_checkable
+class PromotionPolicy(Protocol):
+    def should_promote(self, fact: HiveFact, source_agent: str) -> bool: ...
+    def should_gossip(self, fact: HiveFact, source_agent: str) -> bool: ...
+    def should_broadcast(self, fact: HiveFact, source_agent: str) -> bool: ...
+```
+
+Then provide a `Default*` dataclass implementation using constants from `constants.py` —
+no magic numbers in the module itself.
+
+### Design the Return Dicts
+
+Every method returns a dict with named keys, not a naked bool or tuple:
+
+```python
+# Good: caller knows what happened at each layer
+{"fact_id": "hf_abc", "promoted": True, "event_published": True, "gossip_triggered": False}
+
+# Bad: caller loses context
+True
+```
+
+This pattern appears throughout the codebase (see `distributed.py`, `controller.py`).
+
+---
+
+## 4. Implementing (No Stubs)
+
+A "stub" is any function that:
+
+- Returns a hardcoded value (`return {}`)
+- Has only `...` in the body
+- Raises `NotImplementedError`
+
+Every method must do real work. For `store_and_promote`:
+
+```python
+def store_and_promote(self, concept, content, confidence, tags=None):
+    # Build the fact
+    fact = HiveFact(...)
+
+    # Layer 1: promote if policy allows
+    if self._policy.should_promote(fact, self._agent_id):
+        fact_id = self._hive_graph.promote_fact(self._agent_id, fact)
+        promoted = True
+
+    # Layer 2: publish event if promoted
+    if promoted:
+        self._event_bus.publish(make_event("FACT_PROMOTED", ...))
+
+    # Layer 3: gossip if policy allows and peers exist
+    if _HAS_GOSSIP and self._peers and self._policy.should_gossip(fact, ...):
+        _run_gossip_round(self._hive_graph, self._peers, self._gossip_protocol)
+
+    return {"fact_id": ..., "promoted": ..., "event_published": ..., "gossip_triggered": ...}
+```
+
+### Graceful Degradation Pattern
+
+Use `try/except ImportError` at module level for optional dependencies:
+
+```python
+try:
+    from .gossip import GossipProtocol, run_gossip_round as _run_gossip_round
+    _HAS_GOSSIP = True
+except ImportError:
+    _HAS_GOSSIP = False
+```
+
+Then guard usage: `if _HAS_GOSSIP and ...`.
+This pattern appears in every module in `hive_mind/`.
+
+---
+
+## 5. Wiring Into Existing Interfaces
+
+The orchestrator connects to three existing interfaces:
+
+| Interface                  | How It Connects                                                       |
+| -------------------------- | --------------------------------------------------------------------- |
+| `HiveGraph` (Layer 1)      | `hive_graph.promote_fact()` and `query_facts()` / `query_federated()` |
+| `EventBus` (Layer 2)       | `event_bus.publish()`, `event_bus.poll()`, `event_bus.unsubscribe()`  |
+| `GossipProtocol` (Layer 3) | `run_gossip_round(hive_graph, peers, protocol)`                       |
+
+The orchestrator is injected with these at construction time — it does not create them.
+This is the **dependency injection** pattern: let callers compose the system.
+
+### Integration with CognitiveAdapter
+
+The existing `cognitive_adapter._promote_to_hive()` still calls `hive.promote_fact()` directly.
+To fully integrate the orchestrator, a caller can pass the orchestrator as the `hive_store`:
+
+```python
+# The orchestrator satisfies the duck-typed promote_fact interface
+adapter = CognitiveAdapter(
+    agent_name="agent_a",
+    hive_store=orchestrator._hive_graph,  # or extend to inject orchestrator directly
+)
+```
+
+Full CognitiveAdapter integration is a future enhancement tracked in DESIGN.md.
+
+---
+
+## 6. Writing the `__init__.py` Export
+
+Always add new exports to `__init__.py` with a graceful try/except:
+
+```python
+try:
+    from .orchestrator import (
+        DefaultPromotionPolicy,
+        HiveMindOrchestrator,
+        PromotionPolicy,
+    )
+    __all__ += [
+        "DefaultPromotionPolicy",
+        "HiveMindOrchestrator",
+        "PromotionPolicy",
+    ]
+except ImportError:
+    _logger.debug("orchestrator module not available")
+```
+
+This keeps the package importable even if an optional dependency is missing.
+
+---
+
+## 7. Writing the Tests
+
+Tests should validate **the contract, not the implementation**:
+
+| Test category        | What to test                                            |
+| -------------------- | ------------------------------------------------------- |
+| Protocol compliance  | `isinstance(DefaultPromotionPolicy(), PromotionPolicy)` |
+| Happy path           | High-confidence fact is promoted, event published       |
+| Negative path        | Low-confidence fact is not promoted, no event           |
+| Edge cases           | Confidence clamping, duplicate content deduplication    |
+| Graceful degradation | No peers → gossip skipped with reason                   |
+| Lifecycle            | `close()` does not raise, is idempotent                 |
+
+Use pytest fixtures for repeated setup. Never test internal `_` attributes.
+
+---
+
+## 8. Summary: The Pattern for Future Modules
+
+```
+1. Read DESIGN.md + existing __init__.py.__all__
+2. Find the seam: something described but not implemented
+3. Write ONE responsibility sentence
+4. Design the Protocol (if pluggable rules exist)
+5. Design the return types (dicts with named keys)
+6. Implement with graceful ImportError guards for optional deps
+7. Wire to existing interfaces via constructor injection
+8. Export from __init__.py with try/except
+9. Write contract tests (29+ passing)
+10. Document here
+```
+
+The key invariant: **a brick should be self-contained, regeneratable, and minimal**.
+If you can't delete the module and recreate it from its interface alone, it's not a proper brick.
+
+---
+
+## Files Created
+
+| File                                                          | Purpose                     |
+| ------------------------------------------------------------- | --------------------------- |
+| `src/amplihack/agents/goal_seeking/hive_mind/orchestrator.py` | The new module              |
+| `tests/hive_mind/test_orchestrator.py`                        | Contract tests (29 passing) |
+| `docs/hive_mind/MODULE_CREATION_GUIDE.md`                     | This document               |

--- a/docs/hive_mind/current-validation-results.md
+++ b/docs/hive_mind/current-validation-results.md
@@ -1,0 +1,124 @@
+# Current Validation Results
+
+This page records the current verified validation snapshot for the distributed hive work and the commands used to reproduce it.
+
+## Accepted Azure Distributed Eval Results
+
+These are the currently accepted full Azure runs for the live `amplihive3175e` path after the final code change that fixed the late infrastructure relation follow-up issue.
+
+| Run | Score    |
+| --- | -------- |
+| 1   | `98.20%` |
+| 2   | `98.80%` |
+| 3   | `98.23%` |
+
+Key blocker questions that stayed fixed across the accepted set:
+
+- `Q11 = 1.00`
+- `Q12 = 1.00`
+- `Q13 = 1.00`
+- `Q40 = 1.00`
+- `Q48 = 1.00`
+- `Q49 = 1.00`
+- `Q50 = 1.00`
+
+Accepted image tag:
+
+- `q49-infrastructure-relation-followup-20260322T064641Z`
+
+## Current Local Validation Slices
+
+### Main `amplihack` repo
+
+Current wrapper-validation result:
+
+- `64 passed`
+- `ruff check` passed for the touched wrapper files
+
+Reproduction command:
+
+```bash
+cd /path/to/amplihack
+
+PYTHONPATH=/path/to/amplihack-agent-eval/src:/path/to/amplihack/src \
+.venv/bin/python -m pytest -q tests/eval/test_long_horizon_memory.py
+
+.venv/bin/ruff check \
+  src/amplihack/eval/long_horizon_memory.py \
+  src/amplihack/eval/long_horizon_multi_seed.py \
+  tests/eval/test_long_horizon_memory.py
+```
+
+### `amplihack-agent-eval` repo
+
+Current source-accurate validation result:
+
+- `42 passed, 1 warning`
+- `ruff check` passed for the touched eval files
+- `bash -n run_distributed_eval.sh` passed
+
+Reproduction command:
+
+```bash
+cd /path/to/amplihack-agent-eval
+
+uv run --with pytest --with ruff python -m pytest -q \
+  tests/test_data_generation.py \
+  tests/test_datasets.py
+
+uv run --with ruff ruff check \
+  src/amplihack_eval/data/long_horizon.py \
+  src/amplihack_eval/core/runner.py \
+  src/amplihack_eval/core/multi_seed.py \
+  src/amplihack_eval/cli.py \
+  src/amplihack_eval/azure/eval_distributed.py \
+  tests/test_data_generation.py \
+  tests/test_datasets.py
+
+bash -n run_distributed_eval.sh
+```
+
+### Why the eval repo reproduction uses `uv run`
+
+In this checkout, running the same CLI integration slice through `.venv/bin/python -m pytest` can pick up a stale installed `amplihack-eval` console script and fail the `--question-set` help assertion even though the source checkout is correct.
+
+Use `uv run` for a source-accurate reproduction, or reinstall the repo in editable mode before relying on the `amplihack-eval` console script.
+
+## How to Reproduce the Accepted Azure Path
+
+### Full clean rerun from source
+
+Run from the eval repo and let the wrapper redeploy current code:
+
+```bash
+cd /path/to/amplihack-agent-eval
+
+export ANTHROPIC_API_KEY=...
+export AMPLIHACK_SOURCE_ROOT=/path/to/amplihack
+
+./run_distributed_eval.sh \
+  --agents 100 \
+  --turns 5000 \
+  --questions 50 \
+  --question-set standard
+```
+
+### Reuse an already deployed hive
+
+```bash
+cd /path/to/amplihack-agent-eval
+
+export ANTHROPIC_API_KEY=...
+export AMPLIHACK_SOURCE_ROOT=/path/to/amplihack
+export SKIP_DEPLOY=1
+export HIVE_NAME=amplihive3175e
+export HIVE_RESOURCE_GROUP=hive-pr3175-rg
+
+./run_distributed_eval.sh \
+  --agents 100 \
+  --turns 5000 \
+  --questions 50 \
+  --question-set standard
+```
+
+If you need to reproduce the exact accepted image rather than the latest source tree, redeploy the same image tag before launching the wrapper.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,15 @@ nav:
           - Migration Worktree Support: features/power-steering/migration-worktree-support.md
           - Troubleshooting: features/power-steering/troubleshooting.md
           - Worktree Support: features/power-steering/worktree-support.md
+  - "Hive Mind & Fleet":
+      - "Design Spec: Memory & Retrieval": hive_mind/CURRENT_DESIGN_SPEC.md
+      - Eval Stack Components: hive_mind/EVAL_COMPONENTS.md
+      - Eval Operator Guide: hive_mind/EVAL_OPERATOR_GUIDE.md
+      - Messaging Transport Investigation: hive_mind/MESSAGING_TRANSPORT_INVESTIGATION.md
+      - Module Creation Guide: hive_mind/MODULE_CREATION_GUIDE.md
+      - Validation Results: hive_mind/current-validation-results.md
+      - Fleet Advanced Proposal: fleet-orchestration/ADVANCED_PROPOSAL.md
+      - Fleet Orchestration Tutorial: fleet-orchestration/TUTORIAL.md
   - Skills:
       - Migrate Session: skills/migrate.md
   - Reference:


### PR DESCRIPTION
## Summary
- Port 6 hive mind docs (design spec, eval components, operator guide, messaging transport investigation, module creation guide, validation results) and 2 fleet orchestration docs (advanced proposal, tutorial) from upstream amplihack
- Add "Hive Mind & Fleet" nav section in mkdocs.yml between Features and Skills
- Apply light-touch Rust adaptations (pip->cargo) and fix broken cross-references to files not ported (ARCHITECTURE.md, DESIGN.md, EVAL.md, STRATEGY_DICTIONARY.md)
- Fix mkdocs anchor warnings in CURRENT_DESIGN_SPEC.md ToC

## Test plan
- [x] `mkdocs build --strict` passes with zero new warnings
- [x] All 8 new files render in nav under "Hive Mind & Fleet" section
- [x] No secrets detected in ported content

Wave 6 -- Group 4 of 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)