### PR TITLE
fix(recipes): bootstrap WORKTREE_SETUP_WORKTREE_PATH alias from RECIPE_VAR (#498)

### DIFF
--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -65,6 +65,7 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-20b-push-cleanup requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Pushing Cleanup Changes ==="
       git add -A
@@ -155,6 +156,7 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-21-pr-ready requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Step 20: Converting PR to Ready ==="
       echo ""

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -214,6 +214,7 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-18c-push-feedback-changes requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Pushing Review Feedback Changes ==="
       git add -A
@@ -312,6 +313,7 @@ steps:
     command: |
       set -euo pipefail
       echo "=== ZERO-BS VERIFICATION ==="
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-19c-zero-bs-verification requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
       echo ""
       echo "Scanning for Zero-BS violations..."

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -120,6 +120,7 @@ steps:
     condition: "goal_already_met != 'true'"
     command: |
       set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Step 15: Commit and Push ===" >&2
       # FIX (#495): commit_result MUST be emitted on every exit path so step-16
@@ -214,6 +215,7 @@ steps:
     condition: "goal_already_met != 'true' && commit_result.pushed == 'true'"
     command: |
       set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-16 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Step 16: Creating Draft PR ===" >&2
 

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -197,6 +197,7 @@ steps:
     max_env_value_bytes: 65536
     command: |
       set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-11b-implement-feedback requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
       echo "=== Checkpoint: Staging Review Feedback ==="
       git add -A

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -160,6 +160,7 @@ steps:
       # Fail-loud (Zero-BS, issue #410): require worktree path from step-04 instead
       # of silently falling back to $PWD (which is the parent repo and produces
       # false-positive no-op failures when the worktree contains real work).
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-08c requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git diff --quiet || ! git diff --cached --quiet || \
          [ -n "$(git ls-files --others --exclude-standard)" ]; then
@@ -256,6 +257,7 @@ steps:
     # (implementation, test_spec, design_spec) produce large outputs.
     max_env_value_bytes: 65536
     command: |
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}" && \
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?checkpoint-after-implementation requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}" && \
       echo "=== Checkpoint: Staging Implementation ===" && \
       git add -A && \

--- a/amplifier-bundle/tools/test_default_workflow_fixes.py
+++ b/amplifier-bundle/tools/test_default_workflow_fixes.py
@@ -2626,5 +2626,265 @@ class TestWorktreeSetupPropagation479(unittest.TestCase):
                 )
 
 
