### PR TITLE
Fix operations docs entrypoint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -460,6 +460,7 @@ Execute complex tasks with simple slash commands.
 
 ### Command Reference
 
+- [Operations Documentation](operations/README.md) - Operational entry point for autonomous mode, safety, and PR recovery readiness
 - [Command Selection Guide](commands/COMMAND_SELECTION_GUIDE.md) - Choose the right command for your task
 - [Amplifier Command](reference/amplifier-command.md) - Launch Amplifier with the amplihack bundle and argv-only prompt delivery
 - [resolve-bundle-asset Command](reference/resolve-bundle-asset-command.md) - Resolve native bundle assets and legacy parity aliases

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -2,7 +2,7 @@
 
 Operational documentation covers release canaries, workflow terminal-state
 behavior, conservative local cleanup, downstream validation, and the curated
-roadmap for rollout work.
+roadmap for rollout work, autonomous mode, and PR recovery readiness.
 
 ## Runbooks and references
 
@@ -13,6 +13,9 @@ roadmap for rollout work.
 | [Workflow Publish and Finalize Resilience](workflow-resilience.md) | Idempotent publish/finalize behavior for no-diff, already-merged, closed-after-merge, and existing-PR states. |
 | [Prompt Delivery Downstream Validation](prompt-delivery-downstream-validation.md) | Simard/RabbitHole-style delegated workflow validation against prompt delivery behavior. |
 | [Operational Roadmap](operational-roadmap.md) | Curated backlog for fleet rollout, Azure DevOps E2E, release contract monitoring, and workflow observability. |
+| [Auto Mode](../AUTO_MODE.md) | Autonomous multi-turn execution. |
+| [Auto Mode Safety](../AUTOMODE_SAFETY.md) | Safety guardrails and approval boundaries for autonomous execution. |
+| [PR Recovery Readiness](../PR_RECOVERY_READINESS.md) | Existing-PR recovery readiness contract. |
 
 ## Operating principles
 

--- a/tests/integration/doc_code_drift_test.rs
+++ b/tests/integration/doc_code_drift_test.rs
@@ -23,6 +23,10 @@ fn read_doc(relative: &str) -> String {
     fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()))
 }
 
+fn doc_exists(relative: &str) -> bool {
+    workspace_root().join(relative).exists()
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // D1: launch-flag-injection.md — drift fixes
 // ═══════════════════════════════════════════════════════════════════════════
@@ -752,6 +756,54 @@ mod mkdocs_navigation {
             assert!(
                 reference_section.contains(doc_file),
                 "'{doc_file}' must be in the Reference section of mkdocs.yml nav"
+            );
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Docs site recovery: top-level README/index conflicts and operations entry
+// ═══════════════════════════════════════════════════════════════════════════
+
+mod docs_site_recovery {
+    use super::*;
+
+    #[test]
+    fn top_level_docs_readme_does_not_conflict_with_index() {
+        assert!(
+            doc_exists("docs/index.md"),
+            "docs/index.md must remain the MkDocs landing page"
+        );
+        assert!(
+            !doc_exists("docs/README.md"),
+            "docs/README.md must not exist because MkDocs treats README.md as an index alias \
+             and strict builds exclude it when docs/index.md is present"
+        );
+    }
+
+    #[test]
+    fn operations_entrypoint_remains_discoverable_from_docs_index() {
+        assert!(
+            doc_exists("docs/operations/README.md"),
+            "docs/operations/README.md must exist as the operations documentation entry point"
+        );
+
+        let index = read_doc("docs/index.md");
+        assert!(
+            index.contains("operations/README.md"),
+            "docs/index.md must link to docs/operations/README.md so deleting the top-level \
+             docs/README.md does not remove operations-doc discoverability"
+        );
+
+        let operations = read_doc("docs/operations/README.md");
+        for expected_link in [
+            "../AUTO_MODE.md",
+            "../AUTOMODE_SAFETY.md",
+            "../PR_RECOVERY_READINESS.md",
+        ] {
+            assert!(
+                operations.contains(expected_link),
+                "docs/operations/README.md must preserve operational guidance link {expected_link}"
             );
         }
     }


### PR DESCRIPTION
Follow-up to #724 after the MkDocs README/index recovery.\n\n## Summary\n- add docs/operations/README.md as the operations documentation entry point\n- link the operations entry point from docs/index.md\n- add docs recovery contract coverage for the README/index conflict and operations discoverability\n\n## Validation\n- mkdocs build --strict\n- cargo test -p amplihack --test doc_code_drift docs_site_recovery -- --nocapture\n- cargo test -p amplihack --test security_hygiene\n- cargo test -p amplihack-launcher --test prompt_delivery\n- cargo test -p amplihack-utils --test prompt_delivery\n- cargo test -p amplihack --test default_workflow_decomposition\n- cargo test -p amplihack --test investigation_workflow_decomposition\n- cargo test -p amplihack --test workflow_prep_git_recovery\n- cargo test -p amplihack --test workflow_publish_pr_metadata\n- cargo test prompt_delivery\n- cargo test workflow\n- cargo fmt\n- cargo clippy --workspace --all-targets