### PR TITLE
Fix automated action failure investigation verification

### DIFF
--- a/amplifier-bundle/recipes/workflow-design.yaml
+++ b/amplifier-bundle/recipes/workflow-design.yaml
@@ -40,6 +40,45 @@ steps:
 
       Consider the INVESTIGATION-FIRST PATTERN if the codebase is unfamiliar.
 
+      ## Automated GitHub Actions failure investigation contract
+
+      If the task reports scheduled action runs, automated action failures, or
+      GitHub Actions workflow failures, prove the failing runs from GitHub
+      Actions evidence before proposing code changes:
+
+      1. Confirm the GitHub CLI service adapter is usable with
+         `gh auth status`; use the existing authenticated session only and do
+         not create, print, or persist tokens.
+      2. Check true schedule-event runs first:
+         `gh run list --event schedule --limit 50`.
+      3. If there are no true schedule-event failures, state exactly:
+         `No recent `schedule` event failures found; treating the report as
+         user-reported automated GitHub Actions failures.`
+      4. Then inspect recent failed automation:
+         `gh run list --status failure --limit 50`.
+      5. For each relevant failed run, inspect metadata and failed logs:
+         `gh run view RUN_ID --json name,url,event,headBranch,headSha,status,conclusion`
+         and `gh run view RUN_ID --log-failed`.
+      6. For GitHub service errors, fail visibly: record the command,
+         permission/authentication failure, rate limit, network failure, or
+         missing log access. Retry once only for transient rate limit or
+         network errors; if the retry still fails, classify the run as
+         external-transient or inaccessible and do not infer a repo root cause.
+      7. Produce an evidence table with: workflow, run URL, event,
+         branch/SHA, failing job, failing step, root-cause excerpt, and
+         classification.
+      8. Classify each failure as one of: repo-caused,
+         generated-template-caused, external-transient, stale, unrelated, or
+         inaccessible.
+      9. Select code/config changes only for repo-caused or
+         generated-template-caused failures; do not patch external-transient,
+         stale, unrelated, or inaccessible failures.
+      10. Implement the narrowest fix and add regression coverage or equivalent
+         static validation for the proven failure mode.
+      11. Closure must include `pre-commit run --all-files`, targeted tests,
+         `gh pr create`, `gh pr checks --watch`, and evidence that the PR is
+         merge-ready.
+
       Output a comprehensive design specification.
     output: "architecture_design"
 

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -49,6 +49,10 @@ name = "smart_orchestrator_decomposition"
 path = "../../tests/integration/smart_orchestrator_decomposition_test.rs"
 
 [[test]]
+name = "automated_action_failure_investigation_contract"
+path = "../../tests/integration/automated_action_failure_investigation_contract_test.rs"
+
+[[test]]
 name = "cli_launch"
 path = "../../tests/integration/cli_launch_test.rs"
 

