### PR TITLE
fix(workflow): propagate local tracking issue references end-to-end (#815, #804)

### DIFF
--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -373,12 +373,12 @@ steps:
   - id: "step-03b-extract-issue-number"
     type: "bash"
     command: |
-      # Extract issue number — handles GitHub, AzDO, and local tracking.
+      # Extract issue number — GitHub/AzDO numeric; local tracking propagates its ref, never coercing to a number, but fails loud on malformed metadata (#815, #804).
       ISSUE_CREATION="$ISSUE_CREATION"; TASK_DESC_RAW="$TASK_DESCRIPTION"
       EXTRACTED=""
       LOCAL_TRACKING_RE='(^|[[:space:]])(tracking_reference|tracking_issue)=(local-[a-zA-Z0-9._:-]+|local-tracking:[a-zA-Z0-9._:-]+)($|[[:space:]])'
       LOCAL_MARKER_RE='(^|[[:space:]])(tracking_system=local|issue_creation=local-tracking|(tracking_reference|tracking_issue)=local[^[:space:]]*)($|[[:space:]])'
-      if [[ "$ISSUE_CREATION" =~ $LOCAL_TRACKING_RE ]]; then printf ''; exit 0; elif [[ "$ISSUE_CREATION" =~ $LOCAL_MARKER_RE ]]; then echo "ERROR: local tracking metadata missing valid local reference." >&2; exit 1; fi
+      if [[ "$ISSUE_CREATION" =~ $LOCAL_TRACKING_RE ]]; then printf '%s' "${BASH_REMATCH[3]}"; exit 0; elif [[ "$ISSUE_CREATION" =~ $LOCAL_MARKER_RE ]]; then echo "ERROR: local tracking metadata missing valid local reference." >&2; exit 1; fi
       if [[ "$ISSUE_CREATION" =~ issues/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ pull/([0-9]+) ]]; then PR_NUMBER="${BASH_REMATCH[1]}"
         command -v gh >/dev/null 2>&1 && EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo '')

--- a/amplifier-bundle/recipes/workflow-terminal-state.yaml
+++ b/amplifier-bundle/recipes/workflow-terminal-state.yaml
@@ -331,12 +331,19 @@ steps:
         command -v gh >/dev/null 2>&1 || fail_terminal_state "FAILED_INVALID_INPUT" "gh is required when pr_number or pr_url is provided"
         [ -x "$PR_SCOPE_HELPER" ] || fail_terminal_state "FAILED_INVALID_INPUT" "workflow_pr_scope.sh is required for scoped current-work PR identity"
         created_after="${WORKFLOW_STARTED_AT:-${RECIPE_STARTED_AT:-${TASK_STARTED_AT:-}}}"
+        # issue_number can carry a non-numeric local tracking reference (e.g.
+        # local-5d904cff4398) when the workflow fell back to local tracking
+        # (#815, #804). PR-scope matching only understands numeric GitHub issue /
+        # AzDO work-item ids, so coerce a non-numeric ref to empty: a local ref
+        # must never filter out the legitimate current-work PR.
+        scoped_issue_id="${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
+        case "$scoped_issue_id" in ''|*[!0-9]*) scoped_issue_id="" ;; esac
         scope_args=(
           --repo "$repo_identity"
           --head "$BRANCH_INPUT"
           --base "$(normalize_base_name "$base_ref")"
-          --issue "${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
-          --work-item "${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
+          --issue "$scoped_issue_id"
+          --work-item "$scoped_issue_id"
           --head-sha "$local_head"
         )
         title_prefix="${EXPECTED_PR_TITLE_PREFIX:-${PR_EXPECTED_TITLE_PREFIX:-}}"

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -216,12 +216,18 @@ validate_final_pr_scope() {
     return 1
   }
   created_after="${WORKFLOW_STARTED_AT:-${RECIPE_STARTED_AT:-${TASK_STARTED_AT:-}}}"
+  scoped_issue_id="${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
+  # issue_number can carry a non-numeric local tracking reference (e.g.
+  # local-5d904cff4398) when the workflow fell back to local tracking (#815,
+  # #804). PR-scope matching only understands numeric ids, so coerce a
+  # non-numeric ref to empty: a local ref must not filter out the current-work PR.
+  case "$scoped_issue_id" in ''|*[!0-9]*) scoped_issue_id="" ;; esac
   scope_args=(
     --repo "$repo_identity"
     --head "$current_branch"
     --base "$expected_base"
-    --issue "${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
-    --work-item "${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
+    --issue "$scoped_issue_id"
+    --work-item "$scoped_issue_id"
     --head-sha "$local_head"
   )
   title_prefix="${EXPECTED_PR_TITLE_PREFIX:-${PR_EXPECTED_TITLE_PREFIX:-}}"

--- a/amplifier-bundle/tools/workflow_pr_ready.sh
+++ b/amplifier-bundle/tools/workflow_pr_ready.sh
@@ -175,12 +175,18 @@ if [[ "$PR_NUMBER" =~ [^[:space:]] ]] && ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; 
   exit 1
 fi
 
+scoped_issue_id="${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
+# issue_number can carry a non-numeric local tracking reference (e.g.
+# local-5d904cff4398) when the workflow fell back to local tracking (#815,
+# #804). PR-scope matching only understands numeric ids, so coerce a
+# non-numeric ref to empty: a local ref must not filter out the current-work PR.
+case "$scoped_issue_id" in ''|*[!0-9]*) scoped_issue_id="" ;; esac
 scope_args=(
   --repo "$repo_identity"
   --head "$current_branch"
   --base "$expected_base"
-  --issue "${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
-  --work-item "${ISSUE_NUMBER:-${RECIPE_VAR_issue_number:-}}"
+  --issue "$scoped_issue_id"
+  --work-item "$scoped_issue_id"
   --head-sha "$local_head"
 )
 title_prefix="${EXPECTED_PR_TITLE_PREFIX:-${PR_EXPECTED_TITLE_PREFIX:-}}"

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -349,6 +349,19 @@ path = "../../tests/integration/issue_746_default_workflow_guidance_test.rs"
 name = "issue_684_host_aware_workflow"
 path = "../../tests/integration/issue_684_host_aware_workflow_test.rs"
 
