### PR TITLE
feat: pr-guide clarity pass, guide back-link, ADO mermaid fallback

### DIFF
--- a/amplifier-bundle/skills/pr-guide/SKILL.md
+++ b/amplifier-bundle/skills/pr-guide/SKILL.md
@@ -199,7 +199,11 @@ acronyms, expands shorthand, and tightens wording while **preserving the
 original meaning** — it never invents new claims or drops caveats. The rewrite
 is pushed back to the PR via `gh pr edit --body-file` (GitHub) or
 `az repos pr update --description` (ADO) — a PR API write, **never** a git
-commit. If the description is already clear, it is left unchanged. See
+commit. It is **not** written on its own: like all publishing, it is opt-in
+(default no-op) and is prepared in memory, then folded into the **single,
+confirmation-gated** description write performed at publish time (see
+`reference.md` → §10b and §11). If the description is already clear, it is left
+unchanged. See
 `reference.md` → *Clarity passes → PR Description Clarity Pass*.
 
 ## Security Notes

--- a/amplifier-bundle/skills/pr-guide/SKILL.md
+++ b/amplifier-bundle/skills/pr-guide/SKILL.md
@@ -25,7 +25,7 @@ Activate when you (or a workflow) ask to:
 - "Explain / document / summarize PR #N"
 - "Generate reviewer notes for this pull request"
 - Run automatically at the **end of `default-workflow`**, right after a PR is
-  opened, to offer a walkthrough.
+  opened, to attach a walkthrough.
 
 Standalone or workflow-invoked — both are supported.
 
@@ -53,7 +53,7 @@ flowchart TD
     E --> F[6. Detect GUI/TUI<br/>capture screenshots best-effort]
     F --> G[7. Build deep links + mermaid]
     G --> H[8. Assemble 5-section doc]
