### PR TITLE
fix: replace python3 -c with jq/yq, add stale-pattern CI test, fix gadugi scenario (#661)

### DIFF
--- a/amplifier-bundle/skills/code-atlas/SECURITY.md
+++ b/amplifier-bundle/skills/code-atlas/SECURITY.md
@@ -187,9 +187,10 @@ with open("package.json") as f:
 ```
 
 ```bash
-# Safe: use yq or python for YAML parsing, not bash eval
+# Safe: use yq for YAML parsing, not bash eval
 yq e '.services | keys' docker-compose.yml
-python3 -c "import yaml,sys; d=yaml.safe_load(sys.stdin); print(list(d.get('services',{}).keys()))" < docker-compose.yml
+# Alternative: parse YAML service names with yq
+yq e '.services | keys | .[]' docker-compose.yml
 ```
 
 **Anti-pattern:**

--- a/amplifier-bundle/skills/code-atlas/tests/test_ci_workflow.sh
+++ b/amplifier-bundle/skills/code-atlas/tests/test_ci_workflow.sh
@@ -178,29 +178,15 @@ fi
 echo ""
 echo "=== YAML Validity ==="
 
-if command -v python3 >/dev/null 2>&1; then
-    yaml_valid=$(python3 -c "
-import sys
-try:
-    import yaml
-    with open('${CI_WORKFLOW}') as f:
-        yaml.safe_load(f)
-    print('true')
-except Exception as e:
-    print('false')
-    sys.stderr.write(str(e) + '\n')
-" 2>/dev/null || echo "false")
-    assert_pass "atlas-ci.yml is valid YAML (python3+yaml)" "$yaml_valid"
-elif command -v yq >/dev/null 2>&1; then
+if command -v yq >/dev/null 2>&1; then
     if yq '.' "$CI_WORKFLOW" > /dev/null 2>&1; then
-        echo "PASS: atlas-ci.yml is valid YAML (yq)"
-        PASS=$((PASS + 1))
+        assert_pass "atlas-ci.yml is valid YAML (yq)" "true"
     else
         echo "FAIL: atlas-ci.yml has invalid YAML syntax"
         FAIL=$((FAIL + 1))
     fi
 else
-    echo "SKIP: YAML validity check (python3+yaml or yq required)"
+    echo "SKIP: YAML validity check (yq required)"
 fi
 
 # ============================================================================

--- a/amplifier-bundle/skills/code-atlas/tests/test_layer7_8.sh
+++ b/amplifier-bundle/skills/code-atlas/tests/test_layer7_8.sh
@@ -448,16 +448,16 @@ assert_file_contains \
     "$RECIPE"
 
 # Validate YAML is parseable
-if command -v python3 &>/dev/null; then
-    if python3 -c "import yaml; yaml.safe_load(open('${RECIPE}'))" 2>/dev/null; then
-        echo "PASS: Recipe YAML is valid (python3 yaml.safe_load)"
+if command -v yq &>/dev/null; then
+    if yq '.' "${RECIPE}" > /dev/null 2>&1; then
+        echo "PASS: Recipe YAML is valid (yq)"
         PASS=$((PASS + 1))
     else
         echo "FAIL: Recipe YAML is invalid — parse error"
         FAIL=$((FAIL + 1))
     fi
 else
-    echo "SKIP: python3 not available — cannot validate YAML syntax"
+    echo "SKIP: yq not available — cannot validate YAML syntax"
 fi
 
 # ---------------------------------------------------------------------------

--- a/amplifier-bundle/skills/gh-work-report/templates/monthly-report.yml
+++ b/amplifier-bundle/skills/gh-work-report/templates/monthly-report.yml
@@ -94,9 +94,9 @@ jobs:
           mkdir -p docs/reports
 
           REPO_COUNT=$(cat /tmp/report-data/repos.json | wc -l)
-          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))")
-          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))")
-          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))")
+          PR_CREATED=$(jq 'length' /tmp/report-data/prs-created.json)
+          PR_MERGED=$(jq 'length' /tmp/report-data/prs-merged.json)
+          ISSUES=$(jq 'length' /tmp/report-data/issues.json)
 
           cat > "$REPORT" << EOF
           # GitHub Activity Report: ${START} → ${END}
@@ -119,62 +119,37 @@ jobs:
 
           echo "| # | Title | Repository | Status | Created |" >> "$REPORT"
           echo "|---|-------|-----------|--------|---------|" >> "$REPORT"
-          python3 -c "
-          import json
-          prs = json.load(open('/tmp/report-data/prs-created.json'))
-          for pr in prs[:100]:
-              repo = pr.get('repository', {})
-              repo_name = repo.get('nameWithOwner', 'unknown') if isinstance(repo, dict) else str(repo)
-              print(f'| [#{pr[\"number\"]}]({pr[\"url\"]}) | {pr[\"title\"]} | {repo_name} | {pr[\"state\"]} | {pr[\"createdAt\"][:10]} |')
-          " >> "$REPORT"
+          jq -r '.[:100][] | "| [#\(.number)](\(.url)) | \(.title) | \((.repository.nameWithOwner // .repository // "unknown") | tostring) | \(.state) | \(.createdAt[:10]) |"' \
+            /tmp/report-data/prs-created.json >> "$REPORT"
 
           echo "" >> "$REPORT"
           echo "## Active Repositories" >> "$REPORT"
           echo "" >> "$REPORT"
           echo "| Repository | Description | Last Push |" >> "$REPORT"
           echo "|-----------|-------------|-----------|" >> "$REPORT"
-          cat /tmp/report-data/repos.json | python3 -c "
-          import json, sys
-          for line in sys.stdin:
-              r = json.loads(line)
-              desc = (r.get('description') or '—')[:60]
-              print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
-          " >> "$REPORT"
+          jq -Rs 'split("\n") | map(select(length > 0)) | map(fromjson) | .[] | "| [\(.nameWithOwner)](\(.url)) | \((.description // "—")[:60]) | \(.pushedAt[:10]) |"' \
+            /tmp/report-data/repos.json >> "$REPORT"
 
           sed -i 's/^          //' "$REPORT"
 
       - name: Update index page
         run: |
-          python3 << 'PYEOF'
-          import os, re
-
-          reports_dir = "docs/reports"
-          reports = sorted(
-              [f for f in os.listdir(reports_dir) if f.endswith(".md") and f != ".gitkeep"],
-              reverse=True
-          )
-
-          index_items = []
-          for r in reports:
-              match = re.search(r"report-(\d{4}-\d{2}-\d{2})-to-(\d{4}-\d{2}-\d{2})", r)
-              if match:
-                  start, end = match.groups()
-                  index_items.append(f'<li><a href="reports/{r}">{start} → {end}</a></li>')
-
-          with open("docs/index.html", "r") as f:
-              html = f.read()
-
-          list_html = "\n".join(index_items) if index_items else "<li>No reports yet</li>"
-          html = re.sub(
-              r"(<!-- REPORT_LIST_START -->).*?(<!-- REPORT_LIST_END -->)",
-              rf"\1\n{list_html}\n\2",
-              html,
-              flags=re.DOTALL
-          )
-
-          with open("docs/index.html", "w") as f:
-              f.write(html)
-          PYEOF
+          reports_dir="docs/reports"
+          list_html=""
+          for r in $(ls -r "$reports_dir"/report-*.md 2>/dev/null); do
+            fname=$(basename "$r")
+            start=$(echo "$fname" | sed -n 's/report-\([0-9-]*\)-to-.*/\1/p')
+            end=$(echo "$fname" | sed -n 's/report-[0-9-]*-to-\([0-9-]*\)\.md/\1/p')
+            if [ -n "$start" ] && [ -n "$end" ]; then
+              list_html="${list_html}<li><a href=\"reports/${fname}\">${start} → ${end}</a></li>\n"
+            fi
+          done
+          [ -z "$list_html" ] && list_html="<li>No reports yet</li>"
+          awk -v items="$list_html" '
+            /<!-- REPORT_LIST_START -->/ { print; printf "%s\n", items; skip=1; next }
+            /<!-- REPORT_LIST_END -->/   { skip=0 }
+            !skip
+          ' docs/index.html > docs/index.html.tmp && mv docs/index.html.tmp docs/index.html
 
       - name: Commit and push
         run: |

--- a/amplifier-bundle/skills/gh-work-report/templates/weekly-report.yml
+++ b/amplifier-bundle/skills/gh-work-report/templates/weekly-report.yml
@@ -105,9 +105,9 @@ jobs:
 
           # Count metrics
           REPO_COUNT=$(cat /tmp/report-data/repos.json | wc -l)
-          PR_CREATED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-created.json'))))")
-          PR_MERGED=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/prs-merged.json'))))")
-          ISSUES=$(python3 -c "import json; print(len(json.load(open('/tmp/report-data/issues.json'))))")
+          PR_CREATED=$(jq 'length' /tmp/report-data/prs-created.json)
+          PR_MERGED=$(jq 'length' /tmp/report-data/prs-merged.json)
+          ISSUES=$(jq 'length' /tmp/report-data/issues.json)
 
           cat > "$REPORT" << EOF
           # GitHub Activity Report: ${START} → ${END}
@@ -131,64 +131,38 @@ jobs:
           # Add PR table
           echo "| # | Title | Repository | Status | Created |" >> "$REPORT"
           echo "|---|-------|-----------|--------|---------|" >> "$REPORT"
-          python3 -c "
-          import json
-          prs = json.load(open('/tmp/report-data/prs-created.json'))
-          for pr in prs[:50]:
-              repo = pr.get('repository', {})
-              repo_name = repo.get('nameWithOwner', 'unknown') if isinstance(repo, dict) else str(repo)
-              print(f'| [#{pr[\"number\"]}]({pr[\"url\"]}) | {pr[\"title\"]} | {repo_name} | {pr[\"state\"]} | {pr[\"createdAt\"][:10]} |')
-          " >> "$REPORT"
+          jq -r '.[:50][] | "| [#\(.number)](\(.url)) | \(.title) | \((.repository.nameWithOwner // .repository // "unknown") | tostring) | \(.state) | \(.createdAt[:10]) |"' \
+            /tmp/report-data/prs-created.json >> "$REPORT"
 
           echo "" >> "$REPORT"
           echo "## Active Repositories" >> "$REPORT"
           echo "" >> "$REPORT"
           echo "| Repository | Description | Last Push |" >> "$REPORT"
           echo "|-----------|-------------|-----------|" >> "$REPORT"
-          cat /tmp/report-data/repos.json | python3 -c "
-          import json, sys
-          for line in sys.stdin:
-              r = json.loads(line)
-              desc = (r.get('description') or '—')[:60]
-              print(f'| [{r[\"nameWithOwner\"]}]({r[\"url\"]}) | {desc} | {r[\"pushedAt\"][:10]} |')
-          " >> "$REPORT"
+          jq -Rs 'split("\n") | map(select(length > 0)) | map(fromjson) | .[] | "| [\(.nameWithOwner)](\(.url)) | \((.description // "—")[:60]) | \(.pushedAt[:10]) |"' \
+            /tmp/report-data/repos.json >> "$REPORT"
 
           # Strip leading whitespace from heredoc
           sed -i 's/^          //' "$REPORT"
 
       - name: Update index page
         run: |
-          python3 << 'PYEOF'
-          import os, re
-
-          reports_dir = "docs/reports"
-          reports = sorted(
-              [f for f in os.listdir(reports_dir) if f.endswith(".md") and f != ".gitkeep"],
-              reverse=True
-          )
-
-          index_items = []
-          for r in reports:
-              match = re.search(r"report-(\d{4}-\d{2}-\d{2})-to-(\d{4}-\d{2}-\d{2})", r)
-              if match:
-                  start, end = match.groups()
-                  index_items.append(f'<li><a href="reports/{r}">{start} → {end}</a></li>')
-
-          with open("docs/index.html", "r") as f:
-              html = f.read()
-
-          # Replace report list placeholder
-          list_html = "\n".join(index_items) if index_items else "<li>No reports yet</li>"
-          html = re.sub(
-              r"(<!-- REPORT_LIST_START -->).*?(<!-- REPORT_LIST_END -->)",
-              rf"\1\n{list_html}\n\2",
-              html,
-              flags=re.DOTALL
-          )
-
-          with open("docs/index.html", "w") as f:
-              f.write(html)
-          PYEOF
+          reports_dir="docs/reports"
+          list_html=""
+          for r in $(ls -r "$reports_dir"/report-*.md 2>/dev/null); do
+            fname=$(basename "$r")
+            start=$(echo "$fname" | sed -n 's/report-\([0-9-]*\)-to-.*/\1/p')
+            end=$(echo "$fname" | sed -n 's/report-[0-9-]*-to-\([0-9-]*\)\.md/\1/p')
+            if [ -n "$start" ] && [ -n "$end" ]; then
+              list_html="${list_html}<li><a href=\"reports/${fname}\">${start} → ${end}</a></li>\n"
+            fi
+          done
+          [ -z "$list_html" ] && list_html="<li>No reports yet</li>"
+          awk -v items="$list_html" '
+            /<!-- REPORT_LIST_START -->/ { print; printf "%s\n", items; skip=1; next }
+            /<!-- REPORT_LIST_END -->/   { skip=0 }
+            !skip
+          ' docs/index.html > docs/index.html.tmp && mv docs/index.html.tmp docs/index.html
 
       - name: Commit and push
         run: |

--- a/amplifier-bundle/skills/migrate/scripts/migrate.sh
+++ b/amplifier-bundle/skills/migrate/scripts/migrate.sh
@@ -99,17 +99,8 @@ detect_cli() {
     local ctx="$cur/.claude/runtime/launcher_context.json"
     if [[ -f "$ctx" ]]; then
       local parsed
-      parsed="$(python3 -c 'import json,sys;import os
-try:
-  d=json.load(open(sys.argv[1]))
-  v=d.get("launcher")
-  if isinstance(v,str):
-    v=v.strip().lower()
-    if v in {"amplifier","claude","codex","copilot"}:
-      print(v)
-except Exception:
-  pass' "$ctx" 2>/dev/null || true)"
-      if [[ -n "$parsed" ]]; then
+      parsed="$(jq -r '.launcher // empty' "$ctx" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]' || true)"
+      if [[ "$parsed" =~ ^(amplifier|claude|codex|copilot)$ ]]; then
         echo "$parsed"
         return
       fi

--- a/amplifier-bundle/skills/transcript-viewer/SKILL.md
+++ b/amplifier-bundle/skills/transcript-viewer/SKILL.md
@@ -337,7 +337,7 @@ For **Claude Code** (`TOOL_CONTEXT="claude-code"`):
    ```bash
    $CCL <file> --format markdown --summary
    # If --summary flag is not supported, just show filename and date
-   head -1 <file> | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('timestamp',''))"
+   head -1 <file> | jq -r '.timestamp // empty'
    ```
 3. Print a summary table:
    ```
