### PR TITLE
docs: port 27 reference pages from upstream (#420)

### DIFF
--- a/docs/reference/LAUNCHER_MODEL_CONFIGURATION.md
+++ b/docs/reference/LAUNCHER_MODEL_CONFIGURATION.md
@@ -1,0 +1,119 @@
+# Launcher Model Configuration
+
+## Default Model Behavior
+
+The amplihack launcher uses `sonnet[1m]` as the default model when launching Claude Code. This provides the optimal balance of performance, extended context window, and cost-effectiveness for most development tasks.
+
+## Model Selection Priority
+
+When the launcher determines which model to use, it follows this strict priority order:
+
+1. **--model Flag** (highest priority)
+   - Explicitly specified model via command-line flag
+   - Example: `amplihack launch --model opus`
+   - Overrides environment variable and hardcoded default
+
+2. **AMPLIHACK_DEFAULT_MODEL Environment Variable**
+   - Set in your shell environment
+   - Example: `export AMPLIHACK_DEFAULT_MODEL=opus`
+   - Overrides hardcoded default but not command-line flag
+
+3. **Hardcoded Default** (lowest priority)
+   - `sonnet[1m]` is used when no other configuration is present
+   - Provides sensible default for most development work
+
+## Usage Examples
+
+### Using the Default Model
+
+```bash
+# Uses sonnet[1m] by default
+amplihack launch
+```
+
+### Override with Command-Line Flag
+
+```bash
+# Use Opus model with extended context
+amplihack launch --model opus[1m]
+
+# Use Haiku for quick tasks
+amplihack launch --model haiku
+
+# Use standard Sonnet without extended context
+amplihack launch --model sonnet
+```
+
+### Override with Environment Variable
+
+```bash
+# Set default model for all amplihack sessions
+export AMPLIHACK_DEFAULT_MODEL=opus[1m]
+
+# Now all launches use Opus by default
+amplihack launch
+
+# Still can override with flag
+amplihack launch --model haiku
+```
+
+## Available Models
+
+| Model        | Context     | Best For                            |
+| ------------ | ----------- | ----------------------------------- |
+| `sonnet[1m]` | 1M tokens   | Default - most development tasks    |
+| `sonnet`     | 200K tokens | Standard development work           |
+| `opus[1m]`   | 1M tokens   | Complex architecture, critical code |
+| `opus`       | 200K tokens | High-quality reasoning              |
+| `haiku`      | 200K tokens | Quick tasks, simple operations      |
+
+## Configuration Persistence
+
+Model selection is **per-session only**. Each time you launch amplihack, the priority hierarchy is evaluated fresh:
+
+- Command-line flags apply to that session only
+- Environment variables persist across shell sessions (until unset)
+- Hardcoded default is always available as fallback
+
+**To permanently change your default model**, set the environment variable in your shell profile:
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export AMPLIHACK_DEFAULT_MODEL=opus[1m]
+
+# Reload shell configuration
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+## Checking Active Model
+
+The active model is displayed in the statusline at the bottom of Claude Code:
+
+```
+~/src/amplihack (main → origin) Sonnet[1m] 🎫 234K 💰$1.23 ⏱12m
+```
+
+For more information about the statusline, see [STATUSLINE.md](./STATUSLINE.md).
+
+## Troubleshooting
+
+### Environment variable not being respected
+
+**Problem**: You set `AMPLIHACK_DEFAULT_MODEL` but the default `sonnet[1m]` is still used.
+
+**Solution**:
+
+1. Verify the variable is exported: `echo $AMPLIHACK_DEFAULT_MODEL`
+2. Check for command-line flags that override it
+3. Ensure you've reloaded your shell after setting it
+
+### Invalid model name
+
+**Problem**: Error when specifying an invalid model name.
+
+**Solution**: Use one of the valid model names listed in the "Available Models" table above. Model names are case-sensitive.
+
+## Related Documentation
+
+- [Statusline Reference](./STATUSLINE.md) - Session information display
+- [Auto Mode](../concepts/auto-mode.md) - Autonomous mode with model selection

--- a/docs/reference/STATUSLINE.md
+++ b/docs/reference/STATUSLINE.md
@@ -1,0 +1,395 @@
+# Statusline Reference
+
+Real-time session information bar displayed at the bottom of Claude Code interface.
+
+## Overview
+
+The statusline shows progress, costs, context usage, and active features for your Claude Code session.
+
+## Indicators Reference
+
+| Indicator             | Shows                     | Format                                      | Notes                                                   |
+| --------------------- | ------------------------- | ------------------------------------------- | ------------------------------------------------------- |
+| **Directory**         | Current working directory | `~/path`                                    | `~` = home directory                                    |
+| **Git Branch**        | Branch name and status    | `(branch → remote)` or `(branch* → remote)` | `*` = uncommitted changes, Cyan = clean, Yellow = dirty |
+| **Repository URI**    | Git remote repository URL | `[github.com/user/repo]`                    | Shortened format (cyan), only if remote exists          |
+| **Model**             | Active Claude model       | `Opus`, `Sonnet`, `Haiku`                   | Red=Opus, Green=Sonnet, Blue=Haiku                      |
+| **Tokens** 🎫         | Total token usage         | `234K`, `1.2M`, or raw number               | M=millions, K=thousands                                 |
+| **Cost** 💰           | Total session cost        | `$1.23`                                     | USD                                                     |
+| **Duration** ⏱        | Session elapsed time      | `15m`, `1h`, `30s`                          | s/m/h format                                            |
+| **Power-Steering** 🚦 | Redirect count            | `🚦×3`                                      | Only when active (purple)                               |
+| **Lock Mode** 🔒      | Lock invocation count     | `🔒×5`                                      | Only when active (yellow)                               |
+
+## Color Coding
+
+### Git Status
+
+- **Cyan**: Clean working tree (no uncommitted changes)
+- **Yellow with `*`**: Dirty working tree (uncommitted changes)
+
+### Model Type
+
+- **Red**: Opus models
+- **Green**: Sonnet models
+- **Blue**: Haiku models
+- **Gray**: Unknown/other models
+
+### Feature Indicators
+
+- **Purple (🚦)**: Power-steering active
+- **Yellow (🔒)**: Lock mode active
+
+## Examples
+
+### Example 1: Clean Development Session
+
+```
+~/src/amplihack4 (main → origin) [github.com/rysweet/amplihack] Sonnet 🎫 234K 💰$1.23 ⏱12m
+```
+
+**Breakdown:**
+
+- **Directory**: `~/src/amplihack4` (~= home shorthand)
+- **Git**: `(main → origin)` cyan = clean branch
+- **Repository**: `[github.com/rysweet/amplihack]` cyan = repository URL
+- **Model**: `Sonnet` green = Sonnet family
+- **Tokens**: `🎫 234K` 234,000 tokens
+- **Cost**: `💰$1.23` $1.23 USD
+- **Duration**: `⏱12m` 12 minutes
+
+### Example 2: Active Development with Features
+
+```
+~/projects/api (feature/auth* → origin) [github.com/org/api-service] Opus 🎫 1.2M 💰$15.67 ⏱1h 🚦×3 🔒×5
+```
+
+**Breakdown:**
+
+- **Directory**: `~/projects/api`
+- **Git**: `(feature/auth* → origin)` yellow = dirty, `*` = uncommitted changes
+- **Repository**: `[github.com/org/api-service]` cyan = repository URL
+- **Model**: `Opus` red = Opus family
+- **Tokens**: `🎫 1.2M` 1.2 million tokens
+- **Cost**: `💰$15.67` $15.67 USD
+- **Duration**: `⏱1h` 1 hour
+- **Power-Steering**: `🚦×3` 3 redirects (purple indicator)
+- **Lock Mode**: `🔒×5` 5 lock invocations (yellow indicator)
+
+## Configuration
+
+To enable the statusline, add this to `~/.amplihack/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "$CLAUDE_PROJECT_DIR/.claude/tools/statusline.sh"
+  }
+}
+```
+
+## Project Structure
+
+The statusline integrates with amplihack's structure:
+
+```
+.claude/
+├── agents/     # Agent definitions (core + specialized)
+├── context/    # Philosophy and patterns
+├── workflow/   # Development processes
+└── commands/   # Slash commands
+```
+
+## Power-Steering
+
+Power-steering is AI-powered session guidance that prevents premature session termination by analyzing your work against 21 completion criteria.
+
+### Purpose
+
+Power-steering analyzes your session using **21 distinct considerations** to determine if work is truly finished, blocking stop attempts when tasks remain incomplete, unfinished TODOs exist, or workflow steps were skipped.
+
+### What It Does
+
+When you try to stop a session, power-steering:
+
+1. **Reads the transcript** - Analyzes the entire conversation history
+2. **Evaluates 21 considerations** - Checks completion against multiple criteria:
+   - Session Completion & Progress (8 checks)
+   - Workflow Process Adherence (3 checks)
+   - Code Quality & Philosophy Compliance (3 checks)
+   - Testing & Local Validation (2 checks)
+   - PR Content & Quality (3 checks)
+   - CI/CD & Mergeability Status (2 checks)
+3. **Makes a decision** - Either approves the stop or blocks it with specific reasons
+4. **Provides continuation prompt** - Tells you exactly what needs completion
+
+### The 21 Considerations
+
+Power-steering evaluates your session against these considerations:
+
+#### Session Completion & Progress (8 checks)
+
+1. Session type matches requirements - Investigation vs development work
+2. TODOs completed - All planned tasks finished
+3. User objectives achieved - Original goals met
+4. Documentation updated - Changes reflected in docs
+5. No pending work - Nothing left unfinished
+6. Questions asked appropriately - Clarified when needed
+7. Session logs complete - All interactions documented
+8. Natural stopping point - Sensible place to pause
+
+#### Workflow Process Adherence (3 checks)
+
+9. Workflow steps followed - Proper sequence maintained
+10. Required steps completed - No skipped stages
+11. Step order correct - Logical progression
+
+#### Code Quality & Philosophy Compliance (3 checks)
+
+12. Code quality verified - Standards met
+13. Philosophy alignment checked - Principles followed
+14. Module boundaries respected - Clean architecture
+
+#### Testing & Local Validation (2 checks)
+
+15. Tests executed - Validation performed
+16. Local testing done - End-to-end verification
+
+#### PR Content & Quality (3 checks)
+
+17. PR created properly - Complete information
+18. PR reviewed - Quality check performed
+19. Review feedback addressed - Changes incorporated
+
+#### CI/CD & Mergeability Status (2 checks)
+
+20. CI passing - All checks green
+21. PR mergeable - Ready for integration
+
+### Indicator Display
+
+When power-steering redirects a stop attempt, the statusline shows:
+
+```
+🚦×N
+```
+
+Where `N` is the number of times power-steering has intervened in **this session**. The indicator appears in **purple** color.
+
+### Configuration
+
+Power-steering can be toggled via `~/.amplihack/.claude/tools/amplihack/.power_steering_config`:
+
+```json
+{
+  "enabled": true // false to disable
+}
+```
+
+### Examples
+
+#### Example 1: Blocked Stop - Incomplete TODOs
+
+```
+User attempts to stop mid-workflow...
+
+🚦 POWER-STEERING REDIRECT 🚦
+
+The session cannot be stopped because:
+- 5 TODOs remain uncompleted
+- Workflow Step 12 (Run Tests) not executed
+- PR not created yet
+
+Continue with: Complete remaining TODOs and execute workflow steps.
+```
+
+#### Example 2: Approved Stop - Work Complete
+
+```
+User attempts to stop after successful merge...
+
+✅ Power-steering approved stop request
+All 21 considerations satisfied:
+- All TODOs completed
+- All workflow steps executed
+- Tests passing
+- PR merged
+- CI green
+
+Session can safely end.
+```
+
+### Session Counter
+
+The counter (`N` in `🚦×N`) tracks interventions **per session only**:
+
+- Resets to 0 at session start
+- Increments each time power-steering blocks a stop
+- Does NOT persist across sessions
+- Helps you see how many times you tried to stop prematurely
+
+## Lock Mode
+
+Lock mode is continuous work mode that forces Claude to keep working until you give explicit permission to stop.
+
+### Purpose
+
+Lock mode enables **uninterrupted autonomous work** by blocking all stop attempts and forcing Claude to continue pursuing the user's objective until explicitly unlocked.
+
+### Commands
+
+#### Enable Lock Mode
+
+```bash
+/amplihack:lock [optional custom instruction]
+```
+
+**Basic usage (default continuation prompt)**:
+
+```bash
+/amplihack:lock
+```
+
+When enabled with no custom message, Claude receives the default continuation prompt:
+
+> "Continue working autonomously and independently. Do not stop. Pursue the user's objective with the highest quality and attention to detail."
+
+**With custom instruction** (up to 1000 characters):
+
+```bash
+/amplihack:lock Focus on security fixes first, then performance optimizations
+```
+
+The custom instruction becomes the continuation prompt that Claude receives whenever it tries to stop.
+
+#### Disable Lock Mode
+
+```bash
+/amplihack:unlock
+```
+
+Immediately disables lock mode and allows normal stop behavior.
+
+### How It Works
+
+When lock mode is active:
+
+1. **All stop attempts blocked** - Claude cannot stop under any circumstances
+2. **Custom prompt delivered** - Your instruction (or default) is sent to Claude
+3. **Autonomous continuation** - Claude resumes work based on the prompt
+4. **Counter increments** - Tracks how many times stop was blocked
+5. **Remains active until unlocked** - Persists across multiple stop attempts
+
+### Indicator Display
+
+When lock mode is active, the statusline shows:
+
+```
+🔒×N
+```
+
+Where `N` is the number of times the lock has **blocked a stop attempt** in **this session**. The indicator appears in **yellow** color.
+
+### Custom Continuation Messages
+
+**Message Constraints**:
+
+- **Maximum length**: 1000 characters (hard limit)
+- **Warning threshold**: 500 characters (shows warning but allows)
+- **Empty message**: Falls back to default continuation prompt
+
+**Examples of effective custom messages:**
+
+```bash
+# Focus directive
+/amplihack:lock Complete all testing before moving to documentation
+
+# Priority order
+/amplihack:lock Fix bugs first, then refactor, then add features
+
+# Quality emphasis
+/amplihack:lock Every function must have comprehensive tests and error handling
+
+# Workflow enforcement
+/amplihack:lock Follow DEFAULT_WORKFLOW.md exactly - do not skip steps
+```
+
+### Examples
+
+#### Example 1: Enable Lock Mode (Default)
+
+```bash
+/amplihack:lock
+```
+
+**Result:**
+
+```
+🔒 LOCK MODE ENABLED 🔒
+
+All stop attempts will be blocked.
+Continuation prompt: [default autonomous work instruction]
+
+To disable: /amplihack:unlock
+```
+
+#### Example 2: Stop Attempt While Locked
+
+```
+Claude attempts to stop...
+
+🔒 LOCK MODE ACTIVE 🔒
+
+Stop attempt blocked. Counter: 3
+
+Continuation prompt delivered:
+"Complete the authentication feature including all tests and documentation"
+
+Resuming work...
+```
+
+### Interaction with Power-Steering
+
+When **both** lock mode and power-steering are active:
+
+1. **Lock mode takes precedence** - Blocks all stops unconditionally
+2. **Power-steering is bypassed** - 21 considerations not evaluated
+3. **Counter tracks both** - Shows lock mode indicator in statusline
+4. **Different purposes**:
+   - **Lock mode** = "Never stop, regardless of completion"
+   - **Power-steering** = "Only stop when work is actually complete"
+
+**Recommendation**: Use lock mode for extended autonomous work sessions. Use power-steering for quality-gated completions.
+
+### Session Counter
+
+The counter (`N` in `🔒×N`) tracks blocked stops **per session only**:
+
+- Resets to 0 at session start
+- Increments each time lock mode blocks a stop
+- Does NOT persist across sessions
+- Helps you see how determined Claude was to stop
+
+### Use Cases
+
+**When to use lock mode:**
+
+1. **Long autonomous tasks** - Multi-hour implementations
+2. **Workflow completion** - Must finish all workflow steps
+3. **Testing marathons** - Comprehensive test suites
+4. **Documentation sprints** - Complete doc overhaul
+5. **Debugging sessions** - Won't stop until bug is fixed
+
+**When NOT to use lock mode:**
+
+1. **Exploratory work** - Need flexibility to pivot
+2. **User collaboration** - Frequent back-and-forth expected
+3. **Uncertain requirements** - May need to stop and clarify
+4. **Short tasks** - Overhead not worth it
+
+## See Also
+
+- [Power-Steering](#power-steering) - AI-powered session guidance
+- [Lock Mode](#lock-mode) - Continuous work mode
+- [Configuration Guide](../howto/configure-hooks.md) - Session hooks and settings
+- [Development Workflow](../concepts/default-workflow.md) - Process customization

--- a/docs/reference/amplifier-command.md
+++ b/docs/reference/amplifier-command.md
@@ -1,0 +1,236 @@
+# Amplifier Command Reference
+
+Launch Microsoft Amplifier with the amplihack bundle for enhanced AI-assisted development.
+
+## Synopsis
+
+```bash
+amplihack amplifier [OPTIONS] [-- AMPLIFIER_ARGS]
+```
+
+## Description
+
+The `amplihack amplifier` command launches Microsoft Amplifier with the amplihack bundle automatically loaded. Amplifier is a multi-model AI development assistant that supports Claude, GPT-4, and other models through a unified interface.
+
+**Key features:**
+
+- Automatically discovers and loads the amplihack bundle
+- Auto-installs Amplifier via `uv` if not present
+- Supports model and provider selection
+- Session resume capability
+- Integration with amplihack's auto mode
+
+## Prerequisites
+
+| Requirement   | Details                                                                                      |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| **uv**        | Required for auto-installation. Install from [docs.astral.sh/uv](https://docs.astral.sh/uv/) |
+| **Amplifier** | Auto-installed on first run via `uv tool install`                                            |
+| **API Keys**  | Configure for your chosen provider (Anthropic, OpenAI, Azure)                                |
+
+## Options
+
+### Session Control
+
+| Option                | Description                                         |
+| --------------------- | --------------------------------------------------- |
+| `--resume SESSION_ID` | Resume an existing Amplifier session                |
+| `--print`             | Single response mode (no tool use, no conversation) |
+
+### Model Selection
+
+| Option                | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `--model MODEL`       | Model to use (e.g., `claude-sonnet-4-20250514`, `gpt-4o`) |
+| `--provider PROVIDER` | Provider to use: `anthropic`, `openai`, `azure`           |
+
+### Auto Mode
+
+| Option          | Description                               |
+| --------------- | ----------------------------------------- |
+| `--auto`        | Run in autonomous mode with task loop     |
+| `--max-turns N` | Maximum turns for auto mode (default: 10) |
+
+### Common Options
+
+| Option            | Description                              |
+| ----------------- | ---------------------------------------- |
+| `--no-reflection` | Disable post-session reflection analysis |
+
+## Usage Examples
+
+### Interactive Session
+
+Start an interactive Amplifier session with the amplihack bundle:
+
+```bash
+amplihack amplifier
+```
+
+**Output:**
+
+```
+Using amplihack bundle: /path/to/amplifier-bundle
+[Amplifier starts in interactive mode]
+```
+
+### Non-Interactive with Prompt
+
+Execute a single task:
+
+```bash
+amplihack amplifier -- -p "Explain the authentication flow in this codebase"
+```
+
+### Single Response Mode
+
+Get a single response without tool use:
+
+```bash
+amplihack amplifier --print -- -p "What does this function do?"
+```
+
+### Model Selection
+
+Use a specific model:
+
+```bash
+# Use GPT-4o
+amplihack amplifier --model gpt-4o --provider openai
+
+# Use Claude Sonnet
+amplihack amplifier --model claude-sonnet-4-20250514 --provider anthropic
+```
+
+### Resume a Session
+
+Continue a previous session:
+
+```bash
+amplihack amplifier --resume session_20250114_120000_abc123
+```
+
+### Auto Mode
+
+Run autonomously with a task:
+
+```bash
+amplihack amplifier --auto -- -p "Implement user authentication with JWT tokens"
+
+# With extended turns for complex tasks
+amplihack amplifier --auto --max-turns 25 -- -p "Refactor the entire API layer"
+```
+
+## Bundle Discovery
+
+The command automatically finds the amplihack bundle using this search order:
+
+1. **Current directory**: `./amplifier-bundle/bundle.md`
+2. **Package location**: Searches up to 5 parent directories from the installed package
+
+If no bundle is found, Amplifier runs without it and displays a warning:
+
+```
+Warning: amplihack bundle not found. Running Amplifier without bundle.
+  Expected location: ./amplifier-bundle/bundle.md
+```
+
+## Installation Behavior
+
+On first run, if Amplifier is not installed:
+
+```
+Installing Amplifier from git+https://github.com/microsoft/amplifier...
+This will install Amplifier as a uv tool.
+Continue? [y/N] y
+✓ Amplifier CLI installed
+```
+
+**Non-interactive mode** (CI/scripts): Installation proceeds automatically without prompting.
+
+## Environment Variables
+
+| Variable            | Description                                         |
+| ------------------- | --------------------------------------------------- |
+| `AMPLIHACK_DEBUG`   | Set to `true` for debug output (shows full command) |
+| `ANTHROPIC_API_KEY` | API key for Anthropic models                        |
+| `OPENAI_API_KEY`    | API key for OpenAI models                           |
+| `AZURE_OPENAI_*`    | Azure OpenAI configuration                          |
+
+## Exit Codes
+
+| Code | Meaning                                              |
+| ---- | ---------------------------------------------------- |
+| `0`  | Success                                              |
+| `1`  | Error (installation failed, command not found, etc.) |
+
+## Troubleshooting
+
+### Amplifier not found after installation
+
+**Problem**: Installation succeeds but `amplifier` command not found.
+
+**Solution**: Ensure `~/.local/bin` (or uv's tool bin directory) is in your PATH:
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### Bundle not found
+
+**Problem**: Warning about missing bundle appears.
+
+**Solution**:
+
+1. Run from the amplihack repository root
+2. Or ensure `amplifier-bundle/bundle.md` exists in your project
+
+### uv not found
+
+**Problem**: Error message about missing `uv`.
+
+**Solution**: Install uv:
+
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+### API key errors
+
+**Problem**: Authentication errors when running.
+
+**Solution**: Set the appropriate API key for your provider:
+
+```bash
+# For Anthropic (Claude models)
+export ANTHROPIC_API_KEY="your-key"
+
+# For OpenAI (GPT models)
+export OPENAI_API_KEY="your-key"
+```
+
+## Comparison with Other Commands
+
+| Command               | Use Case                                            |
+| --------------------- | --------------------------------------------------- |
+| `amplihack amplifier` | Multi-model support, Amplifier features             |
+| `amplihack claude`    | Claude Code with amplihack hooks and power steering |
+| `amplihack copilot`   | GitHub Copilot CLI integration                      |
+| `amplihack codex`     | OpenAI Codex CLI integration                        |
+
+Choose `amplifier` when you need:
+
+- Multi-model flexibility (switch between Claude, GPT-4, etc.)
+- Amplifier-specific features
+- The amplihack bundle context without full Claude Code hooks
+
+## Related Documentation
+
+- [Command Selection Guide](../commands/COMMAND_SELECTION_GUIDE.md) - Choose the right command
+- [Auto Mode Guide](../concepts/auto-mode.md) - Autonomous execution details
+- [Launcher Model Configuration](./LAUNCHER_MODEL_CONFIGURATION.md) - Model selection for Claude launcher

--- a/docs/reference/append-handler.md
+++ b/docs/reference/append-handler.md
@@ -1,0 +1,184 @@
+# AppendHandler Reference
+
+`AppendHandler` writes agent output to timestamped files on disk. It is the persistence layer used by post-session hooks and batch recipe runs to capture results for later inspection.
+
+## Contents
+
+- [Overview](#overview)
+- [AppendResult](#appendresult)
+- [Filename Format](#filename-format)
+- [Usage Examples](#usage-examples)
+- [Error Handling](#error-handling)
+- [API](#api)
+
+---
+
+## Overview
+
+```python
+from amplihack.append_handler import AppendHandler, AppendResult
+```
+
+`AppendHandler` writes one file per append call. Files are created atomically using `os.open()` with `O_CREAT | O_WRONLY | O_EXCL` to prevent overwriting existing output. The caller receives an `AppendResult` describing the outcome.
+
+---
+
+## AppendResult
+
+`AppendResult` is a dataclass describing a single append operation:
+
+```python
+@dataclass
+class AppendResult:
+    success: bool
+    file_path: str | None        # Absolute path of the file written, or None on failure
+    bytes_written: int           # 0 on failure
+    error: str | None            # Error message string, or None on success
+```
+
+**Attributes**
+
+| Attribute       | Type          | Description                                                        |
+| --------------- | ------------- | ------------------------------------------------------------------ |
+| `success`       | `bool`        | `True` if the file was written without error.                      |
+| `file_path`     | `str \| None` | Absolute path of the written file. `None` if `success` is `False`. |
+| `bytes_written` | `int`         | Number of bytes written. `0` on failure.                           |
+| `error`         | `str \| None` | Human-readable error description. `None` on success.               |
+
+**Checking the result:**
+
+```python
+from amplihack.append_handler import AppendHandler
+
+handler = AppendHandler(output_dir="~/.amplihack/.claude/runtime/output")
+result = handler.append("Agent completed task successfully.\n\nSummary: 3 files modified.")
+
+if result.success:
+    print(f"Saved {result.bytes_written} bytes to {result.file_path}")
+else:
+    print(f"Failed to save: {result.error}")
+```
+
+---
+
+## Filename Format
+
+Each file is named with a timestamp derived from the moment `append()` is called:
+
+```
+YYYYMMDD_HHMMSS_ffffff.txt
+```
+
+Where `ffffff` is microseconds (6 digits), providing sub-second uniqueness even under rapid sequential calls.
+
+**Examples:**
+
+```
+20260312_143022_483921.txt
+20260312_143022_501847.txt   # same second, different microsecond
+```
+
+This format sorts lexicographically in chronological order, which simplifies log browsing with standard shell tools:
+
+```bash
+ls ~/.amplihack/.claude/runtime/output/ | tail -5
+# 20260312_140011_002341.txt
+# 20260312_143022_483921.txt
+# 20260312_143022_501847.txt
+# 20260312_151300_119204.txt
+# 20260312_162500_883412.txt
+```
+
+> **Note:** Prior to v0.9.2, timestamps used `%Y%m%d_%H%M%S` (no microseconds). Files from old runs keep their original names; the new format is used only for files written by v0.9.2 and later.
+
+---
+
+## Usage Examples
+
+### Write a session summary
+
+```python
+from amplihack.append_handler import AppendHandler
+
+handler = AppendHandler(output_dir="~/.amplihack/.claude/runtime/output")
+
+summary = """
+Session complete.
+
+Tasks completed: 3
+Files modified: auth.py, tests/test_auth.py, README.md
+""".strip()
+
+result = handler.append(summary)
+print(f"Written to: {result.file_path}")
+# Written to: /home/user/.amplihack/.claude/runtime/output/20260312_143022_483921.txt
+```
+
+### Persist all recipe step outputs
+
+```python
+from amplihack.append_handler import AppendHandler
+from amplihack.recipes.runner import RecipeRunner
+
+runner = RecipeRunner()
+handler = AppendHandler(output_dir="./run-logs")
+recipe_result = runner.run("default-workflow", {"task_description": "add caching layer"})
+
+for step in recipe_result.step_results:
+    if step.output:
+        result = handler.append(f"# {step.step_name}\n\n{step.output}")
+        print(f"Step {step.step_id} saved: {result.file_path}")
+```
+
+### Handle permission errors
+
+```python
+handler = AppendHandler(output_dir="/root/protected")
+result = handler.append("some content")
+
+if not result.success:
+    # result.error contains the OS error string, e.g. "Permission denied: '/root/protected/...'"
+    import logging
+    logging.error("Could not write output: %s", result.error)
+```
+
+---
+
+## Error Handling
+
+`append()` never raises. All errors are captured in the returned `AppendResult`:
+
+| Condition                       | `result.success` | `result.error`                               |
+| ------------------------------- | ---------------- | -------------------------------------------- |
+| Write succeeded                 | `True`           | `None`                                       |
+| Output directory does not exist | `False`          | `"[Errno 2] No such file or directory: '…'"` |
+| Permission denied               | `False`          | `"[Errno 13] Permission denied: '…'"`        |
+| Disk full                       | `False`          | `"[Errno 28] No space left on device"`       |
+
+---
+
+## API
+
+### `AppendHandler(output_dir: str)`
+
+Constructs a handler that writes files to `output_dir`. The directory is expanded (supports `~`) but **not created** — callers must ensure it exists before the first `append()` call.
+
+### `handler.append(content: str) -> AppendResult`
+
+Writes `content` to a new timestamped file in `output_dir`. Uses `os.open()` with `O_CREAT | O_WRONLY | O_EXCL` to guarantee each call creates a unique file.
+
+**Parameters**
+
+| Name      | Type  | Description                      |
+| --------- | ----- | -------------------------------- |
+| `content` | `str` | Text to write. Encoded as UTF-8. |
+
+**Returns** `AppendResult` — always. Never raises.
+
+---
+
+## See Also
+
+- [RecipeResult Reference](./recipe-result.md) — step outputs that AppendHandler typically persists
+- [Trace Logging API](./trace-logging-api.md) — structured logging alongside file-based output
+- [Runtime Directory Layout](../howto/develop-amplihack.md) — where output files live

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,152 @@
+# amplihack CLI Reference
+
+Complete command-line reference for the `amplihack` top-level command.
+
+## Contents
+
+- [Synopsis](#synopsis)
+- [Global Flags](#global-flags)
+- [Subcommands](#subcommands)
+- [Exit Codes](#exit-codes)
+- [Environment Variables](#environment-variables)
+- [Examples](#examples)
+
+---
+
+## Synopsis
+
+```
+amplihack [--version] [--help] <subcommand> [<args>]
+```
+
+Running `amplihack` with no subcommand launches Claude Code directly. In
+user-facing docs, prefer the explicit `amplihack claude` form;
+`amplihack launch` remains a compatibility alias.
+
+---
+
+## Global Flags
+
+These flags are accepted before any subcommand.
+
+| Flag           | Description                                       |
+| -------------- | ------------------------------------------------- |
+| `--version`    | Print `amplihack <version>` to stdout and exit 0. |
+| `--help`, `-h` | Print a brief usage summary and exit 0.           |
+
+### `--version`
+
+Prints the installed version string and exits immediately. No network requests, no configuration loading.
+
+```bash
+amplihack --version
+# amplihack 0.9.2
+```
+
+The version string comes from the `__version__` attribute in `amplihack/__init__.py`, which is set from `pyproject.toml` at build time. It follows [Semantic Versioning](https://semver.org/).
+
+---
+
+## Subcommands
+
+| Subcommand   | Description                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------- |
+| `version`    | Show amplihack version.                                                                     |
+| `install`    | Install amplihack agents and tools to `~/.claude`.                                          |
+| `uninstall`  | Remove amplihack agents and tools from `~/.claude`.                                         |
+| `update`     | Update amplihack, delegating to the Rust CLI when one is installed.                         |
+| `claude`     | Launch Claude Code. Preferred explicit launcher in user-facing docs.                        |
+| `launch`     | Compatibility alias for `claude`; `amplihack` with no subcommand also launches Claude Code. |
+| `RustyClawd` | Launch RustyClawd (Rust implementation).                                                    |
+| `copilot`    | Launch GitHub Copilot CLI.                                                                  |
+| `codex`      | Launch OpenAI Codex CLI.                                                                    |
+| `amplifier`  | Launch Microsoft Amplifier with amplihack bundle.                                           |
+| `uvx-help`   | Get help with UVX deployment.                                                               |
+| `plugin`     | Install, uninstall, and list amplihack plugins.                                             |
+| `memory`     | Manage the amplihack memory backend.                                                        |
+| `new`        | Generate a new goal-seeking agent.                                                          |
+| `recipe`     | Run, list, validate, and inspect workflow recipes.                                          |
+| `mode`       | Claude installation mode commands.                                                          |
+| `fleet`      | Manage coding agents across VMs.                                                            |
+
+See the documentation for each subcommand:
+
+- [Recipe CLI Reference](./recipe-cli-reference.md)
+- [Memory CLI Reference](./memory-cli-reference.md)
+- [Plugin CLI Reference](#)
+
+---
+
+## Exit Codes
+
+| Code | Meaning                                                               |
+| ---- | --------------------------------------------------------------------- |
+| `0`  | Completed successfully (or `--version` / `--help` printed).           |
+| `1`  | User error (bad argument, missing config). Stderr contains a message. |
+| `2`  | Internal error. Stderr contains a traceback.                          |
+
+---
+
+## Environment Variables
+
+These variables are read at startup. All are optional.
+
+| Variable                   | Default         | Effect                                                                                                                                                                                                                                                        |
+| -------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AMPLIHACK_AGENT_BINARY`   | set by launcher | Identifies the active tool in the child process environment. Set automatically to `claude`, `copilot`, `codex`, or `amplifier` by the corresponding launcher before spawning the subprocess. Read by skills and hooks to adapt behaviour to the active agent. |
+| `AMPLIHACK_DEBUG`          | unset           | Set to `true` to print debug messages during CLI execution.                                                                                                                                                                                                   |
+| `AMPLIHACK_ENABLE_BLARIFY` | unset           | Set to `1` to enable blarify code-graph indexing.                                                                                                                                                                                                             |
+| `AMPLIHACK_HOME`           | `~/.amplihack`  | Override the root directory for staged framework files and runtime data. Set automatically by each launcher when not already present in the environment; an existing value is always preserved.                                                               |
+| `AMPLIHACK_LOG_LEVEL`      | `WARNING`       | Python logging level for the launcher (`DEBUG`, `INFO`, `WARNING`, `ERROR`).                                                                                                                                                                                  |
+
+---
+
+## Examples
+
+### Check the installed version
+
+```bash
+amplihack --version
+# amplihack 0.9.2
+```
+
+### Launch an interactive Claude session
+
+Prefer `amplihack claude` in user-facing docs. `amplihack launch` remains
+supported as a compatibility alias.
+
+```bash
+amplihack claude
+# or simply:
+amplihack
+# compatibility alias:
+amplihack launch
+```
+
+### Launch an interactive Copilot session
+
+```bash
+amplihack copilot
+```
+
+### Run a workflow recipe non-interactively
+
+```bash
+amplihack recipe run default-workflow \
+  --context '{"task_description": "Add input validation to the login endpoint"}'
+```
+
+### Enable blarify code indexing for a session
+
+```bash
+AMPLIHACK_ENABLE_BLARIFY=1 amplihack claude
+```
+
+---
+
+## See Also
+
+- [Getting Started](../tutorials/amplihack-tutorial.md)
+- [Recipe CLI Reference](./recipe-cli-reference.md)
+- [Blarify Code Indexing](../howto/enable-blarify.md)
+- [Configuration Guide](#)

--- a/docs/reference/code-atlas-reference.md
+++ b/docs/reference/code-atlas-reference.md
@@ -1,0 +1,350 @@
+---
+type: reference
+skill: code-atlas
+version: 1.1.0
+updated: 2026-03-16
+---
+
+# Code Atlas Reference
+
+Complete reference for all flags, layer IDs, output files, schemas, and error codes. API-CONTRACTS.md v1.1.0.
+
+---
+
+## Invocation Flags
+
+| Flag                  | Type      | Default              | Description                                           |
+| --------------------- | --------- | -------------------- | ----------------------------------------------------- |
+| `codebase_path`       | string    | `.`                  | Root directory to analyze                             |
+| `layers`              | int[]     | `[1,2,3,4,5,6,7,8]`  | Which layers to build                                 |
+| `journeys`            | Journey[] | `[]`                 | Named user journeys (see journey schema)              |
+| `output_dir`          | string    | `docs/atlas`         | Where to write atlas output                           |
+| `diagram_formats`     | string[]  | `["mermaid","dot"]`  | Output formats: `mermaid`, `dot`, or `both`           |
+| `bug_hunt`            | boolean   | `true`               | Run all three passes after building                   |
+| `publish`             | boolean   | `false`              | Trigger GitHub Pages publication                      |
+| `--density-threshold` | string    | `nodes=50,edges=100` | Override density guard thresholds (integers 1–10,000) |
+
+### Invocation Examples
+
+```
+# Full atlas (all 8 layers + 3-pass bug hunt)
+/code-atlas
+
+# Specific layers, no bug hunt
+/code-atlas layers=3,4 bug_hunt=false
+
+# Custom journey + publish
+/code-atlas journeys="checkout: POST /api/orders" publish=true
+
+# Single service, DOT only
+/code-atlas codebase_path=services/billing diagram_formats=dot
+
+# Layer 7 only — per-service component diagrams
+/code-atlas layers=7
+
+# Layer 8 only — symbol bindings (LSP-assisted if available)
+/code-atlas layers=8
+
+# Override density thresholds for dense microservices
+/code-atlas --density-threshold nodes=100,edges=200
+
+# Layers 7+8 only — deep internal structure analysis
+/code-atlas layers=7,8 bug_hunt=false
+```
+
+---
+
+## Layer IDs
+
+| Layer | Name                           | Content                                                        |
+| ----- | ------------------------------ | -------------------------------------------------------------- |
+| 1     | Runtime Topology               | Services, containers, ports, inter-service connections         |
+| 2     | Compile-time Dependencies      | Package imports, module boundaries, external library versions  |
+| 3     | API Contracts                  | All routes, handlers, DTOs, middleware chains                  |
+| 4     | Data Flow                      | DTO-to-storage chain, transformation steps                     |
+| 5     | User Journey Scenarios         | Named end-to-end paths as sequence diagrams                    |
+| 6     | Exhaustive Inventory           | Tables: services, env vars, data stores, external deps         |
+| 7     | Service Component Architecture | Per-service module/package diagrams; internal coupling mapping |
+| 8     | AST+LSP Symbol Bindings        | Cross-file references, dead code, interface mismatches         |
+
+---
+
+## Output File Layout
+
+```
+docs/atlas/
+├── README.md                        # Atlas index
+├── staleness-map.yaml               # Glob→layer map for CI paths: filters
+│
+├── repo-surface/
+│   ├── README.md                    # Layer narrative
+│   ├── topology.dot                 # Graphviz DOT source
+│   ├── topology.mmd                 # Mermaid source
+│   └── topology.svg                 # Pre-rendered SVG (committed)
+│
+├── compile-deps/
+│   ├── README.md
+│   ├── deps.mmd
+│   ├── deps.svg
+│   └── inventory.md                 # Package inventory table (REQUIRED)
+│
+├── api-contracts/
+│   ├── README.md
+│   ├── routes.mmd
+│   ├── routes.svg
+│   └── inventory.md                 # Route inventory table (REQUIRED)
+│
+├── data-flow/
+│   ├── README.md
+│   ├── dataflow.mmd
+│   └── dataflow.svg
+│
+├── user-journeys/
+│   ├── README.md
+│   └── {journey-name}.mmd           # One file per journey (minimum 3)
+│
+├── inventory/
+│   ├── services.md                  # 6a: Service inventory (REQUIRED)
+│   ├── env-vars.md                  # 6b: Env var inventory (REQUIRED)
+│   ├── data-stores.md               # 6c: Data store inventory (REQUIRED)
+│   └── external-deps.md             # 6d: External dependency inventory (REQUIRED)
+│
+├── service-components/       # NEW in v1.1.0
+│   ├── README.md                    # Lists services analysed; analysis date
+│   ├── {service-name}.mmd           # One per service (Mermaid graph TD; SEC-11 name)
+│   └── {service-name}.svg           # Pre-rendered SVG (when mmdc available)
+│
+├── ast-lsp-bindings/         # NEW in v1.1.0
+│   ├── README.md                    # Line 1: **Mode:** lsp-assisted|static-approximation
+│   ├── symbol-references.mmd        # Cross-file reference graph
+│   ├── dead-code.md                 # Unreferenced exported symbols table
+│   └── mismatched-interfaces.md     # Call-site/definition mismatch table
+│
+├── bug-reports/
+│   ├── {YYYY-MM-DD}-pass1-{slug}.md # Pass 1 findings (contradiction hunt)
+│   ├── {YYYY-MM-DD}-pass2-{slug}.md # Pass 2 findings (fresh-eyes cross-check)
+│   └── {YYYY-MM-DD}-pass3-{slug}.md # Pass 3 findings (scenario deep-dive + verdicts)
+│
+└── experiments/                     # NEW in v1.1.0 — Appendix A records
+    └── {YYYY-MM-DD}-mermaid-vs-graphviz-L{N}.md
+```
+
+---
+
+## Staleness Trigger Table
+
+| File Pattern                                                                                                  | Layer(s) Affected | Rebuild Command              |
+| ------------------------------------------------------------------------------------------------------------- | ----------------- | ---------------------------- |
+| `docker-compose*.yml`, `k8s/**/*.yaml`, `kubernetes/**/*.yaml`, `helm/**/*.yaml`                              | 1                 | `/code-atlas rebuild layer1` |
+| `go.mod`, `package.json`, `*.csproj`, `Cargo.toml`, `requirements*.txt`, `pyproject.toml`                     | 2                 | `/code-atlas rebuild layer2` |
+| `*route*.ts`, `*route*.go`, `*controller*.go`, `*controller*.ts`, `*views*.py`, `*router*.ts`, `*handler*.go` | 3                 | `/code-atlas rebuild layer3` |
+| `*dto*.ts`, `*schema*.py`, `*_request.go`, `*_response.go`, `*types*.ts`, `*model*.go`                        | 4                 | `/code-atlas rebuild layer4` |
+| `*page*.tsx`, `*page*.ts`, `cmd/**/*.go`, `cli/**/*.py`                                                       | 5                 | `/code-atlas rebuild layer5` |
+| `.env.example`, `services/*/README.md`, `apps/*/README.md`                                                    | 6                 | `/code-atlas rebuild layer6` |
+| `**/__init__.py`, `**/package.json` (workspace), `**/*.mod`                                                   | 7                 | `/code-atlas rebuild layer7` |
+| `**/*.py`, `**/*.ts`, `**/*.go`, `**/*.cs`, `**/*.rs` (any source)                                            | 8                 | `/code-atlas rebuild layer8` |
+| Any of the above                                                                                              | All               | `/code-atlas rebuild all`    |
+
+---
+
+## Journey Schema
+
+```yaml
+journeys:
+  - name: string # Slug: used in Layer 5 filename (journey-{name}.mmd)
+    entry: string # Route or event: "POST /api/orders" or "kafka:EventName"
+    description: string # One sentence; used as sequence diagram title
+```
+
+---
+
+## BugReport Format
+
+```typescript
+interface BugReport {
+  id: string; // Slug: "route-dto-mismatch-order-customerid"
+  title: string; // One sentence
+  severity: "critical" | "major" | "minor" | "info";
+  pass: 1 | 2 | 3; // Bug-hunt pass that found this (v1.1.0: added 3)
+  layers_involved: (1 | 2 | 3 | 4 | 5 | 6 | 7 | 8)[]; // v1.1.0: extended to 8 layers
+  evidence: Evidence[];
+  recommendation: string;
+}
+
+interface Evidence {
+  type: "code-quote" | "layer-reference" | "diagram-annotation";
+  file: string; // Relative path from codebase root — NEVER absolute (SEC-16)
+  line?: number;
+  content: string; // Quoted code or layer data (credentials redacted per SEC-09)
+}
+```
+
+**Pass semantics:**
+
+| Pass | Name                       | Description                                                |
+| ---- | -------------------------- | ---------------------------------------------------------- |
+| 1    | Comprehensive Build + Hunt | Structural contradictions found during atlas construction  |
+| 2    | Fresh-Eyes Cross-Check     | Independent re-examination without Pass 1 anchoring        |
+| 3    | Scenario Deep-Dive         | Per-journey traces; also produces `JourneyVerdict` objects |
+
+## JourneyVerdict Format (Pass 3)
+
+```typescript
+interface JourneyVerdict {
+  journey_name: string; // Matches a Layer 5 journey name
+  verdict: "PASS" | "FAIL" | "NEEDS_ATTENTION";
+  criteria: VerdictCriterion[];
+  rationale: string; // Required one paragraph
+}
+
+interface VerdictCriterion {
+  criterion: string;
+  status: "pass" | "fail" | "attention";
+  evidence: string; // "file:line" (relative) or "no evidence found"
+}
+```
+
+**Verdict levels:**
+
+| Verdict           | Condition                               |
+| ----------------- | --------------------------------------- |
+| `PASS`            | All criteria: `pass`                    |
+| `FAIL`            | ≥1 criterion: `fail`                    |
+| `NEEDS_ATTENTION` | ≥1 criterion: `attention`; none: `fail` |
+
+## Density Threshold Configuration
+
+```
+Default: nodes=50, edges=100
+Override: /code-atlas --density-threshold nodes=N,edges=M
+Valid range: 1–10,000 for both values (SEC-13)
+```
+
+When triggered, the required prompt wording is:
+
+```
+This diagram has {N} nodes and {M} edges, which may render poorly.
+Please choose:
+  (a) Full diagram anyway
+  (b) Simplified/clustered diagram
+  (c) Table representation
+```
+
+Only `a`, `b`, or `c` are accepted (SEC-14). Selecting `c` emits `DENSITY_THRESHOLD_EXCEEDED` in the completion summary. No other input is silently accepted or defaulted.
+
+---
+
+## Severity Levels
+
+| Severity | Definition                                | Example                              |
+| -------- | ----------------------------------------- | ------------------------------------ |
+| critical | System cannot function; data loss risk    | Missing required route handler       |
+| major    | Feature broken; incorrect behavior        | Route reads field not in DTO         |
+| minor    | Degraded behavior; workaround exists      | Orphaned env var declared but unused |
+| info     | Documentation drift; no functional impact | README references removed route      |
+
+---
+
+## Language Support Matrix
+
+| Language   | Layer 1 | Layer 2 | Layer 3 | Layer 4 | Notes                                      |
+| ---------- | ------- | ------- | ------- | ------- | ------------------------------------------ |
+| Go         | 90%     | 95%     | 80%     | 85%     | `handler*.go` and `model*.go` covered      |
+| TypeScript | 90%     | 90%     | 85%     | 90%     | NestJS decorators require extra patterns   |
+| Python     | 90%     | 90%     | 80%     | 80%     | Delegates to `code-visualizer` for Layer 2 |
+| .NET (C#)  | 85%     | 85%     | 75%     | 80%     | Controllers + minimal API both covered     |
+| Rust       | 85%     | 80%     | 70%     | 70%     | axum + actix-web patterns covered          |
+| Java       | 60%     | 65%     | 60%     | 60%     | Spring Boot basic patterns                 |
+| GraphQL    | —       | —       | 40%     | 40%     | Resolver mapping requires special handling |
+
+---
+
+## Exit Codes
+
+### check-atlas-staleness.sh
+
+| Code | Meaning                          |
+| ---- | -------------------------------- |
+| 0    | Atlas is fresh — no stale layers |
+| 1    | One or more layers are stale     |
+| 2    | Usage error                      |
+
+### rebuild-atlas-all.sh
+
+| Code | Meaning                                                 |
+| ---- | ------------------------------------------------------- |
+| 0    | Success                                                 |
+| 1    | Error (not a git repo, not writable, validation failed) |
+
+---
+
+## Error Codes
+
+| Code                         | Layer   | Meaning                                           | Fallback                                |
+| ---------------------------- | ------- | ------------------------------------------------- | --------------------------------------- |
+| `LAYER_SOURCE_NOT_FOUND`     | Any     | No source files matched for this layer            | Layer skipped; build continues          |
+| `DELEGATION_FAILED`          | Any     | Sub-skill/agent returned invalid output           | `analyzer` agent used instead           |
+| `DOT_RENDER_FAILED`          | 1–5     | Graphviz not installed or DOT syntax invalid      | Mermaid-only output                     |
+| `SVG_TOO_LARGE`              | Any     | mmdc produced SVG exceeding 5MB                   | SVG skipped; source file kept           |
+| `PUBLISH_FAILED`             | publish | GitHub Pages push failed                          | Output written locally only             |
+| `JOURNEY_UNDER_MINIMUM`      | 5       | Fewer than 3 journeys derived                     | Build continues with available journeys |
+| `INCOMPLETE_INVENTORY`       | 6       | Required inventory columns missing                | Partial table written with warning      |
+| `FILE_TOO_LARGE`             | Any     | File exceeds 10MB size limit                      | File skipped (SEC-08)                   |
+| `DENSITY_THRESHOLD_EXCEEDED` | density | User selected table via density prompt (option c) | Table written; SkillError logged        |
+| `LAYER7_SOURCE_NOT_FOUND`    | 7       | No intra-service structure discoverable           | Layer 7 skipped for that service        |
+| `LAYER8_LSP_UNAVAILABLE`     | 8       | LSP tooling not found                             | Static-approximation mode used          |
+
+---
+
+## Environment Variables
+
+No environment variables are required by the skill itself. The CI scripts read these from the GitHub Actions environment:
+
+| Variable          | Script              | Purpose                            |
+| ----------------- | ------------------- | ---------------------------------- |
+| `GITHUB_BASE_REF` | Used by `--pr` mode | Base branch for PR diff            |
+| `GITHUB_SHA`      | Used in build stamp | Current commit SHA                 |
+| `GITHUB_TOKEN`    | atlas-ci.yml        | GitHub API auth for issue creation |
+
+---
+
+## Inventory Table Column Schemas
+
+**Route Inventory (Layer 3 — `api-contracts/inventory.md`):**
+
+| Column       | Required | Description                                  |
+| ------------ | -------- | -------------------------------------------- |
+| Method       | Yes      | HTTP verb: GET, POST, PUT, PATCH, DELETE     |
+| Path         | Yes      | URL path with placeholders: `/api/users/:id` |
+| Handler      | Yes      | Handler function: `UserController.create`    |
+| Auth         | Yes      | `None`, `JWT`, `API Key`, etc.               |
+| Request DTO  | No       | Input DTO name or `—`                        |
+| Response DTO | No       | Output DTO name or `—`                       |
+| Middleware   | No       | Comma-separated middleware names             |
+
+**Env Var Inventory (Layer 6b — `inventory/env-vars.md`):**
+
+| Column      | Required | Description                                 |
+| ----------- | -------- | ------------------------------------------- |
+| Variable    | Yes      | Key name only (never the value)             |
+| Required    | Yes      | `yes` or `no`                               |
+| Default     | No       | Default value if not set, or `—`            |
+| Used By     | Yes      | Service(s) that reference this variable     |
+| Declared In | Yes      | File where it is documented: `.env.example` |
+
+**Env var classification logic:**
+
+- `Required: yes` — if the service fails to start without it (database URLs, JWT secrets)
+- `Required: no` — if there is a default value or the feature degrades gracefully
+- Source of truth: `.env.example` (canonical), `.env.production`, `.env.staging` (environment-specific overrides)
+- `.env.local` and `.env.development` are excluded (developer overrides, not part of inventory)
+
+**Circular dependency representation (Layer 2):**
+Cycles in the dependency graph appear as bi-directional edges in the diagram:
+
+```mermaid
+A -->|import| B
+B -->|import| A
+```
+
+Cycles are always filed as `severity: major` bugs in `bug-reports/` with the cycle path documented in the evidence. A cycle in `compile-deps` means the build order is undefined and refactoring is required.

--- a/docs/reference/copilot-installation-implementation.md
+++ b/docs/reference/copilot-installation-implementation.md
@@ -1,0 +1,447 @@
+# Reference: Copilot CLI Installation Implementation
+
+Technical reference for maintainers of the Copilot CLI installation system.
+
+## Architecture
+
+### Installation Flow
+
+```
+┌─────────────────────────────────────┐
+│ launch_copilot()                    │
+│                                     │
+│ 1. Check if already installed      │
+│    shutil.which("copilot")         │
+│                                     │
+│ 2. Install if needed               │
+│    install_copilot()               │
+│    - Runs npm install -g           │
+│    - Returns True/False            │
+│                                     │
+│ 3. Report status                   │
+│    - Trust installer return value  │
+│    - Print success/failure         │
+│    - Exit with appropriate code    │
+│                                     │
+│ 4. Launch CLI                      │
+│    subprocess.run(["copilot"])     │
+└─────────────────────────────────────┘
+```
+
+### Current binary contract
+
+The current runtime launches the `copilot` CLI from `@github/copilot`. Older
+references to `github-copilot-cli` below are historical and should not be read
+as the current install/launch contract.
+
+### Module Structure
+
+**File**: `amplihack/launcher/__init__.py`
+
+```python
+def launch_copilot() -> None:
+    """Launch GitHub Copilot CLI, installing if needed."""
+
+def install_copilot() -> bool:
+    """Install GitHub Copilot CLI via npm.
+
+    Returns:
+        True if installation succeeded, False otherwise
+    """
+```
+
+## Implementation Details
+
+### Installation Check
+
+**Function**: `shutil.which("copilot")`
+
+**Purpose**: Check if Copilot CLI binary is in PATH
+
+**Behavior**:
+
+- Returns full path if found: `/home/user/.local/bin/copilot`
+- Returns `None` if not found
+- Searches current process's PATH environment variable
+- Does not search outside PATH
+
+**Limitations**:
+
+- Only sees PATH at process start time
+- Does not detect binaries added after process starts
+- Subprocess environment may differ from parent
+
+### Installation Process
+
+**Function**: `install_copilot()`
+
+**Implementation**:
+
+```python
+def install_copilot() -> bool:
+    """Install GitHub Copilot CLI via npm."""
+    try:
+        result = subprocess.run(
+            ["npm", "install", "-g", "@github/copilot"],
+            check=False,  # Don't raise on failure
+            capture_output=True,
+            text=True
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        # npm not found
+        return False
+    except Exception as e:
+        print(f"Installation error: {e}")
+        return False
+```
+
+**Validation**:
+
+- Checks npm exit code (0 = success)
+- Does NOT re-verify with `shutil.which()`
+- Trusts npm's success indication
+
+**Why trust npm exit code?**
+
+- npm validates installation internally
+- Exit code 0 guarantees success
+- Binary is written before npm exits
+- Avoids PATH propagation race condition
+
+### Status Reporting
+
+**Success Path**:
+
+```python
+if not shutil.which("github-copilot-cli"):
+    success = install_copilot()
+    if not success:
+        print("Failed to install Copilot CLI")
+        sys.exit(1)
+    print("Successfully installed Copilot CLI")
+```
+
+**Failure Path**:
+
+```python
+# npm install failed
+if not success:
+    print("Failed to install Copilot CLI")
+    sys.exit(1)
+```
+
+## Bug History
+
+### Original Bug (v0.3.1)
+
+**Code**:
+
+```python
+if not shutil.which("github-copilot-cli"):
+    success = install_copilot()
+
+    # Redundant verification (BUG)
+    if not shutil.which("github-copilot-cli"):
+        print("Failed to install Copilot CLI")
+        sys.exit(1)
+```
+
+**Issue**: Redundant `shutil.which()` check after installation
+
+**Root Cause**: PATH propagation timing
+
+**Symptoms**: False negative when installation succeeded
+
+### The Fix (v0.3.2)
+
+**Change**: Remove redundant verification
+
+**Code**:
+
+```python
+if not shutil.which("github-copilot-cli"):
+    success = install_copilot()
+    if not success:
+        print("Failed to install Copilot CLI")
+        sys.exit(1)
+    print("Successfully installed Copilot CLI")
+```
+
+**Result**: Accurate status reporting
+
+## PATH Propagation
+
+### The Problem
+
+**Scenario**: Install binary, check PATH immediately
+
+**What happens**:
+
+1. npm installs binary to `~/.local/bin/github-copilot-cli`
+2. Binary exists on disk
+3. Shell updates PATH (asynchronously)
+4. Current process hasn't seen PATH update yet
+5. `shutil.which()` can't find binary
+
+**Timeline**:
+
+```
+T+0ms:  npm install starts
+T+100ms: Binary written to disk
+T+110ms: npm exits with code 0
+T+120ms: Shell updates PATH
+T+130ms: shutil.which() checks PATH (binary not visible yet)
+T+200ms: PATH propagates to current process
+```
+
+**Solution**: Trust installer exit code, don't re-check PATH
+
+### Platform Differences
+
+**Linux/macOS**:
+
+- PATH updates propagate to child processes
+- Parent process sees stale PATH
+- `shutil.which()` searches parent's PATH
+
+**Windows**:
+
+- Similar behavior with different timing
+- Registry updates may be involved
+- Environment blocks cached per process
+
+## Testing Strategy
+
+### Unit Tests
+
+**Test**: Installation triggers when needed
+
+```python
+def test_launch_copilot_installs_when_missing(monkeypatch):
+    """Verify installation happens when CLI not found."""
+    with patch('shutil.which', return_value=None), \
+         patch('amplihack.launcher.install_copilot', return_value=True), \
+         patch('subprocess.run'):
+        launch_copilot()
+        # Should succeed without raising
+```
+
+**Test**: Failure reported accurately
+
+```python
+def test_launch_copilot_reports_install_failure(monkeypatch):
+    """Verify failure message when installation fails."""
+    with patch('shutil.which', return_value=None), \
+         patch('amplihack.launcher.install_copilot', return_value=False):
+        with pytest.raises(SystemExit) as exc:
+            launch_copilot()
+        assert exc.value.code == 1
+```
+
+**Test**: No installation when already present
+
+```python
+def test_launch_copilot_skips_install_when_present(monkeypatch):
+    """Verify no installation when CLI already exists."""
+    install_mock = Mock()
+    with patch('shutil.which', return_value='/usr/bin/github-copilot-cli'), \
+         patch('amplihack.launcher.install_copilot', install_mock), \
+         patch('subprocess.run'):
+        launch_copilot()
+        install_mock.assert_not_called()
+```
+
+### Integration Tests
+
+**Test**: Fresh installation
+
+```bash
+# Remove Copilot CLI
+npm uninstall -g github-copilot-cli
+
+# Verify not installed
+! which github-copilot-cli
+
+# Run amplihack
+amplihack copilot
+
+# Verify success
+test $? -eq 0
+which github-copilot-cli
+```
+
+**Test**: Existing installation
+
+```bash
+# Ensure installed
+npm install -g github-copilot-cli
+
+# Run amplihack (should skip install)
+amplihack copilot
+
+# Verify success
+test $? -eq 0
+```
+
+## Error Handling
+
+### npm Not Found
+
+```python
+try:
+    result = subprocess.run(["npm", ...])
+except FileNotFoundError:
+    return False  # npm not installed
+```
+
+**User sees**: "Failed to install Copilot CLI"
+
+**Solution**: Install npm: `sudo apt install npm`
+
+### npm Install Failure
+
+**Causes**:
+
+- Network issues
+- Permissions problems
+- Disk space exhausted
+- Package not found
+
+**Detection**: `result.returncode != 0`
+
+**User sees**: "Failed to install Copilot CLI"
+
+**Solution**: Check npm logs: `npm install -g github-copilot-cli`
+
+### Permission Denied
+
+**Cause**: Global npm install requires write access
+
+**Detection**: npm exit code, stderr contains "EACCES"
+
+**Solution**: Use `sudo` or configure npm prefix:
+
+```bash
+npm config set prefix ~/.local
+export PATH=~/.local/bin:$PATH
+```
+
+## Design Decisions
+
+### Why Trust npm Exit Code?
+
+**Options considered**:
+
+1. Trust npm exit code (chosen)
+2. Re-verify with `shutil.which()`
+3. Check binary exists on disk
+4. Test execution with `--version`
+
+**Decision**: Trust npm exit code
+
+**Rationale**:
+
+- npm validates internally before exiting
+- Avoids PATH propagation timing issues
+- Simplest implementation
+- npm exit codes are reliable (industry standard)
+
+### Why Not Test Execution?
+
+**Alternative**: Run `github-copilot-cli --version` to verify
+
+**Rejected because**:
+
+- Adds complexity (parse version output)
+- Same PATH propagation issue
+- Unnecessary overhead
+- npm validation is sufficient
+
+### Why No Retry Logic?
+
+**Alternative**: Retry if verification fails
+
+**Rejected because**:
+
+- Masks real installation failures
+- Delays feedback to user
+- npm should succeed or fail definitively
+- Retries won't fix PATH timing (not a transient error)
+
+## Maintenance Notes
+
+### When to Modify
+
+**Change installer if**:
+
+- npm package name changes
+- Installation method changes (not npm)
+- Different global vs. local install needed
+
+**Don't change if**:
+
+- Seeing "PATH not propagated" issues (by design)
+- Want to verify installation (trust npm)
+- Need to support alternative install methods (use separate function)
+
+### Testing Checklist
+
+Before releasing changes:
+
+- [ ] Unit tests pass
+- [ ] Integration test on fresh system
+- [ ] Test with Copilot already installed
+- [ ] Test with npm not installed
+- [ ] Test with permission denied errors
+- [ ] Test on Linux, macOS, Windows
+- [ ] Exit codes correct (0 success, 1 failure)
+- [ ] Messages clear and accurate
+
+### Code Review Focus
+
+**Check these during review**:
+
+1. **No redundant verification**: Don't re-check after installation
+2. **Trust installer**: Use return value, not PATH lookup
+3. **Exit codes correct**: 0 for success, 1 for failure
+4. **Messages accurate**: Match actual result
+5. **Error handling**: Catch npm not found, install failures
+
+## Related Code
+
+**Files**:
+
+- `amplihack/launcher/__init__.py` - Main implementation
+- `tests/test_launcher.py` - Unit tests
+- `scripts/install.sh` - Installation script
+
+**Dependencies**:
+
+- `shutil.which()` - PATH lookup
+- `subprocess.run()` - Execute npm, launch CLI
+- `sys.exit()` - Exit with status code
+
+## Future Improvements
+
+### Potential Enhancements
+
+1. **Verbose mode**: Show npm output on failure
+2. **Offline install**: Support installing from cache
+3. **Version check**: Verify minimum version requirements
+4. **Auto-upgrade**: Detect outdated installation
+5. **Alternative installers**: Support pip, brew, etc.
+
+### Not Recommended
+
+1. **Retry verification**: Masks real issues
+2. **PATH manipulation**: Fragile, platform-specific
+3. **Binary download**: npm handles this better
+4. **Version pinning**: Users may want latest
+
+---
+
+**Audience**: Maintainers and contributors
+**Scope**: Implementation details
+**Last Updated**: 2025-02-13
+**Version**: 0.3.2

--- a/docs/reference/copilot-parity-control-plane.md
+++ b/docs/reference/copilot-parity-control-plane.md
@@ -1,0 +1,229 @@
+---
+title: "Copilot Parity Control Plane Reference"
+description: "Reference for the Copilot launcher wrapper contract, XPIA precedence, Rust runner discovery, and nested Copilot normalization."
+last_updated: 2026-04-02
+review_schedule: as-needed
+owner: amplihack
+doc_type: reference
+---
+
+# Copilot Parity Control Plane Reference
+
+## Overview
+
+The Copilot parity control plane gives GitHub Copilot CLI the same staged amplihack surfaces that Claude Code receives through `.claude/` settings, while respecting Copilot's native `.github/` hook and agent discovery model.
+
+## Components
+
+| Component                          | Path                                               | Responsibility                                                                                                       |
+| ---------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Copilot launcher                   | `src/amplihack/launcher/copilot.py`                | Stages agents, hooks, commands, recipes, and generated wrappers before launching Copilot CLI                         |
+| Rust recipe runner bridge          | `src/amplihack/recipes/rust_runner.py`             | Discovers `recipe-runner-rs`, enforces version compatibility, builds subprocess environment, and parses JSON results |
+| Nested Copilot compatibility layer | `src/amplihack/recipes/rust_runner_copilot.py`     | Merges prompt fragments and injects permissive defaults only when explicit Copilot permission flags are absent       |
+| Smart-orchestrator classify step   | `amplifier-bundle/recipes/smart-orchestrator.yaml` | Case-switches on `AMPLIHACK_AGENT_BINARY` to omit Claude-only flags for Copilot/codex binaries                       |
+| Canonical XPIA hook                | `.claude/tools/xpia/hooks/pre_tool_use.py`         | Fail-closed Bash policy evaluation backed by `xpia-defend`                                                           |
+| XPIA compatibility shim            | `.claude/tools/xpia/hooks/pre_tool_use_rust.py`    | Delegates to `pre_tool_use.py` so both historical entrypoints behave identically                                     |
+| Generated wrapper                  | `.github/hooks/pre-tool-use`                       | Emits the single Copilot-facing permission payload after evaluating amplihack and XPIA outputs                       |
+
+## Generated Copilot Hook Wrappers
+
+| Wrapper                            | Generated scripts                                              | Notes                                                                |
+| ---------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `.github/hooks/session-start`      | `session_start.py`                                             | Single-script wrapper                                                |
+| `.github/hooks/session-stop`       | `stop.py`, `session_stop.py`                                   | Multi-script wrapper; captures stdin once and pipes it to both hooks |
+| `.github/hooks/pre-tool-use`       | `pre_tool_use.py` plus XPIA `pre_tool_use.py`                  | Special wrapper with JSON aggregation                                |
+| `.github/hooks/post-tool-use`      | `post_tool_use.py`                                             | Single-script wrapper                                                |
+| `.github/hooks/user-prompt-submit` | `user_prompt_submit.py`, `workflow_classification_reminder.py` | Multi-script wrapper                                                 |
+
+## Pre-Tool-Use Decision Precedence
+
+The generated `.github/hooks/pre-tool-use` wrapper evaluates both hook stacks and emits one final JSON object.
+
+| Priority | Source    | Accepted signal                                  | Result                                                   |
+| -------- | --------- | ------------------------------------------------ | -------------------------------------------------------- |
+| 1        | XPIA      | `permissionDecision` = `allow`, `deny`, or `ask` | Return the XPIA payload unchanged                        |
+| 2        | amplihack | `permissionDecision` = `allow`, `deny`, or `ask` | Return the amplihack payload unchanged                   |
+| 3        | amplihack | `block: true`                                    | Convert to `{"permissionDecision":"deny","message":...}` |
+| 4        | none      | no explicit decision                             | Return `{}`                                              |
+
+This contract keeps XPIA in control of explicit Bash security decisions while preserving existing amplihack block semantics.
+
+## XPIA Hook Contract
+
+### Input
+
+`pre_tool_use.py` accepts JSON on stdin or as the first argv value.
+
+```json
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "pwd"
+  },
+  "cwd": "/path/to/repo",
+  "session_id": "optional-session-id"
+}
+```
+
+### Output
+
+Allow:
+
+```json
+{}
+```
+
+Deny:
+
+```json
+{
+  "permissionDecision": "deny",
+  "message": "..."
+}
+```
+
+### Canonical and compatibility entrypoints
+
+| Entrypoint                                      | Behavior                        |
+| ----------------------------------------------- | ------------------------------- |
+| `.claude/tools/xpia/hooks/pre_tool_use.py`      | Canonical fail-closed hook      |
+| `.claude/tools/xpia/hooks/pre_tool_use_rust.py` | Delegates to the canonical hook |
+
+### Audit logging
+
+The canonical XPIA hook writes audit events to:
+
+```text
+~/.claude/logs/xpia/rust_security_YYYYMMDD.log
+```
+
+## Rust Runner Discovery and Execution
+
+### Binary discovery order
+
+`rust_runner.py` resolves the runner in this order:
+
+1. `RECIPE_RUNNER_RS_PATH`
+2. `recipe-runner-rs` on `PATH`
+3. `~/.cargo/bin/recipe-runner-rs`
+4. `~/.local/bin/recipe-runner-rs`
+
+If the runner is still missing, the bridge raises `RustRunnerNotFoundError`.
+
+### Version gating
+
+The bridge checks the discovered binary before execution. Unknown, unparseable, or too-old versions are rejected with an explicit version error. The Rust-selected path does not silently fall back to a Python runner.
+
+### Startup banners
+
+The bridge emits two stderr banners during execution:
+
+```text
+[amplihack] recipe-runner --- starting: <recipe>
+[amplihack] recipe-runner --- executing: <recipe>
+```
+
+### Response contract
+
+The Rust runner must emit JSON on stdout. If stdout is unparseable:
+
+- non-zero exit codes become explicit runtime errors
+- signal termination is surfaced as a signal-specific error
+- empty or malformed stdout becomes an "unparseable output" error
+
+## Smart-Orchestrator Classify Step
+
+The `classify-and-decompose` step in `smart-orchestrator.yaml` uses a `bash`
+step type with a case-switch on `AMPLIHACK_AGENT_BINARY`:
+
+| Binary pattern         | Flags used                                                                       | Classifier constraint               |
+| ---------------------- | -------------------------------------------------------------------------------- | ----------------------------------- |
+| `*copilot*`, `*codex*` | `--allow-all-tools`                                                              | Injected into prompt text           |
+| `*` (default/claude)   | `--dangerously-skip-permissions`, `--disallowed-tools`, `--append-system-prompt` | Passed via `--append-system-prompt` |
+
+Both branches unset `CLAUDECODE` via `env -u CLAUDECODE` to prevent the
+subprocess from detecting a parent Claude Code session, which would alter
+agent behavior. Both branches deliver the prompt via `-p`.
+
+On failure, the step emits the binary name, exit code, and stderr content (or a
+diagnostic hint if stderr is empty) before propagating the exit code.
+
+## Nested Copilot Normalization Rules
+
+The compatibility layer normalizes nested Copilot launches created by the Rust recipe runner.
+
+### Prompt merging
+
+The normalizer removes and merges these flags into one final `-p` payload:
+
+- `--system-prompt`
+- `--append-system-prompt`
+- `-p`
+- `--prompt=`
+
+Merged prompt parts are joined with a blank line.
+
+The normalizer also drops Claude-only `--dangerously-skip-permissions` because
+Copilot CLI does not accept it.
+
+### Permission preservation
+
+The normalizer treats these as explicit tool-permission flags:
+
+- `--allow-all-tools`
+- `--allow-tool`
+- `--deny-tool`
+
+It treats these as explicit path-permission flags:
+
+- `--allow-all-paths`
+- `--allow-path`
+- `--deny-path`
+
+If no explicit tool or path permission appears, it prefixes the nested command with:
+
+```text
+--allow-all-tools --allow-all-paths
+```
+
+If explicit flags are already present, it preserves them and does not widen permissions.
+
+When a Claude-oriented nested launch passes `--disallowed-tools`, the normalizer
+removes that unsupported flag, treats it as an explicit no-tools decision, and
+adds a no-tools instruction to the merged prompt. That prevents the wrapper from
+re-introducing `--allow-all-tools` behind the caller's back.
+
+## Environment Variables
+
+| Variable                        | Scope                      | Default     | Meaning                                               |
+| ------------------------------- | -------------------------- | ----------- | ----------------------------------------------------- |
+| `AMPLIHACK_AGENT_BINARY`        | launcher and nested runner | `claude`    | Selects the agent binary for nested recipe execution  |
+| `AMPLIHACK_HOOK_ENGINE`         | launcher                   | auto-detect | Selects `rust` or `python` for amplihack hook staging |
+| `RECIPE_RUNNER_RS_PATH`         | Rust runner bridge         | unset       | Explicit path to `recipe-runner-rs`                   |
+| `RECIPE_RUNNER_INSTALL_TIMEOUT` | Rust runner install helper | `300`       | Timeout, in seconds, for auto-install attempts        |
+
+## Context Spillover Rules
+
+Large recipe context values are passed safely.
+
+| Limit                   | Behavior                                             |
+| ----------------------- | ---------------------------------------------------- |
+| `< 32,768` UTF-8 bytes  | Passed inline via `--set key=value`                  |
+| `>= 32,768` UTF-8 bytes | Spilled to a temp file and passed as a `file://` URI |
+
+Spill directories are created with `tempfile.mkdtemp(...)`, which produces a private process-scoped directory and avoids predictable temp paths.
+
+## Safe Command Example
+
+```bash
+printf '%s\n' '{"tool_name":"Bash","tool_input":{"command":"pwd"}}' \
+  | python3 .claude/tools/xpia/hooks/pre_tool_use.py
+# Output: {}
+```
+
+## Related Documents
+
+- [Tutorial: Enable the Copilot parity control plane](../tutorials/copilot-parity-control-plane.md)
+- [How to Configure the Copilot Parity Control Plane](../howto/configure-copilot-parity-control-plane.md)
+- [Understanding the Copilot Parity Control Plane](../concepts/copilot-parity-control-plane.md)
+- [Hooks Comparison](../concepts/hooks-comparison.md)

--- a/docs/reference/github-pages-api.md
+++ b/docs/reference/github-pages-api.md
@@ -1,0 +1,779 @@
+# GitHub Pages API Reference
+
+Complete Python API reference for generating, validating, and deploying documentation sites to GitHub Pages.
+
+## Module
+
+```python
+from claude_skills.documentation_writing.github_pages import (
+    # Configuration
+    SiteConfig,
+    DeploymentConfig,
+    # Results
+    GenerationResult,
+    ValidationResult,
+    ValidationIssue,
+    DeploymentResult,
+    # Functions
+    generate_site,
+    validate_site,
+    deploy_site,
+    preview_locally,
+)
+```
+
+## Functions
+
+### generate_site()
+
+Generate a documentation site using MkDocs with Material theme.
+
+```python
+def generate_site(config: SiteConfig) -> GenerationResult:
+    """Generate documentation site using MkDocs.
+
+    Args:
+        config: Site configuration
+
+    Returns:
+        GenerationResult with success status and details
+
+    Raises:
+        FileNotFoundError: If docs_dir doesn't exist
+        PermissionError: If unable to write to output directory
+        subprocess.CalledProcessError: If mkdocs build fails
+    """
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/generator.py:23`](#)
+
+**Example**:
+
+```python
+from claude_skills.documentation_writing.github_pages import SiteConfig, generate_site
+
+config = SiteConfig(
+    project_name="amplihack",
+    project_url="https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding",
+    docs_dir="docs",
+    output_dir="site",
+)
+
+result = generate_site(config)
+
+if result.success:
+    print(f"Generated {len(result.pages)} pages at {result.site_dir}")
+    print(f"Configuration written to {result.config_file}")
+else:
+    print(f"Generation failed: {result.errors}")
+
+# Check warnings (non-fatal issues)
+for warning in result.warnings:
+    print(f"Warning: {warning}")
+```
+
+**Content Discovery**:
+
+The generator automatically discovers:
+
+- All `*.md` files in `docs_dir` (recursive)
+- `README.md` in project root (copied to `docs/index.md` if no index exists)
+- CLI command help text (from `amplihack --help`)
+
+**What It Creates**:
+
+- `mkdocs.yml` - MkDocs configuration file
+- `site/` - Generated HTML documentation
+- `site/.nojekyll` - Disables Jekyll processing on GitHub Pages
+
+---
+
+### validate_site()
+
+Run three-pass validation on generated documentation site.
+
+```python
+def validate_site(site_dir: Path | str) -> ValidationResult:
+    """Run complete three-pass validation on documentation site.
+
+    Args:
+        site_dir: Path to generated site directory
+
+    Returns:
+        ValidationResult with scores from all three passes
+
+    Raises:
+        FileNotFoundError: If site_dir doesn't exist
+    """
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/validator.py:53`](#)
+
+**Example**:
+
+```python
+from claude_skills.documentation_writing.github_pages import validate_site
+
+validation = validate_site("site")
+
+# Check overall pass/fail
+if validation.passed:
+    print("Documentation meets all quality standards")
+else:
+    print("Documentation needs improvement")
+
+# Review individual pass scores
+print(f"Pass 1 - Coverage: {validation.pass1_coverage}%")
+print(f"Pass 2 - Clarity: {validation.pass2_clarity_score}%")
+print(f"Pass 3 - Grounded: {validation.pass3_grounded_pct}%")
+
+# Review all issues
+for issue in validation.issues:
+    print(f"\n[{issue.severity.upper()}] Pass {issue.pass_number}")
+    print(f"Location: {issue.location}")
+    print(f"Message: {issue.message}")
+    if issue.suggestion:
+        print(f"Suggestion: {issue.suggestion}")
+```
+
+**Validation Passes**:
+
+1. **Pass 1 - Coverage** (target: 100%):
+   - Checks that all features are documented
+   - If no features list provided, verifies basic documentation exists
+
+2. **Pass 2 - Clarity** (target: ≥ 80%):
+   - Navigation depth (≤ 3 levels recommended)
+   - Descriptive headings (not "Overview", "Introduction")
+   - Contextful links (not "click here")
+   - Content structure (no walls of text > 300 words)
+
+3. **Pass 3 - Reality** (target: ≥ 95%):
+   - No future tense ("will be", "coming soon")
+   - No TODO markers
+   - No placeholder examples (foo, bar, example.com)
+   - Exception: `[PLANNED]` sections are allowed
+
+**Overall Pass Criteria**:
+
+```python
+passed = (
+    coverage >= 100.0
+    and clarity >= 80.0
+    and grounded >= 95.0
+)
+```
+
+---
+
+### deploy_site()
+
+Deploy generated documentation site to GitHub Pages.
+
+```python
+def deploy_site(config: DeploymentConfig) -> DeploymentResult:
+    """Deploy documentation site to GitHub Pages.
+
+    Args:
+        config: Deployment configuration
+
+    Returns:
+        DeploymentResult with deployment status
+
+    Raises:
+        TypeError: If config is None
+        ValueError: If site_dir doesn't exist or is empty
+        PermissionError: If unable to copy files
+    """
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/deployer.py:20`](#)
+
+**Example**:
+
+```python
+from claude_skills.documentation_writing.github_pages import DeploymentConfig, deploy_site
+
+config = DeploymentConfig(
+    site_dir="site",
+    repo_path=".",
+    commit_message="Update documentation [skip ci]",
+    force_push=False,  # Never force push unless you know what you're doing
+)
+
+result = deploy_site(config)
+
+if result.success:
+    print(f"Deployed successfully")
+    print(f"Branch: {result.branch}")
+    print(f"Commit: {result.commit_sha}")
+    print(f"URL: {result.url}")
+else:
+    print(f"Deployment failed")
+    for error in result.errors:
+        print(f"  Error: {error}")
+```
+
+**Deployment Process**:
+
+1. Validates `site_dir` exists and has content
+2. Checks git status (warns if uncommitted changes)
+3. Saves current branch name
+4. Creates or switches to `gh-pages` branch
+5. Clears all files except `.git`
+6. Copies site contents to repository root
+7. Adds `.nojekyll` file
+8. Commits changes
+9. Pushes to remote
+10. Returns to original branch
+
+**Rollback on Failure**:
+
+If deployment fails, the deployer automatically:
+
+- Rolls back to the original branch
+- Preserves local uncommitted changes
+- Returns detailed error messages
+
+**Safety Features**:
+
+- Never force pushes by default (`force_push=False`)
+- Validates branch names for security
+- Validates GitHub URLs for security
+- No auto-installation of dependencies
+
+---
+
+### preview_locally()
+
+Start local preview server for documentation site.
+
+```python
+def preview_locally(config_path: Path | str = "mkdocs.yml", port: int = 8000) -> None:
+    """Start local preview server for documentation site.
+
+    Args:
+        config_path: Path to mkdocs.yml configuration
+        port: Port to serve on (default: 8000)
+
+    Note:
+        This function blocks until the server is stopped (Ctrl+C).
+    """
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/generator.py:145`](#)
+
+**Example**:
+
+```python
+from claude_skills.documentation_writing.github_pages import preview_locally
+
+# Starts server at http://127.0.0.1:8000
+# Press Ctrl+C to stop
+preview_locally(config_path="mkdocs.yml", port=8000)
+```
+
+**Preview Features**:
+
+- Auto-reloads on file changes
+- Watches `docs/` directory
+- Live preview at `http://127.0.0.1:8000`
+- Blocking function (use Ctrl+C to stop)
+
+**Alternative** - Use MkDocs CLI directly:
+
+```bash
+mkdocs serve --dev-addr 127.0.0.1:8000
+```
+
+---
+
+## Configuration Classes
+
+### SiteConfig
+
+Configuration for documentation site generation.
+
+```python
+@dataclass
+class SiteConfig:
+    """Configuration for site generation.
+
+    Attributes:
+        project_name: Name of the project (used in site title)
+        project_url: GitHub repository URL
+        docs_dir: Path to documentation directory (default: "docs")
+        output_dir: Path for generated site output (default: "site")
+        theme: MkDocs theme to use (default: "material")
+        theme_features: List of Material theme features to enable
+        nav_structure: Custom navigation structure (auto-generated if None)
+    """
+
+    project_name: str
+    project_url: str
+    docs_dir: str | Path = "docs"
+    output_dir: str | Path = "site"
+    theme: str = "material"
+    theme_features: list[str] | None = None
+    nav_structure: dict | None = None
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/__init__.py:31`](#)
+
+**Example with Defaults**:
+
+```python
+from claude_skills.documentation_writing.github_pages import SiteConfig
+
+config = SiteConfig(
+    project_name="My Project",
+    project_url="https://github.com/user/repo",
+)
+# Uses defaults: docs_dir="docs", output_dir="site", theme="material"
+```
+
+**Example with Custom Theme Features**:
+
+```python
+config = SiteConfig(
+    project_name="My Project",
+    project_url="https://github.com/user/repo",
+    theme_features=[
+        "navigation.tabs",
+        "navigation.sections",
+        "navigation.expand",
+        "navigation.top",
+        "search.highlight",
+        "search.suggest",
+        "search.share",
+        "content.code.copy",
+        "content.code.annotate",
+    ],
+)
+```
+
+**Example with Custom Navigation**:
+
+```python
+config = SiteConfig(
+    project_name="My Project",
+    project_url="https://github.com/user/repo",
+    nav_structure={
+        "Home": "index.md",
+        "Getting Started": [
+            {"Installation": "getting-started/install.md"},
+            {"Quick Start": "getting-started/quick-start.md"},
+        ],
+        "API Reference": [
+            {"Core API": "reference/core.md"},
+            {"Advanced API": "reference/advanced.md"},
+        ],
+    },
+)
+```
+
+**URL Validation**:
+
+The `project_url` must be a valid GitHub URL:
+
+- HTTPS: `https://github.com/user/repo`
+- SSH: `git@github.com:user/repo.git`
+- With `.git`: `https://github.com/user/repo.git`
+
+Invalid URLs raise `ValueError`.
+
+---
+
+### DeploymentConfig
+
+Configuration for GitHub Pages deployment.
+
+```python
+@dataclass
+class DeploymentConfig:
+    """Configuration for deployment.
+
+    Attributes:
+        site_dir: Path to generated site directory
+        repo_path: Path to git repository root (default: ".")
+        commit_message: Commit message for deployment (default: "Update docs")
+        force_push: Whether to force push (DANGEROUS - default: False)
+    """
+
+    site_dir: str | Path
+    repo_path: str | Path = "."
+    commit_message: str = "Update docs"
+    force_push: bool = False
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/__init__.py:54`](#)
+
+**Example**:
+
+```python
+from claude_skills.documentation_writing.github_pages import DeploymentConfig
+
+config = DeploymentConfig(
+    site_dir="site",
+    repo_path=".",
+    commit_message="Update documentation [skip ci]",
+)
+```
+
+**⚠️ Force Push Warning**:
+
+```python
+# DANGEROUS - Only use if you know what you're doing
+config = DeploymentConfig(
+    site_dir="site",
+    force_push=True,  # Overwrites remote history!
+)
+```
+
+Force push should ONLY be used when:
+
+- Remote `gh-pages` branch is corrupted
+- Intentionally rebuilding from scratch
+- Coordinated with all team members
+
+---
+
+## Result Classes
+
+### GenerationResult
+
+Result of documentation site generation.
+
+```python
+@dataclass
+class GenerationResult:
+    """Result of site generation.
+
+    Attributes:
+        success: Whether generation succeeded
+        site_dir: Path to generated site directory
+        pages: List of generated page paths
+        errors: List of error messages
+        warnings: List of warning messages
+        config_file: Path to generated mkdocs.yml
+    """
+
+    success: bool
+    site_dir: Path
+    pages: list[str]
+    errors: list[str]
+    warnings: list[str]
+    config_file: Path | None
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/__init__.py:71`](#)
+
+**Example**:
+
+```python
+result = generate_site(config)
+
+if result.success:
+    print(f"Success! Generated {len(result.pages)} pages")
+    print(f"Site directory: {result.site_dir}")
+    print(f"Configuration: {result.config_file}")
+
+    # List all generated pages
+    for page in result.pages:
+        print(f"  - {page}")
+
+    # Check for warnings
+    if result.warnings:
+        print("\nWarnings:")
+        for warning in result.warnings:
+            print(f"  - {warning}")
+else:
+    print("Generation failed:")
+    for error in result.errors:
+        print(f"  - {error}")
+```
+
+**Common Warnings**:
+
+- "No markdown files found in docs directory"
+- "No README.md or index.md found"
+- "Could not copy README to index.md: ..."
+
+---
+
+### ValidationResult
+
+Result of three-pass documentation validation.
+
+```python
+@dataclass
+class ValidationResult:
+    """Result of three-pass validation.
+
+    Attributes:
+        passed: Whether validation passed all thresholds
+        issues: List of all validation issues found
+        pass1_coverage: Coverage percentage (target: 100%)
+        pass2_clarity_score: Clarity score (target: >= 80%)
+        pass3_grounded_pct: Percentage of grounded content (target: >= 95%)
+    """
+
+    passed: bool
+    issues: list[ValidationIssue]
+    pass1_coverage: float
+    pass2_clarity_score: float
+    pass3_grounded_pct: float
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/__init__.py:111`](#)
+
+**Example**:
+
+```python
+validation = validate_site("site")
+
+# Check overall pass
+if validation.passed:
+    print("✓ All validation passes succeeded")
+else:
+    print("✗ Validation failed - review issues below")
+
+# Show scores
+print(f"\nScores:")
+print(f"  Coverage: {validation.pass1_coverage}% (target: 100%)")
+print(f"  Clarity: {validation.pass2_clarity_score}% (target: ≥80%)")
+print(f"  Grounded: {validation.pass3_grounded_pct}% (target: ≥95%)")
+
+# Group issues by severity
+errors = [i for i in validation.issues if i.severity == "error"]
+warnings = [i for i in validation.issues if i.severity == "warning"]
+info = [i for i in validation.issues if i.severity == "info"]
+
+print(f"\nIssues: {len(errors)} errors, {len(warnings)} warnings, {len(info)} info")
+```
+
+---
+
+### ValidationIssue
+
+Single validation issue found during site validation.
+
+```python
+@dataclass
+class ValidationIssue:
+    """Single validation issue.
+
+    Attributes:
+        severity: Issue severity level ("error", "warning", "info")
+        pass_number: Which validation pass found this (1, 2, or 3)
+        location: File path and optionally line number
+        message: Description of the issue
+        suggestion: Optional suggestion for fixing the issue
+    """
+
+    severity: Literal["error", "warning", "info"]
+    pass_number: int
+    location: str
+    message: str
+    suggestion: str | None = None
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/__init__.py:92`](#)
+
+**Example**:
+
+```python
+validation = validate_site("site")
+
+# Review all issues with suggestions
+for issue in validation.issues:
+    print(f"\n[{issue.severity.upper()}] Pass {issue.pass_number}")
+    print(f"File: {issue.location}")
+    print(f"Issue: {issue.message}")
+    if issue.suggestion:
+        print(f"Fix: {issue.suggestion}")
+
+# Filter by pass number
+pass3_issues = [i for i in validation.issues if i.pass_number == 3]
+print(f"\nPass 3 (Reality) found {len(pass3_issues)} issues")
+
+# Filter by severity
+errors = [i for i in validation.issues if i.severity == "error"]
+if errors:
+    print("\nCritical errors that must be fixed:")
+    for error in errors:
+        print(f"  - {error.message}")
+```
+
+**Severity Levels**:
+
+- `error`: Critical issues that prevent passing validation
+- `warning`: Issues that should be fixed but don't prevent passing
+- `info`: Suggestions for improvement
+
+---
+
+### DeploymentResult
+
+Result of GitHub Pages deployment.
+
+```python
+@dataclass
+class DeploymentResult:
+    """Result of deployment.
+
+    Attributes:
+        success: Whether deployment succeeded
+        branch: Branch deployed to (usually "gh-pages")
+        commit_sha: SHA of the deployment commit (None if failed)
+        url: GitHub Pages URL (None if failed)
+        errors: List of error messages
+    """
+
+    success: bool
+    branch: str
+    commit_sha: str | None
+    url: str | None
+    errors: list[str]
+```
+
+**Source**: [`~/.amplihack/.claude/skills/documentation-writing/github_pages/__init__.py:130`](#)
+
+**Example**:
+
+```python
+result = deploy_site(config)
+
+if result.success:
+    print(f"✓ Deployment successful")
+    print(f"Branch: {result.branch}")
+    print(f"Commit: {result.commit_sha}")
+    print(f"URL: {result.url}")
+    print(f"\nVisit: {result.url}")
+else:
+    print(f"✗ Deployment failed")
+    for error in result.errors:
+        print(f"  Error: {error}")
+
+# Handle specific error cases
+if "Permission denied" in str(result.errors):
+    print("\nAction: Check git remote access (SSH keys or HTTPS credentials)")
+elif "push failed" in str(result.errors):
+    print("\nAction: Try pulling latest changes first")
+```
+
+**Success Case**:
+
+```python
+DeploymentResult(
+    success=True,
+    branch="gh-pages",
+    commit_sha="a1b2c3d4e5f6...",
+    url="https://user.github.io/repo/",
+    errors=[],
+)
+```
+
+**Failure Case**:
+
+```python
+DeploymentResult(
+    success=False,
+    branch="gh-pages",
+    commit_sha=None,
+    url=None,
+    errors=["push failed: Permission denied (publickey)"],
+)
+```
+
+**No Changes Case**:
+
+```python
+DeploymentResult(
+    success=True,
+    branch="gh-pages",
+    commit_sha=None,
+    url="https://user.github.io/repo/",
+    errors=["No changes to deploy"],
+)
+```
+
+---
+
+## Environment Variables
+
+Currently no environment variables are supported. All configuration is explicit via dataclasses.
+
+---
+
+## Complete Example
+
+End-to-end workflow from generation to deployment:
+
+```python
+from claude_skills.documentation_writing.github_pages import (
+    SiteConfig,
+    DeploymentConfig,
+    generate_site,
+    validate_site,
+    deploy_site,
+)
+
+# Step 1: Configure and generate
+config = SiteConfig(
+    project_name="My Amazing Project",
+    project_url="https://github.com/user/repo",
+    docs_dir="docs",
+    output_dir="site",
+)
+
+print("Generating site...")
+result = generate_site(config)
+
+if not result.success:
+    print(f"Generation failed: {result.errors}")
+    exit(1)
+
+print(f"✓ Generated {len(result.pages)} pages")
+
+# Step 2: Validate
+print("\nValidating site...")
+validation = validate_site(result.site_dir)
+
+print(f"Coverage: {validation.pass1_coverage}%")
+print(f"Clarity: {validation.pass2_clarity_score}%")
+print(f"Grounded: {validation.pass3_grounded_pct}%")
+
+if not validation.passed:
+    print(f"\n⚠️  Validation failed - {len(validation.issues)} issues found")
+    for issue in validation.issues[:5]:  # Show first 5
+        print(f"  - {issue.message}")
+
+    # Continue anyway or exit based on your needs
+    # exit(1)
+
+# Step 3: Deploy
+print("\nDeploying to GitHub Pages...")
+deploy_config = DeploymentConfig(
+    site_dir=str(result.site_dir),
+    repo_path=".",
+    commit_message="Update documentation [skip ci]",
+)
+
+deployment = deploy_site(deploy_config)
+
+if deployment.success:
+    print(f"✓ Deployed successfully")
+    print(f"URL: {deployment.url}")
+else:
+    print(f"✗ Deployment failed: {deployment.errors}")
+    exit(1)
+```
+
+---
+
+## See Also
+
+- [Generate GitHub Pages Sites How-To](../howto/github-pages-deployment.md) - Task-oriented guide
+- [First Documentation Site Tutorial](../tutorials/first-docs-site.md) - Beginner tutorial
+- [Documentation Guidelines](#) - Eight rules for good docs

--- a/docs/reference/goal-seeking-agents-quick-reference.md
+++ b/docs/reference/goal-seeking-agents-quick-reference.md
@@ -1,0 +1,241 @@
+# Goal-Seeking Agents Quick Reference
+
+Fast lookup for common commands, patterns, and workflows.
+
+## Quick Start
+
+```bash
+# Create a new goal-seeking agent
+amplihack new "Security auditor that scans code for vulnerabilities"
+
+# Create with specific SDK
+amplihack new --sdk copilot "API documentation generator"
+amplihack new --sdk claude "Meeting notes synthesizer"
+amplihack new --sdk microsoft "Code review assistant"
+
+# Enable multi-agent architecture
+amplihack new --multi-agent --sdk copilot "Complex research agent"
+
+# Enable dynamic agent spawning
+amplihack new --enable-spawning --sdk claude "Adaptive learning agent"
+```
+
+## CLI Reference
+
+### Agent Generation
+
+| Command                                 | Description                                        |
+| --------------------------------------- | -------------------------------------------------- |
+| `amplihack new <goal>`                  | Generate agent with default SDK (copilot)          |
+| `--sdk {copilot,claude,microsoft,mini}` | Choose SDK backend                                 |
+| `--multi-agent`                         | Enable coordinator + memory + spawner architecture |
+| `--enable-spawning`                     | Enable dynamic sub-agent spawning                  |
+| `--domain {security,meetings,data,...}` | Generate domain-specific agent                     |
+
+### Evaluation Commands
+
+| Command                                           | Description                      |
+| ------------------------------------------------- | -------------------------------- |
+| `python -m amplihack.eval.progressive_test_suite` | Run L1-L12 eval                  |
+| `--runs 3`                                        | 3-run median eval (recommended)  |
+| `--grader-votes 3`                                | Multi-vote grading for stability |
+| `--sdk {mini,claude,copilot,microsoft}`           | Test specific SDK                |
+| `--parallel N`                                    | Run N evals concurrently         |
+
+### Self-Improvement Loop
+
+| Command                                  | Description                |
+| ---------------------------------------- | -------------------------- |
+| `python -m amplihack.eval.sdk_eval_loop` | Run improvement iterations |
+| `--sdk copilot --iterations 5`           | 5 loops on Copilot SDK     |
+| `python -m amplihack.eval.matrix_eval`   | 5-way agent comparison     |
+
+## SDK Selection Guide
+
+| SDK           | Best For                            | Pros                            | Cons                    |
+| ------------- | ----------------------------------- | ------------------------------- | ----------------------- |
+| **Copilot**   | GitHub workflows, code review       | Native GitHub integration, fast | Requires GitHub account |
+| **Claude**    | Complex reasoning, research         | Large context, strong reasoning | Higher cost             |
+| **Microsoft** | Enterprise workflows, Teams         | Azure integration, governance   | Requires Azure setup    |
+| **Mini**      | Testing, prototypes, cost-sensitive | Lightweight, no dependencies    | Limited capabilities    |
+
+## Evaluation Levels (L1-L12)
+
+| Level   | Focus                    | Pass Threshold |
+| ------- | ------------------------ | -------------- |
+| **L1**  | Simple Recall            | ≥85%           |
+| **L2**  | Multi-Source Synthesis   | ≥85%           |
+| **L3**  | Temporal Reasoning       | ≥70%           |
+| **L4**  | Procedural Application   | ≥80%           |
+| **L5**  | Contradiction Resolution | ≥75%           |
+| **L6**  | Incremental Updates      | ≥85%           |
+| **L7**  | Teaching Transfer        | NLG ≥0.7       |
+| **L8**  | Metacognition            | ≥50%           |
+| **L9**  | Causal Reasoning         | ≥50%           |
+| **L10** | Counterfactual Reasoning | ≥40%           |
+| **L11** | Novel Skill Acquisition  | ≥50%           |
+| **L12** | Far Transfer             | ≥60%           |
+
+## Common Patterns
+
+### Generate and Evaluate
+
+```bash
+# 1. Generate agent
+amplihack new --sdk copilot "Code documentation agent"
+
+# 2. Navigate to generated directory
+cd code_documentation_agent/
+
+# 3. Run 3-run median eval with multi-vote grading
+python -m amplihack.eval.progressive_test_suite \
+  --runs 3 \
+  --grader-votes 3 \
+  --sdk copilot
+```
+
+### Self-Improvement Loop
+
+```bash
+# Run 5 improvement iterations
+python -m amplihack.eval.sdk_eval_loop \
+  --sdk copilot \
+  --iterations 5 \
+  --output improvement_report.json
+```
+
+### Multi-SDK Comparison
+
+```bash
+# Compare all 4 SDKs
+python -m amplihack.eval.matrix_eval \
+  --runs 3 \
+  --output sdk_comparison.json
+```
+
+### Long-Horizon Memory Stress Test
+
+```bash
+# 1000-turn dialogue evaluation
+python -m amplihack.eval.long_horizon_memory \
+  --turns 1000 \
+  --questions 20 \
+  --output memory_eval.json
+```
+
+## Agent Architecture
+
+### Single-Agent (Default)
+
+```
+┌──────────────────────┐
+│   Learning Agent     │
+│                      │
+│ - 7 Learning Tools   │
+│ - Memory System      │
+│ - Intent Classifier  │
+│ - Agentic Loop       │
+└──────────────────────┘
+```
+
+### Multi-Agent (--multi-agent)
+
+```
+┌────────────────────────────────────────┐
+│          Coordinator Agent             │
+│   (Task routing and delegation)        │
+└───────────┬────────────────────────────┘
+            │
+    ┌───────┴────────┬──────────────┐
+    ▼                ▼              ▼
+┌─────────┐    ┌──────────┐   ┌──────────┐
+│ Memory  │    │ Reasoning│   │ Research │
+│ Agent   │    │ Agent    │   │ Agent    │
+└─────────┘    └──────────┘   └──────────┘
+```
+
+### With Spawning (--enable-spawning)
+
+```
+┌────────────────────────────────────────┐
+│          Coordinator Agent             │
+└───────────┬────────────────────────────┘
+            │
+    ┌───────┴────────┬──────────────────┐
+    ▼                ▼                  ▼
+┌─────────┐    ┌──────────┐   ┌──────────────────┐
+│ Memory  │    │ Reasoning│   │ Agent Spawner    │
+│ Agent   │    │ Agent    │   │ (Dynamic)        │
+└─────────┘    └──────────┘   └──────────────────┘
+                                       │
+                            ┌──────────┴──────────┐
+                            ▼                     ▼
+                     ┌──────────┐         ┌──────────┐
+                     │Retrieval │         │Synthesis │
+                     │Sub-Agent │         │Sub-Agent │
+                     └──────────┘         └──────────┘
+```
+
+## 7 Learning Tools
+
+| Tool                  | Purpose                 | Example                   |
+| --------------------- | ----------------------- | ------------------------- |
+| `learn_from_content`  | Extract and store facts | Learn from articles, docs |
+| `search_memory`       | Retrieve knowledge      | Find relevant facts       |
+| `synthesize_answer`   | Combine facts to answer | Answer complex questions  |
+| `calculate`           | Safe arithmetic         | Compute medal totals      |
+| `explain_knowledge`   | Teach concepts          | Explain to beginners      |
+| `find_knowledge_gaps` | Identify missing info   | Know what you don't know  |
+| `verify_fact`         | Cross-check claims      | Validate contradictions   |
+
+## Environment Variables
+
+| Variable                | Purpose                 | Default                    |
+| ----------------------- | ----------------------- | -------------------------- |
+| `ANTHROPIC_API_KEY`     | Claude API access       | Required for Claude/Mini   |
+| `OPENAI_API_KEY`        | OpenAI access           | Required for Microsoft SDK |
+| `COPILOT_MODEL`         | Copilot model selection | `gpt-4`                    |
+| `CLAUDE_AGENT_MODEL`    | Claude SDK model        | `claude-opus-4`            |
+| `MICROSOFT_AGENT_MODEL` | Microsoft SDK model     | `gpt-4`                    |
+| `EVAL_MODEL`            | Evaluation LLM          | `claude-opus-4`            |
+| `GRADER_MODEL`          | Grading LLM             | `claude-opus-4`            |
+
+## Troubleshooting
+
+| Problem                   | Solution                                                                            |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| Import errors for SDK     | Install SDK: `cargo install github-copilot-sdk` / `claude-agents` / `agent-framework` |
+| Low eval scores           | Run with `--runs 3 --grader-votes 3` for stability                                  |
+| Memory retrieval failures | Increase `simple_retrieval_threshold` in config                                     |
+| Slow evaluation           | Use `--parallel 4` for concurrent runs                                              |
+| SDK agent not responding  | Check API keys, verify SDK installation                                             |
+
+## File Structure
+
+```
+my_agent/
+├── goal_prompt.md           # Agent goal and capabilities
+├── prompts/                 # Markdown prompt templates
+│   ├── system.md
+│   ├── learning_task.md
+│   └── synthesis_template.md
+├── sdk_tools.json           # SDK-specific tool configs
+├── sub_agents/              # Multi-agent configs (if --multi-agent)
+│   ├── coordinator.yaml
+│   ├── memory_agent.yaml
+│   └── spawner.yaml
+├── tests/                   # Unit tests
+└── README.md                # Usage guide
+```
+
+## Related Documentation
+
+- **Tutorial**: [Goal-Seeking Agent Tutorial](../tutorials/GOAL_SEEKING_AGENT_TUTORIAL.md)
+- **Tutorial**: [LearningAgent Refactor Walkthrough](../tutorials/learning-agent-refactor-tutorial.md)
+- **How-To**: [Goal Agent Generator Guide](../concepts/agent-generator.md)
+- **How-To**: [Maintain the Refactored LearningAgent](../howto/maintain-learning-agent-modules.md)
+- **Reference**: [Eval System Architecture](../concepts/eval-system-architecture.md)
+- **Reference**: [LearningAgent Module Reference](./learning-agent-module-reference.md)
+- **Explanation**: [Comprehensive Guide](../concepts/goal-seeking-agents.md)
+- **Explanation**: [LearningAgent Module Architecture](../concepts/learning-agent-module-architecture.md)
+- **SDK Guide**: [SDK Adapters Guide](#)

--- a/docs/reference/hook-persistence-implementation.md
+++ b/docs/reference/hook-persistence-implementation.md
@@ -1,0 +1,296 @@
+# Hook Persistence Implementation Reference
+
+Technical reference for the hook persistence fix implemented in v0.9.1.
+
+## Overview
+
+This document describes the implementation details of the fix for Issue #2335, which resolved the hook restoration bug where SettingsManager would wipe out hooks on exit.
+
+## Problem Statement
+
+### Symptom
+
+```
+Stop hook error: Failed with non-blocking status code: /bin/sh: 1: /home/azureuser/.claude/tools/amplihack/hooks/stop.py: not found
+```
+
+### Root Cause
+
+The problematic execution flow was:
+
+1. `launch_interactive()` creates `SettingsManager` context
+2. `SettingsManager.__enter__()` backs up current settings.json (WITHOUT hooks)
+3. `ensure_settings_json()` adds hooks to settings.json (WITH hooks)
+4. User works in Claude Code session (hooks function correctly)
+5. User exits Claude Code
+6. `SettingsManager.__exit__()` restores backup (WITHOUT hooks)
+7. Next launch: hooks missing from settings.json
+
+## Implementation Details
+
+### File Modified
+
+`src/amplihack/launcher/core.py`
+
+### Changes Made
+
+**Before (Buggy Code):**
+
+```python
+def launch_interactive(
+    append_system_prompt: Path | None = None,
+    force_staging: bool = False,
+    checkout_repo: str | None = None,
+    claude_args: list[str] | None = None,
+    verbose: bool = False,
+) -> int:
+    """Launch Claude Code interactively."""
+
+    # Create settings manager for temporary changes
+    settings_manager = SettingsManager(
+        project_dir=Path.cwd(),
+        backup_settings=True,
+        restore_on_exit=True,
+    )
+
+    with settings_manager:  # ← BUG: Creates backup BEFORE hooks added
+        # Ensure settings.json exists with hooks
+        ensure_settings_json()  # ← Adds hooks AFTER backup created
+
+        # Launch Claude Code
+        launcher = ClaudeLauncher(
+            append_system_prompt=append_system_prompt,
+            force_staging=force_staging,
+            checkout_repo=checkout_repo,
+            claude_args=claude_args,
+            verbose=verbose,
+        )
+
+        if not launcher.prepare_launch():
+            return 1
+
+        return launcher.launch_claude()
+    # ← On exit: SettingsManager restores backup WITHOUT hooks (BUG)
+```
+
+**After (Fixed Code):**
+
+```python
+def launch_interactive(
+    append_system_prompt: Path | None = None,
+    force_staging: bool = False,
+    checkout_repo: str | None = None,
+    claude_args: list[str] | None = None,
+    verbose: bool = False,
+) -> int:
+    """Launch Claude Code interactively."""
+
+    # Ensure settings.json exists with hooks (permanent change)
+    ensure_settings_json()  # ← Direct write - no backup/restore
+
+    # Launch Claude Code
+    launcher = ClaudeLauncher(
+        append_system_prompt=append_system_prompt,
+        force_staging=force_staging,
+        checkout_repo=checkout_repo,
+        claude_args=claude_args,
+        verbose=verbose,
+    )
+
+    if not launcher.prepare_launch():
+        return 1
+
+    return launcher.launch_claude()
+    # ← On exit: hooks persist in settings.json (FIXED)
+```
+
+### Lines Changed
+
+- **Removed:** ~15 lines (SettingsManager initialization and context manager usage)
+- **Added:** 0 lines (simpler solution)
+- **Net change:** -15 lines (code simplification)
+
+## ensure_settings_json() Behavior
+
+The `ensure_settings_json()` function:
+
+1. Checks if `~/.claude/settings.json` exists
+2. If not, creates it with default configuration
+3. Ensures hooks section contains amplihack hooks
+4. Writes directly to settings.json (no backup)
+5. Returns without cleanup
+
+**Implementation location:** `src/amplihack/config/settings.py`
+
+```python
+def ensure_settings_json() -> None:
+    """Ensure settings.json exists with amplihack hooks."""
+    settings_path = Path.home() / ".claude" / "settings.json"
+
+    if settings_path.exists():
+        settings = json.loads(settings_path.read_text())
+    else:
+        settings = {}
+
+    # Add hooks if not present
+    if "hooks" not in settings:
+        settings["hooks"] = create_default_hooks()
+
+    # Write back to file
+    settings_path.write_text(json.dumps(settings, indent=2))
+```
+
+## Hook Path Fixing
+
+Additionally, the launcher automatically fixes hook paths to use absolute paths:
+
+**Implementation:** `src/amplihack/launcher/core.py` - `_fix_hook_paths_in_settings()`
+
+```python
+def _fix_hook_paths_in_settings(self, target_dir: Path) -> bool:
+    """Fix relative hook paths to absolute in settings.json."""
+    settings_path = target_dir / ".claude" / "settings.json"
+
+    if not settings_path.exists():
+        return True  # No settings to fix
+
+    settings = json.loads(settings_path.read_text())
+
+    if "hooks" not in settings:
+        return True  # No hooks to fix
+
+    # Convert relative paths to absolute
+    for hook_type, hook_configs in settings["hooks"].items():
+        for config in hook_configs:
+            for hook in config.get("hooks", []):
+                if "command" in hook:
+                    cmd = hook["command"]
+                    if not Path(cmd).is_absolute():
+                        # Convert to absolute using target_dir
+                        hook["command"] = str((target_dir / cmd).resolve())
+
+    # Write back
+    settings_path.write_text(json.dumps(settings, indent=2))
+    return True
+```
+
+## Testing Verification
+
+### Manual Test Procedure
+
+```bash
+# Step 1: Clean state
+rm ~/.claude/settings.json
+
+# Step 2: Launch amplihack
+amplihack
+
+# Step 3: Verify hooks added
+cat ~/.claude/settings.json | grep -A10 hooks
+# Expected: SessionStart, Stop, PostToolUse hooks present
+
+# Step 4: Exit Claude Code
+# (Use Claude Code's exit command)
+
+# Step 5: Verify hooks persisted
+cat ~/.claude/settings.json | grep -A10 hooks
+# Expected: Hooks still present (FIXED - previously would be missing)
+
+# Step 6: Re-launch amplihack
+amplihack
+# Expected: No "hook not found" errors
+```
+
+### Automated Test
+
+```python
+def test_hook_persistence():
+    """Test that hooks persist after launch."""
+    # Setup
+    settings_file = Path.home() / ".claude" / "settings.json"
+    settings_file.unlink(missing_ok=True)
+
+    # Execute launch
+    launch_interactive()
+
+    # Verify hooks added
+    settings = json.loads(settings_file.read_text())
+    assert "hooks" in settings
+    assert "SessionStart" in settings["hooks"]
+
+    # Simulate exit (settings_manager would restore here in old code)
+    # In fixed code, nothing happens
+
+    # Verify hooks still present
+    settings = json.loads(settings_file.read_text())
+    assert "hooks" in settings  # FIXED: hooks persist
+```
+
+## Impact Analysis
+
+### Positive Impacts
+
+1. **Hooks persist across sessions** - No more reinstallation required
+2. **Simpler code** - Removed unnecessary abstraction
+3. **Correct pattern usage** - SettingsManager only used for temporary changes
+4. **Fewer errors** - Eliminates "hook not found" class of errors
+5. **Better user experience** - Install once, works forever
+
+### No Breaking Changes
+
+The fix is fully backward compatible:
+
+- Existing installations automatically benefit
+- No user action required
+- No API changes
+- No configuration changes needed
+
+### Performance Impact
+
+**Negligible:** Removed ~15 lines of backup/restore code actually slightly improves launch performance (no backup creation or restoration).
+
+## Related Files
+
+- **Implementation:** `src/amplihack/launcher/core.py`
+- **Hook Creation:** `src/amplihack/config/settings.py`
+- **Tests:** `tests/test_launcher_core.py`
+- **Issue:** GitHub Issue [#2335](https://github.com/rysweet/amplihack/issues/2335)
+
+## Future Considerations
+
+### If Temporary Hook Configuration Needed
+
+For future use cases requiring temporary hooks:
+
+```python
+# Hypothetical future code
+def test_with_temporary_hooks():
+    """Test with temporary hooks that should revert."""
+    with SettingsManager() as settings:  # OK for temporary testing
+        settings.add_temporary_test_hooks()
+        run_integration_tests()
+        # On exit: temporary hooks automatically removed
+
+def launch_interactive():
+    """Launch with permanent hooks."""
+    ensure_settings_json()  # Permanent hooks - no revert
+    # ... launch ...
+```
+
+**Key distinction:** Clearly document intention (temporary vs permanent) and use appropriate pattern.
+
+### SettingsManager Still Valid For
+
+- Testing with experimental configurations
+- Preview modes
+- Debugging with temporary overrides
+- Scenarios requiring automatic cleanup
+
+**Just not for permanent installation operations.**
+
+## See Also
+
+- [Changelog v0.9.1](../features/power-steering/changelog-v0.9.1.md) - Release notes
+- [Hook Configuration Guide](../howto/configure-hooks.md) - User guide
+- [SettingsManager vs Permanent Changes](../concepts/settings-manager-vs-permanent-changes.md) - Architecture concept
+- [Troubleshoot Hooks](../howto/troubleshoot-hooks.md) - Diagnostic guide

--- a/docs/reference/learning-agent-module-reference.md
+++ b/docs/reference/learning-agent-module-reference.md
@@ -1,0 +1,298 @@
+---
+title: LearningAgent Module Reference
+description: Public API, configuration surface, file ownership, and validation references for the refactored LearningAgent.
+last_updated: 2026-03-30
+review_schedule: quarterly
+owner: goal-seeking
+doc_type: reference
+related:
+  - ../GOAL_SEEKING_AGENTS.md
+  - ../concepts/learning-agent-module-architecture.md
+  - ../howto/maintain-learning-agent-modules.md
+  - ../tutorials/learning-agent-refactor-tutorial.md
+---
+
+# LearningAgent Module Reference
+
+## Overview
+
+`LearningAgent` is the shared goal-seeking engine responsible for:
+
+- learning facts from content
+- retrieving knowledge from memory
+- reasoning about temporal changes
+- synthesizing final answers with an LLM
+
+The refactor preserves the existing public API while moving implementation details into focused modules.
+
+## Compatibility imports
+
+| Import                                                                   | Status                               | Notes                                                                       |
+| ------------------------------------------------------------------------ | ------------------------------------ | --------------------------------------------------------------------------- |
+| `from amplihack.agents.goal_seeking.learning_agent import LearningAgent` | Primary compatibility path           | Stable import path for direct callers                                       |
+| `from amplihack.agents.goal_seeking import LearningAgent`                | Supported for backward compatibility | Import works even though `LearningAgent` is not added to `__all__`          |
+| `from amplihack.agents.goal_seeking import GoalSeekingAgent`             | Preferred public entry point         | `GoalSeekingAgent` delegates learning and answering work to `LearningAgent` |
+
+## Constructor
+
+```python
+LearningAgent(
+    agent_name: str = "learning_agent",
+    model: str | None = None,
+    storage_path: Path | None = None,
+    use_hierarchical: bool = False,
+    prompt_variant: int | None = None,
+    **kwargs: Any,
+)
+```
+
+### Constructor parameters
+
+| Parameter          | Type           | Default            | Description                                                                 |
+| ------------------ | -------------- | ------------------ | --------------------------------------------------------------------------- |
+| `agent_name`       | `str`          | `"learning_agent"` | Memory namespace and runtime identity                                       |
+| `model`            | `str \| None`  | `None`             | Explicit LLM model override                                                 |
+| `storage_path`     | `Path \| None` | `None`             | Custom memory storage location                                              |
+| `use_hierarchical` | `bool`         | `False`            | Use cognitive or hierarchical memory adapters instead of the flat retriever |
+| `prompt_variant`   | `int \| None`  | `None`             | Load a synthesis prompt variant instead of the default prompt               |
+| `**kwargs`         | `Any`          | -                  | Reserved compatibility surface for callers and wrappers                     |
+
+## Public methods
+
+### `learn_from_content`
+
+```python
+async def learn_from_content(self, content: str) -> dict[str, Any]
+```
+
+Extracts facts from content, attaches source and temporal metadata, stores the resulting facts, and optionally stores a summary concept map.
+
+**Returns**
+
+| Key               | Meaning                                    |
+| ----------------- | ------------------------------------------ |
+| `facts_extracted` | Number of facts extracted from the content |
+| `facts_stored`    | Number of facts written to memory          |
+| `content_summary` | Short summary of the learned content       |
+
+### `answer_question`
+
+```python
+async def answer_question(
+    self,
+    question: str,
+    question_level: str = "L1",
+    return_trace: bool = False,
+    _skip_qanda_store: bool = False,
+    _force_simple: bool = False,
+) -> str | tuple[str, ReasoningTrace | None]
+```
+
+Runs the standard answer pipeline:
+
+1. detect intent
+2. select retrieval strategy
+3. perform math or temporal preprocessing when needed
+4. synthesize the final answer
+
+**Parameters**
+
+| Parameter           | Type   | Default  | Description                                                               |
+| ------------------- | ------ | -------- | ------------------------------------------------------------------------- |
+| `question`          | `str`  | required | Question to answer                                                        |
+| `question_level`    | `str`  | `"L1"`   | Difficulty hint for prompt selection and synthesis style                  |
+| `return_trace`      | `bool` | `False`  | Return a `ReasoningTrace` alongside the answer                            |
+| `_skip_qanda_store` | `bool` | `False`  | Internal flag used to skip writing Q and A history facts                  |
+| `_force_simple`     | `bool` | `False`  | Internal flag used to force exhaustive simple retrieval in fallback cases |
+
+### `answer_question_agentic`
+
+```python
+async def answer_question_agentic(
+    self,
+    question: str,
+    max_iterations: int = 3,
+    return_trace: bool = False,
+) -> str | tuple[str, ReasoningTrace | None]
+```
+
+Runs the single-shot answer pipeline first, checks completeness, searches for missing facts, and re-synthesizes only when that adds information.
+
+### `get_memory_stats`
+
+```python
+def get_memory_stats(self) -> dict[str, Any]
+```
+
+Returns memory statistics from the active backend.
+
+### `flush_memory`
+
+```python
+def flush_memory(self) -> None
+```
+
+Flushes memory caches without discarding stored knowledge.
+
+### `close`
+
+```python
+def close(self) -> None
+```
+
+Closes the underlying memory backend and releases agent resources.
+
+## Module ownership map
+
+The eight primary files are the stable ownership boundaries for the refactor.
+
+| File                      | Owns                                                                       |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `learning_agent.py`       | constructor, shared state, lifecycle, retry helpers, public delegation     |
+| `learning_ingestion.py`   | ingestion pipeline, fact batch preparation, source labels, summary storage |
+| `answer_synthesizer.py`   | answer synthesis, completeness evaluation, prompt assembly                 |
+| `retrieval_strategies.py` | retrieval selection, simple/entity/concept/aggregation strategies          |
+| `intent_detector.py`      | intent classification and routing metadata                                 |
+| `temporal_reasoning.py`   | transition chains, temporal lookups, temporal parsing                      |
+| `code_synthesis.py`       | generated Python for hard temporal reasoning cases                         |
+| `knowledge_utils.py`      | arithmetic validation, knowledge explanation, fact verification helpers    |
+
+## Expected method placement
+
+The refactor keeps these methods with their owning modules.
+
+### `learning_ingestion.py`
+
+- `learn_from_content`
+- `_truncate_learning_content`
+- `_extract_source_label`
+- `_build_store_fact_kwargs`
+- `_build_summary_store_kwargs`
+- `prepare_fact_batch`
+- `store_fact_batch`
+- `_store_summary_concept_map`
+- `_detect_temporal_metadata_fast`
+- `_detect_temporal_metadata`
+- `_extract_facts_with_llm`
+
+### `intent_detector.py`
+
+- `_detect_intent`
+- `SIMPLE_INTENTS`
+- `AGGREGATION_INTENTS`
+
+### `temporal_reasoning.py`
+
+- `_transition_chain_from_facts`
+- `retrieve_transition_chain`
+- `_extract_temporal_state_values`
+- `_collapse_change_count_transitions`
+- `_collapse_temporal_lookup_transitions`
+- `_format_temporal_lookup_answer`
+- `_parse_temporal_index`
+- `_heuristic_temporal_entity_field`
+- `_should_short_circuit_temporal_answer`
+
+### `code_synthesis.py`
+
+- `temporal_code_synthesis`
+- `_code_generation_tool`
+
+### `knowledge_utils.py`
+
+- `_validate_arithmetic`
+- `_compute_math_result`
+- `_explain_knowledge`
+- `_find_knowledge_gaps`
+- `_verify_fact`
+- `get_memory_stats`
+
+### `retrieval_strategies.py`
+
+- `_simple_retrieval`
+- `_keyword_expanded_retrieval`
+- `_entity_retrieval`
+- `_concept_retrieval`
+- `_aggregation_retrieval`
+- `_get_summary_nodes`
+- and the rest of the retrieval-adjacent helpers that support those strategies
+
+### `answer_synthesizer.py`
+
+- `answer_question`
+- `answer_question_agentic`
+- `_evaluate_answer_completeness`
+- `_synthesize_with_llm`
+
+## Registered actions
+
+The facade still registers the same high-level actions on `ActionExecutor`.
+
+| Action                | Backing behavior                                 |
+| --------------------- | ------------------------------------------------ |
+| `read_content`        | content ingestion input helper                   |
+| `search_memory`       | memory lookup through the active backend         |
+| `synthesize_answer`   | LLM synthesis via `answer_synthesizer.py`        |
+| `calculate`           | deterministic arithmetic helper                  |
+| `code_generation`     | temporal code generation via `code_synthesis.py` |
+| `explain_knowledge`   | topic explanation helper                         |
+| `find_knowledge_gaps` | knowledge gap analysis                           |
+| `verify_fact`         | fact validation against stored knowledge         |
+
+## Configuration surface
+
+The refactor does not add new runtime configuration. It preserves the existing knobs.
+
+### Constructor-driven configuration
+
+| Knob               | Scope                    | Effect                                                              |
+| ------------------ | ------------------------ | ------------------------------------------------------------------- |
+| `model`            | extraction and synthesis | Chooses the LLM used for prompts and completions                    |
+| `storage_path`     | memory backend           | Changes where memory data is stored                                 |
+| `use_hierarchical` | memory backend           | Selects `CognitiveAdapter` or `FlatRetrieverAdapter` when available |
+| `prompt_variant`   | synthesis                | Loads a variant prompt for eval or experimentation                  |
+
+### Environment variables
+
+| Variable     | Used when          | Effect                              |
+| ------------ | ------------------ | ----------------------------------- |
+| `EVAL_MODEL` | `model` is omitted | Provides the default LLM model name |
+
+No new environment variables are introduced by the module split.
+
+## Internal helper modules
+
+Private support files may exist to keep the primary modules small. Two common patterns are expected:
+
+- retrieval support helpers such as `_retrieval_core.py`, `_retrieval_entity.py`, and `_retrieval_meta.py`
+- synthesis support helpers such as `_answer_prompting.py`
+
+These files stay private implementation details. Callers should continue to target `LearningAgent`, not individual support modules.
+
+## Test layout
+
+| Test file                          | Scope                                 |
+| ---------------------------------- | ------------------------------------- |
+| `test_learning_agent_core.py`      | constructor, retry, lifecycle         |
+| `test_learning_agent_ingestion.py` | ingestion and storage                 |
+| `test_learning_agent_retrieval.py` | retrieval strategies and fallbacks    |
+| `test_learning_agent_temporal.py`  | temporal reasoning and code synthesis |
+| `test_math_intent.py`              | math and intent behavior              |
+| `test_agentic_answer_mode.py`      | answer refinement behavior            |
+| `test_goal_seeking_agent.py`       | higher-level agent compatibility      |
+
+## Validation commands
+
+The refactored LearningAgent is validated with focused checks:
+
+```bash
+uv run ruff check src/amplihack/agents/goal_seeking tests/agents/goal_seeking
+uv run pyright src/amplihack/agents/goal_seeking tests/agents/goal_seeking
+uv run python -m pytest tests/agents/goal_seeking/
+```
+
+## Related docs
+
+- [Understanding the LearningAgent module architecture](../concepts/learning-agent-module-architecture.md)
+- [How to maintain and extend the refactored LearningAgent](../howto/maintain-learning-agent-modules.md)
+- [Tutorial: trace the refactored LearningAgent end to end](../tutorials/learning-agent-refactor-tutorial.md)

--- a/docs/reference/memory-cli-reference.md
+++ b/docs/reference/memory-cli-reference.md
@@ -1,0 +1,146 @@
+# Memory CLI Reference
+
+This page documents the current top-level `amplihack memory` surface.
+
+## Synopsis
+
+```bash
+amplihack memory <subcommand> [options]
+```
+
+## Supported Subcommands
+
+| Subcommand | Purpose                                         |
+| ---------- | ----------------------------------------------- |
+| `tree`     | Visualize the top-level session memory graph    |
+| `clean`    | Delete matching top-level session-memory rows   |
+| `export`   | Export an agent-local hierarchical memory store |
+| `import`   | Import an agent-local hierarchical memory store |
+
+## `memory tree`
+
+`amplihack memory tree` renders the repo's top-level session memory graph using `MemoryDatabase`, the SQLite-backed store at `~/.amplihack/memory.db` by default.
+
+```bash
+amplihack memory tree [--session SESSION] [--type TYPE] [--depth N] [--backend sqlite]
+```
+
+### Options
+
+| Flag                | Meaning                                              |
+| ------------------- | ---------------------------------------------------- |
+| `--session SESSION` | Filter by session ID                                 |
+| `--type TYPE`       | Filter by the current legacy parser types            |
+| `--depth N`         | Limit tree depth                                     |
+| `--backend sqlite`  | Explicit SQLite backend selection for parity tooling |
+
+### Current `--type` choices
+
+The current parser accepts these legacy compatibility names:
+
+- `conversation`
+- `decision`
+- `pattern`
+- `context`
+- `learning`
+- `artifact`
+
+### Examples
+
+```bash
+amplihack memory tree
+amplihack memory tree --depth 2
+amplihack memory tree --session demo_run_01
+amplihack memory tree --type learning
+amplihack memory tree --backend sqlite
+```
+
+## `memory clean`
+
+`amplihack memory clean` removes top-level session-memory records from the SQLite store when their session ID matches a wildcard pattern.
+
+```bash
+amplihack memory clean --pattern PATTERN [--backend sqlite] [--no-dry-run] [--confirm]
+```
+
+### Options
+
+| Flag               | Meaning                                                  |
+| ------------------ | -------------------------------------------------------- |
+| `--pattern`        | Wildcard pattern for matching session IDs                |
+| `--backend sqlite` | Explicit SQLite backend selection for parity tooling     |
+| `--no-dry-run`     | Delete matching sessions instead of reporting only       |
+| `--confirm`        | Skip the interactive confirmation prompt before deletion |
+
+### Examples
+
+```bash
+amplihack memory clean --pattern 'test_*'
+amplihack memory clean --pattern 'old_run_*' --no-dry-run
+amplihack memory clean --pattern 'tmp_*' --no-dry-run --confirm
+```
+
+## `memory export`
+
+`memory export` copies an agent-local hierarchical memory store into a portable JSON file or raw Kuzu directory.
+
+```bash
+amplihack memory export --agent AGENT --output OUTPUT [--format {json,kuzu}] [--storage-path STORAGE_PATH]
+```
+
+### Options
+
+| Flag                          | Meaning                                                |
+| ----------------------------- | ------------------------------------------------------ |
+| `--agent AGENT`               | Agent name to export                                   |
+| `--output OUTPUT`             | Output file path for JSON or output directory for Kuzu |
+| `--format {json,kuzu}`        | Export format; default is `json`                       |
+| `--storage-path STORAGE_PATH` | Override the agent's hierarchical-memory storage path  |
+
+### Examples
+
+```bash
+amplihack memory export --agent incident-memory-agent --output ./incident-memory.json
+amplihack memory export --agent incident-memory-agent --output ./incident-memory-kuzu --format kuzu
+```
+
+## `memory import`
+
+`memory import` loads a JSON export into an existing agent memory store, or replaces an agent's raw Kuzu store.
+
+```bash
+amplihack memory import --agent AGENT --input INPUT [--format {json,kuzu}] [--merge] [--storage-path STORAGE_PATH]
+```
+
+### Options
+
+| Flag                          | Meaning                                               |
+| ----------------------------- | ----------------------------------------------------- |
+| `--agent AGENT`               | Target agent name                                     |
+| `--input INPUT`               | Input file path for JSON or input directory for Kuzu  |
+| `--format {json,kuzu}`        | Import format; default is `json`                      |
+| `--merge`                     | Merge into existing memory instead of replacing it    |
+| `--storage-path STORAGE_PATH` | Override the agent's hierarchical-memory storage path |
+
+### Important caveat
+
+`--merge` is supported only for JSON imports. Raw Kuzu imports replace the target store.
+
+### Examples
+
+```bash
+amplihack memory import --agent incident-memory-agent --input ./incident-memory.json --merge
+amplihack memory import --agent incident-memory-agent --input ./incident-memory-kuzu --format kuzu
+```
+
+## What Is Still Not Exposed by the Top-Level CLI
+
+The current top-level parser does **not** expose these older surfaces:
+
+- `amplihack memory evaluate`
+
+If you need the backend evaluation module directly, run:
+
+```bash
+python -m amplihack.memory.cli_evaluate --backend sqlite
+```

--- a/docs/reference/memory-enabled-agents-api.md
+++ b/docs/reference/memory-enabled-agents-api.md
@@ -1,0 +1,22 @@
+# Memory-Enabled Agents API Reference (Superseded)
+
+This older page described the standalone `amplihack-memory-lib` API as if it were the primary memory story for the repo.
+
+That is no longer the best starting point for this checkout.
+
+## Use These Docs Instead
+
+- [Agent Memory Quickstart](../howto/agent-memory-quickstart.md)
+- [Memory-enabled agents architecture](../concepts/memory-enabled-agents-architecture.md)
+- [Memory tutorial](../tutorials/memory-enabled-agents-getting-started.md)
+- [How to integrate memory into agents](../howto/integrate-memory-into-agents.md)
+- [Memory CLI reference](./memory-cli-reference.md)
+
+## Why This Page Was Retired
+
+The previous version centered an older standalone SQLite-first API surface and did not reflect the current split between:
+
+- the in-repo CLI memory backend under `src/amplihack/memory`
+- the generated `amplihack new --enable-memory` scaffold that packages `amplihack_memory` helpers into a standalone agent bundle
+
+If you still need deep standalone-library details, read the `amplihack-memory-lib` package docs directly. For this repo, start with the replacement docs above.

--- a/docs/reference/platform-bridge-api.md
+++ b/docs/reference/platform-bridge-api.md
@@ -1,0 +1,619 @@
+# Platform Bridge API Reference
+
+Complete API documentation fer the platform bridge module.
+
+## Module: `claude.tools.platform_bridge`
+
+### Public API
+
+```python
+__all__ = [
+    "PlatformBridge",
+    "detect_platform",
+    "Platform",
+    "PlatformDetectionError",
+    "CLIToolMissingError"
+]
+```
+
+## Classes
+
+### `PlatformBridge`
+
+Main entry point fer platform-agnostic git operations.
+
+**Constructor**:
+
+```python
+PlatformBridge(repo_path: str = ".") -> PlatformBridge
+```
+
+**Parameters**:
+
+- `repo_path` (str, optional): Path to git repository. Defaults to current directory.
+
+**Raises**:
+
+- `PlatformDetectionError`: If platform cannot be determined from git remotes
+- `NotAGitRepositoryError`: If repo_path not be a git repository
+
+**Example**:
+
+```python
+from claude.tools.platform_bridge import PlatformBridge
+
+# Use current directory
+bridge = PlatformBridge()
+
+# Use specific repository
+bridge = PlatformBridge("/path/to/repo")
+```
+
+**Attributes**:
+
+- `platform` (Platform): Detected platform (GitHub or AzureDevOps)
+- `repo_path` (Path): Absolute path to repository
+
+---
+
+### `PlatformBridge.create_issue()`
+
+Create an issue (GitHub) or work item (Azure DevOps).
+
+**Signature**:
+
+```python
+def create_issue(
+    self,
+    title: str,
+    body: str,
+    labels: Optional[List[str]] = None
+) -> Dict[str, Any]
+```
+
+**Parameters**:
+
+- `title` (str): Issue/work item title (required, max 256 characters)
+- `body` (str): Issue/work item description (required)
+- `labels` (List[str], optional): Labels/tags to apply (GitHub only)
+
+**Returns**:
+
+```python
+{
+    "number": 42,                    # Issue/work item number
+    "url": "https://...",            # Web URL to issue
+    "title": "Issue title",          # Created title
+    "state": "open"                  # Current state
+}
+```
+
+**Raises**:
+
+- `CLIToolMissingError`: If gh/az CLI not installed
+- `subprocess.CalledProcessError`: If CLI command fails
+
+**Example**:
+
+```python
+issue = bridge.create_issue(
+    title="Add authentication",
+    body="Implement JWT authentication\n\n## Requirements\n- Token validation\n- Refresh tokens",
+    labels=["enhancement", "security"]  # GitHub only
+)
+
+print(f"Created issue #{issue['number']}: {issue['url']}")
+```
+
+**GitHub Command**:
+
+```bash
+gh issue create --title "..." --body "..." --label "enhancement,security"
+```
+
+**Azure DevOps Command**:
+
+```bash
+az boards work-item create --type "User Story" --title "..." --description "..."
+```
+
+---
+
+### `PlatformBridge.create_draft_pr()`
+
+Create a draft pull request on both platforms.
+
+**Signature**:
+
+```python
+def create_draft_pr(
+    self,
+    title: str,
+    body: str,
+    source_branch: str,
+    target_branch: str = "main"
+) -> Dict[str, Any]
+```
+
+**Parameters**:
+
+- `title` (str): PR title (required, max 256 characters)
+- `body` (str): PR description in markdown (required)
+- `source_branch` (str): Source branch name (required)
+- `target_branch` (str): Target branch name (default: "main")
+
+**Returns**:
+
+```python
+{
+    "number": 123,                   # PR number
+    "url": "https://...",            # Web URL to PR
+    "title": "PR title",             # Created title
+    "state": "draft",                # Initial state
+    "source_branch": "feat/auth",    # Source branch
+    "target_branch": "main"          # Target branch
+}
+```
+
+**Raises**:
+
+- `CLIToolMissingError`: If gh/az CLI not installed
+- `BranchNotFoundError`: If source branch doesn't exist
+- `subprocess.CalledProcessError`: If CLI command fails
+
+**Example**:
+
+```python
+pr = bridge.create_draft_pr(
+    title="feat: Add JWT authentication",
+    body="## Summary\n\nImplements JWT authentication\n\n## Test Plan\n- Unit tests\n- Integration tests",
+    source_branch="feat/auth",
+    target_branch="main"
+)
+
+print(f"Draft PR #{pr['number']}: {pr['url']}")
+```
+
+**GitHub Command**:
+
+```bash
+gh pr create --draft --title "..." --body "..." --head feat/auth --base main
+```
+
+**Azure DevOps Command**:
+
+```bash
+az repos pr create --draft true --title "..." --description "..." --source-branch feat/auth --target-branch main
+```
+
+---
+
+### `PlatformBridge.mark_pr_ready()`
+
+Mark a draft PR as ready fer review.
+
+**Signature**:
+
+```python
+def mark_pr_ready(self, pr_number: int) -> Dict[str, Any]
+```
+
+**Parameters**:
+
+- `pr_number` (int): Pull request number (required)
+
+**Returns**:
+
+```python
+{
+    "number": 123,              # PR number
+    "state": "open",            # New state (no longer draft)
+    "success": True             # Operation succeeded
+}
+```
+
+**Raises**:
+
+- `CLIToolMissingError`: If gh/az CLI not installed
+- `PRNotFoundError`: If PR number doesn't exist
+- `subprocess.CalledProcessError`: If CLI command fails
+
+**Example**:
+
+```python
+result = bridge.mark_pr_ready(pr_number=123)
+
+if result['success']:
+    print(f"PR #{result['number']} be ready fer review!")
+```
+
+**GitHub Command**:
+
+```bash
+gh pr ready 123
+```
+
+**Azure DevOps Command**:
+
+```bash
+az repos pr update --id 123 --status Active
+```
+
+---
+
+### `PlatformBridge.add_pr_comment()`
+
+Add a comment to a pull request.
+
+**Signature**:
+
+```python
+def add_pr_comment(
+    self,
+    pr_number: int,
+    comment: str
+) -> Dict[str, Any]
+```
+
+**Parameters**:
+
+- `pr_number` (int): Pull request number (required)
+- `comment` (str): Comment text in markdown (required)
+
+**Returns**:
+
+```python
+{
+    "comment_id": "456",         # Comment identifier
+    "pr_number": 123,            # PR number
+    "body": "Comment text",      # Created comment
+    "url": "https://..."         # Web URL to comment
+}
+```
+
+**Raises**:
+
+- `CLIToolMissingError`: If gh/az CLI not installed
+- `PRNotFoundError`: If PR number doesn't exist
+- `subprocess.CalledProcessError`: If CLI command fails
+
+**Example**:
+
+```python
+comment = bridge.add_pr_comment(
+    pr_number=123,
+    comment="All tests be passin'! Ready fer merge. 🚢"
+)
+
+print(f"Added comment: {comment['url']}")
+```
+
+**GitHub Command**:
+
+```bash
+gh pr comment 123 --body "All tests be passin'! Ready fer merge. 🚢"
+```
+
+**Azure DevOps Command**:
+
+```bash
+az repos pr create-thread --id 123 --comment-text "All tests be passin'! Ready fer merge. 🚢"
+```
+
+---
+
+### `PlatformBridge.check_ci_status()`
+
+Check CI/CD pipeline status fer a pull request.
+
+**Signature**:
+
+```python
+def check_ci_status(self, pr_number: int) -> Dict[str, Any]
+```
+
+**Parameters**:
+
+- `pr_number` (int): Pull request number (required)
+
+**Returns**:
+
+```python
+{
+    "all_passing": True,           # All checks passed
+    "total_checks": 5,             # Total number of checks
+    "passed": 5,                   # Number passed
+    "failed": 0,                   # Number failed
+    "pending": 0,                  # Number still runnin'
+    "checks": [                    # List of individual checks
+        {
+            "name": "build",
+            "status": "success",
+            "url": "https://..."
+        },
+        {
+            "name": "test",
+            "status": "success",
+            "url": "https://..."
+        }
+    ]
+}
+```
+
+**Raises**:
+
+- `CLIToolMissingError`: If gh/az CLI not installed
+- `PRNotFoundError`: If PR number doesn't exist
+- `subprocess.CalledProcessError`: If CLI command fails
+
+**Example**:
+
+```python
+status = bridge.check_ci_status(pr_number=123)
+
+if status['all_passing']:
+    print("All checks passed! Ready to merge.")
+elif status['pending'] > 0:
+    print(f"Waitin' on {status['pending']} checks...")
+else:
+    print(f"Failed checks: {status['failed']}")
+    for check in status['checks']:
+        if check['status'] == 'failure':
+            print(f"  - {check['name']}: {check['url']}")
+```
+
+**GitHub Command**:
+
+```bash
+gh pr checks 123
+```
+
+**Azure DevOps Command**:
+
+```bash
+az pipelines runs list --branch refs/pull/123/merge
+```
+
+---
+
+## Functions
+
+### `detect_platform()`
+
+Standalone function to detect platform from git remotes without creatin' a PlatformBridge instance.
+
+**Signature**:
+
+```python
+def detect_platform(repo_path: str = ".") -> Platform
+```
+
+**Parameters**:
+
+- `repo_path` (str, optional): Path to git repository. Defaults to current directory.
+
+**Returns**:
+
+- `Platform.GITHUB` - Repository hosted on GitHub
+- `Platform.AZDO` - Repository hosted on Azure DevOps
+
+**Raises**:
+
+- `PlatformDetectionError`: If platform cannot be determined
+- `NotAGitRepositoryError`: If repo_path not be a git repository
+
+**Example**:
+
+```python
+from claude.tools.platform_bridge import detect_platform, Platform
+
+platform = detect_platform()
+
+if platform == Platform.GITHUB:
+    print("This be a GitHub repository")
+elif platform == Platform.AZDO:
+    print("This be an Azure DevOps repository")
+```
+
+**Detection Logic**:
+
+1. Run `git remote -v` in repo_path
+2. Extract URLs from output
+3. Check `origin` remote first
+4. Fall back to first available remote
+5. Match URL patterns:
+   - `github.com` → `Platform.GITHUB`
+   - `dev.azure.com` or `visualstudio.com` → `Platform.AZDO`
+6. Raise `PlatformDetectionError` if no match
+
+---
+
+## Enums
+
+### `Platform`
+
+Enumeration of supported platforms.
+
+```python
+class Platform(Enum):
+    GITHUB = "github"
+    AZDO = "azdo"
+```
+
+**Members**:
+
+- `Platform.GITHUB` - GitHub platform
+- `Platform.AZDO` - Azure DevOps platform
+
+**Example**:
+
+```python
+from claude.tools.platform_bridge import Platform
+
+if bridge.platform == Platform.GITHUB:
+    print("Using GitHub operations")
+```
+
+---
+
+## Exceptions
+
+### `PlatformDetectionError`
+
+Raised when platform cannot be determined from git remotes.
+
+**Inheritance**: `Exception`
+
+**Common Causes**:
+
+- No git remotes configured
+- Remote URL doesn't match known patterns
+- Not a git repository
+
+**Example**:
+
+```python
+from claude.tools.platform_bridge import PlatformBridge, PlatformDetectionError
+
+try:
+    bridge = PlatformBridge()
+except PlatformDetectionError as e:
+    print(f"Could not detect platform: {e}")
+    print("Add a remote: git remote add origin <url>")
+```
+
+---
+
+### `CLIToolMissingError`
+
+Raised when required CLI tool (gh or az) not be installed.
+
+**Inheritance**: `Exception`
+
+**Attributes**:
+
+- `tool_name` (str): Name of missing tool ("gh" or "az")
+- `install_command` (str): Platform-specific installation command
+
+**Example**:
+
+```python
+from claude.tools.platform_bridge import PlatformBridge, CLIToolMissingError
+
+try:
+    bridge = PlatformBridge()
+    issue = bridge.create_issue(title="Test", body="Body")
+except CLIToolMissingError as e:
+    print(f"Missing: {e.tool_name}")
+    print(f"Install with: {e.install_command}")
+```
+
+---
+
+### `PRNotFoundError`
+
+Raised when specified PR number doesn't exist.
+
+**Inheritance**: `Exception`
+
+**Attributes**:
+
+- `pr_number` (int): PR number that wasn't found
+
+**Example**:
+
+```python
+from claude.tools.platform_bridge import PRNotFoundError
+
+try:
+    bridge.mark_pr_ready(pr_number=999)
+except PRNotFoundError as e:
+    print(f"PR #{e.pr_number} doesn't exist")
+```
+
+---
+
+### `BranchNotFoundError`
+
+Raised when specified branch doesn't exist in repository.
+
+**Inheritance**: `Exception`
+
+**Attributes**:
+
+- `branch_name` (str): Branch name that wasn't found
+
+**Example**:
+
+```python
+from claude.tools.platform_bridge import BranchNotFoundError
+
+try:
+    pr = bridge.create_draft_pr(
+        title="Test",
+        body="Body",
+        source_branch="nonexistent-branch"
+    )
+except BranchNotFoundError as e:
+    print(f"Branch '{e.branch_name}' doesn't exist")
+```
+
+---
+
+## Type Hints
+
+All functions use proper type hints:
+
+```python
+from typing import Dict, List, Optional, Any
+from pathlib import Path
+
+class PlatformBridge:
+    def __init__(self, repo_path: str = ".") -> None: ...
+
+    def create_issue(
+        self,
+        title: str,
+        body: str,
+        labels: Optional[List[str]] = None
+    ) -> Dict[str, Any]: ...
+
+    def create_draft_pr(
+        self,
+        title: str,
+        body: str,
+        source_branch: str,
+        target_branch: str = "main"
+    ) -> Dict[str, Any]: ...
+```
+
+---
+
+## Thread Safety
+
+The platform bridge be **thread-safe** fer read operations but **not thread-safe** fer write operations:
+
+**Safe** (multiple threads):
+
+```python
+# Multiple threads can check CI status simultaneously
+status1 = bridge.check_ci_status(pr_number=123)
+status2 = bridge.check_ci_status(pr_number=456)
+```
+
+**Unsafe** (avoid):
+
+```python
+# Don't create multiple PRs from different threads
+# Results be unpredictable
+```
+
+Fer concurrent operations, create separate `PlatformBridge` instances per thread.
+
+---
+
+## See Also
+
+- [Platform Bridge Overview](../tutorials/platform-bridge-quickstart.md) - Complete usage guide
+- [Security Documentation](security-recommendations.md) - Security analysis
+- [Contributing Guide](../contributing/file-organization.md) - Extend with new platforms

--- a/docs/reference/prerequisite-checking.md
+++ b/docs/reference/prerequisite-checking.md
@@ -1,0 +1,370 @@
+# Prerequisite Checking System
+
+**Last Updated**: 2026-02-03
+**Version**: 0.9.0
+
+## Overview
+
+The prerequisite checking system ensures all required tools are installed before launching amplihack. It provides cross-platform detection, interactive installation, and comprehensive error handling.
+
+## Core Components
+
+### PrerequisiteChecker
+
+Main class that orchestrates prerequisite verification and installation.
+
+**Responsibilities:**
+
+- Detect operating system and platform
+- Check for required tools (claude, node, npm, rg)
+- Prompt for interactive installation
+- Execute platform-specific install commands
+- Audit all installation attempts
+
+### InstallationResult
+
+Unified dataclass representing the outcome of an installation attempt.
+
+```python
+@dataclass
+class InstallationResult:
+    """Result of an installation attempt."""
+    tool: str                                    # Tool being installed
+    success: bool                                # Whether installation succeeded
+    command_executed: list[str]                  # Command that was run
+    stdout: str                                  # Standard output
+    stderr: str                                  # Standard error
+    exit_code: int                               # Process exit code
+    timestamp: str                               # ISO 8601 timestamp
+    user_approved: bool                          # User approval status
+    message: str = ""                            # Human-readable summary
+    verification_result: "ToolCheckResult | None" = None  # Post-install verification
+```
+
+**Key Attributes:**
+
+- `message`: User-friendly description of result
+- `verification_result`: Optional verification that tool works after install
+- `command_executed`: Full command for audit trail
+
+### Exception Handling
+
+All subprocess operations use comprehensive exception handling:
+
+```python
+def check_copilot() -> bool:
+    """Check if Copilot CLI is installed.
+
+    Handles:
+    - FileNotFoundError: Command not found (standard)
+    - PermissionError: WSL permission denied (non-existent commands)
+    - TimeoutExpired: Hanging command
+    """
+    try:
+        subprocess.run(["copilot", "--version"],
+                      capture_output=True, timeout=5, check=False)
+        return True
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
+        return False
+```
+
+**Why PermissionError?**
+On Windows Subsystem for Linux (WSL), attempting to execute a non-existent command can raise `PermissionError` instead of `FileNotFoundError`. The system handles both gracefully.
+
+## Platform Detection
+
+Automatic OS detection with WSL support:
+
+```python
+class Platform(str, Enum):
+    MACOS = "macos"
+    LINUX = "linux"
+    WSL = "wsl"
+    WINDOWS = "windows"
+    UNKNOWN = "unknown"
+```
+
+**Detection Logic:**
+
+1. Check for WSL indicators (`/proc/version` contains "Microsoft")
+2. Fall back to `platform.system()` mapping
+3. Handle unknown platforms gracefully
+
+## Installation Commands
+
+Platform-specific commands for each tool:
+
+| Platform | Tool | Command                       |
+| -------- | ---- | ----------------------------- |
+| macOS    | node | `brew install node`           |
+| macOS    | rg   | `brew install ripgrep`        |
+| Linux    | node | `sudo apt install -y nodejs`  |
+| Linux    | npm  | `sudo apt install -y npm`     |
+| Linux    | rg   | `sudo apt install -y ripgrep` |
+| WSL      | node | `sudo apt install -y nodejs`  |
+
+## Interactive Installation
+
+User approval workflow:
+
+1. **Detection**: Check if tool is available
+2. **Prompt**: Ask user for approval with command preview
+3. **Execute**: Run platform-specific install command
+4. **Audit**: Log all attempts (success or failure)
+5. **Verify**: Optional post-install verification
+
+```python
+# Example approval prompt
+Do you want to proceed with installing node? [y/N]: y
+
+Installing node...
+The following command will be executed to install node:
+  sudo apt install -y nodejs
+```
+
+## Audit Logging
+
+All installation attempts logged to `.claude/runtime/logs/installation_audit.jsonl`:
+
+```json
+{
+  "timestamp": "2026-02-03T10:30:00Z",
+  "tool": "node",
+  "platform": "linux",
+  "command": ["sudo", "apt", "install", "-y", "nodejs"],
+  "user_approved": true,
+  "success": true,
+  "exit_code": 0,
+  "error_message": null
+}
+```
+
+## Error Recovery
+
+### Common Scenarios
+
+| Error             | Cause                    | Resolution                         |
+| ----------------- | ------------------------ | ---------------------------------- |
+| PermissionError   | WSL non-existent command | Returns false, prompts for install |
+| FileNotFoundError | Tool not in PATH         | Returns false, prompts for install |
+| TimeoutExpired    | Hanging subprocess       | Returns false, skips tool          |
+| Exit code 1       | Install failed           | Logs error, shows stderr to user   |
+
+### Example Error Handling
+
+```python
+# Safe subprocess wrapper
+def safe_subprocess_call(cmd: list[str], context: str, timeout: int = 30):
+    """Safely execute subprocess with comprehensive error handling."""
+    try:
+        result = subprocess.run(
+            cmd,
+            stdin=sys.stdin,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout
+        )
+        return (result.returncode, result.stdout, result.stderr)
+    except FileNotFoundError:
+        return (-1, "", f"{context}: Command not found")
+    except subprocess.TimeoutExpired:
+        return (-1, "", f"{context}: Command timed out after {timeout}s")
+    except PermissionError:
+        return (-1, "", f"{context}: Permission denied")
+```
+
+## Usage Examples
+
+### Check Prerequisites
+
+```python
+from amplihack.utils.prerequisites import check_prerequisites
+
+# Non-interactive check
+success = check_prerequisites(interactive=False)
+if not success:
+    print("Missing prerequisites detected")
+    sys.exit(1)
+```
+
+### Interactive Installation
+
+```python
+from amplihack.utils.prerequisites import check_prerequisites
+
+# Interactive with prompts
+success = check_prerequisites(interactive=True)
+# User will be prompted to install missing tools
+```
+
+### Check Specific Tool
+
+```python
+from amplihack.launcher.copilot import check_copilot
+
+if check_copilot():
+    print("Copilot CLI is installed")
+else:
+    print("Copilot CLI not found")
+```
+
+## Integration Points
+
+### Launcher Integration
+
+All launchers check prerequisites before execution:
+
+```python
+from amplihack.utils.prerequisites import check_prerequisites
+
+def launch():
+    if not check_prerequisites(interactive=True):
+        sys.exit(1)
+    # Continue with launch...
+```
+
+### Copilot Launcher
+
+Specific copilot check with auto-install:
+
+```python
+from amplihack.launcher.copilot import check_copilot, install_copilot
+
+if not check_copilot():
+    print("Copilot CLI not found. Auto-installing...")
+    if install_copilot():
+        print("✓ Copilot CLI installed")
+```
+
+## Testing
+
+### Unit Test Coverage
+
+Comprehensive tests for all exception paths:
+
+```python
+# tests/launcher/test_copilot.py
+class TestCheckCopilot:
+    def test_check_copilot_installed(self, mock_run):
+        """Test when copilot is available."""
+
+    def test_check_copilot_not_found(self, mock_run):
+        """Test FileNotFoundError handling."""
+
+    def test_check_copilot_permission_error(self, mock_run):
+        """Test PermissionError handling (WSL)."""
+
+    def test_check_copilot_timeout(self, mock_run):
+        """Test TimeoutExpired handling."""
+```
+
+### Manual Testing
+
+Test in realistic environments:
+
+```bash
+# Test on fresh WSL system
+cargo install amplihack-rs amplihack copilot
+
+# Test on macOS
+cargo install amplihack-rs amplihack claude
+
+# Test prerequisite detection
+amplihack --check-prereqs
+```
+
+## Troubleshooting
+
+### Issue: PermissionError on WSL
+
+**Symptom**: `PermissionError: [Errno 13] Permission denied: 'copilot'`
+
+**Cause**: WSL raises PermissionError for non-existent commands
+
+**Solution**: System automatically handles this and prompts for installation
+
+### Issue: Installation fails with exit code 1
+
+**Symptom**: Tool installation command fails
+
+**Causes**:
+
+- Network connectivity issues
+- Package repository problems
+- Insufficient permissions
+
+**Solution**: Check stderr output in audit log for specific error
+
+### Issue: Tool installed but not detected
+
+**Symptom**: Installation succeeds but verification fails
+
+**Causes**:
+
+- Tool not in PATH
+- Shell environment not updated
+- Need to restart shell
+
+**Solution**:
+
+```bash
+# Reload shell
+source ~/.bashrc  # or ~/.zshrc
+
+# Verify PATH
+echo $PATH | grep -o '[^:]*node[^:]*'
+```
+
+## Related Documentation
+
+- [Installation Guide](../howto/first-install.md)
+- [Prerequisites Overview](prerequisites.md)
+- [Platform Support](#)
+
+## Security Considerations
+
+- **No shell=True**: All subprocess calls use list arguments to prevent shell injection
+- **Hardcoded commands**: Only pre-approved commands in `INSTALL_COMMANDS` can be executed
+- **User approval required**: Every installation prompts for explicit confirmation
+- **Command preview**: Users see exact command before approval
+- **Audit logging**: All attempts logged to `.claude/runtime/logs/installation_audit.jsonl`
+- **Privilege escalation**: Commands using `sudo` are clearly marked in prompts
+
+### Command Dictionaries (Security Design)
+
+The system maintains TWO separate command dictionaries for security:
+
+1. **INSTALL_COMMANDS_DISPLAY** (string format)
+   - Multiple installation options shown to users
+   - Examples: "# Ubuntu/Debian:\nsudo apt install nodejs\n# Fedora..."
+   - Never executed, only for display
+
+2. **INSTALL_COMMANDS** (List[str] format)
+   - Single hardcoded command per platform/tool
+   - Example: ["sudo", "apt", "install", "-y", "nodejs"]
+   - Prevents shell injection (no shell=True)
+   - Only these commands can be executed
+
+This separation ensures users see all options but only vetted commands can be executed.
+
+## Performance
+
+- Tool checks use 5-second timeouts for responsiveness
+- Installation commands use 30-second default timeout
+- Interactive prompts skip in CI environments (no TTY)
+- Version parsing is fail-safe (invalid versions return False, not errors)
+
+## Design Decisions
+
+### Why Unified InstallationResult?
+
+Previously had duplicate dataclass definitions causing TypeErrors. Consolidated to single source of truth with all necessary fields.
+
+### Why Handle PermissionError?
+
+WSL-specific behavior where non-existent commands raise PermissionError instead of standard FileNotFoundError. Cross-platform compatibility requires handling both.
+
+### Why Interactive Installation?
+
+Security and user control - never install software without explicit approval. All commands shown to user before execution.

--- a/docs/reference/quality-audit-cycle-recipe.md
+++ b/docs/reference/quality-audit-cycle-recipe.md
@@ -1,0 +1,174 @@
+# Quality Audit Cycle Recipe Reference
+
+Reference for the `quality-audit-cycle` recipe
+(`amplifier-bundle/recipes/quality-audit-cycle.yaml`), version 4.0.0.
+
+## Context Variables
+
+| Variable               | Default                        | Description                                                   |
+| ---------------------- | ------------------------------ | ------------------------------------------------------------- |
+| `target_path`          | `src/amplihack`                | Directory to audit                                            |
+| `repo_path`            | `.`                            | Repository root; sets `working_dir` for agent steps           |
+| `min_cycles`           | `3`                            | Minimum audit cycles (always run at least this many)          |
+| `max_cycles`           | `6`                            | Maximum cycles (safety valve)                                 |
+| `validation_threshold` | `2`                            | Minimum validators that must agree (out of 3)                 |
+| `severity_threshold`   | `medium`                       | Minimum severity to report (`low`/`medium`/`high`/`critical`) |
+| `module_loc_limit`     | `300`                          | Flag modules exceeding this LOC count                         |
+| `fix_all_per_cycle`    | `true`                         | Must fix ALL confirmed findings before next cycle (#2842)     |
+| `categories`           | (all)                          | Comma-separated category filter                               |
+| `output_dir`           | `./eval_results/quality_audit` | Where to write audit output files                             |
+
+### Internal State Variables
+
+These are managed by the recipe loop and should not be set manually:
+
+`audit_findings`, `validation_agent_1`, `validation_agent_2`, `validation_agent_3`,
+`validated_findings`, `fix_results`, `fix_verification`,
+`cycle_number`, `cycle_history`, `recurse_decision`, `summary`,
+`self_improvement_results`
+
+## Steps
+
+| Step ID                | Type  | Purpose                                                            |
+| ---------------------- | ----- | ------------------------------------------------------------------ |
+| `seek`                 | agent | Scan codebase for quality issues (escalating depth)                |
+| `validate-agent-1/2/3` | agent | Three independent validators confirm/reject findings               |
+| `merge-validations`    | bash  | Merge validator outputs, require ≥`validation_threshold` agreement |
+| `fix`                  | agent | Fix ALL confirmed findings (fix-all-per-cycle rule)                |
+| `verify-fixes`         | bash  | Compare confirmed findings against fix results                     |
+| `accumulate-history`   | bash  | Append cycle findings to history for next cycle's SEEK             |
+| `recurse-decision`     | bash  | Decide CONTINUE or STOP based on cycle count and new findings      |
+| `summary`              | agent | Produce consolidated audit report                                  |
+| `self-improvement`     | agent | Review the audit process itself for workflow improvements          |
+
+### Loop Behavior
+
+```
+Cycle 1: seek → validate(×3) → merge → fix → verify → accumulate → decision
+Cycle 2: seek(deeper) → validate(×3) → merge → fix → verify → accumulate → decision
+Cycle 3+: seek(deepest) → validate(×3) → merge → fix → verify → accumulate → decision
+```
+
+- **Minimum cycles** always run regardless of findings.
+- **Continue past minimum** if any high/critical findings or >3 medium findings
+  emerged in the current cycle.
+- **Stop** at `max_cycles` unconditionally.
+
+## Bash Step Safety
+
+### The Problem
+
+Bash steps receive context variables via `{{variable}}` template interpolation.
+When a variable contains JSON (e.g., `{{validated_findings}}`), the raw JSON
+is pasted into the bash script. Characters like `"`, `{`, `}`, `$`, and
+backticks can be interpreted as bash syntax, causing errors like:
+
+```
+/bin/bash: line 3: crates/: Is a directory
+/bin/bash: line 14: json: command not found
+```
+
+### Safe Pattern: Temp Files + Quoted Heredocs
+
+Write JSON to temp files via single-quoted heredocs (`<<'EOF'`) so bash never
+interprets the content, then read from the file in Python:
+
+```yaml
+- id: "verify-fixes"
+  type: "bash"
+  command: |
+    _VALIDATED_TMPFILE=$(mktemp)
+    _FIX_RESULTS_TMPFILE=$(mktemp)
+    trap 'rm -f "$_VALIDATED_TMPFILE" "$_FIX_RESULTS_TMPFILE"' EXIT
+    cat > "$_VALIDATED_TMPFILE" <<'__VALIDATED_EOF__'
+    {{validated_findings}}
+    __VALIDATED_EOF__
+    cat > "$_FIX_RESULTS_TMPFILE" <<'__FIX_RESULTS_EOF__'
+    {{fix_results}}
+    __FIX_RESULTS_EOF__
+
+    export VALIDATED_FILE="$_VALIDATED_TMPFILE"
+    export FIX_RESULTS_FILE="$_FIX_RESULTS_TMPFILE"
+
+    python3 - <<'PYEOF'
+    import os
+    from amplihack.utils.defensive import parse_llm_json
+    with open(os.environ['VALIDATED_FILE']) as f:
+        validated = parse_llm_json(f.read())
+    # ... process safely in Python ...
+    PYEOF
+```
+
+**Why this works:** The `<<'__VALIDATED_EOF__'` (single-quoted delimiter) prevents
+bash from expanding `$variables` and backticks inside the heredoc. The JSON is
+written to a temp file — never assigned to a shell variable — so special
+characters like `{`, `}`, `$`, and backticks are inert. The `trap` ensures
+cleanup on exit.
+
+### Unsafe Pattern: Direct Interpolation in Bash
+
+```yaml
+# UNSAFE — template variables expand as bash code
+- id: "bad-step"
+  type: "bash"
+  command: |
+    FINDINGS={{validated_findings}}  # JSON becomes bash syntax
+    echo "$FINDINGS" | python3 -c "import sys, json; ..."
+```
+
+This fails because `{{validated_findings}}` expands to raw JSON like
+`{"validated": [...]}`, which bash interprets as command groups.
+
+### Alternative: Inline Python via Quoted Heredoc
+
+For simpler steps that only need one variable:
+
+```yaml
+- id: "recurse-decision"
+  type: "bash"
+  command: |
+    _TMPFILE=$(mktemp)
+    trap 'rm -f "$_TMPFILE"' EXIT
+    cat > "$_TMPFILE" <<'__EOF__'
+    {{validated_findings}}
+    __EOF__
+
+    python3 - <<'PYEOF'
+    from amplihack.utils.defensive import parse_llm_json
+    with open("'$_TMPFILE'") as f:
+        data = parse_llm_json(f.read())
+    PYEOF
+```
+
+> **Note:** The heredoc delimiter **must** be single-quoted (`<<'__EOF__'`).
+> An unquoted delimiter (`<<__EOF__`) allows bash to expand `$` and backticks
+> inside the heredoc, re-introducing the injection vulnerability.
+
+## Invocation
+
+Use `run_recipe_by_name()` from Python:
+
+```python
+from amplihack.recipes import run_recipe_by_name
+
+result = run_recipe_by_name(
+    "quality-audit-cycle",
+    user_context={
+        "target_path": "src/amplihack",
+        "repo_path": ".",
+        "min_cycles": "3",
+        "max_cycles": "6",
+    },
+    progress=True,
+)
+```
+
+> **Do not use** `amplihack recipe execute` — this CLI form is deprecated.
+> `run_recipe_by_name()` is the canonical invocation, consistent with
+> `dev-orchestrator` and all other recipe workflows.
+
+## See Also
+
+- [How to Run a Quality Audit](../howto/run-quality-audit.md) — task-focused guide
+- [SKILL.md](#) — skill activation
+  and detection categories

--- a/docs/reference/recipe-cli-reference.md
+++ b/docs/reference/recipe-cli-reference.md
@@ -1,0 +1,821 @@
+# Recipe CLI Reference
+
+Complete command-line reference for the `amplihack recipe` subcommand group. All recipe commands execute workflow recipes using code-enforced step progression.
+
+## Contents
+
+- [Global Options](#global-options)
+- [amplihack recipe list](#amplihack-recipe-list)
+- [amplihack recipe run](#amplihack-recipe-run)
+- [amplihack recipe validate](#amplihack-recipe-validate)
+- [amplihack recipe show](#amplihack-recipe-show)
+- [Exit Codes](#exit-codes)
+- [Environment Variables](#environment-variables)
+
+## Global Options
+
+Options that apply to all `amplihack recipe` commands.
+
+```bash
+amplihack recipe [GLOBAL_OPTIONS] <command> [OPTIONS]
+```
+
+| Option            | Description                | Default |
+| ----------------- | -------------------------- | ------- |
+| `--help`, `-h`    | Show help message and exit | -       |
+| `--version`       | Show recipe runner version | -       |
+| `--verbose`, `-v` | Enable verbose output      | `false` |
+| `--quiet`, `-q`   | Suppress non-error output  | `false` |
+
+**Examples**:
+
+```bash
+# Show recipe subcommand help
+amplihack recipe --help
+
+# Check recipe runner version
+amplihack recipe --version
+# Output: amplihack recipe runner 1.0.0
+
+# Verbose mode shows detailed step execution
+amplihack recipe --verbose list
+```
+
+## amplihack recipe list
+
+List all available workflow recipes discovered from standard recipe directories.
+
+### Synopsis
+
+```bash
+amplihack recipe list [OPTIONS]
+```
+
+### Description
+
+Scans recipe discovery paths and displays all available recipes with their descriptions. Recipe discovery order (later paths override earlier):
+
+1. `amplifier-bundle/recipes/` - Bundled recipes from Microsoft Amplifier
+2. `src/amplihack/amplifier-bundle/recipes/` - Package-embedded recipes
+3. `~/.amplihack/.claude/recipes/` - User-installed recipes
+4. `.claude/recipes/` - Project-specific recipes
+
+### Options
+
+| Option              | Description                                    | Default |
+| ------------------- | ---------------------------------------------- | ------- |
+| `--format <format>` | Output format: `text`, `json`, `yaml`, `table` | `text`  |
+| `--long`, `-l`      | Show extended details (path, steps, version)   | `false` |
+
+### Examples
+
+```bash
+# List all recipes (default format)
+amplihack recipe list
+```
+
+**Output**:
+
+```
+Available recipes:
+  default-workflow        22-step development workflow (requirements through merge)
+  verification-workflow   Post-implementation verification and testing
+  investigation           Deep codebase analysis and understanding
+  code-review             Multi-perspective code review
+  security-audit          Security-focused analysis pipeline
+  refactor                Systematic refactoring with safety checks
+  bug-triage              Bug investigation and root cause analysis
+  ddd-workflow            Document-driven development (6 phases)
+  ci-diagnostic           CI failure diagnosis and fix loop
+  quick-fix               Lightweight fix for simple issues
+```
+
+**Long format**:
+
+```bash
+amplihack recipe list --long
+```
+
+**Output**:
+
+```
+Available recipes:
+
+default-workflow (version 1.0)
+  Description: 22-step development workflow (requirements through merge)
+  Steps: 22
+  Path: /home/user/.amplihack/.claude/recipes/default-workflow.yaml
+
+verification-workflow (version 1.0)
+  Description: Post-implementation verification and testing
+  Steps: 8
+  Path: /home/user/.amplihack/.claude/recipes/verification-workflow.yaml
+
+...
+```
+
+**JSON format**:
+
+```bash
+amplihack recipe list --format json
+```
+
+**Output**:
+
+```json
+{
+  "recipes": [
+    {
+      "name": "default-workflow",
+      "description": "22-step development workflow (requirements through merge)",
+      "version": "1.0",
+      "steps": 22,
+      "path": "/home/user/.amplihack/.claude/recipes/default-workflow.yaml"
+    },
+    {
+      "name": "verification-workflow",
+      "description": "Post-implementation verification and testing",
+      "version": "1.0",
+      "steps": 8,
+      "path": "/home/user/.amplihack/.claude/recipes/verification-workflow.yaml"
+    }
+  ]
+}
+```
+
+**Table format**:
+
+```bash
+amplihack recipe list --format table
+```
+
+**Output**:
+
+```
+NAME                    DESCRIPTION                                              STEPS
+default-workflow        22-step development workflow (requirements through merge)   22
+verification-workflow   Post-implementation verification and testing                 8
+investigation           Deep codebase analysis and understanding                    12
+code-review             Multi-perspective code review                                6
+security-audit          Security-focused analysis pipeline                           9
+refactor                Systematic refactoring with safety checks                   10
+bug-triage              Bug investigation and root cause analysis                    7
+ddd-workflow            Document-driven development (6 phases)                      18
+ci-diagnostic           CI failure diagnosis and fix loop                            5
+quick-fix               Lightweight fix for simple issues                            4
+```
+
+### Exit Codes
+
+| Code | Meaning                                |
+| ---- | -------------------------------------- |
+| `0`  | Success - recipes found and listed     |
+| `1`  | No recipes found in any discovery path |
+
+## amplihack recipe run
+
+Execute a workflow recipe with runtime context. Steps execute sequentially with code-enforced progression (models cannot skip steps).
+
+### Synopsis
+
+```bash
+amplihack recipe run <recipe> [OPTIONS]
+```
+
+### Arguments
+
+| Argument   | Description                             | Required |
+| ---------- | --------------------------------------- | -------- |
+| `<recipe>` | Recipe name or path to recipe YAML file | Yes      |
+
+### Description
+
+Loads a recipe and executes each step in order:
+
+- Agent steps call AI agents via SDK adapter
+- Bash steps execute shell commands
+- Template variables in prompts/commands expand from context
+- Step outputs store in context for later steps
+- Steps with conditions may skip based on previous results
+
+Execution continues until:
+
+- All steps complete successfully (exit 0)
+- A step fails (exit > 0)
+- User interrupts with Ctrl+C (exit 130)
+
+### Options
+
+| Option                  | Description                             | Default     |
+| ----------------------- | --------------------------------------- | ----------- |
+| `--context <json>`      | Runtime context as JSON string          | `{}`        |
+| `--context-file <path>` | Load context from JSON file             | -           |
+| `--adapter <name>`      | SDK adapter: `claude`, `copilot`, `cli` | Auto-detect |
+| `--dry-run`             | Show steps without executing            | `false`     |
+| `--resume-from <step>`  | Resume from specific step ID            | -           |
+| `--stop-at <step>`      | Stop after specific step ID             | -           |
+| `--output <path>`       | Write execution log to file             | -           |
+| `--interactive`         | Prompt for approval before each step    | `false`     |
+
+### Examples
+
+**Basic execution**:
+
+```bash
+amplihack recipe run default-workflow \
+  --context '{"task_description": "Add user authentication", "repo_path": "."}'
+```
+
+**Output**:
+
+```
+[Recipe] default-workflow (22 steps)
+[Step 1/22] clarify-requirements (agent: prompt-writer)
+  Running: Analyze and clarify task requirements...
+  ✓ Completed in 3.2s
+  Output: context.clarified_requirements
+
+[Step 2/22] design (agent: architect)
+  Running: Design solution architecture...
+  ✓ Completed in 8.7s
+  Output: context.design_spec
+
+[Step 3/22] create-branch (type: bash)
+  Running: git checkout -b feat/user-auth
+  ✓ Completed in 0.3s
+
+...
+
+[Step 22/22] merge (type: bash)
+  Running: git merge --ff-only feat/user-auth
+  ✓ Completed in 0.5s
+
+Recipe completed successfully in 18m 32s
+```
+
+**Load context from file**:
+
+```bash
+# Create context file
+cat > context.json <<EOF
+{
+  "task_description": "Add JWT authentication to API",
+  "repo_path": "/home/user/myproject",
+  "branch_name": "feat/jwt-auth"
+}
+EOF
+
+# Run with context file
+amplihack recipe run default-workflow --context-file context.json
+```
+
+**Dry run mode**:
+
+```bash
+amplihack recipe run verification-workflow --dry-run
+```
+
+**Output**:
+
+```
+[DRY RUN] verification-workflow (8 steps)
+[Step 1/8] run-tests (type: bash)
+  Would execute: cd . && python -m pytest tests/ -v
+[Step 2/8] check-coverage (type: bash)
+  Would execute: cd . && pytest --cov=. --cov-report=term
+[Step 3/8] lint-check (agent: reviewer)
+  Would run agent: amplihack:reviewer
+  Prompt: Review code for style violations...
+
+No changes made (dry run mode)
+```
+
+**Resume from checkpoint**:
+
+```bash
+# Initial run fails at step 15
+amplihack recipe run default-workflow \
+  --context '{"task_description": "Add rate limiting"}'
+# ... fails at step 15: implement-logic
+
+# Fix the issue, then resume from step 15
+amplihack recipe run default-workflow \
+  --context '{"task_description": "Add rate limiting"}' \
+  --resume-from implement-logic
+```
+
+**Partial execution**:
+
+```bash
+# Run only steps 1-5 (stop before step 6)
+amplihack recipe run default-workflow \
+  --context '{"task_description": "Add caching"}' \
+  --stop-at write-tests
+```
+
+**Interactive mode**:
+
+```bash
+amplihack recipe run security-audit --interactive
+```
+
+**Output**:
+
+```
+[Step 1/8] scan-dependencies (agent: security)
+  Prompt: Scan package.json for vulnerable dependencies...
+
+Continue? [y/n]: y
+  ✓ Completed in 4.1s
+
+[Step 2/8] check-auth (agent: security)
+  Prompt: Review authentication implementation...
+
+Continue? [y/n]: n
+  Aborted by user
+
+Recipe stopped at step 2/8
+```
+
+**Save execution log**:
+
+```bash
+amplihack recipe run default-workflow \
+  --context '{"task_description": "Add webhooks"}' \
+  --output execution-log.json
+```
+
+**Log format**:
+
+```json
+{
+  "recipe": "default-workflow",
+  "start_time": "2026-02-14T10:30:00Z",
+  "end_time": "2026-02-14T10:48:32Z",
+  "duration_seconds": 1112,
+  "status": "completed",
+  "steps": [
+    {
+      "id": "clarify-requirements",
+      "type": "agent",
+      "agent": "amplihack:prompt-writer",
+      "start_time": "2026-02-14T10:30:01Z",
+      "duration_seconds": 3.2,
+      "status": "completed",
+      "output": "Store in context.clarified_requirements"
+    }
+  ]
+}
+```
+
+**Specify adapter**:
+
+```bash
+# Force Claude Agent SDK
+amplihack recipe run default-workflow --adapter claude \
+  --context '{"task_description": "Add monitoring"}'
+
+# Use GitHub Copilot SDK
+amplihack recipe run default-workflow --adapter copilot \
+  --context '{"task_description": "Add monitoring"}'
+
+# Generic CLI adapter (fallback)
+amplihack recipe run default-workflow --adapter cli \
+  --context '{"task_description": "Add monitoring"}'
+```
+
+**Run recipe from file path**:
+
+```bash
+# Absolute path
+amplihack recipe run /home/user/custom-recipes/my-workflow.yaml \
+  --context '{"target": "src/api"}'
+
+# Relative path
+amplihack recipe run ../shared-recipes/api-workflow.yaml \
+  --context '{"target": "src/api"}'
+```
+
+### Exit Codes
+
+| Code  | Meaning                           |
+| ----- | --------------------------------- |
+| `0`   | Success - all steps completed     |
+| `1`   | Recipe validation failed          |
+| `2`   | Missing required context variable |
+| `3`   | Step execution failed             |
+| `4`   | Agent not found                   |
+| `5`   | Adapter not available             |
+| `130` | Interrupted by user (Ctrl+C)      |
+
+## amplihack recipe validate
+
+Validate a recipe YAML file without executing it. Checks syntax, structure, agent references, and template variables.
+
+### Synopsis
+
+```bash
+amplihack recipe validate <file> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Description              | Required |
+| -------- | ------------------------ | -------- |
+| `<file>` | Path to recipe YAML file | Yes      |
+
+### Description
+
+Performs comprehensive validation:
+
+1. **YAML syntax** - Parses file as valid YAML
+2. **Required fields** - Checks `name` and `steps` are present
+3. **Step structure** - Validates each step has required fields
+4. **Unique IDs** - Ensures step IDs are unique within recipe
+5. **Agent references** - Verifies agents exist in agent directories
+6. **Template variables** - Checks `{{variables}}` are defined in context
+7. **Conditions** - Validates step conditions are valid Python expressions
+8. **Dependencies** - Detects circular dependencies in step conditions
+
+### Options
+
+| Option              | Description                   | Default |
+| ------------------- | ----------------------------- | ------- |
+| `--strict`          | Treat warnings as errors      | `false` |
+| `--format <format>` | Output format: `text`, `json` | `text`  |
+
+### Examples
+
+**Valid recipe**:
+
+```bash
+amplihack recipe validate my-workflow.yaml
+```
+
+**Output**:
+
+```
+Validating my-workflow.yaml...
+  [OK] Valid YAML syntax
+  [OK] Required fields present (name, steps)
+  [OK] All step IDs unique
+  [OK] Template variables resolve against context
+  [OK] Agent references valid (architect, builder, tester)
+  [OK] No circular dependencies
+
+Recipe "my-workflow" is valid (5 steps)
+```
+
+**Invalid recipe**:
+
+```bash
+amplihack recipe validate broken-recipe.yaml
+```
+
+**Output**:
+
+```
+Validating broken-recipe.yaml...
+  [OK] Valid YAML syntax
+  [OK] Required fields present
+  [FAIL] Step ID "test" appears 2 times (must be unique)
+  [FAIL] Agent reference "amplihack:unknown-agent" not found
+  [WARN] Context variable "{{missing_var}}" used but not defined
+
+Recipe validation failed with 2 errors, 1 warning
+```
+
+**Strict mode**:
+
+```bash
+amplihack recipe validate my-recipe.yaml --strict
+```
+
+Warnings become errors in strict mode. Returns exit code 1 if any warnings or errors found.
+
+**JSON output**:
+
+```bash
+amplihack recipe validate my-recipe.yaml --format json
+```
+
+**Output**:
+
+```json
+{
+  "valid": false,
+  "errors": [
+    {
+      "type": "duplicate_step_id",
+      "step_id": "test",
+      "message": "Step ID 'test' appears 2 times (must be unique)"
+    },
+    {
+      "type": "invalid_agent",
+      "agent": "amplihack:unknown-agent",
+      "message": "Agent reference 'amplihack:unknown-agent' not found"
+    }
+  ],
+  "warnings": [
+    {
+      "type": "undefined_variable",
+      "variable": "missing_var",
+      "message": "Context variable '{{missing_var}}' used but not defined"
+    }
+  ]
+}
+```
+
+### Exit Codes
+
+| Code | Meaning                          |
+| ---- | -------------------------------- |
+| `0`  | Success - recipe is valid        |
+| `1`  | Validation failed (errors found) |
+| `2`  | File not found or not readable   |
+
+## amplihack recipe show
+
+Display detailed information about a recipe including metadata, context variables, and step-by-step breakdown.
+
+### Synopsis
+
+```bash
+amplihack recipe show <recipe> [OPTIONS]
+```
+
+### Arguments
+
+| Argument   | Description                             | Required |
+| ---------- | --------------------------------------- | -------- |
+| `<recipe>` | Recipe name or path to recipe YAML file | Yes      |
+
+### Description
+
+Shows complete recipe details:
+
+- Metadata (name, description, version, author)
+- File path
+- Context variable definitions
+- Full step list with prompts, agents, commands
+- Step dependencies and outputs
+
+### Options
+
+| Option              | Description                                    | Default |
+| ------------------- | ---------------------------------------------- | ------- |
+| `--format <format>` | Output format: `text`, `json`, `yaml`, `table` | `text`  |
+| `--steps-only`      | Show only step list (omit metadata)            | `false` |
+
+### Examples
+
+**Show full recipe details**:
+
+```bash
+amplihack recipe show default-workflow
+```
+
+**Output**:
+
+```
+Recipe: default-workflow
+Description: 22-step development workflow (requirements through merge)
+Version: 1.0
+Author: amplihack
+Path: /home/user/.amplihack/.claude/recipes/default-workflow.yaml
+
+Context Variables:
+  task_description (required): Description of what to implement
+  repo_path (optional, default="."): Repository root path
+  branch_name (optional): Override branch name
+
+Steps (22):
+  1. clarify-requirements (agent: prompt-writer)
+     Prompt: |
+       Analyze and clarify the following task:
+       {{task_description}}
+
+       Rewrite as unambiguous, testable requirements.
+     Output: clarified_requirements
+
+  2. design (agent: architect)
+     Prompt: |
+       Design a solution for:
+       {{task_description}}
+
+       Requirements:
+       {{clarified_requirements}}
+     Uses: clarified_requirements
+     Output: design_spec
+
+  3. create-branch (type: bash)
+     Command: git checkout -b {{branch_name}}
+
+  ...
+
+  22. merge (type: bash)
+      Command: git merge --ff-only {{branch_name}}
+      Condition: tests_pass && ci_success
+```
+
+**Show steps only**:
+
+```bash
+amplihack recipe show default-workflow --steps-only
+```
+
+**Output**:
+
+```
+Steps (22):
+  1. clarify-requirements (agent: prompt-writer)
+  2. design (agent: architect)
+  3. create-branch (type: bash)
+  4. write-tests (agent: tester)
+  ...
+  22. merge (type: bash)
+```
+
+**JSON format**:
+
+```bash
+amplihack recipe show default-workflow --format json
+```
+
+**Output**:
+
+```json
+{
+  "name": "default-workflow",
+  "description": "22-step development workflow (requirements through merge)",
+  "version": "1.0",
+  "author": "amplihack",
+  "path": "/home/user/.amplihack/.claude/recipes/default-workflow.yaml",
+  "context": {
+    "task_description": {
+      "required": true,
+      "default": "",
+      "description": "Description of what to implement"
+    },
+    "repo_path": {
+      "required": false,
+      "default": ".",
+      "description": "Repository root path"
+    },
+    "branch_name": {
+      "required": false,
+      "default": null,
+      "description": "Override branch name"
+    }
+  },
+  "steps": [
+    {
+      "id": "clarify-requirements",
+      "type": "agent",
+      "agent": "amplihack:prompt-writer",
+      "prompt": "Analyze and clarify the following task:\n{{task_description}}\n\nRewrite as unambiguous, testable requirements.",
+      "output": "clarified_requirements"
+    }
+  ]
+}
+```
+
+**YAML format**:
+
+```bash
+amplihack recipe show default-workflow --format yaml
+```
+
+Returns the original recipe YAML content.
+
+**Table format**:
+
+```bash
+amplihack recipe show default-workflow --format table
+```
+
+**Output**:
+
+```
+STEP  ID                      TYPE   AGENT/COMMAND                     OUTPUT
+1     clarify-requirements    agent  amplihack:prompt-writer           clarified_requirements
+2     design                  agent  amplihack:architect               design_spec
+3     create-branch           bash   git checkout -b {{branch_name}}   -
+4     write-tests             agent  amplihack:tester                  test_files
+5     implement-logic         agent  amplihack:builder                 implementation
+6     review-code             agent  amplihack:reviewer                review_feedback
+7     run-tests               bash   pytest tests/ -v                  test_results
+8     commit-changes          bash   git commit -m "..."               -
+...
+```
+
+### Exit Codes
+
+| Code | Meaning                              |
+| ---- | ------------------------------------ |
+| `0`  | Success - recipe found and displayed |
+| `1`  | Recipe not found                     |
+
+## Exit Codes
+
+Summary of all exit codes used by recipe CLI commands.
+
+| Code  | Meaning                           | Commands          |
+| ----- | --------------------------------- | ----------------- |
+| `0`   | Success                           | All commands      |
+| `1`   | General error                     | All commands      |
+| `2`   | Invalid arguments or missing file | `validate`, `run` |
+| `3`   | Step execution failed             | `run`             |
+| `4`   | Agent not found                   | `run`             |
+| `5`   | Adapter not available             | `run`             |
+| `130` | Interrupted by user (Ctrl+C)      | `run`             |
+
+**Check exit code in shell**:
+
+```bash
+amplihack recipe run my-recipe --context '{...}'
+echo $?  # Prints exit code
+```
+
+**Use exit codes in scripts**:
+
+```bash
+#!/bin/bash
+set -e  # Exit on any error
+
+if amplihack recipe run default-workflow --context '{...}'; then
+  echo "Recipe succeeded"
+  notify-user "Deployment complete"
+else
+  exit_code=$?
+  echo "Recipe failed with code: $exit_code"
+  notify-user "Deployment failed"
+  exit $exit_code
+fi
+```
+
+## Environment Variables
+
+Environment variables that affect recipe CLI behavior.
+
+### AMPLIHACK_RECIPE_PATH
+
+Additional directories to search for recipes (colon-separated list).
+
+```bash
+export AMPLIHACK_RECIPE_PATH="/opt/company-recipes:/home/user/my-recipes"
+amplihack recipe list  # Includes recipes from both directories
+```
+
+Discovery order with `AMPLIHACK_RECIPE_PATH`:
+
+1. Built-in recipes
+2. User recipes (`~/.amplihack/.claude/recipes/`)
+3. Directories in `AMPLIHACK_RECIPE_PATH` (left to right)
+4. Project recipes (`.claude/recipes/`)
+
+### AMPLIHACK_ADAPTER
+
+Default SDK adapter when `--adapter` is not specified.
+
+```bash
+export AMPLIHACK_ADAPTER=copilot
+amplihack recipe run default-workflow --context '{...}'  # Uses copilot adapter
+```
+
+Valid values: `claude`, `copilot`, `cli`, `auto`
+
+### AMPLIHACK_VERBOSE
+
+Enable verbose output for all recipe commands.
+
+```bash
+export AMPLIHACK_VERBOSE=1
+amplihack recipe list  # Shows detailed discovery process
+```
+
+Equivalent to passing `--verbose` flag to each command.
+
+### AMPLIHACK_DRY_RUN
+
+Enable dry-run mode by default.
+
+```bash
+export AMPLIHACK_DRY_RUN=1
+amplihack recipe run my-recipe --context '{...}'  # Previews without executing
+```
+
+Override with explicit flag:
+
+```bash
+export AMPLIHACK_DRY_RUN=1
+amplihack recipe run my-recipe --dry-run=false --context '{...}'  # Actually executes
+```
+
+---
+
+**See also**:
+
+- [Recipe CLI How-To Guide](../howto/recipe-cli-commands.md) - Task-oriented usage examples
+- [Recipe Runner Overview](../howto/run-a-recipe.md) - Architecture and YAML format
+- [Creating Custom Recipes](../howto/run-a-recipe.md) - Recipe development guide

--- a/docs/reference/recipe-result.md
+++ b/docs/reference/recipe-result.md
@@ -1,0 +1,166 @@
+# RecipeResult Reference
+
+`RecipeResult` represents the outcome of running a workflow recipe. It captures whether the recipe succeeded, how many steps ran, and the result of each individual step.
+
+## Contents
+
+- [Class Overview](#class-overview)
+- [Attributes](#attributes)
+- [String Representation](#string-representation)
+- [Step Results](#step-results)
+- [Usage Examples](#usage-examples)
+- [Integration with Recipe Runner](#integration-with-recipe-runner)
+
+---
+
+## Class Overview
+
+```python
+from amplihack.recipes.models import RecipeResult, StepResult, RecipeStatus
+```
+
+`RecipeResult` is a dataclass. It is returned by `RecipeRunner.run()` and by the `amplihack recipe run` CLI command when `--output json` is used.
+
+---
+
+## Attributes
+
+| Attribute          | Type               | Description                                                               |
+| ------------------ | ------------------ | ------------------------------------------------------------------------- |
+| `recipe_name`      | `str`              | The name of the recipe that was run (e.g. `"default-workflow"`).          |
+| `status`           | `RecipeStatus`     | Overall outcome: `SUCCESS`, `FAILURE`, or `PARTIAL`.                      |
+| `step_results`     | `list[StepResult]` | Ordered list of results, one per step that executed.                      |
+| `duration_seconds` | `float`            | Wall-clock time from recipe start to finish.                              |
+| `error`            | `str \| None`      | Human-readable error message if `status` is `FAILURE`. `None` on success. |
+
+---
+
+## String Representation
+
+`str(result)` returns a one-line summary suitable for logging:
+
+```
+RecipeResult(<recipe-name>: <STATUS>, <N> steps)
+```
+
+**Examples:**
+
+```python
+result = runner.run("default-workflow", context)
+
+print(str(result))
+# RecipeResult(default-workflow: SUCCESS, 22 steps)
+
+failed_result = runner.run("quick-fix", context)
+print(str(failed_result))
+# RecipeResult(quick-fix: FAILURE, 3 steps)
+```
+
+The summary includes:
+
+- The recipe name as written in the recipe YAML file
+- The overall `STATUS` in uppercase
+- The count of steps that **completed** (not the total steps defined in the recipe)
+
+> **Note:** Prior to v0.9.2, `str(result)` returned a verbose multi-line representation that included individual step IDs (e.g. `step-1`). Code that parsed `str(result)` should be updated to use `result.step_results` directly for structured access.
+
+---
+
+## Step Results
+
+Each entry in `step_results` is a `StepResult`:
+
+```python
+@dataclass
+class StepResult:
+    step_id: str          # e.g. "step-1", "step-2"
+    step_name: str        # Human-readable step name from recipe YAML
+    status: StepStatus    # SUCCESS, FAILURE, SKIPPED
+    output: str | None    # Agent output or None if skipped
+    duration_seconds: float
+```
+
+Accessing step results directly:
+
+```python
+result = runner.run("default-workflow", context)
+
+for step in result.step_results:
+    print(f"{step.step_id}: {step.status.value} ({step.duration_seconds:.1f}s)")
+
+# step-1: SUCCESS (2.3s)
+# step-2: SUCCESS (8.1s)
+# step-3: FAILURE (1.0s)
+```
+
+---
+
+## Usage Examples
+
+### Check overall status
+
+```python
+from amplihack.recipes.runner import RecipeRunner
+from amplihack.recipes.models import RecipeStatus
+
+runner = RecipeRunner()
+result = runner.run("default-workflow", {"task_description": "add input validation"})
+
+if result.status == RecipeStatus.SUCCESS:
+    print(f"Done in {result.duration_seconds:.1f}s")
+else:
+    print(f"Failed: {result.error}")
+```
+
+### Count successful steps
+
+```python
+from amplihack.recipes.models import StepStatus
+
+successes = sum(1 for s in result.step_results if s.status == StepStatus.SUCCESS)
+print(f"{successes} of {len(result.step_results)} steps succeeded")
+```
+
+### Serialise to JSON
+
+```python
+import json
+import dataclasses
+
+# RecipeResult is a dataclass; convert with asdict()
+data = dataclasses.asdict(result)
+print(json.dumps(data, indent=2, default=str))
+```
+
+### Log a one-line summary
+
+```python
+import logging
+
+log = logging.getLogger(__name__)
+log.info(str(result))
+# INFO: RecipeResult(default-workflow: SUCCESS, 22 steps)
+```
+
+---
+
+## Integration with Recipe Runner
+
+`RecipeResult` is what the CLI surfaces when `--output json` is requested:
+
+```bash
+amplihack recipe run default-workflow \
+  --context '{"task_description": "add login endpoint"}' \
+  --output json | jq '.status'
+# "SUCCESS"
+```
+
+The JSON schema mirrors `dataclasses.asdict(result)` with the `status` field serialised as the string value of the `RecipeStatus` enum.
+
+---
+
+## See Also
+
+- [Recipe CLI Reference](./recipe-cli-reference.md) — `amplihack recipe run` and `--output json`
+- [Recipe CLI Examples](../howto/recipe-cli-examples.md) — real-world workflow scenarios
+- [Recipe Resilience](../concepts/recipe-resilience.md) — how partial failures and retries are handled

--- a/docs/reference/resumable-workstream-timeouts.md
+++ b/docs/reference/resumable-workstream-timeouts.md
@@ -1,0 +1,331 @@
+# Resumable Workstream Timeouts Reference
+
+> [Home](../index.md) > Reference > Resumable Workstream Timeouts
+>
+> **Implemented in issue #4032:** This page defines the shipped timeout, progress, resume, and cleanup contract for multitask workstreams.
+
+Field-level contract for configurable timeout handling, durable workstream state, checkpoint-boundary resume, and cleanup gating in the multitask orchestrator.
+
+## Contents
+
+- [Contract Status](#contract-status)
+- [Workstream Identity](#workstream-identity)
+- [Configuration Inputs and Precedence](#configuration-inputs-and-precedence)
+- [Lifecycle States](#lifecycle-states)
+- [Durable State Layout](#durable-state-layout)
+- [Progress and Heartbeat Contracts](#progress-and-heartbeat-contracts)
+- [Resume Contract](#resume-contract)
+- [Affected Code Surfaces](#affected-code-surfaces)
+- [Cleanup Eligibility Rules](#cleanup-eligibility-rules)
+- [Determinism and Security Invariants](#determinism-and-security-invariants)
+
+---
+
+## Contract Status
+
+- `ParallelOrchestrator.monitor()` enforces configurable runtime budgets and transitions over-budget workstreams to resumable lifecycle states instead of deleting them.
+- `rust_runner_execution.py` publishes both the legacy PID-scoped progress file and a durable workstream progress sidecar under `tmp_base/state/`.
+- `timeout_policy`, `lifecycle_state`, and `checkpoint_id` are shipped contract names for automation, reporting, and cleanup decisions.
+
+---
+
+## Workstream Identity
+
+The preserved workstream is keyed by its `issue` value.
+
+| Asset                            | Ownership rule                                                    |
+| -------------------------------- | ----------------------------------------------------------------- |
+| `ws-<issue>/`                    | Working directory for the multitask stream identified by `issue`. |
+| `log-<issue>.txt`                | Persistent log for that same workstream identity.                 |
+| `state/ws-<issue>.json`          | Canonical durable state for that workstream identity.             |
+| `state/ws-<issue>.progress.json` | Durable progress sidecar for that workstream identity.            |
+
+Rules:
+
+- same `issue` + same `tmp_base` means the same resumable workstream
+- change either one and you have created a new workstream
+- branch name, task text, or description may evolve, but identity must remain stable across retry, cleanup, and report paths
+
+---
+
+## Configuration Inputs and Precedence
+
+These are the implemented inputs for issue #4032.
+
+| Field            | Surface                                                                           | Type          | Default              | Meaning                                                                                           |
+| ---------------- | --------------------------------------------------------------------------------- | ------------- | -------------------- | ------------------------------------------------------------------------------------------------- |
+| `max_runtime`    | `--max-runtime`, `AMPLIHACK_MAX_RUNTIME`, workstream config, recipe context       | `int` seconds | `7200`               | Maximum monitor budget before the orchestrator transitions an active workstream out of `running`. |
+| `timeout_policy` | `--timeout-policy`, `AMPLIHACK_TIMEOUT_POLICY`, workstream config, recipe context | `str` enum    | `interrupt-preserve` | Controls whether timeout stops the current subprocess while preserving resumable state.           |
+
+Specific inputs beat general defaults:
+
+1. Per-workstream JSON overrides win for that workstream.
+2. Explicit CLI flags win for run-wide defaults when no per-workstream override exists.
+3. Recipe context propagated from `smart-orchestrator` seeds defaults when CLI flags are absent.
+4. Environment variables provide ambient defaults.
+5. Built-in fallback remains `7200` seconds with preservation semantics on timeout.
+
+### `timeout_policy` Values
+
+| Value                | Behavior                                                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `interrupt-preserve` | Send termination to the subprocess, persist state as resumable, and preserve worktree/workdir/logs for a later rerun.                            |
+| `continue-preserve`  | Persist resumable state as soon as the runtime budget is crossed, but keep the subprocess running until it exits on its own or is stopped later. |
+
+---
+
+## Lifecycle States
+
+`lifecycle_state` is the canonical retention and resume signal.
+
+| Value                   | Meaning                                                                | Cleanup eligible |
+| ----------------------- | ---------------------------------------------------------------------- | ---------------- |
+| `running`               | Active subprocess with a live workstream.                              | No               |
+| `completed`             | Terminal success.                                                      | Yes              |
+| `failed_terminal`       | Terminal failure with no supported continuation path.                  | Yes              |
+| `failed_resumable`      | Failure after durable state exists and the run can be continued.       | No               |
+| `timed_out_resumable`   | Runtime budget expired while work remained resumable.                  | No               |
+| `interrupted_resumable` | Shutdown, `SIGINT`, or manual stop preserved the run for continuation. | No               |
+| `abandoned`             | Operator intentionally marked the workstream disposable.               | Yes              |
+
+Compatibility `status` fields in heartbeat or progress consumers may still read as `running`, `completed`, or `failed`. New cleanup and resume decisions should use `lifecycle_state`.
+
+---
+
+## Durable State Layout
+
+The multitask orchestrator stores resumable state under:
+
+```text
+<tmp_base>/state/
+```
+
+With the default temporary base:
+
+```text
+/tmp/amplihack-workstreams/state/
+```
+
+### File Layout
+
+| Path                                          | Purpose                                                                                  |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `<tmp_base>/ws-<issue>/`                      | Preserved workstream directory containing launcher files and local workstream artifacts. |
+| `<tmp_base>/log-<issue>.txt`                  | Persistent log for the workstream.                                                       |
+| `<tmp_base>/state/ws-<issue>.json`            | Canonical durable workstream state file.                                                 |
+| `<tmp_base>/state/ws-<issue>.progress.json`   | Durable progress sidecar keyed by workstream identity.                                   |
+| `/tmp/amplihack-progress-<recipe>-<pid>.json` | Legacy PID-scoped progress file kept for compatibility.                                  |
+
+### Planned State File Shape
+
+```json
+{
+  "issue": 4032,
+  "recipe": "default-workflow",
+  "lifecycle_state": "timed_out_resumable",
+  "cleanup_eligible": false,
+  "attempt": 2,
+  "last_pid": 424242,
+  "last_exit_code": -15,
+  "current_step": "step-12-run-precommit",
+  "checkpoint_id": "checkpoint-after-review-feedback",
+  "work_dir": "/tmp/amplihack-workstreams/ws-4032",
+  "worktree_path": "/home/user/src/amplihack/worktrees/fix/issue-4032-resumable-timeouts",
+  "log_file": "/tmp/amplihack-workstreams/log-4032.txt",
+  "progress_sidecar": "/tmp/amplihack-workstreams/state/ws-4032.progress.json",
+  "created_at": "2026-04-01T06:10:00Z",
+  "updated_at": "2026-04-01T06:25:12Z"
+}
+```
+
+### Rules
+
+- Writes are atomic and rooted under `tmp_base/state/`.
+- `cleanup_eligible` is derived from `lifecycle_state` and persisted for reporting and cleanup commands.
+- Startup reuses existing `ws-*` and `state/` entries instead of deleting them.
+- Logs are retained independently of the workstream directory.
+
+---
+
+## Progress and Heartbeat Contracts
+
+### Legacy PID-Scoped Progress File
+
+`rust_runner_execution.py` continues to publish:
+
+```text
+/tmp/amplihack-progress-<recipe-name>-<pid>.json
+```
+
+Payload:
+
+```json
+{
+  "recipe_name": "default-workflow",
+  "current_step": 12,
+  "total_steps": 0,
+  "step_name": "step-12-run-precommit",
+  "elapsed_seconds": 244.218,
+  "status": "running",
+  "pid": 424242,
+  "updated_at": 1775025059.2169325
+}
+```
+
+This file remains unchanged for compatibility.
+
+### Durable Workstream Progress Sidecar
+
+Issue #4032 adds an orchestrator-owned sidecar keyed by workstream rather than PID:
+
+```json
+{
+  "issue": 4032,
+  "recipe_name": "default-workflow",
+  "current_step": 12,
+  "step_name": "step-12-run-precommit",
+  "checkpoint_id": "checkpoint-after-review-feedback",
+  "status": "running",
+  "pid": 424242,
+  "updated_at": 1775025059.2169325
+}
+```
+
+### Heartbeat Event
+
+Heartbeat output includes resumable fields directly:
+
+```json
+{
+  "type": "heartbeat",
+  "elapsed_seconds": 300,
+  "summary": {
+    "running": 0,
+    "completed": 0,
+    "failed": 1,
+    "total": 1
+  },
+  "workstreams": [
+    {
+      "issue": 4032,
+      "status": "failed",
+      "lifecycle_state": "timed_out_resumable",
+      "step": "step-12-run-precommit",
+      "checkpoint_id": "checkpoint-after-review-feedback",
+      "worktree_path": "/home/user/src/amplihack/worktrees/fix/issue-4032-resumable-timeouts",
+      "log_path": "/tmp/amplihack-workstreams/log-4032.txt",
+      "elapsed_s": 300
+    }
+  ]
+}
+```
+
+### Heartbeat Summary Compatibility
+
+- The top-level summary keeps the legacy `running/completed/failed/total` buckets during initial rollout.
+- Resumable states may still contribute to `summary.failed` for backward compatibility.
+- Per-workstream `lifecycle_state` is the authoritative field for automation and cleanup decisions.
+
+### Report Output
+
+`report()` surfaces the same contract for each workstream:
+
+- lifecycle state
+- runtime
+- resume checkpoint
+- preserved worktree path
+- log path
+- cleanup eligibility
+
+---
+
+## Resume Contract
+
+Resume is checkpoint-boundary based.
+
+### Automatic Resume
+
+When a rerun finds:
+
+- the same workstream identity
+- preserved `ws-*` and state files under the same `tmp_base`
+- a resumable lifecycle state
+
+the orchestrator reuses the saved worktree and injects the saved resume metadata into the nested workflow run.
+
+### Named Checkpoints
+
+`default-workflow` currently defines these relevant checkpoints:
+
+- `checkpoint-after-implementation`
+- `checkpoint-after-review-feedback`
+
+If implementation adds more resume boundaries later, they must be named and durable before the public docs expand.
+
+### Public Input Surface
+
+The docs intentionally do **not** lock a public `resume_from_step` parameter. If a caller-visible resume selector is added, it should be checkpoint-based rather than raw step-based.
+
+### What Resume Does Not Do
+
+Resume does not:
+
+- reconstruct state from logs alone
+- depend only on a stale PID-scoped temp file
+- pretend arbitrary mid-step replay exists
+- delete and recreate the worktree before continuing
+
+---
+
+## Affected Code Surfaces
+
+| Surface                                              | Previous behavior                                                                                       | Implemented contract                                                                                                                          |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ParallelOrchestrator.monitor()`                     | Used `max_runtime=7200`, terminated active workstreams, and immediately cleaned their work directories. | Enforces configurable timeout inputs per workstream and transitions active streams to `timed_out_resumable` without deleting preserved state. |
+| `ParallelOrchestrator.cleanup_running()`             | Terminates running subprocesses only.                                                                   | Records `interrupted_resumable` and preserves the workstream directory, worktree, logs, and state.                                            |
+| `ParallelOrchestrator.cleanup_merged()`              | Deletes merged workstreams by PR status alone.                                                          | Deletes only workstreams that are both selected for cleanup and lifecycle-cleanup-eligible.                                                   |
+| `ParallelOrchestrator.report()` and heartbeat output | Only model `running`, `completed`, and `failed`.                                                        | Surface `lifecycle_state`, checkpoint, worktree path, log path, and cleanup eligibility while preserving summary compatibility.               |
+| `run()`                                              | Accepted only `config_path`, `mode`, and `recipe`.                                                      | Threads timeout inputs through launch, monitor, and resume behavior without breaking existing defaults.                                       |
+| `rust_runner_execution._write_progress_file()`       | Publishes only the PID-scoped progress file.                                                            | Continues the legacy file and also writes a durable workstream sidecar.                                                                       |
+
+---
+
+## Cleanup Eligibility Rules
+
+Cleanup answers one question: **is this workstream both terminal and disposable?**
+
+| Lifecycle state         | Auto cleanup during monitor   | Cleanup command may delete |
+| ----------------------- | ----------------------------- | -------------------------- |
+| `completed`             | Yes                           | Yes                        |
+| `failed_terminal`       | Yes                           | Yes                        |
+| `abandoned`             | No automatic retry; removable | Yes                        |
+| `running`               | No                            | No                         |
+| `failed_resumable`      | No                            | No                         |
+| `timed_out_resumable`   | No                            | No                         |
+| `interrupted_resumable` | No                            | No                         |
+
+Startup cleanup follows the same table. A preserved resumable workstream is never deleted merely because it already exists on disk.
+
+---
+
+## Determinism and Security Invariants
+
+The feature relies on these invariants:
+
+- timeout and resume decisions use durable orchestrator-owned signals
+- `lifecycle_state` is persisted explicitly instead of inferred from log text
+- timeout alone never marks a workstream cleanup-eligible
+- state and progress sidecars are rooted under `tmp_base/state/`
+- state writes use atomic replace semantics
+- state directories are private to the orchestrator
+- preserved worktrees are reused, not reconstructed from logs
+
+If one of those invariants cannot be met, the workstream should fail loudly instead of silently falling back to destructive cleanup.
+
+---
+
+## See Also
+
+- [Resumable workstream timeouts overview](../features/resumable-workstream-timeouts.md)
+- [How to configure resumable workstream timeouts](../howto/configure-resumable-workstream-timeouts.md)
+- [Tutorial: resumable workstream timeouts](../tutorials/resumable-workstream-timeouts.md)

--- a/docs/reference/rust-runner-execution.md
+++ b/docs/reference/rust-runner-execution.md
@@ -1,0 +1,275 @@
+# Rust Runner Execution — API Reference
+
+Module: `amplihack.recipes.rust_runner_execution`
+
+Subprocess management, progress tracking, JSONL event emission, and log I/O helpers for the Rust recipe runner. Consumed primarily by [`rust_runner.py`](#); callers outside that module should use the public surface documented below.
+
+## Contents
+
+- [Public API](#public-api)
+  - [execute_rust_command](#execute_rust_command)
+  - [read_progress_file](#read_progress_file)
+  - [emit_step_transition](#emit_step_transition)
+  - [build_rust_env](#build_rust_env)
+- [Data Shapes](#data-shapes)
+  - [Progress file JSON](#progress-file-json)
+  - [JSONL step-transition event](#jsonl-step-transition-event)
+- [Environment Variables](#environment-variables)
+- [Security Model](#security-model)
+- [Internal Functions](#internal-functions)
+
+---
+
+## Public API
+
+### `execute_rust_command`
+
+```python
+def execute_rust_command(
+    cmd: list[str],
+    *,
+    name: str,
+    progress: bool,
+    env_builder: Callable[[], dict[str, str]],
+) -> RecipeResult:
+```
+
+Run a compiled `recipe-runner-rs` command and return a fully typed [`RecipeResult`](./recipe-result.md).
+
+| Parameter     | Type                           | Description                                                                                                                                    |
+| ------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cmd`         | `list[str]`                    | Argument list (first element is the binary path). Never passed through a shell.                                                                |
+| `name`        | `str`                          | Recipe name, used for progress-file paths and log file naming.                                                                                 |
+| `progress`    | `bool`                         | When `True`, creates a per-recipe log file, writes progress JSON after each step marker, and prints the log path to stderr for live `tail -f`. |
+| `env_builder` | `Callable[[], dict[str, str]]` | Zero-argument callable that returns the subprocess environment. Use [`build_rust_env`](#build_rust_env) unless you have a custom requirement.  |
+
+Returns a [`RecipeResult`](./recipe-result.md) with `success`, `step_results`, `context`, and `log_path`.
+
+Raises `RuntimeError` on non-zero exit or JSON parse failure.
+
+**Example:**
+
+```python
+import shutil
+from amplihack.recipes.rust_runner_execution import execute_rust_command, build_rust_env
+from amplihack.recipes.rust_runner import find_rust_binary, _build_rust_env
+
+binary = find_rust_binary()
+cmd = [binary, "run", "--recipe", "my-recipe"]
+# _build_rust_env() is the pre-wired wrapper that supplies the correct wrapper_factory.
+result = execute_rust_command(
+    cmd=cmd,
+    name="my-recipe",
+    progress=True,
+    env_builder=_build_rust_env,
+)
+print(result.success, result.log_path)
+```
+
+---
+
+### `read_progress_file`
+
+```python
+def read_progress_file(path: Path | str) -> dict[str, Any] | None:
+```
+
+Read and validate a progress JSON file written by the recipe runner. Returns `None` on any I/O or parse error — callers must handle the `None` case gracefully.
+
+**Example:**
+
+```python
+import tempfile, os
+from pathlib import Path
+from amplihack.recipes.rust_runner_execution import read_progress_file
+
+progress_dir = Path(tempfile.gettempdir())
+path = progress_dir / "amplihack-progress-my_recipe-12345.json"
+info = read_progress_file(path)
+if info:
+    total = info.get("total_steps") or 0  # 0 means unknown; Python layer always writes 0
+    step_label = f"{info['current_step']}" + (f"/{total}" if total else "")
+    print(f"Step {step_label}: {info.get('step_name', '')}")
+```
+
+Returned dict fields (required fields are always present when the function returns non-`None`; optional fields may be absent):
+
+| Field             | Type    | Required | Description                                                                                                                                         |
+| ----------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `recipe_name`     | `str`   | ✓        | Sanitized recipe name                                                                                                                               |
+| `current_step`    | `int`   | ✓        | 1-based index of the running step                                                                                                                   |
+| `status`          | `str`   | ✓        | One of `running`, `completed`, `failed`                                                                                                             |
+| `pid`             | `int`   | ✓        | PID of the recipe-runner-rs process                                                                                                                 |
+| `total_steps`     | `int`   | optional | Total step count; the Python streaming layer always writes `0` (unknown) — only a Rust binary that reports step totals will supply a non-zero value |
+| `step_name`       | `str`   | optional | Human-readable step label                                                                                                                           |
+| `elapsed_seconds` | `float` | optional | Seconds since recipe start                                                                                                                          |
+| `updated_at`      | `float` | optional | Unix timestamp of last write                                                                                                                        |
+
+---
+
+### `emit_step_transition`
+
+```python
+def emit_step_transition(step_name: str, status: str) -> None:
+```
+
+Write a machine-readable JSONL step-transition event to **stderr** with immediate flush.
+
+| Parameter   | Values                                        |
+| ----------- | --------------------------------------------- |
+| `step_name` | Arbitrary label matching the recipe step name |
+| `status`    | `"start"` · `"done"` · `"fail"` · `"skip"`    |
+
+This function is called automatically by the streaming layer; only call it directly from custom step implementations that execute outside the Rust binary (e.g., Python pre/post-hooks).
+
+**Output format:**
+
+```json
+{ "type": "step_transition", "step": "validate-inputs", "status": "start", "ts": 1743554401.12 }
+```
+
+**Filtering:** Parent processes suppress these lines from user-visible output via `_STEP_TRANSITION_PREFIX` detection.
+
+---
+
+### `build_rust_env`
+
+```python
+def build_rust_env(
+    *,
+    wrapper_factory: Callable[[str], str],
+    which: Callable[..., str | None],
+) -> dict[str, str]:
+```
+
+Return a filtered environment dictionary suitable for passing to `subprocess.Popen`. Only variables on the `_ALLOWED_RUST_ENV_VARS` allowlist are included, preventing accidental secret leakage (e.g. `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`).
+
+Both parameters are keyword-only:
+
+| Parameter         | Type                         | Description                                                                                                                                                                            |
+| ----------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wrapper_factory` | `Callable[[str], str]`       | Takes the real `copilot` binary path and returns a path to a temporary directory containing a shim `copilot` script. Used to intercept nested `copilot` invocations inside the recipe. |
+| `which`           | `Callable[..., str \| None]` | Locates the real `copilot` binary on `PATH` (pass `shutil.which`).                                                                                                                     |
+
+If `AMPLIHACK_AGENT_BINARY` is not `"copilot"`, neither callable is invoked.
+
+> **Note:** Most callers should use `rust_runner._build_rust_env()` directly — it is the pre-wired version that supplies the Copilot compatibility `wrapper_factory`. Call `build_rust_env()` directly only when you need a custom wrapper strategy.
+
+**Allowlisted variable families:**
+
+| Family           | Examples                                                         |
+| ---------------- | ---------------------------------------------------------------- |
+| `AMPLIHACK_*`    | `AMPLIHACK_HOME`, `AMPLIHACK_SESSION_ID`, `AMPLIHACK_RECIPE_LOG` |
+| Path & shell     | `PATH`, `HOME`, `SHELL`, `USER`                                  |
+| Proxy            | `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` (case-insensitive)       |
+| TLS / CA bundles | `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`          |
+| Locale           | `LANG`, `LC_ALL`, `LC_CTYPE`                                     |
+| Temp dirs        | `TMPDIR`, `TMP`, `TEMP`                                          |
+| Runtime          | `PYTHONPATH`, `RECIPE_RUNNER_RS_PATH`, `CLAUDE_PROJECT_DIR`      |
+
+---
+
+## Data Shapes
+
+### Progress file JSON
+
+Written to `/tmp/amplihack-progress-<recipe>-<pid>.json` after each step transition.
+
+```json
+{
+  "recipe_name": "smart-orchestrator",
+  "current_step": 3,
+  "total_steps": 0,
+  "step_name": "Run builder agent",
+  "elapsed_seconds": 42.8,
+  "status": "running",
+  "pid": 98765,
+  "updated_at": 1743554401.5
+}
+```
+
+> **Note:** `total_steps` is always `0` when written by the Python streaming layer (the Rust binary does not report step totals). Treat `0` as "unknown".
+
+An optional workstream sidecar at `$AMPLIHACK_WORKSTREAM_PROGRESS_FILE` augments the main file with:
+
+```json
+{
+  "recipe_name": "smart-orchestrator",
+  "current_step": 3,
+  "step_name": "Run builder agent",
+  "status": "running",
+  "pid": 98765,
+  "updated_at": 1743554401.5,
+  "issue": "1234",
+  "checkpoint_id": "cp-abc",
+  "worktree_path": "/home/user/repo/worktrees/issue-1234"
+}
+```
+
+### JSONL step-transition event
+
+Emitted to stderr; one line per step transition.
+
+```
+{"type":"step_transition","step":"<step-name>","status":"<start|done|fail|skip>","ts":<float>}
+```
+
+Heartbeat pings from long-running steps use a separate type:
+
+```
+{"type":"heartbeat","step":"<step-name>","ts":<float>}
+```
+
+---
+
+## Environment Variables
+
+| Variable                             | Description                                                                                           |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `AMPLIHACK_RECIPE_LOG`               | Set automatically to the log file path when `progress=True`. Child processes can append to this file. |
+| `AMPLIHACK_WORKSTREAM_PROGRESS_FILE` | Optional path for the workstream progress sidecar. Set by the workstream orchestrator.                |
+| `AMPLIHACK_WORKSTREAM_STATE_FILE`    | Optional path to a workstream state JSON file read for issue/checkpoint context.                      |
+
+---
+
+## Security Model
+
+| Property                   | Mechanism                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------- |
+| No shell injection         | `subprocess.Popen` always receives a `list[str]`; `shell=False` is the default                            |
+| Symlink-safe file creation | Progress and log files opened with `O_NOFOLLOW                                                            | O_CREAT`; mode `0o600` |
+| Atomic writes              | Progress JSON written via `tempfile.NamedTemporaryFile` + `os.replace()`; readers never see partial files |
+| Path traversal prevention  | `_validate_path_within_tmpdir()` rejects any resolved path outside `tempfile.gettempdir()`                |
+| Minimal env surface        | `build_rust_env()` allowlist excludes all credential variables                                            |
+| Recipe name sanitization   | Recipe names reduced to `[a-zA-Z0-9_]`, capped at 64 characters before use in file paths                  |
+
+---
+
+## Internal Functions
+
+These functions are implementation details; do not call them directly.
+
+| Function                                                                    | Purpose                                                                                 |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `_validate_path_within_tmpdir(path)`                                        | Raises `ValueError` if `path.resolve()` escapes `tempfile.gettempdir()`                 |
+| `_atomic_write_json(path, payload)`                                         | Write JSON payload atomically; falls back to direct write on cross-device rename errors |
+| `_progress_file_path(recipe_name, pid)`                                     | Returns `/tmp/amplihack-progress-<sanitized>-<pid>.json`                                |
+| `_recipe_log_path(recipe_name, pid)`                                        | Returns `/tmp/amplihack-recipe-<sanitized>-<pid>.log`                                   |
+| `_stream_process_output(process)`                                           | Basic stdout/stderr drain (no progress tracking)                                        |
+| `_stream_process_output_with_progress(process, recipe_name, log_file_path)` | Thread-based drain with step-marker detection and log tee                               |
+| `_run_rust_process(cmd, progress, env, recipe_name)`                        | Spawn process, select streaming mode, return `(stdout, stderr, returncode, log_path)`   |
+| `_meaningful_stderr_tail(stderr)`                                           | Last 5 lines of stderr after filtering metadata lines                                   |
+| `_is_progress_metadata_line(line)`                                          | Returns `True` for step-transition and heartbeat JSONL lines                            |
+| `_raise_process_failure(stderr, returncode)`                                | Raise `RuntimeError` with signal name or trimmed stderr                                 |
+| `_parse_rust_response(stdout, stderr, returncode, name)`                    | JSON parse with structured error fallback                                               |
+| `_validate_rust_response_payload(data, name)`                               | Assert contract: `success` (bool), `step_results` (list), `context` (dict)              |
+| `_build_step_results(step_results_data)`                                    | Convert raw JSON list to `list[StepResult]`                                             |
+
+---
+
+**See also:**
+
+- [Recipe Result data model](./recipe-result.md)
+- [Recipe CLI Reference](./recipe-cli-reference.md)
+- [Rust Runner Execution Architecture](../concepts/rust-runner-execution-architecture.md)
+- [Issue Classifier Workflow](../howto/configure-issue-classifier-workflow.md)

--- a/docs/reference/staging-api.md
+++ b/docs/reference/staging-api.md
@@ -1,0 +1,313 @@
+# Staging API Reference
+
+Developer reference for the unified .claude/ staging mechanism.
+
+## Overview
+
+All amplihack commands (except `claude`) call `_ensure_amplihack_staged()` before launching their respective tools. This ensures `~/.amplihack/.claude/` is populated with agents, skills, tools, and framework files.
+
+## Core Functions
+
+### `_ensure_amplihack_staged()`
+
+Ensures amplihack framework files are staged to `~/.amplihack/.claude/`.
+
+**Signature:**
+
+```python
+def _ensure_amplihack_staged() -> None:
+    """Ensure amplihack is staged to ~/.amplihack/.claude/ (UVX mode only)."""
+```
+
+**Behavior:**
+
+1. Detects deployment mode via `deployment.get_deployment_mode()`
+2. Returns immediately if not in UVX mode (development uses source files)
+3. Creates `~/.amplihack/.claude/` if missing
+4. Calls `copytree_manifest()` to copy framework files
+5. Handles errors gracefully with user-friendly messages
+
+**Called by:**
+
+- `cmd_copilot()` - Before launching GitHub Copilot CLI
+- `cmd_amplifier()` - Before launching Microsoft Amplifier
+- `cmd_rustyclawd()` - Before launching Rustyclawd
+- `cmd_codex()` - Before launching Codex
+
+**NOT called by:**
+
+- `cmd_claude()` - Uses different staging mechanism for plugin support
+
+**Example:**
+
+```python
+def cmd_copilot(args):
+    """Launch GitHub Copilot CLI with amplihack."""
+    # Ensure staging before launching
+    _ensure_amplihack_staged()
+
+    # Launch tool with full framework access
+    launch_copilot_with_hooks()
+```
+
+### `copytree_manifest()`
+
+Copies files from source to destination based on manifest specification.
+
+**Signature:**
+
+```python
+def copytree_manifest(
+    source: Path,
+    dest: Path,
+    manifest: Dict[str, List[str]],
+    overwrite: bool = True
+) -> None:
+    """Copy directory tree using manifest to filter files."""
+```
+
+**Parameters:**
+
+- `source`: Source directory (package's `.claude/` directory)
+- `dest`: Destination directory (`~/.amplihack/.claude/`)
+- `manifest`: Dictionary mapping subdirectories to glob patterns
+- `overwrite`: Whether to replace existing files (default: True)
+
+**Manifest Format:**
+
+```python
+STAGING_MANIFEST = {
+    "agents": ["**/*.md"],              # All agent markdown files
+    "skills": ["**/*.md", "**/*.py"],   # Skill docs and Python files
+    "commands": ["**/*.py", "**/*.sh"], # Command scripts
+    "tools": ["**/*.py"],               # Tool utilities
+    "hooks": ["**/*.py", "**/*.sh"],    # Hook scripts
+    "context": ["**/*.md"],             # Context documentation
+    "workflow": ["**/*.md"],            # Workflow definitions
+}
+```
+
+**Example:**
+
+```python
+from pathlib import Path
+from amplihack.deployment import copytree_manifest
+
+source = Path(__file__).parent / ".claude"
+dest = Path.home() / ".amplihack" / ".claude"
+
+copytree_manifest(
+    source=source,
+    dest=dest,
+    manifest=STAGING_MANIFEST,
+    overwrite=True
+)
+```
+
+### `get_deployment_mode()`
+
+Detects current deployment mode (development vs UVX).
+
+**Signature:**
+
+```python
+def get_deployment_mode() -> str:
+    """Detect deployment mode: 'development' or 'uvx'."""
+```
+
+**Returns:**
+
+- `"development"`: Running from source (editable install, git clone)
+- `"uvx"`: Running from UVX isolated environment
+
+**Detection Logic:**
+
+```python
+def get_deployment_mode() -> str:
+    # Check for .git directory (development)
+    if (Path(__file__).parent.parent / ".git").exists():
+        return "development"
+
+    # Check for UVX environment markers
+    if "/.local/share/uv/" in str(Path(__file__)):
+        return "uvx"
+
+    return "uvx"  # Default to UVX if uncertain
+```
+
+**Example:**
+
+```python
+from amplihack.deployment import get_deployment_mode
+
+mode = get_deployment_mode()
+if mode == "uvx":
+    print("Running in UVX deployment mode")
+    _ensure_amplihack_staged()
+else:
+    print("Running in development mode - using source files")
+```
+
+## Constants
+
+### `STAGING_MANIFEST`
+
+Defines which files to copy during staging.
+
+```python
+STAGING_MANIFEST: Dict[str, List[str]] = {
+    "agents": ["**/*.md"],
+    "skills": ["**/*.md", "**/*.py"],
+    "commands": ["**/*.py", "**/*.sh"],
+    "tools": ["**/*.py"],
+    "hooks": ["**/*.py", "**/*.sh"],
+    "context": ["**/*.md"],
+    "workflow": ["**/*.md"],
+}
+```
+
+### `STAGING_TARGET`
+
+Target directory for staged files.
+
+```python
+STAGING_TARGET: Path = Path.home() / ".amplihack" / ".claude"
+```
+
+## Error Handling
+
+### Permission Errors
+
+```python
+try:
+    _ensure_amplihack_staged()
+except PermissionError as e:
+    print(f"Error: Cannot write to ~/.amplihack/.claude/")
+    print(f"Details: {e}")
+    print("Fix: chmod -R u+w ~/.amplihack/")
+    sys.exit(1)
+```
+
+### Missing Source Files
+
+```python
+try:
+    copytree_manifest(source, dest, STAGING_MANIFEST)
+except FileNotFoundError as e:
+    print(f"Error: Cannot find source files to stage")
+    print(f"Details: {e}")
+    print("This indicates a corrupted package installation")
+    sys.exit(1)
+```
+
+## Testing
+
+### Verify Staging in Tests
+
+```python
+import pytest
+from pathlib import Path
+from amplihack.cli import _ensure_amplihack_staged
+
+def test_staging_creates_directory(tmp_path, monkeypatch):
+    """Test that staging creates target directory."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    _ensure_amplihack_staged()
+
+    staged_dir = tmp_path / ".amplihack" / ".claude"
+    assert staged_dir.exists()
+    assert (staged_dir / "agents").exists()
+    assert (staged_dir / "skills").exists()
+
+def test_staging_skipped_in_dev_mode(monkeypatch):
+    """Test that staging is skipped in development mode."""
+    monkeypatch.setattr(
+        "amplihack.deployment.get_deployment_mode",
+        lambda: "development"
+    )
+
+    # Should return without staging
+    _ensure_amplihack_staged()
+    # No staging directory created
+```
+
+### Manual Testing
+
+```bash
+# Test staging from package
+cargo install amplihack-rs amplihack copilot --help
+
+# Verify staging occurred
+ls -la ~/.amplihack/.claude/
+
+# Test re-staging (should be fast)
+cargo install amplihack-rs amplihack copilot --help
+
+# Test with clean slate
+rm -rf ~/.amplihack/.claude/
+cargo install amplihack-rs amplihack copilot --help
+```
+
+## Troubleshooting
+
+### Staging Not Happening
+
+**Symptom**: Agents/skills not available after running command.
+
+**Check deployment mode:**
+
+```python
+from amplihack.deployment import get_deployment_mode
+print(get_deployment_mode())
+# Should print: "uvx"
+```
+
+**Check staging call:**
+
+```bash
+# Add debug output to _ensure_amplihack_staged()
+# Should see: "Staging amplihack to ~/.amplihack/.claude/..."
+```
+
+### Stale Files After Update
+
+**Symptom**: Old behavior persists after package upgrade.
+
+**Force re-staging:**
+
+```bash
+# Remove staged files
+rm -rf ~/.amplihack/.claude/
+
+# Re-run command
+cargo install amplihack-rs amplihack copilot
+```
+
+### Partial Staging
+
+**Symptom**: Some files staged but not others.
+
+**Check manifest:**
+
+```python
+from amplihack.cli import STAGING_MANIFEST
+print(STAGING_MANIFEST)
+# Verify expected patterns are present
+```
+
+**Check source files:**
+
+```bash
+# Find package location
+python -c "import amplihack; print(amplihack.__file__)"
+
+# Check source .claude/ directory
+ls -la /path/to/package/.claude/
+```
+
+## Related
+
+- [Verify Staging](../howto/verify-claude-staging.md) - User guide
+- [Unified Staging Architecture](../concepts/unified-staging-architecture.md) - Design rationale
+- [UVX Deployment](#) - Deployment patterns

--- a/docs/reference/token-sanitizer.md
+++ b/docs/reference/token-sanitizer.md
@@ -1,0 +1,135 @@
+# Token Sanitizer Reference
+
+The token sanitizer (`amplihack.utils.token_sanitizer`) replaces API keys and secrets in request and response bodies before they are logged, stored in memory, or forwarded to external services.
+
+## Contents
+
+- [What Gets Sanitized](#what-gets-sanitized)
+- [Pattern Ordering](#pattern-ordering)
+- [Usage](#usage)
+- [API](#api)
+- [Adding Custom Patterns](#adding-custom-patterns)
+- [Redacted Tokens](#redacted-tokens)
+
+---
+
+## What Gets Sanitized
+
+The sanitizer detects and replaces the following token types:
+
+| Token Type            | Pattern                     | Redacted Form                      |
+| --------------------- | --------------------------- | ---------------------------------- |
+| OpenAI project key    | `sk-proj-…`                 | `sk-proj-***`                      |
+| OpenAI standard key   | `sk-…`                      | `sk-***`                           |
+| Azure subscription ID | UUID format in Azure paths  | `[REDACTED:azure-subscription-id]` |
+| GitHub PAT            | `ghp_…` or `github_pat_…`   | `ghp_***` / `github_pat_***`       |
+| Generic bearer token  | `Bearer <token>` in headers | `[REDACTED:bearer-token]`          |
+
+---
+
+## Pattern Ordering
+
+**Patterns are matched in order from most specific to least specific.** This is critical for correct redaction.
+
+The `sk-proj-` pattern is placed **before** the `sk-` pattern. Without this ordering, every project key would be mis-redacted as a generic OpenAI key:
+
+```
+Input:    sk-proj-abc123…
+Correct:  sk-proj-***   (sk-proj- matches first)
+Incorrect: sk-***        (if sk- matched first)
+```
+
+The redacted form matters: downstream systems use the prefix to decide which key management vault was the source and to alert on unexpected key types appearing in logs.
+
+---
+
+## Usage
+
+```python
+from amplihack.utils.token_sanitizer import sanitize
+
+raw_body = '{"api_key": "sk-proj-xxxxxxxxxxxxxxxxxxxxxxxx"}'  # pragma: allowlist secret
+clean_body = sanitize(raw_body)
+print(clean_body)
+# {"api_key": "sk-proj-***"}  # pragma: allowlist secret
+```
+
+The function is idempotent — the replacement strings (e.g. `sk-***`) contain only three asterisks after the prefix, which is shorter than the `{6,}` minimum required by any pattern. A second call produces the same output.
+
+```python
+# Idempotent: safe to call twice
+twice = sanitize(sanitize(raw_body))
+assert twice == sanitize(raw_body)
+```
+
+---
+
+## API
+
+### `sanitize(text: str) -> str`
+
+Scans `text` for known secret patterns and replaces each match with its redacted form. Returns the sanitized string.
+
+**Parameters**
+
+| Name   | Type  | Description                                            |
+| ------ | ----- | ------------------------------------------------------ |
+| `text` | `str` | Input text, typically a JSON request or response body. |
+
+**Returns** `str` — A copy of `text` with all recognised secrets replaced using the `***` format (e.g. `sk-***`, `sk-proj-***`).
+
+**Raises** Nothing. Errors in regex compilation surface at import time, not at call time.
+
+---
+
+### `sanitize_dict(data: dict | None) -> dict`
+
+Recursively sanitizes a dictionary. Returns a new dict with secrets replaced.
+
+- Keys in `FULLY_REDACT_KEYS` (includes `Authorization`, `X-Api-Key`) have their **entire value** replaced with `[REDACTED:bearer-token]`.
+- All other string values are passed through `sanitize()`.
+- Nested dicts and lists are processed recursively.
+- `None` input returns an empty dict.
+
+```python
+from amplihack.utils.token_sanitizer import sanitize_dict
+
+raw = {"Authorization": "Bearer sk-ant-abc123", "Content-Type": "application/json"}
+clean = sanitize_dict(raw)
+# {"Authorization": "[REDACTED:bearer-token]", "Content-Type": "application/json"}
+```
+
+---
+
+## Adding Custom Patterns
+
+Patterns are defined as a list of `(raw_string_regex, replacement)` tuples in `token_sanitizer.py`. Insert more-specific patterns **before** less-specific ones:
+
+```python
+# In token_sanitizer.py — maintain specificity order
+PATTERNS = [
+    (r"sk-proj-[a-zA-Z0-9_-]{6,}", "sk-proj-***"),  # More specific
+    (r"sk-[a-zA-Z0-9_-]{6,}",       "sk-***"),       # Less specific — MUST follow
+    # Add project-specific patterns here, most specific first
+]
+```
+
+---
+
+## Redacted Tokens
+
+Redacted values appear in:
+
+- The amplihack proxy access log (`~/.amplihack/.claude/runtime/logs/proxy.log`)
+- Memory records created from sanitized request content
+- Trace logs when `AMPLIHACK_LOG_LEVEL=DEBUG`
+
+Each redacted form preserves the token prefix for routing context (e.g. `sk-proj-***` vs `sk-***`) while ensuring the secret value never appears in any log or stored record.
+
+---
+
+## See Also
+
+- [Proxy Configuration Guide](#) — proxy setup and logging configuration
+- [Security Recommendations](security-recommendations.md) — key rotation and vault practices
+- [Trace Logging API](./trace-logging-api.md) — how sanitized data flows into trace logs

--- a/docs/reference/trace-logging-api.md
+++ b/docs/reference/trace-logging-api.md
@@ -1,0 +1,744 @@
+# Trace Logging API Reference
+
+**Complete technical reference for native binary trace logging architecture, modules, and APIs**
+
+## Architecture Overview
+
+Native binary trace logging uses a modular architecture with four main components:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    amplihack Session                     │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────┐
+│                    TraceLogger                           │
+│  • Checks AMPLIHACK_TRACE_LOGGING                       │
+│  • Creates session-scoped JSONL files                   │
+│  • Manages file lifecycle                               │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────┐
+│                  TokenSanitizer                          │
+│  • Removes API keys and secrets                         │
+│  • Redacts sensitive headers                            │
+│  • Preserves structure for debugging                    │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────┐
+│              JSONL Trace File Writer                     │
+│  .claude/runtime/amplihack-traces/                      │
+│    trace_YYYYMMDD_HHMMSS_SESSION.jsonl                  │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Module Reference
+
+### TraceLogger
+
+**Location**: `src/trace/trace_logger.py`
+
+**Purpose**: Main trace logging coordinator.
+
+#### Class: `TraceLogger`
+
+```python
+class TraceLogger:
+    """
+    Session-scoped trace logger for Claude API calls.
+
+    Automatically creates JSONL trace files when AMPLIHACK_TRACE_LOGGING=true.
+    Captures request/response pairs for debugging.
+    """
+
+    def __init__(self, session_id: Optional[str] = None):
+        """
+        Initialize trace logger.
+
+        Args:
+            session_id: Unique session identifier (auto-generated if None)
+        """
+        pass
+
+    def is_enabled(self) -> bool:
+        """
+        Check if trace logging is enabled.
+
+        Returns:
+            True if AMPLIHACK_TRACE_LOGGING environment variable is set to 'true'
+
+        Example:
+            logger = TraceLogger()
+            if logger.is_enabled():
+                print("Trace logging active")
+            # Output: Trace logging active
+        """
+        pass
+
+    def log_request(self, request: Dict[str, Any]) -> None:
+        """
+        Log Claude API request.
+
+        Args:
+            request: API request dictionary containing model, messages, etc.
+
+        Example:
+            request = {
+                "model": "claude-sonnet-4-5-20250929",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 1024
+            }
+            logger.log_request(request)
+            # Writes sanitized request to JSONL file
+        """
+        pass
+
+    def log_response(self, response: Dict[str, Any]) -> None:
+        """
+        Log Claude API response.
+
+        Args:
+            response: API response dictionary containing content, usage, etc.
+
+        Example:
+            response = {
+                "id": "msg_abc123",
+                "content": [{"type": "text", "text": "Hello! How can I help?"}],
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": 8,
+                    "total_tokens": 20
+                }
+            }
+            logger.log_response(response)
+            # Writes sanitized response to JSONL file
+        """
+        pass
+
+    def log_error(self, error: Exception, context: Optional[Dict] = None) -> None:
+        """
+        Log API error.
+
+        Args:
+            error: Exception that occurred
+            context: Optional context dictionary
+
+        Example:
+            try:
+                response = call_claude_api(request)
+            except RateLimitError as e:
+                logger.log_error(e, {"request_id": "req_123"})
+            # Writes error entry to JSONL file
+        """
+        pass
+
+    def close(self) -> None:
+        """
+        Close trace logger and flush file.
+
+        Example:
+            logger = TraceLogger()
+            # ... logging operations ...
+            logger.close()
+            # File handle closed, all data flushed
+        """
+        pass
+
+    @property
+    def trace_file_path(self) -> Optional[Path]:
+        """
+        Get current trace file path.
+
+        Returns:
+            Path to trace file, or None if logging disabled
+
+        Example:
+            logger = TraceLogger()
+            print(logger.trace_file_path)
+            # Output: .claude/runtime/amplihack-traces/trace_20260122_143022_a3f9d8.jsonl
+        """
+        pass
+```
+
+#### Configuration
+
+```python
+# Environment variables
+AMPLIHACK_TRACE_LOGGING = os.getenv("AMPLIHACK_TRACE_LOGGING", "false")
+AMPLIHACK_TRACE_DIR = os.getenv(
+    "AMPLIHACK_TRACE_DIR",
+    ".claude/runtime/amplihack-traces"
+)
+AMPLIHACK_TRACE_RETENTION_DAYS = int(
+    os.getenv("AMPLIHACK_TRACE_RETENTION_DAYS", "30")
+)
+
+# File naming
+TRACE_FILE_PATTERN = "trace_{date}_{time}_{session}.jsonl"
+# Example: trace_20260122_143022_a3f9d8.jsonl
+
+# Date format: YYYYMMDD
+# Time format: HHMMSS
+# Session: 6-character hex ID
+```
+
+---
+
+### TokenSanitizer
+
+**Location**: `src/trace/token_sanitizer.py`
+
+**Purpose**: Remove sensitive data from trace logs.
+
+#### Class: `TokenSanitizer`
+
+```python
+class TokenSanitizer:
+    """
+    Sanitizes sensitive tokens and credentials from trace data.
+
+    Removes API keys, bearer tokens, and other sensitive information
+    while preserving structure for debugging.
+    """
+
+    REDACTED = "[REDACTED]"
+
+    # Patterns to redact
+    API_KEY_PATTERNS = [
+        r'sk-ant-api\d{2}-[\w-]+',  # Anthropic API keys
+        r'sk-proj-[\w-]+',           # OpenAI project keys
+        r'sk-[\w-]+',                # Generic API keys
+    ]
+
+    HEADER_KEYS = [
+        'x-api-key',
+        'authorization',
+        'x-auth-token',
+        'cookie',
+    ]
+
+    def sanitize(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Sanitize dictionary recursively.
+
+        Args:
+            data: Input dictionary to sanitize
+
+        Returns:
+            Sanitized copy of data
+
+        Example:
+            sanitizer = TokenSanitizer()
+
+            data = {
+                "headers": {"x-api-key": "sk-ant-api03-abc123..."},
+                "body": {"prompt": "Hello"}
+            }
+
+            sanitized = sanitizer.sanitize(data)
+            print(sanitized)
+            # Output: {'headers': {'x-api-key': '[REDACTED]'}, 'body': {'prompt': 'Hello'}}
+        """
+        pass
+
+    def sanitize_string(self, text: str) -> str:
+        """
+        Sanitize string by replacing sensitive patterns.
+
+        Args:
+            text: Input string
+
+        Returns:
+            Sanitized string
+
+        Example:
+            sanitizer = TokenSanitizer()
+
+            text = "API key: sk-ant-api03-abc123def456"
+            sanitized = sanitizer.sanitize_string(text)
+            print(sanitized)
+            # Output: API key: [REDACTED]
+        """
+        pass
+
+    def is_sensitive_key(self, key: str) -> bool:
+        """
+        Check if dictionary key contains sensitive data.
+
+        Args:
+            key: Dictionary key to check
+
+        Returns:
+            True if key is sensitive
+
+        Example:
+            sanitizer = TokenSanitizer()
+
+            print(sanitizer.is_sensitive_key("x-api-key"))
+            # Output: True
+
+            print(sanitizer.is_sensitive_key("content-type"))
+            # Output: False
+        """
+        pass
+```
+
+#### Sanitization Rules
+
+```python
+# Headers sanitized
+SANITIZED_HEADERS = [
+    'x-api-key',
+    'authorization',
+    'x-auth-token',
+    'cookie',
+    'set-cookie',
+]
+
+# Patterns sanitized
+SANITIZED_PATTERNS = [
+    r'sk-ant-api\d{2}-[\w-]+',      # Anthropic: sk-ant-api03-...
+    r'sk-proj-[\w-]+',               # OpenAI: sk-proj-...
+    r'sk-[\w-]+',                    # Generic: sk-...
+    r'Bearer\s+[\w\-\.]+',           # Bearer tokens
+    r'Basic\s+[\w\-\.]+',            # Basic auth
+    r'[A-Za-z0-9+/]{40,}={0,2}',    # Base64 tokens (40+ chars)
+]
+
+# Environment variables sanitized
+SANITIZED_ENV_VARS = [
+    'ANTHROPIC_API_KEY',
+    'OPENAI_API_KEY',
+    'CLAUDE_API_KEY',
+    'API_KEY',
+    'SECRET_KEY',
+    'PASSWORD',
+    'TOKEN',
+]
+```
+
+---
+
+### File Writer
+
+**Location**: `src/trace/file_writer.py`
+
+**Purpose**: Atomic JSONL file operations.
+
+#### Class: `JSONLWriter`
+
+```python
+class JSONLWriter:
+    """
+    Atomic JSONL file writer with automatic directory creation.
+
+    Thread-safe writes with file locking.
+    """
+
+    def __init__(self, file_path: Path):
+        """
+        Initialize JSONL writer.
+
+        Args:
+            file_path: Path to JSONL file
+
+        Example:
+            from pathlib import Path
+            from trace.file_writer import JSONLWriter
+
+            writer = JSONLWriter(Path(".claude/runtime/amplihack-traces/trace.jsonl"))
+        """
+        pass
+
+    def write(self, data: Dict[str, Any]) -> None:
+        """
+        Write dictionary as JSONL line.
+
+        Args:
+            data: Dictionary to write
+
+        Example:
+            writer = JSONLWriter(Path("trace.jsonl"))
+
+            entry = {
+                "timestamp": "2026-01-22T14:30:22.451Z",
+                "event": "request",
+                "data": {"model": "claude-sonnet-4-5-20250929"}
+            }
+
+            writer.write(entry)
+            # Appends JSON line to file
+        """
+        pass
+
+    def close(self) -> None:
+        """
+        Close file handle and flush.
+
+        Example:
+            writer = JSONLWriter(Path("trace.jsonl"))
+            writer.write({"event": "test"})
+            writer.close()
+            # File handle closed, data flushed
+        """
+        pass
+```
+
+---
+
+## Trace Entry Schema
+
+### Request Entry
+
+```json
+{
+  "timestamp": "2026-01-22T14:30:22.451Z",
+  "session_id": "a3f9d8",
+  "event": "request",
+  "request": {
+    "model": "claude-sonnet-4-5-20250929",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello, Claude!"
+      }
+    ],
+    "max_tokens": 1024,
+    "temperature": 1.0,
+    "system": "You are a helpful assistant."
+  }
+}
+```
+
+### Response Entry
+
+```json
+{
+  "timestamp": "2026-01-22T14:30:23.102Z",
+  "session_id": "a3f9d8",
+  "event": "response",
+  "response": {
+    "id": "msg_abc123def456",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "Hello! How can I help you today?"
+      }
+    ],
+    "model": "claude-sonnet-4-5-20250929",
+    "stop_reason": "end_turn",
+    "usage": {
+      "prompt_tokens": 12,
+      "completion_tokens": 8,
+      "total_tokens": 20
+    }
+  }
+}
+```
+
+### Error Entry
+
+```json
+{
+  "timestamp": "2026-01-22T14:30:24.789Z",
+  "session_id": "a3f9d8",
+  "event": "error",
+  "error": {
+    "type": "rate_limit_error",
+    "message": "Rate limit exceeded. Please retry after 30 seconds.",
+    "code": 429,
+    "retry_after": 30
+  },
+  "context": {
+    "request_id": "req_abc123",
+    "model": "claude-sonnet-4-5-20250929"
+  }
+}
+```
+
+---
+
+## Performance Characteristics
+
+### Overhead Measurements
+
+```python
+# Disabled (AMPLIHACK_TRACE_LOGGING=false)
+def measure_disabled_overhead():
+    """
+    Measure overhead when trace logging is disabled.
+
+    Returns:
+        ~0.05ms per API call (environment variable check only)
+    """
+    pass
+
+# Enabled (AMPLIHACK_TRACE_LOGGING=true)
+def measure_enabled_overhead():
+    """
+    Measure overhead when trace logging is enabled.
+
+    Returns:
+        ~8-10ms per API call:
+          - 2ms: Sanitization
+          - 3ms: JSON serialization
+          - 4ms: File I/O (buffered)
+    """
+    pass
+```
+
+### Optimization Techniques
+
+```python
+# 1. Lazy initialization
+class TraceLogger:
+    def __init__(self):
+        self._file_writer = None  # Only created if enabled
+
+    @property
+    def file_writer(self):
+        if self._file_writer is None and self.is_enabled():
+            self._file_writer = JSONLWriter(self.trace_file_path)
+        return self._file_writer
+
+# 2. Buffered writes
+class JSONLWriter:
+    def __init__(self, file_path):
+        self.file = open(file_path, 'a', buffering=8192)  # 8KB buffer
+
+# 3. Early exit on disabled
+def log_request(self, request):
+    if not self.is_enabled():
+        return  # <0.1ms exit
+
+    # ... logging logic ...
+```
+
+---
+
+## Error Handling
+
+### File System Errors
+
+```python
+class TraceLogger:
+    def log_request(self, request):
+        try:
+            self._write_entry(request)
+        except OSError as e:
+            # Disk full, permission denied, etc.
+            logging.warning(f"Trace logging failed: {e}")
+            # Continue execution - trace failure should not break system
+
+        except Exception as e:
+            # Unexpected error
+            logging.error(f"Unexpected trace error: {e}", exc_info=True)
+            # Continue execution
+```
+
+### Sanitization Errors
+
+```python
+class TokenSanitizer:
+    def sanitize(self, data):
+        try:
+            return self._recursive_sanitize(data)
+        except Exception as e:
+            logging.warning(f"Sanitization failed: {e}")
+            # Return redacted placeholder instead of failing
+            return {"error": "[SANITIZATION_FAILED]"}
+```
+
+---
+
+## Testing
+
+### Unit Tests
+
+```python
+# tests/trace/test_trace_logger.py
+
+def test_trace_logger_disabled():
+    """Verify zero overhead when disabled."""
+    os.environ["AMPLIHACK_TRACE_LOGGING"] = "false"
+    logger = TraceLogger()
+
+    assert not logger.is_enabled()
+    assert logger.trace_file_path is None
+
+    # Should not create files
+    logger.log_request({"model": "claude"})
+    assert not Path(".claude/runtime/amplihack-traces").exists()
+
+
+def test_trace_logger_enabled():
+    """Verify logging when enabled."""
+    os.environ["AMPLIHACK_TRACE_LOGGING"] = "true"
+    logger = TraceLogger(session_id="test123")
+
+    assert logger.is_enabled()
+    assert logger.trace_file_path is not None
+
+    # Should create trace file
+    logger.log_request({"model": "claude"})
+
+    assert logger.trace_file_path.exists()
+    lines = logger.trace_file_path.read_text().strip().split("\n")
+    assert len(lines) == 1
+
+    entry = json.loads(lines[0])
+    assert entry["event"] == "request"
+    assert entry["session_id"] == "test123"
+
+
+def test_token_sanitizer():
+    """Verify sensitive data removal."""
+    sanitizer = TokenSanitizer()
+
+    data = {
+        "headers": {
+            "x-api-key": "sk-ant-api03-abc123",
+            "content-type": "application/json"
+        }
+    }
+
+    sanitized = sanitizer.sanitize(data)
+
+    assert sanitized["headers"]["x-api-key"] == "[REDACTED]"
+    assert sanitized["headers"]["content-type"] == "application/json"
+```
+
+### Integration Tests
+
+```python
+# tests/integration/test_trace_integration.py
+
+def test_end_to_end_trace_logging():
+    """Test complete trace logging flow."""
+    os.environ["AMPLIHACK_TRACE_LOGGING"] = "true"
+
+    # Initialize components
+    logger = TraceLogger()
+
+    # Log a request/response pair
+    logger.log_request({"model": "claude-sonnet-4-5-20250929", "messages": [{"role": "user", "content": "Test"}]})
+    logger.log_response({"id": "msg_123", "content": [{"type": "text", "text": "Hello"}], "usage": {"total_tokens": 20}})
+
+    # Verify trace file
+    assert logger.trace_file_path.exists()
+
+    entries = [
+        json.loads(line)
+        for line in logger.trace_file_path.read_text().strip().split("\n")
+    ]
+
+    # Should have request and response
+    assert len(entries) >= 2
+    assert entries[0]["event"] == "request"
+    assert entries[1]["event"] == "response"
+
+    # Verify sanitization
+    request_entry = entries[0]
+    assert "x-api-key" not in request_entry.get("request", {}).get("headers", {})
+
+    logger.close()
+```
+
+---
+
+## Extension Points
+
+### Custom Sanitizers
+
+```python
+class CustomSanitizer(TokenSanitizer):
+    """Add custom sanitization rules."""
+
+    def sanitize(self, data):
+        # Call parent sanitization
+        sanitized = super().sanitize(data)
+
+        # Add custom rules
+        if "email" in sanitized:
+            sanitized["email"] = self._redact_email(sanitized["email"])
+
+        return sanitized
+
+    def _redact_email(self, email: str) -> str:
+        """Redact email addresses."""
+        if "@" in email:
+            local, domain = email.split("@")
+            return f"{local[0]}***@{domain}"
+        return email
+```
+
+### Custom Trace Formats
+
+```python
+class CSVTraceWriter(JSONLWriter):
+    """Write traces in CSV format instead of JSONL."""
+
+    def __init__(self, file_path: Path):
+        super().__init__(file_path)
+        self._write_header()
+
+    def _write_header(self):
+        """Write CSV header."""
+        self.file.write("timestamp,session_id,event,model,tokens\n")
+
+    def write(self, data: Dict[str, Any]):
+        """Write as CSV row."""
+        row = f"{data['timestamp']},{data['session_id']},{data['event']},"
+        row += f"{data.get('request', {}).get('model', 'N/A')},"
+        row += f"{data.get('response', {}).get('usage', {}).get('total_tokens', 0)}\n"
+        self.file.write(row)
+```
+
+---
+
+## Security Considerations
+
+### File Permissions
+
+```python
+# Trace files created with owner-only permissions
+def create_trace_file(path: Path):
+    """Create trace file with restricted permissions."""
+    # Touch file
+    path.touch()
+
+    # Set permissions: rw------- (600)
+    os.chmod(path, 0o600)
+
+    return path
+```
+
+### API Key Redaction
+
+```python
+# Multiple layers of protection
+class TokenSanitizer:
+    # 1. Pattern matching
+    API_KEY_PATTERNS = [r'sk-ant-api\d{2}-[\w-]+', ...]
+
+    # 2. Header filtering
+    SENSITIVE_HEADERS = ['x-api-key', 'authorization', ...]
+
+    # 3. Environment variable filtering
+    SENSITIVE_ENV_VARS = ['ANTHROPIC_API_KEY', ...]
+
+    # All applied recursively to nested structures
+```
+
+---
+
+## Next Steps
+
+- [Feature Overview: Trace Logging](../features/trace-logging.md) - High-level feature description
+- [How-To: Trace Logging](../howto/trace-logging.md) - Practical recipes
+- [Troubleshooting: Trace Logging](../howto/trace-logging.md) - Fix common issues

--- a/docs/reference/user-prompt-submit-hook-api.md
+++ b/docs/reference/user-prompt-submit-hook-api.md
@@ -1,0 +1,416 @@
+# UserPromptSubmit Hook API Reference
+
+Developer reference for the UserPromptSubmit hook implementation, focusing on framework injection via CLAUDE.md vs AMPLIHACK.md comparison.
+
+## Overview
+
+The UserPromptSubmit hook injects context on every user message:
+
+1. User preferences (behavioral guidance)
+2. Agent memories (when agents mentioned)
+3. Framework instructions (when CLAUDE.md differs from AMPLIHACK.md)
+
+This document focuses on the framework injection mechanism (item 3).
+
+## Hook Signature
+
+**File**: `~/.amplihack/.claude/tools/amplihack/hooks/user_prompt_submit.py`
+
+**Hook Type**: `UserPromptSubmit`
+
+**Trigger**: Before processing each user message
+
+**Input**:
+
+```json
+{
+  "session_id": "string",
+  "transcript_path": "path",
+  "cwd": "path",
+  "hook_event_name": "UserPromptSubmit",
+  "userMessage": {
+    "text": "user's prompt text"
+  }
+}
+```
+
+**Output**:
+
+```json
+{
+  "additionalContext": "string - injected context"
+}
+```
+
+## Core API
+
+### `_inject_amplihack_if_different() -> str`
+
+Compares CLAUDE.md vs AMPLIHACK.md and injects framework instructions if they differ.
+
+**Returns**: AMPLIHACK.md contents if different, empty string if identical
+
+**Algorithm**:
+
+```python
+def _inject_amplihack_if_different(self) -> str:
+    # 1. Find AMPLIHACK.md (priority order)
+    amplihack_md = self._find_amplihack_md()
+    if not amplihack_md:
+        return ""
+
+    # 2. Find CLAUDE.md (project root)
+    claude_md = self.project_root / "CLAUDE.md"
+
+    # 3. Check cache using mtimes
+    amplihack_mtime = amplihack_md.stat().st_mtime
+    claude_mtime = claude_md.stat().st_mtime if claude_md.exists() else 0
+
+    if self._amplihack_cache_timestamp == (amplihack_mtime, claude_mtime):
+        return self._amplihack_cache  # Cache hit
+
+    # 4. Read both files
+    amplihack_content = amplihack_md.read_text(encoding="utf-8")
+    claude_content = claude_md.read_text(encoding="utf-8") if claude_md.exists() else ""
+
+    # 5. Compare (whitespace-normalized)
+    if claude_content.strip() == amplihack_content.strip():
+        result = ""  # Files identical, skip injection
+    else:
+        result = amplihack_content  # Files differ, inject framework
+
+    # 6. Update cache
+    self._amplihack_cache = result
+    self._amplihack_cache_timestamp = (amplihack_mtime, claude_mtime)
+
+    return result
+```
+
+**Performance**:
+
+- First call: ~50-100ms (reads 2 files, ~2000 lines each)
+- Cached calls: <1ms (mtime check only)
+- Cache invalidation: Only when either file's mtime changes
+
+### File Resolution Priority
+
+**AMPLIHACK.md search order**:
+
+1. `$CLAUDE_PLUGIN_ROOT/AMPLIHACK.md` - Plugin mode (Claude Code)
+2. `~/.amplihack/.claude/AMPLIHACK.md` - Centralized staging (all tools)
+3. `.claude/AMPLIHACK.md` - Per-project mode (development)
+
+**CLAUDE.md location**: Always `project_root/CLAUDE.md`
+
+```python
+def _find_amplihack_md(self) -> Optional[Path]:
+    # Try plugin location
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        path = Path(plugin_root) / "AMPLIHACK.md"
+        if path.exists():
+            return path
+
+    # Try centralized staging
+    path = Path.home() / ".amplihack" / ".claude" / "AMPLIHACK.md"
+    if path.exists():
+        return path
+
+    # Try per-project
+    path = self.project_root / ".claude" / "AMPLIHACK.md"
+    if path.exists():
+        return path
+
+    return None
+```
+
+## Caching Implementation
+
+### Cache Structure
+
+```python
+class UserPromptSubmitHook(HookProcessor):
+    def __init__(self):
+        super().__init__("user_prompt_submit")
+        # Cache for comparison result
+        self._amplihack_cache: Optional[str] = None
+        # Cache key: tuple of (amplihack_mtime, claude_mtime)
+        self._amplihack_cache_timestamp: Optional[Tuple[float, float]] = None
+```
+
+### Cache Invalidation Rules
+
+Cache is invalidated when:
+
+- **AMPLIHACK.md changes** (package update, manual edit)
+- **CLAUDE.md changes** (user customization)
+- **Hook process restarts** (new session, reload)
+
+Cache is **not** invalidated when:
+
+- User sends message (cache used)
+- Other files change
+- Environment variables change
+
+### Cache Performance
+
+**Cache hit rate**: ~99% in typical usage
+
+- First message: Cache miss (reads files)
+- Subsequent messages: Cache hits (uses mtimes)
+- File edit: Cache miss (mtime changed)
+- Next message: Cache hit again
+
+**Timing measurements**:
+
+```
+Cache miss (read + compare): ~80ms
+Cache hit (mtime check):     <1ms
+Speedup factor:              80x
+```
+
+## Whitespace Normalization
+
+Files are compared using whitespace-normalized content:
+
+```python
+if claude_content.strip() == amplihack_content.strip():
+    # Files are identical (ignoring leading/trailing whitespace)
+```
+
+**Rationale**: Formatting differences shouldn't trigger injection:
+
+- Line ending differences (LF vs CRLF)
+- Trailing whitespace
+- Extra newlines at end
+
+**Not normalized**:
+
+- Internal whitespace (indentation, spacing)
+- Content structure
+- Comments
+
+This balances correctness (ignore formatting) with accuracy (detect real changes).
+
+## Error Handling
+
+All errors result in graceful degradation:
+
+```python
+try:
+    return self._inject_amplihack_if_different()
+except Exception as e:
+    self.log(f"Could not check AMPLIHACK.md vs CLAUDE.md: {e}", "WARNING")
+    return ""  # Empty injection, never block Claude
+```
+
+**Specific error cases**:
+
+| Error                | Behavior                    | Log Level | Exit Code |
+| -------------------- | --------------------------- | --------- | --------- |
+| AMPLIHACK.md missing | Skip injection, log info    | INFO      | 0         |
+| CLAUDE.md missing    | Treat as empty, inject      | DEBUG     | 0         |
+| Read permission      | Skip injection, log warning | WARNING   | 0         |
+| Encoding error       | Skip injection, log warning | WARNING   | 0         |
+| Compare error        | Skip injection, log warning | WARNING   | 0         |
+
+**Never fails** - hook always exits 0 to prevent blocking Claude Code.
+
+## Injection Context Format
+
+When files differ, full AMPLIHACK.md is injected without modification:
+
+```
+# Framework Instruction Injection (from AMPLIHACK.md)
+
+[entire AMPLIHACK.md contents]
+```
+
+**No processing**:
+
+- No truncation
+- No summarization
+- No filtering
+- Complete file contents
+
+This ensures all framework instructions are available.
+
+## Process Integration
+
+### Full process() Method Flow
+
+```python
+def process(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+    context_parts = []
+
+    # 1. Inject user preferences
+    preferences = self._get_preferences()
+    if preferences:
+        context_parts.append(self.build_preference_context(preferences))
+
+    # 2. Inject agent memories (if agents mentioned)
+    user_prompt = input_data.get("userMessage", {}).get("text", "")
+    memory_context = self._inject_memories_for_agents(user_prompt)
+    if memory_context:
+        context_parts.append(memory_context)
+
+    # 3. Inject framework instructions (if CLAUDE.md differs)
+    amplihack_context = self._inject_amplihack_if_different()
+    if amplihack_context:
+        context_parts.append(amplihack_context)
+        self.log("Injected AMPLIHACK.md framework instructions")
+
+    # Combine all context
+    full_context = "\n\n".join(context_parts)
+
+    return {
+        "additionalContext": full_context
+    }
+```
+
+**Order matters**: Preferences → Memories → Framework ensures proper priority.
+
+## Logging and Metrics
+
+### Log Events
+
+**Log file**: `~/.amplihack/.claude/runtime/logs/user_prompt_submit.log`
+
+```
+[INFO] Detected agents: ['architect', 'builder']
+[INFO] Injected 5 preferences on user prompt
+[INFO] Injected AMPLIHACK.md framework instructions
+[DEBUG] CLAUDE.md matches AMPLIHACK.md - skipping framework injection
+[WARNING] AMPLIHACK.md not found - skipping framework injection
+[WARNING] Could not check AMPLIHACK.md vs CLAUDE.md: [error]
+```
+
+### Metrics Tracked
+
+**Metrics file**: `~/.amplihack/.claude/runtime/metrics/user_prompt_submit_metrics.jsonl`
+
+```json
+{"timestamp": "2025-01-27T...", "preferences_injected": 5}
+{"timestamp": "2025-01-27T...", "agent_memory_injected": 3}
+{"timestamp": "2025-01-27T...", "agents_detected": 2}
+{"timestamp": "2025-01-27T...", "context_length": 2847}
+```
+
+**Available metrics**:
+
+- `preferences_injected`: Number of preferences injected
+- `agent_memory_injected`: Number of agent memories injected
+- `agents_detected`: Number of agents detected in prompt
+- `context_length`: Total character count of injected context
+
+## Testing
+
+### Unit Testing
+
+Test the comparison logic:
+
+```python
+def test_inject_amplihack_different_files():
+    """Test injection when CLAUDE.md differs from AMPLIHACK.md."""
+    hook = UserPromptSubmitHook()
+
+    # Setup: Create different files
+    write_file("CLAUDE.md", "Custom project instructions")
+    write_file(".claude/AMPLIHACK.md", "Framework instructions")
+
+    result = hook._inject_amplihack_if_different()
+
+    assert result == "Framework instructions"
+    assert "Injected AMPLIHACK.md" in hook.logs
+
+def test_inject_amplihack_identical_files():
+    """Test no injection when files are identical."""
+    hook = UserPromptSubmitHook()
+
+    # Setup: Create identical files
+    write_file("CLAUDE.md", "Same content")
+    write_file(".claude/AMPLIHACK.md", "Same content")
+
+    result = hook._inject_amplihack_if_different()
+
+    assert result == ""
+    assert "skipping framework injection" in hook.logs
+```
+
+### Integration Testing
+
+Test full hook execution:
+
+```bash
+# Test with different files
+echo '{"userMessage": {"text": "test"}, "cwd": "'$(pwd)'"}' | \
+  python3 .claude/tools/amplihack/hooks/user_prompt_submit.py
+
+# Verify output contains AMPLIHACK.md
+```
+
+### Performance Testing
+
+Measure cache performance:
+
+```bash
+# Run 100 messages and measure timing
+for i in {1..100}; do
+  time echo '{"userMessage": {"text": "test '$i'"}}' | \
+    python3 .claude/tools/amplihack/hooks/user_prompt_submit.py > /dev/null
+done
+
+# Expected: First run ~80ms, rest <1ms
+```
+
+## Development Guidelines
+
+### When to Modify This API
+
+Modify `_inject_amplihack_if_different()` when:
+
+- Changing comparison logic (e.g., semantic comparison)
+- Adding new file locations
+- Optimizing cache strategy
+- Changing injection format
+
+**Do not modify** for:
+
+- Adding new context types (use new methods)
+- Changing injection order (modify `process()`)
+- Preference handling (separate method)
+
+### Backward Compatibility
+
+The API maintains backward compatibility:
+
+- **Input format**: Never change hook input schema
+- **Output format**: Always return `{"additionalContext": str}`
+- **File locations**: Always check old locations first
+- **Cache format**: Version cache keys if structure changes
+
+### Performance Considerations
+
+Keep these performance targets:
+
+- **First message**: <100ms total hook time
+- **Cached messages**: <5ms total hook time
+- **Cache hit rate**: >95%
+- **Memory usage**: <10MB per hook process
+
+The current implementation exceeds all targets.
+
+## Related APIs
+
+- **`find_user_preferences()`**: Locate USER_PREFERENCES.md file
+- **`get_cached_preferences()`**: Read preferences with caching
+- **`build_preference_context()`**: Format preferences for injection
+- **`_inject_memories_for_agents()`**: Agent memory injection
+
+See `USER_PROMPT_SUBMIT_README.md` for preference and memory APIs.
+
+## Related
+
+- [Verify Framework Injection](../howto/verify-framework-injection.md) - User guide
+- [Framework Injection Architecture](../concepts/framework-injection-architecture.md) - Design rationale
+- [Hook Configuration Guide](../howto/configure-hooks.md) - Hook system overview

--- a/docs/reference/workflow-issue-extraction.md
+++ b/docs/reference/workflow-issue-extraction.md
@@ -1,0 +1,292 @@
+# Workflow Issue Extraction (Step 03b)
+
+> [Home](../index.md) > Reference > Workflow Issue Extraction
+
+Reference for the three-tier issue-number extraction logic in
+`default-workflow` step `03b`. This step resolves a GitHub issue number from
+the workflow context so that downstream steps can link the working branch,
+commit, and pull request to the correct issue.
+
+## Contents
+
+- [Overview](#overview)
+- [Three-Tier Extraction](#three-tier-extraction)
+  - [Tier 1 — Direct issue URL](#tier-1--direct-issue-url)
+  - [Tier 2 — Pull request URL](#tier-2--pull-request-url)
+  - [Tier 3 — Bare #N reference](#tier-3--bare-n-reference)
+- [Output Contract](#output-contract)
+- [Shell Security Constraints](#shell-security-constraints)
+- [Configuration](#configuration)
+- [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
+- [Related](#related)
+
+---
+
+## Overview
+
+Step `03b` accepts a free-form `task_description` string (e.g. a copied GitHub
+issue URL, a PR URL, or a plain-text description containing `#123`) and
+produces a canonical `issue_number` integer that the rest of the workflow uses.
+
+```
+task_description  ──►  03b extraction  ──►  issue_number (int | null)
+                                             branch_prefix
+                                             issue_title (str | null)
+```
+
+If no issue number can be resolved, `issue_number` is `null` and the workflow
+continues with an anonymous branch name.
+
+---
+
+## Three-Tier Extraction
+
+The tiers are evaluated in order; the first match wins.
+
+### Tier 1 — Direct issue URL
+
+**Pattern**: `https://github.com/<owner>/<repo>/issues/<N>`
+
+When `task_description` contains a URL whose path component is
+`/issues/<digits>`, the issue number is extracted directly from the URL without
+any network call.
+
+```
+Input:  "Fix the crash described in https://github.com/rysweet/amplihack/issues/3960"
+Match:  issues/3960
+Output: issue_number=3960
+```
+
+This tier is purely regex-based and never calls `gh`.
+
+---
+
+### Tier 2 — Pull request URL
+
+**Pattern**: `https://github.com/<owner>/<repo>/pull/<N>`
+
+When `task_description` contains a PR URL, step `03b` calls `gh pr view` to
+retrieve the list of issues that the PR closes:
+
+```bash
+gh pr view <N> \
+    --repo <owner>/<repo> \
+    --json closingIssuesReferences \
+    --jq '.closingIssuesReferences[0].number'
+```
+
+The first closing issue reference is used. If the PR closes no issues,
+extraction falls through to Tier 3.
+
+```
+Input:  "Continue work on https://github.com/rysweet/amplihack/pull/4143"
+gh call: closingIssuesReferences → [3960, 3983]
+Output: issue_number=3960   (first reference)
+```
+
+**Timeout**: 60 seconds. If `gh` does not respond within the timeout, Tier 2
+is skipped and extraction falls through to Tier 3.
+
+---
+
+### Tier 3 — Bare `#N` reference
+
+**Pattern**: `#<digits>` anywhere in `task_description`
+
+When neither a direct issue URL nor a PR URL is found, step `03b` scans
+`task_description` for bare `#N` patterns. Each candidate is verified with:
+
+```bash
+gh issue view <N> --json url --jq '.url // ""'
+```
+
+The command returns the issue URL. If the URL path contains `/issues/`, the
+candidate is accepted. Candidates that return an empty URL (non-existent or
+wrong repo) are skipped.
+
+```
+Input:  "Resume work on #3983 and #3960"
+gh verify 3983 → url: "https://github.com/rysweet/amplihack/issues/3983"
+  → contains /issues/ → issue_number=3983
+```
+
+**Timeout**: 60 seconds per candidate.
+
+If no candidate passes verification, `issue_number` is `null`.
+
+---
+
+## Output Contract
+
+After step `03b` completes, the workflow context contains:
+
+| Field          | Type          | Description                                             |
+| -------------- | ------------- | ------------------------------------------------------- |
+| `issue_number` | `int \| null` | Resolved GitHub issue number, or `null` if unresolvable |
+
+> **Planned enhancements**: `issue_title` (fetched from GitHub), `branch_prefix`
+> (inferred from context), and `extraction_tier` (which tier produced the result)
+> are targeted for a follow-up to improve debuggability.
+
+### Example output (Tier 1)
+
+```json
+{
+  "issue_number": 3960
+}
+```
+
+### Example output (no match)
+
+```json
+{
+  "issue_number": null
+}
+```
+
+---
+
+## Shell Security Constraints
+
+Step `03b` follows the same shell-security rules as the rest of the default
+workflow:
+
+| Constraint                          | Detail                                                                                                                                                                         |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **No `shell=True`**                 | All `gh` subprocess calls use a list-form argv; no shell interpolation                                                                                                         |
+| **Heredoc delimiter single-quoted** | The `EOFISSUECREATION` delimiter in the issue-creation heredoc is always single-quoted (`'EOFISSUECREATION'`) to prevent shell metacharacter expansion from `task_description` |
+| **60-second timeout**               | Every `gh` subprocess call carries `timeout=60`; hung subprocesses do not stall the workflow                                                                                   |
+| **No credential logging**           | `gh` output is captured in memory and never written to disk unredacted                                                                                                         |
+
+---
+
+## Configuration
+
+Step `03b` reads the following values from the workflow context:
+
+| Context key           | Required | Description                                                                |
+| --------------------- | -------- | -------------------------------------------------------------------------- |
+| `task_description`    | Yes      | Free-form string describing the task                                       |
+| `repo_path`           | Yes      | Absolute path used to derive `owner/repo` from `git remote get-url origin` |
+| `expected_gh_account` | No       | If set, `gh api /user` is checked before Tier 2/3 network calls            |
+
+No environment variables are specific to step `03b`; it relies on the
+authenticated `gh` CLI configured in the user's shell.
+
+---
+
+## Examples
+
+### Resolving from an issue URL
+
+```yaml
+# Recipe context snippet
+task_description: |
+  Fix path-traversal bug.
+  See https://github.com/rysweet/amplihack/issues/3960
+```
+
+```
+Tier 1 match: 3960
+issue_number: 3960
+```
+
+---
+
+### Resolving from a PR URL
+
+```yaml
+task_description: "Resume https://github.com/rysweet/amplihack/pull/4143"
+```
+
+```
+No issues/ URL found → Tier 2
+gh pr view 4143 --json closingIssuesReferences
+→ [3960, 3983]
+issue_number: 3960
+```
+
+---
+
+### Resolving from a bare `#N` pattern
+
+```yaml
+task_description: "Continue work on #3983"
+```
+
+```
+No issues/ URL, no pull/ URL → Tier 3
+gh issue view 3983 → url contains /issues/ → accepted
+issue_number: 3983
+```
+
+---
+
+### No resolvable issue
+
+```yaml
+task_description: "Refactor the config module for clarity"
+```
+
+```
+No URL, no #N → issue_number: null
+branch name falls back to slugified task_description
+```
+
+---
+
+## Troubleshooting
+
+**`gh: command not found`**
+
+Install and authenticate the GitHub CLI: `gh auth login`.
+Step `03b` degrades gracefully — Tier 1 (regex-only) still works without `gh`.
+
+**Tier 2 returns no closing issues**
+
+The PR may not use closing keywords (`Closes #N`, `Fixes #N`). Add a closing
+keyword to the PR description, or supply the issue URL directly in
+`task_description`.
+
+**Tier 3 skips a valid issue number**
+
+The issue may not exist in the repository that `gh` is authenticated against,
+or the `gh issue view` call returned an empty URL. Check that the issue exists
+and that `gh auth status` shows the correct account. Closed issues that are
+still in the repository will also resolve successfully — verification is
+URL-based (`*/issues/*`), not state-based.
+
+**Tier 3 does not resolve a `#N` that is present**
+
+The `#N` pattern requires at least one digit. Values like `#` alone or
+`#abc` are not matched. Check that the issue exists in the resolved repository
+and that `gh issue view <N>` returns a URL containing `/issues/`.
+
+---
+
+## Related
+
+- [Workflow Execution Guardrails Reference](recipe-quick-reference.md)
+  — canonical execution root and GitHub identity gate (also part of the default
+  workflow)
+- [How to Configure Workflow Execution Guardrails](../howto/configure-hooks.md)
+- [Default Workflow](../concepts/default-workflow.md) — full step list
+- [Lock Session ID Sanitization](security-recommendations.md)
+  — the security fix delivered alongside this extraction improvement (PR #4143)
+- Issues [#3960](https://github.com/rysweet/amplihack/issues/3960) and
+  [#3983](https://github.com/rysweet/amplihack/issues/3983) — originating work
+- PR [#4143](https://github.com/rysweet/amplihack/pull/4143) — implementation
+
+---
+
+**Metadata**
+
+| Field       | Value                                                         |
+| ----------- | ------------------------------------------------------------- |
+| Status      | Planned / PR #4143                                            |
+| Issues      | #3960, #3983                                                  |
+| PR          | #4143                                                         |
+| Recipe file | `amplifier-bundle/recipes/default-workflow.yaml` (step `03b`) |
+| Test file   | `amplifier-bundle/tools/test_default_workflow_fixes.py`       |
+| Gadugi spec | `tests/gadugi/lock-recovery-and-issue-extraction.yaml`        |

--- a/docs/reference/workflow-publish-import-validation.md
+++ b/docs/reference/workflow-publish-import-validation.md
@@ -1,0 +1,352 @@
+# Workflow Publish Import Validation Reference
+
+> [Home](../index.md) > Reference > Workflow Publish Import Validation
+
+Field-level contract for the scoped publish-validation stage used by workflow publishes.
+
+## Contents
+
+- [Status and Naming](#status-and-naming)
+- [Definitions](#definitions)
+- [Workflow Contract](#workflow-contract)
+- [Allowlist Boundary and Root Resolution](#allowlist-boundary-and-root-resolution)
+- [Publish Manifest Format](#publish-manifest-format)
+- [Scope Builder Helper](#scope-builder-helper)
+- [Scoped Mode for Import Checking](#scoped-mode-for-import-checking)
+- [Counts and Logs](#counts-and-logs)
+- [Failure Semantics](#failure-semantics)
+- [Security Invariants](#security-invariants)
+- [Non-Goals](#non-goals)
+
+---
+
+## Status and Naming
+
+This page documents the contract implemented for issue 4064.
+
+Current tree state:
+
+- `amplifier-bundle/recipes/default-workflow.yaml` still defines **Step 15** as
+  **Commit and Push**, and now runs the scoped publish import validation before
+  creating the commit
+- `scripts/pre-commit/build_publish_validation_scope.py` builds the scoped
+  validation file from the staged publish manifest
+- `scripts/pre-commit/check_imports.py` supports `--files-from` scoped mode
+- the later `git commit` skips only the pre-commit `check-imports` hook because
+  the scoped validator already ran inside Step 15
+
+The import validation remains a **publish-only substep inserted immediately
+before the current commit/push step**. Older issue discussion used "Step 15" as
+shorthand, and this reference keeps that shorthand without renumbering the workflow.
+
+---
+
+## Definitions
+
+| Term                      | Meaning                                                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| publish manifest          | Newline-delimited repo-relative file list produced by Step 15 from the staged publish surface.                                              |
+| seed file                 | A `.py` file that appears directly in the publish manifest.                                                                                 |
+| expanded local dependency | A repo-local `.py` file reached by import resolution from a seed file and still inside an already-allowed root.                             |
+| validation scope          | The final deduplicated newline-delimited `.py` file list passed to `check_imports.py --files-from`.                                         |
+| allowed root              | A repo subtree derived from a manifest seed file that bounds dependency expansion.                                                          |
+| publish-relevant surface  | The staged publish artifacts plus repo-local Python dependencies reachable from those artifacts without escaping the already-allowed roots. |
+
+---
+
+## Workflow Contract
+
+The publish-validation stage performs these operations in order:
+
+1. read the staged publish manifest
+2. normalize and validate manifest paths
+3. keep published `.py` files as seed files
+4. derive the allowed roots from those seed files
+5. expand only resolvable repo-local Python dependencies inside those
+   already-allowed roots
+6. write the final validation scope file
+7. report `seed_count`, `expanded_local_dep_count`, and `validated_count`
+8. run `check_imports.py --files-from <scope-file>`
+9. create the commit while skipping the repo-wide pre-commit `check-imports`
+   hook
+
+### Required Invariants
+
+| Invariant                           | Contract                                                                                |
+| ----------------------------------- | --------------------------------------------------------------------------------------- |
+| Publish-only insertion point        | The new stage runs immediately before the current commit/push step.                     |
+| Exact scope                         | The stage validates only the files in the generated validation scope.                   |
+| No repo-wide fallback               | Scoped mode does not rediscover or glob unrelated repository files.                     |
+| No repo-wide hook rerun             | After the scoped run, `git commit` suppresses only the pre-commit `check-imports` hook. |
+| Optional dependency neutrality      | `textual` and `amplifier_core` matter only when the scoped files import them.           |
+| Scenario isolation                  | `.claude/scenarios/**` does not block unrelated workflow publishes.                     |
+| Fail closed on real in-scope errors | Missing imports inside the validation scope still fail the publish.                     |
+| Explicit empty-scope success        | No scoped Python files means success after a reported no-op, not silent skipping.       |
+
+---
+
+## Allowlist Boundary and Root Resolution
+
+The scope builder must derive an allowlist of roots from the manifest's Python
+seed files. Dependency expansion may add only repo-local `.py` files that
+resolve under one of those already-allowed roots. It must never create a new
+top-level root during expansion.
+
+### Derived Root Rules
+
+| Seed path shape                       | Derived root                                                         | Notes                                                                                 |
+| ------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `src/<package>/...`                   | `src/<package>/`                                                     | Top-level runtime package root.                                                       |
+| `amplifier-bundle/modules/<name>/...` | `amplifier-bundle/modules/<name>/`                                   | Stay inside that bundle module unless another root was separately seeded.             |
+| `amplifier-bundle/<subtree>/...`      | `amplifier-bundle/<subtree>/`                                        | `tools`, `recipes`, and other sibling bundle subtrees are not inferred automatically. |
+| `.claude/scenarios/<name>/...`        | `.claude/scenarios/<name>/` only when explicitly seeded              | Scenario files stay out of unrelated publishes by default.                            |
+| Other Python files                    | Closest owning package directory, or the containing script directory | Do not escalate to a repo-wide root.                                                  |
+
+### Cross-Root Rule
+
+A dependency may resolve into another root only when that root was already
+derived from a manifest seed.
+
+Example:
+
+```text
+manifest seeds:
+  amplifier-bundle/tools/orch_helper.py
+  src/amplihack/recipes/recipe_command.py
+
+allowed roots:
+  amplifier-bundle/tools/
+  src/amplihack/
+```
+
+In that case, dependency expansion may move between those two roots because
+both were seeded explicitly. If the manifest seeds only
+`amplifier-bundle/tools/orch_helper.py`, the builder must **not** infer a hidden
+alias that broadens the scope into `src/amplihack/`.
+
+This rule is deliberate: bundle wrappers that rely on runtime package files
+must seed both roots when both belong to the intended publish surface.
+
+---
+
+## Publish Manifest Format
+
+The publish manifest is a UTF-8 text file with one repo-relative path per line.
+
+### Accepted Input
+
+```text
+amplifier-bundle/tools/orch_helper.py
+src/amplihack/recipes/__init__.py
+src/amplihack/recipes/recipe_command.py
+```
+
+### Rejected Input
+
+- absolute paths
+- `..` traversal
+- CR, LF, or NUL inside a path entry
+- directories
+- missing files
+- files that resolve outside the repository root
+
+Duplicate entries are allowed in the manifest input but are removed after
+normalization.
+
+---
+
+## Scope Builder Helper
+
+Helper script that will turn the publish manifest into the exact Python file
+list that the new stage validates.
+
+### Synopsis
+
+```bash
+python scripts/pre-commit/build_publish_validation_scope.py \
+  --manifest <path> \
+  --output <path> \
+  [--repo-root <path>]
+```
+
+### Arguments
+
+| Argument             | Required | Meaning                                                                                 |
+| -------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `--manifest <path>`  | Yes      | Path to the newline-delimited publish manifest.                                         |
+| `--output <path>`    | Yes      | Path where the scoped validation file is written.                                       |
+| `--repo-root <path>` | No       | Repository root used for path normalization. Defaults to the current working directory. |
+
+### Output Contract
+
+The helper does two things on success:
+
+1. writes the scoped validation file named by `--output`
+2. prints JSON to stdout with these fields:
+
+```json
+{
+  "seed_count": 2,
+  "expanded_local_dep_count": 1,
+  "validated_count": 3
+}
+```
+
+The scope file contains repo-relative `.py` files only, one per line.
+
+### Resolution Rules
+
+- manifest-derived `.py` files become seed files
+- non-Python manifest entries remain part of the publish but do not enter import
+  smoke validation
+- dependency expansion follows only repo-local Python imports that resolve
+  inside the already-allowed roots
+- the helper must not create new top-level roots during expansion
+- unresolved third-party imports are left for `check_imports.py` to validate
+  during smoke import
+- expansion is cycle-safe and deduplicated
+
+### Exit Codes
+
+| Code | Meaning                                                  |
+| ---- | -------------------------------------------------------- |
+| `0`  | Scope built successfully.                                |
+| `1`  | Manifest missing, unreadable, or contains invalid paths. |
+
+---
+
+## Scoped Mode for Import Checking
+
+Scoped mode for `scripts/pre-commit/check_imports.py`.
+
+### Synopsis
+
+```bash
+python scripts/pre-commit/check_imports.py FILES...
+python scripts/pre-commit/check_imports.py --files-from <path>
+```
+
+### Arguments
+
+| Argument              | Required | Meaning                                                                                                                       |
+| --------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `FILES...`            | No       | Existing positional file list for legacy callers. Mutually exclusive with `--files-from`.                                     |
+| `--files-from <path>` | No       | Read the exact repo-relative validation scope from a newline-delimited file. The new publish-validation stage uses this mode. |
+
+### Scope-File Rules
+
+When `--files-from` is supplied:
+
+- `--files-from` and positional `FILES...` are mutually exclusive
+- the scope file is UTF-8 text with one repo-relative `.py` path per line
+- blank lines are ignored
+- comments are not supported
+- leading and trailing whitespace is trimmed before validation
+- paths are normalized and deduplicated, preserving first occurrence
+- absolute paths, traversal paths, directories, missing files, out-of-repo
+  paths, and non-`.py` entries fail before import testing starts
+- validation runs against that exact list
+- the script does not fall back to repository-wide file discovery
+- an empty scope file is valid and exits successfully after reporting that no
+  Python files were checked
+- Step 15 may then skip the pre-commit `check-imports` hook because the scoped
+  validation already executed explicitly
+
+Without `--files-from`, `check_imports.py` keeps its existing positional-file
+behavior.
+
+### Exit Codes
+
+| Code | Meaning                                                      |
+| ---- | ------------------------------------------------------------ |
+| `0`  | Import validation succeeded, including the empty-scope case. |
+| `1`  | Type-import validation or smoke-import validation failed.    |
+| `2`  | Invalid CLI usage or invalid `--files-from` input.           |
+
+---
+
+## Counts and Logs
+
+The new stage should log these fields before running `check_imports.py`:
+
+| Field                      | Meaning                                                             |
+| -------------------------- | ------------------------------------------------------------------- |
+| `publish_manifest`         | Path to the manifest emitted by the publish-selection path.         |
+| `validation_scope`         | Path to the scoped `.py` file list passed to `check_imports.py`.    |
+| `seed_count`               | Count of unique seed files taken directly from the manifest.        |
+| `expanded_local_dep_count` | Count of additional repo-local files added by dependency expansion. |
+| `validated_count`          | Count of files passed to `check_imports.py --files-from`.           |
+
+`validated_count` equals `seed_count + expanded_local_dep_count`.
+
+---
+
+## Failure Semantics
+
+| Condition                                                    | Result                                                          |
+| ------------------------------------------------------------ | --------------------------------------------------------------- |
+| Manifest missing or unreadable                               | The new stage fails before import smoke testing starts.         |
+| Manifest contains unsafe or out-of-repo paths                | The new stage fails.                                            |
+| Validation scope is empty                                    | The new stage succeeds after reporting an empty Python surface. |
+| A scoped file imports missing `textual`                      | The new stage fails.                                            |
+| A scoped file imports missing `amplifier_core`               | The new stage fails.                                            |
+| Only unrelated files import `textual`                        | The new stage does not fail for that reason.                    |
+| Only unrelated files import `amplifier_core`                 | The new stage does not fail for that reason.                    |
+| Imports exist only in unrelated `.claude/scenarios/**` files | The new stage does not fail for that reason.                    |
+| A scoped file imports any genuinely missing required module  | The new stage fails.                                            |
+
+Example relevant failure:
+
+```text
+❌ IMPORT VALIDATION FAILED - FIX BEFORE COMMITTING
+
+Import Errors:
+
+  tests/fixtures/workflow_publish/relevant_missing_import.py:
+    FAILED: No module named 'definitely_missing_module'
+```
+
+---
+
+## Security Invariants
+
+The scoped validation contract enforces these invariants:
+
+- manifest and scope paths are normalized exactly once
+- no absolute or traversal paths enter the scope
+- no resolved file outside the repository root enters the scope
+- dependency expansion is AST-only and repo-local
+- the scope builder does not execute arbitrary code while building the scope
+- `check_imports.py` still executes top-level module code for the scoped files
+  it smoke-imports, so publish runs must not rely on secrets or privileged
+  ambient access
+- cycle-safe deduplication prevents recursive local import graphs from
+  expanding forever
+
+If the workflow cannot preserve these invariants, it fails closed.
+
+---
+
+## Non-Goals
+
+This feature does not do any of the following:
+
+- disable the new validation stage
+- add a global allowlist that hides legitimate `textual` or `amplifier_core`
+  failures
+- validate unrelated repository files "just in case"
+- make `.claude/scenarios/**` part of the import-validation surface for
+  unrelated workflow publishes
+- infer hidden cross-root aliases from bundle wrappers to runtime packages
+- replace scenario-asset validation with Python import smoke tests
+
+Future publishes that intentionally include scenario assets can define a
+separate validation contract. That is outside the scope of this feature.
+
+---
+
+## See Also
+
+- [Workflow publish import validation overview](../features/workflow-publish-import-validation.md)
+- [How to configure workflow publish import validation](../howto/configure-workflow-publish-import-validation.md)
+- [Tutorial: workflow publish import validation](../tutorials/session-start-workflow-classification.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -229,6 +229,33 @@ nav:
       - Goal Agent Example Prompt: reference/goal-agent-example-prompt.md
       - Code Review Practices: reference/code-review.md
       - Prerequisites: reference/prerequisites.md
+      - Launcher Model Configuration: reference/LAUNCHER_MODEL_CONFIGURATION.md
+      - Status Line: reference/STATUSLINE.md
+      - amplifier Command: reference/amplifier-command.md
+      - Append Handler: reference/append-handler.md
+      - CLI Reference: reference/cli.md
+      - Code Atlas Reference: reference/code-atlas-reference.md
+      - Copilot Installation Implementation: reference/copilot-installation-implementation.md
+      - Copilot Parity Control Plane: reference/copilot-parity-control-plane.md
+      - GitHub Pages API: reference/github-pages-api.md
+      - Goal-Seeking Agents Quick Reference: reference/goal-seeking-agents-quick-reference.md
+      - Hook Persistence Implementation: reference/hook-persistence-implementation.md
+      - Learning Agent Module Reference: reference/learning-agent-module-reference.md
+      - Memory CLI Reference: reference/memory-cli-reference.md
+      - Memory-Enabled Agents API: reference/memory-enabled-agents-api.md
+      - Platform Bridge API: reference/platform-bridge-api.md
+      - Prerequisite Checking: reference/prerequisite-checking.md
+      - Quality Audit Cycle Recipe: reference/quality-audit-cycle-recipe.md
+      - Recipe CLI Reference: reference/recipe-cli-reference.md
+      - Recipe Result: reference/recipe-result.md
+      - Resumable Workstream Timeouts: reference/resumable-workstream-timeouts.md
+      - Rust Runner Execution: reference/rust-runner-execution.md
+      - Staging API: reference/staging-api.md
+      - Token Sanitizer: reference/token-sanitizer.md
+      - Trace Logging API: reference/trace-logging-api.md
+      - User Prompt Submit Hook API: reference/user-prompt-submit-hook-api.md
+      - Workflow Issue Extraction: reference/workflow-issue-extraction.md
+      - Workflow Publish/Import Validation: reference/workflow-publish-import-validation.md
   - Concepts:
       - Philosophy: concepts/philosophy.md
       - Patterns: concepts/patterns.md


### PR DESCRIPTION
## Summary
- Ports 27 reference docs from upstream amplihack
- Adds 27 nav entries to existing Reference section
- Cross-references adapted for amplihack-rs doc structure
- Light-touch Rust adaptation applied

Wave 7 PR 3 of 6 for issue #420 documentation parity.

## Test plan
- [x] `mkdocs build --strict` passes with zero warnings
- [x] All 27 new files exist and are non-empty
- [x] Nav entries added for all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)