### PR TITLE
Update merge-ready for GitHub and AzDO

### DIFF
--- a/amplifier-bundle/skills/merge-ready/SKILL.md
+++ b/amplifier-bundle/skills/merge-ready/SKILL.md
@@ -1,34 +1,55 @@
 ---
 name: merge-ready
-description: Checks whether a pull request satisfies the project's merge criteria and records the required evidence in the PR description. Use with `/merge-ready` before review or merge when QA-team scenarios, docs links, quality-audit convergence, CI status, and diff scope must be verified.
+description: Checks whether a PR/pull request satisfies the project's merge criteria and records the required evidence in the PR/pull request description. Use with `/merge-ready` before review or merge when QA-team scenarios, docs links, quality-audit convergence, checks/build validation status, and diff scope must be verified.
 disable-model-invocation: true
 argument-hint: [pr-number]
 ---
 
 # Merge Ready
 
-Use this skill as the final gate before calling a PR ready for review or merge.
+Use this skill as the final gate before calling a PR/pull request ready for review, merge, or closure.
 
 This skill coordinates existing project workflows. It does **not** replace:
 
 - `qa-team` for outside-in scenario authoring and execution
-- `quality-audit` for iterative SEEK → VALIDATE → FIX review
-- `default-workflow` for substantive fixes discovered while making the PR merge-ready
+- `quality-audit` for iterative SEEK -> VALIDATE -> FIX review
+- `default-workflow` for substantive fixes discovered while making the PR/pull request merge-ready
 
-Use [pr-description-template.md](pr-description-template.md) to update the PR description with the required evidence.
+Use [pr-description-template.md](pr-description-template.md) to update the PR/pull request description with the required evidence.
+
+## Platform scope
+
+The top-level merge-readiness contract is platform-neutral. Use platform-specific commands and terminology only inside the matching platform path:
+
+- **GitHub**: GitHub pull requests, GitHub Actions, `gh`, GitHub issues, review conversations, and branch protection.
+- **Azure DevOps/AzDO**: Azure DevOps, AzDO, Azure Repos pull requests, Azure Pipelines, `az repos`, `az pipelines`, Azure Boards work items, PR threads, and branch policies.
+
+When the platform cannot be detected, inspect the repository remote, PR URL, or available CLI context first. If the platform still cannot be proven, report `NOT_MERGE_READY` with a platform-access blocker instead of assuming GitHub behavior.
+
+Platform detection signals:
+
+- **GitHub**: `github.com` remotes or PR URLs, `gh repo view`, `gh pr status`, or hosting metadata that identifies a GitHub repository.
+- **Azure DevOps/AzDO**: `dev.azure.com` or `*.visualstudio.com` remotes or PR URLs, Azure Repos remote paths, `az repos pr show`, or hosting metadata that identifies an Azure DevOps project/repository.
 
 ## Required outcome
 
-A PR is merge-ready only when **all** of the following are true:
+A PR/pull request is merge-ready only when **all** of the following are true:
 
 1. `qa-team` scenarios were written or updated, validated with `gadugi-test validate`, and actually run with `gadugi-test run`.
 2. User-facing docs were updated when the change affects APIs, configuration, deployment, CLI behavior, or other external surfaces.
-3. `quality-audit` completed at least 3 SEEK → VALIDATE → FIX cycles, continued past 3 if critical or high findings remained, and ended on a clean final cycle.
-4. All GitHub Actions checks are green with **0 failures**.
-5. The PR description contains concrete evidence for criteria 1–4 and 6.
-6. The diff contains no unrelated changes.
+3. `quality-audit` completed at least 3 SEEK -> VALIDATE -> FIX cycles, continued past 3 if critical or high findings remained, and ended on a clean final cycle.
+4. Checks/build validation for the current head revision passed according to the active platform and repository policy.
+5. PR/pull request metadata is complete and reviewable.
+6. Required reviews/approvals are satisfied, with no outstanding requested changes.
+7. Merge conflicts are absent.
+8. Required policies/protection rules are satisfied.
+9. Required linked work items/issues are present or explicitly not applicable under project policy.
+10. Required comments/threads are resolved or explicitly acknowledged as non-blocking.
+11. Final merge/close verification is documented for the intended outcome, and, if a merge or close action was performed, the platform state confirms it.
+12. The PR/pull request description contains concrete evidence for all other criteria, including scope.
+13. The diff contains no unrelated changes.
 
-If any criterion is missing, the PR is **not merge-ready**.
+If any criterion is missing, stale, inaccessible, or blocked by external approval, check, or policy state, the PR/pull request is **not merge-ready**.
 
 ## Non-negotiable guardrails
 
