### PR TITLE
Fix default workflow terminal evidence gate

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -165,10 +165,3 @@ steps:
   - id: "workflow-finalize"
     type: "recipe"
     recipe: "workflow-finalize"
-
-  - id: "workflow-terminal-state"
-    type: "recipe"
-    recipe: "workflow-terminal-state"
-    context:
-      terminal_gate_mode: "strict"
-    output: "terminal_state_final"

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -123,6 +123,8 @@ context:
   should_finalize: "true"
   should_run_ci_wait: "true"
   should_merge: "true"
+  implementation_terminal_evidence: ""
+  verification_terminal_evidence: ""
 
 steps:
   # Git precondition is enforced in workflow-prep/step-01 before the first
@@ -163,3 +165,10 @@ steps:
   - id: "workflow-finalize"
     type: "recipe"
     recipe: "workflow-finalize"
+
+  - id: "workflow-terminal-state"
+    type: "recipe"
+    recipe: "workflow-terminal-state"
+    context:
+      terminal_gate_mode: "strict"
+    output: "terminal_state_final"

--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -102,6 +102,9 @@ steps:
 
   - id: "execute-single-round-1-development"
     type: "recipe"
+    # Issue #752: this step must remain fatal-by-default. default-workflow now
+    # performs strict terminal-state validation, and any nonzero result must
+    # propagate through smart-orchestrator instead of becoming hollow success.
     # NOTE: force_single_workstream may be Value::Bool(true) when set via CLI
     # --set (parse_context_value coerces "true" -> Bool). The condition evaluator
     # handles Bool/String cross-type coercion (fix #3069 in recipe-runner-rs).
@@ -220,6 +223,8 @@ steps:
 
   - id: "execute-single-fallback-blocked-development"
     type: "recipe"
+    # Issue #752: preserve default-workflow's strict terminal-state failure
+    # through adaptive single-session execution as well.
     # Fires when blocked from spawning subworkstreams — adapts to single session
     # workstream_count may be Number or String (fix #3606, supersedes #3570).
     condition: |
@@ -357,6 +362,9 @@ steps:
 
   - id: "adaptive-execute-development"
     type: "recipe"
+    # Issue #752: adaptive recovery is still development execution; do not mark
+    # this non-fatal or smart-orchestrator can report success after a failed
+    # default-workflow terminal gate.
     condition: |
       adaptive_recipe == 'default-workflow'
     recipe: "default-workflow"

--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -102,9 +102,6 @@ steps:
 
   - id: "execute-single-round-1-development"
     type: "recipe"
-    # Issue #752: this step must remain fatal-by-default. default-workflow now
-    # performs strict terminal-state validation, and any nonzero result must
-    # propagate through smart-orchestrator instead of becoming hollow success.
     # NOTE: force_single_workstream may be Value::Bool(true) when set via CLI
     # --set (parse_context_value coerces "true" -> Bool). The condition evaluator
     # handles Bool/String cross-type coercion (fix #3069 in recipe-runner-rs).
@@ -223,8 +220,6 @@ steps:
 
   - id: "execute-single-fallback-blocked-development"
     type: "recipe"
-    # Issue #752: preserve default-workflow's strict terminal-state failure
-    # through adaptive single-session execution as well.
     # Fires when blocked from spawning subworkstreams — adapts to single session
     # workstream_count may be Number or String (fix #3606, supersedes #3570).
     condition: |
@@ -362,9 +357,6 @@ steps:
 
   - id: "adaptive-execute-development"
     type: "recipe"
