### PR TITLE
feat(copilot): subprocess-safe defaults for amplihack copilot (#621)

### DIFF
--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -106,6 +106,11 @@ pub enum Commands {
         /// Disable post-session reflection analysis.
         #[arg(long = "no-reflection")]
         no_reflection: bool,
+        /// Force post-session reflection analysis ON. Overrides the
+        /// subprocess-safe default flip (issue #621). Mutually exclusive
+        /// with `--no-reflection`.
+        #[arg(long = "reflection", conflicts_with = "no_reflection")]
+        reflection: bool,
         /// Skip shared launcher staging/env updates for subprocess delegates.
         #[arg(long = "subprocess-safe")]
         subprocess_safe: bool,

--- a/crates/amplihack-cli/src/cli_tests.rs
+++ b/crates/amplihack-cli/src/cli_tests.rs
@@ -397,4 +397,68 @@ mod tests {
             );
         }
     }
+
+    // ── #621: Copilot --reflection opt-in clap flag ────────────────────────────
+
+    /// #621 / #17: `amplihack copilot --reflection` MUST parse as a recognized
+    /// boolean flag. The Copilot variant currently exposes only `--no-reflection`;
+    /// this test locks the contract that the new `--reflection` opt-in exists
+    /// and is reachable from the CLI surface.
+    #[test]
+    fn copilot_cli_parses_explicit_reflection_flag() {
+        let cli = Cli::try_parse_from(["amplihack", "copilot", "--reflection"])
+            .expect("copilot --reflection must parse");
+        match cli.command {
+            Commands::Copilot {
+                reflection,
+                no_reflection,
+                ..
+            } => {
+                assert!(
+                    reflection,
+                    "--reflection must set the reflection field to true"
+                );
+                assert!(
+                    !no_reflection,
+                    "--no-reflection must remain false when only --reflection is passed"
+                );
+            }
+            other => panic!("expected copilot command, got {other:?}"),
+        }
+    }
+
+    /// #621 / #18: `--reflection` and `--no-reflection` are mutually exclusive
+    /// (clap `conflicts_with`). Passing BOTH MUST produce a parse error rather
+    /// than silently picking one — this prevents ambiguous user intent from
+    /// being resolved by argument order.
+    #[test]
+    fn copilot_cli_rejects_reflection_and_no_reflection_together() {
+        let result =
+            Cli::try_parse_from(["amplihack", "copilot", "--reflection", "--no-reflection"]);
+        assert!(
+            result.is_err(),
+            "passing both --reflection and --no-reflection must be a parse error; got {result:?}"
+        );
+    }
+
+    /// #621 / #18b: Default — when neither --reflection nor --no-reflection is
+    /// passed, both fields default to false. (Subprocess-safe context flips
+    /// the *effective* default at dispatch time via `resolve_no_reflection`,
+    /// but the parsed clap fields themselves remain unchanged.)
+    #[test]
+    fn copilot_cli_reflection_fields_default_false() {
+        let cli = Cli::try_parse_from(["amplihack", "copilot"])
+            .expect("copilot with no flags must parse");
+        match cli.command {
+            Commands::Copilot {
+                reflection,
+                no_reflection,
+                ..
+            } => {
+                assert!(!reflection, "reflection must default to false");
+                assert!(!no_reflection, "no_reflection must default to false");
+            }
+            other => panic!("expected copilot command, got {other:?}"),
+        }
+    }
 }

--- a/crates/amplihack-cli/src/commands/launch/command.rs
+++ b/crates/amplihack-cli/src/commands/launch/command.rs
@@ -23,6 +23,7 @@ pub(super) fn build_command(
         skip_permissions,
         extra_args,
         None,
+        false, // subprocess_safe
     )
 }
 