@@ -36,33 +57,54 @@ If any criterion is missing, the PR is **not merge-ready**.
 - Do **not** claim docs are irrelevant without checking the changed surfaces.
 - Do **not** accept fewer than 3 quality-audit cycles.
 - Do **not** accept a quality-audit result unless the final cycle is clean.
-- Do **not** accept pending or failing CI.
-- Do **not** mark a PR merge-ready until the PR description itself is updated with evidence.
-- Do **not** silently ignore blockers such as missing environment access, missing PR access, or missing test tooling. Report them explicitly.
+- Do **not** accept pending, failing, cancelled, stale, or unavailable checks/build validation.
+- Do **not** mark a PR/pull request merge-ready until the description itself is updated with evidence.
+- Do **not** bypass policies/protection rules, required checks, required approvals, or required linked work item rules.
+- Do **not** silently ignore blockers such as missing environment access, missing PR/pull request access, missing test tooling, missing CLI authentication, or missing platform permissions. Report them explicitly.
 
 ## Workflow
 
-### 1. Establish PR context
+### 1. Establish PR/pull request context
 
-Identify the target PR from `$ARGUMENTS` if provided; otherwise use the current branch's PR.
+Identify the target PR/pull request from `$ARGUMENTS` if provided; otherwise use the current branch's PR/pull request.
 
 Gather:
 
-- PR number, URL, title, and current PR description
+- platform and repository/project identity
+- PR/pull request ID, URL, title, source branch, target branch, and current description
 - changed files and current diff scope
 - whether the change touches external or user-facing surfaces
-- current CI status
+- current checks/build validation status for the current head revision
+- metadata, reviews/approvals, mergeability, policies/protection, linked work items/issues, and comments/threads
 
-Useful commands:
+#### GitHub path
+
+Use GitHub-specific commands only when the PR is a GitHub pull request.
 
 ```bash
-gh pr view "$PR" --json number,url,title,body
+gh pr view "$PR" --json number,url,title,body,headRefName,baseRefName,mergeStateStatus,mergeable,reviewDecision,isDraft,closingIssuesReferences
 gh pr diff "$PR" --name-only
 gh pr checks "$PR"
-git diff --name-only origin/main...HEAD
+git diff --name-only "origin/$(gh pr view "$PR" --json baseRefName --jq .baseRefName)"...HEAD
 ```
 
-If no PR exists yet, you may still prepare evidence, but the final verdict must remain blocked until the PR exists and CI status is available.
+For unresolved review conversations or branch protection details, use `gh pr view`, `gh api`, the GitHub UI, or authorized repository settings evidence. Record the exact source used.
+
+#### Azure DevOps/AzDO path
+
+Use AzDO-specific commands only when the PR is an Azure Repos pull request.
+
+```bash
+az repos pr show --id "$PR_ID" --output json
+az repos pr policy list --id "$PR_ID" --output table
+az repos pr work-item list --id "$PR_ID" --output table
+az repos pr reviewer list --id "$PR_ID" --output table
+az repos pr show --id "$PR_ID" --query "{source:sourceRefName,target:targetRefName,mergeStatus:mergeStatus,status:status,title:title}" --output json
+```
+
+For PR threads or build validation details that are not exposed by the installed CLI version, use the Azure DevOps UI or authorized REST API evidence. Record the exact source used.
+
+If no PR/pull request exists yet, you may still prepare evidence, but the final verdict must remain blocked until the PR/pull request exists and platform checks/build validation status is available.
 
 ### 2. Satisfy the QA criterion with `qa-team`
 
@@ -87,7 +129,7 @@ If the environment needed to run the scenario does not exist, stop and report a 
 
 ### 3. Satisfy the docs criterion
 
-Inspect the changed files and decide whether the PR changes any user-facing surface:
+Inspect the changed files and decide whether the PR/pull request changes any user-facing surface:
 
 - APIs
 - configuration
@@ -95,22 +137,22 @@ Inspect the changed files and decide whether the PR changes any user-facing surf
 - CLI or TUI behavior
 - user-visible workflows
 
-If yes, update the corresponding docs and add links to those docs in the PR description.
+If yes, update the corresponding docs and add links to those docs in the PR/pull request description.
 
-If no, list the changed surfaces you checked and explain why each is internal-only. For example: "Changed surfaces reviewed: `rust_runner.py`, `smart-orchestrator.yaml` — both are internal orchestration plumbing with no CLI/API/config impact."
+If no, list the changed surfaces you checked and explain why each is internal-only. For example: "Changed surfaces reviewed: `rust_runner.py`, `smart-orchestrator.yaml` -- both are internal orchestration plumbing with no CLI/API/config impact."
 
 ### 4. Satisfy the quality-audit criterion
 
 Invoke `quality-audit` and require the full iterative loop:
 
 - minimum 3 cycles
