### PR TITLE
fix(launch): persist AMPLIHACK_AGENT_BINARY in launcher context (#506)

### DIFF
--- a/crates/amplihack-cli/src/commands/launch/context.rs
+++ b/crates/amplihack-cli/src/commands/launch/context.rs
@@ -23,6 +23,15 @@ pub(super) fn persist_launcher_context(
 
     let mut environment = BTreeMap::new();
     environment.insert("AMPLIHACK_LAUNCHER".to_string(), "copilot".to_string());
+    // Issue #506: nested re-launches (recipe-runner sub-recipes, agent
+    // tasks) read AMPLIHACK_AGENT_BINARY from the persisted launcher
+    // context to choose the active agent binary. Without this entry the
+    // child process inherits no preference, falls back to claude, and
+    // exits 1 with claude-not-found. The value is hardcoded here because
+    // this branch is gated by `tool == "copilot"` above — reading from
+    // std::env would be wrong (the parent may not have it set even when
+    // we explicitly know we are launching copilot).
+    environment.insert("AMPLIHACK_AGENT_BINARY".to_string(), "copilot".to_string());
     write_launcher_context(
         project_root,
         LauncherKind::Copilot,

--- a/crates/amplihack-cli/src/commands/launch/tests_env.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_env.rs
@@ -260,6 +260,75 @@ fn persist_launcher_context_writes_copilot_context_file() {
     );
 }
 
+/// Issue #506 regression: when launching with `--tool copilot`, the
+/// persisted `launcher_context.json` must include
+/// `AMPLIHACK_AGENT_BINARY=copilot` in its environment map so nested
+/// re-launches (recipe runner sub-recipes, agent tasks) inherit the
+/// correct active binary instead of silently falling back to claude.
+///
+/// Per Decision 2 in the requirements doc the value is hardcoded —
+/// `persist_launcher_context` only runs when `tool == "copilot"`, so
+/// reading from `std::env::var` would be wrong (the env var may be
+/// missing on the parent process even though we know we are launching
+/// copilot). The test is intentionally tight: it asserts the exact key
+/// and value, so any future "lost in translation" change at this
+/// chokepoint surfaces immediately.
+///
+/// TDD note: this test is expected to FAIL until the implementation
+/// adds the explicit `environment.insert("AMPLIHACK_AGENT_BINARY", …)`
+/// line in `persist_launcher_context`.
+#[test]
+fn persist_launcher_context_writes_agent_binary_for_copilot() {
+    let dir = tempfile::tempdir().unwrap();
+
+    persist_launcher_context("copilot", Some(dir.path()), &[]).unwrap();
+
+    let context = read_launcher_context(dir.path()).unwrap();
+    assert_eq!(context.launcher, LauncherKind::Copilot);
+    assert_eq!(
+        context
+            .environment
+            .get("AMPLIHACK_AGENT_BINARY")
+            .map(String::as_str),
+        Some("copilot"),
+        "issue #506: persisted launcher context must propagate \
+         AMPLIHACK_AGENT_BINARY=copilot so nested launches stay on the \
+         copilot binary; got environment={:?}",
+        context.environment
+    );
+    // Defense-in-depth: AMPLIHACK_LAUNCHER must remain alongside the new
+    // AMPLIHACK_AGENT_BINARY entry — they are independent contracts and
+    // the fix must add, not replace.
+    assert_eq!(
+        context
+            .environment
+            .get("AMPLIHACK_LAUNCHER")
+            .map(String::as_str),
+        Some("copilot"),
+        "AMPLIHACK_LAUNCHER must still be present after #506 fix"
+    );
+}
+
+/// Issue #506 scope guard: the fix must NOT start persisting a launcher
+/// context for non-copilot tools. The early-return at context.rs:14-16
+/// is load-bearing — sub-launches under claude/codex/amplifier rely on
+/// the absence of a stale context file. Asserting "no file written"
+/// keeps the scope of #506 tight.
+#[test]
+fn persist_launcher_context_writes_nothing_for_non_copilot_tools() {
+    let dir = tempfile::tempdir().unwrap();
+
+    persist_launcher_context("claude", Some(dir.path()), &[]).unwrap();
+    persist_launcher_context("codex", Some(dir.path()), &[]).unwrap();
+    persist_launcher_context("amplifier", Some(dir.path()), &[]).unwrap();
+
+    assert!(
+        read_launcher_context(dir.path()).is_none(),
+        "issue #506 fix must remain copilot-only — no context file may \
+         be written for claude/codex/amplifier launches"
+    );
+}
+
 #[test]
 fn build_command_skips_dangerous_flag_for_copilot() {
     let _home_guard = home_env_lock()


### PR DESCRIPTION
Closes #506

## Problem
When a launcher invokes amplihack with copilot as the active binary, `persist_launcher_context` writes a `launcher_context.json` for nested re-launches but does not include `AMPLIHACK_AGENT_BINARY` in the environment map. Nested recipe-runner sub-recipes and agent tasks therefore inherit no agent-binary preference, fall back to claude, and exit 1 with claude-not-found on copilot-only installs.

## Fix
Insert `AMPLIHACK_AGENT_BINARY=copilot` into the persisted `environment` map alongside the existing `AMPLIHACK_LAUNCHER` entry. The value is hardcoded because this branch is already gated by `tool == "copilot"` — reading from `std::env` would be wrong (the parent may not have it set even when we explicitly know we are launching copilot).

## Tests
- `persist_launcher_context_writes_agent_binary_for_copilot` — asserts the new key/value lands in the persisted context and `AMPLIHACK_LAUNCHER` is preserved alongside it.
- `persist_launcher_context_writes_nothing_for_non_copilot_tools` — scope guard: no stale context file for claude/codex/amplifier launches.

## Validation
- `TMPDIR=/tmp cargo test -p amplihack-cli --lib persist_launcher_context` → 3 passed.
- `cargo clippy -p amplihack-cli --lib -- -D warnings` → clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>