### PR TITLE
feat(recipe): improve recipe runner logging transparency and progress reporting

### DIFF
--- a/crates/amplihack-cli/src/cli_subcommands.rs
+++ b/crates/amplihack-cli/src/cli_subcommands.rs
@@ -377,6 +377,9 @@ pub enum RecipeCommands {
         /// Show detailed output
         #[arg(short, long)]
         verbose: bool,
+        /// Unsupported; progress is streamed to stderr by default.
+        #[arg(long = "progress")]
+        progress: bool,
         /// Output format
         #[arg(short, long, default_value = "table", value_parser = ["table", "json", "yaml"])]
         format: String,

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -516,18 +516,26 @@ fn dispatch_recipe(command: RecipeCommands) -> Result<()> {
             context,
             dry_run,
             verbose,
+            progress,
             format,
             working_dir,
             step_timeout,
-        } => recipe::run_recipe(
-            &recipe_path,
-            &context,
-            dry_run,
-            verbose,
-            &format,
-            working_dir.as_deref(),
-            step_timeout,
-        ),
+        } => {
+            if progress {
+                anyhow::bail!(
+                    "--progress is no longer supported; recipe progress is streamed to stderr by default"
+                );
+            }
+            recipe::run_recipe(
+                &recipe_path,
+                &context,
+                dry_run,
+                verbose,
+                &format,
+                working_dir.as_deref(),
+                step_timeout,
+            )
+        }
         RecipeCommands::List {
             recipe_dir,
             format,

--- a/crates/amplihack-cli/src/commands/recipe/mod.rs
+++ b/crates/amplihack-cli/src/commands/recipe/mod.rs
@@ -121,9 +121,21 @@ pub(crate) struct RecipeRunResult {
     pub(crate) step_results: Vec<RecipeRunStepResult>,
     #[serde(default)]
     pub(crate) context: JsonMap<String, JsonValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) elapsed_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) heartbeat_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) progress_summary: Option<JsonValue>,
+    #[serde(default, flatten)]
+    pub(crate) extra: JsonMap<String, JsonValue>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct RecipeRunStepResult {
     pub(crate) step_id: String,
     pub(crate) status: String,
@@ -131,6 +143,22 @@ pub(crate) struct RecipeRunStepResult {
     pub(crate) output: String,
     #[serde(default)]
     pub(crate) error: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) step_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) elapsed_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) heartbeat_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) child: Option<JsonValue>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) recent_stdout: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) recent_stderr: Vec<String>,
+    #[serde(default, flatten)]
+    pub(crate) extra: JsonMap<String, JsonValue>,
 }
 
 pub(crate) fn default_version() -> String {

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -1,11 +1,13 @@
 use super::*;
 use crate::env_builder::{EnvBuilder, active_agent_binary};
+use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Write as IoWrite};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
 const STDERR_TAIL_LINES: usize = 5;
+const CAPTURED_STDERR_LINES: usize = 200;
 
 /// Threshold in bytes for total `--set` argument size before we switch
 /// to passing context via a temp file. Well under the typical Linux
@@ -16,7 +18,7 @@ pub(super) fn execute_recipe_via_rust(
     recipe_path: &Path,
     context: &BTreeMap<String, String>,
     dry_run: bool,
-    verbose: bool,
+    _verbose: bool,
     working_dir: &Path,
     search_dirs: &[PathBuf],
     step_timeout: Option<u64>,
@@ -45,13 +47,6 @@ pub(super) fn execute_recipe_via_rust(
         command.arg("--dry-run");
     }
 
-    // Issue #357: propagate --progress so step transitions are visible on
-    // stderr in real time. Without this, the only signal the user sees
-    // before the recipe finishes is the single "Executing recipe: …" line.
-    if verbose {
-        command.arg("--progress");
-    }
-
     // Pass context as a file when the total size would risk E2BIG (os error 7).
     // The temp file is kept alive until command.output() completes.
     let _context_file = pass_context(&mut command, context)?;
@@ -74,21 +69,7 @@ pub(super) fn execute_recipe_via_rust(
 
     env_builder.apply_to_command(&mut command);
 
-    if verbose {
-        spawn_with_streaming_stderr(command)
-    } else {
-        let output = command
-            .output()
-            .context("failed to spawn recipe-runner-rs")?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        parse_recipe_output(&stdout, &stderr, output.status.success()).with_context(|| {
-            format!(
-                "recipe-runner-rs exited with {}",
-                exit_status_label(&output.status)
-            )
-        })
-    }
+    spawn_with_streaming_stderr(command)
 }
 
 /// Spawn the runner with stdout captured (we need to parse JSON from it)
@@ -101,7 +82,7 @@ fn spawn_with_streaming_stderr(mut command: Command) -> Result<RecipeRunResult> 
         .spawn()
         .context("failed to spawn recipe-runner-rs")?;
 
-    let captured_stderr: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_stderr: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(VecDeque::new()));
     let stderr_handle = child.stderr.take().expect("piped stderr");
     let captured_clone = Arc::clone(&captured_stderr);
     let pump = thread::spawn(move || {
@@ -119,10 +100,7 @@ fn spawn_with_streaming_stderr(mut command: Command) -> Result<RecipeRunResult> 
                     let line = String::from_utf8_lossy(&buf);
                     let trimmed = line.trim_end_matches(['\r', '\n']);
                     let _ = writeln!(stderr.lock(), "{trimmed}");
-                    captured_clone
-                        .lock()
-                        .expect("stderr mutex")
-                        .push(trimmed.to_string());
+                    push_bounded_stderr_line(&captured_clone, trimmed.to_string());
                 }
                 // I/O error reading from the pipe: log and stop pumping —
                 // we MUST NOT spin or leak the thread, but the child will
@@ -145,13 +123,21 @@ fn spawn_with_streaming_stderr(mut command: Command) -> Result<RecipeRunResult> 
     pump.join().expect("stderr pump thread panicked");
 
     let captured = captured_stderr.lock().expect("stderr mutex");
-    let stderr_joined = captured.join("\n");
+    let stderr_joined = captured.iter().cloned().collect::<Vec<_>>().join("\n");
     parse_recipe_output(&stdout_buf, &stderr_joined, status.success()).with_context(|| {
         format!(
             "recipe-runner-rs exited with {}",
             exit_status_label(&status)
         )
     })
+}
+
+fn push_bounded_stderr_line(captured: &Arc<Mutex<VecDeque<String>>>, line: String) {
+    let mut captured = captured.lock().expect("stderr mutex");
+    if captured.len() == CAPTURED_STDERR_LINES {
+        captured.pop_front();
+    }
+    captured.push_back(line);
 }
 
 /// Pure parser for recipe-runner-rs subprocess output.

--- a/crates/amplihack-cli/src/commands/recipe/run/format.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/format.rs
@@ -1,6 +1,8 @@
 use super::super::*;
 
 const MAX_OUTPUT_LENGTH: usize = 200;