@@ -362,8 +362,7 @@ For **GitHub Copilot CLI** (`TOOL_CONTEXT="copilot"`):
      session_id=$(basename "$session_dir")
      events_file="$session_dir/events.jsonl"
      if [[ -f "$events_file" ]]; then
-       timestamp=$(head -1 "$events_file" | python3 -c \
-         "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('timestamp',''))" 2>/dev/null)
+       timestamp=$(head -1 "$events_file" | jq -r '.timestamp // empty' 2>/dev/null)
        echo "$timestamp  $session_id"
      fi
    done

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -258,3 +258,9 @@ path = "../../tests/integration/issue_655_656_skill_fetch_resilience_test.rs"
 [[test]]
 name = "p1_workflow_reliability"
 path = "../../tests/integration/p1_workflow_reliability_test.rs"
+
+# Issue #661: Scan SKILL.md files for stale Python recipe-runner patterns.
+# Prevents re-introduction of run_recipe_by_name, python3 -c recipe, etc.
+[[test]]
+name = "no_stale_python_patterns"
+path = "../../tests/integration/no_stale_python_patterns_test.rs"

--- a/docs/claude/skills/transcript-viewer/SKILL.md
+++ b/docs/claude/skills/transcript-viewer/SKILL.md
@@ -338,7 +338,7 @@ For **Claude Code** (`TOOL_CONTEXT="claude-code"`):
    ```bash
    $CCL <file> --format markdown --summary
    # If --summary flag is not supported, just show filename and date
-   head -1 <file> | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('timestamp',''))"
+   head -1 <file> | jq -r '.timestamp // empty'
    ```
 3. Print a summary table:
    ```
@@ -363,8 +363,7 @@ For **GitHub Copilot CLI** (`TOOL_CONTEXT="copilot"`):
      session_id=$(basename "$session_dir")
      events_file="$session_dir/events.jsonl"
      if [[ -f "$events_file" ]]; then
-       timestamp=$(head -1 "$events_file" | python3 -c \
-         "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('timestamp',''))" 2>/dev/null)
+       timestamp=$(head -1 "$events_file" | jq -r '.timestamp // empty' 2>/dev/null)
        echo "$timestamp  $session_id"
      fi
    done

--- a/tests/integration/no_stale_python_patterns_test.rs
+++ b/tests/integration/no_stale_python_patterns_test.rs
@@ -1,0 +1,178 @@
+/// CI regression test — Issue #661: no stale Python recipe-runner patterns.
+///
+/// Scans all SKILL.md files under `amplifier-bundle/skills/` and
+/// `docs/claude/skills/` for patterns that indicate leftover Python
+/// recipe-runner usage that should have been replaced with Rust CLI
+/// equivalents.
+///
+/// Checked patterns:
+///   - `run_recipe_by_name`      — legacy Python recipe invocation
+///   - `from amplihack.recipes import` — legacy Python import
+///   - `python3 -c` + `recipe`   — inline Python recipe calls
+///
+/// Excludes dynamic-debugger (debugpy is a legitimate Python tool).
+///
+/// # Running
+///
+/// ```bash
+/// cargo test --test no_stale_python_patterns -- --nocapture
+/// ```
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn workspace_root() -> PathBuf {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.pop(); // bins/amplihack → bins/
+    root.pop(); // bins/ → workspace root
+    root
+}
+
+/// Recursively find every `SKILL.md` (case-insensitive) under `dir`.
+fn find_skill_files(dir: &Path) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    if !dir.is_dir() {
+        return result;
+    }
+    for entry in fs::read_dir(dir).expect("read dir") {
+        let entry = entry.expect("read dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            result.extend(find_skill_files(&path));
+        } else if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.eq_ignore_ascii_case("SKILL.md"))
+        {
+            result.push(path);
+        }
+    }
+    result
+}
+
+/// Returns true if the path is under a `dynamic-debugger` directory
+/// (debugpy is a legitimate Python tool — exempt from this scan).
+fn is_dynamic_debugger(path: &Path) -> bool {
+    path.components().any(|c| {
+        c.as_os_str()
+            .to_str()
+            .is_some_and(|s| s == "dynamic-debugger")
+    })
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// TC-STALE-01: No `run_recipe_by_name` in any SKILL.md.
+#[test]
+fn no_run_recipe_by_name_in_skill_files() {
+    let root = workspace_root();
+    let dirs = [
+        root.join("amplifier-bundle/skills"),
+        root.join("docs/claude/skills"),
+    ];
+
+    let mut violations = Vec::new();
+    for dir in &dirs {
+        for path in find_skill_files(dir) {
+            if is_dynamic_debugger(&path) {
+                continue;
+            }
+            let content = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            for (i, line) in content.lines().enumerate() {
+                if line.contains("run_recipe_by_name") {
+                    violations.push(format!(
+                        "  {}:{}: {}",
+                        path.strip_prefix(&root).unwrap_or(&path).display(),
+                        i + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "Found stale `run_recipe_by_name` references in SKILL.md files:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// TC-STALE-02: No `from amplihack.recipes import` in any SKILL.md.
+#[test]
+fn no_python_recipe_import_in_skill_files() {
+    let root = workspace_root();
+    let dirs = [
+        root.join("amplifier-bundle/skills"),
+        root.join("docs/claude/skills"),
+    ];
+
+    let mut violations = Vec::new();
+    for dir in &dirs {
+        for path in find_skill_files(dir) {
+            if is_dynamic_debugger(&path) {
+                continue;
+            }
+            let content = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            for (i, line) in content.lines().enumerate() {
+                if line.contains("from amplihack.recipes import")
+                    || line.contains("from amplihack.recipes import")
+                {
+                    violations.push(format!(
+                        "  {}:{}: {}",
+                        path.strip_prefix(&root).unwrap_or(&path).display(),
+                        i + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "Found stale `from amplihack.recipes import` references in SKILL.md files:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// TC-STALE-03: No `python3 -c` combined with `recipe` in any SKILL.md.
+#[test]
+fn no_python3_c_recipe_in_skill_files() {
+    let root = workspace_root();
+    let dirs = [
+        root.join("amplifier-bundle/skills"),
+        root.join("docs/claude/skills"),
+    ];
+
+    let re = Regex::new(r"python3\s+-c.*recipe").expect("compile regex");
+
+    let mut violations = Vec::new();
+    for dir in &dirs {
+        for path in find_skill_files(dir) {
+            if is_dynamic_debugger(&path) {
+                continue;
+            }
+            let content = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            for (i, line) in content.lines().enumerate() {
+                if re.is_match(line) {
+                    violations.push(format!(
+                        "  {}:{}: {}",
+                        path.strip_prefix(&root).unwrap_or(&path).display(),
+                        i + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "Found stale `python3 -c ... recipe` calls in SKILL.md files:\n{}",
+        violations.join("\n")
+    );
+}

--- a/tests/outside-in/scenario1-fleet-status-basic.yaml
+++ b/tests/outside-in/scenario1-fleet-status-basic.yaml
@@ -8,6 +8,11 @@ scenario:
   type: cli
   tags: [smoke, fleet, ac5, ac9, issue-77]
 
+  agents:
+    - name: amplihack-cli
+      type: cli
+      command: amplihack
+
   prerequisites:
     - "amplihack release binary exists at ./target/release/amplihack"
     - "No Python interpreter required on PATH"


### PR DESCRIPTION
## Summary

Addresses all three tasks from #661 in a single PR.

### TASK 1: Replace python3 -c with jq/yq/native shell

Replaced all `python3 -c` JSON/YAML calls in amplifier-bundle skills with `jq`, `yq`, or native shell equivalents:

| File | Change |
|------|--------|
| weekly-report.yml | 5 `python3 -c` → `jq` + `awk` for index page |
| monthly-report.yml | 5 `python3 -c` → `jq` + `awk` for index page |
| transcript-viewer/SKILL.md | 2 `python3 -c` → `jq` (both copies) |
| code-atlas/SECURITY.md | Python YAML example → `yq` |
| test_ci_workflow.sh | Python yaml validation → `yq` |
| test_layer7_8.sh | Python yaml validation → `yq` |
| migrate.sh | Python JSON parsing → `jq` |

Dynamic-debugger left untouched (debugpy is legitimate Python).

### TASK 2: CI regression test

New `no_stale_python_patterns_test.rs` scans all SKILL.md files under `amplifier-bundle/skills/` and `docs/claude/skills/` for:
- `run_recipe_by_name`
- `from amplihack.recipes import`
- `python3 -c.*recipe`

Registered in `bins/amplihack/Cargo.toml`. All 3 test cases pass.

### TASK 3: Fix gadugi-test scenario loading

Added missing `agents` section to `scenario1-fleet-status-basic.yaml`. Root cause: gadugi-test's `validateScenario()` requires a non-empty `agents` array, and scenario1 was the only scenario missing it.

## Test Plan

- [x] `cargo test --test no_stale_python_patterns` — 3/3 pass
- [x] `cargo test --test issue_655_656_skill_fetch_resilience` — 18/18 pass (no regression)
- [x] `gadugi-test run --scenario "Fleet Status" --directory tests/outside-in` — scenario now loads
- [x] Pre-commit hooks: YAML, TOML, fmt, clippy all pass

Closes #661