### PR TITLE
Harden install/update PATH conflict handling

### DIFF
--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -173,18 +173,40 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
 pub(super) fn path_conflict_warning_after_install(
     report: &crate::path_conflicts::PathConflictReport,
 ) -> Option<String> {
-    let amplihack = report.resolution("amplihack")?;
-    let preferred = amplihack.preferred_user_candidate.as_ref()?;
-    if !amplihack.is_shadowed_by_earlier_path_entry {
-        return None;
+    let mut warning = String::new();
+    for binary_name in ["amplihack", "amplihack-hooks"] {
+        let Some(resolution) = report.resolution(binary_name) else {
+            continue;
+        };
+
+        if resolution.is_shadowed_by_earlier_path_entry {
+            let Some(preferred) = resolution.preferred_user_candidate.as_ref() else {
+                continue;
+            };
+            append_shadow_warning(&mut warning, binary_name, resolution, &preferred.path);
+        } else if resolution.has_ambiguous_candidates {
+            append_ambiguity_warning(&mut warning, binary_name, resolution);
+        }
     }
 
-    let mut warning = String::new();
-    if is_python_script(&amplihack.resolved.path) {
+    if warning.is_empty() {
+        None
+    } else {
+        Some(warning.trim_end().to_string())
+    }
+}
+
+fn append_shadow_warning(
+    warning: &mut String,
+    binary_name: &str,
+    resolution: &crate::path_conflicts::BinaryResolution,
+    preferred_path: &std::path::Path,
+) {
+    if binary_name == "amplihack" && is_python_script(&resolution.resolved.path) {
         warning.push_str(&format!(
             "  ⚠️  A Python `amplihack` script at {} shadows the Rust binary at {}.\n",
-            amplihack.resolved.path.display(),
-            preferred.path.display()
+            resolution.resolved.path.display(),
+            preferred_path.display()
         ));
         warning.push_str(
             "     The Python script will intercept `amplihack` commands, preventing the Rust CLI from running.\n",
@@ -192,28 +214,44 @@ pub(super) fn path_conflict_warning_after_install(
         warning.push_str("     To fix, do one of the following:\n");
         warning.push_str(&format!(
             "       1. Remove the Python script:  rm {}\n",
-            amplihack.resolved.path.display()
+            resolution.resolved.path.display()
         ));
         warning.push_str(
             "       2. Reorder PATH so ~/.local/bin comes first:  export PATH=\"$HOME/.local/bin:$PATH\"\n",
         );
-        warning.push_str("       3. Uninstall the Python package:  pip uninstall amplihack");
-    } else {
-        warning.push_str(&format!(
-            "  ⚠️  `{}` at {} shadows the Rust binary at {}.\n",
-            "amplihack",
-            amplihack.resolved.path.display(),
-            preferred.path.display()
-        ));
-        warning.push_str(
-            "     Reorder PATH so ~/.local/bin comes first:  export PATH=\"$HOME/.local/bin:$PATH\"\n",
-        );
-        warning.push_str(&format!(
-            "     Or run the user-level binary directly: {}",
-            preferred.path.display()
-        ));
+        warning.push_str("       3. Uninstall the Python package:  pip uninstall amplihack\n");
+        return;
     }
-    Some(warning)
+
+    warning.push_str(&format!(
+        "  ⚠️  `{}` at {} shadows the user-level binary at {}.\n",
+        binary_name,
+        resolution.resolved.path.display(),
+        preferred_path.display()
+    ));
+    warning.push_str(
+        "     Reorder PATH so ~/.local/bin comes first:  export PATH=\"$HOME/.local/bin:$PATH\"\n",
+    );
+    warning.push_str(&format!(
+        "     Or run the user-level binary directly: {}\n",
+        preferred_path.display()
+    ));
+}
+
+fn append_ambiguity_warning(
+    warning: &mut String,
+    binary_name: &str,
+    resolution: &crate::path_conflicts::BinaryResolution,
+) {
+    warning.push_str(&format!(
+        "  ⚠️  Multiple distinct `{binary_name}` binaries are on PATH:\n"
+    ));
+    for candidate in &resolution.canonical_candidates {
+        warning.push_str(&format!("     - {}\n", candidate.path.display()));
+    }
+    warning.push_str(
+        "     Remove stale candidates or reorder PATH so the intended user-level install resolves first.\n",
+    );
 }
 
 /// Check whether a file is a Python script (shebang or .py extension).

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -26,7 +26,7 @@
 //!    upstream, only attempted when none of the above yields a usable root.
 
 use super::types::{REPO_ARCHIVE_URL, REPO_GIT_URL};
-use crate::update::{extract_archive, http_get, validate_download_url};
+use crate::update::{extract_archive, http_get_with_retry, validate_download_url};
 use anyhow::{Context, Result, bail};
 use std::collections::VecDeque;
 use std::fs;
@@ -111,7 +111,7 @@ pub(super) fn download_and_extract_framework_repo(destination: &Path) -> Result<
 
     // git not available — fall back to HTTP tarball download
     validate_download_url(REPO_ARCHIVE_URL)?;
-    let archive_bytes = http_get(REPO_ARCHIVE_URL)
+    let archive_bytes = http_get_with_retry(REPO_ARCHIVE_URL)
         .with_context(|| format!("failed to download framework archive from {REPO_ARCHIVE_URL}"))?;
     extract_archive(&archive_bytes, destination).with_context(|| {
         format!(

--- a/crates/amplihack-cli/src/commands/install/tests/path_conflict_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/path_conflict_tests.rs
@@ -81,3 +81,69 @@ fn install_does_not_warn_when_path_aliases_resolve_to_same_user_binary() {
         "canonical symlink aliases to the same user-level binaries must not create noisy install warnings"
     );
 }
+
+#[test]
+fn install_warns_when_user_level_hooks_binary_is_shadowed() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    let local_bin = temp.path().join(".local/bin");
+    let system_bin = temp.path().join("usr/local/bin");
+    create_exe_stub(&local_bin, "amplihack");
+    let local_hooks = create_exe_stub(&local_bin, "amplihack-hooks");
+    create_exe_stub(&system_bin, "amplihack");
+    let system_hooks = create_exe_stub(&system_bin, "amplihack-hooks");
+
+    let report = analyze_path_conflicts(&PathAnalysisInput {
+        home_dir: temp.path().to_path_buf(),
+        current_exe: local_bin.join("amplihack"),
+        path_dirs: vec![system_bin.clone(), local_bin.clone()],
+        binary_names: vec!["amplihack-hooks".into()],
+    })
+    .unwrap();
+
+    let warning = binary::path_conflict_warning_after_install(&report)
+        .expect("shadowed hooks binary should produce actionable warning text");
+
+    crate::test_support::restore_home(previous);
+
+    assert!(warning.contains("amplihack-hooks"));
+    assert!(warning.contains(&system_hooks.display().to_string()));
+    assert!(warning.contains(&local_hooks.display().to_string()));
+    assert!(warning.contains("export PATH=\"$HOME/.local/bin:$PATH\""));
+}
+
+#[test]
+fn install_warns_when_multiple_distinct_binary_candidates_create_ambiguity() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    let local_bin = temp.path().join(".local/bin");
+    let other_bin = temp.path().join("other/bin");
+    let local_amplihack = create_exe_stub(&local_bin, "amplihack");
+    let other_amplihack = create_exe_stub(&other_bin, "amplihack");
+
+    let report = analyze_path_conflicts(&PathAnalysisInput {
+        home_dir: temp.path().to_path_buf(),
+        current_exe: local_amplihack.clone(),
+        path_dirs: vec![local_bin, other_bin],
+        binary_names: vec!["amplihack".into()],
+    })
+    .unwrap();
+
+    let warning = binary::path_conflict_warning_after_install(&report)
+        .expect("distinct duplicate candidates should produce ambiguity guidance");
+
+    crate::test_support::restore_home(previous);
+
+    assert!(warning.contains("Multiple distinct `amplihack` binaries"));
+    assert!(warning.contains(&local_amplihack.display().to_string()));
+    assert!(warning.contains(&other_amplihack.display().to_string()));
+    assert!(warning.contains("Remove stale candidates or reorder PATH"));
+}

--- a/crates/amplihack-cli/src/update/mod.rs
+++ b/crates/amplihack-cli/src/update/mod.rs
@@ -8,7 +8,7 @@ pub use check::{
     should_skip_update_check_for_subcommand,
 };
 pub(crate) use install::extract_archive;
-pub(crate) use network::{fetch_branch_head_sha, http_get, validate_download_url};
+pub(crate) use network::{fetch_branch_head_sha, http_get_with_retry, validate_download_url};
 
 use anyhow::{Result, anyhow, bail};
 use semver::Version;

--- a/crates/amplihack-cli/src/update/network.rs
+++ b/crates/amplihack-cli/src/update/network.rs
@@ -12,6 +12,35 @@ const HTTP_MAX_ATTEMPTS: u32 = 3;
 /// Initial backoff delay in milliseconds (doubles on each retry).
 const HTTP_INITIAL_BACKOFF_MS: u64 = 500;
 
+#[derive(Debug, thiserror::Error)]
+enum HttpClientError {
+    #[error("no stable v* release has been published for {repo} yet")]
+    LatestReleaseNotFound { repo: &'static str },
+    #[error("{message}")]
+    Status {
+        status: u16,
+        url: String,
+        message: String,
+    },
+    #[error("HTTP request failed for {url}: {source}")]
+    Transport {
+        url: String,
+        source: Box<ureq::Error>,
+    },
+    #[error("failed to read HTTP response from {url}: {source}")]
+    Read { url: String, source: std::io::Error },
+}
+
+impl HttpClientError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::LatestReleaseNotFound { .. } => false,
+            Self::Status { status, .. } => *status == 429 || *status >= 500,
+            Self::Transport { .. } | Self::Read { .. } => true,
+        }
+    }
+}
+
 /// Fetch the current HEAD commit SHA for `<owner>/<repo>` on `branch`.
 ///
 /// Uses the GitHub commits API — the full object is large, so we ask for
@@ -23,7 +52,7 @@ const HTTP_INITIAL_BACKOFF_MS: u64 = 500;
 /// endpoint (neither repo publishes tagged releases we can rely on).
 pub(crate) fn fetch_branch_head_sha(owner_repo: &str, branch: &str) -> Result<String> {
     let url = format!("https://api.github.com/repos/{owner_repo}/commits/{branch}");
-    let body = http_get(&url).with_context(|| format!("failed to query {url}"))?;
+    let body = http_get_with_retry(&url).with_context(|| format!("failed to query {url}"))?;
     let value: serde_json::Value =
         serde_json::from_slice(&body).with_context(|| format!("invalid JSON from {url}"))?;
     let sha = value
@@ -61,7 +90,7 @@ pub(super) fn fetch_latest_release() -> Result<UpdateRelease> {
 
     let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
     let asset_name = expected_archive_name()?;
-    let response = http_get(&url)
+    let response = http_get_with_retry(&url)
         .with_context(|| format!("failed to query latest stable release from {GITHUB_REPO}"))?;
     parse_latest_release(response, &asset_name)
 }
@@ -89,6 +118,16 @@ pub(super) fn is_retryable_error(error: &ureq::Error) -> bool {
         ureq::Error::Status(status, _) => *status == 429 || *status >= 500,
         ureq::Error::Transport(_) => true,
     }
+}
+
+pub(super) fn is_retryable_http_get_error(error: &anyhow::Error) -> bool {
+    if let Some(error) = error.downcast_ref::<HttpClientError>() {
+        return error.is_retryable();
+    }
+    if let Some(error) = error.downcast_ref::<ureq::Error>() {
+        return is_retryable_error(error);
+    }
+    false
 }
 
 /// User-friendly message for GitHub-specific HTTP error codes.
@@ -119,10 +158,7 @@ pub(crate) fn http_get_with_retry(url: &str) -> Result<Vec<u8>> {
         match http_get(url) {
             Ok(body) => return Ok(body),
             Err(err) => {
-                let is_retryable = err
-                    .downcast_ref::<ureq::Error>()
-                    .map(is_retryable_error)
-                    .unwrap_or(true);
+                let is_retryable = is_retryable_http_get_error(&err);
 
                 if !is_retryable || attempt == HTTP_MAX_ATTEMPTS {
                     return Err(err);
@@ -143,7 +179,7 @@ pub(crate) fn http_get_with_retry(url: &str) -> Result<Vec<u8>> {
     unreachable!("loop exits via return inside the body")
 }
 
-pub(crate) fn http_get(url: &str) -> Result<Vec<u8>> {
+fn http_get(url: &str) -> Result<Vec<u8>> {
     // SEC-1: Reject URLs from unexpected hosts before making any network call.
     validate_download_url(url)?;
 
@@ -160,12 +196,23 @@ pub(crate) fn http_get(url: &str) -> Result<Vec<u8>> {
     {
         Ok(response) => response,
         Err(ureq::Error::Status(404, _)) if url.ends_with("/releases/latest") => {
-            bail!("no stable v* release has been published for {GITHUB_REPO} yet")
+            return Err(HttpClientError::LatestReleaseNotFound { repo: GITHUB_REPO }.into());
         }
-        Err(ureq::Error::Status(status @ (403 | 429), _)) => {
-            bail!("{}", github_error_message(status, url))
+        Err(ureq::Error::Status(status, _)) => {
+            return Err(HttpClientError::Status {
+                status,
+                url: url.to_string(),
+                message: github_error_message(status, url),
+            }
+            .into());
         }
-        Err(error) => return Err(anyhow!("HTTP request failed for {url}: {error}")),
+        Err(error) => {
+            return Err(HttpClientError::Transport {
+                url: url.to_string(),
+                source: Box::new(error),
+            }
+            .into());
+        }
     };
 
     let limit = MAX_BINARY_DOWNLOAD_BYTES;
@@ -179,7 +226,10 @@ pub(crate) fn http_get(url: &str) -> Result<Vec<u8>> {
         .into_reader()
         .take(limit as u64)
         .read_to_end(&mut body)
-        .with_context(|| format!("failed to read HTTP response from {url}"))?;
+        .map_err(|source| HttpClientError::Read {
+            url: url.to_string(),
+            source,
+        })?;
 
     if body.len() == limit {
         bail!(
@@ -229,4 +279,37 @@ pub(super) fn parse_latest_release(body: Vec<u8>, asset_name: &str) -> Result<Up
         asset_url: asset.browser_download_url.clone(),
         checksum_url,
     })
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::*;
+
+    #[test]
+    fn retry_classifier_preserves_structured_http_status_semantics() {
+        for (status, retryable) in [(403, false), (404, false), (429, true), (500, true)] {
+            let url = "https://api.github.com/repos/rysweet/amplihack-rs/releases/latest";
+            let err: anyhow::Error = HttpClientError::Status {
+                status,
+                url: url.to_string(),
+                message: github_error_message(status, url),
+            }
+            .into();
+            assert_eq!(
+                is_retryable_http_get_error(&err),
+                retryable,
+                "unexpected retry classification for HTTP {status}"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_classifier_does_not_retry_permanent_local_errors() {
+        let err: anyhow::Error =
+            HttpClientError::LatestReleaseNotFound { repo: GITHUB_REPO }.into();
+        assert!(!is_retryable_http_get_error(&err));
+
+        let err = anyhow!("download URL is not from an allowed GitHub host");
+        assert!(!is_retryable_http_get_error(&err));
+    }
 }


### PR DESCRIPTION
## Summary

- Harden update target selection so current user-local binaries are compared against the running binary version, not the incoming release version.
- Surface explicit PATH conflict guidance when update safely repairs to user-local `~/.local/bin` targets instead of silently proceeding while stale earlier PATH entries remain.
- Add regression coverage that the safe repair guidance avoids old temp-copy / permission-denied failure wording.

## Testing

- `cargo test --workspace --locked --quiet`
- Targeted `amplihack-cli` path-conflict, install output, install warning, update target, and post-update command tests.

## Step 13: Local Testing Results

### Scenario 1 — Branch install smoke/version output
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-695-path-conflict-reliability amplihack --version`
Result: PASS
Output: branch resolved to `1947b5e2ae0b828855ecf4b4ce4ead654e857f10`; Rust CLI built from the PR branch; final output `amplihack 0.9.70`; no `session_start.sh ❌`, `post_tool_use.sh ❌`, `pre_tool_use.sh ❌`, `profile_management`, or `Skipping symlink` regressions.

### Scenario 2 — Stale PATH install smoke with shadowing warning
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-695-path-conflict-reliability amplihack install --local /home/azureuser/src/amplihack-rs/worktrees/feat/issue-695-implement-the-next-high-impact-amplihack-rs-reliab`
Result: PASS
Output: branch resolved to `1947b5e2ae0b828855ecf4b4ce4ead654e857f10`; install printed `amplihack ... shadows the user-level binary`, `amplihack-hooks ... shadows the user-level binary`, `✅ Required framework assets found`, `✅ Source-derived framework manifest verified`, and `✅ Amplihack installation completed successfully!`; no `session_start.sh ❌`, `post_tool_use.sh ❌`, `pre_tool_use.sh ❌`, `profile_management`, or `Skipping symlink` regressions.