### PR TITLE
Fix workflow-prep Azure DevOps issue reuse

### DIFF
--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -274,7 +274,6 @@ steps:
       TASK_DESC="$TASK_DESCRIPTION"
       ISSUE_TITLE="${TASK_DESC//$'\n'/ }"; ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"; ISSUE_TITLE="${ISSUE_TITLE:0:200}"
       ISSUE_REQS="$FINAL_REQUIREMENTS"
-      # FIX #684: Guard git commands — fall back to local tracking outside git repos
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "[skip] not a git repo — using local tracking" >&2
         LOCAL_ISSUE=$(($(date +%s) % 1000000))
@@ -282,13 +281,12 @@ steps:
         exit 0
       fi
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
-      # Extract referenced issue/work-item from task_description (idempotency)
       REF_ISSUE_NUM=""
       if [[ "$TASK_DESC" =~ AB#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"; fi
       [ -n "$REF_ISSUE_NUM" ] && ! [[ "$REF_ISSUE_NUM" =~ ^[0-9]+$ ]] && REF_ISSUE_NUM=""
-      # --- GitHub path ---
-      if [ "$HOST_TYPE" = "github" ]; then
+      case "$HOST_TYPE" in
+      github)
         if [ -n "$REF_ISSUE_NUM" ]; then
           EXISTING_URL=$(timeout 60 gh issue view "$REF_ISSUE_NUM" --json url --jq '.url // ""' 2>/dev/null || echo '')
           [ -n "$EXISTING_URL" ] && { printf '%s\n' "$EXISTING_URL"; exit 0; }
@@ -304,12 +302,14 @@ steps:
         gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "$LABEL_NAME" 2>&1 || \
           gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY"
         exit $?
-      fi
-      # --- Azure DevOps path (az boards work-item) ---
-      if [ "$HOST_TYPE" = "azdo" ]; then
+        ;;
+      azdo|azure-devops)
+        if [[ "${ISSUE_NUMBER:-}" =~ ^[0-9]+$ ]]; then
+          printf 'ISSUE_REFERENCE=AB#%s\n' "$ISSUE_NUMBER" >> "${GITHUB_OUTPUT:-/dev/null}"
+          printf 'AB#%s\n' "$ISSUE_NUMBER"; exit 0
+        fi
         REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
         AZDO_ORG=""; AZDO_PROJECT=""
-        # Bash regex replaces 6 echo|sed subprocess spawns with built-in matching
         if [[ "$REMOTE_URL" =~ dev\.azure\.com/([^/]+)/([^/]+)/ ]]; then
           AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
         elif [[ "$REMOTE_URL" =~ ([^/.]+)\.visualstudio\.com/([^/]+)/ ]]; then
@@ -317,7 +317,6 @@ steps:
         elif [[ "$REMOTE_URL" =~ ssh\.dev\.azure\.com[:/]v3/([^/]+)/([^/]+)/ ]]; then
           AZDO_ORG="${BASH_REMATCH[1]}"; AZDO_PROJECT="${BASH_REMATCH[2]}"
         fi
-        # FIX #684: Decode %XX percent-encoding (e.g. My%20Project → My Project)
         _pct_decode() {
           local e="$1" d="" i=0 ch hex
           while [ "$i" -lt "${#e}" ]; do
@@ -337,13 +336,11 @@ steps:
         }
         [ -n "$AZDO_ORG" ] && { AZDO_ORG=$(_pct_decode "$AZDO_ORG") || { AZDO_ORG=""; AZDO_PROJECT=""; }; }
         [ -n "$AZDO_PROJECT" ] && { AZDO_PROJECT=$(_pct_decode "$AZDO_PROJECT") || { AZDO_ORG=""; AZDO_PROJECT=""; }; }
-        # Security: validate org/project captures against safe character set
         if [[ -n "$AZDO_ORG" ]] && ! [[ "$AZDO_ORG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
           echo "WARN: AZDO_ORG contains unexpected characters — using local tracking" >&2
           AZDO_ORG=""
         fi
-        # Project names may contain spaces (decoded from %20)
-        if [[ -n "$AZDO_PROJECT" ]] && ! [[ "$AZDO_PROJECT" =~ ^[a-zA-Z0-9._ -]+$ ]]; then
+        if [[ -n "$AZDO_PROJECT" ]] && ! [[ "$AZDO_PROJECT" =~ ^[a-zA-Z0-9._[:space:]-]+$ ]]; then
           echo "WARN: AZDO_PROJECT contains unexpected characters — using local tracking" >&2
           AZDO_PROJECT=""
         fi
@@ -363,8 +360,8 @@ steps:
         else
           echo "WARN: 'az' CLI not found or org/project empty — using local tracking for AzDO remote" >&2
         fi
-      fi
-      # --- Local tracking fallback (unknown remote or az CLI unavailable) ---
+        ;;
+      esac
       echo "INFO: Using local tracking for issue management (remote: $HOST_TYPE)" >&2
       LOCAL_ISSUE=$(($(date +%s) % 1000000))
       printf 'local-tracking:%s\n' "$LOCAL_ISSUE"


### PR DESCRIPTION
## Summary
- Route workflow-prep step-03 with a shell-safe host case dispatch.
- Reuse numeric ISSUE_NUMBER as AB#<number> for azdo and azure-devops without calling gh or az.
- Preserve GitHub issue handling and generic local-tracking fallback.

## Tests
- cargo test --test default_workflow_decomposition --quiet
- cargo test --test issue_684_host_aware_workflow --quiet
- cargo test --test workflow_prep_git_recovery --quiet
- bash tests/issue_684_azdo_remote_detection.sh
- Direct step-03 behavior check with stubbed gh/az for azdo, azure-devops, and generic fallback

Closes #718