### PR TITLE
Fix Step 13 toolchain-aware outside-in validation

### DIFF
--- a/amplifier-bundle/context/DISCOVERIES_ARCHIVE.md
+++ b/amplifier-bundle/context/DISCOVERIES_ARCHIVE.md
@@ -2020,13 +2020,21 @@ Code committed after unit tests and reviews but missing real user experience val
 
 ### Solution
 
-**ALWAYS test with `uvx --from <branch>` before committing**:
+**ALWAYS run toolchain-aware outside-in validation before committing**:
 
 ```bash
-uvx --from git+https://github.com/org/repo@branch package command
+# Examples: choose based on the detected project/toolchain.
+cargo run -- <user-command>
+npm run <documented-script>
+uv run <module-or-script>
+go run ./cmd/<name> -- <user-command>
+dotnet run --project <project> -- <user-command>
 ```
 
-This verifies: package installation, dependency resolution, actual user workflow, error messages, config updates.
+Use `uvx` only when validating a Python/uv-distributed CLI path is appropriate.
+The goal is to verify package or binary execution, dependency resolution, actual
+user workflow, error messages, and config updates without mandating one global
+installer.
 
 ### Key Learnings
 

--- a/amplifier-bundle/recipes/smart-validate-summarize.yaml
+++ b/amplifier-bundle/recipes/smart-validate-summarize.yaml
@@ -68,6 +68,7 @@ steps:
       2. For each workstream, determine whether outside-in testing was performed:
          - Look for "Step 13: Local Testing Results" evidence
          - Look for `qa-team` or `outside-in-testing` skill invocation
+         - Look for detected toolchains and a chosen outside-in validation strategy
          - Look for at least 2 test scenario results (PASS/FAIL)
 
       3. Report your findings in this format:
@@ -82,6 +83,7 @@ steps:
            - Workstream: <name or PR URL>
            - qa-team / outside-in-testing skill invoked: YES / NO / UNKNOWN
            - Step 13 results documented: YES / NO / UNKNOWN
+           - Chosen validation strategy documented: YES / NO / UNKNOWN
            - Test scenarios executed: <count or UNKNOWN>
            - VERDICT: PASS / FAIL / CANNOT_VERIFY
          ```
@@ -94,7 +96,8 @@ steps:
          `OUTSIDE_IN_VALIDATION: FAILED -- <describe which workstreams are missing outside-in testing>`
 
          When FAILED, state clearly what outside-in testing is missing and the
-         command the developer should run to complete it.
+         toolchain-aware validation strategy the developer should choose or run
+         to complete it.
 
       6. If no Development work was done (e.g., task was purely informational
          and produced no code changes or PRs), end with:

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -26,14 +26,15 @@ steps:
         echo "The outside-in testing step (step-13-local-testing) must be completed" && \
         echo "before the PR review phase can begin." && \
         echo "" && \
-        echo "Required: Invoke the qa-team skill (outside-in-testing alias also works) and document at least" && \
-        echo "2 test scenarios in the PR description under 'Step 13: Local Testing Results'." && \
+        echo "Required: Invoke the qa-team skill (outside-in-testing alias also works), document the" && \
+        echo "detected toolchains, chosen validation strategy, and at least 2 test scenarios in the" && \
+        echo "PR description under 'Step 13: Local Testing Results'." && \
         exit 1 ; \
       fi && \
       echo "Compliance check: local_testing_gate is populated." && \
       echo "" && \
       echo "Verify PR description contains 'Step 13: Local Testing Results' section" && \
-      echo "with actual test execution evidence (not just planning)." && \
+      echo "with detected toolchains, chosen strategy, and actual test execution evidence (not just planning)." && \
       echo "" && \
       echo "=== Compliance Check PASSED ==="
     output: "step_13_compliance_check"

--- a/amplifier-bundle/recipes/workflow-precommit-test.yaml
+++ b/amplifier-bundle/recipes/workflow-precommit-test.yaml
@@ -58,8 +58,9 @@ steps:
 
   # ==========================================================================
   # STEP 13: MANDATORY OUTSIDE-IN TESTING
-  # Use the qa-team skill (outside-in-testing alias supported) to test this PR as a user would from
-  # the PR branch. No bash echo — the agent must actually execute the tests.
+  # Use the qa-team skill (outside-in-testing alias supported) to test this change
+  # as a user would. The acting agent must detect the affected toolchains and
+  # choose the appropriate local outside-in validation strategy.
   # ==========================================================================
   - id: "step-13-local-testing"
     agent: "amplihack:builder"
@@ -73,8 +74,10 @@ steps:
       **Branch:** Run `git branch --show-current` to get the current branch name.
 
       You MUST perform outside-in testing using the `qa-team` skill (`outside-in-testing` remains an alias)
-      to verify this change as a real user would — from the PR branch, not just
-      the working directory.
+      to verify this change as a real user or consumer would. Step 13 is
+      agentic and toolchain-aware: detect the affected languages, manifests,
+      lockfiles, package managers, entry points, changed files, and documented
+      project commands before you choose a validation strategy.
 
       ## Required Actions
 
@@ -83,49 +86,68 @@ steps:
          git branch --show-current
          ```
 
