### PR TITLE
feat(install): best-effort mermaid CLI (mmdc) install for pr-guide

### DIFF
--- a/amplifier-bundle/skills/pr-guide/reference.md
+++ b/amplifier-bundle/skills/pr-guide/reference.md
@@ -377,9 +377,17 @@ render mermaid natively in PR descriptions/comments, convert each diagram to an
 | Step | What |
 | --- | --- |
 | 1 | Take the mermaid source for the diagram. |
-| 2a (preferred) | Render locally with the mermaid CLI: `mmdc -i <diagram>.mmd -o <diagram>.svg` (or `.png`), write to the temp dir (`0600`), publish via the PR attachments API (same flow as screenshots, §11), and rewrite to the attachment URL. |
+| 2a (preferred) | Render locally with the mermaid CLI: `mmdc -i <diagram>.mmd -o <diagram>.svg` (or `.png`), write to the temp dir (`0600`), publish via the PR attachments API (same flow as screenshots, §11), and rewrite to the attachment URL. `amplihack install` provisions `mmdc` (npm `@mermaid-js/mermaid-cli`) on a **best-effort** basis, so it is often already on `PATH`; if absent, install it with `npm install -g @mermaid-js/mermaid-cli` or fall through to 2b. |
 | 2b (last resort) | Use the hosted renderer: URL-safe-base64-encode the mermaid source and embed `![diagram](https://mermaid.ink/img/<base64-encoded-diagram>)`. |
 | 3 | Replace the ` ```mermaid ` fence with `![<caption>](<url>)` **in the ADO output only**. GitHub keeps native ` ```mermaid ` fences and needs no conversion. |
+
+**Provisioning note:** `amplihack install` attempts a best-effort
+`npm install -g @mermaid-js/mermaid-cli` so the preferred local `mmdc` path
+(2a) is available without a manual step. The attempt is optional and never
+blocks install — when npm is unavailable, the install fails, or
+`AMPLIHACK_SKIP_MMDC` is set, `mmdc` is simply absent and this skill falls back
+to `mermaid.ink` (2b). See
+[Best-Effort Mermaid CLI Provisioning](../../../docs/features/mermaid-cli-best-effort-install.md).
 
 **Privacy / security note:** `mermaid.ink` sends the diagram source to a
 **third-party** service. For internal or sensitive repositories prefer native

--- a/crates/amplihack-cli/src/commands/install/mermaid_cli.rs
+++ b/crates/amplihack-cli/src/commands/install/mermaid_cli.rs
@@ -1,0 +1,130 @@
+//! Best-effort install of the mermaid CLI (`mmdc`, npm package
+//! `@mermaid-js/mermaid-cli`) during `amplihack install` (issue #828).
+//!
+//! The `pr-guide` skill renders mermaid diagrams to images locally for Azure
+//! DevOps (where mermaid does not render in PR descriptions/comments),
+//! preferring a local `mmdc` over the third-party `mermaid.ink` service for
+//! privacy. `mmdc` pulls in puppeteer + a headless Chromium download
+//! (hundreds of MB) and requires Node/npm, which may be absent or restricted
+//! in many environments.
+//!
+//! Per the install-completeness invariant in
+//! `amplifier-bundle/context/PHILOSOPHY.md`, `amplihack install` must fail
+//! loudly ONLY for REQUIRED components. mmdc is NOT required, so this phase is
+//! strictly best-effort: every failure path warns-and-continues, and
+//! [`ensure_mermaid_cli`] ALWAYS returns `Ok`. It must never abort the
+//! overall install.
+//!
+//! Behavior:
+//! 1. If `AMPLIHACK_SKIP_MMDC` is set (any non-empty value) → `SkippedByEnv`.
+//! 2. If `mmdc --version` succeeds (already on PATH) → `AlreadyPresent`.
+//! 3. If `npm --version` fails (npm absent) → `SkippedNoNpm` (informative,
+//!    not an error).
+//! 4. Otherwise run `npm install -g @mermaid-js/mermaid-cli`; on failure
+//!    warn-and-continue → `Failed`.
+//! 5. Re-probe `mmdc`. Present → `Installed`. Still absent (e.g. npm prefix
+//!    not on PATH) → warn-and-continue → `Failed`.
+
+use anyhow::Result;
+use std::process::{Command, Stdio};
+
+/// The scoped npm package that provides the `mmdc` binary. Hardcoded exactly;
+/// never constructed from env/config/user input (no command-injection surface).
+const MERMAID_CLI_PACKAGE: &str = "@mermaid-js/mermaid-cli";
+
+/// User-facing line shown when mmdc could not be provisioned. Shared by the
+/// `Failed` and the defense-in-depth `Err(_)` arms in `mod.rs` so the message
+/// stays in one place.
+pub(super) const FALLBACK_NOTICE: &str = "  ⚠️  mermaid CLI not installed; pr-guide will fall back to mermaid.ink for Azure DevOps diagrams";
+
+/// What [`ensure_mermaid_cli`] did. Lets the caller pretty-print a one-line
+/// user-facing status banner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Outcome {
+    /// `mmdc` was already discoverable on PATH at probe time → skipped.
+    AlreadyPresent,
+    /// `npm install -g @mermaid-js/mermaid-cli` succeeded and the re-probe
+    /// found `mmdc` on PATH.
+    Installed,
+    /// `AMPLIHACK_SKIP_MMDC` was set (any non-empty value) → opted out.
+    SkippedByEnv,
+    /// `npm` was not available → skipped with an informative message.
+    SkippedNoNpm,
+    /// `npm install` was attempted but failed (network/permission/Chromium
+    /// download), or it reported success yet `mmdc` is still not on PATH.
+    /// Best-effort: warned and continued.
+    Failed,
+}
+
+/// Probe a binary by running `<bin> --version`. Returns `true` only if the
+/// command spawned and exited successfully. Any spawn error (binary absent on
+/// PATH) or non-zero exit yields `false`. We only need the exit status, so the
+/// child's stdout/stderr are discarded via `Stdio::null()` — this both keeps
+/// the install console quiet and avoids allocating/reading capture pipes.
+fn version_probe_succeeds(bin: &str) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// Ensure the mermaid CLI (`mmdc`) is available, best-effort. Always returns
+/// `Ok` — a missing/broken mmdc must never block `amplihack install`. See the
+/// module docs for the full decision flow.
+pub(super) fn ensure_mermaid_cli() -> Result<Outcome> {
+    // (1) Opt-out: any non-empty value disables the attempt entirely, taking
+    // precedence over every probe (for minimal/offline environments).
+    let skip = std::env::var_os("AMPLIHACK_SKIP_MMDC")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    if skip {
+        return Ok(Outcome::SkippedByEnv);
+    }
+
+    // (2) Preflight: already installed? Skip without touching npm.
+    if version_probe_succeeds("mmdc") {
+        return Ok(Outcome::AlreadyPresent);
+    }
+
+    // (3) Preflight: npm available? If not, skip (not an error).
+    if !version_probe_succeeds("npm") {
+        return Ok(Outcome::SkippedNoNpm);
+    }
+
+    // (4) Install. Arg-vector form only (no shell): prevents injection. No
+    // sudo / no privilege escalation; no hard timeout (the Chromium download
+    // is legitimately slow and is bounded by npm's own network timeouts).
+    let install_result = Command::new("npm")
+        .args(["install", "-g", MERMAID_CLI_PACKAGE])
+        .status();
+
+    match install_result {
+        Ok(status) if status.success() => {
+            // (5) Re-probe: npm may have succeeded but placed mmdc in a prefix
+            // that isn't on PATH. Don't claim success unless mmdc is reachable.
+            if version_probe_succeeds("mmdc") {
+                Ok(Outcome::Installed)
+            } else {
+                tracing::warn!(
+                    "npm install -g {MERMAID_CLI_PACKAGE} reported success but mmdc is \
+                     still not on PATH (npm global prefix may not be on PATH)"
+                );
+                Ok(Outcome::Failed)
+            }
+        }
+        Ok(status) => {
+            tracing::warn!(
+                code = status.code(),
+                "npm install -g {MERMAID_CLI_PACKAGE} exited non-zero"
+            );
+            Ok(Outcome::Failed)
+        }
+        Err(err) => {
+            tracing::warn!(%err, "failed to spawn npm install -g {MERMAID_CLI_PACKAGE}");
+            Ok(Outcome::Failed)
+        }
+    }
+}

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -9,6 +9,7 @@ mod filesystem;
 mod hooks;
 pub(crate) mod interactive;
 mod manifest;
