### PR TITLE
docs(pr-guide): correct ADO native mermaid status (Sprint 274) + edge-case hardening

### DIFF
--- a/amplifier-bundle/skills/pr-guide/SKILL.md
+++ b/amplifier-bundle/skills/pr-guide/SKILL.md
@@ -137,10 +137,11 @@ data degrades the guide gracefully instead of aborting. See `reference.md` →
 - Markdown is written to an **OS temp file** (`$TMPDIR`/`/tmp`) with `0600`
   permissions — never committed.
 - The skill **automatically attaches** the guide to the PR:
-  1. **Fits in PR description?** If the existing description + a separator +
-     the guide is under the platform's description limit (GitHub ~65,000
-     chars; ADO 4,000 chars), **append** the guide to the PR description
-     below an `---` separator.
+  1. **Fits in PR description?** If the description that will actually be
+     written (the clarity-rewritten text from the PR Description Clarity Pass,
+     otherwise the existing description) + a separator + the guide is under the
+     platform's description limit (GitHub ~65,000 chars; ADO 4,000 chars),
+     **append** the guide to the PR description below an `---` separator.
   2. **Too long for description?** Post the guide as a **PR comment** instead
      (GitHub ~65,000 char limit; ADO 150,000 char limit). ADO's 4,000-char
      description limit means the guide will almost always go to a comment

--- a/amplifier-bundle/skills/pr-guide/reference.md
+++ b/amplifier-bundle/skills/pr-guide/reference.md
@@ -357,30 +357,34 @@ Use the `mermaid-diagram-generator` skill's conventions for syntax. Prefer
 `flowchart` for architecture/flow and `sequenceDiagram` for request/response
 interactions.
 
-### Mermaid on Azure DevOps (no native PR rendering — image fallback)
+### Mermaid on Azure DevOps (native rendering with image fallback)
 
-Azure DevOps renders mermaid in **markdown file previews, the PR file-diff
-view, and Wiki pages**, but **does not render mermaid in PR descriptions or PR
-comments** — a ` ```mermaid ` fence pasted into a description or comment stays
-as literal code (confirmed against ADO Repos Sprint 246+ / Sprint 259,
-2024–2025). Re-check the current release notes when in doubt; if native
-PR-description/comment support ships later, prefer it and skip the conversion.
+Azure DevOps historically did **not** render mermaid in PR descriptions or PR
+comments — only in markdown file previews, the PR file-diff view, and Wiki pages
+(Sprint 246–259, 2024–2025). As of **Sprint 274 (May 2026)**, ADO added native
+` ```mermaid ` rendering in **PR descriptions, comments, and wikis** (rolling out
+across organizations).
 
