### PR TITLE
docs: investigation for #434 gherkin v2 experiment disposition

### DIFF
--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -190,3 +190,10 @@ path = "../../tests/integration/self_improvement_loop_skip_test.rs"
 [[test]]
 name = "discoveries_doc"
 path = "../../tests/integration/discoveries_doc_test.rs"
+
+# Issue #434: Gherkin v2 experiment disposition investigation.
+# Verifies investigation doc structure, index.md linkage, and regression guards
+# ensuring gherkin-expert skill/agent/allowlist entry remain present.
+[[test]]
+name = "gherkin_investigation_doc"
+path = "../../tests/integration/gherkin_investigation_doc_test.rs"

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,6 +98,14 @@ amplihack-rs is the Rust implementation of the amplihack CLI. It replaces the Py
 - [Memory Tree](./concepts/memory-tree.md) — Mental model and CLI surface for the `amplihack memory tree` command
 - [Five-Type Memory (Superseded)](./concepts/five-type-memory.md) — Redirect from the legacy 5-type memory guide to current memory documentation
 
+### Investigations
+
+- [Unifying Dual Status Classifiers (#2898)](./investigations/2898-status-classifiers.md) — Whether merging two keyword classifiers into one module is warranted (conclusion: do not merge)
+- [Shell Injection in Task Description Heredoc (#3045, #3076)](./investigations/3045-3076-task-description-heredoc-shell-injection.md) — Heredoc expansion risk in recipe shell steps
+- [Step-03 Idempotency Guards](./investigations/step-03-idempotency-guards-analysis.md) — Analysis of deduplication guards in recipe step-03
+- [Step-03 External Service Integration](./investigations/step03-external-service-integration-assessment.md) — Assessment of external service dependencies in step-03
+- [Gherkin v2 Experiment Disposition (#434)](./investigations/434-gherkin-v2-experiment-disposition.md) — Why the upstream experiment doc needs no port: the gherkin-expert skill already ships in the bundle
+
 ## Quick Start
 
 ```sh

--- a/docs/investigations/434-gherkin-v2-experiment-disposition.md
+++ b/docs/investigations/434-gherkin-v2-experiment-disposition.md
@@ -1,0 +1,86 @@
+# Investigation: Disposition of Upstream Gherkin v2 Experiment Findings (#434)
+
+**Date**: 2026-04-28
+**Scope**: Investigation only — no code changes
+**Disposition**: Closed as not-planned
+
+---
+
+## Summary
+
+Issue #434 asked whether to port the upstream `gherkin_v2_experiment_findings.md`
+document into amplihack-rs, or remove the `"gherkin-expert"` string from
+`known_skills.rs` if the feature is unused.
+
+**Conclusion: CLOSE AS NOT-PLANNED — no parity gap exists.**
+
+The gherkin-expert capability already ships in amplihack-rs through the
+amplifier-bundle. The upstream document is an informational experiment log, not a
+feature specification. There is nothing to port and nothing to remove.
+
+---
+
+## 1. What the Issue Claimed
+
+Issue #434 (tracked from the #420 documentation parity audit) reported:
+
+- Upstream carries `docs/gherkin_v2_experiment_findings.md`
+- The only amplihack-rs hit for "gherkin" is a string in `known_skills.rs`
+- No agent, recipe, or workflow uses gherkin v2 today
+
+The issue suggested either porting the experiment as an eval scenario or
+removing the string from `known_skills.rs`.
+
+## 2. What the Codebase Actually Contains
+
+A broader search reveals the gherkin-expert is a live, functional skill:
+
+| File | Purpose |
+|---|---|
+| `amplifier-bundle/skills/gherkin-expert/SKILL.md` | Full skill definition with triggers, usage, and examples |
+| `amplifier-bundle/agents/specialized/gherkin-expert.md` | Agent definition for BDD/Gherkin test generation |
+| `crates/amplihack-hooks/src/known_skills.rs` | Valid allowlist entry referencing the bundle skill |
+| `docs/howto/use_gherkin_expert.md` | User-facing how-to guide |
+| `docs/guides/formal-specifications-as-prompt-language.md` | Related guide referencing gherkin patterns |
+
+The initial grep (`crates/*/src/`) only searched Rust source files, missing the
+bundle and documentation directories where the skill lives.
+
+## 3. Why No Action Is Needed
+
+### The upstream document is informational, not a feature spec
+
+`gherkin_v2_experiment_findings.md` records the results of a past experiment. It
+describes what was tried and what was learned. It is not a specification for a
+feature that needs implementing.
+
+### The gherkin-expert capability already exists
+
+The amplifier-bundle ships a complete gherkin-expert skill (SKILL.md) and agent
+(gherkin-expert.md). The `known_skills.rs` entry correctly references this
+bundle skill. Removing it would break skill discovery.
+
+### No parity gap
+
+The parity audit flagged this because the grep was too narrow. The capability
+exists — it is bundled, documented, and registered.
+
+## 4. Decision
+
+| Aspect | Decision |
+|---|---|
+| Port upstream document? | No — it is an experiment log, not a feature spec |
+| Remove `known_skills.rs` entry? | No — it references a valid, live skill |
+| Create eval scenario? | No — skill already functions; eval is orthogonal |
+| Issue disposition | Closed as not-planned |
+
+## 5. Risks Considered
+
+- **False positive from narrow grep**: The original issue was filed based on a
+  grep limited to `crates/*/src/`. A repo-wide search immediately shows the
+  skill exists. Future parity audits should search the full repository including
+  `amplifier-bundle/`.
+
+- **Removing a valid entry**: Had the `known_skills.rs` entry been removed, the
+  gherkin-expert skill would no longer be discoverable by the hooks system. This
+  would be a regression, not cleanup.

--- a/tests/integration/gherkin_investigation_doc_test.rs
+++ b/tests/integration/gherkin_investigation_doc_test.rs
@@ -1,0 +1,180 @@
+//! Documentation and invariant tests for issue #434.
+//!
+//! Issue #434 was closed as not-planned after investigation showed the
+//! gherkin-expert skill already ships in the amplifier-bundle. These tests
+//! verify:
+//!   1. The investigation doc exists with correct structure
+//!   2. The doc is linked from docs/index.md
+//!   3. The gherkin-expert skill files remain present (regression guard)
+//!   4. The known_skills.rs allowlist still contains "gherkin-expert"
+//!
+//! Test proportionality: investigation-only change -> verification tests only.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop(); // tests/
+    path.pop(); // workspace root
+    path
+}
+
+fn read_file(relative: &str) -> String {
+    let path = workspace_root().join(relative);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Investigation document existence and structure
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn investigation_doc_exists() {
+    let path =
+        workspace_root().join("docs/investigations/434-gherkin-v2-experiment-disposition.md");
+    assert!(
+        path.exists(),
+        "docs/investigations/434-gherkin-v2-experiment-disposition.md must exist (issue #434)"
+    );
+}
+
+#[test]
+fn investigation_doc_has_title() {
+    let doc = read_file("docs/investigations/434-gherkin-v2-experiment-disposition.md");
+    assert!(
+        doc.contains(
+            "# Investigation: Disposition of Upstream Gherkin v2 Experiment Findings (#434)"
+        ),
+        "Investigation doc must have the correct title heading"
+    );
+}
+
+#[test]
+fn investigation_doc_has_disposition() {
+    let doc = read_file("docs/investigations/434-gherkin-v2-experiment-disposition.md");
+    assert!(
+        doc.contains("Closed as not-planned"),
+        "Investigation doc must state the disposition as 'Closed as not-planned'"
+    );
+}
+
+#[test]
+fn investigation_doc_has_summary_section() {
+    let doc = read_file("docs/investigations/434-gherkin-v2-experiment-disposition.md");
+    assert!(
+        doc.contains("## Summary"),
+        "Investigation doc must include a Summary section"
+    );
+}
+
+#[test]
+fn investigation_doc_has_decision_section() {
+    let doc = read_file("docs/investigations/434-gherkin-v2-experiment-disposition.md");
+    assert!(
+        doc.contains("## 4. Decision"),
+        "Investigation doc must include a Decision section"
+    );
+}
+
+#[test]
+fn investigation_doc_has_evidence_table() {
+    let doc = read_file("docs/investigations/434-gherkin-v2-experiment-disposition.md");
+    // The evidence table lists the 5 key files proving gherkin-expert exists
+    let evidence_files = [
+        "amplifier-bundle/skills/gherkin-expert/SKILL.md",
+        "amplifier-bundle/agents/specialized/gherkin-expert.md",
+        "known_skills.rs",
+    ];
+    for file in &evidence_files {
+        assert!(
+            doc.contains(file),
+            "Investigation doc must reference evidence file: {file}"
+        );
+    }
+}
+
+#[test]
+fn investigation_doc_has_risks_section() {
+    let doc = read_file("docs/investigations/434-gherkin-v2-experiment-disposition.md");
+    assert!(
+        doc.contains("## 5. Risks Considered"),
+        "Investigation doc must include a Risks section"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Integration: linked from docs/index.md
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn index_links_to_investigation_doc() {
+    let index = read_file("docs/index.md");
+    assert!(
+        index.contains("434-gherkin-v2-experiment-disposition.md"),
+        "docs/index.md must link to the #434 investigation document"
+    );
+}
+
+#[test]
+fn index_link_is_in_investigations_section() {
+    let index = read_file("docs/index.md");
+    let investigations_pos = index.find("### Investigations");
+    let link_pos = index.find("434-gherkin-v2-experiment-disposition.md");
+    assert!(
+        investigations_pos.is_some() && link_pos.is_some(),
+        "Both Investigations section and #434 link must exist in index.md"
+    );
+    assert!(
+        investigations_pos.unwrap() < link_pos.unwrap(),
+        "#434 investigation link should appear after the Investigations section heading"
+    );
+}
+
+#[test]
+fn index_link_has_descriptive_summary() {
+    let index = read_file("docs/index.md");
+    // The index entry should mention both issue number and key conclusion
+    assert!(
+        index.contains("#434") || index.contains("434"),
+        "Index entry must reference issue #434"
+    );
+    assert!(
+        index.contains("gherkin-expert"),
+        "Index entry must mention the gherkin-expert skill"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Regression guard: gherkin-expert skill must remain present
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gherkin_skill_definition_exists() {
+    let path = workspace_root().join("amplifier-bundle/skills/gherkin-expert/SKILL.md");
+    assert!(
+        path.exists(),
+        "amplifier-bundle/skills/gherkin-expert/SKILL.md must exist — \
+         removing it would break the gherkin-expert capability (see #434)"
+    );
+}
+
+#[test]
+fn gherkin_agent_definition_exists() {
+    let path = workspace_root().join("amplifier-bundle/agents/specialized/gherkin-expert.md");
+    assert!(
+        path.exists(),
+        "amplifier-bundle/agents/specialized/gherkin-expert.md must exist — \
+         removing it would break the gherkin-expert capability (see #434)"
+    );
+}
+
+#[test]
+fn known_skills_contains_gherkin_expert() {
+    let src = read_file("crates/amplihack-hooks/src/known_skills.rs");
+    assert!(
+        src.contains("\"gherkin-expert\""),
+        "known_skills.rs must contain \"gherkin-expert\" in the allowlist — \
+         removing it would break skill discovery (see #434 investigation)"
+    );
+}


### PR DESCRIPTION
## Summary

- Closes #434 — documents investigation concluding the upstream `gherkin_v2_experiment_findings.md` needs no port
- The gherkin-expert skill already ships in `amplifier-bundle/` (SKILL.md + agent + `known_skills.rs` entry)
- No code changes: the `"gherkin-expert"` entry in `known_skills.rs` is valid and must stay

## Changes

- `docs/investigations/434-gherkin-v2-experiment-disposition.md` — investigation document with evidence table and decision rationale
- `docs/index.md` — added link under Investigations section
- `tests/integration/gherkin_investigation_doc_test.rs` — 13 tests: doc structure (7), index integration (3), regression guards (3)
- `bins/amplihack/Cargo.toml` — registered test target

## Test plan

- [x] All 13 `gherkin_investigation_doc` tests pass locally
- [x] `cargo fmt` and `cargo clippy` clean
- [x] No source code modified — zero regression risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)