### PR TITLE
fix(artifact-guard): exempt launcher-owned .claude/runtime bookkeeping (#807)

### DIFF
--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -483,7 +483,35 @@ fn add_violation_if_prohibited(
     }
 }
 
+/// Runtime bookkeeping files that the amplihack launcher and session tracker
+/// write into `<repo>/.claude/runtime/` as a normal, unavoidable part of
+/// launching an agent. They live under the path the `claude-runtime` rule
+/// otherwise blocks, but they are the launcher's OWN state — not leftover agent
+/// pollution — so the guard must never flag them. Treating them as violations
+/// turned a clean end-of-run guard step into a hard failure (issue #807), which
+/// in turn left `recipe-runner-rs` and its child agents hung after the work was
+/// already committed and pushed.
+///
+/// The exemption is intentionally narrow: only these specific launcher-owned
+/// files are exempt. Everything else under `.claude/runtime/` (session logs,
+/// metrics, locks, power-steering state, stray runtime output) is still blocked
+/// so the guard keeps catching genuine runtime pollution. Paths mirror
+/// `amplihack_types::ProjectDirs::launcher_context_file` and `sessions_log_file`.
+const LAUNCHER_OWNED_RUNTIME_FILES: &[&str] = &[
+    ".claude/runtime/launcher_context.json",
+    ".claude/runtime/sessions.jsonl",
+];
+
+/// Whether `path` is a launcher-owned runtime bookkeeping file that the guard
+/// must never treat as a prohibited artifact. See [`LAUNCHER_OWNED_RUNTIME_FILES`].
+fn is_launcher_owned_runtime_file(path: &str) -> bool {
+    LAUNCHER_OWNED_RUNTIME_FILES.contains(&path)
+}
+
 fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static ArtifactRule> {
+    if is_launcher_owned_runtime_file(path) {
+        return None;
+    }
     if path_has_component(path, "node_modules") {
         return rule("node-modules");
     }

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -134,6 +134,93 @@ fn ignored_present_dist_plugin_runtime_and_cache_artifacts_are_blocked() {
 }
 
 #[test]
+fn launcher_owned_runtime_files_are_exempt_while_other_runtime_state_is_blocked() {
+    // Regression for issue #807: the amplihack launcher writes its own
+    // bookkeeping into `<repo>/.claude/runtime/` as part of every launch. The
+    // guard must not flag those launcher-owned files (which turned the
+    // end-of-run guard step into a hang), but must still block genuine runtime
+    // pollution under the same directory.
+    let tmp = repo();
+    write_file(&tmp.path().join(".gitignore"), ".claude/runtime/\n");
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore claude runtime"]);
+
+    // Launcher-owned bookkeeping (exempt).
+    write_file(
+        &tmp.path().join(".claude/runtime/launcher_context.json"),
+        "{}\n",
+    );
+    write_file(&tmp.path().join(".claude/runtime/sessions.jsonl"), "{}\n");
+    // Genuine runtime pollution under the same directory (still blocked).
+    write_file(&tmp.path().join(".claude/runtime/session.json"), "{}\n");
+    write_file(
+        &tmp.path().join(".claude/runtime/metrics/tool.json"),
+        "{}\n",
+    );
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    for exempt in [
+        ".claude/runtime/launcher_context.json",
+        ".claude/runtime/sessions.jsonl",
+    ] {
+        assert!(
+            !report.violations.iter().any(|v| v.path == exempt),
+            "launcher-owned runtime file {exempt} must be exempt; got {:#?}",
+            report.violations
+        );
+    }
+    for blocked in [
+        ".claude/runtime/session.json",
+        ".claude/runtime/metrics/tool.json",
+    ] {
+        let violation = violation_for(&report.violations, blocked, ArtifactSource::IgnoredPresent);
+        assert_eq!(
+            violation.rule_id, "claude-runtime",
+            "{blocked} must still be blocked as claude-runtime"
+        );
+    }
+}
+
+#[test]
+fn launcher_context_is_exempt_regardless_of_git_source() {
+    // The exemption is path-based and applies whether the launcher file is
+    // staged, untracked, or ignored-present — the end-of-run guard runs in
+    // `pre-publish` mode and must stay clean in every case.
+    let tmp = repo();
+
+    // Staged (force-added past .gitignore).
+    write_file(
+        &tmp.path().join(".claude/runtime/launcher_context.json"),
+        "{}\n",
+    );
+    run_git(
+        tmp.path(),
+        &["add", "-f", ".claude/runtime/launcher_context.json"],
+    );
+
+    // Untracked sessions log.
+    write_file(&tmp.path().join(".claude/runtime/sessions.jsonl"), "{}\n");
+
+    let report = scan_artifacts(
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::PrePublish),
+    )
+    .expect("scan artifacts");
+
+    assert!(
+        report.is_clean(),
+        "launcher-owned runtime files must not be flagged in any source; got {:#?}",
+        report.violations
+    );
+    assert!(
+        tmp.path()
+            .join(".claude/runtime/launcher_context.json")
+            .exists(),
+        "guard must not delete launcher state"
+    );
+}
+
+#[test]
 fn ignored_present_workflow_session_artifacts_are_blocked() {
     let tmp = repo();
     write_file(

--- a/docs/artifact-guard.md
+++ b/docs/artifact-guard.md
@@ -121,7 +121,7 @@ repository worktree:
 | --- | --- | --- |
 | Dependency trees | `node_modules/`, `packages/*/node_modules/` | Blocked |
 | Plugin bundles | `dist/plugin.js`, `*/dist/plugin.js` | Blocked |
-| Claude runtime | `.claude/runtime/` | Blocked |
+| Claude runtime | `.claude/runtime/` | Blocked (except launcher-owned bookkeeping — see below) |
 | Nested worktrees | `worktrees/` | Blocked |
 | Cache directories | `.cache/`, `.npm/`, `.pnpm-store/`, `.yarn/cache/`, `.turbo/`, `.parcel-cache/`, `.pytest_cache/` | Blocked |
 | Build output | `dist/`, `build/`, `coverage/`, `.next/`, `out/`, `logs/`, `outputs/`, `index.scip` | Blocked |
@@ -131,6 +131,27 @@ repository worktree:
 Rules match normalized repo-relative paths using `/` separators. The guard does
 not need to read artifact file contents; path-level scanning is the intended
 contract.
+
+### Built-in launcher exemptions
+
+The amplihack launcher and session tracker write a small set of bookkeeping
+files into `<repo>/.claude/runtime/` as a normal, unavoidable part of launching
+an agent. These files are the launcher's own state, not leftover agent
+pollution, so the guard never flags them even though they sit under the
+otherwise-blocked `.claude/runtime/` tree:
+
+| Exempt path | Writer |
+| --- | --- |
+| `.claude/runtime/launcher_context.json` | Launcher / hooks (adaptive launcher detection) |
+| `.claude/runtime/sessions.jsonl` | Session tracker (nesting detection) |
+
+This is a built-in implicit exemption, not a `.amplihack-artifact-allowlist`
+entry, and it is intentionally narrow. Every other path under
+`.claude/runtime/` (session logs, metrics, locks, power-steering state, and any
+stray runtime output) is still blocked. Before this exemption, the launcher's
+own `launcher_context.json` failed the end-of-run `pre-publish` guard, which in
+turn left `recipe-runner-rs` and its child agents hung after the work was
+already committed and pushed (issue #807).
 
 ## Allowlist configuration
 

--- a/tests/integration/artifact_guard_cli_tests.rs
+++ b/tests/integration/artifact_guard_cli_tests.rs
@@ -167,6 +167,93 @@ fn cli_returns_exit_0_for_clean_repository() {
 }
 
 #[test]
+fn cli_exits_0_when_only_launcher_owned_runtime_files_are_present() {
+    // Regression for issue #807: the launcher's own `.claude/runtime/` files
+    // must not turn the end-of-run guard into a non-zero exit (which hung the
+    // runner). The pre-publish guard over a worktree that only contains launcher
+    // bookkeeping must return a clean exit 0.
+    let tmp = repo();
+    write_file(&tmp.path().join(".gitignore"), ".claude/runtime/\n");
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore claude runtime"]);
+    write_file(
+        &tmp.path().join(".claude/runtime/launcher_context.json"),
+        "{}\n",
+    );
+    write_file(&tmp.path().join(".claude/runtime/sessions.jsonl"), "{}\n");
+
+    let output = Command::new(bin())
+        .args([
+            "hygiene",
+            "artifact-guard",
+            "--mode",
+            "pre-publish",
+            "--repo",
+        ])
+        .arg(tmp.path())
+        .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
+        .output()
+        .expect("run artifact guard");
+
+    assert!(
+        output.status.success(),
+        "launcher-owned runtime files must not block the guard\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cli_exits_1_cleanly_for_genuine_runtime_pollution_next_to_launcher_files() {
+    // The exemption is narrow: a real leftover under `.claude/runtime/` still
+    // produces a clean non-zero exit (not a hang), even when the launcher's own
+    // exempt files sit beside it.
+    let tmp = repo();
+    write_file(&tmp.path().join(".gitignore"), ".claude/runtime/\n");
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore claude runtime"]);
+    write_file(
+        &tmp.path().join(".claude/runtime/launcher_context.json"),
+        "{}\n",
+    );
+    write_file(&tmp.path().join(".claude/runtime/session.json"), "{}\n");
+
+    let output = Command::new(bin())
+        .args([
+            "hygiene",
+            "artifact-guard",
+            "--mode",
+            "pre-publish",
+            "--repo",
+        ])
+        .arg(tmp.path())
+        .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
+        .output()
+        .expect("run artifact guard");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "genuine runtime pollution must exit 1\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains(".claude/runtime/session.json"),
+        "must report the genuine runtime leftover; got:\n{combined}"
+    );
+    assert!(
+        !combined.contains("launcher_context.json"),
+        "must not report the exempt launcher file; got:\n{combined}"
+    );
+}
+
+#[test]
 fn cli_returns_exit_2_for_invalid_allowlist() {
     let tmp = repo();
     let allowlist = tmp.path().join(".amplihack-artifact-allowlist");


### PR DESCRIPTION
## Summary

Fixes #807. The artifact guard's `claude-runtime` rule flagged the launcher's
**own** runtime bookkeeping file `.claude/runtime/launcher_context.json` (and
`.claude/runtime/sessions.jsonl`) as leftover pollution. Because the guard runs
as the end-of-run `pre-publish` step (`step-20a-artifact-guard` /
`step-14g-artifact-guard`), this false positive failed every launcher-driven
recipe run **after** the work was already committed and pushed — which is what
left `recipe-runner-rs` and its child `copilot` agents hung for 30–40+ minutes.

### Root cause

`amplihack launch` and the session tracker write `launcher_context.json` /
`sessions.jsonl` into `<repo>/.claude/runtime/` as a normal, unavoidable part of
launching an agent (`ProjectDirs::launcher_context_file` / `sessions_log_file`).
`rule_for_path` then matched them via:

```rust
if path == ".claude/runtime" || path.starts_with(".claude/runtime/") {
    return rule("claude-runtime");
}
```

So the launcher's own state was reported as a prohibited artifact, turning a
clean end-of-run guard step into a hard failure.

### Fix

Add a **narrow, built-in implicit exemption** for the two launcher/session-tracker
bookkeeping files, checked before any rule matching:

```rust
const LAUNCHER_OWNED_RUNTIME_FILES: &[&str] = &[
    ".claude/runtime/launcher_context.json",
    ".claude/runtime/sessions.jsonl",
];
```

Everything else under `.claude/runtime/` (session logs, metrics, locks,
power-steering, stray output) stays blocked, so the guard keeps catching
genuine runtime pollution. This is a built-in exemption, **not** a
`.amplihack-artifact-allowlist` entry (the user allowlist still rejects broad
`.claude/runtime/**` entries unchanged).

Relocating runtime state outside the worktree (the issue's alternative) was
rejected: `ProjectDirs` roots **all** runtime state (locks, metrics, logs,
power-steering, launcher_context, sessions) under `<repo>/.claude/runtime/`;
moving it would ripple through hook injection and nesting detection across many
crates — a large blast radius for a targeted false-positive fix.

### Scope note on the issue's second ask

The issue also asks that a guard violation produce a clean non-zero exit **and
tear down the child process tree**. The CLI guard (`amplihack hygiene
artifact-guard`) **already** exits cleanly with code `1` on violations
(`command_error::exit_error(1)`); there is no hang in amplihack-rs. The child-tree
teardown belongs to the orchestration engine **`recipe-runner-rs`, which is the
separate `rysweet/amplihack-recipe-runner` repo** (installed via
`cargo install --git …/amplihack-recipe-runner`), not amplihack-rs. This PR
removes the trigger for the reported hang; a follow-up issue should be filed on
`amplihack-recipe-runner` for defensive teardown. The unrelated `npm ci` /
symlinked-`node_modules` observation is likewise left out of scope.

## Changes

| File | Change |
| --- | --- |
| `crates/amplihack-utils/src/artifact_guard.rs` | Built-in exemption for launcher-owned runtime files |
| `crates/amplihack-utils/src/tests/artifact_guard_tests.rs` | 2 unit tests (exempt across staged/untracked/ignored; siblings still blocked) |
| `tests/integration/artifact_guard_cli_tests.rs` | 2 CLI tests (exit 0 when only launcher files; exit 1 cleanly for genuine pollution beside them) |
| `docs/artifact-guard.md` | Document the built-in launcher exemption |

## Evidence

**Tests (criterion 1 — validated):**

- `cargo test -p amplihack-utils artifact_guard` → `17 passed; 0 failed`
  (incl. new `launcher_owned_runtime_files_are_exempt_while_other_runtime_state_is_blocked`,
  `launcher_context_is_exempt_regardless_of_git_source`).
- `cargo test -p amplihack --test artifact_guard_cli` → `7 passed; 0 failed`
  (incl. new `cli_exits_0_when_only_launcher_owned_runtime_files_are_present`,
  `cli_exits_1_cleanly_for_genuine_runtime_pollution_next_to_launcher_files`).
- `--test artifact_guard_workflow` → `9 passed`; `--test pre_commit_artifact_guard` → `7 passed` (no regressions).

**Docs (criterion 2):** `docs/artifact-guard.md` updated — rules table + new
"Built-in launcher exemptions" section.

**Quality review (criterion 3):** Reviewed across three passes — (a) correctness:
exemption is path-exact and source-independent, normalized for `\`→`/`; (b)
security: exemption is narrow, does not weaken the user allowlist validation,
genuine `.claude/runtime/` pollution still blocked; (c) scope: only the guard
surface touched, no dependency or lockfile changes. No critical/high/medium
findings remain.

**Local gates (criterion 4 — CI parity):**

- `cargo fmt --check` → clean.
- `cargo clippy --locked -- -D warnings` (whole workspace, the exact CI command) → clean.
- `amplihack hygiene artifact-guard --repo . --mode pre-commit` (self-scan) → `Artifact Guard clean`.
- pre-commit hooks on commit: artifact-guard / cargo-fmt / cargo-clippy → all Passed.

**Scope (criterion 6):** 4 files, guard-only diff; no unrelated edits.

Closes #807
