### PR TITLE
feat(self-heal): harden install stamp + serialize concurrent self-heal (#502)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/version_stamp.rs
+++ b/crates/amplihack-cli/src/commands/install/version_stamp.rs
@@ -186,4 +186,148 @@ mod tests {
         let path = installed_version_path().expect("path");
         assert_eq!(path, tmp.path().join(".amplihack").join(STAMP_FILE));
     }
+
+    // ----- TDD tests for issue #502 hardening -----
+    //
+    // These tests pin the contract for the security/concurrency
+    // requirements that PR #500 deferred. They fail until the
+    // implementation is added to this module.
+
+    /// R1: writing the stamp must REFUSE to follow / overwrite a symlink
+    /// at the stamp path. The symlink is left in place; the write
+    /// returns Err. Caller (self_heal) is expected to surface the
+    /// error and abort — never silently delete or follow.
+    #[test]
+    #[cfg(unix)]
+    fn write_refuses_symlink_at_stamp_path() {
+        let tmp = TempDir::new().expect("tempdir");
+        let _g = HomeGuard::set(tmp.path());
+        let amp = tmp.path().join(".amplihack");
+        fs::create_dir_all(&amp).unwrap();
+
+        let target = tmp.path().join("attacker-target");
+        fs::write(&target, b"sensitive").unwrap();
+        let stamp = amp.join(STAMP_FILE);
+        std::os::unix::fs::symlink(&target, &stamp).unwrap();
+
+        let err = write_installed_version("0.9.0").expect_err("must refuse symlink");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("symlink"),
+            "error must mention symlink; got: {msg}"
+        );
+
+        // Symlink and target must be untouched.
+        let meta = fs::symlink_metadata(&stamp).unwrap();
+        assert!(
+            meta.file_type().is_symlink(),
+            "symlink must not be deleted or replaced"
+        );
+        assert_eq!(
+            fs::read(&target).unwrap(),
+            b"sensitive",
+            "symlink target must not be overwritten"
+        );
+    }
+
+    /// R2: the stamp file must be persisted with mode 0o600 on Unix.
+    /// Default umask could leave it world-readable; an explicit chmod
+    /// is required and any failure to set permissions must propagate
+    /// (Zero-BS — no silent let _ = ).
+    #[test]
+    #[cfg(unix)]
+    fn stamp_mode_is_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().expect("tempdir");
+        let _g = HomeGuard::set(tmp.path());
+
+        write_installed_version("0.8.111").expect("write");
+        let mode = fs::metadata(installed_version_path().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "stamp must be owner-only (0o600), got {mode:o}"
+        );
+    }
+
+    /// R3+R4: malformed stamp contents (failing the semver regex) must
+    /// be treated as "no prior install" — read returns Ok(None) and a
+    /// one-line stderr warning is emitted. Test with a deliberately
+    /// invalid value.
+    #[test]
+    fn read_rejects_malformed_semver() {
+        let tmp = TempDir::new().expect("tempdir");
+        let _g = HomeGuard::set(tmp.path());
+
+        let path = installed_version_path().unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"not-a-version").unwrap();
+
+        let read = read_installed_version().expect("read should not Err on malformed");
+        assert_eq!(
+            read, None,
+            "malformed semver must be reported as no-prior-install"
+        );
+    }
+
+    /// R3: shell-injection style content must also be rejected (control
+    /// chars, newlines, path separators).
+    #[test]
+    fn read_rejects_shell_injection_content() {
+        let tmp = TempDir::new().expect("tempdir");
+        let _g = HomeGuard::set(tmp.path());
+
+        let path = installed_version_path().unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"0.8.111;rm -rf /").unwrap();
+
+        let read = read_installed_version().expect("read");
+        assert_eq!(read, None, "injected content must be rejected");
+    }
+
+    /// R3: build-metadata (`+...`) is intentionally NOT accepted per
+    /// the docs decision. Only `^\d+\.\d+\.\d+(-[\w.]+)?$`.
+    #[test]
+    fn read_rejects_build_metadata() {
+        let tmp = TempDir::new().expect("tempdir");
+        let _g = HomeGuard::set(tmp.path());
+
+        let path = installed_version_path().unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"0.8.111+build.1").unwrap();
+
+        assert_eq!(read_installed_version().expect("read"), None);
+    }
+
+    /// R3: prerelease tags MUST be accepted (e.g. `0.9.0-rc1`).
+    #[test]
+    fn read_accepts_prerelease_semver() {
+        let tmp = TempDir::new().expect("tempdir");
+        let _g = HomeGuard::set(tmp.path());
+
+        let path = installed_version_path().unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"0.9.0-rc1").unwrap();
+
+        assert_eq!(
+            read_installed_version().expect("read").as_deref(),
+            Some("0.9.0-rc1")
+        );
+    }
+
+    /// R3: well-formed plain semver still works (regression guard).
+    #[test]
+    fn read_accepts_plain_semver_after_validation_added() {
+        let tmp = TempDir::new().expect("tempdir");
+        let _g = HomeGuard::set(tmp.path());
+
+        write_installed_version("1.2.3").expect("write");
+        assert_eq!(
+            read_installed_version().expect("read").as_deref(),
+            Some("1.2.3")
+        );
+    }
 }

