### PR TITLE
fix(recipes): never strand a pushed branch — emit commit_result.pushed contract (#495)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
           fi
       - name: Recipes — no bare python invocations (issue #248)
         run: scripts/check-recipes-no-python.sh
+      - name: Recipes — PR always opens after successful push (issue #495)
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-pr-always-opens.sh
+      - name: Recipes — static guard validation scope (issue #495)
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-static-guard-validation-scope.sh
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/amplifier-bundle/recipes/consensus-publish.yaml
+++ b/amplifier-bundle/recipes/consensus-publish.yaml
@@ -129,14 +129,29 @@ steps:
       PR_TITLE=$(printf '%s' "$_TASK_DESC" | tr '\n\r' ' ' | cut -c1-200)
       PR_CREATED=false
       if git remote get-url origin >/dev/null 2>&1; then
+        # FIX (#495): capture gh stderr so we can emit a workflow-command
+        # warning when the push succeeded earlier but PR creation now fails.
+        # Without this, branches get stranded silently. `::` is replaced with
+        # `:_:` to defend against workflow-command injection in stderr.
+        _pr_stderr_file=$(mktemp -t consensus-pr-XXXXXX)
         if gh pr create \
           --title "$PR_TITLE" \
           --body "$PR_BODY" \
-          --label "consensus-validated" 2>/dev/null; then
+          --label "consensus-validated" 2>"$_pr_stderr_file"; then
           PR_CREATED=true
         else
-          echo "PR creation failed" >&2
+          _pr_rc=$?
+          echo "PR creation failed (exit $_pr_rc)" >&2
+          cat "$_pr_stderr_file" >&2
+          # If the prior step9 push succeeded, this is a stranded-branch case
+          # — emit a GitHub Actions workflow-command warning so it's visible
+          # in CI logs. Sanitize `::` to prevent workflow-command injection.
+          if [ "${COMMIT_RESULT_PUSHED:-false}" = "true" ] || [ "${COMMIT_RESULT_PUSHED:-false}" = "True" ]; then
+            _safe_msg=$(sed -E 's/::/:_:/g' "$_pr_stderr_file" | tr '\n' ' ' | head -c 400)
+            echo "::warning title=consensus-publish stranded push::push succeeded (commit_result.pushed=true) but gh pr create failed: ${_safe_msg}" >&2
+          fi
         fi
+        rm -f "$_pr_stderr_file"
       else
         echo "Skipping PR creation — no remote configured" >&2
       fi
@@ -154,4 +169,3 @@ steps:
   # CONSENSUS GATE 5: Expert Panel for PR Review (MANDATORY)
   # Deploy: reviewer, security, optimizer, patterns, tester agents
   # ---------------------------------------------------------------------------
-

--- a/amplifier-bundle/recipes/tests/test-pr-always-opens.sh
+++ b/amplifier-bundle/recipes/tests/test-pr-always-opens.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# test-pr-always-opens.sh — regression test for issue: recipes strand pushed
+# branches without opening a PR when post-push validation fails (e.g. the
+# legacy `build_publish_validation_scope.py` helper is missing).
+#
+# Contract under test (from RETCON_DOCS §5, §7):
+#   1. step-15-commit-push MUST emit a commit_result JSON with a strict
+#      string field `pushed` ("true"|"false") on every exit path (trap-on-EXIT).
+#   2. The post-push validation step MUST be wrapped warn-and-continue
+#      so that a missing build_publish_validation_*.py never aborts the recipe.
+#   3. step-16-create-draft-pr MUST run whenever pushed=="true", regardless
+#      of any post-push validation failure.
+#   4. The fake `gh` shim MUST be invoked with `pr create` after a successful
+#      push even when validation failed.
+#   5. The captured invocation log MUST contain no token material (defense
+#      in depth — nothing in the recipe should echo gh auth output).
+#
+# This test SHOULD FAIL before the workflow-publish.yaml hardening lands.
+# It MUST PASS once the recipe emits commit_result and the PR-creation step
+# is gated on commit_result.pushed=="true".
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-pr-always-opens.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-publish.yaml"
+
+if [[ ! -f "${RECIPE}" ]]; then
+    echo "HARNESS-ERROR: ${RECIPE} not found" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d -t pr-always-opens-XXXXXX)"
+trap 'rm -rf "${WORK}"' EXIT
+
+mkdir -p "${WORK}/bin"
+GH_LOG="${WORK}/gh-invocations.log"
+: > "${GH_LOG}"
+
+# Fake `gh` shim — records every invocation, never contacts the network,
+# never prints token material.
+cat > "${WORK}/bin/gh" <<'SHIM'
+#!/usr/bin/env bash
+# Records arguments to gh-invocations.log. Returns success for `pr create`,
+# success for `pr list` (returns empty list = no existing PR), success for
+# `auth status` (without printing the token). Any other subcommand exits 0.
+log="${GH_INVOCATIONS_LOG:?GH_INVOCATIONS_LOG must be set}"
+printf '%s\n' "$*" >> "$log"
+case "${1:-}-${2:-}" in
+    pr-create)
+        echo "https://github.com/example/repo/pull/9999"
+        ;;
+    pr-list)
+        # No pre-existing PR — empty JSON array
+        echo "[]"
+        ;;
+    auth-status)
+        echo "Logged in (no-token-here)" >&2
+        ;;
+esac
+exit 0
+SHIM
+chmod +x "${WORK}/bin/gh"
+export GH_INVOCATIONS_LOG="${GH_LOG}"
+
+# --- Assertion 1: workflow-publish.yaml MUST emit commit_result with pushed
+# field on the step-15 commit/push step.
+if ! grep -qE 'commit_result' "${RECIPE}"; then
+    echo "FAIL[1]: workflow-publish.yaml does not emit commit_result" >&2
+    exit 1
+fi
+if ! grep -qE '"pushed"[[:space:]]*:[[:space:]]*"(true|false)"' "${RECIPE}" \
+   && ! grep -qE 'pushed[[:space:]]*[:=]' "${RECIPE}"; then
+    echo "FAIL[1b]: commit_result does not record a pushed field" >&2
+    exit 1
+fi
+
+# --- Assertion 2: PR-creation step MUST be gated on pushed=="true" (or the
+# fallback should_create_pr boolean per RETCON_DOCS §4).
+if ! grep -qE 'commit_result.*pushed.*true|should_create_pr' "${RECIPE}"; then
+    echo "FAIL[2]: PR-creation step is not gated on pushed status" >&2
+    exit 1
+fi
+
+# --- Assertion 3: Post-push validation MUST be warn-and-continue (no bare
+# invocation that can abort the recipe under set -e).
+if grep -nE 'build_publish_validation' "${RECIPE}" >/dev/null 2>&1; then
+    # If the recipe still references the helper at all, it MUST be wrapped.
+    if ! grep -qE 'if[[:space:]]*!.*build_publish_validation|WARN.*validation' \
+            "${RECIPE}"; then
+        echo "FAIL[3]: build_publish_validation reference is not warn-and-continue" >&2
+        exit 1
+    fi
+fi
+
+# --- Assertion 4: Simulate the post-push contract end-to-end with the fake
+# gh shim. Build a minimal harness that mirrors the recipe's commit_result
+# emission and PR-creation gate.
+HARNESS="${WORK}/run.sh"
+cat > "${HARNESS}" <<'HARNESS_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="${WORK}/bin:${PATH}"
+
+# Mirror step-15: emit commit_result on EXIT regardless of later failures.
+commit_result_file="${WORK}/commit_result.json"
+pushed="false"
+sha=""
+branch="feat/test-branch"
+reason=""
+emit_commit_result() {
+    jq -n \
+        --arg pushed "${pushed}" \
+        --arg sha    "${sha}" \
+        --arg branch "${branch}" \
+        --arg reason "${reason}" \
+        '{pushed:$pushed,sha:$sha,branch:$branch,reason:$reason}' \
+        > "${commit_result_file}"
+}
+trap emit_commit_result EXIT
+
+# Pretend git push succeeded.
+pushed="true"
+sha="0000000000000000000000000000000000000000"
+reason="ok"
+
+# Mirror post-push validation: helper missing → warn-and-continue (NOT abort).
+if ! command -v build_publish_validation_scope.py >/dev/null 2>&1; then
+    echo "WARN: build_publish_validation_scope.py missing, continuing" >&2
+fi
+
+# Mirror step-16 gate: if pushed=="true", create PR even though validation
+# couldn't run.
+emit_commit_result   # flush before reading (trap also fires on normal exit)
+if [[ "$(jq -r '.pushed' "${commit_result_file}")" == "true" ]]; then
+    # Idempotency probe (mirrors existing recipe behavior).
+    existing="$(gh pr list --head "${branch}" --json number 2>/dev/null || echo '[]')"
+    if [[ "${existing}" == "[]" ]]; then
+        gh pr create \
+            --title "fix(recipes): never strand pushed work without opening PR" \
+            --body  "Fixes #PLACEHOLDER" \
+            --head  "${branch}" \
+            --base  "main"
+    fi
+fi
+HARNESS_EOF
+chmod +x "${HARNESS}"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "HARNESS-ERROR: jq required" >&2
+    exit 2
+fi
+
+WORK="${WORK}" bash "${HARNESS}"
+
+# --- Assertion 4: gh pr create MUST have been called.
+if ! grep -qE '^pr create' "${GH_LOG}"; then
+    echo "FAIL[4]: gh pr create was not invoked after successful push" >&2
+    echo "--- gh-invocations.log ---" >&2
+    cat "${GH_LOG}" >&2
+    exit 1
+fi
+
+# --- Assertion 5: invocation log MUST be free of token material.
+if grep -qiE 'token|ghp_|github_pat_' "${GH_LOG}"; then
+    echo "FAIL[5]: gh-invocations.log contains token-like material" >&2
+    exit 1
+fi
+
+# --- Assertion 6: commit_result.json MUST be a strict {pushed,sha,branch,reason}
+# object with pushed as the string "true" (not boolean true).
+if ! jq -e '.pushed == "true" and (.sha|type=="string") and (.branch|type=="string")' \
+        "${WORK}/commit_result.json" >/dev/null; then
+    echo "FAIL[6]: commit_result.json schema/type contract violated" >&2
+    cat "${WORK}/commit_result.json" >&2
+    exit 1
+fi
+
+echo "PASS: PR is opened even when post-push validation cannot run."
+exit 0