+# Issues #815/#804: default-workflow local tracking issue-number extraction.
+# step-03b must accept hash-based `local-<hash>` references (propagate them),
+# never surface a bare number for a local fallback, and never abort the workflow.
+[[test]]
+name = "issue_815_804_local_tracking_extract"
+path = "../../tests/integration/issue_815_804_local_tracking_extract_test.rs"
+
+# Issues #815/#804: downstream PR-scope consumers (pr_ready, final_status) must
+# coerce a non-numeric local tracking issue_number to empty before scope matching.
+[[test]]
+name = "issue_815_804_local_tracking_scope_args"
+path = "../../tests/integration/issue_815_804_local_tracking_scope_args_test.rs"
+
 # Issue #778: merge-ready must be platform-neutral, with explicit GitHub and
 # Azure DevOps/AzDO guidance for every merge-readiness aspect.
 [[test]]

--- a/docs/recipes/issue-815-804-local-tracking-issue-number.md
+++ b/docs/recipes/issue-815-804-local-tracking-issue-number.md
@@ -1,0 +1,88 @@
+# Local Tracking Issue-Number Extraction (Issues #815, #804)
+
+`default-workflow` no longer hard-fails — and no longer silently drops the
+tracking reference — when the workflow falls back to **local tracking** and
+produces a hash-based reference such as `local-5d904cff4398` instead of a
+numeric GitHub issue or Azure DevOps work-item id.
+
+---
+
+## Problem
+
+When issue creation is unavailable (no GitHub/AzDO access, permissions, offline
+runs), `workflow-prep` `step-03-create-issue` falls back to local tracking and
+emits metadata like:
+
+```text
+tracking_system=local
+tracking_reference=local-5d904cff4398
+tracking_issue=local-5d904cff4398
+issue_creation=local-tracking
+```
+
+`step-03b-extract-issue-number` then tried to extract a **numeric** issue
+number from this output. Because the local reference is non-numeric, the step
+aborted the whole workflow *after* classification, analysis, and ambiguity
+resolution had already completed:
+
+```text
+ERROR: step-03b failed to extract issue number from issue_creation output.
+    tracking_system=local
+    tracking_reference=local-5d904cff4398
+    issue_creation=local-tracking
+```
+
+This was deterministic for local-tracking mode and defeated the purpose of the
+enforced default workflow.
+
+## Solution
+
+### 1. `step-03b-extract-issue-number` propagates the local reference
+
+The step now branches on local-tracking metadata and **propagates the
+well-formed local reference verbatim** (`local-<hash>`, `local-issue-<n>`,
+legacy `local-tracking:<n>`) as the `issue_number` output, instead of dropping
+it to an empty string. It still:
+
+- extracts real **numeric** ids for GitHub issues/PRs and AzDO work items,
+- **never surfaces a bare embedded number** for a local fallback (e.g.
+  `local-issue-763` yields `local-issue-763`, never `763`, so it can never
+  become a `Closes #763` against an unrelated issue), and
+- **fails closed** (with credential sanitization) for genuinely unparseable
+  output and for malformed local metadata that carries markers but no usable
+  reference.
+
+This satisfies issue #815's preferred fix: *"emit the local tracking id as a
+valid tracking identifier without numeric parsing."*
+
+### 2. Terminal-state PR scoping ignores non-numeric ids
+
+Because `issue_number` can now legitimately carry a non-numeric local
+reference, `workflow-terminal-state` coerces a non-numeric value to empty
+before passing `--issue` / `--work-item` to `workflow_pr_scope.sh`. PR-scope
+matching only understands numeric GitHub issue / AzDO work-item ids, so a local
+reference must never filter out the legitimate current-work PR (which would
+otherwise surface as `no_scoped_pr`).
+
+## Behavior summary
+
+| `issue_creation` payload                                   | `issue_number` output |
+| ---------------------------------------------------------- | --------------------- |
+| `tracking_reference=local-5d904cff4398` (local fallback)   | `local-5d904cff4398`  |
+| `tracking_reference=local-issue-763` + `issue_number=763`  | `local-issue-763`     |
+| `tracking_reference=local-tracking:123` (legacy)           | `local-tracking:123`  |
+| `https://github.com/org/repo/issues/901`                   | `901`                 |
+| `https://dev.azure.com/org/proj/_workitems/edit/4242`      | `4242`                |
+| local markers present, no valid reference                  | fails closed (exit 1) |
+| unparseable, non-local output                              | fails closed (exit 1) |
+
+## Verification
+
+- `tests/integration/issue_815_804_local_tracking_extract_test.rs` and the
+  local-tracking cases in `issue_684_host_aware_workflow_test.rs` and
+  `default_workflow_decomposition_test.rs` execute the **shipped** recipe bash
+  body for every row above.
+- `tests/integration/default_workflow_terminal_state.rs` proves a local
+  tracking `issue_number` does not filter out the current-work PR.
+- `tests/gadugi/scenarios/issue-815-804-local-tracking-extract.yaml` exercises
+  the same extraction end-to-end via `gadugi-test run`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
           - Tutorial: tutorials/pr-recovery-readiness.md
           - Reference: reference/pr-recovery-readiness.md
       - Terminal-State Provider Safety: reference/workflow-terminal-state-provider-safety.md
