### PR TITLE
Fix #520: set working_dir on implementation-phase agent steps

### DIFF
--- a/amplifier-bundle/recipes/workflow-design.yaml
+++ b/amplifier-bundle/recipes/workflow-design.yaml
@@ -21,6 +21,7 @@ context: {}
 steps:
   - id: "step-05-architecture"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5: Research and Design - Architecture
 
@@ -44,6 +45,7 @@ steps:
 
   - id: "step-05b-api-design"
     agent: "amplihack:api-designer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5b: API Design (if applicable)
 
@@ -61,6 +63,7 @@ steps:
 
   - id: "step-05c-database-design"
     agent: "amplihack:database"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5c: Database Design (if applicable)
 
@@ -78,6 +81,7 @@ steps:
 
   - id: "step-05d-security-review"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5d: Security Requirements Review
 
@@ -97,6 +101,7 @@ steps:
 
   - id: "step-05e-design-consolidation"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 5e: Design Consolidation
 
@@ -126,6 +131,7 @@ steps:
   # ==========================================================================
   - id: "step-06-documentation"
     agent: "amplihack:documentation-writer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6: Retcon Documentation Writing
 
@@ -147,6 +153,7 @@ steps:
 
   - id: "step-06b-documentation-review"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6b: Documentation Review
 
@@ -163,6 +170,7 @@ steps:
 
   - id: "step-06c-documentation-refinement"
     agent: "amplihack:documentation-writer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     prompt: |
       # Step 6c: Documentation Refinement
 

--- a/amplifier-bundle/recipes/workflow-precommit-test.yaml
+++ b/amplifier-bundle/recipes/workflow-precommit-test.yaml
@@ -23,6 +23,7 @@ context:
 steps:
   - id: "step-12-run-precommit"
     agent: "amplihack:pre-commit-diagnostic"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 12: Run Tests and Pre-commit Hooks
@@ -61,6 +62,7 @@ steps:
   # ==========================================================================
   - id: "step-13-local-testing"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 13: Mandatory Outside-In Testing (CANNOT BE SKIPPED)

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -32,6 +32,7 @@ context:
 steps:
   - id: "step-14-bump-version"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 14: Bump Version in pyproject.toml (MANDATORY - DO NOT SKIP)
@@ -301,6 +302,7 @@ steps:
   # ==========================================================================
   - id: "step-16b-outside-in-fix-loop"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 16b: Outside-In Testing and Fix Loop (MANDATORY)

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -30,6 +30,7 @@ context:
 steps:
   - id: "step-09-refactor"
     agent: "amplihack:cleanup"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 9: Refactor and Simplify
@@ -59,6 +60,7 @@ steps:
 
   - id: "step-09b-optimize"
     agent: "amplihack:optimizer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 9b: Performance Optimization
@@ -80,6 +82,7 @@ steps:
   # ==========================================================================
   - id: "step-10-pre-commit-review"
     agent: "amplihack:reviewer"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 10: Review Pass Before Commit
@@ -112,6 +115,7 @@ steps:
 
   - id: "step-10b-security-review"
     agent: "amplihack:security"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 10b: Security Review
@@ -132,6 +136,7 @@ steps:
 
   - id: "step-10c-philosophy-check"
     agent: "amplihack:philosophy-guardian"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 10c: Philosophy Compliance Check
@@ -154,6 +159,7 @@ steps:
   # ==========================================================================
   - id: "step-11-incorporate-feedback"
     agent: "amplihack:architect"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 11: Assess Review Feedback
@@ -172,6 +178,7 @@ steps:
 
   - id: "step-11b-implement-feedback"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "goal_already_met != 'true'"
     prompt: |
       # Step 11b: Implement Review Feedback

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -23,6 +23,7 @@ context:
 steps:
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
     prompt: |
       # Step 7: TDD - Write Tests First
@@ -53,6 +54,7 @@ steps:
   # ==========================================================================
   - id: "step-08-implement"
     agent: "amplihack:builder"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
     prompt: |
       # Step 8: Implement the Solution
@@ -231,6 +233,7 @@ steps:
 
   - id: "step-08b-integration"
     agent: "amplihack:integration"
+    working_dir: "{{worktree_setup.worktree_path}}"
     condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
     prompt: |
       # Step 8b: External Service Integration


### PR DESCRIPTION
## Summary

Adds `working_dir: "{{worktree_setup.worktree_path}}"` to all 22 agent steps across the implementation-phase workflow recipes:

- `workflow-design.yaml` (8 steps)
- `workflow-tdd.yaml` (3 steps)
- `workflow-refactor-review.yaml` (7 steps)
- `workflow-precommit-test.yaml` (2 steps)
- `workflow-publish.yaml` (2 steps)

## Why

Without this, agents inherit the recipe-runner's CWD (the main repo dir) and write file edits to the wrong branch. step-15-commit-push then fails with `Nothing staged to commit`. This was reproduced in deyhonification wave 1 attempt — wasted 1221s of compute and stranded 26 files on `main`. See #511 for full post-mortem and #520 for root-cause analysis.

## Why this is the right fix

`recipe-runner-rs` already supports `working_dir` on agent steps (`cli_subprocess.rs:325-345`, comment: *"Use the recipe's working_dir so agents operate against the real repo"*). The same pattern is already used in `consensus-pr-feedback.yaml` and `consensus-merge-finalize.yaml`. This PR is the missing recipe-side wiring to bring the implementation-phase recipes into conformance.

## Validation

- ✅ All 5 modified YAMLs parse cleanly with `python3 -c "import yaml; yaml.safe_load(...)"`
- ✅ `working_dir` field structurally matches the working pattern in `consensus-pr-feedback.yaml:51`
- ✅ 22 agent steps modified (verified via grep count)
- ⏳ End-to-end validation: next deyhonification wave attempt will exercise this path; if step-15 succeeds it confirms the fix.

## Diff size

5 files changed, 22 insertions(+) — purely additive, no logic changes, no behavior change for other agents.

## Closes
Closes #520

## Co-authored-by
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>