### PR TITLE
Fix workflow runtime artifact isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplihack"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-memory",
  "async-trait",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-eval"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "serde",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-generator"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "serde",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-asset-resolver-bin"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-cli",
  "tracing",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-blarify"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-builders"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-builders",
  "amplihack-hive",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-context"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-delegation"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "globset",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-domain-agents"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-fleet"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hive"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-cli",
  "amplihack-security",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-launcher"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-utils",
  "anyhow",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-memory"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-multilspy"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-orchestration"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-utils",
  "async-trait",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recovery"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-reflection"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-remote"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-safety"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-security"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "once_cell",
  "regex",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-session"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "filetime",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-utils"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "base64",
  "chrono",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-workflows"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-utils",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -19,6 +19,11 @@
 #      evidence proves implementation+verification, publish/PR state, explicit
 #      no-op, or an explicit failure. Planning, analysis, design, and worktree
 #      prep are not success evidence by themselves.
+#   6. Issue #780: generated workflow runtime artifacts are lifecycle-managed
+#      before Artifact Guard and broad staging. Artifact Guard stays strict; the
+#      workflow must clean only known `.claude/runtime` and owned nested
+#      `worktrees/` artifacts, fail closed on unsafe cleanup targets, and leave
+#      unrelated artifacts for Artifact Guard to reject.
 #
 # This test SHOULD FAIL before the issue #573 reliability fixes land. It MUST
 # PASS once workflow-worktree resolves local/remote origin/HEAD before
@@ -36,6 +41,7 @@ WORKTREE_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-worktree.yaml"
 PUBLISH_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-publish.yaml"
 PUBLISH_HELPER="${REPO_ROOT}/amplifier-bundle/tools/workflow_publish_pr.sh"
 TDD_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-tdd.yaml"
+PRECOMMIT_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-precommit-test.yaml"
 REFACTOR_REVIEW_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-refactor-review.yaml"
 PR_REVIEW_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-pr-review.yaml"
 FINALIZE_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-finalize.yaml"
@@ -45,6 +51,7 @@ SMART_EXECUTE_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/smart-execute-routin
 SMART_ORCHESTRATOR_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/smart-orchestrator.yaml"
 FINAL_STATUS_TOOL="${REPO_ROOT}/amplifier-bundle/tools/workflow_final_status.sh"
 PR_SCOPE_HELPER="${REPO_ROOT}/amplifier-bundle/tools/workflow_pr_scope.sh"
+RUNTIME_ARTIFACT_HELPER="${REPO_ROOT}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
 
 if [[ ! -f "${WORKTREE_RECIPE}" ]]; then
     echo "HARNESS-ERROR: ${WORKTREE_RECIPE} not found" >&2
@@ -58,7 +65,7 @@ if [[ ! -f "${PUBLISH_HELPER}" ]]; then
     echo "HARNESS-ERROR: ${PUBLISH_HELPER} not found" >&2
     exit 2
 fi
-for recipe in "${TDD_RECIPE}" "${REFACTOR_REVIEW_RECIPE}" "${PR_REVIEW_RECIPE}" "${FINALIZE_RECIPE}"; do
+for recipe in "${TDD_RECIPE}" "${PRECOMMIT_RECIPE}" "${REFACTOR_REVIEW_RECIPE}" "${PR_REVIEW_RECIPE}" "${FINALIZE_RECIPE}"; do
     if [[ ! -f "${recipe}" ]]; then
         echo "HARNESS-ERROR: ${recipe} not found" >&2
         exit 2
