### PR TITLE
fix: restore green CI — revert spurious version bump + register pr-guide skill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplihack"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-core"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-memory",
  "async-trait",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-eval"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-generator"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "serde",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-asset-resolver-bin"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-cli",
  "tracing",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-blarify"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-builders"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-builders",
  "amplihack-hive",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-context"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-delegation"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "globset",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-domain-agents"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-fleet"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hive"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-cli",
  "amplihack-security",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-launcher"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-types",
  "amplihack-utils",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-memory"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-multilspy"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-orchestration"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-utils",
  "async-trait",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recovery"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-reflection"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-remote"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-safety"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-security"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "once_cell",
  "regex",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-session"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "filetime",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-utils"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "base64",
  "chrono",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-workflows"
-version = "0.11.30"
+version = "0.11.1"
 dependencies = [
  "amplihack-utils",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.30"
+version = "0.11.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/crates/amplihack-hooks/src/known_skills.rs
+++ b/crates/amplihack-hooks/src/known_skills.rs
@@ -91,6 +91,7 @@ static AMPLIHACK_SKILLS: &[&str] = &[
     "poet-analyst",
     "political-scientist-analyst",
     "pptx",
+    "pr-guide",
     "pr-review-assistant",
     "pre-commit-manager",
     "psychologist-analyst",
@@ -168,7 +169,7 @@ mod tests {
 
     #[test]
     fn skill_count_is_reasonable() {
-        assert_eq!(skill_count(), 121);
+        assert_eq!(skill_count(), 122);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`main` CI (`cargo test --workspace`) has been **red for days** due to multiple unrelated pre-existing breakages from recent commits. `cargo test` is fail-fast, so they surface one at a time. This PR fixes the deterministic blockers so CI can go green again (required before any open PR — including #819, the issue #807 artifact-guard fix — can merge).

### Fix 1 — revert spurious version bump (commit 1)

`[workspace.package].version` was changed `0.11.1 → 0.11.30` in b123c10 ("clarity revisions for pr-guide skill"), an unrelated docs commit that jumped 29 patches without updating `package.json` (still 0.11.1) or the release-line contract (still 0.11.1). Reverted to `0.11.1` (Cargo.toml + Cargo.lock via `cargo update --workspace`; 72 external deps unchanged). Fixes:
- `version_contract_test::package_json_version_matches_root_workspace_version`
- `issue_672_workflow_reliability_contracts::workspace_version_matches_latest_release_line`

### Fix 2 — register the bundled pr-guide skill (commit 2)

The `pr-guide` skill (`amplifier-bundle/skills/pr-guide/SKILL.md`, `name: pr-guide`) was bundled by #812/#814 but never added to the `AMPLIHACK_SKILLS` registry. Inserted `"pr-guide"` in sorted position and bumped the expected count 121 → 122. Fixes:
- `known_skills::tests::registry_matches_bundled_skill_frontmatter_names`
- `known_skills::tests::skill_count_is_reasonable`

## Evidence

- `cargo test -p amplihack-hooks --lib known_skills` → 7 passed.
- Version contract checks replicated: `package.json == workspace == 0.11.1`, and `workspace == "0.11.1"`.
- Artifact Guard self-scan → clean.
- Diffs are minimal: Cargo.toml (1 line), Cargo.lock (version lines only, no dep drift), known_skills.rs (1 entry + 1 count).

## Scope

These are pre-existing, unrelated-to-each-other breakages bundled here solely because both block ALL CI. If `0.11.30` was intentional, the alternative is to bump package.json + the issue_672 assertion together — but the evidence (unrelated commit, untouched siblings) indicates it was not.