### PR TITLE
fix(install): stage skills to ~/.copilot/ during install

### DIFF
--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -429,5 +429,17 @@ fn local_install(
     version_stamp::write_installed_version(crate::VERSION)
         .context("writing installed-version stamp")?;
 
+    // Stage assets to ~/.copilot/skills/ so Copilot CLI picks them up
+    // without requiring a separate `amplihack copilot` launch. Best-effort
+    // and intentionally AFTER the version stamp: a failure here must not
+    // block the install or leave the version stamp unwritten.
+    match crate::copilot_setup::ensure_copilot_home_staged() {
+        Ok(()) => println!("  ✅ Copilot home staged (~/.copilot/)"),
+        Err(err) => {
+            tracing::warn!(%err, "failed to stage copilot home during install");
+            eprintln!("  ⚠️  Copilot home staging skipped: {err}");
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Problem

`amplihack install` stages skills to `~/.amplihack/.claude/skills/` but never calls `ensure_copilot_home_staged()`, leaving `~/.copilot/skills/` stale. The copilot staging only runs during `amplihack copilot` launch (bootstrap), so users who run:

```
amplihack update && amplihack install
```

...and then start Copilot CLI directly get a stale skill set — notably missing `dev-orchestrator` and 30+ other skills that were added since the last `amplihack copilot` launch.

## Root Cause

`ensure_copilot_home_staged()` is only called in `bootstrap.rs` when `tool == "copilot"`. The `run_install()` function in `commands/install/mod.rs` never calls it.

## Fix

Add a best-effort `ensure_copilot_home_staged()` call at the end of `run_install()`. Failure is logged via `tracing::warn` and printed as a warning, but does not block the install.

## Testing

- `cargo test -p amplihack-cli -- install` — 2 install integration tests pass
- `cargo build -p amplihack-cli` — clean build
- Manual verification: after `amplihack install`, `~/.copilot/skills/dev-orchestrator/` now exists

## Impact

- **Before**: 89 skills in `~/.copilot/skills/` vs 120 in `~/.amplihack/.claude/skills/` (31 missing)
- **After**: Both directories are in sync after install
