### PR TITLE
fix: Windows release build timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-targets: false
+          cache-on-failure: true
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
 
@@ -68,6 +69,7 @@ jobs:
           # The full workspace test profile links large native artifacts. Restoring
           # target/ can exhaust GitHub-hosted runner disk before tests start.
           cache-targets: false
+          cache-on-failure: true
       - run: cargo test --workspace --locked
 
   install-smoke:
@@ -85,6 +87,7 @@ jobs:
           # hydrates instead of rebuilding the workspace from scratch.
           key: x86_64-unknown-linux-gnu
           cache-targets: false
+          cache-on-failure: true
       - name: Install from local checkout
         run: cargo install --path bins/amplihack --locked
       - name: Verify binary
@@ -127,6 +130,7 @@ jobs:
         with:
           key: ${{ matrix.target }}
           cache-targets: false
+          cache-on-failure: true
 
       - name: Install GNU cross toolchain
         if: matrix.gnu_cross_toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: version-bump
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 45
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -141,6 +141,7 @@ jobs:
         with:
           key: release-${{ matrix.target }}
           cache-targets: false
+          cache-on-failure: true
 
       - name: Install GNU cross toolchain
         if: matrix.gnu_cross_toolchain


### PR DESCRIPTION
## Root cause

The version bump from `0.11.1` → `0.11.30` changed every workspace crate version in `Cargo.lock`, busting the `Swatinem/rust-cache` key. A cold Windows build compiles all dependencies from scratch (~40+ min) and exceeded the 45-min timeout. Twice.

**Evidence:**
- Last successful Windows build (Jun 20, cached): **5 min 23 sec** — started from `amplihack-utils`
- Failed Windows build (Jun 25, cold): **39 min** before timeout — started from `proc-macro2`

## Fixes

1. **Increase build timeout** from 45 → 90 minutes (`release.yml`)
2. **Add `cache-on-failure: true`** to all `Swatinem/rust-cache` steps (`release.yml` + `ci.yml`) — saves partial cache even on timeout/failure, so subsequent runs don't start from zero again