### PR TITLE
Fix workflow commit author attribution

### DIFF
--- a/amplifier-bundle/recipes/consensus-pr-feedback.yaml
+++ b/amplifier-bundle/recipes/consensus-pr-feedback.yaml
@@ -35,8 +35,19 @@ steps:
         exit 1
       fi
       amplihack hygiene artifact-guard --repo . --mode pre-publish
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$GIT_IDENTITY_HELPER"
       git add -A
-      git commit -m "Address PR review feedback" || echo "Nothing to commit (working tree clean)" >&2
+      STAGED=$(git diff --cached --name-only)
+      if [ -n "$STAGED" ]; then
+        amplihack_prepare_git_commit_identity
+        git commit -m "Address PR review feedback"
+      else
+        echo "Nothing to commit (working tree clean)" >&2
+      fi
       if git remote get-url origin >/dev/null 2>&1; then
         git pull --rebase || echo "WARNING: rebase failed, pushing anyway" >&2
         git push || echo "WARNING: push failed — may need manual push" >&2

--- a/amplifier-bundle/recipes/consensus-pr-feedback.yaml
+++ b/amplifier-bundle/recipes/consensus-pr-feedback.yaml
@@ -35,14 +35,10 @@ steps:
         exit 1
       fi
       amplihack hygiene artifact-guard --repo . --mode pre-publish
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         git commit -m "Address PR review feedback"
       else

--- a/amplifier-bundle/recipes/consensus-publish.yaml
+++ b/amplifier-bundle/recipes/consensus-publish.yaml
@@ -33,6 +33,11 @@ steps:
 
       # Stage all changes
       amplihack hygiene artifact-guard --repo . --mode pre-publish
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$GIT_IDENTITY_HELPER"
       git add -A
 
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
@@ -59,7 +64,19 @@ steps:
       COMMIT_EOF
       )
 
-      git commit -m "$COMMIT_MSG" 2>/dev/null || echo "Commit prepared"
+      COMMITTED=false
+      if [ -n "$(git diff --cached --name-only)" ]; then
+        amplihack_prepare_git_commit_identity
+        if git commit -m "$COMMIT_MSG"; then
+          COMMITTED=true
+        else
+          commit_rc=$?
+          echo "ERROR: git commit failed during consensus step9-commit (exit $commit_rc)" >&2
+          exit "$commit_rc"
+        fi
+      else
+        echo "No staged changes to commit" >&2
+      fi
       PUSH_RESULT=false
       PUSH_REASON="no_remote"
       if git remote get-url origin >/dev/null 2>&1; then
@@ -73,7 +90,7 @@ steps:
         echo "Skipping push — no remote configured" >&2
       fi
 
-      echo "{\"committed\": true, \"pushed\": $PUSH_RESULT, \"push_reason\": \"$PUSH_REASON\"}"
+      echo "{\"committed\": $COMMITTED, \"pushed\": $PUSH_RESULT, \"push_reason\": \"$PUSH_REASON\"}"
     output: "commit_result"
     parse_json: true
 

