### PR TITLE
feat: default copilot launch to --remote mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Unreleased changes appear at the top under `[Unreleased]`.
 
 ## [Unreleased] — Recipe Execution Hardening
 
+### Added
+
+- **Copilot `--remote` by default** — `amplihack copilot` now injects
+  `--remote` automatically, offloading compute to GitHub's cloud. Disable
+  with `AMPLIHACK_COPILOT_NO_REMOTE=1` or by passing `--no-remote` explicitly.
+
 ### Fixed
 
 - **executor.rs: shell steps hang in non-interactive environments (#277)** —

--- a/crates/amplihack-cli/src/commands/launch/command.rs
+++ b/crates/amplihack-cli/src/commands/launch/command.rs
@@ -77,6 +77,14 @@ pub(super) fn build_command_for_dir(
         cmd.arg("--allow-all");
     }
 
+    // Inject --remote for Copilot by default. Remote mode offloads compute to
+    // GitHub's cloud, which is the preferred mode for amplihack orchestration.
+    // Skip injection if the user already passed --remote, or if
+    // AMPLIHACK_COPILOT_NO_REMOTE=1.
+    if binary.name == "copilot" && should_inject_copilot_remote(extra_args) {
+        cmd.arg("--remote");
+    }
+
     cmd.args(extra_args);
     cmd
 }
@@ -95,6 +103,18 @@ pub(crate) fn should_inject_copilot_allow_all(extra_args: &[String]) -> bool {
             || a == "--allow-all-urls"
     });
     !already_present
+}
+
+/// Decide whether `amplihack` should inject `--remote` into a Copilot
+/// invocation. Returns false if the user already passed `--remote` or
+/// `--no-remote`, or if `AMPLIHACK_COPILOT_NO_REMOTE=1` is set.
+pub(crate) fn should_inject_copilot_remote(extra_args: &[String]) -> bool {
+    if std::env::var("AMPLIHACK_COPILOT_NO_REMOTE").as_deref() == Ok("1") {
+        return false;
+    }
+    !extra_args
+        .iter()
+        .any(|a| a == "--remote" || a == "--no-remote")
 }
 
 fn inject_uvx_plugin_args(

--- a/crates/amplihack-cli/src/commands/launch/tests_command.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_command.rs
@@ -420,3 +420,122 @@ fn claude_does_not_get_allow_all_injected() {
         );
     });
 }
+
+#[test]
+fn copilot_gets_remote_injected_by_default() {
+    with_uvx_detection_disabled(|| {
+        unsafe {
+            std::env::remove_var("AMPLIHACK_COPILOT_NO_REMOTE");
+        }
+        let binary = BinaryInfo {
+            name: "copilot".to_string(),
+            path: PathBuf::from("/usr/bin/copilot"),
+            version: None,
+        };
+        let cmd = build_command(&binary, false, false, false, &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            args.iter().any(|a| a == "--remote"),
+            "copilot launch must include --remote by default; got {args:?}"
+        );
+    });
+}
+
+#[test]
+fn copilot_skips_remote_when_user_already_passed_it() {
+    with_uvx_detection_disabled(|| {
+        unsafe {
+            std::env::remove_var("AMPLIHACK_COPILOT_NO_REMOTE");
+        }
+        let binary = BinaryInfo {
+            name: "copilot".to_string(),
+            path: PathBuf::from("/usr/bin/copilot"),
+            version: None,
+        };
+        let extra = vec!["--remote".to_string()];
+        let cmd = build_command(&binary, false, false, false, &extra);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        let remote_count = args.iter().filter(|a| a.as_str() == "--remote").count();
+        assert_eq!(
+            remote_count, 1,
+            "should not duplicate --remote when user already supplied it; got {args:?}"
+        );
+    });
+}
+
+#[test]
+fn copilot_skips_remote_when_env_opt_out() {
+    with_uvx_detection_disabled(|| {
+        unsafe {
+            std::env::set_var("AMPLIHACK_COPILOT_NO_REMOTE", "1");
+        }
+        let binary = BinaryInfo {
+            name: "copilot".to_string(),
+            path: PathBuf::from("/usr/bin/copilot"),
+            version: None,
+        };
+        let cmd = build_command(&binary, false, false, false, &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        unsafe {
+            std::env::remove_var("AMPLIHACK_COPILOT_NO_REMOTE");
+        }
+        assert!(
+            !args.iter().any(|a| a == "--remote"),
+            "opt-out must suppress --remote; got {args:?}"
+        );
+    });
+}
+
+#[test]
+fn claude_does_not_get_remote_injected() {
+    with_uvx_detection_disabled(|| {
+        let binary = BinaryInfo {
+            name: "claude".to_string(),
+            path: PathBuf::from("/usr/bin/claude"),
+            version: None,
+        };
+        let cmd = build_command(&binary, false, false, false, &[]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            !args.iter().any(|a| a == "--remote"),
+            "non-copilot tools must not get --remote; got {args:?}"
+        );
+    });
+}
+
+#[test]
+fn copilot_skips_remote_when_user_passes_no_remote() {
+    with_uvx_detection_disabled(|| {
+        unsafe {
+            std::env::remove_var("AMPLIHACK_COPILOT_NO_REMOTE");
+        }
+        let binary = BinaryInfo {
+            name: "copilot".to_string(),
+            path: PathBuf::from("/usr/bin/copilot"),
+            version: None,
+        };
+        // User explicitly opted out via --no-remote; we must NOT inject --remote.
+        let extra = vec!["--no-remote".to_string()];
+        let cmd = build_command(&binary, false, false, false, &extra);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            !args.iter().any(|a| a == "--remote"),
+            "must not inject --remote when user passed --no-remote; got {args:?}"
+        );
+    });
+}

