### PR TITLE
Fix stale smart-orchestrator bundle repair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplihack"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-memory",
  "async-trait",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-eval"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "serde",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-generator"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-asset-resolver-bin"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-cli",
  "tracing",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-blarify"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-builders"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-builders",
  "amplihack-hive",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-context"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-delegation"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "globset",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-domain-agents"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-fleet"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hive"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-cli",
  "amplihack-security",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-launcher"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-utils",
  "anyhow",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-memory"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-multilspy"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-orchestration"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-utils",
  "async-trait",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recovery"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-reflection"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-remote"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-safety"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-security"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "once_cell",
  "regex",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-session"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "filetime",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-utils"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "base64",
  "chrono",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-workflows"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "amplihack-utils",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/crates/amplihack-cli/src/commands/install/bundle_compat.rs
+++ b/crates/amplihack-cli/src/commands/install/bundle_compat.rs
@@ -10,14 +10,6 @@ pub(super) const REQUIRED_SMART_RECIPES: &[&str] = &[
     "smart-validate-summarize",
 ];
 
-const REQUIRED_MANIFEST_RECIPES: &[&str] = &[
-    "smart-orchestrator",
-    "smart-classify-route",
-    "smart-execute-routing",
-    "smart-reflect-loop",
-    "smart-validate-summarize",
-];
-
 const STALE_SMART_ORCHESTRATOR_MARKERS: &[&str] = &[
     "resolve-bundle-asset helper-path",
     "importlib",
@@ -229,17 +221,19 @@ fn validate_recipe_manifest(recipes: &Path) -> Result<(), BundleCompatibilityErr
     let Some(object) = manifest.as_object() else {
         return Err(BundleCompatibilityError::NonObjectManifest(path));
     };
-    for recipe in REQUIRED_MANIFEST_RECIPES {
-        let Some(value) = object.get(*recipe) else {
+    for recipe in
+        std::iter::once("smart-orchestrator").chain(REQUIRED_SMART_RECIPES.iter().copied())
+    {
+        let Some(value) = object.get(recipe) else {
             return Err(BundleCompatibilityError::MissingManifestEntry {
                 path: path.clone(),
-                recipe: (*recipe).to_string(),
+                recipe: recipe.to_string(),
             });
         };
         if !matches!(value, serde_json::Value::String(hash) if !hash.trim().is_empty()) {
             return Err(BundleCompatibilityError::InvalidManifestEntry {
                 path: path.clone(),
-                recipe: (*recipe).to_string(),
+                recipe: recipe.to_string(),
             });
         }
     }
@@ -252,18 +246,11 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
-    const REQUIRED_SUB_RECIPES: &[&str] = &[
-        "smart-classify-route",
-        "smart-execute-routing",
-        "smart-reflect-loop",
-        "smart-validate-summarize",
-    ];
-
     fn write_compatible_bundle(bundle: &Path) {
         let recipes = bundle.join("recipes");
         fs::create_dir_all(&recipes).unwrap();
         fs::write(recipes.join("smart-orchestrator.yaml"), compatible_smart()).unwrap();
-        for recipe in REQUIRED_SUB_RECIPES {
+        for recipe in REQUIRED_SMART_RECIPES {
             fs::write(
                 recipes.join(format!("{recipe}.yaml")),
                 format!("name: \"{recipe}\"\nsteps: []\n"),

--- a/crates/amplihack-cli/src/commands/install/bundle_compat.rs
+++ b/crates/amplihack-cli/src/commands/install/bundle_compat.rs
@@ -52,6 +52,14 @@ pub(super) enum BundleCompatibilityError {
         "framework bundle compatibility check failed: smart-orchestrator at {path} does not reference required sub-recipe {recipe}"
     )]
     MissingSmartRecipeReference { path: PathBuf, recipe: String },
+    #[error(
+        "framework bundle compatibility check failed: companion recipe {recipe} at {path} is invalid: {reason}"
+    )]
+    InvalidCompanionRecipe {
+        recipe: String,
+        path: PathBuf,
+        reason: String,
+    },
     #[error("framework bundle compatibility check failed: missing recipe manifest at {0}")]
     MissingManifest(PathBuf),
     #[error(
@@ -102,7 +110,8 @@ pub(super) fn validate_framework_bundle_compatibility(
     for &recipe in REQUIRED_SMART_RECIPES {
         let companion_path = require_recipe_file(&recipes, recipe)?;
         let companion = read_file(&companion_path)?;
-        parse_yaml(&companion_path, &companion)?;
+        let companion_yaml = parse_yaml(&companion_path, &companion)?;
+        validate_companion_recipe_contract(&companion_path, recipe, &companion_yaml)?;
         if !smart_recipe_refs.contains(recipe) {
             return Err(BundleCompatibilityError::MissingSmartRecipeReference {
                 path: smart_path.clone(),
@@ -233,6 +242,68 @@ fn top_level_recipe_steps(value: &Value) -> BTreeSet<&str> {
     references
 }
 
+fn validate_companion_recipe_contract(
+    path: &Path,
+    recipe: &str,
+    value: &Value,
+) -> Result<(), BundleCompatibilityError> {
+    let Value::Mapping(mapping) = value else {
+        return Err(invalid_companion_recipe(
+            path,
+            recipe,
+            "recipe YAML root must be a mapping",
+        ));
+    };
+    match mapping_string(mapping, "name") {
+        Some(name) if name == recipe => {}
+        Some(name) => {
+            return Err(invalid_companion_recipe(
+                path,
+                recipe,
+                format!("name is {name:?}, expected {recipe:?}"),
+            ));
+        }
+        None => {
+            return Err(invalid_companion_recipe(
+                path,
+                recipe,
+                "missing required name field",
+            ));
+        }
+    }
+
+    match mapping.get(Value::String("steps".to_string())) {
+        Some(Value::Sequence(steps)) if !steps.is_empty() => Ok(()),
+        Some(Value::Sequence(_)) => Err(invalid_companion_recipe(
+            path,
+            recipe,
+            "steps must contain at least one step",
+        )),
+        Some(_) => Err(invalid_companion_recipe(
+            path,
+            recipe,
+            "steps must be a sequence",
+        )),
+        None => Err(invalid_companion_recipe(
+            path,
+            recipe,
+            "missing required steps field",
+        )),
+    }
+}
+
+fn invalid_companion_recipe(
+    path: &Path,
+    recipe: &str,
+    reason: impl Into<String>,
+) -> BundleCompatibilityError {
+    BundleCompatibilityError::InvalidCompanionRecipe {
+        recipe: recipe.to_string(),
+        path: path.to_path_buf(),
+        reason: reason.into(),
+    }
+}
+
 fn mapping_value<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
     let Value::Mapping(mapping) = value else {
         return None;
@@ -308,7 +379,7 @@ mod tests {
         for recipe in REQUIRED_SMART_RECIPES {
             fs::write(
                 recipes.join(format!("{recipe}.yaml")),
-                format!("name: \"{recipe}\"\nsteps: []\n"),
+                format!("name: \"{recipe}\"\nsteps:\n  - id: smoke\n    type: bash\n    command: 'true'\n"),
             )
             .unwrap();
         }
@@ -418,6 +489,46 @@ steps:
         assert!(
             msg.contains("smart-reflect-loop") && msg.contains("recipe"),
             "error must name the missing companion recipe, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_required_companion_recipe_steps() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/smart-classify-route.yaml"),
+            "name: \"smart-classify-route\"\nsteps: []\n",
+        )
+        .unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("empty companion recipe must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("smart-classify-route") && msg.contains("steps"),
+            "error must name empty companion recipe steps, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_required_companion_recipe_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/smart-execute-routing.yaml"),
+            "name: \"wrong-recipe\"\nsteps:\n  - id: smoke\n    type: bash\n    command: 'true'\n",
+        )
+        .unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("wrong-name companion recipe must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("smart-execute-routing") && msg.contains("wrong-recipe"),
+            "error must name wrong companion recipe name, got: {msg}"
         );
     }
 

--- a/crates/amplihack-cli/src/commands/install/bundle_compat.rs
+++ b/crates/amplihack-cli/src/commands/install/bundle_compat.rs
@@ -1,4 +1,5 @@
 use serde_yaml::Value;
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -93,15 +94,16 @@ pub(super) fn validate_framework_bundle_compatibility(
     let smart = read_file(&smart_path)?;
     reject_stale_smart_orchestrator(&smart_path, &smart)?;
     let smart_yaml = parse_yaml(&smart_path, &smart)?;
+    let smart_recipe_refs = recipe_references(&smart_yaml);
 
-    for recipe in REQUIRED_SMART_RECIPES {
+    for &recipe in REQUIRED_SMART_RECIPES {
         let companion_path = require_recipe_file(&recipes, recipe)?;
         let companion = read_file(&companion_path)?;
         parse_yaml(&companion_path, &companion)?;
-        if !contains_recipe_reference(&smart_yaml, recipe) {
+        if !smart_recipe_refs.contains(recipe) {
             return Err(BundleCompatibilityError::MissingSmartRecipeReference {
                 path: smart_path.clone(),
-                recipe: (*recipe).to_string(),
+                recipe: recipe.to_string(),
             });
         }
     }
@@ -189,17 +191,30 @@ fn reject_stale_smart_orchestrator(path: &Path, raw: &str) -> Result<(), BundleC
     Ok(())
 }
 
-fn contains_recipe_reference(value: &Value, expected: &str) -> bool {
+fn recipe_references(value: &Value) -> HashSet<&str> {
+    let mut references = HashSet::new();
+    collect_recipe_references(value, &mut references);
+    references
+}
+
+fn collect_recipe_references<'a>(value: &'a Value, references: &mut HashSet<&'a str>) {
     match value {
-        Value::Mapping(mapping) => mapping.iter().any(|(key, value)| {
-            (matches!(key, Value::String(k) if k == "recipe")
-                && matches!(value, Value::String(v) if v == expected))
-                || contains_recipe_reference(value, expected)
-        }),
-        Value::Sequence(items) => items
-            .iter()
-            .any(|item| contains_recipe_reference(item, expected)),
-        _ => false,
+        Value::Mapping(mapping) => {
+            for (key, value) in mapping {
+                if matches!(key, Value::String(k) if k == "recipe")
+                    && let Value::String(recipe) = value
+                {
+                    references.insert(recipe.as_str());
+                }
+                collect_recipe_references(value, references);
+            }
+        }
+        Value::Sequence(items) => {
+            for item in items {
+                collect_recipe_references(item, references);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/amplihack-cli/src/commands/install/bundle_compat.rs
+++ b/crates/amplihack-cli/src/commands/install/bundle_compat.rs
@@ -1,0 +1,430 @@
+use serde_yaml::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+pub(super) const REQUIRED_SMART_RECIPES: &[&str] = &[
+    "smart-classify-route",
+    "smart-execute-routing",
+    "smart-reflect-loop",
+    "smart-validate-summarize",
+];
+
+const REQUIRED_MANIFEST_RECIPES: &[&str] = &[
+    "smart-orchestrator",
+    "smart-classify-route",
+    "smart-execute-routing",
+    "smart-reflect-loop",
+    "smart-validate-summarize",
+];
+
+const STALE_SMART_ORCHESTRATOR_MARKERS: &[&str] = &[
+    "resolve-bundle-asset helper-path",
+    "importlib",
+    "parse-decomposition",
+];
+
+#[derive(Debug, Error)]
+pub(super) enum BundleCompatibilityError {
+    #[error(
+        "framework bundle compatibility check failed: no amplifier-bundle recipes directory found under {0}"
+    )]
+    MissingBundle(PathBuf),
+    #[error("framework bundle compatibility check failed: {0} is a symlink")]
+    SymlinkedPath(PathBuf),
+    #[error(
+        "framework bundle compatibility check failed: missing required recipe {recipe} at {path}"
+    )]
+    MissingRecipe { recipe: String, path: PathBuf },
+    #[error("framework bundle compatibility check failed: failed to read {path}: {source}")]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("framework bundle compatibility check failed: invalid YAML in {path}: {source}")]
+    InvalidYaml {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error(
+        "framework bundle compatibility check failed: smart-orchestrator at {path} is stale or incompatible ({marker})"
+    )]
+    StaleSmartOrchestrator { path: PathBuf, marker: String },
+    #[error(
+        "framework bundle compatibility check failed: smart-orchestrator at {path} does not reference required sub-recipe {recipe}"
+    )]
+    MissingSmartRecipeReference { path: PathBuf, recipe: String },
+    #[error("framework bundle compatibility check failed: missing recipe manifest at {0}")]
+    MissingManifest(PathBuf),
+    #[error(
+        "framework bundle compatibility check failed: failed to read recipe manifest {path}: {source}"
+    )]
+    ReadManifest {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error(
+        "framework bundle compatibility check failed: invalid recipe manifest JSON in {path}: {source}"
+    )]
+    InvalidManifest {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error(
+        "framework bundle compatibility check failed: recipe manifest {0} is not a JSON object"
+    )]
+    NonObjectManifest(PathBuf),
+    #[error(
+        "framework bundle compatibility check failed: recipe manifest {path} is missing required entry {recipe}"
+    )]
+    MissingManifestEntry { path: PathBuf, recipe: String },
+    #[error(
+        "framework bundle compatibility check failed: recipe manifest {path} has an invalid hash entry for {recipe}"
+    )]
+    InvalidManifestEntry { path: PathBuf, recipe: String },
+}
+
+pub(super) fn validate_framework_bundle_compatibility(
+    root_or_bundle: &Path,
+) -> Result<(), BundleCompatibilityError> {
+    let bundle = resolve_bundle_root(root_or_bundle)?;
+    reject_symlink(&bundle)?;
+    let recipes = bundle.join("recipes");
+    reject_symlink(&recipes)?;
+
+    let smart_path = recipes.join("smart-orchestrator.yaml");
+    require_recipe_file(&recipes, "smart-orchestrator")?;
+    let smart = read_file(&smart_path)?;
+    reject_stale_smart_orchestrator(&smart_path, &smart)?;
+    let smart_yaml = parse_yaml(&smart_path, &smart)?;
+
+    for recipe in REQUIRED_SMART_RECIPES {
+        let companion_path = require_recipe_file(&recipes, recipe)?;
+        let companion = read_file(&companion_path)?;
+        parse_yaml(&companion_path, &companion)?;
+        if !contains_recipe_reference(&smart_yaml, recipe) {
+            return Err(BundleCompatibilityError::MissingSmartRecipeReference {
+                path: smart_path.clone(),
+                recipe: (*recipe).to_string(),
+            });
+        }
+    }
+
+    validate_recipe_manifest(&recipes)?;
+    Ok(())
+}
+
+pub(super) fn validate_staged_framework_bundle(
+    bundle: &Path,
+) -> Result<(), BundleCompatibilityError> {
+    validate_framework_bundle_compatibility(bundle)
+}
+
+pub(super) fn is_compatible_framework_bundle(root_or_bundle: &Path) -> bool {
+    validate_framework_bundle_compatibility(root_or_bundle).is_ok()
+}
+
+fn resolve_bundle_root(root_or_bundle: &Path) -> Result<PathBuf, BundleCompatibilityError> {
+    if root_or_bundle.join("recipes").is_dir() {
+        return Ok(root_or_bundle.to_path_buf());
+    }
+
+    let nested = root_or_bundle.join("amplifier-bundle");
+    if nested.join("recipes").is_dir() {
+        return Ok(nested);
+    }
+
+    Err(BundleCompatibilityError::MissingBundle(
+        root_or_bundle.to_path_buf(),
+    ))
+}
+
+fn reject_symlink(path: &Path) -> Result<(), BundleCompatibilityError> {
+    let metadata =
+        fs::symlink_metadata(path).map_err(|source| BundleCompatibilityError::ReadFile {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if metadata.file_type().is_symlink() {
+        return Err(BundleCompatibilityError::SymlinkedPath(path.to_path_buf()));
+    }
+    Ok(())
+}
+
+fn require_recipe_file(recipes: &Path, recipe: &str) -> Result<PathBuf, BundleCompatibilityError> {
+    let path = recipes.join(format!("{recipe}.yaml"));
+    let metadata =
+        fs::symlink_metadata(&path).map_err(|_| BundleCompatibilityError::MissingRecipe {
+            recipe: recipe.to_string(),
+            path: path.clone(),
+        })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(BundleCompatibilityError::MissingRecipe {
+            recipe: recipe.to_string(),
+            path,
+        });
+    }
+    Ok(path)
+}
+
+fn read_file(path: &Path) -> Result<String, BundleCompatibilityError> {
+    fs::read_to_string(path).map_err(|source| BundleCompatibilityError::ReadFile {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn parse_yaml(path: &Path, raw: &str) -> Result<Value, BundleCompatibilityError> {
+    serde_yaml::from_str(raw).map_err(|source| BundleCompatibilityError::InvalidYaml {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn reject_stale_smart_orchestrator(path: &Path, raw: &str) -> Result<(), BundleCompatibilityError> {
+    for marker in STALE_SMART_ORCHESTRATOR_MARKERS {
+        if raw.contains(marker) {
+            return Err(BundleCompatibilityError::StaleSmartOrchestrator {
+                path: path.to_path_buf(),
+                marker: (*marker).to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn contains_recipe_reference(value: &Value, expected: &str) -> bool {
+    match value {
+        Value::Mapping(mapping) => mapping.iter().any(|(key, value)| {
+            (matches!(key, Value::String(k) if k == "recipe")
+                && matches!(value, Value::String(v) if v == expected))
+                || contains_recipe_reference(value, expected)
+        }),
+        Value::Sequence(items) => items
+            .iter()
+            .any(|item| contains_recipe_reference(item, expected)),
+        _ => false,
+    }
+}
+
+fn validate_recipe_manifest(recipes: &Path) -> Result<(), BundleCompatibilityError> {
+    let path = recipes.join("_recipe_manifest.json");
+    if !path.is_file() {
+        return Err(BundleCompatibilityError::MissingManifest(path));
+    }
+    let raw =
+        fs::read_to_string(&path).map_err(|source| BundleCompatibilityError::ReadManifest {
+            path: path.clone(),
+            source,
+        })?;
+    let manifest: serde_json::Value =
+        serde_json::from_str(&raw).map_err(|source| BundleCompatibilityError::InvalidManifest {
+            path: path.clone(),
+            source,
+        })?;
+    let Some(object) = manifest.as_object() else {
+        return Err(BundleCompatibilityError::NonObjectManifest(path));
+    };
+    for recipe in REQUIRED_MANIFEST_RECIPES {
+        let Some(value) = object.get(*recipe) else {
+            return Err(BundleCompatibilityError::MissingManifestEntry {
+                path: path.clone(),
+                recipe: (*recipe).to_string(),
+            });
+        };
+        if !matches!(value, serde_json::Value::String(hash) if !hash.trim().is_empty()) {
+            return Err(BundleCompatibilityError::InvalidManifestEntry {
+                path: path.clone(),
+                recipe: (*recipe).to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    const REQUIRED_SUB_RECIPES: &[&str] = &[
+        "smart-classify-route",
+        "smart-execute-routing",
+        "smart-reflect-loop",
+        "smart-validate-summarize",
+    ];
+
+    fn write_compatible_bundle(bundle: &Path) {
+        let recipes = bundle.join("recipes");
+        fs::create_dir_all(&recipes).unwrap();
+        fs::write(recipes.join("smart-orchestrator.yaml"), compatible_smart()).unwrap();
+        for recipe in REQUIRED_SUB_RECIPES {
+            fs::write(
+                recipes.join(format!("{recipe}.yaml")),
+                format!("name: \"{recipe}\"\nsteps: []\n"),
+            )
+            .unwrap();
+        }
+        fs::write(
+            recipes.join("_recipe_manifest.json"),
+            r#"{
+  "smart-classify-route": "250c8da0ee348745",
+  "smart-execute-routing": "11612506ae846a47",
+  "smart-orchestrator": "8d55ee4817dbc815",
+  "smart-reflect-loop": "7b8101dfce096480",
+  "smart-validate-summarize": "007548c49e9654fb"
+}
+"#,
+        )
+        .unwrap();
+    }
+
+    fn compatible_smart() -> &'static str {
+        r#"name: "smart-orchestrator"
+description: "Composable smart task orchestrator"
+steps:
+  - id: "smart-classify-route"
+    type: "recipe"
+    recipe: "smart-classify-route"
+  - id: "smart-execute-routing"
+    type: "recipe"
+    recipe: "smart-execute-routing"
+  - id: "smart-reflect-loop"
+    type: "recipe"
+    recipe: "smart-reflect-loop"
+  - id: "smart-validate-summarize"
+    type: "recipe"
+    recipe: "smart-validate-summarize"
+"#
+    }
+
+    fn stale_monolithic_smart() -> &'static str {
+        r#"name: "smart-orchestrator"
+description: "old monolithic smart task orchestrator"
+steps:
+  - id: "parse-decomposition"
+    type: "shell"
+    command: |
+      HELPER="$(amplihack resolve-bundle-asset helper-path)"
+      python3 - <<'PY'
+      import importlib
+      module = importlib.import_module("orch_helper")
+      module.parse_decomposition()
+      PY
+"#
+    }
+
+    #[test]
+    fn accepts_current_composable_smart_orchestrator_contract() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+
+        validate_framework_bundle_compatibility(&bundle)
+            .expect("current composable smart-orchestrator bundle must be accepted");
+        validate_staged_framework_bundle(&bundle)
+            .expect("staged compatible smart-orchestrator bundle must be accepted");
+        assert!(
+            is_compatible_framework_bundle(&bundle),
+            "compatibility predicate must accept a composable smart-orchestrator with all companion recipes"
+        );
+    }
+
+    #[test]
+    fn rejects_stale_monolithic_smart_orchestrator_using_helper_path_importlib() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/smart-orchestrator.yaml"),
+            stale_monolithic_smart(),
+        )
+        .unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("stale monolithic smart-orchestrator must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("smart-orchestrator")
+                && (msg.contains("stale")
+                    || msg.contains("incompatible")
+                    || msg.contains("resolve-bundle-asset helper-path")
+                    || msg.contains("importlib")),
+            "error must make the stale smart-orchestrator incompatibility actionable, got: {msg}"
+        );
+        assert!(
+            !is_compatible_framework_bundle(&bundle),
+            "compatibility predicate must not accept the old monolithic smart-orchestrator"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_required_companion_recipe() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::remove_file(bundle.join("recipes/smart-reflect-loop.yaml")).unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("missing required smart sub-recipe must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("smart-reflect-loop") && msg.contains("recipe"),
+            "error must name the missing companion recipe, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_sub_recipe_reference_even_when_file_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/smart-orchestrator.yaml"),
+            compatible_smart().replace(
+                "recipe: \"smart-execute-routing\"",
+                "recipe: \"default-workflow\"",
+            ),
+        )
+        .unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("smart-orchestrator must reference every required phase recipe");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("smart-execute-routing") && msg.contains("smart-orchestrator"),
+            "error must name the missing sub-recipe reference, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_manifest_missing_required_smart_recipe_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/_recipe_manifest.json"),
+            r#"{
+  "smart-classify-route": "250c8da0ee348745",
+  "smart-orchestrator": "8d55ee4817dbc815",
+  "smart-reflect-loop": "7b8101dfce096480",
+  "smart-validate-summarize": "007548c49e9654fb"
+}
+"#,
+        )
+        .unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("recipe manifest must cover every required smart-orchestrator recipe");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("_recipe_manifest.json") && msg.contains("smart-execute-routing"),
+            "error must name the missing manifest entry, got: {msg}"
+        );
+    }
+}

--- a/crates/amplihack-cli/src/commands/install/bundle_compat.rs
+++ b/crates/amplihack-cli/src/commands/install/bundle_compat.rs
@@ -1,5 +1,5 @@
 use serde_yaml::Value;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -15,7 +15,10 @@ const STALE_SMART_ORCHESTRATOR_MARKERS: &[&str] = &[
     "resolve-bundle-asset helper-path",
     "importlib",
     "parse-decomposition",
+    "orch_helper.py",
 ];
+
+const EXECUTABLE_STEP_FIELDS: &[&str] = &["command", "script", "run"];
 
 #[derive(Debug, Error)]
 pub(super) enum BundleCompatibilityError {
@@ -92,9 +95,9 @@ pub(super) fn validate_framework_bundle_compatibility(
     let smart_path = recipes.join("smart-orchestrator.yaml");
     require_recipe_file(&recipes, "smart-orchestrator")?;
     let smart = read_file(&smart_path)?;
-    reject_stale_smart_orchestrator(&smart_path, &smart)?;
     let smart_yaml = parse_yaml(&smart_path, &smart)?;
-    let smart_recipe_refs = recipe_references(&smart_yaml);
+    reject_stale_smart_orchestrator(&smart_path, &smart_yaml)?;
+    let smart_recipe_refs = top_level_recipe_steps(&smart_yaml);
 
     for &recipe in REQUIRED_SMART_RECIPES {
         let companion_path = require_recipe_file(&recipes, recipe)?;
@@ -179,43 +182,79 @@ fn parse_yaml(path: &Path, raw: &str) -> Result<Value, BundleCompatibilityError>
     })
 }
 
-fn reject_stale_smart_orchestrator(path: &Path, raw: &str) -> Result<(), BundleCompatibilityError> {
-    for marker in STALE_SMART_ORCHESTRATOR_MARKERS {
-        if raw.contains(marker) {
-            return Err(BundleCompatibilityError::StaleSmartOrchestrator {
-                path: path.to_path_buf(),
-                marker: (*marker).to_string(),
-            });
+fn reject_stale_smart_orchestrator(
+    path: &Path,
+    yaml: &Value,
+) -> Result<(), BundleCompatibilityError> {
+    let Some(Value::Sequence(steps)) = mapping_value(yaml, "steps") else {
+        return Ok(());
+    };
+
+    for step in steps {
+        let Value::Mapping(mapping) = step else {
+            continue;
+        };
+        for field in EXECUTABLE_STEP_FIELDS {
+            let Some(executable) = mapping_string(mapping, field) else {
+                continue;
+            };
+            for marker in STALE_SMART_ORCHESTRATOR_MARKERS {
+                if executable.contains(marker) {
+                    return Err(BundleCompatibilityError::StaleSmartOrchestrator {
+                        path: path.to_path_buf(),
+                        marker: (*marker).to_string(),
+                    });
+                }
+            }
         }
     }
     Ok(())
 }
 
-fn recipe_references(value: &Value) -> HashSet<&str> {
-    let mut references = HashSet::new();
-    collect_recipe_references(value, &mut references);
+fn top_level_recipe_steps(value: &Value) -> BTreeSet<&str> {
+    let mut references = BTreeSet::new();
+    let Some(Value::Sequence(steps)) = mapping_value(value, "steps") else {
+        return references;
+    };
+
+    for step in steps {
+        let Value::Mapping(mapping) = step else {
+            continue;
+        };
+        if mapping_string(mapping, "type") != Some("recipe") {
+            continue;
+        }
+        if let Some(recipe) = mapping_string(mapping, "recipe") {
+            references.insert(recipe);
+        }
+    }
+
     references
 }
 
-fn collect_recipe_references<'a>(value: &'a Value, references: &mut HashSet<&'a str>) {
-    match value {
-        Value::Mapping(mapping) => {
-            for (key, value) in mapping {
-                if matches!(key, Value::String(k) if k == "recipe")
-                    && let Value::String(recipe) = value
-                {
-                    references.insert(recipe.as_str());
-                }
-                collect_recipe_references(value, references);
-            }
+fn mapping_value<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+    let Value::Mapping(mapping) = value else {
+        return None;
+    };
+    mapping.iter().find_map(|(candidate, value)| {
+        if matches!(candidate, Value::String(candidate) if candidate == key) {
+            Some(value)
+        } else {
+            None
         }
-        Value::Sequence(items) => {
-            for item in items {
-                collect_recipe_references(item, references);
-            }
+    })
+}
+
+fn mapping_string<'a>(mapping: &'a serde_yaml::Mapping, key: &str) -> Option<&'a str> {
+    mapping.iter().find_map(|(candidate, value)| {
+        if matches!(candidate, Value::String(candidate) if candidate == key)
+            && let Value::String(value) = value
+        {
+            Some(value.as_str())
+        } else {
+            None
         }
-        _ => {}
-    }
+    })
 }
 
 fn validate_recipe_manifest(recipes: &Path) -> Result<(), BundleCompatibilityError> {
@@ -401,6 +440,90 @@ steps:
         assert!(
             msg.contains("smart-execute-routing") && msg.contains("smart-orchestrator"),
             "error must name the missing sub-recipe reference, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_required_recipe_names_only_in_metadata_or_context() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/smart-orchestrator.yaml"),
+            r#"name: "smart-orchestrator"
+description: "Recipe names below are inert metadata, not executable recipe steps"
+metadata:
+  recipes:
+    - recipe: "smart-classify-route"
+    - recipe: "smart-execute-routing"
+context:
+  smart_reflect_loop:
+    recipe: "smart-reflect-loop"
+  smart_validate_summarize:
+    recipe: "smart-validate-summarize"
+steps:
+  - id: "metadata-only"
+    type: "bash"
+    command: "echo metadata only"
+"#,
+        )
+        .unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("required smart sub-recipes must be top-level type: recipe steps");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("smart-classify-route") && msg.contains("smart-orchestrator"),
+            "metadata/context recipe keys must not satisfy the structural recipe-step contract, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn accepts_stale_marker_text_in_comments_and_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/smart-orchestrator.yaml"),
+            format!(
+                r#"{}
+# Historical note only: resolve-bundle-asset helper-path importlib parse-decomposition orch_helper.py
+metadata:
+  migration_note: "Old text resolve-bundle-asset helper-path importlib parse-decomposition orch_helper.py is inert"
+"#,
+                compatible_smart()
+            ),
+        )
+        .unwrap();
+
+        validate_framework_bundle_compatibility(&bundle)
+            .expect("comments and inert metadata must not trip stale executable marker checks");
+    }
+
+    #[test]
+    fn rejects_executable_stale_orch_helper_py_reference() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/smart-orchestrator.yaml"),
+            format!(
+                r#"{}
+  - id: "old-helper-script"
+    type: "bash"
+    command: "python3 amplifier-bundle/tools/orch_helper.py"
+"#,
+                compatible_smart()
+            ),
+        )
+        .unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("executable orch_helper.py references must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("orch_helper.py") && msg.contains("smart-orchestrator"),
+            "error must name the stale executable helper marker, got: {msg}"
         );
     }
 

--- a/crates/amplihack-cli/src/commands/install/bundle_compat.rs
+++ b/crates/amplihack-cli/src/commands/install/bundle_compat.rs
@@ -121,7 +121,8 @@ pub(super) fn validate_staged_framework_bundle(
     validate_framework_bundle_compatibility(bundle)
 }
 
-pub(super) fn is_compatible_framework_bundle(root_or_bundle: &Path) -> bool {
+#[cfg(test)]
+fn is_compatible_framework_bundle(root_or_bundle: &Path) -> bool {
     validate_framework_bundle_compatibility(root_or_bundle).is_ok()
 }
 

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -25,16 +25,24 @@
 //! 6. **Network download** (legacy fallback) — `git clone` / tarball from
 //!    upstream, only attempted when none of the above yields a usable root.
 
-use super::bundle_compat::{
-    is_compatible_framework_bundle, validate_framework_bundle_compatibility,
-};
+use super::bundle_compat::validate_framework_bundle_compatibility;
 use super::types::{REPO_ARCHIVE_URL, REPO_GIT_URL};
 use crate::update::{extract_archive, http_get_with_retry, validate_download_url};
 use anyhow::{Context, Result, bail};
 use std::collections::VecDeque;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[cfg(not(test))]
+const GIT_CLONE_TIMEOUT: Duration = Duration::from_secs(300);
+#[cfg(test)]
+const GIT_CLONE_TIMEOUT: Duration = Duration::from_millis(250);
+const GIT_CLONE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+const CAPTURE_LIMIT: usize = 8192;
 
 /// Locate the bundled framework source from the amplihack-rs source tree.
 ///
@@ -105,14 +113,16 @@ fn compatible_candidate(candidate: PathBuf, label: &str) -> Option<PathBuf> {
     if !candidate.join("amplifier-bundle").is_dir() {
         return None;
     }
-    if is_compatible_framework_bundle(&candidate) {
-        return Some(candidate);
+    match validate_framework_bundle_compatibility(&candidate) {
+        Ok(()) => Some(candidate),
+        Err(err) => {
+            eprintln!(
+                "⚠️  Skipping incompatible framework bundle from {label}: {}: {err:#}",
+                candidate.display()
+            );
+            None
+        }
     }
-    eprintln!(
-        "⚠️  Skipping incompatible framework bundle from {label}: {}",
-        candidate.display()
-    );
-    None
 }
 
 /// Fetch the framework repository into `destination`.
@@ -170,7 +180,11 @@ fn which_git() -> Result<PathBuf> {
 
 /// Run `git clone --depth 1 <REPO_GIT_URL> <destination>`.
 fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
-    let status = std::process::Command::new(git_path)
+    let stdout_file = tempfile::NamedTempFile::new()
+        .context("failed to create temporary stdout file for git clone")?;
+    let stderr_file = tempfile::NamedTempFile::new()
+        .context("failed to create temporary stderr file for git clone")?;
+    let mut child = std::process::Command::new(git_path)
         .args([
             "clone",
             "--depth",
@@ -179,14 +193,71 @@ fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
             &destination.to_string_lossy(),
         ])
         .stdin(Stdio::null())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
+        .stdout(Stdio::from(
+            stdout_file
+                .as_file()
+                .try_clone()
+                .context("failed to clone git stdout handle")?,
+        ))
+        .stderr(Stdio::from(
+            stderr_file
+                .as_file()
+                .try_clone()
+                .context("failed to clone git stderr handle")?,
+        ))
+        .spawn()
         .with_context(|| format!("failed to spawn git clone for {REPO_GIT_URL}"))?;
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child
+            .try_wait()
+            .context("failed to poll git clone status")?
+        {
+            break status;
+        }
+        if started.elapsed() >= GIT_CLONE_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            let stdout = read_limited(stdout_file.path())?;
+            let stderr = read_limited(stderr_file.path())?;
+            bail!(
+                "git clone timed out after {:?} for {REPO_GIT_URL} into {}\nstdout:\n{}\nstderr:\n{}",
+                GIT_CLONE_TIMEOUT,
+                destination.display(),
+                stdout,
+                stderr
+            );
+        }
+        thread::sleep(GIT_CLONE_POLL_INTERVAL);
+    };
     if !status.success() {
-        return Err(crate::command_error::exit_error(1));
+        let stdout = read_limited(stdout_file.path())?;
+        let stderr = read_limited(stderr_file.path())?;
+        bail!(
+            "git clone failed with status {status} for {REPO_GIT_URL} into {}\nstdout:\n{}\nstderr:\n{}",
+            destination.display(),
+            stdout,
+            stderr
+        );
     }
     Ok(())
+}
+
+fn read_limited(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("failed to open captured output {}", path.display()))?;
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take((CAPTURE_LIMIT + 1) as u64)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read captured output {}", path.display()))?;
+    let truncated = bytes.len() > CAPTURE_LIMIT;
+    bytes.truncate(CAPTURE_LIMIT);
+    let mut text = String::from_utf8_lossy(&bytes).into_owned();
+    if truncated {
+        text.push_str("\n...<truncated>");
+    }
+    Ok(text)
 }
 
 pub(super) fn find_framework_repo_root(root: &Path) -> Result<PathBuf> {
@@ -227,5 +298,67 @@ pub(super) fn find_compatible_framework_repo_root(root: &Path, source: &str) -> 
             repo_root.display()
         ));
     }
+
     Ok(repo_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn fake_git(dir: &Path, body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = dir.join("git");
+        fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_clone_reports_nonzero_exit_with_captured_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let fake = fake_git(
+            temp.path(),
+            "echo stdout-marker; echo stderr-marker >&2; exit 42",
+        );
+
+        let err = git_clone_framework_repo(&fake, &temp.path().join("dest"))
+            .expect_err("non-zero git clone must fail");
+        let msg = format!("{err:#}");
+
+        assert!(
+            msg.contains("status"),
+            "error must include exit status: {msg}"
+        );
+        assert!(
+            msg.contains("stdout-marker") && msg.contains("stderr-marker"),
+            "error must include captured stdout/stderr: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_clone_times_out_and_reaps_child() {
+        let temp = tempfile::tempdir().unwrap();
+        let fake = fake_git(temp.path(), "echo started; /bin/sleep 5");
+        let start = Instant::now();
+
+        let err = git_clone_framework_repo(&fake, &temp.path().join("dest"))
+            .expect_err("hung git clone must time out");
+        let msg = format!("{err:#}");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "test timeout should be bounded, elapsed {:?}",
+            start.elapsed()
+        );
+        assert!(msg.contains("timed out"), "error must name timeout: {msg}");
+        assert!(
+            msg.contains("started"),
+            "timeout error must include captured output: {msg}"
+        );
+    }
 }

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -268,6 +268,16 @@ fn terminate_git_clone(child: &mut std::process::Child) {
             }
         }
     }
+    #[cfg(windows)]
+    {
+        let pid = child.id().to_string();
+        let _ = std::process::Command::new("taskkill")
+            .args(["/PID", &pid, "/T", "/F"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
     let _ = child.kill();
     let _ = child.wait();
 }

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -32,6 +32,8 @@ use anyhow::{Context, Result, bail};
 use std::collections::VecDeque;
 use std::fs;
 use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::thread;
@@ -184,7 +186,8 @@ fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
         .context("failed to create temporary stdout file for git clone")?;
     let stderr_file = tempfile::NamedTempFile::new()
         .context("failed to create temporary stderr file for git clone")?;
-    let mut child = std::process::Command::new(git_path)
+    let mut command = std::process::Command::new(git_path);
+    command
         .args([
             "clone",
             "--depth",
@@ -204,7 +207,19 @@ fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
                 .as_file()
                 .try_clone()
                 .context("failed to clone git stderr handle")?,
-        ))
+        ));
+    #[cfg(unix)]
+    // SAFETY: `pre_exec` runs after fork and before exec. `setsid` is async-signal-safe
+    // and isolates the git clone process tree so timeout cleanup can terminate it.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command
         .spawn()
         .with_context(|| format!("failed to spawn git clone for {REPO_GIT_URL}"))?;
     let started = Instant::now();
@@ -216,8 +231,7 @@ fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
             break status;
         }
         if started.elapsed() >= GIT_CLONE_TIMEOUT {
-            let _ = child.kill();
-            let _ = child.wait();
+            terminate_git_clone(&mut child);
             let stdout = read_limited(stdout_file.path())?;
             let stderr = read_limited(stderr_file.path())?;
             bail!(
@@ -241,6 +255,21 @@ fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn terminate_git_clone(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        let pid = child.id() as libc::pid_t;
+        if pid > 0 {
+            // Negative pid targets the process group created with setsid above.
+            unsafe {
+                let _ = libc::kill(-pid, libc::SIGKILL);
+            }
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn read_limited(path: &Path) -> Result<String> {
@@ -343,7 +372,14 @@ mod tests {
     #[test]
     fn git_clone_times_out_and_reaps_child() {
         let temp = tempfile::tempdir().unwrap();
-        let fake = fake_git(temp.path(), "echo started; /bin/sleep 5");
+        let marker = temp.path().join("orphan-marker");
+        let fake = fake_git(
+            temp.path(),
+            &format!(
+                "(/bin/sleep 1; echo orphan > '{}') & echo started; /bin/sleep 5",
+                marker.display()
+            ),
+        );
         let start = Instant::now();
 
         let err = git_clone_framework_repo(&fake, &temp.path().join("dest"))
@@ -359,6 +395,11 @@ mod tests {
         assert!(
             msg.contains("started"),
             "timeout error must include captured output: {msg}"
+        );
+        thread::sleep(Duration::from_millis(1_200));
+        assert!(
+            !marker.exists(),
+            "timeout cleanup must terminate git clone descendants"
         );
     }
 }

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -25,6 +25,7 @@
 //! 6. **Network download** (legacy fallback) — `git clone` / tarball from
 //!    upstream, only attempted when none of the above yields a usable root.
 
+use super::bundle_compat::is_compatible_framework_bundle;
 use super::types::{REPO_ARCHIVE_URL, REPO_GIT_URL};
 use crate::update::{extract_archive, http_get_with_retry, validate_download_url};
 use anyhow::{Context, Result, bail};
@@ -44,8 +45,8 @@ pub(super) fn find_bundled_framework_root() -> Option<PathBuf> {
     // 1. AMPLIHACK_HOME env var — explicit user override
     if let Ok(home) = std::env::var("AMPLIHACK_HOME") {
         let p = PathBuf::from(&home);
-        if p.join("amplifier-bundle").is_dir() {
-            return Some(p);
+        if let Some(root) = compatible_candidate(p, "AMPLIHACK_HOME") {
+            return Some(root);
         }
     }
 
@@ -53,8 +54,8 @@ pub(super) fn find_bundled_framework_root() -> Option<PathBuf> {
     if let Ok(cwd) = std::env::current_dir() {
         let mut dir: Option<PathBuf> = Some(cwd);
         while let Some(d) = dir {
-            if d.join("amplifier-bundle").is_dir() {
-                return Some(d);
+            if let Some(root) = compatible_candidate(d.clone(), "current directory") {
+                return Some(root);
             }
             dir = d.parent().map(Path::to_path_buf);
         }
@@ -64,8 +65,8 @@ pub(super) fn find_bundled_framework_root() -> Option<PathBuf> {
     if let Ok(exe) = std::env::current_exe() {
         let mut dir = exe.parent().map(Path::to_path_buf);
         while let Some(d) = dir {
-            if d.join("amplifier-bundle").is_dir() {
-                return Some(d);
+            if let Some(root) = compatible_candidate(d.clone(), "executable parent") {
+                return Some(root);
             }
             dir = d.parent().map(Path::to_path_buf);
         }
@@ -80,18 +81,35 @@ pub(super) fn find_bundled_framework_root() -> Option<PathBuf> {
         .map(Path::to_path_buf);
     if let Some(ref root) = workspace_root
         && root.join("amplifier-bundle").is_dir()
+        && let Some(root) = compatible_candidate(root.clone(), "compile-time workspace root")
     {
-        return Some(root.clone());
+        return Some(root);
     }
 
     // 5. ~/.amplihack (from prior staged install)
     if let Ok(home) = std::env::var("HOME") {
         let dot = PathBuf::from(home).join(".amplihack");
-        if dot.join("amplifier-bundle").is_dir() && dot.join(".claude").is_dir() {
-            return Some(dot);
+        if dot.join(".claude").is_dir()
+            && let Some(root) = compatible_candidate(dot, "~/.amplihack")
+        {
+            return Some(root);
         }
     }
 
+    None
+}
+
+fn compatible_candidate(candidate: PathBuf, label: &str) -> Option<PathBuf> {
+    if !candidate.join("amplifier-bundle").is_dir() {
+        return None;
+    }
+    if is_compatible_framework_bundle(&candidate) {
+        return Some(candidate);
+    }
+    eprintln!(
+        "⚠️  Skipping incompatible framework bundle from {label}: {}",
+        candidate.display()
+    );
     None
 }
 

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -25,7 +25,9 @@
 //! 6. **Network download** (legacy fallback) — `git clone` / tarball from
 //!    upstream, only attempted when none of the above yields a usable root.
 
-use super::bundle_compat::is_compatible_framework_bundle;
+use super::bundle_compat::{
+    is_compatible_framework_bundle, validate_framework_bundle_compatibility,
+};
 use super::types::{REPO_ARCHIVE_URL, REPO_GIT_URL};
 use crate::update::{extract_archive, http_get_with_retry, validate_download_url};
 use anyhow::{Context, Result, bail};
@@ -124,7 +126,7 @@ fn compatible_candidate(candidate: PathBuf, label: &str) -> Option<PathBuf> {
 pub(super) fn download_and_extract_framework_repo(destination: &Path) -> Result<PathBuf> {
     if let Ok(git_path) = which_git() {
         git_clone_framework_repo(&git_path, destination)?;
-        return find_framework_repo_root(destination);
+        return find_compatible_framework_repo_root(destination, REPO_GIT_URL);
     }
 
     // git not available — fall back to HTTP tarball download
@@ -137,7 +139,7 @@ pub(super) fn download_and_extract_framework_repo(destination: &Path) -> Result<
             destination.display()
         )
     })?;
-    find_framework_repo_root(destination)
+    find_compatible_framework_repo_root(destination, REPO_ARCHIVE_URL)
 }
 
 /// Resolve the `git` binary path from PATH.
@@ -196,6 +198,7 @@ pub(super) fn find_framework_repo_root(root: &Path) -> Result<PathBuf> {
         if dir.join(".claude").is_dir() || dir.join("amplifier-bundle").is_dir() {
             return Ok(dir);
         }
+
         for entry in
             fs::read_dir(&dir).with_context(|| format!("failed to read {}", dir.display()))?
         {
@@ -214,4 +217,15 @@ pub(super) fn find_framework_repo_root(root: &Path) -> Result<PathBuf> {
         "downloaded framework archive did not contain a repository root with .claude or amplifier-bundle under {}",
         root.display()
     )
+}
+
+pub(super) fn find_compatible_framework_repo_root(root: &Path, source: &str) -> Result<PathBuf> {
+    let repo_root = find_framework_repo_root(root)?;
+    if let Err(error) = validate_framework_bundle_compatibility(&repo_root) {
+        return Err(anyhow::anyhow!(
+            "downloaded framework bundle from {source} is incompatible at {}: {error}",
+            repo_root.display()
+        ));
+    }
+    Ok(repo_root)
 }

--- a/crates/amplihack-cli/src/commands/install/directories.rs
+++ b/crates/amplihack-cli/src/commands/install/directories.rs
@@ -460,6 +460,7 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
             )
         });
     }
+    // This validated staging tree is the exact tree moved into place below.
 
     if target_bundle.exists() {
         let backup = target_bundle.with_extension("old");
@@ -496,12 +497,6 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
         "  ✅ Staged amplifier-bundle to {}",
         target_bundle.display()
     );
-    validate_staged_framework_bundle(&target_bundle).with_context(|| {
-        format!(
-            "installed amplifier-bundle at {} is incompatible",
-            target_bundle.display()
-        )
-    })?;
     Ok(true)
 }
 

--- a/crates/amplihack-cli/src/commands/install/directories.rs
+++ b/crates/amplihack-cli/src/commands/install/directories.rs
@@ -1,5 +1,8 @@
 //! Directory creation, tree copying, and framework asset initialization.
 
+use super::bundle_compat::{
+    validate_framework_bundle_compatibility, validate_staged_framework_bundle,
+};
 use super::filesystem::*;
 use super::types::*;
 use anyhow::{Context, Result};
@@ -413,6 +416,12 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
             source_bundle.display()
         );
     }
+    validate_framework_bundle_compatibility(&source_bundle).with_context(|| {
+        format!(
+            "source amplifier-bundle at {} is incompatible",
+            source_bundle.display()
+        )
+    })?;
 
     let target_bundle = claude_dir
         .parent()
@@ -442,6 +451,15 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
             staging_temp.display()
         )
     })?;
+    if let Err(err) = validate_staged_framework_bundle(&staging_temp) {
+        let _ = fs::remove_dir_all(&staging_temp);
+        return Err(err).with_context(|| {
+            format!(
+                "copied amplifier-bundle staging dir {} is incompatible",
+                staging_temp.display()
+            )
+        });
+    }
 
     if target_bundle.exists() {
         let backup = target_bundle.with_extension("old");
@@ -478,6 +496,12 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
         "  ✅ Staged amplifier-bundle to {}",
         target_bundle.display()
     );
+    validate_staged_framework_bundle(&target_bundle).with_context(|| {
+        format!(
+            "installed amplifier-bundle at {} is incompatible",
+            target_bundle.display()
+        )
+    })?;
     Ok(true)
 }
 

--- a/crates/amplihack-cli/src/commands/install/directories.rs
+++ b/crates/amplihack-cli/src/commands/install/directories.rs
@@ -460,7 +460,6 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
             )
         });
     }
