### PR TITLE
fix(install): remove dead Python XPIA hook verification

### DIFF
--- a/crates/amplihack-cli/src/commands/install/paths.rs
+++ b/crates/amplihack-cli/src/commands/install/paths.rs
@@ -67,8 +67,8 @@ pub(super) fn global_settings_path() -> Result<PathBuf> {
 ///
 /// Fresh native installs use unified `amplihack-hooks <subcmd>` entries for the
 /// live hook path, but the presence of staged XPIA assets is still used to
-/// verify optional installation state and to upgrade legacy `tools/xpia/hooks/*.py`
-/// settings entries in place during reinstall.
+/// verify optional installation state and to upgrade legacy hook settings
+/// entries in place during reinstall.
 pub(super) fn xpia_hooks_dir() -> Result<PathBuf> {
     Ok(home_dir()?
         .join(".amplihack")

--- a/crates/amplihack-cli/src/commands/install/settings.rs
+++ b/crates/amplihack-cli/src/commands/install/settings.rs
@@ -122,14 +122,7 @@ pub(super) fn verify_framework_assets(claude_dir: &Path) -> Result<()> {
     if !xpia_dir.exists() {
         println!("  ℹ️  XPIA security hooks not installed (optional feature)");
     } else {
-        for file in XPIA_HOOK_FILES {
-            let hook_path = xpia_dir.join(file);
-            if hook_path.exists() {
-                println!("    ✅ {file} found");
-            } else {
-                println!("    ❌ {file} missing");
-            }
-        }
+        println!("  ✅ XPIA security hooks directory found");
     }
 
     Ok(())

--- a/crates/amplihack-cli/src/commands/install/tests/settings_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/settings_tests.rs
@@ -75,7 +75,7 @@ fn ensure_settings_json_succeeds_without_legacy_python_hook_files() {
 }
 
 #[test]
-fn ensure_settings_json_with_xpia_assets_keeps_unified_native_wrappers() {
+fn ensure_settings_json_with_xpia_dir_keeps_unified_native_wrappers() {
     let _guard = crate::test_support::home_env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -85,13 +85,11 @@ fn ensure_settings_json_with_xpia_assets_keeps_unified_native_wrappers() {
     let staging_dir = temp.path().join(".amplihack/.claude");
     let xpia_hooks = staging_dir.join("tools/xpia/hooks");
     fs::create_dir_all(&xpia_hooks).unwrap();
-    for file in XPIA_HOOK_FILES {
-        fs::write(xpia_hooks.join(file), "print(1)\n").unwrap();
-    }
+    // No .py or .sh stub files — the Rust binary IS the XPIA implementation.
     let hooks_bin = create_exe_stub(temp.path(), "amplihack-hooks");
 
     let result = settings::ensure_settings_json(&staging_dir, 99999, &hooks_bin)
-        .expect("settings setup should succeed with staged xpia assets");
+        .expect("settings setup should succeed with xpia dir present (no script files needed)");
     assert!(result.0, "settings setup must succeed");
 
     let settings_raw = fs::read_to_string(temp.path().join(".claude/settings.json")).unwrap();
@@ -230,5 +228,163 @@ fn backup_metadata_is_always_valid_json() {
             meta.get("backup_path").is_some(),
             "backup metadata must have 'backup_path'"
         );
+    }
+}
+
+// ─── TDD: XPIA Python removal — tests written before implementation ─────────
+
+#[test]
+fn xpia_hook_files_constant_must_not_exist() {
+    // After the change, XPIA_HOOK_FILES should be deleted from types.rs.
+    // This test verifies the constant is not referenced anywhere in production
+    // code by checking the source file directly.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let types_src = fs::read_to_string(
+        std::path::Path::new(manifest_dir).join("src/commands/install/types.rs"),
+    )
+    .expect("types.rs must be readable");
+
+    assert!(
+        !types_src.contains("XPIA_HOOK_FILES"),
+        "XPIA_HOOK_FILES constant must be removed from types.rs — \
+         XPIA security is implemented by the Rust amplihack-hooks binary, \
+         not by .py/.sh script files"
+    );
+}
+
+#[test]
+fn verify_framework_assets_does_not_check_individual_xpia_files() {
+    // After the change, verify_framework_assets should NOT iterate over
+    // individual hook files in the xpia directory. It should only check
+    // whether the xpia directory exists.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let settings_src = fs::read_to_string(
+        std::path::Path::new(manifest_dir).join("src/commands/install/settings.rs"),
+    )
+    .expect("settings.rs must be readable");
+
+    // The per-file loop `for file in XPIA_HOOK_FILES` must be gone
+    assert!(
+        !settings_src.contains("XPIA_HOOK_FILES"),
+        "verify_framework_assets must not reference XPIA_HOOK_FILES — \
+         the per-file verification loop should be removed"
+    );
+
+    // Should still have the xpia_dir.exists() check (informational)
+    assert!(
+        settings_src.contains("xpia_dir") || settings_src.contains("xpia_hooks_dir"),
+        "verify_framework_assets should still check for xpia directory existence"
+    );
+}
+
+#[test]
+fn xpia_hooks_dir_docstring_has_no_python_reference() {
+    // After the change, the xpia_hooks_dir() docstring should not mention *.py files.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let paths_src = fs::read_to_string(
+        std::path::Path::new(manifest_dir).join("src/commands/install/paths.rs"),
+    )
+    .expect("paths.rs must be readable");
+
+    // Find the docstring for xpia_hooks_dir (between /// comments before the fn)
+    let fn_idx = paths_src
+        .find("fn xpia_hooks_dir")
+        .expect("xpia_hooks_dir function must exist");
+    let preceding = &paths_src[..fn_idx];
+
+    assert!(
+        !preceding.contains("*.py"),
+        "xpia_hooks_dir docstring must not reference *.py files — \
+         Python XPIA hooks are dead legacy code"
+    );
+}
+
+#[test]
+fn verify_framework_assets_succeeds_with_empty_xpia_dir() {
+    // After the change, verify_framework_assets should succeed when the
+    // xpia directory exists but contains NO script files — because the
+    // Rust binary handles everything.
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    // Create staged assets
+    create_minimal_staged_assets(temp.path());
+
+    // Create the xpia hooks directory but leave it EMPTY
+    let xpia_dir = temp.path().join(".amplihack/.claude/tools/xpia/hooks");
+    fs::create_dir_all(&xpia_dir).unwrap();
+
+    let result = settings::verify_framework_assets(&temp.path().join(".amplihack/.claude"));
+
+    crate::test_support::restore_home(previous);
+
+    // Must succeed — no individual file checks
+    assert!(
+        result.is_ok(),
+        "verify_framework_assets must succeed with empty xpia dir — \
+         it should not check for individual .py/.sh files: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn xpia_hook_specs_use_binary_subcmd_not_scripts() {
+    // XPIA_HOOK_SPECS must remain intact and use BinarySubcmd exclusively.
+    // This is the CORRECT way XPIA hooks are implemented — via the Rust binary.
+    for spec in XPIA_HOOK_SPECS {
+        match &spec.cmd {
+            HookCommandKind::BinarySubcmd { subcmd } => {
+                assert!(
+                    !subcmd.is_empty(),
+                    "XPIA hook spec for '{}' must have a non-empty subcmd",
+                    spec.event
+                );
+                assert!(
+                    !subcmd.contains(".py") && !subcmd.contains(".sh"),
+                    "XPIA hook spec subcmd must not reference script files: {subcmd}"
+                );
+            }
+        }
+    }
+
+    // Verify the three expected XPIA events are present
+    let events: Vec<&str> = XPIA_HOOK_SPECS.iter().map(|s| s.event).collect();
+    assert!(
+        events.contains(&"SessionStart"),
+        "XPIA must include SessionStart"
+    );
+    assert!(
+        events.contains(&"PreToolUse"),
+        "XPIA must include PreToolUse"
+    );
+    assert!(
+        events.contains(&"PostToolUse"),
+        "XPIA must include PostToolUse"
+    );
+}
+
+#[test]
+fn no_production_code_references_xpia_hook_files() {
+    // Comprehensive check: no non-test production code should reference
+    // XPIA_HOOK_FILES after the cleanup.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let install_dir = std::path::Path::new(manifest_dir).join("src/commands/install");
+
+    for entry in fs::read_dir(&install_dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.extension().map_or(false, |e| e == "rs")
+            && !path.to_str().unwrap_or("").contains("tests")
+        {
+            let content = fs::read_to_string(&path).unwrap();
+            assert!(
+                !content.contains("XPIA_HOOK_FILES"),
+                "Production file {} must not reference XPIA_HOOK_FILES",
+                path.display()
+            );
+        }
     }
 }

--- a/crates/amplihack-cli/src/commands/install/types.rs
+++ b/crates/amplihack-cli/src/commands/install/types.rs
@@ -158,9 +158,6 @@ pub(super) const RUNTIME_DIRS: &[&str] = &[
     "runtime/security",
     "runtime/analysis",
 ];
-pub(super) const XPIA_HOOK_FILES: &[&str] =
-    &["session_start.sh", "post_tool_use.sh", "pre_tool_use.sh"];
-
 /// Discriminates between hook command styles.
 #[derive(Clone)]
 pub(super) enum HookCommandKind {

--- a/docs/howto/settings-hook-configuration.md
+++ b/docs/howto/settings-hook-configuration.md
@@ -4,55 +4,80 @@
 
 Amplihack automatically configures hooks in `~/.claude/settings.json` during installation and CLI initialization. This guide explains the hook configuration process and how to troubleshoot issues.
 
-## Automatic Configuration (New in v0.5.27)
+## Automatic Configuration
 
-Starting in v0.5.27, hook configuration is **completely automatic** - no user prompts required.
+Hook configuration is **completely automatic** — no user prompts required.
 
-When `amplihack-hooks` is installed, amplihack registers native hook
-subcommands automatically. Hook configuration is binary-first and does not
-require helper scripts in the installed framework bundle.
+The `amplihack-hooks` binary provides all hook functionality as native subcommands. There are no Python or shell script hook files to install, validate, or maintain. Hook registration writes `amplihack-hooks <subcommand>` entries directly into `settings.json`.
 
 ### What Happens Automatically
 
 When you run `amplihack` or install the framework:
 
-1. **Validation**: Hook files are validated before configuration
+1. **Binary resolution**: The installer locates the `amplihack-hooks` binary (see [Binary Resolution](../reference/binary-resolution.md))
 2. **Backup**: Settings are backed up to `~/.claude/settings.json.backup.<timestamp>`
-3. **Configuration**: Hooks are added/updated in settings.json
+3. **Registration**: Hook subcommand entries are added/updated in settings.json
 4. **Verification**: System confirms hooks are properly configured
 
 **No user intervention required!**
 
-## Hook Validation
+## Hook Architecture
+
+### Rust-Native Hooks
+
+All hooks are implemented as subcommands of the compiled `amplihack-hooks` binary. The installer registers entries like:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "amplihack-hooks session-start"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": "amplihack-hooks post-tool-use"
+      }
+    ]
+  }
+}
+```
+
+**Hook Subcommands:**
+
+| Subcommand | Event | Purpose |
+|---|---|---|
+| `session-start` | SessionStart | Session initialization and context setup |
+| `pre-tool-use` | PreToolUse | Pre-tool analysis (registered when XPIA assets present) |
+| `post-tool-use` | PostToolUse | Post-tool analysis and workflow enforcement |
+| `stop` | Stop | Session cleanup and metrics flush |
+| `pre-compact` | PreCompact | Context preservation before compaction |
+
+**XPIA security behavior:** When the `tools/xpia` directory is present in the staged framework assets, the `session-start`, `pre-tool-use`, and `post-tool-use` subcommands additionally activate XPIA defense logic (implemented in `amplihack-security::XpiaDefender`). No extra hook entries are added — the same `amplihack-hooks <subcommand>` invocation handles both framework and security duties. The `pre-tool-use` subcommand is only registered when XPIA assets are present.
 
 ### What Is Validated
 
-The system validates that all required hook files exist before configuring them:
+The installer validates:
 
-**Amplihack Hooks (Required):**
+- The `amplihack-hooks` binary exists and is executable
+- Hook command strings contain no shell metacharacters (injection prevention)
+- Each hook entry is syntactically correct before writing to settings.json
 
-- `session_start.py` - Runs when Claude Code session starts
-- `stop.py` - Runs when Claude Code session stops
-- `post_tool_use.py` - Runs after each tool invocation
-- `pre_compact.py` - Runs before context compaction
-
-**XPIA Hooks (Optional):**
-
-- `session_start.py` - Security initialization
-- `post_tool_use.py` - Security monitoring
-- `pre_tool_use.py` - Input validation
+**No per-file hook script validation occurs** — all hook logic lives in the compiled binary.
 
 ### Error Messages
 
-If required hooks are missing, you'll see:
+If the hooks binary is not found:
 
 ```