-- each cycle is SEEK → VALIDATE (multi-agent consensus) → FIX
+- each cycle is SEEK -> VALIDATE (multi-agent consensus) -> FIX
 - continue past 3 cycles if critical or high findings remain
 - final cycle must be clean: zero critical or high findings, and zero medium findings that pose correctness or security risks
 
 Every fix uncovered during this audit must follow `default-workflow`. If the audit finds issues that require code or docs changes, switch to `default-workflow` for those fixes, complete the work, then return to this skill and resume verification.
 
-Capture in the PR description:
+Capture in the PR/pull request description:
 
 - cycle count
 - confirmed findings per cycle
@@ -118,45 +160,54 @@ Capture in the PR description:
 - convergence summary
 - explicit statement that the final cycle was clean (zero critical/high findings, zero medium correctness/security findings)
 
-### 5. Satisfy the CI criterion
+### 5. Verify platform merge-readiness aspects
 
-Check all GitHub Actions status for the PR.
+Collect explicit evidence for every aspect below before declaring `MERGE_READY`.
 
-Rules:
-
-- all checks must be green (skipped checks from conditional workflows are acceptable but must be listed)
-- rerun only clearly flaky jobs
-- fix real failures before continuing
-- 0 failures is the only passing state
-- if CI is pending, red, cancelled, or unavailable, the PR is not merge-ready
-- document any skipped checks by name and skip reason in the PR description
-
-Useful commands:
-
-```bash
-gh pr checks "$PR"
-gh run list --branch "$(git branch --show-current)"
-```
-
-If CI is pending, red, cancelled, or unavailable, the PR is not merge-ready.
+| Aspect | GitHub path | Azure DevOps/AzDO path |
+| --- | --- | --- |
+| Checks/build validation | Use GitHub Actions and other status checks for the current head. `gh pr checks "$PR"` must show required checks green; skipped conditional checks are allowed only when named with the skip reason. Rerun only clearly flaky jobs and fix real failures. | Use Azure Pipelines/build validation and branch policy status for the current source commit. `az repos pr policy list --id "$PR_ID"` and pipeline run evidence must show required validations approved/succeeded; optional or skipped validations must be named with the policy reason. |
+| PR/pull request metadata | Use `gh pr view` or the GitHub UI to confirm title, description, base branch, head branch, draft state, labels/milestone if required, and reviewer visibility. A draft pull request is not merge-ready unless project policy explicitly allows draft readiness. | Use `az repos pr show` or the AzDO UI to confirm title, description, source branch, target branch, draft state if supported, required labels/tags if used by the project, and reviewer visibility. A draft Azure Repos PR is not merge-ready unless project policy explicitly allows draft readiness. |
+| Reviews/approvals | Use `gh pr view --json reviewDecision,reviews,reviewRequests` or the GitHub UI. Required approving reviews must be present, requested changes must be cleared, and stale approvals must be revalidated after source changes when protection requires it. | Use `az repos pr reviewer list --id "$PR_ID"` and branch policy status. Required reviewers or reviewer groups must have approved or not voted blocking/rejected; stale votes must be revalidated after source changes when policy requires it. |
+| Merge conflicts | Use `gh pr view --json mergeable,mergeStateStatus` or the GitHub UI. `CONFLICTING`, dirty, unknown, or stale mergeability is blocking until refreshed and clean. | Use `az repos pr show --id "$PR_ID" --query mergeStatus` or the AzDO UI. Conflict, failure, rejected, or unknown merge status is blocking until refreshed and clean. |
+| Policies/protection | Use branch protection/ruleset evidence from `gh pr view`, `gh api`, or the GitHub UI. Required checks, required reviews, signed commit rules, linear history, merge queue, and required conversation resolution must all be satisfied. | Use branch policy evidence from `az repos pr policy list --id "$PR_ID"`, `az repos policy`, or the AzDO UI. Build validation, minimum reviewers, required reviewers, comment resolution, linked work item, status checks, and merge strategy policies must all be satisfied. |
+| Linked work items/issues | Use `gh pr view --json closingIssuesReferences` or the GitHub UI. Required issue links or closing keywords must point to the correct issue(s), or the PR description must state why no issue is required under project policy. | Use `az repos pr work-item list --id "$PR_ID"` or the AzDO UI. Required Azure Boards work items must be linked to the PR, or the PR description must state why no work item is required under project policy. |
+| Comments/threads | Use `gh pr view --json comments,reviews` plus review conversation evidence from `gh api` or the GitHub UI. Required review conversations must be resolved; unresolved comments must be explicitly marked non-blocking by an authorized reviewer or project policy. | Use PR thread evidence from the AzDO UI or authorized REST API. Required threads must be resolved; active comments must be explicitly marked non-blocking by an authorized reviewer or project policy. |
+| Final merge/close verification | If authorized to merge, use `gh pr merge` according to project policy, then verify `gh pr view "$PR" --json state,mergedAt,mergedBy,mergeCommit`. If closing without merge, verify `state:CLOSED` and document the close reason. If not authorized to perform the final action, document the exact external approval or permission blocker. | If authorized to complete the PR, use the platform-approved completion command, UI, or automation according to project policy, then verify `az repos pr show --id "$PR_ID" --query "{status:status,closedBy:closedBy,closedDate:closedDate,lastMergeCommit:lastMergeCommit}"`. `az repos pr update --id "$PR_ID" --status completed` is an example only, not the default path. If abandoning/closing without merge, verify `status:abandoned` and document the reason. If not authorized to perform the final action, document the exact external approval or permission blocker. |
 
 ### 6. Enforce scope
 
