### PR TITLE
fix(update): re-exec new binary as subprocess after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Unreleased changes appear at the top under `[Unreleased]`.
 
 ### Fixed
 
+- **`amplihack update` runs OLD binary's install code (#683)** — After
+  downloading a new binary, the post-update install step now spawns the
+  **new** binary as a subprocess (`amplihack install --force-refresh`)
+  instead of calling `run_install` in-process with the old binary's code.
+  `download_and_replace()` returns the installed binary path explicitly,
+  avoiding reliance on `current_exe()` which resolves to a deleted inode
+  on Linux after atomic rename. The subprocess runs with
+  `AMPLIHACK_NO_UPDATE_CHECK=1` and `AMPLIHACK_NONINTERACTIVE=1` to
+  prevent recursion and interactive prompts.
+
 - **Stale Python tool references across documentation (#666)** — All
   `orch_helper.py` and `session_tree.py` references in SKILL.md, tutorials,
   reference docs, and audit reports now point to their native Rust replacements

--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -23,6 +23,11 @@ pub enum Commands {
         /// Accepted for diagnostic scripts; install already prints phase-level detail
         #[arg(long)]
         verbose: bool,
+        /// Force a fresh network download of amplifier-bundle assets.
+        /// Used internally by `amplihack update` when spawning the new binary
+        /// as a post-update install subprocess (issue #683).
+        #[arg(long = "force-refresh", hide = true)]
+        force_refresh: bool,
     },
     /// Remove amplihack agents and tools
     Uninstall,

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -40,7 +40,8 @@ pub fn dispatch(command: Commands) -> Result<()> {
             local,
             interactive,
             verbose: _,
-        } => install::run_install(local, interactive, false),
+            force_refresh,
+        } => install::run_install(local, interactive, force_refresh),
         Commands::Uninstall => install::run_uninstall(),
         Commands::Launch {
             resume,

--- a/crates/amplihack-cli/src/update/check.rs
+++ b/crates/amplihack-cli/src/update/check.rs
@@ -90,14 +90,31 @@ pub fn run_update(skip_install: bool) -> Result<()> {
         "New version available: v{} -> v{}",
         CURRENT_VERSION, release.version
     );
-    super::install::download_and_replace(&release)?;
+    let installed_exe = super::install::download_and_replace(&release)?;
     write_cache(&cache_path()?, &release.version)?;
 
-    // Re-stage framework assets after binary swap (fix #249, #487).
+    // Re-stage framework assets after binary swap (fix #249, #487, #683).
     // The new binary may depend on updated assets in amplifier-bundle.
     // Users can opt out with --skip-install (alias --no-install).
+    //
+    // Issue #683: We must NOT call `run_install` in-process — that would
+    // execute the OLD binary's compiled-in code. Instead we spawn the NEW
+    // binary as a subprocess so the freshly-installed code runs.
     super::post_install::run_post_update_install(skip_install, || {
-        crate::commands::install::run_install(None, false, true)
+        let mut cmd = build_install_command(&installed_exe);
+        let status = cmd.status().with_context(|| {
+            format!(
+                "failed to spawn post-update install subprocess {}",
+                installed_exe.display()
+            )
+        })?;
+        if !status.success() {
+            bail!(
+                "post-update install subprocess {} exited with {status}",
+                installed_exe.display()
+            );
+        }
+        Ok(())
     })?;
     Ok(())
 }
@@ -328,4 +345,27 @@ fn print_update_notice(latest: &str) {
     eprintln!(
         "\x1b[33mA newer version of amplihack is available (v{latest}). Run 'amplihack update' to upgrade.\x1b[0m"
     );
+}
+
+/// Build a `Command` that re-execs the newly installed binary with
+/// `install --force-refresh` so the NEW binary's install code runs.
+///
+/// # Issue #683
+/// After `download_and_replace` writes the new binary to disk, we must NOT
+/// call `run_install` in-process (that runs OLD compiled-in code). Instead
+/// we spawn the new binary as a subprocess.
+///
+/// The `installed_exe` path comes from `download_and_replace`'s return value
+/// — never from `current_exe()`, which may resolve to a deleted inode after
+/// atomic rename on Linux.
+pub(super) fn build_install_command(installed_exe: &Path) -> std::process::Command {
+    let mut cmd = std::process::Command::new(installed_exe);
+    cmd.arg("install")
+        .arg("--force-refresh")
+        .env("AMPLIHACK_NO_UPDATE_CHECK", "1")
+        .env("AMPLIHACK_NONINTERACTIVE", "1")
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit());
+    cmd
 }

