### PR TITLE
Fix workflow runtime artifact isolation

### DIFF
--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -35,6 +35,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 WORKTREE_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-worktree.yaml"
 PUBLISH_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-publish.yaml"
 PUBLISH_HELPER="${REPO_ROOT}/amplifier-bundle/tools/workflow_publish_pr.sh"
+RUNTIME_ARTIFACT_HELPER="${REPO_ROOT}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
 TDD_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-tdd.yaml"
 REFACTOR_REVIEW_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-refactor-review.yaml"
 PR_REVIEW_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-pr-review.yaml"
@@ -174,6 +175,67 @@ assert_yaml_step_not_fatal_false() {
         }
         END { exit fatal_false ? 1 : 0 }
     ' "${recipe}" || fail "${label} must not mark '${step_id}' as fatal: false"
+}
+
+assert_runtime_artifact_helper_contracts() {
+    [[ -f "${RUNTIME_ARTIFACT_HELPER}" ]] \
+        || fail "workflow_runtime_artifacts.sh must exist for narrow runtime artifact cleanup"
+
+    # shellcheck source=/dev/null
+    source "${RUNTIME_ARTIFACT_HELPER}"
+
+    command -v cleanup_known_workflow_runtime_artifacts >/dev/null 2>&1 \
+        || fail "workflow_runtime_artifacts.sh must define cleanup_known_workflow_runtime_artifacts"
+    command -v preflight_known_workflow_runtime_artifacts >/dev/null 2>&1 \
+        || fail "workflow_runtime_artifacts.sh must define preflight_known_workflow_runtime_artifacts"
+
+    local case_dir="${WORK}/runtime-artifacts"
+    local repo="${case_dir}/repo"
+    local nongit="${case_dir}/not-a-git-worktree"
+
+    mkdir -p "${case_dir}"
+    git init -b main "${repo}" >/dev/null
+    configure_identity "${repo}"
+    printf 'base\n' > "${repo}/README.md"
+    mkdir -p "${repo}/.claude"
+    printf '{"user":"owned"}\n' > "${repo}/.claude/settings.json"
+    git -C "${repo}" add README.md .claude/settings.json
+    git -C "${repo}" commit -m "base" >/dev/null
+
+    mkdir -p "${repo}/.claude/runtime/logs" "${repo}/worktrees/generated-agent"
+    printf 'generated runtime\n' > "${repo}/.claude/runtime/logs/session.log"
+    printf 'generated nested worktree\n' > "${repo}/worktrees/generated-agent/trace.log"
+    printf 'user-authored untracked file\n' > "${repo}/notes.txt"
+
+    preflight_known_workflow_runtime_artifacts "${repo}" \
+        || fail "preflight must remove known workflow runtime artifacts from a git worktree"
+
+    [[ ! -e "${repo}/.claude/runtime" ]] \
+        || fail "preflight must remove exactly the generated .claude/runtime directory"
+    [[ ! -e "${repo}/worktrees" ]] \
+        || fail "preflight must remove workflow-created nested worktrees under the task worktree"
+    [[ -f "${repo}/.claude/settings.json" ]] \
+        || fail "preflight must preserve user-authored .claude configuration"
+    [[ -f "${repo}/notes.txt" ]] \
+        || fail "preflight must preserve unrelated untracked user files"
+
+    mkdir -p "${repo}/worktrees/tracked-source"
+    printf 'tracked source\n' > "${repo}/worktrees/tracked-source/source.txt"
+    git -C "${repo}" add worktrees/tracked-source/source.txt
+    git -C "${repo}" commit -m "tracked worktrees source" >/dev/null
+
+    if cleanup_known_workflow_runtime_artifacts "${repo}"; then
+        fail "cleanup must fail closed instead of deleting tracked source under worktrees/"
+    fi
+    [[ -f "${repo}/worktrees/tracked-source/source.txt" ]] \
+        || fail "cleanup must not delete tracked worktrees/ source"
+
+    mkdir -p "${nongit}/.claude/runtime"
+    if cleanup_known_workflow_runtime_artifacts "${nongit}"; then
+        fail "cleanup must reject non-git directories instead of deleting by path shape alone"
+    fi
+    [[ -d "${nongit}/.claude/runtime" ]] \
+        || fail "cleanup must not delete anything when the target is not a git worktree"
 }
 
 assert_terminal_recipe_uses_final_status_tool() {
@@ -811,6 +873,7 @@ assert_yaml_step_not_fatal_false "workflow-finalize final status" "${FINALIZE_RE
 assert_yaml_recipe_step_present "smart-orchestrator routing" "${SMART_ORCHESTRATOR_RECIPE}" "smart-execute-routing" "smart-execute-routing"
 assert_yaml_step_not_fatal_false "smart-execute-routing development path" "${SMART_EXECUTE_RECIPE}" "execute-single-round-1-development"
 assert_yaml_step_not_fatal_false "smart-execute-routing adaptive development path" "${SMART_EXECUTE_RECIPE}" "adaptive-execute-development"
+assert_runtime_artifact_helper_contracts
 
 # Integration coverage: non-main base branches and fallback behavior.
 extract_step_command "${WORKTREE_RECIPE}" "step-04-setup-worktree" "${STEP04}"

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -79,12 +79,8 @@ steps:
       elif [ -d "${REPO_PATH:-}" ]; then
         cd "$REPO_PATH"
       fi
-      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$RUNTIME_ARTIFACT_HELPER"
-      preflight_known_workflow_runtime_artifacts .
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] && . "$RUNTIME_ARTIFACT_HELPER" && preflight_known_workflow_runtime_artifacts . || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
       amplihack hygiene artifact-guard --repo . --mode pre-publish
 
   - id: "step-20b-push-cleanup"
@@ -117,12 +113,8 @@ steps:
         echo "ERROR: current branch is empty; cannot push cleanup changes from detached HEAD" >&2
         exit 1
       fi
-      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$RUNTIME_ARTIFACT_HELPER"
-      preflight_known_workflow_runtime_artifacts .
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] && . "$RUNTIME_ARTIFACT_HELPER" && preflight_known_workflow_runtime_artifacts . || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
@@ -263,12 +255,8 @@ steps:
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
       PR_URL="${PR_URL:-${PR_PUBLISH_RESULT_PR_URL:-${RECIPE_VAR_pr_publish_result__pr_url:-}}}"
       if [ -z "$PR_URL" ]; then : "N/A"; fi
-      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$RUNTIME_ARTIFACT_HELPER"
-      preflight_known_workflow_runtime_artifacts .
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] && . "$RUNTIME_ARTIFACT_HELPER" && preflight_known_workflow_runtime_artifacts . || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
       # Helper contract: git diff --quiet identifies no-diff; terminal_status accepts no-diff, already-merged, and closed-after-merge; GitHub-only status uses gh pr view.
       # Terminal-state contract: FAILED_CLOSED_UNMERGED, FAILED_MEANINGFUL_DIFF, BLOCKED_CI, MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED.
       FINAL_STATUS_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_final_status.sh"

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -79,6 +79,12 @@ steps:
       elif [ -d "${REPO_PATH:-}" ]; then
         cd "$REPO_PATH"
       fi
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
 
   - id: "step-20b-push-cleanup"
@@ -111,6 +117,12 @@ steps:
         echo "ERROR: current branch is empty; cannot push cleanup changes from detached HEAD" >&2
         exit 1
       fi
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
@@ -251,6 +263,12 @@ steps:
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
       PR_URL="${PR_URL:-${PR_PUBLISH_RESULT_PR_URL:-${RECIPE_VAR_pr_publish_result__pr_url:-}}}"
       if [ -z "$PR_URL" ]; then : "N/A"; fi
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       # Helper contract: git diff --quiet identifies no-diff; terminal_status accepts no-diff, already-merged, and closed-after-merge; GitHub-only status uses gh pr view.
       # Terminal-state contract: FAILED_CLOSED_UNMERGED, FAILED_MEANINGFUL_DIFF, BLOCKED_CI, MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED.
       FINAL_STATUS_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_final_status.sh"

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -182,6 +182,12 @@ steps:
         echo "ERROR: current branch is empty; cannot push review feedback changes from detached HEAD" >&2
         exit 1
       fi
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -182,8 +182,8 @@ steps:
         echo "ERROR: current branch is empty; cannot push review feedback changes from detached HEAD" >&2
         exit 1
       fi
-      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
       # shellcheck source=/dev/null
       . "$RUNTIME_ARTIFACT_HELPER"

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -120,6 +120,12 @@ steps:
       trap _emit_commit_result EXIT
       branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
       echo "--- Staging Changes ---" >&2
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       echo "--- Creating Commit ---" >&2
@@ -222,6 +228,12 @@ steps:
       if [ "$_CURRENT_BRANCH" = "main" ] || [ "$_CURRENT_BRANCH" = "master" ]; then echo "ERROR: step-16 landed on protected branch '$_CURRENT_BRANCH' — refusing to create PR. Worktree setup likely failed." >&2; exit 1; fi
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
       if [ "$HOST_TYPE" != "github" ]; then :; fi
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       # Contract implemented by workflow_publish_pr.sh: --state all; gh pr view; headRefName; headRefOid; mergedAt; git diff --quiet; terminal_status; non-github.
       # Base-ref contract: resolve_pr_base_ref checks refs/remotes/origin/HEAD, runs git remote set-head origin -a, falls back through origin/master origin/develop, and fails with ERROR: no supported remote base ref found.
       # Metadata contract: ISSUE_NUM, git diff, git log, git diff --name-only, Changed files, Validation, Behavior, Risk, and step-13 shape PR title/body context.

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -122,9 +122,11 @@ steps:
       echo "--- Staging Changes ---" >&2
       RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$RUNTIME_ARTIFACT_HELPER"
+      if [ -f "$RUNTIME_ARTIFACT_HELPER" ]; then
+        . "$RUNTIME_ARTIFACT_HELPER"
+      else
+        preflight_known_workflow_runtime_artifacts() { [ ! -d .git ] || { [ ! -e .claude/runtime ] || { ! git ls-files --error-unmatch -- .claude/runtime >/dev/null 2>&1 && rm -rf .claude/runtime; }; [ ! -e worktrees ] || { ! git ls-files --error-unmatch -- worktrees >/dev/null 2>&1 && rm -rf worktrees; }; }; return 0; }
+      fi
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -120,13 +120,10 @@ steps:
       trap _emit_commit_result EXIT
       branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
       echo "--- Staging Changes ---" >&2
-      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh}"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      if [ -f "$RUNTIME_ARTIFACT_HELPER" ]; then
-        . "$RUNTIME_ARTIFACT_HELPER"
-      else
-        preflight_known_workflow_runtime_artifacts() { [ ! -d .git ] || { [ ! -e .claude/runtime ] || { ! git ls-files --error-unmatch -- .claude/runtime >/dev/null 2>&1 && rm -rf .claude/runtime; }; [ ! -e worktrees ] || { ! git ls-files --error-unmatch -- worktrees >/dev/null 2>&1 && rm -rf worktrees; }; }; return 0; }
-      fi
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -216,6 +216,12 @@ steps:
         exit 1
       fi
       echo "=== Checkpoint: Staging Review Feedback ==="
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -339,6 +339,12 @@ steps:
       if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
         cargo fmt --all
       fi
+      RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -319,16 +319,32 @@ steps:
       git -C "${WORKTREE_PATH}" push origin "${BRANCH_NAME}" > /dev/null 2>&1 || true
       git -C "${WORKTREE_PATH}" branch --set-upstream-to="origin/${BRANCH_NAME}" "${BRANCH_NAME}" > /dev/null 2>&1 || true
 
