### PR TITLE
Fix local tracking issue extraction

### DIFF
--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -376,8 +376,9 @@ steps:
       # Extract issue number — handles GitHub, AzDO, and local tracking.
       ISSUE_CREATION="$ISSUE_CREATION"; TASK_DESC_RAW="$TASK_DESCRIPTION"
       EXTRACTED=""
-      LOCAL_TRACKING_RE='(^|[[:space:]])(tracking_system=local|issue_creation=local-tracking|(tracking_reference|tracking_issue)=(local-|local-tracking:)[^[:space:]]+)($|[[:space:]])'
-      if [[ "$ISSUE_CREATION" =~ $LOCAL_TRACKING_RE ]]; then printf ''; exit 0; fi
+      LOCAL_TRACKING_RE='(^|[[:space:]])(tracking_reference|tracking_issue)=(local-[a-zA-Z0-9._:-]+|local-tracking:[a-zA-Z0-9._:-]+)($|[[:space:]])'
+      LOCAL_MARKER_RE='(^|[[:space:]])(tracking_system=local|issue_creation=local-tracking|(tracking_reference|tracking_issue)=local[^[:space:]]*)($|[[:space:]])'
+      if [[ "$ISSUE_CREATION" =~ $LOCAL_TRACKING_RE ]]; then printf ''; exit 0; elif [[ "$ISSUE_CREATION" =~ $LOCAL_MARKER_RE ]]; then echo "ERROR: local tracking metadata missing valid local reference." >&2; exit 1; fi
       if [[ "$ISSUE_CREATION" =~ issues/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ pull/([0-9]+) ]]; then PR_NUMBER="${BASH_REMATCH[1]}"
         command -v gh >/dev/null 2>&1 && EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo '')

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -376,13 +376,13 @@ steps:
       # Extract issue number — handles GitHub, AzDO, and local tracking.
       ISSUE_CREATION="$ISSUE_CREATION"; TASK_DESC_RAW="$TASK_DESCRIPTION"
       EXTRACTED=""
