### PR TITLE
Fix recipe runs outside git repositories

### DIFF
--- a/amplifier-bundle/context/PHILOSOPHY.md
+++ b/amplifier-bundle/context/PHILOSOPHY.md
@@ -56,6 +56,8 @@ Like a brick model, our software is built from small, clear modules. Each module
 - **No swallowed exceptions**: Handle errors transparently and ensure they are visible during development
 - **Install completeness**: `amplihack install` MUST guarantee that every component the user-facing CLI advertises is actually present and functional after install completes. This includes: every framework asset the post-install verifier checks (e.g. `CLAUDE.md`, hooks, settings), every helper binary that recipes/skills/hooks invoke (e.g. `recipe-runner-rs`), and every PATH-resident command users will type. If install cannot place a component, install must fail loudly with a precise error — never finish "successfully" while the verifier prints `❌`. When adding a new component (binary, asset, hook), update both the install staging code AND the verifier in the same change so they cannot drift.
 
+Recipes are deterministic orchestration of agentic steps, not implicit shells that assume the host environment is already perfect. Any host-tool call (`git`, `gh`, `cargo`, package managers, cloud CLIs) must declare or check its preconditions at the step boundary and surface clear errors when those preconditions are required. Optional host-tool work, such as telemetry or decorative status reporting, must skip visibly with an explicit note instead of silently degrading; strict workflow work, such as branch, worktree, commit, or PR creation, must fail loudly with an actionable message.
+
 ### 4. Library vs Custom Code
 
 Choosing between custom code and external libraries is a judgment call that evolves with requirements:

--- a/amplifier-bundle/recipes/consensus-merge-finalize.yaml
+++ b/amplifier-bundle/recipes/consensus-merge-finalize.yaml
@@ -24,10 +24,14 @@ steps:
     type: "bash"
     command: |
       echo "Checking CI status..."
-      if git remote get-url origin >/dev/null 2>&1; then
-        gh pr checks 2>/dev/null || echo "CI check pending"
+      if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        if git remote get-url origin >/dev/null 2>&1; then
+          gh pr checks 2>/dev/null || echo "CI check pending"
+        else
+          echo "[skip] not a git repo remote; skipping CI check" >&2
+        fi
       else
-        echo "Skipping CI check — no remote configured" >&2
+        echo "[skip] not a git repo; skipping CI check" >&2
       fi
       echo '{"ci_checked": true}'
     output: "ci_status"

--- a/amplifier-bundle/recipes/consensus-pr-feedback.yaml
+++ b/amplifier-bundle/recipes/consensus-pr-feedback.yaml
@@ -25,6 +25,10 @@ steps:
     type: "bash"
     command: |
       echo "Pushing review updates..."
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step12-push-updates requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
       git add -A
       git commit -m "Address PR review feedback" 2>/dev/null || true
       if git remote get-url origin >/dev/null 2>&1; then
@@ -173,4 +177,3 @@ steps:
   # ============================================================================
   # STEP 14: ENSURE PR IS MERGEABLE
   # ============================================================================
-

--- a/amplifier-bundle/recipes/consensus-preflight.yaml
+++ b/amplifier-bundle/recipes/consensus-preflight.yaml
@@ -27,8 +27,8 @@ steps:
       REPO="$REPO_PATH"
       if [ ! -d "$REPO" ]; then
         ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' does not exist"
-      elif ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
-        ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' is not a git repository"
+      elif ! git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        ERRORS="${ERRORS}\n  ✗ step0-preflight requires a git repo at $REPO; either \`git init\` or rerun from a checkout"
       fi
       if [ -z "$TASK_DESCRIPTION" ]; then
         ERRORS="${ERRORS}\n  ✗ task_description is empty"
@@ -112,4 +112,3 @@ steps:
   # CONSENSUS GATE 1: Multi-Agent Debate for Ambiguous Requirements
   # IF AMBIGUOUS → Deploy 3-5 specialized agents for structured debate
   # ---------------------------------------------------------------------------
-

--- a/amplifier-bundle/recipes/consensus-publish.yaml
+++ b/amplifier-bundle/recipes/consensus-publish.yaml
@@ -24,6 +24,10 @@ steps:
     type: "bash"
     command: |
       echo "Committing changes..."
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step9-commit requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
 
       # Stage all changes
       git add -A