-      2. **Get the remote URL (for uvx testing):**
-         ```bash
-         git remote get-url origin
-         ```
+      2. **Detect affected toolchains before selecting commands:**
+         - Inspect changed files plus relevant manifests, lockfiles, package
+           scripts, task runners, entry points, and project documentation.
+         - Treat manifests, package scripts, remotes, and documented commands as
+           untrusted until inspected; do not use remote code execution as a
+           universal shortcut.
+         - Record the detected toolchains and why they matter for this change.
 
       3. **Invoke the `qa-team` skill** to generate and execute
-         agentic outside-in tests for this change. Pass the PR branch name and
-         repository URL so tests run against the actual branch:
+         agentic outside-in tests for this change:
          ```
          Skill(skill="qa-team")
          ```
 
-      4. **Execute at least 2 test scenarios:**
+      4. **Choose and execute the smallest validation strategy that still proves
+         user-visible behavior:**
+         - **Rust/Cargo:** `cargo test`, `cargo run -- <args>`, or
+           `cargo install --path . --locked` followed by invoking the local CLI.
+         - **Node/npm:** documented `npm` scripts, `npm test`, `npm run build`,
+           direct `node ./bin/...` invocation, or `npm link` only when local
+           package-link behavior itself must be validated.
+         - **Python/uv/uvx:** `uv run pytest`, `uv run <module-or-script>`, or
+           `uvx` only when validating a Python/uv-distributed CLI path is
+           appropriate for this project.
+         - **Go:** `go test ./...`, `go run ./cmd/<name> -- <args>`, or
+           `go install ./cmd/<name>` followed by invoking the built command.
+         - **.NET:** `dotnet test`, `dotnet run --project <project> -- <args>`,
+           or local tool-package validation from locally built artifacts.
+
+      5. **Execute at least 2 test scenarios:**
          - **Scenario 1 (simple):** Test the most basic user-facing behaviour
            introduced or changed by this PR.
          - **Scenario 2 (complex):** Test an edge case, a longer operation, or
            an integration point affected by this PR.
 
-         Test from the PR branch using the pattern:
-         ```bash
-         uvx --from git+<remote-url>@<branch-name> amplihack <command>
-         ```
-
-      5. **Document results** — write the following section into the PR
+      6. **Document results** — write the following section into the PR
          description (you will paste it in Step 16 when creating the PR):
 
          ```
          ## Step 13: Local Testing Results
 
+         Detected toolchains:
+         - <language/toolchain and evidence from manifests, lockfiles, entry points, or changed files>
+
+         Chosen validation strategy:
+         - <commands/scenarios selected and why they prove the user-visible behavior>
+
          ### Scenario 1 — <brief description>
-         Command: `uvx --from git+...@<branch> amplihack <command>`
+         Command: `<actual local outside-in command>`
          Result: PASS / FAIL
          Output: <key output lines>
 
          ### Scenario 2 — <brief description>
-         Command: `uvx --from git+...@<branch> amplihack <command>`
+         Command: `<actual local outside-in command>`
          Result: PASS / FAIL
          Output: <key output lines>
          ```
 
       ## What Counts as Testing
 
-      - Running the actual changed code with test inputs via `uvx --from git+...`
+      - Running the actual changed code with test inputs through a user or
+        consumer boundary selected for the detected toolchain
       - Verifying error messages, output format, and user experience
       - Checking that existing functionality still works (regression check)
 

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -249,19 +249,24 @@ steps:
        **PR URL:** {{pr_publish_result.pr_url}}
 
        Required:
-       1. Get branch and remote with `git branch --show-current` and `git remote get-url origin`.
-       2. Invoke `Skill(skill="qa-team")`.
-       3. Run at least one simple and one edge/integration scenario via:
-       ```bash
-       uvx --from git+<remote-url>@<branch-name> amplihack <command>
-       ```
-       4. If a test fails, diagnose, fix, commit, push, and retry up to 3 times:
+       1. Get the current branch with `git branch --show-current`.
+       2. Detect affected languages, manifests, lockfiles, package managers,
+          entry points, changed files, and documented project commands before
+          choosing a validation strategy.
+       3. Invoke `Skill(skill="qa-team")`.
+       4. Run at least one simple and one edge/integration scenario through the
+          appropriate outside-in user or consumer boundary for the detected
+          toolchain. Examples include local `cargo`, `npm`, `uv`/Python, `go`,
+          or `dotnet` commands; `uvx` is only appropriate for Python/uv CLI
+          distribution validation when that project shape warrants it.
+       5. If a test fails, diagnose, fix, commit, push, and retry up to 3 times:
           ```bash
           amplihack hygiene artifact-guard --repo . --mode pre-publish && git add -A && git commit -m "fix: <describe the fix found during outside-in testing>"
           git pull --rebase && git push
           ```
-       5. If failures persist after 3 iterations, document them honestly.
+       6. If failures persist after 3 iterations, document them honestly.
 
        Update the PR description with a "Step 16b: Outside-In Testing Results"
-       section listing each scenario, command, result, key output, and fix count.
+       section listing detected toolchains, chosen strategy, each scenario,
+       command, result, key output, and fix count.
     output: "outside_in_fix_loop_results"

--- a/amplifier-bundle/tools/amplihack/considerations.yaml
+++ b/amplifier-bundle/tools/amplihack/considerations.yaml
@@ -380,7 +380,7 @@
     SATISFIED when:
     - Agent ran pytest/npm test/cargo test and output shows passing results
     - Agent ran a validation script and confirmed it passed
