### PR TITLE
Implement prompt delivery across launch paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ version = "0.9.70"
 dependencies = [
  "amplihack-builders",
  "amplihack-hive",
+ "amplihack-launcher",
  "amplihack-memory",
  "amplihack-reflection",
  "amplihack-remote",
@@ -280,6 +281,7 @@ dependencies = [
 name = "amplihack-launcher"
 version = "0.9.70"
 dependencies = [
+ "amplihack-utils",
  "anyhow",
  "chrono",
  "libc",

--- a/crates/amplihack-cli/Cargo.toml
+++ b/crates/amplihack-cli/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 amplihack-hive = { path = "../amplihack-hive" }
+amplihack-launcher = { workspace = true }
 amplihack-types = { workspace = true }
 amplihack-state = { workspace = true }
 amplihack-utils = { workspace = true }

--- a/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
@@ -1,4 +1,8 @@
 use super::*;
+use amplihack_launcher::flag_matrix::{AgentBinary, prompt_delivery_caps_for};
+use amplihack_launcher::prompt_delivery::{DeliveredCommand, build_command_with_prompt_delivery};
+use amplihack_utils::prompt_delivery::PromptDelivery;
+use std::ffi::OsString;
 
 pub(super) fn philosophy_context() -> &'static str {
     "AUTONOMOUS MODE: You are in auto mode. Do NOT ask questions. Make decisions using:\n1. Explicit user requirements (highest priority)\n2. @.claude/context/USER_PREFERENCES.md guidance\n3. @.claude/context/PHILOSOPHY.md principles\n4. @.claude/workflow/DEFAULT_WORKFLOW.md patterns\n5. @.claude/context/USER_REQUIREMENT_PRIORITY.md for conflicts\n\nDecision Authority:\n- YOU DECIDE implementation details and architecture\n- YOU PRESERVE explicit user requirements and hard constraints\n- WHEN AMBIGUOUS choose the simplest modular option"
@@ -56,6 +60,7 @@ pub(super) fn extract_prompt_args(args: &[String]) -> Option<ParsedPromptArgs> {
     })
 }
 
+#[cfg(test)]
 pub(super) fn build_auto_command(
     tool: AutoModeTool,
     execution_dir: &Path,
@@ -64,33 +69,72 @@ pub(super) fn build_auto_command(
     passthrough_args: &[String],
     prompt: &str,
 ) -> Result<Command> {
+    Ok(
+        build_auto_command_with_prompt_delivery(AutoModePromptDeliveryOptions {
+            tool,
+            execution_dir: execution_dir.to_path_buf(),
+            project_dir: project_dir.to_path_buf(),
+            node_options: node_options.map(str::to_string),
+            passthrough_args: passthrough_args.to_vec(),
+            prompt: prompt.to_string(),
+            requested_delivery: amplihack_utils::prompt_delivery::from_env(),
+        })?
+        .command,
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct AutoModePromptDeliveryOptions {
+    pub tool: AutoModeTool,
+    pub execution_dir: PathBuf,
+    pub project_dir: PathBuf,
+    pub node_options: Option<String>,
+    pub passthrough_args: Vec<String>,
+    pub prompt: String,
+    pub requested_delivery: PromptDelivery,
+}
+
+pub fn build_auto_command_with_prompt_delivery(
+    options: AutoModePromptDeliveryOptions,
+) -> Result<DeliveredCommand> {
     let current_exe = env::current_exe().context("failed to resolve current executable")?;
-    let mut command = Command::new(current_exe);
-    command.current_dir(execution_dir);
+    let mut args = vec![
+        OsString::from(options.tool.subcommand()),
+        OsString::from("--no-reflection"),
+        OsString::from("--subprocess-safe"),
+        OsString::from("--"),
+    ];
+    args.extend(build_tool_passthrough_prefix_args(
+        options.tool,
+        &options.passthrough_args,
+    ));
+    let mut delivered = build_command_with_prompt_delivery(
+        current_exe.as_os_str(),
+        args.iter(),
+        &options.prompt,
+        options.requested_delivery,
+        prompt_delivery_caps_for(agent_binary_for_tool(options.tool)),
+    )?;
+    delivered.command.current_dir(&options.execution_dir);
     let env_builder = EnvBuilder::new()
         .with_amplihack_session_id()
         .with_incremented_session_tree_context()
-        .with_amplihack_vars_with_node_options(node_options)
-        .with_agent_binary(tool.slug())
+        .with_amplihack_vars_with_node_options(options.node_options.as_deref())
+        .with_agent_binary(options.tool.slug())
         .with_amplihack_home()
         .with_asset_resolver()
-        .with_project_graph_db(project_dir)?;
-    let env_builder = if execution_dir != project_dir {
+        .with_project_graph_db(&options.project_dir)?;
+    let env_builder = if options.execution_dir != options.project_dir {
         env_builder.set("AMPLIHACK_IS_STAGED", "1").set(
             "AMPLIHACK_ORIGINAL_CWD",
-            project_dir.to_string_lossy().into_owned(),
+            options.project_dir.to_string_lossy().into_owned(),
         )
     } else {
         env_builder
     };
     let env_builder = env_builder.set("AMPLIHACK_AUTO_MODE", "1");
-    env_builder.apply_to_command(&mut command);
-    command.arg(tool.subcommand());
-    command.arg("--no-reflection");
-    command.arg("--subprocess-safe");
-    command.arg("--");
-    command.args(build_tool_passthrough_args(tool, passthrough_args, prompt));
-    Ok(command)
+    env_builder.apply_to_command(&mut delivered.command);
+    Ok(delivered)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -191,6 +235,7 @@ fn extract_leading_slash_commands(prompt: &str) -> (String, String) {
     (commands.join(" "), trimmed[index..].trim().to_string())
 }
 
+#[cfg(test)]
 pub(super) fn build_tool_passthrough_args(
     tool: AutoModeTool,
     passthrough_args: &[String],
@@ -247,6 +292,62 @@ pub(super) fn build_tool_passthrough_args(
         }
     }
     args
+}
+
+fn build_tool_passthrough_prefix_args(
+    tool: AutoModeTool,
+    passthrough_args: &[String],
+) -> Vec<OsString> {
+    let mut args = passthrough_args.to_vec();
+    match tool {
+        AutoModeTool::Claude | AutoModeTool::RustyClawd => {
+            if !args
+                .iter()
+                .any(|arg| arg == "--dangerously-skip-permissions")
+            {
+                args.push("--dangerously-skip-permissions".to_string());
+            }
+            if !args.iter().any(|arg| arg == "--verbose") {
+                args.push("--verbose".to_string());
+            }
+            args.push("-p".to_string());
+        }
+        AutoModeTool::Copilot => {
+            args = strip_claude_only_flags(args);
+            let has_allow_all = args.iter().any(|a| a == "--allow-all");
+            let has_allow_all_tools = args.iter().any(|a| a == "--allow-all-tools");
+            if !has_allow_all && !has_allow_all_tools {
+                args.push("--allow-all".to_string());
+            }
+            if !args.iter().any(|arg| arg == "--add-dir") {
+                args.push("--add-dir".to_string());
+                args.push("/".to_string());
+            }
+            args.push("-p".to_string());
+        }
+        AutoModeTool::Codex => {
+            if !args
+                .iter()
+                .any(|arg| arg == "--dangerously-bypass-approvals-and-sandbox")
+            {
+                args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
+            }
+            args.push("exec".to_string());
+        }
+        AutoModeTool::Amplifier => {
+            args.push("-p".to_string());
+        }
+    }
+    args.into_iter().map(OsString::from).collect()
+}
+
+fn agent_binary_for_tool(tool: AutoModeTool) -> AgentBinary {
+    match tool {
+        AutoModeTool::Claude | AutoModeTool::RustyClawd => AgentBinary::Claude,
+        AutoModeTool::Copilot => AgentBinary::Copilot,
+        AutoModeTool::Codex => AgentBinary::Codex,
+        AutoModeTool::Amplifier => AgentBinary::Amplifier,
+    }
 }
 
 /// Strip Claude-only flags that Copilot CLI does not accept.

--- a/crates/amplihack-cli/src/commands/auto_mode/mod.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/mod.rs
@@ -11,7 +11,7 @@ use crate::env_builder::EnvBuilder;
 use crate::memory_config::prepare_memory_config;
 use crate::nesting::NestingDetector;
 use crate::session_tracker::SessionTracker;
-use crate::util::run_output_with_timeout;
+use amplihack_launcher::prompt_delivery::DeliveredCommand;
 use anyhow::{Context, Result, bail};
 use chrono::Local;
 use std::env;
@@ -22,6 +22,7 @@ use std::process::Command;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
+    mpsc,
 };
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -29,6 +30,7 @@ mod helpers;
 mod run;
 mod session;
 
+pub use helpers::{AutoModePromptDeliveryOptions, build_auto_command_with_prompt_delivery};
 pub use run::run_auto_mode;
 
 const QUERY_TIMEOUT: Duration = Duration::from_secs(30 * 60);
@@ -103,13 +105,16 @@ impl PromptExecutor for SystemPromptExecutor {
         passthrough_args: &[String],
         prompt: &str,
     ) -> Result<ExecutionResult> {
-        let command = helpers::build_auto_command(
-            tool,
-            execution_dir,
-            project_dir,
-            self.node_options.as_deref(),
-            passthrough_args,
-            prompt,
+        let delivered = helpers::build_auto_command_with_prompt_delivery(
+            helpers::AutoModePromptDeliveryOptions {
+                tool,
+                execution_dir: execution_dir.to_path_buf(),
+                project_dir: project_dir.to_path_buf(),
+                node_options: self.node_options.clone(),
+                passthrough_args: passthrough_args.to_vec(),
+                prompt: prompt.to_string(),
+                requested_delivery: amplihack_utils::prompt_delivery::from_env(),
+            },
         )
         .with_context(|| {
             format!(
@@ -117,7 +122,7 @@ impl PromptExecutor for SystemPromptExecutor {
                 tool.subcommand()
             )
         })?;
-        let output = run_output_with_timeout(command, QUERY_TIMEOUT)?;
+        let output = run_delivered_output_with_timeout(delivered, QUERY_TIMEOUT)?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -139,6 +144,56 @@ impl PromptExecutor for SystemPromptExecutor {
             stdout,
             stderr,
         })
+    }
+}
+
+fn run_delivered_output_with_timeout(
+    delivered: DeliveredCommand,
+    timeout: Duration,
+) -> Result<std::process::Output> {
+    let DeliveredCommand {
+        mut command,
+        delivery_handle,
+        stdin_payload,
+        ..
+    } = delivered;
+    command.stdout(std::process::Stdio::piped());
+    command.stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().context("failed to spawn subprocess")?;
+    let pid = child.id();
+    if let Some(payload) = stdin_payload
+        && let Some(mut stdin) = child.stdin.take()
+    {
+        stdin
+            .write_all(&payload)
+            .context("failed to write prompt to child stdin")?;
+        stdin.flush().context("failed to flush child stdin")?;
+    }
+    let (tx, rx) = mpsc::channel::<std::io::Result<std::process::Output>>();
+    std::thread::spawn(move || {
+        let result = child.wait_with_output();
+        drop(delivery_handle);
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result.context("failed to wait for subprocess output"),
+        Err(_elapsed) => {
+            #[cfg(unix)]
+            {
+                let kill_result = Command::new("kill")
+                    .args(["-TERM", &pid.to_string()])
+                    .status();
+                if let Err(e) = kill_result {
+                    tracing::warn!(pid, error = %e, "failed to terminate timed-out subprocess");
+                }
+            }
+            bail!(
+                "subprocess timed out after {} seconds (pid {})",
+                timeout.as_secs(),
+                pid
+            )
+        }
     }
 }
 

--- a/crates/amplihack-cli/src/commands/doctor/mod.rs
+++ b/crates/amplihack-cli/src/commands/doctor/mod.rs
@@ -21,6 +21,10 @@
 
 mod checks;
 
+use amplihack_launcher::flag_matrix::{
+    delivery_mode_name, prompt_delivery_name, prompt_delivery_report_for,
+};
+use amplihack_utils::prompt_delivery::{AUTO_TEMPFILE_THRESHOLD_BYTES, PromptDelivery, from_env};
 use anyhow::{Result, bail};
 use std::path::PathBuf;
 
@@ -107,23 +111,74 @@ pub fn print_summary(results: &[(bool, String)]) -> (usize, usize) {
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
+pub struct PromptDeliveryDoctorOptions {
+    pub requested: PromptDelivery,
+    pub diagnostic_prompt_size: usize,
+}
+
+pub fn render_prompt_delivery_diagnostics(options: PromptDeliveryDoctorOptions) -> String {
+    let report = prompt_delivery_report_for(options.requested, options.diagnostic_prompt_size);
+    let mut output = String::new();
+    output.push_str("Prompt delivery\n");
+    output.push_str(&format!(
+        "  requested: {}\n",
+        prompt_delivery_name(report.requested)
+    ));
+    output.push_str(&format!(
+        "  auto threshold: {} bytes\n",
+        AUTO_TEMPFILE_THRESHOLD_BYTES
+    ));
+    output.push('\n');
+    for entry in report.entries {
+        output.push_str(&format!("  {}\n", entry.binary));
+        output.push_str(&format!(
+            "    capabilities: {}\n",
+            capabilities_label(&entry.caps)
+        ));
+        if !entry.note.is_empty() {
+            output.push_str(&format!("    note: {}\n", entry.note));
+        }
+        output.push_str(&format!(
+            "    effective for long prompt: {}\n",
+            delivery_mode_name(entry.effective_mode)
+        ));
+        if !entry.warning.is_empty() {
+            output.push_str(&format!("    warning: {}\n", entry.warning));
+        }
+        output.push('\n');
+    }
+    output
+}
+
+fn capabilities_label(caps: &amplihack_utils::prompt_delivery::DeliveryCaps) -> String {
+    let mut labels = Vec::new();
+    if caps.supports_argv {
+        labels.push("argv");
+    }
+    if caps.supports_tempfile {
+        labels.push("tempfile");
+    }
+    if caps.supports_stdin {
+        labels.push("stdin");
+    }
+    if labels.is_empty() {
+        "none".to_string()
+    } else {
+        labels.join(", ")
+    }
+}
+
+pub fn render_doctor_help() -> String {
+    "Run system health checks\n\n\
+Usage:\n  amplihack doctor\n  amplihack doctor node [--ensure]\n  amplihack doctor copilot [--ensure-node]\n\n\
+Commands:\n  node       Diagnose Node.js >=24.0.0 for Copilot CLI\n  copilot    Diagnose Copilot CLI prerequisites\n\n\
+Options:\n  --ensure        Print remediation and use safe auto-remediation only when available\n  --ensure-node   Run the Node.js ensure flow before Copilot checks\n\n\
+Prompt delivery:\n  AMPLIHACK_PROMPT_DELIVERY=auto|argv|tempfile|stdin selects the requested subprocess prompt delivery mode.\n"
+        .to_string()
+}
+
 fn print_help() {
-    println!("Run system health checks");
-    println!();
-    println!("Usage:");
-    println!("  amplihack doctor");
-    println!("  amplihack doctor node [--ensure]");
-    println!("  amplihack doctor copilot [--ensure-node]");
-    println!();
-    println!("Commands:");
-    println!("  node       Diagnose Node.js >=24.0.0 for Copilot CLI");
-    println!("  copilot    Diagnose Copilot CLI prerequisites");
-    println!();
-    println!("Options:");
-    println!(
-        "  --ensure        Print remediation and use safe auto-remediation only when available"
-    );
-    println!("  --ensure-node   Run the Node.js ensure flow before Copilot checks");
+    print!("{}", render_doctor_help());
 }
 
 /// Run doctor checks, print the summary, and exit 1 if any check failed.
@@ -162,6 +217,10 @@ fn run_all_checks() -> Result<()> {
     let r1 = check_hooks_installed();
     let r2 = check_settings_valid_json();
     let r5 = check_amplihack_version();
+    let prompt_delivery = render_prompt_delivery_diagnostics(PromptDeliveryDoctorOptions {
+        requested: from_env(),
+        diagnostic_prompt_size: 64 * 1024,
+    });
 
     // Collect results in canonical display order (1–5), waiting for threads.
     let results = vec![
@@ -176,6 +235,7 @@ fn run_all_checks() -> Result<()> {
         h4.join()
             .unwrap_or_else(|_| (false, "tmux: internal thread panicked".to_string())),
         r5,
+        (true, prompt_delivery),
     ];
 
     let (_, failed) = print_summary(&results);

--- a/crates/amplihack-cli/tests/auto_mode_prompt_delivery.rs
+++ b/crates/amplihack-cli/tests/auto_mode_prompt_delivery.rs
@@ -1,0 +1,85 @@
+//! Red-phase auto-mode prompt-delivery tests.
+//!
+//! Auto mode must stop inserting large prompts directly into child argv through
+//! duplicate prompt construction. It should use the same launcher
+//! prompt-delivery abstraction as normal launch paths.
+
+use amplihack_cli::commands::auto_mode::{
+    AutoModePromptDeliveryOptions, AutoModeTool, build_auto_command_with_prompt_delivery,
+};
+use amplihack_utils::prompt_delivery::{DeliveryMode, PromptDelivery};
+
+const PAYLOAD_SIZE: usize = 64 * 1024;
+
+fn synthetic_prompt() -> String {
+    let pattern = "auto-mode issue 652: don't truncate 'quotes' or $(shell)\n";
+    let mut prompt = String::with_capacity(PAYLOAD_SIZE);
+    while prompt.len() < PAYLOAD_SIZE {
+        prompt.push_str(pattern);
+    }
+    prompt.truncate(PAYLOAD_SIZE);
+    prompt
+}
+
+fn argv(command: &std::process::Command) -> Vec<String> {
+    command
+        .get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect()
+}
+
+#[test]
+fn auto_mode_command_records_prompt_delivery_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let prompt = synthetic_prompt();
+
+    let delivered = build_auto_command_with_prompt_delivery(AutoModePromptDeliveryOptions {
+        tool: AutoModeTool::Copilot,
+        execution_dir: dir.path().to_path_buf(),
+        project_dir: dir.path().to_path_buf(),
+        node_options: Some("--max-old-space-size=32768".to_string()),
+        passthrough_args: vec!["--model".to_string(), "gpt-5.5".to_string()],
+        prompt: prompt.clone(),
+        requested_delivery: PromptDelivery::Tempfile,
+    })
+    .expect("auto-mode delivery-aware command should build");
+
+    assert_eq!(delivered.selected_mode, DeliveryMode::Argv);
+    let warnings = format!("{:?}", delivered.warnings);
+    assert!(
+        warnings.contains("degrading to argv") || warnings.contains("Argv"),
+        "argv-only Copilot must produce a deterministic warning for tempfile requests"
+    );
+    assert_eq!(
+        argv(&delivered.command)
+            .iter()
+            .filter(|arg| *arg == &prompt)
+            .count(),
+        1,
+        "until Copilot has a verified long-form contract, auto mode must pass the prompt once as a structured argv element"
+    );
+}
+
+#[test]
+fn auto_mode_does_not_duplicate_prompt_between_wrapper_and_child_args() {
+    let dir = tempfile::tempdir().unwrap();
+    let prompt = synthetic_prompt();
+
+    let delivered = build_auto_command_with_prompt_delivery(AutoModePromptDeliveryOptions {
+        tool: AutoModeTool::Amplifier,
+        execution_dir: dir.path().to_path_buf(),
+        project_dir: dir.path().to_path_buf(),
+        node_options: None,
+        passthrough_args: vec![],
+        prompt: prompt.clone(),
+        requested_delivery: PromptDelivery::Auto,
+    })
+    .expect("amplifier auto-mode delivery-aware command should build");
+
+    let args = argv(&delivered.command);
+    assert_eq!(
+        args.iter().filter(|arg| *arg == &prompt).count(),
+        1,
+        "auto mode must not pass the prompt once to amplihack and again to the nested child; args: {args:?}"
+    );
+}

--- a/crates/amplihack-cli/tests/doctor_prompt_delivery.rs
+++ b/crates/amplihack-cli/tests/doctor_prompt_delivery.rs
@@ -1,0 +1,70 @@
+//! Red-phase CLI doctor tests for prompt-delivery diagnostics.
+//!
+//! The doctor surface must report modes, static capabilities, effective
+//! degradation, and warnings without printing raw prompt data.
+
+use amplihack_cli::commands::doctor::{
+    PromptDeliveryDoctorOptions, render_prompt_delivery_diagnostics,
+};
+use amplihack_utils::prompt_delivery::PromptDelivery;
+
+#[test]
+fn doctor_reports_requested_mode_capabilities_effective_modes_and_warnings() {
+    let output = render_prompt_delivery_diagnostics(PromptDeliveryDoctorOptions {
+        requested: PromptDelivery::Tempfile,
+        diagnostic_prompt_size: 64 * 1024,
+    });
+
+    assert!(output.contains("Prompt delivery"));
+    assert!(output.contains("requested: tempfile"));
+    assert!(output.contains("auto threshold: 4096 bytes"));
+
+    for binary in ["claude", "copilot", "codex", "amplifier"] {
+        assert!(
+            output.contains(binary),
+            "doctor prompt-delivery section must include {binary}; output:\n{output}"
+        );
+        assert!(
+            output.contains("capabilities: argv"),
+            "current verified contracts must be reported as argv-only; output:\n{output}"
+        );
+        assert!(
+            output.contains("effective for long prompt: argv"),
+            "unsupported tempfile requests must degrade to argv; output:\n{output}"
+        );
+    }
+
+    assert!(output.contains("requested tempfile is unsupported; degrading to argv"));
+}
+
+#[test]
+fn doctor_output_never_contains_raw_prompt_material() {
+    let output = render_prompt_delivery_diagnostics(PromptDeliveryDoctorOptions {
+        requested: PromptDelivery::Stdin,
+        diagnostic_prompt_size: 64 * 1024,
+    });
+
+    for forbidden in [
+        "don't shell-quote",
+        "$PATH",
+        "apostrophe",
+        "64 KiB prompt",
+        "simard-prompt-",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "doctor diagnostics must not print prompt bytes or tempfile paths; found {forbidden:?} in:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn doctor_help_lists_prompt_delivery_environment_override() {
+    let help = amplihack_cli::commands::doctor::render_doctor_help();
+
+    assert!(help.contains("AMPLIHACK_PROMPT_DELIVERY"));
+    assert!(help.contains("auto"));
+    assert!(help.contains("argv"));
+    assert!(help.contains("tempfile"));
+    assert!(help.contains("stdin"));
+}

--- a/crates/amplihack-launcher/Cargo.toml
+++ b/crates/amplihack-launcher/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description = "Extended launcher support for all agent types (Codex, Amplifier, Copilot)"
 
 [dependencies]
+amplihack-utils = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 libc = { workspace = true }

--- a/crates/amplihack-launcher/src/amplifier.rs
+++ b/crates/amplihack-launcher/src/amplifier.rs
@@ -12,6 +12,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tracing::{debug, info, warn};
 
+use crate::flag_matrix::AgentBinary;
+use crate::prompt_delivery::{DeliveredCommand, build_tool_command_from_env};
+
 /// Amplifier binary detection result.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AmplifierInfo {
@@ -112,17 +115,17 @@ pub fn build_amplifier_command(
     project_path: &Path,
     extra_args: &[String],
 ) -> Command {
-    let mut cmd = Command::new("amplifier");
-    cmd.current_dir(project_path);
-    cmd.arg("run");
-    if !prompt.is_empty() {
-        cmd.args(["--prompt", prompt]);
-    }
-    for arg in extra_args {
-        cmd.arg(arg);
-    }
-    cmd.env("AMPLIHACK_AGENT_BINARY", "amplifier");
-    cmd
+    build_amplifier_command_with_prompt_delivery(prompt, project_path, extra_args)
+        .expect("argv-only amplifier prompt delivery should not fail")
+        .command
+}
+
+pub fn build_amplifier_command_with_prompt_delivery(
+    prompt: &str,
+    project_path: &Path,
+    extra_args: &[String],
+) -> std::io::Result<DeliveredCommand> {
+    build_tool_command_from_env(AgentBinary::Amplifier, project_path, extra_args, prompt)
 }
 
 /// Full launch: ensure installed, register bundle, sync docs, build command.

--- a/crates/amplihack-launcher/src/auto_mode_exec.rs
+++ b/crates/amplihack-launcher/src/auto_mode_exec.rs
@@ -4,7 +4,7 @@
 //! retry logic, instruction injection, and session lifecycle.
 
 use anyhow::{Context, Result};
-use std::process::Command;
+use std::io::Write as _;
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
@@ -12,6 +12,8 @@ use crate::auto_mode::{
     AutoModeConfig, SdkBackend, SessionMetrics, SessionResult, TurnResult, format_elapsed,
     is_retryable_output, sanitize_injected_content,
 };
+use crate::flag_matrix::{AgentBinary, prompt_delivery_caps_for};
+use crate::prompt_delivery::build_command_with_prompt_delivery;
 
 /// Autonomous execution engine.
 ///
@@ -147,22 +149,54 @@ impl AutoMode {
 
     fn run_sdk(&self, prompt: &str) -> Result<(i32, String)> {
         let binary = match self.config.sdk {
-            SdkBackend::Claude => "claude",
-            SdkBackend::Copilot => "copilot",
-            SdkBackend::Codex => "codex",
+            SdkBackend::Claude => AgentBinary::Claude,
+            SdkBackend::Copilot => AgentBinary::Copilot,
+            SdkBackend::Codex => AgentBinary::Codex,
         };
-        let mut cmd = Command::new(binary);
-        cmd.current_dir(&self.config.working_dir);
-        cmd.args(["--print", "--output-format", "text", "-p", prompt]);
+        let mut delivered = build_command_with_prompt_delivery(
+            std::ffi::OsStr::new(binary.env_value()),
+            ["--print", "--output-format", "text", "-p"],
+            prompt,
+            amplihack_utils::prompt_delivery::from_env(),
+            prompt_delivery_caps_for(binary),
+        )
+        .with_context(|| format!("failed to build {} prompt delivery", binary.env_value()))?;
+        delivered.command.current_dir(&self.config.working_dir);
         if let Some(timeout) = self.config.query_timeout_secs {
-            cmd.env("AMPLIHACK_QUERY_TIMEOUT", timeout.to_string());
+            delivered
+                .command
+                .env("AMPLIHACK_QUERY_TIMEOUT", timeout.to_string());
         }
-        let output = cmd
-            .output()
-            .with_context(|| format!("failed to run {binary}"))?;
+        let output = Self::run_delivered_output(delivered)
+            .with_context(|| format!("failed to run {}", binary.env_value()))?;
         let code = output.status.code().unwrap_or(1);
         let text = String::from_utf8_lossy(&output.stdout).to_string();
         Ok((code, text))
+    }
+
+    fn run_delivered_output(
+        delivered: crate::prompt_delivery::DeliveredCommand,
+    ) -> std::io::Result<std::process::Output> {
+        let crate::prompt_delivery::DeliveredCommand {
+            mut command,
+            delivery_handle,
+            stdin_payload,
+            ..
+        } = delivered;
+        let output = if let Some(payload) = stdin_payload {
+            command.stdout(std::process::Stdio::piped());
+            command.stderr(std::process::Stdio::piped());
+            let mut child = command.spawn()?;
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(&payload)?;
+                stdin.flush()?;
+            }
+            child.wait_with_output()?
+        } else {
+            command.output()?
+        };
+        drop(delivery_handle);
+        Ok(output)
     }
 
     pub(crate) fn should_continue(&self) -> bool {

--- a/crates/amplihack-launcher/src/codex.rs
+++ b/crates/amplihack-launcher/src/codex.rs
@@ -13,6 +13,9 @@ use std::process::Command;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
+use crate::flag_matrix::AgentBinary;
+use crate::prompt_delivery::{DeliveredCommand, build_tool_command_from_env};
+
 /// Maximum time to wait for a version-check subprocess.
 const VERSION_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -95,17 +98,17 @@ pub fn configure_codex(project_path: &Path) -> Result<()> {
 
 /// Build the command to launch Codex with the given prompt.
 pub fn build_codex_command(prompt: &str, project_path: &Path, extra_args: &[String]) -> Command {
-    let mut cmd = Command::new("codex");
-    cmd.current_dir(project_path);
-    if !prompt.is_empty() {
-        cmd.args(["--prompt", prompt]);
-    }
-    for arg in extra_args {
-        cmd.arg(arg);
-    }
-    // Set agent binary env var for nested sessions
-    cmd.env("AMPLIHACK_AGENT_BINARY", "codex");
-    cmd
+    build_codex_command_with_prompt_delivery(prompt, project_path, extra_args)
+        .expect("argv-only codex prompt delivery should not fail")
+        .command
+}
+
+pub fn build_codex_command_with_prompt_delivery(
+    prompt: &str,
+    project_path: &Path,
+    extra_args: &[String],
+) -> std::io::Result<DeliveredCommand> {
+    build_tool_command_from_env(AgentBinary::Codex, project_path, extra_args, prompt)
 }
 
 /// Ensure Codex is installed and up-to-date, then return a ready command.

--- a/crates/amplihack-launcher/src/flag_matrix.rs
+++ b/crates/amplihack-launcher/src/flag_matrix.rs
@@ -13,6 +13,7 @@ pub enum AgentBinary {
     Claude,
     Copilot,
     Codex,
+    Amplifier,
 }
 
 impl AgentBinary {
@@ -22,6 +23,7 @@ impl AgentBinary {
             Self::Claude => "claude",
             Self::Copilot => "copilot",
             Self::Codex => "codex",
+            Self::Amplifier => "amplifier",
         }
     }
 }
@@ -57,6 +59,14 @@ pub struct FlagSet {
     pub supports_allow_all_tools: bool,
     /// Supports `--remote` (Copilot-specific — offload to GitHub cloud).
     pub supports_remote: bool,
+    /// Supports structured argv task-prompt delivery.
+    pub supports_prompt_argv: bool,
+    /// Supports task-prompt tempfile delivery through a verified CLI contract.
+    pub supports_prompt_tempfile: bool,
+    /// Supports task-prompt stdin delivery through a verified CLI contract.
+    pub supports_prompt_stdin: bool,
+    /// Verified task-prompt tempfile flag, when supported.
+    pub prompt_tempfile_flag: Option<&'static str>,
     /// The env var name set to identify the agent binary in nested sessions.
     pub agent_binary_env: &'static str,
 }
@@ -78,6 +88,10 @@ pub fn flags_for(binary: AgentBinary) -> FlagSet {
             supports_print: true,
             supports_allow_all_tools: false,
             supports_remote: false,
+            supports_prompt_argv: true,
+            supports_prompt_tempfile: false,
+            supports_prompt_stdin: false,
+            prompt_tempfile_flag: None,
             agent_binary_env: "AMPLIHACK_AGENT_BINARY",
         },
         AgentBinary::Copilot => FlagSet {
@@ -90,6 +104,10 @@ pub fn flags_for(binary: AgentBinary) -> FlagSet {
             supports_print: false,
             supports_allow_all_tools: true,
             supports_remote: true,
+            supports_prompt_argv: true,
+            supports_prompt_tempfile: false,
+            supports_prompt_stdin: false,
+            prompt_tempfile_flag: None,
             agent_binary_env: "AMPLIHACK_AGENT_BINARY",
         },
         AgentBinary::Codex => FlagSet {
@@ -102,8 +120,143 @@ pub fn flags_for(binary: AgentBinary) -> FlagSet {
             supports_print: false,
             supports_allow_all_tools: false,
             supports_remote: false,
+            supports_prompt_argv: true,
+            supports_prompt_tempfile: false,
+            supports_prompt_stdin: false,
+            prompt_tempfile_flag: None,
             agent_binary_env: "AMPLIHACK_AGENT_BINARY",
         },
+        AgentBinary::Amplifier => FlagSet {
+            binary: AgentBinary::Amplifier,
+            supports_append_prompt: false,
+            supports_add_dir: false,
+            supports_model: false,
+            supports_skip_permissions: false,
+            supports_resume: false,
+            supports_print: false,
+            supports_allow_all_tools: false,
+            supports_remote: false,
+            supports_prompt_argv: true,
+            supports_prompt_tempfile: false,
+            supports_prompt_stdin: false,
+            prompt_tempfile_flag: None,
+            agent_binary_env: "AMPLIHACK_AGENT_BINARY",
+        },
+    }
+}
+
+/// Return prompt-delivery capabilities for a binary.
+pub fn prompt_delivery_caps_for(
+    binary: AgentBinary,
+) -> amplihack_utils::prompt_delivery::DeliveryCaps {
+    let flags = flags_for(binary);
+    amplihack_utils::prompt_delivery::DeliveryCaps {
+        supports_argv: flags.supports_prompt_argv,
+        supports_tempfile: flags.supports_prompt_tempfile,
+        supports_stdin: flags.supports_prompt_stdin,
+        tempfile_flag: flags.prompt_tempfile_flag,
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromptDeliveryReport {
+    pub requested: amplihack_utils::prompt_delivery::PromptDelivery,
+    pub prompt_size: usize,
+    pub entries: Vec<PromptDeliveryReportEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromptDeliveryReportEntry {
+    pub binary: AgentBinary,
+    pub caps: amplihack_utils::prompt_delivery::DeliveryCaps,
+    pub effective_mode: amplihack_utils::prompt_delivery::DeliveryMode,
+    pub warning: String,
+    pub note: String,
+}
+
+/// Build deterministic prompt-delivery diagnostics for doctor output.
+pub fn prompt_delivery_report_for(
+    requested: amplihack_utils::prompt_delivery::PromptDelivery,
+    prompt_size: usize,
+) -> PromptDeliveryReport {
+    let entries = ALL_BINARIES
+        .iter()
+        .copied()
+        .map(|binary| {
+            let caps = prompt_delivery_caps_for(binary);
+            let effective_mode =
+                amplihack_utils::prompt_delivery::select_mode(requested, prompt_size, &caps);
+            PromptDeliveryReportEntry {
+                binary,
+                caps,
+                effective_mode,
+                warning: warning_for(requested, effective_mode, &caps),
+                note: note_for(binary),
+            }
+        })
+        .collect();
+    PromptDeliveryReport {
+        requested,
+        prompt_size,
+        entries,
+    }
+}
+
+fn warning_for(
+    requested: amplihack_utils::prompt_delivery::PromptDelivery,
+    effective: amplihack_utils::prompt_delivery::DeliveryMode,
+    caps: &amplihack_utils::prompt_delivery::DeliveryCaps,
+) -> String {
+    use amplihack_utils::prompt_delivery::PromptDelivery;
+    let unsupported = match requested {
+        PromptDelivery::Auto => false,
+        PromptDelivery::Argv => !caps.supports_argv,
+        PromptDelivery::Tempfile => !caps.supports_tempfile,
+        PromptDelivery::Stdin => !caps.supports_stdin,
+    };
+    if !unsupported {
+        return String::new();
+    }
+    format!(
+        "requested {} is unsupported; degrading to {}",
+        prompt_delivery_name(requested),
+        delivery_mode_name(effective)
+    )
+}
+
+fn note_for(binary: AgentBinary) -> String {
+    match binary {
+        AgentBinary::Claude => {
+            "task-prompt tempfile/stdin support pending verified Claude contract".to_string()
+        }
+        AgentBinary::Copilot => {
+            "no verified Copilot prompt-file or stdin task-prompt contract".to_string()
+        }
+        AgentBinary::Codex => {
+            "stdin support pending verified Codex command contract".to_string()
+        }
+        AgentBinary::Amplifier => {
+            "Amplifier is routed through prompt_delivery as argv-only until a long-form contract exists".to_string()
+        }
+    }
+}
+
+pub fn prompt_delivery_name(
+    mode: amplihack_utils::prompt_delivery::PromptDelivery,
+) -> &'static str {
+    match mode {
+        amplihack_utils::prompt_delivery::PromptDelivery::Auto => "auto",
+        amplihack_utils::prompt_delivery::PromptDelivery::Argv => "argv",
+        amplihack_utils::prompt_delivery::PromptDelivery::Tempfile => "tempfile",
+        amplihack_utils::prompt_delivery::PromptDelivery::Stdin => "stdin",
+    }
+}
+
+pub fn delivery_mode_name(mode: amplihack_utils::prompt_delivery::DeliveryMode) -> &'static str {
+    match mode {
+        amplihack_utils::prompt_delivery::DeliveryMode::Argv => "argv",
+        amplihack_utils::prompt_delivery::DeliveryMode::Tempfile => "tempfile",
+        amplihack_utils::prompt_delivery::DeliveryMode::Stdin => "stdin",
     }
 }
 
@@ -112,6 +265,7 @@ pub const ALL_BINARIES: &[AgentBinary] = &[
     AgentBinary::Claude,
     AgentBinary::Copilot,
     AgentBinary::Codex,
+    AgentBinary::Amplifier,
 ];
 
 // ---------------------------------------------------------------------------
@@ -169,6 +323,17 @@ mod tests {
     }
 
     #[test]
+    fn prompt_delivery_caps_are_argv_only_until_contracts_are_verified() {
+        for binary in ALL_BINARIES {
+            let caps = prompt_delivery_caps_for(*binary);
+            assert!(caps.supports_argv);
+            assert!(!caps.supports_tempfile);
+            assert!(!caps.supports_stdin);
+            assert_eq!(caps.tempfile_flag, None);
+        }
+    }
+
+    #[test]
     fn codex_does_not_support_remote() {
         let flags = flags_for(AgentBinary::Codex);
         assert!(!flags.supports_remote);
@@ -197,6 +362,14 @@ mod tests {
         assert!(!flags.supports_print);
         assert!(!flags.supports_allow_all_tools);
         assert!(!flags.supports_remote);
+    }
+
+    #[test]
+    fn amplifier_has_explicit_prompt_delivery_row() {
+        let flags = flags_for(AgentBinary::Amplifier);
+        assert!(flags.supports_prompt_argv);
+        assert!(!flags.supports_prompt_tempfile);
+        assert!(!flags.supports_prompt_stdin);
     }
 
     // -----------------------------------------------------------------------
@@ -296,6 +469,6 @@ mod tests {
 
     #[test]
     fn all_binaries_contains_three_variants() {
-        assert_eq!(ALL_BINARIES.len(), 3);
+        assert_eq!(ALL_BINARIES.len(), 4);
     }
 }

--- a/crates/amplihack-launcher/src/lib.rs
+++ b/crates/amplihack-launcher/src/lib.rs
@@ -28,6 +28,7 @@ pub mod launcher_core;
 pub mod memory_config;
 pub mod nesting_detector;
 pub mod platform_check;
+pub mod prompt_delivery;
 pub mod repo_checkout;
 pub mod session_capture;
 pub mod session_tracker;

--- a/crates/amplihack-launcher/src/prompt_delivery.rs
+++ b/crates/amplihack-launcher/src/prompt_delivery.rs
@@ -1,0 +1,154 @@
+//! Delivery-aware command builders for launcher subprocesses.
+
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+use amplihack_utils::prompt_delivery::{
+    DeliveryCaps, DeliveryHandle, DeliveryMode, PromptDelivery, deliver, from_env, select_mode,
+};
+
+use crate::flag_matrix::{
+    AgentBinary, delivery_mode_name, prompt_delivery_caps_for, prompt_delivery_name,
+};
+
+#[derive(Debug)]
+pub struct DeliveredCommand {
+    pub command: Command,
+    pub delivery_handle: DeliveryHandle,
+    pub requested_mode: PromptDelivery,
+    pub selected_mode: DeliveryMode,
+    pub warnings: Vec<DeliveryWarning>,
+    pub stdin_payload: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DeliveryWarning {
+    UnsupportedMode {
+        requested: PromptDelivery,
+        effective: DeliveryMode,
+        message: String,
+    },
+}
+
+impl DeliveryWarning {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::UnsupportedMode { message, .. } => message,
+        }
+    }
+}
+
+pub fn build_command_with_prompt_delivery<I, S>(
+    program: &OsStr,
+    args: I,
+    prompt: &str,
+    requested: PromptDelivery,
+    caps: DeliveryCaps,
+) -> io::Result<DeliveredCommand>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new(program);
+    command.args(args);
+    finish_prompt_delivery(command, prompt, requested, caps)
+}
+
+pub fn build_tool_command_with_prompt_delivery(
+    binary: AgentBinary,
+    project_path: &Path,
+    extra_args: &[String],
+    prompt: &str,
+    requested: PromptDelivery,
+) -> io::Result<DeliveredCommand> {
+    let mut command = Command::new(binary.env_value());
+    command.current_dir(project_path);
+    command.env("AMPLIHACK_AGENT_BINARY", binary.env_value());
+
+    for arg in prompt_prefix_args(binary, extra_args) {
+        command.arg(arg);
+    }
+
+    finish_prompt_delivery(command, prompt, requested, prompt_delivery_caps_for(binary))
+}
+
+pub fn build_tool_command_from_env(
+    binary: AgentBinary,
+    project_path: &Path,
+    extra_args: &[String],
+    prompt: &str,
+) -> io::Result<DeliveredCommand> {
+    build_tool_command_with_prompt_delivery(binary, project_path, extra_args, prompt, from_env())
+}
+
+fn finish_prompt_delivery(
+    mut command: Command,
+    prompt: &str,
+    requested: PromptDelivery,
+    caps: DeliveryCaps,
+) -> io::Result<DeliveredCommand> {
+    let selected_mode = select_mode(requested, prompt.len(), &caps);
+    let warnings = warnings_for(requested, selected_mode, &caps);
+    let delivery_handle = deliver(&mut command, prompt, requested, &caps)?;
+    let stdin_payload = (selected_mode == DeliveryMode::Stdin).then(|| prompt.as_bytes().to_vec());
+    Ok(DeliveredCommand {
+        command,
+        delivery_handle,
+        requested_mode: requested,
+        selected_mode,
+        warnings,
+        stdin_payload,
+    })
+}
+
+fn warnings_for(
+    requested: PromptDelivery,
+    effective: DeliveryMode,
+    caps: &DeliveryCaps,
+) -> Vec<DeliveryWarning> {
+    let unsupported = match requested {
+        PromptDelivery::Auto => false,
+        PromptDelivery::Argv => !caps.supports_argv,
+        PromptDelivery::Tempfile => !caps.supports_tempfile,
+        PromptDelivery::Stdin => !caps.supports_stdin,
+    };
+    if !unsupported {
+        return Vec::new();
+    }
+    vec![DeliveryWarning::UnsupportedMode {
+        requested,
+        effective,
+        message: format!(
+            "requested {} is unsupported; degrading to {}",
+            prompt_delivery_name(requested),
+            delivery_mode_name(effective)
+        ),
+    }]
+}
+
+fn prompt_prefix_args(binary: AgentBinary, extra_args: &[String]) -> Vec<OsString> {
+    let mut args = Vec::new();
+    match binary {
+        AgentBinary::Claude => {
+            args.push("--dangerously-skip-permissions".into());
+            args.extend(extra_args.iter().map(OsString::from));
+            args.push("-p".into());
+        }
+        AgentBinary::Copilot => {
+            args.extend(extra_args.iter().map(OsString::from));
+            args.push("-p".into());
+        }
+        AgentBinary::Codex => {
+            args.extend(extra_args.iter().map(OsString::from));
+            args.push("--prompt".into());
+        }
+        AgentBinary::Amplifier => {
+            args.push("run".into());
+            args.extend(extra_args.iter().map(OsString::from));
+            args.push("--prompt".into());
+        }
+    }
+    args
+}

--- a/crates/amplihack-launcher/tests/prompt_delivery.rs
+++ b/crates/amplihack-launcher/tests/prompt_delivery.rs
@@ -1,0 +1,206 @@
+//! Red-phase prompt-delivery integration contracts for launcher command builders.
+//!
+//! These tests intentionally name the public API expected from the green phase:
+//! static capability metadata plus delivery-aware command builders that preserve
+//! the selected mode, warnings, and RAII handle alongside the `Command`.
+
+use std::ffi::OsStr;
+use std::path::Path;
+
+use amplihack_launcher::flag_matrix::{
+    ALL_BINARIES, AgentBinary, prompt_delivery_caps_for, prompt_delivery_report_for,
+};
+use amplihack_launcher::prompt_delivery::{
+    DeliveryWarning, build_command_with_prompt_delivery, build_tool_command_with_prompt_delivery,
+};
+use amplihack_utils::prompt_delivery::{DeliveryMode, PromptDelivery};
+
+const PAYLOAD_SIZE: usize = 64 * 1024;
+
+fn synthetic_prompt() -> String {
+    let pattern = "issue 652: don't shell-quote `$PATH`; keep \"bytes\" intact\n";
+    let mut prompt = String::with_capacity(PAYLOAD_SIZE);
+    while prompt.len() < PAYLOAD_SIZE {
+        prompt.push_str(pattern);
+    }
+    prompt.truncate(PAYLOAD_SIZE);
+    prompt
+}
+
+fn argv(command: &std::process::Command) -> Vec<String> {
+    command
+        .get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect()
+}
+
+#[test]
+fn capability_matrix_covers_all_prompt_binaries_without_speculation() {
+    assert!(
+        ALL_BINARIES.contains(&AgentBinary::Amplifier),
+        "Amplifier must be represented in launcher prompt-delivery metadata"
+    );
+
+    for binary in [
+        AgentBinary::Claude,
+        AgentBinary::Copilot,
+        AgentBinary::Codex,
+        AgentBinary::Amplifier,
+    ] {
+        let caps = prompt_delivery_caps_for(binary);
+        assert!(
+            caps.supports_argv,
+            "{binary} must support structured argv prompt delivery"
+        );
+    }
+
+    let claude = prompt_delivery_caps_for(AgentBinary::Claude);
+    assert!(
+        !claude.supports_tempfile,
+        "Claude task-prompt tempfile support must stay disabled until a verified task-prompt file contract exists; --append-system-prompt is a different prompt role"
+    );
+    assert!(
+        !claude.supports_stdin,
+        "Claude stdin task-prompt support is not verified"
+    );
+
+    let copilot = prompt_delivery_caps_for(AgentBinary::Copilot);
+    assert!(
+        !copilot.supports_tempfile && !copilot.supports_stdin,
+        "Copilot must remain argv-only until a prompt-file or stdin contract is verified"
+    );
+
+    let codex = prompt_delivery_caps_for(AgentBinary::Codex);
+    assert!(
+        !codex.supports_tempfile && !codex.supports_stdin,
+        "Codex stdin support is pending a named verified command contract and must not be enabled speculatively"
+    );
+
+    let amplifier = prompt_delivery_caps_for(AgentBinary::Amplifier);
+    assert!(
+        !amplifier.supports_tempfile && !amplifier.supports_stdin,
+        "Amplifier must be migrated through prompt_delivery as argv-only unless a long-form contract is verified"
+    );
+}
+
+#[test]
+fn argv_only_builders_still_use_one_structured_argv_element_for_raw_prompt() {
+    let prompt = synthetic_prompt();
+
+    for binary in [
+        AgentBinary::Claude,
+        AgentBinary::Copilot,
+        AgentBinary::Codex,
+        AgentBinary::Amplifier,
+    ] {
+        let delivered = build_tool_command_with_prompt_delivery(
+            binary,
+            Path::new("/tmp"),
+            &[],
+            &prompt,
+            PromptDelivery::Auto,
+        )
+        .expect("delivery-aware launcher command should build");
+
+        assert_eq!(
+            delivered.selected_mode,
+            DeliveryMode::Argv,
+            "{binary} has no verified long-form delivery contract yet"
+        );
+        assert!(
+            delivered.delivery_handle.tempfile_path().is_none(),
+            "{binary} argv mode must not create a tempfile"
+        );
+
+        let args = argv(&delivered.command);
+        assert_eq!(
+            args.iter().filter(|arg| *arg == &prompt).count(),
+            1,
+            "{binary} must pass the raw prompt exactly once as one argv element, not via shell splitting. Args: {args:?}"
+        );
+    }
+}
+
+#[test]
+fn unsupported_tempfile_request_degrades_to_argv_with_warning() {
+    let prompt = synthetic_prompt();
+
+    let delivered = build_tool_command_with_prompt_delivery(
+        AgentBinary::Copilot,
+        Path::new("/tmp"),
+        &[],
+        &prompt,
+        PromptDelivery::Tempfile,
+    )
+    .expect("unsupported explicit mode should degrade, not fail");
+
+    assert_eq!(delivered.selected_mode, DeliveryMode::Argv);
+    assert!(
+        delivered.warnings.iter().any(|warning| {
+            matches!(
+                warning,
+                DeliveryWarning::UnsupportedMode {
+                    requested: PromptDelivery::Tempfile,
+                    effective: DeliveryMode::Argv,
+                    ..
+                }
+            )
+        }),
+        "explicit tempfile on an argv-only binary must produce a deterministic degradation warning; got {:?}",
+        delivered.warnings
+    );
+}
+
+#[test]
+fn generic_long_form_builder_keeps_large_prompt_out_of_argv_when_caps_support_tempfile() {
+    let prompt = synthetic_prompt();
+
+    let delivered = build_command_with_prompt_delivery(
+        OsStr::new("cat"),
+        std::iter::empty::<&str>(),
+        &prompt,
+        PromptDelivery::Tempfile,
+        amplihack_utils::prompt_delivery::DeliveryCaps::argv_and_tempfile(""),
+    )
+    .expect("generic delivery-aware command should build");
+
+    assert_eq!(delivered.selected_mode, DeliveryMode::Tempfile);
+    assert!(
+        delivered.delivery_handle.tempfile_path().is_some(),
+        "tempfile mode must return a live RAII handle"
+    );
+    assert!(
+        !argv(&delivered.command)
+            .iter()
+            .any(|arg| arg.contains(&prompt[..256])),
+        "large prompt must not appear in argv when tempfile is selected"
+    );
+}
+
+#[test]
+fn prompt_delivery_report_matches_doctor_order_and_effective_modes() {
+    let report = prompt_delivery_report_for(PromptDelivery::Tempfile, PAYLOAD_SIZE);
+
+    let binaries: Vec<_> = report.entries.iter().map(|entry| entry.binary).collect();
+    assert_eq!(
+        binaries,
+        vec![
+            AgentBinary::Claude,
+            AgentBinary::Copilot,
+            AgentBinary::Codex,
+            AgentBinary::Amplifier,
+        ],
+        "doctor and launcher reports must use a stable binary order"
+    );
+    assert!(
+        report
+            .entries
+            .iter()
+            .all(|entry| entry.effective_mode == DeliveryMode::Argv),
+        "current verified launcher contracts are argv-only, so tempfile requests degrade to argv"
+    );
+    assert!(
+        report.entries.iter().all(|entry| !entry.warning.is_empty()),
+        "every argv-only binary should explain an unsupported tempfile request"
+    );
+}

--- a/crates/amplihack-orchestration/Cargo.toml
+++ b/crates/amplihack-orchestration/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+amplihack-utils = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -18,4 +19,3 @@ once_cell = "1"
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync", "test-util"] }
-amplihack-utils = { path = "../amplihack-utils" }

--- a/crates/amplihack-orchestration/src/claude_process.rs
+++ b/crates/amplihack-orchestration/src/claude_process.rs
@@ -7,14 +7,18 @@
 use std::collections::HashMap;
 use std::io::Write as _;
 use std::path::PathBuf;
+use std::process::Command as StdCommand;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use amplihack_utils::prompt_delivery::{
+    DeliveryCaps, DeliveryHandle, DeliveryMode, PromptDelivery, deliver, from_env, select_mode,
+};
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use thiserror::Error;
-use tokio::io::AsyncReadExt;
-use tokio::process::Command;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command as TokioCommand;
 use tokio::time::timeout as tokio_timeout;
 
 /// Pre-split command lookup: maps `AMPLIHACK_DELEGATE` value to its binary
@@ -38,6 +42,12 @@ pub static DELEGATE_COMMANDS: Lazy<HashMap<String, Vec<String>>> = Lazy::new(|| 
 /// Appends `--dangerously-skip-permissions -p <prompt>` and optional
 /// `--model <model>`.
 pub fn build_command(delegate: Option<&str>, prompt: &str, model: Option<&str>) -> Vec<String> {
+    let mut cmd = build_command_prefix(delegate, model);
+    cmd.push(prompt.to_string());
+    cmd
+}
+
+fn build_command_prefix(delegate: Option<&str>, model: Option<&str>) -> Vec<String> {
     let prefix: Vec<String> = match delegate {
         None => {
             tracing::warn!(
@@ -60,13 +70,44 @@ pub fn build_command(delegate: Option<&str>, prompt: &str, model: Option<&str>) 
 
     let mut cmd = prefix;
     cmd.push("--dangerously-skip-permissions".to_string());
-    cmd.push("-p".to_string());
-    cmd.push(prompt.to_string());
     if let Some(m) = model {
         cmd.push("--model".to_string());
         cmd.push(m.to_string());
     }
+    cmd.push("-p".to_string());
     cmd
+}
+
+#[derive(Debug)]
+pub struct DeliveredProcessCommand {
+    pub command: StdCommand,
+    pub delivery_handle: DeliveryHandle,
+    pub selected_mode: DeliveryMode,
+    pub stdin_payload: Option<Vec<u8>>,
+}
+
+pub fn build_command_with_prompt_delivery<I, S>(
+    program: &str,
+    args: I,
+    prompt: &str,
+    requested: PromptDelivery,
+    caps: DeliveryCaps,
+) -> std::io::Result<DeliveredProcessCommand>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let mut command = StdCommand::new(program);
+    command.args(args);
+    let selected_mode = select_mode(requested, prompt.len(), &caps);
+    let delivery_handle = deliver(&mut command, prompt, requested, &caps)?;
+    let stdin_payload = (selected_mode == DeliveryMode::Stdin).then(|| prompt.as_bytes().to_vec());
+    Ok(DeliveredProcessCommand {
+        command,
+        delivery_handle,
+        selected_mode,
+        stdin_payload,
+    })
 }
 
 /// Result of a single process execution.
@@ -147,6 +188,41 @@ impl TokioProcessRunner {
     pub fn new() -> Self {
         Self
     }
+
+    pub async fn run_with_prompt_delivery_for_test<I, S>(
+        &self,
+        opts: RunOptions,
+        requested: PromptDelivery,
+        caps: DeliveryCaps,
+        program: &str,
+        args: I,
+    ) -> ProcessResult
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        let start = Instant::now();
+        let mut delivered = match build_command_with_prompt_delivery(
+            program,
+            args,
+            &opts.prompt,
+            requested,
+            caps,
+        ) {
+            Ok(command) => command,
+            Err(e) => {
+                return ProcessResult::err(
+                    format!("prompt delivery failed: {e}"),
+                    opts.process_id,
+                    start.elapsed(),
+                );
+            }
+        };
+        if let Some(dir) = &opts.working_dir {
+            delivered.command.current_dir(dir);
+        }
+        run_delivered_command(delivered, opts.timeout, opts.process_id, start).await
+    }
 }
 
 #[async_trait]
@@ -154,7 +230,7 @@ impl ProcessRunner for TokioProcessRunner {
     async fn run(&self, opts: RunOptions) -> ProcessResult {
         let start = Instant::now();
         let delegate = std::env::var("AMPLIHACK_DELEGATE").ok();
-        let cmd_parts = build_command(delegate.as_deref(), &opts.prompt, opts.model.as_deref());
+        let cmd_parts = build_command_prefix(delegate.as_deref(), opts.model.as_deref());
         let (program, args) = match cmd_parts.split_first() {
             Some(parts) => parts,
             None => {
@@ -166,72 +242,140 @@ impl ProcessRunner for TokioProcessRunner {
             }
         };
 
-        let mut command = Command::new(program);
-        command.args(args);
-        command.stdin(std::process::Stdio::null());
-        command.stdout(std::process::Stdio::piped());
-        command.stderr(std::process::Stdio::piped());
-        // Ensure the child is terminated if we drop it before wait completes
-        // (e.g., on timeout). Mirrors Python's terminate()/kill() behavior.
-        command.kill_on_drop(true);
-        if let Some(dir) = &opts.working_dir {
-            command.current_dir(dir);
-        }
-
-        let spawn_result = command.spawn();
-        let mut child = match spawn_result {
-            Ok(c) => c,
+        let mut delivered = match build_command_with_prompt_delivery(
+            program,
+            args,
+            &opts.prompt,
+            from_env(),
+            delivery_caps_for_delegate(delegate.as_deref()),
+        ) {
+            Ok(command) => command,
             Err(e) => {
                 return ProcessResult::err(
-                    format!("Failed to spawn '{program}': {e}"),
+                    format!("prompt delivery failed: {e}"),
                     opts.process_id,
                     start.elapsed(),
                 );
             }
         };
+        if let Some(dir) = &opts.working_dir {
+            delivered.command.current_dir(dir);
+        }
 
-        let mut stdout_pipe = child.stdout.take();
-        let mut stderr_pipe = child.stderr.take();
+        run_delivered_command(delivered, opts.timeout, opts.process_id, start).await
+    }
+}
 
-        let read_streams = async {
-            let mut out = String::new();
-            let mut err = String::new();
-            if let Some(p) = stdout_pipe.as_mut() {
-                let _ = p.read_to_string(&mut out).await;
-            }
-            if let Some(p) = stderr_pipe.as_mut() {
-                let _ = p.read_to_string(&mut err).await;
-            }
-            let status = child.wait().await;
-            (status, out, err)
-        };
+async fn run_delivered_command(
+    delivered: DeliveredProcessCommand,
+    timeout: Option<Duration>,
+    process_id: String,
+    start: Instant,
+) -> ProcessResult {
+    let DeliveredProcessCommand {
+        mut command,
+        delivery_handle,
+        stdin_payload,
+        ..
+    } = delivered;
+    if stdin_payload.is_none() {
+        command.stdin(std::process::Stdio::null());
+    }
+    command.stdout(std::process::Stdio::piped());
+    command.stderr(std::process::Stdio::piped());
+    let program = command.get_program().to_string_lossy().into_owned();
+    let mut command = TokioCommand::from(command);
+    command.kill_on_drop(true);
+    let spawn_result = command.spawn();
+    let mut child = match spawn_result {
+        Ok(c) => c,
+        Err(e) => {
+            return ProcessResult::err(
+                format!("Failed to spawn '{program}': {e}"),
+                process_id,
+                start.elapsed(),
+            );
+        }
+    };
 
-        let (status, out, err) = match opts.timeout {
-            Some(t) => match tokio_timeout(t, read_streams).await {
-                Ok(v) => v,
-                Err(_) => {
-                    return ProcessResult::err(
-                        format!("Timed out after {t:?}"),
-                        opts.process_id,
-                        start.elapsed(),
-                    );
-                }
-            },
-            None => read_streams.await,
-        };
-
-        let duration = start.elapsed();
-        match status {
-            Ok(s) => ProcessResult {
-                exit_code: s.code().unwrap_or(-1),
-                output: out,
-                stderr: err,
-                duration,
-                process_id: opts.process_id,
-            },
-            Err(e) => ProcessResult::err(format!("wait failed: {e}"), opts.process_id, duration),
+    if let Some(payload) = stdin_payload
+        && let Some(mut stdin) = child.stdin.take()
+    {
+        if let Err(e) = stdin.write_all(&payload).await {
+            return ProcessResult::err(
+                format!("failed to write prompt to child stdin: {e}"),
+                process_id,
+                start.elapsed(),
+            );
+        }
+        if let Err(e) = stdin.flush().await {
+            return ProcessResult::err(
+                format!("failed to flush child stdin: {e}"),
+                process_id,
+                start.elapsed(),
+            );
         }
     }
+
+    let mut stdout_pipe = child.stdout.take();
+    let mut stderr_pipe = child.stderr.take();
+
+    let read_streams = async {
+        let mut out = String::new();
+        let mut err = String::new();
+        if let Some(p) = stdout_pipe.as_mut() {
+            let _ = p.read_to_string(&mut out).await;
+        }
+        if let Some(p) = stderr_pipe.as_mut() {
+            let _ = p.read_to_string(&mut err).await;
+        }
+        let status = child.wait().await;
+        (status, out, err)
+    };
+
+    let (status, out, err) = match timeout {
+        Some(t) => match tokio_timeout(t, read_streams).await {
+            Ok(v) => v,
+            Err(_) => {
+                return ProcessResult::err(
+                    format!("Timed out after {t:?}"),
+                    process_id,
+                    start.elapsed(),
+                );
+            }
+        },
+        None => read_streams.await,
+    };
+
+    drop(delivery_handle);
+    let duration = start.elapsed();
+    match status {
+        Ok(s) => ProcessResult {
+            exit_code: s.code().unwrap_or(-1),
+            output: out,
+            stderr: err,
+            duration,
+            process_id,
+        },
+        Err(e) => ProcessResult::err(format!("wait failed: {e}"), process_id, duration),
+    }
+}
+
+fn delivery_caps_for_delegate(_delegate: Option<&str>) -> DeliveryCaps {
+    DeliveryCaps::argv_only()
+}
+
+pub async fn run_delivered_command_for_test(
+    delivered: DeliveredProcessCommand,
+    timeout: Duration,
+) -> std::io::Result<ProcessResult> {
+    Ok(run_delivered_command(
+        delivered,
+        Some(timeout),
+        "prompt-delivery-test".to_string(),
+        Instant::now(),
+    )
+    .await)
 }
 
 /// Internal mock expectation entry.

--- a/crates/amplihack-orchestration/tests/prompt_delivery_lifecycle.rs
+++ b/crates/amplihack-orchestration/tests/prompt_delivery_lifecycle.rs
@@ -1,0 +1,122 @@
+//! Red-phase async lifecycle tests for orchestration prompt delivery.
+//!
+//! The green phase must adapt `amplihack-utils::prompt_delivery` for Tokio
+//! process orchestration without duplicating mode-selection logic. The returned
+//! delivery handle has to live until the child exits, and stdin delivery must
+//! write, flush, close, then await.
+
+#![cfg(unix)]
+
+use std::path::Path;
+use std::time::Duration;
+
+use amplihack_orchestration::claude_process::{
+    RunOptions, TokioProcessRunner, build_command_with_prompt_delivery,
+    run_delivered_command_for_test,
+};
+use amplihack_utils::prompt_delivery::{DeliveryCaps, DeliveryMode, PromptDelivery};
+
+const PAYLOAD_SIZE: usize = 64 * 1024;
+
+fn synthetic_prompt() -> String {
+    let pattern = "stdin/tempfile lifecycle: don't truncate 'apostrophes' or $DOLLARS\n";
+    let mut prompt = String::with_capacity(PAYLOAD_SIZE);
+    while prompt.len() < PAYLOAD_SIZE {
+        prompt.push_str(pattern);
+    }
+    prompt.truncate(PAYLOAD_SIZE);
+    prompt
+}
+
+#[tokio::test]
+async fn tokio_stdin_delivery_writes_flushes_closes_and_awaits_child() {
+    let prompt = synthetic_prompt();
+    let delivered = build_command_with_prompt_delivery(
+        "cat",
+        std::iter::empty::<&str>(),
+        &prompt,
+        PromptDelivery::Stdin,
+        DeliveryCaps {
+            supports_argv: true,
+            supports_tempfile: false,
+            supports_stdin: true,
+            tempfile_flag: None,
+        },
+    )
+    .expect("stdin-capable delivered command should build");
+
+    assert_eq!(delivered.selected_mode, DeliveryMode::Stdin);
+    assert_eq!(
+        delivered.stdin_payload.as_deref(),
+        Some(prompt.as_bytes()),
+        "stdin mode must expose the exact payload bytes for the Tokio spawn path"
+    );
+
+    let result = run_delivered_command_for_test(delivered, Duration::from_secs(5))
+        .await
+        .expect("cat should exit after stdin is closed");
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.output, prompt);
+}
+
+#[tokio::test]
+async fn tokio_tempfile_delivery_keeps_handle_alive_until_after_wait() {
+    let prompt = synthetic_prompt();
+    let delivered = build_command_with_prompt_delivery(
+        "cat",
+        std::iter::empty::<&str>(),
+        &prompt,
+        PromptDelivery::Tempfile,
+        DeliveryCaps::argv_and_tempfile(""),
+    )
+    .expect("tempfile-capable delivered command should build");
+
+    let path = delivered
+        .delivery_handle
+        .tempfile_path()
+        .expect("tempfile mode must expose a path")
+        .to_path_buf();
+    assert!(path.exists(), "tempfile must exist before spawn");
+
+    let result = run_delivered_command_for_test(delivered, Duration::from_secs(5))
+        .await
+        .expect("cat should read the tempfile before the handle is dropped");
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.output, prompt);
+    assert!(
+        !path.exists(),
+        "orchestration must drop the DeliveryHandle only after the child exits"
+    );
+}
+
+#[tokio::test]
+async fn process_runner_uses_delivery_path_for_large_delegate_prompt() {
+    let runner = TokioProcessRunner::new();
+    let prompt = synthetic_prompt();
+
+    let result = runner
+        .run_with_prompt_delivery_for_test(
+            RunOptions {
+                prompt: prompt.clone(),
+                process_id: "prompt-delivery-lifecycle".to_string(),
+                timeout: Some(Duration::from_secs(5)),
+                model: None,
+                working_dir: Some(Path::new("/tmp").to_path_buf()),
+            },
+            PromptDelivery::Auto,
+            DeliveryCaps {
+                supports_argv: true,
+                supports_tempfile: false,
+                supports_stdin: true,
+                tempfile_flag: None,
+            },
+            "cat",
+            std::iter::empty::<&str>(),
+        )
+        .await;
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.output, prompt);
+}

--- a/crates/amplihack-utils/src/prompt_delivery.rs
+++ b/crates/amplihack-utils/src/prompt_delivery.rs
@@ -212,11 +212,7 @@ pub fn select_mode(
                 DeliveryMode::Stdin
             } else {
                 tracing::warn!("stdin mode unsupported by binary capabilities; degrading");
-                if caps.supports_tempfile {
-                    DeliveryMode::Tempfile
-                } else {
-                    DeliveryMode::Argv
-                }
+                DeliveryMode::Argv
             }
         }
     }

--- a/crates/amplihack-utils/tests/prompt_delivery.rs
+++ b/crates/amplihack-utils/tests/prompt_delivery.rs
@@ -195,6 +195,24 @@ fn explicit_env_with_unsupported_mode_degrades_deterministically() {
     );
 }
 
+#[test]
+fn explicit_stdin_request_degrades_directly_to_argv_not_tempfile() {
+    let caps = DeliveryCaps {
+        supports_argv: true,
+        supports_tempfile: true,
+        supports_stdin: false,
+        tempfile_flag: Some("--prompt-file"),
+    };
+
+    let mode = select_mode(PromptDelivery::Stdin, 64 * 1024, &caps);
+
+    assert_eq!(
+        mode,
+        DeliveryMode::Argv,
+        "explicit Stdin on a binary without a verified stdin contract must degrade directly to Argv; it must not switch prompt roles by falling back to Tempfile"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 7. invalid_env_value_warns_and_defaults_to_auto
 // ---------------------------------------------------------------------------

--- a/docs/amplihack-rs-parity.md
+++ b/docs/amplihack-rs-parity.md
@@ -1,0 +1,353 @@
+---
+title: "amplihack-rs Parity Reference"
+description: "Rust parity reference for subprocess prompt delivery across Claude, Copilot, Codex, and Amplifier launch paths."
+last_updated: 2026-06-05
+review_schedule: quarterly
+owner: rysweet
+doc_type: reference
+---
+
+# amplihack-rs Parity Reference
+
+This reference describes Rust subprocess prompt delivery parity for `amplihack`
+launcher, orchestration, auto-mode, and doctor surfaces.
+
+## Contents
+
+- [Subprocess prompt delivery](#subprocess-prompt-delivery)
+- [Configuration](#configuration)
+- [Binary capability matrix](#binary-capability-matrix)
+- [Mode selection](#mode-selection)
+- [Usage examples](#usage-examples)
+- [Rust API](#rust-api)
+- [Doctor reporting](#doctor-reporting)
+- [Regression contract](#regression-contract)
+- [Security and lifecycle guarantees](#security-and-lifecycle-guarantees)
+- [Troubleshooting](#troubleshooting)
+
+## Subprocess prompt delivery
+
+amplihack-rs routes prompt-bearing subprocess launches through
+`amplihack-utils::prompt_delivery`. The delivery engine supports three concrete
+prompt channels:
+
+| Mode | Behavior | Primary use |
+| --- | --- | --- |
+| `argv` | Appends the prompt as one structured process argument. | Short prompts and binaries with no long-form prompt channel. |
+| `tempfile` | Writes the prompt to a restricted temporary file and passes the file path using the binary's verified prompt-file contract. | Long prompts when the target binary supports prompt files. |
+| `stdin` | Pipes the prompt to child stdin, then closes stdin before waiting for the child. | Long prompts when the target binary supports prompt input from stdin. |
+
+The Rust launcher, orchestration, and auto-mode paths use the same selector and
+capability metadata. A long prompt is not manually shell-escaped or interpolated
+into a shell command string.
+
+### Parity status
+
+| Parity area | Rust behavior |
+| --- | --- |
+| Subprocess prompt delivery | `argv`, `tempfile`, and `stdin` are selected through `amplihack-utils::prompt_delivery` using static per-binary capabilities. Unsupported explicit `tempfile` requests degrade to `stdin` when supported, otherwise `argv`. Unsupported explicit `stdin` requests degrade directly to `argv`. |
+
+## Configuration
+
+Set `AMPLIHACK_PROMPT_DELIVERY` to choose the requested prompt delivery mode.
+This setting applies to migrated subprocess launch paths.
+
+```bash
+# Default: choose the safest supported channel for the target binary and prompt size.
+unset AMPLIHACK_PROMPT_DELIVERY
+amplihack claude -- "Summarize this repository"
+
+# Request prompt-file delivery when the selected binary supports it.
+AMPLIHACK_PROMPT_DELIVERY=tempfile \
+  amplihack claude -- "Review this 64 KiB prompt without shell parsing"
+
+# Request stdin delivery once the selected binary has a verified stdin contract.
+AMPLIHACK_PROMPT_DELIVERY=stdin \
+  amplihack codex -- "Analyze this generated task description"
+
+# Force argv delivery for compatibility diagnostics.
+AMPLIHACK_PROMPT_DELIVERY=argv \
+  amplihack copilot -- "Short prompt"
+```
+
+### `AMPLIHACK_PROMPT_DELIVERY`
+
+| Value | Meaning |
+| --- | --- |
+| unset, empty, or `auto` | Use automatic mode selection. |
+| `argv` | Request structured argv delivery. |
+| `tempfile` | Request temporary-file delivery. |
+| `stdin` | Request stdin delivery. |
+
+Values are case-insensitive. Unknown values resolve to `auto` and emit a
+warning. The environment variable is a request, not a capability override: a
+binary only uses `tempfile` or `stdin` when the launcher has a verified contract
+for that binary.
+
+## Binary capability matrix
+
+Capabilities are static launcher metadata, not user-controlled configuration.
+Tempfile and stdin support are only marked when the binary has a verified
+task-prompt contract for that channel.
+
+| Binary | `argv` | `tempfile` | Tempfile flag | `stdin` | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Claude Code | Supported | Pending verification | None for task prompts | Unsupported | `--append-system-prompt` is a system-prompt file contract. It must not be used for task-prompt delivery unless the implementation intentionally changes prompt role and documents that role change. Until a verified task-prompt file contract exists, Claude task prompts remain on `argv`. |
+| GitHub Copilot CLI | Supported | Unsupported | None | Unsupported | Copilot receives prompts through argv because no verified prompt-file or stdin prompt contract is advertised. |
+| Codex | Supported | Unsupported | None | Pending verification | Codex stdin delivery requires a named, tested command contract that reads the task prompt from stdin. Until that contract is verified, Codex task prompts remain on `argv`. |
+| Microsoft Amplifier | Supported | Unsupported | None | Unsupported | Amplifier is routed through `prompt_delivery`, but tempfile and stdin remain unsupported until Amplifier exposes a verified contract. |
+
+When a future binary version adds a prompt-file or stdin contract, update
+`crates/amplihack-launcher/src/flag_matrix.rs` first, then update this table.
+
+## Mode selection
+
+`prompt_delivery` resolves a requested mode into an effective mode using the
+prompt size and the selected binary's capabilities.
+
+| Requested mode | Selection rule |
+| --- | --- |
+| `auto` | Use `argv` for prompts at or below 4096 bytes when supported. For larger prompts, prefer `tempfile`, then `stdin`, then `argv`. |
+| `argv` | Use `argv` when supported; otherwise degrade to `tempfile`, then `stdin`, then `argv`. |
+| `tempfile` | Use `tempfile` when supported; otherwise degrade to `stdin`, then `argv`. |
+| `stdin` | Use `stdin` when supported; otherwise degrade directly to `argv`. Do not degrade an explicit stdin request to tempfile, because stdin and prompt-file delivery have different process contracts. |
+
+Every unsupported explicit-mode degradation emits a warning that names the
+requested mode and the effective mode. The warning does not include the raw
+prompt, temporary-file contents, or stdin payload.
+
+## Usage examples
+
+### Send a long prompt safely through auto mode
+
+Create a long prompt and let amplihack choose the safest supported delivery
+channel for the child binary.
+
+```bash
+python3 - <<'PY' > /tmp/amplihack-long-prompt.txt
+print("Review this text safely: " + ("don't shell-expand $HOME; " * 4096))
+PY
+
+AMPLIHACK_PROMPT_DELIVERY=auto \
+  amplihack claude -- "$(cat /tmp/amplihack-long-prompt.txt)"
+```
+
+This shell form still passes the prompt to the parent `amplihack` process as one
+argv element. The parity guarantee in this document applies to the child agent
+subprocess launched by amplihack. Until Claude has a verified task-prompt
+tempfile contract, the effective child delivery mode for Claude is `argv`.
+
+### Diagnose unsupported requested modes
+
+Requesting tempfile delivery for a binary without a verified tempfile contract
+degrades safely.
+
+```bash
+AMPLIHACK_PROMPT_DELIVERY=tempfile \
+  amplihack copilot -- "Explain the current branch"
+```
+
+Copilot CLI has no verified tempfile flag, so the effective mode is `argv` and a
+warning is emitted. The prompt is still passed as a structured argv element; it
+is not shell-interpolated.
+
+### Use prompt delivery in auto-mode
+
+Auto-mode uses the same prompt delivery path as ordinary launcher execution.
+
+```bash
+AMPLIHACK_PROMPT_DELIVERY=auto \
+  amplihack auto --agent claude --task "$(cat /tmp/amplihack-long-prompt.txt)"
+```
+
+The `DeliveryHandle` returned by the prompt delivery engine is owned until the
+subprocess exits. For future verified tempfile contracts, that keeps the
+temporary prompt file available for the entire child lifetime.
+
+## Rust API
+
+The generic delivery engine lives in `amplihack-utils`. The low-level API exists
+for delivery mutation; launcher-level command building wraps it with binary
+capability metadata.
+
+```rust
+use std::process::Command;
+
+use amplihack_utils::prompt_delivery::{
+    DeliveryCaps, DeliveryHandle, DeliveryMode, PromptDelivery, deliver, from_env,
+};
+
+fn build_command(prompt: &str) -> std::io::Result<(Command, DeliveryHandle)> {
+    let mut cmd = Command::new("claude");
+    let requested = from_env();
+    let caps = DeliveryCaps::argv_only();
+    let handle = deliver(&mut cmd, prompt, requested, &caps)?;
+    Ok((cmd, handle))
+}
+```
+
+### Public types
+
+| Type | Purpose |
+| --- | --- |
+| `PromptDelivery` | Caller-requested mode: `Auto`, `Argv`, `Tempfile`, or `Stdin`. |
+| `DeliveryMode` | Effective mode selected after applying capabilities and degradation rules. |
+| `DeliveryCaps` | Per-binary capability descriptor for argv, tempfile, stdin, and tempfile flag support. |
+| `DeliveryHandle` | RAII owner for delivery resources. Keep it alive until the child process has exited. |
+
+### Public functions
+
+| Function | Purpose |
+| --- | --- |
+| `from_env()` | Parses `AMPLIHACK_PROMPT_DELIVERY` and returns a `PromptDelivery` request. |
+| `select_mode(requested, prompt_size, caps)` | Resolves a requested mode to an effective `DeliveryMode`. |
+| `deliver(cmd, prompt, requested, caps)` | Mutates a structured `std::process::Command` for the effective delivery mode and returns a `DeliveryHandle`. |
+
+### Launcher API
+
+Launcher command builders will expose delivery-aware construction instead of
+pushing prompt strings directly into argv.
+
+```rust
+use amplihack_launcher::flag_matrix::AgentBinary;
+use amplihack_launcher::prompt_delivery::build_tool_command_with_prompt_delivery;
+use amplihack_utils::prompt_delivery::PromptDelivery;
+
+let delivered = build_tool_command_with_prompt_delivery(
+    AgentBinary::Claude,
+    std::env::current_dir()?.as_path(),
+    &[],
+    "Summarize this repository",
+    PromptDelivery::Auto,
+)?;
+
+let mut child = delivered.command.spawn()?;
+let status = child.wait()?;
+drop(delivered.delivery_handle);
+```
+
+The `DeliveredCommand` shape is:
+
+| Field | Meaning |
+| --- | --- |
+| `command` | Structured `std::process::Command` with prompt delivery applied. |
+| `delivery_handle` | RAII handle that owns tempfile resources or marks stdin ownership. |
+| `requested_mode` | Mode requested by configuration. |
+| `effective_mode` | Mode actually selected for the target binary. |
+| `warnings` | Deterministic degradation or invalid-configuration warnings safe for logs. |
+| `stdin_payload` | Prompt bytes to write when the effective mode is `stdin`; absent for `argv` and `tempfile`. |
+
+### Async orchestration contract
+
+Async orchestration builds a `std::process::Command`, applies
+`prompt_delivery::deliver`, then convert the command to `tokio::process::Command`
+for spawning. It does not duplicate delivery selection logic.
+
+When the effective mode is `stdin`, orchestration writes the complete prompt to
+child stdin, flushes it, drops stdin to close the pipe, then awaits child exit.
+The `DeliveryHandle` remains owned until after `wait` completes.
+
+## Doctor reporting
+
+`amplihack doctor` reports prompt delivery diagnostics without printing prompt
+contents.
+
+```bash
+AMPLIHACK_PROMPT_DELIVERY=tempfile amplihack doctor
+```
+
+Example output:
+
+```text
+Prompt delivery
+  requested: tempfile
+  auto threshold: 4096 bytes
+
+  claude
+    capabilities: argv
+    note: task-prompt tempfile support pending verified Claude contract
+    effective for long prompt: argv
+
+  copilot
+    capabilities: argv
+    effective for long prompt: argv
+    warning: requested tempfile is unsupported; degrading to argv
+
+  codex
+    capabilities: argv
+    note: stdin support pending verified Codex command contract
+    effective for long prompt: argv
+    warning: requested tempfile is unsupported; degrading to argv
+
+  amplifier
+    capabilities: argv
+    effective for long prompt: argv
+    warning: requested tempfile is unsupported; degrading to argv
+```
+
+Doctor diagnostics are deterministic:
+
+- they list the requested mode,
+- they list static capabilities per binary,
+- they show the effective mode for a long prompt,
+- they show degradation warnings when a requested mode is unsupported,
+- they never include raw prompt data.
+
+## Regression contract
+
+Prompt delivery behavior is defined by these externally visible contracts:
+
+| Contract | Required behavior |
+| --- | --- |
+| Long prompt privacy | For every migrated command builder with a verified long-form mode, a raw 64 KiB prompt containing apostrophes is absent from child argv when `auto`, `tempfile`, or `stdin` selects that long-form delivery mode. Binaries with only `argv` support are explicitly exempt and must still pass the prompt as one structured argv element. |
+| Prompt fidelity | The same 64 KiB apostrophe-containing prompt round-trips unchanged through the selected delivery channel. |
+| Structured argv safety | When `argv` is selected, the prompt is passed as one argv element. Apostrophes, quotes, semicolons, dollar signs, and shell metacharacters are not interpreted by a shell. |
+| Unsupported tempfile request | A requested `tempfile` mode degrades to `stdin` when supported, otherwise to `argv`, and emits a warning. |
+| Unsupported stdin request | A requested `stdin` mode degrades directly to `argv` and emits a warning. It does not degrade to `tempfile`. |
+| Tempfile lifetime | Tempfile prompts remain readable until the child process exits and are unlinked when the `DeliveryHandle` is dropped. |
+| Stdin lifecycle | Stdin payloads are written completely, flushed, and closed before the child is awaited. |
+| Diagnostics safety | Doctor output, logs, and warnings include modes, capabilities, and degradation messages, but never include raw prompt bytes. |
+
+## Security and lifecycle guarantees
+
+Prompt delivery follows these guarantees:
+
+| Guarantee | Detail |
+| --- | --- |
+| No shell command construction | Prompts are passed through `Command` argv, restricted tempfiles, or child stdin. |
+| No prompt logging | Diagnostics and warnings describe modes and capabilities only. |
+| Restricted tempfiles | Tempfile prompts are created with owner-only permissions on Unix and are unlinked by RAII drop. |
+| Child-lifetime ownership | `DeliveryHandle` lives until the child exits, preventing premature tempfile deletion. |
+| Closed stdin | Stdin payloads are written, flushed, and closed before waiting, preventing deadlocks. |
+| Static capabilities | Users cannot force an unsupported binary to claim tempfile or stdin support. |
+| Deterministic degradation | Unsupported modes always degrade through the documented order with warnings. |
+
+## Troubleshooting
+
+### A requested mode is not used
+
+Run doctor with the same environment:
+
+```bash
+AMPLIHACK_PROMPT_DELIVERY=tempfile amplihack doctor
+```
+
+If the selected binary lists only `argv`, the requested long-form mode is not
+available for that binary. Use a binary with a verified long-form prompt contract
+or leave `AMPLIHACK_PROMPT_DELIVERY=auto`.
+
+### A long prompt still appears in argv
+
+Check the binary capability row in doctor output. Long prompts remain in child
+argv when the target binary has no verified `tempfile` or `stdin` task-prompt
+contract.
+
+### A tempfile prompt disappears before the child reads it
+
+Keep the returned `DeliveryHandle` alive until after the child process has been
+waited on. Dropping the handle unlinks the tempfile.
+
+### A stdin-launched child hangs
+
+Write the full stdin payload, flush it, then drop the stdin handle before
+awaiting process exit. Holding stdin open can make the child wait for more input.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -38,4 +38,4 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 
 ## Additional Features
 
-Additional feature documentation will be added as features are ported from upstream.
+- [amplihack-rs Parity Reference](../amplihack-rs-parity.md) - subprocess prompt delivery configuration, binary capability matrix, doctor diagnostics, and Rust API.

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,9 @@ amplihack copilot
 | Workflows           | ✅ All      | ✅ All    | ✅ All      | ⚠️ Limited |
 | Auto Mode           | ✅ Yes      | ✅ Yes    | ✅ Yes      | ⚠️ Limited |
 
+See [amplihack-rs parity](amplihack-rs-parity.md) for subprocess
+prompt delivery support across Claude Code, Amplifier, Copilot CLI, and Codex.
+
 **New to amplihack?** After launching, try the interactive tutorial:
 
 ```
@@ -176,6 +179,7 @@ Understand the philosophy and architecture behind amplihack.
 - [Enable Blarify Code Indexing](howto/enable-blarify.md) - `AMPLIHACK_ENABLE_BLARIFY`, non-interactive skip, staleness detection
 - [Blarify Architecture](blarify_architecture.md) - Understanding the Blarify integration
 - [Documentation Knowledge Graph](documentation_knowledge_graph.md) - How docs connect
+- [amplihack-rs Parity Reference](amplihack-rs-parity.md) - Subprocess prompt delivery capabilities, configuration, diagnostics, and Rust API
 
 ### Key Features
 


### PR DESCRIPTION
## Summary\n- Routes launcher, orchestration, and auto-mode prompt-bearing subprocesses through shared Rust prompt_delivery selection and capability metadata.\n- Adds deterministic doctor diagnostics for requested/effective prompt delivery modes and per-binary capabilities.\n- Adds regression coverage for argv/tempfile/stdin selection, 64 KiB apostrophe payload round-trips, async DeliveryHandle lifetime, stdin write/flush/close, auto-mode, and doctor output.\n- Documents subprocess prompt delivery parity in docs/amplihack-rs-parity.md.\n\n## Capability decisions\n- Claude, Copilot, Codex, and Amplifier are marked argv-only for task prompts until verified tempfile/stdin task-prompt contracts exist.\n- Unsupported explicit tempfile requests degrade deterministically to argv for current binaries.\n- Unsupported explicit stdin requests degrade directly to argv.\n- Amplifier is migrated through prompt_delivery as argv-only; follow-up for long-form Amplifier support filed as #709.\n\nCloses #652.\n\n## Validation\n- cargo fmt --all\n- cargo clippy --all-targets -- -D warnings\n- cargo test -p amplihack-utils --test prompt_delivery --quiet\n- cargo test -p amplihack-launcher --test prompt_delivery --quiet\n- cargo test -p amplihack-orchestration --test prompt_delivery_lifecycle --quiet\n- cargo test -p amplihack-orchestration --test prompt_delivery_apostrophes --quiet\n- cargo test -p amplihack-cli --test doctor_prompt_delivery --quiet\n- cargo test -p amplihack-cli --test auto_mode_prompt_delivery --quiet\n- CARGO_TARGET_DIR=/tmp/amplihack-rs-target-issue652 cargo test --workspace -- --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu\n\nNote: the first workspace run using the default target directory failed because /home had only ~2 GiB available and a nested smoke-test build hit ENOSPC. Rerunning with CARGO_TARGET_DIR on /tmp, which had sufficient space, passed.

## Step 13: Local Testing Results

### Scenario 1 — Auto prompt-delivery diagnostics are visible to users
Command: `AMPLIHACK_UVX_CACHE=/tmp/amplihack-uvx-issue652-step13 AMPLIHACK_PROMPT_DELIVERY=auto uvx --from git+https://github.com/rysweet/amplihack-rs.git@refs/pull/711/head amplihack doctor`
Result: PASS
Output:
```text
✓ Prompt delivery
  requested: auto
  auto threshold: 4096 bytes
  claude
    capabilities: argv
    effective for long prompt: argv
  copilot
    capabilities: argv
    effective for long prompt: argv
  codex
    capabilities: argv
    effective for long prompt: argv
  amplifier
    capabilities: argv
    effective for long prompt: argv
```
Note: command exit was 1 because this local host lacks amplihack hooks in settings.json; the prompt-delivery diagnostic check itself passed and emitted the expected user-facing output from the PR build.

### Scenario 2 — Tempfile prompt-delivery request degrades safely to argv
Command: `AMPLIHACK_UVX_CACHE=/tmp/amplihack-uvx-issue652-step13 AMPLIHACK_PROMPT_DELIVERY=tempfile uvx --from git+https://github.com/rysweet/amplihack-rs.git@refs/pull/711/head amplihack doctor`
Result: PASS
Output:
```text
✓ Prompt delivery
  requested: tempfile
  auto threshold: 4096 bytes
  claude
    capabilities: argv
    effective for long prompt: argv
    warning: requested tempfile is unsupported; degrading to argv
  copilot
    capabilities: argv
    effective for long prompt: argv
    warning: requested tempfile is unsupported; degrading to argv
  codex
    capabilities: argv
    effective for long prompt: argv
    warning: requested tempfile is unsupported; degrading to argv
  amplifier
    capabilities: argv
    effective for long prompt: argv
    warning: requested tempfile is unsupported; degrading to argv
```
Note: command exit was 1 because this local host lacks amplihack hooks in settings.json; the prompt-delivery diagnostic check itself passed. Output was also checked to ensure raw prompt material/tempfile path markers were not leaked.
