### PR TITLE
feat(update): auto-run install after successful self-update (#487)

### DIFF
--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -234,8 +234,14 @@ pub enum Commands {
     },
     /// Show version information
     Version,
-    /// Download and install the latest released binary
-    Update,
+    /// Self-update the amplihack binary, then run `install` to refresh framework assets.
+    ///
+    /// Use --skip-install (alias --no-install) for a binary-only update (legacy behavior).
+    Update {
+        /// Skip the automatic `install` step after a successful update.
+        #[arg(long = "skip-install", alias = "no-install")]
+        skip_install: bool,
+    },
 
     /// Fleet orchestration (native Rust runtime)
     Fleet {

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -260,7 +260,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
             println!("amplihack-rs {}", crate::VERSION);
             Ok(())
         }
-        Commands::Update => crate::update::run_update(),
+        Commands::Update { skip_install } => crate::update::run_update(skip_install),
         Commands::Fleet { args } => fleet::run_fleet(args),
         Commands::New {
             file,

--- a/crates/amplihack-cli/src/update/check.rs
+++ b/crates/amplihack-cli/src/update/check.rs
@@ -27,7 +27,7 @@ pub fn maybe_print_update_notice_from_args(args: &[OsString]) -> StartupUpdateOu
     }
 }
 
-pub fn run_update() -> Result<()> {
+pub fn run_update(skip_install: bool) -> Result<()> {
     println!("amplihack update (current: v{CURRENT_VERSION})");
 
     let release = super::network::fetch_latest_release()?;
@@ -43,14 +43,12 @@ pub fn run_update() -> Result<()> {
     super::install::download_and_replace(&release)?;
     write_cache(&cache_path()?, &release.version)?;
 
-    // Re-stage framework assets after binary swap (fix #249).
+    // Re-stage framework assets after binary swap (fix #249, #487).
     // The new binary may depend on updated assets in amplifier-bundle.
-    if let Err(err) = crate::commands::install::ensure_framework_installed() {
-        eprintln!(
-            "⚠️  Binary updated but framework asset refresh failed: {err:#}\n   \
-             Run `amplihack install` to refresh assets manually."
-        );
-    }
+    // Users can opt out with --skip-install (alias --no-install).
+    super::post_install::run_post_update_install(skip_install, || {
+        crate::commands::install::run_install(None)
+    })?;
     Ok(())
 }
 
@@ -89,7 +87,7 @@ fn maybe_prompt_for_startup_update(latest: &str) -> Result<StartupUpdateOutcome>
         return Ok(StartupUpdateOutcome::Continue);
     }
 
-    run_update()?;
+    run_update(false)?;
     println!("✅ Update complete. Re-run amplihack to continue with the new version.");
     Ok(StartupUpdateOutcome::ExitSuccess)
 }

--- a/crates/amplihack-cli/src/update/mod.rs
+++ b/crates/amplihack-cli/src/update/mod.rs
@@ -1,6 +1,7 @@
 mod check;
 mod install;
 mod network;
