### PR TITLE
Fix install completeness test launcher

### DIFF
--- a/crates/amplihack-cli/tests/issue_538_install_completeness.rs
+++ b/crates/amplihack-cli/tests/issue_538_install_completeness.rs
@@ -7,6 +7,7 @@
 //! - install must fail loudly when a required bundle category is missing.
 //! - a successful install must stage every source skill/agent/command child dir.
 
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -31,6 +32,51 @@ fn workspace_root() -> PathBuf {
     }
 }
 
+fn valid_existing_binary(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn workspace_debug_amplihack() -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("debug")
+        .join(format!("amplihack{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn resolve_amplihack_binary() -> PathBuf {
+    if let Some(path) = std::env::var_os("AMPLIHACK_PROBE_BIN") {
+        let path = PathBuf::from(path);
+        if valid_existing_binary(&path) {
+            return path;
+        }
+        panic!(
+            "AMPLIHACK_PROBE_BIN is set to {}, but that path is not an existing file",
+            path.display()
+        );
+    }
+
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_amplihack") {
+        let path = PathBuf::from(path);
+        if valid_existing_binary(&path) {
+            return path;
+        }
+        panic!(
+            "CARGO_BIN_EXE_amplihack is set to {}, but that path is not an existing file",
+            path.display()
+        );
+    }
+
+    let fallback = workspace_debug_amplihack();
+    if valid_existing_binary(&fallback) {
+        return fallback;
+    }
+
+    panic!(
+        "no prebuilt amplihack binary found; set AMPLIHACK_PROBE_BIN or build the workspace binary before running this test (checked {})",
+        fallback.display()
+    );
+}
+
 fn write_stub_binary(dir: &Path, name: &str) -> PathBuf {
     fs::create_dir_all(dir).expect("create stub binary dir");
     let path = dir.join(name);
@@ -45,18 +91,13 @@ fn write_stub_binary(dir: &Path, name: &str) -> PathBuf {
     path
 }
 
-fn cargo_amplihack_install(home: &Path, hooks_bin: &Path, source: &Path) -> Command {
-    let mut cmd = Command::new(env!("CARGO"));
+fn amplihack_install_command(home: &Path, hooks_bin: &Path, source: &Path) -> Command {
+    let mut cmd = Command::new(resolve_amplihack_binary());
     let recipe_runner = hooks_bin
         .parent()
         .expect("stub binary has parent")
         .join("recipe-runner-rs");
     cmd.current_dir(workspace_root())
-        .arg("run")
-        .arg("--quiet")
-        .arg("--package")
-        .arg("amplihack")
-        .arg("--")
         .arg("install")
         .arg("--local")
         .arg(source)
@@ -157,6 +198,30 @@ steps:
 }
 
 #[test]
+fn install_command_launcher_is_not_cargo() {
+    let cmd = amplihack_install_command(
+        Path::new("/tmp/amplihack-test-home"),
+        Path::new("/tmp/amplihack-hooks"),
+        Path::new("/tmp/amplihack-source"),
+    );
+    let program = Path::new(cmd.get_program());
+    assert_ne!(
+        program.file_name(),
+        Some(OsStr::new("cargo")),
+        "install completeness tests must launch a prebuilt amplihack binary, not Cargo"
+    );
+
+    let args = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    assert!(
+        !args.iter().any(|arg| arg == "run" || arg == "build"),
+        "install completeness tests must not request nested builds; args: {args:?}"
+    );
+}
+
+#[test]
 fn npm_package_manifest_includes_amplifier_bundle_assets() {
     let package_json =
         fs::read_to_string(workspace_root().join("package.json")).expect("read package.json");
@@ -181,7 +246,7 @@ fn install_fails_loudly_when_required_source_skills_are_missing() {
     write_stub_binary(&stub_dir, "recipe-runner-rs");
     create_bundle_missing_skills(source.path());
 
-    let output = cargo_amplihack_install(home.path(), &hooks_bin, source.path())
+    let output = amplihack_install_command(home.path(), &hooks_bin, source.path())
         .output()
         .expect("run amplihack install");
     let combined_output = format!(
@@ -213,7 +278,7 @@ fn install_stages_every_source_skill_agent_and_command_directory() {
     write_stub_binary(&stub_dir, "recipe-runner-rs");
     let workspace = workspace_root();
 
-    cargo_amplihack_install(home.path(), &hooks_bin, &workspace)
+    amplihack_install_command(home.path(), &hooks_bin, &workspace)
         .assert()
         .success();
 

--- a/crates/amplihack-cli/tests/issue_538_install_completeness.rs
+++ b/crates/amplihack-cli/tests/issue_538_install_completeness.rs
@@ -7,7 +7,7 @@
 //! - install must fail loudly when a required bundle category is missing.
 //! - a successful install must stage every source skill/agent/command child dir.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -33,6 +33,20 @@ fn workspace_root() -> PathBuf {
 }
 
 fn valid_existing_binary(path: &Path) -> bool {
+    path.is_file() && is_executable(path)
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::metadata(path)
+        .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
     path.is_file()
 }
 
@@ -44,37 +58,49 @@ fn workspace_debug_amplihack() -> PathBuf {
 }
 
 fn resolve_amplihack_binary() -> PathBuf {
-    if let Some(path) = std::env::var_os("AMPLIHACK_PROBE_BIN") {
+    resolve_amplihack_binary_from(
+        std::env::var_os("AMPLIHACK_PROBE_BIN"),
+        std::env::var_os("CARGO_BIN_EXE_amplihack"),
+        &workspace_debug_amplihack(),
+    )
+    .unwrap_or_else(|message| panic!("{message}"))
+}
+
+fn resolve_amplihack_binary_from(
+    probe_bin: Option<OsString>,
+    cargo_bin: Option<OsString>,
+    fallback: &Path,
+) -> Result<PathBuf, String> {
+    if let Some(path) = probe_bin {
         let path = PathBuf::from(path);
         if valid_existing_binary(&path) {
-            return path;
+            return Ok(path);
         }
-        panic!(
-            "AMPLIHACK_PROBE_BIN is set to {}, but that path is not an existing file",
+        return Err(format!(
+            "AMPLIHACK_PROBE_BIN is set to {}, but that path is not an existing executable file",
             path.display()
-        );
+        ));
     }
 
-    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_amplihack") {
+    if let Some(path) = cargo_bin {
         let path = PathBuf::from(path);
         if valid_existing_binary(&path) {
-            return path;
+            return Ok(path);
         }
-        panic!(
-            "CARGO_BIN_EXE_amplihack is set to {}, but that path is not an existing file",
+        return Err(format!(
+            "CARGO_BIN_EXE_amplihack is set to {}, but that path is not an existing executable file",
             path.display()
-        );
+        ));
     }
 
-    let fallback = workspace_debug_amplihack();
     if valid_existing_binary(&fallback) {
-        return fallback;
+        return Ok(fallback.to_path_buf());
     }
 
-    panic!(
+    Err(format!(
         "no prebuilt amplihack binary found; set AMPLIHACK_PROBE_BIN or build the workspace binary before running this test (checked {})",
         fallback.display()
-    );
+    ))
 }
 
 fn write_stub_binary(dir: &Path, name: &str) -> PathBuf {
@@ -92,7 +118,16 @@ fn write_stub_binary(dir: &Path, name: &str) -> PathBuf {
 }
 
 fn amplihack_install_command(home: &Path, hooks_bin: &Path, source: &Path) -> Command {
-    let mut cmd = Command::new(resolve_amplihack_binary());
+    amplihack_install_command_with_binary(resolve_amplihack_binary(), home, hooks_bin, source)
+}
+
+fn amplihack_install_command_with_binary(
+    binary: impl AsRef<Path>,
+    home: &Path,
+    hooks_bin: &Path,
+    source: &Path,
+) -> Command {
+    let mut cmd = Command::new(binary.as_ref());
     let recipe_runner = hooks_bin
         .parent()
         .expect("stub binary has parent")
@@ -199,7 +234,10 @@ steps:
 
 #[test]
 fn install_command_launcher_is_not_cargo() {
-    let cmd = amplihack_install_command(
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let binary = write_stub_binary(temp.path(), "amplihack");
+    let cmd = amplihack_install_command_with_binary(
+        &binary,
         Path::new("/tmp/amplihack-test-home"),
         Path::new("/tmp/amplihack-hooks"),
         Path::new("/tmp/amplihack-source"),
@@ -218,6 +256,81 @@ fn install_command_launcher_is_not_cargo() {
     assert!(
         !args.iter().any(|arg| arg == "run" || arg == "build"),
         "install completeness tests must not request nested builds; args: {args:?}"
+    );
+}
+
+#[test]
+fn binary_resolver_prefers_probe_bin_over_cargo_bin_and_fallback() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let probe_bin = write_stub_binary(temp.path(), "probe-amplihack");
+    let cargo_bin = write_stub_binary(temp.path(), "cargo-amplihack");
+    let fallback = write_stub_binary(temp.path(), "fallback-amplihack");
+
+    let resolved = resolve_amplihack_binary_from(
+        Some(OsString::from(&probe_bin)),
+        Some(OsString::from(&cargo_bin)),
+        &fallback,
+    )
+    .expect("resolve probe binary");
+
+    assert_eq!(resolved, probe_bin);
+}
+
+#[test]
+fn binary_resolver_uses_cargo_bin_when_probe_bin_is_unset() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let cargo_bin = write_stub_binary(temp.path(), "cargo-amplihack");
+    let fallback = write_stub_binary(temp.path(), "fallback-amplihack");
+
+    let resolved = resolve_amplihack_binary_from(None, Some(OsString::from(&cargo_bin)), &fallback)
+        .expect("resolve Cargo-provided binary");
+
+    assert_eq!(resolved, cargo_bin);
+}
+
+#[test]
+fn binary_resolver_uses_existing_fallback_without_env_paths() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let fallback = write_stub_binary(temp.path(), "fallback-amplihack");
+
+    let resolved = resolve_amplihack_binary_from(None, None, &fallback).expect("resolve fallback");
+
+    assert_eq!(resolved, fallback);
+}
+
+#[test]
+fn binary_resolver_rejects_invalid_probe_bin_instead_of_falling_back() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let missing_probe = temp.path().join("missing-probe-amplihack");
+    let cargo_bin = write_stub_binary(temp.path(), "cargo-amplihack");
+    let fallback = write_stub_binary(temp.path(), "fallback-amplihack");
+
+    let error = resolve_amplihack_binary_from(
+        Some(OsString::from(&missing_probe)),
+        Some(OsString::from(&cargo_bin)),
+        &fallback,
+    )
+    .expect_err("invalid AMPLIHACK_PROBE_BIN must fail");
+
+    assert!(
+        error.contains("AMPLIHACK_PROBE_BIN") && error.contains("existing executable file"),
+        "unexpected resolver error: {error}"
+    );
+}
+
+#[test]
+fn binary_resolver_fails_clearly_when_no_prebuilt_binary_is_available() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let fallback = temp.path().join("missing-fallback-amplihack");
+
+    let error = resolve_amplihack_binary_from(None, None, &fallback)
+        .expect_err("missing prebuilt binary must fail");
+
+    assert!(
+        error.contains("no prebuilt amplihack binary found")
+            && error.contains("AMPLIHACK_PROBE_BIN")
+            && error.contains(&fallback.display().to_string()),
+        "unexpected resolver error: {error}"
     );
 }
 


### PR DESCRIPTION
## Summary
- replace nested `cargo run --package amplihack` in install completeness tests with direct invocation of a prebuilt `amplihack` binary
- add resolver precedence for `AMPLIHACK_PROBE_BIN`, runtime `CARGO_BIN_EXE_amplihack`, and existing workspace `target/debug/amplihack`
- add a regression guard that the install test launcher is not Cargo-backed and does not request `run`/`build`

## Validation
- `cargo build --locked -p amplihack`
- `AMPLIHACK_PROBE_BIN="$PWD/target/debug/amplihack" cargo test --locked -p amplihack-cli --test issue_538_install_completeness`
- `TMPDIR=/home/azureuser/tmp pre-commit run --all-files`
- `TMPDIR=/home/azureuser/tmp CARGO_TARGET_DIR=/home/azureuser/tmp/amplihack-precommit-target AMPLIHACK_PROBE_BIN="$PWD/target/debug/amplihack" cargo test --workspace --locked`

Note: an initial full workspace test using default `/tmp` failed with `No space left on device`; rerunning with temp/target paths under `/home` passed.