--- a/crates/amplihack-cli/src/update/install.rs
+++ b/crates/amplihack-cli/src/update/install.rs
@@ -43,7 +43,7 @@ pub(super) fn verify_sha256(archive_bytes: &[u8], checksum_url: &str) -> Result<
     Ok(())
 }
 
-pub(super) fn download_and_replace(release: &UpdateRelease) -> Result<()> {
+pub(super) fn download_and_replace(release: &UpdateRelease) -> Result<PathBuf> {
     let archive_bytes = super::network::http_get_with_retry(&release.asset_url)?;
 
     if let Some(checksum_url) = &release.checksum_url {
@@ -147,7 +147,7 @@ pub(super) fn download_and_replace(release: &UpdateRelease) -> Result<()> {
         let _ = fs::remove_file(&path);
     }
 
-    Ok(())
+    Ok(current_exe)
 }
 
 /// Invoke `<binary> --version` and confirm the output contains `expected`.

--- a/crates/amplihack-cli/src/update/tests/build_install_command.rs
+++ b/crates/amplihack-cli/src/update/tests/build_install_command.rs
@@ -1,0 +1,157 @@
+//! TDD tests for `build_install_command` (issue #683).
+//!
+//! These tests define the contract for the subprocess re-exec approach:
+//! after downloading a new binary, `run_update` must spawn the NEW binary
+//! as a subprocess with `install --force-refresh`, not call `run_install`
+//! in-process with the OLD binary's compiled-in code.
+//!
+//! ## Test status (TDD Step 7)
+//! - `uses_provided_binary_path` → PASSES (stub has correct program)
+//! - All other tests → FAIL (stub is missing args/env vars)
+//! - Tests will PASS once implementation is complete (Step 8)
+
+use std::path::PathBuf;
+
+use super::super::check::build_install_command;
+
+// ============================================================================
+// Program path tests
+// ============================================================================
+
+/// The function must use the exact path passed in, not `current_exe()`.
+/// On Linux, `current_exe()` resolves to `/proc/self/exe` which points to
+/// the deleted inode after atomic rename. Using the explicit path returned
+/// by `download_and_replace` avoids this.
+#[test]
+fn uses_provided_binary_path() {
+    let fake_path = PathBuf::from("/tmp/test-amplihack/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    assert_eq!(
+        cmd.get_program(),
+        fake_path.as_os_str(),
+        "must use the provided binary path, not current_exe() or a hardcoded path"
+    );
+}
+
+/// Edge case: paths containing spaces must be preserved exactly.
+/// The `Command` API handles quoting automatically, but we verify the
+/// path is passed through without modification.
+#[test]
+fn handles_path_with_spaces() {
+    let fake_path = PathBuf::from("/home/user name/local/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    assert_eq!(
+        cmd.get_program(),
+        fake_path.as_os_str(),
+        "must preserve paths with spaces exactly as provided"
+    );
+}
+
+// ============================================================================
+// Argument tests
+// ============================================================================
+
+/// The subprocess must pass `install` as the first argument (subcommand).
+#[test]
+fn includes_install_subcommand_arg() {
+    let fake_path = PathBuf::from("/usr/local/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+    assert!(
+        args.contains(&"install".to_string()),
+        "must include 'install' subcommand, got args: {args:?}"
+    );
+}
+
+/// The subprocess must pass `--force-refresh` so the new binary knows this
+/// install was triggered by an update (not a manual `amplihack install`).
+#[test]
+fn includes_force_refresh_flag() {
+    let fake_path = PathBuf::from("/usr/local/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+    assert!(
+        args.contains(&"--force-refresh".to_string()),
+        "must include '--force-refresh' flag, got args: {args:?}"
+    );
+}
+
+/// Arguments must be in the correct order: subcommand first, then flags.
+/// clap requires the subcommand name before any flags.
+#[test]
+fn args_in_correct_order() {
+    let fake_path = PathBuf::from("/usr/local/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+    let install_pos = args.iter().position(|a| a == "install");
+    let force_refresh_pos = args.iter().position(|a| a == "--force-refresh");
+    assert!(
+        install_pos.is_some() && force_refresh_pos.is_some(),
+        "both 'install' and '--force-refresh' must be present, got: {args:?}"
+    );
+    assert!(
+        install_pos.unwrap() < force_refresh_pos.unwrap(),
+        "'install' must come before '--force-refresh', got: {args:?}"
+    );
+}
+
+// ============================================================================
+// Environment variable tests
+// ============================================================================
+
+/// The subprocess must set `AMPLIHACK_NO_UPDATE_CHECK=1` to prevent the new
+/// binary from re-checking for updates (infinite recursion guard).
+#[test]
+fn sets_no_update_check_env() {
+    let fake_path = PathBuf::from("/usr/local/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    let envs: Vec<(String, Option<String>)> = cmd
+        .get_envs()
+        .map(|(k, v)| {
+            (
+                k.to_string_lossy().to_string(),
+                v.map(|v| v.to_string_lossy().to_string()),
+            )
+        })
+        .collect();
+    assert!(
+        envs.contains(&(
+            "AMPLIHACK_NO_UPDATE_CHECK".to_string(),
+            Some("1".to_string())
+        )),
+        "must set AMPLIHACK_NO_UPDATE_CHECK=1 to prevent update recursion, got envs: {envs:?}"
+    );
+}
+
+/// The subprocess must set `AMPLIHACK_NONINTERACTIVE=1` to suppress any
+/// interactive prompts during the automated install step.
+#[test]
+fn sets_noninteractive_env() {
+    let fake_path = PathBuf::from("/usr/local/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    let envs: Vec<(String, Option<String>)> = cmd
+        .get_envs()
+        .map(|(k, v)| {
+            (
+                k.to_string_lossy().to_string(),
+                v.map(|v| v.to_string_lossy().to_string()),
+            )
+        })
+        .collect();
+    assert!(
+        envs.contains(&(
+            "AMPLIHACK_NONINTERACTIVE".to_string(),
+            Some("1".to_string())
+        )),
+        "must set AMPLIHACK_NONINTERACTIVE=1 to suppress prompts, got envs: {envs:?}"
+    );
+}

--- a/crates/amplihack-cli/src/update/tests/mod.rs
+++ b/crates/amplihack-cli/src/update/tests/mod.rs
@@ -1,3 +1,4 @@
+mod build_install_command;
 mod classify_skip_reason;
 mod network;
 mod skip_line;

--- a/crates/amplihack-cli/tests/bugfix_install_tests.rs
+++ b/crates/amplihack-cli/tests/bugfix_install_tests.rs
@@ -168,10 +168,16 @@ fn update_check_source_includes_framework_restage() {
         run_update_body.contains("run_post_update_install"),
         "run_post_update_install() must be called inside run_update(), not elsewhere"
     );
-    // The closure passed to the helper must invoke the full install code path.
+    // Issue #683: run_update must NOT call run_install in-process after
+    // binary swap. The closure must use build_install_command to spawn the
+    // NEW binary as a subprocess instead.
     assert!(
-        run_update_body.contains("crate::commands::install::run_install"),
-        "the post-update install closure must call commands::install::run_install"
+        !run_update_body.contains("crate::commands::install::run_install"),
+        "run_update must NOT call run_install in-process (issue #683 fix)"
+    );
+    assert!(
+        run_update_body.contains("build_install_command"),
+        "run_update must use build_install_command to spawn the new binary as a subprocess"
     );
 }
 
@@ -349,5 +355,137 @@ fn clone_rs_error_mentions_both_markers() {
     assert!(
         bail_msg.contains(".claude") && bail_msg.contains("amplifier-bundle"),
         "error message must mention both .claude and amplifier-bundle, got: {bail_msg}"
+    );
+}
+
+// ============================================================================
+// Bug #683: run_update must re-exec NEW binary, not call old code in-process
+// ============================================================================
+
+#[test]
+fn download_and_replace_returns_pathbuf() {
+    // Contract (#683): download_and_replace must return Result<PathBuf>
+    // so run_update can pass the installed path to build_install_command.
+    // Returning Result<()> means the caller has no way to know where the
+    // new binary was written (current_exe() is unreliable after rename).
+    let install_src = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/update/install.rs"
+    ));
+    let fn_sig_start = install_src
+        .find("fn download_and_replace")
+        .expect("download_and_replace must exist");
+    // Grab enough of the signature to see the return type
+    let fn_sig = &install_src[fn_sig_start..(fn_sig_start + 200).min(install_src.len())];
+    assert!(
+        fn_sig.contains("Result<PathBuf>"),
+        "download_and_replace must return Result<PathBuf> (not Result<()>), got: {}",
+        fn_sig.lines().next().unwrap_or("")
+    );
+}
+
+#[test]
+fn run_update_captures_installed_path_from_download() {
+    // Contract (#683): run_update must capture the PathBuf returned by
+    // download_and_replace and pass it to the subprocess builder.
+    // Without this, the subprocess would need to call current_exe() which
+    // is unreliable on Linux after atomic rename.
+    let check_src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/update/check.rs"));
+    let run_update_start = check_src
+        .find("fn run_update(")
+        .expect("run_update must exist");
+    let run_update_body = &check_src[run_update_start..];
+    let next_fn = run_update_body[1..]
+        .find("\nfn ")
+        .unwrap_or(run_update_body.len());
+    let run_update_body = &run_update_body[..next_fn];
+    // Must assign download_and_replace result to a variable (let binding)
+    assert!(
+        run_update_body.contains("let "),
+        "run_update must capture download_and_replace return value in a let binding"
+    );
+    // Must pass the captured path to build_install_command
+    assert!(
+        run_update_body.contains("build_install_command"),
+        "run_update must pass installed path to build_install_command"
+    );
+}
+
+#[test]
+fn install_variant_has_hidden_force_refresh_flag() {
+    // Contract (#683): Commands::Install must have a hidden --force-refresh flag
+    // so the update subprocess can signal it was triggered by an update.
+    // This flag must be hidden from --help to avoid confusing users.
+    let cli_src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli_commands.rs"));
+
+    // Must have the field
+    assert!(
+        cli_src.contains("force_refresh"),
+        "Install variant must have a force_refresh field"
+    );
+    // Must be wired as --force-refresh CLI flag
+    assert!(
+        cli_src.contains("force-refresh"),
+        "Install variant must expose --force-refresh flag"
+    );
+    // Must be hidden from --help output
+    assert!(
+        cli_src.contains("hide = true") || cli_src.contains("hide=true"),
+        "--force-refresh must be hidden from --help output (internal flag)"
+    );
+}
+
+#[test]
+fn build_install_command_source_sets_recursion_guard() {
+    // Contract (#683): build_install_command must set AMPLIHACK_NO_UPDATE_CHECK
+    // and AMPLIHACK_NONINTERACTIVE env vars in the subprocess to prevent
+    // infinite recursion and suppress interactive prompts.
+    let check_src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/update/check.rs"));
+    let fn_start = check_src
+        .find("fn build_install_command")
+        .expect("build_install_command must exist in check.rs");
+    let fn_body = &check_src[fn_start..];
+    // Find the function's closing brace
+    let mut brace_depth = 0;
+    let mut fn_end = fn_body.len();
+    for (i, ch) in fn_body.char_indices() {
+        if ch == '{' {
+            brace_depth += 1;
+        }
+        if ch == '}' {
+            brace_depth -= 1;
+            if brace_depth == 0 {
+                fn_end = i + 1;
+                break;
+            }
+        }
+    }
+    let fn_body = &fn_body[..fn_end];
+    assert!(
+        fn_body.contains("AMPLIHACK_NO_UPDATE_CHECK"),
+        "build_install_command must set AMPLIHACK_NO_UPDATE_CHECK env var to prevent recursion"
+    );
+    assert!(
+        fn_body.contains("AMPLIHACK_NONINTERACTIVE"),
+        "build_install_command must set AMPLIHACK_NONINTERACTIVE env var to suppress prompts"
+    );
+}
+
+#[test]
+fn dispatch_passes_force_refresh_to_run_install() {
+    // Contract (#683): the dispatch function must destructure force_refresh
+    // from Commands::Install and pass it to run_install.
+    let dispatch_src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/commands/mod.rs"));
+    let install_dispatch = dispatch_src
+        .find("Commands::Install")
+        .expect("Commands::Install dispatch must exist");
+    let dispatch_body = &dispatch_src[install_dispatch..];
+    let next_command = dispatch_body[1..]
+        .find("Commands::")
+        .unwrap_or(dispatch_body.len());
+    let install_block = &dispatch_body[..next_command];
+    assert!(
+        install_block.contains("force_refresh"),
+        "dispatch must destructure and pass force_refresh to run_install"
     );
 }

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -21,6 +21,7 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 
 ## Update Check
 
+- [Post-Update Install — Re-exec New Binary](update-reexec-new-binary.md) — after `amplihack update` downloads a new binary, the post-update install step spawns the **new** binary as a subprocess instead of running the old binary's compiled-in install code (issue [#683](https://github.com/rysweet/amplihack-rs/issues/683)).
 - [Startup Self-Update Prompt — Subprocess-Safe Skip](startup-update-prompt-subprocess-safe.md) — startup self-update prompt skips automatically in CI, delegated agents, non-TTY stdin, with `--subprocess-safe`, or when `AMPLIHACK_NONINTERACTIVE` / `AMPLIHACK_AGENT_BINARY` is set; emits a single skip-line to stderr (issue [#625](https://github.com/rysweet/amplihack-rs/issues/625)).
 
 ## Workflow Recovery

--- a/docs/features/self-heal-asset-restage.md
+++ b/docs/features/self-heal-asset-restage.md
@@ -34,9 +34,9 @@ Every launch, before command dispatch, `amplihack` performs a startup-time
    The third argument (`force_refresh: false`) means self-heal prefers the
    local `~/.amplihack/amplifier-bundle/` if it exists, falling back to a
    network download only when no local source is found. This keeps startup
-   fast for the common case. For the post-update install path (where a fresh
-   download is required), see `update::check` which passes
-   `force_refresh: true`.
+   fast for the common case. For the post-update install path (where the
+   **new** binary is spawned as a subprocess with `--force-refresh`), see
+   [Post-Update Install — Re-exec New Binary](update-reexec-new-binary.md).
 4. On success, write the new version into the stamp file and emit a single
    line on stderr:
 

--- a/docs/features/update-reexec-new-binary.md
+++ b/docs/features/update-reexec-new-binary.md
@@ -1,0 +1,206 @@
+# Post-Update Install: Re-exec New Binary
+
+> [Home](../index.md) > [Features](README.md) > Post-Update Install Re-exec
+
+When `amplihack update` downloads a new binary, the post-update install step
+spawns the **new** binary as a subprocess rather than running the old binary's
+compiled-in install code. This ensures that fixes, asset changes, and
+configuration migrations shipped in the new version take effect immediately —
+without requiring the user to manually run `amplihack install` a second time.
+
+## Problem
+
+Issue [#683](https://github.com/rysweet/amplihack-rs/issues/683).
+
+`amplihack update` performs two steps:
+
+1. **Binary swap** — downloads and atomically replaces the on-disk binary.
+2. **Post-update install** — re-stages framework assets in `~/.amplihack`.
+
+Prior to this fix, step 2 called `crate::commands::install::run_install`
+**in-process**. Because the old binary was still the running process image,
+the install step executed the **old** binary's code — not the newly downloaded
+version's code. Any fixes shipped in the new binary (such as PR
+[#687](https://github.com/rysweet/amplihack-rs/pull/687) removing stale XPIA
+hook file verification) would not take effect until the user manually ran
+`amplihack install` with the new binary.
+
+The result was a class of "phantom failures": users ran `amplihack update`,
+saw a success message, but the old install code — with its old bugs — had
+just re-staged assets. The new binary's fixes were present on disk but had
+never executed.
+
+### Why `current_exe()` is unreliable after binary replacement
+
+On Linux, `/proc/self/exe` points to the running process's inode. After an
+atomic rename replaces the binary on disk, the old inode is still referenced
+by the running process. Resolving `std::env::current_exe()` may return a path
+with a ` (deleted)` suffix, or resolve to a different inode than the
+newly-written file. macOS exhibits a similar conceptual problem — the running
+process image remains the old executable regardless of filesystem changes.
+
+## How it works
+
+After `download_and_replace()` atomically installs the new binary,
+`run_update()` spawns the new binary as a child process instead of calling
+`run_install` in-process:
+
+```
+amplihack update
+  │
+  ├─ download_and_replace(&release)
+  │    → downloads, verifies SHA-256, atomic rename
+  │    → returns Result<PathBuf> with the installed binary path
+  │
+  ├─ write version cache
+  │
+  └─ run_post_update_install(skip_install, || { ... })
+       │
+       ├─ skip_install = true  → skip, return Ok(())
+       │
+       └─ skip_install = false →
+            build_install_command(&installed_exe)
+              → Command::new(installed_exe)
+              → args: ["install", "--force-refresh"]
+              → env: AMPLIHACK_NO_UPDATE_CHECK=1
+              → env: AMPLIHACK_NONINTERACTIVE=1
+            cmd.status()?
+              → spawns NEW binary as subprocess
+              → inherits stdin/stdout/stderr
+              → non-zero exit → bail with path + status
+```
+
+### Key design decisions
+
+1. **Explicit path, not `current_exe()`** — `download_and_replace()` returns
+   the destination `PathBuf` — the same path as `current_exe()`, resolved
+   before the atomic rename overwrites it — so the caller has a valid
+   filesystem path to the new binary without needing to re-resolve
+   `current_exe()` (which would point to a deleted inode on Linux). This path
+   is passed directly to `Command::new()`.
+
+2. **`--force-refresh` hidden flag** — The subprocess runs with
+   `amplihack install --force-refresh`, a hidden CLI flag that forces a fresh
+   network download of `amplifier-bundle/` assets instead of reusing stale
+   local copies. This flag is not shown in `--help` output; it exists solely
+   for the update→install subprocess path.
+
+3. **Recursion prevention** — The subprocess environment includes
+   `AMPLIHACK_NO_UPDATE_CHECK=1`, which prevents the child `amplihack install`
+   from triggering its own update check. Combined with `install` being in the
+   self-heal skip list (see [Self-Heal Asset Re-Stage](self-heal-asset-restage.md)),
+   this prevents infinite recursion.
+
+4. **Non-interactive** — `AMPLIHACK_NONINTERACTIVE=1` is set to suppress any
+   interactive prompts in the child process, since the update is already
+   user-initiated and no further consent is needed.
+
+5. **Inherited stdio** — `stdin`, `stdout`, and `stderr` are inherited so the
+   user sees install progress in real time. The subprocess behaves as if the
+   user ran `amplihack install` directly.
+
+### `--skip-install` bypass
+
+The existing `--skip-install` (alias `--no-install`) flag on
+`amplihack update` continues to work. When set, the entire post-update
+install step is skipped — no subprocess is spawned. The binary is updated
+on disk but framework assets are not re-staged:
+
+```sh
+# Update binary only, skip post-update install
+amplihack update --skip-install
+```
+
+Users can then run `amplihack install` manually at a time of their choosing.
+The [self-heal](self-heal-asset-restage.md) mechanism will also catch the
+version mismatch on the next launch and trigger an automatic re-install.
+
+## Failure modes
+
+### Subprocess exits non-zero
+
+The error message includes both the executable path and the exit status:
+
+```
+Error: post-update install subprocess /home/user/.local/bin/amplihack exited with exit status: 1
+```
+
+The binary update itself has already succeeded. The user can re-run
+`amplihack install` manually. The self-heal mechanism will also retry
+automatically on the next `amplihack` invocation.
+
+### New binary missing or not executable
+
+If the path returned by `download_and_replace()` does not exist or lacks
+execute permission, `Command::new().status()` returns an I/O error that
+propagates with full context. This should not happen in practice because
+`download_and_replace()` sets `0o755` permissions and uses atomic rename.
+
+### Old binary without `--force-refresh`
+
+If an older binary (pre-#683) is somehow spawned as the subprocess, it will
+not recognize the `--force-refresh` flag and clap will exit with an error.
+This is the correct behavior — it surfaces the version mismatch explicitly
+rather than silently running stale install code. The error message will
+include the unrecognized flag name.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| `crates/amplihack-cli/src/update/install.rs` | `download_and_replace()` returns `Result<PathBuf>` with the installed binary path (captured before atomic rename). |
+| `crates/amplihack-cli/src/update/check.rs` | `run_update()` captures the returned path, passes it to `build_install_command()`. The closure given to `run_post_update_install` spawns the subprocess and checks its exit status. |
+| `crates/amplihack-cli/src/update/check.rs` | `build_install_command(installed_exe: &Path) -> Command` — constructs the subprocess command with args and env vars. Visibility: `pub(super)` for testability. |
+| `crates/amplihack-cli/src/cli_commands.rs` | `Commands::Install` gains a hidden `--force-refresh` flag (`#[arg(long = "force-refresh", hide = true)]`). |
+| `crates/amplihack-cli/src/commands/mod.rs` | Destructures and passes `force_refresh` through to `run_install`. |
+| `crates/amplihack-cli/src/update/post_install.rs` | Unchanged. The closure injection pattern continues to work — the closure now spawns a subprocess instead of calling `run_install`. |
+
+No new crate dependencies introduced.
+
+## Testing
+
+| Test | Location | What it verifies |
+|------|----------|------------------|
+| `build_install_command_uses_provided_binary_path` | `update/tests/build_install_command.rs` | Subprocess targets the explicit path, not `current_exe()` |
+| `build_install_command_includes_install_and_force_refresh_args` | `update/tests/build_install_command.rs` | Args are `["install", "--force-refresh"]` in order |
+| `build_install_command_sets_no_update_check_env` | `update/tests/build_install_command.rs` | `AMPLIHACK_NO_UPDATE_CHECK=1` is set |
+| `build_install_command_sets_noninteractive_env` | `update/tests/build_install_command.rs` | `AMPLIHACK_NONINTERACTIVE=1` is set |
+| `update_check_source_includes_framework_restage` | `tests/bugfix_install_tests.rs` | Source-level assertion that `run_update` uses `build_install_command` (not `run_install` in-process) |
+| Existing `run_post_update_install` tests | `update/post_install.rs` | Skip-install bypass, closure invocation, error propagation — all still pass unchanged |
+
+## Interaction with related features
+
+### Self-heal asset re-stage
+
+The [self-heal](self-heal-asset-restage.md) mechanism acts as a safety net.
+If the post-update subprocess install fails for any reason, the next
+`amplihack` launch will detect the version-stamp mismatch and re-run install
+automatically. The self-heal path calls `run_install` **in-process** (not
+via subprocess), which is correct because there is no binary replacement in
+flight — the running binary IS the new binary by that point.
+
+The self-heal doc's reference to the post-update install path (line 37–39,
+`force_refresh: true`) remains accurate — the subprocess passes
+`--force-refresh` which has the same semantic effect.
+
+### Startup self-update prompt
+
+The [subprocess-safe skip](startup-update-prompt-subprocess-safe.md)
+mechanism prevents the post-update install subprocess from triggering its
+own update prompt. The `AMPLIHACK_NO_UPDATE_CHECK=1` env var set by
+`build_install_command` is one of the skip signals documented there.
+
+## See also
+
+- [Install Command Reference](../reference/install-command.md) — the install
+  procedure invoked by the subprocess.
+- [Self-Heal Asset Re-Stage](self-heal-asset-restage.md) — the startup-time
+  safety net that catches missed post-update installs.
+- [Startup Self-Update Prompt — Subprocess-Safe Skip](startup-update-prompt-subprocess-safe.md) —
+  how the update check is suppressed in the subprocess.
+- [Environment Variables Reference](../reference/environment-variables.md) —
+  `AMPLIHACK_NO_UPDATE_CHECK`, `AMPLIHACK_NONINTERACTIVE`.
+- Issue [#683](https://github.com/rysweet/amplihack-rs/issues/683) — the
+  bug report that motivated this change.
+- PR [#687](https://github.com/rysweet/amplihack-rs/pull/687) — the XPIA
+  hook removal that exposed the stale-code problem.

--- a/docs/reference/install-command.md
+++ b/docs/reference/install-command.md
@@ -38,6 +38,7 @@ fall back to a source build.
 | `--interactive` | `bool` | `false` | Launch a guided setup wizard that prompts for default tool, hook scope, and update-check preference. Requires a TTY; falls back to defaults with a warning if stdin is not a terminal. See [Interactive Install](../howto/interactive-install.md). |
 | `--local <PATH>` | `PathBuf` | absent | Install from a specific local directory instead of using the bundled source. The path must exist, be a directory, and contain a `.claude` subdirectory (at `<PATH>/.claude` or `<PATH>/../.claude`). Without `--local`, the installer uses bundled framework assets from the amplihack-rs source tree. |
 | `--verbose` | `bool` | `false` | Accepted for diagnostic scripts. The install command already emits phase-level diagnostics by default. |
+| `--force-refresh` | `bool` | `false` | **Hidden.** Forces a fresh network download of `amplifier-bundle/` assets, bypassing the local source resolution order (steps 1–4). Used internally by `amplihack update` when spawning the new binary as a post-update install subprocess. Not shown in `--help` output. See [Post-Update Install — Re-exec New Binary](../features/update-reexec-new-binary.md). |
 
 The `--interactive` and `--local` flags compose: `--interactive` controls configuration preferences while `--local` controls the framework source path.
 


### PR DESCRIPTION
## Problem

After `amplihack update` downloads and replaces the binary on disk, `run_update()` was calling `run_install()` **in-process** — executing the OLD binary's compiled-in code. This caused stale verification checks (e.g. deleted XPIA `.sh` files from PR #687) to fire on every update even after the fix was shipped in a newer version.

**Root cause**: `download_and_replace()` writes the new binary to disk, but the running process still has the old code in memory. Calling `crate::commands::install::run_install()` runs the OLD binary's install logic.

## Solution

Spawn the **NEW** binary as a subprocess instead of calling install in-process:

1. `download_and_replace()` now returns `Result<PathBuf>` — the installed binary path
2. `run_update()` captures this path and passes it to `build_install_command()`
3. `build_install_command()` creates a `Command` that runs `<new-binary> install --force-refresh`
4. Hidden `--force-refresh` flag added to Install command (internal use only)
5. Subprocess env sets `AMPLIHACK_NO_UPDATE_CHECK=1` and `AMPLIHACK_NONINTERACTIVE=1` to prevent recursion

## Test Coverage

- 7 unit tests for `build_install_command` contract (args, env vars, path handling)
- 6 integration tests verifying source-level invariants (return type, dispatch wiring, flag presence)

## Files Changed

| File | Change |
|------|--------|
| `update/check.rs` | `run_update` spawns subprocess; `build_install_command()` added |
| `update/install.rs` | `download_and_replace` returns `Result<PathBuf>` |
| `cli_commands.rs` | Hidden `--force-refresh` flag on Install |
| `commands/mod.rs` | Pass `force_refresh` through dispatch |
| `update/tests/build_install_command.rs` | 7 unit tests |
| `tests/bugfix_install_tests.rs` | 6 integration tests |

Closes #683