### PR TITLE
Harden default-workflow terminal-state handling

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -112,6 +112,17 @@ context:
   final_cleanup: ""
   quality_audit_results: ""
   ci_status: ""
+  # Evidence-based terminal-state outputs produced by workflow-terminal-state.
+  # These suppress stale mutation/publish/finalize work after a branch is
+  # already merged, obsolete, or cleanly no-diff.
+  terminal_success: "false"
+  terminal_state: ""
+  terminal_reason: ""
+  publish_status: ""
+  should_publish: "true"
+  should_finalize: "true"
+  should_run_ci_wait: "true"
+  should_merge: "true"
 
 steps:
   # Git precondition is enforced in workflow-prep/step-01 before the first

--- a/amplifier-bundle/recipes/workflow-design.yaml
+++ b/amplifier-bundle/recipes/workflow-design.yaml
@@ -193,7 +193,9 @@ steps:
   #
   # Defensive: if `gh` is missing, ISSUE_NUMBER is unset, or any probe call
   # fails, we set goal_already_met="false" and let the workflow proceed
-  # normally — never short-circuit on uncertainty.
+  # normally — never short-circuit on uncertainty. Even when true, this legacy
+  # signal is only supporting evidence; workflow-terminal-state remains the
+  # authoritative fail-closed arbiter for dirty worktrees, PR state, diffs, and CI.
   - id: "step-06d-goal-already-met-probe"
     type: "bash"
     condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -17,10 +17,23 @@ inputs:
 context:
   worktree_setup: ""
   allow_no_op: false
+  terminal_success: "false"
+  terminal_state: ""
+  terminal_reason: ""
+  publish_status: ""
+  should_publish: "true"
+  should_finalize: "true"
+  should_run_ci_wait: "true"
+  should_merge: "true"
 
 steps:
+  - id: "finalize-terminal-state"
+    type: "recipe"
+    recipe: "workflow-terminal-state"
+
   - id: "step-20-final-cleanup"
     agent: "amplihack:cleanup"
+    condition: "terminal_state.terminal_success != 'true' && terminal_state.should_finalize == 'true'"
     prompt: |
       # Step 20: Final Cleanup and Verification
 
@@ -52,6 +65,7 @@ steps:
 
   - id: "step-20b-push-cleanup"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true' && terminal_state.should_finalize == 'true'"
     command: |
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
@@ -139,6 +153,7 @@ steps:
 
   - id: "step-20c-quality-audit"
     agent: "amplihack:core:reviewer"
+    condition: "terminal_state.terminal_success != 'true' && terminal_state.should_finalize == 'true'"
     prompt: |
       # Step 20c: Quality Audit Loop
 
@@ -161,6 +176,7 @@ steps:
 
   - id: "step-21-pr-ready"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true' && terminal_state.should_run_ci_wait == 'true'"
     command: |
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
@@ -180,6 +196,7 @@ steps:
 
   - id: "step-22-ensure-mergeable"
     agent: "amplihack:ci-diagnostic-workflow"
+    condition: "terminal_state.terminal_success != 'true' && terminal_state.should_run_ci_wait == 'true'"
     prompt: |
       # Step 21: Ensure PR is Mergeable (TASK COMPLETION POINT)
 
@@ -193,6 +210,7 @@ steps:
 
   - id: "step-22b-final-status"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true' && terminal_state.should_finalize == 'true'"
     command: |
       set -euo pipefail
       cd "${REPO_PATH:?step-22b-final-status requires repo_path; ensure parent recipe propagated repo_path context}"
@@ -201,6 +219,7 @@ steps:
       PR_URL="${PR_URL:-${PR_PUBLISH_RESULT_PR_URL:-${RECIPE_VAR_pr_publish_result__pr_url:-}}}"
       if [ -z "$PR_URL" ]; then : "N/A"; fi
       # Helper contract: git diff --quiet identifies no-diff; terminal_status accepts no-diff, already-merged, and closed-after-merge; GitHub-only status uses gh pr view.
+      # Terminal-state contract: FAILED_DIRTY_WORKTREE, FAILED_CLOSED_UNMERGED, FAILED_MEANINGFUL_DIFF, BLOCKED_CI, MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED.
       FINAL_STATUS_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_final_status.sh"
       if [ ! -f "$FINAL_STATUS_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then FINAL_STATUS_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_final_status.sh"; fi
       [ -f "$FINAL_STATUS_HELPER" ] || { echo "ERROR: workflow final-status helper not found: $FINAL_STATUS_HELPER" >&2; exit 1; }
@@ -217,13 +236,21 @@ steps:
       export ISSUE_VAL
       PR_VAL="${PR_URL:-${PR_PUBLISH_RESULT_PR_URL:-${RECIPE_VAR_pr_publish_result__pr_url:-}}}"
       export PR_VAL
-      TERMINAL_OUTCOME="${PR_PUBLISH_RESULT_STATE:-${RECIPE_VAR_pr_publish_result__state:-active-pr}}"
+      TERMINAL_STATE_VALUE="${TERMINAL_STATE_TERMINAL_STATE:-${RECIPE_VAR_terminal_state__terminal_state:-${PR_PUBLISH_RESULT_STATE:-${RECIPE_VAR_pr_publish_result__state:-active-pr}}}}"
+      TERMINAL_SUCCESS_VALUE="${TERMINAL_STATE_TERMINAL_SUCCESS:-${RECIPE_VAR_terminal_state__terminal_success:-false}}"
+      PUBLISH_STATUS_VALUE="${TERMINAL_STATE_PUBLISH_STATUS:-${RECIPE_VAR_terminal_state__publish_status:-${PR_PUBLISH_RESULT_STATE:-${RECIPE_VAR_pr_publish_result__state:-active-pr}}}}"
+      TERMINAL_REASON_VALUE="${TERMINAL_STATE_TERMINAL_REASON:-${RECIPE_VAR_terminal_state__terminal_reason:-}}"
+      TERMINAL_OUTCOME="$TERMINAL_STATE_VALUE"
       export TERMINAL_OUTCOME
       jq -n \
         --arg task "${TASK_VAL}" \
         --arg issue "${ISSUE_VAL}" \
         --arg pr "${PR_VAL}" \
         --arg terminal_outcome "${TERMINAL_OUTCOME}" \
+        --arg terminal_state "${TERMINAL_STATE_VALUE}" \
+        --arg terminal_success "${TERMINAL_SUCCESS_VALUE}" \
+        --arg terminal_reason "${TERMINAL_REASON_VALUE}" \
+        --arg publish_status "${PUBLISH_STATUS_VALUE}" \
         '{
           workflow: "default-workflow",
           version: "2.0.0",
@@ -231,6 +258,11 @@ steps:
           issue_number: $issue,
           pr_url: $pr,
           terminal_outcome: $terminal_outcome,
+          terminal_state: $terminal_state,
+          terminal_success: $terminal_success,
+          terminal_reason: $terminal_reason,
+          publish_status: $publish_status,
+          terminal_vocabulary: ["MERGED", "CLOSED_OBSOLETE", "NO_DIFF_SUCCESS", "FOLLOWUP_CREATED", "BLOCKED_CI"],
           status: "complete",
           steps_completed: 23,
           phases_completed: [
@@ -244,6 +276,6 @@ steps:
             step_18_implement_feedback: true
           },
           philosophy_compliant: true,
-          ready_to_merge: ($terminal_outcome == "active-pr" or $terminal_outcome == "create-new-pr" or $terminal_outcome == "existing-open-pr")
+          ready_to_merge: (($terminal_success != "true") and ($terminal_outcome == "active-pr" or $terminal_outcome == "create-new-pr" or $terminal_outcome == "existing-open-pr" or $terminal_outcome == "FOLLOWUP_CREATED"))
         }'
     output: "workflow_result"

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -3,22 +3,19 @@ description: "Phase 7: PR review cycle — compliance, reviewer, gates (17a-19d)
 version: "1.0.0"
 author: "Amplihack Team"
 tags: ["development", "review", "pr"]
-
 recursion:
   max_depth: 6
   max_total_steps: 80
-
 inputs:
   - name: worktree_setup.worktree_path
     description: "Absolute path to the per-task worktree produced by workflow-worktree (step-04). Required by bash steps in step-18c-push-feedback-changes that cd into the worktree. step-19c-zero-bs-verification falls back to REPO_PATH or cwd if the worktree is already cleaned up."
-
 context:
   worktree_setup: ""
   allow_no_op: false
-
 steps:
   - id: "step-17a-compliance-verification"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true'"
     command: |
       echo "=== Step 17a: Step 13 Compliance Verification ===" && \
       echo "" && \
@@ -40,16 +37,14 @@ steps:
       echo "" && \
       echo "=== Compliance Check PASSED ==="
     output: "step_13_compliance_check"
-
   - id: "step-17b-reviewer-agent"
     agent: "amplihack:reviewer"
+    condition: "terminal_state.terminal_success != 'true'"
     prompt: |
       # Step 17b: Comprehensive Code Review (MANDATORY)
-
       **PR URL:** {{pr_publish_result.pr_url}}
       **Requirements:** {{final_requirements}}
       **Implementation:** {{review_feedback}}
-
       **Review Checklist:**
       - [ ] Code quality and standards
       - [ ] Test coverage adequate
@@ -57,82 +52,68 @@ steps:
       - [ ] No unimplemented functions
       - [ ] Logic correctness
       - [ ] Edge case handling
-
       **Actions:**
       1. Perform comprehensive code review
       2. Identify issues and improvements
       3. **POST review comments on PR** (this is required evidence)
-
       **Output:** Review findings and confirmation posted to PR.
     output: "pr_review"
-
   - id: "step-17c-security-review"
     agent: "amplihack:security"
+    condition: "terminal_state.terminal_success != 'true'"
     prompt: |
       # Step 17c: Security Review (MANDATORY)
-
       **PR URL:** {{pr_publish_result.pr_url}}
       **Implementation:** {{review_feedback}}
       **Previous Review:** {{pr_review}}
-
       Security review of the PR:
       - [ ] Verify all security requirements met
       - [ ] Check for any new vulnerabilities
       - [ ] Confirm sensitive data handling
       - [ ] Review authentication/authorization if applicable
       - [ ] Check for injection vulnerabilities
-
       **Actions:**
       1. Perform security analysis
       2. **POST security findings as PR comments** (this is required evidence)
-
       **Output:** Security findings and confirmation posted to PR.
     output: "pr_security_review"
-
   - id: "step-17d-philosophy-guardian"
     agent: "amplihack:philosophy-guardian"
+    condition: "terminal_state.terminal_success != 'true'"
     prompt: |
       # Step 17d: Philosophy Guardian Review (MANDATORY)
-
       **PR URL:** {{pr_publish_result.pr_url}}
       **Implementation:** {{review_feedback}}
       **Code Review:** {{pr_review}}
-
       Philosophy compliance review:
       - [ ] Ruthless simplicity achieved
       - [ ] Bricks & studs pattern followed
       - [ ] Zero-BS implementation (no stubs, faked APIs, swallowed exceptions)
       - [ ] No over-engineering
       - [ ] Clean module boundaries
-
       **Actions:**
       1. Verify philosophy compliance
       2. **POST philosophy check as PR comment** (this is required evidence)
-
       **Output:** Compliance status and confirmation posted to PR.
     output: "pr_philosophy_review"
-
   - id: "step-17e-address-blocking-issues"
     agent: "amplihack:builder"
+    condition: "terminal_state.terminal_success != 'true'"
     prompt: |
       # Step 17e: Address Blocking Issues (MANDATORY)
-
       **PR Review:** {{pr_review}}
       **Security Review:** {{pr_security_review}}
       **Philosophy Review:** {{pr_philosophy_review}}
-
       Review all findings from Steps 16a-16d and address any blocking issues:
-
       1. Identify blocking issues from each review
       2. Implement fixes for each blocking issue
       3. If issues found, re-run applicable reviews after fixing
-
       **Output:** Summary of blocking issues found and how they were addressed.
       If no blocking issues, state "No blocking issues found."
     output: "blocking_issues_addressed"
-
   - id: "step-17f-verification-gate"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true'"
     command: |
       echo "=== STEP 17 VERIFICATION GATE ===" && \
       echo "" && \
@@ -149,46 +130,40 @@ steps:
       echo "" && \
       echo "=== GATE PASSED - Proceed to Step 18 ==="
     output: "step_17_gate_status"
-
   - id: "step-18a-analyze-feedback"
     agent: "amplihack:architect"
+    condition: "terminal_state.terminal_success != 'true'"
     prompt: |
       # Step 18a: Analyze Review Feedback (MANDATORY)
-
       **PR Review:** {{pr_review}}
       **Security Review:** {{pr_security_review}}
       **Philosophy Review:** {{pr_philosophy_review}}
-
       Analyze ALL feedback from Step 16 reviews:
       1. Categorize each item: blocking issues vs. suggestions vs. questions
       2. Prioritize blocking issues first
       3. Create action plan for addressing each item
-
       **Output:** Structured analysis of all feedback with action plan.
     output: "feedback_analysis"
-
   - id: "step-18b-implement-feedback"
     agent: "amplihack:builder"
+    condition: "terminal_state.terminal_success != 'true'"
     prompt: |
       # Step 18b: Implement Review Feedback (MANDATORY)
-
       **Feedback Analysis:** {{feedback_analysis}}
       **PR Review:** {{pr_review}}
       **Security Review:** {{pr_security_review}}
       **Philosophy Review:** {{pr_philosophy_review}}
       **Current Implementation:** {{review_feedback}}
-
       **Checklist:**
       - [ ] Address EVERY blocking issue
       - [ ] Address suggestions where appropriate
       - [ ] For disagreements, document reasoning
       - [ ] Ensure changes don't introduce new issues
-
       **Output:** Summary of changes for each feedback item.
     output: "pr_feedback_changes"
-
   - id: "step-18c-push-feedback-changes"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true'"
     command: |
       set -euo pipefail
       export GIT_PAGER=cat
@@ -274,9 +249,9 @@ steps:
       fi
       echo "=== Changes Pushed ==="
     output: "feedback_push_result"
-
   - id: "step-18d-respond-to-comments"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true'"
     command: |
       echo "=== Responding to Review Comments ===" && \
       echo "" && \
@@ -288,9 +263,9 @@ steps:
       echo "" && \
       echo "=== Comment Responses Complete ==="
     output: "comment_responses"
-
   - id: "step-18e-verification-gate"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true'"
     command: |
       echo "=== STEP 18 VERIFICATION GATE ===" && \
       echo "" && \
@@ -305,15 +280,13 @@ steps:
       echo "" && \
       echo "=== GATE PASSED - Proceed to Step 19 ==="
     output: "step_18_gate_status"
-
   - id: "step-19a-philosophy-check"
     agent: "amplihack:reviewer"
+    condition: "terminal_state.terminal_success != 'true'"
     prompt: |
       # Step 19a: Philosophy Compliance Review (MANDATORY)
-
       **Implementation:** {{pr_feedback_changes}}
       **Requirements:** {{final_requirements}}
-
       Philosophy compliance verification:
       - [ ] Ruthless simplicity achieved
       - [ ] No over-engineering or unnecessary complexity
@@ -321,29 +294,25 @@ steps:
       - [ ] No Forbidden Pattern violations (FORBIDDEN_PATTERNS.md): no error swallowing, no silent fallbacks, no data loss, no shell anti-patterns (|| true, >/dev/null), no async misuse, no config divergence, no validation gaps
       - [ ] All tests passing
       - [ ] Documentation complete and accurate
-
       **Output:** Detailed philosophy compliance findings.
     output: "philosophy_check"
-
   - id: "step-19b-patterns-check"
     agent: "amplihack:patterns"
+    condition: "terminal_state.terminal_success != 'true'"
     prompt: |
       # Step 19b: Pattern Compliance Review (MANDATORY)
-
       **Implementation:** {{pr_feedback_changes}}
-
       Pattern compliance verification:
       - [ ] Design patterns used correctly
       - [ ] Architectural patterns followed
       - [ ] Code organization patterns maintained
       - [ ] No anti-patterns introduced
       - [ ] No Forbidden Patterns (error swallowing, silent fallbacks, || true, >/dev/null, fire-and-forget async, unchecked HTTP responses, log-only catches)
-
       **Output:** Pattern compliance findings with any violations.
     output: "patterns_check"
-
   - id: "step-19c-zero-bs-verification"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true'"
     command: |
       set -euo pipefail
       echo "=== ZERO-BS VERIFICATION ==="
@@ -383,9 +352,9 @@ steps:
       echo ""
       echo "=== Zero-BS Verification Complete ==="
     output: "zero_bs_check"
-
   - id: "step-19d-verification-gate"
     type: "bash"
+    condition: "terminal_state.terminal_success != 'true'"
     command: |
       PHIL_CHECK="$PHILOSOPHY_CHECK"
       PAT_CHECK="$PATTERNS_CHECK"

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -19,12 +19,24 @@ inputs:
 context:
   worktree_setup: ""
   allow_no_op: false
+  terminal_success: "false"
+  terminal_state: ""
+  terminal_reason: ""
+  publish_status: ""
+  should_publish: "true"
+  should_finalize: "true"
+  should_run_ci_wait: "true"
+  should_merge: "true"
 
 steps:
+  - id: "publish-terminal-state"
+    type: "recipe"
+    recipe: "workflow-terminal-state"
+
   - id: "step-14-bump-version"
     agent: "amplihack:architect"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "goal_already_met != 'true'"
+    condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"
     prompt: |
        # Step 14: Bump Version in Cargo.toml (MANDATORY)
 
@@ -65,7 +77,7 @@ steps:
 
   - id: "step-15-commit-push"
     type: "bash"
-    condition: "goal_already_met != 'true'"
+    condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"
     command: |
       set -euo pipefail
       export GIT_PAGER=cat
