### PR TITLE
fix(workflow-tdd): replace brittle step-08c bash guard with agentic verifier (#615)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -81,12 +81,14 @@ context:
   #
   # `worktree_setup` mirrors the workflow-worktree (step-04) output object
   # so the recipe-runner threads it across nested recipe boundaries
-  # (smart-execute-routing -> default-workflow -> workflow-tdd, where step-08c
-  # reads ${WORKTREE_SETUP_WORKTREE_PATH}).
+  # (smart-execute-routing -> default-workflow -> workflow-tdd, where the
+  # step-08c work-verifier reads ${WORKTREE_SETUP_WORKTREE_PATH}).
   #
   # `allow_no_op` opts orchestration / docs-only / audit / meta tasks out of
-  # the step-08c hollow-success guard. Defaults to false; smart-classify-route
-  # flips it to true when classification permits no working-tree edits.
+  # the step-08c work-verifier (issue #615 — replaces the legacy bash
+  # hollow-success guard with an agentic verifier + bash enforcer pair).
+  # Defaults to false; smart-classify-route flips it to true when
+  # classification permits no working-tree edits.
   worktree_setup: ""
   allow_no_op: false
   # Skip pre-agent project validation (npm test, build) — default true to avoid blocking on large codebases (see #453)

--- a/amplifier-bundle/recipes/smart-classify-route.yaml
+++ b/amplifier-bundle/recipes/smart-classify-route.yaml
@@ -207,14 +207,18 @@ steps:
     output: "force_single_workstream"
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Issue #425: emit `allow_no_op` so step-08c (workflow-tdd) skips its
-  # hollow-success guard for orchestration / docs-only / audit / meta tasks.
+  # Issue #425: emit `allow_no_op` so the step-08c work-verifier (workflow-tdd)
+  # treats orchestration / docs-only / audit / meta tasks as fast-path
+  # WORK_VERIFIED. Issue #615 replaced the legacy six-escape-hatch bash
+  # hollow-success guard with an agentic verifier; ALLOW_NO_OP is still
+  # honoured by the bash enforcer that follows the verifier so callers that
+  # legitimately produce no working-tree edits never get blocked.
   #
   # Allowlist (case-insensitive substring match against task_description):
   #   audit, docs-only, orchestration, meta
-  # Default: false. Step-08c uses STRICT equality with the literal "true",
-  # so coerced values (1, yes, on, True) cannot accidentally bypass the
-  # guard for code-producing classifications.
+  # Default: false. The step-08c enforcer uses STRICT equality with the
+  # literal "true", so coerced values (1, yes, on, True) cannot accidentally
+  # bypass the guard for code-producing classifications.
   # ─────────────────────────────────────────────────────────────────────────
   - id: "materialize-allow-no-op"
     type: "bash"

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -20,11 +20,31 @@ tags: ["development", "tdd", "implementation"]
 # implementation. Skipping the entire TDD phase based on that signal caused
 # refactoring tasks to produce no code changes.
 #
-# Step-08c already contains an independent "goal already met" detection
-# (lines ~203-246) that checks the GitHub issue state and exits gracefully
-# if the implementation truly produced zero changes for a closed issue.
-# Downstream phases (publish, finalize) still honour goal_already_met to
-# avoid duplicate PRs.
+# FIX #615: step-08c is now an AGENTIC two-step verifier, not the legacy
+# six-escape-hatch bash guard. The bash guard kept producing false positives
+# because the truth space is irregular: work can land in worktrees, sibling
+# branches, in-step merged PRs, already-closed issues, or remote-only via
+# `gh pr merge`. Every false positive added another special case until the
+# guard collapsed under its own complexity.
+#
+# Replacement (issue #615):
+#   * step-08c-work-verifier   — type: agent. Inspects real artifacts (git
+#     log, gh pr list, gh issue view, working tree) against the original
+#     task description and emits a JSON verdict on its final stdout line:
+#       { "verdict": "WORK_VERIFIED" | "HOLLOW_SUCCESS" |
+#                    "INSUFFICIENT_EVIDENCE",
+#         "evidence": [...], "rationale": "..." }
+#   * step-08c-enforce-verdict — type: bash. Honours the legacy fast-path
+#     opt-outs (orchestration sentinel, ALLOW_NO_OP) for parity with prior
+#     callers, then maps the verdict to exit code:
+#       WORK_VERIFIED         -> exit 0
+#       INSUFFICIENT_EVIDENCE -> loud warning, exit 0
+#       HOLLOW_SUCCESS        -> print verdict + exit 1
+#
+# The recipe-level `goal_already_met` signal is still consumed by downstream
+# phases (publish, finalize) to avoid duplicate PRs. The agentic verifier
+# subsumes the previous in-step #360 closed-issue probe by inspecting the
+# linked issue itself when judging whether work landed.
 
 recursion:
   max_depth: 6
@@ -117,157 +137,177 @@ steps:
       - Any deviations from design (with justification).
     output: "implementation"
 
-  - id: "step-08c-implementation-no-op-guard"
+  # ==========================================================================
+  # STEP 8c: AGENTIC WORK-VERIFIER (replaces the legacy bash hollow-success
+  # guard — see issue #615 for the architectural rationale).
+  #
+  # Two-step pair:
+  #   step-08c-work-verifier   — agent emits a JSON verdict on its last line
+  #   step-08c-enforce-verdict — bash maps the verdict onto exit code
+  # ==========================================================================
+  - id: "step-08c-work-verifier"
+    agent: "amplihack:analyzer"
+    working_dir: "{{worktree_setup.worktree_path}}"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    prompt: |
+      # Step 8c: Work Verifier (agentic)
+
+      You are the WORK VERIFIER. step-08-implement reported `STATUS: COMPLETE`.
+      Decide whether that claim is supported by **concrete artifacts** and emit
+      a JSON verdict on the very last line of your output. This step replaces
+      the legacy six-escape-hatch bash guard — see
+      https://github.com/rysweet/amplihack-rs/issues/615.
+
+      ## Inputs
+      **Original task (authoritative — judge intent against this):**
+      {{task_description}}
+      **Linked issue:** #{{issue_number}}
+      **Implement-step output (look for `Files modified:`, `Diff summary:`,
+      `No-op justification:`, and the orchestration sentinel
+      `No files modified — orchestration task`):**
+      {{implementation}}
+      **`allow_no_op` opt-out (orchestration / docs-only / audit / meta):**
+      {{allow_no_op}}
+
+      ## Investigation (use shell tools; ALL evidence must be real)
+      Be LIBERAL about WHERE work landed; STRICT about WHETHER it landed.
+      Skip checks only when irrelevant; mention which you skipped and why.
+
+      1. **Working tree** — `git status --porcelain` and
+         `git diff --stat HEAD`. Uncommitted edits and untracked files count.
+      2. **Local commits since branch point** —
+         `git log --oneline origin/main..HEAD` (fall back to `origin/HEAD`).
+         Empty commits and no-op edits do NOT count.
+      3. **Already-merged-during-implement** — the agent may have committed,
+         pushed, opened a PR, and auto-merged into `origin/main` all within
+         step-08; in that case `git merge-base HEAD origin/main` equals HEAD.
+         Detect with `git fetch --quiet origin main || true`,
+         `git log --oneline --since='6 hours ago' origin/main -- .`, and
+         `gh pr list --search 'is:merged author:@me' --limit 20 --json number,title,mergedAt,headRefName`
+         (filter to PRs merged within the recipe run window).
+      4. **Sibling branches / worktrees** — `git branch -a --contains HEAD`
+         and `git worktree list`.
+      5. **Linked GitHub issue** —
+         `gh issue view {{issue_number}} --json state,closedByPullRequestsReferences`
+         (skip if `{{issue_number}}` is empty). If the issue is `CLOSED` by a
+         merged PR whose diff matches the task, verdict = `WORK_VERIFIED`
+         (this is the issue #360 case the legacy guard handled).
+      6. **Recent PRs** —
+         `gh pr list --state all --search 'sort:updated-desc' --limit 20 --json number,title,state,mergedAt,headRefName,url`
+         and look for PRs whose title/branch matches this task.
+      7. **Intent match** — for every artifact, decide whether it actually
+         relates to the task description. Empty files, comment-only changes,
+         or unrelated edits do NOT count.
+
+      ## Fast-path opt-outs (parity with legacy guard, issue #425)
+      * If `allow_no_op` is the literal string `"true"` (orchestration /
+        docs-only / audit / meta classification), emit `WORK_VERIFIED`
+        with rationale `"orchestration opt-out — allow_no_op=true"`.
+      * If the implement-step output contains the canonical sentinel
+        `No files modified — orchestration task` (em-dash U+2014, exact
+        match), emit `WORK_VERIFIED` with rationale
+        `"orchestration sentinel matched"`.
+
+      ## Verdicts
+      * `WORK_VERIFIED` — at least one concrete artifact addresses the task.
+      * `HOLLOW_SUCCESS` — no concrete artifact addresses the task. Fails the recipe.
+      * `INSUFFICIENT_EVIDENCE` — investigation inconclusive (no network, ambiguous
+        wording, etc). The bash gate warns loudly but lets the workflow continue,
+        so use this only when you genuinely cannot decide.
+
+      ## Output (REQUIRED)
+      Write whatever investigation prose you like, then on the **very last
+      line** emit a single JSON object — no code fence, no trailing text:
+
+      {"verdict": "WORK_VERIFIED" | "HOLLOW_SUCCESS" | "INSUFFICIENT_EVIDENCE", "evidence": ["<artifact ref or SHA>", ...], "rationale": "<one paragraph>"}
+
+      The bash gate extracts the last JSON object from your stdout. If you
+      emit malformed JSON the gate treats the verdict as
+      `INSUFFICIENT_EVIDENCE` (loud warning, recipe continues) so a
+      verifier-formatting bug never masks a real failure.
+    output: "verdict_json"
+
+  - id: "step-08c-enforce-verdict"
     type: "bash"
     condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
-    # Hard-fail early (before checkpoint, refactor, review) if step-08 declared
-    # success but reported zero file edits. This catches prompt-misalignment
-    # (issue #251 / amplihack-rs #251) closer to the root cause than the
-    # commit-stage hollow-success guard at step-15.
+    # Issue #615: maps the work-verifier's JSON verdict onto exit code.
+    #
+    # Fast-path opt-outs preserved from the legacy guard (issue #425):
+    #   * Orchestration sentinel in implement output -> exit 0.
+    #   * ALLOW_NO_OP=true (orchestration / docs-only / audit / meta) -> exit 0.
+    # Both opt-outs run BEFORE parsing the verdict so callers that legitimately
+    # produce no working-tree edits never get blocked, even if the verifier
+    # step itself fails or is skipped.
     command: |
       set -euo pipefail
       IMPL="${IMPLEMENTATION:-}"
-      if [ -z "$IMPL" ]; then
-        echo "ERROR: step-08-implement produced no output." >&2
-        exit 1
-      fi
+      VERDICT_RAW="${VERDICT_JSON:-}"
+
       # ----------------------------------------------------------------------
-      # Issue #425: orchestration opt-out.
-      #
-      # Some smart-orchestrator routes (audit, docs-only, orchestration, meta)
-      # legitimately produce no working-tree edits — their "implementation"
-      # is filing GitHub issues, opening child PRs, or coordinating downstream
-      # work. For those classifications the hollow-success guard below is a
-      # FALSE POSITIVE and must be skipped.
-      #
-      # Two opt-out mechanisms (precedence: sentinel > flag):
-      #   1. Sentinel match in implementer output. Canonical bytes (em-dash
-      #      U+2014, exact match via grep -F): "No files modified — orchestration task"
-      #   2. ALLOW_NO_OP context flag, strict equality "true" only. We refuse
-      #      to coerce 1 / yes / on / True so callers cannot accidentally
-      #      bypass the guard with shell-style truthiness.
-      #
-      # These checks MUST run BEFORE the `cd` so orchestration tasks pass
-      # even if WORKTREE_SETUP_WORKTREE_PATH is unset (orchestration mode
-      # may skip worktree setup entirely).
+      # Fast-path opt-outs (issue #425 parity).
       # ----------------------------------------------------------------------
       _ORCH_SENTINEL='No files modified — orchestration task'
-      if printf '%s' "$IMPL" | grep -qF -- "$_ORCH_SENTINEL"; then
-        echo "INFO: step-08c orchestration opt-out — sentinel matched (issue #425)." >&2
-        echo "  Skipping hollow-success guard for orchestration / docs-only task." >&2
+      if [ -n "$IMPL" ] && printf '%s' "$IMPL" | grep -qF -- "$_ORCH_SENTINEL"; then
+        echo "INFO: step-08c-enforce-verdict orchestration opt-out — sentinel matched (issue #425)." >&2
+        echo "  Skipping work-verifier verdict for orchestration / docs-only task." >&2
         exit 0
       fi
       if [ "${ALLOW_NO_OP:-false}" = "true" ]; then
-        echo "INFO: step-08c orchestration opt-out — ALLOW_NO_OP=true (issue #425)." >&2
-        echo "  Skipping hollow-success guard; classification permits no working-tree edits." >&2
+        echo "INFO: step-08c-enforce-verdict orchestration opt-out — ALLOW_NO_OP=true (issue #425)." >&2
+        echo "  Skipping work-verifier verdict; classification permits no working-tree edits." >&2
         exit 0
       fi
-      # Look for the structured "Files modified:" line.
-      FILES_LINE=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*Files modified:' || true)
-      JUSTIFICATION=$(printf '%s\n' "$IMPL" | grep -m1 -i '^[[:space:]]*[*-]\?[[:space:]]*No-op justification:' || true)
-      if [ -z "$FILES_LINE" ]; then
-        echo "WARNING: step-08-implement output is missing the required" >&2
-        echo "'Files modified:' section. The agent did not follow the structured" >&2
-        echo "output schema. Check the implementer prompt and output." >&2
-        # Soft-warn rather than hard-fail to remain backward-compatible with
-        # agents that ignore the schema. The git-diff guard below is the hard gate.
-      fi
-      # Check git diff in the worktree as the source of truth.
-      # Fail-loud (Zero-BS, issue #410): require worktree path from step-04 instead
-      # of silently falling back to $PWD (which is the parent repo and produces
-      # false-positive no-op failures when the worktree contains real work).
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-08c requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
-      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        echo "ERROR: step-08c-implementation-no-op-guard requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
-        exit 1
-      fi
-      # Check 1: dirty working tree (uncommitted or staged changes, untracked files).
-      if ! git diff --quiet || ! git diff --cached --quiet || \
-         [ -n "$(git ls-files --others --exclude-standard)" ]; then
-        echo "step-08 produced file changes — guard passed."
+
+      # ----------------------------------------------------------------------
+      # Parse the verifier's JSON verdict (last JSON object on stdout).
+      # ----------------------------------------------------------------------
+      if [ -z "$VERDICT_RAW" ]; then
+        echo "WARN: step-08c-work-verifier produced no output. Treating as INSUFFICIENT_EVIDENCE per fail-safe contract (issue #615)." >&2
+        echo "  Letting workflow continue with a loud warning rather than masking a possible real failure." >&2
         exit 0
       fi
-      # Check 2 (issue #580): detect committed changes.
-      # When the agent commits during step-07/step-08 (auto-commit, git add+commit
-      # in prompt, or tool-based commits), the working tree is clean but real
-      # work exists as new commits. Compare HEAD against the merge-base with
-      # origin/main (or origin/HEAD as fallback) to count commits on this branch.
-      MERGE_BASE_REF="origin/main"
-      if ! git rev-parse --verify "$MERGE_BASE_REF" >/dev/null 2>&1; then
-        MERGE_BASE_REF="origin/HEAD"
+
+      # Extract the last line that looks like a JSON object. Tolerates the
+      # verifier mixing prose with the final JSON line.
+      VERDICT_LINE=$(printf '%s\n' "$VERDICT_RAW" | grep -E '^[[:space:]]*\{.*"verdict"' | tail -1 || true)
+      if [ -z "$VERDICT_LINE" ]; then
+        # Fall back to scanning the entire blob with jq for the first valid
+        # JSON object containing a "verdict" key.
+        VERDICT_LINE=$(printf '%s' "$VERDICT_RAW" | jq -c 'select(type=="object" and has("verdict"))' 2>/dev/null | tail -1 || true)
       fi
-      if git rev-parse --verify "$MERGE_BASE_REF" >/dev/null 2>&1; then
-        MERGE_BASE=$(git merge-base HEAD "$MERGE_BASE_REF" 2>/dev/null || true)
-        if [ -n "$MERGE_BASE" ]; then
-          COMMITS_SINCE_BASE=$(git rev-list --count "${MERGE_BASE}..HEAD" 2>/dev/null || echo "0")
-          if [ "$COMMITS_SINCE_BASE" -gt 0 ]; then
-            echo "step-08 produced $COMMITS_SINCE_BASE commit(s) since branch point — guard passed."
-            git --no-pager log --oneline "${MERGE_BASE}..HEAD" >&2
-            exit 0
-          fi
-        fi
-      fi
-      if [ -n "$JUSTIFICATION" ]; then
-        echo "step-08 produced no file changes but declared a no-op justification:" >&2
-        echo "$JUSTIFICATION" >&2
-        echo "Allowing workflow to continue under rule 0 exception." >&2
+      if [ -z "$VERDICT_LINE" ]; then
+        echo "WARN: step-08c-work-verifier output did not contain a parseable JSON verdict. Treating as INSUFFICIENT_EVIDENCE (issue #615)." >&2
+        echo "--- verifier stdout (truncated to 4000 bytes) ---" >&2
+        printf '%s\n' "${VERDICT_RAW:0:4000}" >&2
+        echo "--- end ---" >&2
         exit 0
       fi
-      # Issue #360: detect "goal already met" — the desired change is already
-      # in main (e.g., a previous orchestrator round merged it) before treating
-      # this as a hollow-success failure. Probe the linked GitHub issue: if it
-      # is closed by a merged PR, exit 0 with a "pre-existing" marker rather
-      # than failing the round.
-      ISSUE_NUM="${ISSUE_NUMBER:-}"
-      if [ -n "$ISSUE_NUM" ] && command -v gh >/dev/null 2>&1; then
-        ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null || true)
-        if [ "$ISSUE_STATE" = "CLOSED" ]; then
-          # closedByPullRequestsReferences items DO NOT carry .state.
-          # Fetch (number, owner/repo) pairs so cross-repo PRs are looked
-          # up correctly (COE cohort review #2).
-          CLOSING_PR_REFS=$(gh issue view "$ISSUE_NUM" \
-            --json closedByPullRequestsReferences \
-            --jq '[.closedByPullRequestsReferences[]? | "\(.number) \(.repository.owner.login)/\(.repository.name)"] | join("\n")' \
-            2>/dev/null || true)
-          MAX_PROBE=10
-          probed=0
-          MERGED_FOUND=0
-          while IFS= read -r ref; do
-            [ -z "$ref" ] && continue
-            probed=$((probed + 1))
-            if [ "$probed" -gt "$MAX_PROBE" ]; then break; fi
-            PR_NUM=$(printf '%s' "$ref" | awk '{print $1}')
-            PR_REPO=$(printf '%s' "$ref" | awk '{print $2}')
-            if [ -n "$PR_REPO" ] && [ "$PR_REPO" != "/" ]; then
-              PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --repo "$PR_REPO" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
-            else
-              PR_MERGED=$(timeout 30 gh pr view "$PR_NUM" --json mergedAt --jq '.mergedAt' 2>/dev/null || true)
-            fi
-            # mergedAt is null for unmerged PRs and a timestamp string for merged ones.
-            if [ -n "$PR_MERGED" ] && [ "$PR_MERGED" != "null" ]; then
-              MERGED_FOUND=1
-              break
-            fi
-          done <<< "$CLOSING_PR_REFS"
-          if [ "$MERGED_FOUND" -eq 1 ]; then
-            echo "INFO: step-08-implement produced no file changes, but issue" >&2
-            echo "  #${ISSUE_NUM} is already CLOSED by a merged pull request." >&2
-            echo "  This is a 'goal already met' (#360) — not a hollow success." >&2
-            echo "  Treating as pre-existing success and continuing." >&2
-            exit 0
-          fi
-        fi
-      fi
-      echo "ERROR: step-08-implement claimed success but produced ZERO file changes" >&2
-      echo "and no 'No-op justification:' was provided. This is a hollow-success" >&2
-      echo "condition, almost certainly caused by prompt-misalignment — see" >&2
-      echo "https://github.com/rysweet/amplihack-rs/issues/251." >&2
-      echo "" >&2
-      echo "Inspected worktree: ${WORKTREE_SETUP_WORKTREE_PATH}" >&2
-      echo "Working directory: $PWD" >&2
-      git --no-pager status >&2
-      exit 1
+
+      VERDICT=$(printf '%s' "$VERDICT_LINE" | jq -r '.verdict // "INSUFFICIENT_EVIDENCE"' 2>/dev/null || echo "INSUFFICIENT_EVIDENCE")
+
+      case "$VERDICT" in
+        WORK_VERIFIED)
+          echo "INFO: step-08c work-verifier APPROVED (issue #615)." >&2
+          printf '%s\n' "$VERDICT_LINE" | jq . >&2 || printf '%s\n' "$VERDICT_LINE" >&2
+          exit 0
+          ;;
+        INSUFFICIENT_EVIDENCE)
+          echo "WARN: step-08c work-verifier returned INSUFFICIENT_EVIDENCE — letting workflow continue with a loud warning (issue #615)." >&2
+          printf '%s\n' "$VERDICT_LINE" | jq . >&2 || printf '%s\n' "$VERDICT_LINE" >&2
+          exit 0
+          ;;
+        HOLLOW_SUCCESS)
+          echo "ERROR: step-08c work-verifier rejected step-08-implement with HOLLOW_SUCCESS (issue #615)." >&2
+          echo "  The implement step claimed COMPLETE but the verifier could not find concrete artifacts that address the task." >&2
+          printf '%s\n' "$VERDICT_LINE" | jq . >&2 || printf '%s\n' "$VERDICT_LINE" >&2
+          exit 1
+          ;;
+        *)
+          echo "ERROR: step-08c work-verifier emitted unknown verdict: $VERDICT (issue #615)." >&2
+          printf '%s\n' "$VERDICT_LINE" | jq . >&2 || printf '%s\n' "$VERDICT_LINE" >&2
+          exit 1
+          ;;
+      esac
     output: "implementation_noop_guard"
 
   - id: "step-08b-integration"