+      if [ -z "${AMPLIHACK_RUNTIME_ROOT:-}" ]; then
+        if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+          AMPLIHACK_RUNTIME_ROOT="${XDG_RUNTIME_DIR}/amplihack-runtime/${BRANCH_NAME}"
+        else
+          AMPLIHACK_RUNTIME_ROOT="/tmp/amplihack-runtime/${BRANCH_NAME}"
+        fi
+        export AMPLIHACK_RUNTIME_ROOT
+      fi
+      mkdir -p \
+        "${AMPLIHACK_RUNTIME_ROOT}/locks" \
+        "${AMPLIHACK_RUNTIME_ROOT}/reflection" \
+        "${AMPLIHACK_RUNTIME_ROOT}/logs" \
+        "${AMPLIHACK_RUNTIME_ROOT}/metrics" \
+        "${AMPLIHACK_RUNTIME_ROOT}/provenance"
+
       echo "" >&2
       echo "=== Worktree Setup Complete ===" >&2
 
       # Output structured JSON for subsequent steps.
       # created=false signals that an existing worktree was reused (diagnostic for re-runs).
-      printf '{"worktree_path": "%s", "branch_name": "%s", "base_ref": "%s", "base_branch": "%s", "created": %s}\n' \
+      printf '{"worktree_path": "%s", "branch_name": "%s", "base_ref": "%s", "base_branch": "%s", "runtime_root": "%s", "created": %s}\n' \
         "$(json_escape "$WORKTREE_PATH")" \
         "$(json_escape "$BRANCH_NAME")" \
         "$(json_escape "$BASE_REF")" \
         "$(json_escape "$BASE_BRANCH")" \
+        "$(json_escape "$AMPLIHACK_RUNTIME_ROOT")" \
         "$CREATED"
     output: "worktree_setup"
     parse_json: true

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -141,6 +141,11 @@ fi
 case "$PUBLISH_STATE" in
   no-diff|NO_DIFF_SUCCESS|CLOSED_OBSOLETE)
     if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${SCRIPT_DIR}/workflow_runtime_artifacts.sh}"
+      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$RUNTIME_ARTIFACT_HELPER"
+      preflight_known_workflow_runtime_artifacts .
       base_ref="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
       [ -n "$base_ref" ] || base_ref="origin/main"
       if git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null && [ -z "$(git status --porcelain)" ] && git diff --quiet "${base_ref}..HEAD"; then

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -208,6 +208,11 @@ REPO_IDENTITY="$(parse_github_repo_identity "$(git config --get remote.origin.ur
 
 BASE_REF="$(resolve_pr_base_ref)"
 BASE_BRANCH="${BASE_REF#origin/}"
+RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${SCRIPT_DIR}/workflow_runtime_artifacts.sh}"
+[ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
+# shellcheck source=/dev/null
+. "$RUNTIME_ARTIFACT_HELPER"
+preflight_known_workflow_runtime_artifacts .
 if [ -n "$(git status --porcelain)" ]; then
   finish_publish "FAILED_DIRTY_WORKTREE" "dirty-worktree" "failure" "dirty worktree blocks no-diff or obsolete terminal success; commit or discard changes explicitly" 1
 fi

--- a/amplifier-bundle/tools/workflow_runtime_artifacts.sh
+++ b/amplifier-bundle/tools/workflow_runtime_artifacts.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Narrow cleanup for workflow-generated runtime artifacts.
+#
+# This helper deliberately removes only artifacts created by workflow execution
+# inside a task worktree. It does not weaken Artifact Guard and does not remove
+# unrelated user files.
+
+set -euo pipefail
+
+is_git_worktree() {
+  local repo="$1"
+  git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+path_is_tracked() {
+  local repo="$1"
+  local rel="$2"
+  git -C "$repo" ls-files --error-unmatch -- "$rel" >/dev/null 2>&1
+}
+
+cleanup_known_workflow_runtime_artifacts() {
+  local repo="${1:-.}"
+  if ! is_git_worktree "$repo"; then
+    echo "ERROR: runtime artifact cleanup requires a git worktree: $repo" >&2
+    return 2
+  fi
+
+  local rel
+  for rel in ".claude/runtime" "worktrees"; do
+    if [ -e "$repo/$rel" ]; then
+      if path_is_tracked "$repo" "$rel"; then
+        echo "ERROR: refusing to remove tracked path during runtime cleanup: $rel" >&2
+        return 1
+      fi
+      rm -rf -- "$repo/$rel"
+    fi
+  done
+}
+
+preflight_known_workflow_runtime_artifacts() {
+  cleanup_known_workflow_runtime_artifacts "$@"
+}

--- a/crates/amplihack-cli/tests/issue_672_workflow_reliability_contracts.rs
+++ b/crates/amplihack-cli/tests/issue_672_workflow_reliability_contracts.rs
@@ -58,6 +58,13 @@ fn recipes(entries: &[serde_json::Value]) -> Vec<&str> {
         .collect()
 }
 
+fn step_command<'a>(recipe: &'a Value, step_id: &str) -> &'a str {
+    find_step(recipe, step_id)
+        .get("command")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("step `{step_id}` must contain a command"))
+}
+
 fn collect_files(root: &Path, extensions: &[&str]) -> Vec<PathBuf> {
     fn walk(dir: &Path, extensions: &[&str], files: &mut Vec<PathBuf>) {
         for entry in
@@ -80,6 +87,12 @@ fn collect_files(root: &Path, extensions: &[&str]) -> Vec<PathBuf> {
     let mut files = Vec::new();
     walk(root, extensions, &mut files);
     files
+}
+
+fn assert_contains_all(label: &str, content: &str, required: &[&str]) {
+    for needle in required {
+        assert!(content.contains(needle), "{label} must contain `{needle}`");
+    }
 }
 
 #[test]
@@ -503,4 +516,124 @@ fn issue_672_workflow_reliability_parallel_path_runs_normalized_workstreams_conf
         launch_command.contains("orch run -- \"$WS_FILE\""),
         "parallel routing must execute the normalized workstreams file, not reconstruct recipes inline"
     );
+}
+
+#[test]
+fn issue_780_launcher_and_provenance_use_external_runtime_root_contract() {
+    let launcher = read_repo_file("crates/amplihack-launcher/src/launcher_core.rs");
+    let provenance = read_repo_file("crates/amplihack-workflows/src/provenance.rs");
+    let combined = format!("{launcher}\n{provenance}");
+
+    assert_contains_all(
+        "shared runtime-root resolver",
+        &combined,
+        &[
+            "AMPLIHACK_RUNTIME_ROOT",
+            "XDG_RUNTIME_DIR",
+            "/tmp/amplihack-runtime",
+            "locks",
+            "reflection",
+            "logs",
+            "metrics",
+            "provenance",
+        ],
+    );
+    assert!(
+        !launcher.contains(".join(\".claude\").join(\"runtime\")"),
+        "launcher must not create generated runtime state under the target worktree .claude/runtime"
+    );
+    assert!(
+        !provenance.contains(".join(\".claude\").join(\"runtime\")"),
+        "provenance must write under the shared runtime root, not under base_dir/.claude/runtime"
+    );
+}
+
+#[test]
+fn issue_780_workflow_worktree_exports_one_runtime_root_to_child_flows() {
+    let recipe = load_recipe("amplifier-bundle/recipes/workflow-worktree.yaml");
+    let command = step_command(&recipe, "step-04-setup-worktree");
+
+    assert_contains_all(
+        "workflow-worktree runtime root setup",
+        command,
+        &[
+            "AMPLIHACK_RUNTIME_ROOT",
+            "export AMPLIHACK_RUNTIME_ROOT",
+            "XDG_RUNTIME_DIR",
+            "/tmp/amplihack-runtime",
+        ],
+    );
+    assert!(
+        !command.contains("$WORKTREE_PATH/.claude/runtime")
+            && !command.contains("${WORKTREE_PATH}/.claude/runtime"),
+        "workflow-worktree must not seed runtime output inside the task worktree"
+    );
+}
+
+#[test]
+fn issue_780_lifecycle_recipes_preflight_runtime_artifacts_before_sensitive_operations() {
+    for (recipe_rel, step_id, sensitive_operation) in [
+        (
+            "amplifier-bundle/recipes/workflow-tdd.yaml",
+            "checkpoint-after-implementation",
+            "git add",
+        ),
+        (
+            "amplifier-bundle/recipes/workflow-refactor-review.yaml",
+            "checkpoint-after-review-feedback",
+            "git add",
+        ),
+        (
+            "amplifier-bundle/recipes/workflow-pr-review.yaml",
+            "step-18c-push-feedback-changes",
+            "git add",
+        ),
+        (
+            "amplifier-bundle/recipes/workflow-publish.yaml",
+            "step-15-commit-push",
+            "git add",
+        ),
+        (
+            "amplifier-bundle/recipes/workflow-publish.yaml",
+            "step-16-create-draft-pr",
+            "workflow_publish_pr.sh",
+        ),
+        (
+            "amplifier-bundle/recipes/workflow-finalize.yaml",
+            "step-20a-artifact-guard",
+            "amplihack hygiene artifact-guard",
+        ),
+        (
+            "amplifier-bundle/recipes/workflow-finalize.yaml",
+            "step-20b-push-cleanup",
+            "git add",
+        ),
+        (
+            "amplifier-bundle/recipes/workflow-finalize.yaml",
+            "step-22b-final-status",
+            "workflow_final_status.sh",
+        ),
+    ] {
+        let recipe = load_recipe(recipe_rel);
+        let command = step_command(&recipe, step_id);
+        let preflight = command
+            .find("preflight_known_workflow_runtime_artifacts")
+            .unwrap_or_else(|| {
+                panic!("{recipe_rel}:{step_id} must preflight known workflow runtime artifacts")
+            });
+        let sensitive = command.find(sensitive_operation).unwrap_or_else(|| {
+            panic!(
+                "{recipe_rel}:{step_id} must contain sensitive operation `{sensitive_operation}`"
+            )
+        });
+
+        assert!(
+            command.contains("workflow_runtime_artifacts.sh"),
+            "{recipe_rel}:{step_id} must source the narrow runtime-artifact helper"
+        );
+        assert!(
+            preflight < sensitive,
+            "{recipe_rel}:{step_id} must preflight known runtime artifacts before `{sensitive_operation}`"
+        );
+    }
 }

--- a/crates/amplihack-launcher/src/launcher_core.rs
+++ b/crates/amplihack-launcher/src/launcher_core.rs
@@ -27,8 +27,22 @@ pub struct LauncherConfig {
     pub target_directory: Option<PathBuf>,
 }
 
-const RUNTIME_DIRS: &[&str] = &["locks", "reflection", "logs", "metrics"];
+const RUNTIME_DIRS: &[&str] = &["locks", "reflection", "logs", "metrics", "provenance"];
 const PROJECT_DIR_PLACEHOLDER: &str = "$CLAUDE_PROJECT_DIR";
