### PR TITLE
Fix philosophy compliance clippy cleanup

### DIFF
--- a/crates/amplihack-cli/src/remote_cli_tests.rs
+++ b/crates/amplihack-cli/src/remote_cli_tests.rs
@@ -1,5 +1,5 @@
 use crate::Cli;
-use clap::{CommandFactory, Parser};
+use clap::CommandFactory;
 
 fn long_help_for(path: &[&str]) -> String {
     let mut command = Cli::command();

--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -520,8 +520,6 @@ mod cli_dispatch_tests {
     //! parses correctly and that recipes don't regress to the old legacy
     //! runtime-asset invocation.
     use crate::{Cli, Commands};
-    use clap::Parser;
-
     #[test]
     fn parses_named_asset_argument() {
         let cli = Cli::try_parse_from([

--- a/crates/amplihack-cli/tests/issue_634_asset_resolution_parity.rs
+++ b/crates/amplihack-cli/tests/issue_634_asset_resolution_parity.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use amplihack_cli::{Cli, Commands, resolve_bundle_asset, runtime_assets};
-use clap::Parser;
 
 #[derive(Clone, Copy)]
 enum ExpectedKind {

--- a/crates/amplihack-types/src/hook_io.rs
+++ b/crates/amplihack-types/src/hook_io.rs
@@ -337,7 +337,7 @@ mod tests {
                 stop_hook_active: Some(true),
                 transcript_path: Some(transcript_path),
                 session_id: Some(session_id),
-            } if transcript_path == PathBuf::from("/tmp/transcript.jsonl")
+            } if transcript_path.as_path() == std::path::Path::new("/tmp/transcript.jsonl")
                 && session_id == "session-789"
         ));
     }


### PR DESCRIPTION
## Summary
- Avoid an unnecessary `PathBuf` allocation in the hook input test assertion.
- Remove stale `clap::Parser` imports from CLI test code.
- Leave the reverted doc drift cache optimization out; it added unnecessary global test state for small docs/config reads.

## QA / outside-in evidence
Rust CLI repo: per QA-team guidance, native Rust tests are the outside-in/behavioral validation path.

- `cargo test -p amplihack-types --lib hook_io::tests::deserialize_stop_accepts_camel_case_optional_aliases -- --nocapture`
- `cargo test -p amplihack-cli remote_cli_tests -- --nocapture`
- `cargo test -p amplihack-cli resolve_bundle_asset::cli_dispatch_tests -- --nocapture`
- `cargo test -p amplihack-cli --test issue_634_asset_resolution_parity -- --nocapture`

## Docs
Not applicable: PR only changes tests/import cleanup; no CLI/API/config/user-facing behavior.

## Quality audit evidence
Scoped 3-cycle audit over PR diff completed:

- Cycle 1 SEEK/VALIDATE/FIX: stub/TODO/panic/output-pattern scan; no confirmed production findings.
- Cycle 2 SEEK/VALIDATE/FIX: security/filesystem/secret/shell-pattern scan; no confirmed findings.
- Cycle 3 SEEK/VALIDATE/FIX: public API/implementation-surface scan; no new public API or implementation surface.
- Final cycle clean: zero critical/high findings and zero medium correctness/security findings.

## CI
All required GitHub checks passed. Skipped checks are conditional release/scan paths.

## Scope
Changed files are limited to test/import cleanup:

- `crates/amplihack-cli/src/remote_cli_tests.rs`
- `crates/amplihack-cli/src/resolve_bundle_asset/mod.rs`
- `crates/amplihack-cli/tests/issue_634_asset_resolution_parity.rs`
- `crates/amplihack-types/src/hook_io.rs`