--- a/amplifier-bundle/recipes/tests/test-static-guard-validation-scope.sh
+++ b/amplifier-bundle/recipes/tests/test-static-guard-validation-scope.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# test-static-guard-validation-scope.sh — verifies that
+# scripts/check-recipes-no-python.sh detects any reintroduction of the legacy
+# `build_publish_validation_*.py` helper inside the shipped scan roots
+# (amplifier-bundle/{recipes,agents,prompts}/).
+#
+# Contract (from RETCON_DOCS §6):
+#   - Pinned regex: build_publish_validation_[A-Za-z0-9_]+\.py
+#   - Scoped to amplifier-bundle/{recipes,agents,prompts}/ (NOT .git/, target/,
+#     node_modules/, docs/).
+#   - Clean tree → exit 0; tree with a fixture violation → exit 1, with the
+#     offending path printed.
+#
+# This test SHOULD FAIL before scripts/check-recipes-no-python.sh is extended
+# with the validation-scope guard.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-static-guard-validation-scope.sh
+# Exit: 0 = pass, 1 = fail, 2 = harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+GUARD="${REPO_ROOT}/scripts/check-recipes-no-python.sh"
+
+if [[ ! -x "${GUARD}" ]]; then
+    echo "HARNESS-ERROR: ${GUARD} not found or not executable" >&2
+    exit 2
+fi
+
+# --- Assertion 1: clean repo (no fixtures) passes the guard.
+if ! "${GUARD}" >/dev/null 2>&1; then
+    echo "FAIL[1]: guard reports failure on the clean tree" >&2
+    "${GUARD}" >&2 || true
+    exit 1
+fi
+
+# --- Assertion 2: the guard's source MUST mention the validation-scope regex.
+if ! grep -qE 'build_publish_validation_\[A-Za-z0-9_\]\+\\\.py|build_publish_validation' \
+        "${GUARD}"; then
+    echo "FAIL[2]: guard does not implement the build_publish_validation_*.py check" >&2
+    exit 1
+fi
+
+# --- Assertion 3: planting a fixture in each scan root triggers exit 1.
+WORK="$(mktemp -d -t static-guard-XXXXXX)"
+trap 'cleanup' EXIT
+PLANTED=()
+cleanup() {
+    for f in "${PLANTED[@]:-}"; do
+        [[ -n "$f" && -f "$f" ]] && rm -f "$f"
+    done
+    rm -rf "${WORK}"
+}
+
+# Use a uniquely named fixture so we can confirm the guard names it.
+FIXTURE_NAME="z-fixture-$$-validation-scope-test.yaml"
+FIXTURE_BODY='# fixture: should be flagged
+steps:
+  - run: build_publish_validation_scope.py --check'
+
+for root in recipes agents prompts; do
+    target_dir="${REPO_ROOT}/amplifier-bundle/${root}"
+    [[ -d "${target_dir}" ]] || continue
+    fixture_path="${target_dir}/${FIXTURE_NAME}"
+    printf '%s\n' "${FIXTURE_BODY}" > "${fixture_path}"
+    PLANTED+=("${fixture_path}")
+
+    set +e
+    output="$("${GUARD}" 2>&1)"
+    rc=$?
+    set -e
+
+    if [[ ${rc} -eq 0 ]]; then
+        echo "FAIL[3:${root}]: guard did not detect fixture at ${fixture_path}" >&2
+        echo "--- guard output ---" >&2
+        printf '%s\n' "${output}" >&2
+        exit 1
+    fi
+
+    if ! printf '%s\n' "${output}" | grep -qF "${FIXTURE_NAME}"; then
+        echo "FAIL[3b:${root}]: guard exited non-zero but did not name the fixture" >&2
+        printf '%s\n' "${output}" >&2
+        exit 1
+    fi
+
+    rm -f "${fixture_path}"
+    PLANTED=("${PLANTED[@]/$fixture_path}")
+done
+
+# --- Assertion 4: docs/ fixture MUST NOT trigger the guard (scope discipline).
+docs_fixture="${REPO_ROOT}/docs/${FIXTURE_NAME}"
+if [[ -d "${REPO_ROOT}/docs" ]]; then
+    printf '%s\n' "${FIXTURE_BODY}" > "${docs_fixture}"
+    PLANTED+=("${docs_fixture}")
+    set +e
+    "${GUARD}" >/dev/null 2>&1
+    rc=$?
+    set -e
+    rm -f "${docs_fixture}"
+    PLANTED=("${PLANTED[@]/$docs_fixture}")
+    if [[ ${rc} -ne 0 ]]; then
+        echo "FAIL[4]: guard incorrectly flagged docs/ (out of scope)" >&2
+        exit 1
+    fi
+fi
+
+echo "PASS: static guard correctly detects build_publish_validation_*.py and respects scope."
+exit 0

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -121,12 +121,44 @@ steps:
     command: |
       set -euo pipefail
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
-      echo "=== Step 15: Commit and Push ==="
-      echo ""
-      echo "--- Staging Changes ---"
+      echo "=== Step 15: Commit and Push ===" >&2
+      echo "" >&2
+
+      # FIX (#495): commit_result MUST be emitted on every exit path so step-16
+      # (PR creation) can be gated on the actual push outcome. The trap-on-EXIT
+      # contract guarantees a strict-shape JSON object with `pushed` as a string
+      # ("true"|"false") regardless of where the script exits. See RETCON_DOCS
+      # §4 for the failure-mode table.
+      #
+      # CONTRACT: This trap MUST be installed AFTER variable initialization but
+      # BEFORE any command that can fail. Reordering produces invalid JSON on
+      # early failures. The static guard does not catch trap-ordering bugs.
+      if ! command -v jq >/dev/null 2>&1; then
+        echo "ERROR: jq is required by step-15 (commit_result emission). Install jq in CI image." >&2
+        exit 2
+      fi
+      pushed="false"
+      sha=""
+      branch=""
+      reason="aborted"
+      _emit_commit_result() {
+        # Use jq -nc --arg for ALL string fields — never printf/heredoc concat
+        # (avoids JSON injection if reason/branch contain quotes or newlines).
+        jq -nc \
+          --arg pushed "$pushed" \
+          --arg sha    "$sha" \
+          --arg branch "$branch" \
+          --arg reason "$reason" \
+          '{pushed:$pushed,sha:$sha,branch:$branch,reason:$reason}'
+      }
+      trap _emit_commit_result EXIT
+
+      branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+      echo "--- Staging Changes ---" >&2
       git add -A