-    H --> I[9. Write temp file · print path · offer to post]
+    H --> I[9. Write temp file · print path · attach to PR]
 ```
 
 See `reference.md` for the exact commands, field mappings, URL formats,
@@ -128,16 +128,15 @@ installed and authenticated (failing fast with the exact `gh auth login` /
 **retries transient errors** (network blips, timeouts, `5xx`, rate limits) with
 bounded exponential backoff (max 3 attempts, honoring `Retry-After`). Read calls
 retry; **publish/mutation calls never auto-retry** (they could duplicate a
-comment) and remain confirmation-gated. Missing optional data degrades the guide
-gracefully instead of aborting. See `reference.md` → *External service
-resilience*.
+comment) — a failed publish is reported, not silently retried. Missing optional
+data degrades the guide gracefully instead of aborting. See `reference.md` →
+*External service resilience*.
 
 ## Output
 
 - Markdown is written to an **OS temp file** (`$TMPDIR`/`/tmp`) with `0600`
   permissions — never committed.
-- The skill **offers to attach** the guide to the PR (opt-in; default no-op).
-  On explicit user confirmation it:
+- The skill **automatically attaches** the guide to the PR:
   1. **Fits in PR description?** If the existing description + a separator +
      the guide is under the platform's description limit (GitHub ~65,000
      chars; ADO 4,000 chars), **append** the guide to the PR description
@@ -199,9 +198,8 @@ acronyms, expands shorthand, and tightens wording while **preserving the
 original meaning** — it never invents new claims or drops caveats. The rewrite
 is pushed back to the PR via `gh pr edit --body-file` (GitHub) or
 `az repos pr update --description` (ADO) — a PR API write, **never** a git
-commit. It is **not** written on its own: like all publishing, it is opt-in
-(default no-op) and is prepared in memory, then folded into the **single,
-confirmation-gated** description write performed at publish time (see
+commit. It is **not** written on its own: it is prepared in memory, then folded
+into the **single** description write performed at publish time (see
 `reference.md` → §10b and §11). If the description is already clear, it is left
 unchanged. See
 `reference.md` → *Clarity passes → PR Description Clarity Pass*.

--- a/amplifier-bundle/skills/pr-guide/SKILL.md
+++ b/amplifier-bundle/skills/pr-guide/SKILL.md
@@ -25,7 +25,7 @@ Activate when you (or a workflow) ask to:
 - "Explain / document / summarize PR #N"
 - "Generate reviewer notes for this pull request"
 - Run automatically at the **end of `default-workflow`**, right after a PR is
-  opened, to attach a walkthrough.
+  opened, to offer a walkthrough.
 
 Standalone or workflow-invoked — both are supported.
 
@@ -136,7 +136,8 @@ resilience*.
 
 - Markdown is written to an **OS temp file** (`$TMPDIR`/`/tmp`) with `0600`
   permissions — never committed.
-- The skill **automatically attaches** the guide to the PR:
+- The skill **offers to attach** the guide to the PR (opt-in; default no-op).
+  On explicit user confirmation it:
   1. **Fits in PR description?** If the existing description + a separator +
      the guide is under the platform's description limit (GitHub ~65,000
      chars; ADO 4,000 chars), **append** the guide to the PR description
@@ -144,7 +145,11 @@ resilience*.
   2. **Too long for description?** Post the guide as a **PR comment** instead
      (GitHub ~65,000 char limit; ADO 150,000 char limit). ADO's 4,000-char
      description limit means the guide will almost always go to a comment
-     on that platform.
+     on that platform. After posting, the skill reads the new comment's ID
+     from the CLI response and inserts a **back-link** into the (already
+     clarified) PR description — e.g.
+     `See the [Illustrated Guide](#issuecomment-<ID>) for a detailed
+     walkthrough of this PR.` See `reference.md` → *Guide-comment back-link*.
 - The absolute path of the temp file is always printed so the user has a
   local copy regardless.
 
@@ -166,7 +171,12 @@ Generate an illustrated guide for PR #123
 The skill is fully standalone, so the same invocation works outside any
 workflow.
 
-## Clarity Pass (on the generated guide)
+## Clarity Passes
+
+Two **distinct** passes run before publishing. They act on separate text and
+must not be conflated.
+
+### Guide Clarity Pass (on the generated guide)
 
 After assembling the document, re-read the generated guide and revise:
 
@@ -179,6 +189,18 @@ After assembling the document, re-read the generated guide and revise:
 3. **Neutral language.** Describe what the code does directly. Do not use
    dramatic contrast phrases like "does X, not some inferior Y" — just
    describe what X is and why.
+
+### PR Description Clarity Pass (on the existing PR description)
+
+A **separate** action from generating the guide. After the guide is built, the
+skill also rewrites the **PR's existing description in place** so a reviewer
+unfamiliar with the work can read it: it removes jargon and unexplained
+acronyms, expands shorthand, and tightens wording while **preserving the
+original meaning** — it never invents new claims or drops caveats. The rewrite
+is pushed back to the PR via `gh pr edit --body-file` (GitHub) or
+`az repos pr update --description` (ADO) — a PR API write, **never** a git
+commit. If the description is already clear, it is left unchanged. See
+`reference.md` → *Clarity passes → PR Description Clarity Pass*.
 
 ## Security Notes
 

--- a/amplifier-bundle/skills/pr-guide/reference.md
+++ b/amplifier-bundle/skills/pr-guide/reference.md
@@ -173,7 +173,7 @@ for attempt in 1..=3:
 ### Write/publish operations are NOT auto-retried
 
 Publishing (set description / post comment) mutates remote state and is already
-**confirmation-gated** (Section 10). Do **not** silently retry a failed publish:
+**confirmation-gated** (Section 11). Do **not** silently retry a failed publish:
 a comment POST may have partially succeeded, so a blind retry risks duplicates.
 On publish failure, report the error and the temp-file path so the user can act
 deliberately. Only retry a publish on explicit user confirmation.
@@ -357,9 +357,39 @@ Use the `mermaid-diagram-generator` skill's conventions for syntax. Prefer
 `flowchart` for architecture/flow and `sequenceDiagram` for request/response
 interactions.
 
+### Mermaid on Azure DevOps (no native PR rendering — image fallback)
+
+Azure DevOps renders mermaid in **markdown file previews, the PR file-diff
+view, and Wiki pages**, but **does not render mermaid in PR descriptions or PR
+comments** — a ` ```mermaid ` fence pasted into a description or comment stays
+as literal code (confirmed against ADO Repos Sprint 246+ / Sprint 259,
+2024–2025). Re-check the current release notes when in doubt; if native
+PR-description/comment support ships later, prefer it and skip the conversion.
+
+Because the guide is published to the PR **description/comment**, mermaid must
+be converted to an **image** on ADO. When `platform == Azure DevOps`, render
+each diagram and embed it as an image instead of a fenced code block:
+
+| Step | What |
+| --- | --- |
+| 1 | Take the mermaid source for the diagram. |
+| 2a (preferred) | Render locally with the mermaid CLI: `mmdc -i <diagram>.mmd -o <diagram>.svg` (or `.png`), write to the temp dir (`0600`), publish via the PR attachments API (same flow as screenshots, §11), and rewrite to the attachment URL. |
+| 2b (fallback) | Use the hosted renderer: URL-safe-base64-encode the mermaid source and embed `![diagram](https://mermaid.ink/img/<base64-encoded-diagram>)`. |
+| 3 | Replace the ` ```mermaid ` fence with `![<caption>](<url>)` **in the ADO output only**. GitHub keeps native ` ```mermaid ` fences and needs no conversion. |
+
+**Privacy / security note:** `mermaid.ink` sends the diagram source to a
+**third-party** service. For internal or sensitive repositories prefer local
+`mmdc` rendering and reserve `mermaid.ink` for public diagrams. Always
+URL-encode the base64 payload and treat the resulting URL as inert data.
+
 ---
 
-## 10. Clarity pass (on the generated guide)
+## 10. Clarity passes
+
+Two **separate** passes run after the guide is assembled. They operate on
+**different text** and must not be conflated.
+
+### 10a. Guide Clarity Pass (on the generated guide)
 
 After assembling the 5-section document, re-read the generated guide and revise:
 
@@ -373,6 +403,36 @@ After assembling the 5-section document, re-read the generated guide and revise:
    dramatic contrast phrases like "does X, not some inferior Y" — just say
    what X is and why.
 4. **Short sentences.** If a sentence needs re-reading to understand, split it.
+
+### 10b. PR Description Clarity Pass (on the existing PR description)
+
+A **distinct, additional** action: rewrite the PR's **existing description in
+place** so a reviewer unfamiliar with the work can understand it. This is not
+the guide and not the guide-clarity pass — it edits the PR's description field
+itself.
+
+**Goals:** remove jargon and unexplained acronyms, expand shorthand, and
+tighten wording **while preserving the original meaning**. Do not add new
+claims, drop caveats, or surface secrets, internal hostnames, or private URLs.
+If the description is already clear, leave it unchanged.
+
+**Commands (PR API writes — never a git commit):**
+
+| Platform | Read | Write |
+| --- | --- | --- |
+| GitHub | `gh pr view <N> --json body --jq .body` | `gh pr edit <N> --body-file <path>` |
+| Azure DevOps | `az repos pr show --id <N> --query description -o tsv` | `az repos pr update --id <N> --description <text>` |
+
+**Ordering:** run the **Guide Clarity Pass first** (on the guide), then the
+**PR Description Clarity Pass** (on the description). The description rewrite is
+prepared **before** publishing (§11) so it can be combined into a **single
+final description write** on whichever publish path runs: appended ahead of the
+guide in the *fits-in-description* path, or ahead of the back-link in the
+*comment-overflow* path — see *Guide-comment back-link*.
+
+**Permissions:** both the rewrite and the back-link need PR-write scope. If the
+session is read-only, **skip** the description rewrite, keep the local guide,
+and tell the user — do not escalate privileges.
 
 ---
 
@@ -403,11 +463,14 @@ The skill should **warn** the user when offering to publish a guide that
 contains local screenshot paths: "Screenshots reference local temp files and
 will appear broken in the published version unless uploaded separately."
 
-### Publishing (automatic — description-first, comment-fallback)
+### Publishing (confirmation-gated — description-first, comment-fallback)
 
-The guide is attached to the PR automatically. No confirmation prompt.
+Publishing is **opt-in** (default no-op): the skill **offers** to attach the
+guide and acts only on **explicit user confirmation**. Once the user confirms,
+it follows the decision logic below to choose between appending to the
+description and posting a comment.
 
-**Decision logic:**
+**Decision logic (runs only after the user confirms publishing):**
 
 1. Read the **existing PR description** (GitHub: `body` from metadata; ADO:
    `description` from `pr show`).
@@ -415,6 +478,10 @@ The guide is attached to the PR automatically. No confirmation prompt.
 3. If `combined_length` is under the platform's description size limit:
    - **Append** the guide to the existing description, separated by `\n\n---\n\n`.
    - Do not replace the existing description — preserve it.
+   - If the **PR Description Clarity Pass** (§10b) also ran, apply its rewrite
+     to the existing-description text **in memory first**, then append the
+     guide to the rewritten text, and perform **one** `pr edit` write. As in
+     the comment-overflow path, never issue two separate description updates.
 4. If `combined_length` exceeds the limit, or appending fails:
    - **Post the guide as a PR comment** instead.
 5. Print which action was taken and the temp-file path.
@@ -465,6 +532,40 @@ the temp-file path so the user can post manually. Do **not** auto-retry a
 failed publish — a comment POST may have partially succeeded, and a blind
 retry risks duplicates. Never auto-commit the doc.
 
+#### Guide-comment back-link
+
+When the guide overflows the description and is posted as a **comment**
+(decision logic step 4 above), insert a link to that comment into the PR
+description so reviewers can find the walkthrough.
+
+**1. Retrieve the comment ID from the CLI response.**
+
+| Platform | How |
+| --- | --- |
+| GitHub | `gh pr comment` prints the new comment URL, e.g. `https://github.com/<owner>/<repo>/pull/<N>#issuecomment-1234567890`. Parse the trailing `issuecomment-<ID>`. |
+| Azure DevOps | The PR Threads POST returns JSON containing the new thread `id`. Use that `id` as the `threadId`. |
+
+**2. Validate the ID** against `^[0-9]+$` before interpolating it into any URL
+or markdown. Abort the back-link (and keep the comment) if it does not match —
+this prevents URL/markdown/command injection from an unexpected response.
+
+**3. Build the back-link:**
+
+| Platform | Link |
+| --- | --- |
+| GitHub | Shorthand within the same PR: `See the [Illustrated Guide](#issuecomment-<ID>) for a detailed walkthrough of this PR.` Full form: `https://github.com/<owner>/<repo>/pull/<N>#issuecomment-<ID>`. |
+| Azure DevOps | `https://dev.azure.com/<org>/<project>/_git/<repo>/pullrequest/<N>?_a=overview&threadId=<ID>` |
+
+**4. Single final write.** The PR Description Clarity Pass (§10b) and this
+back-link both edit the description. Combine them: apply the clarity rewrite
+**in memory**, append the back-link line to that text, then perform **one**
+`gh pr edit --body-file` / `az repos pr update --description` write. This avoids
+two separate description updates and the noisy edit history they create.
+
+Insert the back-link **only** in the comment-overflow case. When the guide fits
+in the description (decision logic step 3), it is already inline and there is no
+separate comment to link to.
+
 ---
 
 ## 12. Security
@@ -484,6 +585,11 @@ retry risks duplicates. Never auto-commit the doc.
 - **Screenshot scope.** Only the app under test; never navigate to
   PR-content-derived URLs.
 - **Path encoding** for deep links only; never use PR paths as local FS targets.
+- **Third-party rendering.** `mermaid.ink` (the ADO image fallback) sends
+  diagram source to an external service — prefer local `mmdc` for internal or
+  sensitive repos; URL-encode the base64 payload.
+- **Numeric ID validation.** Comment/thread IDs used in back-links must match
+  `^[0-9]+$` before URL/markdown interpolation.
 - **Publishing is opt-in** and confirmation-gated; default no-op.
 
 ---

--- a/amplifier-bundle/skills/pr-guide/reference.md
+++ b/amplifier-bundle/skills/pr-guide/reference.md
@@ -172,11 +172,11 @@ for attempt in 1..=3:
 
 ### Write/publish operations are NOT auto-retried
 
-Publishing (set description / post comment) mutates remote state and is already
-**confirmation-gated** (Section 11). Do **not** silently retry a failed publish:
-a comment POST may have partially succeeded, so a blind retry risks duplicates.
-On publish failure, report the error and the temp-file path so the user can act
-deliberately. Only retry a publish on explicit user confirmation.
+Publishing (set description / post comment) mutates remote state. Do **not**
+silently retry a failed publish: a comment POST may have partially succeeded, so
+a blind retry risks duplicates. On publish failure, report the error and the
+temp-file path so the user can act deliberately. Only retry a publish on
+explicit user confirmation.
 
 ### Timeouts
 
@@ -463,14 +463,13 @@ The skill should **warn** the user when offering to publish a guide that
 contains local screenshot paths: "Screenshots reference local temp files and
 will appear broken in the published version unless uploaded separately."
 
-### Publishing (confirmation-gated — description-first, comment-fallback)
+### Publishing (automatic — description-first, comment-fallback)
 
-Publishing is **opt-in** (default no-op): the skill **offers** to attach the
-guide and acts only on **explicit user confirmation**. Once the user confirms,
-it follows the decision logic below to choose between appending to the
-description and posting a comment.
+The guide is attached to the PR automatically — no confirmation prompt. It
+follows the decision logic below to choose between appending to the description
+and posting a comment.
 
-**Decision logic (runs only after the user confirms publishing):**
+**Decision logic:**
 
 1. Read the **existing PR description** (GitHub: `body` from metadata; ADO:
    `description` from `pr show`).
@@ -595,7 +594,7 @@ separate comment to link to.
   sensitive repos; URL-encode the base64 payload.
 - **Numeric ID validation.** Comment/thread IDs used in back-links must match
   `^[0-9]+$` before URL/markdown interpolation.
-- **Publishing is opt-in** and confirmation-gated; default no-op.
+- **Publishing writes** to the PR description/comment only — never a git commit.
 
 ---
 

--- a/amplifier-bundle/skills/pr-guide/reference.md
+++ b/amplifier-bundle/skills/pr-guide/reference.md
@@ -474,7 +474,12 @@ description and posting a comment.
 
 1. Read the **existing PR description** (GitHub: `body` from metadata; ADO:
    `description` from `pr show`).
-2. Compute `combined_length = len(existing_description) + len("\n\n---\n\n") + len(guide)`.
+2. Compute `combined_length = len(description) + len("\n\n---\n\n") + len(guide)`,
+   where `description` is the **clarity-rewritten** text when the PR Description
+   Clarity Pass (§10b) ran (it can expand acronyms/shorthand and grow the text),
+   otherwise the existing description. Always measure the text that will actually
+   be written so the fit check matches the write (important on ADO's hard
+   4,000-char limit).
 3. If `combined_length` is under the platform's description size limit:
    - **Append** the guide to the existing description, separated by `\n\n---\n\n`.
    - Do not replace the existing description — preserve it.

--- a/amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh
+++ b/amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh
@@ -625,8 +625,7 @@ else
 fi
 
 # Single final description write (avoid double updates with the clarity pass).
-if grep_both "single final write" || (grep_both "single" && grep_both "write") \
-  || (grep_both "one" && grep_both "write"); then
+if grep_both "single final write"; then
   pass "combines clarity rewrite + back-link into a single final write"
 else
   fail "must combine the clarity rewrite and back-link into one final write"

--- a/amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh
+++ b/amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh
@@ -494,6 +494,207 @@ else
   pass "no secrets detected in skill files"
 fi
 
+# grep across the combined corpus using a FIXED (non-regex) string. Needed for
+# markers containing regex metacharacters like `[`, `]`, `(`, `)`, `#`, `?`.
+grep_both_f() { grep -qiF -- "$1" "${BOTH_FILES[@]}" 2>/dev/null; }
+
+# ─── Test 15: PR Description Clarity Pass (R1) ──────────────────────────────
+# A NEW, separate action that rewrites the *existing* PR description in place,
+# preserving meaning and removing jargon. Must be distinct from the existing
+# Guide Clarity Pass and appear in BOTH files (SKILL index + reference detail).
+
+echo ""
+echo "Test 15: PR Description Clarity Pass (in-place description rewrite)"
+
+# The named marker must exist in each file individually (not just the corpus),
+# because SKILL.md is the index and reference.md is the detail.
+if grep -qiF "PR Description Clarity Pass" "$SKILL_FILE"; then
+  pass "SKILL.md names the 'PR Description Clarity Pass'"
+else
+  fail "SKILL.md must name the 'PR Description Clarity Pass'"
+fi
+
+if grep -qiF "PR Description Clarity Pass" "$REFERENCE_FILE"; then
+  pass "reference.md names the 'PR Description Clarity Pass'"
+else
+  fail "reference.md must name the 'PR Description Clarity Pass'"
+fi
+
+# Must be disambiguated from the guide-clarity pass (both names present).
+if grep_both_f "Guide Clarity Pass"; then
+  pass "disambiguated from the 'Guide Clarity Pass'"
+else
+  fail "must keep 'Guide Clarity Pass' distinct from 'PR Description Clarity Pass'"
+fi
+
+# It is a SEPARATE action operating on the EXISTING description, in place.
+if (grep_both "separate" || grep_both "distinct" || grep_both "additional") \
+  && grep_both "existing" && (grep_both "in place" || grep_both "in-place"); then
+  pass "framed as a separate, in-place rewrite of the existing description"
+else
+  fail "must frame it as a separate in-place rewrite of the existing description"
+fi
+
+# Meaning must be preserved by the rewrite.
+if grep_both "preserv" && grep_both "meaning"; then
+  pass "rewrite preserves the original meaning"
+else
+  fail "must state the description rewrite preserves meaning"
+fi
+
+# It removes jargon so unfamiliar reviewers can read it.
+if grep_both "jargon" && (grep_both "unfamiliar" || grep_both "reviewer"); then
+  pass "removes jargon for reviewers unfamiliar with the work"
+else
+  fail "must remove jargon so unfamiliar reviewers can understand the description"
+fi
+
+# Performed via PR API writes (gh pr edit / az repos pr update), never a commit.
+if grep_both "gh pr edit" && grep_both "body-file"; then
+  pass "GitHub rewrite uses 'gh pr edit --body-file'"
+else
+  fail "must rewrite the GitHub description via 'gh pr edit --body-file'"
+fi
+
+if grep_both "az repos pr update" && grep_both "description"; then
+  pass "Azure DevOps rewrite uses 'az repos pr update --description'"
+else
+  fail "must rewrite the ADO description via 'az repos pr update --description'"
+fi
+
+# ─── Test 16: Guide-comment back-link (R2) ──────────────────────────────────
+# When the guide overflows the description and is posted as a comment, a link to
+# that comment must be inserted back into the PR description. Covers both
+# platforms, comment-ID retrieval, numeric validation, and single-final-write.
+
+echo ""
+echo "Test 16: Guide-comment back-link (comment-overflow path)"
+
+if grep_both "back-link" || grep_both "back link"; then
+  pass "documents a guide-comment back-link"
+else
+  fail "must document inserting a back-link to the guide comment"
+fi
+
+# Back-link only in the comment-overflow case.
+if grep_both "overflow" || grep_both "too long" || grep_both "comment-overflow"; then
+  pass "back-link is scoped to the comment-overflow case"
+else
+  fail "must scope the back-link to the comment-overflow case"
+fi
+
+# GitHub shorthand back-link (exact illustrative form).
+if grep_both_f "[Illustrated Guide](#issuecomment-"; then
+  pass "GitHub shorthand back-link: [Illustrated Guide](#issuecomment-<ID>)"
+else
+  fail "must show the GitHub shorthand [Illustrated Guide](#issuecomment-<ID>)"
+fi
+
+# GitHub full-form comment URL.
+if grep_both "github.com" && grep_both_f "#issuecomment-"; then
+  pass "GitHub full-form comment URL uses #issuecomment-<ID>"
+else
+  fail "must document the GitHub #issuecomment-<ID> comment URL"
+fi
+
+# ADO back-link URL with threadId.
+if grep_both "dev.azure.com" && grep_both_f "_a=overview&threadId="; then
+  pass "ADO back-link uses ?_a=overview&threadId=<ID>"
+else
+  fail "must document the ADO ?_a=overview&threadId=<ID> back-link"
+fi
+
+# Comment-ID retrieval from the CLI response (GitHub URL parse; ADO thread id).
+if grep_both "gh pr comment" && (grep_both "parse" || grep_both "trailing"); then
+  pass "retrieves the GitHub comment ID by parsing the CLI response URL"
+else
+  fail "must retrieve the GitHub comment ID from the 'gh pr comment' response"
+fi
+
+if (grep_both "thread" && grep_both "id") && grep_both "threadId"; then
+  pass "reuses the ADO thread id as threadId"
+else
+  fail "must reuse the ADO PR-thread id as the threadId"
+fi
+
+# Numeric validation of the ID before interpolation (injection guard).
+if grep_both_f "^[0-9]+$" || grep_both "numeric"; then
+  pass "validates the comment/thread ID as numeric before use"
+else
+  fail "must validate the comment/thread ID against ^[0-9]+\$"
+fi
+
+# Single final description write (avoid double updates with the clarity pass).
+if grep_both "single final write" || (grep_both "single" && grep_both "write") \
+  || (grep_both "one" && grep_both "write"); then
+  pass "combines clarity rewrite + back-link into a single final write"
+else
+  fail "must combine the clarity rewrite and back-link into one final write"
+fi
+
+# ─── Test 17: Mermaid on Azure DevOps (R3) ──────────────────────────────────
+# ADO does not natively render mermaid in PR descriptions/comments. Document the
+# image fallback (mmdc CLI or mermaid.ink) and the embed-as-image instruction,
+# with a third-party privacy note. Lives in reference.md.
+
+echo ""
+echo "Test 17: Mermaid on Azure DevOps (image fallback)"
+
+if grep -qiF "Mermaid on Azure DevOps" "$REFERENCE_FILE"; then
+  pass "reference.md has a labeled 'Mermaid on Azure DevOps' section"
+else
+  fail "reference.md must include a 'Mermaid on Azure DevOps' section"
+fi
+
+# ADO has no native mermaid rendering in PR description/comment.
+if grep_both "no native" || grep_both "does not render" || grep_both "not.*natively"; then
+  pass "states ADO does not natively render mermaid in PR descriptions/comments"
+else
+  fail "must state ADO has no native mermaid rendering in PR descriptions/comments"
+fi
+
+# Note about checking for recent/native support.
+if grep_both "release notes" || grep_both "recent" || grep_both "later" || grep_both "re-check"; then
+  pass "notes checking for recent/native ADO mermaid support"
+else
+  fail "must note checking whether ADO added native support recently"
+fi
+
+# Fallback option a: local mermaid CLI (mmdc).
+if grep_both "mmdc"; then
+  pass "documents the local 'mmdc' (mermaid CLI) fallback"
+else
+  fail "must document the mmdc (mermaid CLI) fallback to SVG/PNG"
+fi
+
+# Fallback option b: mermaid.ink hosted renderer with base64 payload.
+if grep_both "mermaid.ink" && grep_both "base64"; then
+  pass "documents the mermaid.ink/<base64-encoded-diagram> fallback"
+else
+  fail "must document the mermaid.ink/img/<base64-encoded-diagram> fallback"
+fi
+
+# Embed as an image (![ ... ]) instead of a ```mermaid fence on ADO.
+if grep_both_f "![" && (grep_both "instead of" || grep_both "rewrite") && grep_both "fence"; then
+  pass "embeds an image instead of a mermaid fence on ADO"
+else
+  fail "must embed an image (![](url)) instead of a mermaid fence on ADO"
+fi
+
+# Third-party privacy note for mermaid.ink.
+if grep_both "third-party" && (grep_both "privacy" || grep_both "sensitive" || grep_both "internal"); then
+  pass "warns mermaid.ink sends diagrams to a third party (privacy note)"
+else
+  fail "must include a privacy note that mermaid.ink is a third-party service"
+fi
+
+# GitHub keeps native mermaid fences (no conversion there).
+if grep_both "GitHub" && grep_both "native" && grep_both "fence"; then
+  pass "GitHub retains native mermaid fences (conversion is ADO-only)"
+else
+  fail "must state GitHub keeps native mermaid fences (ADO-only conversion)"
+fi
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 
 echo ""

--- a/amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh
+++ b/amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh
@@ -383,17 +383,17 @@ else
   fail "must print the absolute path of the generated file"
 fi
 
-# Offer (not force) to post as description or comment.
-if grep_both "offer" && (grep_both "comment" && grep_both "description"); then
-  pass "offers to post as PR description or comment"
+# Attach to PR description or comment.
+if (grep_both "attach" || grep_both "append") && (grep_both "comment" && grep_both "description"); then
+  pass "attaches the guide to the PR description or comment"
 else
-  fail "must offer to post the content as a PR description or comment"
+  fail "must attach the guide to a PR description or comment"
 fi
 
-if grep_both "confirm" || grep_both "opt-in" || grep_both "no-op"; then
-  pass "publishing is confirmation-gated (default no-op)"
+if grep_both "automatic" && (grep_both "attach" || grep_both "append"); then
+  pass "publishing is automatic (description-first, comment-fallback)"
 else
-  fail "publishing must be confirmation-gated, default no-op"
+  fail "publishing must be automatic"
 fi
 
 # Never auto-commit the generated doc.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.11.1",
+  "version": "0.11.30",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Three enhancements to the `pr-guide` skill:

### 1. PR Description Clarity Pass
After generating the guide, the skill also reviews and rewrites the existing PR description to be clear and free of jargon — preserving meaning, improving readability for unfamiliar reviewers.

### 2. Guide-Comment Link in Description
When the guide is too long for the PR description and must be posted as a comment, the skill inserts a link back to the guide comment in the description (e.g. `See the [Illustrated Guide](#issuecomment-NNNN) for a detailed walkthrough.`). Supports both GitHub (`#issuecomment-ID`) and Azure DevOps (`?_a=overview&threadId=ID`) link formats.

### 3. Mermaid Diagrams on Azure DevOps

Example ADO reference showing the rendering issue: https://dev.azure.com/acs-mdash/acs-mdash/_git/hyenas/pullrequest/529

## Tests

```
Results: 87 passed, 0 failed
```

(+25 new tests covering the three new features)

Closes #823