### PR TITLE
fix(#625): NotLaunch precedence over SubprocessSafe in classify_skip_reason

### DIFF
--- a/crates/amplihack-cli/src/update/check.rs
+++ b/crates/amplihack-cli/src/update/check.rs
@@ -238,12 +238,17 @@ pub(super) fn should_skip_update_check(args: &[OsString]) -> bool {
 /// Precedence (first match wins):
 ///   1. ExplicitOptOut: `AMPLIHACK_NO_UPDATE_CHECK=1` or
 ///      `AMPLIHACK_PARITY_TEST=1`. Silent — never emits the skip-line.
-///   2. SubprocessSafe (env): `AMPLIHACK_NONINTERACTIVE` non-empty,
+///   2. NotLaunch: `args[1]` is not in
+///      `{launch, claude, copilot, codex, amplifier}`. Silent — the check
+///      would never have fired for this subcommand, so there is nothing to
+///      announce as "suppressed". This MUST take precedence over the
+///      SubprocessSafe checks below: per spec, the skip-line is only emitted
+///      when the invocation WOULD have triggered the check (recognized launch
+///      subcommand) but a subprocess-safe signal suppressed it.
+///   3. SubprocessSafe (env): `AMPLIHACK_NONINTERACTIVE` non-empty,
 ///      `AMPLIHACK_AGENT_BINARY` non-empty, or `CI` non-empty.
-///   3. SubprocessSafe (argv): linear OsStr-equality scan of `args[1..]`
+///   4. SubprocessSafe (argv): linear OsStr-equality scan of `args[1..]`
 ///      for the literal `--subprocess-safe` long flag.
-///   4. NotLaunch: `args[1]` is not in
-///      `{launch, claude, copilot, codex, amplifier}`.
 ///
 /// `None` only when a recognized launch subcommand is invoked AND no other
 /// signal fires.
@@ -257,7 +262,22 @@ pub(super) fn classify_skip_reason(args: &[OsString]) -> Option<SkipReason> {
         return Some(SkipReason::ExplicitOptOut);
     }
 
-    // (2) SubprocessSafe via env — emit the skip-line.
+    // (2) NotLaunch: silent passthrough for non-launch subcommands.
+    //
+    // This MUST run before the SubprocessSafe checks — see precedence note in
+    // the doc-comment above. For e.g. `amplihack --version` running inside an
+    // agent subprocess (AMPLIHACK_AGENT_BINARY=copilot), we want pure
+    // passthrough with no extra stderr noise, since the update check was
+    // never going to fire for `--version` regardless.
+    let first_arg = args.get(1).and_then(|arg| arg.to_str());
+    if !matches!(
+        first_arg,
+        Some("launch") | Some("claude") | Some("copilot") | Some("codex") | Some("amplifier")
+    ) {
+        return Some(SkipReason::NotLaunch);
+    }
+
+    // (3) SubprocessSafe via env — emit the skip-line.
     //
     // Each var is treated as an opaque presence signal: any non-empty value
     // triggers skip. Empty string is the documented "no delegation" sentinel
@@ -274,22 +294,13 @@ pub(super) fn classify_skip_reason(args: &[OsString]) -> Option<SkipReason> {
         return Some(SkipReason::SubprocessSafe);
     }
 
-    // (3) SubprocessSafe via argv: linear OsStr-equality scan for the
+    // (4) SubprocessSafe via argv: linear OsStr-equality scan for the
     // literal `--subprocess-safe` clap long flag. We scan pre-clap so the
     // skip can fire before any update I/O. Match must be by full equality
     // so e.g. `--subprocess-safe-foo` or `--no-subprocess-safe` do NOT count.
     let needle = std::ffi::OsStr::new(SUBPROCESS_SAFE_ARG);
     if args.iter().skip(1).any(|a| a.as_os_str() == needle) {
         return Some(SkipReason::SubprocessSafe);
-    }
-
-    // (4) NotLaunch: silent passthrough for non-launch subcommands.
-    let first_arg = args.get(1).and_then(|arg| arg.to_str());
-    if !matches!(
-        first_arg,
-        Some("launch") | Some("claude") | Some("copilot") | Some("codex") | Some("amplifier")
-    ) {
-        return Some(SkipReason::NotLaunch);
     }
 
     None

--- a/crates/amplihack-cli/src/update/tests.rs
+++ b/crates/amplihack-cli/src/update/tests.rs
@@ -1,4 +1,5 @@
 use super::check::should_skip_update_check;
+use super::check::{SkipReason, classify_skip_reason};
 use super::install::{binary_filename, extract_archive, find_binary};
 use super::network::{
     github_error_message, is_retryable_error, parse_latest_release, validate_download_url,
@@ -838,6 +839,66 @@ fn should_not_skip_update_check_when_no_signals_set_for_launch_subcommand() {
     assert!(
         !should_skip_update_check(&[OsString::from("amplihack"), OsString::from("copilot")]),
         "with all skip-signal env vars cleared, a launch subcommand must NOT skip"
+    );
+}
+
+#[test]
+fn classify_skip_reason_for_non_launch_subcommand_returns_not_launch_even_with_env_signals() {
+    // Regression test for issue #625 outside-in finding: when stdin is a
+    // TTY and the subcommand is non-launch (e.g. `amplihack --version`),
+    // BUT a SubprocessSafe env signal is set (as is common inside agent
+    // subprocesses where AMPLIHACK_AGENT_BINARY=copilot is exported), the
+    // classification MUST resolve to NotLaunch, not SubprocessSafe.
+    //
+    // Per spec: "Do NOT emit for AMPLIHACK_NO_UPDATE_CHECK / AMPLIHACK_PARITY_TEST
+    // or for non-launch subcommands." If SubprocessSafe took precedence over
+    // NotLaunch, then `amplihack --version` running inside an agent subprocess
+    // would unnecessarily emit the skip-line for a subcommand that never
+    // would have triggered the update check in the first place.
+    let _lock = crate::test_support::env_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _env = SkipSignalEnvGuard::capture_and_clear();
+
+    // Set every SubprocessSafe env signal simultaneously to prove that
+    // NotLaunch wins over all of them when the subcommand is non-launch.
+    unsafe {
+        std::env::set_var("AMPLIHACK_NONINTERACTIVE", "1");
+        std::env::set_var("AMPLIHACK_AGENT_BINARY", "copilot");
+        std::env::set_var("CI", "true");
+    }
+
+    for non_launch in ["--version", "--help", "version", "update", "doctor"] {
+        let args = [OsString::from("amplihack"), OsString::from(non_launch)];
+        let reason = classify_skip_reason(&args);
+        assert_eq!(
+            reason,
+            Some(SkipReason::NotLaunch),
+            "non-launch subcommand `{non_launch}` MUST classify as NotLaunch \
+             (silent passthrough), not SubprocessSafe, even when every \
+             SubprocessSafe env signal is set; got {reason:?}. \
+             This protects `amplihack --version` from emitting the skip-line \
+             when run inside an agent subprocess."
+        );
+    }
+}
+
+#[test]
+fn classify_skip_reason_explicit_opt_out_wins_over_not_launch_for_non_launch_subcommand() {
+    // ExplicitOptOut takes precedence over NotLaunch (both silent — order
+    // is observable only via the SkipReason variant returned).
+    let _lock = crate::test_support::env_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _env = SkipSignalEnvGuard::capture_and_clear();
+    unsafe { std::env::set_var(NO_UPDATE_CHECK_ENV, "1") };
+    let args = [OsString::from("amplihack"), OsString::from("--version")];
+    assert_eq!(
+        classify_skip_reason(&args),
+        Some(SkipReason::ExplicitOptOut),
+        "ExplicitOptOut MUST take precedence over NotLaunch so the variant \
+         accurately reflects user intent (preserved for future telemetry / \
+         debug logging hooks)"
     );
 }
 

--- a/crates/amplihack-cli/tests/issue_625_update_prompt_subprocess_safe.rs
+++ b/crates/amplihack-cli/tests/issue_625_update_prompt_subprocess_safe.rs
@@ -297,6 +297,45 @@ fn non_launch_subcommand_does_not_emit_skip_line() {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Test 5b — non-launch subcommand WITH SubprocessSafe env signals: STILL silent.
+// Regression test for the outside-in finding that NotLaunch must take precedence
+// over SubprocessSafe env vars in `classify_skip_reason`. Per spec: "Do NOT emit
+// for AMPLIHACK_NO_UPDATE_CHECK / AMPLIHACK_PARITY_TEST or for non-launch
+// subcommands." Real-world impact: `amplihack --version` running inside an
+// agent subprocess (where AMPLIHACK_AGENT_BINARY=copilot is exported) must
+// remain pure passthrough with no skip-line noise on stderr.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn non_launch_subcommand_stays_silent_under_subprocess_safe_env() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let mut cmd = cmd_with_clean_env(home.path());
+    // Set every SubprocessSafe env signal simultaneously to prove that
+    // NotLaunch wins for `--version` regardless.
+    cmd.env("AMPLIHACK_NONINTERACTIVE", "1");
+    cmd.env("AMPLIHACK_AGENT_BINARY", "copilot");
+    cmd.env("CI", "true");
+    cmd.arg("--version");
+
+    let (stdout, stderr) = run_with_timeout(cmd, Duration::from_secs(15));
+
+    assert!(
+        !stderr.contains(SKIP_LINE),
+        "skip-line must NOT print for `amplihack --version` even when every \
+         SubprocessSafe env signal is set — non-launch subcommands stay silent. \
+         stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(PROMPT_FRAGMENT) && !stdout.contains(PROMPT_FRAGMENT),
+        "prompt must NOT print for `amplihack --version`; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("amplihack ") || stderr.contains("amplihack "),
+        "version output must still print; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Test 6 — explicit opt-out via AMPLIHACK_NO_UPDATE_CHECK=1: silent skip.
 // MUST NOT emit the skip-line (this is an ExplicitOptOut, not SubprocessSafe).
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up fix for issue #625, surfaced by Step 13 outside-in testing of PR #628.

PR #628 added the `SUBPROCESS_SAFE_SKIP_LINE` ("`amplihack: skipping update check (subprocess-safe / no TTY)`") for `launch`/`copilot`/`claude`/`codex`/`amplifier` subcommands when any subprocess-safe signal is set. Outside-in testing revealed that the line ALSO printed for non-launch subcommands like `amplihack --version` whenever a SubprocessSafe env signal (`CI`, `AMPLIHACK_AGENT_BINARY`, `AMPLIHACK_NONINTERACTIVE`) was exported in the parent shell — which is the normal case inside agent subprocesses.

Per the issue #625 spec: *"Do NOT emit for AMPLIHACK_NO_UPDATE_CHECK / AMPLIHACK_PARITY_TEST or for non-launch subcommands."* The skip-line is only meaningful when the update check WOULD have triggered.

## Root cause

In `classify_skip_reason` (PR #628), the precedence put SubprocessSafe (env + argv) BEFORE NotLaunch:

```
1. ExplicitOptOut
2. SubprocessSafe (env)   ← fires for any non-launch subcommand too
3. SubprocessSafe (argv)  ← fires for any non-launch subcommand too
4. NotLaunch
```

Result: `amplihack --version` running with `CI=true` returned `Some(SubprocessSafe)` and emitted the skip-line, even though the update check would never have fired for `--version` regardless.

## Fix

Reorder precedence in `crates/amplihack-cli/src/update/check.rs`:

```
1. ExplicitOptOut         (silent)
2. NotLaunch              (silent — NEW position)
3. SubprocessSafe via env (skip-line)
4. SubprocessSafe via argv (skip-line)
```

ExplicitOptOut still wins over NotLaunch so the `SkipReason` variant accurately reflects user intent (preserves the variant for any future telemetry / debug-log hook).

## Step 13: Local Testing Results

### Scenario 1 — original issue #625 reproducer (subprocess-safe launch under no-TTY)
Command: `AMPLIHACK_TEST_FAKE_LATEST_VERSION=99.99.99 amplihack copilot --help </dev/null`
Result: **PASS**
Output:
```
amplihack: skipping update check (subprocess-safe / no TTY)
Launch GitHub Copilot CLI
…
real0m0.004s
```
Exits in 4ms. Skip-line printed. No prompt hang.

### Scenario 2 — regression: non-launch subcommand under every SubprocessSafe env signal
Command: `AMPLIHACK_NONINTERACTIVE=1 AMPLIHACK_AGENT_BINARY=copilot CI=true amplihack --version`
Result: **PASS** (after this fix; **FAIL** before)
Output before this fix:
```
amplihack: skipping update check (subprocess-safe / no TTY)
amplihack 0.9.3
```
Output after this fix:
```
amplihack 0.9.3
```
Skip-line correctly suppressed for non-launch subcommand.

### Additional validation (all 5 subprocess-safe signals × launch subcommand)
| Signal | skip-line emitted? | Prompt hang? |
|---|---|---|
| `AMPLIHACK_NONINTERACTIVE=1` | ✅ yes | ✅ no |
| `AMPLIHACK_AGENT_BINARY=copilot` | ✅ yes | ✅ no |
| `CI=true` | ✅ yes | ✅ no |
| `CI=1` | ✅ yes | ✅ no |
| stdin not a TTY | ✅ yes | ✅ no |
| `--subprocess-safe` argv | ✅ yes | ✅ no |
| `AMPLIHACK_NO_UPDATE_CHECK=1` (ExplicitOptOut) | ✅ silent | ✅ no |
| `AMPLIHACK_PARITY_TEST=1` (ExplicitOptOut) | ✅ silent | ✅ no |

## Tests added

* `crates/amplihack-cli/src/update/tests.rs`:
  - `classify_skip_reason_for_non_launch_subcommand_returns_not_launch_even_with_env_signals` — proves NotLaunch wins over every SubprocessSafe env signal for `--version`, `--help`, `version`, `update`, `doctor`.
  - `classify_skip_reason_explicit_opt_out_wins_over_not_launch_for_non_launch_subcommand` — proves ExplicitOptOut still wins over NotLaunch.

* `crates/amplihack-cli/tests/issue_625_update_prompt_subprocess_safe.rs`:
  - `non_launch_subcommand_stays_silent_under_subprocess_safe_env` — outside-in regression: spawns the binary with all three env signals set and asserts the skip-line is absent for `--version`.

## Test results

* 124 update unit tests pass (122 + 2 new precedence tests).
* 11 issue_625 integration tests pass (10 + 1 new regression test).
* PTY harness still verifies the interactive 5s timeout.
* 1455 total `amplihack-cli` lib tests pass; 0 regressions.

## Out of scope

* No change to the public `should_skip_update_check` boolean contract.
* No change to ExplicitOptOut / network short-circuit / PTY timeout logic.
* No use of `gh pr merge --admin` (forbidden by user policy).

Closes nothing — issue #625 was already CLOSED by PR #628; this is a forward fix for a finding that surfaced *during* outside-in verification of that merge.


---

## Step 16b: Outside-In Testing Results

**Date**: 2026-05-13
**Method**: User-equivalent install via `uvx --from git+https://github.com/rysweet/amplihack-rs.git@fix/issue-625-followup-not-launch-precedence amplihack <args>` (compiled from source via cargo install, ~4 minutes one-time build, then cached).
**Branch tested**: `fix/issue-625-followup-not-launch-precedence` @ commit `815a840` (== merge commit `6be1726` on `main`).
**Fix iterations needed during outside-in testing**: 0.

### Scenarios Executed

| # | Scenario | Command | Expected | Result |
|---|---|---|---|---|
| 1 | **Original issue #625 reproducer** — subprocess (no TTY) + advertised newer release | `AMPLIHACK_TEST_FAKE_LATEST_VERSION=99.99.99 uvx ... amplihack copilot --help </dev/null` | exit ≤7s; skip-line printed; no prompt | ✅ **PASS** — exit 0s, skip-line present |
| 2 | `AMPLIHACK_NONINTERACTIVE=1` (preserved signal) | `AMPLIHACK_NONINTERACTIVE=1 ... amplihack copilot --help` | skip-line=1, prompt=0, exit <2s | ✅ **PASS** — 1s |
| 3 | `--subprocess-safe` argv flag | `... amplihack copilot --subprocess-safe --help` | skip-line=1, prompt=0 | ✅ **PASS** — 0s |
| 4 | `AMPLIHACK_AGENT_BINARY=copilot` env (NEW signal) | `AMPLIHACK_AGENT_BINARY=copilot ... amplihack copilot --help` | skip-line=1, prompt=0 | ✅ **PASS** — 0s |
| 5 | `CI=true` env (NEW signal) | `CI=true ... amplihack copilot --help` | skip-line=1, prompt=0 | ✅ **PASS** — 1s |
| 6 | **Non-launch passthrough** (regression target of this PR) | `... amplihack --help` | skip-line=0, prompt=0 (silent) | ✅ **PASS** — 0s, no skip line |
| 7 | **Interactive PTY** — real TTY, no skip signals, advertised new release | `AMPLIHACK_TEST_FAKE_LATEST_VERSION=99.99.99 amplihack copilot --help` under `pty.fork()` | prompt printed; 5s hard timeout fires; exit ≤7.5s; no skip line | ✅ **PASS** — `elapsed=5.01s`, prompt seen, no skip line |

### Key Output (Scenario 7 — proves both halves of fix)
```
elapsed=5.01s
A newer version of amplihack is available (v0.9.32). Run 'amplihack update' to upgrade.
Update now? [y/N] (5s timeout):
Launch GitHub Copilot CLI
...
prompt_seen=True  skip_seen=False  exit_within_7_5s=True
RESULT: PASS
```

### Verdict
- **7 of 7 outside-in scenarios PASS**.
- **0 fix iterations needed** — the merged fix (PR #628 + this PR #629) handles all 5 subprocess-safe signals, preserves silent ExplicitOptOut, suppresses skip-line for non-launch subcommands, and preserves the interactive 5s hard wall-clock timeout (`libc::poll`).
- Original issue #625 reproducer (the indefinite hang) is fully resolved end-to-end as a user would experience via `uvx`.
