### PR TITLE
fix: complete round 1 maintenance gaps

### DIFF
--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -58,6 +58,8 @@ pub(super) fn execute_recipe_via_rust(
         .with_asset_resolver()
         .with_pager_safe_defaults()
         .with_python_sanitization()
+        .unset("CLAUDECODE")
+        .set("AMPLIHACK_NONINTERACTIVE", "1")
         .with_project_graph_db(working_dir)?;
 
     // Issue #439: propagate --step-timeout as AMPLIHACK_STEP_TIMEOUT env var.

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
@@ -414,6 +414,82 @@ fn test_execute_recipe_via_rust_sets_pager_safe_env() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_execute_recipe_via_rust_forces_noninteractive_and_strips_claudecode() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    let amplihack_home = temp.path().join("amplihack-home");
+    std::fs::create_dir_all(&amplihack_home).expect("failed to create amplihack home");
+
+    std::fs::write(
+        &runner,
+        "#!/bin/sh\ncat <<EOF\n{\"recipe_name\":\"subprocess-env-probe\",\"success\":true,\"step_results\":[],\"context\":{\"noninteractive\":\"$AMPLIHACK_NONINTERACTIVE\",\"claudecode\":\"${CLAUDECODE+present}\"}}\nEOF\n",
+    )
+    .expect("failed to write runner stub");
+
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&runner, std::fs::Permissions::from_mode(0o755))
+        .expect("failed to chmod runner");
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: subprocess-env-probe\nsteps: []\n")
+        .expect("failed to write recipe");
+
+    let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+    let prev_home = std::env::var_os("AMPLIHACK_HOME");
+    let prev_noninteractive = std::env::var_os("AMPLIHACK_NONINTERACTIVE");
+    let prev_claudecode = std::env::var_os("CLAUDECODE");
+    unsafe {
+        std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+        std::env::set_var("AMPLIHACK_HOME", &amplihack_home);
+        std::env::set_var("AMPLIHACK_NONINTERACTIVE", "0");
+        std::env::set_var("CLAUDECODE", "1");
+    }
+
+    let result = execute::execute_recipe_via_rust(
+        &recipe,
+        &BTreeMap::new(),
+        true,
+        false,
+        temp.path(),
+        &[],
+        None,
+    )
+    .expect("recipe run must succeed");
+
+    match prev_runner {
+        Some(value) => unsafe { std::env::set_var("RECIPE_RUNNER_RS_PATH", value) },
+        None => unsafe { std::env::remove_var("RECIPE_RUNNER_RS_PATH") },
+    }
+    match prev_home {
+        Some(value) => unsafe { std::env::set_var("AMPLIHACK_HOME", value) },
+        None => unsafe { std::env::remove_var("AMPLIHACK_HOME") },
+    }
+    match prev_noninteractive {
+        Some(value) => unsafe { std::env::set_var("AMPLIHACK_NONINTERACTIVE", value) },
+        None => unsafe { std::env::remove_var("AMPLIHACK_NONINTERACTIVE") },
+    }
+    match prev_claudecode {
+        Some(value) => unsafe { std::env::set_var("CLAUDECODE", value) },
+        None => unsafe { std::env::remove_var("CLAUDECODE") },
+    }
+
+    assert_eq!(
+        result.context.get("noninteractive"),
+        Some(&JsonValue::String("1".to_string())),
+        "recipe-runner subprocesses must force AMPLIHACK_NONINTERACTIVE=1 even when the parent has another value"
+    );
+    assert_eq!(
+        result.context.get("claudecode"),
+        Some(&JsonValue::String(String::new())),
+        "recipe-runner subprocesses must not inherit CLAUDECODE because nested Claude sessions treat it as an active host marker"
+    );
+}
+
+#[test]
 fn test_execute_recipe_via_rust_reports_nonzero_exit_with_stderr() {
     let _guard = crate::test_support::home_env_lock()
         .lock()

--- a/crates/amplihack-hooks/src/pre_tool_use/tests/pre_tool_use_tests.rs
+++ b/crates/amplihack-hooks/src/pre_tool_use/tests/pre_tool_use_tests.rs
@@ -39,6 +39,23 @@ fn blocks_no_verify() {
 }
 
 #[test]
+fn blocks_no_verify_from_camel_case_host_payload() {
+    let hook = PreToolUseHook;
+    let input: HookInput = serde_json::from_value(serde_json::json!({
+        "hookEventName": "PreToolUse",
+        "toolName": "Bash",
+        "toolInput": {"command": "git commit --no-verify -m 'test'"},
+        "sessionId": "session-123"
+    }))
+    .expect("camelCase PreToolUse host payload must deserialize");
+
+    let result = hook.process(input).unwrap();
+
+    assert_eq!(result["block"], true);
+    assert!(result["message"].as_str().unwrap().contains("--no-verify"));
+}
+
+#[test]
 fn blocks_no_verify_on_push() {
     let hook = PreToolUseHook;
     let result = hook

--- a/crates/amplihack-hooks/src/protocol.rs
+++ b/crates/amplihack-hooks/src/protocol.rs
@@ -7,6 +7,7 @@
 //! - Telemetry (stderr JSON line per invocation)
 
 use amplihack_types::HookInput;
+use anyhow::Context;
 use serde::Serialize;
 use std::io::{self, Read, Write};
 use std::panic::AssertUnwindSafe;
@@ -54,7 +55,8 @@ pub fn run_hook<H: Hook>(hook: H) {
     let result = std::panic::catch_unwind(AssertUnwindSafe(|| -> anyhow::Result<()> {
         let input_json = read_stdin()?;
 
-        let input: HookInput = serde_json::from_str(&input_json).unwrap_or(HookInput::Unknown);
+        let input: HookInput =
+            serde_json::from_str(&input_json).context("failed to deserialize hook input JSON")?;
 
         // Unknown events get versioned empty output (graceful forward-compat).
         if matches!(input, HookInput::Unknown) {

--- a/crates/amplihack-types/src/hook_io.rs
+++ b/crates/amplihack-types/src/hook_io.rs
@@ -3,7 +3,7 @@
 //! These types model the JSON protocol that hook hosts use to communicate
 //! with hook binaries via stdin/stdout.
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, de::Error as DeError};
 use serde_json::Value;
 use std::path::PathBuf;
 
@@ -11,88 +11,216 @@ use std::path::PathBuf;
 ///
 /// Uses `#[serde(other)]` for forward-compatibility: unknown hook events
 /// deserialize to `Unknown` instead of failing.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "hook_event_name")]
+#[derive(Debug, Clone)]
 pub enum HookInput {
     /// Pre-tool-use: decide whether to allow/deny a tool invocation.
-    #[serde(rename = "PreToolUse")]
     PreToolUse {
         tool_name: String,
         tool_input: Value,
-        #[serde(default)]
         session_id: Option<String>,
     },
 
     /// Post-tool-use: observe tool results for metrics/validation.
-    #[serde(rename = "PostToolUse")]
     PostToolUse {
         tool_name: String,
         tool_input: Value,
-        #[serde(default)]
         tool_result: Option<Value>,
-        #[serde(default)]
         session_id: Option<String>,
     },
 
     /// Stop: session is ending, decide whether to block or allow.
-    #[serde(rename = "Stop")]
     Stop {
-        #[serde(default)]
         stop_hook_active: Option<bool>,
-        #[serde(default)]
         transcript_path: Option<PathBuf>,
-        #[serde(default)]
         session_id: Option<String>,
     },
 
     /// Session start: initialize session state.
-    #[serde(rename = "SessionStart")]
     SessionStart {
-        #[serde(default)]
         session_id: Option<String>,
-        #[serde(default)]
         cwd: Option<PathBuf>,
-        #[serde(flatten)]
         extra: Value,
     },
 
     /// Session stop: finalize session state.
-    #[serde(rename = "SessionStop")]
     SessionStop {
-        #[serde(default)]
         session_id: Option<String>,
-        #[serde(default)]
         transcript_path: Option<PathBuf>,
-        #[serde(flatten)]
         extra: Value,
     },
 
     /// User prompt submission: process user prompt before LLM call.
-    #[serde(rename = "UserPromptSubmit")]
     UserPromptSubmit {
-        #[serde(default)]
         user_prompt: Option<String>,
-        #[serde(default)]
         session_id: Option<String>,
-        #[serde(flatten)]
         extra: Value,
     },
 
     /// Pre-compact: context window is about to be compacted.
-    #[serde(rename = "PreCompact")]
     PreCompact {
-        #[serde(default)]
         session_id: Option<String>,
-        #[serde(default)]
         transcript_path: Option<PathBuf>,
-        #[serde(flatten)]
         extra: Value,
     },
 
     /// Unknown hook event — forward-compatibility.
     /// New hook events from the host deserialize here instead of failing.
-    #[serde(other)]
     Unknown,
+}
+
+type JsonMap = serde_json::Map<String, Value>;
+
+const EVENT_FIELDS: &[&str] = &["hook_event_name", "hookEventName"];
+const TOOL_NAME_FIELDS: &[&str] = &["tool_name", "toolName"];
+const TOOL_INPUT_FIELDS: &[&str] = &["tool_input", "toolInput"];
+const TOOL_RESULT_FIELDS: &[&str] = &["tool_result", "toolResult"];
+const SESSION_ID_FIELDS: &[&str] = &["session_id", "sessionId"];
+const STOP_HOOK_ACTIVE_FIELDS: &[&str] = &["stop_hook_active", "stopHookActive"];
+const TRANSCRIPT_PATH_FIELDS: &[&str] = &["transcript_path", "transcriptPath"];
+const CWD_FIELDS: &[&str] = &["cwd"];
+const USER_PROMPT_FIELDS: &[&str] = &["user_prompt", "userPrompt"];
+
+impl<'de> Deserialize<'de> for HookInput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        let Some(map) = value.as_object() else {
+            return Ok(HookInput::Unknown);
+        };
+
+        let event = optional_typed_field::<String, D::Error>(map, EVENT_FIELDS)?
+            .map(|name| normalize_hook_event_name(&name))
+            .or_else(|| infer_hook_event_name(map));
+        let extra = || extra_fields(map);
+
+        match event.as_deref() {
+            Some("pretooluse") => Ok(HookInput::PreToolUse {
+                tool_name: required_typed_field(map, TOOL_NAME_FIELDS, "PreToolUse")?,
+                tool_input: required_value_field(map, TOOL_INPUT_FIELDS, "PreToolUse")?,
+                session_id: optional_typed_field(map, SESSION_ID_FIELDS)?,
+            }),
+            Some("posttooluse") => Ok(HookInput::PostToolUse {
+                tool_name: required_typed_field(map, TOOL_NAME_FIELDS, "PostToolUse")?,
+                tool_input: required_value_field(map, TOOL_INPUT_FIELDS, "PostToolUse")?,
+                tool_result: optional_value_field(map, TOOL_RESULT_FIELDS),
+                session_id: optional_typed_field(map, SESSION_ID_FIELDS)?,
+            }),
+            Some("stop") => Ok(HookInput::Stop {
+                stop_hook_active: optional_typed_field(map, STOP_HOOK_ACTIVE_FIELDS)?,
+                transcript_path: optional_typed_field(map, TRANSCRIPT_PATH_FIELDS)?,
+                session_id: optional_typed_field(map, SESSION_ID_FIELDS)?,
+            }),
+            Some("sessionstart") => Ok(HookInput::SessionStart {
+                session_id: optional_typed_field(map, SESSION_ID_FIELDS)?,
+                cwd: optional_typed_field(map, CWD_FIELDS)?,
+                extra: extra(),
+            }),
+            Some("sessionstop") => Ok(HookInput::SessionStop {
+                session_id: optional_typed_field(map, SESSION_ID_FIELDS)?,
+                transcript_path: optional_typed_field(map, TRANSCRIPT_PATH_FIELDS)?,
+                extra: extra(),
+            }),
+            Some("userpromptsubmit") => Ok(HookInput::UserPromptSubmit {
+                user_prompt: optional_typed_field(map, USER_PROMPT_FIELDS)?,
+                session_id: optional_typed_field(map, SESSION_ID_FIELDS)?,
+                extra: extra(),
+            }),
+            Some("precompact") => Ok(HookInput::PreCompact {
+                session_id: optional_typed_field(map, SESSION_ID_FIELDS)?,
+                transcript_path: optional_typed_field(map, TRANSCRIPT_PATH_FIELDS)?,
+                extra: extra(),
+            }),
+            Some(_) | None => Ok(HookInput::Unknown),
+        }
+    }
+}
+
+fn find_field<'a>(map: &'a JsonMap, names: &[&str]) -> Option<&'a Value> {
+    names.iter().find_map(|name| map.get(*name))
+}
+
+fn has_any_field(map: &JsonMap, names: &[&str]) -> bool {
+    names.iter().any(|name| map.contains_key(*name))
+}
+
+fn optional_typed_field<T, E>(map: &JsonMap, names: &[&str]) -> Result<Option<T>, E>
+where
+    T: for<'de> Deserialize<'de>,
+    E: DeError,
+{
+    let Some(value) = find_field(map, names) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    T::deserialize(value.clone()).map(Some).map_err(E::custom)
+}
+
+fn required_typed_field<T, E>(map: &JsonMap, names: &[&str], event: &str) -> Result<T, E>
+where
+    T: for<'de> Deserialize<'de>,
+    E: DeError,
+{
+    optional_typed_field(map, names)?.ok_or_else(|| E::custom(missing_field_message(event, names)))
+}
+
+fn optional_value_field(map: &JsonMap, names: &[&str]) -> Option<Value> {
+    find_field(map, names).cloned()
+}
+
+fn required_value_field<E>(map: &JsonMap, names: &[&str], event: &str) -> Result<Value, E>
+where
+    E: DeError,
+{
+    optional_value_field(map, names).ok_or_else(|| E::custom(missing_field_message(event, names)))
+}
+
+fn missing_field_message(event: &str, names: &[&str]) -> String {
+    format!(
+        "{event} payload missing required field `{}`",
+        names.join("`/`")
+    )
+}
+
+fn normalize_hook_event_name(name: &str) -> String {
+    name.chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn infer_hook_event_name(map: &JsonMap) -> Option<String> {
+    if has_any_field(map, TOOL_RESULT_FIELDS) {
+        return Some("posttooluse".to_string());
+    }
+    if has_any_field(map, TOOL_NAME_FIELDS) || has_any_field(map, TOOL_INPUT_FIELDS) {
+        return Some("pretooluse".to_string());
+    }
+    None
+}
+
+fn extra_fields(map: &JsonMap) -> Value {
+    let mut extra = map.clone();
+    for field in [
+        EVENT_FIELDS,
+        TOOL_NAME_FIELDS,
+        TOOL_INPUT_FIELDS,
+        TOOL_RESULT_FIELDS,
+        SESSION_ID_FIELDS,
+        STOP_HOOK_ACTIVE_FIELDS,
+        TRANSCRIPT_PATH_FIELDS,
+        CWD_FIELDS,
+        USER_PROMPT_FIELDS,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        extra.remove(*field);
+    }
+    Value::Object(extra)
 }
 
 #[cfg(test)]
@@ -141,5 +269,109 @@ mod tests {
         }"#;
         let input: HookInput = serde_json::from_str(json).unwrap();
         assert!(matches!(input, HookInput::PreToolUse { .. }));
+    }
+
+    #[test]
+    fn deserialize_pre_tool_use_accepts_camel_case_host_aliases() {
+        let json = r#"{
+            "hookEventName": "PreToolUse",
+            "toolName": "Bash",
+            "toolInput": {"command": "git commit --no-verify -m test"},
+            "sessionId": "session-123"
+        }"#;
+
+        let input: HookInput = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(
+            input,
+            HookInput::PreToolUse {
+                tool_name,
+                tool_input,
+                session_id: Some(session_id),
+            } if tool_name == "Bash"
+                && tool_input["command"] == "git commit --no-verify -m test"
+                && session_id == "session-123"
+        ));
+    }
+
+    #[test]
+    fn deserialize_post_tool_use_accepts_camel_case_host_aliases() {
+        let json = r#"{
+            "hookEventName": "PostToolUse",
+            "toolName": "Bash",
+            "toolInput": {"command": "cargo test"},
+            "toolResult": {"exit_code": 0},
+            "sessionId": "session-456"
+        }"#;
+
+        let input: HookInput = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(
+            input,
+            HookInput::PostToolUse {
+                tool_name,
+                tool_input,
+                tool_result: Some(tool_result),
+                session_id: Some(session_id),
+            } if tool_name == "Bash"
+                && tool_input["command"] == "cargo test"
+                && tool_result["exit_code"] == 0
+                && session_id == "session-456"
+        ));
+    }
+
+    #[test]
+    fn deserialize_stop_accepts_camel_case_optional_aliases() {
+        let json = r#"{
+            "hookEventName": "Stop",
+            "stopHookActive": true,
+            "transcriptPath": "/tmp/transcript.jsonl",
+            "sessionId": "session-789"
+        }"#;
+
+        let input: HookInput = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(
+            input,
+            HookInput::Stop {
+                stop_hook_active: Some(true),
+                transcript_path: Some(transcript_path),
+                session_id: Some(session_id),
+            } if transcript_path == PathBuf::from("/tmp/transcript.jsonl")
+                && session_id == "session-789"
+        ));
+    }
+
+    #[test]
+    fn deserialize_known_tool_event_missing_required_field_stays_invalid() {
+        let missing_tool_input = r#"{
+            "hookEventName": "PreToolUse",
+            "toolName": "Bash"
+        }"#;
+
+        assert!(
+            serde_json::from_str::<HookInput>(missing_tool_input).is_err(),
+            "known PreToolUse payloads without required toolInput must fail instead of degrading to Unknown"
+        );
+    }
+
+    #[test]
+    fn deserialize_pre_tool_use_without_event_name() {
+        let json = r#"{
+            "tool_name": "Bash",
+            "tool_input": {"command": "git merge --no-verify feature-branch"}
+        }"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert!(matches!(input, HookInput::PreToolUse { tool_name, .. } if tool_name == "Bash"));
+    }
+
+    #[test]
+    fn deserialize_known_tool_shape_without_event_missing_required_field_stays_invalid() {
+        let missing_tool_input = r#"{"toolName": "Bash"}"#;
+
+        assert!(
+            serde_json::from_str::<HookInput>(missing_tool_input).is_err(),
+            "tool-like payloads without hookEventName must still require toolInput"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- run cargo fmt before workflow-tdd checkpoint commits
- remove the dead profile-management install warning and suppress known-safe bundled symlink noise
- harden workflow-finalize PR ready handling for missing gh, gh failures, already-ready PRs, and merged PRs
- make recipe-runner subprocess execution noninteractive, unset CLAUDECODE, and force git/gh pagers to cat
- align workspace package and lockfile versions with v0.9.70

## Validation
- cargo test -p amplihack-cli
- cargo test -p amplihack-hooks
- cargo test -p amplihack-cli known_safe_bundled_symlink_predicate_is_tightly_scoped
- cargo test -p amplihack-cli test_execute_recipe_via_rust_sets_subprocess_safe_env
- cargo test -p amplihack-cli --test issue_439_no_per_step_timeout tdd_checkpoint_formats_rust_before_commit -- --exact
- cargo test -p amplihack-cli --test issue_439_no_per_step_timeout finalize_pr_ready_handles_gh_and_pr_state_failures -- --exact
- git diff --check