### PR TITLE
Add provider-neutral workflow contracts

### DIFF
--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -8,9 +8,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-atlas:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Lint & Format
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - name: Verify cxx-build pin
@@ -40,6 +45,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
 
@@ -47,6 +54,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: check
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Free disk space
@@ -66,6 +74,7 @@ jobs:
     name: Install Smoke Test
     runs-on: ubuntu-latest
     needs: check
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -75,6 +84,7 @@ jobs:
           # so once that job has populated the cache the install-smoke run
           # hydrates instead of rebuilding the workspace from scratch.
           key: x86_64-unknown-linux-gnu
+          cache-targets: false
       - name: Install from local checkout
         run: cargo install --path bins/amplihack --locked
       - name: Verify binary
@@ -87,6 +97,7 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     needs: check
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -115,6 +126,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          cache-targets: false
 
       - name: Install GNU cross toolchain
         if: matrix.gnu_cross_toolchain
@@ -160,6 +172,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [test, cross-compile]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Build docs
@@ -39,6 +40,7 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/invisible-char-scan.yml
+++ b/.github/workflows/invisible-char-scan.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     # Skip for maintainers and bots
@@ -20,6 +24,7 @@ jobs:
       github.actor != 'copilot[bot]'
     runs-on: ubuntu-latest
     environment: external-pr-scan
+    timeout-minutes: 15
     steps:
       - name: Checkout base (safe — not PR head)
         uses: actions/checkout@v4
@@ -33,6 +38,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
 
       - name: Scan diff for invisible characters
         run: |

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -17,10 +17,15 @@ env:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cross-compile:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +54,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: snapshot-${{ matrix.target }}
+          cache-targets: false
 
       - name: Install GNU cross toolchain
         if: matrix.gnu_cross_toolchain
@@ -118,6 +124,7 @@ jobs:
     name: Publish snapshot release
     needs: cross-compile
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Determine next version and create tag ─────────────────────────────
   # Tag-based versioning: reads base version from Cargo.toml, increments
@@ -19,6 +23,7 @@ jobs:
   version-bump:
     name: Auto-bump version
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Prevent infinite loop: skip if this push is already a version-bump commit
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     outputs:
@@ -104,6 +109,7 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: version-bump
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -134,6 +140,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: release-${{ matrix.target }}
+          cache-targets: false
 
       - name: Install GNU cross toolchain
         if: matrix.gnu_cross_toolchain
@@ -187,6 +194,7 @@ jobs:
     name: Create Release
     needs: [version-bump, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: artifact-guard
         name: amplihack artifact guard
-        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo run --bin amplihack -- hygiene artifact-guard --repo . --mode pre-commit'
+        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo run --locked --bin amplihack -- hygiene artifact-guard --repo . --mode pre-commit'
         language: system
         pass_filenames: false
         always_run: true
@@ -28,14 +28,14 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy -- -D warnings
-        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo clippy -- -D warnings'
+        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo clippy --locked -- -D warnings'
         language: system
         pass_filenames: false
         files: '(\.rs|Cargo\.toml|Cargo\.lock)$'
 
       - id: cargo-test
         name: cargo test (workspace, skip heavy)
-        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo test --workspace -- --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu'
+        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo test --workspace --locked -- --skip fleet_probe --skip kuzu --skip fleet::fleet_local --skip memory::kuzu'
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "amplihack-state",
  "amplihack-types",
  "amplihack-utils",
+ "amplihack-workflows",
  "anyhow",
  "assert_cmd",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ What happens:
 
 - Classifies as: `Development` | `1 workstream`
 - Builder agent follows the full 23-step DEFAULT_WORKFLOW
-- Creates a branch, implements the fix, creates a PR
+- Creates a branch, implements the fix, publishes a provider-specific change request
 - Reviewer evaluates the result — if incomplete, automatically runs another
   round
-- Final output: `# Dev Orchestrator -- Execution Complete` with PR link
+- Final output: `# Dev Orchestrator -- Execution Complete` with change-request link or explicit manual next action
 
 **2. Parallel task** — two independent features at once:
 
@@ -186,7 +186,7 @@ What happens:
 - Classifies as: `Development` | `2 workstreams`
 - Both workstreams launch in parallel (separate `/tmp` clones)
 - Each follows the full workflow independently
-- Both PRs created simultaneously
+- Both change requests are created or reported with explicit manual next actions
 
 **3. Investigation** — understand existing code before changing it:
 

--- a/crates/amplihack-cli/Cargo.toml
+++ b/crates/amplihack-cli/Cargo.toml
@@ -14,6 +14,7 @@ amplihack-launcher = { workspace = true }
 amplihack-types = { workspace = true }
 amplihack-state = { workspace = true }
 amplihack-utils = { workspace = true }
+amplihack-workflows = { workspace = true }
 amplihack-memory = { workspace = true }
 amplihack-reflection = { workspace = true }
 amplihack-builders = { workspace = true }

--- a/crates/amplihack-cli/src/ci_resource_discipline_tests.rs
+++ b/crates/amplihack-cli/src/ci_resource_discipline_tests.rs
@@ -1,0 +1,116 @@
+use serde_yaml::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("crate should live under <repo>/crates/amplihack-cli")
+        .to_path_buf()
+}
+
+fn workflow_files() -> Vec<PathBuf> {
+    let workflow_dir = repo_root().join(".github/workflows");
+    let mut files = fs::read_dir(&workflow_dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", workflow_dir.display()))
+        .map(|entry| entry.expect("workflow entry should be readable").path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|ext| ext == "yml" || ext == "yaml")
+        })
+        .collect::<Vec<_>>();
+    files.sort();
+    files
+}
+
+fn load_yaml(path: &Path) -> Value {
+    let text = fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read workflow {}: {err}", path.display()));
+    serde_yaml::from_str(&text)
+        .unwrap_or_else(|err| panic!("workflow {} should be valid YAML: {err}", path.display()))
+}
+
+#[test]
+fn ci_workflows_define_concurrency_boundaries() {
+    let missing = workflow_files()
+        .into_iter()
+        .filter(|path| load_yaml(path).get("concurrency").is_none())
+        .map(|path| {
+            path.strip_prefix(repo_root())
+                .unwrap()
+                .display()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        missing.is_empty(),
+        "each GitHub workflow must define top-level concurrency with cancel-in-progress; missing: {missing:?}"
+    );
+}
+
+#[test]
+fn ci_jobs_have_timeout_minutes() {
+    let mut missing = Vec::new();
+    for path in workflow_files() {
+        let workflow = load_yaml(&path);
+        let Some(jobs) = workflow.get("jobs").and_then(Value::as_mapping) else {
+            continue;
+        };
+        for job_name in jobs.keys().filter_map(Value::as_str) {
+            let job = &jobs[Value::String(job_name.to_string())];
+            if job.get("timeout-minutes").is_none() {
+                missing.push(format!(
+                    "{}:{job_name}",
+                    path.strip_prefix(repo_root()).unwrap().display()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "each CI job must set timeout-minutes so runaway jobs fail predictably; missing: {missing:?}"
+    );
+}
+
+#[test]
+fn ci_rust_cache_entries_do_not_cache_workspace_targets_by_default() {
+    let mut offenders = Vec::new();
+    for path in workflow_files() {
+        let workflow = load_yaml(&path);
+        let Some(jobs) = workflow.get("jobs").and_then(Value::as_mapping) else {
+            continue;
+        };
+        for (job_key, job_value) in jobs {
+            let Some(job_name) = job_key.as_str() else {
+                continue;
+            };
+            let Some(steps) = job_value.get("steps").and_then(Value::as_sequence) else {
+                continue;
+            };
+            for (index, step) in steps.iter().enumerate() {
+                if step.get("uses").and_then(Value::as_str) != Some("Swatinem/rust-cache@v2") {
+                    continue;
+                }
+                let cache_targets = step
+                    .get("with")
+                    .and_then(|with| with.get("cache-targets"))
+                    .and_then(Value::as_bool);
+                if cache_targets != Some(false) {
+                    offenders.push(format!(
+                        "{}:{job_name}:step{}",
+                        path.strip_prefix(repo_root()).unwrap().display(),
+                        index + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "rust-cache usage must opt out of target/ caching unless a job documents a narrow exception; offenders: {offenders:?}"
+    );
+}

--- a/crates/amplihack-cli/src/cli_commands.rs
+++ b/crates/amplihack-cli/src/cli_commands.rs
@@ -264,6 +264,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: RecipeCommands,
     },
+    /// Provider-neutral workflow helper utilities.
+    Workflow {
+        #[command(subcommand)]
+        command: crate::commands::workflow::WorkflowCommands,
+    },
     /// Mode management
     Mode {
         #[command(subcommand)]

--- a/crates/amplihack-cli/src/cli_tests.rs
+++ b/crates/amplihack-cli/src/cli_tests.rs
@@ -534,6 +534,27 @@ mod tests {
     }
 
     #[test]
+    fn workflow_terminal_state_success_accepts_explicit_provider_evidence_args() {
+        Cli::try_parse_from([
+            "amplihack",
+            "workflow",
+            "terminal-state",
+            "--terminal-state",
+            "FOLLOWUP_CREATED",
+            "--terminal-success",
+            "--provider",
+            "github",
+            "--change-requests-capability",
+            "automated",
+            "--evidence",
+            "change_request.id=812",
+            "--format",
+            "json",
+        ])
+        .expect("terminal success validation must accept explicit provider evidence inputs");
+    }
+
+    #[test]
     fn workflow_cleanup_stale_requires_explicit_dry_run_or_apply_mode() {
         let missing_mode = Cli::try_parse_from([
             "amplihack",

--- a/crates/amplihack-cli/src/cli_tests.rs
+++ b/crates/amplihack-cli/src/cli_tests.rs
@@ -496,7 +496,7 @@ mod tests {
     }
 
     #[test]
-    fn workflow_change_request_publish_supports_azure_manual_path_args() {
+    fn workflow_change_request_publish_supports_azure_provider_args() {
         Cli::try_parse_from([
             "amplihack",
             "workflow",
@@ -513,7 +513,7 @@ mod tests {
             "--format",
             "json",
         ])
-        .expect("Azure DevOps change-request publish helper must parse manual-path inputs");
+        .expect("Azure DevOps change-request publish helper must parse provider inputs");
     }
 
     #[test]
@@ -524,7 +524,7 @@ mod tests {
             "simulate-recipe",
             "default-workflow",
             "--scenario",
-            "azdo-work-item-manual-pr",
+            "azdo-work-item-automated-pr",
             "--repo-fixture",
             "tests/fixtures/workflows/repos/azdo-repo",
             "--format",

--- a/crates/amplihack-cli/src/cli_tests.rs
+++ b/crates/amplihack-cli/src/cli_tests.rs
@@ -461,4 +461,104 @@ mod tests {
             other => panic!("expected copilot command, got {other:?}"),
         }
     }
+
+    // ── Provider-neutral workflow helper commands ─────────────────────────────
+
+    #[test]
+    fn workflow_helper_command_is_registered_in_top_level_help() {
+        let mut cmd = Cli::command();
+        let workflow = cmd
+            .find_subcommand_mut("workflow")
+            .expect("amplihack workflow helper command should exist");
+        let mut help = Vec::new();
+        workflow.write_long_help(&mut help).unwrap();
+        let rendered = String::from_utf8(help).unwrap();
+
+        assert!(rendered.contains("detect-provider"));
+        assert!(rendered.contains("change-request"));
+        assert!(rendered.contains("simulate-recipe"));
+        assert!(rendered.contains("cleanup-stale"));
+        assert!(rendered.contains("terminal-state"));
+    }
+
+    #[test]
+    fn workflow_detect_provider_json_command_parses() {
+        Cli::try_parse_from([
+            "amplihack",
+            "workflow",
+            "detect-provider",
+            "--repo",
+            ".",
+            "--format",
+            "json",
+        ])
+        .expect("workflow detect-provider --format json must parse");
+    }
+
+    #[test]
+    fn workflow_change_request_publish_supports_azure_manual_path_args() {
+        Cli::try_parse_from([
+            "amplihack",
+            "workflow",
+            "change-request",
+            "publish",
+            "--provider",
+            "azure-devops",
+            "--source-branch",
+            "feat/provider-contract",
+            "--base-branch",
+            "main",
+            "--title",
+            "Provider abstraction",
+            "--format",
+            "json",
+        ])
+        .expect("Azure DevOps change-request publish helper must parse manual-path inputs");
+    }
+
+    #[test]
+    fn workflow_simulate_recipe_command_parses_without_live_provider_args() {
+        Cli::try_parse_from([
+            "amplihack",
+            "workflow",
+            "simulate-recipe",
+            "default-workflow",
+            "--scenario",
+            "azdo-work-item-manual-pr",
+            "--repo-fixture",
+            "tests/fixtures/workflows/repos/azdo-repo",
+            "--format",
+            "json",
+        ])
+        .expect("simulate-recipe helper must parse deterministic local fixture inputs");
+    }
+
+    #[test]
+    fn workflow_cleanup_stale_requires_explicit_dry_run_or_apply_mode() {
+        let missing_mode = Cli::try_parse_from([
+            "amplihack",
+            "workflow",
+            "cleanup-stale",
+            "--provider",
+            "github",
+            "--format",
+            "json",
+        ]);
+        assert!(
+            missing_mode.is_err(),
+            "cleanup-stale must not default into mutating or ambiguous behavior"
+        );
+
+        Cli::try_parse_from([
+            "amplihack",
+            "workflow",
+            "cleanup-stale",
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+        ])
+        .expect("cleanup-stale --dry-run must parse");
+    }
 }

--- a/crates/amplihack-cli/src/commands/mod.rs
+++ b/crates/amplihack-cli/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub mod remote;
 pub mod rustyclawd;
 pub mod session_tree;
 pub mod uvx_help;
+pub mod workflow;
 
 use crate::{
     BuilderCommands, Commands, HygieneCommands, MemoryCommands, ModeCommands, MultitaskCommands,
@@ -301,6 +302,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
             limit,
         ),
         Commands::Recipe { command } => dispatch_recipe(command),
+        Commands::Workflow { command } => workflow::dispatch(command),
         Commands::Mode { command } => dispatch_mode(command),
         Commands::Lock { message } => lock::run_lock(message.as_deref()),
         Commands::Unlock => lock::run_unlock(),

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -199,6 +199,17 @@ pub(super) fn execute_recipe_via_rust(
     // `context_env_pairs` (they are not EnvBuilder-managed).
     command.envs(context_env_pairs(context));
 
+    let runtime_dir = tempfile::Builder::new()
+        .prefix("amplihack-workflow-")
+        .tempdir()
+        .context("failed to create isolated workflow runtime directory")?;
+    let artifact_dir = runtime_dir.path().join("artifacts");
+    let tmp_dir = runtime_dir.path().join("tmp");
+    std::fs::create_dir_all(&artifact_dir)
+        .context("failed to create isolated workflow artifact directory")?;
+    std::fs::create_dir_all(&tmp_dir)
+        .context("failed to create isolated workflow tmp directory")?;
+
     let env_builder = EnvBuilder::new()
         .with_agent_binary(active_agent_binary())
         .with_session_tree_context()
@@ -220,6 +231,9 @@ pub(super) fn execute_recipe_via_rust(
 
     env_builder.apply_to_command(&mut command);
     command.env("AMPLIHACK_RECIPE_RUN_ID", correlation.run_id());
+    command.env("AMPLIHACK_WORKFLOW_RUNTIME_DIR", runtime_dir.path());
+    command.env("AMPLIHACK_WORKFLOW_ARTIFACT_DIR", &artifact_dir);
+    command.env("TMPDIR", &tmp_dir);
 
     spawn_with_streaming_stderr(command, correlation)
 }
@@ -359,9 +373,10 @@ fn push_bounded_stderr_line(captured: &Arc<Mutex<VecDeque<String>>>, line: Strin
 
 /// Pure parser for recipe-runner-rs subprocess output.
 ///
-/// Behavior (issue #332):
-/// - Empty/whitespace-only stdout + success: returns a default `RecipeRunResult`
-///   with `success = true` (treats "ran but produced no JSON" as a no-op success).
+/// Behavior:
+/// - Empty/whitespace-only stdout + success returns an explicit hollow-success
+///   terminal failure. A runner that produced no structured result must not
+///   become a success-shaped no-op.
 /// - Empty/whitespace-only stdout + failure: errors with the meaningful stderr
 ///   tail surfaced so callers see the upstream cause.
 /// - Non-empty stdout: parses as JSON; on failure, errors with a bounded stdout
@@ -377,8 +392,21 @@ pub(super) fn parse_recipe_output(
     let trimmed = stdout.trim();
     if trimmed.is_empty() {
         if exit_success {
+            let mut extra = JsonMap::new();
+            extra.insert(
+                "workflow_result".into(),
+                serde_json::json!({
+                    "terminal_state": "HOLLOW_SUCCESS",
+                    "terminal_success": false,
+                    "terminal_reason": "recipe-runner-rs exited successfully but produced no structured workflow output",
+                    "required_next_action": "Inspect recipe-runner logs and rerun with structured JSON output."
+                }),
+            );
             return Ok(RecipeRunResult {
-                success: true,
+                success: false,
+                status: Some("HOLLOW_SUCCESS".into()),
+                phase: Some("finalization".into()),
+                extra,
                 ..RecipeRunResult::default()
             });
         }

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -232,6 +232,7 @@ pub(super) fn execute_recipe_via_rust(
     env_builder.apply_to_command(&mut command);
     command.env("AMPLIHACK_RECIPE_RUN_ID", correlation.run_id());
     command.env("AMPLIHACK_WORKFLOW_RUNTIME_DIR", runtime_dir.path());
+    command.env("AMPLIHACK_RUNTIME_ROOT", runtime_dir.path());
     command.env("AMPLIHACK_WORKFLOW_ARTIFACT_DIR", &artifact_dir);
     command.env("TMPDIR", &tmp_dir);
 

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
@@ -1343,20 +1343,33 @@ fn only_final_pointer(stderr: &str) -> JsonValue {
 // parse_recipe_output — pure parser unit tests (issue #332)
 // -------------------------------------------------------------------------
 
-/// Empty stdout + exit success: must return a default RecipeRunResult with
-/// success = true, not an error. This resolves issue #332 where
-/// recipe-runner-rs producing no output crashed the launcher.
+/// Empty stdout + exit success is a hollow workflow success and must fail
+/// closed with explicit terminal/finalization state instead of becoming a
+/// success-shaped no-op.
 #[test]
-fn parse_empty_stdout_success_returns_default_with_success_true() {
+fn parse_empty_stdout_success_returns_hollow_success_terminal_failure() {
     let result =
         execute::parse_recipe_output("", "", true).expect("empty stdout on success must not error");
-    assert!(result.success, "success flag must be true on empty+success");
     assert_eq!(
-        result.recipe_name, "",
-        "default recipe_name is empty string"
+        result.success, false,
+        "empty successful runner output must not be reported as workflow success"
     );
-    assert!(result.step_results.is_empty(), "no step results expected");
-    assert!(result.context.is_empty(), "no context expected");
+    assert_eq!(
+        result
+            .extra
+            .get("workflow_result")
+            .and_then(|value| value.get("terminal_state"))
+            .and_then(JsonValue::as_str),
+        Some("HOLLOW_SUCCESS")
+    );
+    assert_eq!(
+        result
+            .extra
+            .get("workflow_result")
+            .and_then(|value| value.get("terminal_success"))
+            .and_then(JsonValue::as_bool),
+        Some(false)
+    );
 }
 
 /// Empty stdout + exit failure: must error with stderr tail surfaced
@@ -1617,10 +1630,91 @@ fn failure_table_bounds_recent_output_snippets() {
 
 /// Whitespace-only stdout (e.g. trailing newline) must be treated as empty.
 #[test]
-fn parse_whitespace_only_stdout_success_returns_default() {
+fn parse_whitespace_only_stdout_success_returns_hollow_success_terminal_failure() {
     let result = execute::parse_recipe_output("   \n\t  \n", "", true)
         .expect("whitespace-only stdout on success must not error");
-    assert!(result.success);
+    assert!(!result.success);
+    assert_eq!(
+        result
+            .extra
+            .get("workflow_result")
+            .and_then(|value| value.get("terminal_state"))
+            .and_then(JsonValue::as_str),
+        Some("HOLLOW_SUCCESS")
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_execute_recipe_via_rust_sets_isolated_runtime_directories() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let repo = temp.path().join("repo");
+    let runner = temp.path().join("recipe-runner-rs");
+    let amplihack_home = temp.path().join("amplihack-home");
+    std::fs::create_dir_all(&repo).expect("failed to create repo dir");
+    std::fs::create_dir_all(&amplihack_home).expect("failed to create amplihack home");
+
+    std::fs::write(
+        &runner,
+        "#!/bin/sh\ncat <<EOF\n{\"recipe_name\":\"runtime-isolation-probe\",\"success\":true,\"step_results\":[],\"context\":{\"runtime_dir\":\"$AMPLIHACK_WORKFLOW_RUNTIME_DIR\",\"artifact_dir\":\"$AMPLIHACK_WORKFLOW_ARTIFACT_DIR\",\"tmpdir\":\"$TMPDIR\"}}\nEOF\n",
+    )
+    .expect("failed to write runner stub");
+    make_executable(&runner);
+
+    let recipe = repo.join("recipe.yaml");
+    std::fs::write(&recipe, "name: runtime-isolation-probe\nsteps: []\n")
+        .expect("failed to write recipe");
+
+    let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+    let prev_home = std::env::var_os("AMPLIHACK_HOME");
+    unsafe {
+        std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+        std::env::set_var("AMPLIHACK_HOME", &amplihack_home);
+    }
+
+    let result =
+        execute::execute_recipe_via_rust(&recipe, &BTreeMap::new(), false, false, &repo, &[], None)
+            .expect("recipe run must succeed");
+
+    restore_env_var("RECIPE_RUNNER_RS_PATH", prev_runner);
+    restore_env_var("AMPLIHACK_HOME", prev_home);
+
+    let runtime_dir = result
+        .context
+        .get("runtime_dir")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let artifact_dir = result
+        .context
+        .get("artifact_dir")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let tmpdir = result
+        .context
+        .get("tmpdir")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let repo_prefix = repo.to_string_lossy();
+
+    assert!(
+        !runtime_dir.is_empty(),
+        "runtime must expose AMPLIHACK_WORKFLOW_RUNTIME_DIR"
+    );
+    assert!(
+        !runtime_dir.starts_with(repo_prefix.as_ref()),
+        "workflow runtime dir must be outside the commit worktree"
+    );
+    assert!(
+        artifact_dir.starts_with(runtime_dir),
+        "workflow artifact dir should be scoped under the isolated runtime dir"
+    );
+    assert!(
+        tmpdir.starts_with(runtime_dir),
+        "TMPDIR should be scoped under the isolated runtime dir for child steps"
+    );
 }
 
 // Issue #691: recipe-runner-rs owns progress emission. The CLI must not pass

--- a/crates/amplihack-cli/src/commands/workflow.rs
+++ b/crates/amplihack-cli/src/commands/workflow.rs
@@ -1,16 +1,16 @@
 use amplihack_workflows::simulation::{RecipeSimulation, RecipeSimulationScenario};
 use amplihack_workflows::stale_cleanup::{
-    CleanupMode, CleanupPlan, CleanupPolicy, StaleChangeRequest,
+    CleanupAction, CleanupMode, CleanupPlan, CleanupPolicy, StaleChangeRequest,
 };
 use amplihack_workflows::workflow_contract::{
-    HelperEnvelope, HelperOperation, ManualAction, ProviderCapabilities, ProviderCapabilityState,
-    ProviderContext, ProviderOperationStatus, RepositoryIdentity, RepositoryProvider,
-    TerminalState, validate_terminal_transition,
+    HelperEnvelope, HelperOperation, ManualAction, ProviderContext, ProviderOperationStatus,
+    RepositoryIdentity, RepositoryProvider, provider_capabilities, provider_default_next_action,
+    provider_from_remote_url, validate_terminal_transition,
 };
 use anyhow::{Context, Result};
 use clap::{ArgGroup, Args, Subcommand, ValueEnum};
 use serde_json::json;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Subcommand, Debug)]
 pub enum WorkflowCommands {
@@ -139,95 +139,53 @@ pub fn dispatch(command: WorkflowCommands) -> Result<()> {
 }
 
 fn run_detect_provider(args: DetectProviderArgs) -> Result<()> {
-    let provider = detect_provider_from_repo(&args.repo);
-    let repository = RepositoryIdentity {
-        remote_url: None,
-        owner: "unknown".into(),
-        name: args
-            .repo
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "repository".into()),
-        default_base: "main".into(),
-    };
-    let capabilities = capabilities_for(provider);
+    let detection = detect_provider_from_repo(&args.repo)?;
+    let provider = detection.provider;
+    let repository = detection.repository;
+    let capabilities = provider_capabilities(provider);
+    let status = provider_status(provider);
     let context = ProviderContext {
         schema_version: 1,
         provider,
         repository: repository.clone(),
         capabilities: capabilities.clone(),
-        status: match provider {
-            RepositoryProvider::GitHub => ProviderOperationStatus::Succeeded,
-            RepositoryProvider::AzureDevOps | RepositoryProvider::Manual => {
-                ProviderOperationStatus::ManualRequired
-            }
-        },
-        next_action: next_action_for(provider).into(),
+        status,
+        next_action: provider_default_next_action(provider).into(),
     };
     let data = json!({
         "repository": repository,
         "capabilities": capabilities,
         "provider_context": context
     });
-    let envelope = match provider {
-        RepositoryProvider::GitHub => HelperEnvelope::succeeded(
-            provider,
-            HelperOperation::DetectProvider,
-            next_action_for(provider),
-            data,
-        ),
-        RepositoryProvider::AzureDevOps | RepositoryProvider::Manual => {
-            HelperEnvelope::manual_required(
-                provider,
-                HelperOperation::DetectProvider,
-                next_action_for(provider),
-                data,
-            )
-        }
-    };
+    let mut envelope = helper_envelope(
+        provider,
+        HelperOperation::DetectProvider,
+        status,
+        provider_default_next_action(provider),
+        data,
+    );
+    envelope.warnings = detection.warnings;
     write_output(&envelope, &args.format)
 }
 
 fn run_publish_change_request(args: PublishChangeRequestArgs) -> Result<()> {
     let provider = RepositoryProvider::from(args.provider);
-    let envelope = match provider {
-        RepositoryProvider::GitHub => HelperEnvelope::succeeded(
-            provider,
-            HelperOperation::PublishChangeRequest,
-            "Inspect the created GitHub pull request and wait for checks.",
-            json!({
-                "change_request": {
-                    "kind": "PullRequest",
-                    "id": "dry-run",
-                    "url": null,
-                    "state": "Open",
-                    "source_branch": args.source_branch,
-                    "base_branch": args.base_branch,
-                    "head_sha": null,
-                    "title": args.title
-                }
-            }),
-        ),
-        RepositoryProvider::AzureDevOps | RepositoryProvider::Manual => {
-            let manual_action = ManualAction {
-                action: "CreateAzureReposPullRequest".into(),
-                instructions: format!(
-                    "Create a pull request from {} to {} titled '{}'.",
-                    args.source_branch, args.base_branch, args.title
-                ),
-                required_inputs: vec!["source_branch".into(), "base_branch".into(), "title".into()],
-            };
-            HelperEnvelope::manual_required(
-                provider,
-                HelperOperation::PublishChangeRequest,
-                "Create the provider pull request manually, then rerun status detection.",
-                json!({
-                    "change_request": null,
-                    "manual_action": manual_action
-                }),
-            )
-        }
-    };
+    let manual_action = manual_publish_action(
+        provider,
+        &args.source_branch,
+        &args.base_branch,
+        &args.title,
+    );
+    let envelope = helper_envelope(
+        provider,
+        HelperOperation::PublishChangeRequest,
+        ProviderOperationStatus::ManualRequired,
+        "Create the provider change request manually, then rerun status detection.",
+        json!({
+            "change_request": null,
+            "manual_action": manual_action
+        }),
+    );
     write_output(&envelope, &args.format)
 }
 
@@ -252,6 +210,7 @@ fn run_simulate_recipe(args: SimulateRecipeArgs) -> Result<()> {
 }
 
 fn run_cleanup_stale(args: CleanupStaleArgs) -> Result<()> {
+    let requested_apply = args.apply;
     let candidates = match args.candidates {
         Some(path) => {
             let text = std::fs::read_to_string(&path)
@@ -261,28 +220,43 @@ fn run_cleanup_stale(args: CleanupStaleArgs) -> Result<()> {
         }
         None => Vec::new(),
     };
+    let provider = args.provider.into();
     let policy = CleanupPolicy {
-        provider: args.provider.into(),
-        mode: if args.apply {
-            CleanupMode::Apply
-        } else {
-            CleanupMode::DryRun
-        },
+        provider,
+        mode: CleanupMode::DryRun,
         workflow_label: args.workflow_label,
         superseded_by_label_prefix: args.superseded_by_label_prefix,
         minimum_age_hours: args.minimum_age_hours,
     };
     let plan = CleanupPlan::build(policy, candidates).map_err(anyhow::Error::msg)?;
-    let envelope = HelperEnvelope::succeeded(
+    let has_eligible_actions = plan
+        .actions
+        .iter()
+        .any(|action| action.action == CleanupAction::WouldCloseAsSuperseded);
+    let status = if requested_apply && has_eligible_actions {
+        ProviderOperationStatus::ManualRequired
+    } else {
+        ProviderOperationStatus::Succeeded
+    };
+    let mut envelope = helper_envelope(
         plan.provider,
         HelperOperation::CleanupStale,
-        if plan.mutations_executed == 0 {
+        status,
+        if requested_apply && has_eligible_actions {
+            "Review the dry-run plan and close eligible change requests through the provider manually."
+        } else if plan.mutations_executed == 0 {
             "Cleanup plan completed without provider mutations."
         } else {
             "Cleanup mutations completed for eligible workflow-owned change requests."
         },
         serde_json::to_value(plan)?,
     );
+    if requested_apply {
+        envelope.warnings.push(
+            "Provider mutation adapters are not wired in this helper; emitted a dry-run cleanup plan instead of mutating remote change requests."
+                .into(),
+        );
+    }
     write_output(&envelope, &args.format)
 }
 
@@ -296,44 +270,232 @@ fn run_terminal_state(args: TerminalStateArgs) -> Result<()> {
     write_output(&result, &args.format)
 }
 
-fn detect_provider_from_repo(repo: &std::path::Path) -> RepositoryProvider {
-    let marker = repo.join(".git/config");
-    let config = std::fs::read_to_string(marker).unwrap_or_default();
-    if config.contains("dev.azure.com") || config.contains("visualstudio.com") {
-        RepositoryProvider::AzureDevOps
-    } else {
-        RepositoryProvider::GitHub
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderDetection {
+    provider: RepositoryProvider,
+    repository: RepositoryIdentity,
+    warnings: Vec<String>,
+}
+
+fn detect_provider_from_repo(repo: &Path) -> Result<ProviderDetection> {
+    let mut warnings = Vec::new();
+    let config = read_git_config(repo)?;
+    let remote_url = config.as_deref().and_then(origin_remote_url);
+    let provider = provider_from_remote_url(remote_url.as_deref());
+    if config.is_none() {
+        warnings.push("No Git config found; provider set to Manual.".into());
+    } else if remote_url.is_none() {
+        warnings.push("No origin remote URL found; provider set to Manual.".into());
+    } else if provider == RepositoryProvider::Manual {
+        warnings.push("Remote provider is unknown; provider set to Manual.".into());
+    }
+
+    let fallback_name = repo
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| "repository".into());
+    let (owner, name) = repository_owner_name(remote_url.as_deref(), &fallback_name);
+    Ok(ProviderDetection {
+        provider,
+        repository: RepositoryIdentity {
+            remote_url,
+            owner,
+            name,
+            default_base: "main".into(),
+        },
+        warnings,
+    })
+}
+
+fn helper_envelope(
+    provider: RepositoryProvider,
+    operation: HelperOperation,
+    status: ProviderOperationStatus,
+    next_action: impl Into<String>,
+    data: serde_json::Value,
+) -> HelperEnvelope {
+    HelperEnvelope {
+        schema_version: 1,
+        provider,
+        operation,
+        status,
+        next_action: next_action.into(),
+        warnings: Vec::new(),
+        data,
     }
 }
 
-fn capabilities_for(provider: RepositoryProvider) -> ProviderCapabilities {
+fn provider_status(provider: RepositoryProvider) -> ProviderOperationStatus {
     match provider {
-        RepositoryProvider::GitHub => ProviderCapabilities {
-            tracking_items: ProviderCapabilityState::Automated,
-            change_requests: ProviderCapabilityState::Automated,
-            stale_cleanup: ProviderCapabilityState::Automated,
-        },
-        RepositoryProvider::AzureDevOps => ProviderCapabilities {
-            tracking_items: ProviderCapabilityState::Automated,
-            change_requests: ProviderCapabilityState::ManualRequired,
-            stale_cleanup: ProviderCapabilityState::ManualRequired,
-        },
-        RepositoryProvider::Manual => ProviderCapabilities {
-            tracking_items: ProviderCapabilityState::ManualRequired,
-            change_requests: ProviderCapabilityState::ManualRequired,
-            stale_cleanup: ProviderCapabilityState::ManualRequired,
-        },
-    }
-}
-
-fn next_action_for(provider: RepositoryProvider) -> &'static str {
-    match provider {
-        RepositoryProvider::GitHub => "No further provider setup is required.",
-        RepositoryProvider::AzureDevOps => {
-            "Use Azure Boards automation where configured; create Azure Repos PRs manually."
+        RepositoryProvider::GitHub => ProviderOperationStatus::Succeeded,
+        RepositoryProvider::AzureDevOps | RepositoryProvider::Manual => {
+            ProviderOperationStatus::ManualRequired
         }
-        RepositoryProvider::Manual => "Run provider-specific change request steps manually.",
     }
+}
+
+fn manual_publish_action(
+    provider: RepositoryProvider,
+    source_branch: &str,
+    base_branch: &str,
+    title: &str,
+) -> ManualAction {
+    let required_inputs = vec!["source_branch".into(), "base_branch".into(), "title".into()];
+    match provider {
+        RepositoryProvider::GitHub => ManualAction {
+            action: "CreateGitHubPullRequest".into(),
+            instructions: format!(
+                "Create a GitHub pull request from {source_branch} to {base_branch} titled '{title}'."
+            ),
+            required_inputs,
+        },
+        RepositoryProvider::AzureDevOps => ManualAction {
+            action: "CreateAzureReposPullRequest".into(),
+            instructions: format!(
+                "Create an Azure Repos pull request from {source_branch} to {base_branch} titled '{title}'."
+            ),
+            required_inputs,
+        },
+        RepositoryProvider::Manual => ManualAction {
+            action: "CreateProviderChangeRequest".into(),
+            instructions: format!(
+                "Create a provider change request from {source_branch} to {base_branch} titled '{title}'."
+            ),
+            required_inputs,
+        },
+    }
+}
+
+fn read_git_config(repo: &Path) -> Result<Option<String>> {
+    let Some(path) = git_config_path(repo)? else {
+        return Ok(None);
+    };
+    std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read Git config from {}", path.display()))
+        .map(Some)
+}
+
+fn git_config_path(repo: &Path) -> Result<Option<PathBuf>> {
+    let dot_git = repo.join(".git");
+    if dot_git.is_dir() {
+        let config = dot_git.join("config");
+        return Ok(config.is_file().then_some(config));
+    }
+    if !dot_git.is_file() {
+        return Ok(None);
+    }
+
+    let marker = std::fs::read_to_string(&dot_git)
+        .with_context(|| format!("failed to read Git marker file {}", dot_git.display()))?;
+    let git_dir = marker
+        .trim()
+        .strip_prefix("gitdir:")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("invalid Git marker file {}", dot_git.display()))?;
+    let git_dir = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        repo.join(git_dir)
+    };
+
+    let worktree_config = git_dir.join("config");
+    if worktree_config.is_file() {
+        return Ok(Some(worktree_config));
+    }
+
+    let common_dir_file = git_dir.join("commondir");
+    if common_dir_file.is_file() {
+        let common_dir = std::fs::read_to_string(&common_dir_file).with_context(|| {
+            format!(
+                "failed to read Git common-dir marker {}",
+                common_dir_file.display()
+            )
+        })?;
+        let common_dir = PathBuf::from(common_dir.trim());
+        let common_dir = if common_dir.is_absolute() {
+            common_dir
+        } else {
+            git_dir.join(common_dir)
+        };
+        let common_config = common_dir.join("config");
+        if common_config.is_file() {
+            return Ok(Some(common_config));
+        }
+    }
+
+    Ok(None)
+}
+
+fn origin_remote_url(config: &str) -> Option<String> {
+    let mut in_origin = false;
+    let mut first_remote_url = None;
+    for line in config.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_origin = trimmed == r#"[remote "origin"]"#;
+            continue;
+        }
+        let Some(url) = trimmed.strip_prefix("url").and_then(|rest| {
+            rest.trim_start()
+                .strip_prefix('=')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        }) else {
+            continue;
+        };
+        if first_remote_url.is_none() {
+            first_remote_url = Some(url.to_string());
+        }
+        if in_origin {
+            return Some(url.to_string());
+        }
+    }
+    first_remote_url
+}
+
+fn repository_owner_name(remote_url: Option<&str>, fallback_name: &str) -> (String, String) {
+    let Some(remote_url) = remote_url else {
+        return ("unknown".into(), fallback_name.into());
+    };
+    if let Some(path) = remote_url
+        .split("github.com")
+        .nth(1)
+        .map(|value| value.trim_start_matches([':', '/']))
+    {
+        return owner_name_from_path(path, fallback_name);
+    }
+    if let Some(after_git) = remote_url.split("/_git/").nth(1) {
+        let name = trim_repo_suffix(after_git);
+        let owner = remote_url
+            .split("/_git/")
+            .next()
+            .and_then(|prefix| prefix.split("dev.azure.com/").nth(1))
+            .map(|path| path.trim_matches('/').to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "azure-devops".into());
+        return (owner, name);
+    }
+    ("unknown".into(), fallback_name.into())
+}
+
+fn owner_name_from_path(path: &str, fallback_name: &str) -> (String, String) {
+    let mut parts = path.trim_matches('/').split('/');
+    let owner = parts.next().filter(|value| !value.is_empty());
+    let name = parts.next().filter(|value| !value.is_empty());
+    match (owner, name) {
+        (Some(owner), Some(name)) => (owner.into(), trim_repo_suffix(name)),
+        _ => ("unknown".into(), fallback_name.into()),
+    }
+}
+
+fn trim_repo_suffix(name: &str) -> String {
+    name.trim_matches('/')
+        .trim_end_matches(".git")
+        .trim()
+        .to_string()
 }
 
 fn minimal_named_scenario(name: &str, recipe: &str, repo_fixture: Option<&PathBuf>) -> String {
@@ -362,7 +524,101 @@ fn write_output<T: serde::Serialize>(value: &T, _format: &str) -> Result<()> {
     Ok(())
 }
 
-#[allow(dead_code)]
-fn _terminal_state_to_keep_type_referenced(state: TerminalState) -> TerminalState {
-    state
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_provider_without_git_config_returns_manual_with_warning() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let detection = detect_provider_from_repo(temp.path()).expect("detection should succeed");
+
+        assert_eq!(detection.provider, RepositoryProvider::Manual);
+        assert_eq!(
+            detection.repository.remote_url, None,
+            "unknown repositories must not synthesize a GitHub remote"
+        );
+        assert!(
+            detection
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("provider set to Manual"))
+        );
+    }
+
+    #[test]
+    fn detect_provider_reads_common_config_for_git_worktree_marker() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let git_dir = temp.path().join("main.git").join("worktrees").join("repo");
+        let common_dir = temp.path().join("main.git");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+        std::fs::create_dir_all(&git_dir).expect("git dir");
+        std::fs::write(
+            repo.join(".git"),
+            format!("gitdir: {}\n", git_dir.display()),
+        )
+        .expect("git marker");
+        std::fs::write(git_dir.join("commondir"), "../..\n").expect("commondir");
+        std::fs::write(
+            common_dir.join("config"),
+            r#"
+[remote "origin"]
+    url = https://dev.azure.com/acme/project/_git/service
+"#,
+        )
+        .expect("config");
+
+        let detection = detect_provider_from_repo(&repo).expect("detection should succeed");
+
+        assert_eq!(detection.provider, RepositoryProvider::AzureDevOps);
+        assert_eq!(detection.repository.owner, "acme/project");
+        assert_eq!(detection.repository.name, "service");
+        assert!(detection.warnings.is_empty());
+    }
+
+    #[test]
+    fn unknown_remote_returns_manual_not_github() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let git = repo.join(".git");
+        std::fs::create_dir_all(&git).expect("git dir");
+        std::fs::write(
+            git.join("config"),
+            r#"
+[remote "origin"]
+    url = ssh://git.example.invalid/acme/service
+"#,
+        )
+        .expect("config");
+
+        let detection = detect_provider_from_repo(&repo).expect("detection should succeed");
+
+        assert_eq!(detection.provider, RepositoryProvider::Manual);
+        assert!(
+            detection
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("unknown"))
+        );
+    }
+
+    #[test]
+    fn manual_publish_actions_are_provider_specific_without_fake_success() {
+        let github = manual_publish_action(RepositoryProvider::GitHub, "feat/x", "main", "Ship x");
+        assert_eq!(github.action, "CreateGitHubPullRequest");
+        assert!(github.instructions.contains("GitHub pull request"));
+
+        let azdo =
+            manual_publish_action(RepositoryProvider::AzureDevOps, "feat/x", "main", "Ship x");
+        assert_eq!(azdo.action, "CreateAzureReposPullRequest");
+        assert!(azdo.instructions.contains("Azure Repos pull request"));
+
+        let manual = manual_publish_action(RepositoryProvider::Manual, "feat/x", "main", "Ship x");
+        assert_eq!(manual.action, "CreateProviderChangeRequest");
+        assert!(
+            !manual.instructions.contains("GitHub") && !manual.instructions.contains("Azure"),
+            "generic manual provider instructions must remain provider-neutral"
+        );
+    }
 }

--- a/crates/amplihack-cli/src/commands/workflow.rs
+++ b/crates/amplihack-cli/src/commands/workflow.rs
@@ -1,0 +1,368 @@
+use amplihack_workflows::simulation::{RecipeSimulation, RecipeSimulationScenario};
+use amplihack_workflows::stale_cleanup::{
+    CleanupMode, CleanupPlan, CleanupPolicy, StaleChangeRequest,
+};
+use amplihack_workflows::workflow_contract::{
+    HelperEnvelope, HelperOperation, ManualAction, ProviderCapabilities, ProviderCapabilityState,
+    ProviderContext, ProviderOperationStatus, RepositoryIdentity, RepositoryProvider,
+    TerminalState, validate_terminal_transition,
+};
+use anyhow::{Context, Result};
+use clap::{ArgGroup, Args, Subcommand, ValueEnum};
+use serde_json::json;
+use std::path::PathBuf;
+
+#[derive(Subcommand, Debug)]
+pub enum WorkflowCommands {
+    /// Detect provider context for the current repository.
+    DetectProvider(DetectProviderArgs),
+    /// Provider-neutral change request operations.
+    ChangeRequest {
+        #[command(subcommand)]
+        command: ChangeRequestCommands,
+    },
+    /// Run a deterministic local recipe simulation fixture.
+    SimulateRecipe(SimulateRecipeArgs),
+    /// Plan or apply stale workflow-owned change-request cleanup.
+    CleanupStale(CleanupStaleArgs),
+    /// Validate or emit explicit workflow terminal state.
+    TerminalState(TerminalStateArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct DetectProviderArgs {
+    #[arg(long, default_value = ".")]
+    repo: PathBuf,
+    #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+    format: String,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ChangeRequestCommands {
+    /// Publish a provider-neutral change request or return a manual action.
+    Publish(PublishChangeRequestArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct PublishChangeRequestArgs {
+    #[arg(long, value_enum)]
+    provider: ProviderArg,
+    #[arg(long)]
+    source_branch: String,
+    #[arg(long)]
+    base_branch: String,
+    #[arg(long)]
+    title: String,
+    #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+    format: String,
+}
+
+#[derive(Args, Debug)]
+pub struct SimulateRecipeArgs {
+    recipe: String,
+    #[arg(long)]
+    scenario: String,
+    #[arg(long)]
+    repo_fixture: Option<PathBuf>,
+    #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+    format: String,
+}
+
+#[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("mode")
+        .required(true)
+        .args(["dry_run", "apply"])
+))]
+pub struct CleanupStaleArgs {
+    #[arg(long, value_enum)]
+    provider: ProviderArg,
+    #[arg(long)]
+    dry_run: bool,
+    #[arg(long)]
+    apply: bool,
+    #[arg(long, default_value = "amplihack-workflow")]
+    workflow_label: String,
+    #[arg(long, default_value = "superseded-by:")]
+    superseded_by_label_prefix: String,
+    #[arg(long, default_value_t = 48)]
+    minimum_age_hours: u64,
+    #[arg(long)]
+    candidates: Option<PathBuf>,
+    #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+    format: String,
+}
+
+#[derive(Args, Debug)]
+pub struct TerminalStateArgs {
+    #[arg(long, default_value = "HOLLOW_SUCCESS")]
+    terminal_state: String,
+    #[arg(long, default_value_t = false)]
+    terminal_success: bool,
+    #[arg(
+        long,
+        default_value = "Inspect workflow evidence and rerun finalization."
+    )]
+    required_next_action: String,
+    #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+    format: String,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ProviderArg {
+    Github,
+    #[value(name = "azure-devops")]
+    AzureDevops,
+    Manual,
+}
+
+impl From<ProviderArg> for RepositoryProvider {
+    fn from(value: ProviderArg) -> Self {
+        match value {
+            ProviderArg::Github => Self::GitHub,
+            ProviderArg::AzureDevops => Self::AzureDevOps,
+            ProviderArg::Manual => Self::Manual,
+        }
+    }
+}
+
+pub fn dispatch(command: WorkflowCommands) -> Result<()> {
+    match command {
+        WorkflowCommands::DetectProvider(args) => run_detect_provider(args),
+        WorkflowCommands::ChangeRequest { command } => match command {
+            ChangeRequestCommands::Publish(args) => run_publish_change_request(args),
+        },
+        WorkflowCommands::SimulateRecipe(args) => run_simulate_recipe(args),
+        WorkflowCommands::CleanupStale(args) => run_cleanup_stale(args),
+        WorkflowCommands::TerminalState(args) => run_terminal_state(args),
+    }
+}
+
+fn run_detect_provider(args: DetectProviderArgs) -> Result<()> {
+    let provider = detect_provider_from_repo(&args.repo);
+    let repository = RepositoryIdentity {
+        remote_url: None,
+        owner: "unknown".into(),
+        name: args
+            .repo
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "repository".into()),
+        default_base: "main".into(),
+    };
+    let capabilities = capabilities_for(provider);
+    let context = ProviderContext {
+        schema_version: 1,
+        provider,
+        repository: repository.clone(),
+        capabilities: capabilities.clone(),
+        status: match provider {
+            RepositoryProvider::GitHub => ProviderOperationStatus::Succeeded,
+            RepositoryProvider::AzureDevOps | RepositoryProvider::Manual => {
+                ProviderOperationStatus::ManualRequired
+            }
+        },
+        next_action: next_action_for(provider).into(),
+    };
+    let data = json!({
+        "repository": repository,
+        "capabilities": capabilities,
+        "provider_context": context
+    });
+    let envelope = match provider {
+        RepositoryProvider::GitHub => HelperEnvelope::succeeded(
+            provider,
+            HelperOperation::DetectProvider,
+            next_action_for(provider),
+            data,
+        ),
+        RepositoryProvider::AzureDevOps | RepositoryProvider::Manual => {
+            HelperEnvelope::manual_required(
+                provider,
+                HelperOperation::DetectProvider,
+                next_action_for(provider),
+                data,
+            )
+        }
+    };
+    write_output(&envelope, &args.format)
+}
+
+fn run_publish_change_request(args: PublishChangeRequestArgs) -> Result<()> {
+    let provider = RepositoryProvider::from(args.provider);
+    let envelope = match provider {
+        RepositoryProvider::GitHub => HelperEnvelope::succeeded(
+            provider,
+            HelperOperation::PublishChangeRequest,
+            "Inspect the created GitHub pull request and wait for checks.",
+            json!({
+                "change_request": {
+                    "kind": "PullRequest",
+                    "id": "dry-run",
+                    "url": null,
+                    "state": "Open",
+                    "source_branch": args.source_branch,
+                    "base_branch": args.base_branch,
+                    "head_sha": null,
+                    "title": args.title
+                }
+            }),
+        ),
+        RepositoryProvider::AzureDevOps | RepositoryProvider::Manual => {
+            let manual_action = ManualAction {
+                action: "CreateAzureReposPullRequest".into(),
+                instructions: format!(
+                    "Create a pull request from {} to {} titled '{}'.",
+                    args.source_branch, args.base_branch, args.title
+                ),
+                required_inputs: vec!["source_branch".into(), "base_branch".into(), "title".into()],
+            };
+            HelperEnvelope::manual_required(
+                provider,
+                HelperOperation::PublishChangeRequest,
+                "Create the provider pull request manually, then rerun status detection.",
+                json!({
+                    "change_request": null,
+                    "manual_action": manual_action
+                }),
+            )
+        }
+    };
+    write_output(&envelope, &args.format)
+}
+
+fn run_simulate_recipe(args: SimulateRecipeArgs) -> Result<()> {
+    let scenario_text = std::fs::read_to_string(&args.scenario).unwrap_or_else(|_| {
+        minimal_named_scenario(&args.scenario, &args.recipe, args.repo_fixture.as_ref())
+    });
+    let scenario: RecipeSimulationScenario = serde_yaml::from_str(&scenario_text)
+        .context("failed to parse workflow simulation scenario")?;
+    let result = RecipeSimulation::run(scenario).map_err(anyhow::Error::new)?;
+    let envelope = HelperEnvelope::succeeded(
+        result.provider,
+        HelperOperation::SimulateRecipe,
+        if result.terminal_success {
+            "Simulation reached a successful terminal state."
+        } else {
+            "Inspect simulation terminal state and required provider action."
+        },
+        serde_json::to_value(result)?,
+    );
+    write_output(&envelope, &args.format)
+}
+
+fn run_cleanup_stale(args: CleanupStaleArgs) -> Result<()> {
+    let candidates = match args.candidates {
+        Some(path) => {
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read candidates from {}", path.display()))?;
+            serde_json::from_str::<Vec<StaleChangeRequest>>(&text)
+                .context("failed to parse cleanup candidates JSON")?
+        }
+        None => Vec::new(),
+    };
+    let policy = CleanupPolicy {
+        provider: args.provider.into(),
+        mode: if args.apply {
+            CleanupMode::Apply
+        } else {
+            CleanupMode::DryRun
+        },
+        workflow_label: args.workflow_label,
+        superseded_by_label_prefix: args.superseded_by_label_prefix,
+        minimum_age_hours: args.minimum_age_hours,
+    };
+    let plan = CleanupPlan::build(policy, candidates).map_err(anyhow::Error::msg)?;
+    let envelope = HelperEnvelope::succeeded(
+        plan.provider,
+        HelperOperation::CleanupStale,
+        if plan.mutations_executed == 0 {
+            "Cleanup plan completed without provider mutations."
+        } else {
+            "Cleanup mutations completed for eligible workflow-owned change requests."
+        },
+        serde_json::to_value(plan)?,
+    );
+    write_output(&envelope, &args.format)
+}
+
+fn run_terminal_state(args: TerminalStateArgs) -> Result<()> {
+    let result = validate_terminal_transition(json!({
+        "terminal_state": args.terminal_state,
+        "terminal_success": args.terminal_success,
+        "required_next_action": args.required_next_action,
+        "evidence_used": []
+    }));
+    write_output(&result, &args.format)
+}
+
+fn detect_provider_from_repo(repo: &std::path::Path) -> RepositoryProvider {
+    let marker = repo.join(".git/config");
+    let config = std::fs::read_to_string(marker).unwrap_or_default();
+    if config.contains("dev.azure.com") || config.contains("visualstudio.com") {
+        RepositoryProvider::AzureDevOps
+    } else {
+        RepositoryProvider::GitHub
+    }
+}
+
+fn capabilities_for(provider: RepositoryProvider) -> ProviderCapabilities {
+    match provider {
+        RepositoryProvider::GitHub => ProviderCapabilities {
+            tracking_items: ProviderCapabilityState::Automated,
+            change_requests: ProviderCapabilityState::Automated,
+            stale_cleanup: ProviderCapabilityState::Automated,
+        },
+        RepositoryProvider::AzureDevOps => ProviderCapabilities {
+            tracking_items: ProviderCapabilityState::Automated,
+            change_requests: ProviderCapabilityState::ManualRequired,
+            stale_cleanup: ProviderCapabilityState::ManualRequired,
+        },
+        RepositoryProvider::Manual => ProviderCapabilities {
+            tracking_items: ProviderCapabilityState::ManualRequired,
+            change_requests: ProviderCapabilityState::ManualRequired,
+            stale_cleanup: ProviderCapabilityState::ManualRequired,
+        },
+    }
+}
+
+fn next_action_for(provider: RepositoryProvider) -> &'static str {
+    match provider {
+        RepositoryProvider::GitHub => "No further provider setup is required.",
+        RepositoryProvider::AzureDevOps => {
+            "Use Azure Boards automation where configured; create Azure Repos PRs manually."
+        }
+        RepositoryProvider::Manual => "Run provider-specific change request steps manually.",
+    }
+}
+
+fn minimal_named_scenario(name: &str, recipe: &str, repo_fixture: Option<&PathBuf>) -> String {
+    format!(
+        r#"name: {name}
+recipe: {recipe}
+repo_fixture: {repo_fixture}
+provider:
+  kind: GitHub
+  capabilities:
+    tracking_items: Automated
+    change_requests: Automated
+    stale_cleanup: Automated
+expect:
+  terminal_state: FOLLOWUP_CREATED
+  terminal_success: true
+"#,
+        repo_fixture = repo_fixture
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "null".into())
+    )
+}
+
+fn write_output<T: serde::Serialize>(value: &T, _format: &str) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn _terminal_state_to_keep_type_referenced(state: TerminalState) -> TerminalState {
+    state
+}

--- a/crates/amplihack-cli/src/commands/workflow.rs
+++ b/crates/amplihack-cli/src/commands/workflow.rs
@@ -3,7 +3,8 @@ use amplihack_workflows::stale_cleanup::{
     CleanupAction, CleanupMode, CleanupPlan, CleanupPolicy, StaleChangeRequest,
 };
 use amplihack_workflows::workflow_contract::{
-    HelperEnvelope, HelperOperation, ManualAction, ProviderCapabilityState, ProviderContext,
+    ChangeRequest, ChangeRequestKind, ChangeRequestStatus, HelperEnvelope, HelperOperation,
+    ManualAction, ProviderCapabilities, ProviderCapabilityState, ProviderContext,
     ProviderOperationStatus, RepositoryProvider, provider_capabilities,
     provider_default_next_action, validate_terminal_transition,
 };
@@ -11,6 +12,7 @@ use anyhow::{Context, Result};
 use clap::{ArgGroup, Args, Subcommand, ValueEnum};
 use serde_json::json;
 use std::path::PathBuf;
+use std::process::{Command, Output};
 
 mod provider_detection;
 
@@ -103,11 +105,21 @@ pub struct TerminalStateArgs {
     terminal_state: String,
     #[arg(long, default_value_t = false)]
     terminal_success: bool,
+    #[arg(long, value_enum)]
+    provider: Option<ProviderArg>,
+    #[arg(long, value_enum)]
+    change_requests_capability: Option<CapabilityArg>,
     #[arg(
         long,
         default_value = "Inspect workflow evidence and rerun finalization."
     )]
     required_next_action: String,
+    #[arg(
+        long = "evidence",
+        value_delimiter = ',',
+        default_value = "workflow-terminal-state-command"
+    )]
+    evidence_used: Vec<String>,
     #[arg(long, default_value = "text", value_parser = ["text", "json"])]
     format: String,
 }
@@ -120,12 +132,31 @@ pub enum ProviderArg {
     Manual,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum CapabilityArg {
+    Automated,
+    ManualRequired,
+    BlockedManualProvider,
+    Unsupported,
+}
+
 impl From<ProviderArg> for RepositoryProvider {
     fn from(value: ProviderArg) -> Self {
         match value {
             ProviderArg::Github => Self::GitHub,
             ProviderArg::AzureDevops => Self::AzureDevOps,
             ProviderArg::Manual => Self::Manual,
+        }
+    }
+}
+
+impl From<CapabilityArg> for ProviderCapabilityState {
+    fn from(value: CapabilityArg) -> Self {
+        match value {
+            CapabilityArg::Automated => Self::Automated,
+            CapabilityArg::ManualRequired => Self::ManualRequired,
+            CapabilityArg::BlockedManualProvider => Self::BlockedManualProvider,
+            CapabilityArg::Unsupported => Self::Unsupported,
         }
     }
 }
@@ -176,16 +207,12 @@ fn run_publish_change_request(args: PublishChangeRequestArgs) -> Result<()> {
     let provider = RepositoryProvider::from(args.provider);
     let capabilities = provider_capabilities(provider);
     if capabilities.change_requests == ProviderCapabilityState::Automated {
-        let envelope = helper_envelope(
+        let envelope = publish_automated_change_request(
             provider,
-            HelperOperation::PublishChangeRequest,
-            ProviderOperationStatus::Failed,
-            "Use the workflow publish provider adapter; this typed CLI command does not create provider pull requests.",
-            json!({
-                "change_request": null,
-                "manual_action": null,
-                "capabilities": capabilities
-            }),
+            capabilities,
+            &args.source_branch,
+            &args.base_branch,
+            &args.title,
         );
         return write_output(&envelope, &args.format);
     }
@@ -281,13 +308,442 @@ fn run_cleanup_stale(args: CleanupStaleArgs) -> Result<()> {
 }
 
 fn run_terminal_state(args: TerminalStateArgs) -> Result<()> {
-    let result = validate_terminal_transition(json!({
+    let mut payload = json!({
         "terminal_state": args.terminal_state,
         "terminal_success": args.terminal_success,
+        "reason": "Terminal state emitted by workflow CLI command.",
         "required_next_action": args.required_next_action,
-        "evidence_used": []
-    }));
+        "evidence_used": args.evidence_used
+    });
+    if let Some(provider) = args.provider {
+        payload["provider"] = serde_json::to_value(RepositoryProvider::from(provider))?;
+    }
+    if let Some(capability) = args.change_requests_capability {
+        payload["capabilities"] = json!({
+            "change_requests": ProviderCapabilityState::from(capability)
+        });
+    }
+    let result = validate_terminal_transition(payload);
     write_output(&result, &args.format)
+}
+
+fn publish_automated_change_request(
+    provider: RepositoryProvider,
+    capabilities: ProviderCapabilities,
+    source_branch: &str,
+    base_branch: &str,
+    title: &str,
+) -> HelperEnvelope {
+    match provider {
+        RepositoryProvider::GitHub => {
+            publish_github_change_request(capabilities, source_branch, base_branch, title)
+        }
+        RepositoryProvider::AzureDevOps => {
+            publish_azdo_change_request(capabilities, source_branch, base_branch, title)
+        }
+        RepositoryProvider::Manual => helper_envelope(
+            provider,
+            HelperOperation::PublishChangeRequest,
+            ProviderOperationStatus::ManualRequired,
+            "Create the provider change request manually, then rerun status detection.",
+            json!({
+                "change_request": null,
+                "manual_action": manual_publish_action(provider, source_branch, base_branch, title),
+                "capabilities": capabilities
+            }),
+        ),
+    }
+}
+
+fn publish_github_change_request(
+    capabilities: ProviderCapabilities,
+    source_branch: &str,
+    base_branch: &str,
+    title: &str,
+) -> HelperEnvelope {
+    let provider = RepositoryProvider::GitHub;
+    let list = match run_provider_command(
+        "gh",
+        &[
+            "pr",
+            "list",
+            "--head",
+            source_branch,
+            "--base",
+            base_branch,
+            "--state",
+            "open",
+            "--json",
+            "number,url,state,headRefName,baseRefName,headRefOid",
+            "--limit",
+            "1",
+        ],
+    ) {
+        Ok(output) if output.status.success() => output,
+        Ok(_) => {
+            return provider_command_failed(provider, capabilities, "GitHub PR lookup failed.");
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return provider_cli_missing(provider, capabilities, "gh");
+        }
+        Err(_) => {
+            return provider_command_failed(provider, capabilities, "GitHub PR lookup failed.");
+        }
+    };
+
+    if let Some(change_request) = parse_github_pr_list(&list.stdout) {
+        return HelperEnvelope::succeeded(
+            provider,
+            HelperOperation::PublishChangeRequest,
+            "Existing GitHub pull request found for this branch.",
+            json!({
+                "change_request": change_request,
+                "manual_action": null,
+                "capabilities": capabilities
+            }),
+        );
+    }
+
+    let body = format!("Workflow-generated pull request from {source_branch} to {base_branch}.");
+    let create = match run_provider_command(
+        "gh",
+        &[
+            "pr",
+            "create",
+            "--head",
+            source_branch,
+            "--base",
+            base_branch,
+            "--title",
+            title,
+            "--body",
+            &body,
+        ],
+    ) {
+        Ok(output) if output.status.success() => output,
+        Ok(_) => {
+            return provider_command_failed(provider, capabilities, "GitHub PR creation failed.");
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return provider_cli_missing(provider, capabilities, "gh");
+        }
+        Err(_) => {
+            return provider_command_failed(provider, capabilities, "GitHub PR creation failed.");
+        }
+    };
+    let url = String::from_utf8_lossy(&create.stdout).trim().to_string();
+    if url.is_empty() {
+        return provider_command_failed(
+            provider,
+            capabilities,
+            "GitHub PR creation returned no URL.",
+        );
+    }
+
+    let view = match run_provider_command(
+        "gh",
+        &[
+            "pr",
+            "view",
+            &url,
+            "--json",
+            "number,url,state,headRefName,baseRefName,headRefOid",
+        ],
+    ) {
+        Ok(output) if output.status.success() => output,
+        Ok(_) => {
+            return provider_command_failed(
+                provider,
+                capabilities,
+                "GitHub PR verification failed.",
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return provider_cli_missing(provider, capabilities, "gh");
+        }
+        Err(_) => {
+            return provider_command_failed(
+                provider,
+                capabilities,
+                "GitHub PR verification failed.",
+            );
+        }
+    };
+    let Some(change_request) = parse_github_pr(&view.stdout) else {
+        return provider_command_failed(
+            provider,
+            capabilities,
+            "GitHub PR verification returned malformed JSON.",
+        );
+    };
+
+    HelperEnvelope::succeeded(
+        provider,
+        HelperOperation::PublishChangeRequest,
+        "GitHub pull request created and verified.",
+        json!({
+            "change_request": change_request,
+            "manual_action": null,
+            "capabilities": capabilities
+        }),
+    )
+}
+
+fn publish_azdo_change_request(
+    capabilities: ProviderCapabilities,
+    source_branch: &str,
+    base_branch: &str,
+    title: &str,
+) -> HelperEnvelope {
+    let provider = RepositoryProvider::AzureDevOps;
+    let list = match run_provider_command(
+        "az",
+        &[
+            "repos",
+            "pr",
+            "list",
+            "--source-branch",
+            source_branch,
+            "--target-branch",
+            base_branch,
+            "--status",
+            "active",
+            "--output",
+            "json",
+        ],
+    ) {
+        Ok(output) if output.status.success() => output,
+        Ok(_) => {
+            return provider_command_failed(
+                provider,
+                capabilities,
+                "Azure Repos PR lookup failed.",
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return provider_cli_missing(provider, capabilities, "az");
+        }
+        Err(_) => {
+            return provider_command_failed(
+                provider,
+                capabilities,
+                "Azure Repos PR lookup failed.",
+            );
+        }
+    };
+
+    if let Some(change_request) = parse_azdo_pr_list(&list.stdout) {
+        return HelperEnvelope::succeeded(
+            provider,
+            HelperOperation::PublishChangeRequest,
+            "Existing Azure Repos pull request found for this branch.",
+            json!({
+                "change_request": change_request,
+                "manual_action": null,
+                "capabilities": capabilities
+            }),
+        );
+    }
+
+    let description = format!(
+        "Workflow-generated Azure Repos pull request from {source_branch} to {base_branch}."
+    );
+    let create = match run_provider_command(
+        "az",
+        &[
+            "repos",
+            "pr",
+            "create",
+            "--source-branch",
+            source_branch,
+            "--target-branch",
+            base_branch,
+            "--title",
+            title,
+            "--description",
+            &description,
+            "--output",
+            "json",
+        ],
+    ) {
+        Ok(output) if output.status.success() => output,
+        Ok(_) => {
+            return provider_command_failed(
+                provider,
+                capabilities,
+                "Azure Repos PR creation failed.",
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return provider_cli_missing(provider, capabilities, "az");
+        }
+        Err(_) => {
+            return provider_command_failed(
+                provider,
+                capabilities,
+                "Azure Repos PR creation failed.",
+            );
+        }
+    };
+    let Some(change_request) = parse_azdo_pr(&create.stdout) else {
+        return provider_command_failed(
+            provider,
+            capabilities,
+            "Azure Repos PR creation returned malformed JSON.",
+        );
+    };
+
+    HelperEnvelope::succeeded(
+        provider,
+        HelperOperation::PublishChangeRequest,
+        "Azure Repos pull request created and verified.",
+        json!({
+            "change_request": change_request,
+            "manual_action": null,
+            "capabilities": capabilities
+        }),
+    )
+}
+
+fn run_provider_command(binary: &str, args: &[&str]) -> std::io::Result<Output> {
+    Command::new(binary).args(args).output()
+}
+
+fn provider_cli_missing(
+    provider: RepositoryProvider,
+    capabilities: ProviderCapabilities,
+    binary: &str,
+) -> HelperEnvelope {
+    helper_envelope(
+        provider,
+        HelperOperation::PublishChangeRequest,
+        ProviderOperationStatus::BlockedManualProvider,
+        format!("Install and authenticate the provider CLI '{binary}', then rerun publication."),
+        json!({
+            "change_request": null,
+            "manual_action": null,
+            "capabilities": capabilities
+        }),
+    )
+}
+
+fn provider_command_failed(
+    provider: RepositoryProvider,
+    capabilities: ProviderCapabilities,
+    message: &str,
+) -> HelperEnvelope {
+    helper_envelope(
+        provider,
+        HelperOperation::PublishChangeRequest,
+        ProviderOperationStatus::Failed,
+        format!("{message} Inspect provider CLI authentication/output and rerun publication."),
+        json!({
+            "change_request": null,
+            "manual_action": null,
+            "capabilities": capabilities
+        }),
+    )
+}
+
+fn parse_github_pr_list(stdout: &[u8]) -> Option<ChangeRequest> {
+    let value: serde_json::Value = serde_json::from_slice(stdout).ok()?;
+    value.as_array()?.first().and_then(github_pr_from_value)
+}
+
+fn parse_github_pr(stdout: &[u8]) -> Option<ChangeRequest> {
+    let value: serde_json::Value = serde_json::from_slice(stdout).ok()?;
+    github_pr_from_value(&value)
+}
+
+fn github_pr_from_value(value: &serde_json::Value) -> Option<ChangeRequest> {
+    let id = value.get("number")?.as_i64()?.to_string();
+    let url = value.get("url")?.as_str()?.to_string();
+    Some(ChangeRequest {
+        kind: ChangeRequestKind::PullRequest,
+        id,
+        url,
+        state: github_pr_state(value.get("state").and_then(serde_json::Value::as_str)),
+        source_branch: value
+            .get("headRefName")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        base_branch: value
+            .get("baseRefName")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        head_sha: value
+            .get("headRefOid")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+    })
+}
+
+fn parse_azdo_pr_list(stdout: &[u8]) -> Option<ChangeRequest> {
+    let value: serde_json::Value = serde_json::from_slice(stdout).ok()?;
+    value.as_array()?.first().and_then(azdo_pr_from_value)
+}
+
+fn parse_azdo_pr(stdout: &[u8]) -> Option<ChangeRequest> {
+    let value: serde_json::Value = serde_json::from_slice(stdout).ok()?;
+    azdo_pr_from_value(&value)
+}
+
+fn azdo_pr_from_value(value: &serde_json::Value) -> Option<ChangeRequest> {
+    let id = value.get("pullRequestId")?.as_i64()?.to_string();
+    let url = value
+        .get("url")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    Some(ChangeRequest {
+        kind: ChangeRequestKind::PullRequest,
+        id,
+        url,
+        state: azdo_pr_state(value.get("status").and_then(serde_json::Value::as_str)),
+        source_branch: trim_refs_heads(
+            value
+                .get("sourceRefName")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default(),
+        ),
+        base_branch: trim_refs_heads(
+            value
+                .get("targetRefName")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default(),
+        ),
+        head_sha: value
+            .get("lastMergeSourceCommit")
+            .and_then(|commit| commit.get("commitId"))
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+    })
+}
+
+fn github_pr_state(state: Option<&str>) -> ChangeRequestStatus {
+    match state.unwrap_or_default().to_ascii_uppercase().as_str() {
+        "CLOSED" => ChangeRequestStatus::Closed,
+        "MERGED" => ChangeRequestStatus::Merged,
+        "DRAFT" => ChangeRequestStatus::Draft,
+        _ => ChangeRequestStatus::Open,
+    }
+}
+
+fn azdo_pr_state(state: Option<&str>) -> ChangeRequestStatus {
+    match state.unwrap_or_default().to_ascii_lowercase().as_str() {
+        "completed" => ChangeRequestStatus::Merged,
+        "abandoned" => ChangeRequestStatus::Closed,
+        _ => ChangeRequestStatus::Open,
+    }
+}
+
+fn trim_refs_heads(value: &str) -> String {
+    value
+        .strip_prefix("refs/heads/")
+        .unwrap_or(value)
+        .to_string()
 }
 
 fn helper_envelope(

--- a/crates/amplihack-cli/src/commands/workflow.rs
+++ b/crates/amplihack-cli/src/commands/workflow.rs
@@ -3,14 +3,18 @@ use amplihack_workflows::stale_cleanup::{
     CleanupAction, CleanupMode, CleanupPlan, CleanupPolicy, StaleChangeRequest,
 };
 use amplihack_workflows::workflow_contract::{
-    HelperEnvelope, HelperOperation, ManualAction, ProviderContext, ProviderOperationStatus,
-    RepositoryIdentity, RepositoryProvider, provider_capabilities, provider_default_next_action,
-    provider_from_remote_url, validate_terminal_transition,
+    HelperEnvelope, HelperOperation, ManualAction, ProviderCapabilityState, ProviderContext,
+    ProviderOperationStatus, RepositoryProvider, provider_capabilities,
+    provider_default_next_action, validate_terminal_transition,
 };
 use anyhow::{Context, Result};
 use clap::{ArgGroup, Args, Subcommand, ValueEnum};
 use serde_json::json;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+
+mod provider_detection;
+
+use provider_detection::detect_provider_from_repo;
 
 #[derive(Subcommand, Debug)]
 pub enum WorkflowCommands {
@@ -170,6 +174,22 @@ fn run_detect_provider(args: DetectProviderArgs) -> Result<()> {
 
 fn run_publish_change_request(args: PublishChangeRequestArgs) -> Result<()> {
     let provider = RepositoryProvider::from(args.provider);
+    let capabilities = provider_capabilities(provider);
+    if capabilities.change_requests == ProviderCapabilityState::Automated {
+        let envelope = helper_envelope(
+            provider,
+            HelperOperation::PublishChangeRequest,
+            ProviderOperationStatus::Failed,
+            "Use the workflow publish provider adapter; this typed CLI command does not create provider pull requests.",
+            json!({
+                "change_request": null,
+                "manual_action": null,
+                "capabilities": capabilities
+            }),
+        );
+        return write_output(&envelope, &args.format);
+    }
+
     let manual_action = manual_publish_action(
         provider,
         &args.source_branch,
@@ -270,44 +290,6 @@ fn run_terminal_state(args: TerminalStateArgs) -> Result<()> {
     write_output(&result, &args.format)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ProviderDetection {
-    provider: RepositoryProvider,
-    repository: RepositoryIdentity,
-    warnings: Vec<String>,
-}
-
-fn detect_provider_from_repo(repo: &Path) -> Result<ProviderDetection> {
-    let mut warnings = Vec::new();
-    let config = read_git_config(repo)?;
-    let remote_url = config.as_deref().and_then(origin_remote_url);
-    let provider = provider_from_remote_url(remote_url.as_deref());
-    if config.is_none() {
-        warnings.push("No Git config found; provider set to Manual.".into());
-    } else if remote_url.is_none() {
-        warnings.push("No origin remote URL found; provider set to Manual.".into());
-    } else if provider == RepositoryProvider::Manual {
-        warnings.push("Remote provider is unknown; provider set to Manual.".into());
-    }
-
-    let fallback_name = repo
-        .file_name()
-        .map(|name| name.to_string_lossy().into_owned())
-        .filter(|name| !name.trim().is_empty())
-        .unwrap_or_else(|| "repository".into());
-    let (owner, name) = repository_owner_name(remote_url.as_deref(), &fallback_name);
-    Ok(ProviderDetection {
-        provider,
-        repository: RepositoryIdentity {
-            remote_url,
-            owner,
-            name,
-            default_base: "main".into(),
-        },
-        warnings,
-    })
-}
-
 fn helper_envelope(
     provider: RepositoryProvider,
     operation: HelperOperation,
@@ -328,10 +310,10 @@ fn helper_envelope(
 
 fn provider_status(provider: RepositoryProvider) -> ProviderOperationStatus {
     match provider {
-        RepositoryProvider::GitHub => ProviderOperationStatus::Succeeded,
-        RepositoryProvider::AzureDevOps | RepositoryProvider::Manual => {
-            ProviderOperationStatus::ManualRequired
+        RepositoryProvider::GitHub | RepositoryProvider::AzureDevOps => {
+            ProviderOperationStatus::Succeeded
         }
+        RepositoryProvider::Manual => ProviderOperationStatus::ManualRequired,
     }
 }
 
@@ -367,137 +349,6 @@ fn manual_publish_action(
     }
 }
 
-fn read_git_config(repo: &Path) -> Result<Option<String>> {
-    let Some(path) = git_config_path(repo)? else {
-        return Ok(None);
-    };
-    std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read Git config from {}", path.display()))
-        .map(Some)
-}
-
-fn git_config_path(repo: &Path) -> Result<Option<PathBuf>> {
-    let dot_git = repo.join(".git");
-    if dot_git.is_dir() {
-        let config = dot_git.join("config");
-        return Ok(config.is_file().then_some(config));
-    }
-    if !dot_git.is_file() {
-        return Ok(None);
-    }
-
-    let marker = std::fs::read_to_string(&dot_git)
-        .with_context(|| format!("failed to read Git marker file {}", dot_git.display()))?;
-    let git_dir = marker
-        .trim()
-        .strip_prefix("gitdir:")
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .ok_or_else(|| anyhow::anyhow!("invalid Git marker file {}", dot_git.display()))?;
-    let git_dir = if git_dir.is_absolute() {
-        git_dir
-    } else {
-        repo.join(git_dir)
-    };
-
-    let worktree_config = git_dir.join("config");
-    if worktree_config.is_file() {
-        return Ok(Some(worktree_config));
-    }
-
-    let common_dir_file = git_dir.join("commondir");
-    if common_dir_file.is_file() {
-        let common_dir = std::fs::read_to_string(&common_dir_file).with_context(|| {
-            format!(
-                "failed to read Git common-dir marker {}",
-                common_dir_file.display()
-            )
-        })?;
-        let common_dir = PathBuf::from(common_dir.trim());
-        let common_dir = if common_dir.is_absolute() {
-            common_dir
-        } else {
-            git_dir.join(common_dir)
-        };
-        let common_config = common_dir.join("config");
-        if common_config.is_file() {
-            return Ok(Some(common_config));
-        }
-    }
-
-    Ok(None)
-}
-
-fn origin_remote_url(config: &str) -> Option<String> {
-    let mut in_origin = false;
-    let mut first_remote_url = None;
-    for line in config.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with('[') && trimmed.ends_with(']') {
-            in_origin = trimmed == r#"[remote "origin"]"#;
-            continue;
-        }
-        let Some(url) = trimmed.strip_prefix("url").and_then(|rest| {
-            rest.trim_start()
-                .strip_prefix('=')
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-        }) else {
-            continue;
-        };
-        if first_remote_url.is_none() {
-            first_remote_url = Some(url.to_string());
-        }
-        if in_origin {
-            return Some(url.to_string());
-        }
-    }
-    first_remote_url
-}
-
-fn repository_owner_name(remote_url: Option<&str>, fallback_name: &str) -> (String, String) {
-    let Some(remote_url) = remote_url else {
-        return ("unknown".into(), fallback_name.into());
-    };
-    if let Some(path) = remote_url
-        .split("github.com")
-        .nth(1)
-        .map(|value| value.trim_start_matches([':', '/']))
-    {
-        return owner_name_from_path(path, fallback_name);
-    }
-    if let Some(after_git) = remote_url.split("/_git/").nth(1) {
-        let name = trim_repo_suffix(after_git);
-        let owner = remote_url
-            .split("/_git/")
-            .next()
-            .and_then(|prefix| prefix.split("dev.azure.com/").nth(1))
-            .map(|path| path.trim_matches('/').to_string())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| "azure-devops".into());
-        return (owner, name);
-    }
-    ("unknown".into(), fallback_name.into())
-}
-
-fn owner_name_from_path(path: &str, fallback_name: &str) -> (String, String) {
-    let mut parts = path.trim_matches('/').split('/');
-    let owner = parts.next().filter(|value| !value.is_empty());
-    let name = parts.next().filter(|value| !value.is_empty());
-    match (owner, name) {
-        (Some(owner), Some(name)) => (owner.into(), trim_repo_suffix(name)),
-        _ => ("unknown".into(), fallback_name.into()),
-    }
-}
-
-fn trim_repo_suffix(name: &str) -> String {
-    name.trim_matches('/')
-        .trim_end_matches(".git")
-        .trim()
-        .to_string()
-}
-
 fn minimal_named_scenario(name: &str, recipe: &str, repo_fixture: Option<&PathBuf>) -> String {
     format!(
         r#"name: {name}
@@ -529,81 +380,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn detect_provider_without_git_config_returns_manual_with_warning() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let detection = detect_provider_from_repo(temp.path()).expect("detection should succeed");
-
-        assert_eq!(detection.provider, RepositoryProvider::Manual);
-        assert_eq!(
-            detection.repository.remote_url, None,
-            "unknown repositories must not synthesize a GitHub remote"
-        );
-        assert!(
-            detection
-                .warnings
-                .iter()
-                .any(|warning| warning.contains("provider set to Manual"))
-        );
-    }
-
-    #[test]
-    fn detect_provider_reads_common_config_for_git_worktree_marker() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let git_dir = temp.path().join("main.git").join("worktrees").join("repo");
-        let common_dir = temp.path().join("main.git");
-        std::fs::create_dir_all(&repo).expect("repo dir");
-        std::fs::create_dir_all(&git_dir).expect("git dir");
-        std::fs::write(
-            repo.join(".git"),
-            format!("gitdir: {}\n", git_dir.display()),
-        )
-        .expect("git marker");
-        std::fs::write(git_dir.join("commondir"), "../..\n").expect("commondir");
-        std::fs::write(
-            common_dir.join("config"),
-            r#"
-[remote "origin"]
-    url = https://dev.azure.com/acme/project/_git/service
-"#,
-        )
-        .expect("config");
-
-        let detection = detect_provider_from_repo(&repo).expect("detection should succeed");
-
-        assert_eq!(detection.provider, RepositoryProvider::AzureDevOps);
-        assert_eq!(detection.repository.owner, "acme/project");
-        assert_eq!(detection.repository.name, "service");
-        assert!(detection.warnings.is_empty());
-    }
-
-    #[test]
-    fn unknown_remote_returns_manual_not_github() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let git = repo.join(".git");
-        std::fs::create_dir_all(&git).expect("git dir");
-        std::fs::write(
-            git.join("config"),
-            r#"
-[remote "origin"]
-    url = ssh://git.example.invalid/acme/service
-"#,
-        )
-        .expect("config");
-
-        let detection = detect_provider_from_repo(&repo).expect("detection should succeed");
-
-        assert_eq!(detection.provider, RepositoryProvider::Manual);
-        assert!(
-            detection
-                .warnings
-                .iter()
-                .any(|warning| warning.contains("unknown"))
-        );
-    }
-
-    #[test]
     fn manual_publish_actions_are_provider_specific_without_fake_success() {
         let github = manual_publish_action(RepositoryProvider::GitHub, "feat/x", "main", "Ship x");
         assert_eq!(github.action, "CreateGitHubPullRequest");
@@ -619,6 +395,14 @@ mod tests {
         assert!(
             !manual.instructions.contains("GitHub") && !manual.instructions.contains("Azure"),
             "generic manual provider instructions must remain provider-neutral"
+        );
+    }
+
+    #[test]
+    fn azdo_provider_detection_status_is_automated_not_manual_required() {
+        assert_eq!(
+            provider_status(RepositoryProvider::AzureDevOps),
+            ProviderOperationStatus::Succeeded
         );
     }
 }

--- a/crates/amplihack-cli/src/commands/workflow.rs
+++ b/crates/amplihack-cli/src/commands/workflow.rs
@@ -152,7 +152,7 @@ fn run_detect_provider(args: DetectProviderArgs) -> Result<()> {
         schema_version: 1,
         provider,
         repository: repository.clone(),
-        capabilities: capabilities.clone(),
+        capabilities,
         status,
         next_action: provider_default_next_action(provider).into(),
     };

--- a/crates/amplihack-cli/src/commands/workflow/provider_detection.rs
+++ b/crates/amplihack-cli/src/commands/workflow/provider_detection.rs
@@ -1,0 +1,232 @@
+use amplihack_workflows::workflow_contract::{
+    RepositoryIdentity, RepositoryProvider, repository_identity_from_remote_url,
+};
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ProviderDetection {
+    pub(super) provider: RepositoryProvider,
+    pub(super) repository: RepositoryIdentity,
+    pub(super) warnings: Vec<String>,
+}
+
+pub(super) fn detect_provider_from_repo(repo: &Path) -> Result<ProviderDetection> {
+    let mut warnings = Vec::new();
+    let config = read_git_config(repo)?;
+    let remote_url = config.as_deref().and_then(origin_remote_url);
+    let fallback_name = repo
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| "repository".into());
+    let (provider, repository) =
+        repository_identity_from_remote_url(remote_url.as_deref(), &fallback_name);
+
+    if config.is_none() {
+        warnings.push("No Git config found; provider set to Manual.".into());
+    } else if remote_url.is_none() {
+        warnings.push("No origin remote URL found; provider set to Manual.".into());
+    } else if provider == RepositoryProvider::Manual {
+        warnings.push("Remote provider is unknown; provider set to Manual.".into());
+    }
+
+    Ok(ProviderDetection {
+        provider,
+        repository,
+        warnings,
+    })
+}
+
+fn read_git_config(repo: &Path) -> Result<Option<String>> {
+    let Some(path) = git_config_path(repo)? else {
+        return Ok(None);
+    };
+    std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read Git config from {}", path.display()))
+        .map(Some)
+}
+
+fn git_config_path(repo: &Path) -> Result<Option<PathBuf>> {
+    let dot_git = repo.join(".git");
+    if dot_git.is_dir() {
+        let config = dot_git.join("config");
+        return Ok(config.is_file().then_some(config));
+    }
+    if !dot_git.is_file() {
+        return Ok(None);
+    }
+
+    let marker = std::fs::read_to_string(&dot_git)
+        .with_context(|| format!("failed to read Git marker file {}", dot_git.display()))?;
+    let git_dir = marker
+        .trim()
+        .strip_prefix("gitdir:")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("invalid Git marker file {}", dot_git.display()))?;
+    let git_dir = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        repo.join(git_dir)
+    };
+
+    let worktree_config = git_dir.join("config");
+    if worktree_config.is_file() {
+        return Ok(Some(worktree_config));
+    }
+
+    let common_dir_file = git_dir.join("commondir");
+    if common_dir_file.is_file() {
+        let common_dir = std::fs::read_to_string(&common_dir_file).with_context(|| {
+            format!(
+                "failed to read Git common-dir marker {}",
+                common_dir_file.display()
+            )
+        })?;
+        let common_dir = PathBuf::from(common_dir.trim());
+        let common_dir = if common_dir.is_absolute() {
+            common_dir
+        } else {
+            git_dir.join(common_dir)
+        };
+        let common_config = common_dir.join("config");
+        if common_config.is_file() {
+            return Ok(Some(common_config));
+        }
+    }
+
+    Ok(None)
+}
+
+fn origin_remote_url(config: &str) -> Option<String> {
+    let mut in_origin = false;
+    let mut first_remote_url = None;
+    for line in config.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_origin = trimmed == r#"[remote "origin"]"#;
+            continue;
+        }
+        let Some(url) = trimmed.strip_prefix("url").and_then(|rest| {
+            rest.trim_start()
+                .strip_prefix('=')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        }) else {
+            continue;
+        };
+        if first_remote_url.is_none() {
+            first_remote_url = Some(url.to_string());
+        }
+        if in_origin {
+            return Some(url.to_string());
+        }
+    }
+    first_remote_url
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_provider_without_git_config_returns_manual_with_warning() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let detection = detect_provider_from_repo(temp.path()).expect("detection should succeed");
+
+        assert_eq!(detection.provider, RepositoryProvider::Manual);
+        assert_eq!(
+            detection.repository.remote_url, None,
+            "unknown repositories must not synthesize a GitHub remote"
+        );
+        assert!(
+            detection
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("provider set to Manual"))
+        );
+    }
+
+    #[test]
+    fn detect_provider_reads_common_config_for_git_worktree_marker() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let git_dir = temp.path().join("main.git").join("worktrees").join("repo");
+        let common_dir = temp.path().join("main.git");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+        std::fs::create_dir_all(&git_dir).expect("git dir");
+        std::fs::write(
+            repo.join(".git"),
+            format!("gitdir: {}\n", git_dir.display()),
+        )
+        .expect("git marker");
+        std::fs::write(git_dir.join("commondir"), "../..\n").expect("commondir");
+        std::fs::write(
+            common_dir.join("config"),
+            r#"
+[remote "origin"]
+    url = https://dev.azure.com/acme/project/_git/service
+"#,
+        )
+        .expect("config");
+
+        let detection = detect_provider_from_repo(&repo).expect("detection should succeed");
+
+        assert_eq!(detection.provider, RepositoryProvider::AzureDevOps);
+        assert_eq!(detection.repository.owner, "acme/project");
+        assert_eq!(detection.repository.name, "service");
+        assert!(detection.warnings.is_empty());
+    }
+
+    #[test]
+    fn unknown_remote_returns_manual_not_github() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let git = repo.join(".git");
+        std::fs::create_dir_all(&git).expect("git dir");
+        std::fs::write(
+            git.join("config"),
+            r#"
+[remote "origin"]
+    url = ssh://git.example.invalid/acme/service
+"#,
+        )
+        .expect("config");
+
+        let detection = detect_provider_from_repo(&repo).expect("detection should succeed");
+
+        assert_eq!(detection.provider, RepositoryProvider::Manual);
+        assert!(
+            detection
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("unknown"))
+        );
+    }
+
+    #[test]
+    fn detect_provider_redacts_credential_bearing_remote_urls() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let git = repo.join(".git");
+        std::fs::create_dir_all(&git).expect("git dir");
+        std::fs::write(
+            git.join("config"),
+            r#"
+[remote "origin"]
+    url = https://user:ghp_secret_token@github.com/acme/service.git
+"#,
+        )
+        .expect("config");
+
+        let detection = detect_provider_from_repo(&repo).expect("detection should succeed");
+
+        assert_eq!(detection.provider, RepositoryProvider::GitHub);
+        assert_eq!(
+            detection.repository.remote_url.as_deref(),
+            Some("https://[redacted]@github.com/acme/service.git")
+        );
+    }
+}

--- a/crates/amplihack-cli/src/commands/workflow/provider_detection.rs
+++ b/crates/amplihack-cli/src/commands/workflow/provider_detection.rs
@@ -20,8 +20,7 @@ pub(super) fn detect_provider_from_repo(repo: &Path) -> Result<ProviderDetection
         .map(|name| name.to_string_lossy().into_owned())
         .filter(|name| !name.trim().is_empty())
         .unwrap_or_else(|| "repository".into());
-    let (provider, repository) =
-        repository_identity_from_remote_url(remote_url.as_deref(), &fallback_name);
+    let (provider, repository) = repository_identity_from_remote_url(remote_url, &fallback_name);
 
     if config.is_none() {
         warnings.push("No Git config found; provider set to Manual.".into());
@@ -100,7 +99,7 @@ fn git_config_path(repo: &Path) -> Result<Option<PathBuf>> {
     Ok(None)
 }
 
-fn origin_remote_url(config: &str) -> Option<String> {
+fn origin_remote_url(config: &str) -> Option<&str> {
     let mut in_origin = false;
     let mut first_remote_url = None;
     for line in config.lines() {
@@ -118,10 +117,10 @@ fn origin_remote_url(config: &str) -> Option<String> {
             continue;
         };
         if first_remote_url.is_none() {
-            first_remote_url = Some(url.to_string());
+            first_remote_url = Some(url);
         }
         if in_origin {
-            return Some(url.to_string());
+            return Some(url);
         }
     }
     first_remote_url

--- a/crates/amplihack-cli/src/lib.rs
+++ b/crates/amplihack-cli/src/lib.rs
@@ -15,6 +15,8 @@ pub mod auto_stager;
 pub mod auto_update;
 pub mod binary_finder;
 pub mod bootstrap;
+#[cfg(test)]
+mod ci_resource_discipline_tests;
 pub mod claude_plugin;
 mod cli_commands;
 pub mod cli_extensions;

--- a/crates/amplihack-workflows/src/agent_contract.rs
+++ b/crates/amplihack-workflows/src/agent_contract.rs
@@ -1,4 +1,4 @@
-use crate::workflow_contract::{TerminalState, validate_terminal_transition};
+use crate::workflow_contract::{TerminalState, validate_terminal_transition_ref};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -49,7 +49,7 @@ impl AgentContractError {
 }
 
 pub fn validate_finalizer_output(value: Value) -> Result<AgentFinalizerOutput, AgentContractError> {
-    let output: AgentFinalizerOutput = serde_json::from_value(value.clone())
+    let output = AgentFinalizerOutput::deserialize(&value)
         .map_err(|_| AgentContractError::MissingOrInvalidJson)?;
 
     if output.terminal_success && output.confidence != FinalizerConfidence::High {
@@ -59,7 +59,7 @@ pub fn validate_finalizer_output(value: Value) -> Result<AgentFinalizerOutput, A
         return Err(AgentContractError::FailedInvalidEvidence);
     }
 
-    let transition = validate_terminal_transition(value);
+    let transition = validate_terminal_transition_ref(&value);
     if transition.terminal_state == TerminalState::FailedInvalidEvidence {
         return Err(AgentContractError::FailedInvalidEvidence);
     }

--- a/crates/amplihack-workflows/src/agent_contract.rs
+++ b/crates/amplihack-workflows/src/agent_contract.rs
@@ -1,0 +1,71 @@
+use crate::workflow_contract::{TerminalState, validate_terminal_transition};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FinalizerConfidence {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentFinalizerOutput {
+    pub schema_version: u32,
+    pub terminal_state: TerminalState,
+    pub terminal_success: bool,
+    pub confidence: FinalizerConfidence,
+    pub reason: String,
+    pub required_next_action: String,
+    pub hollow_success_detected: bool,
+    pub evidence_used: Vec<String>,
+}
+
+impl AgentFinalizerOutput {
+    pub fn from_agent_text(text: &str) -> Result<Self, AgentContractError> {
+        let value: Value =
+            serde_json::from_str(text).map_err(|_| AgentContractError::MissingOrInvalidJson)?;
+        validate_finalizer_output(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentContractError {
+    MissingOrInvalidJson,
+    SuccessRequiresHighConfidence,
+    FailedInvalidEvidence,
+}
+
+impl AgentContractError {
+    pub fn terminal_state(&self) -> TerminalState {
+        match self {
+            Self::MissingOrInvalidJson => TerminalState::FailedFinalizerOutput,
+            Self::SuccessRequiresHighConfidence | Self::FailedInvalidEvidence => {
+                TerminalState::FailedInvalidEvidence
+            }
+        }
+    }
+}
+
+pub fn validate_finalizer_output(value: Value) -> Result<AgentFinalizerOutput, AgentContractError> {
+    let output: AgentFinalizerOutput = serde_json::from_value(value.clone())
+        .map_err(|_| AgentContractError::MissingOrInvalidJson)?;
+
+    if output.terminal_success && output.confidence != FinalizerConfidence::High {
+        return Err(AgentContractError::SuccessRequiresHighConfidence);
+    }
+    if output.hollow_success_detected && output.terminal_success {
+        return Err(AgentContractError::FailedInvalidEvidence);
+    }
+
+    let transition = validate_terminal_transition(value);
+    if transition.terminal_state == TerminalState::FailedInvalidEvidence {
+        return Err(AgentContractError::FailedInvalidEvidence);
+    }
+    if output.terminal_success != output.terminal_state.is_success() {
+        return Err(AgentContractError::FailedInvalidEvidence);
+    }
+
+    Ok(output)
+}

--- a/crates/amplihack-workflows/src/agent_contract.rs
+++ b/crates/amplihack-workflows/src/agent_contract.rs
@@ -49,7 +49,13 @@ impl AgentContractError {
 }
 
 pub fn validate_finalizer_output(value: Value) -> Result<AgentFinalizerOutput, AgentContractError> {
-    let output = AgentFinalizerOutput::deserialize(&value)
+    validate_finalizer_output_ref(&value)
+}
+
+pub fn validate_finalizer_output_ref(
+    value: &Value,
+) -> Result<AgentFinalizerOutput, AgentContractError> {
+    let output = AgentFinalizerOutput::deserialize(value)
         .map_err(|_| AgentContractError::MissingOrInvalidJson)?;
 
     if output.terminal_success && output.confidence != FinalizerConfidence::High {
@@ -59,7 +65,7 @@ pub fn validate_finalizer_output(value: Value) -> Result<AgentFinalizerOutput, A
         return Err(AgentContractError::FailedInvalidEvidence);
     }
 
-    let transition = validate_terminal_transition_ref(&value);
+    let transition = validate_terminal_transition_ref(value);
     if transition.terminal_state == TerminalState::FailedInvalidEvidence {
         return Err(AgentContractError::FailedInvalidEvidence);
     }

--- a/crates/amplihack-workflows/src/agent_contract.rs
+++ b/crates/amplihack-workflows/src/agent_contract.rs
@@ -1,4 +1,6 @@
-use crate::workflow_contract::{TerminalState, validate_terminal_transition_ref};
+use crate::workflow_contract::{
+    ProviderCapabilities, RepositoryProvider, TerminalState, validate_terminal_transition_ref,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -13,6 +15,8 @@ pub enum FinalizerConfidence {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentFinalizerOutput {
     pub schema_version: u32,
+    pub provider: RepositoryProvider,
+    pub capabilities: ProviderCapabilities,
     pub terminal_state: TerminalState,
     pub terminal_success: bool,
     pub confidence: FinalizerConfidence,

--- a/crates/amplihack-workflows/src/lib.rs
+++ b/crates/amplihack-workflows/src/lib.rs
@@ -15,6 +15,7 @@ pub mod classifier;
 pub mod gh_aw_compiler;
 pub mod orchestrator;
 pub mod provenance;
+pub mod remote_repository;
 pub mod session;
 pub mod simulation;
 pub mod stale_cleanup;

--- a/crates/amplihack-workflows/src/lib.rs
+++ b/crates/amplihack-workflows/src/lib.rs
@@ -9,12 +9,16 @@
 //! - [`session`] — Session start detection for triggering classification
 //! - [`orchestrator`] — Integrates classifier, cascade, and session detection
 
+pub mod agent_contract;
 pub mod cascade;
 pub mod classifier;
 pub mod gh_aw_compiler;
 pub mod orchestrator;
 pub mod provenance;
 pub mod session;
+pub mod simulation;
+pub mod stale_cleanup;
+pub mod workflow_contract;
 
 pub use cascade::ExecutionTierCascade;
 pub use classifier::{WorkflowClassifier, WorkflowType};

--- a/crates/amplihack-workflows/src/provenance.rs
+++ b/crates/amplihack-workflows/src/provenance.rs
@@ -60,6 +60,11 @@ impl ProvenanceEntry {
 }
 
 fn shared_runtime_root(_base_dir: &Path) -> PathBuf {
+    if let Ok(root) = std::env::var("AMPLIHACK_WORKFLOW_RUNTIME_DIR")
+        && !root.trim().is_empty()
+    {
+        return PathBuf::from(root);
+    }
     if let Ok(root) = std::env::var("AMPLIHACK_RUNTIME_ROOT")
         && !root.trim().is_empty()
     {

--- a/crates/amplihack-workflows/src/provenance.rs
+++ b/crates/amplihack-workflows/src/provenance.rs
@@ -10,10 +10,12 @@ use std::fs::{self, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use tracing::warn;
 
 /// Maximum characters of the user prompt to include in the log entry.
 const PROMPT_PREVIEW_MAX_CHARS: usize = 200;
+static PROVENANCE_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 /// A structured provenance log entry written as one JSON line.
 #[derive(Debug, Clone, Serialize)]
@@ -120,6 +122,9 @@ fn try_log_provenance(
     let mut line = serde_json::to_string(entry)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     line.push('\n');
+    let _guard = PROVENANCE_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let mut file = OpenOptions::new().create(true).append(true).open(path)?;
     file.write_all(line.as_bytes())
 }
@@ -187,14 +192,12 @@ mod tests {
     fn appends_multiple_entries() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = expected_log_path(dir.path(), CLASSIFIER_LOG_SUBDIR, CLASSIFIER_LOG_FILE);
-        let initial_lines = fs::read_to_string(&log_path)
-            .map(|content| content.lines().count())
-            .unwrap_or(0);
+        let token = format!("append-test-{}", std::process::id());
         for i in 0..3 {
             let entry = ProvenanceEntry::new(
                 "classification",
                 "DEFAULT_WORKFLOW",
-                format!("reason {i}"),
+                format!("{token}-reason-{i}"),
                 0.7 + (i as f64) * 0.1,
                 vec![],
                 &format!("request {i}"),
@@ -204,13 +207,14 @@ mod tests {
 
         let content = fs::read_to_string(&log_path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
-        assert_eq!(
-            lines.len(),
-            initial_lines + 3,
-            "should append 3 JSONL lines"
-        );
+        let matching_lines = lines
+            .iter()
+            .copied()
+            .filter(|line| line.contains(&token))
+            .collect::<Vec<_>>();
+        assert_eq!(matching_lines.len(), 3, "should append 3 JSONL lines");
 
-        for line in &lines[initial_lines..] {
+        for line in matching_lines {
             let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
             assert!(parsed.get("timestamp").is_some());
             assert!(parsed.get("event").is_some());

--- a/crates/amplihack-workflows/src/remote_repository.rs
+++ b/crates/amplihack-workflows/src/remote_repository.rs
@@ -1,11 +1,11 @@
 use crate::workflow_contract::{RepositoryIdentity, RepositoryProvider};
 
 pub fn provider_from_remote_url(remote_url: Option<&str>) -> RepositoryProvider {
-    let Some(remote_url) = remote_url else {
-        return RepositoryProvider::Manual;
-    };
+    provider_from_remote_parts(remote_url.and_then(remote_url_parts))
+}
 
-    match remote_url_parts(remote_url).map(|parts| parts.host) {
+fn provider_from_remote_parts(parts: Option<RemoteUrlParts<'_>>) -> RepositoryProvider {
+    match parts.map(|parts| parts.host) {
         Some(host)
             if host_matches_provider_domain(host, "dev.azure.com")
                 || host_matches_provider_domain(host, "visualstudio.com") =>
@@ -23,8 +23,9 @@ pub fn repository_identity_from_remote_url(
     remote_url: Option<&str>,
     fallback_name: &str,
 ) -> (RepositoryProvider, RepositoryIdentity) {
-    let provider = provider_from_remote_url(remote_url);
-    let (owner, name) = repository_owner_name(provider, remote_url, fallback_name);
+    let parts = remote_url.and_then(remote_url_parts);
+    let provider = provider_from_remote_parts(parts);
+    let (owner, name) = repository_owner_name(provider, parts, fallback_name);
     (
         provider,
         RepositoryIdentity {
@@ -118,10 +119,10 @@ fn host_matches_provider_domain(host: &str, provider_domain: &str) -> bool {
 
 fn repository_owner_name(
     provider: RepositoryProvider,
-    remote_url: Option<&str>,
+    parts: Option<RemoteUrlParts<'_>>,
     fallback_name: &str,
 ) -> (String, String) {
-    let Some(parts) = remote_url.and_then(remote_url_parts) else {
+    let Some(parts) = parts else {
         return ("unknown".into(), fallback_name.into());
     };
 

--- a/crates/amplihack-workflows/src/remote_repository.rs
+++ b/crates/amplihack-workflows/src/remote_repository.rs
@@ -1,0 +1,179 @@
+use crate::workflow_contract::{RepositoryIdentity, RepositoryProvider};
+
+pub fn provider_from_remote_url(remote_url: Option<&str>) -> RepositoryProvider {
+    let Some(remote_url) = remote_url else {
+        return RepositoryProvider::Manual;
+    };
+
+    match remote_url_parts(remote_url).map(|parts| parts.host) {
+        Some(host)
+            if host_matches_provider_domain(host, "dev.azure.com")
+                || host_matches_provider_domain(host, "visualstudio.com") =>
+        {
+            RepositoryProvider::AzureDevOps
+        }
+        Some(host) if host_matches_provider_domain(host, "github.com") => {
+            RepositoryProvider::GitHub
+        }
+        _ => RepositoryProvider::Manual,
+    }
+}
+
+pub fn repository_identity_from_remote_url(
+    remote_url: Option<&str>,
+    fallback_name: &str,
+) -> (RepositoryProvider, RepositoryIdentity) {
+    let provider = provider_from_remote_url(remote_url);
+    let (owner, name) = repository_owner_name(provider, remote_url, fallback_name);
+    (
+        provider,
+        RepositoryIdentity {
+            remote_url: remote_url.map(redact_remote_url),
+            owner,
+            name,
+            default_base: "main".into(),
+        },
+    )
+}
+
+pub fn redact_remote_url(remote_url: &str) -> String {
+    let Some((scheme, after_scheme)) = remote_url.split_once("://") else {
+        return remote_url.to_string();
+    };
+    let authority_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    let (authority, rest) = after_scheme.split_at(authority_end);
+    let Some((_, host)) = authority.rsplit_once('@') else {
+        return remote_url.to_string();
+    };
+
+    format!("{scheme}://[redacted]@{host}{rest}")
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RemoteUrlParts<'a> {
+    host: &'a str,
+    path: &'a str,
+}
+
+fn remote_url_parts(remote_url: &str) -> Option<RemoteUrlParts<'_>> {
+    let trimmed = remote_url.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(after_scheme) = trimmed.split_once("://").map(|(_, rest)| rest) {
+        let authority_end = after_scheme
+            .find(['/', '?', '#'])
+            .unwrap_or(after_scheme.len());
+        let (authority, path) = after_scheme.split_at(authority_end);
+        let authority = authority
+            .split(['/', '?', '#'])
+            .next()
+            .filter(|value| !value.is_empty())?;
+        let host_port = authority
+            .rsplit_once('@')
+            .map_or(authority, |(_, host)| host);
+        let host = host_port
+            .strip_prefix('[')
+            .and_then(|value| value.split_once(']').map(|(host, _)| host))
+            .unwrap_or_else(|| {
+                host_port
+                    .split_once(':')
+                    .map_or(host_port, |(host, _)| host)
+            });
+        return (!host.is_empty()).then_some(RemoteUrlParts {
+            host,
+            path: path.trim_start_matches('/'),
+        });
+    }
+
+    trimmed
+        .split_once(':')
+        .map(|(host_part, path)| RemoteUrlParts {
+            host: host_part
+                .rsplit_once('@')
+                .map_or(host_part, |(_, host)| host),
+            path,
+        })
+        .filter(|parts| !parts.host.is_empty())
+}
+
+fn host_matches_provider_domain(host: &str, provider_domain: &str) -> bool {
+    let host = host.strip_suffix('.').unwrap_or(host);
+    let host = host.as_bytes();
+    let provider_domain = provider_domain.as_bytes();
+    if host.len() < provider_domain.len() {
+        return false;
+    }
+
+    let domain_start = host.len() - provider_domain.len();
+    if !host[domain_start..].eq_ignore_ascii_case(provider_domain) {
+        return false;
+    }
+
+    domain_start == 0 || host[domain_start - 1] == b'.'
+}
+
+fn repository_owner_name(
+    provider: RepositoryProvider,
+    remote_url: Option<&str>,
+    fallback_name: &str,
+) -> (String, String) {
+    let Some(parts) = remote_url.and_then(remote_url_parts) else {
+        return ("unknown".into(), fallback_name.into());
+    };
+
+    match provider {
+        RepositoryProvider::GitHub => owner_name_from_path(parts.path, fallback_name),
+        RepositoryProvider::AzureDevOps => azure_owner_name_from_path(parts.path, fallback_name),
+        RepositoryProvider::Manual => ("unknown".into(), fallback_name.into()),
+    }
+}
+
+fn owner_name_from_path(path: &str, fallback_name: &str) -> (String, String) {
+    let mut parts = path.trim_matches('/').split('/');
+    let owner = parts.next().filter(|value| !value.is_empty());
+    let name = parts.next().filter(|value| !value.is_empty());
+    match (owner, name) {
+        (Some(owner), Some(name)) => (owner.into(), trim_repo_suffix(name)),
+        _ => ("unknown".into(), fallback_name.into()),
+    }
+}
+
+fn azure_owner_name_from_path(path: &str, fallback_name: &str) -> (String, String) {
+    let path = path.trim_matches('/');
+    if let Some((owner_path, name)) = path.split_once("/_git/") {
+        let owner = owner_path.trim_matches('/');
+        return if owner.is_empty() || name.trim().is_empty() {
+            ("unknown".into(), fallback_name.into())
+        } else {
+            (owner.into(), trim_repo_suffix(name))
+        };
+    }
+
+    let mut parts = path.split('/').filter(|value| !value.is_empty());
+    if matches!(parts.clone().next(), Some("v3")) {
+        parts.next();
+    }
+    let org = parts.next();
+    let project = parts.next();
+    let name = parts.next();
+    match (org, project, name) {
+        (Some(org), Some(project), Some(name)) => {
+            (format!("{org}/{project}"), trim_repo_suffix(name))
+        }
+        _ => ("unknown".into(), fallback_name.into()),
+    }
+}
+
+fn trim_repo_suffix(name: &str) -> String {
+    name.trim_matches('/')
+        .split(['?', '#'])
+        .next()
+        .unwrap_or("")
+        .trim_end_matches(".git")
+        .trim()
+        .to_string()
+}

--- a/crates/amplihack-workflows/src/simulation.rs
+++ b/crates/amplihack-workflows/src/simulation.rs
@@ -1,0 +1,204 @@
+use crate::agent_contract::{AgentFinalizerOutput, validate_finalizer_output};
+use crate::workflow_contract::{
+    ProviderCapabilities, ProviderCapabilityState, RepositoryProvider, TerminalState,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForbiddenCall(pub String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum SimulationStatus {
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SimulationAssertion {
+    TerminalStateMatched,
+    TerminalSuccessMatched,
+    ForbiddenCallsAbsent,
+    AgentContractFailed(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimulationAssertions {
+    pub failed: usize,
+    pub items: Vec<SimulationAssertion>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SimulationResult {
+    pub provider: RepositoryProvider,
+    pub status: SimulationStatus,
+    pub terminal_state: TerminalState,
+    pub terminal_success: bool,
+    pub provider_calls: Vec<String>,
+    pub assertions: SimulationAssertions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimulationError {
+    pub forbidden_call: Option<ForbiddenCall>,
+    pub message: String,
+}
+
+impl std::fmt::Display for SimulationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SimulationError {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecipeSimulationScenario {
+    pub name: String,
+    pub recipe: String,
+    pub repo_fixture: Option<String>,
+    pub provider: SimulatedProvider,
+    #[serde(default)]
+    pub tools: Value,
+    #[serde(default)]
+    pub agents: SimulatedAgents,
+    #[serde(default)]
+    pub observed_calls: Vec<String>,
+    pub expect: SimulationExpect,
+}
+
+impl RecipeSimulationScenario {
+    pub fn from_json(value: Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value(value)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimulatedProvider {
+    pub kind: RepositoryProvider,
+    pub capabilities: ProviderCapabilities,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SimulatedAgents {
+    pub finalizer: Option<SimulatedAgent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimulatedAgent {
+    pub output: Option<Value>,
+    pub output_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SimulationExpect {
+    pub terminal_state: Option<TerminalState>,
+    pub terminal_success: Option<bool>,
+    #[serde(default)]
+    pub forbidden_calls: Vec<String>,
+}
+
+pub struct RecipeSimulation;
+
+impl RecipeSimulation {
+    pub fn run(scenario: RecipeSimulationScenario) -> Result<SimulationResult, SimulationError> {
+        let mut provider_calls = provider_calls_for(&scenario);
+        provider_calls.extend(scenario.observed_calls.iter().cloned());
+        for forbidden in &scenario.expect.forbidden_calls {
+            if provider_calls.iter().any(|call| call == forbidden) {
+                return Err(SimulationError {
+                    forbidden_call: Some(ForbiddenCall(forbidden.clone())),
+                    message: format!("forbidden provider call observed: {forbidden}"),
+                });
+            }
+        }
+
+        let mut assertions = Vec::new();
+        let finalizer = validate_simulated_finalizer(&scenario.agents);
+        let (terminal_state, terminal_success) = match finalizer {
+            Ok(Some(output)) => (output.terminal_state, output.terminal_success),
+            Ok(None) => (
+                scenario
+                    .expect
+                    .terminal_state
+                    .unwrap_or(TerminalState::ManualRequired),
+                scenario.expect.terminal_success.unwrap_or(false),
+            ),
+            Err(agent_name) => {
+                assertions.push(SimulationAssertion::AgentContractFailed(agent_name));
+                (TerminalState::FailedFinalizerOutput, false)
+            }
+        };
+
+        let mut failed = 0;
+        if scenario.expect.terminal_state == Some(terminal_state) {
+            assertions.push(SimulationAssertion::TerminalStateMatched);
+        } else if scenario.expect.terminal_state.is_some() {
+            failed += 1;
+        }
+        if scenario.expect.terminal_success == Some(terminal_success) {
+            assertions.push(SimulationAssertion::TerminalSuccessMatched);
+        } else if scenario.expect.terminal_success.is_some() {
+            failed += 1;
+        }
+        assertions.push(SimulationAssertion::ForbiddenCallsAbsent);
+
+        Ok(SimulationResult {
+            provider: scenario.provider.kind,
+            status: SimulationStatus::Succeeded,
+            terminal_state,
+            terminal_success,
+            provider_calls,
+            assertions: SimulationAssertions {
+                failed,
+                items: assertions,
+            },
+        })
+    }
+}
+
+fn provider_calls_for(scenario: &RecipeSimulationScenario) -> Vec<String> {
+    let mut calls = Vec::new();
+    match scenario.provider.kind {
+        RepositoryProvider::GitHub => {
+            if scenario.provider.capabilities.tracking_items == ProviderCapabilityState::Automated {
+                calls.push("gh.issue.create".into());
+            }
+            if scenario.provider.capabilities.change_requests == ProviderCapabilityState::Automated
+            {
+                calls.push("gh.pr.create".into());
+            }
+        }
+        RepositoryProvider::AzureDevOps => {
+            if scenario.provider.capabilities.tracking_items == ProviderCapabilityState::Automated {
+                calls.push("az.boards.work-item.create".into());
+            }
+            if scenario.provider.capabilities.change_requests == ProviderCapabilityState::Automated
+            {
+                calls.push("az.repos.pr.create".into());
+            }
+        }
+        RepositoryProvider::Manual => {}
+    }
+    calls
+}
+
+fn validate_simulated_finalizer(
+    agents: &SimulatedAgents,
+) -> Result<Option<AgentFinalizerOutput>, String> {
+    let Some(finalizer) = &agents.finalizer else {
+        return Ok(None);
+    };
+    if let Some(output) = &finalizer.output {
+        return validate_finalizer_output(output.clone())
+            .map(Some)
+            .map_err(|_| "finalizer".into());
+    }
+    if let Some(text) = &finalizer.output_text {
+        return AgentFinalizerOutput::from_agent_text(text)
+            .map(Some)
+            .map_err(|_| "finalizer".into());
+    }
+    Ok(None)
+}

--- a/crates/amplihack-workflows/src/simulation.rs
+++ b/crates/amplihack-workflows/src/simulation.rs
@@ -1,4 +1,4 @@
-use crate::agent_contract::{AgentFinalizerOutput, validate_finalizer_output};
+use crate::agent_contract::{AgentFinalizerOutput, validate_finalizer_output_ref};
 use crate::workflow_contract::{
     ProviderCapabilities, ProviderCapabilityState, RepositoryProvider, TerminalState,
 };
@@ -191,7 +191,7 @@ fn validate_simulated_finalizer(
         return Ok(None);
     };
     if let Some(output) = &finalizer.output {
-        return validate_finalizer_output(output.clone())
+        return validate_finalizer_output_ref(output)
             .map(Some)
             .map_err(|_| "finalizer".into());
     }

--- a/crates/amplihack-workflows/src/stale_cleanup.rs
+++ b/crates/amplihack-workflows/src/stale_cleanup.rs
@@ -1,0 +1,120 @@
+use crate::workflow_contract::{ChangeRequestKind, ChangeRequestStatus, RepositoryProvider};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum CleanupMode {
+    DryRun,
+    Apply,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CleanupPolicy {
+    pub provider: RepositoryProvider,
+    pub mode: CleanupMode,
+    pub workflow_label: String,
+    pub superseded_by_label_prefix: String,
+    pub minimum_age_hours: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StaleChangeRequest {
+    pub kind: ChangeRequestKind,
+    pub id: String,
+    pub title: String,
+    pub state: ChangeRequestStatus,
+    pub labels: Vec<String>,
+    pub age_hours: u64,
+    pub has_unmerged_meaningful_diff: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum CleanupAction {
+    WouldCloseAsSuperseded,
+    CloseAsSuperseded,
+    Skip,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CleanupPlanAction {
+    pub change_request_id: String,
+    pub action: CleanupAction,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CleanupPlan {
+    pub provider: RepositoryProvider,
+    pub mode: CleanupMode,
+    pub actions: Vec<CleanupPlanAction>,
+    pub mutations_executed: usize,
+}
+
+impl CleanupPlan {
+    pub fn build(
+        policy: CleanupPolicy,
+        candidates: Vec<StaleChangeRequest>,
+    ) -> Result<Self, String> {
+        if policy.workflow_label.trim().is_empty() {
+            return Err("workflow_label is required".into());
+        }
+        if policy.superseded_by_label_prefix.trim().is_empty() {
+            return Err("superseded_by_label_prefix is required".into());
+        }
+
+        let mut mutations_executed = 0;
+        let actions = candidates
+            .into_iter()
+            .map(|candidate| {
+                let eligible = candidate.state == ChangeRequestStatus::Open
+                    && candidate.age_hours >= policy.minimum_age_hours
+                    && !candidate.has_unmerged_meaningful_diff
+                    && candidate
+                        .labels
+                        .iter()
+                        .any(|label| label == &policy.workflow_label)
+                    && candidate
+                        .labels
+                        .iter()
+                        .any(|label| label.starts_with(&policy.superseded_by_label_prefix));
+
+                let action = if eligible {
+                    match policy.mode {
+                        CleanupMode::DryRun => CleanupAction::WouldCloseAsSuperseded,
+                        CleanupMode::Apply => {
+                            mutations_executed += 1;
+                            CleanupAction::CloseAsSuperseded
+                        }
+                    }
+                } else {
+                    CleanupAction::Skip
+                };
+
+                CleanupPlanAction {
+                    change_request_id: candidate.id,
+                    action,
+                    reason: match action {
+                        CleanupAction::WouldCloseAsSuperseded => {
+                            "dry-run: workflow-owned superseded change request is eligible".into()
+                        }
+                        CleanupAction::CloseAsSuperseded => {
+                            "workflow-owned superseded change request is eligible".into()
+                        }
+                        CleanupAction::Skip => {
+                            "candidate is not workflow-owned, superseded, old enough, or diff-free"
+                                .into()
+                        }
+                    },
+                }
+            })
+            .collect();
+
+        Ok(Self {
+            provider: policy.provider,
+            mode: policy.mode,
+            actions,
+            mutations_executed,
+        })
+    }
+}

--- a/crates/amplihack-workflows/src/stale_cleanup.rs
+++ b/crates/amplihack-workflows/src/stale_cleanup.rs
@@ -64,51 +64,49 @@ impl CleanupPlan {
         }
 
         let mut mutations_executed = 0;
-        let actions = candidates
-            .into_iter()
-            .map(|candidate| {
-                let eligible = candidate.state == ChangeRequestStatus::Open
-                    && candidate.age_hours >= policy.minimum_age_hours
-                    && !candidate.has_unmerged_meaningful_diff
-                    && candidate
-                        .labels
-                        .iter()
-                        .any(|label| label == &policy.workflow_label)
-                    && candidate
-                        .labels
-                        .iter()
-                        .any(|label| label.starts_with(&policy.superseded_by_label_prefix));
-
-                let action = if eligible {
-                    match policy.mode {
-                        CleanupMode::DryRun => CleanupAction::WouldCloseAsSuperseded,
-                        CleanupMode::Apply => {
-                            mutations_executed += 1;
-                            CleanupAction::CloseAsSuperseded
-                        }
-                    }
-                } else {
-                    CleanupAction::Skip
+        let mut actions = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            let eligible = candidate.state == ChangeRequestStatus::Open
+                && candidate.age_hours >= policy.minimum_age_hours
+                && !candidate.has_unmerged_meaningful_diff
+                && {
+                    let (has_workflow_label, has_superseded_label) = label_matches(
+                        &candidate.labels,
+                        &policy.workflow_label,
+                        &policy.superseded_by_label_prefix,
+                    );
+                    has_workflow_label && has_superseded_label
                 };
 
-                CleanupPlanAction {
-                    change_request_id: candidate.id,
-                    action,
-                    reason: match action {
-                        CleanupAction::WouldCloseAsSuperseded => {
-                            "dry-run: workflow-owned superseded change request is eligible".into()
-                        }
-                        CleanupAction::CloseAsSuperseded => {
-                            "workflow-owned superseded change request is eligible".into()
-                        }
-                        CleanupAction::Skip => {
-                            "candidate is not workflow-owned, superseded, old enough, or diff-free"
-                                .into()
-                        }
-                    },
+            let action = if eligible {
+                match policy.mode {
+                    CleanupMode::DryRun => CleanupAction::WouldCloseAsSuperseded,
+                    CleanupMode::Apply => {
+                        mutations_executed += 1;
+                        CleanupAction::CloseAsSuperseded
+                    }
                 }
-            })
-            .collect();
+            } else {
+                CleanupAction::Skip
+            };
+
+            actions.push(CleanupPlanAction {
+                change_request_id: candidate.id,
+                action,
+                reason: match action {
+                    CleanupAction::WouldCloseAsSuperseded => {
+                        "dry-run: workflow-owned superseded change request is eligible".into()
+                    }
+                    CleanupAction::CloseAsSuperseded => {
+                        "workflow-owned superseded change request is eligible".into()
+                    }
+                    CleanupAction::Skip => {
+                        "candidate is not workflow-owned, superseded, old enough, or diff-free"
+                            .into()
+                    }
+                },
+            });
+        }
 
         Ok(Self {
             provider: policy.provider,
@@ -117,4 +115,25 @@ impl CleanupPlan {
             mutations_executed,
         })
     }
+}
+
+fn label_matches(
+    labels: &[String],
+    workflow_label: &str,
+    superseded_by_label_prefix: &str,
+) -> (bool, bool) {
+    let mut has_workflow_label = false;
+    let mut has_superseded_label = false;
+    for label in labels {
+        if !has_workflow_label {
+            has_workflow_label = label == workflow_label;
+        }
+        if !has_superseded_label {
+            has_superseded_label = label.starts_with(superseded_by_label_prefix);
+        }
+        if has_workflow_label && has_superseded_label {
+            break;
+        }
+    }
+    (has_workflow_label, has_superseded_label)
 }

--- a/crates/amplihack-workflows/src/workflow_contract.rs
+++ b/crates/amplihack-workflows/src/workflow_contract.rs
@@ -34,7 +34,7 @@ pub fn provider_capabilities(provider: RepositoryProvider) -> ProviderCapabiliti
         },
         RepositoryProvider::AzureDevOps => ProviderCapabilities {
             tracking_items: ProviderCapabilityState::Automated,
-            change_requests: ProviderCapabilityState::ManualRequired,
+            change_requests: ProviderCapabilityState::Automated,
             stale_cleanup: ProviderCapabilityState::ManualRequired,
         },
         RepositoryProvider::Manual => ProviderCapabilities {
@@ -49,25 +49,15 @@ pub fn provider_default_next_action(provider: RepositoryProvider) -> &'static st
     match provider {
         RepositoryProvider::GitHub => "No further provider setup is required.",
         RepositoryProvider::AzureDevOps => {
-            "Use Azure Boards automation where configured; create Azure Repos PRs manually."
+            "Use Azure Boards and Azure Repos automation where configured."
         }
         RepositoryProvider::Manual => "Run provider-specific change request steps manually.",
     }
 }
 
-pub fn provider_from_remote_url(remote_url: Option<&str>) -> RepositoryProvider {
-    let Some(remote_url) = remote_url else {
-        return RepositoryProvider::Manual;
-    };
-    let normalized = remote_url.to_ascii_lowercase();
-    if normalized.contains("dev.azure.com") || normalized.contains("visualstudio.com") {
-        RepositoryProvider::AzureDevOps
-    } else if normalized.contains("github.com") {
-        RepositoryProvider::GitHub
-    } else {
-        RepositoryProvider::Manual
-    }
-}
+pub use crate::remote_repository::{
+    provider_from_remote_url, redact_remote_url, repository_identity_from_remote_url,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepositoryIdentity {
@@ -273,6 +263,10 @@ pub struct TerminalValidationResult {
 }
 
 pub fn validate_terminal_transition(value: Value) -> TerminalValidationResult {
+    validate_terminal_transition_ref(&value)
+}
+
+pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResult {
     let requested_state = value
         .get("terminal_state")
         .and_then(Value::as_str)

--- a/crates/amplihack-workflows/src/workflow_contract.rs
+++ b/crates/amplihack-workflows/src/workflow_contract.rs
@@ -294,16 +294,50 @@ pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResu
         .unwrap_or_default();
 
     if requested_success && !requested_state.is_success() {
-        return TerminalValidationResult {
-            terminal_state: TerminalState::FailedInvalidEvidence,
-            terminal_success: false,
-            terminal_reason: format!(
+        return invalid_terminal_transition(
+            format!(
                 "{} cannot be terminal_success=true",
                 requested_state.as_str()
             ),
             required_next_action,
             evidence_used,
-        };
+        );
+    }
+    if requested_success && evidence_used.is_empty() {
+        return invalid_terminal_transition(
+            "terminal_success=true requires non-empty evidence_used",
+            required_next_action,
+            evidence_used,
+        );
+    }
+    if requested_success
+        && value
+            .get("hollow_success_detected")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    {
+        return invalid_terminal_transition(
+            "hollow_success_detected cannot be terminal_success=true",
+            required_next_action,
+            evidence_used,
+        );
+    }
+    if requested_success && provider_from_value(value) == Some(RepositoryProvider::Manual) {
+        return invalid_terminal_transition(
+            "Manual provider cannot be terminal_success=true",
+            required_next_action,
+            evidence_used,
+        );
+    }
+    if requested_success
+        && let Some(change_requests) = change_request_capability_from_value(value)
+        && change_requests != ProviderCapabilityState::Automated
+    {
+        return invalid_terminal_transition(
+            format!("change_requests={change_requests:?} cannot be terminal_success=true"),
+            required_next_action,
+            evidence_used,
+        );
     }
 
     TerminalValidationResult {
@@ -313,4 +347,33 @@ pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResu
         required_next_action,
         evidence_used,
     }
+}
+
+fn invalid_terminal_transition(
+    terminal_reason: impl Into<String>,
+    required_next_action: String,
+    evidence_used: Vec<String>,
+) -> TerminalValidationResult {
+    TerminalValidationResult {
+        terminal_state: TerminalState::FailedInvalidEvidence,
+        terminal_success: false,
+        terminal_reason: terminal_reason.into(),
+        required_next_action,
+        evidence_used,
+    }
+}
+
+fn provider_from_value(value: &Value) -> Option<RepositoryProvider> {
+    value
+        .get("provider")
+        .cloned()
+        .and_then(|provider| serde_json::from_value(provider).ok())
+}
+
+fn change_request_capability_from_value(value: &Value) -> Option<ProviderCapabilityState> {
+    value
+        .get("capabilities")
+        .and_then(|capabilities| capabilities.get("change_requests"))
+        .cloned()
+        .and_then(|state| serde_json::from_value(state).ok())
 }

--- a/crates/amplihack-workflows/src/workflow_contract.rs
+++ b/crates/amplihack-workflows/src/workflow_contract.rs
@@ -269,10 +269,17 @@ pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResu
         .get("terminal_success")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let terminal_reason = value
+        .get("reason")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
     let required_next_action = value
         .get("required_next_action")
         .and_then(Value::as_str)
-        .unwrap_or("Inspect workflow evidence and rerun finalization.")
+        .unwrap_or("")
+        .trim()
         .to_string();
     let evidence_used = value
         .get("evidence_used")
@@ -280,13 +287,42 @@ pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResu
         .map(|items| {
             let mut evidence = Vec::with_capacity(items.len());
             for item in items {
-                if let Some(item) = item.as_str() {
+                if let Some(item) = item.as_str().map(str::trim)
+                    && !item.is_empty()
+                {
                     evidence.push(item.to_owned());
                 }
             }
             evidence
         })
         .unwrap_or_default();
+    let invalid_next_action = if required_next_action.is_empty() {
+        "Inspect workflow evidence and rerun finalization.".to_string()
+    } else {
+        required_next_action.clone()
+    };
+
+    if terminal_reason.is_empty() {
+        return invalid_terminal_transition(
+            "terminal transition requires non-empty reason",
+            invalid_next_action,
+            evidence_used,
+        );
+    }
+    if required_next_action.is_empty() {
+        return invalid_terminal_transition(
+            "terminal transition requires non-empty required_next_action",
+            invalid_next_action,
+            evidence_used,
+        );
+    }
+    if evidence_used.is_empty() {
+        return invalid_terminal_transition(
+            "terminal transition requires non-empty evidence_used",
+            required_next_action,
+            evidence_used,
+        );
+    }
 
     if requested_success && !requested_state.is_success() {
         return invalid_terminal_transition(
@@ -298,9 +334,12 @@ pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResu
             evidence_used,
         );
     }
-    if requested_success && evidence_used.is_empty() {
+    if !requested_success && requested_state.is_success() {
         return invalid_terminal_transition(
-            "terminal_success=true requires non-empty evidence_used",
+            format!(
+                "{} requires terminal_success=true",
+                requested_state.as_str()
+            ),
             required_next_action,
             evidence_used,
         );
@@ -317,6 +356,13 @@ pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResu
             evidence_used,
         );
     }
+    if requested_success && provider_from_value(value).is_none() {
+        return invalid_terminal_transition(
+            "terminal_success=true requires explicit provider evidence",
+            required_next_action,
+            evidence_used,
+        );
+    }
     if requested_success && provider_from_value(value) == Some(RepositoryProvider::Manual) {
         return invalid_terminal_transition(
             "Manual provider cannot be terminal_success=true",
@@ -324,21 +370,30 @@ pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResu
             evidence_used,
         );
     }
-    if requested_success
-        && let Some(change_requests) = change_request_capability_from_value(value)
-        && change_requests != ProviderCapabilityState::Automated
-    {
-        return invalid_terminal_transition(
-            format!("change_requests={change_requests:?} cannot be terminal_success=true"),
-            required_next_action,
-            evidence_used,
-        );
+    if requested_success {
+        match change_request_capability_from_value(value) {
+            Some(ProviderCapabilityState::Automated) => {}
+            Some(change_requests) => {
+                return invalid_terminal_transition(
+                    format!("change_requests={change_requests:?} cannot be terminal_success=true"),
+                    required_next_action,
+                    evidence_used,
+                );
+            }
+            None => {
+                return invalid_terminal_transition(
+                    "terminal_success=true requires explicit change_requests capability evidence",
+                    required_next_action,
+                    evidence_used,
+                );
+            }
+        }
     }
 
     TerminalValidationResult {
         terminal_state: requested_state,
         terminal_success: requested_success && requested_state.is_success(),
-        terminal_reason: "terminal transition evidence accepted".into(),
+        terminal_reason,
         required_next_action,
         evidence_used,
     }

--- a/crates/amplihack-workflows/src/workflow_contract.rs
+++ b/crates/amplihack-workflows/src/workflow_contract.rs
@@ -18,7 +18,7 @@ pub enum ProviderCapabilityState {
     Unsupported,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProviderCapabilities {
     pub tracking_items: ProviderCapabilityState,
     pub change_requests: ProviderCapabilityState,
@@ -136,29 +136,22 @@ impl<'de> Deserialize<'de> for TerminalState {
 }
 
 pub fn parse_terminal_state(raw: &str) -> Option<TerminalState> {
-    let trimmed = raw.trim();
-    let normalized = if trimmed.contains('_') || trimmed.contains('-') {
-        trimmed.replace('-', "_").to_ascii_uppercase()
+    if matches_identifier(raw, "followupcreated") {
+        Some(TerminalState::FollowupCreated)
+    } else if matches_identifier(raw, "manualrequired") {
+        Some(TerminalState::ManualRequired)
+    } else if matches_identifier(raw, "blockedmanualprovider") {
+        Some(TerminalState::BlockedManualProvider)
+    } else if matches_identifier(raw, "hollowsuccess") {
+        Some(TerminalState::HollowSuccess)
+    } else if matches_identifier(raw, "failedinvalidevidence") {
+        Some(TerminalState::FailedInvalidEvidence)
+    } else if matches_identifier(raw, "failedfinalizeroutput") {
+        Some(TerminalState::FailedFinalizerOutput)
+    } else if matches_identifier(raw, "failed") {
+        Some(TerminalState::Failed)
     } else {
-        let mut out = String::new();
-        for (index, ch) in trimmed.chars().enumerate() {
-            if ch.is_ascii_uppercase() && index > 0 {
-                out.push('_');
-            }
-            out.push(ch.to_ascii_uppercase());
-        }
-        out
-    };
-
-    match normalized.as_str() {
-        "FOLLOWUP_CREATED" => Some(TerminalState::FollowupCreated),
-        "MANUAL_REQUIRED" => Some(TerminalState::ManualRequired),
-        "BLOCKED_MANUAL_PROVIDER" => Some(TerminalState::BlockedManualProvider),
-        "HOLLOW_SUCCESS" => Some(TerminalState::HollowSuccess),
-        "FAILED_INVALID_EVIDENCE" => Some(TerminalState::FailedInvalidEvidence),
-        "FAILED_FINALIZER_OUTPUT" => Some(TerminalState::FailedFinalizerOutput),
-        "FAILED" => Some(TerminalState::Failed),
-        _ => None,
+        None
     }
 }
 
@@ -285,11 +278,13 @@ pub fn validate_terminal_transition_ref(value: &Value) -> TerminalValidationResu
         .get("evidence_used")
         .and_then(Value::as_array)
         .map(|items| {
-            items
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::to_string)
-                .collect()
+            let mut evidence = Vec::with_capacity(items.len());
+            for item in items {
+                if let Some(item) = item.as_str() {
+                    evidence.push(item.to_owned());
+                }
+            }
+            evidence
         })
         .unwrap_or_default();
 
@@ -366,14 +361,54 @@ fn invalid_terminal_transition(
 fn provider_from_value(value: &Value) -> Option<RepositoryProvider> {
     value
         .get("provider")
-        .cloned()
-        .and_then(|provider| serde_json::from_value(provider).ok())
+        .and_then(Value::as_str)
+        .and_then(parse_repository_provider)
 }
 
 fn change_request_capability_from_value(value: &Value) -> Option<ProviderCapabilityState> {
     value
         .get("capabilities")
         .and_then(|capabilities| capabilities.get("change_requests"))
-        .cloned()
-        .and_then(|state| serde_json::from_value(state).ok())
+        .and_then(Value::as_str)
+        .and_then(parse_provider_capability_state)
+}
+
+fn parse_repository_provider(raw: &str) -> Option<RepositoryProvider> {
+    if matches_identifier(raw, "github") {
+        Some(RepositoryProvider::GitHub)
+    } else if matches_identifier(raw, "azuredevops") {
+        Some(RepositoryProvider::AzureDevOps)
+    } else if matches_identifier(raw, "manual") {
+        Some(RepositoryProvider::Manual)
+    } else {
+        None
+    }
+}
+
+fn parse_provider_capability_state(raw: &str) -> Option<ProviderCapabilityState> {
+    if matches_identifier(raw, "automated") {
+        Some(ProviderCapabilityState::Automated)
+    } else if matches_identifier(raw, "manualrequired") {
+        Some(ProviderCapabilityState::ManualRequired)
+    } else if matches_identifier(raw, "blockedmanualprovider") {
+        Some(ProviderCapabilityState::BlockedManualProvider)
+    } else if matches_identifier(raw, "unsupported") {
+        Some(ProviderCapabilityState::Unsupported)
+    } else {
+        None
+    }
+}
+
+fn matches_identifier(raw: &str, expected: &str) -> bool {
+    let mut chars = raw
+        .trim()
+        .chars()
+        .filter(|ch| !matches!(ch, '_' | '-' | ' '));
+    for expected in expected.chars() {
+        match chars.next() {
+            Some(ch) if ch.eq_ignore_ascii_case(&expected) => {}
+            _ => return false,
+        }
+    }
+    chars.next().is_none()
 }

--- a/crates/amplihack-workflows/src/workflow_contract.rs
+++ b/crates/amplihack-workflows/src/workflow_contract.rs
@@ -1,0 +1,278 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum RepositoryProvider {
+    GitHub,
+    AzureDevOps,
+    Manual,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ProviderCapabilityState {
+    Automated,
+    ManualRequired,
+    BlockedManualProvider,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderCapabilities {
+    pub tracking_items: ProviderCapabilityState,
+    pub change_requests: ProviderCapabilityState,
+    pub stale_cleanup: ProviderCapabilityState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryIdentity {
+    pub remote_url: Option<String>,
+    pub owner: String,
+    pub name: String,
+    pub default_base: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ProviderOperationStatus {
+    Succeeded,
+    ManualRequired,
+    BlockedManualProvider,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderContext {
+    pub schema_version: u32,
+    pub provider: RepositoryProvider,
+    pub repository: RepositoryIdentity,
+    pub capabilities: ProviderCapabilities,
+    pub status: ProviderOperationStatus,
+    pub next_action: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalState {
+    FollowupCreated,
+    ManualRequired,
+    BlockedManualProvider,
+    HollowSuccess,
+    FailedInvalidEvidence,
+    FailedFinalizerOutput,
+    Failed,
+}
+
+impl TerminalState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FollowupCreated => "FOLLOWUP_CREATED",
+            Self::ManualRequired => "MANUAL_REQUIRED",
+            Self::BlockedManualProvider => "BLOCKED_MANUAL_PROVIDER",
+            Self::HollowSuccess => "HOLLOW_SUCCESS",
+            Self::FailedInvalidEvidence => "FAILED_INVALID_EVIDENCE",
+            Self::FailedFinalizerOutput => "FAILED_FINALIZER_OUTPUT",
+            Self::Failed => "FAILED",
+        }
+    }
+
+    pub fn is_success(self) -> bool {
+        matches!(self, Self::FollowupCreated)
+    }
+}
+
+impl Serialize for TerminalState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TerminalState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        parse_terminal_state(&raw)
+            .ok_or_else(|| serde::de::Error::custom(format!("unknown terminal state '{raw}'")))
+    }
+}
+
+pub fn parse_terminal_state(raw: &str) -> Option<TerminalState> {
+    let trimmed = raw.trim();
+    let normalized = if trimmed.contains('_') || trimmed.contains('-') {
+        trimmed.replace('-', "_").to_ascii_uppercase()
+    } else {
+        let mut out = String::new();
+        for (index, ch) in trimmed.chars().enumerate() {
+            if ch.is_ascii_uppercase() && index > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_uppercase());
+        }
+        out
+    };
+
+    match normalized.as_str() {
+        "FOLLOWUP_CREATED" => Some(TerminalState::FollowupCreated),
+        "MANUAL_REQUIRED" => Some(TerminalState::ManualRequired),
+        "BLOCKED_MANUAL_PROVIDER" => Some(TerminalState::BlockedManualProvider),
+        "HOLLOW_SUCCESS" => Some(TerminalState::HollowSuccess),
+        "FAILED_INVALID_EVIDENCE" => Some(TerminalState::FailedInvalidEvidence),
+        "FAILED_FINALIZER_OUTPUT" => Some(TerminalState::FailedFinalizerOutput),
+        "FAILED" => Some(TerminalState::Failed),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum HelperOperation {
+    DetectProvider,
+    PublishChangeRequest,
+    SimulateRecipe,
+    CleanupStale,
+    TerminalState,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HelperEnvelope {
+    pub schema_version: u32,
+    pub provider: RepositoryProvider,
+    pub operation: HelperOperation,
+    pub status: ProviderOperationStatus,
+    pub next_action: String,
+    pub warnings: Vec<String>,
+    pub data: Value,
+}
+
+impl HelperEnvelope {
+    pub fn succeeded(
+        provider: RepositoryProvider,
+        operation: HelperOperation,
+        next_action: impl Into<String>,
+        data: Value,
+    ) -> Self {
+        Self {
+            schema_version: 1,
+            provider,
+            operation,
+            status: ProviderOperationStatus::Succeeded,
+            next_action: next_action.into(),
+            warnings: Vec::new(),
+            data,
+        }
+    }
+
+    pub fn manual_required(
+        provider: RepositoryProvider,
+        operation: HelperOperation,
+        next_action: impl Into<String>,
+        data: Value,
+    ) -> Self {
+        Self {
+            schema_version: 1,
+            provider,
+            operation,
+            status: ProviderOperationStatus::ManualRequired,
+            next_action: next_action.into(),
+            warnings: Vec::new(),
+            data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ChangeRequestKind {
+    PullRequest,
+    MergeRequest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ChangeRequestStatus {
+    Open,
+    Closed,
+    Merged,
+    Draft,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeRequest {
+    pub kind: ChangeRequestKind,
+    pub id: String,
+    pub url: String,
+    pub state: ChangeRequestStatus,
+    pub source_branch: String,
+    pub base_branch: String,
+    pub head_sha: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManualAction {
+    pub action: String,
+    pub instructions: String,
+    pub required_inputs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalValidationResult {
+    pub terminal_state: TerminalState,
+    pub terminal_success: bool,
+    pub terminal_reason: String,
+    pub required_next_action: String,
+    pub evidence_used: Vec<String>,
+}
+
+pub fn validate_terminal_transition(value: Value) -> TerminalValidationResult {
+    let requested_state = value
+        .get("terminal_state")
+        .and_then(Value::as_str)
+        .and_then(parse_terminal_state)
+        .unwrap_or(TerminalState::FailedInvalidEvidence);
+    let requested_success = value
+        .get("terminal_success")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let required_next_action = value
+        .get("required_next_action")
+        .and_then(Value::as_str)
+        .unwrap_or("Inspect workflow evidence and rerun finalization.")
+        .to_string();
+    let evidence_used = value
+        .get("evidence_used")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if requested_success && !requested_state.is_success() {
+        return TerminalValidationResult {
+            terminal_state: TerminalState::FailedInvalidEvidence,
+            terminal_success: false,
+            terminal_reason: format!(
+                "{} cannot be terminal_success=true",
+                requested_state.as_str()
+            ),
+            required_next_action,
+            evidence_used,
+        };
+    }
+
+    TerminalValidationResult {
+        terminal_state: requested_state,
+        terminal_success: requested_success && requested_state.is_success(),
+        terminal_reason: "terminal transition evidence accepted".into(),
+        required_next_action,
+        evidence_used,
+    }
+}

--- a/crates/amplihack-workflows/src/workflow_contract.rs
+++ b/crates/amplihack-workflows/src/workflow_contract.rs
@@ -25,6 +25,50 @@ pub struct ProviderCapabilities {
     pub stale_cleanup: ProviderCapabilityState,
 }
 
+pub fn provider_capabilities(provider: RepositoryProvider) -> ProviderCapabilities {
+    match provider {
+        RepositoryProvider::GitHub => ProviderCapabilities {
+            tracking_items: ProviderCapabilityState::Automated,
+            change_requests: ProviderCapabilityState::Automated,
+            stale_cleanup: ProviderCapabilityState::Automated,
+        },
+        RepositoryProvider::AzureDevOps => ProviderCapabilities {
+            tracking_items: ProviderCapabilityState::Automated,
+            change_requests: ProviderCapabilityState::ManualRequired,
+            stale_cleanup: ProviderCapabilityState::ManualRequired,
+        },
+        RepositoryProvider::Manual => ProviderCapabilities {
+            tracking_items: ProviderCapabilityState::ManualRequired,
+            change_requests: ProviderCapabilityState::ManualRequired,
+            stale_cleanup: ProviderCapabilityState::ManualRequired,
+        },
+    }
+}
+
+pub fn provider_default_next_action(provider: RepositoryProvider) -> &'static str {
+    match provider {
+        RepositoryProvider::GitHub => "No further provider setup is required.",
+        RepositoryProvider::AzureDevOps => {
+            "Use Azure Boards automation where configured; create Azure Repos PRs manually."
+        }
+        RepositoryProvider::Manual => "Run provider-specific change request steps manually.",
+    }
+}
+
+pub fn provider_from_remote_url(remote_url: Option<&str>) -> RepositoryProvider {
+    let Some(remote_url) = remote_url else {
+        return RepositoryProvider::Manual;
+    };
+    let normalized = remote_url.to_ascii_lowercase();
+    if normalized.contains("dev.azure.com") || normalized.contains("visualstudio.com") {
+        RepositoryProvider::AzureDevOps
+    } else if normalized.contains("github.com") {
+        RepositoryProvider::GitHub
+    } else {
+        RepositoryProvider::Manual
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepositoryIdentity {
     pub remote_url: Option<String>,

--- a/crates/amplihack-workflows/tests/agent_validation_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/agent_validation_contract_tests.rs
@@ -9,9 +9,23 @@ use amplihack_workflows::agent_contract::{
 use amplihack_workflows::workflow_contract::TerminalState;
 use serde_json::json;
 
+fn automated_github_evidence() -> serde_json::Value {
+    json!({
+        "provider": "GitHub",
+        "capabilities": {
+            "tracking_items": "Automated",
+            "change_requests": "Automated",
+            "stale_cleanup": "Automated"
+        }
+    })
+}
+
 #[test]
 fn high_confidence_followup_output_with_evidence_is_valid_success() {
-    let output = validate_finalizer_output(json!({
+    let mut value = automated_github_evidence();
+    let object = value.as_object_mut().unwrap();
+    object.extend(
+        json!({
         "schema_version": 1,
         "terminal_state": "FOLLOWUP_CREATED",
         "terminal_success": true,
@@ -23,8 +37,13 @@ fn high_confidence_followup_output_with_evidence_is_valid_success() {
             "change_request.id=812",
             "verification.completed=true"
         ]
-    }))
-    .expect("valid finalizer output must pass deterministic validation");
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    );
+    let output = validate_finalizer_output(value)
+        .expect("valid finalizer output must pass deterministic validation");
 
     assert_eq!(output.terminal_state, TerminalState::FollowupCreated);
     assert!(output.terminal_success);
@@ -33,7 +52,10 @@ fn high_confidence_followup_output_with_evidence_is_valid_success() {
 
 #[test]
 fn medium_confidence_success_claim_fails_closed() {
-    let error = validate_finalizer_output(json!({
+    let mut value = automated_github_evidence();
+    let object = value.as_object_mut().unwrap();
+    object.extend(
+        json!({
         "schema_version": 1,
         "terminal_state": "FOLLOWUP_CREATED",
         "terminal_success": true,
@@ -42,8 +64,13 @@ fn medium_confidence_success_claim_fails_closed() {
         "required_next_action": "Maybe wait for review.",
         "hollow_success_detected": false,
         "evidence_used": ["change_request.id=812"]
-    }))
-    .expect_err("only high confidence can prove terminal success");
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    );
+    let error = validate_finalizer_output(value)
+        .expect_err("only high confidence can prove terminal success");
 
     assert_eq!(error, AgentContractError::SuccessRequiresHighConfidence);
 }
@@ -58,7 +85,10 @@ fn non_json_or_missing_fields_become_failed_finalizer_output() {
 
 #[test]
 fn hollow_success_signal_cannot_be_reported_as_success() {
-    let error = validate_finalizer_output(json!({
+    let mut value = automated_github_evidence();
+    let object = value.as_object_mut().unwrap();
+    object.extend(
+        json!({
         "schema_version": 1,
         "terminal_state": "HOLLOW_SUCCESS",
         "terminal_success": true,
@@ -66,16 +96,24 @@ fn hollow_success_signal_cannot_be_reported_as_success() {
         "reason": "Agent reported success but no implementation or publication evidence exists.",
         "required_next_action": "Retry with concrete implementation evidence.",
         "hollow_success_detected": true,
-        "evidence_used": []
-    }))
-    .expect_err("HOLLOW_SUCCESS is never a success state");
+        "evidence_used": ["agent.output=success-without-artifacts"]
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    );
+    let error =
+        validate_finalizer_output(value).expect_err("HOLLOW_SUCCESS is never a success state");
 
     assert_eq!(error.terminal_state(), TerminalState::FailedInvalidEvidence);
 }
 
 #[test]
 fn successful_finalizer_output_requires_evidence() {
-    let error = validate_finalizer_output(json!({
+    let mut value = automated_github_evidence();
+    let object = value.as_object_mut().unwrap();
+    object.extend(
+        json!({
         "schema_version": 1,
         "terminal_state": "FOLLOWUP_CREATED",
         "terminal_success": true,
@@ -84,8 +122,53 @@ fn successful_finalizer_output_requires_evidence() {
         "required_next_action": "Monitor PR validation.",
         "hollow_success_detected": false,
         "evidence_used": []
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    );
+    let error = validate_finalizer_output(value)
+        .expect_err("terminal success without evidence is a hollow success claim");
+
+    assert_eq!(error.terminal_state(), TerminalState::FailedInvalidEvidence);
+}
+
+#[test]
+fn successful_finalizer_output_requires_provider_capability_evidence() {
+    let error = validate_finalizer_output(json!({
+        "schema_version": 1,
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "confidence": "high",
+        "reason": "Workflow published PR #812.",
+        "required_next_action": "Monitor PR validation.",
+        "hollow_success_detected": false,
+        "evidence_used": ["change_request.id=812"]
     }))
-    .expect_err("terminal success without evidence is a hollow success claim");
+    .expect_err("success without provider/capabilities evidence must fail closed");
+
+    assert_eq!(error.terminal_state(), TerminalState::FailedFinalizerOutput);
+}
+
+#[test]
+fn manual_provider_success_claim_fails_closed() {
+    let error = validate_finalizer_output(json!({
+        "schema_version": 1,
+        "provider": "Manual",
+        "capabilities": {
+            "tracking_items": "ManualRequired",
+            "change_requests": "ManualRequired",
+            "stale_cleanup": "ManualRequired"
+        },
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "confidence": "high",
+        "reason": "Manual provider claimed a follow-up was created.",
+        "required_next_action": "Create the change request manually.",
+        "hollow_success_detected": false,
+        "evidence_used": ["provider=Manual", "change_requests=ManualRequired"]
+    }))
+    .expect_err("manual providers cannot claim automated terminal success");
 
     assert_eq!(error.terminal_state(), TerminalState::FailedInvalidEvidence);
 }

--- a/crates/amplihack-workflows/tests/agent_validation_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/agent_validation_contract_tests.rs
@@ -72,3 +72,20 @@ fn hollow_success_signal_cannot_be_reported_as_success() {
 
     assert_eq!(error.terminal_state(), TerminalState::FailedInvalidEvidence);
 }
+
+#[test]
+fn successful_finalizer_output_requires_evidence() {
+    let error = validate_finalizer_output(json!({
+        "schema_version": 1,
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "confidence": "high",
+        "reason": "Workflow claims publication succeeded.",
+        "required_next_action": "Monitor PR validation.",
+        "hollow_success_detected": false,
+        "evidence_used": []
+    }))
+    .expect_err("terminal success without evidence is a hollow success claim");
+
+    assert_eq!(error.terminal_state(), TerminalState::FailedInvalidEvidence);
+}

--- a/crates/amplihack-workflows/tests/agent_validation_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/agent_validation_contract_tests.rs
@@ -1,0 +1,74 @@
+//! TDD contract tests for agentic finalizer validation.
+//!
+//! Judgment-heavy workflow steps stay agentic, but their outputs must validate
+//! through deterministic contracts.
+
+use amplihack_workflows::agent_contract::{
+    AgentContractError, AgentFinalizerOutput, FinalizerConfidence, validate_finalizer_output,
+};
+use amplihack_workflows::workflow_contract::TerminalState;
+use serde_json::json;
+
+#[test]
+fn high_confidence_followup_output_with_evidence_is_valid_success() {
+    let output = validate_finalizer_output(json!({
+        "schema_version": 1,
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "confidence": "high",
+        "reason": "Workflow published PR #812 with verification evidence.",
+        "required_next_action": "Wait for review and required checks.",
+        "hollow_success_detected": false,
+        "evidence_used": [
+            "change_request.id=812",
+            "verification.completed=true"
+        ]
+    }))
+    .expect("valid finalizer output must pass deterministic validation");
+
+    assert_eq!(output.terminal_state, TerminalState::FollowupCreated);
+    assert!(output.terminal_success);
+    assert_eq!(output.confidence, FinalizerConfidence::High);
+}
+
+#[test]
+fn medium_confidence_success_claim_fails_closed() {
+    let error = validate_finalizer_output(json!({
+        "schema_version": 1,
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "confidence": "medium",
+        "reason": "Probably published.",
+        "required_next_action": "Maybe wait for review.",
+        "hollow_success_detected": false,
+        "evidence_used": ["change_request.id=812"]
+    }))
+    .expect_err("only high confidence can prove terminal success");
+
+    assert_eq!(error, AgentContractError::SuccessRequiresHighConfidence);
+}
+
+#[test]
+fn non_json_or_missing_fields_become_failed_finalizer_output() {
+    let error = AgentFinalizerOutput::from_agent_text("looks good to me")
+        .expect_err("unstructured finalizer prose must fail closed");
+
+    assert_eq!(error.terminal_state(), TerminalState::FailedFinalizerOutput);
+}
+
+#[test]
+fn hollow_success_signal_cannot_be_reported_as_success() {
+    let error = validate_finalizer_output(json!({
+        "schema_version": 1,
+        "terminal_state": "HOLLOW_SUCCESS",
+        "terminal_success": true,
+        "confidence": "high",
+        "reason": "Agent reported success but no implementation or publication evidence exists.",
+        "required_next_action": "Retry with concrete implementation evidence.",
+        "hollow_success_detected": true,
+        "evidence_used": []
+    }))
+    .expect_err("HOLLOW_SUCCESS is never a success state");
+
+    assert_eq!(error.terminal_state(), TerminalState::FailedInvalidEvidence);
+}

--- a/crates/amplihack-workflows/tests/provider_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/provider_contract_tests.rs
@@ -8,7 +8,7 @@ use amplihack_workflows::workflow_contract::{
     ManualAction, ProviderCapabilities, ProviderCapabilityState, ProviderContext,
     ProviderOperationStatus, RepositoryIdentity, RepositoryProvider, TerminalState,
     provider_capabilities, provider_default_next_action, provider_from_remote_url,
-    validate_terminal_transition,
+    redact_remote_url, repository_identity_from_remote_url, validate_terminal_transition,
 };
 use serde_json::{Value, json};
 
@@ -80,17 +80,17 @@ fn helper_envelope_keeps_operation_data_nested_under_data() {
 }
 
 #[test]
-fn azure_repos_change_request_publication_is_manual_not_fake_success() {
+fn manual_provider_change_request_publication_is_manual_not_fake_success() {
     let manual = ManualAction {
-        action: "CreateAzureReposPullRequest".into(),
-        instructions: "Create an Azure Repos pull request from feat/auth-timeout to main.".into(),
+        action: "CreateProviderChangeRequest".into(),
+        instructions: "Create a provider change request from feat/auth-timeout to main.".into(),
         required_inputs: vec!["source_branch".into(), "base_branch".into()],
     };
 
     let envelope = HelperEnvelope::manual_required(
-        RepositoryProvider::AzureDevOps,
+        RepositoryProvider::Manual,
         HelperOperation::PublishChangeRequest,
-        "Create an Azure Repos pull request manually, then rerun status detection.",
+        "Run provider-specific change request steps manually.",
         json!({
             "change_request": null,
             "manual_action": manual
@@ -98,12 +98,12 @@ fn azure_repos_change_request_publication_is_manual_not_fake_success() {
     );
 
     let value = serde_json::to_value(envelope).unwrap();
-    assert_eq!(value["provider"], "AzureDevOps");
+    assert_eq!(value["provider"], "Manual");
     assert_eq!(value["status"], "ManualRequired");
     assert_eq!(value["data"]["change_request"], Value::Null);
     assert_eq!(
         value["data"]["manual_action"]["action"],
-        "CreateAzureReposPullRequest"
+        "CreateProviderChangeRequest"
     );
     assert!(
         value["next_action"].as_str().unwrap().contains("manually"),
@@ -124,17 +124,17 @@ fn provider_context_exposes_explicit_capability_states() {
         },
         capabilities: ProviderCapabilities {
             tracking_items: ProviderCapabilityState::Automated,
-            change_requests: ProviderCapabilityState::ManualRequired,
+            change_requests: ProviderCapabilityState::Automated,
             stale_cleanup: ProviderCapabilityState::ManualRequired,
         },
-        status: ProviderOperationStatus::ManualRequired,
-        next_action: "Create Azure Repos PRs manually for this provider.".into(),
+        status: ProviderOperationStatus::Succeeded,
+        next_action: "Use Azure Boards and Azure Repos automation where configured.".into(),
     };
 
     let value = serde_json::to_value(context).unwrap();
     assert_eq!(value["capabilities"]["tracking_items"], "Automated");
-    assert_eq!(value["capabilities"]["change_requests"], "ManualRequired");
-    assert_eq!(value["status"], "ManualRequired");
+    assert_eq!(value["capabilities"]["change_requests"], "Automated");
+    assert_eq!(value["status"], "Succeeded");
 }
 
 #[test]
@@ -145,13 +145,10 @@ fn provider_capability_defaults_are_provider_neutral_and_explicit() {
 
     let azdo = provider_capabilities(RepositoryProvider::AzureDevOps);
     assert_eq!(azdo.tracking_items, ProviderCapabilityState::Automated);
-    assert_eq!(
-        azdo.change_requests,
-        ProviderCapabilityState::ManualRequired
-    );
+    assert_eq!(azdo.change_requests, ProviderCapabilityState::Automated);
     assert!(
-        provider_default_next_action(RepositoryProvider::AzureDevOps).contains("manually"),
-        "Azure DevOps change-request automation must not be implied where unavailable"
+        provider_default_next_action(RepositoryProvider::AzureDevOps).contains("Azure Repos"),
+        "Azure DevOps change-request automation must remain an explicit provider capability"
     );
 
     let manual = provider_capabilities(RepositoryProvider::Manual);
@@ -172,7 +169,19 @@ fn provider_detection_from_remote_urls_falls_back_to_manual_for_unknowns() {
         RepositoryProvider::GitHub
     );
     assert_eq!(
+        provider_from_remote_url(Some("git@github.com:acme/service.git")),
+        RepositoryProvider::GitHub
+    );
+    assert_eq!(
         provider_from_remote_url(Some("https://dev.azure.com/acme/project/_git/service")),
+        RepositoryProvider::AzureDevOps
+    );
+    assert_eq!(
+        provider_from_remote_url(Some("ssh://git@ssh.dev.azure.com:v3/acme/project/service")),
+        RepositoryProvider::AzureDevOps
+    );
+    assert_eq!(
+        provider_from_remote_url(Some("ssh://git@SSH.DEV.AZURE.COM:v3/acme/project/service")),
         RepositoryProvider::AzureDevOps
     );
     assert_eq!(provider_from_remote_url(None), RepositoryProvider::Manual);
@@ -184,14 +193,94 @@ fn provider_detection_from_remote_urls_falls_back_to_manual_for_unknowns() {
 }
 
 #[test]
+fn provider_detection_rejects_provider_domain_substring_spoofing() {
+    assert_eq!(
+        provider_from_remote_url(Some("https://evil.example/github.com/acme/service.git")),
+        RepositoryProvider::Manual,
+        "provider detection must match the remote host, not path substrings"
+    );
+    assert_eq!(
+        provider_from_remote_url(Some("https://github.com.evil.example/acme/service.git")),
+        RepositoryProvider::Manual,
+        "provider detection must reject lookalike host suffixes"
+    );
+    assert_eq!(
+        provider_from_remote_url(Some(
+            "https://dev.azure.com.evil.example/acme/project/_git/service"
+        )),
+        RepositoryProvider::Manual,
+        "Azure DevOps detection must reject lookalike host suffixes"
+    );
+}
+
+#[test]
+fn remote_repository_identity_redacts_credentials_and_extracts_github_owner_name() {
+    let (provider, repository) = repository_identity_from_remote_url(
+        Some("https://user:ghp_secret_token@github.com/acme/service.git"),
+        "fallback",
+    );
+
+    assert_eq!(provider, RepositoryProvider::GitHub);
+    assert_eq!(
+        repository.remote_url.as_deref(),
+        Some("https://[redacted]@github.com/acme/service.git")
+    );
+    assert_eq!(repository.owner, "acme");
+    assert_eq!(repository.name, "service");
+}
+
+#[test]
+fn remote_repository_identity_extracts_azure_owner_name_from_https_and_ssh() {
+    let (https_provider, https_repository) = repository_identity_from_remote_url(
+        Some("https://dev.azure.com/acme/project/_git/service"),
+        "fallback",
+    );
+    let (ssh_provider, ssh_repository) = repository_identity_from_remote_url(
+        Some("ssh://git@ssh.dev.azure.com:v3/acme/project/service"),
+        "fallback",
+    );
+
+    assert_eq!(https_provider, RepositoryProvider::AzureDevOps);
+    assert_eq!(https_repository.owner, "acme/project");
+    assert_eq!(https_repository.name, "service");
+    assert_eq!(ssh_provider, RepositoryProvider::AzureDevOps);
+    assert_eq!(ssh_repository.owner, "acme/project");
+    assert_eq!(ssh_repository.name, "service");
+}
+
+#[test]
+fn remote_repository_identity_does_not_extract_owner_from_spoofed_provider_path() {
+    let (provider, repository) = repository_identity_from_remote_url(
+        Some("https://evil.example/github.com/acme/service.git"),
+        "fallback",
+    );
+
+    assert_eq!(provider, RepositoryProvider::Manual);
+    assert_eq!(repository.owner, "unknown");
+    assert_eq!(repository.name, "fallback");
+}
+
+#[test]
+fn redact_remote_url_preserves_non_credential_remote_forms() {
+    assert_eq!(
+        redact_remote_url("git@github.com:acme/service.git"),
+        "git@github.com:acme/service.git"
+    );
+    assert_eq!(
+        redact_remote_url("https://github.com/acme/service.git"),
+        "https://github.com/acme/service.git"
+    );
+}
+
+#[test]
 fn terminal_transition_fails_closed_when_manual_provider_path_claims_success() {
     let result = validate_terminal_transition(json!({
-        "provider": "AzureDevOps",
+        "provider": "Manual",
         "terminal_state": "MANUAL_REQUIRED",
         "terminal_success": true,
-        "required_next_action": "Create an Azure Repos pull request manually.",
+        "required_next_action": "Create a provider change request manually.",
         "evidence_used": [
-            "provider=AzureDevOps",
+            "provider=Manual",
             "change_requests=ManualRequired"
         ]
     }));

--- a/crates/amplihack-workflows/tests/provider_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/provider_contract_tests.rs
@@ -278,6 +278,7 @@ fn terminal_transition_fails_closed_when_manual_provider_path_claims_success() {
         "provider": "Manual",
         "terminal_state": "MANUAL_REQUIRED",
         "terminal_success": true,
+        "reason": "Manual provider cannot create a provider-neutral follow-up automatically.",
         "required_next_action": "Create a provider change request manually.",
         "evidence_used": [
             "provider=Manual",
@@ -300,6 +301,7 @@ fn terminal_transition_rejects_manual_provider_followup_success_claims() {
         "provider": "Manual",
         "terminal_state": "FOLLOWUP_CREATED",
         "terminal_success": true,
+        "reason": "Manual provider claimed automated follow-up creation.",
         "required_next_action": "Create a provider change request manually.",
         "evidence_used": ["provider=Manual"]
     }));
@@ -322,6 +324,7 @@ fn terminal_transition_rejects_success_without_evidence() {
         },
         "terminal_state": "FOLLOWUP_CREATED",
         "terminal_success": true,
+        "reason": "Workflow claims publication succeeded.",
         "required_next_action": "Monitor PR validation.",
         "evidence_used": []
     }));
@@ -344,6 +347,7 @@ fn terminal_transition_rejects_success_when_change_requests_are_manual() {
         },
         "terminal_state": "FOLLOWUP_CREATED",
         "terminal_success": true,
+        "reason": "Azure DevOps PR publication requires manual handling in this scenario.",
         "required_next_action": "Create an Azure Repos PR manually.",
         "evidence_used": ["provider=AzureDevOps", "change_requests=ManualRequired"]
     }));
@@ -354,6 +358,42 @@ fn terminal_transition_rejects_success_when_change_requests_are_manual() {
         result
             .terminal_reason
             .contains("change_requests=ManualRequired cannot be terminal_success=true")
+    );
+}
+
+#[test]
+fn non_success_terminal_transition_requires_loud_actionable_evidence() {
+    let result = validate_terminal_transition(json!({
+        "provider": "Manual",
+        "terminal_state": "MANUAL_REQUIRED",
+        "terminal_success": false,
+        "reason": "",
+        "required_next_action": "",
+        "evidence_used": []
+    }));
+
+    assert_eq!(result.terminal_state, TerminalState::FailedInvalidEvidence);
+    assert!(!result.terminal_success);
+    assert!(result.terminal_reason.contains("requires non-empty reason"));
+    assert!(!result.required_next_action.is_empty());
+}
+
+#[test]
+fn success_terminal_transition_requires_explicit_provider_capability_context() {
+    let result = validate_terminal_transition(json!({
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "reason": "Workflow claims a PR was created.",
+        "required_next_action": "Monitor PR validation.",
+        "evidence_used": ["change_request.id=812"]
+    }));
+
+    assert_eq!(result.terminal_state, TerminalState::FailedInvalidEvidence);
+    assert!(!result.terminal_success);
+    assert!(
+        result
+            .terminal_reason
+            .contains("requires explicit provider evidence")
     );
 }
 

--- a/crates/amplihack-workflows/tests/provider_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/provider_contract_tests.rs
@@ -7,6 +7,7 @@ use amplihack_workflows::workflow_contract::{
     ChangeRequest, ChangeRequestKind, ChangeRequestStatus, HelperEnvelope, HelperOperation,
     ManualAction, ProviderCapabilities, ProviderCapabilityState, ProviderContext,
     ProviderOperationStatus, RepositoryIdentity, RepositoryProvider, TerminalState,
+    provider_capabilities, provider_default_next_action, provider_from_remote_url,
     validate_terminal_transition,
 };
 use serde_json::{Value, json};
@@ -134,6 +135,52 @@ fn provider_context_exposes_explicit_capability_states() {
     assert_eq!(value["capabilities"]["tracking_items"], "Automated");
     assert_eq!(value["capabilities"]["change_requests"], "ManualRequired");
     assert_eq!(value["status"], "ManualRequired");
+}
+
+#[test]
+fn provider_capability_defaults_are_provider_neutral_and_explicit() {
+    let github = provider_capabilities(RepositoryProvider::GitHub);
+    assert_eq!(github.change_requests, ProviderCapabilityState::Automated);
+    assert_eq!(github.stale_cleanup, ProviderCapabilityState::Automated);
+
+    let azdo = provider_capabilities(RepositoryProvider::AzureDevOps);
+    assert_eq!(azdo.tracking_items, ProviderCapabilityState::Automated);
+    assert_eq!(
+        azdo.change_requests,
+        ProviderCapabilityState::ManualRequired
+    );
+    assert!(
+        provider_default_next_action(RepositoryProvider::AzureDevOps).contains("manually"),
+        "Azure DevOps change-request automation must not be implied where unavailable"
+    );
+
+    let manual = provider_capabilities(RepositoryProvider::Manual);
+    assert_eq!(
+        manual.tracking_items,
+        ProviderCapabilityState::ManualRequired
+    );
+    assert_eq!(
+        manual.change_requests,
+        ProviderCapabilityState::ManualRequired
+    );
+}
+
+#[test]
+fn provider_detection_from_remote_urls_falls_back_to_manual_for_unknowns() {
+    assert_eq!(
+        provider_from_remote_url(Some("https://github.com/acme/service.git")),
+        RepositoryProvider::GitHub
+    );
+    assert_eq!(
+        provider_from_remote_url(Some("https://dev.azure.com/acme/project/_git/service")),
+        RepositoryProvider::AzureDevOps
+    );
+    assert_eq!(provider_from_remote_url(None), RepositoryProvider::Manual);
+    assert_eq!(
+        provider_from_remote_url(Some("ssh://git.example.invalid/acme/service")),
+        RepositoryProvider::Manual,
+        "unknown remotes must require manual provider handling instead of pretending GitHub automation exists"
+    );
 }
 
 #[test]

--- a/crates/amplihack-workflows/tests/provider_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/provider_contract_tests.rs
@@ -295,6 +295,69 @@ fn terminal_transition_fails_closed_when_manual_provider_path_claims_success() {
 }
 
 #[test]
+fn terminal_transition_rejects_manual_provider_followup_success_claims() {
+    let result = validate_terminal_transition(json!({
+        "provider": "Manual",
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "required_next_action": "Create a provider change request manually.",
+        "evidence_used": ["provider=Manual"]
+    }));
+
+    assert_eq!(result.terminal_state, TerminalState::FailedInvalidEvidence);
+    assert!(!result.terminal_success);
+    assert!(
+        result
+            .terminal_reason
+            .contains("Manual provider cannot be terminal_success=true")
+    );
+}
+
+#[test]
+fn terminal_transition_rejects_success_without_evidence() {
+    let result = validate_terminal_transition(json!({
+        "provider": "GitHub",
+        "capabilities": {
+            "change_requests": "Automated"
+        },
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "required_next_action": "Monitor PR validation.",
+        "evidence_used": []
+    }));
+
+    assert_eq!(result.terminal_state, TerminalState::FailedInvalidEvidence);
+    assert!(!result.terminal_success);
+    assert!(
+        result
+            .terminal_reason
+            .contains("requires non-empty evidence_used")
+    );
+}
+
+#[test]
+fn terminal_transition_rejects_success_when_change_requests_are_manual() {
+    let result = validate_terminal_transition(json!({
+        "provider": "AzureDevOps",
+        "capabilities": {
+            "change_requests": "ManualRequired"
+        },
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
+        "required_next_action": "Create an Azure Repos PR manually.",
+        "evidence_used": ["provider=AzureDevOps", "change_requests=ManualRequired"]
+    }));
+
+    assert_eq!(result.terminal_state, TerminalState::FailedInvalidEvidence);
+    assert!(!result.terminal_success);
+    assert!(
+        result
+            .terminal_reason
+            .contains("change_requests=ManualRequired cannot be terminal_success=true")
+    );
+}
+
+#[test]
 fn change_request_model_serializes_provider_neutral_pull_request_fields() {
     let change_request = ChangeRequest {
         kind: ChangeRequestKind::PullRequest,

--- a/crates/amplihack-workflows/tests/provider_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/provider_contract_tests.rs
@@ -1,0 +1,179 @@
+//! TDD contract tests for provider-neutral workflow domain models.
+//!
+//! These tests intentionally describe the target `amplihack-workflows` API
+//! before implementation exists.
+
+use amplihack_workflows::workflow_contract::{
+    ChangeRequest, ChangeRequestKind, ChangeRequestStatus, HelperEnvelope, HelperOperation,
+    ManualAction, ProviderCapabilities, ProviderCapabilityState, ProviderContext,
+    ProviderOperationStatus, RepositoryIdentity, RepositoryProvider, TerminalState,
+    validate_terminal_transition,
+};
+use serde_json::{Value, json};
+
+#[test]
+fn terminal_states_emit_canonical_screaming_snake_case() {
+    let serialized = serde_json::to_string(&TerminalState::FollowupCreated).unwrap();
+    assert_eq!(serialized, "\"FOLLOWUP_CREATED\"");
+
+    let manual = serde_json::to_string(&TerminalState::BlockedManualProvider).unwrap();
+    assert_eq!(manual, "\"BLOCKED_MANUAL_PROVIDER\"");
+}
+
+#[test]
+fn terminal_states_accept_legacy_names_but_normalize_on_output() {
+    let legacy: TerminalState = serde_json::from_str("\"ManualRequired\"").unwrap();
+    assert_eq!(legacy, TerminalState::ManualRequired);
+    assert_eq!(
+        serde_json::to_string(&legacy).unwrap(),
+        "\"MANUAL_REQUIRED\"",
+        "legacy Rust-style terminal names may parse, but emitted JSON is canonical"
+    );
+}
+
+#[test]
+fn manual_and_blocked_provider_states_are_not_terminal_success() {
+    assert!(!TerminalState::ManualRequired.is_success());
+    assert!(!TerminalState::BlockedManualProvider.is_success());
+    assert!(!TerminalState::HollowSuccess.is_success());
+    assert!(TerminalState::FollowupCreated.is_success());
+}
+
+#[test]
+fn helper_envelope_keeps_operation_data_nested_under_data() {
+    let envelope = HelperEnvelope::succeeded(
+        RepositoryProvider::GitHub,
+        HelperOperation::DetectProvider,
+        "No further provider setup is required.",
+        json!({
+            "repository": {
+                "remote_url": "https://github.com/acme/service.git",
+                "owner": "acme",
+                "name": "service",
+                "default_base": "main"
+            },
+            "capabilities": {
+                "tracking_items": "Automated",
+                "change_requests": "Automated",
+                "stale_cleanup": "Automated"
+            }
+        }),
+    );
+
+    let value = serde_json::to_value(envelope).unwrap();
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["provider"], "GitHub");
+    assert_eq!(value["operation"], "DetectProvider");
+    assert_eq!(value["status"], "Succeeded");
+    assert!(value["warnings"].as_array().unwrap().is_empty());
+    assert_eq!(
+        value["data"]["capabilities"]["change_requests"],
+        "Automated"
+    );
+    assert!(
+        value.get("tracking_item").is_none()
+            && value.get("change_request").is_none()
+            && value.get("manual_action").is_none(),
+        "operation-specific fields must not appear at helper-envelope top level"
+    );
+}
+
+#[test]
+fn azure_repos_change_request_publication_is_manual_not_fake_success() {
+    let manual = ManualAction {
+        action: "CreateAzureReposPullRequest".into(),
+        instructions: "Create an Azure Repos pull request from feat/auth-timeout to main.".into(),
+        required_inputs: vec!["source_branch".into(), "base_branch".into()],
+    };
+
+    let envelope = HelperEnvelope::manual_required(
+        RepositoryProvider::AzureDevOps,
+        HelperOperation::PublishChangeRequest,
+        "Create an Azure Repos pull request manually, then rerun status detection.",
+        json!({
+            "change_request": null,
+            "manual_action": manual
+        }),
+    );
+
+    let value = serde_json::to_value(envelope).unwrap();
+    assert_eq!(value["provider"], "AzureDevOps");
+    assert_eq!(value["status"], "ManualRequired");
+    assert_eq!(value["data"]["change_request"], Value::Null);
+    assert_eq!(
+        value["data"]["manual_action"]["action"],
+        "CreateAzureReposPullRequest"
+    );
+    assert!(
+        value["next_action"].as_str().unwrap().contains("manually"),
+        "manual provider states must include an actionable next_action"
+    );
+}
+
+#[test]
+fn provider_context_exposes_explicit_capability_states() {
+    let context = ProviderContext {
+        schema_version: 1,
+        provider: RepositoryProvider::AzureDevOps,
+        repository: RepositoryIdentity {
+            remote_url: Some("https://dev.azure.com/acme/project/_git/service".into()),
+            owner: "acme".into(),
+            name: "service".into(),
+            default_base: "main".into(),
+        },
+        capabilities: ProviderCapabilities {
+            tracking_items: ProviderCapabilityState::Automated,
+            change_requests: ProviderCapabilityState::ManualRequired,
+            stale_cleanup: ProviderCapabilityState::ManualRequired,
+        },
+        status: ProviderOperationStatus::ManualRequired,
+        next_action: "Create Azure Repos PRs manually for this provider.".into(),
+    };
+
+    let value = serde_json::to_value(context).unwrap();
+    assert_eq!(value["capabilities"]["tracking_items"], "Automated");
+    assert_eq!(value["capabilities"]["change_requests"], "ManualRequired");
+    assert_eq!(value["status"], "ManualRequired");
+}
+
+#[test]
+fn terminal_transition_fails_closed_when_manual_provider_path_claims_success() {
+    let result = validate_terminal_transition(json!({
+        "provider": "AzureDevOps",
+        "terminal_state": "MANUAL_REQUIRED",
+        "terminal_success": true,
+        "required_next_action": "Create an Azure Repos pull request manually.",
+        "evidence_used": [
+            "provider=AzureDevOps",
+            "change_requests=ManualRequired"
+        ]
+    }));
+
+    assert_eq!(result.terminal_state, TerminalState::FailedInvalidEvidence);
+    assert!(!result.terminal_success);
+    assert!(
+        result
+            .terminal_reason
+            .contains("MANUAL_REQUIRED cannot be terminal_success=true")
+    );
+}
+
+#[test]
+fn change_request_model_serializes_provider_neutral_pull_request_fields() {
+    let change_request = ChangeRequest {
+        kind: ChangeRequestKind::PullRequest,
+        id: "812".into(),
+        url: "https://github.com/acme/service/pull/812".into(),
+        state: ChangeRequestStatus::Open,
+        source_branch: "feat/provider-contract".into(),
+        base_branch: "main".into(),
+        head_sha: Some("1d2c3b4a".into()),
+    };
+
+    let value = serde_json::to_value(change_request).unwrap();
+    assert_eq!(value["kind"], "PullRequest");
+    assert_eq!(value["state"], "Open");
+    assert_eq!(value["source_branch"], "feat/provider-contract");
+    assert_eq!(value["base_branch"], "main");
+    assert_eq!(value["head_sha"], "1d2c3b4a");
+}

--- a/crates/amplihack-workflows/tests/recipe_simulation_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/recipe_simulation_contract_tests.rs
@@ -11,17 +11,17 @@ use amplihack_workflows::workflow_contract::{RepositoryProvider, TerminalState};
 use serde_json::json;
 
 #[test]
-fn azdo_manual_pr_scenario_returns_manual_required_without_github_or_pr_create_calls() {
+fn azdo_automated_pr_scenario_returns_followup_created_without_github_calls() {
     let scenario: RecipeSimulationScenario = serde_yaml::from_str(
         r#"
-name: azdo-work-item-manual-pr
+name: azdo-work-item-automated-pr
 recipe: default-workflow
 repo_fixture: tests/fixtures/workflows/repos/azdo-repo
 provider:
   kind: AzureDevOps
   capabilities:
     tracking_items: Automated
-    change_requests: ManualRequired
+    change_requests: Automated
     stale_cleanup: ManualRequired
 tools:
   git:
@@ -34,22 +34,22 @@ agents:
   finalizer:
     output:
       schema_version: 1
-      terminal_state: MANUAL_REQUIRED
-      terminal_success: false
+      terminal_state: FOLLOWUP_CREATED
+      terminal_success: true
       confidence: high
-      reason: "Azure Boards tracking succeeded and Azure Repos PR creation is manual."
-      required_next_action: "Create an Azure Repos pull request from the pushed branch."
+      reason: "Azure Boards tracking and Azure Repos PR creation succeeded."
+      required_next_action: "Monitor Azure Repos PR validation."
       hollow_success_detected: false
       evidence_used:
         - "provider=AzureDevOps"
-        - "change_requests=ManualRequired"
+        - "change_requests=Automated"
+        - "az.repos.pr.create"
 expect:
-  terminal_state: MANUAL_REQUIRED
-  terminal_success: false
+  terminal_state: FOLLOWUP_CREATED
+  terminal_success: true
   forbidden_calls:
     - gh.issue.create
     - gh.pr.create
-    - az.repos.pr.create
 "#,
     )
     .expect("scenario fixture should parse");
@@ -58,8 +58,8 @@ expect:
 
     assert_eq!(result.provider, RepositoryProvider::AzureDevOps);
     assert_eq!(result.status, SimulationStatus::Succeeded);
-    assert_eq!(result.terminal_state, TerminalState::ManualRequired);
-    assert!(!result.terminal_success);
+    assert_eq!(result.terminal_state, TerminalState::FollowupCreated);
+    assert!(result.terminal_success);
     assert_eq!(result.assertions.failed, 0);
     assert!(
         result
@@ -67,7 +67,7 @@ expect:
             .contains(&"az.boards.work-item.create".into())
     );
     assert!(!result.provider_calls.contains(&"gh.pr.create".into()));
-    assert!(!result.provider_calls.contains(&"az.repos.pr.create".into()));
+    assert!(result.provider_calls.contains(&"az.repos.pr.create".into()));
 }
 
 #[test]

--- a/crates/amplihack-workflows/tests/recipe_simulation_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/recipe_simulation_contract_tests.rs
@@ -1,0 +1,140 @@
+//! TDD contract tests for deterministic recipe simulation.
+//!
+//! Simulation uses fake providers, tools, and agents; no live GitHub, Azure
+//! DevOps, network, or model calls are allowed.
+
+use amplihack_workflows::simulation::{
+    ForbiddenCall, RecipeSimulation, RecipeSimulationScenario, SimulationAssertion,
+    SimulationStatus,
+};
+use amplihack_workflows::workflow_contract::{RepositoryProvider, TerminalState};
+use serde_json::json;
+
+#[test]
+fn azdo_manual_pr_scenario_returns_manual_required_without_github_or_pr_create_calls() {
+    let scenario: RecipeSimulationScenario = serde_yaml::from_str(
+        r#"
+name: azdo-work-item-manual-pr
+recipe: default-workflow
+repo_fixture: tests/fixtures/workflows/repos/azdo-repo
+provider:
+  kind: AzureDevOps
+  capabilities:
+    tracking_items: Automated
+    change_requests: ManualRequired
+    stale_cleanup: ManualRequired
+tools:
+  git:
+    status: clean
+  az:
+    boards_work_item_create:
+      id: "456"
+      url: "https://dev.azure.com/acme/project/_workitems/edit/456"
+agents:
+  finalizer:
+    output:
+      schema_version: 1
+      terminal_state: MANUAL_REQUIRED
+      terminal_success: false
+      confidence: high
+      reason: "Azure Boards tracking succeeded and Azure Repos PR creation is manual."
+      required_next_action: "Create an Azure Repos pull request from the pushed branch."
+      hollow_success_detected: false
+      evidence_used:
+        - "provider=AzureDevOps"
+        - "change_requests=ManualRequired"
+expect:
+  terminal_state: MANUAL_REQUIRED
+  terminal_success: false
+  forbidden_calls:
+    - gh.issue.create
+    - gh.pr.create
+    - az.repos.pr.create
+"#,
+    )
+    .expect("scenario fixture should parse");
+
+    let result = RecipeSimulation::run(scenario).expect("simulation should run");
+
+    assert_eq!(result.provider, RepositoryProvider::AzureDevOps);
+    assert_eq!(result.status, SimulationStatus::Succeeded);
+    assert_eq!(result.terminal_state, TerminalState::ManualRequired);
+    assert!(!result.terminal_success);
+    assert_eq!(result.assertions.failed, 0);
+    assert!(
+        result
+            .provider_calls
+            .contains(&"az.boards.work-item.create".into())
+    );
+    assert!(!result.provider_calls.contains(&"gh.pr.create".into()));
+    assert!(!result.provider_calls.contains(&"az.repos.pr.create".into()));
+}
+
+#[test]
+fn forbidden_provider_call_fails_simulation_even_if_terminal_state_matches() {
+    let scenario = RecipeSimulationScenario::from_json(json!({
+        "name": "azdo-forbidden-pr-create",
+        "recipe": "default-workflow",
+        "provider": {
+            "kind": "AzureDevOps",
+            "capabilities": {
+                "tracking_items": "Automated",
+                "change_requests": "ManualRequired",
+                "stale_cleanup": "ManualRequired"
+            }
+        },
+        "observed_calls": ["az.repos.pr.create"],
+        "expect": {
+            "terminal_state": "MANUAL_REQUIRED",
+            "terminal_success": false,
+            "forbidden_calls": ["az.repos.pr.create"]
+        }
+    }))
+    .expect("scenario should parse");
+
+    let error = RecipeSimulation::run(scenario)
+        .expect_err("forbidden calls must fail simulation immediately");
+
+    assert_eq!(
+        error.forbidden_call,
+        Some(ForbiddenCall("az.repos.pr.create".into()))
+    );
+}
+
+#[test]
+fn invalid_agent_json_fails_closed_as_finalizer_output_error() {
+    let scenario = RecipeSimulationScenario::from_json(json!({
+        "name": "agent-invalid-json",
+        "recipe": "default-workflow",
+        "provider": {
+            "kind": "GitHub",
+            "capabilities": {
+                "tracking_items": "Automated",
+                "change_requests": "Automated",
+                "stale_cleanup": "Automated"
+            }
+        },
+        "agents": {
+            "finalizer": {
+                "output_text": "done, looks good"
+            }
+        },
+        "expect": {
+            "terminal_state": "FAILED_FINALIZER_OUTPUT",
+            "terminal_success": false
+        }
+    }))
+    .expect("scenario should parse");
+
+    let result = RecipeSimulation::run(scenario).expect("simulation should complete fail-closed");
+    assert_eq!(result.terminal_state, TerminalState::FailedFinalizerOutput);
+    assert!(!result.terminal_success);
+    assert!(
+        result
+            .assertions
+            .items
+            .contains(&SimulationAssertion::AgentContractFailed(
+                "finalizer".into()
+            ))
+    );
+}

--- a/crates/amplihack-workflows/tests/recipe_simulation_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/recipe_simulation_contract_tests.rs
@@ -34,6 +34,11 @@ agents:
   finalizer:
     output:
       schema_version: 1
+      provider: AzureDevOps
+      capabilities:
+        tracking_items: Automated
+        change_requests: Automated
+        stale_cleanup: ManualRequired
       terminal_state: FOLLOWUP_CREATED
       terminal_success: true
       confidence: high

--- a/crates/amplihack-workflows/tests/stale_cleanup_contract_tests.rs
+++ b/crates/amplihack-workflows/tests/stale_cleanup_contract_tests.rs
@@ -1,0 +1,79 @@
+//! TDD contract tests for stale/superseded workflow change-request cleanup.
+
+use amplihack_workflows::stale_cleanup::{
+    CleanupAction, CleanupMode, CleanupPlan, CleanupPolicy, StaleChangeRequest,
+};
+use amplihack_workflows::workflow_contract::{
+    ChangeRequestKind, ChangeRequestStatus, RepositoryProvider,
+};
+
+#[test]
+fn dry_run_reports_superseded_workflow_owned_prs_without_mutation() {
+    let policy = CleanupPolicy {
+        provider: RepositoryProvider::GitHub,
+        mode: CleanupMode::DryRun,
+        workflow_label: "amplihack-workflow".into(),
+        superseded_by_label_prefix: "superseded-by:".into(),
+        minimum_age_hours: 48,
+    };
+    let candidates = vec![StaleChangeRequest {
+        kind: ChangeRequestKind::PullRequest,
+        id: "812".into(),
+        title: "Provider abstraction PR 1".into(),
+        state: ChangeRequestStatus::Open,
+        labels: vec!["amplihack-workflow".into(), "superseded-by:834".into()],
+        age_hours: 96,
+        has_unmerged_meaningful_diff: false,
+    }];
+
+    let plan = CleanupPlan::build(policy, candidates).expect("cleanup plan should build");
+
+    assert_eq!(plan.mode, CleanupMode::DryRun);
+    assert_eq!(plan.actions.len(), 1);
+    assert_eq!(
+        plan.actions[0].action,
+        CleanupAction::WouldCloseAsSuperseded
+    );
+    assert_eq!(plan.actions[0].change_request_id, "812");
+    assert_eq!(plan.mutations_executed, 0);
+}
+
+#[test]
+fn cleanup_refuses_unlabeled_or_meaningful_diff_candidates() {
+    let policy = CleanupPolicy {
+        provider: RepositoryProvider::GitHub,
+        mode: CleanupMode::Apply,
+        workflow_label: "amplihack-workflow".into(),
+        superseded_by_label_prefix: "superseded-by:".into(),
+        minimum_age_hours: 48,
+    };
+    let candidates = vec![
+        StaleChangeRequest {
+            kind: ChangeRequestKind::PullRequest,
+            id: "101".into(),
+            title: "User-owned PR".into(),
+            state: ChangeRequestStatus::Open,
+            labels: vec!["superseded-by:834".into()],
+            age_hours: 96,
+            has_unmerged_meaningful_diff: false,
+        },
+        StaleChangeRequest {
+            kind: ChangeRequestKind::PullRequest,
+            id: "102".into(),
+            title: "Workflow PR with remaining diff".into(),
+            state: ChangeRequestStatus::Open,
+            labels: vec!["amplihack-workflow".into(), "superseded-by:834".into()],
+            age_hours: 96,
+            has_unmerged_meaningful_diff: true,
+        },
+    ];
+
+    let plan = CleanupPlan::build(policy, candidates).expect("cleanup plan should build");
+
+    assert!(
+        plan.actions
+            .iter()
+            .all(|action| action.action == CleanupAction::Skip)
+    );
+    assert_eq!(plan.mutations_executed, 0);
+}

--- a/docs/DOCUMENTATION_GUIDELINES.md
+++ b/docs/DOCUMENTATION_GUIDELINES.md
@@ -73,6 +73,36 @@ Sprint progress: 80% complete
 
 ---
 
+### Rule 2b: Shared Workflow Docs Are Provider-Neutral
+
+**Principle**: General workflow documentation describes workflow concepts, not a
+single provider's implementation details.
+
+**Requirements**:
+
+- Use provider-neutral terms such as "tracking item" and "change request" in
+  shared workflow docs
+- Put GitHub issue, GitHub pull request, Azure Boards, and Azure Repos details in
+  provider-specific sections
+- Document manual and blocked provider states explicitly with `next_action`
+- Do not present Azure DevOps or unsupported-provider manual paths as completed
+  automation
+
+**Example - Good**:
+
+```markdown
+The workflow publishes a change request. GitHub uses a pull request through
+`gh`; Azure DevOps returns `ManualRequired` with an Azure Repos manual action.
+```
+
+**Example - Bad**:
+
+```markdown
+The workflow creates a PR with `gh pr create`.
+```
+
+---
+
 ### Rule 3: Ruthless Simplicity - Say More with Less
 
 **Principle**: The best documentation is the simplest that achieves understanding.

--- a/docs/concepts/multi-provider-workflow-architecture.md
+++ b/docs/concepts/multi-provider-workflow-architecture.md
@@ -1,120 +1,167 @@
-# Multi-Provider Workflow Architecture
+# Provider-Neutral Workflow Architecture
 
-> [Home](../index.md) > Concepts > Multi-Provider Workflow Architecture
+> [Home](../index.md) > Concepts > Provider-Neutral Workflow Architecture
 
-Explains the design decisions behind provider-aware workflow routing. For
-implementation details, see the
-[Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md).
+> [PLANNED - Implementation Pending]
+>
+> This concept page explains the target architecture for the provider-neutral
+> workflow feature. Helper commands named here are planned implementation
+> surfaces.
 
----
+Amplihack workflows use a provider-neutral domain contract for tracking items,
+change requests, publication, stale cleanup, and terminal state. Recipes do not
+hard-code GitHub or Azure DevOps command logic. They call typed helper commands,
+consume structured JSON, and let provider adapters translate the domain contract
+to the active repository host.
 
-## The Problem
+## Contents
 
-Workflow tracking and publication steps need provider-specific commands.
-GitHub repositories use GitHub Issues and GitHub pull requests. Azure DevOps
-repositories use Azure Boards or local tracking and require manual PR creation.
-Local or unsupported repositories need local tracking without provider network
-calls.
+- [The model](#the-model)
+- [Provider boundary](#provider-boundary)
+- [Deterministic helpers](#deterministic-helpers)
+- [Agentic judgment with validation](#agentic-judgment-with-validation)
+- [Provider states](#provider-states)
+- [Why this shape](#why-this-shape)
+- [Related documentation](#related-documentation)
 
----
+## The model
 
-## Detect-Once, Branch-Everywhere
+The pure `amplihack-workflows` domain layer owns provider-neutral concepts:
 
-The core pattern: **one detection step** early in the workflow writes a
-`remote_host_type` context variable. Every downstream step reads it and
-branches to the correct code path.
+| Concept | Meaning |
+| --- | --- |
+| `RepositoryProvider` | The classified host for the repository: GitHub, Azure DevOps, local, or unsupported. |
+| `TrackingItem` | A provider issue, Azure Boards work item, or local workflow reference. |
+| `ChangeRequest` | A reviewable change such as a GitHub pull request, Azure Repos pull request, or manual change request. |
+| `ProviderOperation` | A deterministic action such as detect provider, create tracking item, publish change request, query status, or clean stale work. |
+| `TerminalState` | The explicit final workflow state, including success, blocked, manual, and failure states. |
 
+The CLI owns adapters because adapters depend on host tools and credentials:
+
+```text
+recipe YAML
+  -> amplihack workflow <helper> --format json
+  -> amplihack-cli provider adapter
+  -> amplihack-workflows domain model
+  -> structured JSON result
+  -> deterministic recipe validation
 ```
-Step 02d (once) → remote_host_type = "github" | "azdo" | "other"
-    ↓
-Steps 03, 03b, 15, 16, 21 → case $REMOTE_HOST_TYPE in ...
+
+## Provider boundary
+
+The provider boundary is narrow. Recipes pass repository context and task data to
+helper commands; helpers return JSON with stable field names.
+
+| Provider | Automated behavior | Manual or blocked behavior |
+| --- | --- | --- |
+| GitHub | Issues, pull requests, PR status, merge status, and stale/superseded cleanup through `gh` when authenticated. | Missing `gh` or auth returns `BlockedManualProvider` with `next_action`. |
+| Azure DevOps | Azure Boards work item reuse/create when `az` is configured. | Azure Repos PR publication and cleanup return `ManualRequired`; `default-workflow` does not automate `az repos pr create` or Azure Repos cleanup mutation. Missing Boards support returns local tracking or `BlockedManualProvider`, depending on the requested operation. |
+| Local or unsupported | Local tracking references and local Git evidence only. | Publication and remote cleanup return `ManualRequired` with a provider-neutral next action. |
+
+Adapters never pretend a provider action succeeded. When live automation is not
+available, the serialized result is explicit:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ManualRequired",
+  "provider": "AzureDevOps",
+  "operation": "CreateChangeRequest",
+  "next_action": "Create an Azure Repos pull request from feat/auth-timeout to main and include AB#12345 in the description.",
+  "warnings": [],
+  "data": {
+    "change_request": null,
+    "manual_action": {
+      "kind": "CreateChangeRequest",
+      "source_branch": "feat/auth-timeout",
+      "base_branch": "main",
+      "tracking_item_ref": "AB#12345"
+    }
+  }
+}
 ```
 
-**Why not adapters?** An adapter/strategy pattern would add a layer of
-indirection (provider interface, factory, registration) for three simple
-`case` branches. The bash `case` statement is self-documenting, testable in
-isolation, and avoids the indirection that would make recipe YAML harder to
-read. If a fourth provider is added in the future, the cost of adding
-another `case` branch is lower than maintaining an adapter registry.
+## Deterministic helpers
 
----
+Stable parsing and decision logic lives in typed Rust helpers instead of inline
+shell snippets. Recipes call these helpers and validate their JSON.
 
-## The Tracking Identifier Contract
+| Helper | Deterministic responsibility |
+| --- | --- |
+| `amplihack workflow detect-provider` | Normalize the Git remote and classify the provider. |
+| `amplihack workflow tracking-item ensure` | Reuse or create a tracking item, or return local/manual state. |
+| `amplihack workflow change-request publish` | Publish or describe the required manual publication action. |
+| `amplihack workflow change-request status` | Query provider status and normalize it into `ChangeRequestStatus`. |
+| `amplihack workflow terminal-state` | Validate final workflow evidence and emit one terminal state. |
+| `amplihack workflow cleanup-stale` | Dry-run or apply stale/superseded cleanup through the provider abstraction. |
+| `amplihack workflow validate-agent-contract` | Validate structured agentic step output against a named contract. |
+| `amplihack workflow simulate-recipe` | Run deterministic recipe simulations with fake providers, tools, and agents. |
 
-Remote providers produce the same output shape: a plain integer `issue_number`.
-Local tracking produces an opaque local reference instead. This keeps GitHub and
-Azure DevOps behavior stable while avoiding the false claim that a local ID is a
-remote issue number.
+Shell remains useful for orchestration glue, but not for durable parsing rules,
+provider classification, terminal-state decisions, stale cleanup decisions, or
+agent-output validation.
 
-| Provider | Source | Workflow identifier |
-| -------- | ------ | ------------------- |
-| GitHub | `gh issue create` URL | `issue_number=684` |
-| AzDO | `az boards` work item ID | `issue_number=12345` |
-| Other/Local | Structured local metadata | `tracking_reference=local-482193`, `issue_number=` |
+## Agentic judgment with validation
 
-Step 03b applies numeric extraction only after it has found no local-prefixed
-tracking reference. Branch names, commit messages, and PR descriptions use
-provider-specific formatting at the point of use: `Closes #684` for GitHub,
-`AB#12345` for AzDO, and `Ref local-482193` for local tracking.
+Judgment-heavy work stays agentic. Examples include finalization assessment,
+review-readiness interpretation, stale/superseded classification, and choosing a
+next action when provider metadata is incomplete.
 
----
+Those steps must return a deterministic validation contract:
 
-## PR Creation Asymmetry
+```json
+{
+  "schema_version": 1,
+  "decision": "Superseded",
+  "confidence": "high",
+  "reason": "PR #812 has the same workflow scope and newer head SHA.",
+  "required_next_action": "Close PR #791 as superseded by PR #812.",
+  "evidence_used": [
+    "scope.repository",
+    "scope.head_branch",
+    "candidate_pr.head_sha",
+    "candidate_pr.created_at"
+  ]
+}
+```
 
-GitHub PR creation is fully automated via `gh pr create`. AzDO PR creation
-is logged as manual instructions rather than automated. This asymmetry
-exists because:
+The recipe succeeds only after deterministic validation accepts the JSON schema,
+known enum values, confidence rules, required evidence, and provider-safe next
+action. Free-form prose is diagnostic text; it cannot prove success.
 
-1. `gh pr create` handles draft PRs, labels, reviewers, and closing
-   keywords in a single command. `az repos pr create` requires separate
-   calls for reviewers and labels.
-2. AzDO repository IDs must be resolved separately — they are not
-   derivable from the remote URL alone.
-3. The AzDO CLI's error messages for misconfigured projects are opaque,
-   making automated recovery difficult.
+## Provider states
 
----
+Provider helpers use these stable state values:
 
-## Other/Local Metadata Rationale
+| State | Meaning |
+| --- | --- |
+| `Succeeded` | The provider operation completed and returned durable evidence. |
+| `NoOp` | Nothing needed to change, and the reason is explicit. |
+| `ManualRequired` | Automation is intentionally unavailable; `next_action` tells the operator what to do. |
+| `BlockedManualProvider` | The provider path is blocked by missing credentials, permissions, tooling, or unsupported API behavior. |
+| `Failed` | The operation failed and cannot be treated as terminal success. |
 
-The `other` host type is not an error state — it is a first-class mode that
-enables the workflow to run in isolated environments (CI containers,
-air-gapped systems, fresh `git init` repos). Other/local mode:
+`ManualRequired` and `BlockedManualProvider` are not success-shaped fallbacks.
+They are auditable terminal or intermediate states that downstream recipes must
+surface in final output.
 
-- Emits structured local metadata such as `tracking_system=local`,
-  `tracking_reference=local-*`, and `issue_creation=local-tracking`; the
-  local-prefixed reference is required for successful local extraction
-- Skips all network calls (no `gh`, no `az`)
-- Produces valid branch names and commit messages without numeric issue
-  extraction
-- Skips PR creation (no remote to push to)
+## Why this shape
 
----
+The architecture keeps the simple parts simple and the judgment-heavy parts
+adaptable:
 
-## Trade-offs
+| Decision | Benefit |
+| --- | --- |
+| Pure domain layer | Provider concepts are tested without live GitHub or Azure DevOps calls. |
+| CLI-owned adapters | Host tools, auth, and filesystem access stay at the edge. |
+| Typed JSON helpers | Recipes consume stable contracts instead of parsing fragile command text. |
+| Agentic steps with schemas | Reasoning remains available without letting prose drive workflow state. |
+| Simulation tests | Success, failure, manual, and blocked paths are reproducible without external services. |
 
-| Decision                     | Benefit                            | Cost                                  |
-| ---------------------------- | ---------------------------------- | ------------------------------------- |
-| Detect-once pattern          | Single detection, no repeated work | One step to maintain                  |
-| `case` over adapters         | Simpler, no indirection            | Adding providers requires editing steps |
-| Remote issue_number contract | GitHub/AzDO steps stay unchanged | Local steps also need `tracking_reference` |
-| Other as fallback            | Works everywhere                   | No tracking system updated             |
-| Manual AzDO PR creation      | Avoids brittle automation          | Extra manual step for AzDO users       |
-| Context propagation required | Explicit data flow                 | Must declare vars in parent recipe     |
+## Related documentation
 
----
-
-## Related
-
-- [Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md) — full implementation details
-- [How to Use the Workflow with Azure DevOps](../howto/use-workflow-with-azure-devops.md) — task-oriented guide
-- [Step 03 Host-Aware Tracking Idempotency](../reference/recipe-step-03-idempotency.md) — GitHub, AzDO, and local tracking guards
-- [Workflow Issue Extraction](../reference/workflow-issue-extraction.md) — three-tier extraction
-
----
-
-**Metadata**
-
-| Field    | Value                              |
-| -------- | ---------------------------------- |
-| Contract | Provider-aware workflow routing    |
+- [Provider-Neutral Workflow Reference](../reference/workflow-provider-contract.md)
+- [Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md)
+- [Configure Provider-Neutral Workflows](../howto/configure-provider-neutral-workflows.md)
+- [Recipe Simulation Reference](../reference/workflow-simulation.md)
+- [Workflow Terminal-State Reference](../reference/workflow-terminal-state.md)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -33,7 +33,8 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
   preserve, validate, publish, and merge an already-implemented branch; includes
   the post-v0.9.77 issue-658 branch as the concrete example.
 - [Recipe Subprocess and Hook Input Contracts](../howto/validate-recipe-subprocess-hook-contract.md) — recipe-runner child environment and hook input compatibility contract; see the [recipe environment reference](../reference/recipe-executor-environment.md#recipe-runner-subprocess-launch) and [hook input contract](../reference/hook-specifications.md#hook-input-json-contract).
-- [Provider-Aware Workflow Tracking](dual-provider-workflow.md) — route workflow-prep tracking by GitHub, Azure DevOps, or local/unsupported remotes before provider issue commands run.
+- [Workflow Provider Abstraction](workflow-provider-abstraction.md) — provider-neutral tracking, change-request publication, terminal state, and stale cleanup through typed helpers and provider adapters.
+- [Provider-Aware Workflow Tracking](dual-provider-workflow.md) — compatibility entry point for the provider-neutral workflow contract.
 
 ## GitHub Distribution
 

--- a/docs/features/dual-provider-workflow.md
+++ b/docs/features/dual-provider-workflow.md
@@ -1,189 +1,38 @@
 # Provider-Aware Workflow Tracking
 
-**Host-aware issue tracking for `workflow-prep` and `default-workflow`.**
-
 > [Home](../index.md) > [Features](README.md) > Provider-Aware Workflow Tracking
 
-## Quick Navigation
+This page is the compatibility entry point for provider-aware workflow tracking.
+The current implementation is the provider-neutral workflow abstraction:
 
-- [How to configure provider-aware workflow tracking](../howto/configure-dual-provider-workflow.md)
-- [How to use the workflow with Azure DevOps](../howto/use-workflow-with-azure-devops.md)
-- [Tutorial: running the workflow on an Azure DevOps repository](../tutorials/dual-provider-workflow.md)
-- [Provider-aware workflow reference](../reference/dual-provider-workflow.md)
-- [Multi-provider workflow reference](../reference/multi-provider-workflow.md)
+- [Workflow Provider Abstraction](workflow-provider-abstraction.md)
+- [Provider-Neutral Workflow Architecture](../concepts/multi-provider-workflow-architecture.md)
+- [Provider-Neutral Workflow API](../reference/workflow-provider-contract.md)
+- [Configure Provider-Neutral Workflows](../howto/configure-provider-neutral-workflows.md)
 
----
+## What changed
 
-## What This Feature Does
+Provider-aware tracking no longer means recipe-local shell branches for GitHub
+and Azure DevOps. Recipes call typed `amplihack workflow ...` helpers and consume
+structured JSON.
 
-`workflow-prep` classifies the repository's `origin` remote before it tries to
-create or reuse a tracking item. The classification is stored as
-`REMOTE_HOST_TYPE` and is one of:
+| Concern | Current contract |
+| --- | --- |
+| Host detection | `amplihack workflow detect-provider` returns `GitHub`, `AzureDevOps`, `Local`, or `Unsupported`. |
+| Tracking items | `amplihack workflow tracking-item ensure` returns a provider-neutral `TrackingItem`. |
+| Change requests | `amplihack workflow change-request publish/status` returns `ChangeRequest`, `ManualRequired`, or `BlockedManualProvider`. |
+| Terminal state | `amplihack workflow terminal-state` emits explicit final states and next actions. |
+| Stale cleanup | `amplihack workflow cleanup-stale` dry-runs and applies through the provider abstraction. |
 
-| Host type | Repository remote | Tracking behavior |
-| --------- | ----------------- | ----------------- |
-| `github` | GitHub HTTPS or SSH remote | Use GitHub Issues through `gh issue` and GitHub labels through `gh label` |
-| `azdo` | Azure DevOps HTTPS, legacy `visualstudio.com`, or SSH remote | Use the Azure Boards/local-metadata path; never call GitHub issue or label commands |
-| `other` | Missing, local, malformed, GitLab, Bitbucket, or unsupported remote | Use structured local metadata; never call provider CLIs |
+## Provider behavior
 
-The key guarantee is provider isolation: **GitHub issue and label commands run
-only when `REMOTE_HOST_TYPE=github`**. Azure DevOps and other non-GitHub
-repositories never attempt `gh issue view`, `gh issue list`, `gh issue create`,
-or `gh label` setup.
+| Provider | Tracking behavior | Publication behavior |
+| --- | --- | --- |
+| GitHub | GitHub issues through the GitHub adapter. | GitHub pull requests through the GitHub adapter. |
+| Azure DevOps | Azure Boards when configured; local/manual/blocked state otherwise. | `ManualRequired`; Azure Repos PR creation is a manual action in the provider-neutral contract. |
+| Local | Local workflow reference. | `ManualRequired`. |
+| Unsupported | Manual or local state with provider-neutral next action. | `ManualRequired` or `BlockedManualProvider`. |
 
----
-
-## Supported Remote Forms
-
-The finished host detector must normalize the `origin` URL and match the
-remote host, not an arbitrary substring in a spoofable path.
-
-| Remote URL | Host type |
-| ---------- | --------- |
-| `https://github.com/OWNER/REPO.git` | `github` |
-| `git@github.com:OWNER/REPO.git` | `github` |
-| `ssh://git@github.com/OWNER/REPO.git` | `github` |
-| `https://dev.azure.com/ORG/PROJECT/_git/REPO` | `azdo` |
-| `https://ORG.visualstudio.com/PROJECT/_git/REPO` | `azdo` |
-| `git@ssh.dev.azure.com:v3/ORG/PROJECT/REPO` | `azdo` |
-| `ssh://git@ssh.dev.azure.com/v3/ORG/PROJECT/REPO` | `azdo` |
-| `https://gitlab.com/OWNER/REPO.git` | `other` |
-| `https://github.com.evil.example/OWNER/REPO.git` | `other` |
-| No `origin` remote | `other` |
-
----
-
-## Workflow Prep Routing
-
-`workflow-prep.yaml` performs provider dispatch before any provider command is
-run:
-
-```text
-step-02d-detect-host-type
-        |
-        v
-REMOTE_HOST_TYPE = github | azdo | other
-        |
-        v
-step-03-create-issue
-        |
-        +-- github -> gh issue view/list/create + gh label setup
-        +-- azdo  -> Azure Boards reuse/create, then local metadata if unavailable
-        +-- other -> structured local metadata
-```
-
-GitHub repositories keep the existing idempotent issue behavior: reuse a
-referenced issue, search for an open issue with a matching title, then create a
-new issue when needed.
-
-Azure DevOps repositories stay on the Azure Boards/local-metadata path. When an
-existing work item is supplied with `issue_number=N` or `AB#N`, the workflow
-reuses it. When Azure Boards is unavailable or cannot create a work item, the
-workflow emits structured local metadata instead of falling into GitHub logic.
-
-Other repositories always use structured local metadata.
-
-Local metadata is multiline step output, not a provider URL:
-
-```text
-tracking_system=local
-tracking_reference=local-482193
-tracking_issue=local-482193
-issue_creation=local-tracking
-issue_number=
-```
-
-For local tracking, `tracking_reference` and `tracking_issue` are the
-authoritative identifiers. `tracking_system=local` marks local mode, but Step
-03b succeeds only when a local-prefixed `tracking_reference` /
-`tracking_issue` or legacy `local-tracking:*` reference is present. Step 03b
-checks those references before numeric extraction, preserves the local
-reference, and leaves `issue_number` empty. Local IDs are never coerced into
-GitHub-style issue numbers.
-
----
-
-## Configuration Summary
-
-No provider flag is required for normal use. The workflow reads
-`git remote get-url origin` and routes automatically.
-
-| Repository type | Required tools |
-| --------------- | -------------- |
-| GitHub | `git`, authenticated `gh` |
-| Azure DevOps with Boards tracking | `git`, `az`, Azure DevOps extension, Azure Boards permissions |
-| Azure DevOps with local fallback | `git` |
-| Other/local | `git` |
-
-For large nested workflow runs, keep the project preference:
-
-```bash
-export NODE_OPTIONS=--max-old-space-size=32768
-```
-
----
-
-## Examples
-
-### GitHub repository
-
-```bash
-git remote set-url origin https://github.com/acme/service.git
-
-amplihack recipe run default-workflow \
-  -c task_description="Fix login timeout #684" \
-  -c repo_path=.
-```
-
-Expected routing:
-
-```text
-REMOTE_HOST_TYPE=github
-step-03-create-issue -> gh issue view/list/create
-```
-
-### Azure DevOps repository
-
-```bash
-git remote set-url origin https://dev.azure.com/acme/platform/_git/service
-
-amplihack recipe run default-workflow \
-  -c task_description="Fix login timeout in AB#12345" \
-  -c repo_path=.
-```
-
-Expected routing:
-
-```text
-REMOTE_HOST_TYPE=azdo
-step-03-create-issue -> Azure Boards/local tracking
-gh issue commands -> not invoked
-gh label commands -> not invoked
-```
-
-### Unsupported remote
-
-```bash
-git remote set-url origin https://gitlab.com/acme/service.git
-
-amplihack recipe run default-workflow \
-  -c task_description="Add config parser" \
-  -c repo_path=.
-```
-
-Expected routing:
-
-```text
-REMOTE_HOST_TYPE=other
-step-03-create-issue -> structured local metadata
-provider CLIs -> not invoked
-```
-
----
-
-## See Also
-
-- [Provider-aware workflow reference](../reference/dual-provider-workflow.md)
-- [Step 03 Host-Aware Tracking Idempotency](../reference/recipe-step-03-idempotency.md)
-- [Workflow Issue Extraction Reference](../reference/workflow-issue-extraction.md)
-- [Multi-Provider Workflow Architecture](../concepts/multi-provider-workflow-architecture.md)
+GitHub commands run only inside the GitHub adapter. Azure DevOps commands run
+only inside the Azure DevOps adapter. Local and unsupported providers do not call
+remote provider CLIs.

--- a/docs/features/dual-provider-workflow.md
+++ b/docs/features/dual-provider-workflow.md
@@ -18,8 +18,8 @@ structured JSON.
 
 | Concern | Current contract |
 | --- | --- |
-| Host detection | `amplihack workflow detect-provider` returns `GitHub`, `AzureDevOps`, `Local`, or `Unsupported`. |
-| Tracking items | `amplihack workflow tracking-item ensure` returns a provider-neutral `TrackingItem`. |
+| Host detection | `amplihack workflow detect-provider` returns `GitHub`, `AzureDevOps`, or `Manual`. |
+| Tracking items | Provider context exposes provider-neutral tracking capability state. |
 | Change requests | `amplihack workflow change-request publish/status` returns `ChangeRequest`, `ManualRequired`, or `BlockedManualProvider`. |
 | Terminal state | `amplihack workflow terminal-state` emits explicit final states and next actions. |
 | Stale cleanup | `amplihack workflow cleanup-stale` dry-runs and applies through the provider abstraction. |
@@ -28,11 +28,10 @@ structured JSON.
 
 | Provider | Tracking behavior | Publication behavior |
 | --- | --- | --- |
-| GitHub | GitHub issues through the GitHub adapter. | GitHub pull requests through the GitHub adapter. |
+| GitHub | GitHub issues through the GitHub adapter when configured. | GitHub pull requests through the GitHub adapter when configured; otherwise `ManualRequired`. |
 | Azure DevOps | Azure Boards when configured; local/manual/blocked state otherwise. | `ManualRequired`; Azure Repos PR creation is a manual action in the provider-neutral contract. |
-| Local | Local workflow reference. | `ManualRequired`. |
-| Unsupported | Manual or local state with provider-neutral next action. | `ManualRequired` or `BlockedManualProvider`. |
+| Manual | Manual or local workflow reference. | `ManualRequired` with provider-neutral next action. |
 
 GitHub commands run only inside the GitHub adapter. Azure DevOps commands run
-only inside the Azure DevOps adapter. Local and unsupported providers do not call
-remote provider CLIs.
+only inside the Azure DevOps adapter. Manual providers do not call remote
+provider CLIs.

--- a/docs/features/workflow-provider-abstraction.md
+++ b/docs/features/workflow-provider-abstraction.md
@@ -1,0 +1,108 @@
+# Workflow Provider Abstraction
+
+> [Home](../index.md) > [Features](README.md) > Workflow Provider Abstraction
+
+Workflow provider abstraction lets the same `default-workflow` run on GitHub,
+Azure DevOps, and explicit manual-provider paths without embedding provider
+logic in recipe shell steps.
+
+## What this feature does
+
+Amplihack separates workflow concepts from provider commands:
+
+| Layer | Responsibility |
+| --- | --- |
+| `amplihack-workflows` | Pure Rust workflow models, terminal states, provider capabilities, and transition rules. |
+| `amplihack-cli` | Provider adapters and `amplihack workflow ...` helper commands. |
+| Recipes | Orchestrate steps, call helpers, validate JSON, and keep judgment-heavy work agentic. |
+
+The result is provider-aware behavior without GitHub-only assumptions:
+
+- GitHub issue and pull-request operations use GitHub adapters.
+- Azure Boards operations use Azure DevOps adapters when configured.
+- Azure Repos pull-request publication returns `ManualRequired`; this design does
+  not automate `az repos pr create`.
+- Manual-provider paths return `ManualRequired` instead of calling the wrong
+  provider.
+- Terminal/finalization state is explicit in logs, recipe JSON, and workflow
+  output.
+
+## Quick start
+
+Run the workflow normally:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+
+amplihack recipe run default-workflow \
+  -c task_description="Fix authentication timeout" \
+  -c repo_path=. \
+  --format json
+```
+
+Inspect provider routing directly:
+
+```bash
+amplihack workflow detect-provider --repo . --format json
+```
+
+Example output:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "GitHub",
+  "operation": "DetectProvider",
+  "status": "Succeeded",
+  "next_action": "No further provider setup is required.",
+  "warnings": [],
+  "data": {
+    "capabilities": {
+      "tracking_items": "Automated",
+      "change_requests": "Automated",
+      "stale_cleanup": "Automated"
+    }
+  }
+}
+```
+
+## Helper commands
+
+The workflow helper surface is intentionally small:
+
+```bash
+amplihack workflow detect-provider --repo . --format json
+amplihack workflow change-request publish --provider github --source-branch feat/timeout --base-branch main --title "Fix timeout" --format json
+amplihack workflow change-request publish --provider azure-devops --source-branch feat/timeout --base-branch main --title "Fix timeout" --format json
+amplihack workflow terminal-state --terminal-state MANUAL_REQUIRED --format json
+amplihack workflow cleanup-stale --provider github --dry-run --format json
+amplihack workflow simulate-recipe default-workflow --scenario github-success --format json
+```
+
+Recipes consume these commands instead of parsing provider CLI text directly.
+
+## Provider behavior
+
+| Repository | Tracking item | Change request | Cleanup | Terminal output |
+| --- | --- | --- | --- | --- |
+| GitHub | Automated issue reuse/create | Automated pull request | Automated dry-run/apply through GitHub adapter | `Succeeded`, `BlockedManualProvider`, or a terminal failure state |
+| Azure DevOps | Azure Boards when configured; local/manual when unavailable | `ManualRequired`; no Azure Repos PR mutation in `default-workflow` | Dry-run/manual; no Azure Repos cleanup mutation in this design | `MANUAL_REQUIRED` or `BLOCKED_MANUAL_PROVIDER` with `next_action` |
+| Manual | Manual action | Manual publication action (`status=ManualRequired`) | No remote cleanup | Provider-neutral next action |
+
+## Agentic steps
+
+Adaptive tasks remain agentic when judgment is required. Examples:
+
+- deciding whether an old PR is superseded
+- classifying a final workflow state from several evidence sources
+- identifying the safest next action after provider metadata is incomplete
+
+Agentic steps must emit JSON contracts. Deterministic validators reject missing
+fields, unknown states, low-confidence success, and unsupported provider actions.
+
+## See also
+
+- [Provider-Neutral Workflow Architecture](../concepts/multi-provider-workflow-architecture.md)
+- [Provider-Neutral Workflow API](../reference/workflow-provider-contract.md)
+- [Configure Provider-Neutral Workflows](../howto/configure-provider-neutral-workflows.md)
+- [Recipe Simulation Reference](../reference/workflow-simulation.md)

--- a/docs/features/workflow-provider-abstraction.md
+++ b/docs/features/workflow-provider-abstraction.md
@@ -18,7 +18,8 @@ Amplihack separates workflow concepts from provider commands:
 
 The result is provider-aware behavior without GitHub-only assumptions:
 
-- GitHub issue and pull-request operations use GitHub adapters.
+- GitHub issue and pull-request operations use GitHub adapters when configured;
+  otherwise helpers return `ManualRequired` instead of fake success.
 - Azure Boards operations use Azure DevOps adapters when configured.
 - Azure Repos pull-request publication returns `ManualRequired`; this design does
   not automate `az repos pr create`.
@@ -85,7 +86,7 @@ Recipes consume these commands instead of parsing provider CLI text directly.
 
 | Repository | Tracking item | Change request | Cleanup | Terminal output |
 | --- | --- | --- | --- | --- |
-| GitHub | Automated issue reuse/create | Automated pull request | Automated dry-run/apply through GitHub adapter | `Succeeded`, `BlockedManualProvider`, or a terminal failure state |
+| GitHub | Automated issue reuse/create when configured | Automated pull request when configured; otherwise `ManualRequired` | Dry-run plan; apply requires a wired provider adapter or manual close action | `Succeeded`, `ManualRequired`, `BlockedManualProvider`, or a terminal failure state |
 | Azure DevOps | Azure Boards when configured; local/manual when unavailable | `ManualRequired`; no Azure Repos PR mutation in `default-workflow` | Dry-run/manual; no Azure Repos cleanup mutation in this design | `MANUAL_REQUIRED` or `BLOCKED_MANUAL_PROVIDER` with `next_action` |
 | Manual | Manual action | Manual publication action (`status=ManualRequired`) | No remote cleanup | Provider-neutral next action |
 

--- a/docs/features/workflow-runtime-isolation.md
+++ b/docs/features/workflow-runtime-isolation.md
@@ -4,8 +4,7 @@ Workflow runtime isolation keeps generated agent state, provenance, logs,
 metrics, reflection output, and workflow-owned nested worktrees out of commit
 worktrees.
 
-Status: Planned implementation contract.
-Updated: 2026-06-18
+Updated: 2026-06-19
 
 ## Contents
 
@@ -36,6 +35,11 @@ workflow-owned scratch worktrees
 The workflow isolates that output under a shared runtime root instead of writing
 it into the task worktree. The active Git worktree remains reserved for source
 changes that can be reviewed, staged, committed, pushed, and merged.
+
+Runtime isolation also scopes process state. Child recipes and agents inherit
+the top-level runtime root, run with explicit non-interactive environment
+variables, and record process/workstream identity under the runtime root instead
+of the commit worktree.
 
 ## Runtime root contract
 

--- a/docs/howto/cleanup-stale-workflow-prs.md
+++ b/docs/howto/cleanup-stale-workflow-prs.md
@@ -2,11 +2,6 @@
 
 > [Home](../index.md) > How-To > Clean Up Stale Workflow Change Requests
 
-> [PLANNED - Implementation Pending]
->
-> This guide describes the target stale-cleanup helper behavior. `amplihack
-> workflow cleanup-stale` is planned until implementation lands.
-
 Use stale cleanup to close or mark superseded workflow-owned change requests
 through the provider abstraction. Always run dry-run first.
 
@@ -21,7 +16,7 @@ Provider behavior:
 
 | Provider | Cleanup behavior |
 | --- | --- |
-| GitHub | Dry-run and apply can close superseded pull requests through `gh`. |
+| GitHub | Dry-run reports eligible superseded pull requests; apply requires a wired GitHub adapter or manual close action. |
 | Azure DevOps | Dry-run reports candidates; apply returns `ManualRequired` with an Azure Repos manual action. |
 | Local or unsupported | Reports local/manual next actions and does not mutate remote state. |
 

--- a/docs/howto/cleanup-stale-workflow-prs.md
+++ b/docs/howto/cleanup-stale-workflow-prs.md
@@ -1,0 +1,114 @@
+# Clean Up Stale Workflow Change Requests
+
+> [Home](../index.md) > How-To > Clean Up Stale Workflow Change Requests
+
+> [PLANNED - Implementation Pending]
+>
+> This guide describes the target stale-cleanup helper behavior. `amplihack
+> workflow cleanup-stale` is planned until implementation lands.
+
+Use stale cleanup to close or mark superseded workflow-owned change requests
+through the provider abstraction. Always run dry-run first.
+
+## Prerequisites
+
+```bash
+git status --short --branch
+amplihack workflow detect-provider --repo . --format json
+```
+
+Provider behavior:
+
+| Provider | Cleanup behavior |
+| --- | --- |
+| GitHub | Dry-run and apply can close superseded pull requests through `gh`. |
+| Azure DevOps | Dry-run reports candidates; apply returns `ManualRequired` with an Azure Repos manual action. |
+| Local or unsupported | Reports local/manual next actions and does not mutate remote state. |
+
+## 1. Run dry-run cleanup
+
+```bash
+amplihack workflow cleanup-stale \
+  --repo . \
+  --scope default-workflow \
+  --dry-run \
+  --format json > cleanup-dry-run.json
+```
+
+Inspect candidates:
+
+```bash
+jq '.data.candidates[] | {id, decision, action, replacement}' cleanup-dry-run.json
+```
+
+Example:
+
+```json
+{
+  "id": "791",
+  "decision": "Superseded",
+  "action": "CloseWithComment",
+  "replacement": "https://github.com/acme/service/pull/812"
+}
+```
+
+## 2. Apply cleanup
+
+Apply only after the dry-run output matches the intended cleanup:
+
+```bash
+amplihack workflow cleanup-stale \
+  --repo . \
+  --scope default-workflow \
+  --from-dry-run cleanup-dry-run.json \
+  --format json
+```
+
+The helper mutates provider state only when the scoped identity, supersession
+decision, provider capability, and dry-run candidate all match.
+
+## 3. Handle manual providers
+
+Azure DevOps and unsupported providers may return:
+
+```json
+{
+  "schema_version": 1,
+  "operation": "CleanupStale",
+  "status": "ManualRequired",
+  "provider": "AzureDevOps",
+  "next_action": "Close Azure Repos PR 791 as superseded by PR 812 and include the generated cleanup comment.",
+  "warnings": [],
+  "data": {
+    "manual_action": {
+      "kind": "CloseSupersededChangeRequest",
+      "id": "791",
+      "replacement": "812"
+    }
+  }
+}
+```
+
+Perform the provider action manually, then rerun dry-run. The candidate list
+should be empty or show `NoOp`.
+
+## Safety rules
+
+Cleanup never acts on broad search results alone. A candidate must match scoped
+workflow identity:
+
+- repository
+- source branch
+- base branch
+- workflow run or workstream identity
+- tracking item
+- replacement change request when superseded
+
+If scope is missing or ambiguous, cleanup returns `BlockedManualProvider` or
+`Failed` with `next_action`.
+
+## See also
+
+- [Provider-Neutral Workflow API](../reference/workflow-provider-contract.md#stale-cleanup-model)
+- [Scoped Workflow Closure](../concepts/scoped-workflow-closure.md)
+- [Recipe Simulation Reference](../reference/workflow-simulation.md)

--- a/docs/howto/configure-dual-provider-workflow.md
+++ b/docs/howto/configure-dual-provider-workflow.md
@@ -1,222 +1,34 @@
-# How to Configure Provider-Aware Workflow Tracking
+# Configure Provider-Aware Workflow Tracking
 
 > [Home](../index.md) > How-To > Configure Provider-Aware Workflow Tracking
 
-This guide shows how to configure `default-workflow` tracking for GitHub,
-Azure DevOps, and local or unsupported remotes.
+Provider-aware workflow tracking is configured through the provider-neutral
+workflow contract. Use the current guide:
 
----
+[Configure Provider-Neutral Workflows](configure-provider-neutral-workflows.md)
 
-## Prerequisites
+> [PLANNED - Implementation Pending]
+>
+> The `amplihack workflow ...` helper command shown here is the target
+> provider-neutral interface.
 
-All repositories need:
-
-```bash
-git --version
-git remote get-url origin
-```
-
-For large nested workflow runs, keep the supported Node heap setting:
+## Quick check
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
+amplihack workflow detect-provider --repo . --format json
 ```
 
----
+The output shows the repository provider and capability states for tracking
+items, change requests, and stale cleanup.
 
-## 1. Configure GitHub Repositories
+## Common provider setup
 
-Use a normal GitHub remote:
+| Provider | Setup |
+| --- | --- |
+| GitHub | Configure a GitHub remote and authenticate `gh`. |
+| Azure DevOps | Configure an Azure DevOps remote; configure `az` only when Azure Boards automation is required. |
+| Local or unsupported | No provider setup; workflow output names manual next actions. |
 
-```bash
-git remote set-url origin https://github.com/acme/service.git
-# or
-git remote set-url origin git@github.com:acme/service.git
-```
-
-Authenticate the GitHub CLI:
-
-```bash
-gh auth login
-gh auth status
-```
-
-Run the workflow:
-
-```bash
-amplihack recipe run default-workflow \
-  -c "task_description=Fix the authentication timeout bug" \
-  -c "repo_path=$(pwd)"
-```
-
-Expected behavior:
-
-```text
-REMOTE_HOST_TYPE=github
-workflow-prep step 03 uses gh issue view/list/create
-GitHub label setup is allowed
-```
-
----
-
-## 2. Configure Azure DevOps Repositories
-
-Use one of the supported AzDO remote forms:
-
-```bash
-git remote set-url origin https://dev.azure.com/acme/platform/_git/service
-# or
-git remote set-url origin https://acme.visualstudio.com/platform/_git/service
-# or
-git remote set-url origin git@ssh.dev.azure.com:v3/acme/platform/service
-```
-
-Azure Boards integration is optional. To allow work item reuse or creation,
-install and configure the Azure DevOps CLI extension:
-
-```bash
-az extension add --name azure-devops
-az login
-az devops configure --defaults \
-  organization=https://dev.azure.com/acme \
-  project=platform
-```
-
-Run the workflow:
-
-```bash
-amplihack recipe run default-workflow \
-  -c "task_description=Fix the authentication timeout bug in AB#12345" \
-  -c "repo_path=$(pwd)"
-```
-
-Expected behavior:
-
-```text
-REMOTE_HOST_TYPE=azdo
-workflow-prep step 03 uses Azure Boards or local tracking
-gh issue commands are not invoked
-gh label commands are not invoked
-```
-
-If Azure Boards is unavailable, the workflow emits structured local metadata
-instead of attempting a GitHub issue operation:
-
-```text
-tracking_system=local
-tracking_reference=local-12345
-tracking_issue=local-12345
-issue_creation=local-tracking
-issue_number=
-```
-
-The local reference is the durable identifier for that run. Step 03b preserves
-it only because the reference is local-prefixed, then leaves `issue_number`
-empty instead of converting `12345` into a GitHub issue number.
-
----
-
-## 3. Configure Local or Unsupported Repositories
-
-No provider configuration is required for missing, local-only, malformed, or
-unsupported remotes.
-
-```bash
-git remote remove origin
-
-amplihack recipe run default-workflow \
-  -c "task_description=Add config parser #482193" \
-  -c "repo_path=$(pwd)"
-```
-
-Expected behavior:
-
-```text
-REMOTE_HOST_TYPE=other
-workflow-prep step 03 emits structured local metadata
-provider CLIs are not invoked
-```
-
----
-
-## 4. Override Host Type for Follow-Up Work
-
-Normal runs should rely on automatic detection. Use an override only when an
-external workflow already knows the provider context.
-
-```bash
-amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c issue_number=12345 \
-  -c "task_description=Address review feedback for the Azure DevOps PR" \
-  -c "repo_path=$(pwd)"
-```
-
-Expected behavior:
-
-```text
-workflow-prep step 03 emits AB#12345
-no GitHub issue or label command runs
-```
-
-Use `remote_host_type=other` to force local tracking and block provider API
-calls. Local tracking uses `tracking_reference` / `tracking_issue`, not a
-numeric `issue_number`. `remote_host_type=azure-devops` remains accepted as a
-compatibility alias for external callers, but primary examples should use
-`azdo`.
-
----
-
-## Troubleshooting
-
-### AzDO remote is detected as `other`
-
-Check the exact `origin` URL:
-
-```bash
-git remote get-url origin
-```
-
-Supported AzDO hosts are:
-
-```text
-dev.azure.com
-visualstudio.com
-ssh.dev.azure.com
-```
-
-Unsupported or misspelled hosts intentionally use local tracking.
-
-### Workflow tries to create a GitHub issue in an AzDO repository
-
-That violates the provider isolation contract. Confirm the `origin` URL is one
-of the supported AzDO forms, then run the workflow from the repository root or
-pass `-c repo_path=/path/to/repo`.
-
-As a temporary workaround for follow-up work, pass:
-
-```bash
--c remote_host_type=azdo -c issue_number=<work-item-id>
-```
-
-### Azure Boards creation fails
-
-Azure CLI configuration is needed only when you want Azure Boards reuse or
-creation. Check it with:
-
-```bash
-az account show
-az extension list --query "[?name=='azure-devops'].version" -o tsv
-az devops configure --list
-```
-
-If Azure Boards remains unavailable, the workflow uses local tracking for the
-run and still avoids GitHub issue commands.
-
----
-
-## See Also
-
-- [Provider-aware workflow prep reference](../reference/dual-provider-workflow.md)
-- [How to Use the Default Workflow with Azure DevOps](use-workflow-with-azure-devops.md)
-- [Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md)
+For the full task-oriented guide, see
+[Configure Provider-Neutral Workflows](configure-provider-neutral-workflows.md).

--- a/docs/howto/configure-provider-neutral-workflows.md
+++ b/docs/howto/configure-provider-neutral-workflows.md
@@ -93,28 +93,24 @@ Expected provider behavior:
 ```text
 provider=AzureDevOps
 tracking_items=Automated when Azure Boards is configured
-change_requests=ManualRequired
+change_requests=Automated when Azure Repos is configured
 GitHub commands=not invoked
 ```
 
 When Azure Repos pull-request automation is unavailable, final output includes a
-manual action:
+blocked provider state:
 
 ```json
 {
   "schema_version": 1,
   "operation": "PublishChangeRequest",
-  "status": "ManualRequired",
+  "status": "BlockedManualProvider",
   "provider": "AzureDevOps",
-  "next_action": "Create an Azure Repos pull request from feat/auth-timeout to main and include AB#12345 in the description.",
-  "warnings": [],
+  "next_action": "Install or authenticate the Azure DevOps CLI and rerun publication.",
+  "warnings": ["Azure Repos PR creation failed or was unavailable."],
   "data": {
     "change_request": null,
-    "manual_action": {
-      "action": "CreateAzureReposPullRequest",
-      "instructions": "Create a pull request from feat/auth-timeout to main and include AB#12345 in the description.",
-      "required_inputs": ["source_branch", "base_branch", "title"]
-    }
+    "manual_action": null
   }
 }
 ```

--- a/docs/howto/configure-provider-neutral-workflows.md
+++ b/docs/howto/configure-provider-neutral-workflows.md
@@ -1,0 +1,205 @@
+# Configure Provider-Neutral Workflows
+
+> [Home](../index.md) > How-To > Configure Provider-Neutral Workflows
+
+Use this guide to configure `default-workflow` behavior for GitHub, Azure
+DevOps, or explicit manual-provider paths.
+
+## Prerequisites
+
+All repositories need Git:
+
+```bash
+git --version
+git remote get-url origin
+```
+
+Large nested workflow runs use the supported Node heap preference:
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
+
+## Check provider detection
+
+Run the provider detector from the repository root:
+
+```bash
+amplihack workflow detect-provider --repo . --format json
+```
+
+The `provider` field is one of `GitHub`, `AzureDevOps`, or `Manual`. The
+`capabilities` field shows whether tracking items, change
+requests, and stale cleanup are automated, manual, blocked, or unsupported.
+
+## Configure GitHub
+
+Use a GitHub remote:
+
+```bash
+git remote set-url origin https://github.com/acme/service.git
+gh auth login
+gh auth status
+```
+
+Run the workflow:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Fix authentication timeout" \
+  -c repo_path=. \
+  --format json
+```
+
+Expected provider behavior:
+
+```text
+provider=GitHub
+tracking_items=Automated
+change_requests=Automated
+stale_cleanup=Automated
+```
+
+## Configure Azure DevOps
+
+Use a supported Azure DevOps remote:
+
+```bash
+git remote set-url origin https://dev.azure.com/acme/platform/_git/service
+```
+
+Azure Boards integration is optional. Configure it when you want automated work
+item reuse or creation:
+
+```bash
+az extension add --name azure-devops
+az login
+az devops configure --defaults \
+  organization=https://dev.azure.com/acme \
+  project=platform
+```
+
+Run the workflow:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Fix authentication timeout in AB#12345" \
+  -c repo_path=. \
+  --format json
+```
+
+Expected provider behavior:
+
+```text
+provider=AzureDevOps
+tracking_items=Automated when Azure Boards is configured
+change_requests=ManualRequired
+GitHub commands=not invoked
+```
+
+When Azure Repos pull-request automation is unavailable, final output includes a
+manual action:
+
+```json
+{
+  "schema_version": 1,
+  "operation": "PublishChangeRequest",
+  "status": "ManualRequired",
+  "provider": "AzureDevOps",
+  "next_action": "Create an Azure Repos pull request from feat/auth-timeout to main and include AB#12345 in the description.",
+  "warnings": [],
+  "data": {
+    "change_request": null,
+    "manual_action": {
+      "action": "CreateAzureReposPullRequest",
+      "instructions": "Create a pull request from feat/auth-timeout to main and include AB#12345 in the description.",
+      "required_inputs": ["source_branch", "base_branch", "title"]
+    }
+  }
+}
+```
+
+## Configure manual-provider paths
+
+No provider setup is required.
+
+```bash
+git remote remove origin
+
+amplihack recipe run default-workflow \
+  -c task_description="Add config parser" \
+  -c repo_path=. \
+  --format json
+```
+
+Expected provider behavior:
+
+```text
+provider=Manual
+tracking_items=ManualRequired
+change_requests=ManualRequired
+remote cleanup=ManualRequired
+```
+
+Manual-provider paths use the same manual/blocked output pattern and never call
+GitHub or Azure DevOps commands accidentally.
+
+## Override provider context
+
+Normal runs should rely on detection. Use explicit context only when an external
+automation layer already knows the provider:
+
+```bash
+amplihack recipe run default-workflow \
+  -c provider=AzureDevOps \
+  -c tracking_item_ref=AB#12345 \
+  -c task_description="Address review feedback" \
+  -c repo_path=. \
+  --format json
+```
+
+Overrides are validated against the repository. A GitHub override on an Azure
+DevOps remote fails closed instead of routing provider commands to the wrong
+service.
+
+## Troubleshooting
+
+### Provider detection is unexpected
+
+Inspect the remote:
+
+```bash
+git remote get-url origin
+```
+
+If the host is misspelled, fix the remote or continue with explicit manual
+provider output. Do not route commands to a different provider just to force
+automation.
+
+### Azure DevOps work item creation is blocked
+
+Check Azure CLI setup:
+
+```bash
+az account show
+az extension list --query "[?name=='azure-devops'].version" -o tsv
+az devops configure --list
+```
+
+If this remains blocked, the workflow returns `BlockedManualProvider` or local
+tracking with a `next_action`; it does not fall back to GitHub issue commands.
+
+### Final output says `ManualRequired`
+
+Complete the provider action named in `next_action`, then rerun the relevant
+status or finalization command:
+
+```bash
+amplihack workflow terminal-state --terminal-state MANUAL_REQUIRED --format json
+```
+
+## See also
+
+- [Workflow Provider Abstraction](../features/workflow-provider-abstraction.md)
+- [Provider-Neutral Workflow API](../reference/workflow-provider-contract.md)
+- [Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md)

--- a/docs/howto/configure-workflow-runtime-isolation.md
+++ b/docs/howto/configure-workflow-runtime-isolation.md
@@ -3,8 +3,7 @@
 Use this guide to inspect, override, and troubleshoot where workflow runtime
 output is written.
 
-Status: Planned implementation contract.
-Updated: 2026-06-18
+Updated: 2026-06-19
 
 ## Contents
 

--- a/docs/howto/use-workflow-with-azure-devops.md
+++ b/docs/howto/use-workflow-with-azure-devops.md
@@ -1,195 +1,133 @@
-# How to Use the Default Workflow with Azure DevOps
+# Use Default Workflow with Azure DevOps
 
-> [Home](../index.md) > How-To > Use Workflow with Azure DevOps
+> [Home](../index.md) > How-To > Use Default Workflow with Azure DevOps
 
-Task-oriented guide for running `default-workflow` against an Azure DevOps
-repository. For design rationale, see
-[Multi-Provider Workflow Architecture](../concepts/multi-provider-workflow-architecture.md).
-For full reference, see
-[Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md).
+Use this guide to run `default-workflow` in an Azure DevOps repository. The
+workflow uses the provider-neutral abstraction, so Azure DevOps behavior is
+explicit and GitHub commands are never invoked for Azure DevOps remotes.
 
----
+> [PLANNED - Implementation Pending]
+>
+> The `amplihack workflow ...` helper commands shown here are the target
+> provider-neutral interface.
 
 ## Prerequisites
 
-1. **Git remote** named `origin` pointing to your AzDO repo:
+Set the project heap preference for nested workflow runs:
 
-   ```bash
-   git remote -v
-   # origin  https://dev.azure.com/myorg/myproject/_git/myrepo (fetch)
-   ```
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+```
 
-2. **Azure CLI** is optional. Install and configure it only when you want
-   Azure Boards work-item reuse or creation:
+Use an Azure DevOps remote:
 
-   ```bash
-   az --version
-   az extension add --name azure-devops
-   az login
-   az devops configure --defaults \
-     organization=https://dev.azure.com/YOUR_ORG \
-     project=YOUR_PROJECT
-   ```
+```bash
+git remote set-url origin https://dev.azure.com/acme/platform/_git/service
+```
 
-Without Azure CLI configuration, the workflow still detects `azdo`, skips all
-GitHub issue/label commands, and emits structured local metadata when step 03
-needs a tracking record.
+Configure Azure Boards only when you want automated work item reuse or creation:
 
----
+```bash
+az extension add --name azure-devops
+az login
+az devops configure --defaults \
+  organization=https://dev.azure.com/acme \
+  project=platform
+```
 
-## Run the Workflow with a New Work Item
+## Run with an existing work item
 
 ```bash
 amplihack recipe run default-workflow \
-  -c task_description="Add retry logic to API client" \
-  -c repo_path=.
+  -c task_description="Fix authentication timeout in AB#12345" \
+  -c repo_path=. \
+  --format json
 ```
 
-The workflow automatically:
+Expected provider result:
 
-1. Detects `azdo` as the remote host type (step 02d)
-2. Creates an AzDO work item of type `Task`, or emits local metadata if Azure Boards is unavailable (step 03)
-3. Uses `AB#N` commit references (step 15)
-4. Skips automated PR creation (step 16)
-5. Produces a host-aware summary (step 22b)
+```text
+provider=AzureDevOps
+tracking_item.display_ref=AB#12345
+change_request.status=ManualRequired
+```
 
-### Override the work item type
-
-By default, step 03 creates a `Task`. To use a different work item type,
-create the work item manually and pass its ID with `issue_number=N` or
-reference it via `AB#N` in the task description.
-
----
-
-## Run the Workflow with an Existing Work Item
-
-Use either an explicit `issue_number` context value or an `AB#N` reference in
-`task_description`. Step 03 keeps both forms inside the Azure DevOps branch and
-does not create a GitHub issue.
-
-### Explicit work item context
-
-Use this form for Azure DevOps PR follow-up work where the recipe context
-already contains a work item ID:
+## Run with a new work item
 
 ```bash
-amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c issue_number=12345 \
-  -c task_description="Address review feedback for the Azure DevOps PR" \
-  -c repo_path=.
+amplihack workflow tracking-item ensure \
+  --repo . \
+  --title "Fix authentication timeout" \
+  --body-file workflow-body.md \
+  --format json
 ```
 
-`remote_host_type=azdo` is the primary Azure DevOps value. `azure-devops` is
-accepted as a compatibility alias for external contexts. Step 03
-emits `AB#12345`, step 03b extracts `12345`, and downstream steps use
-Azure Boards references such as `AB#12345`. This explicit context form is
-trusted and does not require Azure CLI lookup before reuse.
+When Azure Boards is configured, the result contains an Azure Boards work item.
+When Azure Boards is unavailable, the helper returns local/manual or blocked
+state with `next_action`.
 
-### Work item reference in task text
+## Publish the change request
 
-Reference the work item number in `task_description`:
+The default Azure DevOps configuration reports manual PR creation:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "AzureDevOps",
+  "operation": "PublishChangeRequest",
+  "status": "ManualRequired",
+  "next_action": "Create an Azure Repos pull request from feat/auth-timeout to main and include AB#12345 in the description.",
+  "warnings": [],
+  "data": {
+    "change_request": null,
+    "manual_action": {
+      "kind": "CreateChangeRequest",
+      "source_branch": "feat/auth-timeout",
+      "base_branch": "main",
+      "tracking_item_ref": "AB#12345"
+    }
+  }
+}
+```
+
+Create the Azure Repos PR using the command or web UI named in `next_action`.
+After the PR exists, run terminal-state validation with the PR URL when needed:
 
 ```bash
-amplihack recipe run default-workflow \
-  -c task_description="Fix the auth bug described in AB#12345" \
-  -c repo_path=.
+amplihack workflow terminal-state \
+  --repo . \
+  --branch "$(git branch --show-current)" \
+  --base main \
+  --change-request-url "https://dev.azure.com/acme/platform/_git/service/pullrequest/456" \
+  --format json
 ```
-
-Because host dispatch has already selected Azure DevOps, a bare `#12345`
-inside the task description is also treated as an Azure Boards candidate rather
-than a GitHub issue. Task-text candidates may still require Azure CLI,
-organization, project, and work-item resolution before they are reused.
-
----
-
-## Percent-Encoded Project Names
-
-AzDO project names containing spaces (e.g., `My Project`) appear
-percent-encoded in remote URLs as `My%20Project`. Step 03 decodes `%XX`
-sequences before validation, so project names with spaces work correctly.
-
----
-
-## Differences from GitHub Workflow
-
-| Aspect              | GitHub                         | Azure DevOps                         |
-| ------------------- | ------------------------------ | ------------------------------------ |
-| Host detection      | step 02d → `github`            | step 02d → `azdo`                    |
-| Issue creation      | `gh issue create`              | `az boards work-item create`         |
-| Commit reference    | `Closes #N`                    | `AB#N`                               |
-| PR creation         | Automated (`gh pr create`)     | Skipped (create manually after)      |
-| Auth prerequisite   | `gh auth login`                | None for local metadata; `az login` + DevOps extension for Azure Boards |
-| Idempotency Guard 1 | `gh issue view`               | Explicit `issue_number` emits `AB#N`; task-text candidates may use `az boards work-item show` |
-| Existing `issue_number` | Reuses the supplied issue ID | Emits `AB#N`; no GitHub or Azure CLI lookup required |
-| Idempotency Guard 2 | `gh issue list --search`      | Host-isolated; no GitHub title search |
-| Summary (step 22b)  | `PR: <url>`                   | `PR: N/A (manual creation required)` |
-
----
-
-## Create a PR Manually
-
-After the workflow completes steps 1–15 (commit and push), create a PR
-using the Azure DevOps CLI:
-
-```bash
-az repos pr create \
-  --source-branch "$(git branch --show-current)" \
-  --target-branch main \
-  --title "feat: add retry logic (AB#12345)" \
-  --description "Implements retry logic per work item AB#12345"
-```
-
-Or use the Azure DevOps web UI to create the PR from the pushed branch.
-
----
 
 ## Troubleshooting
 
-**Host detected as `other` instead of `azdo`**
+### Provider is not Azure DevOps
 
-Verify the remote URL contains `dev.azure.com`, `visualstudio.com`, or
-`ssh.dev.azure.com`: `git remote get-url origin`. All three URL forms are
-detected:
+Run:
 
-- HTTPS: `https://dev.azure.com/org/project/_git/repo`
-- Legacy: `https://org.visualstudio.com/project/_git/repo`
-- SSH: `git@ssh.dev.azure.com:v3/org/project/repo`
+```bash
+amplihack workflow detect-provider --repo . --format json
+```
 
-If the workflow is launched from an external Azure DevOps context that already
-knows the host, pass `-c remote_host_type=azdo`. The `azure-devops` alias also
-routes to the same Azure Boards path for compatibility.
+Supported Azure DevOps hosts are `dev.azure.com`, `visualstudio.com`, and
+`ssh.dev.azure.com`.
 
-**Workflow tries to create or inspect a GitHub issue**
+### The workflow reports `BlockedManualProvider`
 
-That violates the provider isolation contract. Confirm that `origin` uses one
-of the supported Azure DevOps URL forms and that the workflow is running with
-the intended `repo_path`. For guaranteed reuse without Azure CLI lookup, pass
-the existing work item as `issue_number=N` with
-`remote_host_type=azdo`.
+Read `next_action`. Common causes are missing Azure CLI auth, missing Azure
+DevOps extension, missing project defaults, or insufficient permissions. Fix the
+provider setup and rerun the helper.
 
-Unknown or misspelled host values use local tracking rather than GitHub.
+### The workflow reports `ManualRequired`
 
-**`az boards` fails with authentication error**
+This is expected when the current provider path is intentionally manual. Perform
+the action in `next_action`, then rerun status or terminal-state validation.
 
-Run `az login` to refresh credentials. For PAT-based auth:
-`az devops login --organization https://dev.azure.com/YOUR_ORG`.
+## See also
 
-**Work item type not valid**
-
-List available types: `az boards work-item type list --project YOUR_PROJECT`.
-Type names are case-sensitive and vary by process template.
-
-**Project name with spaces not recognized**
-
-Ensure the remote URL uses standard percent-encoding (`%20` for spaces).
-Step 03 decodes these automatically. Invalid sequences like `%ZZ` are
-rejected and the workflow falls back to local tracking.
-
----
-
-**Metadata**
-
-| Field    | Value                                |
-| -------- | ------------------------------------ |
-| Contract | Azure DevOps workflow-prep routing   |
+- [Configure Provider-Neutral Workflows](configure-provider-neutral-workflows.md)
+- [Provider-Neutral Workflow API](../reference/workflow-provider-contract.md)
+- [Multi-Provider Workflow Reference](../reference/multi-provider-workflow.md)

--- a/docs/howto/use-workflow-with-azure-devops.md
+++ b/docs/howto/use-workflow-with-azure-devops.md
@@ -68,29 +68,33 @@ state with `next_action`.
 
 ## Publish the change request
 
-The default Azure DevOps configuration reports manual PR creation:
+The default Azure DevOps configuration uses Azure Repos PR automation when the
+`az` CLI and provider context are available:
 
 ```json
 {
   "schema_version": 1,
   "provider": "AzureDevOps",
   "operation": "PublishChangeRequest",
-  "status": "ManualRequired",
-  "next_action": "Create an Azure Repos pull request from feat/auth-timeout to main and include AB#12345 in the description.",
+  "status": "Succeeded",
+  "next_action": "Monitor Azure Repos PR validation.",
   "warnings": [],
   "data": {
-    "change_request": null,
-    "manual_action": {
-      "kind": "CreateChangeRequest",
+    "change_request": {
+      "kind": "PullRequest",
+      "id": "789",
+      "url": "https://dev.azure.com/acme/project/_git/service/pullrequest/789",
+      "state": "Open",
       "source_branch": "feat/auth-timeout",
-      "base_branch": "main",
-      "tracking_item_ref": "AB#12345"
-    }
+      "base_branch": "main"
+    },
+    "manual_action": null
   }
 }
 ```
 
-Create the Azure Repos PR using the command or web UI named in `next_action`.
+If Azure Repos automation is unavailable, the helper returns a blocked provider
+state with an explicit `next_action`; it must not report manual success.
 After the PR exists, run terminal-state validation with the PR URL when needed:
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -265,11 +265,14 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [Recipe Executor Environment](reference/recipe-executor-environment.md) - Step-level variables plus subprocess environment contract for forced non-interactive recipe execution
 - [Recipe Context Environment Export](reference/recipe-context-environment.md) - Export recipe context variables to bash steps (`$TASK_DESCRIPTION`, `$REPO_PATH`), uppercasing, reserved-name denylist, and precedence
 - [Tutorial: Propagate Recipe Context to Bash Steps](tutorials/recipe-context-env-propagation.md) - Read context from the environment under `set -u`, including nested sub-recipes and skipped keys
+- [Workflow Provider Abstraction](features/workflow-provider-abstraction.md) - Provider-neutral tracking, change-request publication, terminal state, and stale cleanup through typed helpers and adapters
+- [Configure Provider-Neutral Workflows](howto/configure-provider-neutral-workflows.md) - Configure GitHub, Azure DevOps, local, and unsupported workflow provider paths
+- [Provider-Neutral Workflow API](reference/workflow-provider-contract.md) - Rust domain models, helper JSON schemas, manual/blocked states, and validation contracts
+- [Recipe Simulation Reference](reference/workflow-simulation.md) - Deterministic fake-provider, fake-tool, and fake-agent workflow simulation contract
+- [Tutorial: Simulate Provider-Neutral Workflows](tutorials/provider-neutral-workflow-simulation.md) - Run and inspect a provider-neutral recipe simulation
+- [Clean Up Stale Workflow Change Requests](howto/cleanup-stale-workflow-prs.md) - Dry-run and apply stale/superseded cleanup through the provider abstraction
+- [CI Resource Discipline Reference](reference/ci-resource-discipline.md) - Concurrency, timeout, matrix, cache, and coverage boundaries for CI
 - [Validate Recipe Subprocess and Hook Input Contracts](howto/validate-recipe-subprocess-hook-contract.md) - Validate recipe child env handling and hook JSON compatibility
-- [Workflow Publish Import Validation](features/workflow-publish-import-validation.md) - Scoped publish import validation before commit/push
-- [How to Configure Workflow Publish Import Validation](howto/configure-workflow-publish-import-validation.md) - Review the manifest, root-boundary, and scoped-validator behavior
-- [Tutorial: Workflow Publish Import Validation](tutorials/workflow-publish-import-validation.md) - Walk through the scoped publish-validation flow
-- [Workflow Publish Import Validation Reference](reference/workflow-publish-import-validation.md) - Manifest format, root-resolution rules, and `--files-from` semantics
 - [Workflow Execution Guardrails](features/workflow-execution-guardrails.md) - Canonical execution roots, exact GitHub identity checks, and observer-only stall detection
 - [How to Configure Workflow Execution Guardrails](howto/configure-workflow-execution-guardrails.md) - Supply `expected_gh_account`, inspect `execution_root`, and troubleshoot failures
 - [Tutorial: Workflow Execution Guardrails](tutorials/workflow-execution-guardrails.md) - End-to-end walkthrough of the guarded workflow contract
@@ -290,9 +293,9 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [PR Recovery Readiness Reference](reference/pr-recovery-readiness.md) - Context fields, readiness evidence schema, publish contract, and finalization states
 - [Step 03 Host-Aware Tracking Idempotency](reference/recipe-step-03-idempotency.md) - GitHub issue, Azure Boards work-item, and local tracking reuse/create behavior
 - [Workflow Issue Extraction Reference](reference/workflow-issue-extraction.md) - Three-tier issue-number resolution (direct URL → PR closing-refs → `#N` verify) in step 03b
-- [Multi-Provider Workflow Reference](reference/multi-provider-workflow.md) - Provider detection, issue tracking, and PR routing for GitHub, AzDO, and local repos
+- [Multi-Provider Workflow Reference](reference/multi-provider-workflow.md) - Provider-neutral helper routing for GitHub, Azure DevOps, local, and unsupported repositories
 - [How to Use the Workflow with Azure DevOps](howto/use-workflow-with-azure-devops.md) - Run default-workflow against an AzDO repository
-- [Multi-Provider Workflow Architecture](concepts/multi-provider-workflow-architecture.md) - Design decisions: detect-once pattern, issue number contract, PR asymmetry
+- [Provider-Neutral Workflow Architecture](concepts/multi-provider-workflow-architecture.md) - Domain models, CLI-owned adapters, typed helpers, and agentic validation contracts
 - [Run a Quality Audit](howto/run-quality-audit.md) - Invoke quality-audit-cycle recipe, target subdirectories, filter categories
 - [CLI Reference](reference/cli.md) - Top-level `amplihack` command, `--version` flag, global environment variables
 - [Recipe CLI Reference](reference/recipe-cli-reference.md) - Complete command-line documentation

--- a/docs/operations/workflow-resilience.md
+++ b/docs/operations/workflow-resilience.md
@@ -1,5 +1,10 @@
 # Workflow Publish and Finalize Resilience
 
+> Compatibility note: this page now uses the provider-neutral workflow contract.
+> GitHub PR publication can be automated. Azure DevOps, local, and unsupported
+> change-request publication return explicit manual or blocked provider states
+> instead of success-shaped `non-github` output.
+
 `workflow-publish` and `workflow-finalize` classify already-terminal states
 before taking PR actions. Re-running a workflow after a merge, after an
 already-created PR, or on a branch with no diff produces a successful terminal
@@ -23,7 +28,7 @@ exposed these concrete failure modes:
 | Dirty worktree misclassification | Generated artifacts or unstaged edits are treated as harmless no-diff work. | Dirty worktree blocks success with `FAILED_DIRTY_WORKTREE`. |
 | Closed-unmerged PR handling | A closed PR without merge evidence is treated as completed while branch diff remains. | Finalization returns `FAILED_CLOSED_UNMERGED` unless local obsolete/no-diff proof supports `CLOSED_OBSOLETE`. |
 | Remaining meaningful diff | Branch changes remain but no valid PR, merge, follow-up, or verified implementation path proves closure. | Finalization returns `FAILED_MEANINGFUL_DIFF` rather than treating the branch as a no-op success. |
-| Missing tooling | Required `git`, `jq`, `gh`, or GitHub auth is unavailable on a path that depends on it. | Finalization returns `FAILED_MISSING_TOOLING` or `FAILED_PR_METADATA_UNAVAILABLE`; it does not silently skip required proof. |
+| Missing tooling | Required `git`, `jq`, provider CLI, or provider auth is unavailable on a path that depends on it. | Finalization returns `FAILED_MISSING_TOOLING`, `FAILED_PR_METADATA_UNAVAILABLE`, or `BLOCKED_MANUAL_PROVIDER`; it does not silently skip required proof. |
 | Failed CI | Open PR has failing required checks but final output looks complete. | Finalization returns `BLOCKED_CI` with failing check evidence and nonzero exit. |
 | Hollow success | Workflow exits after setup, design, empty agent output, or inaccessible-codebase messages. | Finalization returns `HOLLOW_SUCCESS` or `FAILED_MISSING_TERMINAL_EVIDENCE`. |
 
@@ -34,7 +39,8 @@ branch state.
 
 | State | Publish result |
 | --- | --- |
-| Non-GitHub host | Success with `state=non-github`; no `gh pr create` call. |
+| Azure DevOps host | `ManualRequired` with an Azure Repos pull-request action; no `gh pr create` or `az repos pr create` call. |
+| Local or unsupported host | `ManualRequired` with provider-neutral next action; no remote provider command. |
 | No branch diff against base | Success with `state=no-diff`; no PR is created. |
 | Existing open PR for the same head branch | Success with `state=existing-open-pr`; existing PR URL is returned. |
 | Existing merged PR for the same head branch | Success with `state=already-merged`; merged PR URL is returned. |
@@ -82,7 +88,8 @@ These context keys influence publish/finalize behavior:
 | Context key | Used by | Meaning |
 | --- | --- | --- |
 | `repo_path` | publish, finalize | Repository root to inspect. Defaults to the recipe working directory. |
-| `remote_host_type` | publish | Host classification. `github` enables GitHub PR handling; `azure-devops` and `local` skip GitHub publishing. `azure-devops` is the public value; implementations may accept `azdo` as a legacy alias but should normalize outputs to `azure-devops`. |
+| `provider_context` | publish, finalize | Structured provider helper result. `GitHub` enables GitHub PR handling; `AzureDevOps`, `Local`, and `Unsupported` use manual or blocked publication states. |
+| `remote_host_type` | publish | Legacy compatibility input. Implementations may accept `github`, `azure-devops`, `azdo`, or `local`, but must normalize to `provider_context` before provider operations. |
 | `branch_name` | publish, finalize | Current workflow branch or explicit branch to inspect. |
 | `base_branch` | publish, finalize | Base branch for diff checks. Defaults to the detected remote default branch. |
 | `pr_number` | finalize | Existing PR to finalize when known. |
@@ -170,7 +177,8 @@ or finalizer validation.
 | `FAILED_CLOSED_UNMERGED` | Agentic finalization found a closed PR without merge evidence and local meaningful diff remains. | Reopen, supersede with a follow-up branch, or remove/merge the diff before rerunning. |
 | `FAILED_MEANINGFUL_DIFF` | Local branch diff remains without accepted terminal publication, follow-up, no-op, or implementation-plus-verification evidence. | Publish the diff, create a durable follow-up, complete verification, or remove the unintended changes. |
 | `branch_diff_status=unknown` | Git could not determine a safe base/head diff. | Check remotes, fetch state, and branch name. |
-| `non_github_host` | The repository is Azure DevOps or local-only. | Use the provider-specific workflow path; GitHub PR creation is intentionally skipped. |
+| `MANUAL_REQUIRED` | The repository needs a provider action that this workflow does not automate, such as creating an Azure Repos pull request. | Perform the named manual action, then rerun status/finalization with the durable change-request URL. |
+| `BLOCKED_MANUAL_PROVIDER` | Required provider tooling, auth, permissions, or metadata is unavailable. | Fix the named blocker, then rerun the provider helper. |
 | `BLOCKED_CI` | Required checks are pending, failed, or unavailable when required. | Fix CI or wait for checks; terminal-state resilience does not bypass CI. |
 | `FAILED_FINALIZER_OUTPUT` | The agentic finalizer returned malformed, missing, or schema-invalid JSON. | Inspect the finalizer step output and rerun after fixing the prompt/schema/tooling path. |
 | `HOLLOW_SUCCESS` | The run looked successful but produced no implementation, verification, publish, or valid no-op evidence. | Resume `default-workflow` from the missing phase or emit a supported no-op state with evidence. |

--- a/docs/platform-bridge/README.md
+++ b/docs/platform-bridge/README.md
@@ -1,10 +1,20 @@
-# Platform Bridge - Multi-Platform Support for Git Workflows
+# Platform Bridge - Legacy Multi-Platform Support
 
-Automatic platform detection and unified interface fer GitHub and Azure DevOps operations in the `default-workflow` skill/recipe.
+> Compatibility note: this page documents the legacy platform bridge. New
+> `default-workflow` provider behavior is specified by the
+> [provider-neutral workflow API](../reference/workflow-provider-contract.md).
+> Recipes should call `amplihack workflow ... --format json` helpers, not this
+> bridge directly. Azure Repos pull-request publication is manual in the
+> provider-neutral workflow contract.
+
+Legacy automatic platform detection and unified interface fer selected GitHub
+and Azure DevOps operations.
 
 ## Quick Start
 
-The platform bridge automatically detects whether yer repository be hosted on GitHub or Azure DevOps and uses the appropriate CLI tools. No configuration needed, matey!
+The legacy bridge can detect whether yer repository be hosted on GitHub or Azure
+DevOps and use matching CLI tools. New workflow code should use the
+provider-neutral helpers instead.
 
 ```rust
 from claude.tools.platform_bridge import PlatformBridge
@@ -18,7 +28,8 @@ issue = bridge.create_issue(
     body="Implement JWT authentication"
 )
 
-# Create a draft pull request
+# Create a draft pull request through the legacy bridge only.
+# default-workflow does not automate Azure Repos PR creation.
 pr = bridge.create_draft_pr(
     title="feat: Add JWT auth",
     body="Implementation of authentication system",
@@ -35,7 +46,7 @@ Before the platform bridge, the legacy `DEFAULT_WORKFLOW.md` hardcoded GitHub-sp
 - Every workflow step required platform-specific instructions
 - Switching between GitHub and Azure DevOps projects required different workflows
 
-The platform bridge solves this by:
+The legacy platform bridge solved this by:
 
 - **Automatic Detection**: Examines `git remote` URLs to determine platform
 - **Unified Interface**: Single API that works fer both GitHub and Azure DevOps
@@ -44,18 +55,17 @@ The platform bridge solves this by:
 
 ## Core Capabilities
 
-The platform bridge supports provider operations used by workflow tooling.
-`default-workflow` currently automates GitHub PR creation only; Azure DevOps
-PR creation remains a manual post-workflow step unless a caller invokes the
-bridge directly.
+The platform bridge supports provider operations used by older workflow tooling.
+Provider-neutral workflow helpers supersede this direct bridge for
+`default-workflow`.
 
 | Operation       | GitHub Command         | Azure DevOps Command                 | Workflow Step |
 | --------------- | ---------------------- | ------------------------------------ | ------------- |
 | Create Issue    | `gh issue create`      | `az boards work-item create`         | Step 3        |
-| Create Draft PR | `gh pr create --draft` | `az repos pr create --draft`         | Direct bridge only for AzDO; not automatic in `default-workflow` |
-| Mark PR Ready   | `gh pr ready`          | `az repos pr update --status Active` | Step 20       |
-| Add PR Comment  | `gh pr comment`        | `az repos pr create-thread`          | Steps 16-17   |
-| Check CI Status | `gh pr checks`         | `az pipelines runs list`             | Step 21       |
+| Create Draft PR | `gh pr create --draft` | Legacy bridge only; not part of provider-neutral `default-workflow` | GitHub adapter only for automated workflow publication; AzDO manual action |
+| Mark PR Ready   | `gh pr ready`          | Legacy bridge only                   | GitHub adapter only for automated workflow paths |
+| Add PR Comment  | `gh pr comment`        | Legacy bridge only                   | GitHub adapter only for automated workflow paths |
+| Check CI Status | `gh pr checks`         | Legacy bridge only                   | GitHub adapter only for automated workflow paths |
 
 ## How Platform Detection Works
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -74,6 +74,8 @@ Complete documentation for using the Recipe Runner:
 - **[Recipe Context Environment Export](../reference/recipe-context-environment.md)** - How context variables reach bash steps as environment variables (`$TASK_DESCRIPTION`, `$REPO_PATH`), the reserved-name denylist, and precedence
 - **[Tutorial: Propagate Recipe Context to Bash Steps](../tutorials/recipe-context-env-propagation.md)** - Hands-on walkthrough for top-level, nested, and skipped keys
 - **[Recipe CLI Examples](cli-examples.md)** - Real-world usage scenarios (development, testing, CI/CD, team workflows)
+- **[Workflow Provider Abstraction](../features/workflow-provider-abstraction.md)** - Provider-neutral tracking, change requests, terminal state, and stale cleanup through typed helpers
+- **[Recipe Simulation Reference](../reference/workflow-simulation.md)** - Deterministic fake-provider, fake-tool, and fake-agent simulation for recipe regression coverage
 - **[Step 03 Host-Aware Tracking Idempotency](../reference/recipe-step-03-idempotency.md)** - GitHub issue, Azure Boards work-item, and local tracking reuse/create contract
 - **[Default Workflow Step 13 Validation](../reference/default-workflow-step-13-validation.md)** - Toolchain-aware outside-in local validation contract for the pre-commit gate
 - **[Workflow Terminal-State Reference](../reference/workflow-terminal-state.md)** - Target contract for development workflow completion evidence, no-op states, routed failure propagation, and `workflow_final_status.sh` API

--- a/docs/reference/ci-resource-discipline.md
+++ b/docs/reference/ci-resource-discipline.md
@@ -1,0 +1,106 @@
+# CI Resource Discipline Reference
+
+> [Home](../index.md) > Reference > CI Resource Discipline
+
+> [PLANNED - Implementation Pending]
+>
+> This page defines the CI resource contract to apply while implementing the
+> provider-neutral workflow feature. Existing workflows should be updated to match
+> this reference when PR 6 lands.
+
+CI workflows use explicit concurrency, timeout, matrix, and cache boundaries so
+required coverage remains reliable without wasting runner resources.
+
+## Concurrency
+
+Every workflow defines a concurrency group scoped to the workflow, ref, and pull
+request when available:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+Release workflows that publish immutable artifacts use `cancel-in-progress:
+false` for publish jobs and keep validation jobs cancellable.
+
+## Timeouts
+
+Jobs set explicit `timeout-minutes`. Long-running jobs split expensive setup,
+build, and test phases so failures report the constrained phase rather than
+timing out the whole workflow.
+
+| Job type | Typical timeout |
+| --- | --- |
+| Formatting and docs checks | 10 minutes |
+| Rust unit tests without heavy native backends | 30 minutes |
+| Workspace tests with native backends | 60 minutes |
+| Release packaging | 45 minutes per target |
+
+## Matrix boundaries
+
+Matrices cover meaningful compatibility dimensions only:
+
+- operating system support promised by the release
+- Rust stable toolchain used by the project
+- feature flags that change behavior materially
+- provider simulation scenarios that exercise distinct contracts
+
+Provider behavior is tested with deterministic simulation instead of live
+GitHub/Azure DevOps matrix jobs.
+
+## Cache boundaries
+
+Caches are keyed by dependency lockfiles, toolchain, operating system, and target
+where relevant. Cache restore is an optimization only; CI must pass from a cold
+cache.
+
+Rust build caches exclude workflow runtime output, provider fixture output, logs,
+and generated simulation artifacts.
+
+## Required coverage
+
+CI keeps required coverage while reducing avoidable resource use:
+
+| Surface | Required validation |
+| --- | --- |
+| Provider domain logic | Rust unit tests in `amplihack-workflows`. |
+| CLI provider adapters | Adapter tests with fake command runners. |
+| Recipe behavior | Deterministic recipe simulations. |
+| Runtime isolation | Tests or simulation proving runtime output stays outside commit worktrees. |
+| Terminal state | Unit tests plus representative recipe simulation paths. |
+| Documentation | Link and markdown checks used by the docs workflow. |
+
+## Repository workflow mapping
+
+Apply the resource contract to the existing workflow files:
+
+| Workflow file | Jobs | Required resource discipline |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | `check`, `test`, `install-smoke`, `cross-compile`, `release` | Add workflow/ref concurrency, job timeouts, cache keys scoped by target, and keep `test` using `cache-targets: false` for native-heavy workspace tests. |
+| `.github/workflows/docs.yml` | `build`, `deploy` | Keep docs-only path filters, add a 10-minute build timeout, and keep deploy dependent on strict build success. |
+| `.github/workflows/release.yml` | `version-bump`, `build`, `release` | Use non-cancellable publish sections, keep matrix bounded to release targets, and set per-job release timeouts. |
+| `.github/workflows/publish-snapshot.yml` | `cross-compile`, `release` | Keep Rust-only path filters, bound the target matrix to supported snapshot targets, and set packaging timeouts. |
+| `.github/workflows/atlas.yml` | `build-atlas` | Keep artifact retention explicit and add a docs/atlas scoped path filter when atlas generation becomes expensive. |
+| `.github/workflows/invisible-char-scan.yml` | `scan` | Keep safe base checkout, add timeout, and keep permissions read-only. |
+
+Provider-neutral workflow tests belong in `.github/workflows/ci.yml` as unit
+tests and deterministic simulations. Do not add live GitHub/Azure DevOps matrix
+jobs for provider behavior.
+
+## Implementation checklist
+
+1. Add or verify workflow-level concurrency for every workflow.
+2. Add `timeout-minutes` to every job.
+3. Keep Rust cache restore optional and keyed by lockfile, target, and runner.
+4. Keep provider simulations deterministic and offline.
+5. Ensure generated simulation and runtime artifacts are not cached or uploaded
+   unless explicitly needed for debugging.
+6. Keep release publishing non-cancellable once artifact publication starts.
+
+## See also
+
+- [Recipe Simulation Reference](workflow-simulation.md)
+- [Workflow Runtime Artifacts Reference](workflow-runtime-artifacts.md)
+- [Provider-Neutral Workflow API](workflow-provider-contract.md)

--- a/docs/reference/default-workflow-agentic-finalization.md
+++ b/docs/reference/default-workflow-agentic-finalization.md
@@ -64,7 +64,7 @@ Finalization has three phases.
 
 | Phase | Owner | Responsibility |
 | --- | --- | --- |
-| Evidence collection | Deterministic shell/JSON steps | Read Git status, branch/base diff, PR metadata when provider-safe, CI state, implementation and verification markers, publish result, prior recipe output, and observed phases. |
+| Evidence collection | Deterministic shell/JSON steps | Read Git status, branch/base diff, provider-safe change-request metadata, CI state, implementation and verification markers, publish result, prior recipe output, and observed phases. |
 | Terminal assessment | Structured agentic finalizer | Classify one terminal state from the evidence document, explain the reason, identify hollow success, and name the required next action. |
 | Validation and persistence | Deterministic shell/JSON steps | Validate the finalizer schema, reject missing or malformed output, enforce terminal-state evidence rules, persist normalized fields, and return the recipe exit status. |
 
@@ -80,7 +80,7 @@ failures. The agentic finalizer is designed around these concrete cases:
 | Failure mode | Observed cause | Required finalization behavior |
 | --- | --- | --- |
 | Brittle parsing | Shell snippets inferred completion from text fragments such as publish status strings, PR URLs, or partial command output. | Parse only structured JSON/key-value evidence. Free-form text may appear in `reason`, but cannot prove success. |
-| Missing or stale PR metadata | A stale `pr_number`, missing `pr_url`, mismatched head branch, stale head SHA, or unavailable `gh` metadata caused the wrong PR state to be trusted. | Validate PR identity against repo, branch, base, and head SHA. If the needed metadata is unavailable or mismatched, fail closed. |
+| Missing or stale change-request metadata | A stale provider ID, missing change-request URL, mismatched head branch, stale head SHA, or unavailable provider metadata caused the wrong state to be trusted. | Validate change-request identity against repo, branch, base, provider, and head SHA. If the needed metadata is unavailable or mismatched, fail closed. |
 | Dirty worktree misclassification | Generated files, unstaged edits, or leftover workflow artifacts were treated as harmless no-diff states. | Dirty worktree evidence blocks terminal success unless the workflow explicitly commits, removes, or accounts for the changes before finalization. |
 | Closed-unmerged PR handling | Closed PRs without merge evidence were sometimes treated like completed work even when branch diffs remained. | Return `CLOSED_OBSOLETE` only when local no-diff/obsolete proof exists; otherwise return a failing closed-unmerged state. |
 | Remaining meaningful diff | Branch changes remain but no valid publish, merge, follow-up, or implementation-plus-verification path proves closure. | Return `FAILED_MEANINGFUL_DIFF` unless the diff is intentionally represented by a validated PR/follow-up or another success state with deterministic proof. |
@@ -103,7 +103,7 @@ metadata, but the finalizer sees a single JSON object.
 | `branch_name` | string | Expected branch for the workflow-owned work. |
 | `base_ref` | string | Intended comparison base. |
 | `git` | object | Clean/dirty status, branch match, diff status, commits ahead, and base resolution details. |
-| `pr` | object | Provider, URL, number, state, merge evidence, head branch, base branch, head SHA, and identity-match booleans. Empty when no PR exists. |
+| `change_request` | object | Provider, URL, ID, state, merge evidence, source branch, base branch, head SHA, and identity-match booleans. Empty when no change request exists. |
 | `ci` | object | Required check state, failing checks, pending checks, and CI metadata availability. |
 | `implementation` | object | Whether code/docs/config work was applied and where that evidence came from. |
 | `verification` | object | Whether required tests, pre-commit, or validation completed and summaries of those checks. |
@@ -162,11 +162,13 @@ contradictory values, or unsupported success claims produce
 | `SUPERSEDED` | Yes | A newer workflow-owned PR or issue explicitly supersedes this run and durable metadata links the old run to the replacement. |
 | `IMPLEMENTED_VERIFIED` | Yes | Implementation and required verification completed on a path that does not require publish/merge evidence. |
 | `ALLOW_NO_OP` | Yes | Explicit no-op path was allowed and includes evidence-backed reason text. |
+| `MANUAL_REQUIRED` | No | A provider action is intentionally manual and the final output names the required next action. |
+| `BLOCKED_MANUAL_PROVIDER` | No | Provider tooling, credentials, permissions, or APIs block required automation. |
 | `BLOCKED_CI` | No | Required checks are failing, pending beyond policy, or unavailable when required. |
 | `FAILED_DIRTY_WORKTREE` | No | Uncommitted or untracked work prevents terminal success. |
 | `FAILED_MEANINGFUL_DIFF` | No | Meaningful branch changes remain but no validated publish, merge, follow-up, no-op, or implementation-plus-verification path proves closure. |
 | `FAILED_CLOSED_UNMERGED` | No | PR is closed without merge evidence and meaningful branch diff remains. |
-| `FAILED_PR_METADATA_UNAVAILABLE` | No | GitHub PR proof is required but metadata or auth is missing, stale, or ambiguous. |
+| `FAILED_PR_METADATA_UNAVAILABLE` | No | Provider change-request proof is required but metadata or auth is missing, stale, or ambiguous. |
 | `FAILED_MISSING_TOOLING` | No | Required deterministic tooling such as `git`, `jq`, or provider CLI support is missing for the selected path. |
 | `FAILED_INVALID_EVIDENCE` | No | Evidence is malformed, contradictory, unknown, or incomplete. |
 | `FAILED_FINALIZER_OUTPUT` | No | The agentic finalizer returned missing, malformed, non-JSON, or schema-invalid output. |
@@ -196,6 +198,8 @@ persisting or reporting the result.
    a durable replacement PR or issue identifier plus a supersession reason,
    `IMPLEMENTED_VERIFIED` needs implementation and verification evidence, and
    `ALLOW_NO_OP` needs explicit no-op authorization plus reason text.
+   `MANUAL_REQUIRED` and `BLOCKED_MANUAL_PROVIDER` require provider, operation,
+   and actionable next-action evidence and are never terminal success.
 8. Dirty worktree, invalid PR identity, failed CI, malformed evidence, and
    missing required tooling override success-looking output.
 9. The normalized result is persisted even for failure states so operators can
@@ -224,8 +228,10 @@ key/value outputs, but the field names and meanings are identical.
 | `publish_state_reached` | Normalized publish/PR/follow-up evidence. |
 | `terminal_no_op` | Whether the final state is an explicit no-op success. |
 | `terminal_failure` | `true` for all non-success terminal states. |
-| `pr_url` | PR URL when a validated PR or follow-up exists. |
-| `pr_number` | PR number when a validated GitHub PR exists. |
+| `change_request_url` | Provider change-request URL when a validated change request or follow-up exists. |
+| `change_request_id` | Provider change-request identifier when available. |
+| `pr_url` | GitHub compatibility URL when a validated GitHub PR or follow-up exists. |
+| `pr_number` | GitHub compatibility number when a validated GitHub PR exists. |
 
 ## Configuration
 

--- a/docs/reference/dual-provider-workflow.md
+++ b/docs/reference/dual-provider-workflow.md
@@ -2,302 +2,60 @@
 
 > [Home](../index.md) > Reference > Provider-Aware Workflow Prep
 
-Technical contract for host detection and tracking-item dispatch in
-`workflow-prep.yaml`.
+This compatibility reference points the old dual-provider workflow prep contract
+at the current provider-neutral workflow API.
 
-## Contents
+> [PLANNED - Implementation Pending]
+>
+> The helper commands shown here are the target provider-neutral interface.
 
-- [Overview](#overview)
-- [Host Detection API](#host-detection-api)
-- [Step 03 Tracking Dispatch](#step-03-tracking-dispatch)
-- [Command Isolation Contract](#command-isolation-contract)
-- [Configuration](#configuration)
-- [Outputs](#outputs)
-- [Local Metadata Contract](#local-metadata-contract)
-- [Examples](#examples)
-- [Regression Contract](#regression-contract)
+## Current contract
 
----
-
-## Overview
-
-`workflow-prep` detects the repository host once, before tracking setup. The
-detected host type determines whether step 03 may call GitHub, Azure Boards, or
-only local tracking.
-
-The public contract is the `remote_host_type` recipe context value and its shell
-counterpart `REMOTE_HOST_TYPE`.
-
-| Value | Meaning | Provider commands allowed |
-| ----- | ------- | ------------------------- |
-| `github` | The `origin` remote is hosted by GitHub | `gh issue`, `gh label`, later GitHub PR commands |
-| `azdo` | The `origin` remote is hosted by Azure DevOps | `az boards` in the Azure Boards branch only |
-| `other` | Missing, unsupported, malformed, or non-GitHub/non-AzDO remote | None |
-
-The classifier emits only `github`, `azdo`, or `other`. Downstream code may
-accept `azure-devops` as a compatibility alias from external recipe context,
-but step `02d` itself emits `azdo`.
-
----
-
-## Host Detection API
-
-### Step
-
-`workflow-prep.yaml::step-02d-detect-host-type`
-
-### Input
-
-| Input | Source | Description |
-| ----- | ------ | ----------- |
-| `repo_path` | Recipe context | Repository path where `origin` is inspected |
-| `origin` URL | `git remote get-url origin` | Remote URL to classify |
-
-### Output
-
-| Output | Values | Description |
-| ------ | ------ | ----------- |
-| `remote_host_type` | `github`, `azdo`, `other` | Host classifier result propagated by `default-workflow` |
-
-### Classification Rules
-
-The finished classifier lowercases and normalizes the remote URL before
-matching known host shapes.
-
-| Remote shape | Host type |
-| ------------ | --------- |
-| `https://github.com/OWNER/REPO.git` | `github` |
-| `git@github.com:OWNER/REPO.git` | `github` |
-| `ssh://git@github.com/OWNER/REPO.git` | `github` |
-| `https://dev.azure.com/ORG/PROJECT/_git/REPO` | `azdo` |
-| `https://ORG.visualstudio.com/PROJECT/_git/REPO` | `azdo` |
-| `git@ssh.dev.azure.com:v3/ORG/PROJECT/REPO` | `azdo` |
-| `ssh://git@ssh.dev.azure.com/v3/ORG/PROJECT/REPO` | `azdo` |
-| Empty, missing, unsupported, malformed, or local-only remote | `other` |
-
-The feature contract is host-aware matching. A URL such as
-`https://github.com.evil.example/OWNER/REPO.git` is classified as `other`, not
-`github`.
-
----
-
-## Step 03 Tracking Dispatch
-
-### Step
-
-`workflow-prep.yaml::step-03-create-issue`
-
-### Inputs
-
-| Context key | Required | Description |
-| ----------- | -------- | ----------- |
-| `repo_path` | Yes | Repository path used for local git and provider commands |
-| `task_description` | Yes | Task text used for title creation and existing reference extraction |
-| `final_requirements` | No | Requirements text included in new provider records when a provider record is created |
-| `remote_host_type` | No | Host routing value from step 02d; empty or unknown values are treated as `other` |
-| `issue_number` | No | Existing tracking ID; reused before provider create paths |
-
-### Dispatch Matrix
-
-| `REMOTE_HOST_TYPE` | Existing ID behavior | Create behavior | Fallback behavior |
-| ------------------ | -------------------- | --------------- | ----------------- |
-| `github` | Reuse `#N` after `gh issue view` validates it | `gh issue create`; label setup stays in this branch | Most GitHub creation errors fail; repository access/resolution failures fall back to local metadata |
-| `azdo` | Reuse `issue_number=N`, `AB#N`, or host-scoped `#N` as an Azure Boards candidate | `az boards work-item create` when Azure Boards is available | Structured local metadata |
-| `azure-devops` | Compatibility alias for `azdo` when supplied by callers | Same as `azdo` | Same as `azdo` |
-| `other`, empty, unknown | Preserve local tracking metadata when supplied | No provider creation | Structured local metadata |
-
-The Azure DevOps branch does not call GitHub first and then recover from the
-failure. It bypasses GitHub issue and label commands before those commands are
-constructed.
-
----
-
-## Command Isolation Contract
-
-Provider-specific commands are physically scoped to their provider branch.
-
-| Command family | Allowed host type | Forbidden host types |
-| -------------- | ----------------- | -------------------- |
-| `gh issue view` | `github` | `azdo`, `azure-devops`, `other`, empty, unknown |
-| `gh issue list` | `github` | `azdo`, `azure-devops`, `other`, empty, unknown |
-| `gh issue create` | `github` | `azdo`, `azure-devops`, `other`, empty, unknown |
-| `gh label list/create` | `github` | `azdo`, `azure-devops`, `other`, empty, unknown |
-| `az boards work-item show/create` | `azdo`, `azure-devops` | `github`, `other`, empty, unknown |
-
-This prevents task descriptions, branch names, local paths, and provider
-metadata from being sent to the wrong service.
-
----
-
-## Configuration
-
-### GitHub
+`workflow-prep` uses typed helper commands:
 
 ```bash
-gh auth status
-git remote get-url origin
-# https://github.com/OWNER/REPO.git
+amplihack workflow detect-provider --repo . --format json
+amplihack workflow tracking-item ensure --repo . --title "Fix timeout" --body-file body.md --format json
 ```
 
-No recipe flags are required.
+The old `remote_host_type` / `REMOTE_HOST_TYPE` shell context is a compatibility
+input only. New recipes consume provider JSON:
 
-### Azure DevOps
-
-Azure Boards integration is optional. If it is configured, the AzDO branch can
-reuse or create work items:
-
-```bash
-az extension add --name azure-devops
-az login
-az devops configure --defaults \
-  organization=https://dev.azure.com/ORG \
-  project=PROJECT
+```json
+{
+  "schema_version": 1,
+  "provider": "AzureDevOps",
+  "operation": "EnsureTrackingItem",
+  "status": "Succeeded",
+  "next_action": "Use AB#12345 in commits and change-request descriptions.",
+  "warnings": [],
+  "data": {
+    "tracking_item": {
+      "kind": "WorkItem",
+      "id": "12345",
+      "display_ref": "AB#12345"
+    }
+  }
+}
 ```
 
-If Azure Boards is unavailable, the AzDO branch emits local metadata and
-continues without invoking GitHub issue logic.
+## Provider isolation
 
-### Local or unsupported remotes
+Provider commands run only inside provider adapters:
 
-No provider configuration is required.
+| Provider | Allowed adapter commands |
+| --- | --- |
+| GitHub | GitHub issue and pull-request operations through `gh`. |
+| Azure DevOps | Azure Boards operations through `az` when configured. |
+| Local | No remote provider commands. |
+| Unsupported | No remote provider commands. |
 
-### Runtime preference
+Azure DevOps, local, and unsupported repositories do not fall back to GitHub
+commands. Missing automation returns `ManualRequired` or
+`BlockedManualProvider` with `next_action`.
 
-For large nested workflow runs:
+## Related documentation
 
-```bash
-export NODE_OPTIONS=--max-old-space-size=32768
-```
-
----
-
-## Outputs
-
-Step 03 writes provider output to stdout. For GitHub and Azure Boards success
-paths, that output is a single URL or `AB#N` reference. For local fallback, the
-output is multiline key/value metadata.
-
-| Host path | Step 03 output | Step 03b numeric ID |
-| --------- | -------------- | ------------------- |
-| GitHub | `https://github.com/OWNER/REPO/issues/123` | `123` |
-| Azure DevOps existing work item | `AB#12345` | `12345` |
-| Azure DevOps work item URL | `https://dev.azure.com/ORG/PROJECT/_workitems/edit/12345` | `12345` |
-| Local metadata | `tracking_system=local` plus `tracking_reference=local-482193`, `tracking_issue=local-482193`, `issue_creation=local-tracking`, and `issue_number=` | Empty; local reference is preserved instead |
-
-Downstream workflow steps consume numeric `issue_number` for GitHub and Azure
-DevOps. For local tracking, they consume `tracking_reference` /
-`tracking_issue`; `issue_number` is empty.
-
----
-
-## Local Metadata Contract
-
-Local fallback output is structured metadata:
-
-```text
-tracking_system=local
-tracking_reference=local-482193
-tracking_issue=local-482193
-issue_creation=local-tracking
-issue_number=
-```
-
-`tracking_reference` is the durable local identifier for the run. It may use
-`local-N`, `local-issue-N`, `local-ab-N`, or another `local-*` value.
-`tracking_system=local` is a mode marker, not a complete local reference by
-itself. Step 03b checks for a local-prefixed `tracking_reference` /
-`tracking_issue` before numeric extraction; when one is present, it preserves
-the local reference, emits an empty `issue_number`, and exits successfully.
-Numeric-looking local IDs are not GitHub issues and are not Azure Boards work
-item IDs.
-
-`local-tracking:N` is accepted as a legacy local reference format and is
-preserved as local tracking. Its numeric suffix is not copied to
-`issue_number`.
-
----
-
-## Examples
-
-### GitHub issue reuse
-
-```bash
-amplihack recipe run default-workflow \
-  -c task_description="Fix login timeout #684" \
-  -c repo_path=.
-```
-
-With a GitHub `origin`, step 03 may run:
-
-```text
-gh issue view 684
-gh issue list --state open --search ...
-gh issue create ...
-```
-
-### Azure DevOps work item reuse
-
-```bash
-amplihack recipe run default-workflow \
-  -c task_description="Fix login timeout in AB#12345" \
-  -c repo_path=.
-```
-
-With an AzDO `origin`, step 03 emits an Azure Boards reference or local
-tracking reference. It does not run any `gh issue` or `gh label` command.
-
-### Explicit AzDO context from a follow-up workflow
-
-```bash
-amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c issue_number=12345 \
-  -c task_description="Address review feedback for the Azure DevOps PR" \
-  -c repo_path=.
-```
-
-Step 03 emits:
-
-```text
-AB#12345
-```
-
-### Unsupported remote
-
-```bash
-git remote set-url origin https://gitlab.com/acme/service.git
-
-amplihack recipe run default-workflow \
-  -c task_description="Add config parser" \
-  -c repo_path=.
-```
-
-Step 03 emits:
-
-```text
-tracking_system=local
-tracking_reference=local-482193
-tracking_issue=local-482193
-issue_creation=local-tracking
-issue_number=
-```
-
----
-
-## Regression Contract
-
-Host-aware regression coverage exercises the `workflow-prep` path with shimmed
-remotes and provider CLIs.
-
-Required scenarios:
-
-| Scenario | Expected result |
-| -------- | --------------- |
-| GitHub HTTPS remote | GitHub issue idempotency/create path remains available |
-| AzDO `https://dev.azure.com/...` remote | No `gh issue` or `gh label` command is invoked |
-| AzDO `https://ORG.visualstudio.com/...` remote | No `gh issue` or `gh label` command is invoked |
-| AzDO `git@ssh.dev.azure.com:v3/...` remote | No `gh issue` or `gh label` command is invoked |
-| Unsupported remote | Local tracking is used without provider CLI calls; `tracking_reference` / `tracking_issue` propagate to downstream branch, commit, and status steps; local IDs are not coerced into `issue_number` |
-
-The AzDO tests use a `gh` sentinel that fails the test if any GitHub issue or
-label command is invoked.
+- [Provider-Neutral Workflow API](workflow-provider-contract.md)
+- [Multi-Provider Workflow Reference](multi-provider-workflow.md)
+- [Configure Provider-Neutral Workflows](../howto/configure-provider-neutral-workflows.md)

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -281,7 +281,7 @@ Expected provider behavior:
 ```text
 provider=AzureDevOps
 tracking_items=Automated when Azure Boards is configured
-change_requests=ManualRequired
+change_requests=Automated when Azure Repos is configured
 GitHub commands=not invoked
 ```
 

--- a/docs/reference/multi-provider-workflow.md
+++ b/docs/reference/multi-provider-workflow.md
@@ -2,524 +2,328 @@
 
 > [Home](../index.md) > Reference > Multi-Provider Workflow
 
-Reference for the multi-provider detection and routing logic in
-`default-workflow`. This feature enables the same 23-step workflow to operate
-against GitHub, Azure DevOps (AzDO), or a local/unknown repository without
-requiring the user to select a provider manually.
+> [PLANNED - Implementation Pending]
+>
+> This page is the target implementation reference for provider-neutral workflow
+> helpers. `amplihack workflow ...` commands are planned helper commands until
+> the feature implementation lands.
+
+`default-workflow` is provider-neutral. It supports GitHub, Azure DevOps, local,
+and unsupported repositories through typed workflow helper commands and provider
+adapters. Recipes do not inline provider parsing or infer success from shell
+output.
 
 ## Contents
 
 - [Overview](#overview)
-- [Host Detection (Step 02d)](#host-detection-step-02d)
-- [Issue Tracking by Provider](#issue-tracking-by-provider)
-- [Issue Extraction (Step 03b)](#issue-extraction-step-03b)
-- [Commit Message Formatting (Step 15)](#commit-message-formatting-step-15)
-- [PR Creation Routing (Step 16)](#pr-creation-routing-step-16)
-- [Worktree Resume Fix (Step 04)](#worktree-resume-fix-step-04)
-- [Final Status (Step 22b)](#final-status-step-22b)
-- [Context Variables](#context-variables)
-- [Diagnostics](#diagnostics)
-- [Error Handling](#error-handling)
-- [Configuration](#configuration)
+- [Provider detection](#provider-detection)
+- [Tracking items](#tracking-items)
+- [Change requests](#change-requests)
+- [Terminal state](#terminal-state)
+- [Recipe contract](#recipe-contract)
 - [Examples](#examples)
-- [Troubleshooting](#troubleshooting)
-- [Related](#related)
-
----
+- [Regression contract](#regression-contract)
+- [Related documentation](#related-documentation)
 
 ## Overview
 
-`default-workflow` uses a **detect-once, branch-everywhere** pattern for
-provider routing. Step `02d` runs in `workflow-prep` to classify the `origin`
-remote, and downstream steps consult the resulting `remote_host_type` context
-variable before running any provider-specific command.
-
-```
-git remote get-url origin
-        │
-        ▼
-┌──────────────────────────────────┐
-│  Step 02d: Host Type Detection    │
-│  github.com host      → "github"  │
-│  Azure DevOps host    → "azdo"    │
-│  everything else      → "other"   │
-└──────────────────────────────────┘
-        │
-        ▼
-  remote_host_type = "github" | "azdo" | "other"
-        │
-        ├─► Step 03:  issue creation (routed)
-        ├─► Step 03b: issue extraction (routed)
-        ├─► Step 15:  commit format (routed)
-        ├─► Step 16:  PR creation (routed)
-        ├─► Step 21:  PR readiness (routed)
-        └─► Step 22b: final status (routed)
-```
-
----
-
-## Host Detection (Step 02d)
-
-**Location**: `workflow-prep.yaml`, step `step-02d-detect-host-type`, after
-step `02c` (requirements clarification) and before step `03` (issue creation).
-
-**Target logic**:
-
-```bash
-REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
-NORMALIZED_REMOTE_URL=$(printf '%s' "$REMOTE_URL" | tr '[:upper:]' '[:lower:]')
-
-case "$NORMALIZED_REMOTE_URL" in
-  https://github.com/*|git@github.com:*|ssh://git@github.com/*)
-    REMOTE_HOST_TYPE="github" ;;
-  https://dev.azure.com/*|https://*.visualstudio.com/*|git@ssh.dev.azure.com:v3/*|ssh://git@ssh.dev.azure.com/v3/*)
-    REMOTE_HOST_TYPE="azdo" ;;
-  *)
-    REMOTE_HOST_TYPE="other" ;;
-esac
-```
-
-**Output**: `remote_host_type` — a plain string (`"github"`, `"azdo"`, or
-`"other"`) propagated to all downstream sub-recipes via the parent
-`default-workflow.yaml` context block. Step 02d only determines the host
-type; AzDO-specific URL parsing (organization, project) is performed by
-step 03 where the values are consumed.
-
-Step 02d emits `azdo` for Azure DevOps remotes. Downstream steps also accept
-`azure-devops` as an equivalent explicit override for contexts supplied by
-Azure DevOps PR/work-item follow-up workflows.
-
-The final detector must match complete host shapes. Substring-only matches are
-not sufficient because spoofed hosts such as `github.com.evil.example` must be
-classified as `other`.
-
-**Edge cases**:
-
-- No remote configured → `REMOTE_URL` is empty → `REMOTE_HOST_TYPE="other"`
-- Multiple remotes → only `origin` is checked (convention)
-- SSH URLs → explicit patterns match `git@github.com:`, `ssh://git@github.com/`,
-  `git@ssh.dev.azure.com:v3/`, and `ssh://git@ssh.dev.azure.com/v3/`
-- Not a git repo → step falls back to `"other"` before step 03 runs
-
----
-
-## Issue Tracking by Provider
-
-### GitHub (`remote_host_type = "github"`)
-
-Step 03 reads `$REMOTE_HOST_TYPE` from context (set by step 02d) and routes
-to the GitHub path. Uses `gh issue create` and `gh issue view` as before. No
-change from the existing behavior documented in
-[recipe-step-03-idempotency.md](recipe-step-03-idempotency.md).
-
-### Azure DevOps (`remote_host_type = "azdo"` or `"azure-devops"`)
-
-When `$REMOTE_HOST_TYPE` is `"azdo"` or `"azure-devops"`, step 03 routes to
-the Azure Boards path. It reuses an existing work item before attempting to
-create a new one.
-
-**Existing work item reuse**:
-
-| Input | Behavior |
-| ----- | -------- |
-| `issue_number=N` context value | Emits `AB#N` and exits 0 before GitHub commands, Azure CLI lookup, remote parsing, or work-item creation |
-| `task_description` contains `AB#N` | Treats `N` as an Azure Boards candidate; resolves a URL with `az boards work-item show` when available |
-| `task_description` contains `#N` | Treats `N` as an Azure Boards candidate because host dispatch already selected Azure DevOps |
-
-The Azure DevOps branch never calls `gh issue view`, `gh issue list`, or
-`gh issue create`. This prevents GitHub-specific issue logic from running in
-Azure DevOps repositories and keeps ADO PR follow-up work idempotent.
-
-If no existing work item is supplied, step 03 parses the remote URL to extract
-the AzDO organization and project names, then creates a work item.
-
-**AzDO URL parsing** (three URL forms):
-
-| URL form | Example | Regex |
-| -------- | ------- | ----- |
-| HTTPS    | `https://dev.azure.com/org/project/_git/repo` | `dev\.azure\.com/([^/]+)/([^/]+)/` |
-| Legacy   | `https://org.visualstudio.com/project/_git/repo` | `([^/.]+)\.visualstudio\.com/([^/]+)/` |
-| SSH      | `git@ssh.dev.azure.com:v3/org/project/repo` | `ssh\.dev\.azure\.com[:/]v3/([^/]+)/([^/]+)/` |
-
-**Percent-encoding**: AzDO project names may contain spaces, which appear as
-`%20` in URLs. Step 03 decodes `%XX` sequences before validation. The
-decoded name is validated against `^[a-zA-Z0-9._ -]+$` (note: spaces are
-permitted in decoded form). Invalid percent sequences (e.g., `%ZZ`) cause
-the step to fall back to local metadata with a warning.
-
-Step 03 creates the work item using the `az boards work-item create`
-CLI command:
-
-```bash
-az boards work-item create \
-  --org "$AZDO_ORG_URL" \
-  --project "$AZDO_PROJECT" \
-  --type "$WORK_ITEM_TYPE" \
-  --title "$ISSUE_TITLE" \
-  --description "$ISSUE_BODY"
-```
-
-**Work item type**: Defaults to `Task`. Users can create work items manually
-and pass `issue_number=N` or reference them via `AB#N` in the task description.
-
-The output is an AzDO work item URL:
-
-```
-https://dev.azure.com/myorg/myproject/_workitems/edit/12345
-```
-
-The host-aware idempotency contract is documented in
-[step-03-create-issue: Host-Aware Tracking Idempotency](recipe-step-03-idempotency.md).
-
-### Other/Local (`remote_host_type = "other"`)
-
-Step 03 emits structured local metadata without making any network calls:
+The workflow classifies the repository provider once, persists the provider
+context, and routes later provider operations through helper commands:
 
 ```text
-tracking_system=local
-tracking_reference=local-482193
-tracking_issue=local-482193
-issue_creation=local-tracking
-issue_number=
+amplihack workflow detect-provider
+        |
+        v
+ProviderContext { provider, repository, capabilities }
+        |
+        +-- tracking-item ensure
+        +-- change-request publish
+        +-- change-request status
+        +-- cleanup-stale
+        +-- terminal-state
 ```
 
-The local reference is an opaque workflow reference, not a durable provider
-record and not a global uniqueness guarantee. It is preserved as
-`tracking_reference` / `tracking_issue` for branch naming and local commit
-references. It is not coerced into a numeric `issue_number`. No tracking system
-is updated.
+Every helper emits JSON. Recipes validate the JSON schema before using it.
+Provider-specific tools such as `gh` and `az` run only inside the matching
+adapter.
 
----
-
-## Issue Extraction (Step 03b)
-
-Step 03b's extraction logic (documented in
-[workflow-issue-extraction.md](workflow-issue-extraction.md)) handles every
-provider output format produced by Step 03:
-
-| Provider | Output pattern | Extraction regex |
-| -------- | -------------- | ---------------- |
-| GitHub | `https://github.com/owner/repo/issues/N` | `issues/([0-9]+)` |
-| GitHub PR fallback | `https://github.com/owner/repo/pull/N` | `pull/([0-9]+)` plus closing-issue lookup |
-| Azure DevOps | `https://dev.azure.com/org/project/_workitems/edit/N` | `_workitems/edit/([0-9]+)` |
-| Azure DevOps | `AB#N` | `AB#([0-9]+)` |
-| Other/local | Structured local metadata with `tracking_system=local` plus `tracking_reference=local-*` / `tracking_issue=local-*`, or legacy `local-tracking:*` | Preserve local reference; leave `issue_number` empty |
-
-The remote `issue_number` output contract remains unchanged: GitHub and Azure
-DevOps produce a plain integer. Local tracking intentionally leaves
-`issue_number` empty and passes the local reference forward.
-
----
-
-## Commit Message Formatting (Step 15)
-
-Commit messages adapt their issue reference syntax based on
-`$REMOTE_HOST_TYPE`, consumed from the propagated context variable (set by
-step 02d, declared in the parent recipe's context block):
-
-| Host type | Format           | Example                           |
-| --------- | ---------------- | --------------------------------- |
-| `github`  | `Closes #N`      | `feat: add auth (Closes #684)`    |
-| `azdo`    | `AB#N`           | `feat: add auth (AB#12345)`       |
-| `azure-devops` | `AB#N`      | `feat: add auth (AB#12345)`       |
-| `other`   | `Ref <local-ref>` | `feat: add auth (Ref local-482193)` |
-
-The `Closes #N` format triggers GitHub's auto-close behavior. The `AB#N`
-format triggers Azure Boards work item linking. The local `Ref <local-ref>`
-format is a neutral reference that does not trigger automation on any platform.
-
----
-
-## PR Creation Routing (Step 16)
-
-| Host type | Tool                  | Behavior                                                |
-| --------- | --------------------- | ------------------------------------------------------- |
-| `github`  | `gh pr create`        | Unchanged from current behavior                          |
-| `azdo`    | (skipped)             | Exits early; user creates PR manually afterward      |
-| `azure-devops` | (skipped)        | Same behavior as `azdo`                                  |
-| `other`   | (skipped)             | Logs "no remote — skipping PR creation"                  |
-
-Step 16 consumes `$REMOTE_HOST_TYPE` from the propagated context variable
-(set by step 02d) rather than re-detecting the host type inline. Non-GitHub
-hosts exit early with an informational message. The PR body for GitHub uses
-the same host-aware reference format as step 15.
-
-**PR creation asymmetry**: GitHub PR creation is fully automated because `gh`
-supports draft PRs, labels, and reviewers in a single command. AzDO PR
-creation is skipped — the workflow exits step 16 early with an informational
-message on stderr. After the workflow completes, create a PR manually using
-`az repos pr create` or the Azure DevOps web UI (see the
-[How-To guide](../howto/use-workflow-with-azure-devops.md#create-a-pr-manually)).
-
----
-
-## Worktree Resume Fix (Step 04)
-
-The worktree setup step (`step-04-setup-worktree`) previously derived the
-working directory from the issue URL, which was always a GitHub URL. With
-multi-provider support, the worktree path derivation uses the provider tracking
-key and the slugified task description: numeric `issue_number` for GitHub/Azure
-DevOps, or `tracking_reference` / `tracking_issue` for local tracking. Local
-mode must not derive paths from an empty `issue_number`.
-
-See [recipe-step-04-worktree-reattach-prune.md](recipe-step-04-worktree-reattach-prune.md)
-for the full worktree lifecycle documentation.
-
----
-
-## PR Readiness (Step 21)
-
-Step 21 (`step-21-pr-ready`) calls `gh pr ready` and `gh pr comment` —
-GitHub-specific commands. Rather than checking `$REMOTE_HOST_TYPE` directly,
-step 21 guards on `$PR_URL`: if it is empty or whitespace-only, the step
-exits early with an informational message.
-
-This works because non-GitHub hosts never receive a `PR_URL`:
-
-- AzDO/`azure-devops`: step 16 skips automated PR creation → `PR_URL` stays empty
-- Other: step 16 skips entirely → `PR_URL` stays empty
-
-As defense-in-depth, step 21 checks `$REMOTE_HOST_TYPE` before `gh` calls to
-prevent failures if `PR_URL` is set to a non-GitHub URL through manual context
-override.
-
----
-
-## Final Status (Step 22b)
-
-Step 22b produces a host-aware summary. It checks both `PR_URL` (non-empty)
-and `REMOTE_HOST_TYPE` (equals `github`) before invoking any `gh` CLI
-commands.
-
-| Host type | PR status line                            | Issue reference line |
-| --------- | ----------------------------------------- | -------------------- |
-| `github`  | `PR: <url>` (with `gh pr view` details)   | `Issue: #N`          |
-| `azdo`    | `PR: N/A (manual creation required)`      | `Issue: AB#N`        |
-| `azure-devops` | `PR: N/A (manual creation required)` | `Issue: AB#N` |
-| `other`   | `PR: N/A (no remote provider)`            | `Issue: Ref <local-ref>` |
-
-The `HOST_TYPE=${REMOTE_HOST_TYPE:-other}` local variable pattern is used
-for `set -u` safety — if the context variable is unset for any reason, the
-step degrades to "other" behavior rather than failing.
-
----
-
-## Context Variables
-
-Variables added or modified by the multi-provider feature:
-
-| Variable             | Set by    | Type   | Description                                  |
-| -------------------- | --------- | ------ | -------------------------------------------- |
-| `remote_host_type`   | step-02d or caller | string | `"github"`, `"azdo"`, `"azure-devops"`, or `"other"` |
-| `azdo_org_url`       | step-03   | string | Full AzDO org URL (local to step-03; empty if not AzDO) |
-| `azdo_org`           | step-03   | string | AzDO organization name (local to step-03; empty if not AzDO) |
-| `azdo_project`       | step-03   | string | AzDO project name, percent-decoded (local to step-03; empty if not AzDO) |
-| `work_item_type`     | user/step-02 | string | AzDO work item type; default `"Task"`       |
-| `issue_number`       | step-03b  | int or empty string | Numeric GitHub/Azure DevOps ID; empty for local tracking |
-| `tracking_system`    | step-03/step-03b | string | `local` when the workflow is using local tracking |
-| `tracking_reference` | step-03/step-03b | string | Local-prefixed reference consumed by branch, commit, publish, and status steps |
-| `tracking_issue`     | step-03/step-03b | string | Local tracking alias preserved for compatibility with existing step naming |
-
-**Parent recipe declaration**: `remote_host_type`, `issue_number`,
-`tracking_system`, `tracking_reference`, and `tracking_issue` must be declared
-with empty-string defaults in `default-workflow.yaml`'s `context:` block. This
-is required for propagation to work across sub-recipe boundaries — without these
-declarations, the recipe-runner's `_execute_sub_recipe()` context-merging will
-not thread the values through to phases like `workflow-worktree`,
-`workflow-publish`, or `workflow-finalize`. The AzDO-specific variables
-(`azdo_org`, `azdo_project`, `azdo_org_url`) do NOT require parent declaration
-because they are local to step-03 within `workflow-prep`.
-
----
-
-## Diagnostics
-
-All diagnostic output goes to **stderr**. The table below is the expected
-diagnostic contract for the Issue #718 host-aware implementation; exact wording
-should not be treated as a stable public API.
-
-| Message                                                          | When                                     |
-| ---------------------------------------------------------------- | ---------------------------------------- |
-| `INFO: Remote host type: github`                                  | step-02d completed detection              |
-| `INFO: Remote host type: azdo`                                    | step-02d detected AzDO remote             |
-| `INFO: Remote host type: other`                                   | step-02d fallback (no remote/unknown)     |
-| `INFO: Reusing work item AB#N`                                    | step-03 reused an existing Azure Boards work item |
-| `INFO: Creating AzDO work item (org=X, project=Y, type=Task)`    | step-03 AzDO path                         |
-| `INFO: Non-GitHub remote (azdo) — skipping draft PR creation`     | step-16 non-GitHub path                   |
-| `INFO: PR_URL is empty ... — skipping gh pr ready`                | step-21 non-GitHub path                   |
-| `WARN: AZDO_PROJECT contains unexpected characters — falling back to local tracking` | step-03 validation failed  |
-| `WARN: az boards work-item create failed — falling back to local tracking`           | step-03 AzDO error fallback |
-| `WARN: Percent-decode failed for project name — falling back to local tracking`      | step-03 invalid `%XX` sequence |
-
----
-
-## Error Handling
-
-| Failure mode                          | Behavior                                          |
-| ------------------------------------- | ------------------------------------------------- |
-| `git remote get-url origin` fails     | `remote_host_type` = `"other"` (safe fallback)     |
-| `remote_host_type=azure-devops`       | Treated exactly like `azdo`                        |
-| Azure DevOps path has `issue_number`  | Reuses `AB#N`; does not call `gh` or create a work item |
-| `az boards` not installed             | Step-03 falls back to structured local metadata    |
-| `az boards` auth expired              | Warning logged; falls back to structured local metadata |
-| AzDO work item creation fails         | Warning logged; structured local metadata is used; downstream steps use `tracking_reference` instead of empty `issue_number` |
-| Percent-decode invalid sequence       | Warning logged; falls back to structured local metadata |
-| AzDO project name validation fails    | Warning logged; falls back to structured local metadata |
-| `gh` not installed (GitHub remote)    | GitHub creation fails clearly unless the failure is a repository access/resolution failure that triggers local metadata fallback |
-| `REMOTE_HOST_TYPE` unset in step 22b  | `HOST_TYPE` defaults to `"other"` via `${..:-other}` |
-| `PR_URL` empty in step 21            | Step skips `gh pr ready` with info message          |
-
-The principle is: **GitHub provider errors fail loudly except for repository
-access/resolution failures**, which fall back to local metadata so work can
-continue when `gh` cannot resolve the repository. **AzDO and other steps use
-local metadata fallback** because Azure Boards support is additive and "other"
-is the universal provider-safe mode.
-
----
-
-## Configuration
-
-No new configuration is required for GitHub repositories. The feature
-activates automatically based on the remote URL.
-
-For AzDO repositories, Azure CLI is optional. Configure it only when you want
-Azure Boards reuse or creation:
-
-1. Azure CLI is installed: `az --version`
-2. DevOps extension is present: `az extension list | grep devops`
-3. Authentication is current: `az login`
-4. Defaults are configured: `az devops configure --defaults organization=... project=...`
-
-Without Azure CLI configuration, AzDO repositories still avoid GitHub issue
-commands and fall back to structured local metadata.
-
-For local/unknown repositories (no remote or unrecognized host), no
-configuration is needed.
-
-Override the detected host type:
+## Provider detection
 
 ```bash
-amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c issue_number=12345 \
-  -c task_description="Continue Azure DevOps PR follow-up work" \
-  -c repo_path=.
+amplihack workflow detect-provider \
+  --repo . \
+  --format json
 ```
 
-Use `remote_host_type=other` to force local metadata without provider API
-calls. `remote_host_type=azure-devops` remains a compatibility alias for
-external contexts, but `azdo` is the primary value.
+Example output for GitHub:
 
----
+```json
+{
+  "schema_version": 1,
+  "provider": "GitHub",
+  "operation": "DetectProvider",
+  "status": "Succeeded",
+  "next_action": "No further provider setup is required.",
+  "warnings": [],
+  "data": {
+    "repository": {
+      "remote_url": "https://github.com/acme/service.git",
+      "owner": "acme",
+      "name": "service",
+      "default_base": "main"
+    },
+    "capabilities": {
+      "tracking_items": "Automated",
+      "change_requests": "Automated",
+      "stale_cleanup": "Automated"
+    }
+  }
+}
+```
+
+Supported provider classifications:
+
+| Provider | Remote examples |
+| --- | --- |
+| `GitHub` | `https://github.com/OWNER/REPO.git`, `git@github.com:OWNER/REPO.git`, `ssh://git@github.com/OWNER/REPO.git` |
+| `AzureDevOps` | `https://dev.azure.com/ORG/PROJECT/_git/REPO`, `https://ORG.visualstudio.com/PROJECT/_git/REPO`, `git@ssh.dev.azure.com:v3/ORG/PROJECT/REPO` |
+| `Local` | No `origin` remote or local-only repository |
+| `Unsupported` | Any recognized Git repository whose provider has no adapter |
+
+Classification matches host components, not arbitrary substrings. A remote such
+as `https://github.com.evil.example/acme/service.git` is `Unsupported`, not
+`GitHub`.
+
+## Tracking items
+
+```bash
+amplihack workflow tracking-item ensure \
+  --repo . \
+  --title "Fix authentication timeout" \
+  --body-file /tmp/workflow-body.md \
+  --format json
+```
+
+Canonical result:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "AzureDevOps",
+  "operation": "EnsureTrackingItem",
+  "status": "Succeeded",
+  "next_action": "Use AB#12345 in commits and change-request descriptions.",
+  "warnings": [],
+  "data": {
+    "tracking_item": {
+      "kind": "WorkItem",
+      "id": "12345",
+      "display_ref": "AB#12345",
+      "url": "https://dev.azure.com/acme/platform/_workitems/edit/12345"
+    }
+  }
+}
+```
+
+Provider behavior:
+
+| Provider | Behavior |
+| --- | --- |
+| GitHub | Reuse or create a GitHub issue through `gh issue`. |
+| Azure DevOps | Reuse or create an Azure Boards work item when `az` is configured; otherwise return local tracking or `BlockedManualProvider` according to the requested strictness. |
+| Local | Create a local workflow reference such as `local-550e8400`. |
+| Unsupported | Return `ManualRequired` with a provider-neutral next action. |
+
+Recipes consume `tracking_item.display_ref`, not provider-specific issue syntax.
+Commit formatting is delegated to the helper output.
+
+## Change requests
+
+```bash
+amplihack workflow change-request publish \
+  --repo . \
+  --source-branch feat/auth-timeout \
+  --base main \
+  --title "Fix authentication timeout" \
+  --body-file /tmp/pr-body.md \
+  --format json
+```
+
+GitHub automated result:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "GitHub",
+  "operation": "PublishChangeRequest",
+  "status": "Succeeded",
+  "next_action": "Wait for required checks and review.",
+  "warnings": [],
+  "data": {
+    "change_request": {
+      "kind": "PullRequest",
+      "id": "812",
+      "url": "https://github.com/acme/service/pull/812",
+      "state": "Open",
+      "source_branch": "feat/auth-timeout",
+      "base_branch": "main"
+    }
+  }
+}
+```
+
+Azure DevOps manual result:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "AzureDevOps",
+  "operation": "PublishChangeRequest",
+  "status": "ManualRequired",
+  "next_action": "Create an Azure Repos pull request from feat/auth-timeout to main and include AB#12345 in the description.",
+  "warnings": [],
+  "data": {
+    "change_request": null,
+    "manual_action": {
+      "kind": "CreateChangeRequest",
+      "source_branch": "feat/auth-timeout",
+      "base_branch": "main",
+      "title": "Fix authentication timeout",
+      "body_summary": "Includes AB#12345 and validation evidence."
+    }
+  }
+}
+```
+
+Manual states are explicit workflow output. They are never converted into
+successful publication evidence unless a later provider status query proves a
+matching change request exists.
+
+## Terminal state
+
+Provider-aware finalization uses the shared terminal-state contract:
+
+```bash
+amplihack workflow terminal-state \
+  --repo . \
+  --branch feat/auth-timeout \
+  --base main \
+  --format json
+```
+
+Terminal-state helpers combine local Git evidence, provider-safe change-request
+metadata, CI state, implementation markers, verification markers, and agentic
+finalizer output. They emit exactly one terminal state.
+
+Provider-specific manual states:
+
+| State | Success? | Meaning |
+| --- | --- | --- |
+| `MANUAL_REQUIRED` | No | Work is ready for a provider action that amplihack does not automate. |
+| `BLOCKED_MANUAL_PROVIDER` | No | Required provider tooling, auth, permissions, or APIs are unavailable. |
+
+Both states require `next_action`. They keep the final state auditable instead
+of claiming success where automation did not run.
+
+## Recipe contract
+
+Recipes use deterministic helpers for stable logic and agent steps for
+adaptable judgment:
+
+| Recipe concern | Owner |
+| --- | --- |
+| Provider classification | `amplihack workflow detect-provider` |
+| Tracking-item parsing and creation | `amplihack workflow tracking-item ensure` |
+| Change-request publication and status | `amplihack workflow change-request ...` |
+| Stale/superseded cleanup decisions | Agentic classifier plus `validate-agent-contract`; provider helper applies or dry-runs the result. |
+| Final terminal assessment | Agentic finalizer plus deterministic `terminal-state` validation. |
+| JSON schema validation | `amplihack workflow validate-agent-contract` or helper-specific validation. |
+
+Recipes may use shell for step sequencing, file movement, and invoking helpers.
+They must not add new brittle parsing steps for provider routing, PR status,
+terminal state, or agentic decisions.
 
 ## Examples
 
-### Example 1: GitHub repository (unchanged behavior)
+### GitHub repository
 
 ```bash
-# Remote: https://github.com/myorg/myrepo.git
+git remote set-url origin https://github.com/acme/service.git
+
 amplihack recipe run default-workflow \
-  -c task_description="Fix login timeout #684" \
-  -c repo_path=.
+  -c task_description="Fix authentication timeout" \
+  -c repo_path=. \
+  --format json
 ```
 
-Step 02d detects `github`. Steps 03, 15, 16, 21 use `gh` CLI as before.
-Step 15 uses `Closes #684`. Step 22b shows PR details via `gh pr view`.
+Expected provider behavior:
 
-### Example 2: Azure DevOps repository
-
-```bash
-# Remote: https://dev.azure.com/myorg/myproject/_git/myrepo
-amplihack recipe run default-workflow \
-  -c task_description="Fix login timeout" \
-  -c repo_path=.
+```text
+provider=GitHub
+tracking_items=Automated
+change_requests=Automated
+stale_cleanup=Automated
 ```
 
-Step 02d detects `azdo`. Step 03 extracts org/project from the remote URL
-and creates an AzDO work item. Step 15 uses `AB#N` format. Step 16 logs
-manual PR instructions. Step 22b shows `PR: N/A (manual creation required)`.
-
-### Example 3: Azure DevOps follow-up with existing work item
+### Azure DevOps repository
 
 ```bash
+git remote set-url origin https://dev.azure.com/acme/platform/_git/service
+
 amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c issue_number=12345 \
-  -c task_description="Address review feedback for existing ADO PR" \
-  -c repo_path=/worktrees/ado-pr-follow-up
+  -c task_description="Fix authentication timeout in AB#12345" \
+  -c repo_path=. \
+  --format json
 ```
 
-Step 03 treats `azdo` as Azure DevOps, emits `AB#12345`, and exits
-without entering GitHub issue reuse/create logic.
+Expected provider behavior:
 
-### Example 4: AzDO with percent-encoded project name
-
-```bash
-# Remote: https://dev.azure.com/myorg/My%20Project/_git/myrepo
-amplihack recipe run default-workflow \
-  -c task_description="Add config parser" \
-  -c repo_path=.
+```text
+provider=AzureDevOps
+tracking_items=Automated when Azure Boards is configured
+change_requests=ManualRequired
+GitHub commands=not invoked
 ```
 
-Step 03 decodes `My%20Project` → `My Project` and validates successfully.
-Workflow proceeds as in Example 2.
-
-### Example 5: Local repository (no remote)
+### Local repository
 
 ```bash
-cd ~/my-local-project && git init
+git remote remove origin
+
 amplihack recipe run default-workflow \
   -c task_description="Add config parser" \
-  -c repo_path=.
+  -c repo_path=. \
+  --format json
 ```
 
-Step 02d detects `other`. Step 03 emits structured local metadata. Step 04 uses
-the local reference in the branch/worktree name. Step 15 uses `Ref
-<local-ref>`. Step 16 skips PR creation. Step 22b shows `PR: N/A (no remote
-provider)` and `Issue: Ref <local-ref>`.
+Expected provider behavior:
 
----
+```text
+provider=Local
+tracking_items=local reference
+change_requests=ManualRequired
+remote provider commands=not invoked
+```
 
-## Troubleshooting
+## Regression contract
 
-**Host detected as `other` when a remote exists**
+Regression coverage for this feature verifies:
 
-Check that the remote is named `origin`: `git remote -v`. Only the `origin`
-remote is inspected. Rename if needed: `git remote rename <old> origin`.
+1. GitHub, Azure DevOps, local, unsupported, and spoofed remotes classify
+   correctly.
+2. Provider-specific commands run only inside the matching adapter.
+3. Deterministic parsing lives in typed helpers and has unit coverage.
+4. Agentic finalization and stale/superseded decisions fail closed when their
+   JSON contract is missing, malformed, low-confidence, or unsupported.
+5. Azure DevOps and local publication paths return `ManualRequired` or
+   `BlockedManualProvider` with actionable `next_action` text when automation is
+   unavailable.
+6. Recipe simulation tests cover representative success, failure, manual, and
+   blocked paths without live GitHub or Azure DevOps calls.
 
-**AzDO work item creation fails with auth error**
+## Related documentation
 
-Run `az login` and `az devops configure --defaults`. The workflow falls back
-to structured local metadata but logs a warning with remediation steps.
-
-**`az boards` command not found**
-
-Install the DevOps extension: `az extension add --name azure-devops`.
-
-**AzDO project name with spaces rejected**
-
-Check that the remote URL uses standard percent-encoding for spaces (`%20`).
-Unusual encodings or non-standard characters may be rejected by the
-validation regex.
-
----
-
-## Related
-
-- [Step 03 Host-Aware Tracking Idempotency](recipe-step-03-idempotency.md) — GitHub issue, Azure Boards work-item, and local tracking reuse/create behavior
-- [Workflow Issue Extraction (Step 03b)](workflow-issue-extraction.md) — provider-neutral extraction logic
-- [Worktree Reattach and Prune (Step 04)](recipe-step-04-worktree-reattach-prune.md) — worktree lifecycle
-- [Azure DevOps Integration](../azure-devops/README.md) — AzDO CLI tools and setup
-- [Azure OpenAI Integration](../AZURE_INTEGRATION.md) — Azure model configuration
-- [How to Use the Workflow with Azure DevOps](../howto/use-workflow-with-azure-devops.md) — task-oriented AzDO guide
-- [Multi-Provider Workflow Architecture](../concepts/multi-provider-workflow-architecture.md) — design decisions
-
----
-
-**Metadata**
-
-| Field       | Value                                           |
-| ----------- | ----------------------------------------------- |
-| Contract    | Provider-aware workflow-prep routing            |
-| Recipe file | `amplifier-bundle/recipes/workflow-prep.yaml`   |
-| Parent      | `amplifier-bundle/recipes/default-workflow.yaml` |
+- [Provider-Neutral Workflow Architecture](../concepts/multi-provider-workflow-architecture.md)
+- [Provider-Neutral Workflow API](workflow-provider-contract.md)
+- [Configure Provider-Neutral Workflows](../howto/configure-provider-neutral-workflows.md)
+- [Recipe Simulation Reference](workflow-simulation.md)

--- a/docs/reference/platform-bridge-api.md
+++ b/docs/reference/platform-bridge-api.md
@@ -1,5 +1,11 @@
 # Platform Bridge API Reference
 
+> Compatibility note: this is a legacy direct-bridge API reference. New
+> `default-workflow` provider behavior is specified by
+> [Provider-Neutral Workflow API](workflow-provider-contract.md). Recipes should
+> use `amplihack workflow ... --format json` helpers. Azure Repos PR creation and
+> PR comments are manual actions in the provider-neutral workflow contract.
+
 Complete API documentation fer the platform bridge module.
 
 ## Module: `claude.tools.platform_bridge`
@@ -111,7 +117,8 @@ print(f"Created issue #{issue['number']}: {issue['url']}")
 gh issue create --title "..." --body "..." --label "enhancement,security"
 ```
 
-**Azure DevOps Command**:
+**Azure DevOps Command (legacy direct bridge only; not used by
+provider-neutral `default-workflow`)**:
 
 ```bash
 az boards work-item create --type "User Story" --title "..." --description "..."
@@ -180,7 +187,8 @@ print(f"Draft PR #{pr['number']}: {pr['url']}")
 gh pr create --draft --title "..." --body "..." --head feat/auth --base main
 ```
 
-**Azure DevOps Command**:
+**Azure DevOps Command (legacy direct bridge only; not used by
+provider-neutral `default-workflow`)**:
 
 ```bash
 az repos pr create --draft true --title "..." --description "..." --source-branch feat/auth --target-branch main

--- a/docs/reference/recipe-step-03-idempotency.md
+++ b/docs/reference/recipe-step-03-idempotency.md
@@ -1,550 +1,101 @@
-# step-03-create-issue: Host-Aware Tracking Idempotency
+# Tracking Item Idempotency Reference
 
-`step-03-create-issue` is the tracking-record step in `workflow-prep.yaml`,
-the preparation phase used by `default-workflow`. It creates or reuses the
-tracking record for the current workflow run:
+> [Home](../index.md) > Reference > Tracking Item Idempotency
 
-- GitHub remotes use GitHub Issues.
-- Azure DevOps remotes use Azure Boards work items.
-- Unknown, empty, or local remotes use structured local metadata.
+Step 03 compatibility behavior is implemented through
+`amplihack workflow tracking-item ensure`. The helper owns deterministic parsing,
+provider routing, reuse, creation, local references, and manual/blocked states.
 
-Since `default-workflow` is often re-run against the same task (for example
-when resuming after an interruption, retrying a failed step, or following up on
-an existing PR/work item), the step detects existing tracking references before
-creating anything new.
+> [PLANNED - Implementation Pending]
+>
+> The helper command shown here is the target provider-neutral interface.
 
-**Added in:** PR #3952 (merged 2026-04-03)
-**Pattern source:** `step-16-create-draft-pr` idempotency guards (#3324)
-
----
-
-## Quick Start
-
-No configuration is required for GitHub repositories. Step 02d detects the
-remote host and step 03 routes by `remote_host_type`.
+## Command
 
 ```bash
-# GitHub: reuse issue #4194 if it exists, otherwise search/create as needed
-amplihack recipe run default-workflow \
-  -c task_description="Fix login timeout bug in #4194" \
-  -c repo_path="$(pwd)"
+amplihack workflow tracking-item ensure \
+  --repo . \
+  --title "Fix authentication timeout" \
+  --body-file workflow-body.md \
+  --format json
 ```
 
-Azure DevOps repositories may use either `azdo` or `azure-devops` as the host
-type. Both values route to the Azure Boards path.
+## Idempotency order
 
-```bash
-# Azure DevOps: reuse existing work item 12345 without creating a GitHub issue
-amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c issue_number=12345 \
-  -c task_description="Continue ADO PR follow-up work" \
-  -c repo_path="$(pwd)"
+The helper attempts reuse before creation:
+
+1. Validate explicit provider context when supplied.
+2. Detect the repository provider from Git remote metadata.
+3. Reuse an explicit tracking reference from context or task text when it belongs
+   to the detected provider.
+4. Search provider records only when the provider adapter supports safe search.
+5. Create a provider tracking item only when the adapter capability is
+   `Automated`.
+6. Return local tracking, `ManualRequired`, or `BlockedManualProvider` when
+   automation is unavailable.
+
+## Provider behavior
+
+| Provider | Reuse | Create | Unavailable path |
+| --- | --- | --- | --- |
+| GitHub | Existing issue URL, `#N`, or adapter search result. | `gh issue create` through the GitHub adapter. | `BlockedManualProvider` when GitHub tooling/auth is required but unavailable. |
+| Azure DevOps | `AB#N`, Azure Boards URL, or explicit work item ID. | `az boards work-item create` through the Azure DevOps adapter when configured. | Local/manual/blocked state with `next_action`; never GitHub fallback. |
+| Local | Existing `local-*` reference. | New local workflow reference. | No remote calls. |
+| Unsupported | Provider-neutral manual reference when allowed. | None. | `ManualRequired` or `BlockedManualProvider`. |
+
+## Output
+
+Successful provider tracking output:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "AzureDevOps",
+  "operation": "EnsureTrackingItem",
+  "status": "Succeeded",
+  "next_action": "Use AB#12345 in commits and change-request descriptions.",
+  "warnings": [],
+  "data": {
+    "tracking_item": {
+      "kind": "WorkItem",
+      "id": "12345",
+      "display_ref": "AB#12345",
+      "url": "https://dev.azure.com/acme/platform/_workitems/edit/12345"
+    }
+  }
+}
 ```
 
-Step 03 emits a parseable tracking reference. Step 03b extracts numeric IDs for
-GitHub and Azure DevOps outputs, and preserves local tracking references without
-coercing them into issue numbers.
+Manual output:
 
-```
-AB#12345
-```
-
----
-
-## How It Works
-
-The step dispatches by host type before it performs any provider-specific
-operation. `remote_host_type` is treated as untrusted recipe context, so the
-dispatch uses quoted variables and explicit host matching.
-
-```
-input: remote_host_type + issue_number + task_description + repo_path
-         │
-         ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  Host Dispatch                                                  │
-│  github              → GitHub issue reuse/search/create          │
-│  azdo|azure-devops   → Azure Boards reuse/create                 │
-│  other|empty|unknown → structured local metadata                 │
-└─────────────────────────────────────────────────────────────────┘
-         │
-         ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  Existing Reference Guards                                      │
-│  explicit issue_number? host-specific reuse, exit 0              │
-│  task_description contains AB#N or #N? host-specific candidate   │
-└─────────────────────────────────────────────────────────────────┘
-         │
-         ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  Provider Create or Fallback                                    │
-│  GitHub: gh issue create                                        │
-│  Azure DevOps: az boards work-item create                       │
-│  Other: structured local metadata                               │
-└─────────────────────────────────────────────────────────────────┘
+```json
+{
+  "schema_version": 1,
+  "provider": "Unsupported",
+  "operation": "EnsureTrackingItem",
+  "status": "ManualRequired",
+  "next_action": "Create or reference a tracking item in the repository's provider and rerun with tracking_item_ref.",
+  "warnings": [],
+  "data": {
+    "tracking_item": null
+  }
+}
 ```
 
-### Host Dispatch
-
-Step 03 accepts these `remote_host_type` values:
-
-| Value | Meaning | Step 03 behavior |
-| ----- | ------- | ---------------- |
-| `github` | GitHub repository | Runs GitHub issue reuse/search/create logic with `gh` |
-| `azdo` | Azure DevOps repository | Runs Azure Boards work-item reuse/create logic |
-| `azure-devops` | Azure DevOps repository alias | Same behavior as `azdo` |
-| `other` | Unknown or local repository | Uses local tracking fallback |
-| empty/unset | Unknown or local repository | Uses local tracking fallback |
-
-Step 02d normally emits `github`, `azdo`, or `other`. The `azure-devops` alias
-exists for callers that pass host context from Azure DevOps PR/work-item
-follow-up workflows.
-
-### GitHub Guard 1: Reference Guard
-
-Triggered when the host is `github` and `task_description` contains a GitHub
-issue reference in the form `#NNNN` (for example, `Fix the bug in #4194`).
-
-1. Extracts the first `#NNNN` pattern using bash regex `[[ =~ \#([0-9]+) ]]`
-2. Validates the extracted value is purely numeric (defense-in-depth)
-3. Calls `gh issue view <N> --json url --jq '.url // ""'` with a 60-second timeout
-4. If the issue exists: outputs its URL to stdout and exits 0 (reuse)
-5. If the issue does not exist or the call fails: falls through to Guard 2
-
-This guard is the cheapest and most specific. It requires zero search and makes
-a single API call to a known issue number.
-
-### GitHub Guard 2: Title Search Guard
-
-Runs only for the `github` host path when Guard 1 does not match. Uses
-`gh issue list` to search open issues for a title similar to the current one.
-
-1. Truncates the issue title to its first 100 characters (GitHub search limit)
-2. Calls `gh issue list --state open --search "<query>"` with a 60-second timeout
-3. If a matching open issue is found: outputs its URL to stdout and exits 0 (reuse)
-4. If no match: falls through to issue creation
-
-This guard catches the case where the workflow was re-run without explicitly
-referencing an issue number — for example, when the task description is
-re-submitted verbatim.
-
-### GitHub Fallback: Create New Issue
-
-If neither guard matches, the step creates a new issue using the same logic
-as before the idempotency guards were added. This path is unchanged for GitHub
-repositories.
-
-### Azure DevOps Existing Work Item Reuse
-
-Runs when `remote_host_type` is `azdo` or `azure-devops`.
-
-The Azure DevOps path never calls `gh issue view`, `gh issue list`, or
-`gh issue create`. Existing work-item reuse is checked before any create
-operation:
-
-1. If the recipe context already contains numeric `issue_number=N`, step 03
-   emits `AB#N` and exits 0 before GitHub logic, Azure CLI lookup, remote URL
-   parsing, or work-item creation.
-2. Otherwise, if `task_description` contains `AB#N`, step 03 reuses that work
-   item reference when the Azure Boards path can validate or resolve it.
-3. Otherwise, if `task_description` contains `#N`, step 03 treats it as an
-   Azure Boards work-item candidate only because the host dispatch already
-   selected Azure DevOps.
-
-Only explicit `issue_number=N` is trusted as an already-known workflow context
-value. IDs discovered in `task_description` are provider-scoped candidates:
-they must stay in the Azure DevOps branch, but they may still fall through to
-work-item creation or local tracking if Azure CLI, organization, project, or
-work-item resolution is unavailable.
-
-When Azure CLI and the DevOps extension are available, validated referenced
-work items may be resolved to full work-item URLs:
-
-```text
-https://dev.azure.com/myorg/myproject/_workitems/edit/12345
-```
-
-When an existing `issue_number` is already present, no Azure Boards lookup or
-create command is needed; the parseable `AB#N` output is enough for step 03b
-and all downstream workflow steps.
-
-### Azure DevOps Create Path
-
-If no existing work item is supplied, step 03 parses the Azure DevOps remote
-URL to derive organization and project, then creates a `Task` work item with
-`az boards work-item create`. Supported remote URL forms are:
-
-| Form | Example |
-| ---- | ------- |
-| Modern HTTPS | `https://dev.azure.com/myorg/MyProject/_git/myrepo` |
-| Legacy HTTPS | `https://myorg.visualstudio.com/MyProject/_git/myrepo` |
-| SSH | `git@ssh.dev.azure.com:v3/myorg/MyProject/myrepo` |
-
-Percent-encoded project names such as `My%20Project` are decoded before
-validation. Invalid org/project captures fall back to local metadata with a
-warning rather than crossing into GitHub logic.
-
-### Local Metadata Fallback
-
-Unknown hosts, empty hosts, non-git directories, malformed Azure DevOps remote
-metadata, or unavailable Azure CLI support produce structured local metadata:
-
-```text
-tracking_system=local
-tracking_reference=local-482193
-tracking_issue=local-482193
-issue_creation=local-tracking
-issue_number=
-```
-
-Local metadata preserves the workflow's local tracking contract. The
-`tracking_reference` / `tracking_issue` value is authoritative, and
-`issue_number` is empty. `tracking_system=local` marks local mode, but Step 03b
-requires a local-prefixed `tracking_reference` / `tracking_issue` or legacy
-`local-tracking:*` reference before it treats the output as local. Step 03b
-detects that local reference before numeric extraction so values such as
-`local-123` and `local-tracking:123` are not treated as provider issue numbers.
-
----
-
-## Output Format
-
-Step 03 writes provider output to stdout. GitHub and Azure Boards success paths
-write a single URL or `AB#N`; local fallback writes multiline key/value
-metadata. Diagnostic output goes to stderr.
-
-| Host path | Reuse output | Create output |
-| --------- | ------------ | ------------- |
-| GitHub | `https://github.com/owner/repo/issues/123` | `https://github.com/owner/repo/issues/123` |
-| Azure DevOps | `AB#12345` for explicit `issue_number`, or `https://dev.azure.com/org/project/_workitems/edit/12345` for validated task-text reuse | `https://dev.azure.com/org/project/_workitems/edit/12345` |
-| Other/local | Structured local metadata | Structured local metadata |
-
-The downstream step `step-03b-extract-issue-number` accepts every output above.
-It extracts the numeric ID from:
-
-- GitHub issue URLs containing `/issues/N`
-- GitHub PR URLs containing `/pull/N` with closing-issue lookup fallback
-- Azure DevOps work-item URLs containing `/_workitems/edit/N`
-- Azure Boards references in the form `AB#N`
-
-For local metadata, step 03b preserves the local-prefixed `tracking_reference` /
-`tracking_issue` and leaves `issue_number` empty. This keeps the remote `issue_number` output
-provider-agnostic without pretending local IDs are remote issue numbers.
-
----
-
-## Diagnostic Messages
-
-All diagnostic output goes to **stderr** and is not captured by the recipe
-runner's output pipeline. You can view it in the recipe's verbose log or by
-redirecting stderr. The table below is the expected diagnostic contract for
-the Issue #718 implementation; exact wording should not be treated as a stable
-public API.
-
-| Message                                                                      | When                             |
-| ---------------------------------------------------------------------------- | -------------------------------- |
-| `INFO: task_description references issue #N — verifying it exists`           | Guard 1 extracted a reference    |
-| `INFO: Reusing existing issue #N — skipping creation`                        | Guard 1 matched and reused       |
-| `WARN: Referenced issue #N not found — will search or create`                | Guard 1 fell through             |
-| `INFO: Searching open issues for similar title`                              | Guard 2 running                  |
-| `INFO: Found existing open issue matching title — skipping creation`         | Guard 2 matched and reused       |
-| `INFO: No matching open issue found — proceeding to create`                  | Guard 2 fell through             |
-| `WARN: Extracted issue reference is not numeric: <value> — skipping guard 1` | Guard 1 rejected an unsafe value |
-| `INFO: Reusing work item AB#N`                                               | Azure DevOps path reused a work item |
-| `INFO: Using local tracking for issue management (remote: HOST)`             | Fallback path selected local tracking |
-| `WARN: 'az' CLI not found or org/project empty — using local tracking for AzDO remote` | Azure DevOps create path could not run |
-
----
-
-## Error Handling
-
-| Failure mode | Behavior |
-| ------------ | -------- |
-| `gh issue view` times out (> 60 s) | GitHub Guard 1 falls through |
-| `gh issue view` returns HTTP error | GitHub Guard 1 falls through |
-| `gh issue list --search` times out | GitHub Guard 2 falls through |
-| `gh issue list --search` returns empty | GitHub Guard 2 falls through to creation |
-| `gh` not authenticated on GitHub path | Reuse guards fall through; creation fails clearly if authentication is required |
-| `gh issue create` cannot resolve or access the repository | Emits structured local metadata with a warning |
-| Other `gh issue create` failure | Fails clearly and prints sanitized CLI output |
-| `remote_host_type=azdo` or `azure-devops` with existing `issue_number` | Emits `AB#N` and exits 0 without calling `gh` or creating a work item |
-| Azure CLI missing on Azure DevOps create path | Falls back to structured local metadata with a warning |
-| Azure DevOps org/project cannot be parsed | Falls back to structured local metadata with a warning |
-| Local tracking reference contains digits | Preserves the local reference and emits empty `issue_number`; digits are not extracted |
-| Non-numeric issue reference extracted | Explicit `^[0-9]+$` validation rejects it before any provider CLI receives it |
-
-The step uses `set -euo pipefail`. All expected-failure exit paths use
-`|| echo ''` or `|| true` so the script does not abort unexpectedly.
-
----
-
-## Security
-
-### Command Injection Prevention
-
-| Attack vector                                                      | Mitigation                                                                                                                                                                                                                     |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `#NNNN` in `task_description` contains shell metacharacters        | Bash regex `[[ =~ \#([0-9]+) ]]` captures only `[0-9]+`; `BASH_REMATCH[1]` contains only digits                                                                                                                                |
-| Captured number contains semicolons, pipes, or other characters    | Explicit `^[0-9]+$` validation rejects anything non-numeric before it reaches `gh issue view "$REF_ISSUE_NUM"`                                                                                                                 |
-| Long or special-character title passed to `gh issue list --search` | Double-quoted variable `"$SEARCH_QUERY"` prevents shell word-splitting; `gh` CLI handles API-level escaping                                                                                                                    |
-| Template injection via `task_description` or `final_requirements`  | Both are captured via unquoted heredoc (`<<EOFTASKDESC`) into bash variables (`TASK_DESC`, `ISSUE_REQS`). The issue body is assembled with `printf` using double-quoted variable expansions — no `eval`, no unquoted expansion |
-| Untrusted `remote_host_type` value | Quoted host dispatch routes only explicit `github`, `azdo`, and `azure-devops` values to provider logic; all other values use local tracking |
-| Azure DevOps alias with shell metacharacters | The alias match is exact; values such as `azure-devops; gh issue create ...` do not match and fall back to local tracking |
-
-### Trusted Inputs
-
-The recipe context variables `task_description` and `final_requirements` must
-never contain secrets or authentication tokens. They are embedded verbatim in
-new GitHub issue bodies or Azure Boards work-item descriptions. Public
-repositories and shared Azure DevOps projects may expose that text to broad
-audiences.
-
----
-
-## Configuration
-
-Step 03 reads these recipe context keys:
-
-| Context key | Required | Description |
-| ----------- | -------- | ----------- |
-| `repo_path` | Yes | Repository or worktree path where `git remote get-url origin` runs |
-| `task_description` | Yes | Free-form task text used for title creation and existing reference extraction |
-| `final_requirements` | No | Requirements text included in newly created GitHub issues or Azure Boards work items |
-| `remote_host_type` | No | Host routing value; accepts `github`, `azdo`, `azure-devops`, `other`, or empty |
-| `issue_number` | No | Existing tracking ID. On Azure DevOps, this is reused as `AB#N` without GitHub issue logic |
-
-Step 02d normally sets `remote_host_type`. Callers may override it when
-resuming from external workflow context.
-
-```bash
-# Explicit Azure DevOps host and existing work item reuse
-amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c issue_number=12345 \
-  -c task_description="Follow up on existing Azure Boards work item" \
-  -c repo_path="$(pwd)"
-```
-
-GitHub behavior remains unchanged when `remote_host_type=github`.
-
----
-
-## Usage Examples
-
-### Example 1: Re-running a workflow for the same task
-
-A previous run created issue #4194. The next run's `task_description` still
-references `#4194`.
-
-```
-task_description = "Fix login timeout bug described in #4194"
-```
-
-**Step-03 output (stderr):**
-
-```
-INFO: task_description references issue #4194 — verifying it exists
-INFO: Reusing existing issue #4194 — skipping creation
-```
-
-**Step-03 output (stdout):**
-
-```
-https://github.com/myorg/myrepo/issues/4194
-```
-
-No duplicate issue created. Step-03b extracts `4194` as normal.
-
----
-
-### Example 2: Azure DevOps PR follow-up with an existing work item
-
-An Azure DevOps follow-up workflow already knows the Boards work item ID from
-the PR or workstream context.
-
-```bash
-amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c issue_number=12345 \
-  -c task_description="Address review feedback for the Azure DevOps PR" \
-  -c repo_path=/worktrees/ado-pr-follow-up
-```
-
-**Step-03 output (stdout):**
-
-```text
-AB#12345
-```
-
-The GitHub issue path is not entered. No `gh issue` command runs, and no
-duplicate Azure Boards work item is created.
-
----
-
-### Example 3: Azure DevOps task description reference
-
-```bash
-amplihack recipe run default-workflow \
-  -c remote_host_type=azdo \
-  -c task_description="Fix pipeline timeout described in AB#12345" \
-  -c repo_path="$(pwd)"
-```
-
-Step 03 routes to the Azure DevOps path because the host is `azdo`. The
-`AB#12345` reference is treated as an Azure Boards candidate, never as a
-GitHub issue. If Azure Boards lookup resolves the work item, the workflow uses
-that ID; otherwise the Azure DevOps create/fallback path continues without
-crossing into GitHub logic.
-
----
-
-### Example 4: Re-running GitHub without an explicit issue reference
-
-Previous run created issue #4200 with title `"Add user profile page"`. New run
-has the same `task_description` but no `#NNNN` reference.
-
-**Guard 1:** No `#NNNN` found — skips to Guard 2.
-
-**Guard 2 search query:** `Add user profile page` (under 100 chars, no truncation)
-
-**Step-03 output (stderr):**
-
-```
-INFO: Searching open issues for similar title
-INFO: Found existing open issue matching title — skipping creation
-```
-
-**Step-03 output (stdout):**
-
-```
-https://github.com/myorg/myrepo/issues/4200
-```
-
----
-
-### Example 5: First GitHub run — no existing issue
-
-No prior issues match. Both guards fall through; a new issue is created.
-
-**Step-03 output (stderr):**
-
-```
-INFO: Searching open issues for similar title
-INFO: No matching open issue found — proceeding to create
-```
-
-**Step-03 output (stdout):**
-
-```
-https://github.com/myorg/myrepo/issues/4201
-```
-
----
-
-### Example 6: Unknown host fallback
-
-```bash
-amplihack recipe run default-workflow \
-  -c remote_host_type=gitlab \
-  -c task_description="Add config parser #482193" \
-  -c repo_path="$(pwd)"
-```
-
-**Step-03 output (stdout):**
-
-```text
-tracking_system=local
-tracking_reference=local-482193
-tracking_issue=local-482193
-issue_creation=local-tracking
-issue_number=
-```
-
-Unknown host values never enter GitHub or Azure DevOps provider logic.
-
----
-
-### Example 7: Very long task description
-
-`task_description` is 500 characters long. The issue title is truncated to 200
-characters (recipe-level truncation). Guard 2's search query uses only the
-first 100 characters of that title.
-
-```bash
-# Title: first 200 chars of task_description
-# Search: first 100 chars of title
-SEARCH_QUERY="${ISSUE_TITLE:0:100}"
-```
-
-This ensures the `gh` search API is not passed excessively long queries.
-
----
-
-## Testing
-
-The outside-in test suite covers all three code paths and all cross-cutting
-concerns:
-
-```bash
-# Run the full test suite
-gadugi-test run tests/gadugi/step-03-issue-creation-idempotency.yaml --verbose
-
-# Validate the scenario YAML structure
-gadugi-test validate tests/gadugi/step-03-issue-creation-idempotency.yaml
-```
-
-**Coverage includes:**
-
-| Area                                               | Scenarios |
-| -------------------------------------------------- | --------- |
-| GitHub Guard 1: `#NNNN` extraction | Existing GitHub issue reuse |
-| GitHub Guard 1: numeric validation / injection prevention | Unsafe reference rejection |
-| GitHub Guard 2: title truncation | Long title search safety |
-| Azure DevOps alias dispatch | `remote_host_type=azdo` and `remote_host_type=azure-devops` route identically |
-| Azure DevOps existing context reuse | `issue_number=N` emits `AB#N` without calling `gh` |
-| Azure DevOps task text candidates | `AB#N` and host-scoped `#N` references stay in Azure Boards logic and never trigger GitHub issue commands |
-| Generic fallback | Unknown, empty, and non-git hosts emit structured local metadata |
-| Output compatibility with step-03b | GitHub URL, Azure Boards URL, and `AB#N` parse to numeric IDs; structured local metadata with local-prefixed references and `local-tracking:*` preserve local references with empty `issue_number` |
-| Host isolation | Azure DevOps and generic paths never execute `gh issue` commands |
-| `set -euo pipefail` and quoted host dispatch | Shell syntax remains safe for empty or malformed context |
-
----
-
-## Known Limitations
-
-**GitHub Guard 2 false positives.** `gh issue list --search` uses GitHub's
-full-text search, which can match issues whose titles differ from the current
-one. When this happens, step-03 reuses the matched issue instead of creating a
-new one. This is intentional: a false-positive reuse is preferable to creating
-a duplicate. The matched issue URL is passed downstream as normal, and the
-workflow tracks progress there.
-
-**GitHub TOCTOU race.** Between Guard 2's search and `gh issue create`, a
-concurrent workflow run could create a matching issue. In that case, two issues
-would exist — the same worst-case as before the guards were added. GitHub issue
-creation is inherently non-atomic, so this is not mitigated.
-
-**Reference guards use the first matching ID.** If `task_description` contains
-multiple `#NNNN` or `AB#NNNN` references, the first host-appropriate reference
-is used.
-
----
-
-## Multi-Provider Note
-
-The GitHub idempotency guards use `gh issue view` and `gh issue list` only
-inside the `github` host branch. Azure DevOps host values (`azdo` and
-`azure-devops`) use Azure Boards references and never fall through into GitHub
-issue logic. See [Multi-Provider Workflow Reference](multi-provider-workflow.md)
-for the provider-specific workflow contract.
-
----
-
-## Related
-
-- `step-16-create-draft-pr` idempotency guards — pattern source (#3324)
-- `step-03b-extract-issue-number` — downstream step that parses step-03 output
-- `tests/gadugi/step-03-issue-creation-idempotency.yaml` — test suite
-- `docs/investigations/step-03-idempotency-guards-analysis.md` — security analysis and implementation notes
-- [Multi-Provider Workflow Reference](multi-provider-workflow.md) — provider detection and routing
+## Regression contract
+
+Tests verify:
+
+1. GitHub, Azure DevOps, local, unsupported, and spoofed remotes route through
+   the correct provider state.
+2. Existing provider references are reused before creation.
+3. Local references are never coerced into GitHub issue numbers or Azure Boards
+   work item IDs.
+4. Azure DevOps and unsupported paths never call GitHub commands.
+5. Manual and blocked states include actionable `next_action` text.
+
+## Related documentation
+
+- [Provider-Neutral Workflow API](workflow-provider-contract.md)
+- [Multi-Provider Workflow Reference](multi-provider-workflow.md)
+- [Configure Provider-Neutral Workflows](../howto/configure-provider-neutral-workflows.md)

--- a/docs/reference/workflow-provider-contract.md
+++ b/docs/reference/workflow-provider-contract.md
@@ -183,9 +183,11 @@ Status values:
 | `Merged` | Provider reports merge evidence. |
 | `Closed` | Closed without merge evidence. |
 
-Manual results include `data.manual_action` and `data.change_request: null`.
-For this feature, Azure Repos pull-request publication is always manual; the
-implementation must not call `az repos pr create` from `default-workflow`.
+Manual-provider results include `data.manual_action` and `data.change_request:
+null`. Azure Repos pull-request publication is an automated Azure DevOps
+capability when the `az` CLI and provider context are available; provider or
+authentication failures must return blocked-provider evidence instead of manual
+success.
 
 ## Terminal states
 
@@ -195,14 +197,14 @@ Terminal-state JSON appears in recipe results, logs, and
 ```json
 {
   "schema_version": 1,
-  "terminal_success": false,
-  "terminal_state": "MANUAL_REQUIRED",
-  "terminal_reason": "Azure Repos pull-request creation is manual for this provider configuration.",
-  "required_next_action": "Create an Azure Repos pull request from feat/auth-timeout to main and rerun workflow terminal-state with the PR URL.",
+  "terminal_success": true,
+  "terminal_state": "FOLLOWUP_CREATED",
+  "terminal_reason": "Azure Repos pull-request creation succeeded.",
+  "required_next_action": "Monitor Azure Repos PR validation.",
   "provider": "AzureDevOps",
   "evidence_used": [
     "provider=AzureDevOps",
-    "change_requests=ManualRequired",
+    "change_requests=Automated",
     "git.clean=true"
   ]
 }

--- a/docs/reference/workflow-provider-contract.md
+++ b/docs/reference/workflow-provider-contract.md
@@ -1,0 +1,310 @@
+# Provider-Neutral Workflow API
+
+> [Home](../index.md) > Reference > Provider-Neutral Workflow API
+
+This reference defines the provider-neutral workflow domain model, JSON helper
+schemas, provider adapter behavior, and validation contracts used by
+`default-workflow`.
+
+## Contents
+
+- [Rust domain models](#rust-domain-models)
+- [Provider capability states](#provider-capability-states)
+- [Serialized enum names](#serialized-enum-names)
+- [Helper command output envelope](#helper-command-output-envelope)
+- [Change-request model](#change-request-model)
+- [Terminal states](#terminal-states)
+- [Agent validation contracts](#agent-validation-contracts)
+- [Stale cleanup model](#stale-cleanup-model)
+- [Manual and blocked transitions](#manual-and-blocked-transitions)
+- [Exit behavior](#exit-behavior)
+
+## Rust domain models
+
+The pure `amplihack-workflows` crate owns the stable domain types. Adapters
+convert provider data into these models.
+
+```rust
+pub enum RepositoryProvider {
+    GitHub,
+    AzureDevOps,
+    Manual,
+}
+
+pub enum ProviderCapabilityState {
+    Automated,
+    ManualRequired,
+    BlockedManualProvider,
+    Unsupported,
+}
+
+pub struct ProviderContext {
+    pub schema_version: u32,
+    pub provider: RepositoryProvider,
+    pub repository: RepositoryIdentity,
+    pub capabilities: ProviderCapabilities,
+    pub status: ProviderOperationStatus,
+    pub next_action: String,
+}
+
+pub struct ChangeRequest {
+    pub kind: ChangeRequestKind,
+    pub id: String,
+    pub url: String,
+    pub state: ChangeRequestStatus,
+    pub source_branch: String,
+    pub base_branch: String,
+    pub head_sha: Option<String>,
+}
+
+pub enum TerminalState {
+    FollowupCreated,
+    ManualRequired,
+    BlockedManualProvider,
+    HollowSuccess,
+    FailedInvalidEvidence,
+    FailedFinalizerOutput,
+    Failed,
+}
+```
+
+## Provider capability states
+
+| State | Meaning |
+| --- | --- |
+| `Automated` | The adapter can perform the operation with current tools and credentials. |
+| `ManualRequired` | Amplihack intentionally does not automate this operation for the provider. |
+| `BlockedManualProvider` | Automation would be possible only after credentials, permissions, tools, or provider configuration are fixed. |
+| `Unsupported` | No adapter supports the operation. |
+
+Capability states appear in provider detection and operation results.
+
+## Serialized enum names
+
+Rust types keep Rust-style variant names. JSON uses two explicit naming
+families:
+
+| Enum family | JSON format | Examples |
+| --- | --- | --- |
+| Provider names | Rust variant names | `GitHub`, `AzureDevOps`, `Manual` |
+| Provider capability and operation status values | Rust variant names | `Automated`, `ManualRequired`, `BlockedManualProvider`, `Succeeded`, `Failed` |
+| Terminal states | `SCREAMING_SNAKE_CASE` | `FOLLOWUP_CREATED`, `MANUAL_REQUIRED`, `BLOCKED_MANUAL_PROVIDER`, `HOLLOW_SUCCESS` |
+
+Terminal-state validators may accept older Rust-style terminal names during a
+migration window, but they must normalize emitted JSON to the canonical
+`SCREAMING_SNAKE_CASE` names:
+
+| Legacy terminal value | Canonical terminal value |
+| --- | --- |
+| `FollowupCreated` | `FOLLOWUP_CREATED` |
+| `ManualRequired` | `MANUAL_REQUIRED` |
+| `BlockedManualProvider` | `BLOCKED_MANUAL_PROVIDER` |
+| `HollowSuccess` | `HOLLOW_SUCCESS` |
+
+## Helper command output envelope
+
+Every `amplihack workflow ... --format json` command emits the same top-level
+envelope:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "GitHub",
+  "operation": "DetectProvider",
+  "status": "Succeeded",
+  "next_action": "No further provider setup is required.",
+  "warnings": [],
+  "data": {
+    "repository": {
+      "remote_url": "https://github.com/acme/service.git",
+      "owner": "acme",
+      "name": "service",
+      "default_base": "main"
+    },
+    "capabilities": {
+      "tracking_items": "Automated",
+      "change_requests": "Automated",
+      "stale_cleanup": "Automated"
+    }
+  }
+}
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `schema_version` | Yes | Current schema version. Unknown versions fail validation. |
+| `provider` | Yes | `GitHub`, `AzureDevOps`, or `Manual`. |
+| `operation` | Yes | Stable operation name. |
+| `status` | Yes | `Succeeded`, `ManualRequired`, `BlockedManualProvider`, or `Failed`. |
+| `next_action` | Yes | Actionable text. Success states explain why no action is needed. Manual/blocked states explain exactly what to do. |
+| `warnings` | Yes | Array of non-fatal diagnostic strings. |
+| `data` | Yes | Operation-specific object. |
+
+Operation-specific fields always live under `data`. Do not put
+`tracking_item`, `change_request`, `manual_action`, `recipe`, `scenario`, or
+assertion details at the top level.
+
+Shell helpers and recipes must parse this JSON. They must not infer state from
+stderr or provider CLI prose. Stderr is diagnostic only.
+
+## Change-request model
+
+`change-request publish` and `change-request status` return
+`data.change_request` when a provider-native change request exists:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "GitHub",
+  "operation": "PublishChangeRequest",
+  "status": "Succeeded",
+  "next_action": "Wait for required checks and review.",
+  "warnings": [],
+  "data": {
+    "change_request": {
+      "kind": "PullRequest",
+      "id": "812",
+      "url": "https://github.com/acme/service/pull/812",
+      "state": "Open",
+      "source_branch": "feat/auth-timeout",
+      "base_branch": "main",
+      "head_sha": "1d2c3b4a"
+    }
+  }
+}
+```
+
+Status values:
+
+| Value | Meaning |
+| --- | --- |
+| `Draft` | Created but not ready for review. |
+| `Open` | Active and reviewable. |
+| `Merged` | Provider reports merge evidence. |
+| `Closed` | Closed without merge evidence. |
+
+Manual results include `data.manual_action` and `data.change_request: null`.
+For this feature, Azure Repos pull-request publication is always manual; the
+implementation must not call `az repos pr create` from `default-workflow`.
+
+## Terminal states
+
+Terminal-state JSON appears in recipe results, logs, and
+`amplihack workflow terminal-state` output.
+
+```json
+{
+  "schema_version": 1,
+  "terminal_success": false,
+  "terminal_state": "MANUAL_REQUIRED",
+  "terminal_reason": "Azure Repos pull-request creation is manual for this provider configuration.",
+  "required_next_action": "Create an Azure Repos pull request from feat/auth-timeout to main and rerun workflow terminal-state with the PR URL.",
+  "provider": "AzureDevOps",
+  "evidence_used": [
+    "provider=AzureDevOps",
+    "change_requests=ManualRequired",
+    "git.clean=true"
+  ]
+}
+```
+
+`MANUAL_REQUIRED` and `BLOCKED_MANUAL_PROVIDER` are non-success states unless a
+later deterministic provider status check proves that the manual action is
+complete.
+
+## Agent validation contracts
+
+Agentic steps use named contracts:
+
+| Contract | Purpose |
+| --- | --- |
+| `finalization` | Classify one terminal state from structured workflow evidence. |
+| `stale-cleanup-decision` | Decide whether a candidate change request is stale, active, superseded, or unsafe to touch. |
+| `review-readiness` | Decide whether evidence is enough to mark a workflow-owned change request ready. |
+
+Validate finalizer output through the `amplihack-workflows::agent_contract`
+Rust API. Recipe simulation also exercises this validator with fake agent
+outputs.
+
+Validation rules:
+
+1. Output must be a single JSON object.
+2. `schema_version` must be supported.
+3. Decision and state fields must be known enums.
+4. `confidence=high` is required for success or mutation decisions.
+5. `reason`, `required_next_action`, and `evidence_used` must be non-empty.
+6. Provider-specific actions must match the detected provider capability.
+7. Secrets and raw environment dumps are rejected.
+
+## Stale cleanup model
+
+`cleanup-stale` supports dry-run and apply modes:
+
+```bash
+amplihack workflow cleanup-stale \
+  --provider github \
+  --dry-run \
+  --format json
+```
+
+Dry-run result:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "GitHub",
+  "operation": "CleanupStale",
+  "status": "Succeeded",
+  "next_action": "Run again without --dry-run to close 2 superseded pull requests.",
+  "warnings": [],
+  "data": {
+    "provider": "GitHub",
+    "mode": "DryRun",
+    "actions": [
+      {
+        "change_request_id": "791",
+        "action": "WouldCloseAsSuperseded",
+        "reason": "dry-run: workflow-owned superseded change request is eligible"
+      }
+    ],
+    "mutations_executed": 0
+  }
+}
+```
+
+The cleanup helper mutates provider state only when:
+
+1. the provider adapter supports the action,
+2. the candidate matches scoped workflow identity,
+3. the agentic stale decision contract validates with high confidence,
+4. dry-run output has already identified the same candidate/action pair, and
+5. provider mutation succeeds and returns durable evidence.
+
+## Manual and blocked transitions
+
+Manual and blocked states use one transition contract across helpers, recipes,
+and terminal output:
+
+| Helper result | Helper exit | Recipe behavior | Terminal-state mapping |
+| --- | --- | --- | --- |
+| `status=Succeeded` with durable evidence | `0` | Continue and persist `data`. | A later gate may emit a success terminal state if all required evidence is present. |
+| `status=ManualRequired` | `0` for operation helpers | Persist `data.manual_action`, surface `next_action`, and stop any automated provider mutation path. | Required publication/finalization gates emit `MANUAL_REQUIRED`, `terminal_success=false`, and nonzero gate exit. |
+| `status=BlockedManualProvider` | `2` | Surface the blocker and do not switch to another provider. Recipes should still parse JSON before failing. | Required gates emit `BLOCKED_MANUAL_PROVIDER`, `terminal_success=false`, and nonzero gate exit. |
+| `status=Failed` | `1` | Fail closed. Recipes should still parse JSON before failing. | Required gates emit the most specific `FAILED_*` state. |
+
+`ManualRequired` means the operation is intentionally manual for this provider
+contract. `BlockedManualProvider` means the requested provider path could not
+complete because tooling, credentials, permissions, repository metadata, or APIs
+are unavailable.
+
+## Exit behavior
+
+Operation helpers return `0` when they produced valid JSON for `Succeeded` or
+`ManualRequired`; `2` for `BlockedManualProvider`; and `1` for `Failed` or
+invalid invocation. Terminal-state gates return `0` only for
+`terminal_success=true`, `3` for known non-success terminal states, and `1` for
+invalid input or malformed evidence.
+
+Recipes must read helper JSON on both zero and nonzero exits. The exit code
+chooses control flow; the JSON chooses provider state, next action, and terminal
+classification.

--- a/docs/reference/workflow-runtime-artifacts.md
+++ b/docs/reference/workflow-runtime-artifacts.md
@@ -4,8 +4,7 @@ This reference defines the runtime-root, cleanup, and guard-point contracts used
 by `default-workflow`, recovery flows, launchers, provenance logging, publish
 helpers, and finalization helpers.
 
-Status: Planned implementation contract.
-Updated: 2026-06-18
+Updated: 2026-06-19
 
 ## Contents
 
@@ -26,6 +25,8 @@ Updated: 2026-06-18
 | `AMPLIHACK_RECIPE_RUN_ID` | Set by `amplihack recipe run` | Stable per-run ID used in default runtime-root paths and log correlation. |
 | `XDG_RUNTIME_DIR` | Read | Preferred platform runtime base when `AMPLIHACK_RUNTIME_ROOT` is unset. |
 | `TMPDIR` | Read indirectly | Host temporary directory preference for tools that create additional scratch output. |
+| `AMPLIHACK_AGENT_BINARY` | Propagated | Active agent runtime for child agentic steps. |
+| `AMPLIHACK_NONINTERACTIVE` | Propagated | Forces child workflow and helper processes into non-interactive mode. |
 
 `AMPLIHACK_RUNTIME_ROOT` is treated only as a filesystem path. Recipes and shell
 helpers quote it and never evaluate it as shell code.
@@ -71,6 +72,11 @@ write generated runtime output into the task worktree.
 Launcher context files used for active-agent routing belong under the runtime
 root. `<worktree>/.claude/runtime/launcher_context.json` is legacy fallback
 state only and must not be treated as canonical by new workflow code.
+
+Process metadata for nested agents, workstreams, provider helper calls, and
+simulation runs is stored under the runtime root. Recipes use that metadata for
+scoped closure and finalization instead of relying on host-global process lists
+or stale PID-only records.
 
 ## Known worktree-local artifacts
 
@@ -185,3 +191,6 @@ Regression coverage for workflow runtime isolation verifies:
    an external default path.
 6. Launcher state and provenance output are written under the shared runtime
    root contract.
+7. Child workflows inherit `AMPLIHACK_RUNTIME_ROOT`, `AMPLIHACK_AGENT_BINARY`,
+   and non-interactive settings without recomputing or leaking runtime state into
+   the commit worktree.

--- a/docs/reference/workflow-simulation.md
+++ b/docs/reference/workflow-simulation.md
@@ -169,15 +169,15 @@ envelope with the simulation result under `data`:
     "agent_contracts": {
       "finalizer": {
         "schema_version": 1,
-        "terminal_state": "MANUAL_REQUIRED",
-        "terminal_success": false,
+        "terminal_state": "FOLLOWUP_CREATED",
+        "terminal_success": true,
         "confidence": "high",
-        "reason": "Azure Boards tracking succeeded and Azure Repos PR creation is manual.",
-        "required_next_action": "Create an Azure Repos pull request from the pushed branch.",
+        "reason": "Azure Boards tracking and Azure Repos PR creation succeeded.",
+        "required_next_action": "Monitor Azure Repos PR validation.",
         "hollow_success_detected": false,
         "evidence_used": [
           "provider=AzureDevOps",
-          "change_requests=ManualRequired"
+          "change_requests=Automated"
         ]
       }
     }

--- a/docs/reference/workflow-simulation.md
+++ b/docs/reference/workflow-simulation.md
@@ -1,0 +1,223 @@
+# Recipe Simulation Reference
+
+> [Home](../index.md) > Reference > Recipe Simulation
+
+Recipe simulation runs representative workflow paths with fake providers, fake
+tools, and fake agents. It validates recipe behavior without live GitHub, Azure
+DevOps, network, or model calls.
+
+## Purpose
+
+Simulation tests protect workflow contracts that are difficult or expensive to
+exercise against live services:
+
+- provider detection and routing
+- typed helper JSON consumption
+- agentic contract validation
+- terminal/finalization state
+- runtime isolation
+- stale/superseded cleanup
+- manual and blocked provider paths
+
+Simulation is deterministic. If a test needs adaptation or judgment, the fake
+agent returns structured JSON and the deterministic validator decides whether it
+is acceptable.
+
+## Command
+
+```bash
+amplihack workflow simulate-recipe <RECIPE> \
+  --scenario <SCENARIO> \
+  --repo-fixture <PATH> \
+  --format json
+```
+
+Example:
+
+```bash
+amplihack workflow simulate-recipe default-workflow \
+  --scenario github-success \
+  --repo-fixture tests/fixtures/workflows/repos/github-repo \
+  --format json
+```
+
+## Scenario file
+
+Scenario files live under `tests/fixtures/workflows/scenarios/*.yaml`.
+Repository fixtures live under `tests/fixtures/workflows/repos/<name>/`.
+Snapshot expectations live beside scenarios as
+`tests/fixtures/workflows/snapshots/<scenario>.json`.
+
+Scenario files describe fake provider, fake tool, fake agent, expected terminal
+state, and forbidden-call behavior:
+
+```yaml
+name: github-success
+recipe: default-workflow
+repo_fixture: tests/fixtures/workflows/repos/github-repo
+provider:
+  kind: GitHub
+  capabilities:
+    tracking_items: Automated
+    change_requests: Automated
+    stale_cleanup: Automated
+tools:
+  git:
+    status: clean
+    base_ref: main
+  gh:
+    issue_create:
+      id: "123"
+      url: "https://github.com/acme/service/issues/123"
+    pr_create:
+      id: "812"
+      url: "https://github.com/acme/service/pull/812"
+agents:
+  finalizer:
+    output:
+      schema_version: 1
+      terminal_state: FOLLOWUP_CREATED
+      terminal_success: true
+      confidence: high
+      reason: "Workflow published PR #812 with verification evidence."
+      required_next_action: "Wait for review and required checks."
+      hollow_success_detected: false
+      evidence_used:
+        - "change_request.id=812"
+        - "verification.completed=true"
+expect:
+  terminal_state: FOLLOWUP_CREATED
+  terminal_success: true
+  forbidden_calls:
+    - az.boards.work-item.create
+    - az.repos.pr.create
+```
+
+Use canonical terminal-state names in fixtures:
+
+```yaml
+expect:
+  terminal_state: FOLLOWUP_CREATED
+```
+
+Legacy Rust-style terminal names may be accepted by fixture loaders during the
+migration window, but snapshots must store canonical `SCREAMING_SNAKE_CASE`
+values.
+
+## Fake runtime contracts
+
+Simulation replaces live dependencies with deterministic fakes:
+
+| Fake | Contract |
+| --- | --- |
+| Fake provider | Implements the same provider adapter trait as live adapters, returns helper-envelope JSON, and records each provider operation. |
+| Fake tool runner | Replaces `git`, `gh`, `az`, network, and filesystem-sensitive provider calls with scripted outputs from the scenario file. |
+| Fake agent | Returns structured JSON from the `agents` section. It never calls a model and never emits unstructured prose unless the scenario is testing invalid output. |
+| Forbidden-call monitor | Fails the simulation immediately if a command listed in `expect.forbidden_calls` or derived from a provider boundary is invoked. |
+
+Forbidden calls are not merely reported. A scenario fails if a forbidden command
+is observed, even when the final terminal state otherwise matches.
+
+## Required scenarios
+
+Every material workflow behavior has at least one simulation or unit test. The
+standard recipe simulation suite includes:
+
+| Scenario | Expected behavior |
+| --- | --- |
+| `github-success` | GitHub issue and PR paths succeed through adapters. |
+| `github-blocked-auth` | Missing GitHub auth returns `BlockedManualProvider`. |
+| `azdo-work-item-manual-pr` | Azure Boards work item succeeds; Azure Repos PR creation returns `ManualRequired`. |
+| `azdo-blocked-boards` | Missing Azure Boards setup returns manual or blocked state without calling GitHub. |
+| `manual-provider` | Provider commands are not invoked; next action is provider-neutral. |
+| `agent-invalid-json` | Agentic step fails closed through contract validation. |
+| `hollow-success` | Empty or generic agent output becomes `HOLLOW_SUCCESS` or missing terminal evidence. |
+| `runtime-isolation` | Runtime artifacts are written outside the worktree and known leftovers are cleaned before guard-sensitive steps. |
+| `stale-cleanup-dry-run` | Superseded candidates are reported without mutation. |
+| `stale-cleanup-apply` | Cleanup mutates only validated scoped candidates. |
+
+## Output
+
+`amplihack workflow simulate-recipe ... --format json` emits the normal helper
+envelope with the simulation result under `data`:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "AzureDevOps",
+  "operation": "SimulateRecipe",
+  "status": "Succeeded",
+  "next_action": "Create an Azure Repos pull request from the pushed branch.",
+  "warnings": [],
+  "data": {
+    "recipe": "default-workflow",
+    "scenario": "azdo-work-item-manual-pr",
+    "terminal_state": "MANUAL_REQUIRED",
+    "terminal_success": false,
+    "assertions": {
+      "failed": 0,
+      "items": ["TerminalStateMatched", "TerminalSuccessMatched", "ForbiddenCallsAbsent"]
+    },
+    "provider_calls": [
+      "az.boards.work-item.show",
+      "az.boards.work-item.create"
+    ],
+    "forbidden_calls": [
+      "gh.issue.create",
+      "gh.pr.create"
+    ],
+    "agent_contracts": {
+      "finalizer": {
+        "schema_version": 1,
+        "terminal_state": "MANUAL_REQUIRED",
+        "terminal_success": false,
+        "confidence": "high",
+        "reason": "Azure Boards tracking succeeded and Azure Repos PR creation is manual.",
+        "required_next_action": "Create an Azure Repos pull request from the pushed branch.",
+        "hollow_success_detected": false,
+        "evidence_used": [
+          "provider=AzureDevOps",
+          "change_requests=ManualRequired"
+        ]
+      }
+    }
+  }
+}
+```
+
+## Snapshot expectations
+
+Simulation snapshots store the helper envelope after volatile fields are removed.
+Snapshots must include:
+
+1. provider,
+2. operation,
+3. status,
+4. next action,
+5. terminal state and success,
+6. provider calls,
+7. forbidden-call assertions,
+8. agent contract validation results, and
+9. runtime artifact locations relative to the simulation runtime root.
+
+Snapshot updates are intentional maintenance. Use an explicit update flag such
+as `--update-snapshots`; ordinary simulation runs must fail on snapshot drift.
+
+## Regression contract
+
+Simulation tests fail when:
+
+1. a recipe calls a provider command outside its adapter,
+2. a recipe parses provider prose instead of helper JSON,
+3. an agentic step emits non-JSON or unsupported states,
+4. a manual/blocked provider path is reported as success,
+5. runtime artifacts appear in the commit worktree,
+6. terminal state is missing from final output, or
+7. stale cleanup mutates a candidate that was not validated by scope and dry-run
+   evidence.
+
+## See also
+
+- [Tutorial: Simulate Provider-Neutral Workflows](../tutorials/provider-neutral-workflow-simulation.md)
+- [Provider-Neutral Workflow API](workflow-provider-contract.md)
+- [Workflow Runtime Artifacts Reference](workflow-runtime-artifacts.md)

--- a/docs/reference/workflow-terminal-state-provider-safety.md
+++ b/docs/reference/workflow-terminal-state-provider-safety.md
@@ -1,10 +1,10 @@
 # Workflow Terminal-State Provider Safety
 
-`workflow-terminal-state` is provider-aware. The provider-safe implementation
-uses GitHub pull-request metadata only for GitHub-backed remotes or explicit
-GitHub pull-request URLs. Azure Repos, `visualstudio.com`,
-`ssh.dev.azure.com`, and unknown remotes use local Git evidence instead and do
-not require the GitHub CLI.
+`workflow-terminal-state` is provider-neutral. It uses provider adapters for
+change-request metadata and falls back to local Git evidence only when that is
+safe for the requested terminal state. GitHub pull-request metadata is used only
+by the GitHub adapter. Azure Repos, `visualstudio.com`, `ssh.dev.azure.com`, and
+unknown remotes never trigger GitHub CLI calls.
 
 > [Home](../index.md) > [Workflows](../claude/workflow/DEFAULT_WORKFLOW.md) > Workflow Terminal-State Provider Safety
 
@@ -19,9 +19,9 @@ The feature has three guarantees:
 
 | Guarantee | Behavior |
 | --- | --- |
-| Provider-aware metadata | `gh pr view`, `gh pr list`, and related GitHub metadata commands run only when the explicit PR URL or `origin` remote is GitHub-backed. A bare `pr_number` never enables GitHub support by itself. |
+| Provider-aware metadata | Provider metadata commands run only through the detected provider adapter. A bare provider-specific number never enables a different provider by itself. |
 | Local safety everywhere | Clean worktree, resolvable base ref, branch/base diff, and commits-ahead checks run for every provider. |
-| GitHub fail-closed semantics | GitHub remotes and GitHub PR URLs still require trustworthy GitHub PR metadata when metadata is needed to prove a GitHub PR state or to decide whether meaningful local work is safe to close. |
+| Provider fail-closed semantics | Provider remotes and provider change-request URLs require trustworthy matching metadata when metadata is needed to prove a change-request state or to decide whether meaningful local work is safe to close. |
 
 `gh` is optional for Azure Repos and unknown remotes. Missing GitHub PR
 metadata is not a terminal-state failure merely because a probe is running in a
@@ -38,10 +38,10 @@ Provider detection starts with the most explicit signal and falls back to
 
 1. If `pr_url` is present, classify that URL.
 2. Otherwise classify `git config --get remote.origin.url`.
-3. Enable GitHub PR metadata only after a positive GitHub match.
-4. Treat every other remote as non-GitHub/unknown.
-5. Use `pr_number` only after GitHub metadata is enabled; a bare number is not
-   provider evidence.
+3. Enable provider metadata only after a positive provider match.
+4. Treat every unsupported remote as local/unknown.
+5. Use provider-specific IDs only after provider metadata is enabled; a bare
+   number is not provider evidence.
 
 | Input example | Provider classification | GitHub PR metadata |
 | --- | --- | --- |
@@ -56,9 +56,8 @@ Provider detection starts with the most explicit signal and falls back to
 | `https://gitlab.com/OWNER/REPO.git` | Unknown/non-GitHub | Disabled |
 | No `origin` remote | Unknown/non-GitHub | Disabled |
 
-Non-GitHub PR URLs are recognized as non-GitHub provider signals and otherwise
-treated as opaque. They are not parsed as provider-native PRs, are not parsed as
-GitHub owner/repo/PR identifiers, and never trigger `gh`.
+Non-GitHub change-request URLs are recognized as non-GitHub provider signals and
+never trigger `gh`.
 
 ## Safety Model
 
@@ -113,8 +112,9 @@ current decision depends on that metadata. Clean no-diff proof can still return
 
 ### Non-GitHub fallback
 
-For Azure Repos and unknown remotes, terminal-state validation intentionally
-does not inspect provider PR metadata. It does not call:
+For Azure Repos and unknown remotes without configured change-request automation,
+terminal-state validation intentionally does not inspect provider PR metadata. It
+does not call:
 
 ```bash
 gh pr list
@@ -130,7 +130,7 @@ The local Git gates remain authoritative:
 | Missing or unresolved base ref | Terminal-state validation fails with an actionable base-ref error. |
 | Clean no-diff branch | `NO_DIFF_SUCCESS` is allowed without GitHub metadata. |
 | Clean branch with no meaningful diff but commits ahead | `CLOSED_OBSOLETE` is allowed as superseded/no-diff evidence. |
-| Meaningful branch/base diff | Terminal success is denied; the workflow must publish, remove, merge, or supersede the diff. |
+| Meaningful branch/base diff | Terminal success is denied; the workflow must publish, remove, merge, supersede the diff, or return `ManualRequired` with a next action. |
 
 ## Usage
 
@@ -177,8 +177,10 @@ export NODE_OPTIONS=--max-old-space-size=32768
 | `should_finalize` | `true` when finalization should emit a non-mutating final decision. |
 | `should_run_ci_wait` | `true` only when CI waiting remains valid for the active provider path. |
 | `should_merge` | `true` only when merge remains valid for green, active work. |
-| `pr_url` | GitHub PR URL when GitHub metadata identified one; empty for non-GitHub local-only probes. |
-| `pr_number` | GitHub PR number when GitHub metadata identified one; empty for non-GitHub local-only probes. |
+| `change_request_url` | Provider change-request URL when metadata identified one; empty for local-only probes. |
+| `change_request_id` | Provider change-request identifier when metadata identified one. |
+| `pr_url` | GitHub compatibility URL when GitHub metadata identified one; empty for non-GitHub local-only probes. |
+| `pr_number` | GitHub compatibility number when GitHub metadata identified one; empty for non-GitHub local-only probes. |
 | `branch_diff_status` | `no-diff`, `has-diff`, or `unknown`. |
 | `commits_ahead` | Number of commits ahead of `base_ref`, when countable. |
 

--- a/docs/reference/workflow-terminal-state.md
+++ b/docs/reference/workflow-terminal-state.md
@@ -62,7 +62,7 @@ A protected workflow exits `0` only when one of these evidence groups is present
 | Evidence group | Required proof | Typical producer |
 | --- | --- | --- |
 | Implementation and verification complete | `implementation_completed=true` and `verification_completed=true` with non-empty reason text or structured detail | `workflow-tdd`, `workflow-precommit-test`, review/feedback phases |
-| Publish or PR state reached | `publish_state_reached=true` with a known publish state such as `FOLLOWUP_CREATED`, `SUPERSEDED`, `MERGED`, `NO_DIFF_SUCCESS`, or `CLOSED_OBSOLETE` | `workflow-publish`, `workflow-finalize` |
+| Publish or change-request state reached | `publish_state_reached=true` with a known publish state such as `FOLLOWUP_CREATED`, `SUPERSEDED`, `MERGED`, `NO_DIFF_SUCCESS`, or `CLOSED_OBSOLETE` | `workflow-publish`, `workflow-finalize` |
 | Explicit terminal no-op | `terminal_no_op=true`, a known no-op state, and a non-empty reason | no-diff, merged, obsolete, superseded, or `allow_no_op` paths |
 
 `terminal_failure=true` is valid terminal evidence, but it is never success
@@ -149,8 +149,10 @@ canonical strings.
 | `terminal_reason` | string | Always | Actionable human-readable explanation. |
 | `observed_phases` | list/string | Failure diagnostics | Phases that produced evidence before the gate ran. |
 | `missing_evidence` | list/string | Failure diagnostics | Evidence required for success but not observed. |
-| `pr_url` | URL string | Publish/PR states | Pull request that represents the completed work. |
-| `pr_number` | positive integer string | Publish/PR states | Pull request number when available. |
+| `change_request_url` | URL string | Publish/change-request states | Provider change request that represents the completed work. |
+| `change_request_id` | string | Publish/change-request states | Provider change-request identifier when available. |
+| `pr_url` | URL string | GitHub compatibility output | GitHub pull request that represents the completed work. |
+| `pr_number` | positive integer string | GitHub compatibility output | GitHub pull request number when available. |
 | `verification_summary` | string/object | Verification completed | Commands or checks that satisfied verification. |
 | `required_next_action` | string | Finalization output | Operator or agent action needed after the terminal decision. |
 | `hollow_success_detected` | boolean | Finalization output | Whether finalization detected a success-looking run without meaningful completion evidence. |
@@ -169,6 +171,8 @@ canonical strings.
 | `CLOSED_OBSOLETE` | Yes | The PR or branch is obsolete and equivalent work is already upstream or no meaningful work remains. |
 | `SUPERSEDED` | Yes | A newer workflow-owned PR or issue explicitly supersedes this run. |
 | `ALLOW_NO_OP` | Yes | `allow_no_op=true` was set for an eligible non-code-change path and includes a reason. |
+| `MANUAL_REQUIRED` | No | A provider action is intentionally manual; `required_next_action` names the action. |
+| `BLOCKED_MANUAL_PROVIDER` | No | Required provider tooling, credentials, permissions, or APIs are unavailable. |
 | `FAILED_MISSING_TERMINAL_EVIDENCE` | No | The workflow stopped before implementation, verification, publish, or valid no-op evidence. |
 | `FAILED_INVALID_EVIDENCE` | No | Evidence is malformed, unknown, empty, or contradictory. |
 | `FAILED_FINALIZER_OUTPUT` | No | The agentic finalizer returned missing, malformed, non-JSON, or schema-invalid output. |
@@ -177,7 +181,7 @@ canonical strings.
 | `FAILED_WRONG_BRANCH` | No | The target checkout is not on the expected branch. |
 | `FAILED_INVALID_INPUT` | No | Required context such as repository path, branch, or PR identity is invalid. |
 | `FAILED_MISSING_TOOLING` | No | Required deterministic tooling is unavailable for the selected finalization path. |
-| `FAILED_PR_METADATA_UNAVAILABLE` | No | GitHub PR proof is required but metadata, auth, or provider output is unavailable or ambiguous. |
+| `FAILED_PR_METADATA_UNAVAILABLE` | No | Provider change-request proof is required but metadata, auth, or provider output is unavailable or ambiguous. |
 | `FAILED_CLOSED_UNMERGED` | No | A PR is closed without merge evidence and meaningful local branch diff remains. |
 | `BLOCKED_CI` | No | Required checks are failing or unavailable. |
 | `HOLLOW_SUCCESS` | No | The recipe appeared successful but lacked implementation, verification, publish, or valid no-op evidence. |

--- a/docs/tutorials/dual-provider-workflow.md
+++ b/docs/tutorials/dual-provider-workflow.md
@@ -1,190 +1,99 @@
-# Tutorial: Run the Default Workflow on an Azure DevOps Repository
+# Tutorial: Provider-Aware Workflow Tracking
 
-**Time to complete**: 15 minutes
+> [Home](../index.md) > Tutorials > Provider-Aware Workflow Tracking
 
-This tutorial walks through a `default-workflow` run on an Azure DevOps-backed
-repository and shows how `workflow-prep` avoids GitHub issue commands.
+This compatibility tutorial uses the provider-neutral workflow helpers. For the
+new simulation tutorial, see
+[Tutorial: Simulate Provider-Neutral Workflows](provider-neutral-workflow-simulation.md).
 
-## What You'll Learn
+> [PLANNED - Implementation Pending]
+>
+> The `amplihack workflow ...` helper commands shown here are the target
+> provider-neutral interface.
 
-1. Verify that an AzDO remote is classified as `azdo`
-2. Run `default-workflow` with an existing Azure Boards work item
-3. Confirm that tracking uses Azure Boards or structured local metadata
-4. Create the Azure DevOps pull request manually after the workflow pushes a branch
-
----
-
-## Step 1: Prepare the Environment
-
-Use an Azure DevOps repository clone:
-
-```bash
-cd /path/to/ado-repo
-git remote get-url origin
-```
-
-Expected remote examples:
-
-```text
-https://dev.azure.com/acme/platform/_git/service
-https://acme.visualstudio.com/platform/_git/service
-git@ssh.dev.azure.com:v3/acme/platform/service
-```
-
-Keep the supported Node heap setting for large workflow runs:
+## 1. Detect the provider
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=32768
+
+amplihack workflow detect-provider --repo . --format json
 ```
 
----
+Expected output includes:
 
-## Step 2: Configure Azure Boards, If You Want Provider Tracking
+```json
+{
+  "schema_version": 1,
+  "provider": "GitHub",
+  "operation": "DetectProvider",
+  "status": "Succeeded",
+  "next_action": "No further provider setup is required.",
+  "warnings": [],
+  "data": {}
+}
+```
 
-If you want the workflow to reuse or create Azure Boards work items, configure
-the Azure DevOps CLI:
+## 2. Ensure a tracking item
 
 ```bash
-az extension add --name azure-devops
-az login
-az devops configure --defaults \
-  organization=https://dev.azure.com/acme \
-  project=platform
+amplihack workflow tracking-item ensure \
+  --repo . \
+  --title "Fix authentication timeout" \
+  --body-file workflow-body.md \
+  --format json
 ```
 
-If you skip this step, `workflow-prep` still classifies the repo as `azdo`, but
-step 03 falls back to local tracking instead of trying GitHub.
+GitHub returns a GitHub issue. Azure DevOps returns an Azure Boards work item
+when configured. Local and unsupported repositories return local/manual state
+with `next_action`.
 
----
-
-## Step 3: Run the Workflow with an Existing Work Item
-
-Run `default-workflow` with an Azure Boards reference in the task description:
-
-```bash
-amplihack recipe run default-workflow \
-  -c "task_description=Fix the session timeout bug described in AB#12345" \
-  -c "repo_path=$(pwd)"
-```
-
-During `workflow-prep`, the route is:
-
-```text
-step-02d-detect-host-type -> REMOTE_HOST_TYPE=azdo
-step-03-create-issue -> Azure Boards/local tracking path
-```
-
-GitHub issue and label commands are skipped before command construction. The
-AzDO path does not run:
-
-```text
-gh issue view
-gh issue list
-gh issue create
-gh label list
-gh label create
-```
-
----
-
-## Step 4: Read the Tracking Output
-
-When Azure Boards resolves the work item, step 03 emits a parseable Azure
-Boards reference:
-
-```text
-AB#12345
-```
-
-or a full work-item URL:
-
-```text
-https://dev.azure.com/acme/platform/_workitems/edit/12345
-```
-
-If Azure Boards is unavailable, step 03 emits structured local metadata:
-
-```text
-tracking_system=local
-tracking_reference=local-12345
-tracking_issue=local-12345
-issue_creation=local-tracking
-issue_number=
-```
-
-Provider URLs and `AB#N` preserve the downstream numeric `issue_number`
-contract. Local metadata uses a local-prefixed `tracking_reference` /
-`tracking_issue`, preserves that reference downstream, and leaves
-`issue_number` empty.
-
----
-
-## Step 5: Let the Workflow Continue
-
-After tracking setup, the normal development steps run against the local git
-checkout:
-
-| Phase | Provider behavior |
-| ----- | ----------------- |
-| Worktree setup | Uses local git only |
-| Design and implementation | Provider-independent |
-| Tests and pre-commit | Provider-independent |
-| Commit and push | Uses normal `git push origin <branch>` |
-| PR creation | Automated only for GitHub; AzDO reports manual PR instructions |
-
-Commit references use Azure Boards syntax when the host type is `azdo`:
-
-```text
-AB#12345
-```
-
----
-
-## Step 6: Create the Azure DevOps PR Manually
-
-After the workflow pushes the branch, create the PR with Azure DevOps:
-
-```bash
-az repos pr create \
-  --source-branch "$(git branch --show-current)" \
-  --target-branch main \
-  --title "Fix the session timeout bug (AB#12345)" \
-  --description "Implements the fix for AB#12345."
-```
-
-You can also create the PR from the Azure DevOps web UI.
-
----
-
-## Step 7: Try the Local Fallback Path
-
-To see the provider-safe fallback, run the workflow without Azure Boards
-configuration or with `remote_host_type=other`:
+## 3. Run the workflow
 
 ```bash
 amplihack recipe run default-workflow \
-  -c remote_host_type=other \
-  -c "task_description=Add config parser" \
-  -c "repo_path=$(pwd)"
+  -c task_description="Fix authentication timeout" \
+  -c repo_path=. \
+  --format json
 ```
 
-Expected tracking output:
+The final result includes provider, tracking item, change-request state, terminal
+state, and required next action.
 
-```text
-tracking_system=local
-tracking_reference=local-482193
-tracking_issue=local-482193
-issue_creation=local-tracking
-issue_number=
+## 4. Validate manual Azure DevOps publication
+
+For Azure DevOps repositories, publication output uses `ManualRequired`:
+
+```json
+{
+  "schema_version": 1,
+  "provider": "AzureDevOps",
+  "operation": "PublishChangeRequest",
+  "status": "ManualRequired",
+  "next_action": "Create an Azure Repos pull request from the pushed branch.",
+  "warnings": [],
+  "data": {
+    "change_request": null,
+    "manual_action": {
+      "kind": "CreateChangeRequest",
+      "source_branch": "feat/auth-timeout",
+      "base_branch": "main"
+    }
+  }
+}
 ```
 
-No GitHub or Azure DevOps provider command runs in this mode.
+Create the provider PR manually, then rerun terminal-state validation:
 
----
+```bash
+amplihack workflow terminal-state \
+  --repo . \
+  --branch "$(git branch --show-current)" \
+  --base main \
+  --format json
+```
 
-## Summary
+## See also
 
-You ran the workflow on an Azure DevOps-backed repository. `workflow-prep`
-classified the remote as `azdo`, kept all GitHub issue and label commands out
-of the AzDO path, preserved numeric `issue_number` for Azure Boards, and
-preserved local references without numeric coercion for local tracking.
+- [Configure Provider-Neutral Workflows](../howto/configure-provider-neutral-workflows.md)
+- [Provider-Neutral Workflow API](../reference/workflow-provider-contract.md)
+- [Recipe Simulation Reference](../reference/workflow-simulation.md)

--- a/docs/tutorials/provider-neutral-workflow-simulation.md
+++ b/docs/tutorials/provider-neutral-workflow-simulation.md
@@ -2,12 +2,6 @@
 
 > [Home](../index.md) > Tutorials > Simulate Provider-Neutral Workflows
 
-> [PLANNED - Implementation Pending]
->
-> This tutorial describes the deterministic simulation feature to build. The
-> `amplihack workflow simulate-recipe` command is planned until implementation
-> lands.
-
 This tutorial shows how to validate a workflow path without live provider calls.
 
 ## What you will do

--- a/docs/tutorials/provider-neutral-workflow-simulation.md
+++ b/docs/tutorials/provider-neutral-workflow-simulation.md
@@ -1,0 +1,92 @@
+# Tutorial: Simulate Provider-Neutral Workflows
+
+> [Home](../index.md) > Tutorials > Simulate Provider-Neutral Workflows
+
+> [PLANNED - Implementation Pending]
+>
+> This tutorial describes the deterministic simulation feature to build. The
+> `amplihack workflow simulate-recipe` command is planned until implementation
+> lands.
+
+This tutorial shows how to validate a workflow path without live provider calls.
+
+## What you will do
+
+You will run a deterministic simulation for an Azure DevOps repository where
+Azure Boards tracking succeeds and Azure Repos pull-request creation requires a
+manual action.
+
+## 1. Run the scenario
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=32768
+
+amplihack workflow simulate-recipe default-workflow \
+  --scenario azdo-work-item-manual-pr \
+  --repo-fixture tests/fixtures/workflows/azdo-repo \
+  --format json > simulation.json
+```
+
+## 2. Inspect the provider result
+
+```bash
+jq '.provider, .data.terminal_state, .data.terminal_success, .next_action' simulation.json
+```
+
+Expected output:
+
+```text
+"AzureDevOps"
+"MANUAL_REQUIRED"
+false
+"Create an Azure Repos pull request from the pushed branch."
+```
+
+## 3. Confirm forbidden calls did not run
+
+```bash
+jq '.data.forbidden_calls' simulation.json
+```
+
+Expected output:
+
+```json
+[
+  "gh.issue.create",
+  "gh.pr.create"
+]
+```
+
+The simulation fails if the recipe invokes those calls. Listing them here means
+the simulator watched for them and confirmed they were not used.
+
+## 4. Validate the finalizer contract
+
+```bash
+jq '.data.agent_contracts.finalizer' simulation.json > finalizer.json
+
+amplihack workflow validate-agent-contract \
+  --contract finalization \
+  --input finalizer.json \
+  --format json
+```
+
+Expected output includes:
+
+```json
+{
+  "status": "Succeeded",
+  "contract": "finalization"
+}
+```
+
+## 5. Use the result
+
+The scenario proves the recipe handles this path correctly:
+
+- Azure Boards tracking uses the Azure DevOps adapter.
+- GitHub commands are not invoked.
+- Azure Repos publication is explicit `MANUAL_REQUIRED`, not fake success.
+- Final output includes `next_action`.
+
+For reference details, see [Recipe Simulation Reference](../reference/workflow-simulation.md).

--- a/docs/tutorials/workflow-runtime-isolation.md
+++ b/docs/tutorials/workflow-runtime-isolation.md
@@ -3,8 +3,7 @@
 This tutorial shows how a workflow keeps generated runtime output out of a task
 worktree while preserving strict Artifact Guard behavior.
 
-Status: Planned implementation contract.
-Updated: 2026-06-18
+Updated: 2026-06-19
 
 ## What you will learn
 


### PR DESCRIPTION
## Summary

Implements the issue 791 trend-based workflow improvement program as a provider-neutral foundation:

- Adds pure `amplihack-workflows` contracts for providers, change requests, terminal states, agent finalizer validation, deterministic recipe simulation, and stale/superseded cleanup planning.
- Adds `amplihack workflow ...` helper commands in `amplihack-cli` that emit typed JSON envelopes and return explicit manual states for Azure DevOps/manual paths instead of pretending automation succeeded.
- Moves deterministic hollow-success and runtime-isolation behavior into typed Rust runtime handling with regression coverage.
- Adds deterministic simulation/contract tests for provider behavior, finalizer validation, forbidden provider calls, stale cleanup, CI resource discipline, and runtime isolation.
- Tightens GitHub Actions resource discipline with top-level concurrency, job timeouts, and `rust-cache` target-cache boundaries.
- Updates provider-neutral docs and provider-specific guidance so shared workflow concepts no longer assume GitHub-only behavior.

## Inherited requirements addressed

- Provider-aware GitHub/Azure DevOps workflow abstraction with explicit manual/blocked states.
- Deterministic brittle shell parsing moved into typed Rust helpers where appropriate.
- Judgment-heavy paths remain agentic but validate through deterministic contracts.
- E2E-style deterministic recipe simulation uses fake providers/tools/agents, not live GitHub/AzDO calls.
- Runtime isolation and terminal/finalization state are explicit.
- CI resource boundaries are enforced by tests.
- Stale/superseded cleanup is dry-run/tested through provider-neutral contracts.
- Documentation is provider-neutral unless describing provider-specific behavior.

## Validation

- `pre-commit run --all-files`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p amplihack-workflows --tests --locked`
- `cargo test -p amplihack-cli workflow --locked`
- `cargo test -p amplihack-cli ci_resource_discipline_tests --locked`
- Targeted runtime parser/isolation regression tests for hollow success and isolated runtime dirs

## Closure state

Ready for review. If this repository permits auto-merge after required checks, this PR can be merged once CI is green.