-❌ Hook validation failed - missing required hooks:
-   • amplihack/session_start.py (expected at /home/user/.amplihack/.claude/tools/amplihack/hooks/session_start.py)
-💡 Please reinstall amplihack to restore missing hooks
+❌ amplihack-hooks binary not found
+💡 Please reinstall amplihack to restore the hooks binary
 ```
 
-**Resolution:** Run `amplihack install` to restore missing hooks.
+**Resolution:** Run `amplihack install` to redeploy the binary.
 
 ## Backups
 
@@ -80,16 +105,16 @@ cp ~/.claude/settings.json.backup.1739673234 ~/.claude/settings.json
 
 ## Troubleshooting
 
-### Problem: "Hook validation failed"
+### Problem: Hooks binary not found
 
-**Symptom:** Error message listing missing hooks during installation
+**Symptom:** Error message about missing `amplihack-hooks` during installation
 
-**Cause:** Required hook files are missing from `~/.amplihack/.claude/tools/amplihack/hooks/`
+**Cause:** The `amplihack-hooks` binary is not in any of the 5 resolution locations
 
 **Solution:**
 
 ```bash
-# Reinstall amplihack to restore hooks
+# Reinstall amplihack to redeploy the binary
 amplihack install
 ```
 
@@ -97,84 +122,65 @@ amplihack install
 
 **Symptom:** Session start hooks or tool hooks don't run
 
-**Cause:** Settings.json not properly configured
+**Cause:** Settings.json not properly configured, or `amplihack-hooks` not on `$PATH`
 
 **Solution:**
 
 ```bash