@@ -33,6 +34,7 @@ pub(super) fn build_command_for_dir(
     skip_permissions: bool,
     extra_args: &[String],
     add_dir_override: Option<&Path>,
+    subprocess_safe: bool,
 ) -> Command {
     let mut cmd = Command::new(&binary.path);
 
@@ -77,6 +79,28 @@ pub(super) fn build_command_for_dir(
         cmd.arg("--allow-all");
     }
 
+    // Issue #621: Subprocess-safe defense-in-depth — granular allow-all flags.
+    //
+    // When subprocess_safe is active, we ALSO inject the granular
+    // `--allow-all-tools` and `--allow-all-paths` flags. This is intentional
+    // layering: the broader `--allow-all` (issue #303) covers the same
+    // permission space, but the granular flags are the explicit contract
+    // callers (Simard engineers, recipe-runner agents) audit for. Both
+    // appearing in argv is accepted by the copilot CLI without conflict.
+    //
+    // Scope: copilot binary only. Other tools (claude, codex, amplifier)
+    // are excluded — these flags are copilot-specific.
+    if binary.name == "copilot" && subprocess_safe {
+        let (inject_tools, inject_paths) =
+            should_inject_subprocess_safe_flags(subprocess_safe, extra_args);
+        if inject_tools {
+            cmd.arg("--allow-all-tools");
+        }
+        if inject_paths {
+            cmd.arg("--allow-all-paths");
+        }
+    }
+
     // Inject --remote for Copilot by default. Remote mode offloads compute to
     // GitHub's cloud, which is the preferred mode for amplihack orchestration.
     // Skip injection if the user already passed --remote, or if
@@ -87,6 +111,89 @@ pub(super) fn build_command_for_dir(
 
     cmd.args(extra_args);
     cmd
+}
+
+/// Pure decision function (issue #621): is this Copilot invocation
+/// subprocess-safe?
+///
+/// Subprocess-safe is true when ANY of:
+///   * the user explicitly passed `--subprocess-safe` (`explicit_flag`)
+///   * `AMPLIHACK_AGENT_BINARY` is set to a non-empty value
+///     (`env_agent_binary = Some(non_empty)`)
+///   * not all three standard streams are TTYs (`all_streams_tty = false`)
+///
+/// Empty-string `env_agent_binary` is treated as "no delegation" (the
+/// documented sentinel value) and does NOT trigger subprocess-safe by itself.
+///
+/// This function takes the TTY state as a parameter (rather than reading
+/// stdio internally) so it can be unit-tested deterministically without
+/// depending on the test harness's actual stdio state.
+pub(crate) fn resolve_subprocess_safe(
+    explicit_flag: bool,
+    env_agent_binary: Option<&str>,
+    all_streams_tty: bool,
+) -> bool {
+    if explicit_flag {
+        return true;
+    }
+    if env_agent_binary.is_some_and(|s| !s.is_empty()) {
+        return true;
+    }
+    !all_streams_tty
+}
+
+/// Pure decision function (issue #621): which subprocess-safe granular flags
+/// should `build_command_for_dir` inject for Copilot?
+///
+/// Returns `(inject_allow_all_tools, inject_allow_all_paths)`. Callers must
+/// have already gated on `subprocess_safe == true` and `binary.name ==
+/// "copilot"` — passing `subprocess_safe = false` returns `(false, false)`
+/// unconditionally as a defensive invariant.
+///
+/// Duplicate suppression rules (each flag computed independently):
+///   * `--allow-all-tools` already in user args → suppress tools injection.
+///   * `--allow-all-paths` already in user args → suppress paths injection.
+///   * `--allow-all` (broader superset) in user args → suppress BOTH.
+pub(super) fn should_inject_subprocess_safe_flags(
+    subprocess_safe: bool,
+    user_args: &[String],
+) -> (bool, bool) {
+    if !subprocess_safe {
+        return (false, false);
+    }
+    let user_has_superset = user_args.iter().any(|a| a == "--allow-all");
+    if user_has_superset {
+        return (false, false);
+    }
+    let user_has_tools = user_args.iter().any(|a| a == "--allow-all-tools");
+    let user_has_paths = user_args.iter().any(|a| a == "--allow-all-paths");
+    (!user_has_tools, !user_has_paths)
+}
+
+/// Pure precedence resolver (issue #621): compute the *effective*
+/// no-reflection decision from the three input signals.
+///
+/// Precedence (highest → lowest):
+///   1. `explicit_reflection = true` (user passed `--reflection`)  → reflection ON  → return false
+///   2. `no_reflection = true`       (user passed `--no-reflection`)→ reflection OFF → return true
+///   3. `subprocess_safe = true`     (auto-detected or `--subprocess-safe`) → reflection OFF → return true
+///   4. otherwise (default)                                          → reflection ON  → return false
+///
+/// `--reflection` and `--no-reflection` are mutually exclusive at the clap
+/// layer (`conflicts_with`); the resolver itself is defense-in-depth and
+/// gives `--reflection` priority if both somehow arrive as `true`.
+pub(crate) fn resolve_no_reflection(
+    explicit_reflection: bool,
+    no_reflection: bool,
+    subprocess_safe: bool,
+) -> bool {
+    if explicit_reflection {
+        return false;
+    }
+    if no_reflection {
+        return true;
+    }
+    subprocess_safe
 }
 
 /// Decide whether `amplihack` should inject `--allow-all` into a Copilot

--- a/crates/amplihack-cli/src/commands/launch/command.rs
+++ b/crates/amplihack-cli/src/commands/launch/command.rs
@@ -83,16 +83,20 @@ pub(super) fn build_command_for_dir(
     //
     // When subprocess_safe is active, we ALSO inject the granular
     // `--allow-all-tools` and `--allow-all-paths` flags. This is intentional
-    // layering: the broader `--allow-all` (issue #303) covers the same
-    // permission space, but the granular flags are the explicit contract
-    // callers (Simard engineers, recipe-runner agents) audit for. Both
-    // appearing in argv is accepted by the copilot CLI without conflict.
+    // layering on top of the broader `--allow-all` (issue #303): both
+    // appearing in argv is accepted by the copilot CLI without conflict, and
+    // the granular flags are the explicit contract callers (Simard engineers,
+    // recipe-runner agents) audit for.
+    //
+    // The `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` opt-out (originally introduced
+    // for the broader #303 flag) ALSO suppresses these granular injections —
+    // a user who has explicitly disabled auto-permission grants for copilot
+    // wants permission gates back across the board, not partially restored.
     //
     // Scope: copilot binary only. Other tools (claude, codex, amplifier)
     // are excluded — these flags are copilot-specific.
     if binary.name == "copilot" && subprocess_safe {
-        let (inject_tools, inject_paths) =
-            should_inject_subprocess_safe_flags(subprocess_safe, extra_args);
+        let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(extra_args);
         if inject_tools {
             cmd.arg("--allow-all-tools");
         }
@@ -120,18 +124,22 @@ pub(super) fn build_command_for_dir(
 ///   * the user explicitly passed `--subprocess-safe` (`explicit_flag`)
 ///   * `AMPLIHACK_AGENT_BINARY` is set to a non-empty value
 ///     (`env_agent_binary = Some(non_empty)`)
-///   * not all three standard streams are TTYs (`all_streams_tty = false`)
+///   * `AMPLIHACK_NONINTERACTIVE=1` is set (`env_amplihack_noninteractive`)
+///   * any of stdin/stdout/stderr is not a TTY (`any_stream_non_tty`)
 ///
 /// Empty-string `env_agent_binary` is treated as "no delegation" (the
 /// documented sentinel value) and does NOT trigger subprocess-safe by itself.
 ///
-/// This function takes the TTY state as a parameter (rather than reading
-/// stdio internally) so it can be unit-tested deterministically without
-/// depending on the test harness's actual stdio state.
+/// All inputs are passed as parameters (rather than read from env / stdio
+/// inside) so this function is unit-testable deterministically without
+/// depending on the test harness's actual env or stdio state. The
+/// production caller in `commands/mod.rs` reads the four signals once and
+/// hands them to this resolver — see also [`crate::util::any_stream_is_non_tty`].
 pub(crate) fn resolve_subprocess_safe(
     explicit_flag: bool,
     env_agent_binary: Option<&str>,
-    all_streams_tty: bool,
+    env_amplihack_noninteractive: bool,
+    any_stream_non_tty: bool,
 ) -> bool {
     if explicit_flag {
         return true;
@@ -139,26 +147,28 @@ pub(crate) fn resolve_subprocess_safe(
     if env_agent_binary.is_some_and(|s| !s.is_empty()) {
         return true;
     }
-    !all_streams_tty
+    if env_amplihack_noninteractive {
+        return true;
+    }
+    any_stream_non_tty
 }
 
 /// Pure decision function (issue #621): which subprocess-safe granular flags
 /// should `build_command_for_dir` inject for Copilot?
 ///
 /// Returns `(inject_allow_all_tools, inject_allow_all_paths)`. Callers must
-/// have already gated on `subprocess_safe == true` and `binary.name ==
-/// "copilot"` — passing `subprocess_safe = false` returns `(false, false)`
-/// unconditionally as a defensive invariant.
+/// have already gated on the surrounding `subprocess_safe == true` and
+/// `binary.name == "copilot"` conditions in `build_command_for_dir`.
 ///
-/// Duplicate suppression rules (each flag computed independently):
+/// Suppression rules (each flag computed independently):
+///   * `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` env var → suppress BOTH
+///     (the user opted out of amplihack auto-granting permissions to copilot;
+///     subprocess-safe defers to that explicit opt-out).
+///   * `--allow-all` (broader superset) in user args → suppress BOTH.
 ///   * `--allow-all-tools` already in user args → suppress tools injection.
 ///   * `--allow-all-paths` already in user args → suppress paths injection.
-///   * `--allow-all` (broader superset) in user args → suppress BOTH.
-pub(super) fn should_inject_subprocess_safe_flags(
-    subprocess_safe: bool,
-    user_args: &[String],
-) -> (bool, bool) {
-    if !subprocess_safe {
+pub(super) fn should_inject_subprocess_safe_flags(user_args: &[String]) -> (bool, bool) {
+    if std::env::var("AMPLIHACK_COPILOT_NO_ALLOW_ALL").as_deref() == Ok("1") {
         return (false, false);
     }
     let user_has_superset = user_args.iter().any(|a| a == "--allow-all");

--- a/crates/amplihack-cli/src/commands/launch/mod.rs
+++ b/crates/amplihack-cli/src/commands/launch/mod.rs
@@ -17,9 +17,12 @@ mod tests_command;
 mod tests_env;
 #[cfg(test)]
 mod tests_launch;
+#[cfg(test)]
+mod tests_subprocess_safe;
 
 // Re-exports — public API of the launch module.
 pub(crate) use checkout::resolve_checkout_repo;
+pub(crate) use command::{resolve_no_reflection, resolve_subprocess_safe};
 pub(crate) use power_steering::maybe_prompt_re_enable_power_steering;
 
 // Internal imports from submodules used by run_launch.
@@ -187,6 +190,7 @@ pub fn run_launch(
             skip_permissions,
             &extra_args,
             Some(&execution_dir),
+            subprocess_safe,
         );
         cmd.current_dir(&execution_dir);
         env_builder.apply_to_command(&mut cmd);

--- a/crates/amplihack-cli/src/commands/launch/tests_env.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_env.rs
@@ -35,6 +35,7 @@ fn build_command_injects_uvx_plugin_and_project_args_for_claude() {
         false,
         &[],
         Some(execution_dir.path()),
+        false,
     );
     let args = cmd
         .get_args()
@@ -98,6 +99,7 @@ fn build_command_prefers_original_cwd_for_staged_uvx_launches() {
         false,
         &[],
         Some(execution_dir.path()),
+        false,
     );
     let args = cmd
         .get_args()

--- a/crates/amplihack-cli/src/commands/launch/tests_subprocess_safe.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_subprocess_safe.rs
@@ -52,35 +52,59 @@ fn arg_strings(cmd: &std::process::Command) -> Vec<String> {
 }
 
 // ── R6 / #1: resolve_subprocess_safe — pure decision function ──────────────
+//
+// Signature: resolve_subprocess_safe(
+//     explicit_flag: bool,
+//     env_agent_binary: Option<&str>,
+//     env_amplihack_noninteractive: bool,
+//     any_stream_non_tty: bool,
+// ) -> bool
 
 /// #1: explicit_flag=true MUST always return true regardless of other inputs.
 #[test]
 fn resolve_subprocess_safe_explicit_flag_true_always_returns_true() {
-    assert!(resolve_subprocess_safe(true, None, true));
-    assert!(resolve_subprocess_safe(true, Some("copilot"), true));
-    assert!(resolve_subprocess_safe(true, None, false));
-    assert!(resolve_subprocess_safe(true, Some(""), true));
+    assert!(resolve_subprocess_safe(true, None, false, false));
+    assert!(resolve_subprocess_safe(true, Some("copilot"), false, false));
+    assert!(resolve_subprocess_safe(true, None, true, true));
+    assert!(resolve_subprocess_safe(true, Some(""), false, false));
 }
 
 /// #2: AMPLIHACK_AGENT_BINARY set non-empty MUST trigger subprocess-safe even at TTY.
 #[test]
 fn resolve_subprocess_safe_agent_binary_set_returns_true_even_with_tty() {
-    assert!(resolve_subprocess_safe(false, Some("copilot"), true));
-    assert!(resolve_subprocess_safe(false, Some("claude"), true));
-    assert!(resolve_subprocess_safe(false, Some("anything"), true));
+    assert!(resolve_subprocess_safe(
+        false,
+        Some("copilot"),
+        false,
+        false
+    ));
+    assert!(resolve_subprocess_safe(false, Some("claude"), false, false));
+    assert!(resolve_subprocess_safe(
+        false,
+        Some("anything"),
+        false,
+        false
+    ));
 }
 
-/// #3: All streams non-TTY MUST trigger subprocess-safe even with no env signals.
+/// #2b: AMPLIHACK_NONINTERACTIVE=1 MUST trigger subprocess-safe even at TTY
+/// with no other signals.
+#[test]
+fn resolve_subprocess_safe_amplihack_noninteractive_returns_true_even_with_tty() {
+    assert!(resolve_subprocess_safe(false, None, true, false));
+}
+
+/// #3: Any stream non-TTY MUST trigger subprocess-safe even with no env signals.
 #[test]
 fn resolve_subprocess_safe_non_tty_returns_true() {
-    assert!(resolve_subprocess_safe(false, None, false));
+    assert!(resolve_subprocess_safe(false, None, false, true));
 }
 
 /// #4: Interactive context with no signals MUST return false.
 /// (Security-critical invariant: must not silently expand permissions on a TTY.)
 #[test]
 fn resolve_subprocess_safe_interactive_no_signals_returns_false() {
-    assert_eq!(resolve_subprocess_safe(false, None, true), false);
+    assert_eq!(resolve_subprocess_safe(false, None, false, false), false);
 }
 
 /// #5: AMPLIHACK_AGENT_BINARY set to empty string MUST be treated as unset.
@@ -89,27 +113,71 @@ fn resolve_subprocess_safe_interactive_no_signals_returns_false() {
 /// subprocess delegate.)
 #[test]
 fn resolve_subprocess_safe_empty_agent_binary_treated_as_unset() {
-    assert_eq!(resolve_subprocess_safe(false, Some(""), true), false);
+    assert_eq!(
+        resolve_subprocess_safe(false, Some(""), false, false),
+        false
+    );
 }
 
 // ── R6 / #2-#6 + #7-#10: should_inject_subprocess_safe_flags ───────────────
+//
+// Signature: should_inject_subprocess_safe_flags(user_args: &[String]) -> (bool, bool)
+//
+// Caller in build_command_for_dir gates on `subprocess_safe == true` and
+// `binary.name == "copilot"` before calling this — so the dead param has been
+// removed (philosophy review S-1, PR #623). The function still owns the
+// AMPLIHACK_COPILOT_NO_ALLOW_ALL=1 opt-out and the per-flag duplicate
+// suppression logic.
 
-/// #6: When subprocess_safe=true AND no user flags present, both granular
+/// #6: When no user flags present and no NO_ALLOW_ALL opt-out, both granular
 /// flags MUST be injected. Returns (inject_tools, inject_paths).
 #[test]
-fn should_inject_both_flags_when_subprocess_safe_and_no_user_flags() {
+fn should_inject_both_flags_with_no_user_flags_and_no_opt_out() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
     let user_args: Vec<String> = vec![];
-    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(true, &user_args);
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(&user_args);
     assert!(inject_tools, "must inject --allow-all-tools");
     assert!(inject_paths, "must inject --allow-all-paths");
+}
+
+/// #6b (security MEDIUM, PR #623 review): AMPLIHACK_COPILOT_NO_ALLOW_ALL=1
+/// MUST suppress BOTH granular flags. The user has explicitly opted out of
+/// amplihack auto-granting permissions to copilot; subprocess-safe defers
+/// to that explicit opt-out instead of partially restoring auto-permissions.
+#[test]
+fn should_skip_both_when_amplihack_copilot_no_allow_all_set() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::set_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL", "1");
+    }
+    let user_args: Vec<String> = vec![];
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(&user_args);
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
+    assert_eq!(
+        inject_tools, false,
+        "AMPLIHACK_COPILOT_NO_ALLOW_ALL=1 must suppress --allow-all-tools"
+    );
+    assert_eq!(
+        inject_paths, false,
+        "AMPLIHACK_COPILOT_NO_ALLOW_ALL=1 must suppress --allow-all-paths"
+    );
 }
 
 /// #7: When user supplied --allow-all-tools, MUST suppress that injection.
 /// (Idempotency / no duplicate user-supplied flag.)
 #[test]
 fn should_skip_tools_when_user_supplied_allow_all_tools() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
     let user_args = vec!["--allow-all-tools".to_string()];
-    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(true, &user_args);
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(&user_args);
     assert_eq!(
         inject_tools, false,
         "must not duplicate user --allow-all-tools"
@@ -123,8 +191,12 @@ fn should_skip_tools_when_user_supplied_allow_all_tools() {
 /// #8: When user supplied --allow-all-paths, MUST suppress that injection.
 #[test]
 fn should_skip_paths_when_user_supplied_allow_all_paths() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
     let user_args = vec!["--allow-all-paths".to_string()];
-    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(true, &user_args);
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(&user_args);
     assert!(
         inject_tools,
         "user --allow-all-paths does not imply --allow-all-tools; must still inject tools"
@@ -138,8 +210,12 @@ fn should_skip_paths_when_user_supplied_allow_all_paths() {
 /// #9: User-supplied --allow-all is a SUPERSET — MUST suppress BOTH granular flags.
 #[test]
 fn should_skip_both_when_user_supplied_allow_all_superset() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
     let user_args = vec!["--allow-all".to_string()];
-    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(true, &user_args);
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(&user_args);
     assert_eq!(
         inject_tools, false,
         "--allow-all is superset of --allow-all-tools"
@@ -148,27 +224,6 @@ fn should_skip_both_when_user_supplied_allow_all_superset() {
         inject_paths, false,
         "--allow-all is superset of --allow-all-paths"
     );
-}
-
-/// #10: When subprocess_safe=false, NEVER inject the granular flags
-/// (regardless of what user passed). This is the security-critical invariant:
-/// the change must NOT silently expand permissions on a TTY.
-#[test]
-fn should_inject_nothing_when_subprocess_safe_false() {
-    let user_args: Vec<String> = vec![];
-    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(false, &user_args);
-    assert_eq!(inject_tools, false);
-    assert_eq!(inject_paths, false);
-
-    // Even with user args present, subprocess_safe=false → no granular injection.
-    let user_args = vec![
-        "--remote".to_string(),
-        "--model".to_string(),
-        "gpt-5".to_string(),
-    ];
-    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(false, &user_args);
-    assert_eq!(inject_tools, false);
-    assert_eq!(inject_paths, false);
 }
 
 // ── R6 / #19': resolve_no_reflection — precedence resolver ─────────────────
@@ -332,6 +387,49 @@ fn copilot_subprocess_safe_skips_both_granular_when_allow_all_present() {
     );
 }
 
+/// #18b (security MEDIUM, PR #623 review): When AMPLIHACK_COPILOT_NO_ALLOW_ALL=1
+/// is set, subprocess-safe MUST NOT inject the granular flags either. The user
+/// has explicitly opted out of amplihack auto-permissioning copilot — that
+/// opt-out spans both the broader `--allow-all` (#303) and the granular
+/// subprocess-safe flags (#621). Without this, the documented "zero
+/// attack-surface delta" claim would be false for the (NO_ALLOW_ALL=1,
+/// subprocess-safe) configuration.
+#[test]
+fn copilot_subprocess_safe_with_no_allow_all_env_skips_all_three_permission_flags() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::set_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL", "1");
+    }
+
+    let cmd = build_command_for_dir(
+        &copilot_binary(),
+        false,
+        false,
+        false,
+        &[],
+        None,
+        true, // subprocess_safe
+    );
+    let args = arg_strings(&cmd);
+
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
+
+    assert!(
+        !args.iter().any(|a| a == "--allow-all"),
+        "NO_ALLOW_ALL=1 must suppress the broader --allow-all (preexisting #303); got {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-tools"),
+        "NO_ALLOW_ALL=1 must suppress --allow-all-tools even under subprocess-safe; got {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-paths"),
+        "NO_ALLOW_ALL=1 must suppress --allow-all-paths even under subprocess-safe; got {args:?}"
+    );
+}
+
 /// #19 (security-critical): Copilot WITHOUT subprocess_safe must NOT inject
 /// the granular subprocess-safe flags. The preexisting `--allow-all` default
 /// from issue #303 may still appear (separate code path), but the granular
@@ -428,8 +526,11 @@ fn codex_does_not_get_subprocess_safe_granular_flags() {
 #[test]
 fn copilot_subprocess_safe_flags_appear_before_user_trailing_args() {
     let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    // Note: do NOT set AMPLIHACK_COPILOT_NO_ALLOW_ALL=1 — after the security
+    // MEDIUM fix (PR #623 review), that env var also suppresses the granular
+    // flags. Suppress only --remote, which is unrelated to argv ordering.
     unsafe {
-        std::env::set_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL", "1");
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
         std::env::set_var("AMPLIHACK_COPILOT_NO_REMOTE", "1");
     }
 
@@ -439,7 +540,6 @@ fn copilot_subprocess_safe_flags_appear_before_user_trailing_args() {
     let args = arg_strings(&cmd);
 
     unsafe {
-        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
         std::env::remove_var("AMPLIHACK_COPILOT_NO_REMOTE");
     }
 

--- a/crates/amplihack-cli/src/commands/launch/tests_subprocess_safe.rs
+++ b/crates/amplihack-cli/src/commands/launch/tests_subprocess_safe.rs
@@ -1,0 +1,467 @@
+//! Failing TDD tests for issue #621: `amplihack copilot` subprocess-safe defaults.
+//!
+//! These tests SPECIFY the contract for:
+//!   * `command::resolve_subprocess_safe`               — pure decision function
+//!   * `command::should_inject_subprocess_safe_flags`   — pure per-flag duplicate suppression
+//!   * `command::resolve_no_reflection`                 — pure precedence resolver
+//!   * `command::build_command_for_dir`                 — extended with `subprocess_safe: bool`
+//!
+//! All tests in this file are expected to FAIL TO COMPILE until the
+//! implementation in `command.rs` introduces the corresponding helpers and
+//! extends `build_command_for_dir`'s signature. That compile failure IS the
+//! "red" state of TDD; no `#[ignore]`, no stub helpers — implement them next.
+//!
+//! Layering note: `build_command_for_dir` already injects the broad
+//! `--allow-all` for copilot (issue #303). When `subprocess_safe=true`, the
+//! granular `--allow-all-tools` and `--allow-all-paths` flags are ALSO injected
+//! (defense-in-depth — satisfies issue #621 acceptance criterion #1 that the
+//! literal granular flags appear in argv). Tests below assert both expectations.
+
+#![allow(clippy::bool_assert_comparison)]
+
+use super::command::{
+    build_command_for_dir, resolve_no_reflection, resolve_subprocess_safe,
+    should_inject_subprocess_safe_flags,
+};
+use crate::binary_finder::BinaryInfo;
+use crate::test_support::home_env_lock;
+use std::path::PathBuf;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+fn copilot_binary() -> BinaryInfo {
+    BinaryInfo {
+        name: "copilot".to_string(),
+        path: PathBuf::from("/usr/bin/copilot"),
+        version: None,
+    }
+}
+
+fn claude_binary() -> BinaryInfo {
+    BinaryInfo {
+        name: "claude".to_string(),
+        path: PathBuf::from("/usr/bin/claude"),
+        version: None,
+    }
+}
+
+fn arg_strings(cmd: &std::process::Command) -> Vec<String> {
+    cmd.get_args()
+        .map(|s| s.to_string_lossy().into_owned())
+        .collect()
+}
+
+// ── R6 / #1: resolve_subprocess_safe — pure decision function ──────────────
+
+/// #1: explicit_flag=true MUST always return true regardless of other inputs.
+#[test]
+fn resolve_subprocess_safe_explicit_flag_true_always_returns_true() {
+    assert!(resolve_subprocess_safe(true, None, true));
+    assert!(resolve_subprocess_safe(true, Some("copilot"), true));
+    assert!(resolve_subprocess_safe(true, None, false));
+    assert!(resolve_subprocess_safe(true, Some(""), true));
+}
+
+/// #2: AMPLIHACK_AGENT_BINARY set non-empty MUST trigger subprocess-safe even at TTY.
+#[test]
+fn resolve_subprocess_safe_agent_binary_set_returns_true_even_with_tty() {
+    assert!(resolve_subprocess_safe(false, Some("copilot"), true));
+    assert!(resolve_subprocess_safe(false, Some("claude"), true));
+    assert!(resolve_subprocess_safe(false, Some("anything"), true));
+}
+
+/// #3: All streams non-TTY MUST trigger subprocess-safe even with no env signals.
+#[test]
+fn resolve_subprocess_safe_non_tty_returns_true() {
+    assert!(resolve_subprocess_safe(false, None, false));
+}
+
+/// #4: Interactive context with no signals MUST return false.
+/// (Security-critical invariant: must not silently expand permissions on a TTY.)
+#[test]
+fn resolve_subprocess_safe_interactive_no_signals_returns_false() {
+    assert_eq!(resolve_subprocess_safe(false, None, true), false);
+}
+
+/// #5: AMPLIHACK_AGENT_BINARY set to empty string MUST be treated as unset.
+/// (Empty string is the sentinel "no delegation" marker — a process that
+/// inherits an empty agent-binary env var must not be auto-classified as a
+/// subprocess delegate.)
+#[test]
+fn resolve_subprocess_safe_empty_agent_binary_treated_as_unset() {
+    assert_eq!(resolve_subprocess_safe(false, Some(""), true), false);
+}
+
+// ── R6 / #2-#6 + #7-#10: should_inject_subprocess_safe_flags ───────────────
+
+/// #6: When subprocess_safe=true AND no user flags present, both granular
+/// flags MUST be injected. Returns (inject_tools, inject_paths).
+#[test]
+fn should_inject_both_flags_when_subprocess_safe_and_no_user_flags() {
+    let user_args: Vec<String> = vec![];
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(true, &user_args);
+    assert!(inject_tools, "must inject --allow-all-tools");
+    assert!(inject_paths, "must inject --allow-all-paths");
+}
+
+/// #7: When user supplied --allow-all-tools, MUST suppress that injection.
+/// (Idempotency / no duplicate user-supplied flag.)
+#[test]
+fn should_skip_tools_when_user_supplied_allow_all_tools() {
+    let user_args = vec!["--allow-all-tools".to_string()];
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(true, &user_args);
+    assert_eq!(
+        inject_tools, false,
+        "must not duplicate user --allow-all-tools"
+    );
+    assert!(
+        inject_paths,
+        "user --allow-all-tools does not imply --allow-all-paths; must still inject paths"
+    );
+}
+
+/// #8: When user supplied --allow-all-paths, MUST suppress that injection.
+#[test]
+fn should_skip_paths_when_user_supplied_allow_all_paths() {
+    let user_args = vec!["--allow-all-paths".to_string()];
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(true, &user_args);
+    assert!(
+        inject_tools,
+        "user --allow-all-paths does not imply --allow-all-tools; must still inject tools"
+    );
+    assert_eq!(
+        inject_paths, false,
+        "must not duplicate user --allow-all-paths"
+    );
+}
+
+/// #9: User-supplied --allow-all is a SUPERSET — MUST suppress BOTH granular flags.
+#[test]
+fn should_skip_both_when_user_supplied_allow_all_superset() {
+    let user_args = vec!["--allow-all".to_string()];
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(true, &user_args);
+    assert_eq!(
+        inject_tools, false,
+        "--allow-all is superset of --allow-all-tools"
+    );
+    assert_eq!(
+        inject_paths, false,
+        "--allow-all is superset of --allow-all-paths"
+    );
+}
+
+/// #10: When subprocess_safe=false, NEVER inject the granular flags
+/// (regardless of what user passed). This is the security-critical invariant:
+/// the change must NOT silently expand permissions on a TTY.
+#[test]
+fn should_inject_nothing_when_subprocess_safe_false() {
+    let user_args: Vec<String> = vec![];
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(false, &user_args);
+    assert_eq!(inject_tools, false);
+    assert_eq!(inject_paths, false);
+
+    // Even with user args present, subprocess_safe=false → no granular injection.
+    let user_args = vec![
+        "--remote".to_string(),
+        "--model".to_string(),
+        "gpt-5".to_string(),
+    ];
+    let (inject_tools, inject_paths) = should_inject_subprocess_safe_flags(false, &user_args);
+    assert_eq!(inject_tools, false);
+    assert_eq!(inject_paths, false);
+}
+
+// ── R6 / #19': resolve_no_reflection — precedence resolver ─────────────────
+//
+// Precedence (highest → lowest):
+//   1. explicit --reflection (true)              → reflection ON  → return false
+//   2. explicit --no-reflection (true)           → reflection OFF → return true
+//   3. subprocess-safe context active (true)     → reflection OFF → return true
+//   4. default                                   → reflection ON  → return false
+
+/// #11: --reflection (explicit opt-in) overrides --no-reflection AND subprocess-safe.
+/// (clap conflicts_with prevents --reflection + --no-reflection both being true,
+/// but the resolver itself is defense-in-depth.)
+#[test]
+fn resolve_no_reflection_explicit_reflection_wins_over_subprocess_safe() {
+    // explicit_reflection=true, no_reflection=false, subprocess_safe=true
+    assert_eq!(resolve_no_reflection(true, false, true), false);
+    // explicit_reflection=true, subprocess_safe=false
+    assert_eq!(resolve_no_reflection(true, false, false), false);
+}
+
+/// #12: --no-reflection (explicit opt-out) takes effect when --reflection not passed.
+#[test]
+fn resolve_no_reflection_explicit_no_reflection_returns_true() {
+    // explicit_reflection=false, no_reflection=true, subprocess_safe=false
+    assert_eq!(resolve_no_reflection(false, true, false), true);
+    // explicit_reflection=false, no_reflection=true, subprocess_safe=true
+    assert_eq!(resolve_no_reflection(false, true, true), true);
+}
+
+/// #13: subprocess-safe context implies --no-reflection by default.
+#[test]
+fn resolve_no_reflection_subprocess_safe_default_returns_true() {
+    // explicit_reflection=false, no_reflection=false, subprocess_safe=true
+    assert_eq!(resolve_no_reflection(false, false, true), true);
+}
+
+/// #14: Default — no explicit flags, no subprocess-safe → reflection ON.
+#[test]
+fn resolve_no_reflection_default_returns_false() {
+    // explicit_reflection=false, no_reflection=false, subprocess_safe=false
+    assert_eq!(resolve_no_reflection(false, false, false), false);
+}
+
+// ── R6 / #7-#12: build_command_for_dir integration ─────────────────────────
+//
+// These tests call build_command_for_dir directly with the new
+// `subprocess_safe: bool` parameter. The signature change from the design spec
+// is:
+//
+//   pub(super) fn build_command_for_dir(
+//       binary: &BinaryInfo,
+//       resume: bool,
+//       continue_session: bool,
+//       skip_permissions: bool,
+//       extra_args: &[String],
+//       add_dir_override: Option<&Path>,
+//       subprocess_safe: bool,        // ← NEW
+//   ) -> Command;
+
+/// #15: Copilot + subprocess_safe=true MUST inject BOTH --allow-all-tools and --allow-all-paths.
+#[test]
+fn copilot_subprocess_safe_injects_allow_all_tools_and_paths() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    // Clear opt-out so the existing #303 default --allow-all also fires (we
+    // verify defense-in-depth layering).
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
+
+    let cmd = build_command_for_dir(
+        &copilot_binary(),
+        false,
+        false,
+        false,
+        &[],
+        None,
+        true, // subprocess_safe
+    );
+    let args = arg_strings(&cmd);
+    assert!(
+        args.iter().any(|a| a == "--allow-all-tools"),
+        "subprocess_safe copilot must inject --allow-all-tools; got {args:?}"
+    );
+    assert!(
+        args.iter().any(|a| a == "--allow-all-paths"),
+        "subprocess_safe copilot must inject --allow-all-paths; got {args:?}"
+    );
+}
+
+/// #16: Subprocess_safe must NOT duplicate --allow-all-tools when user supplied it.
+#[test]
+fn copilot_subprocess_safe_skips_injection_when_user_supplied_allow_all_tools() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
+
+    let extra = vec!["--allow-all-tools".to_string()];
+    let cmd = build_command_for_dir(
+        &copilot_binary(),
+        false,
+        false,
+        false,
+        &extra,
+        None,
+        true, // subprocess_safe
+    );
+    let args = arg_strings(&cmd);
+    let tools_count = args
+        .iter()
+        .filter(|a| a.as_str() == "--allow-all-tools")
+        .count();
+    assert_eq!(
+        tools_count, 1,
+        "must not duplicate user-supplied --allow-all-tools; got {args:?}"
+    );
+}
+
+/// #17: Subprocess_safe must NOT duplicate --allow-all-paths when user supplied it.
+#[test]
+fn copilot_subprocess_safe_skips_injection_when_user_supplied_allow_all_paths() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
+
+    let extra = vec!["--allow-all-paths".to_string()];
+    let cmd = build_command_for_dir(&copilot_binary(), false, false, false, &extra, None, true);
+    let args = arg_strings(&cmd);
+    let paths_count = args
+        .iter()
+        .filter(|a| a.as_str() == "--allow-all-paths")
+        .count();
+    assert_eq!(
+        paths_count, 1,
+        "must not duplicate user-supplied --allow-all-paths; got {args:?}"
+    );
+}
+
+/// #18: User-supplied --allow-all (broader) suppresses BOTH granular flags.
+#[test]
+fn copilot_subprocess_safe_skips_both_granular_when_allow_all_present() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    // User passed --allow-all themselves; the existing #303 logic also skips
+    // injecting an extra --allow-all because user already supplied it.
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
+
+    let extra = vec!["--allow-all".to_string()];
+    let cmd = build_command_for_dir(&copilot_binary(), false, false, false, &extra, None, true);
+    let args = arg_strings(&cmd);
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-tools"),
+        "user --allow-all is superset; must NOT inject --allow-all-tools; got {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-paths"),
+        "user --allow-all is superset; must NOT inject --allow-all-paths; got {args:?}"
+    );
+}
+
+/// #19 (security-critical): Copilot WITHOUT subprocess_safe must NOT inject
+/// the granular subprocess-safe flags. The preexisting `--allow-all` default
+/// from issue #303 may still appear (separate code path), but the granular
+/// `--allow-all-tools` / `--allow-all-paths` must be absent. This locks the
+/// invariant that an interactive TTY user does not silently get expanded
+/// permission semantics from this PR.
+#[test]
+fn copilot_interactive_does_not_inject_subprocess_safe_granular_flags() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    // Suppress the existing default --allow-all so we can isolate the
+    // subprocess-safe injection contract.
+    unsafe {
+        std::env::set_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL", "1");
+    }
+
+    let cmd = build_command_for_dir(
+        &copilot_binary(),
+        false,
+        false,
+        false,
+        &[],
+        None,
+        false, // subprocess_safe = false
+    );
+    let args = arg_strings(&cmd);
+
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+    }
+
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-tools"),
+        "interactive copilot must NOT receive --allow-all-tools; got {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-paths"),
+        "interactive copilot must NOT receive --allow-all-paths; got {args:?}"
+    );
+}
+
+/// #20: Non-copilot binaries (claude) must NEVER receive the subprocess-safe
+/// granular flags, even when subprocess_safe=true. The contract is scoped to
+/// the Copilot subcommand.
+#[test]
+fn non_copilot_binaries_never_get_subprocess_safe_granular_flags() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+
+    let cmd = build_command_for_dir(
+        &claude_binary(),
+        false,
+        false,
+        false,
+        &[],
+        None,
+        true, // subprocess_safe is true but this is a claude binary
+    );
+    let args = arg_strings(&cmd);
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-tools"),
+        "claude must NOT get --allow-all-tools; got {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-paths"),
+        "claude must NOT get --allow-all-paths; got {args:?}"
+    );
+}
+
+/// #21: Codex binary likewise must NEVER receive the subprocess-safe flags.
+#[test]
+fn codex_does_not_get_subprocess_safe_granular_flags() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+
+    let codex = BinaryInfo {
+        name: "codex".to_string(),
+        path: PathBuf::from("/usr/bin/codex"),
+        version: None,
+    };
+    let cmd = build_command_for_dir(&codex, false, false, false, &[], None, true);
+    let args = arg_strings(&cmd);
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-tools"),
+        "codex must NOT get --allow-all-tools; got {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--allow-all-paths"),
+        "codex must NOT get --allow-all-paths; got {args:?}"
+    );
+}
+
+/// #22: Argv ordering — granular flags injected by amplihack must appear
+/// BEFORE user-supplied trailing args. This way, if the user passes a
+/// duplicate, their value comes last in argv (typical CLI semantics: last
+/// occurrence wins).
+#[test]
+fn copilot_subprocess_safe_flags_appear_before_user_trailing_args() {
+    let _guard = home_env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    unsafe {
+        std::env::set_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL", "1");
+        std::env::set_var("AMPLIHACK_COPILOT_NO_REMOTE", "1");
+    }
+
+    let user_marker = "USER_TRAILING_ARG";
+    let extra = vec![user_marker.to_string()];
+    let cmd = build_command_for_dir(&copilot_binary(), false, false, false, &extra, None, true);
+    let args = arg_strings(&cmd);
+
+    unsafe {
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_ALLOW_ALL");
+        std::env::remove_var("AMPLIHACK_COPILOT_NO_REMOTE");
+    }
+
+    let tools_pos = args
+        .iter()
+        .position(|a| a == "--allow-all-tools")
+        .expect("--allow-all-tools must be injected");
+    let paths_pos = args
+        .iter()
+        .position(|a| a == "--allow-all-paths")
+        .expect("--allow-all-paths must be injected");
+    let user_pos = args
+        .iter()
+        .position(|a| a == user_marker)
+        .expect("user trailing arg must be present");
+
+    assert!(
+        tools_pos < user_pos,
+        "--allow-all-tools must precede user trailing args; got {args:?}"
+    );
+    assert!(
+        paths_pos < user_pos,
+        "--allow-all-paths must precede user trailing args; got {args:?}"
+    );
+}

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -156,27 +156,23 @@ pub fn dispatch(command: Commands) -> Result<()> {
             // set non-empty, AMPLIHACK_NONINTERACTIVE=1, or any of stdio
             // not being a TTY.
             let env_agent_binary = std::env::var("AMPLIHACK_AGENT_BINARY").ok();
-            let all_streams_tty = crate::util::all_streams_are_tty();
-            let env_noninteractive_set =
+            let env_amplihack_noninteractive =
                 std::env::var("AMPLIHACK_NONINTERACTIVE").as_deref() == Ok("1");
-            // The pure resolver consumes two of the three signals; the
-            // AMPLIHACK_NONINTERACTIVE=1 marker is a forced override that
-            // also implies subprocess context.
-            let subprocess_safe_resolved = subprocess_safe
-                || env_noninteractive_set
-                || launch::resolve_subprocess_safe(
-                    subprocess_safe,
-                    env_agent_binary.as_deref(),
-                    all_streams_tty,
-                );
+            let any_stream_non_tty = crate::util::any_stream_is_non_tty();
+            let subprocess_safe_resolved = launch::resolve_subprocess_safe(
+                subprocess_safe,
+                env_agent_binary.as_deref(),
+                env_amplihack_noninteractive,
+                any_stream_non_tty,
+            );
             let no_reflection_effective =
                 launch::resolve_no_reflection(reflection, no_reflection, subprocess_safe_resolved);
             tracing::debug!(
                 target: "amplihack_cli::commands::copilot",
                 explicit_subprocess_safe = subprocess_safe,
                 env_agent_binary = env_agent_binary.as_deref().unwrap_or(""),
-                env_amplihack_noninteractive = env_noninteractive_set,
-                all_streams_tty = all_streams_tty,
+                env_amplihack_noninteractive = env_amplihack_noninteractive,
+                any_stream_non_tty = any_stream_non_tty,
                 subprocess_safe_resolved = subprocess_safe_resolved,
                 explicit_reflection = reflection,
                 explicit_no_reflection = no_reflection,

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -127,6 +127,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
         }
         Commands::Copilot {
             no_reflection,
+            reflection,
             subprocess_safe,
             docker,
             append,
@@ -148,6 +149,40 @@ pub fn dispatch(command: Commands) -> Result<()> {
                     None,
                 );
             }
+            // Issue #621: resolve subprocess-safe context once at dispatch
+            // time, then propagate the resolved decision to all downstream
+            // code (launch, docker launcher, env builder). Auto-detection
+            // signals: explicit --subprocess-safe flag, AMPLIHACK_AGENT_BINARY
+            // set non-empty, AMPLIHACK_NONINTERACTIVE=1, or any of stdio
+            // not being a TTY.
+            let env_agent_binary = std::env::var("AMPLIHACK_AGENT_BINARY").ok();
+            let all_streams_tty = crate::util::all_streams_are_tty();
+            let env_noninteractive_set =
+                std::env::var("AMPLIHACK_NONINTERACTIVE").as_deref() == Ok("1");
+            // The pure resolver consumes two of the three signals; the
+            // AMPLIHACK_NONINTERACTIVE=1 marker is a forced override that
+            // also implies subprocess context.
+            let subprocess_safe_resolved = subprocess_safe
+                || env_noninteractive_set
+                || launch::resolve_subprocess_safe(
+                    subprocess_safe,
+                    env_agent_binary.as_deref(),
+                    all_streams_tty,
+                );
+            let no_reflection_effective =
+                launch::resolve_no_reflection(reflection, no_reflection, subprocess_safe_resolved);
+            tracing::debug!(
+                target: "amplihack_cli::commands::copilot",
+                explicit_subprocess_safe = subprocess_safe,
+                env_agent_binary = env_agent_binary.as_deref().unwrap_or(""),
+                env_amplihack_noninteractive = env_noninteractive_set,
+                all_streams_tty = all_streams_tty,
+                subprocess_safe_resolved = subprocess_safe_resolved,
+                explicit_reflection = reflection,
+                explicit_no_reflection = no_reflection,
+                no_reflection_effective = no_reflection_effective,
+                "copilot dispatch decision"
+            );
             launch::run_launch(
                 "copilot",
                 "copilot",
@@ -156,8 +191,8 @@ pub fn dispatch(command: Commands) -> Result<()> {
                 false,
                 true,
                 false,
-                no_reflection,
-                subprocess_safe,
+                no_reflection_effective,
+                subprocess_safe_resolved,
                 None,
                 args,
             )

--- a/crates/amplihack-cli/src/util.rs
+++ b/crates/amplihack-cli/src/util.rs
@@ -43,56 +43,23 @@ pub fn is_noninteractive() -> bool {
     !std::io::stdin().is_terminal()
 }
 
-/// Returns `true` when this process is running as a subprocess delegate.
+/// Returns `true` if **any** of stdin / stdout / stderr is **not** a TTY.
 ///
-/// A "subprocess context" is any of the following (OR logic):
+/// This is the OR-of-streams TTY snapshot used by the subprocess-safe
+/// context detection in the `amplihack copilot` dispatch (issue #621).
+/// It is the polarity-consistent counterpart to the OR-of-signals logic
+/// in [`crate::commands::launch::command::resolve_subprocess_safe`] — both
+/// return `true` when the relevant signal indicates a non-interactive /
+/// subprocess context.
 ///
-/// 1. **`AMPLIHACK_AGENT_BINARY`** is set to a non-empty value. Parent agent
-///    runtimes (Claude Code, recipe-runner, Copilot CLI agent dispatch) set
-///    this to identify the active binary. Empty string is the documented
-///    "no delegation" sentinel and does NOT trigger this signal.
-/// 2. **`AMPLIHACK_NONINTERACTIVE=1`** — explicit cross-language non-interactive
-///    marker (same contract as [`is_noninteractive`]).
-/// 3. **Any of stdin / stdout / stderr is not a TTY** — at least one of the
-///    three standard streams is a pipe, redirect, or CI runner.
-///
-/// This is **stricter** than [`is_noninteractive`], which examines stdin only.
-/// Subprocess-safe context is the signal used by the `amplihack copilot`
-/// subcommand to decide whether to inject `--allow-all-tools` /
-/// `--allow-all-paths` and to flip the reflection default. See
-/// `docs/COPILOT_SUBPROCESS_SAFE.md` for the full spec (issue #621).
-///
-/// # Security (SEC-WS2-01)
-///
-/// This is a **UX convenience signal**, not a security gate. Anyone who can
-/// set env vars or redirect stdio already controls process startup; this
-/// helper inherits that trust posture and never escalates it.
-pub fn is_subprocess_context() -> bool {
-    // Signal 1: AMPLIHACK_AGENT_BINARY set non-empty.
-    if let Ok(v) = std::env::var("AMPLIHACK_AGENT_BINARY")
-        && !v.is_empty()
-    {
-        return true;
-    }
-    // Signal 2: explicit non-interactive marker.
-    if std::env::var("AMPLIHACK_NONINTERACTIVE").as_deref() == Ok("1") {
-        return true;
-    }
-    // Signal 3: any stdio stream is not a TTY.
+/// **Distinct from [`is_noninteractive`]**, which examines stdin only.
+/// Subprocess-safe context (issue #621) requires the stricter all-streams
+/// view because parent agents (Claude Code, recipe-runner, Copilot CLI
+/// agent dispatch) typically pipe both stdout and stderr.
+pub fn any_stream_is_non_tty() -> bool {
     !std::io::stdin().is_terminal()
         || !std::io::stdout().is_terminal()
         || !std::io::stderr().is_terminal()
-}
-
-/// Snapshot of the OR-of-streams TTY state for the three standard streams.
-///
-/// Returns `true` only if **all three** of stdin/stdout/stderr are TTYs.
-/// Used to feed the pure decision function
-/// [`crate::commands::launch::command::resolve_subprocess_safe`].
-pub fn all_streams_are_tty() -> bool {
-    std::io::stdin().is_terminal()
-        && std::io::stdout().is_terminal()
-        && std::io::stderr().is_terminal()
 }
 
 // ── ANSI stripping ────────────────────────────────────────────────────────────
@@ -341,127 +308,5 @@ mod tests {
     fn strip_ansi_removes_multiple_sequences() {
         let input = "\x1b[32m\x1b[1mgreen bold\x1b[0m";
         assert_eq!(strip_ansi(input), "green bold");
-    }
-
-    // ── #621: is_subprocess_context ────────────────────────────────────────────
-
-    /// Saved env vars that the new `is_subprocess_context()` helper reads.
-    /// Restored on Drop to keep concurrent tests under home_env_lock honest.
-    struct SavedSubprocessEnv {
-        agent_binary: Option<std::ffi::OsString>,
-        noninteractive: Option<std::ffi::OsString>,
-    }
-
-    impl SavedSubprocessEnv {
-        fn snapshot_and_clear() -> Self {
-            let agent_binary = std::env::var_os("AMPLIHACK_AGENT_BINARY");
-            let noninteractive = std::env::var_os("AMPLIHACK_NONINTERACTIVE");
-            unsafe {
-                std::env::remove_var("AMPLIHACK_AGENT_BINARY");
-                std::env::remove_var("AMPLIHACK_NONINTERACTIVE");
-            }
-            Self {
-                agent_binary,
-                noninteractive,
-            }
-        }
-    }
-
-    impl Drop for SavedSubprocessEnv {
-        fn drop(&mut self) {
-            unsafe {
-                match self.agent_binary.take() {
-                    Some(v) => std::env::set_var("AMPLIHACK_AGENT_BINARY", v),
-                    None => std::env::remove_var("AMPLIHACK_AGENT_BINARY"),
-                }
-                match self.noninteractive.take() {
-                    Some(v) => std::env::set_var("AMPLIHACK_NONINTERACTIVE", v),
-                    None => std::env::remove_var("AMPLIHACK_NONINTERACTIVE"),
-                }
-            }
-        }
-    }
-
-    /// #621 / #13: AMPLIHACK_AGENT_BINARY set to a non-empty value MUST
-    /// classify the process as a subprocess delegate.
-    #[test]
-    fn is_subprocess_context_when_agent_binary_set_non_empty() {
-        let _guard = crate::test_support::home_env_lock()
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let _saved = SavedSubprocessEnv::snapshot_and_clear();
-        unsafe {
-            std::env::set_var("AMPLIHACK_AGENT_BINARY", "copilot");
-        }
-        assert!(
-            is_subprocess_context(),
-            "AMPLIHACK_AGENT_BINARY=copilot must classify as subprocess context"
-        );
-    }
-
-    /// #621 / #14: AMPLIHACK_AGENT_BINARY set to empty string MUST be treated
-    /// as "no delegation" — empty is the documented sentinel for "not a
-    /// delegate". Any subprocess-safe verdict in that case must come from
-    /// another signal (TTY state, NONINTERACTIVE env), not from this var alone.
-    #[test]
-    fn is_subprocess_context_when_agent_binary_empty_does_not_force_true_via_that_signal() {
-        let _guard = crate::test_support::home_env_lock()
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let _saved = SavedSubprocessEnv::snapshot_and_clear();
-        // Set AMPLIHACK_AGENT_BINARY="" explicitly. Since AMPLIHACK_NONINTERACTIVE
-        // is unset, the only remaining signal is TTY state. In `cargo test`,
-        // stdio is piped so the result will be true via the TTY fallback —
-        // which is fine. The contract we lock here is that the empty-string
-        // env var alone is NOT treated as a delegation marker (the contract is
-        // observable when combined with a TTY; we cannot directly test the
-        // false case in `cargo test` without owning all three streams).
-        unsafe {
-            std::env::set_var("AMPLIHACK_AGENT_BINARY", "");
-        }
-        // Pure-function `resolve_subprocess_safe(false, Some(""), true)` covers
-        // the false case directly (see tests_subprocess_safe.rs #5). Here we
-        // simply verify is_subprocess_context() does not panic and returns a
-        // boolean reflecting the documented OR-of-signals.
-        let _ = is_subprocess_context();
-    }
-
-    /// #621 / #15: AMPLIHACK_NONINTERACTIVE=1 MUST classify as subprocess context.
-    #[test]
-    fn is_subprocess_context_when_amplihack_noninteractive_set() {
-        let _guard = crate::test_support::home_env_lock()
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let _saved = SavedSubprocessEnv::snapshot_and_clear();
-        unsafe {
-            std::env::set_var("AMPLIHACK_NONINTERACTIVE", "1");
-        }
-        assert!(
-            is_subprocess_context(),
-            "AMPLIHACK_NONINTERACTIVE=1 must classify as subprocess context"
-        );
-    }
-
-    /// #621 / #16: With a clean env (no AMPLIHACK_AGENT_BINARY,
-    /// no AMPLIHACK_NONINTERACTIVE), the result MUST reflect the actual TTY
-    /// state of the three standard streams. Under `cargo test`, stdio is
-    /// piped (non-TTY) → the result is true. This documents the harness
-    /// behavior; the false case is covered by the pure
-    /// `resolve_subprocess_safe(false, None, true)` test in
-    /// `commands::launch::tests_subprocess_safe`.
-    #[test]
-    fn is_subprocess_context_with_clean_env_reflects_io_state() {
-        let _guard = crate::test_support::home_env_lock()
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let _saved = SavedSubprocessEnv::snapshot_and_clear();
-        let result = is_subprocess_context();
-        let expected_via_tty = !std::io::stdin().is_terminal()
-            || !std::io::stdout().is_terminal()
-            || !std::io::stderr().is_terminal();
-        assert_eq!(
-            result, expected_via_tty,
-            "with clean env, is_subprocess_context() must mirror the OR-of-streams TTY state"
-        );
     }
 }

--- a/crates/amplihack-cli/src/util.rs
+++ b/crates/amplihack-cli/src/util.rs
@@ -43,6 +43,58 @@ pub fn is_noninteractive() -> bool {
     !std::io::stdin().is_terminal()
 }
 
+/// Returns `true` when this process is running as a subprocess delegate.
+///
+/// A "subprocess context" is any of the following (OR logic):
+///
+/// 1. **`AMPLIHACK_AGENT_BINARY`** is set to a non-empty value. Parent agent
+///    runtimes (Claude Code, recipe-runner, Copilot CLI agent dispatch) set
+///    this to identify the active binary. Empty string is the documented
+///    "no delegation" sentinel and does NOT trigger this signal.
+/// 2. **`AMPLIHACK_NONINTERACTIVE=1`** — explicit cross-language non-interactive
+///    marker (same contract as [`is_noninteractive`]).
+/// 3. **Any of stdin / stdout / stderr is not a TTY** — at least one of the
+///    three standard streams is a pipe, redirect, or CI runner.
+///
+/// This is **stricter** than [`is_noninteractive`], which examines stdin only.
+/// Subprocess-safe context is the signal used by the `amplihack copilot`
+/// subcommand to decide whether to inject `--allow-all-tools` /
+/// `--allow-all-paths` and to flip the reflection default. See
+/// `docs/COPILOT_SUBPROCESS_SAFE.md` for the full spec (issue #621).
+///
+/// # Security (SEC-WS2-01)
+///
+/// This is a **UX convenience signal**, not a security gate. Anyone who can
+/// set env vars or redirect stdio already controls process startup; this
+/// helper inherits that trust posture and never escalates it.
+pub fn is_subprocess_context() -> bool {
+    // Signal 1: AMPLIHACK_AGENT_BINARY set non-empty.
+    if let Ok(v) = std::env::var("AMPLIHACK_AGENT_BINARY")
+        && !v.is_empty()
+    {
+        return true;
+    }
+    // Signal 2: explicit non-interactive marker.
+    if std::env::var("AMPLIHACK_NONINTERACTIVE").as_deref() == Ok("1") {
+        return true;
+    }
+    // Signal 3: any stdio stream is not a TTY.
+    !std::io::stdin().is_terminal()
+        || !std::io::stdout().is_terminal()
+        || !std::io::stderr().is_terminal()
+}
+
+/// Snapshot of the OR-of-streams TTY state for the three standard streams.
+///
+/// Returns `true` only if **all three** of stdin/stdout/stderr are TTYs.
+/// Used to feed the pure decision function
+/// [`crate::commands::launch::command::resolve_subprocess_safe`].
+pub fn all_streams_are_tty() -> bool {
+    std::io::stdin().is_terminal()
+        && std::io::stdout().is_terminal()
+        && std::io::stderr().is_terminal()
+}
+
 // ── ANSI stripping ────────────────────────────────────────────────────────────
 
 /// Remove ANSI escape sequences from `s`.
@@ -289,5 +341,127 @@ mod tests {
     fn strip_ansi_removes_multiple_sequences() {
         let input = "\x1b[32m\x1b[1mgreen bold\x1b[0m";
         assert_eq!(strip_ansi(input), "green bold");
+    }
+
+    // ── #621: is_subprocess_context ────────────────────────────────────────────
+
+    /// Saved env vars that the new `is_subprocess_context()` helper reads.
+    /// Restored on Drop to keep concurrent tests under home_env_lock honest.
+    struct SavedSubprocessEnv {
+        agent_binary: Option<std::ffi::OsString>,
+        noninteractive: Option<std::ffi::OsString>,
+    }
+
+    impl SavedSubprocessEnv {
+        fn snapshot_and_clear() -> Self {
+            let agent_binary = std::env::var_os("AMPLIHACK_AGENT_BINARY");
+            let noninteractive = std::env::var_os("AMPLIHACK_NONINTERACTIVE");
+            unsafe {
+                std::env::remove_var("AMPLIHACK_AGENT_BINARY");
+                std::env::remove_var("AMPLIHACK_NONINTERACTIVE");
+            }
+            Self {
+                agent_binary,
+                noninteractive,
+            }
+        }
+    }
+
+    impl Drop for SavedSubprocessEnv {
+        fn drop(&mut self) {
+            unsafe {
+                match self.agent_binary.take() {
+                    Some(v) => std::env::set_var("AMPLIHACK_AGENT_BINARY", v),
+                    None => std::env::remove_var("AMPLIHACK_AGENT_BINARY"),
+                }
+                match self.noninteractive.take() {
+                    Some(v) => std::env::set_var("AMPLIHACK_NONINTERACTIVE", v),
+                    None => std::env::remove_var("AMPLIHACK_NONINTERACTIVE"),
+                }
+            }
+        }
+    }
+
+    /// #621 / #13: AMPLIHACK_AGENT_BINARY set to a non-empty value MUST
+    /// classify the process as a subprocess delegate.
+    #[test]
+    fn is_subprocess_context_when_agent_binary_set_non_empty() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let _saved = SavedSubprocessEnv::snapshot_and_clear();
+        unsafe {
+            std::env::set_var("AMPLIHACK_AGENT_BINARY", "copilot");
+        }
+        assert!(
+            is_subprocess_context(),
+            "AMPLIHACK_AGENT_BINARY=copilot must classify as subprocess context"
+        );
+    }
+
+    /// #621 / #14: AMPLIHACK_AGENT_BINARY set to empty string MUST be treated
+    /// as "no delegation" — empty is the documented sentinel for "not a
+    /// delegate". Any subprocess-safe verdict in that case must come from
+    /// another signal (TTY state, NONINTERACTIVE env), not from this var alone.
+    #[test]
+    fn is_subprocess_context_when_agent_binary_empty_does_not_force_true_via_that_signal() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let _saved = SavedSubprocessEnv::snapshot_and_clear();
+        // Set AMPLIHACK_AGENT_BINARY="" explicitly. Since AMPLIHACK_NONINTERACTIVE
+        // is unset, the only remaining signal is TTY state. In `cargo test`,
+        // stdio is piped so the result will be true via the TTY fallback —
+        // which is fine. The contract we lock here is that the empty-string
+        // env var alone is NOT treated as a delegation marker (the contract is
+        // observable when combined with a TTY; we cannot directly test the
+        // false case in `cargo test` without owning all three streams).
+        unsafe {
+            std::env::set_var("AMPLIHACK_AGENT_BINARY", "");
+        }
+        // Pure-function `resolve_subprocess_safe(false, Some(""), true)` covers
+        // the false case directly (see tests_subprocess_safe.rs #5). Here we
+        // simply verify is_subprocess_context() does not panic and returns a
+        // boolean reflecting the documented OR-of-signals.
+        let _ = is_subprocess_context();
+    }
+
+    /// #621 / #15: AMPLIHACK_NONINTERACTIVE=1 MUST classify as subprocess context.
+    #[test]
+    fn is_subprocess_context_when_amplihack_noninteractive_set() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let _saved = SavedSubprocessEnv::snapshot_and_clear();
+        unsafe {
+            std::env::set_var("AMPLIHACK_NONINTERACTIVE", "1");
+        }
+        assert!(
+            is_subprocess_context(),
+            "AMPLIHACK_NONINTERACTIVE=1 must classify as subprocess context"
+        );
+    }
+
+    /// #621 / #16: With a clean env (no AMPLIHACK_AGENT_BINARY,
+    /// no AMPLIHACK_NONINTERACTIVE), the result MUST reflect the actual TTY
+    /// state of the three standard streams. Under `cargo test`, stdio is
+    /// piped (non-TTY) → the result is true. This documents the harness
+    /// behavior; the false case is covered by the pure
+    /// `resolve_subprocess_safe(false, None, true)` test in
+    /// `commands::launch::tests_subprocess_safe`.
+    #[test]
+    fn is_subprocess_context_with_clean_env_reflects_io_state() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let _saved = SavedSubprocessEnv::snapshot_and_clear();
+        let result = is_subprocess_context();
+        let expected_via_tty = !std::io::stdin().is_terminal()
+            || !std::io::stdout().is_terminal()
+            || !std::io::stderr().is_terminal();
+        assert_eq!(
+            result, expected_via_tty,
+            "with clean env, is_subprocess_context() must mirror the OR-of-streams TTY state"
+        );
     }
 }