-    # Issue #752: adaptive recovery is still development execution; do not mark
-    # this non-fatal or smart-orchestrator can report success after a failed
-    # default-workflow terminal gate.
     condition: |
       adaptive_recipe == 'default-workflow'
     recipe: "default-workflow"

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -17,6 +17,10 @@ tags: ["smart-orchestrator","orchestrator","composable","classify","route","refl
 # Context flows automatically between sub-recipes via recipe-runner's
 # _execute_sub_recipe() merging. task_type, workstream_count, recursion_guard,
 # round_N_result, and other intermediate outputs propagate forward.
+#
+# Issue #752 invariant: Development routing must preserve default-workflow's
+# strict terminal-state gate. Do not mark smart-execute-routing fatal:false or
+# convert its nonzero result into a successful orchestration summary.
 
 context:
   task_description: ""

--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -629,7 +629,7 @@ assert_terminal_status_case \
     "TERMINAL_REASON=required checks failed"
 
 assert_terminal_recipe_uses_final_status_tool
-assert_yaml_recipe_step_present "default-workflow terminal closure" "${DEFAULT_RECIPE}" "workflow-terminal-state" "workflow-terminal-state"
+assert_yaml_step_not_fatal_false "workflow-finalize final status" "${FINALIZE_RECIPE}" "step-22b-final-status"
 assert_yaml_recipe_step_present "smart-orchestrator routing" "${SMART_ORCHESTRATOR_RECIPE}" "smart-execute-routing" "smart-execute-routing"
 assert_yaml_step_not_fatal_false "smart-execute-routing development path" "${SMART_EXECUTE_RECIPE}" "execute-single-round-1-development"
 assert_yaml_step_not_fatal_false "smart-execute-routing adaptive development path" "${SMART_EXECUTE_RECIPE}" "adaptive-execute-development"

--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test-default-workflow-reliability.sh — regression coverage for issue #573.
+# test-default-workflow-reliability.sh — regression coverage for default-workflow reliability issues.
 #
 # Contracts under test:
 #   1. workflow-worktree chooses a usable remote base without assuming origin/main.
@@ -15,6 +15,10 @@
 #      with git rev-parse --git-path hooks/pre-commit and scope
 #      PRE_COMMIT_ALLOW_NO_CONFIG=1 only to commits where that hook exists and
 #      .pre-commit-config.yaml is absent.
+#   5. Issue #752: development/code-change workflows fail closed unless terminal
+#      evidence proves implementation+verification, publish/PR state, explicit
+#      no-op, or an explicit failure. Planning, analysis, design, and worktree
+#      prep are not success evidence by themselves.
 #
 # This test SHOULD FAIL before the issue #573 reliability fixes land. It MUST
 # PASS once workflow-worktree resolves local/remote origin/HEAD before
@@ -30,10 +34,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 WORKTREE_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-worktree.yaml"
 PUBLISH_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-publish.yaml"
+PUBLISH_HELPER="${REPO_ROOT}/amplifier-bundle/tools/workflow_publish_pr.sh"
 TDD_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-tdd.yaml"
 REFACTOR_REVIEW_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-refactor-review.yaml"
 PR_REVIEW_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-pr-review.yaml"
 FINALIZE_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-finalize.yaml"
+TERMINAL_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-terminal-state.yaml"
+DEFAULT_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/default-workflow.yaml"
+SMART_EXECUTE_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/smart-execute-routing.yaml"
+SMART_ORCHESTRATOR_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/smart-orchestrator.yaml"
+FINAL_STATUS_TOOL="${REPO_ROOT}/amplifier-bundle/tools/workflow_final_status.sh"
 
 if [[ ! -f "${WORKTREE_RECIPE}" ]]; then
     echo "HARNESS-ERROR: ${WORKTREE_RECIPE} not found" >&2
@@ -43,9 +53,19 @@ if [[ ! -f "${PUBLISH_RECIPE}" ]]; then
     echo "HARNESS-ERROR: ${PUBLISH_RECIPE} not found" >&2
     exit 2
 fi
+if [[ ! -f "${PUBLISH_HELPER}" ]]; then
+    echo "HARNESS-ERROR: ${PUBLISH_HELPER} not found" >&2
+    exit 2
+fi
 for recipe in "${TDD_RECIPE}" "${REFACTOR_REVIEW_RECIPE}" "${PR_REVIEW_RECIPE}" "${FINALIZE_RECIPE}"; do
     if [[ ! -f "${recipe}" ]]; then
         echo "HARNESS-ERROR: ${recipe} not found" >&2
+        exit 2
+    fi
+done
+for path in "${TERMINAL_RECIPE}" "${DEFAULT_RECIPE}" "${SMART_EXECUTE_RECIPE}" "${SMART_ORCHESTRATOR_RECIPE}" "${FINAL_STATUS_TOOL}"; do
+    if [[ ! -f "${path}" ]]; then
+        echo "HARNESS-ERROR: ${path} not found" >&2
         exit 2
     fi
 done
@@ -112,6 +132,122 @@ configure_identity() {
     local repo="$1"
     git -C "${repo}" config user.email "test@example.invalid"
     git -C "${repo}" config user.name "Recipe Reliability Test"
+}
+
+assert_yaml_recipe_step_present() {
+    local label="$1"
+    local recipe="$2"
+    local step_id="$3"
+    local child_recipe="$4"
+
+    awk -v step_id="${step_id}" -v child_recipe="${child_recipe}" '
+        $0 ~ "^[[:space:]]*- id: \"" step_id "\"[[:space:]]*$" {
+            in_step = 1
+            next
+        }
+        in_step && /^[[:space:]]*- id: / {
+            exit
+        }
+        in_step && $0 ~ "^[[:space:]]*recipe: \"" child_recipe "\"[[:space:]]*$" {
+            found = 1
+        }
+        END { exit found ? 0 : 1 }
+    ' "${recipe}" || fail "${label} must invoke recipe '${child_recipe}' via step '${step_id}'"
+}
+
+assert_yaml_step_not_fatal_false() {
+    local label="$1"
+    local recipe="$2"
+    local step_id="$3"
+
+    awk -v step_id="${step_id}" '
+        $0 ~ "^[[:space:]]*- id: \"" step_id "\"[[:space:]]*$" {
+            in_step = 1
+            next
+        }
+        in_step && /^[[:space:]]*- id: / {
+            exit
+        }
+        in_step && /^[[:space:]]*fatal:[[:space:]]*false[[:space:]]*$/ {
+            fatal_false = 1
+        }
+        END { exit fatal_false ? 1 : 0 }
+    ' "${recipe}" || fail "${label} must not mark '${step_id}' as fatal: false"
+}
+
+assert_terminal_recipe_uses_final_status_tool() {
+    grep -qF 'workflow_final_status.sh' "${TERMINAL_RECIPE}" \
+        || fail "workflow-terminal-state must wrap workflow_final_status.sh as the canonical terminal gate"
+}
+
+create_terminal_status_repo() {
+    local repo="$1"
+    local branch="${2:-feat/issue-752-terminal-state}"
+
+    git init -b main "${repo}" >/dev/null
+    configure_identity "${repo}"
+    printf 'base\n' > "${repo}/README.md"
+    git -C "${repo}" add README.md
+    git -C "${repo}" commit -m "base" >/dev/null
+    git -C "${repo}" checkout -b "${branch}" >/dev/null
+}
+
+assert_terminal_status_case() {
+    local label="$1"
+    local expected_rc="$2"
+    local expected_status="$3"
+    local expected_state="$4"
+    local expected_text="$5"
+    shift 5
+
+    local case_dir="${WORK}/terminal-status-${label}"
+    local repo="${case_dir}/repo"
+    local stdout_file="${case_dir}/stdout.log"
+    local stderr_file="${case_dir}/stderr.log"
+    local status=0
+
+    mkdir -p "${case_dir}"
+    create_terminal_status_repo "${repo}"
+
+    (
+        export REPO_PATH="${repo}"
+        export WORKTREE_SETUP_WORKTREE_PATH="${repo}"
+        export WORKFLOW_CLASSIFICATION="Development"
+        export RECIPE_NAME="default-workflow"
+        export TASK_DESCRIPTION="Issue 752 terminal-state ${label}"
+        export ISSUE_NUMBER="752"
+        export BRANCH_NAME="feat/issue-752-terminal-state"
+        export BASE_REF="main"
+        unset PR_URL PR_NUMBER PR_PUBLISH_RESULT_PR_URL RECIPE_VAR_pr_publish_result__pr_url
+        unset IMPLEMENTATION_COMPLETED VERIFICATION_COMPLETED PUBLISH_STATE_REACHED TERMINAL_NO_OP TERMINAL_FAILURE
+        unset TERMINAL_STATE TERMINAL_REASON OBSERVED_PHASES ALLOW_NO_OP
+        for assignment in "$@"; do
+            export "${assignment}"
+        done
+        bash "${FINAL_STATUS_TOOL}"
+    ) >"${stdout_file}" 2>"${stderr_file}" || status=$?
+
+    if [[ "${status}" != "${expected_rc}" ]]; then
+        echo "--- terminal-status ${label} stdout ---" >&2
+        cat "${stdout_file}" >&2
+        echo "--- terminal-status ${label} stderr ---" >&2
+        cat "${stderr_file}" >&2
+        fail "workflow_final_status ${label} exited ${status}, expected ${expected_rc}"
+    fi
+
+    grep -qF "terminal_success=${expected_status}" "${stdout_file}" \
+        || fail "workflow_final_status ${label} must emit terminal_success=${expected_status}"
+    grep -qF "terminal_state=${expected_state}" "${stdout_file}" \
+        || fail "workflow_final_status ${label} must emit terminal_state=${expected_state}"
+    if [[ -n "${expected_text}" ]]; then
+        if ! grep -qF "${expected_text}" "${stdout_file}" && ! grep -qF "${expected_text}" "${stderr_file}"; then
+            echo "--- terminal-status ${label} stdout ---" >&2
+            cat "${stdout_file}" >&2
+            echo "--- terminal-status ${label} stderr ---" >&2
+            cat "${stderr_file}" >&2
+            fail "workflow_final_status ${label} must mention '${expected_text}'"
+        fi
+    fi
 }
 
 assert_commit_guard_static() {
@@ -401,6 +537,103 @@ if not isinstance(data["created"], bool):
 PY
 }
 
+# Issue #752 terminal-state contract coverage. These assertions are expected
+# to fail before workflow_final_status.sh and workflow-terminal-state.yaml are
+# converted from publish-status summaries into the canonical fail-closed gate.
+assert_terminal_status_case \
+    "worktree-only-missing-evidence" \
+    "1" \
+    "false" \
+    "FAILED_MISSING_TERMINAL_EVIDENCE" \
+    "missing_evidence=implementation_completed,verification_completed,publish_state_reached,terminal_no_op" \
+    "OBSERVED_PHASES=workflow-prep,workflow-worktree"
+
+assert_terminal_status_case \
+    "analysis-design-only-missing-evidence" \
+    "1" \
+    "false" \
+    "FAILED_MISSING_TERMINAL_EVIDENCE" \
+    "workflow-design" \
+    "OBSERVED_PHASES=workflow-prep,workflow-worktree,workflow-design"
+
+assert_terminal_status_case \
+    "implementation-and-verification-success" \
+    "0" \
+    "true" \
+    "IMPLEMENTED_VERIFIED" \
+    "terminal_reason=implementation and verification evidence present" \
+    "OBSERVED_PHASES=workflow-prep,workflow-worktree,workflow-design,workflow-tdd,workflow-precommit-test" \
+    "IMPLEMENTATION_COMPLETED=true" \
+    "VERIFICATION_COMPLETED=true" \
+    "TERMINAL_STATE=IMPLEMENTED_VERIFIED" \
+    "TERMINAL_REASON=implementation and verification evidence present"
+
+assert_terminal_status_case \
+    "publish-state-success" \
+    "0" \
+    "true" \
+    "FOLLOWUP_CREATED" \
+    "publish_state_reached=true" \
+    "OBSERVED_PHASES=workflow-prep,workflow-worktree,workflow-design,workflow-tdd,workflow-precommit-test,workflow-publish" \
+    "IMPLEMENTATION_COMPLETED=true" \
+    "VERIFICATION_COMPLETED=true" \
+    "PUBLISH_STATE_REACHED=true" \
+    "TERMINAL_STATE=FOLLOWUP_CREATED" \
+    "TERMINAL_REASON=published follow-up pull request" \
+    "PR_URL=https://github.com/example/repo/pull/752"
+
+assert_terminal_status_case \
+    "explicit-no-op-success" \
+    "0" \
+    "true" \
+    "ALLOW_NO_OP" \
+    "terminal_no_op=true" \
+    "OBSERVED_PHASES=workflow-prep,workflow-worktree,workflow-design" \
+    "ALLOW_NO_OP=true" \
+    "TERMINAL_NO_OP=true" \
+    "TERMINAL_STATE=ALLOW_NO_OP" \
+    "TERMINAL_REASON=allow_no_op was explicitly selected for a non-code-change path"
+
+assert_terminal_status_case \
+    "terminal-probe-no-diff-success" \
+    "0" \
+    "true" \
+    "NO_DIFF_SUCCESS" \
+    "terminal_no_op=true" \
+    "OBSERVED_PHASES=workflow-prep,workflow-worktree,workflow-design,workflow-publish" \
+    "TERMINAL_STATE_TERMINAL_SUCCESS=true" \
+    "TERMINAL_STATE=NO_DIFF_SUCCESS" \
+    "TERMINAL_REASON=branch already has no meaningful diff"
+
+assert_terminal_status_case \
+    "malformed-evidence-fails" \
+    "2" \
+    "false" \
+    "FAILED_INVALID_EVIDENCE" \
+    "IMPLEMENTATION_COMPLETED" \
+    "OBSERVED_PHASES=workflow-prep,workflow-worktree,workflow-tdd" \
+    "IMPLEMENTATION_COMPLETED=maybe" \
+    "VERIFICATION_COMPLETED=true"
+
+assert_terminal_status_case \
+    "terminal-failure-overrides-success-looking-markers" \
+    "1" \
+    "false" \
+    "BLOCKED_CI" \
+    "terminal_failure=true" \
+    "OBSERVED_PHASES=workflow-prep,workflow-worktree,workflow-design,workflow-tdd,workflow-precommit-test" \
+    "IMPLEMENTATION_COMPLETED=true" \
+    "VERIFICATION_COMPLETED=true" \
+    "TERMINAL_FAILURE=true" \
+    "TERMINAL_STATE=BLOCKED_CI" \
+    "TERMINAL_REASON=required checks failed"
+
+assert_terminal_recipe_uses_final_status_tool
+assert_yaml_recipe_step_present "default-workflow terminal closure" "${DEFAULT_RECIPE}" "workflow-terminal-state" "workflow-terminal-state"
+assert_yaml_recipe_step_present "smart-orchestrator routing" "${SMART_ORCHESTRATOR_RECIPE}" "smart-execute-routing" "smart-execute-routing"
+assert_yaml_step_not_fatal_false "smart-execute-routing development path" "${SMART_EXECUTE_RECIPE}" "execute-single-round-1-development"
+assert_yaml_step_not_fatal_false "smart-execute-routing adaptive development path" "${SMART_EXECUTE_RECIPE}" "adaptive-execute-development"
+
 # Integration coverage: non-main base branches and fallback behavior.
 extract_step_command "${WORKTREE_RECIPE}" "step-04-setup-worktree" "${STEP04}"
 run_worktree_case "origin-head-prefers-develop-over-master" "origin/develop" "no" "yes"
@@ -421,7 +654,7 @@ if ! awk '
         handled = 1
     }
     END { exit handled ? 0 : 1 }
-' "${PUBLISH_RECIPE}"; then
+' "${PUBLISH_RECIPE}" "${PUBLISH_HELPER}"; then
     fail "workflow-publish must keep explicit gh pr create failure handling"
 fi
 
@@ -490,6 +723,7 @@ chmod +x "${WORK}/bin/gh"
     export WORKTREE_SETUP_WORKTREE_PATH="${PR_REPO}"
     export TASK_DESCRIPTION="Fix default workflow reliability"
     export ISSUE_NUMBER="573"
+    export REMOTE_HOST_TYPE="github"
     unset DESIGN_SPEC design_spec RECIPE_VAR_design_spec RECIPE_VAR_DESIGN_SPEC
     bash "${STEP16}"
 ) >"${WORK}/step16.out" 2>"${WORK}/step16.err" || {
@@ -506,12 +740,12 @@ if ! grep -q '^pr create' "${GH_LOG}"; then
     fail "workflow-publish did not invoke gh pr create when DESIGN_SPEC was missing"
 fi
 
-if [[ "$(grep -c '^pr list' "${GH_LOG}")" -lt 3 ]]; then
+if [[ "$(grep -c '^pr list' "${GH_LOG}")" -ne 2 ]]; then
     echo "--- gh log ---" >&2
     cat "${GH_LOG}" >&2
     echo "--- step-16 stderr ---" >&2
     cat "${WORK}/step16.err" >&2
-    fail "workflow-publish must retry transient gh pr list failures before continuing"
+    fail "workflow-publish must retry one transient gh pr list failure before continuing"
 fi
 
 if [[ "$(grep -c '^pr create' "${GH_LOG}")" -ne 3 ]]; then

--- a/amplifier-bundle/recipes/workflow-precommit-test.yaml
+++ b/amplifier-bundle/recipes/workflow-precommit-test.yaml
@@ -139,6 +139,42 @@ steps:
       any failures with root cause analysis).
     output: "local_testing_gate"
 
