### PR TITLE
test(prompt_delivery): TDD red-phase tests for rysweet/Simard#1897

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
 name = "amplihack-orchestration"
 version = "0.9.3"
 dependencies = [
+ "amplihack-utils",
  "async-trait",
  "once_cell",
  "serde",

--- a/crates/amplihack-orchestration/Cargo.toml
+++ b/crates/amplihack-orchestration/Cargo.toml
@@ -18,3 +18,4 @@ once_cell = "1"
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync", "test-util"] }
+amplihack-utils = { path = "../amplihack-utils" }

--- a/crates/amplihack-orchestration/tests/prompt_delivery_apostrophes.rs
+++ b/crates/amplihack-orchestration/tests/prompt_delivery_apostrophes.rs
@@ -1,0 +1,196 @@
+//! TDD red-phase behavioural test for the apostrophe-survival contract.
+//!
+//! Reproduces the failure mode tracked in Simard #1871 / #1879 / #1897:
+//! a 64 KiB prompt that embeds apostrophes, double quotes, backslashes,
+//! newlines, and control bytes must round-trip through every supported
+//! delivery mode without truncation or shell-escape corruption.
+//!
+//! These tests fail until `amplihack-utils::prompt_delivery::deliver` is
+//! implemented per the design note on Simard #1897. They are intentionally
+//! NOT `#[ignore]`-d so they show up red in CI for the implementation PR.
+//!
+//! Approach: rather than depend on the real claude / copilot / codex
+//! binaries, we use POSIX `cat` as a stand-in echo target:
+//!   * `Argv`     → `sh -c 'printf "%s" "$1"' sh <prompt>`
+//!   * `Tempfile` → `cat <tempfile-path>`
+//!   * `Stdin`    → `cat` (reads its own stdin)
+//!
+//! All three should yield exactly the bytes we handed `deliver`. Any
+//! difference indicates a shell-escape / truncation bug in the helper.
+
+#![cfg(unix)]
+
+use std::process::{Command, Stdio};
+
+use amplihack_utils::prompt_delivery::{DeliveryCaps, DeliveryMode, PromptDelivery, deliver};
+
+const PAYLOAD_SIZE: usize = 64 * 1024;
+
+fn synthetic_payload() -> String {
+    // Patterns mirroring the bug repro: apostrophes (#1871 root cause),
+    // double quotes, backslashes, newlines, and a low control byte that
+    // sometimes trips PTY canonical mode.
+    let pattern = b"a'\\\"b\n\x01";
+    let mut out = Vec::with_capacity(PAYLOAD_SIZE);
+    while out.len() < PAYLOAD_SIZE {
+        out.extend_from_slice(pattern);
+    }
+    out.truncate(PAYLOAD_SIZE);
+    // Replace the control byte so we keep valid UTF-8 — but apostrophe is
+    // the one that actually matters per the original bug.
+    out.iter_mut().for_each(|b| {
+        if *b == 0x01 {
+            *b = b'.';
+        }
+    });
+    String::from_utf8(out).expect("ascii pattern is valid utf-8")
+}
+
+fn run(mut cmd: Command, prompt: &str, mode: DeliveryMode) -> String {
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("harness should spawn");
+    // For stdin mode the helper would normally take the child's stdin and
+    // write to it before wait(). Until that is implemented this branch
+    // emulates the eventual behaviour so the assertion still measures
+    // round-trip integrity end-to-end.
+    if mode == DeliveryMode::Stdin {
+        use std::io::Write;
+        if let Some(mut sin) = child.stdin.take() {
+            sin.write_all(prompt.as_bytes())
+                .expect("write to child stdin should succeed");
+        }
+    }
+    let out = child
+        .wait_with_output()
+        .expect("harness should run to completion");
+    assert!(
+        out.status.success(),
+        "harness exited non-zero: {:?}",
+        out.status
+    );
+    String::from_utf8(out.stdout).expect("harness stdout should be utf-8")
+}
+
+#[test]
+fn argv_roundtrip_small_payload() {
+    let prompt = "a'b\"c\\d\ne";
+    let caps = DeliveryCaps::argv_only();
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg("printf '%s' \"$1\"").arg("sh");
+    let _handle = deliver(&mut cmd, prompt, PromptDelivery::Argv, &caps)
+        .expect("argv delivery should succeed");
+    let got = run(cmd, prompt, DeliveryMode::Argv);
+    assert_eq!(got, prompt, "argv round-trip must be byte-exact");
+}
+
+#[test]
+fn argv_roundtrip_at_4kb_boundary() {
+    let unit = "a'b\\\"c\n";
+    let repeats = 4096 / unit.len() + 1;
+    let prompt: String = unit.repeat(repeats).chars().take(4096).collect();
+    assert_eq!(prompt.len(), 4096, "prompt sized to exactly 4 KiB");
+    let caps = DeliveryCaps::argv_only();
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg("printf '%s' \"$1\"").arg("sh");
+    let _handle = deliver(&mut cmd, &prompt, PromptDelivery::Argv, &caps)
+        .expect("argv delivery should succeed at 4 KiB");
+    let got = run(cmd, &prompt, DeliveryMode::Argv);
+    assert_eq!(got, prompt, "4 KiB argv round-trip must be byte-exact");
+}
+
+#[test]
+fn tempfile_roundtrip_64kb_apostrophes() {
+    let prompt = synthetic_payload();
+    let caps = DeliveryCaps::argv_and_tempfile("");
+    // For `cat`, we need the file path as a positional arg, not under a
+    // flag. We declare an empty flag in caps so the helper appends only
+    // the path. (The real claude/copilot binaries will use a real flag.)
+    let mut cmd = Command::new("cat");
+    let handle = deliver(&mut cmd, &prompt, PromptDelivery::Tempfile, &caps)
+        .expect("tempfile delivery should succeed");
+    assert_eq!(handle.mode(), DeliveryMode::Tempfile);
+    let got = run(cmd, &prompt, DeliveryMode::Tempfile);
+    assert_eq!(
+        got.len(),
+        prompt.len(),
+        "tempfile round-trip byte count must match (got {} vs {})",
+        got.len(),
+        prompt.len()
+    );
+    assert_eq!(got, prompt, "tempfile round-trip must be byte-exact");
+    drop(handle);
+}
+
+#[test]
+fn stdin_roundtrip_64kb_apostrophes() {
+    let prompt = synthetic_payload();
+    let caps = DeliveryCaps::all_modes("--prompt-file");
+    let mut cmd = Command::new("cat");
+    let handle = deliver(&mut cmd, &prompt, PromptDelivery::Stdin, &caps)
+        .expect("stdin delivery should succeed");
+    assert_eq!(handle.mode(), DeliveryMode::Stdin);
+    let got = run(cmd, &prompt, DeliveryMode::Stdin);
+    assert_eq!(got, prompt, "stdin round-trip must be byte-exact");
+}
+
+#[test]
+fn tempfile_path_does_not_leak_after_child_exits() {
+    let prompt = synthetic_payload();
+    let caps = DeliveryCaps::argv_and_tempfile("");
+    let mut cmd = Command::new("cat");
+    let handle = deliver(&mut cmd, &prompt, PromptDelivery::Tempfile, &caps)
+        .expect("tempfile delivery should succeed");
+    let path = handle
+        .tempfile_path()
+        .expect("tempfile mode handle must expose a path")
+        .to_path_buf();
+    let _ = run(cmd, &prompt, DeliveryMode::Tempfile);
+    drop(handle);
+    assert!(
+        !path.exists(),
+        "tempfile must be unlinked after handle drop: {path:?}"
+    );
+}
+
+#[test]
+fn concurrent_deliveries_use_distinct_tempfiles() {
+    use std::thread;
+    let prompt = synthetic_payload();
+    let caps = DeliveryCaps::argv_and_tempfile("");
+
+    let mut handles = Vec::new();
+    let mut paths = Vec::new();
+    for _ in 0..4 {
+        let mut cmd = Command::new("cat");
+        let h = deliver(&mut cmd, &prompt, PromptDelivery::Tempfile, &caps)
+            .expect("tempfile delivery should succeed");
+        paths.push(
+            h.tempfile_path()
+                .expect("tempfile path must be exposed")
+                .to_path_buf(),
+        );
+        let prompt_clone = prompt.clone();
+        handles.push(thread::spawn(move || {
+            run(cmd, &prompt_clone, DeliveryMode::Tempfile)
+        }));
+        // Keep `h` alive until the spawned thread reads it; in the real
+        // implementation the handle owns the NamedTempFile so we must NOT
+        // drop it here. Leak it for the duration of the test by stashing.
+        std::mem::forget(h);
+    }
+    for h in handles {
+        let got = h.join().expect("worker thread should not panic");
+        assert_eq!(got, prompt, "every concurrent delivery must round-trip");
+    }
+    // All temp paths must be unique.
+    let mut sorted = paths.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        paths.len(),
+        "concurrent tempfile deliveries must produce distinct paths: {paths:?}"
+    );
+}

