### PR TITLE
perf: reduce runtime asset lookup allocations

### DIFF
--- a/bins/amplihack-asset-resolver/src/main.rs
+++ b/bins/amplihack-asset-resolver/src/main.rs
@@ -6,17 +6,17 @@ fn main() {
         .with_target(false)
         .init();
 
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() != 2 {
-        eprintln!("Usage: amplihack-asset-resolver <asset>");
-        eprintln!("  <asset> is either:");
-        eprintln!(
-            "    - a named asset: {}",
-            resolve_bundle_asset::named_asset_names()
-        );
-        eprintln!("    - a relative path starting with 'amplifier-bundle/'");
-        std::process::exit(2);
-    }
+    let mut args = std::env::args();
+    let _program = args.next();
 
-    std::process::exit(resolve_bundle_asset::run_cli(&args[1]));
+    match (args.next(), args.next()) {
+        (Some(asset), None) => std::process::exit(resolve_bundle_asset::run_cli(&asset)),
+        _ => {
+            eprintln!(
+                "{}",
+                resolve_bundle_asset::usage_text("amplihack-asset-resolver")
+            );
+            std::process::exit(2);
+        }
+    }
 }

--- a/bins/amplihack-asset-resolver/tests/usage.rs
+++ b/bins/amplihack-asset-resolver/tests/usage.rs
@@ -1,0 +1,25 @@
+//! TDD contracts for standalone resolver usage output.
+//!
+//! The binary should not maintain its own named-asset list. Its no-argument
+//! usage text must reflect the CLI library's canonical name helper.
+
+use std::process::Command;
+
+use amplihack_cli::resolve_bundle_asset;
+
+#[test]
+fn no_argument_usage_lists_canonical_named_assets() {
+    let output = Command::new(env!("CARGO_BIN_EXE_amplihack-asset-resolver"))
+        .output()
+        .expect("run amplihack-asset-resolver without args");
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8(output.stderr).expect("usage stderr is utf-8");
+    let canonical_names = resolve_bundle_asset::named_asset_names().join(", ");
+
+    assert!(
+        stderr.contains(&format!("    - a named asset: {canonical_names}")),
+        "standalone resolver usage must derive supported names from the CLI library; stderr was:\n{stderr}"
+    );
+}