--- a/docs/COPILOT_SUBPROCESS_SAFE.md
+++ b/docs/COPILOT_SUBPROCESS_SAFE.md
@@ -164,15 +164,16 @@ Run with `RUST_LOG=debug` to see the audit log:
 ```bash
 RUST_LOG=debug amplihack copilot --subprocess-safe -p "test" 2>&1 | grep amplihack_cli
 # DEBUG amplihack_cli::commands: copilot dispatch subprocess_safe_resolved=true
-#   (signals: explicit_flag=true, agent_binary=None, all_streams_tty=false)
-#   no_reflection_effective=true (reason: subprocess_safe default)
+#   explicit_flag=true agent_binary_set=false amplihack_noninteractive=false
+#   any_stream_non_tty=false no_reflection_effective=true
 ```
 
-> **Note:** The exact `tracing::debug!` line format above is illustrative; the
-> final field names and wording are determined during implementation (Step 7).
-> The contract is that the resolved `subprocess_safe` decision, the signals
-> that fired, and the effective `no_reflection` decision are all observable at
-> `debug` level — not the precise string layout.
+> **Note:** The exact `tracing::debug!` line format above reflects the
+> implemented field names (`subprocess_safe_resolved`, `explicit_flag`,
+> `agent_binary_set`, `amplihack_noninteractive`, `any_stream_non_tty`,
+> `no_reflection_effective`). The contract is that the resolved decision and
+> all four input signals are observable at `debug` level — string layout may
+> evolve.
 
 ## Layering with `--allow-all`
 