@@ -370,6 +377,7 @@ run_commit_guard_case() {
         export PATH="${bin_dir}:${PATH}"
         export REAL_GIT="${real_git}"
         export COMMIT_ENV_LOG="${commit_env_log}"
+        export WORKFLOW_RUNTIME_ARTIFACT_HELPER="${RUNTIME_ARTIFACT_HELPER}"
         export WORKTREE_SETUP_WORKTREE_PATH="${repo}"
         export RECIPE_VAR_worktree_setup__worktree_path="${repo}"
         export EXPECTED_PRE_COMMIT_ALLOW_NO_CONFIG="${expected_env}"
@@ -579,6 +587,325 @@ assert_scoped_pr_helper_contracts() {
         || fail "multiple scoped candidates must emit structured reason multiple_scoped_prs"
 }
 
+assert_file_contains() {
+    local label="$1"
+    local file="$2"
+    local needle="$3"
+
+    grep -qF -- "${needle}" "${file}" \
+        || fail "${label} must contain '${needle}'"
+}
+
+first_line_containing() {
+    local file="$1"
+    local needle="$2"
+
+    awk -v needle="${needle}" 'index($0, needle) { print NR; exit }' "${file}"
+}
+
+assert_order_in_file() {
+    local label="$1"
+    local file="$2"
+    local before="$3"
+    local after="$4"
+    local before_line
+    local after_line
+
+    before_line="$(first_line_containing "${file}" "${before}")"
+    after_line="$(first_line_containing "${file}" "${after}")"
+    [[ -n "${before_line}" ]] || fail "${label} must contain '${before}'"
+    [[ -n "${after_line}" ]] || fail "${label} must contain '${after}'"
+    if [[ "${before_line}" -ge "${after_line}" ]]; then
+        local start_line
+        local end_line
+        if [[ "${before_line}" -lt "${after_line}" ]]; then
+            start_line="${before_line}"
+            end_line="${after_line}"
+        else
+            start_line="${after_line}"
+            end_line="${before_line}"
+        fi
+        start_line=$((start_line > 5 ? start_line - 5 : 1))
+        end_line=$((end_line + 5))
+        echo "--- ${label} inspected file: ${file} ---" >&2
+        sed -n "${start_line},${end_line}p" "${file}" >&2
+        fail "${label} must run '${before}' before '${after}'"
+    fi
+}
+
+assert_runtime_preflight_is_not_silenced() {
+    local label="$1"
+    local file="$2"
+
+    if grep -nF 'preflight_known_workflow_runtime_artifacts' "${file}" | grep -E '\|\|[[:space:]]*(true|:)|2>/dev/null' >&2; then
+        fail "${label} must fail closed when workflow runtime artifact preflight fails"
+    fi
+}
+
+assert_step_sources_runtime_helper_and_preflights_before() {
+    local label="$1"
+    local step_file="$2"
+    local needle="$3"
+
+    assert_file_contains "${label}" "${step_file}" 'workflow_runtime_artifacts.sh'
+    assert_file_contains "${label}" "${step_file}" 'preflight_known_workflow_runtime_artifacts'
+    assert_order_in_file "${label}" "${step_file}" 'preflight_known_workflow_runtime_artifacts' "${needle}"
+    assert_runtime_preflight_is_not_silenced "${label}" "${step_file}"
+}
+
+assert_recipe_text_preflights_before() {
+    local label="$1"
+    local recipe="$2"
+    local needle="$3"
+
+    assert_file_contains "${label}" "${recipe}" 'workflow_runtime_artifacts.sh'
+    assert_file_contains "${label}" "${recipe}" 'preflight_known_workflow_runtime_artifacts'
+    assert_order_in_file "${label}" "${recipe}" 'preflight_known_workflow_runtime_artifacts' "${needle}"
+    assert_runtime_preflight_is_not_silenced "${label}" "${recipe}"
+}
+
+assert_runtime_artifact_lifecycle_wiring() {
+    local step_tdd="${WORK}/issue-780-tdd-checkpoint.sh"
+    local step_refactor_review="${WORK}/issue-780-refactor-review-checkpoint.sh"
+    local step_publish_guard="${WORK}/issue-780-publish-guard.sh"
+    local step_publish_commit="${WORK}/issue-780-publish-commit.sh"
+    local step_pr_review_feedback="${WORK}/issue-780-pr-review-feedback.sh"
+    local step_finalize_guard="${WORK}/issue-780-finalize-guard.sh"
+    local step_finalize_cleanup="${WORK}/issue-780-finalize-cleanup.sh"
+
+    extract_step_command "${TDD_RECIPE}" "checkpoint-after-implementation" "${step_tdd}"
+    extract_step_command "${REFACTOR_REVIEW_RECIPE}" "checkpoint-after-review-feedback" "${step_refactor_review}"
+    extract_step_command "${PUBLISH_RECIPE}" "step-14g-artifact-guard" "${step_publish_guard}"
+    extract_step_command "${PUBLISH_RECIPE}" "step-15-commit-push" "${step_publish_commit}"
+    extract_step_command "${PR_REVIEW_RECIPE}" "step-18c-push-feedback-changes" "${step_pr_review_feedback}"
+    extract_step_command "${FINALIZE_RECIPE}" "step-20a-artifact-guard" "${step_finalize_guard}"
+    extract_step_command "${FINALIZE_RECIPE}" "step-20b-push-cleanup" "${step_finalize_cleanup}"
+
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-tdd checkpoint runtime preflight" \
+        "${step_tdd}" \
+        'amplihack hygiene artifact-guard --repo . --mode pre-publish'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-tdd checkpoint broad staging runtime preflight" \
+        "${step_tdd}" \
+        'git add -A'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-refactor-review checkpoint runtime preflight" \
+        "${step_refactor_review}" \
+        'amplihack hygiene artifact-guard --repo . --mode pre-publish'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-refactor-review broad staging runtime preflight" \
+        "${step_refactor_review}" \
+        'git add -A'
+
+    assert_recipe_text_preflights_before \
+        "workflow-precommit-test runtime preflight before pre-commit" \
+        "${PRECOMMIT_RECIPE}" \
+        'pre-commit run --all-files'
+
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-publish publish guard runtime preflight" \
+        "${step_publish_guard}" \
+        'amplihack hygiene artifact-guard --repo . --mode pre-publish'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-publish commit/push runtime preflight" \
+        "${step_publish_commit}" \
+        'amplihack hygiene artifact-guard --repo . --mode pre-publish'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-publish broad staging runtime preflight" \
+        "${step_publish_commit}" \
+        'git add -A'
+    assert_recipe_text_preflights_before \
+        "workflow-publish outside-in fix-loop runtime preflight" \
+        "${PUBLISH_RECIPE}" \
+        'git add -A && git commit -m "fix: <describe the fix found during outside-in testing>"'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-pr-review feedback runtime preflight" \
+        "${step_pr_review_feedback}" \
+        'amplihack hygiene artifact-guard --repo . --mode pre-publish'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-pr-review broad staging runtime preflight" \
+        "${step_pr_review_feedback}" \
+        'git add -A'
+
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-finalize final guard runtime preflight" \
+        "${step_finalize_guard}" \
+        'amplihack hygiene artifact-guard --repo . --mode pre-publish'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-finalize push cleanup runtime preflight" \
+        "${step_finalize_cleanup}" \
+        'amplihack hygiene artifact-guard --repo . --mode pre-publish'
+    assert_step_sources_runtime_helper_and_preflights_before \
+        "workflow-finalize broad staging runtime preflight" \
+        "${step_finalize_cleanup}" \
+        'git add -A'
+
+    assert_file_contains \
+        "workflow-worktree external placement contract" \
+        "${WORKTREE_RECIPE}" \
+        'AMPLIHACK_WORKTREE_PARENT'
+    assert_file_contains \
+        "workflow-worktree nested worktree ownership marker contract" \
+        "${WORKTREE_RECIPE}" \
+        '.amplihack-workflow-worktree'
+}
+
+create_runtime_artifact_repo() {
+    local repo="$1"
+
+    git init -b main "${repo}" >/dev/null
+    configure_identity "${repo}"
+    mkdir -p "${repo}/.claude"
+    printf 'base\n' > "${repo}/README.md"
+    printf '{"permissions":{"allow":[],"deny":[]}}\n' > "${repo}/.claude/settings.json"
+    git -C "${repo}" add README.md .claude/settings.json
+    git -C "${repo}" commit -m "base" >/dev/null
+    git -C "${repo}" checkout -b feat/issue-780-runtime-artifacts >/dev/null
+}
+
+assert_runtime_helper_exports_contract() {
+    [[ -f "${RUNTIME_ARTIFACT_HELPER}" ]] \
+        || fail "workflow_runtime_artifacts.sh must exist as the shared lifecycle helper"
+
+    (
+        # shellcheck disable=SC1090
+        source "${RUNTIME_ARTIFACT_HELPER}"
+        declare -F cleanup_known_workflow_runtime_artifacts >/dev/null
+        declare -F preflight_known_workflow_runtime_artifacts >/dev/null
+    ) || fail "workflow_runtime_artifacts.sh must export cleanup_known_workflow_runtime_artifacts and preflight_known_workflow_runtime_artifacts"
+}
+
+run_runtime_artifact_helper() {
+    local function_name="$1"
+    local repo="$2"
+
+    (
+        # shellcheck disable=SC1090
+        source "${RUNTIME_ARTIFACT_HELPER}"
+        "${function_name}" "${repo}"
+    )
+}
+
+assert_runtime_preflight_cleans_runtime_dir_and_preserves_settings() {
+    local repo="${WORK}/issue-780-runtime-cleanup-repo"
+
+    create_runtime_artifact_repo "${repo}"
+    mkdir -p "${repo}/.claude/runtime/session-123"
+    printf 'generated session state\n' > "${repo}/.claude/runtime/session-123/state.json"
+
+    run_runtime_artifact_helper preflight_known_workflow_runtime_artifacts "${repo}" \
+        || fail "preflight must clean generated .claude/runtime content"
+
+    [[ ! -e "${repo}/.claude/runtime" ]] \
+        || fail "preflight must remove empty .claude/runtime after cleaning generated runtime content"
+    [[ -f "${repo}/.claude/settings.json" ]] \
+        || fail "preflight must preserve .claude/settings.json"
+    [[ "$(git -C "${repo}" status --short .claude/settings.json)" == "" ]] \
+        || fail "preflight must not modify tracked .claude/settings.json"
+}
+
+assert_runtime_preflight_cleans_owned_nested_worktree() {
+    local repo="${WORK}/issue-780-owned-worktree-cleanup-repo"
+    local nested
+
+    create_runtime_artifact_repo "${repo}"
+    nested="${repo}/worktrees/feat-owned-runtime-artifact"
+    mkdir -p "${nested}"
+    printf 'workflow-created\n' > "${nested}/.amplihack-workflow-worktree"
+    printf 'generated nested worktree artifact\n' > "${nested}/state.txt"
+
+    run_runtime_artifact_helper preflight_known_workflow_runtime_artifacts "${repo}" \
+        || fail "preflight must clean workflow-owned nested worktrees"
+
+    [[ ! -e "${nested}" ]] \
+        || fail "preflight must remove nested worktrees only when the ownership marker is present"
+}
+
+assert_runtime_cleanup_preserves_tracked_files_by_failing_closed() {
+    local repo="${WORK}/issue-780-tracked-runtime-repo"
+
+    create_runtime_artifact_repo "${repo}"
+    mkdir -p "${repo}/.claude/runtime"
+    printf 'tracked runtime state\n' > "${repo}/.claude/runtime/tracked.txt"
+    git -C "${repo}" add .claude/runtime/tracked.txt
+    git -C "${repo}" commit -m "track runtime fixture" >/dev/null
+
+    if run_runtime_artifact_helper cleanup_known_workflow_runtime_artifacts "${repo}" >"${WORK}/tracked-runtime.out" 2>"${WORK}/tracked-runtime.err"; then
+        fail "cleanup must fail closed instead of deleting tracked files under .claude/runtime"
+    fi
+    [[ -f "${repo}/.claude/runtime/tracked.txt" ]] \
+        || fail "cleanup must preserve tracked files under .claude/runtime"
+}
+
+assert_runtime_cleanup_rejects_unmarked_nested_worktrees() {
+    local repo="${WORK}/issue-780-unmarked-worktree-repo"
+    local nested
+
+    create_runtime_artifact_repo "${repo}"
+    nested="${repo}/worktrees/unmarked-user-dir"
+    mkdir -p "${nested}"
+    printf 'user-owned untracked content\n' > "${nested}/notes.txt"
+
+    if run_runtime_artifact_helper cleanup_known_workflow_runtime_artifacts "${repo}" >"${WORK}/unmarked-worktree.out" 2>"${WORK}/unmarked-worktree.err"; then
+        fail "cleanup must fail closed on unmarked nested worktrees instead of deleting or ignoring ambiguous user content"
+    fi
+    [[ -f "${nested}/notes.txt" ]] \
+        || fail "cleanup must preserve unmarked nested worktree content"
+}
+
+assert_runtime_cleanup_rejects_non_git_targets() {
+    local not_repo="${WORK}/issue-780-not-a-git-repo"
+
+    mkdir -p "${not_repo}/.claude/runtime"
+    printf 'generated state\n' > "${not_repo}/.claude/runtime/state.json"
+
+    if run_runtime_artifact_helper cleanup_known_workflow_runtime_artifacts "${not_repo}" >"${WORK}/not-git.out" 2>"${WORK}/not-git.err"; then
+        fail "cleanup must fail closed when the target is not a real git worktree"
+    fi
+    [[ -f "${not_repo}/.claude/runtime/state.json" ]] \
+        || fail "cleanup must not delete files when repo validation fails"
+}
+
+assert_runtime_preflight_leaves_unknown_artifacts_for_artifact_guard() {
+    local repo="${WORK}/issue-780-unknown-artifact-repo"
+
+    create_runtime_artifact_repo "${repo}"
+    mkdir -p "${repo}/.claude/runtime/session-456" "${repo}/node_modules/example"
+    printf 'generated session state\n' > "${repo}/.claude/runtime/session-456/state.json"
+    printf 'unexpected dependency artifact\n' > "${repo}/node_modules/example/index.js"
+
+    run_runtime_artifact_helper preflight_known_workflow_runtime_artifacts "${repo}" \
+        || fail "preflight must clean known workflow runtime artifacts even when unknown artifacts remain"
+    [[ ! -e "${repo}/.claude/runtime" ]] \
+        || fail "preflight must remove known runtime artifacts before Artifact Guard"
+    [[ -f "${repo}/node_modules/example/index.js" ]] \
+        || fail "preflight must not remove unknown artifacts such as node_modules"
+
+    command -v amplihack >/dev/null 2>&1 \
+        || fail "amplihack CLI is required to prove unknown artifacts still fail Artifact Guard"
+    if AMPLIHACK_SKIP_AUTO_INSTALL=1 amplihack hygiene artifact-guard --repo "${repo}" --mode pre-publish >"${WORK}/unknown-artifact.out" 2>"${WORK}/unknown-artifact.err"; then
+        fail "Artifact Guard must still fail for unknown artifacts after workflow runtime preflight"
+    fi
+    if ! grep -qF 'node_modules' "${WORK}/unknown-artifact.out" "${WORK}/unknown-artifact.err"; then
+        echo "--- Artifact Guard stdout ---" >&2
+        cat "${WORK}/unknown-artifact.out" >&2
+        echo "--- Artifact Guard stderr ---" >&2
+        cat "${WORK}/unknown-artifact.err" >&2
+        fail "Artifact Guard failure must identify the remaining unknown artifact"
+    fi
+}
+
+assert_runtime_artifact_helper_dynamic_contracts() {
+    assert_runtime_helper_exports_contract
+    assert_runtime_preflight_cleans_runtime_dir_and_preserves_settings
+    assert_runtime_preflight_cleans_owned_nested_worktree
+    assert_runtime_cleanup_preserves_tracked_files_by_failing_closed
+    assert_runtime_cleanup_rejects_unmarked_nested_worktrees
+    assert_runtime_cleanup_rejects_non_git_targets
+    assert_runtime_preflight_leaves_unknown_artifacts_for_artifact_guard
+}
+
 create_origin_with_branches() {
     local base_branch="$1"
     local origin_dir="$2"
@@ -635,6 +962,8 @@ run_worktree_case() {
     local branch_name
     local worktree_path
     local worktree_sha
+    local repo_root_real
+    local worktree_real
 
     clone_case_repo "${expected_ref#origin/}" "${case_dir}" "${remove_origin_head}" "${add_master}"
 
@@ -658,8 +987,16 @@ run_worktree_case() {
     branch_name="$(grep -o '"branch_name": "[^"]*"' "${stdout_file}" | sed 's/.*": "\(.*\)"/\1/' | tail -1)"
     [[ -n "${branch_name}" ]] || fail "workflow-worktree did not emit branch_name for ${label}"
 
-    worktree_path="${case_dir}/worktrees/${branch_name}"
+    worktree_path="$(grep -o '"worktree_path": "[^"]*"' "${stdout_file}" | sed 's/.*": "\(.*\)"/\1/' | tail -1)"
+    [[ -n "${worktree_path}" ]] || fail "workflow-worktree did not emit worktree_path for ${label}"
     [[ -d "${worktree_path}" ]] || fail "workflow-worktree did not create ${worktree_path}"
+    repo_root_real="$(cd "${case_dir}" && pwd -P)"
+    worktree_real="$(cd "${worktree_path}" && pwd -P)"
+    case "${worktree_real}" in
+        "${repo_root_real}"|"${repo_root_real}"/*)
+            fail "workflow-worktree created nested worktree ${worktree_real}; expected external placement outside ${repo_root_real}"
+            ;;
+    esac
 
     worktree_sha="$(git -C "${worktree_path}" rev-parse HEAD)"
     if [[ "${worktree_sha}" != "${expected_sha}" ]]; then
@@ -811,6 +1148,12 @@ assert_yaml_step_not_fatal_false "workflow-finalize final status" "${FINALIZE_RE
 assert_yaml_recipe_step_present "smart-orchestrator routing" "${SMART_ORCHESTRATOR_RECIPE}" "smart-execute-routing" "smart-execute-routing"
 assert_yaml_step_not_fatal_false "smart-execute-routing development path" "${SMART_EXECUTE_RECIPE}" "execute-single-round-1-development"
 assert_yaml_step_not_fatal_false "smart-execute-routing adaptive development path" "${SMART_EXECUTE_RECIPE}" "adaptive-execute-development"
+
+# Issue #780 lifecycle contract: known workflow runtime artifacts are cleaned or
+# rejected before Artifact Guard and broad staging, while unknown artifacts still
+# remain Artifact Guard violations.
+assert_runtime_artifact_lifecycle_wiring
+assert_runtime_artifact_helper_dynamic_contracts
 
 # Integration coverage: non-main base branches and fallback behavior.
 extract_step_command "${WORKTREE_RECIPE}" "step-04-setup-worktree" "${STEP04}"

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -79,6 +79,13 @@ steps:
       elif [ -d "${REPO_PATH:-}" ]; then
         cd "$REPO_PATH"
       fi
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then RUNTIME_ARTIFACT_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ]; then RUNTIME_ARTIFACT_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 1; }
+      # shellcheck disable=SC1090
+      source "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
 
   - id: "step-20b-push-cleanup"
@@ -111,6 +118,13 @@ steps:
         echo "ERROR: current branch is empty; cannot push cleanup changes from detached HEAD" >&2
         exit 1
       fi
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then RUNTIME_ARTIFACT_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ]; then RUNTIME_ARTIFACT_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 1; }
+      # shellcheck disable=SC1090
+      source "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -182,6 +182,13 @@ steps:
         echo "ERROR: current branch is empty; cannot push review feedback changes from detached HEAD" >&2
         exit 1
       fi
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then RUNTIME_ARTIFACT_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ]; then RUNTIME_ARTIFACT_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 1; }
+      # shellcheck disable=SC1090
+      source "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-precommit-test.yaml
+++ b/amplifier-bundle/recipes/workflow-precommit-test.yaml
@@ -42,13 +42,19 @@ steps:
 
       2. **Install if needed:** `pre-commit install`
 
-      3. **Run all checks:**
+      3. **Preflight workflow runtime artifacts immediately before pre-commit:**
+         ```bash
+         . "${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+         preflight_known_workflow_runtime_artifacts "${WORKTREE_SETUP_WORKTREE_PATH:-.}"
+         ```
+
+      4. **Run all checks:**
          ```bash
          pre-commit run --all-files
          cargo test --workspace --locked
          ```
 
-      4. **Fix any issues:**
+      5. **Fix any issues:**
          - Linting issues
          - Formatting issues
          - Type checking errors

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -82,6 +82,13 @@ steps:
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-14g requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then RUNTIME_ARTIFACT_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ]; then RUNTIME_ARTIFACT_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 1; }
+      # shellcheck disable=SC1090
+      source "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
 
   - id: "step-15-commit-push"
@@ -120,6 +127,13 @@ steps:
       trap _emit_commit_result EXIT
       branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
       echo "--- Staging Changes ---" >&2
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then RUNTIME_ARTIFACT_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ]; then RUNTIME_ARTIFACT_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 1; }
+      # shellcheck disable=SC1090
+      source "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       echo "--- Creating Commit ---" >&2
@@ -261,6 +275,8 @@ steps:
           distribution validation when that project shape warrants it.
        5. If a test fails, diagnose, fix, commit, push, and retry up to 3 times:
           ```bash
+          . "${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+          preflight_known_workflow_runtime_artifacts .
           amplihack hygiene artifact-guard --repo . --mode pre-publish && git add -A && git commit -m "fix: <describe the fix found during outside-in testing>"
           git pull --rebase && git push
           ```

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -216,6 +216,13 @@ steps:
         exit 1
       fi
       echo "=== Checkpoint: Staging Review Feedback ==="
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then RUNTIME_ARTIFACT_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ]; then RUNTIME_ARTIFACT_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 1; }
+      # shellcheck disable=SC1090
+      source "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -339,6 +339,13 @@ steps:
       if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
         cargo fmt --all
       fi
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then RUNTIME_ARTIFACT_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      if [ ! -f "$RUNTIME_ARTIFACT_HELPER" ]; then RUNTIME_ARTIFACT_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; fi
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 1; }
+      # shellcheck disable=SC1090
+      source "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -50,6 +50,95 @@ steps:
         printf '%s' "$s"
       }
 
+      canonical_dir() {
+        local path="$1"
+        mkdir -p "$path"
+        (cd "$path" && pwd -P)
+      }
+
+      branch_path_slug() {
+        local branch="$1"
+        local slug
+        local hash
+        slug="$(printf '%s' "$branch" | tr -c 'A-Za-z0-9._-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+        [ -n "$slug" ] || slug="worktree"
+        hash="$(printf '%s' "$branch" | git hash-object --stdin | cut -c1-8)"
+        printf '%s-%s\n' "$slug" "$hash"
+      }
+
+      resolve_worktree_path() {
+        local branch="$1"
+        local slug="$2"
+        local repo_root
+        local repo_parent
+        local repo_parent_name
+        local parent
+        local parent_real
+        local git_dir
+
+        repo_root="$(git rev-parse --show-toplevel)"
+        repo_root="$(cd "$repo_root" && pwd -P)"
+        repo_parent="$(dirname "$repo_root")"
+        repo_parent_name="$(basename "$repo_parent")"
+
+        if [ -n "${AMPLIHACK_WORKTREE_PARENT:-}" ]; then
+          case "$AMPLIHACK_WORKTREE_PARENT" in
+            /*) parent="$AMPLIHACK_WORKTREE_PARENT" ;;
+            *) parent="$repo_root/$AMPLIHACK_WORKTREE_PARENT" ;;
+          esac
+        elif [ "$repo_parent_name" = "worktrees" ]; then
+          parent="$repo_parent"
+        else
+          parent="$repo_parent/worktrees"
+        fi
+
+        if parent_real="$(canonical_dir "$parent")"; then
+          case "$parent_real" in
+            "$repo_root"|"$repo_root"/*)
+              if [ "${AMPLIHACK_ALLOW_NESTED_WORKTREE:-}" != "1" ]; then
+                echo "ERROR: resolved workflow worktree parent '$parent_real' is inside repository '$repo_root'; set AMPLIHACK_WORKTREE_PARENT to an external directory or AMPLIHACK_ALLOW_NESTED_WORKTREE=1 for explicit compatibility fallback." >&2
+                return 1
+              fi
+              ;;
+          esac
+          git_dir="$(git rev-parse --absolute-git-dir)"
+          git_dir="$(cd "$git_dir" && pwd -P)"
+          case "$parent_real" in
+            "$git_dir"|"$git_dir"/*)
+              echo "ERROR: resolved workflow worktree parent '$parent_real' is inside git dir '$git_dir'; refusing unsafe placement." >&2
+              return 1
+              ;;
+          esac
+          if [ ! -w "$parent_real" ]; then
+            echo "ERROR: resolved workflow worktree parent '$parent_real' is not writable." >&2
+            return 1
+          fi
+          if [ "${AMPLIHACK_ALLOW_NESTED_WORKTREE:-}" != "1" ]; then
+            printf '%s/%s\n' "$parent_real" "$slug"
+            return 0
+          fi
+        elif [ "${AMPLIHACK_ALLOW_NESTED_WORKTREE:-}" != "1" ]; then
+          echo "ERROR: could not create external workflow worktree parent '$parent'." >&2
+          return 1
+        fi
+
+        echo "WARNING: AMPLIHACK_ALLOW_NESTED_WORKTREE=1 set; using nested compatibility worktree for '$branch'." >&2
+        printf '%s/worktrees/%s\n' "$repo_root" "$slug"
+      }
+
+      mark_nested_workflow_worktree_if_needed() {
+        local path="$1"
+        local repo_root
+
+        repo_root="$(git rev-parse --show-toplevel)"
+        repo_root="$(cd "$repo_root" && pwd -P)"
+        case "$(cd "$path" && pwd -P)" in
+          "$repo_root"/worktrees/*)
+            touch "$path/.amplihack-workflow-worktree"
+            ;;
+        esac
+      }
+
       # ========================================================================
       # NEW (#342): Existing-branch / PR targeting path.
       # When EXISTING_BRANCH or PR_NUMBER is set, reuse an existing branch
@@ -125,9 +214,7 @@ steps:
             WORKTREE_PATH="$REPO_PATH"
             echo "INFO: Caller already on branch '$BRANCH_NAME'; using REPO_PATH as worktree." >&2
           else
-            # SECURITY: WORKTREE_PATH construction is safe because BRANCH_NAME
-            # has passed git check-ref-format above (rejects .., leading -, etc.).
-            WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+            WORKTREE_PATH="$(resolve_worktree_path "$BRANCH_NAME" "$(branch_path_slug "$BRANCH_NAME")")"
             if [ -d "$WORKTREE_PATH" ]; then
               # Issue #642: worktree dir exists from a prior run. If it's a
               # valid git worktree on the right branch, reuse it. Otherwise
@@ -136,20 +223,24 @@ steps:
               if [ "$WT_BRANCH" = "$BRANCH_NAME" ]; then
                 echo "INFO: Reusing existing worktree directory at '$WORKTREE_PATH' (branch matches)." >&2
               else
-                echo "INFO: Removing stale worktree at '$WORKTREE_PATH' (was '$WT_BRANCH', need '$BRANCH_NAME')." >&2
-                git worktree remove --force "$WORKTREE_PATH" >&2 2>/dev/null || rm -rf "$WORKTREE_PATH"
+                echo "INFO: Removing stale git worktree at '$WORKTREE_PATH' (was '$WT_BRANCH', need '$BRANCH_NAME')." >&2
+                git worktree remove --force "$WORKTREE_PATH" >&2 2>/dev/null || { echo "ERROR: refusing to remove non-worktree directory at '$WORKTREE_PATH'; inspect it manually." >&2; exit 1; }
                 if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
                   git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+                  mark_nested_workflow_worktree_if_needed "$WORKTREE_PATH"
                 elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
                   git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+                  mark_nested_workflow_worktree_if_needed "$WORKTREE_PATH"
                 fi
               fi
             elif git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
               # Local branch exists: attach without -b (safe re-attach).
               git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+              mark_nested_workflow_worktree_if_needed "$WORKTREE_PATH"
             elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
               # Remote-only: create local tracking branch on attach.
               git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+              mark_nested_workflow_worktree_if_needed "$WORKTREE_PATH"
             else
               echo "ERROR: branch '$BRANCH_NAME' not found locally or on origin." >&2
               exit 1
@@ -258,7 +349,7 @@ steps:
           BRANCH_NAME="feat/task-unnamed-$(date +%s)"
         fi
       fi
-      WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+      WORKTREE_PATH="$(resolve_worktree_path "$BRANCH_NAME" "$(branch_path_slug "$BRANCH_NAME")")"
 
       echo "Branch: ${BRANCH_NAME}" >&2
       echo "Worktree: ${WORKTREE_PATH}" >&2
@@ -305,11 +396,13 @@ steps:
         else
           echo "INFO: Branch '${BRANCH_NAME}' exists (clean) but worktree is missing — adding worktree without -b." >&2
           git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}" >&2
+          mark_nested_workflow_worktree_if_needed "$WORKTREE_PATH"
         fi
         CREATED=true
       else
         echo "INFO: Creating new branch and worktree." >&2
         git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" "${BASE_REF}" >&2
+        mark_nested_workflow_worktree_if_needed "$WORKTREE_PATH"
         CREATED=true
       fi
 

--- a/amplifier-bundle/tools/workflow_runtime_artifacts.sh
+++ b/amplifier-bundle/tools/workflow_runtime_artifacts.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Shared lifecycle helper for workflow-generated runtime artifacts.
+#
+# Artifact Guard remains strict and read-only. This helper only removes the
+# workflow-owned artifacts that recipes themselves may generate before guarded
+# lifecycle phases run.
+
+workflow_runtime_artifacts_error() {
+  echo "ERROR: workflow runtime artifact cleanup: $*" >&2
+}
+
+workflow_runtime_artifacts_info() {
+  echo "INFO: workflow runtime artifact cleanup: $*" >&2
+}
+
+workflow_runtime_artifacts_resolve_repo() {
+  local candidate="${1:-}"
+  local top
+
+  if [ -z "$candidate" ]; then
+    candidate="${WORKTREE_SETUP_WORKTREE_PATH:-}"
+  fi
+  if [ -z "$candidate" ]; then
+    candidate="${RECIPE_VAR_worktree_setup__worktree_path:-}"
+  fi
+  if [ -z "$candidate" ]; then
+    candidate="${REPO_PATH:-}"
+  fi
+  if [ -z "$candidate" ]; then
+    candidate="."
+  fi
+
+  if [ "$candidate" = "/" ]; then
+    workflow_runtime_artifacts_error "refusing to use '/' as the cleanup target"
+    return 1
+  fi
+  if [ ! -d "$candidate" ]; then
+    workflow_runtime_artifacts_error "target is not a directory: $candidate"
+    return 1
+  fi
+  if ! top="$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null)"; then
+    workflow_runtime_artifacts_error "target is not a git worktree: $candidate"
+    return 1
+  fi
+  if [ -z "$top" ] || [ "$top" = "/" ]; then
+    workflow_runtime_artifacts_error "resolved git top-level is unsafe: ${top:-<empty>}"
+    return 1
+  fi
+  if ! top="$(cd "$top" && pwd -P)"; then
+    workflow_runtime_artifacts_error "could not canonicalize git top-level for $candidate"
+    return 1
+  fi
+  if [ "$top" = "/" ]; then
+    workflow_runtime_artifacts_error "refusing to clean repository root '/'"
+    return 1
+  fi
+
+  printf '%s\n' "$top"
+}
+
+workflow_runtime_artifacts_canonical_existing() {
+  local path="$1"
+
+  if [ ! -e "$path" ]; then
+    workflow_runtime_artifacts_error "cannot canonicalize missing path: $path"
+    return 1
+  fi
+  if [ -d "$path" ] && [ ! -L "$path" ]; then
+    (cd "$path" && pwd -P)
+  else
+    local parent
+    parent="$(dirname "$path")"
+    printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$(basename "$path")"
+  fi
+}
+
+workflow_runtime_artifacts_assert_inside_repo() {
+  local repo="$1"
+  local path="$2"
+  local label="$3"
+  local canonical
+
+  canonical="$(workflow_runtime_artifacts_canonical_existing "$path")" || return 1
+  case "$canonical" in
+    "$repo"|"$repo"/*) return 0 ;;
+    *)
+      workflow_runtime_artifacts_error "$label escapes repository root: $canonical (repo: $repo)"
+      return 1
+      ;;
+  esac
+}
+
+workflow_runtime_artifacts_tracked_under() {
+  local repo="$1"
+  local rel="$2"
+
+  git -C "$repo" ls-files -- "$rel"
+}
+
+workflow_runtime_artifacts_cleanup_runtime_dir() {
+  local repo="$1"
+  local runtime="$repo/.claude/runtime"
+  local tracked
+
+  [ -e "$runtime" ] || return 0
+  if [ -L "$runtime" ]; then
+    workflow_runtime_artifacts_error ".claude/runtime is a symlink; refusing cleanup"
+    return 1
+  fi
+  if [ ! -d "$runtime" ]; then
+    workflow_runtime_artifacts_error ".claude/runtime exists but is not a directory"
+    return 1
+  fi
+  workflow_runtime_artifacts_assert_inside_repo "$repo" "$runtime" ".claude/runtime" || return 1
+
+  tracked="$(workflow_runtime_artifacts_tracked_under "$repo" ".claude/runtime")"
+  if [ -n "$tracked" ]; then
+    workflow_runtime_artifacts_error "tracked files exist under .claude/runtime; refusing to delete tracked content"
+    printf '%s\n' "$tracked" | sed 's/^/  tracked: /' >&2
+    return 1
+  fi
+
+  workflow_runtime_artifacts_info "removing generated .claude/runtime"
+  rm -rf -- "$runtime"
+}
+
+workflow_runtime_artifacts_path_is_owned_or_ancestor() {
+  local path="$1"
+  shift
+  local owner
+
+  for owner in "$@"; do
+    case "$path" in
+      "$owner"|"$owner"/*) return 0 ;;
+    esac
+    if [ -d "$path" ]; then
+      case "$owner" in
+        "$path"/*) return 0 ;;
+      esac
+    fi
+  done
+  return 1
+}
+
+workflow_runtime_artifacts_cleanup_nested_worktrees() {
+  local repo="$1"
+  local worktrees="$repo/worktrees"
+  local tracked
+  local marker
+  local owner
+  local path
+  local -a markers=()
+  local -a owners=()
+
+  [ -e "$worktrees" ] || return 0
+  if [ -L "$worktrees" ]; then
+    workflow_runtime_artifacts_error "worktrees is a symlink; refusing cleanup"
+    return 1
+  fi
+  if [ ! -d "$worktrees" ]; then
+    workflow_runtime_artifacts_error "worktrees exists but is not a directory"
+    return 1
+  fi
+  workflow_runtime_artifacts_assert_inside_repo "$repo" "$worktrees" "worktrees" || return 1
+
+  tracked="$(workflow_runtime_artifacts_tracked_under "$repo" "worktrees")"
+  if [ -n "$tracked" ]; then
+    workflow_runtime_artifacts_error "tracked files exist under worktrees; refusing to delete tracked content"
+    printf '%s\n' "$tracked" | sed 's/^/  tracked: /' >&2
+    return 1
+  fi
+
+  while IFS= read -r marker; do
+    markers+=("$marker")
+    owner="$(dirname "$marker")"
+    if [ "$owner" = "$worktrees" ]; then
+      workflow_runtime_artifacts_error "ownership marker at worktrees root is unsafe; marker must live inside a nested worktree"
+      return 1
+    fi
+    if [ -L "$owner" ]; then
+      workflow_runtime_artifacts_error "marked nested worktree is a symlink: ${owner#"$repo"/}"
+      return 1
+    fi
+    workflow_runtime_artifacts_assert_inside_repo "$repo" "$owner" "marked nested worktree" || return 1
+    owners+=("$owner")
+  done < <(find "$worktrees" -name ".amplihack-workflow-worktree" -type f -print)
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if [ "${#owners[@]}" -gt 0 ] && workflow_runtime_artifacts_path_is_owned_or_ancestor "$path" "${owners[@]}"; then
+      continue
+    fi
+    workflow_runtime_artifacts_error "unmarked nested worktree content remains under worktrees: ${path#"$repo"/}"
+    return 1
+  done < <(find "$worktrees" -mindepth 1 -print)
+
+  for owner in "${owners[@]}"; do
+    workflow_runtime_artifacts_info "removing workflow-owned nested worktree ${owner#"$repo"/}"
+    rm -rf -- "$owner"
+  done
+
+  if [ -d "$worktrees" ]; then
+    find "$worktrees" -depth -type d -empty -exec rmdir {} +
+  fi
+}
+
+cleanup_known_workflow_runtime_artifacts() {
+  local repo
+
+  repo="$(workflow_runtime_artifacts_resolve_repo "${1:-}")" || return 1
+  workflow_runtime_artifacts_cleanup_runtime_dir "$repo" || return 1
+  workflow_runtime_artifacts_cleanup_nested_worktrees "$repo" || return 1
+}
+
+preflight_known_workflow_runtime_artifacts() {
+  local repo
+
+  repo="$(workflow_runtime_artifacts_resolve_repo "${1:-}")" || return 1
+  cleanup_known_workflow_runtime_artifacts "$repo" || return 1
+
+  if [ -e "$repo/.claude/runtime" ]; then
+    workflow_runtime_artifacts_error ".claude/runtime remains after cleanup"
+    return 1
+  fi
+  if [ -d "$repo/worktrees" ] && find "$repo/worktrees" -name ".amplihack-workflow-worktree" -type f -print -quit | grep -q .; then
+    workflow_runtime_artifacts_error "marked workflow nested worktrees remain after cleanup"
+    return 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  case "${1:-preflight}" in
+    cleanup)
+      shift
+      cleanup_known_workflow_runtime_artifacts "${1:-}"
+      ;;
+    preflight)
+      shift || true
+      preflight_known_workflow_runtime_artifacts "${1:-}"
+      ;;
+    *)
+      echo "Usage: $0 [cleanup|preflight] [repo]" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/docs/artifact-guard.md
+++ b/docs/artifact-guard.md
@@ -10,7 +10,7 @@ moves, unstages, or rewrites files.
 
 ## Contents
 
-- [Planned behavior](#planned-behavior)
+- [Behavior](#behavior)
 - [Command-line interface](#command-line-interface)
 - [Default prohibited rules](#default-prohibited-rules)
 - [Allowlist configuration](#allowlist-configuration)
@@ -40,7 +40,7 @@ cache directories when those paths indicate parent-worktree pollution.
 `target/` directory in the repository, and the guard must not make ordinary
 `cargo test`, `cargo clippy`, or pre-commit usage hostile. By default:
 
-| `target/` source | Planned result |
+| `target/` source | Result |
 | --- | --- |
 | Staged | Violation |
 | Tracked | Violation |
@@ -151,7 +151,7 @@ examples/minimal-node-project/node_modules/.package-lock.json
 
 Matching semantics:
 
-| Rule | Planned behavior |
+| Rule | Behavior |
 | --- | --- |
 | Path root | Entries are relative to the repository root |
 | Separators | `/` only; Windows-style `\` separators are rejected |
@@ -194,7 +194,7 @@ across the whole repository.
 
 ## Workflow and pre-commit coverage
 
-Artifact Guard will run before every broad staging operation in the bundled
+Artifact Guard runs before every broad staging operation in the bundled
 recipes, not just publish and finalize. The initial guarded recipe set is every
 recipe that currently invokes `git add -A`:
 
@@ -211,7 +211,7 @@ recipe that currently invokes `git add -A`:
 Future recipe changes must preserve the rule: any new `git add -A` or equivalent
 broad-staging step needs an Artifact Guard gate immediately before it.
 
-The planned pre-commit hook is a full repository scan:
+The pre-commit hook is a full repository scan:
 
 ```yaml
 - id: artifact-guard
@@ -237,6 +237,20 @@ The checked-in pre-commit Cargo hooks set `CARGO_TARGET_DIR` under
 `${TMPDIR:-/tmp}` so running the guard, clippy, or tests from hooks does not
 recreate Cargo build output inside the parent worktree.
 
+Bundled workflows run
+[`preflight_known_workflow_runtime_artifacts`](reference/workflow-runtime-artifacts.md)
+immediately before guard-sensitive phases. That preflight removes only known
+workflow-owned `.claude/runtime/` output and marked nested workflow worktrees.
+Artifact Guard still blocks unexpected artifacts and remains read-only.
+
+`workflow-worktree.yaml` should create new workflow worktrees outside the active
+repository root, normally in a sibling `worktrees` directory. Nested
+`<repo>/worktrees/...` placement is a compatibility path only; if it is used,
+it must be explicitly enabled with `AMPLIHACK_ALLOW_NESTED_WORKTREE=1`, the
+nested worktree must carry `.amplihack-workflow-worktree`, and cleanup must
+still fail closed on symlinks, tracked markers, tracked content, or unmarked
+sibling directories.
+
 ## Output isolation
 
 The preferred fix for a violation is output isolation, not allowlisting.
@@ -251,6 +265,7 @@ These locations are intentionally not prohibited by default:
 <repo>/.amplihack/generated/
 <git-common-dir>/.claude/runtime/
 /tmp/amplihack-<purpose>-<id>/
+<repo-parent>/worktrees/<branch-path-slug>/
 ```
 
 Use `CARGO_TARGET_DIR` for workflow-owned Rust builds that need to avoid the
@@ -350,6 +365,20 @@ If the guard reports `node_modules/`, `.claude/runtime/`, or another
 ignored-present artifact, relocate or remove the local output. Do not treat
 `.gitignore` as approval to keep parent-worktree pollution.
 
+For workflow-generated `.claude/runtime/` or marked nested workflow worktrees,
+use the workflow runtime artifact preflight helper before rerunning the guarded
+phase:
+
+```bash
+. ./amplifier-bundle/tools/workflow_runtime_artifacts.sh
+preflight_known_workflow_runtime_artifacts .
+amplihack hygiene artifact-guard --repo . --mode all
+```
+
+If preflight refuses to clean a path, inspect the reported reason instead of
+adding an allowlist entry. Tracked files, symlinks, and unmarked nested
+worktrees require explicit human cleanup.
+
 For an intentional fixture, add the narrowest allowlist entry that preserves the
 test:
 
@@ -377,6 +406,8 @@ proper output placement.
 
 ## Related documentation
 
+- [Workflow Runtime Artifacts Reference](reference/workflow-runtime-artifacts.md)
+- [Preflight Workflow Runtime Artifacts](howto/preflight-workflow-runtime-artifacts.md)
 - [Recipe CLI Reference](reference/recipe-cli-reference.md)
 - [Pre-Commit Diagnostics](claude/agents/amplihack/specialized/pre-commit-diagnostic.md)
 - [Developing amplihack](DEVELOPING_AMPLIHACK.md)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,6 +34,7 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
   the post-v0.9.77 issue-658 branch as the concrete example.
 - [Recipe Subprocess and Hook Input Contracts](../howto/validate-recipe-subprocess-hook-contract.md) — recipe-runner child environment and hook input compatibility contract; see the [recipe environment reference](../reference/recipe-executor-environment.md#recipe-runner-subprocess-launch) and [hook input contract](../reference/hook-specifications.md#hook-input-json-contract).
 - [Provider-Aware Workflow Tracking](dual-provider-workflow.md) — route workflow-prep tracking by GitHub, Azure DevOps, or local/unsupported remotes before provider issue commands run.
+- [Workflow Runtime Artifacts](../reference/workflow-runtime-artifacts.md) — isolate or clean workflow-generated `.claude/runtime` and marked nested worktrees before strict Artifact Guard gates.
 
 ## GitHub Distribution
 

--- a/docs/howto/preflight-workflow-runtime-artifacts.md
+++ b/docs/howto/preflight-workflow-runtime-artifacts.md
@@ -1,0 +1,175 @@
+---
+title: "Preflight Workflow Runtime Artifacts"
+description: "How to use the workflow runtime artifact helper before Artifact Guard, staging, pre-commit, publish, and finalization."
+last_updated: 2026-06-18
+review_schedule: quarterly
+owner: amplihack
+doc_type: howto
+---
+
+# Preflight Workflow Runtime Artifacts
+
+> [Home](../index.md) > How-To > Preflight Workflow Runtime Artifacts
+
+Use this guide when editing bundled recipes that run checkpoints, broad staging,
+pre-commit, publish, or finalization. The workflow runtime artifact helper
+removes known generated leftovers before strict Artifact Guard gates run.
+
+## Before you start
+
+You need:
+
+- a real git worktree
+- the bundled helper at `amplifier-bundle/tools/workflow_runtime_artifacts.sh`
+- Artifact Guard available through `amplihack hygiene artifact-guard`
+
+Do not add `.claude/runtime/` or `worktrees/` to the Artifact Guard allowlist.
+The fix is lifecycle cleanup and output isolation, not weakening enforcement.
+
+## 1. Source the helper
+
+In a recipe shell step, source the helper before calling its functions:
+
+```bash
+. "$AMPLIHACK_HOME/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+```
+
+When `AMPLIHACK_HOME` is not available in a local development shell, source the
+checkout-relative file:
+
+```bash
+. ./amplifier-bundle/tools/workflow_runtime_artifacts.sh
+```
+
+## 2. Preflight the active worktree
+
+Call preflight with the canonical worktree path when the recipe has one:
+
+```bash
+preflight_known_workflow_runtime_artifacts "$WORKTREE_SETUP_WORKTREE_PATH"
+```
+
+When the path is omitted, the helper resolves the repository from recipe context
+variables and then from the current directory:
+
+```bash
+preflight_known_workflow_runtime_artifacts
+```
+
+Use the explicit argument when possible. It makes the guarded target obvious in
+logs and avoids relying on ambient `cwd`.
+
+## 3. Run Artifact Guard after preflight
+
+Place Artifact Guard immediately after preflight:
+
+```bash
+preflight_known_workflow_runtime_artifacts "$repo"
+amplihack hygiene artifact-guard --repo "$repo" --mode all
+```
+
+This order means known workflow-generated `.claude/runtime/` and marked nested
+workflow worktrees are removed first. Unknown artifacts are still reported by
+Artifact Guard.
+
+## 4. Stage only after both gates pass
+
+For broad staging, the safe sequence is:
+
+```bash
+preflight_known_workflow_runtime_artifacts "$repo"
+amplihack hygiene artifact-guard --repo "$repo" --mode all
+git -C "$repo" add -A
+```
+
+Do not insert generated-output steps between Artifact Guard and `git add -A`.
+If a command can create runtime output, run preflight and Artifact Guard again
+before staging.
+
+## 5. Create new workflow worktrees outside the active repo
+
+`workflow-worktree.yaml` should create new branch worktrees outside the active
+commit worktree. The default parent is a sibling `worktrees` directory:
+
+```text
+../worktrees/<branch-path-slug>
+```
+
+When the active repository is already inside a `worktrees` directory, create the
+new worktree as a sibling of the active repository:
+
+```text
+../<branch-path-slug>
+```
+
+Set `AMPLIHACK_WORKTREE_PARENT` only when a recipe or test needs an explicit
+external parent. The resolved final path must still be outside the active
+repository root. If no safe external parent is available, fail the workflow
+instead of falling back to `"$repo/worktrees/..."`.
+
+## 6. Mark compatibility nested worktrees
+
+`workflow-worktree.yaml` avoids creating nested worktrees inside commit
+worktrees. Creating a new nested worktree is allowed only for explicit emergency
+compatibility runs with `AMPLIHACK_ALLOW_NESTED_WORKTREE=1`. If that fallback is
+used, create the ownership marker at the nested worktree root:
+
+```bash
+touch "$repo/worktrees/$branch_slug/.amplihack-workflow-worktree"
+```
+
+The marker is the cleanup proof. Without it, cleanup fails closed and leaves the
+directory in place for inspection.
+
+Do not track the marker. A tracked marker or tracked nested worktree content
+turns the directory into source-controlled content, so cleanup must refuse to
+delete it.
+
+## 7. Keep user files out of cleanup paths
+
+The cleanup helper only owns these generated paths:
+
+```text
+.claude/runtime/
+worktrees/<marked-workflow-worktree>/
+```
+
+Do not place user notes, local scratch files, checked-in fixtures, or manual
+worktrees under those paths. Use a project-specific location outside the commit
+worktree, an ignored `.amplihack/` runtime path, or a normal branch worktree
+outside the active commit worktree.
+
+## Recipe placement checklist
+
+Add preflight immediately before these phases:
+
+| Phase | Required placement |
+| --- | --- |
+| Checkpoint | Before checkpoint Artifact Guard. |
+| Broad staging | Before Artifact Guard and `git add -A`. |
+| Pre-commit | Immediately before `pre-commit run`. |
+| Publish | Before publish Artifact Guard and before commit/push staging. |
+| Finalization | Before final Artifact Guard, final staging, and push cleanup. |
+
+The placement must be local to the guarded action. A preflight several steps
+earlier is not sufficient because nested agents can create runtime output after
+that point.
+
+## Troubleshooting
+
+| Symptom | Meaning | Action |
+| --- | --- | --- |
+| `not a git worktree` | The target path cannot be validated with `git rev-parse --show-toplevel`. | Pass the real repository or workflow worktree path. |
+| `.claude/runtime is a symlink` | Cleanup refuses symlink targets. | Remove the symlink after confirming it is not needed, then rerun. |
+| `tracked files under .claude/runtime` | Cleanup refuses to delete tracked content. | Inspect the tracked paths and remove or relocate them intentionally. |
+| `worktrees is a symlink` | Cleanup refuses to traverse a symlinked worktree parent. | Replace it with a real directory only after confirming ownership. |
+| `worktrees/<name> is a symlink` | Cleanup refuses symlinked nested worktrees. | Remove or relocate the symlink manually after inspection. |
+| `unmarked nested worktree` | `worktrees/<name>/` lacks `.amplihack-workflow-worktree`. | Add the marker only if the workflow created it, otherwise move or remove the directory manually. |
+| `tracked marker or nested content` | Cleanup refuses to delete source-controlled content under `worktrees/`. | Remove the tracked files through normal Git changes or move them outside cleanup paths. |
+| Artifact Guard still reports `node_modules/` | Preflight is not a general artifact cleaner. | Remove or relocate the dependency tree; do not allowlist it broadly. |
+
+## Related documentation
+
+- [Workflow Runtime Artifacts Reference](../reference/workflow-runtime-artifacts.md)
+- [Artifact Guard](../artifact-guard.md)
+- [Workflow Publish and Finalize Resilience](../operations/workflow-resilience.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,6 +140,7 @@ amplihack copilot
 - [Profile Management](PROFILE_MANAGEMENT.md) - Multiple environment configurations
 - [Hook Configuration](HOOK_CONFIGURATION_GUIDE.md) - Customize framework behavior
 - [Artifact Guard](artifact-guard.md) - Guard for broad staging, pre-commit, and workflow publication artifacts
+- [Workflow Runtime Artifacts](reference/workflow-runtime-artifacts.md) - Cleanup and preflight contract for workflow-generated `.claude/runtime` and marked nested worktrees
 - [Memory Configuration Consent](features/memory-consent-prompt.md) - Intelligent memory settings with timeout protection
 - [Verify .claude/ Staging](howto/verify-claude-staging.md) - Check that framework files are properly staged
 - [Verify Runtime Asset Resolution](howto/verify-runtime-asset-resolution.md) - Check helper, session, hooks, and multitask asset parity
@@ -267,6 +268,9 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [How to Configure Workflow Publish Import Validation](howto/configure-workflow-publish-import-validation.md) - Review the manifest, root-boundary, and scoped-validator behavior
 - [Tutorial: Workflow Publish Import Validation](tutorials/workflow-publish-import-validation.md) - Walk through the scoped publish-validation flow
 - [Workflow Publish Import Validation Reference](reference/workflow-publish-import-validation.md) - Manifest format, root-resolution rules, and `--files-from` semantics
+- [Workflow Runtime Artifacts Reference](reference/workflow-runtime-artifacts.md) - Shared helper API, safety contract, and lifecycle placement for generated workflow artifacts
+- [Preflight Workflow Runtime Artifacts](howto/preflight-workflow-runtime-artifacts.md) - Use cleanup/preflight before Artifact Guard, broad staging, pre-commit, publish, and finalization
+- [Tutorial: Workflow Runtime Artifact Isolation](tutorials/workflow-runtime-artifact-isolation.md) - Practice cleanup of `.claude/runtime` and marked nested worktrees while preserving strict Artifact Guard failures
 - [Workflow Execution Guardrails](features/workflow-execution-guardrails.md) - Canonical execution roots, exact GitHub identity checks, and observer-only stall detection
 - [How to Configure Workflow Execution Guardrails](howto/configure-workflow-execution-guardrails.md) - Supply `expected_gh_account`, inspect `execution_root`, and troubleshoot failures
 - [Tutorial: Workflow Execution Guardrails](tutorials/workflow-execution-guardrails.md) - End-to-end walkthrough of the guarded workflow contract

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -78,6 +78,8 @@ Complete documentation for using the Recipe Runner:
 - **[How to Diagnose Workflow Terminal-State Failures](../howto/diagnose-workflow-terminal-state.md)** - Recovery guide for missing terminal evidence after planning, analysis, design, or worktree-only execution
 - **[Tutorial: Workflow Terminal-State Closure](../tutorials/workflow-terminal-state-closure.md)** - Walk through successful evidence, planning-only failure, and rerun behavior
 - **[Scoped Workflow Closure](../reference/scoped-workflow-closure.md)** - Persisted PR, process, and workstream ownership contract for default-workflow closure
+- **[Workflow Runtime Artifacts Reference](../reference/workflow-runtime-artifacts.md)** - Shared cleanup/preflight helper contract for generated `.claude/runtime` and marked nested workflow worktrees
+- **[Preflight Workflow Runtime Artifacts](../howto/preflight-workflow-runtime-artifacts.md)** - How to place preflight before Artifact Guard, broad staging, pre-commit, publish, and finalization
 
 ## Why It Exists
 

--- a/docs/reference/workflow-runtime-artifacts.md
+++ b/docs/reference/workflow-runtime-artifacts.md
@@ -1,0 +1,298 @@
+---
+title: "Workflow Runtime Artifacts Reference"
+description: "Reference contract for isolating and preflighting workflow-generated .claude/runtime and nested worktree artifacts before Artifact Guard gates."
+last_updated: 2026-06-18
+review_schedule: quarterly
+owner: amplihack
+doc_type: reference
+---
+
+# Workflow Runtime Artifacts Reference
+
+> [Home](../index.md) > Reference > Workflow Runtime Artifacts
+
+Workflow runtime artifact handling keeps generated agent runtime output out of
+commit worktrees before strict Artifact Guard gates run. The cleanup helper
+removes only known workflow-owned artifacts and fails closed when it cannot
+prove a target is safe.
+
+Artifact Guard remains the enforcement boundary. It is still read-only, strict,
+and responsible for blocking unexpected artifacts.
+
+## Contents
+
+- [Artifact classes](#artifact-classes)
+- [Helper file](#helper-file)
+- [Repository resolution](#repository-resolution)
+- [External workflow worktree placement](#external-workflow-worktree-placement)
+- [Safety contract](#safety-contract)
+- [Function reference](#function-reference)
+- [Recipe lifecycle coverage](#recipe-lifecycle-coverage)
+- [Configuration](#configuration)
+- [Regression expectations](#regression-expectations)
+
+## Artifact classes
+
+The workflow helper recognizes two generated artifact classes:
+
+| Artifact | Path | Cleanup rule |
+| --- | --- | --- |
+| Agent runtime output | `.claude/runtime/` | Remove the runtime directory and its untracked or ignored generated contents after verifying the path is not tracked and not a symlink. Never remove `.claude/` itself. |
+| Legacy workflow-created nested worktrees | `worktrees/<name>/` | Remove only untracked or ignored nested worktree directories that contain `.amplihack-workflow-worktree`. Reject unmarked or tracked content. |
+
+The helper does not remove dependency trees, build outputs, caches, logs outside
+the recognized paths, or arbitrary untracked files. Those remain Artifact Guard
+violations when prohibited.
+
+## Helper file
+
+Recipes source the shared helper from:
+
+```text
+amplifier-bundle/tools/workflow_runtime_artifacts.sh
+```
+
+The helper exposes these shell functions:
+
+```bash
+cleanup_known_workflow_runtime_artifacts [repo]
+preflight_known_workflow_runtime_artifacts [repo]
+```
+
+Both functions write concise status and error messages to stderr. They do not
+print file contents.
+
+## Repository resolution
+
+When a function receives an explicit `repo` argument, that value is authoritative.
+When the argument is omitted, the helper resolves the target repository using
+this precedence order:
+
+| Precedence | Source |
+| --- | --- |
+| 1 | explicit function argument |
+| 2 | `WORKTREE_SETUP_WORKTREE_PATH` |
+| 3 | `RECIPE_VAR_worktree_setup__worktree_path` |
+| 4 | `REPO_PATH` |
+| 5 | current working directory |
+
+After selecting a candidate, the helper runs:
+
+```bash
+git -C "$repo" rev-parse --show-toplevel
+```
+
+The resolved top level becomes the cleanup root. Empty paths, `/`, non-git
+directories, and paths that cannot be resolved to a real git worktree fail with a
+visible error.
+
+## External workflow worktree placement
+
+`workflow-worktree.yaml` must avoid creating new worktrees inside the active
+commit worktree. New workflow worktrees use this placement contract:
+
+1. Reuse an existing Git worktree for the target branch when `git worktree list`
+   reports one.
+2. Use `REPO_PATH` directly when the caller is already on the target branch.
+3. Otherwise create the new worktree outside the resolved repository root.
+
+The external parent directory is resolved in this order:
+
+| Precedence | Parent directory |
+| --- | --- |
+| 1 | `AMPLIHACK_WORKTREE_PARENT`, when set. Relative values resolve from the resolved repository root. |
+| 2 | If the resolved repository root's parent directory is named `worktrees`, that parent directory. |
+| 3 | Otherwise, `../worktrees` relative to the resolved repository root. |
+
+The final worktree path is:
+
+```text
+<external-parent>/<branch-path-slug>
+```
+
+`branch-path-slug` is derived from the validated Git branch name by replacing
+every character outside `[A-Za-z0-9._-]` with `-`, collapsing repeated `-`, and
+appending a short deterministic hash when needed to avoid collisions. The branch
+name itself remains unchanged for Git operations.
+
+If the external parent cannot be created, is not writable, resolves inside the
+active repository root, or would place the worktree under `.git/`, the workflow
+fails closed. It must not silently fall back to `REPO_PATH/worktrees/...`.
+
+Nested placement is only a compatibility path for worktrees that already exist
+or for an explicitly requested emergency fallback with
+`AMPLIHACK_ALLOW_NESTED_WORKTREE=1`. Any workflow-created nested worktree under
+`worktrees/<name>/` must contain
+`.amplihack-workflow-worktree` at the nested worktree root before any later
+cleanup can remove it. Without that explicit variable, external placement
+failure is a hard workflow failure.
+
+## Safety contract
+
+Cleanup is fail-closed. Before deleting anything, the helper verifies:
+
+1. The target is a real git worktree or repository.
+2. The resolved repository root is non-empty and not `/`.
+3. Cleanup targets are inside the resolved repository root.
+4. Cleanup targets are not symlinks.
+5. No tracked files exist under `.claude/runtime/` or `worktrees/`.
+6. Nested `worktrees/<name>/` directories contain `.amplihack-workflow-worktree`
+   before they are removed.
+
+If any check fails, cleanup exits nonzero and leaves the repository unchanged as
+far as the failing target is concerned. The workflow then stops before
+checkpoint, staging, pre-commit, publish, or finalization can hide the problem.
+
+### Preserved files
+
+The helper always preserves:
+
+- tracked files
+- `.claude/settings.json`
+- `.claude/` itself
+- untracked user files outside `.claude/runtime/` and marked nested worktrees
+- unmarked or ambiguous `worktrees/` content
+
+Unmarked nested worktrees are not guessed. They are reported as unsafe so the
+owner can inspect them.
+
+### Unsafe cleanup examples
+
+These cases must fail nonzero and leave the target in place:
+
+| Unsafe state | Required behavior |
+| --- | --- |
+| `.claude/runtime` is a symlink | Refuse cleanup. |
+| `.claude/runtime/` contains any tracked file | Refuse cleanup. |
+| `worktrees` is a symlink | Refuse cleanup. |
+| `worktrees/<name>` is a symlink | Refuse cleanup. |
+| `worktrees/<name>/` lacks `.amplihack-workflow-worktree` | Refuse cleanup. |
+| `worktrees/<name>/.amplihack-workflow-worktree` is tracked | Refuse cleanup; tracked marker files do not prove workflow ownership. |
+| `worktrees/<name>/` contains tracked content | Refuse cleanup. |
+| `worktrees/<unmarked-sibling>/` exists beside a marked worktree | Remove only the marked safe target, then fail closed because ambiguous content remains. |
+
+## Function reference
+
+### `cleanup_known_workflow_runtime_artifacts`
+
+```bash
+cleanup_known_workflow_runtime_artifacts [repo]
+```
+
+Removes known workflow-generated artifacts from the resolved repository root.
+
+| Behavior | Contract |
+| --- | --- |
+| Repository validation | Must pass before cleanup starts. |
+| `.claude/runtime/` | The entire runtime directory is removed only when the path is not a symlink and contains no tracked files. Empty runtime directories are removed too because Artifact Guard treats the path itself as runtime leakage. |
+| `.claude/settings.json` | Preserved because `.claude/` is never removed. |
+| `worktrees/<name>/` | Removed only when marked with `.amplihack-workflow-worktree`, not symlinked, and free of tracked files. |
+| Empty `worktrees/` | Removed after marked children are cleaned. |
+| Ambiguous `worktrees/` | Fails nonzero when unmarked content remains. |
+| Output | Logs path-level cleanup actions and failure reasons only. |
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Known workflow artifacts were absent or cleaned safely. |
+| nonzero | Repository resolution, path validation, tracked-file detection, symlink detection, or ownership-marker validation failed. |
+
+### `preflight_known_workflow_runtime_artifacts`
+
+```bash
+preflight_known_workflow_runtime_artifacts [repo]
+```
+
+Runs cleanup first, then verifies that known workflow artifacts no longer remain
+in a state that would trip Artifact Guard.
+
+| Check | Result |
+| --- | --- |
+| Cleanup fails | Preflight fails with the cleanup error. |
+| `.claude/runtime/` remains | Preflight fails. |
+| Marked nested workflow worktree remains | Preflight fails. |
+| Unmarked nested `worktrees/` content exists | Preflight fails closed instead of deleting it. |
+| Unknown prohibited artifact exists | Preflight succeeds; Artifact Guard remains responsible for blocking it. |
+
+Preflight is intentionally narrower than Artifact Guard. It prepares known
+workflow-owned paths for strict scanning; it does not authorize other artifacts.
+
+## Recipe lifecycle coverage
+
+Recipes call `preflight_known_workflow_runtime_artifacts` immediately before any
+phase that relies on a clean commit worktree:
+
+| Recipe | Placement |
+| --- | --- |
+| `workflow-tdd.yaml` | Before checkpoint Artifact Guard and immediately before broad `git add -A` staging. |
+| `workflow-precommit-test.yaml` | Immediately before pre-commit execution. |
+| `workflow-publish.yaml` | Before publish Artifact Guard and before commit or push staging. |
+| `workflow-finalize.yaml` | Before final Artifact Guard, final staging, and push cleanup. |
+| `workflow-worktree.yaml` | Create new worktrees using the external placement contract. Reuse existing branch worktrees when available. Write `.amplihack-workflow-worktree` only for explicit nested compatibility worktrees. |
+
+The required order around guard-sensitive phases is:
+
+```bash
+preflight_known_workflow_runtime_artifacts "$repo"
+amplihack hygiene artifact-guard --repo "$repo" --mode all
+git -C "$repo" add -A
+```
+
+Do not swap the first two lines. Artifact Guard should report unexpected
+artifacts after workflow-owned runtime leftovers have been handled.
+
+## Configuration
+
+No feature flag is required. Runtime artifact cleanup is part of normal bundled
+workflow execution.
+
+| Configuration | Meaning |
+| --- | --- |
+| `WORKTREE_SETUP_WORKTREE_PATH` | Preferred workflow worktree path from setup steps. |
+| `RECIPE_VAR_worktree_setup__worktree_path` | Recipe-runner flattened context value for the setup worktree. |
+| `REPO_PATH` | Repository fallback when worktree setup context is absent. |
+| `AMPLIHACK_WORKTREE_PARENT` | Optional explicit parent for new external workflow worktrees. |
+| `AMPLIHACK_ALLOW_NESTED_WORKTREE` | Emergency compatibility switch. Only `1` permits creating a new nested workflow worktree, and the created directory still requires `.amplihack-workflow-worktree`. |
+| `.amplihack-workflow-worktree` | Ownership marker required before deleting nested workflow-created `worktrees/<name>/`. |
+
+The helper does not modify `NODE_OPTIONS`, `AMPLIHACK_HOME`,
+`AMPLIHACK_AGENT_BINARY`, Git configuration, remotes, credentials, or allowlists.
+
+## Regression expectations
+
+Regression tests for workflow runtime artifacts belong in
+`amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh`. Add a
+clearly named group, such as `workflow-runtime-artifact-preflight`, that covers
+these invariants:
+
+| Scenario | Expected result |
+| --- | --- |
+| `.claude/runtime/` exists with untracked generated content | Preflight removes it before Artifact Guard. |
+| `.claude/runtime/` exists but is empty | Preflight removes the empty directory. |
+| `.claude/settings.json` exists | Preflight preserves it. |
+| `.claude/runtime/` contains tracked content | Cleanup fails closed. |
+| `.claude/runtime` is a symlink | Cleanup fails closed. |
+| `worktrees/<name>/` contains `.amplihack-workflow-worktree` and no tracked files | Preflight removes it before Artifact Guard. |
+| `worktrees/` or `worktrees/<name>/` is a symlink | Cleanup fails closed. |
+| `.amplihack-workflow-worktree` is tracked | Cleanup fails closed. |
+| `worktrees/<name>/` is unmarked | Cleanup fails closed; Artifact Guard still blocks if scanned. |
+| New `workflow-worktree.yaml` worktree setup runs from a repository root | Output `worktree_path` is outside the resolved repository root unless an existing branch worktree is reused. |
+| New `workflow-worktree.yaml` worktree setup runs from an existing `worktrees/<current>` worktree | Output `worktree_path` is a sibling under the existing external `worktrees` parent, not nested under the current repo root. |
+| Unknown prohibited artifact such as `node_modules/` exists | Preflight does not remove it; Artifact Guard fails. |
+| Target path is not a git worktree | Cleanup fails with a visible repository validation error. |
+
+Use test names that expose the contract directly, for example:
+`assert_runtime_preflight_removes_untracked_runtime`,
+`assert_runtime_preflight_preserves_claude_settings`,
+`assert_runtime_preflight_rejects_symlink_targets`,
+`assert_runtime_preflight_rejects_tracked_nested_worktree_content`,
+`assert_workflow_worktree_creates_external_sibling_path`, and
+`assert_artifact_guard_still_blocks_unknown_node_modules`.
+
+## Related documentation
+
+- [Artifact Guard](../artifact-guard.md)
+- [Preflight Workflow Runtime Artifacts](../howto/preflight-workflow-runtime-artifacts.md)
+- [Tutorial: Workflow Runtime Artifact Isolation](../tutorials/workflow-runtime-artifact-isolation.md)
+- [Workflow Execution Guardrails](workflow-execution-guardrails.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -125,6 +125,22 @@ how to rerun when finalization fails closed.
 
 **Duration**: ~15 minutes
 
+### [Workflow Runtime Artifact Isolation](workflow-runtime-artifact-isolation.md)
+
+Practice the lifecycle that removes workflow-generated `.claude/runtime/` and
+marked nested workflow worktrees before strict Artifact Guard gates.
+
+**Topics Covered**:
+
+- Cleaning known workflow runtime output before guard-sensitive phases
+- Preserving `.claude/settings.json`
+- Using `.amplihack-workflow-worktree` ownership markers
+- Confirming unknown artifacts still fail Artifact Guard
+
+**Prerequisites**: amplihack installed, writable Git checkout, `git`
+
+**Duration**: ~10 minutes
+
 ---
 
 ## Platform-Specific Quick Starts

--- a/docs/tutorials/workflow-runtime-artifact-isolation.md
+++ b/docs/tutorials/workflow-runtime-artifact-isolation.md
@@ -1,0 +1,142 @@
+---
+title: "Tutorial: Workflow Runtime Artifact Isolation"
+description: "Practice the lifecycle that removes workflow-generated runtime artifacts before strict Artifact Guard gates."
+last_updated: 2026-06-18
+review_schedule: quarterly
+owner: amplihack
+doc_type: tutorial
+---
+
+# Tutorial: Workflow Runtime Artifact Isolation
+
+> [Home](../index.md) > Tutorials > Workflow Runtime Artifact Isolation
+
+This tutorial walks through the runtime artifact lifecycle used by bundled
+workflows. You will create a temporary repository, add workflow-generated
+artifacts, preflight them, and confirm Artifact Guard still blocks unexpected
+artifacts.
+
+## What you will learn
+
+- How `.claude/runtime/` is cleaned before guard-sensitive phases.
+- How workflow-owned nested worktrees are identified by marker files.
+- Why preflight does not replace Artifact Guard.
+
+## Prerequisites
+
+- `git`
+- `amplihack`
+- a shell with access to this checkout
+
+## 1. Create a temporary repository
+
+```bash
+tmprepo="$(mktemp -d)"
+git -C "$tmprepo" init
+git -C "$tmprepo" config user.email "dev@example.com"
+git -C "$tmprepo" config user.name "Amplihack Dev"
+printf 'hello\n' >"$tmprepo/README.md"
+git -C "$tmprepo" add README.md
+git -C "$tmprepo" commit -m "initial"
+```
+
+You now have a real git worktree that the helper can validate.
+
+## 2. Add workflow-generated runtime output
+
+```bash
+mkdir -p "$tmprepo/.claude/runtime/logs"
+printf 'generated\n' >"$tmprepo/.claude/runtime/logs/session.log"
+mkdir -p "$tmprepo/.claude"
+printf '{"permissions":{}}\n' >"$tmprepo/.claude/settings.json"
+```
+
+The helper owns `.claude/runtime/`, but it does not own `.claude/settings.json`.
+
+## 3. Add a marked nested workflow worktree
+
+```bash
+mkdir -p "$tmprepo/worktrees/feat-issue-780"
+touch "$tmprepo/worktrees/feat-issue-780/.amplihack-workflow-worktree"
+printf 'generated worktree output\n' >"$tmprepo/worktrees/feat-issue-780/output.txt"
+```
+
+The marker tells cleanup that this nested worktree was created by the workflow
+and may be removed when it contains no tracked files.
+
+## 4. Run preflight
+
+From the amplihack checkout, source the helper and preflight the temporary
+repository:
+
+```bash
+. ./amplifier-bundle/tools/workflow_runtime_artifacts.sh
+preflight_known_workflow_runtime_artifacts "$tmprepo"
+```
+
+After preflight, the generated runtime and marked nested worktree are gone:
+
+```bash
+test ! -e "$tmprepo/.claude/runtime"
+test ! -e "$tmprepo/worktrees/feat-issue-780"
+test -f "$tmprepo/.claude/settings.json"
+```
+
+The settings file remains because cleanup never removes `.claude/` itself.
+
+## 5. Confirm Artifact Guard passes after cleanup
+
+```bash
+amplihack hygiene artifact-guard --repo "$tmprepo" --mode all
+```
+
+Artifact Guard sees no workflow runtime leakage because preflight already
+handled known workflow-owned artifacts.
+
+## 6. Confirm unknown artifacts still fail
+
+Add an unrelated prohibited artifact:
+
+```bash
+mkdir -p "$tmprepo/node_modules/example"
+printf 'generated dependency tree\n' >"$tmprepo/node_modules/example/file.txt"
+```
+
+Run preflight and Artifact Guard:
+
+```bash
+preflight_known_workflow_runtime_artifacts "$tmprepo"
+if amplihack hygiene artifact-guard --repo "$tmprepo" --mode all; then
+  echo "ERROR: Artifact Guard unexpectedly allowed node_modules" >&2
+  exit 1
+else
+  echo "blocked as expected"
+fi
+```
+
+Preflight does not delete `node_modules/`. Artifact Guard blocks it because the
+strict guard remains responsible for unknown prohibited artifacts.
+
+## 7. Clean up
+
+```bash
+rm -rf "$tmprepo"
+```
+
+## What happened
+
+The workflow lifecycle has two boundaries:
+
+1. `preflight_known_workflow_runtime_artifacts` removes only known
+   workflow-owned `.claude/runtime/` and marked nested `worktrees/` output.
+2. `amplihack hygiene artifact-guard` blocks any prohibited artifact that still
+   exists.
+
+This keeps normal workflow execution from leaving generated runtime or nested
+worktree artifacts inside commit worktrees without weakening Artifact Guard.
+
+## Related documentation
+
+- [Preflight Workflow Runtime Artifacts](../howto/preflight-workflow-runtime-artifacts.md)
+- [Workflow Runtime Artifacts Reference](../reference/workflow-runtime-artifacts.md)
+- [Artifact Guard](../artifact-guard.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Add a fail-closed `workflow_runtime_artifacts.sh` helper that cleans only known workflow-generated `.claude/runtime` and marked nested `worktrees/` artifacts.
- Preflight runtime artifacts before checkpoint, broad staging, pre-commit guidance, publish, review feedback, and finalization Artifact Guard phases.
- Move new workflow worktrees outside active commit worktrees by default, with explicit marked nested compatibility fallback only.
- Add regression coverage and docs for the runtime artifact lifecycle while keeping Artifact Guard strict.

## Validation

- `bash amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh`
- `CARGO_TARGET_DIR=/tmp/amplihack-rs-target cargo test --test artifact_guard_cli --test artifact_guard_workflow --test pre_commit_artifact_guard --locked`
- `PRE_COMMIT_HOME=/tmp/amplihack-pre-commit-cache CARGO_TARGET_DIR=/tmp/amplihack-rs-target pre-commit run --all-files`

Closes #780