+      - Local Tracking Issue-Number Extraction: recipes/issue-815-804-local-tracking-issue-number.md
   - Agents:
       - Overview: claude/agents/README.md
       - Core Agents:

--- a/tests/gadugi/run-step-03b-scenario.sh
+++ b/tests/gadugi/run-step-03b-scenario.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Self-asserting gadugi-test scenario body for issues #815 / #804.
+#
+# Drives the SHIPPED step-03b-extract-issue-number recipe logic (via
+# run-step-03b.sh) through the regression cases and exits non-zero if any
+# case regresses. Designed to be launched by the gadugi `execute` action with
+# no arguments, then checked with `validate_exit_code`.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN="$SCRIPT_DIR/run-step-03b.sh"
+fail=0
+
+check_eq() { # <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    echo "PASS: $1 => '$3'"
+  else
+    echo "FAIL: $1 => expected '$2', got '$3'"
+    fail=1
+  fi
+}
+
+# 1. Exact #815/#804 shape: hash-based local reference is propagated verbatim.
+out="$("$RUN" $'tracking_system=local\ntracking_reference=local-5d904cff4398\ntracking_issue=local-5d904cff4398\nissue_creation=local-tracking\n' 'update PR !598 guide')"
+rc=$?
+check_eq "hash local ref accepted+propagated" "local-5d904cff4398" "$out"
+check_eq "hash local ref does not abort (exit 0)" "0" "$rc"
+
+# 2. A local fallback must NOT surface a bare embedded number.
+out="$("$RUN" $'tracking_system=local\ntracking_reference=local-issue-763\ntracking_issue=local-issue-763\nissue_creation=local-tracking\nissue_number=763\n' 'local fallback')"
+check_eq "local fallback propagates reference, not bare number" "local-issue-763" "$out"
+
+# 3. Real GitHub issue numbers still extract numerically.
+out="$("$RUN" "https://github.com/example-org/example-repo/issues/901" 'gh follow-up')"
+check_eq "github issue still numeric" "901" "$out"
+
+# 4. Malformed local metadata (no reference) must fail closed.
+if "$RUN" $'tracking_system=local\nissue_creation=local-tracking\nissue_number=763\n' 'no usable reference' >/dev/null 2>&1; then
+  echo "FAIL: malformed local metadata must fail closed but succeeded"
+  fail=1
+else
+  echo "PASS: malformed local metadata fails closed"
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "ALL_CASES_PASSED"
+  exit 0
+fi
+echo "SCENARIO_FAILED"
+exit 1

--- a/tests/gadugi/run-step-03b.sh
+++ b/tests/gadugi/run-step-03b.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Self-locating harness that runs the SHIPPED `step-03b-extract-issue-number`
+# bash body from amplifier-bundle/recipes/workflow-prep.yaml against a given
+# issue_creation payload. Used by the gadugi-test scenario for issues
+# #815/#804 so the scenario exercises the real recipe logic (not a copy).
+#
+# Usage: run-step-03b.sh <issue_creation> [task_description]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECIPE="$SCRIPT_DIR/../../amplifier-bundle/recipes/workflow-prep.yaml"
+[ -f "$RECIPE" ] || { echo "ERROR: recipe not found: $RECIPE" >&2; exit 2; }
+
+ISSUE_CREATION_INPUT="${1:?usage: run-step-03b.sh <issue_creation> [task_description]}"
+TASK_DESCRIPTION_INPUT="${2:-}"
+
+# Extract the step-03b command body verbatim from the YAML.
+STEP_BODY="$(
+  RECIPE_PATH="$RECIPE" python3 - <<'PY'
+import os, yaml
+with open(os.environ["RECIPE_PATH"]) as fh:
+    recipe = yaml.safe_load(fh)
+for step in recipe["steps"]:
+    if step.get("id") == "step-03b-extract-issue-number":
+        print(step["command"], end="")
+        break
+else:
+    raise SystemExit("step-03b-extract-issue-number not found")
+PY
+)"
+
+ISSUE_CREATION="$ISSUE_CREATION_INPUT" TASK_DESCRIPTION="$TASK_DESCRIPTION_INPUT" \
+  bash -c "$STEP_BODY"

--- a/tests/gadugi/scenarios/issue-815-804-local-tracking-extract.yaml
+++ b/tests/gadugi/scenarios/issue-815-804-local-tracking-extract.yaml
@@ -1,0 +1,43 @@
+name: issue-815-804-local-tracking-extract
+description: >
+  Regression scenario for amplihack issues #815 and #804. When default-workflow
+  falls back to local tracking, step-03b-extract-issue-number must accept the
+  hash-based local reference (local-<hash>), propagate it verbatim, never
+  surface a bare embedded number, still extract real numeric GitHub issues, and
+  fail closed on malformed local metadata. Exercises the SHIPPED recipe bash via
+  tests/gadugi/run-step-03b-scenario.sh.
+version: "1.0"
+config:
+  timeout: 60000
+environment:
+  requires: []
+agents:
+  - name: cli-agent
+    type: cli
+    config: {}
+metadata:
+  tags: [cli, regression, workflow-prep]
+  priority: high
+steps:
+  - name: run-step-03b-regression-cases
+    agent: cli-agent
+    action: execute
+    params:
+      command: tests/gadugi/run-step-03b-scenario.sh
+    timeout: 30000
+  - name: all-regression-cases-pass
+    agent: cli-agent
+    action: validate_exit_code
+    params:
+      expected: 0
+  - name: propagates-local-tracking-reference
+    agent: cli-agent
+    action: validate_output
+    params:
+      expected: "local-5d904cff4398"
+assertions:
+  - name: all-cases-passed
+    type: output_contains
+    params:
+      target: stdout
+      expected: ALL_CASES_PASSED

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -1013,24 +1013,31 @@ fn workflow_prep_step_03b_handles_azdo_work_item_urls() {
 }
 
 #[test]
