### PR TITLE
feat(install): best-effort mermaid CLI (mmdc) provisioning (closes #828)

### DIFF
--- a/amplifier-bundle/skills/pr-guide/reference.md
+++ b/amplifier-bundle/skills/pr-guide/reference.md
@@ -386,6 +386,14 @@ render mermaid natively in PR descriptions/comments, convert each diagram to an
 ADO rendering or local `mmdc`, and reserve `mermaid.ink` for public diagrams.
 Always URL-encode the base64 payload and treat the resulting URL as inert data.
 
+**Provisioning `mmdc`.** `amplihack install` provisions the mermaid CLI
+(`mmdc`, npm package `@mermaid-js/mermaid-cli`) on a **best-effort** basis so the
+preferred local-render path (step 2a) is available out of the box. It is an
+optional component: the install detects an existing `mmdc`, skips when `npm` is
+unavailable, and never aborts the install on failure (it warns and continues,
+leaving the `mermaid.ink` fallback in place). Set `AMPLIHACK_SKIP_MMDC=1` to opt
+out in minimal or offline environments.
+
 ---
 
 ## 10. Clarity passes

--- a/crates/amplihack-cli/src/commands/install/mermaid_cli.rs
+++ b/crates/amplihack-cli/src/commands/install/mermaid_cli.rs
@@ -1,0 +1,158 @@
+//! Best-effort mermaid CLI (`mmdc`) install phase (issue #828).
+//!
+//! The pr-guide skill prefers rendering mermaid diagrams to images with the
+//! local mermaid CLI (`mmdc`, npm package `@mermaid-js/mermaid-cli`) instead of
+//! the third-party `mermaid.ink` service — see
+//! `amplifier-bundle/skills/pr-guide/reference.md`, section
+//! "Mermaid on Azure DevOps". To make that local path available out of the box,
+//! `amplihack install` provisions `mmdc` on a best-effort basis.
+//!
+//! **Optional / best-effort by design.** Unlike `recipe-runner-rs` (a REQUIRED
+//! component that bails when missing), `mmdc` is OPTIONAL: it pulls in puppeteer
+//! plus a headless Chromium download (hundreds of MB) and requires Node/npm,
+//! which may be absent or restricted in many environments. Per the
+//! install-completeness invariant in `amplifier-bundle/context/PHILOSOPHY.md`,
+//! install must fail loudly only for REQUIRED components. A failed `mmdc`
+//! install therefore emits a warning and continues — it never aborts the
+//! install. [`ensure_mermaid_cli`] consequently returns an [`Outcome`] (never a
+//! `Result`): there is no error path to propagate.
+//!
+//! Behavior:
+//! 1. Opt-out: if `AMPLIHACK_SKIP_MMDC` is set to any non-empty value, skip
+//!    entirely (minimal/offline environments).
+//! 2. Preflight: if `mmdc --version` succeeds, it is already installed — skip.
+//! 3. Preflight: if `npm --version` fails, npm is unavailable — skip with an
+//!    informative message (never an error).
+//! 4. Install: run `npm install -g @mermaid-js/mermaid-cli`, then re-probe.
+//!    Any failure (non-zero exit, spawn error, or a success that still leaves
+//!    `mmdc` off PATH) warns and continues.
+
+use std::process::{Command, Stdio};
+
+/// User-facing failure message shown when the optional `mmdc` install does not
+/// complete. pr-guide still works — it falls back to `mermaid.ink`.
+const FALLBACK_NOTICE: &str =
+    "mermaid CLI not installed; pr-guide will fall back to mermaid.ink for Azure DevOps diagrams";
+
+/// What [`ensure_mermaid_cli`] did, so callers (and tests) can reason about the
+/// branch taken without inspecting stdout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Outcome {
+    /// `AMPLIHACK_SKIP_MMDC` was set — the whole phase was skipped.
+    SkippedByEnv,
+    /// `mmdc --version` already succeeded — nothing to do.
+    AlreadyPresent,
+    /// `npm` was not available, so no install was attempted.
+    SkippedNpmAbsent,
+    /// `npm install -g @mermaid-js/mermaid-cli` succeeded and `mmdc` is now
+    /// reachable on PATH.
+    Installed,
+    /// An install attempt was made but did not leave a working `mmdc` (non-zero
+    /// exit, spawn error, or success without a PATH-reachable binary). Warned
+    /// and continued — never fatal.
+    InstallFailed,
+}
+
+/// Ensure the mermaid CLI (`mmdc`) is available, best-effort. Prints
+/// user-facing status lines and **always** returns — there is no failure path
+/// that propagates to the caller.
+pub(super) fn ensure_mermaid_cli() -> Outcome {
+    // 1. Opt-out for minimal/offline environments. Truthy if set to any
+    //    non-empty value (matches the `recipe_runner.rs` env convention; the
+    //    `=1` form in the docs is illustrative).
+    if env_opt_out() {
+        println!("  ℹ AMPLIHACK_SKIP_MMDC set; skipping mermaid CLI install");
+        return Outcome::SkippedByEnv;
+    }
+
+    // 2. Already installed? `mmdc --version` is a fast PATH probe.
+    if mermaid_cli_present() {
+        println!("  ✓ mermaid CLI (mmdc) already installed; skipping");
+        return Outcome::AlreadyPresent;
+    }
+
+    // 3. npm available? Without it there is nothing we can do — skip, do not
+    //    error.
+    if !npm_present() {
+        println!(
+            "  ℹ npm not available; skipping mermaid CLI install \
+             (pr-guide will fall back to mermaid.ink)"
+        );
+        return Outcome::SkippedNpmAbsent;
+    }
+
+    // 4. Attempt the best-effort global install. No hard timeout: the Chromium
+    //    download is legitimately slow; we rely on npm's own network timeouts.
+    println!("Installing mermaid CLI for local diagram rendering...");
+    match run_npm_install() {
+        Ok(true) => {
+            // npm reported success — re-probe in case the global-prefix binary
+            // landed off PATH (mirrors recipe_runner's ~/.cargo/bin caveat).
+            if mermaid_cli_present() {
+                println!("  ✓ mermaid CLI (mmdc) installed");
+                Outcome::Installed
+            } else {
+                warn_and_continue(
+                    "npm install -g @mermaid-js/mermaid-cli reported success but mmdc is \
+                     not reachable on PATH",
+                );
+                Outcome::InstallFailed
+            }
+        }
+        Ok(false) => {
+            warn_and_continue("npm install -g @mermaid-js/mermaid-cli exited non-zero");
+            Outcome::InstallFailed
+        }
+        Err(err) => {
+            warn_and_continue(&format!("failed to run npm install for mermaid CLI: {err}"));
+            Outcome::InstallFailed
+        }
+    }
+}
+
+/// Emit the warn-and-continue pair: a structured `tracing::warn!` carrying the
+/// specific failure detail, plus the locked user-facing fallback notice.
+fn warn_and_continue(detail: &str) {
+    tracing::warn!("{detail}");
+    eprintln!("  ⚠️  {FALLBACK_NOTICE}");
+}
+
+/// `true` when `AMPLIHACK_SKIP_MMDC` is set to any non-empty value.
+fn env_opt_out() -> bool {
+    std::env::var_os("AMPLIHACK_SKIP_MMDC")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+/// `true` when `mmdc --version` spawns and exits successfully.
+fn mermaid_cli_present() -> bool {
+    command_succeeds("mmdc", &["--version"])
+}
+
+/// `true` when `npm --version` spawns and exits successfully.
+fn npm_present() -> bool {
+    command_succeeds("npm", &["--version"])
+}
+
+/// Run `npm install -g @mermaid-js/mermaid-cli`, inheriting stdio so the user
+/// sees npm's progress. Returns `Ok(true)` on a zero exit, `Ok(false)` on a
+/// non-zero exit, and `Err` if the process could not be spawned.
+fn run_npm_install() -> std::io::Result<bool> {
+    let status = Command::new("npm")
+        .args(["install", "-g", "@mermaid-js/mermaid-cli"])
+        .status()?;
+    Ok(status.success())
+}
+
+/// Spawn `program args...` with all stdio nulled and report whether it exited
+/// successfully. A spawn error (e.g. binary not on PATH) maps to `false`.
+fn command_succeeds(program: &str, args: &[&str]) -> bool {
+    Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -9,6 +9,7 @@ mod filesystem;
 mod hooks;
 pub(crate) mod interactive;
 mod manifest;
+mod mermaid_cli;
 pub(crate) mod paths;
 mod recipe_runner;
 mod settings;
@@ -477,6 +478,14 @@ fn local_install(
             eprintln!("  ⚠️  Copilot home staging skipped: {err}");
         }
     }
+
+    // Issue #828: best-effort provisioning of the mermaid CLI (mmdc) so the
+    // pr-guide skill can render diagrams locally for Azure DevOps instead of
+    // the third-party mermaid.ink service. Optional component — it warns and
+    // continues on any failure and must never abort the install.
+    println!();
+    println!("🧜 Provisioning mermaid CLI for local diagram rendering:");
+    mermaid_cli::ensure_mermaid_cli();
 
     Ok(())
 }