-      echo ""
-      echo "--- Creating Commit ---"
+      echo "" >&2
+      echo "--- Creating Commit ---" >&2
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
       TASK_DESC="$TASK_DESCRIPTION"
       ISSUE_NUMBER="$ISSUE_NUMBER"
@@ -156,14 +188,16 @@ steps:
           echo "produced no git artifacts. Check that agents created files in the worktree," >&2
           echo "not in AMPLIHACK_HOME or other locations." >&2
           git --no-pager status >&2
+          reason="nothing-to-commit"
           exit 1
         fi
       fi
-      echo ""
-      echo "--- Pushing to Remote ---"
+      echo "" >&2
+      echo "--- Pushing to Remote ---" >&2
       # REL-002: Detect missing upstream tracking branch before rev-list
       if ! git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
         echo "WARNING: No upstream tracking branch configured — skipping push" >&2
+        reason="no-upstream"
         exit 0
       fi
       COMMITS_AHEAD=$(git rev-list --count @{u}..HEAD)
@@ -171,13 +205,40 @@ steps:
         # REL-001: No stderr suppression on rebase — surface conflict diagnostics
         # Split into separate statements so set -e catches rebase failures
         git pull --rebase
-        git push
+        # FIX (#495): capture push stderr, redact tokens before assigning to
+        # `reason` (which is JSON-emitted via jq --arg). Token redaction defends
+        # against accidental credential leak via authenticated remote URLs.
+        push_stderr_file=$(mktemp -t step15-push-XXXXXX)
+        # shellcheck disable=SC2064
+        trap "rm -f \"$push_stderr_file\"; _emit_commit_result" EXIT
+        if git push 2>"$push_stderr_file"; then
+          # Only mutate `pushed` AFTER successful push — this is the contract
+          # that step-16's gate depends on.
+          pushed="true"
+          raw_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
+          if printf '%s' "$raw_sha" | grep -qE '^[0-9a-f]{40}$'; then
+            sha="$raw_sha"
+          else
+            sha=""
+          fi
+          reason="pushed"
+        else
+          push_rc=$?
+          # Sanitize: strip credentials from authenticated remote URLs.
+          sanitized=$(sed -E 's#https://[^@[:space:]]+@#https://REDACTED@#g' "$push_stderr_file" | tr '\n' ' ' | head -c 500)
+          reason="push-failed: ${sanitized}"
+          echo "ERROR: git push failed (exit $push_rc)" >&2
+          cat "$push_stderr_file" >&2
+          exit "$push_rc"
+        fi
       else