--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -16,7 +16,7 @@ fn is_safe_path_char(ch: char) -> bool {
 /// Named asset mappings for runtime bundle assets.
 ///
 /// Each entry is `(name, &[relative_paths])` where relative_paths are tried in order.
-const NAMED_ASSETS: &[(&str, &[&str])] = &[
+const NAMED_ASSETS: [(&str, &[&str]); 4] = [
     // hooks/ dir — native Rust hooks binary reads config from here.
     ("hooks-dir", &["amplifier-bundle/tools/amplihack/hooks"]),
     // helper-path — orchestration helper script. The Python orch_helper.py
@@ -106,16 +106,23 @@ pub fn resolve_asset(relative_path: &str) -> Result<PathBuf> {
 /// 3. Walk up from cwd for a repo/project root marker
 /// 4. Workspace root (compile-time anchor)
 /// 5. cwd
-pub fn named_asset_relative_paths() -> &'static [(&'static str, &'static [&'static str])] {
+pub fn named_asset_relative_paths() -> [(&'static str, &'static [&'static str]); 4] {
     NAMED_ASSETS
 }
 
-pub fn named_asset_names() -> String {
-    NAMED_ASSETS
-        .iter()
-        .map(|(n, _)| *n)
-        .collect::<Vec<_>>()
-        .join(", ")
+pub fn named_asset_names() -> [&'static str; 4] {
+    NAMED_ASSETS.map(|(name, _)| name)
+}
+
+fn named_asset_names_csv() -> String {
+    named_asset_names().join(", ")
+}
+
+pub fn usage_text(program_name: &str) -> String {
+    format!(
+        "Usage: {program_name} <asset>\n  <asset> is either:\n    - a named asset: {}\n    - a relative path starting with 'amplifier-bundle/'",
+        named_asset_names_csv()
+    )
 }
 
 pub fn resolve_named_asset(name: &str) -> Result<PathBuf> {
@@ -126,7 +133,7 @@ pub fn resolve_named_asset(name: &str) -> Result<PathBuf> {
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "Unknown asset name {name:?}. Expected one of: {}",
-                named_asset_names()
+                named_asset_names_csv()
             )
         })?;
 
@@ -177,7 +184,7 @@ pub fn run_cli(arg: &str) -> i32 {
     if !arg.contains('/') {
         eprintln!(
             "ERROR: Unknown asset name {arg:?}. Expected one of: {}",
-            named_asset_names()
+            named_asset_names_csv()
         );
         return 1;
     }

--- a/crates/amplihack-cli/src/runtime_assets.rs
+++ b/crates/amplihack-cli/src/runtime_assets.rs
@@ -15,9 +15,16 @@ use crate::resolve_bundle_asset;
 /// Each asset name maps to one or more candidate relative paths tried in order.
 pub fn asset_relative_paths() -> HashMap<&'static str, Vec<&'static str>> {
     resolve_bundle_asset::named_asset_relative_paths()
-        .iter()
-        .map(|(name, paths)| (*name, (*paths).to_vec()))
+        .into_iter()
+        .map(|(name, paths)| (name, paths.to_vec()))
         .collect()
+}
+
+fn relative_paths_for(asset_name: &str) -> Option<&'static [&'static str]> {
+    resolve_bundle_asset::named_asset_relative_paths()
+        .into_iter()
+        .find(|(name, _)| *name == asset_name)
+        .map(|(_, paths)| paths)
 }
 
 /// Iterate candidate runtime root directories.
@@ -74,9 +81,7 @@ pub fn iter_runtime_roots() -> Vec<PathBuf> {
 ///
 /// Tries each relative path variant under each root in order.
 pub fn resolve_asset_path(asset_name: &str, search_roots: &[PathBuf]) -> Result<PathBuf> {
-    let asset_map = asset_relative_paths();
-    let rel_paths = asset_map
-        .get(asset_name)
+    let rel_paths = relative_paths_for(asset_name)
         .with_context(|| format!("unknown asset name: {asset_name}"))?;
 
     for root in search_roots {

--- a/crates/amplihack-cli/tests/pr_712_named_asset_canonicalization.rs
+++ b/crates/amplihack-cli/tests/pr_712_named_asset_canonicalization.rs
@@ -1,0 +1,146 @@
+//! TDD contracts for PR #712 named asset mapping centralization.
+//!
+//! These tests protect the canonical helper API and ensure runtime consumers
+//! delegate to the ordered mapping helpers instead of duplicating asset names.
+
+use amplihack_cli::{resolve_bundle_asset, runtime_assets};
+
+const EXPECTED_NAMES: &[&str] = &[
+    "hooks-dir",
+    "helper-path",
+    "session-tree-path",
+    "multitask-orchestrator",
+];
+
+const EXPECTED_MAPPINGS: &[(&str, &[&str])] = &[
+    ("hooks-dir", &["amplifier-bundle/tools/amplihack/hooks"]),
+    (
+        "helper-path",
+        &["amplifier-bundle/bin/multitask-orchestrator.sh"],
+    ),
+    (
+        "session-tree-path",
+        &["amplifier-bundle/tools/amplihack/session"],
+    ),
+    (
+        "multitask-orchestrator",
+        &["amplifier-bundle/bin/multitask-orchestrator.sh"],
+    ),
+];
+
+#[test]
+fn canonical_named_asset_table_is_ordered_complete_and_read_only() {
+    assert_eq!(
+        resolve_bundle_asset::named_asset_relative_paths(),
+        EXPECTED_MAPPINGS,
+        "canonical named asset table must be the single ordered source of truth"
+    );
+}
+
+#[test]
+fn canonical_named_asset_names_are_derived_in_table_order() {
+    assert_eq!(
+        resolve_bundle_asset::named_asset_names(),
+        EXPECTED_NAMES,
+        "name listing must be derived from canonical mapping order"
+    );
+}
+
+#[test]
+fn runtime_assets_named_mapping_matches_canonical_table_exactly() {
+    let runtime_map = runtime_assets::asset_relative_paths();
+    let canonical = resolve_bundle_asset::named_asset_relative_paths();
+
+    assert_eq!(
+        runtime_map.len(),
+        canonical.len(),
+        "runtime_assets must not add or omit named assets"
+    );
+
+    for (name, relative_paths) in canonical {
+        assert_eq!(
+            runtime_map.get(name).map(Vec::as_slice),
+            Some(relative_paths),
+            "runtime_assets mapping for {name} must delegate to the canonical table"
+        );
+    }
+}
+
+#[test]
+fn session_tree_path_is_covered_by_every_named_asset_surface() {
+    assert!(
+        resolve_bundle_asset::named_asset_names().contains(&"session-tree-path"),
+        "session-tree-path must remain in generated supported-name lists"
+    );
+    assert_eq!(
+        resolve_bundle_asset::named_asset_relative_paths()
+            .iter()
+            .find(|(name, _)| *name == "session-tree-path")
+            .map(|(_, paths)| *paths),
+        Some(["amplifier-bundle/tools/amplihack/session"].as_slice()),
+        "session-tree-path must resolve to the legacy session anchor"
+    );
+    assert_eq!(
+        runtime_assets::asset_relative_paths()
+            .get("session-tree-path")
+            .map(Vec::as_slice),
+        Some(["amplifier-bundle/tools/amplihack/session"].as_slice()),
+        "runtime compatibility lookup must include session-tree-path"
+    );
+}
+
+#[test]
+fn unknown_named_asset_error_uses_canonical_name_order() {
+    let message = resolve_bundle_asset::resolve_named_asset("legacy-python-helper")
+        .expect_err("unknown named asset must fail")
+        .to_string();
+
+    assert_eq!(
+        message,
+        format!(
+            "Unknown asset name \"legacy-python-helper\". Expected one of: {}",
+            EXPECTED_NAMES.join(", ")
+        ),
+        "unknown-name diagnostics must be generated from canonical names"
+    );
+    assert_eq!(
+        resolve_bundle_asset::run_cli("legacy-python-helper"),
+        1,
+        "single-token unknown asset names must remain a not-found condition"
+    );
+}
+
+#[test]
+fn docs_named_asset_table_matches_canonical_names_and_paths() {
+    let docs = include_str!("../../../docs/reference/resolve-bundle-asset-command.md");
+
+    for (name, relative_paths) in resolve_bundle_asset::named_asset_relative_paths() {
+        for relative_path in relative_paths {
+            assert!(
+                docs.contains(&format!("| `{name}` | `{relative_path}` |")),
+                "docs must list canonical mapping {name} -> {relative_path}"
+            );
+        }
+    }
+}
+
+#[test]
+fn named_asset_lookup_remains_exact_static_name_only() {
+    for invalid_name in [
+        " helper-path",
+        "helper-path ",
+        "HELPER-PATH",
+        "helper-path/..",
+        "../helper-path",
+        "$helper-path",
+        "/helper-path",
+    ] {
+        let message = resolve_bundle_asset::resolve_named_asset(invalid_name)
+            .expect_err("invalid named asset form must not resolve")
+            .to_string();
+        assert!(
+            message.starts_with("Unknown asset name"),
+            "{invalid_name:?} must be rejected as an unknown exact name, got: {message}"
+        );
+    }
+}

--- a/docs/howto/verify-runtime-asset-resolution.md
+++ b/docs/howto/verify-runtime-asset-resolution.md
@@ -32,10 +32,10 @@ stale system binary appears first, repair the path order with
 
 ## Resolve every parity asset
 
-Run the fixed allowlist of runtime assets:
+Run the canonical ordered list of runtime assets:
 
 ```bash
-for asset in helper-path session-tree-path hooks-dir multitask-orchestrator; do
+for asset in hooks-dir helper-path session-tree-path multitask-orchestrator; do
   path="$(amplihack resolve-bundle-asset "$asset")"
   printf '%s -> %s\n' "$asset" "$path"
   test -e "$path"
@@ -45,9 +45,9 @@ done
 Expected output shape:
 
 ```text
+hooks-dir -> /home/alice/.amplihack/amplifier-bundle/tools/amplihack/hooks
 helper-path -> /home/alice/.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
 session-tree-path -> /home/alice/.amplihack/amplifier-bundle/tools/amplihack/session
-hooks-dir -> /home/alice/.amplihack/amplifier-bundle/tools/amplihack/hooks
 multitask-orchestrator -> /home/alice/.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh
 ```
 
@@ -91,11 +91,8 @@ amplihack-asset-resolver session-tree-path
 ```
 
 Both forms print the same absolute paths as `amplihack resolve-bundle-asset`.
-
-Some standalone `amplihack-asset-resolver` no-argument usage text may still
-list only `multitask-orchestrator` as the named-asset example. That help text
-is stale; the standalone resolver dispatches valid arguments through the same
-registered asset table used by `amplihack resolve-bundle-asset`.
+The standalone resolver also derives its no-argument usage text from the same
+Rust named-asset table, so usage output and accepted names stay in sync.
 
 ## Interpret failures
 
@@ -104,7 +101,6 @@ registered asset table used by `amplihack resolve-bundle-asset`.
 | `Unknown asset name` | The binary does not know the named asset. | Update `amplihack` and rerun `amplihack install`. |
 | `Bundle asset not found` | The name is registered, but the file or directory is missing from every runtime root. | Set `AMPLIHACK_HOME` to the installed bundle root or reinstall amplihack. |
 | Exit code `2` | The argument is an invalid relative path. | Use one of the named assets above or a safe `amplifier-bundle/...` path. |
-| Help text omits a valid asset | The help example is stale, not a resolver failure. | Use the named asset table in the reference as the source of truth. |
 
 ## Related
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -107,13 +107,22 @@ AMPLIHACK_AGENT_BINARY="../bin/evil" amplihack copilot
 **Example:** `/home/alice/.local/bin/amplihack-asset-resolver`
 **Set by:** `EnvBuilder::with_asset_resolver()`
 
-Absolute path to the native bundle-asset resolver. Child processes can execute this binary with a single relative asset path argument, for example:
+Absolute path to the native bundle-asset resolver. Child processes can execute
+this binary with a single supported named asset or relative asset path argument,
+for example:
 
 ```sh
 "$AMPLIHACK_ASSET_RESOLVER" amplifier-bundle/recipes/smart-orchestrator.yaml
+"$AMPLIHACK_ASSET_RESOLVER" hooks-dir
 ```
 
 That returns the resolved absolute path on stdout and exits non-zero on invalid input or missing assets.
+The standalone binary resolves assets through the same CLI resolver as
+[`amplihack resolve-bundle-asset`](./resolve-bundle-asset-command.md).
+
+The CLI library's Rust named-asset table is the shared source for the
+standalone binary's usage/listing output and the runtime helper mappings, so
+those consumers stay in sync with the command.
 
 **Resolution order (first match wins):**
 

--- a/docs/reference/resolve-bundle-asset-command.md
+++ b/docs/reference/resolve-bundle-asset-command.md
@@ -30,6 +30,11 @@ This is the native Rust asset resolver for recipe shell steps, hooks, and
 child tools. It keeps the legacy Python asset names that recipes and helper
 scripts still use, while resolving them to the current Rust/runtime assets.
 
+The Rust `NAMED_ASSETS` table in the CLI library is the code-owned source for
+named assets. The CLI command, standalone `amplihack-asset-resolver` binary,
+and runtime asset helpers use that table instead of maintaining separate
+mapping or usage lists.
+
 ## Arguments
 
 | Argument | Required | Description |
@@ -40,10 +45,19 @@ scripts still use, while resolving them to the current Rust/runtime assets.
 
 | Name | Resolves to | Expected type | Purpose |
 | ---- | ----------- | ------------- | ------- |
+| `hooks-dir` | `amplifier-bundle/tools/amplihack/hooks` | directory | Compatibility alias for hook configuration assets used by launcher and recipe preflight paths. |
 | `helper-path` | `amplifier-bundle/bin/multitask-orchestrator.sh` | file | Compatibility alias for legacy orchestration-helper callers. |
 | `session-tree-path` | `amplifier-bundle/tools/amplihack/session` | directory | Compatibility anchor for callers that still request the old session-tree asset name. |
-| `hooks-dir` | `amplifier-bundle/tools/amplihack/hooks` | directory | Compatibility alias for hook configuration assets used by launcher and recipe preflight paths. |
 | `multitask-orchestrator` | `amplifier-bundle/bin/multitask-orchestrator.sh` | file | Native multitask orchestrator wrapper. |
+
+This documentation mirrors the canonical Rust `NAMED_ASSETS` table; the code
+table owns supported names. Named assets are matched by exact static name only:
+there are no aliases, fuzzy matches, path traversal forms, environment
+expansions, shell fragments, or absolute paths for named-asset lookup.
+
+Unknown-name diagnostics, usage text, runtime asset lookup, and standalone
+resolver behavior derive from that same ordered table, so generated name lists
+stay in this order.
 
 Named assets are resolved against runtime roots in priority order:
 
@@ -118,10 +132,13 @@ The value must point at the directory that contains `amplifier-bundle/`.
 
 Launchers and recipe runners set `AMPLIHACK_ASSET_RESOLVER` to the absolute
 path of `amplihack-asset-resolver` when the standalone binary is available.
-Child tools can call it without knowing where `amplihack` itself is installed:
+Child tools can call it with either a supported named asset or a safe
+`amplifier-bundle/...` relative path without knowing where `amplihack` itself
+is installed:
 
 ```sh
 "$AMPLIHACK_ASSET_RESOLVER" amplifier-bundle/recipes/smart-orchestrator.yaml
+"$AMPLIHACK_ASSET_RESOLVER" hooks-dir
 ```
 
 See [Environment Variables](./environment-variables.md#amplihack_asset_resolver)
@@ -133,10 +150,24 @@ The CLI and standalone binary share the same resolver module.
 
 | Function | Purpose |
 | -------- | ------- |
+| `named_asset_relative_paths()` | Return the canonical read-only named-asset table as ordered `(name, relative_paths)` entries. Runtime consumers use this instead of defining their own map. |
+| `named_asset_names()` | Return the supported named assets in canonical order for usage text, listing output, tests, and diagnostics. |
 | `resolve_named_asset(name)` | Resolve one of the named assets above to an existing path. |
 | `resolve_asset(relative_path)` | Resolve a validated `amplifier-bundle/...` relative path. |
 | `validate_relative_path(relative_path)` | Reject traversal, absolute paths, unsafe characters, and paths outside `amplifier-bundle/`. |
 | `run_cli(arg)` | Dispatch one CLI argument and return the process exit code. |
+
+### Canonical mapping refactor contract
+
+- `runtime_assets` delegates its named-asset map to the
+  `named_asset_relative_paths()` helper, preserving its public behavior while
+  removing duplicate mapping data.
+- `amplihack-asset-resolver` delegates argument dispatch, supported-name
+  listing, and resolution to the CLI library. It does not keep independent
+  asset-name knowledge.
+- New named assets are added only to the canonical table. Documentation, usage
+  output, runtime compatibility checks, and unknown-name diagnostics must all
+  reflect that table.
 
 ## Exit Codes
 
@@ -166,6 +197,9 @@ This distinction matters for recipes that use `|| true` guards: exit 1
 
 ## Security Constraints
 
+- Named assets match exact static names only; aliases, fuzzy matching, path
+  traversal, environment expansion, shell fragments, and absolute paths are not
+  accepted as named assets.
 - Path traversal (`..`) is rejected at validation time.
 - Only characters in `A-Z a-z 0-9 _ - . /` are allowed.
 - Resolved paths are canonicalized; symlinks are followed but must resolve


### PR DESCRIPTION
## Summary
- remove heap allocation from canonical named-asset helper APIs by returning fixed-size arrays
- avoid rebuilding the legacy runtime-assets HashMap/Vecs on every `resolve_asset_path` lookup
- avoid collecting standalone resolver CLI args before dispatching
- add canonicalization/usage tests and docs so the shared mapping contract does not drift again

## Validation
- `NODE_OPTIONS=--max-old-space-size=32768 cargo fmt --check`
- `RUSTFLAGS='-D warnings' NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli --test issue_634_asset_resolution_parity -- --nocapture`
- `NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli --test pr_712_named_asset_canonicalization -- --nocapture`
- `NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli runtime_assets -- --nocapture`
- `NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli resolve_bundle_asset -- --nocapture`
- `NODE_OPTIONS=--max-old-space-size=32768 cargo run -q -p amplihack-asset-resolver-bin --`
- `NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli --no-run`

## Step 13: Local Testing Results

### Scenario 1 — Resolve legacy helper-path alias to native orchestrator
Command: `AMPLIHACK_HOME=/tmp/tmp.UgEoHOM0Lc uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-634-runtime-assets-perf amplihack resolve-bundle-asset helper-path`
Result: PASS
Output: exit code 0; `/tmp/tmp.UgEoHOM0Lc/amplifier-bundle/bin/multitask-orchestrator.sh`; no `orch_helper.py` path appeared.

### Scenario 2 — Unknown legacy Python helper remains a not-found named asset
Command: `AMPLIHACK_HOME=/tmp/tmp.UgEoHOM0Lc uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-634-runtime-assets-perf amplihack resolve-bundle-asset legacy-python-helper`
Result: PASS
Output: exit code 1; `ERROR: Unknown asset name "legacy-python-helper". Expected one of: hooks-dir, helper-path, session-tree-path, multitask-orchestrator`
