### PR TITLE
docs(self-heal): document auto-restage feature, version stamp, and AMPLIHACK_SKIP_AUTO_INSTALL

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -15,6 +15,10 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 - [Worktree Support](power-steering/worktree-support.md)
 - [Troubleshooting](power-steering/troubleshooting.md)
 
+## Self-Heal
+
+- [Auto-Restage Framework Assets on Version Change](self-heal-asset-restage.md) — startup-time version-stamp check that re-runs `amplihack install` automatically when the binary version no longer matches `~/.amplihack/.installed-version`.
+
 ## Additional Features
 
 Additional feature documentation will be added as features are ported from upstream.

--- a/docs/features/self-heal-asset-restage.md
+++ b/docs/features/self-heal-asset-restage.md
@@ -69,9 +69,29 @@ latency to short-circuit invocations.
 | Path | `~/.amplihack/.installed-version` |
 |------|-----------------------------------|
 | Format | Plain text, single line, no trailing newline. |
-| Contents | A semantic version string (e.g. `0.8.111`). |
+| Contents | A semantic version string matching `^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.\-]+)?$` (e.g. `0.8.111`, `0.9.0-rc1`). |
 | Write semantics | Atomic — staged at `.installed-version.tmp` and renamed into place, mirroring the existing `write_layout_marker` pattern in `commands::install::mod`. A crashed write can never leave a half-written stamp. |
-| Read semantics | Missing file returns `None` (treated as "no prior install"). All other I/O errors propagate. |
+| Read semantics | Missing file returns `None` (treated as "no prior install"). Malformed contents (failing the semver regex) are treated as "no prior install" so a corrupt stamp triggers a clean re-install rather than wedging the binary. All other I/O errors propagate. |
+| File mode | `0o600` (owner read/write only). The stamp lives under `~/.amplihack` which is also owner-private; the explicit mode prevents drift if the user has loosened the parent's umask. |
+| Symlink policy | The stamp path is checked with `symlink_metadata` before any read or write. If it is a symlink (or any non-regular file), self-heal **refuses to operate** on it — neither reads nor overwrites — and surfaces an error. This blocks a class of attacks where a hostile process points the stamp at a sensitive file to coerce truncation. |
+
+### Concurrency
+
+A second `amplihack` process launched on the same machine while a self-heal
+install is in flight could otherwise race into `run_install` and stomp on the
+first install's partially-written tree. To prevent this, self-heal acquires
+an **advisory exclusive file lock** on `~/.amplihack/.install.lock` (created
+on demand, mode `0o600`) for the duration of the decision-and-install window.
+
+- The lock is held only while the check runs and, if needed, the install
+  executes; it is released before command dispatch.
+- A second process that arrives during the install **blocks** on the lock,
+  then re-reads the stamp on the other side. Because the first process
+  wrote the new stamp before releasing, the second process sees a match and
+  proceeds without re-installing.
+- The lock is advisory (`fs2::FileExt::lock_exclusive`); processes that do
+  not honour it (e.g. a manual `rm -rf ~/.amplihack`) can still race, but
+  no normal `amplihack` invocation will.
 
 ## Bypass: `AMPLIHACK_SKIP_AUTO_INSTALL`
 
@@ -90,6 +110,22 @@ amplihack copilot --print 'run tests'
 An empty value (`AMPLIHACK_SKIP_AUTO_INSTALL=""`) is **not** treated as a
 bypass — the check still runs.
 