-        echo "WARNING: Nothing to push - branch is up to date with remote"
+        echo "WARNING: Nothing to push - branch is up to date with remote" >&2
+        reason="nothing-to-push"
       fi
-      echo ""
-      echo "=== Commit and Push Complete ==="
+      echo "" >&2
+      echo "=== Commit and Push Complete ===" >&2
     output: "commit_result"
+    parse_json: true
 
   # ==========================================================================
   # STEP 16: OPEN PULL REQUEST AS DRAFT
@@ -185,7 +246,7 @@ steps:
   # ==========================================================================
   - id: "step-16-create-draft-pr"
     type: "bash"
-    condition: "goal_already_met != 'true'"
+    condition: "goal_already_met != 'true' && commit_result.pushed == 'true'"
     command: |
       set -euo pipefail
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-16 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -122,42 +122,22 @@ steps:
       set -euo pipefail
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Step 15: Commit and Push ===" >&2
-      echo "" >&2
-
       # FIX (#495): commit_result MUST be emitted on every exit path so step-16
-      # (PR creation) can be gated on the actual push outcome. The trap-on-EXIT
-      # contract guarantees a strict-shape JSON object with `pushed` as a string
-      # ("true"|"false") regardless of where the script exits. See RETCON_DOCS
-      # §4 for the failure-mode table.
-      #
-      # CONTRACT: This trap MUST be installed AFTER variable initialization but
-      # BEFORE any command that can fail. Reordering produces invalid JSON on
-      # early failures. The static guard does not catch trap-ordering bugs.
+      # (PR creation) can be gated on the actual push outcome. Trap installed
+      # AFTER var init, BEFORE any failing command — reordering produces invalid JSON.
       if ! command -v jq >/dev/null 2>&1; then
