### PR TITLE
docs(USER_PREFERENCES): add 'never foreground-sleep' MANDATORY rule

### DIFF
--- a/amplifier-bundle/context/USER_PREFERENCES.md
+++ b/amplifier-bundle/context/USER_PREFERENCES.md
@@ -6,6 +6,15 @@
 
 Work autonomously. Follow workflows without asking permission between steps. Only ask when truly blocked on critical missing information.
 
+## Background work and monitoring (MANDATORY)
+
+**NEVER foreground-sleep.** Long waits MUST run as detached background processes (tmux, `bash mode=async detach=true`, or equivalent). Foreground `sleep N` blocks the user from issuing new instructions and is not acceptable.
+
+- Use detached tmux for any orch / recipe runner / build that may take more than ~30 seconds.
+- For polling status, use SHORT non-blocking checks (≤ 30s sleep) only when actively iterating, never long blocking sleeps (> 60s).
+- Background processes that must persist beyond the session MUST use `detach: true` (or `tmux new-session -d`).
+- When delegating long work, return control to the user immediately after launching; do not block on completion.
+
 ## Core Preferences
 
 | Setting             | Value                      |


### PR DESCRIPTION
Adds 'Background work and monitoring (MANDATORY)' section to amplifier-bundle/context/USER_PREFERENCES.md.

Rule (per repeated user feedback in session):
- NEVER foreground-sleep — long waits MUST be detached (tmux, async detach=true)
- Polling uses SHORT non-blocking checks (≤ 30s)
- Detached processes that must persist beyond session use detach=true / tmux -d
- Return control to the user immediately after launching long work

Mirrors the same rule already present in the installed ~/.amplihack copy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>