### PR TITLE
fix(workflow): add Azure DevOps support to default-workflow Step 3 and fix resume path

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -100,6 +100,7 @@ context:
   refactored_code: ""
   pre_commit_review: ""
   review_feedback: ""
+  remote_host_type: ""
   pr_url: ""
   pr_review: ""
   pr_security_review: ""

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -233,15 +233,24 @@ steps:
       else
         echo "WARNING: step-21 worktree path gone and REPO_PATH unset, using cwd=$(pwd)" >&2
       fi
-      echo "=== Step 20: Converting PR to Ready ==="
+      echo "=== Step 21: Converting PR to Ready ==="
       echo ""
+
+      # FIX #684/#682: Guard PR_URL before invoking gh commands
+      PR_URL="${PR_URL:-}"
+      if [ -z "$PR_URL" ]; then
+        echo "INFO: PR_URL is empty (non-GitHub remote or PR creation skipped) — skipping gh pr ready" >&2
+        echo "=== PR Ready: SKIPPED (no PR URL) ==="
+        exit 0
+      fi
+
       echo "--- Verifying All Steps Complete ---"
       echo ""
       echo "--- Converting PR to Ready ---"
-      gh pr ready
+      gh pr ready "$PR_URL"
       echo ""
       echo "--- Adding Ready Comment ---"
-      gh pr comment --body "## Ready for Final Review
+      gh pr comment "$PR_URL" --body "## Ready for Final Review
 
       All workflow steps completed:
       - [x] Requirements clarified

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -308,7 +308,7 @@ steps:
       echo ""
       # FIX #684: Host-aware summary — guard gh commands with both PR_URL and host type
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
-      PR_URL="$PR_URL"
+      PR_URL="${PR_URL:-}"
       if [ -z "$PR_URL" ]; then
         if [ "$HOST_TYPE" = "azdo" ]; then
           echo "PR Status: N/A (manual creation required)" >&2

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -236,9 +236,9 @@ steps:
       echo "=== Step 21: Converting PR to Ready ==="
       echo ""
 
-      # FIX #684/#682: Guard PR_URL before invoking gh commands
+      # FIX #684/#682: Guard PR_URL before invoking gh commands (whitespace-tolerant)
       PR_URL="${PR_URL:-}"
-      if [ -z "$PR_URL" ]; then
+      if [[ ! "$PR_URL" =~ [^[:space:]] ]]; then
         echo "INFO: PR_URL is empty (non-GitHub remote or PR creation skipped) — skipping gh pr ready" >&2
         echo "=== PR Ready: SKIPPED (no PR URL) ==="
         exit 0

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -317,7 +317,7 @@ steps:
         fi
       elif [ "$HOST_TYPE" = "github" ]; then
         echo "PR Status:"
-        gh pr view "$PR_URL" --json state,mergeable,reviews,statusCheckRollup
+        timeout 60 gh pr view "$PR_URL" --json state,mergeable,reviews,statusCheckRollup
       else
         echo "WARNING: PR_URL set but host is '$HOST_TYPE'; skipping gh pr view" >&2
       fi

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -236,11 +236,12 @@ steps:
       echo "=== Step 21: Converting PR to Ready ==="
       echo ""
 
-      # FIX #684/#682: Guard PR_URL before invoking gh commands (whitespace-tolerant)
+      # FIX #684/#682: Guard PR_URL and host type before invoking gh commands
       PR_URL="${PR_URL:-}"
-      if [[ ! "$PR_URL" =~ [^[:space:]] ]]; then
-        echo "INFO: PR_URL is empty (non-GitHub remote or PR creation skipped) — skipping gh pr ready" >&2
-        echo "=== PR Ready: SKIPPED (no PR URL) ==="
+      HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
+      if [[ ! "$PR_URL" =~ [^[:space:]] ]] || [ "$HOST_TYPE" != "github" ]; then
+        echo "INFO: PR_URL is empty or non-GitHub host ($HOST_TYPE) — skipping gh pr ready" >&2
+        echo "=== PR Ready: SKIPPED (no PR URL or non-GitHub host) ==="
         exit 0
       fi
 
@@ -305,22 +306,39 @@ steps:
       cd "${REPO_PATH:?step-22b-final-status requires repo_path; ensure parent recipe propagated repo_path context}"
       echo "=== WORKFLOW COMPLETE ==="
       echo ""
-      # FIX (#597): Use $PR_URL to identify the PR instead of relying on the
-      # current branch (which is "main" in the parent repo, not the feature branch).
+      # FIX #684: Host-aware summary — guard gh commands with both PR_URL and host type
+      HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
       PR_URL="$PR_URL"
       if [ -z "$PR_URL" ]; then
-        echo "WARNING: PR_URL is empty; skipping PR status check" >&2
-      else
+        if [ "$HOST_TYPE" = "azdo" ]; then
+          echo "PR Status: N/A (manual creation required)" >&2
+        else
+          echo "PR Status: N/A (no remote provider)" >&2
+        fi
+      elif [ "$HOST_TYPE" = "github" ]; then
         echo "PR Status:"
         gh pr view "$PR_URL" --json state,mergeable,reviews,statusCheckRollup
+      else
+        echo "WARNING: PR_URL set but host is '$HOST_TYPE'; skipping gh pr view" >&2
       fi
       echo ""
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
       TASK_DESC="$TASK_DESCRIPTION"
       ISSUE_NUMBER="$ISSUE_NUMBER"
       printf '=== Task: %s ===\n' "$TASK_DESC"
-      printf '=== Issue: #%s ===\n' "$ISSUE_NUMBER"
-      printf '=== PR: %s ===\n' "$PR_URL"
+      # Host-aware issue and PR references
+      case "$HOST_TYPE" in
+        github) echo "=== Issue: #${ISSUE_NUMBER} ===" ;;
+        azdo)   echo "=== Issue: AB#${ISSUE_NUMBER} ===" ;;
+        *)      echo "=== Issue: Ref #${ISSUE_NUMBER} ===" ;;
+      esac
+      if [ -n "$PR_URL" ]; then
+        printf '=== PR: %s ===\n' "$PR_URL"
+      elif [ "$HOST_TYPE" = "azdo" ]; then
+        echo "=== PR: N/A (manual creation required) ==="
+      else
+        echo "=== PR: N/A (no remote provider) ==="
+      fi
       echo ""
       echo "All 23 workflow steps completed successfully."
     output: "final_status"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -19,11 +19,9 @@ recursion:
 context: {}
 
 steps:
-  # ==========================================================================
   # STEP 0: WORKFLOW PREPARATION (MANDATORY - DO NOT SKIP)
-  # Creates tracking structure for all 23 workflow steps.
-  # CRITICAL: Must complete before ANY implementation work begins.
-  # Prevents "completion bias" - ensures mandatory review steps (0, 14, 17-18) not skipped.
+  # Creates tracking structure. Must complete before ANY implementation work.
+  # Prevents "completion bias" - ensures mandatory review steps not skipped.
   # ==========================================================================
   - id: "step-00-workflow-preparation"
     type: "bash"
@@ -77,11 +75,7 @@ steps:
       printf 'Repository: %s\n' "$REPO_PATH"
     output: "workflow_init"
 
-  # ==========================================================================
   # STEP 1: PREPARE THE WORKSPACE
-  # Ensure a clean local environment that is up to date.
-  # Actions: verify no unstashed changes, git fetch, check git status
-  # ==========================================================================
   - id: "step-01-prepare-workspace"
     type: "bash"
     command: |
@@ -135,9 +129,7 @@ steps:
       fi
     output: "workspace_status"
 
-  # ==========================================================================
   # STEP 2: REWRITE AND CLARIFY REQUIREMENTS
-  # ==========================================================================
   - id: "step-02-clarify-requirements"
     agent: "amplihack:prompt-writer"
     prompt: |
@@ -249,10 +241,28 @@ steps:
     output: "final_requirements"
 
   # ==========================================================================
-  # STEP 3: CREATE GITHUB ISSUE
-  # Create a GitHub issue documenting the task with problem description,
-  # requirements, constraints, success criteria, and appropriate labels.
+  # STEP 02d: DETECT REMOTE HOST TYPE
+  # Output propagates via parent context to all downstream sub-recipes.
   # ==========================================================================
+  - id: "step-02d-detect-host-type"
+    type: "bash"
+    command: |
+      set -euo pipefail; cd "$REPO_PATH"
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "[skip] not a git repo — defaulting to 'other'" >&2
+        printf 'other'; exit 0
+      fi
+      REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+      case "$REMOTE_URL" in
+        *github.com*) HT="github" ;;
+        *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*) HT="azdo" ;;
+        *) HT="other" ;;
+      esac
+      echo "INFO: Remote host type: $HT" >&2
+      printf '%s' "$HT"
+    output: "remote_host_type"
+
+  # STEP 3: CREATE TRACKING ISSUE (GitHub / AzDO / local fallback)
   - id: "step-03-create-issue"
     type: "bash"
     command: |
@@ -269,21 +279,15 @@ steps:
         printf 'local-tracking:%s\n' "$LOCAL_ISSUE"
         exit 0
       fi
-      # FIX #684: Detect remote host type before issuing host-specific commands
+      HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
       REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
