### PR TITLE
fix: guard workflow artifact leaks

### DIFF
--- a/.amplihack-artifact-allowlist
+++ b/.amplihack-artifact-allowlist
@@ -1,0 +1,11 @@
+# Artifact Guard allowlist
+#
+# This file is repo-controlled and security-sensitive. Add only narrow,
+# reviewed exceptions for intentional generated artifacts. Do not allowlist
+# root artifact directories such as node_modules/, dist/, .claude/runtime/, or
+# worktrees/.
+#
+# No active exceptions are required for normal repository development. The
+# placeholder below documents the intended shape without matching generated
+# runtime paths.
+docs/fixtures/artifact-guard/intentional-placeholder.txt

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,19 @@ __pycache__/
 *.pyo
 worktrees/
 site/
+node_modules/
+dist/
+build/
+coverage/
+out/
+.cache/
+.npm/
+.pnpm-store/
+.yarn/cache/
+.turbo/
+.parcel-cache/
+.pytest_cache/
+.next/
 
 # Amplihack runtime directories (auto-generated)
 .claude/logs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: artifact-guard
+        name: amplihack artifact guard
+        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo run --bin amplihack -- hygiene artifact-guard --repo . --mode pre-commit'
+        language: system
+        pass_filenames: false
+        always_run: true
+
       - id: cargo-fmt
         name: cargo fmt --all --check
         entry: cargo fmt --all --check
@@ -21,14 +28,14 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy -- -D warnings
-        entry: cargo clippy -- -D warnings
+        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo clippy -- -D warnings'
         language: system
         pass_filenames: false
         files: '(\.rs|Cargo\.toml|Cargo\.lock)$'
 
       - id: cargo-test
         name: cargo test (workspace, skip heavy)
-        entry: bash -c 'cargo test --workspace -- --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu'
+        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo test --workspace -- --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu'
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -535,6 +535,9 @@ Custom workflows:
   validation and troubleshooting
 - **[Workflow Customization](https://rysweet.github.io/amplihack-rs/WORKFLOW_COMPLETION/)** -
   Modify development process
+- **[Artifact Guard](docs/artifact-guard.md)** - Guard for blocking
+  generated/runtime artifacts before broad staging, pre-commit, and workflow
+  publication
 - **[Hooks Comparison](docs/HOOKS_COMPARISON.md)** - Adaptive hook system
   details
 

--- a/amplifier-bundle/recipes/consensus-pr-feedback.yaml
+++ b/amplifier-bundle/recipes/consensus-pr-feedback.yaml
@@ -25,6 +25,7 @@ steps:
     condition: "pr_review_consensus.final_verdict == 'needs_work'"
     type: "bash"
     command: |
+      set -euo pipefail
       export GIT_PAGER=cat
       export PAGER=cat
       export LESS=FRX

--- a/amplifier-bundle/recipes/consensus-pr-feedback.yaml
+++ b/amplifier-bundle/recipes/consensus-pr-feedback.yaml
@@ -33,6 +33,7 @@ steps:
         echo "ERROR: step12-push-updates requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
         exit 1
       fi
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       git commit -m "Address PR review feedback" || echo "Nothing to commit (working tree clean)" >&2
       if git remote get-url origin >/dev/null 2>&1; then

--- a/amplifier-bundle/recipes/consensus-publish.yaml
+++ b/amplifier-bundle/recipes/consensus-publish.yaml
@@ -31,6 +31,7 @@ steps:
       fi
 
       # Stage all changes
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
 
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.

--- a/amplifier-bundle/recipes/consensus-publish.yaml
+++ b/amplifier-bundle/recipes/consensus-publish.yaml
@@ -24,6 +24,7 @@ steps:
   - id: "step9-commit"
     type: "bash"
     command: |
+      set -euo pipefail
       echo "Committing changes..."
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "ERROR: step9-commit requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -63,6 +63,19 @@ steps:
       **FINAL CHECK:** All explicit user requirements preserved.
     output: "final_cleanup"
 
+  - id: "step-20a-artifact-guard"
+    type: "bash"
+    condition: "terminal_state.terminal_success != 'true' && terminal_state.should_finalize == 'true'"
+    command: |
+      set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-}}"
+      if [ -d "${WORKTREE_SETUP_WORKTREE_PATH:-}" ]; then
+        cd "$WORKTREE_SETUP_WORKTREE_PATH"
+      elif [ -d "${REPO_PATH:-}" ]; then
+        cd "$REPO_PATH"
+      fi
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
+
   - id: "step-20b-push-cleanup"
     type: "bash"
     condition: "terminal_state.terminal_success != 'true' && terminal_state.should_finalize == 'true'"
@@ -93,6 +106,7 @@ steps:
         echo "ERROR: current branch is empty; cannot push cleanup changes from detached HEAD" >&2
         exit 1
       fi
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -181,6 +181,7 @@ steps:
         echo "ERROR: current branch is empty; cannot push review feedback changes from detached HEAD" >&2
         exit 1
       fi
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -75,6 +75,15 @@ steps:
     output: "version_bump"
     parse_json: true
 
+  - id: "step-14g-artifact-guard"
+    type: "bash"
+    condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"
+    command: |
+      set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-14g requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
+
   - id: "step-15-commit-push"
     type: "bash"
     condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"
@@ -111,6 +120,7 @@ steps:
       trap _emit_commit_result EXIT
       branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
       echo "--- Staging Changes ---" >&2
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       echo "--- Creating Commit ---" >&2
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
@@ -246,6 +256,7 @@ steps:
        ```
        4. If a test fails, diagnose, fix, commit, push, and retry up to 3 times:
           ```bash
+          amplihack hygiene artifact-guard --repo . --mode pre-publish
           git add -A && git commit -m "fix: <describe the fix found during outside-in testing>"
           git pull --rebase && git push
           ```

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -257,8 +257,7 @@ steps:
        ```
        4. If a test fails, diagnose, fix, commit, push, and retry up to 3 times:
           ```bash
-          amplihack hygiene artifact-guard --repo . --mode pre-publish
-          git add -A && git commit -m "fix: <describe the fix found during outside-in testing>"
+          amplihack hygiene artifact-guard --repo . --mode pre-publish && git add -A && git commit -m "fix: <describe the fix found during outside-in testing>"
           git pull --rebase && git push
           ```
        5. If failures persist after 3 iterations, document them honestly.

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -216,6 +216,7 @@ steps:
         exit 1
       fi
       echo "=== Checkpoint: Staging Review Feedback ==="
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -348,6 +348,7 @@ steps:
       if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
         cargo fmt --all
       fi
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -52,9 +52,6 @@ steps:
       Output test files with clear file path headers.
     output: "test_spec"
 
-  # ==========================================================================
-  # STEP 8: IMPLEMENT THE SOLUTION
-  # ==========================================================================
   - id: "step-08-implement"
     agent: "amplihack:builder"
     working_dir: "{{worktree_setup.worktree_path}}"
@@ -321,9 +318,6 @@ steps:
       Skip if no external integrations are required.
     output: "integration_code"
 
-  # --------------------------------------------------------------------------
-  # CHECKPOINT: Stage implementation work to prevent loss if later steps fail
-  # --------------------------------------------------------------------------
   - id: "checkpoint-after-implementation"
     type: "bash"
     condition: "resume_checkpoint != 'checkpoint-after-implementation' and resume_checkpoint != 'checkpoint-after-review-feedback'"
@@ -394,7 +388,3 @@ steps:
       [ -f "$HELPER" ] || { echo "ERROR: workflow implementation evidence helper not found: $HELPER" >&2; exit 2; }
       bash "$HELPER"
     output: "implementation_terminal_evidence"
-
-  # ==========================================================================
-  # STEP 9: REFACTOR AND SIMPLIFY
-  # ==========================================================================

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -135,6 +135,19 @@ path = "../../tests/integration/workflow_finalize_resilience.rs"
 name = "hygiene_cleanup"
 path = "../../tests/integration/hygiene_cleanup.rs"
 
+# Issue #755: Artifact Guard CLI, workflow, and pre-commit contracts.
+[[test]]
+name = "artifact_guard_cli"
+path = "../../tests/integration/artifact_guard_cli_tests.rs"
+
+[[test]]
+name = "artifact_guard_workflow"
+path = "../../tests/integration/artifact_guard_workflow_tests.rs"
+
+[[test]]
+name = "pre_commit_artifact_guard"
+path = "../../tests/integration/pre_commit_artifact_guard_tests.rs"
+
 [[test]]
 name = "doctor_node_remediation"
 path = "../../tests/integration/doctor_node_remediation_test.rs"