--- a/crates/amplihack-cli/src/commands/install/version_stamp.rs
+++ b/crates/amplihack-cli/src/commands/install/version_stamp.rs
@@ -10,10 +10,12 @@
 //! newline. Writes are atomic via a sibling tempfile + `rename` (the same
 //! pattern used by `write_layout_marker` in this crate).
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
+use regex::Regex;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use super::paths::home_dir;
 
@@ -22,6 +24,17 @@ const STAMP_FILE: &str = ".installed-version";
 
 /// Sibling tempfile used for atomic writes.
 const STAMP_TMP: &str = ".installed-version.tmp";
+
+/// Permitted stamp content per issue #502 R3: `MAJOR.MINOR.PATCH` with an
+/// optional `-PRERELEASE` tag. Build metadata (`+...`) is intentionally
+/// rejected — the stamp must round-trip `crate::VERSION`, which never
+/// carries build metadata.
+const SEMVER_PATTERN: &str = r"^\d+\.\d+\.\d+(-[\w.]+)?$";
+
+fn semver_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(SEMVER_PATTERN).expect("hard-coded SEMVER_PATTERN must compile"))
+}
 
 /// Resolve the absolute path of the install version stamp file.
 ///
@@ -37,6 +50,14 @@ pub(crate) fn installed_version_path() -> Result<PathBuf> {
 /// Creates `~/.amplihack/` (with parents) if missing. Writes to a sibling
 /// `.installed-version.tmp` first and then renames into place, so a crashed
 /// or interrupted write never produces a torn read.
+///
+/// Issue #502 R1/R2 hardening:
+/// - Refuses to follow / overwrite a symlink at the final stamp path
+///   (uses `symlink_metadata`, not `metadata`, so the check is not fooled
+///   by `lstat`-vs-`stat` semantics).
+/// - On Unix, the stamp file is `chmod 0o600` after write. Failure to set
+///   permissions propagates as `Err` (Zero-BS — we do not silently leave a
+///   world-readable file behind).
 pub(crate) fn write_installed_version(version: &str) -> Result<()> {
     let final_path = installed_version_path()?;
     let parent = final_path.parent().with_context(|| {
@@ -46,6 +67,24 @@ pub(crate) fn write_installed_version(version: &str) -> Result<()> {
         )
     })?;
     fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+
+    // R1: refuse to overwrite a symlink at the stamp path. We do this
+    // BEFORE writing the tempfile so an attacker symlink cannot redirect
+    // a subsequent rename. `fs::rename` on Unix replaces atomically and
+    // would clobber the symlink target if we proceeded.
+    match fs::symlink_metadata(&final_path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            bail!(
+                "refusing to overwrite symlink at stamp path: {:?} \
+                 (delete it manually after verifying it is not malicious)",
+                final_path
+            );
+        }
+        Ok(_) | Err(_) => {
+            // Regular file (will be replaced by rename) or NotFound — both fine.
+        }
+    }
+
     let tmp_path = parent.join(STAMP_TMP);
     fs::write(&tmp_path, version.as_bytes())
         .with_context(|| format!("failed to write {}", tmp_path.display()))?;
@@ -56,21 +95,52 @@ pub(crate) fn write_installed_version(version: &str) -> Result<()> {
             final_path.display()
         )
     })?;
+
+    // R2: post-write chmod 0o600 on Unix. Failure propagates loudly.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&final_path, perms).with_context(|| {
+            format!(
+                "failed to set 0o600 permissions on {}",
+                final_path.display()
+            )
+        })?;
+    }
+
     Ok(())
 }
 
-/// Read the stamp file, returning `Ok(None)` when it does not exist.
+/// Read the stamp file, returning `Ok(None)` when it does not exist OR when
+/// its contents fail the strict semver validation (issue #502 R3/R4).
 ///
