### PR TITLE
docs: document recipe runner hook contracts

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -31,6 +31,7 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 - [Existing Branch Finalization Runbook](post-v0977-finalization.md) — inspect,
   preserve, validate, publish, and merge an already-implemented branch; includes
   the post-v0.9.77 issue-658 branch as the concrete example.
+- [Recipe Subprocess and Hook Input Contracts](../howto/validate-recipe-subprocess-hook-contract.md) — recipe-runner child environment and hook input compatibility contract; see the [recipe environment reference](../reference/recipe-executor-environment.md#recipe-runner-subprocess-launch) and [hook input contract](../reference/hook-specifications.md#hook-input-json-contract).
 
 ## GitHub Distribution
 

--- a/docs/howto/validate-recipe-subprocess-hook-contract.md
+++ b/docs/howto/validate-recipe-subprocess-hook-contract.md
@@ -1,0 +1,152 @@
+---
+title: "Validate Recipe Subprocess and Hook Input Contracts"
+description: "Check that recipe execution runs non-interactively, strips Claude-only session state, and accepts supported hook JSON aliases."
+last_updated: 2026-06-05
+review_schedule: as-needed
+owner: amplihack
+doc_type: howto
+---
+
+# Validate Recipe Subprocess and Hook Input Contracts
+
+Use this guide when changing `amplihack recipe run`, `EnvBuilder`, hook wrappers,
+or `HookInput` deserialization. It validates the implemented subprocess and hook
+input contract.
+
+## Prerequisites
+
+- `amplihack` and `amplihack-hooks` are on `PATH`
+- You are in an `amplihack-rs` checkout
+- Rust toolchain is installed
+
+## 1. Check recipe subprocess behavior with a stub runner
+
+Use `RECIPE_RUNNER_RS_PATH` to replace `recipe-runner-rs` with a temporary stub
+that prints the child environment observed by the actual `amplihack recipe run`
+subprocess launch:
+
+```bash
+tmpdir="$(mktemp -d)"
+cat >"$tmpdir/recipe-runner-rs" <<'SH'
+#!/usr/bin/env sh
+printf '%s\n' "{
+  \"recipe_name\":\"env-probe\",
+  \"success\":true,
+  \"env_probe\":{
+    \"AMPLIHACK_NONINTERACTIVE\":\"${AMPLIHACK_NONINTERACTIVE:-}\",
+    \"CLAUDECODE_PRESENT\":\"${CLAUDECODE+x}\",
+    \"AMPLIHACK_AGENT_BINARY\":\"${AMPLIHACK_AGENT_BINARY:-}\"
+  }
+}"
+SH
+chmod +x "$tmpdir/recipe-runner-rs"
+
+env -u AMPLIHACK_NONINTERACTIVE \
+  CLAUDECODE=1 \
+  RECIPE_RUNNER_RS_PATH="$tmpdir/recipe-runner-rs" \
+  amplihack recipe run default-workflow \
+  -c task_description="Inspect repository documentation" \
+  -c repo_path=. \
+  --format json
+```
+
+The JSON output includes `env_probe`. The child process contract is:
+
+| Variable | Expected child state |
+|----------|----------------------|
+| `AMPLIHACK_NONINTERACTIVE` | `1` |
+| `CLAUDECODE_PRESENT` | empty string |
+| `AMPLIHACK_AGENT_BINARY` | active launcher binary, when set by the launcher |
+
+If a recipe or nested agent prompts for input, treat that as a subprocess
+environment bug.
+
+## 2. Check canonical hook input
+
+Send canonical snake_case hook input:
+
+```bash
+printf '%s\n' '{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {"command": "pwd"}
+}' | amplihack-hooks pre-tool-use
+```
+
+The hook accepts the payload. Depending on policy, the output is either `{}` or
+a permission decision such as:
+
+```json
+{
+  "permissionDecision": "allow"
+}
+```
+
+## 3. Check camelCase hook input
+
+Send the same payload using supported host aliases:
+
+```bash
+printf '%s\n' '{
+  "hookEventName": "PreToolUse",
+  "toolName": "Bash",
+  "toolInput": {"command": "pwd"},
+  "sessionId": "example-session"
+}' | amplihack-hooks pre-tool-use
+```
+
+The hook accepts the payload exactly as it accepts the canonical form.
+
+## 4. Check optional-field tolerance
+
+Stop hooks can omit optional fields:
+
+```bash
+printf '%s\n' '{
+  "hook_event_name": "Stop"
+}' | amplihack-hooks stop
+```
+
+The hook deserializes the payload with absent optional fields instead of failing
+at the JSON boundary.
+
+## 5. Check required-field strictness
+
+Tool events still require `tool_name` and `tool_input`:
+
+```bash
+printf '%s\n' '{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash"
+}' | amplihack-hooks pre-tool-use
+```
+
+This payload is invalid because `tool_input` is missing. The hook runtime must
+not convert incomplete known tool events into `Unknown`. Depending on the hook
+failure policy, the executable may return an error response or fail-open output,
+but the deserialization path must record the payload as invalid rather than
+future-compatible.
+
+## Developer validation
+
+Run the focused Rust tests for the two contracts by name:
+
+```bash
+cargo test -p amplihack-cli recipe_runner_child_environment
+cargo test -p amplihack-types hook_input_accepts_camel_case_aliases
+cargo test -p amplihack-types hook_input_rejects_missing_required_tool_fields
+cargo test -p amplihack-hooks malformed_known_tool_event_is_not_unknown
+```
+
+These tests cover the centralized subprocess environment and the typed
+`HookInput` JSON boundary. The CLI stub check above verifies the subprocess
+contract end to end.
+
+## Related
+
+- [Recipe Executor Environment](../reference/recipe-executor-environment.md) —
+  full subprocess and step environment reference
+- [Hook Specifications Reference](../reference/hook-specifications.md) — hook
+  events, commands, and JSON input contract
+- [Run amplihack in Non-interactive Mode](run-in-noninteractive-mode.md) —
+  top-level non-interactive usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -250,6 +250,8 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [Recipe Runner Overview](recipes/README.md) - Architecture, YAML format, and creating custom recipes
 - [UltraThink Recipe Runner Integration](recipes/RECIPE_RUNNER_ULTRATHINK_INTEGRATION.md) - How ultrathink uses Recipe Runner for code-enforced workflow execution
 - [Recipe CLI Commands How-To](howto/recipe-cli-commands.md) - Task-oriented guide for using recipe commands
+- [Recipe Executor Environment](reference/recipe-executor-environment.md) - Step-level variables plus subprocess environment contract for forced non-interactive recipe execution
+- [Validate Recipe Subprocess and Hook Input Contracts](howto/validate-recipe-subprocess-hook-contract.md) - Validate recipe child env handling and hook JSON compatibility
 - [Workflow Publish Import Validation](features/workflow-publish-import-validation.md) - Scoped publish import validation before commit/push
 - [How to Configure Workflow Publish Import Validation](howto/configure-workflow-publish-import-validation.md) - Review the manifest, root-boundary, and scoped-validator behavior
 - [Tutorial: Workflow Publish Import Validation](tutorials/workflow-publish-import-validation.md) - Walk through the scoped publish-validation flow

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -19,6 +19,8 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [NODE_OPTIONS](#node_options)
 - [Variables injected by recipe executor](#variables-injected-by-recipe-executor)
   - [AMPLIHACK_STEP_TIMEOUT](#amplihack_step_timeout)
+  - [AMPLIHACK_NONINTERACTIVE (recipe runner subprocess)](#amplihack_noninteractive-recipe-runner-subprocess)
+  - [CLAUDECODE (recipe runner subprocess)](#claudecode-recipe-runner-subprocess)
   - [AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS](#amplihack_recipe_heartbeat_interval_seconds)
   - [AMPLIHACK_RECIPE_SNIPPET_LINES](#amplihack_recipe_snippet_lines)
   - [AMPLIHACK_RECIPE_SNIPPET_BYTES](#amplihack_recipe_snippet_bytes)
@@ -335,11 +337,11 @@ When startup does not supply an explicit value, `EnvBuilder` still falls back to
 
 ## Variables injected by recipe executor
 
-These variables are read or set by the recipe executor (`amplihack recipe run`)
-while running recipe steps. Non-interactive shell-step variables are always set.
-Heartbeat, snippet, and JSONL log variables are optional user configuration. See
-[Recipe Executor Environment](./recipe-executor-environment.md) and
-[Recipe Runner Logging](./recipe-runner-logging.md) for full details.
+These variables are read, set, or removed by the recipe execution path
+(`amplihack recipe run`) while launching `recipe-runner-rs` and running recipe
+steps. Heartbeat, snippet, and JSONL log variables are optional user
+configuration. See [Recipe Executor Environment](./recipe-executor-environment.md)
+and [Recipe Runner Logging](./recipe-runner-logging.md) for full details.
 
 ---
 
@@ -370,6 +372,56 @@ amplihack recipe run recipe.yaml
 **Why it exists:** The default-workflow recipes no longer define `timeout_seconds` on agent steps, so agent steps run to completion without artificial time limits. This variable provides an opt-in escape hatch for CI environments that need wall-clock budgets. The env var approach is forward-compatible — `recipe-runner-rs` can adopt it independently without CLI changes.
 
 **Security note:** The value is always a `u64` rendered as a string. No shell metacharacters are possible. The CLI rejects non-numeric input at parse time via clap's type enforcement.
+
+---
+
+### AMPLIHACK_NONINTERACTIVE (recipe runner subprocess)
+
+**Type:** flag
+**Value:** `1`
+**Set by:** `amplihack recipe run` centralized subprocess environment
+
+The recipe runner launch writes `AMPLIHACK_NONINTERACTIVE=1` into the
+`recipe-runner-rs` child environment. This is stronger than top-level launcher
+propagation: the value is forced for recipe execution even when the parent
+process is interactive and the parent environment does not contain
+`AMPLIHACK_NONINTERACTIVE`.
+
+This prevents nested recipe, hook, and agent subprocesses from asking for input
+or showing interactive update prompts while an automated workflow is already in
+progress.
+
+```sh
+# The recipe-runner child receives AMPLIHACK_NONINTERACTIVE=1.
+env -u AMPLIHACK_NONINTERACTIVE \
+  amplihack recipe run default-workflow \
+  -c task_description="Update generated docs" \
+  -c repo_path=.
+```
+
+---
+
+### CLAUDECODE (recipe runner subprocess)
+
+**Type:** removed environment variable
+**Removed by:** `amplihack recipe run` centralized subprocess environment
+
+The recipe runner launch explicitly removes `CLAUDECODE` from the
+`recipe-runner-rs` child environment. The variable is Claude-Code-specific
+session state, not a portable amplihack routing signal. Leaving it set in a
+nested recipe can make downstream agents believe they are running inside the
+original Claude Code host even when the active launcher is Copilot, Codex, or
+Amplifier.
+
+Use `AMPLIHACK_AGENT_BINARY` for runtime routing. It is validated, propagated,
+and documented as the active agent selector.
+
+```sh
+# The parent value is ignored for the recipe-runner child.
+CLAUDECODE=1 amplihack recipe run smart-orchestrator \
+  -c task_description="Review the open PR" \
+  -c repo_path=.
+```
 
 ---
 

--- a/docs/reference/hook-specifications.md
+++ b/docs/reference/hook-specifications.md
@@ -74,6 +74,100 @@ Each hook is written as a wrapper object under the event key:
 - The two `UserPromptSubmit` entries must appear in order: `workflow-classification-reminder` first, then `user-prompt-submit`. The installer preserves this order on both fresh install and idempotent update.
 - Hook commands are written with the **absolute path** to `amplihack-hooks` resolved at install time. If the binary moves, re-run `amplihack install` to update the paths.
 
+## Hook Input JSON Contract
+
+Hook binaries read one JSON object from stdin and deserialize it into the shared
+`HookInput` type. The compatibility contract is host-agnostic: Claude Code,
+Copilot wrappers, Amplifier, and tests can send the same semantic payload.
+
+The contract has two layers:
+
+- **Typed input boundary:** known events deserialize with their required fields;
+  malformed known-event payloads are invalid.
+- **Hook executable boundary:** hooks keep their existing fail-open policy for
+  processing errors and panics, but do not convert malformed known-event JSON
+  into `Unknown`. `Unknown` is reserved for valid payloads whose event name is
+  not recognized yet.
+
+### Event discriminator
+
+The canonical discriminator is `hook_event_name`. The deserializer also accepts
+the known camelCase alias `hookEventName`.
+
+```json
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "pwd"
+  }
+}
+```
+
+Equivalent camelCase input:
+
+```json
+{
+  "hookEventName": "PreToolUse",
+  "toolName": "Bash",
+  "toolInput": {
+    "command": "pwd"
+  }
+}
+```
+
+### Field aliases
+
+| Canonical field | Accepted alias | Used by |
+|-----------------|----------------|---------|
+| `hook_event_name` | `hookEventName` | All hook events |
+| `tool_name` | `toolName` | `PreToolUse`, `PostToolUse` |
+| `tool_input` | `toolInput` | `PreToolUse`, `PostToolUse` |
+| `tool_result` | `toolResult` | `PostToolUse` |
+| `session_id` | `sessionId` | All events with session context |
+| `stop_hook_active` | `stopHookActive` | `Stop` |
+| `transcript_path` | `transcriptPath` | `Stop`, `SessionStop`, `PreCompact` |
+| `user_prompt` | `userPrompt` | `UserPromptSubmit` |
+
+Unknown additional fields are ignored unless a variant explicitly captures them
+as extra event data.
+
+### Required and optional fields
+
+Missing optional fields deserialize to `None` / absent values. Required semantic
+fields remain strict at both the typed boundary and the hook executable entry.
+
+| Event | Required fields | Optional fields |
+|-------|-----------------|-----------------|
+| `PreToolUse` | `tool_name`, `tool_input` | `session_id` |
+| `PostToolUse` | `tool_name`, `tool_input` | `tool_result`, `session_id` |
+| `Stop` | none beyond event name | `stop_hook_active`, `transcript_path`, `session_id` |
+| `SessionStart` | none beyond event name | `session_id`, `cwd`, extra fields |
+| `SessionStop` | none beyond event name | `session_id`, `transcript_path`, extra fields |
+| `UserPromptSubmit` | none beyond event name | `user_prompt`, `session_id`, extra fields |
+| `PreCompact` | none beyond event name | `session_id`, `transcript_path`, extra fields |
+
+Malformed JSON, a missing event discriminator, or a missing required field for a
+tool event is invalid input. The compatibility layer is intentionally narrow: it
+accepts known host schema drift without treating incomplete tool payloads as
+valid or silently mapping them to `Unknown`.
+
+### Unknown events
+
+Future hook events with a valid event discriminator deserialize to `Unknown`
+instead of failing. This makes the hook boundary forward-compatible while
+keeping known event payloads typed and strict. Malformed known events are not
+future events and must not use this path.
+
+```json
+{
+  "hook_event_name": "FutureEvent",
+  "payload": {
+    "anything": true
+  }
+}
+```
+
 ## Hook Descriptions
 
 ### 1. SessionStart — `session-start`

--- a/docs/reference/recipe-executor-environment.md
+++ b/docs/reference/recipe-executor-environment.md
@@ -4,10 +4,47 @@ Complete reference for the environment variables, prerequisite checks, and conte
 
 ## Contents
 
+- [Recipe runner subprocess launch](#recipe-runner-subprocess-launch)
 - [Shell step environment injection](#shell-step-environment-injection)
 - [Agent step context augmentation](#agent-step-context-augmentation)
 - [Prerequisite validation](#prerequisite-validation)
 - [Interaction with AMPLIHACK_NONINTERACTIVE](#interaction-with-amplihack_noninteractive)
+
+---
+
+## Recipe runner subprocess launch
+
+`amplihack recipe run` launches `recipe-runner-rs` through the centralized
+Rust subprocess environment builder. The child process is prepared for
+non-interactive nested execution before the runner receives any recipe context.
+
+| Variable | Child value | Behavior |
+|----------|-------------|----------|
+| `AMPLIHACK_NONINTERACTIVE` | `1` | Always forced for the recipe-runner subprocess, even when the parent shell is interactive |
+| `CLAUDECODE` | *(removed)* | Explicitly unset so nested agents do not detect a parent Claude Code session |
+| `AMPLIHACK_AGENT_BINARY` | Active launcher binary | Propagates the current runtime selection, such as `copilot`, `claude`, `codex`, or `amplifier` |
+| `AMPLIHACK_HOME` | Resolved framework home | Gives the runner access to installed recipes, hooks, skills, and agents |
+| `AMPLIHACK_ASSET_RESOLVER` | Resolved native resolver path, when available | Lets nested tools resolve bundled assets without hardcoded paths |
+| `AMPLIHACK_GRAPH_DB_PATH` | Project-local graph DB path | Keeps launched hooks and memory/code-graph features on the same project store |
+| `PAGER` / pager-related defaults | Pager-safe values | Prevents child commands from blocking on interactive pagers |
+
+This contract applies to the runner subprocess itself. Shell and agent steps
+inside the recipe receive the additional step-level variables described below.
+
+### Example
+
+```bash
+# Parent has Claude Code session state and no explicit non-interactive flag.
+CLAUDECODE=1 env -u AMPLIHACK_NONINTERACTIVE \
+  amplihack recipe run default-workflow \
+  -c task_description="Summarize the current repository" \
+  -c repo_path=.
+```
+
+The `recipe-runner-rs` child sees `AMPLIHACK_NONINTERACTIVE=1` and does not see
+`CLAUDECODE`. Nested agent launches therefore use the active agent routing
+contract instead of inheriting Claude-specific session behavior from the parent
+environment.
 
 ---
 
@@ -87,10 +124,13 @@ The recipe executor's environment injection is independent of the top-level `AMP
 | Scope | Variable | Set by |
 |-------|----------|--------|
 | Top-level CLI launch | `AMPLIHACK_NONINTERACTIVE=1` | User or CI configuration |
+| Recipe runner subprocess | `AMPLIHACK_NONINTERACTIVE=1` | `amplihack recipe run` centralized subprocess environment |
 | Recipe shell steps | `CI=true`, `NONINTERACTIVE=1`, `DEBIAN_FRONTEND=noninteractive` | Recipe executor (always) |
 | Recipe agent steps | `NONINTERACTIVE=1` in context map | Recipe executor (always) |
 
-The recipe executor always sets non-interactive flags for its child processes, even when the top-level CLI is running interactively. This is by design: recipe steps are automated and should never prompt for input.
+The runner subprocess contract aligns the top-level recipe launch with the
+existing step-level non-interactive behavior. Recipe execution is automated and
+must never prompt for input.
 
 ---
 


### PR DESCRIPTION
## Summary
- document the recipe-runner subprocess environment contract added by PR #694
- document hook input aliases and strict malformed known-event handling
- add a validation how-to for the subprocess and hook contracts

## Validation
- git diff --check
