### PR TITLE
fix(recipe): use PR_URL in step-22b-final-status instead of current branch (#597)

### DIFF
--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -282,13 +282,19 @@ steps:
       cd "${REPO_PATH:?step-22b-final-status requires repo_path; ensure parent recipe propagated repo_path context}"
       echo "=== WORKFLOW COMPLETE ==="
       echo ""
-      echo "PR Status:"
-      gh pr view --json state,mergeable,reviews,statusCheckRollup
+      # FIX (#597): Use $PR_URL to identify the PR instead of relying on the
+      # current branch (which is "main" in the parent repo, not the feature branch).
+      PR_URL="$PR_URL"
+      if [ -z "$PR_URL" ]; then
+        echo "WARNING: PR_URL is empty; skipping PR status check" >&2
+      else
+        echo "PR Status:"
+        gh pr view "$PR_URL" --json state,mergeable,reviews,statusCheckRollup
+      fi
       echo ""
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
       TASK_DESC="$TASK_DESCRIPTION"
       ISSUE_NUMBER="$ISSUE_NUMBER"
-      PR_URL="$PR_URL"
       printf '=== Task: %s ===\n' "$TASK_DESC"
       printf '=== Issue: #%s ===\n' "$ISSUE_NUMBER"
       printf '=== PR: %s ===\n' "$PR_URL"


### PR DESCRIPTION
## Summary
Fixes #597: step-22b-final-status fails with "no pull requests found for branch main" when the PR targets the default branch.

## Root Cause
`step-22b-final-status` runs `gh pr view --json ...` from `$REPO_PATH` (the parent repo root), where the checked-out branch is `main` (the default branch). Since there is no PR for `main`, `gh pr view` fails.

## Fix
Pass `$PR_URL` (already available in context from step-16-create-draft-pr) to `gh pr view "$PR_URL" --json ...` so it looks up the correct PR regardless of which branch is checked out. Added a guard for empty `$PR_URL` to degrade gracefully.

step-22-ensure-mergeable was also checked — it is an agent step that receives `{{pr_url}}` in its prompt template, so it is not affected.

## Testing
- All 1302 cargo tests pass (1 pre-existing flaky test unrelated to this change)
- All 3 recipe shell tests pass
- Pre-commit hooks pass

Closes #597