### PR TITLE
feat(cli,recipes): enforce and document no-timeout policy for default-workflow

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -24,6 +24,14 @@ tags: ["development", "feature", "bugfix", "refactoring", "standard", "full-work
 #
 # Context flows automatically between sub-recipes via recipe-runner's
 # `_execute_sub_recipe()` context-merging.
+#
+# NO-TIMEOUT POLICY: Neither this recipe nor any of its nine sub-recipes
+# declare a per-step `timeout:` YAML field. Agent steps run to natural
+# completion; the only shell `timeout` calls that appear are inside bash
+# step scripts guarding external network commands (gh, curl, git remote
+# operations) and are therefore not mid-thought abort gates.
+# This policy is enforced by CI (see crates/amplihack-cli/tests/).
+# Invoke with: amplihack recipe run default-workflow --step-timeout 0
 
 recursion:
   max_depth: 6

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -30,8 +30,10 @@ tags: ["development", "feature", "bugfix", "refactoring", "standard", "full-work
 # completion; the only shell `timeout` calls that appear are inside bash
 # step scripts guarding external network commands (gh, curl, git remote
 # operations) and are therefore not mid-thought abort gates.
-# This policy is enforced by CI (see crates/amplihack-cli/tests/).
-# Invoke with: amplihack recipe run default-workflow --step-timeout 0
+# This policy is enforced by CI (see crates/amplihack-cli/tests/). The
+# `--step-timeout 0` flag is optional runtime configuration for callers that
+# want to clear the runner's ambient timeout hint; it is not the policy
+# mechanism.
 
 recursion:
   max_depth: 6

--- a/crates/amplihack-cli/src/cli_subcommands.rs
+++ b/crates/amplihack-cli/src/cli_subcommands.rs
@@ -383,7 +383,11 @@ pub enum RecipeCommands {
         /// Working directory for execution
         #[arg(short = 'w', long = "working-dir")]
         working_dir: Option<String>,
-        /// Override step timeout in seconds (0 = disable all step timeouts)
+        /// Per-step timeout hint in seconds propagated as AMPLIHACK_STEP_TIMEOUT
+        /// to the recipe runner subprocess. 0 signals "no timeout" to any
+        /// subprocess that honours the env var. Note: recipe-runner-rs enforces
+        /// only per-step YAML `timeout:` fields; default-workflow and all its
+        /// sub-recipes intentionally have none, so agent steps never time out.
         #[arg(long = "step-timeout")]
         step_timeout: Option<u64>,
     },

--- a/crates/amplihack-cli/tests/issue_439_no_per_step_timeout.rs
+++ b/crates/amplihack-cli/tests/issue_439_no_per_step_timeout.rs
@@ -303,20 +303,15 @@ fn default_workflow_chain_has_no_yaml_timeout_fields() {
                         "{name}.yaml: step `{id}` has YAML `{field}:` at step root"
                     ));
                 }
-                if step
-                    .get("agent")
-                    .and_then(|a| a.get(field))
-                    .is_some()
-                {
+                if step.get("agent").and_then(|a| a.get(field)).is_some() {
                     violations.push(format!(
                         "{name}.yaml: step `{id}` has YAML `agent.{field}:`"
                     ));
                 }
                 if let Some(bash) = step.get("bash") {
                     if bash.get(field).is_some() {
-                        violations.push(format!(
-                            "{name}.yaml: step `{id}` has YAML `bash.{field}:`"
-                        ));
+                        violations
+                            .push(format!("{name}.yaml: step `{id}` has YAML `bash.{field}:`"));
                     }
                 }
             }

--- a/crates/amplihack-cli/tests/issue_439_no_per_step_timeout.rs
+++ b/crates/amplihack-cli/tests/issue_439_no_per_step_timeout.rs
@@ -251,3 +251,85 @@ fn quality_loop_keeps_recipe_level_default_step_timeout() {
         path.display()
     );
 }