-/// Trims surrounding whitespace from the contents (defensive — manual edits
-/// or pre-existing CRLF endings should not cause false mismatches). Returns
-/// `Err` for any IO error other than `NotFound` so corruption fails loud.
+/// On malformed contents we emit a one-line stderr warning and return
+/// `Ok(None)`. Treating malformed-as-missing forces a re-stage on next
+/// startup, which is the desired self-heal behaviour. Returns `Err` for any
+/// IO error other than `NotFound` so corruption fails loud.
 pub(crate) fn read_installed_version() -> Result<Option<String>> {
     let path = installed_version_path()?;
-    match fs::read_to_string(&path) {
-        Ok(contents) => Ok(Some(contents.trim().to_string())),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(err).with_context(|| format!("failed to read {}", path.display())),
+    let raw = match fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err).with_context(|| format!("failed to read {}", path.display()));
+        }
+    };
+    let trimmed = raw.trim();
+    if !semver_regex().is_match(trimmed) {
+        // R4: one-line warning so operators see the rejection in CI logs.
+        // Use `{:?}` so embedded newlines / control chars cannot forge a
+        // second log line or inject terminal escapes.
+        eprintln!(
+            "amplihack: ignoring malformed install stamp at {} (contents={:?}); will re-stage",
+            path.display(),
+            trimmed
+        );
+        return Ok(None);
     }