-        echo "ERROR: jq is required by step-15 (commit_result emission). Install jq in CI image." >&2
+        echo "ERROR: jq is required by step-15 (commit_result emission)." >&2
         exit 2
       fi
-      pushed="false"
-      sha=""
-      branch=""
-      reason="aborted"
+      pushed="false"; sha=""; branch=""; reason="aborted"
       _emit_commit_result() {
-        # Use jq -nc --arg for ALL string fields — never printf/heredoc concat
-        # (avoids JSON injection if reason/branch contain quotes or newlines).
-        jq -nc \
-          --arg pushed "$pushed" \
-          --arg sha    "$sha" \
-          --arg branch "$branch" \
-          --arg reason "$reason" \
+        jq -nc --arg pushed "$pushed" --arg sha "$sha" --arg branch "$branch" --arg reason "$reason" \
           '{pushed:$pushed,sha:$sha,branch:$branch,reason:$reason}'
       }
       trap _emit_commit_result EXIT
-
       branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-
       echo "--- Staging Changes ---" >&2
       git add -A
-      echo "" >&2
       echo "--- Creating Commit ---" >&2
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
       TASK_DESC="$TASK_DESCRIPTION"
@@ -177,22 +157,15 @@ steps:
         fi
         if [ "$ALT_WORKTREE_COMMITS" -gt 0 ]; then
           echo "INFO: Nothing staged in ${WORKTREE_SETUP_WORKTREE_PATH:-(unset)}, but the" >&2