-fn workflow_prep_step_03b_local_tracking_succeeds_without_numeric_issue_number() {
+fn workflow_prep_step_03b_local_tracking_propagates_reference_without_coercing_to_number() {
+    // #815/#804: well-formed local tracking has no real GitHub/AzDO issue, so
+    // step-03b must propagate the non-numeric local reference (never the bare
+    // embedded number, which could become a `Closes #123` for an unrelated
+    // issue) and never abort the workflow.
     let cases = [
         (
             "local tracking system",
             "tracking_system=local\ntracking_reference=local-123\ntracking_issue=local-123\nissue_creation=local-tracking\n",
+            "local-123",
         ),
         (
             "local-* reference",
             "tracking_reference=local-123\ntracking_issue=local-123\nissue_creation=local-tracking\n",
+            "local-123",
         ),
         (
             "legacy local-tracking reference",
             "tracking_reference=local-tracking:123\ntracking_issue=local-tracking:123\n",
+            "local-tracking:123",
         ),
     ];
 
     let runner = Step03bRunner::new();
-    for (name, issue_creation) in cases {
+    for (name, issue_creation, expected) in cases {
         let run = runner.run_extract_issue_number(issue_creation, "");
         assert!(
             run.status.success(),
@@ -1038,8 +1045,12 @@ fn workflow_prep_step_03b_local_tracking_succeeds_without_numeric_issue_number()
             run.stderr
         );
         assert_eq!(
-            run.stdout, "",
-            "{name} must leave issue_number empty instead of coercing local IDs to numbers"
+            run.stdout, expected,
+            "{name} must propagate the local tracking reference verbatim"
+        );
+        assert_ne!(
+            run.stdout, "123",
+            "{name} must not coerce a local ID to the bare embedded number"
         );
     }
 }

--- a/tests/integration/default_workflow_terminal_state.rs
+++ b/tests/integration/default_workflow_terminal_state.rs
@@ -252,6 +252,17 @@ fn run_terminal_state(
     pr_url: Option<&str>,
     fake_path: &Path,
 ) -> TerminalRun {
+    run_terminal_state_with_issue(repo_path, worktree_path, branch_name, pr_url, fake_path, "")
+}
+
+fn run_terminal_state_with_issue(
+    repo_path: &Path,
+    worktree_path: Option<&Path>,
+    branch_name: &str,
+    pr_url: Option<&str>,
+    fake_path: &Path,
+    issue_number: &str,
+) -> TerminalRun {
     let command = step_commands(&load_recipe("workflow-terminal-state"));
     let old_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{old_path}", fake_path.display());
@@ -264,6 +275,7 @@ fn run_terminal_state(
         .env("BASE_REF", "main")
         .env("PR_NUMBER", "")
         .env("PR_URL", pr_url.unwrap_or(""))
+        .env("RECIPE_VAR_issue_number", issue_number)
         .env(
             "WORKFLOW_PR_SCOPE_HELPER",
             workspace_helper_path("workflow_pr_scope.sh"),
@@ -785,6 +797,41 @@ fn terminal_state_rejects_stale_pr_head_sha() {
     assert!(
         run.stderr.contains("no_scoped_pr"),
         "stderr should explain stale PR metadata: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn terminal_state_scopes_current_work_pr_despite_local_tracking_issue_number() {
+    // #815/#804: when the workflow falls back to local tracking, issue_number
+    // carries a non-numeric reference (e.g. local-5d904cff4398). PR-scope
+    // matching only understands numeric issue/work-item ids, so the local ref
+    // must be coerced away rather than filtering out the legitimate
+    // current-work PR (which would surface as `no_scoped_pr`).
+    let fixture = setup_repo();
+    let worktree = create_feature_worktree(&fixture);
+    commit_feature_change(&worktree);
+    let fake_tmp = TempDir::new().expect("fake gh tempdir");
+    let fake_path = fake_gh(&fake_tmp, &matching_pr_json(&worktree, "OPEN", ""), 0);
+
+    let run = run_terminal_state_with_issue(
+        &fixture.repo,
+        Some(&worktree),
+        "feature",
+        Some("https://github.com/owner/repo/pull/7"),
+        &fake_path,
+        "local-5d904cff4398",
+    );
+
+    assert!(
+        !run.stderr.contains("no_scoped_pr"),
+        "local tracking issue_number must not filter out the current-work PR; stderr:\n{}\njson: {}",
+        run.stderr,
+        run.json
+    );
+    assert_ne!(
+        run.json["terminal_state"], "FAILED_INVALID_INPUT",
+        "local tracking issue_number must not cause a scoped-PR input failure; stderr:\n{}",
         run.stderr
     );
 }

--- a/tests/integration/issue_684_host_aware_workflow_test.rs
+++ b/tests/integration/issue_684_host_aware_workflow_test.rs
@@ -1187,7 +1187,12 @@ fn step_03b_has_local_tracking_metadata_extraction_contract() {
 }
 
 #[test]
-fn step_03b_skips_issue_number_for_local_tracking_metadata() {
+fn step_03b_propagates_local_reference_for_local_tracking_metadata() {
+    // #815/#804: a local fallback has no real GitHub/AzDO issue, so step-03b
+    // must NOT surface the derived bare number (763) — that could later become
+    // a `Closes #763` reference closing an unrelated issue. It must instead
+    // propagate the non-numeric local tracking reference and never abort, so
+    // the workflow proceeds past prep and stays traceable.
     let output = run_step_03b(
         "tracking_system=local\ntracking_reference=local-issue-763\ntracking_issue=local-issue-763\nissue_creation=local-tracking\nissue_number=763\n",
         "Create tracking for local fallback",
@@ -1201,8 +1206,13 @@ fn step_03b_skips_issue_number_for_local_tracking_metadata() {
     );
     assert_eq!(
         stdout.trim(),
-        "",
-        "step-03b must leave issue_number empty for local tracking metadata"
+        "local-issue-763",
+        "step-03b must propagate the non-numeric local tracking reference"
+    );
+    assert_ne!(
+        stdout.trim(),
+        "763",
+        "step-03b must not surface the bare derived number for local tracking"
     );
 }
 

--- a/tests/integration/issue_815_804_local_tracking_extract_test.rs
+++ b/tests/integration/issue_815_804_local_tracking_extract_test.rs
@@ -1,0 +1,209 @@
+//! Regression tests for issues #815 and #804 — default-workflow local tracking
+//! issue-number extraction.
+//!
+//! ## Problem
+//!
+//! When `step-03-create-issue` falls back to local tracking it emits a
+//! hash-based reference (`local-<hash>`, e.g. `local-5d904cff4398`) instead of
+//! a numeric GitHub issue number. `step-03b-extract-issue-number` previously
+//! dropped that reference to an empty issue_number (or, in earlier revisions,
+//! hard-failed), losing traceability — and on malformed metadata it aborted the
+//! workflow after classification/analysis had already succeeded.
+//!
+//! ## Contract verified here
+//!
+//! `step-03b-extract-issue-number` must:
+//!   * propagate a well-formed local tracking reference (`local-<hash>`,
+//!     `local-issue-<n>`, legacy `local-tracking:<n>`) verbatim downstream,
+//!   * never surface the bare embedded number for a local fallback (a derived
+//!     number must not become a `Closes #N` closing an unrelated issue),
+//!   * still extract real numeric issue/work-item numbers for GitHub/AzDO, and
+//!   * still fail closed (with sanitization) for genuinely unparseable output
+//!     and for malformed local metadata that carries markers but no reference.
+//!
+//! The tests execute the real bash body extracted from the recipe YAML — they
+//! do not re-implement the logic — so they stay coupled to the shipped recipe.
+
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+use serde_yaml::Value;
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // bins/amplihack -> bins
+    p.pop(); // bins -> workspace root
+    p
+}
+
+/// Extract the bash `command:` body of `step-03b-extract-issue-number` from the
+/// shipped `workflow-prep.yaml` recipe.
+fn step_03b_body() -> String {
+    let path = workspace_root().join("amplifier-bundle/recipes/workflow-prep.yaml");
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let recipe: Value =
+        serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    let steps = recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("workflow-prep.yaml must have a top-level 'steps' sequence");
+    for step in steps {
+        if step.get("id").and_then(Value::as_str) == Some("step-03b-extract-issue-number") {
+            return step
+                .get("command")
+                .and_then(Value::as_str)
+                .expect("step-03b-extract-issue-number must define a 'command' body")
+                .to_owned();
+        }
+    }
+    panic!("step-03b-extract-issue-number not found in workflow-prep.yaml");
+}
+
+fn run_step_03b(issue_creation: &str, task_description: &str) -> Output {
+    Command::new("bash")
+        .arg("-c")
+        .arg(step_03b_body())
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("ISSUE_CREATION", issue_creation)
+        .env("TASK_DESCRIPTION", task_description)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run step-03b-extract-issue-number")
+}
+
+fn stdout_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+/// The exact failing shape reported in issues #815 and #804: hash-based local
+/// metadata with no numeric issue number anywhere.
+#[test]
+fn hash_based_local_reference_is_accepted_and_propagated() {
+    let out = run_step_03b(
+        "tracking_system=local\ntracking_reference=local-5d904cff4398\ntracking_issue=local-5d904cff4398\nissue_creation=local-tracking\n",
+        "update PR !598 guide and start stacked XPIA implementation workstreams",
+    );
+    assert!(
+        out.status.success(),
+        "step-03b must not abort on a hash-based local reference; stderr:\n{}",
+        stderr_of(&out)
+    );
+    assert_eq!(
+        stdout_of(&out),
+        "local-5d904cff4398",
+        "step-03b must propagate the hash-based local tracking reference downstream"
+    );
+}
+
+/// `local-issue-763` carries `issue_number=763`, but a local fallback must NOT
+/// surface the bare `763` (it could become a `Closes #763` closing an unrelated
+/// issue). It must propagate the non-numeric reference instead.
+#[test]
+fn local_tracking_never_surfaces_bare_number() {
+    let out = run_step_03b(
+        "tracking_system=local\ntracking_reference=local-issue-763\ntracking_issue=local-issue-763\nissue_creation=local-tracking\nissue_number=763\n",
+        "Create tracking for local fallback",
+    );
+    assert!(out.status.success(), "stderr:\n{}", stderr_of(&out));
+    assert_eq!(stdout_of(&out), "local-issue-763");
+    assert_ne!(
+        stdout_of(&out),
+        "763",
+        "local tracking must not surface a bare numeric issue id"
+    );
+}
+
+/// Legacy `local-tracking:<n>` references must be propagated verbatim too.
+#[test]
+fn legacy_local_tracking_colon_reference_is_propagated() {
+    let out = run_step_03b(
+        "tracking_reference=local-tracking:123\ntracking_issue=local-tracking:123\n",
+        "legacy local tracking shape",
+    );
+    assert!(out.status.success(), "stderr:\n{}", stderr_of(&out));
+    assert_eq!(stdout_of(&out), "local-tracking:123");
+}
+
+/// Regression guard: real GitHub issue numbers must still extract numerically.
+#[test]
+fn numeric_github_issue_number_still_extracts() {
+    let out = run_step_03b(
+        "https://github.com/example-org/example-repo/issues/901",
+        "GitHub follow-up",
+    );
+    assert!(out.status.success(), "stderr:\n{}", stderr_of(&out));
+    assert_eq!(
+        stdout_of(&out),
+        "901",
+        "real GitHub issue numbers must still extract numerically"
+    );
+}
+
+/// Regression guard: real AzDO work-item numbers must still extract numerically.
+#[test]
+fn azdo_work_item_number_still_extracts() {
+    let out = run_step_03b(
+        "https://dev.azure.com/org/proj/_workitems/edit/4242",
+        "AzDO follow-up",
+    );
+    assert!(out.status.success(), "stderr:\n{}", stderr_of(&out));
+    assert_eq!(stdout_of(&out), "4242");
+}
+
+/// Malformed local metadata (markers present, no valid `local-*` reference) must
+/// keep failing loud rather than fabricating an issue number — the local-ref
+/// acceptance must not weaken this deliberate fail-closed guard.
+#[test]
+fn malformed_local_metadata_without_reference_fails_closed() {
+    let out = run_step_03b(
+        "tracking_system=local\nissue_creation=local-tracking\nissue_number=763\n",
+        "Fallback with no usable reference",
+    );
+    assert!(
+        !out.status.success(),
+        "malformed local metadata must fail closed; stdout:\n{}",
+        stdout_of(&out)
+    );
+    assert_eq!(
+        stdout_of(&out),
+        "",
+        "malformed local metadata must not emit a fabricated issue number"
+    );
+    assert!(
+        stderr_of(&out).contains("local tracking metadata missing valid local reference"),
+        "fail-closed diagnostic must be preserved; stderr:\n{}",
+        stderr_of(&out)
+    );
+}
+
+/// Genuinely unparseable, non-local output must still fail closed and sanitize
+/// any credential-bearing text.
+#[test]
+fn unparseable_non_local_output_still_fails_closed() {
+    let out = run_step_03b(
+        "GraphQL: rate limit exceeded for https://token:ghp_secret123@github.com/example-org/example-repo",
+        "Create tracking with no usable reference",
+    );
+    assert!(
+        !out.status.success(),
+        "non-local unparseable output must still fail closed; stdout:\n{}",
+        stdout_of(&out)
+    );
+    let stderr = stderr_of(&out);
+    assert!(
+        stderr.contains("ERROR: step-03b failed to extract issue number"),
+        "hard-fail must keep its diagnostic; stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("ghp_secret123"),
+        "credential-bearing issue_creation output must be sanitized; stderr:\n{stderr}"
+    );
+}

--- a/tests/integration/issue_815_804_local_tracking_scope_args_test.rs
+++ b/tests/integration/issue_815_804_local_tracking_scope_args_test.rs
@@ -1,0 +1,237 @@
+//! Regression tests for issues #815 / #804 — downstream PR-scope consumers must
+//! coerce a non-numeric local tracking `issue_number` (e.g. `local-5d904cff4398`)
+//! to an empty `--issue` / `--work-item` before calling `workflow_pr_scope.sh`.
+//!
+//! `step-03b-extract-issue-number` now propagates a local tracking reference as
+//! `issue_number`. PR-scope matching only understands numeric GitHub issue /
+//! AzDO work-item ids, so every consumer that forwards `issue_number` to
+//! `workflow_pr_scope.sh` must drop a non-numeric ref — otherwise the jq filter
+//! rejects the legitimate current-work PR (`no_scoped_pr`). This locks that
+//! contract for `workflow_pr_ready.sh` and `workflow_final_status.sh` (the
+//! `workflow-terminal-state` consumer is covered in
+//! `default_workflow_terminal_state.rs`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // bins/amplihack -> bins
+    p.pop(); // bins -> workspace root
+    p
+}
+
+fn helper_path(name: &str) -> PathBuf {
+    workspace_root().join("amplifier-bundle/tools").join(name)
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .status()
+        .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+    assert!(status.success(), "git {args:?} failed");
+}
+
+/// Minimal GitHub-remote repo on a `feature` branch with an `origin/main` base.
+fn setup_repo(tmp: &Path) -> PathBuf {
+    let repo = tmp.join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "user.name", "Workflow Test"]);
+    fs::write(repo.join("README.md"), "base\n").expect("write readme");
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "base"]);
+    git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ],
+    );
+    git(&repo, &["update-ref", "refs/remotes/origin/main", "main"]);
+    git(&repo, &["switch", "-c", "feature"]);
+    fs::write(repo.join("feature.txt"), "feature\n").expect("write feature");
+    git(&repo, &["add", "feature.txt"]);
+    git(&repo, &["commit", "-m", "feature"]);
+    repo
+}
+
+/// A stub `workflow_pr_scope.sh` that records every argument it receives (one
+/// `[arg]` per line) and then fails closed with `no_scoped_pr`.
+fn recorder_scope_helper(tmp: &Path, log: &Path) -> PathBuf {
+    let stub = tmp.join("scope-recorder.sh");
+    fs::write(
+        &stub,
+        format!(
+            "#!/usr/bin/env bash\nfor a in \"$@\"; do printf '[%s]\\n' \"$a\" >> {log:?}; done\nprintf '{{\"ok\":false,\"reason\":\"no_scoped_pr\"}}\\n'\nexit 1\n",
+            log = log.display().to_string()
+        ),
+    )
+    .expect("write stub");
+    make_executable(&stub);
+    stub
+}
+
+/// A no-op `gh` so `command -v gh` succeeds where the consumer requires it.
+fn stub_gh(bin_dir: &Path) {
+    fs::create_dir_all(bin_dir).expect("create bin dir");
+    let gh = bin_dir.join("gh");
+    fs::write(&gh, "#!/usr/bin/env bash\nexit 0\n").expect("write gh");
+    make_executable(&gh);
+}
+
+/// Returns the argument value immediately following `--<flag>` in the recorded
+/// `[arg]`-per-line log.
+fn arg_value(log: &str, flag: &str) -> String {
+    let lines: Vec<&str> = log.lines().collect();
+    let needle = format!("[{flag}]");
+    let idx = lines
+        .iter()
+        .position(|l| *l == needle)
+        .unwrap_or_else(|| panic!("flag {flag} not recorded; log:\n{log}"));
+    let raw = lines
+        .get(idx + 1)
+        .unwrap_or_else(|| panic!("no value after {flag}; log:\n{log}"));
+    raw.trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_string()
+}
+
+fn run_pr_ready(repo: &Path, bin_dir: &Path, stub: &Path, issue_env: &[(&str, &str)]) {
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let mut cmd = Command::new("bash");
+    cmd.arg(helper_path("workflow_pr_ready.sh"))
+        .current_dir(repo)
+        .env("PATH", format!("{}:{old_path}", bin_dir.display()))
+        .env("WORKFLOW_PR_SCOPE_HELPER", stub);
+    for (k, v) in issue_env {
+        cmd.env(k, v);
+    }
+    let _ = cmd.output().expect("run workflow_pr_ready.sh");
+}
+
+fn run_final_status(repo: &Path, bin_dir: &Path, stub: &Path, issue_env: &[(&str, &str)]) {
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let mut cmd = Command::new("bash");
+    cmd.arg(helper_path("workflow_final_status.sh"))
+        .current_dir(repo)
+        .env("PATH", format!("{}:{old_path}", bin_dir.display()))
+        .env("WORKFLOW_PR_SCOPE_HELPER", stub)
+        .env("REMOTE_HOST_TYPE", "github")
+        .env("PR_URL", "https://github.com/owner/repo/pull/7")
+        .env("TASK_DESCRIPTION", "test task");
+    for (k, v) in issue_env {
+        cmd.env(k, v);
+    }
+    let _ = cmd.output().expect("run workflow_final_status.sh");
+}
+
+#[test]
+fn pr_ready_coerces_local_tracking_issue_number_to_empty() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = setup_repo(tmp.path());
+    let bin_dir = tmp.path().join("bin");
+    stub_gh(&bin_dir);
+    let log = tmp.path().join("scope-args.log");
+    let stub = recorder_scope_helper(tmp.path(), &log);
+
+    run_pr_ready(
+        &repo,
+        &bin_dir,
+        &stub,
+        &[("RECIPE_VAR_issue_number", "local-5d904cff4398")],
+    );
+
+    let recorded = fs::read_to_string(&log).expect("read scope args log");
+    assert_eq!(
+        arg_value(&recorded, "--issue"),
+        "",
+        "pr_ready must pass an empty --issue for a local tracking reference; log:\n{recorded}"
+    );
+    assert_eq!(
+        arg_value(&recorded, "--work-item"),
+        "",
+        "pr_ready must pass an empty --work-item for a local tracking reference; log:\n{recorded}"
+    );
+}
+
+#[test]
+fn pr_ready_preserves_numeric_issue_number() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = setup_repo(tmp.path());
+    let bin_dir = tmp.path().join("bin");
+    stub_gh(&bin_dir);
+    let log = tmp.path().join("scope-args.log");
+    let stub = recorder_scope_helper(tmp.path(), &log);
+
+    run_pr_ready(&repo, &bin_dir, &stub, &[("ISSUE_NUMBER", "763")]);
+
+    let recorded = fs::read_to_string(&log).expect("read scope args log");
+    assert_eq!(
+        arg_value(&recorded, "--issue"),
+        "763",
+        "pr_ready must preserve a real numeric issue number; log:\n{recorded}"
+    );
+}
+
+#[test]
+fn final_status_coerces_local_tracking_issue_number_to_empty() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = setup_repo(tmp.path());
+    let bin_dir = tmp.path().join("bin");
+    stub_gh(&bin_dir);
+    let log = tmp.path().join("scope-args.log");
+    let stub = recorder_scope_helper(tmp.path(), &log);
+
+    run_final_status(
+        &repo,
+        &bin_dir,
+        &stub,
+        &[("RECIPE_VAR_issue_number", "local-5d904cff4398")],
+    );
+
+    let recorded = fs::read_to_string(&log).expect("read scope args log");
+    assert_eq!(
+        arg_value(&recorded, "--issue"),
+        "",
+        "final_status must pass an empty --issue for a local tracking reference; log:\n{recorded}"
+    );
+    assert_eq!(
+        arg_value(&recorded, "--work-item"),
+        "",
+        "final_status must pass an empty --work-item for a local tracking reference; log:\n{recorded}"
+    );
+}
+
+#[test]
+fn final_status_preserves_numeric_issue_number() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = setup_repo(tmp.path());
+    let bin_dir = tmp.path().join("bin");
+    stub_gh(&bin_dir);
+    let log = tmp.path().join("scope-args.log");
+    let stub = recorder_scope_helper(tmp.path(), &log);
+
+    run_final_status(&repo, &bin_dir, &stub, &[("ISSUE_NUMBER", "763")]);
+
+    let recorded = fs::read_to_string(&log).expect("read scope args log");
+    assert_eq!(
+        arg_value(&recorded, "--issue"),
+        "763",
+        "final_status must preserve a real numeric issue number; log:\n{recorded}"
+    );
+}


