### PR TITLE
Fix Amplifier auto-mode prompt argv contract

### DIFF
--- a/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
@@ -298,7 +298,7 @@ pub(super) fn build_tool_passthrough_args(
             args.push(prompt.to_string());
         }
         AutoModeTool::Amplifier => {
-            args.push("-p".to_string());
+            args.insert(0, "run".to_string());
             args.push(prompt.to_string());
         }
     }
@@ -346,7 +346,7 @@ fn build_tool_passthrough_prefix_args(
             args.push("exec".to_string());
         }
         AutoModeTool::Amplifier => {
-            args.push("-p".to_string());
+            args.insert(0, "run".to_string());
         }
     }
     args.into_iter().map(OsString::from).collect()

--- a/crates/amplihack-cli/tests/auto_mode_prompt_delivery.rs
+++ b/crates/amplihack-cli/tests/auto_mode_prompt_delivery.rs
@@ -85,6 +85,47 @@ fn auto_mode_does_not_duplicate_prompt_between_wrapper_and_child_args() {
 }
 
 #[test]
+fn amplifier_auto_mode_uses_documented_run_positional_prompt_contract() {
+    let dir = tempfile::tempdir().unwrap();
+    let prompt = "issue #709: keep quotes, $PATH, and\nnewlines".to_string();
+
+    let delivered = build_auto_command_with_prompt_delivery(AutoModePromptDeliveryOptions {
+        tool: AutoModeTool::Amplifier,
+        execution_dir: dir.path().to_path_buf(),
+        project_dir: dir.path().to_path_buf(),
+        node_options: None,
+        passthrough_args: vec![
+            "--provider".to_string(),
+            "openai".to_string(),
+            "--model".to_string(),
+            "amp-test".to_string(),
+        ],
+        prompt: prompt.clone(),
+        requested_delivery: PromptDelivery::Auto,
+    })
+    .expect("amplifier auto-mode delivery-aware command should build");
+
+    let args = argv(&delivered.command);
+    let passthrough_start = args
+        .iter()
+        .position(|arg| arg == "--")
+        .expect("nested amplihack command must separate wrapper and Amplifier args")
+        + 1;
+    assert_eq!(
+        &args[passthrough_start..],
+        &[
+            "run".to_string(),
+            "--provider".to_string(),
+            "openai".to_string(),
+            "--model".to_string(),
+            "amp-test".to_string(),
+            prompt,
+        ],
+        "Amplifier auto-mode must use `amplifier run [OPTIONS] [PROMPT]` without a synthetic prompt flag"
+    );
+}
+
+#[test]
 fn amplifier_auto_mode_rejects_explicit_unsupported_prompt_delivery_modes() {
     let dir = tempfile::tempdir().unwrap();
     let prompt = synthetic_prompt();


### PR DESCRIPTION
## Summary
- Removes the synthetic `-p` prompt prefix from Amplifier auto-mode command construction.
- Routes Amplifier auto-mode prompts as `run [OPTIONS] [PROMPT]`, matching the issue #709 argv-only contract.
- Adds regression coverage for passthrough options plus a prompt containing shell-sensitive characters/newlines.

## Validation
- `cargo fmt --all --check`
- `cargo test -p amplihack-cli --test auto_mode_prompt_delivery`
- `cargo test -p amplihack-launcher --test prompt_delivery`
- `cargo test -p amplihack-cli commands::launch::tests_launch::run_launch_rejects_explicit_unsupported_amplifier_prompt_delivery_modes`
- `cargo clippy -- -D warnings`

Follow-up to #715 / issue #709.