### PR TITLE
Optimize install completeness test helpers

### DIFF
--- a/crates/amplihack-cli/tests/issue_538_install_completeness.rs
+++ b/crates/amplihack-cli/tests/issue_538_install_completeness.rs
@@ -19,17 +19,22 @@ fn install_command_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-fn workspace_root() -> PathBuf {
-    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut cur: &Path = &crate_dir;
-    loop {
-        if cur.join("amplifier-bundle").is_dir() && cur.join("Cargo.toml").is_file() {
-            return cur.to_path_buf();
+fn workspace_root() -> &'static Path {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+
+    ROOT.get_or_init(|| {
+        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut cur: &Path = &crate_dir;
+        loop {
+            if cur.join("amplifier-bundle").is_dir() && cur.join("Cargo.toml").is_file() {
+                return cur.to_path_buf();
+            }
+            cur = cur
+                .parent()
+                .expect("walked above filesystem root looking for workspace root");
         }
-        cur = cur
-            .parent()
-            .expect("walked above filesystem root looking for workspace root");
-    }
+    })
+    .as_path()
 }
 
 fn valid_existing_binary(path: &Path) -> bool {
@@ -394,7 +399,7 @@ fn install_stages_every_source_skill_agent_and_command_directory() {
     let hooks_bin = write_install_tooling(home.path());
     let workspace = workspace_root();
 
-    amplihack_install_command(home.path(), &hooks_bin, &workspace)
+    amplihack_install_command(home.path(), &hooks_bin, workspace)
         .assert()
         .success();
 
@@ -402,13 +407,17 @@ fn install_stages_every_source_skill_agent_and_command_directory() {
     let staged_claude = home.path().join(".amplihack/.claude");
     let staged_bundle = home.path().join(".amplihack/amplifier-bundle");
 
-    for (source_category, staged_category) in [
-        ("skills", "skills"),
-        ("agents", "agents"),
-        ("commands", "commands"),
+    let source_skills = immediate_child_dirs(&source_bundle.join("skills"));
+    let source_agents = immediate_child_dirs(&source_bundle.join("agents"));
+    let source_commands = immediate_child_dirs(&source_bundle.join("commands"));
+
+    for (source_category, staged_category, children) in [
+        ("skills", "skills", &source_skills),
+        ("agents", "agents", &source_agents),
+        ("commands", "commands", &source_commands),
     ] {
-        for child in immediate_child_dirs(&source_bundle.join(source_category)) {
-            let staged = staged_claude.join(staged_category).join(&child);
+        for child in children {
+            let staged = staged_claude.join(staged_category).join(child);
             assert!(
                 staged.is_dir(),
                 "source amplifier-bundle/{source_category}/{child} must be staged at {}",
@@ -417,8 +426,8 @@ fn install_stages_every_source_skill_agent_and_command_directory() {
         }
     }
 
-    for child in immediate_child_dirs(&source_bundle.join("skills")) {
-        let staged = staged_bundle.join("skills").join(&child);
+    for child in &source_skills {
+        let staged = staged_bundle.join("skills").join(child);
         assert!(
             staged.is_dir(),
             "source skill {child} must also be present in the staged full amplifier-bundle at {}",
@@ -426,7 +435,7 @@ fn install_stages_every_source_skill_agent_and_command_directory() {
         );
     }
 
-    let source_skill_count = immediate_child_dirs(&source_bundle.join("skills")).len();
+    let source_skill_count = source_skills.len();
     let staged_skill_count = immediate_child_dirs(&staged_claude.join("skills")).len();
     assert!(
         staged_skill_count >= source_skill_count,


### PR DESCRIPTION
## Summary\n- Cache workspace root discovery in install completeness tests\n- Reuse source directory listings during staging assertions\n- Preserve the prebuilt-binary resolver and no-nested-Cargo guard\n\n## Validation\n- cargo fmt --check\n- cargo test -p amplihack-cli --test issue_538_install_completeness --locked\n- pre-commit run --files crates/amplihack-cli/tests/issue_538_install_completeness.rs\n- cargo test --workspace --locked attempted locally but blocked by disk exhaustion while writing Rust artifacts (os error 28); using CI for full workspace validation

## Step 13: Local Testing Results

### Scenario 1 — Branch-installed CLI reports version
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@perf/issue-538-install-completeness-tests amplihack --version`
Result: PASS
Output:
```text
Updated https://github.com/rysweet/amplihack-rs.git (e70bcb1c2d0e0224888418bfadb3c128ea68f2aa)
Installed package `amplihack v0.11.1 (...)` (executables `amplihack`, `scan-invisible-chars`)
Installed package `amplihack-hooks-bin v0.11.1 (...)` (executable `amplihack-hooks`)
amplihack 0.11.1
```

### Scenario 2 — Branch-installed CLI exposes install integration help with isolated Amplihack state
Command: `HOME=$(mktemp -d) XDG_CACHE_HOME=$HOME/.cache CARGO_HOME=/home/azureuser/.cargo RUSTUP_HOME=/home/azureuser/.rustup UV_CACHE_DIR=$(mktemp -d) AMPLIHACK_NONINTERACTIVE=1 uvx --from git+https://github.com/rysweet/amplihack-rs.git@perf/issue-538-install-completeness-tests amplihack install --help`
Result: PASS
Output:
```text
Updated https://github.com/rysweet/amplihack-rs.git (e70bcb1c2d0e0224888418bfadb3c128ea68f2aa)
Installed package `amplihack v0.11.1 (...)` (executables `amplihack`, `scan-invisible-chars`)
Installed package `amplihack-hooks-bin v0.11.1 (...)` (executable `amplihack-hooks`)
Install amplihack framework assets to ~/.amplihack/.claude and wire ~/.claude/settings.json

Usage: amplihack install [OPTIONS]

Options:
      --local <LOCAL>  Install from a local directory instead of cloning from git
      --interactive    Run the interactive configuration wizard to choose default tool, hook scope, and update-check preference
      --verbose        Accepted for diagnostic scripts; install already prints phase-level detail
  -h, --help           Print help
```