-Review the diff and confirm the PR is focused on the intended change. If unrelated changes are present, report them as blockers and do not mark the PR ready.
+Review the diff and confirm the PR/pull request is focused on the intended change. If unrelated changes are present, report them as blockers and do not mark the PR/pull request ready.
 
-### 7. Update the PR description
+Platform-neutral evidence is enough for scope when it names the source and target branches and lists changed files. Use the platform diff, local Git diff, or both.
 
-**This step must not be performed until steps 2–6 have all completed and evidence has been collected.** Do not update the PR description with placeholder or anticipated evidence.
+### 7. Update the PR/pull request description
+
+**This step must not be performed until steps 2-6 have all completed and evidence has been collected.** Do not update the description with placeholder or anticipated evidence.
 
 Use [pr-description-template.md](pr-description-template.md) and replace every placeholder with actual evidence. Keep the wording concise, but make the evidence concrete enough that a reviewer can verify the work without guessing.
 
-If the PR description already has useful sections, merge the evidence into the existing structure instead of duplicating headings.
+If the description already has useful sections, merge the evidence into the existing structure instead of duplicating headings.
+
+#### GitHub path
+
+```bash
+gh pr edit "$PR" --body-file pr-description.md
+```
+
+#### Azure DevOps/AzDO path
+
+```bash
+az repos pr update --id "$PR_ID" --description "$(cat pr-description.md)"
+```
+
+If the platform CLI cannot update the description safely, update it through the authorized UI/API and record that evidence source.
 
 ### 8. Return a binary verdict
 
 End with one of these outcomes:
 
-- `MERGE_READY`: every criterion passed and the PR description was updated
+- `MERGE_READY`: every criterion passed, required evidence was added to the PR/pull request description, and no platform blocker remains
 - `NOT_MERGE_READY`: one or more blockers remain
 
 Use this format:
