### PR TITLE
Simplify operations docs entrypoint links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -460,7 +460,6 @@ Execute complex tasks with simple slash commands.
 
 ### Command Reference
 
-- [Operations Documentation](operations/README.md) - Operational entry point for autonomous mode, safety, and PR recovery readiness
 - [Command Selection Guide](commands/COMMAND_SELECTION_GUIDE.md) - Choose the right command for your task
 - [Amplifier Command](reference/amplifier-command.md) - Launch Amplifier with the amplihack bundle and argv-only prompt delivery
 - [resolve-bundle-asset Command](reference/resolve-bundle-asset-command.md) - Resolve native bundle assets and legacy parity aliases


### PR DESCRIPTION
Follow-up simplification after #725.\n\n## Summary\n- remove a duplicate Operations Documentation link from the Command Reference section\n- keep the canonical Operations section link to docs/operations/README.md\n- preserve the docs recovery contract and strict MkDocs behavior\n\n## Validation\n- NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack --test doc_code_drift docs_site_recovery -- --nocapture\n- NODE_OPTIONS=--max-old-space-size=32768 mkdocs build --strict\n- NODE_OPTIONS=--max-old-space-size=32768 focused hygiene, prompt_delivery, and workflow cargo tests\n- NODE_OPTIONS=--max-old-space-size=32768 cargo fmt\n- NODE_OPTIONS=--max-old-space-size=32768 cargo clippy --workspace --all-targets