### PR DESCRIPTION
## Summary

`default-workflow` fails / loses traceability when it falls back to **local
tracking** and emits a hash-based reference (e.g. `local-5d904cff4398`) instead
of a numeric issue id. `step-03b-extract-issue-number` previously dropped that
reference to an empty `issue_number` (and, in older revisions, hard-failed —
aborting the workflow *after* classification/analysis had already completed).

This change teaches `step-03b` to **propagate** a well-formed local reference
verbatim (`local-<hash>`, `local-issue-<n>`, legacy `local-tracking:<n>`) as
`issue_number`, satisfying issue #815's preferred fix ("emit the local tracking
id as a valid tracking identifier without numeric parsing"), while still:

- extracting real **numeric** GitHub issue/PR and AzDO work-item ids,
- **never** surfacing a bare embedded number for a local fallback (so it can
  never become a `Closes #N` against an unrelated issue), and
- **failing closed** (with credential sanitization) for unparseable output and
  for malformed local metadata that carries markers but no usable reference.

Because `issue_number` can now legitimately be non-numeric, the **three**
consumers that forward it into `workflow_pr_scope.sh` —
`workflow-terminal-state`, `workflow_pr_ready.sh`, and
`workflow_final_status.sh` — coerce a non-numeric id to empty before PR-scope
matching. The scope matcher treats an empty id as "match-any" but a non-empty
non-numeric id as a non-match, so without this coercion a local reference would
filter out the legitimate current-work PR (`no_scoped_pr`).
(`workflow_publish_pr.sh` has a pre-existing `^[0-9]+$` hard-gate that already
rejected empty *and* non-numeric ids; unchanged here and out of scope.)