@@ -78,6 +82,10 @@ steps:
     type: "bash"
     command: |
       echo "Creating pull request..."
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step10-create-pr requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
 
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
       _TASK_DESC="$TASK_DESCRIPTION"

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -100,6 +100,9 @@ context:
   ci_status: ""
 
 steps:
+  # Git precondition is enforced in workflow-prep/step-01 before the first
+  # direct git operation: default-workflow requires a git repo at <cwd>; either
+  # `git init` or rerun from a checkout.
   - id: "workflow-prep"
     type: "recipe"
     recipe: "workflow-prep"

--- a/amplifier-bundle/recipes/investigation-prep.yaml
+++ b/amplifier-bundle/recipes/investigation-prep.yaml
@@ -25,8 +25,6 @@ steps:
       REPO="{{repo_path}}"
       if [ ! -d "$REPO" ]; then
         ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' does not exist"
-      elif ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
-        ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' is not a git repository"
       fi
       if [ -z "{{task_description}}" ]; then
         ERRORS="${ERRORS}\n  ✗ task_description is empty"
@@ -173,4 +171,3 @@ steps:
       ```
     output: "ambiguity_resolution"
     parse_json: true
-

--- a/amplifier-bundle/recipes/investigation-workflow.yaml
+++ b/amplifier-bundle/recipes/investigation-workflow.yaml
@@ -18,7 +18,6 @@ context:
   investigation_question: ""
 context_validation:
   task_description: "nonempty"
-  repo_path: "git_repo"
 
   # Path to focus investigation on (optional)
   codebase_path: ""

--- a/amplifier-bundle/recipes/quality-loop.yaml
+++ b/amplifier-bundle/recipes/quality-loop.yaml
@@ -53,7 +53,7 @@ steps:
       done
       gh auth status >/dev/null || { echo "preflight: gh CLI is not authenticated" >&2; exit 1; }
       REPO="{{repo_path}}"
-      git -C "$REPO" rev-parse --git-dir >/dev/null || { echo "preflight: '$REPO' is not a git repository" >&2; exit 1; }
+      git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null || { echo "ERROR: preflight requires a git repo at $REPO; either \`git init\` or rerun from a checkout" >&2; exit 1; }
       if [ -n "$(git -C "$REPO" status --porcelain)" ]; then
         echo "preflight: working tree at '$REPO' is not clean" >&2; git -C "$REPO" status --short >&2; exit 1
       fi
@@ -65,6 +65,10 @@ steps:
       set -euo pipefail
       IFS=$'\n\t'
       REPO="{{repo_path}}"
+      if ! git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: refresh-checkout requires a git repo at $REPO; either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
       git -C "$REPO" fetch --prune origin
       git -C "$REPO" checkout main
       git -C "$REPO" pull --ff-only origin main

--- a/amplifier-bundle/recipes/smart-classify-route.yaml
+++ b/amplifier-bundle/recipes/smart-classify-route.yaml
@@ -34,8 +34,6 @@ steps:
       fi
       if [ ! -d "$REPO" ]; then
         ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' does not exist"
-      elif ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
-        ERRORS="${ERRORS}\n  ✗ repo_path '$REPO' is not a git repository"
       fi
       HELPER_PATH="$(amplihack resolve-bundle-asset helper-path 2>/dev/null || true)"
       if [ -z "$HELPER_PATH" ] || [ ! -f "$HELPER_PATH" ]; then

--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -64,14 +64,12 @@ steps:
     type: "bash"
     condition: "'Operations' in task_type"
     command: |
-      cd "$REPO_PATH" 2>/dev/null || true
+      if [ ! -d "$REPO_PATH" ]; then echo "[skip] repo_path '$REPO_PATH' does not exist; skipping operations git telemetry" >&2; echo ""; exit 0; fi
+      cd "$REPO_PATH"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then echo "[skip] not a git repo; skipping operations git telemetry" >&2; echo ""; exit 0; fi
       CHANGED=$(git diff --name-only 2>/dev/null | head -1)
       UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null | head -1)
-      if [ -n "$CHANGED" ] || [ -n "$UNTRACKED" ]; then
-        echo "true"
-      else
-        echo ""
-      fi
+      if [ -n "$CHANGED" ] || [ -n "$UNTRACKED" ]; then echo "true"; else echo ""; fi
     output: "ops_modified_files"
 
   # ─────────────────────────────────────────────────────────────────────────

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -51,7 +51,6 @@ context:
 
 context_validation:
   task_description: "nonempty"
-  repo_path: "git_repo"
 
 steps:
   - id: "smart-classify-route"

--- a/amplifier-bundle/recipes/verification-workflow.yaml
+++ b/amplifier-bundle/recipes/verification-workflow.yaml
@@ -116,6 +116,10 @@ steps:
     command: |
       cd {{repo_path}} && \
       echo "=== Step 3: Committing Changes ===" && \
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+        echo "ERROR: step-03-commit requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2; \
+        exit 1; \
+      fi && \
       git status --short && \
       echo "" && \
       echo "Ready to commit with message based on: {{change_description}}" && \

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -67,6 +67,10 @@ steps:
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-20b-push-cleanup requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step-20b-push-cleanup requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
       echo "=== Pushing Cleanup Changes ==="
       git add -A
       if ! git diff --cached --quiet; then

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -216,6 +216,10 @@ steps:
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-18c-push-feedback-changes requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step-18c-push-feedback-changes requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
       echo "=== Pushing Review Feedback Changes ==="
       git add -A
       if [ -n "$(git diff --cached --name-only)" ]; then

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -90,6 +90,10 @@ steps:
       echo "" && \
       echo "Current directory: $(pwd)" && \
       echo "" && \
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+        echo "ERROR: step-01-prepare-workspace requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2; \
+        exit 1; \
+      fi && \
       echo "--- Git Status ---" && \
       git status && \
       echo "" && \

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -123,6 +123,10 @@ steps:
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step-15-commit-push requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
       echo "=== Step 15: Commit and Push ===" >&2
       # FIX (#495): commit_result MUST be emitted on every exit path so step-16
       # (PR creation) can be gated on the actual push outcome. Trap installed
@@ -218,6 +222,10 @@ steps:
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-16 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step-16-create-draft-pr requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
       echo "=== Step 16: Creating Draft PR ===" >&2
 
       # FIX (#3324): Idempotency guard — detect pre-existing PRs before creating one

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -206,6 +206,10 @@ steps:
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-11b-implement-feedback requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: checkpoint-after-review-feedback requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
       echo "=== Checkpoint: Staging Review Feedback ==="
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -164,6 +164,10 @@ steps:
       # false-positive no-op failures when the worktree contains real work).
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-08c requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step-08c-implementation-no-op-guard requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
       if ! git diff --quiet || ! git diff --cached --quiet || \
          [ -n "$(git ls-files --others --exclude-standard)" ]; then
         echo "step-08 produced file changes — guard passed."
@@ -262,6 +266,10 @@ steps:
     command: |
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}" && \
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?checkpoint-after-implementation requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}" && \
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+        echo "ERROR: checkpoint-after-implementation requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2; \
+        exit 1; \
+      fi && \
       echo "=== Checkpoint: Staging Implementation ===" && \
       git add -A && \
       STAGED=$(git diff --cached --name-only) && \

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -29,6 +29,10 @@ steps:
         exit 1
       fi
       cd "$REPO_PATH"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "ERROR: step-04-setup-worktree requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
 
       echo "=== Step 4: Creating Worktree and Branch ===" >&2
       echo "" >&2

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -197,3 +197,7 @@ path = "../../tests/integration/discoveries_doc_test.rs"
 [[test]]
 name = "gherkin_investigation_doc"
 path = "../../tests/integration/gherkin_investigation_doc_test.rs"
+
+[[test]]
+name = "issue_537_git_optional_recipes"
+path = "tests/issue_537_git_optional_recipes.rs"

--- a/bins/amplihack/tests/issue_537_git_optional_recipes.rs
+++ b/bins/amplihack/tests/issue_537_git_optional_recipes.rs
@@ -1,0 +1,337 @@
+//! TDD tests for issue #537.
+//!
+//! Contract:
+//! - smart-orchestrator dry-run is usable from a non-git working directory.
+//! - smart-orchestrator dry-run still succeeds from a git working directory.
+//! - investigation-workflow is git-optional and dry-runs successfully outside git.
+//! - direct recipe git commands are either strict with a loud precondition or
+//!   optional with an explicit visible skip.
+
+use serde_yaml::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn workspace_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .ancestors()
+        .find(|path| path.join("amplifier-bundle/recipes").is_dir())
+        .map(Path::to_path_buf)
+        .expect("workspace must contain amplifier-bundle/recipes")
+}
+
+fn recipes_dir() -> PathBuf {
+    workspace_root().join("amplifier-bundle/recipes")
+}
+
+fn recipe_path(name: &str) -> PathBuf {
+    recipes_dir().join(name)
+}
+
+fn amplihack_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_amplihack"))
+}
+
+fn run_recipe_from(cwd: &Path, recipe: &Path, extra_args: &[&str]) -> Output {
+    let mut command = Command::new(amplihack_bin());
+    command
+        .current_dir(cwd)
+        .env("AMPLIHACK_HOME", workspace_root())
+        .env("AMPLIHACK_NONINTERACTIVE", "1")
+        .env_remove("CLAUDECODE")
+        .arg("recipe")
+        .arg("run")
+        .arg(recipe)
+        .args(extra_args);
+
+    command.output().expect("failed to run amplihack binary")
+}
+
+fn combined_output(output: &Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_not_raw_git_128(output: &Output) {
+    let combined = combined_output(output);
+    assert!(
+        !combined.contains("exit 128")
+            && !combined.contains("exited with 128")
+            && !combined.contains("exit status: 128")
+            && !combined.contains("fatal: not a git repository"),
+        "missing git context must not leak as raw git exit-128/fatal output.\n{combined}"
+    );
+}
+
+#[test]
+fn smart_orchestrator_dry_run_from_non_git_dir_succeeds_or_reports_structured_git_error() {
+    let non_git = tempfile::tempdir().expect("create non-git tempdir");
+
+    let output = run_recipe_from(
+        non_git.path(),
+        &recipe_path("smart-orchestrator.yaml"),
+        &[
+            "--dry-run",
+            "-c",
+            "task_description=hello",
+            "-c",
+            "repo_path=.",
+        ],
+    );
+
+    assert_not_raw_git_128(&output);
+    if output.status.success() {
+        return;
+    }
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("requires a git repo")
+            && combined.contains("git init")
+            && combined.contains("rerun from a checkout"),
+        "non-git smart-orchestrator failure must be structured and actionable, \
+         not broad top-level git validation.\n{combined}"
+    );
+}
+
+#[test]
+fn smart_orchestrator_dry_run_from_git_dir_succeeds() {
+    let git_dir = tempfile::tempdir().expect("create git tempdir");
+    let init = Command::new("git")
+        .arg("init")
+        .arg("--quiet")
+        .current_dir(git_dir.path())
+        .output()
+        .expect("run git init");
+    assert!(
+        init.status.success(),
+        "git init failed:\n{}",
+        combined_output(&init)
+    );
+
+    let output = run_recipe_from(
+        git_dir.path(),
+        &recipe_path("smart-orchestrator.yaml"),
+        &[
+            "--dry-run",
+            "-c",
+            "task_description=hello",
+            "-c",
+            "repo_path=.",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "smart-orchestrator dry-run must succeed inside a git repo.\n{}",
+        combined_output(&output)
+    );
+}
+
+#[test]
+fn investigation_workflow_dry_run_from_non_git_dir_succeeds() {
+    let non_git = tempfile::tempdir().expect("create non-git tempdir");
+
+    let output = run_recipe_from(
+        non_git.path(),
+        &recipe_path("investigation-workflow.yaml"),
+        &[
+            "--dry-run",
+            "-c",
+            "task_description=hello",
+            "-c",
+            "investigation_question=hello",
+            "-c",
+            "repo_path=.",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "investigation-workflow must be runnable from a non-git directory.\n{}",
+        combined_output(&output)
+    );
+}
+
+#[test]
+fn git_optional_entry_recipes_do_not_require_git_repo_context_validation() {
+    for recipe in ["smart-orchestrator.yaml", "investigation-workflow.yaml"] {
+        let value = load_yaml(&recipe_path(recipe));
+        let repo_validation = value
+            .get("context_validation")
+            .and_then(|validation| validation.get("repo_path"))
+            .and_then(Value::as_str);
+
+        assert_ne!(
+            repo_validation,
+            Some("git_repo"),
+            "{recipe} must not reject non-git directories at top-level validation; \
+             git requirements belong at git-dependent step boundaries"
+        );
+    }
+}
+
+#[test]
+fn direct_git_recipe_steps_are_guarded_or_visibly_skipped() {
+    let mut violations = Vec::new();
+
+    for recipe in all_recipe_files() {
+        let yaml = load_yaml(&recipe);
+        for step in steps(&yaml) {
+            let Some(command) = step.get("command").and_then(Value::as_str) else {
+                continue;
+            };
+            if !contains_git_command(command) {
+                continue;
+            }
+
+            let step_id = step
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>");
+            let guarded = command.contains("git rev-parse --is-inside-work-tree")
+                || command.contains("git -C")
+                    && command.contains("rev-parse --is-inside-work-tree");
+            let loud = command.contains("requires a git repo")
+                && command.contains("git init")
+                && command.contains("rerun from a checkout");
+            let visible_skip = command.contains("[skip] not a git repo");
+
+            if !(guarded && (loud || visible_skip)) {
+                violations.push(format!(
+                    "{} step {step_id} uses git without an explicit strict \
+                     precondition or visible optional skip",
+                    recipe.file_name().unwrap().to_string_lossy()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "issue #537 requires every direct recipe git command to be guarded:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn investigation_recipe_family_has_no_direct_git_operations() {
+    let mut offenders = Vec::new();
+    for recipe in all_recipe_files() {
+        let name = recipe.file_name().unwrap().to_string_lossy();
+        if !(name.starts_with("investigation-") || name.starts_with("qa-")) {
+            continue;
+        }
+
+        let yaml = load_yaml(&recipe);
+        for step in steps(&yaml) {
+            let Some(command) = step.get("command").and_then(Value::as_str) else {
+                continue;
+            };
+            if contains_git_command(command) {
+                let step_id = step
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("<unknown>");
+                offenders.push(format!("{name} step {step_id}"));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "investigation/Q&A recipes must run from any directory without direct git operations:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn git_required_workflow_recipes_document_loud_git_preconditions() {
+    for recipe in [
+        "default-workflow.yaml",
+        "workflow-prep.yaml",
+        "workflow-worktree.yaml",
+        "workflow-tdd.yaml",
+        "workflow-publish.yaml",
+    ] {
+        let source = fs::read_to_string(recipe_path(recipe)).expect("read recipe");
+        assert!(
+            source.contains("requires a git repo")
+                && source.contains("git init")
+                && source.contains("rerun from a checkout"),
+            "{recipe} must fail loudly before strict git-dependent work with: \
+             \"requires a git repo ... either `git init` or rerun from a checkout\""
+        );
+    }
+}
+
+#[test]
+fn operations_git_telemetry_uses_visible_non_git_skip() {
+    let source =
+        fs::read_to_string(recipe_path("smart-execute-routing.yaml")).expect("read routing recipe");
+    let routing = load_yaml(&recipe_path("smart-execute-routing.yaml"));
+    let step = step_command(&routing, "ops-file-change-check")
+        .expect("ops-file-change-check command must exist");
+
+    assert!(
+        step.contains("git rev-parse --is-inside-work-tree"),
+        "ops-file-change-check must probe git availability before git diff/ls-files"
+    );
+    assert!(
+        step.contains("[skip] not a git repo"),
+        "optional operations git telemetry must visibly skip outside git"
+    );
+    assert!(
+        !source.contains("cd \"$REPO_PATH\" 2>/dev/null || true"),
+        "optional git telemetry must not hide a failed cd with `|| true`"
+    );
+}
+
+fn all_recipe_files() -> Vec<PathBuf> {
+    let mut files = fs::read_dir(recipes_dir())
+        .expect("read recipes dir")
+        .map(|entry| entry.expect("read recipe entry").path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("yaml"))
+        .collect::<Vec<_>>();
+    files.sort();
+    files
+}
+
+fn load_yaml(path: &Path) -> Value {
+    let body = fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    serde_yaml::from_str(&body)
+        .unwrap_or_else(|err| panic!("failed to parse {} as YAML: {err}", path.display()))
+}
+
+fn steps(recipe: &Value) -> Vec<&Value> {
+    recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .map(|steps| steps.iter().collect())
+        .unwrap_or_default()
+}
+
+fn step_command<'a>(recipe: &'a Value, step_id: &str) -> Option<&'a str> {
+    steps(recipe).into_iter().find_map(|step| {
+        (step.get("id").and_then(Value::as_str) == Some(step_id))
+            .then(|| step.get("command").and_then(Value::as_str))
+            .flatten()
+    })
+}
+
+fn contains_git_command(command: &str) -> bool {
+    command.lines().any(|line| {
+        let trimmed = line.trim_start();
+        !trimmed.starts_with('#')
+            && (trimmed.starts_with("git ")
+                || trimmed.contains(" git ")
+                || trimmed.contains(" git -C ")
+                || trimmed.contains("$(git ")
+                || trimmed.contains("! git "))
+    })
+}

--- a/docs/howto/run-a-recipe.md
+++ b/docs/howto/run-a-recipe.md
@@ -126,6 +126,51 @@ Steps:
 
 ---
 
+## Run from a non-git directory
+
+Routing, Q&A, and investigation recipes can run from any existing directory.
+This is useful for scratch analysis, CI smoke checks, containers, and temporary
+workspaces where no checkout exists yet.
+
+```sh
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+
+amplihack recipe run ~/.amplihack/.claude/recipes/investigation-workflow.yaml \
+  -c task_description="Compare the available deployment approaches" \
+  -c repo_path=.
+```
+
+`smart-orchestrator` can also be dry-run outside Git to inspect routing:
+
+```sh
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+
+amplihack recipe run ~/.amplihack/.claude/recipes/smart-orchestrator.yaml \
+  -c task_description="hello" \
+  -c repo_path=. \
+  --dry-run
+```
+
+Dry-run inspects routing only; it does not execute downstream Git-required
+steps.
+
+If routing selects a development, publish, PR, worktree, or TDD workflow, the
+Git-dependent step checks for repository state before running `git`. Outside a
+checkout it fails with a clear precondition error:
+
+```text
+ERROR: step <workflow>/<step> requires a git repo at /tmp/demo; either `git init` or rerun from a checkout
+```
+
+Initialize the directory with `git init` or rerun the recipe from an existing
+checkout when you need branch, worktree, commit, diff, or pull-request behavior.
+Optional Git telemetry prints an explicit `[skip] not a git repo ...` note and
+continues.
+
+---
+
 ## Supply context variables
 
 Context variables fill template slots in the recipe. Supply them with `-c`:

--- a/docs/howto/troubleshoot-recipe-execution.md
+++ b/docs/howto/troubleshoot-recipe-execution.md
@@ -8,6 +8,7 @@ Use this guide when a recipe step fails unexpectedly — a shell step hangs, an 
 - [Agent step completes but changes nothing](#agent-step-completes-but-changes-nothing)
 - [Shell step fails with "python3 not found"](#shell-step-fails-with-python3-not-found)
 - [Workflow classification routes to the wrong type](#workflow-classification-routes-to-the-wrong-type)
+- [Workflow step requires a Git repository](#workflow-step-requires-a-git-repository)
 - [Agent step killed by step timeout](#agent-step-killed-by-step-timeout)
 - [Update completes but assets are stale](#update-completes-but-assets-are-stale)
 - [Install fails after switching to the Rust repository](#install-fails-after-switching-to-the-rust-repository)
@@ -149,6 +150,57 @@ amplihack classify "Add an agentic disk-cleanup loop. Extend src/cmd_cleanup.rs 
 amplihack classify "disk cleanup on staging servers"
 # Expected: workflow=Ops
 ```