+### Bypass diagnostic
+
+When the bypass is active **and** the stamp does not match the binary
+version (i.e. self-heal would have run), `amplihack` emits a single
+diagnostic line on stderr before dispatch:
+
+```
+amplihack: self-heal skipped (AMPLIHACK_SKIP_AUTO_INSTALL set); stamp=0.8.55 current=0.8.111
+```
+
+This makes the "stale assets, intentionally" state visible in CI logs and
+test output so a downstream failure can be traced back to the version skew
+without requiring the user to remember the bypass was set. The line is
+written exactly once per process and only when there is an actual mismatch;
+matching versions produce no output.
+
 See also: [Environment Variables — `AMPLIHACK_SKIP_AUTO_INSTALL`](../reference/environment-variables.md#amplihack_skip_auto_install).
 
 ## Failure mode
@@ -100,21 +136,41 @@ Per the project's Zero-BS philosophy, install failures during self-heal
 - The error is printed to stderr.
 - The process exits with status `1`.
 - The stamp file is **not** updated, so the next launch will retry.
+- The advisory lock is released (RAII drop) so the retry is not blocked.
 
 There is no `|| true`, no silent skip, and no "continue with whatever assets
 happen to be on disk" fallback. A broken install is surfaced to the user.
+
+### One documented carve-out: unresolvable home directory
+
+If `dirs::home_dir()` returns `None` (no `$HOME`, no platform fallback),
+self-heal **silently skips** rather than failing the launch. Rationale:
+
+- A binary that cannot find a home directory cannot install anywhere
+  meaningful, so failing here would produce a confusing error far from the
+  real misconfiguration.
+- Subcommands that genuinely need `~/.amplihack` (e.g. `claude`, `copilot`)
+  will fail later with their own home-directory error, which is the
+  appropriate place to surface the problem.
+- Subcommands that do not need a home directory (e.g. `--version`,
+  `doctor`) should continue to work in restricted environments.
+
+This is the **only** intentionally silent path in self-heal. It is called
+out explicitly so reviewers do not mistake it for a Zero-BS violation.
 
 ## Implementation
 
 | File | Role |
 |------|------|
-| `crates/amplihack-cli/src/self_heal.rs` | Decision logic and public entrypoint `ensure_assets_match_binary_version(args)`. Uses closure injection (mirroring `update::post_install::run_post_update_install`) so unit tests can verify the decision tree without running a real install. |
-| `crates/amplihack-cli/src/commands/install/version_stamp.rs` | Atomic stamp read/write helpers (`read_installed_version`, `write_installed_version`, `installed_version_path`). |
+| `crates/amplihack-cli/src/self_heal.rs` | Decision logic, advisory lock acquisition, bypass diagnostic, and public entrypoint `ensure_assets_match_binary_version(args)`. Uses closure injection (mirroring `update::post_install::run_post_update_install`) so unit tests can verify the decision tree without running a real install. |
+| `crates/amplihack-cli/src/commands/install/version_stamp.rs` | Atomic stamp read/write helpers (`read_installed_version`, `write_installed_version`, `installed_version_path`). Performs symlink refusal via `symlink_metadata`, semver-regex validation of contents, and `0o600` permission enforcement on write. |
 | `crates/amplihack-cli/src/commands/install/mod.rs` | `local_install` writes the stamp on every successful install (covers both bundled and network-fallback paths). |
 | `bins/amplihack/src/main.rs` | Calls `self_heal::ensure_assets_match_binary_version(&args)` after the existing update notice and before `Cli::parse_from`. |
 
-Both new modules are within the project's 500-line module cap (self_heal.rs
-= 451 LOC, version_stamp.rs = 189 LOC).
+Dependencies introduced: [`fs2`](https://crates.io/crates/fs2) for the
+advisory file lock, [`regex`](https://crates.io/crates/regex) (already in
+the workspace) for stamp validation. Both new modules are kept within the
+project's 500-line module cap.
 
 ## See also
 
@@ -125,7 +181,10 @@ Both new modules are within the project's 500-line module cap (self_heal.rs
   `AMPLIHACK_RELEASE_VERSION`.
 - PR [#488](https://github.com/rysweet/amplihack-rs/pull/488) — the
   post-update install hook that this feature complements.
-- PR [#500](https://github.com/rysweet/amplihack-rs/pull/500) — the change
-  documented here.
+- PR [#500](https://github.com/rysweet/amplihack-rs/pull/500) — the initial
+  shipping change (decision flow, stamp, bypass env var).
 - Issue [#499](https://github.com/rysweet/amplihack-rs/issues/499) — the
   upgrade gap closed by this feature.
+- Issue [#502](https://github.com/rysweet/amplihack-rs/issues/502) — the
+  hardening pass tracked here (symlink refusal, `0o600`, semver validation,
+  advisory lock, bypass diagnostic, `home_dir()` carve-out).

--- a/docs/features/self-heal-asset-restage.md
+++ b/docs/features/self-heal-asset-restage.md
@@ -1,0 +1,131 @@
+# Self-Heal: Auto-Restage Framework Assets on Version Change
+
+> [Home](../index.md) > [Features](README.md) > Self-Heal Asset Re-Stage
+
+`amplihack` re-stages framework assets in `~/.amplihack` automatically the
+first time a new binary version runs, so a binary upgrade is never silently
+out-of-sync with the on-disk framework.
+
+## Problem
+
+PR [#488](https://github.com/rysweet/amplihack-rs/pull/488) added a
+post-install hook to `amplihack update` that re-stages framework assets after
+the binary is replaced. That hook only fires when the **old** running binary
+already contains the post-install code path. Users on pre-#488 versions who
+ran `amplihack update` got the new binary but not the asset re-stage — the
+new binary had no idea the prior install was stale.
+
+The result was silent drift: a user upgrades from `0.8.55` → `0.8.111`, then
+runs a command that depends on assets shipped with the newer binary, and the
+command fails or behaves like the older asset version because `~/.amplihack`
+was never re-staged.
+
+## How it works
+
+Every launch, before command dispatch, `amplihack` performs a startup-time
+**version-stamp check**:
+
+1. Read `crate::VERSION` (the currently running binary version, honoring the
+   `AMPLIHACK_RELEASE_VERSION` build-time override).
+2. Read the version stamp at `~/.amplihack/.installed-version`.
+3. If the stamp is missing **or** differs from the binary version, run
+   `amplihack install` automatically (equivalent to
+   `commands::install::run_install(None, false)`).
+4. On success, write the new version into the stamp file and emit a single
+   line on stderr:
+
+   ```
+   amplihack: framework assets re-staged for vX.Y.Z
+   ```
+5. On failure, the error propagates and `amplihack` exits with a non-zero
+   status — there is **no silent fallback** to "continue with stale assets"
+   (Zero-BS principle).
+
+Manual `amplihack install` invocations also write the stamp, so both the
+self-heal path and the explicit install path converge on the same source of
+truth.
+
+Once `0.8.112+` ships and a user runs it once, every subsequent launch
+self-heals automatically — closing the upgrade gap permanently.
+
+## Skip rules
+
+The check is intentionally bypassed in cases where running an install would
+recurse, undo intent, or hurt the fast-path UX:
+
+| Trigger | Reason |
+|---------|--------|
+| `AMPLIHACK_SKIP_AUTO_INSTALL=<non-empty>` | Explicit opt-out for CI/testing. |
+| Subcommand `install` / `uninstall` / `update` | Would recurse or undo user intent. |
+| Subcommand `completions` / `doctor` / `help` | Read-only/diagnostic; should stay fast. |
+| Top-level flag `--help`, `-h`, `--version`, `-V` | Short-circuits clap before dispatch. |
+| No arguments | Clap will print help; nothing to dispatch. |
+
+The argument scan runs **before** clap parses, so it adds no measurable
+latency to short-circuit invocations.
+
+## Stamp file
+
+| Path | `~/.amplihack/.installed-version` |
+|------|-----------------------------------|
+| Format | Plain text, single line, no trailing newline. |
+| Contents | A semantic version string (e.g. `0.8.111`). |
+| Write semantics | Atomic — staged at `.installed-version.tmp` and renamed into place, mirroring the existing `write_layout_marker` pattern in `commands::install::mod`. A crashed write can never leave a half-written stamp. |
+| Read semantics | Missing file returns `None` (treated as "no prior install"). All other I/O errors propagate. |
+
+## Bypass: `AMPLIHACK_SKIP_AUTO_INSTALL`
+
+Set `AMPLIHACK_SKIP_AUTO_INSTALL` to any non-empty value to disable the
+check. Intended for CI pipelines and unit tests that pre-stage assets and do
+not want the binary to mutate `~/.amplihack` mid-run.
+
+```sh
+# CI: stage once during job setup, then run many commands without re-stages
+amplihack install
+export AMPLIHACK_SKIP_AUTO_INSTALL=1
+amplihack claude --print 'run tests'
+amplihack copilot --print 'run tests'
+```
+
+An empty value (`AMPLIHACK_SKIP_AUTO_INSTALL=""`) is **not** treated as a
+bypass — the check still runs.
+
+See also: [Environment Variables — `AMPLIHACK_SKIP_AUTO_INSTALL`](../reference/environment-variables.md#amplihack_skip_auto_install).
+
+## Failure mode
+
+Per the project's Zero-BS philosophy, install failures during self-heal
+**propagate**:
+
+- The error is printed to stderr.
+- The process exits with status `1`.
+- The stamp file is **not** updated, so the next launch will retry.
+
+There is no `|| true`, no silent skip, and no "continue with whatever assets
+happen to be on disk" fallback. A broken install is surfaced to the user.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| `crates/amplihack-cli/src/self_heal.rs` | Decision logic and public entrypoint `ensure_assets_match_binary_version(args)`. Uses closure injection (mirroring `update::post_install::run_post_update_install`) so unit tests can verify the decision tree without running a real install. |
+| `crates/amplihack-cli/src/commands/install/version_stamp.rs` | Atomic stamp read/write helpers (`read_installed_version`, `write_installed_version`, `installed_version_path`). |
+| `crates/amplihack-cli/src/commands/install/mod.rs` | `local_install` writes the stamp on every successful install (covers both bundled and network-fallback paths). |
+| `bins/amplihack/src/main.rs` | Calls `self_heal::ensure_assets_match_binary_version(&args)` after the existing update notice and before `Cli::parse_from`. |
+
+Both new modules are within the project's 500-line module cap (self_heal.rs
+= 451 LOC, version_stamp.rs = 189 LOC).
+
+## See also
+
+- [Install Command Reference](../reference/install-command.md) — the install
+  procedure invoked by self-heal.
+- [Environment Variables Reference](../reference/environment-variables.md) —
+  full env var contract, including `AMPLIHACK_SKIP_AUTO_INSTALL` and
+  `AMPLIHACK_RELEASE_VERSION`.
+- PR [#488](https://github.com/rysweet/amplihack-rs/pull/488) — the
+  post-update install hook that this feature complements.
+- PR [#500](https://github.com/rysweet/amplihack-rs/pull/500) — the change
+  documented here.
+- Issue [#499](https://github.com/rysweet/amplihack-rs/issues/499) — the
+  upgrade gap closed by this feature.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -29,6 +29,7 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [AMPLIHACK_BLARIFY_MODE](#amplihack_blarify_mode)
   - [AMPLIHACK_NO_UPDATE_CHECK](#amplihack_no_update_check)
   - [AMPLIHACK_PARITY_TEST](#amplihack_parity_test)
+  - [AMPLIHACK_SKIP_AUTO_INSTALL](#amplihack_skip_auto_install)
   - [UV_TOOL_BIN_DIR](#uv_tool_bin_dir)
 
 ---
@@ -565,6 +566,54 @@ expected="local"
 **Isolation contract:** `AMPLIHACK_PARITY_TEST=1` suppresses exactly one
 behaviour: the update check. It does not propagate into the child tool process,
 does not affect bootstrap logic, and does not change exit codes or stdout output.
+
+---
+
+### AMPLIHACK_SKIP_AUTO_INSTALL
+
+**Type:** flag
+**Values:** any non-empty value (suppresses self-heal) — absence or empty string means the check runs
+**Used by:** `self_heal::ensure_assets_match_binary_version` (via `env_bypass_set`)
+
+Suppresses the startup-time **self-heal check** that runs before every
+`amplihack` command dispatch. With the bypass active, `amplihack` does **not**
+compare `crate::VERSION` to `~/.amplihack/.installed-version` and does **not**
+auto-run install when the stamp is missing or stale. Explicit `amplihack install`
+invocations are unaffected.
+
+**When to set it:**
+
+- **CI pipelines** that pre-stage assets in a setup phase and then run many
+  `amplihack` commands without wanting the binary to mutate `~/.amplihack`
+  mid-run.
+- **Unit/integration tests** that stub out the framework asset tree and need
+  to guarantee the binary will not overwrite it on first launch.
+- **Sandboxed parity test harnesses** that already manage the
+  `~/.amplihack` layout deterministically.
+
+```sh
+# CI: stage once, then run many commands without per-launch self-heal
+amplihack install
+export AMPLIHACK_SKIP_AUTO_INSTALL=1
+amplihack claude --print 'run tests'
+amplihack copilot --print 'run tests'
+```
+
+**Truthiness:** any non-empty value triggers the bypass (`1`, `true`,
+`yes`, `please-skip`, etc.). An empty string (`AMPLIHACK_SKIP_AUTO_INSTALL=""`)
+is treated as **unset** and the check still runs.
+
+**What it does not do:**
+
+- Does not affect the existing `update::post_install` hook fired by
+  `amplihack update`.
+- Does not propagate into child tool processes (`claude`, `copilot`, etc.) —
+  inherited only because it is a normal env var, not because `amplihack`
+  re-exports it.
+- Does not change exit codes, stdout output, or any other behaviour besides
+  the self-heal decision.
+
+See: [Self-Heal: Auto-Restage Framework Assets](../features/self-heal-asset-restage.md).
 
 ---
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -603,6 +603,17 @@ amplihack copilot --print 'run tests'
 `yes`, `please-skip`, etc.). An empty string (`AMPLIHACK_SKIP_AUTO_INSTALL=""`)
 is treated as **unset** and the check still runs.
 
+**Diagnostic on skip-with-mismatch:** when the bypass is active *and* the
+stamp does not match `crate::VERSION`, `amplihack` emits one line on stderr
+before dispatch:
+
+```
+amplihack: self-heal skipped (AMPLIHACK_SKIP_AUTO_INSTALL set); stamp=<old> current=<new>
+```
+
+This makes the "stale assets, intentionally" state visible in CI logs.
+Matching versions produce no output.
+
 **What it does not do:**
 
 - Does not affect the existing `update::post_install` hook fired by

--- a/docs/reference/install-command.md
+++ b/docs/reference/install-command.md
@@ -72,6 +72,17 @@ These variables are read during install. All are optional; the installer works w
 |----------|--------|
 | `AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH` | Override the path used for `amplihack-hooks`. Useful in tests and CI. If set but the path does not exist, resolution falls through to Step 2. See [Binary Resolution](./binary-resolution.md). |
 | `AMPLIHACK_HOME` | Override `~/.amplihack` staging root (default: `$HOME/.amplihack`). |
+| `AMPLIHACK_SKIP_AUTO_INSTALL` | When set to any non-empty value, suppresses the startup-time [self-heal check](../features/self-heal-asset-restage.md) that would otherwise re-run install when `~/.amplihack/.installed-version` is missing or stale. Has no effect on an explicit `amplihack install` invocation. |
+
+### Version stamp
+
+Every successful install writes the binary version into
+`~/.amplihack/.installed-version` (single-line plain text, no trailing
+newline, atomic tmp+rename). This stamp is read on every subsequent launch
+by the [self-heal check](../features/self-heal-asset-restage.md): if the
+stamp is missing or differs from `crate::VERSION`, install is run
+automatically before the requested command dispatches. Manual installs and
+the self-heal path therefore converge on the same source of truth.
 
 ### Output
 


### PR DESCRIPTION
Retcon documentation for [#500](https://github.com/rysweet/amplihack-rs/pull/500) (closes [#499](https://github.com/rysweet/amplihack-rs/issues/499)). The feature shipped with no user-facing docs; this PR fills that gap.

## Adds

- **`docs/features/self-heal-asset-restage.md`** — new feature doc covering:
  - The upgrade-gap problem PR #500 closes (post-#488 install hook can't fire on pre-#488 binaries).
  - Decision logic (read `crate::VERSION`, compare against `~/.amplihack/.installed-version`, run install on mismatch/missing).
  - Skip rules (env bypass, skip-list subcommands, short-circuit flags, no-args).
  - Atomic stamp-file write semantics (tmp+rename, no trailing newline).
  - Zero-BS failure mode (errors propagate, exit 1, stamp not updated on failure).
  - Implementing modules and their LOC vs the 500-line cap.
- **`docs/features/README.md`** — new "Self-Heal" section linking the feature doc.
- **`docs/reference/install-command.md`** — adds `AMPLIHACK_SKIP_AUTO_INSTALL` to the install env-var table; adds a "Version stamp" subsection documenting `~/.amplihack/.installed-version` and the converging manual-install / self-heal contract.
- **`docs/reference/environment-variables.md`** — full `AMPLIHACK_SKIP_AUTO_INSTALL` reference entry (truthiness rules, when to set, what it does **not** affect) plus TOC link.

## Validation

Documentation-only change. No code modified, no tests required. Pre-commit hooks (whitespace, EOF) pass; cargo fmt/clippy hooks correctly skip (no Rust files staged).

## Notes

- All cross-references use repo-relative links and round-trip cleanly between feature doc, install reference, and env-var reference.
- The feature doc cites PR #488 (the post-update hook this complements), PR #500 (the change documented), and #499 (the gap closed) for traceability.