+  - id: "verification-terminal-evidence"
+    type: "bash"
+    condition: "goal_already_met != 'true'"
+    parse_json: true
+    command: |
+      set -euo pipefail
+
+      normalize_bool() {
+        case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+          "true"|"1"|"yes"|"y") printf 'true\n' ;;
+          *) printf 'false\n' ;;
+        esac
+      }
+
+      emit_evidence() {
+        jq -nc \
+          --arg verification_completed "$1" \
+          --arg terminal_no_op "$2" \
+          --arg terminal_state "$3" \
+          --arg terminal_reason "$4" \
+          '{verification_completed:$verification_completed,terminal_no_op:$terminal_no_op,terminal_state:$terminal_state,terminal_reason:$terminal_reason}'
+      }
+
+      allow_no_op="$(normalize_bool "${ALLOW_NO_OP:-${RECIPE_VAR_allow_no_op:-false}}")"
+      if [ "$allow_no_op" = "true" ]; then
+        emit_evidence "false" "true" "ALLOW_NO_OP" "allow_no_op was explicitly selected for a non-code-change path"
+        exit 0
+      fi
+
+      if [ -n "${PRECOMMIT_RESULTS:-}" ] && [ -n "${LOCAL_TESTING_GATE:-}" ]; then
+        emit_evidence "true" "false" "VERIFICATION_COMPLETED" "pre-commit and outside-in local testing phases produced validation output"
+      else
+        emit_evidence "false" "false" "VERIFICATION_UNPROVEN" "pre-commit and outside-in local testing evidence is missing"
+      fi
+    output: "verification_terminal_evidence"
+
   # ==========================================================================
   # STEP 14: BUMP VERSION IN CARGO.TOML (MANDATORY - DO NOT SKIP)
   # Before committing, bump version to reflect change type.

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -15,9 +15,6 @@ tags: ["development", "tdd", "implementation"]
 #   enforce-verdict bash gate), replacing the legacy bash hollow-success guard.
 #   Verdicts: WORK_VERIFIED→exit 0, INSUFFICIENT_EVIDENCE→warn+exit 0,
 #   HOLLOW_SUCCESS→exit 1. See issue #615 for full design.
-# FIX #624: enforce-verdict normalizes LLM synonym verdicts and fail-safes
-#   unknown strings to INSUFFICIENT_EVIDENCE instead of exit 1.
-
 recursion:
   max_depth: 6
   max_total_steps: 80
@@ -391,52 +388,10 @@ steps:
     parse_json: true
     command: |
       set -euo pipefail
-
-      normalize_bool() {
-        case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
-          "true"|"1"|"yes"|"y") printf 'true\n' ;;
-          *) printf 'false\n' ;;
-        esac
-      }
-
-      emit_evidence() {
-        jq -nc \
-          --arg implementation_completed "$1" \
-          --arg terminal_no_op "$2" \
-          --arg terminal_state "$3" \
-          --arg terminal_reason "$4" \
-          '{implementation_completed:$implementation_completed,terminal_no_op:$terminal_no_op,terminal_state:$terminal_state,terminal_reason:$terminal_reason}'
-      }
-
-      allow_no_op="$(normalize_bool "${ALLOW_NO_OP:-${RECIPE_VAR_allow_no_op:-false}}")"
-      impl="${IMPLEMENTATION:-}"
-      verdict_raw="${VERDICT_JSON:-}"
-      orchestration_sentinel='No files modified — orchestration task'
-
-      if [ "$allow_no_op" = "true" ]; then
-        emit_evidence "false" "true" "ALLOW_NO_OP" "allow_no_op was explicitly selected for a non-code-change path"
-        exit 0
-      fi
-      if [ -n "$impl" ] && printf '%s' "$impl" | grep -qF -- "$orchestration_sentinel"; then
-        emit_evidence "false" "true" "ALLOW_NO_OP" "implementation output contained the explicit orchestration no-op sentinel"
-        exit 0
-      fi
-
-      verdict_line="$(printf '%s\n' "$verdict_raw" | grep -E '^[[:space:]]*\{.*"verdict"' | tail -1 || true)"
-      if [ -n "$verdict_line" ]; then
-        verdict="$(printf '%s' "$verdict_line" | jq -r '.verdict // ""' 2>/dev/null || true)"
-      else
-        verdict=""
-      fi
-      case "$verdict" in
-        VERIFIED|SUCCESS|APPROVED|PASS|PASSED) verdict="WORK_VERIFIED" ;;
-      esac
-
-      if [ "$verdict" = "WORK_VERIFIED" ]; then
-        emit_evidence "true" "false" "IMPLEMENTATION_COMPLETED" "step-08c work-verifier approved concrete implementation artifacts"
-      else
-        emit_evidence "false" "false" "IMPLEMENTATION_UNPROVEN" "step-08c did not produce WORK_VERIFIED implementation evidence"
-      fi
+      HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_implementation_evidence.sh"
+      [ -f "$HELPER" ] || HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_implementation_evidence.sh"
+      [ -f "$HELPER" ] || { echo "ERROR: workflow implementation evidence helper not found: $HELPER" >&2; exit 2; }
+      bash "$HELPER"
     output: "implementation_terminal_evidence"
 
   # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -385,6 +385,60 @@ steps:
       echo "=== Checkpoint Complete ==="
     output: "impl_checkpoint"
 
+  - id: "implementation-terminal-evidence"
+    type: "bash"
+    condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
+    parse_json: true
+    command: |
+      set -euo pipefail
+
+      normalize_bool() {
+        case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+          "true"|"1"|"yes"|"y") printf 'true\n' ;;
+          *) printf 'false\n' ;;
+        esac
+      }
+
+      emit_evidence() {
+        jq -nc \
+          --arg implementation_completed "$1" \
+          --arg terminal_no_op "$2" \
+          --arg terminal_state "$3" \
+          --arg terminal_reason "$4" \
+          '{implementation_completed:$implementation_completed,terminal_no_op:$terminal_no_op,terminal_state:$terminal_state,terminal_reason:$terminal_reason}'
+      }
+
+      allow_no_op="$(normalize_bool "${ALLOW_NO_OP:-${RECIPE_VAR_allow_no_op:-false}}")"
+      impl="${IMPLEMENTATION:-}"
+      verdict_raw="${VERDICT_JSON:-}"
+      orchestration_sentinel='No files modified — orchestration task'
+
+      if [ "$allow_no_op" = "true" ]; then
+        emit_evidence "false" "true" "ALLOW_NO_OP" "allow_no_op was explicitly selected for a non-code-change path"
+        exit 0
+      fi
+      if [ -n "$impl" ] && printf '%s' "$impl" | grep -qF -- "$orchestration_sentinel"; then
+        emit_evidence "false" "true" "ALLOW_NO_OP" "implementation output contained the explicit orchestration no-op sentinel"
+        exit 0
+      fi
+
+      verdict_line="$(printf '%s\n' "$verdict_raw" | grep -E '^[[:space:]]*\{.*"verdict"' | tail -1 || true)"
+      if [ -n "$verdict_line" ]; then
+        verdict="$(printf '%s' "$verdict_line" | jq -r '.verdict // ""' 2>/dev/null || true)"
+      else
+        verdict=""
+      fi
+      case "$verdict" in
+        VERIFIED|SUCCESS|APPROVED|PASS|PASSED) verdict="WORK_VERIFIED" ;;
+      esac
+
+      if [ "$verdict" = "WORK_VERIFIED" ]; then
+        emit_evidence "true" "false" "IMPLEMENTATION_COMPLETED" "step-08c work-verifier approved concrete implementation artifacts"
+      else
+        emit_evidence "false" "false" "IMPLEMENTATION_UNPROVEN" "step-08c did not produce WORK_VERIFIED implementation evidence"
+      fi
+    output: "implementation_terminal_evidence"
+
   # ==========================================================================
   # STEP 9: REFACTOR AND SIMPLIFY
   # ==========================================================================

--- a/amplifier-bundle/recipes/workflow-terminal-state.yaml
+++ b/amplifier-bundle/recipes/workflow-terminal-state.yaml
@@ -423,6 +423,9 @@ steps:
     command: |
       set -euo pipefail
       export GIT_PAGER=cat GH_PAGER=cat PAGER=cat LESS=FRX
+      if [ "${TERMINAL_GATE_MODE:-${RECIPE_VAR_terminal_gate_mode:-probe}}" != "strict" ]; then
+        exit 0
+      fi
 
       helper=""
       if [ -n "${AMPLIHACK_HOME:-}" ] && [ -f "${AMPLIHACK_HOME}/amplifier-bundle/tools/workflow_final_status.sh" ]; then

--- a/amplifier-bundle/recipes/workflow-terminal-state.yaml
+++ b/amplifier-bundle/recipes/workflow-terminal-state.yaml
@@ -31,10 +31,12 @@ context:
   pr_number: ""
   pr_url: ""
   goal_already_met: "false"
+  terminal_gate_mode: "probe"
 
 steps:
   - id: "probe-terminal-state"
     type: "bash"
+    condition: "terminal_gate_mode != 'strict'"
     parse_json: true
     command: |
       set -euo pipefail
@@ -413,4 +415,26 @@ steps:
       should_run_ci_wait="true"
       should_merge="true"
       emit_terminal_state
+    output: "terminal_state"
+
+  - id: "strict-terminal-state"
+    type: "bash"
+    condition: "terminal_gate_mode == 'strict'"
+    command: |
+      set -euo pipefail
+      export GIT_PAGER=cat GH_PAGER=cat PAGER=cat LESS=FRX
+
+      helper=""
+      if [ -n "${AMPLIHACK_HOME:-}" ] && [ -f "${AMPLIHACK_HOME}/amplifier-bundle/tools/workflow_final_status.sh" ]; then
+        helper="${AMPLIHACK_HOME}/amplifier-bundle/tools/workflow_final_status.sh"
+      elif [ -n "${REPO_PATH:-}" ] && [ -f "${REPO_PATH}/amplifier-bundle/tools/workflow_final_status.sh" ]; then
+        helper="${REPO_PATH}/amplifier-bundle/tools/workflow_final_status.sh"
+      elif [ -f "./amplifier-bundle/tools/workflow_final_status.sh" ]; then
+        helper="./amplifier-bundle/tools/workflow_final_status.sh"
+      fi
+      [ -n "$helper" ] || { echo "ERROR: workflow terminal-state helper not found; set AMPLIHACK_HOME or run from an amplihack checkout" >&2; exit 2; }
+
+      : "${OBSERVED_PHASES:=workflow-prep,workflow-worktree,workflow-design,workflow-tdd,workflow-refactor-review,workflow-precommit-test,workflow-publish,workflow-pr-review,workflow-finalize}"
+      export OBSERVED_PHASES
+      bash "$helper"
     output: "terminal_state"

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -132,6 +132,26 @@ if [ "$probe_success" = "true" ]; then
 fi
 
 case "$PUBLISH_STATE" in