-    // This validated staging tree is the exact tree moved into place below.
 
     if target_bundle.exists() {
         let backup = target_bundle.with_extension("old");
@@ -492,6 +491,13 @@ pub(super) fn copy_amplifier_bundle(repo_root: &Path, claude_dir: &Path) -> Resu
             )
         })?;
     }
+
+    validate_staged_framework_bundle(&target_bundle).with_context(|| {
+        format!(
+            "staged amplifier-bundle at {} is incompatible after atomic replacement",
+            target_bundle.display()
+        )
+    })?;
 
     println!(
         "  ✅ Staged amplifier-bundle to {}",

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -1,6 +1,7 @@
 //! Native install and uninstall commands.
 
 mod binary;
+mod bundle_compat;
 mod clone;
 mod copilot_plugin;
 mod directories;
@@ -20,6 +21,7 @@ pub(crate) mod version_stamp;
 mod tests;
 
 use binary::{deploy_binaries, find_hooks_binary};
+use bundle_compat::validate_framework_bundle_compatibility;
 use clone::{download_and_extract_framework_repo, find_bundled_framework_root};
 use directories::*;
 use filesystem::{all_rel_dirs, get_all_files_and_dirs};
@@ -289,6 +291,14 @@ fn local_install(
         layout.marker_str(),
         source_root.display()
     );
+    if layout == SourceLayout::Bundle {
+        validate_framework_bundle_compatibility(&source_root).with_context(|| {
+            format!(
+                "source amplifier-bundle at {} is incompatible",
+                source_root.display()
+            )
+        })?;
+    }
     let copied_dirs = copytree_manifest(&source_root, layout, &claude_dir)?;
     if copied_dirs.is_empty() {
         bail!(

--- a/crates/amplihack-cli/src/commands/install/settings.rs
+++ b/crates/amplihack-cli/src/commands/install/settings.rs
@@ -194,13 +194,13 @@ pub(super) fn read_settings_json(settings_path: &Path) -> Result<Value> {
     match serde_json::from_str::<Value>(&raw) {
         Ok(Value::Object(map)) => Ok(Value::Object(map)),
         Ok(_) => Ok(Value::Object(Map::new())),
-        Err(_) => {
-            tracing::warn!(
-                "Settings file {} contains invalid JSON, using empty defaults",
+        Err(err) => Err(err).with_context(|| {
+            format!(
+                "failed to parse JSON in {}. The original file was left unchanged; \
+                 fix the malformed settings.json or move it aside before running install",
                 settings_path.display()
-            );
-            Ok(Value::Object(Map::new()))
-        }
+            )
+        }),
     }
 }
 
@@ -421,12 +421,20 @@ mod tests {
     }
 
     #[test]
-    fn read_invalid_json_returns_empty_object() {
+    fn read_invalid_json_returns_error() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         fs::write(tmp.path(), "not json at all").unwrap();
-        let result = read_settings_json(tmp.path()).unwrap();
-        assert!(result.is_object());
-        assert!(result.as_object().unwrap().is_empty());
+        let err = read_settings_json(tmp.path())
+            .expect_err("malformed settings.json must fail loudly, not become {}");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(tmp.path().to_string_lossy().as_ref())
+                && (msg.contains("parse")
+                    || msg.contains("JSON")
+                    || msg.contains("expected")
+                    || msg.contains("invalid")),
+            "error must name the malformed settings file and parse problem, got:\n{msg}"
+        );
     }
 
     #[test]

--- a/crates/amplihack-cli/src/commands/install/tests/helpers.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/helpers.rs
@@ -139,7 +139,9 @@ steps:
     ] {
         fs::write(
             recipes.join(format!("{recipe}.yaml")),
-            format!("name: \"{recipe}\"\nsteps: []\n"),
+            format!(
+                "name: \"{recipe}\"\nsteps:\n  - id: smoke\n    type: bash\n    command: 'true'\n"
+            ),
         )
         .unwrap();
     }

--- a/crates/amplihack-cli/src/commands/install/tests/helpers.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/helpers.rs
@@ -42,17 +42,7 @@ pub(super) fn create_source_repo(root: &Path) {
         fs::write(bundle.join(dir).join("marker.txt"), "x\n").unwrap();
     }
     fs::write(bundle.join("tools/statusline.sh"), "echo hi\n").unwrap();
-    for recipe in [
-        "smart-orchestrator.yaml",
-        "default-workflow.yaml",
-        "investigation-workflow.yaml",
-    ] {
-        fs::write(
-            bundle.join("recipes").join(recipe),
-            "name: test-recipe\nsteps: []\n",
-        )
-        .unwrap();
-    }
+    write_compatible_recipe_bundle(&bundle.join("recipes"));
 }
 
 pub(super) fn create_minimal_staged_assets(root: &Path) {
@@ -68,17 +58,7 @@ pub(super) fn create_minimal_staged_assets(root: &Path) {
     let bundle = root.join(".amplihack/amplifier-bundle");
     fs::create_dir_all(bundle.join("recipes")).unwrap();
     fs::create_dir_all(bundle.join("tools")).unwrap();
-    for recipe in [
-        "smart-orchestrator.yaml",
-        "default-workflow.yaml",
-        "investigation-workflow.yaml",
-    ] {
-        fs::write(
-            bundle.join("recipes").join(recipe),
-            "name: test-recipe\nsteps: []\n",
-        )
-        .unwrap();
-    }
+    write_compatible_recipe_bundle(&bundle.join("recipes"));
 }
 
 /// Build a bundle-only source repo (no top-level `.claude/`), as shipped by
@@ -103,17 +83,7 @@ pub(super) fn create_bundle_only_source_repo(root: &Path) {
         fs::write(bundle.join(dir).join("marker.txt"), "x\n").unwrap();
     }
     fs::write(bundle.join("tools/statusline.sh"), "echo hi\n").unwrap();
-    for recipe in [
-        "smart-orchestrator.yaml",
-        "default-workflow.yaml",
-        "investigation-workflow.yaml",
-    ] {
-        fs::write(
-            bundle.join("recipes").join(recipe),
-            "name: test-recipe\nsteps: []\n",
-        )
-        .unwrap();
-    }
+    write_compatible_recipe_bundle(&bundle.join("recipes"));
     fs::write(root.join("CLAUDE.md"), "root\n").unwrap();
     // Crucially: NO `.claude/` directory anywhere — that's the bug condition
     // for issue #416.
@@ -136,6 +106,55 @@ pub(super) fn create_exe_stub(dir: &Path, name: &str) -> std::path::PathBuf {
         fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
     path
+}
+
+fn write_compatible_recipe_bundle(recipes: &Path) {
+    fs::create_dir_all(recipes).unwrap();
+    fs::write(
+        recipes.join("smart-orchestrator.yaml"),
+        r#"name: "smart-orchestrator"
+steps:
+  - id: "smart-classify-route"
+    type: "recipe"
+    recipe: "smart-classify-route"
+  - id: "smart-execute-routing"
+    type: "recipe"
+    recipe: "smart-execute-routing"
+  - id: "smart-reflect-loop"
+    type: "recipe"
+    recipe: "smart-reflect-loop"
+  - id: "smart-validate-summarize"
+    type: "recipe"
+    recipe: "smart-validate-summarize"
+"#,
+    )
+    .unwrap();
+    for recipe in [
+        "default-workflow",
+        "investigation-workflow",
+        "smart-classify-route",
+        "smart-execute-routing",
+        "smart-reflect-loop",
+        "smart-validate-summarize",
+    ] {
+        fs::write(
+            recipes.join(format!("{recipe}.yaml")),
+            format!("name: \"{recipe}\"\nsteps: []\n"),
+        )
+        .unwrap();
+    }
+    fs::write(
+        recipes.join("_recipe_manifest.json"),
+        r#"{
+  "smart-classify-route": "250c8da0ee348745",
+  "smart-execute-routing": "11612506ae846a47",
+  "smart-orchestrator": "8d55ee4817dbc815",
+  "smart-reflect-loop": "7b8101dfce096480",
+  "smart-validate-summarize": "007548c49e9654fb"
+}
+"#,
+    )
+    .unwrap();
 }
 
 pub(super) fn build_canonical_native_hook_settings(hooks_bin: &Path) -> serde_json::Value {

--- a/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
@@ -500,6 +500,49 @@ fn find_framework_repo_root_finds_github_tarball_layout() {
 }
 
 #[test]
+fn find_compatible_framework_repo_root_accepts_downloaded_composable_bundle() {
+    let temp = tempfile::tempdir().unwrap();
+    let extracted = temp.path().join("amplihack-main");
+    create_source_repo(&extracted);
+
+    let found = clone::find_compatible_framework_repo_root(temp.path(), "test download").unwrap();
+
+    assert_eq!(found, extracted);
+}
+
+#[test]
+fn find_compatible_framework_repo_root_rejects_downloaded_stale_bundle() {
+    let temp = tempfile::tempdir().unwrap();
+    let extracted = temp.path().join("amplihack-main");
+    create_source_repo(&extracted);
+    fs::write(
+        extracted.join("amplifier-bundle/recipes/smart-orchestrator.yaml"),
+        r#"name: "smart-orchestrator"
+steps:
+  - id: "parse-decomposition"
+    type: "shell"
+    command: |
+      HELPER="$(amplihack resolve-bundle-asset helper-path)"
+      python3 - <<'PY'
+      import importlib
+      PY
+"#,
+    )
+    .unwrap();
+
+    let err = clone::find_compatible_framework_repo_root(temp.path(), "test download")
+        .expect_err("downloaded stale smart-orchestrator bundle must be rejected");
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("downloaded framework bundle")
+            && msg.contains("incompatible")
+            && msg.contains("smart-orchestrator"),
+        "error must explain the incompatible downloaded bundle, got: {msg}"
+    );
+}
+
+#[test]
 fn find_framework_repo_root_errors_when_archive_lacks_claude_dir() {
     let temp = tempfile::tempdir().unwrap();
     fs::create_dir_all(temp.path().join("archive-root/empty")).unwrap();

--- a/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
@@ -1,5 +1,6 @@
 use super::helpers::*;
 use super::*;
+use crate::commands::install::bundle_compat::REQUIRED_SMART_RECIPES;
 use std::fs;
 
 #[test]
@@ -743,13 +744,6 @@ fn copy_amplifier_bundle_replaces_existing_atomically() {
     );
 }
 
