### PR TITLE
Cache doc drift test file reads

### DIFF
--- a/tests/integration/doc_code_drift_test.rs
+++ b/tests/integration/doc_code_drift_test.rs
@@ -8,19 +8,37 @@
 //! source-of-truth in Rust source code. No binary execution required — these
 //! are pure file-content assertions.
 
+use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
-fn workspace_root() -> PathBuf {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.pop(); // tests/
-    path.pop(); // workspace root
-    path
+fn workspace_root() -> &'static Path {
+    static WORKSPACE_ROOT: OnceLock<PathBuf> = OnceLock::new();
+    WORKSPACE_ROOT
+        .get_or_init(|| {
+            let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            path.pop(); // tests/
+            path.pop(); // workspace root
+            path
+        })
+        .as_path()
 }
 
 fn read_doc(relative: &str) -> String {
+    static DOC_CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    let cache = DOC_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache.lock().expect("doc cache mutex poisoned");
+
+    if let Some(doc) = cache.get(relative) {
+        return doc.clone();
+    }
+
     let path = workspace_root().join(relative);
-    fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()))
+    let doc = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
+    cache.insert(relative.to_owned(), doc.clone());
+    doc
 }
 
 fn doc_exists(relative: &str) -> bool {


### PR DESCRIPTION
## Summary
- cache the doc drift test workspace root with OnceLock
- cache repeated documentation reads across doc drift integration tests
- keep assertion behavior unchanged while reducing repeated filesystem work

## Validation
- cargo fmt --check
- cargo test -p amplihack --test doc_code_drift -- --nocapture
- cargo test -p amplihack-utils --test prompt_delivery_downstream -- --nocapture
- cargo test -p amplihack-cli --test auto_mode_prompt_delivery -- --nocapture
- cargo test -p amplihack-cli --test doctor_prompt_delivery -- --nocapture

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>