### PR TITLE
docs(philosophy): add 'Install completeness' invariant under Zero-BS

### DIFF
--- a/amplifier-bundle/context/PHILOSOPHY.md
+++ b/amplifier-bundle/context/PHILOSOPHY.md
@@ -54,6 +54,7 @@ Like a brick model, our software is built from small, clear modules. Each module
 - **Do not compromise**: Always choose quality over speed of implementation
 - **No faked APIs or mock implementations**: Implement real functionality from the start, do not create fake data or mock services (except in tests)
 - **No swallowed exceptions**: Handle errors transparently and ensure they are visible during development
+- **Install completeness**: `amplihack install` MUST guarantee that every component the user-facing CLI advertises is actually present and functional after install completes. This includes: every framework asset the post-install verifier checks (e.g. `CLAUDE.md`, hooks, settings), every helper binary that recipes/skills/hooks invoke (e.g. `recipe-runner-rs`), and every PATH-resident command users will type. If install cannot place a component, install must fail loudly with a precise error — never finish "successfully" while the verifier prints `❌`. When adding a new component (binary, asset, hook), update both the install staging code AND the verifier in the same change so they cannot drift.
 
 ### 4. Library vs Custom Code
 


### PR DESCRIPTION
Encodes the invariant: `amplihack install` MUST guarantee every advertised component is present and functional after install completes — including framework assets the verifier checks (e.g. `CLAUDE.md`), helper binaries that recipes/skills/hooks invoke (e.g. `recipe-runner-rs`), and PATH-resident commands. Install must fail loudly if it cannot place a component — never finish 'successfully' while the verifier prints ❌.

Triggered by user feedback after a fresh install on a new host showed:

```
🔍 Verifying staged framework assets:
❌ Missing required framework assets:
  • CLAUDE.md (expected at /home/azureuser/.amplihack/CLAUDE.md)

🦀 Ensuring Rust recipe runner:
❌ recipe-runner-rs not installed (recipe execution will fail without it)
```

The actual code fixes for both bugs are being delivered by a separate orchestrator-driven PR (filed concurrently). This PR only updates the prompt/spec so future install changes encode the invariant up-front.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>