+mod mermaid_cli;
 pub(crate) mod paths;
 mod recipe_runner;
 mod settings;
@@ -475,6 +476,43 @@ fn local_install(
         Err(err) => {
             tracing::warn!(%err, "failed to stage copilot home during install");
             eprintln!("  ⚠️  Copilot home staging skipped: {err}");
+        }
+    }
+
+    // Best-effort: provision the mermaid CLI (mmdc) so the pr-guide skill can
+    // render diagrams locally for Azure DevOps instead of relying on the
+    // third-party mermaid.ink service. mmdc is OPTIONAL (it pulls in puppeteer
+    // + a headless Chromium download and needs Node/npm), so per the
+    // install-completeness invariant a failure here must warn-and-continue and
+    // never abort the install. Intentionally AFTER the version stamp + manifest
+    // so this optional step can never leave required state unwritten.
+    println!("Installing mermaid CLI for local diagram rendering...");
+    match mermaid_cli::ensure_mermaid_cli() {
+        Ok(mermaid_cli::Outcome::AlreadyPresent) => {
+            println!("  ✓ mermaid CLI (mmdc) already installed; skipping");
+        }
+        Ok(mermaid_cli::Outcome::Installed) => {
+            println!("  ✅ mermaid CLI (mmdc) installed for local diagram rendering");
+        }
+        Ok(mermaid_cli::Outcome::SkippedByEnv) => {
+            println!("  ℹ AMPLIHACK_SKIP_MMDC set; skipping mermaid CLI install");
+        }
+        Ok(mermaid_cli::Outcome::SkippedNoNpm) => {
+            println!(
+                "  ℹ npm not available; skipping mermaid CLI install \
+                 (pr-guide will fall back to mermaid.ink)"
+            );
+        }
+        Ok(mermaid_cli::Outcome::Failed) => {
+            tracing::warn!("best-effort mermaid CLI install did not complete");
+            eprintln!("{}", mermaid_cli::FALLBACK_NOTICE);
+        }
+        Err(err) => {
+            // ensure_mermaid_cli is contractually always-Ok; this arm exists
+            // for defense-in-depth so a future regression still cannot abort
+            // the install.
+            tracing::warn!(%err, "unexpected error from best-effort mermaid CLI install");
+            eprintln!("{}", mermaid_cli::FALLBACK_NOTICE);
         }
     }
 