--- a/amplifier-bundle/recipes/consensus-publish.yaml
+++ b/amplifier-bundle/recipes/consensus-publish.yaml
@@ -33,11 +33,6 @@ steps:
 
       # Stage all changes
       amplihack hygiene artifact-guard --repo . --mode pre-publish
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$GIT_IDENTITY_HELPER"
       git add -A
 
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
@@ -66,6 +61,7 @@ steps:
 
       COMMITTED=false
       if [ -n "$(git diff --cached --name-only)" ]; then
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         if git commit -m "$COMMIT_MSG"; then
           COMMITTED=true

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -116,11 +116,17 @@ steps:
       RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] && . "$RUNTIME_ARTIFACT_HELPER" && preflight_known_workflow_runtime_artifacts . || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
       amplihack hygiene artifact-guard --repo . --mode pre-publish
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
         commit_with_pre_commit_guard() {
           local pre_commit_hook
+          amplihack_prepare_git_commit_identity
           pre_commit_hook="$(git rev-parse --git-path hooks/pre-commit)"
           if [ -f "$pre_commit_hook" ] && [ ! -f .pre-commit-config.yaml ]; then
             PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit "$@"

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -115,11 +115,7 @@ steps:
       fi
       RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] && . "$RUNTIME_ARTIFACT_HELPER" && preflight_known_workflow_runtime_artifacts . || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$GIT_IDENTITY_HELPER"
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -115,11 +115,11 @@ steps:
       fi
       RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] && . "$RUNTIME_ARTIFACT_HELPER" && preflight_known_workflow_runtime_artifacts . || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -115,12 +115,12 @@ steps:
       fi
       RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] && . "$RUNTIME_ARTIFACT_HELPER" && preflight_known_workflow_runtime_artifacts . || { echo "ERROR: workflow runtime artifact helper not found: $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
-      amplihack hygiene artifact-guard --repo . --mode pre-publish
       GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
       [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
       [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
       # shellcheck source=/dev/null
       . "$GIT_IDENTITY_HELPER"
+      amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -189,14 +189,10 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel)}/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel)}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_output_file=$(mktemp -t step18c-review-feedback-commit-XXXXXX)
         commit_with_pre_commit_guard() {
           local pre_commit_hook

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -189,12 +189,18 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
         commit_output_file=$(mktemp -t step18c-review-feedback-commit-XXXXXX)
         commit_with_pre_commit_guard() {
           local pre_commit_hook
+          amplihack_prepare_git_commit_identity
           pre_commit_hook="$(git rev-parse --git-path hooks/pre-commit)"
           if [ -f "$pre_commit_hook" ] && [ ! -f .pre-commit-config.yaml ]; then
             PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit "$@"

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -189,7 +189,7 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel)}/amplifier-bundle/tools/git-identity.sh"
       [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
       [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
       # shellcheck source=/dev/null

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -126,6 +126,11 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$GIT_IDENTITY_HELPER"
       git add -A
       echo "--- Creating Commit ---" >&2
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
@@ -141,6 +146,7 @@ steps:
       esac
       COMMIT_MSG=$(printf '%s\n\nImplements %s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\n%s' "$COMMIT_TITLE" "$ISSUE_IMPL" "$ISSUE_REF")
       if [ -n "$(git diff --cached --name-only)" ]; then
+        amplihack_prepare_git_commit_identity
         git commit -m "$COMMIT_MSG"
       else
         # FIX (#282): hollow-success false-positive when agent worked in an
@@ -273,7 +279,12 @@ steps:
           distribution validation when that project shape warrants it.
        5. If a test fails, diagnose, fix, commit, push, and retry up to 3 times:
           ```bash
-          amplihack hygiene artifact-guard --repo . --mode pre-publish && git add -A && git commit -m "fix: <describe the fix found during outside-in testing>"
+          GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+          . "$GIT_IDENTITY_HELPER"
+          amplihack hygiene artifact-guard --repo . --mode pre-publish && git add -A
+          amplihack_prepare_git_commit_identity
+          git commit -m "fix: <describe the fix found during outside-in testing>"
           git pull --rebase && git push
           ```
        6. If failures persist after 3 iterations, document them honestly.

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -126,11 +126,6 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$GIT_IDENTITY_HELPER"
       git add -A
       echo "--- Creating Commit ---" >&2
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
@@ -146,6 +141,7 @@ steps:
       esac
       COMMIT_MSG=$(printf '%s\n\nImplements %s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\n%s' "$COMMIT_TITLE" "$ISSUE_IMPL" "$ISSUE_REF")
       if [ -n "$(git diff --cached --name-only)" ]; then
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         git commit -m "$COMMIT_MSG"
       else

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -223,11 +223,17 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
         commit_with_pre_commit_guard() {
           local pre_commit_hook
+          amplihack_prepare_git_commit_identity
           pre_commit_hook="$(git rev-parse --git-path hooks/pre-commit)"
           if [ -f "$pre_commit_hook" ] && [ ! -f .pre-commit-config.yaml ]; then
             PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit "$@"

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -223,14 +223,10 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -346,11 +346,17 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+      # shellcheck source=/dev/null
+      . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
         commit_with_pre_commit_guard() {
           local pre_commit_hook
+          amplihack_prepare_git_commit_identity
           pre_commit_hook="$(git rev-parse --git-path hooks/pre-commit)"
           if [ -f "$pre_commit_hook" ] && [ ! -f .pre-commit-config.yaml ]; then
             PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit "$@"

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -346,11 +346,7 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
-      [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
-      # shellcheck source=/dev/null
-      . "$GIT_IDENTITY_HELPER"
+      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -346,10 +346,10 @@ steps:
       . "$RUNTIME_ARTIFACT_HELPER"
       preflight_known_workflow_runtime_artifacts .
       amplihack hygiene artifact-guard --repo . --mode pre-publish
-      GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/tools/git-identity.sh
+++ b/amplifier-bundle/tools/git-identity.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# Shared Git commit identity resolver for amplihack-managed workflow commits.
+
+amplihack_detect_remote_host_type() {
+    local remote_url="${1:-}"
+    local remote_lower
+
+    if [ -z "$remote_url" ]; then
+        remote_url="$(git remote get-url origin 2>/dev/null || true)"
+    fi
+
+    remote_lower="$(printf '%s' "$remote_url" | tr '[:upper:]' '[:lower:]')"
+    case "$remote_lower" in
+        *github.com:*|*github.com/*)
+            printf 'github\n'
+            ;;
+        *dev.azure.com/*|*visualstudio.com/*|*ssh.dev.azure.com/*)
+            printf 'azdo\n'
+            ;;
+        *)
+            printf 'unknown\n'
+            ;;
+    esac
+}
+
+amplihack_validate_git_identity() {
+    local name="${1:-}"
+    local email="${2:-}"
+    local label="${3:-identity}"
+    local lower_email local_part domain lower_name
+
+    name="$(_amplihack_trim "$name")"
+    email="$(_amplihack_trim "$email")"
+    lower_name="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')"
+    lower_email="$(printf '%s' "$email" | tr '[:upper:]' '[:lower:]')"
+    local_part="${lower_email%@*}"
+    domain="${lower_email#*@}"
+
+    if [ -z "$name" ]; then
+        echo "ERROR: unsafe Git $label: missing name" >&2
+        return 1
+    fi
+    if [ -z "$email" ]; then
+        echo "ERROR: unsafe Git $label: missing email" >&2
+        return 1
+    fi
+    if ! printf '%s' "$email" | grep -Eq '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'; then
+        echo "ERROR: unsafe Git $label: malformed email" >&2
+        return 1
+    fi
+    case "$domain" in
+        localhost|*.localhost|*.local|*.internal|*.lan|*.invalid|localdomain|*.localdomain)
+            echo "ERROR: unsafe Git $label: localhost or private host email domain is not allowed" >&2
+            return 1
+            ;;
+    esac
+    case "$local_part" in
+        azureuser|root|ubuntu|vsts|runner|agent|build|buildagent|svc|service|defaultuser)
+            echo "ERROR: unsafe Git $label: VM/service account email is not allowed" >&2
+            return 1
+            ;;
+    esac
+    case "$lower_name" in
+        ""|"unknown"|"unknown user"|"root"|"build agent"|"azure pipelines"|"azure devops")
+            echo "ERROR: unsafe Git $label: VM/service account name is not allowed" >&2
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+amplihack_resolve_git_identity() {
+    local author_name="" author_email="" committer_name="" committer_email=""
+    local reason=""
+
+    if _amplihack_get_explicit_identity author_name author_email committer_name committer_email reason; then
+        _amplihack_print_identity "$author_name" "$author_email" "$committer_name" "$committer_email"
+        return 0
+    fi
+    if [ -n "$reason" ]; then
+        _amplihack_fail_identity "$reason"
+        return 1
+    fi
+
+    if _amplihack_get_existing_git_env_identity author_name author_email committer_name committer_email reason; then
+        _amplihack_print_identity "$author_name" "$author_email" "$committer_name" "$committer_email"
+        return 0
+    fi
+    if [ -n "$reason" ]; then
+        _amplihack_fail_identity "$reason"
+        return 1
+    fi
+
+    if _amplihack_get_repo_local_identity author_name author_email; then
+        _amplihack_print_identity "$author_name" "$author_email" "$author_name" "$author_email"
+        return 0
+    fi
+
+    if _amplihack_get_provider_identity author_name author_email; then
+        _amplihack_print_identity "$author_name" "$author_email" "$author_name" "$author_email"
+        return 0
+    fi
+
+    _amplihack_fail_identity "no safe explicit, environment, repo-local, or authenticated provider identity was found"
+    return 1
+}
+
+amplihack_prepare_git_commit_identity() {
+    local resolved author_name author_email committer_name committer_email
+
+    resolved="$(amplihack_resolve_git_identity)" || return 1
+    IFS=$'\t' read -r author_name author_email committer_name committer_email <<<"$resolved"
+
+    export GIT_AUTHOR_NAME="$author_name"
+    export GIT_AUTHOR_EMAIL="$author_email"
+    export GIT_COMMITTER_NAME="$committer_name"
+    export GIT_COMMITTER_EMAIL="$committer_email"
+}
+
+_amplihack_get_explicit_identity() {
+    local __author_name_ref="$1" __author_email_ref="$2" __committer_name_ref="$3" __committer_email_ref="$4" __reason_ref="$5"
+    local explicit_author_name explicit_author_email explicit_committer_name explicit_committer_email any_explicit
+
+    explicit_author_name="$(_amplihack_explicit_value AMPLIHACK_GIT_AUTHOR_NAME author_name)"
+    explicit_author_email="$(_amplihack_explicit_value AMPLIHACK_GIT_AUTHOR_EMAIL author_email)"
+    explicit_committer_name="$(_amplihack_explicit_value AMPLIHACK_GIT_COMMITTER_NAME committer_name)"
+    explicit_committer_email="$(_amplihack_explicit_value AMPLIHACK_GIT_COMMITTER_EMAIL committer_email)"
+    any_explicit="$explicit_author_name$explicit_author_email$explicit_committer_name$explicit_committer_email"
+
+    if [ -z "$any_explicit" ]; then
+        printf -v "$__reason_ref" '%s' ""
+        return 1
+    fi
+
+    if [ -z "$explicit_author_name" ] || [ -z "$explicit_author_email" ]; then
+        printf -v "$__reason_ref" '%s' "explicit AMPLIHACK_GIT_AUTHOR_NAME and AMPLIHACK_GIT_AUTHOR_EMAIL must both be set"
+        return 1
+    fi
+    if { [ -n "$explicit_committer_name" ] && [ -z "$explicit_committer_email" ]; } || { [ -z "$explicit_committer_name" ] && [ -n "$explicit_committer_email" ]; }; then
+        printf -v "$__reason_ref" '%s' "explicit AMPLIHACK_GIT_COMMITTER_NAME and AMPLIHACK_GIT_COMMITTER_EMAIL must be set together"
+        return 1
+    fi
+    if [ -z "$explicit_committer_name" ] && [ -z "$explicit_committer_email" ]; then
+        explicit_committer_name="$explicit_author_name"
+        explicit_committer_email="$explicit_author_email"
+    fi
+    if ! amplihack_validate_git_identity "$explicit_author_name" "$explicit_author_email" "author from AMPLIHACK_GIT_*"; then
+        printf -v "$__reason_ref" '%s' "explicit AMPLIHACK_GIT_AUTHOR_* identity is invalid or unsafe"
+        return 1
+    fi
+    if ! amplihack_validate_git_identity "$explicit_committer_name" "$explicit_committer_email" "committer from AMPLIHACK_GIT_*"; then
+        printf -v "$__reason_ref" '%s' "explicit AMPLIHACK_GIT_COMMITTER_* identity is invalid or unsafe"
+        return 1
+    fi
+
+    printf -v "$__author_name_ref" '%s' "$explicit_author_name"
+    printf -v "$__author_email_ref" '%s' "$explicit_author_email"
+    printf -v "$__committer_name_ref" '%s' "$explicit_committer_name"
+    printf -v "$__committer_email_ref" '%s' "$explicit_committer_email"
+    printf -v "$__reason_ref" '%s' ""
+    return 0
+}
+
+_amplihack_get_existing_git_env_identity() {
+    local __author_name_ref="$1" __author_email_ref="$2" __committer_name_ref="$3" __committer_email_ref="$4" __reason_ref="$5"
+    local env_author_name="${GIT_AUTHOR_NAME:-}" env_author_email="${GIT_AUTHOR_EMAIL:-}"
+    local env_committer_name="${GIT_COMMITTER_NAME:-}" env_committer_email="${GIT_COMMITTER_EMAIL:-}"
+    local any_git_env="$env_author_name$env_author_email$env_committer_name$env_committer_email"
+
+    if [ -z "$any_git_env" ]; then
+        printf -v "$__reason_ref" '%s' ""
+        return 1
+    fi
+    if [ -z "$env_author_name" ] || [ -z "$env_author_email" ] || [ -z "$env_committer_name" ] || [ -z "$env_committer_email" ]; then
+        printf -v "$__reason_ref" '%s' "existing GIT_AUTHOR_* and GIT_COMMITTER_* identity must be complete"
+        return 1
+    fi
+    if ! amplihack_validate_git_identity "$env_author_name" "$env_author_email" "author from existing Git environment"; then
+        printf -v "$__reason_ref" '%s' "existing GIT_AUTHOR_* identity is invalid or unsafe"
+        return 1
+    fi
+    if ! amplihack_validate_git_identity "$env_committer_name" "$env_committer_email" "committer from existing Git environment"; then
+        printf -v "$__reason_ref" '%s' "existing GIT_COMMITTER_* identity is invalid or unsafe"
+        return 1
+    fi
+
+    printf -v "$__author_name_ref" '%s' "$env_author_name"
+    printf -v "$__author_email_ref" '%s' "$env_author_email"
+    printf -v "$__committer_name_ref" '%s' "$env_committer_name"
+    printf -v "$__committer_email_ref" '%s' "$env_committer_email"
+    printf -v "$__reason_ref" '%s' ""
+    return 0
+}
+
+_amplihack_get_repo_local_identity() {
+    local __author_name_ref="$1" __author_email_ref="$2"
+    local name email
+
+    name="$(git config --local --get user.name 2>/dev/null || true)"
+    email="$(git config --local --get user.email 2>/dev/null || true)"
+    if [ -z "$name" ] && [ -z "$email" ]; then
+        return 1
+    fi
+    if amplihack_validate_git_identity "$name" "$email" "from repo-local git config" >/dev/null 2>&1; then
+        printf -v "$__author_name_ref" '%s' "$(_amplihack_trim "$name")"
+        printf -v "$__author_email_ref" '%s' "$(_amplihack_trim "$email")"
+        return 0
+    fi
+    return 1
+}
+
+_amplihack_get_provider_identity() {
+    local __author_name_ref="$1" __author_email_ref="$2"
+    local host_type="${REMOTE_HOST_TYPE:-}"
+
+    if [ -z "$host_type" ]; then
+        host_type="$(amplihack_detect_remote_host_type)"
+    fi
+    case "$host_type" in
+        github)
+            _amplihack_get_github_identity "$__author_name_ref" "$__author_email_ref"
+            ;;
+        azdo|azure-devops)
+            _amplihack_get_azdo_identity "$__author_name_ref" "$__author_email_ref"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+_amplihack_get_github_identity() {
+    local __author_name_ref="$1" __author_email_ref="$2"
+    local login id name email
+
+    command -v gh >/dev/null 2>&1 || return 1
+    gh auth status >/dev/null 2>&1 || return 1
+
+    login="$(_amplihack_provider_value gh api user --jq .login)"
+    id="$(_amplihack_provider_value gh api user --jq .id)"
+    name="$(_amplihack_provider_value gh api user --jq .name)"
+    email="$(_amplihack_provider_value gh api user --jq .email)"
+
+    if [ -z "$name" ]; then
+        name="$login"
+    fi
+    if [ -z "$email" ]; then
+        if [ -n "$id" ] && [ -n "$login" ]; then
+            email="${id}+${login}@users.noreply.github.com"
+        fi
+    fi
+
+    if amplihack_validate_git_identity "$name" "$email" "from authenticated GitHub account" >/dev/null 2>&1; then
+        printf -v "$__author_name_ref" '%s' "$name"
+        printf -v "$__author_email_ref" '%s' "$email"
+        return 0
+    fi
+    return 1
+}
+
+_amplihack_get_azdo_identity() {
+    local __author_name_ref="$1" __author_email_ref="$2"
+    local account_name account_type
+
+    command -v az >/dev/null 2>&1 || return 1
+
+    account_name="$(_amplihack_provider_value az account show --query user.name -o tsv)"
+    account_type="$(_amplihack_provider_value az account show --query user.type -o tsv)"
+    account_type="$(printf '%s' "$account_type" | tr '[:upper:]' '[:lower:]')"
+    if [ -n "$account_type" ] && [ "$account_type" != "user" ]; then
+        return 1
+    fi
+
+    if amplihack_validate_git_identity "$account_name" "$account_name" "from authenticated Azure CLI account" >/dev/null 2>&1; then
+        printf -v "$__author_name_ref" '%s' "$account_name"
+        printf -v "$__author_email_ref" '%s' "$account_name"
+        return 0
+    fi
+    return 1
+}
+
+_amplihack_provider_value() {
+    local value
+
+    value="$("$@" 2>/dev/null || true)"
+    value="$(printf '%s' "$value" | sed -n '1p')"
+    value="$(_amplihack_trim "$value")"
+    case "$value" in
+        ""|"null"|"None")
+            return 0
+            ;;
+        *)
+            printf '%s\n' "$value"
+            ;;
+    esac
+}
+
+_amplihack_explicit_value() {
+    local env_name="$1"
+    local config_key="$2"
+    local value="${!env_name:-}"
+
+    if [ -n "$value" ]; then
+        _amplihack_trim "$value"
+        return 0
+    fi
+    _amplihack_config_value "$env_name" "$config_key"
+}
+
+_amplihack_config_value() {
+    local env_name="$1"
+    local config_key="$2"
+    local file value
+
+    while IFS= read -r file; do
+        [ -f "$file" ] || continue
+        value="$(awk -v env_name="$env_name" -v config_key="$config_key" '
+            function trim(s) {
+                sub(/^[[:space:]]+/, "", s)
+                sub(/[[:space:]]+$/, "", s)
+                return s
+            }
+            function unquote(s) {
+                s = trim(s)
+                if ((s ~ /^".*"$/) || (s ~ /^'\''.*'\''$/)) {
+                    s = substr(s, 2, length(s) - 2)
+                }
+                return s
+            }
+            /^[[:space:]]*($|#|;)/ { next }
+            /^[[:space:]]*\[[^]]+\][[:space:]]*$/ {
+                section = $0
+                gsub(/^[[:space:]]*\[/, "", section)
+                gsub(/\][[:space:]]*$/, "", section)
+                section = trim(section)
+                next
+            }
+            index($0, "=") {
+                key = substr($0, 1, index($0, "=") - 1)
+                value = substr($0, index($0, "=") + 1)
+                sub(/[[:space:]]+#.*$/, "", value)
+                sub(/[[:space:]]+;.*$/, "", value)
+                key = trim(key)
+                value = unquote(value)
+                if (key == env_name || key == "git_identity." config_key || (section == "git_identity" && key == config_key)) {
+                    print value
+                    exit
+                }
+            }
+        ' "$file" | sed -n '1p')"
+        if [ -n "$value" ]; then
+            printf '%s\n' "$value"
+            return 0
+        fi
+        value="$(_amplihack_json_config_value "$file" "$config_key")"
+        if [ -n "$value" ]; then
+            printf '%s\n' "$value"
+            return 0
+        fi
+    done < <(_amplihack_candidate_config_files)
+}
+
+_amplihack_json_config_value() {
+    local file="$1"
+    local config_key="$2"
+
+    command -v python3 >/dev/null 2>&1 || return 0
+    python3 - "$file" "$config_key" <<'PY' 2>/dev/null
+import json
+import sys
+
+path, key = sys.argv[1], sys.argv[2]
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    sys.exit(0)
+
+value = data.get("git_identity", {}).get(key)
+if isinstance(value, str) and value:
+    print(value)
+PY
+}
+
+_amplihack_candidate_config_files() {
+    if [ -n "${AMPLIHACK_CONFIG:-}" ]; then
+        printf '%s\n' "$AMPLIHACK_CONFIG"
+    fi
+    if [ -n "${HOME:-}" ]; then
+        printf '%s\n' "$HOME/.amplihack/config"
+    fi
+    if [ -n "${AMPLIHACK_HOME:-}" ]; then
+        printf '%s\n' "$AMPLIHACK_HOME/config"
+        printf '%s\n' "$AMPLIHACK_HOME/.amplihack/config"
+    fi
+}
+
+_amplihack_print_identity() {
+    printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4"
+}
+
+_amplihack_fail_identity() {
+    local reason="$1"
+
+    {
+        echo "ERROR: Amplihack could not determine a safe Git commit identity."
+        echo "Reason: $reason"
+        echo
+        echo "Set explicit identity before running commit-producing workflows:"
+        echo '  export AMPLIHACK_GIT_AUTHOR_NAME="Your Name"'
+        echo '  export AMPLIHACK_GIT_AUTHOR_EMAIL="you@example.com"'
+        echo
+        echo "Optionally set AMPLIHACK_GIT_COMMITTER_NAME and AMPLIHACK_GIT_COMMITTER_EMAIL"
+        echo "when the committer should differ from the author. Alternatively configure"
+        echo "safe repo-local Git identity with:"
+        echo '  git config --local user.name "Your Name"'
+        echo '  git config --local user.email "you@example.com"'
+        echo
+        echo "Amplihack refuses VM/service fallback identities such as azureuser@...,"
+        echo "localhost-style emails, malformed emails, and incomplete identities."
+    } >&2
+}
+
+_amplihack_trim() {
+    printf '%s' "${1:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+}

--- a/docs/howto/configure-workflow-commit-identity.md
+++ b/docs/howto/configure-workflow-commit-identity.md
@@ -1,0 +1,198 @@
+# Configure Workflow Commit Identity
+
+Use explicit commit identity configuration when Amplihack creates commits in
+repositories where provider inference is unavailable or where VM-local Git
+defaults could be unsafe.
+
+Amplihack validates author and committer identity before every workflow-created
+commit. If Amplihack cannot find a safe identity, it fails before running
+`git commit`.
+
+## Choose an identity source
+
+Use the first source that fits your environment:
+
+| Environment | Recommended configuration |
+| --- | --- |
+| Shared VM, Codespace, or Azure-hosted agent | Set `AMPLIHACK_GIT_AUTHOR_NAME` and `AMPLIHACK_GIT_AUTHOR_EMAIL`. |
+| Repeated local workflow runs | Set `git_identity.author_name` and `git_identity.author_email` in `~/.amplihack/config`. |
+| Azure DevOps repository | Use explicit Amplihack variables or repo-local Git config. |
+| GitHub repository with authenticated `gh` | No config required when GitHub identity inference is acceptable. |
+| Existing wrapper already exports Git identity | Export all four safe `GIT_AUTHOR_*` and `GIT_COMMITTER_*` variables. |
+| Repository with a team-specific local identity | Set `git config --local user.name` and `git config --local user.email`. |
+
+## Set explicit Amplihack identity
+
+Export the author identity before running a workflow:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+
+amplihack recipe run default-workflow \
+  -c repo_path=. \
+  -c task_description="Fix provider-safe workflow commit attribution"
+```
+
+When both committer variables are omitted, Amplihack uses the author identity for
+the committer identity too.
+
+Set committer variables only when your workflow intentionally needs separate
+human author and committer attribution:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+export AMPLIHACK_GIT_COMMITTER_NAME="Riley Reviewer"
+export AMPLIHACK_GIT_COMMITTER_EMAIL="riley@example.com"
+
+amplihack recipe run workflow-finalize -c repo_path=.
+```
+
+Amplihack validates both identities. If you set one committer variable, you must
+set the other. Service-looking committer identities are rejected because workflow
+commits must not silently fall back to automation or VM account attribution.
+
+## Save explicit identity in Amplihack config
+
+Use `~/.amplihack/config` when you want the same explicit identity to apply to
+future Amplihack workflow runs without exporting shell variables each time:
+
+```json
+{
+  "git_identity": {
+    "author_name": "Mona Example",
+    "author_email": "mona@example.com",
+    "committer_name": "Mona Example",
+    "committer_email": "mona@example.com"
+  }
+}
+```
+
+Environment variables override config-file values for the current process.
+
+## Use existing Git environment variables
+
+Advanced wrappers may already export Git's standard commit identity variables.
+Amplihack accepts them only when all four values are present and safe:
+
+```bash
+export GIT_AUTHOR_NAME="Mona Example"
+export GIT_AUTHOR_EMAIL="mona@example.com"
+export GIT_COMMITTER_NAME="Mona Example"
+export GIT_COMMITTER_EMAIL="mona@example.com"
+
+amplihack recipe run default-workflow \
+  -c repo_path=. \
+  -c task_description="Run with wrapper-provided Git identity"
+```
+
+Prefer `AMPLIHACK_GIT_*` for normal use. The standard Git environment variables
+are process-wide and may affect non-Amplihack `git commit` commands in the same
+shell.
+
+## Configure repository-local Git identity
+
+Use repository-local config when all workflow commits in the repository should
+use the same identity and you do not want to export environment variables:
+
+```bash
+git config --local user.name "Mona Example"
+git config --local user.email "mona@example.com"
+
+amplihack recipe run workflow-publish \
+  -c repo_path=. \
+  -c task_description="Publish workflow changes"
+```
+
+This writes to `.git/config` for the current repository only. Amplihack does not
+write global Git config and does not require you to set one.
+
+## Use GitHub inference
+
+For GitHub repositories, authenticate `gh` before running the workflow:
+
+```bash
+gh auth status
+
+amplihack recipe run workflow-publish \
+  -c repo_path=. \
+  -c remote_host_type=github \
+  -c task_description="Publish GitHub workflow changes"
+```
+
+When explicit identity, complete safe Git environment variables, and safe local
+Git identity are absent, Amplihack uses the authenticated GitHub account. It uses
+the public email when available and the account's GitHub noreply email
+otherwise. It uses the public profile name when available and falls back to the
+login when the profile name is empty. The resulting name and email must pass
+validation.
+
+## Use Azure DevOps safely
+
+For Azure DevOps repositories, prefer explicit variables:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+
+amplihack recipe run workflow-publish \
+  -c repo_path=. \
+  -c remote_host_type=azdo \
+  -c task_description="Publish Azure DevOps workflow changes"
+```
+
+If explicit variables are not present, a safe repository-local Git identity is
+also accepted:
+
+```bash
+git config --local user.name "Mona Example"
+git config --local user.email "mona@example.com"
+
+amplihack recipe run workflow-finalize \
+  -c repo_path=. \
+  -c remote_host_type=azdo
+```
+
+Azure CLI account inference is used only as a last provider source and only when
+the authenticated account provides a normal user email address. VM, service,
+runner, automation, localhost-style, and malformed emails fail closed. The
+canonical recipe host type is `azdo`; `azure-devops` is only a user-facing alias
+where workflow preparation normalizes it.
+
+## Fix an unsafe VM identity failure
+
+If a workflow fails because it found `azureuser@...`, `runner@localhost`, or a
+similar VM-local identity, set an explicit identity and rerun the workflow:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+
+amplihack recipe run default-workflow \
+  -c repo_path=. \
+  -c task_description="Continue after configuring commit identity"
+```
+
+Do not fix the failure by setting `git config --global` on the VM. A global VM
+identity can leak into unrelated repositories and does not prove the intended
+attribution for the current workflow.
+
+## Check the resulting commit identity
+
+After the workflow creates a commit, inspect the latest commit:
+
+```bash
+git log -1 --format='Author: %an <%ae>%nCommitter: %cn <%ce>'
+```
+
+Expected output:
+
+```text
+Author: Mona Example <mona@example.com>
+Committer: Mona Example <mona@example.com>
+```
+
+If the output shows a VM-local or unexpected identity, treat that as a workflow
+bug. Amplihack-created commits are expected to fail before commit rather than
+fall back to unsafe identity.

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,6 +199,9 @@ Understand the philosophy and architecture behind amplihack.
 
 Proven methodologies for consistent, high-quality results.
 
+- [Workflow Commit Identity](workflows.md) - Planned safe author and committer
+  attribution for Amplihack-created workflow commits
+
 ### Automatic Workflow Classification ⭐ NEW
 
 **Mandatory at Session Start** (Issue #2353) - amplihack now automatically classifies your request and executes the appropriate workflow when you start a session:
@@ -278,6 +281,9 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [How to Configure Workflow Runtime Isolation](howto/configure-workflow-runtime-isolation.md) - Set `AMPLIHACK_RUNTIME_ROOT`, inspect runtime files, and troubleshoot guard failures
 - [Tutorial: Workflow Runtime Isolation](tutorials/workflow-runtime-isolation.md) - Practice the runtime isolation and strict Artifact Guard contract
 - [Workflow Runtime Artifacts Reference](reference/workflow-runtime-artifacts.md) - Environment variables, shell helper API, lifecycle hooks, and regression contract
+- [Workflow Commit Identity Reference](reference/workflow-commit-identity.md) - Explicit author/committer identity contract for workflow-created commits
+- [How to Configure Workflow Commit Identity](howto/configure-workflow-commit-identity.md) - Setup for `AMPLIHACK_GIT_*`, repo-local Git identity, and provider-safe fallbacks
+- [Tutorial: Verify Workflow Commit Identity](tutorials/workflow-commit-identity.md) - Disposable-repository walkthrough for explicit, repo-local, GitHub, and Azure DevOps commit attribution
 - [Default Workflow Step 13 Validation Reference](reference/default-workflow-step-13-validation.md) - Toolchain-aware outside-in local validation contract for Step 13
 - [Workflow Terminal-State Reference](reference/workflow-terminal-state.md) - Target contract for development completion evidence, no-op states, failure semantics, and shell helper API
 - [Default Workflow Agentic Finalization](reference/default-workflow-agentic-finalization.md) - Structured finalizer schema, terminal-state vocabulary, configuration, and examples for robust workflow closure

--- a/docs/reference/workflow-commit-identity.md
+++ b/docs/reference/workflow-commit-identity.md
@@ -1,0 +1,269 @@
+# Workflow Commit Identity Reference
+
+This reference describes Amplihack workflow commit identity behavior. The shared
+identity contract is implemented by `amplifier-bundle/tools/git-identity.sh`.
+Every Amplihack recipe path that creates a commit uses that helper before
+invoking `git commit`.
+
+## Contents
+
+- [Configuration variables](#configuration-variables)
+- [Identity resolution order](#identity-resolution-order)
+- [Validation rules](#validation-rules)
+- [Provider inference](#provider-inference)
+- [Shell helper API](#shell-helper-api)
+- [Recipe contract](#recipe-contract)
+- [Failures](#failures)
+
+## Configuration variables
+
+Use explicit Amplihack identity variables when the repository cannot provide a
+safe local identity or when provider inference is not desired.
+
+| Environment variable | Config key | Required | Description |
+| --- | --- | --- | --- |
+| `AMPLIHACK_GIT_AUTHOR_NAME` | `git_identity.author_name` | Yes, for explicit author config | Author name for workflow-created commits. |
+| `AMPLIHACK_GIT_AUTHOR_EMAIL` | `git_identity.author_email` | Yes, for explicit author config | Author email for workflow-created commits. |
+| `AMPLIHACK_GIT_COMMITTER_NAME` | `git_identity.committer_name` | Optional pair | Committer name. Defaults to the author name only when both committer fields are omitted. |
+| `AMPLIHACK_GIT_COMMITTER_EMAIL` | `git_identity.committer_email` | Optional pair | Committer email. Defaults to the author email only when both committer fields are omitted. |
+
+Example:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+export AMPLIHACK_GIT_COMMITTER_NAME="Mona Example"
+export AMPLIHACK_GIT_COMMITTER_EMAIL="mona@example.com"
+
+amplihack recipe run default-workflow \
+  -c repo_path=. \
+  -c task_description="Update provider-safe workflow commits"
+```
+
+Environment variables apply only to the workflow process and its child commit
+steps. Amplihack config lives in `~/.amplihack/config` as JSON:
+
+```json
+{
+  "git_identity": {
+    "author_name": "Mona Example",
+    "author_email": "mona@example.com",
+    "committer_name": "Mona Example",
+    "committer_email": "mona@example.com"
+  }
+}
+```
+
+Environment variables override config-file values. Amplihack does not write
+global Git configuration.
+
+Partial explicit configuration is invalid. Set both author fields. Set both
+committer fields or omit both committer fields to use the author identity for the
+committer.
+
+## Identity resolution order
+
+Before each Amplihack-created `git commit`, the workflow resolves a complete
+author identity and a complete committer identity in this order:
+
+1. Explicit Amplihack environment variables and config:
+   `AMPLIHACK_GIT_AUTHOR_*`, `AMPLIHACK_GIT_COMMITTER_*`, and
+   `git_identity.*`.
+2. Existing complete and safe Git environment variables for advanced callers:
+   `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and
+   `GIT_COMMITTER_EMAIL`.
+3. Safe repository-local Git configuration from `user.name` and `user.email`.
+4. Authenticated provider context for the detected remote host.
+5. Fail-fast with remediation instructions.
+
+Every source is validated before use. Unsafe values are rejected even when they
+come from explicit environment variables.
+
+## Validation rules
+
+Amplihack requires complete names and email addresses for both author and
+committer identities. Missing committer fields default from the author only when
+both committer fields are absent; providing exactly one committer field fails
+validation.
+
+An identity is rejected when any required field is missing or unsafe:
+
+| Unsafe value | Examples |
+| --- | --- |
+| Missing name or email | Empty `user.name`, unset `GIT_AUTHOR_EMAIL`. |
+| Malformed email | `mona`, `mona@`, `mona example@example.com`. |
+| Localhost or machine-local email | `mona@localhost`, `mona@vm`, `mona@localdomain`. |
+| VM account identity | `azureuser@...`, generated VM hostnames. |
+| Service-looking email | Generic service, runner, build, or automation account emails. |
+
+The check is intentionally fail-closed. If Amplihack cannot prove that the
+identity is user-intended, it stops before the commit instead of creating a
+misattributed commit.
+
+## Provider inference
+
+Provider inference is used only after explicit variables, existing safe Git
+environment, and repository-local Git config are unavailable.
+
+### GitHub
+
+For GitHub remotes, Amplihack uses the authenticated `gh` account when needed.
+It prefers the account's public email when one is available. When the public
+email is hidden, Amplihack uses the authenticated account's GitHub noreply
+address.
+
+For the name, Amplihack prefers a non-empty public profile name. If the profile
+name is absent, Amplihack falls back to the authenticated login. The resulting
+name and email must pass the same safety checks as explicit identities.
+
+Example inferred identity:
+
+```text
+GIT_AUTHOR_NAME=Mona Example
+GIT_AUTHOR_EMAIL=12345678+mona@users.noreply.github.com
+GIT_COMMITTER_NAME=Mona Example
+GIT_COMMITTER_EMAIL=12345678+mona@users.noreply.github.com
+```
+
+GitHub inference fails if `gh` is unavailable, unauthenticated, or returns an
+identity that does not pass validation.
+
+### Azure DevOps (`azdo`)
+
+The canonical recipe host type for Azure DevOps is `azdo`. User-facing
+`azure-devops` may be accepted as an input alias by workflow preparation, but
+identity code and recipe context use `azdo`.
+
+For Azure DevOps remotes, Amplihack first expects explicit Amplihack identity
+variables or safe repository-local Git config. If those are unavailable and the
+Azure CLI is authenticated, Amplihack may use the Azure CLI account identity
+only when it exposes a safe user email address.
+
+Example safe Azure CLI account:
+
+```text
+mona@example.com
+```
+
+Example rejected Azure CLI accounts:
+
+```text
+azureuser@build-vm
+svc-deploy@example.com
+runner@localhost
+```
+
+For Azure CLI inference, Amplihack uses the safe account email for both the Git
+name and email because the CLI does not consistently expose a separate human
+display name.
+
+Azure DevOps inference is conservative because Azure-hosted development
+environments often expose VM-local identities that are not the user's intended
+commit attribution.
+
+## Shell helper API
+
+Recipes source the shared helper:
+
+```bash
+. "$AMPLIHACK_HOME/amplifier-bundle/tools/git-identity.sh"
+```
+
+### `amplihack_prepare_git_commit_identity`
+
+Resolves, validates, and exports all Git identity variables required for a
+commit:
+
+```bash
+amplihack_prepare_git_commit_identity
+git commit -m "Update workflow behavior"
+```
+
+On success, the function exports:
+
+```bash
+GIT_AUTHOR_NAME
+GIT_AUTHOR_EMAIL
+GIT_COMMITTER_NAME
+GIT_COMMITTER_EMAIL
+```
+
+On failure, it prints a clear remediation message to stderr and returns nonzero.
+
+### `amplihack_resolve_git_identity`
+
+Resolves the candidate author and committer identity using the documented
+precedence order. This function is used by
+`amplihack_prepare_git_commit_identity` and by tests that need to inspect
+resolution without creating a commit.
+
+### `amplihack_validate_git_identity`
+
+Validates a name and email pair. The function rejects incomplete, malformed,
+localhost-style, VM-looking, and service-looking identities.
+
+### `amplihack_detect_remote_host_type`
+
+Classifies the repository remote as `github`, `azdo`, or `unknown`.
+Provider inference uses this value to decide whether `gh` or Azure CLI identity
+lookup is allowed.
+
+## Recipe contract
+
+Every Amplihack recipe path that creates a commit calls
+`amplihack_prepare_git_commit_identity` immediately before `git commit`.
+
+The guard applies to every recipe with an executable `git commit` call. Current
+known commit-producing recipe paths are:
+
+| Recipe | Commit path |
+| --- | --- |
+| `workflow-publish.yaml` | Publish commits and follow-up publish commits. |
+| `workflow-finalize.yaml` | Finalization and cleanup commits. |
+| `workflow-pr-review.yaml` | PR review remediation commits. |
+| `workflow-tdd.yaml` | Implementation checkpoint commits. |
+| `workflow-refactor-review.yaml` | Review-feedback checkpoint commits. |
+| `consensus-publish.yaml` | Consensus result publication commits. |
+| `consensus-pr-feedback.yaml` | PR feedback publication commits. |
+
+Recipes may stage files before identity preparation, but they must not run
+`git commit` until the helper has exported a complete author and committer
+identity for the current shell step.
+
+Static coverage should search all recipe YAML files for executable `git commit`
+calls and fail when a commit path does not prepare identity first. This prevents
+future recipes from bypassing the helper.
+
+## Failures
+
+When no safe identity is available, the workflow stops before the commit with a
+message that points to explicit configuration:
+
+```text
+Amplihack could not determine a safe Git commit identity.
+Set AMPLIHACK_GIT_AUTHOR_NAME and AMPLIHACK_GIT_AUTHOR_EMAIL, or configure
+repository-local git user.name and user.email.
+```
+
+Recommended remediation:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+
+amplihack recipe run workflow-publish \
+  -c repo_path=. \
+  -c task_description="Publish completed workflow changes"
+```
+
+For persistent repository-local configuration without changing global Git
+config:
+
+```bash
+git config --local user.name "Mona Example"
+git config --local user.email "mona@example.com"
+```
+
+Do not fix this by setting global Git config on a shared VM. Global VM config can
+affect unrelated repositories and does not prove the identity was intended for
+the current workflow commit.

--- a/docs/tutorials/workflow-commit-identity.md
+++ b/docs/tutorials/workflow-commit-identity.md
@@ -1,0 +1,148 @@
+# Tutorial: Verify Workflow Commit Identity
+
+This tutorial shows Amplihack workflow commit identity behavior. It uses a
+disposable local repository so you can verify author and committer resolution
+without publishing branches or creating pull requests.
+
+Do not use `workflow-publish` for this tutorial in a real repository. Publish
+workflows can create and push real commits.
+
+## Before you start
+
+The helper is available at:
+
+```text
+$AMPLIHACK_HOME/amplifier-bundle/tools/git-identity.sh
+```
+
+Use a temporary directory:
+
+```bash
+DEMO_REPO="$(mktemp -d)"
+cd "$DEMO_REPO"
+git init
+```
+
+## 1. Configure an explicit identity
+
+Set the identity that Amplihack should use for workflow-created commits:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+```
+
+The committer identity defaults to the author identity only when both
+`AMPLIHACK_GIT_COMMITTER_NAME` and `AMPLIHACK_GIT_COMMITTER_EMAIL` are omitted.
+If you set either committer variable, set both.
+
+## 2. Prepare identity with the helper
+
+Source the helper and prepare the commit identity:
+
+```bash
+. "$AMPLIHACK_HOME/amplifier-bundle/tools/git-identity.sh"
+amplihack_prepare_git_commit_identity
+```
+
+The helper exports:
+
+```text
+GIT_AUTHOR_NAME=Mona Example
+GIT_AUTHOR_EMAIL=mona@example.com
+GIT_COMMITTER_NAME=Mona Example
+GIT_COMMITTER_EMAIL=mona@example.com
+```
+
+## 3. Create a local test commit
+
+Create and commit a local file:
+
+```bash
+printf 'workflow identity demo\n' > identity-demo.txt
+git add identity-demo.txt
+git commit -m "test: verify workflow commit identity"
+```
+
+## 4. Inspect the commit
+
+Check the author and committer on the latest commit:
+
+```bash
+git log -1 --format='Author: %an <%ae>%nCommitter: %cn <%ce>'
+```
+
+Expected output:
+
+```text
+Author: Mona Example <mona@example.com>
+Committer: Mona Example <mona@example.com>
+```
+
+## 5. Try repository-local configuration
+
+Unset explicit Amplihack variables and configure identity only for the temporary
+repository:
+
+```bash
+unset AMPLIHACK_GIT_AUTHOR_NAME
+unset AMPLIHACK_GIT_AUTHOR_EMAIL
+unset AMPLIHACK_GIT_COMMITTER_NAME
+unset AMPLIHACK_GIT_COMMITTER_EMAIL
+
+git config --local user.name "Mona Example"
+git config --local user.email "mona@example.com"
+
+amplihack_prepare_git_commit_identity
+```
+
+Amplihack accepts the repo-local identity because it is complete, email-safe, and
+scoped to the current repository.
+
+## 6. Understand provider behavior
+
+GitHub repositories can infer identity from authenticated `gh` when explicit
+identity, complete safe Git environment variables, and repo-local identity are
+unavailable:
+
+```bash
+gh auth status
+amplihack_detect_remote_host_type
+amplihack_prepare_git_commit_identity
+```
+
+For GitHub, Amplihack uses the public email when available and the GitHub noreply
+email otherwise. It uses the public profile name when available and falls back to
+the login when the profile name is empty. The resulting name and email must pass
+validation.
+
+For Azure DevOps, the canonical host type is `azdo`:
+
+```bash
+amplihack recipe run workflow-publish \
+  -c repo_path=. \
+  -c remote_host_type=azdo \
+  -c task_description="Publish Azure DevOps workflow changes"
+```
+
+Use that command only in a branch or repository where publishing is intended.
+Azure CLI inference is accepted only when the account provides a safe user email.
+VM, service, runner, automation, localhost-style, and malformed emails fail
+closed.
+
+## 7. Recognize fail-fast protection
+
+When Amplihack sees an unsafe identity such as `azureuser@build-vm`,
+`runner@localhost`, `svc-deploy@example.com`, or a missing email, it stops before
+committing.
+
+Fix the failure by setting explicit Amplihack variables:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+```
+
+The workflow should never create an Amplihack-owned commit attributed to a VM,
+service, runner, or ambiguous login-only account. A fail-fast identity error is
+the intended safe behavior.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,120 @@
+# Workflows
+
+Amplihack workflows run declarative recipes that may create commits, publish
+branches, review pull requests, and finalize work.
+
+## Workflow commit identity
+
+Every Amplihack-owned workflow commit resolves an explicit Git author and
+committer identity before calling `git commit`. Commit-producing recipes source
+the shared
+`amplifier-bundle/tools/git-identity.sh` helper, which exports
+`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and
+`GIT_COMMITTER_EMAIL` for the commit step. Recipes must not rely on global Git
+config, VM user accounts, or shell defaults.
+
+The identity guard covers every recipe path that executes `git commit`, not only
+the original publish/finalize paths:
+
+| Recipe | Behavior |
+| --- | --- |
+| `workflow-publish` | Sets explicit identity before publish commits and follow-up publish commits. |
+| `workflow-finalize` | Sets explicit identity before finalization and cleanup commits. |
+| `workflow-pr-review` | Sets explicit identity before PR review remediation commits. |
+| `workflow-tdd` | Sets explicit identity before implementation checkpoint commits. |
+| `workflow-refactor-review` | Sets explicit identity before review-feedback checkpoint commits. |
+| `consensus-publish` | Sets explicit identity before consensus publication commits. |
+| `consensus-pr-feedback` | Sets explicit identity before PR feedback commits. |
+
+Static coverage fails if a recipe contains an executable `git commit`
+without preparing identity first.
+
+## Configure identity for workflows
+
+Use explicit Amplihack variables when running workflows on shared machines,
+Azure-hosted environments, or any repository where VM-local Git config might be
+present:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+
+amplihack recipe run default-workflow \
+  -c repo_path=. \
+  -c task_description="Update workflow-owned commit behavior"
+```
+
+When both committer variables are omitted, Amplihack uses the author identity for
+the committer identity. If either `AMPLIHACK_GIT_COMMITTER_NAME` or
+`AMPLIHACK_GIT_COMMITTER_EMAIL` is set, both must be set and safe.
+
+You can also save the same explicit identity in `~/.amplihack/config`:
+
+```json
+{
+  "git_identity": {
+    "author_name": "Mona Example",
+    "author_email": "mona@example.com"
+  }
+}
+```
+
+Existing complete and safe Git environment variables are accepted for advanced
+callers:
+
+```bash
+export GIT_AUTHOR_NAME="Mona Example"
+export GIT_AUTHOR_EMAIL="mona@example.com"
+export GIT_COMMITTER_NAME="Mona Example"
+export GIT_COMMITTER_EMAIL="mona@example.com"
+```
+
+Repository-local Git config is also accepted:
+
+```bash
+git config --local user.name "Mona Example"
+git config --local user.email "mona@example.com"
+```
+
+Amplihack never writes global Git config.
+
+## Provider behavior
+
+GitHub repositories can infer identity from authenticated `gh` when explicit
+Amplihack variables, safe Git environment variables, and safe repo-local Git
+config are unavailable. Amplihack uses the public GitHub email when available
+and the authenticated account's GitHub noreply email otherwise. It uses the
+public profile name when available, falling back to the login when the profile
+name is empty. The resulting name and email must pass validation.
+
+Azure DevOps repositories should use explicit Amplihack variables or safe
+repo-local Git config. The canonical workflow host type is `azdo`; the
+user-facing `azure-devops` value is only an alias when a workflow normalizes it.
+Azure CLI account inference is accepted only when the authenticated account can
+provide a normal user email address. VM, service, runner, localhost, and
+automation-looking emails are rejected.
+
+## Unsafe identity failures
+
+Amplihack stops before committing when it finds an unsafe identity such as:
+
+```text
+azureuser@build-vm
+runner@localhost
+mona@
+```
+
+Fix the failure by exporting a safe identity:
+
+```bash
+export AMPLIHACK_GIT_AUTHOR_NAME="Mona Example"
+export AMPLIHACK_GIT_AUTHOR_EMAIL="mona@example.com"
+```
+
+Then rerun the workflow.
+
+## More information
+
+- [How to Configure Workflow Commit Identity](howto/configure-workflow-commit-identity.md)
+- [Tutorial: Verify Workflow Commit Identity](tutorials/workflow-commit-identity.md)
+- [Workflow Commit Identity Reference](reference/workflow-commit-identity.md)

--- a/tests/git_identity_test.sh
+++ b/tests/git_identity_test.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# TDD tests for workflow-created git commit identity resolution.
+#
+# These tests define the contract for amplifier-bundle/tools/git-identity.sh.
+# Expected before implementation: FAIL. Expected after implementation: PASS.
+#
+# Run: bash tests/git_identity_test.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/amplifier-bundle/tools/git-identity.sh"
+
+pass=0
+fail=0
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+record_pass() {
+    echo "PASS: $1"
+    pass=$((pass + 1))
+}
+
+record_fail() {
+    echo "FAIL: $1"
+    if [ $# -gt 1 ] && [ -n "$2" ]; then
+        printf '      %s\n' "$2"
+    fi
+    fail=$((fail + 1))
+}
+
+assert() {
+    local desc="$1"
+    shift
+    if "$@"; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "command failed: $*"
+    fi
+}
+
+assert_eq() {
+    local desc="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "expected: <$expected>; actual: <$actual>"
+    fi
+}
+
+new_repo() {
+    local name="$1"
+    local remote_url="${2:-}"
+    local repo="$TMPROOT/$name"
+    mkdir -p "$repo"
+    git -C "$repo" init -q
+    if [ -n "$remote_url" ]; then
+        git -C "$repo" remote add origin "$remote_url"
+    fi
+    printf '%s\n' "$repo"
+}
+
+make_fake_bin() {
+    local dir="$TMPROOT/fake-bin"
+    mkdir -p "$dir"
+
+    cat >"$dir/gh" <<'GH_EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+if [ "${1:-}" = "auth" ]; then
+    exit 0
+fi
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "user/emails" ]; then
+    if [ -n "${AMPLIHACK_TEST_GH_PUBLIC_EMAIL:-}" ]; then
+        printf '[{"email":"%s","primary":true,"verified":true,"visibility":"public"}]\n' "$AMPLIHACK_TEST_GH_PUBLIC_EMAIL"
+        exit 0
+    fi
+    printf '[]\n'
+    exit 0
+fi
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "user" ]; then
+    case " $* " in
+        *" --jq .login "*|*" -q .login "*) printf 'octocat\n' ;;
+        *" --jq .id "*|*" -q .id "*) printf '583231\n' ;;
+        *" --jq .name "*|*" -q .name "*) printf 'Octo Cat\n' ;;
+        *" --jq .email "*|*" -q .email "*) printf '%s\n' "${AMPLIHACK_TEST_GH_PUBLIC_EMAIL:-}" ;;
+        *)
+            if [ -n "${AMPLIHACK_TEST_GH_PUBLIC_EMAIL:-}" ]; then
+                email_json="\"$AMPLIHACK_TEST_GH_PUBLIC_EMAIL\""
+            else
+                email_json="null"
+            fi
+            printf '{"login":"octocat","id":583231,"name":"Octo Cat","email":%s}\n' "$email_json"
+            ;;
+    esac
+    exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+GH_EOF
+
+    cat >"$dir/az" <<'AZ_EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+if [ "${1:-}" = "account" ] && [ "${2:-}" = "show" ]; then
+    account_email="${AMPLIHACK_TEST_AZ_ACCOUNT_EMAIL:-az.user@example.com}"
+    account_type="${AMPLIHACK_TEST_AZ_ACCOUNT_TYPE:-user}"
+    case " $* " in
+        *" --query user.name "*|*" -q user.name "*) printf '%s\n' "$account_email" ;;
+        *" --query user.type "*|*" -q user.type "*) printf '%s\n' "$account_type" ;;
+        *) printf '{"user":{"name":"%s","type":"%s"}}\n' "$account_email" "$account_type" ;;
+    esac
+    exit 0
+fi
+echo "unexpected az invocation: $*" >&2
+exit 1
+AZ_EOF
+
+    chmod +x "$dir/gh" "$dir/az"
+    printf '%s\n' "$dir"
+}
+
+run_prepare() {
+    local repo="$1"
+    shift
+    local fake_bin="$1"
+    shift
+    (
+        cd "$repo" || exit 1
+        env -i \
+            PATH="$fake_bin:$PATH" \
+            HOME="$TMPROOT/home" \
+            REPO_PATH="$repo" \
+            AMPLIHACK_HOME="$REPO_ROOT" \
+            HELPER="$HELPER" \
+            "$@" \
+            bash -c '
+                set -euo pipefail
+                . "$HELPER"
+                amplihack_prepare_git_commit_identity >/dev/null
+                printf "%s|%s|%s|%s\n" \
+                    "${GIT_AUTHOR_NAME:-}" \
+                    "${GIT_AUTHOR_EMAIL:-}" \
+                    "${GIT_COMMITTER_NAME:-}" \
+                    "${GIT_COMMITTER_EMAIL:-}"
+            '
+    )
+}
+
+run_prepare_expect_failure() {
+    local repo="$1"
+    shift
+    local fake_bin="$1"
+    shift
+    (
+        cd "$repo" || exit 1
+        env -i \
+            PATH="$fake_bin:$PATH" \
+            HOME="$TMPROOT/home" \
+            REPO_PATH="$repo" \
+            AMPLIHACK_HOME="$REPO_ROOT" \
+            HELPER="$HELPER" \
+            "$@" \
+            bash -c '
+                set -euo pipefail
+                . "$HELPER"
+                amplihack_prepare_git_commit_identity
+            '
+    ) 2>&1
+}
+
+detect_host() {
+    local url="$1"
+    env -i PATH="$PATH" HELPER="$HELPER" bash -c '
+        set -euo pipefail
+        . "$HELPER"
+        amplihack_detect_remote_host_type "$1"
+    ' _ "$url"
+}
+
+echo "=== Git identity helper TDD tests ==="
+echo "Helper: $HELPER"
+echo
+
+fake_bin="$(make_fake_bin)"
+
+# --- Contract: helper file and public functions ------------------------------
+assert "git-identity.sh exists" test -f "$HELPER"
+
+for fn in \
+    amplihack_prepare_git_commit_identity \
+    amplihack_resolve_git_identity \
+    amplihack_validate_git_identity \
+    amplihack_detect_remote_host_type
+do
+    assert "exports public function: $fn" \
+        bash -c ". '$HELPER' 2>/dev/null && declare -F '$fn' >/dev/null"
+done
+
+# --- Contract: remote host detection -----------------------------------------
+github_host="$(detect_host "https://github.com/octo/repo.git" 2>/dev/null)"
+assert_eq "detects GitHub HTTPS remotes" "github" "$github_host"
+
+azdo_host="$(detect_host "https://dev.azure.com/org/project/_git/repo" 2>/dev/null)"
+assert_eq "detects Azure DevOps HTTPS remotes" "azdo" "$azdo_host"
+
+visualstudio_host="$(detect_host "https://org.visualstudio.com/project/_git/repo" 2>/dev/null)"
+assert_eq "detects legacy visualstudio.com remotes" "azdo" "$visualstudio_host"
+
+unknown_host="$(detect_host "https://gitlab.com/org/repo.git" 2>/dev/null)"
+assert_eq "detects unknown remotes" "unknown" "$unknown_host"
+
+# --- Contract: explicit AMPLIHACK_GIT_* env wins over every other source -----
+repo="$(new_repo explicit "https://dev.azure.com/org/project/_git/repo")"
+git -C "$repo" config --local user.name "azureuser"
+git -C "$repo" config --local user.email "azureuser@vm.internal"
+actual="$(run_prepare "$repo" "$fake_bin" \
+    AMPLIHACK_GIT_AUTHOR_NAME="Explicit Author" \
+    AMPLIHACK_GIT_AUTHOR_EMAIL="explicit.author@example.com" \
+    AMPLIHACK_GIT_COMMITTER_NAME="Explicit Committer" \
+    AMPLIHACK_GIT_COMMITTER_EMAIL="explicit.committer@example.com" \
+    GIT_AUTHOR_NAME="Ignored Author" \
+    GIT_AUTHOR_EMAIL="ignored.author@example.com" \
+    GIT_COMMITTER_NAME="Ignored Committer" \
+    GIT_COMMITTER_EMAIL="ignored.committer@example.com" \
+    2>/dev/null)"
+assert_eq "explicit AMPLIHACK_GIT_* identity has highest precedence" \
+    "Explicit Author|explicit.author@example.com|Explicit Committer|explicit.committer@example.com" \
+    "$actual"
+
+# --- Contract: explicit Amplihack config is accepted when env is absent -------
+repo="$(new_repo explicit-config "https://dev.azure.com/org/project/_git/repo")"
+mkdir -p "$TMPROOT/home/.amplihack"
+cat >"$TMPROOT/home/.amplihack/config" <<'CONFIG_EOF'
+{
+  "git_identity": {
+    "author_name": "Config Author",
+    "author_email": "config.author@example.com",
+    "committer_name": "Config Committer",
+    "committer_email": "config.committer@example.com"
+  }
+}
+CONFIG_EOF
+actual="$(run_prepare "$repo" "$fake_bin" 2>/dev/null)"
+assert_eq "explicit Amplihack config identity is used when env is absent" \
+    "Config Author|config.author@example.com|Config Committer|config.committer@example.com" \
+    "$actual"
+rm -f "$TMPROOT/home/.amplihack/config"
+
+# --- Contract: existing complete safe Git env is preserved -------------------
+repo="$(new_repo existing-env "https://dev.azure.com/org/project/_git/repo")"
+git -C "$repo" config --local user.name "azureuser"
+git -C "$repo" config --local user.email "azureuser@vm.internal"
+actual="$(run_prepare "$repo" "$fake_bin" \
+    GIT_AUTHOR_NAME="Existing Author" \
+    GIT_AUTHOR_EMAIL="existing.author@example.com" \
+    GIT_COMMITTER_NAME="Existing Committer" \
+    GIT_COMMITTER_EMAIL="existing.committer@example.com" \
+    2>/dev/null)"
+assert_eq "complete safe GIT_AUTHOR_* and GIT_COMMITTER_* env is preserved" \
+    "Existing Author|existing.author@example.com|Existing Committer|existing.committer@example.com" \
+    "$actual"
+
+# --- Contract: safe repo-local config is used without global config ----------
+repo="$(new_repo repo-local "https://dev.azure.com/org/project/_git/repo")"
+git -C "$repo" config --local user.name "Repo Local User"
+git -C "$repo" config --local user.email "repo.local@example.com"
+actual="$(run_prepare "$repo" "$fake_bin" 2>/dev/null)"
+assert_eq "safe repo-local git config populates both author and committer" \
+    "Repo Local User|repo.local@example.com|Repo Local User|repo.local@example.com" \
+    "$actual"
+
+# --- Contract: GitHub provider fallback uses authenticated noreply identity ---
+repo="$(new_repo github-public "https://github.com/octo/repo.git")"
+actual="$(run_prepare "$repo" "$fake_bin" \
+    AMPLIHACK_TEST_GH_PUBLIC_EMAIL="octo.public@example.com" \
+    2>/dev/null)"
+assert_eq "GitHub fallback prefers authenticated public email when available" \
+    "Octo Cat|octo.public@example.com|Octo Cat|octo.public@example.com" \
+    "$actual"
+
+repo="$(new_repo github-fallback "https://github.com/octo/repo.git")"
+actual="$(run_prepare "$repo" "$fake_bin" 2>/dev/null)"
+assert_eq "GitHub fallback uses authenticated noreply email when public email is unavailable" \
+    "Octo Cat|583231+octocat@users.noreply.github.com|Octo Cat|583231+octocat@users.noreply.github.com" \
+    "$actual"
+
+# --- Contract: Azure provider fallback accepts safe authenticated email -------
+repo="$(new_repo azdo-fallback "https://dev.azure.com/org/project/_git/repo")"
+actual="$(run_prepare "$repo" "$fake_bin" \
+    AMPLIHACK_TEST_AZ_ACCOUNT_EMAIL="az.user@example.com" \
+    2>/dev/null)"
+case "$actual" in
+    *"|az.user@example.com|"*"|az.user@example.com") record_pass "Azure CLI fallback accepts safe authenticated email" ;;
+    *) record_fail "Azure CLI fallback accepts safe authenticated email" "actual: <$actual>" ;;
+esac
+
+# --- Contract: unsafe VM/service identities fail closed ----------------------
+repo="$(new_repo azdo-unsafe "https://dev.azure.com/org/project/_git/repo")"
+git -C "$repo" config --local user.name "azureuser"
+git -C "$repo" config --local user.email "azureuser@vm.internal"
+out="$(run_prepare_expect_failure "$repo" "$fake_bin" \
+    AMPLIHACK_TEST_AZ_ACCOUNT_EMAIL="azureuser@buildvm.local" \
+    2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "AMPLIHACK_GIT_AUTHOR_NAME" && printf '%s' "$out" | grep -q "AMPLIHACK_GIT_AUTHOR_EMAIL"; then
+    record_pass "unsafe azureuser identity fails with explicit configuration guidance"
+else
+    record_fail "unsafe azureuser identity fails with explicit configuration guidance" "rc=$rc output: $out"
+fi
+
+repo="$(new_repo malformed "https://github.com/octo/repo.git")"
+out="$(run_prepare_expect_failure "$repo" "$fake_bin" \
+    AMPLIHACK_GIT_AUTHOR_NAME="Bad Author" \
+    AMPLIHACK_GIT_AUTHOR_EMAIL="not-an-email" \
+    AMPLIHACK_GIT_COMMITTER_NAME="Bad Committer" \
+    AMPLIHACK_GIT_COMMITTER_EMAIL="committer@example.com" \
+    2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -Eq "AMPLIHACK_GIT|invalid|malformed|unsafe"; then
+    record_pass "malformed explicit identity fails closed"
+else
+    record_fail "malformed explicit identity fails closed" "rc=$rc output: $out"
+fi
+
+if [ ! -f "$TMPROOT/home/.gitconfig" ]; then
+    record_pass "identity preparation does not mutate global git config"
+else
+    record_fail "identity preparation does not mutate global git config" "$TMPROOT/home/.gitconfig was created"
+fi
+
+echo
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi

--- a/tests/recipe_commit_identity_static_test.sh
+++ b/tests/recipe_commit_identity_static_test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Static TDD tests for workflow recipe commit identity safety.
+#
+# Every amplihack-created commit path must source the shared identity helper and
+# call amplihack_prepare_git_commit_identity immediately before git commit.
+# Expected before implementation: FAIL. Expected after implementation: PASS.
+#
+# Run: bash tests/recipe_commit_identity_static_test.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RECIPES_DIR="$REPO_ROOT/amplifier-bundle/recipes"
+HELPER="$REPO_ROOT/amplifier-bundle/tools/git-identity.sh"
+
+pass=0
+fail=0
+
+record_pass() {
+    echo "PASS: $1"
+    pass=$((pass + 1))
+}
+
+record_fail() {
+    echo "FAIL: $1"
+    if [ $# -gt 1 ] && [ -n "$2" ]; then
+        printf '      %s\n' "$2"
+    fi
+    fail=$((fail + 1))
+}
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "condition: $cond"
+    fi
+}
+
+commit_command_lines() {
+    local file="$1"
+    grep -nE '(^|[;&|[:space:]])(PRE_COMMIT_ALLOW_NO_CONFIG=1[[:space:]]+)?git[[:space:]]+commit([[:space:]]|$)' "$file" \
+        | grep -vE '^[0-9]+:[[:space:]]*echo .*git commit|git commit failed during|git commit message|git commit messages'
+}
+
+commit_recipe_files() {
+    local file
+    find "$RECIPES_DIR" -name '*.yaml' -type f | sort | while IFS= read -r file; do
+        if [ -n "$(commit_command_lines "$file")" ]; then
+            printf '%s\n' "$file"
+        fi
+    done
+}
+
+has_prepare_immediately_before_commit() {
+    local file="$1"
+    local line="$2"
+    local start=$((line - 8))
+    if [ "$start" -lt 1 ]; then
+        start=1
+    fi
+    sed -n "${start},${line}p" "$file" | grep -q 'amplihack_prepare_git_commit_identity'
+}
+
+echo "=== Recipe commit identity static TDD tests ==="
+echo "Recipes: $RECIPES_DIR"
+echo "Helper:  $HELPER"
+echo
+
+assert "shared git identity helper exists" "[ -f '$HELPER' ]"
+
+expected_files=(
+    "$RECIPES_DIR/workflow-publish.yaml"
+    "$RECIPES_DIR/workflow-finalize.yaml"
+    "$RECIPES_DIR/workflow-pr-review.yaml"
+    "$RECIPES_DIR/consensus-publish.yaml"
+)
+
+for file in "${expected_files[@]}"; do
+    assert "$(basename "$file") exists" "[ -f '$file' ]"
+done
+
+mapfile -t files < <(commit_recipe_files)
+if [ "${#files[@]}" -gt 0 ]; then
+    record_pass "found commit-producing recipe files"
+else
+    record_fail "found commit-producing recipe files" "no git commit commands found under $RECIPES_DIR"
+fi
+
+for file in "${files[@]}"; do
+    name="$(basename "$file")"
+
+    assert "$name sources git-identity.sh" \
+        "grep -q 'git-identity\.sh' '$file'"
+
+    assert "$name calls amplihack_prepare_git_commit_identity" \
+        "grep -q 'amplihack_prepare_git_commit_identity' '$file'"
+
+    assert "$name does not silence git commit failures as success" \
+        "! grep -Eq 'git[[:space:]]+commit.*2>/dev/null[[:space:]]*\\|\\|[[:space:]]*echo' '$file'"
+
+    while IFS=: read -r line_no line_text; do
+        [ -n "$line_no" ] || continue
+        if has_prepare_immediately_before_commit "$file" "$line_no"; then
+            record_pass "$name line $line_no prepares identity before git commit"
+        else
+            record_fail "$name line $line_no prepares identity before git commit" "$line_text"
+        fi
+    done < <(commit_command_lines "$file")
+done
+
+if command -v python3 >/dev/null 2>&1; then
+    if python3 - <<'PY' "$RECIPES_DIR"
+import pathlib
+import sys
+
+try:
+    import yaml
+except Exception:
+    sys.exit(2)
+
+recipes = pathlib.Path(sys.argv[1])
+for path in recipes.glob("*.yaml"):
+    with path.open("r", encoding="utf-8") as fh:
+        yaml.safe_load(fh)
+PY
+    then
+        record_pass "all recipe YAML files parse"
+    else
+        rc=$?
+        if [ "$rc" = "2" ]; then
+            record_pass "PyYAML unavailable; YAML parse check skipped"
+        else
+            record_fail "all recipe YAML files parse" "python yaml.safe_load failed"
+        fi
+    fi
+else
+    record_pass "python3 unavailable; YAML parse check skipped"
+fi
+
+echo
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add shared git identity helper for Amplihack-created commits
- Wire every commit-producing recipe to prepare author and committer identity before git commit
- Document explicit AMPLIHACK_GIT_* configuration and fail-fast remediation

## Tests
- bash tests/git_identity_test.sh
- bash tests/recipe_commit_identity_static_test.sh
- NODE_OPTIONS=--max-old-space-size=32768 pre-commit run --all-files