+# ===========================================================================
+# Issue #498: WORKTREE_SETUP_WORKTREE_PATH alias bootstrap
+# ===========================================================================
+#
+# The recipe-runner emits sub-recipe outputs as nested-scalar env vars of the
+# form `RECIPE_VAR_worktree_setup__worktree_path` but does NOT also emit the
+# legacy uppercase alias `WORKTREE_SETUP_WORKTREE_PATH` that the bash steps
+# guard on with `${WORKTREE_SETUP_WORKTREE_PATH:?...}`. As a result, every
+# downstream step that depends on the worktree path aborts loudly even though
+# the value IS available under the nested name.
+#
+# Fix (YAML-layer bootstrap, runner-side fix tracked separately):
+# Insert this line directly above each existing fail-loud `cd` guard:
+#
+#     : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
+#
+# Semantics:
+#   * `:=` assigns the inner expansion to WORKTREE_SETUP_WORKTREE_PATH ONLY
+#     when WORKTREE_SETUP_WORKTREE_PATH is unset or empty (idempotent;
+#     forward-compatible if the runner later emits the alias natively).
+#   * `:-` on the inner expansion is REQUIRED because steps run under
+#     `set -u`; without it, an unset RECIPE_VAR_* would trip
+#     `unbound variable` before the outer `:?` guard could fire its
+#     diagnostic.
+#   * The existing `${...:?diagnostic}` guard on the next line is preserved
+#     verbatim — Zero-BS fail-loud behavior is unchanged when BOTH names are
+#     unset.
+#
+# These tests are RED until the YAML is patched. They become GREEN after the
+# bootstrap line is added directly above each cd guard.
+
+_ISSUE_498_YAMLS: tuple[Path, ...] = (
+    _RECIPES_DIR / "workflow-tdd.yaml",
+    _RECIPES_DIR / "workflow-publish.yaml",
+    _RECIPES_DIR / "workflow-pr-review.yaml",
+    _RECIPES_DIR / "workflow-finalize.yaml",
+    _RECIPES_DIR / "workflow-refactor-review.yaml",
+)
+
+# Exact bootstrap line, modulo leading indentation (which must match the
+# guard line indentation in the YAML literal block scalar).
+_ISSUE_498_BOOTSTRAP = (
+    ': "${WORKTREE_SETUP_WORKTREE_PATH'
+    ':=${RECIPE_VAR_worktree_setup__worktree_path:-}}"'
+)
+
+# Guard prefix we look for (the diagnostic message text varies per step;
+# we only match the variable+colon-question prefix to enumerate by `cd`
+# occurrence rather than by step name — naming may drift but the guard
+# pattern is invariant).
+_ISSUE_498_GUARD_PREFIX = 'cd "${WORKTREE_SETUP_WORKTREE_PATH:?'
+
+
+def _find_issue_498_guard_lines(yaml_path: Path) -> list[tuple[int, str, str]]:
+    """Return [(lineno, guard_line, line_above), ...] for every fail-loud
+    `cd "${WORKTREE_SETUP_WORKTREE_PATH:?...}"` guard in the file.
+    Line numbers are 1-based. Includes the line immediately above each
+    guard so the bootstrap-presence check can inspect it."""
+    text = yaml_path.read_text()
+    lines = text.splitlines()
+    out: list[tuple[int, str, str]] = []
+    for idx, line in enumerate(lines):
+        if _ISSUE_498_GUARD_PREFIX in line:
+            above = lines[idx - 1] if idx > 0 else ""
+            out.append((idx + 1, line, above))
+    return out
+
+
+class TestWorktreeSetupAliasBootstrap498(unittest.TestCase):
+    """
+    Regression tests for issue #498.
+
+    Symptom: Downstream workflow steps abort with the diagnostic
+        "worktree path missing — refusing to operate outside checkpoint
+         worktree (step-XX requires worktree_setup.worktree_path ...)"
+    even though step-04 (workflow-worktree) ran successfully and the
+    value IS available in the environment as
+    `RECIPE_VAR_worktree_setup__worktree_path`.
+
+    Root cause: the recipe-runner's nested-scalar emission for sub-recipe
+    outputs does not also emit the legacy uppercase alias name that the
+    consumer steps guard on. (Runner-side native fix is tracked in a
+    follow-up against rysweet/amplihack-recipe-runner.)
+
+    Fix: each consumer step bootstraps the alias from the nested var
+    immediately above its existing fail-loud guard.
+
+    These tests assert:
+      A) Bootstrap line is present immediately above EVERY fail-loud
+         `cd "${WORKTREE_SETUP_WORKTREE_PATH:?...}"` guard across all
+         five affected recipe files.
+      B) When only `RECIPE_VAR_worktree_setup__worktree_path` is set
+         (alias unset, mimicking what the runner currently emits), the
+         bootstrap binds the alias and the cd succeeds.
+      C) When BOTH variables are unset, the existing fail-loud `:?`
+         guard still aborts with a diagnostic — the bootstrap is
+         additive, not a silent fallback (Zero-BS preserved).
+    """
+
+    def test_bootstrap_present_before_each_guard(self):
+        """Static gate: every fail-loud `cd` guard must have the alias
+        bootstrap on the line immediately above it, with matching
+        indentation and the exact `:=${RECIPE_VAR_worktree_setup__worktree_path:-}` form."""
+        offenders: list[str] = []
+        total_guards = 0
+        for yaml_path in _ISSUE_498_YAMLS:
+            self.assertTrue(
+                yaml_path.exists(),
+                f"Recipe file missing: {yaml_path}",
+            )
+            guards = _find_issue_498_guard_lines(yaml_path)
+            self.assertGreater(
+                len(guards), 0,
+                f"Expected at least one `cd \"${{WORKTREE_SETUP_WORKTREE_PATH:?...}}\"` "
+                f"guard in {yaml_path.name}; found none. Did the file move or rename?",
+            )
+            for lineno, guard_line, above in guards:
+                total_guards += 1
+                # Bootstrap must be present (substring match — indentation may
+                # differ but the literal text after stripping must be exact).
+                if _ISSUE_498_BOOTSTRAP not in above:
+                    offenders.append(
+                        f"  {yaml_path.name}:L{lineno}\n"
+                        f"    guard: {guard_line.rstrip()}\n"
+                        f"    above: {above.rstrip()!r}\n"
+                        f"    expected the line above to contain:\n"
+                        f"      {_ISSUE_498_BOOTSTRAP}"
+                    )
+                    continue
+                # Indentation of the bootstrap must match the guard line
+                # so it sits cleanly inside the same YAML literal block.
+                guard_indent = len(guard_line) - len(guard_line.lstrip())
+                above_indent = len(above) - len(above.lstrip())
+                if above_indent != guard_indent:
+                    offenders.append(
+                        f"  {yaml_path.name}:L{lineno}\n"
+                        f"    bootstrap indentation ({above_indent}) does not "
+                        f"match guard indentation ({guard_indent}).\n"
+                        f"    above: {above!r}\n"
+                        f"    guard: {guard_line!r}"
+                    )
+        self.assertEqual(
+            offenders, [],
+            f"Issue #498: alias-bootstrap line missing or misaligned above "
+            f"{len(offenders)}/{total_guards} fail-loud cd guard(s).\n"
+            f"Insert this line directly above each guard, with matching "
+            f"indentation:\n"
+            f"  {_ISSUE_498_BOOTSTRAP}\n"
+            f"Offenders:\n" + "\n".join(offenders),
+        )
+
+    def test_bootstrap_binds_alias_from_recipe_var(self):
+        """End-to-end (positive): when only the nested
+        `RECIPE_VAR_worktree_setup__worktree_path` is set (alias unset,
+        mimicking current runner behavior), the bootstrap+guard pair must
+        bind the alias and `cd` into the worktree without aborting."""
+        # Use the workflow-tdd step-08c guard as the canonical case.
+        guards = _find_issue_498_guard_lines(_RECIPES_DIR / "workflow-tdd.yaml")
+        self.assertGreater(len(guards), 0, "No guards found in workflow-tdd.yaml")
+        _, guard_line, above = guards[0]
+        # The snippet under test is the bootstrap immediately followed by
+        # the guard. Strip any surrounding indentation so bash can parse
+        # the literal block as a standalone script.
+        snippet = textwrap.dedent(
+            "\n".join([above.lstrip(), guard_line.lstrip()])
+        )
+
+        tmp = tempfile.mkdtemp()
+        try:
+            # Deterministic env: explicit, no inheritance from os.environ
+            # except PATH (needed to locate /bin/bash, /usr/bin/printf, etc.).
+            # Never merge os.environ — prevents host-secret leakage and
+            # ensures the test is reproducible across machines.
+            env = {
+                "PATH": os.environ["PATH"],
+                "RECIPE_VAR_worktree_setup__worktree_path": tmp,
+                # WORKTREE_SETUP_WORKTREE_PATH deliberately UNSET — the
+                # bootstrap must populate it from the nested var.
+            }
+            # Run under `set -eu` to exercise the strict-mode constraint
+            # the workflow steps actually run under.
+            wrapped = "set -eu\n" + snippet + "\n" + 'printf "%s" "$PWD"\n'
+            result = subprocess.run(
+                ["bash", "-c", wrapped],
+                capture_output=True, text=True, env=env, cwd=tmp,
+            )
+            self.assertEqual(
+                result.returncode, 0,
+                f"Issue #498: bootstrap+guard snippet must succeed when only "
+                f"RECIPE_VAR_worktree_setup__worktree_path is set "
+                f"(alias unset). Got rc={result.returncode}\n"
+                f"snippet={snippet!r}\n"
+                f"stdout={result.stdout!r}\n"
+                f"stderr={result.stderr!r}",
+            )
+            # Resolve symlinks because mkdtemp on macOS returns /var paths
+            # that resolve to /private/var; on Linux it's a no-op.
+            self.assertEqual(
+                Path(result.stdout).resolve(), Path(tmp).resolve(),
+                f"Bootstrap should have cd'd into the worktree path "
+                f"{tmp!r}, but ended up in {result.stdout!r}",
+            )
+            self.assertNotIn(
+                "unbound variable", result.stderr,
+                "Bootstrap must use `:-` on the inner expansion so `set -u` "
+                "does not abort before the outer `:?` guard can fire.\n"
+                f"stderr={result.stderr}",
+            )
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_fail_loud_when_both_unset(self):
+        """End-to-end (negative): when BOTH WORKTREE_SETUP_WORKTREE_PATH
+        and RECIPE_VAR_worktree_setup__worktree_path are unset, the
+        existing fail-loud `:?` guard must still abort with its
+        diagnostic. The bootstrap is additive — Zero-BS preserved, no
+        silent fallback introduced."""
+        guards = _find_issue_498_guard_lines(_RECIPES_DIR / "workflow-tdd.yaml")
+        self.assertGreater(len(guards), 0, "No guards found in workflow-tdd.yaml")
+        _, guard_line, above = guards[0]
+        snippet = textwrap.dedent(
+            "\n".join([above.lstrip(), guard_line.lstrip()])
+        )
+
+        # Deterministic env: PATH only, both worktree vars deliberately
+        # absent. No os.environ merge.
+        env = {"PATH": os.environ["PATH"]}
+        wrapped = "set -eu\n" + snippet + "\n"
+        result = subprocess.run(
+            ["bash", "-c", wrapped],
+            capture_output=True, text=True, env=env,
+        )
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Issue #498: when BOTH WORKTREE_SETUP_WORKTREE_PATH and "
+            "RECIPE_VAR_worktree_setup__worktree_path are unset, the "
+            "fail-loud `:?` guard MUST abort. Got rc=0 — bootstrap "
+            "introduced a silent fallback (Zero-BS violation).\n"
+            f"stdout={result.stdout!r}\n"
+            f"stderr={result.stderr!r}",
+        )
+        # Diagnostic from the `:?` guard must mention worktree_setup so
+        # the operator can trace back to the upstream cause.
+        self.assertIn(
+            "worktree_setup", result.stderr,
+            "Failure diagnostic must mention `worktree_setup` so the "
+            "operator can trace to the upstream sub-recipe.\n"
+            f"stderr={result.stderr}",
+        )
+        # Bootstrap must not leak `unbound variable` from `set -u`
+        # tripping on the inner expansion before the outer `:?` fires.
+        self.assertNotIn(
+            "unbound variable", result.stderr,
+            "Bootstrap must use `:-` on the inner expansion to suppress "
+            "set -u abortion; the OUTER `:?` should be the one that "
+            "fires the diagnostic.\n"
+            f"stderr={result.stderr}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Recipe-runner emits nested step outputs only as `RECIPE_VAR_<step>__<key>` env vars, not the legacy uppercase `WORKTREE_SETUP_WORKTREE_PATH` alias. Workflow steps consuming the alias via `cd "${WORKTREE_SETUP_WORKTREE_PATH:?...}"` correctly fail loud when the alias is unset, blocking smart-orchestrator at `checkpoint-after-implementation`.

## Fix

Insert a forward-compatible bootstrap line directly above each fail-loud `cd` guard:

```bash
: "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
```

Binds the uppercase alias from the nested `RECIPE_VAR` if absent, while preserving fail-loud behavior when both vars are unset (empty `:-` → empty string → `:?` aborts loudly). Inner `:-` is required because steps run under `set -u`.

## Scope

All 9 affected steps across 5 workflow recipes:
- `workflow-tdd.yaml` — step-08c, checkpoint-after-implementation
- `workflow-publish.yaml` — step-15, step-16
- `workflow-pr-review.yaml` — step-18c, step-19c
- `workflow-finalize.yaml` — step-20b, step-21
- `workflow-refactor-review.yaml` — step-11b

## Tests

Added `TestWorktreeSetupAliasBootstrap498` with three regressions:
- **Static gate** — bootstrap precedes every fail-loud `cd` guard
- **Positive** — alias binds when only the nested `RECIPE_VAR` is set
- **Negative** — fail-loud preserved when both vars are unset

Subprocess tests pass explicit `env=` (no `os.environ` inheritance) for determinism and host-secret-leakage prevention.

## Validation

- ✅ `python3 -m unittest TestWorktreeSetupAliasBootstrap498` — all 3 pass
- ✅ PyYAML round-trip parses all 5 modified files
- ✅ Pre-existing test failure count unchanged (24 errors, all unrelated to #498)
- ✅ Zero-BS preserved — no silent fallbacks introduced; existing `:?` guards untouched

## Follow-up

A separate issue will be filed against `rysweet/amplihack-recipe-runner` to emit uppercase aliases for nested scalar leaves natively. Once landed, this YAML bootstrap becomes a forward-compatible no-op.

Closes #498