+# Verify the binary is accessible
+which amplihack-hooks
+
 # Reconfigure settings
 amplihack install  # This will reconfigure hooks automatically
 ```
 
-### Problem: XPIA hooks warning
+### Problem: XPIA hooks directory info message
 
-**Symptom:** Warning about missing XPIA hooks during configuration
+**Symptom:** Informational message that XPIA security hooks directory is not installed
 
-**Cause:** XPIA security hooks are optional and not installed
+**Cause:** The `tools/xpia` directory was not present in the staged framework assets
 
 **Solution:**
 
-- This is normal if you haven't installed XPIA
-- To install XPIA: Follow XPIA installation instructions
-- To disable warning: Ignore (it's informational only)
+- This is normal if your framework bundle does not include XPIA assets
+- XPIA security is an optional feature — the info message is not an error
+- When XPIA assets are present, the installer automatically registers the XPIA hook subcommands via the `amplihack-hooks` binary
 
 ## Advanced: Path Expansion
 
-Hook paths support environment variable expansion:
+Hook command paths support environment variable expansion:
 
 - `$HOME` expands to your home directory
 - `~` expands to your home directory
 - Other environment variables are expanded automatically
 
-Example:
-
-```
-$HOME/.amplihack/.claude/tools/amplihack/hooks/session_start.py
-→ /home/username/.amplihack/.claude/tools/amplihack/hooks/session_start.py
-```
+The `amplihack-hooks` binary is typically deployed to `~/.local/bin/amplihack-hooks` and found via `$PATH`.
 
 ## For Developers
 
-### validate_hook_paths() Function
+### Hook Registration Internals
 
-New in v0.5.27, this function validates hook files exist before configuration:
+Hook specifications are defined in `crates/amplihack-cli/src/commands/install/types.rs`:
 
-```rust
-// use amplihack_settings:: validate_hook_paths
+- `AMPLIHACK_HOOK_SPECS` — required amplihack hook subcommands
+- `XPIA_HOOK_SPECS` — optional XPIA security hook subcommands
 