-          echo "current branch '$CURRENT_BRANCH' is $ALT_WORKTREE_COMMITS commit(s) ahead of" >&2
-          echo "its upstream. The agent likely committed via an alternate worktree on" >&2
-          echo "the same branch; treating as success." >&2
+          echo "current branch '$CURRENT_BRANCH' is $ALT_WORKTREE_COMMITS commit(s) ahead of upstream." >&2
           git --no-pager log --oneline -"$ALT_WORKTREE_COMMITS" >&2
         else
-          echo "ERROR: Nothing staged to commit. The implementation step may have written files" >&2
-          echo "outside the worktree (${WORKTREE_SETUP_WORKTREE_PATH:-(unset)}), or no code changes were produced." >&2
-          echo "This is a hollow-success condition — the workflow completed structurally but" >&2
-          echo "produced no git artifacts. Check that agents created files in the worktree," >&2
-          echo "not in AMPLIHACK_HOME or other locations." >&2
+          echo "ERROR: Nothing staged to commit. Implementation may have written files outside the worktree." >&2
           git --no-pager status >&2
           reason="nothing-to-commit"
           exit 1
         fi
       fi
-      echo "" >&2
       echo "--- Pushing to Remote ---" >&2
       # REL-002: Detect missing upstream tracking branch before rev-list
       if ! git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
@@ -202,29 +175,22 @@ steps:
       fi
       COMMITS_AHEAD=$(git rev-list --count @{u}..HEAD)
       if [ "$COMMITS_AHEAD" -ne 0 ]; then
-        # REL-001: No stderr suppression on rebase — surface conflict diagnostics
-        # Split into separate statements so set -e catches rebase failures
+        # REL-001: surface rebase conflict diagnostics, no stderr suppression
         git pull --rebase
-        # FIX (#495): capture push stderr, redact tokens before assigning to
-        # `reason` (which is JSON-emitted via jq --arg). Token redaction defends
-        # against accidental credential leak via authenticated remote URLs.
+        # FIX (#495): capture push stderr, redact tokens before reason emission.
         push_stderr_file=$(mktemp -t step15-push-XXXXXX)
         # shellcheck disable=SC2064
         trap "rm -f \"$push_stderr_file\"; _emit_commit_result" EXIT
         if git push 2>"$push_stderr_file"; then
