### PR TITLE
fix: investigation-workflow context propagation (#594)

### DIFF
--- a/amplifier-bundle/recipes/investigation-prep.yaml
+++ b/amplifier-bundle/recipes/investigation-prep.yaml
@@ -64,6 +64,19 @@ steps:
       fi
     output: "investigation_question"
 
+  # Issue #594: normalize repo_path → codebase_path so direct invocation
+  # (`amplihack recipe run investigation-workflow -c repo_path=.`) propagates
+  # the path to downstream prompts that read {{codebase_path}}.
+  - id: "normalize-codebase-path"
+    type: "bash"
+    command: |
+      if [ -z "${CODEBASE_PATH:-}" ] && [ -n "${REPO_PATH:-}" ]; then
+        printf '%s' "${REPO_PATH}"
+      else
+        printf '%s' "${CODEBASE_PATH:-.}"
+      fi
+    output: "codebase_path"
+
   # ==========================================================================
   # INITIALIZATION: Track start time for efficiency metrics
   # ==========================================================================

--- a/amplifier-bundle/recipes/investigation-workflow.yaml
+++ b/amplifier-bundle/recipes/investigation-workflow.yaml
@@ -14,13 +14,19 @@ tags: ["investigation","workflow","composable","explore","verify","report"]
 # Context flows automatically between sub-recipes.
 
 context:
-  # The main question to investigate
+  # The main question to investigate. When invoked via smart-orchestrator,
+  # this is set by the routing step. When invoked directly, it's populated
+  # from task_description (see investigation-prep preflight).
   investigation_question: ""
-context_validation:
-  task_description: "nonempty"
 
-  # Path to focus investigation on (optional)
+  # task_description is the canonical input from `amplihack recipe run -c`.
+  # Maps to investigation_question if that field is blank.
+  task_description: ""
+
+  # Path to focus investigation on (optional).
+  # repo_path is the canonical input; maps to codebase_path.
   codebase_path: ""
+  repo_path: ""
 
   # Investigation type determines agent selection:
   # - code: analyzer + patterns (default)
@@ -43,6 +49,9 @@ context_validation:
   # Efficiency tracking (internal)
   _start_time: ""
   _message_count: 0
+
+context_validation:
+  task_description: "nonempty"
 
 steps:
   - id: "investigation-prep"

--- a/tests/integration/investigation_workflow_decomposition_test.rs
+++ b/tests/integration/investigation_workflow_decomposition_test.rs
@@ -16,6 +16,7 @@ const PHASE_RECIPES: &[&str] = &[
 const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "preflight-validation",
     "normalize-question",
+    "normalize-codebase-path",
     "init-tracking",
     "scope-definition",
     "clarify-ambiguities",


### PR DESCRIPTION
Fixes #594

## Problem

When `investigation-workflow` is invoked directly (`amplihack recipe run investigation-workflow -c task_description=...`), context variables arrived blank in downstream prompts. The scope-definition agent saw empty fields and investigated a generic inferred target instead of the user's question.

## Root Cause

Context fields (`codebase_path`, `investigation_type`, `depth`, etc.) were placed under `context_validation:` instead of `context:` in investigation-workflow.yaml. The recipe runner only propagates vars declared in `context:` to sub-recipes.

## Fix

1. Moved all context fields into `context:` block in investigation-workflow.yaml
2. Added `task_description` and `repo_path` as declared context vars
3. Added `normalize-codebase-path` step in investigation-prep.yaml (mirrors existing `normalize-question` pattern)

## Verification Evidence

- **Context propagation test**: `recipe-runner-rs` correctly maps `task_description` → `investigation_question` and `repo_path` → `codebase_path` in downstream prompts (verified with test-normalize.yaml and test-context.yaml payloads)
- **Integration tests**: 6/6 investigation_workflow_decomposition tests pass (including new `normalize-codebase-path` step in inventory)
- **Recipe integration**: 19/19 recipe decomposition tests pass (`default_workflow_decomposition` + `smart_orchestrator_decomposition`)
- **CI**: 8/8 checks green (Lint, Test, 4× Build, Install Smoke, Security)
- **Scope**: 3 files — 2 recipe YAML files + 1 test inventory update
- **Docs**: No user-facing surface change — investigation-workflow SKILL.md already documents correct `-c task_description=... -c repo_path=.` invocation