### PR TITLE
docs: port testing, security & skills pages from upstream (#420)

### DIFF
--- a/docs/security/lock-session-id-sanitization.md
+++ b/docs/security/lock-session-id-sanitization.md
@@ -1,0 +1,216 @@
+# Lock Tool Session ID Sanitization
+
+> [Home](../index.md) > [Security](./README.md) > Lock Session ID Sanitization
+
+Security hardening for the lock tool and stop hook: session identifiers are
+sanitized before they are used as filesystem path components or written into
+lock-file metadata, preventing path-traversal and metadata-injection attacks.
+
+## Contents
+
+- [Problem Solved](#problem-solved)
+- [Sanitization Rules](#sanitization-rules)
+- [API Reference](#api-reference)
+  - [\_sanitize_session_id](#_sanitize_session_id)
+- [Where Sanitization Is Applied](#where-sanitization-is-applied)
+- [Security Invariants](#security-invariants)
+- [Error Handling and Fallback](#error-handling-and-fallback)
+- [Testing](#testing)
+- [Related](#related)
+
+---
+
+## Problem Solved
+
+The lock tool stores the current `AMPLIHACK_SESSION_ID` in lock-file metadata
+so that a stop hook can distinguish its own lock from a stale lock left by a
+crashed session. Two attack surfaces existed:
+
+| Attack                 | Mechanism                                                                | Example payload                   |
+| ---------------------- | ------------------------------------------------------------------------ | --------------------------------- |
+| **Path traversal**     | `session_id` used as a directory name when constructing the counter path | `../../etc/cron.d/evil`           |
+| **Metadata injection** | `session_id` written verbatim as a value in the key-value lock file      | `myid\nsession_id=attacker_value` |
+
+Both attack surfaces are now closed by a single sanitization helper applied on
+every write path and validated on every read path.
+
+---
+
+## Sanitization Rules
+
+```
+allowed characters: A–Z  a–z  0–9  _  -
+replacement:        any other byte → _
+empty guard:        if session_id is falsy → "unknown"
+hard rejects (read path only):  values containing / or ..
+```
+
+The transformation is idempotent — sanitizing an already-clean ID returns it
+unchanged.
+
+```python
+import re
+
+def _sanitize_session_id(session_id: str | None) -> str:
+    """Return a filesystem-safe, injection-free version of session_id."""
+    if not session_id:
+        return "unknown"
+    return re.sub(r"[^A-Za-z0-9_\-]", "_", session_id)
+```
+
+---
+
+## API Reference
+
+### `_sanitize_session_id`
+
+```python
+from amplihack.tools.lock_tool import _sanitize_session_id
+
+safe_id = _sanitize_session_id(raw_session_id)
+```
+
+| Parameter    | Type          | Description                                                 |
+| ------------ | ------------- | ----------------------------------------------------------- |
+| `session_id` | `str \| None` | Raw value from `AMPLIHACK_SESSION_ID` or lock-file metadata |
+
+**Returns**: `str` — sanitized identifier, guaranteed to contain only
+`[A-Za-z0-9_-]` and never be empty.
+
+**Raises**: nothing — all edge cases return `"unknown"`.
+
+**Examples**:
+
+```python
+_sanitize_session_id("my-session_01")      # → "my-session_01"  (unchanged)
+_sanitize_session_id("../../etc/passwd")   # → "______etc_passwd"
+_sanitize_session_id("abc\nid=evil")       # → "abc_id_evil"
+_sanitize_session_id("   ")               # → "___"
+_sanitize_session_id("")                   # → "unknown"
+_sanitize_session_id(None)                 # → "unknown"
+```
+
+---
+
+## Where Sanitization Is Applied
+
+Sanitization is applied consistently on both write and read paths so that
+counter directories named with sanitized IDs are found correctly even after
+the sanitization was introduced mid-flight.
+
+### `lock_tool.py` (canonical — two copies kept in sync)
+
+| Function               | Action                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------- |
+| `create_lock()`        | Sanitizes `session_id` before writing `session_id=<value>` into lock metadata         |
+| `read_lock_metadata()` | Rejects any value containing `/` or `..`; returns `None` to trigger TTL-only recovery |
+
+### `stop.py` (stop hook)
+
+| Function                      | Action                                                                                        |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| `_increment_lock_counter()`   | Sanitizes `session_id` before constructing the counter directory path                         |
+| `_get_lock_recovery_reason()` | Sanitizes both the stored and live session IDs before comparing; rejects malformed stored IDs |
+
+### `_copilot_stop_handler_impl.py` (Python package mirror)
+
+Mirrors the same sanitization as `stop.py` so that Python package consumers
+and standalone hook consumers behave identically. Any change to either file
+must be reflected in the other.
+
+---
+
+## Security Invariants
+
+The following invariants must never be broken:
+
+1. **No path separator** — the sanitized session ID never contains `/` or `\`.
+2. **No newline** — the sanitized value never contains `\n`, `\r`, or other
+   control characters, preventing metadata file corruption.
+3. **Non-empty** — the sanitized value is never an empty string; unknown
+   sessions fall back to `"unknown"`.
+4. **Lock file permissions unchanged** — `os.O_CREAT | os.O_EXCL | os.O_WRONLY`
+   with mode `0o600` remain in force; sanitization does not relax permissions.
+5. **No `shell=True`** — no subprocess call in the lock/stop stack uses
+   `shell=True`; this is validated by static analysis and must remain absent.
+6. **TTL recovery preserved** — when `AMPLIHACK_SESSION_ID` is unset the lock
+   tool falls back to TTL-only recovery without error.
+
+---
+
+## Error Handling and Fallback
+
+```
+┌─────────────────────────────────────────────────────┐
+│ create_lock()                                        │
+│   session_id = os.environ.get("AMPLIHACK_SESSION_ID")│
+│   if session_id:                                     │
+│       safe_id = _sanitize_session_id(session_id)     │
+│       write "session_id=<safe_id>" to lock file      │
+│   else:                                              │
+│       omit session_id line → TTL-only recovery       │
+└─────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────┐
+│ read_lock_metadata() (read path guard)               │
+│   raw = parse_value("session_id", lock_file)         │
+│   if "/" in raw or ".." in raw:                      │
+│       log warning, return None  (TTL fallback)       │
+│   return raw                                         │
+└─────────────────────────────────────────────────────┘
+```
+
+If the stored `session_id` is rejected on read, the lock tool falls back to
+TTL-based stale-lock detection. The lock is not silently ignored — it is still
+subject to the configured `AMPLIHACK_LOCK_TTL_SECONDS`.
+
+---
+
+## Testing
+
+Tests covering the sanitization are spread across four files:
+
+| File                                                             | What it tests                                                                                                                                    |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tests/test_lock_unlock.py`                                      | Path-traversal and newline-injection inputs to `create_lock()`; read-path rejection of `/` and `..` values                                       |
+| `.claude/tools/amplihack/hooks/tests/test_stop_state_machine.py` | `_increment_lock_counter()` path construction with adversarial session IDs; `_get_lock_recovery_reason()` metadata comparison after sanitization |
+| `tests/hooks/test_copilot_stop_handler.py`                       | Mirror parity: identical sanitization behaviour in `_copilot_stop_handler_impl.py`                                                               |
+| `tests/outside_in/test_stop_hook_safety_valve_e2e.py`            | End-to-end: adversarial `AMPLIHACK_SESSION_ID` does not escape the session counter directory                                                     |
+
+Run all sanitization-related tests:
+
+```bash
+pytest tests/test_lock_unlock.py \
+       .claude/tools/amplihack/hooks/tests/test_stop_state_machine.py \
+       tests/hooks/test_copilot_stop_handler.py \
+       tests/outside_in/test_stop_hook_safety_valve_e2e.py \
+       -v -k "sanitiz or traversal or injection or session_id"
+```
+
+---
+
+## Related
+
+- [Power Steering File Locking](./power-steering-file-locking.md) — lock
+  acquisition, timeout, and fail-open behaviour
+- [Security Recommendations](../SECURITY_RECOMMENDATIONS.md) — input validation
+  patterns used across the codebase
+- [Token Sanitization Guide](./TOKEN_SANITIZATION_GUIDE.md) — analogous
+  sanitization for API tokens in log output
+- Issues [#3960](https://github.com/rysweet/amplihack/issues/3960) and
+  [#3983](https://github.com/rysweet/amplihack/issues/3983) — originating bug
+  reports
+- PR [#4143](https://github.com/rysweet/amplihack/pull/4143) — implementation
+
+---
+
+**Metadata**
+
+| Field         | Value                                                           |
+| ------------- | --------------------------------------------------------------- |
+| Status        | Planned / PR #4143                                              |
+| Issues        | #3960, #3983                                                    |
+| PR            | #4143                                                           |
+| Files changed | `lock_tool.py` (×2), `stop.py`, `_copilot_stop_handler_impl.py` |
+| Python        | 3.8+                                                            |
+| Dependencies  | `re` (stdlib only)                                              |

--- a/docs/security/platform-bridge-security.md
+++ b/docs/security/platform-bridge-security.md
@@ -1,0 +1,414 @@
+# Platform Bridge - Security Documentation
+
+Security analysis and best practices fer the platform bridge module.
+
+## Security Model
+
+The platform bridge follows a **delegation security model** where authentication and authorization be handled by official CLI tools (gh and az), not by the bridge itself.
+
+### Core Principles
+
+1. **No Credential Storage**: Bridge never stores or handles credentials
+2. **CLI Authentication**: Delegates all authentication to gh/az CLI tools
+3. **Input Validation**: All user inputs be validated before subprocess calls
+4. **Safe Subprocess**: Parameterized commands prevent shell injection
+5. **Fail Secure**: Errors don't leak sensitive information
+
+## Authentication Delegation
+
+### GitHub Authentication
+
+The bridge uses `gh` CLI fer all GitHub operations:
+
+```python
+# Bridge NEVER handles GitHub tokens directly
+bridge = PlatformBridge()  # No tokens or credentials passed
+
+# Authentication handled by gh CLI
+issue = bridge.create_issue(title="Test", body="Body")
+# Under the hood: gh uses credentials from ~/.config/gh/hosts.yml
+```
+
+**User Authentication Flow**:
+
+1. User runs: `gh auth login`
+2. GitHub CLI authenticates through OAuth
+3. Credentials stored in `~/.config/gh/hosts.yml`
+4. Bridge calls `gh` commands which use stored credentials
+
+**Benefits**:
+
+- Bridge code never sees tokens
+- GitHub handles token refresh
+- Standard gh security model applies
+
+### Azure DevOps Authentication
+
+The bridge uses `az` CLI fer all Azure DevOps operations:
+
+```python
+# Bridge NEVER handles Azure DevOps PATs directly
+bridge = PlatformBridge()  # No tokens or credentials passed
+
+# Authentication handled by az CLI
+issue = bridge.create_issue(title="Test", body="Body")
+# Under the hood: az uses credentials from ~/.azure/
+```
+
+**User Authentication Flow**:
+
+1. User runs: `az login`
+2. Azure CLI authenticates through browser
+3. Credentials stored in `~/.azure/`
+4. Bridge calls `az` commands which use stored credentials
+
+**Benefits**:
+
+- Bridge code never sees tokens or PATs
+- Azure handles token refresh
+- Standard az security model applies
+
+## Input Validation
+
+All user inputs be validated before bein' passed to subprocess calls.
+
+### Title Validation
+
+```python
+def _validate_title(title: str) -> None:
+    """Validate issue/PR title"""
+    if not title or not title.strip():
+        raise ValueError("Title cannot be empty")
+
+    if len(title) > 256:
+        raise ValueError("Title too long (max 256 characters)")
+
+    # No shell metacharacters in title
+    dangerous_chars = ['$', '`', '$(', '|', '&', ';']
+    if any(char in title for char in dangerous_chars):
+        raise ValueError(f"Title contains invalid characters: {dangerous_chars}")
+```
+
+### Branch Name Validation
+
+```python
+def _validate_branch_name(branch: str) -> None:
+    """Validate git branch name"""
+    if not branch or not branch.strip():
+        raise ValueError("Branch name cannot be empty")
+
+    # Git branch name rules
+    invalid_patterns = ['..',  '~', '^', ':', '\\', '*', '?', '[']
+    if any(pattern in branch for pattern in invalid_patterns):
+        raise ValueError(f"Branch name contains invalid patterns")
+
+    if branch.startswith('/') or branch.endswith('/'):
+        raise ValueError("Branch name cannot start or end with /")
+```
+
+### Body/Description Validation
+
+```python
+def _validate_body(body: str) -> None:
+    """Validate issue/PR body"""
+    if not body or not body.strip():
+        raise ValueError("Body cannot be empty")
+
+    # No null bytes (can confuse subprocess)
+    if '\x00' in body:
+        raise ValueError("Body contains null bytes")
+
+    # Reasonable size limit (prevent DoS)
+    if len(body) > 65536:  # 64KB
+        raise ValueError("Body too large (max 64KB)")
+```
+
+## Safe Subprocess Usage
+
+All subprocess calls use **parameterized commands** to prevent shell injection.
+
+### Correct Pattern (Safe)
+
+```python
+# SAFE - Command and args as list
+subprocess.run(
+    ["gh", "issue", "create", "--title", title, "--body", body],
+    capture_output=True,
+    text=True,
+    timeout=30
+)
+```
+
+**Why this be safe**:
+
+- Command and arguments passed as list
+- No shell interpretation
+- Arguments can't be interpreted as commands
+- Even if title/body contain `; rm -rf /`, they be treated as literal strings
+
+### Anti-Pattern (Unsafe)
+
+```python
+# UNSAFE - Don't do this!
+subprocess.run(
+    f"gh issue create --title '{title}' --body '{body}'",
+    shell=True,  # ❌ Dangerous!
+    capture_output=True
+)
+```
+
+**Why this be dangerous**:
+
+- Shell interprets the entire string
+- Special characters in title/body can execute commands
+- Example attack: `title = "test'; rm -rf /; echo '"`
+
+### Timeout Protection
+
+All subprocess calls have timeouts to prevent hangs:
+
+```python
+result = subprocess.run(
+    cmd,
+    capture_output=True,
+    text=True,
+    timeout=30  # 30 second timeout
+)
+```
+
+**Timeout Values**:
+
+- Standard operations: 30 seconds
+- CI status checks: 60 seconds (can be slow)
+- Large file uploads: 120 seconds
+
+## Error Handling
+
+Errors be handled to prevent information leakage:
+
+### Safe Error Messages
+
+```python
+try:
+    result = subprocess.run(cmd, ...)
+    if result.returncode != 0:
+        # Don't expose full command in error
+        raise RuntimeError(f"Operation failed: {sanitize_error(result.stderr)}")
+
+except subprocess.TimeoutExpired:
+    # Don't expose what command timed out
+    raise RuntimeError("Operation timed out after 30 seconds")
+
+except Exception as e:
+    # Don't expose internal details
+    raise RuntimeError(f"Unexpected error: {type(e).__name__}")
+```
+
+### Information Leakage Prevention
+
+**What we DON'T expose**:
+
+- Full subprocess commands (might contain sensitive args)
+- File system paths (might reveal directory structure)
+- Internal stack traces (might reveal implementation details)
+
+**What we DO expose**:
+
+- Operation type (e.g., "create issue failed")
+- User-actionable guidance (e.g., "run gh auth login")
+- Error categories (e.g., "authentication required")
+
+## Filesystem Security
+
+The bridge reads git configuration but never writes to filesystem (except through CLI tools).
+
+### Read-Only Operations
+
+```python
+# Bridge only reads git config
+def _get_git_remote(repo_path: Path) -> str:
+    """Read git remote URL (read-only)"""
+    result = subprocess.run(
+        ["git", "remote", "-v"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True
+    )
+    return result.stdout
+```
+
+### No Filesystem Writes
+
+The bridge **never** writes to:
+
+- Git configuration (`.git/config`)
+- Credential files (`~/.config/gh/`, `~/.azure/`)
+- System directories
+- Temporary files with sensitive data
+
+All writes be handled by official CLI tools which have their own security models.
+
+## Threat Model
+
+### Threats We Mitigate
+
+1. **Shell Injection**: Parameterized commands prevent command injection
+2. **Credential Theft**: No credentials stored or handled by bridge
+3. **Information Leakage**: Error messages don't expose sensitive details
+4. **DoS via Large Inputs**: Size limits on all inputs
+5. **Path Traversal**: Repository paths validated
+
+### Threats Out of Scope
+
+These be handled by CLI tools or operating system:
+
+1. **Network Security**: gh/az CLI handle HTTPS connections
+2. **Token Refresh**: CLI tools manage token lifecycle
+3. **Multi-Factor Auth**: Handled by GitHub/Azure DevOps
+4. **Rate Limiting**: CLI tools handle API rate limits
+5. **Audit Logging**: Platform services log all operations
+
+### Trust Boundaries
+
+```
+User Code → PlatformBridge → gh/az CLI → GitHub/Azure DevOps API
+   ↑            ↑                ↑              ↑
+   |            |                |              |
+   |            |                |              +-- Trusted (official API)
+   |            |                +----------------- Trusted (official CLI)
+   |            +---------------------------------- Trusted (our code)
+   +----------------------------------------------- Untrusted (user input)
+```
+
+**Trust Assumptions**:
+
+- User input be UNTRUSTED (validate everything)
+- gh/az CLI tools be TRUSTED (official tools)
+- Platform APIs be TRUSTED (GitHub/Azure)
+- Operating system be TRUSTED (subprocess isolation)
+
+## Security Best Practices
+
+### For Users
+
+1. **Keep CLI Tools Updated**:
+
+   ```bash
+   # GitHub CLI
+   gh version  # Check current version
+   brew upgrade gh  # Update (macOS)
+
+   # Azure CLI
+   az version  # Check current version
+   brew upgrade azure-cli  # Update (macOS)
+   ```
+
+2. **Use Secure Authentication**:
+
+   ```bash
+   # GitHub - Use OAuth, not PATs
+   gh auth login  # Follow OAuth flow
+
+   # Azure - Use browser auth
+   az login  # Opens browser
+   ```
+
+3. **Review Permissions**:
+
+   ```bash
+   # GitHub - Check token permissions
+   gh auth status
+
+   # Azure - Check account permissions
+   az account show
+   ```
+
+4. **Rotate Credentials Regularly**:
+
+   ```bash
+   # GitHub - Refresh auth
+   gh auth refresh
+
+   # Azure - Re-login periodically
+   az logout && az login
+   ```
+
+### For Developers
+
+1. **Never Add Credential Parameters**:
+
+   ```python
+   # ❌ WRONG - Don't add token parameters
+   def create_issue(self, title: str, token: str):
+       ...
+
+   # ✅ RIGHT - Delegate to CLI
+   def create_issue(self, title: str):
+       subprocess.run(["gh", "issue", "create", ...])
+   ```
+
+2. **Always Validate Inputs**:
+
+   ```python
+   # ✅ RIGHT - Validate before subprocess
+   def create_issue(self, title: str, body: str):
+       self._validate_title(title)
+       self._validate_body(body)
+       subprocess.run([...])
+   ```
+
+3. **Use Parameterized Commands**:
+
+   ```python
+   # ✅ RIGHT - List of args
+   subprocess.run(["gh", "issue", "create", "--title", title])
+
+   # ❌ WRONG - String with shell=True
+   subprocess.run(f"gh issue create --title '{title}'", shell=True)
+   ```
+
+4. **Set Timeouts**:
+
+   ```python
+   # ✅ RIGHT - Always set timeout
+   subprocess.run(cmd, timeout=30)
+
+   # ❌ WRONG - No timeout (can hang forever)
+   subprocess.run(cmd)
+   ```
+
+## Security Audit Checklist
+
+When reviewin' platform bridge code:
+
+- [ ] No credential storage or handling
+- [ ] All subprocess calls use list (not string with shell=True)
+- [ ] All user inputs validated before subprocess
+- [ ] Timeouts set on all subprocess calls
+- [ ] Error messages don't leak sensitive info
+- [ ] No filesystem writes except through CLI tools
+- [ ] Branch names validated against git rules
+- [ ] Size limits enforced on all inputs
+- [ ] No null bytes in string inputs
+- [ ] Exception handling prevents info leakage
+
+## Reporting Security Issues
+
+If ye discover a security vulnerability in the platform bridge:
+
+1. **Don't** open a public GitHub issue
+2. **Do** email security@amplihack.dev with details
+3. Include:
+   - Description of vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if ye have one)
+
+We'll respond within 48 hours and coordinate a fix.
+
+## See Also
+
+- [Platform Bridge Overview](../platform-bridge/README.md) - Feature documentation
+- [API Reference](../reference/platform-bridge-api.md) - Complete API
+- [GitHub CLI Security](https://cli.github.com/manual/gh_auth_login) - gh authentication
+- [Azure CLI Security](https://learn.microsoft.com/cli/azure/authenticate-azure-cli) - az authentication

--- a/docs/skills/SKILL_BUILDER_EXAMPLES.md
+++ b/docs/skills/SKILL_BUILDER_EXAMPLES.md
@@ -1,0 +1,422 @@
+# Skill Builder Command - Usage Examples
+
+This document provides practical examples of using the `/amplihack:skill-builder` command.
+
+## Quick Start
+
+```bash
+/amplihack:skill-builder <skill-name> <skill-type> <description>
+```
+
+**Skill Types**: `skill`, `agent`, `command`, `scenario`
+
+## Example 1: Creating a Claude Code Skill (Auto-Discovery)
+
+Create an auto-discoverable skill that loads when Claude detects relevance:
+
+```bash
+/amplihack:skill-builder json-validator skill "Validates JSON data against schemas with detailed error reporting and format checking"
+```
+
+**Expected Workflow:**
+
+1. Validates arguments (name, type, description)
+2. Creates todo list with 8 steps
+3. Invokes prompt-writer to clarify requirements
+4. Invokes architect to design skill structure with progressive disclosure
+5. Invokes builder to generate SKILL.md with YAML frontmatter
+6. Invokes reviewer to validate philosophy compliance
+7. Validates YAML frontmatter and token budget
+8. Creates directory and file at: `~/.amplihack/.claude/skills/json-validator/SKILL.md`
+
+**Expected Output:**
+
+- Auto-discoverable skill with keyword-rich description
+- Progressive disclosure structure (SKILL.md core <5K tokens)
+- Optional supporting files (reference.md, examples.md, scripts/)
+- Activates automatically when user says "validate JSON" or similar
+- Philosophy compliance score >85%
+
+**How It Works After Creation:**
+
+```
+User: "Can you validate this JSON for me?"
+Claude: *json-validator skill loads automatically*
+        "I'll validate that JSON using schema validation..."
+```
+
+## Example 2: Creating an Agent Skill
+
+Create a specialized agent for data transformation:
+
+```bash
+/amplihack:skill-builder data-transformer agent "Transforms data between JSON, YAML, XML, and CSV formats with schema validation"
+```
+
+**Expected Workflow:**
+
+1. Validates arguments (name, type, description)
+2. Creates todo list with 8 steps
+3. Invokes prompt-writer to clarify requirements
+4. Invokes architect to design skill structure
+5. Invokes builder to generate skill file
+6. Invokes reviewer to validate philosophy compliance
+7. Validates YAML frontmatter and structure
+8. Creates file at: `~/.amplihack/.claude/agents/amplihack/specialized/data-transformer.md`
+
+**Expected Output:**
+
+- Complete agent skill file with YAML frontmatter
+- Clear responsibilities and execution instructions
+- 2-3 usage examples
+- Validation rules and error handling
+- Philosophy compliance notes
+- References to documentation
+
+## Example 2: Creating a Command Skill
+
+Create a slash command for dependency analysis:
+
+```bash
+/amplihack:skill-builder analyze-dependencies command "Analyzes project dependencies, identifies outdated packages, and generates security report"
+```
+
+**Expected Workflow:**
+
+1. Validates arguments
+2. Clarifies requirements (what to analyze, report format)
+3. Designs command structure (arguments, options, output)
+4. Generates command file with proper frontmatter
+5. Reviews for philosophy compliance
+6. Validates YAML and structure
+7. Creates file at: `~/.amplihack/.claude/commands/amplihack/analyze-dependencies.md`
+
+**Key Features:**
+
+- `argument-hint` in YAML frontmatter
+- Clear usage instructions with examples
+- Argument parsing and validation
+- Error handling and user feedback
+- Integration with existing tools
+
+## Example 3: Creating a Scenario Skill
+
+Create a production-ready tool for code review:
+
+```bash
+/amplihack:skill-builder code-reviewer scenario "Reviews code for quality, security, performance, and best practices with detailed reports"
+```
+
+**Expected Workflow:**
+
+1. Validates arguments
+2. Clarifies requirements (what to review, criteria)
+3. Designs comprehensive scenario structure
+4. Generates complete scenario with directory structure
+5. Reviews for production readiness
+6. Validates all components
+7. Creates directory: `~/.amplihack/.claude/scenarios/code-reviewer/`
+   - `SKILL.md` - Main skill definition
+   - `README.md` - User-facing documentation
+   - `tool.py` - Implementation placeholder
+   - `tests/` - Test directory structure
+   - `examples/` - Usage examples
+
+**Maturity Path:**
+
+- Starts as `experimental`
+- Graduates to `beta` after 2-3 successful uses
+- Reaches `stable` after 1+ week of stability
+
+## Example 4: Simple Agent (Minimal Complexity)
+
+Create a simple formatter agent:
+
+```bash
+/amplihack:skill-builder json-formatter agent "Formats JSON with configurable indentation and sorting"
+```
+
+**Complexity Assessment:**
+
+- Scope: Simple (single purpose)
+- Implementation: Straightforward
+- Token Budget: ~3,000 (recommended for simple skills)
+
+**Generated Structure:**
+
+- Basic YAML frontmatter
+- Clear purpose statement
+- Simple usage instructions
+- 2-3 examples
+- Minimal validation rules
+
+## Example 5: Complex Scenario (High Complexity)
+
+Create a comprehensive system analysis tool:
+
+```bash
+/amplihack:skill-builder system-analyzer scenario "Analyzes entire codebase for architecture patterns, dependencies, security issues, performance bottlenecks, and generates comprehensive report with recommendations"
+```
+
+**Complexity Assessment:**
+
+- Scope: Complex (multi-system analysis)
+- Implementation: Advanced (multiple integrations)
+- Token Budget: ~8,000 (recommended for complex skills)
+
+**Generated Structure:**
+
+- Comprehensive YAML frontmatter with dependencies
+- Detailed purpose and responsibilities
+- Multiple usage modes (quick, standard, deep)
+- Extensive examples (5-7 scenarios)
+- Advanced validation and error handling
+- Integration points with multiple systems
+- Philosophy compliance checks
+
+## Validation Examples
+
+### Valid Skill Names ✅
+
+- `data-transformer`
+- `code-reviewer`
+- `api-client`
+- `json-formatter`
+- `system-analyzer`
+
+### Invalid Skill Names ❌
+
+- `DataTransformer` (camelCase not allowed)
+- `data_transformer` (underscores not allowed)
+- `data transformer` (spaces not allowed)
+- `dt` (too short, min 3 chars)
+- `DataTransformerWithVeryLongNameThatExceedsMaxLength` (too long, max 50 chars)
+
+### Valid Skill Types ✅
+
+- `agent`
+- `command`
+- `scenario`
+- `AGENT` (normalized to lowercase)
+- `Command` (normalized to lowercase)
+
+### Invalid Skill Types ❌
+
+- `tool` (not a recognized type)
+- `utility` (not a recognized type)
+- `helper` (not a recognized type)
+
+### Valid Descriptions ✅
+
+- "Transforms data between formats" (clear and concise)
+- "Analyzes code for security vulnerabilities and generates report" (specific and detailed)
+- "Formats JSON with customizable options" (simple and direct)
+
+### Invalid Descriptions ❌
+
+- "Does stuff" (too vague, length < 10)
+- "Transform" (too short, not descriptive)
+- "A comprehensive multi-system integrated super-advanced tool that does everything you could possibly imagine with extensive features and capabilities beyond imagination..." (too long, length > 200)
+
+## Testing Your Generated Skills
+
+### For Agent Skills
+
+Test by invoking the agent from another command or agent:
+
+```markdown
+**Task for {skill-name}:**
+
+{Provide test input matching the agent's contract}
+
+Expected:
+
+- {Expected output 1}
+- {Expected output 2}
+```
+
+### For Command Skills
+
+Test by invoking the slash command:
+
+```bash
+/{skill-name} {test-arguments}
+```
+
+Verify:
+
+- Arguments are parsed correctly
+- Validation works as expected
+- Output is formatted properly
+- Error handling works for invalid inputs
+
+### For Scenario Skills
+
+Test by running through Makefile (once integrated):
+
+```bash
+make {skill-name} TARGET={test-target}
+```
+
+Verify:
+
+- Tool executes successfully
+- Output meets expectations
+- Tests pass (if test suite created)
+- Documentation is clear and accurate
+
+## Common Issues and Solutions
+
+### Issue: "Invalid skill name"
+
+**Cause**: Name doesn't follow kebab-case convention
+**Solution**: Use lowercase letters, numbers, and hyphens only
+
+### Issue: "Missing required field in YAML"
+
+**Cause**: Generated skill missing name, description, or version
+**Solution**: Builder agent should always include these; review and regenerate
+
+### Issue: "Token budget too high"
+
+**Cause**: Skill is too complex or has excessive documentation
+**Solution**: Simplify scope, break into multiple skills, or optimize documentation
+
+### Issue: "Philosophy compliance failed"
+
+**Cause**: Generated skill contains stubs, TODOs, or placeholders
+**Solution**: Reviewer catches these; builder regenerates with complete implementation
+
+### Issue: "File already exists"
+
+**Cause**: Skill with same name already exists
+**Solution**: Choose different name or remove existing file first
+
+## Advanced Usage
+
+### Creating Related Skills
+
+Build a family of related skills:
+
+```bash
+# 1. Core transformer agent
+/amplihack:skill-builder data-transformer agent "Core data transformation engine"
+
+# 2. JSON-specific command
+/amplihack:skill-builder json-transform command "Transform JSON files using data-transformer agent"
+
+# 3. Full scenario tool
+/amplihack:skill-builder batch-transform scenario "Batch transform multiple files with progress tracking"
+```
+
+### Iterating on Skills
+
+If first generation isn't perfect:
+
+```bash
+# 1. Review the generated skill
+# 2. Identify specific improvements
+# 3. Re-run with refined description
+
+/amplihack:skill-builder data-transformer agent "Transforms data between JSON, YAML, XML formats with schema validation, error recovery, and detailed logging"
+```
+
+### Integration with Workflow
+
+Use generated skills in your workflow:
+
+```bash
+# 1. Create the skill
+/amplihack:skill-builder api-client agent "HTTP client with retry logic and error handling"
+
+# 2. Use in /ultrathink workflow
+/ultrathink "Implement new API endpoint using api-client agent"
+
+# 3. Agent orchestration will leverage new skill
+```
+
+## Best Practices
+
+### Naming Skills
+
+1. Use clear, descriptive names
+2. Follow single responsibility principle
+3. Keep names under 30 characters when possible
+4. Use consistent naming patterns (e.g., `{domain}-{action}`)
+
+### Writing Descriptions
+
+1. Be specific about WHAT the skill does
+2. Mention key features or capabilities
+3. Keep under 150 characters for clarity
+4. Avoid implementation details (HOW)
+
+### Choosing Skill Type
+
+- **Agent**: Internal automation, invoked by other agents
+- **Command**: User-facing, slash command interface
+- **Scenario**: Production tool, may have UI/CLI
+
+### Token Budget Management
+
+- Simple skills: 2,000-4,000 tokens
+- Medium skills: 4,000-6,000 tokens
+- Complex skills: 6,000-10,000 tokens
+- Avoid exceeding 10,000 unless absolutely necessary
+
+### Philosophy Alignment
+
+- Always prioritize simplicity
+- Include working examples, no stubs
+- Make skills self-contained
+- Ensure regeneratability from spec
+- Document integration points clearly
+
+## Success Criteria
+
+A successfully generated skill should:
+
+1. ✅ Pass all validation checks (name, type, YAML, structure)
+2. ✅ Achieve >85% philosophy compliance score
+3. ✅ Include 2-3 concrete usage examples
+4. ✅ Have clear instructions for execution
+5. ✅ Be immediately usable without editing
+6. ✅ Include proper error handling
+7. ✅ Reference relevant documentation
+8. ✅ Stay within recommended token budget
+
+## Next Steps After Creation
+
+1. **Review**: Read the generated skill file
+2. **Test**: Try using the skill with sample inputs
+3. **Iterate**: Refine if needed by regenerating
+4. **Integrate**: Use in your workflow or commands
+5. **Document**: Add to project documentation
+6. **Share**: Contribute to team's skill library
+
+## Getting Help
+
+If you encounter issues:
+
+1. Check this examples file
+2. Review the main command documentation
+3. Examine similar existing skills
+4. Test with simpler examples first
+5. Validate arguments before running
+6. Check agent logs for detailed errors
+
+## Contributing
+
+To improve the skill builder:
+
+1. Document patterns you discover
+2. Share successful skill examples
+3. Report issues or edge cases
+4. Suggest template improvements
+5. Add new validation rules
+
+---
+
+**Last Updated**: 2025-11-15
+**Version**: 1.0.0
+**Status**: Phase 1 Complete

--- a/docs/skills/SKILL_CATALOG.md
+++ b/docs/skills/SKILL_CATALOG.md
@@ -1,0 +1,322 @@
+# Claude Code Skills Catalog
+
+**Last Updated**: November 24, 2025
+
+This document provides a comprehensive catalog of all Claude Code skills available in amplihack.
+
+## About Claude Code Skills
+
+Claude Code Skills are modular, reusable capabilities that extend Claude's functionality. They consist of folders containing a `SKILL.md` file with YAML frontmatter and Markdown instructions, along with optional supporting scripts and resources.
+
+**Key Benefits:**
+
+- **Token Efficient**: Skills load on-demand, consuming minimal tokens until needed
+- **Auto-Detection**: Claude automatically uses skills based on context
+- **Philosophy Aligned**: All skills follow amplihack's ruthless simplicity and modular design
+- **Portable**: Work across Claude.ai, API, and Claude Code environments
+- **Self-Contained**: Each skill is independently usable and testable
+
+## Skill Types
+
+Amplihack has **THREE types of skills** that work together:
+
+### Type 1: Capability Skills (13+ skills)
+
+**Purpose**: Provide specific new functionality for tasks beyond coding.
+
+These skills add NEW capabilities like decision recording, email drafting, meeting synthesis, etc. They don't wrap existing agents - they provide genuinely new functionality.
+
+| Skill                         | Score | Description                                                                           | Issue                                                                                | PR                                                                                 |
+| ----------------------------- | ----- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| **module-spec-generator**     | 50.0  | Generate brick module specifications                                                  | [#1219](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1219) | -                                                                                  |
+| **meeting-synthesizer**       | 50.0  | Extract action items and decisions from meetings                                      | [#1220](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1220) | [#1231](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1231) |
+| **decision-logger**           | 49.5  | Structured decision recording (What\|Why\|Alternatives)                               | [#1221](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1221) | [#1231](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1231) |
+| **mermaid-diagram-generator** | 48.0  | Converts descriptions to Mermaid diagrams                                             | [#1222](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1222) | [#1268](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1268) |
+| **email-drafter**             | 47.0  | Professional email generation (formal/casual/technical)                               | [#1223](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1223) | [#1232](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1232) |
+| **philosophy-guardian**       | 45.5  | Reviews code against amplihack philosophy                                             | [#1224](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1224) | [#1235](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1235) |
+| **test-gap-analyzer**         | 44.5  | Identifies untested functions and coverage gaps                                       | [#1225](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1225) | [#1233](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1233) |
+| **storytelling-synthesizer**  | 44.0  | Transforms technical work into compelling narratives                                  | [#1226](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1226) | [#1236](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1236) |
+| **learning-path-builder**     | 43.5  | Creates personalized technology learning paths                                        | [#1227](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1227) | [#1237](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1237) |
+| **code-smell-detector**       | 42.5  | Detects anti-patterns and over-engineering                                            | [#1228](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1228) | [#1234](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1234) |
+| **knowledge-extractor**       | 40.5  | Extracts learnings to DISCOVERIES.md and PATTERNS.md                                  | [#1229](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1229) | [#1238](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1238) |
+| **pr-review-assistant**       | 40.0  | Philosophy-aware PR reviews                                                           | [#1230](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1230) | [#1258](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1258) |
+| **context-management**        | 48.5  | Proactive context window management via token monitoring and intelligent snapshots    | [#1347](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1347) | -                                                                                  |
+| **dynamic-debugger** 🆕       | 92.0  | Interactive debugging for Python/C++/Rust via DAP-MCP (opt-in, disabled by default)   | [#1552](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/issues/1552) | [#1553](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1553) |
+| **multitask** 🆕              | -     | Parallel workstream execution with Recipe Runner code-enforced workflows              | [#2306](https://github.com/rysweet/amplihack/issues/2306)                            | [#2308](https://github.com/rysweet/amplihack/pull/2308)                            |
+| **workiq-wsl** 🆕             | -     | Access M365 data (emails, calendar, files) from WSL via Windows Copilot CLI bridge    | -                                                                                    | [#3136](https://github.com/rysweet/amplihack/pull/3136)                            |
+| **crusty-old-engineer** ð     | -     | Curmudgeonly engineering advisor for architecture, legacy, and tooling reality checks | [#3564](https://github.com/rysweet/amplihack/issues/3564)                            | [#3565](https://github.com/rysweet/amplihack/pull/3565)                            |
+
+### Type 2: Domain Expert Analyst Skills (23 skills)
+
+**Purpose**: Analyze events through specialized disciplinary lenses using rigorous academic frameworks.
+
+These skills provide deep domain expertise for multi-perspective analysis of events, policies, and phenomena. Each analyst applies discipline-specific theories, methods, and evidence.
+
+**Social Sciences** (5):
+
+- **economist-analyst** - Markets, incentives, supply/demand, policy analysis
+- **political-scientist-analyst** - Power, institutions, IR theory, comparative politics
+- **historian-analyst** - Causation, continuity/change, historical context, precedents
+- **sociologist-analyst** - Social structures, inequality, collective behavior
+- **anthropologist-analyst** - Cultural analysis, ethnography, cross-cultural comparison
+
+**Humanities & Communication** (4):
+
+- **novelist-analyst** - Narrative structure, character development, dramatic tension
+- **journalist-analyst** - Investigation, verification, 5Ws+H, fact-checking
+- **poet-analyst** - Metaphor, imagery, close reading, emotional truth
+- **futurist-analyst** - Scenario planning, trend analysis, strategic foresight
+
+**Natural Sciences** (5):
+
+- **physicist-analyst** - Physical principles, conservation laws, modeling
+- **chemist-analyst** - Molecular structure, reactions, synthesis planning
+- **psychologist-analyst** - Cognition, behavior, social influence, neuroscience
+- **environmentalist-analyst** - Ecosystems, climate, sustainability, biodiversity
+- **biologist-analyst** - Evolution, genetics, ecology, systems biology
+
+**Applied Fields** (6):
+
+- **computer-scientist-analyst** - Algorithms, complexity, systems design
+- **cybersecurity-analyst** - Threat modeling, defense, incident response
+- **lawyer-analyst** - Legal analysis, IRAC, statutory interpretation
+- **indigenous-leader-analyst** - Traditional knowledge, Seven Generations, Two-Eyed Seeing
+- **engineer-analyst** - Systems analysis, optimization, failure analysis, trade-offs
+- **urban-planner-analyst** - Land use, zoning, transportation, housing, sustainability
+
+**Philosophy & Ethics** (3):
+
+- **ethicist-analyst** - Moral frameworks, value conflicts, normative analysis
+- **philosopher-analyst** - Logic, epistemology, metaphysics, conceptual analysis
+- **epidemiologist-analyst** - Disease patterns, public health, outbreak investigation
+
+**Key Features**:
+
+- All 23 analysts have comprehensive test suites (tests/quiz.md with 5 scenarios each)
+- Domain-specific search capability
+- Progressive disclosure structure (SKILL.md + README.md + QUICK_REFERENCE.md)
+- 100+ scholarly sources preserved across all agents
+- Consistent 16-section template pattern
+- PR: [#1346](https://github.com/rysweet/MicrosoftHackathon2025-AgenticCoding/pull/1346)
+
+### Type 3: Agent-Wrapper Skills (7 skills)
+
+**Purpose**: Auto-detect when to invoke existing agents, reducing need to remember command names.
+
+These skills are thin coordination layers that automatically trigger amplihack's existing agents based on conversation context.
+
+| Skill                         | Auto-Triggers                                              | Invokes                        | Location                                                                                            |
+| ----------------------------- | ---------------------------------------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| **Architecting Solutions**    | Design questions, "how should I", architecture discussions | Architect agent                | [development/architecting-solutions/](../../.claude/skills/development/architecting-solutions/)     |
+| **Reviewing Code**            | "review this", before PR, quality checks                   | Reviewer agent                 | [quality/reviewing-code/](../../.claude/skills/quality/reviewing-code/)                             |
+| **Testing Code**              | New features, "add tests", test gaps                       | Tester agent                   | [quality/testing-code/](../../.claude/skills/quality/testing-code/)                                 |
+| **Researching Topics**        | "how does X work", unfamiliar terms                        | Web search + knowledge builder | [research/researching-topics/](../../.claude/skills/research/researching-topics/)                   |
+| **Analyzing Problems Deeply** | Complex problems, "I'm not sure", ambiguity                | Ultrathink workflow            | [meta-cognitive/analyzing-deeply/](../../.claude/skills/meta-cognitive/analyzing-deeply/)           |
+| **Setting Up Projects**       | New projects, missing configs, pre-commit setup            | Builder agent + templates      | [development/setting-up-projects/](../../.claude/skills/development/setting-up-projects/)           |
+| **Creating Pull Requests**    | "create PR", ready to merge                                | Smart PR generation            | [collaboration/creating-pull-requests/](../../.claude/skills/collaboration/creating-pull-requests/) |
+
+## Research & Documentation
+
+### Research Reports
+
+- **[Complete Research Report](../../.claude/runtime/logs/20251108_skills_research/RESEARCH.md)** (357 lines)
+  - Comprehensive analysis of Claude Code Skills ecosystem
+  - Comparison with MCP (Model Context Protocol)
+  - 23+ documented skills from Anthropic and community
+  - Key insights from Simon Willison and other experts
+
+- **[Evaluation Matrix & Ideas](../../.claude/runtime/logs/20251108_skills_research/EVALUATION_MATRIX_AND_IDEAS.md)** (842 lines)
+  - 6-criteria evaluation framework aligned with amplihack philosophy
+  - 20 brainstormed skill ideas with priority scores
+  - Implementation phases and effort estimates
+  - Detailed scoring rubrics
+
+### Evaluation Criteria (Capability Skills)
+
+Capability skills were evaluated on:
+
+1. **Ruthless Simplicity** (1-5): Single clear purpose, minimal dependencies
+2. **Modular Design** (1-5): Self-contained, clear interfaces (bricks & studs)
+3. **Zero-BS Implementation** (1-5): Actually works, no stubs
+4. **Reusability** (1-5): Useful across multiple contexts
+5. **Maintenance Burden** (1-5, lower is better): Stable dependencies
+6. **User Value** (1-5): Solves frequent pain points, measurable time savings
+
+**Priority Score Formula:**
+
+```
+Priority = (Simplicity * 2) + (Modular * 2) + (Zero-BS * 1.5) +
+           (Reusability * 1.5) + ((6 - Maintenance) * 1) + (User Value * 2.5)
+Max Score: 50 points
+```
+
+All capability skills scored 40.0-50.0 (HIGH priority).
+
+## Using Skills
+
+Skills are automatically discovered from:
+
+- User settings: `~/.config/claude/skills/`
+- Project settings: `~/.amplihack/.claude/skills/`
+- Plugin-provided skills
+- Built-in skills
+
+### Invoking Skills
+
+**Capability Skills** (explicit invocation):
+
+```
+Claude, use the decision-logger skill to record this architectural decision.
+Claude, analyze test coverage using test-gap-analyzer.
+Claude, generate a Mermaid diagram for this workflow.
+```
+
+**Agent-Wrapper Skills** (automatic detection):
+
+```
+User: "How should I design the authentication system?"
+→ Architecting Solutions skill auto-activates
+→ Provides design analysis automatically
+
+User: "Can you review this code?"
+→ Reviewing Code skill auto-activates
+→ Performs comprehensive review
+```
+
+### Managing Skills
+
+```bash
+/agents                # List available agents and skills
+/reload-skills         # Reload after modifications
+```
+
+## Skill Structure
+
+Each skill follows this structure:
+
+```
+skill-name/
+├── SKILL.md           # Required: YAML frontmatter + instructions
+├── README.md          # Optional: User-facing documentation
+├── examples/          # Optional: Example usage
+└── tests/             # Optional: Validation tests
+```
+
+### SKILL.md Format
+
+```yaml
+---
+name: skill-name
+description: |
+  Clear description of what this skill does and when Claude should use it.
+  Include both the capability AND the usage context.
+---
+
+# Skill Instructions
+
+Detailed instructions for Claude on how to use this skill...
+
+## Examples
+Concrete examples with input/output...
+```
+
+### YAML Frontmatter Requirements
+
+**Critical**: The YAML frontmatter MUST:
+
+1. Start at the **first line** of SKILL.md (no title or content before `---`)
+2. Use proper `---` delimiters (not code blocks like ````yaml`)
+3. Contain no HTML comments within the YAML section
+4. Include at minimum: `name` and `description` fields
+
+**Common Mistakes Fixed in v0.9.0** (PR #2811):
+
+- ❌ Metadata in `````yaml` code block instead of frontmatter
+- ❌ Title heading before frontmatter
+- ❌ HTML comments (`<!-- -->`) inside YAML
+- ❌ Missing frontmatter entirely
+
+**Example of Correct Format**:
+
+```yaml
+---
+name: example-skill
+description: |
+  A clear description of what this skill does.
+---
+# Example Skill
+
+Content starts after the frontmatter...
+```
+
+**Example of Incorrect Format**:
+
+```yaml
+# Example Skill  ← WRONG: Title before frontmatter
+---
+name: example-skill
+<!-- This is a comment -->  ← WRONG: HTML in YAML
+description: Example
+---
+```
+
+## Quality Standards
+
+All skills meet these quality standards:
+
+- ✅ **Complete Documentation**: SKILL.md with YAML frontmatter
+- ✅ **Clear Examples**: Real-world usage demonstrations
+- ✅ **Philosophy Aligned**: Ruthless simplicity, modular design, zero-BS
+- ✅ **Tested**: Quality review completed
+- ✅ **Production Ready**: No stubs, TODOs, or placeholders
+
+## Creating New Skills
+
+### For Capability Skills
+
+To create a new capability skill:
+
+1. **Research**: Check if similar skills exist
+2. **Evaluate**: Score against 6 criteria (target score: 40+)
+3. **Create**: Follow skill structure above
+4. **Document**: Clear SKILL.md with examples
+5. **Test**: Validate with real usage
+6. **Review**: Ensure philosophy compliance
+
+See [Evaluation Matrix](../../.claude/runtime/logs/20251108_skills_research/EVALUATION_MATRIX_AND_IDEAS.md) for guidance on prioritization.
+
+### For Agent-Wrapper Skills
+
+To create an agent-wrapper skill:
+
+1. **Identify Pattern**: Find repetitive agent invocations
+2. **Define Triggers**: What phrases/contexts should activate this?
+3. **Create Thin Wrapper**: Just detection logic + agent invocation
+4. **No Logic Duplication**: All real work stays in agents
+5. **Test Auto-Detection**: Verify skill activates appropriately
+
+## Related Documentation
+
+- [CLAUDE.md](../../CLAUDE.md) - Project overview and agent system
+- [PHILOSOPHY.md](../../.claude/context/PHILOSOPHY.md) - Ruthless simplicity principles
+- [PATTERNS.md](../../.claude/context/PATTERNS.md) - Reusable solution patterns
+- [Agent Catalog](../../.claude/agents/CATALOG.md) - Specialized agents
+
+## Contributing
+
+When adding new skills:
+
+1. Determine skill type (capability vs. agent-wrapper)
+2. Create GitHub issue with rationale
+3. Implement in separate worktree/branch
+4. Follow naming: `feat/issue-{number}-{skill-name}`
+5. Create PR with comprehensive description
+6. Link to research and evaluation docs (if capability skill)
+7. Ensure quality review completed
+
+---
+
+**Total Skills**: 43 (14 capability + 23 analyst + 7 agent-wrapper - 1 deprecated)
+**Status**: Production Ready
+
+🤖 Skills documentation maintained as part of amplihack project

--- a/docs/testing/AUTO_MODE_UI_TEST_SUITE.md
+++ b/docs/testing/AUTO_MODE_UI_TEST_SUITE.md
@@ -1,0 +1,504 @@
+# Auto Mode Interactive UI - Comprehensive TDD Test Suite
+
+## Executive Summary
+
+This comprehensive test-driven development (TDD) test suite provides complete specifications for implementing the Auto Mode Interactive UI feature. All tests are designed to **FAIL initially** and serve as living documentation guiding implementation.
+
+## Test Suite Overview
+
+### Files Created
+
+1. **tests/unit/test_auto_mode_ui.py** (380 lines)
+   - UI component tests
+   - 10 test classes, 40+ tests
+   - Coverage: Initialization, title generation, session details, todos, logs, input, keyboard commands, edge cases
+
+2. **tests/unit/test_ui_threading.py** (300 lines)
+   - Threading and concurrency tests
+   - 6 test classes, 25+ tests
+   - Coverage: Background threads, thread safety, communication, shutdown, synchronization, error handling
+
+3. **tests/unit/test_ui_sdk_integration.py** (280 lines)
+   - Claude SDK integration tests
+   - 6 test classes, 30+ tests
+   - Coverage: Title generation, cost tracking, todo updates, streaming, error handling, performance
+
+4. **tests/integration/test_auto_mode_ui_integration.py** (320 lines)
+   - End-to-end integration tests
+   - 5 test classes, 20+ tests
+   - Coverage: Full workflows, prompt injection, pause/resume, exit behavior, error recovery
+
+5. **tests/unit/README_AUTO_MODE_UI_TESTS.md** (Complete documentation)
+   - Test structure and organization
+   - Implementation guide by phase
+   - Common issues and solutions
+   - Success criteria
+
+**Total**: 1,280+ lines of comprehensive tests, 115+ test cases
+
+## Testing Pyramid Distribution
+
+```
+         /\
+        /  \      E2E Tests (10%)
+       /____\     - Full workflows
+      /      \    Integration Tests (30%)
+     /        \   - Component interaction
+    /__________\  Unit Tests (60%)
+                  - Individual components
+```
+
+### Coverage by Type
+
+- **Unit Tests**: 60% (~70 tests) - Component isolation, edge cases, boundaries
+- **Integration Tests**: 30% (~35 tests) - SDK integration, thread communication
+- **E2E Tests**: 10% (~20 tests) - Complete user journeys
+
+## Feature Requirements Tested
+
+### 1. Interactive UI with 5 Areas
+
+- ✓ Title panel (generated from prompt via Claude SDK)
+- ✓ Session details panel (turn counter, elapsed time, cost tracking)
+- ✓ Todo list panel (status indicators, current task highlighting)
+- ✓ Log area panel (streaming output, timestamps, buffer management)
+- ✓ Prompt input panel (multiline support, instruction queueing)
+
+### 2. Keyboard Commands
+
+- ✓ 'x' - Exit UI, continue auto mode in background
+- ✓ 'p' - Pause/resume execution
+- ✓ 'k' - Kill auto mode completely
+- ✓ 'h' - Show help overlay (bonus)
+
+### 3. Claude Agent SDK Integration
+
+- ✓ Title generation via SDK query()
+- ✓ Cost tracking (input/output tokens, estimated cost)
+- ✓ Message streaming (AssistantMessage, ToolUseMessage, ResultMessage)
+- ✓ Error handling (connection errors, rate limits, timeouts)
+- ✓ Performance metrics (latency, throughput)
+
+### 4. Rich CLI Library Implementation
+
+- ✓ Layout structure (5 panels with proper sizing)
+- ✓ Live updates (panel content refresh)
+- ✓ Styling (colors, highlighting, status indicators)
+- ✓ Unicode support (emoji, CJK characters)
+
+### 5. Thread-Based Execution
+
+- ✓ Background thread for auto mode
+- ✓ Main thread for UI rendering
+- ✓ Thread-safe state sharing (Locks, Events, Queue)
+- ✓ Graceful shutdown and cleanup
+- ✓ No deadlocks or race conditions
+
+## Test Organization
+
+### Phase 1: UI Foundation
+
+**File**: test_auto_mode_ui.py
+**Classes**: TestAutoModeUIInitialization, TestUITitleGeneration, TestSessionDetailsDisplay
+
+**Focus**:
+
+- UI instance creation with ui_mode=True
+- Rich layout with 5 panels
+- Title generation (SDK + fallback)
+- Session panel (turn, time, cost)
+
+**Key Tests**:
+
+- test_ui_mode_creates_ui_instance()
+- test_ui_has_required_components()
+- test_title_generation_uses_claude_sdk()
+- test_session_panel_shows_turn_counter()
+
+### Phase 2: Threading Infrastructure
+
+**File**: test_ui_threading.py
+**Classes**: TestAutoModeBackgroundThread, TestThreadSafeStateSharing, TestGracefulShutdown
+
+**Focus**:
+
+- Background thread creation
+- Thread-safe state (turn, logs, todos, cost)
+- UI-to-AutoMode communication
+- Shutdown and cleanup
+
+**Key Tests**:
+
+- test_auto_mode_creates_background_thread()
+- test_turn_counter_is_thread_safe()
+- test_log_queue_is_thread_safe()
+- test_shutdown_cleans_up_resources()
+
+### Phase 3: SDK Integration
+
+**File**: test_ui_sdk_integration.py
+**Classes**: TestTitleGenerationViaSDK, TestCostTrackingDisplay, TestSDKStreamingToUI
+
+**Focus**:
+
+- Claude SDK query() calls
+- Token counting and cost calculation
+- Message streaming to logs
+- Error handling and retries
+
+**Key Tests**:
+
+- test_title_generation_calls_claude_sdk()
+- test_cost_accumulates_across_turns()
+- test_assistant_messages_stream_to_logs()
+- test_sdk_connection_error_shown_in_ui()
+
+### Phase 4: User Interactions
+
+**File**: test_auto_mode_ui.py
+**Classes**: TestPromptInputHandling, TestKeyboardCommands, TestTodoListIntegration
+
+**Focus**:
+
+- Keyboard command handling
+- Prompt input and injection
+- Todo list updates
+- Log area updates
+
+**Key Tests**:
+
+- test_keyboard_command_x_exits_ui()
+- test_keyboard_command_p_pauses_execution()
+- test_input_creates_instruction_file()
+- test_todo_panel_displays_current_todos()
+
+### Phase 5: End-to-End Workflows
+
+**File**: test_auto_mode_ui_integration.py
+**Classes**: TestFullUIWorkflow, TestPromptInjectionViaUI, TestPauseAndResume
+
+**Focus**:
+
+- Complete startup to completion
+- Live instruction injection
+- Pause/resume flow
+- Exit to terminal mode
+
+**Key Tests**:
+
+- test_ui_starts_and_displays_initial_state()
+- test_inject_instruction_during_execution()
+- test_pause_stops_new_turns()
+- test_exit_ui_keeps_automode_running()
+
+## Critical Paths Tested
+
+### Startup Flow
+
+1. AutoMode(ui_mode=True) → Creates UI instance
+2. UI.**init**() → Creates 5 panels with Rich layout
+3. generate_title() → Claude SDK query for concise title
+4. start_background() → Creates execution thread
+5. UI render loop → Display initial state
+
+### Execution Flow
+
+1. Auto mode runs in background thread
+2. Logs queued via Queue → UI consumes and displays
+3. Turn counter updated → Session panel refreshes
+4. Todos updated → Todo panel refreshes
+5. Cost info updated → Session panel shows tokens/cost
+
+### Injection Flow
+
+1. User types in input panel → Text queued
+2. User submits → Write to append/TIMESTAMP.md
+3. Auto mode checks before turn → Detects new file
+4. Read and sanitize content → Append to execute prompt
+5. Move to appended/ → Process instruction
+
+### Pause/Resume Flow
+
+1. User presses 'p' → Set pause_event
+2. Auto mode checks event → Complete current turn
+3. Auto mode waits on event → No new turns start
+4. User presses 'p' again → Clear pause_event
+5. Auto mode continues → Normal execution resumes
+
+### Exit Flow
+
+1. User presses 'x' → Set ui.should_exit()
+2. UI render loop exits → Close UI
+3. Switch to terminal mode → Continue logging to stdout
+4. Auto mode continues → Background thread alive
+5. Eventually completes → Cleanup and exit
+
+## Boundary Conditions Tested
+
+### Empty/Zero Cases
+
+- Empty prompt → Default title "Auto Mode Session"
+- max_turns=0 → Graceful handling
+- Empty todo list → "No tasks yet" message
+- No cost info → Display "N/A"
+
+### Large Values
+
+- 500+ char prompts → Truncate to 50 chars
+- 1M+ tokens → Comma formatting (1,000,000)
+- 100+ rapid log messages → Batch updates (30/sec)
+- 1000+ log lines → Buffer truncation
+
+### Edge Cases
+
+- Negative elapsed time → Clamp to 0s (clock skew)
+- Unicode in logs → Emoji, CJK display correctly
+- Concurrent reads/writes → No race conditions
+- Thread timeout → Max 5s wait on shutdown
+
+### Error Cases
+
+- SDK connection error → Display error, continue
+- Rate limit (429) → Show retry countdown, backoff
+- UI thread crash → Auto mode isolated, continues
+- Missing Rich library → Fall back to terminal
+- Disk full → Skip log write, continue
+
+## Thread Safety Verification
+
+### Protected State
+
+- **turn_counter**: threading.Lock
+- **todos_list**: threading.Lock
+- **cost_info**: threading.Lock
+- **log_messages**: Queue (thread-safe by default)
+
+### Signals
+
+- **pause_event**: threading.Event
+- **stop_event**: threading.Event
+
+### Race Condition Tests
+
+- 100 concurrent turn increments → Final value correct
+- Concurrent todo reads/writes → No corruption
+- Log queue overflow → Oldest dropped, no block
+
+### Deadlock Prevention
+
+- Timeout on all Queue.get() calls (1-5 seconds)
+- Timeout on Thread.join() calls (5 seconds)
+- Lock acquisition order documented
+- Test completes in <5 seconds
+
+## Performance Targets
+
+### UI Responsiveness
+
+- **Frame Rate**: 30 FPS target (33ms per frame)
+- **Input Latency**: <100ms from keypress to UI update
+- **Log Batching**: Max 30 updates/sec (reduce flickering)
+
+### Memory Usage
+
+- **Log Buffer**: 1000 lines max (~100KB)
+- **Queue Size**: 500 items max (~50KB)
+- **No Leaks**: Memory stable over 1000 turns
+
+### Throughput
+
+- **Streaming**: Handle 100+ messages/sec
+- **Tokens/sec**: Display output rate
+- **Turn Latency**: Track and display per-turn time
+
+## Implementation Roadmap
+
+### Week 1: UI Foundation
+
+- [ ] Add ui_mode parameter to AutoMode
+- [ ] Create UIManager class with Rich layout
+- [ ] Implement 5 panel structure
+- [ ] Basic title generation (truncate prompt)
+- **Tests to Pass**: TestAutoModeUIInitialization (10 tests)
+
+### Week 2: Threading Infrastructure
+
+- [ ] Add background thread for execution
+- [ ] Implement thread-safe state (Locks)
+- [ ] Add log queue (Queue)
+- [ ] Implement pause/stop events (Event)
+- **Tests to Pass**: TestAutoModeBackgroundThread, TestThreadSafeStateSharing (15 tests)
+
+### Week 3: SDK Integration
+
+- [ ] Async title generation via SDK
+- [ ] Cost tracking from ResultMessage.usage
+- [ ] Message streaming to log queue
+- [ ] Error handling with retry
+- **Tests to Pass**: TestTitleGenerationViaSDK, TestCostTrackingDisplay (20 tests)
+
+### Week 4: User Interactions
+
+- [ ] Keyboard input handling (x, p, k)
+- [ ] Prompt input panel with submit
+- [ ] Instruction file creation
+- [ ] Todo list updates
+- **Tests to Pass**: TestKeyboardCommands, TestPromptInputHandling (15 tests)
+
+### Week 5: E2E Integration
+
+- [ ] Complete startup workflow
+- [ ] Live injection during execution
+- [ ] Pause/resume functionality
+- [ ] Exit to terminal mode
+- **Tests to Pass**: TestFullUIWorkflow, TestPromptInjectionViaUI (20 tests)
+
+### Week 6: Polish & Bug Fixes
+
+- [ ] Fix remaining edge cases
+- [ ] Performance optimization
+- [ ] UI styling and colors
+- [ ] Help overlay ('h' command)
+- **Tests to Pass**: All remaining tests (~35 tests)
+
+**Total**: ~115 tests to pass over 6 weeks
+
+## Running the Tests
+
+### All Tests
+
+```bash
+# Run all unit tests
+pytest tests/unit/test_auto_mode_ui.py -v
+pytest tests/unit/test_ui_threading.py -v
+pytest tests/unit/test_ui_sdk_integration.py -v
+
+# Run all integration tests
+pytest tests/integration/test_auto_mode_ui_integration.py -v
+
+# Run everything
+pytest tests/unit/test_auto_mode_ui.py tests/unit/test_ui_threading.py tests/unit/test_ui_sdk_integration.py tests/integration/test_auto_mode_ui_integration.py -v
+```
+
+### By Phase
+
+```bash
+# Phase 1: UI Foundation
+pytest tests/unit/test_auto_mode_ui.py::TestAutoModeUIInitialization -v
+pytest tests/unit/test_auto_mode_ui.py::TestUITitleGeneration -v
+
+# Phase 2: Threading
+pytest tests/unit/test_ui_threading.py::TestAutoModeBackgroundThread -v
+pytest tests/unit/test_ui_threading.py::TestThreadSafeStateSharing -v
+
+# Phase 3: SDK Integration
+pytest tests/unit/test_ui_sdk_integration.py::TestTitleGenerationViaSDK -v
+pytest tests/unit/test_ui_sdk_integration.py::TestSDKStreamingToUI -v
+
+# Phase 4: User Interactions
+pytest tests/unit/test_auto_mode_ui.py::TestKeyboardCommands -v
+pytest tests/unit/test_auto_mode_ui.py::TestPromptInputHandling -v
+
+# Phase 5: E2E
+pytest tests/integration/test_auto_mode_ui_integration.py::TestFullUIWorkflow -v
+```
+
+### With Coverage
+
+```bash
+pytest tests/unit/test_auto_mode_ui.py \
+       tests/unit/test_ui_threading.py \
+       tests/unit/test_ui_sdk_integration.py \
+       tests/integration/test_auto_mode_ui_integration.py \
+       --cov=amplihack.launcher.auto_mode \
+       --cov-report=html \
+       --cov-report=term-missing
+```
+
+## Expected Initial State
+
+**All tests should FAIL** with AttributeError until implementation begins:
+
+```
+FAILED test_auto_mode_ui.py::TestAutoModeUIInitialization::test_ui_mode_creates_ui_instance
+    AttributeError: 'AutoMode' object has no attribute 'ui_enabled'
+
+FAILED test_ui_threading.py::TestAutoModeBackgroundThread::test_auto_mode_creates_background_thread
+    AttributeError: 'AutoMode' object has no attribute 'start_background'
+
+FAILED test_ui_sdk_integration.py::TestTitleGenerationViaSDK::test_title_generation_calls_claude_sdk
+    AttributeError: 'NoneType' object has no attribute 'generate_title_async'
+
+FAILED test_auto_mode_ui_integration.py::TestFullUIWorkflow::test_ui_starts_and_displays_initial_state
+    AttributeError: 'AutoMode' object has no attribute 'start_ui'
+```
+
+This is **expected and correct** - tests drive implementation!
+
+## Success Criteria
+
+### Code Complete
+
+- [ ] All 115+ tests passing
+- [ ] Code coverage >85%
+- [ ] No race conditions detected
+- [ ] Memory usage stable
+
+### Performance Targets Met
+
+- [ ] UI renders at 30 FPS
+- [ ] Input latency <100ms
+- [ ] No blocking operations
+- [ ] Graceful degradation on errors
+
+### Quality Gates Passed
+
+- [ ] Manual testing confirms usability
+- [ ] No crashes on edge cases
+- [ ] Clean shutdown on all paths
+- [ ] Documentation complete
+
+### User Acceptance
+
+- [ ] UI is intuitive and responsive
+- [ ] Commands work as expected
+- [ ] Error messages are helpful
+- [ ] Performance is acceptable
+
+## Next Steps
+
+1. **Start Implementation**: Begin with Phase 1 (UI Foundation)
+2. **TDD Cycle**: Red (test fails) → Green (minimal code to pass) → Refactor
+3. **Incremental Progress**: Pass tests in order, phase by phase
+4. **Review & Iterate**: Code review after each phase
+5. **Manual Testing**: Real usage testing throughout
+6. **Performance Profiling**: Optimize hotspots as needed
+
+## Documentation References
+
+- **Main README**: tests/unit/README_AUTO_MODE_UI_TESTS.md
+- **Test Files**:
+  - tests/unit/test_auto_mode_ui.py
+  - tests/unit/test_ui_threading.py
+  - tests/unit/test_ui_sdk_integration.py
+  - tests/integration/test_auto_mode_ui_integration.py
+- **Existing Code**: src/amplihack/launcher/auto_mode.py
+
+## Contact & Support
+
+For questions about this test suite:
+
+1. Read the detailed README in tests/unit/
+2. Review test code for specifications
+3. Check existing auto_mode.py for current implementation
+4. Refer to Rich library docs for UI patterns
+
+---
+
+**Generated**: 2025-01-28
+**Test Files**: 4
+**Test Classes**: 27
+**Test Cases**: 115+
+**Lines of Test Code**: 1,280+
+**Coverage Target**: >85%
+**Implementation Time**: 6 weeks estimated

--- a/docs/testing/TEST_FIXES_NEEDED.md
+++ b/docs/testing/TEST_FIXES_NEEDED.md
@@ -1,0 +1,249 @@
+# Test Fixes Needed
+
+## Overview
+
+This document outlines the specific fixes needed to get all 60 tests passing
+(currently 40/60 passing).
+
+## Issue 1: Monkeypatch Issues with Path Objects (5 tests)
+
+### Problem
+
+Python 3.13 Path objects have read-only attributes that cannot be patched with
+pytest's monkeypatch.
+
+### Affected Tests
+
+- `test_unit_process_004_permission_error_accessing_lock_file`
+- `test_unit_process_005_oserror_accessing_lock_file`
+- `test_unit_prompt_006_permission_error_reading_custom_prompt`
+- `test_unit_prompt_007_oserror_reading_custom_prompt`
+- `test_unit_prompt_008_unicode_decode_error_reading_custom_prompt`
+
+### Solution Option 1: Mock at Module Level
+
+Instead of mocking the instance, mock at the import level:
+
+```python
+def test_unit_process_004_permission_error_accessing_lock_file(stop_hook):
+    """UNIT-PROCESS-004: Permission error accessing lock file."""
+    import pathlib
+
+    original_exists = pathlib.Path.exists
+
+    def mock_exists(self):
+        if str(self) == str(stop_hook.lock_flag):
+            raise PermissionError("Access denied")
+        return original_exists(self)
+
+    with patch.object(pathlib.Path, 'exists', mock_exists):
+        input_data = {"session_id": "test_123", "hook_event_name": "stop"}
+        result = stop_hook.process(input_data)
+
+        assert result == {}
+        log_content = stop_hook.log_file.read_text()
+        assert "Cannot access lock file" in log_content
+```
+
+### Solution Option 2: Integration Test Approach
+
+Accept that testing exception paths requires real file system errors, making
+these integration tests:
+
+```python
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix permissions only")
+def test_unit_process_004_permission_error_accessing_lock_file(stop_hook):
+    """UNIT-PROCESS-004: Permission error accessing lock file."""
+    import os
+
+    # Create lock file with no permissions
+    stop_hook.lock_flag.touch()
+    os.chmod(stop_hook.lock_flag, 0o000)
+
+    try:
+        input_data = {"session_id": "test_123", "hook_event_name": "stop"}
+        result = stop_hook.process(input_data)
+
+        assert result == {}
+    finally:
+        # Restore permissions for cleanup
+        os.chmod(stop_hook.lock_flag, 0o644)
+```
+
+## Issue 2: Subprocess Environment Setup (14 tests)
+
+### Problem
+
+The `captured_subprocess` fixture runs stop.py in a subprocess, but the
+subprocess doesn't find the temp project root correctly. The hook needs to know
+where to look for lock files and logs.
+
+### Root Cause
+
+Stop.py uses `get_project_root()` which searches for `.claude` directory
+starting from its own location, but in tests we want it to use the temp
+directory.
+
+### Solution: Add Environment Variable Support to stop.py
+
+**Step 1**: Update `hook_processor.py` to check environment variable first:
+
+```python
+def __init__(self, hook_name: str):
+    """Initialize the hook processor."""
+    self.hook_name = hook_name
+
+    # Check for environment override (used in testing)
+    env_root = os.environ.get('AMPLIHACK_PROJECT_ROOT')
+    if env_root:
+        self.project_root = Path(env_root)
+    else:
+        # Use clean import path resolution
+        try:
+            sys.path.insert(0, str(Path(__file__).parent.parent))
+            from paths import get_project_root
+            self.project_root = get_project_root()
+        except ImportError:
+            # Fallback logic...
+```
+
+**Step 2**: The `captured_subprocess` fixture already sets this environment
+variable:
+
+```python
+env = os.environ.copy()
+env['AMPLIHACK_PROJECT_ROOT'] = str(temp_project_root)
+```
+
+This fix would make all 14 subprocess tests pass immediately.
+
+### Affected Tests (All using captured_subprocess)
+
+**Integration Tests (10)**:
+
+- `test_integ_subprocess_002_hook_executed_with_active_lock`
+- `test_integ_lock_002_lock_file_deleted_and_hook_responds`
+- `test_integ_lock_003_continuous_work_mode_scenario`
+- `test_integ_prompt_001_default_to_custom_prompt_transition`
+- `test_integ_prompt_002_custom_prompt_file_updated_during_execution`
+- `test_integ_prompt_003_custom_prompt_file_deleted_during_lock_active`
+- `test_integ_prompt_004_custom_prompt_with_edge_case_content`
+- `test_integ_log_001_log_file_created_and_populated`
+- `test_integ_log_002_metrics_file_created_and_populated`
+- `test_integ_log_004_concurrent_logging_from_multiple_hook_executions`
+
+**E2E Tests (4)**:
+
+- `test_e2e_workflow_002_continuous_work_mode_active`
+- `test_e2e_workflow_003_continuous_work_mode_disabled`
+- `test_e2e_error_002_recovery_from_missing_directories`
+- `test_e2e_perf_001_hook_performance_under_load` (minor impact)
+
+## Issue 3: Performance Test Margin
+
+### Current Status
+
+Test passes with 250ms limit (was failing at 200ms with max=209ms).
+
+### Recommendation
+
+Keep the 250ms limit for tests to account for CI/test environment overhead.
+Production monitoring should enforce the 200ms requirement.
+
+## Implementation Priority
+
+### High Priority (Unblocks 14 tests)
+
+1. Add `AMPLIHACK_PROJECT_ROOT` environment variable support to
+   `hook_processor.py`
+   - **Impact**: 14 tests will pass
+   - **Effort**: 5 minutes (2 line change)
+   - **Risk**: None (only affects testing)
+
+### Medium Priority (Fixes 5 tests)
+
+2. Fix monkeypatch issues with Path objects
+   - **Impact**: 5 tests will pass
+   - **Effort**: 15 minutes (rewrite 5 test functions)
+   - **Risk**: Low (just test refactoring)
+
+### Low Priority (Optional)
+
+3. Generate coverage report
+   - **Impact**: Visibility into coverage percentage
+   - **Effort**: 2 minutes (run pytest --cov)
+   - **Risk**: None
+
+## Expected Results After Fixes
+
+| Category    | Current   | After Fix 1 | After Fix 2 | Total     |
+| ----------- | --------- | ----------- | ----------- | --------- |
+| Unit        | 31/36     | 31/36       | 36/36       | 36/36     |
+| Integration | 6/18      | 16/18       | 16/18       | 16/18     |
+| E2E         | 3/6       | 6/6         | 6/6         | 6/6       |
+| **Total**   | **40/60** | **53/60**   | **58/60**   | **58/60** |
+
+_Note: 2 tests (permission-related) may remain platform-dependent and skip on
+Windows_
+
+## Quick Fix Commands
+
+### Apply Fix #1 (Environment Variable Support)
+
+```bash
+cd /Users/ryan/src/tempsaturday/worktree-issue-962
+
+# Edit hook_processor.py to add env var support
+# (See solution above for exact code)
+```
+
+### Run Tests After Fix #1
+
+```bash
+python -m pytest tests/unit/test_stop_hook*.py tests/unit/test_hook_processor_run.py \
+                 tests/integration/test_stop_hook*.py tests/e2e/test_stop_hook*.py -v
+
+# Expected: 53/60 passing (up from 40/60)
+```
+
+### Apply Fix #2 (Monkeypatch Issues)
+
+```bash
+# Update the 5 affected test functions with module-level patching
+# (See solution option 1 above for pattern)
+```
+
+### Run Tests After Fix #2
+
+```bash
+python -m pytest tests/unit/test_stop_hook*.py tests/unit/test_hook_processor_run.py \
+                 tests/integration/test_stop_hook*.py tests/e2e/test_stop_hook*.py -v
+
+# Expected: 58/60 passing (platform-dependent tests may skip)
+```
+
+### Generate Coverage Report
+
+```bash
+python -m pytest tests/unit/ tests/integration/ tests/e2e/ \
+  --cov=.claude/tools/amplihack/hooks \
+  --cov-report=html --cov-report=term
+
+# View report
+open htmlcov/index.html  # macOS
+# or
+xdg-open htmlcov/index.html  # Linux
+```
+
+## Conclusion
+
+With two simple fixes:
+
+1. **5 minute fix** for environment variable support → +13 tests passing
+2. **15 minute fix** for monkeypatch issues → +5 tests passing
+
+We can achieve **58/60 tests passing (97%)** with platform-appropriate skips for
+permission tests.
+
+The test suite is **production-ready** and provides comprehensive validation of
+the stop hook fix for Issue #962.

--- a/docs/testing/TEST_IMPLEMENTATION_SUMMARY.md
+++ b/docs/testing/TEST_IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,277 @@
+# Test Suite Implementation Summary: Stop Hook Fix (Issue #962)
+
+## Executive Summary
+
+**Status**: ✅ Complete - All 60 tests implemented **Passing**: 40/60 (67%)
+**Failing**: 20/60 (33% - primarily subprocess environment setup issues)
+**Implementation Quality**: Excellent test coverage with comprehensive test IDs
+matching specification
+
+## Test Suite Structure
+
+### Unit Tests (36 tests) - Status: 31/36 passing (86%)
+
+#### StopHook.process() Tests (12 tests) - 10/12 passing
+
+- ✅ UNIT-PROCESS-001: No lock file exists
+- ✅ UNIT-PROCESS-002: Lock file exists with default prompt
+- ✅ UNIT-PROCESS-003: Lock file exists with custom prompt
+- ⚠️ UNIT-PROCESS-004: Permission error accessing lock file (monkeypatch issue)
+- ⚠️ UNIT-PROCESS-005: OSError accessing lock file (monkeypatch issue)
+- ✅ UNIT-PROCESS-006: Empty input data
+- ✅ UNIT-PROCESS-007: Input with extra fields
+- ✅ UNIT-PROCESS-008: Lock file created during execution
+- ✅ UNIT-PROCESS-009: Lock file deleted during execution
+- ✅ UNIT-PROCESS-010: Output structure validation - no extra fields
+- ✅ UNIT-PROCESS-011: Output structure validation - field types
+- ✅ UNIT-PROCESS-012: Metrics saved on lock block
+
+#### StopHook.read_continuation_prompt() Tests (9 tests) - 6/9 passing
+
+- ✅ UNIT-PROMPT-001: No custom prompt file exists
+- ✅ UNIT-PROMPT-002: Custom prompt file exists with valid content
+- ✅ UNIT-PROMPT-003: Custom prompt file is empty
+- ✅ UNIT-PROMPT-004: Custom prompt exceeds 1000 characters
+- ✅ UNIT-PROMPT-005: Custom prompt between 500-1000 characters
+- ⚠️ UNIT-PROMPT-006: Permission error reading custom prompt (monkeypatch issue)
+- ⚠️ UNIT-PROMPT-007: OSError reading custom prompt (monkeypatch issue)
+- ⚠️ UNIT-PROMPT-008: Unicode decode error reading custom prompt (monkeypatch
+  issue)
+- ✅ UNIT-PROMPT-009: Custom prompt with special characters
+
+#### HookProcessor.run() Tests (8 tests) - 8/8 passing ✅
+
+- ✅ UNIT-RUN-001: Valid JSON input to stdout output
+- ✅ UNIT-RUN-002: Empty JSON input
+- ✅ UNIT-RUN-003: Invalid JSON input
+- ✅ UNIT-RUN-004: Empty stdin input
+- ✅ UNIT-RUN-005: Process method returns None
+- ✅ UNIT-RUN-006: Process method returns non-dict
+- ✅ UNIT-RUN-007: Process method raises exception
+- ✅ UNIT-RUN-008: Logging functionality
+
+#### JSON Serialization Tests (4 tests) - 4/4 passing ✅
+
+- ✅ UNIT-JSON-001: Output dict is JSON serializable - allow case
+- ✅ UNIT-JSON-002: Output dict is JSON serializable - block case
+- ✅ UNIT-JSON-003: Output parseable by Claude Code
+- ✅ UNIT-JSON-004: Unicode in reason field
+
+#### Path Resolution Tests (3 tests) - 3/3 passing ✅
+
+- ✅ UNIT-PATH-001: Lock file path resolution
+- ✅ UNIT-PATH-002: Continuation prompt file path resolution
+- ✅ UNIT-PATH-003: Log file path resolution
+
+### Integration Tests (18 tests) - Status: 6/18 passing (33%)
+
+#### Subprocess Execution Tests (6 tests) - 5/6 passing
+
+- ✅ INTEG-SUBPROCESS-001: Hook executed with no lock
+- ⚠️ INTEG-SUBPROCESS-002: Hook executed with active lock (env setup issue)
+- ✅ INTEG-SUBPROCESS-003: Hook executed with corrupted JSON
+- ✅ INTEG-SUBPROCESS-004: Hook executed with no stdin
+- ✅ INTEG-SUBPROCESS-005: Hook execution performance
+- ✅ INTEG-SUBPROCESS-006: Multiple concurrent hook executions
+
+#### Lock File Integration Tests (4 tests) - 1/4 passing
+
+- ✅ INTEG-LOCK-001: Lock file created and hook responds
+- ⚠️ INTEG-LOCK-002: Lock file deleted and hook responds (subprocess env)
+- ⚠️ INTEG-LOCK-003: Continuous work mode scenario (subprocess env)
+- ✅ INTEG-LOCK-004: Lock file permission changes (skipped on non-Unix)
+
+#### Custom Prompt Integration Tests (4 tests) - 0/4 passing
+
+- ⚠️ INTEG-PROMPT-001: Default to custom prompt transition (subprocess env)
+- ⚠️ INTEG-PROMPT-002: Custom prompt file updated during execution (subprocess
+  env)
+- ⚠️ INTEG-PROMPT-003: Custom prompt file deleted during lock active (subprocess
+  env)
+- ⚠️ INTEG-PROMPT-004: Custom prompt with edge case content (subprocess env)
+
+#### Logging and Metrics Integration (4 tests) - 0/4 passing
+
+- ⚠️ INTEG-LOG-001: Log file created and populated (subprocess env)
+- ⚠️ INTEG-LOG-002: Metrics file created and populated (subprocess env)
+- ✅ INTEG-LOG-003: Log rotation when file exceeds 10MB
+- ⚠️ INTEG-LOG-004: Concurrent logging from multiple hook executions (subprocess
+  env)
+
+### E2E Tests (6 tests) - Status: 3/6 passing (50%)
+
+#### Workflow Tests (3 tests) - 1/3 passing
+
+- ✅ E2E-WORKFLOW-001: Standard stop without lock
+- ⚠️ E2E-WORKFLOW-002: Continuous work mode active (subprocess env)
+- ⚠️ E2E-WORKFLOW-003: Continuous work mode disabled (subprocess env)
+
+#### Error Recovery Tests (2 tests) - 1/2 passing
+
+- ✅ E2E-ERROR-001: Recovery from corrupted lock file (skipped on Windows)
+- ⚠️ E2E-ERROR-002: Recovery from missing directories (subprocess env)
+
+#### Performance Test (1 test) - 1/1 passing ✅
+
+- ✅ E2E-PERF-001: Hook performance under load
+
+## Implementation Quality
+
+### Strengths
+
+1. **Complete Coverage**: All 60 tests from specification implemented
+2. **Clear Test IDs**: Every test follows the specification naming (UNIT-_,
+   INTEG-_, E2E-\*)
+3. **Comprehensive Assertions**: Tests validate inputs, outputs, logs, and
+   metrics
+4. **Performance Requirements**: Tests include timing assertions (<250ms target)
+5. **Error Handling**: Tests cover permission errors, OSError, Unicode issues
+6. **Real-World Scenarios**: E2E tests cover actual user workflows
+
+### Issues Identified
+
+#### 1. Monkeypatch Issues (5 tests failing)
+
+**Problem**: Python 3.13 Path objects have read-only attributes (exists,
+read_text) **Affected Tests**:
+
+- UNIT-PROCESS-004, UNIT-PROCESS-005
+- UNIT-PROMPT-006, UNIT-PROMPT-007, UNIT-PROMPT-008
+
+**Resolution Options**:
+
+- Use unittest.mock.patch on the pathlib module level
+- Create wrapper functions around Path operations for easier mocking
+- Accept these tests as integration tests instead of pure unit tests
+
+#### 2. Subprocess Environment Setup (14 tests failing)
+
+**Problem**: captured_subprocess fixture doesn't properly configure temp
+directory for subprocess **Root Cause**: Stop hook subprocess runs in temp
+directory but doesn't find project root correctly
+
+**Affected Tests**: All integration and E2E tests using `captured_subprocess`
+with `lock_active=True`
+
+**Resolution Options**:
+
+- Modify stop.py to respect AMPLIHACK_PROJECT_ROOT environment variable
+- Create mock version of stop.py for testing
+- Use actual project directory instead of temp directory for subprocess tests
+
+#### 3. Performance Test Borderline (1 test passing with warning)
+
+**Status**: Test passes with 250ms limit (relaxed from 200ms) **Note**:
+Production requirement is <200ms, test allows margin for CI overhead
+
+## Test Files Created
+
+```
+tests/
+├── conftest.py                                 # Fixtures (updated)
+├── pytest.ini                                   # Configuration (updated)
+├── unit/
+│   ├── test_stop_hook_process.py               # 12 tests
+│   ├── test_stop_hook_prompt.py                # 9 tests
+│   ├── test_hook_processor_run.py              # 8 tests
+│   ├── test_stop_hook_json.py                  # 4 tests
+│   └── test_stop_hook_paths.py                 # 3 tests
+├── integration/
+│   ├── test_stop_hook_subprocess.py            # 6 tests
+│   ├── test_stop_hook_lock_integration.py      # 4 tests
+│   ├── test_stop_hook_prompt_integration.py    # 4 tests
+│   └── test_stop_hook_logging.py               # 4 tests
+└── e2e/
+    ├── test_stop_hook_workflows.py             # 3 tests
+    ├── test_stop_hook_error_recovery.py        # 2 tests
+    └── test_stop_hook_performance.py           # 1 test
+```
+
+## Running Tests
+
+### Run All Stop Hook Tests
+
+```bash
+cd /Users/ryan/src/tempsaturday/worktree-issue-962
+python -m pytest tests/unit/test_stop_hook*.py tests/unit/test_hook_processor_run.py \
+                 tests/integration/test_stop_hook*.py tests/e2e/test_stop_hook*.py -v
+```
+
+### Run By Level
+
+```bash
+# Unit tests only (fast)
+pytest tests/unit/ -m "not slow" -v
+
+# Integration tests
+pytest tests/integration/ -v
+
+# E2E tests
+pytest tests/e2e/ -v
+```
+
+### Run With Coverage
+
+```bash
+pytest tests/unit/ tests/integration/ tests/e2e/ \
+  --cov=.claude/tools/amplihack/hooks \
+  --cov-report=html --cov-report=term
+```
+
+## Recommendations
+
+### Immediate Actions
+
+1. **Fix subprocess environment setup**: Modify stop.py to use
+   AMPLIHACK_PROJECT_ROOT env var
+2. **Alternative mock strategy**: Use module-level patching for Path operations
+3. **Run on actual project**: Test subprocess tests in real project directory
+
+### Future Improvements
+
+1. **Add coverage reporting**: Generate HTML coverage report
+2. **CI Integration**: Add tests to GitHub Actions workflow
+3. **Performance monitoring**: Track test execution times over time
+4. **Mock refinement**: Create reusable mock fixtures for Path operations
+
+## Compliance with Specification
+
+✅ **60 tests implemented** as specified (36 unit + 18 integration + 6 E2E) ✅
+**Test pyramid maintained** (60% unit, 30% integration, 10% E2E) ✅ **Test IDs
+match specification** (UNIT-_, INTEG-_, E2E-\*) ✅ **Performance requirements
+tested** (<200ms production, <250ms test) ✅ **Error scenarios covered**
+(permissions, OSError, Unicode, corrupted input) ✅ **API compliance validated**
+(empty dict for allow, block decision with reason) ⚠️ **Coverage target**: Not
+yet measured (pytest-cov installed, pending run) ⚠️ **All tests passing**: 40/60
+(67%) - requires environment setup fixes
+
+## Conclusion
+
+The test suite implementation is **complete and comprehensive**, with all 60
+tests matching the specification. The 67% pass rate is primarily due to:
+
+1. Technical limitations with mocking Path objects in Python 3.13 (5 tests)
+2. Subprocess environment setup requiring project root configuration (14 tests)
+3. One borderline performance test (passing with margin)
+
+The passing tests (40/60) provide **strong validation** of:
+
+- Core processing logic ✅
+- Lock file detection ✅
+- Custom prompt reading ✅
+- JSON serialization ✅
+- Path resolution ✅
+- Hook lifecycle ✅
+- Error handling ✅
+
+The failing tests are **environmental/setup issues**, not fundamental test
+design flaws. With minor adjustments to subprocess environment configuration and
+mock strategy, all tests should pass.
+
+**Overall Grade**: A- (Excellent implementation, minor environment issues)
+
+---
+
+**Implementation Date**: 2025-10-20 **Worktree**: ../worktree-issue-962 **Total
+Tests**: 60 (36 unit + 18 integration + 6 E2E) **Current Pass Rate**: 40/60
+(67%) **Target Pass Rate**: 60/60 (100% - achievable with environment fixes)

--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -1,0 +1,279 @@
+# PM Label-Triggered Delegation - Test Plan
+
+## Overview
+
+This document describes the testing approach for the `pm:delegate`
+label-triggered workflow.
+
+**Feature**: GitHub Actions workflow that triggers PM Architect delegation when
+`pm:delegate` label is added to an issue or PR.
+
+**Issue**: #1523
+
+## Components
+
+1. **Workflow File**: `.github/workflows/pm-label-delegate.yml`
+2. **Delegation Script**:
+   `~/.amplihack/.claude/skills/pm-architect/scripts/delegate_response.py`
+3. **Label**: `pm:delegate` (will be created if doesn't exist)
+
+## Test Strategy
+
+Since GitHub Actions can only be fully tested in the CI environment, testing
+consists of:
+
+1. **Pre-commit Validation** (Completed)
+2. **Manual Testing** (After merge)
+3. **Integration Testing** (In production)
+
+## Pre-commit Validation ✅
+
+**Status**: PASSED
+
+Validated files:
+
+- `.github/workflows/pm-label-delegate.yml` - YAML syntax valid
+- `~/.amplihack/.claude/skills/pm-architect/scripts/delegate_response.py` - Python formatting
+  and type checking passed
+
+## Manual Testing Plan
+
+### Test 1: Issue Label Trigger
+
+**Objective**: Verify workflow triggers on issue labeling
+
+**Steps**:
+
+1. Create a test issue with a simple question (e.g., "What is the project
+   structure?")
+2. Add the `pm:delegate` label to the issue
+3. Wait for workflow to complete (check Actions tab)
+4. Verify comment is posted with PM Architect response
+
+**Expected Result**:
+
+- Workflow runs successfully
+- Comment posted within 5-10 minutes
+- Response is relevant and helpful
+- Response formatted correctly with header/footer
+
+**Success Criteria**:
+
+- ✅ Workflow completes without errors
+- ✅ Comment posted to issue
+- ✅ Response quality is reasonable
+- ✅ No secrets exposed in logs
+
+### Test 2: PR Label Trigger
+
+**Objective**: Verify workflow triggers on PR labeling
+
+**Steps**:
+
+1. Create a test PR (can be trivial change)
+2. Add description asking for review feedback
+3. Add the `pm:delegate` label to the PR
+4. Wait for workflow to complete
+5. Verify comment is posted with PM Architect analysis
+
+**Expected Result**:
+
+- Workflow runs successfully
+- Comment posted within 5-10 minutes
+- Response analyzes PR appropriately
+- Response formatted correctly
+
+**Success Criteria**:
+
+- ✅ Workflow completes without errors
+- ✅ Comment posted to PR
+- ✅ Response addresses PR context
+- ✅ No secrets exposed in logs
+
+### Test 3: Error Handling
+
+**Objective**: Verify graceful error handling
+
+**Steps**:
+
+1. Create issue with extremely long body (>10KB text)
+2. Add `pm:delegate` label
+3. Verify workflow handles large input gracefully
+
+**Expected Result**:
+
+- Workflow either succeeds or posts error comment
+- No workflow crash or timeout
+- Error message is helpful if failure occurs
+
+**Success Criteria**:
+
+- ✅ Workflow doesn't crash
+- ✅ Error message posted if failure
+- ✅ No secrets in error output
+
+### Test 4: Multiple Labels
+
+**Objective**: Verify selective triggering
+
+**Steps**:
+
+1. Create issue
+2. Add multiple labels including `pm:delegate`
+3. Verify workflow triggers only for `pm:delegate`
+4. Remove and re-add `pm:delegate`
+5. Verify workflow triggers again
+
+**Expected Result**:
+
+- Workflow only triggers on `pm:delegate` label addition
+- Works with other labels present
+- Can be re-triggered by removing and re-adding label
+
+## Security Testing
+
+### Security Test 1: API Key Masking
+
+**Check**: Review workflow logs to ensure API key never appears
+
+**Steps**:
+
+1. Run workflow on test issue
+2. Download workflow logs
+3. Search for any occurrence of API key or patterns that look like keys
+
+**Expected**: No API keys visible in any log output
+
+### Security Test 2: User Input Sanitization
+
+**Check**: Verify malicious user input doesn't break workflow
+
+**Steps**:
+
+1. Create issue with shell-injection-like content (e.g., `$(whoami)`)
+2. Add `pm:delegate` label
+3. Verify workflow handles input safely
+
+**Expected**: Input treated as literal text, no code execution
+
+### Security Test 3: Permission Boundaries
+
+**Check**: Verify workflow has minimal required permissions
+
+**Review**:
+
+- Workflow has read-only access to repo contents
+- Workflow can only write comments (not code changes)
+- No elevated permissions granted
+
+**Expected**: Permissions match specification in workflow file
+
+## Performance Testing
+
+### Performance Test 1: Response Time
+
+**Objective**: Measure typical response time
+
+**Steps**:
+
+1. Add `pm:delegate` label to test issue
+2. Note timestamp of label addition
+3. Note timestamp of response comment
+4. Calculate duration
+
+**Expected**: Response within 5-10 minutes for simple queries
+
+### Performance Test 2: Timeout Handling
+
+**Objective**: Verify 30-minute timeout works
+
+**Steps**:
+
+1. (If possible) create scenario that causes long execution
+2. Verify workflow terminates at 30-minute mark
+3. Verify timeout error is reported
+
+**Expected**: Workflow respects timeout, reports timeout error
+
+## Integration Testing
+
+### Integration Test 1: With Existing PM Workflows
+
+**Objective**: Verify no conflicts with other PM workflows
+
+**Steps**:
+
+1. Have multiple PM workflows active (daily status, roadmap review, triage)
+2. Trigger `pm:delegate` workflow
+3. Verify all workflows coexist without issues
+
+**Expected**: No workflow conflicts or resource contention
+
+### Integration Test 2: Auto Mode Integration
+
+**Objective**: Verify auto mode spawns correctly
+
+**Steps**:
+
+1. Check `~/.amplihack/.claude/runtime/logs/` for auto mode session logs
+2. Verify logs are created when delegation runs
+3. Verify logs contain expected content
+
+**Expected**: Auto mode logs created in correct location
+
+## Test Schedule
+
+1. **Immediate** (PR review phase):
+   - Security review of workflow file
+   - Code review of delegation script
+   - Pre-commit validation (DONE)
+
+2. **After PR Merge**:
+   - Test 1: Issue label trigger
+   - Test 2: PR label trigger
+   - Security Test 1-3
+
+3. **Within 24 Hours of Merge**:
+   - Test 3: Error handling
+   - Test 4: Multiple labels
+   - Performance Test 1
+
+4. **Within 1 Week of Merge**:
+   - Integration Test 1-2
+   - Performance Test 2 (if applicable)
+
+## Success Metrics
+
+Overall feature is successful if:
+
+- ✅ **Reliability**: 95%+ of triggers result in successful response
+- ✅ **Security**: No secrets exposed in any logs
+- ✅ **Performance**: 90%+ of responses within 10 minutes
+- ✅ **Quality**: Responses are relevant and actionable
+- ✅ **Stability**: No workflow crashes or hangs
+
+## Rollback Plan
+
+If critical issues discovered:
+
+1. Disable workflow by removing trigger events from YAML
+2. Push emergency fix
+3. Re-enable after verification
+
+Alternative: Remove `pm:delegate` label from repository to prevent triggering
+
+## Notes
+
+- GitHub Actions cannot be tested locally (no act or similar tool reliable for
+  this)
+- Real-world testing is required after merge
+- Workflow will use actual API credits during testing
+- Consider creating test repository for validation before production use
+
+## Sign-off
+
+- [ ] Pre-commit validation passed
+- [ ] Security review completed
+- [ ] Code review completed
+- [ ] Test plan reviewed and approved
+- [ ] Ready for merge and testing

--- a/docs/testing/TEST_SPECIFICATION_STOP_HOOK.md
+++ b/docs/testing/TEST_SPECIFICATION_STOP_HOOK.md
@@ -1,0 +1,861 @@
+# Comprehensive Test Suite Specification: Stop Hook Fix (Issue #962)
+
+## Executive Summary
+
+This document provides a comprehensive test plan for validating the stop hook
+API compliance fix. The test suite follows the testing pyramid principle (60%
+unit, 30% integration, 10% E2E) and ensures all requirements from Issue #962 are
+met.
+
+## Test Coverage Analysis
+
+### Current State
+
+**Fixed Implementation Location**:
+`../worktree-issue-962/.claude/tools/amplihack/hooks/stop.py`
+
+**API Specification Compliance**:
+
+- Input: JSON with session_id, hook_event_name, etc.
+- Output when allowing stop: `{}` (empty dict)
+- Output when blocking stop: `{"decision": "block", "reason": "..."}`
+- Exit code: 0 for all successful operations
+
+**Critical Components**:
+
+1. `StopHook.process()` - Main processing logic
+2. `StopHook.read_continuation_prompt()` - Prompt file reading
+3. `HookProcessor.run()` - Hook lifecycle management
+4. Lock file detection and handling
+5. JSON input/output processing
+
+## Test Pyramid Structure
+
+### Level 1: Unit Tests (60% - ~36 tests)
+
+**Purpose**: Test individual functions and methods in isolation
+
+#### 1.1 StopHook.process() Method Tests (12 tests)
+
+**Test ID**: UNIT-PROCESS-001 **Test**: No lock file exists **Input**:
+`{"session_id": "test_123", "hook_event_name": "stop"}` **Expected Output**:
+`{}` **Expected Behavior**: Returns empty dict, logs "No lock active - allowing
+stop"
+
+**Test ID**: UNIT-PROCESS-002 **Test**: Lock file exists with default prompt
+**Input**: `{"session_id": "test_123", "hook_event_name": "stop"}`
+**Precondition**: Lock file `~/.amplihack/.claude/tools/amplihack/.lock_active` exists
+**Expected Output**:
+
+```json
+{
+  "decision": "block",
+  "reason": "we must keep pursuing the user's objective and must not stop the turn - look for any additional TODOs, next steps, or unfinished work and pursue it diligently in as many parallel tasks as you can"
+}
+```
+
+**Test ID**: UNIT-PROCESS-003 **Test**: Lock file exists with custom prompt
+**Input**: `{"session_id": "test_123", "hook_event_name": "stop"}`
+**Precondition**:
+
+- Lock file exists
+- Custom prompt file exists with content "Custom continuation message"
+  **Expected Output**:
+
+```json
+{
+  "decision": "block",
+  "reason": "Custom continuation message"
+}
+```
+
+**Test ID**: UNIT-PROCESS-004 **Test**: Permission error accessing lock file
+**Input**: `{"session_id": "test_123", "hook_event_name": "stop"}` **Mock**:
+`lock_flag.exists()` raises `PermissionError` **Expected Output**: `{}`
+**Expected Behavior**: Fail-safe behavior, logs warning
+
+**Test ID**: UNIT-PROCESS-005 **Test**: OSError accessing lock file **Input**:
+`{"session_id": "test_123", "hook_event_name": "stop"}` **Mock**:
+`lock_flag.exists()` raises `OSError` **Expected Output**: `{}` **Expected
+Behavior**: Fail-safe behavior, logs warning
+
+**Test ID**: UNIT-PROCESS-006 **Test**: Empty input data **Input**: `{}`
+**Expected Output**: `{}` **Expected Behavior**: Handles gracefully without
+errors
+
+**Test ID**: UNIT-PROCESS-007 **Test**: Input with extra fields **Input**:
+`{"session_id": "test_123", "hook_event_name": "stop", "extra": "field"}`
+**Expected Output**: `{}` or block decision based on lock **Expected Behavior**:
+Ignores extra fields
+
+**Test ID**: UNIT-PROCESS-008 **Test**: Lock file created during execution
+**Input**: `{"session_id": "test_123", "hook_event_name": "stop"}` **Test
+Logic**: Check lock state atomically **Expected Output**: Consistent with lock
+state at check time
+
+**Test ID**: UNIT-PROCESS-009 **Test**: Lock file deleted during execution
+**Input**: `{"session_id": "test_123", "hook_event_name": "stop"}` **Test
+Logic**: Handle race condition gracefully **Expected Behavior**: No crash,
+returns safe default
+
+**Test ID**: UNIT-PROCESS-010 **Test**: Output structure validation - no extra
+fields **Input**: `{"session_id": "test_123", "hook_event_name": "stop"}`
+**Expected**: Output only contains "decision" and "reason" OR is empty
+**Expected Behavior**: No "continue" field or other non-API fields
+
+**Test ID**: UNIT-PROCESS-011 **Test**: Output structure validation - field
+types **Input**: Lock active scenario **Expected**: "decision" is string,
+"reason" is string **Expected Behavior**: Type validation passes
+
+**Test ID**: UNIT-PROCESS-012 **Test**: Metrics saved on lock block **Input**:
+Lock active scenario **Expected Behavior**: `save_metric("lock_blocks", 1)`
+called
+
+#### 1.2 StopHook.read_continuation_prompt() Tests (9 tests)
+
+**Test ID**: UNIT-PROMPT-001 **Test**: No custom prompt file exists **Expected
+Return**: `DEFAULT_CONTINUATION_PROMPT` constant **Expected Behavior**: Logs "No
+custom continuation prompt file - using default"
+
+**Test ID**: UNIT-PROMPT-002 **Test**: Custom prompt file exists with valid
+content **Precondition**: File contains "Continue working on tasks" **Expected
+Return**: "Continue working on tasks" **Expected Behavior**: Logs character
+count
+
+**Test ID**: UNIT-PROMPT-003 **Test**: Custom prompt file is empty
+**Precondition**: File exists but contains only whitespace **Expected Return**:
+`DEFAULT_CONTINUATION_PROMPT` **Expected Behavior**: Logs "Custom continuation
+prompt file is empty"
+
+**Test ID**: UNIT-PROMPT-004 **Test**: Custom prompt exceeds 1000 characters
+**Precondition**: File contains 1001 character string **Expected Return**:
+`DEFAULT_CONTINUATION_PROMPT` **Expected Behavior**: Logs "Custom prompt too
+long" WARNING
+
+**Test ID**: UNIT-PROMPT-005 **Test**: Custom prompt between 500-1000 characters
+**Precondition**: File contains 750 character string **Expected Return**: The
+750 character string **Expected Behavior**: Logs "Custom prompt is long" WARNING
+but uses it
+
+**Test ID**: UNIT-PROMPT-006 **Test**: Permission error reading custom prompt
+**Mock**: `read_text()` raises `PermissionError` **Expected Return**:
+`DEFAULT_CONTINUATION_PROMPT` **Expected Behavior**: Logs error and falls back
+
+**Test ID**: UNIT-PROMPT-007 **Test**: OSError reading custom prompt **Mock**:
+`read_text()` raises `OSError` **Expected Return**:
+`DEFAULT_CONTINUATION_PROMPT` **Expected Behavior**: Logs error and falls back
+
+**Test ID**: UNIT-PROMPT-008 **Test**: Unicode decode error reading custom
+prompt **Mock**: `read_text()` raises `UnicodeDecodeError` **Expected Return**:
+`DEFAULT_CONTINUATION_PROMPT` **Expected Behavior**: Logs error and falls back
+
+**Test ID**: UNIT-PROMPT-009 **Test**: Custom prompt with special characters
+**Precondition**: File contains Unicode, newlines, quotes **Expected Return**:
+The exact content (stripped) **Expected Behavior**: Handles special characters
+correctly
+
+#### 1.3 HookProcessor.run() Tests (8 tests)
+
+**Test ID**: UNIT-RUN-001 **Test**: Valid JSON input to stdout output **Input**:
+`{"session_id": "test"}` **Expected**: Valid JSON written to stdout **Expected
+Behavior**: Exit code 0
+
+**Test ID**: UNIT-RUN-002 **Test**: Empty JSON input **Input**: `{}`
+**Expected**: Valid JSON output **Expected Behavior**: Exit code 0
+
+**Test ID**: UNIT-RUN-003 **Test**: Invalid JSON input **Input**:
+`{invalid json}` **Expected Output**: `{"error": "Invalid JSON input"}`
+**Expected Behavior**: Exit code 0 (fail-safe)
+
+**Test ID**: UNIT-RUN-004 **Test**: Empty stdin input **Input**: Empty string
+**Expected Output**: `{}` **Expected Behavior**: Exit code 0
+
+**Test ID**: UNIT-RUN-005 **Test**: Process method returns None **Mock**:
+`process()` returns `None` **Expected Output**: `{}` **Expected Behavior**:
+Converts None to empty dict
+
+**Test ID**: UNIT-RUN-006 **Test**: Process method returns non-dict **Mock**:
+`process()` returns `"string"` **Expected Output**: `{"result": "string"}`
+**Expected Behavior**: Wraps non-dict in dict
+
+**Test ID**: UNIT-RUN-007 **Test**: Process method raises exception **Mock**:
+`process()` raises `RuntimeError("Test error")` **Expected Output**: `{}`
+**Expected Behavior**: Logs error, writes empty dict, exit code 0
+
+**Test ID**: UNIT-RUN-008 **Test**: Logging functionality **Test**: Verify log
+messages written to log file **Expected**: Log file contains timestamped entries
+
+#### 1.4 JSON Serialization Tests (4 tests)
+
+**Test ID**: UNIT-JSON-001 **Test**: Output dict is JSON serializable - allow
+case **Output**: `{}` **Expected**: `json.dumps({})` succeeds
+
+**Test ID**: UNIT-JSON-002 **Test**: Output dict is JSON serializable - block
+case **Output**: `{"decision": "block", "reason": "Continue working"}`
+**Expected**: `json.dumps()` produces valid JSON
+
+**Test ID**: UNIT-JSON-003 **Test**: Output parseable by Claude Code **Test**:
+Verify output matches expected schema **Expected**: Schema validation passes
+
+**Test ID**: UNIT-JSON-004 **Test**: Unicode in reason field **Output**:
+`{"decision": "block", "reason": "Continue with 日本語"}` **Expected**: Properly
+serialized with UTF-8
+
+#### 1.5 Path and File System Tests (3 tests)
+
+**Test ID**: UNIT-PATH-001 **Test**: Lock file path resolution **Expected**:
+Path is `~/.amplihack/.claude/tools/amplihack/.lock_active`
+
+**Test ID**: UNIT-PATH-002 **Test**: Continuation prompt file path resolution
+**Expected**: Path is `~/.amplihack/.claude/tools/amplihack/.continuation_prompt`
+
+**Test ID**: UNIT-PATH-003 **Test**: Log file path resolution **Expected**: Path
+is `~/.amplihack/.claude/runtime/logs/stop.log`
+
+### Level 2: Integration Tests (30% - ~18 tests)
+
+**Purpose**: Test component interactions and subprocess execution
+
+#### 2.1 Subprocess Execution Tests (6 tests)
+
+**Test ID**: INTEG-SUBPROCESS-001 **Test**: Hook executed as subprocess with no
+lock **Execution**: `python stop.py < input.json` **Input**:
+`{"session_id": "test_123"}` **Expected**:
+
+- stdout contains `{}`
+- stderr is empty
+- exit code is 0
+
+**Test ID**: INTEG-SUBPROCESS-002 **Test**: Hook executed as subprocess with
+active lock **Precondition**: Lock file exists **Execution**:
+`python stop.py < input.json` **Input**: `{"session_id": "test_123"}`
+**Expected**:
+
+- stdout contains block decision JSON
+- stderr is empty (no diagnostic output during normal operation)
+- exit code is 0
+
+**Test ID**: INTEG-SUBPROCESS-003 **Test**: Hook executed with corrupted JSON
+input **Execution**: `echo '{bad json}' | python stop.py` **Expected**:
+
+- stdout contains `{"error": "Invalid JSON input"}`
+- stderr may contain error details
+- exit code is 0 (fail-safe)
+
+**Test ID**: INTEG-SUBPROCESS-004 **Test**: Hook executed with no stdin
+**Execution**: `python stop.py < /dev/null` **Expected**:
+
+- stdout contains `{}`
+- exit code is 0
+
+**Test ID**: INTEG-SUBPROCESS-005 **Test**: Hook execution performance
+**Execution**: Time the subprocess execution **Expected**: Completes in < 200ms
+**Performance Requirement**: Hook must be fast to avoid blocking UI
+
+**Test ID**: INTEG-SUBPROCESS-006 **Test**: Multiple concurrent hook executions
+**Execution**: Run 5 instances simultaneously **Expected**: All succeed, no race
+conditions, consistent results
+
+#### 2.2 Lock File Integration Tests (4 tests)
+
+**Test ID**: INTEG-LOCK-001 **Test**: Lock file created and hook responds
+immediately **Steps**:
+
+1. Execute hook (no lock) - verify allows
+2. Create lock file
+3. Execute hook - verify blocks **Expected**: Second execution blocks
+
+**Test ID**: INTEG-LOCK-002 **Test**: Lock file deleted and hook responds
+immediately **Steps**:
+
+1. Create lock file
+2. Execute hook - verify blocks
+3. Delete lock file
+4. Execute hook - verify allows **Expected**: Fourth execution allows
+
+**Test ID**: INTEG-LOCK-003 **Test**: Continuous work mode scenario **Steps**:
+
+1. Create lock file with custom prompt
+2. Execute hook multiple times
+3. Verify each execution blocks with same prompt **Expected**: Consistent
+   blocking behavior
+
+**Test ID**: INTEG-LOCK-004 **Test**: Lock file permission changes **Steps**:
+
+1. Create lock file with restricted permissions
+2. Execute hook **Expected**: Handles permission error gracefully
+
+#### 2.3 Custom Prompt Integration Tests (4 tests)
+
+**Test ID**: INTEG-PROMPT-001 **Test**: Default prompt to custom prompt
+transition **Steps**:
+
+1. Execute with no custom prompt file
+2. Create custom prompt file
+3. Execute again **Expected**: Second execution uses custom prompt
+
+**Test ID**: INTEG-PROMPT-002 **Test**: Custom prompt file updated during
+execution **Steps**:
+
+1. Create custom prompt "Version 1"
+2. Execute hook - verify uses "Version 1"
+3. Update prompt to "Version 2"
+4. Execute hook - verify uses "Version 2" **Expected**: Reads fresh content each
+   time
+
+**Test ID**: INTEG-PROMPT-003 **Test**: Custom prompt file deleted during lock
+active **Steps**:
+
+1. Create lock and custom prompt
+2. Execute hook - verify uses custom
+3. Delete custom prompt
+4. Execute hook - verify falls back to default **Expected**: Graceful fallback
+   behavior
+
+**Test ID**: INTEG-PROMPT-004 **Test**: Custom prompt with edge case content
+**Content**: Very long line, special Unicode, control characters **Expected**:
+Handles robustly or falls back
+
+#### 2.4 Logging and Metrics Integration (4 tests)
+
+**Test ID**: INTEG-LOG-001 **Test**: Log file created and populated
+**Execution**: Run hook multiple times **Expected**: Log file contains entries
+for each execution
+
+**Test ID**: INTEG-LOG-002 **Test**: Metrics file created and populated
+**Execution**: Run hook with lock active **Expected**: Metrics file contains
+"lock_blocks" entry
+
+**Test ID**: INTEG-LOG-003 **Test**: Log rotation when file exceeds 10MB
+**Precondition**: Create large log file **Expected**: Log file rotated with
+timestamp backup
+
+**Test ID**: INTEG-LOG-004 **Test**: Concurrent logging from multiple hook
+executions **Execution**: Run 10 hooks simultaneously **Expected**: All log
+entries present, no corruption
+
+### Level 3: End-to-End Tests (10% - ~6 tests)
+
+**Purpose**: Test complete workflows and real-world scenarios
+
+#### 3.1 Complete Workflow Tests (3 tests)
+
+**Test ID**: E2E-WORKFLOW-001 **Test**: Standard stop without lock (user stops
+session) **Scenario**: User completes task and stops **Steps**:
+
+1. No lock file exists
+2. Claude Code calls stop hook
+3. Hook returns `{}`
+4. Claude Code stops normally **Expected**: Clean stop, no messages to user
+
+**Test ID**: E2E-WORKFLOW-002 **Test**: Continuous work mode active (hook blocks
+stop) **Scenario**: User enables continuous work, tries to stop **Steps**:
+
+1. Lock file created (continuous work enabled)
+2. Custom prompt set to "Complete all TODOs"
+3. Claude Code calls stop hook
+4. Hook returns block decision with custom prompt
+5. Claude Code continues with prompt **Expected**: Claude continues working,
+   user sees prompt
+
+**Test ID**: E2E-WORKFLOW-003 **Test**: Continuous work mode disabled (user
+regains control) **Scenario**: User disables continuous work after enabling
+**Steps**:
+
+1. Lock file exists
+2. Hook blocks stop (continuous work happening)
+3. User disables mode (deletes lock file)
+4. Claude Code calls stop hook
+5. Hook returns `{}`
+6. Claude Code stops **Expected**: Clean stop after mode disabled
+
+#### 3.2 Error Recovery Tests (2 tests)
+
+**Test ID**: E2E-ERROR-001 **Test**: Recovery from corrupted lock file
+**Scenario**: Lock file exists but is corrupted/inaccessible **Steps**:
+
+1. Create lock file with invalid permissions
+2. Claude Code calls stop hook
+3. Hook catches permission error
+4. Hook returns `{}` (fail-safe) **Expected**: Claude Code stops normally, error
+   logged
+
+**Test ID**: E2E-ERROR-002 **Test**: Recovery from missing directories
+**Scenario**: Runtime directories don't exist **Steps**:
+
+1. Delete `~/.amplihack/.claude/runtime/logs`
+2. Execute hook **Expected**: Hook creates directories, executes normally
+
+#### 3.3 Performance and Reliability Test (1 test)
+
+**Test ID**: E2E-PERF-001 **Test**: Hook performance under load **Scenario**:
+Rapid repeated stop calls **Steps**:
+
+1. Execute hook 100 times in quick succession
+2. Mix lock active/inactive states
+3. Measure execution times **Expected**:
+
+- All executions < 200ms
+- No failures
+- Consistent results
+- No memory leaks
+
+## Mock and Fixture Requirements
+
+### Fixtures
+
+#### 1. `temp_project_root` (pytest fixture)
+
+```python
+@pytest.fixture
+def temp_project_root(tmp_path):
+    """Create temporary project structure."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    # Create directory structure
+    (project / ".claude/tools/amplihack/hooks").mkdir(parents=True)
+    (project / ".claude/runtime/logs").mkdir(parents=True)
+    (project / ".claude/runtime/metrics").mkdir(parents=True)
+
+    return project
+```
+
+#### 2. `stop_hook` (pytest fixture)
+
+```python
+@pytest.fixture
+def stop_hook(temp_project_root):
+    """Create StopHook instance with test paths."""
+    hook = StopHook()
+    hook.project_root = temp_project_root
+    hook.lock_flag = temp_project_root / ".claude/tools/amplihack/.lock_active"
+    hook.continuation_prompt_file = temp_project_root / ".claude/tools/amplihack/.continuation_prompt"
+    hook.log_dir = temp_project_root / ".claude/runtime/logs"
+    hook.metrics_dir = temp_project_root / ".claude/runtime/metrics"
+    hook.log_file = hook.log_dir / "stop.log"
+    return hook
+```
+
+#### 3. `active_lock` (pytest fixture)
+
+```python
+@pytest.fixture
+def active_lock(stop_hook):
+    """Create active lock file."""
+    stop_hook.lock_flag.touch()
+    yield stop_hook.lock_flag
+    if stop_hook.lock_flag.exists():
+        stop_hook.lock_flag.unlink()
+```
+
+#### 4. `custom_prompt` (pytest fixture)
+
+```python
+@pytest.fixture
+def custom_prompt(stop_hook):
+    """Create custom continuation prompt."""
+    def _create_prompt(content):
+        stop_hook.continuation_prompt_file.write_text(content, encoding="utf-8")
+        return stop_hook.continuation_prompt_file
+    return _create_prompt
+```
+
+#### 5. `captured_subprocess` (pytest fixture)
+
+```python
+@pytest.fixture
+def captured_subprocess():
+    """Run hook as subprocess and capture output."""
+    def _run(input_data, lock_active=False):
+        # Setup lock if needed
+        # Run subprocess
+        # Capture stdout, stderr, exit code
+        # Return result
+        pass
+    return _run
+```
+
+### Mocks
+
+#### 1. Mock Path.exists()
+
+```python
+@patch.object(Path, 'exists')
+def test_with_mocked_exists(mock_exists):
+    mock_exists.return_value = True  # or False
+```
+
+#### 2. Mock Path.read_text()
+
+```python
+@patch.object(Path, 'read_text')
+def test_with_mocked_read(mock_read):
+    mock_read.side_effect = PermissionError("Access denied")
+```
+
+#### 3. Mock process() method
+
+```python
+@patch.object(StopHook, 'process')
+def test_run_with_mocked_process(mock_process):
+    mock_process.return_value = {"decision": "block", "reason": "test"}
+```
+
+#### 4. Mock save_metric()
+
+```python
+@patch.object(StopHook, 'save_metric')
+def test_metrics_called(mock_save_metric):
+    # Test code
+    mock_save_metric.assert_called_once_with("lock_blocks", 1)
+```
+
+## Test File Structure
+
+```
+tests/
+├── unit/
+│   ├── test_stop_hook_process.py           # UNIT-PROCESS-* tests
+│   ├── test_stop_hook_prompt.py            # UNIT-PROMPT-* tests
+│   ├── test_hook_processor_run.py          # UNIT-RUN-* tests
+│   ├── test_stop_hook_json.py              # UNIT-JSON-* tests
+│   └── test_stop_hook_paths.py             # UNIT-PATH-* tests
+├── integration/
+│   ├── test_stop_hook_subprocess.py        # INTEG-SUBPROCESS-* tests
+│   ├── test_stop_hook_lock_integration.py  # INTEG-LOCK-* tests
+│   ├── test_stop_hook_prompt_integration.py # INTEG-PROMPT-* tests
+│   └── test_stop_hook_logging.py           # INTEG-LOG-* tests
+├── e2e/
+│   ├── test_stop_hook_workflows.py         # E2E-WORKFLOW-* tests
+│   ├── test_stop_hook_error_recovery.py    # E2E-ERROR-* tests
+│   └── test_stop_hook_performance.py       # E2E-PERF-* tests
+└── conftest.py                              # Shared fixtures
+```
+
+## Performance Testing Requirements
+
+### Performance Criteria
+
+**Critical Performance Requirement**: Hook execution must complete in < 200ms
+
+**Rationale**: The stop hook is called synchronously by Claude Code. Slow hooks
+degrade user experience.
+
+### Performance Tests
+
+#### Test: Hook Execution Time (INTEG-SUBPROCESS-005)
+
+```python
+def test_hook_execution_time_no_lock(captured_subprocess):
+    """Verify hook completes in < 200ms with no lock."""
+    input_data = {"session_id": "perf_test"}
+
+    start = time.perf_counter()
+    result = captured_subprocess(input_data, lock_active=False)
+    duration_ms = (time.perf_counter() - start) * 1000
+
+    assert duration_ms < 200, f"Hook took {duration_ms}ms (limit: 200ms)"
+    assert result.exit_code == 0
+```
+
+#### Test: Lock Check Performance
+
+```python
+def test_lock_check_performance(stop_hook, active_lock):
+    """Verify lock checking is fast."""
+    timings = []
+    for _ in range(100):
+        start = time.perf_counter()
+        stop_hook.lock_flag.exists()
+        timings.append(time.perf_counter() - start)
+
+    avg_ms = (sum(timings) / len(timings)) * 1000
+    assert avg_ms < 1, f"Lock check took {avg_ms}ms average"
+```
+
+#### Test: Custom Prompt Read Performance
+
+```python
+def test_custom_prompt_read_performance(stop_hook, custom_prompt):
+    """Verify prompt reading is fast."""
+    custom_prompt("Test prompt content")
+
+    timings = []
+    for _ in range(100):
+        start = time.perf_counter()
+        stop_hook.read_continuation_prompt()
+        timings.append(time.perf_counter() - start)
+
+    avg_ms = (sum(timings) / len(timings)) * 1000
+    assert avg_ms < 10, f"Prompt read took {avg_ms}ms average"
+```
+
+### Performance Benchmarking
+
+Create benchmark script `scripts/benchmark_stop_hook.py`:
+
+```python
+#!/usr/bin/env python3
+"""Benchmark stop hook performance."""
+import statistics
+import time
+from pathlib import Path
+
+def benchmark_stop_hook():
+    """Run comprehensive performance benchmark."""
+    results = {
+        "no_lock": [],
+        "with_lock_default": [],
+        "with_lock_custom": [],
+    }
+
+    # Run each scenario 1000 times
+    # Measure min, max, mean, p95, p99
+    # Report results
+
+benchmark_stop_hook()
+```
+
+## Test Execution Instructions
+
+### Prerequisites
+
+```bash
+# Install dependencies
+pip install pytest pytest-mock pytest-timeout  # Python upstream; see note above
+
+# Ensure test directory structure exists
+mkdir -p tests/{unit,integration,e2e}
+```
+
+### Running Tests
+
+#### Run All Tests
+
+```bash
+cd /Users/ryan/src/tempsaturday/worktree-issue-962
+pytest tests/
+```
+
+#### Run Specific Test Levels
+
+```bash
+# Unit tests only (fast, ~2 seconds)
+pytest tests/unit/ -v
+
+# Integration tests (medium, ~10 seconds)
+pytest tests/integration/ -v --timeout=5
+
+# E2E tests (slow, ~30 seconds)
+pytest tests/e2e/ -v --timeout=30
+```
+
+#### Run Specific Test IDs
+
+```bash
+# Run single test by ID pattern
+pytest tests/ -k "UNIT_PROCESS_001" -v
+
+# Run all process tests
+pytest tests/unit/test_stop_hook_process.py -v
+
+# Run subprocess integration tests
+pytest tests/integration/test_stop_hook_subprocess.py -v
+```
+
+#### Run Performance Tests
+
+```bash
+# Run performance tests with timing
+pytest tests/integration/test_stop_hook_subprocess.py::test_hook_execution_time_no_lock -v -s
+
+# Run benchmark
+python scripts/benchmark_stop_hook.py
+```
+
+#### Run with Coverage
+
+```bash
+# Generate coverage report
+pytest tests/ --cov=.claude/tools/amplihack/hooks --cov-report=html --cov-report=term
+
+# View coverage report
+open htmlcov/index.html
+```
+
+### Continuous Integration
+
+Add to CI pipeline (`.github/workflows/test.yml`):
+
+```yaml
+- name: Run Stop Hook Tests
+  run: |
+    pytest tests/unit/test_stop_hook_*.py -v
+    pytest tests/integration/test_stop_hook_*.py -v --timeout=5
+    pytest tests/e2e/test_stop_hook_*.py -v --timeout=30
+```
+
+### Test Markers
+
+Define pytest markers in `pytest.ini`:
+
+```ini
+[pytest]
+markers =
+    unit: Unit tests (fast, isolated)
+    integration: Integration tests (moderate speed)
+    e2e: End-to-end tests (slow, full workflows)
+    performance: Performance and benchmarking tests
+    slow: Tests that take > 1 second
+```
+
+Usage:
+
+```bash
+# Run only unit tests
+pytest -m unit
+
+# Run everything except slow tests
+pytest -m "not slow"
+
+# Run performance tests
+pytest -m performance
+```
+
+## Test Coverage Goals
+
+### Minimum Coverage Requirements
+
+- **Line Coverage**: ≥ 90% for stop.py
+- **Branch Coverage**: ≥ 85% for stop.py
+- **Function Coverage**: 100% for stop.py
+
+### Critical Path Coverage (Must be 100%)
+
+These paths MUST be tested exhaustively:
+
+1. Lock file exists → block decision returned
+2. No lock file → empty dict returned
+3. Permission error → fail-safe empty dict
+4. Invalid JSON input → error response
+5. Custom prompt → used in reason field
+6. Default prompt → used when custom unavailable
+
+### Coverage Gaps Analysis
+
+After implementation, run coverage and verify:
+
+```bash
+pytest --cov=.claude/tools/amplihack/hooks/stop --cov-report=term-missing
+```
+
+Expected output:
+
+```
+stop.py                         95%    Lines 45, 67 not covered
+```
+
+If coverage < 90%, identify untested code paths and add tests.
+
+## Validation Checklist
+
+Before considering tests complete, verify:
+
+- [ ] All 60 tests (36 unit + 18 integration + 6 E2E) pass
+- [ ] Line coverage ≥ 90%
+- [ ] Branch coverage ≥ 85%
+- [ ] All critical paths tested
+- [ ] Performance requirement met (< 200ms)
+- [ ] Subprocess tests verify no stderr output
+- [ ] Subprocess tests verify exit code 0
+- [ ] JSON output is valid and parseable
+- [ ] Permission errors handled gracefully
+- [ ] Corrupted input handled gracefully
+- [ ] Continuous work mode tested end-to-end
+- [ ] Lock file race conditions handled
+- [ ] Custom prompt edge cases tested
+- [ ] Logging and metrics verified
+- [ ] No regressions from previous tests
+
+## TDD Approach
+
+### Red-Green-Refactor Cycle
+
+1. **Red**: Write failing test first
+2. **Green**: Implement minimal code to pass
+3. **Refactor**: Improve code while keeping tests green
+
+### Implementation Order
+
+**Phase 1**: Unit tests for process() method
+
+- Implement UNIT-PROCESS-001 to 012
+- These guide the core logic implementation
+
+**Phase 2**: Unit tests for read_continuation_prompt()
+
+- Implement UNIT-PROMPT-001 to 009
+- These guide prompt handling logic
+
+**Phase 3**: Unit tests for run() lifecycle
+
+- Implement UNIT-RUN-001 to 008
+- These verify hook lifecycle correctness
+
+**Phase 4**: Integration tests
+
+- Implement subprocess tests first (critical for API compliance)
+- Then lock and prompt integration tests
+- Finally logging tests
+
+**Phase 5**: E2E tests
+
+- Implement workflow tests (validate user scenarios)
+- Then error recovery tests
+- Finally performance tests
+
+### Builder Agent Instructions
+
+When implementing tests:
+
+1. **Start with fixtures** in `conftest.py`
+2. **Implement unit tests** in order (PROCESS → PROMPT → RUN → JSON → PATH)
+3. **Run tests frequently** after each test file
+4. **Fix failures immediately** before moving to next test
+5. **Add integration tests** after all unit tests pass
+6. **Verify subprocess behavior** matches API spec exactly
+7. **Add E2E tests** last to validate complete workflows
+8. **Run full suite** before marking task complete
+
+## Success Criteria
+
+Tests are considered complete and successful when:
+
+1. **All 60 tests pass** consistently
+2. **Coverage goals met** (≥90% line, ≥85% branch)
+3. **Performance requirements met** (< 200ms)
+4. **API compliance verified**:
+   - Empty dict `{}` when allowing stop
+   - Block decision with reason when blocking
+   - Exit code 0 always
+   - No stderr output during normal operation
+5. **Edge cases handled**:
+   - Permission errors
+   - Corrupted JSON
+   - Missing files
+   - Race conditions
+6. **Continuous work mode validated** end-to-end
+
+## References
+
+- **Issue #962**: https://github.com/[repo]/issues/962
+- **Claude Code Hook API**: See official documentation
+- **Testing Pyramid**: 60% unit, 30% integration, 10% E2E
+- **pytest Documentation**: https://docs.pytest.org/
+- **Coverage.py**: https://coverage.readthedocs.io/
+
+---
+
+**Document Version**: 1.0 **Author**: Tester Agent **Date**: 2025-10-20
+**Status**: Ready for Implementation

--- a/docs/testing/session_management_test_coverage.md
+++ b/docs/testing/session_management_test_coverage.md
@@ -1,0 +1,435 @@
+# TDD Test Coverage: Auto Mode Session Management
+
+## Overview
+
+This document describes the comprehensive failing tests created for session management functionality in `auto_mode.py`. Following TDD principles, these tests define success criteria BEFORE implementation.
+
+**Test File**: `/home/azureuser/src/MicrosoftHackathon2025-AgenticCoding/worktrees/feat-session-management/tests/test_auto_mode_session_management.py`
+
+## Test Categories
+
+### 1. Message Tracking (8 tests)
+
+**Purpose**: Ensure all messages are captured during auto mode execution for transcript generation.
+
+#### Tests:
+
+- `test_auto_mode_has_messages_list` - AutoMode must have `self.messages` list
+- `test_messages_captured_during_clarify_phase` - Messages captured in Turn 1 (clarify)
+- `test_messages_captured_during_planning_phase` - Messages captured in Turn 2 (plan)
+- `test_messages_captured_during_execution_phase` - Messages captured in execution turns
+- `test_messages_captured_during_evaluation_phase` - Messages captured after each execute
+- `test_message_format_includes_required_fields` - Messages match transcript builder format
+- `test_all_phases_captured_in_complete_session` - All phases present in complete session
+
+**Expected Message Format**:
+
+```python
+{
+    'role': 'user' | 'assistant',
+    'content': 'message content',
+    'timestamp': 'ISO format timestamp',
+    'phase': 'clarifying' | 'planning' | 'executing' | 'evaluating' | 'summarizing',
+    'turn': 1-N
+}
+```
+
+**Success Criteria**:
+
+- ✓ Messages list exists and starts empty
+- ✓ Messages captured at each phase
+- ✓ Message format compatible with ClaudeTranscriptBuilder
+- ✓ All phases represented in complete session
+
+---
+
+### 2. Duration Tracking (6 tests)
+
+**Purpose**: Track session duration and format it human-readable for logs and transcripts.
+
+#### Tests:
+
+- `test_session_duration_calculated_correctly` - Duration = current_time - start_time
+- `test_duration_formatted_as_seconds_for_short_sessions` - "45s" for 45 seconds
+- `test_duration_formatted_as_minutes_and_seconds` - "2m 5s" for 125 seconds
+- `test_duration_appears_in_progress_string` - Progress shows "[Turn 2/10 | Planning | 1m 23s]"
+- `test_session_duration_tracked_in_metadata` - Duration stored in session_metadata
+- `test_duration_formatted_for_export` - Both seconds and formatted duration in metadata
+
+**Success Criteria**:
+
+- ✓ Duration calculated from start to current time
+- ✓ Format: "<60s" → "Xs", ">=60s" → "Xm Ys"
+- ✓ Duration visible in progress logs
+- ✓ Duration available in session metadata for export
+
+---
+
+### 3. Fork Detection (6 tests)
+
+**Purpose**: Automatically fork sessions at 60-minute threshold to prevent context loss.
+
+#### Tests:
+
+- `test_fork_not_triggered_before_60_minutes` - No fork at 59 minutes
+- `test_fork_triggered_at_60_minutes` - Fork triggers at exactly 60 minutes
+- `test_fork_triggered_after_60_minutes` - Fork triggers after 60 minutes
+- `test_fork_creates_new_session_with_context` - New AutoMode with continuation context
+- `test_fork_exports_current_session_before_forking` - Export transcript before fork
+- `test_fork_logs_continuation_marker` - Log fork event with new session ID
+
+**Fork Workflow**:
+
+```python
+if session_duration >= 60 minutes:
+    1. Export current session transcript
+    2. Create summary of work so far
+    3. Create new AutoMode instance
+    4. Pass summary as context to new session
+    5. Log fork event
+    6. Continue execution in new session
+```
+
+**Success Criteria**:
+
+- ✓ Fork detection at 60-minute threshold
+- ✓ Export before forking
+- ✓ Context carried forward
+- ✓ Fork events logged
+
+---
+
+### 4. Export Integration (7 tests)
+
+**Purpose**: Export session data to transcript files compatible with ClaudeTranscriptBuilder.
+
+#### Tests:
+
+- `test_export_method_exists` - `_export_session_transcript()` method exists
+- `test_export_creates_transcript_file` - Creates `CONVERSATION_TRANSCRIPT.md`
+- `test_export_includes_all_messages` - All messages from `self.messages` in transcript
+- `test_export_includes_duration_metadata` - Duration in transcript header
+- `test_export_called_in_stop_hook` - Export triggered when session ends
+- `test_export_creates_json_for_programmatic_access` - JSON version created
+
+**Export File Structure**:
+
+```
+.claude/runtime/logs/<session_id>/
+├── CONVERSATION_TRANSCRIPT.md  (markdown, human-readable)
+├── conversation_transcript.json (json, programmatic access)
+└── session_summary.json         (summary statistics)
+```
+
+**Success Criteria**:
+
+- ✓ Export method exists and is callable
+- ✓ Markdown and JSON transcripts created
+- ✓ All messages included in transcript
+- ✓ Duration metadata in transcript
+- ✓ Export triggered at session end
+
+---
+
+### 5. Backward Compatibility (5 tests)
+
+**Purpose**: Ensure session management doesn't break existing auto_mode usage.
+
+#### Tests:
+
+- `test_auto_mode_works_without_session_tracking` - Optional `enable_session_management` flag
+- `test_existing_public_api_unchanged` - Public methods unchanged
+- `test_session_management_minimal_overhead` - <5% performance overhead
+- `test_session_dir_structure_compatible` - Files in `~/.amplihack/.claude/runtime/logs/<session_id>/`
+- `test_existing_hooks_still_called` - `session_start` and `stop` hooks still called
+
+**Backward Compatibility Requirements**:
+
+```python
+# Old code still works
+auto_mode = AutoMode(sdk="claude", prompt="Test")
+auto_mode.run()  # Works as before
+
+# New code with session management
+auto_mode = AutoMode(sdk="claude", prompt="Test", enable_session_management=True)
+auto_mode.run()  # Includes message tracking and export
+```
+
+**Success Criteria**:
+
+- ✓ Existing code works without changes
+- ✓ Session management is optional
+- ✓ No required new parameters
+- ✓ Minimal performance impact (<5% overhead)
+- ✓ Hooks still called as expected
+
+---
+
+### 6. Session Metadata (3 tests)
+
+**Purpose**: Collect structured metadata for transcript builder and analysis.
+
+#### Tests:
+
+- `test_session_metadata_structure` - Metadata has all required fields
+- `test_session_metadata_phase_breakdown` - Time spent in each phase
+- `test_session_metadata_compatible_with_transcript_builder` - JSON-serializable format
+
+**Metadata Structure**:
+
+```python
+{
+    "session_id": "auto_claude_1234567890",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:05:00",
+    "duration_seconds": 300,
+    "duration_formatted": "5m 0s",
+    "total_turns": 5,
+    "max_turns": 10,
+    "prompt": "User's initial prompt",
+    "sdk": "claude",
+    "phase_breakdown": {
+        "clarifying": 30,
+        "planning": 45,
+        "executing": 180,
+        "evaluating": 30,
+        "summarizing": 15
+    }
+}
+```
+
+**Success Criteria**:
+
+- ✓ Complete metadata structure
+- ✓ Phase time breakdown
+- ✓ JSON-serializable
+- ✓ Compatible with ClaudeTranscriptBuilder
+
+---
+
+## Test Execution Summary
+
+### Current Status: ALL TESTS FAILING (Expected)
+
+This is correct TDD behavior:
+
+1. ✓ Write failing tests FIRST
+2. ⏳ Implement functionality to make tests pass
+3. ⏳ Refactor while keeping tests green
+
+### Running the Tests
+
+```bash
+# Run all session management tests
+python tests/test_auto_mode_session_management.py
+
+# Expected output: ~35 failures/errors
+# This is GOOD - tests define what needs to be implemented
+```
+
+### Test Failure Categories
+
+1. **AttributeError** - Methods/attributes don't exist yet:
+   - `self.messages` list
+   - `_should_fork_session()` method
+   - `_fork_session()` method
+   - `_export_session_transcript()` method
+   - `session_metadata` attribute
+
+2. **TypeError** - Parameters don't exist yet:
+   - `enable_session_management` flag
+
+3. **Logic Failures** - Functionality not implemented:
+   - Message capture during phases
+   - Duration tracking in metadata
+   - Export integration
+   - Fork detection
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Basic Message Tracking
+
+1. Add `self.messages = []` to `__init__()`
+2. Add `_capture_message()` helper method
+3. Call `_capture_message()` at each phase
+4. Ensure message format matches tests
+
+**Tests to pass**: TestMessageTracking (8 tests)
+
+### Phase 2: Duration Tracking
+
+1. Add `self.session_metadata = {}` to `__init__()`
+2. Track phase start/end times
+3. Calculate phase durations
+4. Update metadata with durations
+
+**Tests to pass**: TestDurationTracking (6 tests)
+
+### Phase 3: Export Integration
+
+1. Add `_export_session_transcript()` method
+2. Integrate with ClaudeTranscriptBuilder
+3. Call export in `finally` block
+4. Create both markdown and JSON files
+
+**Tests to pass**: TestExportIntegration (7 tests)
+
+### Phase 4: Fork Detection
+
+1. Add `_should_fork_session()` method
+2. Add `_fork_session()` method
+3. Check duration at each turn
+4. Export before forking
+5. Create new session with context
+
+**Tests to pass**: TestForkDetection (6 tests)
+
+### Phase 5: Metadata & Compatibility
+
+1. Complete metadata structure
+2. Add `enable_session_management` flag
+3. Ensure backward compatibility
+4. Performance validation
+
+**Tests to pass**: TestSessionMetadata (3 tests) + TestBackwardCompatibility (5 tests)
+
+---
+
+## Success Metrics
+
+### Code Coverage
+
+- **Target**: >95% coverage of new session management code
+- **Focus**: All new methods and attributes
+
+### Test Coverage
+
+- **Total Tests**: 35
+- **Categories**: 6 (Message Tracking, Duration, Fork, Export, Compatibility, Metadata)
+- **Current Status**: 0/35 passing (Expected - TDD approach)
+
+### Performance Requirements
+
+- **Overhead**: <5% performance impact when enabled
+- **Memory**: <10MB additional memory for typical session
+- **Export Time**: <1s for 100 messages
+
+### Quality Gates
+
+- ✓ All 35 tests passing
+- ✓ No breaking changes to public API
+- ✓ Backward compatible with existing code
+- ✓ Integration with ClaudeTranscriptBuilder validated
+- ✓ Fork workflow tested end-to-end
+
+---
+
+## Integration Points
+
+### 1. ClaudeTranscriptBuilder
+
+**File**: `~/.amplihack/.claude/tools/amplihack/builders/claude_transcript_builder.py`
+
+**Interface**:
+
+```python
+from builders.claude_transcript_builder import ClaudeTranscriptBuilder
+
+builder = ClaudeTranscriptBuilder(session_id=self.session_id)
+transcript_path = builder.build_session_transcript(
+    messages=self.messages,
+    metadata=self.session_metadata
+)
+```
+
+### 2. Stop Hook
+
+**File**: `~/.amplihack/.claude/tools/amplihack/hooks/stop.py`
+
+**Integration**: Export should be called before stop hook runs, allowing stop hook to process the transcript.
+
+### 3. Session Start Hook
+
+**File**: `~/.amplihack/.claude/tools/amplihack/hooks/session_start.py`
+
+**Integration**: Session start hook should receive session metadata, including whether this is a forked session.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Current)
+
+- Test individual methods in isolation
+- Mock external dependencies
+- Focus on logic correctness
+
+### Integration Tests (Future)
+
+- Test interaction with ClaudeTranscriptBuilder
+- Test interaction with hooks
+- Test complete session lifecycle
+
+### E2E Tests (Future)
+
+- Test real auto mode sessions
+- Validate transcript quality
+- Test fork workflow in real scenarios
+
+---
+
+## Critical Test Cases
+
+### Most Important Tests (Must Pass First)
+
+1. **test_auto_mode_has_messages_list** - Foundation for all message tracking
+2. **test_message_format_includes_required_fields** - Ensures compatibility
+3. **test_export_method_exists** - Core export functionality
+4. **test_session_metadata_structure** - Metadata foundation
+5. **test_existing_public_api_unchanged** - Backward compatibility
+
+### High-Risk Tests (Focus on Edge Cases)
+
+1. **test_fork_triggered_at_60_minutes** - Exact threshold behavior
+2. **test_session_management_minimal_overhead** - Performance impact
+3. **test_export_called_in_stop_hook** - Integration with existing hooks
+4. **test_fork_exports_current_session_before_forking** - Data integrity
+
+---
+
+## Notes for Implementation
+
+### Design Decisions
+
+1. **Message Format**: Follow ClaudeTranscriptBuilder expectations exactly
+2. **Fork Threshold**: 60 minutes (configurable in future)
+3. **Export Timing**: In `finally` block to ensure it always runs
+4. **Backward Compatibility**: Optional via `enable_session_management` flag
+5. **Performance**: Lazy initialization, minimal overhead
+
+### Future Enhancements
+
+1. Configurable fork threshold
+2. Compression for large sessions
+3. Streaming export (don't wait for end)
+4. Multiple export formats (HTML, PDF)
+5. Session replay functionality
+
+---
+
+## Conclusion
+
+These tests provide complete coverage for session management functionality:
+
+- ✓ Message tracking across all phases
+- ✓ Duration tracking and formatting
+- ✓ Fork detection at 60 minutes
+- ✓ Export integration with transcript builder
+- ✓ Backward compatibility preservation
+- ✓ Metadata collection and structure
+
+**Current Status**: All 35 tests failing as expected (TDD approach)
+
+**Next Step**: Implement functionality to make tests pass, one category at a time.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,18 @@ nav:
       - Fleet Orchestration Tutorial: fleet-orchestration/TUTORIAL.md
   - Skills:
       - Migrate Session: skills/migrate.md
+      - Skill Builder Examples: skills/SKILL_BUILDER_EXAMPLES.md
+      - Skill Catalog: skills/SKILL_CATALOG.md
+  - Testing:
+      - Auto Mode UI Test Suite: testing/AUTO_MODE_UI_TEST_SUITE.md
+      - Test Fixes Needed: testing/TEST_FIXES_NEEDED.md
+      - Test Implementation Summary: testing/TEST_IMPLEMENTATION_SUMMARY.md
+      - Test Plan: testing/TEST_PLAN.md
+      - Test Specification Stop Hook: testing/TEST_SPECIFICATION_STOP_HOOK.md
+      - Session Management Test Coverage: testing/session_management_test_coverage.md
+  - Security:
+      - Lock Session ID Sanitization: security/lock-session-id-sanitization.md
+      - Platform Bridge Security: security/platform-bridge-security.md
   - Reference:
       - install Command: reference/install-command.md
       - Install Manifest: reference/install-manifest.md


### PR DESCRIPTION
## Summary
- Ports 6 testing, 2 security, and 2 skills docs from upstream amplihack
- Creates new Testing and Security nav sections
- Appends 2 entries to existing Skills section

Wave 7 PR 5 of 6 for issue #420 documentation parity.

## Test plan
- [x] `mkdocs build --strict` passes with zero warnings
- [x] All 10 new files exist and are non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)