### PR TITLE
docs: specify install/update PATH conflict handling

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,6 +22,7 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 ## Update Check
 
 - [Post-Update Install — Re-exec New Binary](update-reexec-new-binary.md) — after `amplihack update` downloads a new binary, the post-update install step spawns the **new** binary as a subprocess instead of running the old binary's compiled-in install code (issue [#683](https://github.com/rysweet/amplihack-rs/issues/683)).
+- [Install/Update PATH Conflict Handling](../reference/install-update-path-conflicts.md) — detects stale system binaries that shadow `~/.local/bin`, prefers safe user-local update targets, and reports manual sudo repair guidance without attempting privileged writes.
 - [Startup Self-Update Prompt — Subprocess-Safe Skip](startup-update-prompt-subprocess-safe.md) — startup self-update prompt skips automatically in CI, delegated agents, non-TTY stdin, with `--subprocess-safe`, or when `AMPLIHACK_NONINTERACTIVE` / `AMPLIHACK_AGENT_BINARY` is set; emits a single skip-line to stderr (issue [#625](https://github.com/rysweet/amplihack-rs/issues/625)).
 
 ## Workflow Recovery

--- a/docs/features/update-reexec-new-binary.md
+++ b/docs/features/update-reexec-new-binary.md
@@ -41,12 +41,17 @@ process image remains the old executable regardless of filesystem changes.
 
 ## How it works
 
-After `download_and_replace()` atomically installs the new binary,
-`run_update()` spawns the new binary as a child process instead of calling
-`run_install` in-process:
+After `run_update()` selects a safe replacement target and
+`download_and_replace()` atomically installs the new binary, it spawns the new
+binary as a child process instead of calling `run_install` in-process:
 
 ```
 amplihack update
+  │
+  ├─ analyze PATH conflicts
+  │    → inspect ordered candidates for amplihack + amplihack-hooks
+  │    → prefer ~/.local/bin when current/writable user binaries exist
+  │    → stop with manual repair guidance for unsafe system targets
   │
   ├─ download_and_replace(&release)
   │    → downloads, verifies SHA-256, atomic rename
@@ -99,6 +104,13 @@ amplihack update
    user sees install progress in real time. The subprocess behaves as if the
    user ran `amplihack install` directly.
 
+6. **Safe target selection** — Before replacing a binary, update analyzes
+   ordered `PATH` candidates for `amplihack` and `amplihack-hooks`. If stale
+   root-owned `/usr/local/bin` entries shadow current user-local binaries,
+   update prefers the writable `~/.local/bin` target when available and prints
+   repair guidance. It never attempts privileged writes or temporary-file copies
+   into unwritable system directories.
+
 ### `--skip-install` bypass
 
 The existing `--skip-install` (alias `--no-install`) flag on
@@ -136,6 +148,17 @@ execute permission, `Command::new().status()` returns an I/O error that
 propagates with full context. This should not happen in practice because
 `download_and_replace()` sets `0o755` permissions and uses atomic rename.
 
+### System binary shadows user-local binary
+
+If `/usr/local/bin/amplihack` appears before `~/.local/bin/amplihack` on
+`PATH`, update reports the conflict. When `~/.local/bin` is writable, the
+user-local binary is updated and the warning explains how to make the shell run
+it first. When no user-writable target exists, update stops before replacement
+and prints sudo/manual repair guidance.
+
+See [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md)
+for the target-selection rules.
+
 ### Old binary without `--force-refresh`
 
 If an older binary (pre-#683) is somehow spawned as the subprocess, it will
@@ -148,6 +171,7 @@ include the unrecognized flag name.
 
 | File | Role |
 |------|------|
+| `crates/amplihack-cli/src/path_conflicts.rs` | Shared side-effect-free PATH analysis and install target decision logic. |
 | `crates/amplihack-cli/src/update/install.rs` | `download_and_replace()` returns `Result<PathBuf>` with the installed binary path (captured before atomic rename). |
 | `crates/amplihack-cli/src/update/check.rs` | `run_update()` captures the returned path, passes it to `build_install_command()`. The closure given to `run_post_update_install` spawns the subprocess and checks its exit status. |
 | `crates/amplihack-cli/src/update/check.rs` | `build_install_command(installed_exe: &Path) -> Command` — constructs the subprocess command with args and env vars. Visibility: `pub(super)` for testability. |
@@ -167,6 +191,8 @@ No new crate dependencies introduced.
 | `build_install_command_sets_noninteractive_env` | `update/tests/build_install_command.rs` | `AMPLIHACK_NONINTERACTIVE=1` is set |
 | `update_check_source_includes_framework_restage` | `tests/bugfix_install_tests.rs` | Source-level assertion that `run_update` uses `build_install_command` (not `run_install` in-process) |
 | Existing `run_post_update_install` tests | `update/post_install.rs` | Skip-install bypass, closure invocation, error propagation — all still pass unchanged |
+| PATH conflict resolver tests | `path_conflicts.rs` | User-bin first, system-bin shadowing, duplicate candidates, safe user-bin preference, and manual repair decisions |
+| Install/update smoke output assertions | install/update tests | Normal output excludes stale hook-file `❌` lines, `profile_management` warnings, and known-safe bundled symlink skip warnings |
 
 ## Interaction with related features
 
@@ -194,6 +220,10 @@ own update prompt. The `AMPLIHACK_NO_UPDATE_CHECK=1` env var set by
 
 - [Install Command Reference](../reference/install-command.md) — the install
   procedure invoked by the subprocess.
+- [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md) —
+  safe target selection, PATH shadowing warnings, and manual repair guidance.
+- [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md) —
+  user-facing repair steps for stale `/usr/local/bin` binaries.
 - [Self-Heal Asset Re-Stage](self-heal-asset-restage.md) — the startup-time
   safety net that catches missed post-update installs.
 - [Startup Self-Update Prompt — Subprocess-Safe Skip](startup-update-prompt-subprocess-safe.md) —

--- a/docs/howto/first-install.md
+++ b/docs/howto/first-install.md
@@ -6,9 +6,7 @@ This guide walks through running `amplihack install` on a machine that has never
 
 | Requirement | Minimum version | Why |
 |-------------|----------------|-----|
-| Rust toolchain | 1.85 (2024 edition) | Build from source |
-| Python 3 | 3.11+ | amplihack SDK hooks run as Python subprocesses |
-| `amplihack` Python package | any | Hooks import `amplihack` at runtime |
+| Rust toolchain | 1.88 (2024 edition) | Build from source |
 | Internet access | — | Default install clones from GitHub (skip with `--local`) |
 | Node.js + npm (optional) | 18+ | Only needed when using the npm/npx wrapper path |
 
@@ -153,6 +151,13 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
+**`⚠️  PATH conflict`**
+
+The installer deployed current binaries to `~/.local/bin`, but another
+`amplihack` or `amplihack-hooks` appears earlier on `PATH`. Follow
+[Repair install/update PATH conflicts](repair-install-update-path-conflicts.md)
+to reorder `PATH` or remove stale system binaries.
+
 **Re-running install**
 
 Install is idempotent. Re-running updates hook registrations in place without duplicating entries. Existing settings (permissions, directories) are preserved. See [Idempotent Installation](../concepts/idempotent-installation.md).
@@ -161,5 +166,6 @@ Install is idempotent. Re-running updates hook registrations in place without du
 
 - [Interactive Install](./interactive-install.md) — guided wizard for tool, scope, and update preferences
 - [Install from a Local Repository](./local-install.md) — offline install without git clone
+- [Repair install/update PATH conflicts](./repair-install-update-path-conflicts.md) — fix stale `/usr/local/bin` binaries
 - [Uninstall amplihack](./uninstall.md) — clean removal
 - [amplihack install reference](../reference/install-command.md) — all flags and options

--- a/docs/howto/repair-install-update-path-conflicts.md
+++ b/docs/howto/repair-install-update-path-conflicts.md
@@ -1,0 +1,200 @@
+---
+title: Repair install/update PATH conflicts
+description: Diagnose and repair stale system-wide amplihack binaries that shadow current user-local binaries.
+last_updated: 2026-06-05
+review_schedule: as-needed
+owner: amplihack-maintainers
+doc_type: howto
+---
+
+# Repair install/update PATH conflicts
+
+Use this guide when `amplihack update` or `amplihack install` reports that a
+stale system-wide binary, usually `/usr/local/bin/amplihack` or
+`/usr/local/bin/amplihack-hooks`, is shadowing the current user-local binary in
+`~/.local/bin`.
+
+`amplihack` never runs `sudo`, deletes system files, or writes to privileged
+locations automatically. It repairs only user-writable install targets and gives
+explicit commands when system files need administrator action.
+
+## Check command resolution order
+
+Show every `amplihack` and `amplihack-hooks` candidate on `PATH`:
+
+```bash
+which -a amplihack
+which -a amplihack-hooks
+```
+
+A healthy user-local install resolves `~/.local/bin` first:
+
+```text
+/home/alice/.local/bin/amplihack
+/home/alice/.local/bin/amplihack-hooks
+```
+
+A conflicting install has an earlier system candidate:
+
+```text
+/usr/local/bin/amplihack
+/home/alice/.local/bin/amplihack
+/usr/local/bin/amplihack-hooks
+/home/alice/.local/bin/amplihack-hooks
+```
+
+In that case the shell runs `/usr/local/bin/amplihack` even though the current
+user-level binaries are present.
+
+## Prefer `~/.local/bin`
+
+Put `~/.local/bin` before `/usr/local/bin` in your shell profile:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+hash -r
+```
+
+For zsh, use `~/.zshrc`:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+hash -r
+```
+
+Verify the result:
+
+```bash
+which -a amplihack
+which -a amplihack-hooks
+amplihack --version
+amplihack-hooks --version
+```
+
+The first result for both binaries should be under `~/.local/bin`.
+
+## Remove stale system binaries
+
+If `/usr/local/bin` still appears first, remove the stale system copies with
+administrator privileges:
+
+```bash
+sudo rm /usr/local/bin/amplihack /usr/local/bin/amplihack-hooks
+hash -r
+```
+
+Then reinstall or update using the user-local binaries:
+
+```bash
+amplihack update
+amplihack install
+```
+
+Only remove the files when they are stale amplihack binaries. If your team
+intentionally manages `/usr/local/bin/amplihack` through a package manager,
+update that package or change `PATH` order instead.
+
+## Run a safe update
+
+When `~/.local/bin/amplihack` and `~/.local/bin/amplihack-hooks` already exist
+and are writable, `amplihack update` uses them as the preferred replacement
+target even if stale root-owned copies also exist in `/usr/local/bin`.
+
+```bash
+amplihack update
+```
+
+If a root-owned system binary blocks automatic repair, the command fails before
+attempting a temporary copy into `/usr/local/bin` and prints manual guidance:
+
+```text
+Cannot update /usr/local/bin/amplihack automatically.
+
+/usr/local/bin/amplihack appears before /home/alice/.local/bin/amplihack on PATH
+and is not writable by the current user.
+
+Run one of:
+  sudo rm /usr/local/bin/amplihack /usr/local/bin/amplihack-hooks
+  export PATH="$HOME/.local/bin:$PATH"
+
+Then run:
+  hash -r
+  amplihack update
+```
+
+This is intentional. The updater avoids misleading errors such as:
+
+```text
+Permission denied (os error 13)
+```
+
+from trying to copy temporary replacement files into `/usr/local/bin`.
+
+## Expected clean install/update output
+
+Successful install and update output should not contain stale hook-file or
+profile warnings. Treat these strings as regressions:
+
+```text
+session_start.sh ❌
+post_tool_use.sh ❌
+pre_tool_use.sh ❌
+profile_management
+Skipping symlink
+```
+
+Known-safe bundled symlinks are skipped silently or reported only when
+diagnostic verbosity explicitly asks for file-copy details. Normal user-facing
+install/update output remains focused on actionable results.
+
+## Troubleshooting
+
+### `amplihack update` still runs the old binary
+
+Clear your shell's command lookup cache:
+
+```bash
+hash -r
+```
+
+Open a new terminal and check again:
+
+```bash
+which -a amplihack
+amplihack --version
+```
+
+### Hooks still point at an old binary
+
+Re-run install after fixing `PATH`:
+
+```bash
+amplihack install
+```
+
+Hook registrations use the compiled `amplihack-hooks` binary. They do not call
+Python hook scripts and do not require `session_start.sh`,
+`post_tool_use.sh`, or `pre_tool_use.sh` files.
+
+### You need a system-wide install
+
+Install both binaries consistently in the same system-managed location and keep
+them writable only by the administrator:
+
+```bash
+sudo install -m 0755 amplihack /usr/local/bin/amplihack
+sudo install -m 0755 amplihack-hooks /usr/local/bin/amplihack-hooks
+```
+
+After that, keep `/usr/local/bin` first on `PATH` and update the system copy
+through the same administrative process. Do not mix a system-wide `amplihack`
+with a user-local `amplihack-hooks`.
+
+## See also
+
+- [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md)
+- [amplihack install reference](../reference/install-command.md)
+- [Post-update install re-exec](../features/update-reexec-new-binary.md)
+- [First-time install](first-install.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,8 @@ Centralized plugin system that works across all your projects:
 - [Prerequisites](PREREQUISITES.md) - System requirements and dependencies
 - [Interactive Installation](INTERACTIVE_INSTALLATION.md) - Step-by-step setup wizard
 - [Quick Start](../README.md) - Basic usage and first commands
+- [PATH Conflict Tutorial](tutorials/repair-install-update-path-conflicts.md) - Learn why stale system binaries can shadow current user-local installs
+- [Repair Install/Update PATH Conflicts](howto/repair-install-update-path-conflicts.md) - Fix stale `/usr/local/bin` binaries that shadow current `~/.local/bin` installs
 
 ### Configuration
 
@@ -142,6 +144,7 @@ amplihack copilot
 
 - [Release Installation](howto/first-install.md) - Install from published binaries or source
 - [Install Manifest](reference/install-manifest.md) - Understand installed files and uninstall state
+- [Install/Update PATH Conflict Reference](reference/install-update-path-conflicts.md) - Target selection, PATH analysis, and output regression guarantees
 - [Azure Integration](AZURE_INTEGRATION.md) - Deploy to Azure cloud
 
 ---

--- a/docs/reference/install-command.md
+++ b/docs/reference/install-command.md
@@ -62,6 +62,7 @@ amplihack install [--interactive]
 ├── 0. maybe_run_wizard()         — if --interactive, prompt for tool/scope/update prefs (skipped otherwise)
 ├── 1. Bundled source, --local path, OR GitHub fallback — obtain framework source
 ├── 2. deploy_binaries()          — copy amplihack + amplihack-hooks (+ asset resolver when present) to ~/.local/bin
+├── 2b. analyze PATH conflicts    — warn if stale earlier PATH entries shadow ~/.local/bin
 ├── 3. copy framework assets      — stage mapped framework assets to ~/.amplihack/.claude/
 ├── 4. create_runtime_dirs()      — create runtime/ subdirs with 0o755 permissions
 ├── 5. ensure_settings_json()     — backup settings.json, register hooks, set permissions
@@ -116,6 +117,19 @@ If `~/.local/bin` is not in `$PATH`, an advisory is printed (install still succe
 ⚠️  ~/.local/bin is not in $PATH
     Add: export PATH="$HOME/.local/bin:$PATH"
 ```
+
+If another candidate appears earlier on `$PATH`, install prints an advisory
+after deploying the user-local binaries:
+
+```text
+⚠️  PATH conflict: /usr/local/bin/amplihack appears before /home/alice/.local/bin/amplihack
+    Your shell may continue to run the stale system binary.
+    Fix: export PATH="$HOME/.local/bin:$PATH" or remove the stale system copy with sudo.
+```
+
+This warning does not mean install failed. It means the shell may still resolve
+`amplihack` or `amplihack-hooks` to an older candidate until `PATH` is repaired.
+See [Install/update PATH conflict reference](./install-update-path-conflicts.md).
 
 ---
 
@@ -216,6 +230,12 @@ Returns an actionable error if none of the five locations yield an executable.
 
 Copies `amplihack` (current executable) and `amplihack-hooks` (resolved by `find_hooks_binary`) to `~/.local/bin` with `0o755` permissions. When a sibling `amplihack-asset-resolver` binary is present, it is deployed too so launched tools and recipe runs can resolve bundle assets without falling back to Python. Returns the list of deployed paths for inclusion in the manifest.
 
+After deployment, install analyzes ordered `PATH` candidates for `amplihack` and
+`amplihack-hooks`. It warns when a system-wide candidate such as
+`/usr/local/bin/amplihack` shadows the freshly deployed `~/.local/bin` binary or
+when the two binaries resolve from different install roots. The analysis is
+side-effect free; install never removes or rewrites privileged system binaries.
+
 > **macOS note:** On macOS with System Integrity Protection (SIP) active, copying the running executable to `~/.local/bin` may produce a quarantined binary. See the [First-time install how-to](../howto/first-install.md#macos-sip-note) for the resolution step.
 
 ### `ensure_settings_json(staging_dir: &Path, timestamp: u64, hooks_bin: &Path) -> Result<(bool, Vec<String>)>`
@@ -247,6 +267,8 @@ Writes wizard results to the install manifest (`default_tool`, `update_check_pre
 ## See Also
 
 - [Interactive Install](../howto/interactive-install.md) — guided setup wizard walkthrough
+- [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md) — repair stale system binaries that shadow `~/.local/bin`
+- [Install/update PATH conflict reference](./install-update-path-conflicts.md) — target selection and resolver API
 - [Hook Specifications](./hook-specifications.md) — the 7 hooks registered by amplihack install
 - [Install Manifest](./install-manifest.md) — manifest schema
 - [Binary Resolution](./binary-resolution.md) — find_hooks_binary lookup detail

--- a/docs/reference/install-update-path-conflicts.md
+++ b/docs/reference/install-update-path-conflicts.md
@@ -1,0 +1,245 @@
+---
+title: Install/update PATH conflict reference
+description: Reference for amplihack install/update target selection, PATH conflict detection, safe repair behavior, and output regression guarantees.
+last_updated: 2026-06-05
+review_schedule: as-needed
+owner: amplihack-maintainers
+doc_type: reference
+---
+
+# Install/update PATH conflict reference
+
+`amplihack install` and `amplihack update` analyze command resolution order
+before reporting binary deployment status or replacing an existing binary. The
+analysis is deterministic, side-effect free, and based on `PATH` order rather
+than only `std::env::current_exe()`.
+
+## Scope
+
+The conflict detector covers these binary names:
+
+| Binary | Purpose |
+| --- | --- |
+| `amplihack` | Main CLI and update target |
+| `amplihack-hooks` | Rust-native hook dispatcher used by registered hooks |
+
+It does not execute discovered binaries. It inspects candidate paths, metadata,
+canonical forms when available, and user-writable target locations.
+
+## Preferred install target
+
+`~/.local/bin` is the preferred user-local target when it already contains
+current or writable `amplihack` and `amplihack-hooks` binaries.
+
+Target selection uses this priority:
+
+| Priority | Target | Used when |
+| --- | --- | --- |
+| 1 | Existing current executable directory | The running binary directory is user-writable and not a known unsafe system target. |
+| 2 | `~/.local/bin` | User-local binaries are present or the directory is creatable/writable. |
+| 3 | Manual repair required | The only viable target is system-owned, root-owned, or otherwise unwritable. |
+
+`/usr/local/bin` is never written automatically unless it is already writable by
+the current user. The updater does not invoke `sudo`, change ownership, delete
+files, or attempt privileged temporary-file copies.
+
+## PATH conflict categories
+
+| Category | Detection | User-facing behavior |
+| --- | --- | --- |
+| User-local first | `~/.local/bin/<binary>` is the first candidate for both binaries. | No warning. Install/update proceeds normally. |
+| System shadowing user-local | A candidate such as `/usr/local/bin/<binary>` appears before `~/.local/bin/<binary>`. | Warn with the shadowing path and the preferred user-local path. |
+| Duplicate candidates | More than one distinct candidate exists for a binary. | Warn when the order is ambiguous or could run a stale binary. |
+| Root-owned stale candidate | Earlier candidate is not writable by the current user and user-local candidate exists. | Prefer safe user-local update when possible; otherwise fail with manual repair guidance. |
+| Mixed binary locations | `amplihack` and `amplihack-hooks` resolve from different install roots. | Warn because hooks may be updated independently from the CLI. |
+
+Canonicalization is best effort. If a path cannot be canonicalized because it
+does not exist or metadata cannot be read, the raw path is still included in the
+report and filesystem errors from later install operations are preserved.
+
+## Update behavior
+
+`amplihack update` downloads the new release, verifies it, and replaces only the
+selected safe target.
+
+If the current executable is `/usr/local/bin/amplihack` but
+`~/.local/bin/amplihack` is present and writable, the updater selects the
+user-local target and reports the system conflict instead of trying to write a
+temporary file into `/usr/local/bin`.
+
+Example:
+
+```text
+⚠️  PATH conflict: /usr/local/bin/amplihack appears before /home/alice/.local/bin/amplihack
+    Updating user-local target: /home/alice/.local/bin/amplihack
+    To run the updated binary first, move ~/.local/bin earlier in PATH or remove the stale system copy.
+```
+
+When no safe user-writable target exists, update exits non-zero before
+replacement:
+
+```text
+Cannot update amplihack automatically because the resolved target is not writable:
+  /usr/local/bin/amplihack
+
+amplihack does not perform privileged writes.
+
+Repair options:
+  1. Move ~/.local/bin before /usr/local/bin in PATH.
+  2. Remove stale system binaries with sudo:
+     sudo rm /usr/local/bin/amplihack /usr/local/bin/amplihack-hooks
+  3. Re-run:
+     hash -r
+     amplihack update
+```
+
+The error is explicit and actionable. It replaces generic permission-denied
+failures caused by blind temporary-file copies into privileged directories.
+
+## Install behavior
+
+`amplihack install` deploys native binaries to `~/.local/bin` and then analyzes
+`PATH` resolution.
+
+When a system binary shadows the deployed user-local binary, install succeeds
+but prints a warning:
+
+```text
+✓ Deployed amplihack → /home/alice/.local/bin/amplihack
+✓ Deployed amplihack-hooks → /home/alice/.local/bin/amplihack-hooks
+⚠️  PATH conflict: /usr/local/bin/amplihack appears before /home/alice/.local/bin/amplihack
+    Your shell may continue to run the stale system binary.
+    Fix: export PATH="$HOME/.local/bin:$PATH" or remove the stale system copy with sudo.
+```
+
+This is an advisory because the install completed successfully and the repair
+requires either a shell profile change or administrator action.
+
+## Hook behavior
+
+Hook registrations use Rust-native binary subcommands:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/alice/.local/bin/amplihack-hooks post-tool-use"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The installer does not deploy or verify Python hook files. The following missing
+file lines are not valid install/update diagnostics:
+
+```text
+session_start.sh ❌
+post_tool_use.sh ❌
+pre_tool_use.sh ❌
+```
+
+Their presence in install/update output is a regression.
+
+## Configuration
+
+No new configuration file is required.
+
+| Input | Role |
+| --- | --- |
+| `PATH` | Source of ordered command candidates. |
+| `HOME` | Used to resolve `~/.local/bin`. |
+| Current executable path | Used as a candidate replacement target, not as the sole source of truth. |
+| Filesystem metadata | Used for existence, file type, ownership, and writability checks. |
+| `AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH` | Still applies to `amplihack-hooks` lookup during install. It does not override PATH conflict reporting. |
+
+Recommended shell configuration:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Contributor API
+
+The shared resolver lives in `crates/amplihack-cli/src/path_conflicts.rs`.
+
+### `PathAnalysisInput`
+
+Inputs supplied by install/update callers and tests.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `path_env` | string | Raw `PATH` value to scan in order. |
+| `home_dir` | `PathBuf` | Home directory used to derive preferred user bin. |
+| `current_exe` | `PathBuf` | Running executable path. |
+| `binary_names` | list | Fixed set: `amplihack`, `amplihack-hooks`. |
+| `filesystem` | trait-backed adapter | Metadata, canonicalization, and writability checks. |
+
+Tests inject temporary directories and filesystem adapters so transition
+coverage is deterministic and does not depend on host `/usr/local/bin`
+permissions.
+
+### `BinaryResolution`
+
+Ordered candidate list for one binary.
+
+| Field | Description |
+| --- | --- |
+| `name` | Binary name. |
+| `candidates` | Existing executable candidates in PATH order. |
+| `first` | First candidate that the shell resolves. |
+| `preferred_user_bin` | Expected `~/.local/bin/<name>` path. |
+| `shadowed_user_bin` | User-local candidate when another path appears earlier. |
+
+### `PathConflictReport`
+
+Side-effect-free analysis result consumed by install and update.
+
+| Field | Description |
+| --- | --- |
+| `resolutions` | Per-binary command resolution details. |
+| `warnings` | User-facing advisory messages for shadowing, duplicates, and mixed roots. |
+| `has_shadowing` | True when user-local binaries are shadowed by earlier candidates. |
+| `has_ambiguity` | True when multiple candidates create an ambiguous command resolution. |
+
+### `InstallTargetDecision`
+
+Decision used by update replacement logic.
+
+| Variant | Meaning |
+| --- | --- |
+| `CurrentExeDir { target }` | Replace the current executable path. |
+| `PreferredUserBin { target, warnings }` | Replace the safe user-local target and report conflicts. |
+| `ManualRepairRequired { attempted_target, guidance }` | Do not replace anything; return actionable guidance. |
+
+Callers must propagate `ManualRepairRequired` as a user-visible error and must
+not fall back to privileged writes.
+
+## Regression output contract
+
+Install/update smoke tests assert that normal user-facing output does not
+contain:
+
+| Forbidden output | Reason |
+| --- | --- |
+| `session_start.sh ❌` | Obsolete Python/shell hook verification. |
+| `post_tool_use.sh ❌` | Obsolete Python/shell hook verification. |
+| `pre_tool_use.sh ❌` | Obsolete Python/shell hook verification. |
+| `profile_management` warning | Old noisy profile-management staging warning. |
+| Known-safe bundled symlink skip warnings | Non-actionable copy noise during normal install/update. |
+
+Diagnostic modes may include explicit file-copy details, but normal
+install/update output must stay free of these known regressions.
+
+## See also
+
+- [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md)
+- [amplihack install reference](install-command.md)
+- [Binary resolution reference](binary-resolution.md)
+- [Post-update install re-exec](../features/update-reexec-new-binary.md)

--- a/docs/tutorials/repair-install-update-path-conflicts.md
+++ b/docs/tutorials/repair-install-update-path-conflicts.md
@@ -1,0 +1,156 @@
+---
+title: Tutorial: understand install/update PATH conflicts
+description: Learn how stale system-wide amplihack binaries shadow current user-local binaries and how the repair guidance works.
+last_updated: 2026-06-05
+review_schedule: as-needed
+owner: amplihack-maintainers
+doc_type: tutorial
+---
+
+# Tutorial: understand install/update PATH conflicts
+
+This tutorial uses temporary fixture binaries to show how `PATH` order affects
+`amplihack install` and `amplihack update`. It does not modify your real
+`/usr/local/bin` or `~/.local/bin`.
+
+## What you will learn
+
+You will create two fake install roots:
+
+- a stale system-style root that appears first on `PATH`
+- a current user-style root that appears later on `PATH`
+
+Then you will change `PATH` order and see why `amplihack` prefers safe
+user-local repair instead of writing to privileged system directories.
+
+## 1. Create temporary fake binaries
+
+```bash
+tmpdir="$(mktemp -d)"
+mkdir -p "$tmpdir/system-bin" "$tmpdir/user-bin"
+
+printf '#!/bin/sh\necho stale-system-amplihack\n' > "$tmpdir/system-bin/amplihack"
+printf '#!/bin/sh\necho stale-system-hooks\n' > "$tmpdir/system-bin/amplihack-hooks"
+
+printf '#!/bin/sh\necho current-user-amplihack\n' > "$tmpdir/user-bin/amplihack"
+printf '#!/bin/sh\necho current-user-hooks\n' > "$tmpdir/user-bin/amplihack-hooks"
+
+chmod +x "$tmpdir/system-bin/amplihack" \
+  "$tmpdir/system-bin/amplihack-hooks" \
+  "$tmpdir/user-bin/amplihack" \
+  "$tmpdir/user-bin/amplihack-hooks"
+```
+
+## 2. Put the stale system root first
+
+```bash
+PATH="$tmpdir/system-bin:$tmpdir/user-bin:$PATH" which -a amplihack
+PATH="$tmpdir/system-bin:$tmpdir/user-bin:$PATH" which -a amplihack-hooks
+```
+
+You should see the system-style root before the user-style root:
+
+```text
+/tmp/.../system-bin/amplihack
+/tmp/.../user-bin/amplihack
+/tmp/.../system-bin/amplihack-hooks
+/tmp/.../user-bin/amplihack-hooks
+```
+
+That is the same shape as a real machine where `/usr/local/bin/amplihack`
+appears before `/home/alice/.local/bin/amplihack`.
+
+Run the fake command:
+
+```bash
+PATH="$tmpdir/system-bin:$tmpdir/user-bin:$PATH" amplihack
+```
+
+Expected output:
+
+```text
+stale-system-amplihack
+```
+
+The shell ran the first candidate, even though a newer user-local candidate
+also exists.
+
+## 3. Put the user root first
+
+```bash
+PATH="$tmpdir/user-bin:$tmpdir/system-bin:$PATH" which -a amplihack
+PATH="$tmpdir/user-bin:$tmpdir/system-bin:$PATH" amplihack
+```
+
+Expected output:
+
+```text
+current-user-amplihack
+```
+
+This is the preferred real configuration:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+With that order, `amplihack update` can update the user-local binary and your
+shell will run the updated binary first.
+
+## 4. Map the tutorial to the real repair
+
+In a real conflict, inspect your actual command resolution:
+
+```bash
+which -a amplihack
+which -a amplihack-hooks
+```
+
+If `/usr/local/bin` appears before `~/.local/bin`, repair it by reordering
+`PATH`:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+hash -r
+```
+
+Or remove stale system copies when they are not managed by a package manager:
+
+```bash
+sudo rm /usr/local/bin/amplihack /usr/local/bin/amplihack-hooks
+hash -r
+```
+
+After repair:
+
+```bash
+amplihack update
+amplihack install
+```
+
+## 5. Clean up the fixture
+
+```bash
+rm -rf "$tmpdir"
+```
+
+## What clean output means
+
+Clean install/update output contains phase summaries and actionable warnings. It
+does not contain stale hook-file checks such as:
+
+```text
+session_start.sh ❌
+post_tool_use.sh ❌
+pre_tool_use.sh ❌
+```
+
+Those files are not part of the Rust-native hook path. Hook registrations call
+`amplihack-hooks` binary subcommands.
+
+## See also
+
+- [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md)
+- [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md)
+- [amplihack install reference](../reference/install-command.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,9 @@ nav:
       - Installation: PREREQUISITES.md
       - Interactive Setup: INTERACTIVE_INSTALLATION.md
       - First-Time Install: howto/first-install.md
+      - PATH Conflict Tutorial: tutorials/repair-install-update-path-conflicts.md
       - Local Install: howto/local-install.md
+      - Repair PATH Conflicts: howto/repair-install-update-path-conflicts.md
       - Uninstall: howto/uninstall.md
   - Core Concepts:
       - Philosophy: claude/context/PHILOSOPHY.md
@@ -203,6 +205,7 @@ nav:
       - Rust Code Quality: reference/rust-code-quality.md
       - CLI Reference: reference/cli.md
       - install Command: reference/install-command.md
+      - Install/Update PATH Conflicts: reference/install-update-path-conflicts.md
       - recipe Command: reference/recipe-command.md
       - RustyClawd Command: reference/rustyclawd-command.md
       - uvx-help Command: reference/uvx-help-command.md


### PR DESCRIPTION
## Summary

Documents the intended install/update behavior for stale system-wide `amplihack` and `amplihack-hooks` binaries that shadow current user-local binaries in `~/.local/bin`.

This is retcon documentation only: it describes the finished feature as the implementation spec, without changing Rust code.

## Changes

- Adds a user-facing repair guide for `/usr/local/bin` vs `~/.local/bin` PATH conflicts.
- Adds a reference page for PATH analysis, safe update target selection, manual repair behavior, contributor API shapes, and noisy-output regression guarantees.
- Adds a tutorial using temporary fixture binaries to demonstrate PATH shadowing safely.
- Links the new docs from the docs index, MkDocs nav, install command reference, first-install guide, and update feature docs.

## Testing

- `git diff --check`
- `mkdocs build --strict`

## Related

- Related to #695