### PR TITLE
fix: restore green CI — sync package.json to workspace version 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.11.30",
+  "version": "0.11.1",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Problem

`main` is currently **red**: the CI `Test` job (`cargo test --workspace --locked`) fails on the `version_contract` suite.

```
test package_json_version_matches_root_workspace_version ... FAILED
assertion `left == right` failed: package.json version must match [workspace.package].version
  left: "0.11.30"
 right: "0.11.1"
```
(failing run on `fb385203`: https://github.com/rysweet/amplihack-rs/actions/runs/28215553687)

## Root cause

A merge-skew between two changes that landed close together:

1. `fcde31d0` ("restore green CI — revert spurious version bump") reverted `[workspace.package].version` **0.11.30 → 0.11.1** on `main`.
2. `fb385203` (squash-merge of #824) carried `package.json` **0.11.30** onto `main` — the value that was correct against the *old* workspace version (0.11.30) but not the reverted one.

Net result on `main`: `package.json` = `0.11.30` while `[workspace.package].version` = `0.11.1` → contract violation.

## Fix

Align `package.json` to the settled source-of-truth version `0.11.1` (one line). No functional change.

## Verification

`tests/integration/version_contract_test.rs:70` asserts `package.json` version equals `[workspace.package].version`. After this change both are `0.11.1`:

```
package.json version        = 0.11.1
[workspace.package] version = 0.11.1   → MATCH
```

The Rust workspace already compiles on CI (the `fb385203` Test job reached the assertion), so this one-line value change restores the `Test` check to green.

## Scope

Focused: `package.json` only (1 line). No unrelated edits.