-      case "$REMOTE_URL" in
-        *github.com*) REMOTE_HOST_TYPE="github" ;;
-        *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*) REMOTE_HOST_TYPE="azdo" ;;
-        *) REMOTE_HOST_TYPE="other" ;;
-      esac
-      echo "INFO: Remote host type: $REMOTE_HOST_TYPE" >&2
       # Extract referenced issue/work-item from task_description (idempotency)
       REF_ISSUE_NUM=""
       if [[ "$TASK_DESC" =~ AB#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"; fi
       [ -n "$REF_ISSUE_NUM" ] && ! [[ "$REF_ISSUE_NUM" =~ ^[0-9]+$ ]] && REF_ISSUE_NUM=""
       # --- GitHub path ---
-      if [ "$REMOTE_HOST_TYPE" = "github" ]; then
+      if [ "$HOST_TYPE" = "github" ]; then
         if [ -n "$REF_ISSUE_NUM" ]; then
           EXISTING_URL=$(timeout 60 gh issue view "$REF_ISSUE_NUM" --json url --jq '.url // ""' 2>/dev/null || echo '')
           [ -n "$EXISTING_URL" ] && { printf '%s\n' "$EXISTING_URL"; exit 0; }
@@ -302,7 +306,7 @@ steps:
         exit $?
       fi
       # --- Azure DevOps path (az boards work-item) ---
-      if [ "$REMOTE_HOST_TYPE" = "azdo" ]; then
+      if [ "$HOST_TYPE" = "azdo" ]; then
         AZDO_ORG=""; AZDO_PROJECT=""
         # Bash regex replaces 6 echo|sed subprocess spawns with built-in matching
         if [[ "$REMOTE_URL" =~ dev\.azure\.com/([^/]+)/([^/]+)/ ]]; then
@@ -312,12 +316,32 @@ steps:
         elif [[ "$REMOTE_URL" =~ ssh\.dev\.azure\.com[:/]v3/([^/]+)/([^/]+)/ ]]; then
           AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
         fi
+        # FIX #684: Decode %XX percent-encoding (e.g. My%20Project → My Project)
+        _pct_decode() {
+          local e="$1" d="" i=0 ch hex
+          while [ "$i" -lt "${#e}" ]; do
+            ch="${e:$i:1}"
+            if [ "$ch" = "%" ] && [ "$((i+2))" -le "${#e}" ]; then
+              hex="${e:$((i+1)):2}"
+              if [[ "$hex" =~ ^[0-9a-fA-F]{2}$ ]]; then
+                d+=$(printf "\\x$hex"); i=$((i+3)); continue
+              fi
+              echo "WARN: Invalid percent-encoding '%${hex}' — using local tracking" >&2
+              echo ""; return 1
+            fi
+            d+="$ch"; i=$((i+1))
+          done
+          printf '%s' "$d"
+        }
+        [ -n "$AZDO_ORG" ] && { AZDO_ORG=$(_pct_decode "$AZDO_ORG") || { AZDO_ORG=""; AZDO_PROJECT=""; }; }
+        [ -n "$AZDO_PROJECT" ] && { AZDO_PROJECT=$(_pct_decode "$AZDO_PROJECT") || { AZDO_ORG=""; AZDO_PROJECT=""; }; }
         # Security: validate org/project captures against safe character set
         if [[ -n "$AZDO_ORG" ]] && ! [[ "$AZDO_ORG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
           echo "WARN: AZDO_ORG contains unexpected characters — using local tracking" >&2
           AZDO_ORG=""
         fi
-        if [[ -n "$AZDO_PROJECT" ]] && ! [[ "$AZDO_PROJECT" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        # Project names may contain spaces (decoded from %20)
+        if [[ -n "$AZDO_PROJECT" ]] && ! [[ "$AZDO_PROJECT" =~ ^[a-zA-Z0-9._ -]+$ ]]; then
           echo "WARN: AZDO_PROJECT contains unexpected characters — using local tracking" >&2
           AZDO_PROJECT=""
         fi
@@ -341,7 +365,7 @@ steps:
         fi
       fi
       # --- Local tracking fallback (unknown remote or az CLI unavailable) ---
-      echo "INFO: Using local tracking for issue management (remote: $REMOTE_HOST_TYPE)" >&2
+      echo "INFO: Using local tracking for issue management (remote: $HOST_TYPE)" >&2
       LOCAL_ISSUE=$(($(date +%s) % 1000000))
       printf 'local-tracking:%s\n' "$LOCAL_ISSUE"
     output: "issue_creation"
@@ -350,8 +374,7 @@ steps:
   - id: "step-03b-extract-issue-number"
     type: "bash"
     command: |
-      # FIX #684: Extract issue number — handles GitHub, AzDO, and local tracking.
-      # Bash regex replaces ~14 printf|grep|grep|head subprocess chains with built-in matching
+      # Extract issue number — handles GitHub, AzDO, and local tracking.
       ISSUE_CREATION="$ISSUE_CREATION"; TASK_DESC_RAW="$TASK_DESCRIPTION"
       EXTRACTED=""
       if [[ "$ISSUE_CREATION" =~ issues/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
@@ -373,7 +396,4 @@ steps:
       printf '%s' "$EXTRACTED"
     output: "issue_number"
 
-  # ==========================================================================
   # STEP 4: SETUP WORKTREE AND BRANCH
-  # Creates isolated worktree and outputs structured JSON for subsequent steps.
-  # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -305,14 +305,23 @@ steps:
         elif [[ "$REMOTE_URL" =~ ssh\.dev\.azure\.com[:/]v3/([^/]+)/([^/]+)/ ]]; then
           AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
         fi
+        # Security: validate org/project captures against safe character set
+        if [[ -n "$AZDO_ORG" ]] && ! [[ "$AZDO_ORG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+          echo "WARN: AZDO_ORG contains unexpected characters — using local tracking" >&2
+          AZDO_ORG=""
+        fi
+        if [[ -n "$AZDO_PROJECT" ]] && ! [[ "$AZDO_PROJECT" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+          echo "WARN: AZDO_PROJECT contains unexpected characters — using local tracking" >&2
+          AZDO_PROJECT=""
+        fi
         AZDO_ORG_URL="https://dev.azure.com/${AZDO_ORG}"
         if command -v az >/dev/null 2>&1; then
           if [ -n "$REF_ISSUE_NUM" ]; then
-            WI_URL=$(az boards work-item show --id "$REF_ISSUE_NUM" --org "$AZDO_ORG_URL" --query "url" -o tsv 2>/dev/null || echo "")
+            WI_URL=$(timeout 60 az boards work-item show --id "$REF_ISSUE_NUM" --org "$AZDO_ORG_URL" --query "url" -o tsv 2>/dev/null || echo "")
             [ -n "$WI_URL" ] && { echo "INFO: Reusing work item AB#$REF_ISSUE_NUM" >&2; printf '%s\n' "$WI_URL"; exit 0; }
           fi
           if [ -n "$AZDO_ORG" ] && [ -n "$AZDO_PROJECT" ]; then
-            WI_RESULT=$(az boards work-item create --title "$ISSUE_TITLE" --type "Task" \
+            WI_RESULT=$(timeout 60 az boards work-item create --title "$ISSUE_TITLE" --type "Task" \
               --org "$AZDO_ORG_URL" --project "$AZDO_PROJECT" --query "[id,url]" -o tsv 2>/dev/null || echo "")
             if [ -n "$WI_RESULT" ]; then
               read -r _ WI_URL <<< "$WI_RESULT"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -345,8 +345,8 @@ steps:
         [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"
       elif [[ "$ISSUE_CREATION" =~ _workitems/edit/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
-      elif [[ "$TASK_DESC_RAW" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ local-tracking:([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
+      elif [[ "$TASK_DESC_RAW" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC_RAW" =~ \#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       fi
       if [ -z "$EXTRACTED" ]; then

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -323,6 +323,7 @@ steps:
             if [ "$ch" = "%" ] && [ "$((i+2))" -le "${#e}" ]; then
               hex="${e:$((i+1)):2}"
               if [[ "$hex" =~ ^[0-9a-fA-F]{2}$ ]]; then
+                [ "$hex" = "00" ] && { echo "WARN: NUL byte in percent-encoding" >&2; echo ""; return 1; }
                 printf -v tmp "\\x$hex"; d+="$tmp"; i=$((i+3)); continue
               fi
               echo "WARN: Invalid percent-encoding '%${hex}' — using local tracking" >&2
@@ -344,23 +345,21 @@ steps:
           echo "WARN: AZDO_PROJECT contains unexpected characters — using local tracking" >&2
           AZDO_PROJECT=""
         fi
-        AZDO_ORG_URL="https://dev.azure.com/${AZDO_ORG}"
-        if command -v az >/dev/null 2>&1; then
+        if command -v az >/dev/null 2>&1 && [ -n "$AZDO_ORG" ] && [ -n "$AZDO_PROJECT" ]; then
+          AZDO_ORG_URL="https://dev.azure.com/${AZDO_ORG}"
           if [ -n "$REF_ISSUE_NUM" ]; then
             WI_URL=$(timeout 60 az boards work-item show --id "$REF_ISSUE_NUM" --org "$AZDO_ORG_URL" --query "url" -o tsv 2>/dev/null || echo "")
             [ -n "$WI_URL" ] && { echo "INFO: Reusing work item AB#$REF_ISSUE_NUM" >&2; printf '%s\n' "$WI_URL"; exit 0; }
           fi
-          if [ -n "$AZDO_ORG" ] && [ -n "$AZDO_PROJECT" ]; then
-            WI_RESULT=$(timeout 60 az boards work-item create --title "$ISSUE_TITLE" --type "Task" \
-              --org "$AZDO_ORG_URL" --project "$AZDO_PROJECT" --query "[id,url]" -o tsv 2>/dev/null || echo "")
-            if [ -n "$WI_RESULT" ]; then
-              read -r _ WI_URL <<< "$WI_RESULT"
-              [ -n "$WI_URL" ] && { printf '%s\n' "$WI_URL"; exit 0; }
-            fi
-            echo "WARN: az boards work-item create failed — using local tracking" >&2
+          WI_RESULT=$(timeout 60 az boards work-item create --title "$ISSUE_TITLE" --type "Task" \
+            --org "$AZDO_ORG_URL" --project "$AZDO_PROJECT" --query "[id,url]" -o tsv 2>/dev/null || echo "")
+          if [ -n "$WI_RESULT" ]; then
+            read -r _ WI_URL <<< "$WI_RESULT"
+            [ -n "$WI_URL" ] && { printf '%s\n' "$WI_URL"; exit 0; }
           fi
+          echo "WARN: az boards work-item create failed — using local tracking" >&2
         else
-          echo "WARN: 'az' CLI not found — using local tracking for AzDO remote" >&2
+          echo "WARN: 'az' CLI not found or org/project empty — using local tracking for AzDO remote" >&2
         fi
       fi
       # --- Local tracking fallback (unknown remote or az CLI unavailable) ---

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -310,7 +310,7 @@ steps:
         # Bash regex replaces 6 echo|sed subprocess spawns with built-in matching
         if [[ "$REMOTE_URL" =~ dev\.azure\.com/([^/]+)/([^/]+)/ ]]; then
           AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
-        elif [[ "$REMOTE_URL" =~ ([^.]+)\.visualstudio\.com/([^/]+)/ ]]; then
+        elif [[ "$REMOTE_URL" =~ ([^/.]+)\.visualstudio\.com/([^/]+)/ ]]; then
           AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
         elif [[ "$REMOTE_URL" =~ ssh\.dev\.azure\.com[:/]v3/([^/]+)/([^/]+)/ ]]; then
           AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -254,7 +254,7 @@ steps:
       fi
       REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
       case "$REMOTE_URL" in
-        *github.com*) HT="github" ;;
+        https://github.com/*|git@github.com:*|ssh://git@github.com/*|https://*@github.com/*) HT="github" ;;
         *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*) HT="azdo" ;;
         *) HT="other" ;;
       esac

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -262,6 +262,13 @@ steps:
       TASK_DESC="$TASK_DESCRIPTION"
       ISSUE_TITLE="${TASK_DESC//$'\n'/ }"; ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"; ISSUE_TITLE="${ISSUE_TITLE:0:200}"
       ISSUE_REQS="$FINAL_REQUIREMENTS"
+      # FIX #684: Guard git commands — fall back to local tracking outside git repos
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "[skip] not a git repo — using local tracking" >&2
+        LOCAL_ISSUE=$(($(date +%s) % 1000000))
+        printf 'local-tracking:%s\n' "$LOCAL_ISSUE"
+        exit 0
+      fi
       # FIX #684: Detect remote host type before issuing host-specific commands
       REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
       case "$REMOTE_URL" in

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -280,7 +280,6 @@ steps:
         exit 0
       fi
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
-      REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
       # Extract referenced issue/work-item from task_description (idempotency)
       REF_ISSUE_NUM=""
       if [[ "$TASK_DESC" =~ AB#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"
@@ -299,14 +298,14 @@ steps:
         fi
         ISSUE_BODY=$(printf '## Task Description\n%s\n\n## Requirements\n%s\n\n## Acceptance Criteria\n- [ ] All explicit requirements met\n- [ ] Tests passing\n- [ ] Philosophy compliant\n- [ ] Documentation updated\n\n## Classification\nGenerated via default-workflow recipe\n' "$TASK_DESC" "$ISSUE_REQS")
         LABEL_NAME="workflow:default"
-        gh label list --limit 1000 2>/dev/null | grep -qw "$LABEL_NAME" || \
-          gh label create "$LABEL_NAME" --color "0366d6" --description "Created by default-workflow recipe" 2>/dev/null || true
+        gh label create "$LABEL_NAME" --color "0366d6" --description "Created by default-workflow recipe" 2>/dev/null || true
         gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "$LABEL_NAME" 2>&1 || \
           gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY"
         exit $?
       fi
       # --- Azure DevOps path (az boards work-item) ---
       if [ "$HOST_TYPE" = "azdo" ]; then
+        REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
         AZDO_ORG=""; AZDO_PROJECT=""
         # Bash regex replaces 6 echo|sed subprocess spawns with built-in matching
         if [[ "$REMOTE_URL" =~ dev\.azure\.com/([^/]+)/([^/]+)/ ]]; then
@@ -324,7 +323,7 @@ steps:
             if [ "$ch" = "%" ] && [ "$((i+2))" -le "${#e}" ]; then
               hex="${e:$((i+1)):2}"
               if [[ "$hex" =~ ^[0-9a-fA-F]{2}$ ]]; then
-                d+=$(printf "\\x$hex"); i=$((i+3)); continue
+                printf -v tmp "\\x$hex"; d+="$tmp"; i=$((i+3)); continue
               fi
               echo "WARN: Invalid percent-encoding '%${hex}' — using local tracking" >&2
               echo ""; return 1

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -258,105 +258,100 @@ steps:
     command: |
       set -euo pipefail
       cd "$REPO_PATH"
-      echo "=== Step 3: Creating GitHub Issue ===" >&2
-
-      # FIX (#469/#311): Use env var — safe against injection and word-splitting.
+      echo "=== Step 3: Creating Tracking Issue ===" >&2
       TASK_DESC="$TASK_DESCRIPTION"
-      # Bash builtins replace tr|cut pipeline — avoids 2 subprocess spawns (matches step-16)
-      ISSUE_TITLE="${TASK_DESC//$'\n'/ }"
-      ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"
-      ISSUE_TITLE="${ISSUE_TITLE:0:200}"
+      ISSUE_TITLE="${TASK_DESC//$'\n'/ }"; ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"; ISSUE_TITLE="${ISSUE_TITLE:0:200}"
       ISSUE_REQS="$FINAL_REQUIREMENTS"
-
-      # Idempotency Guard 1: Reuse issue referenced in task_description (#NNNN)
-      # Mirrors step-16-create-draft-pr idempotency pattern (#3324).
-      # Bash regex replaces printf|grep|head|tr pipeline — avoids 4 subprocess spawns
-      if [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then
-          REF_ISSUE_NUM="${BASH_REMATCH[1]}"
-      else
-          REF_ISSUE_NUM=""
-      fi
-      # Defense-in-depth: validate numeric before interpolating into gh command
-      if [ -n "$REF_ISSUE_NUM" ] && ! [[ "$REF_ISSUE_NUM" =~ ^[0-9]+$ ]]; then
-          echo "WARN: Extracted issue reference is not numeric: $REF_ISSUE_NUM — skipping guard 1" >&2
-          REF_ISSUE_NUM=""
-      fi
-      if [ -n "$REF_ISSUE_NUM" ]; then
-          echo "INFO: task_description references issue #$REF_ISSUE_NUM — verifying it exists" >&2
+      # FIX #684: Detect remote host type before issuing host-specific commands
+      REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+      case "$REMOTE_URL" in
+        *github.com*) REMOTE_HOST_TYPE="github" ;;
+        *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*) REMOTE_HOST_TYPE="azdo" ;;
+        *) REMOTE_HOST_TYPE="other" ;;
+      esac
+      echo "INFO: Remote host type: $REMOTE_HOST_TYPE" >&2
+      # Extract referenced issue/work-item from task_description (idempotency)
+      REF_ISSUE_NUM=""
+      if [[ "$TASK_DESC" =~ AB#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"
+      elif [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"; fi
+      [ -n "$REF_ISSUE_NUM" ] && ! [[ "$REF_ISSUE_NUM" =~ ^[0-9]+$ ]] && REF_ISSUE_NUM=""
+      # --- GitHub path ---
+      if [ "$REMOTE_HOST_TYPE" = "github" ]; then
+        if [ -n "$REF_ISSUE_NUM" ]; then
           EXISTING_URL=$(timeout 60 gh issue view "$REF_ISSUE_NUM" --json url --jq '.url // ""' 2>/dev/null || echo '')
-          if [ -n "$EXISTING_URL" ]; then
-              echo "INFO: Reusing existing issue #$REF_ISSUE_NUM — skipping creation" >&2
-              printf '%s\n' "$EXISTING_URL"
-              exit 0
+          [ -n "$EXISTING_URL" ] && { printf '%s\n' "$EXISTING_URL"; exit 0; }
+        fi
+        SEARCH_Q="${ISSUE_TITLE:0:100}"
+        if [ -n "$SEARCH_Q" ]; then
+          FOUND_URL=$(timeout 60 gh issue list --state open --search "$SEARCH_Q" --json url --jq '.[0].url // ""' 2>/dev/null || echo '')
+          [ -n "$FOUND_URL" ] && { printf '%s\n' "$FOUND_URL"; exit 0; }
+        fi
+        ISSUE_BODY=$(printf '## Task Description\n%s\n\n## Requirements\n%s\n\n## Acceptance Criteria\n- [ ] All explicit requirements met\n- [ ] Tests passing\n- [ ] Philosophy compliant\n- [ ] Documentation updated\n\n## Classification\nGenerated via default-workflow recipe\n' "$TASK_DESC" "$ISSUE_REQS")
+        LABEL_NAME="workflow:default"
+        gh label list --limit 1000 2>/dev/null | grep -qw "$LABEL_NAME" || \
+          gh label create "$LABEL_NAME" --color "0366d6" --description "Created by default-workflow recipe" 2>/dev/null || true
+        gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "$LABEL_NAME" 2>&1 || \
+          gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY"
+        exit $?
+      fi
+      # --- Azure DevOps path (az boards work-item) ---
+      if [ "$REMOTE_HOST_TYPE" = "azdo" ]; then
+        AZDO_ORG=""; AZDO_PROJECT=""
+        case "$REMOTE_URL" in
+          *dev.azure.com/*) AZDO_ORG=$(echo "$REMOTE_URL" | sed -n 's|.*dev\.azure\.com/\([^/]*\)/\([^/]*\)/.*|\1|p')
+                            AZDO_PROJECT=$(echo "$REMOTE_URL" | sed -n 's|.*dev\.azure\.com/\([^/]*\)/\([^/]*\)/.*|\2|p') ;;
+          *visualstudio.com/*) AZDO_ORG=$(echo "$REMOTE_URL" | sed -n 's|.*//\([^.]*\)\.visualstudio\.com/\([^/]*\)/.*|\1|p')
+                               AZDO_PROJECT=$(echo "$REMOTE_URL" | sed -n 's|.*//\([^.]*\)\.visualstudio\.com/\([^/]*\)/.*|\2|p') ;;
+          *ssh.dev.azure.com*) AZDO_ORG=$(echo "$REMOTE_URL" | sed -n 's|.*ssh\.dev\.azure\.com[:/]v3/\([^/]*\)/\([^/]*\)/.*|\1|p')
+                               AZDO_PROJECT=$(echo "$REMOTE_URL" | sed -n 's|.*ssh\.dev\.azure\.com[:/]v3/\([^/]*\)/\([^/]*\)/.*|\2|p') ;;
+        esac
+        AZDO_ORG_URL="https://dev.azure.com/${AZDO_ORG}"
+        if command -v az >/dev/null 2>&1; then
+          if [ -n "$REF_ISSUE_NUM" ]; then
+            WI_URL=$(az boards work-item show --id "$REF_ISSUE_NUM" --org "$AZDO_ORG_URL" --query "url" -o tsv 2>/dev/null || echo "")
+            [ -n "$WI_URL" ] && { echo "INFO: Reusing work item AB#$REF_ISSUE_NUM" >&2; printf '%s\n' "$WI_URL"; exit 0; }
           fi
-          echo "WARN: Referenced issue #$REF_ISSUE_NUM not found — will search or create" >&2
-      fi
-
-      # Idempotency Guard 2: Search open issues for similar title
-      SEARCH_QUERY="${ISSUE_TITLE:0:100}"
-      if [ -n "$SEARCH_QUERY" ]; then
-          echo "INFO: Searching open issues for similar title" >&2
-          FOUND_URL=$(timeout 60 gh issue list --state open --search "$SEARCH_QUERY" --json url --jq '.[0].url // ""' 2>/dev/null || echo '')
-          if [ -n "$FOUND_URL" ]; then
-              echo "INFO: Found existing open issue matching title — skipping creation" >&2
-              printf '%s\n' "$FOUND_URL"
-              exit 0
+          if [ -n "$AZDO_ORG" ] && [ -n "$AZDO_PROJECT" ]; then
+            WI_RESULT=$(az boards work-item create --title "$ISSUE_TITLE" --type "Task" \
+              --org "$AZDO_ORG_URL" --project "$AZDO_PROJECT" --query "[id,url]" -o tsv 2>/dev/null || echo "")
+            if [ -n "$WI_RESULT" ]; then
+              WI_URL=$(echo "$WI_RESULT" | awk '{print $2}')
+              [ -n "$WI_URL" ] && { printf '%s\n' "$WI_URL"; exit 0; }
+            fi
+            echo "WARN: az boards work-item create failed — using local tracking" >&2
           fi
-          echo "INFO: No matching open issue found — proceeding to create" >&2
+        else
+          echo "WARN: 'az' CLI not found — using local tracking for AzDO remote" >&2
+        fi
       fi
-
-      # Normal path: create a new issue
-      ISSUE_BODY=$(printf '## Task Description\n%s\n\n## Requirements\n%s\n\n## Acceptance Criteria\n- [ ] All explicit requirements met\n- [ ] Tests passing\n- [ ] Philosophy compliant\n- [ ] Documentation updated\n\n## Classification\nGenerated via default-workflow recipe\n' "$TASK_DESC" "$ISSUE_REQS")
-      LABEL_NAME="workflow:default"
-      if ! gh label list --limit 1000 2>/dev/null | grep -qw "$LABEL_NAME"; then
-        gh label create "$LABEL_NAME" \
-          --color "0366d6" \
-          --description "Created by default-workflow recipe" 2>/dev/null || true
-      fi
-      gh issue create \
-        --title "$ISSUE_TITLE" \
-        --body "$ISSUE_BODY" \
-        --label "$LABEL_NAME" 2>&1 || \
-      gh issue create \
-        --title "$ISSUE_TITLE" \
-        --body "$ISSUE_BODY"
+      # --- Local tracking fallback (unknown remote or az CLI unavailable) ---
+      echo "INFO: Using local tracking for issue management (remote: $REMOTE_HOST_TYPE)" >&2
+      LOCAL_ISSUE=$(($(date +%s) % 1000000))
+      printf 'local-tracking:%s\n' "$LOCAL_ISSUE"
     output: "issue_creation"
     parse_json: false
 
   - id: "step-03b-extract-issue-number"
     type: "bash"
     command: |
-      # Extract issue number from the creation output.
-      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
-      ISSUE_CREATION="$ISSUE_CREATION"
-      TASK_DESC_RAW="$TASK_DESCRIPTION"
-      # FIX (#4233): Match both issue URLs (issues/NNN) and PR URLs (pull/NNN).
-      # If the output is a PR URL, resolve the linked issue via gh pr view.
+      # FIX #684: Extract issue number — handles GitHub, AzDO, and local tracking.
+      ISSUE_CREATION="$ISSUE_CREATION"; TASK_DESC_RAW="$TASK_DESCRIPTION"
       EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
       if [ -z "$EXTRACTED" ]; then
-        # Try PR URL — step-03 may have returned a PR URL if reusing an existing PR
         PR_NUMBER=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
         if [ -n "$PR_NUMBER" ]; then
-          echo "INFO: step-03b found PR URL (not issue URL) — resolving linked issue from PR #$PR_NUMBER" >&2
           EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo '')
-          # If no linked issue, use the PR number as the issue number
-          # (downstream steps can handle PR-only workflows)
-          if [ -z "$EXTRACTED" ]; then
-            echo "INFO: PR #$PR_NUMBER has no linked issue — using PR number as reference" >&2
-            EXTRACTED="$PR_NUMBER"
-          fi
+          [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"
         fi
       fi
-      if [ -z "$EXTRACTED" ]; then
-        # Last resort: scan for bare #NNNN references in the task description
-        EXTRACTED=$(printf '%s' "$TASK_DESC_RAW" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | head -1)
-      fi
+      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE '_workitems/edit/[0-9]+' | grep -oE '[0-9]+' | head -1)
+      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'AB#[0-9]+' | grep -oE '[0-9]+' | head -1)
+      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$TASK_DESC_RAW" | grep -oE 'AB#[0-9]+' | grep -oE '[0-9]+' | head -1)
+      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'local-tracking:[0-9]+' | grep -oE '[0-9]+' | head -1)
+      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$TASK_DESC_RAW" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | head -1)
       if [ -z "$EXTRACTED" ]; then
         echo "ERROR: step-03b failed to extract issue number from issue_creation output." >&2
-        echo "Raw issue_creation output was:" >&2
         printf '%s\n' "$ISSUE_CREATION" >&2
-        echo "This means step-03a (create-issue) likely failed or returned unexpected output." >&2
-        echo "Downstream steps (commit, PR) will fail without a valid issue number." >&2
         exit 1
       fi
       printf '%s' "$EXTRACTED"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -297,14 +297,14 @@ steps:
       # --- Azure DevOps path (az boards work-item) ---
       if [ "$REMOTE_HOST_TYPE" = "azdo" ]; then
         AZDO_ORG=""; AZDO_PROJECT=""
-        case "$REMOTE_URL" in
-          *dev.azure.com/*) AZDO_ORG=$(echo "$REMOTE_URL" | sed -n 's|.*dev\.azure\.com/\([^/]*\)/\([^/]*\)/.*|\1|p')
-                            AZDO_PROJECT=$(echo "$REMOTE_URL" | sed -n 's|.*dev\.azure\.com/\([^/]*\)/\([^/]*\)/.*|\2|p') ;;
-          *visualstudio.com/*) AZDO_ORG=$(echo "$REMOTE_URL" | sed -n 's|.*//\([^.]*\)\.visualstudio\.com/\([^/]*\)/.*|\1|p')
-                               AZDO_PROJECT=$(echo "$REMOTE_URL" | sed -n 's|.*//\([^.]*\)\.visualstudio\.com/\([^/]*\)/.*|\2|p') ;;
-          *ssh.dev.azure.com*) AZDO_ORG=$(echo "$REMOTE_URL" | sed -n 's|.*ssh\.dev\.azure\.com[:/]v3/\([^/]*\)/\([^/]*\)/.*|\1|p')
-                               AZDO_PROJECT=$(echo "$REMOTE_URL" | sed -n 's|.*ssh\.dev\.azure\.com[:/]v3/\([^/]*\)/\([^/]*\)/.*|\2|p') ;;
-        esac
+        # Bash regex replaces 6 echo|sed subprocess spawns with built-in matching
+        if [[ "$REMOTE_URL" =~ dev\.azure\.com/([^/]+)/([^/]+)/ ]]; then
+          AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
+        elif [[ "$REMOTE_URL" =~ ([^.]+)\.visualstudio\.com/([^/]+)/ ]]; then
+          AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
+        elif [[ "$REMOTE_URL" =~ ssh\.dev\.azure\.com[:/]v3/([^/]+)/([^/]+)/ ]]; then
+          AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
+        fi
         AZDO_ORG_URL="https://dev.azure.com/${AZDO_ORG}"
         if command -v az >/dev/null 2>&1; then
           if [ -n "$REF_ISSUE_NUM" ]; then
@@ -315,7 +315,7 @@ steps:
             WI_RESULT=$(az boards work-item create --title "$ISSUE_TITLE" --type "Task" \
               --org "$AZDO_ORG_URL" --project "$AZDO_PROJECT" --query "[id,url]" -o tsv 2>/dev/null || echo "")
             if [ -n "$WI_RESULT" ]; then
-              WI_URL=$(echo "$WI_RESULT" | awk '{print $2}')
+              read -r _ WI_URL <<< "$WI_RESULT"
               [ -n "$WI_URL" ] && { printf '%s\n' "$WI_URL"; exit 0; }
             fi
             echo "WARN: az boards work-item create failed — using local tracking" >&2
@@ -335,20 +335,20 @@ steps:
     type: "bash"
     command: |
       # FIX #684: Extract issue number — handles GitHub, AzDO, and local tracking.
+      # Bash regex replaces ~14 printf|grep|grep|head subprocess chains with built-in matching
       ISSUE_CREATION="$ISSUE_CREATION"; TASK_DESC_RAW="$TASK_DESCRIPTION"
-      EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1)
-      if [ -z "$EXTRACTED" ]; then
-        PR_NUMBER=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
-        if [ -n "$PR_NUMBER" ]; then
-          EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo '')
-          [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"
-        fi
+      EXTRACTED=""
+      if [[ "$ISSUE_CREATION" =~ issues/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
+      elif [[ "$ISSUE_CREATION" =~ pull/([0-9]+) ]]; then
+        PR_NUMBER="${BASH_REMATCH[1]}"
+        EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo '')
+        [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"
+      elif [[ "$ISSUE_CREATION" =~ _workitems/edit/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
+      elif [[ "$ISSUE_CREATION" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
+      elif [[ "$TASK_DESC_RAW" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
+      elif [[ "$ISSUE_CREATION" =~ local-tracking:([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
+      elif [[ "$TASK_DESC_RAW" =~ \#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       fi
-      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE '_workitems/edit/[0-9]+' | grep -oE '[0-9]+' | head -1)
-      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'AB#[0-9]+' | grep -oE '[0-9]+' | head -1)
-      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$TASK_DESC_RAW" | grep -oE 'AB#[0-9]+' | grep -oE '[0-9]+' | head -1)
-      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$ISSUE_CREATION" | grep -oE 'local-tracking:[0-9]+' | grep -oE '[0-9]+' | head -1)
-      [ -z "$EXTRACTED" ] && EXTRACTED=$(printf '%s' "$TASK_DESC_RAW" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | head -1)
       if [ -z "$EXTRACTED" ]; then
         echo "ERROR: step-03b failed to extract issue number from issue_creation output." >&2
         printf '%s\n' "$ISSUE_CREATION" >&2

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -103,7 +103,14 @@ steps:
       TASK_DESC="$TASK_DESCRIPTION"
       ISSUE_NUMBER="$ISSUE_NUMBER"
       COMMIT_TITLE=$(printf 'feat: %.72s' "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
-      COMMIT_MSG=$(printf '%s\n\nImplements issue #%s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\nCloses #%s' "$COMMIT_TITLE" "$ISSUE_NUMBER" "$ISSUE_NUMBER")
+      # FIX #684: Host-aware commit references
+      HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
+      case "$HOST_TYPE" in
+        github) ISSUE_REF="Closes #${ISSUE_NUMBER}"; ISSUE_IMPL="issue #${ISSUE_NUMBER}" ;;
+        azdo)   ISSUE_REF="AB#${ISSUE_NUMBER}"; ISSUE_IMPL="AB#${ISSUE_NUMBER}" ;;
+        *)      ISSUE_REF="Ref #${ISSUE_NUMBER}"; ISSUE_IMPL="issue #${ISSUE_NUMBER}" ;;
+      esac
+      COMMIT_MSG=$(printf '%s\n\nImplements %s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\n%s' "$COMMIT_TITLE" "$ISSUE_IMPL" "$ISSUE_REF")
       if [ -n "$(git diff --cached --name-only)" ]; then
         git commit -m "$COMMIT_MSG"
       else
@@ -184,16 +191,10 @@ steps:
       fi
       echo "=== Step 16: Creating Draft PR ===" >&2
 
-      # FIX #684: Detect remote host type — skip PR creation for non-GitHub hosts
-      REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
-      REMOTE_HOST_TYPE="other"
-      case "$REMOTE_URL" in
-        *github.com*)            REMOTE_HOST_TYPE="github" ;;
-        *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*)
-                                 REMOTE_HOST_TYPE="azdo" ;;
-      esac
-      if [ "$REMOTE_HOST_TYPE" != "github" ]; then
-          echo "INFO: Non-GitHub remote ($REMOTE_HOST_TYPE) — skipping draft PR creation" >&2
+      # FIX #684: Consume REMOTE_HOST_TYPE from step-02d — skip PR creation for non-GitHub
+      HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
+      if [ "$HOST_TYPE" != "github" ]; then
+          echo "INFO: Non-GitHub remote ($HOST_TYPE) — skipping draft PR creation" >&2
           printf ''
           exit 0
       fi
@@ -350,7 +351,9 @@ steps:
       PR_TITLE="${TASK_DESC//$'\n'/ }"
       PR_TITLE="${PR_TITLE//$'\r'/ }"
       PR_TITLE="${PR_TITLE:0:200}"
-      PR_BODY=$(printf '## Summary\n%s\n\n## Issue\nCloses #%s\n\n## Changes\n%s\n\n## Testing\n- Unit tests added\n- Local testing completed\n- Pre-commit hooks pass\n\n## Checklist\n- [x] Tests pass\n- [x] Documentation updated\n- [x] No stubs or TODOs\n- [ ] Code review completed\n- [ ] Philosophy check passed\n\n---\n*This PR was created as a draft for review before merging.*\n' "$TASK_DESC" "$ISSUE_NUM" "$PR_DESIGN")
+      # Host-aware PR body (only reached for GitHub due to early exit above)
+      ISSUE_LINK="Closes #${ISSUE_NUM}"
+      PR_BODY=$(printf '## Summary\n%s\n\n## Issue\n%s\n\n## Changes\n%s\n\n## Testing\n- Unit tests added\n- Local testing completed\n- Pre-commit hooks pass\n\n## Checklist\n- [x] Tests pass\n- [x] Documentation updated\n- [x] No stubs or TODOs\n- [ ] Code review completed\n- [ ] Philosophy check passed\n\n---\n*This PR was created as a draft for review before merging.*\n' "$TASK_DESC" "$ISSUE_LINK" "$PR_DESIGN")
       gh_pr_create_with_retry
     output: "pr_url"
 

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -75,6 +75,12 @@ steps:
         echo "ERROR: step-15-commit-push requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
         exit 1
       fi
+      # Security: refuse to commit/push on protected branches (guards REPO_PATH fallback)
+      _CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+      if [ "$_CURRENT_BRANCH" = "main" ] || [ "$_CURRENT_BRANCH" = "master" ]; then
+        echo "ERROR: step-15 landed on protected branch '$_CURRENT_BRANCH' — refusing to commit. Worktree setup likely failed." >&2
+        exit 1
+      fi
       echo "=== Step 15: Commit and Push ===" >&2
       # FIX (#495): commit_result MUST be emitted on every exit path so step-16
       # (PR creation) can be gated on the actual push outcome. Trap installed
@@ -168,6 +174,12 @@ steps:
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-16 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: step-16-create-draft-pr requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
+        exit 1
+      fi
+      # Security: refuse to create PR from protected branches (guards REPO_PATH fallback)
+      _CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+      if [ "$_CURRENT_BRANCH" = "main" ] || [ "$_CURRENT_BRANCH" = "master" ]; then
+        echo "ERROR: step-16 landed on protected branch '$_CURRENT_BRANCH' — refusing to create PR. Worktree setup likely failed." >&2
         exit 1
       fi
       echo "=== Step 16: Creating Draft PR ===" >&2

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -69,7 +69,7 @@ steps:
     condition: "goal_already_met != 'true'"
     command: |
       set -euo pipefail
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-$REPO_PATH}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: step-15-commit-push requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
@@ -164,7 +164,7 @@ steps:
     condition: "goal_already_met != 'true' && commit_result.pushed == 'true'"
     command: |
       set -euo pipefail
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-$REPO_PATH}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-16 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: step-16-create-draft-pr requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -69,7 +69,7 @@ steps:
     condition: "goal_already_met != 'true'"
     command: |
       set -euo pipefail
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-$REPO_PATH}}"
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-15 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: step-15-commit-push requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
@@ -164,7 +164,7 @@ steps:
     condition: "goal_already_met != 'true' && commit_result.pushed == 'true'"
     command: |
       set -euo pipefail
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-$REPO_PATH}}"
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-16 requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: step-16-create-draft-pr requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
@@ -172,7 +172,7 @@ steps:
       fi
       echo "=== Step 16: Creating Draft PR ===" >&2
 
-      # FIX #684: Detect remote host type — skip PR creation only for known non-GitHub hosts
+      # FIX #684: Detect remote host type — skip PR creation for non-GitHub hosts
       REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
       REMOTE_HOST_TYPE="other"
       case "$REMOTE_URL" in
@@ -180,9 +180,9 @@ steps:
         *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*)
                                  REMOTE_HOST_TYPE="azdo" ;;
       esac
-      if [ "$REMOTE_HOST_TYPE" = "azdo" ]; then
-          echo "INFO: Remote is Azure DevOps — skipping draft PR creation (use az repos pr create)" >&2
-          printf '\n'
+      if [ "$REMOTE_HOST_TYPE" != "github" ]; then
+          echo "INFO: Non-GitHub remote ($REMOTE_HOST_TYPE) — skipping draft PR creation" >&2
+          printf ''
           exit 0
       fi
 

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -172,6 +172,20 @@ steps:
       fi
       echo "=== Step 16: Creating Draft PR ===" >&2
 
+      # FIX #684: Detect remote host type — skip PR creation only for known non-GitHub hosts
+      REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+      REMOTE_HOST_TYPE="other"
+      case "$REMOTE_URL" in
+        *github.com*)            REMOTE_HOST_TYPE="github" ;;
+        *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*)
+                                 REMOTE_HOST_TYPE="azdo" ;;
+      esac
+      if [ "$REMOTE_HOST_TYPE" = "azdo" ]; then
+          echo "INFO: Remote is Azure DevOps — skipping draft PR creation (use az repos pr create)" >&2
+          printf '\n'
+          exit 0
+      fi
+
       # Idempotency guard: detect pre-existing PRs before creating one.
       CURRENT_BRANCH=$(git branch --show-current)
       ISSUE_NUM="$ISSUE_NUMBER"

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -204,7 +204,7 @@ steps:
     max_env_value_bytes: 65536
     command: |
       set -euo pipefail
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-$REPO_PATH}}"
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?checkpoint-after-review-feedback requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: checkpoint-after-review-feedback requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -204,8 +204,8 @@ steps:
     max_env_value_bytes: 65536
     command: |
       set -euo pipefail
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
-      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-11b-implement-feedback requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-$REPO_PATH}}"
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?checkpoint-after-review-feedback requires worktree_setup.worktree_path; ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: checkpoint-after-review-feedback requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
         exit 1

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -319,7 +319,7 @@ steps:
     max_env_value_bytes: 65536
     command: |
       set -euo pipefail
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-$REPO_PATH}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?checkpoint-after-implementation requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: checkpoint-after-implementation requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -319,7 +319,7 @@ steps:
     max_env_value_bytes: 65536
     command: |
       set -euo pipefail
-      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-$REPO_PATH}}"
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?checkpoint-after-implementation requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: checkpoint-after-implementation requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -265,6 +265,12 @@ path = "../../tests/integration/p1_workflow_reliability_test.rs"
 name = "no_stale_python_patterns"
 path = "../../tests/integration/no_stale_python_patterns_test.rs"
 
+# Issue #684: Host-aware workflow steps (commit refs, PR body, summary, percent-decode).
+# TDD-RED tests — fail until implementation lands across 4 recipe files.
+[[test]]
+name = "issue_684_host_aware_workflow"
+path = "../../tests/integration/issue_684_host_aware_workflow_test.rs"
+
 # code-philosophy-audit recipe structural parity tests.
 [[test]]
 name = "code_philosophy_audit_recipe"

--- a/crates/amplihack-cli/src/commands/cs_validate/build.rs
+++ b/crates/amplihack-cli/src/commands/cs_validate/build.rs
@@ -201,8 +201,10 @@ Program.cs(12,1): error CS0246: The type or namespace name 'Foo' could not be fo
         assert_eq!(diags.len(), 0);
 
         // With "Warning" threshold — should include
-        let mut config2 = CsValidatorConfig::default();
-        config2.analyzer_severity_threshold = "Warning".to_string();
+        let config2 = CsValidatorConfig {
+            analyzer_severity_threshold: "Warning".to_string(),
+            ..CsValidatorConfig::default()
+        };
         let diags = parse_dotnet_diagnostics(output, &config2);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
@@ -216,8 +218,10 @@ Program.cs(12,1): error CS0246: The type or namespace name 'Foo' could not be fo
         let diags = parse_dotnet_diagnostics(output, &config);
         assert_eq!(diags.len(), 0);
 
-        let mut config2 = CsValidatorConfig::default();
-        config2.analyzer_severity_threshold = "Info".to_string();
+        let config2 = CsValidatorConfig {
+            analyzer_severity_threshold: "Info".to_string(),
+            ..CsValidatorConfig::default()
+        };
         let diags = parse_dotnet_diagnostics(output, &config2);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Info);

--- a/crates/amplihack-cli/src/commands/install/tests/settings_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/settings_tests.rs
@@ -376,7 +376,7 @@ fn no_production_code_references_xpia_hook_files() {
     for entry in fs::read_dir(&install_dir).unwrap() {
         let entry = entry.unwrap();
         let path = entry.path();
-        if path.extension().map_or(false, |e| e == "rs")
+        if path.extension().is_some_and(|e| e == "rs")
             && !path.to_str().unwrap_or("").contains("tests")
         {
             let content = fs::read_to_string(&path).unwrap();

--- a/crates/amplihack-cli/tests/issue_439_no_per_step_timeout.rs
+++ b/crates/amplihack-cli/tests/issue_439_no_per_step_timeout.rs
@@ -336,11 +336,8 @@ fn default_workflow_chain_has_no_yaml_timeout_fields() {
                         "{name}.yaml: step `{id}` has YAML `agent.{field}:`"
                     ));
                 }
-                if let Some(bash) = step.get("bash") {
-                    if bash.get(field).is_some() {
-                        violations
-                            .push(format!("{name}.yaml: step `{id}` has YAML `bash.{field}:`"));
-                    }
+                if step.get("bash").and_then(|b| b.get(field)).is_some() {
+                    violations.push(format!("{name}.yaml: step `{id}` has YAML `bash.{field}:`"));
                 }
             }
         }

--- a/crates/amplihack-remote/src/orchestrator.rs
+++ b/crates/amplihack-remote/src/orchestrator.rs
@@ -438,7 +438,7 @@ mod tests {
         };
         let age = vm.age_hours();
         // Should be approximately 2 hours (within tolerance)
-        assert!(age >= 1.9 && age <= 2.1, "age was {age}");
+        assert!((1.9..=2.1).contains(&age), "age was {age}");
     }
 
     #[test]

--- a/docs/concepts/multi-provider-workflow-architecture.md
+++ b/docs/concepts/multi-provider-workflow-architecture.md
@@ -21,13 +21,13 @@ fail silently or produce broken output.
 ## Detect-Once, Branch-Everywhere
 
 The core pattern: **one detection step** early in the workflow writes a
-`remote_provider` context variable. Every downstream step reads it and
+`remote_host_type` context variable. Every downstream step reads it and
 branches to the correct code path.
 
 ```
-Step 01b (once) → remote_provider = "github" | "azdo" | "local"
+Step 02d (once) → remote_host_type = "github" | "azdo" | "other"
     ↓
-Steps 03, 03b, 15, 16, 21 → case $REMOTE_PROVIDER in ...
+Steps 03, 03b, 15, 16, 21 → case $REMOTE_HOST_TYPE in ...
 ```
 
 **Why not adapters?** An adapter/strategy pattern would add a layer of
@@ -44,17 +44,17 @@ another `case` branch is lower than maintaining an adapter registry.
 All providers produce the same output: a plain integer `issue_number`. This
 is the contract that downstream steps depend on.
 
-| Provider | Source                    | Example |
-| -------- | ------------------------- | ------- |
-| GitHub   | `gh issue create` URL     | `684`   |
-| AzDO     | `az boards` work item ID  | `12345` |
-| Local    | Synthetic (PID + epoch)   | `4821937` |
+| Provider   | Source                    | Example   |
+| ---------- | ------------------------- | --------- |
+| GitHub     | `gh issue create` URL     | `684`     |
+| AzDO       | `az boards` work item ID  | `12345`   |
+| Other/Local | Synthetic (PID + epoch)  | `4821937` |
 
 By normalizing to an integer at step 03b, no downstream step needs to know
 which provider produced it. Branch names, commit messages, and PR
 descriptions all use `issue_number` as a plain number with provider-specific
-formatting applied only at the point of use (e.g., `#684` for GitHub,
-`AB#12345` for AzDO, `[local-4821937]` for local).
+formatting applied only at the point of use (e.g., `Closes #684` for GitHub,
+`AB#12345` for AzDO, `Ref #4821937` for other).
 
 ---
 
@@ -77,11 +77,11 @@ integration is more robust.
 
 ---
 
-## Local Fallback Rationale
+## Other/Local Fallback Rationale
 
-The `local` provider is not an error state — it is a first-class mode that
+The `other` host type is not an error state — it is a first-class mode that
 enables the workflow to run in isolated environments (CI containers,
-air-gapped systems, fresh `git init` repos). Local mode:
+air-gapped systems, fresh `git init` repos). Other/local mode:
 
 - Generates a synthetic `issue_number` using PID + epoch seconds for
   collision resistance
@@ -98,7 +98,7 @@ air-gapped systems, fresh `git init` repos). Local mode:
 | Detect-once pattern          | Single detection, no repeated work | One step to maintain                  |
 | `case` over adapters         | Simpler, no indirection            | Adding providers requires editing steps |
 | Numeric issue_number contract | Downstream steps stay unchanged   | Provider URL information is lost       |
-| Local as fallback            | Works everywhere                   | No tracking system updated             |
+| Other as fallback            | Works everywhere                   | No tracking system updated             |
 | Manual AzDO PR creation      | Avoids brittle automation          | Extra manual step for AzDO users       |
 | Context propagation required | Explicit data flow                 | Must declare vars in parent recipe     |
 
@@ -117,5 +117,5 @@ air-gapped systems, fresh `git init` repos). Local mode:
 
 | Field  | Value                                                     |
 | ------ | --------------------------------------------------------- |
-| Status | In Progress (retcon documentation; implementation pending) |
+| Status | Specification (implementation pending)                      |
 | Issue  | #684                                                      |

--- a/docs/concepts/multi-provider-workflow-architecture.md
+++ b/docs/concepts/multi-provider-workflow-architecture.md
@@ -1,0 +1,121 @@
+# Multi-Provider Workflow Architecture
+
+> [Home](../index.md) > Concepts > Multi-Provider Workflow Architecture
+
+Explains the design decisions behind the multi-provider workflow feature
+([Issue #684](https://github.com/rysweet/amplihack-rs/issues/684)). For
+implementation details, see the
+[Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md).
+
+---
+
+## The Problem
+
+`default-workflow` steps 03, 03b, 15, 16, and 21 call `gh` (GitHub CLI)
+unconditionally. When the repository remote points to Azure DevOps, these
+steps fail with confusing errors. When no remote exists (local-only), they
+fail silently or produce broken output.
+
+---
+
+## Detect-Once, Branch-Everywhere
+
+The core pattern: **one detection step** early in the workflow writes a
+`remote_provider` context variable. Every downstream step reads it and
+branches to the correct code path.
+
+```
+Step 01b (once) → remote_provider = "github" | "azdo" | "local"
+    ↓
+Steps 03, 03b, 15, 16, 21 → case $REMOTE_PROVIDER in ...
+```
+
+**Why not adapters?** An adapter/strategy pattern would add a layer of
+indirection (provider interface, factory, registration) for three simple
+`case` branches. The bash `case` statement is self-documenting, testable in
+isolation, and avoids the indirection that would make recipe YAML harder to
+read. If a fourth provider is added in the future, the cost of adding
+another `case` branch is lower than maintaining an adapter registry.
+
+---
+
+## The Issue Number Contract
+
+All providers produce the same output: a plain integer `issue_number`. This
+is the contract that downstream steps depend on.
+
+| Provider | Source                    | Example |
+| -------- | ------------------------- | ------- |
+| GitHub   | `gh issue create` URL     | `684`   |
+| AzDO     | `az boards` work item ID  | `12345` |
+| Local    | Synthetic (PID + epoch)   | `4821937` |
+
+By normalizing to an integer at step 03b, no downstream step needs to know
+which provider produced it. Branch names, commit messages, and PR
+descriptions all use `issue_number` as a plain number with provider-specific
+formatting applied only at the point of use (e.g., `#684` for GitHub,
+`AB#12345` for AzDO, `[local-4821937]` for local).
+
+---
+
+## PR Creation Asymmetry
+
+GitHub PR creation is fully automated via `gh pr create`. AzDO PR creation
+is logged as manual instructions rather than automated. This asymmetry
+exists because:
+
+1. `gh pr create` handles draft PRs, labels, reviewers, and closing
+   keywords in a single command. `az repos pr create` requires separate
+   calls for reviewers and labels.
+2. AzDO repository IDs must be resolved separately — they are not
+   derivable from the remote URL alone.
+3. The AzDO CLI's error messages for misconfigured projects are opaque,
+   making automated recovery difficult.
+
+Automated AzDO PR creation is planned as a follow-up once the AzDO CLI
+integration is more robust.
+
+---
+
+## Local Fallback Rationale
+
+The `local` provider is not an error state — it is a first-class mode that
+enables the workflow to run in isolated environments (CI containers,
+air-gapped systems, fresh `git init` repos). Local mode:
+
+- Generates a synthetic `issue_number` using PID + epoch seconds for
+  collision resistance
+- Skips all network calls (no `gh`, no `az`)
+- Produces valid branch names and commit messages
+- Skips PR creation (no remote to push to)
+
+---
+
+## Trade-offs
+
+| Decision                     | Benefit                            | Cost                                  |
+| ---------------------------- | ---------------------------------- | ------------------------------------- |
+| Detect-once pattern          | Single detection, no repeated work | One step to maintain                  |
+| `case` over adapters         | Simpler, no indirection            | Adding providers requires editing steps |
+| Numeric issue_number contract | Downstream steps stay unchanged   | Provider URL information is lost       |
+| Local as fallback            | Works everywhere                   | No tracking system updated             |
+| Manual AzDO PR creation      | Avoids brittle automation          | Extra manual step for AzDO users       |
+| Context propagation required | Explicit data flow                 | Must declare vars in parent recipe     |
+
+---
+
+## Related
+
+- [Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md) — full implementation details
+- [How to Use the Workflow with Azure DevOps](../howto/use-workflow-with-azure-devops.md) — task-oriented guide
+- [Step 03 Idempotency Guards](../reference/recipe-step-03-idempotency.md) — GitHub-specific guards
+- [Workflow Issue Extraction](../reference/workflow-issue-extraction.md) — three-tier extraction
+
+---
+
+**Metadata**
+
+| Field  | Value                                                     |
+| ------ | --------------------------------------------------------- |
+| Status | In Progress (retcon documentation; implementation pending) |
+| Issue  | #684                                                      |

--- a/docs/howto/use-workflow-with-azure-devops.md
+++ b/docs/howto/use-workflow-with-azure-devops.md
@@ -50,7 +50,7 @@ The workflow automatically:
 1. Detects `azdo` as the remote host type (step 02d)
 2. Creates an AzDO work item of type `Task` (step 03)
 3. Uses `AB#N` commit references (step 15)
-4. Logs manual PR creation instructions (step 16)
+4. Skips automated PR creation (step 16)
 5. Produces a host-aware summary (step 22b)
 
 ### Override the work item type
@@ -91,7 +91,7 @@ sequences before validation, so project names with spaces work correctly.
 | Host detection      | step 02d → `github`            | step 02d → `azdo`                    |
 | Issue creation      | `gh issue create`              | `az boards work-item create`         |
 | Commit reference    | `Closes #N`                    | `AB#N`                               |
-| PR creation         | Automated (`gh pr create`)     | Manual (instructions logged)         |
+| PR creation         | Automated (`gh pr create`)     | Skipped (create manually after)      |
 | Auth prerequisite   | `gh auth login`                | `az login` + DevOps extension        |
 | Idempotency Guard 1 | `gh issue view`               | `az boards work-item show`           |
 | Idempotency Guard 2 | `gh issue list --search`      | Not yet implemented (planned: WIQL query) |

--- a/docs/howto/use-workflow-with-azure-devops.md
+++ b/docs/howto/use-workflow-with-azure-devops.md
@@ -8,6 +8,9 @@ repository. For design rationale, see
 For full reference, see
 [Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md).
 
+> **Note**: This document describes the target design for issue #684. Some
+> recipe YAML changes are implementation-pending.
+
 ---
 
 ## Prerequisites
@@ -47,10 +50,11 @@ amplihack recipe run default-workflow \
 
 The workflow automatically:
 
-1. Detects `azdo` as the remote provider (step 01b)
+1. Detects `azdo` as the remote host type (step 02d)
 2. Creates an AzDO work item of type `Task` (step 03)
 3. Uses `AB#N` commit references (step 15)
 4. Logs manual PR creation instructions (step 16)
+5. Produces a host-aware summary (step 22b)
 
 ### Override the work item type
 
@@ -70,7 +74,9 @@ Common types: `Task`, `Bug`, `User Story`, `Feature`, `Epic`.
 
 ## Run the Workflow with an Existing Work Item
 
-Reference the work item number in `task_description`:
+Reference the work item number in `task_description` — the idempotency
+guard in step 03 will detect the `AB#N` reference and reuse the existing
+work item:
 
 ```bash
 amplihack recipe run default-workflow \
@@ -78,14 +84,13 @@ amplihack recipe run default-workflow \
   -c repo_path=.
 ```
 
-Or pass the issue number directly to skip step 03:
+---
 
-```bash
-amplihack recipe run default-workflow \
-  -c issue_number=12345 \
-  -c task_description="Fix the auth bug" \
-  -c repo_path=.
-```
+## Percent-Encoded Project Names
+
+AzDO project names containing spaces (e.g., `My Project`) appear
+percent-encoded in remote URLs as `My%20Project`. Step 03 decodes `%XX`
+sequences before validation, so project names with spaces work correctly.
 
 ---
 
@@ -93,12 +98,14 @@ amplihack recipe run default-workflow \
 
 | Aspect              | GitHub                         | Azure DevOps                         |
 | ------------------- | ------------------------------ | ------------------------------------ |
+| Host detection      | step 02d → `github`            | step 02d → `azdo`                    |
 | Issue creation      | `gh issue create`              | `az boards work-item create`         |
-| Issue reference     | `#N`                           | `AB#N`                               |
+| Commit reference    | `Closes #N`                    | `AB#N`                               |
 | PR creation         | Automated (`gh pr create`)     | Manual (instructions logged)         |
 | Auth prerequisite   | `gh auth login`                | `az login` + DevOps extension        |
 | Idempotency Guard 1 | `gh issue view`               | `az boards work-item show`           |
 | Idempotency Guard 2 | `gh issue list --search`      | `az boards query` (WIQL)             |
+| Summary (step 22b)  | `PR: <url>`                   | `PR: N/A (manual creation required)` |
 
 ---
 
@@ -121,11 +128,15 @@ Or use the Azure DevOps web UI to create the PR from the pushed branch.
 
 ## Troubleshooting
 
-**Provider detected as `local` instead of `azdo`**
+**Host detected as `other` instead of `azdo`**
 
-Verify the remote URL contains `dev.azure.com` or `visualstudio.com`:
-`git remote get-url origin`. SSH-style AzDO URLs
-(`git@ssh.dev.azure.com:v3/org/project/repo`) are also detected.
+Verify the remote URL contains `dev.azure.com`, `visualstudio.com`, or
+`ssh.dev.azure.com`: `git remote get-url origin`. All three URL forms are
+detected:
+
+- HTTPS: `https://dev.azure.com/org/project/_git/repo`
+- Legacy: `https://org.visualstudio.com/project/_git/repo`
+- SSH: `git@ssh.dev.azure.com:v3/org/project/repo`
 
 **`az boards` fails with authentication error**
 
@@ -137,11 +148,17 @@ Run `az login` to refresh credentials. For PAT-based auth:
 List available types: `az boards work-item type list --project YOUR_PROJECT`.
 Type names are case-sensitive and vary by process template.
 
+**Project name with spaces not recognized**
+
+Ensure the remote URL uses standard percent-encoding (`%20` for spaces).
+Step 03 decodes these automatically. Invalid sequences like `%ZZ` are
+rejected and the workflow falls back to local tracking.
+
 ---
 
 **Metadata**
 
-| Field  | Value                                                     |
-| ------ | --------------------------------------------------------- |
-| Status | In Progress (retcon documentation; implementation pending) |
-| Issue  | #684                                                      |
+| Field  | Value     |
+| ------ | --------- |
+| Status | Specification (implementation pending) |
+| Issue  | #684      |

--- a/docs/howto/use-workflow-with-azure-devops.md
+++ b/docs/howto/use-workflow-with-azure-devops.md
@@ -8,9 +8,6 @@ repository. For design rationale, see
 For full reference, see
 [Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md).
 
-> **Note**: This document describes the target design for issue #684. Some
-> recipe YAML changes are implementation-pending.
-
 ---
 
 ## Prerequisites
@@ -58,17 +55,10 @@ The workflow automatically:
 
 ### Override the work item type
 
-By default, step 03 creates a `Task`. Override for other types:
-
-```bash
-amplihack recipe run default-workflow \
-  -c task_description="Fix null reference in auth module" \
-  -c work_item_type=Bug \
-  -c repo_path=.
-```
-
-Valid types depend on your AzDO process template (Agile, Scrum, Basic, CMMI).
-Common types: `Task`, `Bug`, `User Story`, `Feature`, `Epic`.
+By default, step 03 creates a `Task`. The `work_item_type` context variable
+override is planned but not yet implemented. To use a different work item
+type, create the work item manually and reference it via `AB#N` in the
+task description.
 
 ---
 
@@ -104,7 +94,7 @@ sequences before validation, so project names with spaces work correctly.
 | PR creation         | Automated (`gh pr create`)     | Manual (instructions logged)         |
 | Auth prerequisite   | `gh auth login`                | `az login` + DevOps extension        |
 | Idempotency Guard 1 | `gh issue view`               | `az boards work-item show`           |
-| Idempotency Guard 2 | `gh issue list --search`      | `az boards query` (WIQL)             |
+| Idempotency Guard 2 | `gh issue list --search`      | Not yet implemented (planned: WIQL query) |
 | Summary (step 22b)  | `PR: <url>`                   | `PR: N/A (manual creation required)` |
 
 ---
@@ -160,5 +150,5 @@ rejected and the workflow falls back to local tracking.
 
 | Field  | Value     |
 | ------ | --------- |
-| Status | Specification (implementation pending) |
+| Status | Implemented |
 | Issue  | #684      |

--- a/docs/howto/use-workflow-with-azure-devops.md
+++ b/docs/howto/use-workflow-with-azure-devops.md
@@ -1,0 +1,147 @@
+# How to Use the Default Workflow with Azure DevOps
+
+> [Home](../index.md) > How-To > Use Workflow with Azure DevOps
+
+Task-oriented guide for running `default-workflow` against an Azure DevOps
+repository. For design rationale, see
+[Multi-Provider Workflow Architecture](../concepts/multi-provider-workflow-architecture.md).
+For full reference, see
+[Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md).
+
+---
+
+## Prerequisites
+
+1. **Azure CLI** installed with the DevOps extension:
+
+   ```bash
+   az --version
+   az extension add --name azure-devops
+   ```
+
+2. **Authenticated** to your AzDO organization:
+
+   ```bash
+   az login
+   az devops configure --defaults \
+     organization=https://dev.azure.com/YOUR_ORG \
+     project=YOUR_PROJECT
+   ```
+
+3. **Git remote** named `origin` pointing to your AzDO repo:
+
+   ```bash
+   git remote -v
+   # origin  https://dev.azure.com/myorg/myproject/_git/myrepo (fetch)
+   ```
+
+---
+
+## Run the Workflow with a New Work Item
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Add retry logic to API client" \
+  -c repo_path=.
+```
+
+The workflow automatically:
+
+1. Detects `azdo` as the remote provider (step 01b)
+2. Creates an AzDO work item of type `Task` (step 03)
+3. Uses `AB#N` commit references (step 15)
+4. Logs manual PR creation instructions (step 16)
+
+### Override the work item type
+
+By default, step 03 creates a `Task`. Override for other types:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Fix null reference in auth module" \
+  -c work_item_type=Bug \
+  -c repo_path=.
+```
+
+Valid types depend on your AzDO process template (Agile, Scrum, Basic, CMMI).
+Common types: `Task`, `Bug`, `User Story`, `Feature`, `Epic`.
+
+---
+
+## Run the Workflow with an Existing Work Item
+
+Reference the work item number in `task_description`:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Fix the auth bug described in AB#12345" \
+  -c repo_path=.
+```
+
+Or pass the issue number directly to skip step 03:
+
+```bash
+amplihack recipe run default-workflow \
+  -c issue_number=12345 \
+  -c task_description="Fix the auth bug" \
+  -c repo_path=.
+```
+
+---
+
+## Differences from GitHub Workflow
+
+| Aspect              | GitHub                         | Azure DevOps                         |
+| ------------------- | ------------------------------ | ------------------------------------ |
+| Issue creation      | `gh issue create`              | `az boards work-item create`         |
+| Issue reference     | `#N`                           | `AB#N`                               |
+| PR creation         | Automated (`gh pr create`)     | Manual (instructions logged)         |
+| Auth prerequisite   | `gh auth login`                | `az login` + DevOps extension        |
+| Idempotency Guard 1 | `gh issue view`               | `az boards work-item show`           |
+| Idempotency Guard 2 | `gh issue list --search`      | `az boards query` (WIQL)             |
+
+---
+
+## Create a PR Manually
+
+After the workflow completes steps 1–15 (commit and push), create a PR
+using the Azure DevOps CLI:
+
+```bash
+az repos pr create \
+  --source-branch "$(git branch --show-current)" \
+  --target-branch main \
+  --title "feat: add retry logic (AB#12345)" \
+  --description "Implements retry logic per work item AB#12345"
+```
+
+Or use the Azure DevOps web UI to create the PR from the pushed branch.
+
+---
+
+## Troubleshooting
+
+**Provider detected as `local` instead of `azdo`**
+
+Verify the remote URL contains `dev.azure.com` or `visualstudio.com`:
+`git remote get-url origin`. SSH-style AzDO URLs
+(`git@ssh.dev.azure.com:v3/org/project/repo`) are also detected.
+
+**`az boards` fails with authentication error**
+
+Run `az login` to refresh credentials. For PAT-based auth:
+`az devops login --organization https://dev.azure.com/YOUR_ORG`.
+
+**Work item type not valid**
+
+List available types: `az boards work-item type list --project YOUR_PROJECT`.
+Type names are case-sensitive and vary by process template.
+
+---
+
+**Metadata**
+
+| Field  | Value                                                     |
+| ------ | --------------------------------------------------------- |
+| Status | In Progress (retcon documentation; implementation pending) |
+| Issue  | #684                                                      |

--- a/docs/index.md
+++ b/docs/index.md
@@ -260,6 +260,9 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [Tutorial: Recover PR 579 Readiness](tutorials/pr-recovery-readiness.md) - Walk through hook and additive-copy readiness evidence for an interrupted PR recovery
 - [PR Recovery Readiness Reference](reference/pr-recovery-readiness.md) - Context fields, readiness evidence schema, publish contract, and finalization states
 - [Workflow Issue Extraction Reference](reference/workflow-issue-extraction.md) - Three-tier issue-number resolution (direct URL → PR closing-refs → `#N` verify) in step 03b
+- [Multi-Provider Workflow Reference](reference/multi-provider-workflow.md) - Provider detection, issue tracking, and PR routing for GitHub, AzDO, and local repos
+- [How to Use the Workflow with Azure DevOps](howto/use-workflow-with-azure-devops.md) - Run default-workflow against an AzDO repository
+- [Multi-Provider Workflow Architecture](concepts/multi-provider-workflow-architecture.md) - Design decisions: detect-once pattern, issue number contract, PR asymmetry
 - [Run a Quality Audit](howto/run-quality-audit.md) - Invoke quality-audit-cycle recipe, target subdirectories, filter categories
 - [CLI Reference](reference/cli.md) - Top-level `amplihack` command, `--version` flag, global environment variables
 - [Recipe CLI Reference](reference/recipe-cli-reference.md) - Complete command-line documentation

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -117,7 +117,7 @@ extract the AzDO organization and project names, then creates a work item.
 | URL form | Example | Regex |
 | -------- | ------- | ----- |
 | HTTPS    | `https://dev.azure.com/org/project/_git/repo` | `dev\.azure\.com/([^/]+)/([^/]+)/` |
-| Legacy   | `https://org.visualstudio.com/project/_git/repo` | `([^.]+)\.visualstudio\.com/([^/]+)/` |
+| Legacy   | `https://org.visualstudio.com/project/_git/repo` | `([^/.]+)\.visualstudio\.com/([^/]+)/` |
 | SSH      | `git@ssh.dev.azure.com:v3/org/project/repo` | `ssh\.dev\.azure\.com[:/]v3/([^/]+)/([^/]+)/` |
 
 **Percent-encoding**: AzDO project names may contain spaces, which appear as

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -4,22 +4,24 @@
 
 Reference for the multi-provider detection and routing logic in
 `default-workflow`. This feature enables the same 23-step workflow to operate
-against GitHub, Azure DevOps (AzDO), or a local-only repository without
+against GitHub, Azure DevOps (AzDO), or a local/unknown repository without
 requiring the user to select a provider manually.
 
-> **Note**: This documentation is written retcon-style ahead of full
-> implementation. The design is finalized; code changes are in progress.
-> See [Issue #684](https://github.com/rysweet/amplihack-rs/issues/684).
+> **Note**: This document describes the target design for issue #684. Recipe
+> YAML changes to match this specification are implementation-pending. The
+> current code has host detection inline in step-03 and does not yet propagate
+> `remote_host_type` via the context block.
 
 ## Contents
 
 - [Overview](#overview)
-- [Provider Detection (Step 01b)](#provider-detection-step-01b)
+- [Host Detection (Step 02d)](#host-detection-step-02d)
 - [Issue Tracking by Provider](#issue-tracking-by-provider)
 - [Issue Extraction (Step 03b)](#issue-extraction-step-03b)
-- [PR Creation Routing (Step 16)](#pr-creation-routing-step-16)
 - [Commit Message Formatting (Step 15)](#commit-message-formatting-step-15)
+- [PR Creation Routing (Step 16)](#pr-creation-routing-step-16)
 - [Worktree Resume Fix (Step 04)](#worktree-resume-fix-step-04)
+- [Final Status (Step 22b)](#final-status-step-22b)
 - [Context Variables](#context-variables)
 - [Diagnostics](#diagnostics)
 - [Error Handling](#error-handling)
@@ -38,88 +40,96 @@ unconditionally, causing failures when the remote pointed to Azure DevOps or
 when no remote existed at all.
 
 The multi-provider workflow introduces a **detect-once, branch-everywhere**
-pattern: step `01b` runs early in `workflow-prep` to detect the remote
-provider, and all downstream steps consult the resulting `remote_provider`
-context variable to choose the correct code path.
+pattern: step `02d` runs in `workflow-prep` to detect the remote host type,
+and all downstream steps consult the resulting `remote_host_type` context
+variable to choose the correct code path.
 
 ```
 git remote get-url origin
         │
         ▼
-┌─────────────────────────────────┐
-│  Step 01b: Provider Detection    │
-│  *.github.com*  → "github"       │
-│  *dev.azure.com*│*vscom* → "azdo"│
-│  everything else → "local"       │
-└─────────────────────────────────┘
+┌──────────────────────────────────┐
+│  Step 02d: Host Type Detection    │
+│  *.github.com*  → "github"        │
+│  *dev.azure.com*│*vscom* → "azdo" │
+│  everything else → "other"        │
+└──────────────────────────────────┘
         │
         ▼
-  remote_provider = "github" | "azdo" | "local"
+  remote_host_type = "github" | "azdo" | "other"
         │
         ├─► Step 03:  issue creation (routed)
         ├─► Step 03b: issue extraction (routed)
         ├─► Step 15:  commit format (routed)
         ├─► Step 16:  PR creation (routed)
-        └─► Step 21:  PR readiness (routed)
+        ├─► Step 21:  PR readiness (routed)
+        └─► Step 22b: final status (routed)
 ```
 
 ---
 
-## Provider Detection (Step 01b)
+## Host Detection (Step 02d)
 
-**Location**: `workflow-prep.yaml`, after step `01` (prepare workspace).
+**Location**: `workflow-prep.yaml`, step `step-02d-detect-host-type`, after
+step `02c` (requirements clarification) and before step `03` (issue creation).
 
 **Logic**:
 
 ```bash
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
 case "$REMOTE_URL" in
-  *github.com*)         PROVIDER="github" ;;
-  *dev.azure.com*|*visualstudio.com*) PROVIDER="azdo" ;;
-  *)                    PROVIDER="local"  ;;
+  *github.com*)         REMOTE_HOST_TYPE="github" ;;
+  *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*)
+                        REMOTE_HOST_TYPE="azdo" ;;
+  *)                    REMOTE_HOST_TYPE="other" ;;
 esac
 ```
 
-**Outputs**:
-
-| Variable         | Type   | Description                                    |
-| ---------------- | ------ | ---------------------------------------------- |
-| `remote_provider` | string | `"github"`, `"azdo"`, or `"local"`             |
-| `azdo_org_url`   | string | Full AzDO org URL (empty if not AzDO)           |
-| `azdo_org`       | string | AzDO organization name (empty if not AzDO)      |
-| `azdo_project`   | string | AzDO project name (empty if not AzDO)            |
-
-**Context propagation**: These variables are outputs of step `01b` in
-`workflow-prep.yaml`. For them to propagate to downstream sub-recipes, they
-must be declared in the parent `default-workflow.yaml` context block with
-empty-string defaults. Without this declaration, the recipe-runner's
-`_execute_sub_recipe()` context-merging will not thread them through to
-phases like `workflow-publish` or `workflow-finalize`.
-
-Step `01b` must be placed in `workflow-prep.yaml` (steps 00–03b phase) since
-that is where provider detection logically belongs — before any step that
-needs to know the provider.
+**Output**: `remote_host_type` — a plain string (`"github"`, `"azdo"`, or
+`"other"`) propagated to all downstream sub-recipes via the parent
+`default-workflow.yaml` context block. Step 02d only determines the host
+type; AzDO-specific URL parsing (organization, project) is performed by
+step 03 where the values are consumed.
 
 **Edge cases**:
 
-- No remote configured → `REMOTE_URL` is empty → `PROVIDER="local"`
+- No remote configured → `REMOTE_URL` is empty → `REMOTE_HOST_TYPE="other"`
 - Multiple remotes → only `origin` is checked (convention)
 - SSH URLs → pattern matching works on both `git@github.com:` and
   `https://github.com/` forms
+- Not a git repo → step falls back to `"other"` before step 03 runs
 
 ---
 
 ## Issue Tracking by Provider
 
-### GitHub (`remote_provider = "github"`)
+### GitHub (`remote_host_type = "github"`)
 
-Step 03 uses `gh issue create` and `gh issue view` as before. No change
-from the existing behavior documented in
+Step 03 reads `$REMOTE_HOST_TYPE` from context (set by step 02d) and routes
+to the GitHub path. Uses `gh issue create` and `gh issue view` as before. No
+change from the existing behavior documented in
 [recipe-step-03-idempotency.md](recipe-step-03-idempotency.md).
 
-### Azure DevOps (`remote_provider = "azdo"`)
+### Azure DevOps (`remote_host_type = "azdo"`)
 
-Step 03 creates an AzDO work item using the `az boards work-item create`
+When `$REMOTE_HOST_TYPE` is `"azdo"`, step 03 parses the remote URL to
+extract the AzDO organization and project names, then creates a work item.
+
+**AzDO URL parsing** (three URL forms):
+
+| URL form | Example | Regex |
+| -------- | ------- | ----- |
+| HTTPS    | `https://dev.azure.com/org/project/_git/repo` | `dev\.azure\.com/([^/]+)/([^/]+)/` |
+| Legacy   | `https://org.visualstudio.com/project/_git/repo` | `([^.]+)\.visualstudio\.com/([^/]+)/` |
+| SSH      | `git@ssh.dev.azure.com:v3/org/project/repo` | `ssh\.dev\.azure\.com[:/]v3/([^/]+)/([^/]+)/` |
+
+**Percent-encoding**: AzDO project names may contain spaces, which appear as
+`%20` in URLs. Step 03 decodes `%XX` sequences before validation. The
+decoded name is validated against `^[a-zA-Z0-9._ -]+$` (note: spaces are
+permitted in decoded form). Invalid percent sequences (e.g., `%ZZ`) cause
+the step to fall back to local tracking with a warning.
+
+Step 03 creates the work item using the `az boards work-item create`
 CLI command:
 
 ```bash
@@ -149,7 +159,7 @@ The idempotency guards (Guard 1 and Guard 2 from
   `az boards work-item show --id <N>`
 - **Guard 2**: Searches via `az boards query` using WIQL title match
 
-### Local (`remote_provider = "local"`)
+### Other/Local (`remote_host_type = "other"`)
 
 Step 03 generates a synthetic issue number for branch naming and commit
 messages, without making any network calls:
@@ -176,7 +186,7 @@ handle all three provider URL formats:
 | -------- | --------------------------------------------------------- | ----------------------------------- |
 | GitHub   | `https://github.com/owner/repo/issues/N`                  | `issues/[0-9]+`                     |
 | AzDO     | `https://dev.azure.com/org/project/_workitems/edit/N`      | `_workitems/edit/[0-9]+`            |
-| Local    | Bare numeric string from synthetic ID                       | `^[0-9]+$`                          |
+| Other    | Bare numeric string from synthetic ID                       | `^[0-9]+$`                          |
 
 The `issue_number` output contract remains unchanged: a plain integer (or
 null). Downstream steps never see the provider URL format — they only
@@ -184,13 +194,36 @@ consume the numeric ID.
 
 ---
 
+## Commit Message Formatting (Step 15)
+
+Commit messages adapt their issue reference syntax based on
+`$REMOTE_HOST_TYPE`, consumed from the propagated context variable (set by
+step 02d, declared in the parent recipe's context block):
+
+| Host type | Format           | Example                           |
+| --------- | ---------------- | --------------------------------- |
+| `github`  | `Closes #N`      | `feat: add auth (Closes #684)`    |
+| `azdo`    | `AB#N`           | `feat: add auth (AB#12345)`       |
+| `other`   | `Ref #N`         | `feat: add auth (Ref #4821937)`   |
+
+The `Closes #N` format triggers GitHub's auto-close behavior. The `AB#N`
+format triggers Azure Boards work item linking. The `Ref #N` format is a
+neutral reference that does not trigger automation on any platform.
+
+---
+
 ## PR Creation Routing (Step 16)
 
-| Provider | Tool                  | Behavior                                                |
-| -------- | --------------------- | ------------------------------------------------------- |
-| GitHub   | `gh pr create`        | Unchanged from current behavior                          |
-| AzDO     | (manual)              | Logs instructions; automated `az repos pr create` planned |
-| Local    | (skipped)             | Logs "no remote — skipping PR creation"                  |
+| Host type | Tool                  | Behavior                                                |
+| --------- | --------------------- | ------------------------------------------------------- |
+| `github`  | `gh pr create`        | Unchanged from current behavior                          |
+| `azdo`    | (manual)              | Logs instructions; automated `az repos pr create` planned |
+| `other`   | (skipped)             | Logs "no remote — skipping PR creation"                  |
+
+Step 16 consumes `$REMOTE_HOST_TYPE` from the propagated context variable
+(set by step 02d) rather than re-detecting the host type inline. Non-GitHub
+hosts exit early with an informational message. The PR body for GitHub uses
+the same host-aware reference format as step 15.
 
 **PR creation asymmetry**: GitHub PR creation is fully automated because `gh`
 supports draft PRs, labels, and reviewers in a single command. AzDO PR
@@ -198,18 +231,6 @@ creation via `az repos pr create` is planned but not yet automated because
 the AzDO CLI requires additional parameters (repository ID, target branch
 resolution) that vary by project configuration. The workflow logs clear
 instructions for manual PR creation in the meantime.
-
----
-
-## Commit Message Formatting (Step 15)
-
-Commit messages adapt their issue reference syntax per provider:
-
-| Provider | Format                      | Example                           |
-| -------- | --------------------------- | --------------------------------- |
-| GitHub   | `Fixes #N` / `Closes #N`    | `feat: add auth (Fixes #684)`     |
-| AzDO     | `AB#N`                       | `feat: add auth (AB#12345)`        |
-| Local    | `[local-N]`                  | `feat: add auth [local-4821937]`   |
 
 ---
 
@@ -226,23 +247,63 @@ for the full worktree lifecycle documentation.
 
 ---
 
+## PR Readiness (Step 21)
+
+Step 21 (`step-21-pr-ready`) calls `gh pr ready` and `gh pr comment` —
+GitHub-specific commands. Rather than checking `$REMOTE_HOST_TYPE` directly,
+step 21 guards on `$PR_URL`: if it is empty or whitespace-only, the step
+exits early with an informational message.
+
+This works because non-GitHub hosts never receive a `PR_URL`:
+
+- AzDO: step 16 skips automated PR creation → `PR_URL` stays empty
+- Other: step 16 skips entirely → `PR_URL` stays empty
+
+As defense-in-depth, the target implementation adds a `$REMOTE_HOST_TYPE`
+check before `gh` calls to prevent failures if `PR_URL` is set to a
+non-GitHub URL through manual context override.
+
+---
+
+## Final Status (Step 22b)
+
+Step 22b produces a host-aware summary. It checks both `PR_URL` (non-empty)
+and `REMOTE_HOST_TYPE` (equals `github`) before invoking any `gh` CLI
+commands.
+
+| Host type | PR status line                            | Issue reference line |
+| --------- | ----------------------------------------- | -------------------- |
+| `github`  | `PR: <url>` (with `gh pr view` details)   | `Issue: #N`          |
+| `azdo`    | `PR: N/A (manual creation required)`      | `Issue: AB#N`        |
+| `other`   | `PR: N/A (no remote provider)`            | `Issue: Ref #N`      |
+
+The `HOST_TYPE=${REMOTE_HOST_TYPE:-other}` local variable pattern is used
+for `set -u` safety — if the context variable is unset for any reason, the
+step degrades to "other" behavior rather than failing.
+
+---
+
 ## Context Variables
 
 Variables added or modified by the multi-provider feature:
 
 | Variable           | Set by    | Type   | Description                                  |
 | ------------------ | --------- | ------ | -------------------------------------------- |
-| `remote_provider`  | step-01b  | string | `"github"`, `"azdo"`, or `"local"`            |
-| `azdo_org_url`     | step-01b  | string | Full AzDO org URL (empty if not AzDO)         |
-| `azdo_org`         | step-01b  | string | AzDO organization name (empty if not AzDO)    |
-| `azdo_project`     | step-01b  | string | AzDO project name (empty if not AzDO)          |
+| `remote_host_type` | step-02d  | string | `"github"`, `"azdo"`, or `"other"`            |
+| `azdo_org_url`     | step-03   | string | Full AzDO org URL (local to step-03; empty if not AzDO) |
+| `azdo_org`         | step-03   | string | AzDO organization name (local to step-03; empty if not AzDO) |
+| `azdo_project`     | step-03   | string | AzDO project name, percent-decoded (local to step-03; empty if not AzDO) |
 | `work_item_type`   | user/step-02 | string | AzDO work item type; default `"Task"`       |
 | `issue_number`     | step-03b  | int    | Numeric ID (unchanged contract)               |
 
-**Parent recipe declaration**: All new context variables (`remote_provider`,
-`azdo_org_url`, `azdo_org`, `azdo_project`, `work_item_type`) must be
-declared with empty-string defaults in `default-workflow.yaml`'s `context:`
-block for propagation to work across sub-recipe boundaries.
+**Parent recipe declaration**: The `remote_host_type` context variable must
+be declared with an empty-string default in `default-workflow.yaml`'s
+`context:` block. This is required for propagation to work across sub-recipe
+boundaries — without this declaration, the recipe-runner's
+`_execute_sub_recipe()` context-merging will not thread the value through to
+phases like `workflow-publish` or `workflow-finalize`. The AzDO-specific
+variables (`azdo_org`, `azdo_project`, `azdo_org_url`) do NOT require parent
+declaration because they are local to step-03 within `workflow-prep`.
 
 ---
 
@@ -250,14 +311,17 @@ block for propagation to work across sub-recipe boundaries.
 
 All diagnostic output goes to **stderr**.
 
-| Message                                                    | When                                   |
-| ---------------------------------------------------------- | -------------------------------------- |
-| `INFO: Detected provider: github`                          | step-01b completed detection            |
-| `INFO: Detected provider: azdo (org=X, project=Y)`        | step-01b detected AzDO remote           |
-| `INFO: Detected provider: local (no remote or unknown)`    | step-01b fallback to local              |
-| `INFO: Creating AzDO work item (type=Task)`                | step-03 AzDO path                       |
-| `INFO: Skipping PR creation — no remote provider`          | step-16 local path                      |
-| `WARN: AzDO work item creation failed — falling back`      | step-03 AzDO error fallback             |
+| Message                                                          | When                                     |
+| ---------------------------------------------------------------- | ---------------------------------------- |
+| `INFO: Remote host type: github`                                  | step-02d completed detection              |
+| `INFO: Remote host type: azdo`                                    | step-02d detected AzDO remote             |
+| `INFO: Remote host type: other`                                   | step-02d fallback (no remote/unknown)     |
+| `INFO: Creating AzDO work item (org=X, project=Y, type=Task)`    | step-03 AzDO path                         |
+| `INFO: Non-GitHub remote (azdo) — skipping draft PR creation`     | step-16 non-GitHub path                   |
+| `INFO: PR_URL is empty ... — skipping gh pr ready`                | step-21 non-GitHub path                   |
+| `WARN: AZDO_PROJECT contains unexpected characters — falling back to local tracking` | step-03 validation failed  |
+| `WARN: az boards work-item create failed — falling back to local tracking`           | step-03 AzDO error fallback |
+| `WARN: Percent-decode failed for project name — falling back to local tracking`      | step-03 invalid `%XX` sequence |
 
 ---
 
@@ -265,15 +329,19 @@ All diagnostic output goes to **stderr**.
 
 | Failure mode                          | Behavior                                          |
 | ------------------------------------- | ------------------------------------------------- |
-| `git remote get-url origin` fails     | `remote_provider` = `"local"` (safe fallback)      |
+| `git remote get-url origin` fails     | `remote_host_type` = `"other"` (safe fallback)     |
 | `az boards` not installed             | Step-03 falls back to local synthetic ID           |
 | `az boards` auth expired              | Warning logged; falls back to local synthetic ID   |
 | AzDO work item creation fails         | Warning logged; synthetic ID used for branch naming |
+| Percent-decode invalid sequence       | Warning logged; falls back to local tracking       |
+| AzDO project name validation fails    | Warning logged; falls back to local tracking       |
 | `gh` not installed (GitHub remote)    | Existing behavior: step-03 fails with clear error  |
+| `REMOTE_HOST_TYPE` unset in step 22b  | `HOST_TYPE` defaults to `"other"` via `${..:-other}` |
+| `PR_URL` empty in step 21            | Step skips `gh pr ready` with info message          |
 
 The principle is: **GitHub steps fail loudly** (because `gh` is a
-prerequisite), while **AzDO and local steps degrade gracefully** (because
-AzDO support is additive and local is the universal fallback).
+prerequisite), while **AzDO and other steps degrade gracefully** (because
+AzDO support is additive and "other" is the universal fallback).
 
 ---
 
@@ -289,13 +357,14 @@ For AzDO repositories, ensure:
 3. Authentication is current: `az login`
 4. Defaults are configured: `az devops configure --defaults organization=... project=...`
 
-For local repositories (no remote), no configuration is needed.
+For local/unknown repositories (no remote or unrecognized host), no
+configuration is needed.
 
-Override the detected provider:
+Override the detected host type:
 
 ```bash
 amplihack recipe run default-workflow \
-  -c remote_provider=local \
+  -c remote_host_type=other \
   -c task_description="Work without any remote" \
   -c repo_path=.
 ```
@@ -313,7 +382,8 @@ amplihack recipe run default-workflow \
   -c repo_path=.
 ```
 
-Step 01b detects `github`. Steps 03, 15, 16, 21 use `gh` CLI as before.
+Step 02d detects `github`. Steps 03, 15, 16, 21 use `gh` CLI as before.
+Step 15 uses `Closes #684`. Step 22b shows PR details via `gh pr view`.
 
 ### Example 2: Azure DevOps repository
 
@@ -324,10 +394,23 @@ amplihack recipe run default-workflow \
   -c repo_path=.
 ```
 
-Step 01b detects `azdo`, extracts org/project. Step 03 creates an AzDO work
-item. Step 15 uses `AB#N` format. Step 16 logs manual PR instructions.
+Step 02d detects `azdo`. Step 03 extracts org/project from the remote URL
+and creates an AzDO work item. Step 15 uses `AB#N` format. Step 16 logs
+manual PR instructions. Step 22b shows `PR: N/A (manual creation required)`.
 
-### Example 3: Local repository (no remote)
+### Example 3: AzDO with percent-encoded project name
+
+```bash
+# Remote: https://dev.azure.com/myorg/My%20Project/_git/myrepo
+amplihack recipe run default-workflow \
+  -c task_description="Add config parser" \
+  -c repo_path=.
+```
+
+Step 03 decodes `My%20Project` → `My Project` and validates successfully.
+Workflow proceeds as in Example 2.
+
+### Example 4: Local repository (no remote)
 
 ```bash
 cd ~/my-local-project && git init
@@ -336,14 +419,15 @@ amplihack recipe run default-workflow \
   -c repo_path=.
 ```
 
-Step 01b detects `local`. Step 03 generates synthetic ID. Steps 15 and 16
-use local formatting / skip PR creation.
+Step 02d detects `other`. Step 03 generates synthetic ID. Step 15 uses
+`Ref #N`. Step 16 skips PR creation. Step 22b shows
+`PR: N/A (no remote provider)`.
 
 ---
 
 ## Troubleshooting
 
-**Provider detected as `local` when a remote exists**
+**Host detected as `other` when a remote exists**
 
 Check that the remote is named `origin`: `git remote -v`. Only the `origin`
 remote is inspected. Rename if needed: `git remote rename <old> origin`.
@@ -356,6 +440,12 @@ to a synthetic ID but logs a warning with remediation steps.
 **`az boards` command not found**
 
 Install the DevOps extension: `az extension add --name azure-devops`.
+
+**AzDO project name with spaces rejected**
+
+Check that the remote URL uses standard percent-encoding for spaces (`%20`).
+Unusual encodings or non-standard characters may be rejected by the
+validation regex.
 
 ---
 
@@ -373,9 +463,9 @@ Install the DevOps extension: `az extension add --name azure-devops`.
 
 **Metadata**
 
-| Field       | Value                                                     |
-| ----------- | --------------------------------------------------------- |
-| Status      | In Progress (retcon documentation; implementation pending) |
-| Issue       | #684                                                      |
-| Recipe file | `amplifier-bundle/recipes/workflow-prep.yaml`              |
-| Parent      | `amplifier-bundle/recipes/default-workflow.yaml`           |
+| Field       | Value                                             |
+| ----------- | ------------------------------------------------- |
+| Status      | Specification (implementation pending)             |
+| Issue       | #684                                              |
+| Recipe file | `amplifier-bundle/recipes/workflow-prep.yaml`      |
+| Parent      | `amplifier-bundle/recipes/default-workflow.yaml`   |

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -214,7 +214,7 @@ neutral reference that does not trigger automation on any platform.
 | Host type | Tool                  | Behavior                                                |
 | --------- | --------------------- | ------------------------------------------------------- |
 | `github`  | `gh pr create`        | Unchanged from current behavior                          |
-| `azdo`    | (manual)              | Logs instructions; automated `az repos pr create` planned |
+| `azdo`    | (skipped)             | Exits early; user creates PR manually afterward      |
 | `other`   | (skipped)             | Logs "no remote — skipping PR creation"                  |
 
 Step 16 consumes `$REMOTE_HOST_TYPE` from the propagated context variable
@@ -224,10 +224,10 @@ the same host-aware reference format as step 15.
 
 **PR creation asymmetry**: GitHub PR creation is fully automated because `gh`
 supports draft PRs, labels, and reviewers in a single command. AzDO PR
-creation via `az repos pr create` is planned but not yet automated because
-the AzDO CLI requires additional parameters (repository ID, target branch
-resolution) that vary by project configuration. The workflow logs clear
-instructions for manual PR creation in the meantime.
+creation is skipped — the workflow exits step 16 early with an informational
+message on stderr. After the workflow completes, create a PR manually using
+`az repos pr create` or the Azure DevOps web UI (see the
+[How-To guide](../howto/use-workflow-with-azure-devops.md#create-a-pr-manually)).
 
 ---
 

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -1,0 +1,381 @@
+# Multi-Provider Workflow Reference
+
+> [Home](../index.md) > Reference > Multi-Provider Workflow
+
+Reference for the multi-provider detection and routing logic in
+`default-workflow`. This feature enables the same 23-step workflow to operate
+against GitHub, Azure DevOps (AzDO), or a local-only repository without
+requiring the user to select a provider manually.
+
+> **Note**: This documentation is written retcon-style ahead of full
+> implementation. The design is finalized; code changes are in progress.
+> See [Issue #684](https://github.com/rysweet/amplihack-rs/issues/684).
+
+## Contents
+
+- [Overview](#overview)
+- [Provider Detection (Step 01b)](#provider-detection-step-01b)
+- [Issue Tracking by Provider](#issue-tracking-by-provider)
+- [Issue Extraction (Step 03b)](#issue-extraction-step-03b)
+- [PR Creation Routing (Step 16)](#pr-creation-routing-step-16)
+- [Commit Message Formatting (Step 15)](#commit-message-formatting-step-15)
+- [Worktree Resume Fix (Step 04)](#worktree-resume-fix-step-04)
+- [Context Variables](#context-variables)
+- [Diagnostics](#diagnostics)
+- [Error Handling](#error-handling)
+- [Configuration](#configuration)
+- [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
+- [Related](#related)
+
+---
+
+## Overview
+
+Prior to this change, `default-workflow` assumed GitHub as the sole hosting
+provider. Steps 03, 03b, 15, 16, and 21 called `gh` CLI commands
+unconditionally, causing failures when the remote pointed to Azure DevOps or
+when no remote existed at all.
+
+The multi-provider workflow introduces a **detect-once, branch-everywhere**
+pattern: step `01b` runs early in `workflow-prep` to detect the remote
+provider, and all downstream steps consult the resulting `remote_provider`
+context variable to choose the correct code path.
+
+```
+git remote get-url origin
+        │
+        ▼
+┌─────────────────────────────────┐
+│  Step 01b: Provider Detection    │
+│  *.github.com*  → "github"       │
+│  *dev.azure.com*│*vscom* → "azdo"│
+│  everything else → "local"       │
+└─────────────────────────────────┘
+        │
+        ▼
+  remote_provider = "github" | "azdo" | "local"
+        │
+        ├─► Step 03:  issue creation (routed)
+        ├─► Step 03b: issue extraction (routed)
+        ├─► Step 15:  commit format (routed)
+        ├─► Step 16:  PR creation (routed)
+        └─► Step 21:  PR readiness (routed)
+```
+
+---
+
+## Provider Detection (Step 01b)
+
+**Location**: `workflow-prep.yaml`, after step `01` (prepare workspace).
+
+**Logic**:
+
+```bash
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+case "$REMOTE_URL" in
+  *github.com*)         PROVIDER="github" ;;
+  *dev.azure.com*|*visualstudio.com*) PROVIDER="azdo" ;;
+  *)                    PROVIDER="local"  ;;
+esac
+```
+
+**Outputs**:
+
+| Variable         | Type   | Description                                    |
+| ---------------- | ------ | ---------------------------------------------- |
+| `remote_provider` | string | `"github"`, `"azdo"`, or `"local"`             |
+| `azdo_org_url`   | string | Full AzDO org URL (empty if not AzDO)           |
+| `azdo_org`       | string | AzDO organization name (empty if not AzDO)      |
+| `azdo_project`   | string | AzDO project name (empty if not AzDO)            |
+
+**Context propagation**: These variables are outputs of step `01b` in
+`workflow-prep.yaml`. For them to propagate to downstream sub-recipes, they
+must be declared in the parent `default-workflow.yaml` context block with
+empty-string defaults. Without this declaration, the recipe-runner's
+`_execute_sub_recipe()` context-merging will not thread them through to
+phases like `workflow-publish` or `workflow-finalize`.
+
+Step `01b` must be placed in `workflow-prep.yaml` (steps 00–03b phase) since
+that is where provider detection logically belongs — before any step that
+needs to know the provider.
+
+**Edge cases**:
+
+- No remote configured → `REMOTE_URL` is empty → `PROVIDER="local"`
+- Multiple remotes → only `origin` is checked (convention)
+- SSH URLs → pattern matching works on both `git@github.com:` and
+  `https://github.com/` forms
+
+---
+
+## Issue Tracking by Provider
+
+### GitHub (`remote_provider = "github"`)
+
+Step 03 uses `gh issue create` and `gh issue view` as before. No change
+from the existing behavior documented in
+[recipe-step-03-idempotency.md](recipe-step-03-idempotency.md).
+
+### Azure DevOps (`remote_provider = "azdo"`)
+
+Step 03 creates an AzDO work item using the `az boards work-item create`
+CLI command:
+
+```bash
+az boards work-item create \
+  --org "$AZDO_ORG_URL" \
+  --project "$AZDO_PROJECT" \
+  --type "$WORK_ITEM_TYPE" \
+  --title "$ISSUE_TITLE" \
+  --description "$ISSUE_BODY"
+```
+
+**Work item type**: Defaults to `Task` when no type is specified. The agent
+may choose a different type (`Bug`, `User Story`, `Feature`, `Epic`) based
+on the `classification` field from step 02's clarified requirements. Users
+can also override the type by passing `-c work_item_type=Bug` to the recipe.
+
+The output is an AzDO work item URL:
+
+```
+https://dev.azure.com/myorg/myproject/_workitems/edit/12345
+```
+
+The idempotency guards (Guard 1 and Guard 2 from
+[recipe-step-03-idempotency.md](recipe-step-03-idempotency.md)) are adapted:
+
+- **Guard 1**: Extracts `AB#NNNN` or `#NNNN` references; verifies via
+  `az boards work-item show --id <N>`
+- **Guard 2**: Searches via `az boards query` using WIQL title match
+
+### Local (`remote_provider = "local"`)
+
+Step 03 generates a synthetic issue number for branch naming and commit
+messages, without making any network calls:
+
+```bash
+# Combine PID and epoch seconds for collision resistance
+SYNTHETIC_ID=$(( ($$ * 100000 + $(date +%s)) % 10000000 ))
+```
+
+This scheme avoids same-second collisions by mixing the process PID with
+the epoch timestamp. The local ID is used only for branch naming
+(`feat/issue-<N>-slug`) and commit message references. No tracking system
+is updated.
+
+---
+
+## Issue Extraction (Step 03b)
+
+Step 03b's three-tier extraction logic (documented in
+[workflow-issue-extraction.md](workflow-issue-extraction.md)) is extended to
+handle all three provider URL formats:
+
+| Provider | URL pattern                                               | Extraction regex                    |
+| -------- | --------------------------------------------------------- | ----------------------------------- |
+| GitHub   | `https://github.com/owner/repo/issues/N`                  | `issues/[0-9]+`                     |
+| AzDO     | `https://dev.azure.com/org/project/_workitems/edit/N`      | `_workitems/edit/[0-9]+`            |
+| Local    | Bare numeric string from synthetic ID                       | `^[0-9]+$`                          |
+
+The `issue_number` output contract remains unchanged: a plain integer (or
+null). Downstream steps never see the provider URL format — they only
+consume the numeric ID.
+
+---
+
+## PR Creation Routing (Step 16)
+
+| Provider | Tool                  | Behavior                                                |
+| -------- | --------------------- | ------------------------------------------------------- |
+| GitHub   | `gh pr create`        | Unchanged from current behavior                          |
+| AzDO     | (manual)              | Logs instructions; automated `az repos pr create` planned |
+| Local    | (skipped)             | Logs "no remote — skipping PR creation"                  |
+
+**PR creation asymmetry**: GitHub PR creation is fully automated because `gh`
+supports draft PRs, labels, and reviewers in a single command. AzDO PR
+creation via `az repos pr create` is planned but not yet automated because
+the AzDO CLI requires additional parameters (repository ID, target branch
+resolution) that vary by project configuration. The workflow logs clear
+instructions for manual PR creation in the meantime.
+
+---
+
+## Commit Message Formatting (Step 15)
+
+Commit messages adapt their issue reference syntax per provider:
+
+| Provider | Format                      | Example                           |
+| -------- | --------------------------- | --------------------------------- |
+| GitHub   | `Fixes #N` / `Closes #N`    | `feat: add auth (Fixes #684)`     |
+| AzDO     | `AB#N`                       | `feat: add auth (AB#12345)`        |
+| Local    | `[local-N]`                  | `feat: add auth [local-4821937]`   |
+
+---
+
+## Worktree Resume Fix (Step 04)
+
+The worktree setup step (`step-04-setup-worktree`) previously derived the
+working directory from the issue URL, which was always a GitHub URL. With
+multi-provider support, the worktree path derivation uses only the
+`issue_number` integer (provider-agnostic) and the slugified task
+description.
+
+See [recipe-step-04-worktree-reattach-prune.md](recipe-step-04-worktree-reattach-prune.md)
+for the full worktree lifecycle documentation.
+
+---
+
+## Context Variables
+
+Variables added or modified by the multi-provider feature:
+
+| Variable           | Set by    | Type   | Description                                  |
+| ------------------ | --------- | ------ | -------------------------------------------- |
+| `remote_provider`  | step-01b  | string | `"github"`, `"azdo"`, or `"local"`            |
+| `azdo_org_url`     | step-01b  | string | Full AzDO org URL (empty if not AzDO)         |
+| `azdo_org`         | step-01b  | string | AzDO organization name (empty if not AzDO)    |
+| `azdo_project`     | step-01b  | string | AzDO project name (empty if not AzDO)          |
+| `work_item_type`   | user/step-02 | string | AzDO work item type; default `"Task"`       |
+| `issue_number`     | step-03b  | int    | Numeric ID (unchanged contract)               |
+
+**Parent recipe declaration**: All new context variables (`remote_provider`,
+`azdo_org_url`, `azdo_org`, `azdo_project`, `work_item_type`) must be
+declared with empty-string defaults in `default-workflow.yaml`'s `context:`
+block for propagation to work across sub-recipe boundaries.
+
+---
+
+## Diagnostics
+
+All diagnostic output goes to **stderr**.
+
+| Message                                                    | When                                   |
+| ---------------------------------------------------------- | -------------------------------------- |
+| `INFO: Detected provider: github`                          | step-01b completed detection            |
+| `INFO: Detected provider: azdo (org=X, project=Y)`        | step-01b detected AzDO remote           |
+| `INFO: Detected provider: local (no remote or unknown)`    | step-01b fallback to local              |
+| `INFO: Creating AzDO work item (type=Task)`                | step-03 AzDO path                       |
+| `INFO: Skipping PR creation — no remote provider`          | step-16 local path                      |
+| `WARN: AzDO work item creation failed — falling back`      | step-03 AzDO error fallback             |
+
+---
+
+## Error Handling
+
+| Failure mode                          | Behavior                                          |
+| ------------------------------------- | ------------------------------------------------- |
+| `git remote get-url origin` fails     | `remote_provider` = `"local"` (safe fallback)      |
+| `az boards` not installed             | Step-03 falls back to local synthetic ID           |
+| `az boards` auth expired              | Warning logged; falls back to local synthetic ID   |
+| AzDO work item creation fails         | Warning logged; synthetic ID used for branch naming |
+| `gh` not installed (GitHub remote)    | Existing behavior: step-03 fails with clear error  |
+
+The principle is: **GitHub steps fail loudly** (because `gh` is a
+prerequisite), while **AzDO and local steps degrade gracefully** (because
+AzDO support is additive and local is the universal fallback).
+
+---
+
+## Configuration
+
+No new configuration is required for GitHub repositories. The feature
+activates automatically based on the remote URL.
+
+For AzDO repositories, ensure:
+
+1. Azure CLI is installed: `az --version`
+2. DevOps extension is present: `az extension list | grep devops`
+3. Authentication is current: `az login`
+4. Defaults are configured: `az devops configure --defaults organization=... project=...`
+
+For local repositories (no remote), no configuration is needed.
+
+Override the detected provider:
+
+```bash
+amplihack recipe run default-workflow \
+  -c remote_provider=local \
+  -c task_description="Work without any remote" \
+  -c repo_path=.
+```
+
+---
+
+## Examples
+
+### Example 1: GitHub repository (unchanged behavior)
+
+```bash
+# Remote: https://github.com/myorg/myrepo.git
+amplihack recipe run default-workflow \
+  -c task_description="Fix login timeout #684" \
+  -c repo_path=.
+```
+
+Step 01b detects `github`. Steps 03, 15, 16, 21 use `gh` CLI as before.
+
+### Example 2: Azure DevOps repository
+
+```bash
+# Remote: https://dev.azure.com/myorg/myproject/_git/myrepo
+amplihack recipe run default-workflow \
+  -c task_description="Fix login timeout" \
+  -c repo_path=.
+```
+
+Step 01b detects `azdo`, extracts org/project. Step 03 creates an AzDO work
+item. Step 15 uses `AB#N` format. Step 16 logs manual PR instructions.
+
+### Example 3: Local repository (no remote)
+
+```bash
+cd ~/my-local-project && git init
+amplihack recipe run default-workflow \
+  -c task_description="Add config parser" \
+  -c repo_path=.
+```
+
+Step 01b detects `local`. Step 03 generates synthetic ID. Steps 15 and 16
+use local formatting / skip PR creation.
+
+---
+
+## Troubleshooting
+
+**Provider detected as `local` when a remote exists**
+
+Check that the remote is named `origin`: `git remote -v`. Only the `origin`
+remote is inspected. Rename if needed: `git remote rename <old> origin`.
+
+**AzDO work item creation fails with auth error**
+
+Run `az login` and `az devops configure --defaults`. The workflow falls back
+to a synthetic ID but logs a warning with remediation steps.
+
+**`az boards` command not found**
+
+Install the DevOps extension: `az extension add --name azure-devops`.
+
+---
+
+## Related
+
+- [Step 03 Idempotency Guards](recipe-step-03-idempotency.md) — GitHub-specific issue creation guards
+- [Workflow Issue Extraction (Step 03b)](workflow-issue-extraction.md) — three-tier extraction logic
+- [Worktree Reattach and Prune (Step 04)](recipe-step-04-worktree-reattach-prune.md) — worktree lifecycle
+- [Azure DevOps Integration](../azure-devops/README.md) — AzDO CLI tools and setup
+- [Azure OpenAI Integration](../AZURE_INTEGRATION.md) — Azure model configuration
+- [How to Use the Workflow with Azure DevOps](../howto/use-workflow-with-azure-devops.md) — task-oriented AzDO guide
+- [Multi-Provider Workflow Architecture](../concepts/multi-provider-workflow-architecture.md) — design decisions
+
+---
+
+**Metadata**
+
+| Field       | Value                                                     |
+| ----------- | --------------------------------------------------------- |
+| Status      | In Progress (retcon documentation; implementation pending) |
+| Issue       | #684                                                      |
+| Recipe file | `amplifier-bundle/recipes/workflow-prep.yaml`              |
+| Parent      | `amplifier-bundle/recipes/default-workflow.yaml`           |

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -7,11 +7,6 @@ Reference for the multi-provider detection and routing logic in
 against GitHub, Azure DevOps (AzDO), or a local/unknown repository without
 requiring the user to select a provider manually.
 
-> **Note**: This document describes the target design for issue #684. Recipe
-> YAML changes to match this specification are implementation-pending. The
-> current code has host detection inline in step-03 and does not yet propagate
-> `remote_host_type` via the context block.
-
 ## Contents
 
 - [Overview](#overview)
@@ -141,10 +136,9 @@ az boards work-item create \
   --description "$ISSUE_BODY"
 ```
 
-**Work item type**: Defaults to `Task` when no type is specified. The agent
-may choose a different type (`Bug`, `User Story`, `Feature`, `Epic`) based
-on the `classification` field from step 02's clarified requirements. Users
-can also override the type by passing `-c work_item_type=Bug` to the recipe.
+**Work item type**: Defaults to `Task`. The `work_item_type` context variable
+override is planned but not yet implemented. Users can create work items
+manually and reference them via `AB#N` in the task description.
 
 The output is an AzDO work item URL:
 
@@ -157,7 +151,8 @@ The idempotency guards (Guard 1 and Guard 2 from
 
 - **Guard 1**: Extracts `AB#NNNN` or `#NNNN` references; verifies via
   `az boards work-item show --id <N>`
-- **Guard 2**: Searches via `az boards query` using WIQL title match
+- **Guard 2**: Not yet implemented. Planned: search via `az boards query`
+  using WIQL title match (similar to `gh issue list --search`)
 
 ### Other/Local (`remote_host_type = "other"`)
 
@@ -465,7 +460,7 @@ validation regex.
 
 | Field       | Value                                             |
 | ----------- | ------------------------------------------------- |
-| Status      | Specification (implementation pending)             |
+| Status      | Implemented                                        |
 | Issue       | #684                                              |
 | Recipe file | `amplifier-bundle/recipes/workflow-prep.yaml`      |
 | Parent      | `amplifier-bundle/recipes/default-workflow.yaml`   |

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -73,7 +73,8 @@ step `02c` (requirements clarification) and before step `03` (issue creation).
 ```bash
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
 case "$REMOTE_URL" in
-  *github.com*)         REMOTE_HOST_TYPE="github" ;;
+  https://github.com/*|git@github.com:*|ssh://git@github.com/*|https://*@github.com/*)
+                        REMOTE_HOST_TYPE="github" ;;
   *dev.azure.com*|*visualstudio.com*|*ssh.dev.azure.com*)
                         REMOTE_HOST_TYPE="azdo" ;;
   *)                    REMOTE_HOST_TYPE="other" ;;
@@ -90,8 +91,9 @@ step 03 where the values are consumed.
 
 - No remote configured → `REMOTE_URL` is empty → `REMOTE_HOST_TYPE="other"`
 - Multiple remotes → only `origin` is checked (convention)
-- SSH URLs → pattern matching works on both `git@github.com:` and
-  `https://github.com/` forms
+- SSH URLs → explicit patterns match `git@github.com:`, `ssh://git@github.com/`,
+  and `https://github.com/` forms; AzDO uses substring matching for
+  `dev.azure.com`, `visualstudio.com`, and `ssh.dev.azure.com`
 - Not a git repo → step falls back to `"other"` before step 03 runs
 
 ---

--- a/docs/reference/recipe-step-03-idempotency.md
+++ b/docs/reference/recipe-step-03-idempotency.md
@@ -333,9 +333,20 @@ reference would have matched.
 
 ---
 
+## Multi-Provider Note
+
+The idempotency guards documented above are **GitHub-specific** — they use
+`gh issue view` and `gh issue list`. When `remote_provider` is `"azdo"` or
+`"local"`, step-03 takes a different code path that does not execute these
+guards. See [Multi-Provider Workflow Reference](multi-provider-workflow.md)
+for the provider-specific issue creation logic.
+
+---
+
 ## Related
 
 - `step-16-create-draft-pr` idempotency guards — pattern source (#3324)
 - `step-03b-extract-issue-number` — downstream step that parses step-03 output
 - `tests/gadugi/step-03-issue-creation-idempotency.yaml` — test suite
 - `docs/investigations/step-03-idempotency-guards-analysis.md` — security analysis and implementation notes
+- [Multi-Provider Workflow Reference](multi-provider-workflow.md) — provider detection and routing

--- a/docs/reference/workflow-issue-extraction.md
+++ b/docs/reference/workflow-issue-extraction.md
@@ -265,6 +265,23 @@ and that `gh issue view <N>` returns a URL containing `/issues/`.
 
 ---
 
+## Multi-Provider Extraction
+
+When `remote_provider` is not `"github"`, step 03b extracts issue numbers
+from provider-specific URL formats in addition to the GitHub patterns above:
+
+| Provider | URL pattern                                           | Extraction regex             |
+| -------- | ----------------------------------------------------- | ---------------------------- |
+| GitHub   | `https://github.com/owner/repo/issues/N`               | `issues/[0-9]+`              |
+| AzDO     | `https://dev.azure.com/org/project/_workitems/edit/N`   | `_workitems/edit/[0-9]+`     |
+| Local    | Bare numeric string from synthetic ID                   | `^[0-9]+$`                   |
+
+The `issue_number` output contract is unchanged: a plain integer regardless
+of provider. See [Multi-Provider Workflow Reference](multi-provider-workflow.md)
+for full details.
+
+---
+
 ## Related
 
 - [Workflow Execution Guardrails Reference](recipe-quick-reference.md)
@@ -274,6 +291,7 @@ and that `gh issue view <N>` returns a URL containing `/issues/`.
 - [Default Workflow](../concepts/default-workflow.md) — full step list
 - [Lock Session ID Sanitization](security-recommendations.md)
   — the security fix delivered alongside this extraction improvement (PR #4143)
+- [Multi-Provider Workflow Reference](multi-provider-workflow.md) — provider detection and routing
 - Issues [#3960](https://github.com/rysweet/amplihack-rs/issues/3960) and
   [#3983](https://github.com/rysweet/amplihack-rs/issues/3983) — originating work
 - PR [#4143](https://github.com/rysweet/amplihack-rs/pull/4143) — implementation

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -723,6 +723,52 @@ fn workflow_prep_step_03b_handles_azdo_work_item_urls() {
 }
 
 // ==========================================================================
+// Issue #684: mid-stage steps must fall back to REPO_PATH when the worktree
+// variable is not propagated from sub-recipe context (step-04).
+// ==========================================================================
+
+#[test]
+fn mid_stage_worktree_steps_fall_back_to_repo_path() {
+    // These steps are mid-pipeline — they SHOULD hard-fail when REPO_PATH is
+    // also empty (via :?), but MUST accept REPO_PATH as a defensive fallback
+    // so that context propagation failures between sub-recipes don't crash
+    // the entire workflow when a valid repo directory is available.
+    let cases = [
+        ("workflow-publish", "step-15-commit-push"),
+        ("workflow-publish", "step-16-create-draft-pr"),
+        ("workflow-tdd", "checkpoint-after-implementation"),
+        (
+            "workflow-refactor-review",
+            "checkpoint-after-review-feedback",
+        ),
+    ];
+    for (recipe, step_id) in cases {
+        let command = step_command(recipe, step_id);
+        assert!(
+            command.contains(":-$REPO_PATH"),
+            "{recipe}/{step_id} must fall back to $REPO_PATH when worktree var is empty"
+        );
+        // Must still hard-fail if BOTH worktree and REPO_PATH are empty
+        assert!(
+            command.contains("WORKTREE_SETUP_WORKTREE_PATH:?"),
+            "{recipe}/{step_id} must hard-fail when worktree AND REPO_PATH are both empty"
+        );
+    }
+}
+
+#[test]
+fn step_18c_does_not_fall_back_to_repo_path() {
+    // step-18c is early-stage and must keep hard-fail (per test
+    // workflow_pr_review_fails_loud_for_required_worktree_context).
+    // It must NOT have a REPO_PATH fallback in the default chain.
+    let command = step_command("workflow-pr-review", "step-18c-push-feedback-changes");
+    assert!(
+        !command.contains(":-$REPO_PATH"),
+        "step-18c must NOT fall back to REPO_PATH — it requires the worktree"
+    );
+}
+
+// ==========================================================================
 // Issue #684: step-16 must handle non-GitHub remotes gracefully.
 // ==========================================================================
 

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -720,6 +720,19 @@ fn workflow_prep_step_03b_handles_azdo_work_item_urls() {
         command.contains("pull/"),
         "step-03b must still handle GitHub PR URLs (pull/NNN)"
     );
+
+    // local-tracking extraction must come before task-desc AB# fallback
+    let local_pos = command
+        .find("local-tracking:")
+        .expect("step-03b must handle local-tracking:NNN");
+    let task_ab_pos = command
+        .find("$TASK_DESC_RAW\" =~ AB#")
+        .or_else(|| command.find("TASK_DESC_RAW =~ AB#"))
+        .expect("step-03b must fall back to task_description AB#");
+    assert!(
+        local_pos < task_ab_pos,
+        "step-03b must check ISSUE_CREATION local-tracking before falling back to TASK_DESC_RAW"
+    );
 }
 
 // ==========================================================================
@@ -745,7 +758,7 @@ fn mid_stage_worktree_steps_fall_back_to_repo_path() {
     for (recipe, step_id) in cases {
         let command = step_command(recipe, step_id);
         assert!(
-            command.contains(":-$REPO_PATH"),
+            command.contains(":-${REPO_PATH:-}"),
             "{recipe}/{step_id} must fall back to $REPO_PATH when worktree var is empty"
         );
         // Must still hard-fail if BOTH worktree and REPO_PATH are empty
@@ -763,7 +776,7 @@ fn step_18c_does_not_fall_back_to_repo_path() {
     // It must NOT have a REPO_PATH fallback in the default chain.
     let command = step_command("workflow-pr-review", "step-18c-push-feedback-changes");
     assert!(
-        !command.contains(":-$REPO_PATH"),
+        !command.contains(":-${REPO_PATH"),
         "step-18c must NOT fall back to REPO_PATH — it requires the worktree"
     );
 }
@@ -783,6 +796,12 @@ fn workflow_publish_step_16_guards_non_github_remotes() {
             || command.contains("github.com"),
         "step-16 must detect the remote host type before attempting PR creation"
     );
+
+    // step-16 must skip PR creation for ALL non-GitHub remotes (not just AzDO)
+    assert!(
+        command.contains("!= \"github\""),
+        "step-16 must skip PR creation for all non-GitHub remotes, not just AzDO"
+    );
 }
 
 // ==========================================================================
@@ -799,12 +818,13 @@ fn workflow_finalize_step_21_guards_pr_url_before_gh_commands() {
         "step-21 must reference PR_URL to guard against empty values"
     );
 
-    // Must check PR_URL is non-empty before calling gh pr ready
+    // Must check PR_URL is non-empty (whitespace-tolerant) before calling gh pr ready
     assert!(
         command.contains("-z \"$PR_URL\"")
             || command.contains("-n \"$PR_URL\"")
             || command.contains("[ -z \"${PR_URL")
-            || command.contains("[ -n \"${PR_URL"),
+            || command.contains("[ -n \"${PR_URL")
+            || command.contains("[^[:space:]]"),
         "step-21 must check PR_URL is non-empty before invoking gh commands"
     );
 

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -587,3 +587,191 @@ fn mandatory_steps_still_present() {
         );
     }
 }
+
+// ==========================================================================
+// Issue #684: step-03 must detect remote host type and branch accordingly.
+// TDD — these tests define the required contract BEFORE implementation.
+// ==========================================================================
+
+#[test]
+fn workflow_prep_step_03_detects_remote_host_type() {
+    let command = step_command("workflow-prep", "step-03-create-issue");
+
+    // Must classify the remote into a REMOTE_HOST_TYPE variable
+    assert!(
+        command.contains("REMOTE_HOST_TYPE"),
+        "step-03 must classify the git remote into a REMOTE_HOST_TYPE variable"
+    );
+
+    // Must check for GitHub
+    assert!(
+        command.contains("github.com"),
+        "step-03 must detect github.com in the remote URL"
+    );
+
+    // Must check for Azure DevOps (both modern and legacy domains)
+    assert!(
+        command.contains("dev.azure.com"),
+        "step-03 must detect dev.azure.com in the remote URL"
+    );
+    assert!(
+        command.contains("visualstudio.com"),
+        "step-03 must detect visualstudio.com in the remote URL"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03_has_github_path_inside_host_conditional() {
+    let command = step_command("workflow-prep", "step-03-create-issue");
+
+    // gh issue commands must still exist (for GitHub remotes)
+    assert!(
+        command.contains("gh issue"),
+        "step-03 must retain 'gh issue' commands for GitHub remotes"
+    );
+
+    // gh issue must NOT appear before REMOTE_HOST_TYPE is set
+    let host_type_pos = command
+        .find("REMOTE_HOST_TYPE")
+        .expect("REMOTE_HOST_TYPE must exist in step-03");
+    let first_gh_issue_pos = command
+        .find("gh issue")
+        .expect("'gh issue' must exist in step-03");
+    assert!(
+        first_gh_issue_pos > host_type_pos,
+        "step-03 must not invoke 'gh issue' before classifying the remote host type"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03_has_azdo_work_item_path() {
+    let command = step_command("workflow-prep", "step-03-create-issue");
+
+    // Must have Azure DevOps work item creation path
+    assert!(
+        command.contains("az boards"),
+        "step-03 must use 'az boards' for Azure DevOps work item creation"
+    );
+
+    // Must support explicit work item ID (AB#NNN pattern)
+    assert!(
+        command.contains("AB#"),
+        "step-03 must support explicit Azure Boards work item references (AB#NNN)"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03_has_local_tracking_fallback() {
+    let command = step_command("workflow-prep", "step-03-create-issue");
+
+    // Must have a fallback for unknown remote types (not GitHub, not AzDO)
+    assert!(
+        command.contains("local-tracking")
+            || command.contains("LOCAL_ISSUE")
+            || command.contains("local_issue")
+            || command.contains("local tracking"),
+        "step-03 must have a local tracking fallback for unknown remote types"
+    );
+
+    // Must NOT hard-fail for unknown remotes
+    assert!(
+        !command.contains("gh auth login"),
+        "step-03 must not suggest 'gh auth login' for non-GitHub remotes"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03_no_host_specific_error_messages_for_wrong_host() {
+    let command = step_command("workflow-prep", "step-03-create-issue");
+
+    // The old error "none of the git remotes configured for this repository
+    // point to a known GitHub host" must not appear as a possible output
+    // for non-GitHub remotes.
+    assert!(
+        !command.contains("none of the git remotes"),
+        "step-03 must not contain GitHub-specific error messages that leak to non-GitHub remotes"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03b_handles_azdo_work_item_urls() {
+    let command = step_command("workflow-prep", "step-03b-extract-issue-number");
+
+    // Must handle Azure DevOps work item URLs (_workitems/edit/NNN)
+    assert!(
+        command.contains("_workitems/edit/"),
+        "step-03b must extract issue numbers from AzDO work item URLs (_workitems/edit/NNN)"
+    );
+
+    // Must handle AB#NNN references
+    assert!(
+        command.contains("AB#"),
+        "step-03b must extract issue numbers from Azure Boards references (AB#NNN)"
+    );
+
+    // Must still handle GitHub issue URLs (regression check)
+    assert!(
+        command.contains("issues/"),
+        "step-03b must still handle GitHub issue URLs (issues/NNN)"
+    );
+
+    // Must still handle GitHub PR URLs (regression check)
+    assert!(
+        command.contains("pull/"),
+        "step-03b must still handle GitHub PR URLs (pull/NNN)"
+    );
+}
+
+// ==========================================================================
+// Issue #684: step-16 must handle non-GitHub remotes gracefully.
+// ==========================================================================
+
+#[test]
+fn workflow_publish_step_16_guards_non_github_remotes() {
+    let command = step_command("workflow-publish", "step-16-create-draft-pr");
+
+    // step-16 must detect remote host type before creating a PR
+    assert!(
+        command.contains("REMOTE_HOST_TYPE")
+            || command.contains("remote_host_type")
+            || command.contains("github.com"),
+        "step-16 must detect the remote host type before attempting PR creation"
+    );
+}
+
+// ==========================================================================
+// Issue #684 + #682: step-21 must guard PR_URL before gh commands.
+// ==========================================================================
+
+#[test]
+fn workflow_finalize_step_21_guards_pr_url_before_gh_commands() {
+    let command = step_command("workflow-finalize", "step-21-pr-ready");
+
+    // Must reference PR_URL variable
+    assert!(
+        command.contains("PR_URL"),
+        "step-21 must reference PR_URL to guard against empty values"
+    );
+
+    // Must check PR_URL is non-empty before calling gh pr ready
+    assert!(
+        command.contains("-z \"$PR_URL\"")
+            || command.contains("-n \"$PR_URL\"")
+            || command.contains("[ -z \"${PR_URL")
+            || command.contains("[ -n \"${PR_URL"),
+        "step-21 must check PR_URL is non-empty before invoking gh commands"
+    );
+
+    // gh pr ready must NOT be invoked unconditionally at the top level
+    // It should be inside a conditional that checks PR_URL
+    let pr_url_check_pos = command
+        .find("PR_URL")
+        .expect("PR_URL must appear in step-21");
+    let gh_pr_ready_pos = command
+        .find("gh pr ready")
+        .expect("'gh pr ready' must still exist for GitHub PRs");
+    assert!(
+        gh_pr_ready_pos > pr_url_check_pos,
+        "step-21 must check PR_URL before invoking 'gh pr ready'"
+    );
+}

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -95,6 +95,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "step-02-clarify-requirements",
     "step-02b-analyze-codebase",
     "step-02c-resolve-ambiguity",
+    "step-02d-detect-host-type",
     "step-03-create-issue",
     "step-03b-extract-issue-number",
     // Phase 1b: workflow-worktree (step 04)
@@ -594,29 +595,34 @@ fn mandatory_steps_still_present() {
 // ==========================================================================
 
 #[test]
-fn workflow_prep_step_03_detects_remote_host_type() {
-    let command = step_command("workflow-prep", "step-03-create-issue");
-
-    // Must classify the remote into a REMOTE_HOST_TYPE variable
-    assert!(
-        command.contains("REMOTE_HOST_TYPE"),
-        "step-03 must classify the git remote into a REMOTE_HOST_TYPE variable"
-    );
+fn workflow_prep_step_02d_detects_remote_host_type() {
+    let command = step_command("workflow-prep", "step-02d-detect-host-type");
 
     // Must check for GitHub
     assert!(
         command.contains("github.com"),
-        "step-03 must detect github.com in the remote URL"
+        "step-02d must detect github.com in the remote URL"
     );
 
     // Must check for Azure DevOps (both modern and legacy domains)
     assert!(
         command.contains("dev.azure.com"),
-        "step-03 must detect dev.azure.com in the remote URL"
+        "step-02d must detect dev.azure.com in the remote URL"
     );
     assert!(
         command.contains("visualstudio.com"),
-        "step-03 must detect visualstudio.com in the remote URL"
+        "step-02d must detect visualstudio.com in the remote URL"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03_consumes_remote_host_type() {
+    let command = step_command("workflow-prep", "step-03-create-issue");
+
+    // Step-03 must consume REMOTE_HOST_TYPE from step-02d (not re-detect)
+    assert!(
+        command.contains("REMOTE_HOST_TYPE"),
+        "step-03 must consume REMOTE_HOST_TYPE from step-02d"
     );
 }
 
@@ -630,16 +636,16 @@ fn workflow_prep_step_03_has_github_path_inside_host_conditional() {
         "step-03 must retain 'gh issue' commands for GitHub remotes"
     );
 
-    // gh issue must NOT appear before REMOTE_HOST_TYPE is set
+    // gh issue must NOT appear before HOST_TYPE is set from REMOTE_HOST_TYPE
     let host_type_pos = command
-        .find("REMOTE_HOST_TYPE")
-        .expect("REMOTE_HOST_TYPE must exist in step-03");
+        .find("HOST_TYPE")
+        .expect("HOST_TYPE must exist in step-03");
     let first_gh_issue_pos = command
         .find("gh issue")
         .expect("'gh issue' must exist in step-03");
     assert!(
         first_gh_issue_pos > host_type_pos,
-        "step-03 must not invoke 'gh issue' before classifying the remote host type"
+        "step-03 must not invoke 'gh issue' before consuming the remote host type"
     );
 }
 

--- a/tests/integration/issue_615_work_verifier_test.rs
+++ b/tests/integration/issue_615_work_verifier_test.rs
@@ -14,12 +14,12 @@
 //!    `step-08c-enforce-verdict` against synthetic `VERDICT_JSON`,
 //!    `IMPLEMENTATION`, and `ALLOW_NO_OP` inputs and assert the exit
 //!    code mapping required by issue #615:
-//!      WORK_VERIFIED          -> 0 silent
-//!      INSUFFICIENT_EVIDENCE  -> 0 with WARN on stderr
-//!      HOLLOW_SUCCESS         -> 1 with rationale on stderr
-//!      empty / unparseable    -> 0 with WARN (fail-safe per issue #615)
-//!      ALLOW_NO_OP=true       -> 0 (issue #425 fast-path)
-//!      orchestration sentinel -> 0 (issue #425 fast-path)
+//!    - WORK_VERIFIED          -> 0 silent
+//!    - INSUFFICIENT_EVIDENCE  -> 0 with WARN on stderr
+//!    - HOLLOW_SUCCESS         -> 1 with rationale on stderr
+//!    - empty / unparseable    -> 0 with WARN (fail-safe per issue #615)
+//!    - ALLOW_NO_OP=true       -> 0 (issue #425 fast-path)
+//!    - orchestration sentinel -> 0 (issue #425 fast-path)
 //!
 //! Why both layers: prompt-content checks would silently pass even if the
 //! bash gate's case-arm logic regressed. Runtime checks would silently pass

--- a/tests/integration/issue_684_host_aware_workflow_test.rs
+++ b/tests/integration/issue_684_host_aware_workflow_test.rs
@@ -1,0 +1,701 @@
+/// Integration tests for issue #684 — Host-aware workflow steps.
+///
+/// ## Problem
+///
+/// The default-workflow assumes GitHub for commit messages (Closes #N),
+/// PR creation, and final status summaries. This breaks on Azure DevOps,
+/// other Git hosts, and repos without remotes.
+///
+/// ## Blockers addressed
+///
+/// 1. **step-15 commit message** hardcodes `Closes #N` (GitHub-only).
+///    Fix: host-aware refs — `AB#N` (AzDO), `Closes #N` (GitHub), `Ref #N` (other).
+/// 2. **step-16 PR body** hardcodes `Closes #N` and has duplicate host detection.
+///    Fix: consume `$REMOTE_HOST_TYPE` from context, not inline re-detection.
+/// 3. **step-22b summary** calls `gh pr view` without host-type guard.
+///    Fix: guard with `REMOTE_HOST_TYPE` check, host-aware issue/PR lines.
+/// 4. **step-03 AzDO parsing** rejects percent-encoded project names (`My%20Project`).
+///    Fix: decode `%XX` before validation, expand regex to allow spaces.
+/// 5. **Context propagation**: `remote_host_type` must be declared in
+///    `default-workflow.yaml` and exported by a new `step-02d-detect-host-type`
+///    in `workflow-prep.yaml`.
+///
+/// ## Test strategy
+///
+/// Mirrors `issue_655_656_skill_fetch_resilience_test.rs`:
+///   - Parse recipe YAML with `serde_yaml` to inspect step command bodies
+///   - Assert structural properties of bash scripts (keywords, patterns, absence)
+///   - No subprocess execution — all tests are structural/contract tests
+///
+/// ## Test status
+///
+/// These tests are written **TDD-RED**. They FAIL until the implementation
+/// changes land across the four recipe files.
+use std::fs;
+use std::path::PathBuf;
+
+use serde_yaml::Value;
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // bins/amplihack -> bins
+    p.pop(); // bins -> workspace root
+    p
+}
+
+fn recipe_path(name: &str) -> PathBuf {
+    workspace_root()
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join(format!("{name}.yaml"))
+}
+
+fn recipe_text(name: &str) -> String {
+    let path = recipe_path(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Recipe parsing helpers (same pattern as issue_655_656 tests)
+// ---------------------------------------------------------------------------
+
+fn load_recipe(name: &str) -> Value {
+    let path = recipe_path(name);
+    let text = recipe_text(name);
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {} as YAML: {e}", path.display()))
+}
+
+/// Extract the `command:` body of a bash step by its `id:` field.
+fn extract_step_body(recipe: &Value, step_id: &str) -> String {
+    let steps = recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("recipe must have a top-level 'steps' sequence");
+
+    for step in steps {
+        let id = step.get("id").and_then(Value::as_str).unwrap_or("");
+        if id == step_id {
+            if let Some(cmd) = step.get("command").and_then(Value::as_str) {
+                return cmd.to_owned();
+            }
+            if let Some(prompt) = step.get("prompt").and_then(Value::as_str) {
+                return prompt.to_owned();
+            }
+            panic!("step '{step_id}' has neither 'command:' nor 'prompt:' body");
+        }
+    }
+    panic!("step '{step_id}' not found in recipe");
+}
+
+/// Check if a step exists in the recipe.
+fn step_exists(recipe: &Value, step_id: &str) -> bool {
+    recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .map(|steps| {
+            steps
+                .iter()
+                .any(|s| s.get("id").and_then(Value::as_str) == Some(step_id))
+        })
+        .unwrap_or(false)
+}
+
+/// Get the `output:` field of a step.
+fn step_output(recipe: &Value, step_id: &str) -> Option<String> {
+    let steps = recipe.get("steps")?.as_sequence()?;
+    for step in steps {
+        if step.get("id").and_then(Value::as_str) == Some(step_id) {
+            return step.get("output").and_then(Value::as_str).map(String::from);
+        }
+    }
+    None
+}
+
+/// Get the context block from default-workflow.yaml.
+fn default_workflow_context(recipe: &Value) -> Value {
+    recipe
+        .get("context")
+        .cloned()
+        .expect("default-workflow.yaml must have a 'context:' block")
+}
+
+// ===========================================================================
+// BLOCKER 1a: default-workflow.yaml — remote_host_type context variable
+// ===========================================================================
+
+#[test]
+fn default_workflow_declares_remote_host_type_context() {
+    let recipe = load_recipe("default-workflow");
+    let context = default_workflow_context(&recipe);
+
+    assert!(
+        context.get("remote_host_type").is_some(),
+        "default-workflow.yaml context block must declare 'remote_host_type' \
+         for cross-sub-recipe propagation. Without this, step-02d's output \
+         cannot reach workflow-publish and workflow-finalize. (Issue #684)"
+    );
+}
+
+// ===========================================================================
+// BLOCKER 1b: workflow-prep.yaml — step-02d-detect-host-type exists
+// ===========================================================================
+
+#[test]
+fn workflow_prep_has_step_02d_detect_host_type() {
+    let recipe = load_recipe("workflow-prep");
+
+    assert!(
+        step_exists(&recipe, "step-02d-detect-host-type"),
+        "workflow-prep.yaml must contain step 'step-02d-detect-host-type'. \
+         This centralized step detects the git remote host type once and \
+         exports it for all downstream steps. (Issue #684)"
+    );
+}
+
+#[test]
+fn step_02d_has_output_remote_host_type() {
+    let recipe = load_recipe("workflow-prep");
+
+    let output = step_output(&recipe, "step-02d-detect-host-type");
+    assert_eq!(
+        output.as_deref(),
+        Some("remote_host_type"),
+        "step-02d-detect-host-type must declare output: 'remote_host_type' \
+         so the recipe runner captures the host type and propagates it to \
+         subsequent steps and sub-recipes. (Issue #684)"
+    );
+}
+
+#[test]
+fn step_02d_detects_github_azdo_other() {
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-02d-detect-host-type");
+
+    // Must detect all three host types
+    assert!(
+        body.contains("github"),
+        "step-02d must detect 'github' host type (Issue #684)"
+    );
+    assert!(
+        body.contains("azdo"),
+        "step-02d must detect 'azdo' host type (Issue #684)"
+    );
+    assert!(
+        body.contains("other"),
+        "step-02d must handle 'other' as the fallback host type (Issue #684)"
+    );
+
+    // Must use git remote get-url to detect
+    assert!(
+        body.contains("git remote get-url"),
+        "step-02d must use 'git remote get-url' to detect the remote type (Issue #684)"
+    );
+}
+
+#[test]
+fn step_02d_detects_all_azdo_url_patterns() {
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-02d-detect-host-type");
+
+    // Must detect all three AzDO URL patterns
+    assert!(
+        body.contains("dev.azure.com"),
+        "step-02d must detect dev.azure.com URLs (Issue #684)"
+    );
+    assert!(
+        body.contains("visualstudio.com"),
+        "step-02d must detect visualstudio.com URLs (Issue #684)"
+    );
+    assert!(
+        body.contains("ssh.dev.azure.com"),
+        "step-02d must detect ssh.dev.azure.com URLs (Issue #684)"
+    );
+}
+
+#[test]
+fn step_02d_does_not_echo_remote_url() {
+    // Security: remote URL may contain embedded PATs
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-02d-detect-host-type");
+
+    let echoes_url = body.contains("echo \"$REMOTE_URL\"")
+        || body.contains("echo $REMOTE_URL")
+        || body.contains("printf '%s' \"$REMOTE_URL\"")
+        || body.contains("printf \"%s\" \"$REMOTE_URL\"");
+
+    assert!(
+        !echoes_url,
+        "step-02d must NOT echo the remote URL directly. Remote URLs may \
+         contain embedded PATs. Use pattern matching (case/[[]]) instead. \
+         (Issue #684, security)"
+    );
+}
+
+#[test]
+fn step_02d_appears_before_step_03() {
+    // step-02d must run before step-03 so REMOTE_HOST_TYPE is available
+    let recipe = load_recipe("workflow-prep");
+    let steps = recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("recipe must have steps");
+
+    let step_02d_idx = steps
+        .iter()
+        .position(|s| s.get("id").and_then(Value::as_str) == Some("step-02d-detect-host-type"));
+    let step_03_idx = steps.iter().position(|s| {
+        s.get("id")
+            .and_then(Value::as_str)
+            .map(|id| id.starts_with("step-03"))
+            .unwrap_or(false)
+    });
+
+    assert!(
+        step_02d_idx.is_some(),
+        "step-02d-detect-host-type must exist in workflow-prep.yaml"
+    );
+    assert!(
+        step_03_idx.is_some(),
+        "step-03 must exist in workflow-prep.yaml"
+    );
+    assert!(
+        step_02d_idx.unwrap() < step_03_idx.unwrap(),
+        "step-02d-detect-host-type (index {}) must appear before step-03 (index {}) \
+         in workflow-prep.yaml so REMOTE_HOST_TYPE is available for issue creation. \
+         (Issue #684)",
+        step_02d_idx.unwrap(),
+        step_03_idx.unwrap()
+    );
+}
+
+// ===========================================================================
+// BLOCKER 1c: step-15 — host-aware commit message
+// ===========================================================================
+
+#[test]
+fn step_15_commit_message_not_hardcoded_closes() {
+    // The commit message must NOT use hardcoded "Closes #N" for all hosts.
+    // It should be conditional based on REMOTE_HOST_TYPE.
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-15-commit-push");
+
+    // Count occurrences of literal "Closes #" in commit message construction.
+    // After the fix, "Closes #" should only appear inside a GitHub conditional,
+    // not as the unconditional default in the COMMIT_MSG printf.
+    let has_unconditional_closes = body.contains("Closes #%s' \"$COMMIT_TITLE\"")
+        || body.contains("Closes #%s\" \"$COMMIT_TITLE\"");
+
+    assert!(
+        !has_unconditional_closes,
+        "step-15 commit message must NOT hardcode 'Closes #N' unconditionally. \
+         Use host-aware refs: 'AB#N' for azdo, 'Closes #N' for github, \
+         'Ref #N' for other. (Issue #684, BLOCKER 1)"
+    );
+}
+
+#[test]
+fn step_15_uses_remote_host_type_for_commit_ref() {
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-15-commit-push");
+
+    // The step must reference REMOTE_HOST_TYPE to decide the issue ref format
+    assert!(
+        body.contains("REMOTE_HOST_TYPE"),
+        "step-15 must use REMOTE_HOST_TYPE to determine the commit message \
+         issue reference format (Closes #N vs AB#N vs Ref #N). (Issue #684)"
+    );
+}
+
+#[test]
+fn step_15_supports_azdo_ab_ref() {
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-15-commit-push");
+
+    assert!(
+        body.contains("AB#"),
+        "step-15 must use 'AB#' format for Azure DevOps work item linking \
+         in commit messages. (Issue #684)"
+    );
+}
+
+#[test]
+fn step_15_supports_neutral_ref() {
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-15-commit-push");
+
+    assert!(
+        body.contains("Ref #"),
+        "step-15 must use 'Ref #' format for non-GitHub/non-AzDO hosts \
+         in commit messages. (Issue #684)"
+    );
+}
+
+// ===========================================================================
+// BLOCKER 1d: step-16 — no duplicate host detection, host-aware PR body
+// ===========================================================================
+
+#[test]
+fn step_16_no_inline_remote_host_type_detection() {
+    // step-16 should consume $REMOTE_HOST_TYPE from context (step-02d output),
+    // not re-detect it inline. Duplicate detection is fragile and violates DRY.
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-16-create-draft-pr");
+
+    // The inline detection pattern from the current code:
+    //   REMOTE_URL=$(git remote get-url origin ...)
+    //   case "$REMOTE_URL" in *github.com*) ...
+    // After the fix, this should be replaced by consuming $REMOTE_HOST_TYPE.
+    let has_inline_case = body.contains("case \"$REMOTE_URL\"") && body.contains("*github.com*)");
+
+    assert!(
+        !has_inline_case,
+        "step-16 must NOT have inline REMOTE_HOST_TYPE detection via \
+         case \"$REMOTE_URL\". It should consume $REMOTE_HOST_TYPE from \
+         context (set by step-02d). (Issue #684, DRY violation)"
+    );
+}
+
+#[test]
+fn step_16_pr_body_not_hardcoded_closes() {
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-16-create-draft-pr");
+
+    // The PR body must not hardcode "Closes #%s" for all hosts
+    let has_unconditional_closes = body.contains("Closes #%s\\n");
+
+    assert!(
+        !has_unconditional_closes,
+        "step-16 PR body must NOT hardcode 'Closes #N'. It should use \
+         host-aware refs like step-15. (Issue #684, BLOCKER 1)"
+    );
+}
+
+#[test]
+fn step_16_consumes_remote_host_type() {
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-16-create-draft-pr");
+
+    assert!(
+        body.contains("REMOTE_HOST_TYPE"),
+        "step-16 must reference REMOTE_HOST_TYPE (from context/env) \
+         to decide PR creation behavior and issue ref format. (Issue #684)"
+    );
+}
+
+// ===========================================================================
+// BLOCKER 2: step-22b — host-aware summary
+// ===========================================================================
+
+#[test]
+fn step_22b_guards_gh_pr_view_with_host_type() {
+    let recipe = load_recipe("workflow-finalize");
+    let body = extract_step_body(&recipe, "step-22b-final-status");
+
+    // gh pr view must be guarded by REMOTE_HOST_TYPE check, not just PR_URL
+    assert!(
+        body.contains("REMOTE_HOST_TYPE"),
+        "step-22b must check REMOTE_HOST_TYPE before calling gh pr view. \
+         Belt-and-suspenders: non-GitHub hosts must never invoke gh. (Issue #684)"
+    );
+}
+
+#[test]
+fn step_22b_issue_line_is_host_aware() {
+    let recipe = load_recipe("workflow-finalize");
+    let body = extract_step_body(&recipe, "step-22b-final-status");
+
+    // The issue summary should not unconditionally use "Issue: #N"
+    // It should adapt based on host type (AB#N for AzDO, #N for GitHub)
+    let has_unconditional_issue_hash = body.contains("'=== Issue: #%s ===\\n'");
+
+    assert!(
+        !has_unconditional_issue_hash,
+        "step-22b issue summary must NOT use unconditional '=== Issue: #N ===' format. \
+         Use host-aware format: 'AB#N' for azdo, '#N' for github. (Issue #684)"
+    );
+}
+
+#[test]
+fn step_22b_pr_line_handles_empty_pr_url() {
+    let recipe = load_recipe("workflow-finalize");
+    let body = extract_step_body(&recipe, "step-22b-final-status");
+
+    // When PR_URL is empty (non-GitHub host), the summary should say
+    // something like "PR: N/A" rather than "PR: " (empty)
+    let has_empty_pr_handling = body.contains("N/A")
+        || body.contains("manual")
+        || body.contains("not created")
+        || body.contains("skipped");
+
+    assert!(
+        has_empty_pr_handling,
+        "step-22b must handle empty PR_URL gracefully in the summary output. \
+         Use 'N/A', 'manual creation required', or similar when PR was not created. \
+         (Issue #684, BLOCKER 2)"
+    );
+}
+
+#[test]
+fn step_22b_uses_host_type_safe_pattern() {
+    // Must use HOST_TYPE=${REMOTE_HOST_TYPE:-other} for set -u safety
+    let recipe = load_recipe("workflow-finalize");
+    let body = extract_step_body(&recipe, "step-22b-final-status");
+
+    let has_safe_default =
+        body.contains("${REMOTE_HOST_TYPE:-") || body.contains("HOST_TYPE=${REMOTE_HOST_TYPE:-");
+
+    assert!(
+        has_safe_default,
+        "step-22b must use safe default pattern '${{REMOTE_HOST_TYPE:-other}}' \
+         or 'HOST_TYPE=${{REMOTE_HOST_TYPE:-other}}' for set -u compatibility. \
+         (Issue #684)"
+    );
+}
+
+// ===========================================================================
+// BLOCKER 3: step-03 — percent-encoded AzDO project names
+// ===========================================================================
+
+#[test]
+fn step_03_decodes_percent_encoding() {
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-03-create-issue");
+
+    // The step must decode %XX sequences (e.g., %20 → space) before validation.
+    // We check for actual decode logic, not incidental mentions of "sed" in comments.
+    let has_percent_decode = body.contains("%20")
+        || body.contains("percent_decode")
+        || body.contains("printf '%b'")  // printf-based decode
+        || body.contains("\\\\x")  // hex escape for printf decode
+        || (body.contains("sed") && body.contains("%[0-9A-Fa-f]")); // sed-based decode with hex pattern
+
+    assert!(
+        has_percent_decode,
+        "step-03 must decode percent-encoded sequences (e.g., %20 → space) \
+         in AzDO project names before validation. URLs like \
+         'dev.azure.com/org/My%20Project/' must be handled. (Issue #684, BLOCKER 3)"
+    );
+}
+
+#[test]
+fn step_03_regex_allows_spaces_in_project_names() {
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-03-create-issue");
+
+    // After percent-decoding, the regex must allow spaces in project names.
+    // The current regex is ^[a-zA-Z0-9._-]+$ which rejects spaces.
+    // The fix should expand to ^[a-zA-Z0-9._ -]+$ (note the space).
+    let has_space_in_regex =
+        body.contains("[a-zA-Z0-9._ -]") || body.contains("[a-zA-Z0-9._[:space:]-]");
+
+    assert!(
+        has_space_in_regex,
+        "step-03 AzDO project name validation regex must allow spaces \
+         (for decoded %20). Change from ^[a-zA-Z0-9._-]+$ to \
+         ^[a-zA-Z0-9._ -]+$. (Issue #684, BLOCKER 3)"
+    );
+}
+
+#[test]
+fn step_03_rejects_invalid_percent_sequences() {
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-03-create-issue");
+
+    // Invalid percent sequences (%ZZ, %G1, etc.) must be caught during decode.
+    // This is separate from the existing "unexpected characters" validation —
+    // it must explicitly handle the decode-failure path.
+    let has_decode_validation = body.contains("%20")
+        || body.contains("percent_decode")
+        || body.contains("printf '%b'")
+        || body.contains("\\\\x");
+
+    assert!(
+        has_decode_validation,
+        "step-03 must have percent-decode logic that implicitly rejects invalid \
+         sequences (e.g., %%ZZ). The decode itself will fail or pass through invalid \
+         sequences which the expanded regex then catches. (Issue #684, BLOCKER 3)"
+    );
+}
+
+// ===========================================================================
+// Cross-cutting: step-03 consumes REMOTE_HOST_TYPE from env
+// ===========================================================================
+
+#[test]
+fn step_03_does_not_redefine_remote_host_type_via_case() {
+    // After step-02d is added, step-03 should consume $REMOTE_HOST_TYPE
+    // from the environment, not re-detect it with its own case block.
+    // Note: step-03 must still USE $REMOTE_HOST_TYPE for branching (github/azdo/other).
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-03-create-issue");
+
+    // Count how many times REMOTE_HOST_TYPE is assigned via case statement.
+    // After the fix, there should be zero case-based assignments — only reads.
+    let has_case_assignment =
+        body.contains("case \"$REMOTE_URL\"") && body.contains("REMOTE_HOST_TYPE=\"github\"");
+
+    assert!(
+        !has_case_assignment,
+        "step-03 must NOT re-detect REMOTE_HOST_TYPE via case statement. \
+         It should consume $REMOTE_HOST_TYPE from context (set by step-02d). \
+         This eliminates duplicate host detection. (Issue #684)"
+    );
+}
+
+// ===========================================================================
+// Step-21: gh pr ready guard (existing PR_URL guard + host-type)
+// ===========================================================================
+
+#[test]
+fn step_21_guards_gh_commands_with_host_type() {
+    let recipe = load_recipe("workflow-finalize");
+    let body = extract_step_body(&recipe, "step-21-pr-ready");
+
+    // step-21 already has a PR_URL guard. After fix, it should also check
+    // REMOTE_HOST_TYPE to prevent gh commands on non-GitHub hosts.
+    assert!(
+        body.contains("REMOTE_HOST_TYPE"),
+        "step-21 must check REMOTE_HOST_TYPE in addition to PR_URL guard \
+         to prevent gh commands on non-GitHub hosts. (Issue #684)"
+    );
+}
+
+// ===========================================================================
+// Brick rule: all recipe files must stay under 400 lines
+// ===========================================================================
+
+#[test]
+fn all_modified_recipes_under_400_lines() {
+    let recipes = [
+        "default-workflow",
+        "workflow-prep",
+        "workflow-publish",
+        "workflow-finalize",
+    ];
+
+    for name in &recipes {
+        let text = recipe_text(name);
+        let line_count = text.lines().count();
+        assert!(
+            line_count <= 400,
+            "{name}.yaml has {line_count} lines — exceeds the 400-line brick limit. \
+             (Issue #684, brick rule)"
+        );
+    }
+}
+
+// ===========================================================================
+// Security: HOST_TYPE safe defaults in all consuming steps
+// ===========================================================================
+
+#[test]
+fn step_15_uses_host_type_safe_default() {
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-15-commit-push");
+
+    let has_safe_default =
+        body.contains("${REMOTE_HOST_TYPE:-") || body.contains("HOST_TYPE=${REMOTE_HOST_TYPE:-");
+
+    assert!(
+        has_safe_default,
+        "step-15 must use safe default pattern for REMOTE_HOST_TYPE \
+         (e.g., '${{REMOTE_HOST_TYPE:-other}}') for set -u safety. (Issue #684)"
+    );
+}
+
+#[test]
+fn step_16_uses_host_type_safe_default() {
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-16-create-draft-pr");
+
+    let has_safe_default =
+        body.contains("${REMOTE_HOST_TYPE:-") || body.contains("HOST_TYPE=${REMOTE_HOST_TYPE:-");
+
+    assert!(
+        has_safe_default,
+        "step-16 must use safe default pattern for REMOTE_HOST_TYPE \
+         (e.g., '${{REMOTE_HOST_TYPE:-other}}') for set -u safety. (Issue #684)"
+    );
+}
+
+// ===========================================================================
+// Preserved invariants: existing step behavior must not regress
+// ===========================================================================
+
+#[test]
+fn step_03_preserves_github_path() {
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-03-create-issue");
+
+    assert!(
+        body.contains("gh issue create"),
+        "step-03 must preserve the GitHub issue creation path (Issue #684)"
+    );
+    assert!(
+        body.contains("gh issue view"),
+        "step-03 must preserve the GitHub issue lookup for idempotency (Issue #684)"
+    );
+}
+
+#[test]
+fn step_03_preserves_azdo_path() {
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-03-create-issue");
+
+    assert!(
+        body.contains("az boards work-item"),
+        "step-03 must preserve the AzDO work-item creation path (Issue #684)"
+    );
+}
+
+#[test]
+fn step_03_preserves_local_tracking_fallback() {
+    let recipe = load_recipe("workflow-prep");
+    let body = extract_step_body(&recipe, "step-03-create-issue");
+
+    assert!(
+        body.contains("local-tracking") || body.contains("local tracking"),
+        "step-03 must preserve the local tracking fallback path (Issue #684)"
+    );
+}
+
+#[test]
+fn step_22b_preserves_pr_url_guard() {
+    // The existing PR_URL empty-check must be preserved
+    let recipe = load_recipe("workflow-finalize");
+    let body = extract_step_body(&recipe, "step-22b-final-status");
+
+    let has_pr_url_check =
+        body.contains("PR_URL") && (body.contains("-z \"$PR_URL\"") || body.contains("PR_URL:-"));
+
+    assert!(
+        has_pr_url_check,
+        "step-22b must preserve the PR_URL empty-check guard. (Issue #684)"
+    );
+}
+
+#[test]
+fn step_15_preserves_set_euo_pipefail() {
+    let recipe = load_recipe("workflow-publish");
+    let body = extract_step_body(&recipe, "step-15-commit-push");
+
+    assert!(
+        body.contains("set -euo pipefail"),
+        "step-15 must preserve 'set -euo pipefail' at the top of the bash block"
+    );
+}
+
+#[test]
+fn step_22b_preserves_set_euo_pipefail() {
+    let recipe = load_recipe("workflow-finalize");
+    let body = extract_step_body(&recipe, "step-22b-final-status");
+
+    assert!(
+        body.contains("set -euo pipefail"),
+        "step-22b must preserve 'set -euo pipefail' at the top of the bash block"
+    );
+}

--- a/tests/integration/p1_workflow_reliability_test.rs
+++ b/tests/integration/p1_workflow_reliability_test.rs
@@ -27,7 +27,7 @@ struct Recipe {
 struct Step {
     id: String,
     #[serde(rename = "type", default)]
-    step_type: Option<String>,
+    _step_type: Option<String>,
     #[serde(default)]
     agent: Option<String>,
     #[serde(default)]
@@ -35,7 +35,7 @@ struct Step {
     #[serde(default)]
     command: Option<String>,
     #[serde(default)]
-    output: Option<String>,
+    _output: Option<String>,
 }
 
 fn workflow_tdd_path() -> PathBuf {

--- a/tests/integration/repo_sweep_issues_599_608_test.rs
+++ b/tests/integration/repo_sweep_issues_599_608_test.rs
@@ -126,11 +126,13 @@ mod ultrathink_refs {
 
     /// Returns true if a line has a stale `/ultrathink` command reference.
     fn is_stale_ultrathink(line: &str, rel_path: &str) -> bool {
-        line.contains("/ultrathink")
-            && !line.contains("feat/ultrathink")
-            && !line.contains("ultrathink-orchestrator")
-            && !line.contains("ultrathink-recipe")
-            && !(rel_path.contains("dev-orchestrator") && line.contains("deprecated"))
+        if !line.contains("/ultrathink") {
+            return false;
+        }
+        !(line.contains("feat/ultrathink")
+            || line.contains("ultrathink-orchestrator")
+            || line.contains("ultrathink-recipe")
+            || (rel_path.contains("dev-orchestrator") && line.contains("deprecated")))
     }
 
     /// TC-SWEEP-602-01: No SKILL.md file (except ultrathink-orchestrator and
@@ -193,7 +195,7 @@ mod python_hook_refs {
 
         for path in collect_skill_files() {
             let content = fs::read_to_string(&path).unwrap_or_default();
-            let rel = path.strip_prefix(&root).unwrap_or(&path);
+            let rel = path.strip_prefix(root).unwrap_or(&path);
             let mut in_code_block = false;
 
             for (i, line) in content.lines().enumerate() {
@@ -496,7 +498,7 @@ mod docs_internal_links {
                     // Resolve relative to the file's directory
                     let target = file_dir.join(path_part);
                     if !target.exists() {
-                        let rel = file.strip_prefix(&workspace_root()).unwrap_or(file);
+                        let rel = file.strip_prefix(workspace_root()).unwrap_or(file);
                         broken.push(format!(
                             "  {}:{}: -> {} (not found)",
                             rel.display(),
@@ -546,7 +548,7 @@ mod docs_internal_links {
 
         for file in &md_files {
             let content = fs::read_to_string(file).unwrap_or_default();
-            let rel = file.strip_prefix(&workspace_root()).unwrap_or(file);
+            let rel = file.strip_prefix(workspace_root()).unwrap_or(file);
 
             for (line_num, line) in content.lines().enumerate() {
                 for dir in &deleted_dirs {

--- a/tests/issue_682_worktree_resume.sh
+++ b/tests/issue_682_worktree_resume.sh
@@ -50,7 +50,7 @@ assert "step-21 references PR_URL variable" \
 
 # --- Test 3: step-21 has PR_URL empty check before gh commands ---------------
 assert "step-21 has PR_URL empty/non-empty check" \
-    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -Eq '\\[ -z .PR_URL|\\[ -n .PR_URL|-z \".PR_URL|-n \".PR_URL'"
+    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -Eq '\\[ -z .PR_URL|\\[ -n .PR_URL|-z \".PR_URL|-n \".PR_URL|PR_URL.*=~|\\[\\[.*PR_URL'"
 
 # --- Test 4: gh pr ready appears AFTER PR_URL check -------------------------
 # The pr ready command must not be invoked unconditionally.

--- a/tests/issue_682_worktree_resume.sh
+++ b/tests/issue_682_worktree_resume.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Tests for Issue #682: step-21-pr-ready must guard PR_URL before invoking
+# gh commands, and resume path must handle missing worktree_setup output.
+#
+# TDD: These tests are written BEFORE the implementation. They define the
+# required contract for the resume-path fix.
+#
+# These tests validate:
+#   1. step-21 checks PR_URL is non-empty before gh pr ready / gh pr comment.
+#   2. step-21 does not unconditionally invoke gh pr ready.
+#   3. Runtime: gh pr ready is NOT called when PR_URL is empty.
+#   4. YAML remains parseable.
+#
+# Run: bash tests/issue_682_worktree_resume.sh
+# Expected before fix: FAIL. Expected after fix: PASS.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FINALIZE_FILE="$REPO_ROOT/amplifier-bundle/recipes/workflow-finalize.yaml"
+
+fail=0
+pass=0
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        echo "PASS: $desc"
+        pass=$((pass+1))
+    else
+        echo "FAIL: $desc"
+        echo "      condition: $cond"
+        fail=$((fail+1))
+    fi
+}
+
+echo "=== Issue #682 TDD tests: worktree resume path / PR_URL guard ==="
+echo "Finalize file: $FINALIZE_FILE"
+echo
+
+# --- Test 1: file exists ----------------------------------------------------
+assert "workflow-finalize.yaml exists" "[ -f '$FINALIZE_FILE' ]"
+
+# --- Test 2: step-21 references PR_URL --------------------------------------
+# Use awk+grep directly (avoids quoting issues with $-vars in YAML command blocks)
+
+assert "step-21 references PR_URL variable" \
+    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -q 'PR_URL'"
+
+# --- Test 3: step-21 has PR_URL empty check before gh commands ---------------
+assert "step-21 has PR_URL empty/non-empty check" \
+    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -Eq '\\[ -z .PR_URL|\\[ -n .PR_URL|-z \".PR_URL|-n \".PR_URL'"
+
+# --- Test 4: gh pr ready appears AFTER PR_URL check -------------------------
+# The pr ready command must not be invoked unconditionally.
+pr_url_line=$(awk '/id: .step-21-pr-ready/,/output:/' "$FINALIZE_FILE" | grep -n 'PR_URL' | head -1 | cut -d: -f1)
+gh_ready_line=$(awk '/id: .step-21-pr-ready/,/output:/' "$FINALIZE_FILE" | grep -n 'gh pr ready' | head -1 | cut -d: -f1)
+
+if [ -n "$pr_url_line" ] && [ -n "$gh_ready_line" ]; then
+    assert "gh pr ready appears after PR_URL reference (line $gh_ready_line > $pr_url_line)" \
+        "[ '$gh_ready_line' -gt '$pr_url_line' ]"
+else
+    assert "both PR_URL and 'gh pr ready' exist in step-21" "false"
+fi
+
+# --- Test 5: gh pr comment also guarded by PR_URL ----------------------------
+assert "gh pr comment is guarded — appears after PR_URL check" \
+    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -q 'gh pr comment'"
+
+# --- Test 6: step-21 emits WARNING or INFO when PR_URL is empty ---------------
+assert "step-21 emits WARNING or INFO when skipping due to empty PR_URL" \
+    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -Eq 'WARNING.*PR_URL|INFO.*PR_URL|PR_URL.*empty|PR_URL.*skip'"
+
+# --- Test 7: Runtime — gh pr ready NOT called with empty PR_URL ---------------
+# Create a mock 'gh' that records invocations and exits non-zero to prove
+# it was called.
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "$tmpdir/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+echo "MOCK_GH_CALLED: $*" >> "$MOCK_GH_LOG"
+exit 0
+MOCK_GH
+chmod +x "$tmpdir/gh"
+
+# Test: with empty PR_URL, the mock gh should NOT be called for 'pr ready'
+export MOCK_GH_LOG="$tmpdir/gh_calls.log"
+export PR_URL=""
+export PATH="$tmpdir:$PATH"
+
+# We can't run the full step, but we can test the expected guard pattern:
+# if [ -n "$PR_URL" ]; then gh pr ready "$PR_URL"; fi
+(
+    set -euo pipefail
+    PR_URL=""
+    if [ -n "$PR_URL" ]; then
+        gh pr ready "$PR_URL"
+        gh pr comment "$PR_URL" --body "test"
+    else
+        echo "INFO: PR_URL is empty — skipping PR ready marking" >&2
+    fi
+) 2>/dev/null
+
+if [ -f "$MOCK_GH_LOG" ] && grep -q 'pr ready' "$MOCK_GH_LOG"; then
+    assert "runtime: gh pr ready NOT called when PR_URL is empty" "false"
+else
+    assert "runtime: gh pr ready NOT called when PR_URL is empty" "true"
+fi
+
+# Test: with non-empty PR_URL, the mock gh SHOULD be called
+export MOCK_GH_LOG="$tmpdir/gh_calls_nonempty.log"
+(
+    set -euo pipefail
+    PR_URL="https://github.com/org/repo/pull/42"
+    if [ -n "$PR_URL" ]; then
+        gh pr ready "$PR_URL"
+    else
+        echo "INFO: PR_URL is empty — skipping" >&2
+    fi
+) 2>/dev/null
+
+assert "runtime: gh pr ready IS called when PR_URL is non-empty" \
+    "[ -f '$tmpdir/gh_calls_nonempty.log' ] && grep -q 'pr ready' '$tmpdir/gh_calls_nonempty.log'"
+
+# --- Test 8: YAML parses cleanly -------------------------------------------
+if command -v python3 >/dev/null 2>&1; then
+    if python3 -c "import yaml" 2>/dev/null; then
+        assert "workflow-finalize.yaml parses with yaml.safe_load" \
+            "python3 -c 'import yaml; yaml.safe_load(open(\"$FINALIZE_FILE\"))'"
+    else
+        echo "SKIP: PyYAML not available"
+    fi
+else
+    echo "SKIP: python3 not available"
+fi
+
+# --- Summary ----------------------------------------------------------------
+echo
+echo "=== Summary: $pass passed, $fail failed ==="
+exit "$fail"

--- a/tests/issue_684_azdo_remote_detection.sh
+++ b/tests/issue_684_azdo_remote_detection.sh
@@ -106,7 +106,7 @@ assert "step-21 references PR_URL variable" \
     "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -q 'PR_URL'"
 
 assert "step-21 checks PR_URL before gh pr ready" \
-    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -Eq '\\[ -z .PR_URL|\\[ -n .PR_URL|-z \".PR_URL|-n \".PR_URL'"
+    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -Eq '\\[ -z .PR_URL|\\[ -n .PR_URL|-z \".PR_URL|-n \".PR_URL|PR_URL.*=~|\\[\\[.*PR_URL'"
 
 # --- Test 9: Runtime remote detection function tests -------------------------
 # These test the expected shell logic for classifying remote URLs.

--- a/tests/issue_684_azdo_remote_detection.sh
+++ b/tests/issue_684_azdo_remote_detection.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Tests for Issue #684: step-03-create-issue must detect git remote host type
+# and branch into GitHub, Azure DevOps, or local-tracking paths.
+#
+# TDD: These tests are written BEFORE the implementation. They define the
+# required contract for multi-host support in the issue creation step.
+#
+# These tests validate:
+#   1. step-03 command contains remote host type detection logic.
+#   2. step-03 has distinct paths for GitHub, AzDO, and unknown remotes.
+#   3. step-03b extracts issue numbers from AzDO work item URLs.
+#   4. step-16 handles non-GitHub remotes (skips or adapts PR creation).
+#   5. No GitHub-specific error messages leak to non-GitHub remote paths.
+#   6. Runtime: detection function classifies remote URLs correctly.
+#   7. YAML remains parseable.
+#
+# Run: bash tests/issue_684_azdo_remote_detection.sh
+# Expected before fix: FAIL. Expected after fix: PASS.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PREP_FILE="$REPO_ROOT/amplifier-bundle/recipes/workflow-prep.yaml"
+PUBLISH_FILE="$REPO_ROOT/amplifier-bundle/recipes/workflow-publish.yaml"
+FINALIZE_FILE="$REPO_ROOT/amplifier-bundle/recipes/workflow-finalize.yaml"
+
+fail=0
+pass=0
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        echo "PASS: $desc"
+        pass=$((pass+1))
+    else
+        echo "FAIL: $desc"
+        echo "      condition: $cond"
+        fail=$((fail+1))
+    fi
+}
+
+echo "=== Issue #684 TDD tests: Azure DevOps remote detection ==="
+echo "Prep file:     $PREP_FILE"
+echo "Publish file:  $PUBLISH_FILE"
+echo "Finalize file: $FINALIZE_FILE"
+echo
+
+# --- Test 1: recipe files exist ----------------------------------------------
+assert "workflow-prep.yaml exists" "[ -f '$PREP_FILE' ]"
+assert "workflow-publish.yaml exists" "[ -f '$PUBLISH_FILE' ]"
+assert "workflow-finalize.yaml exists" "[ -f '$FINALIZE_FILE' ]"
+
+# --- Test 2: step-03 contains remote host type detection ---------------------
+assert "step-03 detects REMOTE_HOST_TYPE" \
+    "grep -q 'REMOTE_HOST_TYPE' '$PREP_FILE'"
+
+assert "step-03 checks for github.com" \
+    "grep -q 'github.com' '$PREP_FILE'"
+
+assert "step-03 checks for dev.azure.com" \
+    "grep -q 'dev.azure.com' '$PREP_FILE'"
+
+assert "step-03 checks for visualstudio.com" \
+    "grep -q 'visualstudio.com' '$PREP_FILE'"
+
+# --- Test 3: step-03 has Azure DevOps work item path -------------------------
+assert "step-03 has 'az boards' for AzDO work items" \
+    "grep -q 'az boards' '$PREP_FILE'"
+
+assert "step-03 supports AB# work item references" \
+    "grep -q 'AB#' '$PREP_FILE'"
+
+# --- Test 4: step-03 has local tracking fallback -----------------------------
+assert "step-03 has local tracking fallback" \
+    "grep -Eq 'local.tracking|LOCAL_ISSUE|local_issue' '$PREP_FILE'"
+
+# --- Test 5: no GitHub-specific error messages for non-GitHub remotes --------
+assert "step-03 does not contain 'gh auth login' error text" \
+    "! grep -q 'gh auth login' '$PREP_FILE'"
+
+assert "step-03 does not contain 'none of the git remotes' error text" \
+    "! grep -q 'none of the git remotes' '$PREP_FILE'"
+
+# --- Test 6: step-03b handles AzDO URLs --------------------------------------
+# Use awk+grep directly (avoids quoting issues with $-vars in YAML command blocks)
+assert "step-03b handles _workitems/edit/ URLs" \
+    "awk '/id: .step-03b-extract-issue-number/,/output:/' '$PREP_FILE' | grep -q '_workitems/edit/'"
+
+assert "step-03b handles AB# references" \
+    "awk '/id: .step-03b-extract-issue-number/,/output:/' '$PREP_FILE' | grep -q 'AB#'"
+
+assert "step-03b still handles GitHub issues/ URLs (regression)" \
+    "awk '/id: .step-03b-extract-issue-number/,/output:/' '$PREP_FILE' | grep -q 'issues/'"
+
+assert "step-03b still handles GitHub pull/ URLs (regression)" \
+    "awk '/id: .step-03b-extract-issue-number/,/output:/' '$PREP_FILE' | grep -q 'pull/'"
+
+# --- Test 7: step-16 handles non-GitHub remotes -----------------------------
+assert "step-16 contains remote host type detection or github.com check" \
+    "grep -Eq 'REMOTE_HOST_TYPE|remote_host_type' '$PUBLISH_FILE' || \
+     awk '/id: \"step-16-create-draft-pr\"/{f=1} f' '$PUBLISH_FILE' | head -30 | grep -q 'github.com'"
+
+# --- Test 8: step-21 guards PR_URL before gh commands -----------------------
+assert "step-21 references PR_URL variable" \
+    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -q 'PR_URL'"
+
+assert "step-21 checks PR_URL before gh pr ready" \
+    "awk '/id: .step-21-pr-ready/,/output:/' '$FINALIZE_FILE' | grep -Eq '\\[ -z .PR_URL|\\[ -n .PR_URL|-z \".PR_URL|-n \".PR_URL'"
+
+# --- Test 9: Runtime remote detection function tests -------------------------
+# These test the expected shell logic for classifying remote URLs.
+# The implementation should use something like:
+#   REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+#   if [[ "$REMOTE_URL" =~ github\.com ]]; then REMOTE_HOST_TYPE="github"
+#   elif [[ "$REMOTE_URL" =~ dev\.azure\.com|visualstudio\.com|ssh\.dev\.azure\.com ]]; then REMOTE_HOST_TYPE="azdo"
+#   else REMOTE_HOST_TYPE="unknown"; fi
+
+# Simulate the detection logic for various URL formats
+detect_host_type() {
+    local url="$1"
+    if [[ "$url" =~ github\.com ]]; then
+        echo "github"
+    elif [[ "$url" =~ dev\.azure\.com|visualstudio\.com|ssh\.dev\.azure\.com ]]; then
+        echo "azdo"
+    else
+        echo "unknown"
+    fi
+}
+
+# GitHub URLs
+assert "detect: https://github.com/org/repo.git → github" \
+    "[ '$(detect_host_type 'https://github.com/org/repo.git')' = 'github' ]"
+
+assert "detect: git@github.com:org/repo.git → github" \
+    "[ '$(detect_host_type 'git@github.com:org/repo.git')' = 'github' ]"
+
+assert "detect: ssh://git@github.com/org/repo.git → github" \
+    "[ '$(detect_host_type 'ssh://git@github.com/org/repo.git')' = 'github' ]"
+
+# Azure DevOps URLs
+assert "detect: https://dev.azure.com/org/project/_git/repo → azdo" \
+    "[ '$(detect_host_type 'https://dev.azure.com/org/project/_git/repo')' = 'azdo' ]"
+
+assert "detect: https://org@dev.azure.com/org/project/_git/repo → azdo" \
+    "[ '$(detect_host_type 'https://org@dev.azure.com/org/project/_git/repo')' = 'azdo' ]"
+
+assert "detect: https://org.visualstudio.com/project/_git/repo → azdo" \
+    "[ '$(detect_host_type 'https://org.visualstudio.com/project/_git/repo')' = 'azdo' ]"
+
+assert "detect: git@ssh.dev.azure.com:v3/org/project/repo → azdo" \
+    "[ '$(detect_host_type 'git@ssh.dev.azure.com:v3/org/project/repo')' = 'azdo' ]"
+
+assert "detect: ssh://git@ssh.dev.azure.com/v3/org/project/repo → azdo" \
+    "[ '$(detect_host_type 'ssh://git@ssh.dev.azure.com/v3/org/project/repo')' = 'azdo' ]"
+
+# Unknown/other remotes
+assert "detect: https://gitlab.com/org/repo.git → unknown" \
+    "[ '$(detect_host_type 'https://gitlab.com/org/repo.git')' = 'unknown' ]"
+
+assert "detect: https://bitbucket.org/org/repo.git → unknown" \
+    "[ '$(detect_host_type 'https://bitbucket.org/org/repo.git')' = 'unknown' ]"
+
+assert "detect: empty URL → unknown" \
+    "[ '$(detect_host_type '')' = 'unknown' ]"
+
+# --- Test 10: AzDO work item ID extraction from various formats ---------------
+extract_azdo_id() {
+    local input="$1"
+    local extracted=""
+    # Try _workitems/edit/NNN
+    extracted=$(printf '%s' "$input" | grep -oE '_workitems/edit/[0-9]+' | grep -oE '[0-9]+' | head -1)
+    if [ -z "$extracted" ]; then
+        # Try AB#NNN
+        extracted=$(printf '%s' "$input" | grep -oE 'AB#[0-9]+' | grep -oE '[0-9]+' | head -1)
+    fi
+    printf '%s' "$extracted"
+}
+
+assert "extract AzDO: _workitems/edit/12345 → 12345" \
+    "[ '$(extract_azdo_id 'https://dev.azure.com/org/project/_workitems/edit/12345')' = '12345' ]"
+
+assert "extract AzDO: AB#6789 → 6789" \
+    "[ '$(extract_azdo_id 'AB#6789')' = '6789' ]"
+
+assert "extract AzDO: 'Created AB#42 in project' → 42" \
+    "[ '$(extract_azdo_id 'Created AB#42 in project')' = '42' ]"
+
+# --- Test 11: YAML parses cleanly -------------------------------------------
+if command -v python3 >/dev/null 2>&1; then
+    if python3 -c "import yaml" 2>/dev/null; then
+        assert "workflow-prep.yaml parses with yaml.safe_load" \
+            "python3 -c 'import yaml; yaml.safe_load(open(\"$PREP_FILE\"))'"
+        assert "workflow-publish.yaml parses with yaml.safe_load" \
+            "python3 -c 'import yaml; yaml.safe_load(open(\"$PUBLISH_FILE\"))'"
+        assert "workflow-finalize.yaml parses with yaml.safe_load" \
+            "python3 -c 'import yaml; yaml.safe_load(open(\"$FINALIZE_FILE\"))'"
+    else
+        echo "SKIP: PyYAML not available"
+    fi
+else
+    echo "SKIP: python3 not available"
+fi
+
+# --- Summary ----------------------------------------------------------------
+echo
+echo "=== Summary: $pass passed, $fail failed ==="
+exit "$fail"

--- a/tests/scenarios/pr-689-merge-ready.yaml
+++ b/tests/scenarios/pr-689-merge-ready.yaml
@@ -1,0 +1,28 @@
+name: pr-689-merge-ready
+description: |
+  Merge-ready QA coverage for PR #689. Exercises Azure DevOps remote detection,
+  GitHub regression protection, and the resume path fallback when step-04 is skipped.
+type: cli
+tags: [merge-ready, workflow, azdo, github, resume]
+
+scenarios:
+  - name: azdo-remote-detection-in-workflow-prep
+    description: workflow-prep routes Azure DevOps remotes and preserves the local fallback.
+    steps:
+      - type: command
+        command: bash ./issue_684_azdo_remote_detection.sh
+        expected_exit_code: 0
+
+  - name: github-remote-still-works-no-regression
+    description: GitHub issue and PR handling still exist after adding host detection.
+    steps:
+      - type: command
+        command: "bash -lc 'cargo test --test default_workflow_decomposition -- workflow_prep_step_03_has_github_path_inside_host_conditional --quiet && cargo test --test default_workflow_decomposition -- workflow_prep_step_03b_handles_azdo_work_item_urls --quiet'"
+        expected_exit_code: 0
+
+  - name: resume-path-works-when-step-04-skipped
+    description: Mid-stage steps fall back to REPO_PATH and PR readiness guards empty PR_URL.
+    steps:
+      - type: command
+        command: "bash -lc 'cargo test --test default_workflow_decomposition -- mid_stage_worktree_steps_fall_back_to_repo_path --quiet && cargo test --test default_workflow_decomposition -- workflow_finalize_step_21_guards_pr_url_before_gh_commands --quiet && bash ./issue_682_worktree_resume.sh'"
+        expected_exit_code: 0


### PR DESCRIPTION
## fix(workflow): add Azure DevOps support to default-workflow Step 3 and fix resume path

Closes #684, Closes #682

### Summary

Adds multi-provider support to the default-workflow recipe chain so it works correctly against GitHub, Azure DevOps, and local/unknown repositories. Previously, steps 03, 15, 16, 21, and 22b assumed GitHub as the sole hosting provider.

**Key changes:**
- **Step 02d** (new): Detect remote host type (`github`/`azdo`/`other`) from `git remote get-url origin`
- **Step 03**: Route issue creation by provider — `gh issue create` for GitHub, `az boards work-item create` for AzDO, synthetic local ID for other
- **Step 03**: Percent-decode `%XX` sequences in AzDO project names (e.g., `My%20Project`)
- **Step 15**: Host-aware commit references — `Closes #N` (GitHub), `AB#N` (AzDO), `Ref #N` (other)
- **Step 16**: Skip PR creation for non-GitHub hosts with info message
- **Step 22b**: Host-aware final summary with provider-specific issue/PR references
- **Step 04**: Fix resume path for worktree variables (bash default values)
- **Clippy**: Fix pre-existing warnings from Rust 1.93 toolchain upgrade

---

## Merge readiness

### QA-team evidence

- Scenario file: `tests/scenarios/pr-689-merge-ready.yaml`
- Validation: `gadugi-test validate tests/scenarios/pr-689-merge-ready.yaml` — passed
- Run: `gadugi-test run tests/scenarios/pr-689-merge-ready.yaml` — passed
- Additional regression tests:
  - `tests/issue_684_azdo_remote_detection.sh` — AzDO detection patterns
  - `tests/issue_682_worktree_resume.sh` — Resume path fix
  - `tests/integration/issue_684_host_aware_workflow_test.rs` — 254 lines of integration tests

### Documentation

- User-facing docs impact: **yes** (workflow behavior changes for AzDO remotes)
- Updated docs:
  - `docs/howto/use-workflow-with-azure-devops.md` (new how-to guide)
  - `docs/reference/multi-provider-workflow.md` (new reference doc, 468 lines)
  - `docs/concepts/multi-provider-workflow-architecture.md` (new architecture doc)
  - `docs/reference/recipe-step-03-idempotency.md` (updated for multi-provider)
  - `docs/reference/workflow-issue-extraction.md` (updated extraction logic)
  - `docs/index.md` (updated with new links)

### Quality-audit

- Cycle 1: Reviewed recipe YAML bash scripts for injection, unquoted variables, edge cases. Found doc overclaims (step 16 described as "logs instructions" but actually exits silently). Fixed in commit 370a269.
- Cycle 2: Code review agent audited all changed recipe files. No critical/high issues. Host detection centralized in step-02d, consuming steps use safe defaults (`${REMOTE_HOST_TYPE:-other}`). `_pct_decode` validates hex before `printf`. AZDO values validated against allowlists after decoding.
- Cycle 3: Final clean cycle — zero critical, zero high, zero medium correctness/security findings.
- Convergence: All doc accuracy issues fixed, code review clean.

### CI

- Command: `gh pr checks 689`
- Result: **all green** ✅
  - Lint & Format: pass
  - Build (4 targets): all pass
  - Test: pass (9m23s)
  - Install Smoke Test: pass
  - GitGuardian: pass
- Skipped checks: `scan` (conditional workflow, not applicable), `deploy` (non-main branch)
- Flaky reruns: none
- Real failures fixed: clippy warnings from Rust 1.93 (commit f346d6c)

### Scope

- 25 files changed, all related to #684 (AzDO support), #682 (resume path), or clippy fixes needed for CI
- No unrelated changes

### Verdict

- **Merge-ready: yes** ✅
- Remaining blockers: none
