### PR TITLE
Fix recipe-runner context-variable env propagation for bash steps (#784)

### DIFF
--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -15,6 +15,141 @@ const CAPTURED_STDERR_LINES: usize = 200;
 /// ARG_MAX (~2MB) to leave room for env vars and other args.
 const CONTEXT_ARG_SIZE_THRESHOLD: usize = 128 * 1024;
 
+/// Maximum byte length of a context value that we export as a single
+/// environment variable. The kernel rejects any individual argv/envp
+/// string longer than `MAX_ARG_STRLEN` (PAGE_SIZE * 32 = 131072 on Linux)
+/// with `E2BIG`. We cap conservatively below that so a pathologically large
+/// value cannot make the spawn fail. Over-limit values are still delivered
+/// to the runner via `--set` / `--context-file` for `{{placeholder}}`
+/// substitution; only the env mirror is skipped (issue #784, regression
+/// guard for the E2BIG / `--context-file` path).
+const CONTEXT_ENV_VALUE_MAX_BYTES: usize = 96 * 1024;
+
+/// Reserved / dangerous environment-variable names that must never be set
+/// from untrusted recipe context (issue bodies, task descriptions and
+/// third-party recipes all flow into the context map). These names are
+/// NOT managed by `EnvBuilder`, so without this denylist a pathological
+/// context key could clobber a process-critical variable or inject code
+/// into a child shell/interpreter. The `AMPLIHACK_` namespace is handled
+/// separately (prefix check) because it is owned by `EnvBuilder`.
+///
+/// Names are compared after uppercasing the context key (see
+/// [`context_env_pairs`]). Covers: path/identity, the dynamic linker,
+/// shell-startup remote-code-execution vectors, word-splitting and
+/// interpreter option-injection vectors.
+const RESERVED_ENV_DENYLIST: &[&str] = &[
+    // path / identity
+    "PATH",
+    "HOME",
+    "SHELL",
+    "PWD",
+    "USER",
+    "LOGNAME",
+    // dynamic linker
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "GLIBC_TUNABLES",
+    // shell-startup remote-code-execution vectors
+    "BASH_ENV",
+    "ENV",
+    "PS4",
+    "PROMPT_COMMAND",
+    "SHELLOPTS",
+    "BASHOPTS",
+    // word splitting
+    "IFS",
+    // interpreter option injection
+    "PYTHONPATH",
+    "NODE_OPTIONS",
+    "PERL5OPT",
+    "RUBYOPT",
+];
+
+/// `true` when `name` is a valid POSIX environment-variable identifier,
+/// i.e. it matches `^[A-Z_][A-Z0-9_]*$`. The transform in
+/// [`context_env_pairs`] uppercases the key first, so only uppercase
+/// ASCII letters, digits and underscores are expected here; anything else
+/// (hyphens, dots, spaces, a leading digit, non-ASCII, empty) is rejected.
+fn is_valid_env_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_uppercase() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Deterministically map recipe context entries to environment variables for
+/// the spawned recipe runner (and, by OS inheritance, every bash step and
+/// nested sub-recipe it runs). This is the fix for issue #784 / #4583: bash
+/// steps under `set -u` reference `$TASK_DESCRIPTION` / `$REPO_PATH`, which
+/// must exist in the environment rather than only being substituted into
+/// `{{placeholder}}` text.
+///
+/// Transform (pure, total — invalid entries are skipped, never fatal):
+/// 1. Uppercase the key (`task_description` → `TASK_DESCRIPTION`).
+/// 2. Drop keys that are not valid env identifiers after uppercasing
+///    (empty, leading digit, hyphen/dot/space, non-ASCII).
+/// 3. Drop keys in the `AMPLIHACK_` namespace (owned by `EnvBuilder`).
+/// 4. Drop reserved/dangerous names ([`RESERVED_ENV_DENYLIST`]).
+/// 5. Drop values containing a NUL byte (rejected by the OS for env vars;
+///    would otherwise panic at spawn time).
+/// 6. Drop values larger than [`CONTEXT_ENV_VALUE_MAX_BYTES`] (would risk
+///    `E2BIG`); they remain available via the recipe context file.
+///
+/// Skipped entries are logged name-only at `warn` level — values may carry
+/// sensitive data and are never logged.
+pub(super) fn context_env_pairs(context: &BTreeMap<String, String>) -> Vec<(String, String)> {
+    let mut pairs = Vec::with_capacity(context.len());
+    for (key, value) in context {
+        let name = key.to_ascii_uppercase();
+        if !is_valid_env_identifier(&name) {
+            tracing::warn!(
+                name = %key,
+                reason = %"invalid_identifier",
+                "recipe context key skipped for env export"
+            );
+            continue;
+        }
+        if name.starts_with("AMPLIHACK_") {
+            tracing::warn!(
+                name = %key,
+                reason = %"reserved_name",
+                "recipe context key skipped for env export"
+            );
+            continue;
+        }
+        if RESERVED_ENV_DENYLIST.contains(&name.as_str()) {
+            tracing::warn!(
+                name = %key,
+                reason = %"reserved_name",
+                "recipe context key skipped for env export"
+            );
+            continue;
+        }
+        if value.contains('\0') {
+            tracing::warn!(
+                name = %key,
+                reason = %"value_contains_nul",
+                "recipe context key skipped for env export"
+            );
+            continue;
+        }
+        if value.len() > CONTEXT_ENV_VALUE_MAX_BYTES {
+            tracing::warn!(
+                name = %key,
+                reason = %"value_too_large",
+                "recipe context key skipped for env export"
+            );
+            continue;
+        }
+        pairs.push((name, value.clone()));
+    }
+    pairs
+}
+
 pub(super) fn execute_recipe_via_rust(
     recipe_path: &Path,
     context: &BTreeMap<String, String>,
@@ -54,6 +189,15 @@ pub(super) fn execute_recipe_via_rust(
     // Pass context as a file when the total size would risk E2BIG (os error 7).
     // The temp file is kept alive until command.output() completes.
     let _context_file = pass_context(&mut command, context)?;
+
+    // Issue #784 / #4583: export recipe context as environment variables so
+    // bash steps (and nested sub-recipes, via OS inheritance) can read
+    // $TASK_DESCRIPTION / $REPO_PATH under `set -u`. Applied at the LOWEST
+    // precedence — written BEFORE EnvBuilder and the run-id below — so every
+    // amplihack-managed/protective variable deterministically wins over any
+    // colliding context key. Reserved/dangerous names are dropped upstream in
+    // `context_env_pairs` (they are not EnvBuilder-managed).
+    command.envs(context_env_pairs(context));
 
     let env_builder = EnvBuilder::new()
         .with_agent_binary(active_agent_binary())

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
@@ -2166,3 +2166,450 @@ fn test_run_recipe_forwards_recipe_parent_as_dash_r() {
         "run_recipe must forward recipe-parent dir as -R; got r_values={r_values:?}\nargv:\n{logged}"
     );
 }
+
+// =========================================================================
+// Issue #784 / #4583 — recipe context variables must be exported as
+// environment variables for bash steps (TASK_DESCRIPTION, REPO_PATH, ...).
+//
+// TDD (RED first): these tests specify the contract for the not-yet-existing
+// `execute::context_env_pairs` pure transform and the env-export wired into
+// `execute_recipe_via_rust`. They fail until the fix is implemented:
+//   * the unit/security tests reference `execute::context_env_pairs`, which
+//     does not exist yet (compile-time RED);
+//   * the integration tests reproduce the runtime symptom — a bash step under
+//     `set -u` that reads $TASK_DESCRIPTION / $REPO_PATH aborts with
+//     "unbound variable" because the context is never exported.
+// =========================================================================
+
+// -------------------------------------------------------------------------
+// Pure transform: context_env_pairs — uppercasing, validation, denylist
+// -------------------------------------------------------------------------
+
+/// Collect `context_env_pairs` output into a map for order-independent
+/// assertions. Last-writer-wins on collision (deterministic BTreeMap order).
+fn context_env_map(context: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    execute::context_env_pairs(context).into_iter().collect()
+}
+
+fn ctx(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+#[test]
+fn test_context_env_pairs_uppercases_known_keys() {
+    let env = context_env_map(&ctx(&[
+        ("task_description", "Fix the bug"),
+        ("repo_path", "/work/repo"),
+    ]));
+    assert_eq!(
+        env.get("TASK_DESCRIPTION"),
+        Some(&"Fix the bug".to_string()),
+        "context key `task_description` must be exported as TASK_DESCRIPTION"
+    );
+    assert_eq!(
+        env.get("REPO_PATH"),
+        Some(&"/work/repo".to_string()),
+        "context key `repo_path` must be exported as REPO_PATH"
+    );
+    // Lowercased originals must NOT appear — only the uppercased name is exported.
+    assert!(env.get("task_description").is_none());
+    assert!(env.get("repo_path").is_none());
+}
+
+#[test]
+fn test_context_env_pairs_preserves_values_verbatim() {
+    // Keys are transformed; values must pass through unchanged (spaces,
+    // punctuation, unicode, leading/trailing whitespace are all preserved).
+    let value = "  Multi word: résumé, 50% done (a=b)  ";
+    let env = context_env_map(&ctx(&[("task_description", value)]));
+    assert_eq!(env.get("TASK_DESCRIPTION"), Some(&value.to_string()));
+}
+
+#[test]
+fn test_context_env_pairs_accepts_mixed_case_and_leading_underscore() {
+    let env = context_env_map(&ctx(&[
+        ("MyVar", "1"),
+        ("ALREADY_UPPER", "2"),
+        ("_private", "3"),
+    ]));
+    assert_eq!(env.get("MYVAR"), Some(&"1".to_string()));
+    assert_eq!(env.get("ALREADY_UPPER"), Some(&"2".to_string()));
+    assert_eq!(
+        env.get("_PRIVATE"),
+        Some(&"3".to_string()),
+        "a leading underscore is a valid env identifier start"
+    );
+}
+
+#[test]
+fn test_context_env_pairs_drops_invalid_identifier_keys() {
+    // Keys that do not match ^[A-Z_][A-Z0-9_]*$ after uppercasing are dropped,
+    // not sanitized — exporting a bogus name is worse than skipping it.
+    let env = context_env_map(&ctx(&[
+        ("my-var", "hyphen"),      // hyphen is illegal -> dropped
+        ("my.var", "dot"),         // dot is illegal -> dropped
+        ("1bad", "leading digit"), // leading digit -> dropped
+        ("with space", "space"),   // space is illegal -> dropped
+        ("", "empty key"),         // empty -> dropped
+        ("ok_key", "kept"),        // control: valid -> kept
+    ]));
+    assert_eq!(env.get("OK_KEY"), Some(&"kept".to_string()));
+    assert!(env.get("MY-VAR").is_none());
+    assert!(env.get("MY.VAR").is_none());
+    assert!(env.get("1BAD").is_none());
+    assert!(env.get("WITH SPACE").is_none());
+    assert!(env.get("").is_none());
+    assert_eq!(
+        env.len(),
+        1,
+        "only the single valid key should survive; got {env:?}"
+    );
+}
+
+#[test]
+fn test_context_env_pairs_drops_values_containing_nul() {
+    // A NUL byte in a value is rejected by the OS for env vars; drop the pair
+    // rather than letting Command::env panic at spawn time.
+    let env = context_env_map(&ctx(&[
+        ("task_description", "bad\0value"),
+        ("repo_path", "/clean"),
+    ]));
+    assert!(
+        env.get("TASK_DESCRIPTION").is_none(),
+        "values containing NUL must be dropped"
+    );
+    assert_eq!(env.get("REPO_PATH"), Some(&"/clean".to_string()));
+}
+
+#[test]
+fn test_context_env_pairs_drops_oversized_values() {
+    // A single env string longer than the kernel's MAX_ARG_STRLEN causes
+    // execve to fail with E2BIG. Oversized values must be skipped from the
+    // env mirror (they remain available via the context file), while
+    // normal-sized values in the same context are still exported. This guards
+    // the regression on `test_large_context_does_not_hit_e2big`.
+    let huge = "x".repeat(256 * 1024);
+    let env = context_env_map(&ctx(&[
+        ("task_description", huge.as_str()),
+        ("repo_path", "/work/repo"),
+    ]));
+    assert!(
+        env.get("TASK_DESCRIPTION").is_none(),
+        "an oversized value must not be exported as an environment variable"
+    );
+    assert_eq!(
+        env.get("REPO_PATH"),
+        Some(&"/work/repo".to_string()),
+        "normal-sized values are still exported alongside a skipped oversized one"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Security: reserved / dangerous env names must never be settable from
+// untrusted recipe context (issue bodies, task descriptions, 3rd-party
+// recipes flow into context). The denylist is the PRIMARY control.
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_context_env_pairs_drops_reserved_and_dangerous_names() {
+    // Each of these context keys uppercases to a name that must be dropped.
+    // Coverage spans: path/identity, dynamic-linker, shell-startup RCE
+    // vectors, word-splitting, and interpreter option injection.
+    let dangerous = [
+        // path / identity
+        "path",
+        "home",
+        "shell",
+        "pwd",
+        "user",
+        "logname",
+        // dynamic linker
+        "ld_preload",
+        "ld_library_path",
+        "dyld_insert_libraries",
+        "dyld_library_path",
+        "glibc_tunables",
+        // shell-startup remote-code-execution vectors
+        "bash_env",
+        "env",
+        "ps4",
+        "prompt_command",
+        "shellopts",
+        "bashopts",
+        // word splitting
+        "ifs",
+        // interpreter option injection
+        "pythonpath",
+        "node_options",
+        "perl5opt",
+        "rubyopt",
+    ];
+    for key in dangerous {
+        let env = context_env_map(&ctx(&[(key, "attacker-controlled")]));
+        assert!(
+            env.is_empty(),
+            "reserved/dangerous context key `{key}` must be dropped, got {env:?}"
+        );
+    }
+}
+
+#[test]
+fn test_context_env_pairs_drops_amplihack_prefixed_keys() {
+    // The AMPLIHACK_ namespace is owned by EnvBuilder; context must never be
+    // able to collide with or override builder-managed correlation/config vars.
+    let env = context_env_map(&ctx(&[
+        ("amplihack_home", "/evil/home"),
+        ("amplihack_recipe_run_id", "spoofed"),
+        ("AMPLIHACK_ASSET_RESOLVER", "/evil/resolver"),
+        ("task_description", "kept"),
+    ]));
+    assert_eq!(
+        env.get("TASK_DESCRIPTION"),
+        Some(&"kept".to_string()),
+        "ordinary keys still pass through"
+    );
+    assert!(env.get("AMPLIHACK_HOME").is_none());
+    assert!(env.get("AMPLIHACK_RECIPE_RUN_ID").is_none());
+    assert!(env.get("AMPLIHACK_ASSET_RESOLVER").is_none());
+}
+
+// -------------------------------------------------------------------------
+// Integration (T1): top-level recipe — a bash step under `set -u` reads
+// $TASK_DESCRIPTION and $REPO_PATH from the environment.
+// -------------------------------------------------------------------------
+
+/// RED reproduction of the reported bug: the stub runner runs `set -u` and
+/// dereferences $TASK_DESCRIPTION / $REPO_PATH (exactly what a real bash step
+/// does). Without the env-export fix, `set -u` aborts with
+/// "TASK_DESCRIPTION: unbound variable", the stub prints nothing, and
+/// `execute_recipe_via_rust` returns Err. With the fix, the stub echoes the
+/// values back through `context` and the run succeeds.
+#[test]
+#[cfg(unix)]
+fn test_execute_recipe_via_rust_exports_context_as_env_under_set_u() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    let amplihack_home = temp.path().join("amplihack-home");
+    std::fs::create_dir_all(&amplihack_home).expect("failed to create amplihack home");
+
+    std::fs::write(
+        &runner,
+        "#!/bin/sh\nset -u\nprintf '{\"recipe_name\":\"ctx-env-probe\",\"success\":true,\"step_results\":[],\"context\":{\"task\":\"%s\",\"repo\":\"%s\"}}' \"$TASK_DESCRIPTION\" \"$REPO_PATH\"\n",
+    )
+    .expect("failed to write runner stub");
+    make_executable(&runner);
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: ctx-env-probe\nsteps: []\n").expect("failed to write recipe");
+
+    let context = ctx(&[
+        ("task_description", "Fix the bug"),
+        ("repo_path", "/work/repo"),
+    ]);
+
+    let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+    let prev_home = std::env::var_os("AMPLIHACK_HOME");
+    let prev_task = std::env::var_os("TASK_DESCRIPTION");
+    let prev_repo = std::env::var_os("REPO_PATH");
+    unsafe {
+        std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+        std::env::set_var("AMPLIHACK_HOME", &amplihack_home);
+        // Ensure no inherited values mask the bug.
+        std::env::remove_var("TASK_DESCRIPTION");
+        std::env::remove_var("REPO_PATH");
+    }
+
+    let result =
+        execute::execute_recipe_via_rust(&recipe, &context, true, false, temp.path(), &[], None);
+
+    restore_env_var("RECIPE_RUNNER_RS_PATH", prev_runner);
+    restore_env_var("AMPLIHACK_HOME", prev_home);
+    restore_env_var("TASK_DESCRIPTION", prev_task);
+    restore_env_var("REPO_PATH", prev_repo);
+
+    let result = result.expect(
+        "recipe run must succeed: recipe context must be exported as env so a \
+         bash step under `set -u` can read $TASK_DESCRIPTION / $REPO_PATH \
+         (issue #784 / #4583)",
+    );
+    assert_eq!(
+        result.context.get("task"),
+        Some(&JsonValue::String("Fix the bug".to_string())),
+        "TASK_DESCRIPTION must be exported to the child env from context key `task_description`"
+    );
+    assert_eq!(
+        result.context.get("repo"),
+        Some(&JsonValue::String("/work/repo".to_string())),
+        "REPO_PATH must be exported to the child env from context key `repo_path`"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Integration (T2): nested / sub-recipe — the env must propagate to
+// grandchild processes (a sub-recipe's bash step) via OS inheritance.
+// This is the canary for "parent context propagated to child sub-recipes".
+// -------------------------------------------------------------------------
+
+/// The stub runner spawns a GRANDCHILD `sh -c 'set -u; ...'`, mirroring a
+/// sub-recipe whose bash step reads $TASK_DESCRIPTION / $REPO_PATH. The
+/// grandchild inherits env from the runner, which inherits from amplihack-cli.
+/// Before the fix the grandchild's `set -u` aborts and the captured values are
+/// empty (assertion RED); after the fix the values propagate through both hops.
+#[test]
+#[cfg(unix)]
+fn test_execute_recipe_via_rust_exports_context_to_nested_subprocess() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    let amplihack_home = temp.path().join("amplihack-home");
+    std::fs::create_dir_all(&amplihack_home).expect("failed to create amplihack home");
+
+    std::fs::write(
+        &runner,
+        "#!/bin/sh\nset -u\nNESTED_TASK=$(sh -c 'set -u; printf %s \"$TASK_DESCRIPTION\"')\nNESTED_REPO=$(sh -c 'set -u; printf %s \"$REPO_PATH\"')\nprintf '{\"recipe_name\":\"nested-ctx-probe\",\"success\":true,\"step_results\":[],\"context\":{\"nested_task\":\"%s\",\"nested_repo\":\"%s\"}}' \"$NESTED_TASK\" \"$NESTED_REPO\"\n",
+    )
+    .expect("failed to write runner stub");
+    make_executable(&runner);
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: nested-ctx-probe\nsteps: []\n").expect("failed to write recipe");
+
+    let context = ctx(&[
+        ("task_description", "Nested task value"),
+        ("repo_path", "/work/nested/repo"),
+    ]);
+
+    let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+    let prev_home = std::env::var_os("AMPLIHACK_HOME");
+    let prev_task = std::env::var_os("TASK_DESCRIPTION");
+    let prev_repo = std::env::var_os("REPO_PATH");
+    unsafe {
+        std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+        std::env::set_var("AMPLIHACK_HOME", &amplihack_home);
+        std::env::remove_var("TASK_DESCRIPTION");
+        std::env::remove_var("REPO_PATH");
+    }
+
+    let result =
+        execute::execute_recipe_via_rust(&recipe, &context, true, false, temp.path(), &[], None);
+
+    restore_env_var("RECIPE_RUNNER_RS_PATH", prev_runner);
+    restore_env_var("AMPLIHACK_HOME", prev_home);
+    restore_env_var("TASK_DESCRIPTION", prev_task);
+    restore_env_var("REPO_PATH", prev_repo);
+
+    let result = result.expect(
+        "nested recipe run must succeed: context env must propagate to a \
+         grandchild sub-recipe bash step under `set -u`",
+    );
+    assert_eq!(
+        result.context.get("nested_task"),
+        Some(&JsonValue::String("Nested task value".to_string())),
+        "TASK_DESCRIPTION must propagate to a grandchild (sub-recipe) process"
+    );
+    assert_eq!(
+        result.context.get("nested_repo"),
+        Some(&JsonValue::String("/work/nested/repo".to_string())),
+        "REPO_PATH must propagate to a grandchild (sub-recipe) process"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Integration (T4): no-regression + security/precedence at the spawn seam.
+// Context is applied at LOWEST precedence: EnvBuilder-managed and reserved
+// names must win, and untrusted context must never clobber PATH/AMPLIHACK_*.
+// -------------------------------------------------------------------------
+
+/// Even when an attacker-controlled recipe supplies `path`, `ld_preload`, and
+/// `amplihack_home` keys, the child must NOT see those values: PATH is left as
+/// inherited, LD_PRELOAD stays empty, and AMPLIHACK_HOME keeps the
+/// builder-managed value. Meanwhile an ordinary key (`task_description`) is
+/// still exported — proving the export works without opening a clobber hole.
+#[test]
+#[cfg(unix)]
+fn test_execute_recipe_via_rust_context_cannot_clobber_reserved_or_builder_env() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    let amplihack_home = temp.path().join("amplihack-home");
+    std::fs::create_dir_all(&amplihack_home).expect("failed to create amplihack home");
+
+    // No `set -u` here: LD_PRELOAD is legitimately unset, so we read it with a
+    // `:-` default to distinguish "unset" (safe) from "attacker value" (bug).
+    std::fs::write(
+        &runner,
+        "#!/bin/sh\nprintf '{\"recipe_name\":\"sec-probe\",\"success\":true,\"step_results\":[],\"context\":{\"task\":\"%s\",\"path\":\"%s\",\"preload\":\"%s\",\"ahome\":\"%s\"}}' \"${TASK_DESCRIPTION:-MISSING}\" \"$PATH\" \"${LD_PRELOAD:-}\" \"${AMPLIHACK_HOME:-}\"\n",
+    )
+    .expect("failed to write runner stub");
+    make_executable(&runner);
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: sec-probe\nsteps: []\n").expect("failed to write recipe");
+
+    let context = ctx(&[
+        ("task_description", "ok"),
+        ("path", "/nonexistent/evil"),
+        ("ld_preload", "/evil.so"),
+        ("amplihack_home", "/evil/home"),
+    ]);
+
+    let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+    let prev_home = std::env::var_os("AMPLIHACK_HOME");
+    let prev_task = std::env::var_os("TASK_DESCRIPTION");
+    let prev_preload = std::env::var_os("LD_PRELOAD");
+    unsafe {
+        std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+        std::env::set_var("AMPLIHACK_HOME", &amplihack_home);
+        std::env::remove_var("TASK_DESCRIPTION");
+        std::env::remove_var("LD_PRELOAD");
+    }
+
+    let result =
+        execute::execute_recipe_via_rust(&recipe, &context, true, false, temp.path(), &[], None);
+
+    restore_env_var("RECIPE_RUNNER_RS_PATH", prev_runner);
+    restore_env_var("AMPLIHACK_HOME", prev_home);
+    restore_env_var("TASK_DESCRIPTION", prev_task);
+    restore_env_var("LD_PRELOAD", prev_preload);
+
+    let result = result.expect("recipe run must succeed");
+
+    assert_eq!(
+        result.context.get("task"),
+        Some(&JsonValue::String("ok".to_string())),
+        "ordinary context keys must still be exported"
+    );
+    let child_path = result
+        .context
+        .get("path")
+        .and_then(JsonValue::as_str)
+        .expect("stub must report PATH");
+    assert_ne!(
+        child_path, "/nonexistent/evil",
+        "context key `path` must NOT clobber the child's PATH"
+    );
+    assert_eq!(
+        result.context.get("preload"),
+        Some(&JsonValue::String(String::new())),
+        "context key `ld_preload` must be dropped (LD_PRELOAD stays unset)"
+    );
+    let child_ahome = result
+        .context
+        .get("ahome")
+        .and_then(JsonValue::as_str)
+        .expect("stub must report AMPLIHACK_HOME");
+    assert_ne!(
+        child_ahome, "/evil/home",
+        "context key `amplihack_home` must NOT override builder-managed AMPLIHACK_HOME"
+    );
+}

--- a/docs/howto/troubleshoot-recipe-execution.md
+++ b/docs/howto/troubleshoot-recipe-execution.md
@@ -5,6 +5,7 @@ Use this guide when a recipe step fails unexpectedly — a shell step hangs, an 
 ## Contents
 
 - [Shell step hangs waiting for input](#shell-step-hangs-waiting-for-input)
+- [Shell step fails with "TASK_DESCRIPTION: unbound variable"](#shell-step-fails-with-task_description-unbound-variable)
 - [Agent step completes but changes nothing](#agent-step-completes-but-changes-nothing)
 - [Shell step fails with "python3 not found"](#shell-step-fails-with-python3-not-found)
 - [Workflow classification routes to the wrong type](#workflow-classification-routes-to-the-wrong-type)
@@ -55,6 +56,80 @@ amplihack recipe run /tmp/env-check.yaml
 #   NONINTERACTIVE=1
 #   DEBIAN_FRONTEND=noninteractive
 ```
+
+---
+
+## Shell step fails with "TASK_DESCRIPTION: unbound variable"
+
+**Symptom:** A bash step that reads a context value from the environment aborts
+immediately, often inside a nested sub-recipe such as `step-03-create-issue`:
+
+```
+TASK_DESCRIPTION: unbound variable
+REPO_PATH: unbound variable
+```
+
+The step uses `set -u` (or `set -euo pipefail`) and references
+`$TASK_DESCRIPTION`, `$REPO_PATH`, or another context value directly rather than
+through a `{{placeholder}}`.
+
+**Cause:** Before context environment export existed, recipe context fed only
+`{{placeholder}}` substitution in step text — it was **not** present in the shell
+step's process environment. Under `set -u`, referencing an unset variable is a
+hard error, so the step failed before doing any work. This blocked
+multi-workstream campaigns at `step-03-create-issue`.
+
+**Fix:** `amplihack recipe run` now exports every recipe context variable to the
+`recipe-runner-rs` subprocess as an environment variable whose name is the
+ASCII-uppercased context key (`task_description` → `TASK_DESCRIPTION`). The
+export is inherited by every shell step and every nested sub-recipe, so the same
+value is available at any depth. No recipe YAML changes are required.
+
+**Verify the fix is active:**
+
+```sh
+cat > /tmp/unbound-check.yaml << 'EOF'
+name: unbound-check
+context:
+  task_description: ""
+  repo_path: "."
+steps:
+  - id: read-env
+    type: bash
+    command: |
+      set -euo pipefail
+      echo "TASK_DESCRIPTION=$TASK_DESCRIPTION"
+      echo "REPO_PATH=$REPO_PATH"
+EOF
+
+amplihack recipe run /tmp/unbound-check.yaml \
+  -c task_description="probe" -c repo_path=.
+# Expected output:
+#   TASK_DESCRIPTION=probe
+#   REPO_PATH=.
+```
+
+**If the variable is still unbound:**
+
+- **The key cannot become a valid identifier.** Only keys whose uppercased form
+  matches `^[A-Z_][A-Z0-9_]*$` are exported. A key with spaces, dots, or a
+  leading digit is skipped — look for a `WARN recipe context key skipped for env
+  export name=… reason=invalid_identifier` line on stderr. These warnings are
+  hidden by the CLI's default log filter (errors only), so re-run with
+  `RUST_LOG=warn` to surface them. Rename the context key (for example
+  `issue-title` → `issue_title`).
+- **The name is reserved.** Names such as `PATH`, `HOME`, `IFS`, `BASH_ENV`,
+  `LD_PRELOAD`, `PYTHONPATH`, and anything beginning with `AMPLIHACK_` are never
+  exported from context (a `reason=reserved_name` warning is logged). Read those
+  values from their canonical source instead of from context.
+- **The context key is genuinely absent.** Confirm the value is supplied via the
+  recipe's `context:` block or a `-c/--context` flag; an unset, un-inferred key
+  produces no environment variable.
+
+See [Recipe Context Environment Export](../reference/recipe-context-environment.md)
+for the full transform rules and denylist, and
+[Propagate Recipe Context to Bash Steps](../tutorials/recipe-context-env-propagation.md)
+for a hands-on walkthrough.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -263,6 +263,8 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [Verify Dev-Orchestrator Routing](howto/verify-dev-orchestrator-routing.md) - Check deterministic Development-to-default-workflow routing from the CLI
 - [Correlate Recipe Runs with Logs](howto/correlate-recipe-runs.md) - Match terminal output, final JSON, child process IDs, and runner log paths by run ID
 - [Recipe Executor Environment](reference/recipe-executor-environment.md) - Step-level variables plus subprocess environment contract for forced non-interactive recipe execution
+- [Recipe Context Environment Export](reference/recipe-context-environment.md) - Export recipe context variables to bash steps (`$TASK_DESCRIPTION`, `$REPO_PATH`), uppercasing, reserved-name denylist, and precedence
+- [Tutorial: Propagate Recipe Context to Bash Steps](tutorials/recipe-context-env-propagation.md) - Read context from the environment under `set -u`, including nested sub-recipes and skipped keys
 - [Validate Recipe Subprocess and Hook Input Contracts](howto/validate-recipe-subprocess-hook-contract.md) - Validate recipe child env handling and hook JSON compatibility
 - [Workflow Publish Import Validation](features/workflow-publish-import-validation.md) - Scoped publish import validation before commit/push
 - [How to Configure Workflow Publish Import Validation](howto/configure-workflow-publish-import-validation.md) - Review the manifest, root-boundary, and scoped-validator behavior

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -71,6 +71,8 @@ Complete documentation for using the Recipe Runner:
 - **[Correlate Recipe Runs with Logs](../howto/correlate-recipe-runs.md)** - Match terminal output, JSON results, child PIDs, and log paths by run ID
 - **[Recipe CLI Reference](../reference/recipe-cli-reference.md)** - Complete command-line reference with all options and exit codes
 - **[Recipe Run Correlation Reference](../reference/recipe-run-correlation.md)** - Stable run IDs, log pointer schema, and result fields
+- **[Recipe Context Environment Export](../reference/recipe-context-environment.md)** - How context variables reach bash steps as environment variables (`$TASK_DESCRIPTION`, `$REPO_PATH`), the reserved-name denylist, and precedence
+- **[Tutorial: Propagate Recipe Context to Bash Steps](../tutorials/recipe-context-env-propagation.md)** - Hands-on walkthrough for top-level, nested, and skipped keys
 - **[Recipe CLI Examples](cli-examples.md)** - Real-world usage scenarios (development, testing, CI/CD, team workflows)
 - **[Step 03 Host-Aware Tracking Idempotency](../reference/recipe-step-03-idempotency.md)** - GitHub issue, Azure Boards work-item, and local tracking reuse/create contract
 - **[Default Workflow Step 13 Validation](../reference/default-workflow-step-13-validation.md)** - Toolchain-aware outside-in local validation contract for the pre-commit gate
@@ -271,6 +273,13 @@ Use `{{variable}}` to inject context values or previous step outputs into prompt
 - `{{repo_path}}` -- from context
 - `{{clarified_requirements}}` -- output from a prior step stored via `output` field
 - `{{nested.key}}` -- dot notation for nested dict values (from `parse_json` steps)
+
+**Bash steps also receive context as environment variables.** Every context key
+is exported (ASCII-uppercased) to bash steps and nested sub-recipes, so a `bash`
+step can read `$TASK_DESCRIPTION` or `$REPO_PATH` directly — including under
+`set -u`. Reserved names (`PATH`, `LD_PRELOAD`, `BASH_ENV`, `IFS`, `AMPLIHACK_*`,
+…) are never exported. See
+[Recipe Context Environment Export](../reference/recipe-context-environment.md).
 
 ## SDK Adapters
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -30,6 +30,7 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [NONINTERACTIVE](#noninteractive)
   - [DEBIAN_FRONTEND](#debian_frontend)
   - [CI (recipe context)](#ci-recipe-context)
+  - [Context-derived recipe variables](#context-derived-recipe-variables)
 - [Variables read by amplihack](#variables-read-by-amplihack)
   - [AMPLIHACK_MEMORY_BACKEND](#amplihack_memory_backend)
   - [HOME](#home)
@@ -636,6 +637,41 @@ Suppresses interactive prompts from `dpkg` and `apt`. Standard Debian/Ubuntu con
 **Set by:** Recipe executor, `execute_shell_step()`
 
 Signals CI-like behavior to npm, yarn, pip, and other tools that check this variable before prompting. Note: this is set by the recipe executor for all recipe steps, independent of whether the top-level process is actually running in a CI system.
+
+---
+
+### Context-derived recipe variables
+
+**Type:** string (one variable per recipe context key)
+**Examples:** `TASK_DESCRIPTION`, `REPO_PATH`, `ISSUE_NUMBER`, `BRANCH_NAME`
+**Set by:** `amplihack recipe run`, context environment export (lowest precedence)
+
+Every recipe context variable is exported to the `recipe-runner-rs` subprocess —
+and therefore to every shell and nested sub-recipe step — as an environment
+variable whose name is the ASCII-uppercased context key. For example,
+`task_description` becomes `TASK_DESCRIPTION` and `repo_path` becomes
+`REPO_PATH`. Bash steps can read these directly, including under `set -u`.
+
+```bash
+amplihack recipe run env-aware-recipe \
+  -c task_description="Add validation" \
+  -c repo_path=.
+# A bash step sees: TASK_DESCRIPTION=Add validation, REPO_PATH=.
+```
+
+The exact set of names depends entirely on the recipe context. Rules:
+
+- Names must be valid shell identifiers (`^[A-Z_][A-Z0-9_]*$`); keys that do not
+  qualify after uppercasing are skipped with a name-only `WARN`.
+- Reserved and dangerous names are never exported — including `PATH`, `HOME`,
+  `SHELL`, `IFS`, the `LD_*`/`DYLD_*` loader variables, `BASH_ENV`, `ENV`, `PS4`,
+  `PROMPT_COMMAND`, `SHELLOPTS`, `BASHOPTS`, `PYTHONPATH`, `NODE_OPTIONS`,
+  `PERL5OPT`, `RUBYOPT`, and any name beginning with `AMPLIHACK_`.
+- Context export is applied at the lowest precedence, so it can never override
+  the `AMPLIHACK_*` variables or `AMPLIHACK_RECIPE_RUN_ID` documented above.
+
+See [Recipe Context Environment Export](./recipe-context-environment.md) for the
+full contract, denylist, and security model.
 
 ---
 

--- a/docs/reference/recipe-context-environment.md
+++ b/docs/reference/recipe-context-environment.md
@@ -1,0 +1,511 @@
+# Recipe Context Environment Export — Reference
+
+Complete reference for how `amplihack recipe run` exports every recipe context
+variable as an environment variable so that bash steps can read them directly —
+including under `set -u` and inside nested sub-recipes.
+
+This contract complements the `{{placeholder}}` template substitution already
+documented in [Recipe Executor Environment](./recipe-executor-environment.md).
+Template substitution rewrites step *text*; context environment export makes the
+same values available to the *process environment* of every shell step.
+
+## Contents
+
+- [Why it exists](#why-it-exists)
+- [Behavior summary](#behavior-summary)
+- [Key transformation rules](#key-transformation-rules)
+- [Reserved-name denylist](#reserved-name-denylist)
+- [Precedence and no-regression guarantees](#precedence-and-no-regression-guarantees)
+- [Nested and sub-recipe propagation](#nested-and-sub-recipe-propagation)
+- [Skip logging](#skip-logging)
+- [API: `context_env_pairs`](#api-context_env_pairs)
+- [Examples](#examples)
+- [Configuration](#configuration)
+- [Security model](#security-model)
+- [resolve-bundle-asset availability](#resolve-bundle-asset-availability)
+- [Related](#related)
+
+---
+
+## Why it exists
+
+Recipe context variables such as `task_description` and `repo_path` were
+substituted into bash step text as `{{task_description}}` placeholders but were
+**not** present in the process environment of the shell step. A bash step that
+referenced `$TASK_DESCRIPTION` or `$REPO_PATH` directly would therefore fail
+under `set -u` (the default hardening for recipe shell steps):
+
+```
+TASK_DESCRIPTION: unbound variable
+REPO_PATH: unbound variable
+```
+
+This blocked every multi-workstream campaign that reached
+`step-03-create-issue`, because that step reads context from the environment.
+Six prior follow-up workstreams all failed at the same step and produced no
+pull requests.
+
+Context environment export closes the gap: the values that feed
+`{{placeholders}}` are now **also** exported as environment variables, so bash
+steps may use either form interchangeably. The export happens once on the
+`recipe-runner-rs` subprocess and is inherited by every nested shell step,
+including those launched from sub-recipes.
+
+---
+
+## Behavior summary
+
+When `amplihack recipe run` launches `recipe-runner-rs`, it applies the merged
+recipe context (the same map fed to `{{placeholder}}` substitution) to the child
+process environment:
+
+| Aspect | Behavior |
+|--------|----------|
+| Source map | The merged recipe context (`context` block + `-c/--context` flags + inferred values) |
+| Name | Context key, ASCII-uppercased (`task_description` → `TASK_DESCRIPTION`) |
+| Value | Context value, unchanged |
+| Scope | The `recipe-runner-rs` subprocess and — through normal process-environment inheritance — every shell and sub-recipe step it spawns (see [propagation](#nested-and-sub-recipe-propagation)) |
+| Validity | Names must be valid POSIX shell identifiers; invalid keys are skipped |
+| Safety | Reserved/dangerous names are never exported (see [denylist](#reserved-name-denylist)) |
+| Precedence | Lowest — builder-managed and correlation variables always win |
+
+No recipe YAML changes are required. Existing recipes that only use
+`{{placeholders}}` are unaffected; recipes that read `$UPPERCASE_NAME` from the
+environment now work.
+
+---
+
+## Key transformation rules
+
+Each context entry `(key, value)` is transformed into a candidate environment
+pair `(NAME, value)`:
+
+1. **Uppercase.** `NAME = key.to_ascii_uppercase()`. Only ASCII letters are
+   case-folded; non-ASCII characters are left unchanged and consequently fail
+   validation in step 2.
+2. **Validate as a shell identifier.** `NAME` must match
+   `^[A-Z_][A-Z0-9_]*$`. This rejects:
+   - empty keys,
+   - keys whose uppercased form begins with a digit,
+   - keys containing any character outside `[A-Z0-9_]` (spaces, dots, dashes,
+     `=`, non-ASCII, etc.).
+3. **Reject control characters in the value.** A value containing a NUL byte
+   (`\0`) cannot be represented in a process environment and is skipped.
+4. **Reject reserved names.** `NAME` must not appear in the
+   [reserved-name denylist](#reserved-name-denylist) and must not begin with the
+   `AMPLIHACK_` prefix.
+5. **Reject oversized values.** A single environment string longer than the
+   kernel's `MAX_ARG_STRLEN` (≈128 KB on Linux) makes the spawn fail with
+   `E2BIG`. Values above a conservative per-variable byte cap are therefore not
+   mirrored into the environment; they are still delivered to the runner via the
+   recipe context file for `{{placeholder}}` substitution.
+
+A candidate that passes all checks is exported. A candidate that fails any
+check is **skipped** (never exported, never fatal) and a name-only warning is
+emitted (see [Skip logging](#skip-logging)).
+
+### Common mappings
+
+| Context key | Exported environment variable |
+|-------------|-------------------------------|
+| `task_description` | `TASK_DESCRIPTION` |
+| `repo_path` | `REPO_PATH` |
+| `issue_number` | `ISSUE_NUMBER` |
+| `branch_name` | `BRANCH_NAME` |
+| `target_path` | `TARGET_PATH` |
+
+### Collision behavior
+
+If two distinct context keys uppercase to the same environment name (for example
+`repo_path` and `REPO_PATH`), the context map is iterated in deterministic
+(sorted) order and the last writer wins. This is well-defined but should be
+avoided in recipe authoring.
+
+---
+
+## Reserved-name denylist
+
+Some environment variables change how the shell or dynamic loader behaves before
+a single line of the step runs. Exporting attacker- or author-controlled values
+into those names would be a code-execution vector. The exporter therefore
+**never** sets any name in the reserved denylist, regardless of context, and
+never sets any name beginning with `AMPLIHACK_` (those are owned by the
+subprocess environment builder).
+
+| Category | Reserved names |
+|----------|----------------|
+| Dynamic linker | `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `GLIBC_TUNABLES` |
+| Shell startup / RCE | `BASH_ENV`, `ENV`, `PS4`, `PROMPT_COMMAND`, `SHELLOPTS`, `BASHOPTS` |
+| Word splitting | `IFS` |
+| Path and identity | `PATH`, `HOME`, `SHELL`, `PWD`, `USER`, `LOGNAME` |
+| Interpreter options | `PYTHONPATH`, `NODE_OPTIONS`, `PERL5OPT`, `RUBYOPT` |
+| Framework-owned prefix | any name starting with `AMPLIHACK_` |
+
+`BASH_ENV` and `PS4` are the most commonly overlooked code-execution vectors —
+`BASH_ENV` names a file sourced before a non-interactive script runs, and `PS4`
+is expanded (and can contain command substitution) whenever `set -x` is active.
+Both are denied.
+
+The denylist is the **primary** control that makes bare (un-prefixed) export
+names acceptable. It is exhaustively covered by tests. See
+[Security model](#security-model).
+
+---
+
+## Precedence and no-regression guarantees
+
+Context environment variables are applied at the **lowest** precedence. The
+spawn seam writes them first, then layers the subprocess environment builder and
+the correlation variable on top:
+
+```
+1. command.envs(context_env_pairs(context))   // context, lowest priority
+2. env_builder.apply_to_command(&mut command) // AMPLIHACK_*, pager-safe, PATH/HOME fallbacks
+3. command.env("AMPLIHACK_RECIPE_RUN_ID", …)  // correlation id, highest priority
+```
+
+Guarantees that follow from this ordering:
+
+- **Builder-managed variables always win.** `AMPLIHACK_NONINTERACTIVE`,
+  `AMPLIHACK_HOME`, `AMPLIHACK_AGENT_BINARY`, `AMPLIHACK_ASSET_RESOLVER`,
+  `AMPLIHACK_GRAPH_DB_PATH`, pager-safe defaults, Python sanitization, and the
+  `CLAUDECODE` removal cannot be overridden by recipe context.
+- **Correlation is immutable.** `AMPLIHACK_RECIPE_RUN_ID` reflects the real run
+  identity even if a context key tried to collide with it (it is also blocked by
+  the `AMPLIHACK_` prefix rule).
+- **`PATH`/`HOME` are never clobbered.** These are on the denylist, so a context
+  key such as `path=/evil` is dropped rather than replacing the process `PATH`.
+- **`--set` / `--context-file` placeholder delivery is unchanged.** The
+  existing argv- and temp-file-based delivery used for `{{placeholder}}`
+  substitution is untouched; environment export is additive.
+
+---
+
+## Nested and sub-recipe propagation
+
+The CLI exports the context **once**, when it spawns the `recipe-runner-rs`
+subprocess. `std::process::Command` starts that child with the parent's
+environment plus the pairs added by `command.envs(...)`, and never clears it, so
+the exported context is guaranteed to reach `recipe-runner-rs` itself. This first
+hop — CLI → `recipe-runner-rs` — is owned by code in this repository and is
+directly testable.
+
+From there, propagation down to individual steps relies on `recipe-runner-rs`
+(an external binary, typically installed in `~/.cargo/bin`) using default,
+inheriting process spawning for its shell steps and nested sub-recipes — that is,
+it does not clear or rewrite the environment before launching them. Under that
+contract:
+
+- the top-level recipe's bash steps see `$TASK_DESCRIPTION` / `$REPO_PATH`;
+- a `type: recipe` sub-step's bash steps see them too;
+- a `sh -c '…'` grandchild launched by a bash step still sees them.
+
+Because this end-to-end path crosses an external binary, it is treated as a
+**verified contract, not an unchecked assumption.** The nested `sh -c` canary in
+the [propagation tutorial](../tutorials/recipe-context-env-propagation.md) — a
+sub-recipe step whose bash command runs
+`sh -c 'set -u; echo "$TASK_DESCRIPTION"'` — exercises the full chain
+(CLI → `recipe-runner-rs` → bash step → grandchild shell) and must print the
+value rather than abort with `unbound variable`. If a future `recipe-runner-rs`
+cleared or rewrote the environment, that canary would fail first, surfacing the
+regression at the seam where it occurs.
+
+This is exactly the "parent context propagated to child" behavior that
+multi-workstream campaigns require. Per-sub-recipe context *overrides* (the
+step-level `context:` dict on a `type: recipe` step) are resolved inside the
+recipe runner's `{{placeholder}}` layer and are out of scope for the CLI-level
+environment export.
+
+---
+
+## Skip logging
+
+When a context entry is skipped, the exporter emits a `WARN`-level
+[trace event](./trace-logging-api.md) naming **only the key**, never the value,
+so sensitive context never leaks into logs:
+
+```
+WARN recipe context key skipped for env export name=ISSUE TITLE reason=invalid_identifier
+WARN recipe context key skipped for env export name=LD_PRELOAD reason=reserved_name
+WARN recipe context key skipped for env export name=NOTES reason=value_contains_nul
+```
+
+> **Visibility (by design).** Skip notices are `WARN`-level `tracing` events
+> emitted by the parent `amplihack` process — the same mechanism the rest of the
+> recipe-run subsystem uses for diagnostics. The CLI initializes its subscriber
+> with `EnvFilter::from_default_env()` and no default directive, so with
+> `RUST_LOG` unset **only `ERROR` is shown** and skip notices are suppressed.
+> This is a deliberate decision: a skipped key is advisory (the run still
+> succeeds), so it is surfaced on demand with `RUST_LOG=warn amplihack recipe
+> run …` (or `info`/`debug`) rather than printed on every run. When a skipped key
+> later causes an `unbound variable` failure, the
+> [troubleshooting guide](../howto/troubleshoot-recipe-execution.md) directs you
+> to re-run with `RUST_LOG=warn` to see which key was dropped and why.
+>
+> **Field rendering.** The fields are recorded as `%`-display values
+> (`name = %name`, `reason = %reason`), which produces the unquoted
+> `name=…`/`reason=…` rendering shown above. This matches the existing
+> recipe-run `tracing::warn!` style in
+> `crates/amplihack-cli/src/commands/recipe/resolve.rs`; named (non-`%`) fields
+> would render quoted instead. The live subscriber also prefixes a timestamp that
+> these examples omit for brevity.
+
+Skip reasons:
+
+| Reason | Meaning |
+|--------|---------|
+| `invalid_identifier` | Uppercased name is empty, starts with a digit, or contains characters outside `[A-Z0-9_]` |
+| `reserved_name` | Name is on the denylist or begins with `AMPLIHACK_` |
+| `value_contains_nul` | Value contains a NUL byte and cannot be represented in the environment |
+| `value_too_large` | Value exceeds the per-variable byte cap (kept below the kernel's `MAX_ARG_STRLEN` to avoid `E2BIG`); the value is still delivered via the recipe context file for `{{placeholder}}` substitution |
+
+Skips are never fatal. A recipe with one un-exportable key still runs; only that
+single key is omitted from the environment (its `{{placeholder}}` form, if used,
+continues to work).
+
+---
+
+## API: `context_env_pairs`
+
+The transform is implemented as a pure, total function so it can be unit-tested
+in isolation from process spawning.
+
+**Location:** `crates/amplihack-cli/src/commands/recipe/run/execute.rs`
+
+```rust
+/// Transform a recipe context map into the environment pairs to export to
+/// `recipe-runner-rs` and its shell steps.
+///
+/// Each `(key, value)` becomes `(KEY, value)` where `KEY` is the ASCII-
+/// uppercased key. Entries are skipped (with a name-only WARN) when the
+/// uppercased name is not a valid shell identifier, is a reserved name, begins
+/// with `AMPLIHACK_`, or the value contains a NUL byte.
+///
+/// Total: invalid entries are skipped, never fatal. Deterministic: input is a
+/// sorted `BTreeMap`, so iteration order — and last-writer-wins on collision —
+/// is stable.
+fn context_env_pairs(context: &BTreeMap<String, String>) -> Vec<(String, String)>;
+```
+
+| Property | Guarantee |
+|----------|-----------|
+| Totality | Never panics, never returns `Err`; invalid entries are dropped |
+| Determinism | Output order follows the sorted `BTreeMap` key order |
+| Purity | No I/O except name-only `WARN` tracing for skipped keys |
+| Idempotence | Calling twice on the same map yields the same pairs |
+
+The companion constant lists the reserved names:
+
+```rust
+/// Environment names that must never be set from recipe context because they
+/// alter shell or dynamic-loader behavior, or are owned by the subprocess
+/// environment builder.
+const RESERVED_ENV_DENYLIST: &[&str];
+```
+
+The spawn seam consumes the helper at the lowest precedence. In
+`execute_recipe_via_rust` (`execute.rs`), the call is inserted immediately after
+`pass_context(&mut command, context)?` and **before**
+`env_builder.apply_to_command(&mut command)`, so the builder and correlation id
+layer on top:
+
+```rust
+// after: let _context_file = pass_context(&mut command, context)?;
+command.envs(context_env_pairs(context));        // context, lowest priority
+// … then env_builder.apply_to_command(&mut command);   // AMPLIHACK_*, pager-safe, PATH/HOME
+// … then command.env("AMPLIHACK_RECIPE_RUN_ID", correlation.run_id());
+```
+
+`EnvBuilder::apply_to_command` does **not** clear the environment — it only
+`env_remove`s its explicitly unset keys and then `command.envs(...)` its own
+pairs — so context variables added first survive except where a builder-managed
+name (or the correlation id) intentionally overrides them.
+
+---
+
+## Examples
+
+### Top-level recipe reading the environment under `set -u`
+
+```yaml
+name: env-aware-recipe
+description: Reads context from the environment, not just {{placeholders}}
+version: "1.0"
+
+context:
+  task_description: ""
+  repo_path: "."
+
+steps:
+  - id: announce
+    type: bash
+    command: |
+      set -euo pipefail
+      echo "task: $TASK_DESCRIPTION"
+      echo "repo: $REPO_PATH"
+```
+
+```bash
+amplihack recipe run env-aware-recipe \
+  -c task_description="Add validation for empty display names" \
+  -c repo_path=.
+```
+
+Output:
+
+```
+task: Add validation for empty display names
+repo: .
+```
+
+The same step could equivalently use `{{task_description}}` in the command text;
+both forms now resolve to the same value.
+
+### Nested sub-recipe inheriting the environment
+
+`parent.yaml`:
+
+```yaml
+name: parent
+context:
+  task_description: ""
+  repo_path: "."
+steps:
+  - id: call-child
+    type: recipe
+    recipe: child
+```
+
+`child.yaml`:
+
+```yaml
+name: child
+steps:
+  - id: read-inherited
+    type: bash
+    command: |
+      set -euo pipefail
+      # Even a grandchild shell sees the exported context.
+      sh -c 'set -u; echo "child sees: $TASK_DESCRIPTION at $REPO_PATH"'
+```
+
+```bash
+amplihack recipe run parent \
+  -c task_description="Ship the fix" \
+  -c repo_path=/work/repo
+```
+
+Output:
+
+```
+child sees: Ship the fix at /work/repo
+```
+
+### A skipped key
+
+The skip notice is a `WARN`-level event, so run with `RUST_LOG=warn` to see it
+(it is suppressed under the default error-only filter):
+
+```bash
+RUST_LOG=warn amplihack recipe run env-aware-recipe \
+  -c task_description="ok" \
+  -c "issue title=has spaces" \
+  -c repo_path=.
+```
+
+`issue title` uppercases to `ISSUE TITLE`, which is not a valid identifier, so it
+is skipped:
+
+```
+WARN recipe context key skipped for env export name=ISSUE TITLE reason=invalid_identifier
+```
+
+The recipe still runs; `TASK_DESCRIPTION` and `REPO_PATH` are exported normally.
+
+---
+
+## Configuration
+
+Context environment export has **no configuration flags**. It is always active
+and additive:
+
+- There is no opt-out. Recipes that do not read environment variables are
+  unaffected because the extra variables are simply present and unused.
+- The set of exported variables is determined entirely by the merged recipe
+  context. To change what is exported, change the context (`context:` block or
+  `-c/--context` flags), not a setting.
+- The reserved-name denylist is fixed in code; it is not user-configurable, by
+  design, because it is a security control.
+
+Large context maps continue to use the existing `--context-file` spill path for
+`{{placeholder}}` delivery (argv size protection); environment export is applied
+unconditionally and is subject only to the operating system's environment-size
+limits.
+
+---
+
+## Security model
+
+The trust boundary is: untrusted content (issue bodies, task descriptions,
+third-party recipes) → environment name and value → inherited by every nested
+shell step via the process environment.
+
+| Control | Description |
+|---------|-------------|
+| V1 — Input validation (allowlist) | Names must match `^[A-Z_][A-Z0-9_]*$`; values must not contain NUL. |
+| V2 — Reserved denylist (primary) | Loader, shell-startup, `IFS`, path/identity, interpreter-option, and `AMPLIHACK_`-prefixed names are never exported. |
+| G2 — Precedence as a control | Context is applied first (lowest priority); the environment builder and correlation id are applied after, so context can never override security-relevant builder configuration. |
+| Name-only logging | Skip warnings log the key name only, never the value, to avoid leaking sensitive context. |
+
+Note on threat shape: at the spawn seam, names and values are passed via
+`Command::env`, which performs **no** shell evaluation. The residual risk is
+therefore *name clobbering* (replacing a meaningful variable), not value
+injection — and clobbering of dangerous names is exactly what the denylist
+prevents.
+
+Defense-in-depth note: prefixing every exported name (for example
+`AMPLIHACK_CTX_TASK_DESCRIPTION`) would eliminate the entire name-clobber class.
+Bare names are retained for ergonomics (`$TASK_DESCRIPTION` is what recipe
+authors expect) and are safe **only** while the denylist remains exhaustive and
+fully test-covered.
+
+---
+
+## resolve-bundle-asset availability
+
+`smart-orchestrator`'s preflight requires the `amplihack resolve-bundle-asset`
+subcommand. That subcommand is implemented and wired in the Rust CLI:
+
+| Surface | Location |
+|---------|----------|
+| Subcommand definition | `crates/amplihack-cli/src/cli_commands.rs` (`ResolveBundleAsset`, `#[command(name = "resolve-bundle-asset")]`) |
+| Dispatch | `crates/amplihack-cli/src/commands/mod.rs` (`Commands::ResolveBundleAsset`) |
+| Implementation | `crates/amplihack-cli/src/resolve_bundle_asset/` |
+| Standalone binary | `bins/amplihack-asset-resolver/` (same single-argument interface) |
+
+A `cargo build -p amplihack-cli` therefore exposes `resolve-bundle-asset`.
+Reports of a "missing" subcommand trace to a **stale installed Python
+`amplihack`** earlier on `PATH`, not to the Rust binary. Confirm which binary is
+in use:
+
+```bash
+command -v amplihack
+amplihack resolve-bundle-asset --help
+```
+
+If the resolved binary is the legacy Python entry point, reinstall or reorder
+`PATH` so the Rust `amplihack` is selected. No code change in this area is
+required to unblock multi-workstream execution; this section exists to document
+the verification. See
+[resolve-bundle-asset command reference](./resolve-bundle-asset-command.md).
+
+---
+
+## Related
+
+- [Recipe Executor Environment](./recipe-executor-environment.md) — Subprocess launch, shell-step and agent-step environment injection
+- [Environment Variables](./environment-variables.md) — All variables read or injected by amplihack, including context-derived names
+- [Tutorial: Propagate Recipe Context to Bash Steps](../tutorials/recipe-context-env-propagation.md) — Hands-on walkthrough for top-level, nested, and skipped keys
+- [Troubleshoot Recipe Execution](../howto/troubleshoot-recipe-execution.md) — Diagnosing `TASK_DESCRIPTION: unbound variable` and related failures
+- [resolve-bundle-asset Command Reference](./resolve-bundle-asset-command.md) — Native bundle asset resolver
+- [Recipe Run Correlation Reference](./recipe-run-correlation.md) — `AMPLIHACK_RECIPE_RUN_ID` and pointer events

--- a/docs/reference/recipe-executor-environment.md
+++ b/docs/reference/recipe-executor-environment.md
@@ -5,6 +5,7 @@ Complete reference for the environment variables, prerequisite checks, and conte
 ## Contents
 
 - [Recipe runner subprocess launch](#recipe-runner-subprocess-launch)
+- [Recipe context environment export](#recipe-context-environment-export)
 - [Shell step environment injection](#shell-step-environment-injection)
 - [Agent step context augmentation](#agent-step-context-augmentation)
 - [Prerequisite validation](#prerequisite-validation)
@@ -46,6 +47,47 @@ The `recipe-runner-rs` child sees `AMPLIHACK_NONINTERACTIVE=1` and
 `AMPLIHACK_RECIPE_RUN_ID=<uuid>`, and it does not see `CLAUDECODE`. Nested agent
 launches therefore use the active agent routing contract instead of inheriting
 Claude-specific session behavior from the parent environment.
+
+---
+
+## Recipe context environment export
+
+In addition to the fixed subprocess variables above, `amplihack recipe run`
+exports **every recipe context variable** to the `recipe-runner-rs` subprocess
+as an environment variable. This lets bash steps read context directly — for
+example `$TASK_DESCRIPTION` and `$REPO_PATH` — instead of only through
+`{{placeholder}}` substitution. Because the export is inherited by every nested
+shell and sub-recipe step, the values work under `set -u` and deep inside
+composed workflows.
+
+| Aspect | Behavior |
+|--------|----------|
+| Source | The merged recipe context (`context` block + `-c/--context` flags + inferred values) |
+| Name | Context key, ASCII-uppercased (`task_description` → `TASK_DESCRIPTION`) |
+| Value | Context value, unchanged |
+| Validity | Names must match `^[A-Z_][A-Z0-9_]*$`; invalid keys are skipped (name-only `WARN`) |
+| Safety | Reserved/dangerous names (`PATH`, `LD_PRELOAD`, `BASH_ENV`, `IFS`, `AMPLIHACK_*`, …) are never exported |
+| Precedence | Lowest — applied before the subprocess builder and `AMPLIHACK_RECIPE_RUN_ID`, so builder-managed and correlation variables always win |
+
+### Example
+
+```bash
+amplihack recipe run env-aware-recipe \
+  -c task_description="Add validation for empty display names" \
+  -c repo_path=.
+```
+
+A bash step of `env-aware-recipe` can then run:
+
+```bash
+set -euo pipefail
+echo "task: $TASK_DESCRIPTION"   # Add validation for empty display names
+echo "repo: $REPO_PATH"          # .
+```
+
+The full contract — transform rules, the reserved-name denylist, the
+`context_env_pairs` API, precedence guarantees, and the security model — is in
+[Recipe Context Environment Export](./recipe-context-environment.md).
 
 ---
 
@@ -138,6 +180,7 @@ must never prompt for input.
 ## Related
 
 - [amplihack recipe](./recipe-command.md) — Full CLI reference for the recipe subcommand
+- [Recipe Context Environment Export](./recipe-context-environment.md) — Exporting recipe context variables to bash steps (uppercased, denylist, precedence)
 - [Environment Variables](./environment-variables.md) — All variables read or injected by amplihack
 - [Recipe Run Correlation Reference](./recipe-run-correlation.md) — Stable recipe run IDs and pointer events
 - [Recipe Execution Flow](../concepts/recipe-execution-flow.md) — Step execution architecture

--- a/docs/tutorials/recipe-context-env-propagation.md
+++ b/docs/tutorials/recipe-context-env-propagation.md
@@ -1,0 +1,203 @@
+# Propagate Recipe Context to Bash Steps
+
+Learn how recipe context variables reach bash steps as environment variables —
+so a step can read `$TASK_DESCRIPTION` and `$REPO_PATH` directly, even under
+`set -u` and inside nested sub-recipes.
+
+## What you will do
+
+1. Run a top-level recipe whose bash step reads context from the environment.
+2. Prove the values arrive under `set -u`.
+3. Confirm a nested sub-recipe inherits the same values.
+4. Observe a skipped (invalid) key being warned about, not crashing the run.
+5. Understand why dangerous names are never exported.
+
+## Before you start
+
+You need:
+
+- `amplihack` installed (the Rust CLI; verify with `command -v amplihack`)
+- a writable scratch directory
+- `bash`
+
+All context values feed both `{{placeholder}}` substitution and the process
+environment. This tutorial uses the environment form on purpose.
+
+## Step 1: Write a recipe that reads the environment
+
+```bash
+mkdir -p /tmp/ctx-env && cd /tmp/ctx-env
+
+cat > top.yaml << 'EOF'
+name: top
+description: Reads context from the environment under set -u
+version: "1.0"
+
+context:
+  task_description: ""
+  repo_path: "."
+
+steps:
+  - id: read-env
+    type: bash
+    command: |
+      set -euo pipefail
+      echo "TASK_DESCRIPTION=$TASK_DESCRIPTION"
+      echo "REPO_PATH=$REPO_PATH"
+EOF
+```
+
+The `set -u` line is the important part: before context environment export
+existed, this step aborted with `TASK_DESCRIPTION: unbound variable`.
+
+## Step 2: Run it and see the values
+
+```bash
+amplihack recipe run /tmp/ctx-env/top.yaml \
+  -c task_description="Add validation for empty display names" \
+  -c repo_path=.
+```
+
+Expected output:
+
+```
+TASK_DESCRIPTION=Add validation for empty display names
+REPO_PATH=.
+```
+
+The keys were lowercase in the context (`task_description`, `repo_path`) and
+arrived uppercased in the environment (`TASK_DESCRIPTION`, `REPO_PATH`). The
+values are passed through unchanged.
+
+## Step 3: Confirm a nested sub-recipe inherits the values
+
+Add a sub-recipe and a grandchild shell to prove inheritance flows all the way
+down.
+
+```bash
+cat > parent.yaml << 'EOF'
+name: parent
+context:
+  task_description: ""
+  repo_path: "."
+steps:
+  - id: call-child
+    type: recipe
+    recipe: child
+EOF
+
+cat > child.yaml << 'EOF'
+name: child
+steps:
+  - id: read-inherited
+    type: bash
+    command: |
+      set -euo pipefail
+      sh -c 'set -u; echo "child sees: $TASK_DESCRIPTION at $REPO_PATH"'
+EOF
+
+amplihack recipe run /tmp/ctx-env/parent.yaml \
+  -c task_description="Ship the fix" \
+  -c repo_path=/work/repo
+```
+
+Expected output:
+
+```
+child sees: Ship the fix at /work/repo
+```
+
+The CLI exports the context once, onto the `recipe-runner-rs` subprocess. The
+sub-recipe step — and even the `sh -c` grandchild it spawns — then inherit those
+values through normal OS process-environment inheritance. Because
+`recipe-runner-rs` is a separate binary, this `sh -c` line is the **canary** for
+the whole chain: it proves the export survives CLI → `recipe-runner-rs` → bash
+step → grandchild shell. If it prints the value (instead of aborting with
+`unbound variable` under `set -u`), end-to-end propagation works — the behavior
+multi-workstream campaigns depend on at `step-03-create-issue`.
+
+## Step 4: Watch an invalid key get skipped, not crash
+
+Context keys that cannot become valid shell identifiers are skipped with a
+name-only warning. The run still succeeds.
+
+The skip notice is a `WARN`-level log from the `amplihack` process. The CLI
+shows only `ERROR` by default, so set `RUST_LOG=warn` to see it:
+
+```bash
+RUST_LOG=warn amplihack recipe run /tmp/ctx-env/top.yaml \
+  -c task_description="ok" \
+  -c "issue title=has spaces" \
+  -c repo_path=. 2>&1 | grep -E 'skipped|TASK_DESCRIPTION|REPO_PATH'
+```
+
+Expected output includes:
+
+```
+WARN recipe context key skipped for env export name=ISSUE TITLE reason=invalid_identifier
+TASK_DESCRIPTION=ok
+REPO_PATH=.
+```
+
+`issue title` uppercases to `ISSUE TITLE`, which contains a space and is not a
+valid identifier, so it is dropped. Note the warning logs the **name only**,
+never the value. `TASK_DESCRIPTION` and `REPO_PATH` still export normally.
+
+## Step 5: Understand the security guardrails
+
+Some names are never exported from context, because setting them would change
+how the shell or dynamic loader behaves before your step runs. Try to inject one
+and confirm it is ignored:
+
+```bash
+cat > guard.yaml << 'EOF'
+name: guard
+steps:
+  - id: probe
+    type: bash
+    command: |
+      set -euo pipefail
+      echo "LD_PRELOAD=[${LD_PRELOAD:-unset}]"
+      echo "PATH unchanged? $(command -v echo >/dev/null && echo yes)"
+EOF
+
+RUST_LOG=warn amplihack recipe run /tmp/ctx-env/guard.yaml \
+  -c ld_preload=/tmp/evil.so \
+  -c path=/evil 2>&1 | grep -E 'LD_PRELOAD|PATH unchanged|skipped'
+```
+
+Expected output:
+
+```
+WARN recipe context key skipped for env export name=LD_PRELOAD reason=reserved_name
+WARN recipe context key skipped for env export name=PATH reason=reserved_name
+LD_PRELOAD=[unset]
+PATH unchanged? yes
+```
+
+`LD_PRELOAD` and `PATH` are on the reserved-name denylist, so the context values
+never reach the environment. The same protection covers `BASH_ENV`, `PS4`,
+`IFS`, the `DYLD_*`/`LD_*` loader variables, interpreter options like
+`PYTHONPATH` and `NODE_OPTIONS`, and any `AMPLIHACK_`-prefixed name.
+
+## Clean up
+
+```bash
+rm -rf /tmp/ctx-env
+```
+
+## What you learned
+
+- Recipe context is exported to bash steps as uppercased environment variables,
+  so `$TASK_DESCRIPTION` and `$REPO_PATH` work under `set -u`.
+- The export is inherited by nested sub-recipes and their grandchild shells.
+- Invalid keys are skipped with a name-only warning instead of failing the run.
+- Dangerous names are never exported, and builder-managed/correlation variables
+  always take precedence over context.
+
+## Related
+
+- [Recipe Context Environment Export — Reference](../reference/recipe-context-environment.md) — Full contract, transform rules, denylist, and API
+- [Recipe Executor Environment — Reference](../reference/recipe-executor-environment.md) — Subprocess and step-level environment injection
+- [Troubleshoot Recipe Execution](../howto/troubleshoot-recipe-execution.md) — Fixing `TASK_DESCRIPTION: unbound variable`
+- [Trace a Recipe Run Across Terminal and JSON Logs](./recipe-run-correlation.md) — Correlating runs by `AMPLIHACK_RECIPE_RUN_ID`


### PR DESCRIPTION
## Problem

Sub-recipe bash steps under `set -u` aborted with `TASK_DESCRIPTION: unbound variable` (and the sibling `REPO_PATH: unbound variable`, #4583). All six Simard follow-up multi-workstream campaigns failed at `step-03-create-issue` for this reason, producing no PRs.

**Root cause:** `amplihack-cli` spawns `recipe-runner-rs` and passes recipe context only as `--set key=value` / `--context-file` for `{{placeholder}}` substitution. Context was **never exported as environment variables**, so bash steps that read `$TASK_DESCRIPTION` / `$REPO_PATH` under `set -u` failed — especially in nested sub-recipes where the parent context was not threaded through.

## Fix

Export every recipe context variable to the spawned runner as an uppercased environment variable in `execute_recipe_via_rust` (`crates/amplihack-cli/src/commands/recipe/run/execute.rs`). OS process inheritance threads these into every bash step and nested sub-recipe.

- **`context_env_pairs`** — new pure, total transform: uppercases keys (`task_description` → `TASK_DESCRIPTION`), drops invalid identifiers, NUL-bearing values, and oversized values; rejects the `AMPLIHACK_` namespace and a reserved/dangerous-name denylist (`PATH`, `HOME`, `LD_PRELOAD`, `BASH_ENV`, `PS4`, `IFS`, `PYTHONPATH`, `NODE_OPTIONS`, …).
- **Lowest precedence** — applied before `EnvBuilder::apply_to_command` and `AMPLIHACK_RECIPE_RUN_ID`, so builder-managed and correlation vars always win and untrusted context cannot clobber `PATH`/`HOME`/`AMPLIHACK_*`.
- **E2BIG guard** — a per-value byte cap below the kernel's `MAX_ARG_STRLEN` prevents a pathologically large context value from re-introducing `E2BIG`; such values are still delivered via `--context-file`.

## resolve-bundle-asset (related infra)

Verified the Rust `amplihack` binary builds and exposes the `resolve-bundle-asset` subcommand (`amplihack resolve-bundle-asset --help` works). The reported "missing subcommand" was a stale installed Python `amplihack` on `PATH` — **no code change needed**.

## Tests (TDD, failing-first)

Added to `tests_execute.rs` (RED confirmed before implementation — `context_env_pairs` did not exist):

- Pure transform: uppercasing, value preservation, mixed-case/leading-underscore, invalid-identifier drop, NUL drop, oversized-value drop.
- Security: reserved/dangerous-name denylist and `AMPLIHACK_`-prefix rejection.
- Integration: top-level `set -u` reproduction; **nested sub-recipe (grandchild) propagation**; no-regression/precedence (context cannot clobber reserved/builder env).

`cargo test -p amplihack-cli` → **1578 passed, 0 failed** (incl. the existing `test_large_context_does_not_hit_e2big` regression test). `cargo fmt` + `cargo clippy -D warnings` clean.

## Docs

- New `docs/reference/recipe-context-environment.md` and `docs/tutorials/recipe-context-env-propagation.md`, linked from `docs/index.md` and `docs/recipes/README.md`.
- Updated `recipe-executor-environment.md`, `environment-variables.md`, and the recipe troubleshooting guide.

## Out of scope

Re-running historical campaigns; recipe-runner architecture refactor; new `resolve-bundle-asset` functionality; oversized-context hardening beyond the E2BIG guard.

Closes #784. Relates to #4583.