### PR TITLE
Replace python3 -c with jq/yq, add regression test, fix gadugi-test CLI executor

### DIFF
--- a/amplifier-bundle/skills/code-atlas/SECURITY.md
+++ b/amplifier-bundle/skills/code-atlas/SECURITY.md
@@ -187,9 +187,8 @@ with open("package.json") as f:
 ```
 
 ```bash
-# Safe: use yq or python for YAML parsing, not bash eval
+# Safe: use yq for YAML parsing, not bash eval
 yq e '.services | keys' docker-compose.yml
-python3 -c "import yaml,sys; d=yaml.safe_load(sys.stdin); print(list(d.get('services',{}).keys()))" < docker-compose.yml
 ```
 
 **Anti-pattern:**

--- a/amplifier-bundle/skills/code-atlas/tests/test_ci_workflow.sh
+++ b/amplifier-bundle/skills/code-atlas/tests/test_ci_workflow.sh
@@ -178,29 +178,15 @@ fi
 echo ""
 echo "=== YAML Validity ==="
 
-if command -v python3 >/dev/null 2>&1; then
-    yaml_valid=$(python3 -c "
-import sys
-try:
-    import yaml
-    with open('${CI_WORKFLOW}') as f:
-        yaml.safe_load(f)
-    print('true')
-except Exception as e:
-    print('false')
-    sys.stderr.write(str(e) + '\n')
-" 2>/dev/null || echo "false")
-    assert_pass "atlas-ci.yml is valid YAML (python3+yaml)" "$yaml_valid"
-elif command -v yq >/dev/null 2>&1; then
+if command -v yq >/dev/null 2>&1; then
     if yq '.' "$CI_WORKFLOW" > /dev/null 2>&1; then
-        echo "PASS: atlas-ci.yml is valid YAML (yq)"
-        PASS=$((PASS + 1))
+        yaml_valid="true"
     else
-        echo "FAIL: atlas-ci.yml has invalid YAML syntax"
-        FAIL=$((FAIL + 1))
+        yaml_valid="false"
     fi
+    assert_pass "atlas-ci.yml is valid YAML (yq)" "$yaml_valid"
 else
-    echo "SKIP: YAML validity check (python3+yaml or yq required)"
+    echo "SKIP: YAML validity check (yq required)"
 fi
 
 # ============================================================================

--- a/amplifier-bundle/skills/code-atlas/tests/test_layer7_8.sh
+++ b/amplifier-bundle/skills/code-atlas/tests/test_layer7_8.sh
@@ -448,16 +448,16 @@ assert_file_contains \
     "$RECIPE"
 
 # Validate YAML is parseable
-if command -v python3 &>/dev/null; then
-    if python3 -c "import yaml; yaml.safe_load(open('${RECIPE}'))" 2>/dev/null; then
-        echo "PASS: Recipe YAML is valid (python3 yaml.safe_load)"
+if command -v yq &>/dev/null; then
+    if yq '.' "${RECIPE}" >/dev/null 2>&1; then
+        echo "PASS: Recipe YAML is valid (yq)"
         PASS=$((PASS + 1))
     else
         echo "FAIL: Recipe YAML is invalid — parse error"
         FAIL=$((FAIL + 1))
     fi
 else
-    echo "SKIP: python3 not available — cannot validate YAML syntax"
+    echo "SKIP: yq not available — cannot validate YAML syntax"
 fi
 
 # ---------------------------------------------------------------------------

--- a/amplifier-bundle/skills/gh-work-report/templates/monthly-report.yml
+++ b/amplifier-bundle/skills/gh-work-report/templates/monthly-report.yml
@@ -94,9 +94,9 @@ jobs:
           mkdir -p docs/reports
 
           REPO_COUNT=$(cat /tmp/report-data/repos.json | wc -l)
-          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))")
-          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))")
-          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))")
+          PR_CREATED=$(jq 'length' /tmp/report-data/prs-created.json)
+          PR_MERGED=$(jq 'length' /tmp/report-data/prs-merged.json)
+          ISSUES=$(jq 'length' /tmp/report-data/issues.json)
 
           cat > "$REPORT" << EOF
           # GitHub Activity Report: ${START} → ${END}
@@ -119,27 +119,23 @@ jobs:
 
           echo "| # | Title | Repository | Status | Created |" >> "$REPORT"
           echo "|---|-------|-----------|--------|---------|" >> "$REPORT"
-          python3 -c "
-          import json
-          prs = json.load(open('/tmp/report-data/prs-created.json'))
-          for pr in prs[:100]:
-              repo = pr.get('repository', {})
-              repo_name = repo.get('nameWithOwner', 'unknown') if isinstance(repo, dict) else str(repo)
-              print(f'| [#{pr[\"number\"]}]({pr[\"url\"]}) | {pr[\"title\"]} | {repo_name} | {pr[\"state\"]} | {pr[\"createdAt\"][:10]} |')
-          " >> "$REPORT"
+          jq -r '
+            .[:100][] |
+            (.repository // {}) as $repo |
+            (if ($repo | type) == "object" then ($repo.nameWithOwner // "unknown") else ($repo | tostring) end) as $repo_name |
+            "| [#\(.number)](\(.url)) | \(.title) | \($repo_name) | \(.state) | \(.createdAt[:10]) |"
+          ' /tmp/report-data/prs-created.json >> "$REPORT"
 
           echo "" >> "$REPORT"
           echo "## Active Repositories" >> "$REPORT"
           echo "" >> "$REPORT"
           echo "| Repository | Description | Last Push |" >> "$REPORT"
           echo "|-----------|-------------|-----------|" >> "$REPORT"
-          cat /tmp/report-data/repos.json | python3 -c "
-          import json, sys
-          for line in sys.stdin:
-              r = json.loads(line)
-              desc = (r.get('description') or '—')[:60]
-              print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
-          " >> "$REPORT"
+          jq -r -s '
+            .[] |
+            ((.description // "—")[:60]) as $desc |
+            "| [\(.nameWithOwner)](\(.url)) | \($desc) | \(.pushedAt[:10]) |"
+          ' /tmp/report-data/repos.json >> "$REPORT"
 
           sed -i 's/^          //' "$REPORT"
 

--- a/amplifier-bundle/skills/gh-work-report/templates/weekly-report.yml
+++ b/amplifier-bundle/skills/gh-work-report/templates/weekly-report.yml
@@ -105,9 +105,9 @@ jobs:
 
           # Count metrics
           REPO_COUNT=$(cat /tmp/report-data/repos.json | wc -l)
-          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))")
-          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))")
-          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))")
+          PR_CREATED=$(jq 'length' /tmp/report-data/prs-created.json)
+          PR_MERGED=$(jq 'length' /tmp/report-data/prs-merged.json)
+          ISSUES=$(jq 'length' /tmp/report-data/issues.json)
 
           cat > "$REPORT" << EOF
           # GitHub Activity Report: ${START} → ${END}
@@ -131,27 +131,23 @@ jobs:
           # Add PR table
           echo "| # | Title | Repository | Status | Created |" >> "$REPORT"
           echo "|---|-------|-----------|--------|---------|" >> "$REPORT"
-          python3 -c "
-          import json
-          prs = json.load(open('/tmp/report-data/prs-created.json'))
-          for pr in prs[:50]:
-              repo = pr.get('repository', {})
-              repo_name = repo.get('nameWithOwner', 'unknown') if isinstance(repo, dict) else str(repo)
-              print(f'| [#{pr[\"number\"]}]({pr[\"url\"]}) | {pr[\"title\"]} | {repo_name} | {pr[\"state\"]} | {pr[\"createdAt\"][:10]} |')
-          " >> "$REPORT"
+          jq -r '
+            .[:50][] |
+            (.repository // {}) as $repo |
+            (if ($repo | type) == "object" then ($repo.nameWithOwner // "unknown") else ($repo | tostring) end) as $repo_name |
+            "| [#\(.number)](\(.url)) | \(.title) | \($repo_name) | \(.state) | \(.createdAt[:10]) |"
+          ' /tmp/report-data/prs-created.json >> "$REPORT"
 
           echo "" >> "$REPORT"
           echo "## Active Repositories" >> "$REPORT"
           echo "" >> "$REPORT"
           echo "| Repository | Description | Last Push |" >> "$REPORT"
           echo "|-----------|-------------|-----------|" >> "$REPORT"
-          cat /tmp/report-data/repos.json | python3 -c "
-          import json, sys
-          for line in sys.stdin:
-              r = json.loads(line)
-              desc = (r.get('description') or '—')[:60]
-              print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
-          " >> "$REPORT"
+          jq -r -s '
+            .[] |
+            ((.description // "—")[:60]) as $desc |
+            "| [\(.nameWithOwner)](\(.url)) | \($desc) | \(.pushedAt[:10]) |"
+          ' /tmp/report-data/repos.json >> "$REPORT"
 
           # Strip leading whitespace from heredoc
           sed -i 's/^          //' "$REPORT"

--- a/amplifier-bundle/skills/migrate/scripts/migrate.sh
+++ b/amplifier-bundle/skills/migrate/scripts/migrate.sh
@@ -99,21 +99,15 @@ detect_cli() {
     local ctx="$cur/.claude/runtime/launcher_context.json"
     if [[ -f "$ctx" ]]; then
       local parsed
-      parsed="$(python3 -c 'import json,sys;import os
-try:
-  d=json.load(open(sys.argv[1]))
-  v=d.get("launcher")
-  if isinstance(v,str):
-    v=v.strip().lower()
-    if v in {"amplifier","claude","codex","copilot"}:
-      print(v)
-except Exception:
-  pass' "$ctx" 2>/dev/null || true)"
-      if [[ -n "$parsed" ]]; then
+      parsed="$(jq -r '.launcher // empty' "$ctx" 2>/dev/null || true)"
+      parsed="$(printf '%s' "$parsed" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+      if [[ -n "$parsed" && "$parsed" =~ $allowed_re ]]; then
         echo "$parsed"
         return
       fi
-      break
+      if [[ -n "$parsed" ]]; then
+        break
+      fi
     fi
     cur="$(dirname "$cur")"
     hops=$((hops + 1))

--- a/amplifier-bundle/skills/transcript-viewer/SKILL.md
+++ b/amplifier-bundle/skills/transcript-viewer/SKILL.md
@@ -337,7 +337,7 @@ For **Claude Code** (`TOOL_CONTEXT="claude-code"`):
    ```bash
    $CCL <file> --format markdown --summary
    # If --summary flag is not supported, just show filename and date
