### PR TITLE
perf: stream npm release archive downloads

### DIFF
--- a/npm/lib/bootstrap.js
+++ b/npm/lib/bootstrap.js
@@ -6,6 +6,8 @@ const fsp = require('node:fs/promises');
 const https = require('node:https');
 const os = require('node:os');
 const path = require('node:path');
+const { Transform } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
 const { setTimeout: delay } = require('node:timers/promises');
 const { spawnSync } = require('node:child_process');
 
@@ -206,6 +208,10 @@ function validateDownloadUrl(url) {
 function verifyArchiveChecksum(archiveBytes, checksumText, archiveUrl) {
   const expectedHex = parseChecksumHex(checksumText);
   const actualHex = crypto.createHash('sha256').update(archiveBytes).digest('hex');
+  verifyArchiveDigest(actualHex, expectedHex, archiveUrl);
+}
+
+function verifyArchiveDigest(actualHex, expectedHex, archiveUrl) {
   if (actualHex.toLowerCase() !== expectedHex.toLowerCase()) {
     throw new Error(`SHA-256 mismatch for ${archiveUrl}`);
   }
@@ -365,6 +371,106 @@ async function download(url, {
   }
 }
 
+function downloadFileOnce(url, destination, { timeoutMs = DOWNLOAD_TIMEOUT_MS } = {}) {
+  return new Promise((resolve, reject) => {
+    const seen = new Set();
+    let settled = false;
+
+    function finish(error, result) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    }
+
+    function fetch(currentUrl) {
+      validateDownloadUrl(currentUrl);
+      if (seen.has(currentUrl)) {
+        finish(new Error(`Redirect loop while downloading ${url}`));
+        return;
+      }
+      seen.add(currentUrl);
+
+      const request = https
+        .get(currentUrl, {
+          headers: {
+            'User-Agent': 'amplihack-npm-wrapper',
+            Accept: 'application/octet-stream,application/vnd.github+json',
+          },
+        }, (response) => {
+          const statusCode = response.statusCode || 0;
+          if ([301, 302, 303, 307, 308].includes(statusCode) && response.headers.location) {
+            response.resume();
+            fetch(response.headers.location);
+            return;
+          }
+          if (statusCode < 200 || statusCode >= 300) {
+            response.resume();
+            const message = `HTTP ${statusCode} while downloading ${currentUrl}`;
+            finish([408, 429, 500, 502, 503, 504].includes(statusCode)
+              ? retryableDownloadError(message)
+              : new Error(message));
+            return;
+          }
+
+          let total = 0;
+          const hash = crypto.createHash('sha256');
+          const meter = new Transform({
+            transform(chunk, _encoding, callback) {
+              total += chunk.length;
+              if (total > DOWNLOAD_SIZE_LIMIT) {
+                callback(new Error(`Download exceeded ${DOWNLOAD_SIZE_LIMIT} bytes`));
+                return;
+              }
+              hash.update(chunk);
+              callback(null, chunk);
+            },
+          });
+
+          pipeline(response, meter, fs.createWriteStream(destination))
+            .then(() => finish(null, {
+              bytes: total,
+              sha256: hash.digest('hex'),
+            }))
+            .catch((error) => finish(error));
+        })
+        .on('error', (error) => finish(error));
+      request.setTimeout(timeoutMs, () => {
+        request.destroy(retryableDownloadError(`Timed out after ${timeoutMs}ms while downloading ${currentUrl}`));
+      });
+    }
+
+    fetch(url);
+  });
+}
+
+async function downloadFile(url, destination, {
+  attempts = DOWNLOAD_MAX_ATTEMPTS,
+  retryDelayMs = DOWNLOAD_RETRY_BASE_DELAY_MS,
+  timeoutMs = DOWNLOAD_TIMEOUT_MS,
+} = {}) {
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error(`Download attempts must be at least 1 for ${url}`);
+  }
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await downloadFileOnce(url, destination, { timeoutMs });
+    } catch (error) {
+      await fsp.rm(destination, { force: true }).catch(() => {});
+      if (attempt >= attempts || !isRetryableDownloadError(error)) {
+        throw error;
+      }
+      await delay(retryDelayMs * attempt);
+    }
+  }
+  throw new Error(`Download attempts exhausted for ${url}`);
+}
+
 /**
  * Resolve the latest published release tag for the configured GitHub repo.
  *
@@ -416,16 +522,16 @@ async function installFromRelease(version, installRoot) {
   }
 
   const { archiveUrl, checksumUrl } = releaseUrls(version, target);
-  const archiveBytes = await download(archiveUrl);
   const checksumBytes = await download(checksumUrl);
-  verifyArchiveChecksum(archiveBytes, checksumBytes.toString('utf8'), archiveUrl);
+  const expectedHex = parseChecksumHex(checksumBytes.toString('utf8'));
 
   const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'amplihack-npm-'));
   try {
     const archivePath = path.join(tempRoot, 'amplihack.tar.gz');
     const extractDir = path.join(tempRoot, 'extract');
     await fsp.mkdir(extractDir, { recursive: true });
-    await fsp.writeFile(archivePath, archiveBytes);
+    const archiveDownload = await downloadFile(archiveUrl, archivePath);
+    verifyArchiveDigest(archiveDownload.sha256, expectedHex, archiveUrl);
 
     const tar = spawnSync('tar', ['-xzf', archivePath, '-C', extractDir], {
       stdio: 'inherit',
@@ -556,6 +662,7 @@ module.exports = {
   cacheStateRoot,
   copyFileAtomic,
   download,
+  downloadFile,
   ensureNativeBinaries,
   findBinary,
   hasLocalCargoWorkspace,

--- a/npm/test/bootstrap.test.js
+++ b/npm/test/bootstrap.test.js
@@ -2,11 +2,13 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const https = require('node:https');
 const os = require('node:os');
 const path = require('node:path');
 const { EventEmitter } = require('node:events');
+const { Readable } = require('node:stream');
 const { setTimeout: delay } = require('node:timers/promises');
 
 const {
@@ -15,6 +17,7 @@ const {
   cacheStateRoot,
   copyFileAtomic,
   download,
+  downloadFile,
   findBinary,
   hasLocalCargoWorkspace,
   latestTagCachePath,
@@ -73,7 +76,7 @@ test('checksum parser extracts the leading digest token', () => {
 
 test('checksum verification requires the published digest to match', () => {
   const archiveBytes = Buffer.from('amplihack');
-  const digest = require('node:crypto').createHash('sha256').update(archiveBytes).digest('hex');
+  const digest = crypto.createHash('sha256').update(archiveBytes).digest('hex');
   assert.doesNotThrow(() => verifyArchiveChecksum(archiveBytes, `${digest}  amplihack.tar.gz\n`, 'https://example.test/archive'));
   assert.throws(() => verifyArchiveChecksum(archiveBytes, `${'a'.repeat(64)}  amplihack.tar.gz\n`, 'https://example.test/archive'));
 });
@@ -86,15 +89,16 @@ test('download URL validation only trusts GitHub release hosts', () => {
 });
 
 function responseFor(statusCode, body = '', headers = {}) {
-  const response = new EventEmitter();
+  const response = new Readable({
+    read() {},
+  });
   response.statusCode = statusCode;
   response.headers = headers;
-  response.resume = () => {};
   response.send = () => {
     if (body.length > 0) {
-      response.emit('data', Buffer.from(body));
+      response.push(Buffer.from(body));
     }
-    response.emit('end');
+    response.push(null);
   };
   return response;
 }
@@ -193,6 +197,33 @@ test('download retries request timeouts', async () => {
     );
     assert.equal(bytes.toString('utf8'), 'after-timeout');
     assert.equal(attempts, 2);
+  });
+});
+
+test('downloadFile retries transient failures and streams bytes to disk', async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'amplihack-download-file-'));
+  const destination = path.join(tempDir, 'archive.tar.gz');
+  const body = 'streamed archive bytes';
+  let attempts = 0;
+  await withMockHttpsGet((_, __, callback) => {
+    process.nextTick(() => {
+      attempts += 1;
+      const response = attempts === 1
+        ? responseFor(503)
+        : responseFor(200, body);
+      callback(response);
+      response.send();
+    });
+  }, async () => {
+    const result = await downloadFile(
+      'https://github.com/rysweet/amplihack-rs/releases/download/v1.2.3/amplihack-x86_64-unknown-linux-gnu.tar.gz',
+      destination,
+      { attempts: 2, retryDelayMs: 0, timeoutMs: 1000 },
+    );
+    assert.equal(await fs.promises.readFile(destination, 'utf8'), body);
+    assert.equal(attempts, 2);
+    assert.equal(result.bytes, Buffer.byteLength(body));
+    assert.equal(result.sha256, crypto.createHash('sha256').update(body).digest('hex'));
   });
 });
 


### PR DESCRIPTION
## Summary
- Stream npm release archive downloads directly to a temp file while hashing, avoiding large in-memory archive buffers during install.
- Keep the existing buffered download path for small API/checksum responses.
- Add coverage for streamed download retry, byte count, digest, and file output.

## Validation
- node --check npm/lib/bootstrap.js
- node --check npm/test/bootstrap.test.js
- node --test npm/test/bootstrap.test.js
- cargo test -p amplihack-cli --locked commands::fleet
- cargo test --locked --test doctor_node_remediation --test issue_615_work_verifier --test version_contract --test workflow_prep_git_recovery --test workflow_publish_pr_metadata
- cargo fmt --check
- cargo clippy --workspace --locked -- -D warnings
- cargo test --workspace --locked