### PR TITLE
fix(recipes): forward investigation_question to investigation-workflow (#507)

### DIFF
--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -127,9 +127,6 @@ steps:
       worktree_setup: "{{worktree_setup}}"
       allow_no_op: "{{allow_no_op}}"
       skip_pre_agent_validation: "{{skip_pre_agent_validation}}"
-    # No explicit context needed: task_description and repo_path flow through
-    # from the parent smart-orchestrator context automatically via context merging
-    # in _execute_sub_recipe().
     output: "round_1_result"
 
   - id: "execute-single-round-1-investigation"
@@ -138,11 +135,8 @@ steps:
     condition: |
       'Investigation' in task_type and ((workstream_count == 1 or workstream_count == '1' or workstream_count == '') or force_single_workstream == 'true')
     recipe: "investigation-workflow"
-    # Issue #507: investigation-workflow's downstream prompts read
-    # `investigation_question`, but parent context only carries
-    # `task_description`. Forward it explicitly here so the nested recipe
-    # receives a non-empty question. Also re-forward `task_description`
-    # so context_validation steps that still read it keep working.
+    # Issue #507: forward investigation_question — investigation-workflow's
+    # downstream prompts read it, but parent context only carries task_description.
     context:
       investigation_question: "{{task_description}}"
       task_description: "{{task_description}}"
@@ -245,8 +239,6 @@ steps:
       worktree_setup: "{{worktree_setup}}"
       allow_no_op: "{{allow_no_op}}"
       skip_pre_agent_validation: "{{skip_pre_agent_validation}}"
-    # No explicit context needed: task_description and repo_path flow through
-    # from the parent smart-orchestrator context automatically.
     output: "round_1_result"
 
   - id: "execute-single-fallback-blocked-investigation"
@@ -256,8 +248,6 @@ steps:
     condition: |
       'Investigation' in task_type and 'BLOCKED' in recursion_guard and workstream_count != 1 and workstream_count != '1' and workstream_count != ''
     recipe: "investigation-workflow"
-    # Issue #507: forward investigation_question explicitly (see
-    # execute-single-round-1-investigation for rationale).
     context:
       investigation_question: "{{task_description}}"
       task_description: "{{task_description}}"
@@ -392,8 +382,6 @@ steps:
     condition: |
       adaptive_recipe == 'investigation-workflow'
     recipe: "investigation-workflow"
-    # Issue #507: forward investigation_question explicitly so adaptive
-    # recovery does not regress to an empty question.
     context:
       investigation_question: "{{task_description}}"
       task_description: "{{task_description}}"

--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -138,9 +138,14 @@ steps:
     condition: |
       'Investigation' in task_type and ((workstream_count == 1 or workstream_count == '1' or workstream_count == '') or force_single_workstream == 'true')
     recipe: "investigation-workflow"
-    # No explicit context needed: task_description and repo_path flow through
-    # from the parent smart-orchestrator context automatically via context merging
-    # in _execute_sub_recipe().
+    # Issue #507: investigation-workflow's downstream prompts read
+    # `investigation_question`, but parent context only carries
+    # `task_description`. Forward it explicitly here so the nested recipe
+    # receives a non-empty question. Also re-forward `task_description`
+    # so context_validation steps that still read it keep working.
+    context:
+      investigation_question: "{{task_description}}"
+      task_description: "{{task_description}}"
     output: "round_1_result"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -251,8 +256,11 @@ steps:
     condition: |
       'Investigation' in task_type and 'BLOCKED' in recursion_guard and workstream_count != 1 and workstream_count != '1' and workstream_count != ''
     recipe: "investigation-workflow"
-    # No explicit context needed: task_description and repo_path flow through
-    # from the parent smart-orchestrator context automatically.
+    # Issue #507: forward investigation_question explicitly (see
+    # execute-single-round-1-investigation for rationale).
+    context:
+      investigation_question: "{{task_description}}"
+      task_description: "{{task_description}}"
     output: "round_1_result"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -384,6 +392,11 @@ steps:
     condition: |
       adaptive_recipe == 'investigation-workflow'
     recipe: "investigation-workflow"
+    # Issue #507: forward investigation_question explicitly so adaptive
+    # recovery does not regress to an empty question.
+    context:
+      investigation_question: "{{task_description}}"
+      task_description: "{{task_description}}"
     output: "round_1_result"
 
   # Cleanup temp workstreams file (best-effort fallback, fix: cleanup-helper-arg-overflow).

--- a/crates/amplihack-cli/tests/issue_507_routing_question_passthrough.rs
+++ b/crates/amplihack-cli/tests/issue_507_routing_question_passthrough.rs
@@ -1,0 +1,145 @@
+//! Regression tests for issue #507: when smart-orchestrator routes a
+//! task to investigation-workflow via `smart-execute-routing.yaml`, the
+//! sub-recipe receives `task_description` (the parent context name) but
+//! investigation-workflow's downstream prompts read
+//! `investigation_question`. Without an explicit context mapping the
+//! nested recipe runs with an empty question and produces hollow
+//! success.
+//!
+//! Per Decision 3 in the requirements doc the fix is at the routing
+//! layer: every step in `smart-execute-routing.yaml` that invokes
+//! `investigation-workflow` must carry an explicit `context:` block
+//! that maps `investigation_question: "{{task_description}}"` (and
+//! preserves `task_description` itself for `context_validation`).
+//!
+//! These tests parse the live YAML files in `amplifier-bundle/recipes/`
+//! and assert structural invariants. They are intentionally
+//! parser-tolerant — we only check the keys/values that the contract
+//! depends on, not the surrounding step ordering.
+//!
+//! TDD note: the first test is expected to FAIL until the routing YAML
+//! is updated. The second test is a guardrail asserting the
+//! defense-in-depth `normalize-question` step in
+//! `investigation-prep.yaml` is preserved (per Decision 3 it stays as a
+//! belt-and-braces fallback alongside the explicit routing context).
+
+use serde_yaml::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workspace_recipes_dir() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .ancestors()
+        .find(|p| p.join("amplifier-bundle/recipes").is_dir())
+        .map(|p| p.join("amplifier-bundle/recipes"))
+        .expect("workspace must contain amplifier-bundle/recipes/")
+}
+
+fn load_yaml(path: &Path) -> Value {
+    let body = fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    serde_yaml::from_str(&body)
+        .unwrap_or_else(|e| panic!("failed to parse {} as YAML: {e}", path.display()))
+}
+
+fn steps(recipe: &Value) -> &[Value] {
+    recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .map(Vec::as_slice)
+        .expect("recipe must have a top-level `steps:` sequence")
+}
+
+/// Returns every step in the recipe whose `recipe:` key resolves to
+/// `investigation-workflow` — there may be more than one (single vs.
+/// multitask routes both invoke it).
+fn investigation_invocations(recipe: &Value) -> Vec<&Value> {
+    steps(recipe)
+        .iter()
+        .filter(|step| {
+            step.get("type").and_then(Value::as_str) == Some("recipe")
+                && step.get("recipe").and_then(Value::as_str) == Some("investigation-workflow")
+        })
+        .collect()
+}
+
+#[test]
+fn smart_execute_routing_passes_investigation_question_to_investigation_workflow() {
+    let routing = load_yaml(&workspace_recipes_dir().join("smart-execute-routing.yaml"));
+    let invocations = investigation_invocations(&routing);
+    assert!(
+        !invocations.is_empty(),
+        "smart-execute-routing.yaml must invoke investigation-workflow at least once"
+    );
+
+    for (idx, step) in invocations.iter().enumerate() {
+        let step_id = step
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        let context = step.get("context").unwrap_or_else(|| {
+            panic!(
+                "issue #507: investigation-workflow invocation '{step_id}' (index {idx}) \
+                 must declare an explicit `context:` block that forwards \
+                 investigation_question — got step without context: {step:?}"
+            )
+        });
+        let context_map = context.as_mapping().unwrap_or_else(|| {
+            panic!("step '{step_id}': `context:` must be a mapping, got {context:?}")
+        });
+
+        let investigation_question = context_map
+            .get(Value::String("investigation_question".to_string()))
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| {
+                panic!(
+                    "issue #507: step '{step_id}' must set \
+                     `investigation_question: \"{{{{task_description}}}}\"` so the \
+                     nested recipe receives the question; got context={context_map:?}"
+                )
+            });
+        assert!(
+            investigation_question.contains("{{task_description}}")
+                || investigation_question.contains("{{ task_description }}"),
+            "issue #507: step '{step_id}' must derive investigation_question from \
+             task_description (template `{{{{task_description}}}}`); got value {investigation_question:?}"
+        );
+
+        // task_description must remain populated for context_validation —
+        // either explicitly forwarded or inherited via parent merging.
+        // If it's explicitly set we assert it's also `{{task_description}}`.
+        if let Some(task_desc) = context_map
+            .get(Value::String("task_description".to_string()))
+            .and_then(Value::as_str)
+        {
+            assert!(
+                task_desc.contains("{{task_description}}")
+                    || task_desc.contains("{{ task_description }}"),
+                "step '{step_id}': if task_description is explicitly forwarded it must \
+                 reference the parent context, not be hardcoded; got {task_desc:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn investigation_prep_keeps_normalize_question_as_defense_in_depth() {
+    // Decision 3 explicitly preserves the `normalize-question` step as a
+    // belt-and-braces fallback — neither change is load-bearing on the
+    // other. If a future refactor removes it, that change must come with
+    // an updated test (and a separate audit of every caller of
+    // investigation-prep), so this guardrail is intentional.
+    let prep = load_yaml(&workspace_recipes_dir().join("investigation-prep.yaml"));
+    let has_normalize = steps(&prep).iter().any(|step| {
+        step.get("id").and_then(Value::as_str) == Some("normalize-question")
+            && step.get("output").and_then(Value::as_str) == Some("investigation_question")
+    });
+    assert!(
+        has_normalize,
+        "issue #507 (Decision 3): investigation-prep.yaml must keep the \
+         `normalize-question` step (output: investigation_question) as a \
+         defense-in-depth fallback for callers that don't pass \
+         investigation_question explicitly"
+    );
+}


### PR DESCRIPTION
Closes #507

## Problem
When smart-orchestrator routes an Investigation task, `smart-execute-routing.yaml` invoked `investigation-workflow` with no explicit `context:` block. Automatic merging carried `task_description` through, but investigation-workflow's downstream prompts read `investigation_question` — so the nested recipe ran with an empty question and produced hollow success (generic placeholder instead of the actual user question).

## Fix (Decision 3 in requirements)
Fix at the routing layer, not at investigation-workflow's input contract. Every step in `smart-execute-routing.yaml` that invokes `investigation-workflow` now declares an explicit `context:` block:

```yaml
context:
  investigation_question: "{{task_description}}"
  task_description: "{{task_description}}"
```

Three call sites updated:
- `execute-single-round-1-investigation`
- `execute-single-fallback-blocked-investigation`
- `adaptive-execute-investigation`

The `normalize-question` defense-in-depth step in `investigation-prep.yaml` is preserved unchanged as a belt-and-braces fallback for callers that don't pass `investigation_question` explicitly — neither change is load-bearing on the other.

## Tests
- `smart_execute_routing_passes_investigation_question_to_investigation_workflow` — parses YAML, asserts every investigation-workflow invocation forwards `investigation_question` from `task_description`.
- `investigation_prep_keeps_normalize_question_as_defense_in_depth` — guardrail asserting the fallback step is preserved.

## Validation
`TMPDIR=/tmp cargo test -p amplihack-cli --test issue_507_routing_question_passthrough` → 2 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>