-   head -1 <file> | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('timestamp',''))"
+   head -1 <file> | jq -r '.timestamp // empty'
    ```
 3. Print a summary table:
    ```
@@ -362,8 +362,7 @@ For **GitHub Copilot CLI** (`TOOL_CONTEXT="copilot"`):
      session_id=$(basename "$session_dir")
      events_file="$session_dir/events.jsonl"
      if [[ -f "$events_file" ]]; then
-       timestamp=$(head -1 "$events_file" | python3 -c \
-         "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('timestamp',''))" 2>/dev/null)
+       timestamp=$(head -1 "$events_file" | jq -r '.timestamp // empty' 2>/dev/null)
        echo "$timestamp  $session_id"
      fi
    done

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -258,3 +258,10 @@ path = "../../tests/integration/issue_655_656_skill_fetch_resilience_test.rs"
 [[test]]
 name = "p1_workflow_reliability"
 path = "../../tests/integration/p1_workflow_reliability_test.rs"
+
+# Regression guard: no stale Python recipe-runner patterns or gratuitous
+# python3 -c JSON/YAML one-liners in SKILL.md and skill shell scripts.
+# Excludes dynamic-debugger (debugpy is a legitimate Python tool).
+[[test]]
+name = "no_stale_python_patterns"
+path = "../../tests/integration/no_stale_python_patterns_test.rs"