--- a/crates/amplihack-cli/src/commands/install/tests/issue_828_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/issue_828_tests.rs
@@ -1,0 +1,125 @@
+//! Hermetic tests for issue #828:
+//! "Add best-effort installation of the mermaid CLI (mmdc) to `amplihack install`".
+//!
+//! The mermaid CLI provisioning is an OPTIONAL component: it must never fail or
+//! block the overall install. These tests exercise every non-network branch of
+//! [`super::super::mermaid_cli::ensure_mermaid_cli`] by manipulating PATH and
+//! the `AMPLIHACK_SKIP_MMDC` opt-out env var under the shared env lock. The
+//! real `npm install -g` path is intentionally NOT exercised (no network).
+//!
+//! Covered contracts:
+//!   * `AMPLIHACK_SKIP_MMDC` set      → skip entirely (`SkippedByEnv`).
+//!   * `mmdc` already on PATH         → skip (`AlreadyPresent`).
+//!   * `npm` absent                   → graceful skip (`SkippedNpmAbsent`).
+//!   * hostile env (both absent)      → never errors; returns an outcome.
+
+use super::super::mermaid_cli::{Outcome, ensure_mermaid_cli};
+use crate::test_support::home_env_lock;
+use std::sync::MutexGuard;
+
+/// Acquire the global env lock (shared with the other env-mutating tests in
+/// this crate) so PATH / env mutations here don't race.
+fn lock_env() -> MutexGuard<'static, ()> {
+    home_env_lock().lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Saved env values restored on drop so a test never leaks PATH / the opt-out
+/// var into a sibling test running in the same process.
+struct EnvSnapshot {
+    path: Option<std::ffi::OsString>,
+    skip: Option<std::ffi::OsString>,
+}
+
+impl EnvSnapshot {
+    fn capture() -> Self {
+        Self {
+            path: std::env::var_os("PATH"),
+            skip: std::env::var_os("AMPLIHACK_SKIP_MMDC"),
+        }
+    }
+}
+
+impl Drop for EnvSnapshot {
+    fn drop(&mut self) {
+        // SAFETY: edition 2024 requires unsafe; tests serialise via the env lock.
+        unsafe {
+            match self.path.take() {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+            match self.skip.take() {
+                Some(v) => std::env::set_var("AMPLIHACK_SKIP_MMDC", v),
+                None => std::env::remove_var("AMPLIHACK_SKIP_MMDC"),
+            }
+        }
+    }
+}
+
+/// Write an executable `mmdc` stub into `dir` that succeeds on `--version`, so
+/// the PATH probe treats mermaid as already installed without a real install.
+fn write_mmdc_stub(dir: &std::path::Path) {
+    let stub = dir.join("mmdc");
+    std::fs::write(&stub, "#!/bin/sh\necho '11.0.0'\nexit 0\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+#[test]
+fn opt_out_env_skips_entirely() {
+    let _guard = lock_env();
+    let _snap = EnvSnapshot::capture();
+    // SAFETY: serialised via env lock; restored by EnvSnapshot on drop.
+    unsafe {
+        std::env::set_var("AMPLIHACK_SKIP_MMDC", "1");
+    }
+    assert_eq!(ensure_mermaid_cli(), Outcome::SkippedByEnv);
+}
+
+#[test]
+fn already_present_mmdc_is_skipped() {
+    let _guard = lock_env();
+    let _snap = EnvSnapshot::capture();
+    let temp = tempfile::tempdir().unwrap();
+    write_mmdc_stub(temp.path());
+    // PATH has only the stub dir: `mmdc --version` resolves to the stub, and we
+    // must short-circuit before ever probing npm.
+    unsafe {
+        std::env::remove_var("AMPLIHACK_SKIP_MMDC");
+        std::env::set_var("PATH", temp.path());
+    }
+    assert_eq!(ensure_mermaid_cli(), Outcome::AlreadyPresent);
+}
+
+#[test]
+fn npm_absent_skips_without_error() {
+    let _guard = lock_env();
+    let _snap = EnvSnapshot::capture();
+    let temp = tempfile::tempdir().unwrap();
+    // Empty PATH dir: neither mmdc nor npm resolvable. Must skip gracefully and
+    // never attempt an install.
+    unsafe {
+        std::env::remove_var("AMPLIHACK_SKIP_MMDC");
+        std::env::set_var("PATH", temp.path());
+    }
+    assert_eq!(ensure_mermaid_cli(), Outcome::SkippedNpmAbsent);
+}
+
+#[test]
+fn never_propagates_error_in_hostile_env() {
+    // `ensure_mermaid_cli` returns `Outcome`, not `Result`: non-fatality is
+    // structural. This asserts it behaviorally — a hostile env yields a skip,
+    // not an install or a panic.
+    let _guard = lock_env();
+    let _snap = EnvSnapshot::capture();
+    let temp = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::remove_var("AMPLIHACK_SKIP_MMDC");
+        std::env::set_var("PATH", temp.path());
+    }
+    let outcome = ensure_mermaid_cli();
+    assert_ne!(outcome, Outcome::Installed);
+    assert_eq!(outcome, Outcome::SkippedNpmAbsent);
+}

--- a/crates/amplihack-cli/src/commands/install/tests/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/mod.rs
@@ -7,6 +7,7 @@ mod hook_specs;
 mod hook_staging_tests;
 mod install_flow;
 mod issue_527_tests;
+mod issue_828_tests;
 mod output_regression_tests;
 mod path_conflict_tests;
 mod same_path_tests;

--- a/crates/amplihack-cli/src/test_support.rs
+++ b/crates/amplihack-cli/src/test_support.rs
@@ -1,11 +1,41 @@
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Mutex, Once, OnceLock};
+
+/// Establish process-wide hermetic defaults for env-mutating tests, exactly
+/// once per test binary.
+///
+/// Issue #828 added a best-effort `npm install -g @mermaid-js/mermaid-cli`
+/// step at the end of `local_install`. Many install tests drive `local_install`
+/// / `run_install` to completion while preserving the real `PATH` (so `npm` is
+/// reachable) without a pre-existing `mmdc` — which would trigger a real,
+/// network-bound Chromium download during `cargo test`. Defaulting
+/// `AMPLIHACK_SKIP_MMDC` here makes that step a no-op for the whole suite.
+///
+/// This runs the first time any test acquires the env lock, before that test
+/// can call `local_install`. Tests that specifically exercise the mermaid CLI
+/// detection branches override `AMPLIHACK_SKIP_MMDC` themselves while holding
+/// the lock, so this default never masks those assertions. We only set the
+/// default when the var is unset, so an explicit value in the environment still
+/// wins.
+fn ensure_hermetic_env_defaults() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        if std::env::var_os("AMPLIHACK_SKIP_MMDC").is_none() {
+            // SAFETY: runs once, before any env-mutating test proceeds past
+            // `env_lock()`; concurrent env mutation is serialised by that lock.
+            unsafe {
+                std::env::set_var("AMPLIHACK_SKIP_MMDC", "1");
+            }
+        }
+    });
+}
 
 /// Single global lock for all environment-mutating tests.
 ///
 /// Both HOME and CWD mutations must serialize through one lock to prevent
 /// races. Tests that need both HOME and CWD should acquire `env_lock()` once.
 pub(crate) fn env_lock() -> &'static Mutex<()> {