-          # Only mutate `pushed` AFTER successful push — this is the contract
-          # that step-16's gate depends on.
+          # Mutate `pushed` ONLY after successful push — step-16's gate contract.
           pushed="true"
           raw_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
           if printf '%s' "$raw_sha" | grep -qE '^[0-9a-f]{40}$'; then
             sha="$raw_sha"
-          else
-            sha=""
           fi
           reason="pushed"
         else
           push_rc=$?
-          # Sanitize: strip credentials from authenticated remote URLs.
           sanitized=$(sed -E 's#https://[^@[:space:]]+@#https://REDACTED@#g' "$push_stderr_file" | tr '\n' ' ' | head -c 500)
           reason="push-failed: ${sanitized}"
           echo "ERROR: git push failed (exit $push_rc)" >&2
@@ -235,7 +201,6 @@ steps:
         echo "WARNING: Nothing to push - branch is up to date with remote" >&2
         reason="nothing-to-push"
       fi
-      echo "" >&2
       echo "=== Commit and Push Complete ===" >&2
     output: "commit_result"
     parse_json: true

--- a/docs/features/workflow-publish-import-validation.md
+++ b/docs/features/workflow-publish-import-validation.md
@@ -1,3 +1,5 @@
+> **Legacy notice:** This document describes the Python `amplihack` implementation and does not apply to `amplihack-rs`.
+
 # Workflow Publish Import Validation
 
 **Scoped publish-validation stage that runs immediately before the current commit/push step.**

--- a/docs/howto/configure-workflow-publish-import-validation.md
+++ b/docs/howto/configure-workflow-publish-import-validation.md
@@ -1,3 +1,5 @@
+> **Legacy notice:** This document describes the Python `amplihack` implementation and does not apply to `amplihack-rs`.
+
 # How to Configure Workflow Publish Import Validation
 
 > [Home](../index.md) > How-To > Configure Workflow Publish Import Validation

--- a/docs/reference/workflow-publish-import-validation.md
+++ b/docs/reference/workflow-publish-import-validation.md
@@ -1,3 +1,5 @@
+> **Legacy notice:** This document describes the Python `amplihack` implementation and does not apply to `amplihack-rs`.
+
 # Workflow Publish Import Validation Reference
 
 > [Home](../index.md) > Reference > Workflow Publish Import Validation

--- a/scripts/check-recipes-no-python.sh
+++ b/scripts/check-recipes-no-python.sh
@@ -85,4 +85,54 @@ EOF
 fi
 
 echo "PASS: amplifier-bundle/recipes/ contains no bare python -m invocations."
+
+# ============================================================================
+# Second pass (issue #495): detect any reintroduction of the legacy
+# `build_publish_validation_<suffix>.py` helper inside shipped bundle dirs.
+#
+# Scope (deliberate): amplifier-bundle/{recipes,agents,prompts}/ only.
+# Excluded: docs/, .git/, target/, node_modules/ — historical references in
+# docs/ are allowed (they describe the prior Python implementation).
+# Pinned regex matches: build_publish_validation_<word>.py
+# ============================================================================
+val_violations=0
+val_log=""
+val_re='build_publish_validation_[A-Za-z0-9_]+\.py'
+
+for sub in recipes agents prompts; do
+    scan_dir="${REPO_ROOT}/amplifier-bundle/${sub}"
+    if [[ ! -d "${scan_dir}" ]]; then
+        continue
+    fi
+    while IFS= read -r -d '' file; do
+        # Skip the recipes/tests/ regression-test directory — those files
+        # legitimately reference build_publish_validation_*.py as fixtures
+        # and as documentation of the contract being tested.
+        case "${file}" in
+            "${REPO_ROOT}/amplifier-bundle/recipes/tests/"*) continue ;;
+        esac
+        while IFS=: read -r lineno content; do
+            val_violations=$((val_violations + 1))
+            val_log+="  ${file#${REPO_ROOT}/}:${lineno}: ${content}"$'\n'
+        done < <(grep -nE -- "${val_re}" "${file}" 2>/dev/null || true)
+    done < <(find "${scan_dir}" -type f \( -name '*.yaml' -o -name '*.yml' -o -name '*.md' -o -name '*.sh' -o -name '*.txt' \) -print0)
+done
+
+if [[ ${val_violations} -gt 0 ]]; then
+    cat >&2 <<EOF
+FAIL: ${val_violations} reference(s) to build_publish_validation_*.py found in
+shipped amplifier-bundle/{recipes,agents,prompts}/.
+
+This guard exists to lock in issue #495: the Python helper
+build_publish_validation_*.py is not shipped in amplihack-rs and any reference
+strands the recipe under a Python-free environment. Use the warn-and-continue
+shell pattern documented in workflow-publish.yaml step-15 instead.
+
+Violations:
+${val_log}
+EOF
+    exit 1
+fi
+
+echo "PASS: amplifier-bundle/{recipes,agents,prompts}/ contains no build_publish_validation_*.py references."
 exit 0


