### PR TITLE
fix(docs-ci): repair mkdocs.yml navigation broken by Wave 7 doc PRs (#420)

### DIFF
--- a/tests/integration/doc_code_drift_test.rs
+++ b/tests/integration/doc_code_drift_test.rs
@@ -717,13 +717,30 @@ mod mkdocs_navigation {
     }
 
     /// All four new entries must be in the Reference section.
+    ///
+    /// Markers are anchored to the top-level mkdocs nav indent (column 0,
+    /// `"\n  - "`) because Wave 7 doc PRs (#469-#474) introduced nested DDD
+    /// subsections literally named `Reference:` and `Concepts:` at deeper
+    /// indent levels. Bare-substring `find()` resolved to those nested
+    /// matches first, inverting the slice. See issue #420.
     #[test]
     fn new_entries_in_reference_section() {
         let config = read_doc("mkdocs.yml");
+        let ref_marker = "\n  - Reference:";
+        let concepts_marker = "\n  - Concepts:";
+        assert_eq!(
+            config.matches(ref_marker).count(),
+            1,
+            "mkdocs.yml must have exactly one top-level '  - Reference:' nav entry; \
+             adding a second would silently mis-slice this test"
+        );
         let reference_start = config
-            .find("Reference:")
-            .expect("mkdocs.yml must have Reference: section");
-        let concepts_start = config.find("Concepts:").unwrap_or(config.len());
+            .find(ref_marker)
+            .expect("mkdocs.yml must have top-level '  - Reference:' nav entry");
+        let concepts_relative = config[reference_start..]
+            .find(concepts_marker)
+            .unwrap_or(config.len() - reference_start);
+        let concepts_start = reference_start + concepts_relative;
         let reference_section = &config[reference_start..concepts_start];
 
         for doc_file in &[


### PR DESCRIPTION
## Summary

Fixes the failing test `mkdocs_navigation::new_entries_in_reference_section` in `tests/integration/doc_code_drift_test.rs` (issue #420) which began panicking on main with:

```
begin <= end (7420 <= 6246) when slicing
```

## Root cause

Wave 7 documentation PRs (#469, #470, #471, #472, #473, #474) introduced Domain-Driven Design subsections under `docs/` whose mkdocs.yml nav entries are literally named `Core Concepts:` (line 125, 6-space indent) and `Reference:` (line 139, 6-space indent). These sit at lower file offsets than the **top-level** nav keys `  - Reference:` (line 191) and `  - Concepts:` (line 271).

Because `str::find()` returns the **first** match, the test's bare-substring markers (`"Reference:"` and `"Concepts:"`) resolved to the nested DDD subsections instead of the top-level nav keys. The resulting slice indices inverted (`begin=7420 > end=6246`) and panicked.

## Fix

**Despite the PR title, this is a test-only change. `mkdocs.yml` is structurally correct and untouched.** The new doc entries from Wave 7 are fine; only the test's slice anchors needed to be made nesting-resistant.

Changes in `tests/integration/doc_code_drift_test.rs`:

1. **Anchor markers on `\n  - `** (newline + 2-space indent) so they can only match top-level nav entries at column 0, not nested 4+ space subsections.
2. **Add a uniqueness assertion** (`config.matches("  - Reference:").count() == 1`) so a future edit that introduces a second top-level `Reference:` entry fails loudly instead of silently mis-slicing.
3. **Search the post-Reference slice** for the `Concepts:` boundary (`config[reference_start..].find(...)`) so a top-level `Concepts:` appearing before `Reference:` cannot invert the slice either.
4. **Preserve the asymmetric `expect()` / `unwrap_or()` pattern**: `Reference:` is the section under test (absence is a fail-loud / zero-BS condition); `Concepts:` is only a boundary marker (may legitimately be removed by future doc reorganization without invalidating the Reference-section assertion).

No changes to `mkdocs.yml` or any `docs/` markdown files.

## Verification

```bash
# Failing test now passes
cargo test -p amplihack --test doc_code_drift mkdocs_navigation::new_entries_in_reference_section
# 1 passed; 0 failed

# All sibling nav tests still pass
cargo test -p amplihack --test doc_code_drift mkdocs_navigation
# 5 passed; 0 failed

# Lint clean
cargo clippy -p amplihack --tests -- -D warnings
# Finished

# Workspace tests: only failures are pre-existing on main and unrelated
# (update::tests::should_skip_update_check_for_update_related_args and
#  update::tests::should_not_skip_update_check_for_launch_subcommands —
#  reproduce on tip of main without this patch).
TMPDIR=/tmp cargo test --workspace --locked
```

## Refs

- Issue: #420
- Wave 7 doc PRs that surfaced the latent bug: #469, #470, #471, #472, #473, #474

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>