-Because the guide is published to the PR **description/comment**, mermaid must
-be converted to an **image** on ADO. When `platform == Azure DevOps`, render
-each diagram and embed it as an image instead of a fenced code block:
+**Preferred (native).** When the target ADO organization renders mermaid
+natively (Sprint 274+), keep the native ` ```mermaid ` fence — exactly like
+GitHub, no conversion. Verify against the organization / current release notes,
+since the rollout may not have reached every tenant.
+
+**Fallback (older / not-yet-enabled tenants).** If the organization does not yet
+render mermaid natively in PR descriptions/comments, convert each diagram to an
+**image** and embed it instead of a fenced code block:
 
 | Step | What |
 | --- | --- |
 | 1 | Take the mermaid source for the diagram. |
 | 2a (preferred) | Render locally with the mermaid CLI: `mmdc -i <diagram>.mmd -o <diagram>.svg` (or `.png`), write to the temp dir (`0600`), publish via the PR attachments API (same flow as screenshots, §11), and rewrite to the attachment URL. |
-| 2b (fallback) | Use the hosted renderer: URL-safe-base64-encode the mermaid source and embed `![diagram](https://mermaid.ink/img/<base64-encoded-diagram>)`. |
+| 2b (last resort) | Use the hosted renderer: URL-safe-base64-encode the mermaid source and embed `![diagram](https://mermaid.ink/img/<base64-encoded-diagram>)`. |
 | 3 | Replace the ` ```mermaid ` fence with `![<caption>](<url>)` **in the ADO output only**. GitHub keeps native ` ```mermaid ` fences and needs no conversion. |
 
 **Privacy / security note:** `mermaid.ink` sends the diagram source to a
-**third-party** service. For internal or sensitive repositories prefer local
-`mmdc` rendering and reserve `mermaid.ink` for public diagrams. Always
-URL-encode the base64 payload and treat the resulting URL as inert data.
+**third-party** service. For internal or sensitive repositories prefer native
+ADO rendering or local `mmdc`, and reserve `mermaid.ink` for public diagrams.
+Always URL-encode the base64 payload and treat the resulting URL as inert data.
 
 ---
 
@@ -550,8 +554,11 @@ description so reviewers can find the walkthrough.
 | Azure DevOps | The PR Threads POST returns JSON containing the new thread `id`. Use that `id` as the `threadId`. |
 
 **2. Validate the ID** against `^[0-9]+$` before interpolating it into any URL
-or markdown. Abort the back-link (and keep the comment) if it does not match —
-this prevents URL/markdown/command injection from an unexpected response.
+or markdown. If it does not match, **drop only the back-link** (keep the posted
+comment) — this prevents URL/markdown/command injection from an unexpected
+response. The PR Description Clarity Pass rewrite still applies to the
+description write; only the back-link line is omitted, and the skill reports that
+the link was skipped.
 
 **3. Build the back-link:**
 
@@ -563,8 +570,12 @@ this prevents URL/markdown/command injection from an unexpected response.
 **4. Single final write.** The PR Description Clarity Pass (§10b) and this
 back-link both edit the description. Combine them: apply the clarity rewrite
 **in memory**, append the back-link line to that text, then perform **one**
-`gh pr edit --body-file` / `az repos pr update --description` write. This avoids
-two separate description updates and the noisy edit history they create.
+`gh pr edit --body-file` / `az repos pr update --description` write. Before
+writing, re-check that the final text is within the platform's description limit
+(notably ADO's hard 4,000 chars); if it would overflow, prefer the compact
+`#issuecomment-<ID>` / `threadId=<ID>` shorthand link, or omit the back-link and
+report it — never write a description that exceeds the limit. This avoids two
+separate description updates and the noisy edit history they create.
 
 Insert the back-link **only** in the comment-overflow case. When the guide fits
 in the description (decision logic step 3), it is already inline and there is no

--- a/amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh
+++ b/amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh
@@ -360,7 +360,7 @@ else
   fail "must fall back gracefully to a textual UI description"
 fi
 
-# ─── Test 10: Output — temp file, path, offer to post ───────────────────────
+# ─── Test 10: Output — temp file, path, automatic attach ────────────────────
 
 echo ""
 echo "Test 10: Output handling"
@@ -645,18 +645,19 @@ else
   fail "reference.md must include a 'Mermaid on Azure DevOps' section"
 fi
 
-# ADO has no native mermaid rendering in PR description/comment.
-if grep_both "no native" || grep_both "does not render" || grep_both "not.*natively"; then
-  pass "states ADO does not natively render mermaid in PR descriptions/comments"
+# ADO native mermaid: documents that native PR-description/comment rendering is
+# now available (Sprint 274, 2026) and is the preferred path when supported.
+if grep_both "Sprint 274" && (grep_both "native" || grep_both "natively"); then
+  pass "documents ADO native mermaid rendering (Sprint 274) as the preferred path"
 else
-  fail "must state ADO has no native mermaid rendering in PR descriptions/comments"
+  fail "must document ADO native mermaid rendering (Sprint 274+) as preferred"
 fi
 
-# Note about checking for recent/native support.
-if grep_both "release notes" || grep_both "recent" || grep_both "later" || grep_both "re-check"; then
-  pass "notes checking for recent/native ADO mermaid support"
+# Note about verifying current support against release notes (rollout may vary).
+if grep_both "release notes" || grep_both "rollout" || grep_both "verify"; then
+  pass "notes verifying current ADO support (release notes / rollout)"
 else
-  fail "must note checking whether ADO added native support recently"
+  fail "must note verifying whether the ADO org renders mermaid natively"
 fi
 
 # Fallback option a: local mermaid CLI (mmdc).


### PR DESCRIPTION
## Summary

Follow-up to #824 (merged at `b368fc37`, before this reviewed work landed). Additive correctness/hardening for the `pr-guide` skill — fully consistent with the settled **auto-attach** behavior (no opt-in / confirmation-gating language is introduced).

### 1. R3 — ADO native mermaid (factual correction)
`main`'s `reference.md` currently states Azure DevOps **"does not render mermaid in PR descriptions or comments."** That is now **factually wrong**: ADO shipped native ` ```mermaid ` rendering in PR descriptions/comments in **Sprint 274 (May 2026)** (building on the file-preview/diff support from Sprint 246–259). The stale guidance pushes an agent to needlessly convert diagrams and risk sending diagram source to the third-party `mermaid.ink` service.

This change makes **native the preferred path** (keep the fence, like GitHub) and demotes `mmdc` / `mermaid.ink` image conversion to a **fallback** for older/not-yet-enabled tenants. Verified against Microsoft Learn release notes (Sprint 274 wiki/repos updates). Test 17 now asserts the native-preferred path instead of the stale "no native rendering" claim.

### 2. SKILL.md fit-check consistency
The Output fit-check now measures the **clarity-rewritten** description (the text actually written) rather than the original, matching the fits-vs-comment decision to the write — important on ADO's hard 4,000-char description limit.

### 3. Back-link edge cases
- If the comment/thread ID fails numeric (`^[0-9]+$`) validation: drop **only** the back-link, keep the posted comment, and report the skip (the description write still happens).
- Re-check the final description against the platform limit before the back-link write; prefer the compact shorthand link or omit the link rather than overflow.

### 4. Stale comment tidy
Align a leftover Test 10 section comment with the auto-attach wording.

## Tests
```
Results: 87 passed, 0 failed
```
`bash amplifier-bundle/skills/pr-guide/tests/test_skill_structure.sh`, exit 0. No new/removed tests — Test 17 assertions retargeted to the native-preferred path.

---

## Merge-readiness evidence

**1. qa-team / gadugi-test scenarios.** A `cli`-type gadugi scenario executes the 87-assertion structural harness and gates on its exit code. `gadugi-test validate` → valid; `gadugi-test run` → `Passed: 1, Failed: 0` with harness output `Results: 87 passed, 0 failed`, command exit 0 — re-run against this exact content.

**2. Docs / changed surfaces.** `pr-guide` is an internal amplihack skill; `SKILL.md` + `reference.md` are its authoritative docs and are updated here. No external user-facing surface. Changed surfaces: `amplifier-bundle/skills/pr-guide/{SKILL.md, reference.md}`.

**3. quality-audit — 3 SEEK→VALIDATE→FIX cycles, ending clean.** These changes were produced and validated across three review cycles (code-review + security-review + rubber-duck): cycle 1 (3 LOW fixed; security clean), cycle 2 (ADO-native-mermaid discovery + edge cases), cycle 3 → **CLEAN: zero critical/high, zero medium correctness/security**. The R3 native-rendering claim was independently verified against Microsoft Learn release notes.

**4. CI.** Expected green — `version_contract` is satisfied on `main` (package.json `0.11.1` == workspace `0.11.1`, fixed in #825) and this diff touches only the pr-guide skill docs/test (no Rust/manifest changes). CI link to be confirmed on this PR.

**6. Focused diff.** `amplifier-bundle/skills/pr-guide/{SKILL.md, reference.md, tests/test_skill_structure.sh}` only. No unrelated edits.

Follow-up to #824 / #823.