+
+---
+
+## Workflow step requires a Git repository
+
+**Symptom:** `amplihack recipe run` starts successfully from a scratch or
+temporary directory, then a development, publish, worktree, TDD, or PR step
+fails before executing its Git command:
+
+```text
+ERROR: step <workflow>/<step> requires a git repo at /tmp/demo; either `git init` or rerun from a checkout
+```
+
+**Cause:** Recipe routing and investigation flows are Git-optional, but the
+selected step needs repository state to create a branch, compute tracked-file
+changes, create a worktree, commit, push, or open a pull request. The recipe
+checks this precondition before running `git` so failures are actionable instead
+of surfacing as a raw Git `exit 128`.
+
+**Fix:** Run the Git-dependent workflow from a checkout:
+
+```sh
+cd /home/user/src/myproject
+amplihack recipe run ~/.amplihack/.claude/recipes/default-workflow.yaml \
+  -c task_description="Fix the pagination bug" \
+  -c repo_path=.
+```
+
+Or initialize the directory when a new repository is appropriate:
+
+```sh
+git init
+amplihack recipe run ~/.amplihack/.claude/recipes/default-workflow.yaml \
+  -c task_description="Create the initial project structure" \
+  -c repo_path=.
+```
+
+If your task is analysis-only, use an investigation or Q&A recipe instead; those
+workflows do not require Git, and history-specific analysis is skipped or marked
+unavailable outside a repository:
+
+```sh
+amplihack recipe run ~/.amplihack/.claude/recipes/investigation-workflow.yaml \
+  -c task_description="Explain the error message" \
+  -c repo_path=.
+```
+
+**Note:** Optional Git telemetry is different from required Git work. When a
+telemetry-only check runs outside a repository, it prints a visible skip message
+such as `[skip] not a git repo at /tmp/demo; skipping operations file-change git
+telemetry` and continues.
 
 ---
 

