### PR TITLE
Fix AzDO PR publication terminal states (#765)

### DIFF
--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -237,7 +237,8 @@ steps:
       # Base-ref contract: resolve_pr_base_ref checks refs/remotes/origin/HEAD, runs git remote set-head origin -a, falls back through origin/master origin/develop, and fails with ERROR: no supported remote base ref found.
       # Metadata contract: ISSUE_NUM, git diff, git log, git diff --name-only, Changed files, Validation, Behavior, Risk, and step-13 shape PR title/body context.
       # PUBLISH_STATE="no-diff"; PUBLISH_STATE="existing-open-pr"; PUBLISH_STATE="already-merged"; PUBLISH_STATE="closed-after-merge"; PUBLISH_STATE="closed-unmerged-with-diff".
-      # Terminal vocabulary: MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED, BLOCKED_CI.
+      # Provider-aware states: GitHub preserves existing scoped PR behavior; AzDO uses REMOTE_HOST_TYPE=azdo with az repos pr list/create.
+      # Terminal vocabulary: MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED, EXISTING_OPEN_PR, BLOCKED_CI, BLOCKED_PROVIDER.
       # gh pr create is called by the helper only after PUBLISH_STATE classification.
       # gh pr create failed is surfaced by workflow_publish_pr.sh as FAILED_PR_CREATE.
       PUBLISH_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_publish_pr.sh"

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -139,6 +139,15 @@ if [ "$probe_success" = "true" ]; then
 fi
 
 case "$PUBLISH_STATE" in
+  BLOCKED_PROVIDER)
+    terminal_success="false"
+    terminal_state_out="BLOCKED_PROVIDER"
+    terminal_reason_out="${PR_PUBLISH_RESULT_MESSAGE:-${RECIPE_VAR_pr_publish_result__message:-provider publication failed or was ambiguous}}"
+    terminal_failure="true"
+    emit_terminal_evidence
+    echo "ERROR: workflow publish provider is blocked: $terminal_reason_out" >&2
+    exit 1
+    ;;
   no-diff|NO_DIFF_SUCCESS|CLOSED_OBSOLETE)
     if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
       RUNTIME_ARTIFACT_HELPER="${WORKFLOW_RUNTIME_ARTIFACT_HELPER:-${SCRIPT_DIR}/workflow_runtime_artifacts.sh}"
@@ -231,7 +240,7 @@ validate_final_pr_scope() {
 }
 
 case "$PUBLISH_STATE" in
-  FOLLOWUP_CREATED|MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS)
+  FOLLOWUP_CREATED|EXISTING_OPEN_PR|MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS)
     publish_state_reached="true"
     ;;
 esac
@@ -286,7 +295,7 @@ emit_terminal_evidence
 
 echo ""
 case "$terminal_state_out" in
-  MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS|FOLLOWUP_CREATED|IMPLEMENTED_VERIFIED|ALLOW_NO_OP|closed-after-merge|already-merged|no-diff)
+  MERGED|CLOSED_OBSOLETE|NO_DIFF_SUCCESS|FOLLOWUP_CREATED|EXISTING_OPEN_PR|IMPLEMENTED_VERIFIED|ALLOW_NO_OP|closed-after-merge|already-merged|no-diff)
     echo "terminal_status=$terminal_state_out"
     ;;
 esac

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -165,6 +165,85 @@ gh_pr_create_with_retry() {
   done
 }
 
