### PR TITLE
fix: close asset resolution parity gaps

### DIFF
--- a/bins/amplihack-asset-resolver/src/main.rs
+++ b/bins/amplihack-asset-resolver/src/main.rs
@@ -10,7 +10,9 @@ fn main() {
     if args.len() != 2 {
         eprintln!("Usage: amplihack-asset-resolver <asset>");
         eprintln!("  <asset> is either:");
-        eprintln!("    - a named asset: multitask-orchestrator");
+        eprintln!(
+            "    - a named asset: hooks-dir, helper-path, session-tree-path, multitask-orchestrator"
+        );
         eprintln!("    - a relative path starting with 'amplifier-bundle/'");
         std::process::exit(2);
     }

--- a/crates/amplihack-cli/src/runtime_assets.rs
+++ b/crates/amplihack-cli/src/runtime_assets.rs
@@ -13,13 +13,15 @@ use tracing::{debug, info, warn};
 /// Each asset name maps to one or more candidate relative paths tried in order.
 pub fn asset_relative_paths() -> HashMap<&'static str, Vec<&'static str>> {
     let mut m = HashMap::new();
-    // NOTE (rysweet/amplihack-rs#285): the "hooks-dir" named asset was removed.
-    // Its only consumers were two `HOOKS_DIR=$(...) || true` lines in
-    // smart-orchestrator.yaml that never read the variable. Both the asset
-    // entry and those shell lines were deleted as part of the first slice of
-    // the umbrella issue eliminating the bundled-Python tools/amplihack/ tree.
-    // Native compatibility wrapper for legacy callers that still resolve the
-    // multitask orchestrator by logical asset name.
+    m.insert("hooks-dir", vec!["amplifier-bundle/tools/amplihack/hooks"]);
+    m.insert(
+        "helper-path",
+        vec!["amplifier-bundle/bin/multitask-orchestrator.sh"],
+    );
+    m.insert(
+        "session-tree-path",
+        vec!["amplifier-bundle/tools/amplihack/session"],
+    );
     m.insert(
         "multitask-orchestrator",
         vec!["amplifier-bundle/bin/multitask-orchestrator.sh"],
@@ -155,8 +157,9 @@ mod tests {
     fn asset_relative_paths_has_known_keys() {
         let paths = asset_relative_paths();
         assert!(paths.contains_key("multitask-orchestrator"));
-        assert!(!paths.contains_key("helper-path"));
-        assert!(!paths.contains_key("session-tree-path"));
+        assert!(paths.contains_key("helper-path"));
+        assert!(paths.contains_key("session-tree-path"));
+        assert!(paths.contains_key("hooks-dir"));
     }
 
     #[test]
@@ -167,18 +170,22 @@ mod tests {
         assert!(orch[0].contains("amplifier-bundle/bin"));
     }
 
-    /// Regression guard for rysweet/amplihack-rs#285: the "hooks-dir" named
-    /// asset and the underlying amplifier-bundle/tools/amplihack/hooks/
-    /// directory have been deleted. Re-introducing the asset key without
-    /// also restoring real consumers would re-create the dead code path
-    /// (HOOKS_DIR was assigned with `|| true` and never read), which is
-    /// exactly what this slice removed.
     #[test]
-    fn hooks_dir_is_not_registered_see_issue_285() {
+    fn helper_path_uses_native_wrapper() {
+        let paths = asset_relative_paths();
+        let helper = &paths["helper-path"];
+        assert_eq!(
+            helper,
+            &vec!["amplifier-bundle/bin/multitask-orchestrator.sh"]
+        );
+    }
+
+    #[test]
+    fn hooks_dir_is_registered_for_legacy_asset_resolution() {
         let paths = asset_relative_paths();
         assert!(
-            !paths.contains_key("hooks-dir"),
-            "hooks-dir asset must remain unregistered (see rysweet/amplihack-rs#285)"
+            paths.contains_key("hooks-dir"),
+            "hooks-dir asset must remain registered for issue #634 parity"
         );
     }
 

--- a/crates/amplihack-cli/tests/issue_634_asset_resolution_parity.rs
+++ b/crates/amplihack-cli/tests/issue_634_asset_resolution_parity.rs
@@ -1,0 +1,240 @@
+//! TDD regression contracts for issue #634.
+//!
+//! These tests define the helper-path and runtime asset-resolution parity
+//! contract that the Rust port must preserve after PR #641 / v0.9.80.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use amplihack_cli::{Cli, Commands, resolve_bundle_asset, runtime_assets};
+use clap::Parser;
+
+#[derive(Clone, Copy)]
+enum ExpectedKind {
+    File,
+    Dir,
+}
+
+#[derive(Clone, Copy)]
+struct AssetCase {
+    name: &'static str,
+    rel_path: &'static str,
+    kind: ExpectedKind,
+}
+
+const ISSUE_634_ASSETS: &[AssetCase] = &[
+    AssetCase {
+        name: "helper-path",
+        rel_path: "amplifier-bundle/bin/multitask-orchestrator.sh",
+        kind: ExpectedKind::File,
+    },
+    AssetCase {
+        name: "multitask-orchestrator",
+        rel_path: "amplifier-bundle/bin/multitask-orchestrator.sh",
+        kind: ExpectedKind::File,
+    },
+    AssetCase {
+        name: "hooks-dir",
+        rel_path: "amplifier-bundle/tools/amplihack/hooks",
+        kind: ExpectedKind::Dir,
+    },
+    AssetCase {
+        name: "session-tree-path",
+        rel_path: "amplifier-bundle/tools/amplihack/session",
+        kind: ExpectedKind::Dir,
+    },
+];
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct IsolatedRuntimeRoot {
+    _lock: MutexGuard<'static, ()>,
+    temp: tempfile::TempDir,
+    prev_home: Option<OsString>,
+    prev_amplihack_home: Option<OsString>,
+}
+
+impl IsolatedRuntimeRoot {
+    fn new() -> Self {
+        let lock = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().expect("create isolated runtime root");
+        for case in ISSUE_634_ASSETS {
+            let path = temp.path().join(case.rel_path);
+            match case.kind {
+                ExpectedKind::File => {
+                    std::fs::create_dir_all(path.parent().expect("asset file has parent"))
+                        .expect("create asset parent");
+                    std::fs::write(&path, "#!/bin/sh\nexit 0\n").expect("write asset file");
+                }
+                ExpectedKind::Dir => {
+                    std::fs::create_dir_all(&path).expect("create asset directory");
+                }
+            }
+        }
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_amplihack_home = std::env::var_os("AMPLIHACK_HOME");
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+            std::env::set_var("AMPLIHACK_HOME", temp.path());
+        }
+
+        Self {
+            _lock: lock,
+            temp,
+            prev_home,
+            prev_amplihack_home,
+        }
+    }
+
+    fn expected_path(&self, rel_path: &str) -> std::path::PathBuf {
+        self.temp
+            .path()
+            .join(rel_path)
+            .canonicalize()
+            .expect("expected asset path canonicalizes")
+    }
+}
+
+impl Drop for IsolatedRuntimeRoot {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prev_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match &self.prev_amplihack_home {
+                Some(value) => std::env::set_var("AMPLIHACK_HOME", value),
+                None => std::env::remove_var("AMPLIHACK_HOME"),
+            }
+        }
+    }
+}
+
+#[test]
+fn issue_634_named_assets_resolve_to_expected_runtime_paths() {
+    let runtime = IsolatedRuntimeRoot::new();
+
+    for case in ISSUE_634_ASSETS {
+        let resolved = resolve_bundle_asset::resolve_named_asset(case.name)
+            .unwrap_or_else(|err| panic!("resolve {}: {err:#}", case.name));
+        let expected = runtime.expected_path(case.rel_path);
+
+        assert_eq!(
+            resolved, expected,
+            "{} must resolve to {}",
+            case.name, case.rel_path
+        );
+        match case.kind {
+            ExpectedKind::File => assert!(
+                resolved.is_file(),
+                "{} must resolve to a file: {}",
+                case.name,
+                resolved.display()
+            ),
+            ExpectedKind::Dir => assert!(
+                resolved.is_dir(),
+                "{} must resolve to a directory: {}",
+                case.name,
+                resolved.display()
+            ),
+        }
+    }
+}
+
+#[test]
+fn issue_634_legacy_runtime_assets_module_matches_named_asset_contract() {
+    let runtime = IsolatedRuntimeRoot::new();
+    let roots = vec![runtime.temp.path().to_path_buf()];
+    let asset_map = runtime_assets::asset_relative_paths();
+
+    for case in ISSUE_634_ASSETS {
+        assert_eq!(
+            asset_map.get(case.name).map(Vec::as_slice),
+            Some([case.rel_path].as_slice()),
+            "runtime_assets mapping for {} must match resolve-bundle-asset",
+            case.name
+        );
+
+        let resolved = runtime_assets::resolve_asset_path(case.name, &roots)
+            .unwrap_or_else(|err| panic!("runtime_assets resolve {}: {err:#}", case.name));
+        assert_eq!(
+            resolved,
+            runtime.expected_path(case.rel_path),
+            "runtime_assets {} must resolve to the same compatibility path",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn issue_634_resolve_bundle_asset_cli_accepts_all_parity_asset_names() {
+    let _runtime = IsolatedRuntimeRoot::new();
+
+    for case in ISSUE_634_ASSETS {
+        assert_eq!(
+            resolve_bundle_asset::run_cli(case.name),
+            0,
+            "resolve-bundle-asset {} must succeed from AMPLIHACK_HOME",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn issue_634_clap_dispatch_preserves_asset_argument_verbatim() {
+    for case in ISSUE_634_ASSETS {
+        let cli = Cli::try_parse_from(["amplihack", "resolve-bundle-asset", case.name])
+            .unwrap_or_else(|err| panic!("parse {}: {err}", case.name));
+
+        match cli.command {
+            Commands::ResolveBundleAsset { asset } => assert_eq!(asset, case.name),
+            other => panic!(
+                "expected ResolveBundleAsset for {}, got {other:?}",
+                case.name
+            ),
+        }
+    }
+}
+
+#[test]
+fn issue_634_unknown_asset_error_lists_supported_parity_asset_names() {
+    let err = resolve_bundle_asset::resolve_named_asset("legacy-python-helper")
+        .expect_err("unknown named asset must fail");
+    let message = err.to_string();
+
+    for case in ISSUE_634_ASSETS {
+        assert!(
+            message.contains(case.name),
+            "unknown-asset error must mention supported asset `{}`; got: {message}",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn issue_634_helper_path_does_not_resolve_to_removed_python_helper() {
+    let runtime = IsolatedRuntimeRoot::new();
+    let resolved = resolve_bundle_asset::resolve_named_asset("helper-path")
+        .expect("helper-path must resolve from isolated runtime root");
+
+    assert_eq!(
+        resolved,
+        runtime.expected_path("amplifier-bundle/bin/multitask-orchestrator.sh")
+    );
+    assert!(
+        !path_contains_component(&resolved, "orch_helper.py"),
+        "helper-path must not regress to the removed Python orch_helper.py path"
+    );
+}
+
+fn path_contains_component(path: &Path, component: &str) -> bool {
+    path.components()
+        .any(|part| part.as_os_str().to_string_lossy() == component)
+}

--- a/docs/HOOK_CONFIGURATION_GUIDE.md
+++ b/docs/HOOK_CONFIGURATION_GUIDE.md
@@ -36,8 +36,12 @@ If you see hook definitions, you need to manually merge amplihack hooks.
 ### Step 2: Find Your Amplihack Installation
 
 ```bash
-# Find where amplihack hooks are installed
-ls -la ~/.claude/tools/amplihack/hooks/
+# Find the native hook runner.
+which amplihack-hooks
+
+# Resolve the bundle hook metadata directory used by parity checks.
+HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir)"
+printf 'hooks-dir -> %s\n' "$HOOKS_DIR"
 ```
 
 ### Step 3: Add Amplihack Hooks to Your Project
@@ -58,7 +62,7 @@ Edit your project's `~/.amplihack/.claude/settings.json` and add the amplihack h
           // ADD AMPLIHACK HOOK
           {
             "type": "command",
-            "command": "/Users/YOUR_USERNAME/.claude/tools/amplihack/hooks/session_start.py",
+            "command": "/Users/YOUR_USERNAME/.local/bin/amplihack-hooks session-start",
             "timeout": 10
           }
         ]
@@ -71,7 +75,7 @@ Edit your project's `~/.amplihack/.claude/settings.json` and add the amplihack h
           // ADD AMPLIHACK HOOK
           {
             "type": "command",
-            "command": "/Users/YOUR_USERNAME/.claude/tools/amplihack/hooks/stop.py",
+            "command": "/Users/YOUR_USERNAME/.local/bin/amplihack-hooks stop",
             "timeout": 120
           }
         ]
@@ -85,7 +89,7 @@ Edit your project's `~/.amplihack/.claude/settings.json` and add the amplihack h
           // ADD AMPLIHACK HOOK
           {
             "type": "command",
-            "command": "/Users/YOUR_USERNAME/.claude/tools/amplihack/hooks/post_tool_use.py"
+            "command": "/Users/YOUR_USERNAME/.local/bin/amplihack-hooks post-tool-use"
           }
         ]
       }
@@ -94,15 +98,15 @@ Edit your project's `~/.amplihack/.claude/settings.json` and add the amplihack h
 }
 ```
 
-**Important:** Replace `/Users/YOUR_USERNAME` with your actual home directory path.
+**Important:** Replace `/Users/YOUR_USERNAME/.local/bin/amplihack-hooks` with
+the absolute path printed by `which amplihack-hooks`.
 
 ### Step 4: Verify Your Configuration
 
 ```bash
-# Check that all hook files exist
-ls -la /Users/YOUR_USERNAME/.claude/tools/amplihack/hooks/session_start.py
-ls -la /Users/YOUR_USERNAME/.claude/tools/amplihack/hooks/stop.py
-ls -la /Users/YOUR_USERNAME/.claude/tools/amplihack/hooks/post_tool_use.py
+# Check that the native hook runner exists and the bundle hook directory resolves.
+test -x /Users/YOUR_USERNAME/.local/bin/amplihack-hooks
+test -d "$(amplihack resolve-bundle-asset hooks-dir)"
 ```
 
 ## Troubleshooting
@@ -112,16 +116,17 @@ ls -la /Users/YOUR_USERNAME/.claude/tools/amplihack/hooks/post_tool_use.py
 If you see errors like:
 
 ```
-⏺ Stop [.claude/tools/amplihack/hooks/stop.py] failed with non-blocking status code 127
+⏺ Stop [amplihack-hooks stop] failed with non-blocking status code 127
 ```
 
 This means:
 
-1. The path is wrong (check for typos)
+1. The `amplihack-hooks` path is wrong (check for typos)
 2. The path is relative instead of absolute
-3. The hook file doesn't exist
+3. The `amplihack-hooks` binary is not installed
 
-**Solution:** Use absolute paths starting with `/Users/` (macOS) or `/home/` (Linux).
+**Solution:** Use the absolute path printed by `which amplihack-hooks`, or
+rerun `amplihack install` to rewrite hook commands automatically.
 
 ### Hooks Not Running At All
 
@@ -178,7 +183,9 @@ If you're still having issues:
 1. Check that amplihack is properly installed:
 
    ```bash
-   ls -la ~/.claude/tools/amplihack/
+   which amplihack
+   which amplihack-hooks
+   amplihack resolve-bundle-asset hooks-dir
    ```
 
 2. Verify your paths are absolute and correct
@@ -207,7 +214,7 @@ Here's a complete example of a project's `~/.amplihack/.claude/settings.json` wi
           },
           {
             "type": "command",
-            "command": "/Users/johndoe/.claude/tools/amplihack/hooks/session_start.py",
+            "command": "/Users/johndoe/.local/bin/amplihack-hooks session-start",
             "timeout": 10
           }
         ]
@@ -223,7 +230,7 @@ Here's a complete example of a project's `~/.amplihack/.claude/settings.json` wi
           },
           {
             "type": "command",
-            "command": "/Users/johndoe/.claude/tools/amplihack/hooks/stop.py",
+            "command": "/Users/johndoe/.local/bin/amplihack-hooks stop",
             "timeout": 120
           }
         ]
@@ -235,7 +242,7 @@ Here's a complete example of a project's `~/.amplihack/.claude/settings.json` wi
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/johndoe/.claude/tools/amplihack/hooks/post_tool_use.py"
+            "command": "/Users/johndoe/.local/bin/amplihack-hooks post-tool-use"
           }
         ]
       }

--- a/docs/bugfixes/bugfix-666-667-668-stale-python-refs.md
+++ b/docs/bugfixes/bugfix-666-667-668-stale-python-refs.md
@@ -40,7 +40,7 @@ reference the Rust replacements directly:
 | `amplifier-bundle/skills/dependency-resolver/README.md` L72 | `ci_status.py` → `gh CLI` (`gh run list`) |
 | `docs/atlas/runtime-topology/README.md` L14 | `session_tree.py` → native recursion guard |
 | `docs/tutorials/dev-orchestrator-tutorial.md` L393-406 | Troubleshooting rewritten for native Rust |
-| `docs/reference/resolve-bundle-asset-command.md` L28,59 | `helper-path` → `amplihack orch helper` |
+| `docs/reference/resolve-bundle-asset-command.md` | `helper-path` documented as a compatibility alias for `amplifier-bundle/bin/multitask-orchestrator.sh` |
 
 **Historical documentation** (audits, P1 plans, publish-validation tutorials)
 received inline deprecation notes preserving historical accuracy:
@@ -72,7 +72,7 @@ Files annotated:
 After this fix, all documentation paths resolve correctly:
 
 ```bash
-# Resolves to native Rust (no Python dependency)
+# Resolves to the native multitask orchestrator wrapper (no Python dependency)
 amplihack resolve-bundle-asset helper-path
 
 # Native recursion guard — no session_tree.py needed

--- a/docs/howto/configure-hooks.md
+++ b/docs/howto/configure-hooks.md
@@ -35,14 +35,21 @@ cat .claude/settings.json 2>/dev/null | grep -A5 hooks
 
 If you see hook definitions, you need to merge manually.
 
-### Step 2: Locate amplihack Hook Scripts
+### Step 2: Locate amplihack Hook Runtime
 
 ```bash
-# The install command places hooks relative to the bundle:
-amplihack resolve-bundle-asset hooks/session_start.py
-amplihack resolve-bundle-asset hooks/stop.py
-amplihack resolve-bundle-asset hooks/post_tool_use.py
+# Hook behavior is served by the native amplihack-hooks binary.
+which amplihack-hooks
+
+# The bundle hook directory remains available for hook metadata and parity checks.
+HOOKS_DIR="$(amplihack resolve-bundle-asset hooks-dir)"
+printf 'hooks-dir -> %s\n' "$HOOKS_DIR"
+test -f "$HOOKS_DIR/README.md"
 ```
+
+Do not pass individual hook script names such as `hooks/session_start.py` to
+`resolve-bundle-asset`. The resolver accepts the named `hooks-dir` asset; hook
+commands themselves run through `amplihack-hooks <subcommand>`.
 
 ### Step 3: Add amplihack Hooks to Project Settings
 
@@ -61,7 +68,7 @@ your existing ones:
           },
           {
             "type": "command",
-            "command": "/home/you/.claude/tools/amplihack/hooks/session_start.py",
+            "command": "/home/you/.local/bin/amplihack-hooks session-start",
             "timeout": 10
           }
         ]
@@ -72,7 +79,7 @@ your existing ones:
         "hooks": [
           {
             "type": "command",
-            "command": "/home/you/.claude/tools/amplihack/hooks/stop.py",
+            "command": "/home/you/.local/bin/amplihack-hooks stop",
             "timeout": 120
           }
         ]
@@ -84,7 +91,7 @@ your existing ones:
         "hooks": [
           {
             "type": "command",
-            "command": "/home/you/.claude/tools/amplihack/hooks/post_tool_use.py"
+            "command": "/home/you/.local/bin/amplihack-hooks post-tool-use"
           }
         ]
       }
@@ -94,23 +101,24 @@ your existing ones:
 ```
 
 !!! warning "Use Absolute Paths"
-    Always use absolute paths for hook commands. Relative paths cause
-    "file not found" errors (exit code 127).
+    Always use the absolute path to `amplihack-hooks` when hand-editing
+    settings. Relative paths cause "file not found" errors (exit code 127).
 
 ### Step 4: Verify
 
 Start a new Claude Code session. Check the output panel for:
 
 ```
-SessionStart [/home/you/.claude/tools/amplihack/hooks/session_start.py] completed
+SessionStart [/home/you/.local/bin/amplihack-hooks session-start] completed
 ```
 
 ## Troubleshooting
 
 ### "Hook not found" (exit code 127)
 
-The hook path is wrong or relative. Use absolute paths starting with `/home/`
-(Linux) or `/Users/` (macOS).
+The `amplihack-hooks` path is wrong or relative. Use an absolute path starting
+with `/home/` (Linux) or `/Users/` (macOS), or rerun `amplihack install` to
+rewrite hook commands automatically.
 
 ### Hooks Not Running
 

--- a/docs/howto/troubleshoot-hooks.md
+++ b/docs/howto/troubleshoot-hooks.md
@@ -13,13 +13,14 @@ cat ~/.claude/settings.json | grep -A5 hooks
 # Expected output: Should show SessionStart, Stop, and PostToolUse hooks
 ```
 
-### 2. Verify Hook Files Exist
+### 2. Verify Hook Runtime Exists
 
 ```bash
-# Check if hook files are installed
-ls -la ~/.claude/tools/amplihack/hooks/
+# Check if the native hook runner is installed
+which amplihack-hooks
 
-# Expected output: session_start.py, stop.py, post_tool_use.py
+# Check if the bundle hook directory resolves for metadata/parity checks
+amplihack resolve-bundle-asset hooks-dir
 ```
 
 ### 3. Check Hook Execution
@@ -27,7 +28,7 @@ ls -la ~/.claude/tools/amplihack/hooks/
 Start Claude Code and look for hook execution messages in the output:
 
 ```
-✓ SessionStart [/home/user/.claude/tools/amplihack/hooks/session_start.py] completed
+✓ SessionStart [/home/user/.local/bin/amplihack-hooks session-start] completed
 ```
 
 ## Common Issues and Solutions
@@ -55,10 +56,10 @@ cargo install amplihack-rs amplihack --version
 **Symptom:**
 
 ```
-⏺ Stop [.claude/tools/amplihack/hooks/stop.py] failed with non-blocking status code 127
+⏺ Stop [amplihack-hooks stop] failed with non-blocking status code 127
 ```
 
-**Cause:** Hook path is incorrect or relative instead of absolute.
+**Cause:** The `amplihack-hooks` path is incorrect, relative, or missing.
 
 **Solution:**
 
@@ -72,7 +73,7 @@ Check and fix hook paths in ~/.claude/settings.json:
         "hooks": [
           {
             "type": "command",
-            "command": "/home/user/.claude/tools/amplihack/hooks/stop.py"
+            "command": "/home/user/.local/bin/amplihack-hooks stop"
           }
         ]
       }
@@ -81,7 +82,8 @@ Check and fix hook paths in ~/.claude/settings.json:
 }
 ```
 
-**Automatic Fix:** As of v0.9.1, amplihack automatically fixes relative paths to absolute during launch.
+**Automatic Fix:** Rerun `amplihack install` to rewrite hook commands with the
+current absolute `amplihack-hooks` path.
 
 ### Issue 3: Hooks Not Running At All
 
@@ -114,13 +116,13 @@ Manually merge amplihack hooks into project settings. See [Hook Configuration Gu
 ⏺ SessionStart failed: Permission denied
 ```
 
-**Cause:** Hook files aren't executable.
+**Cause:** The `amplihack-hooks` binary is not executable.
 
 **Solution:**
 
 ```bash
-# Make hooks executable
-chmod +x ~/.claude/tools/amplihack/hooks/*.py
+# Reinstall to restore executable permissions
+amplihack install
 ```
 
 ### Issue 5: Hook Timeout
@@ -161,8 +163,9 @@ echo "2. Project Settings Hooks:"
 grep -A10 hooks .claude/settings.json 2>/dev/null || echo "   No project hooks found"
 echo ""
 
-echo "3. Hook Files:"
-ls -lh ~/.claude/tools/amplihack/hooks/ 2>/dev/null || echo "   Hook directory not found"
+echo "3. Hook Runtime:"
+which amplihack-hooks 2>/dev/null || echo "   amplihack-hooks not found"
+amplihack resolve-bundle-asset hooks-dir 2>/dev/null || echo "   hooks-dir not found"
 echo ""
 
 echo "4. Recent Hook Execution (from logs):"

--- a/docs/howto/verify-runtime-asset-resolution.md
+++ b/docs/howto/verify-runtime-asset-resolution.md
@@ -1,0 +1,113 @@
+---
+title: Verify runtime asset resolution
+description: Confirm native amplihack asset resolution for helper, session, hooks, and multitask assets.
+last_updated: 2026-06-05
+review_schedule: as-needed
+owner: amplihack-maintainers
+doc_type: howto
+---
+
+# Verify runtime asset resolution
+
+Use this guide to confirm that a Rust amplihack install resolves the legacy
+Python-era asset names and the current native multitask asset from the same
+runtime bundle.
+
+## Prerequisites
+
+- `amplihack` is installed and on `PATH`
+- The installed bundle root contains `amplifier-bundle/`
+- Optional: `amplihack-asset-resolver` is installed for child-process checks
+
+## Check the installed binary
+
+```bash
+amplihack --version
+which amplihack
+```
+
+The binary should be the user-local or release binary you expect to test. If a
+stale system binary appears first, repair the path order with
+[Repair install/update PATH conflicts](./repair-install-update-path-conflicts.md).
+
+## Resolve every parity asset
+
+Run the fixed allowlist of runtime assets:
+
+```bash
+for asset in helper-path session-tree-path hooks-dir multitask-orchestrator; do
+  path="$(amplihack resolve-bundle-asset "$asset")"
+  printf '%s -> %s\n' "$asset" "$path"
+  test -e "$path"
+done
+```
+
+Expected output shape:
+
+```text
+helper-path -> /home/alice/.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
+session-tree-path -> /home/alice/.amplihack/amplifier-bundle/tools/amplihack/session
+hooks-dir -> /home/alice/.amplihack/amplifier-bundle/tools/amplihack/hooks
+multitask-orchestrator -> /home/alice/.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
+```
+
+## Check expected file types
+
+```bash
+test -f "$(amplihack resolve-bundle-asset helper-path)"
+test -d "$(amplihack resolve-bundle-asset session-tree-path)"
+test -d "$(amplihack resolve-bundle-asset hooks-dir)"
+test -f "$(amplihack resolve-bundle-asset multitask-orchestrator)"
+```
+
+All commands exit `0` when the installed bundle matches the resolver contract.
+
+## Verify a custom bundle root
+
+Set `AMPLIHACK_HOME` when validating a non-default install root:
+
+```bash
+AMPLIHACK_HOME="$HOME/.amplihack" amplihack resolve-bundle-asset helper-path
+```
+
+`AMPLIHACK_HOME` must point to the directory that contains
+`amplifier-bundle/`, not to `amplifier-bundle/` itself.
+
+## Verify child-process resolution
+
+Recipe runners and launchers expose the standalone resolver through
+`AMPLIHACK_ASSET_RESOLVER` when the binary is available:
+
+```bash
+if [ -n "${AMPLIHACK_ASSET_RESOLVER:-}" ]; then
+  "$AMPLIHACK_ASSET_RESOLVER" helper-path
+fi
+```
+
+You can also call the resolver binary directly:
+
+```bash
+amplihack-asset-resolver session-tree-path
+```
+
+Both forms print the same absolute paths as `amplihack resolve-bundle-asset`.
+
+Some standalone `amplihack-asset-resolver` no-argument usage text may still
+list only `multitask-orchestrator` as the named-asset example. That help text
+is stale; the standalone resolver dispatches valid arguments through the same
+registered asset table used by `amplihack resolve-bundle-asset`.
+
+## Interpret failures
+
+| Symptom | Meaning | Fix |
+| ------- | ------- | --- |
+| `Unknown asset name` | The binary does not know the named asset. | Update `amplihack` and rerun `amplihack install`. |
+| `Bundle asset not found` | The name is registered, but the file or directory is missing from every runtime root. | Set `AMPLIHACK_HOME` to the installed bundle root or reinstall amplihack. |
+| Exit code `2` | The argument is an invalid relative path. | Use one of the named assets above or a safe `amplifier-bundle/...` path. |
+| Help text omits a valid asset | The help example is stale, not a resolver failure. | Use the named asset table in the reference as the source of truth. |
+
+## Related
+
+- [resolve-bundle-asset Command Reference](../reference/resolve-bundle-asset-command.md)
+- [Environment Variables](../reference/environment-variables.md#amplihack_asset_resolver)
+- [Install Manifest](../reference/install-manifest.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,7 @@ amplihack copilot
 - [Hook Configuration](HOOK_CONFIGURATION_GUIDE.md) - Customize framework behavior
 - [Memory Configuration Consent](features/memory-consent-prompt.md) - Intelligent memory settings with timeout protection
 - [Verify .claude/ Staging](howto/verify-claude-staging.md) - Check that framework files are properly staged
+- [Verify Runtime Asset Resolution](howto/verify-runtime-asset-resolution.md) - Check helper, session, hooks, and multitask asset parity
 - [Verify Framework Injection](howto/verify-framework-injection.md) - Check that AMPLIHACK.md injection is working
 - [Enable Blarify Code Indexing](howto/enable-blarify.md) - Opt-in code graph indexing with env var, non-interactive mode, and staleness detection
 
@@ -454,6 +455,7 @@ Execute complex tasks with simple slash commands.
 
 - [Command Selection Guide](commands/COMMAND_SELECTION_GUIDE.md) - Choose the right command for your task
 - [Amplifier Command](reference/amplifier-command.md) - Launch Amplifier with amplihack bundle
+- [resolve-bundle-asset Command](reference/resolve-bundle-asset-command.md) - Resolve native bundle assets and legacy parity aliases
 
 ### Core Commands
 

--- a/docs/recipes/P1_WORKFLOW_RELIABILITY_FIXES.md
+++ b/docs/recipes/P1_WORKFLOW_RELIABILITY_FIXES.md
@@ -98,11 +98,11 @@ Two named assets re-registered in the `NAMED_ASSETS` table:
 | Name | Resolves to | Fallback |
 |---|---|---|
 | `hooks-dir` | `amplifier-bundle/tools/amplihack/hooks/` | — |
-| `helper-path` | `amplihack orch helper` (native Rust) |  |
+| `helper-path` | `amplifier-bundle/bin/multitask-orchestrator.sh` | — |
 
-`helper-path` now resolves to the native Rust `amplihack orch helper` command.
-The fallback paths are retained but
-are no longer shipped.
+`helper-path` is a compatibility alias for callers that still request the
+legacy orchestration-helper asset name. It resolves to the native multitask
+orchestrator wrapper shipped with the bundle.
 
 ### Usage
 
@@ -111,9 +111,9 @@ are no longer shipped.
 amplihack resolve-bundle-asset hooks-dir
 # /home/user/.amplihack/amplifier-bundle/tools/amplihack/hooks
 
-# The orchestrator helper is now a native Rust subcommand:
-amplihack orch helper
-# (No resolve-bundle-asset lookup needed — use directly)
+# Resolve the legacy helper alias
+amplihack resolve-bundle-asset helper-path
+# /home/user/.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
 ```
 
 ### Configuration

--- a/docs/reference/resolve-bundle-asset-command.md
+++ b/docs/reference/resolve-bundle-asset-command.md
@@ -1,4 +1,13 @@
-# amplihack resolve-bundle-asset — Command Reference
+---
+title: resolve-bundle-asset command reference
+description: Resolve amplihack bundle assets and legacy parity aliases from native Rust tools.
+last_updated: 2026-06-05
+review_schedule: as-needed
+owner: amplihack-maintainers
+doc_type: reference
+---
+
+# amplihack resolve-bundle-asset - Command Reference
 
 ## Synopsis
 
@@ -6,32 +15,47 @@
 amplihack resolve-bundle-asset <ASSET>
 ```
 
+The standalone resolver binary accepts the same single argument:
+
+```
+amplihack-asset-resolver <ASSET>
+```
+
 ## Description
 
 Resolves a named bundle asset or a relative path under `amplifier-bundle/` to
 an absolute filesystem path. Prints the resolved path to stdout on success.
 
-This command replaces `amplihack runtime_assets` in recipe shell
-steps, providing the same path-resolution logic without a Python dependency.
+This is the native Rust asset resolver for recipe shell steps, hooks, and
+child tools. It keeps the legacy Python asset names that recipes and helper
+scripts still use, while resolving them to the current Rust/runtime assets.
 
 ## Arguments
 
 | Argument | Required | Description |
-|----------|----------|-------------|
+| -------- | -------- | ----------- |
 | `<ASSET>` | yes | A named asset key (e.g. `multitask-orchestrator`) or a relative path starting with `amplifier-bundle/`. |
 
 ### Named Assets
 
-| Name | Resolves to |
-|------|-------------|
-| `hooks-dir` | `amplifier-bundle/tools/amplihack/hooks/` |
-| `helper-path` | `amplihack orch helper` (native Rust) |
-| `multitask-orchestrator` | `amplifier-bundle/bin/multitask-orchestrator.sh` |
+| Name | Resolves to | Expected type | Purpose |
+| ---- | ----------- | ------------- | ------- |
+| `helper-path` | `amplifier-bundle/bin/multitask-orchestrator.sh` | file | Compatibility alias for legacy orchestration-helper callers. |
+| `session-tree-path` | `amplifier-bundle/tools/amplihack/session` | directory | Compatibility anchor for callers that still request the old session-tree asset name. |
+| `hooks-dir` | `amplifier-bundle/tools/amplihack/hooks` | directory | Compatibility alias for hook configuration assets used by launcher and recipe preflight paths. |
+| `multitask-orchestrator` | `amplifier-bundle/bin/multitask-orchestrator.sh` | file | Native multitask orchestrator wrapper. |
 
-`hooks-dir` and `helper-path` were re-registered in issue #614 to restore
-compatibility with `smart-orchestrator.yaml` preflight steps (lines 58, 74)
-which resolve these assets during recipe startup. `helper-path` tries two
-candidate paths in order and returns the first that exists on disk.
+Named assets are resolved against runtime roots in priority order:
+
+1. `AMPLIHACK_HOME`
+2. `~/.amplihack`
+3. The nearest ancestor of the current directory containing `amplifier-bundle/`
+   or `.claude/`
+4. The compiled workspace/package root
+5. The current working directory
+
+The first existing candidate wins. Missing named assets fail with exit code
+`1`; invalid relative paths fail with exit code `2`.
 
 ### Relative Paths
 
@@ -50,28 +74,74 @@ must:
 amplihack resolve-bundle-asset multitask-orchestrator
 # Output: /home/user/.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
 
-# Resolve the hooks directory (used by smart-orchestrator preflight)
+# Resolve the hooks directory
 amplihack resolve-bundle-asset hooks-dir
 # Output: /home/user/.amplihack/amplifier-bundle/tools/amplihack/hooks
 
-# Resolve the orchestrator helper (now native Rust)
+# Resolve the legacy helper alias to the native orchestrator wrapper
 amplihack resolve-bundle-asset helper-path
-# Output: Use `amplihack orch helper` directly — helper-path is a native Rust subcommand
+# Output: /home/user/.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
+
+# Resolve the legacy session-tree anchor
+amplihack resolve-bundle-asset session-tree-path
+# Output: /home/user/.amplihack/amplifier-bundle/tools/amplihack/session
 
 # Resolve a relative path under amplifier-bundle/
 amplihack resolve-bundle-asset amplifier-bundle/tools/statusline.sh
 # Output: /home/user/.amplihack/amplifier-bundle/tools/statusline.sh
 
+# Resolve through the standalone child-process API
+amplihack-asset-resolver helper-path
+# Output: /home/user/.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
+
 # Attempt to resolve an unknown named asset
 amplihack resolve-bundle-asset nonexistent-thing
-# Stderr: ERROR: Unknown asset name "nonexistent-thing". Expected one of: hooks-dir, helper-path, multitask-orchestrator
+# Stderr: ERROR: Unknown asset name "nonexistent-thing". Expected one of: hooks-dir, helper-path, session-tree-path, multitask-orchestrator
 # Exit: 1
 ```
+
+## Configuration
+
+### `AMPLIHACK_HOME`
+
+Set `AMPLIHACK_HOME` when the bundle is installed somewhere other than
+`~/.amplihack`:
+
+```sh
+AMPLIHACK_HOME=/opt/amplihack amplihack resolve-bundle-asset helper-path
+# Output: /opt/amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
+```
+
+The value must point at the directory that contains `amplifier-bundle/`.
+
+### `AMPLIHACK_ASSET_RESOLVER`
+
+Launchers and recipe runners set `AMPLIHACK_ASSET_RESOLVER` to the absolute
+path of `amplihack-asset-resolver` when the standalone binary is available.
+Child tools can call it without knowing where `amplihack` itself is installed:
+
+```sh
+"$AMPLIHACK_ASSET_RESOLVER" amplifier-bundle/recipes/smart-orchestrator.yaml
+```
+
+See [Environment Variables](./environment-variables.md#amplihack_asset_resolver)
+for resolver discovery order.
+
+## Rust API
+
+The CLI and standalone binary share the same resolver module.
+
+| Function | Purpose |
+| -------- | ------- |
+| `resolve_named_asset(name)` | Resolve one of the named assets above to an existing path. |
+| `resolve_asset(relative_path)` | Resolve a validated `amplifier-bundle/...` relative path. |
+| `validate_relative_path(relative_path)` | Reject traversal, absolute paths, unsafe characters, and paths outside `amplifier-bundle/`. |
+| `run_cli(arg)` | Dispatch one CLI argument and return the process exit code. |
 
 ## Exit Codes
 
 | Code | Meaning |
-|------|---------|
+| ---- | ------- |
 | `0` | Asset resolved — absolute path printed to stdout |
 | `1` | Asset not found — the named key or relative path does not exist on disk, **or** the argument is an unregistered named asset (no `/` and not in the named-asset table) |
 | `2` | Invalid input — the relative path failed validation (null bytes, unsafe characters, path traversal, missing `amplifier-bundle/` prefix) |
@@ -86,7 +156,7 @@ lack the `amplifier-bundle/` prefix.
 
 ```sh
 $ amplihack resolve-bundle-asset unknown-asset
-ERROR: Unknown asset name "unknown-asset". Expected one of: hooks-dir, helper-path, multitask-orchestrator
+ERROR: Unknown asset name "unknown-asset". Expected one of: hooks-dir, helper-path, session-tree-path, multitask-orchestrator
 $ echo $?
 1
 ```
@@ -103,6 +173,7 @@ This distinction matters for recipes that use `|| true` guards: exit 1
 
 ## Related
 
+- [Verify Runtime Asset Resolution](../howto/verify-runtime-asset-resolution.md) — Confirm helper, session, hooks, and orchestrator assets resolve in an install
 - [Install Completeness Verification](./install-completeness.md) — What must be staged and verified during install
 - [Install Manifest](./install-manifest.md) — What gets installed to `~/.amplihack/.claude`
 - [recipe Command](./recipe-command.md) — Recipes that use `resolve-bundle-asset` in shell steps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - PATH Conflict Tutorial: tutorials/repair-install-update-path-conflicts.md
       - Local Install: howto/local-install.md
       - Repair PATH Conflicts: howto/repair-install-update-path-conflicts.md
+      - Runtime Asset Resolution: howto/verify-runtime-asset-resolution.md
       - Uninstall: howto/uninstall.md
   - Core Concepts:
       - Philosophy: claude/context/PHILOSOPHY.md


### PR DESCRIPTION
## Summary
- align the legacy runtime_assets helper map with resolve-bundle-asset for helper-path, session-tree-path, hooks-dir, and multitask-orchestrator
- update standalone resolver usage text and resolver docs to reflect the four parity assets
- add issue #634 regression coverage for isolated AMPLIHACK_HOME resolution and legacy runtime_assets parity

## Evidence
- PR #641 is merged and latest release is v0.9.80
- current installed runtime resolves all four parity assets to existing paths
- stale standalone usage text was fixed as documentation/source polish

## Tests
- cargo fmt --check
- cargo test -p amplihack-cli --test issue_634_asset_resolution_parity -- --nocapture
- cargo test -p amplihack-cli runtime_assets -- --nocapture
- cargo test -p amplihack-asset-resolver-bin -- --nocapture
- pre-commit: cargo clippy -- -D warnings

Closes #634