### PR TITLE
Harden path conflict audit edge cases

### DIFF
--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -263,19 +263,23 @@ fn is_python_script(path: &std::path::Path) -> bool {
     let Ok(file) = std::fs::File::open(path) else {
         return false;
     };
-    let mut first_line = Vec::new();
-    let mut reader = std::io::BufReader::new(file);
-    let Ok(_) = std::io::BufRead::read_until(&mut reader, b'\n', &mut first_line) else {
+    let mut first_bytes = Vec::new();
+    let mut limited = std::io::Read::take(std::io::BufReader::new(file), 1024);
+    let Ok(_) = std::io::Read::read_to_end(&mut limited, &mut first_bytes) else {
         return false;
     };
+    let mut first_line = first_bytes
+        .split(|byte| *byte == b'\n')
+        .next()
+        .unwrap_or(&first_bytes);
     while first_line
         .last()
         .is_some_and(|byte| *byte == b'\n' || *byte == b'\r')
     {
-        first_line.pop();
+        first_line = &first_line[..first_line.len() - 1];
     }
 
-    if let Ok(first_line) = std::str::from_utf8(&first_line) {
+    if let Ok(first_line) = std::str::from_utf8(first_line) {
         return first_line.starts_with("#!")
             && (first_line.contains("python") || first_line.contains("Python"));
     }

--- a/crates/amplihack-cli/src/commands/install/tests/path_conflict_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/path_conflict_tests.rs
@@ -80,6 +80,40 @@ fn install_warns_for_python_shadow_with_long_shebang_line() {
 }
 
 #[test]
+fn install_uses_generic_shadow_warning_for_large_non_python_binary() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    let local_bin = temp.path().join(".local/bin");
+    let system_bin = temp.path().join("usr/local/bin");
+    let local_amplihack = create_exe_stub(&local_bin, "amplihack");
+    create_exe_stub(&local_bin, "amplihack-hooks");
+    let system_amplihack = create_exe_stub(&system_bin, "amplihack");
+    create_exe_stub(&system_bin, "amplihack-hooks");
+    fs::write(&system_amplihack, vec![b'x'; 2 * 1024 * 1024]).unwrap();
+
+    let report = analyze_path_conflicts(&PathAnalysisInput {
+        home_dir: temp.path().to_path_buf(),
+        current_exe: local_amplihack,
+        path_dirs: vec![system_bin, local_bin],
+        binary_names: vec!["amplihack".into()],
+    })
+    .unwrap();
+
+    let warning = binary::path_conflict_warning_after_install(&report)
+        .expect("shadowed non-Python binary should still produce generic warning text");
+
+    crate::test_support::restore_home(previous);
+
+    assert!(warning.contains("shadows the user-level binary"));
+    assert!(!warning.contains("Python `amplihack` script"));
+    assert!(!warning.contains("pip uninstall amplihack"));
+}
+
+#[test]
 fn install_does_not_warn_when_path_aliases_resolve_to_same_user_binary() {
     let _guard = crate::test_support::home_env_lock()
         .lock()

--- a/crates/amplihack-cli/src/path_conflicts.rs
+++ b/crates/amplihack-cli/src/path_conflicts.rs
@@ -58,6 +58,9 @@ pub(crate) fn analyze_path_conflicts(input: &PathAnalysisInput) -> Result<PathCo
     for binary_name in &input.binary_names {
         let filename = binary_filename(binary_name);
         let preferred_binary_path = preferred_user_bin.join(&filename);
+        let preferred_canonical_path = preferred_binary_path
+            .canonicalize()
+            .unwrap_or_else(|_| preferred_binary_path.clone());
         let candidates = path_candidates(&filename, &input.path_dirs)?;
         if candidates.is_empty() {
             continue;
@@ -66,7 +69,10 @@ pub(crate) fn analyze_path_conflicts(input: &PathAnalysisInput) -> Result<PathCo
         let resolved = candidates[0].clone();
         let preferred_user_candidate = candidates
             .iter()
-            .find(|candidate| candidate.path == preferred_binary_path)
+            .find(|candidate| {
+                candidate.path == preferred_binary_path
+                    || candidate.canonical_path == preferred_canonical_path
+            })
             .cloned();
         let canonical_candidates = collapse_canonical_candidates(&candidates);
         let preferred_is_shadowed = preferred_user_candidate.as_ref().is_some_and(|preferred| {

--- a/crates/amplihack-cli/src/path_conflicts/target.rs
+++ b/crates/amplihack-cli/src/path_conflicts/target.rs
@@ -56,6 +56,19 @@ pub(crate) fn update_path_conflict_notice(
     let mut notice = String::new();
     for (binary_name, resolution) in &report.resolutions {
         if !resolution.is_shadowed_by_earlier_path_entry {
+            let user_target = install_dir.join(binary_filename(binary_name));
+            if resolution.resolved.path != user_target
+                && resolution.preferred_user_candidate.is_none()
+            {
+                notice.push_str(&format!(
+                    "  ⚠️  PATH conflict: `{binary_name}` resolves to {} instead of the user-local target {}\n",
+                    resolution.resolved.path.display(),
+                    user_target.display()
+                ));
+                notice.push_str(
+                    "     The updated binary may not run until the user-local install is earlier in PATH.\n",
+                );
+            }
             continue;
         }
         let Some(preferred) = resolution.preferred_user_candidate.as_ref() else {
@@ -104,7 +117,10 @@ pub(crate) fn decide_update_install_target(
         .unwrap_or_else(|| path_is_writable(&input.report.current_exe));
 
     if input.report.preferred_user_bin.exists()
-        && user_bin_pair_is_writable(&input.report.preferred_user_bin, &input.candidate_probes)
+        && user_bin_pair_exists_and_is_writable(
+            &input.report.preferred_user_bin,
+            &input.candidate_probes,
+        )
         && (current_exe_denied || report_has_shadowing(&input.report))
     {
         return Ok(InstallTargetDecision::PreferredUserBin {
@@ -181,9 +197,15 @@ pub(crate) fn probe_candidates_without_exec(
     probes
 }
 
-fn user_bin_pair_is_writable(user_bin: &Path, probes: &BTreeMap<PathBuf, BinaryProbe>) -> bool {
+fn user_bin_pair_exists_and_is_writable(
+    user_bin: &Path,
+    probes: &BTreeMap<PathBuf, BinaryProbe>,
+) -> bool {
     ["amplihack", "amplihack-hooks"].into_iter().all(|name| {
         let path = user_bin.join(binary_filename(name));
+        if !path.is_file() {
+            return false;
+        }
         probes
             .get(&path)
             .map(|probe| probe.writable)

--- a/crates/amplihack-cli/src/path_conflicts/tests.rs
+++ b/crates/amplihack-cli/src/path_conflicts/tests.rs
@@ -101,6 +101,66 @@ fn canonical_duplicate_detection_does_not_treat_symlink_alias_as_ambiguity() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn alias_to_user_bin_is_treated_as_preferred_candidate() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let user_bin = home.join(".local/bin");
+    let aliases = temp.path().join("aliases");
+    let user_amplihack = write_executable(&user_bin, "amplihack");
+
+    fs::create_dir_all(&aliases).unwrap();
+    std::os::unix::fs::symlink(&user_amplihack, aliases.join("amplihack")).unwrap();
+
+    let report = analyze_path_conflicts(&analysis_input(
+        &home,
+        &user_amplihack,
+        vec![aliases.clone()],
+    ))
+    .unwrap();
+
+    let amplihack = report.resolution("amplihack").unwrap();
+    assert_eq!(
+        amplihack.preferred_user_candidate.as_ref().map(|c| &c.path),
+        Some(&aliases.join("amplihack")),
+        "PATH aliases that canonicalize to ~/.local/bin must count as the preferred user binary"
+    );
+    assert!(
+        !amplihack.is_shadowed_by_earlier_path_entry,
+        "a PATH alias that resolves to the user binary should not produce repair noise"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn system_binary_shadowing_alias_to_user_bin_is_reported_as_shadowing() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let user_bin = home.join(".local/bin");
+    let aliases = temp.path().join("aliases");
+    let usr_local_bin = temp.path().join("usr/local/bin");
+    let user_amplihack = write_executable(&user_bin, "amplihack");
+    let system_amplihack = write_executable(&usr_local_bin, "amplihack");
+
+    fs::create_dir_all(&aliases).unwrap();
+    std::os::unix::fs::symlink(&user_amplihack, aliases.join("amplihack")).unwrap();
+
+    let report = analyze_path_conflicts(&analysis_input(
+        &home,
+        &system_amplihack,
+        vec![usr_local_bin.clone(), aliases.clone()],
+    ))
+    .unwrap();
+
+    let amplihack = report.resolution("amplihack").unwrap();
+    assert_eq!(amplihack.resolved.path, system_amplihack);
+    assert!(
+        amplihack.is_shadowed_by_earlier_path_entry,
+        "system binaries before a PATH alias to ~/.local/bin must still be reported as shadowing"
+    );
+}
+
 #[test]
 fn distinct_duplicate_candidates_are_reported_as_ambiguous() {
     let temp = tempfile::tempdir().unwrap();
@@ -242,6 +302,38 @@ fn root_owned_system_candidate_requires_manual_repair_without_privileged_copy_at
 }
 
 #[test]
+fn writable_empty_user_bin_does_not_silently_repair_denied_system_install() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let user_bin = home.join(".local/bin");
+    let usr_local_bin = temp.path().join("usr/local/bin");
+    fs::create_dir_all(&user_bin).unwrap();
+    let system_amplihack = write_executable(&usr_local_bin, "amplihack");
+    write_executable(&usr_local_bin, "amplihack-hooks");
+
+    let report = analyze_path_conflicts(&analysis_input(
+        &home,
+        &system_amplihack,
+        vec![usr_local_bin.clone()],
+    ))
+    .unwrap();
+    let mut probes = BTreeMap::new();
+    probes.insert(system_amplihack, BinaryProbe { writable: false });
+
+    let decision = decide_update_install_target(TargetDecisionInput {
+        report,
+        candidate_probes: probes,
+        denied_system_prefixes: vec![temp.path().join("usr/local")],
+    })
+    .unwrap();
+
+    assert!(
+        matches!(decision, InstallTargetDecision::ManualRepairRequired { .. }),
+        "a writable user-bin directory without existing user-level binaries is not enough to redirect updates away from a denied system install: {decision:?}"
+    );
+}
+
+#[test]
 fn denied_system_prefix_is_never_selected_even_when_probe_says_writable() {
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path().join("home");
@@ -307,5 +399,43 @@ fn update_notice_reports_shadowed_user_local_repair_without_permission_noise() {
     assert!(
         !notice.contains("Permission denied copying") && !notice.contains("failed to copy"),
         "repair guidance must replace temp-copy permission failures, got: {notice}"
+    );
+}
+
+#[test]
+fn update_notice_reports_user_local_target_missing_from_path_resolution() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let user_bin = home.join(".local/bin");
+    let usr_local_bin = temp.path().join("usr/local/bin");
+    write_executable(&user_bin, "amplihack");
+    write_executable(&user_bin, "amplihack-hooks");
+    let system_amplihack = write_executable(&usr_local_bin, "amplihack");
+    write_executable(&usr_local_bin, "amplihack-hooks");
+
+    let report = analyze_path_conflicts(&analysis_input(
+        &home,
+        &system_amplihack,
+        vec![usr_local_bin.clone()],
+    ))
+    .unwrap();
+    let probes = probe_candidates_without_exec(&report);
+
+    let decision = decide_update_install_target(TargetDecisionInput {
+        report: report.clone(),
+        candidate_probes: probes,
+        denied_system_prefixes: vec![temp.path().join("usr/local")],
+    })
+    .unwrap();
+
+    let notice = super::update_path_conflict_notice(&report, &decision)
+        .expect("updating a user-local target that is not on PATH must produce guidance");
+    assert!(notice.contains("instead of the user-local target"));
+    assert!(notice.contains(&usr_local_bin.join("amplihack").display().to_string()));
+    assert!(notice.contains(&user_bin.join("amplihack").display().to_string()));
+    assert!(notice.contains("earlier in PATH"));
+    assert!(
+        !notice.contains("Permission denied copying") && !notice.contains("failed to copy"),
+        "PATH guidance must not regress to copy-failure noise, got: {notice}"
     );
 }


### PR DESCRIPTION
Follow-up from the PR #699 quality audit loop.\n\nChanges:\n- Treat PATH aliases that canonicalize to ~/.local/bin as preferred user candidates, avoiding safe-alias noise while still detecting system binaries that shadow those aliases.\n- Require existing user-level amplihack and amplihack-hooks files before redirecting denied-system updates to ~/.local/bin.\n- Emit update guidance when user-local targets are selected but are absent from command resolution.\n- Bound Python-shadow shebang inspection to avoid scanning large binaries.\n\nValidation:\n- cargo test -p amplihack-cli path_conflict --quiet\n- cargo test -p amplihack-cli install_target --quiet\n- cargo test -p amplihack-cli --quiet\n- cargo clippy -p amplihack-cli --all-targets -- -D warnings