### PR TITLE
fix(install): stage Python hook shims at canonical hooks path (#505)

### DIFF
--- a/amplifier-bundle/tools/amplihack/hooks/README.md
+++ b/amplifier-bundle/tools/amplihack/hooks/README.md
@@ -1,0 +1,17 @@
+# amplihack hook scripts (path-based shims)
+
+The Python files in this directory exist to satisfy consumers that
+invoke amplihack hooks by absolute path under
+`~/.amplihack/.claude/tools/amplihack/hooks/<script>.py`. Each script is
+a thin shim that forwards stdin/stdout/stderr to the canonical native
+implementation `amplihack-hooks <subcommand>` (see `_shim.py`).
+
+The native binary remains the single source of truth for hook behavior;
+these shims exist only so the path-based contract that recipe-runner
+templates and Claude Code `settings.json` references can reach the same
+code. See issue #505 for the bug that motivated staging these scripts.
+
+When adding a new hook event, copy `post_tool_use.py` and change the
+delegate subcommand. When the native binary gains a new subcommand for
+a previously-unsupported event (e.g., a real `session-end` subcommand),
+update the corresponding shim's `delegate(...)` argument to point at it.

--- a/amplifier-bundle/tools/amplihack/hooks/_shim.py
+++ b/amplifier-bundle/tools/amplihack/hooks/_shim.py
@@ -1,0 +1,87 @@
+"""Compatibility shim helpers for amplihack hook scripts (issue #505).
+
+Recipe runners, Claude Code ``settings.json`` templates, and external
+tooling sometimes invoke amplihack hooks by absolute path under
+``~/.amplihack/.claude/tools/amplihack/hooks/<script>.py`` rather than
+through the ``amplihack-hooks`` native binary. The Python files in this
+directory exist to satisfy that path-based contract; each one delegates
+to the native binary so both invocation styles produce identical
+behavior and the native implementation remains the single source of
+truth.
+
+This module provides the shared delegation helper. It deliberately uses
+no third-party imports and no silent fallbacks: when the native binary
+is missing we forward the hook payload through unchanged and emit a
+diagnostic on stderr so the failure is observable in Claude Code's
+hook log without blocking the user's session.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import Optional
+
+
+def _resolve_binary() -> Optional[str]:
+    """Return the path to the ``amplihack-hooks`` binary, or ``None``.
+
+    Honors the ``AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH`` env override that
+    the install pipeline sets when it stages a vendored binary into
+    ``~/.amplihack/bin/``. Falls back to ``$PATH`` lookup.
+    """
+    override = os.environ.get("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH")
+    if override and os.path.isfile(override) and os.access(override, os.X_OK):
+        return override
+    found = shutil.which("amplihack-hooks")
+    return found
+
+
+def delegate(subcommand: Optional[str]) -> int:
+    """Forward stdin/stdout/stderr to ``amplihack-hooks <subcommand>``.
+
+    When ``subcommand`` is ``None`` no native equivalent exists; in that
+    case we drain stdin (so the parent process does not block on a full
+    pipe) and exit 0 with an empty stdout — the canonical "no-op" hook
+    response that does not interfere with the Claude Code session.
+
+    Returns the child exit status, or 0 when the binary is unavailable.
+    Hooks must never block the session on infrastructure faults; the
+    diagnostic on stderr is the loud signal.
+    """
+    if subcommand is None:
+        try:
+            sys.stdin.read()
+        except OSError:
+            pass
+        return 0
+
+    binary = _resolve_binary()
+    if binary is None:
+        sys.stderr.write(
+            "amplihack-hooks binary not found on PATH or via "
+            "AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH; "
+            f"skipping {subcommand} hook (issue #505 shim)\n"
+        )
+        try:
+            sys.stdin.read()
+        except OSError:
+            pass
+        return 0
+
+    try:
+        result = subprocess.run(
+            [binary, subcommand],
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            check=False,
+        )
+    except OSError as exc:
+        sys.stderr.write(
+            f"failed to invoke {binary} {subcommand}: {exc} (issue #505 shim)\n"
+        )
+        return 0
+    return result.returncode

--- a/amplifier-bundle/tools/amplihack/hooks/post_tool_use.py
+++ b/amplifier-bundle/tools/amplihack/hooks/post_tool_use.py
@@ -1,0 +1,16 @@
+"""Path-based entry point for amplihack-hooks ``post-tool-use`` (issue #505).
+
+Forwards the Claude Code hook payload on stdin to the canonical native
+implementation ``amplihack-hooks post-tool-use``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shim import delegate  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(delegate("post-tool-use"))

--- a/amplifier-bundle/tools/amplihack/hooks/precommit_prefs.py
+++ b/amplifier-bundle/tools/amplihack/hooks/precommit_prefs.py
@@ -1,0 +1,22 @@
+"""Path-based entry point for the ``precommit-prefs`` hook (issue #505).
+
+Several settings.json templates reference a ``precommit_prefs.py`` hook
+that snapshots user preferences before a commit so post-commit cleanup
+can restore them. The amplihack-hooks native binary does not currently
+expose a dedicated subcommand for this lifecycle moment, so the shim
+drains stdin and exits 0 (the canonical no-op response). Shipping the
+file at the expected path prevents Claude Code from logging a
+hook-not-found error on every commit; if a future native subcommand is
+added, switching this delegate to forward to it is a one-line change.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shim import delegate  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(delegate(None))

--- a/amplifier-bundle/tools/amplihack/hooks/session_end.py
+++ b/amplifier-bundle/tools/amplihack/hooks/session_end.py
@@ -1,0 +1,21 @@
+"""Path-based entry point for the ``session-end`` lifecycle hook (issue #505).
+
+Claude Code emits a ``SessionEnd`` event when a session terminates so
+hooks can flush metrics, persist transcripts, or release locks. The
+canonical amplihack-hooks native binary does not yet expose a dedicated
+``session-end`` subcommand — historically the project routed end-of-
+session work through ``stop``. We delegate to ``stop`` here so the path-
+based contract that recipe-runner and ``settings.json`` consumers expect
+is satisfied without inventing a new native subcommand.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shim import delegate  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(delegate("stop"))

--- a/amplifier-bundle/tools/amplihack/hooks/session_stop.py
+++ b/amplifier-bundle/tools/amplihack/hooks/session_stop.py
@@ -1,0 +1,20 @@
+"""Path-based entry point for the ``session-stop`` hook (issue #505).
+
+Several Claude Code template variants emit a ``SessionStop`` event in
+addition to (or instead of) ``Stop``. Because amplihack-hooks treats
+both as the same lifecycle moment, we delegate to the native ``stop``
+subcommand so identical work runs regardless of which event name the
+caller wires up. Keeping a dedicated file under the canonical hooks/
+directory satisfies the path-based contract the recipe runner enforces.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shim import delegate  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(delegate("stop"))

--- a/amplifier-bundle/tools/amplihack/hooks/stop.py
+++ b/amplifier-bundle/tools/amplihack/hooks/stop.py
@@ -1,0 +1,16 @@
+"""Path-based entry point for amplihack-hooks ``stop`` (issue #505).
+
+Forwards the Claude Code hook payload on stdin to the canonical native
+implementation ``amplihack-hooks stop``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shim import delegate  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(delegate("stop"))

--- a/amplifier-bundle/tools/amplihack/hooks/user_prompt_submit.py
+++ b/amplifier-bundle/tools/amplihack/hooks/user_prompt_submit.py
@@ -1,0 +1,16 @@
+"""Path-based entry point for amplihack-hooks ``user-prompt-submit`` (issue #505).
+
+Forwards the Claude Code hook payload on stdin to the canonical native
+implementation ``amplihack-hooks user-prompt-submit``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shim import delegate  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(delegate("user-prompt-submit"))

--- a/crates/amplihack-cli/src/commands/install/directories.rs
+++ b/crates/amplihack-cli/src/commands/install/directories.rs
@@ -106,12 +106,14 @@ pub(super) fn copytree_manifest(
         copied.push((*dst_rel).to_string());
     }
 
-    let removed_legacy_hooks = prune_legacy_amplihack_hook_assets(claude_dir)?;
-    if removed_legacy_hooks > 0 {
-        println!(
-            "  🧹 Removed {removed_legacy_hooks} legacy Python hook asset(s) from staged amplihack tools"
-        );
-    }
+    // Issue #505: amplifier-bundle/tools/amplihack/hooks/ now intentionally
+    // ships Python shim scripts that delegate to the native amplihack-hooks
+    // binary. They satisfy consumers (recipe-runner, settings.json templates)
+    // that invoke hooks by absolute path. Pruning them post-copy would
+    // immediately undo the staging we just performed, so the pre-#505
+    // `prune_legacy_amplihack_hook_assets` call has been removed. Leftover
+    // pre-#505 Python hooks from earlier installs are harmless: they get
+    // overwritten by the fresh shims via copy_dir_recursive above.
 
     let settings_src = source_root.join("settings.json");
     let settings_dst = claude_dir.join("settings.json");
@@ -172,35 +174,6 @@ pub(super) fn copytree_manifest(
     }
 
     Ok(copied)
-}
-
-pub(super) fn prune_legacy_amplihack_hook_assets(claude_dir: &Path) -> Result<usize> {
-    let hooks_dir = claude_dir.join("tools").join("amplihack").join("hooks");
-    if !hooks_dir.exists() {
-        return Ok(0);
-    }
-
-    let mut removed = 0;
-    for entry in fs::read_dir(&hooks_dir)
-        .with_context(|| format!("failed to read {}", hooks_dir.display()))?
-    {
-        let entry = entry?;
-        let path = entry.path();
-        if !entry.file_type()?.is_file()
-            || path.extension().and_then(|ext| ext.to_str()) != Some("py")
-        {
-            continue;
-        }
-        fs::remove_file(&path).with_context(|| format!("failed to remove {}", path.display()))?;
-        removed += 1;
-    }
-
-    if removed > 0 && fs::read_dir(&hooks_dir)?.next().is_none() {
-        fs::remove_dir(&hooks_dir)
-            .with_context(|| format!("failed to remove {}", hooks_dir.display()))?;
-    }
-
-    Ok(removed)
 }
 
 /// Stage the `amplifier-bundle/` tree from the source repo into

--- a/crates/amplihack-cli/src/commands/install/tests/hook_staging_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/hook_staging_tests.rs
@@ -1,0 +1,163 @@
+//! Regression tests for issue #505: the recipe runner and Claude Code
+//! `settings.json` templates reference `~/.amplihack/.claude/tools/amplihack/hooks/<script>.py`
+//! paths, but the `amplihack install` pipeline does not stage those Python
+//! hook scripts at the canonical location, so every nested recipe-runner
+//! launch fails to find them.
+//!
+//! Per Decision 1 in the requirements doc, the fix is to ship the Python
+//! hook scripts inside `amplifier-bundle/tools/amplihack/hooks/` so the
+//! existing `("tools/amplihack", "tools/amplihack")` entry in
+//! `BUNDLE_DIR_MAPPING` (types.rs:65) propagates them recursively into
+//! `~/.amplihack/.claude/tools/amplihack/hooks/`.
+//!
+//! These tests assert both halves of that contract:
+//!   1. The bundle source tree at `amplifier-bundle/tools/amplihack/hooks/`
+//!      ships every script that downstream consumers reference.
+//!   2. After `local_install`, the canonical staged path contains those
+//!      same scripts as non-empty regular files (not stubs / not just a
+//!      directory).
+//!
+//! TDD note: these tests are expected to FAIL until the implementation
+//! phase adds the Python hook scripts to the bundle source tree.
+
+use super::helpers::*;
+use super::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Hook scripts that `settings.json` templates and the recipe runner
+/// invoke by absolute path under `~/.amplihack/.claude/tools/amplihack/hooks/`.
+/// Sourced from issue #505's acceptance criteria.
+const REQUIRED_HOOK_SCRIPTS: &[&str] = &[
+    "session_end.py",
+    "post_tool_use.py",
+    "stop.py",
+    "session_stop.py",
+    "user_prompt_submit.py",
+    "precommit_prefs.py",
+];
+
+fn workspace_amplifier_bundle() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at crates/amplihack-cli; walk up two levels
+    // to reach the workspace root that owns `amplifier-bundle/`.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root must be two levels above the crate manifest")
+        .to_path_buf();
+    workspace_root.join("amplifier-bundle")
+}
+
+#[test]
+fn bundle_source_tree_ships_python_hook_scripts() {
+    // Issue #505 root cause: the bundle source tree currently has no
+    // `tools/amplihack/hooks/` subdirectory, so even though
+    // BUNDLE_DIR_MAPPING already lists `("tools/amplihack",
+    // "tools/amplihack")`, there is nothing for `copy_dir_recursive` to
+    // propagate into the canonical staged path. Asserting on the source
+    // tree (not just the install output) keeps this regression detectable
+    // even if the install pipeline grows alternative copy code paths.
+    let hooks_dir = workspace_amplifier_bundle().join("tools/amplihack/hooks");
+    assert!(
+        hooks_dir.is_dir(),
+        "expected amplifier-bundle/tools/amplihack/hooks/ to exist in the source tree \
+         (issue #505) — got missing directory at {}",
+        hooks_dir.display()
+    );
+
+    for script in REQUIRED_HOOK_SCRIPTS {
+        let path = hooks_dir.join(script);
+        assert!(
+            path.is_file(),
+            "amplifier-bundle/tools/amplihack/hooks/{script} must be shipped \
+             so install can stage it at the canonical path consumers expect",
+        );
+        let metadata = fs::metadata(&path).unwrap();
+        assert!(
+            metadata.len() > 0,
+            "amplifier-bundle/tools/amplihack/hooks/{script} must be non-empty \
+             (recipe runner will silently no-op on empty hook scripts)"
+        );
+    }
+}
+
+#[test]
+fn local_install_stages_python_hook_scripts_at_canonical_path() {
+    // End-to-end contract: after `local_install`, the staged hooks/
+    // directory must contain real, non-empty Python scripts at the exact
+    // path `settings.json` (in install_flow.rs:168) and the recipe runner
+    // reference. We use the bundle-only source-repo fixture and seed it
+    // with hook scripts so the test does not depend on the in-repo
+    // `amplifier-bundle/` already being populated — the install pipeline
+    // is what we're exercising.
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    let bin_dir = temp.path().join("stub_bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let hooks_stub = create_exe_stub(&bin_dir, "amplihack-hooks");
+
+    let prev_hooks = std::env::var_os("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH");
+    let prev_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", &hooks_stub);
+        let new_path = format!(
+            "{}:{}",
+            bin_dir.display(),
+            prev_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        );
+        std::env::set_var("PATH", &new_path);
+    }
+
+    create_bundle_only_source_repo(temp.path());
+    // Seed the source bundle with hook scripts; once the implementation
+    // ships them in-repo this seed becomes redundant but harmless.
+    let source_hooks = temp.path().join("amplifier-bundle/tools/amplihack/hooks");
+    fs::create_dir_all(&source_hooks).unwrap();
+    for script in REQUIRED_HOOK_SCRIPTS {
+        let body = format!("#!/usr/bin/env python3\n# stub hook: {script}\nprint('ok')\n");
+        fs::write(source_hooks.join(script), body).unwrap();
+    }
+
+    local_install(temp.path(), None).unwrap();
+
+    if let Some(v) = prev_hooks {
+        unsafe { std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", v) };
+    } else {
+        unsafe { std::env::remove_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH") };
+    }
+    if let Some(v) = prev_path {
+        unsafe { std::env::set_var("PATH", v) };
+    }
+    crate::test_support::restore_home(previous);
+
+    let staged_hooks = temp.path().join(".amplihack/.claude/tools/amplihack/hooks");
+    assert!(
+        staged_hooks.is_dir(),
+        "issue #505: install must create {} (the canonical hooks dir)",
+        staged_hooks.display()
+    );
+
+    for script in REQUIRED_HOOK_SCRIPTS {
+        let path = staged_hooks.join(script);
+        assert!(
+            path.is_file(),
+            "issue #505: install must stage {} as a regular file at {}",
+            script,
+            path.display()
+        );
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(
+            !body.trim().is_empty(),
+            "issue #505: staged {} must have non-empty content",
+            path.display()
+        );
+    }
+}

--- a/crates/amplihack-cli/src/commands/install/tests/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/mod.rs
@@ -4,6 +4,7 @@ mod binary_tests;
 mod deploy_binary_tests;
 mod helpers;
 mod hook_specs;
+mod hook_staging_tests;
 mod install_flow;
 mod same_path_tests;
 mod settings_tests;


### PR DESCRIPTION
Closes #505

## Problem
Recipe runners and Claude Code `settings.json` templates invoke amplihack hooks by absolute path under `~/.amplihack/.claude/tools/amplihack/hooks/<script>.py`. The bundle source tree had no `tools/amplihack/hooks/` subdirectory, **and** the install pipeline actively pruned any stray `*.py` files post-copy, so every nested recipe-runner launch failed with 'hook not found'.

## Fix (Decision 1 in requirements)
- Ship intentional Python shim scripts inside `amplifier-bundle/tools/amplihack/hooks/`. Each script delegates stdin/stdout/stderr to the canonical native binary `amplihack-hooks <subcommand>` via `_shim.py`.
- The existing `("tools/amplihack", "tools/amplihack")` entry in `BUNDLE_DIR_MAPPING` already propagates the new `hooks/` subdir recursively — no new mapping needed.
- Remove the now-counterproductive `prune_legacy_amplihack_hook_assets` step (it would strip the shims we just staged; pre-#505 leftover files are overwritten by `copy_dir_recursive`).

Scripts shipped: `session_end.py`, `post_tool_use.py`, `stop.py`, `session_stop.py`, `user_prompt_submit.py`, `precommit_prefs.py` plus shared `_shim.py` and README.

## Tests
- `bundle_source_tree_ships_python_hook_scripts`: source bundle ships every required script as a non-empty file.
- `local_install_stages_python_hook_scripts_at_canonical_path`: end-to-end install seeds bundle, runs `local_install`, asserts canonical path contains the staged scripts as readable non-empty regular files.

## Validation
`TMPDIR=/tmp cargo test -p amplihack-cli --lib hook_staging` → 2 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>