--- a/docs/reference/recipe-command.md
+++ b/docs/reference/recipe-command.md
@@ -21,6 +21,7 @@ inspects, validates, and runs YAML recipe files.
   - [Supplying context](#supplying-context)
   - [Context inference](#context-inference)
   - [Context environment variables](#context-environment-variables)
+- [Git context behavior](#git-context-behavior)
 - [Recipe search path](#recipe-search-path)
 - [Recipe runner binary](#recipe-runner-binary)
 - [Exit codes](#exit-codes)
@@ -246,6 +247,13 @@ amplihack recipe run ~/.amplihack/.claude/recipes/default-workflow.yaml \
 amplihack recipe run ~/.amplihack/.claude/recipes/verification.yaml \
   -c task_description="Bump the version number" \
   --format json
+
+# Run an investigation from any directory, including a non-git temp directory
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+amplihack recipe run ~/.amplihack/.claude/recipes/investigation-workflow.yaml \
+  -c task_description="Explain the deployment options" \
+  -c repo_path=.
 ```
 
 **Example output (table, dry run):**
@@ -387,6 +395,61 @@ Recipe defaults in the `context:` block are the lowest-priority source.
 | `AMPLIHACK_CONTEXT_<KEY>` | Any context variable named `<key>` |
 | `AMPLIHACK_TASK_DESCRIPTION` | `task_description` |
 | `AMPLIHACK_REPO_PATH` | `repo_path` |
+
+---
+
+## Git context behavior
+
+`amplihack recipe run` does not require the current working directory to be a
+Git repository unless the selected recipe or step needs Git semantics. Recipes
+validate universal inputs first, such as `task_description` and whether
+`repo_path` exists, then each host-tool step checks its own prerequisites.
+This keeps routing, Q&A, and investigation recipes usable from existing scratch
+directories, containers, and temporary folders.
+
+The bundled recipes follow these Git-context rules:
+
+| Recipe or step type | Git requirement | Behavior outside a Git repository |
+|---------------------|-----------------|-----------------------------------|
+| `smart-orchestrator` routing and dry-runs | Optional | Runs classification and routing. Dry-runs stop there and do not execute downstream Git-required steps; normal runs let selected Git-only steps report their own precondition. |
+| `investigation-workflow` and Q&A workflows | Not required | Do not require Git. History-specific analysis is skipped or marked unavailable when no repository is present. |
+| Development, publish, PR, worktree, and TDD workflow steps | Required when they create branches, commits, worktrees, PRs, or inspect tracked changes | Fail before the Git operation with a structured, actionable precondition error. |
+| Telemetry and status-only Git checks | Optional | Print a visible `[skip] not a git repo ...` note and continue. |
+
+Strict Git-required steps fail with an error shaped like:
+
+```text
+ERROR: step <workflow>/<step> requires a git repo at /work/app; either `git init` or rerun from a checkout
+```
+
+That error means the recipe is valid, but the selected workflow needs repository
+state. To resolve it, either initialize the directory:
+
+```sh
+git init
+amplihack recipe run ~/.amplihack/.claude/recipes/default-workflow.yaml \
+  -c task_description="Implement the feature" \
+  -c repo_path=.
+```
+
+or rerun from an existing checkout:
+
+```sh
+cd /home/user/src/myproject
+amplihack recipe run ~/.amplihack/.claude/recipes/default-workflow.yaml \
+  -c task_description="Implement the feature" \
+  -c repo_path=.
+```
+
+Optional Git telemetry never hides failures with `|| true`. When no repository
+is present, it emits a visible skip note instead:
+
+```text
+[skip] not a git repo at /tmp/amplihack-demo; skipping operations file-change git telemetry
+```
+
+This distinction is intentional: optional observations may be skipped, but
+required host-tool work must fail before doing partial or misleading work.
 
 ---
 

--- a/tests/issue_537_non_git_recipe_run_repro.sh
+++ b/tests/issue_537_non_git_recipe_run_repro.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Reproduction for issue #537: `amplihack recipe run` currently assumes the
+# caller is inside a Git repository before routing can decide whether Git is
+# actually needed.
+#
+# Run: bash tests/issue_537_non_git_recipe_run_repro.sh
+# Expected before fix: captures a non-zero run from a non-git tempdir.
+# Expected after fix: command succeeds, proving the raw Git-context failure no
+# longer reproduces.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR_REPRO="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_REPRO"' EXIT
+
+ln -s "$REPO_ROOT/amplifier-bundle" "$TMPDIR_REPRO/amplifier-bundle"
+
+echo "=== Issue #537 non-git recipe-run reproduction ==="
+echo "repo root: $REPO_ROOT"
+echo "non-git cwd: $TMPDIR_REPRO"
+echo
+
+(
+  cd "$TMPDIR_REPRO" || exit 99
+  AMPLIHACK_HOME="$REPO_ROOT" \
+    amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+      -c task_description="hello" \
+      -c repo_path=. \
+      >"$TMPDIR_REPRO/stdout.txt" \
+      2>"$TMPDIR_REPRO/stderr.txt"
+)
+rc=$?
+
+echo "exit_code=$rc"
+echo "--- stdout ---"
+sed -n '1,160p' "$TMPDIR_REPRO/stdout.txt"
+echo "--- stderr ---"
+sed -n '1,200p' "$TMPDIR_REPRO/stderr.txt"
+
+if [ "$rc" -eq 0 ]; then
+  echo "No longer reproduces: non-git smart-orchestrator run succeeded."
+  exit 0
+fi
+
+if grep -Eiq 'not a git repository|git repo|exit(ed)? with 128|exit status: 128|fatal:' \
+  "$TMPDIR_REPRO/stdout.txt" "$TMPDIR_REPRO/stderr.txt"; then
+  echo "Reproduced issue #537: non-git cwd triggered a Git-context failure."
+  exit 0
+fi
+
+echo "Command failed, but not with the expected Git-context symptom." >&2
+exit 1


### PR DESCRIPTION
## Summary
- Removes top-level git-repo validation from smart-orchestrator and investigation-workflow so routing/investigation dry-runs work from non-git directories.
- Adds explicit fail-loud git preconditions to strict git-dependent recipe steps and visible skip messages for optional git telemetry.
- Adds issue #537 repro script, integration coverage, docs, and philosophy guidance for host-tool preconditions.

Closes #537

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test -p amplihack --test issue_537_git_optional_recipes
- cargo test -p amplihack --test default_workflow_decomposition --test smart_orchestrator_decomposition

## Note
Full TMPDIR=/tmp cargo test was attempted repeatedly. The suite reached unrelated no-python/golden stages but the shared runner exhausted /home target space or blocked behind concurrent cargo/test activity. The issue-specific and affected decomposition coverage passed.