--- a/crates/amplihack-cli/src/cli_subcommands.rs
+++ b/crates/amplihack-cli/src/cli_subcommands.rs
@@ -12,6 +12,26 @@ pub const MIN_CLEANUP_APPLY_OLDER_THAN_HOURS: u64 = MIN_CLEANUP_APPLY_OLDER_THAN
 pub enum HygieneCommands {
     /// Conservative local cleanup for stale worktrees, detached Cargo targets, and session artifacts
     Cleanup(HygieneCleanupArgs),
+    /// Block generated/runtime artifacts before broad staging, commit, or publication
+    ArtifactGuard(HygieneArtifactGuardArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+#[command(
+    after_help = "Modes: pre-commit and pre-publish scan staged, tracked, untracked, and ignored-present artifact paths. staged scans staged paths only. worktree scans tracked, untracked, and ignored-present paths. exit code 0 = clean, exit code 1 = prohibited artifacts found, exit code 2 = configuration, mode, allowlist, Git, or path error. The guard reports clear remediation and does not delete, move, unstage, or rewrite artifacts. Use a narrow repo-controlled allowlist only for intentional generated artifacts."
+)]
+pub struct HygieneArtifactGuardArgs {
+    /// Repository worktree to scan.
+    #[arg(long)]
+    pub repo: Option<PathBuf>,
+
+    /// Scan mode.
+    #[arg(long, default_value = "pre-commit", value_parser = ["pre-commit", "pre-publish", "all", "staged", "worktree"])]
+    pub mode: String,
+
+    /// Optional repo-controlled allowlist file.
+    #[arg(long)]
+    pub allowlist: Option<PathBuf>,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/crates/amplihack-cli/src/commands/hygiene/artifact_guard.rs
+++ b/crates/amplihack-cli/src/commands/hygiene/artifact_guard.rs
@@ -1,0 +1,89 @@
+use std::path::PathBuf;
+
+use amplihack_utils::artifact_guard::{
+    ArtifactGuardConfig, ArtifactGuardMode, ArtifactGuardReport, scan_artifacts,
+};
+use anyhow::Result;
+
+use crate::{HygieneArtifactGuardArgs, command_error};
+
+pub fn run(args: HygieneArtifactGuardArgs) -> Result<()> {
+    let repo = match args.repo {
+        Some(repo) => repo,
+        None => std::env::current_dir().map_err(|error| {
+            eprintln!("Artifact Guard configuration error: resolve current directory: {error}");
+            command_error::exit_error(2)
+        })?,
+    };
+
+    let mode = match ArtifactGuardMode::parse(&args.mode) {
+        Ok(mode) => mode,
+        Err(error) => {
+            eprintln!("Artifact Guard configuration error: {error}");
+            return Err(command_error::exit_error(2));
+        }
+    };
+
+    let mut config = ArtifactGuardConfig::new(&repo).with_mode(mode);
+    if let Some(allowlist) = args.allowlist {
+        config = config.with_allowlist(allowlist);
+    } else {
+        let default_allowlist = PathBuf::from(".amplihack-artifact-allowlist");
+        if repo.join(&default_allowlist).exists() {
+            config = config.with_allowlist(default_allowlist);
+        }
+    }
+
+    match scan_artifacts(&config) {
+        Ok(report) if report.is_clean() => {
+            println!(
+                "Artifact Guard clean: no prohibited artifacts found in {} (mode: {}).",
+                report.repo.display(),
+                report.mode
+            );
+            Ok(())
+        }
+        Ok(report) => {
+            print_violation_report(&report);
+            Err(command_error::exit_error(1))
+        }
+        Err(error) => {
+            eprintln!("Artifact Guard configuration error: {error}");
+            eprintln!(
+                "Fix the repository path, Git state, mode, or allowlist and rerun the guard."
+            );
+            Err(command_error::exit_error(2))
+        }
+    }
+}
+
+fn print_violation_report(report: &ArtifactGuardReport) {
+    eprintln!(
+        "Artifact Guard blocked {} prohibited artifact path(s) in {} (mode: {}).",
+        report.violations.len(),
+        report.repo.display(),
+        report.mode
+    );
+    eprintln!();
+    eprintln!("{:<16} {:<48} rule", "source", "path");
+    for violation in &report.violations {
+        eprintln!(
+            "{:<16} {:<48} {}",
+            violation.source, violation.path, violation.rule_id
+        );
+    }
+    eprintln!();
+    eprintln!("Remediation:");
+    eprintln!("  - Remove local artifact leftovers from the parent worktree.");
+    eprintln!(
+        "  - Move generated, plugin, cache, and runtime output into an ignored isolated directory outside the parent worktree."
+    );
+    eprintln!(
+        "  - If intentional source material, add a narrow reviewed entry to .amplihack-artifact-allowlist."
+    );
+    eprintln!();
+    eprintln!("First violation detail:");
+    if let Some(first) = report.violations.first() {
+        eprintln!("  {}: {}", first.path, first.remediation);
+    }
+}

--- a/crates/amplihack-cli/src/commands/hygiene/mod.rs
+++ b/crates/amplihack-cli/src/commands/hygiene/mod.rs
@@ -1,1 +1,2 @@
+pub mod artifact_guard;
 pub mod cleanup;

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -390,6 +390,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
 fn dispatch_hygiene(command: HygieneCommands) -> Result<()> {
     match command {
         HygieneCommands::Cleanup(args) => hygiene::cleanup::run(args),
+        HygieneCommands::ArtifactGuard(args) => hygiene::artifact_guard::run(args),
     }
 }
 

--- a/crates/amplihack-cli/src/lib.rs
+++ b/crates/amplihack-cli/src/lib.rs
@@ -83,9 +83,10 @@ pub const VERSION: &str = match option_env!("AMPLIHACK_RELEASE_VERSION") {
 
 pub use cli_commands::Commands;
 pub use cli_subcommands::{
-    BuilderCommands, HygieneCleanupArgs, HygieneCommands, MIN_CLEANUP_APPLY_OLDER_THAN_HOURS,
-    MIN_CLEANUP_APPLY_OLDER_THAN_SECS, MemoryCommands, ModeCommands, MultitaskCommands,
-    PluginCommands, QueryCodeCommands, RecipeCommands, ReflectCommands, RemoteCommands,
+    BuilderCommands, HygieneArtifactGuardArgs, HygieneCleanupArgs, HygieneCommands,
+    MIN_CLEANUP_APPLY_OLDER_THAN_HOURS, MIN_CLEANUP_APPLY_OLDER_THAN_SECS, MemoryCommands,
+    ModeCommands, MultitaskCommands, PluginCommands, QueryCodeCommands, RecipeCommands,
+    ReflectCommands, RemoteCommands,
 };
 
 fn graph_db_backend_value_parser() -> PossibleValuesParser {

--- a/crates/amplihack-cli/src/self_heal.rs
+++ b/crates/amplihack-cli/src/self_heal.rs
@@ -253,6 +253,17 @@ fn args_should_skip(args: &[OsString]) -> bool {
         }
     }
 
+    let positionals: Vec<&str> = args
+        .iter()
+        .skip(1)
+        .filter_map(|arg| arg.to_str())
+        .filter(|arg| !arg.starts_with('-'))
+        .collect();
+
+    if matches!(positionals.as_slice(), ["hygiene", "artifact-guard", ..]) {
+        return true;
+    }
+
     // First non-flag positional is the subcommand candidate.
     for arg in args.iter().skip(1) {
         let Some(s) = arg.to_str() else { continue };
@@ -492,6 +503,56 @@ mod tests {
         )
         .expect("ok");
         assert_eq!(calls.get(), 0);
+    }
+
+    #[test]
+    fn hygiene_artifact_guard_skips_startup_self_heal() {
+        let tmp = TempDir::new().unwrap();
+        let _g = EnvGuard::new(tmp.path(), None);
+
+        let calls = Cell::new(0u32);
+        let mut buf = Vec::new();
+        ensure_assets_match_binary_version_with(
+            &args(&[
+                "amplihack",
+                "hygiene",
+                "artifact-guard",
+                "--repo",
+                ".",
+                "--mode",
+                "pre-publish",
+            ]),
+            &mut buf,
+            counting_installer(&calls, crate::VERSION),
+        )
+        .expect("ok");
+
+        assert_eq!(
+            calls.get(),
+            0,
+            "artifact guard is a read-only safety gate and must not self-heal before scanning"
+        );
+    }
+
+    #[test]
+    fn other_hygiene_commands_still_use_startup_self_heal() {
+        let tmp = TempDir::new().unwrap();
+        let _g = EnvGuard::new(tmp.path(), None);
+
+        let calls = Cell::new(0u32);
+        let mut buf = Vec::new();
+        ensure_assets_match_binary_version_with(
+            &args(&["amplihack", "hygiene", "cleanup", "--all"]),
+            &mut buf,
+            counting_installer(&calls, crate::VERSION),
+        )
+        .expect("ok");
+
+        assert_eq!(
+            calls.get(),
+            1,
+            "only hygiene artifact-guard should bypass startup self-heal"
+        );
     }
 
     #[test]

--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -1,0 +1,714 @@
+//! Artifact Guard for generated/runtime repository pollution.
+//!
+//! The guard scans Git-visible paths plus targeted ignored-present artifact
+//! roots. It reports violations only; it never deletes, unstages, or rewrites
+//! repository files.
+
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
+use std::fmt;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use thiserror::Error;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArtifactGuardConfig {
+    repo: PathBuf,
+    mode: ArtifactGuardMode,
+    allowlist: Option<PathBuf>,
+}
+
+impl ArtifactGuardConfig {
+    pub fn new(repo: &Path) -> Self {
+        Self {
+            repo: repo.to_path_buf(),
+            mode: ArtifactGuardMode::All,
+            allowlist: None,
+        }
+    }
+
+    pub fn with_mode(mut self, mode: ArtifactGuardMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn with_allowlist(mut self, allowlist: PathBuf) -> Self {
+        self.allowlist = Some(allowlist);
+        self
+    }
+
+    pub fn mode(&self) -> ArtifactGuardMode {
+        self.mode
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ArtifactGuardMode {
+    #[default]
+    All,
+    Staged,
+    Worktree,
+    PreCommit,
+    PrePublish,
+}
+
+impl ArtifactGuardMode {
+    pub fn parse(value: &str) -> Result<Self, ArtifactGuardError> {
+        match value {
+            "all" => Ok(Self::All),
+            "staged" => Ok(Self::Staged),
+            "worktree" => Ok(Self::Worktree),
+            "pre-commit" => Ok(Self::PreCommit),
+            "pre-publish" => Ok(Self::PrePublish),
+            other => Err(ArtifactGuardError::InvalidMode(other.to_string())),
+        }
+    }
+
+    fn scans_staged(self) -> bool {
+        matches!(
+            self,
+            Self::All | Self::Staged | Self::PreCommit | Self::PrePublish
+        )
+    }
+
+    fn scans_worktree(self) -> bool {
+        matches!(
+            self,
+            Self::All | Self::Worktree | Self::PreCommit | Self::PrePublish
+        )
+    }
+}
+
+impl fmt::Display for ArtifactGuardMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::All => "all",
+            Self::Staged => "staged",
+            Self::Worktree => "worktree",
+            Self::PreCommit => "pre-commit",
+            Self::PrePublish => "pre-publish",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ArtifactSource {
+    Staged,
+    Tracked,
+    Untracked,
+    IgnoredPresent,
+}
+
+impl fmt::Display for ArtifactSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Staged => "staged",
+            Self::Tracked => "tracked",
+            Self::Untracked => "untracked",
+            Self::IgnoredPresent => "ignored-present",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArtifactRule {
+    pub id: &'static str,
+    pub description: &'static str,
+    remediation: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArtifactViolation {
+    pub path: String,
+    pub source: ArtifactSource,
+    pub rule_id: String,
+    pub remediation: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ArtifactGuardReport {
+    pub repo: PathBuf,
+    pub mode: ArtifactGuardMode,
+    pub violations: Vec<ArtifactViolation>,
+}
+
+impl ArtifactGuardReport {
+    pub fn is_clean(&self) -> bool {
+        self.violations.is_empty()
+    }
+
+    pub fn has_violations(&self) -> bool {
+        !self.is_clean()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ArtifactGuardError {
+    #[error("artifact guard repo must resolve inside a git worktree: {0}")]
+    NotGitWorktree(String),
+    #[error("artifact guard git command failed: git {args} (exit {code:?}): {stderr}")]
+    Git {
+        args: String,
+        code: Option<i32>,
+        stderr: String,
+    },
+    #[error("artifact guard invalid mode: {0}")]
+    InvalidMode(String),
+    #[error("artifact guard allowlist error: {0}")]
+    Allowlist(String),
+    #[error("artifact guard path escaped repository root: {0}")]
+    PathEscape(String),
+    #[error("artifact guard I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ArtifactAllowlist {
+    entries: Vec<AllowlistEntry>,
+}
+
+impl ArtifactAllowlist {
+    pub fn load(path: &Path) -> Result<Self, ArtifactGuardError> {
+        let content = fs::read_to_string(path).map_err(|error| {
+            ArtifactGuardError::Allowlist(format!("read allowlist {}: {error}", path.display()))
+        })?;
+        Self::parse(&content, path)
+    }
+
+    pub fn parse(content: &str, path: &Path) -> Result<Self, ArtifactGuardError> {
+        let mut entries = Vec::new();
+        for (index, raw) in content.lines().enumerate() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            validate_allowlist_entry(line, path, index + 1)?;
+            entries.push(AllowlistEntry::new(line));
+        }
+
+        if entries.is_empty() {
+            return Err(ArtifactGuardError::Allowlist(format!(
+                "{} contains no reviewed entries; empty allowlists are unsafe",
+                path.display()
+            )));
+        }
+
+        entries.sort_by(|left, right| left.pattern.cmp(&right.pattern));
+        entries.dedup_by(|left, right| left.pattern == right.pattern);
+        Ok(Self { entries })
+    }
+
+    fn is_allowed(&self, path: &str) -> bool {
+        self.entries.iter().any(|entry| entry.matches(path))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AllowlistEntry {
+    pattern: String,
+}
+
+impl AllowlistEntry {
+    fn new(pattern: &str) -> Self {
+        Self {
+            pattern: normalize_slashes(pattern),
+        }
+    }
+
+    fn matches(&self, path: &str) -> bool {
+        glob_matches(&self.pattern, path)
+    }
+}
+
+const REMEDIATION: &str = "remove the artifact from the parent worktree, or move generated/runtime output into an ignored isolated directory outside the parent worktree; if intentional, add a narrow reviewed .amplihack-artifact-allowlist entry";
+
+const DEFAULT_RULES: &[ArtifactRule] = &[
+    ArtifactRule {
+        id: "node-modules",
+        description: "Node dependency tree",
+        remediation: REMEDIATION,
+    },
+    ArtifactRule {
+        id: "plugin-bundle",
+        description: "Generated plugin bundle",
+        remediation: REMEDIATION,
+    },
+    ArtifactRule {
+        id: "claude-runtime",
+        description: "Claude runtime state",
+        remediation: REMEDIATION,
+    },
+    ArtifactRule {
+        id: "nested-worktree",
+        description: "Nested worktree under parent repository",
+        remediation: REMEDIATION,
+    },
+    ArtifactRule {
+        id: "cache-artifact",
+        description: "Cache directory artifact",
+        remediation: REMEDIATION,
+    },
+    ArtifactRule {
+        id: "build-artifact",
+        description: "Build output artifact",
+        remediation: REMEDIATION,
+    },
+];
+
+const IGNORED_PRESENT_ROOTS: &[&str] = &[
+    "node_modules",
+    "dist/plugin.js",
+    "dist",
+    ".claude/runtime",
+    "worktrees",
+    ".cache",
+    ".npm",
+    ".pnpm-store",
+    ".yarn/cache",
+    ".turbo",
+    ".parcel-cache",
+    ".pytest_cache",
+    ".next/cache",
+    ".next",
+    "build",
+    "coverage",
+    "out",
+    "logs",
+    "outputs",
+    "index.scip",
+];
+
+pub fn scan_artifacts(
+    config: &ArtifactGuardConfig,
+) -> Result<ArtifactGuardReport, ArtifactGuardError> {
+    let repo = resolve_repo_root(&config.repo)?;
+    let allowlist = load_effective_allowlist(config, &repo)?;
+    let mut violations = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    if config.mode.scans_staged() {
+        scan_git_paths(
+            &repo,
+            &["diff", "--cached", "--name-only", "-z"],
+            ArtifactSource::Staged,
+            &allowlist,
+            &mut violations,
+            &mut seen,
+        )?;
+    }
+
+    if config.mode.scans_worktree() {
+        scan_git_paths(
+            &repo,
+            &["ls-files", "-z"],
+            ArtifactSource::Tracked,
+            &allowlist,
+            &mut violations,
+            &mut seen,
+        )?;
+        scan_git_paths(
+            &repo,
+            &["ls-files", "--others", "--exclude-standard", "-z"],
+            ArtifactSource::Untracked,
+            &allowlist,
+            &mut violations,
+            &mut seen,
+        )?;
+        scan_ignored_present(&repo, &allowlist, &mut violations, &mut seen)?;
+    }
+
+    violations.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then(left.source.cmp(&right.source))
+            .then(left.rule_id.cmp(&right.rule_id))
+    });
+
+    Ok(ArtifactGuardReport {
+        repo,
+        mode: config.mode,
+        violations,
+    })
+}
+
+fn resolve_repo_root(repo: &Path) -> Result<PathBuf, ArtifactGuardError> {
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(repo)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|error| ArtifactGuardError::NotGitWorktree(error.to_string()))?;
+    if !output.status.success() {
+        return Err(ArtifactGuardError::NotGitWorktree(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let root = PathBuf::from(stdout.trim());
+    root.canonicalize()
+        .map_err(|error| ArtifactGuardError::NotGitWorktree(error.to_string()))
+}
+
+fn load_effective_allowlist(
+    config: &ArtifactGuardConfig,
+    repo: &Path,
+) -> Result<ArtifactAllowlist, ArtifactGuardError> {
+    let Some(path) = config.allowlist.as_ref().cloned().or_else(|| {
+        let default = repo.join(".amplihack-artifact-allowlist");
+        default.exists().then_some(default)
+    }) else {
+        return Ok(ArtifactAllowlist::default());
+    };
+
+    let allowlist_path = if path.is_absolute() {
+        path
+    } else {
+        repo.join(path)
+    };
+    ArtifactAllowlist::load(&allowlist_path)
+}
+
+fn scan_git_paths(
+    repo: &Path,
+    args: &[&str],
+    source: ArtifactSource,
+    allowlist: &ArtifactAllowlist,
+    violations: &mut Vec<ArtifactViolation>,
+    seen: &mut BTreeSet<(ArtifactSource, String)>,
+) -> Result<(), ArtifactGuardError> {
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(repo)
+        .args(args)
+        .output()
+        .map_err(|error| ArtifactGuardError::Git {
+            args: args.join(" "),
+            code: None,
+            stderr: error.to_string(),
+        })?;
+    if !output.status.success() {
+        return Err(ArtifactGuardError::Git {
+            args: args.join(" "),
+            code: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    for raw in output.stdout.split(|byte| *byte == 0) {
+        if raw.is_empty() {
+            continue;
+        }
+        let path = String::from_utf8_lossy(raw);
+        add_violation_if_prohibited(&path, source, allowlist, violations, seen);
+    }
+    Ok(())
+}
+
+fn scan_ignored_present(
+    repo: &Path,
+    allowlist: &ArtifactAllowlist,
+    violations: &mut Vec<ArtifactViolation>,
+    seen: &mut BTreeSet<(ArtifactSource, String)>,
+) -> Result<(), ArtifactGuardError> {
+    for root in IGNORED_PRESENT_ROOTS {
+        let candidate = repo.join(root);
+        if !candidate.exists() {
+            continue;
+        }
+        let report_path = first_reportable_path(&candidate).unwrap_or(candidate);
+        let relative = repo_relative_path(repo, &report_path)?;
+        if is_git_ignored(repo, &relative)? {
+            add_violation_if_prohibited(
+                &relative,
+                ArtifactSource::IgnoredPresent,
+                allowlist,
+                violations,
+                seen,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn first_reportable_path(path: &Path) -> Option<PathBuf> {
+    if path.is_file() {
+        return Some(path.to_path_buf());
+    }
+    let mut stack = vec![path.to_path_buf()];
+    let mut visited = 0usize;
+    while let Some(current) = stack.pop() {
+        visited += 1;
+        if visited > 256 {
+            return Some(path.to_path_buf());
+        }
+        if current.is_file() {
+            return Some(current);
+        }
+        if !current.is_dir() {
+            continue;
+        }
+        let mut children = fs::read_dir(&current)
+            .ok()?
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|child| child.file_name() != Some(OsStr::new(".git")))
+            .collect::<Vec<_>>();
+        children.sort();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+    Some(path.to_path_buf())
+}
+
+fn is_git_ignored(repo: &Path, relative: &str) -> Result<bool, ArtifactGuardError> {
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(repo)
+        .args(["check-ignore", "-q", "--", relative])
+        .output()
+        .map_err(|error| ArtifactGuardError::Git {
+            args: format!("check-ignore -q -- {relative}"),
+            code: None,
+            stderr: error.to_string(),
+        })?;
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        code => Err(ArtifactGuardError::Git {
+            args: format!("check-ignore -q -- {relative}"),
+            code,
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        }),
+    }
+}
+
+fn add_violation_if_prohibited(
+    raw_path: &str,
+    source: ArtifactSource,
+    allowlist: &ArtifactAllowlist,
+    violations: &mut Vec<ArtifactViolation>,
+    seen: &mut BTreeSet<(ArtifactSource, String)>,
+) {
+    let path = normalize_slashes(raw_path.trim_end_matches('/'));
+    if path.is_empty() || allowlist.is_allowed(&path) {
+        return;
+    }
+    let Some(rule) = rule_for_path(&path, source) else {
+        return;
+    };
+    if seen.insert((source, path.clone())) {
+        violations.push(ArtifactViolation {
+            path,
+            source,
+            rule_id: rule.id.to_string(),
+            remediation: rule.remediation.to_string(),
+        });
+    }
+}
+
+fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static ArtifactRule> {
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.contains(&"node_modules") {
+        return rule("node-modules");
+    }
+    if path == "dist/plugin.js" || path.ends_with("/dist/plugin.js") {
+        return rule("plugin-bundle");
+    }
+    if path == ".claude/runtime" || path.starts_with(".claude/runtime/") {
+        return rule("claude-runtime");
+    }
+    if path == "worktrees" || path.starts_with("worktrees/") {
+        return rule("nested-worktree");
+    }
+    if is_cache_path(path, &parts) {
+        return rule("cache-artifact");
+    }
+    if is_build_artifact_path(path, &parts, source) {
+        return rule("build-artifact");
+    }
+    None
+}
+
+fn rule(id: &str) -> Option<&'static ArtifactRule> {
+    DEFAULT_RULES.iter().find(|rule| rule.id == id)
+}
+
+fn is_cache_path(path: &str, parts: &[&str]) -> bool {
+    parts.iter().any(|part| {
+        matches!(
+            *part,
+            ".cache" | ".npm" | ".pnpm-store" | ".turbo" | ".parcel-cache" | ".pytest_cache"
+        )
+    }) || path == ".yarn/cache"
+        || path.starts_with(".yarn/cache/")
+        || path.contains("/.yarn/cache/")
+        || path == ".next/cache"
+        || path.starts_with(".next/cache/")
+        || path.contains("/.next/cache/")
+}
+
+fn is_build_artifact_path(path: &str, parts: &[&str], source: ArtifactSource) -> bool {
+    if parts.contains(&"target") {
+        return source != ArtifactSource::IgnoredPresent;
+    }
+    if path == "index.scip" || path.ends_with("/index.scip") {
+        return true;
+    }
+    if parts.iter().any(|part| {
+        matches!(
+            *part,
+            "dist" | "build" | "coverage" | "out" | "logs" | "outputs"
+        )
+    }) {
+        return true;
+    }
+    path == ".next" || path.starts_with(".next/") || path.contains("/.next/")
+}
+
+fn repo_relative_path(repo: &Path, path: &Path) -> Result<String, ArtifactGuardError> {
+    let relative = path
+        .strip_prefix(repo)
+        .map_err(|_| ArtifactGuardError::PathEscape(path.display().to_string()))?;
+    normalize_repo_relative(relative)
+}
+
+fn normalize_repo_relative(path: &Path) -> Result<String, ArtifactGuardError> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let part = part
+                    .to_str()
+                    .ok_or_else(|| ArtifactGuardError::PathEscape(path.display().to_string()))?;
+                parts.push(part);
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(ArtifactGuardError::PathEscape(path.display().to_string()));
+            }
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+fn normalize_slashes(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn validate_allowlist_entry(
+    entry: &str,
+    path: &Path,
+    line: usize,
+) -> Result<(), ArtifactGuardError> {
+    let unsafe_reason = |reason: &str| {
+        ArtifactGuardError::Allowlist(format!(
+            "{}:{line} unsafe allowlist entry `{entry}`: {reason}",
+            path.display()
+        ))
+    };
+
+    if entry.starts_with('/') {
+        return Err(unsafe_reason("absolute paths are not allowed"));
+    }
+    if entry.contains('\\') {
+        return Err(unsafe_reason("use / separators, not backslashes"));
+    }
+    let normalized = normalize_slashes(entry.trim_end_matches('/'));
+    if normalized.is_empty() {
+        return Err(unsafe_reason("empty entries are not allowed"));
+    }
+    let parts: Vec<&str> = normalized.split('/').collect();
+    if parts.contains(&"..") {
+        return Err(unsafe_reason("parent traversal is not allowed"));
+    }
+    if matches!(normalized.as_str(), "*" | "**" | "**/*" | "*/**") {
+        return Err(unsafe_reason("repository-wide patterns are not allowed"));
+    }
+    if is_root_prohibited_exemption(&normalized) {
+        return Err(unsafe_reason(
+            "root artifact directories cannot be allowlisted broadly",
+        ));
+    }
+    if normalized.starts_with("**/node_modules") || normalized.contains("/node_modules/**") {
+        return Err(unsafe_reason(
+            "node_modules directory exemptions are too broad",
+        ));
+    }
+    Ok(())
+}
+
+fn is_root_prohibited_exemption(pattern: &str) -> bool {
+    matches!(
+        pattern,
+        "node_modules"
+            | "node_modules/**"
+            | "dist"
+            | "dist/**"
+            | "build"
+            | "build/**"
+            | "coverage"
+            | "coverage/**"
+            | ".claude/runtime"
+            | ".claude/runtime/**"
+            | "worktrees"
+            | "worktrees/**"
+            | ".cache"
+            | ".cache/**"
+            | ".next"
+            | ".next/**"
+            | "out"
+            | "out/**"
+            | "logs"
+            | "logs/**"
+            | "outputs"
+            | "outputs/**"
+    )
+}
+
+fn glob_matches(pattern: &str, path: &str) -> bool {
+    let pattern_parts: Vec<&str> = pattern.split('/').collect();
+    let path_parts: Vec<&str> = path.split('/').collect();
+    glob_parts_match(&pattern_parts, &path_parts)
+}
+
+fn glob_parts_match(pattern: &[&str], path: &[&str]) -> bool {
+    if pattern.is_empty() {
+        return path.is_empty();
+    }
+    if pattern[0] == "**" {
+        return glob_parts_match(&pattern[1..], path)
+            || (!path.is_empty() && glob_parts_match(pattern, &path[1..]));
+    }
+    if path.is_empty() {
+        return false;
+    }
+    segment_matches(pattern[0], path[0]) && glob_parts_match(&pattern[1..], &path[1..])
+}
+
+fn segment_matches(pattern: &str, text: &str) -> bool {
+    segment_match_bytes(pattern.as_bytes(), text.as_bytes())
+}
+
+fn segment_match_bytes(pattern: &[u8], text: &[u8]) -> bool {
+    if pattern.is_empty() {
+        return text.is_empty();
+    }
+    match pattern[0] {
+        b'*' => {
+            segment_match_bytes(&pattern[1..], text)
+                || (!text.is_empty() && segment_match_bytes(pattern, &text[1..]))
+        }
+        b'?' => !text.is_empty() && segment_match_bytes(&pattern[1..], &text[1..]),
+        byte => {
+            !text.is_empty() && byte == text[0] && segment_match_bytes(&pattern[1..], &text[1..])
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/artifact_guard_tests.rs"]
+mod tests;

--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -274,7 +274,13 @@ pub fn scan_artifacts(
     if config.mode.scans_staged() {
         scan_git_paths(
             &repo,
-            &["diff", "--cached", "--name-only", "-z"],
+            &[
+                "diff",
+                "--cached",
+                "--diff-filter=ACMRTUXB",
+                "--name-only",
+                "-z",
+            ],
             ArtifactSource::Staged,
             &allowlist,
             &mut violations,

--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -257,9 +257,18 @@ const DEFAULT_RULES: &[ArtifactRule] = &[
         description: "Build output artifact",
         remediation: REMEDIATION,
     },
+    ArtifactRule {
+        id: "workflow-session-artifact",
+        description: "Workflow/session runtime artifact",
+        remediation: REMEDIATION,
+    },
 ];
 
 const IGNORED_PRESENT_ROOTS: &[&str] = &[
+    "recipe-runner.log",
+    "plan.md",
+    ".copilot/session-state",
+    ".amplihack/session-state",
     "node_modules",
     "dist/plugin.js",
     "dist",
@@ -524,6 +533,9 @@ fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static Artifact
     if path == "worktrees" || path.starts_with("worktrees/") {
         return rule("nested-worktree");
     }
+    if is_workflow_session_artifact_path(path) {
+        return rule("workflow-session-artifact");
+    }
     if is_cache_path(path, &parts) {
         return rule("cache-artifact");
     }
@@ -531,6 +543,15 @@ fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static Artifact
         return rule("build-artifact");
     }
     None
+}
+
+fn is_workflow_session_artifact_path(path: &str) -> bool {
+    path == "recipe-runner.log"
+        || path == "plan.md"
+        || path == ".copilot/session-state"
+        || path.starts_with(".copilot/session-state/")
+        || path == ".amplihack/session-state"
+        || path.starts_with(".amplihack/session-state/")
 }
 
 fn rule(id: &str) -> Option<&'static ArtifactRule> {

--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -5,12 +5,10 @@
 //! repository files.
 
 use std::collections::BTreeSet;
-use std::ffi::OsStr;
 use std::fmt;
 use std::fs;
-use std::io::Write;
-use std::path::{Component, Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use thiserror::Error;
 
@@ -265,33 +263,6 @@ const DEFAULT_RULES: &[ArtifactRule] = &[
     },
 ];
 
-const IGNORED_PRESENT_ROOTS: &[&str] = &[
-    "recipe-runner.log",
-    "plan.md",
-    ".copilot/session-state",
-    ".amplihack/session-state",
-    "node_modules",
-    "dist/plugin.js",
-    "dist",
-    ".claude/runtime",
-    "worktrees",
-    ".cache",
-    ".npm",
-    ".pnpm-store",
-    ".yarn/cache",
-    ".turbo",
-    ".parcel-cache",
-    ".pytest_cache",
-    ".next/cache",
-    ".next",
-    "build",
-    "coverage",
-    "out",
-    "logs",
-    "outputs",
-    "index.scip",
-];
-
 pub fn scan_artifacts(
     config: &ArtifactGuardConfig,
 ) -> Result<ArtifactGuardReport, ArtifactGuardError> {
@@ -423,105 +394,45 @@ fn scan_ignored_present(
     violations: &mut Vec<ArtifactViolation>,
     seen: &mut BTreeSet<(ArtifactSource, String)>,
 ) -> Result<(), ArtifactGuardError> {
-    let mut candidates = Vec::new();
-    for root in IGNORED_PRESENT_ROOTS {
-        let candidate = repo.join(root);
-        if !candidate.exists() {
-            continue;
-        }
-        let report_path = first_reportable_path(&candidate).unwrap_or(candidate);
-        candidates.push(repo_relative_path(repo, &report_path)?);
-    }
-
-    let ignored = git_ignored_paths(repo, &candidates)?;
-    for relative in candidates {
-        if ignored.contains(&relative) {
-            add_violation_if_prohibited(
-                &relative,
-                ArtifactSource::IgnoredPresent,
-                allowlist,
-                violations,
-                seen,
-            );
-        }
-    }
-    Ok(())
-}
-
-fn first_reportable_path(path: &Path) -> Option<PathBuf> {
-    if path.is_file() {
-        return Some(path.to_path_buf());
-    }
-    let mut stack = vec![path.to_path_buf()];
-    let mut visited = 0usize;
-    while let Some(current) = stack.pop() {
-        visited += 1;
-        if visited > 256 {
-            return Some(path.to_path_buf());
-        }
-        if current.is_file() {
-            return Some(current);
-        }
-        if !current.is_dir() {
-            continue;
-        }
-        let mut children = fs::read_dir(&current)
-            .ok()?
-            .filter_map(Result::ok)
-            .map(|entry| entry.path())
-            .filter(|child| child.file_name() != Some(OsStr::new(".git")))
-            .collect::<Vec<_>>();
-        children.sort();
-        for child in children.into_iter().rev() {
-            stack.push(child);
-        }
-    }
-    Some(path.to_path_buf())
-}
-
-fn git_ignored_paths(
-    repo: &Path,
-    relative_paths: &[String],
-) -> Result<BTreeSet<String>, ArtifactGuardError> {
-    if relative_paths.is_empty() {
-        return Ok(BTreeSet::new());
-    }
-
-    let mut child = Command::new("git")
+    let args = [
+        "ls-files",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "-z",
+    ];
+    let output = Command::new("git")
         .args(["-C"])
         .arg(repo)
-        .args(["check-ignore", "-z", "--stdin"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+        .args(args)
+        .output()
         .map_err(|error| ArtifactGuardError::Git {
-            args: "check-ignore -z --stdin".to_string(),
+            args: args.join(" "),
             code: None,
             stderr: error.to_string(),
         })?;
-
-    if let Some(stdin) = child.stdin.as_mut() {
-        for relative in relative_paths {
-            stdin.write_all(relative.as_bytes())?;
-            stdin.write_all(&[0])?;
-        }
-    }
-
-    let output = child.wait_with_output()?;
-    match output.status.code() {
-        Some(0) | Some(1) => Ok(output
-            .stdout
-            .split(|byte| *byte == 0)
-            .filter(|raw| !raw.is_empty())
-            .map(|raw| String::from_utf8_lossy(raw).to_string())
-            .collect()),
-        code => Err(ArtifactGuardError::Git {
-            args: "check-ignore -z --stdin".to_string(),
-            code,
+    if !output.status.success() {
+        return Err(ArtifactGuardError::Git {
+            args: args.join(" "),
+            code: output.status.code(),
             stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        }),
+        });
     }
+
+    for raw in output.stdout.split(|byte| *byte == 0) {
+        if raw.is_empty() {
+            continue;
+        }
+        let path = String::from_utf8_lossy(raw);
+        add_violation_if_prohibited(
+            &path,
+            ArtifactSource::IgnoredPresent,
+            allowlist,
+            violations,
+            seen,
+        );
+    }
+    Ok(())
 }
 
 fn add_violation_if_prohibited(
@@ -629,32 +540,6 @@ fn is_build_artifact_path(path: &str, source: ArtifactSource) -> bool {
     path == ".next" || path.starts_with(".next/") || path.contains("/.next/")
 }
 
-fn repo_relative_path(repo: &Path, path: &Path) -> Result<String, ArtifactGuardError> {
-    let relative = path
-        .strip_prefix(repo)
-        .map_err(|_| ArtifactGuardError::PathEscape(path.display().to_string()))?;
-    normalize_repo_relative(relative)
-}
-
-fn normalize_repo_relative(path: &Path) -> Result<String, ArtifactGuardError> {
-    let mut parts = Vec::new();
-    for component in path.components() {
-        match component {
-            Component::Normal(part) => {
-                let part = part
-                    .to_str()
-                    .ok_or_else(|| ArtifactGuardError::PathEscape(path.display().to_string()))?;
-                parts.push(part);
-            }
-            Component::CurDir => {}
-            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
-                return Err(ArtifactGuardError::PathEscape(path.display().to_string()));
-            }
-        }
-    }
-    Ok(parts.join("/"))
-}
-
 fn normalize_slashes(path: &str) -> String {
     path.replace('\\', "/")
 }
@@ -706,6 +591,12 @@ fn is_root_prohibited_exemption(pattern: &str) -> bool {
         pattern,
         "node_modules"
             | "node_modules/**"
+            | "recipe-runner.log"
+            | "plan.md"
+            | ".copilot/session-state"
+            | ".copilot/session-state/**"
+            | ".amplihack/session-state"
+            | ".amplihack/session-state/**"
             | "dist"
             | "dist/**"
             | "build"

--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -8,8 +8,9 @@ use std::collections::BTreeSet;
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs;
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use thiserror::Error;
 
@@ -422,14 +423,19 @@ fn scan_ignored_present(
     violations: &mut Vec<ArtifactViolation>,
     seen: &mut BTreeSet<(ArtifactSource, String)>,
 ) -> Result<(), ArtifactGuardError> {
+    let mut candidates = Vec::new();
     for root in IGNORED_PRESENT_ROOTS {
         let candidate = repo.join(root);
         if !candidate.exists() {
             continue;
         }
         let report_path = first_reportable_path(&candidate).unwrap_or(candidate);
-        let relative = repo_relative_path(repo, &report_path)?;
-        if is_git_ignored(repo, &relative)? {
+        candidates.push(repo_relative_path(repo, &report_path)?);
+    }
+
+    let ignored = git_ignored_paths(repo, &candidates)?;
+    for relative in candidates {
+        if ignored.contains(&relative) {
             add_violation_if_prohibited(
                 &relative,
                 ArtifactSource::IgnoredPresent,
@@ -473,22 +479,45 @@ fn first_reportable_path(path: &Path) -> Option<PathBuf> {
     Some(path.to_path_buf())
 }
 
-fn is_git_ignored(repo: &Path, relative: &str) -> Result<bool, ArtifactGuardError> {
-    let output = Command::new("git")
+fn git_ignored_paths(
+    repo: &Path,
+    relative_paths: &[String],
+) -> Result<BTreeSet<String>, ArtifactGuardError> {
+    if relative_paths.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+
+    let mut child = Command::new("git")
         .args(["-C"])
         .arg(repo)
-        .args(["check-ignore", "-q", "--", relative])
-        .output()
+        .args(["check-ignore", "-z", "--stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|error| ArtifactGuardError::Git {
-            args: format!("check-ignore -q -- {relative}"),
+            args: "check-ignore -z --stdin".to_string(),
             code: None,
             stderr: error.to_string(),
         })?;
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        for relative in relative_paths {
+            stdin.write_all(relative.as_bytes())?;
+            stdin.write_all(&[0])?;
+        }
+    }
+
+    let output = child.wait_with_output()?;
     match output.status.code() {
-        Some(0) => Ok(true),
-        Some(1) => Ok(false),
+        Some(0) | Some(1) => Ok(output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|raw| !raw.is_empty())
+            .map(|raw| String::from_utf8_lossy(raw).to_string())
+            .collect()),
         code => Err(ArtifactGuardError::Git {
-            args: format!("check-ignore -q -- {relative}"),
+            args: "check-ignore -z --stdin".to_string(),
             code,
             stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
         }),
@@ -520,8 +549,7 @@ fn add_violation_if_prohibited(
 }
 
 fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static ArtifactRule> {
-    let parts: Vec<&str> = path.split('/').collect();
-    if parts.contains(&"node_modules") {
+    if path_has_component(path, "node_modules") {
         return rule("node-modules");
     }
     if path == "dist/plugin.js" || path.ends_with("/dist/plugin.js") {
@@ -536,10 +564,10 @@ fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static Artifact
     if is_workflow_session_artifact_path(path) {
         return rule("workflow-session-artifact");
     }
-    if is_cache_path(path, &parts) {
+    if is_cache_path(path) {
         return rule("cache-artifact");
     }
-    if is_build_artifact_path(path, &parts, source) {
+    if is_build_artifact_path(path, source) {
         return rule("build-artifact");
     }
     None
@@ -558,13 +586,26 @@ fn rule(id: &str) -> Option<&'static ArtifactRule> {
     DEFAULT_RULES.iter().find(|rule| rule.id == id)
 }
 
-fn is_cache_path(path: &str, parts: &[&str]) -> bool {
-    parts.iter().any(|part| {
-        matches!(
-            *part,
-            ".cache" | ".npm" | ".pnpm-store" | ".turbo" | ".parcel-cache" | ".pytest_cache"
-        )
-    }) || path == ".yarn/cache"
+fn path_has_component(path: &str, component: &str) -> bool {
+    path.split('/').any(|part| part == component)
+}
+
+fn path_has_any_component(path: &str, components: &[&str]) -> bool {
+    path.split('/').any(|part| components.contains(&part))
+}
+
+fn is_cache_path(path: &str) -> bool {
+    path_has_any_component(
+        path,
+        &[
+            ".cache",
+            ".npm",
+            ".pnpm-store",
+            ".turbo",
+            ".parcel-cache",
+            ".pytest_cache",
+        ],
+    ) || path == ".yarn/cache"
         || path.starts_with(".yarn/cache/")
         || path.contains("/.yarn/cache/")
         || path == ".next/cache"
@@ -572,19 +613,17 @@ fn is_cache_path(path: &str, parts: &[&str]) -> bool {
         || path.contains("/.next/cache/")
 }
 
-fn is_build_artifact_path(path: &str, parts: &[&str], source: ArtifactSource) -> bool {
-    if parts.contains(&"target") {
+fn is_build_artifact_path(path: &str, source: ArtifactSource) -> bool {
+    if path_has_component(path, "target") {
         return source != ArtifactSource::IgnoredPresent;
     }
     if path == "index.scip" || path.ends_with("/index.scip") {
         return true;
     }
-    if parts.iter().any(|part| {
-        matches!(
-            *part,
-            "dist" | "build" | "coverage" | "out" | "logs" | "outputs"
-        )
-    }) {
+    if path_has_any_component(
+        path,
+        &["dist", "build", "coverage", "out", "logs", "outputs"],
+    ) {
         return true;
     }
     path == ".next" || path.starts_with(".next/") || path.contains("/.next/")

--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -351,12 +351,30 @@ fn load_effective_allowlist(
         return Ok(ArtifactAllowlist::default());
     };
 
-    let allowlist_path = if path.is_absolute() {
-        path
+    let allowlist_path = resolve_allowlist_path(&path, repo)?;
+    ArtifactAllowlist::load(&allowlist_path)
+}
+
+fn resolve_allowlist_path(path: &Path, repo: &Path) -> Result<PathBuf, ArtifactGuardError> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
     } else {
         repo.join(path)
     };
-    ArtifactAllowlist::load(&allowlist_path)
+    let canonical = candidate.canonicalize().map_err(|error| {
+        ArtifactGuardError::Allowlist(format!(
+            "resolve allowlist {}: {error}",
+            candidate.display()
+        ))
+    })?;
+    if !canonical.starts_with(repo) {
+        return Err(ArtifactGuardError::PathEscape(format!(
+            "allowlist {} resolved outside repository root {}",
+            canonical.display(),
+            repo.display()
+        )));
+    }
+    Ok(canonical)
 }
 
 fn scan_git_paths(
@@ -576,7 +594,9 @@ fn validate_allowlist_entry(
     if parts.contains(&"..") {
         return Err(unsafe_reason("parent traversal is not allowed"));
     }
-    if matches!(normalized.as_str(), "*" | "**" | "**/*" | "*/**") {
+    if matches!(normalized.as_str(), "*" | "**" | "**/*" | "*/**")
+        || (!normalized.contains('/') && contains_glob_wildcard(&normalized))
+    {
         return Err(unsafe_reason("repository-wide patterns are not allowed"));
     }
     if is_root_prohibited_exemption(&normalized) {
@@ -593,37 +613,40 @@ fn validate_allowlist_entry(
 }
 
 fn is_root_prohibited_exemption(pattern: &str) -> bool {
-    matches!(
-        pattern,
-        "node_modules"
-            | "node_modules/**"
-            | "recipe-runner.log"
-            | "plan.md"
-            | ".copilot/session-state"
-            | ".copilot/session-state/**"
-            | ".amplihack/session-state"
-            | ".amplihack/session-state/**"
-            | "dist"
-            | "dist/**"
-            | "build"
-            | "build/**"
-            | "coverage"
-            | "coverage/**"
-            | ".claude/runtime"
-            | ".claude/runtime/**"
-            | "worktrees"
-            | "worktrees/**"
-            | ".cache"
-            | ".cache/**"
-            | ".next"
-            | ".next/**"
-            | "out"
-            | "out/**"
-            | "logs"
-            | "logs/**"
-            | "outputs"
-            | "outputs/**"
-    )
+    const ROOT_ARTIFACTS: &[&str] = &[
+        "node_modules",
+        "recipe-runner.log",
+        "plan.md",
+        ".copilot/session-state",
+        ".amplihack/session-state",
+        "dist",
+        "build",
+        "coverage",
+        ".claude/runtime",
+        "worktrees",
+        ".cache",
+        ".next",
+        "out",
+        "logs",
+        "outputs",
+    ];
+
+    ROOT_ARTIFACTS.iter().any(|root| {
+        root_artifact_suffix(pattern, root).is_some_and(|suffix| {
+            suffix.is_empty() || suffix == "**" || contains_glob_wildcard(suffix)
+        })
+    })
+}
+
+fn root_artifact_suffix<'a>(pattern: &'a str, root: &str) -> Option<&'a str> {
+    if pattern == root {
+        return Some("");
+    }
+    pattern.strip_prefix(root)?.strip_prefix('/')
+}
+
+fn contains_glob_wildcard(value: &str) -> bool {
+    value.contains('*') || value.contains('?')
 }
 
 fn glob_matches(pattern: &str, path: &str) -> bool {

--- a/crates/amplihack-utils/src/lib.rs
+++ b/crates/amplihack-utils/src/lib.rs
@@ -26,6 +26,7 @@
 
 /// Single source of truth for resolving the active agent binary identifier.
 pub mod agent_binary;
+pub mod artifact_guard;
 pub mod bundle_generator;
 pub mod claude_cli;
 pub mod claude_md;

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -389,9 +389,13 @@ fn allowlist_rejects_absolute_parent_traversing_empty_or_broad_entries() {
         "../dist/plugin.js",
         "node_modules/",
         "node_modules/**",
+        "dist/*",
         "dist/**",
+        "build/*",
         "recipe-runner.log",
         "plan.md",
+        "*.log",
+        ".copilot/session-state/*",
         ".copilot/session-state/**",
         ".amplihack/session-state/**",
         ".claude/runtime/**",
@@ -406,6 +410,23 @@ fn allowlist_rejects_absolute_parent_traversing_empty_or_broad_entries() {
             "unsafe entry `{entry}` must produce a clear allowlist error; got: {message}"
         );
     }
+}
+
+#[test]
+fn explicit_allowlist_path_must_stay_inside_repo() {
+    let tmp = repo();
+    let outside = TempDir::new().expect("outside tempdir");
+    let outside_allowlist = outside.path().join("artifact-allowlist");
+    write_file(&outside_allowlist, "dist/plugin.js\n");
+
+    let error = scan_artifacts(&default_config(tmp.path()).with_allowlist(outside_allowlist))
+        .expect_err("allowlists outside the repository must fail closed");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("allowlist") && message.contains("outside repository root"),
+        "outside-repo allowlist must be rejected clearly; got: {message}"
+    );
 }
 
 #[test]

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -309,6 +309,29 @@ fn tracked_generated_artifacts_are_blocked_even_when_not_staged() {
 }
 
 #[test]
+fn staged_deletion_of_tracked_generated_artifact_allows_cleanup_commit() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join("dist/plugin.js"),
+        "committed generated bundle\n",
+    );
+    run_git(tmp.path(), &["add", "-f", "dist/plugin.js"]);
+    run_git(
+        tmp.path(),
+        &["commit", "-qm", "accidentally commit plugin bundle"],
+    );
+    run_git(tmp.path(), &["rm", "-q", "dist/plugin.js"]);
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    assert!(
+        report.is_clean(),
+        "staged deletion cleanup commits should not be blocked; got {:#?}",
+        report.violations
+    );
+}
+
+#[test]
 fn narrow_allowlist_entry_exempts_only_the_exact_documented_artifact() {
     let tmp = repo();
     write_file(

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -179,6 +179,72 @@ fn ignored_present_workflow_session_artifacts_are_blocked() {
 }
 
 #[test]
+fn nested_ignored_present_artifacts_are_blocked() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join(".gitignore"),
+        "frontend/node_modules/\npackages/app/dist/\n",
+    );
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(
+        tmp.path(),
+        &["commit", "-qm", "ignore nested generated outputs"],
+    );
+
+    write_file(
+        &tmp.path().join("frontend/node_modules/leak/package.json"),
+        "{}\n",
+    );
+    write_file(
+        &tmp.path().join("packages/app/dist/assets/app.js"),
+        "bundle\n",
+    );
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    violation_for(
+        &report.violations,
+        "frontend/node_modules/leak/package.json",
+        ArtifactSource::IgnoredPresent,
+    );
+    violation_for(
+        &report.violations,
+        "packages/app/dist/assets/app.js",
+        ArtifactSource::IgnoredPresent,
+    );
+}
+
+#[test]
+fn narrow_allowlist_entry_does_not_hide_sibling_ignored_artifacts() {
+    let tmp = repo();
+    write_file(&tmp.path().join(".gitignore"), "dist/\n");
+    write_file(
+        &tmp.path().join(".amplihack-artifact-allowlist"),
+        "# reviewed generated fixture\ndist/plugin.js\n",
+    );
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore dist output"]);
+
+    write_file(&tmp.path().join("dist/plugin.js"), "intentional fixture\n");
+    write_file(&tmp.path().join("dist/zz-leak.bin"), "leak\n");
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    assert!(
+        !report
+            .violations
+            .iter()
+            .any(|violation| violation.path == "dist/plugin.js"),
+        "exact allowlist entry must suppress only dist/plugin.js"
+    );
+    violation_for(
+        &report.violations,
+        "dist/zz-leak.bin",
+        ArtifactSource::IgnoredPresent,
+    );
+}
+
+#[test]
 fn untracked_nested_worktrees_and_build_artifacts_are_blocked() {
     let tmp = repo();
     write_file(
@@ -301,6 +367,10 @@ fn allowlist_rejects_absolute_parent_traversing_empty_or_broad_entries() {
         "node_modules/",
         "node_modules/**",
         "dist/**",
+        "recipe-runner.log",
+        "plan.md",
+        ".copilot/session-state/**",
+        ".amplihack/session-state/**",
         ".claude/runtime/**",
         "worktrees/**",
     ] {

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -134,6 +134,51 @@ fn ignored_present_dist_plugin_runtime_and_cache_artifacts_are_blocked() {
 }
 
 #[test]
+fn ignored_present_workflow_session_artifacts_are_blocked() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join(".gitignore"),
+        "recipe-runner.log\nplan.md\n.copilot/session-state/\n.amplihack/session-state/\n",
+    );
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(
+        tmp.path(),
+        &["commit", "-qm", "ignore workflow runtime outputs"],
+    );
+
+    write_file(&tmp.path().join("recipe-runner.log"), "recipe output\n");
+    write_file(&tmp.path().join("plan.md"), "temporary plan\n");
+    write_file(
+        &tmp.path()
+            .join(".copilot/session-state/session-123/files/output.json"),
+        "{}\n",
+    );
+    write_file(
+        &tmp.path()
+            .join(".amplihack/session-state/session-123/workflow.json"),
+        "{}\n",
+    );
+
+    let report = scan_artifacts(
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::PrePublish),
+    )
+    .expect("scan artifacts");
+
+    for path in [
+        "recipe-runner.log",
+        "plan.md",
+        ".copilot/session-state/session-123/files/output.json",
+        ".amplihack/session-state/session-123/workflow.json",
+    ] {
+        let violation = violation_for(&report.violations, path, ArtifactSource::IgnoredPresent);
+        assert_eq!(
+            violation.rule_id, "workflow-session-artifact",
+            "{path} must be classified as a workflow/session artifact"
+        );
+    }
+}
+
+#[test]
 fn untracked_nested_worktrees_and_build_artifacts_are_blocked() {
     let tmp = repo();
     write_file(

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -1,0 +1,299 @@
+//! crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+//!
+//! Contracts for issue #755 Artifact Guard.
+//!
+//! These tests define the reusable library contract:
+//! scan staged, tracked, untracked, and ignored-present generated/runtime
+//! artifacts; fail closed on unsafe allowlists; report violations without
+//! deleting, moving, unstaging, or rewriting files.
+
+use super::{
+    ArtifactAllowlist, ArtifactGuardConfig, ArtifactGuardMode, ArtifactSource, ArtifactViolation,
+    scan_artifacts,
+};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|e| panic!("run git {args:?} in {}: {e}", repo.display()));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+        repo.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| panic!("create {}: {e}", parent.display()));
+    }
+    fs::write(path, content).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+fn repo() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    run_git(tmp.path(), &["init", "-q"]);
+    run_git(
+        tmp.path(),
+        &["config", "user.email", "artifact-guard@example.invalid"],
+    );
+    run_git(tmp.path(), &["config", "user.name", "Artifact Guard Test"]);
+    write_file(&tmp.path().join("README.md"), "# fixture\n");
+    run_git(tmp.path(), &["add", "README.md"]);
+    run_git(tmp.path(), &["commit", "-qm", "initial"]);
+    tmp
+}
+
+fn default_config(repo: &Path) -> ArtifactGuardConfig {
+    ArtifactGuardConfig::new(repo).with_mode(ArtifactGuardMode::PreCommit)
+}
+
+fn violation_for<'a>(
+    violations: &'a [ArtifactViolation],
+    path: &str,
+    source: ArtifactSource,
+) -> &'a ArtifactViolation {
+    violations
+        .iter()
+        .find(|violation| violation.path == path && violation.source == source)
+        .unwrap_or_else(|| {
+            panic!("missing violation path={path} source={source:?}; got {violations:#?}")
+        })
+}
+
+#[test]
+fn staged_node_modules_are_blocked_before_broad_staging_or_commit() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join("node_modules/leak/index.js"),
+        "module.exports = 1;\n",
+    );
+    run_git(tmp.path(), &["add", "-f", "node_modules/leak/index.js"]);
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    assert!(report.has_violations(), "staged node_modules must block");
+    let violation = violation_for(
+        &report.violations,
+        "node_modules/leak/index.js",
+        ArtifactSource::Staged,
+    );
+    assert_eq!(violation.rule_id, "node-modules");
+    assert!(
+        violation.remediation.contains("remove")
+            && violation
+                .remediation
+                .contains("outside the parent worktree"),
+        "violation must include clear remediation, got: {}",
+        violation.remediation
+    );
+    assert!(
+        tmp.path().join("node_modules/leak/index.js").exists(),
+        "guard must not delete artifacts"
+    );
+}
+
+#[test]
+fn ignored_present_dist_plugin_runtime_and_cache_artifacts_are_blocked() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join(".gitignore"),
+        "dist/plugin.js\n.claude/runtime/\n.next/cache/\n",
+    );
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore generated outputs"]);
+
+    write_file(
+        &tmp.path().join("dist/plugin.js"),
+        "generated plugin bundle\n",
+    );
+    write_file(&tmp.path().join(".claude/runtime/session.json"), "{}\n");
+    write_file(&tmp.path().join(".next/cache/webpack/index.bin"), "cache\n");
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    for (path, rule_id) in [
+        ("dist/plugin.js", "plugin-bundle"),
+        (".claude/runtime/session.json", "claude-runtime"),
+        (".next/cache/webpack/index.bin", "cache-artifact"),
+    ] {
+        let violation = violation_for(&report.violations, path, ArtifactSource::IgnoredPresent);
+        assert_eq!(
+            violation.rule_id, rule_id,
+            "{path} must be classified by the expected rule"
+        );
+    }
+}
+
+#[test]
+fn untracked_nested_worktrees_and_build_artifacts_are_blocked() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join("worktrees/feature/README.md"),
+        "nested worktree\n",
+    );
+    write_file(&tmp.path().join("coverage/lcov.info"), "TN:\n");
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    violation_for(
+        &report.violations,
+        "worktrees/feature/README.md",
+        ArtifactSource::Untracked,
+    );
+    violation_for(
+        &report.violations,
+        "coverage/lcov.info",
+        ArtifactSource::Untracked,
+    );
+}
+
+#[test]
+fn normal_source_files_and_ignored_rust_target_do_not_block_local_development() {
+    let tmp = repo();
+    write_file(&tmp.path().join("src/lib.rs"), "pub fn ok() {}\n");
+    write_file(&tmp.path().join(".gitignore"), "target/\n");
+    write_file(
+        &tmp.path().join("target/debug/deps/libfixture.rlib"),
+        "build output\n",
+    );
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    assert!(
+        report.is_clean(),
+        "ordinary source files and ignored Rust target/ output should not block; got {:#?}",
+        report.violations
+    );
+}
+
+#[test]
+fn tracked_generated_artifacts_are_blocked_even_when_not_staged() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join("dist/plugin.js"),
+        "committed generated bundle\n",
+    );
+    run_git(tmp.path(), &["add", "-f", "dist/plugin.js"]);
+    run_git(
+        tmp.path(),
+        &["commit", "-qm", "accidentally commit plugin bundle"],
+    );
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    violation_for(
+        &report.violations,
+        "dist/plugin.js",
+        ArtifactSource::Tracked,
+    );
+}
+
+#[test]
+fn narrow_allowlist_entry_exempts_only_the_exact_documented_artifact() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join(".amplihack-artifact-allowlist"),
+        "# Security-reviewed fixture for issue #755 tests.\ndist/plugin.js\n",
+    );
+    write_file(
+        &tmp.path().join("dist/plugin.js"),
+        "intentional checked fixture\n",
+    );
+    write_file(&tmp.path().join("node_modules/leak/index.js"), "leak\n");
+
+    let config =
+        default_config(tmp.path()).with_allowlist(tmp.path().join(".amplihack-artifact-allowlist"));
+    let report = scan_artifacts(&config).expect("scan artifacts");
+
+    assert!(
+        !report
+            .violations
+            .iter()
+            .any(|violation| violation.path == "dist/plugin.js"),
+        "exact allowlist entry must suppress only dist/plugin.js"
+    );
+    violation_for(
+        &report.violations,
+        "node_modules/leak/index.js",
+        ArtifactSource::Untracked,
+    );
+}
+
+#[test]
+fn allowlist_accepts_comments_blank_lines_and_narrow_entries() {
+    let tmp = repo();
+    let allowlist = tmp.path().join(".amplihack-artifact-allowlist");
+    write_file(
+        &allowlist,
+        "\n# reviewed fixture exception\n\ndocs/fixtures/plugin-output/dist/plugin.js\n",
+    );
+
+    let loaded = ArtifactAllowlist::load(&allowlist).expect("load allowlist");
+
+    assert!(
+        loaded.is_allowed("docs/fixtures/plugin-output/dist/plugin.js"),
+        "narrow reviewed entries must be active"
+    );
+}
+
+#[test]
+fn allowlist_rejects_absolute_parent_traversing_empty_or_broad_entries() {
+    let tmp = repo();
+    let allowlist = tmp.path().join(".amplihack-artifact-allowlist");
+
+    for entry in [
+        "/tmp/dist/plugin.js",
+        "../dist/plugin.js",
+        "node_modules/",
+        "node_modules/**",
+        "dist/**",
+        ".claude/runtime/**",
+        "worktrees/**",
+    ] {
+        write_file(&allowlist, &format!("{entry}\n"));
+        let error = ArtifactAllowlist::load(&allowlist)
+            .expect_err("unsafe allowlist entry must fail closed");
+        let message = error.to_string();
+        assert!(
+            message.contains("allowlist") && message.contains("unsafe"),
+            "unsafe entry `{entry}` must produce a clear allowlist error; got: {message}"
+        );
+    }
+}
+
+#[test]
+fn allowlist_with_no_reviewed_entries_fails_closed() {
+    let tmp = repo();
+    let allowlist = tmp.path().join(".amplihack-artifact-allowlist");
+    write_file(&allowlist, "\n# comments only\n");
+
+    let error = ArtifactAllowlist::load(&allowlist).expect_err("empty allowlists must fail closed");
+
+    assert!(
+        error.to_string().contains("allowlist") && error.to_string().contains("unsafe"),
+        "comments-only allowlist must be rejected clearly; got: {error}"
+    );
+}
+
+#[test]
+fn repo_path_must_resolve_inside_a_git_worktree() {
+    let tmp = TempDir::new().expect("tempdir");
+
+    let error = scan_artifacts(&default_config(tmp.path()))
+        .expect_err("non-git directories must fail closed");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("git") && message.contains("worktree"),
+        "non-git repo errors must be explicit; got: {message}"
+    );
+}

--- a/docs/artifact-guard.md
+++ b/docs/artifact-guard.md
@@ -1,0 +1,380 @@
+# Artifact Guard
+
+**Status:** Implemented.
+
+Artifact Guard prevents generated, runtime, cache, and build artifacts from
+leaking into the parent repository worktree during agent and plugin workflows.
+It is a blocking safety gate for broad staging, pre-commit, and publication
+paths. It reports violations with remediation guidance and never deletes,
+moves, unstages, or rewrites files.
+
+## Contents
+
+- [Planned behavior](#planned-behavior)
+- [Command-line interface](#command-line-interface)
+- [Default prohibited rules](#default-prohibited-rules)
+- [Allowlist configuration](#allowlist-configuration)
+- [Workflow and pre-commit coverage](#workflow-and-pre-commit-coverage)
+- [Output isolation](#output-isolation)
+- [Intended Rust API](#intended-rust-api)
+- [Fixing violations](#fixing-violations)
+
+## Behavior
+
+Artifact Guard:
+
+1. Scan repo-relative paths only.
+2. Check staged paths before commit.
+3. Check tracked, untracked, and selected ignored-present artifact paths before
+   broad staging and workflow publication.
+4. Fail closed on invalid configuration, invalid paths, Git failures, and unsafe
+   allowlist entries.
+5. Print actionable remediation before exiting.
+6. Leave the repository unchanged.
+
+`.gitignore` reduces Git noise, but it is not an authorization mechanism. The
+guard may still report ignored-present dependency trees, runtime directories, or
+cache directories when those paths indicate parent-worktree pollution.
+
+`target/` is intentionally special-cased. Normal Rust commands create an ignored
+`target/` directory in the repository, and the guard must not make ordinary
+`cargo test`, `cargo clippy`, or pre-commit usage hostile. By default:
+
+| `target/` source | Planned result |
+| --- | --- |
+| Staged | Violation |
+| Tracked | Violation |
+| Untracked because it is not ignored | Violation |
+| Ignored-present only | Not a violation |
+
+Workflow steps that need strict build-output isolation should set
+`CARGO_TARGET_DIR` to an isolated location instead of relying on the default
+repo-local `target/` directory.
+
+## Command-line interface
+
+```bash
+amplihack hygiene artifact-guard \
+  --repo <path> \
+  --mode <mode> \
+  [--allowlist <path>]
+```
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--repo <path>` | Repository worktree to scan. The path must resolve inside a Git repository. | current directory |
+| `--mode <mode>` | Scan mode: `pre-commit`, `pre-publish`, `all`, `staged`, or `worktree`. | `pre-commit` |
+| `--allowlist <path>` | Optional allowlist file. Relative paths resolve from the repository root. | `.amplihack-artifact-allowlist` when present |
+
+| Mode | Sources checked | Typical use |
+| --- | --- | --- |
+| `pre-commit` | Staged, tracked, untracked, and selected ignored-present artifact candidates | Local pre-commit hook |
+| `pre-publish` | Staged, tracked, untracked, and selected ignored-present artifact candidates | Workflow broad-staging and PR/finalize gates |
+| `all` | Staged, tracked, untracked, and selected ignored-present artifact candidates | Manual full safety scan |
+| `staged` | Staged paths only | Diagnose why a commit is blocked |
+| `worktree` | Tracked, untracked, and selected ignored-present artifact candidates | Check local leftovers before cleanup or staging |
+
+Use `all` for safety gates. Use `staged` only for focused debugging because it
+does not detect ignored or untracked leftovers.
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | No prohibited artifacts were found |
+| `1` | Prohibited artifacts were found |
+| `2` | The guard could not complete because configuration, paths, mode, allowlist, or Git state was invalid |
+
+Violation output:
+
+```text
+Artifact Guard blocked 3 prohibited artifact paths.
+
+source           path                  rule
+staged           dist/plugin.js        plugin-bundle
+ignored-present  node_modules/         dependency-tree
+untracked        .claude/runtime/      claude-runtime
+
+Remediation:
+  - Move generated, plugin, cache, and runtime output into an isolated directory.
+  - Remove local artifact leftovers from the parent worktree.
+  - If the artifact is intentional source material, add a narrow reviewed entry
+    to .amplihack-artifact-allowlist.
+```
+
+Configuration errors exit with code `2`:
+
+```text
+Artifact Guard configuration error:
+  .amplihack-artifact-allowlist:4 rejects absolute paths: /tmp/plugin.js
+
+Fix the allowlist entry or run without the allowlist.
+```
+
+## Default prohibited rules
+
+Artifact Guard rejects these paths by default when they appear in the parent
+repository worktree:
+
+| Rule | Examples | Ignored-present behavior |
+| --- | --- | --- |
+| Dependency trees | `node_modules/`, `packages/*/node_modules/` | Blocked |
+| Plugin bundles | `dist/plugin.js`, `*/dist/plugin.js` | Blocked |
+| Claude runtime | `.claude/runtime/` | Blocked |
+| Nested worktrees | `worktrees/` | Blocked |
+| Cache directories | `.cache/`, `.npm/`, `.pnpm-store/`, `.yarn/cache/`, `.turbo/`, `.parcel-cache/`, `.pytest_cache/` | Blocked |
+| Build output | `dist/`, `build/`, `coverage/`, `.next/`, `out/`, `logs/`, `outputs/`, `index.scip` | Blocked |
+| Rust build output | `target/` | Blocked only when staged, tracked, or untracked |
+| Generated indexes and logs | `index.scip`, generated runtime logs, generated output directories | Blocked |
+
+Rules match normalized repo-relative paths using `/` separators. The guard does
+not need to read artifact file contents; path-level scanning is the intended
+contract.
+
+## Allowlist configuration
+
+The default allowlist path is `.amplihack-artifact-allowlist`. This file is
+repo-controlled configuration and should be reviewed like a security-sensitive
+change because it can permit generated artifacts that the guard would otherwise
+block.
+
+Format:
+
+```text
+# Blank lines and comments are ignored.
+# Entries are repo-relative and use / separators.
+
+tests/fixtures/plugin-output/dist/plugin.js
+docs/fixtures/generated-manifests/*.json
+examples/minimal-node-project/node_modules/.package-lock.json
+```
+
+Matching semantics:
+
+| Rule | Planned behavior |
+| --- | --- |
+| Path root | Entries are relative to the repository root |
+| Separators | `/` only; Windows-style `\` separators are rejected |
+| Case | Case-sensitive matching |
+| Exact paths | `tests/fixtures/dist/plugin.js` matches only that path |
+| `*`, `?`, `[]` | Supported within a path segment |
+| `**` | Supported across path segments |
+| Directory entries | Must use an explicit suffix such as `tests/fixtures/output/**`; a bare directory does not imply recursive matching |
+| Duplicates | Duplicate entries are allowed but normalized to one effective rule |
+| Comments | Lines beginning with `#` after optional whitespace are ignored |
+
+Valid entries are narrow and intentional:
+
+```text
+tests/fixtures/plugin-output/dist/plugin.js
+tests/fixtures/plugin-output/dist/**
+examples/generated-output/build/expected-manifest.json
+```
+
+Invalid entries fail closed with exit code `2`:
+
+```text
+/absolute/path
+../outside-repo
+node_modules/
+node_modules/**
+**/node_modules/**
+dist/
+dist/**
+build/**
+*
+**/*
+```
+
+Directory allowlists are accepted only for narrow fixture or example paths. They
+must not exempt a default prohibited directory directly at the repository root or
+across the whole repository.
+
+## Workflow and pre-commit coverage
+
+Artifact Guard will run before every broad staging operation in the bundled
+recipes, not just publish and finalize. The initial guarded recipe set is every
+recipe that currently invokes `git add -A`:
+
+| Recipe | Guard placement |
+| --- | --- |
+| `workflow-finalize.yaml` | Before final broad staging |
+| `workflow-publish.yaml` | Before publication staging and before any broad staging in remediation paths |
+| `workflow-refactor-review.yaml` | Before broad staging |
+| `workflow-tdd.yaml` | Before broad staging |
+| `workflow-pr-review.yaml` | Before broad staging |
+| `consensus-publish.yaml` | Before broad staging |
+| `consensus-pr-feedback.yaml` | Before broad staging |
+
+Future recipe changes must preserve the rule: any new `git add -A` or equivalent
+broad-staging step needs an Artifact Guard gate immediately before it.
+
+The planned pre-commit hook is a full repository scan:
+
+```yaml
+- id: artifact-guard
+  name: amplihack artifact guard
+entry: amplihack hygiene artifact-guard --repo . --mode pre-commit
+  language: system
+  pass_filenames: false
+always_run: true
+```
+
+`pass_filenames: false` is required. Git normally passes only staged filenames to
+pre-commit hooks, which would miss ignored and untracked artifact leftovers.
+Artifact Guard must inspect repository state itself.
+
+For local source checkouts where `amplihack` is not on `PATH`, use the workspace
+binary:
+
+```bash
+cargo run --bin amplihack -- hygiene artifact-guard --repo . --mode all
+```
+
+The checked-in pre-commit Cargo hooks set `CARGO_TARGET_DIR` under
+`${TMPDIR:-/tmp}` so running the guard, clippy, or tests from hooks does not
+recreate Cargo build output inside the parent worktree.
+
+## Output isolation
+
+The preferred fix for a violation is output isolation, not allowlisting.
+Allowlisting is only for intentional checked-in fixtures or reviewed generated
+artifacts.
+
+These locations are intentionally not prohibited by default:
+
+```text
+<repo>/.amplihack/runtime/
+<repo>/.amplihack/cache/
+<repo>/.amplihack/generated/
+<git-common-dir>/.claude/runtime/
+/tmp/amplihack-<purpose>-<id>/
+```
+
+Use `CARGO_TARGET_DIR` for workflow-owned Rust builds that need to avoid the
+repo-local `target/` directory:
+
+```bash
+CARGO_TARGET_DIR=.amplihack/cache/cargo-target cargo test --workspace
+```
+
+Avoid writing generated output directly to:
+
+```text
+<repo>/node_modules/
+<repo>/dist/plugin.js
+<repo>/.claude/runtime/
+<repo>/worktrees/
+<repo>/build/
+```
+
+## Intended Rust API
+
+The guard core should live in `amplihack_utils::artifact_guard` so CLI commands,
+recipes, and tests share one implementation. This is the intended public shape;
+implementation may rename fields only if this document is updated in the same
+change.
+
+```rust
+pub struct ArtifactGuardConfig {
+    pub repo_path: PathBuf,
+    pub mode: ArtifactGuardMode,
+    pub allowlist_path: Option<PathBuf>,
+}
+
+pub enum ArtifactGuardMode {
+    All,
+    Staged,
+    Worktree,
+}
+
+pub enum ArtifactSource {
+    Staged,
+    Tracked,
+    Untracked,
+    IgnoredPresent,
+}
+
+pub struct ArtifactViolation {
+    pub path: String,
+    pub source: ArtifactSource,
+    pub rule_id: String,
+    pub message: String,
+}
+
+pub struct ArtifactGuardReport {
+    pub repo_root: PathBuf,
+    pub mode: ArtifactGuardMode,
+    pub violations: Vec<ArtifactViolation>,
+}
+
+pub fn run_artifact_guard(
+    config: ArtifactGuardConfig,
+) -> Result<ArtifactGuardReport, ArtifactGuardError>;
+```
+
+`run_artifact_guard` resolves the repository root, validates the allowlist,
+collects candidate paths from Git, applies prohibited rules, applies allowlist
+exceptions, and returns a structured report. It must not mutate the repository.
+
+Errors are fail-closed:
+
+| Error class | Examples |
+| --- | --- |
+| Repository errors | `--repo` is not a Git worktree, Git command fails |
+| Path errors | Path escapes repo root, path cannot be normalized |
+| Mode errors | Unknown CLI mode |
+| Allowlist errors | Unreadable file, absolute path, parent traversal, broad exemption |
+
+## Fixing violations
+
+For a blocked commit:
+
+```bash
+amplihack hygiene artifact-guard --repo . --mode staged
+git restore --staged dist/plugin.js
+```
+
+Then move the build output to an isolated location or remove the local artifact
+if it is not needed.
+
+For ignored leftovers before publication:
+
+```bash
+amplihack hygiene artifact-guard --repo . --mode all
+```
+
+If the guard reports `node_modules/`, `.claude/runtime/`, or another
+ignored-present artifact, relocate or remove the local output. Do not treat
+`.gitignore` as approval to keep parent-worktree pollution.
+
+For an intentional fixture, add the narrowest allowlist entry that preserves the
+test:
+
+```text
+tests/fixtures/plugin-output/dist/plugin.js
+```
+
+Commit the allowlist change with the fixture. Reviewers should confirm the
+artifact is necessary, deterministic, and safe to keep in the repository.
+
+## Review expectations
+
+Review these changes carefully:
+
+1. New or changed `.amplihack-artifact-allowlist` entries.
+2. Changes to prohibited rules.
+3. Recipe edits around `git add -A`, publication, finalization, or PR creation.
+4. Pre-commit changes that remove `pass_filenames: false`.
+5. Build, plugin, or runtime changes that redirect outputs into the parent
+   worktree.
+
+Reviewers should verify that generated and runtime outputs are isolated, guard
+failures are visible, and allowlist entries are not used as substitutes for
+proper output placement.
+
+## Related documentation
+
+- [Recipe CLI Reference](reference/recipe-cli-reference.md)
+- [Pre-Commit Diagnostics](claude/agents/amplihack/specialized/pre-commit-diagnostic.md)
+- [Developing amplihack](DEVELOPING_AMPLIHACK.md)

--- a/docs/artifact-guard.md
+++ b/docs/artifact-guard.md
@@ -157,7 +157,7 @@ Matching semantics:
 | Separators | `/` only; Windows-style `\` separators are rejected |
 | Case | Case-sensitive matching |
 | Exact paths | `tests/fixtures/dist/plugin.js` matches only that path |
-| `*`, `?`, `[]` | Supported within a path segment |
+| `*`, `?` | Supported within a path segment |
 | `**` | Supported across path segments |
 | Directory entries | Must use an explicit suffix such as `tests/fixtures/output/**`; a bare directory does not imply recursive matching |
 | Duplicates | Duplicate entries are allowed but normalized to one effective rule |
@@ -179,8 +179,10 @@ Invalid entries fail closed with exit code `2`:
 node_modules/
 node_modules/**
 **/node_modules/**
+dist/*
 dist/
 dist/**
+*.log
 build/**
 *
 **/*

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,6 +139,7 @@ amplihack copilot
 
 - [Profile Management](PROFILE_MANAGEMENT.md) - Multiple environment configurations
 - [Hook Configuration](HOOK_CONFIGURATION_GUIDE.md) - Customize framework behavior
+- [Artifact Guard](artifact-guard.md) - Guard for broad staging, pre-commit, and workflow publication artifacts
 - [Memory Configuration Consent](features/memory-consent-prompt.md) - Intelligent memory settings with timeout protection
 - [Verify .claude/ Staging](howto/verify-claude-staging.md) - Check that framework files are properly staged
 - [Verify Runtime Asset Resolution](howto/verify-runtime-asset-resolution.md) - Check helper, session, hooks, and multitask asset parity

--- a/tests/integration/artifact_guard_cli_tests.rs
+++ b/tests/integration/artifact_guard_cli_tests.rs
@@ -1,0 +1,202 @@
+//! tests/integration/artifact_guard_cli_tests.rs
+//!
+//! Contracts for the `amplihack hygiene artifact-guard` CLI.
+//!
+//! The command must scan the whole repository state, return exit code 1 for
+//! artifact violations, return exit code 2 for configuration/Git failures, and
+//! print actionable remediation without deleting artifacts.
+
+use amplihack_cli::Cli;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_amplihack")
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|e| panic!("run git {args:?} in {}: {e}", repo.display()));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+        repo.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| panic!("create {}: {e}", parent.display()));
+    }
+    fs::write(path, content).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+fn repo() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    run_git(tmp.path(), &["init", "-q"]);
+    run_git(
+        tmp.path(),
+        &["config", "user.email", "artifact-guard@example.invalid"],
+    );
+    run_git(tmp.path(), &["config", "user.name", "Artifact Guard Test"]);
+    write_file(&tmp.path().join("README.md"), "# fixture\n");
+    run_git(tmp.path(), &["add", "README.md"]);
+    run_git(tmp.path(), &["commit", "-qm", "initial"]);
+    tmp
+}
+
+#[test]
+fn hygiene_artifact_guard_cli_surface_parses_repo_mode_and_allowlist() {
+    let parsed = Cli::try_parse_from([
+        "amplihack",
+        "hygiene",
+        "artifact-guard",
+        "--repo",
+        "/tmp/example-repo",
+        "--mode",
+        "pre-commit",
+        "--allowlist",
+        "/tmp/example-repo/.amplihack-artifact-allowlist",
+    ]);
+
+    assert!(
+        parsed.is_ok(),
+        "hygiene artifact-guard must parse --repo, --mode, and --allowlist: {parsed:?}"
+    );
+}
+
+#[test]
+fn artifact_guard_help_documents_exit_codes_and_remediation_behavior() {
+    let error = Cli::try_parse_from(["amplihack", "hygiene", "artifact-guard", "--help"])
+        .expect_err("clap help exits through an error-like display result");
+    let help = error.to_string();
+
+    for required in [
+        "pre-commit",
+        "pre-publish",
+        "exit code 0",
+        "exit code 1",
+        "exit code 2",
+        "does not delete",
+        "allowlist",
+    ] {
+        assert!(
+            help.contains(required),
+            "artifact-guard help must document `{required}`; got:\n{help}"
+        );
+    }
+}
+
+#[test]
+fn cli_returns_exit_1_with_paths_and_remediation_for_artifact_violations() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join("dist/plugin.js"),
+        "generated plugin bundle\n",
+    );
+
+    let output = Command::new(bin())
+        .args([
+            "hygiene",
+            "artifact-guard",
+            "--mode",
+            "pre-commit",
+            "--repo",
+        ])
+        .arg(tmp.path())
+        .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
+        .output()
+        .expect("run artifact guard");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "artifact violations must exit 1\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("dist/plugin.js"),
+        "must print repo-relative path"
+    );
+    assert!(
+        combined.contains("remove") && combined.contains("outside the parent worktree"),
+        "must print clear remediation; got:\n{combined}"
+    );
+    assert!(
+        tmp.path().join("dist/plugin.js").exists(),
+        "CLI guard must not silently delete artifacts"
+    );
+}
+
+#[test]
+fn cli_returns_exit_0_for_clean_repository() {
+    let tmp = repo();
+
+    let output = Command::new(bin())
+        .args([
+            "hygiene",
+            "artifact-guard",
+            "--mode",
+            "pre-commit",
+            "--repo",
+        ])
+        .arg(tmp.path())
+        .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
+        .output()
+        .expect("run artifact guard");
+
+    assert!(
+        output.status.success(),
+        "clean repos must exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cli_returns_exit_2_for_invalid_allowlist() {
+    let tmp = repo();
+    let allowlist = tmp.path().join(".amplihack-artifact-allowlist");
+    write_file(&allowlist, "node_modules/**\n");
+
+    let output = Command::new(bin())
+        .args([
+            "hygiene",
+            "artifact-guard",
+            "--mode",
+            "pre-commit",
+            "--repo",
+        ])
+        .arg(tmp.path())
+        .arg("--allowlist")
+        .arg(&allowlist)
+        .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
+        .output()
+        .expect("run artifact guard");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "invalid allowlist must exit 2\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("allowlist") && stderr.contains("unsafe"),
+        "invalid allowlist error must be clear; got:\n{stderr}"
+    );
+}

--- a/tests/integration/artifact_guard_workflow_tests.rs
+++ b/tests/integration/artifact_guard_workflow_tests.rs
@@ -1,0 +1,218 @@
+//! tests/integration/artifact_guard_workflow_tests.rs
+//!
+//! Structural contracts for issue #755 workflow integration.
+//!
+//! Every recipe that performs broad staging must invoke Artifact Guard first so
+//! generated/runtime artifacts cannot be swept into a default workflow commit
+//! or PR publication path.
+
+use serde_yaml::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn recipes_dir() -> PathBuf {
+    workspace_root().join("amplifier-bundle").join("recipes")
+}
+
+fn recipe_path(name: &str) -> PathBuf {
+    recipes_dir().join(name)
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn load_recipe(name: &str) -> Value {
+    let path = recipe_path(name);
+    serde_yaml::from_str(&read(&path)).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn steps(recipe: &Value) -> &[Value] {
+    recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("recipe must contain top-level steps")
+}
+
+fn step_index(recipe: &Value, id: &str) -> usize {
+    steps(recipe)
+        .iter()
+        .position(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .unwrap_or_else(|| panic!("missing recipe step `{id}`"))
+}
+
+fn step_text<'a>(recipe: &'a Value, id: &str, field: &str) -> &'a str {
+    steps(recipe)
+        .iter()
+        .find(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .and_then(|step| step.get(field).and_then(Value::as_str))
+        .unwrap_or_else(|| panic!("step `{id}` must contain a {field}"))
+}
+
+fn recipe_files() -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for entry in fs::read_dir(recipes_dir()).expect("read recipes dir") {
+        let path = entry.expect("recipe dir entry").path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("yaml") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    files
+}
+
+#[test]
+fn publish_runs_artifact_guard_before_commit_push_and_pr_publication_paths() {
+    let recipe = load_recipe("workflow-publish.yaml");
+    let commit_index = step_index(&recipe, "step-15-commit-push");
+    let publish_index = step_index(&recipe, "step-16-create-draft-pr");
+    let fix_loop_index = step_index(&recipe, "step-16b-outside-in-fix-loop");
+
+    let guard_index = steps(&recipe)
+        .iter()
+        .position(|step| {
+            step.get("command")
+                .and_then(Value::as_str)
+                .is_some_and(|command| {
+                    command.contains("amplihack hygiene artifact-guard")
+                        && command.contains("--mode pre-publish")
+                })
+        })
+        .expect("workflow-publish must include an artifact guard command step");
+
+    assert!(
+        guard_index < commit_index && guard_index < publish_index && guard_index < fix_loop_index,
+        "artifact guard must run before broad staging, PR creation, and outside-in fix publication"
+    );
+}
+
+#[test]
+fn finalize_runs_artifact_guard_before_cleanup_commit_or_final_push() {
+    let recipe = load_recipe("workflow-finalize.yaml");
+    let push_cleanup_index = step_index(&recipe, "step-20b-push-cleanup");
+
+    let guard_index = steps(&recipe)
+        .iter()
+        .position(|step| {
+            step.get("command")
+                .and_then(Value::as_str)
+                .is_some_and(|command| {
+                    command.contains("amplihack hygiene artifact-guard")
+                        && command.contains("--mode pre-publish")
+                })
+        })
+        .expect("workflow-finalize must include an artifact guard command step");
+
+    assert!(
+        guard_index < push_cleanup_index,
+        "artifact guard must run before workflow-finalize cleanup commit/push"
+    );
+}
+
+#[test]
+fn every_recipe_with_git_add_all_invokes_guard_first() {
+    let mut missing = Vec::new();
+
+    for path in recipe_files() {
+        let text = read(&path);
+        let broad_add_positions: Vec<usize> = ["git add -A", "git add --all", "git add ."]
+            .iter()
+            .flat_map(|needle| text.match_indices(needle).map(|(index, _)| index))
+            .collect();
+        if broad_add_positions.is_empty() {
+            continue;
+        }
+
+        let guard_position = text.find("amplihack hygiene artifact-guard");
+        for add_position in broad_add_positions {
+            if !guard_position.is_some_and(|guard| guard < add_position) {
+                missing.push(format!(
+                    "{}: missing artifact guard before broad staging at byte {add_position}",
+                    path.strip_prefix(workspace_root())
+                        .unwrap_or(&path)
+                        .display()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "all broad staging recipes must run Artifact Guard first:\n{}",
+        missing.join("\n")
+    );
+}
+
+#[test]
+fn publish_and_finalize_do_not_inline_shell_delete_artifacts_as_remediation() {
+    for recipe_name in ["workflow-publish.yaml", "workflow-finalize.yaml"] {
+        let text = read(&recipe_path(recipe_name));
+        for forbidden in [
+            "rm -rf node_modules",
+            "rm -rf dist",
+            "rm -rf .claude/runtime",
+            "git clean -fdx",
+            "git reset --hard",
+        ] {
+            assert!(
+                !text.contains(forbidden),
+                "{recipe_name} must fail with remediation, not silently delete artifacts via `{forbidden}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn guard_command_uses_structured_cli_arguments_not_shell_interpolation() {
+    for recipe_name in ["workflow-publish.yaml", "workflow-finalize.yaml"] {
+        let recipe = load_recipe(recipe_name);
+        let commands: Vec<&str> = steps(&recipe)
+            .iter()
+            .filter_map(|step| step.get("command").and_then(Value::as_str))
+            .filter(|command| command.contains("amplihack hygiene artifact-guard"))
+            .collect();
+
+        assert!(
+            !commands.is_empty(),
+            "{recipe_name} must invoke amplihack hygiene artifact-guard"
+        );
+        for command in commands {
+            assert!(
+                command.contains("--repo .") || command.contains("--repo \"$REPO_PATH\""),
+                "{recipe_name} guard must pass an explicit repo path; command was:\n{command}"
+            );
+            assert!(
+                command.contains("--mode pre-publish"),
+                "{recipe_name} guard must use pre-publish mode before PR/finalize publication; command was:\n{command}"
+            );
+            assert!(
+                !command.contains("eval ") && !command.contains("sh -c"),
+                "{recipe_name} guard must not be invoked through eval/sh -c; command was:\n{command}"
+            );
+        }
+    }
+}
+
+#[test]
+fn workflow_publish_outside_in_fix_loop_guards_its_inline_git_add_all() {
+    let recipe = load_recipe("workflow-publish.yaml");
+    let prompt = step_text(&recipe, "step-16b-outside-in-fix-loop", "prompt");
+    let guard = prompt
+        .find("amplihack hygiene artifact-guard")
+        .expect("outside-in fix loop must guard its inline git add -A");
+    let add = prompt
+        .find("git add -A")
+        .expect("outside-in fix loop currently contains broad staging");
+
+    assert!(
+        guard < add,
+        "outside-in fix loop must invoke artifact guard immediately before broad staging"
+    );
+}

--- a/tests/integration/artifact_guard_workflow_tests.rs
+++ b/tests/integration/artifact_guard_workflow_tests.rs
@@ -206,6 +206,50 @@ fn every_recipe_with_git_add_all_invokes_guard_first() {
 }
 
 #[test]
+fn recipe_commands_with_guarded_broad_staging_fail_loudly() {
+    let mut unsafe_commands = Vec::new();
+
+    for path in recipe_files() {
+        let recipe = serde_yaml::from_str::<Value>(&read(&path))
+            .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+        for step in steps(&recipe) {
+            let id = step
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>");
+            let Some(command) = step.get("command").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(guard_position) = command.find("amplihack hygiene artifact-guard") else {
+                continue;
+            };
+            let broad_add_after_guard =
+                ["git add -A", "git add --all", "git add ."]
+                    .iter()
+                    .any(|needle| {
+                        command
+                            .match_indices(needle)
+                            .any(|(add_position, _)| guard_position < add_position)
+                    });
+            if broad_add_after_guard && !command.contains("set -euo pipefail") {
+                unsafe_commands.push(format!(
+                    "{}:{id} guards broad staging but lacks `set -euo pipefail`",
+                    path.strip_prefix(workspace_root())
+                        .unwrap_or(&path)
+                        .display()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        unsafe_commands.is_empty(),
+        "guard failures must stop broad staging:\n{}",
+        unsafe_commands.join("\n")
+    );
+}
+
+#[test]
 fn publish_and_finalize_do_not_inline_shell_delete_artifacts_as_remediation() {
     for recipe_name in ["workflow-publish.yaml", "workflow-finalize.yaml"] {
         let text = read(&recipe_path(recipe_name));

--- a/tests/integration/artifact_guard_workflow_tests.rs
+++ b/tests/integration/artifact_guard_workflow_tests.rs
@@ -96,24 +96,79 @@ fn publish_runs_artifact_guard_before_commit_push_and_pr_publication_paths() {
 #[test]
 fn finalize_runs_artifact_guard_before_cleanup_commit_or_final_push() {
     let recipe = load_recipe("workflow-finalize.yaml");
+    let final_cleanup_index = step_index(&recipe, "step-20-final-cleanup");
+    let guard_index = step_index(&recipe, "step-20a-artifact-guard");
     let push_cleanup_index = step_index(&recipe, "step-20b-push-cleanup");
-
-    let guard_index = steps(&recipe)
-        .iter()
-        .position(|step| {
-            step.get("command")
-                .and_then(Value::as_str)
-                .is_some_and(|command| {
-                    command.contains("amplihack hygiene artifact-guard")
-                        && command.contains("--mode pre-publish")
-                })
-        })
-        .expect("workflow-finalize must include an artifact guard command step");
+    let guard_command = step_text(&recipe, "step-20a-artifact-guard", "command");
 
     assert!(
-        guard_index < push_cleanup_index,
-        "artifact guard must run before workflow-finalize cleanup commit/push"
+        guard_command.contains("amplihack hygiene artifact-guard")
+            && guard_command.contains("--mode pre-publish"),
+        "workflow-finalize step-20a must invoke Artifact Guard in pre-publish mode"
     );
+    assert!(
+        final_cleanup_index < guard_index && guard_index < push_cleanup_index,
+        "artifact guard must run after agent cleanup and before workflow-finalize cleanup commit/push"
+    );
+}
+
+#[test]
+fn finalize_push_cleanup_guards_immediately_before_broad_staging() {
+    let recipe = load_recipe("workflow-finalize.yaml");
+    let command = step_text(&recipe, "step-20b-push-cleanup", "command");
+    let guard = command
+        .find("amplihack hygiene artifact-guard --repo . --mode pre-publish")
+        .expect("step-20b must guard the exact repo before broad staging");
+    let add = command
+        .find("git add -A")
+        .expect("step-20b currently performs broad staging");
+    let between = &command[guard..add];
+
+    assert!(
+        guard < add,
+        "step-20b must invoke Artifact Guard before git add -A"
+    );
+    assert!(
+        between
+            .lines()
+            .filter(|line| {
+                let trimmed = line.trim();
+                !trimmed.is_empty()
+                    && !trimmed.starts_with("amplihack hygiene artifact-guard")
+                    && !trimmed.starts_with("git add -A")
+            })
+            .count()
+            == 0,
+        "Artifact Guard must be the deterministic final gate immediately before git add -A; intervening lines:\n{between}"
+    );
+}
+
+#[test]
+fn finalize_artifact_guard_failures_are_not_silenced() {
+    let recipe = load_recipe("workflow-finalize.yaml");
+    let guard_commands: Vec<&str> = steps(&recipe)
+        .iter()
+        .filter_map(|step| step.get("command").and_then(Value::as_str))
+        .filter(|command| command.contains("amplihack hygiene artifact-guard"))
+        .collect();
+
+    assert!(
+        !guard_commands.is_empty(),
+        "workflow-finalize must invoke Artifact Guard"
+    );
+    for command in guard_commands {
+        for line in command
+            .lines()
+            .filter(|line| line.contains("amplihack hygiene artifact-guard"))
+        {
+            assert!(
+                !line.contains("|| true")
+                    && !line.contains("|| :")
+                    && !line.contains("2>/dev/null"),
+                "Artifact Guard failures must fail loudly, not be hidden: `{line}`"
+            );
+        }
+    }
 }
 
 #[test]

--- a/tests/integration/artifact_guard_workflow_tests.rs
+++ b/tests/integration/artifact_guard_workflow_tests.rs
@@ -309,9 +309,17 @@ fn workflow_publish_outside_in_fix_loop_guards_its_inline_git_add_all() {
     let add = prompt
         .find("git add -A")
         .expect("outside-in fix loop currently contains broad staging");
+    let guarded_line = prompt[guard..]
+        .lines()
+        .next()
+        .expect("guard snippet must be line-oriented");
 
     assert!(
         guard < add,
         "outside-in fix loop must invoke artifact guard immediately before broad staging"
+    );
+    assert!(
+        guarded_line.contains("&& git add -A"),
+        "outside-in fix loop snippet must hard-chain guard success to broad staging; line was `{guarded_line}`"
     );
 }

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -132,6 +132,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     // Phase 6: workflow-publish (terminal gate + steps 14-16b)
     "publish-terminal-state",
     "step-14-bump-version",
+    "step-14g-artifact-guard",
     "step-15-commit-push",
     "step-16-create-draft-pr",
     "step-16b-outside-in-fix-loop",
@@ -154,6 +155,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     // Phase 8: workflow-finalize (terminal gate + steps 20-22b + complete)
     "finalize-terminal-state",
     "step-20-final-cleanup",
+    "step-20a-artifact-guard",
     "step-20b-push-cleanup",
     "step-20c-quality-audit",
     "step-21-pr-ready",

--- a/tests/integration/pre_commit_artifact_guard_tests.rs
+++ b/tests/integration/pre_commit_artifact_guard_tests.rs
@@ -1,0 +1,146 @@
+//! tests/integration/pre_commit_artifact_guard_tests.rs
+//!
+//! Contracts for local pre-commit Artifact Guard wiring.
+//!
+//! The hook must scan repository state rather than only the filenames passed by
+//! pre-commit, because issue #755 is about ignored/untracked generated artifacts
+//! left in the parent worktree.
+
+use serde_yaml::Value;
+use std::fs;
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn pre_commit_config() -> Value {
+    let path = workspace_root().join(".pre-commit-config.yaml");
+    let text = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn local_hooks(config: &Value) -> Vec<&Value> {
+    config
+        .get("repos")
+        .and_then(Value::as_sequence)
+        .expect("pre-commit config must contain repos")
+        .iter()
+        .filter(|repo| repo.get("repo").and_then(Value::as_str) == Some("local"))
+        .flat_map(|repo| {
+            repo.get("hooks")
+                .and_then(Value::as_sequence)
+                .expect("local repo must contain hooks")
+        })
+        .collect()
+}
+
+fn hook<'a>(hooks: &'a [&Value], id: &str) -> &'a Value {
+    hooks
+        .iter()
+        .copied()
+        .find(|hook| hook.get("id").and_then(Value::as_str) == Some(id))
+        .unwrap_or_else(|| panic!("missing local pre-commit hook `{id}`"))
+}
+
+#[test]
+fn pre_commit_config_has_full_repo_artifact_guard_hook() {
+    let config = pre_commit_config();
+    let hooks = local_hooks(&config);
+    let hook = hook(&hooks, "artifact-guard");
+
+    assert_eq!(
+        hook.get("pass_filenames").and_then(Value::as_bool),
+        Some(false),
+        "Artifact Guard must scan full repo state, not only pre-commit filenames"
+    );
+    assert_eq!(
+        hook.get("language").and_then(Value::as_str),
+        Some("system"),
+        "Artifact Guard should use the repo's system-command hook convention"
+    );
+    assert_eq!(
+        hook.get("always_run").and_then(Value::as_bool),
+        Some(true),
+        "Artifact Guard must run even when only ignored/untracked artifacts are present"
+    );
+}
+
+#[test]
+fn pre_commit_artifact_guard_entry_uses_repo_cli_and_pre_commit_mode() {
+    let config = pre_commit_config();
+    let hooks = local_hooks(&config);
+    let hook = hook(&hooks, "artifact-guard");
+    let entry = hook
+        .get("entry")
+        .and_then(Value::as_str)
+        .expect("artifact guard hook must declare an entry");
+
+    assert!(
+        entry.contains("amplihack hygiene artifact-guard")
+            || entry.contains("cargo run --bin amplihack -- hygiene artifact-guard"),
+        "hook must invoke the Artifact Guard CLI or repo-local cargo fallback; entry was `{entry}`"
+    );
+    assert!(
+        entry.contains("--repo .") && entry.contains("--mode pre-commit"),
+        "hook must pass explicit repo and pre-commit mode; entry was `{entry}`"
+    );
+    assert!(
+        entry.contains("CARGO_TARGET_DIR") && entry.contains("/tmp"),
+        "cargo fallback must isolate build output outside the parent worktree; entry was `{entry}`"
+    );
+}
+
+#[test]
+fn pre_commit_artifact_guard_hook_is_not_limited_by_files_filter() {
+    let config = pre_commit_config();
+    let hooks = local_hooks(&config);
+    let hook = hook(&hooks, "artifact-guard");
+
+    assert!(
+        hook.get("files").is_none() && hook.get("types").is_none(),
+        "Artifact Guard hook must not use files/types filters because ignored-present artifacts may not be in the commit file list"
+    );
+}
+
+#[test]
+fn pre_commit_hook_order_runs_artifact_guard_before_format_lint_and_tests() {
+    let config = pre_commit_config();
+    let hooks = local_hooks(&config);
+    let artifact_index = hooks
+        .iter()
+        .position(|hook| hook.get("id").and_then(Value::as_str) == Some("artifact-guard"))
+        .expect("artifact guard hook must exist");
+
+    for later_hook in ["cargo-fmt", "cargo-clippy", "cargo-test"] {
+        let later_index = hooks
+            .iter()
+            .position(|hook| hook.get("id").and_then(Value::as_str) == Some(later_hook))
+            .unwrap_or_else(|| panic!("missing expected hook `{later_hook}`"));
+        assert!(
+            artifact_index < later_index,
+            "Artifact Guard should fail fast before `{later_hook}`"
+        );
+    }
+}
+
+#[test]
+fn pre_commit_build_hooks_use_isolated_target_dir() {
+    let config = pre_commit_config();
+    let hooks = local_hooks(&config);
+
+    for id in ["cargo-clippy", "cargo-test"] {
+        let hook = hook(&hooks, id);
+        let entry = hook
+            .get("entry")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("{id} must declare an entry"));
+        assert!(
+            entry.contains("CARGO_TARGET_DIR") && entry.contains("/tmp"),
+            "{id} must isolate Cargo build output outside the parent worktree; entry was `{entry}`"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add Artifact Guard library and CLI to block staged, tracked, untracked, and ignored-present generated/runtime artifacts
- wire the guard before broad staging in publish/finalize and other recipes, plus local pre-commit
- ignore common artifact noise while keeping an explicit repo-controlled allowlist and documentation

Fixes #755

## Validation
- pre-commit run --all-files
- cargo test -p amplihack-utils artifact_guard -- --nocapture
- cargo test -p amplihack --test artifact_guard_cli --test artifact_guard_workflow --test pre_commit_artifact_guard -- --nocapture
- cargo test --workspace -- --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu (blocked: existing golden tests hard-code target/debug/amplihack when CARGO_TARGET_DIR is isolated; rerun with default target was blocked by concurrent Cargo locks)

## Step 13: Local Testing Results

### Scenario 1 — Artifact guard help surface
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-755-default-workflow-closure-workstream-for-issue-755 amplihack hygiene artifact-guard --help`
Result: PASS
Output: `Block generated/runtime artifacts before broad staging, commit, or publication`; help documented `pre-commit`, `pre-publish`, `staged`, and `worktree` modes; exit code meanings; and the non-mutating remediation behavior.

### Scenario 2 — Worktree artifact violation blocks publication
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-755-default-workflow-closure-workstream-for-issue-755 amplihack hygiene artifact-guard --mode worktree --repo /tmp/tmp.4HR9IOQw2L/repo`
Result: PASS
Output: `Artifact Guard blocked 1 prohibited artifact path(s) in /tmp/tmp.4HR9IOQw2L/repo (mode: worktree).`; flagged `.copilot/session-state/leaked-session/files/result.txt` as `workflow-session-artifact`; printed remediation to remove or move local artifact leftovers, or use a narrow reviewed allowlist entry when intentional; command exited with status 1 as expected.

## Step 16b: Outside-In Testing Results

### Scenario 1 - Simple help surface
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-755-default-workflow-closure-workstream-for-issue-755 amplihack hygiene artifact-guard --help`
Result: PASS
Key output: `Block generated/runtime artifacts before broad staging, commit, or publication`; help lists `pre-commit`, `pre-publish`, `all`, `staged`, and `worktree` modes plus exit codes 0/1/2 and states the guard does not delete artifacts.
Fix count: 0

### Scenario 2 - Edge/integration ignored workflow artifact blocks publication
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-755-default-workflow-closure-workstream-for-issue-755 amplihack hygiene artifact-guard --mode worktree --repo <temp-git-repo-with-ignored-.copilot/session-state-artifact>`
Result: PASS
Key output: `Artifact Guard blocked 1 prohibited artifact path(s)`; flagged `.copilot/session-state/leaked-session/files/result.txt` from `ignored-present` as `workflow-session-artifact`; returned exit status 1 as expected and printed remediation without deleting the artifact.
Fix count: 0

### Local guard/workflow validation
Command: `uvx pre-commit install && uvx pre-commit run --all-files`
Result: PASS
Key output: merge-conflict, whitespace, EOF, YAML, TOML, large-file, artifact-guard, cargo-fmt, and cargo-clippy hooks passed from a clean detached worktree at PR head `0b1bd64`.
Fix count: 0

Command: `cargo test -p amplihack-utils artifact_guard -- --nocapture && cargo test -p amplihack --test artifact_guard_cli --test artifact_guard_workflow --test pre_commit_artifact_guard -- --nocapture`
Result: PASS
Key output: artifact guard unit tests passed (11/11); CLI tests passed (5/5); workflow tests passed (8/8); pre-commit artifact guard tests passed (5/5).
Fix count: 0

### CI follow-up
Command: `gh run view 27396373294 --job 80964565109 --log-failed`
Result: DIAGNOSED; no new fix needed
Key output: the historical failing Test job was `default_workflow_decomposition::composed_step_inventory_matches_expected_in_order`, expecting 62 steps but seeing 64. Later commits on the same PR branch already resolved this: latest PR #759 CI Test is green at `0b1bd64`.
Fix count: 0