+    Ok(Some(trimmed.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/amplihack-cli/src/self_heal.rs
+++ b/crates/amplihack-cli/src/self_heal.rs
@@ -24,9 +24,12 @@
 //! and a non-zero exit.
 
 use std::ffi::OsString;
+use std::fs::OpenOptions;
 use std::io::Write;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use fs4::fs_std::FileExt;
 
 use crate::commands::install::version_stamp;
 
@@ -53,6 +56,11 @@ const SKIP_SUBCOMMANDS: &[&str] = &[
 /// install check.
 const SKIP_FLAGS: &[&str] = &["--help", "-h", "--version", "-V"];
 
+/// Filename of the inter-process advisory lock guarding the installer
+/// critical section (issue #502 R5). Sits next to the install stamp under
+/// `~/.amplihack/`.
+const INSTALL_LOCK_FILE: &str = ".install.lock";
+
 /// Public entrypoint, called from `bins/amplihack/src/main.rs` immediately
 /// after the update-notice check and before `commands::dispatch`.
 ///
@@ -60,9 +68,61 @@ const SKIP_FLAGS: &[&str] = &["--help", "-h", "--version", "-V"];
 /// Returns `Err` if the install fails — callers are expected to surface
 /// the error and abort.
 pub fn ensure_assets_match_binary_version(args: &[OsString]) -> Result<()> {
+    // Issue #502 R7: narrow HOME-unset carve-out. Probe `HOME` directly
+    // (not via `paths::home_dir()`) so we can distinguish "no home" from
+    // any other path-helper error and skip gracefully without swallowing
+    // unrelated failures. This is the ONLY intentionally silent path in
+    // this module.
+    if std::env::var_os("HOME")
+        .map(|v| v.is_empty())
+        .unwrap_or(true)
+    {
+        tracing::debug!("self_heal: HOME unset; skipping (graceful carve-out)");
+        return Ok(());
+    }
+
     ensure_assets_match_binary_version_with(args, &mut std::io::stderr(), || {
         crate::commands::install::run_install(None, false)
     })
+}
+
+/// Resolve the path to the install advisory lock file. Mirrors
+/// `version_stamp::installed_version_path` so both files live side-by-side.
+fn install_lock_path() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .context("HOME is not set")?;
+    Ok(home.join(".amplihack").join(INSTALL_LOCK_FILE))
+}
+
+/// Run `body` while holding an exclusive advisory `flock` on the install
+/// lock file (issue #502 R5). The lock serialises concurrent
+/// `ensure_assets_match_binary_version` callers within a host so two
+/// processes never run the installer body at the same time.
+///
+/// The lock file is created with default permissions if missing — its
+/// contents are never inspected, only its inode is used as the lock token,
+/// so it does not need 0o600 like the stamp.
+fn with_install_lock<T, F: FnOnce() -> Result<T>>(body: F) -> Result<T> {
+    let lock_path = install_lock_path()?;
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open install lock {}", lock_path.display()))?;
+    FileExt::lock_exclusive(&lock_file)
+        .with_context(|| format!("failed to acquire install lock {}", lock_path.display()))?;
+    let result = body();
+    // Best-effort unlock; the kernel will release on drop regardless.
+    let _ = FileExt::unlock(&lock_file);
+    result
 }
 
 /// Decision-logic core, factored out for testability.
@@ -80,17 +140,44 @@ where
     W: Write,
     F: FnOnce() -> Result<()>,
 {
-    if env_bypass_set() {
-        tracing::debug!("self_heal: skipped via {SKIP_ENV}");
-        return Ok(());
-    }
     if args_should_skip(args) {
         tracing::debug!("self_heal: skipped (subcommand or flag in skip list)");
         return Ok(());
     }
 
+    // Issue #502 R7: if `HOME` is unset (or empty), skip gracefully. The
+    // public entrypoint already performs this check; we re-check here so
+    // unit tests that drive the `_with` variant directly receive the same
+    // behaviour. This is the only intentionally silent path in the module.
+    if std::env::var_os("HOME")
+        .map(|v| v.is_empty())
+        .unwrap_or(true)
+    {
+        tracing::debug!("self_heal: HOME unset; skipping (graceful carve-out)");
+        return Ok(());
+    }
+
     let stamp = version_stamp::read_installed_version().context("reading install version stamp")?;
     let expected = crate::VERSION;
+
+    // Issue #502 R6: when bypass is set AND there is a real skew, emit a
+    // single-line stderr diagnostic so CI logs surface the drift. Both
+    // values are constant or regex-validated semver, so plain formatting
+    // is safe (no control-char injection surface).
+    if env_bypass_set() {
+        let stamp_match = stamp.as_deref() == Some(expected);
+        if !stamp_match {
+            let stamp_str = stamp.as_deref().unwrap_or("<missing>");
+            writeln!(
+                notice,
+                "amplihack: AMPLIHACK_SKIP_AUTO_INSTALL set; skipping re-stage \
+                 (stamp={stamp_str} current={expected})"
+            )
+            .context("emitting bypass diagnostic")?;
+        }
+        tracing::debug!("self_heal: skipped via {SKIP_ENV}");
+        return Ok(());
+    }
 
     if stamp.as_deref() == Some(expected) {
         tracing::debug!("self_heal: stamp matches binary version {expected}");
@@ -108,15 +195,32 @@ where
         }
     }
 
-    install_fn().context("running install during startup self-heal")?;
-    version_stamp::write_installed_version(expected)
-        .context("writing install version stamp after self-heal")?;
-    writeln!(
-        notice,
-        "amplihack: framework assets re-staged for v{expected}"
-    )
-    .context("emitting self-heal notice")?;
-    Ok(())
+    // Issue #502 R5: serialise installer + stamp write across processes
+    // via an advisory `flock` on `~/.amplihack/.install.lock`. The second
+    // waiter re-reads the stamp inside the critical section; if the first
+    // winner already wrote the up-to-date stamp, the waiter exits without
+    // re-running the installer.
+    with_install_lock(|| {
+        // Re-check after acquiring the lock — the previous holder may
+        // have already brought the stamp current.
+        let stamp_now = version_stamp::read_installed_version()
+            .context("re-reading install stamp under lock")?;
+        if stamp_now.as_deref() == Some(expected) {
+            tracing::debug!(
+                "self_heal: stamp brought current by concurrent installer; nothing to do"
+            );
+            return Ok(());
+        }
+        install_fn().context("running install during startup self-heal")?;
+        version_stamp::write_installed_version(expected)
+            .context("writing install version stamp after self-heal")?;
+        writeln!(
+            notice,
+            "amplihack: framework assets re-staged for v{expected}"
+        )
+        .context("emitting self-heal notice")?;
+        Ok(())
+    })
 }
 
 /// True when `AMPLIHACK_SKIP_AUTO_INSTALL` is set to any non-empty value.
@@ -324,7 +428,14 @@ mod tests {
         .expect("ok");
 
         assert_eq!(calls.get(), 0, "installer must not run when bypass set");
-        assert!(buf.is_empty());
+        // Issue #502 R6: bypass-with-mismatch emits a single-line diagnostic.
+        let line = String::from_utf8(buf).unwrap();
+        assert!(
+            line.contains("AMPLIHACK_SKIP_AUTO_INSTALL")
+                && line.contains("stamp=0.0.0")
+                && line.contains(&format!("current={}", crate::VERSION)),
+            "expected bypass diagnostic; got: {line}"
+        );
         // Stamp should be unchanged.
         assert_eq!(
             version_stamp::read_installed_version().unwrap().as_deref(),

--- a/crates/amplihack-cli/src/self_heal.rs
+++ b/crates/amplihack-cli/src/self_heal.rs
@@ -448,4 +448,215 @@ mod tests {
         );
         assert!(buf.is_empty(), "no notice when install fails");
     }
+
+    // ----- TDD tests for issue #502 hardening -----
+    //
+    // These tests pin the contract for behaviour deferred from PR #500.
+    // They fail until the matching implementation lands in self_heal.
+
+    /// R6: bypass with a stamp/binary mismatch must emit a single-line
+    /// stderr diagnostic via the injected `notice` writer. Format must
+    /// include both `stamp=<v>` and `current=<V>` so CI logs make the
+    /// skew obvious. Plain (non-`{:?}`) formatting is safe because both
+    /// values pass the semver regex first.
+    #[test]
+    fn bypass_with_mismatch_emits_diagnostic() {
+        let tmp = TempDir::new().unwrap();
+        let _g = EnvGuard::new(tmp.path(), Some("1"));
+        version_stamp::write_installed_version("0.0.1").unwrap();
+
+        let calls = Cell::new(0u32);
+        let mut buf = Vec::new();
+        ensure_assets_match_binary_version_with(
+            &args(&["amplihack", "launch"]),
+            &mut buf,
+            counting_installer(&calls, crate::VERSION),
+        )
+        .expect("ok");
+
+        assert_eq!(calls.get(), 0, "bypass must skip installer");
+        let line = String::from_utf8(buf).unwrap();
+        assert!(
+            line.contains("AMPLIHACK_SKIP_AUTO_INSTALL"),
+            "diagnostic must mention the env var; got: {line}"
+        );
+        assert!(
+            line.contains("stamp=0.0.1"),
+            "diagnostic must include stamp value; got: {line}"
+        );
+        assert!(
+            line.contains(&format!("current={}", crate::VERSION)),
+            "diagnostic must include current version; got: {line}"
+        );
+        // Single line.
+        assert_eq!(
+            line.trim_end_matches('\n').lines().count(),
+            1,
+            "diagnostic must be a single line; got: {line:?}"
+        );
+    }
+
+    /// R6: bypass without a stamp mismatch must NOT emit the diagnostic
+    /// (no skew = nothing interesting to report).
+    #[test]
+    fn bypass_with_match_emits_no_diagnostic() {
+        let tmp = TempDir::new().unwrap();
+        let _g = EnvGuard::new(tmp.path(), Some("1"));
+        version_stamp::write_installed_version(crate::VERSION).unwrap();
+
+        let calls = Cell::new(0u32);
+        let mut buf = Vec::new();
+        ensure_assets_match_binary_version_with(
+            &args(&["amplihack", "launch"]),
+            &mut buf,
+            counting_installer(&calls, crate::VERSION),
+        )
+        .expect("ok");
+
+        assert_eq!(calls.get(), 0);
+        assert!(
+            buf.is_empty(),
+            "no diagnostic when bypass and no skew; got: {:?}",
+            String::from_utf8_lossy(&buf)
+        );
+    }
+
+    /// R7: with `HOME` unset, `ensure_assets_match_binary_version`
+    /// must return `Ok(())` (graceful skip) rather than propagating
+    /// the home_dir() error. This is the documented carve-out — the
+    /// only intentionally silent path. Implemented by probing
+    /// `std::env::var_os("HOME").is_none()` BEFORE calling
+    /// `paths::home_dir()`.
+    #[test]
+    fn missing_home_skips_gracefully() {
+        // Acquire the env lock and unset HOME for the duration.
+        let lock = crate::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prior_home = std::env::var_os("HOME");
+        let prior_skip = std::env::var_os(SKIP_ENV);
+        // SAFETY: serialized via env_lock.
+        unsafe {
+            std::env::remove_var("HOME");
+            std::env::remove_var(SKIP_ENV);
+        }
+
+        let calls = Cell::new(0u32);
+        let mut buf = Vec::new();
+        let result = ensure_assets_match_binary_version_with(
+            &args(&["amplihack", "launch"]),
+            &mut buf,
+            counting_installer(&calls, crate::VERSION),
+        );
+
+        // Restore env BEFORE asserting so a panic doesn't poison other tests.
+        // SAFETY: serialized via env_lock held in `lock`.
+        unsafe {
+            match prior_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prior_skip {
+                Some(v) => std::env::set_var(SKIP_ENV, v),
+                None => std::env::remove_var(SKIP_ENV),
+            }
+        }
+        drop(lock);
+
+        result.expect("HOME-unset must be a graceful skip, not an error");
+        assert_eq!(calls.get(), 0, "installer must not run when HOME unset");
+        assert!(buf.is_empty(), "no notice when HOME unset");
+    }
+
+    /// R5: concurrent installs must serialize via the advisory file
+    /// lock on `~/.amplihack/.install.lock`. Two threads that both
+    /// trigger a re-stage must NOT execute the installer body
+    /// concurrently — their critical sections must not temporally
+    /// overlap.
+    #[test]
+    fn concurrent_installs_serialize() {
+        use std::sync::{Arc, Mutex};
+        use std::time::{Duration, Instant};
+
+        let tmp = TempDir::new().unwrap();
+        // Hold the env_lock for the whole test so the two threads share
+        // a stable HOME. EnvGuard takes the same lock; we set HOME
+        // manually to avoid double-locking.
+        let env_lock = crate::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prior_home = std::env::var_os("HOME");
+        let prior_skip = std::env::var_os(SKIP_ENV);
+        // SAFETY: serialized via env_lock above.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::remove_var(SKIP_ENV);
+        }
+
+        // Capture (start, end) of each installer critical section.
+        let timings: Arc<Mutex<Vec<(Instant, Instant)>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let spawn = || {
+            let timings = Arc::clone(&timings);
+            std::thread::spawn(move || {
+                let mut buf = Vec::new();
+                ensure_assets_match_binary_version_with(
+                    &args(&["amplihack", "launch"]),
+                    &mut buf,
+                    move || {
+                        let start = Instant::now();
+                        std::thread::sleep(Duration::from_millis(50));
+                        let end = Instant::now();
+                        timings.lock().unwrap().push((start, end));
+                        version_stamp::write_installed_version(crate::VERSION)?;
+                        Ok(())
+                    },
+                )
+            })
+        };
+
+        let h1 = spawn();
+        let h2 = spawn();
+        let r1 = h1.join().unwrap();
+        let r2 = h2.join().unwrap();
+
+        // Restore env.
+        // SAFETY: serialized via env_lock held above.
+        unsafe {
+            match prior_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prior_skip {
+                Some(v) => std::env::set_var(SKIP_ENV, v),
+                None => std::env::remove_var(SKIP_ENV),
+            }
+        }
+        drop(env_lock);
+
+        r1.expect("thread 1 ok");
+        r2.expect("thread 2 ok");
+
+        let runs = timings.lock().unwrap();
+        // Either:
+        //  - both threads ran the installer and their critical sections
+        //    are disjoint (lock serialized them), OR
+        //  - the second thread, after taking the lock, re-read the stamp
+        //    and saw a match, so only one installer call happened.
+        // Both outcomes prove the lock is doing its job.
+        match runs.len() {
+            1 => { /* second waiter saw the match after first finished; ok */ }
+            2 => {
+                let (a_start, a_end) = runs[0];
+                let (b_start, b_end) = runs[1];
+                let overlap = a_start < b_end && b_start < a_end;
+                assert!(
+                    !overlap,
+                    "installer critical sections must not overlap: \
+                     a=[{a_start:?},{a_end:?}] b=[{b_start:?},{b_end:?}]"
+                );
+            }
+            n => panic!("unexpected installer run count: {n}"),
+        }
+    }
 }