+  no-diff|NO_DIFF_SUCCESS|CLOSED_OBSOLETE)
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      base_ref="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+      [ -n "$base_ref" ] || base_ref="origin/main"
+      if git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null && [ -z "$(git status --porcelain)" ] && git diff --quiet "${base_ref}..HEAD"; then
+        if [ "$PUBLISH_STATE" = "no-diff" ]; then
+          PUBLISH_STATE="NO_DIFF_SUCCESS"
+        fi
+      else
+        echo "ERROR: publish reported terminal no-diff/obsolete state but final clean-worktree diff could not confirm that state" >&2
+        exit 1
+      fi
+    else
+      echo "ERROR: publish reported terminal no-diff/obsolete state but final clean-worktree diff could not confirm that state" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+case "$PUBLISH_STATE" in
   FOLLOWUP_CREATED|MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS)
     publish_state_reached="true"
     ;;

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -5,11 +5,24 @@ echo "=== WORKFLOW COMPLETE ==="
 echo ""
 
 export GH_PAGER=cat PAGER=cat LESS=FRX
+
 HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
 PR_URL="${PR_URL:-${PR_PUBLISH_RESULT_PR_URL:-${RECIPE_VAR_pr_publish_result__pr_url:-}}}"
 PUBLISH_STATE="${PR_PUBLISH_RESULT_STATE:-${RECIPE_VAR_pr_publish_result__state:-}}"
-terminal_status="${PUBLISH_STATE:-active-pr}"
-final_status_rc=0
+TASK_DESC="${TASK_DESCRIPTION:-}"
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+
+terminal_success="false"
+terminal_state_out=""
+terminal_reason_out=""
+terminal_failure="false"
+implementation_completed="false"
+verification_completed="false"
+publish_state_reached="false"
+terminal_no_op="false"
+missing_evidence=""
+invalid_evidence=""
+normalized_bool="false"
 
 sanitize_gh_stderr() {
   sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
@@ -44,25 +57,140 @@ gh_pr_view_with_retry() {
   done
 }
 
-case "$terminal_status" in
-  MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS|closed-after-merge|already-merged|no-diff) echo "terminal_status=$terminal_status" ;;
-esac
+normalize_bool() {
+  local name="$1"
+  local raw="$2"
+  local value
+  value="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    ""|"false"|"0"|"no"|"n") normalized_bool="false" ;;
+    "true"|"1"|"yes"|"y") normalized_bool="true" ;;
+    *)
+      invalid_evidence="${invalid_evidence}${invalid_evidence:+,}${name}"
+      normalized_bool="false"
+      ;;
+  esac
+}
 
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  BASE_REF="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
-  [ -n "$BASE_REF" ] || BASE_REF="origin/main"
-  if git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null && [ -z "$(git status --porcelain)" ] && git diff --quiet "${BASE_REF}..HEAD"; then
-    if [ "$terminal_status" = "CLOSED_OBSOLETE" ]; then
-      echo "terminal_status=CLOSED_OBSOLETE"
-    else
-      terminal_status="NO_DIFF_SUCCESS"
-      echo "terminal_status=NO_DIFF_SUCCESS"
-    fi
-  elif [ "$terminal_status" = "no-diff" ] || [ "$terminal_status" = "NO_DIFF_SUCCESS" ] || [ "$terminal_status" = "CLOSED_OBSOLETE" ]; then
-    echo "ERROR: publish reported terminal no-diff/obsolete state but final clean-worktree diff could not confirm that state" >&2
-    final_status_rc=1
-  fi
+join_missing_evidence() {
+  local result=""
+  [ "$implementation_completed" = "true" ] || result="${result}${result:+,}implementation_completed"
+  [ "$verification_completed" = "true" ] || result="${result}${result:+,}verification_completed"
+  [ "$publish_state_reached" = "true" ] || result="${result}${result:+,}publish_state_reached"
+  [ "$terminal_no_op" = "true" ] || result="${result}${result:+,}terminal_no_op"
+  printf '%s\n' "$result"
+}
+
+emit_terminal_evidence() {
+  echo "terminal_success=$terminal_success"
+  echo "terminal_state=$terminal_state_out"
+  [ -z "$terminal_reason_out" ] || echo "terminal_reason=$terminal_reason_out"
+  echo "implementation_completed=$implementation_completed"
+  echo "verification_completed=$verification_completed"
+  echo "publish_state_reached=$publish_state_reached"
+  echo "terminal_no_op=$terminal_no_op"
+  echo "terminal_failure=$terminal_failure"
+  [ -z "${OBSERVED_PHASES:-}" ] || echo "observed_phases=${OBSERVED_PHASES}"
+  [ -z "$missing_evidence" ] || echo "missing_evidence=$missing_evidence"
+  [ -z "$invalid_evidence" ] || echo "invalid_evidence=$invalid_evidence"
+}
+
+impl_input="${IMPLEMENTATION_COMPLETED:-${IMPLEMENTATION_TERMINAL_EVIDENCE_IMPLEMENTATION_COMPLETED:-${RECIPE_VAR_implementation_terminal_evidence__implementation_completed:-}}}"
+verify_input="${VERIFICATION_COMPLETED:-${VERIFICATION_TERMINAL_EVIDENCE_VERIFICATION_COMPLETED:-${RECIPE_VAR_verification_terminal_evidence__verification_completed:-}}}"
+publish_input="${PUBLISH_STATE_REACHED:-${PUBLISH_TERMINAL_EVIDENCE_PUBLISH_STATE_REACHED:-${RECIPE_VAR_publish_terminal_evidence__publish_state_reached:-}}}"
+no_op_input="${TERMINAL_NO_OP:-${IMPLEMENTATION_TERMINAL_EVIDENCE_TERMINAL_NO_OP:-${RECIPE_VAR_implementation_terminal_evidence__terminal_no_op:-${VERIFICATION_TERMINAL_EVIDENCE_TERMINAL_NO_OP:-${RECIPE_VAR_verification_terminal_evidence__terminal_no_op:-}}}}}"
+failure_input="${TERMINAL_FAILURE:-${TERMINAL_STATE_TERMINAL_FAILURE:-${RECIPE_VAR_terminal_state__terminal_failure:-}}}"
+allow_no_op_input="${ALLOW_NO_OP:-${RECIPE_VAR_allow_no_op:-false}}"
+probe_success_input="${TERMINAL_STATE_TERMINAL_SUCCESS:-${RECIPE_VAR_terminal_state__terminal_success:-}}"
+probe_state_input="${TERMINAL_STATE:-${TERMINAL_STATE_TERMINAL_STATE:-${RECIPE_VAR_terminal_state__terminal_state:-}}}"
+
+normalize_bool "IMPLEMENTATION_COMPLETED" "$impl_input"
+implementation_completed="$normalized_bool"
+normalize_bool "VERIFICATION_COMPLETED" "$verify_input"
+verification_completed="$normalized_bool"
+normalize_bool "PUBLISH_STATE_REACHED" "$publish_input"
+publish_state_reached="$normalized_bool"
+normalize_bool "TERMINAL_NO_OP" "$no_op_input"
+terminal_no_op="$normalized_bool"
+normalize_bool "TERMINAL_FAILURE" "$failure_input"
+terminal_failure="$normalized_bool"
+normalize_bool "ALLOW_NO_OP" "$allow_no_op_input"
+allow_no_op="$normalized_bool"
+normalize_bool "TERMINAL_STATE_TERMINAL_SUCCESS" "$probe_success_input"
+probe_success="$normalized_bool"
+
+if [ "$allow_no_op" = "true" ]; then
+  terminal_no_op="true"
 fi
+
+if [ "$probe_success" = "true" ]; then
+  case "$probe_state_input" in
+    MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS)
+      terminal_no_op="true"
+      ;;
+  esac
+fi
+
+case "$PUBLISH_STATE" in
+  FOLLOWUP_CREATED|MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS)
+    publish_state_reached="true"
+    ;;
+esac
+if [ -n "$PR_URL" ]; then
+  publish_state_reached="true"
+fi
+
+if [ -n "$invalid_evidence" ]; then
+  terminal_success="false"
+  terminal_state_out="FAILED_INVALID_EVIDENCE"
+  terminal_reason_out="invalid boolean evidence marker(s): $invalid_evidence"
+  emit_terminal_evidence
+  echo "ERROR: workflow terminal evidence contains invalid boolean value(s): $invalid_evidence" >&2
+  exit 2
+fi
+
+if [ "$terminal_failure" = "true" ]; then
+  terminal_success="false"
+  terminal_state_out="${TERMINAL_STATE:-${TERMINAL_STATE_TERMINAL_STATE:-${RECIPE_VAR_terminal_state__terminal_state:-TERMINAL_FAILURE}}}"
+  terminal_reason_out="${TERMINAL_REASON:-${TERMINAL_STATE_TERMINAL_REASON:-${RECIPE_VAR_terminal_state__terminal_reason:-explicit terminal failure evidence was reported}}}"
+  emit_terminal_evidence
+  echo "ERROR: workflow terminal failure: $terminal_state_out: $terminal_reason_out" >&2
+  exit 1
+fi
+
+if [ "$terminal_no_op" = "true" ]; then
+  terminal_success="true"
+  terminal_state_out="${TERMINAL_STATE:-${TERMINAL_STATE_TERMINAL_STATE:-${RECIPE_VAR_terminal_state__terminal_state:-ALLOW_NO_OP}}}"
+  terminal_reason_out="${TERMINAL_REASON:-${TERMINAL_STATE_TERMINAL_REASON:-${RECIPE_VAR_terminal_state__terminal_reason:-allow_no_op was explicitly selected for a non-code-change path}}}"
+elif [ "$publish_state_reached" = "true" ]; then
+  terminal_success="true"
+  terminal_state_out="${TERMINAL_STATE:-${TERMINAL_STATE_TERMINAL_STATE:-${RECIPE_VAR_terminal_state__terminal_state:-${PUBLISH_STATE:-FOLLOWUP_CREATED}}}}"
+  terminal_reason_out="${TERMINAL_REASON:-${TERMINAL_STATE_TERMINAL_REASON:-${RECIPE_VAR_terminal_state__terminal_reason:-${PR_PUBLISH_RESULT_MESSAGE:-${RECIPE_VAR_pr_publish_result__message:-publish/PR state reached}}}}}"
+elif [ "$implementation_completed" = "true" ] && [ "$verification_completed" = "true" ]; then
+  terminal_success="true"
+  terminal_state_out="${TERMINAL_STATE:-${TERMINAL_STATE_TERMINAL_STATE:-${RECIPE_VAR_terminal_state__terminal_state:-IMPLEMENTED_VERIFIED}}}"
+  terminal_reason_out="${TERMINAL_REASON:-${TERMINAL_STATE_TERMINAL_REASON:-${RECIPE_VAR_terminal_state__terminal_reason:-implementation and verification evidence present}}}"
+else
+  terminal_success="false"
+  terminal_state_out="FAILED_MISSING_TERMINAL_EVIDENCE"
+  terminal_reason_out="development workflow reached closure without implementation+verification, publish/PR state, or explicit no-op evidence"
+  missing_evidence="$(join_missing_evidence)"
+  emit_terminal_evidence
+  echo "ERROR: workflow terminal evidence is incomplete for a development/code-change workflow." >&2
+  echo "ERROR: missing_evidence=$missing_evidence" >&2
+  echo "ERROR: observed_phases=${OBSERVED_PHASES:-unknown}" >&2
+  echo "ERROR: expected one of: implementation_completed=true with verification_completed=true; publish_state_reached=true; terminal_no_op=true; or terminal_failure=true." >&2
+  exit 1
+fi
+
+emit_terminal_evidence
+
+echo ""
+case "$terminal_state_out" in
+  MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS|FOLLOWUP_CREATED|IMPLEMENTED_VERIFIED|ALLOW_NO_OP|closed-after-merge|already-merged|no-diff)
+    echo "terminal_status=$terminal_state_out"
+    ;;
+esac
 
 if [ -z "$PR_URL" ]; then
   if [ "$HOST_TYPE" = "azdo" ]; then
