### PR TITLE
Fix workflow-prep Azure DevOps issue reuse

### DIFF
--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -282,13 +282,13 @@ steps:
         exit 0
       fi
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
-      # Extract referenced issue/work-item from task_description (idempotency)
+      EXISTING_ISSUE_NUMBER="${ISSUE_NUMBER:-}"
       REF_ISSUE_NUM=""
       if [[ "$TASK_DESC" =~ AB#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"; fi
       [ -n "$REF_ISSUE_NUM" ] && ! [[ "$REF_ISSUE_NUM" =~ ^[0-9]+$ ]] && REF_ISSUE_NUM=""
-      # --- GitHub path ---
-      if [ "$HOST_TYPE" = "github" ]; then
+      case "$HOST_TYPE" in
+      github)
         if [ -n "$REF_ISSUE_NUM" ]; then
           EXISTING_URL=$(timeout 60 gh issue view "$REF_ISSUE_NUM" --json url --jq '.url // ""' 2>/dev/null || echo '')
           [ -n "$EXISTING_URL" ] && { printf '%s\n' "$EXISTING_URL"; exit 0; }
@@ -304,12 +304,11 @@ steps:
         gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "$LABEL_NAME" 2>&1 || \
           gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY"
         exit $?
-      fi
-      # --- Azure DevOps path (az boards work-item) ---
-      if [ "$HOST_TYPE" = "azdo" ]; then
+        ;;
+      azdo|azure-devops)
+        if [[ "$EXISTING_ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then printf 'AB#%s\n' "$EXISTING_ISSUE_NUMBER"; exit 0; fi
         REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
         AZDO_ORG=""; AZDO_PROJECT=""
-        # Bash regex replaces 6 echo|sed subprocess spawns with built-in matching
         if [[ "$REMOTE_URL" =~ dev\.azure\.com/([^/]+)/([^/]+)/ ]]; then
           AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
         elif [[ "$REMOTE_URL" =~ ([^/.]+)\.visualstudio\.com/([^/]+)/ ]]; then
@@ -337,13 +336,12 @@ steps:
         }
         [ -n "$AZDO_ORG" ] && { AZDO_ORG=$(_pct_decode "$AZDO_ORG") || { AZDO_ORG=""; AZDO_PROJECT=""; }; }
         [ -n "$AZDO_PROJECT" ] && { AZDO_PROJECT=$(_pct_decode "$AZDO_PROJECT") || { AZDO_ORG=""; AZDO_PROJECT=""; }; }
-        # Security: validate org/project captures against safe character set
         if [[ -n "$AZDO_ORG" ]] && ! [[ "$AZDO_ORG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
           echo "WARN: AZDO_ORG contains unexpected characters — using local tracking" >&2
           AZDO_ORG=""
         fi
         # Project names may contain spaces (decoded from %20)
-        if [[ -n "$AZDO_PROJECT" ]] && ! [[ "$AZDO_PROJECT" =~ ^[a-zA-Z0-9._ -]+$ ]]; then
+        if [[ -n "$AZDO_PROJECT" ]] && ! [[ "$AZDO_PROJECT" =~ ^[a-zA-Z0-9._[:space:]-]+$ ]]; then
           echo "WARN: AZDO_PROJECT contains unexpected characters — using local tracking" >&2
           AZDO_PROJECT=""
         fi
@@ -363,7 +361,8 @@ steps:
         else
           echo "WARN: 'az' CLI not found or org/project empty — using local tracking for AzDO remote" >&2
         fi
-      fi
+        ;;
+      esac
       # --- Local tracking fallback (unknown remote or az CLI unavailable) ---
       echo "INFO: Using local tracking for issue management (remote: $HOST_TYPE)" >&2
       LOCAL_ISSUE=$(($(date +%s) % 1000000))

--- a/docs/azure-devops/README.md
+++ b/docs/azure-devops/README.md
@@ -114,6 +114,25 @@ These tools follow clean architecture principles:
 
 ## Common Workflows
 
+### 0. Run `default-workflow` with Azure Boards tracking
+
+`default-workflow` detects Azure DevOps remotes and routes Step 03 tracking to
+Azure Boards instead of GitHub Issues. Existing work items can be reused with
+either `issue_number=N` or `AB#N`.
+
+```bash
+amplihack recipe run default-workflow \
+  -c remote_host_type=azure-devops \
+  -c issue_number=12345 \
+  -c task_description="Address review feedback for the Azure DevOps PR" \
+  -c repo_path=.
+```
+
+See [How to Use the Default Workflow with Azure DevOps](../howto/use-workflow-with-azure-devops.md)
+for the task-oriented guide and
+[Step 03 Host-Aware Tracking Idempotency](../reference/recipe-step-03-idempotency.md)
+for the issue/work-item reuse contract.
+
 ### 1. Create Epic → Feature → Story Hierarchy
 
 ```bash

--- a/docs/howto/use-workflow-with-azure-devops.md
+++ b/docs/howto/use-workflow-with-azure-devops.md
@@ -55,24 +55,50 @@ The workflow automatically:
 
 ### Override the work item type
 
-By default, step 03 creates a `Task`. The `work_item_type` context variable
-override is planned but not yet implemented. To use a different work item
-type, create the work item manually and reference it via `AB#N` in the
-task description.
+By default, step 03 creates a `Task`. To use a different work item type,
+create the work item manually and pass its ID with `issue_number=N` or
+reference it via `AB#N` in the task description.
 
 ---
 
 ## Run the Workflow with an Existing Work Item
 
-Reference the work item number in `task_description` — the idempotency
-guard in step 03 will detect the `AB#N` reference and reuse the existing
-work item:
+Use either an explicit `issue_number` context value or an `AB#N` reference in
+`task_description`. Step 03 keeps both forms inside the Azure DevOps branch and
+does not create a GitHub issue.
+
+### Explicit work item context
+
+Use this form for Azure DevOps PR follow-up work where the recipe context
+already contains a work item ID:
+
+```bash
+amplihack recipe run default-workflow \
+  -c remote_host_type=azure-devops \
+  -c issue_number=12345 \
+  -c task_description="Address review feedback for the Azure DevOps PR" \
+  -c repo_path=.
+```
+
+`remote_host_type=azure-devops` is accepted as an alias for `azdo`. Step 03
+emits `AB#12345`, step 03b extracts `12345`, and downstream steps use
+Azure Boards references such as `AB#12345`. This explicit context form is
+trusted and does not require Azure CLI lookup before reuse.
+
+### Work item reference in task text
+
+Reference the work item number in `task_description`:
 
 ```bash
 amplihack recipe run default-workflow \
   -c task_description="Fix the auth bug described in AB#12345" \
   -c repo_path=.
 ```
+
+Because host dispatch has already selected Azure DevOps, a bare `#12345`
+inside the task description is also treated as an Azure Boards candidate rather
+than a GitHub issue. Task-text candidates may still require Azure CLI,
+organization, project, and work-item resolution before they are reused.
 
 ---
 
@@ -93,8 +119,9 @@ sequences before validation, so project names with spaces work correctly.
 | Commit reference    | `Closes #N`                    | `AB#N`                               |
 | PR creation         | Automated (`gh pr create`)     | Skipped (create manually after)      |
 | Auth prerequisite   | `gh auth login`                | `az login` + DevOps extension        |
-| Idempotency Guard 1 | `gh issue view`               | `az boards work-item show`           |
-| Idempotency Guard 2 | `gh issue list --search`      | Not yet implemented (planned: WIQL query) |
+| Idempotency Guard 1 | `gh issue view`               | Explicit `issue_number` emits `AB#N`; task-text candidates may use `az boards work-item show` |
+| Existing `issue_number` | Reuses the supplied issue ID | Emits `AB#N`; no GitHub or Azure CLI lookup required |
+| Idempotency Guard 2 | `gh issue list --search`      | Host-isolated; no GitHub title search |
 | Summary (step 22b)  | `PR: <url>`                   | `PR: N/A (manual creation required)` |
 
 ---
@@ -128,6 +155,18 @@ detected:
 - Legacy: `https://org.visualstudio.com/project/_git/repo`
 - SSH: `git@ssh.dev.azure.com:v3/org/project/repo`
 
+If the workflow is launched from an external Azure DevOps context that already
+knows the host, pass `-c remote_host_type=azure-devops`. The alias routes to
+the same Azure Boards path as `azdo`.
+
+**Workflow tries to create or inspect a GitHub issue**
+
+Ensure `remote_host_type` is `azdo` or `azure-devops`. For guaranteed reuse
+without Azure CLI lookup, pass the existing work item as `issue_number=N`.
+`AB#N` in task text remains Azure DevOps-scoped, but may need Azure Boards
+lookup before reuse. Unknown or misspelled host values use local tracking
+rather than GitHub.
+
 **`az boards` fails with authentication error**
 
 Run `az login` to refresh credentials. For PAT-based auth:
@@ -150,5 +189,5 @@ rejected and the workflow falls back to local tracking.
 
 | Field  | Value     |
 | ------ | --------- |
-| Status | Implemented |
-| Issue  | #684      |
+| Status | Issue #718 target contract |
+| Issues | #684, #718 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -270,6 +270,7 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [How to Recover an Existing PR with `default-workflow`](howto/recover-existing-pr-with-default-workflow.md) - Supply `pr_number`, `existing_branch`, and issue requirements without manually merging
 - [Tutorial: Recover PR 579 Readiness](tutorials/pr-recovery-readiness.md) - Walk through hook and additive-copy readiness evidence for an interrupted PR recovery
 - [PR Recovery Readiness Reference](reference/pr-recovery-readiness.md) - Context fields, readiness evidence schema, publish contract, and finalization states
+- [Step 03 Host-Aware Tracking Idempotency](reference/recipe-step-03-idempotency.md) - GitHub issue, Azure Boards work-item, and local tracking reuse/create behavior
 - [Workflow Issue Extraction Reference](reference/workflow-issue-extraction.md) - Three-tier issue-number resolution (direct URL → PR closing-refs → `#N` verify) in step 03b
 - [Multi-Provider Workflow Reference](reference/multi-provider-workflow.md) - Provider detection, issue tracking, and PR routing for GitHub, AzDO, and local repos
 - [How to Use the Workflow with Azure DevOps](howto/use-workflow-with-azure-devops.md) - Run default-workflow against an AzDO repository

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -70,6 +70,7 @@ Complete documentation for using the Recipe Runner:
 - **[Recipe CLI Commands How-To](../howto/recipe-cli-commands.md)** - Task-oriented guide for using recipe commands
 - **[Recipe CLI Reference](../reference/recipe-cli-reference.md)** - Complete command-line reference with all options and exit codes
 - **[Recipe CLI Examples](cli-examples.md)** - Real-world usage scenarios (development, testing, CI/CD, team workflows)
+- **[Step 03 Host-Aware Tracking Idempotency](../reference/recipe-step-03-idempotency.md)** - GitHub issue, Azure Boards work-item, and local tracking reuse/create contract
 
 ## Why It Exists
 

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -51,7 +51,7 @@ git remote get-url origin
 └──────────────────────────────────┘
         │
         ▼
-  remote_host_type = "github" | "azdo" | "other"
+  remote_host_type = "github" | "azdo" | "azure-devops" | "other"
         │
         ├─► Step 03:  issue creation (routed)
         ├─► Step 03b: issue extraction (routed)
@@ -87,6 +87,10 @@ esac
 type; AzDO-specific URL parsing (organization, project) is performed by
 step 03 where the values are consumed.
 
+Step 02d emits `azdo` for Azure DevOps remotes. Downstream steps also accept
+`azure-devops` as an equivalent explicit override for contexts supplied by
+Azure DevOps PR/work-item follow-up workflows.
+
 **Edge cases**:
 
 - No remote configured → `REMOTE_URL` is empty → `REMOTE_HOST_TYPE="other"`
@@ -107,10 +111,26 @@ to the GitHub path. Uses `gh issue create` and `gh issue view` as before. No
 change from the existing behavior documented in
 [recipe-step-03-idempotency.md](recipe-step-03-idempotency.md).
 
-### Azure DevOps (`remote_host_type = "azdo"`)
+### Azure DevOps (`remote_host_type = "azdo"` or `"azure-devops"`)
 
-When `$REMOTE_HOST_TYPE` is `"azdo"`, step 03 parses the remote URL to
-extract the AzDO organization and project names, then creates a work item.
+When `$REMOTE_HOST_TYPE` is `"azdo"` or `"azure-devops"`, step 03 routes to
+the Azure Boards path. It reuses an existing work item before attempting to
+create a new one.
+
+**Existing work item reuse**:
+
+| Input | Behavior |
+| ----- | -------- |
+| `issue_number=N` context value | Emits `AB#N` and exits 0 before GitHub commands, Azure CLI lookup, remote parsing, or work-item creation |
+| `task_description` contains `AB#N` | Treats `N` as an Azure Boards candidate; resolves a URL with `az boards work-item show` when available |
+| `task_description` contains `#N` | Treats `N` as an Azure Boards candidate because host dispatch already selected Azure DevOps |
+
+The Azure DevOps branch never calls `gh issue view`, `gh issue list`, or
+`gh issue create`. This prevents GitHub-specific issue logic from running in
+Azure DevOps repositories and keeps ADO PR follow-up work idempotent.
+
+If no existing work item is supplied, step 03 parses the remote URL to extract
+the AzDO organization and project names, then creates a work item.
 
 **AzDO URL parsing** (three URL forms):
 
@@ -138,9 +158,8 @@ az boards work-item create \
   --description "$ISSUE_BODY"
 ```
 
-**Work item type**: Defaults to `Task`. The `work_item_type` context variable
-override is planned but not yet implemented. Users can create work items
-manually and reference them via `AB#N` in the task description.
+**Work item type**: Defaults to `Task`. Users can create work items manually
+and pass `issue_number=N` or reference them via `AB#N` in the task description.
 
 The output is an AzDO work item URL:
 
@@ -148,13 +167,8 @@ The output is an AzDO work item URL:
 https://dev.azure.com/myorg/myproject/_workitems/edit/12345
 ```
 
-The idempotency guards (Guard 1 and Guard 2 from
-[recipe-step-03-idempotency.md](recipe-step-03-idempotency.md)) are adapted:
-
-- **Guard 1**: Extracts `AB#NNNN` or `#NNNN` references; verifies via
-  `az boards work-item show --id <N>`
-- **Guard 2**: Not yet implemented. Planned: search via `az boards query`
-  using WIQL title match (similar to `gh issue list --search`)
+The host-aware idempotency contract is documented in
+[step-03-create-issue: Host-Aware Tracking Idempotency](recipe-step-03-idempotency.md).
 
 ### Other/Local (`remote_host_type = "other"`)
 
@@ -162,32 +176,33 @@ Step 03 generates a synthetic issue number for branch naming and commit
 messages, without making any network calls:
 
 ```bash
-# Combine PID and epoch seconds for collision resistance
-SYNTHETIC_ID=$(( ($$ * 100000 + $(date +%s)) % 10000000 ))
+SYNTHETIC_ID=$(( $(date +%s) % 1000000 ))
 ```
 
-This scheme avoids same-second collisions by mixing the process PID with
-the epoch timestamp. The local ID is used only for branch naming
-(`feat/issue-<N>-slug`) and commit message references. No tracking system
-is updated.
+The synthetic ID is an opaque local workflow reference, not a durable provider
+record and not a global uniqueness guarantee. It is used only for branch naming
+(`feat/issue-<N>-slug`) and commit message references. No tracking system is
+updated.
 
 ---
 
 ## Issue Extraction (Step 03b)
 
-Step 03b's three-tier extraction logic (documented in
-[workflow-issue-extraction.md](workflow-issue-extraction.md)) is extended to
-handle all three provider URL formats:
+Step 03b's extraction logic (documented in
+[workflow-issue-extraction.md](workflow-issue-extraction.md)) handles every
+provider output format produced by Step 03:
 
-| Provider | URL pattern                                               | Extraction regex                    |
-| -------- | --------------------------------------------------------- | ----------------------------------- |
-| GitHub   | `https://github.com/owner/repo/issues/N`                  | `issues/[0-9]+`                     |
-| AzDO     | `https://dev.azure.com/org/project/_workitems/edit/N`      | `_workitems/edit/[0-9]+`            |
-| Other    | Bare numeric string from synthetic ID                       | `^[0-9]+$`                          |
+| Provider | Output pattern | Extraction regex |
+| -------- | -------------- | ---------------- |
+| GitHub | `https://github.com/owner/repo/issues/N` | `issues/([0-9]+)` |
+| GitHub PR fallback | `https://github.com/owner/repo/pull/N` | `pull/([0-9]+)` plus closing-issue lookup |
+| Azure DevOps | `https://dev.azure.com/org/project/_workitems/edit/N` | `_workitems/edit/([0-9]+)` |
+| Azure DevOps | `AB#N` | `AB#([0-9]+)` |
+| Other/local | `local-tracking:N` | `local-tracking:([0-9]+)` |
 
-The `issue_number` output contract remains unchanged: a plain integer (or
-null). Downstream steps never see the provider URL format — they only
-consume the numeric ID.
+The `issue_number` output contract remains unchanged: a plain integer.
+Downstream steps never see the provider URL format — they only consume the
+numeric ID.
 
 ---
 
@@ -201,6 +216,7 @@ step 02d, declared in the parent recipe's context block):
 | --------- | ---------------- | --------------------------------- |
 | `github`  | `Closes #N`      | `feat: add auth (Closes #684)`    |
 | `azdo`    | `AB#N`           | `feat: add auth (AB#12345)`       |
+| `azure-devops` | `AB#N`      | `feat: add auth (AB#12345)`       |
 | `other`   | `Ref #N`         | `feat: add auth (Ref #4821937)`   |
 
 The `Closes #N` format triggers GitHub's auto-close behavior. The `AB#N`
@@ -215,6 +231,7 @@ neutral reference that does not trigger automation on any platform.
 | --------- | --------------------- | ------------------------------------------------------- |
 | `github`  | `gh pr create`        | Unchanged from current behavior                          |
 | `azdo`    | (skipped)             | Exits early; user creates PR manually afterward      |
+| `azure-devops` | (skipped)        | Same behavior as `azdo`                                  |
 | `other`   | (skipped)             | Logs "no remote — skipping PR creation"                  |
 
 Step 16 consumes `$REMOTE_HOST_TYPE` from the propagated context variable
@@ -253,12 +270,12 @@ exits early with an informational message.
 
 This works because non-GitHub hosts never receive a `PR_URL`:
 
-- AzDO: step 16 skips automated PR creation → `PR_URL` stays empty
+- AzDO/`azure-devops`: step 16 skips automated PR creation → `PR_URL` stays empty
 - Other: step 16 skips entirely → `PR_URL` stays empty
 
-As defense-in-depth, the target implementation adds a `$REMOTE_HOST_TYPE`
-check before `gh` calls to prevent failures if `PR_URL` is set to a
-non-GitHub URL through manual context override.
+As defense-in-depth, step 21 checks `$REMOTE_HOST_TYPE` before `gh` calls to
+prevent failures if `PR_URL` is set to a non-GitHub URL through manual context
+override.
 
 ---
 
@@ -272,6 +289,7 @@ commands.
 | --------- | ----------------------------------------- | -------------------- |
 | `github`  | `PR: <url>` (with `gh pr view` details)   | `Issue: #N`          |
 | `azdo`    | `PR: N/A (manual creation required)`      | `Issue: AB#N`        |
+| `azure-devops` | `PR: N/A (manual creation required)` | `Issue: AB#N` |
 | `other`   | `PR: N/A (no remote provider)`            | `Issue: Ref #N`      |
 
 The `HOST_TYPE=${REMOTE_HOST_TYPE:-other}` local variable pattern is used
@@ -286,7 +304,7 @@ Variables added or modified by the multi-provider feature:
 
 | Variable           | Set by    | Type   | Description                                  |
 | ------------------ | --------- | ------ | -------------------------------------------- |
-| `remote_host_type` | step-02d  | string | `"github"`, `"azdo"`, or `"other"`            |
+| `remote_host_type` | step-02d or caller | string | `"github"`, `"azdo"`, `"azure-devops"`, or `"other"` |
 | `azdo_org_url`     | step-03   | string | Full AzDO org URL (local to step-03; empty if not AzDO) |
 | `azdo_org`         | step-03   | string | AzDO organization name (local to step-03; empty if not AzDO) |
 | `azdo_project`     | step-03   | string | AzDO project name, percent-decoded (local to step-03; empty if not AzDO) |
@@ -306,13 +324,16 @@ declaration because they are local to step-03 within `workflow-prep`.
 
 ## Diagnostics
 
-All diagnostic output goes to **stderr**.
+All diagnostic output goes to **stderr**. The table below is the expected
+diagnostic contract for the Issue #718 host-aware implementation; exact wording
+should not be treated as a stable public API.
 
 | Message                                                          | When                                     |
 | ---------------------------------------------------------------- | ---------------------------------------- |
 | `INFO: Remote host type: github`                                  | step-02d completed detection              |
 | `INFO: Remote host type: azdo`                                    | step-02d detected AzDO remote             |
 | `INFO: Remote host type: other`                                   | step-02d fallback (no remote/unknown)     |
+| `INFO: Reusing work item AB#N`                                    | step-03 reused an existing Azure Boards work item |
 | `INFO: Creating AzDO work item (org=X, project=Y, type=Task)`    | step-03 AzDO path                         |
 | `INFO: Non-GitHub remote (azdo) — skipping draft PR creation`     | step-16 non-GitHub path                   |
 | `INFO: PR_URL is empty ... — skipping gh pr ready`                | step-21 non-GitHub path                   |
@@ -327,6 +348,8 @@ All diagnostic output goes to **stderr**.
 | Failure mode                          | Behavior                                          |
 | ------------------------------------- | ------------------------------------------------- |
 | `git remote get-url origin` fails     | `remote_host_type` = `"other"` (safe fallback)     |
+| `remote_host_type=azure-devops`       | Treated exactly like `azdo`                        |
+| Azure DevOps path has `issue_number`  | Reuses `AB#N`; does not call `gh` or create a work item |
 | `az boards` not installed             | Step-03 falls back to local synthetic ID           |
 | `az boards` auth expired              | Warning logged; falls back to local synthetic ID   |
 | AzDO work item creation fails         | Warning logged; synthetic ID used for branch naming |
@@ -361,10 +384,14 @@ Override the detected host type:
 
 ```bash
 amplihack recipe run default-workflow \
-  -c remote_host_type=other \
-  -c task_description="Work without any remote" \
+  -c remote_host_type=azure-devops \
+  -c issue_number=12345 \
+  -c task_description="Continue Azure DevOps PR follow-up work" \
   -c repo_path=.
 ```
+
+Use `remote_host_type=other` to force local tracking without provider API
+calls.
 
 ---
 
@@ -395,7 +422,20 @@ Step 02d detects `azdo`. Step 03 extracts org/project from the remote URL
 and creates an AzDO work item. Step 15 uses `AB#N` format. Step 16 logs
 manual PR instructions. Step 22b shows `PR: N/A (manual creation required)`.
 
-### Example 3: AzDO with percent-encoded project name
+### Example 3: Azure DevOps follow-up with existing work item
+
+```bash
+amplihack recipe run default-workflow \
+  -c remote_host_type=azure-devops \
+  -c issue_number=12345 \
+  -c task_description="Address review feedback for existing ADO PR" \
+  -c repo_path=/worktrees/ado-pr-follow-up
+```
+
+Step 03 treats `azure-devops` as Azure DevOps, emits `AB#12345`, and exits
+without entering GitHub issue reuse/create logic.
+
+### Example 4: AzDO with percent-encoded project name
 
 ```bash
 # Remote: https://dev.azure.com/myorg/My%20Project/_git/myrepo
@@ -407,7 +447,7 @@ amplihack recipe run default-workflow \
 Step 03 decodes `My%20Project` → `My Project` and validates successfully.
 Workflow proceeds as in Example 2.
 
-### Example 4: Local repository (no remote)
+### Example 5: Local repository (no remote)
 
 ```bash
 cd ~/my-local-project && git init
@@ -448,8 +488,8 @@ validation regex.
 
 ## Related
 
-- [Step 03 Idempotency Guards](recipe-step-03-idempotency.md) — GitHub-specific issue creation guards
-- [Workflow Issue Extraction (Step 03b)](workflow-issue-extraction.md) — three-tier extraction logic
+- [Step 03 Host-Aware Tracking Idempotency](recipe-step-03-idempotency.md) — GitHub issue, Azure Boards work-item, and local tracking reuse/create behavior
+- [Workflow Issue Extraction (Step 03b)](workflow-issue-extraction.md) — provider-neutral extraction logic
 - [Worktree Reattach and Prune (Step 04)](recipe-step-04-worktree-reattach-prune.md) — worktree lifecycle
 - [Azure DevOps Integration](../azure-devops/README.md) — AzDO CLI tools and setup
 - [Azure OpenAI Integration](../AZURE_INTEGRATION.md) — Azure model configuration
@@ -462,7 +502,7 @@ validation regex.
 
 | Field       | Value                                             |
 | ----------- | ------------------------------------------------- |
-| Status      | Implemented                                        |
-| Issue       | #684                                              |
+| Status      | Issue #718 target contract                         |
+| Issues      | #684, #718                                        |
 | Recipe file | `amplifier-bundle/recipes/workflow-prep.yaml`      |
 | Parent      | `amplifier-bundle/recipes/default-workflow.yaml`   |

--- a/docs/reference/recipe-step-03-idempotency.md
+++ b/docs/reference/recipe-step-03-idempotency.md
@@ -1,11 +1,17 @@
-# step-03-create-issue: Idempotency Guards
+# step-03-create-issue: Host-Aware Tracking Idempotency
 
-`step-03-create-issue` is the issue-creation step in `default-workflow.yaml`.
-It creates a GitHub issue to track the current workflow run. Since the
-default-workflow is often re-run against the same task (e.g., when resuming
-after an interruption, retrying a failed step, or running in a loop), the step
-uses two idempotency guards to detect and reuse an existing issue instead of
-creating a duplicate.
+`step-03-create-issue` is the tracking-record step in `workflow-prep.yaml`,
+the preparation phase used by `default-workflow`. It creates or reuses the
+tracking record for the current workflow run:
+
+- GitHub remotes use GitHub Issues.
+- Azure DevOps remotes use Azure Boards work items.
+- Unknown, empty, or local remotes use local synthetic tracking IDs.
+
+Since `default-workflow` is often re-run against the same task (for example
+when resuming after an interruption, retrying a failed step, or following up on
+an existing PR/work item), the step detects existing tracking references before
+creating anything new.
 
 **Added in:** PR #3952 (merged 2026-04-03)
 **Pattern source:** `step-16-create-draft-pr` idempotency guards (#3324)
@@ -14,61 +20,90 @@ creating a duplicate.
 
 ## Quick Start
 
-No configuration is required. The guards activate automatically every time
-`step-03-create-issue` runs.
+No configuration is required for GitHub repositories. Step 02d detects the
+remote host and step 03 routes by `remote_host_type`.
 
 ```bash
-# Run the default workflow — step-03 handles deduplication transparently
-amplihack recipe run default-workflow -c task_description="Fix login timeout bug in #4194" \
+# GitHub: reuse issue #4194 if it exists, otherwise search/create as needed
+amplihack recipe run default-workflow \
+  -c task_description="Fix login timeout bug in #4194" \
   -c repo_path="$(pwd)"
 ```
 
-If a prior run already created an issue for this task, step-03 reuses it and
-logs:
+Azure DevOps repositories may use either `azdo` or `azure-devops` as the host
+type. Both values route to the Azure Boards path.
+
+```bash
+# Azure DevOps: reuse existing work item 12345 without creating a GitHub issue
+amplihack recipe run default-workflow \
+  -c remote_host_type=azure-devops \
+  -c issue_number=12345 \
+  -c task_description="Continue ADO PR follow-up work" \
+  -c repo_path="$(pwd)"
+```
+
+Step 03 emits a parseable tracking reference, and step 03b extracts the same
+numeric ID for downstream branch, commit, and PR logic.
 
 ```
-INFO: task_description references issue #4194 — verifying it exists
-INFO: Reusing existing issue #4194 — skipping creation
+AB#12345
 ```
 
 ---
 
 ## How It Works
 
-The step runs three checks in priority order before creating a new issue:
+The step dispatches by host type before it performs any provider-specific
+operation. `remote_host_type` is treated as untrusted recipe context, so the
+dispatch uses quoted variables and explicit host matching.
 
 ```
-input: task_description + ISSUE_TITLE
+input: remote_host_type + issue_number + task_description + repo_path
          │
          ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Guard 1 — Reference Guard                                      │
-│  Does task_description contain #NNNN?                           │
-│  yes → gh issue view #NNNN (timeout 60s)                        │
-│         issue found? → output URL, exit 0 (reuse)              │
-│         not found   → fall through to Guard 2                   │
-│  no  → fall through to Guard 2                                  │
+│  Host Dispatch                                                  │
+│  github              → GitHub issue reuse/search/create          │
+│  azdo|azure-devops   → Azure Boards reuse/create                 │
+│  other|empty|unknown → local synthetic tracking                  │
 └─────────────────────────────────────────────────────────────────┘
          │
          ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Guard 2 — Title Search Guard                                   │
-│  gh issue list --state open --search <first 100 chars of title> │
-│         match found? → output URL, exit 0 (reuse)              │
-│         no match    → fall through to creation                  │
+│  Existing Reference Guards                                      │
+│  explicit issue_number? host-specific reuse, exit 0              │
+│  task_description contains AB#N or #N? host-specific candidate   │
 └─────────────────────────────────────────────────────────────────┘
          │
          ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Fallback — Create New Issue                                    │
-│  gh issue create (original behavior, unchanged)                 │
+│  Provider Create or Fallback                                    │
+│  GitHub: gh issue create                                        │
+│  Azure DevOps: az boards work-item create                       │
+│  Other: local-tracking:N                                        │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Guard 1: Reference Guard
+### Host Dispatch
 
-Triggered when `task_description` contains a GitHub issue reference in the form
-`#NNNN` (e.g., `Fix the bug in #4194`).
+Step 03 accepts these `remote_host_type` values:
+
+| Value | Meaning | Step 03 behavior |
+| ----- | ------- | ---------------- |
+| `github` | GitHub repository | Runs GitHub issue reuse/search/create logic with `gh` |
+| `azdo` | Azure DevOps repository | Runs Azure Boards work-item reuse/create logic |
+| `azure-devops` | Azure DevOps repository alias | Same behavior as `azdo` |
+| `other` | Unknown or local repository | Uses local tracking fallback |
+| empty/unset | Unknown or local repository | Uses local tracking fallback |
+
+Step 02d normally emits `github`, `azdo`, or `other`. The `azure-devops` alias
+exists for callers that pass host context from Azure DevOps PR/work-item
+follow-up workflows.
+
+### GitHub Guard 1: Reference Guard
+
+Triggered when the host is `github` and `task_description` contains a GitHub
+issue reference in the form `#NNNN` (for example, `Fix the bug in #4194`).
 
 1. Extracts the first `#NNNN` pattern using bash regex `[[ =~ \#([0-9]+) ]]`
 2. Validates the extracted value is purely numeric (defense-in-depth)
@@ -79,10 +114,10 @@ Triggered when `task_description` contains a GitHub issue reference in the form
 This guard is the cheapest and most specific. It requires zero search and makes
 a single API call to a known issue number.
 
-### Guard 2: Title Search Guard
+### GitHub Guard 2: Title Search Guard
 
-Always runs when Guard 1 does not match. Uses `gh issue list` to search open
-issues for a title similar to the current one.
+Runs only for the `github` host path when Guard 1 does not match. Uses
+`gh issue list` to search open issues for a title similar to the current one.
 
 1. Truncates the issue title to its first 100 characters (GitHub search limit)
 2. Calls `gh issue list --state open --search "<query>"` with a 60-second timeout
@@ -93,31 +128,97 @@ This guard catches the case where the workflow was re-run without explicitly
 referencing an issue number — for example, when the task description is
 re-submitted verbatim.
 
-### Fallback: Create New Issue
+### GitHub Fallback: Create New Issue
 
 If neither guard matches, the step creates a new issue using the same logic
-as before the idempotency guards were added. This path is completely unchanged.
+as before the idempotency guards were added. This path is unchanged for GitHub
+repositories.
+
+### Azure DevOps Existing Work Item Reuse
+
+Runs when `remote_host_type` is `azdo` or `azure-devops`.
+
+The Azure DevOps path never calls `gh issue view`, `gh issue list`, or
+`gh issue create`. Existing work-item reuse is checked before any create
+operation:
+
+1. If the recipe context already contains numeric `issue_number=N`, step 03
+   emits `AB#N` and exits 0 before GitHub logic, Azure CLI lookup, remote URL
+   parsing, or work-item creation.
+2. Otherwise, if `task_description` contains `AB#N`, step 03 reuses that work
+   item reference when the Azure Boards path can validate or resolve it.
+3. Otherwise, if `task_description` contains `#N`, step 03 treats it as an
+   Azure Boards work-item candidate only because the host dispatch already
+   selected Azure DevOps.
+
+Only explicit `issue_number=N` is trusted as an already-known workflow context
+value. IDs discovered in `task_description` are provider-scoped candidates:
+they must stay in the Azure DevOps branch, but they may still fall through to
+work-item creation or local tracking if Azure CLI, organization, project, or
+work-item resolution is unavailable.
+
+When Azure CLI and the DevOps extension are available, validated referenced
+work items may be resolved to full work-item URLs:
+
+```text
+https://dev.azure.com/myorg/myproject/_workitems/edit/12345
+```
+
+When an existing `issue_number` is already present, no Azure Boards lookup or
+create command is needed; the parseable `AB#N` output is enough for step 03b
+and all downstream workflow steps.
+
+### Azure DevOps Create Path
+
+If no existing work item is supplied, step 03 parses the Azure DevOps remote
+URL to derive organization and project, then creates a `Task` work item with
+`az boards work-item create`. Supported remote URL forms are:
+
+| Form | Example |
+| ---- | ------- |
+| Modern HTTPS | `https://dev.azure.com/myorg/MyProject/_git/myrepo` |
+| Legacy HTTPS | `https://myorg.visualstudio.com/MyProject/_git/myrepo` |
+| SSH | `git@ssh.dev.azure.com:v3/myorg/MyProject/myrepo` |
+
+Percent-encoded project names such as `My%20Project` are decoded before
+validation. Invalid org/project captures fall back to local tracking with a
+warning rather than crossing into GitHub logic.
+
+### Local Tracking Fallback
+
+Unknown hosts, empty hosts, non-git directories, malformed Azure DevOps remote
+metadata, or unavailable Azure CLI support produce a local tracking reference:
+
+```text
+local-tracking:482193
+```
+
+Local tracking preserves the workflow's numeric `issue_number` contract without
+calling GitHub or Azure DevOps APIs.
 
 ---
 
 ## Output Format
 
-All three paths (both guards and the creation fallback) write a single GitHub
-issue URL to stdout:
+Step 03 writes exactly one tracking reference to stdout. Diagnostic output goes
+to stderr.
 
-```
-https://github.com/owner/repo/issues/123
-```
+| Host path | Reuse output | Create output |
+| --------- | ------------ | ------------- |
+| GitHub | `https://github.com/owner/repo/issues/123` | `https://github.com/owner/repo/issues/123` |
+| Azure DevOps | `AB#12345` for explicit `issue_number`, or `https://dev.azure.com/org/project/_workitems/edit/12345` for validated task-text reuse | `https://dev.azure.com/org/project/_workitems/edit/12345` |
+| Other/local | `local-tracking:482193` | `local-tracking:482193` |
 
-The downstream step `step-03b-extract-issue-number` extracts the issue number
-from this URL using:
+The downstream step `step-03b-extract-issue-number` accepts every output above.
+It extracts the numeric ID from:
 
-```bash
-grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | head -1
-```
+- GitHub issue URLs containing `/issues/N`
+- GitHub PR URLs containing `/pull/N` with closing-issue lookup fallback
+- Azure DevOps work-item URLs containing `/_workitems/edit/N`
+- Azure Boards references in the form `AB#N`
+- Local tracking references in the form `local-tracking:N`
 
-This extraction works identically for guard output and newly-created issue
-output, so `step-03b` requires no changes.
+This keeps the downstream `issue_number` output provider-agnostic.
 
 ---
 
@@ -125,7 +226,9 @@ output, so `step-03b` requires no changes.
 
 All diagnostic output goes to **stderr** and is not captured by the recipe
 runner's output pipeline. You can view it in the recipe's verbose log or by
-redirecting stderr.
+redirecting stderr. The table below is the expected diagnostic contract for
+the Issue #718 implementation; exact wording should not be treated as a stable
+public API.
 
 | Message                                                                      | When                             |
 | ---------------------------------------------------------------------------- | -------------------------------- |
@@ -136,19 +239,25 @@ redirecting stderr.
 | `INFO: Found existing open issue matching title — skipping creation`         | Guard 2 matched and reused       |
 | `INFO: No matching open issue found — proceeding to create`                  | Guard 2 fell through             |
 | `WARN: Extracted issue reference is not numeric: <value> — skipping guard 1` | Guard 1 rejected an unsafe value |
+| `INFO: Reusing work item AB#N`                                               | Azure DevOps path reused a work item |
+| `INFO: Using local tracking for issue management (remote: HOST)`             | Fallback path selected local tracking |
+| `WARN: 'az' CLI not found or org/project empty — using local tracking for AzDO remote` | Azure DevOps create path could not run |
 
 ---
 
 ## Error Handling
 
-| Failure mode                           | Behavior                                                                                                                           |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `gh issue view` times out (> 60 s)     | `timeout` returns exit 124; `\|\| echo ''` catches it; guard falls through                                                         |
-| `gh issue view` returns HTTP error     | `2>/dev/null` suppresses noise; `\|\| echo ''` falls through                                                                       |
-| `gh issue list --search` times out     | Same as above                                                                                                                      |
-| `gh issue list --search` returns empty | Empty string; guard falls through to creation                                                                                      |
-| `gh` not authenticated                 | `2>/dev/null` and `\|\| echo ''` suppress; both guards fall through; creation proceeds normally (or fails with a clear auth error) |
-| Non-numeric issue reference extracted  | Explicit `^[0-9]+$` validation skips guard 1 with a `WARN` message                                                                 |
+| Failure mode | Behavior |
+| ------------ | -------- |
+| `gh issue view` times out (> 60 s) | GitHub Guard 1 falls through |
+| `gh issue view` returns HTTP error | GitHub Guard 1 falls through |
+| `gh issue list --search` times out | GitHub Guard 2 falls through |
+| `gh issue list --search` returns empty | GitHub Guard 2 falls through to creation |
+| `gh` not authenticated on GitHub path | Reuse guards fall through; creation fails clearly if authentication is required |
+| `remote_host_type=azdo` or `azure-devops` with existing `issue_number` | Emits `AB#N` and exits 0 without calling `gh` or creating a work item |
+| Azure CLI missing on Azure DevOps create path | Falls back to `local-tracking:N` with a warning |
+| Azure DevOps org/project cannot be parsed | Falls back to `local-tracking:N` with a warning |
+| Non-numeric issue reference extracted | Explicit `^[0-9]+$` validation rejects it before any provider CLI receives it |
 
 The step uses `set -euo pipefail`. All expected-failure exit paths use
 `|| echo ''` or `|| true` so the script does not abort unexpectedly.
@@ -165,31 +274,44 @@ The step uses `set -euo pipefail`. All expected-failure exit paths use
 | Captured number contains semicolons, pipes, or other characters    | Explicit `^[0-9]+$` validation rejects anything non-numeric before it reaches `gh issue view "$REF_ISSUE_NUM"`                                                                                                                 |
 | Long or special-character title passed to `gh issue list --search` | Double-quoted variable `"$SEARCH_QUERY"` prevents shell word-splitting; `gh` CLI handles API-level escaping                                                                                                                    |
 | Template injection via `task_description` or `final_requirements`  | Both are captured via unquoted heredoc (`<<EOFTASKDESC`) into bash variables (`TASK_DESC`, `ISSUE_REQS`). The issue body is assembled with `printf` using double-quoted variable expansions — no `eval`, no unquoted expansion |
+| Untrusted `remote_host_type` value | Quoted host dispatch routes only explicit `github`, `azdo`, and `azure-devops` values to provider logic; all other values use local tracking |
+| Azure DevOps alias with shell metacharacters | The alias match is exact; values such as `azure-devops; gh issue create ...` do not match and fall back to local tracking |
 
 ### Trusted Inputs
 
 The recipe context variables `task_description` and `final_requirements` must
 never contain secrets or authentication tokens. They are embedded verbatim in
-the GitHub issue body, which is publicly visible on public repositories.
+new GitHub issue bodies or Azure Boards work-item descriptions. Public
+repositories and shared Azure DevOps projects may expose that text to broad
+audiences.
 
 ---
 
 ## Configuration
 
-The guards require no configuration. They activate automatically on every
-`step-03-create-issue` execution.
+Step 03 reads these recipe context keys:
 
-The only tuneable behaviour is the `condition: "not issue_number"` guard on
-the step itself: if `issue_number` is already set in the recipe context (e.g.,
-passed in explicitly via `-c issue_number=42`), the entire step is skipped.
+| Context key | Required | Description |
+| ----------- | -------- | ----------- |
+| `repo_path` | Yes | Repository or worktree path where `git remote get-url origin` runs |
+| `task_description` | Yes | Free-form task text used for title creation and existing reference extraction |
+| `final_requirements` | No | Requirements text included in newly created GitHub issues or Azure Boards work items |
+| `remote_host_type` | No | Host routing value; accepts `github`, `azdo`, `azure-devops`, `other`, or empty |
+| `issue_number` | No | Existing tracking ID. On Azure DevOps, this is reused as `AB#N` without GitHub issue logic |
+
+Step 02d normally sets `remote_host_type`. Callers may override it when
+resuming from external workflow context.
 
 ```bash
-# Skip step-03 entirely — use a pre-existing issue number
+# Explicit Azure DevOps alias and existing work item reuse
 amplihack recipe run default-workflow \
-  -c issue_number=42 \
-  -c task_description="Fix login timeout" \
+  -c remote_host_type=azure-devops \
+  -c issue_number=12345 \
+  -c task_description="Follow up on existing Azure Boards work item" \
   -c repo_path="$(pwd)"
 ```
+
+GitHub behavior remains unchanged when `remote_host_type=github`.
 
 ---
 
@@ -221,7 +343,48 @@ No duplicate issue created. Step-03b extracts `4194` as normal.
 
 ---
 
-### Example 2: Re-running without an explicit issue reference
+### Example 2: Azure DevOps PR follow-up with an existing work item
+
+An Azure DevOps follow-up workflow already knows the Boards work item ID from
+the PR or workstream context.
+
+```bash
+amplihack recipe run default-workflow \
+  -c remote_host_type=azure-devops \
+  -c issue_number=12345 \
+  -c task_description="Address review feedback for the Azure DevOps PR" \
+  -c repo_path=/worktrees/ado-pr-follow-up
+```
+
+**Step-03 output (stdout):**
+
+```text
+AB#12345
+```
+
+The GitHub issue path is not entered. No `gh issue` command runs, and no
+duplicate Azure Boards work item is created.
+
+---
+
+### Example 3: Azure DevOps task description reference
+
+```bash
+amplihack recipe run default-workflow \
+  -c remote_host_type=azdo \
+  -c task_description="Fix pipeline timeout described in AB#12345" \
+  -c repo_path="$(pwd)"
+```
+
+Step 03 routes to the Azure DevOps path because the host is `azdo`. The
+`AB#12345` reference is treated as an Azure Boards candidate, never as a
+GitHub issue. If Azure Boards lookup resolves the work item, the workflow uses
+that ID; otherwise the Azure DevOps create/fallback path continues without
+crossing into GitHub logic.
+
+---
+
+### Example 4: Re-running GitHub without an explicit issue reference
 
 Previous run created issue #4200 with title `"Add user profile page"`. New run
 has the same `task_description` but no `#NNNN` reference.
@@ -245,7 +408,7 @@ https://github.com/myorg/myrepo/issues/4200
 
 ---
 
-### Example 3: First run — no existing issue
+### Example 5: First GitHub run — no existing issue
 
 No prior issues match. Both guards fall through; a new issue is created.
 
@@ -264,7 +427,26 @@ https://github.com/myorg/myrepo/issues/4201
 
 ---
 
-### Example 4: Very long task description
+### Example 6: Unknown host fallback
+
+```bash
+amplihack recipe run default-workflow \
+  -c remote_host_type=gitlab \
+  -c task_description="Add config parser" \
+  -c repo_path="$(pwd)"
+```
+
+**Step-03 output (stdout):**
+
+```text
+local-tracking:482193
+```
+
+Unknown host values never enter GitHub or Azure DevOps provider logic.
+
+---
+
+### Example 7: Very long task description
 
 `task_description` is 500 characters long. The issue title is truncated to 200
 characters (recipe-level truncation). Guard 2's search query uses only the
@@ -293,53 +475,50 @@ gadugi-test run tests/gadugi/step-03-issue-creation-idempotency.yaml --verbose
 gadugi-test validate tests/gadugi/step-03-issue-creation-idempotency.yaml
 ```
 
-**Coverage (20 scenarios):**
+**Coverage includes:**
 
 | Area                                               | Scenarios |
 | -------------------------------------------------- | --------- |
-| Guard 1: `#NNNN` extraction                        | S11, S12  |
-| Guard 1: numeric validation / injection prevention | S13       |
-| Guard 2: title truncation                          | S14, S15  |
-| Output URL compatibility with step-03b             | S16       |
-| Both guards exit 0 on reuse                        | S10       |
-| Guard ordering (1 before 2, creation last)         | S17       |
-| API failure fallthrough (`\|\| echo ''`)           | S20       |
-| `timeout 60` wrappers                              | S7        |
-| Stderr routing                                     | S8        |
-| `set -euo pipefail`                                | S19       |
-| Pattern provenance (step-16 reference)             | S18       |
-| YAML structure grep checks                         | S1–S9     |
+| GitHub Guard 1: `#NNNN` extraction | Existing GitHub issue reuse |
+| GitHub Guard 1: numeric validation / injection prevention | Unsafe reference rejection |
+| GitHub Guard 2: title truncation | Long title search safety |
+| Azure DevOps alias dispatch | `remote_host_type=azdo` and `remote_host_type=azure-devops` route identically |
+| Azure DevOps existing context reuse | `issue_number=N` emits `AB#N` without calling `gh` |
+| Azure DevOps task text candidates | `AB#N` and host-scoped `#N` references stay in Azure Boards logic and never trigger GitHub issue commands |
+| Generic fallback | Unknown, empty, and non-git hosts emit `local-tracking:N` |
+| Output compatibility with step-03b | GitHub URL, Azure Boards URL, `AB#N`, and `local-tracking:N` parse to numeric IDs |
+| Host isolation | Azure DevOps and generic paths never execute `gh issue` commands |
+| `set -euo pipefail` and quoted host dispatch | Shell syntax remains safe for empty or malformed context |
 
 ---
 
 ## Known Limitations
 
-**Guard 2 false positives.** `gh issue list --search` uses GitHub's full-text
-search, which can match issues whose titles differ from the current one. When
-this happens, step-03 reuses the matched issue instead of creating a new one.
-This is intentional: a false-positive reuse is preferable to creating a
-duplicate. The matched issue URL is passed downstream as normal, and the
+**GitHub Guard 2 false positives.** `gh issue list --search` uses GitHub's
+full-text search, which can match issues whose titles differ from the current
+one. When this happens, step-03 reuses the matched issue instead of creating a
+new one. This is intentional: a false-positive reuse is preferable to creating
+a duplicate. The matched issue URL is passed downstream as normal, and the
 workflow tracks progress there.
 
-**TOCTOU race.** Between Guard 2's search and `gh issue create`, a concurrent
-workflow run could create a matching issue. In that case, two issues would
-exist — the same worst-case as before the guards were added. GitHub issue
+**GitHub TOCTOU race.** Between Guard 2's search and `gh issue create`, a
+concurrent workflow run could create a matching issue. In that case, two issues
+would exist — the same worst-case as before the guards were added. GitHub issue
 creation is inherently non-atomic, so this is not mitigated.
 
-**Guard 1 uses only the first `#NNNN` reference.** If `task_description`
-contains multiple issue references, only the first one is checked. If that
-issue was closed or deleted, Guard 1 falls through to Guard 2 even if a later
-reference would have matched.
+**Reference guards use the first matching ID.** If `task_description` contains
+multiple `#NNNN` or `AB#NNNN` references, the first host-appropriate reference
+is used.
 
 ---
 
 ## Multi-Provider Note
 
-The idempotency guards documented above are **GitHub-specific** — they use
-`gh issue view` and `gh issue list`. When `remote_provider` is `"azdo"` or
-`"local"`, step-03 takes a different code path that does not execute these
-guards. See [Multi-Provider Workflow Reference](multi-provider-workflow.md)
-for the provider-specific issue creation logic.
+The GitHub idempotency guards use `gh issue view` and `gh issue list` only
+inside the `github` host branch. Azure DevOps host values (`azdo` and
+`azure-devops`) use Azure Boards references and never fall through into GitHub
+issue logic. See [Multi-Provider Workflow Reference](multi-provider-workflow.md)
+for the provider-specific workflow contract.
 
 ---
 

--- a/docs/reference/workflow-issue-extraction.md
+++ b/docs/reference/workflow-issue-extraction.md
@@ -2,18 +2,19 @@
 
 > [Home](../index.md) > Reference > Workflow Issue Extraction
 
-Reference for the three-tier issue-number extraction logic in
-`default-workflow` step `03b`. This step resolves a GitHub issue number from
-the workflow context so that downstream steps can link the working branch,
-commit, and pull request to the correct issue.
+Reference for the issue-number extraction logic in `default-workflow` step
+`03b`. This step resolves a provider-neutral tracking number from the workflow
+context so downstream steps can link the working branch, commit, and pull
+request to the correct GitHub issue, Azure Boards work item, or local tracking
+ID.
 
 ## Contents
 
 - [Overview](#overview)
-- [Three-Tier Extraction](#three-tier-extraction)
-  - [Tier 1 — Direct issue URL](#tier-1--direct-issue-url)
-  - [Tier 2 — Pull request URL](#tier-2--pull-request-url)
-  - [Tier 3 — Bare #N reference](#tier-3--bare-n-reference)
+- [Extraction Order](#extraction-order)
+  - [Primary source: Step 03 output](#primary-source-step-03-output)
+  - [Compatibility fallback: task text references](#compatibility-fallback-task-text-references)
+- [Provider Output Formats](#provider-output-formats)
 - [Output Contract](#output-contract)
 - [Shell Security Constraints](#shell-security-constraints)
 - [Configuration](#configuration)
@@ -25,95 +26,111 @@ commit, and pull request to the correct issue.
 
 ## Overview
 
-Step `03b` accepts a free-form `task_description` string (e.g. a copied GitHub
-issue URL, a PR URL, or a plain-text description containing `#123`) and
-produces a canonical `issue_number` integer that the rest of the workflow uses.
+Step `03b` accepts the `issue_creation` output from step 03 plus the original
+`task_description`, then produces a canonical `issue_number` integer that the
+rest of the workflow uses.
 
 ```
-task_description  ──►  03b extraction  ──►  issue_number (int | null)
-                                             branch_prefix
-                                             issue_title (str | null)
+issue_creation + task_description ──► 03b extraction ──► issue_number (int)
 ```
 
-If no issue number can be resolved, `issue_number` is `null` and the workflow
-continues with an anonymous branch name.
+Step 03 is responsible for emitting a parseable tracking reference. If neither
+Step 03 output nor the compatibility task-text fallback is parseable, Step 03b
+fails loudly instead of silently continuing with the wrong branch or commit
+reference.
 
 ---
 
-## Three-Tier Extraction
+## Extraction Order
 
-The tiers are evaluated in order; the first match wins.
+The sources are evaluated in order; the first match wins.
 
-### Tier 1 — Direct issue URL
+### Primary source: Step 03 output
 
-**Pattern**: `https://github.com/<owner>/<repo>/issues/<N>`
+Step 03b first parses the `issue_creation` value emitted by Step 03. This is
+the canonical source because Step 03 owns host dispatch, provider validation,
+reuse decisions, and create/fallback behavior.
 
-When `task_description` contains a URL whose path component is
-`/issues/<digits>`, the issue number is extracted directly from the URL without
-any network call.
+Supported `issue_creation` formats:
+
+| Step 03 output | Extraction behavior |
+| -------------- | ------------------- |
+| `https://github.com/owner/repo/issues/N` | Extracts `N` from `/issues/N` without a network call |
+| `https://github.com/owner/repo/pull/N` | Uses `gh pr view` to read the first closing issue; falls back to PR number `N` if no closing issue resolves |
+| `https://dev.azure.com/org/project/_workitems/edit/N` | Extracts `N` from `/_workitems/edit/N` without a network call |
+| `AB#N` | Extracts `N` without a network call |
+| `local-tracking:N` | Extracts `N` without a network call |
 
 ```
-Input:  "Fix the crash described in https://github.com/rysweet/amplihack-rs/issues/3960"
+Input:  "https://github.com/rysweet/amplihack-rs/issues/3960"
 Match:  issues/3960
 Output: issue_number=3960
 ```
 
-This tier is purely regex-based and never calls `gh`.
-
----
-
-### Tier 2 — Pull request URL
-
-**Pattern**: `https://github.com/<owner>/<repo>/pull/<N>`
-
-When `task_description` contains a PR URL, step `03b` calls `gh pr view` to
-retrieve the list of issues that the PR closes:
+For pull request URLs, Step 03b calls:
 
 ```bash
 gh pr view <N> \
-    --repo <owner>/<repo> \
     --json closingIssuesReferences \
     --jq '.closingIssuesReferences[0].number'
 ```
 
-The first closing issue reference is used. If the PR closes no issues,
-extraction falls through to Tier 3.
+The first closing issue reference is used. If the PR closes no issues or the
+lookup fails, the PR number itself is used as the numeric tracking ID. Step 03b
+does not scan `task_description` for GitHub issue or PR URLs.
 
 ```
-Input:  "Continue work on https://github.com/rysweet/amplihack-rs/pull/4143"
+Input:  "https://github.com/rysweet/amplihack-rs/pull/4143"
 gh call: closingIssuesReferences → [3960, 3983]
 Output: issue_number=3960   (first reference)
 ```
 
-**Timeout**: 60 seconds. If `gh` does not respond within the timeout, Tier 2
-is skipped and extraction falls through to Tier 3.
+**Timeout**: 60 seconds. If `gh` does not respond within the timeout, the PR
+number is used as the fallback tracking ID.
 
 ---
 
-### Tier 3 — Bare `#N` reference
+### Compatibility fallback: task text references
 
-**Pattern**: `#<digits>` anywhere in `task_description`
+If `issue_creation` is not parseable, Step 03b falls back to references in
+`task_description` for compatibility with older or manually supplied contexts:
 
-When neither a direct issue URL nor a PR URL is found, step `03b` scans
-`task_description` for bare `#N` patterns. Each candidate is verified with:
-
-```bash
-gh issue view <N> --json url --jq '.url // ""'
-```
-
-The command returns the issue URL. If the URL path contains `/issues/`, the
-candidate is accepted. Candidates that return an empty URL (non-existent or
-wrong repo) are skipped.
+| Task text pattern | Extraction behavior |
+| ----------------- | ------------------- |
+| `AB#N` | Extracts `N` |
+| `#N` | Extracts `N` |
 
 ```
-Input:  "Resume work on #3983 and #3960"
-gh verify 3983 → url: "https://github.com/rysweet/amplihack-rs/issues/3983"
-  → contains /issues/ → issue_number=3983
+issue_creation:   "unparseable legacy value"
+task_description: "Continue work on AB#12345"
+Output:           issue_number=12345
 ```
 
-**Timeout**: 60 seconds per candidate.
+This fallback is intentionally regex-only. Step 03 is responsible for deciding
+whether `#N` means a GitHub issue, Azure Boards work item, or local reference;
+Step 03b only preserves the numeric workflow contract.
 
-If no candidate passes verification, `issue_number` is `null`.
+---
+
+## Provider Output Formats
+
+Step 03b extracts IDs from the provider-specific output formats produced by
+`step-03-create-issue`, plus task-text fallback references used for
+compatibility.
+
+| Provider path | Step 03 output | Extraction result |
+| ------------- | -------------- | ----------------- |
+| GitHub issue | `https://github.com/owner/repo/issues/3960` | `3960` |
+| GitHub PR fallback | `https://github.com/owner/repo/pull/4143` | First closing issue, or `4143` if none resolves |
+| Azure DevOps work item URL | `https://dev.azure.com/org/project/_workitems/edit/12345` | `12345` |
+| Azure Boards shorthand | `AB#12345` | `12345` |
+| Local tracking | `local-tracking:482193` | `482193` |
+| Compatibility Azure Boards reference | `AB#12345` in `task_description` | `12345` |
+| Compatibility bare reference | `#12345` in `task_description` | `12345` |
+
+The `AB#N` shorthand is the canonical reuse output for Azure DevOps runs that
+start with an existing `issue_number` context value. It lets Step 03 reuse a
+known work item without requiring a live Azure CLI lookup.
 
 ---
 
@@ -123,13 +140,9 @@ After step `03b` completes, the workflow context contains:
 
 | Field          | Type          | Description                                             |
 | -------------- | ------------- | ------------------------------------------------------- |
-| `issue_number` | `int \| null` | Resolved GitHub issue number, or `null` if unresolvable |
+| `issue_number` | `int` | Provider-neutral tracking number extracted from step 03 output |
 
-> **Planned enhancements**: `issue_title` (fetched from GitHub), `branch_prefix`
-> (inferred from context), and `extraction_tier` (which tier produced the result)
-> are targeted for a follow-up to improve debuggability.
-
-### Example output (Tier 1)
+### Example output
 
 ```json
 {
@@ -137,13 +150,8 @@ After step `03b` completes, the workflow context contains:
 }
 ```
 
-### Example output (no match)
-
-```json
-{
-  "issue_number": null
-}
-```
+If extraction fails, step 03b exits non-zero and prints the unparseable
+`issue_creation` value to stderr.
 
 ---
 
@@ -152,12 +160,13 @@ After step `03b` completes, the workflow context contains:
 Step `03b` follows the same shell-security rules as the rest of the default
 workflow:
 
-| Constraint                          | Detail                                                                                                                                                                         |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **No `shell=True`**                 | All `gh` subprocess calls use a list-form argv; no shell interpolation                                                                                                         |
-| **Heredoc delimiter single-quoted** | The `EOFISSUECREATION` delimiter in the issue-creation heredoc is always single-quoted (`'EOFISSUECREATION'`) to prevent shell metacharacter expansion from `task_description` |
-| **60-second timeout**               | Every `gh` subprocess call carries `timeout=60`; hung subprocesses do not stall the workflow                                                                                   |
-| **No credential logging**           | `gh` output is captured in memory and never written to disk unredacted                                                                                                         |
+| Constraint | Detail |
+| ---------- | ------ |
+| **Quoted variables** | `ISSUE_CREATION` and `TASK_DESCRIPTION` are assigned and matched with quoted shell variables |
+| **Regex-only numeric capture** | Every accepted identifier is captured with `[0-9]+`; no provider CLI receives an unvalidated ID |
+| **60-second timeout** | GitHub PR closing-issue lookup uses `timeout 60`; hung subprocesses do not stall the workflow |
+| **No provider crossover** | Azure Boards formats (`AB#N`, `_workitems/edit/N`) are parsed locally and do not require GitHub CLI calls |
+| **Visible failure** | If no supported pattern matches, the step exits non-zero and prints the unparseable `issue_creation` value to stderr |
 
 ---
 
@@ -165,14 +174,14 @@ workflow:
 
 Step `03b` reads the following values from the workflow context:
 
-| Context key           | Required | Description                                                                |
-| --------------------- | -------- | -------------------------------------------------------------------------- |
-| `task_description`    | Yes      | Free-form string describing the task                                       |
-| `repo_path`           | Yes      | Absolute path used to derive `owner/repo` from `git remote get-url origin` |
-| `expected_gh_account` | No       | If set, `gh api /user` is checked before Tier 2/3 network calls            |
+| Context key | Required | Description |
+| ----------- | -------- | ----------- |
+| `issue_creation` | Yes | Step 03 output: GitHub URL, Azure Boards URL, `AB#N`, or `local-tracking:N` |
+| `task_description` | Yes | Free-form string used only as a compatibility fallback source for `AB#N` or `#N` references |
 
-No environment variables are specific to step `03b`; it relies on the
-authenticated `gh` CLI configured in the user's shell.
+No environment variables are specific to step `03b`. GitHub PR closing-issue
+lookup relies on the authenticated `gh` CLI configured in the user's shell.
+Azure Boards and local tracking extraction are regex-only.
 
 ---
 
@@ -182,13 +191,11 @@ authenticated `gh` CLI configured in the user's shell.
 
 ```yaml
 # Recipe context snippet
-task_description: |
-  Fix path-traversal bug.
-  See https://github.com/rysweet/amplihack-rs/issues/3960
+issue_creation: "https://github.com/rysweet/amplihack-rs/issues/3960"
 ```
 
 ```
-Tier 1 match: 3960
+issues/ match: 3960
 issue_number: 3960
 ```
 
@@ -197,11 +204,10 @@ issue_number: 3960
 ### Resolving from a PR URL
 
 ```yaml
-task_description: "Resume https://github.com/rysweet/amplihack-rs/pull/4143"
+issue_creation: "https://github.com/rysweet/amplihack-rs/pull/4143"
 ```
 
 ```
-No issues/ URL found → Tier 2
 gh pr view 4143 --json closingIssuesReferences
 → [3960, 3983]
 issue_number: 3960
@@ -209,29 +215,56 @@ issue_number: 3960
 
 ---
 
-### Resolving from a bare `#N` pattern
+### Resolving from compatibility task text fallback
 
 ```yaml
+issue_creation: "legacy output"
 task_description: "Continue work on #3983"
 ```
 
 ```
-No issues/ URL, no pull/ URL → Tier 3
-gh issue view 3983 → url contains /issues/ → accepted
+No supported issue_creation format → task text fallback
 issue_number: 3983
 ```
 
 ---
 
-### No resolvable issue
+### Resolving from an Azure Boards shorthand
 
 ```yaml
-task_description: "Refactor the config module for clarity"
+issue_creation: "AB#12345"
+task_description: "Address review feedback for the Azure DevOps PR"
 ```
 
 ```
-No URL, no #N → issue_number: null
-branch name falls back to slugified task_description
+AB# match: 12345
+issue_number: 12345
+```
+
+---
+
+### Resolving from local tracking
+
+```yaml
+issue_creation: "local-tracking:482193"
+```
+
+```
+local-tracking match: 482193
+issue_number: 482193
+```
+
+---
+
+### Invalid step 03 output
+
+```yaml
+issue_creation: "unparseable provider output"
+```
+
+```
+No supported pattern → step 03b exits non-zero
+stderr includes the unparseable issue_creation value
 ```
 
 ---
@@ -241,43 +274,41 @@ branch name falls back to slugified task_description
 **`gh: command not found`**
 
 Install and authenticate the GitHub CLI: `gh auth login`.
-Step `03b` degrades gracefully — Tier 1 (regex-only) still works without `gh`.
+Only GitHub PR closing-issue lookup requires `gh`; direct issue URLs, Azure
+Boards outputs, `AB#N`, and `local-tracking:N` still parse without it.
 
-**Tier 2 returns no closing issues**
+**GitHub PR lookup returns no closing issues**
 
-The PR may not use closing keywords (`Closes #N`, `Fixes #N`). Add a closing
-keyword to the PR description, or supply the issue URL directly in
-`task_description`.
+The PR may not use closing keywords (`Closes #N`, `Fixes #N`). In that case
+Step 03b uses the PR number itself as the numeric tracking ID.
 
-**Tier 3 skips a valid issue number**
+**Task text fallback resolves a bare `#N` unexpectedly**
 
-The issue may not exist in the repository that `gh` is authenticated against,
-or the `gh issue view` call returned an empty URL. Check that the issue exists
-and that `gh auth status` shows the correct account. Closed issues that are
-still in the repository will also resolve successfully — verification is
-URL-based (`*/issues/*`), not state-based.
+Step 03b does not verify bare `#N` against a provider. Provider validation must
+happen in Step 03 before it emits `issue_creation`.
 
-**Tier 3 does not resolve a `#N` that is present**
+**Task text fallback does not resolve a `#N` that is present**
 
 The `#N` pattern requires at least one digit. Values like `#` alone or
-`#abc` are not matched. Check that the issue exists in the resolved repository
-and that `gh issue view <N>` returns a URL containing `/issues/`.
+`#abc` are not matched.
 
 ---
 
 ## Multi-Provider Extraction
 
-When `remote_provider` is not `"github"`, step 03b extracts issue numbers
-from provider-specific URL formats in addition to the GitHub patterns above:
+Step 03b extracts issue numbers from provider-specific URL formats in addition
+to GitHub issue and PR patterns:
 
-| Provider | URL pattern                                           | Extraction regex             |
-| -------- | ----------------------------------------------------- | ---------------------------- |
-| GitHub   | `https://github.com/owner/repo/issues/N`               | `issues/[0-9]+`              |
-| AzDO     | `https://dev.azure.com/org/project/_workitems/edit/N`   | `_workitems/edit/[0-9]+`     |
-| Local    | Bare numeric string from synthetic ID                   | `^[0-9]+$`                   |
+| Provider | Accepted pattern | Extraction regex |
+| -------- | ---------------- | ---------------- |
+| GitHub | `https://github.com/owner/repo/issues/N` | `issues/([0-9]+)` |
+| GitHub PR | `https://github.com/owner/repo/pull/N` | `pull/([0-9]+)` plus closing-issue lookup |
+| Azure DevOps | `https://dev.azure.com/org/project/_workitems/edit/N` | `_workitems/edit/([0-9]+)` |
+| Azure DevOps | `AB#N` | `AB#([0-9]+)` |
+| Local | `local-tracking:N` | `local-tracking:([0-9]+)` |
 
-The `issue_number` output contract is unchanged: a plain integer regardless
-of provider. See [Multi-Provider Workflow Reference](multi-provider-workflow.md)
+The `issue_number` output contract is unchanged: a plain integer regardless of
+provider. See [Multi-Provider Workflow Reference](multi-provider-workflow.md)
 for full details.
 
 ---
@@ -302,8 +333,8 @@ for full details.
 
 | Field       | Value                                                         |
 | ----------- | ------------------------------------------------------------- |
-| Status      | Planned / PR #4143                                            |
-| Issues      | #3960, #3983                                                  |
+| Status      | Issue #718 target contract                                    |
+| Issues      | #3960, #3983, #718                                            |
 | PR          | #4143                                                         |
 | Recipe file | `amplifier-bundle/recipes/default-workflow.yaml` (step `03b`) |
 | Test file   | `amplifier-bundle/tools/test_default_workflow_fixes.py`       |

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -627,6 +627,57 @@ fn workflow_prep_step_03_consumes_remote_host_type() {
 }
 
 #[test]
+fn workflow_prep_step_03_accepts_azure_devops_host_alias() {
+    let command = step_command("workflow-prep", "step-03-create-issue");
+
+    assert!(
+        command.contains("azdo"),
+        "step-03 must continue to support the existing 'azdo' Azure DevOps host value"
+    );
+    assert!(
+        command.contains("azure-devops"),
+        "step-03 must also support the explicit 'azure-devops' host value from recipe context"
+    );
+
+    let alias_dispatch = command.contains("azdo|azure-devops")
+        || command.contains("azure-devops|azdo")
+        || (command.contains("\"azdo\"") && command.contains("\"azure-devops\""))
+        || (command.contains("'azdo'") && command.contains("'azure-devops'"));
+    assert!(
+        alias_dispatch,
+        "step-03 must dispatch 'azdo' and 'azure-devops' through the same Azure DevOps branch"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03_reuses_existing_issue_number_before_provider_commands() {
+    let command = step_command("workflow-prep", "step-03-create-issue");
+
+    let issue_number_pos = command
+        .find("ISSUE_NUMBER")
+        .expect("step-03 must read existing ISSUE_NUMBER context before creating/searching issues");
+    let first_gh_issue_pos = command
+        .find("gh issue")
+        .expect("step-03 must retain GitHub issue logic for GitHub hosts");
+    let first_az_boards_pos = command
+        .find("az boards")
+        .expect("step-03 must retain Azure Boards create/lookup logic for Azure DevOps hosts");
+
+    assert!(
+        issue_number_pos < first_gh_issue_pos,
+        "step-03 must check existing ISSUE_NUMBER before entering GitHub issue logic"
+    );
+    assert!(
+        issue_number_pos < first_az_boards_pos,
+        "step-03 must check existing ISSUE_NUMBER before Azure CLI work-item logic"
+    );
+    assert!(
+        command.contains("AB#"),
+        "step-03 must emit an Azure Boards reference such as AB#N when reusing existing work items"
+    );
+}
+
+#[test]
 fn workflow_prep_step_03_has_github_path_inside_host_conditional() {
     let command = step_command("workflow-prep", "step-03-create-issue");
 

--- a/tests/integration/issue_684_host_aware_workflow_test.rs
+++ b/tests/integration/issue_684_host_aware_workflow_test.rs
@@ -32,7 +32,10 @@
 /// These tests are written **TDD-RED**. They FAIL until the implementation
 /// changes land across the four recipe files.
 use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
 
 use serde_yaml::Value;
 
@@ -113,6 +116,98 @@ fn step_output(recipe: &Value, step_id: &str) -> Option<String> {
         }
     }
     None
+}
+
+fn write_executable(path: &std::path::Path, content: &str) {
+    let mut file = fs::File::create(path).expect("create shim executable");
+    file.write_all(content.as_bytes())
+        .expect("write shim executable");
+    drop(file);
+    let mut perms = fs::metadata(path).expect("shim metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod shim executable");
+}
+
+#[derive(Debug)]
+struct Step03Run {
+    output: Output,
+    gh_log: String,
+    az_log: String,
+}
+
+fn run_step_03(host_type: &str, issue_number: &str, task_description: &str) -> Step03Run {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo_dir = temp.path().join("repo");
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&repo_dir).expect("mkdir repo");
+    fs::create_dir_all(&bin_dir).expect("mkdir bin");
+
+    let gh_log = temp.path().join("gh.log");
+    let az_log = temp.path().join("az.log");
+
+    write_executable(
+        &bin_dir.join("git"),
+        r#"#!/bin/sh
+case "$1:$2" in
+  rev-parse:--is-inside-work-tree) exit 0 ;;
+  remote:get-url) printf '%s\n' 'https://dev.azure.com/example-org/My%20Project/_git/example-repo'; exit 0 ;;
+  *) echo "unexpected git invocation: $*" >&2; exit 2 ;;
+esac
+"#,
+    );
+
+    write_executable(
+        &bin_dir.join("gh"),
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+if [ "$1:$2:$3" = "issue:view:718" ]; then
+  printf '%s\n' 'https://github.com/example-org/example-repo/issues/718'
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 7
+"#,
+    );
+
+    write_executable(
+        &bin_dir.join("az"),
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$AZ_LOG"
+echo "unexpected az invocation: $*" >&2
+exit 7
+"#,
+    );
+
+    let path = format!(
+        "{}:{}",
+        bin_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let command = extract_step_body(&load_recipe("workflow-prep"), "step-03-create-issue");
+
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(command)
+        .env_clear()
+        .env("PATH", path)
+        .env("REPO_PATH", &repo_dir)
+        .env("REMOTE_HOST_TYPE", host_type)
+        .env("TASK_DESCRIPTION", task_description)
+        .env("FINAL_REQUIREMENTS", "Issue #718 regression requirements")
+        .env("ISSUE_NUMBER", issue_number)
+        .env("GH_LOG", &gh_log)
+        .env("AZ_LOG", &az_log)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run step-03-create-issue");
+
+    Step03Run {
+        output,
+        gh_log: fs::read_to_string(&gh_log).unwrap_or_default(),
+        az_log: fs::read_to_string(&az_log).unwrap_or_default(),
+    }
 }
 
 /// Get the context block from default-workflow.yaml.
@@ -518,6 +613,129 @@ fn step_03_rejects_invalid_percent_sequences() {
         "step-03 must have percent-decode logic that implicitly rejects invalid \
          sequences (e.g., %%ZZ). The decode itself will fail or pass through invalid \
          sequences which the expanded regex then catches. (Issue #684, BLOCKER 3)"
+    );
+}
+
+// ===========================================================================
+// Issue #718: step-03 reuses existing Azure DevOps work item context
+// ===========================================================================
+
+#[test]
+fn step_03_reuses_existing_issue_number_for_azure_devops_alias_without_gh_or_az() {
+    let run = run_step_03(
+        "azure-devops",
+        "718",
+        "ADO follow-up work with existing issue context",
+    );
+
+    let stdout = String::from_utf8_lossy(&run.output.stdout);
+    let stderr = String::from_utf8_lossy(&run.output.stderr);
+    assert!(
+        run.output.status.success(),
+        "azure-devops host with existing ISSUE_NUMBER must succeed; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "AB#718",
+        "azure-devops host with existing ISSUE_NUMBER must reuse the Azure Boards work item directly"
+    );
+    assert!(
+        run.gh_log.is_empty(),
+        "azure-devops host must not enter GitHub issue logic when ISSUE_NUMBER exists; gh log:\n{}",
+        run.gh_log
+    );
+    assert!(
+        run.az_log.is_empty(),
+        "azure-devops host must not call Azure CLI when ISSUE_NUMBER already supplies the work item; az log:\n{}",
+        run.az_log
+    );
+}
+
+#[test]
+fn step_03_reuses_existing_issue_number_for_azdo_alias_without_gh_or_az() {
+    let run = run_step_03(
+        "azdo",
+        "718",
+        "ADO follow-up work with existing issue context",
+    );
+
+    let stdout = String::from_utf8_lossy(&run.output.stdout);
+    let stderr = String::from_utf8_lossy(&run.output.stderr);
+    assert!(
+        run.output.status.success(),
+        "azdo host with existing ISSUE_NUMBER must succeed; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "AB#718",
+        "azdo host with existing ISSUE_NUMBER must reuse the Azure Boards work item directly"
+    );
+    assert!(
+        run.gh_log.is_empty(),
+        "azdo host must not enter GitHub issue logic when ISSUE_NUMBER exists; gh log:\n{}",
+        run.gh_log
+    );
+    assert!(
+        run.az_log.is_empty(),
+        "azdo host must not call Azure CLI when ISSUE_NUMBER already supplies the work item; az log:\n{}",
+        run.az_log
+    );
+}
+
+#[test]
+fn step_03_preserves_github_existing_issue_reuse_path() {
+    let run = run_step_03("github", "718", "GitHub follow-up for #718");
+
+    let stdout = String::from_utf8_lossy(&run.output.stdout);
+    let stderr = String::from_utf8_lossy(&run.output.stderr);
+    assert!(
+        run.output.status.success(),
+        "github host with referenced issue must succeed; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "https://github.com/example-org/example-repo/issues/718",
+        "github host must preserve existing gh issue reuse semantics"
+    );
+    assert!(
+        run.gh_log.contains("issue view 718"),
+        "github host must use gh issue view for referenced issues; gh log:\n{}",
+        run.gh_log
+    );
+    assert!(
+        run.az_log.is_empty(),
+        "github host must not call Azure CLI; az log:\n{}",
+        run.az_log
+    );
+}
+
+#[test]
+fn step_03_preserves_generic_local_tracking_fallback() {
+    let run = run_step_03(
+        "other",
+        "718",
+        "Generic host follow-up with existing context",
+    );
+
+    let stdout = String::from_utf8_lossy(&run.output.stdout);
+    let stderr = String::from_utf8_lossy(&run.output.stderr);
+    assert!(
+        run.output.status.success(),
+        "generic host must succeed via local tracking fallback; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.trim().starts_with("local-tracking:"),
+        "generic host must preserve local tracking fallback; stdout:\n{stdout}"
+    );
+    assert!(
+        run.gh_log.is_empty(),
+        "generic host must not call gh issue commands; gh log:\n{}",
+        run.gh_log
+    );
+    assert!(
+        run.az_log.is_empty(),
+        "generic host must not call Azure CLI; az log:\n{}",
+        run.az_log
     );
 }
 


### PR DESCRIPTION
## Summary
- Fix workflow-prep step-03 host dispatch for azdo and azure-devops.
- Reuse numeric ISSUE_NUMBER as AB#<number> for Azure DevOps without calling gh or az.
- Preserve GitHub issue reuse and generic local-tracking fallback behavior.
- Document workflow-prep issue reference resolution.

Fixes #718

## Tests
- cargo test --test issue_684_host_aware_workflow -- --nocapture
- cargo test --test default_workflow_decomposition -- --nocapture
- cargo test --test investigation_workflow_decomposition -- --nocapture
- cargo test --test consensus_workflow_decomposition -- --nocapture
- cargo test --test workflow_prep_git_recovery -- --nocapture
- bash tests/issue_684_azdo_remote_detection.sh