Closes #815
Closes #804

## Criterion 1 — qa-team scenarios (gadugi-test)

A `gadugi-test` scenario exercises the **shipped** recipe extraction end-to-end
(`tests/gadugi/scenarios/issue-815-804-local-tracking-extract.yaml`, driven by
the self-asserting `tests/gadugi/run-step-03b-scenario.sh`, which runs the real
step-03b bash extracted from `workflow-prep.yaml`):

```
$ gadugi-test validate -f tests/gadugi/scenarios/issue-815-804-local-tracking-extract.yaml
✓ Scenario "issue-815-804-local-tracking-extract" is valid

$ gadugi-test run -d tests/gadugi/scenarios -s issue-815-804-local-tracking-extract
✓ Passed: 1   ✗ Failed: 0   - Total: 1
```

## Criterion 2 — Docs

- New: `docs/recipes/issue-815-804-local-tracking-issue-number.md` (problem,
  solution, behavior table, verification) — registered in `mkdocs.yml` nav.

## Criterion 3 — quality-audit (3 SEEK→VALIDATE→FIX cycles, ended clean)

- **Cycle 1** — self-audit: propagating a non-numeric `issue_number` would break
  PR-scope matching in `workflow-terminal-state`. FIX: numeric guard.
- **Cycle 2** — independent `code-review` agent found the **identical** unguarded
  expression in `workflow_pr_ready.sh` and `workflow_final_status.sh` (the latter
  hard-fails the finalize gate). VALIDATE: reproduced via the real
  `workflow_pr_scope.sh` jq filter (`--issue local-…` → 0 matches; `--issue ""`
  → 1 match). FIX: same guard + new regression tests.