@@ -173,7 +185,7 @@ steps:
 
   - id: "step-16-create-draft-pr"
     type: "bash"
-    condition: "goal_already_met != 'true' && commit_result.pushed == 'true'"
+    condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true' && commit_result.pushed == 'true'"
     command: |
       set -euo pipefail
       export GIT_PAGER=cat PAGER=cat LESS=FRX
@@ -188,6 +200,7 @@ steps:
       # Base-ref contract: resolve_pr_base_ref checks refs/remotes/origin/HEAD, runs git remote set-head origin -a, falls back through origin/master origin/develop, and fails with ERROR: no supported remote base ref found.
       # Metadata contract: ISSUE_NUM, git diff, git log, git diff --name-only, Changed files, Validation, Behavior, Risk, and step-13 shape PR title/body context.
       # PUBLISH_STATE="no-diff"; PUBLISH_STATE="existing-open-pr"; PUBLISH_STATE="already-merged"; PUBLISH_STATE="closed-after-merge"; PUBLISH_STATE="closed-unmerged-with-diff".
+      # Terminal vocabulary: MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED, BLOCKED_CI.
       # gh_pr_create_with_retry is called by the helper only after PUBLISH_STATE classification.
       PUBLISH_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_publish_pr.sh"
       if [ ! -f "$PUBLISH_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then PUBLISH_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_publish_pr.sh"; fi
@@ -199,7 +212,7 @@ steps:
   - id: "step-16b-outside-in-fix-loop"
     agent: "amplihack:builder"
     working_dir: "{{worktree_setup.worktree_path}}"
-    condition: "goal_already_met != 'true'"
+    condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"
     prompt: |
        # Step 16b: Outside-In Testing and Fix Loop (MANDATORY)
 

--- a/amplifier-bundle/recipes/workflow-terminal-state.yaml
+++ b/amplifier-bundle/recipes/workflow-terminal-state.yaml
@@ -1,0 +1,270 @@
+name: "workflow-terminal-state"
+description: "Reusable default-workflow terminal-state probe for merged, obsolete, no-diff, follow-up, and blocked states"
+version: "1.0.0"
+author: "Amplihack Team"
+tags: ["development", "terminal-state", "publish", "finalize"]
+
+recursion:
+  max_depth: 1
+  max_total_steps: 4
+
+inputs:
+  - name: repo_path
+    description: "Repository path used for git and gh probes."
+  - name: branch_name
+    description: "Expected branch name; defaults to the current branch when empty."
+  - name: base_ref
+    description: "Intended base ref; defaults to origin/HEAD, origin/main, origin/master, or origin/develop."
+  - name: pr_number
+    description: "Optional PR number to validate and inspect."
+  - name: pr_url
+    description: "Optional PR URL to validate and inspect."
+  - name: goal_already_met
+    description: "Legacy design signal; used only as supporting evidence and never as an override."
+
+context:
+  repo_path: "."
+  branch_name: ""
+  base_ref: ""
+  pr_number: ""
+  pr_url: ""
+  goal_already_met: "false"
+
+steps:
+  - id: "probe-terminal-state"
+    type: "bash"
+    parse_json: true
+    command: |
+      set -euo pipefail
+      export GIT_PAGER=cat GH_PAGER=cat PAGER=cat LESS=FRX
+
+      if ! command -v jq >/dev/null 2>&1; then
+        echo "ERROR: jq is required by workflow-terminal-state." >&2
+        exit 2
+      fi
+
+      terminal_success="false"
+      terminal_state="FOLLOWUP_CREATED"
+      terminal_reason="meaningful unmerged work remains; publish should continue"
+      publish_status="FOLLOWUP_CREATED"
+      should_publish="true"
+      should_finalize="true"
+      should_run_ci_wait="true"
+      should_merge="true"
+      pr_url_result=""
+      pr_number_result=""
+      branch_diff_status="unknown"
+      commits_ahead="0"
+
+      emit_terminal_state() {
+        jq -nc \
+          --arg terminal_success "$terminal_success" \
+          --arg terminal_state "$terminal_state" \
+          --arg terminal_reason "$terminal_reason" \
+          --arg publish_status "$publish_status" \
+          --arg should_publish "$should_publish" \
+          --arg should_finalize "$should_finalize" \
+          --arg should_run_ci_wait "$should_run_ci_wait" \
+          --arg should_merge "$should_merge" \
+          --arg pr_url "$pr_url_result" \
+          --arg pr_number "$pr_number_result" \
+          --arg branch_diff_status "$branch_diff_status" \
+          --arg commits_ahead "$commits_ahead" \
+          '{terminal_success:$terminal_success,terminal_state:$terminal_state,terminal_reason:$terminal_reason,publish_status:$publish_status,should_publish:$should_publish,should_finalize:$should_finalize,should_run_ci_wait:$should_run_ci_wait,should_merge:$should_merge,pr_url:$pr_url,pr_number:$pr_number,branch_diff_status:$branch_diff_status,commits_ahead:$commits_ahead}'
+      }
+
+      fail_terminal_state() {
+        terminal_success="false"
+        terminal_state="$1"
+        terminal_reason="$2"
+        publish_status="$1"
+        should_publish="false"
+        should_finalize="false"
+        should_run_ci_wait="false"
+        should_merge="false"
+        emit_terminal_state
+        echo "ERROR: workflow-terminal-state: $terminal_state: $terminal_reason" >&2
+        exit 1
+      }
+
+      success_terminal_state() {
+        terminal_success="true"
+        terminal_state="$1"
+        terminal_reason="$2"
+        publish_status="$1"
+        should_publish="false"
+        should_finalize="false"
+        should_run_ci_wait="false"
+        should_merge="false"
+        emit_terminal_state
+        exit 0
+      }
+
+      sanitize_gh_stderr() {
+        sed -E 's#https://[^@[:space:]]+@#https://REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
+      }
+
+      is_transient_gh_error() {
+        [ -s "$1" ] && grep -Eiq 'HTTP 5[0-9][0-9]|(^|[^0-9])(502|503|504)([^0-9]|$)|rate limit|timed out|timeout|temporar|connection reset|connection refused|TLS handshake|network|server error' "$1"
+      }
+
+      gh_with_retry() {
+        local label="$1" stderr_file output status attempt delay=1
+        shift
+        for attempt in 1 2 3; do
+          stderr_file=$(mktemp -t terminal-state-gh-XXXXXX)
+          if output=$(timeout 60 gh "$@" 2>"$stderr_file"); then
+            rm -f "$stderr_file"
+            printf '%s\n' "$output"
+            return 0
+          fi
+          status=$?
+          if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
+            echo "WARNING: gh $label failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
+            rm -f "$stderr_file"
+            sleep "$delay"
+            delay=$((delay * 2))
+            continue
+          fi
+          echo "ERROR: gh $label failed (exit ${status})" >&2
+          [ ! -s "$stderr_file" ] || echo "gh $label stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
+          rm -f "$stderr_file"
+          return "$status"
+        done
+      }
+
+      REPO_DIR="${REPO_PATH:-${RECIPE_VAR_repo_path:-{{repo_path}}}}"
+      BRANCH_INPUT="${BRANCH_NAME:-${RECIPE_VAR_branch_name:-{{branch_name}}}}"
+      BASE_INPUT="${BASE_REF:-${RECIPE_VAR_base_ref:-{{base_ref}}}}"
+      PR_NUMBER_INPUT="${PR_NUMBER:-${RECIPE_VAR_pr_number:-{{pr_number}}}}"
+      PR_URL_INPUT="${PR_URL:-${RECIPE_VAR_pr_url:-{{pr_url}}}}"
+      GOAL_ALREADY_MET_INPUT="${GOAL_ALREADY_MET:-${RECIPE_VAR_goal_already_met:-{{goal_already_met}}}}"
+
+      [ -n "$REPO_DIR" ] || fail_terminal_state "FAILED_INVALID_INPUT" "repo_path is required"
+      cd "$REPO_DIR" 2>/dev/null || fail_terminal_state "FAILED_INVALID_INPUT" "repo_path does not exist or is not accessible"
+      git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail_terminal_state "FAILED_INVALID_INPUT" "workflow-terminal-state requires a git repo at repo_path; either git init or rerun from a checkout"
+
+      if [ -z "$BRANCH_INPUT" ] || [ "$BRANCH_INPUT" = "''" ]; then
+        BRANCH_INPUT="$(git branch --show-current 2>/dev/null || true)"
+      fi
+      [ -n "$BRANCH_INPUT" ] || fail_terminal_state "FAILED_INVALID_INPUT" "branch_name is empty and current HEAD is detached"
+      git check-ref-format --branch "$BRANCH_INPUT" >/dev/null 2>&1 || fail_terminal_state "FAILED_INVALID_INPUT" "branch_name is malformed: $BRANCH_INPUT"
+
+      resolve_base_ref() {
+        local candidate
+        if [ -n "$BASE_INPUT" ] && [ "$BASE_INPUT" != "''" ]; then
+          printf '%s\n' "$BASE_INPUT"
+          return 0
+        fi
+        candidate="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+        if [ -n "$candidate" ] && git rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then printf '%s\n' "$candidate"; return 0; fi
+        git remote set-head origin -a >/dev/null 2>&1 || true
+        candidate="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+        if [ -n "$candidate" ] && git rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then printf '%s\n' "$candidate"; return 0; fi
+        for candidate in origin/main origin/master origin/develop main master develop; do
+          if git rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then printf '%s\n' "$candidate"; return 0; fi
+        done
+        return 1
+      }
+
+      base_ref="$(resolve_base_ref)" || fail_terminal_state "FAILED_INVALID_INPUT" "base_ref is missing and no supported base ref could be resolved"
+      if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+        fail_terminal_state "FAILED_INVALID_INPUT" "base_ref does not resolve to a commit: $base_ref"
+      fi
+
+      if [ -n "$PR_NUMBER_INPUT" ] && [ "$PR_NUMBER_INPUT" != "''" ] && ! [[ "$PR_NUMBER_INPUT" =~ ^[0-9][0-9]*$ ]]; then
+        fail_terminal_state "FAILED_INVALID_INPUT" "pr_number is malformed: $PR_NUMBER_INPUT"
+      fi
+      if [ -n "$PR_URL_INPUT" ] && [ "$PR_URL_INPUT" != "''" ] && ! [[ "$PR_URL_INPUT" =~ ^https://[^[:space:]]+/pull/[0-9]+$ ]]; then
+        fail_terminal_state "FAILED_INVALID_INPUT" "pr_url is malformed or not a pull request URL"
+      fi
+
+      # Dirty worktree is the first trust boundary. No terminal success is
+      # allowed while uncommitted state might contain real work.
+      if [ -n "$(git status --porcelain)" ]; then
+        fail_terminal_state "FAILED_DIRTY_WORKTREE" "dirty worktree blocks terminal success"
+      fi
+
+      pr_json=""
+      pr_target=""
+      if [ -n "$PR_URL_INPUT" ] && [ "$PR_URL_INPUT" != "''" ]; then
+        pr_target="$PR_URL_INPUT"
+      elif [ -n "$PR_NUMBER_INPUT" ] && [ "$PR_NUMBER_INPUT" != "''" ]; then
+        pr_target="$PR_NUMBER_INPUT"
+      fi
+
+      if [ -n "$pr_target" ]; then
+        command -v gh >/dev/null 2>&1 || fail_terminal_state "FAILED_INVALID_INPUT" "gh is required when pr_number or pr_url is provided"
+        if ! pr_json="$(gh_with_retry "pr view" pr view "$pr_target" --json state,mergedAt,headRefName,baseRefName,headRefOid,number,url,statusCheckRollup)"; then
+          fail_terminal_state "FAILED_INVALID_INPUT" "unavailable PR metadata for $pr_target"
+        fi
+      elif command -v gh >/dev/null 2>&1; then
+        # Best-effort same-branch discovery. Ambiguity here is not terminal:
+        # meaningful diffs still publish, and clean no-diff can succeed from git.
+        if ! pr_json="$(gh_with_retry "pr list" pr list --head "$BRANCH_INPUT" --state all --json state,mergedAt,headRefName,baseRefName,headRefOid,number,url,statusCheckRollup --jq '.[0] // {}')"; then
+          echo "WARNING: gh pr list failed during best-effort branch PR discovery; continuing with git-only terminal-state evidence" >&2
+          pr_json="{}"
+        fi
+      fi
+
+      if [ -n "$pr_json" ] && [ "$pr_json" != "{}" ]; then
+        pr_url_result="$(printf '%s' "$pr_json" | jq -r '.url // ""')"
+        pr_number_result="$(printf '%s' "$pr_json" | jq -r '(.number // "") | tostring')"
+        pr_state="$(printf '%s' "$pr_json" | jq -r '.state // ""')"
+        pr_merged_at="$(printf '%s' "$pr_json" | jq -r '.mergedAt // ""')"
+        pr_head="$(printf '%s' "$pr_json" | jq -r '.headRefName // ""')"
+        pr_base="$(printf '%s' "$pr_json" | jq -r '.baseRefName // ""')"
+        expected_base="${base_ref#origin/}"
+        if [ -n "$pr_head" ] && [ "$pr_head" != "$BRANCH_INPUT" ]; then
+          fail_terminal_state "FAILED_INVALID_INPUT" "ambiguous PR metadata: headRefName '$pr_head' does not match branch_name '$BRANCH_INPUT'"
+        fi
+        if [ -n "$pr_base" ] && [ "$pr_base" != "$expected_base" ]; then
+          fail_terminal_state "FAILED_INVALID_INPUT" "ambiguous PR metadata: baseRefName '$pr_base' does not match base_ref '$expected_base'"
+        fi
+
+        failing_checks="$(printf '%s' "$pr_json" | jq '[.statusCheckRollup[]? | select((.conclusion? // "") as $c | $c == "FAILURE" or $c == "ERROR" or $c == "TIMED_OUT" or $c == "CANCELLED")] | length')"
+        if [ "${failing_checks:-0}" -gt 0 ]; then
+          fail_terminal_state "BLOCKED_CI" "real failing checks block terminal success"
+        fi
+
+        if [ "$pr_state" = "MERGED" ] || { [ "$pr_state" = "CLOSED" ] && [ -n "$pr_merged_at" ] && [ "$pr_merged_at" != "null" ]; }; then
+          success_terminal_state "MERGED" "PR is merged or closed-after-merge"
+        fi
+      fi
+
+      # Closed-unmerged PRs are failure unless git proves no meaningful work remains.
+      if [ -n "$pr_json" ] && [ "$pr_json" != "{}" ] && [ "$(printf '%s' "$pr_json" | jq -r '.state // ""')" = "CLOSED" ]; then
+        echo "INFO: closed-unmerged PR found; checking obsolete proof" >&2
+        if git diff --quiet "${base_ref}..HEAD"; then
+          branch_diff_status="no-diff"
+          commits_ahead="$(git rev-list --count "${base_ref}..HEAD" 2>/dev/null || echo "0")"
+          success_terminal_state "CLOSED_OBSOLETE" "closed-unmerged PR is obsolete because no meaningful diff remains"
+        fi
+        fail_terminal_state "FAILED_CLOSED_UNMERGED" "closed-unmerged PR still has meaningful diff"
+      fi
+
+      if git diff --quiet "${base_ref}..HEAD"; then
+        branch_diff_status="no-diff"
+        commits_ahead="$(git rev-list --count "${base_ref}..HEAD" 2>/dev/null || echo "0")"
+        if [ "$commits_ahead" = "0" ]; then
+          success_terminal_state "NO_DIFF_SUCCESS" "clean branch has no meaningful diff or commits against base"
+        fi
+        success_terminal_state "CLOSED_OBSOLETE" "branch is superseded upstream: no meaningful diff remains despite local commits"
+      fi
+
+      branch_diff_status="has-diff"
+      commits_ahead="$(git rev-list --count "${base_ref}..HEAD" 2>/dev/null || echo "0")"
+      if [ "$GOAL_ALREADY_MET_INPUT" = "true" ]; then
+        fail_terminal_state "FAILED_MEANINGFUL_DIFF" "goal_already_met=true is ambiguous because meaningful unmerged diff remains"
+      fi
+
+      terminal_success="false"
+      terminal_state="FOLLOWUP_CREATED"
+      terminal_reason="meaningful unmerged work remains; follow-up publish should continue"
+      publish_status="FOLLOWUP_CREATED"
+      should_publish="true"
+      should_finalize="true"
+      should_run_ci_wait="true"
+      should_merge="true"
+      emit_terminal_state
+    output: "terminal_state"

--- a/amplifier-bundle/recipes/workflow-terminal-state.yaml
+++ b/amplifier-bundle/recipes/workflow-terminal-state.yaml
@@ -9,6 +9,8 @@ recursion:
   max_total_steps: 4
 
 inputs:
+  - name: worktree_setup.worktree_path
+    description: "Preferred workflow worktree path. When present, all git and gh probes operate in this checkout instead of repo_path."
   - name: repo_path
     description: "Repository path used for git and gh probes."
   - name: branch_name
@@ -117,8 +119,9 @@ steps:
             rm -f "$stderr_file"
             printf '%s\n' "$output"
             return 0
+          else
+            status=$?
           fi
-          status=$?
           if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
             echo "WARNING: gh $label failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
             rm -f "$stderr_file"
@@ -133,22 +136,77 @@ steps:
         done
       }
 
-      REPO_DIR="${REPO_PATH:-${RECIPE_VAR_repo_path:-{{repo_path}}}}"
-      BRANCH_INPUT="${BRANCH_NAME:-${RECIPE_VAR_branch_name:-{{branch_name}}}}"
-      BASE_INPUT="${BASE_REF:-${RECIPE_VAR_base_ref:-{{base_ref}}}}"
-      PR_NUMBER_INPUT="${PR_NUMBER:-${RECIPE_VAR_pr_number:-{{pr_number}}}}"
-      PR_URL_INPUT="${PR_URL:-${RECIPE_VAR_pr_url:-{{pr_url}}}}"
-      GOAL_ALREADY_MET_INPUT="${GOAL_ALREADY_MET:-${RECIPE_VAR_goal_already_met:-{{goal_already_met}}}}"
+      parse_github_repo_identity() {
+        local url="$1" path owner repo
+        case "$url" in
+          git@github.com:*) path="${url#git@github.com:}" ;;
+          ssh://git@github.com/*) path="${url#ssh://git@github.com/}" ;;
+          https://github.com/*) path="${url#https://github.com/}" ;;
+          http://github.com/*) path="${url#http://github.com/}" ;;
+          *) return 1 ;;
+        esac
+        path="${path%%\?*}"
+        path="${path%%#*}"
+        path="${path%.git}"
+        owner="${path%%/*}"
+        repo="${path#*/}"
+        repo="${repo%%/*}"
+        [ -n "$owner" ] && [ -n "$repo" ] && [ "$owner" != "$repo" ] || return 1
+        printf '%s/%s\n' "$owner" "$repo"
+      }
 
