### PR TITLE
Fix workflow finalization evidence handling

### DIFF
--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -254,6 +254,20 @@ steps:
       bash "$FINAL_STATUS_HELPER"
     output: "final_status"
 
+  - id: "step-22c-agentic-finalization"
+    type: "bash"
+    condition: "terminal_state.terminal_success != 'true' && terminal_state.should_finalize == 'true'"
+    parse_json: true
+    command: |
+      set -euo pipefail
+      cd "${REPO_PATH:?step-22c-agentic-finalization requires repo_path; ensure parent recipe propagated repo_path context}"
+      export GH_PAGER=cat PAGER=cat LESS=FRX
+      AGENTIC_FINALIZATION_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_agentic_finalization.sh"
+      if [ ! -f "$AGENTIC_FINALIZATION_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then AGENTIC_FINALIZATION_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_agentic_finalization.sh"; fi
+      [ -x "$AGENTIC_FINALIZATION_HELPER" ] || { echo "ERROR: workflow agentic-finalization helper not found or not executable: $AGENTIC_FINALIZATION_HELPER" >&2; exit 1; }
+      bash "$AGENTIC_FINALIZATION_HELPER"
+    output: "agentic_finalization"
+
   - id: "workflow-complete"
     type: "bash"
     parse_json: true
@@ -268,6 +282,10 @@ steps:
       TERMINAL_SUCCESS_VALUE="${TERMINAL_STATE_TERMINAL_SUCCESS:-${RECIPE_VAR_terminal_state__terminal_success:-false}}"
       PUBLISH_STATUS_VALUE="${TERMINAL_STATE_PUBLISH_STATUS:-${RECIPE_VAR_terminal_state__publish_status:-${PR_PUBLISH_RESULT_STATE:-${RECIPE_VAR_pr_publish_result__state:-active-pr}}}}"
       TERMINAL_REASON_VALUE="${TERMINAL_STATE_TERMINAL_REASON:-${RECIPE_VAR_terminal_state__terminal_reason:-}}"
+      AGENTIC_DECISION_VALUE="${AGENTIC_FINALIZATION_DECISION:-${RECIPE_VAR_agentic_finalization__decision:-not_run}}"
+      AGENTIC_CONFIDENCE_VALUE="${AGENTIC_FINALIZATION_CONFIDENCE:-${RECIPE_VAR_agentic_finalization__confidence:-0}}"
+      AGENTIC_BLOCKING_REASONS_VALUE="${AGENTIC_FINALIZATION_BLOCKING_REASONS_TEXT:-${RECIPE_VAR_agentic_finalization__blocking_reasons_text:-}}"
+      AGENTIC_EVIDENCE_SUMMARY_VALUE="${AGENTIC_FINALIZATION_EVIDENCE_SUMMARY:-${RECIPE_VAR_agentic_finalization__evidence_summary:-}}"
       TERMINAL_OUTCOME="$TERMINAL_STATE_VALUE"
       export TERMINAL_OUTCOME
       jq -n \
@@ -279,6 +297,10 @@ steps:
         --arg terminal_success "${TERMINAL_SUCCESS_VALUE}" \
         --arg terminal_reason "${TERMINAL_REASON_VALUE}" \
         --arg publish_status "${PUBLISH_STATUS_VALUE}" \
+        --arg agentic_decision "${AGENTIC_DECISION_VALUE}" \
+        --arg agentic_confidence "${AGENTIC_CONFIDENCE_VALUE}" \
+        --arg agentic_blocking_reasons "${AGENTIC_BLOCKING_REASONS_VALUE}" \
+        --arg agentic_evidence_summary "${AGENTIC_EVIDENCE_SUMMARY_VALUE}" \
         '{
           workflow: "default-workflow",
           version: "2.0.0",
@@ -290,9 +312,19 @@ steps:
           terminal_success: $terminal_success,
           terminal_reason: $terminal_reason,
           publish_status: $publish_status,
+          agentic_finalization: {
+            decision: $agentic_decision,
+            confidence: $agentic_confidence,
+            blocking_reasons: (if $agentic_blocking_reasons == "" then [] else ($agentic_blocking_reasons | split("\n")) end),
+            evidence_summary: $agentic_evidence_summary
+          },
+          agentic_decision: $agentic_decision,
+          agentic_confidence: $agentic_confidence,
+          agentic_blocking_reasons: (if $agentic_blocking_reasons == "" then [] else ($agentic_blocking_reasons | split("\n")) end),
+          agentic_evidence_summary: $agentic_evidence_summary,
           terminal_vocabulary: ["MERGED", "CLOSED_OBSOLETE", "NO_DIFF_SUCCESS", "FOLLOWUP_CREATED", "BLOCKED_CI"],
           status: "complete",
-          steps_completed: 23,
+          steps_completed: 24,
           phases_completed: [
             "requirements-clarification", "design", "implementation",
             "testing", "review", "merge"

--- a/amplifier-bundle/tools/workflow_agentic_finalization.sh
+++ b/amplifier-bundle/tools/workflow_agentic_finalization.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GIT_PAGER=cat GH_PAGER=cat PAGER=cat LESS=FRX
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq CLI not found - cannot validate workflow agentic finalization JSON" >&2
+  exit 2
+fi
+if ! command -v git >/dev/null 2>&1; then
+  echo "ERROR: git CLI not found - cannot collect workflow agentic finalization evidence" >&2
+  exit 2
+fi
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "ERROR: timeout CLI not found - cannot bound workflow agentic finalization" >&2
+  exit 2
+fi
+
+tmp_files=()
+cleanup_tmp_files() {
+  local file
+  for file in "${tmp_files[@]}"; do
+    [ ! -e "$file" ] || rm -f "$file"
+  done
+}
+trap cleanup_tmp_files EXIT
+
+new_tmp_file() {
+  local file
+  file="$(mktemp -t workflow-agentic-finalization-XXXXXX)"
+  tmp_files+=("$file")
+  printf '%s\n' "$file"
+}
+
+redact_sensitive_output() {
+  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 1000
+}
+
+json_array_from_lines() {
+  if [ "$#" -eq 0 ]; then
+    jq -nc '[]'
+    return 0
+  fi
+  printf '%s\n' "$@" | jq -R -s -c 'split("\n")[:-1]'
+}
+
+normalize_bool() {
+  local raw="$1"
+  case "$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')" in
+    true|1|yes|y) printf 'true\n' ;;
+    *) printf 'false\n' ;;
+  esac
+}
+
+repo_dir="${WORKTREE_SETUP_WORKTREE_PATH:-${RECIPE_VAR_worktree_setup__worktree_path:-}}"
+[ -n "$repo_dir" ] || repo_dir="${REPO_PATH:-${RECIPE_VAR_repo_path:-.}}"
+cd "$repo_dir"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "ERROR: workflow_agentic_finalization.sh requires a git worktree at $repo_dir" >&2
+  exit 2
+}
+
+current_branch="$(git branch --show-current)"
+expected_branch="${BRANCH_NAME:-${RECIPE_VAR_branch_name:-}}"
+case "$expected_branch" in "{{branch_name}}"|"''") expected_branch="" ;; esac
+if [ -n "$expected_branch" ] && [ "$current_branch" != "$expected_branch" ]; then
+  jq -nc \
+    --arg reason "branch mismatch: current branch '$current_branch' does not match expected '$expected_branch'" \
+    '{schema_version:"1",decision:"blocked",terminal_success:false,terminal_state:"FAILED_INVALID_EVIDENCE",terminal_reason:$reason,publish_status:"FAILED_INVALID_EVIDENCE",ready_for_review:false,confidence:"0",blocking_reasons:[$reason],blocking_reasons_text:$reason,evidence_summary:"branch identity mismatch",artifact_scope:{safe:true,blocked_paths:[],runtime_artifacts_present:false},evidence:{},agent_assessment:{summary:"blocked before agentic finalization",hollow_success:true,required_actions:[$reason]}}'
+  echo "ERROR: workflow agentic finalization blocked: branch mismatch" >&2
+  exit 1
+fi
+
+base_ref="${BASE_REF:-${RECIPE_VAR_base_ref:-}}"
+case "$base_ref" in "{{base_ref}}"|"''") base_ref="" ;; esac
+if [ -z "$base_ref" ]; then
+  for candidate in origin/HEAD origin/main origin/master origin/develop main master develop; do
+    if git rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1; then
+      base_ref="$candidate"
+      break
+    fi
+  done
+fi
+
+status_porcelain="$(git status --porcelain)"
+staged_paths="$(git diff --cached --name-only)"
+untracked_paths="$(git ls-files --others --exclude-standard)"
+runtime_artifacts_present="false"
+generated_runtime_artifacts=()
+if [ -e ".claude/runtime" ]; then
+  runtime_artifacts_present="true"
+  generated_runtime_artifacts+=(".claude/runtime")
+fi
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  case "$path" in
+    .claude/runtime|.claude/runtime/*) generated_runtime_artifacts+=("$path") ;;
+  esac
+done <<EOF
+$staged_paths
+$untracked_paths
+EOF
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  case "$line" in
+    *".claude/runtime"*) generated_runtime_artifacts+=("$line") ;;
+  esac
+done <<EOF
+$status_porcelain
+EOF
+
+generated_runtime_artifacts_json="$(json_array_from_lines "${generated_runtime_artifacts[@]}")"
+artifact_safe="true"
+if [ "$(printf '%s' "$generated_runtime_artifacts_json" | jq 'length')" -gt 0 ]; then
+  artifact_safe="false"
+fi
+
+issue_number="${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
+task_description="${TASK_DESCRIPTION:-${RECIPE_VAR_task_description:-}}"
+pr_url="${PR_URL:-${PR_PUBLISH_RESULT_PR_URL:-${RECIPE_VAR_pr_publish_result__pr_url:-}}}"
+pr_number="${PR_NUMBER:-${PR_PUBLISH_RESULT_PR_NUMBER:-${RECIPE_VAR_pr_publish_result__pr_number:-}}}"
+terminal_success="$(normalize_bool "${FINAL_STATUS_TERMINAL_SUCCESS:-${TERMINAL_STATE_TERMINAL_SUCCESS:-${RECIPE_VAR_terminal_state__terminal_success:-false}}}")"
+terminal_state="${FINAL_STATUS_TERMINAL_STATE:-${TERMINAL_STATE_TERMINAL_STATE:-${RECIPE_VAR_terminal_state__terminal_state:-FOLLOWUP_CREATED}}}"
+terminal_reason="${FINAL_STATUS_TERMINAL_REASON:-${TERMINAL_STATE_TERMINAL_REASON:-${RECIPE_VAR_terminal_state__terminal_reason:-agentic finalization is evaluating deterministic terminal evidence}}}"
+publish_status="${FINAL_STATUS_PUBLISH_STATUS:-${TERMINAL_STATE_PUBLISH_STATUS:-${RECIPE_VAR_terminal_state__publish_status:-$terminal_state}}}"
+commits_ahead="unknown"
+if [ -n "$base_ref" ]; then
+  commits_ahead="$(git rev-list --count "${base_ref}..HEAD")"
+fi
+
+staged_paths_json="$(printf '%s\n' "$staged_paths" | jq -R -s -c 'split("\n")[:-1] | map(select(length > 0))')"
+untracked_paths_json="$(printf '%s\n' "$untracked_paths" | jq -R -s -c 'split("\n")[:-1] | map(select(length > 0))')"
+status_porcelain_json="$(printf '%s\n' "$status_porcelain" | jq -R -s -c 'split("\n")[:-1] | map(select(length > 0))')"
+evidence_file="${FINALIZATION_EVIDENCE_FILE:-}"
+if [ -z "$evidence_file" ]; then
+  evidence_file="$(new_tmp_file)"
+fi
+
+jq -nc \
+  --arg task "$task_description" \
+  --arg issue_number "$issue_number" \
+  --arg current_branch "$current_branch" \
+  --arg base_ref "$base_ref" \
+  --arg commits_ahead "$commits_ahead" \
+  --arg pr_url "$pr_url" \
+  --arg pr_number "$pr_number" \
+  --arg terminal_success "$terminal_success" \
+  --arg terminal_state "$terminal_state" \
+  --arg terminal_reason "$terminal_reason" \
+  --arg publish_status "$publish_status" \
+  --argjson status_porcelain "$status_porcelain_json" \
+  --argjson staged_paths "$staged_paths_json" \
+  --argjson untracked_paths "$untracked_paths_json" \
+  --argjson generated_runtime_artifacts "$generated_runtime_artifacts_json" \
+  --arg artifact_safe "$artifact_safe" \
+  --arg runtime_artifacts_present "$runtime_artifacts_present" \
+  '{
+    task:$task,
+    issue_number:$issue_number,
+    branch:$current_branch,
+    base_ref:$base_ref,
+    commits_ahead:$commits_ahead,
+    pr_url:$pr_url,
+    pr_number:$pr_number,
+    terminal:{success:($terminal_success == "true"),state:$terminal_state,reason:$terminal_reason,publish_status:$publish_status},
+    git:{status_porcelain:$status_porcelain,staged_paths:$staged_paths,untracked_paths:$untracked_paths},
+    artifact_scope:{safe:($artifact_safe == "true"),blocked_paths:$generated_runtime_artifacts,runtime_artifacts_present:($runtime_artifacts_present == "true")}
+  }' >"$evidence_file"
+
+emit_blocked() {
+  local reason="$1" summary="$2"
+  local terminal_state_value="${3:-FAILED_INVALID_EVIDENCE}"
+  jq -nc \
+    --arg reason "$reason" \
+    --arg summary "$summary" \
+    --arg terminal_state_value "$terminal_state_value" \
+    --slurpfile evidence "$evidence_file" \
+    '{
+      schema_version:"1",
+      decision:"blocked",
+      terminal_success:false,
+      terminal_state:$terminal_state_value,
+      terminal_reason:$reason,
+      publish_status:$terminal_state_value,
+      ready_for_review:false,
+      confidence:"0",
+      blocking_reasons:[$reason],
+      blocking_reasons_text:$reason,
+      evidence_summary:$summary,
+      artifact_scope:($evidence[0].artifact_scope // {safe:false,blocked_paths:[],runtime_artifacts_present:false}),
+      evidence:($evidence[0] // {}),
+      agent_assessment:{summary:$summary,hollow_success:true,required_actions:[$reason]}
+    }'
+}
+
+if [ "$artifact_safe" != "true" ]; then
+  emit_blocked "generated_runtime_artifacts present in finalization scope" "Artifact scope contains generated .claude/runtime artifacts"
+  echo "ERROR: workflow agentic finalization blocked: generated runtime artifacts are present in artifact_scope" >&2
+  exit 1
+fi
+
+if [ -n "$status_porcelain" ]; then
+  emit_blocked "dirty worktree blocks agentic finalization" "git status --porcelain reported uncommitted work" "FAILED_DIRTY_WORKTREE"
+  echo "ERROR: workflow agentic finalization blocked: dirty worktree" >&2
+  exit 1
+fi
+
+agent_binary="${AMPLIHACK_AGENT_BINARY:-}"
+if [ -z "$agent_binary" ]; then
+  emit_blocked "AMPLIHACK_AGENT_BINARY is required for bounded agentic finalization" "missing agent binary"
+  echo "ERROR: AMPLIHACK_AGENT_BINARY is required for agentic finalization" >&2
+  exit 2
+fi
+if ! command -v "$agent_binary" >/dev/null 2>&1; then
+  emit_blocked "AMPLIHACK_AGENT_BINARY '$agent_binary' is not executable on PATH" "agent binary unavailable"
+  echo "ERROR: AMPLIHACK_AGENT_BINARY '$agent_binary' is not executable on PATH" >&2
+  exit 2
+fi
+
+prompt_file="$(new_tmp_file)"
+finalizer_output_file="$(new_tmp_file)"
+stderr_file="$(new_tmp_file)"
+cat >"$prompt_file" <<EOF
+# agentic finalization
+
+Assess whether this workflow branch is ready, blocked, needs_human, or finalized.
+Use only the deterministic evidence below. Do not run commands.
+Return exactly one JSON object with:
+schema_version, decision, terminal_success, terminal_state, terminal_reason,
+publish_status, ready_for_review, confidence, blocking_reasons, evidence_summary,
+artifact_scope, evidence, and agent_assessment.
+
+Valid decisions: ready, blocked, needs_human, finalized.
+Valid terminal states include FOLLOWUP_CREATED, MERGED, CLOSED_OBSOLETE,
+NO_DIFF_SUCCESS, BLOCKED_CI, FAILED_INVALID_EVIDENCE, and FAILED_DIRTY_WORKTREE.
+Set agent_assessment.hollow_success=true if the evidence cannot prove the claim.
+
+Evidence:
+$(cat "$evidence_file")
+EOF
+
+timeout_seconds="${AGENTIC_FINALIZATION_TIMEOUT_SECONDS:-120}"
+if ! timeout "$timeout_seconds" "$agent_binary" <"$prompt_file" >"$finalizer_output_file" 2>"$stderr_file"; then
+  stderr_summary="$(redact_sensitive_output "$stderr_file")"
+  emit_blocked "agentic finalization invocation failed; stderr: $stderr_summary" "bounded agent invocation failed"
+  echo "ERROR: agentic finalization invocation failed; stderr: $stderr_summary" >&2
+  exit 1
+fi
+
+schema_filter='
+  type == "object" and
+  (.schema_version | type == "string") and
+  (.decision | type == "string") and
+  (.terminal_success | type == "boolean") and
+  (.terminal_state | type == "string" and length > 0) and
+  (.terminal_reason | type == "string" and length > 0) and
+  (.publish_status | type == "string" and length > 0) and
+  (.ready_for_review | type == "boolean") and
+  (.artifact_scope | type == "object") and
+  (.artifact_scope.safe | type == "boolean") and
+  (.artifact_scope.blocked_paths | type == "array") and
+  (.evidence | type == "object") and
+  (.agent_assessment | type == "object") and
+  (.agent_assessment.hollow_success | type == "boolean") and
+  (.agent_assessment.required_actions | type == "array")
+'
+
+if ! jq -e "$schema_filter" "$finalizer_output_file" >/dev/null; then
+  emit_blocked "malformed_agentic_finalization" "agentic finalizer output was malformed"
+  echo "ERROR: malformed_agentic_finalization: finalizer_output failed schema validation" >&2
+  exit 1
+fi
+
+decision="$(jq -r '.decision' "$finalizer_output_file")"
+case "$decision" in
+  ready|blocked|needs_human|finalized) ;;
+  *)
+    emit_blocked "malformed_agentic_finalization: unknown decision '$decision'" "unknown decision"
+    echo "ERROR: malformed_agentic_finalization: unknown decision '$decision'" >&2
+    exit 1
+    ;;
+esac
+
+hollow_success="$(jq -r '.agent_assessment.hollow_success' "$finalizer_output_file")"
+if [ "$hollow_success" = "true" ] && { [ "$decision" = "ready" ] || [ "$decision" = "finalized" ]; }; then
+  emit_blocked "hollow_success" "agentic finalizer claimed success without sufficient evidence"
+  echo "ERROR: hollow_success: ready/finalized decisions require non-hollow evidence" >&2
+  exit 1
+fi
+
+agent_artifact_safe="$(jq -r '.artifact_scope.safe' "$finalizer_output_file")"
+if [ "$agent_artifact_safe" != "true" ] && [ "$decision" != "blocked" ] && [ "$decision" != "needs_human" ]; then
+  emit_blocked "malformed_agentic_finalization: unsafe artifact_scope cannot be ready" "artifact_scope contradiction"
+  echo "ERROR: malformed_agentic_finalization: unsafe artifact_scope cannot be ready" >&2
+  exit 1
+fi
+
+agent_terminal_state="$(jq -r '.terminal_state' "$finalizer_output_file")"
+agent_terminal_success="$(jq -r '.terminal_success' "$finalizer_output_file")"
+case "$agent_terminal_state" in
+  MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS)
+    if [ "$agent_terminal_success" != "true" ] || [ "$decision" = "ready" ]; then
+      emit_blocked "malformed_agentic_finalization: terminal success contradiction" "terminal_state contradiction"
+      echo "ERROR: malformed_agentic_finalization: terminal success contradiction" >&2
+      exit 1
+    fi
+    ;;
+  FAILED_*|BLOCKED_CI|FAILED_DIRTY_WORKTREE)
+    if [ "$decision" = "ready" ] || [ "$decision" = "finalized" ]; then
+      emit_blocked "malformed_agentic_finalization: blocked terminal_state cannot be successful" "terminal_state contradiction"
+      echo "ERROR: malformed_agentic_finalization: blocked terminal_state cannot be successful" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+jq -c \
+  --slurpfile deterministic_evidence "$evidence_file" \
+  '{
+    schema_version,
+    decision,
+    terminal_success,
+    terminal_state,
+    terminal_reason,
+    publish_status,
+    ready_for_review,
+    confidence: ((.confidence // .agent_assessment.confidence // 0) | tostring),
+    blocking_reasons: (.blocking_reasons // .agent_assessment.required_actions // []),
+    blocking_reasons_text: ((.blocking_reasons // .agent_assessment.required_actions // []) | join("\n")),
+    evidence_summary: (.evidence_summary // .agent_assessment.summary // ""),
+    artifact_scope,
+    evidence: (.evidence + {deterministic:$deterministic_evidence[0]}),
+    agent_assessment
+  }' "$finalizer_output_file"

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -132,6 +132,10 @@ name = "workflow_finalize_resilience"
 path = "../../tests/integration/workflow_finalize_resilience.rs"
 
 [[test]]
+name = "workflow_agentic_finalization"
+path = "../../tests/integration/workflow_agentic_finalization.rs"
+
+[[test]]
 name = "hygiene_cleanup"
 path = "../../tests/integration/hygiene_cleanup.rs"
 

--- a/docs/howto/finalize-existing-workflow-branch.md
+++ b/docs/howto/finalize-existing-workflow-branch.md
@@ -1,0 +1,269 @@
+# How to Finalize an Existing Workflow Branch
+
+Use this guide to recover a branch that already contains implementation work,
+exclude generated artifacts, validate finalization evidence, and leave the work
+ready for review or terminally closed through the issue #769 agentic finalizer.
+
+## Before you start
+
+- Run from the branch that contains the implementation.
+- Keep generated runtime directories out of the commit scope.
+- Preserve Node memory settings when validation includes Node tooling:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+---
+
+## 1. Inspect the Worktree
+
+```bash
+git --no-pager status --short
+git --no-pager diff --name-only
+git --no-pager diff --cached --name-only
+```
+
+Separate issue-relevant changes from generated artifacts. Issue-relevant files
+can include recipes, helper tools, tests, source, docs, discoverability links,
+and `.gitignore` changes that directly support the issue.
+
+Generated runtime paths such as `.claude/runtime/` are never issue-relevant
+commit scope.
+
+---
+
+## 2. Remove Generated Runtime Artifacts
+
+If `.claude/runtime/` or another generated artifact is staged, unstage it:
+
+```bash
+git restore --staged .claude/runtime 2>/dev/null || true
+```
+
+If a runtime log is needed for debugging, extract only the minimum redacted
+snippet outside the repository. Do not copy the whole runtime directory:
+
+```bash
+mkdir -p /tmp/amplihack-finalization-evidence
+grep -R "workflow-finalize" .claude/runtime 2>/dev/null \
+  | sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' \
+  > /tmp/amplihack-finalization-evidence/workflow-finalize-redacted.log || true
+```
+
+Remove generated runtime leftovers from the worktree:
+
+```bash
+rm -rf .claude/runtime
+```
+
+Do not add `.claude/runtime/` to an allowlist. Runtime state is generated output,
+not source material.
+
+---
+
+## 3. Run Artifact Guard
+
+Run a full safety scan before staging:
+
+```bash
+amplihack hygiene artifact-guard --repo . --mode all
+```
+
+A clean result exits `0`. A blocked result names the unsafe paths:
+
+```text
+Artifact Guard blocked 1 prohibited artifact paths.
+
+source           path                  rule
+untracked        .claude/runtime/      claude-runtime
+```
+
+Fix the paths and rerun the guard. Do not weaken Artifact Guard to make a branch
+publishable.
+
+---
+
+## 4. Run Workflow Finalization
+
+Run `workflow-finalize` with the existing branch and PR context:
+
+```bash
+result_file="$(mktemp -t workflow-finalize-XXXXXX.json)"
+
+amplihack recipe run workflow-finalize \
+  -c repo_path="$PWD" \
+  -c branch_name="$(git branch --show-current)" \
+  -c issue_number=769 \
+  -c pr_number=123 \
+  -c pr_url="https://github.com/rysweet/amplihack-rs/pull/123" \
+  --format json > "$result_file"
+```
+
+Inspect terminal-state and finalizer evidence:
+
+```bash
+jq '.. | objects | select(has("terminal_state") or has("decision")) | {
+  decision,
+  terminal_success,
+  terminal_state,
+  terminal_reason,
+  publish_status,
+  ready_for_review,
+  artifact_scope
+}' "$result_file"
+```
+
+Expected target outcomes:
+
+| Outcome | Meaning |
+| --- | --- |
+| `decision="ready"` with `terminal_state="FOLLOWUP_CREATED"` | The branch has reviewable PR work. This is PR-ready, not merged/final terminal success. |
+| `decision="finalized"` with `NO_DIFF_SUCCESS`, `MERGED`, or `CLOSED_OBSOLETE` | No further commit or publish work is required. |
+| `decision="blocked"` | Fix the named problem and rerun finalization. |
+
+---
+
+## 5. Run Local Validation
+
+Run pre-commit and the tests for the changed area:
+
+```bash
+pre-commit run --all-files
+
+cargo test --test workflow_finalize_terminal_state
+cargo test --test workflow_finalize_resilience
+cargo test --test default_workflow_decomposition
+```
+
+Also run the `workflow_agentic_finalization` helper/schema tests when the
+change touches finalization evidence or artifact scope.
+
+---
+
+## 6. Stage Only Issue-Relevant Files
+
+Stage explicit files. Do not rely on `git add -A` until Artifact Guard is clean
+and status has been reviewed.
+
+Example for an implementation that touches recipes, helper tools, tests, and
+docs:
+
+```bash
+git add \
+  amplifier-bundle/recipes/workflow-finalize.yaml \
+  amplifier-bundle/recipes/workflow-terminal-state.yaml \
+  amplifier-bundle/tools/workflow_agentic_finalization.sh \
+  tests/integration/workflow_finalize_terminal_state.rs \
+  tests/integration/workflow_finalize_resilience.rs \
+  tests/integration/workflow_agentic_finalization.rs \
+  docs/reference/workflow-agentic-finalization.md \
+  docs/howto/finalize-existing-workflow-branch.md \
+  docs/tutorials/workflow-agentic-finalization.md \
+  docs/index.md \
+  docs/recipes/README.md \
+  docs/tutorials/README.md
+```
+
+Adjust the list to match the actual issue-relevant diff. Include `.gitignore`
+only when the issue intentionally changes ignore policy.
+
+Review the staged set:
+
+```bash
+git --no-pager diff --cached --name-status
+git --no-pager diff --cached --stat
+```
+
+If `.claude/runtime/`, dependency trees, build output, logs, or local config
+appear in the staged diff, unstage and remove them before committing.
+
+---
+
+## 7. Commit and Push
+
+Use a focused commit message that references the issue:
+
+```bash
+git commit -m "Fix workflow finalization evidence handling for issue #769"
+git push -u origin "$(git branch --show-current)"
+```
+
+The pre-commit hook runs Artifact Guard again. A hook failure is a real
+finalization failure; fix the reported paths and rerun the commit.
+
+---
+
+## 8. Create or Update the Pull Request
+
+Create a PR if one does not exist:
+
+```bash
+gh pr create \
+  --base main \
+  --head "$(git branch --show-current)" \
+  --title "Fix workflow finalization evidence handling" \
+  --body "$(cat <<'EOF'
+Refs #769
+
+## Summary
+- Adds bounded agentic finalization evidence validation.
+- Preserves deterministic terminal-state and final-status gates.
+- Keeps generated .claude/runtime artifacts out of commit scope.
+
+## Validation
+- pre-commit run --all-files
+- cargo test --test workflow_finalize_terminal_state
+- cargo test --test workflow_finalize_resilience
+- cargo test --test workflow_agentic_finalization
+EOF
+)"
+```
+
+Update an existing PR:
+
+```bash
+gh pr edit 123 \
+  --body "$(cat <<'EOF'
+Refs #769
+
+## Summary
+- Adds bounded agentic finalization evidence validation.
+- Preserves deterministic terminal-state and final-status gates.
+- Keeps generated .claude/runtime artifacts out of commit scope.
+
+## Validation
+- pre-commit run --all-files
+- cargo test --test workflow_finalize_terminal_state
+- cargo test --test workflow_finalize_resilience
+- cargo test --test workflow_agentic_finalization
+EOF
+)"
+```
+
+The PR is ready for review when Artifact Guard is clean, validation has passed,
+the staged scope contains only issue-relevant files, and finalization reports
+`ready` with `ready_for_review=true`.
+
+The workflow is terminally finalized only when finalization reports
+`finalized` with `NO_DIFF_SUCCESS`, `MERGED`, or `CLOSED_OBSOLETE`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Artifact Guard blocks `.claude/runtime/` | Agent runtime output leaked into the parent worktree | Unstage it, remove it from the worktree, rerun Artifact Guard. |
+| `FAILED_INVALID_EVIDENCE` | Finalizer output is malformed, contradictory, or missing required fields | Fix the producing recipe/helper logic and rerun `workflow-finalize`. |
+| `FAILED_DIRTY_WORKTREE` | Meaningful uncommitted work remains after finalization | Stage and commit issue-relevant files, or remove unrelated leftovers. |
+| `BLOCKED_CI` | Required checks or PR readiness failed | Diagnose the failing check, fix only issue-related failures, rerun validation. |
+| PR lookup fails | Missing or mismatched `pr_number`, `pr_url`, branch, or GitHub auth | Pass the correct PR context and verify `gh auth status`. |
+| `decision="ready"` but `terminal_success=false` | The PR is ready for review but not merged or otherwise terminal | Continue normal review/merge flow; do not treat PR readiness as merged closure. |
+
+## See Also
+
+- [Workflow Agentic Finalization Reference](../reference/workflow-agentic-finalization.md)
+- [Tutorial: Workflow Agentic Finalization](../tutorials/workflow-agentic-finalization.md)
+- [Artifact Guard](../artifact-guard.md)
+- [How to Diagnose Workflow Terminal-State Failures](./diagnose-workflow-terminal-state.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -275,6 +275,9 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [Workflow Terminal-State Reference](reference/workflow-terminal-state.md) - Target contract for development completion evidence, no-op states, failure semantics, and shell helper API
 - [How to Diagnose Workflow Terminal-State Failures](howto/diagnose-workflow-terminal-state.md) - Investigate missing evidence after planning, analysis, design, or worktree-only runs
 - [Tutorial: Workflow Terminal-State Closure](tutorials/workflow-terminal-state-closure.md) - Walk through completion evidence, planning-only failure, and rerun semantics
+- [Workflow Agentic Finalization Reference](reference/workflow-agentic-finalization.md) - Issue #769 contract for bounded finalizer assessment on top of deterministic terminal-state and final-status gates
+- [How to Finalize an Existing Workflow Branch](howto/finalize-existing-workflow-branch.md) - Target flow for cleaning generated artifacts, validating finalization evidence, staging issue-relevant files, and preparing a PR
+- [Tutorial: Workflow Agentic Finalization](tutorials/workflow-agentic-finalization.md) - Target walkthrough for `.claude/runtime` cleanup, Artifact Guard, finalizer decisions, validation, and PR publication
 - [Workflow-Owned PR Recovery Readiness](features/pr-recovery-readiness.md) - Recover an existing PR through `default-workflow` with branch reuse, hook readiness, additive-copy readiness, and workflow-owned finalization
 - [Existing Branch Finalization Runbook](features/post-v0977-finalization.md) - Finish an already-implemented branch through preservation, validation, PR publication, CI gating, and policy-ready merge
 - [How to Recover an Existing PR with `default-workflow`](howto/recover-existing-pr-with-default-workflow.md) - Supply `pr_number`, `existing_branch`, and issue requirements without manually merging

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -77,6 +77,9 @@ Complete documentation for using the Recipe Runner:
 - **[Workflow Terminal-State Reference](../reference/workflow-terminal-state.md)** - Target contract for development workflow completion evidence, no-op states, routed failure propagation, and `workflow_final_status.sh` API
 - **[How to Diagnose Workflow Terminal-State Failures](../howto/diagnose-workflow-terminal-state.md)** - Recovery guide for missing terminal evidence after planning, analysis, design, or worktree-only execution
 - **[Tutorial: Workflow Terminal-State Closure](../tutorials/workflow-terminal-state-closure.md)** - Walk through successful evidence, planning-only failure, and rerun behavior
+- **[Workflow Agentic Finalization Reference](../reference/workflow-agentic-finalization.md)** - Issue #769 contract for bounded finalizer assessment layered on deterministic terminal-state and final-status enforcement
+- **[How to Finalize an Existing Workflow Branch](../howto/finalize-existing-workflow-branch.md)** - Target recovery flow for artifact cleanup, finalization validation, focused staging, and PR readiness
+- **[Tutorial: Workflow Agentic Finalization](../tutorials/workflow-agentic-finalization.md)** - Target hands-on finalization flow for an existing issue branch with generated runtime artifacts excluded
 - **[Scoped Workflow Closure](../reference/scoped-workflow-closure.md)** - Persisted PR, process, and workstream ownership contract for default-workflow closure
 
 ## Why It Exists

--- a/docs/reference/workflow-agentic-finalization.md
+++ b/docs/reference/workflow-agentic-finalization.md
@@ -1,0 +1,303 @@
+# Workflow Agentic Finalization Reference
+
+> [Home](../index.md) > Reference > Workflow Agentic Finalization
+
+This reference defines the issue #769 contract for bounded agentic
+finalization. The implementation layers `workflow_agentic_finalization.sh` and
+schema validation on top of the deterministic `workflow-terminal-state`,
+`workflow_pr_ready.sh`, `workflow_final_status.sh`, and `workflow-complete`
+gates.
+
+## Contents
+
+- [Purpose](#purpose)
+- [Finalization Surfaces](#finalization-surfaces)
+- [Finalization Pipeline](#finalization-pipeline)
+- [Helper API](#helper-api)
+- [Input Context](#input-context)
+- [Output Schema](#output-schema)
+- [Decision and Terminal-State Semantics](#decision-and-terminal-state-semantics)
+- [Implementation Requirements](#implementation-requirements)
+- [Artifact Scope](#artifact-scope)
+- [Failure Semantics](#failure-semantics)
+- [Security Invariants](#security-invariants)
+
+---
+
+## Purpose
+
+`workflow-finalize` must not report code-change completion from brittle or
+ambiguous evidence. Issue #769 makes finalization more resilient
+by combining:
+
+1. deterministic repository and PR evidence,
+2. Artifact Guard scope checks,
+3. bounded agent assessment,
+4. strict JSON schema validation, and
+5. the shared terminal-state vocabulary.
+
+The agentic finalizer is advisory. It can explain why a branch is ready,
+blocked, or already finalized, but it cannot override deterministic failures.
+
+---
+
+## Finalization Surfaces
+
+| Surface | Contract |
+| --- | --- |
+| Initial terminal probe | `workflow-terminal-state.yaml` runs first and emits `terminal_state`, `terminal_success`, `publish_status`, and continuation flags. Proven terminal states skip redundant finalize work. |
+| PR readiness | `workflow_pr_ready.sh` handles open, merged, closed-after-merge, and closed-unmerged PR readiness paths. |
+| Final status | `workflow_final_status.sh` reports no-diff, merged, closed-after-merge, closed-unmerged, meaningful-diff, blocked-CI, and follow-up states. |
+| Agentic helper | `amplifier-bundle/tools/workflow_agentic_finalization.sh` collects deterministic evidence, invokes the bounded agent assessment through `AMPLIHACK_AGENT_BINARY`, and schema-validates the result. |
+| Output shape | `workflow-complete` emits existing terminal fields plus `agentic_decision`, `agentic_confidence`, `agentic_blocking_reasons`, and `agentic_evidence_summary`. |
+| Tests | Integration tests cover helper existence, executable mode, schema validation, malformed-output rejection, hollow-success rejection, contradiction rejection, and artifact scope. |
+
+---
+
+## Finalization Pipeline
+
+`workflow-finalize.yaml` runs in this order:
+
+1. Run `workflow-terminal-state` as the first probe.
+2. If `terminal_success=true`, skip redundant cleanup/publish work and carry the
+   proven terminal state into `workflow-complete`.
+3. If the state is active (`FOLLOWUP_CREATED`) and `should_finalize=true`, run
+   cleanup, Artifact Guard, push cleanup, PR readiness, CI/mergeability, and final
+   status as the current recipe does.
+4. Collect deterministic evidence from Git status, branch/base diff, validation
+   commands, Artifact Guard, PR metadata, `workflow_pr_ready.sh`, and
+   `workflow_final_status.sh`.
+5. Invoke `workflow_agentic_finalization.sh` with only the
+   collected evidence and bounded task context.
+6. Validate helper stdout with `jq` against the required schema.
+7. Reject malformed output, unknown enum values, unsafe artifact scope, hollow
+   success, and contradictions with deterministic evidence.
+8. Map the accepted finalizer decision to the shared terminal-state fields used
+   by `workflow-complete`.
+
+The pipeline is intentionally additive. Existing deterministic terminal-state
+behavior remains the source of truth when it proves a terminal success or
+terminal failure.
+
+---
+
+## Helper API
+
+The helper lives at:
+
+```bash
+amplifier-bundle/tools/workflow_agentic_finalization.sh
+```
+
+The helper reads recipe context and deterministic evidence from environment
+variables and files, then writes one JSON object to stdout. It must be executable
+after install and must fail closed when dependencies, input, repository state, or
+agent output are invalid.
+
+Direct invocation:
+
+```bash
+export REPO_PATH="$PWD"
+export TASK_DESCRIPTION="Adaptive recovery for issue #769 workflow finalization"
+export ISSUE_NUMBER=769
+export BRANCH_NAME="$(git branch --show-current)"
+export PR_URL="https://github.com/rysweet/amplihack-rs/pull/123"
+export FINALIZATION_EVIDENCE_FILE="$(mktemp -t workflow-finalization-evidence-XXXXXX.json)"
+
+bash amplifier-bundle/tools/workflow_agentic_finalization.sh
+```
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Valid finalizer JSON was emitted. |
+| `1` | Finalization reached a known blocking state, such as unsafe artifacts, failed checks, or uncommitted meaningful work. |
+| `2` | The helper could not run because input, dependencies, repository state, or JSON output was invalid. |
+
+---
+
+## Input Context
+
+| Context key / environment variable | Required | Description |
+| --- | --- | --- |
+| `repo_path` / `REPO_PATH` | Yes | Repository root used for Git, Artifact Guard, and PR inspection. |
+| `worktree_setup.worktree_path` / `WORKTREE_SETUP_WORKTREE_PATH` | No | Preferred workflow worktree. When present, evidence collection runs there instead of `repo_path`. |
+| `task_description` / `TASK_DESCRIPTION` | Yes | Original task used to evaluate whether the implementation satisfies the requested outcome. |
+| `final_requirements` / `FINAL_REQUIREMENTS` | No | Normalized requirements from earlier workflow phases. |
+| `issue_number` / `ISSUE_NUMBER` | No | Issue the branch or PR should reference. |
+| `branch_name` / `BRANCH_NAME` | No | Expected branch. Defaults to the current branch. |
+| `base_ref` / `BASE_REF` | No | Base ref for diff comparison. Defaults to the same base resolution as `workflow-terminal-state`. |
+| `pr_number` / `PR_NUMBER` | No | Pull request number to inspect. |
+| `pr_url` / `PR_URL` | No | Pull request URL to inspect. |
+| `finalization_evidence_file` / `FINALIZATION_EVIDENCE_FILE` | No | Optional path where the helper writes the deterministic evidence bundle. |
+| `AMPLIHACK_AGENT_BINARY` | Yes | Agent binary used for the bounded finalization assessment. |
+| `allow_no_op` / `ALLOW_NO_OP` | No | Allows an explicit no-op only when paired with a valid no-op state and reason. |
+
+`jq` is required for schema validation. `gh` is required only for GitHub PR
+metadata paths. GitHub credentials are read through the existing authenticated
+`gh` CLI session and must not be written into finalization JSON.
+
+---
+
+## Output Schema
+
+The helper emits one JSON object:
+
+```json
+{
+  "schema_version": "1",
+  "decision": "ready",
+  "terminal_success": false,
+  "terminal_state": "FOLLOWUP_CREATED",
+  "terminal_reason": "implementation is committed, validation passed, and PR is open for issue #769",
+  "publish_status": "FOLLOWUP_CREATED",
+  "ready_for_review": true,
+  "artifact_scope": {
+    "safe": true,
+    "blocked_paths": [],
+    "runtime_artifacts_present": false
+  },
+  "evidence": {
+    "branch": "feat/issue-769-the-recipe-exitfinalization-step-is-brittle-and-of",
+    "issue_number": "769",
+    "pr_url": "https://github.com/rysweet/amplihack-rs/pull/123",
+    "modified_paths": [],
+    "validation": [
+      "pre-commit run --all-files",
+      "cargo test --test workflow_finalize_terminal_state",
+      "cargo test --test workflow_finalize_resilience"
+    ]
+  },
+  "agent_assessment": {
+    "summary": "Finalization evidence is complete and review scope excludes generated runtime artifacts.",
+    "hollow_success": false,
+    "required_actions": []
+  }
+}
+```
+
+Required top-level fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `schema_version` | string | Schema version. Initial value is `"1"`. |
+| `decision` | enum | `ready`, `blocked`, `needs_human`, or `finalized`. |
+| `terminal_success` | boolean | `true` only for terminal success states that require no further workflow action. |
+| `terminal_state` | enum | Shared terminal-state vocabulary. |
+| `terminal_reason` | string | Non-empty actionable explanation. |
+| `publish_status` | enum/string | Publish-facing state used by downstream recipe steps. |
+| `ready_for_review` | boolean | `true` when the current work is represented by an open reviewable PR but is not merged yet. |
+| `artifact_scope.safe` | boolean | Whether generated artifacts are absent from commit scope. |
+| `artifact_scope.blocked_paths` | array | Unsafe repo-relative artifact paths, if any. |
+| `evidence` | object | Deterministic evidence used for the decision. |
+| `agent_assessment.hollow_success` | boolean | `true` when the finalizer could not prove meaningful completion. |
+| `agent_assessment.required_actions` | array | Concrete follow-up actions for blocked decisions. |
+
+The helper emits native JSON booleans. Recipe wiring may translate accepted
+values into string context variables because existing YAML recipe context is
+string-oriented.
+
+Unknown additional fields are ignored. Unknown enum values in required fields
+fail closed.
+
+---
+
+## Decision and Terminal-State Semantics
+
+`decision` is the agentic finalizer vocabulary. `terminal_state` remains the
+machine-checkable workflow vocabulary defined in
+[Workflow Terminal-State Reference](./workflow-terminal-state.md).
+
+| Decision | Typical terminal state | Meaning |
+| --- | --- | --- |
+| `ready` | `FOLLOWUP_CREATED` | The branch has meaningful completed work represented by an open PR or follow-up publication. It is ready for review, not terminally complete. |
+| `finalized` | `NO_DIFF_SUCCESS` | No meaningful diff remains against the base ref. |
+| `finalized` | `MERGED` | The workflow-owned PR is merged. |
+| `finalized` | `CLOSED_OBSOLETE` | The PR or branch is obsolete because equivalent work is already upstream. |
+| `blocked` | `FAILED_INVALID_EVIDENCE` | Output was malformed, contradictory, or incomplete. |
+| `blocked` | `FAILED_DIRTY_WORKTREE` | Meaningful uncommitted work remains outside a valid no-op path. |
+| `blocked` | `BLOCKED_CI` | Required validation or CI is failing. |
+
+`FOLLOWUP_CREATED` is an active continuation state. It can mean "the current
+work is published and ready for review," but it is not a terminal success for
+the whole lifecycle unless project policy defines PR readiness as the completion
+point for that workflow run. Merged, obsolete, and no-diff states are terminal
+success states.
+
+---
+
+## Implementation Requirements
+
+The issue #769 implementation includes:
+
+1. `amplifier-bundle/tools/workflow_agentic_finalization.sh` with executable bit
+   preserved by install/package flows.
+2. Recipe wiring in `workflow-finalize.yaml` after deterministic evidence
+   collection and before `workflow-complete`.
+3. A deterministic evidence bundle written before the helper runs.
+4. `jq` schema validation for helper output.
+5. Fail-closed handling for malformed JSON, missing required fields, unknown enum
+   values, unsafe artifacts, hollow success, and deterministic contradiction.
+6. Tests for helper discovery, executable-bit validation, schema acceptance,
+   malformed-output rejection, blocked artifact scope, no-diff finalization,
+   ready-for-review mapping, and contradiction rejection.
+
+---
+
+## Artifact Scope
+
+Generated runtime artifacts are never valid commit scope. Artifact Guard blocks
+them before broad staging and before publication/finalization gates.
+
+Default blocked examples include:
+
+| Path | Reason |
+| --- | --- |
+| `.claude/runtime/` | Agent runtime state and generated logs. |
+| `target/` when staged, tracked, or unignored | Rust build output. |
+| `node_modules/` | Dependency tree. |
+| `dist/`, `build/`, `coverage/` | Generated build or test output. |
+
+`.gitignore` is noise reduction, not authorization. Ignored generated output can
+still block finalization if it leaks into the parent worktree or commit scope.
+
+---
+
+## Failure Semantics
+
+Finalization fails closed when any of these conditions are true:
+
+- the helper is missing, not executable, or cannot find required tools;
+- Artifact Guard reports blocked paths such as `.claude/runtime/`;
+- helper output is non-JSON, empty JSON, missing required fields, or contains
+  unknown enum values;
+- the helper claims success while `agent_assessment.hollow_success` is `true`;
+- deterministic evidence contradicts the agentic assessment;
+- PR identity does not match the repository, branch, or expected issue; or
+- required validation is absent or failing.
+
+Failure output includes `decision="blocked"`, a failing `terminal_state`, a
+non-empty `terminal_reason`, and actionable `required_actions` when available.
+
+---
+
+## Security Invariants
+
+- Treat finalizer output as untrusted until `jq` schema validation passes.
+- Never execute commands proposed by the finalizer.
+- Quote repository paths, branch names, PR URLs, and issue values in shell steps.
+- Redact credentials and authenticated remotes from captured evidence.
+- Do not commit raw transcripts, `.claude/runtime`, local config, dependency
+  trees, build output, or generated logs.
+- Do not copy `.claude/runtime` wholesale into `/tmp`; extract only the minimum
+  redacted evidence needed for debugging outside the repository, then delete the
+  runtime directory.
+- Do not weaken Artifact Guard to make finalization pass.
+
+## See Also
+
+- [How to Finalize an Existing Workflow Branch](../howto/finalize-existing-workflow-branch.md)
+- [Tutorial: Workflow Agentic Finalization](../tutorials/workflow-agentic-finalization.md)
+- [Workflow Terminal-State Reference](./workflow-terminal-state.md)
+- [Artifact Guard](../artifact-guard.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -108,6 +108,35 @@ python .claude/skills/multitask/orchestrator.py workstreams.json \
   --timeout-policy interrupt-preserve
 ```
 
+### [Workflow Agentic Finalization](workflow-agentic-finalization.md)
+
+Walkthrough for the issue #769 agentic finalization flow: finalize an
+already-implemented issue branch while excluding generated runtime artifacts
+from commit scope.
+
+**Topics Covered**:
+
+- Cleaning `.claude/runtime/` from staged and untracked state
+- Running Artifact Guard before broad staging
+- Inspecting `ready`, `blocked`, and `finalized` finalizer decisions
+- Running finalization-focused validation
+- Preparing a PR that references the issue and records validation
+
+**Prerequisites**: Writable clone of `amplihack`, `jq`, `gh`, and an existing issue branch
+
+**Duration**: ~20 minutes
+
+**Start Learning**:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+amplihack recipe run workflow-finalize \
+  -c repo_path="$PWD" \
+  -c branch_name="$(git branch --show-current)" \
+  -c issue_number=769 \
+  --format json
+```
+
 ---
 
 ## Platform-Specific Quick Starts

--- a/docs/tutorials/workflow-agentic-finalization.md
+++ b/docs/tutorials/workflow-agentic-finalization.md
@@ -1,0 +1,291 @@
+# Tutorial: Workflow Agentic Finalization
+
+This tutorial shows the issue #769 finalization flow for an already-implemented
+workflow branch. It uses the `workflow_agentic_finalization.sh` helper and the
+schema-validation gate wired into `workflow-finalize.yaml`.
+
+## What you will learn
+
+- Clean generated `.claude/runtime` artifacts from finalization scope.
+- Run Artifact Guard before broad staging.
+- Run `workflow-finalize` against an existing issue branch.
+- Interpret `ready`, `blocked`, and `finalized` decisions without confusing PR
+  readiness with terminal merge/no-diff closure.
+- Stage only issue-relevant files and prepare a PR body.
+
+## Prerequisites
+
+- `amplihack` is installed.
+- You are in a Git checkout on the feature branch.
+- `jq`, `git`, and `gh` are installed.
+- The branch contains implementation changes for an issue.
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+---
+
+## 1. Start from the Existing Branch
+
+Confirm the branch and current changes:
+
+```bash
+git branch --show-current
+git --no-pager status --short
+```
+
+For this tutorial, the branch is an issue branch:
+
+```text
+feat/issue-769-the-recipe-exitfinalization-step-is-brittle-and-of
+```
+
+The branch may already contain staged or modified source files. Do not reset the
+branch. Preserve the implementation and finalize it safely.
+
+---
+
+## 2. Remove Generated Runtime Output
+
+If `.claude/runtime/` appears in status output, remove it from commit scope:
+
+```bash
+git restore --staged .claude/runtime 2>/dev/null || true
+```
+
+If runtime output contains evidence you need, extract only a redacted snippet
+outside the repository:
+
+```bash
+mkdir -p /tmp/amplihack-finalization-evidence
+grep -R "workflow-finalize" .claude/runtime 2>/dev/null \
+  | sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' \
+  > /tmp/amplihack-finalization-evidence/workflow-finalize-redacted.log || true
+```
+
+Then remove the generated directory:
+
+```bash
+rm -rf .claude/runtime
+git --no-pager status --short
+```
+
+The status output should not include `.claude/runtime/`.
+
+---
+
+## 3. Run Artifact Guard
+
+Run the guard before staging anything broadly:
+
+```bash
+amplihack hygiene artifact-guard --repo . --mode all
+```
+
+Expected output is no violations and exit code `0`. If the guard reports a
+blocked path, fix that path before continuing.
+
+---
+
+## 4. Run Agentic Finalization
+
+Run `workflow-finalize` with branch and issue context:
+
+```bash
+result_file="$(mktemp -t workflow-finalize-XXXXXX.json)"
+
+amplihack recipe run workflow-finalize \
+  -c repo_path="$PWD" \
+  -c branch_name="$(git branch --show-current)" \
+  -c issue_number=769 \
+  --format json > "$result_file"
+```
+
+If a PR already exists, pass its identity too:
+
+```bash
+amplihack recipe run workflow-finalize \
+  -c repo_path="$PWD" \
+  -c branch_name="$(git branch --show-current)" \
+  -c issue_number=769 \
+  -c pr_number=123 \
+  -c pr_url="https://github.com/rysweet/amplihack-rs/pull/123" \
+  --format json > "$result_file"
+```
+
+---
+
+## 5. Read the Finalization Decision
+
+Inspect the decision and terminal state:
+
+```bash
+jq '.. | objects | select(has("decision") or has("terminal_state")) | {
+  decision,
+  terminal_success,
+  terminal_state,
+  terminal_reason,
+  publish_status,
+  ready_for_review
+}' "$result_file"
+```
+
+A branch that is ready for PR review looks like this:
+
+```json
+{
+  "decision": "ready",
+  "terminal_success": false,
+  "terminal_state": "FOLLOWUP_CREATED",
+  "terminal_reason": "implementation is committed, validation passed, and PR is open for issue #769",
+  "publish_status": "FOLLOWUP_CREATED",
+  "ready_for_review": true
+}
+```
+
+This means the finalization phase has enough evidence for review readiness. It
+does not mean the PR is merged.
+
+An already-complete no-diff branch looks like this:
+
+```json
+{
+  "decision": "finalized",
+  "terminal_success": true,
+  "terminal_state": "NO_DIFF_SUCCESS",
+  "terminal_reason": "branch has no meaningful diff against the base ref",
+  "publish_status": "NO_DIFF_SUCCESS",
+  "ready_for_review": false
+}
+```
+
+A blocked branch names the required action:
+
+```json
+{
+  "decision": "blocked",
+  "terminal_success": false,
+  "terminal_state": "FAILED_INVALID_EVIDENCE",
+  "terminal_reason": "Artifact Guard blocked generated runtime artifacts in .claude/runtime/",
+  "publish_status": "FAILED_INVALID_EVIDENCE",
+  "ready_for_review": false
+}
+```
+
+Do not treat a blocked decision as success even if earlier workflow steps exited
+successfully.
+
+---
+
+## 6. Validate the Changed Area
+
+Run the finalization checks:
+
+```bash
+pre-commit run --all-files
+
+cargo test --test workflow_finalize_terminal_state
+cargo test --test workflow_finalize_resilience
+cargo test --test workflow_agentic_finalization
+```
+
+Fix failures caused by the finalization change and rerun the failing command.
+Unrelated baseline failures belong in the PR notes, not in hidden local state.
+
+---
+
+## 7. Stage the Review Scope
+
+Stage only issue-relevant files. Example:
+
+```bash
+git add \
+  amplifier-bundle/recipes/workflow-finalize.yaml \
+  amplifier-bundle/tools/workflow_agentic_finalization.sh \
+  tests/integration/workflow_agentic_finalization.rs \
+  docs/reference/workflow-agentic-finalization.md \
+  docs/howto/finalize-existing-workflow-branch.md \
+  docs/tutorials/workflow-agentic-finalization.md \
+  docs/index.md \
+  docs/recipes/README.md \
+  docs/tutorials/README.md
+```
+
+Adjust the list to the actual diff. Include related recipe, helper, test, docs,
+discoverability, and `.gitignore` files only when they directly support the
+issue.
+
+Review the staged diff:
+
+```bash
+git --no-pager diff --cached --name-status
+```
+
+The staged diff must not include `.claude/runtime/`, build output, dependency
+trees, logs, or local configuration.
+
+---
+
+## 8. Publish the PR
+
+Commit and push:
+
+```bash
+git commit -m "Fix workflow finalization evidence handling for issue #769"
+git push -u origin "$(git branch --show-current)"
+```
+
+Create the PR if needed:
+
+```bash
+gh pr create \
+  --base main \
+  --head "$(git branch --show-current)" \
+  --title "Fix workflow finalization evidence handling" \
+  --body "Refs #769
+
+Summary:
+- Adds bounded agentic finalization evidence validation.
+- Preserves deterministic terminal-state and final-status gates.
+- Excludes generated .claude/runtime artifacts from commit scope.
+
+Validation:
+- pre-commit run --all-files
+- cargo test --test workflow_finalize_terminal_state
+- cargo test --test workflow_finalize_resilience
+- cargo test --test workflow_agentic_finalization"
+```
+
+If a PR already exists, update its body with the same summary and validation
+notes:
+
+```bash
+gh pr edit 123 --body-file <(cat <<'EOF'
+Refs #769
+
+Summary:
+- Adds bounded agentic finalization evidence validation.
+- Preserves deterministic terminal-state and final-status gates.
+- Excludes generated .claude/runtime artifacts from commit scope.
+
+Validation:
+- pre-commit run --all-files
+- cargo test --test workflow_finalize_terminal_state
+- cargo test --test workflow_finalize_resilience
+- cargo test --test workflow_agentic_finalization
+EOF
+)
+```
+
+The workflow is ready for review when the PR is open, validation is passing,
+Artifact Guard is clean, and finalization reports `decision="ready"` with
+`ready_for_review=true`.
+
+The workflow is terminally finalized only when finalization reports
+`decision="finalized"` with `NO_DIFF_SUCCESS`, `MERGED`, or `CLOSED_OBSOLETE`.
+
+## Next Steps
+
+- Use [How to Finalize an Existing Workflow Branch](../howto/finalize-existing-workflow-branch.md) for the task-oriented checklist.
+- Use [Workflow Agentic Finalization Reference](../reference/workflow-agentic-finalization.md) for schema and implementation requirements.

--- a/tests/integration/artifact_guard_workflow_tests.rs
+++ b/tests/integration/artifact_guard_workflow_tests.rs
@@ -323,3 +323,38 @@ fn workflow_publish_outside_in_fix_loop_guards_its_inline_git_add_all() {
         "outside-in fix loop snippet must hard-chain guard success to broad staging; line was `{guarded_line}`"
     );
 }
+
+#[test]
+fn agentic_finalization_keeps_generated_runtime_artifacts_out_of_commit_scope() {
+    let gitignore = read(&workspace_root().join(".gitignore"));
+    assert!(
+        gitignore
+            .lines()
+            .any(|line| line.trim() == ".claude/runtime/"),
+        ".gitignore must exclude generated .claude/runtime artifacts"
+    );
+
+    let helper_path = workspace_root()
+        .join("amplifier-bundle")
+        .join("tools")
+        .join("workflow_agentic_finalization.sh");
+    assert!(
+        helper_path.exists(),
+        "agentic finalization helper must inspect artifact scope before final reporting"
+    );
+    let helper = read(&helper_path);
+
+    for required in [
+        ".claude/runtime",
+        "git status --porcelain",
+        "git diff --cached --name-only",
+        "generated_runtime_artifacts",
+        "artifact_scope",
+        "exit 1",
+    ] {
+        assert!(
+            helper.contains(required),
+            "agentic finalization helper must keep runtime artifacts out of commit evidence; missing `{required}`"
+        );
+    }
+}

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -215,6 +215,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "step-21-pr-ready",
     "step-22-ensure-mergeable",
     "step-22b-final-status",
+    "step-22c-agentic-finalization",
     "workflow-complete",
 ];
 
@@ -278,6 +279,55 @@ fn composer_calls_nine_phase_subrecipes_in_order() {
             "composer step id should match recipe name for traceability"
         );
     }
+}
+
+#[test]
+fn workflow_finalize_subrecipe_includes_agentic_finalization_gate() {
+    let finalize = load("workflow-finalize");
+    let agentic_steps: Vec<_> = finalize
+        .steps
+        .iter()
+        .filter(|step| {
+            step.id.contains("agentic-finalization")
+                || step
+                    .command
+                    .as_deref()
+                    .is_some_and(|command| command.contains("workflow_agentic_finalization.sh"))
+        })
+        .collect();
+
+    assert_eq!(
+        agentic_steps.len(),
+        1,
+        "workflow-finalize must own exactly one agentic finalization gate"
+    );
+
+    let final_status_index = finalize
+        .steps
+        .iter()
+        .position(|step| step.id == "step-22b-final-status")
+        .expect("workflow-finalize missing deterministic final status step");
+    let agentic_index = finalize
+        .steps
+        .iter()
+        .position(|step| {
+            step.id.contains("agentic-finalization")
+                || step
+                    .command
+                    .as_deref()
+                    .is_some_and(|command| command.contains("workflow_agentic_finalization.sh"))
+        })
+        .expect("workflow-finalize missing agentic finalization gate");
+    let complete_index = finalize
+        .steps
+        .iter()
+        .position(|step| step.id == "workflow-complete")
+        .expect("workflow-finalize missing workflow-complete step");
+
+    assert!(
+        final_status_index < agentic_index && agentic_index < complete_index,
+        "agentic finalization gate must run after deterministic final status and before workflow-complete"
+    );
 }
 
 /// Every phase sub-recipe must parse and have a non-empty step list.

--- a/tests/integration/workflow_agentic_finalization.rs
+++ b/tests/integration/workflow_agentic_finalization.rs
@@ -1,0 +1,231 @@
+//! tests/integration/workflow_agentic_finalization.rs
+//!
+//! TDD-red contracts for issue #769 agentic workflow finalization.
+//! These tests define the helper and recipe wiring expected after the current
+//! deterministic terminal-state baseline grows an advisory agentic finalizer.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde_yaml::Value;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn recipe_path(name: &str) -> PathBuf {
+    workspace_root()
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join(format!("{name}.yaml"))
+}
+
+fn helper_path() -> PathBuf {
+    workspace_root()
+        .join("amplifier-bundle")
+        .join("tools")
+        .join("workflow_agentic_finalization.sh")
+}
+
+fn read(path: PathBuf) -> String {
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn helper_text() -> String {
+    let path = helper_path();
+    assert!(
+        path.exists(),
+        "issue #769 requires amplifier-bundle/tools/workflow_agentic_finalization.sh"
+    );
+    read(path)
+}
+
+fn load_recipe(name: &str) -> Value {
+    let path = recipe_path(name);
+    serde_yaml::from_str(&read(path)).unwrap_or_else(|e| panic!("parse {name}.yaml: {e}"))
+}
+
+fn steps(recipe: &Value) -> &[Value] {
+    recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("recipe must contain top-level steps")
+}
+
+fn step_index(recipe: &Value, id: &str) -> usize {
+    steps(recipe)
+        .iter()
+        .position(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .unwrap_or_else(|| panic!("recipe missing step `{id}`"))
+}
+
+fn command_step_index_containing(recipe: &Value, needle: &str) -> usize {
+    steps(recipe)
+        .iter()
+        .position(|step| {
+            step.get("command")
+                .and_then(Value::as_str)
+                .is_some_and(|command| command.contains(needle))
+        })
+        .unwrap_or_else(|| panic!("recipe must contain a bash step with `{needle}`"))
+}
+
+fn step_command<'a>(recipe: &'a Value, id: &str) -> &'a str {
+    steps(recipe)
+        .iter()
+        .find(|step| step.get("id").and_then(Value::as_str) == Some(id))
+        .and_then(|step| step.get("command").and_then(Value::as_str))
+        .unwrap_or_else(|| panic!("step `{id}` must be a bash command step"))
+}
+
+#[test]
+fn helper_exists_is_executable_and_uses_safe_shell_contract() {
+    let path = helper_path();
+    assert!(
+        path.exists(),
+        "agentic finalization helper must exist at {}",
+        path.display()
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&path)
+            .unwrap_or_else(|e| panic!("stat {}: {e}", path.display()))
+            .permissions()
+            .mode();
+        assert!(
+            mode & 0o111 != 0,
+            "workflow_agentic_finalization.sh must preserve executable mode"
+        );
+    }
+
+    let text = read(path);
+    for required in [
+        "set -euo pipefail",
+        "command -v jq",
+        "command -v git",
+        "timeout",
+        "AMPLIHACK_AGENT_BINARY",
+    ] {
+        assert!(
+            text.contains(required),
+            "agentic finalization helper must contain `{required}`"
+        );
+    }
+    for forbidden in ["eval ", "sh -c", "${var@P}", "${!"] {
+        assert!(
+            !text.contains(forbidden),
+            "agentic finalization helper must not use unsafe shell construct `{forbidden}`"
+        );
+    }
+}
+
+#[test]
+fn helper_validates_structured_agentic_decision_schema_before_success() {
+    let text = helper_text();
+
+    for required in [
+        "jq -e",
+        "decision",
+        "ready",
+        "blocked",
+        "needs_human",
+        "confidence",
+        "terminal_state",
+        "terminal_success",
+        "evidence_summary",
+        "blocking_reasons",
+        "malformed_agentic_finalization",
+        "hollow_success",
+    ] {
+        assert!(
+            text.contains(required),
+            "agentic finalization helper schema contract must contain `{required}`"
+        );
+    }
+
+    assert!(
+        text.contains("exit 1"),
+        "malformed, ambiguous, or hollow finalizer output must fail closed"
+    );
+}
+
+#[test]
+fn helper_rejects_generated_runtime_artifacts_as_commit_evidence() {
+    let text = helper_text();
+
+    for required in [
+        ".claude/runtime",
+        "git status --porcelain",
+        "git diff --cached --name-only",
+        "git ls-files --others --exclude-standard",
+        "artifact_scope",
+        "generated_runtime_artifacts",
+    ] {
+        assert!(
+            text.contains(required),
+            "agentic finalization helper must inspect artifact scope with `{required}`"
+        );
+    }
+
+    assert!(
+        !text.contains("git add -A .claude/runtime")
+            && !text.contains("git add .claude/runtime")
+            && !text.contains("cp -R .claude/runtime"),
+        "generated runtime artifacts must never be staged or copied wholesale"
+    );
+}
+
+#[test]
+fn workflow_finalize_runs_agentic_assessment_after_deterministic_evidence_before_report() {
+    let recipe = load_recipe("workflow-finalize");
+    let deterministic_status = step_index(&recipe, "step-22b-final-status");
+    let agentic = command_step_index_containing(&recipe, "workflow_agentic_finalization.sh");
+    let complete = step_index(&recipe, "workflow-complete");
+
+    assert!(
+        deterministic_status < agentic && agentic < complete,
+        "workflow-finalize must run deterministic status, then agentic finalization, then final report"
+    );
+
+    let agentic_step = &steps(&recipe)[agentic];
+    assert_eq!(
+        agentic_step.get("parse_json").and_then(Value::as_bool),
+        Some(true),
+        "agentic finalization step must parse structured JSON output"
+    );
+    assert_eq!(
+        agentic_step.get("output").and_then(Value::as_str),
+        Some("agentic_finalization"),
+        "agentic finalization output must be available to workflow-complete"
+    );
+}
+
+#[test]
+fn workflow_complete_reports_agentic_decision_without_overriding_terminal_state() {
+    let recipe = load_recipe("workflow-finalize");
+    let command = step_command(&recipe, "workflow-complete");
+
+    for required in [
+        "agentic_finalization",
+        "agentic_decision",
+        "agentic_confidence",
+        "agentic_blocking_reasons",
+        "terminal_state",
+        "terminal_success",
+    ] {
+        assert!(
+            command.contains(required),
+            "workflow-complete must expose `{required}` in final JSON"
+        );
+    }
+
+    assert!(
+        command.contains("terminal_success") && command.contains("agentic_decision"),
+        "agentic readiness may inform final reporting but terminal_state remains the machine-checkable authority"
+    );
+}

--- a/tests/integration/workflow_finalize_resilience.rs
+++ b/tests/integration/workflow_finalize_resilience.rs
@@ -179,6 +179,50 @@ fn workflow_complete_json_reports_terminal_outcome_instead_of_unconditional_merg
 }
 
 #[test]
+fn agentic_finalization_helper_fails_closed_on_malformed_or_hollow_output() {
+    let command = helper_text("workflow_agentic_finalization.sh");
+
+    for required in [
+        "jq -e",
+        "malformed_agentic_finalization",
+        "hollow_success",
+        "unknown decision",
+        "exit 1",
+        "decision",
+        "blocking_reasons",
+    ] {
+        assert!(
+            command.contains(required),
+            "agentic finalizer must fail closed on invalid output; missing `{required}`"
+        );
+    }
+}
+
+#[test]
+fn agentic_finalization_helper_uses_bounded_visible_agent_invocation() {
+    let command = helper_text("workflow_agentic_finalization.sh");
+
+    for required in [
+        "AMPLIHACK_AGENT_BINARY",
+        "timeout",
+        "agentic finalization",
+        "finalizer_output",
+        "stderr",
+        "exit",
+    ] {
+        assert!(
+            command.contains(required),
+            "agentic finalizer invocation must be bounded and visible; missing `{required}`"
+        );
+    }
+
+    assert!(
+        !command.contains("|| true") && !command.contains("2>/dev/null"),
+        "agentic finalizer failures must not be hidden"
+    );
+}
+
+#[test]
 fn pr_ready_helper_fails_closed_when_pr_view_metadata_is_unavailable() {
     let tmp = TempDir::new().expect("tempdir");
     let bin_dir = tmp.path().join("bin");

--- a/tests/integration/workflow_finalize_terminal_state.rs
+++ b/tests/integration/workflow_finalize_terminal_state.rs
@@ -148,3 +148,46 @@ fn final_status_reports_terminal_success_and_blocked_semantics_structurally() {
         "workflow-complete must not unconditionally report complete without terminal_success evidence"
     );
 }
+
+#[test]
+fn finalize_places_agentic_assessment_between_terminal_evidence_and_completion() {
+    let recipe = load_finalize_recipe();
+    let final_status_index = step_index(&recipe, "step-22b-final-status");
+    let agentic_index = steps(&recipe)
+        .iter()
+        .position(|step| {
+            step.get("command")
+                .and_then(Value::as_str)
+                .is_some_and(|command| command.contains("workflow_agentic_finalization.sh"))
+        })
+        .expect("workflow-finalize must invoke workflow_agentic_finalization.sh");
+    let complete_index = step_index(&recipe, "workflow-complete");
+
+    assert!(
+        final_status_index < agentic_index && agentic_index < complete_index,
+        "agentic finalization must run after deterministic terminal evidence and before final reporting"
+    );
+}
+
+#[test]
+fn workflow_complete_surfaces_agentic_finalizer_contract() {
+    let recipe = load_finalize_recipe();
+    let command = step_command(&recipe, "workflow-complete");
+
+    for required in [
+        "agentic_decision",
+        "agentic_confidence",
+        "agentic_blocking_reasons",
+        "agentic_evidence_summary",
+    ] {
+        assert!(
+            command.contains(required),
+            "workflow-complete JSON must expose `{required}` from agentic finalization"
+        );
+    }
+
+    assert!(
+        command.contains("terminal_state") && command.contains("terminal_success"),
+        "agentic finalization must augment, not replace, machine-checkable terminal state"
+    );
+}


### PR DESCRIPTION
Refs #769

## Summary
- Adds `workflow_agentic_finalization.sh` as a bounded, schema-validated finalizer that collects deterministic git/artifact evidence and rejects malformed output, hollow success, dirty worktrees, and generated `.claude/runtime` artifacts.
- Wires the agentic finalization gate after deterministic final status and before `workflow-complete`, while preserving terminal-state authority and surfacing agentic decision fields in final JSON.
- Adds finalization-focused integration coverage and docs for recovering existing workflow branches without committing generated runtime artifacts.

## Validation
- `pre-commit run --all-files`
- `cargo test --test workflow_agentic_finalization --test workflow_finalize_terminal_state --test workflow_finalize_resilience --test default_workflow_decomposition --test artifact_guard_workflow`
- `cargo test -p amplihack-cli --lib`
- `cargo test --workspace --locked`
- Functional smoke test for `workflow_agentic_finalization.sh` with a temporary clean repo and fake bounded agent
- GitHub PR checks passing after rerunning the transient `Test` job failure

## Artifact Guard recovery
- Removed generated `.claude/runtime` from the worktree before staging.
- Staged only issue #769 source, recipe, helper, test, and documentation files.
- Verified the helper is committed with executable mode `100755` and no `.claude/runtime` artifacts are in the PR scope.