@@ -164,14 +215,23 @@ Use this format:
 ```markdown
 Verdict: MERGE_READY | NOT_MERGE_READY
 
+Platform: GitHub | Azure DevOps/AzDO | unknown
+
 Criteria:
 
 - QA-team: pass | fail
 - Docs: pass | fail | not-applicable
 - Quality-audit: pass | fail
-- CI: pass | fail
+- Checks/build validation: pass | fail
+- Metadata: pass | fail
+- Reviews/approvals: pass | fail
+- Merge conflicts: pass | fail
+- Policies/protection: pass | fail
+- Linked work items/issues: pass | fail | not-applicable
+- Comments/threads: pass | fail | not-applicable
+- Final merge/close verification: pass | fail | not-performed
 - Scope: pass | fail
-- PR description evidence: pass | fail
+- Description evidence: pass | fail
 
 Blockers:
 
@@ -183,9 +243,14 @@ Blockers:
 Stop and report `NOT_MERGE_READY` when any of these are true:
 
 - no runnable environment exists for the required gadugi scenario
-- the PR or CI status cannot be accessed
+- the PR/pull request or checks/build validation status cannot be accessed
+- platform access or authentication cannot prove required metadata, reviews/approvals, mergeability, policies/protection, linked work items/issues, comments/threads, or final state
 - quality-audit has not converged to a clean final cycle
 - docs changes are needed but not yet written
+- checks/build validation is pending, failing, cancelled, stale, skipped without policy support, or unavailable
+- required reviews/approvals, linked work items/issues, comments/threads, or policies/protection remain unsatisfied
+- merge conflicts are present or mergeability cannot be determined
+- final merge/close action is blocked by permissions, external approval, required waiting period, or platform policy
 - the diff contains unrelated changes
 
 Do not substitute promises or TODOs for evidence.

--- a/amplifier-bundle/skills/merge-ready/pr-description-template.md
+++ b/amplifier-bundle/skills/merge-ready/pr-description-template.md
@@ -1,8 +1,13 @@
-# PR description evidence template
+# PR/pull request description evidence template
 
-Copy these sections into the PR description and replace every placeholder with actual evidence.
+Copy these sections into the PR/pull request description and replace every placeholder with actual evidence. Use platform-neutral wording for shared evidence, then include the GitHub or Azure DevOps/AzDO details that apply.
 
 ## Merge readiness
+
+- Platform: `<GitHub / Azure DevOps/AzDO>`
+- PR/pull request: `<number or ID and URL>`
+- Source -> target: `<source branch> -> <target branch>`
+- Current head revision: `<commit SHA>`
 
 ### QA-team evidence
 
@@ -18,7 +23,7 @@ Copy these sections into the PR description and replace every placeholder with a
 
 - User-facing docs impact: `<yes / no>`
 - Updated docs: `<doc path or link, or "none">`
-- PR description links added: `<list of links or "n/a">`
+- Description links added: `<list of links or "n/a">`
 - Rationale if not applicable: `<list of changed surfaces checked and why each is internal-only>`
 
 ### Quality-audit
@@ -31,20 +36,138 @@ Copy these sections into the PR description and replace every placeholder with a
 - Fixes followed default-workflow: `<yes / no>`
 - Convergence summary: `<why the audit is considered complete>`
 
-### CI
+### Checks/build validation
 
-- Checks command: `gh pr checks <pr>`
-- Result: `<all green / failures remain / pending>`
-- Skipped checks: `<list of skipped check names and skip reason, or "none">`
-- Flaky reruns performed: `<none or list>`
+- Evidence source: `<platform CLI command, UI link, API response, or artifact>`
+- Current head validated: `<commit SHA>`
+- Required checks/build validations: `<all passed / failures remain / pending / unavailable>`
+- Optional or skipped validations: `<list of names and policy-supported skip reason, or "none">`
+- Reruns performed: `<none or list>`
 - Real failures fixed: `<none or summary>`
+
+GitHub example:
+
+```text
+Evidence source: gh pr checks 123
+Required checks/build validations: all passed in GitHub Actions for abc1234
+Optional or skipped validations: docs-preview skipped by path filter
+```
+
+Azure DevOps/AzDO example:
+
+```text
+Evidence source: az repos pr policy list --id 123 and Azure Pipelines run 456
+Required checks/build validations: build validation succeeded for abc1234
+Optional or skipped validations: deployment validation not required for docs-only path
+```
+
+### PR/pull request metadata
+
+- Title: `<reviewable title>`
+- Description complete: `<yes / no>`
+- Source branch: `<branch>`
+- Target branch: `<branch>`
+- Draft state: `<not draft / draft / not supported>`
+- Required labels/tags/milestone: `<satisfied / not applicable / missing details>`
+- Metadata evidence source: `<platform CLI command, UI link, or API response>`
+
+GitHub example: `gh pr view <pr> --json title,body,headRefName,baseRefName,isDraft,labels,milestone`
+
+Azure DevOps/AzDO example: `az repos pr show --id <id> --output json`
+
+### Reviews/approvals
+
+- Required approvals: `<satisfied / missing / not applicable>`
+- Requested changes or blocking votes: `<none / list>`
+- Stale approval policy checked: `<yes / no / not applicable>`
+- Review evidence source: `<platform CLI command, UI link, or API response>`
+
+GitHub example: `gh pr view <pr> --json reviewDecision,reviews,reviewRequests`
+
+Azure DevOps/AzDO example: `az repos pr reviewer list --id <id>`
+
+### Merge conflicts
+
+- Mergeability status: `<clean / conflicts / unknown>`
+- Conflict evidence source: `<platform CLI command, UI link, or API response>`
+- Conflict resolution required: `<none / summary>`
+
+GitHub example: `gh pr view <pr> --json mergeable,mergeStateStatus`
+
+Azure DevOps/AzDO example: `az repos pr show --id <id> --query mergeStatus`
+
+### Policies/protection
+
+- Required policies/protection: `<satisfied / missing / blocked / not applicable>`
+- Required checks/build policy: `<satisfied / blocked / not applicable>`
+- Required review policy: `<satisfied / blocked / not applicable>`
+- Required conversation/thread policy: `<satisfied / blocked / not applicable>`
+- Policy evidence source: `<platform CLI command, UI link, or API response>`
+
+GitHub example: branch protection or ruleset evidence from `gh api`, `gh pr view`, or the GitHub UI.
+
+Azure DevOps/AzDO example: `az repos pr policy list --id <id>`
+
+### Linked work items/issues
+
+- Required linked work items/issues: `<satisfied / not applicable / missing>`
+- Linked items: `<issue numbers, work item IDs, or "none">`
+- Rationale if not applicable: `<project policy reason>`
+- Link evidence source: `<platform CLI command, UI link, or API response>`
+
+GitHub example:
+
+```text
+Linked issues: Fixes #123
+Evidence source: gh pr view 456 --json closingIssuesReferences
+```
+
+Azure DevOps/AzDO example:
+
+```text
+Linked work items: AB#12345
+Evidence source: az repos pr work-item list --id 456
+```
+
+### Comments/threads
+
+- Required comments/threads resolved: `<yes / no / not applicable>`
+- Unresolved but non-blocking comments/threads: `<none or list with policy/reviewer reason>`
+- Comment/thread evidence source: `<platform CLI command, UI link, or API response>`
+
+GitHub example: review conversation evidence from `gh api`, `gh pr view`, or the GitHub UI.
+
+Azure DevOps/AzDO example: PR thread evidence from the Azure DevOps UI or authorized REST API.
 
 ### Scope
 
 - Changed files reviewed: `<summary or command used>`
 - Unrelated changes: `<none or list>`
 
+### Final merge/close verification
+
+- Intended final action: `<merge / close without merge / abandon / readiness only>`
+- Authorized actor: `<name, team, automation, or "not authorized">`
+- Final action performed: `<yes / no>`
+- Final platform state: `<merged / closed / completed / abandoned / open / not performed>`
+- Verification evidence source: `<platform CLI command, UI link, API response, or "not performed because readiness only">`
+- Remaining external blockers: `<none or list>`
+
+GitHub example:
+
+```text
+Final platform state: merged
+Verification evidence source: gh pr view 456 --json state,mergedAt,mergedBy,mergeCommit
+```
+
+Azure DevOps/AzDO example:
+
+```text
+Final platform state: completed
+Verification evidence source: az repos pr show --id 456 --query "{status:status,closedBy:closedBy,closedDate:closedDate,lastMergeCommit:lastMergeCommit}"
+```
+
 ### Verdict
 
-- Merge-ready: `<yes / no>`
+- Verdict: `<MERGE_READY / NOT_MERGE_READY>`
 - Remaining blockers: `<none or list>`

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -334,6 +334,12 @@ path = "../../tests/integration/issue_746_default_workflow_guidance_test.rs"
 name = "issue_684_host_aware_workflow"
 path = "../../tests/integration/issue_684_host_aware_workflow_test.rs"
 
+# Issue #778: merge-ready must be platform-neutral, with explicit GitHub and
+# Azure DevOps/AzDO guidance for every merge-readiness aspect.
+[[test]]
+name = "merge_ready_platform_contract"
+path = "../../tests/integration/merge_ready_platform_contract_test.rs"
+
 # code-philosophy-audit recipe structural parity tests.
 [[test]]
 name = "code_philosophy_audit_recipe"

--- a/tests/integration/merge_ready_platform_contract_test.rs
+++ b/tests/integration/merge_ready_platform_contract_test.rs
@@ -1,0 +1,283 @@
+//! TDD contract tests for the merge-ready skill platform-neutral contract.
+//!
+//! These tests fail against the previous GitHub-only merge-ready wording and
+//! pass once the skill gives explicit GitHub and Azure DevOps/AzDO guidance for
+//! each required merge-readiness aspect.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut dir = crate_dir.clone();
+    while !dir.join("amplifier-bundle").exists() {
+        if !dir.pop() {
+            panic!("could not find amplifier-bundle from {crate_dir:?}");
+        }
+    }
+    dir
+}
+
+fn merge_ready_skill() -> String {
+    let path = repo_root().join("amplifier-bundle/skills/merge-ready/SKILL.md");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn merge_ready_template() -> String {
+    let path = repo_root().join("amplifier-bundle/skills/merge-ready/pr-description-template.md");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn assert_contains_all(haystack: &str, needles: &[&str], context: &str) {
+    for needle in needles {
+        assert!(
+            haystack.contains(needle),
+            "{context} must contain `{needle}`"
+        );
+    }
+}
+
+fn markdown_table_row<'a>(document: &'a str, aspect: &str) -> Vec<&'a str> {
+    let prefix = format!("| {aspect} |");
+    let row = document
+        .lines()
+        .find(|line| line.starts_with(&prefix))
+        .unwrap_or_else(|| panic!("merge-readiness matrix must include row `{aspect}`"));
+
+    row.trim_matches('|').split('|').map(str::trim).collect()
+}
+
+fn markdown_section<'a>(document: &'a str, heading: &str) -> &'a str {
+    let start = document
+        .find(heading)
+        .unwrap_or_else(|| panic!("document must include heading `{heading}`"));
+    let remainder = &document[start..];
+    let next_heading = remainder
+        .lines()
+        .skip(1)
+        .scan(heading.len(), |offset, line| {
+            let current = *offset;
+            *offset += line.len() + 1;
+            Some((current, line))
+        })
+        .find_map(|(offset, line)| line.starts_with("### ").then_some(offset));
+
+    match next_heading {
+        Some(end) => &remainder[..end],
+        None => remainder,
+    }
+}
+
+#[test]
+fn skill_top_level_contract_uses_platform_neutral_merge_readiness_terms() {
+    let skill = merge_ready_skill();
+    let neutral_intro = skill
+        .split("## Platform scope")
+        .next()
+        .expect("skill must have content before Platform scope");
+    let required_outcome = skill
+        .split("## Required outcome")
+        .nth(1)
+        .and_then(|section| section.split("## Non-negotiable guardrails").next())
+        .expect("skill must have a Required outcome section");
+
+    assert_contains_all(
+        &skill,
+        &[
+            "PR/pull request",
+            "checks/build validation",
+            "reviews/approvals",
+            "policies/protection",
+            "linked work items/issues",
+            "comments/threads",
+        ],
+        "merge-ready skill",
+    );
+
+    for neutral_section in [neutral_intro, required_outcome] {
+        for github_specific in [
+            "GitHub Actions",
+            "`gh`",
+            "branch protection",
+            "GitHub issues",
+        ] {
+            assert!(
+                !neutral_section.contains(github_specific),
+                "top-level neutral merge-readiness sections must not use GitHub-specific term `{github_specific}`"
+            );
+        }
+    }
+
+    assert!(
+        !skill.contains("CI status"),
+        "merge-ready skill must use checks/build validation wording instead of GitHub-flavored CI status"
+    );
+}
+
+#[test]
+fn skill_declares_github_and_azure_devops_platform_paths() {
+    let skill = merge_ready_skill();
+
+    assert_contains_all(
+        &skill,
+        &[
+            "The top-level merge-readiness contract is platform-neutral.",
+            "**GitHub**: GitHub pull requests, GitHub Actions, `gh`, GitHub issues, review conversations, and branch protection.",
+            "**Azure DevOps/AzDO**: Azure DevOps, AzDO, Azure Repos pull requests, Azure Pipelines, `az repos`, `az pipelines`, Azure Boards work items, PR threads, and branch policies.",
+            "report `NOT_MERGE_READY` with a platform-access blocker instead of assuming GitHub behavior",
+            "Platform detection signals:",
+            "`github.com` remotes or PR URLs",
+            "`dev.azure.com` or `*.visualstudio.com` remotes or PR URLs",
+            "Azure Repos remote paths",
+        ],
+        "platform scope",
+    );
+}
+
+#[test]
+fn merge_readiness_matrix_covers_every_required_aspect_for_both_platforms() {
+    let skill = merge_ready_skill();
+
+    let aspects = [
+        (
+            "Checks/build validation",
+            &["GitHub Actions", "`gh pr checks \"$PR\"`"][..],
+            &[
+                "Azure Pipelines",
+                "`az repos pr policy list --id \"$PR_ID\"`",
+            ][..],
+        ),
+        (
+            "PR/pull request metadata",
+            &["`gh pr view`", "GitHub UI"][..],
+            &["`az repos pr show`", "Azure Repos PR"][..],
+        ),
+        (
+            "Reviews/approvals",
+            &["reviewDecision", "requested changes"][..],
+            &[
+                "`az repos pr reviewer list --id \"$PR_ID\"`",
+                "branch policy status",
+            ][..],
+        ),
+        (
+            "Merge conflicts",
+            &["mergeable", "mergeStateStatus"][..],
+            &["mergeStatus", "AzDO UI"][..],
+        ),
+        (
+            "Policies/protection",
+            &["branch protection", "`gh api`"][..],
+            &[
+                "branch policy evidence",
+                "`az repos pr policy list --id \"$PR_ID\"`",
+            ][..],
+        ),
+        (
+            "Linked work items/issues",
+            &["closingIssuesReferences", "issue links"][..],
+            &[
+                "`az repos pr work-item list --id \"$PR_ID\"`",
+                "Azure Boards work items",
+            ][..],
+        ),
+        (
+            "Comments/threads",
+            &["review conversation", "`gh api`"][..],
+            &["PR thread evidence", "authorized REST API"][..],
+        ),
+        (
+            "Final merge/close verification",
+            &["`gh pr merge`", "mergedAt"][..],
+            &[
+                "platform-approved completion command",
+                "`az repos pr show --id \"$PR_ID\"",
+                "`az repos pr update --id \"$PR_ID\" --status completed` is an example only, not the default path",
+            ][..],
+        ),
+    ];
+
+    for (aspect, github_requirements, azdo_requirements) in aspects {
+        let cells = markdown_table_row(&skill, aspect);
+        assert_eq!(
+            cells.len(),
+            3,
+            "matrix row `{aspect}` must have Aspect, GitHub path, and Azure DevOps/AzDO path cells"
+        );
+        assert_eq!(cells[0], aspect);
+        assert_contains_all(
+            cells[1],
+            github_requirements,
+            &format!("GitHub guidance for {aspect}"),
+        );
+        assert_contains_all(
+            cells[2],
+            azdo_requirements,
+            &format!("Azure DevOps/AzDO guidance for {aspect}"),
+        );
+    }
+}
+
+#[test]
+fn skill_requires_evidence_or_not_merge_ready_for_external_blockers() {
+    let skill = merge_ready_skill();
+
+    assert_contains_all(
+        &skill,
+        &[
+            "Collect explicit evidence for every aspect below before declaring `MERGE_READY`.",
+            "If any criterion is missing, stale, inaccessible, or blocked by external approval, check, or policy state, the PR/pull request is **not merge-ready**.",
+            "`MERGE_READY`: every criterion passed, required evidence was added to the PR/pull request description, and no platform blocker remains",
+            "`NOT_MERGE_READY`: one or more blockers remain",
+            "platform access or authentication cannot prove required metadata, reviews/approvals, mergeability, policies/protection, linked work items/issues, comments/threads, or final state",
+        ],
+        "evidence and blocker contract",
+    );
+}
+
+#[test]
+fn evidence_template_has_platform_neutral_fields_and_examples_for_all_aspects() {
+    let template = merge_ready_template();
+
+    assert_contains_all(
+        &template,
+        &[
+            "# PR/pull request description evidence template",
+            "- Platform: `<GitHub / Azure DevOps/AzDO>`",
+            "- PR/pull request: `<number or ID and URL>`",
+            "- Verdict: `<MERGE_READY / NOT_MERGE_READY>`",
+        ],
+        "template header and verdict",
+    );
+
+    for heading in [
+        "### Checks/build validation",
+        "### PR/pull request metadata",
+        "### Reviews/approvals",
+        "### Merge conflicts",
+        "### Policies/protection",
+        "### Linked work items/issues",
+        "### Comments/threads",
+        "### Final merge/close verification",
+    ] {
+        let section = markdown_section(&template, heading);
+        assert!(
+            section.contains("GitHub example:"),
+            "{heading} must include clearly labeled GitHub guidance"
+        );
+        assert!(
+            section.contains("Azure DevOps/AzDO example:"),
+            "{heading} must include clearly labeled Azure DevOps/AzDO guidance"
+        );
+    }
+
+    assert_contains_all(
+        &template,
+        &[
+            "- Required linked work items/issues: `<satisfied / not applicable / missing>`",
+            "- Required comments/threads resolved: `<yes / no / not applicable>`",
+            "Evidence source: az repos pr work-item list --id 456",
+            "Azure DevOps/AzDO example: PR thread evidence from the Azure DevOps UI or authorized REST API.",
+        ],
+        "linked work item and thread evidence",
+    );
+}