-      [ -n "$REPO_DIR" ] || fail_terminal_state "FAILED_INVALID_INPUT" "repo_path is required"
-      cd "$REPO_DIR" 2>/dev/null || fail_terminal_state "FAILED_INVALID_INPUT" "repo_path does not exist or is not accessible"
-      git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail_terminal_state "FAILED_INVALID_INPUT" "workflow-terminal-state requires a git repo at repo_path; either git init or rerun from a checkout"
+      normalize_base_name() {
+        local ref="$1"
+        ref="${ref#refs/heads/}"
+        ref="${ref#origin/}"
+        printf '%s\n' "$ref"
+      }
 
+      WORKTREE_INPUT="${WORKTREE_SETUP_WORKTREE_PATH:-}"
+      [ -n "$WORKTREE_INPUT" ] || WORKTREE_INPUT="${RECIPE_VAR_worktree_setup__worktree_path:-}"
+      REPO_DIR="${REPO_PATH:-}"
+      [ -n "$REPO_DIR" ] || REPO_DIR="${RECIPE_VAR_repo_path:-}"
+      [ -n "$REPO_DIR" ] || REPO_DIR="{{repo_path}}"
+      BRANCH_INPUT="${BRANCH_NAME:-}"
+      [ -n "$BRANCH_INPUT" ] || BRANCH_INPUT="${RECIPE_VAR_branch_name:-}"
+      [ -n "$BRANCH_INPUT" ] || BRANCH_INPUT="{{branch_name}}"
+      BASE_INPUT="${BASE_REF:-}"
+      [ -n "$BASE_INPUT" ] || BASE_INPUT="${RECIPE_VAR_base_ref:-}"
+      [ -n "$BASE_INPUT" ] || BASE_INPUT="{{base_ref}}"
+      PR_NUMBER_INPUT="${PR_NUMBER:-}"
+      [ -n "$PR_NUMBER_INPUT" ] || PR_NUMBER_INPUT="${RECIPE_VAR_pr_number:-}"
+      [ -n "$PR_NUMBER_INPUT" ] || PR_NUMBER_INPUT="{{pr_number}}"
+      PR_URL_INPUT="${PR_URL:-}"
+      [ -n "$PR_URL_INPUT" ] || PR_URL_INPUT="${RECIPE_VAR_pr_url:-}"
+      [ -n "$PR_URL_INPUT" ] || PR_URL_INPUT="{{pr_url}}"
+      GOAL_ALREADY_MET_INPUT="${GOAL_ALREADY_MET:-}"
+      [ -n "$GOAL_ALREADY_MET_INPUT" ] || GOAL_ALREADY_MET_INPUT="${RECIPE_VAR_goal_already_met:-}"
+      [ -n "$GOAL_ALREADY_MET_INPUT" ] || GOAL_ALREADY_MET_INPUT="{{goal_already_met}}"
+      [ "$REPO_DIR" != "{{repo_path}}" ] || REPO_DIR="."
+      case "$BRANCH_INPUT" in "{{branch_name}}"|"''") BRANCH_INPUT="" ;; esac
+      case "$BASE_INPUT" in "{{base_ref}}"|"''") BASE_INPUT="" ;; esac
+      case "$PR_NUMBER_INPUT" in "{{pr_number}}"|"''") PR_NUMBER_INPUT="" ;; esac
+      case "$PR_URL_INPUT" in "{{pr_url}}"|"''") PR_URL_INPUT="" ;; esac
+      case "$GOAL_ALREADY_MET_INPUT" in "{{goal_already_met}}"|"''") GOAL_ALREADY_MET_INPUT="false" ;; esac
+      TARGET_REPO_DIR="$REPO_DIR"
+      if [ -n "$WORKTREE_INPUT" ] && [ "$WORKTREE_INPUT" != "''" ]; then
+        TARGET_REPO_DIR="$WORKTREE_INPUT"
+      fi
+
+      [ -n "$TARGET_REPO_DIR" ] || fail_terminal_state "FAILED_INVALID_INPUT" "repo_path or worktree_setup.worktree_path is required"
+      cd "$TARGET_REPO_DIR" 2>/dev/null || fail_terminal_state "FAILED_INVALID_INPUT" "target checkout does not exist or is not accessible: $TARGET_REPO_DIR"
+      git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail_terminal_state "FAILED_INVALID_INPUT" "workflow-terminal-state requires a git repo at target checkout; either git init or rerun from a checkout"
+
+      current_branch="$(git branch --show-current 2>/dev/null || true)"
       if [ -z "$BRANCH_INPUT" ] || [ "$BRANCH_INPUT" = "''" ]; then
-        BRANCH_INPUT="$(git branch --show-current 2>/dev/null || true)"
+        BRANCH_INPUT="$current_branch"
       fi
       [ -n "$BRANCH_INPUT" ] || fail_terminal_state "FAILED_INVALID_INPUT" "branch_name is empty and current HEAD is detached"
       git check-ref-format --branch "$BRANCH_INPUT" >/dev/null 2>&1 || fail_terminal_state "FAILED_INVALID_INPUT" "branch_name is malformed: $BRANCH_INPUT"
+      if [ "$current_branch" != "$BRANCH_INPUT" ]; then
+        fail_terminal_state "FAILED_WRONG_BRANCH" "target checkout branch '$current_branch' does not match branch_name '$BRANCH_INPUT'"
+      fi
+      local_head="$(git rev-parse --verify HEAD 2>/dev/null)" || fail_terminal_state "FAILED_INVALID_INPUT" "target checkout HEAD does not resolve"
 
       resolve_base_ref() {
         local candidate
@@ -185,8 +243,13 @@ steps:
         fail_terminal_state "FAILED_DIRTY_WORKTREE" "dirty worktree blocks terminal success"
       fi
 
+      repo_identity="$(parse_github_repo_identity "$(git config --get remote.origin.url 2>/dev/null || true)" || true)"
+      repo_owner="${repo_identity%%/*}"
+      repo_name="${repo_identity#*/}"
+
       pr_json=""
       pr_target=""
+      pr_lookup_failed="false"
       if [ -n "$PR_URL_INPUT" ] && [ "$PR_URL_INPUT" != "''" ]; then
         pr_target="$PR_URL_INPUT"
       elif [ -n "$PR_NUMBER_INPUT" ] && [ "$PR_NUMBER_INPUT" != "''" ]; then
@@ -195,34 +258,55 @@ steps:
 
       if [ -n "$pr_target" ]; then
         command -v gh >/dev/null 2>&1 || fail_terminal_state "FAILED_INVALID_INPUT" "gh is required when pr_number or pr_url is provided"
-        if ! pr_json="$(gh_with_retry "pr view" pr view "$pr_target" --json state,mergedAt,headRefName,baseRefName,headRefOid,number,url,statusCheckRollup)"; then
+        if ! pr_json="$(gh_with_retry "pr view" pr view "$pr_target" --json state,mergedAt,headRefName,baseRefName,headRefOid,headRepositoryOwner,headRepository,baseRepository,number,url,statusCheckRollup)"; then
           fail_terminal_state "FAILED_INVALID_INPUT" "unavailable PR metadata for $pr_target"
         fi
       elif command -v gh >/dev/null 2>&1; then
-        # Best-effort same-branch discovery. Ambiguity here is not terminal:
-        # meaningful diffs still publish, and clean no-diff can succeed from git.
-        if ! pr_json="$(gh_with_retry "pr list" pr list --head "$BRANCH_INPUT" --state all --json state,mergedAt,headRefName,baseRefName,headRefOid,number,url,statusCheckRollup --jq '.[0] // {}')"; then
-          echo "WARNING: gh pr list failed during best-effort branch PR discovery; continuing with git-only terminal-state evidence" >&2
+        # Same-branch discovery is exact. If it fails, only clean no-diff can
+        # still prove terminal success without PR metadata.
+        if ! pr_json="$(gh_with_retry "pr list" pr list --head "$BRANCH_INPUT" --state all --json state,mergedAt,headRefName,baseRefName,headRefOid,headRepositoryOwner,headRepository,baseRepository,number,url,statusCheckRollup --jq '.[0] // {}')"; then
+          echo "WARNING: gh pr list failed during same-branch PR discovery; meaningful diffs will fail closed" >&2
           pr_json="{}"
+          pr_lookup_failed="true"
         fi
       fi
 
       if [ -n "$pr_json" ] && [ "$pr_json" != "{}" ]; then
-        pr_url_result="$(printf '%s' "$pr_json" | jq -r '.url // ""')"
-        pr_number_result="$(printf '%s' "$pr_json" | jq -r '(.number // "") | tostring')"
-        pr_state="$(printf '%s' "$pr_json" | jq -r '.state // ""')"
-        pr_merged_at="$(printf '%s' "$pr_json" | jq -r '.mergedAt // ""')"
-        pr_head="$(printf '%s' "$pr_json" | jq -r '.headRefName // ""')"
-        pr_base="$(printf '%s' "$pr_json" | jq -r '.baseRefName // ""')"
-        expected_base="${base_ref#origin/}"
-        if [ -n "$pr_head" ] && [ "$pr_head" != "$BRANCH_INPUT" ]; then
+        mapfile -t pr_fields < <(
+          printf '%s' "$pr_json" | jq -r '.url // "", ((.number // "") | tostring), .state // "", .mergedAt // "", .headRefName // "", .baseRefName // "", .headRefOid // "", (.headRepositoryOwner.login // .headRepositoryOwner.name // .headRepositoryOwner // ""), (.headRepository.name // ((.headRepository.nameWithOwner // "") | split("/") | .[-1]) // ""), (.baseRepository.owner.login // .baseRepository.owner.name // ((.baseRepository.nameWithOwner // "") | split("/") | .[0]) // ""), (.baseRepository.name // ((.baseRepository.nameWithOwner // "") | split("/") | .[-1]) // ""), ([.statusCheckRollup[]? | select((.conclusion? // "") as $c | $c == "FAILURE" or $c == "ERROR" or $c == "TIMED_OUT" or $c == "CANCELLED")] | length | tostring)'
+        )
+        pr_url_result="${pr_fields[0]:-}"
+        pr_number_result="${pr_fields[1]:-}"
+        pr_state="${pr_fields[2]:-}"
+        pr_merged_at="${pr_fields[3]:-}"
+        pr_head="${pr_fields[4]:-}"
+        pr_base="${pr_fields[5]:-}"
+        pr_head_oid="${pr_fields[6]:-}"
+        pr_head_owner="${pr_fields[7]:-}"
+        pr_head_repo="${pr_fields[8]:-}"
+        pr_base_owner="${pr_fields[9]:-}"
+        pr_base_repo="${pr_fields[10]:-}"
+        failing_checks="${pr_fields[11]:-0}"
+        expected_base="$(normalize_base_name "$base_ref")"
+        [ -n "$repo_identity" ] || fail_terminal_state "FAILED_INVALID_INPUT" "unable to determine current GitHub repo identity from origin remote"
+        [ -n "$pr_head" ] || fail_terminal_state "FAILED_INVALID_INPUT" "PR metadata is missing headRefName"
+        [ -n "$pr_base" ] || fail_terminal_state "FAILED_INVALID_INPUT" "PR metadata is missing baseRefName"
+        [ -n "$pr_head_oid" ] || fail_terminal_state "FAILED_INVALID_INPUT" "PR metadata is missing headRefOid"
+        [ -n "$pr_head_owner" ] && [ -n "$pr_head_repo" ] || fail_terminal_state "FAILED_INVALID_INPUT" "PR metadata is missing head repository identity"
+        [ -n "$pr_base_owner" ] && [ -n "$pr_base_repo" ] || fail_terminal_state "FAILED_INVALID_INPUT" "PR metadata is missing base repository identity"
+        if [ "$pr_head" != "$BRANCH_INPUT" ]; then
           fail_terminal_state "FAILED_INVALID_INPUT" "ambiguous PR metadata: headRefName '$pr_head' does not match branch_name '$BRANCH_INPUT'"
         fi
-        if [ -n "$pr_base" ] && [ "$pr_base" != "$expected_base" ]; then
+        if [ "$pr_base" != "$expected_base" ]; then
           fail_terminal_state "FAILED_INVALID_INPUT" "ambiguous PR metadata: baseRefName '$pr_base' does not match base_ref '$expected_base'"
         fi
+        if [ "$pr_head_oid" != "$local_head" ]; then
+          fail_terminal_state "FAILED_INVALID_INPUT" "stale PR metadata: headRefOid '$pr_head_oid' does not match local HEAD '$local_head'"
+        fi
+        if [ "$pr_head_owner/$pr_head_repo" != "$repo_owner/$repo_name" ] || [ "$pr_base_owner/$pr_base_repo" != "$repo_owner/$repo_name" ]; then
+          fail_terminal_state "FAILED_INVALID_INPUT" "ambiguous PR metadata: PR repo '$pr_head_owner/$pr_head_repo' -> '$pr_base_owner/$pr_base_repo' does not match current repo '$repo_owner/$repo_name'"
+        fi
 
-        failing_checks="$(printf '%s' "$pr_json" | jq '[.statusCheckRollup[]? | select((.conclusion? // "") as $c | $c == "FAILURE" or $c == "ERROR" or $c == "TIMED_OUT" or $c == "CANCELLED")] | length')"
         if [ "${failing_checks:-0}" -gt 0 ]; then
           fail_terminal_state "BLOCKED_CI" "real failing checks block terminal success"
         fi
@@ -233,7 +317,7 @@ steps:
       fi
 
       # Closed-unmerged PRs are failure unless git proves no meaningful work remains.
-      if [ -n "$pr_json" ] && [ "$pr_json" != "{}" ] && [ "$(printf '%s' "$pr_json" | jq -r '.state // ""')" = "CLOSED" ]; then
+      if [ -n "$pr_json" ] && [ "$pr_json" != "{}" ] && [ "${pr_state:-}" = "CLOSED" ]; then
         echo "INFO: closed-unmerged PR found; checking obsolete proof" >&2
         if git diff --quiet "${base_ref}..HEAD"; then
           branch_diff_status="no-diff"
@@ -254,6 +338,9 @@ steps:
 
       branch_diff_status="has-diff"
       commits_ahead="$(git rev-list --count "${base_ref}..HEAD" 2>/dev/null || echo "0")"
+      if [ "$pr_lookup_failed" = "true" ]; then
+        fail_terminal_state "FAILED_PR_METADATA_UNAVAILABLE" "unavailable PR metadata for branch '$BRANCH_INPUT'; refusing to continue with meaningful diff"
+      fi
       if [ "$GOAL_ALREADY_MET_INPUT" = "true" ]; then
         fail_terminal_state "FAILED_MEANINGFUL_DIFF" "goal_already_met=true is ambiguous because meaningful unmerged diff remains"
       fi

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -10,17 +10,49 @@ PR_URL="${PR_URL:-${PR_PUBLISH_RESULT_PR_URL:-${RECIPE_VAR_pr_publish_result__pr
 PUBLISH_STATE="${PR_PUBLISH_RESULT_STATE:-${RECIPE_VAR_pr_publish_result__state:-}}"
 terminal_status="${PUBLISH_STATE:-active-pr}"
 
+sanitize_gh_stderr() {
+  sed -E 's#https://[^@[:space:]]+@#https://REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
+}
+
+is_transient_gh_error() {
+  [ -s "$1" ] && grep -Eiq 'HTTP 5[0-9][0-9]|(^|[^0-9])(502|503|504)([^0-9]|$)|rate limit|timed out|timeout|temporar|connection reset|connection refused|TLS handshake|network|server error' "$1"
+}
+
+gh_pr_view_with_retry() {
+  local stderr_file output status attempt delay=1
+  for attempt in 1 2 3; do
+    stderr_file=$(mktemp -t step22b-gh-pr-view-XXXXXX)
+    if output=$(timeout 60 gh pr view "$@" 2>"$stderr_file"); then
+      rm -f "$stderr_file"
+      printf '%s\n' "$output"
+      return 0
+    fi
+    status=$?
+    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
+      echo "WARNING: final PR status lookup failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
+      rm -f "$stderr_file"
+      sleep "$delay"
+      delay=$((delay * 2))
+      continue
+    fi
+    echo "WARNING: final PR status lookup failed (exit ${status}); continuing with terminal-state result" >&2
+    [ ! -s "$stderr_file" ] || echo "gh pr view stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
+    rm -f "$stderr_file"
+    return "$status"
+  done
+}
+
 case "$terminal_status" in
-  closed-after-merge|already-merged|no-diff) echo "terminal_status=$terminal_status" ;;
+  MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS|closed-after-merge|already-merged|no-diff) echo "terminal_status=$terminal_status" ;;
 esac
 
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   BASE_REF="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
   [ -n "$BASE_REF" ] || BASE_REF="origin/main"
   if git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null && git diff --quiet "${BASE_REF}..HEAD"; then
