### PR TITLE
Perf: trim prompt delivery overhead

### DIFF
--- a/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
@@ -45,14 +45,19 @@ pub(super) fn extract_prompt_args(args: &[String]) -> Option<ParsedPromptArgs> {
     // We only do this when there's exactly one non-flag arg to avoid ambiguity
     // (e.g. `--model sonnet "prompt"` has two non-flag args: "sonnet" and "prompt").
     if prompt.is_none() {
-        let non_flag_indices: Vec<usize> = passthrough_args
-            .iter()
-            .enumerate()
-            .filter(|(_, a)| !a.starts_with('-'))
-            .map(|(i, _)| i)
-            .collect();
-        if non_flag_indices.len() == 1 {
-            prompt = Some(passthrough_args.remove(non_flag_indices[0]));
+        let mut non_flag_index = None;
+        let mut non_flag_count = 0;
+        for (index, arg) in passthrough_args.iter().enumerate() {
+            if !arg.starts_with('-') {
+                non_flag_index = Some(index);
+                non_flag_count += 1;
+                if non_flag_count > 1 {
+                    break;
+                }
+            }
+        }
+        if let (1, Some(index)) = (non_flag_count, non_flag_index) {
+            prompt = Some(passthrough_args.remove(index));
         }
     }
 
@@ -309,6 +314,13 @@ fn build_tool_passthrough_prefix_args(
     tool: AutoModeTool,
     passthrough_args: &[String],
 ) -> Vec<OsString> {
+    if tool == AutoModeTool::Amplifier {
+        let mut args = Vec::with_capacity(passthrough_args.len() + 1);
+        args.push(OsString::from("run"));
+        args.extend(passthrough_args.iter().map(OsString::from));
+        return args;
+    }
+
     let mut args = passthrough_args.to_vec();
     match tool {
         AutoModeTool::Claude | AutoModeTool::RustyClawd => {
@@ -345,9 +357,7 @@ fn build_tool_passthrough_prefix_args(
             }
             args.push("exec".to_string());
         }
-        AutoModeTool::Amplifier => {
-            args.insert(0, "run".to_string());
-        }
+        AutoModeTool::Amplifier => {}
     }
     args.into_iter().map(OsString::from).collect()
 }

--- a/crates/amplihack-utils/src/prompt_delivery.rs
+++ b/crates/amplihack-utils/src/prompt_delivery.rs
@@ -291,7 +291,6 @@ pub fn deliver(
                 .prefix("simard-prompt-")
                 .tempfile()?;
             named.write_all(prompt.as_bytes())?;
-            named.as_file_mut().sync_all().ok();
 
             // tempfile::Builder already creates with 0600 on Unix; re-assert
             // it here as a belt-and-braces guarantee against any future


### PR DESCRIPTION
## Summary
- remove unnecessary fsync when writing prompt tempfiles for subprocess handoff
- avoid allocating a temporary index vector when extracting auto-mode positional prompts
- build Amplifier auto-mode prefix args without cloning then shifting passthrough args

## Validation
- cargo fmt --all --check
- cargo test -p amplihack-launcher --test prompt_delivery --quiet
- cargo test -p amplihack-cli auto_mode --quiet
- cargo test -p amplihack-cli --test auto_mode_prompt_delivery --quiet
- cargo clippy -p amplihack-utils -p amplihack-launcher -p amplihack-cli --all-targets -- -D warnings

Follow-up to #709.