### PR TITLE
Fix issue #723 hygiene cleanup clippy follow-up

### DIFF
--- a/crates/amplihack-cli/src/commands/hygiene/cleanup.rs
+++ b/crates/amplihack-cli/src/commands/hygiene/cleanup.rs
@@ -706,8 +706,10 @@ fn is_running_session(path: &Path, guards: &SessionGuards) -> bool {
     if guards.protected_ids.contains(name) {
         return true;
     }
-    if let Some(runtime_locks) = &guards.runtime_locks
-        && runtime_locks.join(name).exists()
+    if guards
+        .runtime_locks
+        .as_ref()
+        .is_some_and(|runtime_locks| runtime_locks.join(name).exists())
     {
         return true;
     }


### PR DESCRIPTION
## Summary
- keep the issue #723 hygiene cleanup runtime lock guard clippy-clean on current main
- preserve active-session protection behavior while avoiding the nested conditional form

## Validation
- cargo test --test hygiene_cleanup
- cargo test --test workflow_publish_resilience
- cargo test --test workflow_finalize_resilience
- cargo test -p amplihack-utils --test prompt_delivery_downstream
- cargo fmt
- cargo clippy --workspace --all-targets

Follow-up for #723.