-    terminal_status="no-diff"
-    echo "terminal_status=no-diff"
-  elif [ "$terminal_status" = "no-diff" ]; then
+    terminal_status="NO_DIFF_SUCCESS"
+    echo "terminal_status=NO_DIFF_SUCCESS"
+  elif [ "$terminal_status" = "no-diff" ] || [ "$terminal_status" = "NO_DIFF_SUCCESS" ]; then
     echo "WARNING: publish reported no-diff but final diff could not confirm that state" >&2
   fi
 fi
@@ -34,7 +66,7 @@ if [ -z "$PR_URL" ]; then
 elif [ "$HOST_TYPE" = "github" ]; then
   echo "PR Status:"
   if command -v gh >/dev/null 2>&1; then
-    timeout 60 gh pr view "$PR_URL" --json state,mergeable,reviews,statusCheckRollup
+    gh_pr_view_with_retry "$PR_URL" --json state,mergeable,reviews,statusCheckRollup || true
   else
     echo "WARNING: gh CLI not found; skipping final PR status lookup" >&2
   fi

--- a/amplifier-bundle/tools/workflow_pr_ready.sh
+++ b/amplifier-bundle/tools/workflow_pr_ready.sh
@@ -18,6 +18,39 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
+sanitize_gh_stderr() {
+  sed -E 's#https://[^@[:space:]]+@#https://REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
+}
+
+is_transient_gh_error() {
+  [ -s "$1" ] && grep -Eiq 'HTTP 5[0-9][0-9]|(^|[^0-9])(502|503|504)([^0-9]|$)|rate limit|timed out|timeout|temporar|connection reset|connection refused|TLS handshake|network|server error' "$1"
+}
+
+gh_with_retry() {
+  local label="$1" stderr_file output status attempt delay=1
+  shift
+  for attempt in 1 2 3; do
+    stderr_file=$(mktemp -t step21-gh-XXXXXX)
+    if output=$(timeout 60 gh "$@" 2>"$stderr_file"); then
+      rm -f "$stderr_file"
+      printf '%s\n' "$output"
+      return 0
+    fi
+    status=$?
+    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
+      echo "WARNING: gh $label failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
+      rm -f "$stderr_file"
+      sleep "$delay"
+      delay=$((delay * 2))
+      continue
+    fi
+    echo "WARNING: gh $label failed (exit ${status})" >&2
+    [ ! -s "$stderr_file" ] || echo "gh $label stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
+    rm -f "$stderr_file"
+    return "$status"
+  done
+}
+
 pr_targets=()
 add_pr_target() {
   local target="$1" existing
@@ -35,7 +68,11 @@ fi
 if [ "${#pr_targets[@]}" -eq 0 ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   current_branch=$(git branch --show-current 2>/dev/null || true)
   if [[ "$current_branch" =~ [^[:space:]] ]]; then
-    while IFS= read -r branch_pr_number; do add_pr_target "$branch_pr_number"; done < <(timeout 60 gh pr list --head "$current_branch" --state all --json number --jq '.[].number' 2>/dev/null || true)
+    if branch_pr_numbers="$(gh_with_retry "pr list" pr list --head "$current_branch" --state all --json number --jq '.[].number')"; then
+      while IFS= read -r branch_pr_number; do add_pr_target "$branch_pr_number"; done <<< "$branch_pr_numbers"
+    else
+      echo "WARNING: unable to discover PRs for branch '$current_branch'; skipping branch discovery" >&2
+    fi
   fi
 fi
 if [ "${#pr_targets[@]}" -eq 0 ]; then
@@ -46,19 +83,14 @@ fi
 terminal_status="active-pr"
 closed_unmerged_seen="false"
 for pr_target in "${pr_targets[@]}"; do
-  pr_json_file=$(mktemp -t step21-pr-view-XXXXXX)
-  if ! timeout 60 gh pr view "$pr_target" --json number,state,isDraft,mergedAt,url >"$pr_json_file" 2>&1; then
-    view_rc=$?
-    echo "WARNING: unable to inspect PR '$pr_target' with gh (exit $view_rc); skipping this PR" >&2
-    cat "$pr_json_file" >&2
-    rm -f "$pr_json_file"
+  if ! pr_json="$(gh_with_retry "pr view" pr view "$pr_target" --json number,state,isDraft,mergedAt,url)"; then
+    echo "WARNING: unable to inspect PR '$pr_target' with gh; skipping this PR" >&2
     continue
   fi
-  pr_url=$(jq -r '.url // ""' "$pr_json_file")
-  pr_state=$(jq -r '.state // ""' "$pr_json_file")
-  pr_is_draft=$(jq -r '.isDraft // false' "$pr_json_file")
-  pr_merged_at=$(jq -r '.mergedAt // ""' "$pr_json_file")
-  rm -f "$pr_json_file"
+  pr_url=$(printf '%s' "$pr_json" | jq -r '.url // ""')
+  pr_state=$(printf '%s' "$pr_json" | jq -r '.state // ""')
+  pr_is_draft=$(printf '%s' "$pr_json" | jq -r '.isDraft // false')
+  pr_merged_at=$(printf '%s' "$pr_json" | jq -r '.mergedAt // ""')
 
   if [ "$pr_state" = "MERGED" ] || [ -n "$pr_merged_at" ]; then
     terminal_status="already-merged"
@@ -74,15 +106,10 @@ for pr_target in "${pr_targets[@]}"; do
   fi
 
   if [ "$pr_is_draft" = "true" ]; then
-    ready_output_file=$(mktemp -t step21-pr-ready-XXXXXX)
-    if timeout 60 gh pr ready "$pr_url" >"$ready_output_file" 2>&1; then
-      cat "$ready_output_file"
-      rm -f "$ready_output_file"
+    if ready_output="$(gh_with_retry "pr ready" pr ready "$pr_url")"; then
+      printf '%s\n' "$ready_output"
     else
-      ready_rc=$?
-      echo "WARNING: gh pr ready failed for '$pr_url' (exit $ready_rc); continuing with visible skip" >&2
-      cat "$ready_output_file" >&2
-      rm -f "$ready_output_file"
+      echo "WARNING: gh pr ready failed for '$pr_url'; continuing with visible skip" >&2
       continue
     fi
   else
@@ -94,15 +121,11 @@ for pr_target in "${pr_targets[@]}"; do
 Workflow steps completed: requirements, design, implementation, tests, code review, philosophy compliance, cleanup, and quality audit.
 
 Ready for merge approval."
-  comment_output_file=$(mktemp -t step21-pr-comment-XXXXXX)
-  if timeout 60 gh pr comment "$pr_url" --body "$ready_body" >"$comment_output_file" 2>&1; then
-    cat "$comment_output_file"
+  if comment_output="$(gh_with_retry "pr comment" pr comment "$pr_url" --body "$ready_body")"; then
+    printf '%s\n' "$comment_output"
   else
-    comment_rc=$?
-    echo "WARNING: gh pr comment failed for '$pr_url' (exit $comment_rc); PR ready state was still evaluated" >&2
-    cat "$comment_output_file" >&2
+    echo "WARNING: gh pr comment failed for '$pr_url'; PR ready state was still evaluated" >&2
   fi
-  rm -f "$comment_output_file"
 done
 
 if [ "$closed_unmerged_seen" = "true" ]; then

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -26,6 +26,39 @@ emit_publish_result() {
     '{state:$state,legacy_state:$legacy_state,terminal_status:$terminal_status,pr_url:$pr_url,pr_number:$pr_number,branch_diff_status:$branch_diff_status,message:$message}'
 }
 
+finish_publish() {
+  local state="$1"
+  local legacy_state="$2"
+  local terminal_status="$3"
+  local message="$4"
+  local exit_code="${5:-0}"
+
+  PUBLISH_STATE="$state"
+  LEGACY_PUBLISH_STATE="$legacy_state"
+  TERMINAL_STATUS="$terminal_status"
+  MESSAGE="$message"
+  emit_publish_result
+  exit "$exit_code"
+}
+
+load_pr_fields() {
+  local pr_json="$1"
+  mapfile -t PR_FIELDS < <(
+    printf '%s' "$pr_json" | jq -r '.url // "", ((.number // "") | tostring), .state // "", .mergedAt // "", .headRefName // "", .baseRefName // "", .headRefOid // "", (.headRepositoryOwner.login // .headRepositoryOwner.name // .headRepositoryOwner // ""), (.headRepository.name // ((.headRepository.nameWithOwner // "") | split("/") | .[-1]) // ""), (.baseRepository.owner.login // .baseRepository.owner.name // ((.baseRepository.nameWithOwner // "") | split("/") | .[0]) // ""), (.baseRepository.name // ((.baseRepository.nameWithOwner // "") | split("/") | .[-1]) // "")'
+  )
+  PR_URL_RESULT="${PR_FIELDS[0]:-}"
+  PR_NUMBER_RESULT="${PR_FIELDS[1]:-}"
+  PR_STATE="${PR_FIELDS[2]:-}"
+  PR_MERGED_AT="${PR_FIELDS[3]:-}"
+  PR_HEAD_REF="${PR_FIELDS[4]:-}"
+  PR_BASE_REF="${PR_FIELDS[5]:-}"
+  PR_HEAD_OID="${PR_FIELDS[6]:-}"
+  PR_HEAD_OWNER="${PR_FIELDS[7]:-}"
+  PR_HEAD_REPO="${PR_FIELDS[8]:-}"
+  PR_BASE_OWNER="${PR_FIELDS[9]:-}"
+  PR_BASE_REPO="${PR_FIELDS[10]:-}"
+}
+
 resolve_pr_base_ref() {
   local candidate
   candidate="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
@@ -33,11 +66,55 @@ resolve_pr_base_ref() {
   git remote set-head origin -a >/dev/null 2>&1 || true
   candidate="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
   if [ -n "$candidate" ] && git rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then printf '%s\n' "$candidate"; return 0; fi
-  for candidate in origin/master origin/develop; do
+  for candidate in origin/main origin/master origin/develop; do
     if git rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null; then printf '%s\n' "$candidate"; return 0; fi
   done
-  echo "ERROR: no supported remote base ref found. Expected origin/HEAD, origin/master, or origin/develop." >&2
+  echo "ERROR: no supported remote base ref found. Expected origin/HEAD, origin/main, origin/master, or origin/develop." >&2
   return 1
+}
+
+parse_github_repo_identity() {
+  local url="$1" path owner repo
+  case "$url" in
+    git@github.com:*) path="${url#git@github.com:}" ;;
+    ssh://git@github.com/*) path="${url#ssh://git@github.com/}" ;;
+    https://github.com/*) path="${url#https://github.com/}" ;;
+    http://github.com/*) path="${url#http://github.com/}" ;;
+    *) return 1 ;;
+  esac
+  path="${path%%\?*}"
+  path="${path%%#*}"
+  path="${path%.git}"
+  owner="${path%%/*}"
+  repo="${path#*/}"
+  repo="${repo%%/*}"
+  [ -n "$owner" ] && [ -n "$repo" ] && [ "$owner" != "$repo" ] || return 1
+  printf '%s/%s\n' "$owner" "$repo"
+}
+
+validate_pr_identity() {
+  local expected_base="$1"
+  if [ -z "$REPO_IDENTITY" ]; then
+    finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "unable to determine current GitHub repo identity from origin remote" 1
+  fi
+  if [ -z "$PR_HEAD_REF" ] || [ -z "$PR_BASE_REF" ] || [ -z "$PR_HEAD_OID" ]; then
+    finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "existing PR metadata is incomplete; refusing to classify terminal state" 1
+  fi
+  if [ "$PR_HEAD_REF" != "$CURRENT_BRANCH" ]; then
+    finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "existing PR headRefName '$PR_HEAD_REF' does not match current branch '$CURRENT_BRANCH'" 1
+  fi
+  if [ "$PR_BASE_REF" != "$expected_base" ]; then
+    finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "existing PR baseRefName '$PR_BASE_REF' does not match base '$expected_base'" 1
+  fi
+  if [ "$PR_HEAD_OID" != "$LOCAL_HEAD" ]; then
+    finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "existing PR headRefOid '$PR_HEAD_OID' does not match local HEAD '$LOCAL_HEAD'" 1
+  fi
+  if [ -z "$PR_HEAD_OWNER" ] || [ -z "$PR_HEAD_REPO" ] || [ -z "$PR_BASE_OWNER" ] || [ -z "$PR_BASE_REPO" ]; then
+    finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "existing PR metadata is missing repository identity" 1
+  fi
+  if [ "$PR_HEAD_OWNER/$PR_HEAD_REPO" != "$REPO_IDENTITY" ] || [ "$PR_BASE_OWNER/$PR_BASE_REPO" != "$REPO_IDENTITY" ]; then
+    finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "existing PR repo '$PR_HEAD_OWNER/$PR_HEAD_REPO' -> '$PR_BASE_OWNER/$PR_BASE_REPO' does not match current repo '$REPO_IDENTITY'" 1
+  fi
 }
 
 sanitize_gh_stderr() {
@@ -52,8 +129,11 @@ gh_pr_list_with_retry() {
   local stderr_file output status attempt delay=1
   for attempt in 1 2 3; do
     stderr_file=$(mktemp -t step16-gh-pr-list-XXXXXX)
-    if output=$(timeout 60 gh pr list "$@" 2>"$stderr_file"); then rm -f "$stderr_file"; printf '%s\n' "$output"; return 0; fi
-    status=$?
+    if output=$(timeout 60 gh pr list "$@" 2>"$stderr_file"); then
+      rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
+    else
+      status=$?
+    fi
     if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
       echo "WARNING: gh pr list failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
       rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
@@ -69,8 +149,11 @@ gh_pr_view_with_retry() {
   local stderr_file output status attempt delay=1
   for attempt in 1 2 3; do
     stderr_file=$(mktemp -t step16-gh-pr-view-XXXXXX)
-    if output=$(timeout 60 gh pr view "$@" 2>"$stderr_file"); then rm -f "$stderr_file"; printf '%s\n' "$output"; return 0; fi
-    status=$?
+    if output=$(timeout 60 gh pr view "$@" 2>"$stderr_file"); then
+      rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
+    else
+      status=$?
+    fi
     if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
       echo "WARNING: gh pr view failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
       rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
@@ -86,8 +169,11 @@ gh_pr_create_with_retry() {
   local stderr_file output status attempt delay=1
   for attempt in 1 2 3; do
     stderr_file=$(mktemp -t step16-gh-pr-create-XXXXXX)
-    if output=$(timeout 60 gh pr create --draft --title "$PR_TITLE" --body "$PR_BODY" 2>"$stderr_file"); then rm -f "$stderr_file"; printf '%s\n' "$output"; return 0; fi
-    status=$?
+    if output=$(timeout 60 gh pr create --draft --title "$PR_TITLE" --body "$PR_BODY" 2>"$stderr_file"); then
+      rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
+    else
+      status=$?
+    fi
     if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
       echo "WARNING: gh pr create failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
       rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
@@ -101,57 +187,52 @@ gh_pr_create_with_retry() {
 
 HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
 if [ "$HOST_TYPE" != "github" ]; then
-  PUBLISH_STATE="non-github"; LEGACY_PUBLISH_STATE="non-github"; TERMINAL_STATUS="success"; MESSAGE="non-GitHub host does not use gh pr create"
-  emit_publish_result
-  exit 0
+  finish_publish "non-github" "non-github" "success" "non-GitHub host does not use gh pr create"
 fi
 
 CURRENT_BRANCH=$(git branch --show-current)
 ISSUE_NUM="$ISSUE_NUMBER"
 if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then echo "ERROR: issue_number is not numeric: $ISSUE_NUM" >&2; exit 1; fi
 if ! command -v gh >/dev/null 2>&1; then echo "ERROR: workflow_publish_pr.sh requires the GitHub CLI ('gh') on PATH." >&2; exit 127; fi
+[ -n "$CURRENT_BRANCH" ] || finish_publish "FAILED_INVALID_INPUT" "invalid-input" "failure" "current branch is empty; cannot publish from detached HEAD" 1
+LOCAL_HEAD="$(git rev-parse --verify HEAD 2>/dev/null)" || finish_publish "FAILED_INVALID_INPUT" "invalid-input" "failure" "local HEAD does not resolve" 1
+REPO_IDENTITY="$(parse_github_repo_identity "$(git config --get remote.origin.url 2>/dev/null || true)" || true)"
 
 BASE_REF="$(resolve_pr_base_ref)"
 BASE_BRANCH="${BASE_REF#origin/}"
 if git diff --quiet "${BASE_REF}..HEAD"; then BRANCH_DIFF_STATUS="no-diff"; else BRANCH_DIFF_STATUS="has-diff"; fi
 
-PR_JSON="$(gh_pr_list_with_retry --head "$CURRENT_BRANCH" --state all --json url,number,state,headRefName,headRefOid,mergedAt --jq '.[0] // {}')"
-if [ "$(printf '%s' "$PR_JSON" | jq -r '.url // ""')" = "" ]; then
-  PR_JSON="$(gh_pr_list_with_retry --state all --json url,number,state,headRefName,headRefOid,mergedAt --jq "[.[] | select(.headRefName | test(\"issue-$ISSUE_NUM\"))] | .[0] // {}")"
+if ! PR_JSON="$(gh_pr_list_with_retry --head "$CURRENT_BRANCH" --state all --json url,number,state,mergedAt,headRefName,baseRefName,headRefOid,headRepositoryOwner,headRepository,baseRepository --jq '.[0] // {}')"; then
+  finish_publish "FAILED_PR_METADATA_UNAVAILABLE" "pr-metadata-unavailable" "failure" "unavailable PR metadata for branch; refusing to risk duplicate PR creation" 1
 fi
+load_pr_fields "$PR_JSON"
 
-EXISTING_PR="$(printf '%s' "$PR_JSON" | jq -r '.url // ""')"
-if [ -n "$EXISTING_PR" ]; then
-  VIEW_JSON="$(gh_pr_view_with_retry "$EXISTING_PR" --json url,number,state,headRefName,headRefOid,mergedAt)"
-  PR_URL_RESULT="$(printf '%s' "$VIEW_JSON" | jq -r '.url // ""')"
-  PR_NUMBER_RESULT="$(printf '%s' "$VIEW_JSON" | jq -r '(.number // "") | tostring')"
-  PR_STATE="$(printf '%s' "$VIEW_JSON" | jq -r '.state // ""')"
-  PR_MERGED_AT="$(printf '%s' "$VIEW_JSON" | jq -r '.mergedAt // ""')"
+if [ -n "$PR_URL_RESULT" ]; then
+  if [ -z "$PR_STATE" ]; then
+    VIEW_JSON="$(gh_pr_view_with_retry "$PR_URL_RESULT" --json url,number,state,mergedAt,headRefName,baseRefName,headRefOid,headRepositoryOwner,headRepository,baseRepository)"
+    load_pr_fields "$VIEW_JSON"
+  fi
+  validate_pr_identity "$BASE_BRANCH"
   case "$PR_STATE:$PR_MERGED_AT" in
-    OPEN:*) PUBLISH_STATE="existing-open-pr"; LEGACY_PUBLISH_STATE="existing-open-pr"; TERMINAL_STATUS="success"; MESSAGE="existing open PR found for branch"; emit_publish_result; exit 0 ;;
-    MERGED:*) PUBLISH_STATE="MERGED"; LEGACY_PUBLISH_STATE="already-merged"; TERMINAL_STATUS="success"; MESSAGE="branch PR is already merged"; emit_publish_result; exit 0 ;;
-    CLOSED:?*) PUBLISH_STATE="MERGED"; LEGACY_PUBLISH_STATE="closed-after-merge"; TERMINAL_STATUS="success"; MESSAGE="branch PR is closed after merge"; emit_publish_result; exit 0 ;;
+    OPEN:*) finish_publish "existing-open-pr" "existing-open-pr" "success" "existing open PR found for branch" ;;
+    MERGED:*) finish_publish "MERGED" "already-merged" "success" "branch PR is already merged" ;;
+    CLOSED:?*) finish_publish "MERGED" "closed-after-merge" "success" "branch PR is closed after merge" ;;
     CLOSED:*)
       if [ "$BRANCH_DIFF_STATUS" = "has-diff" ]; then
-        PUBLISH_STATE="FAILED_CLOSED_UNMERGED"; LEGACY_PUBLISH_STATE="closed-unmerged-with-diff"; TERMINAL_STATUS="failure"; MESSAGE="existing PR was closed without merge and branch still has diff; reopen it or create a new branch intentionally"
-        emit_publish_result
-        exit 1
+        finish_publish "FAILED_CLOSED_UNMERGED" "closed-unmerged-with-diff" "failure" "existing PR was closed without merge and branch still has diff; reopen it or create a new branch intentionally" 1
       fi
-      PUBLISH_STATE="CLOSED_OBSOLETE"; LEGACY_PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; MESSAGE="closed unmerged PR exists but branch has no diff against base"; emit_publish_result; exit 0 ;;
+      finish_publish "CLOSED_OBSOLETE" "no-diff" "success" "closed unmerged PR exists but branch has no diff against base" ;;
   esac
 fi
 
 if [ "$BRANCH_DIFF_STATUS" = "no-diff" ]; then
-  PUBLISH_STATE="NO_DIFF_SUCCESS"; LEGACY_PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; MESSAGE="branch has no diff against base; no PR created"
-  emit_publish_result
-  exit 0
+  finish_publish "NO_DIFF_SUCCESS" "no-diff" "success" "branch has no diff against base; no PR created"
 fi
 
 COMMITS_AHEAD=$(git rev-list --count "${BASE_REF}..HEAD" 2>/dev/null || echo "0")
 if [ "$COMMITS_AHEAD" -eq 0 ]; then
-  PUBLISH_STATE="NO_DIFF_SUCCESS"; LEGACY_PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; BRANCH_DIFF_STATUS="no-diff"; MESSAGE="0 commits ahead of ${BASE_BRANCH}; no PR created"
-  emit_publish_result
-  exit 0
+  BRANCH_DIFF_STATUS="no-diff"
+  finish_publish "NO_DIFF_SUCCESS" "no-diff" "success" "0 commits ahead of ${BASE_BRANCH}; no PR created"
 fi
 
 CHANGED_FILES=$(git diff --name-only "${BASE_REF}..HEAD" 2>/dev/null | head -40 || true)
@@ -175,8 +256,8 @@ PR_BODY=$(printf '## Summary\nConcise workflow-generated PR for %s.\n\n## Issue\
 
 PUBLISH_STATE="FOLLOWUP_CREATED"
 LEGACY_PUBLISH_STATE="create-new-pr"
-PR_URL_RESULT="$(gh_pr_create_with_retry)"
+if ! PR_URL_RESULT="$(gh_pr_create_with_retry)"; then
+  finish_publish "FAILED_PR_CREATE" "create-pr-failed" "failure" "draft PR creation failed; GitHub API state is ambiguous" 1
+fi
 PR_NUMBER_RESULT="$(printf '%s\n' "$PR_URL_RESULT" | sed -nE 's#.*/pull/([0-9]+).*#\1#p' | head -1)"
-TERMINAL_STATUS="success"
-MESSAGE="draft PR created"
-emit_publish_result
+finish_publish "$PUBLISH_STATE" "$LEGACY_PUBLISH_STATE" "success" "draft PR created"

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -7,6 +7,7 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 PUBLISH_STATE="unknown"
+LEGACY_PUBLISH_STATE="unknown"
 TERMINAL_STATUS="failure"
 PR_URL_RESULT=""
 PR_NUMBER_RESULT=""
@@ -16,12 +17,13 @@ MESSAGE="not classified"
 emit_publish_result() {
   jq -nc \
     --arg state "$PUBLISH_STATE" \
+    --arg legacy_state "$LEGACY_PUBLISH_STATE" \
     --arg terminal_status "$TERMINAL_STATUS" \
     --arg pr_url "$PR_URL_RESULT" \
     --arg pr_number "$PR_NUMBER_RESULT" \
     --arg branch_diff_status "$BRANCH_DIFF_STATUS" \
     --arg message "$MESSAGE" \
-    '{state:$state,terminal_status:$terminal_status,pr_url:$pr_url,pr_number:$pr_number,branch_diff_status:$branch_diff_status,message:$message}'
+    '{state:$state,legacy_state:$legacy_state,terminal_status:$terminal_status,pr_url:$pr_url,pr_number:$pr_number,branch_diff_status:$branch_diff_status,message:$message}'
 }
 
 resolve_pr_base_ref() {
@@ -50,7 +52,7 @@ gh_pr_list_with_retry() {
   local stderr_file output status attempt delay=1
   for attempt in 1 2 3; do
     stderr_file=$(mktemp -t step16-gh-pr-list-XXXXXX)
-    if output=$(gh pr list "$@" 2>"$stderr_file"); then rm -f "$stderr_file"; printf '%s\n' "$output"; return 0; fi
+    if output=$(timeout 60 gh pr list "$@" 2>"$stderr_file"); then rm -f "$stderr_file"; printf '%s\n' "$output"; return 0; fi
     status=$?
     if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
       echo "WARNING: gh pr list failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
@@ -63,11 +65,28 @@ gh_pr_list_with_retry() {
   done
 }
 
+gh_pr_view_with_retry() {
+  local stderr_file output status attempt delay=1
+  for attempt in 1 2 3; do
+    stderr_file=$(mktemp -t step16-gh-pr-view-XXXXXX)
+    if output=$(timeout 60 gh pr view "$@" 2>"$stderr_file"); then rm -f "$stderr_file"; printf '%s\n' "$output"; return 0; fi
+    status=$?
+    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
+      echo "WARNING: gh pr view failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
+      rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
+    fi
+    echo "ERROR: gh pr view failed (exit ${status}); existing PR state is ambiguous." >&2
+    [ ! -s "$stderr_file" ] || echo "gh pr view stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
+    rm -f "$stderr_file"
+    return "$status"
+  done
+}
+
 gh_pr_create_with_retry() {
   local stderr_file output status attempt delay=1
   for attempt in 1 2 3; do
     stderr_file=$(mktemp -t step16-gh-pr-create-XXXXXX)
-    if output=$(gh pr create --draft --title "$PR_TITLE" --body "$PR_BODY" 2>"$stderr_file"); then rm -f "$stderr_file"; printf '%s\n' "$output"; return 0; fi
+    if output=$(timeout 60 gh pr create --draft --title "$PR_TITLE" --body "$PR_BODY" 2>"$stderr_file"); then rm -f "$stderr_file"; printf '%s\n' "$output"; return 0; fi
     status=$?
     if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
       echo "WARNING: gh pr create failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
@@ -82,7 +101,7 @@ gh_pr_create_with_retry() {
 
 HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
 if [ "$HOST_TYPE" != "github" ]; then
-  PUBLISH_STATE="non-github"; TERMINAL_STATUS="success"; MESSAGE="non-GitHub host does not use gh pr create"
+  PUBLISH_STATE="non-github"; LEGACY_PUBLISH_STATE="non-github"; TERMINAL_STATUS="success"; MESSAGE="non-GitHub host does not use gh pr create"
   emit_publish_result
   exit 0
 fi
@@ -103,34 +122,34 @@ fi
 
 EXISTING_PR="$(printf '%s' "$PR_JSON" | jq -r '.url // ""')"
 if [ -n "$EXISTING_PR" ]; then
-  VIEW_JSON="$(gh pr view "$EXISTING_PR" --json url,number,state,headRefName,headRefOid,mergedAt)"
+  VIEW_JSON="$(gh_pr_view_with_retry "$EXISTING_PR" --json url,number,state,headRefName,headRefOid,mergedAt)"
   PR_URL_RESULT="$(printf '%s' "$VIEW_JSON" | jq -r '.url // ""')"
   PR_NUMBER_RESULT="$(printf '%s' "$VIEW_JSON" | jq -r '(.number // "") | tostring')"
   PR_STATE="$(printf '%s' "$VIEW_JSON" | jq -r '.state // ""')"
   PR_MERGED_AT="$(printf '%s' "$VIEW_JSON" | jq -r '.mergedAt // ""')"
   case "$PR_STATE:$PR_MERGED_AT" in
-    OPEN:*) PUBLISH_STATE="existing-open-pr"; TERMINAL_STATUS="success"; MESSAGE="existing open PR found for branch"; emit_publish_result; exit 0 ;;
-    MERGED:*) PUBLISH_STATE="already-merged"; TERMINAL_STATUS="success"; MESSAGE="branch PR is already merged"; emit_publish_result; exit 0 ;;
-    CLOSED:?*) PUBLISH_STATE="closed-after-merge"; TERMINAL_STATUS="success"; MESSAGE="branch PR is closed after merge"; emit_publish_result; exit 0 ;;
+    OPEN:*) PUBLISH_STATE="existing-open-pr"; LEGACY_PUBLISH_STATE="existing-open-pr"; TERMINAL_STATUS="success"; MESSAGE="existing open PR found for branch"; emit_publish_result; exit 0 ;;
+    MERGED:*) PUBLISH_STATE="MERGED"; LEGACY_PUBLISH_STATE="already-merged"; TERMINAL_STATUS="success"; MESSAGE="branch PR is already merged"; emit_publish_result; exit 0 ;;
+    CLOSED:?*) PUBLISH_STATE="MERGED"; LEGACY_PUBLISH_STATE="closed-after-merge"; TERMINAL_STATUS="success"; MESSAGE="branch PR is closed after merge"; emit_publish_result; exit 0 ;;
     CLOSED:*)
       if [ "$BRANCH_DIFF_STATUS" = "has-diff" ]; then
