### PR TITLE
fix(install): handle deleted source binary in deploy_binary (#524)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/filesystem.rs
+++ b/crates/amplihack-cli/src/commands/install/filesystem.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 use std::collections::{BTreeSet, VecDeque};
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 /// Atomically deploy a binary from `src` to `dst` using rename-then-replace.
@@ -25,6 +26,28 @@ pub(super) fn deploy_binary(src: &Path, dst: &Path) -> Result<()> {
         && s == d
     {
         return Ok(());
+    }
+
+    // Deleted-source short-circuit (issue #524).
+    //
+    // When `amplihack update` swaps the on-disk binary, the still-running
+    // process's argv[0] points at a now-unlinked inode (Linux marks it
+    // "(deleted)" in /proc/self/exe). The auto-launched install step then
+    // re-invokes deploy_binary with that deleted path as `src` and the
+    // freshly-installed binary as `dst`. fs::copy would fail with ENOENT.
+    //
+    // If `src` is gone but `dst` is already a regular file, the deployment
+    // outcome is already satisfied — treat as a no-op. Match ErrorKind::NotFound
+    // exactly (not Err(_)) so PermissionDenied or other I/O errors still
+    // propagate, and require dst.is_file() (not exists()) to reject directories,
+    // FIFOs, and sockets as valid deployed targets.
+    if let Err(e) = src.metadata()
+        && e.kind() == io::ErrorKind::NotFound
+    {
+        if dst.is_file() {
+            return Ok(());
+        }
+        return Err(e).with_context(|| format!("source binary not found: {}", src.display()));
     }
 
     let dst_dir = dst

--- a/crates/amplihack-cli/src/commands/install/tests/deploy_binary_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/deploy_binary_tests.rs
@@ -3,6 +3,7 @@
 
 use super::super::filesystem::deploy_binary;
 use std::fs;
+use std::io;
 use tempfile::TempDir;
 
 #[test]
@@ -74,5 +75,47 @@ fn deploy_binary_cleans_up_temp_on_success() {
     assert!(
         leftovers.is_empty(),
         "no temp files should remain: {leftovers:?}"
+    );
+}
+
+#[test]
+fn deleted_source_with_existing_dst_is_noop() {
+    // Issue #524: after `amplihack update` swaps the binary, the running
+    // process's argv[0] points at a deleted inode. The auto-launched install
+    // step then re-invokes deploy_binary with src == argv[0] (now ENOENT) and
+    // dst == the freshly-written binary. This must succeed as a no-op since
+    // the destination is already the correct, up-to-date binary.
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("src-deleted");
+    let dst = tmp.path().join("dst-current");
+    fs::write(&src, b"old/deleted bytes").unwrap();
+    fs::write(&dst, b"freshly-installed bytes").unwrap();
+    fs::remove_file(&src).unwrap();
+
+    deploy_binary(&src, &dst).expect("deleted-source-with-dst should be Ok");
+    assert_eq!(
+        fs::read(&dst).unwrap(),
+        b"freshly-installed bytes",
+        "dst must remain untouched"
+    );
+}
+
+#[test]
+fn missing_source_and_missing_dst_returns_error() {
+    // Guard rail for the #524 fix: if both src and dst are absent there is
+    // nothing to deploy and no already-installed binary; propagate the
+    // original ENOENT instead of silently masking a real failure.
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("nonexistent-src");
+    let dst = tmp.path().join("nonexistent-dst");
+
+    let err = deploy_binary(&src, &dst).expect_err("missing-both should error");
+    let io_err = err
+        .downcast_ref::<io::Error>()
+        .expect("root cause should be io::Error");
+    assert_eq!(
+        io_err.kind(),
+        io::ErrorKind::NotFound,
+        "should propagate NotFound, got: {err:?}"
     );
 }


### PR DESCRIPTION
Closes #524.

## Bug

`amplihack update` followed by auto-launched `install` failed with:
```
failed to copy /home/azureuser/.local/bin/amplihack (deleted) to .amplihack.new.PID: No such file or directory (os error 2)
```

## Root cause

After `amplihack update` writes the new binary in place, the still-running process's `argv[0]` points at a now-unlinked inode (Linux marks it `(deleted)`). The auto-launched install step calls `deploy_binary(src=argv[0], dst=fresh_binary)`. `fs::copy` fails with ENOENT because `src` no longer exists on disk.

The existing canonicalize-equality check at `filesystem.rs:24` doesn't catch this because the deleted source can no longer be canonicalized.

## Fix

In `deploy_binary`, after the canonicalize-equality check: if `src.metadata()` returns `ErrorKind::NotFound` AND `dst` is already a regular file, treat as a no-op — the destination is already the correct, up-to-date binary. Other `io::Error` kinds (PermissionDenied, etc.) still propagate. Non-file destinations (directory, FIFO, socket) are still rejected.

## Test

`deleted_source_with_existing_dst_is_noop` writes both `src` and `dst`, deletes `src`, then asserts `deploy_binary` succeeds and `dst` is untouched. Reproduces the deleted-inode scenario portably (no `(deleted)` suffix needed; ENOENT behaves the same).

Generated by smart-orchestrator. Scope-creep `.github/hooks/` files written by workflow infrastructure were excluded from this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>