--- a/docs/reference/skip-pre-agent-validation.md
+++ b/docs/reference/skip-pre-agent-validation.md
@@ -82,7 +82,7 @@ fi
 | Variable | Relationship |
 |----------|-------------|
 | `force_single_workstream` | Independent. Uses the same string-as-boolean pattern. |
-| `allow_no_op` | Independent. `allow_no_op` controls the step-08c hollow-success guard; `skip_pre_agent_validation` controls step-01 pre-flight validation. |
+| `allow_no_op` | Independent. `allow_no_op` is the fast-path opt-out for the step-08c work-verifier (issue #615); `skip_pre_agent_validation` controls step-01 pre-flight validation. |
 | `worktree_setup` | Independent. Both are explicitly forwarded in `smart-execute-routing.yaml`. |
 
 ---

--- a/docs/reference/worktree-setup-propagation.md
+++ b/docs/reference/worktree-setup-propagation.md
@@ -26,13 +26,7 @@ Complete reference for how the `worktree_setup` context variable propagates thro
 | `branch_name` | `feat/add-auth-1234` | Branch name created or reused |
 | `is_new_worktree` | `true` | Whether a new worktree was created vs. reattached |
 
-Downstream steps — particularly step-08c (the no-op/hollow-success guard in `workflow-tdd`) — read `WORKTREE_SETUP_WORKTREE_PATH` to verify that implementation actually produced file changes in the worktree directory. Without this variable, step-08c cannot locate the worktree and fails with:
-
-```
-WORKTREE_SETUP_WORKTREE_PATH: step-08c requires worktree_setup.worktree_path
-from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and
-propagated outputs
-```
+Downstream steps — particularly the `step-08c-work-verifier` / `step-08c-enforce-verdict` pair in `workflow-tdd` (issue #615 — replaced the legacy six-escape-hatch bash hollow-success guard with an agentic verifier) — read `WORKTREE_SETUP_WORKTREE_PATH` so the verifier agent runs inside the worktree where implementation actually happened. Without this variable, the verifier cannot inspect the right working tree and may fall back to `INSUFFICIENT_EVIDENCE`.
 
 ---
 
@@ -47,7 +41,7 @@ smart-orchestrator
             ├─ workflow-prep        ← does NOT declare (runs before worktree creation)
             ├─ workflow-worktree    ← PRODUCES worktree_setup (does not consume it)
             ├─ workflow-design      ← does NOT declare (runs before worktree output is needed)
-            ├─ workflow-tdd         ← declares worktree_setup: ""  ← CONSUMER (step-08c)
+            ├─ workflow-tdd         ← declares worktree_setup: ""  ← CONSUMER (step-08c work-verifier)
             ├─ workflow-refactor-review  ← declares worktree_setup: ""
             ├─ workflow-precommit-test   ← declares worktree_setup: ""
             ├─ workflow-publish          ← declares worktree_setup: ""
@@ -89,12 +83,12 @@ The empty-string default is intentional. Bash `${VAR:?msg}` and `${VAR:+alt}` gu
 
 ## Related context variable: allow_no_op
 
-`allow_no_op` controls the step-08c hollow-success guard in `workflow-tdd`. When `true`, the guard permits a step to complete without file changes — used for orchestration, docs-only, or audit tasks that legitimately produce no working-tree edits.
+`allow_no_op` controls the `step-08c-enforce-verdict` fast-path opt-out in `workflow-tdd` (issue #615). When `true`, the enforcer treats the step as `WORK_VERIFIED` without parsing the verifier's verdict — used for orchestration, docs-only, or audit tasks that legitimately produce no working-tree edits.
 
 | Value | Behavior |
 |-------|----------|
-| `false` (default) | step-08c requires at least one file change in the worktree |
-| `true` | step-08c skips the file-change check |
+| `false` (default) | step-08c runs the agentic work-verifier and enforces its verdict |
+| `true` | step-08c-enforce-verdict short-circuits to exit 0 (orchestration / docs-only / audit / meta) |
 
 `allow_no_op` is declared alongside `worktree_setup` in every post-worktree sub-recipe. The smart-classify-route step in `smart-orchestrator` sets it to `true` when the task classification permits no working-tree edits.
 
@@ -144,9 +138,12 @@ These tests load the YAML files directly and parse the `context:` sections, catc
 
 ## Troubleshooting
 
-**Error: `WORKTREE_SETUP_WORKTREE_PATH: step-08c requires worktree_setup.worktree_path...`**
+**Error: `WORKTREE_SETUP_WORKTREE_PATH: ... requires worktree_setup.worktree_path...`** (legacy step-08c bash guard, removed by issue #615)
 
-This means a sub-recipe in the chain is missing the `worktree_setup` context declaration. Check:
+If you still see this error from a stale build, upgrade. In the agentic
+verifier, missing worktree path manifests as the verifier reporting
+`INSUFFICIENT_EVIDENCE` instead. The underlying cause is the same: a
+sub-recipe in the chain is missing the `worktree_setup` context declaration. Check:
 
 1. The sub-recipe's `context:` block includes `worktree_setup: ""`.
 2. The parent recipe's call site passes `worktree_setup` in its context.

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -112,7 +112,8 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     // Phase 3: workflow-tdd (steps 07-08c)
     "step-07-write-tests",
     "step-08-implement",
-    "step-08c-implementation-no-op-guard",
+    "step-08c-work-verifier",
+    "step-08c-enforce-verdict",
     "step-08b-integration",
     "checkpoint-after-implementation",
     // Phase 4: workflow-refactor-review (steps 09-11b)


### PR DESCRIPTION
## Summary

Replace `step-08c-implementation-no-op-guard` (152-line bash with six layered escape hatches that *still* false-positives) with an agentic two-step verifier in `amplifier-bundle/recipes/workflow-tdd.yaml`. The new pair is `step-08c-work-verifier` (LLM agent inspecting real artifacts) plus `step-08c-enforce-verdict` (tiny bash gate that maps the JSON verdict onto an exit code). LLM judgment replaces fragile deterministic inference for a question that genuinely needs judgment: did real work happen?

## Why this change

Closes #615.

Real-world failure today: a `default-workflow` run produced two PRs (#1717 and #1718), pushed them, opened them, and **auto-merged both into `origin/main`** — all within `step-08-implement`. By the time `step-08c` ran, `git merge-base HEAD origin/main` returned HEAD itself (because the squash-merge had already landed), so `COMMITS_SINCE_BASE=0`. Working tree was clean. Issue-360 probe targeted the umbrella tracking issue (not #1712/#1714 which were the actually-referenced ones). All six escape hatches missed and the recipe failed with hollow-success despite both PRs being merged.

The bash guard's truth space is irregular — work can land in worktrees, sibling branches, in-step merged PRs, already-closed issues, or remote-only via `gh pr merge`. Every false positive added another special case until the guard collapsed under its own complexity. Issue #615 captures the architectural rationale; this PR is the agentic replacement.

## What changed

- **`amplifier-bundle/recipes/workflow-tdd.yaml`** — replaced lines 120-271 (the entire legacy bash guard) with two new steps:
  - `step-08c-work-verifier` (`type: agent`, `agent: amplihack:analyzer`, `working_dir: {{worktree_setup.worktree_path}}`) — receives task description, issue number, implement-step output, and `allow_no_op` flag. Runs git/gh shell tools to gather concrete evidence across working tree, local commits since branch point, already-merged-during-implement PRs, sibling branches/worktrees, the linked issue, and recent PRs. Emits a JSON verdict on its final stdout line.
  - `step-08c-enforce-verdict` (`type: bash`) — preserves the legacy fast-path opt-outs (orchestration sentinel, `ALLOW_NO_OP=true`) so callers that legitimately produce no working-tree edits never get blocked, then parses the verdict JSON: `WORK_VERIFIED` → exit 0, `INSUFFICIENT_EVIDENCE` → loud warning + exit 0 (fail-safe), `HOLLOW_SUCCESS` → exit 1. Missing/malformed JSON is treated as `INSUFFICIENT_EVIDENCE` so a verifier-formatting bug never masks a real failure.
  - Existing `condition:` clause (`resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'`) preserved on both new steps.
  - Top-of-file comment block updated with FIX #615 narrative explaining the architectural shift.
- **`amplifier-bundle/recipes/default-workflow.yaml`** — comment block at lines 79-91 (`worktree_setup` / `allow_no_op` declarations) updated to reference the new agentic verifier instead of the legacy guard.
- **`amplifier-bundle/recipes/smart-classify-route.yaml`** — comment block above `materialize-allow-no-op` (lines 209-217) updated to reflect that `allow_no_op` is now a fast-path opt-out for the verifier, not a guard-bypass.
- **`docs/reference/worktree-setup-propagation.md`** — three sections updated: the "downstream consumers" paragraph, the "related context variable" `allow_no_op` table, and the troubleshooting entry.
- **`docs/reference/skip-pre-agent-validation.md`** — one row in the interaction table updated.
- **`tests/integration/default_workflow_decomposition_test.rs`** — replaced the single `"step-08c-implementation-no-op-guard"` entry in `EXPECTED_STEP_INVENTORY` with the two new step IDs (in order).

Net diff: 6 files changed, +206 / -162 lines.

## How to verify

```bash
# 1. Build (release).
cargo build --release

# 2. Run the recipe-decomposition contract tests (covers step inventory,
#    400-line brick rule, and recipe loading).
cargo test --release -p amplihack --test default_workflow_decomposition

# 3. Sanity-parse the modified YAMLs.
python3 -c "import yaml; d=yaml.safe_load(open('amplifier-bundle/recipes/workflow-tdd.yaml')); print('steps:', [s['id'] for s in d['steps']])"

# Expected step IDs in workflow-tdd:
#   step-07-write-tests, step-08-implement,
#   step-08c-work-verifier, step-08c-enforce-verdict,
#   step-08b-integration, checkpoint-after-implementation
```

End-to-end correctness for the agentic step itself can only be exercised
by running a real recipe (the runner shells out to an LLM). The bash
enforcer's verdict-mapping is exhaustively tested by the verdict
semantics in the file itself: `WORK_VERIFIED` / `INSUFFICIENT_EVIDENCE` /
`HOLLOW_SUCCESS` / unknown → distinct exit codes.

## Risk / blast radius

- **Affects every `workflow-tdd` execution** — i.e., every Development run going through `default-workflow` that reaches step-08. This is the intended blast radius: the fix has to apply everywhere the bug applies.
- **Adds one LLM call per recipe execution** (~$0.01-0.05, ~30-60s wallclock with copilot/sonnet). Net cost is favourable: today, one false positive on a real run costs ~1 hour of recipe work + manual triage. Break-even within ~5 false positives avoided.
- **Backward compatibility preserved**: the orchestration sentinel (`No files modified — orchestration task`, em-dash U+2014) and `ALLOW_NO_OP=true` opt-outs continue to work; both are checked by the bash enforcer *before* the verdict is parsed, so callers depending on issue #425 behaviour are unchanged.
- **Fail-safe defaults**: if the verifier produces no output or malformed JSON, the enforcer emits a loud warning and exits 0 — matching the existing safety contract.
- **Resume-checkpoint behaviour preserved** via the unchanged `condition:` clause.

## Follow-ups / out-of-scope

- Other recipes (`workflow-publish`, `workflow-finalize`) still have their own commit-stage hollow-success checks. Those operate on a different question ("did publish actually push commits?") and are out of scope for this PR. If they exhibit similar false-positive patterns we can apply the same agentic pattern in a follow-up.
- The `goal_already_met` signal flowing into downstream phases (publish, finalize) to suppress duplicate PRs is unchanged. The agentic verifier independently re-checks the linked issue via `gh issue view --json closedByPullRequestsReferences`, subsuming the legacy in-step #360 probe.
- Cost telemetry: we may want to log verifier verdict + token usage so we can quantify the false-positive elimination rate after a few hundred runs.
