### PR TITLE
fix(workflow-tdd): remove goal_already_met guard from TDD steps (#611)

### DIFF
--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -11,6 +11,20 @@ tags: ["development", "tdd", "implementation"]
 # workflow via recipe-runner's automatic context-merging in
 # `_execute_sub_recipe()`; outputs declared by these steps propagate back to
 # the parent and are visible to subsequent phase recipes.
+#
+# FIX #611: TDD steps (07/08/08c/08b) do NOT check goal_already_met.
+# The pre-flight probe (step-06d in workflow-design) sets goal_already_met
+# when the linked GitHub issue is closed by a merged PR. However, a closed
+# issue does not always mean the current task is complete — the design may
+# say "no test changes needed" for a refactoring that still requires
+# implementation. Skipping the entire TDD phase based on that signal caused
+# refactoring tasks to produce no code changes.
+#
+# Step-08c already contains an independent "goal already met" detection
+# (lines ~203-246) that checks the GitHub issue state and exits gracefully
+# if the implementation truly produced zero changes for a closed issue.
+# Downstream phases (publish, finalize) still honour goal_already_met to
+# avoid duplicate PRs.
 
 recursion:
   max_depth: 6
@@ -24,7 +38,7 @@ steps:
   - id: "step-07-write-tests"
     agent: "amplihack:tester"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 7: TDD - Write Tests First
 
@@ -55,7 +69,7 @@ steps:
   - id: "step-08-implement"
     agent: "amplihack:builder"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8: Implement the Solution
 
@@ -105,7 +119,7 @@ steps:
 
   - id: "step-08c-implementation-no-op-guard"
     type: "bash"
-    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     # Hard-fail early (before checkpoint, refactor, review) if step-08 declared
     # success but reported zero file edits. This catches prompt-misalignment
     # (issue #251 / amplihack-rs #251) closer to the root cause than the
@@ -259,7 +273,7 @@ steps:
   - id: "step-08b-integration"
     agent: "amplihack:integration"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback' and goal_already_met != 'true'"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
     prompt: |
       # Step 8b: External Service Integration
 


### PR DESCRIPTION
## Problem

When the architecture step outputs "No test changes needed" (a refactoring where existing tests still pass), the `goal_already_met` context variable is set to `'true'` by the step-06d pre-flight probe, causing **all** TDD/implementation steps (07, 08, 08c, 08b) to be skipped via their condition guard:

```yaml
condition: "... and goal_already_met != 'true'"
```

This means ANY refactoring task where existing tests don't need modification produces no code changes — the workflow writes docs but never creates/modifies code.

## Fix

Remove `goal_already_met != 'true'` from the conditions of steps 07, 08, 08c, and 08b in `workflow-tdd.yaml`. The TDD/implementation phase now **always runs** (unless resuming from a checkpoint).

### Why this is safe

- **Step-08c already handles the genuine case**: its internal bash script (lines ~203–246) independently detects when the linked GitHub issue is closed by a merged PR and exits gracefully instead of failing on zero file changes.
- **Downstream phases still honour `goal_already_met`**: workflow-publish, workflow-refactor-review, workflow-precommit-test, and workflow-finalize retain their `goal_already_met != 'true'` guards to avoid duplicate PRs and redundant reviews.
- **For a real "goal already met" scenario**: step-08 runs but produces no changes → step-08c detects closed issue + zero changes → exits 0 → checkpoint stages nothing → downstream skips correctly.

## Testing

- All 13 `default_workflow_decomposition` tests pass
- All 74 recipe-related unit tests pass
- YAML validates cleanly (`recipe-runner-rs --validate-only`)

Fixes #611