### PR TITLE
refactor: share bundle asset named mappings

### DIFF
--- a/bins/amplihack-asset-resolver/src/main.rs
+++ b/bins/amplihack-asset-resolver/src/main.rs
@@ -11,7 +11,8 @@ fn main() {
         eprintln!("Usage: amplihack-asset-resolver <asset>");
         eprintln!("  <asset> is either:");
         eprintln!(
-            "    - a named asset: hooks-dir, helper-path, session-tree-path, multitask-orchestrator"
+            "    - a named asset: {}",
+            resolve_bundle_asset::named_asset_names()
         );
         eprintln!("    - a relative path starting with 'amplifier-bundle/'");
         std::process::exit(2);

--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -106,7 +106,11 @@ pub fn resolve_asset(relative_path: &str) -> Result<PathBuf> {
 /// 3. Walk up from cwd for a repo/project root marker
 /// 4. Workspace root (compile-time anchor)
 /// 5. cwd
-fn named_asset_names() -> String {
+pub fn named_asset_relative_paths() -> &'static [(&'static str, &'static [&'static str])] {
+    NAMED_ASSETS
+}
+
+pub fn named_asset_names() -> String {
     NAMED_ASSETS
         .iter()
         .map(|(n, _)| *n)
@@ -115,7 +119,7 @@ fn named_asset_names() -> String {
 }
 
 pub fn resolve_named_asset(name: &str) -> Result<PathBuf> {
-    let rel_paths = NAMED_ASSETS
+    let rel_paths = named_asset_relative_paths()
         .iter()
         .find(|(n, _)| *n == name)
         .map(|(_, paths)| *paths)
@@ -160,7 +164,10 @@ fn resolve_result_to_exit(result: Result<PathBuf>) -> i32 {
 
 pub fn run_cli(arg: &str) -> i32 {
     // Dispatch named assets (e.g. "multitask-orchestrator")
-    if NAMED_ASSETS.iter().any(|(name, _)| *name == arg) {
+    if named_asset_relative_paths()
+        .iter()
+        .any(|(name, _)| *name == arg)
+    {
         return resolve_result_to_exit(resolve_named_asset(arg));
     }
 

--- a/crates/amplihack-cli/src/runtime_assets.rs
+++ b/crates/amplihack-cli/src/runtime_assets.rs
@@ -8,25 +8,16 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
 
+use crate::resolve_bundle_asset;
+
 /// Well-known asset relative paths keyed by logical asset name.
 ///
 /// Each asset name maps to one or more candidate relative paths tried in order.
 pub fn asset_relative_paths() -> HashMap<&'static str, Vec<&'static str>> {
-    let mut m = HashMap::new();
-    m.insert("hooks-dir", vec!["amplifier-bundle/tools/amplihack/hooks"]);
-    m.insert(
-        "helper-path",
-        vec!["amplifier-bundle/bin/multitask-orchestrator.sh"],
-    );
-    m.insert(
-        "session-tree-path",
-        vec!["amplifier-bundle/tools/amplihack/session"],
-    );
-    m.insert(
-        "multitask-orchestrator",
-        vec!["amplifier-bundle/bin/multitask-orchestrator.sh"],
-    );
-    m
+    resolve_bundle_asset::named_asset_relative_paths()
+        .iter()
+        .map(|(name, paths)| (*name, (*paths).to_vec()))
+        .collect()
 }
 
 /// Iterate candidate runtime root directories.


### PR DESCRIPTION
## Summary
- expose the active `resolve-bundle-asset` named asset table for reuse
- derive the legacy `runtime_assets` helper map from that table
- derive standalone `amplihack-asset-resolver` usage text from the same source

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 cargo fmt --check`
- `RUSTFLAGS='-D warnings' NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli --test issue_634_asset_resolution_parity -- --nocapture`
- `NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli runtime_assets -- --nocapture`
- `NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli resolve_bundle_asset -- --nocapture`
- `NODE_OPTIONS=--max-old-space-size=32768 cargo run -q -p amplihack-asset-resolver-bin --`

Follow-up simplification after #708 / #634 closure; does not change the runtime parity contract.