### PR TITLE
feat(docs): add project-level discoveries rolling log

### DIFF
--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -182,3 +182,11 @@ path = "../../tests/integration/sdk_comparison_optional_python_test.rs"
 [[test]]
 name = "self_improvement_loop_skip"
 path = "../../tests/integration/self_improvement_loop_skip_test.rs"
+
+# Issue #435: docs/discoveries.md rolling log.
+# Verifies the file exists, follows the prescribed format (title, archive
+# policy, entry format guide, category tags, dated seed entry, ToC), and
+# is linked from docs/index.md under Contributing.
+[[test]]
+name = "discoveries_doc"
+path = "../../tests/integration/discoveries_doc_test.rs"

--- a/docs/discoveries.md
+++ b/docs/discoveries.md
@@ -1,0 +1,70 @@
+# Discoveries
+
+A rolling log of non-obvious problems, solutions, and patterns discovered during amplihack-rs development. Each entry captures a single learning so future contributors avoid re-discovering the same gotchas.
+
+**Archive policy**: When this file exceeds 100 entries, move entries older than 3 months to `discoveries-archive.md` in this directory.
+
+## Entry Format
+
+Each entry follows this structure:
+
+```markdown
+## Short Title (YYYY-MM-DD)
+
+**Category**: build | ci | testing | architecture | workflow | tooling | docs
+
+### Problem
+
+One-paragraph description of the unexpected behavior.
+
+### Root Cause
+
+Why it happened — the non-obvious part worth recording.
+
+### Solution
+
+What fixed it and why that fix is correct.
+
+### Key Learnings
+
+- Bullet points a future reader can act on without reading the full entry.
+```
+
+**Guidelines**:
+
+- One discovery per entry. If you found two things, write two entries.
+- Use the date you confirmed the fix, not the date you noticed the symptom.
+- Link to the relevant PR or issue when one exists.
+- Keep entries factual. Skip praise, hedging, and narrative filler.
+
+---
+
+## Table of Contents
+
+### April 2026
+
+- [Docs-only rolling log chosen over Rust hook wiring](#docs-only-rolling-log-chosen-over-rust-hook-wiring-2026-04-28)
+
+---
+
+## Docs-only rolling log chosen over Rust hook wiring (2026-04-28)
+
+**Category**: docs
+
+### Problem
+
+Issue [#435](https://github.com/rysweet/amplihack-rs/issues/435) requested a project-level `DISCOVERIES.md` mirroring the upstream `amplifier-bundle/context/DISCOVERIES.md`. Two options were proposed: (1) a lightweight `docs/discoveries.md` rolling log, or (2) wiring a Rust hook in `crates/amplihack-hooks/` to auto-capture discoveries at session boundaries.
+
+### Root Cause
+
+The upstream discoveries file works well as a manually-curated knowledge base. Automating capture via hooks would require changes to the Rust hook crate, a new CLI subcommand, and persistent storage plumbing — all for uncertain value since the best discoveries are written by humans reflecting on what surprised them.
+
+### Solution
+
+Option 1: create `docs/discoveries.md` with a clear format guide and seed entry. No Rust code changes. The file lives alongside the rest of the project documentation and is linked from `docs/index.md`.
+
+### Key Learnings
+
+- Start with the simplest version that delivers value. A markdown file with a format guide costs nothing to maintain and can be upgraded later.
+- Hook-based automation is a separate concern. If demand emerges, a future issue can wire `amplihack discoveries add "..."` without changing this file's structure.
+- The upstream `amplifier-bundle/context/DISCOVERIES.md` (2,400+ lines, Oct 2025 – Jan 2026) validates the format: problem / root cause / solution / key learnings works well at scale.

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,7 @@ amplihack uninstall
 
 - [File Organization](./contributing/file-organization.md) — Where files go in the repository
 - [Documentation Parity Audit](./contributing/documentation-parity-audit.md) — How upstream docs were audited and ported, and how to maintain parity
+- [Discoveries](./discoveries.md) — Rolling log of non-obvious problems, solutions, and patterns found during development
 
 ## Related
 

--- a/tests/integration/discoveries_doc_test.rs
+++ b/tests/integration/discoveries_doc_test.rs
@@ -1,0 +1,144 @@
+//! Documentation structure tests for issue #435.
+//!
+//! These tests verify that `docs/discoveries.md` exists, follows the
+//! prescribed format, and is linked from `docs/index.md`. Pure
+//! file-content assertions — no binary execution required.
+//!
+//! Test proportionality: docs-only change → verification tests only.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop(); // tests/
+    path.pop(); // workspace root
+    path
+}
+
+fn read_doc(relative: &str) -> String {
+    let path = workspace_root().join(relative);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Existence and structure
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn discoveries_file_exists() {
+    let path = workspace_root().join("docs/discoveries.md");
+    assert!(path.exists(), "docs/discoveries.md must exist (issue #435)");
+}
+
+#[test]
+fn discoveries_has_title_heading() {
+    let doc = read_doc("docs/discoveries.md");
+    assert!(
+        doc.starts_with("# Discoveries"),
+        "docs/discoveries.md must start with '# Discoveries' heading"
+    );
+}
+
+#[test]
+fn discoveries_has_archive_policy() {
+    let doc = read_doc("docs/discoveries.md");
+    let lower = doc.to_lowercase();
+    assert!(
+        lower.contains("archive policy") || lower.contains("discoveries-archive"),
+        "docs/discoveries.md must document an archive policy for old entries"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Entry format guide
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn discoveries_has_entry_format_section() {
+    let doc = read_doc("docs/discoveries.md");
+    assert!(
+        doc.contains("## Entry Format") || doc.contains("## Format"),
+        "docs/discoveries.md must include an entry format guide"
+    );
+}
+
+#[test]
+fn discoveries_format_includes_required_fields() {
+    let doc = read_doc("docs/discoveries.md");
+    let required_fields = ["Problem", "Root Cause", "Solution", "Key Learnings"];
+    for field in &required_fields {
+        assert!(
+            doc.contains(field),
+            "Entry format must document the '{field}' field"
+        );
+    }
+}
+
+#[test]
+fn discoveries_format_includes_category_tag() {
+    let doc = read_doc("docs/discoveries.md");
+    assert!(
+        doc.contains("Category"),
+        "Entry format must include a Category tag"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Seed entry — at least one real entry must exist
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn discoveries_has_at_least_one_dated_entry() {
+    let doc = read_doc("docs/discoveries.md");
+    // Entries use the pattern: ## Title (YYYY-MM-DD)
+    let has_dated_entry = doc.lines().any(|line| {
+        line.starts_with("## ")
+                && line.contains('(')
+                && line.contains(')')
+                // Must contain a date-like pattern: 4 digits, dash, 2 digits
+                && line.chars().filter(|c| c.is_ascii_digit()).count() >= 8
+    });
+    assert!(
+        has_dated_entry,
+        "docs/discoveries.md must contain at least one dated entry \
+         in '## Title (YYYY-MM-DD)' format"
+    );
+}
+
+#[test]
+fn discoveries_has_table_of_contents() {
+    let doc = read_doc("docs/discoveries.md");
+    assert!(
+        doc.contains("## Table of Contents") || doc.contains("## Contents"),
+        "docs/discoveries.md must include a Table of Contents section"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Integration: linked from index.md
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn index_links_to_discoveries() {
+    let index = read_doc("docs/index.md");
+    assert!(
+        index.contains("discoveries.md"),
+        "docs/index.md must link to discoveries.md"
+    );
+}
+
+#[test]
+fn index_discoveries_link_is_in_contributing_section() {
+    let index = read_doc("docs/index.md");
+    let contributing_pos = index.find("Contributing");
+    let discoveries_pos = index.find("discoveries.md");
+    assert!(
+        contributing_pos.is_some() && discoveries_pos.is_some(),
+        "Both Contributing section and discoveries.md link must exist in index.md"
+    );
+    assert!(
+        contributing_pos.unwrap() < discoveries_pos.unwrap(),
+        "discoveries.md link should appear after the Contributing section heading"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #435

- Creates `docs/discoveries.md` — a rolling log of non-obvious problems, solutions, and patterns discovered during amplihack-rs development, mirroring the upstream `amplifier-bundle/context/DISCOVERIES.md` structure
- Adds format guide (problem / root cause / solution / key learnings), archive policy, and a seed entry documenting the Option 1 decision
- Links from `docs/index.md` under the Contributing section
- Adds 10 integration tests verifying file existence, structure, format fields, seed entry, and index.md linkage

## Design Decision

**Option 1 chosen** (lightweight `docs/discoveries.md` rolling log) over Option 2 (Rust hook wiring in `crates/amplihack-hooks/`). Rationale: start with the simplest version that delivers value; hook automation is a separate concern for a future issue if demand emerges.

## Test plan

- [x] `cargo test --test discoveries_doc` — 10/10 pass
- [x] Pre-commit hooks pass (fmt, clippy, toml check)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)