-hooks = [
-    {"type": "SessionStart", "file": "session_start.py", "timeout": 10}
-]
-
-all_valid, missing = validate_hook_paths(
-    "amplihack",
-    hooks,
-    "~/.amplihack/.claude/tools/amplihack/hooks"
-)
-
-if not all_valid:
-    print(f"Missing hooks: {missing}")
-```
-
-**Returns:**
-
-- `all_valid` (bool): True if all hooks exist
-- `missing` (list): List of missing hook descriptions with expected paths
+Both use `HookCommandKind::BinarySubcmd` to generate `"amplihack-hooks <subcmd>"` command strings. The installer calls `validate_hook_command_string()` on each generated command before writing to settings.json.
 
 ### Running Tests
 
 ```bash
-# Run hook validation tests
-python -m unittest tests.unit.test_validate_hook_paths
+# Run settings-related tests
+cargo test -p amplihack-cli -- settings
 
-# Run all settings tests
-python -m unittest discover -s tests -p "test_*settings*.py"
+# Run all install tests
+cargo test -p amplihack-cli -- install
 ```
 
 ## Related Documentation
 
 - [How to Configure the Copilot Parity Control Plane](./configure-copilot-parity-control-plane.md)
 - [Copilot Parity Control Plane Reference](../reference/hook-specifications.md)
+- [Binary Resolution](../reference/binary-resolution.md)
 - Main README: Setup and installation guide
 - PHILOSOPHY.md: Zero-BS principle and validation approach
-- Settings migration: See `src/amplihack/settings.py` docstrings

--- a/docs/reference/install-command.md
+++ b/docs/reference/install-command.md
@@ -104,7 +104,7 @@ Successful install prints a phase-by-phase progress summary:
 ✓ Created runtime directories
 ✓ Backed up ~/.claude/settings.json → settings.json.backup.1741651200
 ✓ Registered 7 Claude Code hooks
-✓ Verified hook scripts
+✓ XPIA hooks directory found
 ✓ Wrote install manifest
 amplihack installed successfully.
 ```