-const ISSUE_734_REQUIRED_SMART_RECIPES: &[&str] = &[
-    "smart-classify-route",
-    "smart-execute-routing",
-    "smart-reflect-loop",
-    "smart-validate-summarize",
-];
-
 fn issue_734_compatible_smart_orchestrator() -> &'static str {
     r#"name: "smart-orchestrator"
 description: "Composable smart task orchestrator"
@@ -786,46 +780,9 @@ steps:
 }
 
 fn issue_734_create_bundle_repo(root: &Path, smart_orchestrator: &str) {
-    let bundle = root.join("amplifier-bundle");
-    for dir in BUNDLE_ESSENTIAL_DESTS {
-        fs::create_dir_all(bundle.join(dir)).unwrap();
-        fs::write(bundle.join(dir).join("marker.txt"), "x\n").unwrap();
-    }
-    fs::create_dir_all(bundle.join("tools")).unwrap();
-    fs::write(bundle.join("tools/statusline.sh"), "echo hi\n").unwrap();
-    fs::write(bundle.join("CLAUDE.md"), "framework\n").unwrap();
-
-    let recipes = bundle.join("recipes");
+    helpers::create_bundle_only_source_repo(root);
+    let recipes = root.join("amplifier-bundle/recipes");
     fs::write(recipes.join("smart-orchestrator.yaml"), smart_orchestrator).unwrap();
-    fs::write(
-        recipes.join("default-workflow.yaml"),
-        "name: \"default-workflow\"\nsteps: []\n",
-    )
-    .unwrap();
-    fs::write(
-        recipes.join("investigation-workflow.yaml"),
-        "name: \"investigation-workflow\"\nsteps: []\n",
-    )
-    .unwrap();
-    for recipe in ISSUE_734_REQUIRED_SMART_RECIPES {
-        fs::write(
-            recipes.join(format!("{recipe}.yaml")),
-            format!("name: \"{recipe}\"\nsteps: []\n"),
-        )
-        .unwrap();
-    }
-    fs::write(
-        recipes.join("_recipe_manifest.json"),
-        r#"{
-  "smart-classify-route": "250c8da0ee348745",
-  "smart-execute-routing": "11612506ae846a47",
-  "smart-orchestrator": "8d55ee4817dbc815",
-  "smart-reflect-loop": "7b8101dfce096480",
-  "smart-validate-summarize": "007548c49e9654fb"
-}
-"#,
-    )
-    .unwrap();
 }
 
 #[test]