+      LOCAL_TRACKING_RE='(^|[[:space:]])(tracking_system=local|tracking_reference=(local-[^[:space:]]+|local-tracking:[^[:space:]]+)|tracking_issue=(local-[^[:space:]]+|local-tracking:[^[:space:]]+)|issue_creation=local-tracking)($|[[:space:]])'
+      if [[ "$ISSUE_CREATION" =~ $LOCAL_TRACKING_RE ]]; then printf ''; exit 0; fi
       if [[ "$ISSUE_CREATION" =~ issues/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ pull/([0-9]+) ]]; then PR_NUMBER="${BASH_REMATCH[1]}"; EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo ''); [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"
       elif [[ "$ISSUE_CREATION" =~ _workitems/edit/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ issue_number=([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
-      elif [[ "$ISSUE_CREATION" =~ local-(issue|ab)-([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[2]}"
-      elif [[ "$ISSUE_CREATION" =~ local-tracking:([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC_RAW" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC_RAW" =~ \#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       fi

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -376,7 +376,7 @@ steps:
       # Extract issue number — handles GitHub, AzDO, and local tracking.
       ISSUE_CREATION="$ISSUE_CREATION"; TASK_DESC_RAW="$TASK_DESCRIPTION"
       EXTRACTED=""
-      LOCAL_TRACKING_RE='(^|[[:space:]])(tracking_system=local|tracking_reference=(local-[^[:space:]]+|local-tracking:[^[:space:]]+)|tracking_issue=(local-[^[:space:]]+|local-tracking:[^[:space:]]+)|issue_creation=local-tracking)($|[[:space:]])'
+      LOCAL_TRACKING_RE='(^|[[:space:]])(tracking_system=local|issue_creation=local-tracking|(tracking_reference|tracking_issue)=(local-|local-tracking:)[^[:space:]]+)($|[[:space:]])'
       if [[ "$ISSUE_CREATION" =~ $LOCAL_TRACKING_RE ]]; then printf ''; exit 0; fi
       if [[ "$ISSUE_CREATION" =~ issues/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ pull/([0-9]+) ]]; then PR_NUMBER="${BASH_REMATCH[1]}"; EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo ''); [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -379,7 +379,9 @@ steps:
       LOCAL_TRACKING_RE='(^|[[:space:]])(tracking_system=local|issue_creation=local-tracking|(tracking_reference|tracking_issue)=(local-|local-tracking:)[^[:space:]]+)($|[[:space:]])'
       if [[ "$ISSUE_CREATION" =~ $LOCAL_TRACKING_RE ]]; then printf ''; exit 0; fi
       if [[ "$ISSUE_CREATION" =~ issues/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
-      elif [[ "$ISSUE_CREATION" =~ pull/([0-9]+) ]]; then PR_NUMBER="${BASH_REMATCH[1]}"; EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo ''); [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"
+      elif [[ "$ISSUE_CREATION" =~ pull/([0-9]+) ]]; then PR_NUMBER="${BASH_REMATCH[1]}"
+        command -v gh >/dev/null 2>&1 && EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo '')
+        [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"
       elif [[ "$ISSUE_CREATION" =~ _workitems/edit/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ issue_number=([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"

--- a/docs/concepts/multi-provider-workflow-architecture.md
+++ b/docs/concepts/multi-provider-workflow-architecture.md
@@ -39,22 +39,23 @@ another `case` branch is lower than maintaining an adapter registry.
 
 ---
 
-## The Issue Number Contract
+## The Tracking Identifier Contract
 
-All providers produce the same output: a plain integer `issue_number`. This
-is the contract that downstream steps depend on.
+Remote providers produce the same output shape: a plain integer `issue_number`.
+Local tracking produces an opaque local reference instead. This keeps GitHub and
+Azure DevOps behavior stable while avoiding the false claim that a local ID is a
+remote issue number.
 
-| Provider   | Source                    | Example   |
-| ---------- | ------------------------- | --------- |
-| GitHub     | `gh issue create` URL     | `684`     |
-| AzDO       | `az boards` work item ID  | `12345`   |
-| Other/Local | Structured local metadata | `482193` |
+| Provider | Source | Workflow identifier |
+| -------- | ------ | ------------------- |
+| GitHub | `gh issue create` URL | `issue_number=684` |
+| AzDO | `az boards` work item ID | `issue_number=12345` |
+| Other/Local | Structured local metadata | `tracking_reference=local-482193`, `issue_number=` |
 
-By normalizing to an integer at step 03b, no downstream step needs to know
-which provider produced it. Branch names, commit messages, and PR
-descriptions all use `issue_number` as a plain number with provider-specific
-formatting applied only at the point of use (e.g., `Closes #684` for GitHub,
-`AB#12345` for AzDO, `Ref #4821937` for other).
+Step 03b applies numeric extraction only after it has found no local-prefixed
+tracking reference. Branch names, commit messages, and PR descriptions use
+provider-specific formatting at the point of use: `Closes #684` for GitHub,
+`AB#12345` for AzDO, and `Ref local-482193` for local tracking.
 
 ---
 
@@ -81,9 +82,11 @@ enables the workflow to run in isolated environments (CI containers,
 air-gapped systems, fresh `git init` repos). Other/local mode:
 
 - Emits structured local metadata such as `tracking_system=local`,
-  `tracking_reference=local-issue-N`, and `issue_creation=local-tracking`
+  `tracking_reference=local-*`, and `issue_creation=local-tracking`; the
+  local-prefixed reference is required for successful local extraction
 - Skips all network calls (no `gh`, no `az`)
-- Produces valid branch names and commit messages
+- Produces valid branch names and commit messages without numeric issue
+  extraction
 - Skips PR creation (no remote to push to)
 
 ---
@@ -94,7 +97,7 @@ air-gapped systems, fresh `git init` repos). Other/local mode:
 | ---------------------------- | ---------------------------------- | ------------------------------------- |
 | Detect-once pattern          | Single detection, no repeated work | One step to maintain                  |
 | `case` over adapters         | Simpler, no indirection            | Adding providers requires editing steps |
-| Numeric issue_number contract | Downstream steps stay unchanged   | Provider URL information is lost       |
+| Remote issue_number contract | GitHub/AzDO steps stay unchanged | Local steps also need `tracking_reference` |
 | Other as fallback            | Works everywhere                   | No tracking system updated             |
 | Manual AzDO PR creation      | Avoids brittle automation          | Extra manual step for AzDO users       |
 | Context propagation required | Explicit data flow                 | Must declare vars in parent recipe     |

--- a/docs/features/dual-provider-workflow.md
+++ b/docs/features/dual-provider-workflow.md
@@ -87,15 +87,19 @@ Local metadata is multiline step output, not a provider URL:
 
 ```text
 tracking_system=local
-tracking_reference=local-issue-482193
-tracking_issue=local-issue-482193
+tracking_reference=local-482193
+tracking_issue=local-482193
 issue_creation=local-tracking
-issue_number=482193
+issue_number=
 ```
 
-`issue_number=N` is present when step 03 can derive a numeric local reference
-from explicit context or task text. Downstream extraction also accepts numeric
-suffixes in `tracking_reference=local-issue-N` and `tracking_reference=local-ab-N`.
+For local tracking, `tracking_reference` and `tracking_issue` are the
+authoritative identifiers. `tracking_system=local` marks local mode, but Step
+03b succeeds only when a local-prefixed `tracking_reference` /
+`tracking_issue` or legacy `local-tracking:*` reference is present. Step 03b
+checks those references before numeric extraction, preserves the local
+reference, and leaves `issue_number` empty. Local IDs are never coerced into
+GitHub-style issue numbers.
 
 ---
 
@@ -163,7 +167,7 @@ gh label commands -> not invoked
 git remote set-url origin https://gitlab.com/acme/service.git
 
 amplihack recipe run default-workflow \
-  -c task_description="Add config parser #482193" \
+  -c task_description="Add config parser" \
   -c repo_path=.
 ```
 

--- a/docs/howto/configure-dual-provider-workflow.md
+++ b/docs/howto/configure-dual-provider-workflow.md
@@ -104,11 +104,15 @@ instead of attempting a GitHub issue operation:
 
 ```text
 tracking_system=local
-tracking_reference=local-issue-12345
-tracking_issue=local-issue-12345
+tracking_reference=local-12345
+tracking_issue=local-12345
 issue_creation=local-tracking
-issue_number=12345
+issue_number=
 ```
+
+The local reference is the durable identifier for that run. Step 03b preserves
+it only because the reference is local-prefixed, then leaves `issue_number`
+empty instead of converting `12345` into a GitHub issue number.
 
 ---
 
@@ -156,8 +160,10 @@ no GitHub issue or label command runs
 ```
 
 Use `remote_host_type=other` to force local tracking and block provider API
-calls. `remote_host_type=azure-devops` remains accepted as a compatibility
-alias for external callers, but primary examples should use `azdo`.
+calls. Local tracking uses `tracking_reference` / `tracking_issue`, not a
+numeric `issue_number`. `remote_host_type=azure-devops` remains accepted as a
+compatibility alias for external callers, but primary examples should use
+`azdo`.
 
 ---
 

--- a/docs/reference/dual-provider-workflow.md
+++ b/docs/reference/dual-provider-workflow.md
@@ -104,7 +104,7 @@ The feature contract is host-aware matching. A URL such as
 | `github` | Reuse `#N` after `gh issue view` validates it | `gh issue create`; label setup stays in this branch | Most GitHub creation errors fail; repository access/resolution failures fall back to local metadata |
 | `azdo` | Reuse `issue_number=N`, `AB#N`, or host-scoped `#N` as an Azure Boards candidate | `az boards work-item create` when Azure Boards is available | Structured local metadata |
 | `azure-devops` | Compatibility alias for `azdo` when supplied by callers | Same as `azdo` | Same as `azdo` |
-| `other`, empty, unknown | Reuse numeric `issue_number=N` only as local context | No provider creation | Structured local metadata |
+| `other`, empty, unknown | Preserve local tracking metadata when supplied | No provider creation | Structured local metadata |
 
 The Azure DevOps branch does not call GitHub first and then recover from the
 failure. It bypasses GitHub issue and label commands before those commands are
@@ -182,10 +182,11 @@ output is multiline key/value metadata.
 | GitHub | `https://github.com/OWNER/REPO/issues/123` | `123` |
 | Azure DevOps existing work item | `AB#12345` | `12345` |
 | Azure DevOps work item URL | `https://dev.azure.com/ORG/PROJECT/_workitems/edit/12345` | `12345` |
-| Local metadata | `tracking_system=local` plus `tracking_reference=local-issue-482193`, `tracking_issue=local-issue-482193`, `issue_creation=local-tracking`, and usually `issue_number=482193` | `482193` when a numeric local reference is present |
+| Local metadata | `tracking_system=local` plus `tracking_reference=local-482193`, `tracking_issue=local-482193`, `issue_creation=local-tracking`, and `issue_number=` | Empty; local reference is preserved instead |
 
-Downstream workflow steps consume only the numeric `issue_number` plus
-`REMOTE_HOST_TYPE`.
+Downstream workflow steps consume numeric `issue_number` for GitHub and Azure
+DevOps. For local tracking, they consume `tracking_reference` /
+`tracking_issue`; `issue_number` is empty.
 
 ---
 
@@ -195,21 +196,24 @@ Local fallback output is structured metadata:
 
 ```text
 tracking_system=local
-tracking_reference=local-issue-482193
-tracking_issue=local-issue-482193
+tracking_reference=local-482193
+tracking_issue=local-482193
 issue_creation=local-tracking
-issue_number=482193
+issue_number=
 ```
 
 `tracking_reference` is the durable local identifier for the run. It may use
-`local-issue-N`, `local-ab-N`, or another `local-*` value when no numeric
-provider-style reference is available. `issue_number=N` is emitted when step 03
-can derive a numeric value from explicit `issue_number`, `AB#N`, `#N`, or a
-numeric local reference. Step 03b must fail visibly if local metadata contains
-no extractable numeric ID and no compatibility task-text fallback can supply one.
+`local-N`, `local-issue-N`, `local-ab-N`, or another `local-*` value.
+`tracking_system=local` is a mode marker, not a complete local reference by
+itself. Step 03b checks for a local-prefixed `tracking_reference` /
+`tracking_issue` before numeric extraction; when one is present, it preserves
+the local reference, emits an empty `issue_number`, and exits successfully.
+Numeric-looking local IDs are not GitHub issues and are not Azure Boards work
+item IDs.
 
-`local-tracking:N` is accepted only as a legacy compatibility format. New docs
-and tests should use the structured metadata above.
+`local-tracking:N` is accepted as a legacy local reference format and is
+preserved as local tracking. Its numeric suffix is not copied to
+`issue_number`.
 
 ---
 
@@ -264,7 +268,7 @@ AB#12345
 git remote set-url origin https://gitlab.com/acme/service.git
 
 amplihack recipe run default-workflow \
-  -c task_description="Add config parser #482193" \
+  -c task_description="Add config parser" \
   -c repo_path=.
 ```
 
@@ -272,10 +276,10 @@ Step 03 emits:
 
 ```text
 tracking_system=local
-tracking_reference=local-issue-482193
-tracking_issue=local-issue-482193
+tracking_reference=local-482193
+tracking_issue=local-482193
 issue_creation=local-tracking
-issue_number=482193
+issue_number=
 ```
 
 ---
@@ -293,7 +297,7 @@ Required scenarios:
 | AzDO `https://dev.azure.com/...` remote | No `gh issue` or `gh label` command is invoked |
 | AzDO `https://ORG.visualstudio.com/...` remote | No `gh issue` or `gh label` command is invoked |
 | AzDO `git@ssh.dev.azure.com:v3/...` remote | No `gh issue` or `gh label` command is invoked |
-| Unsupported remote | Local tracking is used without provider CLI calls |
+| Unsupported remote | Local tracking is used without provider CLI calls; `tracking_reference` / `tracking_issue` propagate to downstream branch, commit, and status steps; local IDs are not coerced into `issue_number` |
 
 The AzDO tests use a `gh` sentinel that fails the test if any GitHub issue or
 label command is invoked.

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -177,16 +177,17 @@ Step 03 emits structured local metadata without making any network calls:
 
 ```text
 tracking_system=local
-tracking_reference=local-issue-482193
-tracking_issue=local-issue-482193
+tracking_reference=local-482193
+tracking_issue=local-482193
 issue_creation=local-tracking
-issue_number=482193
+issue_number=
 ```
 
 The local reference is an opaque workflow reference, not a durable provider
-record and not a global uniqueness guarantee. It is used only for branch naming
-(`feat/issue-<N>-slug`) and commit message references when a numeric ID is
-available. No tracking system is updated.
+record and not a global uniqueness guarantee. It is preserved as
+`tracking_reference` / `tracking_issue` for branch naming and local commit
+references. It is not coerced into a numeric `issue_number`. No tracking system
+is updated.
 
 ---
 
@@ -202,11 +203,11 @@ provider output format produced by Step 03:
 | GitHub PR fallback | `https://github.com/owner/repo/pull/N` | `pull/([0-9]+)` plus closing-issue lookup |
 | Azure DevOps | `https://dev.azure.com/org/project/_workitems/edit/N` | `_workitems/edit/([0-9]+)` |
 | Azure DevOps | `AB#N` | `AB#([0-9]+)` |
-| Other/local | Structured local metadata with `issue_number=N` or `tracking_reference=local-issue-N` / `local-ab-N` | `issue_number=([0-9]+)` or `local-(issue\|ab)-([0-9]+)` |
+| Other/local | Structured local metadata with `tracking_system=local` plus `tracking_reference=local-*` / `tracking_issue=local-*`, or legacy `local-tracking:*` | Preserve local reference; leave `issue_number` empty |
 
-The `issue_number` output contract remains unchanged: a plain integer.
-Downstream steps never see the provider URL format — they only consume the
-numeric ID.
+The remote `issue_number` output contract remains unchanged: GitHub and Azure
+DevOps produce a plain integer. Local tracking intentionally leaves
+`issue_number` empty and passes the local reference forward.
 
 ---
 
@@ -221,11 +222,11 @@ step 02d, declared in the parent recipe's context block):
 | `github`  | `Closes #N`      | `feat: add auth (Closes #684)`    |
 | `azdo`    | `AB#N`           | `feat: add auth (AB#12345)`       |
 | `azure-devops` | `AB#N`      | `feat: add auth (AB#12345)`       |
-| `other`   | `Ref #N`         | `feat: add auth (Ref #4821937)`   |
+| `other`   | `Ref <local-ref>` | `feat: add auth (Ref local-482193)` |
 
 The `Closes #N` format triggers GitHub's auto-close behavior. The `AB#N`
-format triggers Azure Boards work item linking. The `Ref #N` format is a
-neutral reference that does not trigger automation on any platform.
+format triggers Azure Boards work item linking. The local `Ref <local-ref>`
+format is a neutral reference that does not trigger automation on any platform.
 
 ---
 
@@ -256,9 +257,10 @@ message on stderr. After the workflow completes, create a PR manually using
 
 The worktree setup step (`step-04-setup-worktree`) previously derived the
 working directory from the issue URL, which was always a GitHub URL. With
-multi-provider support, the worktree path derivation uses only the
-`issue_number` integer (provider-agnostic) and the slugified task
-description.
+multi-provider support, the worktree path derivation uses the provider tracking
+key and the slugified task description: numeric `issue_number` for GitHub/Azure
+DevOps, or `tracking_reference` / `tracking_issue` for local tracking. Local
+mode must not derive paths from an empty `issue_number`.
 
 See [recipe-step-04-worktree-reattach-prune.md](recipe-step-04-worktree-reattach-prune.md)
 for the full worktree lifecycle documentation.
@@ -294,7 +296,7 @@ commands.
 | `github`  | `PR: <url>` (with `gh pr view` details)   | `Issue: #N`          |
 | `azdo`    | `PR: N/A (manual creation required)`      | `Issue: AB#N`        |
 | `azure-devops` | `PR: N/A (manual creation required)` | `Issue: AB#N` |
-| `other`   | `PR: N/A (no remote provider)`            | `Issue: Ref #N`      |
+| `other`   | `PR: N/A (no remote provider)`            | `Issue: Ref <local-ref>` |
 
 The `HOST_TYPE=${REMOTE_HOST_TYPE:-other}` local variable pattern is used
 for `set -u` safety — if the context variable is unset for any reason, the
@@ -306,23 +308,27 @@ step degrades to "other" behavior rather than failing.
 
 Variables added or modified by the multi-provider feature:
 
-| Variable           | Set by    | Type   | Description                                  |
-| ------------------ | --------- | ------ | -------------------------------------------- |
-| `remote_host_type` | step-02d or caller | string | `"github"`, `"azdo"`, `"azure-devops"`, or `"other"` |
-| `azdo_org_url`     | step-03   | string | Full AzDO org URL (local to step-03; empty if not AzDO) |
-| `azdo_org`         | step-03   | string | AzDO organization name (local to step-03; empty if not AzDO) |
-| `azdo_project`     | step-03   | string | AzDO project name, percent-decoded (local to step-03; empty if not AzDO) |
-| `work_item_type`   | user/step-02 | string | AzDO work item type; default `"Task"`       |
-| `issue_number`     | step-03b  | int    | Numeric ID (unchanged contract)               |
+| Variable             | Set by    | Type   | Description                                  |
+| -------------------- | --------- | ------ | -------------------------------------------- |
+| `remote_host_type`   | step-02d or caller | string | `"github"`, `"azdo"`, `"azure-devops"`, or `"other"` |
+| `azdo_org_url`       | step-03   | string | Full AzDO org URL (local to step-03; empty if not AzDO) |
+| `azdo_org`           | step-03   | string | AzDO organization name (local to step-03; empty if not AzDO) |
+| `azdo_project`       | step-03   | string | AzDO project name, percent-decoded (local to step-03; empty if not AzDO) |
+| `work_item_type`     | user/step-02 | string | AzDO work item type; default `"Task"`       |
+| `issue_number`       | step-03b  | int or empty string | Numeric GitHub/Azure DevOps ID; empty for local tracking |
+| `tracking_system`    | step-03/step-03b | string | `local` when the workflow is using local tracking |
+| `tracking_reference` | step-03/step-03b | string | Local-prefixed reference consumed by branch, commit, publish, and status steps |
+| `tracking_issue`     | step-03/step-03b | string | Local tracking alias preserved for compatibility with existing step naming |
 
-**Parent recipe declaration**: The `remote_host_type` context variable must
-be declared with an empty-string default in `default-workflow.yaml`'s
-`context:` block. This is required for propagation to work across sub-recipe
-boundaries — without this declaration, the recipe-runner's
-`_execute_sub_recipe()` context-merging will not thread the value through to
-phases like `workflow-publish` or `workflow-finalize`. The AzDO-specific
-variables (`azdo_org`, `azdo_project`, `azdo_org_url`) do NOT require parent
-declaration because they are local to step-03 within `workflow-prep`.
+**Parent recipe declaration**: `remote_host_type`, `issue_number`,
+`tracking_system`, `tracking_reference`, and `tracking_issue` must be declared
+with empty-string defaults in `default-workflow.yaml`'s `context:` block. This
+is required for propagation to work across sub-recipe boundaries — without these
+declarations, the recipe-runner's `_execute_sub_recipe()` context-merging will
+not thread the values through to phases like `workflow-worktree`,
+`workflow-publish`, or `workflow-finalize`. The AzDO-specific variables
+(`azdo_org`, `azdo_project`, `azdo_org_url`) do NOT require parent declaration
+because they are local to step-03 within `workflow-prep`.
 
 ---
 
@@ -356,7 +362,7 @@ should not be treated as a stable public API.
 | Azure DevOps path has `issue_number`  | Reuses `AB#N`; does not call `gh` or create a work item |
 | `az boards` not installed             | Step-03 falls back to structured local metadata    |
 | `az boards` auth expired              | Warning logged; falls back to structured local metadata |
-| AzDO work item creation fails         | Warning logged; structured local metadata is used for branch naming when numeric |
+| AzDO work item creation fails         | Warning logged; structured local metadata is used; downstream steps use `tracking_reference` instead of empty `issue_number` |
 | Percent-decode invalid sequence       | Warning logged; falls back to structured local metadata |
 | AzDO project name validation fails    | Warning logged; falls back to structured local metadata |
 | `gh` not installed (GitHub remote)    | GitHub creation fails clearly unless the failure is a repository access/resolution failure that triggers local metadata fallback |
@@ -463,13 +469,14 @@ Workflow proceeds as in Example 2.
 ```bash
 cd ~/my-local-project && git init
 amplihack recipe run default-workflow \
-  -c task_description="Add config parser #482193" \
+  -c task_description="Add config parser" \
   -c repo_path=.
 ```
 
-Step 02d detects `other`. Step 03 emits structured local metadata. Step 15 uses
-`Ref #N`. Step 16 skips PR creation. Step 22b shows
-`PR: N/A (no remote provider)`.
+Step 02d detects `other`. Step 03 emits structured local metadata. Step 04 uses
+the local reference in the branch/worktree name. Step 15 uses `Ref
+<local-ref>`. Step 16 skips PR creation. Step 22b shows `PR: N/A (no remote
+provider)` and `Issue: Ref <local-ref>`.
 
 ---
 

--- a/docs/reference/recipe-step-03-idempotency.md
+++ b/docs/reference/recipe-step-03-idempotency.md
@@ -42,8 +42,9 @@ amplihack recipe run default-workflow \
   -c repo_path="$(pwd)"
 ```
 
-Step 03 emits a parseable tracking reference, and step 03b extracts the same
-numeric ID for downstream branch, commit, and PR logic.
+Step 03 emits a parseable tracking reference. Step 03b extracts numeric IDs for
+GitHub and Azure DevOps outputs, and preserves local tracking references without
+coercing them into issue numbers.
 
 ```
 AB#12345
@@ -191,16 +192,19 @@ metadata, or unavailable Azure CLI support produce structured local metadata:
 
 ```text
 tracking_system=local
-tracking_reference=local-issue-482193
-tracking_issue=local-issue-482193
+tracking_reference=local-482193
+tracking_issue=local-482193
 issue_creation=local-tracking
-issue_number=482193
+issue_number=
 ```
 
-Local metadata preserves the workflow's numeric `issue_number` contract when a
-numeric local reference can be derived from explicit `issue_number`, `AB#N`,
-`#N`, or `local-issue-N` / `local-ab-N`. If no numeric local reference is
-available, step 03b must fail visibly instead of inventing an ID silently.
+Local metadata preserves the workflow's local tracking contract. The
+`tracking_reference` / `tracking_issue` value is authoritative, and
+`issue_number` is empty. `tracking_system=local` marks local mode, but Step 03b
+requires a local-prefixed `tracking_reference` / `tracking_issue` or legacy
+`local-tracking:*` reference before it treats the output as local. Step 03b
+detects that local reference before numeric extraction so values such as
+`local-123` and `local-tracking:123` are not treated as provider issue numbers.
 
 ---
 
@@ -223,11 +227,10 @@ It extracts the numeric ID from:
 - GitHub PR URLs containing `/pull/N` with closing-issue lookup fallback
 - Azure DevOps work-item URLs containing `/_workitems/edit/N`
 - Azure Boards references in the form `AB#N`
-- Local metadata containing `issue_number=N`
-- Local metadata references in the form `tracking_reference=local-issue-N` or `tracking_reference=local-ab-N`
-- Legacy local tracking references in the form `local-tracking:N`
 
-This keeps the downstream `issue_number` output provider-agnostic.
+For local metadata, step 03b preserves the local-prefixed `tracking_reference` /
+`tracking_issue` and leaves `issue_number` empty. This keeps the remote `issue_number` output
+provider-agnostic without pretending local IDs are remote issue numbers.
 
 ---
 
@@ -268,6 +271,7 @@ public API.
 | `remote_host_type=azdo` or `azure-devops` with existing `issue_number` | Emits `AB#N` and exits 0 without calling `gh` or creating a work item |
 | Azure CLI missing on Azure DevOps create path | Falls back to structured local metadata with a warning |
 | Azure DevOps org/project cannot be parsed | Falls back to structured local metadata with a warning |
+| Local tracking reference contains digits | Preserves the local reference and emits empty `issue_number`; digits are not extracted |
 | Non-numeric issue reference extracted | Explicit `^[0-9]+$` validation rejects it before any provider CLI receives it |
 
 The step uses `set -euo pipefail`. All expected-failure exit paths use
@@ -451,10 +455,10 @@ amplihack recipe run default-workflow \
 
 ```text
 tracking_system=local
-tracking_reference=local-issue-482193
-tracking_issue=local-issue-482193
+tracking_reference=local-482193
+tracking_issue=local-482193
 issue_creation=local-tracking
-issue_number=482193
+issue_number=
 ```
 
 Unknown host values never enter GitHub or Azure DevOps provider logic.
@@ -501,7 +505,7 @@ gadugi-test validate tests/gadugi/step-03-issue-creation-idempotency.yaml
 | Azure DevOps existing context reuse | `issue_number=N` emits `AB#N` without calling `gh` |
 | Azure DevOps task text candidates | `AB#N` and host-scoped `#N` references stay in Azure Boards logic and never trigger GitHub issue commands |
 | Generic fallback | Unknown, empty, and non-git hosts emit structured local metadata |
-| Output compatibility with step-03b | GitHub URL, Azure Boards URL, `AB#N`, structured local metadata, and legacy `local-tracking:N` parse to numeric IDs |
+| Output compatibility with step-03b | GitHub URL, Azure Boards URL, and `AB#N` parse to numeric IDs; structured local metadata with local-prefixed references and `local-tracking:*` preserve local references with empty `issue_number` |
 | Host isolation | Azure DevOps and generic paths never execute `gh issue` commands |
 | `set -euo pipefail` and quoted host dispatch | Shell syntax remains safe for empty or malformed context |
 

--- a/docs/reference/workflow-issue-extraction.md
+++ b/docs/reference/workflow-issue-extraction.md
@@ -60,7 +60,7 @@ Supported `issue_creation` formats:
 | `https://github.com/owner/repo/pull/N` | Uses `gh pr view` to read the first closing issue; falls back to PR number `N` if no closing issue resolves |
 | `https://dev.azure.com/org/project/_workitems/edit/N` | Extracts `N` from `/_workitems/edit/N` without a network call |
 | `AB#N` | Extracts `N` without a network call |
-| Structured local metadata with `tracking_system=local` | Preserves local tracking metadata; leaves `issue_number` empty |
+| Structured local metadata with `tracking_system=local` plus a valid local-prefixed `tracking_reference` or `tracking_issue` | Preserves local tracking metadata; leaves `issue_number` empty |
 | Local reference `tracking_reference=local-*` or `tracking_issue=local-*` | Preserves the local reference; leaves `issue_number` empty |
 | Legacy reference `tracking_reference=local-tracking:*` or `tracking_issue=local-tracking:*` | Preserves the local reference; leaves `issue_number` empty |
 
@@ -179,16 +179,18 @@ commit messages, publish output, and final status.
 
 ### Local detection contract
 
-Local extraction succeeds when Step 03 emits local mode or a local reference:
+Local extraction succeeds only when Step 03 emits a local-prefixed tracking
+reference:
 
-- `tracking_system=local`
 - `tracking_reference=local-*`
 - `tracking_issue=local-*`
 - `tracking_reference=local-tracking:*`
 - `tracking_issue=local-tracking:*`
 
-The `local-*` prefix is intentional. It prevents unrelated numeric text in local
-metadata from being treated as a GitHub issue or Azure Boards work item.
+The `local-*` prefix is intentional. `tracking_system=local` and
+`issue_creation=local-tracking` are mode markers, not sufficient identifiers.
+This prevents unrelated numeric text in malformed local metadata from being
+treated as a GitHub issue or Azure Boards work item.
 
 ---
 

--- a/docs/reference/workflow-issue-extraction.md
+++ b/docs/reference/workflow-issue-extraction.md
@@ -2,11 +2,9 @@
 
 > [Home](../index.md) > Reference > Workflow Issue Extraction
 
-Reference for the issue-number extraction logic in `default-workflow` step
-`03b`. This step resolves a provider-neutral tracking number from the workflow
-context so downstream steps can link the working branch, commit, and pull
-request to the correct GitHub issue, Azure Boards work item, or local tracking
-ID.
+Reference for the tracking extraction logic in `default-workflow` step `03b`.
+This step resolves a numeric `issue_number` for GitHub and Azure DevOps, or
+preserves a local-prefixed tracking reference for local/unsupported repositories.
 
 ## Contents
 
@@ -27,17 +25,20 @@ ID.
 ## Overview
 
 Step `03b` accepts the `issue_creation` output from step 03 plus the original
-`task_description`, then produces a canonical `issue_number` integer that the
-rest of the workflow uses.
+`task_description`. For GitHub and Azure DevOps outputs, it produces a
+canonical `issue_number` integer. For local tracking outputs, it preserves
+`tracking_reference` / `tracking_issue` and leaves `issue_number` empty.
 
 ```
-issue_creation + task_description ──► 03b extraction ──► issue_number (int)
+issue_creation + task_description ──► 03b extraction ──► issue_number or local reference
 ```
 
-Step 03 is responsible for emitting a parseable tracking reference. If neither
-Step 03 output nor the compatibility task-text fallback is parseable, Step 03b
-fails loudly instead of silently continuing with the wrong branch or commit
-reference.
+Step 03 is responsible for emitting a parseable tracking reference. Local
+tracking is recognized before any numeric extraction runs, so values such as
+`local-123` and `local-tracking:123` remain local identifiers instead of
+becoming issue number `123`. If neither Step 03 output nor the compatibility
+task-text fallback is parseable, Step 03b fails loudly instead of silently
+continuing with the wrong branch or commit reference.
 
 ---
 
@@ -59,9 +60,9 @@ Supported `issue_creation` formats:
 | `https://github.com/owner/repo/pull/N` | Uses `gh pr view` to read the first closing issue; falls back to PR number `N` if no closing issue resolves |
 | `https://dev.azure.com/org/project/_workitems/edit/N` | Extracts `N` from `/_workitems/edit/N` without a network call |
 | `AB#N` | Extracts `N` without a network call |
-| Structured local metadata with `issue_number=N` | Extracts `N` without a network call |
-| Structured local metadata with `tracking_reference=local-issue-N` or `tracking_reference=local-ab-N` | Extracts `N` without a network call |
-| Legacy `local-tracking:N` | Extracts `N` without a network call |
+| Structured local metadata with `tracking_system=local` plus `tracking_reference=local-*` or `tracking_issue=local-*` | Preserves the local reference; leaves `issue_number` empty |
+| Local reference `tracking_reference=local-*` or `tracking_issue=local-*` | Preserves the local reference; leaves `issue_number` empty |
+| Legacy `local-tracking:*` | Preserves the local reference; leaves `issue_number` empty |
 
 ```
 Input:  "https://github.com/rysweet/amplihack-rs/issues/3960"
@@ -108,9 +109,12 @@ task_description: "Continue work on AB#12345"
 Output:           issue_number=12345
 ```
 
-This fallback is intentionally regex-only. Step 03 is responsible for deciding
-whether `#N` means a GitHub issue, Azure Boards work item, or local reference;
-Step 03b only preserves the numeric workflow contract.
+This fallback is intentionally regex-only and runs only after local tracking has
+been ruled out. Step 03 is responsible for deciding whether `#N` means a GitHub
+issue or Azure Boards work item; Step 03b preserves the remote numeric workflow
+contract without converting local tracking IDs. If input is local but lacks a
+supported local reference prefix, Step 03b must fail instead of falling through
+to bare `#N` extraction.
 
 ---
 
@@ -126,7 +130,7 @@ compatibility.
 | GitHub PR fallback | `https://github.com/owner/repo/pull/4143` | First closing issue, or `4143` if none resolves |
 | Azure DevOps work item URL | `https://dev.azure.com/org/project/_workitems/edit/12345` | `12345` |
 | Azure Boards shorthand | `AB#12345` | `12345` |
-| Local metadata | `tracking_system=local` plus `tracking_reference=local-issue-482193`, `tracking_issue=local-issue-482193`, `issue_creation=local-tracking`, and `issue_number=482193` | `482193` |
+| Local metadata | `tracking_system=local` plus `tracking_reference=local-482193`, `tracking_issue=local-482193`, `issue_creation=local-tracking`, and `issue_number=` | Preserved local reference; empty `issue_number` |
 | Compatibility Azure Boards reference | `AB#12345` in `task_description` | `12345` |
 | Compatibility bare reference | `#12345` in `task_description` | `12345` |
 
@@ -140,9 +144,12 @@ known work item without requiring a live Azure CLI lookup.
 
 After step `03b` completes, the workflow context contains:
 
-| Field          | Type          | Description                                             |
-| -------------- | ------------- | ------------------------------------------------------- |
-| `issue_number` | `int` | Provider-neutral tracking number extracted from step 03 output |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `issue_number` | `int` or empty string | Numeric provider ID for GitHub/AzDO, empty for local tracking |
+| `tracking_reference` | `string`, optional | Authoritative local tracking reference; required for local success unless legacy `local-tracking:*` is the source |
+| `tracking_issue` | `string`, optional | Local tracking issue/reference alias preserved from step 03 |
+| `tracking_system` | `string`, optional | `local` when step 03 selected local tracking |
 
 ### Example output
 
@@ -152,8 +159,36 @@ After step `03b` completes, the workflow context contains:
 }
 ```
 
+For local tracking:
+
+```json
+{
+  "tracking_system": "local",
+  "tracking_reference": "local-482193",
+  "tracking_issue": "local-482193",
+  "issue_number": ""
+}
+```
+
 If extraction fails, step 03b exits non-zero and prints the unparseable
 `issue_creation` value to stderr.
+
+These fields must be declared in the parent workflow context so they propagate
+past `workflow-prep`. Downstream steps use `issue_number` for GitHub/Azure
+DevOps, and `tracking_reference` / `tracking_issue` for local branch names,
+commit messages, publish output, and final status.
+
+### Local detection contract
+
+`tracking_system=local` is only a mode marker. It is not sufficient on its own.
+Local extraction succeeds only when one of these local references is present:
+
+- `tracking_reference=local-*`
+- `tracking_issue=local-*`
+- legacy `local-tracking:*`
+
+The `local-*` prefix is intentional. It prevents unrelated numeric text in local
+metadata from being treated as a GitHub issue or Azure Boards work item.
 
 ---
 
@@ -168,6 +203,7 @@ workflow:
 | **Regex-only numeric capture** | Every accepted identifier is captured with `[0-9]+`; no provider CLI receives an unvalidated ID |
 | **60-second timeout** | GitHub PR closing-issue lookup uses `timeout 60`; hung subprocesses do not stall the workflow |
 | **No provider crossover** | Azure Boards formats (`AB#N`, `_workitems/edit/N`) are parsed locally and do not require GitHub CLI calls |
+| **Local before numeric** | Local metadata is detected before numeric regex extraction so `local-123` and `local-tracking:123` are not coerced into issue `123` |
 | **Visible failure** | If no supported pattern matches, the step exits non-zero and prints the unparseable `issue_creation` value to stderr |
 
 ---
@@ -178,12 +214,13 @@ Step `03b` reads the following values from the workflow context:
 
 | Context key | Required | Description |
 | ----------- | -------- | ----------- |
-| `issue_creation` | Yes | Step 03 output: GitHub URL, Azure Boards URL, `AB#N`, structured local metadata, or legacy `local-tracking:N` |
+| `issue_creation` | Yes | Step 03 output: GitHub URL, Azure Boards URL, `AB#N`, structured local metadata with a local-prefixed reference, or legacy `local-tracking:*` |
 | `task_description` | Yes | Free-form string used only as a compatibility fallback source for `AB#N` or `#N` references |
 
 No environment variables are specific to step `03b`. GitHub PR closing-issue
 lookup relies on the authenticated `gh` CLI configured in the user's shell.
-Azure Boards and local tracking extraction are regex-only.
+Azure Boards extraction is regex-only. Local tracking preservation is prefix and
+metadata based.
 
 ---
 
@@ -250,16 +287,35 @@ issue_number: 12345
 ```yaml
 issue_creation: |
   tracking_system=local
-  tracking_reference=local-issue-482193
-  tracking_issue=local-issue-482193
+  tracking_reference=local-482193
+  tracking_issue=local-482193
   issue_creation=local-tracking
-  issue_number=482193
+  issue_number=
 ```
 
 ```
-issue_number metadata match: 482193
-issue_number: 482193
+local tracking match: tracking_reference=local-482193
+tracking_reference: local-482193
+issue_number: ""
 ```
+
+---
+
+### Resolving from legacy local tracking
+
+```yaml
+issue_creation: "local-tracking:123"
+task_description: "Add config parser"
+```
+
+```
+legacy local tracking match: local-tracking:123
+tracking_reference: local-tracking:123
+issue_number: ""
+```
+
+The numeric suffix is preserved as part of the local reference. It is not copied
+to `issue_number`.
 
 ---
 
@@ -283,7 +339,7 @@ stderr includes the unparseable issue_creation value
 Install and authenticate the GitHub CLI: `gh auth login`.
 Only GitHub PR closing-issue lookup requires `gh`; direct issue URLs, Azure
 Boards outputs, `AB#N`, structured local metadata, and legacy
-`local-tracking:N` still parse without it.
+`local-tracking:*` still resolve without it.
 
 **GitHub PR lookup returns no closing issues**
 
@@ -313,13 +369,14 @@ to GitHub issue and PR patterns:
 | GitHub PR | `https://github.com/owner/repo/pull/N` | `pull/([0-9]+)` plus closing-issue lookup |
 | Azure DevOps | `https://dev.azure.com/org/project/_workitems/edit/N` | `_workitems/edit/([0-9]+)` |
 | Azure DevOps | `AB#N` | `AB#([0-9]+)` |
-| Local | Structured metadata with `issue_number=N` | `issue_number=([0-9]+)` |
-| Local | Structured metadata with `tracking_reference=local-issue-N` or `tracking_reference=local-ab-N` | `local-(issue\|ab)-([0-9]+)` |
-| Local legacy | `local-tracking:N` | `local-tracking:([0-9]+)` |
+| Local | Structured metadata with `tracking_system=local` plus `tracking_reference=local-*` or `tracking_issue=local-*` | Preserve the local reference; leave `issue_number` empty |
+| Local | `tracking_reference=local-*` or `tracking_issue=local-*` | Preserve the local reference; leave `issue_number` empty |
+| Local legacy | `local-tracking:*` | Preserve the local reference; leave `issue_number` empty |
 
-The `issue_number` output contract is unchanged: a plain integer regardless of
-provider. See [Multi-Provider Workflow Reference](multi-provider-workflow.md)
-for full details.
+The remote `issue_number` output contract is unchanged: GitHub and Azure DevOps
+produce plain integers. Local tracking intentionally does not. See
+[Multi-Provider Workflow Reference](multi-provider-workflow.md) for full
+details.
 
 ---
 

--- a/docs/reference/workflow-issue-extraction.md
+++ b/docs/reference/workflow-issue-extraction.md
@@ -60,9 +60,9 @@ Supported `issue_creation` formats:
 | `https://github.com/owner/repo/pull/N` | Uses `gh pr view` to read the first closing issue; falls back to PR number `N` if no closing issue resolves |
 | `https://dev.azure.com/org/project/_workitems/edit/N` | Extracts `N` from `/_workitems/edit/N` without a network call |
 | `AB#N` | Extracts `N` without a network call |
-| Structured local metadata with `tracking_system=local` plus `tracking_reference=local-*` or `tracking_issue=local-*` | Preserves the local reference; leaves `issue_number` empty |
+| Structured local metadata with `tracking_system=local` | Preserves local tracking metadata; leaves `issue_number` empty |
 | Local reference `tracking_reference=local-*` or `tracking_issue=local-*` | Preserves the local reference; leaves `issue_number` empty |
-| Legacy `local-tracking:*` | Preserves the local reference; leaves `issue_number` empty |
+| Legacy reference `tracking_reference=local-tracking:*` or `tracking_issue=local-tracking:*` | Preserves the local reference; leaves `issue_number` empty |
 
 ```
 Input:  "https://github.com/rysweet/amplihack-rs/issues/3960"
@@ -112,9 +112,8 @@ Output:           issue_number=12345
 This fallback is intentionally regex-only and runs only after local tracking has
 been ruled out. Step 03 is responsible for deciding whether `#N` means a GitHub
 issue or Azure Boards work item; Step 03b preserves the remote numeric workflow
-contract without converting local tracking IDs. If input is local but lacks a
-supported local reference prefix, Step 03b must fail instead of falling through
-to bare `#N` extraction.
+contract without converting local tracking IDs. If Step 03 marks the output as local, Step 03b must skip numeric extraction
+instead of falling through to bare `#N` extraction.
 
 ---
 
@@ -130,7 +129,7 @@ compatibility.
 | GitHub PR fallback | `https://github.com/owner/repo/pull/4143` | First closing issue, or `4143` if none resolves |
 | Azure DevOps work item URL | `https://dev.azure.com/org/project/_workitems/edit/12345` | `12345` |
 | Azure Boards shorthand | `AB#12345` | `12345` |
-| Local metadata | `tracking_system=local` plus `tracking_reference=local-482193`, `tracking_issue=local-482193`, `issue_creation=local-tracking`, and `issue_number=` | Preserved local reference; empty `issue_number` |
+| Local metadata | `tracking_system=local` plus `tracking_reference=local-482193`, `tracking_issue=local-482193`, `issue_creation=local-tracking`, and `issue_number=` | Preserved local tracking metadata; empty `issue_number` |
 | Compatibility Azure Boards reference | `AB#12345` in `task_description` | `12345` |
 | Compatibility bare reference | `#12345` in `task_description` | `12345` |
 
@@ -147,7 +146,7 @@ After step `03b` completes, the workflow context contains:
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `issue_number` | `int` or empty string | Numeric provider ID for GitHub/AzDO, empty for local tracking |
-| `tracking_reference` | `string`, optional | Authoritative local tracking reference; required for local success unless legacy `local-tracking:*` is the source |
+| `tracking_reference` | `string`, optional | Authoritative local tracking reference when Step 03 emits one |
 | `tracking_issue` | `string`, optional | Local tracking issue/reference alias preserved from step 03 |
 | `tracking_system` | `string`, optional | `local` when step 03 selected local tracking |
 
@@ -180,12 +179,13 @@ commit messages, publish output, and final status.
 
 ### Local detection contract
 
-`tracking_system=local` is only a mode marker. It is not sufficient on its own.
-Local extraction succeeds only when one of these local references is present:
+Local extraction succeeds when Step 03 emits local mode or a local reference:
 
+- `tracking_system=local`
 - `tracking_reference=local-*`
 - `tracking_issue=local-*`
-- legacy `local-tracking:*`
+- `tracking_reference=local-tracking:*`
+- `tracking_issue=local-tracking:*`
 
 The `local-*` prefix is intentional. It prevents unrelated numeric text in local
 metadata from being treated as a GitHub issue or Azure Boards work item.
@@ -214,7 +214,7 @@ Step `03b` reads the following values from the workflow context:
 
 | Context key | Required | Description |
 | ----------- | -------- | ----------- |
-| `issue_creation` | Yes | Step 03 output: GitHub URL, Azure Boards URL, `AB#N`, structured local metadata with a local-prefixed reference, or legacy `local-tracking:*` |
+| `issue_creation` | Yes | Step 03 output: GitHub URL, Azure Boards URL, `AB#N`, structured local metadata with `tracking_system=local`, or local-prefixed tracking metadata |
 | `task_description` | Yes | Free-form string used only as a compatibility fallback source for `AB#N` or `#N` references |
 
 No environment variables are specific to step `03b`. GitHub PR closing-issue
@@ -304,12 +304,12 @@ issue_number: ""
 ### Resolving from legacy local tracking
 
 ```yaml
-issue_creation: "local-tracking:123"
+issue_creation: "tracking_reference=local-tracking:123"
 task_description: "Add config parser"
 ```
 
 ```
-legacy local tracking match: local-tracking:123
+legacy local tracking match: tracking_reference=local-tracking:123
 tracking_reference: local-tracking:123
 issue_number: ""
 ```
@@ -338,8 +338,7 @@ stderr includes the unparseable issue_creation value
 
 Install and authenticate the GitHub CLI: `gh auth login`.
 Only GitHub PR closing-issue lookup requires `gh`; direct issue URLs, Azure
-Boards outputs, `AB#N`, structured local metadata, and legacy
-`local-tracking:*` still resolve without it.
+Boards outputs, `AB#N`, and structured local metadata still resolve without it.
 
 **GitHub PR lookup returns no closing issues**
 

--- a/docs/reference/workflow-issue-extraction.md
+++ b/docs/reference/workflow-issue-extraction.md
@@ -88,8 +88,8 @@ gh call: closingIssuesReferences → [3960, 3983]
 Output: issue_number=3960   (first reference)
 ```
 
-**Timeout**: 60 seconds. If `gh` does not respond within the timeout, the PR
-number is used as the fallback tracking ID.
+**Timeout**: 60 seconds. If `gh` is unavailable or does not respond within the
+timeout, the PR number is used as the fallback tracking ID.
 
 ---
 

--- a/docs/tutorials/dual-provider-workflow.md
+++ b/docs/tutorials/dual-provider-workflow.md
@@ -106,14 +106,16 @@ If Azure Boards is unavailable, step 03 emits structured local metadata:
 
 ```text
 tracking_system=local
-tracking_reference=local-ab-12345
-tracking_issue=local-ab-12345
+tracking_reference=local-12345
+tracking_issue=local-12345
 issue_creation=local-tracking
-issue_number=12345
+issue_number=
 ```
 
-Provider URLs, `AB#N`, and local metadata with a numeric local reference
-preserve the downstream `issue_number` contract.
+Provider URLs and `AB#N` preserve the downstream numeric `issue_number`
+contract. Local metadata uses a local-prefixed `tracking_reference` /
+`tracking_issue`, preserves that reference downstream, and leaves
+`issue_number` empty.
 
 ---
 
@@ -157,12 +159,12 @@ You can also create the PR from the Azure DevOps web UI.
 ## Step 7: Try the Local Fallback Path
 
 To see the provider-safe fallback, run the workflow without Azure Boards
-configuration or with `remote_host_type=other` and a numeric local reference:
+configuration or with `remote_host_type=other`:
 
 ```bash
 amplihack recipe run default-workflow \
   -c remote_host_type=other \
-  -c "task_description=Add config parser #482193" \
+  -c "task_description=Add config parser" \
   -c "repo_path=$(pwd)"
 ```
 
@@ -170,10 +172,10 @@ Expected tracking output:
 
 ```text
 tracking_system=local
-tracking_reference=local-issue-482193
-tracking_issue=local-issue-482193
+tracking_reference=local-482193
+tracking_issue=local-482193
 issue_creation=local-tracking
-issue_number=482193
+issue_number=
 ```
 
 No GitHub or Azure DevOps provider command runs in this mode.
@@ -184,5 +186,5 @@ No GitHub or Azure DevOps provider command runs in this mode.
 
 You ran the workflow on an Azure DevOps-backed repository. `workflow-prep`
 classified the remote as `azdo`, kept all GitHub issue and label commands out
-of the AzDO path, and preserved the numeric `issue_number` contract through
-Azure Boards or local tracking.
+of the AzDO path, preserved numeric `issue_number` for Azure Boards, and
+preserved local references without numeric coercion for local tracking.

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -25,10 +25,8 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
-use std::sync::{
-    LazyLock,
-    atomic::{AtomicUsize, Ordering},
-};
+use std::sync::LazyLock;
+use tempfile::TempDir;
 
 const BRICK_LIMIT: usize = 400;
 
@@ -66,8 +64,6 @@ static WORKFLOW_PR_REVIEW_YAML: LazyLock<serde_yaml::Value> = LazyLock::new(|| {
     serde_yaml::from_str(recipe_text(name))
         .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 });
-
-static STEP_COMMAND_RUN_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Deserialize)]
 struct Recipe {
@@ -137,47 +133,55 @@ struct StepRun {
     stderr: String,
 }
 
-fn run_step_03b_extract_issue_number(issue_creation: &str, task_description: &str) -> StepRun {
-    let shim_dir = std::env::temp_dir().join(format!(
-        "amplihack-step-03b-test-{}-{}",
-        std::process::id(),
-        STEP_COMMAND_RUN_COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
-    fs::create_dir_all(&shim_dir).unwrap_or_else(|e| panic!("create {}: {e}", shim_dir.display()));
+struct Step03bRunner {
+    _shim_dir: TempDir,
+    path: String,
+}
 
-    let gh_shim = shim_dir.join("gh");
-    fs::write(&gh_shim, "#!/usr/bin/env bash\nexit 0\n")
-        .unwrap_or_else(|e| panic!("write {}: {e}", gh_shim.display()));
-    let mut permissions = fs::metadata(&gh_shim)
-        .unwrap_or_else(|e| panic!("stat {}: {e}", gh_shim.display()))
-        .permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&gh_shim, permissions)
-        .unwrap_or_else(|e| panic!("chmod {}: {e}", gh_shim.display()));
+impl Step03bRunner {
+    fn new() -> Self {
+        let shim_dir = TempDir::new().expect("create step-03b gh shim tempdir");
+        let gh_shim = shim_dir.path().join("gh");
+        fs::write(&gh_shim, "#!/usr/bin/env bash\nexit 0\n")
+            .unwrap_or_else(|e| panic!("write {}: {e}", gh_shim.display()));
+        let mut permissions = fs::metadata(&gh_shim)
+            .unwrap_or_else(|e| panic!("stat {}: {e}", gh_shim.display()))
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&gh_shim, permissions)
+            .unwrap_or_else(|e| panic!("chmod {}: {e}", gh_shim.display()));
 
-    let path = match std::env::var("PATH") {
-        Ok(existing) if !existing.is_empty() => format!("{}:{existing}", shim_dir.display()),
-        _ => shim_dir.display().to_string(),
-    };
+        let path = match std::env::var("PATH") {
+            Ok(existing) if !existing.is_empty() => {
+                format!("{}:{existing}", shim_dir.path().display())
+            }
+            _ => shim_dir.path().display().to_string(),
+        };
 
-    let output = Command::new("bash")
-        .arg("-c")
-        .arg(step_command(
-            "workflow-prep",
-            "step-03b-extract-issue-number",
-        ))
-        .env("ISSUE_CREATION", issue_creation)
-        .env("TASK_DESCRIPTION", task_description)
-        .env("PATH", path)
-        .output()
-        .expect("run step-03b-extract-issue-number command");
+        Self {
+            _shim_dir: shim_dir,
+            path,
+        }
+    }
 
-    let _ = fs::remove_dir_all(&shim_dir);
+    fn run_extract_issue_number(&self, issue_creation: &str, task_description: &str) -> StepRun {
+        let output = Command::new("bash")
+            .arg("-c")
+            .arg(step_command(
+                "workflow-prep",
+                "step-03b-extract-issue-number",
+            ))
+            .env("ISSUE_CREATION", issue_creation)
+            .env("TASK_DESCRIPTION", task_description)
+            .env("PATH", &self.path)
+            .output()
+            .expect("run step-03b-extract-issue-number command");
 
-    StepRun {
-        status: output.status,
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        StepRun {
+            status: output.status,
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        }
     }
 }
 
@@ -1025,8 +1029,9 @@ fn workflow_prep_step_03b_local_tracking_succeeds_without_numeric_issue_number()
         ),
     ];
 
+    let runner = Step03bRunner::new();
     for (name, issue_creation) in cases {
-        let run = run_step_03b_extract_issue_number(issue_creation, "");
+        let run = runner.run_extract_issue_number(issue_creation, "");
         assert!(
             run.status.success(),
             "{name} must skip numeric extraction and exit successfully; stderr:\n{}",
@@ -1060,8 +1065,9 @@ fn workflow_prep_step_03b_remote_references_keep_numeric_extraction_behavior() {
         ("azure boards shorthand", "AB#654", "654"),
     ];
 
+    let runner = Step03bRunner::new();
     for (name, issue_creation, expected) in cases {
-        let run = run_step_03b_extract_issue_number(issue_creation, "");
+        let run = runner.run_extract_issue_number(issue_creation, "");
         assert!(
             run.status.success(),
             "{name} must still extract a numeric issue/work-item id; stderr:\n{}",

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -21,8 +21,14 @@
 
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
-use std::sync::LazyLock;
+use std::process::{Command, ExitStatus};
+use std::sync::{
+    LazyLock,
+    atomic::{AtomicUsize, Ordering},
+};
 
 const BRICK_LIMIT: usize = 400;
 
@@ -60,6 +66,8 @@ static WORKFLOW_PR_REVIEW_YAML: LazyLock<serde_yaml::Value> = LazyLock::new(|| {
     serde_yaml::from_str(recipe_text(name))
         .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 });
+
+static STEP_COMMAND_RUN_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Deserialize)]
 struct Recipe {
@@ -121,6 +129,56 @@ fn step_command(recipe: &str, step_id: &str) -> &'static str {
         .command
         .as_deref()
         .unwrap_or_else(|| panic!("{recipe}.yaml step {step_id} must be a bash step"))
+}
+
+struct StepRun {
+    status: ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_step_03b_extract_issue_number(issue_creation: &str, task_description: &str) -> StepRun {
+    let stub_dir = std::env::temp_dir().join(format!(
+        "amplihack-step-03b-test-{}-{}",
+        std::process::id(),
+        STEP_COMMAND_RUN_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir_all(&stub_dir).unwrap_or_else(|e| panic!("create {}: {e}", stub_dir.display()));
+
+    let gh_stub = stub_dir.join("gh");
+    fs::write(&gh_stub, "#!/usr/bin/env bash\nexit 0\n")
+        .unwrap_or_else(|e| panic!("write {}: {e}", gh_stub.display()));
+    let mut permissions = fs::metadata(&gh_stub)
+        .unwrap_or_else(|e| panic!("stat {}: {e}", gh_stub.display()))
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&gh_stub, permissions)
+        .unwrap_or_else(|e| panic!("chmod {}: {e}", gh_stub.display()));
+
+    let path = match std::env::var("PATH") {
+        Ok(existing) if !existing.is_empty() => format!("{}:{existing}", stub_dir.display()),
+        _ => stub_dir.display().to_string(),
+    };
+
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(step_command(
+            "workflow-prep",
+            "step-03b-extract-issue-number",
+        ))
+        .env("ISSUE_CREATION", issue_creation)
+        .env("TASK_DESCRIPTION", task_description)
+        .env("PATH", path)
+        .output()
+        .expect("run step-03b-extract-issue-number command");
+
+    let _ = fs::remove_dir_all(&stub_dir);
+
+    StepRun {
+        status: output.status,
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
 }
 
 fn step_prompt(recipe: &str, step_id: &str) -> &'static str {
@@ -948,6 +1006,95 @@ fn workflow_prep_step_03b_handles_azdo_work_item_urls() {
         local_pos < task_ab_pos,
         "step-03b must check ISSUE_CREATION local-tracking before falling back to TASK_DESC_RAW"
     );
+}
+
+#[test]
+fn workflow_prep_step_03b_local_tracking_system_succeeds_without_numeric_issue_number() {
+    let run = run_step_03b_extract_issue_number(
+        "tracking_system=local\ntracking_reference=local-123\ntracking_issue=local-123\nissue_creation=local-tracking\n",
+        "",
+    );
+
+    assert!(
+        run.status.success(),
+        "local tracking must skip numeric extraction and exit successfully; stderr:\n{}",
+        run.stderr
+    );
+    assert_eq!(
+        run.stdout, "",
+        "local tracking must leave issue_number empty instead of coercing local-123 to 123"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03b_local_reference_prefix_succeeds_without_numeric_issue_number() {
+    let run = run_step_03b_extract_issue_number(
+        "tracking_reference=local-123\ntracking_issue=local-123\nissue_creation=local-tracking\n",
+        "",
+    );
+
+    assert!(
+        run.status.success(),
+        "local-* references must be treated as local tracking, not remote issue numbers; stderr:\n{}",
+        run.stderr
+    );
+    assert_eq!(
+        run.stdout, "",
+        "local-* references must preserve the local identifier without emitting issue_number=123"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03b_legacy_local_tracking_reference_is_not_coerced_to_issue_number() {
+    let run = run_step_03b_extract_issue_number(
+        "tracking_reference=local-tracking:123\ntracking_issue=local-tracking:123\n",
+        "",
+    );
+
+    assert!(
+        run.status.success(),
+        "legacy local-tracking:* references must skip numeric extraction; stderr:\n{}",
+        run.stderr
+    );
+    assert_eq!(
+        run.stdout, "",
+        "local-tracking:123 is a local identifier and must not emit issue_number=123"
+    );
+}
+
+#[test]
+fn workflow_prep_step_03b_remote_references_keep_numeric_extraction_behavior() {
+    let cases = [
+        (
+            "github issue URL",
+            "https://github.com/owner/repo/issues/456",
+            "456",
+        ),
+        (
+            "github pull request URL",
+            "https://github.com/owner/repo/pull/789",
+            "789",
+        ),
+        (
+            "azure devops work item URL",
+            "https://dev.azure.com/org/project/_workitems/edit/321",
+            "321",
+        ),
+        ("azure boards shorthand", "AB#654", "654"),
+    ];
+
+    for (name, issue_creation, expected) in cases {
+        let run = run_step_03b_extract_issue_number(issue_creation, "");
+        assert!(
+            run.status.success(),
+            "{name} must still extract a numeric issue/work-item id; stderr:\n{}",
+            run.stderr
+        );
+        assert_eq!(
+            run.stdout, expected,
+            "{name} must preserve existing numeric extraction behavior"
+        );
+    }
 }
 
 // ==========================================================================

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -1045,6 +1045,41 @@ fn workflow_prep_step_03b_local_tracking_succeeds_without_numeric_issue_number()
 }
 
 #[test]
+fn workflow_prep_step_03b_rejects_malformed_local_tracking_metadata() {
+    let cases = [
+        (
+            "local markers without a reference",
+            "tracking_system=local\nissue_creation=local-tracking\nissue_number=763\n",
+        ),
+        (
+            "local reference with shell metacharacter",
+            "tracking_reference=local-123;rm\ntracking_issue=local-123;rm\nissue_number=763\n",
+        ),
+    ];
+
+    let runner = Step03bRunner::new();
+    for (name, issue_creation) in cases {
+        let run = runner.run_extract_issue_number(issue_creation, "Fallback #999");
+        assert!(
+            !run.status.success(),
+            "{name} must fail instead of coercing malformed local metadata; stdout:\n{}\nstderr:\n{}",
+            run.stdout,
+            run.stderr
+        );
+        assert_eq!(
+            run.stdout, "",
+            "{name} must not emit a numeric issue number from malformed local metadata"
+        );
+        assert!(
+            run.stderr
+                .contains("local tracking metadata missing valid local reference"),
+            "{name} must explain the malformed local metadata; stderr:\n{}",
+            run.stderr
+        );
+    }
+}
+
+#[test]
 fn workflow_prep_step_03b_remote_references_keep_numeric_extraction_behavior() {
     let cases = [
         (

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -138,26 +138,26 @@ struct StepRun {
 }
 
 fn run_step_03b_extract_issue_number(issue_creation: &str, task_description: &str) -> StepRun {
-    let stub_dir = std::env::temp_dir().join(format!(
+    let shim_dir = std::env::temp_dir().join(format!(
         "amplihack-step-03b-test-{}-{}",
         std::process::id(),
         STEP_COMMAND_RUN_COUNTER.fetch_add(1, Ordering::Relaxed)
     ));
-    fs::create_dir_all(&stub_dir).unwrap_or_else(|e| panic!("create {}: {e}", stub_dir.display()));
+    fs::create_dir_all(&shim_dir).unwrap_or_else(|e| panic!("create {}: {e}", shim_dir.display()));
 
-    let gh_stub = stub_dir.join("gh");
-    fs::write(&gh_stub, "#!/usr/bin/env bash\nexit 0\n")
-        .unwrap_or_else(|e| panic!("write {}: {e}", gh_stub.display()));
-    let mut permissions = fs::metadata(&gh_stub)
-        .unwrap_or_else(|e| panic!("stat {}: {e}", gh_stub.display()))
+    let gh_shim = shim_dir.join("gh");
+    fs::write(&gh_shim, "#!/usr/bin/env bash\nexit 0\n")
+        .unwrap_or_else(|e| panic!("write {}: {e}", gh_shim.display()));
+    let mut permissions = fs::metadata(&gh_shim)
+        .unwrap_or_else(|e| panic!("stat {}: {e}", gh_shim.display()))
         .permissions();
     permissions.set_mode(0o755);
-    fs::set_permissions(&gh_stub, permissions)
-        .unwrap_or_else(|e| panic!("chmod {}: {e}", gh_stub.display()));
+    fs::set_permissions(&gh_shim, permissions)
+        .unwrap_or_else(|e| panic!("chmod {}: {e}", gh_shim.display()));
 
     let path = match std::env::var("PATH") {
-        Ok(existing) if !existing.is_empty() => format!("{}:{existing}", stub_dir.display()),
-        _ => stub_dir.display().to_string(),
+        Ok(existing) if !existing.is_empty() => format!("{}:{existing}", shim_dir.display()),
+        _ => shim_dir.display().to_string(),
     };
 
     let output = Command::new("bash")
@@ -172,7 +172,7 @@ fn run_step_03b_extract_issue_number(issue_creation: &str, task_description: &st
         .output()
         .expect("run step-03b-extract-issue-number command");
 
-    let _ = fs::remove_dir_all(&stub_dir);
+    let _ = fs::remove_dir_all(&shim_dir);
 
     StepRun {
         status: output.status,
@@ -1009,57 +1009,34 @@ fn workflow_prep_step_03b_handles_azdo_work_item_urls() {
 }
 
 #[test]
-fn workflow_prep_step_03b_local_tracking_system_succeeds_without_numeric_issue_number() {
-    let run = run_step_03b_extract_issue_number(
-        "tracking_system=local\ntracking_reference=local-123\ntracking_issue=local-123\nissue_creation=local-tracking\n",
-        "",
-    );
+fn workflow_prep_step_03b_local_tracking_succeeds_without_numeric_issue_number() {
+    let cases = [
+        (
+            "local tracking system",
+            "tracking_system=local\ntracking_reference=local-123\ntracking_issue=local-123\nissue_creation=local-tracking\n",
+        ),
+        (
+            "local-* reference",
+            "tracking_reference=local-123\ntracking_issue=local-123\nissue_creation=local-tracking\n",
+        ),
+        (
+            "legacy local-tracking reference",
+            "tracking_reference=local-tracking:123\ntracking_issue=local-tracking:123\n",
+        ),
+    ];
 
-    assert!(
-        run.status.success(),
-        "local tracking must skip numeric extraction and exit successfully; stderr:\n{}",
-        run.stderr
-    );
-    assert_eq!(
-        run.stdout, "",
-        "local tracking must leave issue_number empty instead of coercing local-123 to 123"
-    );
-}
-
-#[test]
-fn workflow_prep_step_03b_local_reference_prefix_succeeds_without_numeric_issue_number() {
-    let run = run_step_03b_extract_issue_number(
-        "tracking_reference=local-123\ntracking_issue=local-123\nissue_creation=local-tracking\n",
-        "",
-    );
-
-    assert!(
-        run.status.success(),
-        "local-* references must be treated as local tracking, not remote issue numbers; stderr:\n{}",
-        run.stderr
-    );
-    assert_eq!(
-        run.stdout, "",
-        "local-* references must preserve the local identifier without emitting issue_number=123"
-    );
-}
-
-#[test]
-fn workflow_prep_step_03b_legacy_local_tracking_reference_is_not_coerced_to_issue_number() {
-    let run = run_step_03b_extract_issue_number(
-        "tracking_reference=local-tracking:123\ntracking_issue=local-tracking:123\n",
-        "",
-    );
-
-    assert!(
-        run.status.success(),
-        "legacy local-tracking:* references must skip numeric extraction; stderr:\n{}",
-        run.stderr
-    );
-    assert_eq!(
-        run.stdout, "",
-        "local-tracking:123 is a local identifier and must not emit issue_number=123"
-    );
+    for (name, issue_creation) in cases {
+        let run = run_step_03b_extract_issue_number(issue_creation, "");
+        assert!(
+            run.status.success(),
+            "{name} must skip numeric extraction and exit successfully; stderr:\n{}",
+            run.stderr
+        );
+        assert_eq!(
+            run.stdout, "",
+            "{name} must leave issue_number empty instead of coercing local IDs to numbers"
+        );
+    }
 }
 
 #[test]

--- a/tests/integration/issue_684_host_aware_workflow_test.rs
+++ b/tests/integration/issue_684_host_aware_workflow_test.rs
@@ -1173,15 +1173,21 @@ fn step_03_github_unexpected_create_failure_remains_error() {
 fn step_03b_has_local_tracking_metadata_extraction_contract() {
     let recipe = load_recipe("workflow-prep");
     let body = extract_step_body(&recipe, "step-03b-extract-issue-number");
+    let local_pos = body
+        .find("LOCAL_TRACKING_RE")
+        .expect("step-03b must define the local tracking guard");
+    let issue_number_pos = body
+        .find("issue_number=([0-9]+)")
+        .expect("step-03b must still support provider numeric extraction");
 
     assert!(
-        body.contains("issue_number=([0-9]+)") && body.contains("local-(issue|ab)-([0-9]+)"),
-        "step-03b must extract numeric IDs from explicit local tracking metadata"
+        local_pos < issue_number_pos,
+        "step-03b must skip numeric extraction before provider issue_number parsing for local metadata"
     );
 }
 
 #[test]
-fn step_03b_extracts_issue_number_from_local_tracking_metadata() {
+fn step_03b_skips_issue_number_for_local_tracking_metadata() {
     let output = run_step_03b(
         "tracking_system=local\ntracking_reference=local-issue-763\ntracking_issue=local-issue-763\nissue_creation=local-tracking\nissue_number=763\n",
         "Create tracking for local fallback",
@@ -1195,8 +1201,8 @@ fn step_03b_extracts_issue_number_from_local_tracking_metadata() {
     );
     assert_eq!(
         stdout.trim(),
-        "763",
-        "step-03b must return the numeric local tracking ID"
+        "",
+        "step-03b must leave issue_number empty for local tracking metadata"
     );
 }
 


### PR DESCRIPTION
## Summary
- Fixes #788 by making workflow-prep step-03b detect local tracking metadata before numeric extraction.
- Leaves local issue_number empty while preserving tracking_reference/tracking_issue as the authoritative local identifier.
- Adds regression coverage for local tracking, GitHub issue/PR refs, and Azure DevOps work item refs.

## Validation
- NODE_OPTIONS=--max-old-space-size=32768 cargo test --test default_workflow_decomposition
- NODE_OPTIONS=--max-old-space-size=32768 pre-commit run --all-files

## Step 13: Local Testing Results

### Scenario 1 — Local tracking reference skips numeric issue extraction
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-788-fix-issue-788-smart-orchestratordefault-workflow-l amplihack recipe run /home/azureuser/.copilot/session-state/5522f518-34fe-409a-a69a-f5785d588b67/files/step13-step03b-harness.yaml -c workflow_prep_asset=/home/azureuser/.cargo/git/checkouts/amplihack-rs-866b650c4bee5b89/623f954/amplifier-bundle/recipes/workflow-prep.yaml -c issue_creation="tracking_system=local tracking_reference=local-482193 tracking_issue=local-482193 issue_creation=local-tracking" -c task_description="Issue 788 local tracking scenario" -c expect_exit=0 -c expect_stdout_set=1 -c expect_stdout=`
Result: PASS
Output: `source_asset=/home/azureuser/.cargo/git/checkouts/amplihack-rs-866b650c4bee5b89/623f954/amplifier-bundle/recipes/workflow-prep.yaml`; `step_exit_code=0`; `step_stdout=`; `scenario_passed=true`

### Scenario 2 — Azure DevOps work item URL still extracts numeric ID
Command: `uvx --from git+https://github.com/rysweet/amplihack-rs.git@feat/issue-788-fix-issue-788-smart-orchestratordefault-workflow-l amplihack recipe run /home/azureuser/.copilot/session-state/5522f518-34fe-409a-a69a-f5785d588b67/files/step13-step03b-harness.yaml -c workflow_prep_asset=/home/azureuser/.cargo/git/checkouts/amplihack-rs-866b650c4bee5b89/623f954/amplifier-bundle/recipes/workflow-prep.yaml -c issue_creation="https://dev.azure.com/example/project/_workitems/edit/763" -c task_description="Issue 788 AzDO regression scenario" -c expect_exit=0 -c expect_stdout_set=1 -c expect_stdout=763`
Result: PASS
Output: `source_asset=/home/azureuser/.cargo/git/checkouts/amplihack-rs-866b650c4bee5b89/623f954/amplifier-bundle/recipes/workflow-prep.yaml`; `step_exit_code=0`; `step_stdout=763`; `scenario_passed=true`