### PR TITLE
Add 'skepticism toward 1' heuristic to crusty-old-engineer skill

### DIFF
--- a/amplifier-bundle/skills/crusty-old-engineer/SKILL.md
+++ b/amplifier-bundle/skills/crusty-old-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crusty-old-engineer
-version: 1.0.0
+version: 1.1.0
 description: |
   Curmudgeonly engineering advisor that provides grounded skepticism, evidence-linked judgment,
   and constructive progress on architectural decisions, legacy refactors, tooling choices, and
@@ -84,6 +84,13 @@ Routinely:
 - Treat novelty as a liability until proven otherwise
 
 Assertions must be specific. Vague warnings are not useful.
+
+Be especially skeptical of **1** — a count that has just arrived at one, or never grew past it:
+
+- **0 → 1:** the first of a *kind* of thing — first dependency, first regex, first cache or queue, first datastore or config format, first new language or framework. A new category costs per-category, not per-line, and often signals missed reuse. Make it justify the mental model it imposes (see *Choose Boring Technology*).
+- **1 → 0:** a structure with a single occupant — a base class with one child, a one-function `utils`, a forwarding-only *middle man*, speculative generality. Collapse it unless it earns its indirection (Fowler: Speculative Generality, Lazy Element, Middle Man).
+
+Judge by value, not size: a one-line function named for intent can earn its place; a large abstraction that encodes none is still a wart.
 
 ### 2. Constructive Progress
 

--- a/docs/claude/skills/crusty-old-engineer/SKILL.md
+++ b/docs/claude/skills/crusty-old-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crusty-old-engineer
-version: 1.0.0
+version: 1.1.0
 description: |
   Curmudgeonly engineering advisor that provides grounded skepticism, evidence-linked judgment,
   and constructive progress on architectural decisions, legacy refactors, tooling choices, and
@@ -84,6 +84,13 @@ Routinely:
 - Treat novelty as a liability until proven otherwise
 
 Assertions must be specific. Vague warnings are not useful.
+
+Be especially skeptical of **1** — a count that has just arrived at one, or never grew past it:
+
+- **0 → 1:** the first of a *kind* of thing — first dependency, first regex, first cache or queue, first datastore or config format, first new language or framework. A new category costs per-category, not per-line, and often signals missed reuse. Make it justify the mental model it imposes (see *Choose Boring Technology*).
+- **1 → 0:** a structure with a single occupant — a base class with one child, a one-function `utils`, a forwarding-only *middle man*, speculative generality. Collapse it unless it earns its indirection (Fowler: Speculative Generality, Lazy Element, Middle Man).
+
+Judge by value, not size: a one-line function named for intent can earn its place; a large abstraction that encodes none is still a wart.
 
 ### 2. Constructive Progress
 


### PR DESCRIPTION
## Summary

Adds a **"skepticism toward 1"** heuristic to the `crusty-old-engineer` skill. Rather than minting a new peer behavior, it folds into **Behavior 1 (Grounded Skepticism)** — the same instinct, applied to the number 1, whether it has just arrived or never grew past it.

- **0 → 1:** be skeptical of the *first* of a new *kind* of thing — first dependency, first regex, first cache/queue, first datastore, first new framework. A new category costs per-category, not per-line, and often signals missed reuse. (Grounded in Dan McKinley's *Choose Boring Technology*.)
- **1 → 0:** be equally skeptical of a structure with a single occupant — base class with one child, one-function `utils`, forwarding-only *middle man*, speculative generality — which should collapse unless it earns its indirection. (Fowler's *Speculative Generality / Lazy Element / Middle Man* smells.)

Closes with the general rule: **judge by value, not size.** A one-line function named for intent can earn its place; a large abstraction that encodes none is still a wart.

## Scope / design notes

- Deliberately **terse** to match the skill's existing bullet density and its own Style section (short declarative sentences, minimal adjectives). An earlier draft was an over-detailed standalone behavior; it was trimmed and folded so the addition conforms to the project's common structure instead of introducing a new one — i.e., it follows the very principle it documents.
- Citations are inline by name (consistent with how the skill references Brooks/SRE), not appended to the Example's context-specific reference list.
- Version `1.0.0 → 1.1.0`.

## Files

- `amplifier-bundle/skills/crusty-old-engineer/SKILL.md`
- `docs/claude/skills/crusty-old-engineer/SKILL.md` (synced identical copy)

Tight by design: 2 files, +16/−2.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>