@@ -82,8 +210,6 @@ else
 fi
 
 echo ""
-TASK_DESC="$TASK_DESCRIPTION"
-ISSUE_NUMBER="$ISSUE_NUMBER"
 printf '=== Task: %s ===\n' "$TASK_DESC"
 case "$HOST_TYPE" in
   github) echo "=== Issue: #${ISSUE_NUMBER} ===" ;;
@@ -100,9 +226,4 @@ else
 fi
 
 echo ""
-if [ "$final_status_rc" -ne 0 ]; then
-  echo "Workflow final status failed; terminal success was not proven." >&2
-  exit "$final_status_rc"
-fi
-
 echo "All 23 workflow steps completed successfully."

--- a/amplifier-bundle/tools/workflow_implementation_evidence.sh
+++ b/amplifier-bundle/tools/workflow_implementation_evidence.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+normalize_bool() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    "true"|"1"|"yes"|"y") printf 'true\n' ;;
+    *) printf 'false\n' ;;
+  esac
+}
+
+emit_evidence() {
+  jq -nc \
+    --arg implementation_completed "$1" \
+    --arg terminal_no_op "$2" \
+    --arg terminal_state "$3" \
+    --arg terminal_reason "$4" \
+    '{implementation_completed:$implementation_completed,terminal_no_op:$terminal_no_op,terminal_state:$terminal_state,terminal_reason:$terminal_reason}'
+}
+
+allow_no_op="$(normalize_bool "${ALLOW_NO_OP:-${RECIPE_VAR_allow_no_op:-false}}")"
+impl="${IMPLEMENTATION:-}"
+verdict_raw="${VERDICT_JSON:-}"
+orchestration_sentinel='No files modified — orchestration task'
+
+if [ "$allow_no_op" = "true" ]; then
+  emit_evidence "false" "true" "ALLOW_NO_OP" "allow_no_op was explicitly selected for a non-code-change path"
+  exit 0
+fi
+if [ -n "$impl" ] && printf '%s' "$impl" | grep -qF -- "$orchestration_sentinel"; then
+  emit_evidence "false" "true" "ALLOW_NO_OP" "implementation output contained the explicit orchestration no-op sentinel"
+  exit 0
+fi
+
+verdict_line="$(printf '%s\n' "$verdict_raw" | grep -E '^[[:space:]]*\{.*"verdict"' | tail -1 || true)"
+if [ -n "$verdict_line" ]; then
+  verdict="$(printf '%s' "$verdict_line" | jq -r '.verdict // ""' 2>/dev/null || true)"
+else
+  verdict=""
+fi
+
+case "$verdict" in
+  WORK_VERIFIED|VERIFIED|SUCCESS|APPROVED|PASS|PASSED)
+    emit_evidence "true" "false" "IMPLEMENTATION_COMPLETED" "step-08c work-verifier approved concrete implementation artifacts"
+    ;;
+  *)
+    emit_evidence "false" "false" "IMPLEMENTATION_UNPROVEN" "step-08c did not produce WORK_VERIFIED implementation evidence"
+    ;;
+esac

--- a/docs/concepts/default-workflow.md
+++ b/docs/concepts/default-workflow.md
@@ -51,17 +51,18 @@ changes. Customize active behavior in
 - CI/CD integration points
 - Review and merge requirements
 
-The canonical `default-workflow` skill/recipe is also idempotent around completed or obsolete work. Before
-publish, PR review, CI waiting, or merge can mutate Git or provider state, the
-workflow evaluates a terminal-state contract. Finalization remains the
-non-mutating arbiter that records the final decision. A proven terminal success
-stops the remaining mutation path instead of creating duplicate commits,
-duplicate follow-up PRs, or stale post-merge publish attempts.
+The terminal-state closure feature makes `default-workflow` idempotent around
+completed or obsolete work. Before publish, PR review, CI waiting, or merge can
+mutate Git or provider state, the workflow evaluates a terminal-state contract.
+Finalization remains the non-mutating arbiter that records the final decision. A
+proven terminal success stops the remaining mutation path instead of creating
+duplicate commits, duplicate follow-up PRs, or stale post-merge publish
+attempts.
 
-### Terminal-State Contract
+### Terminal-State Target Contract
 
-`workflow-terminal-state` is the evidence gate shared by publish, PR review, and
-finalize. It returns these outputs:
+`workflow-terminal-state` is the target evidence gate shared by publish, PR
+review, and finalize. It returns these outputs:
 
 | Output | Meaning |
 | --- | --- |
@@ -138,6 +139,24 @@ shortcut around evidence. A goal-met claim can support terminal success only
 when the terminal-state probe also proves a clean no-diff, merged, or obsolete
 state. Dirty work, failing CI, closed-unmerged PRs, and meaningful unmerged diffs
 override `goal_already_met`.
+
+The same terminal-state system is the target final closure gate for development
+tasks. A code-change workflow cannot report success after only planning,
+analysis, design, or worktree preparation. Before `default-workflow` or a routed
+`smart-orchestrator` development workstream exits successfully, it must prove one
+of these states:
+
+- implementation and verification completed
+- publish, PR, merge, obsolete, or no-diff state reached
+- explicit terminal no-op such as `allow_no_op`, `MERGED`, `SUPERSEDED`,
+  `CLOSED_OBSOLETE`, or `NO_DIFF_SUCCESS`
+
+If the evidence is missing, malformed, or contradictory, the workflow exits
+nonzero with observed phases, missing evidence, and the next action. See
+[Workflow Terminal-State Reference](../reference/workflow-terminal-state.md) for
+the marker contract and
+[How to Diagnose Workflow Terminal-State Failures](../howto/diagnose-workflow-terminal-state.md)
+for recovery examples.
 
 ## When This Workflow Applies
 