+
+/// (6) The full default-workflow chain (top-level recipe + all 9 sub-recipes)
+/// must have zero YAML `timeout:` fields at any level (step root, `agent.*`,
+/// or `bash.*`).  Agent steps intentionally run to natural completion; the
+/// only `timeout` appearances allowed are shell-command uses *inside* bash
+/// script text (e.g. `timeout 60 gh pr list …`), which this test does not
+/// inspect.
+///
+/// This enforces the NO-TIMEOUT POLICY documented at the top of
+/// `amplifier-bundle/recipes/default-workflow.yaml`.
+#[test]
+fn default_workflow_chain_has_no_yaml_timeout_fields() {
+    const CHAIN: &[&str] = &[
+        "default-workflow",
+        "workflow-prep",
+        "workflow-worktree",
+        "workflow-design",
+        "workflow-tdd",
+        "workflow-refactor-review",
+        "workflow-precommit-test",
+        "workflow-publish",
+        "workflow-pr-review",
+        "workflow-finalize",
+    ];
+
+    let dir = recipes_dir();
+    let mut violations: Vec<String> = Vec::new();
+
+    for name in CHAIN {
+        let path = dir.join(format!("{name}.yaml"));
+        if !path.exists() {
+            // Sub-recipe not present in this checkout — skip rather than fail
+            // so the test can run in a partial checkout environment.
+            continue;
+        }
+        let recipe = load_yaml(&path);
+        let Some(steps) = recipe.get("steps").and_then(Value::as_sequence) else {
+            continue;
+        };
+        for (idx, step) in steps.iter().enumerate() {
+            let id = step
+                .get("id")
+                .and_then(Value::as_str)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| format!("<step #{idx}>"));
+
+            for field in ["timeout", "timeout_seconds"] {
+                if step.get(field).is_some() {
+                    violations.push(format!(
+                        "{name}.yaml: step `{id}` has YAML `{field}:` at step root"
+                    ));
+                }
+                if step
+                    .get("agent")
+                    .and_then(|a| a.get(field))
+                    .is_some()
+                {
+                    violations.push(format!(
+                        "{name}.yaml: step `{id}` has YAML `agent.{field}:`"
+                    ));
+                }
+                if let Some(bash) = step.get("bash") {
+                    if bash.get(field).is_some() {
+                        violations.push(format!(
+                            "{name}.yaml: step `{id}` has YAML `bash.{field}:`"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "default-workflow NO-TIMEOUT POLICY violation — no YAML timeout fields \
+         permitted in the default-workflow recipe chain:\n  {}\n\n\
+         Agent steps must run to natural completion. If you need to guard a \
+         network bash command, use the shell `timeout` command inside the \
+         script text, not a YAML `timeout:` field.",
+        violations.join("\n  ")
+    );
+}


### PR DESCRIPTION
## Summary

Investigation of `amplihack recipe run --step-timeout 0` revealed three gaps:

### Root-cause findings

1. **Broken promise in CLI help**: `--step-timeout <N>` sets `AMPLIHACK_STEP_TIMEOUT=N` as an env var for the recipe-runner-rs subprocess, but **recipe-runner-rs does not read that env var** (confirmed via source inspection of `~/.cargo/git/checkouts/amplihack-recipe-runner-*/` and binary strings). The `0 = disable all step timeouts` claim in the help text was therefore inaccurate.

2. **Default-workflow chain already has no YAML timeout fields**: `default-workflow.yaml` and all nine sub-recipes (`workflow-prep`, `workflow-worktree`, `workflow-design`, `workflow-tdd`, `workflow-refactor-review`, `workflow-precommit-test`, `workflow-publish`, `workflow-pr-review`, `workflow-finalize`) have **zero YAML `timeout:` fields**. Agent steps run to natural completion; shell `timeout` commands inside bash script text guard only external network calls and are not mid-thought abort gates.

3. **No dedicated enforcement test**: The existing issue_439 tests cover all recipes generically (no agent-step timeouts, network-only bash timeouts ≥1800s) but no test specifically locked the entire default-workflow chain to a zero-YAML-timeout invariant.

### Changes

| File | Change |
|------|--------|
| `crates/amplihack-cli/src/cli_subcommands.rs` | Fix `--step-timeout` help text to accurately describe env-var propagation and actual no-timeout guarantee |
| `amplifier-bundle/recipes/default-workflow.yaml` | Add `NO-TIMEOUT POLICY` comment block for discoverability |
| `crates/amplihack-cli/tests/issue_439_no_per_step_timeout.rs` | Add test #6: `default_workflow_chain_has_no_yaml_timeout_fields` |

### New test

```
test default_workflow_chain_has_no_yaml_timeout_fields ... ok
```

Walks all 10 YAML files in the default-workflow recipe chain and asserts zero YAML `timeout:`/`timeout_seconds:` fields at step root, `agent.*`, and `bash.*` levels. All 6 tests in `issue_439_no_per_step_timeout` pass.

### Not attempted

- `amplihack recipe run default-workflow --step-timeout 0` was **not** invoked. The flag sets an env var that `recipe-runner-rs` ignores; running the full 23-step workflow in this repo would create branches, issues, and PRs as side effects. Fixing `AMPLIHACK_STEP_TIMEOUT` consumption in `recipe-runner-rs` (a separate repo) is out of scope.
- No RabbitHole/eatme/drinkme files were touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>