--- a/tests/scenarios/pr-689-merge-ready.yaml
+++ b/tests/scenarios/pr-689-merge-ready.yaml
@@ -26,3 +26,10 @@ scenarios:
       - type: command
         command: "bash -lc 'cargo test --test default_workflow_decomposition -- mid_stage_worktree_steps_fall_back_to_repo_path --quiet && cargo test --test default_workflow_decomposition -- workflow_finalize_step_21_guards_pr_url_before_gh_commands --quiet && bash ./issue_682_worktree_resume.sh'"
         expected_exit_code: 0
+
+  - name: merge-ready-skill-platform-contract
+    description: Merge-ready skill stays platform-neutral and covers GitHub plus Azure DevOps/AzDO for every required readiness aspect.
+    steps:
+      - type: command
+        command: "bash -lc 'cargo test --test merge_ready_platform_contract --quiet'"
+        expected_exit_code: 0


### PR DESCRIPTION
## Summary
- make merge-ready platform-neutral at the top level
- add explicit GitHub and Azure DevOps/AzDO guidance for all merge-readiness aspects
- update evidence template and add regression contract tests

Closes #778

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 CARGO_TARGET_DIR=/tmp/amplihack-issue778-target cargo test --test merge_ready_platform_contract --quiet
- NODE_OPTIONS=--max-old-space-size=32768 CARGO_TARGET_DIR=/tmp/amplihack-issue778-target pre-commit run --all-files