--- a/crates/amplihack-utils/src/lib.rs
+++ b/crates/amplihack-utils/src/lib.rs
@@ -49,6 +49,9 @@ pub mod prerequisites;
 pub mod process;
 pub mod project_init;
 pub(crate) mod project_init_detect;
+/// Subprocess prompt-delivery helper (argv/tempfile/stdin). See Simard
+/// issue #1897. STUB module in the TDD red phase.
+pub mod prompt_delivery;
 /// Secure file and directory creation with restrictive permissions.
 pub mod secure_files;
 pub mod send_input_allowlist;

--- a/crates/amplihack-utils/src/prompt_delivery.rs
+++ b/crates/amplihack-utils/src/prompt_delivery.rs
@@ -1,0 +1,176 @@
+//! Subprocess prompt-delivery helper — STUB for the TDD red phase.
+//!
+//! This module is intentionally incomplete. It establishes the public API
+//! surface that the implementation must satisfy and lets the test suite at
+//! `tests/prompt_delivery.rs` *compile* while still *failing* — the canonical
+//! TDD "tests first" red state.
+//!
+//! Implementation tracks Simard issue #1897 and the follow-up amplihack-rs
+//! issue linked from there. See the design note on Simard #1897 for the
+//! full contract, including:
+//! - env var: `AMPLIHACK_PROMPT_DELIVERY` (`auto|argv|tempfile|stdin`)
+//! - auto-promotion threshold at 4 KiB
+//! - deterministic degradation order on unsupported modes
+//! - RAII lifecycle for temp files
+//!
+//! DO NOT MERGE without replacing every `unimplemented_stub!` with a real
+//! implementation and removing this header note.
+
+use std::path::Path;
+use std::process::Command;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Requested delivery mode. `Auto` defers to [`select_mode`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromptDelivery {
+    Auto,
+    Argv,
+    Tempfile,
+    Stdin,
+}
+
+/// Per-binary capability descriptor — mirrors the additions proposed for
+/// `crates/amplihack-launcher/src/flag_matrix.rs::FlagSet`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeliveryCaps {
+    pub supports_argv: bool,
+    pub supports_tempfile: bool,
+    pub supports_stdin: bool,
+    /// CLI flag the binary uses to consume a prompt file (e.g. `--prompt-file`).
+    /// `None` means the binary has no documented file-prompt flag.
+    pub tempfile_flag: Option<&'static str>,
+}
+
+impl DeliveryCaps {
+    pub fn argv_only() -> Self {
+        Self {
+            supports_argv: true,
+            supports_tempfile: false,
+            supports_stdin: false,
+            tempfile_flag: None,
+        }
+    }
+
+    pub fn argv_and_tempfile(flag: &'static str) -> Self {
+        Self {
+            supports_argv: true,
+            supports_tempfile: true,
+            supports_stdin: false,
+            tempfile_flag: Some(flag),
+        }
+    }
+
+    pub fn all_modes(tempfile_flag: &'static str) -> Self {
+        Self {
+            supports_argv: true,
+            supports_tempfile: true,
+            supports_stdin: true,
+            tempfile_flag: Some(tempfile_flag),
+        }
+    }
+}
+
+/// The mode actually selected after considering caps + env.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeliveryMode {
+    Argv,
+    Tempfile,
+    Stdin,
+}
+
+/// RAII handle returned by [`deliver`]. Owns temp resources for the lifetime
+/// of the spawned child. Drop unlinks any temp file and joins any stdin
+/// writer task.
+#[derive(Debug)]
+pub struct DeliveryHandle {
+    mode: DeliveryMode,
+    // Real implementation will hold an `Option<tempfile::NamedTempFile>` here
+    // and (for stdin mode) a join handle or a writer thread.
+    #[allow(dead_code)]
+    _opaque: (),
+}
+
+impl DeliveryHandle {
+    pub fn mode(&self) -> DeliveryMode {
+        self.mode
+    }
+
+    /// Path to the temp file, if `mode == Tempfile`. `None` otherwise.
+    pub fn tempfile_path(&self) -> Option<&Path> {
+        // Stub returns None unconditionally — real impl returns the path.
+        None
+    }
+}
+
+impl Drop for DeliveryHandle {
+    fn drop(&mut self) {
+        // Empty stub Drop: the real impl unlinks the temp file (RAII via
+        // tempfile::NamedTempFile) and tears down any stdin writer task.
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — STUBS
+// ---------------------------------------------------------------------------
+
+/// The auto-promotion threshold (bytes). Prompts at-or-below this size stay
+/// on argv when the binary supports it. See PTY canonical-mode line cap
+/// rationale in Simard #1879.
+pub const AUTO_TEMPFILE_THRESHOLD_BYTES: usize = 4096;
+
+/// Env-var name that selects the delivery mode at runtime.
+pub const ENV_VAR_NAME: &str = "AMPLIHACK_PROMPT_DELIVERY";
+
+/// Parse the [`ENV_VAR_NAME`] environment variable.
+///
+/// - Unset, empty, or unrecognised values → `Auto` (with a `tracing::warn!`
+///   for unrecognised values; quiet for unset/empty).
+/// - Case-insensitive: `TempFile`, `TEMPFILE`, and `tempfile` all map to
+///   `Tempfile`.
+pub fn from_env() -> PromptDelivery {
+    // STUB: always returns Auto, ignoring the env. Tests will fail.
+    PromptDelivery::Auto
+}
+
+/// Resolve the actual delivery mode given a requested mode, the prompt size,
+/// and the binary's capabilities.
+///
+/// Algorithm (see design note for the prose version):
+/// 1. If `requested != Auto`: honour it when supported, else degrade
+///    deterministically through `Tempfile → Stdin → Argv` and `tracing::warn!`.
+/// 2. If `requested == Auto`:
+///    a. `prompt_size <= AUTO_TEMPFILE_THRESHOLD_BYTES` + `supports_argv` → `Argv`.
+///    b. else `supports_tempfile` → `Tempfile`.
+///    c. else `supports_stdin` → `Stdin`.
+///    d. else `Argv` + warn.
+pub fn select_mode(
+    _requested: PromptDelivery,
+    _prompt_size: usize,
+    _caps: &DeliveryCaps,
+) -> DeliveryMode {
+    // STUB: always returns Argv — wrong for large prompts and explicit overrides.
+    DeliveryMode::Argv
+}
+
+/// Apply prompt delivery to a `Command`.
+///
+/// Mutates `cmd` to either append the prompt as an argv element, append a
+/// path to a temp file (using `caps.tempfile_flag`), or configure piped
+/// stdin and stage the prompt to be written on spawn. Returns a
+/// [`DeliveryHandle`] that the caller MUST keep alive until the child has
+/// been waited on.
+pub fn deliver(
+    _cmd: &mut Command,
+    _prompt: &str,
+    _requested: PromptDelivery,
+    _caps: &DeliveryCaps,
+) -> std::io::Result<DeliveryHandle> {
+    // STUB: returns an Argv handle but does NOT mutate the command. Tests fail.
+    Ok(DeliveryHandle {
+        mode: DeliveryMode::Argv,
+        _opaque: (),
+    })
+}

--- a/crates/amplihack-utils/tests/prompt_delivery.rs
+++ b/crates/amplihack-utils/tests/prompt_delivery.rs
@@ -1,0 +1,406 @@
+//! TDD red-phase tests for `amplihack_utils::prompt_delivery`.
+//!
+//! Tracks Simard issue #1897 and the linked amplihack-rs follow-up. These
+//! tests are written against the public API surface only; they DELIBERATELY
+//! fail until `prompt_delivery::{from_env, select_mode, deliver}` are
+//! implemented per the design note.
+//!
+//! Run with:
+//!     cargo test -p amplihack-utils --test prompt_delivery
+//!
+//! Expected red state right now: every test that exercises real behaviour
+//! (everything except the pure type-shape sanity checks) fails. That is the
+//! TDD contract — the implementation PR turns them green.
+
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+use amplihack_utils::prompt_delivery::{
+    AUTO_TEMPFILE_THRESHOLD_BYTES, DeliveryCaps, DeliveryMode, ENV_VAR_NAME, PromptDelivery,
+    deliver, from_env, select_mode,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn claude_like_caps() -> DeliveryCaps {
+    DeliveryCaps::all_modes("--prompt-file")
+}
+
+fn copilot_like_caps() -> DeliveryCaps {
+    DeliveryCaps::argv_and_tempfile("--prompt-file")
+}
+
+fn codex_like_caps() -> DeliveryCaps {
+    DeliveryCaps::argv_only()
+}
+
+/// Build a prompt of exactly `size` bytes. Content includes apostrophes,
+/// double quotes, and backslashes so that any surviving shell-escape bug
+/// from #1871 surfaces immediately.
+fn synthetic_prompt(size: usize) -> String {
+    let pattern = b"a'\\\"b\n";
+    let mut out = Vec::with_capacity(size);
+    while out.len() < size {
+        out.extend_from_slice(pattern);
+    }
+    out.truncate(size);
+    String::from_utf8(out).expect("ascii pattern is valid utf-8")
+}
+
+/// Mutex-guard env access — tests within this binary run on a shared
+/// process and `set_var` is not thread-safe across threads.
+fn with_env<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    // Ignore poisoning: when a TDD-red test panics holding the lock we still
+    // want subsequent env tests to run their own assertions.
+    let _g = LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let previous = std::env::var(ENV_VAR_NAME).ok();
+    // SAFETY: serialized via LOCK above.
+    unsafe {
+        match value {
+            Some(v) => std::env::set_var(ENV_VAR_NAME, v),
+            None => std::env::remove_var(ENV_VAR_NAME),
+        }
+    }
+    let out = f();
+    unsafe {
+        match previous {
+            Some(v) => std::env::set_var(ENV_VAR_NAME, v),
+            None => std::env::remove_var(ENV_VAR_NAME),
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// 1. auto_selects_argv_for_small_prompt
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_selects_argv_for_small_prompt() {
+    let caps = claude_like_caps();
+    let mode = select_mode(PromptDelivery::Auto, 100, &caps);
+    assert_eq!(
+        mode,
+        DeliveryMode::Argv,
+        "100-byte prompt + full-cap binary should auto-select Argv"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. auto_selects_tempfile_for_large_prompt
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_selects_tempfile_for_large_prompt() {
+    let caps = claude_like_caps();
+    let mode = select_mode(PromptDelivery::Auto, 8 * 1024, &caps);
+    assert_eq!(
+        mode,
+        DeliveryMode::Tempfile,
+        "8 KiB prompt + tempfile-capable binary should auto-select Tempfile"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. auto_falls_back_to_stdin_when_tempfile_unsupported
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_falls_back_to_stdin_when_tempfile_unsupported() {
+    let caps = DeliveryCaps {
+        supports_argv: true,
+        supports_tempfile: false,
+        supports_stdin: true,
+        tempfile_flag: None,
+    };
+    let mode = select_mode(PromptDelivery::Auto, 8 * 1024, &caps);
+    assert_eq!(
+        mode,
+        DeliveryMode::Stdin,
+        "8 KiB prompt + stdin-only binary should auto-select Stdin"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. auto_falls_back_to_argv_when_no_long_form_supported
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_falls_back_to_argv_when_no_long_form_supported() {
+    let caps = codex_like_caps();
+    let mode = select_mode(PromptDelivery::Auto, 8 * 1024, &caps);
+    assert_eq!(
+        mode,
+        DeliveryMode::Argv,
+        "argv-only binary must fall back to Argv even for large prompts"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. explicit_env_overrides_auto
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_env_overrides_auto() {
+    with_env(Some("stdin"), || {
+        let parsed = from_env();
+        assert_eq!(
+            parsed,
+            PromptDelivery::Stdin,
+            "env=stdin should parse to Stdin"
+        );
+        let mode = select_mode(parsed, 100, &claude_like_caps());
+        assert_eq!(
+            mode,
+            DeliveryMode::Stdin,
+            "explicit Stdin must win over the auto-threshold rule"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// 6. explicit_env_with_unsupported_mode_degrades_deterministically
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_env_with_unsupported_mode_degrades_deterministically() {
+    let caps = codex_like_caps(); // argv-only
+    let mode = select_mode(PromptDelivery::Stdin, 100, &caps);
+    assert_eq!(
+        mode,
+        DeliveryMode::Argv,
+        "explicit Stdin on argv-only binary must degrade to Argv"
+    );
+
+    // tempfile request on a stdin-only binary should land on stdin per the
+    // documented degradation chain (Tempfile → Stdin → Argv).
+    let caps = DeliveryCaps {
+        supports_argv: true,
+        supports_tempfile: false,
+        supports_stdin: true,
+        tempfile_flag: None,
+    };
+    let mode = select_mode(PromptDelivery::Tempfile, 100, &caps);
+    assert_eq!(
+        mode,
+        DeliveryMode::Stdin,
+        "explicit Tempfile on stdin-capable binary must degrade to Stdin"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. invalid_env_value_warns_and_defaults_to_auto
+// ---------------------------------------------------------------------------
+
+#[test]
+fn invalid_env_value_warns_and_defaults_to_auto() {
+    with_env(Some("garbage-value-xyz"), || {
+        let parsed = from_env();
+        assert_eq!(
+            parsed,
+            PromptDelivery::Auto,
+            "unrecognised env value must fall back to Auto"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// 8. parser_is_case_insensitive
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parser_is_case_insensitive() {
+    for value in ["argv", "ARGV", "ArGv"] {
+        with_env(Some(value), || {
+            assert_eq!(
+                from_env(),
+                PromptDelivery::Argv,
+                "env={value} should parse to Argv"
+            );
+        });
+    }
+    for value in ["tempfile", "TempFile", "TEMPFILE"] {
+        with_env(Some(value), || {
+            assert_eq!(
+                from_env(),
+                PromptDelivery::Tempfile,
+                "env={value} should parse to Tempfile"
+            );
+        });
+    }
+    for value in ["stdin", "Stdin", "STDIN"] {
+        with_env(Some(value), || {
+            assert_eq!(
+                from_env(),
+                PromptDelivery::Stdin,
+                "env={value} should parse to Stdin"
+            );
+        });
+    }
+    for value in ["auto", "Auto", "AUTO"] {
+        with_env(Some(value), || {
+            assert_eq!(
+                from_env(),
+                PromptDelivery::Auto,
+                "env={value} should parse to Auto"
+            );
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 9. tempfile_handle_drops_file_on_drop
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tempfile_handle_drops_file_on_drop() {
+    let caps = claude_like_caps();
+    let prompt = synthetic_prompt(8 * 1024);
+    let mut cmd = Command::new("/bin/true");
+    let handle = deliver(&mut cmd, &prompt, PromptDelivery::Tempfile, &caps)
+        .expect("deliver should succeed for tempfile mode");
+    assert_eq!(
+        handle.mode(),
+        DeliveryMode::Tempfile,
+        "handle mode should be Tempfile"
+    );
+    let path = handle
+        .tempfile_path()
+        .expect("tempfile mode handle must expose a path")
+        .to_path_buf();
+    assert!(
+        path.exists(),
+        "tempfile path should exist while handle is alive: {path:?}"
+    );
+    drop(handle);
+    assert!(
+        !path.exists(),
+        "tempfile must be unlinked when handle is dropped: {path:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 10. tempfile_handle_perms_are_0600 (Unix-only)
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn tempfile_handle_perms_are_0600() {
+    let caps = claude_like_caps();
+    let prompt = synthetic_prompt(8 * 1024);
+    let mut cmd = Command::new("/bin/true");
+    let handle = deliver(&mut cmd, &prompt, PromptDelivery::Tempfile, &caps)
+        .expect("deliver should succeed for tempfile mode");
+    let path = handle
+        .tempfile_path()
+        .expect("tempfile mode handle must expose a path");
+    let meta = std::fs::metadata(path).expect("temp file should exist");
+    let mode_bits = meta.permissions().mode() & 0o7777;
+    assert_eq!(
+        mode_bits, 0o600,
+        "tempfile must be created with 0600 permissions"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 11. deliver_mutates_command_for_argv
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deliver_mutates_command_for_argv() {
+    let caps = codex_like_caps();
+    let prompt = "hello prompt";
+    let mut cmd = Command::new("/bin/true");
+    cmd.arg("--existing");
+    let _handle = deliver(&mut cmd, prompt, PromptDelivery::Argv, &caps)
+        .expect("argv delivery should succeed");
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        args.iter().any(|a| a == prompt),
+        "argv mode must append the prompt verbatim. Got args: {args:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 12. deliver_mutates_command_for_tempfile
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deliver_mutates_command_for_tempfile() {
+    let caps = claude_like_caps();
+    let prompt = synthetic_prompt(8 * 1024);
+    let mut cmd = Command::new("/bin/true");
+    let handle = deliver(&mut cmd, &prompt, PromptDelivery::Tempfile, &caps)
+        .expect("tempfile delivery should succeed");
+    let path = handle
+        .tempfile_path()
+        .expect("path must be exposed")
+        .to_path_buf();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        args.iter().any(|a| a == "--prompt-file"),
+        "tempfile mode must append the documented flag. Got args: {args:?}"
+    );
+    assert!(
+        args.iter().any(|a| a.as_str() == path.to_string_lossy()),
+        "tempfile mode must append the temp file path. Got args: {args:?}"
+    );
+    // And the prompt must NEVER appear inline in argv.
+    assert!(
+        !args.iter().any(|a| a.contains(&prompt[..200])),
+        "tempfile mode must not leak the prompt into argv"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 13. auto_threshold_is_inclusive
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_threshold_is_inclusive() {
+    let caps = claude_like_caps();
+    let mode = select_mode(PromptDelivery::Auto, AUTO_TEMPFILE_THRESHOLD_BYTES, &caps);
+    assert_eq!(
+        mode,
+        DeliveryMode::Argv,
+        "prompts AT the threshold should stay on argv (inclusive boundary)"
+    );
+    let mode = select_mode(
+        PromptDelivery::Auto,
+        AUTO_TEMPFILE_THRESHOLD_BYTES + 1,
+        &caps,
+    );
+    assert_eq!(
+        mode,
+        DeliveryMode::Tempfile,
+        "prompts one byte over the threshold should promote to Tempfile"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 14. copilot_like_caps_auto_long_prompt_uses_tempfile
+// ---------------------------------------------------------------------------
+
+#[test]
+fn copilot_like_caps_auto_long_prompt_uses_tempfile() {
+    let caps = copilot_like_caps();
+    let mode = select_mode(PromptDelivery::Auto, 64 * 1024, &caps);
+    assert_eq!(
+        mode,
+        DeliveryMode::Tempfile,
+        "Copilot-like caps (no stdin, has tempfile) should pick Tempfile for 64 KiB"
+    );
+}


### PR DESCRIPTION
# TDD red phase: subprocess prompt-delivery contract (argv/tempfile/stdin)

## What this PR is

The **failing tests** — the red phase of TDD — that drive implementation of the subprocess prompt-delivery contract called out in **`rysweet/Simard#1897`**. It does NOT contain the implementation. The implementation lands in a follow-up PR.

Refs: `rysweet/Simard#1897` `rysweet/Simard#1879` `rysweet/Simard#1871` `rysweet/Simard#1878`.

## Why now / scope

`rysweet/Simard#1897` is the most foundational and self-contained item in the amplihack-rs parity inventory; it likely unblocks downstream work on `#1899` (engineer subcommand). The Python amplihack reference also lacks an equivalent contract, so the design originates in the Simard `#1878` working fix (`build_copilot_terminal_objective` shell mktemp) and is generalised here.

Blast radius is strictly:
- Added `crates/amplihack-utils/src/prompt_delivery.rs` (stub module, new file).
- Added `crates/amplihack-utils/tests/prompt_delivery.rs` (test file, new).
- Added `crates/amplihack-orchestration/tests/prompt_delivery_apostrophes.rs` (test file, new).
- Added 1 line to `crates/amplihack-utils/src/lib.rs` re-exporting the module.
- Added `amplihack-utils` as a `dev-dependencies` entry to `crates/amplihack-orchestration/Cargo.toml`.
- Resulting one-line `Cargo.lock` update.

No production code paths are touched. No existing tests are modified.

## Contract under test

See the full design note posted as a comment on `rysweet/Simard#1897`. Summary:

- **Env var:** `AMPLIHACK_PROMPT_DELIVERY` ∈ `{auto, argv, tempfile, stdin}`, default `auto`. Case-insensitive parsing; unknown → warn + auto.
- **Auto rule:** prompts ≤ 4 KiB on `argv`, larger on `tempfile`, falling through to `stdin` then `argv` based on per-binary capability flags.
- **Explicit override:** wins over auto; if mode is unsupported by the target binary, degrades deterministically through `Tempfile → Stdin → Argv` with `tracing::warn!`.
- **Lifecycle:** `tempfile::NamedTempFile` (0600 perms on Unix) owned by an RAII `DeliveryHandle`. `stdin` mode pipes prompt to child stdin then closes it.

## Tests added

### `crates/amplihack-utils/tests/prompt_delivery.rs` — 14 unit tests

| # | Name                                                                  | Asserts                                          |
| - | --------------------------------------------------------------------- | ------------------------------------------------ |
| 1 | `auto_selects_argv_for_small_prompt`                                  | 100 B + claude-like caps → `Argv`.               |
| 2 | `auto_selects_tempfile_for_large_prompt`                              | 8 KiB + claude-like caps → `Tempfile`.           |
| 3 | `auto_falls_back_to_stdin_when_tempfile_unsupported`                  | 8 KiB + stdin-only → `Stdin`.                    |
| 4 | `auto_falls_back_to_argv_when_no_long_form_supported`                 | 8 KiB + codex-like → `Argv` + warn.              |
| 5 | `explicit_env_overrides_auto`                                         | `env=stdin` + 100 B → `Stdin`.                   |
| 6 | `explicit_env_with_unsupported_mode_degrades_deterministically`       | `Stdin` on argv-only → `Argv`; `Tempfile` on stdin-only → `Stdin`. |
| 7 | `invalid_env_value_warns_and_defaults_to_auto`                        | unknown env → `Auto`.                            |
| 8 | `parser_is_case_insensitive`                                          | every spelling of each value parses correctly.   |
| 9 | `tempfile_handle_drops_file_on_drop`                                  | path exists pre-drop, gone post-drop.            |
| 10 | `tempfile_handle_perms_are_0600`                                     | Unix mode bits == 0o600.                         |
| 11 | `deliver_mutates_command_for_argv`                                   | argv mode appends the prompt verbatim.           |
| 12 | `deliver_mutates_command_for_tempfile`                               | tempfile mode appends `--prompt-file <path>`, never inlines prompt. |
| 13 | `auto_threshold_is_inclusive`                                        | exactly 4 KiB stays on argv; 4 KiB + 1 promotes. |
| 14 | `copilot_like_caps_auto_long_prompt_uses_tempfile`                   | copilot-like (no stdin) + 64 KiB → `Tempfile`.   |

**Current state:** `cargo test -p amplihack-utils --test prompt_delivery` → `3 passed; 11 failed; 0 ignored`. The 3 passing are trivial "argv is the right answer here" cases that the stub gets correct by accident; the 11 failing are the meaningful red-phase assertions.

### `crates/amplihack-orchestration/tests/prompt_delivery_apostrophes.rs` — 6 behavioural tests

Reproduces the 64 KiB apostrophe-containing payload from `Simard#1871` end-to-end against real subprocesses (`cat`, `sh -c printf`) used as standalone echo harnesses — no dependency on the actual claude/copilot/codex binaries.

| # | Name                                              | Mode       |
| - | ------------------------------------------------- | ---------- |
| 1 | `argv_roundtrip_small_payload`                    | `Argv`     |
| 2 | `argv_roundtrip_at_4kb_boundary`                  | `Argv`     |
| 3 | `tempfile_roundtrip_64kb_apostrophes`             | `Tempfile` |
| 4 | `stdin_roundtrip_64kb_apostrophes`                | `Stdin`    |
| 5 | `tempfile_path_does_not_leak_after_child_exits`   | `Tempfile` |
| 6 | `concurrent_deliveries_use_distinct_tempfiles`    | `Tempfile` |

**Current state:** `cargo test -p amplihack-orchestration --test prompt_delivery_apostrophes` → `0 passed; 6 failed; 0 ignored`. Every assertion is meaningful (no flukes).

## Why tests are NOT `#[ignore]`-d

TDD red phase must be visible. CI for this PR will show exactly which assertions break, and CI for the green-phase implementation PR will show each one flipping to green as the code lands. Hiding the red state behind `#[ignore]` defeats the point.

## Quality gates run locally

| Gate                                                                        | Result                                |
| --------------------------------------------------------------------------- | ------------------------------------- |
| `cargo fmt --all`                                                           | clean                                 |
| `cargo clippy -p amplihack-utils --tests`                                   | clean (0 warnings)                    |
| `cargo clippy -p amplihack-orchestration --tests`                           | clean (0 warnings)                    |
| `cargo build -p amplihack-utils --tests`                                    | clean                                 |
| `cargo build -p amplihack-orchestration --tests`                            | clean                                 |
| `cargo test -p amplihack-utils --lib`                                       | 441 pass, 0 fail (no regressions)     |
| `cargo test -p amplihack-orchestration --lib`                               | 56 pass, 0 fail (no regressions)      |
| `cargo test -p amplihack-utils --test prompt_delivery`                      | 3 pass, **11 fail** (intended)        |
| `cargo test -p amplihack-orchestration --test prompt_delivery_apostrophes` | 0 pass, **6 fail** (intended)         |
| pre-commit hooks (fmt + clippy + trailing-whitespace etc.)                 | clean                                 |

## Draft status

This PR is **draft**. It should NOT be merged until the green-phase implementation PR is ready to merge alongside it (or it can be merged first, accepting that `prompt_delivery::*` tests are red on `main` until the implementation lands — caller's choice; flag in review).

## Out of scope

- Migrating the six call sites in `claude_process.rs`, `copilot_launcher.rs`, `codex.rs`, `claude_binary_manager.rs`. Tracked in the follow-up implementation issue.
- Python amplihack side of the contract — file separately if/when Python adopts it.
- `amplihack doctor` sub-check reporting active mode per adapter — listed as a follow-up sub-task in the implementation issue.

## QA notes (qa-team criterion)

End-to-end behavioural scenarios for an internal-only helper are encoded as `cargo test` integration tests. The 6 orchestration tests act as the qa-team-equivalent scenario set because the surface is internal to the Rust workspace (no CLI / TUI / HTTP / MCP surface exposed). No gadugi `tests/gadugi/` scenarios apply at this layer.

## Docs

This is an internal helper with no user-facing surface yet. Once the implementation PR lands and the helper is wired into `claude_process.rs`, `copilot_launcher.rs`, and `codex.rs`, `docs/amplihack-rs-parity.md` should gain a row documenting the env var and the per-binary capability matrix. That doc change belongs in the implementation PR, not this red-phase PR.

## Co-authored-by

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