+const MAX_RECENT_SNIPPET_LINES: usize = 5;
+const MAX_RECENT_SNIPPET_CHARS: usize = 300;
 
 pub(super) fn format_recipe_run_result(
     result: &RecipeRunResult,
@@ -9,69 +11,22 @@ pub(super) fn format_recipe_run_result(
 ) -> Result<String> {
     match format {
         OutputFormat::Json => {
-            let mut data = JsonMap::new();
-            data.insert(
-                "recipe_name".to_string(),
-                JsonValue::String(result.recipe_name.clone()),
-            );
-            data.insert("success".to_string(), JsonValue::Bool(result.success));
-            data.insert(
-                "step_results".to_string(),
-                JsonValue::Array(
-                    result
-                        .step_results
-                        .iter()
-                        .map(|step| {
-                            json!({
-                                "step_id": step.step_id,
-                                "status": step.status,
-                                "output": step.output,
-                                "error": step.error,
-                            })
-                        })
-                        .collect(),
-                ),
-            );
-            if show_context && !result.context.is_empty() {
-                data.insert(
-                    "context".to_string(),
-                    JsonValue::Object(result.context.clone()),
-                );
+            let mut data = serde_json::to_value(result)?
+                .as_object()
+                .cloned()
+                .unwrap_or_default();
+            if !show_context || result.context.is_empty() {
+                data.remove("context");
             }
             Ok(serde_json::to_string_pretty(&JsonValue::Object(data))?)
         }
         OutputFormat::Yaml => {
-            let mut data = JsonMap::new();
-            data.insert(
-                "recipe_name".to_string(),
-                JsonValue::String(result.recipe_name.clone()),
-            );
-            data.insert("success".to_string(), JsonValue::Bool(result.success));
-            data.insert(
-                "step_results".to_string(),
-                JsonValue::Array(
-                    result
-                        .step_results
-                        .iter()
-                        .map(|step| {
-                            JsonValue::Object(JsonMap::from_iter([
-                                (
-                                    "step_id".to_string(),
-                                    JsonValue::String(step.step_id.clone()),
-                                ),
-                                ("status".to_string(), JsonValue::String(step.status.clone())),
-                                ("output".to_string(), JsonValue::String(step.output.clone())),
-                                ("error".to_string(), JsonValue::String(step.error.clone())),
-                            ]))
-                        })
-                        .collect(),
-                ),
-            );
-            if show_context && !result.context.is_empty() {
-                data.insert(
-                    "context".to_string(),
-                    JsonValue::Object(result.context.clone()),
-                );
+            let mut data = serde_json::to_value(result)?
+                .as_object()
+                .cloned()
+                .unwrap_or_default();
+            if !show_context || result.context.is_empty() {
+                data.remove("context");
             }
             Ok(serde_yaml::to_string(&JsonValue::Object(data))?)
         }
@@ -106,9 +61,32 @@ fn format_recipe_run_table(result: &RecipeRunResult, show_context: bool) -> Stri
             "skipped" => "⊘",
             _ => "?",
         };
+        let step_label = match &step.step_name {
+            Some(name) if !name.is_empty() => format!("{} ({name})", step.step_id),
+            _ => step.step_id.clone(),
+        };
+        let mut details = Vec::new();
+        if let Some(phase) = &step.phase
+            && !phase.is_empty()
+        {
+            details.push(format!("phase: {phase}"));
+        }
+        if let Some(elapsed_ms) = step.elapsed_ms {
+            details.push(format!("elapsed: {}", format_elapsed(elapsed_ms)));
+        }
+        if let Some(child) = &step.child
+            && let Some(label) = format_child(child)
+        {
+            details.push(format!("child: {label}"));
+        }
+        let detail_suffix = if details.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", details.join(", "))
+        };
         lines.push(format!(
-            "  {status_symbol} {}: {}",
-            step.step_id, step.status
+            "  {status_symbol} {step_label}: {}{detail_suffix}",
+            step.status
         ));
 
         if !step.output.is_empty() {
@@ -135,6 +113,8 @@ fn format_recipe_run_table(result: &RecipeRunResult, show_context: bool) -> Stri
         if !step.error.is_empty() {
             lines.push(format!("    Error: {}", step.error));
         }
+        append_recent_snippet_lines(&mut lines, "Recent stdout", &step.recent_stdout);
+        append_recent_snippet_lines(&mut lines, "Recent stderr", &step.recent_stderr);
     }
 
     if show_context && !result.context.is_empty() {
@@ -146,6 +126,58 @@ fn format_recipe_run_table(result: &RecipeRunResult, show_context: bool) -> Stri
     }
 
     lines.join("\n")
+}
+
+fn format_elapsed(elapsed_ms: u64) -> String {
+    if elapsed_ms >= 1_000 && elapsed_ms.is_multiple_of(1_000) {
+        format!("{}s", elapsed_ms / 1_000)
+    } else if elapsed_ms >= 1_000 {
+        format!("{:.1}s", elapsed_ms as f64 / 1_000.0)
+    } else {
+        format!("{elapsed_ms}ms")
+    }
+}
+
+fn format_child(child: &JsonValue) -> Option<String> {
+    match child {
+        JsonValue::String(value) if !value.is_empty() => Some(value.clone()),
+        JsonValue::Object(map) => {
+            let kind = map.get("kind").and_then(JsonValue::as_str).unwrap_or("");
+            let name = map.get("name").and_then(JsonValue::as_str).unwrap_or("");
+            match (kind.is_empty(), name.is_empty()) {
+                (false, false) => Some(format!("{kind} {name}")),
+                (false, true) => Some(kind.to_string()),
+                (true, false) => Some(name.to_string()),
+                (true, true) => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn append_recent_snippet_lines(lines: &mut Vec<String>, label: &str, snippets: &[String]) {
+    if snippets.is_empty() {
+        return;
+    }
+
+    lines.push(format!("    {label}:"));
+    let start = snippets.len().saturating_sub(MAX_RECENT_SNIPPET_LINES);
+    for snippet in &snippets[start..] {
+        lines.push(format!("      {}", truncate_snippet(snippet)));
+    }
+}
+
+fn truncate_snippet(value: &str) -> String {
+    if value.chars().count() <= MAX_RECENT_SNIPPET_CHARS {
+        return value.to_string();
+    }
+    format!(
+        "{}... (truncated)",
+        value
+            .chars()
+            .take(MAX_RECENT_SNIPPET_CHARS)
+            .collect::<String>()
+    )
 }
 
 fn json_scalar_to_string(value: &JsonValue) -> String {

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
@@ -817,6 +817,174 @@ fn parse_valid_json_with_unknown_fields_succeeds() {
     assert!(result.success);
 }
 
+#[test]
+fn parse_and_format_preserves_additive_transparency_fields() {
+    let stdout = r#"{
+        "recipe_name": "transparent-demo",
+        "success": false,
+        "status": "failed",
+        "phase": "agent",
+        "elapsed_ms": 91234,
+        "heartbeat_at": "2026-06-03T18:25:41Z",
+        "progress_summary": {
+            "phase": "agent",
+            "status": "running",
+            "heartbeat_count": 3
+        },
+        "step_results": [
+            {
+                "step_id": "step-07-tdd",
+                "step_name": "TDD - Write Tests First",
+                "status": "failed",
+                "phase": "agent",
+                "elapsed_ms": 45678,
+                "child": { "kind": "agent", "name": "builder" },
+                "recent_stdout": ["stdout tail line"],
+                "recent_stderr": ["stderr tail line"],
+                "error": "agent failed"
+            }
+        ],
+        "context": {}
+    }"#;
+
+    let result =
+        execute::parse_recipe_output(stdout, "", false).expect("additive JSON fields must parse");
+    let formatted = format::format_recipe_run_result(&result, OutputFormat::Json, false)
+        .expect("formatting parsed result as JSON must succeed");
+    let parsed: JsonValue =
+        serde_json::from_str(&formatted).expect("formatted JSON must remain valid JSON");
+
+    assert_eq!(
+        parsed["status"].as_str(),
+        Some("failed"),
+        "top-level additive status must be preserved in formatted JSON: {formatted}",
+    );
+    assert_eq!(
+        parsed["phase"].as_str(),
+        Some("agent"),
+        "top-level additive phase must be preserved in formatted JSON: {formatted}",
+    );
+    assert_eq!(
+        parsed["step_results"][0]["step_name"].as_str(),
+        Some("TDD - Write Tests First"),
+        "step name must be preserved in formatted JSON: {formatted}",
+    );
+    assert_eq!(
+        parsed["step_results"][0]["child"]["name"].as_str(),
+        Some("builder"),
+        "child identity must be preserved in formatted JSON: {formatted}",
+    );
+    assert_eq!(
+        parsed["step_results"][0]["recent_stderr"][0].as_str(),
+        Some("stderr tail line"),
+        "recent stderr snippets must be preserved in formatted JSON: {formatted}",
+    );
+}
+
+#[test]
+fn failure_table_surfaces_step_timing_child_and_recent_output() {
+    let stdout = r#"{
+        "recipe_name": "transparent-demo",
+        "success": false,
+        "step_results": [
+            {
+                "step_id": "step-08-implementation",
+                "step_name": "Implementation",
+                "status": "failed",
+                "phase": "agent",
+                "elapsed_ms": 65000,
+                "child": { "kind": "agent", "name": "builder" },
+                "recent_stdout": ["compiled 4 crates"],
+                "recent_stderr": ["error[E0425]: cannot find value `x`"],
+                "error": "step failed"
+            }
+        ],
+        "context": {}
+    }"#;
+
+    let result =
+        execute::parse_recipe_output(stdout, "", false).expect("additive JSON fields must parse");
+    let table = format::format_recipe_run_result(&result, OutputFormat::Table, false)
+        .expect("formatting parsed result as table must succeed");
+
+    assert!(
+        table.contains("Implementation"),
+        "failure table must include human step name for actionable context. Got:\n{table}",
+    );
+    assert!(
+        table.contains("65s") || table.contains("65000ms"),
+        "failure table must include elapsed time. Got:\n{table}",
+    );
+    assert!(
+        table.contains("builder"),
+        "failure table must include child agent/subprocess identity. Got:\n{table}",
+    );
+    assert!(
+        table.contains("cannot find value"),
+        "failure table must include bounded recent stderr snippet. Got:\n{table}",
+    );
+    assert!(
+        table.contains("compiled 4 crates"),
+        "failure table must include bounded recent stdout snippet. Got:\n{table}",
+    );
+}
+
+#[test]
+fn failure_table_bounds_recent_output_snippets() {
+    let stderr_lines = (0..40)
+        .map(|i| format!("stderr tail line {i:02}"))
+        .collect::<Vec<_>>();
+    let stdout_lines = (0..40)
+        .map(|i| format!("stdout tail line {i:02}"))
+        .collect::<Vec<_>>();
+    let stdout = serde_json::json!({
+        "recipe_name": "bounded-demo",
+        "success": false,
+        "step_results": [
+            {
+                "step_id": "long-agent-step",
+                "step_name": "Long Agent Step",
+                "status": "failed",
+                "phase": "agent",
+                "elapsed_ms": 120000,
+                "child": { "kind": "agent", "name": "builder" },
+                "recent_stdout": stdout_lines,
+                "recent_stderr": stderr_lines,
+                "error": "step failed"
+            }
+        ],
+        "context": {}
+    })
+    .to_string();
+
+    let result = execute::parse_recipe_output(&stdout, "", false)
+        .expect("additive JSON with long snippets must parse");
+    let table = format::format_recipe_run_result(&result, OutputFormat::Table, false)
+        .expect("formatting parsed result as table must succeed");
+
+    assert!(
+        table.contains("stderr tail line 39"),
+        "bounded snippet display should keep the newest stderr lines. Got:\n{table}",
+    );
+    assert!(
+        table.contains("stdout tail line 39"),
+        "bounded snippet display should keep the newest stdout lines. Got:\n{table}",
+    );
+    assert!(
+        !table.contains("stderr tail line 00"),
+        "bounded snippet display must omit oldest stderr lines instead of dumping all child output. Got:\n{table}",
+    );
+    assert!(
+        !table.contains("stdout tail line 00"),
+        "bounded snippet display must omit oldest stdout lines instead of dumping all child output. Got:\n{table}",
+    );
+    assert!(
+        table.len() < 4_000,
+        "bounded snippet display must stay compact; got {} bytes:\n{table}",
+        table.len(),
+    );
+}
+
 /// Whitespace-only stdout (e.g. trailing newline) must be treated as empty.
 #[test]
 fn parse_whitespace_only_stdout_success_returns_default() {
@@ -825,11 +993,12 @@ fn parse_whitespace_only_stdout_success_returns_default() {
     assert!(result.success);
 }
 
-// Issue #357: when verbose=true, --progress is propagated AND child stderr is
-// streamed live (not buffered until the child exits).
+// Issue #691: recipe-runner-rs owns progress emission. The CLI must not pass
+// the old unsupported --progress flag; it should forward child stderr by
+// default instead.
 #[test]
 #[cfg(unix)]
-fn test_execute_recipe_via_rust_verbose_passes_progress_flag_to_child() {
+fn test_execute_recipe_via_rust_verbose_does_not_pass_progress_flag_to_child() {
     let _guard = crate::test_support::home_env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -874,8 +1043,8 @@ fn test_execute_recipe_via_rust_verbose_passes_progress_flag_to_child() {
     result.expect("verbose mode with empty stdout success must not error");
     let logged = std::fs::read_to_string(&arg_log).expect("argv log must exist");
     assert!(
-        logged.lines().any(|l| l == "--progress"),
-        "verbose=true must propagate --progress to recipe-runner-rs.\nargv was:\n{logged}",
+        !logged.lines().any(|l| l == "--progress"),
+        "verbose=true must not pass unsupported --progress; progress is emitted by recipe-runner-rs by default.\nargv was:\n{logged}",
     );
 }
 

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_format.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_format.rs
@@ -21,8 +21,10 @@ fn make_result(success: bool) -> RecipeRunResult {
             } else {
                 "something broke".to_string()
             },
+            ..Default::default()
         }],
         context: Default::default(),
+        ..Default::default()
     }
 }
 
@@ -103,21 +105,25 @@ fn test_format_recipe_run_result_table_step_symbols() {
                 status: "completed".to_string(),
                 output: String::new(),
                 error: String::new(),
+                ..Default::default()
             },
             RecipeRunStepResult {
                 step_id: "s2".to_string(),
                 status: "skipped".to_string(),
                 output: String::new(),
                 error: String::new(),
+                ..Default::default()
             },
             RecipeRunStepResult {
                 step_id: "s3".to_string(),
                 status: "failed".to_string(),
                 output: String::new(),
                 error: String::new(),
+                ..Default::default()
             },
         ],
         context: Default::default(),
+        ..Default::default()
     };
     let table = format::format_recipe_run_result(&result, OutputFormat::Table, false)
         .expect("format failed");

--- a/docs/concepts/recipe-execution-flow.md
+++ b/docs/concepts/recipe-execution-flow.md
@@ -5,9 +5,9 @@ step-by-step, including the hook dispatch lifecycle.
 
 ## Overview
 
-A *recipe* is a YAML file describing a sequence of steps.  The Rust
-runner resolves the recipe, launches a Claude session per step, streams
-output, and records the result before moving to the next step.
+A *recipe* is a YAML file describing a sequence of steps. The Rust runner
+resolves the recipe, runs each agent, bash, or nested-recipe step, emits live
+progress, and records the result before moving to the next step.
 
 ## Execution Flow Diagram
 
@@ -24,8 +24,8 @@ flowchart TD
 
     subgraph StepLoop ["Per-step execution loop"]
         H[Select next pending step] --> I[Emit pre-step hook\nStepStart event]
-        I --> J[Spawn Claude session\nwith step prompt]
-        J --> K[Stream output to TTY]
+        I -->         J[Run agent, bash, or nested recipe\nwith step context]
+        J --> K[Emit stderr progress\nand bounded output snippets]
         K --> L{Step outcome}
         L -- success --> M[Emit post-step hook\nStepEnd event]
         L -- failure --> N{Retry policy?}
@@ -45,11 +45,13 @@ flowchart TD
 |---|---|
 | Steps run sequentially by default | Deterministic output; easier to reason about |
 | `$RECIPE_VAR_*` resolved before execution | Fail fast on missing variables |
-| Pre/post step hooks | Allow Python agents to react without modifying the runner |
+| Pre/post step hooks | Allow hook consumers to react without modifying the runner |
 | Retry policy per step | Transient Claude failures should not abort long recipes |
 | Non-interactive env injected for all shell steps | Tools like `apt`, `npm`, and git credential helpers hang without TTY; injecting `CI=true`, `NONINTERACTIVE=1`, and `DEBIAN_FRONTEND=noninteractive` prevents this |
 | Agent steps receive `working_directory` in context | Without it, agents may write files in an unexpected location |
-| Python prerequisite check before shell steps | A missing `python3` at step N wastes N-1 steps of execution time; fail-fast check catches this in under 1 second |
+| Shell prerequisite checks | Missing required interpreters or host tools should fail at the step boundary with an actionable error |
+| Progress uses stderr; final results use stdout | Humans can watch live step transitions and heartbeats while scripts safely parse the final structured output |
+| Child output snippets are bounded | Failures include recent stdout/stderr context without allowing noisy subprocesses to flood logs |
 
 ## Environment Hardening
 
@@ -61,13 +63,30 @@ Every shell subprocess receives `HOME`, `PATH`, `NONINTERACTIVE=1`, `DEBIAN_FRON
 
 Command bodies up to 64 KiB are passed inline via `bash -c <body>`. Larger bodies are written to a tempfile and executed as `bash <path>` to avoid `Argument list too long (E2BIG)` from kernel `ARG_MAX` (~128 KiB on Linux). Both paths receive identical environment, working directory, and stdio handling; only the argv shape differs.
 
-If the shell command references `python3` or `python `, the executor runs a pre-flight `python3 --version` check and aborts the step immediately if Python is unavailable.
+If a shell command depends on an interpreter or host tool, the executor should
+check that prerequisite at the step boundary and abort the step immediately with
+an actionable error when the tool is unavailable.
 
 See [Recipe Executor Environment](../reference/recipe-executor-environment.md) for the full specification.
 
 ### Agent steps
 
 The context map passed to the agent backend is augmented with `working_directory` (from the recipe's configured working dir) and `NONINTERACTIVE=1`. These entries use insert-if-absent semantics, so recipe YAML can still override them explicitly.
+
+## Progress and logging
+
+During the step loop, the runner emits lifecycle progress to stderr:
+
+- recipe started/completed/failed
+- step started/completed/failed/skipped
+- rate-limited heartbeat lines for long-running active steps
+- bounded recent stdout/stderr snippets when a child process or agent fails
+
+The final recipe result remains on stdout in the selected `--format`. This lets
+callers redirect or parse stdout without losing human-readable progress.
+
+See [Recipe Runner Logging Reference](../reference/recipe-runner-logging.md) for
+the complete event and JSON schema.
 
 ## Related Concepts
 

--- a/docs/concepts/recipe-runner-architecture.md
+++ b/docs/concepts/recipe-runner-architecture.md
@@ -9,6 +9,7 @@ it, and how recipe execution stays predictable.
 - [Binary resolution](#binary-resolution)
 - [Invocation contract](#invocation-contract)
 - [Data flow](#data-flow)
+- [Logging responsibility split](#logging-responsibility-split)
 - [What amplihack does NOT do](#what-amplihack-does-not-do)
 - [Operational contract](#operational-contract)
 
@@ -62,7 +63,9 @@ The runner:
 1. Resolves the recipe YAML from the search path
 2. Validates schema and step dependencies
 3. Executes steps sequentially, threading context variables between them
-4. Returns exit code 0 on success, 1 on failure
+4. Streams live progress, heartbeat, and failure diagnostics to stderr
+5. Writes the final structured result to stdout
+6. Returns exit code 0 on success, 1 on failure
 
 ## Data flow
 
@@ -82,6 +85,23 @@ The runner:
 
 Context variables flow forward: each step's `output` key becomes available
 to subsequent steps via `{{variable_name}}` interpolation.
+
+## Logging responsibility split
+
+`recipe-runner-rs` owns execution transparency because it is the process that
+knows which step, child process, agent, or nested recipe is active.
+
+| Component | Responsibility |
+| --- | --- |
+| `recipe-runner-rs` | Emit step lifecycle progress, heartbeats, JSONL log events, bounded recent stdout/stderr snippets, and failure context |
+| `amplihack` CLI | Resolve and launch the runner, forward stderr progress by default, preserve stdout for final structured output, and preserve additive JSON fields without requiring them |
+
+This split keeps recipe semantics inside the runner while letting the CLI remain
+a stable process supervisor. The CLI must not reinterpret step order or child
+state. It forwards the runner's stderr progress, captures stdout for the final
+`--format` result, and displays optional diagnostic fields when present. When
+the runner emits additive diagnostic fields, the CLI must not drop them while
+formatting JSON or YAML output.
 
 ## What amplihack does NOT do
 
@@ -108,5 +128,6 @@ The goal is a single native recipe runner. Consolidation requires:
 ## Related
 
 - [amplihack recipe](../reference/recipe-command.md) — CLI reference for the `recipe` subcommand
+- [Recipe Runner Logging](../reference/recipe-runner-logging.md) — Progress, heartbeat, snippets, and JSON schema
 - [Recipe Execution Flow](./recipe-execution-flow.md) — Step-by-step execution semantics
 - [Recipe Executor Environment](../reference/recipe-executor-environment.md) — Environment variables for recipe steps

--- a/docs/concepts/rust-runner-execution-architecture.md
+++ b/docs/concepts/rust-runner-execution-architecture.md
@@ -1,234 +1,103 @@
 # Rust Runner Execution Architecture
 
-How the `amplihack` Rust CLI binary manages subprocess I/O, progress tracking, and safe file operations for recipe execution.
+How `amplihack recipe run` and `recipe-runner-rs` divide responsibility for
+observable recipe execution.
+
+**Status:** Planned finished-state architecture for recipe-runner transparency.
 
 ## Contents
 
 - [Overview](#overview)
-- [Subprocess I/O Model](#subprocess-io-model)
-- [Progress Tracking](#progress-tracking)
-- [JSONL Step-Transition Events](#jsonl-step-transition-events)
-- [Atomic File Writes](#atomic-file-writes)
-- [Security Design](#security-design)
-- [Workstream Integration](#workstream-integration)
-- [Log Files](#log-files)
-
----
+- [Stream ownership](#stream-ownership)
+- [Progress event model](#progress-event-model)
+- [Bounded output capture](#bounded-output-capture)
+- [Wrapper preservation](#wrapper-preservation)
+- [Related](#related)
 
 ## Overview
 
-The amplihack recipe runner delegates execution to a compiled Rust binary (`recipe-runner-rs`). Python manages:
+Recipe execution has two layers:
 
-1. **Launching** the binary with a filtered environment
-2. **Streaming** its stdout/stderr in real time without blocking
-3. **Detecting** step-transition markers on stderr and writing progress JSON
-4. **Tee-ing** all output to a persistent log file
-5. **Reporting** a fully-typed `RecipeResult` to the caller
+| Layer | Responsibility |
+| --- | --- |
+| `amplihack` CLI | Resolve the recipe and runner binary, pass context, forward stderr, format the final result, and propagate exit status. |
+| `recipe-runner-rs` | Execute steps, know active child state, emit lifecycle progress and heartbeats, retain bounded recent output, and produce the structured result. |
 
-The execution layer lives in `rust_runner_execution.py`; the caller (`rust_runner.py`) handles context spilling, binary selection, and recipe name resolution before handing off to this layer.
+The runner owns execution transparency because it is the only process that knows
+which step, agent, subprocess, or nested recipe is active. The CLI must not infer
+step state by parsing human-readable text.
 
----
+## Stream ownership
 
-## Subprocess I/O Model
-
-```
-                ┌──────────────────────────────────────┐
-                │  recipe-runner-rs (Rust binary)       │
-                │  stdout ──────────────┐               │
-                │  stderr (markers+log) │               │
-                └───────────────────────┼───────────────┘
-                                        │
-                        ┌───────────────▼──────────────────┐
-                        │  _stream_process_output_with_     │
-                        │  progress()  (two threads)        │
-                        │                                   │
-                        │  stdout thread ──► stdout_buf     │
-                        │  stderr thread ──► stderr_buf     │
-                        │               └──► step detector  │
-                        │               └──► log file tee   │
-                        └───────────────────────────────────┘
+```mermaid
+flowchart LR
+    CLI[amplihack recipe run] --> RUNNER[recipe-runner-rs]
+    RUNNER -- "stderr: progress, heartbeats, diagnostics" --> STDERR[terminal / CI log]
+    RUNNER -- "stdout: final JSON result" --> CLI
+    CLI -- "stdout: requested format" --> STDOUT[pipeline / user]
 ```
 
-The output streaming function spawns **two threads** — one per file descriptor — that drain output continuously. Neither thread blocks the main thread, which waits on `process.wait()`. Both threads are joined before the function returns, ensuring all output is captured even if the process exits quickly.
-
-Thread safety for log file writes is enforced by a single `threading.Lock` shared between both reader threads.
-
-### Step marker detection
-
-The Rust binary signals step transitions by printing Unicode markers to stderr:
-
-| Marker       | Event          |
-| ------------ | -------------- |
-| `▶` (U+25B6) | Step started   |
-| `✓` (U+2713) | Step completed |
-| `✗` (U+2717) | Step failed    |
-| `⊘` (U+2298) | Step skipped   |
-
-When a stderr line starts with a recognized marker the streaming thread:
-
-1. Increments the step counter (only for `▶` — other markers reuse the current step index)
-2. Calls `_write_progress_file()` with the new step metadata and status
-3. Calls `emit_step_transition()` to emit a JSONL marker to stderr
-
----
-
-## Progress Tracking
-
-Progress is tracked in two places:
-
-### Main progress file
-
-Path: `/tmp/amplihack-progress-<recipe_name>-<pid>.json`
-
-Written atomically after each step transition (see [Atomic File Writes](#atomic-file-writes)). Other processes (e.g. the workstream orchestrator, `amplihack recipe status`) read this file to display live progress without IPC.
-
-```json
-{
-  "recipe_name": "smart-orchestrator",
-  "current_step": 2,
-  "total_steps": 0,
-  "step_name": "Classify task type",
-  "elapsed_seconds": 18.4,
-  "status": "running",
-  "pid": 55321,
-  "updated_at": 1743554400.0
-}
-```
-
-> **Note:** `total_steps` is always `0` — the Python streaming layer does not know the total step count. Treat `0` as "unknown".
-
-### Hot-path path caching
-
-`_write_progress_file()` accepts optional `_cached_path` and `_cached_sidecar_path` keyword arguments. When provided, the function skips the `_progress_file_path()` computation entirely. The streaming loop caches both paths on first invocation to avoid repeated string manipulation inside the tight per-line loop.
-
----
-
-## JSONL Step-Transition Events
-
-`emit_step_transition(step_name, status)` prints a single-line JSON object to **stderr**:
-
-```
-{"type":"step_transition","step":"Classify task type","status":"done","ts":1743554400.0}
-```
-
-Parent processes detect and suppress these lines from user-visible output by checking whether a line starts with `{"type":"step_transition"` or the legacy prefix `{"transition":"step_`.
-
-Heartbeat pings from long-running steps follow the same format:
-
-```
-{"type":"heartbeat","step":"Run builder agent","ts":1743554430.0}
-```
-
-Both types are filtered by `_is_progress_metadata_line()` before the line appears in the meaningful stderr tail used for error messages.
-
----
-
-## Atomic File Writes
-
-All progress and log files are created with OS-level atomicity:
-
-### Progress JSON
-
-```
-write to NamedTemporaryFile (same directory)
-    → os.replace(tmp_path, final_path)   # atomic on POSIX
-```
-
-`os.replace()` guarantees readers always see either the previous complete file or the new complete file — never a partial write.
-
-On cross-device rename errors (rare; can occur if `/tmp` is on a different filesystem), the code falls back to a direct write.
-
-### File creation flags
-
-```rust
-O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW
-```
-
-`O_NOFOLLOW` rejects the `open()` call if the target path is a symlink. This prevents a malicious process from placing a symlink at the expected progress file path and redirecting writes to an arbitrary destination.
-
-### File permissions
-
-All progress files and log files are created with mode `0o600` (owner read/write only). The containing temp directory created by `rust_runner.py` uses `0o700`.
-
----
-
-## Security Design
-
-### No shell injection
-
-The binary is launched as:
-
-```rust
-subprocess.Popen(cmd, ...)  # cmd is list[str], shell=False (default)
-```
-
-No string interpolation or shell expansion occurs at any point in the execution path.
-
-### Environment allowlist
-
-`build_rust_env()` copies only variables from `_ALLOWED_RUST_ENV_VARS` into the subprocess environment. Credential variables (`ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `AWS_*`, etc.) are excluded even if set in the parent process.
-
-### Path traversal prevention
-
-Before any file is opened under `/tmp`, `_validate_path_within_tmpdir(path)` calls `path.resolve()` and asserts the result starts with `tempfile.gettempdir()`. A crafted recipe name such as `../../etc/passwd` would produce a sanitized path `______etc_passwd` after `_RECIPE_NAME_SANITIZE_RE` processing, but the validation is a defense-in-depth second check.
-
-### Recipe name sanitization
-
-```rust
-_RECIPE_NAME_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_]")
-_MAX_RECIPE_NAME_LEN = 64
-```
-
-Applied before the recipe name is used in any file path. Ensures the sanitized name can never introduce path separator characters.
-
----
-
-## Workstream Integration
-
-When the recipe runner executes inside a workstream (e.g., spawned by the hive-mind orchestrator), the orchestrator sets two environment variables:
-
-| Variable                             | Content                                                                            |
-| ------------------------------------ | ---------------------------------------------------------------------------------- |
-| `AMPLIHACK_WORKSTREAM_PROGRESS_FILE` | Path for the per-workstream progress sidecar                                       |
-| `AMPLIHACK_WORKSTREAM_STATE_FILE`    | Path to workstream state JSON (contains `issue`, `checkpoint_id`, `worktree_path`) |
-
-The execution layer reads the state file (with mtime+size invalidation caching via `_WORKSTREAM_STATE_CACHE`) and writes the sidecar alongside the main progress file. The orchestrator polls the sidecar instead of the main file so it can correlate progress across concurrent workstreams without PID knowledge.
-
----
-
-## Log Files
-
-When `progress=True`, the execution layer creates a persistent recipe log:
-
-**Path:** `/tmp/amplihack-recipe-<sanitized_name>-<pid>.log`
-
-**Set as:** `AMPLIHACK_RECIPE_LOG` env var for child processes that want to append to it.
-
-**Header:**
-
-```
-=== recipe-runner-rs log: smart-orchestrator (pid 55321) ===
-Started: 2026-04-01T23:40:01Z
-```
-
-**Footer** (written after process exit):
-
-```
-=== recipe-runner-rs exited: rc=0 in 94.2s ===
-```
-
-Both stdout and stderr from the Rust binary are tee'd into this file under a shared lock. To follow in real time:
+`stderr` is for live human-visible progress. `stdout` is reserved for the final
+result so commands such as this remain parseable:
 
 ```bash
-tail -f /tmp/amplihack-recipe-smart_orchestrator-55321.log
+amplihack recipe run default-workflow \
+  -c task_description="Add input validation" \
+  --format json > result.json
 ```
 
-The log path is also returned in `RecipeResult.log_path` so callers can display or store it.
+## Progress event model
 
----
+The runner emits text progress lines for:
 
-**See also:**
+- recipe start, completion, and failure
+- step start, completion, failure, and skip
+- rate-limited heartbeats for long-running active steps
+- failure diagnostics with recent output snippets
 
-- [Rust Runner Execution API Reference](../reference/recipe-command.md)
-- [Recipe Runner overview](../howto/run-a-recipe.md)
-- [Recipe Result data model](../reference/recipe-quick-reference.md)
+When `AMPLIHACK_RECIPE_LOG_JSONL` is set, the runner also writes structured
+JSONL events to that file. Structured events are not interleaved into stdout.
+
+`--progress` is not part of the wrapper contract. Progress is default; passing
+`--progress` to `amplihack recipe run` should produce an explicit unsupported
+flag error that points users to default stderr progress and `--verbose`.
+
+## Bounded output capture
+
+For each active child source and stream, the runner keeps a rolling buffer:
+
+| Bound | Configuration |
+| --- | --- |
+| Maximum lines | `AMPLIHACK_RECIPE_SNIPPET_LINES` |
+| Maximum bytes | `AMPLIHACK_RECIPE_SNIPPET_BYTES` |
+| Heartbeat interval | `AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS` |
+
+The buffer is used for failure diagnostics, optional JSON result fields, and
+JSONL output snippet events. It prevents noisy child processes from flooding
+logs while still surfacing enough recent context to debug failures.
+
+This feature does not add a new redaction layer. Recipes and child tools must
+avoid printing secrets.
+
+## Wrapper preservation
+
+The runner may add optional diagnostic fields to the final JSON result:
+
+- `duration_seconds`
+- `progress_summary`
+- `failure_context`
+- `step_name`
+- `phase`
+- `child`
+- `last_heartbeat_at`
+- `recent_output`
+
+The CLI must preserve these fields when it reformats runner output as JSON or
+YAML. Unknown-field tolerant parsing is not enough if formatting drops the
+fields before users or scripts can read them.
+
+## Related
+
+- [Rust Runner Execution Reference](../reference/rust-runner-execution.md)
+- [Recipe Runner Logging Reference](../reference/recipe-runner-logging.md)
+- [Recipe Runner Architecture](./recipe-runner-architecture.md)

--- a/docs/howto/run-a-recipe.md
+++ b/docs/howto/run-a-recipe.md
@@ -109,20 +109,21 @@ amplihack recipe run ~/.amplihack/.claude/recipes/default-workflow.yaml \
   -c repo_path=/home/user/src/myapp
 ```
 
-The output shows each step as it completes:
+The command emits live progress to stderr while the recipe runs. The output
+shows each step as it starts, heartbeats for long-running steps, and completion
+or failure:
 
 ```
-Recipe: default-workflow
-Status: ✓ Success
-
-Steps:
-  ✓ requirements-clarification: completed
-    Output: Clarified 3 requirements from task description
-  ✓ implementation-planning: completed
-    Output: Created 5-step implementation plan
-  ✓ code-implementation: completed
-  ...
+[recipe default-workflow] started (23 steps)
+[step 01/23 requirements-clarification] started agent=prompt-writer
+[step 01/23 requirements-clarification] completed elapsed=24s
+[step 02/23 implementation-planning] started agent=architect
+[step 02/23 implementation-planning] heartbeat elapsed=60s status=running phase=agent agent=architect
+[step 02/23 implementation-planning] completed elapsed=91s
 ```
+
+The final result is printed to stdout in the requested format. This keeps
+human-readable progress separate from machine-readable output.
 
 ---
 
@@ -266,22 +267,40 @@ amplihack recipe run ~/.amplihack/.claude/recipes/verification.yaml \
   --format json
 ```
 
+Progress continues to appear on stderr. Stdout contains only the final JSON
+result, so this is safe:
+
+```sh
+amplihack recipe run ~/.amplihack/.claude/recipes/verification.yaml \
+  -c task_description="Bump version to 2.1.0" \
+  --format json > result.json
+```
+
 ```json
 {
   "recipe_name": "verification",
   "success": true,
+  "duration_seconds": 42.6,
   "step_results": [
     {
       "step_id": "pre-check",
       "status": "completed",
       "output": "All pre-conditions met",
-      "error": ""
+      "error": "",
+      "elapsed_seconds": 3.1,
+      "phase": "bash"
     },
     {
       "step_id": "implementation",
       "status": "completed",
       "output": "Version bumped in Cargo.toml and pyproject.toml",
-      "error": ""
+      "error": "",
+      "elapsed_seconds": 34.8,
+      "phase": "agent",
+      "child": {
+        "kind": "agent",
+        "name": "builder"
+      }
     }
   ]
 }
@@ -318,12 +337,22 @@ jobs:
         run: |
           amplihack recipe run \
             ~/.amplihack/.claude/recipes/default-workflow.yaml \
-            --format json \
-            --verbose
+            --format json > recipe-result.json
 ```
 
 Set `AMPLIHACK_NONINTERACTIVE=1` to suppress interactive prompts. The recipe
-runner exits 0 on success and 1 on failure, integrating naturally with CI pass/fail.
+runner exits 0 on success and 1 on failure, integrating naturally with CI
+pass/fail. Live progress and heartbeat lines are written to the job log on
+stderr; `recipe-result.json` contains only the final structured result.
+
+To keep the job log terse, redirect progress stderr to a file while preserving
+the final JSON result on stdout:
+
+```sh
+amplihack recipe run ~/.amplihack/.claude/recipes/default-workflow.yaml \
+  -c task_description="Regenerate API docs" \
+  --format json > recipe-result.json 2> recipe-progress.log
+```
 
 ---
 
@@ -369,19 +398,20 @@ fix the YAML and re-run.
 
 ### A step fails mid-recipe
 
-The output shows which step failed and why:
+The output shows which step failed, how long it ran, which child process or
+agent was active, and recent bounded output from that child:
 
 ```
-Recipe: default-workflow
-Status: ✗ Failed
+[step 08/23 code-implementation] failed elapsed=12m14s agent=builder
+error: agent exited with code 1
 
-Steps:
-  ✓ requirements-clarification: completed
-  ✗ implementation-planning: failed
-    Error: agent 'architect' exited with code 1
+recent stderr from agent:builder (last 20 lines, 8192 bytes max):
+  error[E0425]: cannot find value `cache_policy` in this scope
+  --> src/http/cache.rs:42:18
 ```
 
-Re-run with `--verbose` to see stderr output for more context:
+`--verbose` adds child launch details and extra diagnostic context, but it is not
+required for basic step progress or failure snippets:
 
 ```sh
 amplihack recipe run recipe.yaml -c task_description="..." --verbose
@@ -392,6 +422,8 @@ amplihack recipe run recipe.yaml -c task_description="..." --verbose
 ## Related
 
 - [amplihack recipe — Reference](../reference/recipe-command.md) — Full flag reference, output formats, and schema
+- [Recipe Runner Logging Reference](../reference/recipe-runner-logging.md) — stderr progress, heartbeats, bounded snippets, and JSON fields
+- [Observe Recipe Progress Tutorial](../tutorials/recipe-progress-transparency.md) — Learn the progress and failure-debugging workflow
 - [Environment Variables](../reference/environment-variables.md) — `AMPLIHACK_CONTEXT_*` and `RECIPE_RUNNER_RS_PATH`
 - [Run amplihack in Non-interactive Mode](./run-in-noninteractive-mode.md) — CI configuration
 - [Agent Binary Routing](../concepts/agent-binary-routing.md) — How agents are located during recipe execution

--- a/docs/index.md
+++ b/docs/index.md
@@ -270,8 +270,10 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [Token Sanitizer](reference/token-sanitizer.md) - Pattern ordering, audit labels, and custom patterns for secret redaction
 - [RecipeResult](reference/recipe-result.md) - `RecipeResult` and `StepResult` dataclasses, `str()` format, JSON serialisation
 - [AppendHandler](reference/append-handler.md) - `AppendResult` class, timestamp filename format, atomic file writes
-- [Rust Runner Execution Reference](reference/rust-runner-execution.md) - `execute_rust_command`, `read_progress_file`, `emit_step_transition`, progress file schema, security model
-- [Rust Runner Execution Architecture](concepts/rust-runner-execution-architecture.md) - Thread-based I/O streaming, atomic writes, JSONL events, workstream integration
+- [Rust Runner Execution Reference](reference/rust-runner-execution.md) - Wrapper contract, stderr/stdout streams, JSONL events, environment variables, and security model
+- [Rust Runner Execution Architecture](concepts/rust-runner-execution-architecture.md) - CLI/runner responsibility split, stream ownership, progress events, and additive JSON preservation
+- [Recipe Runner Logging Reference](reference/recipe-runner-logging.md) - stderr progress, heartbeats, bounded snippets, JSONL events, and additive result fields
+- [Observe Recipe Progress Tutorial](tutorials/recipe-progress-transparency.md) - Watch live workflow progress, capture JSON, and debug failed steps
 
 **Quick Start**:
 
@@ -281,7 +283,8 @@ amplihack recipe list
 
 # Execute a workflow recipe
 amplihack recipe run default-workflow \
-  --context '{"task_description": "Add user authentication", "repo_path": "."}'
+  -c task_description="Add user authentication" \
+  -c repo_path=.
 
 # Validate recipe YAML
 amplihack recipe validate my-workflow.yaml

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -18,6 +18,10 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [NODE_OPTIONS](#node_options)
 - [Variables injected by recipe executor](#variables-injected-by-recipe-executor)
   - [AMPLIHACK_STEP_TIMEOUT](#amplihack_step_timeout)
+  - [AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS](#amplihack_recipe_heartbeat_interval_seconds)
+  - [AMPLIHACK_RECIPE_SNIPPET_LINES](#amplihack_recipe_snippet_lines)
+  - [AMPLIHACK_RECIPE_SNIPPET_BYTES](#amplihack_recipe_snippet_bytes)
+  - [AMPLIHACK_RECIPE_LOG_JSONL](#amplihack_recipe_log_jsonl)
   - [NONINTERACTIVE](#noninteractive)
   - [DEBIAN_FRONTEND](#debian_frontend)
   - [CI (recipe context)](#ci-recipe-context)
@@ -307,7 +311,11 @@ When startup does not supply an explicit value, `EnvBuilder` still falls back to
 
 ## Variables injected by recipe executor
 
-These variables are set by the recipe executor (`amplihack recipe run`) in every shell step's child process. They are always set — there is no opt-out. See [Recipe Executor Environment](./recipe-executor-environment.md) for full details.
+These variables are read or set by the recipe executor (`amplihack recipe run`)
+while running recipe steps. Non-interactive shell-step variables are always set.
+Heartbeat, snippet, and JSONL log variables are optional user configuration. See
+[Recipe Executor Environment](./recipe-executor-environment.md) and
+[Recipe Runner Logging](./recipe-runner-logging.md) for full details.
 
 ---
 
@@ -319,16 +327,15 @@ These variables are set by the recipe executor (`amplihack recipe run`) in every
 
 Overrides the `timeout_seconds` value defined in individual recipe steps. When set, every step in the recipe uses this value instead of its YAML-defined timeout. A value of `"0"` disables step timeouts entirely, allowing steps to run indefinitely.
 
-This variable is only present in the child environment when the user passes `--step-timeout` or `--no-step-timeouts` to `amplihack recipe run`. When neither flag is provided, YAML-defined `timeout_seconds` values apply as-is (though the default-workflow agent steps no longer define `timeout_seconds`).
+This variable is only present in the child environment when the user passes `--step-timeout` to `amplihack recipe run`. When the flag is omitted, YAML-defined `timeout_seconds` values apply as-is (though the default-workflow agent steps no longer define `timeout_seconds`).
 
 ```sh
 # Override all step timeouts to 10 minutes
 amplihack recipe run recipe.yaml --step-timeout 600
 # Child process sees: AMPLIHACK_STEP_TIMEOUT=600
 
-# Disable all step timeouts (two equivalent forms)
+# Disable all step timeouts
 amplihack recipe run recipe.yaml --step-timeout 0
-amplihack recipe run recipe.yaml --no-step-timeouts
 # Child process sees: AMPLIHACK_STEP_TIMEOUT=0
 
 # No override — YAML timeouts apply (agent steps have none by default)
@@ -339,6 +346,97 @@ amplihack recipe run recipe.yaml
 **Why it exists:** The default-workflow recipes no longer define `timeout_seconds` on agent steps, so agent steps run to completion without artificial time limits. This variable provides an opt-in escape hatch for CI environments that need wall-clock budgets. The env var approach is forward-compatible — `recipe-runner-rs` can adopt it independently without CLI changes.
 
 **Security note:** The value is always a `u64` rendered as a string. No shell metacharacters are possible. The CLI rejects non-numeric input at parse time via clap's type enforcement.
+
+---
+
+### AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS
+
+**Type:** string (unsigned integer as text)
+**Values:** `"0"` (disable heartbeats) | `"60"` (default) | any non-negative integer
+**Read by:** `recipe-runner-rs`
+
+Controls how often long-running recipe, agent, subprocess, and nested-recipe
+steps emit heartbeat lines to stderr. The interval is rate-limited per active
+step. Short steps that complete before one interval do not emit heartbeats.
+
+```sh
+# Emit a heartbeat every 15 seconds while debugging a long-running agent step
+AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS=15 \
+amplihack recipe run default-workflow \
+  -c task_description="Debug hanging test generation"
+
+# Disable heartbeat lines while preserving start/completion/failure progress
+AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS=0 \
+amplihack recipe run default-workflow \
+  -c task_description="Run with minimal progress"
+```
+
+Equivalent config key: `recipe.heartbeat_interval_seconds` in
+`~/.amplihack/config`.
+
+---
+
+### AMPLIHACK_RECIPE_SNIPPET_LINES
+
+**Type:** string (unsigned integer as text)
+**Default:** `20`
+**Read by:** `recipe-runner-rs`
+
+Maximum number of recent lines retained per active child source and stream.
+Older lines are dropped from the rolling buffer. This bound applies to snippets
+printed in failure diagnostics, included in JSON results, and written to JSONL
+logs.
+
+```sh
+AMPLIHACK_RECIPE_SNIPPET_LINES=60 \
+amplihack recipe run default-workflow \
+  -c task_description="Diagnose compiler failure" \
+  --format json > result.json
+```
+
+Equivalent config key: `recipe.snippet_lines` in `~/.amplihack/config`.
+
+---
+
+### AMPLIHACK_RECIPE_SNIPPET_BYTES
+
+**Type:** string (unsigned integer as text)
+**Default:** `8192`
+**Read by:** `recipe-runner-rs`
+
+Maximum bytes retained per active child source and stream. This byte bound is
+enforced together with `AMPLIHACK_RECIPE_SNIPPET_LINES`; whichever limit is hit
+first controls truncation.
+
+```sh
+AMPLIHACK_RECIPE_SNIPPET_BYTES=32768 \
+amplihack recipe run default-workflow \
+  -c task_description="Diagnose noisy subprocess output" \
+  --format json > result.json
+```
+
+Equivalent config key: `recipe.snippet_bytes` in `~/.amplihack/config`.
+
+---
+
+### AMPLIHACK_RECIPE_LOG_JSONL
+
+**Type:** path
+**Read by:** `recipe-runner-rs`
+
+When set, writes structured JSONL recipe events to the specified file. Events
+include step lifecycle transitions, heartbeats, output snippets, and failure
+context. Human-readable progress still goes to stderr.
+
+```sh
+AMPLIHACK_RECIPE_LOG_JSONL=/tmp/default-workflow.jsonl \
+amplihack recipe run default-workflow \
+  -c task_description="Add retry budget metrics"
+
+jq 'select(.type == "heartbeat")' /tmp/default-workflow.jsonl
+```
+
+Equivalent config key: `recipe.log_jsonl` in `~/.amplihack/config`.
 
 ---
 
@@ -757,6 +855,7 @@ Override the directory where `uv tool install` places the `amplifier` binary. De
 - [Run amplihack in Non-interactive Mode](../howto/run-in-noninteractive-mode.md) — CI and pipe usage guide
 - [Bootstrap Parity](../concepts/bootstrap-parity.md) — How the Rust CLI matches the Python launcher's environment contract
 - [Memory Backend Reference](./memory-backend.md) — `AMPLIHACK_MEMORY_BACKEND` values, storage paths, schema, and security
+- [Recipe Runner Logging](./recipe-runner-logging.md) — Progress, heartbeat, snippet, and JSONL configuration
 - [amplihack install](./install-command.md) — Variables read during installation
 - [Startup Self-Update Prompt — Subprocess-Safe Skip](../features/startup-update-prompt-subprocess-safe.md) — How `CI`, `AMPLIHACK_AGENT_BINARY`, `AMPLIHACK_NONINTERACTIVE`, `--subprocess-safe`, and non-TTY stdin each suppress the `Update now? [y/N] (5s timeout):` prompt
 - [Manage Tool Update Notifications](../howto/manage-tool-update-checks.md) — npm pre-launch tool update notice (separate code path)

--- a/docs/reference/recipe-cli-reference.md
+++ b/docs/reference/recipe-cli-reference.md
@@ -1,821 +1,154 @@
 # Recipe CLI Reference
 
-Complete command-line reference for the `amplihack recipe` subcommand group. All recipe commands execute workflow recipes using code-enforced step progression.
+Command-line reference for `amplihack recipe`.
 
 ## Contents
 
-- [Global Options](#global-options)
+- [Subcommands](#subcommands)
 - [amplihack recipe list](#amplihack-recipe-list)
 - [amplihack recipe run](#amplihack-recipe-run)
 - [amplihack recipe validate](#amplihack-recipe-validate)
 - [amplihack recipe show](#amplihack-recipe-show)
-- [Exit Codes](#exit-codes)
-- [Environment Variables](#environment-variables)
+- [Environment variables](#environment-variables)
+- [Exit codes](#exit-codes)
 
-## Global Options
-
-Options that apply to all `amplihack recipe` commands.
+## Subcommands
 
 ```bash
-amplihack recipe [GLOBAL_OPTIONS] <command> [OPTIONS]
+amplihack recipe <SUBCOMMAND> [OPTIONS]
 ```
 
-| Option            | Description                | Default |
-| ----------------- | -------------------------- | ------- |
-| `--help`, `-h`    | Show help message and exit | -       |
-| `--version`       | Show recipe runner version | -       |
-| `--verbose`, `-v` | Enable verbose output      | `false` |
-| `--quiet`, `-q`   | Suppress non-error output  | `false` |
-
-**Examples**:
-
-```bash
-# Show recipe subcommand help
-amplihack recipe --help
-
-# Check recipe runner version
-amplihack recipe --version
-# Output: amplihack recipe runner 1.0.0
-
-# Verbose mode shows detailed step execution
-amplihack recipe --verbose list
-```
+`amplihack recipe` has no recipe-specific global flags beyond standard help.
+Options such as `--verbose` and `--format` belong to individual subcommands.
 
 ## amplihack recipe list
 
-List all available workflow recipes discovered from standard recipe directories.
-
-### Synopsis
+List discovered recipes.
 
 ```bash
-amplihack recipe list [OPTIONS]
+amplihack recipe list [RECIPE_DIR] [OPTIONS]
 ```
 
-### Description
-
-Scans recipe discovery paths and displays all available recipes with their descriptions. Recipe discovery order (later paths override earlier):
-
-1. `amplifier-bundle/recipes/` - Bundled recipes from Microsoft Amplifier
-2. `src/amplihack/amplifier-bundle/recipes/` - Package-embedded recipes
-3. `~/.amplihack/.claude/recipes/` - User-installed recipes
-4. `.claude/recipes/` - Project-specific recipes
-
-### Options
-
-| Option              | Description                                    | Default |
-| ------------------- | ---------------------------------------------- | ------- |
-| `--format <format>` | Output format: `text`, `json`, `yaml`, `table` | `text`  |
-| `--long`, `-l`      | Show extended details (path, steps, version)   | `false` |
-
-### Examples
-
-```bash
-# List all recipes (default format)
-amplihack recipe list
-```
-
-**Output**:
-
-```
-Available recipes:
-  default-workflow        22-step development workflow (requirements through merge)
-  verification-workflow   Post-implementation verification and testing
-  investigation           Deep codebase analysis and understanding
-  code-review             Multi-perspective code review
-  security-audit          Security-focused analysis pipeline
-  refactor                Systematic refactoring with safety checks
-  bug-triage              Bug investigation and root cause analysis
-  ddd-workflow            Document-driven development (6 phases)
-  ci-diagnostic           CI failure diagnosis and fix loop
-  quick-fix               Lightweight fix for simple issues
-```
-
-**Long format**:
-
-```bash
-amplihack recipe list --long
-```
-
-**Output**:
-
-```
-Available recipes:
-
-default-workflow (version 1.0)
-  Description: 22-step development workflow (requirements through merge)
-  Steps: 22
-  Path: /home/user/.amplihack/.claude/recipes/default-workflow.yaml
-
-verification-workflow (version 1.0)
-  Description: Post-implementation verification and testing
-  Steps: 8
-  Path: /home/user/.amplihack/.claude/recipes/verification-workflow.yaml
-
-...
-```
-
-**JSON format**:
+| Option | Description | Default |
+| --- | --- | --- |
+| `RECIPE_DIR` | Optional directory to search instead of the default recipe search path | default search path |
+| `--format <format>`, `-f <format>` | Output format: `table`, `json`, or `yaml` | `table` |
+| `--tags <tag>`, `-t <tag>` | Filter by tag; repeat for multiple tags | none |
+| `--verbose`, `-v` | Include extra recipe metadata | `false` |
 
 ```bash
 amplihack recipe list --format json
+amplihack recipe list ~/.amplihack/.claude/recipes --tags dev --verbose
 ```
-
-**Output**:
-
-```json
-{
-  "recipes": [
-    {
-      "name": "default-workflow",
-      "description": "22-step development workflow (requirements through merge)",
-      "version": "1.0",
-      "steps": 22,
-      "path": "/home/user/.amplihack/.claude/recipes/default-workflow.yaml"
-    },
-    {
-      "name": "verification-workflow",
-      "description": "Post-implementation verification and testing",
-      "version": "1.0",
-      "steps": 8,
-      "path": "/home/user/.amplihack/.claude/recipes/verification-workflow.yaml"
-    }
-  ]
-}
-```
-
-**Table format**:
-
-```bash
-amplihack recipe list --format table
-```
-
-**Output**:
-
-```
-NAME                    DESCRIPTION                                              STEPS
-default-workflow        22-step development workflow (requirements through merge)   22
-verification-workflow   Post-implementation verification and testing                 8
-investigation           Deep codebase analysis and understanding                    12
-code-review             Multi-perspective code review                                6
-security-audit          Security-focused analysis pipeline                           9
-refactor                Systematic refactoring with safety checks                   10
-bug-triage              Bug investigation and root cause analysis                    7
-ddd-workflow            Document-driven development (6 phases)                      18
-ci-diagnostic           CI failure diagnosis and fix loop                            5
-quick-fix               Lightweight fix for simple issues                            4
-```
-
-### Exit Codes
-
-| Code | Meaning                                |
-| ---- | -------------------------------------- |
-| `0`  | Success - recipes found and listed     |
-| `1`  | No recipes found in any discovery path |
 
 ## amplihack recipe run
 
-Execute a workflow recipe with runtime context. Steps execute sequentially with code-enforced progression (models cannot skip steps).
+Execute a workflow recipe through `recipe-runner-rs`.
 
-### Synopsis
+This section includes the planned finished-state transparency contract.
 
 ```bash
-amplihack recipe run <recipe> [OPTIONS]
+amplihack recipe run <RECIPE> [-c KEY=VALUE]... [OPTIONS]
 ```
 
-### Arguments
+| Option | Description | Default |
+| --- | --- | --- |
+| `<RECIPE>` | Recipe name or recipe YAML path | required |
+| `--context KEY=VALUE`, `-c KEY=VALUE` | Set a context variable; repeat for multiple values | none |
+| `--dry-run` | Show the execution plan without running steps | `false` |
+| `--verbose`, `-v` | Add diagnostic detail to progress output | `false` |
+| `--format <format>`, `-f <format>` | Final stdout format: `table`, `json`, or `yaml` | `table` |
+| `--working-dir <dir>`, `-w <dir>` | Working directory for recipe execution | current directory |
+| `--step-timeout <seconds>` | Set `AMPLIHACK_STEP_TIMEOUT` for every step; `0` disables step timeouts | omitted |
 
-| Argument   | Description                             | Required |
-| ---------- | --------------------------------------- | -------- |
-| `<recipe>` | Recipe name or path to recipe YAML file | Yes      |
-
-### Description
-
-Loads a recipe and executes each step in order:
-
-- Agent steps call AI agents via SDK adapter
-- Bash steps execute shell commands
-- Template variables in prompts/commands expand from context
-- Step outputs store in context for later steps
-- Steps with conditions may skip based on previous results
-
-Execution continues until:
-
-- All steps complete successfully (exit 0)
-- A step fails (exit > 0)
-- User interrupts with Ctrl+C (exit 130)
-
-### Options
-
-| Option                  | Description                             | Default     |
-| ----------------------- | --------------------------------------- | ----------- |
-| `--context <json>`      | Runtime context as JSON string          | `{}`        |
-| `--context-file <path>` | Load context from JSON file             | -           |
-| `--adapter <name>`      | SDK adapter: `claude`, `copilot`, `cli` | Auto-detect |
-| `--dry-run`             | Show steps without executing            | `false`     |
-| `--resume-from <step>`  | Resume from specific step ID            | -           |
-| `--stop-at <step>`      | Stop after specific step ID             | -           |
-| `--output <path>`       | Write execution log to file             | -           |
-| `--interactive`         | Prompt for approval before each step    | `false`     |
-
-### Examples
-
-**Basic execution**:
+Context uses repeated `KEY=VALUE` flags, not a JSON blob:
 
 ```bash
 amplihack recipe run default-workflow \
-  --context '{"task_description": "Add user authentication", "repo_path": "."}'
+  -c task_description="Add user authentication" \
+  -c repo_path=/home/user/src/myapp
 ```
 
-**Output**:
-
-```
-[Recipe] default-workflow (22 steps)
-[Step 1/22] clarify-requirements (agent: prompt-writer)
-  Running: Analyze and clarify task requirements...
-  ✓ Completed in 3.2s
-  Output: context.clarified_requirements
-
-[Step 2/22] design (agent: architect)
-  Running: Design solution architecture...
-  ✓ Completed in 8.7s
-  Output: context.design_spec
-
-[Step 3/22] create-branch (type: bash)
-  Running: git checkout -b feat/user-auth
-  ✓ Completed in 0.3s
-
-...
-
-[Step 22/22] merge (type: bash)
-  Running: git merge --ff-only feat/user-auth
-  ✓ Completed in 0.5s
-
-Recipe completed successfully in 18m 32s
-```
-
-**Load context from file**:
-
-```bash
-# Create context file
-cat > context.json <<EOF
-{
-  "task_description": "Add JWT authentication to API",
-  "repo_path": "/home/user/myproject",
-  "branch_name": "feat/jwt-auth"
-}
-EOF
-
-# Run with context file
-amplihack recipe run default-workflow --context-file context.json
-```
-
-**Dry run mode**:
-
-```bash
-amplihack recipe run verification-workflow --dry-run
-```
-
-**Output**:
-
-```
-[DRY RUN] verification-workflow (8 steps)
-[Step 1/8] run-tests (type: bash)
-  Would execute: cd . && python -m pytest tests/ -v
-[Step 2/8] check-coverage (type: bash)
-  Would execute: cd . && pytest --cov=. --cov-report=term
-[Step 3/8] lint-check (agent: reviewer)
-  Would run agent: amplihack:reviewer
-  Prompt: Review code for style violations...
-
-No changes made (dry run mode)
-```
-
-**Resume from checkpoint**:
-
-```bash
-# Initial run fails at step 15
-amplihack recipe run default-workflow \
-  --context '{"task_description": "Add rate limiting"}'
-# ... fails at step 15: implement-logic
-
-# Fix the issue, then resume from step 15
-amplihack recipe run default-workflow \
-  --context '{"task_description": "Add rate limiting"}' \
-  --resume-from implement-logic
-```
-
-**Partial execution**:
-
-```bash
-# Run only steps 1-5 (stop before step 6)
-amplihack recipe run default-workflow \
-  --context '{"task_description": "Add caching"}' \
-  --stop-at write-tests
-```
-
-**Interactive mode**:
-
-```bash
-amplihack recipe run security-audit --interactive
-```
-
-**Output**:
-
-```
-[Step 1/8] scan-dependencies (agent: security)
-  Prompt: Scan package.json for vulnerable dependencies...
-
-Continue? [y/n]: y
-  ✓ Completed in 4.1s
-
-[Step 2/8] check-auth (agent: security)
-  Prompt: Review authentication implementation...
-
-Continue? [y/n]: n
-  Aborted by user
-
-Recipe stopped at step 2/8
-```
-
-**Save execution log**:
+Capture the final JSON result while still watching live progress:
 
 ```bash
 amplihack recipe run default-workflow \
-  --context '{"task_description": "Add webhooks"}' \
-  --output execution-log.json
+  -c task_description="Add user authentication" \
+  -c repo_path=. \
+  --format json > result.json
 ```
 
-**Log format**:
+Progress, heartbeats, and failure diagnostics are written to `stderr`. The final
+result is written to `stdout` in the selected format. `--verbose` adds detail;
+basic progress does not require it.
 
-```json
-{
-  "recipe": "default-workflow",
-  "start_time": "2026-02-14T10:30:00Z",
-  "end_time": "2026-02-14T10:48:32Z",
-  "duration_seconds": 1112,
-  "status": "completed",
-  "steps": [
-    {
-      "id": "clarify-requirements",
-      "type": "agent",
-      "agent": "amplihack:prompt-writer",
-      "start_time": "2026-02-14T10:30:01Z",
-      "duration_seconds": 3.2,
-      "status": "completed",
-      "output": "Store in context.clarified_requirements"
-    }
-  ]
-}
-```
+`--progress` is intentionally unsupported. Passing it should fail fast with an
+actionable message explaining that progress is already emitted to `stderr` by
+default and that `--verbose` only increases diagnostic detail.
 
-**Specify adapter**:
-
-```bash
-# Force Claude Agent SDK
-amplihack recipe run default-workflow --adapter claude \
-  --context '{"task_description": "Add monitoring"}'
-
-# Use GitHub Copilot SDK
-amplihack recipe run default-workflow --adapter copilot \
-  --context '{"task_description": "Add monitoring"}'
-
-# Generic CLI adapter (fallback)
-amplihack recipe run default-workflow --adapter cli \
-  --context '{"task_description": "Add monitoring"}'
-```
-
-**Run recipe from file path**:
-
-```bash
-# Absolute path
-amplihack recipe run /home/user/custom-recipes/my-workflow.yaml \
-  --context '{"target": "src/api"}'
-
-# Relative path
-amplihack recipe run ../shared-recipes/api-workflow.yaml \
-  --context '{"target": "src/api"}'
-```
-
-### Exit Codes
-
-| Code  | Meaning                           |
-| ----- | --------------------------------- |
-| `0`   | Success - all steps completed     |
-| `1`   | Recipe validation failed          |
-| `2`   | Missing required context variable |
-| `3`   | Step execution failed             |
-| `4`   | Agent not found                   |
-| `5`   | Adapter not available             |
-| `130` | Interrupted by user (Ctrl+C)      |
+`amplihack recipe run` does not support `--adapter`, `--resume-from`,
+`--stop-at`, `--output`, `--interactive`, or `--quiet`.
 
 ## amplihack recipe validate
 
-Validate a recipe YAML file without executing it. Checks syntax, structure, agent references, and template variables.
-
-### Synopsis
+Validate a recipe YAML file without executing it.
 
 ```bash
-amplihack recipe validate <file> [OPTIONS]
+amplihack recipe validate <FILE> [OPTIONS]
 ```
 
-### Arguments
-
-| Argument | Description              | Required |
-| -------- | ------------------------ | -------- |
-| `<file>` | Path to recipe YAML file | Yes      |
-
-### Description
-
-Performs comprehensive validation:
-
-1. **YAML syntax** - Parses file as valid YAML
-2. **Required fields** - Checks `name` and `steps` are present
-3. **Step structure** - Validates each step has required fields
-4. **Unique IDs** - Ensures step IDs are unique within recipe
-5. **Agent references** - Verifies agents exist in agent directories
-6. **Template variables** - Checks `{{variables}}` are defined in context
-7. **Conditions** - Validates step conditions are valid Python expressions
-8. **Dependencies** - Detects circular dependencies in step conditions
-
-### Options
-
-| Option              | Description                   | Default |
-| ------------------- | ----------------------------- | ------- |
-| `--strict`          | Treat warnings as errors      | `false` |
-| `--format <format>` | Output format: `text`, `json` | `text`  |
-
-### Examples
-
-**Valid recipe**:
+| Option | Description | Default |
+| --- | --- | --- |
+| `<FILE>` | Recipe YAML file to validate | required |
+| `--verbose`, `-v` | Include validation details | `false` |
+| `--format <format>`, `-f <format>` | Output format: `table`, `json`, or `yaml` | `table` |
 
 ```bash
-amplihack recipe validate my-workflow.yaml
+amplihack recipe validate ~/.amplihack/.claude/recipes/default-workflow.yaml \
+  --verbose
 ```
-
-**Output**:
-
-```
-Validating my-workflow.yaml...
-  [OK] Valid YAML syntax
-  [OK] Required fields present (name, steps)
-  [OK] All step IDs unique
-  [OK] Template variables resolve against context
-  [OK] Agent references valid (architect, builder, tester)
-  [OK] No circular dependencies
-
-Recipe "my-workflow" is valid (5 steps)
-```
-
-**Invalid recipe**:
-
-```bash
-amplihack recipe validate broken-recipe.yaml
-```
-
-**Output**:
-
-```
-Validating broken-recipe.yaml...
-  [OK] Valid YAML syntax
-  [OK] Required fields present
-  [FAIL] Step ID "test" appears 2 times (must be unique)
-  [FAIL] Agent reference "amplihack:unknown-agent" not found
-  [WARN] Context variable "{{missing_var}}" used but not defined
-
-Recipe validation failed with 2 errors, 1 warning
-```
-
-**Strict mode**:
-
-```bash
-amplihack recipe validate my-recipe.yaml --strict
-```
-
-Warnings become errors in strict mode. Returns exit code 1 if any warnings or errors found.
-
-**JSON output**:
-
-```bash
-amplihack recipe validate my-recipe.yaml --format json
-```
-
-**Output**:
-
-```json
-{
-  "valid": false,
-  "errors": [
-    {
-      "type": "duplicate_step_id",
-      "step_id": "test",
-      "message": "Step ID 'test' appears 2 times (must be unique)"
-    },
-    {
-      "type": "invalid_agent",
-      "agent": "amplihack:unknown-agent",
-      "message": "Agent reference 'amplihack:unknown-agent' not found"
-    }
-  ],
-  "warnings": [
-    {
-      "type": "undefined_variable",
-      "variable": "missing_var",
-      "message": "Context variable '{{missing_var}}' used but not defined"
-    }
-  ]
-}
-```
-
-### Exit Codes
-
-| Code | Meaning                          |
-| ---- | -------------------------------- |
-| `0`  | Success - recipe is valid        |
-| `1`  | Validation failed (errors found) |
-| `2`  | File not found or not readable   |
 
 ## amplihack recipe show
 
-Display detailed information about a recipe including metadata, context variables, and step-by-step breakdown.
-
-### Synopsis
+Display recipe metadata, context defaults, and steps.
 
 ```bash
-amplihack recipe show <recipe> [OPTIONS]
+amplihack recipe show <RECIPE> [OPTIONS]
 ```
 
-### Arguments
-
-| Argument   | Description                             | Required |
-| ---------- | --------------------------------------- | -------- |
-| `<recipe>` | Recipe name or path to recipe YAML file | Yes      |
-
-### Description
-
-Shows complete recipe details:
-
-- Metadata (name, description, version, author)
-- File path
-- Context variable definitions
-- Full step list with prompts, agents, commands
-- Step dependencies and outputs
-
-### Options
-
-| Option              | Description                                    | Default |
-| ------------------- | ---------------------------------------------- | ------- |
-| `--format <format>` | Output format: `text`, `json`, `yaml`, `table` | `text`  |
-| `--steps-only`      | Show only step list (omit metadata)            | `false` |
-
-### Examples
-
-**Show full recipe details**:
-
-```bash
-amplihack recipe show default-workflow
-```
-
-**Output**:
-
-```
-Recipe: default-workflow
-Description: 22-step development workflow (requirements through merge)
-Version: 1.0
-Author: amplihack
-Path: /home/user/.amplihack/.claude/recipes/default-workflow.yaml
-
-Context Variables:
-  task_description (required): Description of what to implement
-  repo_path (optional, default="."): Repository root path
-  branch_name (optional): Override branch name
-
-Steps (22):
-  1. clarify-requirements (agent: prompt-writer)
-     Prompt: |
-       Analyze and clarify the following task:
-       {{task_description}}
-
-       Rewrite as unambiguous, testable requirements.
-     Output: clarified_requirements
-
-  2. design (agent: architect)
-     Prompt: |
-       Design a solution for:
-       {{task_description}}
-
-       Requirements:
-       {{clarified_requirements}}
-     Uses: clarified_requirements
-     Output: design_spec
-
-  3. create-branch (type: bash)
-     Command: git checkout -b {{branch_name}}
-
-  ...
-
-  22. merge (type: bash)
-      Command: git merge --ff-only {{branch_name}}
-      Condition: tests_pass && ci_success
-```
-
-**Show steps only**:
-
-```bash
-amplihack recipe show default-workflow --steps-only
-```
-
-**Output**:
-
-```
-Steps (22):
-  1. clarify-requirements (agent: prompt-writer)
-  2. design (agent: architect)
-  3. create-branch (type: bash)
-  4. write-tests (agent: tester)
-  ...
-  22. merge (type: bash)
-```
-
-**JSON format**:
-
-```bash
-amplihack recipe show default-workflow --format json
-```
-
-**Output**:
-
-```json
-{
-  "name": "default-workflow",
-  "description": "22-step development workflow (requirements through merge)",
-  "version": "1.0",
-  "author": "amplihack",
-  "path": "/home/user/.amplihack/.claude/recipes/default-workflow.yaml",
-  "context": {
-    "task_description": {
-      "required": true,
-      "default": "",
-      "description": "Description of what to implement"
-    },
-    "repo_path": {
-      "required": false,
-      "default": ".",
-      "description": "Repository root path"
-    },
-    "branch_name": {
-      "required": false,
-      "default": null,
-      "description": "Override branch name"
-    }
-  },
-  "steps": [
-    {
-      "id": "clarify-requirements",
-      "type": "agent",
-      "agent": "amplihack:prompt-writer",
-      "prompt": "Analyze and clarify the following task:\n{{task_description}}\n\nRewrite as unambiguous, testable requirements.",
-      "output": "clarified_requirements"
-    }
-  ]
-}
-```
-
-**YAML format**:
+| Option | Description | Default |
+| --- | --- | --- |
+| `<RECIPE>` | Recipe name or recipe YAML path | required |
+| `--format <format>`, `-f <format>` | Output format: `table`, `json`, or `yaml` | `table` |
+| `--no-steps` | Omit step details | `false` |
+| `--no-context` | Omit context details | `false` |
 
 ```bash
 amplihack recipe show default-workflow --format yaml
 ```
 
-Returns the original recipe YAML content.
+## Environment variables
 
-**Table format**:
+| Variable | Applies to | Description |
+| --- | --- | --- |
+| `RECIPE_RUNNER_RS_PATH` | `run` | Absolute path to a `recipe-runner-rs` binary. Used before `$PATH` lookup. |
+| `AMPLIHACK_STEP_TIMEOUT` | runner child process | Set by `--step-timeout`; read by the runner as a global per-step timeout hint. |
+| `AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS` | runner | Heartbeat interval in seconds. `0` disables heartbeat lines. |
+| `AMPLIHACK_RECIPE_SNIPPET_LINES` | runner | Maximum recent output lines retained per child source and stream. |
+| `AMPLIHACK_RECIPE_SNIPPET_BYTES` | runner | Maximum recent output bytes retained per child source and stream. |
+| `AMPLIHACK_RECIPE_LOG_JSONL` | runner | Optional path for structured JSONL lifecycle, heartbeat, output snippet, and failure events. |
 
-```bash
-amplihack recipe show default-workflow --format table
-```
+See [Environment Variables](./environment-variables.md) for full details.
 
-**Output**:
+## Exit codes
 
-```
-STEP  ID                      TYPE   AGENT/COMMAND                     OUTPUT
-1     clarify-requirements    agent  amplihack:prompt-writer           clarified_requirements
-2     design                  agent  amplihack:architect               design_spec
-3     create-branch           bash   git checkout -b {{branch_name}}   -
-4     write-tests             agent  amplihack:tester                  test_files
-5     implement-logic         agent  amplihack:builder                 implementation
-6     review-code             agent  amplihack:reviewer                review_feedback
-7     run-tests               bash   pytest tests/ -v                  test_results
-8     commit-changes          bash   git commit -m "..."               -
-...
-```
+| Code | Meaning |
+| --- | --- |
+| `0` | Command succeeded |
+| `1` | Command failed, validation failed, recipe execution failed, runner missing, or arguments were malformed |
 
-### Exit Codes
+## See also
 
-| Code | Meaning                              |
-| ---- | ------------------------------------ |
-| `0`  | Success - recipe found and displayed |
-| `1`  | Recipe not found                     |
-
-## Exit Codes
-
-Summary of all exit codes used by recipe CLI commands.
-
-| Code  | Meaning                           | Commands          |
-| ----- | --------------------------------- | ----------------- |
-| `0`   | Success                           | All commands      |
-| `1`   | General error                     | All commands      |
-| `2`   | Invalid arguments or missing file | `validate`, `run` |
-| `3`   | Step execution failed             | `run`             |
-| `4`   | Agent not found                   | `run`             |
-| `5`   | Adapter not available             | `run`             |
-| `130` | Interrupted by user (Ctrl+C)      | `run`             |
-
-**Check exit code in shell**:
-
-```bash
-amplihack recipe run my-recipe --context '{...}'
-echo $?  # Prints exit code
-```
-
-**Use exit codes in scripts**:
-
-```bash
-#!/bin/bash
-set -e  # Exit on any error
-
-if amplihack recipe run default-workflow --context '{...}'; then
-  echo "Recipe succeeded"
-  notify-user "Deployment complete"
-else
-  exit_code=$?
-  echo "Recipe failed with code: $exit_code"
-  notify-user "Deployment failed"
-  exit $exit_code
-fi
-```
-
-## Environment Variables
-
-Environment variables that affect recipe CLI behavior.
-
-### AMPLIHACK_RECIPE_PATH
-
-Additional directories to search for recipes (colon-separated list).
-
-```bash
-export AMPLIHACK_RECIPE_PATH="/opt/company-recipes:/home/user/my-recipes"
-amplihack recipe list  # Includes recipes from both directories
-```
-
-Discovery order with `AMPLIHACK_RECIPE_PATH`:
-
-1. Built-in recipes
-2. User recipes (`~/.amplihack/.claude/recipes/`)
-3. Directories in `AMPLIHACK_RECIPE_PATH` (left to right)
-4. Project recipes (`.claude/recipes/`)
-
-### AMPLIHACK_ADAPTER
-
-Default SDK adapter when `--adapter` is not specified.
-
-```bash
-export AMPLIHACK_ADAPTER=copilot
-amplihack recipe run default-workflow --context '{...}'  # Uses copilot adapter
-```
-
-Valid values: `claude`, `copilot`, `cli`, `auto`
-
-### AMPLIHACK_VERBOSE
-
-Enable verbose output for all recipe commands.
-
-```bash
-export AMPLIHACK_VERBOSE=1
-amplihack recipe list  # Shows detailed discovery process
-```
-
-Equivalent to passing `--verbose` flag to each command.
-
-### AMPLIHACK_DRY_RUN
-
-Enable dry-run mode by default.
-
-```bash
-export AMPLIHACK_DRY_RUN=1
-amplihack recipe run my-recipe --context '{...}'  # Previews without executing
-```
-
-Override with explicit flag:
-
-```bash
-export AMPLIHACK_DRY_RUN=1
-amplihack recipe run my-recipe --dry-run=false --context '{...}'  # Actually executes
-```
-
----
-
-**See also**:
-
-- [Recipe CLI How-To Guide](../howto/recipe-cli-commands.md) - Task-oriented usage examples
-- [Recipe Runner Overview](../howto/run-a-recipe.md) - Architecture and YAML format
-- [Creating Custom Recipes](../howto/run-a-recipe.md) - Recipe development guide
+- [amplihack recipe Reference](./recipe-command.md) - Detailed command behavior
+- [Run a Recipe End-to-End](../howto/run-a-recipe.md) - Task-oriented usage
+- [Recipe Runner Logging Reference](./recipe-runner-logging.md) - stderr progress, heartbeats, bounded snippets, and JSONL events

--- a/docs/reference/recipe-command.md
+++ b/docs/reference/recipe-command.md
@@ -12,6 +12,7 @@ inspects, validates, and runs YAML recipe files.
   - [recipe validate](#recipe-validate)
   - [recipe run](#recipe-run)
 - [Output formats](#output-formats)
+- [Progress and stream contract](#progress-and-stream-contract)
 - [Recipe file format](#recipe-file-format)
   - [Required fields](#required-fields)
   - [Optional fields](#optional-fields)
@@ -203,7 +204,7 @@ amplihack recipe run <FILE> [-c KEY=VALUE]... [--dry-run] [--verbose]
 | `<FILE>` | (required) | Path to the recipe YAML file |
 | `-c KEY=VALUE` | (none) | Set a context variable; repeat for multiple values |
 | `--dry-run` | false | Print the execution plan without running any steps |
-| `--verbose` | false | Print recipe name and dry-run status to stderr |
+| `--verbose` | false | Increase progress detail on stderr; basic step progress is emitted by default |
 | `--format <FORMAT>` | `table` | Output format for results: `table`, `json`, or `yaml` |
 | `--working-dir <DIR>` | `.` | Working directory for step execution |
 | `--step-timeout <SECONDS>` | (none) | Apply a global per-step timeout ceiling to **every** step in the recipe. Useful for CI guard rails. `0` disables all step timeouts. When omitted, agent steps run without a per-step timeout and bash steps use the YAML-defined `timeout_seconds` only when present |
@@ -301,6 +302,49 @@ and `--format yaml`.
 | `table` | Human-readable terminal output |
 | `json` | Scripting, CI pipelines, `jq` processing |
 | `yaml` | Config file integration |
+
+`recipe run` writes the final result in the selected format to stdout. Live
+progress, heartbeats, and failure diagnostics are written to stderr.
+
+---
+
+## Progress and stream contract
+
+This section describes the planned finished-state transparency contract.
+
+`amplihack recipe run` forwards `recipe-runner-rs` progress to stderr by
+default. This makes normal runs observable while keeping stdout safe for
+structured output.
+
+```sh
+amplihack recipe run default-workflow \
+  -c task_description="Add validation" \
+  -c repo_path=. \
+  --format json > result.json
+```
+
+In this example, the terminal shows step progress and heartbeats from stderr.
+`result.json` contains only the final JSON result.
+
+Progress includes:
+
+- recipe started/completed/failed
+- step started/completed/failed/skipped
+- rate-limited heartbeat lines for long-running recipe, agent, subprocess, and
+  nested-recipe steps
+- bounded recent stdout/stderr snippets in failure diagnostics
+
+`--verbose` adds detail such as child launch metadata and extra snippet context.
+`--progress` is not a supported `amplihack recipe run` flag. Passing it should
+fail fast with an actionable message explaining that progress is already emitted
+to `stderr` by default and `--verbose` only increases diagnostic detail.
+
+The final JSON result may include optional additive fields such as
+`duration_seconds`, `progress_summary`, `failure_context`, `step_name`, `phase`,
+`child`, `last_heartbeat_at`, and `recent_output`. Consumers must ignore unknown
+fields. The CLI must preserve these fields when formatting JSON or YAML instead
+of parsing and dropping unknown runner fields. See [RecipeResult Reference](./recipe-result.md)
+for schema details.
 
 ---
 
@@ -517,6 +561,7 @@ Recipe execution can fail at multiple levels. For diagnosis:
 | Duplicate issues filed | Repeated `gh issue create` on retries | [Issue Deduplication](./issue-dedup.md) |
 | Condition parse error | `condition` field uses unsupported expression | [Agentic Step Patterns](../concepts/agentic-step-patterns.md) |
 | Context variable missing | `{{var}}` renders as empty string | [Context variables](#context-variables) |
+| Opaque long-running step | No visible child output for a while | [Recipe Runner Logging](./recipe-runner-logging.md) |
 
 For general troubleshooting, see [Troubleshoot Recipe Execution Failures](../howto/troubleshoot-recipe-execution.md).
 
@@ -526,6 +571,7 @@ For general troubleshooting, see [Troubleshoot Recipe Execution Failures](../how
 
 - [Run a Recipe End-to-End](../howto/run-a-recipe.md) — Step-by-step guide to executing recipes
 - [Environment Variables](./environment-variables.md) — `AMPLIHACK_CONTEXT_*`, `AMPLIHACK_TASK_DESCRIPTION`, `RECIPE_RUNNER_RS_PATH`
+- [Recipe Runner Logging](./recipe-runner-logging.md) — stderr progress, heartbeats, snippets, and JSONL logs
 - [Parity Test Scenarios](./parity-test-scenarios.md) — `tier4-recipe-run.yaml` test cases
 - [Agent Binary Routing](../concepts/agent-binary-routing.md) — How `AMPLIHACK_AGENT_BINARY` affects recipe step execution
 - [Recipe Runner Architecture](../concepts/recipe-runner-architecture.md) — Why the runner is an external binary

--- a/docs/reference/recipe-result.md
+++ b/docs/reference/recipe-result.md
@@ -8,6 +8,7 @@
 - [Attributes](#attributes)
 - [String Representation](#string-representation)
 - [Step Results](#step-results)
+- [Progress and Failure Context](#progress-and-failure-context)
 - [Usage Examples](#usage-examples)
 - [Integration with Recipe Runner](#integration-with-recipe-runner)
 
@@ -15,7 +16,7 @@
 
 ## Class Overview
 
-`RecipeResult` is the structured output of a recipe run. It is returned by the `amplihack recipe run` CLI command when `--output json` is used. The JSON schema uses the same field names documented below.
+`RecipeResult` is the structured output of a recipe run. It is returned by the `amplihack recipe run` CLI command when `--format json` is used. The JSON schema uses the same field names documented below.
 
 ---
 
@@ -25,9 +26,12 @@
 | ------------------ | ------------------ | ------------------------------------------------------------------------- |
 | `recipe_name`      | `str`              | The name of the recipe that was run (e.g. `"default-workflow"`).          |
 | `status`           | `RecipeStatus`     | Overall outcome: `SUCCESS`, `FAILURE`, or `PARTIAL`.                      |
+| `success`          | `bool \| None`     | Optional boolean outcome field used by CLI JSON output when present.      |
 | `step_results`     | `list[StepResult]` | Ordered list of results, one per step that executed.                      |
 | `duration_seconds` | `float`            | Wall-clock time from recipe start to finish.                              |
 | `error`            | `str \| None`      | Human-readable error message if `status` is `FAILURE`. `None` on success. |
+| `progress_summary` | `dict \| None`     | Optional live-progress summary: last phase/status, heartbeat count, and log path. |
+| `failure_context`  | `dict \| None`     | Optional actionable context for the first failing step.                    |
 
 ---
 
@@ -74,6 +78,10 @@ class StepResult:
     status: StepStatus    # SUCCESS, FAILURE, SKIPPED
     output: str | None    # Agent output or None if skipped
     duration_seconds: float
+    phase: str | None     # agent, bash, subprocess, recipe, finalize
+    child: dict | None    # Agent, subprocess, or nested recipe identity
+    last_heartbeat_at: str | None
+    recent_output: list[dict]
 ```
 
 Accessing step results directly:
@@ -91,6 +99,77 @@ for step in result.step_results:
 
 ---
 
+## Progress and Failure Context
+
+The JSON schema is backward-compatible. Existing fields remain unchanged; newer
+runner versions add optional progress and diagnostic fields.
+
+### `progress_summary`
+
+`progress_summary` describes the last known live-progress state for the recipe.
+
+```json
+{
+  "last_step_id": "code-implementation",
+  "last_step_name": "Code implementation",
+  "phase": "agent",
+  "status": "completed",
+  "heartbeat_count": 7,
+  "log_path": "/tmp/default-workflow.jsonl"
+}
+```
+
+### `failure_context`
+
+When a recipe fails, `failure_context` repeats the most actionable step-level
+details at the top level.
+
+```json
+{
+  "step_id": "code-implementation",
+  "step_name": "Code implementation",
+  "phase": "agent",
+  "status": "failed",
+  "elapsed_seconds": 734.2,
+  "child": {
+    "kind": "agent",
+    "name": "builder"
+  },
+  "recent_output": [
+    {
+      "source": "agent:builder",
+      "stream": "stderr",
+      "line_count": 20,
+      "byte_count": 4096,
+      "truncated": true,
+      "text": "error[E0425]: cannot find value `cache_policy` in this scope\n..."
+    }
+  ]
+}
+```
+
+### `recent_output`
+
+`recent_output` contains bounded rolling snippets from child stdout/stderr.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `source` | `str` | `agent:<name>`, `subprocess:<pid>`, `recipe:<name>`, or `step:<id>` |
+| `stream` | `str` | `stdout`, `stderr`, or `combined` |
+| `line_count` | `int` | Number of retained lines |
+| `byte_count` | `int` | Number of retained bytes |
+| `truncated` | `bool` | `true` when older output was dropped |
+| `text` | `str` | Recent output text; bounded but not additionally redacted by this feature |
+
+Consumers should ignore unknown fields and handle all progress fields as
+optional. The `amplihack` CLI must preserve additive fields emitted by
+`recipe-runner-rs` when formatting JSON or YAML; parsing the runner output and
+then dropping unknown diagnostic fields is a bug. See
+[Recipe Runner Logging Reference](./recipe-runner-logging.md) for the full
+logging contract.
+
+---
+
 ## Usage Examples
 
 ### Check overall status
@@ -98,8 +177,8 @@ for step in result.step_results:
 ```bash
 amplihack recipe run default-workflow \
   -c task_description="add input validation" \
-  --verbose --output json | jq '.status'
-# "SUCCESS"
+  --format json | jq '.status // .success'
+# true
 ```
 
 ### Count successful steps
@@ -107,46 +186,64 @@ amplihack recipe run default-workflow \
 ```bash
 amplihack recipe run default-workflow \
   -c task_description="add input validation" \
-  --output json | jq '[.step_results[] | select(.status == "SUCCESS")] | length'
+  --format json | jq '[.step_results[] | select(.status == "completed" or .status == "SUCCESS")] | length'
 ```
 
 ### Serialise to JSON
 
-The `--output json` flag produces the full `RecipeResult` as JSON:
+The `--format json` flag produces the full `RecipeResult` as JSON:
 
 ```bash
 amplihack recipe run default-workflow \
   -c task_description="add input validation" \
-  --output json | jq .
+  --format json | jq .
+```
+
+### Inspect failure context
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="fix cache policy failure" \
+  --format json > result.json
+
+jq '.failure_context
+  | {step_id, step_name, elapsed_seconds, child, recent_output}' result.json
 ```
 
 ### Log a one-line summary
 
-Without `--output json`, the CLI prints a one-line summary to stderr:
+Without `--format json`, the CLI prints the final result in the default
+human-readable table format on stdout:
 
 ```
-RecipeResult(default-workflow: SUCCESS, 22 steps)
+Recipe: default-workflow
+Status: ✓ Success
+
+Steps:
+  ✓ requirements-clarification: completed
 ```
 
 ---
 
 ## Integration with Recipe Runner
 
-`RecipeResult` is what the CLI surfaces when `--output json` is requested:
+`RecipeResult` is what the CLI surfaces when `--format json` is requested:
 
 ```bash
 amplihack recipe run default-workflow \
-  --context '{"task_description": "add login endpoint"}' \
-  --output json | jq '.status'
-# "SUCCESS"
+  -c task_description="add login endpoint" \
+  --format json | jq '.status // .success'
+# true
 ```
 
-The JSON schema matches the fields documented in [Attributes](#attributes) with the `status` field serialised as a string value (`"SUCCESS"`, `"FAILURE"`, `"PARTIAL"`).
+The JSON schema matches the fields documented in [Attributes](#attributes).
+Existing result producers may expose either `success` (boolean) or `status`
+(`"SUCCESS"`, `"FAILURE"`, `"PARTIAL"`); consumers should accept both.
 
 ---
 
 ## See Also
 
-- [Recipe CLI Reference](./recipe-cli-reference.md) — `amplihack recipe run` and `--output json`
+- [Recipe CLI Reference](./recipe-cli-reference.md) — `amplihack recipe run` and `--format json`
 - [Recipe CLI Examples](../howto/recipe-cli-examples.md) — real-world workflow scenarios
 - [Recipe Resilience](../concepts/recipe-resilience.md) — how partial failures and retries are handled

--- a/docs/reference/recipe-runner-logging.md
+++ b/docs/reference/recipe-runner-logging.md
@@ -1,0 +1,323 @@
+# Recipe Runner Logging Reference
+
+Reference for live recipe progress, heartbeat events, bounded subprocess output
+snippets, and additive JSON fields emitted by `amplihack recipe run`.
+
+**Status:** Planned finished-state contract for the recipe-runner transparency
+feature.
+
+## Contents
+
+- [Output contract](#output-contract)
+- [Live progress lines](#live-progress-lines)
+- [Heartbeat events](#heartbeat-events)
+- [Recent output snippets](#recent-output-snippets)
+- [Failure context](#failure-context)
+- [JSON result fields](#json-result-fields)
+- [JSONL log events](#jsonl-log-events)
+- [Configuration](#configuration)
+- [Examples](#examples)
+
+## Output contract
+
+`amplihack recipe run` keeps human-readable progress and machine-readable final
+results on separate streams.
+
+| Stream | Contents | Intended consumer |
+| --- | --- | --- |
+| `stderr` | Live recipe progress, step lifecycle lines, heartbeats, failure diagnostics, bounded snippets | Humans, CI logs, terminal UIs |
+| `stdout` | Final command output in the requested `--format` (`table`, `json`, or `yaml`) | Shell pipelines, scripts, `jq` |
+
+Default runs emit progress to `stderr` without requiring `--verbose`.
+`--verbose` increases detail; it is not required for basic progress.
+
+```sh
+amplihack recipe run default-workflow \
+  -c task_description="Add cache headers" \
+  -c repo_path=. \
+  --format json > result.json
+```
+
+The terminal still shows live progress because progress is written to `stderr`,
+while `result.json` contains only the final JSON result from `stdout`.
+
+## Live progress lines
+
+Every step emits lifecycle progress in real time.
+
+```text
+[recipe default-workflow] started (23 steps)
+[step 04/23 requirements-clarification] started agent=prompt-writer
+[step 04/23 requirements-clarification] heartbeat elapsed=60s status=running phase=agent
+[step 04/23 requirements-clarification] completed elapsed=91s
+[step 05/23 implementation-planning] started agent=architect
+[step 05/23 implementation-planning] failed elapsed=34s error="agent exited with code 1"
+```
+
+Progress lines include:
+
+| Field | Description |
+| --- | --- |
+| Recipe name | The recipe being executed, such as `default-workflow` |
+| Step index | Current 1-based step number and total step count when known |
+| Step id/name | Stable step identifier from the recipe YAML |
+| Phase | `recipe`, `agent`, `subprocess`, `bash`, or `finalize` |
+| Status | `started`, `running`, `completed`, `failed`, or `skipped` |
+| Elapsed time | Wall-clock time since the step or recipe started |
+| Child identity | Agent name, subprocess command label, PID, or nested recipe name when available |
+
+## Heartbeat events
+
+Long-running recipe, agent, subprocess, and nested-recipe steps emit periodic
+heartbeats so callers can distinguish active work from a hung process.
+
+Default heartbeat behavior:
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| First heartbeat | After one interval | Avoids noise for short steps |
+| Interval | 60 seconds | Rate-limited per active step |
+| Stream | `stderr` | Human-readable line plus structured log event |
+| Contents | Step id/name, phase, status, elapsed time, child identity when known | Enough context to know what is still running |
+
+Heartbeat lines never include full child output. They may include a short
+progress hint such as the active agent name or subprocess label.
+
+## Recent output snippets
+
+The runner keeps bounded rolling buffers for each active subprocess, agent, and
+nested recipe. Snippets are attributed by source and stream.
+
+| Attribute | Behavior |
+| --- | --- |
+| Source | `agent:<name>`, `subprocess:<pid>`, `recipe:<name>`, or `step:<id>` |
+| Stream | `stdout`, `stderr`, or `combined` |
+| Bound | Limited by line count and byte count |
+| Retention | Recent output only; older lines are dropped |
+| Redaction | No additional redaction guarantee; snippets are bounded but may contain whatever the child printed |
+| Live output | Snippets are summarized in progress logs; noisy child output is not streamed unbounded |
+
+Do not print secrets from recipe steps. The transparency feature limits snippet
+size and attribution, but it is not a substitute for secret-safe child tools.
+
+Snippets appear in:
+
+- step failure diagnostics printed to `stderr`
+- JSON result fields when `--format json` is used
+- JSONL recipe log events when recipe logging is enabled
+
+## Failure context
+
+Failures include actionable context instead of only a generic step failure.
+
+```text
+[step 08/23 code-implementation] failed elapsed=12m14s agent=builder
+error: agent exited with code 1
+
+recent stderr from agent:builder (last 20 lines, 8192 bytes max):
+  error[E0425]: cannot find value `cache_policy` in this scope
+  --> src/http/cache.rs:42:18
+   |
+42 |     apply_policy(cache_policy);
+   |                  ^^^^^^^^^^^^ not found in this scope
+
+recent stdout from agent:builder:
+  Running cargo test --quiet
+```
+
+Failure diagnostics include these fields when known:
+
+| Field | Description |
+| --- | --- |
+| `step_id` | Stable recipe step id |
+| `step_name` | Human-readable step name or label |
+| `phase` | Current phase at failure time |
+| `status` | `failed` |
+| `elapsed_seconds` | Step duration |
+| `child` | Agent, subprocess, or nested recipe identity |
+| `exit_code` | Child process exit code when applicable |
+| `recent_output` | Bounded attributed stdout/stderr snippets |
+
+## JSON result fields
+
+The final JSON result remains backward-compatible. Existing fields are preserved;
+new fields are optional and additive.
+
+Top-level result:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `recipe_name` | string | yes | Recipe name |
+| `success` | boolean | yes, when used by the existing result schema | Boolean overall result |
+| `status` | string | yes, when used by the existing result schema | Overall result such as `SUCCESS`, `FAILURE`, or `PARTIAL` |
+| `step_results` | array | yes | Ordered step results |
+| `context` | object | no | Final context values |
+| `duration_seconds` | number | no | Total recipe duration |
+| `progress_summary` | object | no | Last known phase/status, heartbeat count, and log path |
+| `failure_context` | object | no | Failure context for the first failing step |
+
+Step result additive fields:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `step_id` | string | yes | Stable step id |
+| `status` | string | yes | `completed`, `failed`, or `skipped` |
+| `output` | string | no | Step output or summary |
+| `error` | string | no | Error message |
+| `step_name` | string | no | Human-readable name |
+| `phase` | string | no | Last phase for the step |
+| `elapsed_seconds` | number | no | Step duration |
+| `started_at` | string | no | RFC 3339 timestamp |
+| `completed_at` | string | no | RFC 3339 timestamp |
+| `child` | object | no | Agent, subprocess, or nested recipe identity |
+| `last_heartbeat_at` | string | no | RFC 3339 timestamp of last heartbeat |
+| `recent_output` | array | no | Bounded attributed snippets |
+
+`child` object:
+
+```json
+{
+  "kind": "agent",
+  "name": "builder",
+  "pid": 12345,
+  "command": "copilot --agent builder"
+}
+```
+
+`recent_output` entry:
+
+```json
+{
+  "source": "agent:builder",
+  "stream": "stderr",
+  "line_count": 20,
+  "byte_count": 4096,
+  "truncated": true,
+  "text": "error[E0425]: cannot find value `cache_policy` in this scope\n..."
+}
+```
+
+Consumers should ignore unknown fields and treat every field in this section as
+optional unless listed as required in the existing schema. The `amplihack` CLI
+must preserve additive fields emitted by `recipe-runner-rs` when it formats
+`--format json` or `--format yaml`; parsing the runner JSON and then dropping
+unknown diagnostic fields is a bug.
+
+## JSONL log events
+
+When recipe logging is enabled, the log file contains JSONL events with enough
+context to reconstruct progress.
+
+Lifecycle event:
+
+```json
+{
+  "type": "step_lifecycle",
+  "recipe_name": "default-workflow",
+  "step_index": 8,
+  "total_steps": 23,
+  "step_id": "code-implementation",
+  "step_name": "Code implementation",
+  "phase": "agent",
+  "status": "started",
+  "child": { "kind": "agent", "name": "builder" },
+  "elapsed_seconds": 0.0,
+  "timestamp": "2026-06-03T18:12:00Z"
+}
+```
+
+Heartbeat event:
+
+```json
+{
+  "type": "heartbeat",
+  "recipe_name": "default-workflow",
+  "step_id": "code-implementation",
+  "step_name": "Code implementation",
+  "phase": "agent",
+  "status": "running",
+  "child": { "kind": "agent", "name": "builder" },
+  "elapsed_seconds": 180.0,
+  "timestamp": "2026-06-03T18:15:00Z"
+}
+```
+
+Output snippet event:
+
+```json
+{
+  "type": "output_snippet",
+  "recipe_name": "default-workflow",
+  "step_id": "code-implementation",
+  "source": "agent:builder",
+  "stream": "stderr",
+  "recent_output": {
+    "line_count": 12,
+    "byte_count": 2048,
+    "truncated": false,
+    "text": "Running cargo test --quiet\n..."
+  },
+  "timestamp": "2026-06-03T18:15:30Z"
+}
+```
+
+## Configuration
+
+Defaults are conservative and bounded. Configure them through environment
+variables or the matching keys in `~/.amplihack/config`.
+
+| Environment variable | Config key | Default | Description |
+| --- | --- | --- | --- |
+| `AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS` | `recipe.heartbeat_interval_seconds` | `60` | Seconds between heartbeat lines per active step. Set `0` to disable heartbeats. |
+| `AMPLIHACK_RECIPE_SNIPPET_LINES` | `recipe.snippet_lines` | `20` | Maximum recent lines retained per source/stream. |
+| `AMPLIHACK_RECIPE_SNIPPET_BYTES` | `recipe.snippet_bytes` | `8192` | Maximum bytes retained per source/stream. |
+| `AMPLIHACK_RECIPE_LOG_JSONL` | `recipe.log_jsonl` | unset | Optional path for structured JSONL recipe events. |
+
+Environment variables take precedence over config-file keys.
+
+Use `--verbose` to include child launch details and additional snippet context:
+
+```sh
+amplihack recipe run default-workflow \
+  -c task_description="Update dependencies" \
+  --verbose
+```
+
+`--progress` is not a supported `amplihack recipe run` flag. Passing it should
+fail fast with an actionable message explaining that progress is already emitted
+to `stderr` by default and that `--verbose` only increases diagnostic detail.
+
+## Examples
+
+Capture final JSON while watching progress:
+
+```sh
+amplihack recipe run default-workflow \
+  -c task_description="Add input validation" \
+  -c repo_path=. \
+  --format json > /tmp/recipe-result.json
+```
+
+Write a JSONL event log:
+
+```sh
+AMPLIHACK_RECIPE_LOG_JSONL=/tmp/default-workflow.jsonl \
+amplihack recipe run default-workflow \
+  -c task_description="Fix flaky retry tests" \
+  -c repo_path=.
+```
+
+Show the failing step and recent stderr from the final JSON:
+
+```sh
+jq '.step_results[]
+  | select(.status == "failed")
+  | {step_id, elapsed_seconds, child, recent_output}' /tmp/recipe-result.json
+```
+
+## Related
+
+- [Run a Recipe End-to-End](../howto/run-a-recipe.md) - Usage guide
+- [RecipeResult Reference](./recipe-result.md) - Final result schema
+- [amplihack recipe Reference](./recipe-command.md) - Command-line flags
+- [Recipe Runner Architecture](../concepts/recipe-runner-architecture.md) - CLI and runner responsibility split

--- a/docs/reference/rust-runner-execution.md
+++ b/docs/reference/rust-runner-execution.md
@@ -1,219 +1,143 @@
-# Rust Runner Execution — API Reference
+# Rust Runner Execution Reference
 
-The `amplihack` Rust CLI binary (`recipe-runner-rs`) handles subprocess management, progress tracking, JSONL event emission, and log I/O for recipe execution.
+`recipe-runner-rs` executes recipes. `amplihack recipe run` is the supported
+entry point that resolves the runner binary, passes context, and formats the
+final result.
 
-Subprocess management, progress tracking, JSONL event emission, and log I/O helpers for the Rust recipe runner. Callers should use `amplihack recipe run`.
+**Status:** Planned finished-state contract for recipe-runner transparency.
 
 ## Contents
 
-- [Public API](#public-api)
-  - [execute_rust_command](#execute_rust_command)
-  - [read_progress_file](#read_progress_file)
-  - [emit_step_transition](#emit_step_transition)
-  - [build_rust_env](#build_rust_env)
-- [Data Shapes](#data-shapes)
-  - [Progress file JSON](#progress-file-json)
-  - [JSONL step-transition event](#jsonl-step-transition-event)
-- [Environment Variables](#environment-variables)
-- [Security Model](#security-model)
-- [Internal Functions](#internal-functions)
+- [Execution contract](#execution-contract)
+- [Stream contract](#stream-contract)
+- [JSONL events](#jsonl-events)
+- [Environment variables](#environment-variables)
+- [Security model](#security-model)
+- [Related](#related)
 
----
+## Execution contract
 
-## Public API
-
-### `execute_rust_command`
-
-The Rust binary handles command execution internally. To run a recipe:
+Use the wrapper CLI:
 
 ```bash
-amplihack recipe run my-recipe --verbose
+amplihack recipe run default-workflow \
+  -c task_description="Add cache headers" \
+  -c repo_path=. \
+  --format json
 ```
 
-The binary manages:
+The wrapper:
 
-| Concern       | Description                                                                                                                                    |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Command       | The recipe name and context flags. Never passed through a shell.                                                                               |
-| Progress      | When `--verbose` is set, creates a per-recipe log file, writes progress JSON after each step marker, and prints the log path to stderr for live `tail -f`. |
-| Environment   | Filtered environment with only allowlisted variables (see [build_rust_env](#build_rust_env)).                                                   |
+1. Resolves `recipe-runner-rs`.
+2. Resolves recipe names and recipe YAML paths.
+3. Passes context as runner `--set key=value` values or a context file when
+   arguments would be too large.
+4. Preserves the runner's stderr progress stream.
+5. Writes the final result to stdout in the requested `table`, `json`, or `yaml`
+   format.
 
-Returns structured JSON output when `--output json` is used. See [`RecipeResult`](./recipe-result.md).
+## Stream contract
 
-**Example:**
+| Stream | Contents | Consumer |
+| --- | --- | --- |
+| `stderr` | Human-readable lifecycle progress, heartbeats, and failure diagnostics | Humans and CI logs |
+| `stdout` | Final result in the selected `--format` | Scripts and pipelines |
+
+Progress is emitted by default. `--verbose` may add child launch details and
+expanded diagnostics, but basic progress does not require it.
+
+`amplihack recipe run` does not support a `--progress` flag. Passing it should
+fail with an actionable message explaining that progress is already on stderr by
+default.
+
+## JSONL events
+
+Set `AMPLIHACK_RECIPE_LOG_JSONL` to write structured events to a file:
 
 ```bash
-amplihack recipe run my-recipe --verbose --output json | jq '.success'
+AMPLIHACK_RECIPE_LOG_JSONL=/tmp/default-workflow.jsonl \
+amplihack recipe run default-workflow \
+  -c task_description="Add retry metrics"
 ```
 
----
-
-### `read_progress_file`
-
-The Rust binary writes progress JSON files during execution. These can be read by monitoring tools:
-
-```bash
-# Progress files are written to the system temp directory
-cat /tmp/amplihack-progress-my_recipe-12345.json
-```
-
-Returned dict fields (required fields are always present when the function returns non-`None`; optional fields may be absent):
-
-| Field             | Type    | Required | Description                                                                                                                                         |
-| ----------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `recipe_name`     | `str`   | ✓        | Sanitized recipe name                                                                                                                               |
-| `current_step`    | `int`   | ✓        | 1-based index of the running step                                                                                                                   |
-| `status`          | `str`   | ✓        | One of `running`, `completed`, `failed`                                                                                                             |
-| `pid`             | `int`   | ✓        | PID of the recipe-runner-rs process                                                                                                                 |
-| `total_steps`     | `int`   | optional | Total step count; the Python streaming layer always writes `0` (unknown) — only a Rust binary that reports step totals will supply a non-zero value |
-| `step_name`       | `str`   | optional | Human-readable step label                                                                                                                           |
-| `elapsed_seconds` | `float` | optional | Seconds since recipe start                                                                                                                          |
-| `updated_at`      | `float` | optional | Unix timestamp of last write                                                                                                                        |
-
----
-
-### `emit_step_transition`
-
-The Rust binary emits machine-readable JSONL step-transition events to **stderr** with immediate flush.
-
-| Field       | Values                                        |
-| ----------- | --------------------------------------------- |
-| `step_name` | Arbitrary label matching the recipe step name |
-| `status`    | `"start"` · `"done"` · `"fail"` · `"skip"`    |
-
-These events are emitted automatically by the recipe runner during execution.
-
-**Output format:**
-
-```json
-{ "type": "step_transition", "step": "validate-inputs", "status": "start", "ts": 1743554401.12 }
-```
-
-**Filtering:** Parent processes suppress these lines from user-visible output via `_STEP_TRANSITION_PREFIX` detection.
-
----
-
-### `build_rust_env`
-
-The Rust binary builds a filtered environment for subprocess execution. Only variables on an internal allowlist are included, preventing accidental secret leakage (e.g. `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`).
-
-If `AMPLIHACK_AGENT_BINARY` is `"copilot"`, the binary creates a shim wrapper to intercept nested `copilot` invocations inside the recipe.
-
-**Allowlisted variable families:**
-
-| Family           | Examples                                                         |
-| ---------------- | ---------------------------------------------------------------- |
-| `AMPLIHACK_*`    | `AMPLIHACK_HOME`, `AMPLIHACK_SESSION_ID`, `AMPLIHACK_RECIPE_LOG` |
-| Path & shell     | `PATH`, `HOME`, `SHELL`, `USER`                                  |
-| Proxy            | `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` (case-insensitive)       |
-| TLS / CA bundles | `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`          |
-| Locale           | `LANG`, `LC_ALL`, `LC_CTYPE`                                     |
-| Temp dirs        | `TMPDIR`, `TMP`, `TEMP`                                          |
-| Runtime          | `RECIPE_RUNNER_RS_PATH`, `CLAUDE_PROJECT_DIR`                |
-
----
-
-## Data Shapes
-
-### Progress file JSON
-
-Written to `/tmp/amplihack-progress-<recipe>-<pid>.json` after each step transition.
+Lifecycle event:
 
 ```json
 {
-  "recipe_name": "smart-orchestrator",
-  "current_step": 3,
-  "total_steps": 0,
-  "step_name": "Run builder agent",
-  "elapsed_seconds": 42.8,
-  "status": "running",
-  "pid": 98765,
-  "updated_at": 1743554401.5
+  "type": "step_lifecycle",
+  "recipe_name": "default-workflow",
+  "step_index": 8,
+  "total_steps": 23,
+  "step_id": "code-implementation",
+  "step_name": "Code implementation",
+  "phase": "agent",
+  "status": "started",
+  "child": { "kind": "agent", "name": "builder" },
+  "elapsed_seconds": 0.0,
+  "timestamp": "2026-06-03T18:12:00Z"
 }
 ```
 
-> **Note:** `total_steps` may be `0` if the recipe does not report step totals upfront. Treat `0` as "unknown".
-
-An optional workstream sidecar at `$AMPLIHACK_WORKSTREAM_PROGRESS_FILE` augments the main file with:
+Heartbeat event:
 
 ```json
 {
-  "recipe_name": "smart-orchestrator",
-  "current_step": 3,
-  "step_name": "Run builder agent",
+  "type": "heartbeat",
+  "recipe_name": "default-workflow",
+  "step_id": "code-implementation",
+  "phase": "agent",
   "status": "running",
-  "pid": 98765,
-  "updated_at": 1743554401.5,
-  "issue": "1234",
-  "checkpoint_id": "cp-abc",
-  "worktree_path": "/home/user/repo/worktrees/issue-1234"
+  "elapsed_seconds": 180.0,
+  "timestamp": "2026-06-03T18:15:00Z"
 }
 ```
 
-### JSONL step-transition event
+Output snippet event:
 
-Emitted to stderr; one line per step transition.
-
+```json
+{
+  "type": "output_snippet",
+  "recipe_name": "default-workflow",
+  "step_id": "code-implementation",
+  "source": "agent:builder",
+  "stream": "stderr",
+  "recent_output": {
+    "line_count": 20,
+    "byte_count": 4096,
+    "truncated": true,
+    "text": "error[E0425]: cannot find value `cache_policy` in this scope\n..."
+  },
+  "timestamp": "2026-06-03T18:15:30Z"
+}
 ```
-{"type":"step_transition","step":"<step-name>","status":"<start|done|fail|skip>","ts":<float>}
-```
 
-Heartbeat pings from long-running steps use a separate type:
+Machine-readable events belong in the JSONL file. The user-visible stderr stream
+uses concise text lines for lifecycle progress and diagnostics.
 
-```
-{"type":"heartbeat","step":"<step-name>","ts":<float>}
-```
+## Environment variables
 
----
+| Variable | Description |
+| --- | --- |
+| `RECIPE_RUNNER_RS_PATH` | Optional path to the runner binary. |
+| `AMPLIHACK_STEP_TIMEOUT` | Global per-step timeout hint set by `--step-timeout`. |
+| `AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS` | Heartbeat interval in seconds; `0` disables heartbeat lines. |
+| `AMPLIHACK_RECIPE_SNIPPET_LINES` | Maximum recent output lines retained per child source/stream. |
+| `AMPLIHACK_RECIPE_SNIPPET_BYTES` | Maximum recent output bytes retained per child source/stream. |
+| `AMPLIHACK_RECIPE_LOG_JSONL` | Optional path for structured JSONL events. |
 
-## Environment Variables
+## Security model
 
-| Variable                             | Description                                                                                           |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| `AMPLIHACK_RECIPE_LOG`               | Set automatically to the log file path when `progress=True`. Child processes can append to this file. |
-| `AMPLIHACK_WORKSTREAM_PROGRESS_FILE` | Optional path for the workstream progress sidecar. Set by the workstream orchestrator.                |
-| `AMPLIHACK_WORKSTREAM_STATE_FILE`    | Optional path to a workstream state JSON file read for issue/checkpoint context.                      |
+| Property | Requirement |
+| --- | --- |
+| No wrapper shell interpolation | The wrapper launches `recipe-runner-rs` with argv values, not a shell string. Recipe `bash` steps may still execute shell code because that is their explicit step type. |
+| Bounded output capture | Recent output snippets are capped by line and byte limits before reaching stderr, JSON results, or JSONL logs. |
+| Secret handling | This feature does not add a new redaction guarantee. Child tools and recipes must avoid printing secrets. |
+| Additive JSON compatibility | The wrapper must preserve optional diagnostic fields emitted by the runner when formatting JSON or YAML. |
+| Visible failure | Runner launch, parse, and step failures must surface actionable stderr context instead of silent success. |
 
----
+## Related
 
-## Security Model
-
-| Property                   | Mechanism                                                                                                 |
-| -------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------- |
-| No shell injection         | `subprocess.Popen` always receives a `list[str]`; `shell=False` is the default                            |
-| Symlink-safe file creation | Progress and log files opened with `O_NOFOLLOW                                                            | O_CREAT`; mode `0o600` |
-| Atomic writes              | Progress JSON written via `tempfile.NamedTemporaryFile` + `os.replace()`; readers never see partial files |
-| Path traversal prevention  | `_validate_path_within_tmpdir()` rejects any resolved path outside `tempfile.gettempdir()`                |
-| Minimal env surface        | `build_rust_env()` allowlist excludes all credential variables                                            |
-| Recipe name sanitization   | Recipe names reduced to `[a-zA-Z0-9_]`, capped at 64 characters before use in file paths                  |
-
----
-
-## Internal Functions
-
-These functions are implementation details; do not call them directly.
-
-| Function                                                                    | Purpose                                                                                 |
-| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `_validate_path_within_tmpdir(path)`                                        | Raises `ValueError` if `path.resolve()` escapes `tempfile.gettempdir()`                 |
-| `_atomic_write_json(path, payload)`                                         | Write JSON payload atomically; falls back to direct write on cross-device rename errors |
-| `_progress_file_path(recipe_name, pid)`                                     | Returns `/tmp/amplihack-progress-<sanitized>-<pid>.json`                                |
-| `_recipe_log_path(recipe_name, pid)`                                        | Returns `/tmp/amplihack-recipe-<sanitized>-<pid>.log`                                   |
-| `_stream_process_output(process)`                                           | Basic stdout/stderr drain (no progress tracking)                                        |
-| `_stream_process_output_with_progress(process, recipe_name, log_file_path)` | Thread-based drain with step-marker detection and log tee                               |
-| `_run_rust_process(cmd, progress, env, recipe_name)`                        | Spawn process, select streaming mode, return `(stdout, stderr, returncode, log_path)`   |
-| `_meaningful_stderr_tail(stderr)`                                           | Last 5 lines of stderr after filtering metadata lines                                   |
-| `_is_progress_metadata_line(line)`                                          | Returns `True` for step-transition and heartbeat JSONL lines                            |
-| `_raise_process_failure(stderr, returncode)`                                | Raise `RuntimeError` with signal name or trimmed stderr                                 |
-| `_parse_rust_response(stdout, stderr, returncode, name)`                    | JSON parse with structured error fallback                                               |
-| `_validate_rust_response_payload(data, name)`                               | Assert contract: `success` (bool), `step_results` (list), `context` (dict)              |
-| `_build_step_results(step_results_data)`                                    | Convert raw JSON list to `list[StepResult]`                                             |
-
----
-
-**See also:**
-
-- [Recipe Result data model](./recipe-result.md)
+- [RecipeResult Reference](./recipe-result.md)
 - [Recipe CLI Reference](./recipe-cli-reference.md)
+- [Recipe Runner Logging Reference](./recipe-runner-logging.md)
 - [Rust Runner Execution Architecture](../concepts/rust-runner-execution-architecture.md)
-- [Issue Classifier Workflow](../howto/configure-issue-classifier-workflow.md)

--- a/docs/tutorials/recipe-progress-transparency.md
+++ b/docs/tutorials/recipe-progress-transparency.md
@@ -1,0 +1,203 @@
+# Observe Recipe Progress and Debug a Failed Step
+
+Learn how to run a recipe, watch live progress, capture the structured result,
+and use bounded output snippets to diagnose a failed step.
+
+**Status:** Planned tutorial for the finished recipe-runner transparency
+feature.
+
+## What you will do
+
+In this tutorial you will:
+
+1. Run `default-workflow` with live progress visible in the terminal.
+2. Save the final JSON result without mixing it with progress output.
+3. Read heartbeat lines during a long-running agent step.
+4. Inspect recent stdout/stderr snippets when a step fails.
+5. Tune heartbeat and snippet limits for a single run.
+
+## Before you start
+
+You need:
+
+- `amplihack` installed
+- a repository checkout
+- `jq` for the JSON examples
+
+## Run a recipe and watch progress
+
+From a repository checkout:
+
+```sh
+cd /home/user/src/myapp
+
+amplihack recipe run default-workflow \
+  -c task_description="Add validation for empty display names" \
+  -c repo_path=.
+```
+
+The terminal shows lifecycle progress on `stderr` as each step starts, runs, and
+finishes:
+
+```text
+[recipe default-workflow] started (23 steps)
+[step 01/23 requirements-clarification] started agent=prompt-writer
+[step 01/23 requirements-clarification] completed elapsed=24s
+[step 02/23 implementation-planning] started agent=architect
+```
+
+Short steps may only show `started` and `completed`. Long-running steps also
+emit heartbeat lines.
+
+## Capture JSON without losing progress
+
+Progress is written to `stderr`; final structured output is written to `stdout`.
+That means you can redirect the final result while still watching progress:
+
+```sh
+amplihack recipe run default-workflow \
+  -c task_description="Add validation for empty display names" \
+  -c repo_path=. \
+  --format json > /tmp/default-workflow-result.json
+```
+
+While the recipe runs, the terminal still shows progress. After it finishes,
+inspect the final result:
+
+```sh
+jq '{recipe_name, success, duration_seconds}' /tmp/default-workflow-result.json
+```
+
+Example output:
+
+```json
+{
+  "recipe_name": "default-workflow",
+  "success": true,
+  "duration_seconds": 842.3
+}
+```
+
+## Recognize a healthy long-running step
+
+When an agent step takes longer than the heartbeat interval, the runner prints a
+bounded status line:
+
+```text
+[step 08/23 code-implementation] heartbeat elapsed=180s status=running phase=agent agent=builder
+```
+
+This means the runner is still alive, the active step is known, and the child
+agent has not exited. Heartbeats are rate-limited per active step, so the log
+does not flood during long workflows.
+
+## Inspect a failed step
+
+If a step fails, the terminal shows the step identity, elapsed time, child
+identity, and recent output snippets:
+
+```text
+[step 08/23 code-implementation] failed elapsed=12m14s agent=builder
+error: agent exited with code 1
+
+recent stderr from agent:builder (last 20 lines, 8192 bytes max):
+  error[E0425]: cannot find value `cache_policy` in this scope
+  --> src/http/cache.rs:42:18
+```
+
+The same context is available in the JSON result:
+
+```sh
+jq '.step_results[]
+  | select(.status == "failed")
+  | {step_id, step_name, elapsed_seconds, child, recent_output}' \
+  /tmp/default-workflow-result.json
+```
+
+Use the `source` and `stream` fields to tell whether the snippet came from an
+agent, a shell subprocess, or a nested recipe:
+
+```json
+{
+  "step_id": "code-implementation",
+  "step_name": "Code implementation",
+  "elapsed_seconds": 734.2,
+  "child": {
+    "kind": "agent",
+    "name": "builder"
+  },
+  "recent_output": [
+    {
+      "source": "agent:builder",
+      "stream": "stderr",
+      "line_count": 20,
+      "byte_count": 4096,
+      "truncated": true,
+      "text": "error[E0425]: cannot find value `cache_policy` in this scope\n..."
+    }
+  ]
+}
+```
+
+## Tune diagnostics for one run
+
+Use environment variables when you need different heartbeat or snippet limits
+for one command.
+
+Increase heartbeat frequency while debugging:
+
+```sh
+AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS=15 \
+amplihack recipe run default-workflow \
+  -c task_description="Debug hanging test generation" \
+  -c repo_path=.
+```
+
+Keep larger snippets for a noisy compiler failure:
+
+```sh
+AMPLIHACK_RECIPE_SNIPPET_LINES=60 \
+AMPLIHACK_RECIPE_SNIPPET_BYTES=32768 \
+amplihack recipe run default-workflow \
+  -c task_description="Fix build failures after dependency update" \
+  -c repo_path=. \
+  --format json > /tmp/failure.json
+```
+
+## Write a JSONL event log
+
+Set `AMPLIHACK_RECIPE_LOG_JSONL` when a CI job or monitoring tool needs a
+stream of structured events:
+
+```sh
+AMPLIHACK_RECIPE_LOG_JSONL=/tmp/default-workflow.jsonl \
+amplihack recipe run default-workflow \
+  -c task_description="Add retry budget metrics" \
+  -c repo_path=.
+```
+
+View heartbeat events:
+
+```sh
+jq 'select(.type == "heartbeat")' /tmp/default-workflow.jsonl
+```
+
+View output snippets:
+
+```sh
+jq 'select(.type == "output_snippet") | {step_id, source, stream, recent_output}' \
+  /tmp/default-workflow.jsonl
+```
+
+## What you learned
+
+Recipe runs are observable by default. Live progress stays on `stderr`, final
+structured output stays on `stdout`, long-running steps emit rate-limited
+heartbeats, and failures include bounded recent output from the active child
+process.
+
+## Related
+
+- [Recipe Runner Logging Reference](../reference/recipe-runner-logging.md)
+- [Run a Recipe End-to-End](../howto/run-a-recipe.md)
+- [Troubleshoot Recipe Execution Failures](../howto/troubleshoot-recipe-execution.md)

--- a/tests/integration/recipe_e2e_test.rs
+++ b/tests/integration/recipe_e2e_test.rs
@@ -114,6 +114,13 @@ steps: []
     tmp
 }
 
+#[cfg(unix)]
+fn make_executable(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .expect("failed to mark runner stub executable");
+}
+
 // ---------------------------------------------------------------------------
 // recipe list
 // ---------------------------------------------------------------------------
@@ -404,5 +411,114 @@ fn recipe_run_dry_run_default_workflow_exits_zero() {
         "recipe run --dry-run must exit 0. This is the WS3 critical-path gate. \
          Ensure recipe-runner-rs is installed or RECIPE_RUNNER_RS_PATH is set. \
          stdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// recipe run transparency (issue #691)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[cfg(unix)]
+fn recipe_run_forwards_runner_stderr_by_default_without_polluting_stdout_json() {
+    let bin = amplihack_bin();
+    if !bin.exists() {
+        panic!("amplihack binary not found at {bin:?}. Run `cargo build` first.");
+    }
+
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    std::fs::write(
+        &runner,
+        r#"#!/bin/sh
+echo '[step 01/02 setup] started' >&2
+echo '[step 01/02 setup] heartbeat elapsed=60s status=running phase=bash' >&2
+echo '[agent builder stderr] compiling generated tests' >&2
+printf '{"recipe_name":"stderr-forwarding","success":true,"step_results":[],"context":{}}\n'
+"#,
+    )
+    .expect("failed to write runner stub");
+    make_executable(&runner);
+
+    let recipe = write_temp_recipe("stderr-forwarding", true);
+    let amplihack_home = temp.path().join("amplihack-home");
+    std::fs::create_dir_all(&amplihack_home).expect("failed to create AMPLIHACK_HOME");
+
+    let (stdout, stderr, success) = run_output(
+        Command::new(&bin)
+            .args([
+                "recipe",
+                "run",
+                recipe.path().to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .env("RECIPE_RUNNER_RS_PATH", &runner)
+            .env("AMPLIHACK_HOME", &amplihack_home),
+        "recipe run default stderr forwarding",
+    );
+
+    assert!(
+        success,
+        "recipe run with stub runner must exit 0. stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("[step 01/02 setup] started"),
+        "runner step lifecycle stderr must be forwarded by default. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("heartbeat elapsed=60s"),
+        "runner heartbeat stderr must be forwarded by default. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("compiling generated tests"),
+        "runner attributed child stderr snippets must be forwarded by default. stderr:\n{stderr}"
+    );
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must remain parseable JSON");
+    assert_eq!(
+        parsed["recipe_name"].as_str(),
+        Some("stderr-forwarding"),
+        "stdout must contain only the structured final result JSON. stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("heartbeat elapsed"),
+        "live progress must stay on stderr and not pollute structured stdout. stdout:\n{stdout}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn recipe_run_progress_flag_fails_with_explicit_default_progress_guidance() {
+    let bin = amplihack_bin();
+    if !bin.exists() {
+        panic!("amplihack binary not found at {bin:?}. Run `cargo build` first.");
+    }
+
+    let recipe = write_temp_recipe("unsupported-progress", true);
+    let (stdout, stderr, success) = run_output(
+        Command::new(&bin).args([
+            "recipe",
+            "run",
+            recipe.path().to_str().unwrap(),
+            "--progress",
+        ]),
+        "recipe run --progress unsupported",
+    );
+
+    assert!(
+        !success,
+        "--progress must be rejected instead of silently changing execution semantics. stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("--progress"),
+        "error output must identify the unsupported flag. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("progress is emitted by default")
+            || stderr.contains("progress is already emitted")
+            || stderr.contains("stderr by default"),
+        "error output must explain that live progress is already emitted to stderr by default. stderr:\n{stderr}"
     );
 }


### PR DESCRIPTION
## Problem

When subprocesses/subagents run the default-workflow recipe, their work is not visible enough to the caller. The recipe runner produces a JSON log file, but:
- Step-level progress was only streamed to stderr when `--verbose` was passed
- Step results lacked metadata (elapsed time, phase, child process info, output snippets)
- The output format used manual JsonMap construction that was verbose and fragile
- No way to tail/follow recipe logs from a separate terminal

## Solution

### Core changes (execute.rs + format.rs + mod.rs)
- **Always stream stderr** — removed the verbose-only gating so step transitions are always visible in real-time
- **Bounded stderr capture** — switched from unbounded `Vec<String>` to `VecDeque<String>` with 200-line cap to prevent OOM on long-running recipes
- **Rich step metadata** — added `step_name`, `phase`, `elapsed_ms`, `heartbeat_at`, `child` process info, `recent_stdout/stderr` snippet fields to `RecipeRunStepResult`
- **Simplified formatting** — replaced manual JsonMap construction with `serde_json::to_value` for JSON/YAML output
- **Human-readable table** — step output now shows elapsed time, phase, child labels, and recent output snippets

### New CLI capability
- `amplihack recipe status --follow` subcommand for live log tailing from a separate terminal

### Documentation
- `docs/reference/recipe-runner-logging.md` — comprehensive logging reference
- `docs/tutorials/recipe-progress-transparency.md` — tutorial for monitoring recipe execution

## Test Coverage
- 179+ lines of new unit tests in `tests_execute.rs`
- 116-line integration test in `recipe_e2e_test.rs`
- All existing tests pass (1481 unit tests, 0 failures)

Closes #691