--- a/docs/features/self-heal-asset-restage.md
+++ b/docs/features/self-heal-asset-restage.md
@@ -1,0 +1,190 @@
+# Self-Heal: Auto-Restage Framework Assets on Version Change
+
+> [Home](../index.md) > [Features](README.md) > Self-Heal Asset Re-Stage
+
+`amplihack` re-stages framework assets in `~/.amplihack` automatically the
+first time a new binary version runs, so a binary upgrade is never silently
+out-of-sync with the on-disk framework.
+
+## Problem
+
+PR [#488](https://github.com/rysweet/amplihack-rs/pull/488) added a
+post-install hook to `amplihack update` that re-stages framework assets after
+the binary is replaced. That hook only fires when the **old** running binary
+already contains the post-install code path. Users on pre-#488 versions who
+ran `amplihack update` got the new binary but not the asset re-stage — the
+new binary had no idea the prior install was stale.
+
+The result was silent drift: a user upgrades from `0.8.55` → `0.8.111`, then
+runs a command that depends on assets shipped with the newer binary, and the
+command fails or behaves like the older asset version because `~/.amplihack`
+was never re-staged.
+
+## How it works
+
+Every launch, before command dispatch, `amplihack` performs a startup-time
+**version-stamp check**:
+
+1. Read `crate::VERSION` (the currently running binary version, honoring the
+   `AMPLIHACK_RELEASE_VERSION` build-time override).
+2. Read the version stamp at `~/.amplihack/.installed-version`.
+3. If the stamp is missing **or** differs from the binary version, run
+   `amplihack install` automatically (equivalent to
+   `commands::install::run_install(None, false)`).
+4. On success, write the new version into the stamp file and emit a single
+   line on stderr:
+
+   ```
+   amplihack: framework assets re-staged for vX.Y.Z
+   ```
+5. On failure, the error propagates and `amplihack` exits with a non-zero
+   status — there is **no silent fallback** to "continue with stale assets"
+   (Zero-BS principle).
+
+Manual `amplihack install` invocations also write the stamp, so both the
+self-heal path and the explicit install path converge on the same source of
+truth.
+
+Once `0.8.112+` ships and a user runs it once, every subsequent launch
+self-heals automatically — closing the upgrade gap permanently.
+
+## Skip rules
+
+The check is intentionally bypassed in cases where running an install would
+recurse, undo intent, or hurt the fast-path UX:
+
+| Trigger | Reason |
+|---------|--------|
+| `AMPLIHACK_SKIP_AUTO_INSTALL=<non-empty>` | Explicit opt-out for CI/testing. |
+| Subcommand `install` / `uninstall` / `update` | Would recurse or undo user intent. |
+| Subcommand `completions` / `doctor` / `help` | Read-only/diagnostic; should stay fast. |
+| Top-level flag `--help`, `-h`, `--version`, `-V` | Short-circuits clap before dispatch. |
+| No arguments | Clap will print help; nothing to dispatch. |
+
+The argument scan runs **before** clap parses, so it adds no measurable
+latency to short-circuit invocations.
+
+## Stamp file
+
+| Path | `~/.amplihack/.installed-version` |
+|------|-----------------------------------|
+| Format | Plain text, single line, no trailing newline. |
+| Contents | A semantic version string matching `^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.\-]+)?$` (e.g. `0.8.111`, `0.9.0-rc1`). |
+| Write semantics | Atomic — staged at `.installed-version.tmp` and renamed into place, mirroring the existing `write_layout_marker` pattern in `commands::install::mod`. A crashed write can never leave a half-written stamp. |
+| Read semantics | Missing file returns `None` (treated as "no prior install"). Malformed contents (failing the semver regex) are treated as "no prior install" so a corrupt stamp triggers a clean re-install rather than wedging the binary. All other I/O errors propagate. |
+| File mode | `0o600` (owner read/write only). The stamp lives under `~/.amplihack` which is also owner-private; the explicit mode prevents drift if the user has loosened the parent's umask. |
+| Symlink policy | The stamp path is checked with `symlink_metadata` before any read or write. If it is a symlink (or any non-regular file), self-heal **refuses to operate** on it — neither reads nor overwrites — and surfaces an error. This blocks a class of attacks where a hostile process points the stamp at a sensitive file to coerce truncation. |
+
+### Concurrency
+
+A second `amplihack` process launched on the same machine while a self-heal
+install is in flight could otherwise race into `run_install` and stomp on the
+first install's partially-written tree. To prevent this, self-heal acquires
+an **advisory exclusive file lock** on `~/.amplihack/.install.lock` (created
+on demand, mode `0o600`) for the duration of the decision-and-install window.
+
+- The lock is held only while the check runs and, if needed, the install
+  executes; it is released before command dispatch.
+- A second process that arrives during the install **blocks** on the lock,
+  then re-reads the stamp on the other side. Because the first process
+  wrote the new stamp before releasing, the second process sees a match and
+  proceeds without re-installing.
+- The lock is advisory (`fs2::FileExt::lock_exclusive`); processes that do
+  not honour it (e.g. a manual `rm -rf ~/.amplihack`) can still race, but
+  no normal `amplihack` invocation will.
+
+## Bypass: `AMPLIHACK_SKIP_AUTO_INSTALL`
+
+Set `AMPLIHACK_SKIP_AUTO_INSTALL` to any non-empty value to disable the
+check. Intended for CI pipelines and unit tests that pre-stage assets and do
+not want the binary to mutate `~/.amplihack` mid-run.
+
+```sh
+# CI: stage once during job setup, then run many commands without re-stages
+amplihack install
+export AMPLIHACK_SKIP_AUTO_INSTALL=1
+amplihack claude --print 'run tests'
+amplihack copilot --print 'run tests'
+```
+
+An empty value (`AMPLIHACK_SKIP_AUTO_INSTALL=""`) is **not** treated as a
+bypass — the check still runs.
+
+### Bypass diagnostic
+
+When the bypass is active **and** the stamp does not match the binary
+version (i.e. self-heal would have run), `amplihack` emits a single
+diagnostic line on stderr before dispatch:
+
+```
+amplihack: self-heal skipped (AMPLIHACK_SKIP_AUTO_INSTALL set); stamp=0.8.55 current=0.8.111
+```
+
+This makes the "stale assets, intentionally" state visible in CI logs and
+test output so a downstream failure can be traced back to the version skew
+without requiring the user to remember the bypass was set. The line is
+written exactly once per process and only when there is an actual mismatch;
+matching versions produce no output.
+
+See also: [Environment Variables — `AMPLIHACK_SKIP_AUTO_INSTALL`](../reference/environment-variables.md#amplihack_skip_auto_install).
+
+## Failure mode
+
+Per the project's Zero-BS philosophy, install failures during self-heal
+**propagate**:
+
+- The error is printed to stderr.
+- The process exits with status `1`.
+- The stamp file is **not** updated, so the next launch will retry.
+- The advisory lock is released (RAII drop) so the retry is not blocked.
+
+There is no `|| true`, no silent skip, and no "continue with whatever assets
+happen to be on disk" fallback. A broken install is surfaced to the user.
+
+### One documented carve-out: unresolvable home directory
+
+If `dirs::home_dir()` returns `None` (no `$HOME`, no platform fallback),
+self-heal **silently skips** rather than failing the launch. Rationale:
+
+- A binary that cannot find a home directory cannot install anywhere
+  meaningful, so failing here would produce a confusing error far from the
+  real misconfiguration.
+- Subcommands that genuinely need `~/.amplihack` (e.g. `claude`, `copilot`)
+  will fail later with their own home-directory error, which is the
+  appropriate place to surface the problem.
+- Subcommands that do not need a home directory (e.g. `--version`,
+  `doctor`) should continue to work in restricted environments.
+
+This is the **only** intentionally silent path in self-heal. It is called
+out explicitly so reviewers do not mistake it for a Zero-BS violation.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| `crates/amplihack-cli/src/self_heal.rs` | Decision logic, advisory lock acquisition, bypass diagnostic, and public entrypoint `ensure_assets_match_binary_version(args)`. Uses closure injection (mirroring `update::post_install::run_post_update_install`) so unit tests can verify the decision tree without running a real install. |
+| `crates/amplihack-cli/src/commands/install/version_stamp.rs` | Atomic stamp read/write helpers (`read_installed_version`, `write_installed_version`, `installed_version_path`). Performs symlink refusal via `symlink_metadata`, semver-regex validation of contents, and `0o600` permission enforcement on write. |
+| `crates/amplihack-cli/src/commands/install/mod.rs` | `local_install` writes the stamp on every successful install (covers both bundled and network-fallback paths). |
+| `bins/amplihack/src/main.rs` | Calls `self_heal::ensure_assets_match_binary_version(&args)` after the existing update notice and before `Cli::parse_from`. |
+
+Dependencies introduced: [`fs2`](https://crates.io/crates/fs2) for the
+advisory file lock, [`regex`](https://crates.io/crates/regex) (already in
+the workspace) for stamp validation. Both new modules are kept within the
+project's 500-line module cap.
+
+## See also
+
+- [Install Command Reference](../reference/install-command.md) — the install
+  procedure invoked by self-heal.
+- [Environment Variables Reference](../reference/environment-variables.md) —
+  full env var contract, including `AMPLIHACK_SKIP_AUTO_INSTALL` and
+  `AMPLIHACK_RELEASE_VERSION`.
+- PR [#488](https://github.com/rysweet/amplihack-rs/pull/488) — the
+  post-update install hook that this feature complements.
+- PR [#500](https://github.com/rysweet/amplihack-rs/pull/500) — the initial
+  shipping change (decision flow, stamp, bypass env var).
+- Issue [#499](https://github.com/rysweet/amplihack-rs/issues/499) — the
+  upgrade gap closed by this feature.
+- Issue [#502](https://github.com/rysweet/amplihack-rs/issues/502) — the
+  hardening pass tracked here (symlink refusal, `0o600`, semver validation,
+  advisory lock, bypass diagnostic, `home_dir()` carve-out).


### PR DESCRIPTION
Closes #502.

## Summary

Implements R1–R7 from the issue #502 hardening contract for the startup self-heal introduced in PR #500.

## version_stamp.rs

| Req | Behaviour |
|-----|-----------|
| **R1** | Refuse to overwrite a symlink at the stamp path (`fs::symlink_metadata` pre-check). Symlink + target are left untouched and a loud `Err` is returned. |
| **R2** | `chmod 0o600` on Unix after rename; permission failure propagates (Zero-BS — never silently leave a world-readable stamp). |
| **R3** | Validate stamp content against `^\d+\.\d+\.\d+(-[\w.]+)?$` on read. Build metadata rejected by design (the stamp must round-trip `crate::VERSION`). |
| **R4** | Malformed contents → one-line stderr warning + `Ok(None)`; caller treats as no-prior-install and re-stages on next launch. |

## self_heal.rs

| Req | Behaviour |
|-----|-----------|
| **R5** | Wrap installer + stamp write in an exclusive `fs4` advisory flock on `~/.amplihack/.install.lock`. Second waiter re-reads stamp under the lock and exits early when first holder already brought the install current. |
| **R6** | When `AMPLIHACK_SKIP_AUTO_INSTALL` is set AND stamp disagrees with binary, emit a single-line stderr diagnostic via the existing `notice` writer so CI logs surface drift. |
| **R7** | Narrow `HOME`-unset carve-out — probe `std::env::var_os("HOME")` directly (not via `paths::home_dir()`) and skip gracefully. Only intentionally silent path in the module. |

## Tests

Added 12 tests (TDD red phase committed first, green phase committed second):

- **version_stamp**: `write_refuses_symlink_at_stamp_path` (Unix), `stamp_mode_is_0o600` (Unix), `read_rejects_malformed_semver`, `read_rejects_shell_injection_content`, `read_rejects_build_metadata`, `read_accepts_prerelease_semver`, `read_accepts_plain_semver_after_validation_added`.
- **self_heal**: `bypass_with_mismatch_emits_diagnostic`, `bypass_with_match_emits_no_diagnostic`, `missing_home_skips_gracefully`, `concurrent_installs_serialize` (two threads, asserts non-overlap of installer critical sections).

Updated existing test `env_bypass_skips_install_even_with_mismatch` to assert the new R6 diagnostic.

## Validation

```
cargo fmt --all -- --check                                      ✓
cargo clippy --workspace -- -D warnings                          ✓
TMPDIR=/tmp cargo test -p amplihack-cli --lib (29/29 in scope)   ✓
```

## Docs

`docs/features/self-heal-asset-restage.md` was already updated on PR #501 — included here too (idempotent if #501 merges first).