-    - Agent used "uvx --from git+..." to test the installed package (outside-in)
+    - Agent ran toolchain-appropriate outside-in validation through the user-facing boundary
     - YAML/config-only changes where agent verified syntax (e.g., `yq`, `yamllint`, or shell parse check)
 
     NOT SATISFIED when:
@@ -410,7 +410,7 @@
 
     SATISFIED when:
     - Agent ran the CLI tool with real arguments and checked output
-    - Agent used "uvx --from git+..." to test the installed package
+    - Agent ran a toolchain-appropriate outside-in command against the actual user workflow
     - Agent imported a module and called functions interactively
     - Agent tested with edge case inputs (empty, large, malformed)
     - Automated test count is substantial (10+ tests passing)

--- a/crates/amplihack-cli/src/signals.rs
+++ b/crates/amplihack-cli/src/signals.rs
@@ -32,10 +32,14 @@ pub fn register_handlers() -> Result<Arc<AtomicBool>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use std::sync::atomic::Ordering;
+
+    static SIGNAL_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn register_handlers_creates_false_flag() {
+        let _guard = SIGNAL_TEST_LOCK.lock().expect("signal test lock poisoned");
         let shutdown = register_handlers().unwrap();
         assert!(!shutdown.load(Ordering::Relaxed));
     }