- **Cycle 3** — final `code-review` pass: **CLEAN — no critical/high/medium
  correctness or security findings**; independently re-ran all suites + the
  gadugi scenario and confirmed the guard is consistent across all three
  consumers and that `publish_pr.sh`'s gate is pre-existing/out of scope.

Commit: `89e6318` (rebased onto `main`).

## Criterion 4 — CI

- `cargo fmt --all --check` ✓ and `cargo clippy -- -D warnings` ✓ (pre-commit + CI).
- `cargo test --workspace --locked` — all suites pass for the changed surface:
  `issue_815_804_local_tracking_extract` (7), `issue_815_804_local_tracking_scope_args`
  (4), `default_workflow_terminal_state` (25), `default_workflow_decomposition`
  (35), `issue_684_host_aware_workflow` (50).
- The branch is rebased onto current `main` (includes #825, which synced
  `package.json`↔workspace to `0.11.1`), so the previously pre-existing
  `version_contract` failure is resolved. CI run linked on this PR.

## Criterion 5 — evidence

This description is the evidence for criteria 1–4 and 6; the CI run is linked on
the PR checks.

## Criterion 6 — Scope (focused diff)

| File | Change |
| --- | --- |
| `amplifier-bundle/recipes/workflow-prep.yaml` | step-03b propagates the local ref (`BASH_REMATCH[3]`) instead of dropping it |
| `amplifier-bundle/recipes/workflow-terminal-state.yaml` | coerce non-numeric `issue_number` → empty before `--issue`/`--work-item` |
| `amplifier-bundle/tools/workflow_pr_ready.sh` | same numeric guard |
| `amplifier-bundle/tools/workflow_final_status.sh` | same numeric guard |
| `tests/integration/issue_815_804_local_tracking_extract_test.rs` | new — 7 cases over shipped step-03b bash |
| `tests/integration/issue_815_804_local_tracking_scope_args_test.rs` | new — pr_ready/final_status coercion |
| `tests/integration/default_workflow_terminal_state.rs` | new case + `issue_number` env plumbing |
| `tests/integration/default_workflow_decomposition_test.rs`, `issue_684_host_aware_workflow_test.rs` | updated local-tracking expectations to assert propagation |
| `bins/amplihack/Cargo.toml` | register the two new test targets |
| `tests/gadugi/**`, `docs/recipes/**`, `mkdocs.yml` | scenario + docs |

No unrelated edits.