--- a/docs/howto/diagnose-workflow-terminal-state.md
+++ b/docs/howto/diagnose-workflow-terminal-state.md
@@ -1,0 +1,249 @@
+# How to Diagnose Workflow Terminal-State Failures
+
+Use this guide when `default-workflow` or `smart-orchestrator` exits nonzero
+with `FAILED_MISSING_TERMINAL_EVIDENCE`, `FAILED_INVALID_EVIDENCE`, or another
+terminal-state error.
+
+## Before you start
+
+- Run from a Git checkout for development workflows.
+- Use the same `repo_path`, `branch_name`, `pr_number`, and `pr_url` values that
+  the failing workflow used.
+- Preserve Node memory settings when checks include Node tooling:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+---
+
+## Read the Failure
+
+Run with JSON output so the failing step and terminal evidence are visible:
+
+```bash
+amplihack recipe run smart-orchestrator \
+  -c task_description="Fix cache invalidation bug" \
+  -c repo_path=. \
+  --format json > result.json
+```
+
+If the shell exits nonzero, inspect the terminal-state failure:
+
+```bash
+jq '(.failure_context // empty),
+    (.step_results[]? | select((.step_id // "") | test("terminal-state|workflow-finalize|default-workflow")))' result.json
+```
+
+Look for these fields:
+
+| Field | What to check |
+| --- | --- |
+| `terminal_state` | Stable failure state such as `FAILED_MISSING_TERMINAL_EVIDENCE`. |
+| `terminal_reason` | Human-readable explanation and next action. |
+| `observed_phases` | Last workflow phases that produced evidence. |
+| `missing_evidence` | Required proof that was absent. |
+
+---
+
+## Fix `FAILED_MISSING_TERMINAL_EVIDENCE`
+
+This means the workflow was classified as a code-change workflow but stopped
+before it proved completion.
+
+Common causes:
+
+| Observed phases | Meaning | Fix |
+| --- | --- | --- |
+| `workflow-prep` only | Requirements or issue setup ran, then execution stopped. | Re-run or resume so worktree, design, implementation, verification, and publish phases execute. |
+| `workflow-prep,workflow-worktree` | Branch/worktree setup completed, but no implementation evidence exists. | Continue into `workflow-design` and `workflow-tdd`; do not treat worktree prep as completion. |
+| `workflow-prep,workflow-worktree,workflow-design` | Design exists, but code and verification did not run. | Continue into implementation and verification, or emit an explicit no-op state if no changes are required. |
+| `workflow-tdd` without verification | Implementation ran but checks did not prove success. | Run pre-commit, targeted tests, or the workflow verification phase. |
+
+Example recovery:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Fix cache invalidation bug" \
+  -c repo_path=. \
+  -c branch_name=feat/cache-invalidation \
+  -c existing_branch=feat/cache-invalidation
+```
+
+The rerun must either continue into implementation/verification/publish or end
+with an explicit terminal no-op/failure state.
+
+---
+
+## Fix `FAILED_INVALID_EVIDENCE`
+
+This means the workflow produced terminal markers, but they were not trustworthy.
+
+Check for:
+
+- unknown `terminal_state`
+- empty `terminal_reason`
+- boolean markers with non-boolean values
+- `terminal_no_op=true` without a no-op state
+- `implementation_completed=true` and `terminal_failure=true` in the same result
+- PR URL or PR number that does not match the repository
+
+Correct the producing recipe step so it emits one coherent state:
+
+```text
+terminal_success=true
+terminal_state=IMPLEMENTED_VERIFIED
+terminal_reason=implementation and verification completed
+implementation_completed=true
+verification_completed=true
+terminal_failure=false
+```
+
+or:
+
+```text
+terminal_success=false
+terminal_state=BLOCKED_CI
+terminal_reason=required status check unit-tests failed
+terminal_failure=true
+```
+
+---
+
+## Use an Explicit No-Op Correctly
+
+Use a terminal no-op only when the task is legitimately complete without further
+code-change work.
+
+Valid examples:
+
+- requested change is already merged
+- branch is clean with no meaningful diff against base
+- issue is explicitly superseded by another workflow-owned PR
+- documentation review, audit, or orchestration task with no requested file edits
+  was classified with `allow_no_op=true`
+
+Example:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Verify the already-merged workflow fix" \
+  -c repo_path=. \
+  -c pr_number=579
+```
+
+Expected terminal evidence:
+
+```text
+terminal_success=true
+terminal_state=MERGED
+terminal_reason=PR #579 is merged
+terminal_no_op=true
+```
+
+Do not use `allow_no_op=true` to bypass failed implementation or verification.
+The gate still requires a valid no-op state and reason.
+
+---
+
+## Verify Routing Propagation
+
+When the failure happens under `smart-orchestrator`, confirm the routed
+`default-workflow` failure is not masked:
+
+```bash
+set +e
+amplihack recipe run smart-orchestrator \
+  -c task_description="Add validation for user input" \
+  -c repo_path=. \
+  --format json > result.json
+status=$?
+set -e
+
+echo "$status"
+jq '.status, .failure_context.step_id, .failure_context.status' result.json
+```
+
+Expected behavior for missing terminal evidence:
+
+```text
+1
+"FAILURE"
+"workflow-terminal-state"
+"failed"
+```
+
+If the command exits `0` while the routed development workflow reports missing
+terminal evidence, the routing layer is incorrectly masking failure.
+
+---
+
+## Run the Terminal-State Evaluator Directly
+
+The shell helper can be run from a checkout to inspect normalized evidence.
+
+```bash
+WORKFLOW_CLASSIFICATION=Development \
+RECIPE_NAME=default-workflow \
+REPO_PATH=. \
+BRANCH_NAME="$(git branch --show-current)" \
+OBSERVED_PHASES="workflow-prep,workflow-worktree,workflow-design" \
+amplifier-bundle/tools/workflow_final_status.sh
+```
+
+Expected result:
+
+```text
+terminal_success=false
+terminal_state=FAILED_MISSING_TERMINAL_EVIDENCE
+missing_evidence=implementation_completed,verification_completed,publish_state_reached,terminal_no_op
+```
+
+Add implementation and verification evidence to confirm a valid success path:
+
+```bash
+WORKFLOW_CLASSIFICATION=Development \
+RECIPE_NAME=default-workflow \
+REPO_PATH=. \
+BRANCH_NAME="$(git branch --show-current)" \
+IMPLEMENTATION_COMPLETED=true \
+VERIFICATION_COMPLETED=true \
+TERMINAL_STATE=IMPLEMENTED_VERIFIED \
+TERMINAL_REASON="implementation and targeted tests completed" \
+amplifier-bundle/tools/workflow_final_status.sh
+```
+
+Expected result:
+
+```text
+terminal_success=true
+terminal_state=IMPLEMENTED_VERIFIED
+```
+
+---
+
+## CI Usage
+
+In CI, run the same workflow command and let the process exit code gate the job:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+
+amplihack recipe run smart-orchestrator \
+  -c task_description="$TASK_DESCRIPTION" \
+  -c repo_path="$GITHUB_WORKSPACE" \
+  --format json > recipe-result.json
+```
+
+Do not post-process `FAILED_MISSING_TERMINAL_EVIDENCE` into success. That state
+means the code-change task did not reach implementation/verification/publish or
+a valid terminal no-op.
+
+---
+
+## See Also
+
+- [Workflow Terminal-State Reference](../reference/workflow-terminal-state.md)
+- [RecipeResult Reference](../reference/recipe-result.md)
+- [Run a Recipe End-to-End](run-a-recipe.md)
+- [How to Troubleshoot Recipe Execution Failures](troubleshoot-recipe-execution.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -268,6 +268,9 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [How to Configure Workflow Execution Guardrails](howto/configure-workflow-execution-guardrails.md) - Supply `expected_gh_account`, inspect `execution_root`, and troubleshoot failures
 - [Tutorial: Workflow Execution Guardrails](tutorials/workflow-execution-guardrails.md) - End-to-end walkthrough of the guarded workflow contract
 - [Workflow Execution Guardrails Reference](reference/workflow-execution-guardrails.md) - Input fields, output schema, signals, and failure semantics
+- [Workflow Terminal-State Reference](reference/workflow-terminal-state.md) - Target contract for development completion evidence, no-op states, failure semantics, and shell helper API
+- [How to Diagnose Workflow Terminal-State Failures](howto/diagnose-workflow-terminal-state.md) - Investigate missing evidence after planning, analysis, design, or worktree-only runs
+- [Tutorial: Workflow Terminal-State Closure](tutorials/workflow-terminal-state-closure.md) - Walk through completion evidence, planning-only failure, and rerun semantics
 - [Workflow-Owned PR Recovery Readiness](features/pr-recovery-readiness.md) - Recover an existing PR through `default-workflow` with branch reuse, hook readiness, additive-copy readiness, and workflow-owned finalization
 - [Existing Branch Finalization Runbook](features/post-v0977-finalization.md) - Finish an already-implemented branch through preservation, validation, PR publication, CI gating, and policy-ready merge
 - [How to Recover an Existing PR with `default-workflow`](howto/recover-existing-pr-with-default-workflow.md) - Supply `pr_number`, `existing_branch`, and issue requirements without manually merging

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -73,6 +73,9 @@ Complete documentation for using the Recipe Runner:
 - **[Recipe Run Correlation Reference](../reference/recipe-run-correlation.md)** - Stable run IDs, log pointer schema, and result fields
 - **[Recipe CLI Examples](cli-examples.md)** - Real-world usage scenarios (development, testing, CI/CD, team workflows)
 - **[Step 03 Host-Aware Tracking Idempotency](../reference/recipe-step-03-idempotency.md)** - GitHub issue, Azure Boards work-item, and local tracking reuse/create contract
+- **[Workflow Terminal-State Reference](../reference/workflow-terminal-state.md)** - Target contract for development workflow completion evidence, no-op states, routed failure propagation, and `workflow_final_status.sh` API
+- **[How to Diagnose Workflow Terminal-State Failures](../howto/diagnose-workflow-terminal-state.md)** - Recovery guide for missing terminal evidence after planning, analysis, design, or worktree-only execution
+- **[Tutorial: Workflow Terminal-State Closure](../tutorials/workflow-terminal-state-closure.md)** - Walk through successful evidence, planning-only failure, and rerun behavior
 
 ## Why It Exists
 

--- a/docs/reference/recipe-cli-reference.md
+++ b/docs/reference/recipe-cli-reference.md
@@ -153,9 +153,19 @@ See [Environment Variables](./environment-variables.md) for full details.
 | `0` | Command succeeded |
 | `1` | Command failed, validation failed, recipe execution failed, runner missing, or arguments were malformed |
 
+For development workflows, exit `0` also requires terminal-state evidence. A
+code-change task that stops after planning, analysis, design, or worktree setup
+exits `1` with `FAILED_MISSING_TERMINAL_EVIDENCE` unless it reaches
+implementation/verification, publish/PR/merge state, or an explicit no-op state.
+The terminal-state shell helper has its own direct invocation exit code `2` for
+invalid helper usage, but `amplihack recipe run` surfaces helper failures as
+recipe failures and exits nonzero, currently `1`. See
+[Workflow Terminal-State Reference](./workflow-terminal-state.md).
+
 ## See also
 
 - [amplihack recipe Reference](./recipe-command.md) - Detailed command behavior
 - [Run a Recipe End-to-End](../howto/run-a-recipe.md) - Task-oriented usage
 - [Recipe Run Correlation Reference](./recipe-run-correlation.md) - Stable run IDs and log pointer events
 - [Recipe Runner Logging Reference](./recipe-runner-logging.md) - stderr progress, heartbeats, bounded snippets, and JSONL events
+- [Workflow Terminal-State Reference](./workflow-terminal-state.md) - Development workflow completion evidence and visible failure contract

--- a/docs/reference/recipe-result.md
+++ b/docs/reference/recipe-result.md
@@ -9,6 +9,7 @@
 - [String Representation](#string-representation)
 - [Step Results](#step-results)
 - [Progress and Failure Context](#progress-and-failure-context)
+- [Terminal-state failures](#terminal-state-failures)
 - [Usage Examples](#usage-examples)
 - [Integration with Recipe Runner](#integration-with-recipe-runner)
 
@@ -219,6 +220,33 @@ logging contract.
 
 ---
 
+## Terminal-state failures
+
+Development workflows include terminal-state evidence in the failing step output
+when completion cannot be proven. These fields are additive and must be
+preserved by JSON/YAML consumers. The target terminal-state feature emits
+boolean markers as canonical lowercase strings (`"true"` or `"false"`) because
+the shell helper output is key/value text; consumers should accept either those
+strings or native booleans:
+
+```json
+{
+  "terminal_success": "false",
+  "terminal_state": "FAILED_MISSING_TERMINAL_EVIDENCE",
+  "terminal_reason": "development workflow stopped after workflow-worktree; implementation, verification, publish, or explicit no-op evidence is required",
+  "observed_phases": "workflow-prep,workflow-worktree",
+  "missing_evidence": "implementation_completed,verification_completed,publish_state_reached,terminal_no_op"
+}
+```
+
+When `workflow-terminal-state` fails, the overall `RecipeResult.status` is
+`FAILURE` and the process exits nonzero. Callers must not reinterpret missing
+terminal evidence as a successful planning run. See
+[Workflow Terminal-State Reference](./workflow-terminal-state.md) for the full
+field contract.
+
+---
+
 ## Usage Examples
 
 ### Check overall status
@@ -297,3 +325,4 @@ Existing result producers may expose either `success` (boolean) or `status`
 - [Recipe Run Correlation Reference](./recipe-run-correlation.md) — `run_id` and `log_pointer` fields
 - [Recipe CLI Examples](../howto/recipe-cli-examples.md) — real-world workflow scenarios
 - [Recipe Resilience](../concepts/recipe-resilience.md) — how partial failures and retries are handled
+- [Workflow Terminal-State Reference](./workflow-terminal-state.md) — development completion evidence and failure semantics

--- a/docs/reference/workflow-terminal-state.md
+++ b/docs/reference/workflow-terminal-state.md
@@ -1,0 +1,418 @@
+# Workflow Terminal-State Reference
+
+> [Home](../index.md) > Reference > Workflow Terminal State
+
+This reference defines the target contract for development workflow terminal
+closure. Development workflows fail closed unless they reach a proven terminal
+state. `default-workflow`, routed `smart-orchestrator` development workstreams,
+and their publish/finalize sub-recipes must use the same terminal-state gate so
+planning, analysis, design, or worktree setup cannot be reported as successful
+code-change completion.
+
+## Contents
+
+- [What the Gate Protects](#what-the-gate-protects)
+- [Valid Success Evidence](#valid-success-evidence)
+- [Evidence Precedence](#evidence-precedence)
+- [Evidence Marker API](#evidence-marker-api)
+- [Recipe Output Contract](#recipe-output-contract)
+- [Shell Helper API](#shell-helper-api)
+- [Configuration](#configuration)
+- [Failure Semantics](#failure-semantics)
+- [Examples](#examples)
+- [Security Invariants](#security-invariants)
+
+---
+
+## What the Gate Protects
+
+The terminal-state gate applies to workflow classifications that can modify code:
+
+- `Development`
+- `Default`
+- `Feature`
+- `Bugfix`
+- `Refactor`
+- routed `smart-orchestrator` workstreams that invoke `default-workflow`
+
+The gate does not turn investigation, Q&A, or operations workflows into
+development workflows. It only enforces the completion contract once a task has
+been routed to code-change semantics.
+
+For protected workflows, these states are never enough for success by
+themselves:
+
+- requirements clarification
+- analysis
+- architecture or design output
+- issue creation
+- worktree or branch preparation
+- skipped implementation
+- skipped verification
+- empty agent output
+- a shell process exiting `0` without terminal evidence
+
+---
+
+## Valid Success Evidence
+
+A protected workflow exits `0` only when one of these evidence groups is present.
+
+| Evidence group | Required proof | Typical producer |
+| --- | --- | --- |
+| Implementation and verification complete | `implementation_completed=true` and `verification_completed=true` with non-empty reason text or structured detail | `workflow-tdd`, `workflow-precommit-test`, review/feedback phases |
+| Publish or PR state reached | `publish_state_reached=true` with a known publish state such as `FOLLOWUP_CREATED`, `MERGED`, `NO_DIFF_SUCCESS`, or `CLOSED_OBSOLETE` | `workflow-publish`, `workflow-finalize` |
+| Explicit terminal no-op | `terminal_no_op=true`, a known no-op state, and a non-empty reason | no-diff, merged, obsolete, superseded, or `allow_no_op` paths |
+
+`terminal_failure=true` is valid terminal evidence, but it is never success
+evidence. It proves the workflow reached a known failing terminal state and must
+exit nonzero.
+
+Unknown, empty, malformed, or contradictory evidence is failure evidence.
+
+---
+
+## Evidence Precedence
+
+The gate evaluates evidence in this order. Implementations and tests must use
+the same precedence so ambiguous marker combinations do not behave differently
+across helper, recipe, and CLI layers.
+
+| Precedence | Evidence | Result |
+| --- | --- | --- |
+| 1 | `terminal_failure=true`, or a known failing `terminal_state` | Fail nonzero. Failure evidence overrides all success-looking markers. |
+| 2 | Malformed, unknown, empty, or contradictory evidence | Fail nonzero with `FAILED_INVALID_EVIDENCE`. |
+| 3 | Valid publish/PR/merge/no-diff state with required details | Succeed, because publish/finalize proves the workflow reached terminal semantics. |
+| 4 | `terminal_no_op=true` with known no-op state and non-empty reason | Succeed only for eligible no-op paths. |
+| 5 | `implementation_completed=true` and `verification_completed=true` | Succeed only when the selected workflow path does not require publish/finalize evidence. |
+| 6 | Anything else | Fail nonzero with `FAILED_MISSING_TERMINAL_EVIDENCE`. |
+
+Contradictory examples include `terminal_failure=true` with
+`terminal_success=true`, `terminal_no_op=true` without a no-op state and reason,
+or `implementation_completed=true` with `verification_completed=false` and no
+valid publish or no-op state.
+
+---
+
+## Evidence Marker API
+
+Recipes communicate terminal progress through structured markers. Marker values
+may be emitted as recipe context keys, JSON step output fields, or exported shell
+environment variables. The terminal-state gate normalizes all three forms into
+the same contract.
+
+Input may use native JSON booleans or boolean strings. The canonical emitted
+form is the lowercase string `"true"` or `"false"` because shell helpers and
+recipe key/value output are string-based. Consumers should accept either native
+booleans or canonical strings, but producers for this feature should emit the
+canonical strings.
+
+### Boolean Markers
+
+| Marker | Type | Meaning |
+| --- | --- | --- |
+| `implementation_completed` | boolean | Code, docs, config, or other requested repository changes were applied. |
+| `verification_completed` | boolean | Required checks for the selected workflow path completed. |
+| `publish_state_reached` | boolean | The workflow reached PR, merge, no-diff, obsolete, or follow-up publication semantics. |
+| `terminal_no_op` | boolean | The workflow intentionally ends without file changes or new publication work. Requires a valid state and reason. |
+| `terminal_failure` | boolean | The workflow has a known failing terminal state and must exit nonzero. |
+
+### Detail Markers
+
+| Marker | Type | Required when | Meaning |
+| --- | --- | --- | --- |
+| `terminal_state` | enum | Always | Stable machine-readable state. |
+| `terminal_reason` | string | Always | Actionable human-readable explanation. |
+| `observed_phases` | list/string | Failure diagnostics | Phases that produced evidence before the gate ran. |
+| `missing_evidence` | list/string | Failure diagnostics | Evidence required for success but not observed. |
+| `pr_url` | URL string | Publish/PR states | Pull request that represents the completed work. |
+| `pr_number` | positive integer string | Publish/PR states | Pull request number when available. |
+| `verification_summary` | string/object | Verification completed | Commands or checks that satisfied verification. |
+
+### Terminal State Vocabulary
+
+| State | Success? | Meaning |
+| --- | --- | --- |
+| `IMPLEMENTED_VERIFIED` | Yes | Implementation and verification both completed. |
+| `FOLLOWUP_CREATED` | Yes | Meaningful work was published or represented by a follow-up PR. |
+| `MERGED` | Yes | The workflow-owned PR is merged or has merge evidence. |
+| `NO_DIFF_SUCCESS` | Yes | The checkout is clean and has no meaningful diff against the intended base. |
+| `CLOSED_OBSOLETE` | Yes | The PR or branch is obsolete and equivalent work is already upstream or no meaningful work remains. |
+| `SUPERSEDED` | Yes | A newer workflow-owned PR or issue explicitly supersedes this run. |
+| `ALLOW_NO_OP` | Yes | `allow_no_op=true` was set for an eligible non-code-change path and includes a reason. |
+| `FAILED_MISSING_TERMINAL_EVIDENCE` | No | The workflow stopped before implementation, verification, publish, or valid no-op evidence. |
+| `FAILED_INVALID_EVIDENCE` | No | Evidence is malformed, unknown, empty, or contradictory. |
+| `FAILED_DIRTY_WORKTREE` | No | Uncommitted work exists and terminal success cannot be proven. |
+| `FAILED_WRONG_BRANCH` | No | The target checkout is not on the expected branch. |
+| `FAILED_INVALID_INPUT` | No | Required context such as repository path, branch, or PR identity is invalid. |
+| `BLOCKED_CI` | No | Required checks are failing or unavailable. |
+
+---
+
+## Recipe Output Contract
+
+`workflow-terminal-state.yaml` is the target recipe-level gate. It wraps the
+shell evaluator and preserves terminal success or failure as recipe success or
+failure.
+
+Successful output includes:
+
+```json
+{
+  "terminal_success": "true",
+  "terminal_state": "IMPLEMENTED_VERIFIED",
+  "terminal_reason": "implementation and verification evidence present",
+  "implementation_completed": "true",
+  "verification_completed": "true",
+  "publish_state_reached": "false",
+  "terminal_no_op": "false",
+  "terminal_failure": "false",
+  "observed_phases": "workflow-prep,workflow-worktree,workflow-design,workflow-tdd,workflow-precommit-test",
+  "missing_evidence": ""
+}
+```
+
+Failure output includes:
+
+```json
+{
+  "terminal_success": "false",
+  "terminal_state": "FAILED_MISSING_TERMINAL_EVIDENCE",
+  "terminal_reason": "development workflow stopped after workflow-worktree; implementation, verification, publish, or explicit no-op evidence is required",
+  "implementation_completed": "false",
+  "verification_completed": "false",
+  "publish_state_reached": "false",
+  "terminal_no_op": "false",
+  "terminal_failure": "true",
+  "observed_phases": "workflow-prep,workflow-worktree",
+  "missing_evidence": "implementation_completed,verification_completed,publish_state_reached,terminal_no_op"
+}
+```
+
+The recipe runner treats a nonzero terminal-state step as recipe failure.
+`smart-execute-routing.yaml` and `smart-orchestrator.yaml` must propagate that
+failure instead of converting it into orchestration success.
+
+---
+
+## Shell Helper API
+
+`amplifier-bundle/tools/workflow_final_status.sh` is the target canonical
+evaluator for this feature. Recipes call it from the repository checkout or
+workflow worktree.
+
+```bash
+amplifier-bundle/tools/workflow_final_status.sh
+```
+
+### Inputs
+
+The helper reads normalized environment variables. Recipe context fields map to
+the same names through `RECIPE_VAR_*` variables when invoked by the runner.
+
+| Environment variable | Type | Description |
+| --- | --- | --- |
+| `WORKFLOW_CLASSIFICATION` | enum string | Workflow class such as `Development`, `Default`, `Investigation`, or `Ops`. |
+| `RECIPE_NAME` | string | Current recipe name. Used for diagnostics and protected-workflow detection. |
+| `REPO_PATH` | path | Repository root used for Git evidence. |
+| `WORKTREE_SETUP_WORKTREE_PATH` | path | Preferred workflow checkout when step 04 created or reused a worktree. |
+| `BRANCH_NAME` | git ref name | Expected branch for development completion. |
+| `BASE_REF` | git ref name | Intended comparison base. |
+| `PR_URL` | URL string | Pull request URL, when publication happened or recovery is in progress. |
+| `PR_NUMBER` | positive integer string | Pull request number, when available. |
+| `ALLOW_NO_OP` | boolean string | Explicit opt-out for eligible no-op paths. Defaults to `false`. |
+| `IMPLEMENTATION_COMPLETED` | boolean string | Direct implementation evidence. |
+| `VERIFICATION_COMPLETED` | boolean string | Direct verification evidence. |
+| `PUBLISH_STATE_REACHED` | boolean string | Direct publish/finalize evidence. |
+| `TERMINAL_NO_OP` | boolean string | Direct no-op evidence. |
+| `TERMINAL_FAILURE` | boolean string | Direct failure evidence. |
+| `TERMINAL_STATE` | enum string | Existing state from a publish/finalize step. |
+| `TERMINAL_REASON` | string | Existing reason from a publish/finalize step. |
+| `OBSERVED_PHASES` | comma-separated string | Optional explicit phase list. |
+
+### Outputs
+
+The helper prints human-readable diagnostics to `stderr` and key/value evidence
+to `stdout`.
+
+```text
+terminal_success=false
+terminal_state=FAILED_MISSING_TERMINAL_EVIDENCE
+terminal_reason=development workflow stopped after workflow-worktree; implementation, verification, publish, or explicit no-op evidence is required
+observed_phases=workflow-prep,workflow-worktree
+missing_evidence=implementation_completed,verification_completed,publish_state_reached,terminal_no_op
+```
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Terminal success is proven, or the workflow is not protected by development terminal-state validation. |
+| `1` | Protected workflow lacks required evidence or has an explicit terminal failure. |
+| `2` | Helper invocation is invalid, required tooling is missing, or input is malformed before evaluation can run. |
+
+These are direct helper exit codes. Through `amplihack recipe run`, any nonzero
+helper result is surfaced as recipe failure and the CLI exits nonzero; current
+CLI behavior reports recipe failures as exit `1` rather than preserving the
+helper's numeric code.
+
+---
+
+## Configuration
+
+### `allow_no_op`
+
+`allow_no_op` is the explicit no-op escape hatch. It is valid only when the
+workflow classification allows a no-op path and the terminal evidence includes a
+reason.
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Review workflow docs and report findings without editing files" \
+  -c repo_path=. \
+  -c allow_no_op=true
+```
+
+`allow_no_op=true` does not hide errors. It succeeds only with
+`terminal_no_op=true`, `terminal_state=ALLOW_NO_OP` or another valid no-op
+state, and a non-empty `terminal_reason`.
+
+### No Silent Relaxation
+
+There is no configuration flag that makes development terminal validation
+advisory. CI, local recipe runs, and nested `smart-orchestrator` routing all use
+the same fail-closed behavior.
+
+### Node Memory Preference
+
+When workflow checks run Node-based tooling, use the configured memory ceiling:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+This affects child tool memory limits only. It does not change terminal-state
+success rules.
+
+---
+
+## Failure Semantics
+
+The terminal-state gate fails visibly when required evidence is missing.
+
+Example diagnostic:
+
+```text
+ERROR: development terminal state not proven
+recipe: default-workflow
+state: FAILED_MISSING_TERMINAL_EVIDENCE
+observed phases: workflow-prep, workflow-worktree, workflow-design
+missing evidence: implementation_completed, verification_completed, publish_state_reached, terminal_no_op
+next action: continue into workflow-tdd/workflow-precommit-test/workflow-publish or emit an explicit terminal no-op/failure state with a reason
+```
+
+This failure exits nonzero from:
+
+- `workflow-terminal-state.yaml`
+- `default-workflow.yaml`
+- `smart-execute-routing.yaml`
+- `smart-orchestrator.yaml`
+- `amplihack recipe run smart-orchestrator ...`
+
+Callers must treat that as an incomplete workflow, not a successful planning
+run.
+
+---
+
+## Examples
+
+### Early Stop After Worktree Prep Fails
+
+```bash
+amplihack recipe run smart-orchestrator \
+  -c task_description="Fix cache invalidation bug" \
+  -c repo_path=. \
+  --format json
+```
+
+If the routed development workstream stops after analysis or worktree setup, the
+command exits `1` and the JSON result contains a failed terminal-state step.
+
+```json
+{
+  "status": "FAILURE",
+  "failure_context": {
+    "step_id": "workflow-terminal-state",
+    "status": "failed"
+  }
+}
+```
+
+### Implementation and Verification Succeed
+
+```text
+terminal_success=true
+terminal_state=IMPLEMENTED_VERIFIED
+terminal_reason=implementation, pre-commit, and targeted tests completed
+implementation_completed=true
+verification_completed=true
+```
+
+The workflow may then continue to publish/finalize, or finish successfully if
+the current recipe path ends at verification.
+
+### No Diff Succeeds Explicitly
+
+```text
+terminal_success=true
+terminal_state=NO_DIFF_SUCCESS
+terminal_reason=clean branch has no meaningful diff or commits against origin/main
+terminal_no_op=true
+```
+
+No-diff success is evidence-based. A clean status alone is not enough if the
+workflow also observed dirty work, branch mismatch, invalid PR identity, or
+malformed terminal markers.
+
+### Contradictory Evidence Fails
+
+```text
+implementation_completed=true
+verification_completed=false
+terminal_no_op=false
+publish_state_reached=false
+```
+
+Result:
+
+```text
+terminal_success=false
+terminal_state=FAILED_MISSING_TERMINAL_EVIDENCE
+missing_evidence=verification_completed,publish_state_reached,terminal_no_op
+```
+
+---
+
+## Security Invariants
+
+- Structured markers, not free-form agent prose, determine terminal success.
+- Protected workflow classifications are validated against a small known set.
+- Missing, empty, unknown, malformed, and contradictory evidence fails closed.
+- `terminal_failure=true` overrides all success-looking markers.
+- No-op states require explicit state and reason text.
+- Git and PR evidence is read only from the workflow checkout or configured
+  repository path.
+- Branch names, PR numbers, and PR URLs are validated before use.
+- Diagnostics do not print full environments, tokens, credentials, or auth
+  headers.
+- Nonzero exit codes are preserved through nested recipe routing.
+
+---
+
+## See Also
+
+- [RecipeResult Reference](./recipe-result.md)
+- [Recipe CLI Reference](./recipe-cli-reference.md)
+- [Workflow Execution Guardrails Reference](./workflow-execution-guardrails.md)
+- [Default Coding Workflow](../concepts/default-workflow.md)
+- [How to Diagnose Workflow Terminal-State Failures](../howto/diagnose-workflow-terminal-state.md)