-        PUBLISH_STATE="closed-unmerged-with-diff"; TERMINAL_STATUS="failure"; MESSAGE="existing PR was closed without merge and branch still has diff; reopen it or create a new branch intentionally"
+        PUBLISH_STATE="FAILED_CLOSED_UNMERGED"; LEGACY_PUBLISH_STATE="closed-unmerged-with-diff"; TERMINAL_STATUS="failure"; MESSAGE="existing PR was closed without merge and branch still has diff; reopen it or create a new branch intentionally"
         emit_publish_result
         exit 1
       fi
-      PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; MESSAGE="closed unmerged PR exists but branch has no diff against base"; emit_publish_result; exit 0 ;;
+      PUBLISH_STATE="CLOSED_OBSOLETE"; LEGACY_PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; MESSAGE="closed unmerged PR exists but branch has no diff against base"; emit_publish_result; exit 0 ;;
   esac
 fi
 
 if [ "$BRANCH_DIFF_STATUS" = "no-diff" ]; then
-  PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; MESSAGE="branch has no diff against base; no PR created"
+  PUBLISH_STATE="NO_DIFF_SUCCESS"; LEGACY_PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; MESSAGE="branch has no diff against base; no PR created"
   emit_publish_result
   exit 0
 fi
 
 COMMITS_AHEAD=$(git rev-list --count "${BASE_REF}..HEAD" 2>/dev/null || echo "0")
 if [ "$COMMITS_AHEAD" -eq 0 ]; then
-  PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; BRANCH_DIFF_STATUS="no-diff"; MESSAGE="0 commits ahead of ${BASE_BRANCH}; no PR created"
+  PUBLISH_STATE="NO_DIFF_SUCCESS"; LEGACY_PUBLISH_STATE="no-diff"; TERMINAL_STATUS="success"; BRANCH_DIFF_STATUS="no-diff"; MESSAGE="0 commits ahead of ${BASE_BRANCH}; no PR created"
   emit_publish_result
   exit 0
 fi
@@ -154,7 +173,8 @@ DIFF_STAT_BODY="${DIFF_STAT:-No diff stat available}"
 ISSUE_LINK="Closes #${ISSUE_NUM}"
 PR_BODY=$(printf '## Summary\nConcise workflow-generated PR for %s.\n\n## Issue\n%s\n\n## Changed files\n%s\n\n## Diff stat\n```text\n%s\n```\n\n## Behavior\n%s\n\n## Validation\n%s\n\n## Risk\n%s\n\n## Checklist\n- [x] Branch has %s commit(s) ahead of %s\n- [ ] Code review completed\n- [ ] Philosophy check passed\n\n---\n*This PR was created as a draft for review before merging.*\n' "$PR_SCOPE" "$ISSUE_LINK" "$CHANGED_FILES_BODY" "$DIFF_STAT_BODY" "$BEHAVIOR_BODY" "$VALIDATION_BODY" "$RISK_BODY" "$COMMITS_AHEAD" "$BASE_BRANCH")
 
-PUBLISH_STATE="create-new-pr"
+PUBLISH_STATE="FOLLOWUP_CREATED"
+LEGACY_PUBLISH_STATE="create-new-pr"
 PR_URL_RESULT="$(gh_pr_create_with_retry)"
 PR_NUMBER_RESULT="$(printf '%s\n' "$PR_URL_RESULT" | sed -nE 's#.*/pull/([0-9]+).*#\1#p' | head -1)"
 TERMINAL_STATUS="success"

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -116,6 +116,18 @@ name = "workflow_publish_resilience"
 path = "../../tests/integration/workflow_publish_resilience.rs"
 
 [[test]]
+name = "default_workflow_terminal_state"
+path = "../../tests/integration/default_workflow_terminal_state.rs"
+
+[[test]]
+name = "workflow_publish_terminal_gate"
+path = "../../tests/integration/workflow_publish_terminal_gate.rs"
+
+[[test]]
+name = "workflow_finalize_terminal_state"
+path = "../../tests/integration/workflow_finalize_terminal_state.rs"
+
+[[test]]
 name = "workflow_finalize_resilience"
 path = "../../tests/integration/workflow_finalize_resilience.rs"
 

--- a/docs/concepts/default-workflow.md
+++ b/docs/concepts/default-workflow.md
@@ -45,6 +45,85 @@ You can customize this workflow by editing this file.
 - CI/CD integration points
 - Review and merge requirements
 