--- a/crates/amplihack-launcher/src/flag_matrix.rs
+++ b/crates/amplihack-launcher/src/flag_matrix.rs
@@ -55,6 +55,8 @@ pub struct FlagSet {
     pub supports_print: bool,
     /// Supports `--allow-all-tools` (Copilot-specific).
     pub supports_allow_all_tools: bool,
+    /// Supports `--remote` (Copilot-specific — offload to GitHub cloud).
+    pub supports_remote: bool,
     /// The env var name set to identify the agent binary in nested sessions.
     pub agent_binary_env: &'static str,
 }
@@ -75,6 +77,7 @@ pub fn flags_for(binary: AgentBinary) -> FlagSet {
             supports_resume: true,
             supports_print: true,
             supports_allow_all_tools: false,
+            supports_remote: false,
             agent_binary_env: "AMPLIHACK_AGENT_BINARY",
         },
         AgentBinary::Copilot => FlagSet {
@@ -86,6 +89,7 @@ pub fn flags_for(binary: AgentBinary) -> FlagSet {
             supports_resume: false,
             supports_print: false,
             supports_allow_all_tools: true,
+            supports_remote: true,
             agent_binary_env: "AMPLIHACK_AGENT_BINARY",
         },
         AgentBinary::Codex => FlagSet {
@@ -97,6 +101,7 @@ pub fn flags_for(binary: AgentBinary) -> FlagSet {
             supports_resume: false,
             supports_print: false,
             supports_allow_all_tools: false,
+            supports_remote: false,
             agent_binary_env: "AMPLIHACK_AGENT_BINARY",
         },
     }
@@ -152,6 +157,24 @@ mod tests {
     }
 
     #[test]
+    fn copilot_supports_remote() {
+        let flags = flags_for(AgentBinary::Copilot);
+        assert!(flags.supports_remote);
+    }
+
+    #[test]
+    fn claude_does_not_support_remote() {
+        let flags = flags_for(AgentBinary::Claude);
+        assert!(!flags.supports_remote);
+    }
+
+    #[test]
+    fn codex_does_not_support_remote() {
+        let flags = flags_for(AgentBinary::Codex);
+        assert!(!flags.supports_remote);
+    }
+
+    #[test]
     fn copilot_does_not_support_append_prompt() {
         let flags = flags_for(AgentBinary::Copilot);
         assert!(!flags.supports_append_prompt);
@@ -173,6 +196,7 @@ mod tests {
         assert!(!flags.supports_resume);
         assert!(!flags.supports_print);
         assert!(!flags.supports_allow_all_tools);
+        assert!(!flags.supports_remote);
     }
 
     // -----------------------------------------------------------------------

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -447,6 +447,27 @@ command line.
 
 ---
 
+### AMPLIHACK_COPILOT_NO_REMOTE
+
+**Type:** flag
+**Values:** `1` suppresses `--remote` injection; absence or any other value keeps the default
+**Used by:** `should_inject_copilot_remote()` in `commands/launch/command.rs`
+
+When `amplihack copilot` launches the Copilot CLI, it injects `--remote` by
+default to offload compute to GitHub's cloud. Set this variable to `1` to
+suppress the injection and run Copilot locally.
+
+```sh
+# Disable remote mode
+AMPLIHACK_COPILOT_NO_REMOTE=1 amplihack copilot
+# Copilot starts without --remote
+```
+
+Users can also pass `--no-remote` directly as an extra arg; the launcher
+detects this and skips injection automatically.
+
+---
+
 ### AMPLIHACK_ENABLE_BLARIFY
 
 **Type:** flag

--- a/docs/reference/flag-matrix.md
+++ b/docs/reference/flag-matrix.md
@@ -62,6 +62,7 @@ Current behavior, derived from `command.rs`:
 | `--dangerously-skip-permissions` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
 | `--model` (auto-inject) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
 | `--allow-all` (auto-inject) | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| `--remote` (auto-inject) | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | `--resume` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `--continue` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `--plugin-dir` (UVX only) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
@@ -74,6 +75,7 @@ Current behavior, derived from `command.rs`:
 |---|---|
 | `AMPLIHACK_DEFAULT_MODEL` | Override the default model (default: `opus[1m]`) |
 | `AMPLIHACK_COPILOT_NO_ALLOW_ALL` | Set to `1` to suppress `--allow-all` injection for Copilot |
+| `AMPLIHACK_COPILOT_NO_REMOTE` | Set to `1` to suppress `--remote` injection for Copilot |
 
 ## Flag injection rules
 
@@ -87,6 +89,10 @@ Current behavior, derived from `command.rs`:
 
 3. **`--allow-all`**: Injected only for `copilot` unless suppressed by env
    var or the user already provided any `--allow-all*` flag.
+
+4. **`--remote`**: Injected only for `copilot` unless suppressed by
+   `AMPLIHACK_COPILOT_NO_REMOTE=1` or the user already passed `--remote`
+   or `--no-remote`.
 
 4. **UVX plugin args**: `--plugin-dir` and `--add-dir` are injected only
    for `claude` when running in a UVX deployment.
@@ -146,8 +152,9 @@ its full flag capabilities.
 |---|---|---|
 | Claude default | `claude`, no extra args | `--model opus[1m]` |
 | Claude skip-perms | `claude`, `--skip-permissions` | `--dangerously-skip-permissions --model opus[1m]` |
-| Copilot default | `copilot`, no extra args | `--allow-all` |
-| Copilot suppressed | `copilot`, `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` | (no flags) |
+| Copilot default | `copilot`, no extra args | `--allow-all --remote` |
+| Copilot suppressed | `copilot`, `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` + `AMPLIHACK_COPILOT_NO_REMOTE=1` | (no flags) |
+| Copilot no-remote | `copilot`, `--no-remote` | `--allow-all` (no `--remote` injected) |
 | Codex default | `codex`, no extra args | (no flags) |
 | User model override | `claude`, `--model sonnet` | `--model sonnet` (no duplicate) |
 


### PR DESCRIPTION
## Summary

Injects `--remote` flag for Copilot by default when launching via `amplihack copilot`. Remote mode offloads compute to GitHub's cloud, which is the preferred mode for amplihack orchestration.

## Disable options

- **Environment variable:** `AMPLIHACK_COPILOT_NO_REMOTE=1`
- **CLI flag:** pass `--no-remote` explicitly
- If `--remote` is already in extra args, injection is skipped (no duplication)

## Changes

### `crates/amplihack-cli/src/commands/launch/command.rs`
- Added `should_inject_copilot_remote()` function (mirrors `should_inject_copilot_allow_all()`)
- Injects `--remote` in `build_command_for_dir()` for copilot binary
- Handles `--no-remote` to prevent conflicting flags

### `crates/amplihack-launcher/src/flag_matrix.rs`
- Added `supports_remote: bool` to `FlagSet` struct
- Set `true` for Copilot, `false` for Claude/Codex

### `crates/amplihack-cli/src/commands/launch/tests_command.rs`
- 5 new tests: default injection, no duplication, env opt-out, --no-remote handling, non-copilot exclusion

### Documentation
- `docs/reference/flag-matrix.md` — added --remote row, env var, injection rule, test cases
- `docs/reference/environment-variables.md` — added `AMPLIHACK_COPILOT_NO_REMOTE` section
- `CHANGELOG.md` — added feature entry under [Unreleased]

## Review notes

- Pattern follows existing `--allow-all` injection exactly
- Security review: trust boundary change acknowledged — code executes on GitHub cloud by default; opt-out mechanisms provided
- All 22 launch command tests + 23 flag matrix tests pass