@@ -43,6 +47,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn signal_sets_flag() {
+        let _guard = SIGNAL_TEST_LOCK.lock().expect("signal test lock poisoned");
         let shutdown = register_handlers().unwrap();
         assert!(!shutdown.load(Ordering::Relaxed));
 

--- a/docs/claude/context/DISCOVERIES.md
+++ b/docs/claude/context/DISCOVERIES.md
@@ -1603,13 +1603,21 @@ Code committed after unit tests and reviews but missing real user experience val
 
 ### Solution
 
-**ALWAYS test with `uvx --from <branch>` before committing**:
+**ALWAYS run toolchain-aware outside-in validation before committing**:
 
 ```bash
-uvx --from git+https://github.com/org/repo@branch package command
+# Examples: choose based on the detected project/toolchain.
+cargo run -- <user-command>
+npm run <documented-script>
+uv run <module-or-script>
+go run ./cmd/<name> -- <user-command>
+dotnet run --project <project> -- <user-command>
 ```
 
-This verifies: package installation, dependency resolution, actual user workflow, error messages, config updates.
+Use `uvx` only when validating a Python/uv-distributed CLI path is appropriate.
+The goal is to verify package or binary execution, dependency resolution, actual
+user workflow, error messages, and config updates without mandating one global
+installer.
 
 ### Key Learnings
 

--- a/docs/claude/skills/default-workflow/SKILL.md
+++ b/docs/claude/skills/default-workflow/SKILL.md
@@ -203,6 +203,21 @@ Agent runtimes that support skills should enter through
 `Skill(skill="default-workflow")` activation is for explicit standalone use or
 orchestrator-unavailable compatibility.
 
+## Step 13 Local Validation Contract
+
+Step 13 is a mandatory outside-in local validation gate. It is agentic and
+toolchain-aware: the acting agent detects affected languages, manifests,
+lockfiles, package managers, entry points, changed files, and documented project
+commands before selecting validation commands.
+
+The step must not require one global validation mechanism across all projects.
+Rust/Cargo, Node/npm, Python/uv, Go, .NET, and other detected toolchains each use
+their own local consumer-facing validation pattern. Python `uvx` is only a
+Python/uv-specific option when that project shape warrants it.
+
+For the full evidence contract and examples, see
+[`docs/reference/default-workflow-step-13-validation.md`](../../../reference/default-workflow-step-13-validation.md).
+
 ## Configuration
 
 Generated preferences and session context name the canonical skill/recipe, not a

--- a/docs/claude/tools/amplihack/considerations.yaml
+++ b/docs/claude/tools/amplihack/considerations.yaml
@@ -356,7 +356,7 @@
     SATISFIED when:
     - Agent ran pytest/npm test/cargo test and output shows passing results
     - Agent ran a validation script and confirmed it passed
-    - Agent used "uvx --from git+..." to test the installed package (outside-in)
+    - Agent ran toolchain-appropriate outside-in validation through the user-facing boundary
     - YAML/config-only changes where agent verified with "python -c 'import yaml; ...'"
 
     NOT SATISFIED when:
@@ -386,7 +386,7 @@
 
     SATISFIED when:
     - Agent ran the CLI tool with real arguments and checked output
-    - Agent used "uvx --from git+..." to test the installed package
+    - Agent ran a toolchain-appropriate outside-in command against the actual user workflow
     - Agent imported a module and called functions interactively
     - Agent tested with edge case inputs (empty, large, malformed)
     - Automated test count is substantial (10+ tests passing)

--- a/docs/claude/workflow/DEFAULT_WORKFLOW.md
+++ b/docs/claude/workflow/DEFAULT_WORKFLOW.md
@@ -373,21 +373,31 @@ After investigation completes, continue with these tasks:
 ### Step 13: Mandatory Local Testing (NOT in CI)
 
 **CRITICAL: Test all changes locally in realistic scenarios BEFORE committing.**
-Test like a user would use the feature - outside-in - not just unit tests.
+Test like a user would use the feature - outside-in - not just unit tests. The
+acting agent detects the affected languages, manifests, lockfiles, entry points,
+and documented project commands before selecting validation commands. Step 13 is
+toolchain-aware; it does not mandate one global installer, package manager, or
+remote execution flow.
 
-- [ ] **Test simple use cases** - Basic functionality verification
-- [ ] **Test complex use cases** - Edge cases and longer operations
-- [ ] **Test integration points** - External dependencies and APIs
+- [ ] **Detect affected toolchains** - Identify relevant language and package-manager signals before choosing commands
+- [ ] **Select outside-in scenarios** - Validate through user or consumer boundaries such as CLI, API, service, package, or library usage
+- [ ] **Test simple use cases** - Basic functionality verification with the selected toolchain strategy
+- [ ] **Test complex use cases** - Edge cases and longer operations when the change has branching behavior
+- [ ] **Test integration points** - External dependencies, APIs, package entry points, and cross-language boundaries
 - [ ] **Verify no regressions** - Ensure existing functionality still works
-- [ ] **Document test results** - What was tested and results for the PR description (to be used in a moment) not in the repo
+- [ ] **Document validation evidence** - Record detected toolchains, chosen strategy, commands, and results for the PR description (not in the repo)
 - [ ] **RULE: Never commit without local testing**
 
-**Examples of required tests:**
+**Examples of toolchain-aware outside-in validation:**
 
-- If proxy changes: Test simple and long requests locally
-- If API changes: Test with real client requests
-- If CLI changes: Run actual commands with various options
-- If database changes: Test with actual data operations
+- If Rust/Cargo changes: run relevant `cargo test` coverage and invoke the CLI or binary locally with realistic arguments
+- If Node/npm changes: use documented `npm` scripts and exercise exported commands, package entry points, or browser/API behavior
+- If Python/uv changes: use `uv run` for tests or scripts; use `uvx` only when validating a Python/uv-distributed CLI path is appropriate
+- If Go changes: run `go test ./...` and exercise `go run` or the built command from the user boundary
+- If .NET changes: run `dotnet test` and exercise `dotnet run`, local tool packages, or service/API behavior
+
+See [Default Workflow Step 13 Validation](../../reference/default-workflow-step-13-validation.md)
+for the full selection contract and evidence format.
 
 **Why this matters:**
 

--- a/docs/concepts/default-workflow.md
+++ b/docs/concepts/default-workflow.md
@@ -403,21 +403,31 @@ After investigation completes, continue with these tasks:
 ### Step 13: Mandatory Local Testing (NOT in CI)
 
 **CRITICAL: Test all changes locally in realistic scenarios BEFORE committing.**
-Test like a user would use the feature - outside-in - not just unit tests.
+Test like a user would use the feature - outside-in - not just unit tests. The
+acting agent detects the affected languages, manifests, lockfiles, entry points,
+and documented project commands before selecting validation commands. Step 13 is
+toolchain-aware; it does not mandate one global installer, package manager, or
+remote execution flow.
 
-- [ ] **Test simple use cases** - Basic functionality verification
-- [ ] **Test complex use cases** - Edge cases and longer operations
-- [ ] **Test integration points** - External dependencies and APIs
+- [ ] **Detect affected toolchains** - Identify relevant language and package-manager signals before choosing commands
+- [ ] **Select outside-in scenarios** - Validate through user or consumer boundaries such as CLI, API, service, package, or library usage
+- [ ] **Test simple use cases** - Basic functionality verification with the selected toolchain strategy
+- [ ] **Test complex use cases** - Edge cases and longer operations when the change has branching behavior
+- [ ] **Test integration points** - External dependencies, APIs, package entry points, and cross-language boundaries
 - [ ] **Verify no regressions** - Ensure existing functionality still works
-- [ ] **Document test results** - What was tested and results for the PR description (to be used in a moment) not in the repo
+- [ ] **Document validation evidence** - Record detected toolchains, chosen strategy, commands, and results for the PR description (not in the repo)
 - [ ] **RULE: Never commit without local testing**
 
-**Examples of required tests:**
+**Examples of toolchain-aware outside-in validation:**
 
-- If proxy changes: Test simple and long requests locally
-- If API changes: Test with real client requests
-- If CLI changes: Run actual commands with various options
-- If database changes: Test with actual data operations
+- If Rust/Cargo changes: run relevant `cargo test` coverage and invoke the CLI or binary locally with realistic arguments
+- If Node/npm changes: use documented `npm` scripts and exercise exported commands, package entry points, or browser/API behavior
+- If Python/uv changes: use `uv run` for tests or scripts; use `uvx` only when validating a Python/uv-distributed CLI path is appropriate
+- If Go changes: run `go test ./...` and exercise `go run` or the built command from the user boundary
+- If .NET changes: run `dotnet test` and exercise `dotnet run`, local tool packages, or service/API behavior
+
+See [Default Workflow Step 13 Validation](../reference/default-workflow-step-13-validation.md)
+for the full selection contract and evidence format.
 
 **Why this matters:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -271,6 +271,7 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [How to Configure Workflow Execution Guardrails](howto/configure-workflow-execution-guardrails.md) - Supply `expected_gh_account`, inspect `execution_root`, and troubleshoot failures
 - [Tutorial: Workflow Execution Guardrails](tutorials/workflow-execution-guardrails.md) - End-to-end walkthrough of the guarded workflow contract
 - [Workflow Execution Guardrails Reference](reference/workflow-execution-guardrails.md) - Input fields, output schema, signals, and failure semantics
+- [Default Workflow Step 13 Validation Reference](reference/default-workflow-step-13-validation.md) - Toolchain-aware outside-in local validation contract for Step 13
 - [Workflow Terminal-State Reference](reference/workflow-terminal-state.md) - Target contract for development completion evidence, no-op states, failure semantics, and shell helper API
 - [How to Diagnose Workflow Terminal-State Failures](howto/diagnose-workflow-terminal-state.md) - Investigate missing evidence after planning, analysis, design, or worktree-only runs
 - [Tutorial: Workflow Terminal-State Closure](tutorials/workflow-terminal-state-closure.md) - Walk through completion evidence, planning-only failure, and rerun semantics

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -73,6 +73,7 @@ Complete documentation for using the Recipe Runner:
 - **[Recipe Run Correlation Reference](../reference/recipe-run-correlation.md)** - Stable run IDs, log pointer schema, and result fields
 - **[Recipe CLI Examples](cli-examples.md)** - Real-world usage scenarios (development, testing, CI/CD, team workflows)
 - **[Step 03 Host-Aware Tracking Idempotency](../reference/recipe-step-03-idempotency.md)** - GitHub issue, Azure Boards work-item, and local tracking reuse/create contract
+- **[Default Workflow Step 13 Validation](../reference/default-workflow-step-13-validation.md)** - Toolchain-aware outside-in local validation contract for the pre-commit gate
 - **[Workflow Terminal-State Reference](../reference/workflow-terminal-state.md)** - Target contract for development workflow completion evidence, no-op states, routed failure propagation, and `workflow_final_status.sh` API
 - **[How to Diagnose Workflow Terminal-State Failures](../howto/diagnose-workflow-terminal-state.md)** - Recovery guide for missing terminal evidence after planning, analysis, design, or worktree-only execution
 - **[Tutorial: Workflow Terminal-State Closure](../tutorials/workflow-terminal-state-closure.md)** - Walk through successful evidence, planning-only failure, and rerun behavior

--- a/docs/reference/default-workflow-step-13-validation.md
+++ b/docs/reference/default-workflow-step-13-validation.md
@@ -1,0 +1,132 @@
+---
+title: "Default Workflow Step 13 Validation Reference"
+description: "Contract for toolchain-aware outside-in local validation in default-workflow Step 13."
+last_updated: 2026-06-13
+review_schedule: quarterly
+owner: amplihack
+doc_type: reference
+---
+
+# Default Workflow Step 13 Validation Reference
+
+> [Home](../index.md) > Reference > Default Workflow Step 13 Validation
+
+Step 13 of `default-workflow` is the local outside-in validation gate. It
+requires the acting agent to validate changes from the perspective of a user or
+consumer before commit, push, and PR publication.
+
+Step 13 is toolchain-aware. It does not prescribe one package manager, installer,
+or command for every repository. The agent detects the languages, package
+managers, manifests, lockfiles, changed files, and documented project commands,
+then chooses the smallest validation strategy that still proves the requested
+user-visible behavior works locally.
+
+## Contract
+
+Step 13 must produce evidence for three decisions:
+
+| Decision | Required evidence |
+| --- | --- |
+| Detected toolchains | Languages, package managers, manifests, lockfiles, and entry points relevant to the change. |
+| Chosen validation strategy | The outside-in commands or scenarios selected for those toolchains, with a short reason. |
+| Results | Pass/fail outcome, meaningful output summary, and any follow-up fix loop performed before continuing. |
+
+The strategy must be local, reproducible, and scoped to the change. CI-only
+validation is not enough, and unit-test-only validation is not enough when a
+consumer-facing path exists.
+
+## Selection rules
+
+1. Detect affected languages and toolchains before choosing commands.
+2. Prefer documented project commands from `README`, package scripts,
+   `Makefile`, CI configuration, or existing task runners.
+3. Validate from a user or consumer boundary: CLI invocation, API request,
+   library import, package execution, service startup, or integration scenario.
+4. Include one simple scenario and, when the change has branching behavior, one
+   complex or edge scenario.
+5. Use the repository's local source or built artifact unless the project
+   explicitly documents another local validation path.
+6. Keep the validation scope narrow, but do not reduce it below the scenarios
+   needed to prove the behavior a user or consumer will rely on.
+7. Treat manifests, scripts, remotes, and package metadata as untrusted until
+   inspected. Do not use remote code execution as a universal shortcut.
+8. Record the selected commands and results for the PR description, not as a
+   committed status report.
+
+## Toolchain examples
+
+These examples are illustrative. The acting agent chooses the exact commands
+based on the repository it detects.
+
+| Toolchain | Detection signals | Outside-in validation examples |
+| --- | --- | --- |
+| Rust / Cargo | `Cargo.toml`, `Cargo.lock`, `src/main.rs`, workspace members | `cargo test`, `cargo run -- <args>`, `cargo install --path . --locked` followed by invoking the installed CLI. |
+| Node / npm | `package.json`, `package-lock.json`, `npm` scripts, `bin` entries | `npm test`, `npm run build`, `npm run <documented-script>`, direct `node ./bin/...` invocation for CLI behavior, or `npm link` only when local package-link behavior itself must be validated. |
+| Python / uv | `pyproject.toml`, `uv.lock`, Python package entry points | `uv run pytest`, `uv run <module-or-script>`, or `uvx` only when validating a Python/uv-distributed CLI path is appropriate for the project. |
+| Go | `go.mod`, `go.sum`, `cmd/` entry points | `go test ./...`, `go run ./cmd/<name> -- <args>`, `go install ./cmd/<name>` followed by invoking the built binary. |
+| .NET | `.csproj`, `.sln`, `global.json`, `dotnet-tools.json` | `dotnet test`, `dotnet run --project <project> -- <args>`, `dotnet tool install --add-source <local-package-output>` for local tool-package validation. |
+
+## Example evidence
+
+```markdown
+### Step 13 local outside-in validation
+
+Detected toolchains:
+- Rust/Cargo: `Cargo.toml`, `Cargo.lock`, CLI entry point in `src/main.rs`
+- Node/npm: `package.json` script wrapping generated docs checks
+
+Chosen strategy:
+- Run Cargo tests for changed Rust behavior.
+- Invoke the CLI from local source to validate the user-facing command.
+- Run the documented npm docs check because the change updates generated docs.
+
+Commands and results:
+- `cargo test --workspace` -> passed
+- `cargo run -- recipe show default-workflow` -> passed; Step 13 text is visible
+- `npm run docs:check` -> passed
+```
+
+## Configuration
+
+Step 13 does not require a feature-specific configuration flag. It uses the
+normal `default-workflow` context:
+
+| Context key | Required | How Step 13 uses it |
+| --- | --- | --- |
+| `repo_path` | Yes | Repository root for toolchain detection and local command execution. |
+| `task_description` | Yes | User-facing behavior to validate outside-in. |
+| Changed files from the active worktree | Yes | Scope for selecting relevant toolchains and scenarios. |
+
+Workflow preferences may strengthen the evidence requirement, such as requiring
+both a simple and complex scenario, but preferences must not force a single
+toolchain command across all repositories.
+
+## Non-goals
+
+- Step 13 does not replace Step 12 unit tests, linters, type checks, or
+  pre-commit hooks.
+- Step 13 does not require every language in a polyglot repository to run when
+  the change clearly affects only one isolated toolchain.
+- Step 13 does not require Python tooling for non-Python projects.
+- Step 13 does not require network-fetched package execution as the universal
+  validation path.
+
+## Regression expectations
+
+Tests covering Step 13 documentation and recipe text should assert the semantic
+contract rather than exact prose:
+
+- The step preserves outside-in local validation intent.
+- The step requires toolchain detection before command selection.
+- The step includes generalized examples for Rust/Cargo, Node/npm, Python/uv,
+  Go, and .NET.
+- Python `uvx` usage is scoped to Python/uv validation only.
+- The step does not present any one tool or network-fetched execution path as
+  globally mandatory.
+- Remote Git install phrases are absent from Step 13 guidance.
+
+## See also
+
+- [Default Workflow Skill](../claude/skills/default-workflow/SKILL.md)
+- [Default Workflow Concept](../concepts/default-workflow.md)
+- [Workflow Execution Guardrails](workflow-execution-guardrails.md)

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -20,10 +20,46 @@
 //! YAML content, fast, and have no external dependencies.
 
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 const BRICK_LIMIT: usize = 400;
+
+const EXTRA_RECIPE_NAMES: &[&str] = &["default-workflow", "smart-validate-summarize"];
+
+static RECIPE_TEXTS: LazyLock<HashMap<&'static str, String>> = LazyLock::new(|| {
+    PHASE_RECIPES
+        .iter()
+        .chain(EXTRA_RECIPE_NAMES)
+        .map(|&name| {
+            let path = recipe_path(name);
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            (name, text)
+        })
+        .collect()
+});
+
+static RECIPES: LazyLock<HashMap<&'static str, Recipe>> = LazyLock::new(|| {
+    RECIPE_TEXTS
+        .iter()
+        .filter(|&(name, _)| *name != "smart-validate-summarize")
+        .map(|(&name, text)| {
+            let path = recipe_path(name);
+            let recipe = serde_yaml::from_str(text)
+                .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+            (name, recipe)
+        })
+        .collect()
+});
+
+static WORKFLOW_PR_REVIEW_YAML: LazyLock<serde_yaml::Value> = LazyLock::new(|| {
+    let name = "workflow-pr-review";
+    let path = recipe_path(name);
+    serde_yaml::from_str(recipe_text(name))
+        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+});
 
 #[derive(Debug, Deserialize)]
 struct Recipe {
@@ -57,40 +93,44 @@ fn recipe_path(name: &str) -> PathBuf {
     recipes_dir().join(format!("{name}.yaml"))
 }
 
-fn recipe_text(name: &str) -> String {
-    let path = recipe_path(name);
-    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+fn recipe_text(name: &str) -> &'static str {
+    RECIPE_TEXTS
+        .get(name)
+        .unwrap_or_else(|| panic!("uncached test recipe: {name}"))
 }
 
-fn load(name: &str) -> Recipe {
-    let path = recipe_path(name);
-    let text = recipe_text(name);
-    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+fn load(name: &str) -> &'static Recipe {
+    RECIPES
+        .get(name)
+        .unwrap_or_else(|| panic!("uncached test recipe: {name}"))
 }
 
-fn load_yaml(name: &str) -> serde_yaml::Value {
-    let path = recipe_path(name);
-    let text = recipe_text(name);
-    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+fn load_yaml(name: &str) -> &'static serde_yaml::Value {
+    match name {
+        "workflow-pr-review" => &WORKFLOW_PR_REVIEW_YAML,
+        _ => panic!("uncached test YAML recipe: {name}"),
+    }
 }
 
-fn step_command(recipe: &str, step_id: &str) -> String {
+fn step_command(recipe: &str, step_id: &str) -> &'static str {
     load(recipe)
         .steps
-        .into_iter()
+        .iter()
         .find(|step| step.id == step_id)
         .unwrap_or_else(|| panic!("{recipe}.yaml missing step {step_id}"))
         .command
+        .as_deref()
         .unwrap_or_else(|| panic!("{recipe}.yaml step {step_id} must be a bash step"))
 }
 
-fn step_prompt(recipe: &str, step_id: &str) -> String {
+fn step_prompt(recipe: &str, step_id: &str) -> &'static str {
     load(recipe)
         .steps
-        .into_iter()
+        .iter()
         .find(|step| step.id == step_id)
         .unwrap_or_else(|| panic!("{recipe}.yaml missing step {step_id}"))
         .prompt
+        .as_deref()
         .unwrap_or_else(|| panic!("{recipe}.yaml step {step_id} must have a prompt"))
 }
 
@@ -279,9 +319,9 @@ fn no_duplicate_step_ids_across_subrecipes() {
     let mut seen: HashSet<String> = HashSet::new();
     let mut dups: Vec<String> = Vec::new();
     for name in PHASE_RECIPES {
-        for step in load(name).steps {
+        for step in &load(name).steps {
             if !seen.insert(step.id.clone()) {
-                dups.push(step.id);
+                dups.push(step.id.clone());
             }
         }
     }
@@ -415,8 +455,8 @@ fn workflow_pr_review_phase_contract_is_strict_and_ordered() {
 
     let step_ids: Vec<String> = load("workflow-pr-review")
         .steps
-        .into_iter()
-        .map(|step| step.id)
+        .iter()
+        .map(|step| step.id.clone())
         .collect();
     assert_eq!(
         step_ids, PR_REVIEW_STEP_INVENTORY,
@@ -520,8 +560,8 @@ fn workflow_finalize_late_steps_are_resilient_to_missing_worktree() {
     let pr_ready = step_command("workflow-finalize", "step-21-pr-ready");
 
     for (step, command) in [
-        ("step-20b-push-cleanup", push_cleanup.as_str()),
-        ("step-21-pr-ready", pr_ready.as_str()),
+        ("step-20b-push-cleanup", push_cleanup),
+        ("step-21-pr-ready", pr_ready),
     ] {
         assert!(
             command.contains("set -euo pipefail"),
@@ -689,7 +729,7 @@ fn base_branch_detection_remains_explicit_and_fail_loud() {
 fn mandatory_steps_still_present() {
     let composed: HashSet<String> = PHASE_RECIPES
         .iter()
-        .flat_map(|name| load(name).steps.into_iter().map(|s| s.id))
+        .flat_map(|name| load(name).steps.iter().map(|s| s.id.clone()))
         .collect();
     for required in [
         "step-00-workflow-preparation",

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -41,6 +41,8 @@ struct Step {
     recipe: Option<String>,
     #[serde(default)]
     command: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
 }
 
 fn recipes_dir() -> PathBuf {
@@ -80,6 +82,16 @@ fn step_command(recipe: &str, step_id: &str) -> String {
         .unwrap_or_else(|| panic!("{recipe}.yaml missing step {step_id}"))
         .command
         .unwrap_or_else(|| panic!("{recipe}.yaml step {step_id} must be a bash step"))
+}
+
+fn step_prompt(recipe: &str, step_id: &str) -> String {
+    load(recipe)
+        .steps
+        .into_iter()
+        .find(|step| step.id == step_id)
+        .unwrap_or_else(|| panic!("{recipe}.yaml missing step {step_id}"))
+        .prompt
+        .unwrap_or_else(|| panic!("{recipe}.yaml step {step_id} must have a prompt"))
 }
 
 /// The expected step inventory of `default-workflow`, in execution order, as
@@ -274,6 +286,103 @@ fn no_duplicate_step_ids_across_subrecipes() {
         }
     }
     assert!(dups.is_empty(), "duplicate step IDs found: {dups:?}");
+}
+
+#[test]
+fn step_13_does_not_mandate_uvx_or_remote_git_install_flow() {
+    let prompt = step_prompt("workflow-precommit-test", "step-13-local-testing");
+    let forbidden_phrases = [
+        "Get the remote URL (for uvx testing)",
+        "git remote get-url origin",
+        "Pass the PR branch name and repository URL so tests run against the actual branch",
+        "uvx --from git+<remote-url>@<branch-name>",
+        "uvx --from git+...@<branch>",
+        "via `uvx --from git+...`",
+    ];
+
+    for phrase in forbidden_phrases {
+        assert!(
+            !prompt.contains(phrase),
+            "Step 13 must not present `{phrase}` as the universal outside-in validation path"
+        );
+    }
+}
+
+#[test]
+fn step_13_requires_agentic_toolchain_detection_before_validation_selection() {
+    let prompt = step_prompt("workflow-precommit-test", "step-13-local-testing");
+    let lower = prompt.to_ascii_lowercase();
+
+    for required in ["outside-in", "detect", "toolchain", "validation strategy"] {
+        assert!(
+            lower.contains(required),
+            "Step 13 must preserve outside-in validation while requiring agents to detect project languages/toolchains and select a validation strategy; missing `{required}`"
+        );
+    }
+
+    assert!(
+        lower.contains("choose") || lower.contains("select"),
+        "Step 13 must delegate validation pattern selection to the acting agent"
+    );
+    assert!(
+        lower.contains("record") && lower.contains("chosen"),
+        "Step 13 must require evidence of the chosen validation strategy, not just raw command output"
+    );
+}
+
+#[test]
+fn step_13_covers_major_toolchain_examples_without_making_uvx_global() {
+    let prompt = step_prompt("workflow-precommit-test", "step-13-local-testing");
+    let lower = prompt.to_ascii_lowercase();
+    let toolchain_examples = [
+        ("Rust/Cargo", lower.contains("cargo")),
+        ("Node/npm", lower.contains("npm")),
+        (
+            "Python/uv/uvx",
+            lower.contains("python") && lower.contains("uv") && lower.contains("uvx"),
+        ),
+        (
+            "Go",
+            lower.contains("go test")
+                || lower.contains("go run")
+                || lower.contains("golang")
+                || prompt.contains("Go/"),
+        ),
+        (".NET", lower.contains("dotnet") || prompt.contains(".NET")),
+    ];
+
+    for (toolchain, present) in toolchain_examples {
+        assert!(
+            present,
+            "Step 13 must include a generalized outside-in validation example for {toolchain}"
+        );
+    }
+
+    assert!(
+        lower.contains("python") && lower.find("python") < lower.rfind("uvx"),
+        "Step 13 may mention uvx only as a Python/uv-specific validation option"
+    );
+}
+
+#[test]
+fn outside_in_validation_gates_require_strategy_evidence_without_uvx_specific_commands() {
+    for recipe in [
+        "smart-validate-summarize",
+        "workflow-pr-review",
+        "workflow-publish",
+    ] {
+        let text = recipe_text(recipe);
+        let lower = text.to_ascii_lowercase();
+
+        assert!(
+            !lower.contains("uvx --from git+"),
+            "{recipe}.yaml must not validate Step 13 by requiring uvx remote Git execution"
+        );
+        assert!(
+            lower.contains("chosen") && lower.contains("strategy"),
+            "{recipe}.yaml must ask for the chosen outside-in validation strategy so reviewers can verify toolchain-aware selection"
+        );
+    }
 }
 
 /// Brick rule: every phase sub-recipe must be ≤ 400 lines. The composer is


### PR DESCRIPTION
## Summary

- Generalizes `workflow-precommit-test` Step 13 so agents detect affected languages/toolchains and choose an appropriate outside-in validation strategy instead of mandating `uvx --from git+...`.
- Scopes `uvx` to Python/uv CLI validation and adds Rust/Cargo, Node/npm, Go, and .NET examples.
- Updates related validation/review/publish recipe guidance plus docs and agent consideration text that previously implied global uvx validation.
- Adds regression coverage for the Step 13 contract and related validation gates.

Closes #767

## Step 13: Local Testing Results

Detected toolchains:
- Rust/Cargo: workspace integration test target validates recipe YAML contracts.
- YAML/docs: recipe and markdown text changed.

Chosen validation strategy:
- Run focused Rust integration regression tests for default-workflow recipe decomposition and Step 13 wording.
- Run repository pre-commit hooks for YAML formatting, artifact guard, Rust formatting, and clippy.
- Run full workspace tests with local temp space and constrained Cargo parallelism to avoid shared `/tmp` disk pressure.

### Scenario 1 — Step 13 regression contract
Command: `NODE_OPTIONS=--max-old-space-size=32768 cargo test -p amplihack --test default_workflow_decomposition -- --nocapture`
Result: PASS
Output: 32 passed; 0 failed.

### Scenario 2 — repository quality gates
Command: `NODE_OPTIONS=--max-old-space-size=32768 pre-commit run --all-files`
Result: PASS
Output: merge conflict, whitespace, YAML/TOML, artifact guard, cargo fmt, and clippy hooks passed.

### Scenario 3 — workspace regression suite
Command: `env -u AMPLIHACK_HOME TMPDIR=/home/azureuser/tmp-cargo CARGO_BUILD_JOBS=2 NODE_OPTIONS=--max-old-space-size=32768 cargo test --workspace --locked`
Result: PASS
Output: completed successfully after moving rustc temp files off the shared `/tmp` filesystem.

## Notes

Initial workspace test attempts failed due `/tmp`/artifact disk pressure and generated runtime logs, not code failures. Generated artifacts were removed and the suite was rerun in a clean environment.