+`default-workflow` is also idempotent around completed or obsolete work. Before
+publish, PR review, CI waiting, or merge can mutate Git or GitHub state, the
+workflow evaluates a terminal-state contract. Finalization remains the
+non-mutating arbiter that records the final decision. A proven terminal success
+stops the remaining mutation path instead of creating duplicate commits,
+duplicate follow-up PRs, or stale post-merge publish attempts.
+
+### Terminal-State Contract
+
+`workflow-terminal-state` is the evidence gate shared by publish, PR review, and
+finalize. It returns these outputs:
+
+| Output | Meaning |
+| --- | --- |
+| `terminal_success` | `true` only when the workflow can stop successfully without publishing more work. |
+| `terminal_state` | Stable status such as `MERGED`, `CLOSED_OBSOLETE`, `NO_DIFF_SUCCESS`, `FOLLOWUP_CREATED`, or `BLOCKED_CI`. |
+| `terminal_reason` | Human-readable evidence for the decision. |
+| `publish_status` | Publish-facing status using the same vocabulary as the terminal state. |
+| `should_publish` | `true` only when meaningful unmerged work should be committed, pushed, and represented by a PR. |
+| `should_finalize` | `true` when the workflow should route to finalize so it can emit the non-mutating final decision; `false` when no finalize phase is part of the current path. |
+| `should_run_ci_wait` | `true` only when CI should be waited on for an active publish path. |
+| `should_merge` | `true` only when merge remains valid for green, active work. |
+
+The probe fails closed. It validates these context inputs before trusting shell
+or GitHub CLI output:
+
+| Input | Requirement |
+| --- | --- |
+| `repo_path` | Existing Git repository used for all local diff and status checks. |
+| `branch_name` | Current or expected branch ref; malformed refs block terminal success. |
+| `base_ref` | Intended comparison base, usually the resolved remote default branch. |
+| `pr_number` | Numeric PR identifier when recovery is tied to an existing PR. |
+| `pr_url` | Same-repository PR URL when a URL is supplied instead of `pr_number`. |
+| `goal_already_met` | Optional design evidence; never overrides dirty, diff, PR, or CI blockers. |
+
+Malformed inputs, unavailable PR metadata, missing base refs, and GitHub CLI
+errors fail closed. The workflow reports the specific evidence gap instead of
+converting an untrusted probe into terminal success.
+
+Terminal-state detection uses this order:
+
+1. Dirty worktree check. Any uncommitted change blocks terminal success because
+   the workflow cannot prove the work is complete or safe to ignore.
+2. Merged PR evidence. A merged PR, including a closed PR with `mergedAt`
+   evidence, returns `MERGED`.
+3. Closed obsolete proof. A closed, unmerged PR returns `CLOSED_OBSOLETE` only
+   when the branch is clean and the intended changes are already represented
+   upstream or there is no meaningful remaining diff.
+4. Clean no-diff proof. A clean branch with no meaningful diff or commits
+   against the intended base returns `NO_DIFF_SUCCESS`.
+5. Meaningful remaining diff. The workflow continues to the publish path and
+   may emit `FOLLOWUP_CREATED`, or `BLOCKED_CI` if checks fail.
+
+The successful terminal states are:
+
+| State | Required evidence | Workflow behavior |
+| --- | --- | --- |
+| `MERGED` | PR is merged, or is closed with merge evidence such as `mergedAt`. | Stop before version bump, commit, push, PR creation/update, CI wait, and merge. |
+| `CLOSED_OBSOLETE` | PR is closed without merge evidence, the worktree is clean, and equivalent work is already upstream or no meaningful branch work remains. | Stop successfully and record the obsolete proof. |
+| `NO_DIFF_SUCCESS` | Worktree is clean and there are no meaningful diffs or commits against the intended base. | Stop successfully without creating a no-op commit or follow-up PR. |
+
+The loud blocking states include:
+
+| State | Meaning |
+| --- | --- |
+| `BLOCKED_DIRTY_WORKTREE` | Uncommitted changes are present. Commit, stash, or remove them through the workflow before claiming terminal success. |
+| `BLOCKED_CLOSED_UNMERGED` | The PR is closed without merge evidence and obsolete/no-diff proof is missing. |
+| `BLOCKED_UNMERGED_DIFF` | Meaningful branch changes remain but cannot be safely published. |
+| `BLOCKED_CI` | Required checks are failing or a CI policy blocks publish or merge. |
+
+Malformed inputs, unavailable PR metadata, missing base refs, and GitHub CLI
+errors are loud blockers even when they do not share one stable status name.
+
+`goal_already_met` remains compatible with older design outputs, but it is not a
+shortcut around evidence. A goal-met claim can support terminal success only
+when the terminal-state probe also proves a clean no-diff, merged, or obsolete
+state. Dirty work, failing CI, closed-unmerged PRs, and meaningful unmerged diffs
+override `goal_already_met`.
+
 ## When This Workflow Applies
 
 This workflow should be followed for:
@@ -315,6 +394,10 @@ Test like a user would use the feature - outside-in - not just unit tests.
 
 ### Step 14: Commit and Push
 
+- [ ] Before staging, version bumping, committing, or pushing, run the
+      terminal-state gate.
+- [ ] If `terminal_success=true`, stop the publish path successfully and do not
+      create a commit, push a branch, create a PR, wait for CI, or merge.
 - [ ] Stage all changes
 - [ ] Write detailed commit message
 - [ ] Reference issue number in commit
@@ -353,6 +436,14 @@ either `design_spec` or `DESIGN_SPEC`; if both are present, `design_spec` takes
 precedence. If both are missing or empty, `workflow-publish` treats the design
 spec as an empty optional section and does not fail under `set -u`.
 
+When the terminal-state gate returns `MERGED`, `CLOSED_OBSOLETE`, or
+`NO_DIFF_SUCCESS`, `workflow-publish` treats the publish step as complete and
+does not run version bump, stage, commit, push, PR create/update, CI wait, or
+merge commands. When it returns `should_publish=true`, publish keeps the normal
+behavior: meaningful diffs are committed and pushed, an existing PR is updated
+or a follow-up PR is created, and the status is reported as `FOLLOWUP_CREATED`
+when that PR represents the remaining work.
+
 **Why Draft First:**
 
 - Allows review and feedback while still iterating
@@ -366,6 +457,12 @@ This ensures you see success messages, error details, and PR URLs.
 ### Step 16: Review the PR
 
 **⚠️ MANDATORY - DO NOT SKIP ⚠️**
+
+Skip PR review only when the terminal-state gate has already returned a
+successful terminal state. This prevents stale post-merge review or CI behavior
+after a PR is already merged, closed obsolete, or proven no-diff. Closed-unmerged
+PRs without obsolete proof, dirty worktrees, meaningful unmerged diffs, and real
+CI failures are not review skips; they remain blockers.
 
 **REQUIRED FOR ALL PRs**
 
@@ -433,6 +530,9 @@ This ensures you see success messages, error details, and PR URLs.
 
 ### Step 20: Convert PR to Ready for Review
 
+- [ ] Re-check terminal state before changing PR readiness.
+- [ ] If `terminal_success=true`, do not call `gh pr ready`; record the terminal
+      state instead.
 - [ ] Convert draft PR to ready-for-review using `gh pr ready`
 - [ ] Verify all previous steps completed
 - [ ] Ensure all review feedback has been addressed
@@ -460,6 +560,13 @@ gh pr ready 2>&1 | cat
 
 ### Step 21: Ensure PR is Mergeable
 
+- [ ] Re-check terminal, dirty, diff, PR, and CI state before waiting on checks
+      or merging.
+- [ ] If the re-check returns `MERGED`, `CLOSED_OBSOLETE`, or
+      `NO_DIFF_SUCCESS`, stop successfully without CI wait or merge.
+- [ ] If the re-check returns `BLOCKED_CI`, `BLOCKED_DIRTY_WORKTREE`,
+      `BLOCKED_CLOSED_UNMERGED`, or `BLOCKED_UNMERGED_DIFF`, fail loudly with
+      the evidence instead of converting the result to success.
 - [ ] Check CI status (all checks passing)
 - [ ] **Always use** ci-diagnostic-workflow agent if CI fails
 - [ ] **💡 TIP**: When investigating CI failures, use `parallel agent investigation` (see `amplifier-bundle/CLAUDE.md` in the amplifier-bundle) to explore logs and code simultaneously

--- a/docs/concepts/default-workflow.md
+++ b/docs/concepts/default-workflow.md
@@ -110,9 +110,9 @@ The loud blocking states include:
 
 | State | Meaning |
 | --- | --- |
-| `BLOCKED_DIRTY_WORKTREE` | Uncommitted changes are present. Commit, stash, or remove them through the workflow before claiming terminal success. |
-| `BLOCKED_CLOSED_UNMERGED` | The PR is closed without merge evidence and obsolete/no-diff proof is missing. |
-| `BLOCKED_UNMERGED_DIFF` | Meaningful branch changes remain but cannot be safely published. |
+| `FAILED_DIRTY_WORKTREE` | Uncommitted changes are present. Commit, stash, or remove them through the workflow before claiming terminal success. |
+| `FAILED_CLOSED_UNMERGED` | The PR is closed without merge evidence and obsolete/no-diff proof is missing. |
+| `FAILED_MEANINGFUL_DIFF` | Meaningful branch changes remain but cannot be safely published. |
 | `BLOCKED_CI` | Required checks are failing or a CI policy blocks publish or merge. |
 
 Malformed inputs, unavailable PR metadata, missing base refs, and GitHub CLI

--- a/docs/howto/recover-existing-pr-with-default-workflow.md
+++ b/docs/howto/recover-existing-pr-with-default-workflow.md
@@ -13,7 +13,7 @@ You need:
 - the existing PR number
 - the exact existing PR branch name
 - issue requirements or acceptance criteria for the recovery scope
-- `gh auth status` working when publish or finalization may touch GitHub
+- `gh auth status` working so the workflow can inspect PR and check metadata
 
 Do not create a replacement branch and do not merge the PR manually. The
 workflow owns branch reuse, readiness remediation, publish, and finalization.
@@ -76,18 +76,36 @@ Run the workflow from the recovery worktree:
 
 ```bash
 REPO_PATH=/home/user/src/amplihack-rs
+BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName --jq .baseRefName)
+PR_URL=$(gh pr view "$PR_NUMBER" --json url --jq .url)
 
 amplihack recipe run default-workflow \
   -c "repo_path=${REPO_PATH}" \
   -c "pr_number=${PR_NUMBER}" \
+  -c "pr_url=${PR_URL}" \
   -c "existing_branch=${EXISTING_BRANCH}" \
+  -c "base_ref=${BASE_REF}" \
   -c "expected_head_sha=${expected_head_sha}" \
+  -c "goal_already_met=false" \
   -c "task_description=Recover PR #579 after interrupted workflow; resolve Copilot hook readiness and additive-copy readiness only; do not manually merge" \
   -c "issue_requirements=#577: Copilot plugin and native hooks are staged, registered, idempotent, and verified. #578: mapped framework directories replace stale amplihack-owned trees safely, preserve rollback, and guard source/destination aliasing."
 ```
 
 The workflow verifies that the PR belongs to the repository at `repo_path` and
 that the PR head branch matches `existing_branch`.
+
+Terminal-state recovery depends on the same configuration context:
+
+| Context value | Purpose |
+| --- | --- |
+| `repo_path` | Repository where the worktree, diff, and status checks run. |
+| `pr_number` | Existing PR to inspect for merged, closed, or active state. |
+| `pr_url` | Same-repository PR URL when the workflow receives a URL alongside or instead of the number. |
+| `existing_branch` | Branch expected to match the PR head and local checkout. |
+| `base_ref` | Comparison base for no-diff and obsolete proof. Resolve it from PR metadata or the repository default branch before terminal-state checks. |
+| `expected_head_sha` | Optional exact head guard for no-op and recovery readiness evidence. |
+| `goal_already_met` | Optional design signal. Keep it false unless external evidence says the goal is already satisfied; it never overrides Git, PR, diff, or CI evidence. |
+| `task_description` and `issue_requirements` | Scope context for recovery and remediation. They do not prove obsolete state; obsolete proof must come from Git and PR evidence. |
 
 ## 4. Check Branch Reuse Evidence
 
@@ -225,7 +243,54 @@ cargo test -p amplihack-cli read_manifest_rejects_path_traversal_in_dirs --lib
 Missing source assets, symlinked source roots, unsafe path entries, failed
 copy/swap, incomplete verification, or an incomplete manifest are blockers.
 
-## 7. Let `workflow-publish` Own Commits and Pushes
+## 7. Interpret Terminal-State Outcomes
+
+During recovery, the workflow checks terminal state before any version bump,
+commit, push, PR creation, CI wait, or merge. A successful terminal state means
+the recovery is complete without more Git or GitHub mutation.
+
+The terminal-state block uses the same shape in publish, PR review, and
+finalization:
+
+```json
+{
+  "workflow_terminal_state": {
+    "terminal_success": true,
+    "terminal_state": "NO_DIFF_SUCCESS",
+    "terminal_reason": "Worktree is clean and the branch has no meaningful diff against origin/main.",
+    "publish_status": "NO_DIFF_SUCCESS",
+    "should_publish": false,
+    "should_finalize": true,
+    "should_run_ci_wait": false,
+    "should_merge": false
+  }
+}
+```
+
+Use the status exactly as emitted:
+
+| Status | Meaning | What the workflow does next |
+| --- | --- | --- |
+| `MERGED` | The PR is already merged, or it is closed with merge evidence. | Stops successfully before publish, CI wait, or merge. |
+| `CLOSED_OBSOLETE` | The PR is closed without merge evidence, but the branch is clean and the intended changes are already upstream or no meaningful work remains. | Stops successfully and records the obsolete proof. |
+| `NO_DIFF_SUCCESS` | The worktree is clean and no meaningful diff or branch-only commits remain against the intended base. | Stops successfully without creating a no-op commit or follow-up PR. |
+| `FOLLOWUP_CREATED` | Meaningful unmerged work remains and the workflow created or updated a PR for it. | Continues through normal CI and merge readiness checks. |
+| `BLOCKED_CI` | Required checks are failing or policy blocks merge. | Fails loudly; do not reinterpret as terminal success. |
+
+Closed-unmerged PRs are failures unless the workflow proves
+`CLOSED_OBSOLETE`. A closed PR with remaining diff evidence is reported as a
+blocker, not as recovered work.
+
+Dirty worktrees also block terminal success. If `git status --porcelain` has
+any output, the workflow cannot prove whether recovery work is complete or safe
+to ignore, so it fails before accepting `MERGED`, `CLOSED_OBSOLETE`, or
+`NO_DIFF_SUCCESS`.
+
+Malformed inputs, unavailable PR metadata, missing base refs, and `gh` command
+errors fail closed. Treat them as blockers to fix in workflow context, not as
+accepted no-op recovery.
+
+## 8. Let `workflow-publish` Own Commits and Pushes
 
 If readiness remediation changes files, the workflow commits and pushes those
 changes to the existing branch. This example shows PR 579:
@@ -245,6 +310,32 @@ changes to the existing branch. This example shows PR 579:
 If no changes are required, `changes_required` and `pushed` are `false`, and the
 workflow records that no publish action was necessary.
 
+If the terminal state is already successful, publish is skipped instead of being
+reported as a no-op publish attempt:
+
+```json
+{
+  "workflow_publish": {
+    "target_pr": 579,
+    "target_branch": "fix/issues-577-578-copilot-hooks-and-additive-copy",
+    "publish_status": "MERGED",
+    "terminal_success": true,
+    "terminal_state": "MERGED",
+    "version_bump_ran": false,
+    "commit_ran": false,
+    "push_ran": false,
+    "pr_create_or_update_ran": false,
+    "ci_wait_ran": false,
+    "merge_ran": false
+  }
+}
+```
+
+Those suppression flags are part of the recovery evidence. They prove the
+workflow did not perform Git or GitHub mutation, including version bump, stage,
+commit, push, PR create/update, CI wait, merge, or duplicate/no-op follow-up PR
+creation after completion was already established.
+
 Dirty readiness documentation or evidence files are handled in one of two ways:
 
 - committed by the workflow as recovery evidence, or
@@ -252,7 +343,7 @@ Dirty readiness documentation or evidence files are handled in one of two ways:
 
 Unclassified dirty readiness files block final readiness.
 
-## 8. Use `workflow-finalize` as the Final Decision
+## 9. Use `workflow-finalize` as the Final Decision
 
 The finalization step emits the recovery decision. This example shows PR 579:
 
@@ -301,6 +392,34 @@ state:
 Do not convert that result into a manual merge. Pending Test and blocked merge
 state mean the PR remains under normal GitHub protection while being recovered
 from the workflow's point of view.
+
+Finalization re-checks terminal, dirty, diff, PR, and CI state before reporting
+completion. A terminal-success finalization looks like this:
+
+```json
+{
+  "workflow_finalize": {
+    "pr_number": 579,
+    "final_status": "finalized",
+    "terminal_success": true,
+    "terminal_state": "CLOSED_OBSOLETE",
+    "terminal_reason": "PR #579 is closed without merge evidence, but the branch is clean and equivalent changes are present on origin/main.",
+    "remaining_blockers": [],
+    "version_bump_ran": false,
+    "commit_ran": false,
+    "push_ran": false,
+    "pr_create_or_update_ran": false,
+    "ci_wait_ran": false,
+    "merge_ran": false
+  }
+}
+```
+
+If finalization observes a dirty worktree, a closed-unmerged PR without obsolete
+proof, a meaningful unmerged diff, or failing required checks, it emits a
+blocking status such as `BLOCKED_DIRTY_WORKTREE`, `BLOCKED_CLOSED_UNMERGED`,
+`BLOCKED_UNMERGED_DIFF`, or `BLOCKED_CI`. Those statuses require remediation;
+they are not successful no-op completions.
 
 Interpret the status exactly as emitted:
 

--- a/docs/howto/recover-existing-pr-with-default-workflow.md
+++ b/docs/howto/recover-existing-pr-with-default-workflow.md
@@ -260,7 +260,7 @@ finalization:
     "terminal_reason": "Worktree is clean and the branch has no meaningful diff against origin/main.",
     "publish_status": "NO_DIFF_SUCCESS",
     "should_publish": false,
-    "should_finalize": true,
+    "should_finalize": false,
     "should_run_ci_wait": false,
     "should_merge": false
   }

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -129,7 +129,8 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     // Phase 5: workflow-precommit-test (steps 12-13)
     "step-12-run-precommit",
     "step-13-local-testing",
-    // Phase 6: workflow-publish (steps 14-16b)
+    // Phase 6: workflow-publish (terminal gate + steps 14-16b)
+    "publish-terminal-state",
     "step-14-bump-version",
     "step-15-commit-push",
     "step-16-create-draft-pr",