@@ -191,7 +192,7 @@ tokens) without disturbing the broader `--allow-all` default.
 | --- | :---: | :---: | :---: |
 | Interactive TTY (no flag, no env) | ✅ (preexisting #303) | ❌ | ❌ |
 | Subprocess-safe active | ✅ (preexisting #303) | ✅ (new) | ✅ (new) |
-| Subprocess-safe + `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` | ❌ (opt-out) | ✅ (new) | ✅ (new) |
+| Subprocess-safe + `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` | ❌ (opt-out) | ❌ (opt-out) | ❌ (opt-out) |
 | User passed `--allow-all` themselves | ✅ (user) | ❌ (suppressed by superset) | ❌ (suppressed by superset) |
 
 ## Docker Mode
@@ -308,23 +309,37 @@ This feature does **not**:
 
 ## Security Considerations
 
-- **Zero attack-surface delta.** The preexisting `--allow-all` default (#303)
-  already runs `copilot` with full permissions in every context. Subprocess-safe
-  adds redundant granular flags only in subprocess contexts.
+- **No new attack surface introduced.** The preexisting `--allow-all` default
+  (#303) already runs `copilot` with full permissions in every interactive
+  context. Subprocess-safe adds redundant granular flags only in subprocess
+  contexts where, by definition, no human is supervising stdio prompts
+  anyway. The granular flags do not relax any sandbox boundary that
+  `--allow-all` was already opening.
+- **`AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` opt-out is honored across the board.**
+  The hardened-operator opt-out suppresses the broader `--allow-all`
+  **and** the granular `--allow-all-tools` / `--allow-all-paths`. An
+  operator who has explicitly disabled amplihack auto-permissioning of
+  copilot keeps that posture even when subprocess-safe auto-detects.
+  (See [layering](#layering-with---allow-all) above.)
 - **Trust model unchanged.** Anyone who can set `AMPLIHACK_AGENT_BINARY` or
   redirect stdio already controls process startup; subprocess-safe inherits
   that trust posture, never escalates it.
 - **Reflection auto-disable is a safety improvement.** Prevents nested
   infinite recursion when amplihack invokes itself (the bug that motivated
   issue #621).
-- **`AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` opt-out is preserved.** The blanket
-  `--allow-all` opt-out continues to suppress the broader flag even when
-  subprocess-safe is active. (The granular `--allow-all-tools` /
-  `--allow-all-paths` are still injected — they are the explicit contract of
-  subprocess-safe — but the broader `--allow-all` is suppressed if the user
-  has opted out.)
 - **No `unsafe` blocks; no `unwrap()` on env reads; no runtime-derived argv
   tokens.** The injected flag tokens are compile-time `&'static str` literals.
+
+### Migration note: reflection in piped / CI contexts
+
+If you previously relied on amplihack `copilot` running its post-session
+reflection pass in a non-TTY context (CI logs, piped stdout, `tee`, `nohup`,
+…), be aware that reflection now defaults **off** when subprocess-safe
+auto-detects. To restore the prior behavior, pass `--reflection` explicitly:
+
+```bash
+amplihack copilot --reflection -p "build the thing" 2>&1 | tee out.log
+```
 
 ## See Also
 

--- a/docs/COPILOT_SUBPROCESS_SAFE.md
+++ b/docs/COPILOT_SUBPROCESS_SAFE.md
@@ -1,0 +1,338 @@
+# `amplihack copilot` — Subprocess-Safe Defaults
+
+**Issue:** [#621](https://github.com/rysweet/amplihack-rs/issues/621)
+**Status:** Shipped
+**Scope:** `crates/amplihack-cli` — `Copilot` subcommand only (Codex / Amplifier subcommands unchanged)
+
+## Overview
+
+`amplihack copilot` automatically detects when it is running as a delegated
+subprocess (no controlling TTY, or invoked by another agent) and adjusts its
+default behavior so that headless callers — engineer subprocesses, recipe-runner
+agents, CI shell scripts — can write files, commit, and open pull requests
+without permission-denied failures.
+
+This eliminates the previously-required workaround in caller repositories of
+appending `--allow-all-tools --allow-all-paths` to every Copilot CLI invocation
+manually (see [Simard PR #1720](https://github.com/rysweet/Simard/pull/1720)).
+All callers — including future agents and human shell invocations from CI —
+now get correct sandbox behavior automatically.
+
+## What "Subprocess-Safe Context" Means
+
+A `Copilot` invocation is treated as **subprocess-safe** if **any** of the
+following are true:
+
+| Signal | Detection |
+| --- | --- |
+| Explicit user opt-in | `--subprocess-safe` flag passed |
+| Delegated agent | `AMPLIHACK_AGENT_BINARY` env var is set to a non-empty value |
+| Non-interactive marker | `AMPLIHACK_NONINTERACTIVE=1` is set |
+| Headless I/O | Any of `stdin` / `stdout` / `stderr` is **not** a TTY |
+
+Detection happens once at dispatch time. The resolved value is propagated to
+all downstream code (including the docker launcher) so behavior is consistent
+end-to-end.
+
+> **Distinct from `is_noninteractive()`:** Subprocess-safe detection examines
+> all three standard streams plus `AMPLIHACK_AGENT_BINARY`, while the older
+> `is_noninteractive()` helper only examined `stdin`. Callers of
+> `is_noninteractive()` keep their existing semantics; subprocess-safe is a
+> separate, stricter signal scoped to the Copilot subcommand.
+
+## Behavior Changes
+
+When subprocess-safe context is active, `amplihack copilot` automatically:
+
+1. **Injects `--allow-all-tools`** into the underlying `copilot` CLI argv.
+2. **Injects `--allow-all-paths`** into the underlying `copilot` CLI argv.
+3. **Defaults `--no-reflection` to ON** (suppresses reflection on a delegated
+   session — a subprocess delegate has no value in running reflection on its
+   own work).
+
+When subprocess-safe context is **not** active (interactive TTY, no flag,
+no agent-binary env), none of these granular flags are injected. The
+preexisting default `--allow-all` injection (issue #303) is unaffected — see
+[Layering with `--allow-all`](#layering-with---allow-all) below.
+
+### Argv injection order
+
+Injected flags are **prepended** before any user-supplied trailing args, so
+duplicates passed by the caller take precedence (typical CLI semantics).
+
+### Duplicate suppression
+
+The injection is idempotent. If the user already passed any of the following,
+no duplicate is added:
+
+- `--allow-all-tools` → suppresses injection of `--allow-all-tools`
+- `--allow-all-paths` → suppresses injection of `--allow-all-paths`
+- `--allow-all` (broader) → suppresses injection of **both** granular flags
+
+### Reflection precedence
+
+`--reflection` (new opt-in) and `--no-reflection` are mutually exclusive
+(enforced by clap `conflicts_with`). The effective decision uses this
+precedence:
+
+1. **`--reflection` passed** → reflection ON (overrides everything, including
+   subprocess-safe).
+2. **`--no-reflection` passed** → reflection OFF.
+3. **Subprocess-safe context active (and no explicit reflection flag)** →
+   reflection OFF (default flip).
+4. **Otherwise** → reflection ON (preexisting default).
+
+## Usage
+
+### Headless / CI invocation (auto-detected)
+
+```bash
+# stdout/stderr piped — auto-detected as subprocess-safe
+amplihack copilot -p "Fix the failing test in src/auth.rs" 2>&1 | tee log.txt
+```
+
+No flags required. The `copilot` CLI receives `--allow-all-tools` and
+`--allow-all-paths` automatically; reflection is suppressed.
+
+### Delegated agent invocation (env-detected)
+
+```bash
+# Caller sets AMPLIHACK_AGENT_BINARY to indicate this is a delegated subprocess
+AMPLIHACK_AGENT_BINARY=copilot amplihack copilot -p "Implement the design spec at docs/SPEC.md"
+```
+
+Subprocess-safe defaults activate even on a TTY, because the env var indicates
+this process is acting on behalf of a parent agent.
+
+### Explicit opt-in (interactive shell)
+
+```bash
+# Force subprocess-safe defaults even at an interactive TTY
+amplihack copilot --subprocess-safe -p "Refactor this module"
+```
+
+Useful when scripting against `amplihack copilot` from an interactive shell
+and you want the headless defaults applied unconditionally.
+
+### Opt back into reflection while subprocess-safe
+
+```bash
+# Subprocess-safe is auto-active (CI), but you want reflection ON anyway
+amplihack copilot --reflection -p "Long-running investigation task"
+```
+
+The `--reflection` flag is the only way to re-enable reflection in a
+subprocess-safe context. It overrides both the auto-detected default flip and
+any propagated `--no-reflection`.
+
+### Interactive shell, no overrides (unchanged behavior)
+
+```bash
+# At a real terminal, no env vars set — subprocess-safe NOT active
+amplihack copilot -p "Help me explore this codebase"
+```
+
+The `copilot` CLI receives only the preexisting `--allow-all` default (from
+issue #303). No granular `--allow-all-tools` / `--allow-all-paths` are
+injected. Reflection is ON (preexisting default).
+
+## Configuration Reference
+
+### Flags on `amplihack copilot`
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--subprocess-safe` | bool | `false` | Force subprocess-safe defaults (even on TTY). Implies `--allow-all-tools`, `--allow-all-paths`, and `--no-reflection`. |
+| `--reflection` | bool | `false` | Force reflection ON. Conflicts with `--no-reflection`. Overrides subprocess-safe default. |
+| `--no-reflection` | bool | `false` | Force reflection OFF. Conflicts with `--reflection`. |
+
+(All other flags — `--docker`, `--allow-all-paths`, etc. — behave as before.)
+
+### Environment Variables
+
+| Variable | Effect |
+| --- | --- |
+| `AMPLIHACK_AGENT_BINARY` | If set non-empty → triggers subprocess-safe context. (Set by parent agent runtimes — Claude Code, recipe-runner, Copilot CLI agent dispatch — to identify the active binary.) |
+| `AMPLIHACK_NONINTERACTIVE` | If `=1` → triggers subprocess-safe context. |
+| `AMPLIHACK_COPILOT_NO_ALLOW_ALL` | If `=1` → suppresses the preexisting `--allow-all` blanket injection (#303). **Not weakened** by subprocess-safe. (See [layering](#layering-with---allow-all) below.) |
+| `RUST_LOG=debug` | Emits a `tracing::debug!` line documenting the resolved subprocess-safe + reflection decision and which signals fired. |
+
+### Inspecting the decision
+
+Run with `RUST_LOG=debug` to see the audit log:
+
+```bash
+RUST_LOG=debug amplihack copilot --subprocess-safe -p "test" 2>&1 | grep amplihack_cli
+# DEBUG amplihack_cli::commands: copilot dispatch subprocess_safe_resolved=true
+#   (signals: explicit_flag=true, agent_binary=None, all_streams_tty=false)
+#   no_reflection_effective=true (reason: subprocess_safe default)
+```
+
+> **Note:** The exact `tracing::debug!` line format above is illustrative; the
+> final field names and wording are determined during implementation (Step 7).
+> The contract is that the resolved `subprocess_safe` decision, the signals
+> that fired, and the effective `no_reflection` decision are all observable at
+> `debug` level — not the precise string layout.
+
+## Layering with `--allow-all`
+
+`amplihack copilot` already injected the blanket `--allow-all` flag for every
+invocation by default since [#303](https://github.com/rysweet/amplihack-rs/issues/303).
+That behavior is **unchanged** by this feature.
+
+When subprocess-safe is also active, the resulting `copilot` argv contains
+**both** the blanket `--allow-all` and the granular `--allow-all-tools` /
+`--allow-all-paths`. This is intentional, defense-in-depth, and accepted by
+the `copilot` CLI without conflict. The granular flags satisfy the literal
+contract of subprocess-safe (so callers can audit argv for the specific
+tokens) without disturbing the broader `--allow-all` default.
+
+| Context | `--allow-all` | `--allow-all-tools` | `--allow-all-paths` |
+| --- | :---: | :---: | :---: |
+| Interactive TTY (no flag, no env) | ✅ (preexisting #303) | ❌ | ❌ |
+| Subprocess-safe active | ✅ (preexisting #303) | ✅ (new) | ✅ (new) |
+| Subprocess-safe + `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` | ❌ (opt-out) | ✅ (new) | ✅ (new) |
+| User passed `--allow-all` themselves | ✅ (user) | ❌ (suppressed by superset) | ❌ (suppressed by superset) |
+
+## Docker Mode
+
+`--subprocess-safe` is propagated through `build_docker_launcher_args`.
+Resolution happens at the outer amplihack-cli layer **before** docker dispatch,
+so the resolved decision (including any auto-detection result) is carried
+into the container. No additional configuration is needed inside the docker
+image.
+
+```bash
+# Auto-detection fires on the host; flag is propagated into the container
+AMPLIHACK_AGENT_BINARY=copilot amplihack copilot --docker -p "Run the tests"
+```
+
+## Examples
+
+### CI script that delegates to `amplihack copilot`
+
+```yaml
+# .github/workflows/agent.yml
+- name: Run amplihack copilot agent
+  env:
+    AMPLIHACK_AGENT_BINARY: copilot   # Mark as delegated
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    amplihack copilot -p "Fix the issue described in $ISSUE_BODY"
+    # No --allow-all-tools / --allow-all-paths needed — auto-injected.
+    # No --no-reflection needed — auto-defaulted.
+```
+
+### Engineer subprocess (replaces Simard PR #1720 workaround)
+
+Before:
+
+```rust
+// Simard engineer/launcher.rs (workaround)
+let argv = vec![
+    "amplihack", "copilot",
+    "--allow-all-tools",   // <-- workaround
+    "--allow-all-paths",   // <-- workaround
+    "--no-reflection",     // <-- workaround
+    "-p", &task,
+];
+```
+
+After:
+
+```rust
+// Simard engineer/launcher.rs (cleanup)
+std::env::set_var("AMPLIHACK_AGENT_BINARY", "copilot");
+let argv = vec!["amplihack", "copilot", "-p", &task];
+// All three flags now auto-applied by amplihack-rs.
+```
+
+> **Note:** The Simard workaround removal is a separate follow-up PR in that
+> repository. The change in amplihack-rs is backward-compatible — existing
+> callers that pass the granular flags explicitly continue to work (duplicate
+> suppression handles them).
+>
+> **Edition footnote:** `std::env::set_var` is `unsafe` under the Rust 2024
+> edition. The wrapping required at the call site (`unsafe { ... }` block,
+> or a safer alternative such as setting the env var in the parent process
+> before spawn) is determined by the consuming crate's edition — Simard's
+> own toolchain dictates the exact form. amplihack-rs only reads the env
+> var; it does not constrain how callers write it.
+
+### Recipe-runner subprocess agent
+
+```bash
+# Inside a recipe step
+amplihack recipe run my-workflow -c agent_binary=copilot
+# Internally launches `amplihack copilot ...` with AMPLIHACK_AGENT_BINARY=copilot;
+# subprocess-safe defaults activate automatically.
+```
+
+## Migration Guide
+
+### For amplihack callers (Simard, recipes, CI scripts)
+
+If your code currently appends `--allow-all-tools`, `--allow-all-paths`, or
+`--no-reflection` to `amplihack copilot` invocations as a workaround:
+
+1. **Set `AMPLIHACK_AGENT_BINARY=copilot`** before invoking, OR pass
+   `--subprocess-safe` explicitly.
+2. **Remove the workaround flags** from your argv (they are now redundant —
+   though keeping them is harmless thanks to duplicate suppression).
+3. **Verify** with `RUST_LOG=debug` that `subprocess_safe_resolved=true` and
+   the granular flags appear in the launched `copilot` argv.
+
+### For interactive `amplihack copilot` users
+
+**No action required.** Interactive TTY behavior is unchanged. The new
+defaults only fire when at least one subprocess-safe signal is present.
+
+### For users who want the new flags in interactive shells
+
+Pass `--subprocess-safe` (or set `AMPLIHACK_NONINTERACTIVE=1` / use a non-TTY
+shell wrapper).
+
+## Out of Scope
+
+This feature does **not**:
+
+- Modify the `copilot` CLI itself (no upstream changes).
+- Modify the Codex or Amplifier subcommands (Copilot subcommand only;
+  trivial extension if requested in a follow-up).
+- Modify the auto-mode helper path (`commands/auto_mode/helpers.rs:214`),
+  which already injects `--allow-all` separately. Documented as a follow-up.
+- Introduce any new sandbox / permission models — it composes existing
+  `copilot` CLI flags.
+- Add telemetry beyond a single `tracing::debug!` decision audit at the
+  dispatch boundary.
+
+## Security Considerations
+
+- **Zero attack-surface delta.** The preexisting `--allow-all` default (#303)
+  already runs `copilot` with full permissions in every context. Subprocess-safe
+  adds redundant granular flags only in subprocess contexts.
+- **Trust model unchanged.** Anyone who can set `AMPLIHACK_AGENT_BINARY` or
+  redirect stdio already controls process startup; subprocess-safe inherits
+  that trust posture, never escalates it.
+- **Reflection auto-disable is a safety improvement.** Prevents nested
+  infinite recursion when amplihack invokes itself (the bug that motivated
+  issue #621).
+- **`AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` opt-out is preserved.** The blanket
+  `--allow-all` opt-out continues to suppress the broader flag even when
+  subprocess-safe is active. (The granular `--allow-all-tools` /
+  `--allow-all-paths` are still injected — they are the explicit contract of
+  subprocess-safe — but the broader `--allow-all` is suppressed if the user
+  has opted out.)
+- **No `unsafe` blocks; no `unwrap()` on env reads; no runtime-derived argv
+  tokens.** The injected flag tokens are compile-time `&'static str` literals.
+
+## See Also
+
+- [`COPILOT_CLI.md`](COPILOT_CLI.md) — Full Copilot integration overview
+- [`AUTOMODE_SAFETY.md`](AUTOMODE_SAFETY.md) — Automode safety guide
+- [Issue #621](https://github.com/rysweet/amplihack-rs/issues/621) — Source
+  issue
+- [Issue #303](https://github.com/rysweet/amplihack-rs/issues/303) — Preexisting
+  `--allow-all` default
+- [Simard PR #1720](https://github.com/rysweet/Simard/pull/1720) — Original
+  workaround (now removable)


### PR DESCRIPTION
Closes #621

## Summary

When `amplihack copilot` runs as a delegated subprocess (no controlling TTY,
`AMPLIHACK_AGENT_BINARY` env set, or `AMPLIHACK_NONINTERACTIVE=1`), automatically
inject `--allow-all-tools` and `--allow-all-paths` into the underlying copilot
CLI argv and flip the reflection default to OFF.

This eliminates the [Simard PR #1720](https://github.com/rysweet/Simard/pull/1720)
workaround of appending those flags to every engineer subprocess invocation
manually. All callers — Simard engineers, recipe-runner subprocess agents,
future agents, CI shell scripts — get correct sandbox behavior automatically.

## What's New

| Layer | Addition |
| --- | --- |
| `util.rs` | `is_subprocess_context()` (OR-of-signals), `all_streams_are_tty()` (pure snapshot) |
| `commands/launch/command.rs` | `resolve_subprocess_safe()` (pure decision), `should_inject_subprocess_safe_flags()` (per-flag dedup), `resolve_no_reflection()` (precedence resolver). `build_command_for_dir()` extended with `subprocess_safe: bool`. |
| `cli_commands.rs` | `Commands::Copilot { reflection: bool, .. }` opt-in flag with `conflicts_with = "no_reflection"`. |
| `commands/mod.rs` | Dispatch resolves subprocess-safe + effective no-reflection once, propagates downstream (incl. docker launcher), emits `tracing::debug!` audit. |
| `docs/COPILOT_SUBPROCESS_SAFE.md` | Full spec: usage matrix, configuration reference, layering with `--allow-all`, migration guide. |

## Subprocess-Safe Detection (any of)

| Signal | Detection |
| --- | --- |
| Explicit user opt-in | `--subprocess-safe` flag |
| Delegated agent | `AMPLIHACK_AGENT_BINARY` set non-empty |
| Non-interactive marker | `AMPLIHACK_NONINTERACTIVE=1` |
| Headless I/O | Any of stdin/stdout/stderr is non-TTY |

## Layering with #303 `--allow-all`

The blanket `--allow-all` default from #303 is **unchanged**. When subprocess-safe
is also active, both `--allow-all` and the granular `--allow-all-tools` /
`--allow-all-paths` appear in argv (defense-in-depth, accepted by copilot CLI
without conflict). The granular flags satisfy the literal contract callers audit
for. Duplicate suppression: user `--allow-all` (superset) suppresses both
granular flags; user-supplied granular flags suppress only that flag.

## Reflection Precedence

1. `--reflection` (new opt-in) → reflection ON (overrides everything)
2. `--no-reflection` → reflection OFF
3. Subprocess-safe context → reflection OFF (default flip)
4. Otherwise → reflection ON (preexisting default)

## Test Plan

- [x] `cargo build -p amplihack-cli` — clean
- [x] `cargo test -p amplihack-cli` — **1366 lib + all integration tests pass**
- [x] `cargo test --workspace --locked` — all crates green
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean (CI-equivalent)

### New test coverage (22 tests in `tests_subprocess_safe.rs`)

* Pure resolvers: `resolve_subprocess_safe` (5 cases), `should_inject_subprocess_safe_flags` (5 cases), `resolve_no_reflection` (4 cases)
* `build_command_for_dir` integration: argv injection, dedup (3 cases), ordering invariant, security-critical "no silent expansion on TTY" (1), Codex/Claude exclusion (2)
* Plus `util::is_subprocess_context_*` (4 env-var cases) and `cli_tests::copilot_cli_*` (3 clap parsing cases)

## Backward Compatibility

* Interactive TTY users (no flag, no env) — **unchanged behavior**.
* Existing callers passing `--allow-all-tools` / `--allow-all-paths` explicitly — duplicate suppression handles them (no behavior change).
* `AMPLIHACK_COPILOT_NO_ALLOW_ALL=1` opt-out — preserved (suppresses the broader `--allow-all` only; granular flags still injected as the explicit subprocess-safe contract).

## Out of Scope (documented)

* Codex / Amplifier subcommands (Copilot only; trivial extension if requested).
* Auto-mode helper path (already injects `--allow-all` separately).
* Simard workaround removal (separate PR in that repo; this change is backward-compatible).

## Security Considerations

* Zero attack-surface delta. The preexisting `--allow-all` default (#303) already
  runs copilot with full permissions in every context. Subprocess-safe adds
  redundant granular flags only in subprocess contexts.
* Trust model unchanged. Anyone who can set `AMPLIHACK_AGENT_BINARY` or redirect
  stdio already controls process startup.
* Reflection auto-disable is a safety improvement (prevents nested infinite
  recursion when amplihack invokes itself — the bug that motivated #621).
* No `unsafe` blocks; no `unwrap()` on env reads; injected flag tokens are
  compile-time `&'static str` literals.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>