+    ensure_hermetic_env_defaults();
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     ENV_LOCK.get_or_init(|| Mutex::new(()))
 }

--- a/crates/amplihack-cli/tests/bugfix_341_install_freshness.rs
+++ b/crates/amplihack-cli/tests/bugfix_341_install_freshness.rs
@@ -164,6 +164,7 @@ fn install_stages_amplifier_bundle_from_local_checkout_not_stale_source() {
     let prev_home = std::env::var_os("HOME");
     let prev_amplihack_home = std::env::var_os("AMPLIHACK_HOME");
     let prev_hooks = std::env::var_os("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH");
+    let prev_skip_mmdc = std::env::var_os("AMPLIHACK_SKIP_MMDC");
     let prev_cwd = std::env::current_dir().ok();
 
     // SAFETY: env mutation is gated by `env_lock()` above. Each integration
@@ -172,6 +173,10 @@ fn install_stages_amplifier_bundle_from_local_checkout_not_stale_source() {
         std::env::set_var("HOME", home.path());
         std::env::remove_var("AMPLIHACK_HOME");
         std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", &hooks_stub);
+        // Issue #828: keep the best-effort mermaid CLI step a no-op so this
+        // hermetic test never triggers a real `npm install -g` Chromium
+        // download.
+        std::env::set_var("AMPLIHACK_SKIP_MMDC", "1");
     }
     std::env::set_current_dir(checkout.path()).expect("chdir into checkout");
 
@@ -206,6 +211,10 @@ fn install_stages_amplifier_bundle_from_local_checkout_not_stale_source() {
         match prev_hooks {
             Some(v) => std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", v),
             None => std::env::remove_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH"),
+        }
+        match prev_skip_mmdc {
+            Some(v) => std::env::set_var("AMPLIHACK_SKIP_MMDC", v),
+            None => std::env::remove_var("AMPLIHACK_SKIP_MMDC"),
         }
     }
 

--- a/crates/amplihack-cli/tests/issue_538_install_completeness.rs
+++ b/crates/amplihack-cli/tests/issue_538_install_completeness.rs
@@ -151,6 +151,7 @@ fn amplihack_install_command_with_binary(
         .env("HOME", home)
         .env("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", hooks_bin)
         .env("RECIPE_RUNNER_RS_PATH", recipe_runner)
+        .env("AMPLIHACK_SKIP_MMDC", "1")
         .env_remove("AMPLIHACK_HOME")
         .env_remove("CLAUDECODE");
     cmd


### PR DESCRIPTION
## Summary

Adds a **best-effort, optional** step to the `amplihack install` flow that provisions the mermaid CLI (`mmdc`, npm package `@mermaid-js/mermaid-cli`). This lets the **pr-guide** skill render mermaid diagrams to images **locally** for Azure DevOps (where mermaid historically does not render in PR descriptions/comments) instead of relying on the third-party `mermaid.ink` service.

Closes #828

## Design (follows the issue's locked decisions)

- **New module** `crates/amplihack-cli/src/commands/install/mermaid_cli.rs` exposing `ensure_mermaid_cli() -> Outcome`. It returns an `Outcome`, never a `Result` — non-fatality is **structural**, there is no error path to propagate.
- **Placement**: end of `local_install`, immediately after the Copilot-home-staging best-effort block (after the version stamp + manifest write).
- **Optional / install-completeness compliant**: only REQUIRED components fail loudly. This step:
  1. Opt-out: `AMPLIHACK_SKIP_MMDC` set to any non-empty value → skip entirely (matches the `recipe_runner.rs` `var_os(..).map(|v| !v.is_empty())` convention).
  2. Preflight present: `mmdc --version` succeeds → skip.
  3. Preflight npm: `npm --version` fails → skip with an informative message (never an error).
  4. Install: `npm install -g @mermaid-js/mermaid-cli`, then re-probe; any failure (non-zero exit, spawn error, or success without a PATH-reachable binary) **warns and continues**.
- Uses `std::process::Command` directly, **no hard timeout** (the puppeteer/Chromium download is legitimately slow), per the issue's resolved decisions.
- **Locked user-facing messages** implemented verbatim (status / already-present / npm-absent / skip-env / failure-fallback).

## Merge-ready evidence

### 1. Tests (qa / scenario coverage)
Hermetic coverage of every non-network branch, following the established install-flow test convention in this crate (the same pattern used by `recipe_runner` / `issue_527_tests`, which cover install steps with Rust lib+integration tests rather than gadugi scenarios):

`crates/amplihack-cli/src/commands/install/tests/issue_828_tests.rs`:
- `opt_out_env_skips_entirely` — `AMPLIHACK_SKIP_MMDC` → `SkippedByEnv`.
- `already_present_mmdc_is_skipped` — stub `mmdc` on PATH → `AlreadyPresent`.
- `npm_absent_skips_without_error` — empty PATH → `SkippedNpmAbsent`.
- `never_propagates_error_in_hostile_env` — both binaries absent → graceful skip, no panic/error.

Run output:
```
running 4 tests
test commands::install::tests::issue_828_tests::already_present_mmdc_is_skipped ... ok
test commands::install::tests::issue_828_tests::opt_out_env_skips_entirely ... ok
test commands::install::tests::issue_828_tests::npm_absent_skips_without_error ... ok
test commands::install::tests::issue_828_tests::never_propagates_error_in_hostile_env ... ok
test result: ok. 4 passed; 0 failed
```

**Test hermeticity for the broader suite** (important correctness fix): the install integration tests drive `local_install`/`run_install` to completion while preserving the real `PATH` (so `npm` is reachable) without a pre-existing `mmdc`. Left unguarded, the new step would have triggered a real global `npm install` (Chromium download) during `cargo test`/CI. This is neutralized by:
- A one-time `AMPLIHACK_SKIP_MMDC` default in `#[cfg(test)] test_support` (covers all in-crate install unit tests).
- Explicit `AMPLIHACK_SKIP_MMDC=1` in the two integration tests that actually execute install (`bugfix_341_install_freshness`, `issue_538_install_completeness`).

Verified both run green and fast (no network):
```
bugfix_341_install_freshness ... ok (1 passed)
issue_538_install_completeness ... ok (9 passed, finished in 7.32s)
```
A full audit confirmed these are the only install-executing tests in the workspace.

### 2. Docs
`amplifier-bundle/skills/pr-guide/reference.md` (Mermaid on Azure DevOps section) now notes that `amplihack install` provisions `mmdc` best-effort and documents the `AMPLIHACK_SKIP_MMDC` opt-out.

### 3. Quality-audit (SEEK → VALIDATE → FIX)
- **Cycle 1 — side-effect safety**: identified that the new step sits inside `local_install`, which install integration tests run end-to-end with `npm` on PATH → would launch a real Chromium download in CI. **Fixed** with the test-default + integration opt-outs above; validated by running those tests.
- **Cycle 2 — security/correctness**: probes and install use fixed-arg `Command` (no shell, no interpolation) → no command injection; opt-out parsing matches repo convention; best-effort contract verified (`Outcome`, never `bail!`; `local_install` still returns `Ok`). Re-probe handles the off-PATH global-prefix case.
- **Cycle 3 — output/contract regressions**: confirmed the new output lines don't trip `install_output_contract` noise patterns (`❌`+hook / `profile_management` / `Skipping symlink`) and that `output_regression_tests` pass (part of 272 green install lib tests). Final cycle clean.

### 4. CI signal (validated locally; full matrix runs in CI)
- `cargo fmt --check` → clean.
- `cargo clippy -- -D warnings` (CI-exact) → clean, 0 warnings.
- `cargo test -p amplihack-cli --lib install` → **272 passed, 0 failed** (includes the 4 new tests).
- Install integration crates → green (see above).
- The `install-smoke` CI job runs `--version/--help/recipe list` (not `amplihack install`), so it does not exercise this step.

### 6. Scope
Focused diff — 8 files, +342/−1, entirely within the mermaid-CLI install feature (new module + wiring, tests + test hermeticity, docs). No unrelated edits. The pre-existing `clippy --all-targets` lints in `tests_execute.rs` / `issue_538:101` are untouched and out of scope (CI clippy does not run `--all-targets`).

## Out of scope (per issue)
pr-guide runtime rendering logic, uninstall-manifest tracking of `mmdc`, Node/npm installation, and non-npm install methods.
