### PR TITLE
fix: strengthen quality-audit zero-stubs detection for Rust

### DIFF
--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -376,6 +376,7 @@ steps:
       }
       scan_or_none "Checking for TODO/FIXME comments" "(TODO|FIXME)" '*.rs' '*.ts' '*.js' '*.sh' '*.bash' '*.md' '*.yaml' '*.yml' Makefile Dockerfile
       scan_or_none "Checking for stub indicators" "(todo!|unimplemented!|panic!.*stub)" '*.rs'
+      scan_or_none "Rust: bail/panic stubs (zero-stubs policy)" 'bail!\("not implemented|bail!\("TODO|bail!\("unimplemented|panic!\("not implemented|panic!\("TODO' '*.rs'
       echo "--- Checking for Forbidden Patterns ---"
       scan_or_none "Shell: || true, >/dev/null 2>&1, set +e" '\|\| true|\|\| :|>/dev/null 2>&1|2>/dev/null|&>/dev/null|set \+e' '*.sh' '*.bash' Makefile Dockerfile
       scan_or_none "Rust: unwrap without context, expect without message" '\.unwrap\(\)$|\.expect\(\"\"\)' '*.rs'

--- a/amplifier-bundle/skills/quality-audit/SKILL.md
+++ b/amplifier-bundle/skills/quality-audit/SKILL.md
@@ -126,9 +126,40 @@ This workflow ruthlessly applies:
 - **Ruthless Simplicity**: Flag over-engineered modules
 - **Module Size Limits**: Target <300 LOC per module
 - **Single Responsibility**: One purpose per brick
-- **Zero-BS**: No stubs, no TODOs, no dead code
+- **Zero-BS / Zero-Stubs**: No stubs, no TODOs, no dead code — see below
 - **Anti-Fallback** (#2805, #2810): Detect silent degradation and error swallowing patterns
 - **Structural Analysis** (#2809): Flag oversized files, deeply nested code, and tangled dependencies
+
+### Zero-Stubs Policy (MANDATORY)
+
+**Every audit cycle MUST include a dedicated stub scan.** A stub is any code that
+claims to implement functionality but actually defers, panics, or returns a
+meaningless default. Stubs are NEVER acceptable in production code — they are the
+#1 source of hollow success (recipe exits 0, but nothing was actually implemented).
+
+**Rust stub patterns** (highest priority — this is a Rust repo):
+
+| Pattern | Severity | Notes |
+|---|---|---|
+| `todo!()` | **critical** | Panics at runtime with "not yet implemented" |
+| `unimplemented!()` | **critical** | Same — panics at runtime |
+| `bail!("not implemented")` | **critical** | Returns error but masks missing logic |
+| `bail!("TODO")` or `bail!("unimplemented")` | **critical** | Same |
+| `panic!("not implemented")` or `panic!("TODO")` | **critical** | Intentional crash as stub |
+| `return Ok(())` in a function with documented side effects | **high** | Empty-body stub |
+| `// TODO:` / `// FIXME:` / `// STUB:` / `// HACK:` | **high** | Deferred work marker |
+| `eprintln!("not yet implemented"); return Ok(())` | **high** | Log-and-skip stub |
+
+**Other language stub patterns**:
+
+| Language | Patterns |
+|---|---|
+| TypeScript/JS | `throw new Error("not implemented")`, empty function body `{}`, `// TODO` |
+| Shell | Functions that just `echo` and `exit 0`, `: # stub` |
+
+**Post-audit double-check**: After every FIX cycle, run a final stub scan across
+ALL changed files. If any stub pattern is found, the cycle is NOT clean — the
+finding must be fixed before proceeding.
 
 ## Detection Categories
 

--- a/amplifier-bundle/tools/amplihack/considerations.yaml
+++ b/amplifier-bundle/tools/amplihack/considerations.yaml
@@ -510,3 +510,46 @@
 # For custom considerations, use checker: "generic" to enable simple keyword
 # matching. The generic analyzer looks for question keywords in the transcript.
 # For more sophisticated checks, implement a custom checker method.
+
+# ============================================================================
+# ZERO-STUBS VERIFICATION (Philosophy Compliance)
+# ============================================================================
+- id: zero_stubs_verification
+  category: Philosophy Compliance
+  question: Are there ZERO stubs in the codebase?
+  description: |
+    Post-audit double-check for stub patterns. A stub is any code that claims
+    to implement functionality but actually defers, panics, or returns a
+    meaningless default. This is the #1 source of hollow success.
+
+    CRITICAL stub patterns that MUST be absent in production code:
+
+    Rust (highest priority):
+    - todo!() — panics at runtime
+    - unimplemented!() — panics at runtime
+    - bail!("not implemented") / bail!("TODO") / bail!("unimplemented")
+    - panic!("not implemented") / panic!("TODO")
+    - return Ok(()) in functions with documented side effects (empty-body stub)
+    - // TODO: / // FIXME: / // STUB: / // HACK: comments
+
+    TypeScript/JavaScript:
+    - throw new Error("not implemented")
+    - Empty function bodies {}
+
+    Shell:
+    - Functions that just echo and exit 0
+    - : # stub
+
+    Verification commands:
+    ```bash
+    rg 'todo!\(\)|unimplemented!\(\)' --glob '*.rs' --glob '!*test*'
+    rg 'bail!\("not implemented|bail!\("TODO|bail!\("unimplemented' --glob '*.rs'
+    rg 'panic!\("not implemented|panic!\("TODO' --glob '*.rs' --glob '!*test*'
+    ```
+
+    If ANY stub pattern is found in production code (non-test files), the
+    audit cycle is NOT clean. The finding must be fixed before proceeding.
+  severity: blocker
+  checker: generic
+  enabled: true
+  applicable_session_types: ["DEVELOPMENT", "MAINTENANCE"]


### PR DESCRIPTION
## Problem


## Fix

| File | Change |
|---|---|
| `quality-audit/SKILL.md` | Added Zero-Stubs Policy section with Rust stub pattern table and post-audit double-check |
| `considerations.yaml` | Added `zero_stubs_verification` blocker consideration |

### Rust stub patterns now detected:

## Merge-Ready Evidence

### QA
- Recipe dry-run: ✅ `amplihack recipe run default-workflow --dry-run` → Success
- Step inventory: ✅ 13/13 `default_workflow_decomposition` tests pass
- Verified scan pattern catches targets: `rg 'bail!..not implemented' --glob '*.rs'` produces matches in test scenarios

### Docs
Not applicable. Changed surfaces: SKILL.md (agent-read skill doc), considerations.yaml (internal audit config), workflow-pr-review.yaml (internal recipe). No CLI/API/config changes.

### CI
Pending — Lint, Test, Build, Install Smoke, Security

### Scope
3 files — skill doc + recipe + consideration config. All directly address zero-stubs gap.