### PR TITLE
feat: default agent binary to copilot, config-driven via launcher_context.json (#489)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "amplihack-hive",
  "amplihack-state",
  "amplihack-types",
+ "amplihack-utils",
  "anyhow",
  "chrono",
  "clap",
@@ -227,6 +228,7 @@ dependencies = [
  "amplihack-security",
  "amplihack-state",
  "amplihack-types",
+ "amplihack-utils",
  "amplihack-workflows",
  "anyhow",
  "regex",
@@ -235,6 +237,7 @@ dependencies = [
  "sha2",
  "shell-words",
  "tempfile",
+ "thiserror",
  "tracing",
 ]
 
@@ -394,6 +397,7 @@ dependencies = [
 name = "amplihack-workflows"
 version = "0.8.0"
 dependencies = [
+ "amplihack-utils",
  "chrono",
  "serde",
  "serde_json",

--- a/amplifier-bundle/skills/migrate/scripts/migrate.sh
+++ b/amplifier-bundle/skills/migrate/scripts/migrate.sh
@@ -79,11 +79,45 @@ done
 #   3. newest session-state dir for the active CLI
 #   4. error
 detect_cli() {
+  # Resolution precedence (matches Rust resolver, issue #489):
+  #   1. AMPLIHACK_AGENT_BINARY env var (allowlist-validated)
+  #   2. .claude/runtime/launcher_context.json walked up from cwd
+  #   3. parent process chain for a known binary
+  #   4. default: copilot
+  local allowed_re='^(amplifier|claude|codex|copilot)$'
   if [[ -n "${AMPLIHACK_AGENT_BINARY:-}" ]]; then
-    echo "$AMPLIHACK_AGENT_BINARY"
-    return
+    local override
+    override="$(printf '%s' "${AMPLIHACK_AGENT_BINARY}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+    if [[ "$override" =~ $allowed_re ]]; then
+      echo "$override"
+      return
+    fi
   fi
-  # Fallback: look at the parent process chain for a known binary.
+  local cur="$PWD"
+  local hops=0
+  while [[ -n "$cur" && "$cur" != "/" && $hops -lt 32 ]]; do
+    local ctx="$cur/.claude/runtime/launcher_context.json"
+    if [[ -f "$ctx" ]]; then
+      local parsed
+      parsed="$(python3 -c 'import json,sys;import os
+try:
+  d=json.load(open(sys.argv[1]))
+  v=d.get("launcher")
+  if isinstance(v,str):
+    v=v.strip().lower()
+    if v in {"amplifier","claude","codex","copilot"}:
+      print(v)
+except Exception:
+  pass' "$ctx" 2>/dev/null || true)"
+      if [[ -n "$parsed" ]]; then
+        echo "$parsed"
+        return
+      fi
+      break
+    fi
+    cur="$(dirname "$cur")"
+    hops=$((hops + 1))
+  done
   local pid="$PPID"
   while [[ -n "$pid" && "$pid" != "1" ]]; do
     local cmd
@@ -95,7 +129,7 @@ detect_cli() {
     esac
     pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
   done
-  echo unknown
+  echo copilot
 }
 
 detect_session_id() {

--- a/amplifier-bundle/skills/pm-architect/scripts/agent_query.py
+++ b/amplifier-bundle/skills/pm-architect/scripts/agent_query.py
@@ -54,31 +54,63 @@ class AgentQueryError(RuntimeError):
     """Raised when PM Architect cannot query any supported agent SDK."""
 
 
+def _read_launcher_from_context_file(start: Path) -> str | None:
+    """Walk up from ``start`` for ``.claude/runtime/launcher_context.json``.
+
+    Returns the validated ``launcher`` value, or ``None`` when missing or
+    invalid.
+    """
+    import json
+
+    allowed = {"amplifier", "claude", "codex", "copilot"}
+    cur: Path | None = start.resolve() if start.exists() else None
+    hops = 0
+    while cur is not None and hops < 32:
+        candidate = cur / ".claude" / "runtime" / "launcher_context.json"
+        if candidate.is_file():
+            try:
+                data = json.loads(candidate.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                return None
+            value = data.get("launcher") if isinstance(data, dict) else None
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized in allowed:
+                    return normalized
+            return None
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+        hops += 1
+    return None
+
+
 def detect_runtime() -> str:
     """Detect which agent runtime is active.
 
+    Resolution precedence:
+      1. ``AMPLIHACK_AGENT_BINARY`` env var (allowlisted: amplifier/claude/codex/copilot)
+      2. ``.claude/runtime/launcher_context.json`` (walked up from cwd)
+      3. Default: ``"copilot"``
+
     Returns:
-        "copilot", "claude", or "unknown"
+        "copilot", "claude", "codex", "amplifier", or "unknown"
     """
-    # 1. Explicit env var (set by amplihack CLI launcher)
+    allowed = {"amplifier", "claude", "codex", "copilot"}
+
+    # 1. Explicit env var (allowlist-validated).
     agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY", "").strip().lower()
-    if agent_binary in ("copilot", "claude"):
+    if agent_binary in allowed:
         return agent_binary
 
-    # 2. LauncherDetector (reads runtime context file)
-    try:
-        from amplihack.context.adaptive.detector import LauncherDetector
+    # 2. Persisted launcher context (canonical state — survives subprocess
+    #    boundaries without env passthrough).
+    from_file = _read_launcher_from_context_file(Path.cwd())
+    if from_file is not None:
+        return from_file
 
-        return LauncherDetector(Path.cwd()).detect()
-    except Exception:
-        pass
-
-    # 3. Fallback: infer from available SDKs
-    if _COPILOT_SDK_OK and not _CLAUDE_SDK_OK:
-        return "copilot"
-    if _CLAUDE_SDK_OK:
-        return "claude"
-    return "unknown"
+    # 3. Default to copilot when no signal is present (issue #489).
+    return "copilot"
 
 
 async def query_agent(prompt: str, project_root: Path) -> str:

--- a/amplifier-bundle/skills/pm-architect/scripts/delegate_response.py
+++ b/amplifier-bundle/skills/pm-architect/scripts/delegate_response.py
@@ -100,15 +100,14 @@ def run_auto_mode_delegation(
         Tuple of (success: bool, output: str)
     """
     try:
-        # Run amplihack auto mode with the active agent binary
-        agent_binary = os.environ.get("AMPLIHACK_AGENT_BINARY")
-        if not agent_binary:
-            import logging
+        # Run amplihack auto mode with the active agent binary, resolved using
+        # the same precedence as the Rust resolver (env -> launcher_context.json
+        # -> "copilot"). Defaults to "copilot" per issue #489.
+        from agent_query import detect_runtime  # type: ignore[import-not-found]
 
-            logging.getLogger(__name__).warning(
-                "AMPLIHACK_AGENT_BINARY not set, defaulting to 'claude'"
-            )
-            agent_binary = "claude"
+        agent_binary = detect_runtime()
+        if agent_binary not in {"amplifier", "claude", "codex", "copilot"}:
+            agent_binary = "copilot"
         cmd = [
             "amplihack",
             agent_binary,

--- a/crates/amplihack-cli/Cargo.toml
+++ b/crates/amplihack-cli/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 amplihack-hive = { path = "../amplihack-hive" }
 amplihack-types = { workspace = true }
 amplihack-state = { workspace = true }
+amplihack-utils = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = "4"

--- a/crates/amplihack-cli/src/env_builder/agent_binary_resolver.rs
+++ b/crates/amplihack-cli/src/env_builder/agent_binary_resolver.rs
@@ -1,0 +1,64 @@
+//! CLI-side thin wrapper around [`amplihack_utils::agent_binary::resolve`].
+//!
+//! The resolver lives in `amplihack-utils` so that every crate (CLI, hooks,
+//! workflows, utils) reaches the same single source of truth. This module
+//! exists so CLI consumers can write
+//!
+//! ```ignore
+//! use amplihack_cli::env_builder::agent_binary_resolver;
+//! let binary = agent_binary_resolver::resolve(&cwd);
+//! ```
+//!
+//! …without taking a direct dependency on the utils-internal API surface
+//! beyond what the documented contract specifies.
+//!
+//! Resolution precedence (issue #489):
+//!   1. `AMPLIHACK_AGENT_BINARY` env var (allowlist-validated)
+//!   2. `<repo>/.claude/runtime/launcher_context.json` `launcher` field
+//!   3. Default: `"copilot"`
+
+use std::path::Path;
+
+use amplihack_utils::agent_binary;
+
+/// Resolve the active agent binary for `cwd` using the canonical precedence.
+///
+/// Always returns an allowlisted binary name (one of `amplifier`, `claude`,
+/// `codex`, `copilot`). Invalid env var values, unreadable launcher context
+/// files, and bogus payloads all fall through to the default `"copilot"`.
+pub fn resolve(cwd: &Path) -> String {
+    match agent_binary::resolve(cwd) {
+        Ok(name) => name,
+        Err(err) => {
+            tracing::warn!(error = %err, "agent_binary resolver failed; falling back to default");
+            agent_binary::DEFAULT_BINARY.to_string()
+        }
+    }
+}
+
+/// Return the built-in default binary name (`"copilot"`).
+pub fn default_binary() -> &'static str {
+    agent_binary::DEFAULT_BINARY
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_copilot() {
+        assert_eq!(default_binary(), "copilot");
+    }
+
+    #[test]
+    fn resolve_returns_allowlisted_value() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Without env override or launcher context file, the result must be
+        // the built-in default.
+        let result = resolve(tmp.path());
+        assert!(
+            agent_binary::ALLOWED_BINARIES.contains(&result.as_str()),
+            "resolver returned non-allowlisted binary: {result}"
+        );
+    }
+}

--- a/crates/amplihack-cli/src/env_builder/helpers.rs
+++ b/crates/amplihack-cli/src/env_builder/helpers.rs
@@ -2,60 +2,26 @@ use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 
-const CLAUDE_PREFIX: &str = "CLAUDE_CODE_";
-const CODEX_PREFIX: &str = "CODEX_";
-
-fn env_nonempty(key: &str) -> bool {
-    matches!(env::var(key), Ok(v) if !v.trim().is_empty())
-}
-
-fn any_prefix_nonempty(prefix: &str) -> bool {
-    for (k, v) in env::vars_os() {
-        let Some(k) = k.to_str() else { continue };
-        if k.starts_with(prefix)
-            && let Some(v) = v.to_str()
-            && !v.trim().is_empty()
-        {
-            return true;
+/// Resolves which agent binary identifier the current process is operating
+/// under. Delegates to [`amplihack_utils::agent_binary::resolve`], which
+/// applies the precedence:
+///
+/// 1. `AMPLIHACK_AGENT_BINARY` env var (explicit override).
+/// 2. `<cwd-or-ancestor>/.claude/runtime/launcher_context.json`.
+/// 3. Built-in default `"copilot"`.
+///
+/// Always returns an allowlisted name (`claude`, `copilot`, `codex`, or
+/// `amplifier`). Unknown / dangerous overrides silently fall through to the
+/// next layer — they never reach `Command::new`.
+pub fn active_agent_binary() -> String {
+    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    match amplihack_utils::agent_binary::resolve(&cwd) {
+        Ok(name) => name,
+        Err(err) => {
+            tracing::warn!(error = %err, "agent binary resolver failed; using built-in default");
+            amplihack_utils::agent_binary::DEFAULT_BINARY.to_string()
         }
     }
-    false
-}
-
-/// Resolves which agent binary identifier the current process is operating under.
-///
-/// Detection priority:
-/// 1. `AMPLIHACK_AGENT_BINARY` (non-empty after trim) — explicit override.
-/// 2. `COPILOT_AGENT_SESSION_ID` (non-empty) → `"copilot"`.
-/// 3. `CLAUDECODE` or any `CLAUDE_CODE_*` env var (non-empty) → `"claude"`.
-/// 4. `CODEX_HOME` or any `CODEX_*` env var (non-empty) → `"codex"`.
-/// 5. Fallback → emit a warning and return `"claude"`.
-///
-/// The override value is **untrusted user input** — callers must allowlist or
-/// otherwise validate it before using it as a `Command::new` target.
-pub fn active_agent_binary() -> String {
-    if let Ok(value) = env::var("AMPLIHACK_AGENT_BINARY")
-        && !value.trim().is_empty()
-    {
-        return value;
-    }
-
-    if env_nonempty("COPILOT_AGENT_SESSION_ID") {
-        return "copilot".to_string();
-    }
-
-    if env_nonempty("CLAUDECODE") || any_prefix_nonempty(CLAUDE_PREFIX) {
-        return "claude".to_string();
-    }
-
-    if env_nonempty("CODEX_HOME") || any_prefix_nonempty(CODEX_PREFIX) {
-        return "codex".to_string();
-    }
-
-    tracing::warn!(
-        "AMPLIHACK_AGENT_BINARY not set; defaulting to 'claude'. This usually means a subprocess was launched outside the amplihack CLI dispatcher."
-    );
-    "claude".to_string()
 }
 
 pub(super) fn find_asset_resolver_binary() -> Option<PathBuf> {

--- a/crates/amplihack-cli/src/env_builder/mod.rs
+++ b/crates/amplihack-cli/src/env_builder/mod.rs
@@ -4,8 +4,9 @@
 //! including AMPLIHACK_* vars and PATH augmentation. Uses set-based
 //! PATH deduplication instead of error-prone substring matching.
 
+pub mod agent_binary_resolver;
 mod builder;
-mod helpers;
+pub mod helpers;
 
 pub use builder::EnvBuilder;
 pub use helpers::active_agent_binary;

--- a/crates/amplihack-cli/src/env_builder/tests_builder.rs
+++ b/crates/amplihack-cli/src/env_builder/tests_builder.rs
@@ -435,104 +435,82 @@ fn lock_agent_env() -> std::sync::MutexGuard<'static, ()> {
         .unwrap_or_else(|p| p.into_inner())
 }
 
-/// Issue #441: explicit AMPLIHACK_AGENT_BINARY override beats any runtime
-/// signal — including when copilot/claude/codex env vars are also present.
+/// Issue #489: explicit AMPLIHACK_AGENT_BINARY override (allowlisted value)
+/// beats any other signal.
 #[test]
 fn override_wins_over_runtime_signals() {
     let _guard = lock_agent_env();
     let _snap = EnvSnapshot::scrub_all();
 
-    unsafe { env::set_var("AMPLIHACK_AGENT_BINARY", "custom") };
+    unsafe { env::set_var("AMPLIHACK_AGENT_BINARY", "claude") };
     unsafe { env::set_var("COPILOT_AGENT_SESSION_ID", "abc123") };
-    unsafe { env::set_var("CLAUDECODE", "1") };
-    unsafe { env::set_var("CODEX_HOME", "/x") };
 
-    assert_eq!(active_agent_binary(), "custom");
+    assert_eq!(active_agent_binary(), "claude");
 }
 
-/// Issue #441: COPILOT_AGENT_SESSION_ID alone -> "copilot".
+/// Issue #489: AMPLIHACK_AGENT_BINARY="copilot" returns "copilot".
 #[test]
 fn detects_copilot_via_session_id() {
     let _guard = lock_agent_env();
     let _snap = EnvSnapshot::scrub_all();
 
-    unsafe { env::set_var("COPILOT_AGENT_SESSION_ID", "session-xyz") };
+    unsafe { env::set_var("AMPLIHACK_AGENT_BINARY", "copilot") };
 
     assert_eq!(active_agent_binary(), "copilot");
 }
 
-/// Issue #441: CLAUDECODE set OR any CLAUDE_CODE_* prefix set -> "claude".
+/// Issue #489: AMPLIHACK_AGENT_BINARY="claude" selects claude.
 #[test]
 fn detects_claude_via_claudecode_or_prefix() {
-    // Sub-case 1: CLAUDECODE exact match
-    {
-        let _guard = lock_agent_env();
-        let _snap = EnvSnapshot::scrub_all();
-        unsafe { env::set_var("CLAUDECODE", "1") };
-        assert_eq!(
-            active_agent_binary(),
-            "claude",
-            "CLAUDECODE should select claude"
-        );
-    }
-    // Sub-case 2: CLAUDE_CODE_* prefix match
-    {
-        let _guard = lock_agent_env();
-        let _snap = EnvSnapshot::scrub_all();
-        unsafe { env::set_var("CLAUDE_CODE_SESSION", "x") };
-        assert_eq!(
-            active_agent_binary(),
-            "claude",
-            "CLAUDE_CODE_* prefix should select claude"
-        );
-    }
+    let _guard = lock_agent_env();
+    let _snap = EnvSnapshot::scrub_all();
+    unsafe { env::set_var("AMPLIHACK_AGENT_BINARY", "claude") };
+    assert_eq!(active_agent_binary(), "claude");
 }
 
-/// Issue #441: CODEX_HOME set OR any CODEX_* prefix set -> "codex".
+/// Issue #489: AMPLIHACK_AGENT_BINARY="codex" selects codex.
 #[test]
 fn detects_codex_via_home_or_prefix() {
-    // Sub-case 1: CODEX_HOME exact match
-    {
-        let _guard = lock_agent_env();
-        let _snap = EnvSnapshot::scrub_all();
-        unsafe { env::set_var("CODEX_HOME", "/opt/codex") };
-        assert_eq!(
-            active_agent_binary(),
-            "codex",
-            "CODEX_HOME should select codex"
-        );
-    }
-    // Sub-case 2: CODEX_* prefix match (not CODEX_HOME)
-    {
-        let _guard = lock_agent_env();
-        let _snap = EnvSnapshot::scrub_all();
-        unsafe { env::set_var("CODEX_SESSION_ID", "x") };
-        assert_eq!(
-            active_agent_binary(),
-            "codex",
-            "CODEX_* prefix should select codex"
-        );
-    }
+    let _guard = lock_agent_env();
+    let _snap = EnvSnapshot::scrub_all();
+    unsafe { env::set_var("AMPLIHACK_AGENT_BINARY", "codex") };
+    assert_eq!(active_agent_binary(), "codex");
 }
 
-/// Issue #441: when no detection vars are set, fall back to "claude" with warn.
+/// Issue #489: when no override and no launcher_context.json, default is
+/// "copilot" (was "claude").
 #[test]
 fn fallback_when_nothing_set() {
     let _guard = lock_agent_env();
     let _snap = EnvSnapshot::scrub_all();
 
-    assert_eq!(active_agent_binary(), "claude");
+    let tmp = tempfile::tempdir().unwrap();
+    let prev = env::current_dir().ok();
+    env::set_current_dir(tmp.path()).unwrap();
+
+    assert_eq!(active_agent_binary(), "copilot");
+
+    if let Some(p) = prev {
+        let _ = env::set_current_dir(p);
+    }
 }
 
-/// Issue #441: empty/whitespace-only override is treated as "not set" and
-/// detection logic proceeds (here: copilot via session id).
+/// Issue #489: empty/whitespace-only override is rejected by the resolver and
+/// the default ("copilot") is used.
 #[test]
 fn empty_override_falls_through_to_detection() {
     let _guard = lock_agent_env();
     let _snap = EnvSnapshot::scrub_all();
 
     unsafe { env::set_var("AMPLIHACK_AGENT_BINARY", "   ") };
-    unsafe { env::set_var("COPILOT_AGENT_SESSION_ID", "session") };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let prev = env::current_dir().ok();
+    env::set_current_dir(tmp.path()).unwrap();
 
     assert_eq!(active_agent_binary(), "copilot");
+
+    if let Some(p) = prev {
+        let _ = env::set_current_dir(p);
+    }
 }

--- a/crates/amplihack-cli/src/rust_trial.rs
+++ b/crates/amplihack-cli/src/rust_trial.rs
@@ -124,10 +124,13 @@ pub fn build_trial_env(trial_home: &Path) -> HashMap<String, String> {
         }
     }
 
-    // Forward AMPLIHACK_AGENT_BINARY if set
-    if let Ok(val) = std::env::var("AMPLIHACK_AGENT_BINARY") {
-        env.insert("AMPLIHACK_AGENT_BINARY".to_string(), val);
-    }
+    // Forward the resolved agent binary so subprocesses see it explicitly,
+    // even when their cwd lacks a launcher_context.json. Resolver returns the
+    // canonical (allowlisted, lowercased) name; falls back to "copilot".
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let resolved = amplihack_utils::agent_binary::resolve(&cwd)
+        .unwrap_or_else(|_| amplihack_utils::agent_binary::DEFAULT_BINARY.to_string());
+    env.insert("AMPLIHACK_AGENT_BINARY".to_string(), resolved);
 
     env
 }

--- a/crates/amplihack-cli/tests/active_agent_binary_default_test.rs
+++ b/crates/amplihack-cli/tests/active_agent_binary_default_test.rs
@@ -1,0 +1,41 @@
+//! TDD: Failing tests for `amplihack_cli::env_builder::helpers::active_agent_binary`
+//! after refactor. The helper must delegate to the shared resolver and:
+//! 1. Default to "copilot" when no env, no launcher_context.
+//! 2. Honor `AMPLIHACK_AGENT_BINARY` allowlisted override.
+//! 3. NEVER return "claude" as the unset-env default.
+
+#![allow(clippy::unwrap_used)]
+
+use amplihack_cli::env_builder::helpers::active_agent_binary;
+
+fn clear_env() {
+    unsafe {
+        std::env::remove_var("AMPLIHACK_AGENT_BINARY");
+    }
+}
+fn set_env(v: &str) {
+    unsafe {
+        std::env::set_var("AMPLIHACK_AGENT_BINARY", v);
+    }
+}
+
+#[test]
+fn default_is_copilot_not_claude() {
+    clear_env();
+    let v = active_agent_binary();
+    assert_eq!(v, "copilot", "default flipped from claude to copilot");
+}
+
+#[test]
+fn explicit_claude_override_still_works() {
+    set_env("claude");
+    assert_eq!(active_agent_binary(), "claude");
+    clear_env();
+}
+
+#[test]
+fn rejected_override_falls_back_to_copilot() {
+    set_env("not-a-real-binary");
+    assert_eq!(active_agent_binary(), "copilot");
+    clear_env();
+}

--- a/crates/amplihack-hooks/Cargo.toml
+++ b/crates/amplihack-hooks/Cargo.toml
@@ -11,9 +11,11 @@ amplihack-state = { workspace = true }
 amplihack-cli = { workspace = true }
 amplihack-security = { workspace = true }
 amplihack-workflows = { workspace = true }
+amplihack-utils = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 shell-words = { workspace = true }
 regex = "1"

--- a/crates/amplihack-hooks/src/binary_hook_resolver.rs
+++ b/crates/amplihack-hooks/src/binary_hook_resolver.rs
@@ -1,0 +1,146 @@
+//! Per-binary hook resolution with hard-error semantics.
+//!
+//! Looks up the canonical hook file path for an `(agent_binary, event)` pair
+//! under `<root>/<binary>/hooks/<EventName>.py`. When the hook is missing the
+//! resolver returns a structured [`HookError::MissingHookForBinary`] — never a
+//! silent fallback to another binary's hook, never a stub-file write.
+//!
+//! ## Security
+//!
+//! * The `binary` parameter is allowlisted via [`amplihack_utils::agent_binary::validate_binary_name`]
+//!   so callers cannot pass `..`, paths, or arbitrary names.
+//! * The constructed path is purely relative-join under the caller-supplied
+//!   `root`; no globs, no symlink following at construct time.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// All hook event variants that the amplihack runtime understands. The
+/// `filename_stem()` matches the on-disk filename (without `.py` extension).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookEvent {
+    PreToolUse,
+    PostToolUse,
+    Stop,
+    SessionStart,
+    SessionEnd,
+    SessionStop,
+    UserPromptSubmit,
+    PreCompact,
+}
+
+impl HookEvent {
+    /// Canonical filename stem (no extension) for this event.
+    pub fn filename_stem(self) -> &'static str {
+        match self {
+            HookEvent::PreToolUse => "PreToolUse",
+            HookEvent::PostToolUse => "PostToolUse",
+            HookEvent::Stop => "Stop",
+            HookEvent::SessionStart => "SessionStart",
+            HookEvent::SessionEnd => "SessionEnd",
+            HookEvent::SessionStop => "SessionStop",
+            HookEvent::UserPromptSubmit => "UserPromptSubmit",
+            HookEvent::PreCompact => "PreCompact",
+        }
+    }
+}
+
+impl fmt::Display for HookEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.filename_stem())
+    }
+}
+
+/// Errors returned by [`expected_hook_path`] and [`resolve_hook`].
+#[derive(Debug, Error)]
+pub enum HookError {
+    /// `binary` was not on the agent-binary allowlist (e.g. `..`, `bash`,
+    /// `claude/../sh`, empty string).
+    #[error("invalid agent binary name: {0:?}")]
+    InvalidBinary(String),
+
+    /// The hook file is absent for the active binary. NO claude fallback is
+    /// applied — the operator must remediate.
+    #[error(
+        "No {event} hook registered for active agent binary '{binary}'. \
+         Expected at: {expected_display}. To fix: either install the hook, \
+         switch binaries via 'amplihack launch --tool <other>', or set \
+         AMPLIHACK_AGENT_BINARY explicitly. {remediation}"
+    )]
+    MissingHookForBinary {
+        binary: String,
+        event: HookEvent,
+        expected_path: PathBuf,
+        remediation: String,
+        /// Pre-formatted display string (PathBuf does not implement Display).
+        expected_display: String,
+    },
+}
+
+/// Construct the canonical hook path: `<root>/<binary>/hooks/<EventName>.py`.
+///
+/// Returns [`HookError::InvalidBinary`] if `binary` is not on the agent-binary
+/// allowlist (which structurally blocks path-traversal escapes).
+pub fn expected_hook_path(
+    root: &Path,
+    binary: &str,
+    event: HookEvent,
+) -> Result<PathBuf, HookError> {
+    let validated = amplihack_utils::agent_binary::validate_binary_name(binary)
+        .ok_or_else(|| HookError::InvalidBinary(binary.to_string()))?;
+    Ok(root
+        .join(validated)
+        .join("hooks")
+        .join(format!("{}.py", event.filename_stem())))
+}
+
+/// Resolve `(binary, event)` to a concrete hook file path.
+///
+/// Returns the path when the file exists. Returns
+/// [`HookError::MissingHookForBinary`] when it does not — never falls back to
+/// another binary's hook, never creates a stub.
+pub fn resolve_hook(root: &Path, binary: &str, event: HookEvent) -> Result<PathBuf, HookError> {
+    let expected = expected_hook_path(root, binary, event)?;
+    if expected.is_file() {
+        return Ok(expected);
+    }
+    let validated = amplihack_utils::agent_binary::validate_binary_name(binary)
+        .ok_or_else(|| HookError::InvalidBinary(binary.to_string()))?;
+    let remediation = format!(
+        "Install the hook at {}, switch binaries via 'amplihack launch --tool <other>', \
+         or set AMPLIHACK_AGENT_BINARY explicitly.",
+        expected.display()
+    );
+    Err(HookError::MissingHookForBinary {
+        binary: validated,
+        event,
+        expected_display: expected.display().to_string(),
+        expected_path: expected,
+        remediation,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filename_stems_are_canonical() {
+        assert_eq!(HookEvent::PreToolUse.filename_stem(), "PreToolUse");
+        assert_eq!(HookEvent::SessionEnd.filename_stem(), "SessionEnd");
+    }
+
+    #[test]
+    fn display_matches_filename_stem() {
+        assert_eq!(format!("{}", HookEvent::SessionEnd), "SessionEnd");
+    }
+
+    #[test]
+    fn expected_path_rejects_invalid_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = expected_hook_path(tmp.path(), "..", HookEvent::Stop).unwrap_err();
+        assert!(matches!(err, HookError::InvalidBinary(_)));
+    }
+}

--- a/crates/amplihack-hooks/src/lib.rs
+++ b/crates/amplihack-hooks/src/lib.rs
@@ -31,6 +31,8 @@ pub mod workflow_classification;
 /// Fingerprint-based GitHub issue deduplication (R1).
 pub mod issue_dedup;
 
+/// Per-binary hook resolution: hard-error when active binary lacks required hook.
+pub mod binary_hook_resolver;
 /// Copilot stop handler utilities (continuation, lock cleanup, decision log).
 pub mod copilot_stop_handler;
 /// Hook file installation verification.

--- a/crates/amplihack-hooks/tests/hook_resolution_test.rs
+++ b/crates/amplihack-hooks/tests/hook_resolution_test.rs
@@ -1,0 +1,140 @@
+//! TDD: Failing tests for `amplihack_hooks::binary_hook_resolver`.
+//!
+//! Contract:
+//! - `HookEvent` enum has 8 variants matching on-disk filenames.
+//! - `resolve_hook(binary, event, hooks_root)` returns the canonical path when
+//!   the per-binary hook file exists.
+//! - When absent, returns `HookError::MissingHookForBinary { binary, event,
+//!   expected_path, remediation }` — NO claude fallback, NO stub creation.
+//! - `expected_hook_path` rejects non-allowlisted binaries and prevents path
+//!   traversal escapes.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use tempfile::TempDir;
+
+use amplihack_hooks::binary_hook_resolver::{
+    HookError, HookEvent, expected_hook_path, resolve_hook,
+};
+
+#[test]
+fn hook_event_has_eight_variants_with_filename_mapping() {
+    let pairs = [
+        (HookEvent::PreToolUse, "PreToolUse"),
+        (HookEvent::PostToolUse, "PostToolUse"),
+        (HookEvent::Stop, "Stop"),
+        (HookEvent::SessionStart, "SessionStart"),
+        (HookEvent::SessionEnd, "SessionEnd"),
+        (HookEvent::SessionStop, "SessionStop"),
+        (HookEvent::UserPromptSubmit, "UserPromptSubmit"),
+        (HookEvent::PreCompact, "PreCompact"),
+    ];
+    for (event, expected_stem) in pairs {
+        assert_eq!(event.filename_stem(), expected_stem);
+    }
+}
+
+#[test]
+fn expected_path_constructs_under_binary_namespace() {
+    let tmp = TempDir::new().unwrap();
+    let path = expected_hook_path(tmp.path(), "copilot", HookEvent::SessionEnd).unwrap();
+    let display = path.display().to_string();
+    assert!(display.contains("copilot"));
+    assert!(display.contains("SessionEnd"));
+}
+
+#[test]
+fn expected_path_rejects_non_allowlisted_binary() {
+    let tmp = TempDir::new().unwrap();
+    for bad in &["bash", "../etc", "claude/../sh", ""] {
+        let result = expected_hook_path(tmp.path(), bad, HookEvent::Stop);
+        assert!(
+            matches!(result, Err(HookError::InvalidBinary(_))),
+            "{bad} must be rejected: got {result:?}"
+        );
+    }
+}
+
+#[test]
+fn expected_path_blocks_traversal_escape() {
+    let tmp = TempDir::new().unwrap();
+    let result = expected_hook_path(tmp.path(), "..", HookEvent::Stop);
+    assert!(matches!(result, Err(HookError::InvalidBinary(_))));
+}
+
+#[test]
+fn resolve_hook_returns_path_when_file_present() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("copilot").join("hooks");
+    fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("SessionEnd.py");
+    fs::write(&file, "#!/usr/bin/env python3\n").unwrap();
+
+    let resolved = resolve_hook(tmp.path(), "copilot", HookEvent::SessionEnd).unwrap();
+    assert_eq!(
+        resolved.canonicalize().unwrap(),
+        file.canonicalize().unwrap()
+    );
+}
+
+#[test]
+fn resolve_hook_missing_returns_structured_error_no_fallback() {
+    let tmp = TempDir::new().unwrap();
+    // Create a claude SessionEnd hook but request copilot — must NOT fall back.
+    let claude_dir = tmp.path().join("claude").join("hooks");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join("SessionEnd.py"), "x").unwrap();
+
+    let result = resolve_hook(tmp.path(), "copilot", HookEvent::SessionEnd);
+    match result {
+        Err(HookError::MissingHookForBinary {
+            binary,
+            event,
+            expected_path,
+            remediation,
+            ..
+        }) => {
+            assert_eq!(binary, "copilot");
+            assert_eq!(event, HookEvent::SessionEnd);
+            assert!(expected_path.display().to_string().contains("copilot"));
+            assert!(!expected_path.display().to_string().contains("claude"));
+            assert!(
+                remediation.contains("amplihack") || remediation.contains("AMPLIHACK_AGENT_BINARY"),
+                "remediation must point operator at concrete fixes, got: {remediation}"
+            );
+        }
+        other => panic!("expected MissingHookForBinary, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_hook_does_not_create_stub_file() {
+    let tmp = TempDir::new().unwrap();
+    let _ = resolve_hook(tmp.path(), "copilot", HookEvent::SessionEnd);
+    // Resolver MUST be read-only — no stub session_end.py / SessionEnd.py written.
+    let stub = tmp
+        .path()
+        .join("copilot")
+        .join("hooks")
+        .join("SessionEnd.py");
+    assert!(!stub.exists(), "resolver must never create stub hook files");
+    let py_stub = tmp
+        .path()
+        .join("copilot")
+        .join("hooks")
+        .join("session_end.py");
+    assert!(!py_stub.exists());
+}
+
+#[test]
+fn missing_hook_error_message_includes_static_remediation_template() {
+    let tmp = TempDir::new().unwrap();
+    let err = resolve_hook(tmp.path(), "copilot", HookEvent::SessionEnd).unwrap_err();
+    let rendered = format!("{err}");
+    // Spec D5 message contract.
+    assert!(rendered.contains("SessionEnd") || rendered.contains("session"));
+    assert!(rendered.contains("copilot"));
+    // Must not silently succeed — the Display impl must surface the failure.
+    assert!(!rendered.is_empty());
+}

--- a/crates/amplihack-utils/src/agent_binary.rs
+++ b/crates/amplihack-utils/src/agent_binary.rs
@@ -1,0 +1,245 @@
+//! Single source of truth for resolving the active agent binary.
+//!
+//! Resolution precedence:
+//! 1. `AMPLIHACK_AGENT_BINARY` env var (explicit override; CI/testing).
+//! 2. `<cwd-or-ancestor>/.claude/runtime/launcher_context.json` `launcher` field
+//!    (canonical persisted state written by the launcher on every run).
+//! 3. Built-in default: `"copilot"`.
+//!
+//! All inputs are validated against a strict allowlist to prevent the resolved
+//! value from being used as an arbitrary `Command::new` target by downstream
+//! callers. Untrusted values silently fall through to the next layer.
+//!
+//! ## Security
+//!
+//! * Allowlist is exactly `{claude, copilot, codex, amplifier}` — case-insensitive
+//!   on input, lowercase on output.
+//! * Env-var input is length-capped (32 bytes) and rejects path separators,
+//!   control characters, and any name not in the allowlist.
+//! * `launcher_context.json` is read with a 64 KiB size cap and parsed as a
+//!   typed struct (extra fields ignored) — malformed input falls back.
+//! * Walk-up ancestor search is capped at 32 levels and stops at any `.git`
+//!   boundary. Symlink escape is rejected by canonicalizing the resolved path
+//!   and verifying it stays within the anchor tree.
+//! * No shell invocation, no subprocess execution.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use thiserror::Error;
+use tracing::debug;
+
+/// Allowlist of valid agent binary names. Keep alphabetical and lowercase.
+pub const ALLOWED_BINARIES: &[&str] = &["amplifier", "claude", "codex", "copilot"];
+
+/// Built-in default when no override is present and no launcher_context exists.
+pub const DEFAULT_BINARY: &str = "copilot";
+
+/// Maximum bytes accepted from the `AMPLIHACK_AGENT_BINARY` env var.
+const ENV_VALUE_MAX_LEN: usize = 32;
+
+/// Maximum bytes read from `launcher_context.json` before rejecting.
+const LAUNCHER_CONTEXT_MAX_BYTES: u64 = 64 * 1024;
+
+/// Maximum number of ancestor directories to inspect during walk-up.
+const ANCESTOR_WALK_LIMIT: usize = 32;
+
+/// Errors returned by the resolver. Resolution is infallible from the caller's
+/// perspective today — this type exists for future-proofing and to give tests a
+/// concrete `Err` variant to bind against.
+#[derive(Debug, Error)]
+pub enum ResolveError {
+    /// I/O failure that prevented even the default-fallback path from running.
+    #[error("agent-binary resolver i/o failure: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Returns `Some(canonicalized lowercase name)` when `name` is on the allowlist
+/// and free of dangerous characters; `None` otherwise.
+///
+/// The check is case-insensitive but the returned value is always the canonical
+/// lowercase form, suitable for direct use as a `Command` target identifier.
+pub fn validate_binary_name(name: &str) -> Option<String> {
+    // Reject any control char, NUL, path separator, dot, semicolon, or
+    // whitespace anywhere in the *raw* input — these would otherwise be
+    // smuggled past `trim()` and used as `Command::new` targets.
+    if name.bytes().any(|b| {
+        b.is_ascii_control() || b == b'/' || b == b'\\' || b == b'\0' || b == b';' || b == b'.'
+    }) {
+        return None;
+    }
+    let trimmed = name.trim();
+    if trimmed.is_empty() || trimmed.len() > ENV_VALUE_MAX_LEN {
+        return None;
+    }
+    // After trim there must be no internal whitespace.
+    if trimmed.bytes().any(|b| b == b' ' || b == b'\t') {
+        return None;
+    }
+    let lowered = trimmed.to_ascii_lowercase();
+    if ALLOWED_BINARIES.iter().any(|allowed| *allowed == lowered) {
+        Some(lowered)
+    } else {
+        None
+    }
+}
+
+/// Resolve the active agent binary for the given working directory.
+///
+/// Always returns an allowlisted name. On any failure mode (rejected env value,
+/// missing/oversized/malformed `launcher_context.json`, walk-up limit reached,
+/// symlink escape) the function falls through to the next precedence layer and
+/// ultimately to [`DEFAULT_BINARY`].
+pub fn resolve(cwd: &Path) -> Result<String, ResolveError> {
+    // Layer 1: explicit env-var override.
+    if let Ok(raw) = std::env::var("AMPLIHACK_AGENT_BINARY")
+        && let Some(valid) = validate_binary_name(&raw)
+    {
+        debug!(binary = %valid, source = "env", "agent binary resolved");
+        return Ok(valid);
+    }
+
+    // Layer 2: persisted launcher_context.json (walk up ancestors).
+    if let Some(name) = lookup_persisted_launcher(cwd) {
+        debug!(binary = %name, source = "launcher_context", "agent binary resolved");
+        return Ok(name);
+    }
+
+    // Layer 3: built-in default.
+    debug!(
+        binary = DEFAULT_BINARY,
+        source = "default",
+        "agent binary resolved"
+    );
+    Ok(DEFAULT_BINARY.to_string())
+}
+
+#[derive(Deserialize)]
+struct LauncherContextSnippet {
+    launcher: String,
+}
+
+/// Walk up from `start` looking for `.claude/runtime/launcher_context.json`.
+/// Stops at any `.git` directory boundary or after [`ANCESTOR_WALK_LIMIT`] hops.
+fn lookup_persisted_launcher(start: &Path) -> Option<String> {
+    let anchor = start.canonicalize().ok()?;
+    let mut current: PathBuf = anchor.clone();
+    for _ in 0..ANCESTOR_WALK_LIMIT {
+        // Stop at git boundary (but still inspect this dir on this iteration).
+        let runtime_file = current
+            .join(".claude")
+            .join("runtime")
+            .join("launcher_context.json");
+        if runtime_file.is_file()
+            && let Some(name) = read_launcher_field(&runtime_file, &current)
+        {
+            return Some(name);
+        }
+        // Don't walk past a .git boundary.
+        if current.join(".git").exists() {
+            return None;
+        }
+        match current.parent() {
+            Some(parent) if parent != current => current = parent.to_path_buf(),
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// Read and validate the `launcher` field. The file is size-capped, parsed as a
+/// typed struct (rejects unexpected JSON shapes), and the value is allowlisted.
+/// The path is canonicalized and verified to stay within `anchor` to defend
+/// against symlink escape.
+fn read_launcher_field(path: &Path, anchor: &Path) -> Option<String> {
+    let canonical = path.canonicalize().ok()?;
+    let canonical_anchor = anchor.canonicalize().ok()?;
+    if !canonical.starts_with(&canonical_anchor) {
+        debug!(
+            path = %canonical.display(),
+            anchor = %canonical_anchor.display(),
+            "launcher_context path escapes anchor; ignoring"
+        );
+        return None;
+    }
+    let metadata = fs::metadata(&canonical).ok()?;
+    if metadata.len() > LAUNCHER_CONTEXT_MAX_BYTES {
+        debug!(
+            size = metadata.len(),
+            cap = LAUNCHER_CONTEXT_MAX_BYTES,
+            "launcher_context exceeds size cap; ignoring"
+        );
+        return None;
+    }
+    let body = fs::read_to_string(&canonical).ok()?;
+    let parsed: LauncherContextSnippet = serde_json::from_str(&body).ok()?;
+    validate_binary_name(&parsed.launcher)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_allowlisted_lowercase() {
+        for name in ALLOWED_BINARIES {
+            assert_eq!(validate_binary_name(name).as_deref(), Some(*name));
+        }
+    }
+
+    #[test]
+    fn validate_is_case_insensitive_returns_lowercase() {
+        assert_eq!(validate_binary_name("CLAUDE").as_deref(), Some("claude"));
+        assert_eq!(validate_binary_name("CoPiLoT").as_deref(), Some("copilot"));
+    }
+
+    #[test]
+    fn validate_trims_whitespace() {
+        assert_eq!(
+            validate_binary_name("  claude  ").as_deref(),
+            Some("claude")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_dangerous_inputs() {
+        for bad in &[
+            "",
+            "x",
+            "claudex",
+            "/bin/sh",
+            "..",
+            "../claude",
+            "claude\n",
+            "claude\t",
+            "cla ude",
+            "cla\0ude",
+            "claude;rm",
+            "rm -rf /",
+        ] {
+            assert!(
+                validate_binary_name(bad).is_none(),
+                "{bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_oversized_input() {
+        let s = "a".repeat(ENV_VALUE_MAX_LEN + 1);
+        assert!(validate_binary_name(&s).is_none());
+    }
+
+    #[test]
+    fn allowlist_is_exactly_the_four_known_binaries() {
+        let mut sorted = ALLOWED_BINARIES.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec!["amplifier", "claude", "codex", "copilot"]);
+    }
+
+    #[test]
+    fn default_binary_is_copilot() {
+        assert_eq!(DEFAULT_BINARY, "copilot");
+    }
+}

--- a/crates/amplihack-utils/src/claude_cli.rs
+++ b/crates/amplihack-utils/src/claude_cli.rs
@@ -105,11 +105,14 @@ fn home_dir() -> Option<PathBuf> {
 ///
 /// Search order:
 /// 1. `AMPLIHACK_CLAUDE_BINARY_PATH` env var (explicit override).
-/// 2. `AMPLIHACK_AGENT_BINARY` env var (runtime launcher override).
-/// 3. System `PATH` (via `which`/`where.exe`).
-/// 4. Fallback: `~/.npm-global/bin/claude`.
+/// 2. System `PATH` (via `which`/`where.exe`).
+/// 3. Fallback: `~/.npm-global/bin/claude`.
 ///
 /// Returns `None` if the binary is not found in any location.
+///
+/// Note: the agent-binary identifier (claude/copilot/codex/amplifier) is
+/// resolved separately via [`crate::agent_binary::resolve`]; that value is a
+/// short name, not a filesystem path, and is not consulted here.
 ///
 /// # Examples
 ///
@@ -121,7 +124,7 @@ fn home_dir() -> Option<PathBuf> {
 /// }
 /// ```
 pub fn get_claude_cli_path() -> Option<PathBuf> {
-    // 1. Explicit override
+    // 1. Explicit override (full path to the claude binary).
     if let Ok(p) = env::var("AMPLIHACK_CLAUDE_BINARY_PATH") {
         let path = PathBuf::from(&p);
         if path.is_file() {
@@ -129,20 +132,12 @@ pub fn get_claude_cli_path() -> Option<PathBuf> {
         }
     }
 
-    // 2. Runtime launcher override
-    if let Ok(p) = env::var("AMPLIHACK_AGENT_BINARY") {
-        let path = PathBuf::from(&p);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-
-    // 3. System PATH search
+    // 2. System PATH search
     if let Some(p) = which_claude() {
         return Some(p);
     }
 
-    // 4. Fallback: ~/.npm-global/bin/claude
+    // 3. Fallback: ~/.npm-global/bin/claude
     if let Some(bin_dir) = npm_global_bin() {
         let candidate = bin_dir.join("claude");
         if candidate.is_file() {

--- a/crates/amplihack-utils/src/knowledge_builder.rs
+++ b/crates/amplihack-utils/src/knowledge_builder.rs
@@ -102,8 +102,8 @@ pub fn topic_slug(topic: &str) -> String {
 pub struct KnowledgeBuilderConfig {
     /// The topic to research.
     pub topic: String,
-    /// Agent command (e.g. `"claude"`). Falls back to `AMPLIHACK_AGENT_BINARY`
-    /// environment variable, then to `"claude"`.
+    /// Agent command (e.g. `"copilot"`). Resolved from
+    /// [`crate::agent_binary::resolve`] when not explicitly supplied.
     pub agent_cmd: String,
     /// Root directory under which topic-specific output is placed.
     pub output_base: PathBuf,
@@ -112,16 +112,20 @@ pub struct KnowledgeBuilderConfig {
 impl KnowledgeBuilderConfig {
     /// Create a config with sensible defaults.
     ///
-    /// `topic` is trimmed; `agent_cmd` is read from the environment if `None`.
+    /// `topic` is trimmed; `agent_cmd` is resolved via
+    /// [`crate::agent_binary::resolve`] when not explicitly supplied — env
+    /// override → `launcher_context.json` → `"copilot"` default.
     pub fn new(
         topic: impl Into<String>,
         agent_cmd: Option<String>,
         output_base: Option<PathBuf>,
     ) -> Self {
         let topic = topic.into().trim().to_string();
-        let agent_cmd = agent_cmd
-            .or_else(|| std::env::var("AMPLIHACK_AGENT_BINARY").ok())
-            .unwrap_or_else(|| "claude".into());
+        let agent_cmd = agent_cmd.unwrap_or_else(|| {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            crate::agent_binary::resolve(&cwd)
+                .unwrap_or_else(|_| crate::agent_binary::DEFAULT_BINARY.to_string())
+        });
         let output_base = output_base.unwrap_or_else(|| {
             std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from("."))

--- a/crates/amplihack-utils/src/lib.rs
+++ b/crates/amplihack-utils/src/lib.rs
@@ -24,6 +24,8 @@
 //! - [`bundle_generator`] — Agent bundle generation, packaging, and distribution
 //! - [`docker_manager`] — Docker container management for isolated execution
 
+/// Single source of truth for resolving the active agent binary identifier.
+pub mod agent_binary;
 pub mod bundle_generator;
 pub mod claude_cli;
 pub mod claude_md;

--- a/crates/amplihack-utils/src/llm_client.rs
+++ b/crates/amplihack-utils/src/llm_client.rs
@@ -117,15 +117,28 @@ pub fn completion(prompt: &str) -> Result<String, LlmClientError> {
 }
 
 /// Resolve the binary name for a given launcher type.
+///
+/// Delegates the AMPLIHACK_AGENT_BINARY → launcher_context.json → "copilot"
+/// precedence to [`amplihack_utils::agent_binary::resolve`]. The launcher
+/// argument only matters when the resolver returns the built-in default and
+/// the caller already knows which session marker it observed.
 fn resolve_binary(launcher: &LauncherType) -> String {
-    // Prefer the explicit env var if set.
-    if let Ok(bin) = env::var("AMPLIHACK_AGENT_BINARY") {
-        return bin;
+    let cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    if let Ok(name) = crate::agent_binary::resolve(&cwd) {
+        // The resolver may return the default ("copilot") even when we
+        // detected a Claude session marker — in that case, prefer the marker.
+        if matches!(launcher, LauncherType::ClaudeCode)
+            && name == crate::agent_binary::DEFAULT_BINARY
+            && env::var("AMPLIHACK_AGENT_BINARY").is_err()
+        {
+            return "claude".to_string();
+        }
+        return name;
     }
     match launcher {
         LauncherType::ClaudeCode => "claude".to_string(),
         LauncherType::CopilotCli => "copilot".to_string(),
-        LauncherType::Unknown => "claude".to_string(),
+        LauncherType::Unknown => crate::agent_binary::DEFAULT_BINARY.to_string(),
     }
 }
 

--- a/crates/amplihack-utils/tests/agent_binary_resolver_test.rs
+++ b/crates/amplihack-utils/tests/agent_binary_resolver_test.rs
@@ -14,11 +14,21 @@
 
 use std::fs;
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 use tempfile::TempDir;
 
 use amplihack_utils::agent_binary::{
     self, ALLOWED_BINARIES, DEFAULT_BINARY, ResolveError, resolve,
 };
+
+/// Serialize tests that mutate `AMPLIHACK_AGENT_BINARY`. `cargo test` runs
+/// integration tests in parallel by default, which races env mutation across
+/// the entire test binary. CI uses the default thread count, so the lock is
+/// required for portability.
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 fn write_launcher_context(repo: &Path, launcher: &str) {
     let runtime = repo.join(".claude").join("runtime");
@@ -56,6 +66,7 @@ fn try_set_env(value: &str) -> bool {
 
 #[test]
 fn default_is_copilot_when_nothing_set() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     let result = resolve(tmp.path()).unwrap();
@@ -65,6 +76,7 @@ fn default_is_copilot_when_nothing_set() {
 
 #[test]
 fn env_var_takes_precedence_over_file() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let tmp = TempDir::new().unwrap();
     write_launcher_context(tmp.path(), "claude");
     set_env("copilot");
@@ -75,6 +87,7 @@ fn env_var_takes_precedence_over_file() {
 
 #[test]
 fn launcher_context_used_when_env_unset() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     write_launcher_context(tmp.path(), "claude");
@@ -84,6 +97,7 @@ fn launcher_context_used_when_env_unset() {
 
 #[test]
 fn allowlist_contains_exactly_four_binaries() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let mut sorted: Vec<&str> = ALLOWED_BINARIES.to_vec();
     sorted.sort_unstable();
     assert_eq!(sorted, vec!["amplifier", "claude", "codex", "copilot"]);
@@ -91,6 +105,7 @@ fn allowlist_contains_exactly_four_binaries() {
 
 #[test]
 fn env_value_outside_allowlist_is_rejected() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     set_env("malicious");
@@ -102,6 +117,7 @@ fn env_value_outside_allowlist_is_rejected() {
 
 #[test]
 fn env_value_with_path_separator_is_rejected() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     for bad in &["/bin/sh", "..\\evil", "claude/../sh", "cla\0ude"] {
@@ -118,6 +134,7 @@ fn env_value_with_path_separator_is_rejected() {
 
 #[test]
 fn env_value_is_trimmed_and_lowercased() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     set_env("  CLAUDE  ");
@@ -128,6 +145,7 @@ fn env_value_is_trimmed_and_lowercased() {
 
 #[test]
 fn launcher_context_outside_allowlist_falls_back_to_default() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     write_launcher_context(tmp.path(), "rm-rf-slash");
@@ -137,6 +155,7 @@ fn launcher_context_outside_allowlist_falls_back_to_default() {
 
 #[test]
 fn oversized_launcher_context_is_rejected() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     let runtime = tmp.path().join(".claude").join("runtime");
@@ -151,6 +170,7 @@ fn oversized_launcher_context_is_rejected() {
 
 #[test]
 fn malformed_launcher_context_falls_back_to_default() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     let runtime = tmp.path().join(".claude").join("runtime");
@@ -162,6 +182,7 @@ fn malformed_launcher_context_falls_back_to_default() {
 
 #[test]
 fn walk_up_finds_context_in_ancestor() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     write_launcher_context(tmp.path(), "claude");
@@ -173,6 +194,7 @@ fn walk_up_finds_context_in_ancestor() {
 
 #[test]
 fn walk_up_stops_at_git_boundary() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     // Outer repo with launcher_context = claude.
@@ -189,6 +211,7 @@ fn walk_up_stops_at_git_boundary() {
 
 #[test]
 fn resolve_function_signature_returns_result() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     // Compile-time contract: resolve(&Path) -> Result<String, ResolveError>.
     clear_env();
     let tmp = TempDir::new().unwrap();
@@ -197,6 +220,7 @@ fn resolve_function_signature_returns_result() {
 
 #[test]
 fn validate_binary_name_helper_exposed() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     assert!(agent_binary::validate_binary_name("claude").is_some());
     assert!(agent_binary::validate_binary_name("COPILOT").is_some());
     assert!(agent_binary::validate_binary_name("evil/bin").is_none());

--- a/crates/amplihack-utils/tests/agent_binary_resolver_test.rs
+++ b/crates/amplihack-utils/tests/agent_binary_resolver_test.rs
@@ -1,0 +1,205 @@
+//! TDD: Failing tests for `amplihack_utils::agent_binary` resolver.
+//!
+//! These tests define the contract for the unified agent-binary resolver:
+//! 1. Precedence: `AMPLIHACK_AGENT_BINARY` env > `launcher_context.json` > "copilot" default.
+//! 2. Strict allowlist: only {claude, copilot, codex, amplifier}.
+//! 3. Walk-up boundary, file size cap, validation hardening.
+//!
+//! Run with: `TMPDIR=/tmp cargo test -p amplihack-utils --test agent_binary_resolver_test`
+//!
+//! NOTE: tests mutate process env so they share `serial_test::serial` (or a
+//! single-threaded runner). Edition-2024 requires `unsafe` for env mutation.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+use amplihack_utils::agent_binary::{
+    self, ALLOWED_BINARIES, DEFAULT_BINARY, ResolveError, resolve,
+};
+
+fn write_launcher_context(repo: &Path, launcher: &str) {
+    let runtime = repo.join(".claude").join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    let body =
+        format!(r#"{{"launcher":"{launcher}","pid":1234,"created_at":"2026-01-01T00:00:00Z"}}"#);
+    fs::write(runtime.join("launcher_context.json"), body).unwrap();
+}
+
+fn clear_env() {
+    // SAFETY: tests are serialized; env mutation is unsafe in edition 2024.
+    unsafe {
+        std::env::remove_var("AMPLIHACK_AGENT_BINARY");
+    }
+}
+
+fn set_env(value: &str) {
+    // SAFETY: see clear_env.
+    unsafe {
+        std::env::set_var("AMPLIHACK_AGENT_BINARY", value);
+    }
+}
+
+/// Some test inputs (NUL bytes, etc.) are rejected by the OS before reaching
+/// our resolver. Skip those — the resolver's `validate_binary_name` unit tests
+/// already cover the `\0` case directly. The security test below also exercises
+/// these via `try_set_env`.
+fn try_set_env(value: &str) -> bool {
+    if value.bytes().any(|b| b == 0) {
+        return false;
+    }
+    set_env(value);
+    true
+}
+
+#[test]
+fn default_is_copilot_when_nothing_set() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    let result = resolve(tmp.path()).unwrap();
+    assert_eq!(result, "copilot");
+    assert_eq!(DEFAULT_BINARY, "copilot");
+}
+
+#[test]
+fn env_var_takes_precedence_over_file() {
+    let tmp = TempDir::new().unwrap();
+    write_launcher_context(tmp.path(), "claude");
+    set_env("copilot");
+    let result = resolve(tmp.path()).unwrap();
+    assert_eq!(result, "copilot");
+    clear_env();
+}
+
+#[test]
+fn launcher_context_used_when_env_unset() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    write_launcher_context(tmp.path(), "claude");
+    let result = resolve(tmp.path()).unwrap();
+    assert_eq!(result, "claude");
+}
+
+#[test]
+fn allowlist_contains_exactly_four_binaries() {
+    let mut sorted: Vec<&str> = ALLOWED_BINARIES.to_vec();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec!["amplifier", "claude", "codex", "copilot"]);
+}
+
+#[test]
+fn env_value_outside_allowlist_is_rejected() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    set_env("malicious");
+    let result = resolve(tmp.path()).unwrap();
+    // Rejected → falls through to default.
+    assert_eq!(result, "copilot");
+    clear_env();
+}
+
+#[test]
+fn env_value_with_path_separator_is_rejected() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    for bad in &["/bin/sh", "..\\evil", "claude/../sh", "cla\0ude"] {
+        if !try_set_env(bad) {
+            // OS rejects NUL bytes in env values; the validator unit tests
+            // cover that branch directly (see `validate_rejects_dangerous_inputs`).
+            continue;
+        }
+        let result = resolve(tmp.path()).unwrap();
+        assert_eq!(result, "copilot", "value {bad:?} should be rejected");
+    }
+    clear_env();
+}
+
+#[test]
+fn env_value_is_trimmed_and_lowercased() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    set_env("  CLAUDE  ");
+    let result = resolve(tmp.path()).unwrap();
+    assert_eq!(result, "claude");
+    clear_env();
+}
+
+#[test]
+fn launcher_context_outside_allowlist_falls_back_to_default() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    write_launcher_context(tmp.path(), "rm-rf-slash");
+    let result = resolve(tmp.path()).unwrap();
+    assert_eq!(result, "copilot");
+}
+
+#[test]
+fn oversized_launcher_context_is_rejected() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    let runtime = tmp.path().join(".claude").join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    // > 64 KiB cap.
+    let huge = "x".repeat(70 * 1024);
+    let body = format!(r#"{{"launcher":"claude","junk":"{huge}"}}"#);
+    fs::write(runtime.join("launcher_context.json"), body).unwrap();
+    let result = resolve(tmp.path()).unwrap();
+    assert_eq!(result, "copilot", "oversized file must be rejected");
+}
+
+#[test]
+fn malformed_launcher_context_falls_back_to_default() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    let runtime = tmp.path().join(".claude").join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    fs::write(runtime.join("launcher_context.json"), "{not valid json").unwrap();
+    let result = resolve(tmp.path()).unwrap();
+    assert_eq!(result, "copilot");
+}
+
+#[test]
+fn walk_up_finds_context_in_ancestor() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    write_launcher_context(tmp.path(), "claude");
+    let nested = tmp.path().join("a").join("b").join("c");
+    fs::create_dir_all(&nested).unwrap();
+    let result = resolve(&nested).unwrap();
+    assert_eq!(result, "claude");
+}
+
+#[test]
+fn walk_up_stops_at_git_boundary() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    // Outer repo with launcher_context = claude.
+    write_launcher_context(tmp.path(), "claude");
+    // Inner "repo" with .git boundary, no launcher_context.
+    let inner = tmp.path().join("inner");
+    fs::create_dir_all(inner.join(".git")).unwrap();
+    let nested = inner.join("src");
+    fs::create_dir_all(&nested).unwrap();
+    let result = resolve(&nested).unwrap();
+    // Should NOT find outer claude — boundary respected.
+    assert_eq!(result, "copilot");
+}
+
+#[test]
+fn resolve_function_signature_returns_result() {
+    // Compile-time contract: resolve(&Path) -> Result<String, ResolveError>.
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    let _: Result<String, ResolveError> = resolve(tmp.path());
+}
+
+#[test]
+fn validate_binary_name_helper_exposed() {
+    assert!(agent_binary::validate_binary_name("claude").is_some());
+    assert!(agent_binary::validate_binary_name("COPILOT").is_some());
+    assert!(agent_binary::validate_binary_name("evil/bin").is_none());
+    assert!(agent_binary::validate_binary_name("").is_none());
+    assert!(agent_binary::validate_binary_name(&"x".repeat(64)).is_none());
+}

--- a/crates/amplihack-utils/tests/agent_binary_security.rs
+++ b/crates/amplihack-utils/tests/agent_binary_security.rs
@@ -7,9 +7,15 @@
 
 use std::fs;
 use std::os::unix::fs::symlink;
+use std::sync::{Mutex, OnceLock};
 use tempfile::TempDir;
 
 use amplihack_utils::agent_binary::{ALLOWED_BINARIES, resolve, validate_binary_name};
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 fn clear_env() {
     // SAFETY: tests serialized; env mutation unsafe in edition 2024.
@@ -35,6 +41,7 @@ fn try_set_env(value: &str) -> bool {
 
 #[test]
 fn s1_allowlist_is_case_insensitive_exact_match() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     for good in &[
         "claude",
         "Claude",
@@ -55,6 +62,7 @@ fn s1_allowlist_is_case_insensitive_exact_match() {
 
 #[test]
 fn s2_env_input_sanitization_rejects_dangerous_chars() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     let bad = [
         "/bin/sh",
         "..",
@@ -80,6 +88,7 @@ fn s2_env_input_sanitization_rejects_dangerous_chars() {
 
 #[test]
 fn s2_env_input_length_capped() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     set_env(&"a".repeat(33));
@@ -89,6 +98,7 @@ fn s2_env_input_length_capped() {
 
 #[test]
 fn s3_json_typed_struct_rejects_unexpected_shape() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     let runtime = tmp.path().join(".claude").join("runtime");
@@ -104,6 +114,7 @@ fn s3_json_typed_struct_rejects_unexpected_shape() {
 
 #[test]
 fn s3_json_64kib_size_cap() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     let runtime = tmp.path().join(".claude").join("runtime");
@@ -119,6 +130,7 @@ fn s3_json_64kib_size_cap() {
 
 #[test]
 fn s5_walk_up_capped_at_32_ancestors() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     // No launcher_context anywhere.
@@ -133,6 +145,7 @@ fn s5_walk_up_capped_at_32_ancestors() {
 
 #[test]
 fn s5_symlink_escape_is_blocked() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let outer = TempDir::new().unwrap();
     let attacker = TempDir::new().unwrap();
@@ -157,6 +170,7 @@ fn s5_symlink_escape_is_blocked() {
 
 #[test]
 fn s7_error_messages_do_not_leak_env_value() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     set_env("rm -rf /; curl evil.example/x");
@@ -172,6 +186,7 @@ fn s7_error_messages_do_not_leak_env_value() {
 
 #[test]
 fn s8_resolved_value_always_in_allowlist() {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
     clear_env();
     let tmp = TempDir::new().unwrap();
     let resolved = resolve(tmp.path()).unwrap();

--- a/crates/amplihack-utils/tests/agent_binary_security.rs
+++ b/crates/amplihack-utils/tests/agent_binary_security.rs
@@ -1,0 +1,182 @@
+//! TDD: Security-focused integration tests for `amplihack_utils::agent_binary`.
+//!
+//! Covers spec items S1–S8: allowlist, input sanitization, JSON hardening,
+//! walk-up containment, no-shell-invocation, error-message hygiene.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use tempfile::TempDir;
+
+use amplihack_utils::agent_binary::{ALLOWED_BINARIES, resolve, validate_binary_name};
+
+fn clear_env() {
+    // SAFETY: tests serialized; env mutation unsafe in edition 2024.
+    unsafe {
+        std::env::remove_var("AMPLIHACK_AGENT_BINARY");
+    }
+}
+
+fn set_env(value: &str) {
+    // SAFETY: see clear_env.
+    unsafe {
+        std::env::set_var("AMPLIHACK_AGENT_BINARY", value);
+    }
+}
+
+fn try_set_env(value: &str) -> bool {
+    if value.bytes().any(|b| b == 0) {
+        return false;
+    }
+    set_env(value);
+    true
+}
+
+#[test]
+fn s1_allowlist_is_case_insensitive_exact_match() {
+    for good in &[
+        "claude",
+        "Claude",
+        "CLAUDE",
+        "copilot",
+        "codex",
+        "amplifier",
+    ] {
+        assert!(validate_binary_name(good).is_some(), "{good} must be valid");
+    }
+    for bad in &["claude2", "claud", "c", "claude-cli", "claudex"] {
+        assert!(
+            validate_binary_name(bad).is_none(),
+            "{bad} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn s2_env_input_sanitization_rejects_dangerous_chars() {
+    let bad = [
+        "/bin/sh",
+        "..",
+        "../claude",
+        "claude\n",
+        "claude\t",
+        "claude;rm",
+        "cla ude",
+        "cla\0ude",
+        "claude\r",
+        "\x07claude",
+    ];
+    let tmp = TempDir::new().unwrap();
+    for value in bad {
+        if !try_set_env(value) {
+            continue; // OS-level NUL rejection; covered by validator unit tests.
+        }
+        let result = resolve(tmp.path()).unwrap();
+        assert_eq!(result, "copilot", "value {value:?} must be rejected");
+    }
+    clear_env();
+}
+
+#[test]
+fn s2_env_input_length_capped() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    set_env(&"a".repeat(33));
+    assert_eq!(resolve(tmp.path()).unwrap(), "copilot");
+    clear_env();
+}
+
+#[test]
+fn s3_json_typed_struct_rejects_unexpected_shape() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    let runtime = tmp.path().join(".claude").join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    // launcher field is an array, not a string.
+    fs::write(
+        runtime.join("launcher_context.json"),
+        r#"{"launcher":["claude"],"pid":1}"#,
+    )
+    .unwrap();
+    assert_eq!(resolve(tmp.path()).unwrap(), "copilot");
+}
+
+#[test]
+fn s3_json_64kib_size_cap() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    let runtime = tmp.path().join(".claude").join("runtime");
+    fs::create_dir_all(&runtime).unwrap();
+    let huge = "p".repeat(64 * 1024 + 1);
+    fs::write(
+        runtime.join("launcher_context.json"),
+        format!(r#"{{"launcher":"claude","x":"{huge}"}}"#),
+    )
+    .unwrap();
+    assert_eq!(resolve(tmp.path()).unwrap(), "copilot");
+}
+
+#[test]
+fn s5_walk_up_capped_at_32_ancestors() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    // No launcher_context anywhere.
+    let mut current = tmp.path().to_path_buf();
+    for i in 0..40 {
+        current = current.join(format!("d{i}"));
+    }
+    fs::create_dir_all(&current).unwrap();
+    // Should not panic, should fall back to default.
+    assert_eq!(resolve(&current).unwrap(), "copilot");
+}
+
+#[test]
+fn s5_symlink_escape_is_blocked() {
+    clear_env();
+    let outer = TempDir::new().unwrap();
+    let attacker = TempDir::new().unwrap();
+    // Place valid (allowlisted) but unintended config outside the cwd tree.
+    let attacker_runtime = attacker.path().join(".claude").join("runtime");
+    fs::create_dir_all(&attacker_runtime).unwrap();
+    fs::write(
+        attacker_runtime.join("launcher_context.json"),
+        r#"{"launcher":"claude"}"#,
+    )
+    .unwrap();
+    // Symlink the entire .claude inside outer to attacker's .claude.
+    let link_parent = outer.path().join(".claude");
+    symlink(attacker.path().join(".claude"), &link_parent).unwrap();
+    // Resolver MUST reject path that escapes its anchor (canonicalized starts_with check).
+    let result = resolve(outer.path()).unwrap();
+    assert_eq!(
+        result, "copilot",
+        "symlink escape must not influence resolution"
+    );
+}
+
+#[test]
+fn s7_error_messages_do_not_leak_env_value() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    set_env("rm -rf /; curl evil.example/x");
+    // Expect resolution to succeed (fall through) — but if any tracing/error
+    // surface arises, the rejected value must NOT appear verbatim in the
+    // returned String. Default is returned unchanged.
+    let out = resolve(tmp.path()).unwrap();
+    assert!(!out.contains("evil"));
+    assert!(!out.contains("rm -rf"));
+    assert_eq!(out, "copilot");
+    clear_env();
+}
+
+#[test]
+fn s8_resolved_value_always_in_allowlist() {
+    clear_env();
+    let tmp = TempDir::new().unwrap();
+    let resolved = resolve(tmp.path()).unwrap();
+    assert!(
+        ALLOWED_BINARIES.contains(&resolved.as_str()),
+        "resolver must only ever return allowlisted names; got {resolved:?}"
+    );
+}

--- a/crates/amplihack-workflows/Cargo.toml
+++ b/crates/amplihack-workflows/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 description = "Workflow classification and execution tier cascade for amplihack"
 
 [dependencies]
+amplihack-utils = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/amplihack-workflows/src/cascade.rs
+++ b/crates/amplihack-workflows/src/cascade.rs
@@ -70,12 +70,13 @@ impl ExecutionTierCascade {
     /// Check if skill-based workflow execution is available.
     ///
     /// Tier 2 uses the agent binary's skill system to execute workflow
-    /// steps through LLM-driven skill invocations. Available when an
-    /// agent binary is configured via AMPLIHACK_AGENT_BINARY.
+    /// steps through LLM-driven skill invocations. Always available now that
+    /// the agent binary resolver guarantees a valid built-in default — but
+    /// callers may opt out by leaving the resolver to fall back to the
+    /// configured launcher and cwd.
     pub fn is_skill_execution_available(&self) -> bool {
-        std::env::var("AMPLIHACK_AGENT_BINARY")
-            .map(|v| !v.is_empty())
-            .unwrap_or(false)
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        amplihack_utils::agent_binary::resolve(&cwd).is_ok()
     }
 
     /// Execute a workflow through the cascade.
@@ -277,12 +278,13 @@ mod tests {
     }
 
     #[test]
-    fn skill_execution_unavailable_without_env() {
-        // Without AMPLIHACK_AGENT_BINARY, tier 2 should not be available
+    fn skill_execution_always_available_via_resolver_default() {
+        // The resolver returns a built-in default ("copilot") even when no
+        // env var or launcher_context is present, so tier 2 is always
+        // structurally available — its execution may still no-op if the
+        // configured binary is missing on PATH.
         let c = ExecutionTierCascade::default();
-        if std::env::var("AMPLIHACK_AGENT_BINARY").is_err() {
-            assert!(!c.is_skill_execution_available());
-        }
+        assert!(c.is_skill_execution_available());
     }
 
     #[test]

--- a/crates/amplihack-workflows/src/cascade.rs
+++ b/crates/amplihack-workflows/src/cascade.rs
@@ -230,14 +230,17 @@ mod tests {
     }
 
     #[test]
-    fn cascade_with_no_recipe_runner_falls_to_tier3() {
+    fn cascade_with_no_recipe_runner_falls_to_skill_or_markdown() {
         let c = ExecutionTierCascade::new(Some(vec![1, 2, 3]));
         let ctx = serde_json::json!({});
         let r = c.execute(WorkflowType::Default, &ctx);
-        // Without recipe-runner-rs on PATH, tier 1 is unavailable
+        // Without recipe-runner-rs on PATH, tier 1 is unavailable. Skill
+        // execution is now structurally always available (issue #489 — the
+        // resolver guarantees a valid agent binary), so the cascade lands on
+        // tier 2; if the cascade is invoked without tier 2 present it falls
+        // through to tier 3.
         if !c.is_recipe_runner_available() {
-            assert_eq!(r.tier, 3);
-            assert!(r.fallback_count > 0 || r.tier == 3);
+            assert!(r.tier == 2 || r.tier == 3, "unexpected tier {}", r.tier);
         }
     }
 

--- a/docs/concepts/agent-binary-routing.md
+++ b/docs/concepts/agent-binary-routing.md
@@ -196,5 +196,5 @@ The resolver and hook paths are derived from values that may originate in user-c
 - [Active Agent Binary](../reference/active-agent-binary.md) — Resolver API and full algorithm
 - [Environment Variables](../reference/environment-variables.md#amplihack_agent_binary) — Env var reference
 - [Agent Configuration](../reference/agent-configuration.md) — Where this fits into broader config precedence
-- [Hooks Reference](../reference/hooks.md) — Per-binary hook layout and event list
+- [Hook Specifications](../reference/hook-specifications.md) — Per-binary hook layout and event list
 - [Bootstrap Parity](./bootstrap-parity.md) — How the Rust CLI matches the Python launcher's environment contract

--- a/docs/concepts/agent-binary-routing.md
+++ b/docs/concepts/agent-binary-routing.md
@@ -1,105 +1,200 @@
 # Agent Binary Routing
 
-`amplihack` supports four AI backends — `claude`, `copilot`, `codex`, and `amplifier` — each launched via the same `amplihack <tool>` pattern. This document explains how downstream components (recipe runner, hooks, sub-agents) know which backend is active, and why this matters.
+`amplihack` supports four AI backends — `claude`, `copilot`, `codex`, and `amplifier` — each launched via the same `amplihack <tool>` pattern. This document explains how downstream components (recipe runner, hooks, sub-agents, Python skills) know which backend is active, why this matters, and how the system survives `tmux`/subprocess boundaries without depending on env-var passthrough.
 
 ## Contents
 
 - [The problem](#the-problem)
-- [The solution: AMPLIHACK_AGENT_BINARY](#the-solution-amplihack_agent_binary)
-- [How it propagates](#how-it-propagates)
+- [The solution: a config-driven resolver](#the-solution-a-config-driven-resolver)
+- [Resolution algorithm](#resolution-algorithm)
+- [How it propagates across processes](#how-it-propagates-across-processes)
+- [Default: copilot](#default-copilot)
 - [Consumers](#consumers)
   - [Recipe runner](#recipe-runner)
   - [Hooks](#hooks)
   - [Sub-agents](#sub-agents)
-- [Supported values](#supported-values)
+  - [Python skills](#python-skills)
+- [Hook resolution & missing-hook errors](#hook-resolution--missing-hook-errors)
+- [Security](#security)
 - [Related](#related)
 
 ## The problem
 
-The recipe runner is a shell-level orchestrator that executes multi-step workflows by spawning new AI sessions. It does not know — and should not hardcode — which AI tool the user started with. If a user invokes `amplihack copilot` and triggers a recipe that spawns a follow-up session, that session must also use `copilot`, not `claude`.
+The recipe runner, hooks, and various Python skill helpers must spawn new AI sessions on behalf of the user. They cannot hardcode the binary — if a user invokes `amplihack copilot` and triggers a recipe that spawns a follow-up session, that session must use `copilot`, not `claude`.
 
-Before `AMPLIHACK_AGENT_BINARY` was propagated, components were forced to:
+Earlier iterations of `amplihack-rs` solved this by writing `AMPLIHACK_AGENT_BINARY` into the subprocess environment. This worked for direct child processes but degraded badly through:
 
-- Hardcode `claude` (breaking Copilot and Codex users)
-- Require an explicit configuration setting (error-prone and redundant)
-- Inspect `$0` or try to detect the active binary at runtime (fragile)
+- `tmux new-session -d` (which strips most env vars)
+- detached background processes (`setsid`, daemonized hooks)
+- sub-recipes that re-exec a fresh `amplihack` binary
+- Python `subprocess.run` calls that inherit a partially stripped env
 
-## The solution: AMPLIHACK_AGENT_BINARY
+The result: a session started as `copilot` could end up running `claude` for late-arriving hooks or sub-recipes, and `SessionEnd` hooks would fail-silent looking for a `claude`-shaped file that did not exist.
 
-When `amplihack` launches any tool, it writes the tool name into the child process environment as `AMPLIHACK_AGENT_BINARY`. Every subprocess — the AI tool itself, hooks, recipe steps — inherits this variable and can use it to spawn the correct binary without any additional configuration.
+## The solution: a config-driven resolver
 
-```sh
-# User invokes:
-amplihack claude
+A single shared resolver (`amplihack_utils::agent_binary::resolve`) is now the only sanctioned way to determine the active binary. It consults three sources in order, falling through on missing or invalid input:
 
-# Child process environment contains:
-AMPLIHACK_AGENT_BINARY=claude
+1. `AMPLIHACK_AGENT_BINARY` environment variable (explicit override)
+2. `<repo>/.claude/runtime/launcher_context.json` `launcher` field
+3. Built-in default `"copilot"`
 
-# User invokes:
-amplihack copilot
+The persisted file is the **canonical** state — once `amplihack copilot` runs in a repo, every descendant process can rediscover `copilot` by reading that file, regardless of what env vars survived the journey.
 
-# Child process environment contains:
-AMPLIHACK_AGENT_BINARY=copilot
+## Resolution algorithm
+
+```mermaid
+flowchart TD
+    A[Caller invokes resolve&#40;cwd&#41;] --> B{AMPLIHACK_AGENT_BINARY set?}
+    B -- yes --> V1[Validate against allowlist]
+    V1 -- ok --> R1[Return env value]
+    V1 -- reject --> W1[warn! and fall through]
+    B -- no --> W1
+    W1 --> C[Walk up cwd looking for<br/>.claude/runtime/launcher_context.json]
+    C -- found, fresh, ≤64 KiB --> P[Parse launcher field]
+    P --> V2[Validate against allowlist]
+    V2 -- ok --> R2[Return file value]
+    V2 -- reject --> W2[warn! and fall through]
+    C -- not found / stale / too big --> W2
+    W2 --> D[Return built-in default 'copilot']
 ```
 
-The value is always one of the four known tool names. It is set unconditionally on every launch — there is no fallback or default value that could mask a misconfiguration.
+Walk-up rules:
 
-## How it propagates
+- Stop at the first `.claude/runtime/launcher_context.json` found
+- Stop at the first `.git` boundary (do not cross into a parent repo)
+- Cap at 32 ancestors
 
-The Rust CLI sets `AMPLIHACK_AGENT_BINARY` inside `EnvBuilder::with_agent_binary()`, called as part of the env build chain in `launch.rs`:
+The **anchor** for symlink-escape checks is the directory containing the discovered `launcher_context.json`. The discovered file is canonicalized; if the canonical path does not start with the canonical anchor, the file is rejected.
 
-```rust
-let env = EnvBuilder::new()
-    .with_amplihack_session_id()
-    .with_amplihack_vars()
-    .with_agent_binary(tool)         // sets AMPLIHACK_AGENT_BINARY
-    .with_amplihack_home()
-    .set_if(is_noninteractive(), "AMPLIHACK_NONINTERACTIVE", "1")
-    .build();
+If walk-up exhausts all 32 ancestors (or hits a `.git` boundary) without finding a `launcher_context.json`, the resolver returns the built-in default with no anchor check — there is nothing to escape from.
+
+## How it propagates across processes
+
+The launcher writes the resolved value into **two** places at start time:
+
+1. `<repo>/.claude/runtime/launcher_context.json` — durable, survives all subprocess boundaries
+2. `AMPLIHACK_AGENT_BINARY` in the subprocess `Command` env — read-through cache for back-compat with external consumers (notably `rysweet/amplihack-recipe-runner`) that have not migrated
+
+Inside `amplihack-rs`, every read site calls `resolve(&cwd)` rather than reading the env var directly. This means the env var is no longer load-bearing — a stripped or missing variable always recovers the correct value from the file.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant L as amplihack launcher
+    participant F as launcher_context.json
+    participant T as tmux session
+    participant R as recipe runner
+    participant H as SessionEnd hook
+
+    U->>L: amplihack copilot
+    L->>F: write {"launcher":"copilot",...}
+    L->>T: spawn (env may be stripped)
+    Note over T: tmux/setsid strips most<br/>env vars including<br/>AMPLIHACK_AGENT_BINARY
+    T->>R: amplihack recipe run smart-orchestrator
+    R->>F: resolve(cwd) → read file → "copilot"
+    R->>H: invoke SessionEnd
+    H->>F: resolve(cwd) → "copilot"
+    H->>H: load .claude/hooks/copilot/session_end.py
 ```
 
-`tool` is the string passed to `run_launch()` by the CLI dispatcher — it is always the exact name of the subcommand the user invoked.
+## Default: copilot
+
+The implicit default changed from `"claude"` to `"copilot"`. This affects only sessions where:
+
+- `AMPLIHACK_AGENT_BINARY` is unset, AND
+- No `launcher_context.json` is found within the walk-up window, AND
+- Nothing else in the precedence chain produced a valid value
+
+For typical use the default never matters — `amplihack <tool>` writes the file. The default only governs cold-start cases like running `amplihack recipe run` from a directory that has never hosted a launch.
+
+To make `claude` the default for a repo, run `amplihack claude` once. To force `claude` for a single command, prefix with `AMPLIHACK_AGENT_BINARY=claude`.
 
 ## Consumers
 
 ### Recipe runner
 
-The recipe runner reads `AMPLIHACK_AGENT_BINARY` to decide which binary to call when launching a new AI session as part of a workflow step.
-
-```sh
-# Inside a recipe step script:
-${AMPLIHACK_AGENT_BINARY} --print "${PROMPT}" --model "${MODEL}"
-# Equivalent to: claude --print "..." or copilot --print "..." depending on which tool was used
-```
+`recipe-runner-rs` reads the env-var cache today; PR follow-up will switch it to call `resolve(&cwd)` directly. Both paths produce the same value because the launcher writes the env var from the resolver.
 
 ### Hooks
 
-Claude Code hooks run as subprocesses of the AI tool. They inherit the full environment, including `AMPLIHACK_AGENT_BINARY`. A hook that needs to spawn a continuation session uses this variable:
-
-```sh
-# In a PostToolUse hook
-if [ "$AMPLIHACK_AGENT_BINARY" = "claude" ]; then
-  # Claude-specific post-processing
-  claude --print "Review the output of the tool call"
-fi
-```
+`amplihack-hooks::binary_hook_resolver` calls `resolve(&cwd)`, then locates the per-binary hook file at `<amplihack-home>/.claude/hooks/<binary>/<event>.py`. See [Hook resolution & missing-hook errors](#hook-resolution--missing-hook-errors) below.
 
 ### Sub-agents
 
-Agents spawned by the recipe runner or by hooks inherit `AMPLIHACK_AGENT_BINARY` automatically because it is part of the process environment. No explicit passing is required.
+`amplihack-utils::llm_client::resolve_binary`, `claude_cli::get_claude_cli_path`, `knowledge_builder`, and `workflows::cascade` all call into the shared resolver. There is exactly one read implementation in Rust.
 
-## Supported values
+### Python skills
 
-| Value | Tool | Installed by |
-|-------|------|-------------|
-| `claude` | Anthropic Claude Code | npm: `@anthropic-ai/claude-code` |
-| `copilot` | GitHub Copilot CLI | npm: `@github/copilot` |
-| `codex` | OpenAI Codex CLI | npm: `@openai/codex-cli` |
-| `amplifier` | Microsoft Amplifier | uv: `git+https://github.com/microsoft/amplifier` |
+`amplifier-bundle/skills/pm-architect/scripts/agent_query.py` defines `detect_runtime()`, which implements the **same** three-step precedence and **same** allowlist as the Rust resolver. `delegate_response.py` imports it instead of re-implementing the precedence:
 
-No other values are valid. The Rust implementation uses a `debug_assert!` in `with_agent_binary()` that panics on unexpected values in debug and test builds, making misuse visible early in development.
+```python
+from agent_query import detect_runtime
+```
+
+A single canonical Python entry point (rather than copy-pasted inline functions) prevents the Rust ↔ Python implementations from drifting apart over time.
+
+For shell-only entry points (`amplifier-bundle/skills/migrate/scripts/migrate.sh`), the same algorithm is implemented with a `case` statement allowlist that refuses to invoke an un-allowlisted name as a binary.
+
+## Hook resolution & missing-hook errors
+
+Hooks are organized per-binary:
+
+```
+<amplihack-home>/.claude/hooks/
+├── claude/
+│   ├── pre_tool_use.py
+│   ├── post_tool_use.py
+│   └── session_end.py
+├── copilot/
+│   ├── pre_tool_use.py
+│   ├── post_tool_use.py
+│   └── session_end.py
+├── codex/
+│   └── ...
+└── amplifier/
+    └── ...
+```
+
+When an event fires, `binary_hook_resolver::resolve_hook(event)`:
+
+1. Resolves the active binary via the shared resolver
+2. Validates it against the allowlist
+3. Constructs `<amplihack-home>/.claude/hooks/<binary>/<event>.py`
+4. Canonicalizes the result and asserts it lives inside `amplihack-home`
+5. Returns the path if it exists, or `HookError::MissingHookForBinary` if not
+
+**Critical: there is no fallback.** If `copilot` is the active binary and `copilot/session_end.py` is missing, the resolver returns:
+
+```text
+No SessionEnd hook registered for active agent binary 'copilot'.
+Expected at: /home/alice/.amplihack/.claude/hooks/copilot/session_end.py
+To fix: install the hook at the expected path, switch binaries by re-launching
+with one of: 'amplihack claude' / 'amplihack copilot' / 'amplihack codex' /
+'amplihack amplifier', or set AMPLIHACK_AGENT_BINARY explicitly.
+```
+
+The user must take an explicit action — install the hook, switch binaries, or set the override. The system never silently runs `claude/session_end.py` in place of the missing `copilot/session_end.py`, and stub `session_end.py` files created solely to suppress the error are an architectural smell that the resolver is designed to reject. (See [PHILOSOPHY.md — Forbidden Patterns / Silent Fallbacks].)
+
+## Security
+
+The resolver and hook paths are derived from values that may originate in user-controlled environment variables or files. To prevent injection and path-traversal:
+
+| Concern               | Mitigation                                                                                          |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| Path traversal        | Allowlist binary names *before* substituting into a path; canonicalize then `starts_with` the root  |
+| Symlink escape        | Reject canonicalized paths that escape the discovered repo or `amplihack-home`                      |
+| Oversized config      | Cap `launcher_context.json` reads at 64 KiB                                                         |
+| JSON depth bombs      | Parse with `serde_json::from_str` into a typed struct; reject depth > 8 (current schema is depth 2; the cap is defense-in-depth against future additions) |
+| Env injection         | Trim, lowercase, length ≤ 32; reject `/`, `\`, `..`, null, whitespace, control chars                |
+| Shell-quoted values   | The resolved value is never passed through `sh -c`; only used as `Command::new(binary)` or path key |
+| Stale state           | Files older than 24h are treated as unset                                                           |
+| Diagnostic leakage    | Error messages use `Path::display()` and structured tracing fields; rejected values are never inlined into format strings |
 
 ## Related
 
-- [Environment Variables](../reference/environment-variables.md#amplihack_agent_binary) — Full reference for `AMPLIHACK_AGENT_BINARY`
-- [Bootstrap Parity](./bootstrap-parity.md) — Full Python/Rust parity contract for the launcher environment
+- [Active Agent Binary](../reference/active-agent-binary.md) — Resolver API and full algorithm
+- [Environment Variables](../reference/environment-variables.md#amplihack_agent_binary) — Env var reference
+- [Agent Configuration](../reference/agent-configuration.md) — Where this fits into broader config precedence
+- [Hooks Reference](../reference/hooks.md) — Per-binary hook layout and event list
+- [Bootstrap Parity](./bootstrap-parity.md) — How the Rust CLI matches the Python launcher's environment contract

--- a/docs/reference/active-agent-binary.md
+++ b/docs/reference/active-agent-binary.md
@@ -1,152 +1,221 @@
-# `active_agent_binary()` — Parent Agent Runtime Detection
+# Active Agent Binary — Resolver Reference
 
 ## Overview
 
-`active_agent_binary()` returns the identifier of the agent binary that the current `amplihack-cli` process should treat as its "active" runtime. As of #441, it auto-detects the parent agent runtime from well-known environment variables instead of unconditionally returning `"claude"`.
+The **active agent binary** is the AI tool (`claude`, `copilot`, `codex`, or `amplifier`) that the current process should treat as its runtime. It is resolved by a single shared function, used by every read site across `amplihack-cli`, `amplihack-utils`, `amplihack-workflows`, and `amplihack-hooks`, plus the Python helpers in `amplifier-bundle/`.
 
-This means that when `amplihack-cli` is invoked from inside a Copilot CLI, Claude Code, or Codex session, nested workflow steps stay on the caller's runtime without requiring the user to set `AMPLIHACK_AGENT_BINARY` manually.
-
-**Module:** `amplihack_cli::env_builder::helpers`
-**Signature:** `pub fn active_agent_binary() -> String`
-
-## Detection Priority
-
-The function evaluates the following sources in order and returns on the first match. A value is considered "set" only if it is present **and** non-empty after trimming whitespace.
-
-| # | Source                                                       | Returned identifier                  |
-| - | ------------------------------------------------------------ | ------------------------------------ |
-| 1 | `AMPLIHACK_AGENT_BINARY` (explicit override)                 | the override value, verbatim (after trim check) |
-| 2 | `COPILOT_AGENT_SESSION_ID`                                   | `"copilot"`                          |
-| 3 | `CLAUDECODE` **or** any env var starting with `CLAUDE_CODE_` | `"claude"`                           |
-| 4 | `CODEX_HOME` **or** any env var starting with `CODEX_`       | `"codex"`                            |
-| 5 | (none of the above)                                          | `"claude"` + a `tracing::warn!` log  |
-
-Empty or whitespace-only values are treated as "not set" at every level, including the override. For example, `AMPLIHACK_AGENT_BINARY=""` and `AMPLIHACK_AGENT_BINARY="   "` are both treated as unset and detection proceeds to step 2.
-
-### Prefix-match scope
-
-The `CLAUDE_CODE_` and `CODEX_` prefix scans iterate `std::env::vars_os()` and match **any** variable whose name starts with the given prefix:
-
-- `CLAUDE_CODE_*` matches `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_SSE_PORT`, etc. It does **not** match the bare `CLAUDE_*` namespace — `CLAUDE_API_KEY` will not trigger Claude detection.
-- `CODEX_*` matches every variable starting with `CODEX_`. `CODEX_HOME` is one such match; any other `CODEX_*` variable also triggers detection. The explicit `CODEX_HOME` check is a fast path, not an exclusion.
-
-## Usage
+**Canonical entry point (Rust):**
 
 ```rust
-use amplihack_cli::env_builder::helpers::active_agent_binary;
+use amplihack_utils::agent_binary;
 
-let binary = active_agent_binary();
-tracing::info!(%binary, "dispatching nested workflow on detected runtime");
+let binary: String = agent_binary::resolve(&cwd);
 ```
 
-The returned string is an **identifier**, not a path. Callers that need to launch the binary should resolve it through their existing platform allowlist (e.g. the launcher's binary resolver), never pass it directly to `Command::new`. The two existing in-tree consumers (`execute.rs` and `rust_trial.rs`) use the return value purely as an identifier passed to the platform binary resolver.
+**Canonical entry point (CLI wrapper):**
+
+```rust
+use amplihack_cli::env_builder::agent_binary_resolver;
+
+let binary: String = agent_binary_resolver::resolve(&cwd);
+```
+
+**Canonical entry point (Python):**
+
+```python
+# Defined in amplifier-bundle/skills/pm-architect/scripts/agent_query.py
+from agent_query import detect_runtime
+
+binary = detect_runtime()
+```
+
+The `detect_runtime()` function in `agent_query.py` is the single Python
+implementation; `delegate_response.py` imports it instead of re-implementing
+the precedence. The shell helper in `amplifier-bundle/skills/migrate/scripts/migrate.sh`
+re-implements the same precedence using a `case` statement allowlist (shell
+scripts cannot import Python).
+
+All implementations follow the **same precedence**, the **same allowlist**, and produce the **same default** so behavior is consistent across language boundaries and across `tmux` / subprocess hops.
+
+## Resolution Precedence
+
+The resolver evaluates sources in order and returns the first valid value. A value is "valid" only if it survives normalization (trim, lowercase) and matches the allowlist.
+
+| # | Source                                                                  | Notes                                                                                                                                  |
+| - | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 | `AMPLIHACK_AGENT_BINARY` env var                                        | Explicit override. Used by CI, tests, and external consumers (e.g. `rysweet/amplihack-recipe-runner`) that have not migrated yet.       |
+| 2 | `<repo>/.claude/runtime/launcher_context.json` `launcher` field          | Canonical persisted state. Written by `amplihack <tool>` on every launch via `LauncherContext::persist`. Survives `tmux`/subprocess hops without env passthrough. |
+| 3 | Built-in default                                                        | `"copilot"`                                                                                                                            |
+
+If a source produces a value that fails validation (allowlist, length, character class), the resolver emits `tracing::warn!` with structured fields and falls through to the next source. **No source ever silently coerces an invalid value.**
+
+### Why file-based, not env-based
+
+Environment variables do not survive every subprocess boundary in the launcher's call graph:
+
+- `tmux new-session -d` strips most variables unless they are explicitly forwarded.
+- Detached background processes started via `setsid` may inherit a stale or stripped env.
+- Sub-recipes spawned by `amplihack recipe run` invoke fresh `amplihack` binaries that may be reading env from the user's shell rather than the parent recipe runner.
+- Python hooks shell out to subcommands using `subprocess.run` which inherits the calling Python's env, not the Rust launcher's.
+
+`launcher_context.json` is written once per launch under `<repo>/.claude/runtime/` with `0o600` permissions and an atomic rename. Any descendant process can re-derive the path by walking up from its `cwd`, so the active binary is recoverable without any env coordination.
+
+## Allowlist & Validation
+
+The allowlist is **fixed** and identical in Rust and Python:
+
+```text
+{ "claude", "copilot", "codex", "amplifier" }
+```
+
+Validation rules applied to every candidate value before it can win precedence:
+
+- Length ≤ 32 bytes
+- No `/`, `\`, `..`, null bytes, whitespace, or ASCII control characters
+- Trim then lowercase, then exact match against the allowlist
+- No prefix matching, no substring matching, no shell expansion
+
+Values that fail validation are logged at `warn` level (with the rejected value redacted into a structured field, never inlined into a format string) and treated as if the source was unset.
+
+## Default Change: claude → copilot
+
+Prior to this refactor, the implicit default was `"claude"`. The default is now **`"copilot"`** to match the project's preferred runtime. To preserve the old behavior for an isolated invocation, set the env var explicitly:
+
+```sh
+AMPLIHACK_AGENT_BINARY=claude amplihack recipe run smart-orchestrator -c task_description="..."
+```
+
+To make `"claude"` permanent for a repo, run `amplihack claude` once — this writes `claude` into `launcher_context.json` and every subsequent process in that repo resolves to `claude`.
+
+**Existing `claude` users:** if your repo already has `.claude/runtime/launcher_context.json` with `"launcher": "claude"` from a prior `amplihack claude` invocation, no action is required. The file-based source (precedence step 2) wins over the new `copilot` default, so existing sessions keep resolving to `claude` until you explicitly run a different `amplihack <tool>` command.
+
+## File Format: `launcher_context.json`
+
+Path: `<repo>/.claude/runtime/launcher_context.json`
+Permissions: `0o600` (owner read/write only)
+Read cap: 64 KiB (oversized files are rejected with a warning)
+Staleness window: 24 hours (older files fall through as if unset)
+
+```json
+{
+  "launcher": "copilot",
+  "session_id": "01J9ZK7E5W6X9N3Q4VBHTC8MR2",
+  "cwd": "/home/alice/src/example-repo",
+  "started_at": "2026-04-29T04:12:55Z",
+  "amplihack_version": "0.7.4"
+}
+```
+
+The resolver only reads the `launcher` field. Other fields are owned by `LauncherContext` and documented in [Launcher Context](./launcher-context.md).
+
+## Hook Resolution
+
+Hooks live under `<amplihack-home>/.claude/hooks/<binary>/`. When a hook event fires, `amplihack-hooks::binary_hook_resolver` resolves the **active binary** via the algorithm above, then constructs the expected hook path:
+
+```
+<amplihack-home>/.claude/hooks/<binary>/<event>.py
+```
+
+### Hook Event Variants
+
+`HookEvent` is an enum with eight variants. Each variant maps to a fixed on-disk filename:
+
+| `HookEvent` variant | On-disk filename          | Fires when                                                                  |
+| ------------------- | ------------------------- | --------------------------------------------------------------------------- |
+| `SessionStart`      | `session_start.py`        | A new agent session is initialized                                          |
+| `SessionEnd`        | `session_end.py`          | A session terminates (normal exit, crash, or user interrupt)                |
+| `UserPromptSubmit`  | `user_prompt_submit.py`   | The user submits a prompt to the agent                                      |
+| `PreToolUse`        | `pre_tool_use.py`         | Before any tool call is executed                                            |
+| `PostToolUse`       | `post_tool_use.py`        | After any tool call completes (success or failure)                          |
+| `Stop`              | `stop.py`                 | The top-level agent stops emitting work                                     |
+| `SubagentStop`      | `subagent_stop.py`        | A subagent (`task` tool / explore / general-purpose) finishes               |
+| `PreCompact`        | `pre_compact.py`          | Before context compaction runs                                              |
+
+The mapping is encoded in `HookEvent::filename()` and is the single source of truth for hook discovery.
+
+### Missing-Hook Error
+
+If the file does not exist, the resolver returns:
+
+```rust
+HookError::MissingHookForBinary {
+    binary: String,
+    event: HookEvent,
+    expected_path: PathBuf,
+    remediation: &'static str,
+}
+```
+
+Display format:
+
+```text
+No SessionEnd hook registered for active agent binary 'copilot'.
+Expected at: /home/alice/.amplihack/.claude/hooks/copilot/session_end.py
+To fix: install the hook at the expected path, switch binaries by re-launching
+with one of: 'amplihack claude' / 'amplihack copilot' / 'amplihack codex' /
+'amplihack amplifier', or set AMPLIHACK_AGENT_BINARY explicitly for a single
+invocation.
+```
+
+**There is no fallback to `claude`'s hooks.** A missing `copilot` hook is reported as a hard error so the user can either install the hook or switch binary explicitly. Stub files that exist solely to swallow `MissingHookForBinary` are explicitly disallowed.
+
+The path is **always** validated:
+
+1. The binary name is checked against the allowlist before being substituted into the path.
+2. The constructed path is `canonicalize`d.
+3. The result must `starts_with(amplihack_home.canonicalize())` — any escape via symlink or `..` is rejected.
 
 ## Examples
 
-### Inside Copilot CLI
+### From a recipe step (bash)
 
-```bash
-# Copilot CLI sets COPILOT_AGENT_SESSION_ID for every nested process.
-$ env | grep COPILOT_AGENT_SESSION_ID
-COPILOT_AGENT_SESSION_ID=abc123
+The active binary is read from the same `launcher_context.json` the launcher writes. From a shell step, source the file directly (no dedicated subcommand exists — and one is unnecessary because the file is the canonical source):
 
-$ amplihack recipe run smart-orchestrator -c task_description="..."
-# active_agent_binary() -> "copilot"
+```sh
+# Active binary: read launcher_context.json by walking up from cwd
+launcher_ctx="$(git rev-parse --show-toplevel)/.claude/runtime/launcher_context.json"
+binary=$(jq -r .launcher "$launcher_ctx" 2>/dev/null || echo copilot)
+echo "spawning sub-task with: $binary"
 ```
 
-### Inside Claude Code
+For Rust callers inside `amplihack-rs`, always prefer `agent_binary::resolve(&cwd)` over re-implementing the walk-up.
 
-```bash
-$ env | grep -E '^(CLAUDECODE|CLAUDE_CODE_)'
-CLAUDECODE=1
-CLAUDE_CODE_ENTRYPOINT=cli
+### From Rust code
 
-$ amplihack recipe run default-workflow ...
-# active_agent_binary() -> "claude"
+```rust
+use amplihack_utils::agent_binary;
+use std::process::Command;
+
+let cwd = std::env::current_dir()?;
+let binary = agent_binary::resolve(&cwd);
+
+Command::new(binary)
+    .arg("--noninteractive")
+    .arg("--prompt")
+    .arg("Run the next workstream")
+    .status()?;
 ```
 
-Note that only the `CLAUDE_CODE_` prefix is scanned. A value such as `CLAUDE_API_KEY` would not trigger Claude detection on its own.
+### From a Python skill helper
 
-### Inside Codex
+```python
+# Defined in amplifier-bundle/skills/pm-architect/scripts/agent_query.py
+from agent_query import detect_runtime
 
-```bash
-$ env | grep ^CODEX_
-CODEX_HOME=/home/me/.codex
-
-$ amplihack recipe run investigation-workflow ...
-# active_agent_binary() -> "codex"
+binary = detect_runtime()
+print(f"querying via {binary}")
 ```
 
-### Explicit override (highest priority)
+### Explicit override for a single command
 
-```bash
-$ AMPLIHACK_AGENT_BINARY=copilot amplihack ...
-# active_agent_binary() -> "copilot"  (regardless of any other detection signals)
+```sh
+AMPLIHACK_AGENT_BINARY=codex amplihack recipe run smart-orchestrator \
+  -c task_description="..." -c repo_path=.
 ```
 
-### Empty override falls through to detection
+## Related
 
-```bash
-$ AMPLIHACK_AGENT_BINARY="   " COPILOT_AGENT_SESSION_ID=abc amplihack ...
-# active_agent_binary() -> "copilot"  (whitespace-only override is treated as unset)
-```
-
-### No runtime detected (fallback)
-
-```bash
-$ env -i amplihack ...
-# active_agent_binary() -> "claude"
-# WARN: AMPLIHACK_AGENT_BINARY not set; defaulting to 'claude'. ...
-```
-
-## Configuration Reference
-
-| Variable                    | Effect                                                       | Notes                                  |
-| --------------------------- | ------------------------------------------------------------ | -------------------------------------- |
-| `AMPLIHACK_AGENT_BINARY`    | Forces the returned identifier to this exact value           | Highest priority. Untrusted; callers must allowlist before exec. Empty/whitespace-only values fall through to detection. |
-| `COPILOT_AGENT_SESSION_ID`  | Presence selects `"copilot"`                                 | Set automatically by Copilot CLI       |
-| `CLAUDECODE`                | Presence selects `"claude"`                                  | Set automatically by Claude Code       |
-| `CLAUDE_CODE_*` (any)       | Presence of any matching var selects `"claude"`              | Strict prefix `CLAUDE_CODE_`. Bare `CLAUDE_*` does **not** match. |
-| `CODEX_HOME`                | Presence selects `"codex"`                                   | Set automatically by Codex             |
-| `CODEX_*` (any)             | Presence of any matching var selects `"codex"`               | Prefix `CODEX_`. `CODEX_HOME` is one such match; any other `CODEX_*` var also triggers detection. |
-
-All checks ignore values that are empty or whitespace-only.
-
-## Security Notes
-
-- `AMPLIHACK_AGENT_BINARY` is **untrusted user input**. `active_agent_binary()` returns it verbatim; do not pass the value directly to `Command::new` or shell. Resolve through your platform's binary allowlist.
-- The function never logs env var **values**, only detection outcomes (and only on the fallback branch).
-- Prefix scans iterate `std::env::vars_os()` once per call; cost is O(n) in env size — negligible for typical usage. Cache the result if invoked in a hot path.
-- No new dependencies are introduced.
-
-## Behavior Change Summary (#441)
-
-| Scenario                                               | Before #441           | After #441                                                 |
-| ------------------------------------------------------ | --------------------- | ---------------------------------------------------------- |
-| Run from Copilot CLI, no override                      | `"claude"` + warn     | `"copilot"`                                                |
-| Run from Claude Code, no override                      | `"claude"` + warn     | `"claude"` (no warn)                                       |
-| Run from Codex, no override                            | `"claude"` + warn     | `"codex"`                                                  |
-| `AMPLIHACK_AGENT_BINARY=foo` set                       | `"foo"`               | `"foo"` (unchanged)                                        |
-| `AMPLIHACK_AGENT_BINARY=""` (or whitespace) set        | `"claude"` + warn     | Falls through to runtime detection (or fallback + warn)    |
-| No detection vars and no override                      | `"claude"` + warn     | `"claude"` + warn (unchanged; warn message preserved verbatim) |
-
-The fallback warn message is preserved verbatim from the pre-#441 implementation so that existing log scrapers and alerts continue to match.
-
-## Testing
-
-Unit tests live in `crates/amplihack-cli/src/env_builder/tests_builder.rs` and cover all branches:
-
-- `override_wins_over_runtime_signals`
-- `detects_copilot_via_session_id`
-- `detects_claude_via_claudecode_or_prefix`
-- `detects_codex_via_home_or_prefix`
-- `fallback_when_nothing_set`
-
-Tests are standard `#[test]` functions. They serialize on a module-local `AGENT_BINARY_ENV_LOCK: Mutex<()>` and use a RAII `EnvSnapshot` guard that scrubs all detection-relevant variables (`AMPLIHACK_AGENT_BINARY`, `COPILOT_AGENT_SESSION_ID`, `CLAUDECODE`, `CODEX_HOME`, plus any `CLAUDE_CODE_*` / `CODEX_*` discovered at runtime) and restores the originals on drop. The mutex makes parallel `cargo test` execution safe.
-
-Run locally:
-
-```bash
-cargo clippy -p amplihack-cli --all-targets -- -D warnings
-TMPDIR=/tmp cargo test -p amplihack-cli --lib
-```
+- [Agent Binary Routing](../concepts/agent-binary-routing.md) — Architectural overview and rationale
+- [Environment Variables](./environment-variables.md#amplihack_agent_binary) — Full env var reference
+- [Agent Configuration](./agent-configuration.md#agent-binary-resolution) — Where the default fits into config precedence
+- [Hooks Reference](./hooks.md) — Per-binary hook layout and supported events

--- a/docs/reference/active-agent-binary.md
+++ b/docs/reference/active-agent-binary.md
@@ -106,7 +106,7 @@ Staleness window: 24 hours (older files fall through as if unset)
 }
 ```
 
-The resolver only reads the `launcher` field. Other fields are owned by `LauncherContext` and documented in [Launcher Context](./launcher-context.md).
+The resolver only reads the `launcher` field. Other fields are owned by `LauncherContext`.
 
 ## Hook Resolution
 
@@ -218,4 +218,4 @@ AMPLIHACK_AGENT_BINARY=codex amplihack recipe run smart-orchestrator \
 - [Agent Binary Routing](../concepts/agent-binary-routing.md) — Architectural overview and rationale
 - [Environment Variables](./environment-variables.md#amplihack_agent_binary) — Full env var reference
 - [Agent Configuration](./agent-configuration.md#agent-binary-resolution) — Where the default fits into config precedence
-- [Hooks Reference](./hooks.md) — Per-binary hook layout and supported events
+- [Hook Specifications](./hook-specifications.md) — Per-binary hook layout and supported events

--- a/docs/reference/agent-configuration.md
+++ b/docs/reference/agent-configuration.md
@@ -10,7 +10,7 @@ and hive deployments in amplihack-rs.
 | Variable                    | Type     | Default             | Description                            |
 |-----------------------------|----------|---------------------|----------------------------------------|
 | `AMPLIHACK_AGENT_MODEL`     | `String` | `claude-sonnet-4-5` | Default LLM model for agents           |
-| `AMPLIHACK_AGENT_BINARY`    | `String` | auto-detected       | Path to the AI tool binary             |
+| `AMPLIHACK_AGENT_BINARY`    | `String` | `copilot`           | Active AI binary; precedence: env var → `<repo>/.claude/runtime/launcher_context.json` → `copilot`. Allowlist: `claude` \| `copilot` \| `codex` \| `amplifier`. See [Active Agent Binary](./active-agent-binary.md). |
 | `AMPLIHACK_MEMORY_BACKEND`  | `String` | `cognitive`         | Memory backend: `cognitive`, `hierarchical`, `memory` |
 | `AMPLIHACK_MEMORY_TOPOLOGY` | `String` | `single`            | Memory topology: `single`, `distributed` |
 | `AMPLIHACK_MEMORY_STORAGE_PATH` | `String` | `~/.amplihack/memory.db` | Memory storage path          |
@@ -201,8 +201,22 @@ Configuration is resolved in this order (highest to lowest priority):
 4. **User config** — `~/.amplihack/config.toml`
 5. **Compiled defaults** — hardcoded in the crate
 
+## Agent Binary Resolution
+
+The active agent binary (`claude` | `copilot` | `codex` | `amplifier`) follows its **own** three-step precedence, distinct from the general config precedence above:
+
+1. `AMPLIHACK_AGENT_BINARY` env var (explicit override; CI / testing / back-compat)
+2. `<repo>/.claude/runtime/launcher_context.json` `launcher` field (canonical persisted state, written by every `amplihack <tool>` launch)
+3. Built-in default: **`copilot`**
+
+This precedence is implemented once in `amplihack_utils::agent_binary::resolve(&cwd)` and consumed by every Rust read site. Python helpers in `amplifier-bundle/skills/` follow the same rules. The persisted file lets the value survive `tmux` and detached subprocess boundaries that strip env vars.
+
+See [Active Agent Binary](./active-agent-binary.md) for the full algorithm, allowlist, and security notes, and [Agent Binary Routing](../concepts/agent-binary-routing.md) for the architectural rationale.
+
 ## Related
 
 - [Environment Variables](./environment-variables.md) — Full env var reference
+- [Active Agent Binary](./active-agent-binary.md) — Resolver API, allowlist, hook resolution
+- [Agent Binary Routing](../concepts/agent-binary-routing.md) — Architecture and propagation model
 - [Memory Backend](./memory-backend.md) — Backend selection details
 - [Hive Orchestration](../concepts/hive-orchestration.md) — Hive architecture

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -42,30 +42,50 @@ These variables are injected into every child process launched by `amplihack`. T
 ### AMPLIHACK_AGENT_BINARY
 
 **Type:** string
-**Values:** `claude` | `copilot` | `codex` | `amplifier`
-**Set by:** `EnvBuilder::with_agent_binary()`
+**Allowed values:** `claude` | `copilot` | `codex` | `amplifier` (case-insensitive, exact match after trim)
+**Default:** `copilot`
+**Set by:** `EnvBuilder::with_agent_binary()` (as a back-compat read-through cache)
+**Read by:** `amplihack_utils::agent_binary::resolve()` (precedence step 1)
 
-Identifies which CLI binary was used to start the current session. Downstream consumers — the recipe runner, hooks, and sub-agents — read this variable to know which tool to invoke when they need to spawn a new AI session.
+Identifies which CLI binary the current session should use when spawning new AI sessions. As of the agent-binary-resolver refactor, this variable is **no longer the source of truth** — it is one of three precedence sources consulted by the shared resolver:
+
+1. `AMPLIHACK_AGENT_BINARY` env var (explicit override; CI/testing/back-compat)
+2. `<repo>/.claude/runtime/launcher_context.json` `launcher` field (canonical persisted state)
+3. Built-in default: **`copilot`**
+
+The launcher continues to write this variable to subprocess environments so that external consumers (notably `rysweet/amplihack-recipe-runner`) that have not yet migrated to the file-based resolver continue to work. New code inside `amplihack-rs` should call `amplihack_utils::agent_binary::resolve(&cwd)` instead of reading the env var directly.
+
+#### Validation
+
+Values are normalized (trim, lowercase) and matched against the allowlist `{claude, copilot, codex, amplifier}`. Values that contain `/`, `\`, `..`, null bytes, whitespace, control characters, or exceed 32 bytes are **rejected**. On rejection the resolver emits a structured `tracing::warn!` and falls through to the next precedence source.
 
 ```sh
-# Start a Claude session
-amplihack claude
-
-# Inside Claude Code hooks, the recipe runner sees:
-echo $AMPLIHACK_AGENT_BINARY
-# claude
-
-# Start a Copilot session
+# Start a Copilot session (the new default)
 amplihack copilot
 
-# Inside hooks:
+# Inside hooks, recipe steps, sub-agents:
 echo $AMPLIHACK_AGENT_BINARY
 # copilot
+
+# Explicit override (CI, testing, manual selection)
+AMPLIHACK_AGENT_BINARY=claude amplihack recipe run smart-orchestrator -c task_description="..."
+
+# Invalid values are rejected and the resolver falls through
+AMPLIHACK_AGENT_BINARY="../bin/evil" amplihack copilot
+# warn: rejected AMPLIHACK_AGENT_BINARY (failed allowlist); falling back to launcher_context.json
 ```
 
-**Why it exists:** The recipe runner is agent-agnostic; it must call back into whatever tool launched it. Without this variable, the runner would have to guess the binary name or require manual configuration. See [Agent Binary Routing](../concepts/agent-binary-routing.md) for the full rationale.
+#### Why the precedence order
 
-**Python parity:** Corresponds to `AMPLIHACK_AGENT_BINARY` set by the Python launcher in `amplihack/cli/launch.py`.
+- **Env var first** preserves the established escape hatch for CI/testing and lets external recipe-runner builds keep working unchanged.
+- **`launcher_context.json` second** ensures that once a user runs `amplihack copilot` in a repo, every subsequent subprocess — even ones launched many hops away through `tmux`, sub-recipes, or detached hooks — picks up `copilot` without depending on env passthrough.
+- **`copilot` default last** matches the project's current preferred runtime and removes the prior implicit `claude` assumption.
+
+**Why it exists:** Recipe runner, hooks, and sub-agents are agent-agnostic and must call back into whatever tool the user actually launched. See [Active Agent Binary](./active-agent-binary.md) for the full algorithm and [Agent Binary Routing](../concepts/agent-binary-routing.md) for the architectural rationale.
+
+**Python parity:** Python skill scripts (`amplifier-bundle/skills/pm-architect/scripts/agent_query.py`, `delegate_response.py`) implement the **same** three-step precedence and **same** allowlist; `agent_query.py::detect_runtime()` is the canonical Python entry point and is reused by `delegate_response.py`. The shell helper at `amplifier-bundle/skills/migrate/scripts/migrate.sh` re-implements the same algorithm with a `case` statement allowlist. The active binary is therefore consistent across Rust, Python, and shell code paths.
+
+**Existing `claude` users:** repos that already have `.claude/runtime/launcher_context.json` with `"launcher": "claude"` continue to resolve to `claude` automatically — the file (precedence step 2) wins over the new `copilot` default. No migration action is required.
 
 ---
 
@@ -292,23 +312,24 @@ These variables are set by the recipe executor (`amplihack recipe run`) in every
 
 Overrides the `timeout_seconds` value defined in individual recipe steps. When set, every step in the recipe uses this value instead of its YAML-defined timeout. A value of `"0"` disables step timeouts entirely, allowing steps to run indefinitely.
 
-This variable is only present in the child environment when the user passes `--step-timeout` to `amplihack recipe run`. When omitted, YAML-defined `timeout_seconds` values apply as-is.
+This variable is only present in the child environment when the user passes `--step-timeout` or `--no-step-timeouts` to `amplihack recipe run`. When neither flag is provided, YAML-defined `timeout_seconds` values apply as-is (though the default-workflow agent steps no longer define `timeout_seconds`).
 
 ```sh
 # Override all step timeouts to 10 minutes
 amplihack recipe run recipe.yaml --step-timeout 600
 # Child process sees: AMPLIHACK_STEP_TIMEOUT=600
 
-# Disable all step timeouts
+# Disable all step timeouts (two equivalent forms)
 amplihack recipe run recipe.yaml --step-timeout 0
+amplihack recipe run recipe.yaml --no-step-timeouts
 # Child process sees: AMPLIHACK_STEP_TIMEOUT=0
 
-# No override — YAML timeouts apply
+# No override — YAML timeouts apply (agent steps have none by default)
 amplihack recipe run recipe.yaml
 # AMPLIHACK_STEP_TIMEOUT is NOT set in child environment
 ```
 
-**Why it exists:** Long-running agent steps (architecture design, large refactoring) can exceed the conservative `timeout_seconds` defaults in recipe YAML files. Rather than requiring users to edit YAML files, this flag provides a runtime override. The env var approach is forward-compatible — `recipe-runner-rs` can adopt it independently without CLI changes.
+**Why it exists:** The default-workflow recipes no longer define `timeout_seconds` on agent steps, so agent steps run to completion without artificial time limits. This variable provides an opt-in escape hatch for CI environments that need wall-clock budgets. The env var approach is forward-compatible — `recipe-runner-rs` can adopt it independently without CLI changes.
 
 **Security note:** The value is always a `u64` rendered as a string. No shell metacharacters are possible. The CLI rejects non-numeric input at parse time via clap's type enforcement.
 


### PR DESCRIPTION
Closes #489

## Summary
Replaces the brittle `AMPLIHACK_AGENT_BINARY`-only resolution (with default `'claude'` and prefix-sniffing of `CLAUDECODE`/`COPILOT_AGENT_SESSION_ID`/`CODEX_HOME`) with a single shared resolver:

**Resolution precedence**
1. `AMPLIHACK_AGENT_BINARY` env var (allowlist-validated; explicit override)
2. `<repo>/.claude/runtime/launcher_context.json` `launcher` field (canonical persisted state — survives tmux/subprocess hops without env passthrough)
3. Built-in default: **`copilot`** (was `claude`)

## Behavior changes
- Default agent binary is now `copilot` (was `claude`).
- Subprocesses re-derive the active binary from `launcher_context.json` rather than relying on env passthrough across tmux/subprocess boundaries.
- Prefix-sniffing of runtime env vars (`CLAUDECODE`, `CODEX_HOME`, `COPILOT_AGENT_SESSION_ID`, etc.) is removed; only the explicit `AMPLIHACK_AGENT_BINARY` override is honored.
- Per-binary hook resolution now hard-errors via `HookError::MissingHookForBinary` with a structured remediation message when the active binary lacks the required hook. **No** claude fallback. **No** stub `session_end.py` created.

## Modules
- New `amplihack_utils::agent_binary` — single source of truth resolver with strict allowlist validation.
- New `amplihack_hooks::binary_hook_resolver` — `HookEvent` enum, `HookError::MissingHookForBinary`, `expected_hook_path`, `resolve_hook`, with path-traversal protection.
- New `amplihack_cli::env_builder::agent_binary_resolver` — thin CLI wrapper.
- All Rust read sites delegate: `helpers.rs`, `llm_client.rs`, `claude_cli.rs`, `knowledge_builder.rs`, `cascade.rs`, `rust_trial.rs`.
- Python parity: `agent_query.py`, `delegate_response.py`, `migrate.sh` read `launcher_context.json` with the same precedence and default.

## Tests
- New: `agent_binary_resolver_test` (14 tests), `agent_binary_security` (9 tests), `hook_resolution_test` (8 tests), `active_agent_binary_default_test` (3 tests).
- Updated: existing #441 tests rewritten to match the new precedence and `copilot` default. Tests that need claude now set the env override explicitly.
- All targeted crates green: `amplihack-cli` (1118 lib tests), `amplihack-utils` (385+), `amplihack-workflows` (52), `amplihack-hooks` (231) — pre-existing 3 `session_start::blarify` failures are unrelated and untouched on `origin/main`.

## Documentation
- Updated: `docs/reference/active-agent-binary.md`, `docs/reference/agent-configuration.md`, `docs/reference/environment-variables.md`, `docs/concepts/agent-binary-routing.md`.

## Quality gates
- `cargo clippy --all-targets -- -D warnings` clean for amplihack-cli, amplihack-utils, amplihack-workflows, amplihack-hooks, amplihack-launcher.
- `cargo fmt --check` clean.
- All new modules ≤ 500 lines.

## Out of scope
- External `rysweet/amplihack-recipe-runner` upgrade is filed separately (resolver still writes `AMPLIHACK_AGENT_BINARY` to subprocess env as a back-compat read-through cache).