--- a/docs/claude/skills/transcript-viewer/SKILL.md
+++ b/docs/claude/skills/transcript-viewer/SKILL.md
@@ -338,7 +338,7 @@ For **Claude Code** (`TOOL_CONTEXT="claude-code"`):
    ```bash
    $CCL <file> --format markdown --summary
    # If --summary flag is not supported, just show filename and date
-   head -1 <file> | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('timestamp',''))"
+   head -1 <file> | jq -r '.timestamp // empty'
    ```
 3. Print a summary table:
    ```
@@ -363,8 +363,7 @@ For **GitHub Copilot CLI** (`TOOL_CONTEXT="copilot"`):
      session_id=$(basename "$session_dir")
      events_file="$session_dir/events.jsonl"
      if [[ -f "$events_file" ]]; then
-       timestamp=$(head -1 "$events_file" | python3 -c \
-         "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('timestamp',''))" 2>/dev/null)
+       timestamp=$(head -1 "$events_file" | jq -r '.timestamp // empty' 2>/dev/null)
        echo "$timestamp  $session_id"
      fi
    done

--- a/tests/integration/no_stale_python_patterns_test.rs
+++ b/tests/integration/no_stale_python_patterns_test.rs
@@ -1,0 +1,193 @@
+//! Regression test: no stale Python recipe-runner patterns in SKILL.md files.
+//!
+//! Scans all SKILL.md files under `amplifier-bundle/skills/` and
+//! `docs/claude/skills/` for patterns that indicate stale Python-based
+//! recipe-runner instructions that should have been replaced with native
+//! Rust CLI equivalents:
+//!
+//! - `run_recipe_by_name` — legacy Python recipe-runner API
+//! - `from amplihack.recipes import` — legacy Python recipe module import
+//! - `python3 -c.*recipe` — inline Python invoking recipe-runner
+//!
+//! Also scans for gratuitous `python3 -c` JSON/YAML one-liners in shell
+//! snippets (excluding dynamic-debugger, which legitimately uses debugpy).
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo test --test no_stale_python_patterns -- --nocapture
+//! ```
+
+use regex::Regex;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn workspace_root() -> PathBuf {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.pop(); // bins/amplihack → bins/
+    root.pop(); // bins/ → workspace root
+    root
+}
+
+/// Recursively find every `SKILL.md` under `dir`.
+fn find_skill_files(dir: &Path) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    if !dir.is_dir() {
+        return result;
+    }
+    for entry in fs::read_dir(dir).expect("read dir") {
+        let entry = entry.expect("read dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            result.extend(find_skill_files(&path));
+        } else if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.eq_ignore_ascii_case("SKILL.md"))
+        {
+            result.push(path);
+        }
+    }
+    result
+}
+
+/// Returns true if a path is inside the dynamic-debugger skill directory
+/// (debugpy is a legitimate Python tool — do not flag it).
+fn is_dynamic_debugger(path: &Path) -> bool {
+    path.components()
+        .any(|c| c.as_os_str() == "dynamic-debugger")
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+/// TC-NOPY-01: No stale Python recipe-runner patterns in any SKILL.md.
+#[test]
+fn tc_nopy_01_no_stale_python_recipe_patterns() {
+    let patterns: Vec<(&str, Regex)> = vec![
+        (
+            "run_recipe_by_name",
+            Regex::new(r"run_recipe_by_name").unwrap(),
+        ),
+        (
+            "from amplihack.recipes import",
+            Regex::new(r"from\s+amplihack\.recipes\s+import").unwrap(),
+        ),
+        (
+            "python3 -c.*recipe",
+            Regex::new(r"python3\s+-c.*recipe").unwrap(),
+        ),
+    ];
+
+    let scan_dirs = [
+        workspace_root().join("amplifier-bundle/skills"),
+        workspace_root().join("docs/claude/skills"),
+    ];
+
+    let mut violations: Vec<String> = Vec::new();
+
+    for dir in &scan_dirs {
+        for skill_file in find_skill_files(dir) {
+            let content = fs::read_to_string(&skill_file).expect("read SKILL.md");
+            let rel_path = skill_file
+                .strip_prefix(&workspace_root())
+                .unwrap_or(&skill_file);
+
+            for (label, regex) in &patterns {
+                for (line_num, line) in content.lines().enumerate() {
+                    if regex.is_match(line) {
+                        violations.push(format!(
+                            "  {}:{}: matches '{}'\n    {}",
+                            rel_path.display(),
+                            line_num + 1,
+                            label,
+                            line.trim()
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Found stale Python recipe-runner patterns in SKILL.md files:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// TC-NOPY-02: No gratuitous `python3 -c` JSON/YAML one-liners in skills.
+///
+/// Scans SKILL.md, SECURITY.md, shell scripts, and YAML templates under
+/// the skills directories. Excludes dynamic-debugger (debugpy is legitimate).
+#[test]
+fn tc_nopy_02_no_python3_json_yaml_oneliners() {
+    let python3_re = Regex::new(r"python3\s+-c").unwrap();
+
+    let scan_dirs = [
+        workspace_root().join("amplifier-bundle/skills"),
+        workspace_root().join("docs/claude/skills"),
+    ];
+
+    let scannable_extensions = ["md", "sh", "yml", "yaml"];
+
+    let mut violations: Vec<String> = Vec::new();
+
+    for dir in &scan_dirs {
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in walkdir(dir) {
+            if is_dynamic_debugger(&entry) {
+                continue;
+            }
+
+            let ext = entry.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if !scannable_extensions.contains(&ext) {
+                continue;
+            }
+
+            let content = match fs::read_to_string(&entry) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let rel_path = entry.strip_prefix(&workspace_root()).unwrap_or(&entry);
+
+            for (line_num, line) in content.lines().enumerate() {
+                if python3_re.is_match(line) {
+                    violations.push(format!(
+                        "  {}:{}: python3 -c found\n    {}",
+                        rel_path.display(),
+                        line_num + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Found python3 -c JSON/YAML one-liners in skills (use jq/yq instead):\n{}",
+        violations.join("\n")
+    );
+}
+
+/// Recursively walk a directory and return all file paths.
+fn walkdir(dir: &Path) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    if !dir.is_dir() {
+        return result;
+    }
+    for entry in fs::read_dir(dir).expect("read dir") {
+        let entry = entry.expect("read dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            result.extend(walkdir(&path));
+        } else {
+            result.push(path);
+        }
+    }
+    result
+}

--- a/tests/outside-in/scenario1-fleet-status-basic.yaml
+++ b/tests/outside-in/scenario1-fleet-status-basic.yaml
@@ -7,6 +7,10 @@ scenario:
     test for fleet cockpit parity (AC5) and no-Python runtime (AC9).
   type: cli
   tags: [smoke, fleet, ac5, ac9, issue-77]
+  agents:
+    - name: amplihack-cli
+      type: cli
+      command: amplihack
 
   prerequisites:
     - "amplihack release binary exists at ./target/release/amplihack"


### PR DESCRIPTION
## Summary

Three tasks in one PR:

### TASK 1: Replace python3 -c with jq/native alternatives

Replaced all gratuitous `python3 -c` JSON/YAML one-liners in skill files with `jq` or `yq`:

- **weekly-report.yml / monthly-report.yml**: 5 calls each → `jq` for JSON array length and record formatting
- **transcript-viewer/SKILL.md** (both copies): 2 calls → `jq -r '.timestamp // empty'`
- **code-atlas/SECURITY.md**: Removed python3 YAML example, kept yq-only
- **code-atlas test scripts**: Changed from python3-first to yq-first (no python3 fallback)
- **migrate.sh**: Replaced python3 JSON launcher detection with `jq`

Dynamic-debugger is excluded (debugpy is a legitimate Python tool).

### TASK 2: CI regression test

New integration test `no_stale_python_patterns` with two test cases:
- **TC-NOPY-01**: Scans all SKILL.md files for stale Python recipe-runner patterns (`run_recipe_by_name`, `from amplihack.recipes import`, `python3 -c.*recipe`)
- **TC-NOPY-02**: Scans skill files (md/sh/yml/yaml) for any `python3 -c` one-liners (excludes dynamic-debugger)

Registered in `bins/amplihack/Cargo.toml` as test target.

### TASK 3: Fix gadugi-test CLI executor bug

**Root cause**: The `scenarioAdapter.adaptStepToOrchestrator()` function only looked for `params.command` to build the target string, but our scenario YAML files use `step.target` directly (OrchestratorScenario format). The adapter was discarding the `target` field, resulting in an empty command string.

**Fixes**:
- **scenarioAdapter**: Preserve `step.target`, `expected`, `contains`, `matches`, `env`, `args`, `description` when present
- **CLIAgent**: Added `launch` to COMMAND_ACTIONS, `verify_exit_code`/`verify_output` as aliases for `validate_*`, support for `step.args` array and `step.env` object, and `contains`/`matches` output verification
- **scenario1**: Added missing `agents` field (required by validator)

**Result**: All 9 scenarios now load successfully (previously scenario1 failed with 'must have at least one agent'). CLI commands execute correctly instead of failing with 'The argument file cannot be empty'.

## Testing

```bash
cargo test --test no_stale_python_patterns -- --nocapture  # Both TCs pass
gadugi-test run --directory tests/outside-in                # All 9 scenarios load
```