@@ -150,7 +151,8 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "step-19b-patterns-check",
     "step-19c-zero-bs-verification",
     "step-19d-verification-gate",
-    // Phase 8: workflow-finalize (steps 20-22b + complete)
+    // Phase 8: workflow-finalize (terminal gate + steps 20-22b + complete)
+    "finalize-terminal-state",
     "step-20-final-cleanup",
     "step-20b-push-cleanup",
     "step-20c-quality-audit",

--- a/tests/integration/default_workflow_terminal_state.rs
+++ b/tests/integration/default_workflow_terminal_state.rs
@@ -5,9 +5,13 @@
 //! implementation exists.
 
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
+use serde_json::Value as JsonValue;
 use serde_yaml::Value;
+use tempfile::TempDir;
 
 fn workspace_root() -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -43,6 +47,183 @@ fn step_commands(recipe: &Value) -> String {
         .filter_map(|step| step.get("command").and_then(Value::as_str))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+struct TerminalRun {
+    success: bool,
+    stdout: String,
+    stderr: String,
+    json: JsonValue,
+}
+
+struct GitFixture {
+    _tmp: TempDir,
+    repo: PathBuf,
+}
+
+fn run_cmd(dir: &Path, program: &str, args: &[&str]) {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("run {program} {args:?} in {}: {e}", dir.display()));
+    assert!(
+        output.status.success(),
+        "command failed: {program} {args:?}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| panic!("create {}: {e}", parent.display()));
+    }
+    fs::write(path, content).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+fn setup_repo() -> GitFixture {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    fs::create_dir(&repo).expect("create repo dir");
+    run_cmd(&repo, "git", &["init", "-b", "main"]);
+    run_cmd(&repo, "git", &["config", "user.email", "test@example.com"]);
+    run_cmd(&repo, "git", &["config", "user.name", "Workflow Test"]);
+    write_file(&repo.join("README.md"), "base\n");
+    run_cmd(&repo, "git", &["add", "README.md"]);
+    run_cmd(&repo, "git", &["commit", "-m", "base"]);
+    run_cmd(
+        &repo,
+        "git",
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ],
+    );
+    GitFixture { _tmp: tmp, repo }
+}
+
+fn create_feature_worktree(fixture: &GitFixture) -> PathBuf {
+    run_cmd(&fixture.repo, "git", &["branch", "feature"]);
+    let worktree = fixture._tmp.path().join("feature-worktree");
+    run_cmd(
+        &fixture.repo,
+        "git",
+        &["worktree", "add", worktree.to_str().unwrap(), "feature"],
+    );
+    worktree
+}
+
+fn commit_feature_change(worktree: &Path) {
+    write_file(&worktree.join("feature.txt"), "feature\n");
+    run_cmd(worktree, "git", &["add", "feature.txt"]);
+    run_cmd(worktree, "git", &["commit", "-m", "feature"]);
+}
+
+fn git_head(dir: &Path) -> String {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("git rev-parse in {}: {e}", dir.display()));
+    assert!(
+        output.status.success(),
+        "git rev-parse failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("utf8 git head")
+        .trim()
+        .to_string()
+}
+
+fn fake_gh(tmp: &TempDir, body: &str, exit_code: i32) -> PathBuf {
+    let bin_dir = tmp.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("create fake gh bin");
+    let gh = bin_dir.join("gh");
+    let script = format!(
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [ {exit_code} -ne 0 ]; then
+  echo "fake gh failure" >&2
+  exit {exit_code}
+fi
+cat <<'JSON'
+{body}
+JSON
+"#
+    );
+    fs::write(&gh, script).expect("write fake gh");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&gh, fs::Permissions::from_mode(0o755)).expect("chmod fake gh");
+    }
+    bin_dir
+}
+
+fn matching_pr_json(worktree: &Path, state: &str, merged_at: &str) -> String {
+    serde_json::json!({
+        "url": "https://github.com/owner/repo/pull/7",
+        "number": 7,
+        "state": state,
+        "mergedAt": merged_at,
+        "headRefName": "feature",
+        "baseRefName": "main",
+        "headRefOid": git_head(worktree),
+        "headRepositoryOwner": { "login": "owner" },
+        "headRepository": { "name": "repo" },
+        "baseRepository": { "name": "repo", "owner": { "login": "owner" } },
+        "statusCheckRollup": []
+    })
+    .to_string()
+}
+
+fn run_terminal_state(
+    repo_path: &Path,
+    worktree_path: Option<&Path>,
+    branch_name: &str,
+    pr_url: Option<&str>,
+    fake_path: &Path,
+) -> TerminalRun {
+    let command = step_commands(&load_recipe("workflow-terminal-state"));
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{old_path}", fake_path.display());
+    let mut cmd = Command::new("bash");
+    cmd.arg("-c")
+        .arg(command)
+        .env("PATH", path)
+        .env("REPO_PATH", repo_path)
+        .env("BRANCH_NAME", branch_name)
+        .env("BASE_REF", "main")
+        .env("PR_NUMBER", "")
+        .env("PR_URL", pr_url.unwrap_or(""))
+        .env("GOAL_ALREADY_MET", "false");
+    if let Some(worktree_path) = worktree_path {
+        cmd.env("RECIPE_VAR_worktree_setup__worktree_path", worktree_path);
+    }
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("run workflow-terminal-state: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let json_line = stdout
+        .lines()
+        .rev()
+        .find(|line| line.trim_start().starts_with('{'))
+        .unwrap_or_else(|| {
+            panic!("terminal-state emitted no JSON\nstdout:\n{stdout}\nstderr:\n{stderr}")
+        });
+    let json = serde_json::from_str(json_line)
+        .unwrap_or_else(|e| panic!("parse terminal JSON `{json_line}`: {e}"));
+    TerminalRun {
+        success: output.status.success(),
+        stdout,
+        stderr,
+        json,
+    }
 }
 
 fn assert_contains_all(haystack: &str, needles: &[&str], context: &str) {
@@ -83,6 +264,7 @@ fn terminal_state_recipe_exists_with_required_io_contract() {
         .collect();
 
     for required_input in [
+        "worktree_setup.worktree_path",
         "repo_path",
         "branch_name",
         "base_ref",
@@ -256,4 +438,175 @@ fn pr_review_phase_skips_stale_review_steps_after_terminal_success() {
             "workflow-pr-review step `{id}` must be gated off for terminal_success=true"
         );
     }
+}
+
+#[test]
+fn terminal_state_uses_worktree_checkout_for_meaningful_diff() {
+    let fixture = setup_repo();
+    let worktree = create_feature_worktree(&fixture);
+    commit_feature_change(&worktree);
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, "{}", 0);
+
+    let run = run_terminal_state(&fixture.repo, Some(&worktree), "feature", None, &fake_path);
+
+    assert!(
+        run.success,
+        "meaningful diff should continue workflow, not fail\nstdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    assert_eq!(run.json["terminal_success"], "false");
+    assert_eq!(run.json["terminal_state"], "FOLLOWUP_CREATED");
+    assert_eq!(run.json["branch_diff_status"], "has-diff");
+}
+
+#[test]
+fn terminal_state_fails_when_repo_checkout_is_not_requested_branch() {
+    let fixture = setup_repo();
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, "{}", 0);
+
+    let run = run_terminal_state(&fixture.repo, None, "feature", None, &fake_path);
+
+    assert!(!run.success, "wrong checkout must fail closed");
+    assert_eq!(run.json["terminal_state"], "FAILED_WRONG_BRANCH");
+}
+
+#[test]
+fn terminal_state_fails_closed_for_dirty_target_worktree() {
+    let fixture = setup_repo();
+    let worktree = create_feature_worktree(&fixture);
+    write_file(&worktree.join("dirty.txt"), "uncommitted\n");
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, "{}", 0);
+
+    let run = run_terminal_state(&fixture.repo, Some(&worktree), "feature", None, &fake_path);
+
+    assert!(!run.success, "dirty worktree must fail closed");
+    assert_eq!(run.json["terminal_state"], "FAILED_DIRTY_WORKTREE");
+}
+
+#[test]
+fn terminal_state_rejects_stale_pr_head_sha() {
+    let fixture = setup_repo();
+    let worktree = create_feature_worktree(&fixture);
+    commit_feature_change(&worktree);
+    let mut pr: JsonValue =
+        serde_json::from_str(&matching_pr_json(&worktree, "OPEN", "")).expect("matching PR JSON");
+    pr["headRefOid"] = JsonValue::String("0000000000000000000000000000000000000000".to_string());
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, &pr.to_string(), 0);
+
+    let run = run_terminal_state(
+        &fixture.repo,
+        Some(&worktree),
+        "feature",
+        Some("https://github.com/owner/repo/pull/7"),
+        &fake_path,
+    );
+
+    assert!(!run.success, "stale PR head SHA must fail closed");
+    assert_eq!(run.json["terminal_state"], "FAILED_INVALID_INPUT");
+    assert!(
+        run.stderr.contains("stale PR metadata"),
+        "stderr should explain stale PR metadata: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn terminal_state_rejects_cross_repo_pr_url() {
+    let fixture = setup_repo();
+    let worktree = create_feature_worktree(&fixture);
+    commit_feature_change(&worktree);
+    let mut pr: JsonValue =
+        serde_json::from_str(&matching_pr_json(&worktree, "OPEN", "")).expect("matching PR JSON");
+    pr["headRepositoryOwner"]["login"] = JsonValue::String("other".to_string());
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, &pr.to_string(), 0);
+
+    let run = run_terminal_state(
+        &fixture.repo,
+        Some(&worktree),
+        "feature",
+        Some("https://github.com/other/repo/pull/7"),
+        &fake_path,
+    );
+
+    assert!(!run.success, "cross-repo PR metadata must fail closed");
+    assert_eq!(run.json["terminal_state"], "FAILED_INVALID_INPUT");
+    assert!(
+        run.stderr.contains("does not match current repo"),
+        "stderr should explain repo identity mismatch: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn terminal_state_rejects_closed_unmerged_pr_with_meaningful_diff() {
+    let fixture = setup_repo();
+    let worktree = create_feature_worktree(&fixture);
+    commit_feature_change(&worktree);
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, &matching_pr_json(&worktree, "CLOSED", ""), 0);
+
+    let run = run_terminal_state(
+        &fixture.repo,
+        Some(&worktree),
+        "feature",
+        Some("https://github.com/owner/repo/pull/7"),
+        &fake_path,
+    );
+
+    assert!(
+        !run.success,
+        "closed-unmerged PR with diff must fail closed"
+    );
+    assert_eq!(run.json["terminal_state"], "FAILED_CLOSED_UNMERGED");
+}
+
+#[test]
+fn terminal_state_fails_closed_when_required_pr_metadata_is_unavailable() {
+    let fixture = setup_repo();
+    let worktree = create_feature_worktree(&fixture);
+    commit_feature_change(&worktree);
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, "", 1);
+
+    let run = run_terminal_state(
+        &fixture.repo,
+        Some(&worktree),
+        "feature",
+        Some("https://github.com/owner/repo/pull/7"),
+        &fake_path,
+    );
+
+    assert!(
+        !run.success,
+        "explicit PR metadata failure must fail closed\nstdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    assert_eq!(run.json["terminal_state"], "FAILED_INVALID_INPUT");
+    assert!(
+        run.stderr.contains("unavailable PR metadata"),
+        "stderr should explain unavailable metadata: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn terminal_state_allows_git_only_no_diff_when_no_pr_dependency_exists() {
+    let fixture = setup_repo();
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, "", 1);
+
+    let run = run_terminal_state(&fixture.repo, None, "main", None, &fake_path);
+
+    assert!(
+        run.success,
+        "clean no-diff branch can prove terminal success without PR metadata\nstdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    assert_eq!(run.json["terminal_success"], "true");
+    assert_eq!(run.json["terminal_state"], "NO_DIFF_SUCCESS");
 }

--- a/tests/integration/default_workflow_terminal_state.rs
+++ b/tests/integration/default_workflow_terminal_state.rs
@@ -1,0 +1,259 @@
+//! tests/integration/default_workflow_terminal_state.rs
+//!
+//! TDD-red contracts for the reusable default-workflow terminal-state probe.
+//! These tests define the evidence and output vocabulary required before the
+//! implementation exists.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde_yaml::Value;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn recipe_path(name: &str) -> PathBuf {
+    workspace_root()
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join(format!("{name}.yaml"))
+}
+
+fn recipe_text(name: &str) -> String {
+    let path = recipe_path(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn load_recipe(name: &str) -> Value {
+    let path = recipe_path(name);
+    let text = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn step_commands(recipe: &Value) -> String {
+    recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("recipe must contain top-level steps")
+        .iter()
+        .filter_map(|step| step.get("command").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn assert_contains_all(haystack: &str, needles: &[&str], context: &str) {
+    for needle in needles {
+        assert!(
+            haystack.contains(needle),
+            "{context} must contain `{needle}`"
+        );
+    }
+}
+
+fn assert_ordered(haystack: &str, needles: &[&str], context: &str) {
+    let mut previous = 0;
+    for needle in needles {
+        let position = haystack[previous..]
+            .find(needle)
+            .map(|offset| previous + offset)
+            .unwrap_or_else(|| panic!("{context} must contain `{needle}` in order"));
+        assert!(
+            position >= previous,
+            "{context} must place `{needle}` after earlier terminal checks"
+        );
+        previous = position;
+    }
+}
+
+#[test]
+fn terminal_state_recipe_exists_with_required_io_contract() {
+    let recipe = load_recipe("workflow-terminal-state");
+    let text = recipe_text("workflow-terminal-state");
+
+    let input_names: Vec<_> = recipe
+        .get("inputs")
+        .and_then(Value::as_sequence)
+        .expect("terminal-state recipe must declare inputs")
+        .iter()
+        .filter_map(|input| input.get("name").and_then(Value::as_str))
+        .collect();
+
+    for required_input in [
+        "repo_path",
+        "branch_name",
+        "base_ref",
+        "pr_number",
+        "pr_url",
+        "goal_already_met",
+    ] {
+        assert!(
+            input_names.contains(&required_input),
+            "workflow-terminal-state must declare input `{required_input}`"
+        );
+    }
+
+    assert_contains_all(
+        &text,
+        &[
+            "terminal_success",
+            "terminal_state",
+            "terminal_reason",
+            "publish_status",
+            "should_publish",
+            "should_finalize",
+            "should_run_ci_wait",
+            "should_merge",
+        ],
+        "terminal-state recipe output contract",
+    );
+}
+
+#[test]
+fn terminal_state_probe_detects_outcomes_in_safe_fail_closed_order() {
+    let recipe = load_recipe("workflow-terminal-state");
+    let command = step_commands(&recipe);
+
+    assert_ordered(
+        &command,
+        &[
+            "git status --porcelain",
+            "FAILED_DIRTY_WORKTREE",
+            "mergedAt",
+            "MERGED",
+            "closed-unmerged",
+            "CLOSED_OBSOLETE",
+            "git diff --quiet",
+            "NO_DIFF_SUCCESS",
+            "FOLLOWUP_CREATED",
+        ],
+        "terminal-state detection order",
+    );
+
+    assert_contains_all(
+        &command,
+        &[
+            "BLOCKED_CI",
+            "FAILED_CLOSED_UNMERGED",
+            "FAILED_MEANINGFUL_DIFF",
+            "ambiguous",
+            "exit 1",
+        ],
+        "terminal-state fail-closed semantics",
+    );
+}
+
+#[test]
+fn terminal_state_probe_validates_inputs_before_git_or_github_trust() {
+    let recipe = load_recipe("workflow-terminal-state");
+    let command = step_commands(&recipe);
+
+    assert_contains_all(
+        &command,
+        &[
+            "git rev-parse --is-inside-work-tree",
+            "git check-ref-format --branch",
+            "base_ref",
+            "pr_number",
+            "pr_url",
+            "^[0-9][0-9]*$",
+            "headRefName",
+            "baseRefName",
+            "headRefOid",
+            "mergedAt",
+        ],
+        "terminal-state input validation",
+    );
+
+    let dirty_position = command
+        .find("git status --porcelain")
+        .expect("dirty worktree check must exist");
+    for trusted_probe in ["gh_with_retry \"pr view\"", "git diff --quiet"] {
+        let probe_position = command
+            .find(trusted_probe)
+            .unwrap_or_else(|| panic!("trusted probe `{trusted_probe}` must exist"));
+        assert!(
+            dirty_position < probe_position,
+            "dirty worktree must be checked before `{trusted_probe}` can produce terminal success"
+        );
+    }
+}
+
+#[test]
+fn terminal_state_probe_wraps_github_metadata_calls_with_bounded_retry() {
+    let recipe = load_recipe("workflow-terminal-state");
+    let command = step_commands(&recipe);
+
+    assert_contains_all(
+        &command,
+        &[
+            "sanitize_gh_stderr",
+            "is_transient_gh_error",
+            "gh_with_retry",
+            "timeout 60 gh",
+            "for attempt in 1 2 3",
+            "retrying (${attempt}/3)",
+            "gh_with_retry \"pr view\"",
+            "gh_with_retry \"pr list\"",
+            "unavailable PR metadata",
+        ],
+        "terminal-state GitHub adapter resilience",
+    );
+
+    assert!(
+        !command.contains("gh pr view \"$pr_target\"")
+            && !command.contains("gh pr list --head \"$BRANCH_INPUT\""),
+        "terminal-state must not call gh metadata endpoints directly without retry/error handling"
+    );
+}
+
+#[test]
+fn default_workflow_propagates_terminal_state_context_between_phase_recipes() {
+    let recipe = load_recipe("default-workflow");
+    let context = recipe
+        .get("context")
+        .and_then(Value::as_mapping)
+        .expect("default-workflow must declare a context mapping");
+
+    for required_key in [
+        "terminal_success",
+        "terminal_state",
+        "terminal_reason",
+        "publish_status",
+        "should_publish",
+        "should_finalize",
+        "should_run_ci_wait",
+        "should_merge",
+    ] {
+        assert!(
+            context.contains_key(Value::String(required_key.to_string())),
+            "default-workflow context must propagate `{required_key}`"
+        );
+    }
+}
+
+#[test]
+fn pr_review_phase_skips_stale_review_steps_after_terminal_success() {
+    let recipe = load_recipe("workflow-pr-review");
+    let steps = recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("workflow-pr-review must contain top-level steps");
+
+    for step in steps {
+        let id = step
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("workflow-pr-review steps must have ids");
+        let condition = step.get("condition").and_then(Value::as_str).unwrap_or("");
+        assert!(
+            condition.contains("terminal_success != 'true'")
+                || condition.contains("terminal_state.terminal_success != 'true'")
+                || condition.contains("should_finalize == 'true'"),
+            "workflow-pr-review step `{id}` must be gated off for terminal_success=true"
+        );
+    }
+}

--- a/tests/integration/workflow_finalize_resilience.rs
+++ b/tests/integration/workflow_finalize_resilience.rs
@@ -25,6 +25,14 @@ fn load_finalize_recipe() -> Value {
     serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 }
 
+fn helper_text(name: &str) -> String {
+    let path = workspace_root()
+        .join("amplifier-bundle")
+        .join("tools")
+        .join(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
 fn step_command(recipe: &Value, id: &str) -> String {
     recipe
         .get("steps")
@@ -77,6 +85,49 @@ fn final_status_accepts_no_diff_and_already_merged_as_successful_terminal_outcom
         assert!(
             command.contains(required),
             "final status must report idempotent successful terminal outcomes; missing `{required}`"
+        );
+    }
+}
+
+#[test]
+fn final_status_uses_resilient_github_status_lookup() {
+    let command = helper_text("workflow_final_status.sh");
+
+    for required in [
+        "sanitize_gh_stderr",
+        "is_transient_gh_error",
+        "gh_pr_view_with_retry",
+        "timeout 60 gh pr view",
+        "for attempt in 1 2 3",
+        "retrying (${attempt}/3)",
+        "final PR status lookup failed",
+    ] {
+        assert!(
+            command.contains(required),
+            "final status must use bounded, visible GitHub status lookup resilience; missing `{required}`"
+        );
+    }
+}
+
+#[test]
+fn pr_ready_helper_retries_github_lookup_ready_and_comment_calls() {
+    let command = helper_text("workflow_pr_ready.sh");
+
+    for required in [
+        "sanitize_gh_stderr",
+        "is_transient_gh_error",
+        "gh_with_retry",
+        "timeout 60 gh",
+        "for attempt in 1 2 3",
+        "retrying (${attempt}/3)",
+        "gh_with_retry \"pr list\"",
+        "gh_with_retry \"pr view\"",
+        "gh_with_retry \"pr ready\"",
+        "gh_with_retry \"pr comment\"",
+    ] {
+        assert!(
+            command.contains(required),
+            "PR-ready helper must use bounded GitHub retries; missing `{required}`"
         );
     }
 }

--- a/tests/integration/workflow_finalize_terminal_state.rs
+++ b/tests/integration/workflow_finalize_terminal_state.rs
@@ -1,0 +1,151 @@
+//! tests/integration/workflow_finalize_terminal_state.rs
+//!
+//! TDD-red contracts for finalization as the loud terminal-state arbiter.
+//! Terminal success may complete the workflow, but dirty work, CI failures,
+//! closed-unmerged PRs, and meaningful unmerged diffs must remain blockers.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde_yaml::Value;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn load_finalize_recipe() -> Value {
+    let path = workspace_root()
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join("workflow-finalize.yaml");
+    let text = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn steps(recipe: &Value) -> &[Value] {
+    recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("workflow-finalize must contain top-level steps")
+}
+
+fn step_index(recipe: &Value, id: &str) -> usize {
+    steps(recipe)
+        .iter()
+        .position(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .unwrap_or_else(|| panic!("workflow-finalize missing step `{id}`"))
+}
+
+fn find_terminal_probe_index(recipe: &Value) -> usize {
+    steps(recipe)
+        .iter()
+        .position(|step| step.get("recipe").and_then(Value::as_str) == Some("workflow-terminal-state"))
+        .expect("workflow-finalize must re-run workflow-terminal-state before mutation, CI, or merge steps")
+}
+
+fn step_condition<'a>(recipe: &'a Value, id: &str) -> &'a str {
+    steps(recipe)
+        .iter()
+        .find(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .and_then(|step| step.get("condition").and_then(Value::as_str))
+        .unwrap_or_else(|| panic!("workflow-finalize step `{id}` must declare a condition"))
+}
+
+fn step_command(recipe: &Value, id: &str) -> String {
+    steps(recipe)
+        .iter()
+        .find(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .and_then(|step| step.get("command").and_then(Value::as_str))
+        .unwrap_or_else(|| panic!("workflow-finalize step `{id}` must be a bash command step"))
+        .to_owned()
+}
+
+fn recipe_text(recipe: &Value) -> String {
+    serde_yaml::to_string(recipe).expect("serialize workflow-finalize")
+}
+
+#[test]
+fn finalize_rechecks_terminal_state_before_mutation_ci_or_merge_steps() {
+    let recipe = load_finalize_recipe();
+    let terminal_probe_index = find_terminal_probe_index(&recipe);
+
+    for guarded_step in [
+        "step-20b-push-cleanup",
+        "step-21-pr-ready",
+        "step-22-ensure-mergeable",
+    ] {
+        let guarded_index = step_index(&recipe, guarded_step);
+        assert!(
+            terminal_probe_index < guarded_index,
+            "workflow-finalize must re-check terminal state before `{guarded_step}`"
+        );
+    }
+}
+
+#[test]
+fn finalize_mutation_and_ci_steps_are_suppressed_for_terminal_success() {
+    let recipe = load_finalize_recipe();
+
+    for guarded_step in [
+        "step-20b-push-cleanup",
+        "step-21-pr-ready",
+        "step-22-ensure-mergeable",
+    ] {
+        let condition = step_condition(&recipe, guarded_step);
+        assert!(
+            condition.contains("terminal_success != 'true'")
+                || condition.contains("terminal_state.terminal_success != 'true'")
+                || condition.contains("should_finalize == 'true'")
+                || condition.contains("should_run_ci_wait == 'true'"),
+            "`{guarded_step}` must be skipped when terminal_success=true; condition was `{condition}`"
+        );
+    }
+}
+
+#[test]
+fn finalize_preserves_loud_blockers_instead_of_converting_them_to_success() {
+    let recipe = load_finalize_recipe();
+    let text = recipe_text(&recipe);
+
+    for blocker in [
+        "FAILED_DIRTY_WORKTREE",
+        "FAILED_CLOSED_UNMERGED",
+        "FAILED_MEANINGFUL_DIFF",
+        "BLOCKED_CI",
+        "exit 1",
+    ] {
+        assert!(
+            text.contains(blocker),
+            "workflow-finalize must preserve loud blocker `{blocker}`"
+        );
+    }
+}
+
+#[test]
+fn final_status_reports_terminal_success_and_blocked_semantics_structurally() {
+    let recipe = load_finalize_recipe();
+    let command = step_command(&recipe, "workflow-complete");
+
+    for required in [
+        "terminal_state",
+        "terminal_success",
+        "MERGED",
+        "CLOSED_OBSOLETE",
+        "NO_DIFF_SUCCESS",
+        "FOLLOWUP_CREATED",
+        "BLOCKED_CI",
+    ] {
+        assert!(
+            command.contains(required),
+            "workflow-complete JSON must expose `{required}`"
+        );
+    }
+
+    assert!(
+        !command.contains("status: \"complete\"") || command.contains("terminal_success"),
+        "workflow-complete must not unconditionally report complete without terminal_success evidence"
+    );
+}

--- a/tests/integration/workflow_publish_resilience.rs
+++ b/tests/integration/workflow_publish_resilience.rs
@@ -149,6 +149,35 @@ fn publish_retries_all_github_pr_metadata_and_mutation_calls() {
 }
 
 #[test]
+fn publish_helper_discovers_prs_with_exact_identity_validation() {
+    let command = helper_text("workflow_publish_pr.sh");
+
+    for required in [
+        "--head \"$CURRENT_BRANCH\"",
+        "baseRefName",
+        "headRefName",
+        "headRefOid",
+        "headRepositoryOwner",
+        "headRepository",
+        "baseRepository",
+        "validate_pr_identity",
+        "parse_github_repo_identity",
+        "does not match current repo",
+    ] {
+        assert!(
+            command.contains(required),
+            "publish helper must validate exact PR identity before trusting an existing PR; missing `{required}`"
+        );
+    }
+
+    assert!(
+        !command.contains("test(\"issue-$ISSUE_NUM\")")
+            && !command.contains("test(\\\"issue-$ISSUE_NUM"),
+        "publish helper must not use broad issue-number PR fallback matching"
+    );
+}
+
+#[test]
 fn publish_treats_non_github_hosts_as_structured_successful_skip() {
     let recipe = load_publish_recipe();
     let command = step_command(&recipe, "step-16-create-draft-pr");

--- a/tests/integration/workflow_publish_resilience.rs
+++ b/tests/integration/workflow_publish_resilience.rs
@@ -25,6 +25,14 @@ fn load_publish_recipe() -> Value {
     serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 }
 
+fn helper_text(name: &str) -> String {
+    let path = workspace_root()
+        .join("amplifier-bundle")
+        .join("tools")
+        .join(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
 fn step<'a>(recipe: &'a Value, id: &str) -> &'a Value {
     recipe
         .get("steps")
@@ -110,6 +118,34 @@ fn publish_never_invokes_create_for_no_diff_or_existing_pr_states() {
             "terminal state `{terminal}` must return before PR creation"
         );
     }
+}
+
+#[test]
+fn publish_retries_all_github_pr_metadata_and_mutation_calls() {
+    let command = helper_text("workflow_publish_pr.sh");
+
+    for required in [
+        "sanitize_gh_stderr",
+        "is_transient_gh_error",
+        "gh_pr_list_with_retry",
+        "gh_pr_view_with_retry",
+        "gh_pr_create_with_retry",
+        "timeout 60 gh pr list",
+        "timeout 60 gh pr view",
+        "timeout 60 gh pr create",
+        "retrying (${attempt}/3)",
+        "refusing to risk duplicate PR creation",
+    ] {
+        assert!(
+            command.contains(required),
+            "publish helper contract must include resilient GitHub call handling; missing `{required}`"
+        );
+    }
+
+    assert!(
+        !command.contains("VIEW_JSON=\"$(gh pr view"),
+        "publish helper must not inspect existing PRs with a raw gh pr view call"
+    );
 }
 
 #[test]

--- a/tests/integration/workflow_publish_terminal_gate.rs
+++ b/tests/integration/workflow_publish_terminal_gate.rs
@@ -1,0 +1,138 @@
+//! tests/integration/workflow_publish_terminal_gate.rs
+//!
+//! TDD-red contracts for suppressing publish mutations after proven terminal
+//! success states such as MERGED, CLOSED_OBSOLETE, and NO_DIFF_SUCCESS.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde_yaml::Value;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn load_publish_recipe() -> Value {
+    let path = workspace_root()
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join("workflow-publish.yaml");
+    let text = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn steps(recipe: &Value) -> &[Value] {
+    recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("workflow-publish must contain top-level steps")
+}
+
+fn step_index(recipe: &Value, id: &str) -> usize {
+    steps(recipe)
+        .iter()
+        .position(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .unwrap_or_else(|| panic!("workflow-publish missing step `{id}`"))
+}
+
+fn find_terminal_probe_index(recipe: &Value) -> usize {
+    steps(recipe)
+        .iter()
+        .position(|step| {
+            step.get("recipe").and_then(Value::as_str) == Some("workflow-terminal-state")
+        })
+        .expect("workflow-publish must invoke workflow-terminal-state before mutation steps")
+}
+
+fn step_condition<'a>(recipe: &'a Value, id: &str) -> &'a str {
+    steps(recipe)
+        .iter()
+        .find(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .and_then(|step| step.get("condition").and_then(Value::as_str))
+        .unwrap_or_else(|| panic!("workflow-publish step `{id}` must declare a condition"))
+}
+
+fn recipe_text(recipe: &Value) -> String {
+    serde_yaml::to_string(recipe).expect("serialize workflow-publish")
+}
+
+#[test]
+fn publish_runs_terminal_state_probe_before_any_mutation_or_publish_step() {
+    let recipe = load_publish_recipe();
+    let terminal_probe_index = find_terminal_probe_index(&recipe);
+
+    for mutation_step in [
+        "step-14-bump-version",
+        "step-15-commit-push",
+        "step-16-create-draft-pr",
+        "step-16b-outside-in-fix-loop",
+    ] {
+        let mutation_index = step_index(&recipe, mutation_step);
+        assert!(
+            terminal_probe_index < mutation_index,
+            "workflow-terminal-state must run before `{mutation_step}`"
+        );
+    }
+}
+
+#[test]
+fn publish_mutation_steps_are_suppressed_when_terminal_success_is_true() {
+    let recipe = load_publish_recipe();
+
+    for mutation_step in [
+        "step-14-bump-version",
+        "step-15-commit-push",
+        "step-16-create-draft-pr",
+        "step-16b-outside-in-fix-loop",
+    ] {
+        let condition = step_condition(&recipe, mutation_step);
+        assert!(
+            condition.contains("terminal_success != 'true'")
+                || condition.contains("terminal_state.terminal_success != 'true'")
+                || condition.contains("should_publish == 'true'")
+                || condition.contains("terminal_state.should_publish == 'true'"),
+            "`{mutation_step}` must skip version/commit/push/PR work when terminal_success=true; condition was `{condition}`"
+        );
+    }
+}
+
+#[test]
+fn publish_uses_required_terminal_and_followup_status_vocabulary() {
+    let recipe = load_publish_recipe();
+    let text = recipe_text(&recipe);
+
+    for status in [
+        "MERGED",
+        "CLOSED_OBSOLETE",
+        "NO_DIFF_SUCCESS",
+        "FOLLOWUP_CREATED",
+        "BLOCKED_CI",
+    ] {
+        assert!(
+            text.contains(status),
+            "workflow-publish must preserve required status `{status}`"
+        );
+    }
+}
+
+#[test]
+fn publish_terminal_success_does_not_wait_for_ci_or_attempt_merge() {
+    let recipe = load_publish_recipe();
+    let text = recipe_text(&recipe);
+
+    assert!(
+        text.contains("should_run_ci_wait") && text.contains("should_merge"),
+        "publish must carry terminal-state outputs that suppress CI wait and merge"
+    );
+    assert!(
+        !text.contains("gh pr merge") || text.contains("should_merge == 'true'"),
+        "publish must not attempt PR merge without an explicit should_merge=true gate"
+    );
+    assert!(
+        !text.contains("ci-diagnostic-workflow") || text.contains("should_run_ci_wait == 'true'"),
+        "publish must not wait on CI without an explicit should_run_ci_wait=true gate"
+    );
+}


### PR DESCRIPTION
## Summary
- Hardened default-workflow terminal-state detection for merged, closed-after-merge, no-diff, and obsolete branch outcomes.
- Added early publish/finalize gates so successful terminal states stop before version bump, commit, push, PR creation, CI wait, or merge.
- Preserved loud failures for dirty worktrees, closed-unmerged PRs with remaining diffs, unavailable/ambiguous PR metadata, and CI blockers.

## Tests
- `cargo test --test default_workflow_terminal_state --test workflow_publish_terminal_gate --test workflow_finalize_terminal_state --locked`
- `cargo test --workspace --locked`

## Step 13: Local Testing Results

### Scenario 1 — No-diff branch skips publish mutations
Command: `AMPLIHACK_HOME=<branch-clone> uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-731-implement-the-highest-priority-follow-up-harden-de amplihack recipe run -f json -w <fixture-repo> -c repo_path=<fixture-repo> -c worktree_setup.worktree_path=<fixture-repo> -c branch_name=main -c base_ref=main -c remote_host_type=other -c goal_already_met=false -c task_description='outside-in no diff terminal state' -c issue_number=731 <branch-clone>/amplifier-bundle/recipes/workflow-publish.yaml`
Result: PASS
Output:
```text
"recipe_name": "workflow-publish"
"success": true
"publish-terminal-state": "completed"
"step-14-bump-version": "skipped"
"step-15-commit-push": "skipped"
"step-16-create-draft-pr": "skipped"
SCENARIO1_PASS publish-terminal-state=completed step14=skipped step15=skipped step16=skipped
```

### Scenario 2 — Closed-unmerged obsolete PR returns terminal success
Command: `PATH=<fake-gh-bin>:[existing PATH] AMPLIHACK_HOME=<branch-clone> uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-731-implement-the-highest-priority-follow-up-harden-de amplihack recipe run -f json -w <fixture-repo> -c repo_path=<fixture-repo> -c worktree_setup.worktree_path=<fixture-repo> -c branch_name=feature -c base_ref=main -c pr_url=https://github.com/owner/repo/pull/7 -c remote_host_type=github -c goal_already_met=false <branch-clone>/amplifier-bundle/recipes/workflow-terminal-state.yaml`
Result: PASS
Output:
```text
"recipe_name": "workflow-terminal-state"
"success": true
"terminal_state":"CLOSED_OBSOLETE"
"terminal_success":"true"
"should_publish":"false"
"should_run_ci_wait":"false"
"should_merge":"false"
SCENARIO2_PASS terminal_state=CLOSED_OBSOLETE terminal_success=true should_publish=false should_run_ci_wait=false should_merge=false
```