--- a/docs/tutorials/workflow-terminal-state-closure.md
+++ b/docs/tutorials/workflow-terminal-state-closure.md
@@ -1,0 +1,155 @@
+# Tutorial: Workflow Terminal-State Closure
+
+This tutorial shows how a development workflow proves completion and how a
+planning-only run fails visibly instead of reporting success.
+
+## What you will learn
+
+- Run `smart-orchestrator` for a code-change task.
+- Recognize missing terminal evidence.
+- Inspect the evidence fields in the recipe result.
+- Rerun the workflow so it reaches implementation, verification, publish, or an
+  explicit no-op state.
+
+## Prerequisites
+
+- `amplihack` is installed.
+- You are in a Git checkout.
+- `jq` is installed for JSON inspection.
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+---
+
+## 1. Run a Development Task
+
+Start with a normal code-change request:
+
+```bash
+amplihack recipe run smart-orchestrator \
+  -c task_description="Add validation for malformed workflow terminal evidence" \
+  -c repo_path=. \
+  --format json > recipe-result.json
+```
+
+During a healthy run, `smart-orchestrator` routes to `default-workflow`, which
+continues through implementation, verification, and publish/finalize phases.
+
+---
+
+## 2. Inspect Terminal Evidence
+
+Read the terminal-state fields:
+
+```bash
+jq '.. | objects | select(has("terminal_state")) | {
+  terminal_success,
+  terminal_state,
+  terminal_reason,
+  observed_phases,
+  missing_evidence
+}' recipe-result.json
+```
+
+A completed implementation and verification path looks like this:
+
+```json
+{
+  "terminal_success": "true",
+  "terminal_state": "IMPLEMENTED_VERIFIED",
+  "terminal_reason": "implementation and targeted tests completed",
+  "observed_phases": "workflow-prep,workflow-worktree,workflow-design,workflow-tdd,workflow-precommit-test",
+  "missing_evidence": ""
+}
+```
+
+The important part is not the exact phase count. The important part is that the
+workflow proves one of the valid terminal states.
+
+---
+
+## 3. Understand a Planning-Only Failure
+
+If a development workflow stops after worktree setup or design, the command
+exits nonzero. The result includes missing evidence:
+
+```json
+{
+  "terminal_success": "false",
+  "terminal_state": "FAILED_MISSING_TERMINAL_EVIDENCE",
+  "terminal_reason": "development workflow stopped after workflow-design; implementation, verification, publish, or explicit no-op evidence is required",
+  "observed_phases": "workflow-prep,workflow-worktree,workflow-design",
+  "missing_evidence": "implementation_completed,verification_completed,publish_state_reached,terminal_no_op"
+}
+```
+
+This is expected behavior. A design or prepared worktree is useful progress, but
+it is not a completed code-change task.
+
+---
+
+## 4. Continue the Workflow
+
+Resume or rerun the development workflow with the existing branch/worktree
+context:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Add validation for malformed workflow terminal evidence" \
+  -c repo_path=. \
+  -c existing_branch="$(git branch --show-current)" \
+  --format json > resumed-result.json
+```
+
+The rerun must reach one of these outcomes:
+
+- `IMPLEMENTED_VERIFIED`
+- `FOLLOWUP_CREATED`
+- `MERGED`
+- `NO_DIFF_SUCCESS`
+- `CLOSED_OBSOLETE`
+- `SUPERSEDED`
+- `ALLOW_NO_OP`
+- a visible terminal failure such as `BLOCKED_CI`
+
+---
+
+## 5. Confirm the Exit Code
+
+Use the shell exit code as the source of truth:
+
+```bash
+set +e
+amplihack recipe run smart-orchestrator \
+  -c task_description="Add validation for malformed workflow terminal evidence" \
+  -c repo_path=. \
+  --format json > recipe-result.json
+status=$?
+set -e
+
+echo "$status"
+```
+
+Expected values:
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Terminal success evidence is proven. |
+| `1` | The recipe failed, including missing terminal evidence. |
+
+Do not treat a JSON result with `FAILED_MISSING_TERMINAL_EVIDENCE` as success
+even if earlier planning or worktree steps completed.
+
+When `amplifier-bundle/tools/workflow_final_status.sh` is invoked directly, it
+may exit `2` for invalid helper invocation, missing tooling, or malformed input
+before evaluation can run. Through `amplihack recipe run`, that helper failure is
+reported as recipe failure and the CLI exits nonzero, currently `1`.
+
+---
+
+## Next Steps
+
+- Use [How to Diagnose Workflow Terminal-State Failures](../howto/diagnose-workflow-terminal-state.md) for recovery patterns.
+- Use [Workflow Terminal-State Reference](../reference/workflow-terminal-state.md) for the field and helper API.

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -117,6 +117,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "step-08c-enforce-verdict",
     "step-08b-integration",
     "checkpoint-after-implementation",
+    "implementation-terminal-evidence",
     // Phase 4: workflow-refactor-review (steps 09-11b)
     "step-09-refactor",
     "step-09b-optimize",
@@ -129,6 +130,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     // Phase 5: workflow-precommit-test (steps 12-13)
     "step-12-run-precommit",
     "step-13-local-testing",
+    "verification-terminal-evidence",
     // Phase 6: workflow-publish (terminal gate + steps 14-16b)
     "publish-terminal-state",
     "step-14-bump-version",


### PR DESCRIPTION
## Summary
- Enforce fail-closed terminal evidence for default-workflow development/code-change runs
- Add strict workflow-terminal-state mode and structured implementation/verification evidence emitters
- Add issue #752 regressions for analysis/worktree-only hollow success and routed failure propagation
- Document the terminal-state evidence contract and diagnostics

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 bash amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
- CMAKE_BUILD_PARALLEL_LEVEL=1 NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-cli recipe --locked
- CMAKE_BUILD_PARALLEL_LEVEL=1 NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack-hive orchestrator --locked
- NODE_OPTIONS=--max-old-space-size=32768 pre-commit run --all-files

Fixes #752