@@ -868,7 +825,6 @@ fn issue_734_copy_rejects_stale_monolithic_smart_orchestrator_without_overwritin
 fn issue_734_run_install_skips_stale_amplihack_home_and_stages_compatible_cwd_bundle() {
     with_install_env(|home| {
         let stale_home = home.join("stale-amplihack-home");
-        fs::create_dir_all(stale_home.join(".claude")).unwrap();
         issue_734_create_bundle_repo(&stale_home, issue_734_stale_monolithic_smart_orchestrator());
 
         let fresh_checkout = home.join("fresh-checkout");
@@ -894,7 +850,7 @@ fn issue_734_run_install_skips_stale_amplihack_home_and_stages_compatible_cwd_bu
             home.join(".amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml"),
         )
         .unwrap();
-        for recipe in ISSUE_734_REQUIRED_SMART_RECIPES {
+        for recipe in REQUIRED_SMART_RECIPES {
             assert!(
                 staged_smart.contains(&format!("recipe: \"{recipe}\"")),
                 "staged smart-orchestrator must reference required sub-recipe {recipe}; got:\n{staged_smart}"

--- a/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
@@ -650,24 +650,38 @@ fn copy_amplifier_bundle_replaces_existing_atomically() {
     let claude_dir = temp.path().join(".amplihack/.claude");
     fs::create_dir_all(&claude_dir).unwrap();
 
-    let bundle_src = repo_root.join("amplifier-bundle");
-    fs::create_dir_all(bundle_src.join("recipes")).unwrap();
-    fs::write(bundle_src.join("recipes/smart-orchestrator.yaml"), "v1\n").unwrap();
+    issue_734_create_bundle_repo(
+        &repo_root,
+        &issue_734_compatible_smart_orchestrator().replace(
+            "Composable smart task orchestrator",
+            "Composable smart task orchestrator v1",
+        ),
+    );
     directories::copy_amplifier_bundle(&repo_root, &claude_dir).unwrap();
 
     let staged = temp.path().join(".amplihack/amplifier-bundle");
-    assert_eq!(
-        fs::read_to_string(staged.join("recipes/smart-orchestrator.yaml")).unwrap(),
-        "v1\n"
+    assert!(
+        fs::read_to_string(staged.join("recipes/smart-orchestrator.yaml"))
+            .unwrap()
+            .contains("v1")
     );
 
-    fs::write(bundle_src.join("recipes/smart-orchestrator.yaml"), "v2\n").unwrap();
+    let bundle_src = repo_root.join("amplifier-bundle");
+    fs::write(
+        bundle_src.join("recipes/smart-orchestrator.yaml"),
+        issue_734_compatible_smart_orchestrator().replace(
+            "Composable smart task orchestrator",
+            "Composable smart task orchestrator v2",
+        ),
+    )
+    .unwrap();
     fs::write(bundle_src.join("recipes/new-recipe.yaml"), "fresh\n").unwrap();
     directories::copy_amplifier_bundle(&repo_root, &claude_dir).unwrap();
 
-    assert_eq!(
-        fs::read_to_string(staged.join("recipes/smart-orchestrator.yaml")).unwrap(),
-        "v2\n",
+    assert!(
+        fs::read_to_string(staged.join("recipes/smart-orchestrator.yaml"))
+            .unwrap()
+            .contains("v2"),
         "re-install must replace existing content"
     );
     assert!(
@@ -684,6 +698,177 @@ fn copy_amplifier_bundle_replaces_existing_atomically() {
         !parent.join("amplifier-bundle.old").exists(),
         "no backup dir must remain after a successful install"
     );
+}
+
+const ISSUE_734_REQUIRED_SMART_RECIPES: &[&str] = &[
+    "smart-classify-route",
+    "smart-execute-routing",
+    "smart-reflect-loop",
+    "smart-validate-summarize",
+];
+
+fn issue_734_compatible_smart_orchestrator() -> &'static str {
+    r#"name: "smart-orchestrator"
+description: "Composable smart task orchestrator"
+steps:
+  - id: "smart-classify-route"
+    type: "recipe"
+    recipe: "smart-classify-route"
+  - id: "smart-execute-routing"
+    type: "recipe"
+    recipe: "smart-execute-routing"
+  - id: "smart-reflect-loop"
+    type: "recipe"
+    recipe: "smart-reflect-loop"
+  - id: "smart-validate-summarize"
+    type: "recipe"
+    recipe: "smart-validate-summarize"
+"#
+}
+
+fn issue_734_stale_monolithic_smart_orchestrator() -> &'static str {
+    r#"name: "smart-orchestrator"
+description: "stale monolithic smart task orchestrator"
+steps:
+  - id: "parse-decomposition"
+    type: "shell"
+    command: |
+      HELPER="$(amplihack resolve-bundle-asset helper-path)"
+      python3 - <<'PY'
+      import importlib
+      helper = importlib.import_module("orch_helper")
+      helper.parse_decomposition()
+      PY
+"#
+}
+
+fn issue_734_create_bundle_repo(root: &Path, smart_orchestrator: &str) {
+    let bundle = root.join("amplifier-bundle");
+    for dir in BUNDLE_ESSENTIAL_DESTS {
+        fs::create_dir_all(bundle.join(dir)).unwrap();
+        fs::write(bundle.join(dir).join("marker.txt"), "x\n").unwrap();
+    }
+    fs::create_dir_all(bundle.join("tools")).unwrap();
+    fs::write(bundle.join("tools/statusline.sh"), "echo hi\n").unwrap();
+    fs::write(bundle.join("CLAUDE.md"), "framework\n").unwrap();
+
+    let recipes = bundle.join("recipes");
+    fs::write(recipes.join("smart-orchestrator.yaml"), smart_orchestrator).unwrap();
+    fs::write(
+        recipes.join("default-workflow.yaml"),
+        "name: \"default-workflow\"\nsteps: []\n",
+    )
+    .unwrap();
+    fs::write(
+        recipes.join("investigation-workflow.yaml"),
+        "name: \"investigation-workflow\"\nsteps: []\n",
+    )
+    .unwrap();
+    for recipe in ISSUE_734_REQUIRED_SMART_RECIPES {
+        fs::write(
+            recipes.join(format!("{recipe}.yaml")),
+            format!("name: \"{recipe}\"\nsteps: []\n"),
+        )
+        .unwrap();
+    }
+    fs::write(
+        recipes.join("_recipe_manifest.json"),
+        r#"{
+  "smart-classify-route": "250c8da0ee348745",
+  "smart-execute-routing": "11612506ae846a47",
+  "smart-orchestrator": "8d55ee4817dbc815",
+  "smart-reflect-loop": "7b8101dfce096480",
+  "smart-validate-summarize": "007548c49e9654fb"
+}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn issue_734_copy_rejects_stale_monolithic_smart_orchestrator_without_overwriting_good_bundle() {
+    let temp = tempfile::tempdir().unwrap();
+    let claude_dir = temp.path().join(".amplihack/.claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+
+    let good_repo = temp.path().join("good-repo");
+    issue_734_create_bundle_repo(&good_repo, issue_734_compatible_smart_orchestrator());
+    directories::copy_amplifier_bundle(&good_repo, &claude_dir).unwrap();
+
+    let stale_repo = temp.path().join("stale-repo");
+    issue_734_create_bundle_repo(&stale_repo, issue_734_stale_monolithic_smart_orchestrator());
+
+    let result = directories::copy_amplifier_bundle(&stale_repo, &claude_dir);
+
+    assert!(
+        result.is_err(),
+        "stale monolithic smart-orchestrator bundles must be rejected before staging"
+    );
+    let staged_smart = fs::read_to_string(
+        temp.path()
+            .join(".amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml"),
+    )
+    .unwrap();
+    assert!(
+        staged_smart.contains("recipe: \"smart-classify-route\""),
+        "existing compatible staged bundle must remain after rejecting stale source"
+    );
+    assert!(
+        !staged_smart.contains("resolve-bundle-asset helper-path")
+            && !staged_smart.contains("importlib")
+            && !staged_smart.contains("orch_helper"),
+        "stale monolithic smart-orchestrator content must not remain staged:\n{staged_smart}"
+    );
+}
+
+#[test]
+fn issue_734_run_install_skips_stale_amplihack_home_and_stages_compatible_cwd_bundle() {
+    with_install_env(|home| {
+        let stale_home = home.join("stale-amplihack-home");
+        fs::create_dir_all(stale_home.join(".claude")).unwrap();
+        issue_734_create_bundle_repo(&stale_home, issue_734_stale_monolithic_smart_orchestrator());
+
+        let fresh_checkout = home.join("fresh-checkout");
+        issue_734_create_bundle_repo(&fresh_checkout, issue_734_compatible_smart_orchestrator());
+        let nested = fresh_checkout.join("nested/project");
+        fs::create_dir_all(&nested).unwrap();
+
+        let previous_amplihack_home = std::env::var_os("AMPLIHACK_HOME");
+        unsafe { std::env::set_var("AMPLIHACK_HOME", &stale_home) };
+        let _cwd = crate::test_support::CwdGuard::set(&nested).unwrap();
+
+        let result = run_install(None, false, false);
+
+        match previous_amplihack_home {
+            Some(value) => unsafe { std::env::set_var("AMPLIHACK_HOME", value) },
+            None => unsafe { std::env::remove_var("AMPLIHACK_HOME") },
+        }
+        result.expect(
+            "install must skip an incompatible AMPLIHACK_HOME bundle and use the compatible cwd checkout",
+        );
+
+        let staged_smart = fs::read_to_string(
+            home.join(".amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml"),
+        )
+        .unwrap();
+        for recipe in ISSUE_734_REQUIRED_SMART_RECIPES {
+            assert!(
+                staged_smart.contains(&format!("recipe: \"{recipe}\"")),
+                "staged smart-orchestrator must reference required sub-recipe {recipe}; got:\n{staged_smart}"
+            );
+            assert!(
+                home.join(format!(".amplihack/amplifier-bundle/recipes/{recipe}.yaml"))
+                    .is_file(),
+                "staged bundle must include required companion recipe {recipe}.yaml"
+            );
+        }
+        assert!(
+            !staged_smart.contains("resolve-bundle-asset helper-path")
+                && !staged_smart.contains("importlib")
+                && !staged_smart.contains("orch_helper"),
+            "stale AMPLIHACK_HOME smart-orchestrator must not remain staged:\n{staged_smart}"
+        );
+    });
 }
 
 // ============================================================================

--- a/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
@@ -1,6 +1,8 @@
 use super::helpers::*;
 use super::*;
-use crate::commands::install::bundle_compat::REQUIRED_SMART_RECIPES;
+use crate::commands::install::bundle_compat::{
+    REQUIRED_SMART_RECIPES, validate_staged_framework_bundle,
+};
 use std::fs;
 
 #[test]
@@ -732,6 +734,8 @@ fn copy_amplifier_bundle_replaces_existing_atomically() {
         staged.join("recipes/new-recipe.yaml").is_file(),
         "re-install must add new files from the source"
     );
+    validate_staged_framework_bundle(&staged)
+        .expect("post-copy destination must satisfy the framework bundle compatibility invariant");
 
     let parent = temp.path().join(".amplihack");
     assert!(

--- a/crates/amplihack-cli/src/commands/install/verification.rs
+++ b/crates/amplihack-cli/src/commands/install/verification.rs
@@ -1,5 +1,6 @@
 //! Source-derived post-install completeness verification.
 
+use super::bundle_compat::validate_staged_framework_bundle;
 use super::filesystem::walk_dirs;
 use super::types::{SOURCE_CONDITIONAL_BUNDLE_DIR_MAPPING, SourceLayout, dir_mapping};
 use anyhow::{Context, Result, bail};
@@ -113,6 +114,12 @@ fn verify_staged_bundle(
                 staged_dir.display()
             ));
         }
+    }
+    if let Err(err) = validate_staged_framework_bundle(&staged_bundle) {
+        missing.push(format!(
+            "staged amplifier-bundle compatibility check failed at {}: {err}",
+            staged_bundle.display()
+        ));
     }
     Ok(())
 }

--- a/crates/amplihack-cli/tests/issue_538_install_completeness.rs
+++ b/crates/amplihack-cli/tests/issue_538_install_completeness.rs
@@ -102,18 +102,56 @@ fn create_bundle_missing_skills(root: &Path) {
         "#!/bin/sh\necho status\n",
     )
     .expect("write statusline");
+    write_compatible_recipe_bundle(&bundle.join("recipes"));
+    fs::write(bundle.join("CLAUDE.md"), "# test bundle\n").expect("write CLAUDE.md");
+}
+
+fn write_compatible_recipe_bundle(recipes: &Path) {
+    fs::write(
+        recipes.join("smart-orchestrator.yaml"),
+        r#"name: "smart-orchestrator"
+steps:
+  - id: "smart-classify-route"
+    type: "recipe"
+    recipe: "smart-classify-route"
+  - id: "smart-execute-routing"
+    type: "recipe"
+    recipe: "smart-execute-routing"
+  - id: "smart-reflect-loop"
+    type: "recipe"
+    recipe: "smart-reflect-loop"
+  - id: "smart-validate-summarize"
+    type: "recipe"
+    recipe: "smart-validate-summarize"
+"#,
+    )
+    .expect("write smart-orchestrator recipe");
     for recipe in [
-        "smart-orchestrator.yaml",
-        "default-workflow.yaml",
-        "investigation-workflow.yaml",
+        "default-workflow",
+        "investigation-workflow",
+        "smart-classify-route",
+        "smart-execute-routing",
+        "smart-reflect-loop",
+        "smart-validate-summarize",
     ] {
         fs::write(
-            bundle.join("recipes").join(recipe),
-            "name: test\nsteps: []\n",
+            recipes.join(format!("{recipe}.yaml")),
+            format!("name: \"{recipe}\"\nsteps: []\n"),
         )
-        .expect("write recipe");
+        .expect("write companion recipe");
     }
-    fs::write(bundle.join("CLAUDE.md"), "# test bundle\n").expect("write CLAUDE.md");
+    fs::write(
+        recipes.join("_recipe_manifest.json"),
+        r#"{
+  "smart-classify-route": "250c8da0ee348745",
+  "smart-execute-routing": "11612506ae846a47",
+  "smart-orchestrator": "8d55ee4817dbc815",
+  "smart-reflect-loop": "7b8101dfce096480",
+  "smart-validate-summarize": "007548c49e9654fb"
+}
+"#,
+    )
+    .expect("write recipe manifest");
 }
 
 #[test]

--- a/crates/amplihack-cli/tests/issue_538_install_completeness.rs
+++ b/crates/amplihack-cli/tests/issue_538_install_completeness.rs
@@ -136,7 +136,9 @@ steps:
     ] {
         fs::write(
             recipes.join(format!("{recipe}.yaml")),
-            format!("name: \"{recipe}\"\nsteps: []\n"),
+            format!(
+                "name: \"{recipe}\"\nsteps:\n  - id: smoke\n    type: bash\n    command: 'true'\n"
+            ),
         )
         .expect("write companion recipe");
     }

--- a/crates/amplihack-cli/tests/issue_672_workflow_reliability_contracts.rs
+++ b/crates/amplihack-cli/tests/issue_672_workflow_reliability_contracts.rs
@@ -71,7 +71,7 @@ fn workspace_version_matches_latest_release_line() {
         .expect("workspace.package.version must exist");
 
     assert_eq!(
-        version, "0.11.0",
+        version, "0.11.1",
         "workspace.package.version must match the latest release line"
     );
 }

--- a/docs/bugfixes/bugfix-675-update-stale-bundle.md
+++ b/docs/bugfixes/bugfix-675-update-stale-bundle.md
@@ -7,10 +7,16 @@
 ## Summary
 
 After `amplihack update` downloads a new binary, the post-update install
-re-stages the **old** `amplifier-bundle/` from `~/.amplihack/` instead of
-downloading fresh framework assets from the upstream archive. This causes
+re-staged the **old** `amplifier-bundle/` from `~/.amplihack/` instead of
+downloading fresh framework assets from the upstream archive. This caused
 new binary + stale recipes, producing errors like "orch_helper.py not found"
 for users who upgraded from Python-era versions.
+
+Issue [#734](https://github.com/rysweet/amplihack-rs/issues/734) adds the
+second half of this protection: local source candidates and staged destinations
+are now validated against the smart-orchestrator compatibility contract, so a
+stale monolithic `smart-orchestrator.yaml` cannot remain staged after a
+successful install/update repair.
 
 ## Root Cause
 
@@ -22,14 +28,15 @@ and triggers post-update install, `run_install()` finds the OLD bundle at
 `~/.amplihack/` and re-stages it — the local copy wins the resolution race
 against the network download.
 
-**Resolution order before fix:**
+**Non-force-refresh local resolution order:**
 
 ```
-1. Compile-time workspace root
-2. AMPLIHACK_HOME
+1. AMPLIHACK_HOME
+2. CWD walk-up
 3. Walk-up from executable
-4. ~/.amplihack/amplifier-bundle/    ← OLD bundle found here, stops looking
-5. Network download (never reached)
+4. Compile-time workspace root
+5. ~/.amplihack/amplifier-bundle/    ← OLD bundle can be found here
+6. Network download
 ```
 
 ## Fix
@@ -43,10 +50,10 @@ a fresh bundle from `REPO_ARCHIVE_URL` (the `main.tar.gz` archive).
 
 | Caller | `force_refresh` | Behavior |
 |--------|-----------------|----------|
-| `amplihack install` (standalone) | `false` | Unchanged — prefers local bundle |
+| `amplihack install` (standalone) | `false` | Prefers compatible local sources |
 | `amplihack update` (post-update) | `true` | **Fix** — always downloads fresh |
-| Self-heal (startup check) | `false` | Unchanged — prefers local for speed |
-| `ensure_framework_installed()` | `false` | Unchanged — bootstrap prefers local |
+| Self-heal (startup check) | `false` | Re-runs install with normal compatible-source resolution |
+| `ensure_framework_installed()` | `false` | Bootstrap prefers compatible local sources |
 
 **No user-facing behavior change** for standalone `amplihack install`. The
 `--local` flag continues to take priority over `force_refresh` (returns early
@@ -101,3 +108,4 @@ amplihack install
   `run_install()` API documentation including `force_refresh`
 - [Manage Tool Update Checks](../howto/manage-tool-update-checks.md) — What
   happens during `amplihack update`
+- [Framework Bundle Compatibility](../reference/framework-bundle-compatibility.md) — stale smart-orchestrator detection and repair

--- a/docs/bugfixes/bugfix-734-stale-smart-orchestrator-bundle.md
+++ b/docs/bugfixes/bugfix-734-stale-smart-orchestrator-bundle.md
@@ -1,0 +1,186 @@
+# Bug Fix #734 — Stale smart-orchestrator bundle after v0.11.0
+
+> **Issue:** [#734](https://github.com/rysweet/amplihack-rs/issues/734)
+
+---
+
+## Summary
+
+After updating to v0.11.0, some installs kept an old
+`~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml`. The installed
+binary was current, but the staged framework bundle still contained the old
+monolithic smart-orchestrator recipe. That recipe tried to run stale
+Python/importlib orchestration behavior during `parse-decomposition`, so
+`smart-orchestrator` failed even though the source tree and release tag carried
+the correct composable recipe.
+
+The fix makes install/update validate framework bundle compatibility before
+accepting a source and after staging the destination. Stale monolithic
+smart-orchestrator assets are rejected and repaired instead of being silently
+reused.
+
+## Root cause
+
+The v0.11.0 source bundle contains the correct composable
+`smart-orchestrator.yaml`, which delegates to four sub-recipes:
+
+1. `smart-classify-route`
+2. `smart-execute-routing`
+3. `smart-reflect-loop`
+4. `smart-validate-summarize`
+
+The failing user install had a stale `AMPLIHACK_HOME` bundle where
+`recipes/smart-orchestrator.yaml` was an older monolithic file. Because local
+bundle discovery checks local candidates before downloading fresh assets, the
+stale local bundle could be selected again and re-staged when no compatibility
+gate rejected it.
+
+This was not a missing `helper-path` or missing `orch_helper.py` problem.
+`helper-path` intentionally resolves to:
+
+```text
+amplifier-bundle/bin/multitask-orchestrator.sh
+```
+
+`orch_helper.py` no longer exists and is not restored by this fix.
+
+## Fix
+
+Install now has a framework bundle compatibility validator that checks the
+smart-orchestrator contract before a bundle can be used or considered staged
+successfully.
+
+The validator requires:
+
+| Asset | Requirement |
+| --- | --- |
+| `recipes/smart-orchestrator.yaml` | Exists and is the composable parent recipe |
+| `recipes/smart-classify-route.yaml` | Exists |
+| `recipes/smart-execute-routing.yaml` | Exists |
+| `recipes/smart-reflect-loop.yaml` | Exists |
+| `recipes/smart-validate-summarize.yaml` | Exists |
+| Parent recipe steps | Reference all four companion recipes with recipe steps |
+| `recipes/_recipe_manifest.json` | Contains non-empty hash entries for `smart-orchestrator` and all four companion recipes |
+
+The check is structural. It does not use line count as a validator and does not
+pin the parent recipe to one exact content hash. Source-derived completeness
+verification still proves files and directories were copied; the compatibility
+validator proves the staged recipe set is semantically current.
+
+The validator rejects:
+
+| Stale behavior | Result |
+| --- | --- |
+| Monolithic smart-orchestrator without the four companion recipe references | Candidate skipped or install fails |
+| Python/importlib orchestration inside `smart-orchestrator.yaml` | Candidate skipped or install fails |
+| `orch_helper.py` as a current dependency | Candidate skipped or install fails |
+| Old `resolve-bundle-asset helper-path` orchestration-helper flow inside the monolithic recipe | Candidate skipped or install fails |
+
+These stale-marker checks apply to the current
+`recipes/smart-orchestrator.yaml` behavior. Historical documentation, tests, and
+bugfix notes may still mention `orch_helper.py`, `importlib`, or old
+`helper-path` usage when describing past failures.
+
+The validator treats every source as untrusted. It only reads files and never
+executes YAML, shell, Python, helper scripts, or bundle assets while deciding
+whether a bundle can be accepted. Missing, unreadable, or incomplete assets fail
+closed.
+
+## Install and update behavior
+
+`amplihack install` validates every local source candidate before accepting it.
+An incompatible `AMPLIHACK_HOME` bundle is skipped, not reused:
+
+```text
+⚠️  Skipping incompatible framework bundle at /home/alice/.amplihack:
+    recipes/smart-orchestrator.yaml is stale
+```
+
+After copying assets, install validates the staged destination. A successful
+install means the stale monolithic `smart-orchestrator.yaml` did not remain in
+`~/.amplihack/amplifier-bundle/recipes/`.
+
+`amplihack update` continues to spawn the new binary for post-update install and
+uses the hidden `--force-refresh` flag. The downloaded bundle is still validated
+before staging and after staging, so update cannot report success while leaving
+an incompatible smart-orchestrator installed.
+
+## User repair
+
+Run:
+
+```sh
+amplihack update
+```
+
+or:
+
+```sh
+amplihack install
+```
+
+Then verify the staged smart-orchestrator:
+
+```sh
+grep -E 'recipe: "(smart-classify-route|smart-execute-routing|smart-reflect-loop|smart-validate-summarize)"' \
+  ~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
+```
+
+All four companion recipes should appear.
+
+## Contributor API
+
+The validator is implemented in:
+
+```text
+crates/amplihack-cli/src/commands/install/bundle_compat.rs
+```
+
+Internal install-module functions:
+
+| Function | Purpose |
+| --- | --- |
+| `validate_framework_bundle_compatibility(root: &Path) -> Result<()>` | Validate a candidate source bundle before source discovery or copy accepts it. |
+| `validate_staged_framework_bundle(root: &Path) -> Result<()>` | Hard-fail install when the staged destination is missing or incompatible. |
+| `is_compatible_framework_bundle(root: &Path) -> bool` | Boolean helper for skipping optional local candidates during source discovery. |
+
+See the
+[framework bundle compatibility reference](../reference/framework-bundle-compatibility.md)
+for the full contract.
+
+## Regression coverage
+
+Tests prove:
+
+1. The canonical repository bundle is accepted.
+2. A stale monolithic smart-orchestrator is rejected.
+3. A stale smart-orchestrator using Python/importlib behavior is rejected.
+4. A stale smart-orchestrator using the old `resolve-bundle-asset helper-path`
+   orchestration-helper path is rejected.
+5. Missing companion recipes are rejected.
+6. Source discovery skips stale `AMPLIHACK_HOME` bundles.
+7. A stale monolithic smart-orchestrator cannot remain staged after
+   install/update repair.
+8. `helper-path` still resolves to
+   `amplifier-bundle/bin/multitask-orchestrator.sh`.
+
+Focused checks:
+
+```sh
+cargo test -p amplihack-cli bundle_compat
+cargo test -p amplihack-cli install_flow
+```
+
+Broader checks:
+
+```sh
+cargo test -p amplihack-cli
+cargo check --workspace
+```
+
+## Related
+
+- [Framework bundle compatibility reference](../reference/framework-bundle-compatibility.md)
+- [Repair a stale framework bundle](../howto/repair-stale-framework-bundle.md)
+- [Bug fix #675 — update does not refresh amplifier-bundle](bugfix-675-update-stale-bundle.md)
+- [Post-update install re-exec](../features/update-reexec-new-binary.md)

--- a/docs/concepts/idempotent-installation.md
+++ b/docs/concepts/idempotent-installation.md
@@ -74,6 +74,19 @@ amplihack install --local .
 
 Hook command strings in `settings.json` are updated to point to the newly deployed binary.
 
+### Stale bundle repair
+
+Idempotency does not mean stale framework files are preserved. Each install
+validates the selected source bundle and the staged destination. If
+`~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml` contains an old
+monolithic recipe, a successful install replaces it with the composable
+smart-orchestrator and verifies the required companion recipes are present.
+
+The repair is structural, not line-count based: the parent recipe must delegate
+to `smart-classify-route`, `smart-execute-routing`, `smart-reflect-loop`, and
+`smart-validate-summarize`. Python/importlib orchestration and current-use
+`orch_helper.py` references are rejected.
+
 ## Example: Idempotent Run Output
 
 The second run of `amplihack install` produces output identical to the first, but each phase reports "updated" rather than "created":
@@ -98,3 +111,4 @@ amplihack installed successfully.
 - [Bootstrap Parity](./bootstrap-parity.md) — why the install sequence is ordered the way it is
 - [Hook Specifications](../reference/hook-specifications.md) — the 7 hooks and their idempotency matching rules
 - [amplihack install reference](../reference/install-command.md) — full command reference
+- [Framework Bundle Compatibility](../reference/framework-bundle-compatibility.md) — stale smart-orchestrator detection and repair

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -23,6 +23,7 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 
 - [Post-Update Install — Re-exec New Binary](update-reexec-new-binary.md) — after `amplihack update` downloads a new binary, the post-update install step spawns the **new** binary as a subprocess instead of running the old binary's compiled-in install code (issue [#683](https://github.com/rysweet/amplihack-rs/issues/683)).
 - [Install/Update PATH Conflict Handling](../reference/install-update-path-conflicts.md) — detects stale system binaries that shadow `~/.local/bin`, prefers safe user-local update targets, and reports manual sudo repair guidance without attempting privileged writes.
+- [Framework Bundle Compatibility](../reference/framework-bundle-compatibility.md) — validates smart-orchestrator source and staged bundles so stale monolithic recipes cannot survive install/update repair (issue [#734](https://github.com/rysweet/amplihack-rs/issues/734)).
 - [Startup Self-Update Prompt — Subprocess-Safe Skip](startup-update-prompt-subprocess-safe.md) — startup self-update prompt skips automatically in CI, delegated agents, non-TTY stdin, with `--subprocess-safe`, or when `AMPLIHACK_NONINTERACTIVE` / `AMPLIHACK_AGENT_BINARY` is set; emits a single skip-line to stderr (issue [#625](https://github.com/rysweet/amplihack-rs/issues/625)).
 
 ## Workflow Recovery

--- a/docs/features/self-heal-asset-restage.md
+++ b/docs/features/self-heal-asset-restage.md
@@ -32,10 +32,12 @@ Every launch, before command dispatch, `amplihack` performs a startup-time
    `amplihack install` automatically (equivalent to
    `commands::install::run_install(None, false, false)`).
    The third argument (`force_refresh: false`) means self-heal prefers the
-   local `~/.amplihack/amplifier-bundle/` if it exists, falling back to a
-   network download only when no local source is found. This keeps startup
-   fast for the common case. For the post-update install path (where the
-   **new** binary is spawned as a subprocess with `--force-refresh`), see
+   compatible local source selected by normal install source resolution,
+   falling back to a network download only when no compatible local source is
+   found. Self-heal does not perform a separate startup compatibility scan; the
+   automatic install run validates candidate and staged framework bundles. For
+   the post-update install path (where the **new** binary is spawned as a
+   subprocess with `--force-refresh`), see
    [Post-Update Install — Re-exec New Binary](update-reexec-new-binary.md).
 4. On success, write the new version into the stamp file and emit a single
    line on stderr:

--- a/docs/features/update-reexec-new-binary.md
+++ b/docs/features/update-reexec-new-binary.md
@@ -88,7 +88,10 @@ amplihack update
    `amplihack install --force-refresh`, a hidden CLI flag that forces a fresh
    network download of `amplifier-bundle/` assets instead of reusing stale
    local copies. This flag is not shown in `--help` output; it exists solely
-   for the update→install subprocess path.
+   for the update→install subprocess path. The downloaded source and staged
+   destination are still validated by the framework bundle compatibility
+   checker, including the composable smart-orchestrator contract added for
+   issue [#734](https://github.com/rysweet/amplihack-rs/issues/734).
 
 3. **Recursion prevention** — The subprocess environment includes
    `AMPLIHACK_NO_UPDATE_CHECK=1`, which prevents the child `amplihack install`
@@ -126,7 +129,8 @@ amplihack update --skip-install
 
 Users can then run `amplihack install` manually at a time of their choosing.
 The [self-heal](self-heal-asset-restage.md) mechanism will also catch the
-version mismatch on the next launch and trigger an automatic re-install.
+version mismatch on the next launch and trigger an automatic re-install when
+the version stamp still indicates the framework was not staged successfully.
 
 ## Failure modes
 
@@ -140,7 +144,8 @@ Error: post-update install subprocess /home/user/.local/bin/amplihack exited wit
 
 The binary update itself has already succeeded. The user can re-run
 `amplihack install` manually. The self-heal mechanism will also retry
-automatically on the next `amplihack` invocation.
+automatically on the next `amplihack` invocation when the version stamp still
+requires an install.
 
 ### New binary missing or not executable
 
@@ -180,6 +185,7 @@ include the unrecognized flag name.
 | `crates/amplihack-cli/src/commands/install/binary.rs` | Deploys user-local binaries and invokes PATH conflict analysis for install-time warnings. |
 | `crates/amplihack-cli/src/commands/install/paths.rs` | Owns user-local path construction and safe path helpers reused by install/update target selection. |
 | `crates/amplihack-cli/src/commands/install/settings.rs` | Keeps hook registrations aligned with the selected `amplihack-hooks` binary path. |
+| `crates/amplihack-cli/src/commands/install/bundle_compat.rs` | Validates source and staged framework bundles so stale smart-orchestrator assets cannot be accepted or remain installed. |
 | `crates/amplihack-cli/src/cli_commands.rs` | `Commands::Install` gains a hidden `--force-refresh` flag (`#[arg(long = "force-refresh", hide = true)]`). |
 | `crates/amplihack-cli/src/commands/mod.rs` | Destructures and passes `force_refresh` through to `run_install`. |
 | `crates/amplihack-cli/src/update/post_install.rs` | Unchanged. The closure injection pattern continues to work — the closure now spawns a subprocess instead of calling `run_install`. |
@@ -198,6 +204,7 @@ No new crate dependencies introduced.
 | Existing `run_post_update_install` tests | `update/post_install.rs` | Skip-install bypass, closure invocation, error propagation — all still pass unchanged |
 | PATH conflict resolver tests | `path_conflicts.rs` | User-bin first, system-bin shadowing, duplicate candidates, safe user-bin preference, and manual repair decisions |
 | Install/update smoke output assertions | install/update tests | Normal output excludes stale hook-file `❌` lines, `profile_management` warnings, and literal `Skipping symlink` noise |
+| Bundle compatibility tests | `commands/install/bundle_compat.rs` and install-flow tests | Stale monolithic smart-orchestrator bundles are rejected; missing companion recipes fail; stale `AMPLIHACK_HOME` is skipped; staged repair cannot leave stale `smart-orchestrator.yaml` behind |
 
 ## Interaction with related features
 
@@ -210,9 +217,13 @@ automatically. The self-heal path calls `run_install` **in-process** (not
 via subprocess), which is correct because there is no binary replacement in
 flight — the running binary IS the new binary by that point.
 
-The self-heal doc's reference to the post-update install path (line 37–39,
-`force_refresh: true`) remains accurate — the subprocess passes
-`--force-refresh` which has the same semantic effect.
+Self-heal does not perform a separate startup-time framework compatibility
+scan. When it re-runs install, that install run uses the same source and staged
+bundle compatibility validation as an explicit `amplihack install`.
+
+The post-update install subprocess still passes `--force-refresh`, so update
+continues to bypass local bundle reuse and validate the downloaded source and
+staged destination.
 
 ### Startup self-update prompt
 

--- a/docs/howto/repair-stale-framework-bundle.md
+++ b/docs/howto/repair-stale-framework-bundle.md
@@ -1,0 +1,182 @@
+---
+title: Repair a stale framework bundle
+description: Diagnose and repair an install where the binary is current but smart-orchestrator recipes are stale.
+last_updated: 2026-06-10
+review_schedule: as-needed
+owner: amplihack-maintainers
+doc_type: howto
+---
+
+# Repair a stale framework bundle
+
+Use this guide when `amplihack --version` shows a current release but
+`amplihack recipe run smart-orchestrator` fails with old recipe behavior,
+especially Python/importlib errors or `orch_helper.py`-style failures.
+
+Current installs validate and repair this automatically. A successful
+`amplihack install` or post-update install replaces stale
+`smart-orchestrator.yaml` assets with the canonical composable recipe and its
+four companion recipes.
+
+## Symptoms
+
+Common symptoms of a stale bundle:
+
+```text
+parse-decomposition failed
+```
+
+```text
+orch_helper.py not found
+```
+
+```text
+ModuleNotFoundError: No module named ...
+```
+
+```text
+resolve-bundle-asset helper-path
+```
+
+The last string is only a stale smart-orchestrator symptom when it appears
+inside the old monolithic recipe execution path. `helper-path` remains a valid
+asset name and correctly resolves to
+`amplifier-bundle/bin/multitask-orchestrator.sh`.
+
+## Repair with install
+
+Run install from the current binary:
+
+```sh
+amplihack install
+```
+
+The installer validates local bundle candidates before using them. If
+`AMPLIHACK_HOME` contains a stale `amplifier-bundle/`, install skips it and uses
+the next compatible local source or a fresh download.
+
+Expected behavior when a stale local bundle is found:
+
+```text
+⚠️  Skipping incompatible framework bundle at /home/alice/.amplihack:
+    recipes/smart-orchestrator.yaml is stale
+✓ Staged framework assets
+✓ Verified staged framework assets
+amplihack installed successfully.
+```
+
+## Repair after update
+
+Normally, no manual step is required:
+
+```sh
+amplihack update
+```
+
+After replacing the binary, update runs:
+
+```sh
+amplihack install --force-refresh
+```
+
+The hidden `--force-refresh` flag downloads fresh framework assets, validates
+the source bundle, stages it, then validates the staged destination. If the
+post-update install fails, the binary update has still completed; run
+`amplihack install` manually to retry the asset repair.
+
+## Repair from a local checkout
+
+Use `--local` when you intentionally want to install from a checkout:
+
+```sh
+cd /path/to/amplihack-rs
+cargo build --release
+./target/release/amplihack install --local .
+```
+
+The local checkout must contain a compatible `amplifier-bundle/`. The installer
+does not trust `--local` blindly; stale or incomplete smart-orchestrator assets
+cause install to fail with an actionable compatibility error.
+
+## Verify the repaired smart-orchestrator
+
+Confirm the staged parent recipe delegates to the four companion recipes:
+
+```sh
+grep -E 'recipe: "(smart-classify-route|smart-execute-routing|smart-reflect-loop|smart-validate-summarize)"' \
+  ~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
+```
+
+Expected output includes all four recipes:
+
+```text
+recipe: "smart-classify-route"
+recipe: "smart-execute-routing"
+recipe: "smart-reflect-loop"
+recipe: "smart-validate-summarize"
+```
+
+Confirm the companion recipes are present:
+
+```sh
+for recipe in smart-classify-route smart-execute-routing smart-reflect-loop smart-validate-summarize; do
+  test -f "$HOME/.amplihack/amplifier-bundle/recipes/${recipe}.yaml" \
+    && echo "ok: ${recipe}"
+done
+```
+
+Confirm `helper-path` still resolves to the multitask wrapper:
+
+```sh
+amplihack resolve-bundle-asset helper-path
+```
+
+Expected suffix:
+
+```text
+amplifier-bundle/bin/multitask-orchestrator.sh
+```
+
+## Verify by running smart-orchestrator
+
+Run a minimal Q&A task:
+
+```sh
+amplihack recipe run smart-orchestrator \
+  -c task_description="What is 2+2?" \
+  -c repo_path=.
+```
+
+The recipe should enter the composable flow:
+
+```text
+smart-classify-route
+smart-execute-routing
+smart-reflect-loop
+smart-validate-summarize
+```
+
+It should not attempt to import Python orchestration helpers or reference
+`orch_helper.py`.
+
+## If install still fails
+
+Capture the compatibility error and the resolved paths:
+
+```sh
+amplihack --version
+which -a amplihack
+echo "AMPLIHACK_HOME=${AMPLIHACK_HOME:-$HOME/.amplihack}"
+amplihack install 2>&1 | tee /tmp/amplihack-install.log
+```
+
+Do not repair this by copying `orch_helper.py` into the bundle or remapping
+`helper-path` to a Python file. Those actions recreate the stale behavior that
+the installer is designed to reject.
+
+## See also
+
+- [Framework bundle compatibility reference](../reference/framework-bundle-compatibility.md)
+- [Install completeness verification](../reference/install-completeness.md)
+- [Post-update install re-exec](../features/update-reexec-new-binary.md)
+- [resolve-bundle-asset command reference](../reference/resolve-bundle-asset-command.md)

--- a/docs/howto/repair-stale-framework-bundle.md
+++ b/docs/howto/repair-stale-framework-bundle.md
@@ -167,7 +167,7 @@ Capture the compatibility error and the resolved paths:
 amplihack --version
 which -a amplihack
 echo "AMPLIHACK_HOME=${AMPLIHACK_HOME:-$HOME/.amplihack}"
-amplihack install 2>&1 | tee /tmp/amplihack-install.log
+amplihack install 2>&1 | tee ./amplihack-install.log
 ```
 
 Do not repair this by copying `orch_helper.py` into the bundle or remapping

--- a/docs/howto/troubleshoot-recipe-execution.md
+++ b/docs/howto/troubleshoot-recipe-execution.md
@@ -11,6 +11,7 @@ Use this guide when a recipe step fails unexpectedly — a shell step hangs, an 
 - [Workflow step requires a Git repository](#workflow-step-requires-a-git-repository)
 - [Agent step killed by step timeout](#agent-step-killed-by-step-timeout)
 - [Update completes but assets are stale](#update-completes-but-assets-are-stale)
+- [smart-orchestrator fails after update with stale Python behavior](#smart-orchestrator-fails-after-update-with-stale-python-behavior)
 - [Install fails after switching to the Rust repository](#install-fails-after-switching-to-the-rust-repository)
 - [Step-08c fails with WORKTREE_SETUP_WORKTREE_PATH not set](#step-08c-fails-with-worktree_setup_worktree_path-not-set)
 - [Step-08c rejects a valid verdict synonym](#step-08c-rejects-a-valid-verdict-synonym)
@@ -240,7 +241,7 @@ If `AMPLIHACK_STEP_TIMEOUT` is set in your shell or CI environment, unset it (`u
 
 ## Update completes but assets are stale
 
-**Symptom:** After running `amplihack update`, the binary version is correct but skills, hooks, or bundled assets show old behavior. Running `amplihack install` manually fixes it.
+**Symptom:** After running `amplihack update`, the binary version is correct but skills, hooks, recipes, or bundled assets show old behavior. Running `amplihack install` manually fixes it.
 
 **Cause:** The update command replaced the binary but did not re-stage framework assets from the new binary's embedded `amplifier-bundle/`.
 
@@ -262,6 +263,61 @@ amplihack --version
 ls ~/.amplihack/.claude/
 # Asset files should have recent timestamps matching the update time
 ```
+
+Since issue #734, the install/update path also validates smart-orchestrator
+compatibility before accepting local bundle candidates and after staging the
+destination. Stale `AMPLIHACK_HOME` bundles are skipped or repaired instead of
+being silently reused.
+
+---
+
+## smart-orchestrator fails after update with stale Python behavior
+
+**Symptom:** `amplihack recipe run smart-orchestrator` fails during
+`parse-decomposition` after update. The installed
+`~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml` may be a large
+old monolithic recipe and may mention Python/importlib, `orch_helper.py`, or an
+old `resolve-bundle-asset helper-path` orchestration-helper path.
+
+**Cause:** The binary is current, but `AMPLIHACK_HOME` still contains stale
+framework bundle assets from an older release. The current smart-orchestrator is
+a composable parent recipe that delegates to four companion recipes:
+
+```text
+smart-classify-route
+smart-execute-routing
+smart-reflect-loop
+smart-validate-summarize
+```
+
+**Fix:** Run install or update with a version that includes the framework bundle
+compatibility validator:
+
+```sh
+amplihack update
+# or
+amplihack install
+```
+
+The installer validates candidate bundles before selecting them. A stale
+`AMPLIHACK_HOME` bundle is skipped, and a successful install validates that the
+staged destination contains the composable smart-orchestrator and all required
+companion recipes.
+
+**Verify:**
+
+```sh
+grep -E 'recipe: "(smart-classify-route|smart-execute-routing|smart-reflect-loop|smart-validate-summarize)"' \
+  ~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
+```
+
+All four recipes should be present.
+
+Do not repair this by restoring `orch_helper.py`. Do not remap `helper-path` to
+`orch_helper.py`. `helper-path` intentionally resolves to
+`amplifier-bundle/bin/multitask-orchestrator.sh`.
+
+See [Repair a stale framework bundle](repair-stale-framework-bundle.md).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,7 @@ Centralized plugin system that works across all your projects:
 - [Quick Start](../README.md) - Basic usage and first commands
 - [PATH Conflict Tutorial](tutorials/repair-install-update-path-conflicts.md) - Learn why stale system binaries can shadow current user-local installs
 - [Repair Install/Update PATH Conflicts](howto/repair-install-update-path-conflicts.md) - Fix stale `/usr/local/bin` binaries that shadow current `~/.local/bin` installs
+- [Repair a Stale Framework Bundle](howto/repair-stale-framework-bundle.md) - Fix installs where the binary is current but smart-orchestrator recipes are stale
 
 ### Configuration
 
@@ -149,6 +150,7 @@ amplihack copilot
 - [Release Installation](howto/first-install.md) - Install from published binaries or source
 - [Install Manifest](reference/install-manifest.md) - Understand installed files and uninstall state
 - [Install/Update PATH Conflict Reference](reference/install-update-path-conflicts.md) - Target selection, PATH analysis, and output regression guarantees
+- [Framework Bundle Compatibility](reference/framework-bundle-compatibility.md) - Smart-orchestrator compatibility contract and stale bundle repair behavior
 - [Azure Integration](AZURE_INTEGRATION.md) - Deploy to Azure cloud
 
 ---

--- a/docs/reference/framework-bundle-compatibility.md
+++ b/docs/reference/framework-bundle-compatibility.md
@@ -1,0 +1,330 @@
+---
+title: Framework bundle compatibility reference
+description: Compatibility contract for install/update framework bundles, smart-orchestrator recipes, and stale bundle repair.
+last_updated: 2026-06-10
+review_schedule: as-needed
+owner: amplihack-maintainers
+doc_type: reference
+---
+
+# Framework bundle compatibility reference
+
+`amplihack install` and `amplihack update` validate the framework bundle before
+accepting it as an install source and after staging it under `AMPLIHACK_HOME`.
+Startup self-heal does not run a separate compatibility scan; when the
+version-stamp safety net re-runs install, that install path inherits the same
+validation.
+
+The validator protects users from mixed-version installs where the binary is
+current but `~/.amplihack/amplifier-bundle/` still contains stale recipes from an
+older release. This specifically covers issue
+[#734](https://github.com/rysweet/amplihack-rs/issues/734), where a stale
+monolithic `smart-orchestrator.yaml` remained installed after v0.11.0 and failed
+during `parse-decomposition`.
+
+## Compatibility contract
+
+A framework bundle is compatible only when its `amplifier-bundle/` tree satisfies
+the current smart-orchestrator contract.
+
+Required files:
+
+| Path | Required role |
+| --- | --- |
+| `amplifier-bundle/recipes/smart-orchestrator.yaml` | Composable parent recipe |
+| `amplifier-bundle/recipes/smart-classify-route.yaml` | Classification, preflight, decomposition, activation, and session setup |
+| `amplifier-bundle/recipes/smart-execute-routing.yaml` | Q&A, operations, development, investigation, parallel, fallback, and adaptive routing |
+| `amplifier-bundle/recipes/smart-reflect-loop.yaml` | Goal-seeking reflection loop |
+| `amplifier-bundle/recipes/smart-validate-summarize.yaml` | Outside-in validation, summary, and completion |
+| `amplifier-bundle/recipes/_recipe_manifest.json` | Recipe manifest containing non-empty hash entries for `smart-orchestrator` and all four companion recipes |
+
+The parent recipe must be the composable smart-orchestrator:
+
+```yaml
+name: "smart-orchestrator"
+steps:
+  - id: "smart-classify-route"
+    type: "recipe"
+    recipe: "smart-classify-route"
+  - id: "smart-execute-routing"
+    type: "recipe"
+    recipe: "smart-execute-routing"
+  - id: "smart-reflect-loop"
+    type: "recipe"
+    recipe: "smart-reflect-loop"
+  - id: "smart-validate-summarize"
+    type: "recipe"
+    recipe: "smart-validate-summarize"
+```
+
+The validator checks structure and required references, not line count. Future
+valid changes may add comments, context keys, or metadata without breaking
+compatibility, as long as the parent recipe still delegates to the four required
+sub-recipes.
+
+The recipe manifest must also contain entries for:
+
+```text
+smart-orchestrator
+smart-classify-route
+smart-execute-routing
+smart-reflect-loop
+smart-validate-summarize
+```
+
+Each entry must have a non-empty hash value. The validator uses this as a
+bundle-manifest sanity check; it does not require one exact recipe file hash.
+
+This is also not an exact content-hash pin. The install path still uses
+source-derived manifest verification to prove required directories were copied,
+but smart-orchestrator compatibility is a structural/content contract. A bundle
+may pass file-presence manifest checks and still fail this validator when the
+recipe content is stale.
+
+## Rejected stale patterns
+
+The installer rejects any candidate or staged bundle whose
+`smart-orchestrator.yaml` matches known incompatible monolithic behavior.
+
+Rejected examples include:
+
+| Pattern | Why it is rejected |
+| --- | --- |
+| A single large monolithic `smart-orchestrator.yaml` that does not delegate to the four sub-recipes | It bypasses the v0.11.0 composable smart-orchestrator contract. |
+| `resolve-bundle-asset helper-path` inside `smart-orchestrator.yaml` as part of old orchestration-helper execution | This belongs to the stale monolithic recipe path and must not remain installed. |
+| Python `importlib` orchestration in `smart-orchestrator.yaml` | The recipe is stale and predates the Rust-native/composable workflow split. |
+| References to `orch_helper.py` as a current smart-orchestrator dependency | `orch_helper.py` no longer exists and must not be restored. |
+
+These stale-marker checks are scoped to
+`amplifier-bundle/recipes/smart-orchestrator.yaml`. Historical documentation,
+tests, or bugfix notes may still mention `orch_helper.py`, `importlib`, or old
+helper-path behavior as examples of stale failures; those references do not
+make the bundle incompatible.
+
+`helper-path` remains a valid named bundle asset, but it resolves to the native
+multitask wrapper:
+
+```text
+helper-path -> amplifier-bundle/bin/multitask-orchestrator.sh
+```
+
+Do not remap `helper-path` to `orch_helper.py`. Do not reintroduce
+`orch_helper.py` to make stale recipes pass validation.
+
+## Source selection behavior
+
+Every local framework source candidate is validated before use.
+
+Default source resolution for `amplihack install`:
+
+| Priority | Candidate | Compatibility behavior |
+| --- | --- | --- |
+| 1 | `AMPLIHACK_HOME` | Explicit user-configured source. Skipped when stale or incompatible. |
+| 2 | Current-working-directory walk-up | Finds the checkout the user is installing from. Used only when compatible. |
+| 3 | Executable-path walk-up | Finds in-tree development binaries under `target/`. Used only when compatible. |
+| 4 | Compile-time workspace root | Fallback for `cargo run`-style invocations. Used only when compatible. |
+| 5 | `~/.amplihack` | Prior staged install location. Skipped when stale or incompatible. |
+| 6 | Network download | Used when no compatible local bundle is available or `--force-refresh` is active. |
+
+An incompatible local candidate does not win the resolution race merely because
+it exists. The installer reports the skipped candidate and continues to the next
+source. If no compatible source can be found or downloaded, install fails.
+
+`amplihack update` runs the new binary as:
+
+```sh
+amplihack install --force-refresh
+```
+
+The hidden `--force-refresh` flag bypasses local source selection and downloads
+fresh framework assets. The downloaded source is still validated before staging,
+and the staged destination is validated after copy.
+
+## Staging behavior
+
+Framework staging is fail-closed:
+
+1. Validate the selected source bundle.
+2. Copy the bundle into the install staging area.
+3. Validate the staged `AMPLIHACK_HOME/amplifier-bundle/`.
+4. Run source-derived install completeness verification.
+5. Persist uninstall manifest and version-success metadata only after the bundle
+   and mapped assets are valid.
+
+If a stale monolithic `smart-orchestrator.yaml` exists at the destination before
+install, a successful install replaces it with the canonical composable recipe.
+The stale file cannot remain staged after a successful install/update repair.
+
+## User-facing diagnostics
+
+When a local candidate is skipped:
+
+```text
+⚠️  Skipping incompatible framework bundle at /home/alice/.amplihack:
+    recipes/smart-orchestrator.yaml is stale: expected composable sub-recipes
+    smart-classify-route, smart-execute-routing, smart-reflect-loop,
+    smart-validate-summarize
+```
+
+When the staged destination fails validation:
+
+```text
+install failed: staged framework bundle is incompatible:
+  /home/alice/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
+  contains stale monolithic smart-orchestrator behavior
+```
+
+When a companion recipe is missing:
+
+```text
+install failed: framework bundle is incompatible:
+  missing required smart-orchestrator companion recipe:
+  amplifier-bundle/recipes/smart-reflect-loop.yaml
+```
+
+Diagnostics include the path and the failed contract. They do not dump full
+recipe contents or environment variables.
+
+## Security model
+
+Framework bundle candidates are treated as untrusted until validation succeeds,
+whether they come from `AMPLIHACK_HOME`, a local checkout, the executable path,
+the compile-time workspace root, `~/.amplihack`, `--local`, or a download.
+
+The compatibility validator only reads files. It does not execute YAML, shell,
+Python, helper scripts, or bundle assets while deciding whether a source can be
+used. Unreadable files, missing companion recipes, and incomplete bundle roots
+fail closed with an explicit error instead of falling back to success-shaped
+defaults.
+
+## Manifest and checksum policy
+
+Framework compatibility validation complements install completeness verification;
+it does not replace it.
+
+| Check | Purpose | Failure mode |
+| --- | --- | --- |
+| Source-derived completeness manifest | Confirms required source directories, child directories, skills, and staged bundle paths were copied. | Missing or partial files/directories fail install. |
+| Smart-orchestrator compatibility validator | Confirms the copied recipes satisfy the current composable contract. | Stale monolithic or incomplete smart-orchestrator assets fail install. |
+| Release archive checksum | Confirms downloaded binaries or archives match the expected remote artifact when that download path provides checksums. | Download/update fails before install staging. |
+
+Do not use a hard-coded SHA-256 of `smart-orchestrator.yaml` as the primary
+compatibility gate. Exact hashes are too strict for harmless comments or
+metadata changes and too weak as the only staged-state check because a matching
+parent file does not prove the required companion recipes were staged. Use the
+structural contract and companion-recipe presence checks instead.
+
+## Configuration
+
+No new configuration is required.
+
+| Input | Effect |
+| --- | --- |
+| `AMPLIHACK_HOME` | Selects the install/staging root. A bundle under this root is validated before it can be reused. |
+| `--local <PATH>` | Uses a caller-provided source path. The path is still validated and fails if incompatible. |
+| `--force-refresh` | Hidden install flag used by post-update install. Bypasses local source candidates, downloads a fresh bundle, then validates source and staged destination. |
+| `AMPLIHACK_SKIP_AUTO_INSTALL` | Suppresses startup self-heal. It does not disable explicit install/update compatibility validation. |
+
+## Contributor API
+
+The install compatibility validator lives in
+`crates/amplihack-cli/src/commands/install/bundle_compat.rs`.
+
+### `validate_framework_bundle_compatibility(root: &Path) -> Result<()>`
+
+Validates a candidate framework source before install accepts it.
+
+Use this before returning a path from source discovery or before copying from a
+user-provided `--local` path.
+
+The `root` may be either:
+
+| Accepted root | Example |
+| --- | --- |
+| Repository root containing `amplifier-bundle/` | `/src/amplihack-rs` |
+| Bundle root itself | `/src/amplihack-rs/amplifier-bundle` |
+
+The function resolves the bundle root internally and returns an error when the
+smart-orchestrator contract is not satisfied.
+
+### `validate_staged_framework_bundle(root: &Path) -> Result<()>`
+
+Validates the staged bundle after copy and atomic replacement.
+
+Use this against the installed Amplihack home, normally:
+
+```text
+~/.amplihack/amplifier-bundle/
+```
+
+This check is a hard install failure. It prevents copy bugs, stale destination
+files, or partial staging from being reported as success.
+
+### `is_compatible_framework_bundle(root: &Path) -> bool`
+
+Boolean helper for source discovery.
+
+Use this when scanning optional local candidates such as `AMPLIHACK_HOME` or an
+executable walk-up path. A `false` result means "do not select this candidate";
+the caller may continue to the next candidate or fall back to network download.
+
+Do not use this helper for final staging verification. Final verification should
+call `validate_staged_framework_bundle()` so the user receives the actionable
+error.
+
+### `BundleCompatibilityError`
+
+Structured error used by the validator. Error messages are stable enough for
+diagnostics and tests, but callers should branch on variants rather than parsing
+human text.
+
+Expected variants:
+
+| Variant | Meaning |
+| --- | --- |
+| `MissingBundleRoot` | No `amplifier-bundle/` directory was found from the provided root. |
+| `MissingSmartOrchestrator` | `recipes/smart-orchestrator.yaml` is absent. |
+| `MissingCompanionRecipe` | One of the four required `smart-*` companion recipes is absent. |
+| `IncompatibleSmartOrchestrator` | The parent recipe does not delegate to the required companion recipes. |
+| `StaleSmartOrchestrator` | Known stale monolithic, Python/importlib, `orch_helper.py`, or old `helper-path` orchestration behavior was detected. |
+| `UnreadableRecipe` | A required recipe file exists but cannot be read. |
+
+## Regression coverage
+
+Tests cover:
+
+1. The repository's canonical `amplifier-bundle/recipes/smart-orchestrator.yaml`
+   is accepted.
+2. A stale monolithic smart-orchestrator using old Python/importlib behavior is
+   rejected.
+3. A stale smart-orchestrator that references `resolve-bundle-asset helper-path`
+   as an orchestration helper is rejected.
+4. A bundle missing any required companion recipe is rejected.
+5. Source discovery skips a stale `AMPLIHACK_HOME` bundle and continues to a
+   compatible source.
+6. Install/update repair replaces a staged stale monolithic
+   `smart-orchestrator.yaml`; it cannot remain staged after success.
+7. `helper-path` continues to resolve to
+   `amplifier-bundle/bin/multitask-orchestrator.sh`.
+
+Focused validation:
+
+```sh
+cargo test -p amplihack-cli bundle_compat
+cargo test -p amplihack-cli install_flow
+```
+
+Workspace validation:
+
+```sh
+cargo test -p amplihack-cli
+cargo check --workspace
+```
+
+## See also
+
+- [amplihack install / uninstall command reference](install-command.md)
+- [Install completeness verification](install-completeness.md)
+- [Post-update install re-exec](../features/update-reexec-new-binary.md)
+- [Repair a stale framework bundle](../howto/repair-stale-framework-bundle.md)
+- [resolve-bundle-asset command reference](resolve-bundle-asset-command.md)

--- a/docs/reference/install-command.md
+++ b/docs/reference/install-command.md
@@ -11,9 +11,11 @@ amplihack uninstall
 
 Bootstraps the amplihack environment on the current machine. On first run, it performs full setup: locates the bundled framework source (or falls back to network download), deploys native binaries, stages framework assets, and registers Claude Code hooks. Subsequent runs are idempotent — they update existing registrations in place without duplication.
 
-Since issue #254, framework assets are bundled in the amplihack-rs source tree. The installer resolves the framework source in this order: (1) compile-time workspace root, (2) `AMPLIHACK_HOME`, (3) walk-up from executable, (4) `~/.amplihack`, (5) network download from upstream (legacy fallback).
+Since issue #254, framework assets are bundled in the amplihack-rs source tree. The installer resolves the framework source in this order: (1) `AMPLIHACK_HOME`, (2) current-working-directory walk-up, (3) executable-path walk-up, (4) compile-time workspace root, (5) `~/.amplihack`, (6) network download from upstream (legacy fallback).
 
-Since issue #675, the post-update installer bypasses steps 1–4 and always downloads a fresh bundle from the network (step 5). This prevents stale `amplifier-bundle/` assets at `~/.amplihack/` from being re-staged after a binary update. Standalone `amplihack install` still uses the original resolution order.
+Since issue #675, the post-update installer bypasses local source selection and always downloads a fresh bundle from the network. This prevents stale `amplifier-bundle/` assets at `~/.amplihack/` from being re-staged after a binary update.
+
+Since issue #734, every local framework source candidate is also checked for smart-orchestrator compatibility before it can be selected. Standalone `amplihack install` still uses the resolver order above, but stale or incompatible local bundles are skipped instead of being reused. See [Framework bundle compatibility](./framework-bundle-compatibility.md).
 
 You can invoke the same command through the npm wrapper package when desired:
 
@@ -24,7 +26,7 @@ npx --yes --package=git+https://github.com/rysweet/amplihack-rs.git -- amplihack
 The wrapper only changes how the native binaries are obtained. Once it hands off
 to the Rust CLI, the install phases below are unchanged.
 
-See [Install Completeness Verification](./install-completeness.md) for the hard-fail contract that prevents partial framework staging from being reported as a successful install.
+See [Install Completeness Verification](./install-completeness.md) for the hard-fail contract that prevents partial framework staging from being reported as a successful install. See [Framework bundle compatibility](./framework-bundle-compatibility.md) for the smart-orchestrator compatibility contract that prevents stale recipe bundles from being accepted.
 
 Published release archives currently cover Linux and macOS on `x64`/`arm64`.
 On Windows, or any other platform without a published release target, the npm
@@ -36,9 +38,9 @@ fall back to a source build.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--interactive` | `bool` | `false` | Launch a guided setup wizard that prompts for default tool, hook scope, and update-check preference. Requires a TTY; falls back to defaults with a warning if stdin is not a terminal. See [Interactive Install](../howto/interactive-install.md). |
-| `--local <PATH>` | `PathBuf` | absent | Install from a specific local directory instead of using the bundled source. The path must exist, be a directory, and contain a `.claude` subdirectory (at `<PATH>/.claude` or `<PATH>/../.claude`). Without `--local`, the installer uses bundled framework assets from the amplihack-rs source tree. |
+| `--local <PATH>` | `PathBuf` | absent | Install from a specific local directory instead of using the bundled source. The path must exist, be a directory, contain a framework root marker, and pass framework bundle compatibility validation. Without `--local`, the installer uses compatible bundled framework assets from the amplihack-rs source tree or falls back to download. |
 | `--verbose` | `bool` | `false` | Accepted for diagnostic scripts. The install command already emits phase-level diagnostics by default. |
-| `--force-refresh` | `bool` | `false` | **Hidden.** Forces a fresh network download of `amplifier-bundle/` assets, bypassing the local source resolution order (steps 1–4). Used internally by `amplihack update` when spawning the new binary as a post-update install subprocess. Not shown in `--help` output. See [Post-Update Install — Re-exec New Binary](../features/update-reexec-new-binary.md). |
+| `--force-refresh` | `bool` | `false` | **Hidden.** Forces a fresh network download of `amplifier-bundle/` assets, bypassing local source resolution. Used internally by `amplihack update` when spawning the new binary as a post-update install subprocess. Not shown in `--help` output. See [Post-Update Install — Re-exec New Binary](../features/update-reexec-new-binary.md). |
 
 The `--interactive` and `--local` flags compose: `--interactive` controls configuration preferences while `--local` controls the framework source path.
 
@@ -49,7 +51,8 @@ The `--interactive` and `--local` flags compose: `--interactive` controls config
 | `0` | Install completed successfully |
 | `1` | `amplihack-hooks` binary not found after 5-step search |
 | `1` | `--local` path does not exist or is not a directory |
-| `1` | `--local` path does not contain a `.claude` directory |
+| `1` | `--local` path does not contain a framework root marker |
+| `1` | selected framework bundle is stale or incompatible |
 | `1` | Framework archive download or extraction failed (non-local mode only) |
 
 Note: A Node.js version below v24 does **not** cause a non-zero exit from `amplihack install`. It produces a warning at the Copilot plugin step. By contrast, `amplihack copilot` exits with code 1 if Node.js < v24. See [Node.js Version Checking](./node-version-checking.md).
@@ -60,10 +63,10 @@ Note: A Node.js version below v24 does **not** cause a non-zero exit from `ampli
 amplihack install [--interactive]
 │
 ├── 0. maybe_run_wizard()         — if --interactive, prompt for tool/scope/update prefs (skipped otherwise)
-├── 1. Bundled source, --local path, OR GitHub fallback — obtain framework source
+├── 1. Bundled source, --local path, OR GitHub fallback — obtain compatible framework source
 ├── 2. deploy_binaries()          — copy amplihack + amplihack-hooks (+ asset resolver when present) to ~/.local/bin
 ├── 2b. analyze PATH conflicts    — warn if stale earlier PATH entries shadow ~/.local/bin
-├── 3. copy framework assets      — stage mapped framework assets to ~/.amplihack/.claude/
+├── 3. copy framework assets      — validate source, stage mapped framework assets, validate staged bundle
 ├── 4. create_runtime_dirs()      — create runtime/ subdirs with 0o755 permissions
 ├── 5. ensure_settings_json()     — backup settings.json, register hooks, set permissions
 ├── 6. verify_framework_assets()  — confirm required staged framework assets exist
@@ -190,19 +193,57 @@ The `force_refresh` parameter controls framework source resolution:
 
 | `force_refresh` | Behavior |
 |-----------------|----------|
-| `false` | **Default.** Resolves the bundled framework root from the amplihack-rs source tree (compile-time path, `AMPLIHACK_HOME`, executable walk-up, `~/.amplihack`). Falls back to network download only when no local source is found. This is the behavior for standalone `amplihack install` and self-heal. |
-| `true` | **Skips local bundle resolution entirely.** Goes directly to `download_and_extract_framework_repo()` to fetch a fresh `amplifier-bundle/` from the upstream archive (`REPO_ARCHIVE_URL`). Used by the post-update installer to ensure that `amplihack update` always refreshes stale framework assets rather than re-staging the old bundle that was already present at `~/.amplihack/amplifier-bundle/`. |
+| `false` | **Default.** Resolves a compatible bundled framework root by checking `AMPLIHACK_HOME`, walking up from the current working directory, walking up from the executable path, checking the compile-time workspace root, then checking `~/.amplihack`. Incompatible local candidates are skipped. Falls back to network download only when no compatible local source is found. This is the behavior for standalone `amplihack install` and install runs triggered by self-heal. |
+| `true` | **Skips local bundle resolution entirely.** Goes directly to `download_and_extract_framework_repo()` to fetch a fresh `amplifier-bundle/` from the upstream archive (`REPO_ARCHIVE_URL`). Used by the post-update installer to ensure that `amplihack update` always refreshes stale framework assets rather than re-staging the old bundle that was already present at `~/.amplihack/amplifier-bundle/`. The downloaded source and staged destination are still validated for compatibility. |
 
-**Priority rule:** When `local` is `Some(path)`, it takes precedence over `force_refresh` — the function returns early with the user-specified path before the bundled-root check. This is correct by design: `--local` is an explicit user override that should not be bypassed.
+**Priority rule:** When `local` is `Some(path)`, it takes precedence over `force_refresh` for source selection, but not for compatibility. The user-specified path must still pass framework bundle validation. This is correct by design: `--local` is an explicit source override, not permission to stage stale smart-orchestrator assets.
 
 **Call sites and their `force_refresh` values:**
 
 | Caller | `force_refresh` | Rationale |
 |--------|-----------------|-----------|
-| `amplihack install` (command dispatcher) | `false` | Standalone install prefers local bundle |
+| `amplihack install` (command dispatcher) | `false` | Standalone install prefers compatible local sources |
 | `amplihack update` (post-update closure) | `true` | **Root cause fix for issue #675** — forces fresh download |
-| Self-heal (startup version-stamp check) | `false` | Prefers local bundle for startup speed |
-| `ensure_framework_installed()` (bootstrap) | `false` | Bootstrap prefers local bundle |
+| Self-heal (startup version-stamp check) | `false` | Re-runs install when the version stamp is stale; it benefits from install compatibility validation but does not perform a separate startup compatibility scan |
+| `ensure_framework_installed()` (bootstrap) | `false` | Bootstrap prefers compatible local sources |
+
+### `validate_framework_bundle_compatibility(root: &Path) -> Result<()>`
+
+Validates a candidate framework bundle before install accepts it as a source.
+The validator accepts either a repository root containing `amplifier-bundle/` or
+the `amplifier-bundle/` directory itself. It requires the composable
+`smart-orchestrator.yaml` and the four companion recipes:
+`smart-classify-route`, `smart-execute-routing`, `smart-reflect-loop`, and
+`smart-validate-summarize`.
+
+Stale monolithic smart-orchestrator recipes, Python/importlib orchestration,
+current-use `orch_helper.py` references, and old `helper-path` orchestration
+helper flows are rejected. `helper-path` itself remains valid and continues to
+resolve to `amplifier-bundle/bin/multitask-orchestrator.sh`.
+
+Those stale-marker checks are scoped to the current
+`recipes/smart-orchestrator.yaml` behavior. Historical docs and tests may still
+mention `orch_helper.py` or old helper-path behavior when describing past
+failures.
+
+Located in `crates/amplihack-cli/src/commands/install/bundle_compat.rs`.
+
+### `validate_staged_framework_bundle(root: &Path) -> Result<()>`
+
+Validates the installed `amplifier-bundle/` after staging. This is a hard
+install failure so stale destination files cannot remain after an otherwise
+successful install/update repair.
+
+Located in `crates/amplihack-cli/src/commands/install/bundle_compat.rs`.
+
+### `is_compatible_framework_bundle(root: &Path) -> bool`
+
+Boolean helper for local source discovery. Use it to skip optional stale
+candidates such as `AMPLIHACK_HOME` while continuing to the next candidate or
+network fallback. Final staging verification should use
+`validate_staged_framework_bundle()` for actionable diagnostics.
+
+Located in `crates/amplihack-cli/src/commands/install/bundle_compat.rs`.
 
 ### `run_uninstall() -> Result<()>`
 
@@ -272,3 +313,4 @@ Writes wizard results to the install manifest (`default_tool`, `update_check_pre
 - [Hook Specifications](./hook-specifications.md) — the 7 hooks registered by amplihack install
 - [Install Manifest](./install-manifest.md) — manifest schema
 - [Binary Resolution](./binary-resolution.md) — find_hooks_binary lookup detail
+- [Framework bundle compatibility](./framework-bundle-compatibility.md) — smart-orchestrator compatibility contract and stale bundle repair

--- a/docs/reference/install-completeness.md
+++ b/docs/reference/install-completeness.md
@@ -38,9 +38,9 @@ Capture the command output when diagnosing install behavior. A successful instal
 
 ## Verification behavior
 
-After copying files, `amplihack install` verifies the staged framework against a source-derived manifest.
+After copying files, `amplihack install` verifies the staged framework against a source-derived completeness manifest. This is separate from the on-disk uninstall manifest that is persisted only after install succeeds.
 
-The manifest is generated from the resolved source at install time. This avoids hard-coded skill counts and stale component lists.
+The completeness manifest is generated from the resolved source at install time. This avoids hard-coded skill counts and stale component lists. Smart-orchestrator compatibility is validated as an additional structural/content gate, not as a hard-coded file hash or line-count check.
 
 Verification checks:
 
@@ -50,7 +50,8 @@ Verification checks:
 4. Every source skill directory exists at the staged skills destination.
 5. The staged skill directory count is at least the source skill directory count. This is an additional guard; extra destination skills cannot mask a missing source skill.
 6. The full staged `amplifier-bundle/` exists under the user's Amplihack home directory.
-7. Source-conditional categories such as `commands/` and `hooks/` are verified when they exist in the source-derived manifest.
+7. The staged `amplifier-bundle/` passes framework bundle compatibility validation, including the composable smart-orchestrator contract.
+8. Source-conditional categories such as `commands/` and `hooks/` are verified when they exist in the source-derived manifest.
 
 If any check fails, `amplihack install` exits non-zero with an actionable error message.
 
@@ -80,6 +81,15 @@ If an individual source component directory is missing from the staged destinati
 
 ```text
 install failed: staged framework component missing: skills/github
+```
+
+If the staged smart-orchestrator bundle is stale:
+
+```text
+install failed: staged framework bundle is incompatible:
+  recipes/smart-orchestrator.yaml is stale: expected composable sub-recipes
+  smart-classify-route, smart-execute-routing, smart-reflect-loop,
+  smart-validate-summarize
 ```
 
 If a copy operation fails:
@@ -154,7 +164,9 @@ The test asserts:
 4. Every source-conditional category is present at the destination when it exists in the source manifest.
 5. The staged skill count is at least the source skill count, in addition to exact source skill name coverage.
 6. The full `amplifier-bundle/` is staged.
-7. Package metadata includes `amplifier-bundle/`.
-8. Copy failures surface both source and destination paths.
+7. The staged `amplifier-bundle/` contains the composable smart-orchestrator and the required companion recipes.
+8. A stale monolithic smart-orchestrator cannot remain staged after install/update repair.
+9. Package metadata includes `amplifier-bundle/`.
+10. Copy failures surface both source and destination paths.
 
 This test prevents regressions where published or local installs silently omit framework components.

--- a/docs/reference/install-completeness.md
+++ b/docs/reference/install-completeness.md
@@ -122,9 +122,9 @@ find ~/.amplihack/.claude/agents -maxdepth 2 -type d | sort
 Reproduce a clean install with logs:
 
 ```bash
-amplihack update 2>&1 | tee /tmp/amp-update.log
+amplihack update 2>&1 | tee ./amp-update.log
 rm -rf ~/.amplihack/.claude
-amplihack install 2>&1 | tee /tmp/amp-install.log
+amplihack install 2>&1 | tee ./amp-install.log
 find ~/.amplihack/.claude -maxdepth 3 -type d | sort > /tmp/installed-dirs.txt
 ```
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -30,7 +30,7 @@ Ahoy, matey! Hit a snag? This be yer map to fix common issues and get back on co
 
 ### Update Issues
 
-- **Stale bundle after update** — If `amplihack update` completes but recipes fail with errors like "orch_helper.py not found", you are on a pre-#675 binary. Run `amplihack install` manually, or update to a version that includes issue #675 (which forces a fresh bundle download during update).
+- **Stale bundle after update** — If `amplihack update` completes but recipes fail with errors like "orch_helper.py not found" or `smart-orchestrator` fails during `parse-decomposition`, run `amplihack install` or `amplihack update` with a version that includes the framework bundle compatibility validator. Current installs skip incompatible `AMPLIHACK_HOME` bundles and verify the staged composable smart-orchestrator. See [Repair a stale framework bundle](../howto/repair-stale-framework-bundle.md).
 
 ### Startup Issues
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Fixes #734 by hardening install/update framework bundle handling so stale monolithic `smart-orchestrator.yaml` assets cannot be accepted or remain staged after repair.

## What changed

- Added an install-time framework bundle compatibility validator for the composable `smart-orchestrator` contract.
- Require the four smart companion recipes and `_recipe_manifest.json` entries for the smart recipe set.
- Reject stale monolithic smart-orchestrator markers such as old `resolve-bundle-asset helper-path` orchestration flow and Python/importlib behavior.
- Skip incompatible local source candidates, including stale `AMPLIHACK_HOME`, and continue to compatible checkout/download sources.
- Validate source bundles before copying, copied staging directories before swap, and installed/staged bundles during completeness verification.
- Preserved `helper-path -> amplifier-bundle/bin/multitask-orchestrator.sh`; this does not restore the removed Python helper path.
- Added regression coverage and docs for diagnosis/repair.

## Validation

- `cargo test -p amplihack-cli bundle_compat`
- `cargo test -p amplihack-cli install_flow`
- `cargo test -p amplihack-cli`
- `cargo check --workspace`
- pre-commit hook: `cargo clippy -- -D warnings`

## Step 13: Local Testing Results

### Scenario 1 — Fresh branch install stages compatible smart-orchestrator
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-734-fix-issue-734-harden-updateinstall-against-stale-f amplihack install`
Result: PASS
Output: staged `amplifier-bundle` into an isolated HOME; `smart-orchestrator.yaml` is 70 lines; required sub-recipes `smart-classify-route`, `smart-execute-routing`, `smart-reflect-loop`, and `smart-validate-summarize` are present in both files and manifest; no stale `resolve-bundle-asset helper-path`, `importlib`, or `orch_helper.py` markers remained.

### Scenario 2 — Stale monolithic smart-orchestrator is repaired and helper-path remains shell-based
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-734-fix-issue-734-harden-updateinstall-against-stale-f amplihack install`
Result: PASS
Output: seeded isolated HOME with stale markers `parse-decomposition`, `resolve-bundle-asset helper-path`, `importlib`, and `orch_helper.py`; install staged a replacement `amplifier-bundle`; repaired bundle includes all four required smart sub-recipes and manifest entries; `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-734-fix-issue-734-harden-updateinstall-against-stale-f amplihack resolve-bundle-asset helper-path` resolved to isolated `.amplihack/amplifier-bundle/bin/multitask-orchestrator.sh`, not `orch_helper.py`.


## Step 13: Local Testing Results

### Scenario 1 — Fresh install stages composable smart-orchestrator
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-734-fix-issue-734-harden-updateinstall-against-stale-f amplihack install`
Result: PASS
Output: staged `smart-orchestrator.yaml` has 70 lines; verified required sub-recipes `smart-classify-route`, `smart-execute-routing`, `smart-reflect-loop`, and `smart-validate-summarize`; install completed successfully.

### Scenario 2 — Stale monolithic bundle repair and helper-path validation
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-734-fix-issue-734-harden-updateinstall-against-stale-f amplihack install` followed by `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-734-fix-issue-734-harden-updateinstall-against-stale-f amplihack resolve-bundle-asset helper-path`
Result: PASS
Output: stale monolithic `smart-orchestrator.yaml` was replaced; all four required smart sub-recipes were repaired; `helper-path` resolved to the isolated test HOME's `amplifier-bundle/bin/multitask-orchestrator.sh`.

## Step 8: Merge-ready audit follow-up

Implemented the reliability follow-up findings from the PR #736 merge-ready audit:

- `git clone` network fallback now captures stdout/stderr, enforces an internal timeout, and kills/reaps timed-out subprocesses.
- Malformed `~/.claude/settings.json` now fails loudly and preserves the original file instead of rewriting `{}` defaults.
- Local framework source selection now skips stale incompatible `AMPLIHACK_HOME` candidates with actionable diagnostics while preserving the issue #734 fallback order.

Validation: `NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli commands::install -- --nocapture` — PASS (`217 passed; 0 failed; 1319 filtered out`).

### Step 8b external service integration follow-up

- Hardened the network fallback `git clone` adapter with a 3-attempt retry budget, bounded internal backoff, and cleanup of partial clone contents before retrying.
- Kept clone execution non-shell, stdout/stderr-captured, timeout-bounded, process-group killed/reaped on Unix, and URL-sanitized in diagnostics.
- Documented clone retry/timeout behavior in the install reliability and install command references.
- Validation: `NODE_OPTIONS=--max-old-space-size=32768 cargo fmt --all && NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli commands::install -- --nocapture && git --no-pager diff --check`.


## Merge-ready evidence update

### QA-team / outside-in evidence

Repo type: Rust CLI. Per `qa-team`, native Rust tests and branch-based CLI runs substitute for `gadugi-test run` in this repository.

- `qa-team` was invoked during Step 13.
- Final branch-based outside-in runs used: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-734-fix-issue-734-harden-updateinstall-against-stale-f amplihack ...`
- Scenario 1 PASS: fresh isolated install staged the 70-line composable `smart-orchestrator.yaml` and all four required sub-recipes.
- Scenario 2 PASS: stale monolithic `smart-orchestrator.yaml` was repaired and `helper-path` resolved to the isolated test HOME's `amplifier-bundle/bin/multitask-orchestrator.sh`.
- Evidence artifacts: `/home/azureuser/.copilot/session-state/12694132-6d51-4455-b6e1-b385cd0d7a32/files/step13-outside-in-final/`.

### Quality audit evidence

- The `quality-audit-cycle` recipe was run against `crates/amplihack-cli/src/commands/install` with `min_cycles=3`, but the recipe failed in `merge-validations` due a JSON parsing infrastructure issue: `jq: Bad JSON in --slurpfile ... Invalid numeric literal`.
- Before that infrastructure failure, it surfaced merge-relevant findings that were fixed in this PR:
  - bounded git clone timeout with captured output;
  - malformed `settings.json` now fails loudly instead of being rewritten as `{}`;
  - stale bundle candidate diagnostics preserve actionable compatibility errors;
  - required smart companion recipes now require matching `name` and non-empty `steps`;
  - git clone timeout cleanup terminates descendant processes on Unix process groups and Windows via `taskkill /T /F`.
- Focused audit cycles after fixes:
  - Cycle 1: reviewer found companion-recipe and timeout-cleanup gaps; security/architecture found no other blockers.
  - Cycle 2: security/architecture clean; reviewer found Windows timeout descendant cleanup gap.
  - Cycle 3: final reviewer confirmation clean, with zero PR-caused critical/high/medium correctness, security, or reliability findings.

### Additional local validation after audit fixes

- `CARGO_TARGET_DIR=/tmp/pr736-target cargo test -p amplihack-cli bundle_compat -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/pr736-target cargo test -p amplihack-cli git_clone -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/pr736-target cargo test -p amplihack-cli read_invalid_json_returns_error -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/pr736-target cargo clippy -p amplihack-cli -- -D warnings`

### Scope

Diff remains focused on issue #734 stale framework bundle repair, install/update compatibility validation, related tests, version metadata, and directly related docs. Skipped CI checks are conditional `scan`, `deploy`, and `Release` jobs.