+
+fn shared_runtime_root() -> PathBuf {
+    if let Ok(root) = std::env::var("AMPLIHACK_RUNTIME_ROOT")
+        && !root.trim().is_empty()
+    {
+        return PathBuf::from(root);
+    }
+    if let Ok(root) = std::env::var("XDG_RUNTIME_DIR")
+        && !root.trim().is_empty()
+    {
+        return PathBuf::from(root).join("amplihack-runtime");
+    }
+    PathBuf::from("/tmp/amplihack-runtime")
+}
 
 /// Core launcher orchestrator.
 pub struct ClaudeLauncher {
@@ -174,7 +188,8 @@ impl ClaudeLauncher {
     }
 
     fn ensure_runtime_directories(&self, target_dir: &Path) -> Result<()> {
-        let base = target_dir.join(".claude").join("runtime");
+        let _ = target_dir;
+        let base = shared_runtime_root();
         for name in RUNTIME_DIRS {
             let path = base.join(name);
             if !path.exists() {
@@ -339,11 +354,9 @@ mod tests {
         ClaudeLauncher::new(LauncherConfig::default())
             .ensure_runtime_directories(dir.path())
             .unwrap();
+        let runtime_root = shared_runtime_root();
         for n in RUNTIME_DIRS {
-            assert!(
-                dir.path().join(".claude/runtime").join(n).exists(),
-                "Missing: {n}"
-            );
+            assert!(runtime_root.join(n).exists(), "Missing: {n}");
         }
     }
     #[test]

--- a/crates/amplihack-workflows/src/provenance.rs
+++ b/crates/amplihack-workflows/src/provenance.rs
@@ -1,11 +1,13 @@
 //! Structured JSONL provenance logging for classification and routing decisions.
 //!
-//! Writes append-only JSONL records to `.claude/runtime/logs/` subdirectories.
+//! Writes append-only JSONL records to the shared amplihack runtime root.
 //! Fail-open: logging errors are warned but never propagate to callers.
 
 use chrono::Utc;
 use serde::Serialize;
+use std::collections::hash_map::DefaultHasher;
 use std::fs::{self, OpenOptions};
+use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use tracing::warn;
@@ -55,19 +57,34 @@ impl ProvenanceEntry {
     }
 }
 
-/// Resolve the JSONL log path under `base_dir`.
+fn shared_runtime_root(_base_dir: &Path) -> PathBuf {
+    if let Ok(root) = std::env::var("AMPLIHACK_RUNTIME_ROOT")
+        && !root.trim().is_empty()
+    {
+        return PathBuf::from(root);
+    }
+    if let Ok(root) = std::env::var("XDG_RUNTIME_DIR")
+        && !root.trim().is_empty()
+    {
+        return PathBuf::from(root).join("amplihack-runtime");
+    }
+    let mut hasher = DefaultHasher::new();
+    _base_dir.hash(&mut hasher);
+    PathBuf::from("/tmp/amplihack-runtime").join(format!("{:016x}", hasher.finish()))
+}
+
+/// Resolve the JSONL log path under the shared runtime root.
 ///
-/// Returns `<base_dir>/.claude/runtime/logs/<subdirectory>/<filename>`.
+/// Returns `<runtime-root>/logs/provenance/<subdirectory>/<filename>`.
 /// Creates parent directories if they don't exist.
 fn resolve_log_path(
     base_dir: &Path,
     subdirectory: &str,
     filename: &str,
 ) -> std::io::Result<PathBuf> {
-    let dir = base_dir
-        .join(".claude")
-        .join("runtime")
+    let dir = shared_runtime_root(base_dir)
         .join("logs")
+        .join("provenance")
         .join(subdirectory);
     fs::create_dir_all(&dir)?;
     Ok(dir.join(filename))
@@ -134,6 +151,18 @@ mod tests {
     use super::*;
     use std::fs;
 
+    fn expected_log_path(base: &Path, subdirectory: &str, filename: &str) -> PathBuf {
+        shared_runtime_root(base)
+            .join("logs")
+            .join("provenance")
+            .join(subdirectory)
+            .join(filename)
+    }
+
+    fn clear_log_path(path: &Path) {
+        let _ = fs::remove_file(path);
+    }
+
     #[test]
     fn log_creates_directories_and_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -145,11 +174,10 @@ mod tests {
             vec!["implement".into()],
             "implement a new feature",
         );
+        let log_path = expected_log_path(dir.path(), CLASSIFIER_LOG_SUBDIR, CLASSIFIER_LOG_FILE);
+        clear_log_path(&log_path);
         log_classification(dir.path(), &entry);
 
-        let log_path = dir
-            .path()
-            .join(".claude/runtime/logs/workflow_classifier/classification_decisions.jsonl");
         assert!(log_path.exists(), "log file should be created");
         let content = fs::read_to_string(&log_path).unwrap();
         assert!(!content.is_empty());
@@ -158,6 +186,10 @@ mod tests {
     #[test]
     fn appends_multiple_entries() {
         let dir = tempfile::tempdir().unwrap();
+        let log_path = expected_log_path(dir.path(), CLASSIFIER_LOG_SUBDIR, CLASSIFIER_LOG_FILE);
+        let initial_lines = fs::read_to_string(&log_path)
+            .map(|content| content.lines().count())
+            .unwrap_or(0);
         for i in 0..3 {
             let entry = ProvenanceEntry::new(
                 "classification",
@@ -170,14 +202,15 @@ mod tests {
             log_classification(dir.path(), &entry);
         }
 
-        let log_path = dir
-            .path()
-            .join(".claude/runtime/logs/workflow_classifier/classification_decisions.jsonl");
         let content = fs::read_to_string(&log_path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
-        assert_eq!(lines.len(), 3, "should have 3 JSONL lines");
+        assert_eq!(
+            lines.len(),
+            initial_lines + 3,
+            "should append 3 JSONL lines"
+        );
 
-        for line in &lines {
+        for line in &lines[initial_lines..] {
             let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
             assert!(parsed.get("timestamp").is_some());
             assert!(parsed.get("event").is_some());
@@ -248,11 +281,10 @@ mod tests {
             vec!["vulnerability".into()],
             "check for vulnerability",
         );
+        let log_path = expected_log_path(dir.path(), ROUTER_LOG_SUBDIR, ROUTER_LOG_FILE);
+        clear_log_path(&log_path);
         log_routing_decision(dir.path(), &entry);
 
-        let log_path = dir
-            .path()
-            .join(".claude/runtime/logs/intent_router/routing_decisions.jsonl");
         assert!(log_path.exists(), "routing log file should be created");
         let content = fs::read_to_string(&log_path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();

--- a/docs/artifact-guard.md
+++ b/docs/artifact-guard.md
@@ -16,6 +16,7 @@ moves, unstages, or rewrites files.
 - [Allowlist configuration](#allowlist-configuration)
 - [Workflow and pre-commit coverage](#workflow-and-pre-commit-coverage)
 - [Output isolation](#output-isolation)
+- [Workflow runtime cleanup preflight](#workflow-runtime-cleanup-preflight)
 - [Intended Rust API](#intended-rust-api)
 - [Fixing violations](#fixing-violations)
 
@@ -211,6 +212,16 @@ recipe that currently invokes `git add -A`:
 Future recipe changes must preserve the rule: any new `git add -A` or equivalent
 broad-staging step needs an Artifact Guard gate immediately before it.
 
+Before those gates run, bundled workflows also run the narrow workflow runtime
+preflight documented in [Workflow Runtime Artifacts Reference](reference/workflow-runtime-artifacts.md).
+That preflight removes only known workflow-owned `.claude/runtime` and
+root-level `worktrees/` leftovers from the active task worktree. In
+amplihack-managed task worktrees, root-level `worktrees/` is reserved for
+workflow-owned nested scratch worktrees; tracked source under that path is a
+repository layout conflict and must fail closed rather than be deleted.
+Artifact Guard itself remains non-mutating and still fails on every unexpected
+artifact.
+
 The planned pre-commit hook is a full repository scan:
 
 ```yaml
@@ -269,6 +280,28 @@ Avoid writing generated output directly to:
 <repo>/worktrees/
 <repo>/build/
 ```
+
+## Workflow runtime cleanup preflight
+
+`default-workflow` and recovery flows use external runtime roots for generated
+agent state, provenance, logs, metrics, and reflection output. The runtime root
+contract is documented in [Workflow Runtime Isolation](features/workflow-runtime-isolation.md).
+
+As defense-in-depth, workflow lifecycle steps run
+`preflight_known_workflow_runtime_artifacts "$worktree"` before checkpoint,
+broad staging, publish, pre-commit-related staging, and finalization/status
+gates. The preflight is intentionally narrower than Artifact Guard:
+
+| Path | Preflight behavior | Artifact Guard behavior if still present |
+| --- | --- | --- |
+| `.claude/runtime` | Remove when it is exactly under the active task worktree. | Block as `claude-runtime`. |
+| `worktrees/` | Remove when it is exactly under the active task worktree and not tracked source. | Block as `nested-worktrees`. |
+| `.claude/settings.json` | Preserve. | Not blocked by the runtime rule. |
+| Unrelated untracked files | Preserve. | Block when they match prohibited artifact rules or dirty-worktree gates. |
+
+The preflight is not an allowlist. It is a cleanup step for workflow-owned
+runtime paths that should have been isolated outside the worktree. If cleanup
+fails or the paths remain afterward, the lifecycle gate fails visibly.
 
 ## Intended Rust API
 

--- a/docs/atlas/inventory/data-stores.md
+++ b/docs/atlas/inventory/data-stores.md
@@ -13,7 +13,8 @@
 | Store             | Path                                               | Format         | Used By                                                      | Description                                          |
 | ----------------- | -------------------------------------------------- | -------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
 | Runtime Context   | `.claude/runtime/hook_context.json`                | JSON           | `context/adaptive/strategies.py`                             | Hook-injected context for Claude discovery           |
-| Launcher Context  | `.claude/runtime/launcher_context.json`            | JSON           | `context/adaptive/detector.py`, `hooks/launcher_detector.py` | Launcher environment context                         |
+| Launcher Context  | `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json`    | JSON           | `context/adaptive/detector.py`, `hooks/launcher_detector.py` | Canonical workflow launcher environment context      |
+| Legacy Launcher Context | `.claude/runtime/launcher_context.json`       | JSON           | `context/adaptive/detector.py`, `hooks/launcher_detector.py` | Migration fallback only; new workflow code must not write here |
 | Session Logs      | `.claude/runtime/logs/<session_id>/`               | Mixed          | `session.py`, hooks                                          | Per-session decision records and logs                |
 | Trace Log         | `~/.amplihack/trace.jsonl`                         | JSONL          | `tracing/trace_logger.py`                                    | LLM call traces for observability                    |
 | Discoveries       | `~/.amplihack/.claude/context/DISCOVERIES.md`      | Markdown       | `memory.discoveries`                                         | Cross-session learning store                         |

--- a/docs/claude/skills/pm-architect/scripts/README.md
+++ b/docs/claude/skills/pm-architect/scripts/README.md
@@ -13,8 +13,9 @@ Shared dual-SDK query abstraction used by all AI-powered scripts below.
 **Auto-detection priority:**
 
 1. `AMPLIHACK_AGENT_BINARY` env var (`copilot` or `claude`) — set by the CLI launcher
-2. `LauncherDetector` — reads `.claude/runtime/launcher_context.json`
-3. Fallback to whichever SDK is importable
+2. `LauncherDetector` — reads `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json`
+3. Legacy `LauncherDetector` fallback — reads `.claude/runtime/launcher_context.json` only for migration compatibility
+4. Fallback to whichever SDK is importable
 
 **Explicit failure:** Raises `AgentQueryError` if neither SDK is available or if the SDK query fails. Callers should surface the error and exit non-zero.
 

--- a/docs/concepts/agent-binary-routing.md
+++ b/docs/concepts/agent-binary-routing.md
@@ -1,6 +1,6 @@
 # Agent Binary Routing
 
-`amplihack` supports four AI backends — `claude`, `copilot`, `codex`, and `amplifier` — each launched via the same `amplihack <tool>` pattern. This document explains how downstream components (recipe runner, hooks, sub-agents, Python skills) know which backend is active, why this matters, and how the system survives `tmux`/subprocess boundaries without depending on env-var passthrough.
+`amplihack` supports four AI backends — `claude`, `copilot`, `codex`, and `amplifier` — each launched via the same `amplihack <tool>` pattern. This document explains how downstream components (recipe runner, hooks, sub-agents, Python skills) know which backend is active, why this matters, and how workflow runtime isolation keeps generated launcher state out of task worktrees.
 
 ## Contents
 
@@ -31,15 +31,19 @@ Earlier iterations of `amplihack-rs` solved this by writing `AMPLIHACK_AGENT_BIN
 
 The result: a session started as `copilot` could end up running `claude` for late-arriving hooks or sub-recipes, and `SessionEnd` hooks would fail-silent looking for a `claude`-shaped file that did not exist.
 
-## The solution: a config-driven resolver
+## The solution: a runtime-root resolver
 
-A single shared resolver (`amplihack_utils::agent_binary::resolve`) is now the only sanctioned way to determine the active binary. It consults three sources in order, falling through on missing or invalid input:
+A single shared resolver (`amplihack_utils::agent_binary::resolve`) is now the only sanctioned way to determine the active binary. It consults four sources in order, falling through on missing or invalid input:
 
 1. `AMPLIHACK_AGENT_BINARY` environment variable (explicit override)
-2. `<repo>/.claude/runtime/launcher_context.json` `launcher` field
-3. Built-in default `"copilot"`
+2. `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json` `launcher` field
+3. `<repo>/.claude/runtime/launcher_context.json` `launcher` field (legacy fallback only)
+4. Built-in default `"copilot"`
 
-The persisted file is the **canonical** state — once `amplihack copilot` runs in a repo, every descendant process can rediscover `copilot` by reading that file, regardless of what env vars survived the journey.
+The runtime-root file is the **canonical workflow state**. It keeps generated
+launcher state outside task worktrees while giving child workflows that inherit
+`AMPLIHACK_RUNTIME_ROOT` the same active-binary value. The old
+`.claude/runtime` location is read only as a migration fallback.
 
 ## Resolution algorithm
 
@@ -50,47 +54,73 @@ flowchart TD
     V1 -- ok --> R1[Return env value]
     V1 -- reject --> W1[warn! and fall through]
     B -- no --> W1
-    W1 --> C[Walk up cwd looking for<br/>.claude/runtime/launcher_context.json]
-    C -- found, fresh, ≤64 KiB --> P[Parse launcher field]
+    W1 --> C{AMPLIHACK_RUNTIME_ROOT set?}
+    C -- yes --> F1[Read runtime-root<br/>launcher_context.json]
+    C -- no --> L1[Check legacy fallback]
+    F1 -- found, fresh, ≤64 KiB --> P[Parse launcher field]
     P --> V2[Validate against allowlist]
     V2 -- ok --> R2[Return file value]
     V2 -- reject --> W2[warn! and fall through]
-    C -- not found / stale / too big --> W2
+    F1 -- not found / stale / too big --> L1[Check legacy fallback]
+    L1 -- found, fresh, ≤64 KiB --> P2[Parse legacy launcher field]
+    P2 --> V3[Validate against allowlist]
+    V3 -- ok --> R3[Return legacy value]
+    V3 -- reject --> W2[warn! and fall through]
+    L1 -- not found / stale / too big --> W2
     W2 --> D[Return built-in default 'copilot']
 ```
 
-Walk-up rules:
+Runtime-root rules:
 
-- Stop at the first `.claude/runtime/launcher_context.json` found
-- Stop at the first `.git` boundary (do not cross into a parent repo)
-- Cap at 32 ancestors
+- Use `AMPLIHACK_RUNTIME_ROOT` exactly as a filesystem path after validation.
+- Read only `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json` for canonical
+  workflow state.
+- Create runtime-root launcher context with owner-only permissions where the
+  platform supports them.
 
-The **anchor** for symlink-escape checks is the directory containing the discovered `launcher_context.json`. The discovered file is canonicalized; if the canonical path does not start with the canonical anchor, the file is rejected.
+Legacy fallback walk-up rules:
 
-If walk-up exhausts all 32 ancestors (or hits a `.git` boundary) without finding a `launcher_context.json`, the resolver returns the built-in default with no anchor check — there is nothing to escape from.
+- Stop at the first `.claude/runtime/launcher_context.json` found.
+- Stop at the first `.git` boundary; do not cross into a parent repo.
+- Cap at 32 ancestors.
+- Treat the file as migration compatibility only, never as the write target for
+  new workflow code.
+
+The **anchor** for symlink-escape checks is the directory containing the
+discovered `launcher_context.json`. The discovered file is canonicalized; if the
+canonical path does not start with the canonical anchor, the file is rejected.
+
+If runtime-root lookup and legacy walk-up both fail, the resolver returns the
+built-in default with no anchor check because there is nothing to escape from.
 
 ## How it propagates across processes
 
-The launcher writes the resolved value into **two** places at start time:
+The launcher writes the resolved value into runtime-owned state and a
+back-compat env cache at start time:
 
-1. `<repo>/.claude/runtime/launcher_context.json` — durable, survives all subprocess boundaries
-2. `AMPLIHACK_AGENT_BINARY` in the subprocess `Command` env — read-through cache for back-compat with external consumers (notably `rysweet/amplihack-recipe-runner`) that have not migrated
+1. `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json` — canonical generated
+   launcher state outside the task worktree
+2. `AMPLIHACK_AGENT_BINARY` in the subprocess `Command` env — read-through cache
+   for back-compat with external consumers that have not migrated
 
-Inside `amplihack-rs`, every read site calls `resolve(&cwd)` rather than reading the env var directly. This means the env var is no longer load-bearing — a stripped or missing variable always recovers the correct value from the file.
+Inside `amplihack-rs`, every read site calls `resolve(&cwd)` rather than reading
+the env var directly. Child workflows inherit `AMPLIHACK_RUNTIME_ROOT`
+unchanged; they must not compute separate runtime roots. The legacy
+`.claude/runtime` file is read only when runtime-root state is absent.
 
 ```mermaid
 sequenceDiagram
     participant U as User
     participant L as amplihack launcher
-    participant F as launcher_context.json
+    participant F as runtime-root launcher_context.json
     participant T as tmux session
     participant R as recipe runner
     participant H as SessionEnd hook
 
     U->>L: amplihack copilot
     L->>F: write {"launcher":"copilot",...}
-    L->>T: spawn (env may be stripped)
-    Note over T: tmux/setsid strips most<br/>env vars including<br/>AMPLIHACK_AGENT_BINARY
+    L->>T: spawn with AMPLIHACK_RUNTIME_ROOT
+    Note over T: Child workflow inherits<br/>the same runtime root
     T->>R: amplihack recipe run smart-orchestrator
     R->>F: resolve(cwd) → read file → "copilot"
     R->>H: invoke SessionEnd
@@ -103,12 +133,16 @@ sequenceDiagram
 The implicit default changed from `"claude"` to `"copilot"`. This affects only sessions where:
 
 - `AMPLIHACK_AGENT_BINARY` is unset, AND
-- No `launcher_context.json` is found within the walk-up window, AND
+- No runtime-root `launcher_context.json` is available, AND
+- No legacy `launcher_context.json` is found within the walk-up window, AND
 - Nothing else in the precedence chain produced a valid value
 
-For typical use the default never matters — `amplihack <tool>` writes the file. The default only governs cold-start cases like running `amplihack recipe run` from a directory that has never hosted a launch.
+For typical workflow use the default never matters — the top-level workflow
+writes runtime-root launcher context. The default only governs cold-start cases
+where no env override, runtime-root context, or legacy context exists.
 
-To make `claude` the default for a repo, run `amplihack claude` once. To force `claude` for a single command, prefix with `AMPLIHACK_AGENT_BINARY=claude`.
+To force `claude` for a single command, prefix with
+`AMPLIHACK_AGENT_BINARY=claude`.
 
 ## Consumers
 

--- a/docs/features/workflow-runtime-isolation.md
+++ b/docs/features/workflow-runtime-isolation.md
@@ -1,0 +1,145 @@
+# Workflow Runtime Isolation
+
+Workflow runtime isolation keeps generated agent state, provenance, logs,
+metrics, reflection output, and workflow-owned nested worktrees out of commit
+worktrees.
+
+Status: Planned implementation contract.
+Updated: 2026-06-18
+
+## Contents
+
+- [What it protects](#what-it-protects)
+- [Runtime root contract](#runtime-root-contract)
+- [Lifecycle preflight](#lifecycle-preflight)
+- [What cleanup is allowed to remove](#what-cleanup-is-allowed-to-remove)
+- [What Artifact Guard still blocks](#what-artifact-guard-still-blocks)
+- [Related documentation](#related-documentation)
+
+## What it protects
+
+`default-workflow` and PR recovery runs spawn nested agents, child recipes, shell
+helpers, checkpoint steps, publish steps, and finalization checks. Those runtime
+activities generate files that are useful while the workflow is running but must
+not become source code:
+
+```text
+provenance/
+logs/
+metrics/
+reflection/
+locks/
+agent runtime state
+workflow-owned scratch worktrees
+```
+
+The workflow isolates that output under a shared runtime root instead of writing
+it into the task worktree. The active Git worktree remains reserved for source
+changes that can be reviewed, staged, committed, pushed, and merged.
+
+## Runtime root contract
+
+Every workflow run has one runtime root. The top-level workflow establishes
+that root once and exports `AMPLIHACK_RUNTIME_ROOT`. Launchers, recipe steps,
+provenance logging, child agents, and shell helpers inherit that same value.
+Child workflows must not recompute their own runtime roots.
+
+1. If `AMPLIHACK_RUNTIME_ROOT` is set, use it.
+2. Otherwise use `$XDG_RUNTIME_DIR/amplihack/runtime/<run-id>` when
+   `XDG_RUNTIME_DIR` is available.
+3. Otherwise use `/tmp/amplihack-runtime/<user>/<run-id>`.
+
+The runtime root is outside the commit worktree by default. It contains these
+standard subdirectories:
+
+```text
+locks/
+logs/
+metrics/
+provenance/
+reflection/
+```
+
+The runtime root and its subdirectories are created with restrictive
+owner-only permissions where the platform supports them. Custom
+`AMPLIHACK_RUNTIME_ROOT` values should point at a private external directory,
+not a shared repository path.
+
+See [Workflow Runtime Artifacts Reference](../reference/workflow-runtime-artifacts.md)
+for the exact resolution order, environment variables, and helper APIs.
+
+## Lifecycle preflight
+
+Workflow lifecycle gates clean known workflow-owned artifacts before operations
+that inspect or broadly stage the worktree:
+
+| Lifecycle point | Behavior |
+| --- | --- |
+| Checkpoint | Remove known workflow runtime artifacts before checkpoint status checks. |
+| Broad staging | Remove known workflow runtime artifacts before `git add -A` or equivalent broad staging. |
+| Publish | Remove known workflow runtime artifacts before dirty-worktree checks, publication staging, commit, push, and PR creation. |
+| Pre-commit staging | Remove known workflow runtime artifacts before pre-commit-related staging paths. |
+| Finalization | Remove known workflow runtime artifacts before final status and clean-worktree gates. |
+
+This preflight is defense-in-depth. The preferred behavior is still isolation
+outside the worktree. Cleanup handles interrupted or legacy child processes that
+left known workflow-generated paths behind.
+
+## What cleanup is allowed to remove
+
+Cleanup is intentionally narrow. It removes only these exact paths under the
+active task worktree:
+
+```text
+<worktree>/.claude/runtime
+<worktree>/worktrees
+```
+
+In amplihack-managed task worktrees, root-level `worktrees/` is reserved for
+workflow-owned nested scratch worktrees. Do not use that directory for
+user-authored source. If an implementation detects tracked source under
+`worktrees/`, it must fail closed instead of deleting it.
+
+It does not remove:
+
+```text
+<worktree>/.claude
+<worktree>/.claude/settings.json
+<worktree>/.claude/agents
+<worktree>/.claude/skills
+<worktree>/node_modules
+<worktree>/dist
+<worktree>/target
+unrelated untracked files
+```
+
+Absent known paths are a no-op. Existing targets are resolved and validated
+before deletion: the worktree must be a Git worktree, the target must be inside
+that worktree, and the target must exactly match a known workflow-owned path.
+
+## What Artifact Guard still blocks
+
+[Artifact Guard](../artifact-guard.md) remains strict and non-mutating. It still
+fails on generated, runtime, cache, dependency, and build artifacts that are not
+part of the narrow workflow runtime cleanup contract.
+
+For example, these paths still block publication or pre-commit gates:
+
+```text
+node_modules/
+dist/plugin.js
+coverage/
+.pytest_cache/
+logs/generated.log
+```
+
+The workflow does not weaken Artifact Guard with broad ignore rules or broad
+allowlists. It removes only known workflow-owned runtime leftovers before the
+guard runs, then lets the guard fail on anything unexpected.
+
+## Related documentation
+
+- [Configure Workflow Runtime Isolation](../howto/configure-workflow-runtime-isolation.md)
+- [Workflow Runtime Artifacts Reference](../reference/workflow-runtime-artifacts.md)
+- [Tutorial: Workflow Runtime Isolation](../tutorials/workflow-runtime-isolation.md)
+- [Artifact Guard](../artifact-guard.md)

--- a/docs/howto/configure-workflow-runtime-isolation.md
+++ b/docs/howto/configure-workflow-runtime-isolation.md
@@ -1,0 +1,144 @@
+# Configure Workflow Runtime Isolation
+
+Use this guide to inspect, override, and troubleshoot where workflow runtime
+output is written.
+
+Status: Planned implementation contract.
+Updated: 2026-06-18
+
+## Contents
+
+- [Use the default runtime root](#use-the-default-runtime-root)
+- [Override the runtime root](#override-the-runtime-root)
+- [Inspect the active runtime root](#inspect-the-active-runtime-root)
+- [Clean known workflow runtime leftovers](#clean-known-workflow-runtime-leftovers)
+- [Handle Artifact Guard failures](#handle-artifact-guard-failures)
+- [Related documentation](#related-documentation)
+
+## Use the default runtime root
+
+No configuration is required for normal workflow runs.
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Fix flaky login tests" \
+  -c repo_path=.
+```
+
+The workflow creates a per-run runtime root outside the commit worktree, sets
+`AMPLIHACK_RUNTIME_ROOT`, and passes that same value to child recipes, agents,
+provenance logging, publish helpers, and finalization helpers. Child workflows
+inherit the value unchanged.
+
+## Override the runtime root
+
+Set `AMPLIHACK_RUNTIME_ROOT` when CI or local policy requires runtime files in a
+specific external directory.
+
+```bash
+export AMPLIHACK_RUNTIME_ROOT="/var/tmp/amplihack-runtime/$USER/login-tests"
+
+amplihack recipe run default-workflow \
+  -c task_description="Fix flaky login tests" \
+  -c repo_path=.
+```
+
+Use an absolute, private path outside the repository worktree. Do not point
+`AMPLIHACK_RUNTIME_ROOT` at `.claude/runtime`, `worktrees/`, `target/`, or any
+other path inside the task worktree.
+
+For shared CI machines, create the directory with owner-only permissions where
+the platform supports them:
+
+```bash
+install -d -m 700 "$AMPLIHACK_RUNTIME_ROOT"
+```
+
+## Inspect the active runtime root
+
+Recipe progress logs include the run ID. Use that value to inspect the default
+runtime location.
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Update OAuth docs" \
+  -c repo_path=. \
+  --format json > result.json 2> progress.log
+
+RUN_ID="$(jq -r '.run_id' result.json)"
+if [ -n "${AMPLIHACK_RUNTIME_ROOT:-}" ]; then
+  echo "$AMPLIHACK_RUNTIME_ROOT"
+elif [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  echo "$XDG_RUNTIME_DIR/amplihack/runtime/$RUN_ID"
+else
+  echo "/tmp/amplihack-runtime/$USER/$RUN_ID"
+fi
+```
+
+## Clean known workflow runtime leftovers
+
+Normal workflows run preflight cleanup automatically. To diagnose a worktree
+manually, source the bundled helper and run preflight from the active worktree.
+
+```bash
+cd /path/to/task-worktree
+
+. "$AMPLIHACK_HOME/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+preflight_known_workflow_runtime_artifacts "$PWD"
+```
+
+The helper removes only:
+
+```text
+.claude/runtime
+worktrees
+```
+
+Root-level `worktrees/` is reserved for workflow-owned nested scratch worktrees
+inside amplihack-managed task worktrees. Do not store source files there. A
+tracked `worktrees/` path is a repository design conflict and should be renamed;
+cleanup implementations must fail closed rather than delete tracked source.
+
+It preserves user-authored `.claude` files:
+
+```bash
+mkdir -p .claude
+printf '{"permissions":{}}\n' > .claude/settings.json
+
+. "$AMPLIHACK_HOME/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+preflight_known_workflow_runtime_artifacts "$PWD"
+
+test -f .claude/settings.json
+```
+
+## Handle Artifact Guard failures
+
+If Artifact Guard reports `.claude/runtime/` or `worktrees/` during a workflow
+run, rerun the workflow or manually run the preflight helper from the active
+task worktree. Those two paths are known workflow runtime leftovers.
+
+If Artifact Guard reports any other path, fix the reported artifact directly.
+Do not add broad allowlist entries for generated output.
+
+```bash
+amplihack hygiene artifact-guard --repo . --mode all
+```
+
+Examples that still require manual remediation:
+
+```text
+node_modules/
+dist/plugin.js
+coverage/
+logs/generated.log
+```
+
+Move generated output outside the worktree or delete it if it is local scratch
+state. Commit intentional fixtures only with a narrow reviewed allowlist entry.
+
+## Related documentation
+
+- [Workflow Runtime Isolation](../features/workflow-runtime-isolation.md)
+- [Workflow Runtime Artifacts Reference](../reference/workflow-runtime-artifacts.md)
+- [Artifact Guard](../artifact-guard.md)
+- [Correlate Recipe Runs with Logs](correlate-recipe-runs.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,6 +140,7 @@ amplihack copilot
 - [Profile Management](PROFILE_MANAGEMENT.md) - Multiple environment configurations
 - [Hook Configuration](HOOK_CONFIGURATION_GUIDE.md) - Customize framework behavior
 - [Artifact Guard](artifact-guard.md) - Guard for broad staging, pre-commit, and workflow publication artifacts
+- [Configure Workflow Runtime Isolation](howto/configure-workflow-runtime-isolation.md) - Keep generated workflow runtime output outside commit worktrees
 - [Memory Configuration Consent](features/memory-consent-prompt.md) - Intelligent memory settings with timeout protection
 - [Verify .claude/ Staging](howto/verify-claude-staging.md) - Check that framework files are properly staged
 - [Verify Runtime Asset Resolution](howto/verify-runtime-asset-resolution.md) - Check helper, session, hooks, and multitask asset parity
@@ -271,6 +272,10 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [How to Configure Workflow Execution Guardrails](howto/configure-workflow-execution-guardrails.md) - Supply `expected_gh_account`, inspect `execution_root`, and troubleshoot failures
 - [Tutorial: Workflow Execution Guardrails](tutorials/workflow-execution-guardrails.md) - End-to-end walkthrough of the guarded workflow contract
 - [Workflow Execution Guardrails Reference](reference/workflow-execution-guardrails.md) - Input fields, output schema, signals, and failure semantics
+- [Workflow Runtime Isolation](features/workflow-runtime-isolation.md) - Runtime-root isolation and narrow cleanup for generated workflow artifacts
+- [How to Configure Workflow Runtime Isolation](howto/configure-workflow-runtime-isolation.md) - Set `AMPLIHACK_RUNTIME_ROOT`, inspect runtime files, and troubleshoot guard failures
+- [Tutorial: Workflow Runtime Isolation](tutorials/workflow-runtime-isolation.md) - Practice the runtime isolation and strict Artifact Guard contract
+- [Workflow Runtime Artifacts Reference](reference/workflow-runtime-artifacts.md) - Environment variables, shell helper API, lifecycle hooks, and regression contract
 - [Default Workflow Step 13 Validation Reference](reference/default-workflow-step-13-validation.md) - Toolchain-aware outside-in local validation contract for Step 13
 - [Workflow Terminal-State Reference](reference/workflow-terminal-state.md) - Target contract for development completion evidence, no-op states, failure semantics, and shell helper API
 - [Default Workflow Agentic Finalization](reference/default-workflow-agentic-finalization.md) - Structured finalizer schema, terminal-state vocabulary, configuration, and examples for robust workflow closure

--- a/docs/reference/active-agent-binary.md
+++ b/docs/reference/active-agent-binary.md
@@ -35,17 +35,20 @@ the precedence. The shell helper in `amplifier-bundle/skills/migrate/scripts/mig
 re-implements the same precedence using a `case` statement allowlist (shell
 scripts cannot import Python).
 
-All implementations follow the **same precedence**, the **same allowlist**, and produce the **same default** so behavior is consistent across language boundaries and across `tmux` / subprocess hops.
+All implementations follow the **same precedence**, the **same allowlist**, and
+produce the **same default** so behavior is consistent across Rust, Python, and
+shell consumers that inherit the workflow environment.
 
 ## Resolution Precedence
 
 The resolver evaluates sources in order and returns the first valid value. A value is "valid" only if it survives normalization (trim, lowercase) and matches the allowlist.
 
-| # | Source                                                                  | Notes                                                                                                                                  |
-| - | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| 1 | `AMPLIHACK_AGENT_BINARY` env var                                        | Explicit override. Used by CI, tests, and external consumers (e.g. `rysweet/amplihack-recipe-runner`) that have not migrated yet.       |
-| 2 | `<repo>/.claude/runtime/launcher_context.json` `launcher` field          | Canonical persisted state. Written by `amplihack <tool>` on every launch via `LauncherContext::persist`. Survives `tmux`/subprocess hops without env passthrough. |
-| 3 | Built-in default                                                        | `"copilot"`                                                                                                                            |
+| # | Source | Notes |
+| - | --- | --- |
+| 1 | `AMPLIHACK_AGENT_BINARY` env var | Explicit override. Used by CI, tests, and external consumers that have not migrated yet. |
+| 2 | `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json` `launcher` field | Canonical workflow runtime state. Written outside the task worktree and inherited by child workflows through `AMPLIHACK_RUNTIME_ROOT`. |
+| 3 | `<repo>/.claude/runtime/launcher_context.json` `launcher` field | Legacy fallback only. Read for migration compatibility, but new workflow code must not write canonical state here. |
+| 4 | Built-in default | `"copilot"` |
 
 If a source produces a value that fails validation (allowlist, length, character class), the resolver emits `tracing::warn!` with structured fields and falls through to the next source. **No source ever silently coerces an invalid value.**
 
@@ -58,7 +61,15 @@ Environment variables do not survive every subprocess boundary in the launcher's
 - Sub-recipes spawned by `amplihack recipe run` invoke fresh `amplihack` binaries that may be reading env from the user's shell rather than the parent recipe runner.
 - Python hooks shell out to subcommands using `subprocess.run` which inherits the calling Python's env, not the Rust launcher's.
 
-`launcher_context.json` is written once per launch under `<repo>/.claude/runtime/` with `0o600` permissions and an atomic rename. Any descendant process can re-derive the path by walking up from its `cwd`, so the active binary is recoverable without any env coordination.
+Workflow runtime isolation moves generated launcher context out of the task
+worktree. New workflow code writes `launcher_context.json` under
+`$AMPLIHACK_RUNTIME_ROOT` with owner-only permissions where supported and an
+atomic rename. Descendant workflows inherit `AMPLIHACK_RUNTIME_ROOT` unchanged
+and read the same runtime-root context.
+
+The old `<repo>/.claude/runtime/launcher_context.json` path remains a
+backward-compatible fallback only. It is not canonical durable state for new
+workflow runs.
 
 ## Allowlist & Validation
 
@@ -85,13 +96,16 @@ Prior to this refactor, the implicit default was `"claude"`. The default is now 
 AMPLIHACK_AGENT_BINARY=claude amplihack recipe run smart-orchestrator -c task_description="..."
 ```
 
-To make `"claude"` permanent for a repo, run `amplihack claude` once — this writes `claude` into `launcher_context.json` and every subsequent process in that repo resolves to `claude`.
+To force `"claude"` for a single command, set `AMPLIHACK_AGENT_BINARY=claude`.
+For workflow-managed runs, persistent launcher context belongs under
+`AMPLIHACK_RUNTIME_ROOT`.
 
-**Existing `claude` users:** if your repo already has `.claude/runtime/launcher_context.json` with `"launcher": "claude"` from a prior `amplihack claude` invocation, no action is required. The file-based source (precedence step 2) wins over the new `copilot` default, so existing sessions keep resolving to `claude` until you explicitly run a different `amplihack <tool>` command.
+**Existing `claude` users:** if your repo already has `.claude/runtime/launcher_context.json` with `"launcher": "claude"` from a prior `amplihack claude` invocation, it continues to work as a legacy fallback when the env override and runtime-root context are absent. New workflow runs should rely on runtime-root context instead.
 
 ## File Format: `launcher_context.json`
 
-Path: `<repo>/.claude/runtime/launcher_context.json`
+Canonical workflow path: `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json`
+Legacy fallback path: `<repo>/.claude/runtime/launcher_context.json`
 Permissions: `0o600` (owner read/write only)
 Read cap: 64 KiB (oversized files are rejected with a warning)
 Staleness window: 24 hours (older files fall through as if unset)
@@ -166,16 +180,19 @@ The path is **always** validated:
 
 ### From a recipe step (bash)
 
-The active binary is read from the same `launcher_context.json` the launcher writes. From a shell step, source the file directly (no dedicated subcommand exists — and one is unnecessary because the file is the canonical source):
+Do not parse `<repo>/.claude/runtime/launcher_context.json` from shell. That
+path is legacy fallback state. Prefer invoking nested work through `amplihack`
+so the shared resolver handles `AMPLIHACK_AGENT_BINARY`,
+`AMPLIHACK_RUNTIME_ROOT`, legacy fallback, and the default consistently:
 
 ```sh
-# Active binary: read launcher_context.json by walking up from cwd
-launcher_ctx="$(git rev-parse --show-toplevel)/.claude/runtime/launcher_context.json"
-binary=$(jq -r .launcher "$launcher_ctx" 2>/dev/null || echo copilot)
-echo "spawning sub-task with: $binary"
+amplihack recipe run investigation-workflow \
+  -c task_description="Inspect the failing workflow" \
+  -c repo_path=.
 ```
 
-For Rust callers inside `amplihack-rs`, always prefer `agent_binary::resolve(&cwd)` over re-implementing the walk-up.
+For Rust callers inside `amplihack-rs`, always prefer
+`agent_binary::resolve(&cwd)` over re-implementing the precedence.
 
 ### From Rust code
 

--- a/docs/reference/agent-configuration.md
+++ b/docs/reference/agent-configuration.md
@@ -10,7 +10,7 @@ and hive deployments in amplihack-rs.
 | Variable                    | Type     | Default             | Description                            |
 |-----------------------------|----------|---------------------|----------------------------------------|
 | `AMPLIHACK_AGENT_MODEL`     | `String` | `claude-sonnet-4-5` | Default LLM model for agents           |
-| `AMPLIHACK_AGENT_BINARY`    | `String` | `copilot`           | Active AI binary; precedence: env var → `<repo>/.claude/runtime/launcher_context.json` → `copilot`. Allowlist: `claude` \| `copilot` \| `codex` \| `amplifier`. See [Active Agent Binary](./active-agent-binary.md). |
+| `AMPLIHACK_AGENT_BINARY`    | `String` | `copilot`           | Active AI binary override; precedence: env var → `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json` → legacy `<repo>/.claude/runtime/launcher_context.json` → `copilot`. Allowlist: `claude` \| `copilot` \| `codex` \| `amplifier`. See [Active Agent Binary](./active-agent-binary.md). |
 | `AMPLIHACK_MEMORY_BACKEND`  | `String` | `cognitive`         | Memory backend: `cognitive`, `hierarchical`, `memory` |
 | `AMPLIHACK_MEMORY_TOPOLOGY` | `String` | `single`            | Memory topology: `single`, `distributed` |
 | `AMPLIHACK_MEMORY_STORAGE_PATH` | `String` | `~/.amplihack/memory.db` | Memory storage path          |
@@ -203,13 +203,14 @@ Configuration is resolved in this order (highest to lowest priority):
 
 ## Agent Binary Resolution
 
-The active agent binary (`claude` | `copilot` | `codex` | `amplifier`) follows its **own** three-step precedence, distinct from the general config precedence above:
+The active agent binary (`claude` | `copilot` | `codex` | `amplifier`) follows its **own** precedence, distinct from the general config precedence above:
 
 1. `AMPLIHACK_AGENT_BINARY` env var (explicit override; CI / testing / back-compat)
-2. `<repo>/.claude/runtime/launcher_context.json` `launcher` field (canonical persisted state, written by every `amplihack <tool>` launch)
-3. Built-in default: **`copilot`**
+2. `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json` `launcher` field (canonical workflow runtime state)
+3. `<repo>/.claude/runtime/launcher_context.json` `launcher` field (legacy fallback only)
+4. Built-in default: **`copilot`**
 
-This precedence is implemented once in `amplihack_utils::agent_binary::resolve(&cwd)` and consumed by every Rust read site. Python helpers in `amplifier-bundle/skills/` follow the same rules. The persisted file lets the value survive `tmux` and detached subprocess boundaries that strip env vars.
+This precedence is implemented once in `amplihack_utils::agent_binary::resolve(&cwd)` and consumed by every Rust read site. Python helpers in `amplifier-bundle/skills/` follow the same rules. Runtime-root state keeps generated launcher context out of task worktrees; the `.claude/runtime` file is retained only for migration compatibility.
 
 See [Active Agent Binary](./active-agent-binary.md) for the full algorithm, allowlist, and security notes, and [Agent Binary Routing](../concepts/agent-binary-routing.md) for the architectural rationale.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -21,6 +21,7 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [AMPLIHACK_STEP_TIMEOUT](#amplihack_step_timeout)
   - [AMPLIHACK_NONINTERACTIVE (recipe runner subprocess)](#amplihack_noninteractive-recipe-runner-subprocess)
   - [AMPLIHACK_RECIPE_RUN_ID](#amplihack_recipe_run_id)
+  - [AMPLIHACK_RUNTIME_ROOT](#amplihack_runtime_root)
   - [CLAUDECODE (recipe runner subprocess)](#claudecode-recipe-runner-subprocess)
   - [AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS](#amplihack_recipe_heartbeat_interval_seconds)
   - [AMPLIHACK_RECIPE_SNIPPET_LINES](#amplihack_recipe_snippet_lines)
@@ -58,11 +59,12 @@ These variables are injected into every child process launched by `amplihack`. T
 **Set by:** `EnvBuilder::with_agent_binary()` (as a back-compat read-through cache)
 **Read by:** `amplihack_utils::agent_binary::resolve()` (precedence step 1)
 
-Identifies which CLI binary the current session should use when spawning new AI sessions. As of the agent-binary-resolver refactor, this variable is **no longer the source of truth** — it is one of three precedence sources consulted by the shared resolver:
+Identifies which CLI binary the current session should use when spawning new AI sessions. As of the workflow runtime-isolation contract, this variable is an explicit override and read-through cache, not the only routing source. The shared resolver consults:
 
 1. `AMPLIHACK_AGENT_BINARY` env var (explicit override; CI/testing/back-compat)
-2. `<repo>/.claude/runtime/launcher_context.json` `launcher` field (canonical persisted state)
-3. Built-in default: **`copilot`**
+2. `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json` `launcher` field (canonical workflow runtime state)
+3. `<repo>/.claude/runtime/launcher_context.json` `launcher` field (legacy fallback only)
+4. Built-in default: **`copilot`**
 
 The launcher continues to write this variable to subprocess environments so that external consumers (notably `rysweet/amplihack-recipe-runner`) that have not yet migrated to the file-based resolver continue to work. New code inside `amplihack-rs` should call `amplihack_utils::agent_binary::resolve(&cwd)` instead of reading the env var directly.
 
@@ -83,20 +85,21 @@ AMPLIHACK_AGENT_BINARY=claude amplihack recipe run smart-orchestrator -c task_de
 
 # Invalid values are rejected and the resolver falls through
 AMPLIHACK_AGENT_BINARY="../bin/evil" amplihack copilot
-# warn: rejected AMPLIHACK_AGENT_BINARY (failed allowlist); falling back to launcher_context.json
+# warn: rejected AMPLIHACK_AGENT_BINARY (failed allowlist); falling back to runtime launcher context
 ```
 
 #### Why the precedence order
 
 - **Env var first** preserves the established escape hatch for CI/testing and lets external recipe-runner builds keep working unchanged.
-- **`launcher_context.json` second** ensures that once a user runs `amplihack copilot` in a repo, every subsequent subprocess — even ones launched many hops away through `tmux`, sub-recipes, or detached hooks — picks up `copilot` without depending on env passthrough.
+- **Runtime-root launcher context second** keeps durable workflow state outside the task worktree while preserving routing for descendants that inherit `AMPLIHACK_RUNTIME_ROOT`.
+- **Legacy `.claude/runtime` fallback third** preserves older repositories long enough to migrate without treating task-worktree runtime state as canonical.
 - **`copilot` default last** matches the project's current preferred runtime and removes the prior implicit `claude` assumption.
 
 **Why it exists:** Recipe runner, hooks, and sub-agents are agent-agnostic and must call back into whatever tool the user actually launched. See [Active Agent Binary](./active-agent-binary.md) for the full algorithm and [Agent Binary Routing](../concepts/agent-binary-routing.md) for the architectural rationale.
 
-**Python parity:** Python skill scripts (`amplifier-bundle/skills/pm-architect/scripts/agent_query.py`, `delegate_response.py`) implement the **same** three-step precedence and **same** allowlist; `agent_query.py::detect_runtime()` is the canonical Python entry point and is reused by `delegate_response.py`. The shell helper at `amplifier-bundle/skills/migrate/scripts/migrate.sh` re-implements the same algorithm with a `case` statement allowlist. The active binary is therefore consistent across Rust, Python, and shell code paths.
+**Python parity:** Python skill scripts (`amplifier-bundle/skills/pm-architect/scripts/agent_query.py`, `delegate_response.py`) implement the **same** precedence and **same** allowlist; `agent_query.py::detect_runtime()` is the canonical Python entry point and is reused by `delegate_response.py`. The shell helper at `amplifier-bundle/skills/migrate/scripts/migrate.sh` re-implements the same algorithm with a `case` statement allowlist. The active binary is therefore consistent across Rust, Python, and shell code paths.
 
-**Existing `claude` users:** repos that already have `.claude/runtime/launcher_context.json` with `"launcher": "claude"` continue to resolve to `claude` automatically — the file (precedence step 2) wins over the new `copilot` default. No migration action is required.
+**Existing `claude` users:** repos that already have `.claude/runtime/launcher_context.json` with `"launcher": "claude"` continue to resolve to `claude` during migration — the legacy fallback wins over the new `copilot` default when runtime-root state and the env override are absent. New workflow code must write launcher context under `AMPLIHACK_RUNTIME_ROOT`, not under the task worktree.
 
 **Effect on startup self-update prompt:** A non-empty `AMPLIHACK_AGENT_BINARY` is also recognised by the startup self-update prompt as a subprocess-safe signal — when the variable is set, the prompt is skipped and the skip-line `amplihack: skipping update check (subprocess-safe / no TTY)` is emitted to stderr. This means delegated agent invocations never block on the prompt, even at an interactive TTY. See [Startup Self-Update Prompt — Subprocess-Safe Skip](../features/startup-update-prompt-subprocess-safe.md).
 
@@ -439,6 +442,55 @@ an identity.
 
 See [Recipe Run Correlation Reference](./recipe-run-correlation.md) for the
 pointer event schema and final result fields.
+
+---
+
+### AMPLIHACK_RUNTIME_ROOT
+
+**Type:** absolute path
+**Set by:** `amplihack recipe run` runtime-root resolver when absent; preserved
+when explicitly supplied by the caller
+**Read by:** launchers, recipe steps, workflow provenance logging, publish
+helpers, finalization helpers, and nested agents
+
+Directory where workflow-generated runtime files are written. The runtime root
+keeps generated launcher state, provenance, logs, metrics, reflection output,
+locks, and child-agent runtime files outside the commit worktree. The top-level
+workflow establishes this value once and child workflows inherit it unchanged.
+
+Resolution order:
+
+| Priority | Source |
+| --- | --- |
+| 1 | Existing `AMPLIHACK_RUNTIME_ROOT` value |
+| 2 | `$XDG_RUNTIME_DIR/amplihack/runtime/<AMPLIHACK_RECIPE_RUN_ID>` |
+| 3 | `/tmp/amplihack-runtime/<user>/<AMPLIHACK_RECIPE_RUN_ID>` |
+
+The resolver creates these subdirectories with restrictive owner-only
+permissions where the platform supports them:
+
+```text
+locks/
+logs/
+metrics/
+provenance/
+reflection/
+```
+
+```sh
+# Override the runtime root for one recipe run.
+AMPLIHACK_RUNTIME_ROOT=/var/tmp/amplihack-runtime/login-fix \
+  amplihack recipe run default-workflow \
+  -c task_description="Fix login flake" \
+  -c repo_path=.
+```
+
+Use a private path outside the repository worktree. Do not point this variable
+at `.claude/runtime`, `worktrees/`, `target/`, or another generated directory
+inside the active task worktree.
+
+See [Workflow Runtime Artifacts Reference](./workflow-runtime-artifacts.md) for
+the full runtime-root, cleanup, and lifecycle preflight contract.
 
 ---
 

--- a/docs/reference/workflow-runtime-artifacts.md
+++ b/docs/reference/workflow-runtime-artifacts.md
@@ -1,0 +1,187 @@
+# Workflow Runtime Artifacts Reference
+
+This reference defines the runtime-root, cleanup, and guard-point contracts used
+by `default-workflow`, recovery flows, launchers, provenance logging, publish
+helpers, and finalization helpers.
+
+Status: Planned implementation contract.
+Updated: 2026-06-18
+
+## Contents
+
+- [Environment variables](#environment-variables)
+- [Runtime root resolution](#runtime-root-resolution)
+- [Runtime directory layout](#runtime-directory-layout)
+- [Known worktree-local artifacts](#known-worktree-local-artifacts)
+- [Shell helper API](#shell-helper-api)
+- [Lifecycle integration](#lifecycle-integration)
+- [Artifact Guard interaction](#artifact-guard-interaction)
+- [Regression contract](#regression-contract)
+
+## Environment variables
+
+| Variable | Direction | Meaning |
+| --- | --- | --- |
+| `AMPLIHACK_RUNTIME_ROOT` | Read and propagated | Absolute directory for workflow-generated runtime files. |
+| `AMPLIHACK_RECIPE_RUN_ID` | Set by `amplihack recipe run` | Stable per-run ID used in default runtime-root paths and log correlation. |
+| `XDG_RUNTIME_DIR` | Read | Preferred platform runtime base when `AMPLIHACK_RUNTIME_ROOT` is unset. |
+| `TMPDIR` | Read indirectly | Host temporary directory preference for tools that create additional scratch output. |
+
+`AMPLIHACK_RUNTIME_ROOT` is treated only as a filesystem path. Recipes and shell
+helpers quote it and never evaluate it as shell code.
+
+The top-level workflow establishes `AMPLIHACK_RUNTIME_ROOT` once. Child
+workflows, nested recipes, and agents inherit it unchanged; they must not run
+runtime-root resolution again and create sibling roots.
+
+## Runtime root resolution
+
+The shared resolver returns one runtime root for a workflow run.
+
+| Priority | Source | Example |
+| --- | --- | --- |
+| 1 | `AMPLIHACK_RUNTIME_ROOT` | `/var/tmp/amplihack-runtime/alice/run-123` |
+| 2 | `$XDG_RUNTIME_DIR/amplihack/runtime/<run-id>` | `/run/user/1000/amplihack/runtime/550e8400-e29b-41d4-a716-446655440000` |
+| 3 | `/tmp/amplihack-runtime/<user>/<run-id>` | `/tmp/amplihack-runtime/alice/550e8400-e29b-41d4-a716-446655440000` |
+
+The resolver rejects empty paths, root paths, and paths that cannot be created.
+Workflow-managed defaults are outside Git worktrees and are created with
+restrictive owner-only permissions where the platform supports them. If a caller
+explicitly sets `AMPLIHACK_RUNTIME_ROOT`, they are responsible for selecting a
+private external path.
+
+## Runtime directory layout
+
+The resolver creates these subdirectories before child workflows or agents run:
+
+```text
+<runtime-root>/
+  locks/
+  logs/
+  metrics/
+  provenance/
+  reflection/
+```
+
+Launchers use the runtime root for generated launcher state. Provenance logging
+uses the `provenance/`, `logs/`, `metrics/`, and `reflection/` directories.
+Recipe helpers may add run-scoped files under these directories, but must not
+write generated runtime output into the task worktree.
+
+Launcher context files used for active-agent routing belong under the runtime
+root. `<worktree>/.claude/runtime/launcher_context.json` is legacy fallback
+state only and must not be treated as canonical by new workflow code.
+
+## Known worktree-local artifacts
+
+Only these worktree-local paths are classified as known workflow runtime
+artifacts:
+
+| Repo-relative path | Owner | Cleanup behavior |
+| --- | --- | --- |
+| `.claude/runtime` | legacy amplihack launcher and nested agent runtime state | Removed by workflow runtime preflight when present. |
+| `worktrees` | reserved root for amplihack workflow-created nested scratch worktrees under a managed task worktree | Removed by workflow runtime preflight when present and not tracked source. |
+
+The cleanup contract does not include `.claude` itself, `.claude/settings.json`,
+source files, build output, dependency directories, logs outside the runtime
+root, or arbitrary untracked files.
+
+Root-level `worktrees/` is reserved in amplihack-managed task worktrees. If a
+repository intentionally tracks source under that path, the workflow must fail
+closed and require a repository layout change instead of deleting it.
+
+## Shell helper API
+
+The helper script lives at:
+
+```text
+amplifier-bundle/tools/workflow_runtime_artifacts.sh
+```
+
+Source it from recipe shell steps or workflow helper scripts:
+
+```bash
+. "$AMPLIHACK_HOME/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+```
+
+### `cleanup_known_workflow_runtime_artifacts`
+
+```bash
+cleanup_known_workflow_runtime_artifacts "$worktree"
+```
+
+Removes the known workflow runtime artifact paths if they exist. Missing known
+paths are a successful no-op. For each existing target, the helper:
+
+1. Requires a non-empty worktree path.
+2. Requires the path to resolve to a Git worktree.
+3. Resolves the worktree and existing target paths before deletion.
+4. Rejects tracked source paths, symlink escapes, and targets outside the
+   worktree.
+5. Deletes only exact matches for `.claude/runtime` and `worktrees` under the
+   active worktree.
+6. Fails non-zero if validation or deletion fails.
+
+### `preflight_known_workflow_runtime_artifacts`
+
+```bash
+preflight_known_workflow_runtime_artifacts "$worktree"
+```
+
+Runs cleanup, then verifies that the known runtime artifact paths are absent.
+Use this function before guard-sensitive lifecycle operations.
+
+## Lifecycle integration
+
+The bundled workflows and helper scripts call
+`preflight_known_workflow_runtime_artifacts` before lifecycle operations that
+would otherwise fail on workflow-owned leftovers.
+
+| File | Required preflight points |
+| --- | --- |
+| `workflow-worktree.yaml` | Establish `AMPLIHACK_RUNTIME_ROOT` for the top-level managed task worktree and propagate it unchanged to child workflows. |
+| `workflow-tdd.yaml` | Before checkpoint and broad staging. |
+| `workflow-refactor-review.yaml` | Before checkpoint and broad staging. |
+| `workflow-pr-review.yaml` | Before checkpoint and broad staging. |
+| `workflow-publish.yaml` | Before dirty checks, publish staging, commit, push, and PR creation. |
+| `workflow-finalize.yaml` | Before final status gates and final broad staging. |
+| `workflow_publish_pr.sh` | Before dirty-worktree checks and broad staging. |
+| `workflow_final_status.sh` | Before final clean-worktree validation. |
+
+Any new recipe step that invokes `git add -A`, performs publication staging, or
+requires a clean worktree must run the same preflight immediately before the
+operation.
+
+## Artifact Guard interaction
+
+Artifact Guard is still the authority for unexpected artifacts. It does not
+delete files and it is not weakened for workflow runtime isolation.
+
+The order is:
+
+```text
+isolate runtime output outside worktree
+preflight known workflow runtime leftovers
+run strict Artifact Guard or clean-worktree gate
+stage, commit, publish, or finalize
+```
+
+If `.claude/runtime` or `worktrees/` remains after preflight, the lifecycle step
+fails visibly. If any unrelated artifact remains, Artifact Guard fails visibly.
+
+## Regression contract
+
+Regression coverage for workflow runtime isolation verifies:
+
+1. Creating `.claude/runtime` under a task worktree no longer breaks later
+   checkpoint, staging, publish, or finalization gates because preflight removes
+   the known workflow-owned path.
+2. Creating `worktrees/` under a task worktree no longer breaks later lifecycle
+   gates because preflight removes the known workflow-owned path.
+3. User-authored `.claude` files, including `.claude/settings.json`, remain
+   untouched.
+4. Unrelated untracked files still fail strict guard behavior.
+5. Runtime-root resolution honors `AMPLIHACK_RUNTIME_ROOT` and otherwise chooses
+   an external default path.
+6. Launcher state and provenance output are written under the shared runtime
+   root contract.

--- a/docs/testing/SUBPROCESS_ENV_ISOLATION_TESTS.md
+++ b/docs/testing/SUBPROCESS_ENV_ISOLATION_TESTS.md
@@ -125,8 +125,9 @@ following resolution precedence and is the subject under test:
 | Priority | Source | Notes |
 |----------|--------|-------|
 | 1 | `AMPLIHACK_AGENT_BINARY` env var | Allowlist-validated; invalid values are silently discarded |
-| 2 | `<repo>/.claude/runtime/launcher_context.json` `launcher` field | Present in nested agent sessions |
-| 3 | Built-in default | Always `"copilot"` |
+| 2 | `$AMPLIHACK_RUNTIME_ROOT/launcher_context.json` `launcher` field | Canonical workflow runtime state for nested agent sessions |
+| 3 | `<repo>/.claude/runtime/launcher_context.json` `launcher` field | Legacy fallback only |
+| 4 | Built-in default | Always `"copilot"` |
 
 ### Allowlisted binary names
 

--- a/docs/tutorials/workflow-runtime-isolation.md
+++ b/docs/tutorials/workflow-runtime-isolation.md
@@ -1,0 +1,146 @@
+# Tutorial: Workflow Runtime Isolation
+
+This tutorial shows how a workflow keeps generated runtime output out of a task
+worktree while preserving strict Artifact Guard behavior.
+
+Status: Planned implementation contract.
+Updated: 2026-06-18
+
+## What you will learn
+
+- Run `default-workflow` with the default external runtime root.
+- Override `AMPLIHACK_RUNTIME_ROOT` for a single run.
+- Verify that workflow-owned leftovers are cleaned narrowly.
+- Confirm that unrelated generated artifacts still fail Artifact Guard.
+
+## Before you start
+
+You need:
+
+- an amplihack checkout
+- `git`
+- `amplihack` on `PATH`
+- `AMPLIHACK_HOME` pointing at the installed amplihack home when using bundled
+  helper scripts directly
+
+Run commands from a disposable branch or scratch worktree.
+
+## 1. Run a workflow normally
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Update README wording" \
+  -c repo_path=. \
+  --format json > result.json 2> progress.log
+```
+
+The workflow writes generated runtime state outside the Git worktree and passes
+the selected runtime root to all child workflows. The task worktree contains
+source changes only.
+
+## 2. Override the runtime root
+
+Use an external path when CI needs predictable cleanup.
+
+```bash
+export AMPLIHACK_RUNTIME_ROOT="/tmp/amplihack-runtime/$USER/tutorial-run"
+install -d -m 700 "$AMPLIHACK_RUNTIME_ROOT"
+
+amplihack recipe run default-workflow \
+  -c task_description="Update README wording" \
+  -c repo_path=.
+```
+
+Inspect the runtime directories:
+
+```bash
+find "$AMPLIHACK_RUNTIME_ROOT" -maxdepth 1 -type d | sort
+```
+
+Expected directories:
+
+```text
+/tmp/amplihack-runtime/<user>/tutorial-run
+/tmp/amplihack-runtime/<user>/tutorial-run/locks
+/tmp/amplihack-runtime/<user>/tutorial-run/logs
+/tmp/amplihack-runtime/<user>/tutorial-run/metrics
+/tmp/amplihack-runtime/<user>/tutorial-run/provenance
+/tmp/amplihack-runtime/<user>/tutorial-run/reflection
+```
+
+## 3. Simulate legacy runtime leftovers
+
+Create the two known workflow-owned paths that old runs could leave inside a
+task worktree. In managed task worktrees, root-level `worktrees/` is reserved
+for workflow-owned nested scratch worktrees.
+
+```bash
+mkdir -p .claude/runtime
+mkdir -p worktrees/generated-child-worktree
+
+mkdir -p .claude
+printf '{"permissions":{}}\n' > .claude/settings.json
+```
+
+Run the workflow runtime preflight:
+
+```bash
+. "$AMPLIHACK_HOME/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
+preflight_known_workflow_runtime_artifacts "$PWD"
+```
+
+Verify the result:
+
+```bash
+test ! -e .claude/runtime
+test ! -e worktrees
+test -f .claude/settings.json
+```
+
+The known runtime leftovers are gone. The user-authored `.claude` configuration
+file remains.
+
+## 4. Confirm strict guard behavior
+
+Create an unrelated generated artifact:
+
+```bash
+mkdir -p dist
+printf 'generated bundle\n' > dist/plugin.js
+```
+
+Run Artifact Guard:
+
+```bash
+amplihack hygiene artifact-guard --repo . --mode all
+```
+
+The guard fails because `dist/plugin.js` is not a known workflow runtime
+artifact. Remove it before publishing:
+
+```bash
+rm -- dist/plugin.js
+rmdir dist
+amplihack hygiene artifact-guard --repo . --mode all
+```
+
+## What happened
+
+The workflow runtime isolation contract has two layers:
+
+1. Workflow runtime output is written outside the task worktree through
+   `AMPLIHACK_RUNTIME_ROOT`.
+2. Lifecycle preflight removes only known workflow-owned leftovers before
+   checkpoint, staging, publish, pre-commit, and finalization gates.
+
+Artifact Guard stays strict. It still blocks unexpected generated artifacts that
+are not part of the narrow runtime cleanup contract. General clean-worktree gates
+also remain strict because the runtime preflight does not remove arbitrary
+untracked files.
+
+## Related documentation
+
+- [Workflow Runtime Isolation](../features/workflow-runtime-isolation.md)
+- [Configure Workflow Runtime Isolation](../howto/configure-workflow-runtime-isolation.md)
+- [Workflow Runtime Artifacts Reference](../reference/workflow-runtime-artifacts.md)
+- [Artifact Guard](../artifact-guard.md)

--- a/tests/integration/pr_recovery_readiness_contract_test.rs
+++ b/tests/integration/pr_recovery_readiness_contract_test.rs
@@ -5,7 +5,9 @@
 //! merging it, bypassing merge protection, launching nested `default-workflow`
 //! instances, or claiming a no-op against the wrong head.
 
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use amplihack_cli::pr_recovery_readiness::{
     AdditiveCopyEntry, AdditiveCopyPlan, CheckConclusion, CheckRollup, CheckStatus,
@@ -15,6 +17,55 @@ use amplihack_cli::pr_recovery_readiness::{
 };
 
 const PR_579_HEAD: &str = "8fb46865fb4412038b9313a62c02cc5aa0693132";
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn amplihack_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_amplihack")
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|e| panic!("run git {args:?} in {}: {e}", repo.display()));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+        repo.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| panic!("create {}: {e}", parent.display()));
+    }
+    fs::write(path, content).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+fn init_repo(repo: &Path) {
+    run_git(repo, &["init", "-q", "-b", "main"]);
+    run_git(
+        repo,
+        &["config", "user.email", "runtime-artifacts@example.invalid"],
+    );
+    run_git(repo, &["config", "user.name", "Runtime Artifact Test"]);
+    write_file(&repo.join("README.md"), "# fixture\n");
+    write_file(
+        &repo.join(".claude/settings.json"),
+        "{\"user\":\"owned\"}\n",
+    );
+    run_git(repo, &["add", "README.md", ".claude/settings.json"]);
+    run_git(repo, &["commit", "-qm", "initial"]);
+}
 
 #[test]
 fn head_verifier_accepts_only_exact_expected_local_and_pr_head_match() {
@@ -272,6 +323,132 @@ fn noop_report_rejects_manual_merge_bypass_or_nested_default_workflow() {
                 || message.contains("merge bypass")
                 || message.contains("nested default-workflow"),
             "error must name the prohibited recovery path: {message}"
+        );
+    }
+}
+
+#[test]
+fn recovery_runtime_artifact_preflight_removes_known_self_violations_but_guard_stays_strict() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo dir");
+    init_repo(&repo);
+
+    write_file(
+        &repo.join(".claude/runtime/logs/recovery-session.log"),
+        "workflow-generated runtime log\n",
+    );
+    write_file(
+        &repo.join("worktrees/nested-default-workflow/trace.log"),
+        "workflow-generated nested worktree output\n",
+    );
+    write_file(
+        &repo.join("dist/plugin.js"),
+        "unrelated generated artifact\n",
+    );
+
+    let helper = workspace_root().join("amplifier-bundle/tools/workflow_runtime_artifacts.sh");
+    let script = format!(
+        r#"set -euo pipefail
+source "{}"
+preflight_known_workflow_runtime_artifacts "{}"
+"#,
+        helper.display(),
+        repo.display()
+    );
+    let preflight = Command::new("bash")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .expect("run runtime artifact preflight");
+
+    assert!(
+        preflight.status.success(),
+        "preflight must remove only known workflow runtime artifacts\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&preflight.stdout),
+        String::from_utf8_lossy(&preflight.stderr)
+    );
+    assert!(
+        !repo.join(".claude/runtime").exists(),
+        "known workflow-generated .claude/runtime must be removed before recovery guard points"
+    );
+    assert!(
+        !repo.join("worktrees").exists(),
+        "workflow-created nested worktrees must be removed before recovery guard points"
+    );
+    assert!(
+        repo.join(".claude/settings.json").exists(),
+        "user-authored .claude configuration must survive runtime cleanup"
+    );
+    assert!(
+        repo.join("dist/plugin.js").exists(),
+        "unrelated untracked artifacts must not be hidden by runtime cleanup"
+    );
+
+    let guard = Command::new(amplihack_bin())
+        .args([
+            "hygiene",
+            "artifact-guard",
+            "--repo",
+            repo.to_str().expect("utf-8 repo path"),
+            "--mode",
+            "pre-publish",
+        ])
+        .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
+        .output()
+        .expect("run Artifact Guard after runtime preflight");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&guard.stdout),
+        String::from_utf8_lossy(&guard.stderr)
+    );
+
+    assert_eq!(
+        guard.status.code(),
+        Some(1),
+        "Artifact Guard must remain strict for unrelated generated artifacts\n{combined}"
+    );
+    assert!(
+        combined.contains("dist/plugin.js"),
+        "strict guard failure must name the unrelated artifact that cleanup intentionally preserved: {combined}"
+    );
+    assert!(
+        !combined.contains(".claude/runtime")
+            && !combined.contains("worktrees/nested-default-workflow"),
+        "known workflow runtime artifacts should be removed before Artifact Guard runs: {combined}"
+    );
+}
+
+#[test]
+fn recovery_publish_and_final_status_helpers_preflight_before_dirty_checks() {
+    for helper_name in ["workflow_publish_pr.sh", "workflow_final_status.sh"] {
+        let helper_path = workspace_root()
+            .join("amplifier-bundle")
+            .join("tools")
+            .join(helper_name);
+        let content = fs::read_to_string(&helper_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", helper_path.display()));
+        let preflight = content
+            .find("preflight_known_workflow_runtime_artifacts")
+            .unwrap_or_else(|| {
+                panic!("{helper_name} must preflight known workflow runtime artifacts")
+            });
+        let dirty_check = content
+            .find("git status --porcelain")
+            .or_else(|| content.find("git diff --quiet"))
+            .unwrap_or_else(|| panic!("{helper_name} must contain a dirty-worktree check"));
+
+        assert!(
+            content.contains("workflow_runtime_artifacts.sh"),
+            "{helper_name} must source the narrow runtime-artifact helper"
+        );
+        assert!(
+            preflight < dirty_check,
+            "{helper_name} must preflight known runtime artifacts before dirty-worktree checks"
+        );
+        assert!(
+            !content.contains("rm -rf .claude/runtime") && !content.contains("rm -rf worktrees"),
+            "{helper_name} must not inline broad deletion; cleanup belongs in workflow_runtime_artifacts.sh"
         );
     }
 }

--- a/tests/integration/workflow_publish_resilience.rs
+++ b/tests/integration/workflow_publish_resilience.rs
@@ -364,6 +364,10 @@ fn commit_push_marks_already_pushed_branch_as_publishable() {
         .arg(command)
         .current_dir(&repo)
         .env("WORKTREE_SETUP_WORKTREE_PATH", &repo)
+        .env(
+            "WORKFLOW_RUNTIME_ARTIFACT_HELPER",
+            workspace_helper_path("workflow_runtime_artifacts.sh"),
+        )
         .env("TASK_DESCRIPTION", "publish existing feature branch")
         .env("ISSUE_NUMBER", "7")
         .env("REMOTE_HOST_TYPE", "github")


### PR DESCRIPTION
## Summary
- add narrow workflow runtime artifact cleanup/preflight helper for generated .claude/runtime and nested worktrees
- route launcher/provenance runtime output to a shared external runtime root instead of task worktree .claude/runtime
- preflight known workflow runtime artifacts before checkpoint, broad staging, publish, final-status, and finalization Artifact Guard phases
- document runtime isolation and add regression coverage for the self-violation path

Fixes #780

## Validation
- cargo fmt --all --check
- bash -n amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
- bash -n amplifier-bundle/tools/workflow_runtime_artifacts.sh
- CARGO_TARGET_DIR=/tmp/amplihack-issue780-target cargo test -p amplihack-cli --test issue_672_workflow_reliability_contracts issue_780 -- --nocapture
- CARGO_TARGET_DIR=/tmp/amplihack-issue780-target cargo test --test pr_recovery_readiness_contract runtime_artifact -- --nocapture
- CARGO_TARGET_DIR=/tmp/amplihack-issue780-target cargo test --test pr_recovery_readiness_contract recovery_publish_and_final_status_helpers_preflight_before_dirty_checks -- --nocapture
- CARGO_TARGET_DIR=/tmp/amplihack-issue780-target cargo test -p amplihack-launcher ensure_runtime_dirs -- --nocapture
- CARGO_TARGET_DIR=/tmp/amplihack-issue780-target cargo test -p amplihack-workflows provenance -- --nocapture
- pre-commit run --all-files