### PR DESCRIPTION
## Summary

Fixes the publish-recipe failure mode in which a successful `git push` could be silently stranded — `step-16-create-draft-pr` would skip PR creation if the surrounding step exited non-zero (e.g., a missing `build_publish_validation_*.py` helper aborted under `set -e`).

Closes #495

## Changes

### Phase A — `workflow-publish.yaml` step-15
- Install an EXIT trap that emits a strict JSON `commit_result` on **every** exit path via `jq -nc --arg`.
- Field shape: `{pushed: "true"|"false", sha: <40-hex|"">, branch: <ref>, reason: <enum>}`
- `reason` values: `aborted` | `nothing-to-commit` | `no-upstream` | `nothing-to-push` | `pushed` | `push-failed: <sanitized>`
- `pushed` is mutated to `"true"` **only after** a successful `git push`.
- Push stderr is token-redacted (`s#https://[^@]+@#https://REDACTED@#g`) before being assigned to `reason`.
- `sha` is validated to 40-hex via `grep -E`.
- Missing `jq` is a hard fail (no silent fallback).

### Phase A.2 — `workflow-publish.yaml` step-16
- New gate condition: `goal_already_met != 'true' && commit_result.pushed == 'true'`.
- Idempotency block (pre-existing PR detection) preserved byte-for-byte.

### Phase B — `consensus-publish.yaml` step-10
- Capture `gh pr create` stderr; emit a `::warning::` workflow command when push succeeded (`COMMIT_RESULT_PUSHED=true`) but PR creation failed (the stranded-branch case).
- `::` sanitized to `:_:` to defend against workflow-command injection.
- `pushed` field stays boolean here (intentional asymmetry — only `workflow-publish.yaml` asserts the string contract that step-16's gate depends on).

### Phase C — `scripts/check-recipes-no-python.sh`
- Second pass detects `build_publish_validation_<word>.py` references inside `amplifier-bundle/{recipes,agents,prompts}/`.
- Excludes `recipes/tests/` (intentional fixtures live there) and `docs/` (legacy references allowed).

### Phase D — three docs files
- Prepend a single-line legacy-notice banner to:
  - `docs/features/workflow-publish-import-validation.md`
  - `docs/howto/configure-workflow-publish-import-validation.md`
  - `docs/reference/workflow-publish-import-validation.md`

### Phase E — `.github/workflows/ci.yml`
- Wire `test-pr-always-opens.sh` and `test-static-guard-validation-scope.sh` next to the existing `check-recipes-no-python.sh` step (`shell: bash` explicit).

## Tests

Both regression tests transition RED → GREEN:

| Test | Before | After |
|------|--------|-------|
| `test-pr-always-opens.sh` | 🔴 RED (`commit_result does not record a pushed field`) | 🟢 GREEN |
| `test-static-guard-validation-scope.sh` | 🔴 RED (`guard does not implement the build_publish_validation_*.py check`) | 🟢 GREEN |

Existing `check-recipes-no-python.sh` stays GREEN.

## Security

- Token redaction in push-stderr capture before JSON emission.
- All JSON string fields built via `jq -nc --arg` (no `printf` concat → no injection).
- `::` → `:_:` in `gh` stderr before echoing into `::warning::` annotation.
- SHA constrained to 40-hex.
- Trap installed AFTER var-init, BEFORE first failing command.
- All variable expansions quoted; no `eval`, no dynamic command construction.
- No new workflow permissions.