+sanitize_provider_stderr() {
+  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
+}
+
+azdo_common_args=()
+configure_azdo_args() {
+  local org_url project_name
+  org_url="${AZDO_ORG_URL:-${SYSTEM_COLLECTIONURI:-}}"
+  project_name="${AZDO_PROJECT:-${SYSTEM_TEAMPROJECT:-}}"
+  azdo_common_args=()
+  [ -n "$org_url" ] && azdo_common_args+=(--org "$org_url")
+  [ -n "$project_name" ] && azdo_common_args+=(--project "$project_name")
+}
+
+az_repos_pr_list_with_retry() {
+  local stderr_file output status attempt delay=1
+  configure_azdo_args
+  for attempt in 1 2 3; do
+    stderr_file=$(mktemp -t step16-az-pr-list-XXXXXX)
+    if output=$(timeout 60 az repos pr list "${azdo_common_args[@]}" --status active --source-branch "$CURRENT_BRANCH" --target-branch "$BASE_BRANCH" --output json 2>"$stderr_file"); then
+      rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
+    else
+      status=$?
+    fi
+    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
+      echo "WARNING: az repos pr list failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_provider_stderr "$stderr_file")" >&2
+      rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
+    fi
+    echo "ERROR: az repos pr list failed (exit ${status}); refusing to risk duplicate PR creation." >&2
+    [ ! -s "$stderr_file" ] || echo "az repos pr list stderr: $(sanitize_provider_stderr "$stderr_file")" >&2
+    rm -f "$stderr_file"
+    return "$status"
+  done
+}
+
+az_repos_pr_create_with_retry() {
+  local stderr_file output status attempt delay=1
+  configure_azdo_args
+  for attempt in 1 2 3; do
+    stderr_file=$(mktemp -t step16-az-pr-create-XXXXXX)
+    if output=$(timeout 60 az repos pr create "${azdo_common_args[@]}" --source-branch "$CURRENT_BRANCH" --target-branch "$BASE_BRANCH" --title "$PR_TITLE" --description "$PR_BODY" --output json 2>"$stderr_file"); then
+      rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
+    else
+      status=$?
+    fi
+    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
+      echo "WARNING: az repos pr create failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_provider_stderr "$stderr_file")" >&2
+      rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
+    fi
+    echo "ERROR: az repos pr create failed (exit ${status}); provider state is ambiguous." >&2
+    [ ! -s "$stderr_file" ] || echo "az repos pr create stderr: $(sanitize_provider_stderr "$stderr_file")" >&2
+    rm -f "$stderr_file"
+    return "$status"
+  done
+}
+
+select_matching_azdo_pr() {
+  local pr_list_json="$1"
+  printf '%s' "$pr_list_json" | jq -c \
+    --arg src "$CURRENT_BRANCH" \
+    --arg src_ref "refs/heads/$CURRENT_BRANCH" \
+    --arg tgt "$BASE_BRANCH" \
+    --arg tgt_ref "refs/heads/$BASE_BRANCH" \
+    'map(select(
+      ((.sourceRefName // "") == $src or (.sourceRefName // "") == $src_ref) and
+      ((.targetRefName // "") == $tgt or (.targetRefName // "") == $tgt_ref) and
+      (((.status // "") | ascii_downcase) == "active")
+    )) | .[0] // empty'
+}
+
+load_azdo_pr_fields() {
+  local pr_json="$1"
+  mapfile -t AZDO_PR_FIELDS < <(
+    printf '%s' "$pr_json" | jq -r '.url // "", ((.pullRequestId // "") | tostring), .status // "", .sourceRefName // "", .targetRefName // ""'
+  )
+  PR_URL_RESULT="${AZDO_PR_FIELDS[0]:-}"
+  PR_NUMBER_RESULT="${AZDO_PR_FIELDS[1]:-}"
+}
+
 scoped_pr_lookup() {
   local scope_output reason created_after expected_pr_title_prefix
   [ -x "$PR_SCOPE_HELPER" ] || finish_publish "FAILED_INVALID_INPUT" "invalid-input" "failure" "workflow_pr_scope.sh is missing or not executable at $PR_SCOPE_HELPER" 1
@@ -193,18 +272,11 @@ scoped_pr_lookup() {
 }
 
 HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
-if [ "$HOST_TYPE" != "github" ]; then
-  finish_publish "non-github" "non-github" "success" "non-GitHub host does not use gh pr create"
-fi
-
 CURRENT_BRANCH=$(git branch --show-current)
 ISSUE_NUM="$ISSUE_NUMBER"
 if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then echo "ERROR: issue_number is not numeric: $ISSUE_NUM" >&2; exit 1; fi
-if ! command -v gh >/dev/null 2>&1; then echo "ERROR: workflow_publish_pr.sh requires the GitHub CLI ('gh') on PATH." >&2; exit 127; fi
 [ -n "$CURRENT_BRANCH" ] || finish_publish "FAILED_INVALID_INPUT" "invalid-input" "failure" "current branch is empty; cannot publish from detached HEAD" 1
 LOCAL_HEAD="$(git rev-parse --verify HEAD 2>/dev/null)" || finish_publish "FAILED_INVALID_INPUT" "invalid-input" "failure" "local HEAD does not resolve" 1
-REPO_IDENTITY="$(parse_github_repo_identity "$(git config --get remote.origin.url 2>/dev/null || true)" || true)"
-[ -n "$REPO_IDENTITY" ] || finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "unable to determine current GitHub repo identity from origin remote" 1
 
 BASE_REF="$(resolve_pr_base_ref)"
 BASE_BRANCH="${BASE_REF#origin/}"
@@ -217,6 +289,55 @@ if [ -n "$(git status --porcelain)" ]; then
   finish_publish "FAILED_DIRTY_WORKTREE" "dirty-worktree" "failure" "dirty worktree blocks no-diff or obsolete terminal success; commit or discard changes explicitly" 1
 fi
 if git diff --quiet "${BASE_REF}..HEAD"; then BRANCH_DIFF_STATUS="no-diff"; else BRANCH_DIFF_STATUS="has-diff"; fi
+
+if [ "$HOST_TYPE" = "azdo" ]; then
+  if [ "$BRANCH_DIFF_STATUS" = "no-diff" ]; then
+    finish_publish "NO_DIFF_SUCCESS" "no-diff" "success" "branch has no diff against base; no PR created"
+  fi
+  COMMITS_AHEAD=$(git rev-list --count "${BASE_REF}..HEAD" 2>/dev/null || echo "0")
+  if [ "$COMMITS_AHEAD" -eq 0 ]; then
+    BRANCH_DIFF_STATUS="no-diff"
+    finish_publish "NO_DIFF_SUCCESS" "no-diff" "success" "0 commits ahead of ${BASE_BRANCH}; no PR created"
+  fi
+  if ! command -v az >/dev/null 2>&1; then
+    finish_publish "BLOCKED_PROVIDER" "azdo-cli-missing" "failure" "Azure DevOps CLI ('az') is required to publish AzDO pull requests" 1
+  fi
+  if ! AZDO_PR_LIST_JSON="$(az_repos_pr_list_with_retry)"; then
+    finish_publish "BLOCKED_PROVIDER" "azdo-pr-list-failed" "failure" "AzDO active PR lookup failed; provider/auth state is ambiguous" 1
+  fi
+  if AZDO_PR_JSON="$(select_matching_azdo_pr "$AZDO_PR_LIST_JSON")" && [ -n "$AZDO_PR_JSON" ]; then
+    load_azdo_pr_fields "$AZDO_PR_JSON"
+    finish_publish "EXISTING_OPEN_PR" "existing-open-pr" "success" "existing active AzDO PR found for branch"
+  fi
+
+  CHANGED_FILES=$(git diff --name-only "${BASE_REF}..HEAD" 2>/dev/null | head -40 || true)
+  CHANGED_FILES_BODY=$(printf '%s\n' "$CHANGED_FILES" | sed '/^$/d; s/^/- /')
+  [ -n "$CHANGED_FILES_BODY" ] || CHANGED_FILES_BODY="- No changed files detected by git diff"
+  DIFF_STAT=$(git diff --stat "${BASE_REF}..HEAD" 2>/dev/null | tail -20 || true)
+  DIFF_STAT_BODY="${DIFF_STAT:-No diff stat available}"
+  PR_TITLE="Update ${CURRENT_BRANCH} (AB#${ISSUE_NUM})"
+  PR_TITLE="${PR_TITLE:0:200}"
+  PR_BODY=$(printf '## Summary\nWorkflow-generated Azure DevOps PR for AB#%s.\n\n## Changed files\n%s\n\n## Diff stat\n```text\n%s\n```\n' "$ISSUE_NUM" "$CHANGED_FILES_BODY" "$DIFF_STAT_BODY")
+  if ! AZDO_CREATED_JSON="$(az_repos_pr_create_with_retry)"; then
+    finish_publish "BLOCKED_PROVIDER" "azdo-pr-create-failed" "failure" "AzDO PR creation failed; provider state is ambiguous" 1
+  fi
+  load_azdo_pr_fields "$AZDO_CREATED_JSON"
+  [ -n "$PR_NUMBER_RESULT" ] || finish_publish "BLOCKED_PROVIDER" "azdo-pr-create-invalid" "failure" "AzDO PR creation returned no pullRequestId" 1
+  PUBLISH_STATE="FOLLOWUP_CREATED"
+  LEGACY_PUBLISH_STATE="create-new-pr"
+  TERMINAL_STATUS="success"
+  MESSAGE="AzDO PR created"
+  emit_publish_result
+  exit 0
+fi
+
+if [ "$HOST_TYPE" != "github" ]; then
+  finish_publish "non-github" "non-github" "success" "non-GitHub host does not use provider PR creation"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then echo "ERROR: workflow_publish_pr.sh requires the GitHub CLI ('gh') on PATH." >&2; exit 127; fi
+REPO_IDENTITY="$(parse_github_repo_identity "$(git config --get remote.origin.url 2>/dev/null || true)" || true)"
+[ -n "$REPO_IDENTITY" ] || finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "unable to determine current GitHub repo identity from origin remote" 1
 
 PR_JSON="$(scoped_pr_lookup)"
 load_pr_fields "$PR_JSON"

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -120,6 +120,10 @@ name = "workflow_publish_resilience"
 path = "../../tests/integration/workflow_publish_resilience.rs"
 
 [[test]]
+name = "workflow_publish_azdo_contract"
+path = "../../tests/integration/workflow_publish_azdo_contract_test.rs"
+
+[[test]]
 name = "default_workflow_terminal_state"
 path = "../../tests/integration/default_workflow_terminal_state.rs"
 

--- a/tests/integration/workflow_publish_azdo_contract_test.rs
+++ b/tests/integration/workflow_publish_azdo_contract_test.rs
@@ -1,0 +1,346 @@
+//! Provider-aware Azure DevOps PR publication contracts.
+
+use serde_json::Value as JsonValue;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn helper_path(name: &str) -> PathBuf {
+    workspace_root()
+        .join("amplifier-bundle")
+        .join("tools")
+        .join(name)
+}
+
+fn helper_text(name: &str) -> String {
+    let path = helper_path(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn workflow_publish_text() -> String {
+    let path = workspace_root()
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join("workflow-publish.yaml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| panic!("create {}: {e}", parent.display()));
+    }
+    fs::write(path, content).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+            .unwrap_or_else(|e| panic!("chmod {}: {e}", path.display()));
+    }
+}
+
+fn run_cmd(dir: &Path, program: &str, args: &[&str]) {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("run {program} {args:?} in {}: {e}", dir.display()));
+    assert!(
+        output.status.success(),
+        "command failed: {program} {args:?}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn create_repo(tmp: &TempDir, with_diff: bool) -> PathBuf {
+    let repo = tmp.path().join("repo");
+    fs::create_dir(&repo).expect("create repo");
+    run_cmd(&repo, "git", &["init", "-b", "main"]);
+    run_cmd(&repo, "git", &["config", "user.email", "test@example.com"]);
+    run_cmd(&repo, "git", &["config", "user.name", "Workflow Test"]);
+    write_file(&repo.join("README.md"), "base\n");
+    run_cmd(&repo, "git", &["add", "README.md"]);
+    run_cmd(&repo, "git", &["commit", "-m", "base"]);
+    run_cmd(
+        &repo,
+        "git",
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://dev.azure.com/org/project/_git/repo",
+        ],
+    );
+    run_cmd(
+        &repo,
+        "git",
+        &["update-ref", "refs/remotes/origin/main", "main"],
+    );
+    run_cmd(&repo, "git", &["switch", "-c", "feature/issue-765"]);
+    if with_diff {
+        write_file(&repo.join("feature.txt"), "feature\n");
+        run_cmd(&repo, "git", &["add", "feature.txt"]);
+        run_cmd(&repo, "git", &["commit", "-m", "feature"]);
+    }
+    repo
+}
+
+fn install_fake_tools(tmp: &TempDir, mode: &str) -> (PathBuf, PathBuf) {
+    let bin_dir = tmp.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+    let az_log = tmp.path().join("az.log");
+    let az = bin_dir.join("az");
+    write_file(
+        &az,
+        &format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> {az_log:?}
+mode={mode:?}
+if [ "${{1:-}}" = "repos" ] && [ "${{2:-}}" = "pr" ] && [ "${{3:-}}" = "list" ]; then
+  case "$mode" in
+    existing)
+      cat <<'JSON'
+[
+  {{"pullRequestId":456,"status":"active","sourceRefName":"refs/heads/feature/issue-765","targetRefName":"refs/heads/main","url":"https://dev.azure.com/org/project/_git/repo/pullrequest/456"}}
+]
+JSON
+      exit 0
+      ;;
+    create|none)
+      printf '[]\n'
+      exit 0
+      ;;
+    authfail)
+      echo "fatal: https://secret-token@dev.azure.com/org/project auth failed" >&2
+      exit 42
+      ;;
+  esac
+fi
+if [ "${{1:-}}" = "repos" ] && [ "${{2:-}}" = "pr" ] && [ "${{3:-}}" = "create" ]; then
+  if [ "$mode" = "create" ]; then
+    cat <<'JSON'
+{{"pullRequestId":789,"status":"active","url":"https://dev.azure.com/org/project/_git/repo/pullrequest/789"}}
+JSON
+    exit 0
+  fi
+  echo "create must not be reached for mode=$mode" >&2
+  exit 77
+fi
+echo "unexpected az call: $*" >&2
+exit 99
+"#,
+            az_log = az_log.display().to_string(),
+            mode = mode
+        ),
+    );
+    make_executable(&az);
+
+    let amplihack = bin_dir.join("amplihack");
+    write_file(
+        &amplihack,
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    );
+    make_executable(&amplihack);
+
+    (bin_dir, az_log)
+}
+
+fn run_publish(repo: &Path, bin_dir: &Path) -> Output {
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    Command::new("bash")
+        .arg(helper_path("workflow_publish_pr.sh"))
+        .current_dir(repo)
+        .env("PATH", format!("{}:{old_path}", bin_dir.display()))
+        .env("REMOTE_HOST_TYPE", "azdo")
+        .env("ISSUE_NUMBER", "765")
+        .env("SYSTEM_COLLECTIONURI", "https://dev.azure.com/org/")
+        .env("SYSTEM_TEAMPROJECT", "project")
+        .output()
+        .expect("run workflow_publish_pr.sh")
+}
+
+fn parse_stdout_json(output: &Output) -> JsonValue {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("parse stdout JSON: {e}\n{stdout}"))
+}
+
+#[test]
+fn publish_recipe_and_helper_declare_azdo_terminal_contract() {
+    let recipe = workflow_publish_text();
+    let helper = helper_text("workflow_publish_pr.sh");
+
+    for required in [
+        "REMOTE_HOST_TYPE",
+        "azdo",
+        "az repos pr list",
+        "az repos pr create",
+        "EXISTING_OPEN_PR",
+        "BLOCKED_PROVIDER",
+        "NO_DIFF_SUCCESS",
+        "FOLLOWUP_CREATED",
+    ] {
+        assert!(
+            recipe.contains(required) || helper.contains(required),
+            "AzDO publish contract missing `{required}`"
+        );
+    }
+    assert!(
+        !helper.contains("non-GitHub host does not use gh pr create"),
+        "AzDO must not be handled as a generic non-GitHub successful skip"
+    );
+}
+
+#[test]
+fn azdo_existing_active_pr_returns_existing_open_pr_without_create() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = create_repo(&tmp, true);
+    let (bin_dir, az_log) = install_fake_tools(&tmp, "existing");
+
+    let output = run_publish(&repo, &bin_dir);
+    assert!(
+        output.status.success(),
+        "existing AzDO PR should be idempotent\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["state"], "EXISTING_OPEN_PR");
+    assert_eq!(json["terminal_status"], "success");
+    assert_eq!(json["pr_number"], "456");
+
+    let log = fs::read_to_string(&az_log).expect("read az log");
+    assert!(
+        log.contains("repos pr list"),
+        "must query active PRs; log:\n{log}"
+    );
+    assert!(
+        !log.contains("repos pr create"),
+        "existing AzDO PR must suppress create; log:\n{log}"
+    );
+}
+
+#[test]
+fn azdo_no_diff_returns_no_diff_success_without_create() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = create_repo(&tmp, false);
+    let (bin_dir, az_log) = install_fake_tools(&tmp, "none");
+
+    let output = run_publish(&repo, &bin_dir);
+    assert!(
+        output.status.success(),
+        "no-diff AzDO branch should be terminal success\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["state"], "NO_DIFF_SUCCESS");
+    assert_eq!(json["branch_diff_status"], "no-diff");
+
+    let log = fs::read_to_string(&az_log).unwrap_or_default();
+    assert!(
+        !log.contains("repos pr create"),
+        "no-diff AzDO branch must not create PR; log:\n{log}"
+    );
+}
+
+#[test]
+fn azdo_diff_without_existing_pr_creates_followup_pr_once() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = create_repo(&tmp, true);
+    let (bin_dir, az_log) = install_fake_tools(&tmp, "create");
+
+    let output = run_publish(&repo, &bin_dir);
+    assert!(
+        output.status.success(),
+        "AzDO branch with diff should create PR\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["state"], "FOLLOWUP_CREATED");
+    assert_eq!(json["terminal_status"], "success");
+    assert_eq!(json["pr_number"], "789");
+
+    let log = fs::read_to_string(&az_log).expect("read az log");
+    assert!(
+        log.contains("repos pr list"),
+        "must check duplicates first; log:\n{log}"
+    );
+    assert_eq!(
+        log.matches("repos pr create").count(),
+        1,
+        "must create exactly one AzDO PR; log:\n{log}"
+    );
+}
+
+#[test]
+fn azdo_auth_or_cli_failure_is_blocked_provider_not_successful_skip() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = create_repo(&tmp, true);
+    let (bin_dir, _az_log) = install_fake_tools(&tmp, "authfail");
+
+    let output = run_publish(&repo, &bin_dir);
+    assert!(
+        !output.status.success(),
+        "AzDO auth/provider failure must block publication\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["state"], "BLOCKED_PROVIDER");
+    assert_eq!(json["terminal_status"], "failure");
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("secret-token"),
+        "provider stderr must redact credential-bearing URLs"
+    );
+}
+
+#[test]
+fn final_status_blocks_azdo_missing_pr_instead_of_manual_success() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = create_repo(&tmp, true);
+
+    let output = Command::new("bash")
+        .arg(helper_path("workflow_final_status.sh"))
+        .current_dir(&repo)
+        .env("REMOTE_HOST_TYPE", "azdo")
+        .env("ISSUE_NUMBER", "765")
+        .env("TASK_DESCRIPTION", "verify AzDO publish terminal state")
+        .env("IMPLEMENTATION_COMPLETED", "true")
+        .env("VERIFICATION_COMPLETED", "true")
+        .env("PUBLISH_STATE_REACHED", "false")
+        .env("PR_PUBLISH_RESULT_STATE", "BLOCKED_PROVIDER")
+        .output()
+        .expect("run workflow_final_status.sh");
+
+    assert!(
+        !output.status.success(),
+        "blocked AzDO publication must not complete manually\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("BLOCKED_PROVIDER") || stderr.contains("BLOCKED_PROVIDER"),
+        "final status must preserve blocked-provider evidence"
+    );
+    assert!(
+        !stdout.contains("manual creation required")
+            && !stderr.contains("manual creation required"),
+        "final status must not represent missing AzDO publication as manual success"
+    );
+}


### PR DESCRIPTION
## Summary
- Add explicit Azure DevOps PR publication semantics to workflow_publish_pr.sh.
- Return EXISTING_OPEN_PR for matching active AzDO PRs instead of creating duplicates.
- Return NO_DIFF_SUCCESS for no-diff AzDO branches and BLOCKED_PROVIDER for AzDO CLI/auth/provider failures.
- Prevent workflow_final_status.sh from treating blocked AzDO publication as manual success.

## Validation
- pre-commit run --all-files
- cargo test -p amplihack --test workflow_publish_azdo_contract --test workflow_publish_resilience --test workflow_publish_terminal_gate --test workflow_finalize_terminal_state --quiet

Closes #765