### PR TITLE
fix: update asset resolution to native Rust paths (#634)

### DIFF
--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -17,19 +17,23 @@ fn is_safe_path_char(ch: char) -> bool {
 ///
 /// Each entry is `(name, &[relative_paths])` where relative_paths are tried in order.
 const NAMED_ASSETS: &[(&str, &[&str])] = &[
-    // Issue #614: re-register hooks-dir and helper-path for smart-orchestrator
-    // preflight compatibility. hooks/ dir exists at amplifier-bundle/tools/amplihack/hooks/.
+    // hooks/ dir — native Rust hooks binary reads config from here.
     ("hooks-dir", &["amplifier-bundle/tools/amplihack/hooks"]),
-    // helper-path resolves to the orchestrator helper script.
+    // helper-path — orchestration helper script. The Python orch_helper.py
+    // was replaced by the native shell orchestrator in the Rust port.
     (
         "helper-path",
-        &[
-            "amplifier-bundle/tools/orch_helper.py",
-            "amplifier-bundle/tools/amplihack/orch_helper.py",
-        ],
+        &["amplifier-bundle/bin/multitask-orchestrator.sh"],
     ),
-    // Native compatibility wrapper for legacy callers that still resolve the
-    // multitask orchestrator by logical asset name.
+    // session-tree-path — session tree state directory. In the Rust port,
+    // session tree tracking is built into the amplihack binary
+    // (crates/amplihack-cli/src/commands/session_tree/). The asset resolves
+    // to the tools/session directory for callers that need a filesystem anchor.
+    (
+        "session-tree-path",
+        &["amplifier-bundle/tools/amplihack/session"],
+    ),
+    // multitask-orchestrator — native shell wrapper.
     (
         "multitask-orchestrator",
         &["amplifier-bundle/bin/multitask-orchestrator.sh"],

--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -355,9 +355,10 @@ mod tests {
         assert!(msg.contains("Unknown asset name"));
         assert!(msg.contains("multitask-orchestrator"));
         // Issue #614: helper-path and hooks-dir are now registered.
+        // Issue #634: session-tree-path is now registered.
         assert!(msg.contains("helper-path"));
         assert!(msg.contains("hooks-dir"));
-        assert!(!msg.contains("session-tree-path"));
+        assert!(msg.contains("session-tree-path"));
     }
 
     /// Issue #614: `resolve-bundle-asset hooks-dir` now resolves successfully

--- a/tests/integration/p1_workflow_reliability_test.rs
+++ b/tests/integration/p1_workflow_reliability_test.rs
@@ -465,13 +465,13 @@ mod ws3_asset_aliases {
         }
     }
 
-    /// NAMED_ASSETS must contain helper-path pointing to orch_helper.py.
+    /// NAMED_ASSETS must contain helper-path pointing to multitask-orchestrator.sh.
     #[test]
-    fn named_assets_helper_path_targets_orch_helper() {
+    fn named_assets_helper_path_targets_orchestrator() {
         let src = resolve_bundle_asset_mod();
         assert!(
-            src.contains("helper-path") && src.contains("orch_helper"),
-            "helper-path must point to orch_helper file (#614)"
+            src.contains("helper-path") && src.contains("multitask-orchestrator"),
+            "helper-path must point to multitask-orchestrator script (#614, #634)"
         );
     }
 


### PR DESCRIPTION
Addresses #634 — asset-resolution surface parity.

## Problem

`helper-path` asset pointed to `orch_helper.py` (doesn't exist in Rust repo), causing resolution failures. `session-tree-path` was not registered at all.

## Fix

| Asset | Before | After |
|---|---|---|
| `helper-path` | `orch_helper.py` ❌ | `multitask-orchestrator.sh` ✅ |
| `session-tree-path` | Not registered ❌ | `tools/amplihack/session/` ✅ |
| `hooks-dir` | (correct) | (unchanged) |
| `multitask-orchestrator` | (correct) | (unchanged) |

## Verification

- All 4 assets resolve: `amplihack resolve-bundle-asset <name>` returns valid paths
- 10/10 resolve_bundle_asset unit tests pass
- 33/33 P1 workflow reliability tests pass
- CI: 8/8 green (Lint, Test, 4× Build, Install Smoke, Security)
- Scope: 2 files — `resolve_bundle_asset/mod.rs` + `p1_workflow_reliability_test.rs`