--- a/crates/amplihack-cli/src/commands/install/tests/mermaid_cli_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/mermaid_cli_tests.rs
@@ -1,0 +1,325 @@
+//! TDD red-phase tests for issue #828:
+//! "Best-effort installation of the mermaid CLI (mmdc) during `amplihack install`".
+//!
+//! Contract under test: `install::mermaid_cli::ensure_mermaid_cli()`.
+//!
+//! The mermaid CLI (`@mermaid-js/mermaid-cli`, binary `mmdc`) lets the
+//! `pr-guide` skill render mermaid diagrams to images locally for Azure
+//! DevOps (where mermaid does not render in PR descriptions/comments),
+//! avoiding the third-party `mermaid.ink` service. It pulls in puppeteer +
+//! a headless Chromium download (hundreds of MB) and requires Node/npm, so
+//! it is an *optional / best-effort* component.
+//!
+//! Per the install-completeness invariant in
+//! `amplifier-bundle/context/PHILOSOPHY.md`, `amplihack install` must fail
+//! loudly ONLY for REQUIRED components. mmdc is NOT required, therefore a
+//! failed mmdc install must warn-and-continue — never abort the install.
+//! This is encoded as: `ensure_mermaid_cli()` ALWAYS returns `Ok`, and the
+//! `Outcome` it returns describes what happened.
+//!
+//! These are *failing* tests in the TDD red phase: they specify the contract
+//! for the upcoming `install/mermaid_cli.rs` module and are expected to fail
+//! to compile (the module does not exist yet) and then pass once the
+//! implementation lands.
+//!
+//! Expected contract:
+//!   pub(super) enum Outcome {
+//!       AlreadyPresent,   // mmdc already on PATH -> skipped
+//!       Installed,        // npm install -g succeeded and re-probe found mmdc
+//!       SkippedByEnv,     // AMPLIHACK_SKIP_MMDC set (any non-empty value)
+//!       SkippedNoNpm,     // npm absent -> skipped with an informative message
+//!       Failed,           // npm install attempted but failed / mmdc still absent
+//!   }
+//!   pub(super) fn ensure_mermaid_cli() -> anyhow::Result<Outcome>;  // always Ok
+//!
+//! All tests are hermetic: PATH is pinned to a single controlled bin
+//! directory so neither a real `npm` nor a real `mmdc` on the developer/CI
+//! host can leak in, and stubs use an absolute `/bin/sh` shebang so they
+//! exec regardless of the pinned PATH. No test performs a real network
+//! install.
+
+use super::super::mermaid_cli::{Outcome, ensure_mermaid_cli};
+use std::fs;
+use std::path::Path;
+
+// ---------------------------------------------------------------------------
+// Hermetic test scaffolding
+// ---------------------------------------------------------------------------
+
+/// Create an executable shell-script stub at `dir/name` with `body`.
+///
+/// Uses an absolute `#!/bin/sh` shebang on purpose: tests pin PATH to a
+/// single controlled directory, so a relative shebang interpreter (e.g.
+/// `#!/usr/bin/env bash`) would fail to resolve `bash` via the empty PATH.
+/// `/bin/sh` is exec'd by the kernel directly without a PATH lookup.
+fn create_script_stub(dir: &Path, name: &str, body: &str) -> std::path::PathBuf {
+    fs::create_dir_all(dir).unwrap();
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    path
+}
+
+/// An `mmdc` stub that succeeds for any args (so `mmdc --version` exits 0)
+/// — i.e. a mermaid CLI that is "already installed".
+fn stub_mmdc_present(bin_dir: &Path) {
+    create_script_stub(bin_dir, "mmdc", "#!/bin/sh\nexit 0\n");
+}
+
+/// An `npm` stub that reports a version (exit 0 for `--version`) but FAILS
+/// any `install` subcommand (exit 1). This lets us drive the failure path
+/// (`npm` present, `mmdc` missing, `npm install -g ...` fails) hermetically
+/// without touching the network.
+fn stub_npm_present_install_fails(bin_dir: &Path) {
+    create_script_stub(
+        bin_dir,
+        "npm",
+        "#!/bin/sh\nif [ \"$1\" = \"install\" ]; then\n  echo 'npm ERR! simulated failure' 1>&2\n  exit 1\nfi\nexit 0\n",
+    );
+}
+
+/// Run `f` with:
+///   * HOME pointed at a fresh tempdir,
+///   * PATH pinned to a single controlled `bin/` directory (so no real
+///     `npm`/`mmdc` on the host can leak in),
+///   * `AMPLIHACK_SKIP_MMDC` cleared (individual tests set it explicitly).
+///
+/// HOME, PATH, and `AMPLIHACK_SKIP_MMDC` are restored on exit, even on panic.
+/// Serialized via the crate-wide HOME/env lock so concurrent env-mutating
+/// tests don't race.
+fn with_mermaid_env<R>(f: impl FnOnce(&Path) -> R) -> R {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let temp = tempfile::tempdir().unwrap();
+    let previous_home = crate::test_support::set_home(temp.path());
+
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+
+    let prev_path = std::env::var_os("PATH");
+    let prev_skip = std::env::var_os("AMPLIHACK_SKIP_MMDC");
+    unsafe {
+        // Pin PATH to ONLY the controlled bin dir: any `npm`/`mmdc` the impl
+        // probes must come from a stub we placed, never the host.
+        std::env::set_var("PATH", &bin_dir);
+        std::env::remove_var("AMPLIHACK_SKIP_MMDC");
+    }
+
+    let result = f(&bin_dir);
+
+    unsafe {
+        match prev_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+        match prev_skip {
+            Some(v) => std::env::set_var("AMPLIHACK_SKIP_MMDC", v),
+            None => std::env::remove_var("AMPLIHACK_SKIP_MMDC"),
+        }
+    }
+    crate::test_support::restore_home(previous_home);
+    result
+}
+
+// ---------------------------------------------------------------------------
+// (1) Opt-out env var short-circuits everything -> SkippedByEnv
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ensure_mermaid_cli_skips_when_opt_out_env_set() {
+    // Requirement #4: an opt-out env var (AMPLIHACK_SKIP_MMDC) disables the
+    // attempt entirely for minimal/offline environments. Truthiness is "any
+    // non-empty value" (matches the recipe_runner var_os(..).map(!is_empty)
+    // convention), so a bare "1" must trigger the skip.
+    //
+    // The skip must take precedence over every other probe: even if neither
+    // mmdc nor npm is present (or both are), setting the env var yields
+    // SkippedByEnv with no install attempt.
+    with_mermaid_env(|_bin_dir| {
+        // SAFETY: env is serialized by with_mermaid_env's lock; restored below.
+        unsafe {
+            std::env::set_var("AMPLIHACK_SKIP_MMDC", "1");
+        }
+
+        let outcome = ensure_mermaid_cli()
+            .expect("issue #828: ensure_mermaid_cli must never return Err (best-effort)");
+
+        assert!(
+            matches!(outcome, Outcome::SkippedByEnv),
+            "issue #828: AMPLIHACK_SKIP_MMDC set must short-circuit to \
+             Outcome::SkippedByEnv, got {outcome:?}"
+        );
+
+        unsafe {
+            std::env::remove_var("AMPLIHACK_SKIP_MMDC");
+        }
+    });
+}
+
+#[test]
+fn ensure_mermaid_cli_opt_out_is_any_nonempty_value() {
+    // Requirement #4 (truthiness semantics): the opt-out is a presence flag,
+    // not strictly "=1". Any non-empty value disables the attempt.
+    with_mermaid_env(|_bin_dir| {
+        unsafe {
+            std::env::set_var("AMPLIHACK_SKIP_MMDC", "yes");
+        }
+
+        let outcome =
+            ensure_mermaid_cli().expect("issue #828: must never return Err (best-effort)");
+
+        assert!(
+            matches!(outcome, Outcome::SkippedByEnv),
+            "issue #828: AMPLIHACK_SKIP_MMDC=<any non-empty> must skip via \
+             Outcome::SkippedByEnv, got {outcome:?}"
+        );
+
+        unsafe {
+            std::env::remove_var("AMPLIHACK_SKIP_MMDC");
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// (2) Already-installed mmdc is detected and skipped -> AlreadyPresent
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ensure_mermaid_cli_skips_when_mmdc_already_present() {
+    // Requirement #2 (preflight): if mmdc is already installed (discoverable
+    // on PATH / responds to `mmdc --version`), skip without invoking npm.
+    //
+    // We place an `mmdc` stub on PATH but deliberately place NO `npm` stub.
+    // If the impl wrongly tried to install, it would have to find npm — and
+    // it can't here — proving the present-check short-circuited before npm.
+    with_mermaid_env(|bin_dir| {
+        stub_mmdc_present(bin_dir);
+
+        let outcome = ensure_mermaid_cli()
+            .expect("issue #828: ensure_mermaid_cli must never return Err (best-effort)");
+
+        assert!(
+            matches!(outcome, Outcome::AlreadyPresent),
+            "issue #828: an mmdc already on PATH must yield \
+             Outcome::AlreadyPresent (skip install), got {outcome:?}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// (3) Missing npm is handled gracefully -> SkippedNoNpm (no error)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ensure_mermaid_cli_skips_when_npm_absent() {
+    // Requirement #2 + #1: when npm is unavailable, skip with an informative
+    // message and DO NOT error. PATH is pinned to an empty bin dir, so
+    // neither npm nor mmdc exists.
+    with_mermaid_env(|_bin_dir| {
+        // No mmdc stub, no npm stub: both absent on the pinned PATH.
+        let outcome = ensure_mermaid_cli()
+            .expect("issue #828: a missing npm must be handled gracefully, not error");
+
+        assert!(
+            matches!(outcome, Outcome::SkippedNoNpm),
+            "issue #828: npm absent must yield Outcome::SkippedNoNpm \
+             (skip, no error), got {outcome:?}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// (4) Install failure does NOT propagate as an install error -> Failed (Ok)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ensure_mermaid_cli_install_failure_does_not_propagate() {
+    // Requirement #1 + #3 (CRITICAL): mmdc is optional. When npm is present
+    // but `npm install -g @mermaid-js/mermaid-cli` fails (network/permission/
+    // Chromium-download failures), ensure_mermaid_cli must capture the failure
+    // and return Ok(Outcome::Failed) — it must NEVER return Err, because that
+    // would propagate up and abort the overall `amplihack install`.
+    //
+    // We stub an npm that reports a version (probe sees it as present) but
+    // fails any `install` subcommand, and we never create an `mmdc`, so the
+    // post-install re-probe also fails -> Outcome::Failed.
+    with_mermaid_env(|bin_dir| {
+        stub_npm_present_install_fails(bin_dir);
+
+        let result = ensure_mermaid_cli();
+
+        assert!(
+            result.is_ok(),
+            "issue #828: a failed mmdc install must be captured and must NOT \
+             propagate as an Err (best-effort / install-completeness invariant), \
+             but got: {:?}",
+            result.err()
+        );
+
+        let outcome = result.unwrap();
+        assert!(
+            matches!(outcome, Outcome::Failed),
+            "issue #828: npm-present + install-fails + mmdc-still-absent must \
+             yield Outcome::Failed, got {outcome:?}"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// (5) Always-Ok guarantee across representative scenarios
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ensure_mermaid_cli_never_returns_err() {
+    // The best-effort contract distilled: across every probe branch
+    // (env-skip, already-present, npm-absent, install-failure),
+    // ensure_mermaid_cli must always return Ok. This is the single most
+    // important property — it is what keeps a missing/broken mmdc from ever
+    // blocking `amplihack install`.
+
+    // env-skip branch
+    with_mermaid_env(|_bin_dir| {
+        unsafe {
+            std::env::set_var("AMPLIHACK_SKIP_MMDC", "1");
+        }
+        assert!(
+            ensure_mermaid_cli().is_ok(),
+            "issue #828: env-skip branch must return Ok"
+        );
+        unsafe {
+            std::env::remove_var("AMPLIHACK_SKIP_MMDC");
+        }
+    });
+
+    // already-present branch
+    with_mermaid_env(|bin_dir| {
+        stub_mmdc_present(bin_dir);
+        assert!(
+            ensure_mermaid_cli().is_ok(),
+            "issue #828: already-present branch must return Ok"
+        );
+    });
+
+    // npm-absent branch
+    with_mermaid_env(|_bin_dir| {
+        assert!(
+            ensure_mermaid_cli().is_ok(),
+            "issue #828: npm-absent branch must return Ok"
+        );
+    });
+
+    // install-failure branch
+    with_mermaid_env(|bin_dir| {
+        stub_npm_present_install_fails(bin_dir);
+        assert!(
+            ensure_mermaid_cli().is_ok(),
+            "issue #828: install-failure branch must return Ok"
+        );
+    });
+}

--- a/crates/amplihack-cli/src/commands/install/tests/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/mod.rs
@@ -7,6 +7,7 @@ mod hook_specs;
 mod hook_staging_tests;
 mod install_flow;
 mod issue_527_tests;
+mod mermaid_cli_tests;
 mod output_regression_tests;
 mod path_conflict_tests;
 mod same_path_tests;

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -36,6 +36,10 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 - [Workflow Provider Abstraction](workflow-provider-abstraction.md) — provider-neutral tracking, change-request publication, terminal state, and stale cleanup through typed helpers and provider adapters.
 - [Provider-Aware Workflow Tracking](dual-provider-workflow.md) — compatibility entry point for the provider-neutral workflow contract.
 
+## Install Provisioning
+
+- [Best-Effort Mermaid CLI Provisioning](mermaid-cli-best-effort-install.md) — `amplihack install` provisions the Mermaid CLI (`mmdc`, npm `@mermaid-js/mermaid-cli`) on a best-effort basis so the `pr-guide` skill can render mermaid diagrams to images locally for Azure DevOps instead of relying on the third-party `mermaid.ink` service. A failed or skipped install warns and continues (never blocks install); disable entirely with `AMPLIHACK_SKIP_MMDC=1` (issue [#828](https://github.com/rysweet/amplihack-rs/issues/828)).
+
 ## GitHub Distribution
 
 - [GitHub Distribution](github-distribution.md) — publish agent bundles to GitHub repositories via the `gh` CLI, with idempotent uploads, visibility control, and tagged releases.

--- a/docs/features/mermaid-cli-best-effort-install.md
+++ b/docs/features/mermaid-cli-best-effort-install.md
@@ -1,0 +1,288 @@
+# Best-Effort Mermaid CLI Provisioning
+
+> [Home](../index.md) > [Features](README.md) > Mermaid CLI Provisioning
+
+`amplihack install` provisions the Mermaid CLI (`mmdc`, the npm package
+[`@mermaid-js/mermaid-cli`](https://www.npmjs.com/package/@mermaid-js/mermaid-cli))
+on a **best-effort** basis. When `mmdc` is available, the
+[`pr-guide`](../../amplifier-bundle/skills/pr-guide/reference.md) skill renders
+mermaid diagrams to images **locally** for Azure DevOps pull requests — where
+mermaid historically does not render inside PR descriptions/comments — instead
+of sending diagram source to the third-party `mermaid.ink` service.
+
+This component is **optional**. A failed or skipped `mmdc` install never fails
+or blocks `amplihack install`. It emits a warning and continues, in keeping
+with the [install-completeness invariant](../reference/install-completeness.md):
+`amplihack install` fails loudly only when a **required** component cannot be
+staged. `mmdc` is not required.
+
+## Why This Matters
+
+The `pr-guide` skill converts mermaid diagrams to images for Azure DevOps
+tenants that do not yet render ` ```mermaid ` fences natively in PR descriptions
+and comments. It has two rendering paths (see
+[pr-guide §9, "Mermaid on Azure DevOps"](../../amplifier-bundle/skills/pr-guide/reference.md)):
+
+| Path | Renderer | Privacy |
+|------|----------|---------|
+| **Preferred** | Local `mmdc -i diagram.mmd -o diagram.svg`, published via the PR attachments API | Diagram source never leaves the machine |
+| **Fallback** | Hosted `https://mermaid.ink/img/<base64>` | Diagram source is sent to a third-party service |
+
+Provisioning `mmdc` at install time means the preferred, privacy-preserving
+local path is available without a separate manual step. Because `mmdc` pulls in
+puppeteer and a headless Chromium download (hundreds of MB) and requires
+Node.js/npm — which may be absent or restricted in CI, containers, or hardened
+servers — the install is deliberately best-effort: it attempts the install when
+it cheaply can, and otherwise steps aside quietly so the `pr-guide` skill falls
+back to `mermaid.ink`.
+
+## Behavior
+
+The provisioning step runs near the end of `amplihack install`, **after** the
+version stamp and install manifest are written and after Copilot-home staging.
+Running last guarantees that an `mmdc` failure can never leave required install
+state unwritten.
+
+### Decision flow
+
+```
+amplihack install
+└── (after version stamp + manifest + copilot-home staging)
+    └── ensure mermaid CLI (best-effort)
+        ├── AMPLIHACK_SKIP_MMDC set (non-empty)?  ── yes ─▶ SkippedByEnv   (info, continue)
+        ├── `mmdc --version` succeeds?            ── yes ─▶ AlreadyPresent (info, continue)
+        ├── `npm --version` fails / npm absent?   ── yes ─▶ SkippedNoNpm   (info, continue)
+        ├── `npm install -g @mermaid-js/mermaid-cli`
+        │     ├── success AND re-probe finds mmdc ─────────▶ Installed     (success, continue)
+        │     └── failure OR mmdc still off PATH  ─────────▶ Failed        (warn, continue)
+        └── (always returns Ok — never aborts install)
+```
+
+### Outcomes
+
+The step resolves to exactly one outcome, each mapped to a user-facing line:
+
+| Outcome | Condition | Message | Stream |
+|---------|-----------|---------|--------|
+| `SkippedByEnv` | `AMPLIHACK_SKIP_MMDC` is set to any non-empty value | `  ℹ AMPLIHACK_SKIP_MMDC set; skipping mermaid CLI install` | stdout |
+| `AlreadyPresent` | `mmdc --version` already succeeds on `PATH` | `  ✓ mermaid CLI (mmdc) already installed; skipping` | stdout |
+| `SkippedNoNpm` | `npm --version` fails (npm not on `PATH`) | `  ℹ npm not available; skipping mermaid CLI install (pr-guide will fall back to mermaid.ink)` | stdout |
+| `Installed` | `npm install -g …` succeeded and the re-probe found `mmdc` | `Installing mermaid CLI for local diagram rendering...` then a success line | stdout |
+| `Failed` | install command failed, **or** succeeded but `mmdc` is still not discoverable on `PATH` | `mermaid CLI not installed; pr-guide will fall back to mermaid.ink for Azure DevOps diagrams` | stderr (`⚠️`) + `tracing::warn!` |
+
+In **every** case the step returns `Ok(())`. Install continues to its normal
+completion banner regardless of the outcome.
+
+### Idempotency
+
+The step is safe to re-run. On any subsequent `amplihack install`, an
+already-installed `mmdc` is detected by the `mmdc --version` probe and the step
+short-circuits to `AlreadyPresent` without contacting npm or re-downloading
+Chromium. Self-heal re-installs (triggered by a stale version stamp) and
+post-update installs therefore do not repeatedly attempt the npm install.
+
+### Non-interactive and offline environments
+
+- The step **never prompts**. It honors `AMPLIHACK_NONINTERACTIVE`
+  automatically because there is no interactive confirmation to suppress — the
+  global `npm install -g` runs the same way whether or not the flag is set.
+- For minimal, offline, or bandwidth-constrained environments, set
+  `AMPLIHACK_SKIP_MMDC=1` to disable the attempt entirely (see below). This
+  avoids even the fast `mmdc`/`npm` probes.
+- When npm is absent, the step skips cleanly with an informational line; it
+  does **not** attempt to install Node.js or npm. (Node.js auto-install is a
+  separate, launch-time mechanism for `amplihack copilot`; see
+  [Node.js Runtime Auto-Install](../concepts/node-runtime-auto-install.md).)
+
+## Configuration
+
+### `AMPLIHACK_SKIP_MMDC`
+
+**Type:** flag
+**Values:** any non-empty value disables the attempt; absence or empty string
+means the step runs.
+
+When set to any non-empty value (`1`, `true`, `yes`, etc.), `amplihack install`
+skips the Mermaid CLI provisioning step entirely — no `mmdc` probe, no `npm`
+probe, and no `npm install`. The step resolves to `SkippedByEnv` and prints one
+informational line. Use it for:
+
+- **Offline or air-gapped installs** that must not reach npm or download
+  Chromium.
+- **Minimal containers/CI** where the hundreds-of-MB puppeteer/Chromium
+  download is undesirable and the `pr-guide` `mermaid.ink` fallback (or native
+  ADO rendering) is acceptable.
+- **Deterministic test harnesses** that manage tool availability explicitly.
+
+```sh
+# Skip the best-effort mermaid CLI install entirely
+AMPLIHACK_SKIP_MMDC=1 amplihack install
+```
+
+**Truthiness:** any non-empty value triggers the skip. An empty string
+(`AMPLIHACK_SKIP_MMDC=""`) is treated as **unset** and the step runs normally.
+This matches the presence-flag convention used elsewhere in the installer (for
+example `AMPLIHACK_SKIP_AUTO_INSTALL`).
+
+## Examples
+
+### Default install on a host with npm
+
+```text
+$ amplihack install
+...
+✅ Amplihack installation completed successfully!
+...
+  ✅ Copilot home staged (~/.copilot/)
+Installing mermaid CLI for local diagram rendering...
+  ✓ mermaid CLI (mmdc) installed
+```
+
+### Install on a host without npm
+
+```text
+$ amplihack install
+...
+✅ Amplihack installation completed successfully!
+...
+  ✅ Copilot home staged (~/.copilot/)
+  ℹ npm not available; skipping mermaid CLI install (pr-guide will fall back to mermaid.ink)
+```
+
+Install still succeeds. The `pr-guide` skill will use the `mermaid.ink`
+fallback (or native ADO rendering) for Azure DevOps diagrams.
+
+### Re-running install when mmdc is already present
+
+```text
+$ amplihack install
+...
+✅ Amplihack installation completed successfully!
+...
+  ✅ Copilot home staged (~/.copilot/)
+  ✓ mermaid CLI (mmdc) already installed; skipping
+```
+
+### Install with the npm step failing (e.g. permission or network error)
+
+```text
+$ amplihack install
+...
+✅ Amplihack installation completed successfully!
+...
+  ✅ Copilot home staged (~/.copilot/)
+Installing mermaid CLI for local diagram rendering...
+  ⚠️  mermaid CLI not installed; pr-guide will fall back to mermaid.ink for Azure DevOps diagrams
+```
+
+The warning is advisory. Exit status is **success** — the optional component
+did not gate the install.
+
+### Skipping the attempt explicitly
+
+```text
+$ AMPLIHACK_SKIP_MMDC=1 amplihack install
+...
+✅ Amplihack installation completed successfully!
+...
+  ✅ Copilot home staged (~/.copilot/)
+  ℹ AMPLIHACK_SKIP_MMDC set; skipping mermaid CLI install
+```
+
+### Installing mmdc manually later
+
+If you skip the attempt or it fails, you can provision `mmdc` yourself at any
+time and the `pr-guide` skill will pick it up automatically on the next run:
+
+```sh
+npm install -g @mermaid-js/mermaid-cli
+mmdc --version   # verify it is on PATH
+```
+
+## How It Works (Implementation Notes)
+
+The step is implemented in
+`crates/amplihack-cli/src/commands/install/mermaid_cli.rs` and invoked from
+`local_install()` in `crates/amplihack-cli/src/commands/install/mod.rs`, after
+the Copilot-home staging block and before the final `Ok(())`.
+
+### `ensure_mermaid_cli() -> Result<Outcome>`
+
+Owns the entire probe → install → re-probe sequence and prints the user-facing
+status line for the resolved outcome. It **always returns `Ok`** — a failed or
+skipped install is encoded in the returned [`Outcome`](#outcome), never as an
+`Err`. The caller pretty-prints based on the outcome and logs `tracing::warn!`
+on `Failed`.
+
+| Step | Action |
+|------|--------|
+| 1 | If `AMPLIHACK_SKIP_MMDC` is non-empty → `Outcome::SkippedByEnv`. |
+| 2 | Probe `mmdc --version`. Success → `Outcome::AlreadyPresent`. |
+| 3 | Probe `npm --version`. Failure → `Outcome::SkippedNoNpm`. |
+| 4 | Run `npm install -g @mermaid-js/mermaid-cli`. On command failure → `Outcome::Failed` (warn + continue). |
+| 5 | Re-probe `mmdc --version`. Success → `Outcome::Installed`. Still absent (e.g. npm global prefix not on `PATH`) → `Outcome::Failed` (warn + continue). |
+
+### Outcome
+
+```rust
+enum Outcome {
+    AlreadyPresent, // mmdc was already discoverable on PATH
+    Installed,      // npm install -g succeeded and re-probe found mmdc
+    SkippedByEnv,   // AMPLIHACK_SKIP_MMDC was set
+    SkippedNoNpm,   // npm not available on PATH
+    Failed,         // install failed, or mmdc not on PATH after install
+}
+```
+
+### Process execution and safety
+
+- Commands are run with `std::process::Command` using the **argument-vector**
+  form (`Command::new("npm").args(["install", "-g", "@mermaid-js/mermaid-cli"])`),
+  never through a shell. This prevents command injection.
+- The package spec `@mermaid-js/mermaid-cli` is hardcoded. It is never built
+  from environment, config, or user input.
+- `AMPLIHACK_SKIP_MMDC` is read as a **presence flag only**
+  (`var_os(..).map(|v| !v.is_empty())`); its value never reaches any command.
+- No privilege escalation: the step never invokes `sudo`. Permission failures
+  resolve to `Failed` (warn-and-continue), not a retry with elevated
+  privileges.
+- No npm integrity bypass flags (no `--unsafe-perm`, no audit/integrity
+  disabling) are used.
+- The `--version` probes are fast and use the abstraction-free `Command`
+  directly. The `npm install -g` has **no hard timeout kill**, because the
+  Chromium download is legitimately slow; it is bounded by npm's own network
+  timeouts. Because the step is non-fatal, a slow or stalled download can never
+  block required install state.
+
+### PATH resolution caveat
+
+`mmdc` and `npm` are resolved via `PATH`, consistent with the installer's other
+`npm`/`cargo`/Copilot invocations. If `npm install -g` succeeds but the npm
+global-prefix `bin` directory is not on `PATH`, the re-probe will not find
+`mmdc` and the step resolves to `Failed` with the fallback warning — even though
+the binary exists off-`PATH`. This mirrors the `~/.cargo/bin` caveat in the
+recipe-runner install path. The installer does not prepend to `PATH`; add the
+npm global bin directory to your `PATH` and re-run, or invoke `mmdc` by its
+absolute path.
+
+## Testing
+
+Hermetic, no-network unit tests live in
+`crates/amplihack-cli/src/commands/install/tests/mermaid_cli_tests.rs` and are
+serialized via `home_env_lock()`. They cover:
+
+- `AMPLIHACK_SKIP_MMDC` set → `SkippedByEnv` short-circuit (no commands run).
+- npm absent (via `PATH` manipulation) → `SkippedNoNpm`, handled gracefully.
+- A stub `mmdc` on `PATH` → `AlreadyPresent` skip.
+- The function **never returns `Err`** — failure does not propagate as an
+  install error.
+
+The tests never perform a real npm install or contact the network.
+
+## See Also
+
+- [pr-guide skill — Mermaid on Azure DevOps](../../amplifier-bundle/skills/pr-guide/reference.md) — how `mmdc` and `mermaid.ink` are used at PR-creation time
+- [amplihack install / uninstall — Command Reference](../reference/install-command.md) — full install phase list and environment variables
+- [Install Completeness Verification](../reference/install-completeness.md) — required vs. optional component contract
+- [Environment Variables — Reference](../reference/environment-variables.md#amplihack_skip_mmdc) — `AMPLIHACK_SKIP_MMDC`
+- [Node.js Runtime Auto-Install](../concepts/node-runtime-auto-install.md) — separate launch-time Node.js provisioning for `amplihack copilot`

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -40,6 +40,7 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [AMPLIHACK_NO_UPDATE_CHECK](#amplihack_no_update_check)
   - [AMPLIHACK_PARITY_TEST](#amplihack_parity_test)
   - [AMPLIHACK_SKIP_AUTO_INSTALL](#amplihack_skip_auto_install)
+  - [AMPLIHACK_SKIP_MMDC](#amplihack_skip_mmdc)
   - [AMPLIHACK_TEST_FAKE_LATEST_VERSION](#amplihack_test_fake_latest_version)
   - [CI](#ci)
   - [UV_TOOL_BIN_DIR](#uv_tool_bin_dir)
@@ -970,6 +971,42 @@ Matching versions produce no output.
   the self-heal decision.
 
 See: [Self-Heal: Auto-Restage Framework Assets](../features/self-heal-asset-restage.md).
+
+---
+
+### AMPLIHACK_SKIP_MMDC
+
+**Type:** flag
+**Values:** any non-empty value (skips the attempt) — absence or empty string means the step runs
+**Used by:** `install::mermaid_cli::ensure_mermaid_cli` (during `amplihack install`)
+
+Disables the **best-effort Mermaid CLI provisioning** step in
+`amplihack install`. When set to any non-empty value, the installer does not
+probe for `mmdc`, does not probe for `npm`, and does not run
+`npm install -g @mermaid-js/mermaid-cli`. The step resolves to `SkippedByEnv`
+and prints one informational line. `amplihack install` otherwise proceeds
+normally — this step is optional and never gates a successful install.
+
+**When to set it:**
+
+- **Offline / air-gapped installs** that must not reach npm or download the
+  puppeteer/Chromium payload (hundreds of MB).
+- **Minimal containers or CI** where local mermaid rendering is unnecessary and
+  the `pr-guide` `mermaid.ink` fallback (or native Azure DevOps rendering) is
+  acceptable.
+- **Deterministic test harnesses** that manage tool availability explicitly.
+
+```sh
+# Skip the best-effort mermaid CLI install entirely
+AMPLIHACK_SKIP_MMDC=1 amplihack install
+```
+
+**Truthiness:** any non-empty value triggers the skip (`1`, `true`, `yes`,
+etc.). An empty string (`AMPLIHACK_SKIP_MMDC=""`) is treated as **unset** and
+the step runs. This matches the presence-flag convention used by
+`AMPLIHACK_SKIP_AUTO_INSTALL`.
+
+See: [Best-Effort Mermaid CLI Provisioning](../features/mermaid-cli-best-effort-install.md).
 
 ---
 

--- a/docs/reference/install-command.md
+++ b/docs/reference/install-command.md
@@ -71,10 +71,13 @@ amplihack install [--interactive]
 ├── 5. ensure_settings_json()     — backup settings.json, register hooks, set permissions
 ├── 6. verify_framework_assets()  — confirm required staged framework assets exist
 ├── 7. apply_config()             — if wizard ran, write preferences to manifest and settings
-└── 8. write_manifest()           — write amplihack-manifest.json for uninstall
+├── 8. write_manifest()           — write amplihack-manifest.json for uninstall
+└── 9. ensure_mermaid_cli()       — best-effort: provision mmdc (npm @mermaid-js/mermaid-cli); warn-and-continue on failure
 ```
 
 Phase 0 runs only when `--interactive` is passed **and** stdin is a TTY. If `--interactive` is set but no TTY is available, the wizard is skipped with a warning to stderr. Phase 7 applies wizard results (default tool, update-check preference) to the manifest and writes hooks to the selected settings.json scope.
+
+Phase 9 runs **after** the version stamp, manifest, and Copilot-home staging, so an `mmdc` failure can never leave required install state unwritten. It is **optional and best-effort**: it attempts `npm install -g @mermaid-js/mermaid-cli` only when npm is available and `mmdc` is missing, and it always continues — a failed or skipped install emits a warning/info line and never fails the install. See [Best-Effort Mermaid CLI Provisioning](../features/mermaid-cli-best-effort-install.md).
 
 ### Environment Variables
 
@@ -85,6 +88,7 @@ These variables are read during install. All are optional; the installer works w
 | `AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH` | Override the path used for `amplihack-hooks`. Useful in tests and CI. If set but the path does not exist, resolution falls through to Step 2. See [Binary Resolution](./binary-resolution.md). |
 | `AMPLIHACK_HOME` | Override `~/.amplihack` staging root (default: `$HOME/.amplihack`). |
 | `AMPLIHACK_SKIP_AUTO_INSTALL` | When set to any non-empty value, suppresses the startup-time [self-heal check](../features/self-heal-asset-restage.md) that would otherwise re-run install when `~/.amplihack/.installed-version` is missing or stale. Has no effect on an explicit `amplihack install` invocation. |
+| `AMPLIHACK_SKIP_MMDC` | When set to any non-empty value, skips the best-effort [Mermaid CLI provisioning](../features/mermaid-cli-best-effort-install.md) step (no `mmdc`/`npm` probe, no `npm install -g @mermaid-js/mermaid-cli`). The install proceeds normally; this optional step never gates a successful install. |
 
 ### Version stamp
 
@@ -110,8 +114,25 @@ Successful install prints a phase-by-phase progress summary:
 ✓ Backed up ~/.claude/settings.json → settings.json.backup.1741651200
 ✓ Registered 7 Claude Code hooks
 ✓ XPIA hooks directory found
-✓ Wrote install manifest
-amplihack installed successfully.
+   Manifest written to ~/.claude/install/amplihack-manifest.json
+✅ Amplihack installation completed successfully!
+```
+
+After the success banner, two best-effort post-install steps run (each prints
+one status line and never fails the install): Copilot-home staging and
+[Mermaid CLI provisioning](../features/mermaid-cli-best-effort-install.md). For
+example, on a host with npm and `mmdc` already present:
+
+```
+  ✅ Copilot home staged (~/.copilot/)
+  ✓ mermaid CLI (mmdc) already installed; skipping
+```
+
+When npm is unavailable the mermaid step skips with an informational line
+instead, and install still succeeds:
+
+```
+  ℹ npm not available; skipping mermaid CLI install (pr-guide will fall back to mermaid.ink)
 ```
 
 If `~/.local/bin` is not in `$PATH`, an advisory is printed (install still succeeds):
@@ -305,7 +326,13 @@ Checks whether the wizard should run (`interactive == true` and stdin is a TTY).
 
 Writes wizard results to the install manifest (`default_tool`, `update_check_preference` fields) and, for repo-local hook scope, to the repo-local `settings.json`. Located in `crates/amplihack-cli/src/commands/install/interactive.rs`.
 
+### `ensure_mermaid_cli() -> Result<Outcome>`
+
+Best-effort provisioning of the Mermaid CLI (`mmdc`, npm `@mermaid-js/mermaid-cli`). Invoked from `local_install()` after Copilot-home staging. Runs probe → optional `npm install -g @mermaid-js/mermaid-cli` → re-probe and prints one status line for the resolved `Outcome` (`AlreadyPresent`, `Installed`, `SkippedByEnv`, `SkippedNoNpm`, `Failed`). **Always returns `Ok`** — a failed or skipped install is encoded in the `Outcome` and warned via `tracing::warn!` + a stderr `⚠️` line, never propagated as an install error. Honors `AMPLIHACK_SKIP_MMDC`. Uses `std::process::Command` in argument-vector form (no shell) with a hardcoded package spec; never escalates privileges. Located in `crates/amplihack-cli/src/commands/install/mermaid_cli.rs`. See [Best-Effort Mermaid CLI Provisioning](../features/mermaid-cli-best-effort-install.md).
+
 ## See Also
+
+- [Best-Effort Mermaid CLI Provisioning](../features/mermaid-cli-best-effort-install.md) — optional `mmdc` install for local mermaid rendering in `pr-guide`
 
 - [Interactive Install](../howto/interactive-install.md) — guided setup wizard walkthrough
 - [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md) — repair stale system binaries that shadow `~/.local/bin`


### PR DESCRIPTION
## Summary

Provisions the mermaid CLI (`mmdc`, npm package `@mermaid-js/mermaid-cli`) during `amplihack install` so the **pr-guide** skill can render mermaid diagrams to images **locally** for Azure DevOps — where mermaid does not render in PR descriptions/comments — instead of relying on the third-party `mermaid.ink` service.

## Best-effort by design

`mmdc` is **not** a required component: it pulls in puppeteer + a headless Chromium download (hundreds of MB) and needs Node/npm. Per the install-completeness invariant (fail loudly only for *required* components), this step is strictly best-effort:

- `ensure_mermaid_cli()` **always returns `Ok`** — a missing/broken mmdc never aborts the install
- **Opt-out** via `AMPLIHACK_SKIP_MMDC` (any non-empty value) for minimal/offline environments
- **Preflight:** skip if `mmdc` already on PATH; skip (not an error) if npm is absent
- **Install:** `npm install -g @mermaid-js/mermaid-cli` via argv array (no shell, no injection surface; package name hardcoded)
- **Re-probe** after install; warn-and-continue on any failure (network, permissions, Chromium download)
- Wired **after** the version stamp + manifest write, so the optional step can never leave required state unwritten

## Tests

6 contract tests in `mermaid_cli_tests.rs`: opt-out env, already-present skip, npm-absent skip, install-failure-does-not-propagate, never-returns-Err. All green; `cargo clippy -- -D warnings` clean.

## Docs

- `docs/features/mermaid-cli-best-effort-install.md`
- `docs/reference/environment-variables.md` (AMPLIHACK_SKIP_MMDC)
- `docs/reference/install-command.md`
- pr-guide `reference.md` notes that install provisions mmdc best-effort

## Note

Reverted the workflow's automatic version bump (0.12.0 → 0.11.1) to keep the established tag-driven versioning convention (matches PR #821) and unblock the `--locked` pre-commit/CI checks.

Closes #828