--- a/crates/amplihack-launcher/src/completion_verifier.rs
+++ b/crates/amplihack-launcher/src/completion_verifier.rs
@@ -58,6 +58,15 @@ impl CompletionVerifier {
         let signals_complete = signals.completion_score >= self.completion_threshold;
         let discrepancies = self.detect_discrepancies(evaluation_result, signals, claimed_complete);
 
+        if claimed_complete && Self::has_incomplete_investigation_evidence(&discrepancies) {
+            return VerificationResult {
+                status: VerificationStatus::Incomplete,
+                verified: false,
+                explanation: "Automated GitHub Actions failure investigation is missing required evidence for completion".to_string(),
+                discrepancies,
+            };
+        }
+
         match (claimed_complete, signals_complete) {
             (true, true) if discrepancies.is_empty() => VerificationResult {
                 status: VerificationStatus::Verified,
@@ -242,7 +251,138 @@ impl CompletionVerifier {
                 .push("Claims ready to merge but PR has conflicts or is not mergeable".into());
         }
 
+        self.detect_automated_actions_investigation_gaps(
+            &lower,
+            claimed_complete,
+            &mut discrepancies,
+        );
+
         discrepancies
+    }
+
+    fn has_incomplete_investigation_evidence(discrepancies: &[String]) -> bool {
+        discrepancies.iter().any(|d| {
+            d.contains("schedule-event finding")
+                || d.contains("failed-run evidence field")
+                || d.contains("repo-caused automated Actions investigation")
+                || d.contains("generated-template-caused automated Actions investigation")
+        })
+    }
+
+    fn detect_automated_actions_investigation_gaps(
+        &self,
+        lower: &str,
+        claimed_complete: bool,
+        discrepancies: &mut Vec<String>,
+    ) {
+        if !claimed_complete || !Self::is_automated_actions_investigation(lower) {
+            return;
+        }
+
+        if !Self::has_schedule_event_finding(lower) {
+            discrepancies.push(
+                "Automated GitHub Actions investigation missing schedule-event finding from `gh run list --event schedule --limit 50`".into(),
+            );
+        }
+
+        for (field, present) in [
+            (
+                "workflow",
+                lower.contains("workflow:")
+                    || lower.contains("workflow name")
+                    || lower.contains("workflow=")
+                    || lower.contains("| workflow"),
+            ),
+            (
+                "run URL",
+                lower.contains("run url")
+                    || lower.contains("run:")
+                    || lower.contains("actions/runs/"),
+            ),
+            ("event", lower.contains("event")),
+            (
+                "branch/SHA",
+                lower.contains("branch/sha") || (lower.contains("branch") && lower.contains("sha")),
+            ),
+            ("failing job", lower.contains("failing job")),
+            ("failing step", lower.contains("failing step")),
+            ("root-cause excerpt", lower.contains("root-cause excerpt")),
+            ("classification", lower.contains("classification")),
+        ] {
+            if !present {
+                discrepancies.push(format!("Automated GitHub Actions investigation missing failed-run evidence field: {field}"));
+            }
+        }
+
+        let fixable_classification = lower.contains("repo-caused")
+            || lower.contains("repo caused")
+            || lower.contains("generated-template-caused")
+            || lower.contains("generated template caused");
+        if !fixable_classification {
+            return;
+        }
+
+        for (evidence, present) in [
+            (
+                "narrow fix",
+                lower.contains("narrow fix") || lower.contains("narrowest fix"),
+            ),
+            (
+                "regression coverage",
+                lower.contains("regression coverage") || lower.contains("regression test"),
+            ),
+            (
+                "pre-commit run --all-files",
+                lower.contains("pre-commit run --all-files"),
+            ),
+            ("targeted tests", lower.contains("targeted test")),
+            (
+                "pull request",
+                lower.contains("pull request")
+                    || lower.contains("pr #")
+                    || lower.contains("/pull/"),
+            ),
+            (
+                "PR CI",
+                lower.contains("pr ci")
+                    || lower.contains("gh pr checks")
+                    || lower.contains("pr checks"),
+            ),
+        ] {
+            if !present {
+                discrepancies.push(format!(
+                    "repo-caused automated Actions investigation missing {evidence} closure evidence"
+                ));
+            }
+        }
+    }
+
+    fn is_automated_actions_investigation(lower: &str) -> bool {
+        let automation_context = lower.contains("scheduled action")
+            || lower.contains("scheduled workflow")
+            || lower.contains("automated action")
+            || lower.contains("github actions")
+            || lower.contains("schedule-event finding")
+            || lower.contains("action failures")
+            || lower.contains("workflow failures")
+            || lower.contains("failing automation");
+
+        let failure_context = lower.contains("fail")
+            || lower.contains("root-cause")
+            || lower.contains("classification")
+            || lower.contains("repo-caused")
+            || lower.contains("generated-template-caused");
+
+        automation_context && failure_context
+    }
+
+    fn has_schedule_event_finding(lower: &str) -> bool {
+        lower.contains("schedule-event finding")
+            || lower.contains("gh run list --event schedule")
+            || lower.contains("no true schedule")
+            || lower.contains("no recent schedule")
+            || lower.contains("schedule event failures")
+            || lower.contains("schedule-event failures")
     }
 
     /// Format verification result as a human-readable report.

--- a/crates/amplihack-launcher/src/completion_verifier_tests.rs
+++ b/crates/amplihack-launcher/src/completion_verifier_tests.rs
@@ -165,3 +165,108 @@ fn discrepancy_ci_claim_mismatch() {
             .any(|d| d.contains("CI passing but CI status is not SUCCESS"))
     );
 }
+
+#[test]
+fn automated_actions_investigation_requires_schedule_event_finding() {
+    let verifier = CompletionVerifier::default();
+    let signals = make_signals(true, true, true, true, true, true, 1.0, Some(776));
+
+    let result = verifier.verify(
+        "Evaluation: complete. Investigated many scheduled action failures. \
+         Fixed the repo-caused issue, pushed a PR, and CI is passing.",
+        &signals,
+    );
+
+    assert_eq!(
+        result.status,
+        VerificationStatus::Incomplete,
+        "scheduled action investigations must remain incomplete until the report \
+         explicitly records whether `gh run list --event schedule --limit 50` \
+         found true schedule-event failures; got {result:?}"
+    );
+    assert!(!result.verified);
+    assert!(
+        result
+            .discrepancies
+            .iter()
+            .any(|d| d.contains("schedule-event finding")),
+        "missing schedule-event finding must be an explicit discrepancy: {:?}",
+        result.discrepancies
+    );
+}
+
+#[test]
+fn automated_actions_investigation_requires_failed_run_evidence_before_completion() {
+    let verifier = CompletionVerifier::default();
+    let signals = make_signals(true, true, true, true, true, true, 1.0, Some(776));
+
+    let result = verifier.verify(
+        "Evaluation: complete. No true scheduled workflow failures existed. \
+         The failing automation was fixed and the PR is ready to merge.",
+        &signals,
+    );
+
+    assert_eq!(
+        result.status,
+        VerificationStatus::Incomplete,
+        "automated GitHub Actions investigations must include a failed-run \
+         evidence table before completion; got {result:?}"
+    );
+    assert!(!result.verified);
+    for required in [
+        "workflow",
+        "run url",
+        "event",
+        "branch/sha",
+        "failing job",
+        "failing step",
+        "root-cause excerpt",
+        "classification",
+    ] {
+        assert!(
+            result
+                .discrepancies
+                .iter()
+                .any(|d| d.to_lowercase().contains(required)),
+            "missing `{required}` evidence field must be reported: {:?}",
+            result.discrepancies
+        );
+    }
+}
+
+#[test]
+fn automated_actions_investigation_requires_fix_validation_and_pr_closure_evidence() {
+    let verifier = CompletionVerifier::default();
+    let signals = make_signals(true, true, true, true, true, true, 1.0, Some(776));
+
+    let result = verifier.verify(
+        "Evaluation: complete. Schedule-event finding: no recent schedule runs. \
+         Evidence: CI run https://github.com/rysweet/amplihack-rs/actions/runs/123 \
+         event push main@0123456 failed job test failed step Run cargo test \
+         root-cause excerpt assertion failed classification repo-caused.",
+        &signals,
+    );
+
+    assert_eq!(
+        result.status,
+        VerificationStatus::Incomplete,
+        "repo-caused automated Actions investigations must not close without \
+         narrow fix, regression coverage, pre-commit, targeted tests, PR URL, \
+         and PR CI closure evidence; got {result:?}"
+    );
+    assert!(!result.verified);
+    for required in [
+        "narrow fix",
+        "regression coverage",
+        "pre-commit run --all-files",
+        "targeted tests",
+        "pull request",
+        "PR CI",
+    ] {
+        assert!(
+            result.discrepancies.iter().any(|d| d.contains(required)),
+            "missing `{required}` closure evidence must be reported: {:?}",
+            result.discrepancies
+        );
+    }
+}

--- a/docs/howto/investigate-automated-action-failures.md
+++ b/docs/howto/investigate-automated-action-failures.md
@@ -1,0 +1,251 @@
+---
+title: Investigate Automated GitHub Actions Failures
+description: How to identify failing automated GitHub Actions runs, prove root causes from logs, fix repo-caused failures, and deliver a merge-ready PR.
+last_updated: 2026-06-14
+review_schedule: quarterly
+owner: amplihack-maintainers
+doc_type: howto
+related: "../reference/automated-action-failure-investigation.md, ../tutorials/automated-action-failure-investigation.md"
+---
+
+# Investigate Automated GitHub Actions Failures
+
+[PLANNED - Implementation Pending]
+
+This document describes the intended behavior for an automated failure-investigation workflow. Until implementation lands, treat commands as the planned operator contract and verify each step manually.
+
+Use this guide when a user reports failing scheduled actions, failing automation, or recurring GitHub Actions failures and the exact source is unclear.
+
+The investigation is evidence-first. The workflow proves whether true `schedule` event runs exist before changing repository code.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Run the Investigation](#run-the-investigation)
+- [Evidence Rules](#evidence-rules)
+- [Classify Failures](#classify-failures)
+- [Fix Repo-Caused Failures](#fix-repo-caused-failures)
+- [Add Regression Coverage](#add-regression-coverage)
+- [Validate and Open the PR](#validate-and-open-the-pr)
+- [Troubleshooting](#troubleshooting)
+
+## Prerequisites
+
+- `gh` installed and authenticated for the target repository.
+- `git` configured with push access.
+- Repository checkout on a dedicated branch or a clean worktree.
+- Large nested workflow runs use the project heap preference:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+The persisted preference lives in the local Amplihack config file, usually `~/.amplihack/config`.
+
+Before collecting Actions evidence, verify the GitHub CLI service adapter:
+
+```bash
+gh auth status
+```
+
+Use the existing authenticated session only. Do not create or print tokens.
+
+## Run the Investigation
+
+Run `smart-orchestrator` from the repository root:
+
+```bash
+amplihack recipe run smart-orchestrator \
+  -c task_description="Investigate failing automated GitHub Actions runs, prove root causes from gh evidence, fix repo-caused failures, add regression coverage, validate, push a PR, and monitor CI." \
+  -c repo_path=.
+```
+
+For a known issue number, include it in the task description:
+
+```bash
+amplihack recipe run smart-orchestrator \
+  -c task_description="Investigate issue #776: user reports many failures in scheduled action runs. Confirm schedule-event evidence first, then fix repo-caused failures and open a PR." \
+  -c repo_path=.
+```
+
+Direct `default-workflow` invocation is only an adaptive fallback after `smart-orchestrator` fails at the infrastructure level, such as parse, decomposition, or launch failure:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Investigate issue #776: user reports many failures in scheduled action runs. Confirm schedule-event evidence first, then fix repo-caused failures and open a PR." \
+  -c repo_path=.
+```
+
+The workflow collects GitHub Actions evidence before it edits files. It checks true scheduled runs first:
+
+```bash
+gh run list --event schedule --limit 50
+```
+
+If no schedule-event runs exist, it records that finding and inspects recent failed automated runs:
+
+```bash
+gh run list --status failure --limit 50
+```
+
+Candidate automated runs include `schedule`, `push`, `pull_request`, and repository-owned `workflow_dispatch` runs from current workflows such as `CI`, `Docs`, `Code Atlas`, `Release`, `Publish Snapshot`, or `Invisible Character Scan`. Exclude manual experiments, stale branches, deleted workflow definitions, unrelated forks, and platform-managed or bot-owned automation unless the user report explicitly names them.
+
+For each candidate run, it records metadata and failed-step logs:
+
+```bash
+gh run view RUN_ID \
+  --json databaseId,name,event,status,conclusion,headBranch,headSha,url,createdAt,updatedAt,jobs
+
+gh run view RUN_ID --log-failed
+```
+
+If a GitHub call fails, record the exact command and category: permission, authentication, rate limit, network, missing log access, not found, or other service failure. Retry once only for transient rate limit or network errors. If the retry still fails, classify the affected run as `external-transient` or `inaccessible`; do not infer a repository root cause from partial metadata.
+
+## Evidence Rules
+
+Every fix must trace to a failed GitHub Actions step. The workflow records an evidence table with:
+
+| Field | Description |
+| --- | --- |
+| Workflow | GitHub Actions workflow name. |
+| Run URL | Permanent URL for the failed run. |
+| Event | Trigger event such as `schedule`, `push`, `pull_request`, `workflow_dispatch`, or automation-specific events. |
+| Branch/SHA | `headBranch` and `headSha` from GitHub Actions metadata. |
+| Failing job | Job name that concluded with failure. |
+| Failing step | Step name from the failed-job log. |
+| Root-cause excerpt | Short sanitized log excerpt tied to repository code, configuration, or external state. |
+| Classification | One of the failure classes in [Classify Failures](#classify-failures). |
+
+Do not use broad assumptions such as "scheduled actions are failing" as the root cause. If `gh run list --event schedule` returns no runs, the report is classified as failing automated GitHub Actions, not true scheduled workflow failure.
+
+## Classify Failures
+
+Classify each failed run before changing code:
+
+| Classification | When to use it | Action |
+| --- | --- | --- |
+| `repo-caused` | The failed step points to checked-in code, workflow YAML, scripts, templates, or tests on the current branch. | Fix the implicated file and add regression coverage when feasible. |
+| `generated-template-caused` | The failed run uses a generated workflow or lock file whose source lives in the repository. | Fix the source template and regenerate committed output. |
+| `external-transient` | Logs show rate limits, network outages, service availability, or runner instability without a repo defect. | Document evidence in the PR or issue; do not patch around it unless retries are already part of the contract. |
+| `stale` | The run came from an old SHA, deleted branch, superseded workflow, or workflow definition no longer present. | Document as stale; do not modify current code unless the same defect exists now. |
+| `unrelated` | The failed run does not match the user report or target automation. | Exclude it from the fix scope and document why. |
+| `inaccessible` | Metadata is visible but required logs are unavailable because of retention or permissions. | Document the missing evidence and next access step; do not infer root cause from workflow names alone. |
+
+## Fix Repo-Caused Failures
+
+Change only the surface implicated by the logs:
+
+| Log points to | Edit |
+| --- | --- |
+| `.github/workflows/*.yml` behavior | The specific workflow file or its generated source. |
+| Repository validation script | The specific `scripts/*.sh` file and its local test or fixture. |
+| Rust command or library behavior | The affected crate under `crates/**` or binary under `bins/**`. |
+| Generated workflow source | The authoritative template under `amplifier-bundle/**`, then regenerate committed output. |
+| Validation tooling defect | The specific pre-commit or validation configuration. |
+
+Avoid broad workflow rewrites, permission expansion, and speculative retries. The default fix is the smallest durable change that makes the proven failure impossible or visibly actionable.
+
+## Add Regression Coverage
+
+Add the closest practical local guard:
+
+| Fixed failure mode | Regression coverage |
+| --- | --- |
+| Rust behavior | A targeted Rust unit, integration, or CLI smoke test. |
+| Shell script behavior | A script test or fixture that exercises the failing branch. |
+| Workflow YAML shape | Static validation, pre-commit hook, or template fixture. |
+| Generated workflow drift | Source-vs-lock sync test or compiler fixture. |
+| External/transient failure | No code regression test; document evidence and expected operator action. |
+
+Regression coverage must fail for the original defect and pass after the fix.
+
+## Validate and Open the PR
+
+Run repository validation from the root:
+
+```bash
+pre-commit run --all-files
+```
+
+Then run targeted tests for the changed surface. Examples:
+
+```bash
+cargo test --workspace --locked
+
+cargo test -p amplihack-launcher completion_verifier
+
+bash scripts/check-recipes-no-python.sh
+```
+
+Commit only relevant changes:
+
+```bash
+git status --short
+git add crates/amplihack-launcher/src/completion_verifier.rs crates/amplihack-launcher/src/completion_verifier_tests.rs
+git commit -m "Require evidence for workflow completion"
+git push --set-upstream origin fix/automated-actions-failures
+```
+
+Open the PR with the evidence chain:
+
+```bash
+gh pr create \
+  --title "Fix automated Actions failure investigation path" \
+  --body-file /tmp/automated-actions-failure-pr.md
+```
+
+The PR body includes:
+
+- schedule-event finding
+- evidence table
+- root cause
+- fix summary
+- regression coverage
+- validation commands
+- remaining external, stale, inaccessible, or unrelated blockers
+
+Monitor PR CI and fix only failures caused by the change:
+
+```bash
+gh pr checks --watch
+```
+
+Closure means the PR is merge-ready or blocked only by documented external or pre-existing failures. Do not merge unless the repository policy explicitly assigns merge ownership to the workflow.
+
+## Troubleshooting
+
+### No scheduled runs exist
+
+If this returns no runs:
+
+```bash
+gh run list --event schedule --limit 50
+```
+
+Record the result and continue with recent failed automated runs:
+
+```bash
+gh run list --status failure --limit 50
+```
+
+The final report must say that no true `schedule` event failures were found.
+
+### Failed logs are missing
+
+Use the run metadata first:
+
+```bash
+gh run view RUN_ID --json databaseId,name,event,conclusion,url,jobs
+```
+
+If logs expired or permissions prevent access, classify the run as stale or inaccessible. Do not infer root cause from workflow names alone.
+
+### CI remains red after the PR fix
+
+Compare the failing PR checks to the original evidence table. Fix failures caused by the change. Document unrelated, external, or pre-existing failures with links to the failing checks and actionable next steps.
+
+## Related
+
+- [Automated Action Failure Investigation Reference](../reference/automated-action-failure-investigation.md)
+- [Tutorial: Investigate an Automated Action Failure](../tutorials/automated-action-failure-investigation.md)
+- [Scoped Workflow Closure](../concepts/scoped-workflow-closure.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -330,6 +330,9 @@ amplihack recipe show default-workflow
 ### GitHub Actions Workflows
 
 - [Configure Issue Classifier](howto/configure-issue-classifier-workflow.md) - Permissions, timeout, label extension, lock file recompilation, and troubleshooting
+- [Investigate Automated Action Failures](howto/investigate-automated-action-failures.md) - Evidence-first workflow for failing scheduled or automated GitHub Actions runs, root-cause classification, fixes, regression coverage, and PR closure
+- [Automated Action Failure Investigation Reference](reference/automated-action-failure-investigation.md) - Inputs, configuration, evidence schema, classification values, PR contract, and closure semantics
+- [Tutorial: Automated Action Failure Investigation](tutorials/automated-action-failure-investigation.md) - End-to-end example from user report to merge-ready PR
 
 ---
 

--- a/docs/reference/automated-action-failure-investigation.md
+++ b/docs/reference/automated-action-failure-investigation.md
@@ -1,0 +1,271 @@
+---
+title: Automated Action Failure Investigation Reference
+description: Reference for inputs, configuration, evidence records, classifications, and closure semantics for automated GitHub Actions failure investigations.
+last_updated: 2026-06-14
+review_schedule: quarterly
+owner: amplihack-maintainers
+doc_type: reference
+related: "../howto/investigate-automated-action-failures.md, ../tutorials/automated-action-failure-investigation.md"
+---
+
+# Automated Action Failure Investigation Reference
+
+[PLANNED - Implementation Pending]
+
+This reference defines the intended contract for investigating user-reported scheduled or automated GitHub Actions failures. Remove this notice after the workflow and examples are proven in CI.
+
+## Command Interface
+
+The workflow is invoked through `smart-orchestrator`:
+
+```bash
+amplihack recipe run smart-orchestrator \
+  -c task_description="Investigate failing automated GitHub Actions runs, prove root causes from gh evidence, fix repo-caused failures, add regression coverage, validate, push a PR, and monitor CI." \
+  -c repo_path=.
+```
+
+Direct recipe invocation is an adaptive fallback, not the primary interface. Use `default-workflow` directly only after `smart-orchestrator` fails at the infrastructure level, such as parse, decomposition, or launch failure:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Investigate failing automated GitHub Actions runs, prove root causes from gh evidence, fix repo-caused failures, add regression coverage, validate, push a PR, and monitor CI." \
+  -c repo_path=.
+```
+
+### Context Parameters
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `task_description` | Yes | Human-readable scope. Include the issue number, reported symptom, and requirement to prove schedule-event evidence before changing code. |
+| `repo_path` | Yes | Repository root or worktree path. Use `.` when running from the root. |
+
+## Required Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `gh` | Source of truth for workflow run metadata, failed jobs, logs, PR creation, and PR CI monitoring. |
+| `git` | Branch, diff, commit, and push operations. |
+| `pre-commit` | Repository-wide validation gate. |
+| Repository test runner | Targeted regression validation for changed files. |
+
+## Configuration
+
+### `NODE_OPTIONS`
+
+Large nested workflow runs use:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=32768
+```
+
+The saved project preference is stored in:
+
+```text
+~/.amplihack/config
+```
+
+### GitHub Authentication
+
+`gh auth status` must show access to the repository. The workflow uses the existing authenticated GitHub CLI session. It does not create, print, or persist tokens.
+
+## GitHub Service Adapter Contract
+
+The workflow integrates with GitHub through the GitHub CLI, not a custom API client. Treat `gh` as the service adapter boundary:
+
+- Check `gh auth status` before collecting evidence.
+- Use the existing authenticated session only.
+- Record the failed command and error category when a GitHub call fails.
+- Retry once only for transient rate limit or network failures.
+- Do not retry permission, authentication, missing log access, or not-found failures as if they were transient.
+- If metadata or logs remain unavailable, classify the run as `external-transient` or `inaccessible` and document the next access step.
+- Do not infer a repository root cause from workflow names, run titles, or partial metadata.
+
+### Repository Permissions
+
+The operator needs permission to:
+
+- read Actions runs and logs
+- create branches
+- push commits
+- open pull requests
+- read PR checks
+
+The investigation must not weaken workflow permissions, branch protection, secret handling, or validation gates to make CI pass.
+
+## Evidence Collection Contract
+
+The workflow queries true schedule-event runs before broad failure searches:
+
+```bash
+gh run list --event schedule --limit 50
+```
+
+If no schedule-event failures exist, the workflow records that as a finding and queries recent failed runs:
+
+```bash
+gh run list --status failure --limit 50
+```
+
+### Automated Run Scope
+
+Treat a failed run as in scope when it is both automated and related to the user report:
+
+| Event or source | Include? | Notes |
+| --- | --- | --- |
+| `schedule` | Yes | Check first and report explicitly whether true scheduled failures exist. |
+| `push` | Yes | Include maintained branches and current workflow definitions. |
+| `pull_request` | Yes | Include PR checks when they match the reported automation or candidate fix. |
+| Repository-owned `workflow_dispatch` | Sometimes | Include only when the user report names manual automation or the run is part of the maintained automation contract. |
+| Bot-authored runs | Sometimes | Include when the bot is executing repository-owned automation, not when it is a platform-managed background task outside the repo contract. |
+| Deleted branches or old SHAs | No fix by default | Classify as `stale` unless the same defect exists on the current branch. |
+| Forks, unrelated experiments, platform-managed workflows | No | Classify as `unrelated` unless the user report explicitly targets them. |
+
+For each candidate failed run, the workflow collects:
+
+```bash
+gh run view RUN_ID \
+  --json databaseId,name,event,status,conclusion,headBranch,headSha,url,createdAt,updatedAt,jobs
+```
+
+Failed-step logs are collected with:
+
+```bash
+gh run view RUN_ID --log-failed
+```
+
+## Evidence Record Schema
+
+Each investigated run produces an evidence record:
+
+```json
+{
+  "workflow": "CI",
+  "run_url": "https://github.com/rysweet/amplihack-rs/actions/runs/1234567890",
+  "event": "push",
+  "head_branch": "main",
+  "head_sha": "0123456789abcdef0123456789abcdef01234567",
+  "failing_job": "test",
+  "failing_step": "Run cargo test",
+  "root_cause_excerpt": "assertion failed: result.requires_follow_up()",
+  "classification": "repo-caused",
+  "repo_surface": "crates/amplihack-launcher/src/completion_verifier.rs"
+}
+```
+
+### Fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `workflow` | Yes | Workflow display name from GitHub Actions. |
+| `run_url` | Yes | Permanent GitHub Actions run URL. |
+| `event` | Yes | Trigger event from run metadata. |
+| `head_branch` | Yes | Branch associated with the run. |
+| `head_sha` | Yes | Commit SHA associated with the run. |
+| `failing_job` | Yes | Failed job name. |
+| `failing_step` | Yes | Failed step name from the job log. |
+| `root_cause_excerpt` | Yes | Short sanitized excerpt that proves the failure cause. |
+| `classification` | Yes | One of the supported classifications. |
+| `repo_surface` | Conditional | Required for `repo-caused` and `generated-template-caused` failures. |
+
+## Classification Values
+
+| Value | Meaning |
+| --- | --- |
+| `repo-caused` | Current repository code, workflow YAML, scripts, templates, or tests caused the failure. |
+| `generated-template-caused` | Generated workflow output failed because its checked-in source template or lock generation is wrong. |
+| `external-transient` | External systems, rate limits, network failures, hosted runner instability, or service outages caused the failure. |
+| `stale` | The run came from an old SHA, deleted branch, expired workflow definition, or superseded automation. |
+| `unrelated` | The run is outside the user-reported automation scope. |
+| `inaccessible` | Metadata is visible but required logs are unavailable because of retention or permissions. |
+
+## Fix Selection Rules
+
+| Classification | Code changes allowed? | Required output |
+| --- | --- | --- |
+| `repo-caused` | Yes | Narrow fix, regression coverage, validation, PR. |
+| `generated-template-caused` | Yes | Fix source, regenerate generated output, add sync coverage, validation, PR. |
+| `external-transient` | No by default | Evidence and operator action. |
+| `stale` | No by default | Evidence that the current branch no longer contains the failed definition. |
+| `unrelated` | No | Reason excluded from scope. |
+| `inaccessible` | No until proven | Missing-log explanation and next access step. |
+
+## Regression Coverage Contract
+
+Regression coverage must be as close as practical to the failed surface:
+
+| Surface | Coverage |
+| --- | --- |
+| Rust crate or binary | `cargo test` for the affected crate, plus CLI smoke test when command behavior changed. |
+| Shell script | Script fixture or targeted shell test. |
+| Workflow source | Static YAML/frontmatter validation. |
+| Generated workflow | Source-vs-lock synchronization test. |
+| Documentation-only clarification | Link validation or markdown validation if configured. |
+
+## PR Body Contract
+
+The pull request body contains these sections:
+
+````markdown
+## Evidence
+
+| Workflow | Run | Event | Branch/SHA | Failed job | Failed step | Classification |
+| --- | --- | --- | --- | --- | --- | --- |
+| CI | https://github.com/rysweet/amplihack-rs/actions/runs/1234567890 | push | main@0123456 | test | Run cargo test | repo-caused |
+
+## Schedule-event finding
+
+No recent `schedule` event failures were found. The user-reported failures are failed automated GitHub Actions runs triggered by `push`.
+
+## Root cause
+
+The `Run cargo test` step failed because the completion verifier accepted an incomplete workflow handoff as successful.
+
+## Fix
+
+Tightened completion verification so missing evidence records are reported as incomplete instead of successful.
+
+## Regression coverage
+
+Added a targeted completion-verifier regression test that fails when a workflow lacks required evidence records.
+
+## Validation
+
+```bash
+pre-commit run --all-files
+cargo test -p amplihack-launcher completion_verifier
+```
+
+## Remaining blockers
+
+None.
+````
+
+Do not include secrets, full environment dumps, or unsanitized logs.
+
+## Closure Semantics
+
+Closure means:
+
+- a branch is pushed
+- a PR is open
+- repo-caused failures are fixed
+- regression coverage exists where feasible
+- required validation has run
+- PR CI is passing, or remaining failures are explicitly classified as external, stale, unrelated, or pre-existing
+
+Closure does not mean automatic merge unless the repository policy assigns merge ownership to the workflow.
+
+## Security Requirements
+
+- Treat workflow names, branch names, logs, and PR text as untrusted input.
+- Do not execute commands copied from logs unless they are verified against repository source.
+- Sanitize log excerpts before including them in commits, PR bodies, or comments.
+- Do not print or persist tokens.
+- Do not broaden `GITHUB_TOKEN` permissions unless the failed step proves a legitimate missing permission and the new permission is minimal.
+- Do not add `eval`, dynamic shell construction, or broad secret exposure paths.
+
+## Related
+
+- [How to Investigate Automated GitHub Actions Failures](../howto/investigate-automated-action-failures.md)
+- [Tutorial: Investigate an Automated Action Failure](../tutorials/automated-action-failure-investigation.md)
+- [Scoped Workflow Closure Reference](./scoped-workflow-closure.md)

--- a/docs/tutorials/automated-action-failure-investigation.md
+++ b/docs/tutorials/automated-action-failure-investigation.md
@@ -1,0 +1,226 @@
+---
+title: Tutorial: Investigate an Automated Action Failure
+description: Walk through a complete automated GitHub Actions failure investigation from user report to merge-ready PR.
+last_updated: 2026-06-14
+review_schedule: quarterly
+owner: amplihack-maintainers
+doc_type: tutorial
+related: "../howto/investigate-automated-action-failures.md, ../reference/automated-action-failure-investigation.md"
+---
+
+# Tutorial: Investigate an Automated Action Failure
+
+[PLANNED - Implementation Pending]
+
+This tutorial shows the intended end-to-end flow for the planned automated failure-investigation workflow. Until implementation lands, use it as a manual walkthrough and keep examples tied to current repository workflows.
+
+This tutorial walks through the standard flow for a user report such as "many scheduled action runs are failing."
+
+You will prove whether scheduled runs exist, identify the actual failing automation, fix only repo-caused failures, and open a merge-ready PR.
+
+## What You'll Do
+
+1. Confirm whether true `schedule` event failures exist.
+2. Find recent failed automated runs.
+3. Capture an evidence table.
+4. Classify failures.
+5. Fix the repo-caused failure.
+6. Add regression coverage.
+7. Open and monitor a PR.
+
+## Prerequisites
+
+From the repository root:
+
+```bash
+gh auth status
+git status --short
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+`gh` is the GitHub service adapter for this workflow. Use the existing authenticated session only; do not create, print, or persist tokens.
+
+Start from a dedicated branch:
+
+```bash
+git switch -c fix/automated-actions-failure
+```
+
+## Step 1: Check Scheduled Runs First
+
+Run:
+
+```bash
+gh run list --event schedule --limit 50
+```
+
+If the repository has no scheduled runs, record that finding:
+
+```text
+No recent `schedule` event workflow runs were found. The report is treated as failing automated GitHub Actions, not true scheduled workflow failure.
+```
+
+## Step 2: List Recent Failures
+
+Run:
+
+```bash
+gh run list --status failure --limit 50
+```
+
+Pick the failures that match the user's report. Prefer runs on maintained branches and recent SHAs.
+
+Include `schedule`, `push`, `pull_request`, and relevant repository-owned `workflow_dispatch` runs. Exclude unrelated manual experiments, stale branches, deleted workflow definitions, forks, and platform-managed or bot-owned automation unless the user report explicitly targets them.
+
+## Step 3: Inspect One Failed Run
+
+Collect metadata:
+
+```bash
+gh run view 1234567890 \
+  --json databaseId,name,event,status,conclusion,headBranch,headSha,url,createdAt,updatedAt,jobs
+```
+
+Collect failed-step logs:
+
+```bash
+gh run view 1234567890 --log-failed
+```
+
+If `gh` reports a transient rate limit or network error, retry once. If it still fails, classify the run as `external-transient`. If metadata is visible but failed logs are unavailable because of permissions or retention, classify it as `inaccessible`. Do not infer a repo defect from partial GitHub metadata.
+
+Extract only the relevant failing lines. Example:
+
+```text
+test	Run cargo test	error: completion verifier accepted a workflow handoff without evidence records
+test	Run cargo test	assertion failed: result.requires_follow_up()
+```
+
+## Step 4: Build the Evidence Table
+
+Create the investigation table:
+
+| Workflow | Run | Event | Branch/SHA | Failed job | Failed step | Root cause | Classification |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| CI | `https://github.com/rysweet/amplihack-rs/actions/runs/1234567890` | `push` | `main@0123456` | `test` | `Run cargo test` | Completion verifier accepted a workflow handoff without required evidence records. | `repo-caused` |
+
+The table is the decision point. If the root cause does not point to a repository surface, do not edit repository files.
+
+## Step 5: Fix the Narrowest Surface
+
+For the example above, edit the Rust surface that owns completion verification:
+
+| File | Purpose |
+| --- | --- |
+| `crates/amplihack-launcher/src/completion_verifier.rs` | Implements completion checks. |
+| `crates/amplihack-launcher/src/completion_verifier_tests.rs` | Proves incomplete handoffs stay incomplete. |
+
+Do not edit `.github/workflows/ci.yml` unless the failed log points to CI YAML behavior rather than Rust behavior.
+
+## Step 6: Add Regression Coverage
+
+Add or update the closest local guard. For a completion-verifier defect, use a targeted Rust test:
+
+```bash
+cargo test -p amplihack-launcher completion_verifier
+```
+
+The test asserts that a workflow handoff without required evidence records remains incomplete.
+
+## Step 7: Validate
+
+Run the repository gate:
+
+```bash
+pre-commit run --all-files
+```
+
+Run targeted validation for the changed surface:
+
+```bash
+cargo test -p amplihack-launcher completion_verifier
+```
+
+## Step 8: Commit and Push
+
+Review the diff:
+
+```bash
+git diff --stat
+git diff -- crates/amplihack-launcher/src/completion_verifier.rs crates/amplihack-launcher/src/completion_verifier_tests.rs
+```
+
+Commit:
+
+```bash
+git add crates/amplihack-launcher/src/completion_verifier.rs crates/amplihack-launcher/src/completion_verifier_tests.rs
+git commit -m "Require evidence for workflow completion"
+git push --set-upstream origin fix/automated-actions-failure
+```
+
+## Step 9: Open the PR
+
+Write the PR body with evidence:
+
+````markdown
+## Evidence
+
+| Workflow | Run | Event | Branch/SHA | Failed job | Failed step | Classification |
+| --- | --- | --- | --- | --- | --- | --- |
+| CI | https://github.com/rysweet/amplihack-rs/actions/runs/1234567890 | push | main@0123456 | test | Run cargo test | repo-caused |
+
+## Schedule-event finding
+
+No recent `schedule` event failures were found. The failing automation is a push-triggered `CI` workflow run.
+
+## Root cause
+
+The completion verifier accepted a workflow handoff without evidence records. The CI test failed because the verifier returned success for an incomplete investigation.
+
+## Fix
+
+Required evidence records before marking automated action investigations complete.
+
+## Regression coverage
+
+Updated the completion-verifier test so missing evidence fails locally before CI.
+
+## Validation
+
+```bash
+pre-commit run --all-files
+cargo test -p amplihack-launcher completion_verifier
+```
+````
+
+Open it:
+
+```bash
+gh pr create \
+  --title "Require evidence for automated action investigations" \
+  --body-file /tmp/automated-actions-failure-pr.md
+```
+
+## Step 10: Monitor CI to Closure
+
+Watch the PR checks:
+
+```bash
+gh pr checks --watch
+```
+
+If CI fails, compare the failure to your evidence table:
+
+| CI result | Action |
+| --- | --- |
+| Same fixed surface fails | Fix the PR. |
+| New failure caused by the change | Fix the PR. |
+| External or transient failure | Document the failing check and rerun if appropriate. |
+| Pre-existing unrelated failure | Document it as a blocker; do not expand the PR scope. |
+
+The work is closed when the PR is merge-ready or blocked only by documented external or pre-existing failures.
+
+## Related
+
+- [How to Investigate Automated GitHub Actions Failures](../howto/investigate-automated-action-failures.md)
+- [Automated Action Failure Investigation Reference](../reference/automated-action-failure-investigation.md)

--- a/tests/integration/automated_action_failure_investigation_contract_test.rs
+++ b/tests/integration/automated_action_failure_investigation_contract_test.rs
@@ -1,0 +1,143 @@
+//! TDD contract tests for automated GitHub Actions failure investigations.
+//!
+//! These tests are written before implementation. They pin the behavior needed
+//! for reports like "many scheduled action runs are failing": prove true
+//! schedule-event evidence first, classify actual failed automation from gh
+//! logs, fix only repo-caused failures, and close through a PR with validation.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut dir = crate_dir.clone();
+    while !dir.join("amplifier-bundle").exists() {
+        if !dir.pop() {
+            panic!("could not find amplifier-bundle from {crate_dir:?}");
+        }
+    }
+    dir
+}
+
+fn workflow_recipe_contract_text() -> String {
+    let recipes_dir = repo_root().join("amplifier-bundle/recipes");
+    let mut combined = String::new();
+    for entry in std::fs::read_dir(&recipes_dir)
+        .unwrap_or_else(|e| panic!("read recipes dir {}: {e}", recipes_dir.display()))
+    {
+        let entry = entry.unwrap_or_else(|e| panic!("read recipe dir entry: {e}"));
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("yaml") {
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read recipe {}: {e}", path.display()));
+            combined.push_str("\n--- ");
+            combined.push_str(&path.display().to_string());
+            combined.push_str(" ---\n");
+            combined.push_str(&text);
+        }
+    }
+    combined
+}
+
+#[test]
+fn workflow_contract_checks_schedule_event_runs_before_broad_failures() {
+    let recipes = workflow_recipe_contract_text();
+
+    for required in [
+        "gh run list --event schedule --limit 50",
+        "gh run list --status failure --limit 50",
+        "No recent `schedule` event",
+    ] {
+        assert!(
+            recipes.contains(required),
+            "workflow recipes must require `{required}` so user-reported \
+             scheduled action failures are proven from GitHub Actions evidence \
+             before any code change"
+        );
+    }
+}
+
+#[test]
+fn workflow_contract_collects_failed_step_logs_and_evidence_table_fields() {
+    let recipes = workflow_recipe_contract_text();
+
+    for required in [
+        "gh run view RUN_ID",
+        "--log-failed",
+        "workflow",
+        "run URL",
+        "event",
+        "branch/SHA",
+        "failing job",
+        "failing step",
+        "root-cause excerpt",
+        "classification",
+    ] {
+        assert!(
+            recipes.contains(required),
+            "workflow recipes must require failed-run evidence field `{required}`"
+        );
+    }
+}
+
+#[test]
+fn workflow_contract_handles_github_service_failures_visibly() {
+    let recipes = workflow_recipe_contract_text();
+
+    for required in [
+        "gh auth status",
+        "existing authenticated session",
+        "permission",
+        "authentication",
+        "rate limit",
+        "network",
+        "missing log access",
+        "Retry once",
+        "external-transient or inaccessible",
+        "do not infer",
+    ] {
+        assert!(
+            recipes.contains(required),
+            "workflow recipes must encode GitHub service integration handling `{required}`"
+        );
+    }
+}
+
+#[test]
+fn workflow_contract_limits_fixes_to_proven_repo_caused_failures() {
+    let recipes = workflow_recipe_contract_text();
+
+    for required in [
+        "repo-caused",
+        "generated-template-caused",
+        "external-transient",
+        "stale",
+        "unrelated",
+        "inaccessible",
+        "do not patch",
+        "narrowest fix",
+    ] {
+        assert!(
+            recipes.contains(required),
+            "workflow recipes must encode classification/fix-selection rule `{required}`"
+        );
+    }
+}
+
+#[test]
+fn workflow_contract_requires_validation_pr_and_ci_closure() {
+    let recipes = workflow_recipe_contract_text();
+
+    for required in [
+        "pre-commit run --all-files",
+        "regression coverage",
+        "targeted tests",
+        "gh pr create",
+        "gh pr checks --watch",
+        "merge-ready",
+    ] {
+        assert!(
+            recipes.contains(required),
+            "workflow recipes must require PR closure evidence `{required}`"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- require automated GitHub Actions investigations to prove schedule-event findings before broad failed-run triage
- require failed-run evidence fields, failed-log collection, repo-caused classification, validation, PR, and CI closure evidence before claiming completion
- add docs for investigating automated action failures and regression coverage in completion verifier/integration tests

Fixes #776

## Validation
- cargo fmt --all --check
- CARGO_MANIFEST_DIR="/home/azureuser/src/amplihack-rs/worktrees/feat/issue-776-investigate-the-users-report-of-many-failures-in-s/bins/amplihack" rustc --edition=2021 --test tests/integration/automated_action_failure_investigation_contract_test.rs -o /tmp/automated-action-contract-test && /tmp/automated-action-contract-test
- cargo test -p amplihack-launcher completion_verifier -- --nocapture
- pre-commit run --all-files