@@ -219,7 +219,7 @@ Copies `amplihack` (current executable) and `amplihack-hooks` (resolved by `find
 
 ### `ensure_settings_json(staging_dir: &Path, timestamp: u64, hooks_bin: &Path) -> Result<(bool, Vec<String>)>`
 
-Reads or creates `~/.claude/settings.json`. Creates a timestamped backup and backup metadata JSON (both with `0o600` permissions). Calls `validate_hook_command_string()` on each command before writing. Calls `update_hook_paths()` for amplihack hooks and (if XPIA is installed) for XPIA hooks. Returns `(settings_existed, registered_event_names)`.
+Reads or creates `~/.claude/settings.json`. Creates a timestamped backup and backup metadata JSON (both with `0o600` permissions). Calls `validate_hook_command_string()` on each command before writing. Calls `update_hook_paths()` for amplihack hooks and, when the XPIA tools directory exists, for XPIA hooks (using `XPIA_HOOK_SPECS` which route through the `amplihack-hooks` binary). Returns `(settings_existed, registered_event_names)`.
 
 ### `validate_hook_command_string(cmd: &str) -> Result<()>`
 
@@ -229,7 +229,7 @@ Validates that a hook command string does not contain shell metacharacters (`|&;
 
 Iterates `specs` and calls `validate_hook_command_string()` on each command string before upserting its hook wrapper into `settings["hooks"][event]`. Uses `wrapper_matches()` for idempotency. Preserves order — `workflow-classification-reminder` always precedes `user-prompt-submit` in the `UserPromptSubmit` array.
 
-The active amplihack install path registers hook **binary subcommands** such as `"amplihack-hooks post-tool-use"`. Historical hook files may still appear in older installations, but they are no longer treated as required runtime hook registrations.
+All hook registrations use **binary subcommands** such as `"amplihack-hooks post-tool-use"`. Both amplihack and XPIA hooks route through the compiled `amplihack-hooks` binary — there are no Python or shell script hook files to deploy or verify.
 
 ### `remove_hook_registrations(settings) -> Result<()>`
 

--- a/docs/reference/install-completeness.md
+++ b/docs/reference/install-completeness.md
@@ -17,7 +17,7 @@ The installer stages the framework components described by the install mapping i
 | `amplifier-bundle/context/` | Shared framework context | Required |
 | `amplifier-bundle/recipes/` | Workflow recipes | Required |
 | `amplifier-bundle/tools/amplihack/` | Amplihack framework tools | Required |
-| `amplifier-bundle/tools/xpia/` | XPIA framework tools | Required |
+| `amplifier-bundle/tools/xpia/` | XPIA framework tools (security patterns, configs) | Required |
 | `amplifier-bundle/behaviors/` | Behavior definitions | Required |
 | `amplifier-bundle/modules/` | Shared framework modules | Required |
 

--- a/tests/scenarios/xpia-verification-removed.yaml
+++ b/tests/scenarios/xpia-verification-removed.yaml
@@ -1,0 +1,24 @@
+name: xpia-verification-removed
+description: Verifies dead Python XPIA hook verification was removed and native XPIA paths still pass QA.
+type: cli
+scenarios:
+  - name: production-code-has-no-xpia-hook-files-constant
+    description: Grep production install code and confirm XPIA_HOOK_FILES no longer exists outside tests.
+    steps:
+      - type: command
+        command: "bash -lc \"! grep -R -n --include='*.rs' 'XPIA_HOOK_FILES' ../crates/amplihack-cli/src/commands/install | grep -v '/tests/'\""
+        expected_exit_code: 0
+
+  - name: xpia-unit-tests-pass
+    description: Run the XPIA-focused amplihack-cli library tests.
+    steps:
+      - type: command
+        command: "cargo test -p amplihack-cli --lib -- xpia"
+        expected_exit_code: 0
+
+  - name: cargo-build-succeeds
+    description: Build the workspace successfully after removing dead verification.
+    steps:
+      - type: command
+        command: "cargo build"
+        expected_exit_code: 0


### PR DESCRIPTION
## Summary

Fixes #683 — removes dead Python XPIA hook verification that produced false-negative `❌ missing` warnings on every install/update.

## Merge-Ready Evidence

### QA (gadugi-test)
- Scenario: `tests/scenarios/xpia-verification-removed.yaml`
- Validate: PASS via `cd tests && gadugi-test validate -f scenarios/xpia-verification-removed.yaml` (`gadugi-test validate -d <file>` is not supported by the installed CLI because `-d` is directory-only)
- Run: PASS via `cd tests && gadugi-test run -d scenarios -s production-code-has-no-xpia-hook-files-constant`, `... -s xpia-unit-tests-pass`, and `... -s cargo-build-succeeds`

### Docs
- `docs/howto/settings-hook-configuration.md` updated to describe Rust-native hook registration and no per-file script validation
- `docs/reference/install-command.md` updated install output/API docs to reflect binary-subcommand XPIA behavior
- `docs/reference/install-completeness.md` updated completeness docs so `tools/xpia` is described as staged assets/patterns, not per-file Python hooks

### Quality Audit
- Cycle 1: SEEK/VALIDATE on `types.rs` deletion — searched repo for `XPIA_HOOK_FILES`; only test assertions remain, no production references or breakage found
- Cycle 2: SEEK/VALIDATE on `settings.rs` — `verify_framework_assets()` still hard-fails required asset gaps through `missing_framework_paths()` and only changed the optional XPIA status message; caller contract at `install/mod.rs` unchanged
- Cycle 3: Independent diff review plus targeted regressions (`cargo test -p amplihack-cli --lib -- install::tests::settings_tests --quiet` and `...wrapper_tests --quiet`) found no material bugs, security issues, or coverage gaps
- Convergence: clean

### CI
- PASS: Build aarch64-apple-darwin
- PASS: Build aarch64-unknown-linux-gnu
- PASS: Build x86_64-apple-darwin
- PASS: Build x86_64-unknown-linux-gnu
- PASS: Install Smoke Test
- PASS: Test
- PASS: Lint & Format
- PASS: build
- PASS: GitGuardian Security Checks
- Skipped (expected): Release / deploy / scan

### Scope
- Focused: diff is limited to install/XPIA cleanup (`paths.rs`, `settings.rs`, `types.rs`, `settings_tests.rs`), 3 directly-related docs, and the merge-readiness QA scenario `tests/scenarios/xpia-verification-removed.yaml`

## Verdict: MERGE_READY