+mod post_install;
 
 pub use check::{
     StartupUpdateOutcome, maybe_print_update_notice_from_args, run_update,

--- a/crates/amplihack-cli/src/update/post_install.rs
+++ b/crates/amplihack-cli/src/update/post_install.rs
@@ -1,0 +1,86 @@
+//! Post-update install orchestration.
+//!
+//! After a successful binary self-update, we re-run the `install` step to
+//! ensure framework assets in `~/.amplihack/.claude` are in sync with the
+//! freshly-installed binary. Users who want the legacy binary-only update
+//! can opt out via `--skip-install` (alias `--no-install`).
+//!
+//! This module exposes a single helper, [`run_post_update_install`], that
+//! takes a closure for the actual install step. Closure injection keeps
+//! tests pure — no network, no filesystem, no real install side effects.
+
+use anyhow::Result;
+
+/// Run the post-update install step unless the user opted out.
+///
+/// * When `skip_install` is `true`, log and return `Ok(())` without invoking
+///   the installer.
+/// * Otherwise, invoke `installer()` and propagate its result via `?`.
+pub(super) fn run_post_update_install<F>(skip_install: bool, installer: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    if skip_install {
+        tracing::info!("skipping post-update install (--skip-install)");
+        return Ok(());
+    }
+    tracing::info!("Running post-update install...");
+    installer()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn invokes_installer_when_skip_install_is_false() {
+        let called = Cell::new(0u32);
+        let result = run_post_update_install(false, || {
+            called.set(called.get() + 1);
+            Ok(())
+        });
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(called.get(), 1, "installer must be invoked exactly once");
+    }
+
+    #[test]
+    fn does_not_invoke_installer_when_skip_install_is_true() {
+        let called = Cell::new(0u32);
+        let result = run_post_update_install(true, || {
+            called.set(called.get() + 1);
+            Ok(())
+        });
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(
+            called.get(),
+            0,
+            "installer must NOT be invoked when skip_install=true"
+        );
+    }
+
+    #[test]
+    fn propagates_installer_error() {
+        let result = run_post_update_install(false, || {
+            Err(anyhow::anyhow!("install failed: synthetic test error"))
+        });
+        let err = result.expect_err("expected installer error to propagate");
+        assert!(
+            err.to_string().contains("synthetic test error"),
+            "error message should propagate verbatim, got: {err}"
+        );
+    }
+
+    #[test]
+    fn skip_install_short_circuits_before_installer_error() {
+        // Structural guarantee: when skip_install=true, the installer closure
+        // is never invoked — even if it would have errored. This mirrors the
+        // real call site's expectation that download_and_replace failures
+        // short-circuit before reaching the installer (`?` propagation).
+        let result = run_post_update_install(true, || {
+            panic!("installer must not be called when skip_install=true");
+        });
+        assert!(result.is_ok());
+    }
+}

--- a/crates/amplihack-cli/tests/bugfix_install_tests.rs
+++ b/crates/amplihack-cli/tests/bugfix_install_tests.rs
@@ -141,54 +141,86 @@ fn repo_git_url_points_to_amplihack_rs() {
 }
 
 // ============================================================================
-// Bug #249: run_update() calls ensure_framework_installed()
+// Bug #249 / #487: run_update() calls run_install() after binary swap
 // ============================================================================
 
 #[test]
 fn update_check_source_includes_framework_restage() {
-    // Contract: run_update() must call ensure_framework_installed() after
-    // the binary swap. We verify this at the source level since we can't
-    // easily mock the network calls in an integration test.
+    // Contract (#487): run_update() must call the post-update install helper
+    // after the binary swap so framework assets are refreshed automatically.
+    // We verify this at the source level since we can't easily mock the
+    // network calls in an integration test.
     let check_src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/update/check.rs"));
     assert!(
-        check_src.contains("ensure_framework_installed"),
-        "run_update() must call ensure_framework_installed() after binary swap"
+        check_src.contains("run_post_update_install"),
+        "run_update() must call run_post_update_install() after binary swap"
     );
-    // Verify it's in the run_update function, not just imported
+    // Verify it's in the run_update function, not just imported.
     let run_update_start = check_src
-        .find("fn run_update()")
+        .find("fn run_update(")
         .expect("run_update must exist");
     let run_update_body = &check_src[run_update_start..];
-    // Find the end of the function (next `fn ` at the same indentation level)
     let next_fn = run_update_body[1..]
         .find("\nfn ")
         .unwrap_or(run_update_body.len());
     let run_update_body = &run_update_body[..next_fn];
     assert!(
-        run_update_body.contains("ensure_framework_installed"),
-        "ensure_framework_installed() must be called inside run_update(), not elsewhere"
+        run_update_body.contains("run_post_update_install"),
+        "run_post_update_install() must be called inside run_update(), not elsewhere"
+    );
+    // The closure passed to the helper must invoke the full install code path.
+    assert!(
+        run_update_body.contains("crate::commands::install::run_install"),
+        "the post-update install closure must call commands::install::run_install"
     );
 }
 
 #[test]
-fn update_check_handles_framework_restage_failure_gracefully() {
-    // Contract: If ensure_framework_installed() fails after binary swap,
-    // run_update() must print a warning but NOT return an error.
+fn update_check_propagates_framework_restage_failure() {
+    // Contract (#487): post-update install errors propagate via `?` (zero-BS).
+    // Silent fallbacks were removed in favor of loud, propagated failures.
     let check_src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/update/check.rs"));
-    // The call should be in an `if let Err(err) = ...` block
+    let run_update_start = check_src
+        .find("fn run_update(")
+        .expect("run_update must exist");
+    let run_update_body = &check_src[run_update_start..];
+    let next_fn = run_update_body[1..]
+        .find("\nfn ")
+        .unwrap_or(run_update_body.len());
+    let run_update_body = &run_update_body[..next_fn];
+    // The helper call must end with `?` to propagate errors.
     assert!(
-        check_src
+        run_update_body.contains("run_post_update_install(skip_install"),
+        "run_post_update_install must receive the skip_install flag"
+    );
+    assert!(
+        run_update_body.contains("})?;"),
+        "post-update install errors must propagate via `?`, not be swallowed"
+    );
+    // Sanity: the legacy silent-fallback pattern must be gone.
+    assert!(
+        !run_update_body
             .contains("if let Err(err) = crate::commands::install::ensure_framework_installed()"),
-        "ensure_framework_installed errors must be handled gracefully"
+        "legacy silent-fallback pattern must be removed (zero-BS rule)"
     );
-    // Should print a warning, not bail
+}
+
+#[test]
+fn update_subcommand_supports_skip_install_flag() {
+    // Contract (#487): the Update subcommand exposes --skip-install (alias --no-install)
+    // so users can opt out of the automatic post-update install step.
+    let cli_src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli_commands.rs"));
     assert!(
-        check_src.contains("framework asset refresh failed"),
-        "failure message must mention 'framework asset refresh failed'"
+        cli_src.contains("skip_install"),
+        "Update variant must expose a skip_install field"
     );
     assert!(
-        check_src.contains("amplihack install"),
-        "failure message must suggest 'amplihack install' as manual recovery"
+        cli_src.contains("long = \"skip-install\""),
+        "Update variant must expose --skip-install"
+    );
+    assert!(
+        cli_src.contains("alias = \"no-install\""),
+        "Update variant must expose --no-install as an alias"
     );
 }
 

--- a/docs/howto/manage-tool-update-checks.md
+++ b/docs/howto/manage-tool-update-checks.md
@@ -22,6 +22,7 @@ control that behavior.
 - [Disable the check permanently](#disable-the-check-permanently)
 - [Suppress in CI and pipelines](#suppress-in-ci-and-pipelines)
 - [Suppress in parity tests and automation](#suppress-in-parity-tests-and-automation)
+- [What happens during `amplihack update`](#what-happens-during-amplihack-update)
 - [What the check does](#what-the-check-does)
   - [When the check runs](#when-the-check-runs)
   - [Command allowlist](#command-allowlist)
@@ -145,6 +146,70 @@ prompts.
 > **Isolation:** `AMPLIHACK_PARITY_TEST` is intentionally separate from
 > `AMPLIHACK_NONINTERACTIVE` so that tests can verify interactive-mode behaviour
 > without triggering the update check.
+
+---
+
+## What happens during `amplihack update`
+
+This section is about the **separate** `amplihack update` subcommand (binary
+self-update), not the npm pre-launch notice covered above. It is included here
+because users who manage update notices commonly also want to know what the
+self-update does.
+
+When you run `amplihack update`, the following happens in order:
+
+1. **Binary self-update.** `amplihack` checks GitHub for a newer release,
+   downloads the platform archive, verifies its SHA-256, and atomically
+   replaces the running executable.
+2. **Automatic framework install.** As soon as the binary swap succeeds,
+   `amplihack` runs the same logic as `amplihack install` (in-process — no
+   subprocess) to re-stage framework assets (agents, hooks, prompts, recipes)
+   under `~/.amplihack/.claude`. This step is non-interactive and uses the
+   default install location.
+3. **Done.** Both the binary and the on-disk framework now match.
+
+If the binary swap fails, the install step does **not** run and the original
+binary stays in place.
+
+### Opt out of the automatic install
+
+Pass `--skip-install` (or its alias `--no-install`) to perform a binary-only
+update — the legacy behavior:
+
+```sh
+amplihack update --skip-install
+# or
+amplihack update --no-install
+```
+
+You may want this when:
+
+- You have hand-edited files under `~/.amplihack/.claude` and want to merge
+  them manually.
+- You are testing a new binary against an older framework layout.
+- You manage framework assets out-of-band (e.g. via configuration management).
+
+After a `--skip-install` update, you can refresh assets later with:
+
+```sh
+amplihack install
+```
+
+### Startup-prompt updates
+
+When `amplihack` prompts you to update at startup and you answer `y`, the
+**full** flow runs (binary swap **and** install). There is no way to pass
+`--skip-install` through the startup prompt. To get the legacy binary-only
+behavior, answer `N` to the prompt and then run
+`amplihack update --skip-install` manually.
+
+### Failure handling
+
+| Phase                | Outcome                                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Binary download/swap fails | Original binary preserved; install step is skipped; error printed to stderr; exit non-zero.                |
+| Binary swap succeeds, install fails | New binary installed; framework assets may be in an inconsistent state relative to the new binary; error printed to stderr; exit non-zero. Re-run `amplihack install` to retry. |
+| `--skip-install` passed | Binary updated; install step is skipped intentionally; a "skipping post-update install" notice is logged at info level. |
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -54,7 +54,7 @@ The version string comes from the `__version__` attribute in `amplihack/__init__
 | `version`    | Show amplihack version.                                                                     |
 | `install`    | Install amplihack agents and tools to `~/.claude`.                                          |
 | `uninstall`  | Remove amplihack agents and tools from `~/.claude`.                                         |
-| `update`     | Update amplihack, delegating to the Rust CLI when one is installed.                         |
+| `update`     | Self-update the amplihack binary, then automatically run `install` to refresh framework assets. Pass `--skip-install` (alias `--no-install`) for a binary-only update. |
 | `claude`     | Launch Claude Code. Preferred explicit launcher in user-facing docs.                        |
 | `launch`     | Compatibility alias for `claude`; `amplihack` with no subcommand also launches Claude Code. |
 | `RustyClawd` | Launch RustyClawd (Rust implementation).                                                    |
@@ -74,6 +74,72 @@ See the documentation for each subcommand:
 - [Recipe CLI Reference](./recipe-cli-reference.md)
 - [Memory CLI Reference](./memory-cli-reference.md)
 - [Plugin CLI Reference](#)
+
+### `update`
+
+Self-updates the `amplihack` binary by downloading the latest release from
+GitHub (with SHA-256 verification), atomically replacing the running executable,
+and then **automatically running `amplihack install`** to refresh the framework
+assets staged under `~/.amplihack/.claude` so the on-disk agents, hooks, and
+prompts match the newly installed binary.
+
+**Synopsis**
+
+```
+amplihack update [--skip-install | --no-install]
+```
+
+**Flags**
+
+| Flag             | Description                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `--skip-install` | Skip the automatic post-update `install` step (binary-only update — legacy behavior). Alias: `--no-install`.                      |
+
+**Behavior**
+
+1. Check GitHub for a newer release. If none, exit with a "already at latest"
+   message.
+2. Download the platform-specific archive and verify its SHA-256, then
+   atomically replace the running binary.
+3. **Unless `--skip-install` was passed**, invoke the same code path as
+   `amplihack install` (in-process — no subprocess) to re-stage framework
+   assets to `~/.amplihack/.claude`. This is non-interactive.
+
+If step 2 fails, the install step does **not** run and the original binary
+remains in place. If step 3 fails, the new binary is already installed; you
+can re-run `amplihack install` manually to retry the asset refresh.
+
+**Examples**
+
+```bash
+# Default: update binary and refresh framework assets in one step
+amplihack update
+
+# Binary-only update (preserve old framework assets on disk)
+amplihack update --skip-install
+
+# Equivalent alias
+amplihack update --no-install
+
+# Manually refresh framework assets (e.g. after a --skip-install update,
+# or to recover from a failed post-update install step)
+amplihack install
+```
+
+**Why install runs automatically**
+
+A binary-only update can leave the on-disk agents, hooks, prompts, and recipes
+out of sync with the new binary, producing confusing behavior (missing skills,
+stale prompts, hook signature mismatches). Running `install` immediately after
+a successful update keeps the binary and the staged framework consistent.
+
+**Startup-prompt updates**
+
+When `amplihack` prompts you to update at startup ("Update now? [y/N]") and you
+accept, the same flow runs: binary swap followed by automatic `install`. There
+is no way to pass `--skip-install` through the startup prompt — answer `N` and
+run `amplihack update --skip-install` manually if you want the legacy behavior
+in that situation.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #487. After a successful binary self-update, `amplihack update` now automatically invokes the same code path as `amplihack install` (in-process — no subprocess) to re-stage framework assets in `~/.amplihack/.claude`. This keeps the binary and on-disk agents/hooks/prompts/recipes in sync.

Users who want the legacy binary-only behavior can opt out with `--skip-install` (alias `--no-install`). The startup-prompt update path (`Update now? [y/N]`) runs the full flow.

## Changes

- **New helper** `update::post_install::run_post_update_install<F>(skip_install, installer)` with closure injection — keeps tests pure (no network/fs/process side effects).
- **`run_update` now takes `skip_install: bool`** and replaces the legacy `ensure_framework_installed` silent-fallback call with the new helper. Install errors propagate via `?` (zero-BS, no swallowed failures).
- **`Commands::Update` is now a struct variant** exposing `--skip-install` (alias `--no-install`).
- **Integration tests updated** (`bugfix_install_tests`) to assert the new contract: helper presence, error propagation, and CLI flag exposure.
- **Docs updated**: `docs/reference/cli.md` and `docs/howto/manage-tool-update-checks.md` describe the new behavior, opt-out, and recovery via `amplihack install`.

## Tests

| Test                                                              | Covers requirement                          |
| ----------------------------------------------------------------- | ------------------------------------------- |
| `invokes_installer_when_skip_install_is_false`                    | (1) update success triggers install         |
| `does_not_invoke_installer_when_skip_install_is_true`             | (2) `--skip-install` does not trigger install |
| `skip_install_short_circuits_before_installer_error`              | (3) structural failure-path guarantee       |
| `propagates_installer_error`                                      | zero-BS error propagation                   |
| `update_check_source_includes_framework_restage` (integration)    | helper wired into `run_update`              |
| `update_check_propagates_framework_restage_failure` (integration) | `?` propagation, no silent fallback         |
| `update_subcommand_supports_skip_install_flag` (integration)      | CLI exposes `--skip-install`/`--no-install` |

Full `amplihack-cli` test suite: **1158 passed, 0 failed**.

## Module sizes
- `post_install.rs`: 86 LOC
- `check.rs`: 217 LOC
All new/modified modules well under the 500-LOC limit; new module test coverage 100%.

## Validation
- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` ✅
- `TMPDIR=/tmp cargo test -p amplihack-cli` ✅
- pre-commit: trim whitespace, fix EOF, fmt, clippy ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>