### PR TITLE
fix(quality-audit): tolerate mixed validator output in merge-validations (#820)

### DIFF
--- a/amplifier-bundle/recipes/quality-audit-cycle.yaml
+++ b/amplifier-bundle/recipes/quality-audit-cycle.yaml
@@ -313,8 +313,12 @@ steps:
       _V1_TMPFILE=$(mktemp)
       _V2_TMPFILE=$(mktemp)
       _V3_TMPFILE=$(mktemp)
-      chmod 600 "$_V1_TMPFILE" "$_V2_TMPFILE" "$_V3_TMPFILE"
-      trap 'rm -f "$_V1_TMPFILE" "$_V2_TMPFILE" "$_V3_TMPFILE"' EXIT
+      _V1_NORMFILE=$(mktemp)
+      _V2_NORMFILE=$(mktemp)
+      _V3_NORMFILE=$(mktemp)
+      chmod 600 "$_V1_TMPFILE" "$_V2_TMPFILE" "$_V3_TMPFILE" \
+                "$_V1_NORMFILE" "$_V2_NORMFILE" "$_V3_NORMFILE"
+      trap 'rm -f "$_V1_TMPFILE" "$_V2_TMPFILE" "$_V3_TMPFILE" "$_V1_NORMFILE" "$_V2_NORMFILE" "$_V3_NORMFILE"' EXIT
       # Single-quoted heredoc delimiters prevent shell expansion.
       # Long unique delimiters mitigate delimiter-collision injection risk (#3696).
       cat > "$_V1_TMPFILE" <<'__AMPLIHACK_SAFE_HEREDOC_V1_TMPWRITE__'
@@ -327,11 +331,42 @@ steps:
       {{validation_agent_3}}
       __AMPLIHACK_SAFE_HEREDOC_V3_TMPWRITE__
 
-      export V1_FILE="$_V1_TMPFILE"
-      export V2_FILE="$_V2_TMPFILE"
-      export V3_FILE="$_V3_TMPFILE"
       export THRESHOLD="{{validation_threshold}}"
       export CYCLE="{{cycle_number}}"
+      export OUTPUT_DIR="{{output_dir}}"
+
+      # Normalize validator output before merge (#820): validators emit JSON
+      # inside markdown/prose (often a ```json fence) +/- log preamble, which
+      # crashes `jq --slurpfile` with "Bad JSON". Recover a single JSON object
+      # via the tolerant `extract-json` helper (same normalizer used by
+      # smart-orchestrator). If non-empty output yields no parseable object,
+      # warn (naming the validator + preserving raw output as an artifact) and
+      # fall back to `{}` so the merge degrades to zero votes instead of dying.
+      normalize_validator() {
+        local _raw="$1" _norm="$2" _label="$3"
+        local _norm_stripped _raw_stripped _artifact_dir _artifact
+        if ! amplihack orch helper extract-json < "$_raw" > "$_norm" 2>/dev/null; then
+          printf '{}' > "$_norm"
+        fi
+        # Empty/whitespace-only or unparseable raw output normalizes to `{}`;
+        # only warn when there WAS content to parse but no JSON object survived.
+        _norm_stripped=$(tr -d '[:space:]' < "$_norm")
+        _raw_stripped=$(tr -d '[:space:]' < "$_raw")
+        if [ "$_norm_stripped" = '{}' ] && [ -n "$_raw_stripped" ]; then
+          _artifact_dir="${OUTPUT_DIR:-/tmp}"
+          mkdir -p "$_artifact_dir" 2>/dev/null || _artifact_dir=$(dirname "$_raw")
+          _artifact="$_artifact_dir/merge-validations-${_label}-cycle${CYCLE:-0}-raw.txt"
+          if ! cp "$_raw" "$_artifact" 2>/dev/null; then _artifact="$_raw"; fi
+          echo "[merge-validations] WARNING: ${_label} produced no parseable JSON object; counting zero votes from it. Raw output preserved at: ${_artifact}" >&2
+        fi
+      }
+      normalize_validator "$_V1_TMPFILE" "$_V1_NORMFILE" "validation_agent_1"
+      normalize_validator "$_V2_TMPFILE" "$_V2_NORMFILE" "validation_agent_2"
+      normalize_validator "$_V3_TMPFILE" "$_V3_NORMFILE" "validation_agent_3"
+
+      export V1_FILE="$_V1_NORMFILE"
+      export V2_FILE="$_V2_NORMFILE"
+      export V3_FILE="$_V3_NORMFILE"
 
       jq -n \
         --slurpfile v1 "$V1_FILE" \

--- a/crates/amplihack-cli/tests/issue_646_quality_audit_cycle_bugs.rs
+++ b/crates/amplihack-cli/tests/issue_646_quality_audit_cycle_bugs.rs
@@ -384,11 +384,13 @@ fn recipe_parses_as_valid_yaml() {
 fn recipe_under_brick_line_limit() {
     let text = recipe_text();
     let lines = text.lines().count();
-    // Original is ~789 lines, net change ~+20 → ~809. Generous ceiling of 850.
+    // #646 bug fixes took the recipe to ~815 lines. #820 added a validator-output
+    // normalization layer to merge-validations (~+35 lines) → ~850. Ceiling of 880
+    // leaves modest headroom while still guarding against unbounded growth.
     assert!(
-        lines <= 850,
-        "quality-audit-cycle.yaml is {lines} lines; expected <= 850 after bug fixes \
-         (original ~789 + ~20 lines of fixes)."
+        lines <= 880,
+        "quality-audit-cycle.yaml is {lines} lines; expected <= 880 \
+         (#646 fixes + #820 merge-validations normalization)."
     );
 }
 

--- a/crates/amplihack-cli/tests/issue_820_merge_validations_mixed_output.rs
+++ b/crates/amplihack-cli/tests/issue_820_merge_validations_mixed_output.rs
@@ -1,0 +1,353 @@
+//! Tests for issue #820: `quality-audit-cycle` `merge-validations` step fails
+//! on mixed validator output.
+//!
+//! Root cause: `merge-validations` wrote each validator agent's RAW output
+//! (`{{validation_agent_N}}`) to a temp file and fed it straight to
+//! `jq -n --slurpfile`. Validators emit their JSON verdict wrapped in
+//! markdown/prose (typically a ```json fence) and sometimes with leading log
+//! preamble, so `jq` aborted the entire audit cycle with
+//! `Bad JSON ... Invalid numeric literal` before the fix/verify/summary phases
+//! could run.
+//!
+//! Fix: normalize each validator's output through the tolerant
+//! `amplihack orch helper extract-json` helper (the same normalizer
+//! smart-orchestrator uses) BEFORE `jq --slurpfile`. If a validator produced
+//! non-empty output with no parseable JSON object, emit a targeted diagnostic
+//! naming the validator + preserving its raw output as an artifact, then fall
+//! back to `{}` so the merge degrades to zero votes instead of crashing.
+//!
+//! These tests cover three layers:
+//!   1. Structural — the recipe wires `extract-json` + diagnostic in correctly.
+//!   2. Behavioral (pure Rust) — `extract_json` recovers the validator JSON
+//!      object from the exact mixed-format inputs that used to crash `jq`.
+//!   3. End-to-end (graceful skip) — the real `merge-validations` bash command
+//!      no longer emits `Bad JSON` on mixed output and produces valid merged
+//!      JSON. Skipped when the `amplihack`/`jq` tooling is unavailable.
+
+use amplihack_cli::commands::orch::extract_json;
+use serde_yaml::Value;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root")
+        .to_path_buf()
+}
+
+fn recipe_path() -> PathBuf {
+    repo_root().join("amplifier-bundle/recipes/quality-audit-cycle.yaml")
+}
+
+fn load_recipe() -> Value {
+    let path = recipe_path();
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn merge_validations_command() -> String {
+    let recipe = load_recipe();
+    let steps = recipe
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("recipe must have steps");
+    let step = steps
+        .iter()
+        .find(|s| s.get("id").and_then(Value::as_str) == Some("merge-validations"))
+        .expect("merge-validations step must exist");
+    step.get("command")
+        .and_then(Value::as_str)
+        .expect("merge-validations must have a command field")
+        .to_string()
+}
+
+// =========================================================================
+// Layer 1: Structural — the recipe must route validator output through the
+// tolerant extract-json normalizer before jq, with a diagnostic fallback.
+// =========================================================================
+
+#[test]
+fn merge_validations_normalizes_via_extract_json() {
+    let cmd = merge_validations_command();
+    assert!(
+        cmd.contains("orch helper extract-json"),
+        "#820: merge-validations must normalize each validator's raw output \
+         through `amplihack orch helper extract-json` before jq.\nCommand:\n{cmd}"
+    );
+}
+
+#[test]
+fn merge_validations_feeds_normalized_files_to_jq() {
+    let cmd = merge_validations_command();
+    // The jq --slurpfile inputs must come from the NORMALIZED files, not the
+    // raw heredoc temp files.
+    for f in ["V1_FILE", "V2_FILE", "V3_FILE"] {
+        assert!(
+            cmd.contains("--slurpfile") && cmd.contains(&format!("\"${f}\"")),
+            "#820: jq must slurp the normalized file via ${f}.\nCommand:\n{cmd}"
+        );
+    }
+    assert!(
+        cmd.contains("export V1_FILE=\"$_V1_NORMFILE\"")
+            && cmd.contains("export V2_FILE=\"$_V2_NORMFILE\"")
+            && cmd.contains("export V3_FILE=\"$_V3_NORMFILE\""),
+        "#820: V*_FILE (the jq inputs) must point at the normalized files \
+         ($_V*_NORMFILE), not the raw heredoc temp files.\nCommand:\n{cmd}"
+    );
+}
+
+#[test]
+fn merge_validations_normalization_runs_before_jq() {
+    let cmd = merge_validations_command();
+    let extract_pos = cmd
+        .find("orch helper extract-json")
+        .expect("must contain extract-json");
+    let jq_pos = cmd
+        .find("jq -n")
+        .or_else(|| cmd.find("jq "))
+        .expect("must contain jq invocation");
+    assert!(
+        extract_pos < jq_pos,
+        "#820: validator output must be normalized BEFORE jq runs.\n\
+         extract-json at {extract_pos}, jq at {jq_pos}."
+    );
+}
+
+#[test]
+fn merge_validations_emits_diagnostic_and_preserves_artifact() {
+    let cmd = merge_validations_command();
+    assert!(
+        cmd.contains("WARNING") && cmd.contains("no parseable JSON object"),
+        "#820: when a validator produced non-empty output with no parseable \
+         JSON, merge-validations must emit a targeted diagnostic instead of a \
+         brittle jq crash.\nCommand:\n{cmd}"
+    );
+    assert!(
+        cmd.contains("Raw output preserved at:"),
+        "#820: the diagnostic must preserve the offending validator's raw \
+         output as an artifact and report its path.\nCommand:\n{cmd}"
+    );
+    // The diagnostic must name which validator failed.
+    assert!(
+        cmd.contains("${_label}") || cmd.contains("$_label"),
+        "#820: the diagnostic must name the offending validator (via its \
+         label) so the failing prompt/output can be repaired.\nCommand:\n{cmd}"
+    );
+}
+
+#[test]
+fn merge_validations_trap_cleans_normalized_files() {
+    let cmd = merge_validations_command();
+    // The EXIT trap must remove the new normalized temp files too (no leaks).
+    let trap_line = cmd
+        .lines()
+        .find(|l| l.contains("trap") && l.contains("EXIT"))
+        .expect("#820: merge-validations must keep a trap ... EXIT cleanup line");
+    for f in ["_V1_NORMFILE", "_V2_NORMFILE", "_V3_NORMFILE"] {
+        assert!(
+            trap_line.contains(f),
+            "#820: EXIT trap must clean up normalized temp file ${f}.\nTrap: {trap_line}"
+        );
+    }
+}
+
+#[test]
+fn merge_validations_still_uses_slurpfile_merge() {
+    // The deterministic vote-counting merge (slurpfile) must be preserved —
+    // we normalize the inputs, we do not replace the merge logic.
+    let cmd = merge_validations_command();
+    assert!(
+        cmd.contains("--slurpfile v1") && cmd.contains("group_by"),
+        "#820: the deterministic slurpfile/group_by merge must be preserved."
+    );
+}
+
+#[test]
+fn recipe_parses_as_valid_yaml() {
+    let _ = load_recipe();
+}
+
+// =========================================================================
+// Layer 2: Behavioral (pure Rust) — the normalizer the recipe now invokes
+// must recover the validator JSON object from exactly the mixed-format
+// inputs that used to crash jq with "Bad JSON".
+// =========================================================================
+
+#[test]
+fn extract_json_recovers_validator_object_from_fenced_prose() {
+    // Real-world validator output: log preamble + prose + a ```json fence.
+    let raw = "Let me validate the findings now.\n\
+        I read src/foo.rs:42 — this is a genuine silent fallback.\n\n\
+        ```json\n\
+        {\"validator\":\"agent-1\",\"cycle\":1,\"validated\":[{\"finding_id\":1,\
+        \"verdict\":\"confirmed\",\"new_severity\":\"high\",\"reasoning\":\"swallows error\"}],\
+        \"confirmed_count\":1,\"false_positive_count\":0}\n\
+        ```";
+    let v = extract_json(raw).expect("#820: must recover the JSON object from fenced prose");
+    assert_eq!(v["validator"], "agent-1");
+    assert_eq!(v["validated"][0]["verdict"], "confirmed");
+    assert_eq!(v["validated"][0]["finding_id"], 1);
+}
+
+#[test]
+fn extract_json_recovers_plain_json_validator_object() {
+    // A validator that emits a bare JSON object (no fence) must also parse.
+    let raw = "{\"validator\":\"agent-2\",\"cycle\":1,\"validated\":[{\"finding_id\":1,\
+        \"verdict\":\"confirmed\",\"new_severity\":\"medium\"}]}";
+    let v = extract_json(raw).expect("#820: must recover a bare JSON object");
+    assert_eq!(v["validated"][0]["new_severity"], "medium");
+}
+
+#[test]
+fn extract_json_recovers_object_with_leading_log_preamble() {
+    // Mixed output: machine log lines, THEN a JSON object on its own line.
+    let raw = "2026-06-25T23:39:00Z INFO starting validation\n\
+        2026-06-25T23:39:01Z INFO read 3 findings\n\
+        {\"validator\":\"agent-3\",\"validated\":[{\"finding_id\":2,\"verdict\":\"false_positive\"}]}";
+    let v = extract_json(raw).expect("#820: must recover object after log preamble");
+    assert_eq!(v["validated"][0]["verdict"], "false_positive");
+}
+
+#[test]
+fn extract_json_returns_none_for_log_only_output() {
+    // A validator that emitted only logs / a stray brace yields no object —
+    // the recipe treats this as zero votes and warns (it must NOT crash jq).
+    let raw = "ERROR: agent timed out before producing structured output\n\
+        [trace] partial log line with a stray { brace but no closing object\n\
+        done.";
+    assert!(
+        extract_json(raw).is_none(),
+        "#820: log-only output must yield no JSON object so the recipe can \
+         degrade to zero votes with a diagnostic."
+    );
+}
+
+// =========================================================================
+// Layer 3: End-to-end (graceful skip) — run the REAL merge-validations bash
+// command against mixed validator output and assert it no longer emits
+// "Bad JSON" and produces valid merged JSON. Skips when amplihack/jq are
+// unavailable so the suite stays green in minimal environments.
+// =========================================================================
+
+fn amplihack_binary() -> Option<PathBuf> {
+    // Primary: the `amplihack` binary sits next to the test executable's parent
+    // (`<target>/<profile>/amplihack`), regardless of CARGO_TARGET_DIR. The test
+    // exe lives at `<target>/<profile>/deps/<name>`.
+    if let Ok(exe) = std::env::current_exe() {
+        // exe = <target>/<profile>/deps/<test-bin>
+        if let Some(profile_dir) = exe.parent().and_then(|deps| deps.parent()) {
+            let candidate = profile_dir.join("amplihack");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    // Fallbacks: explicit CARGO_TARGET_DIR, then the default workspace target/.
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Ok(dir) = std::env::var("CARGO_TARGET_DIR") {
+        roots.push(PathBuf::from(dir));
+    }
+    roots.push(repo_root().join("target"));
+    for root in roots {
+        for profile in ["debug", "release"] {
+            let p = root.join(profile).join("amplihack");
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+fn tool_on_path(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn merge_validations_end_to_end_handles_mixed_output() {
+    let Some(amplihack) = amplihack_binary() else {
+        eprintln!(
+            "skip: target/{{debug,release}}/amplihack not built; run `cargo build` \
+             to exercise the merge-validations end-to-end path"
+        );
+        return;
+    };
+    if !tool_on_path("jq") {
+        eprintln!("skip: `jq` not available on PATH");
+        return;
+    }
+
+    // v1: prose + ```json fence (confirmed). v2: bare JSON (confirmed).
+    // v3: log-only garbage (no JSON object → diagnostic, zero votes).
+    let v1 = "Let me validate.\n```json\n{\"validated\":[{\"finding_id\":1,\
+        \"verdict\":\"confirmed\",\"new_severity\":\"high\",\"reasoning\":\"swallows error\"}]}\n```";
+    let v2 = "{\"validated\":[{\"finding_id\":1,\"verdict\":\"confirmed\",\
+        \"new_severity\":\"medium\",\"reasoning\":\"agrees\"}]}";
+    let v3 = "ERROR: agent crashed\n[trace] stray { brace, no object\n";
+
+    let tmp = std::env::temp_dir().join(format!("qac820-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("mk tmp dir");
+
+    let cmd = merge_validations_command()
+        .replace("{{validation_agent_1}}", v1)
+        .replace("{{validation_agent_2}}", v2)
+        .replace("{{validation_agent_3}}", v3)
+        .replace("{{validation_threshold}}", "2")
+        .replace("{{cycle_number}}", "1")
+        .replace("{{output_dir}}", tmp.to_str().unwrap());
+
+    // Prepend the built amplihack dir so `amplihack orch helper extract-json`
+    // resolves to the binary under test.
+    let bin_dir = amplihack.parent().unwrap().to_path_buf();
+    let path = format!(
+        "{}:{}",
+        bin_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let out = Command::new("bash")
+        .arg("-c")
+        .arg(&cmd)
+        .env("PATH", path)
+        .output()
+        .expect("run merge-validations bash");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "#820: merge-validations must succeed on mixed validator output.\n\
+         exit: {:?}\nstderr:\n{stderr}\nstdout:\n{stdout}",
+        out.status.code()
+    );
+    assert!(
+        !stderr.contains("Bad JSON"),
+        "#820: merge-validations must NOT emit a `jq: Bad JSON` error on mixed \
+         output.\nstderr:\n{stderr}"
+    );
+    // The garbage validator must trigger the targeted diagnostic.
+    assert!(
+        stderr.contains("no parseable JSON object"),
+        "#820: the log-only validator must trigger the diagnostic.\nstderr:\n{stderr}"
+    );
+
+    let merged: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("#820: merged output must be valid JSON: {e}\nstdout:\n{stdout}")
+    });
+    // Two validators confirmed finding 1 (>= threshold 2) → confirmed.
+    assert_eq!(
+        merged["confirmed_count"], 1,
+        "#820: finding 1 must be confirmed by the two well-formed validators.\n{merged:#}"
+    );
+    assert_eq!(merged["validated"][0]["verdict"], "confirmed");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/docs/reference/quality-audit-cycle-recipe.md
+++ b/docs/reference/quality-audit-cycle-recipe.md
@@ -55,6 +55,43 @@ Cycle 3+: seek(deepest) → validate(×3) → merge → fix → verify → accum
   emerged in the current cycle.
 - **Stop** at `max_cycles` unconditionally.
 
+### merge-validations: Validator-Output Normalization (#820)
+
+The three validator agents are prompted to emit a JSON verdict object, but
+agent output is free-form text: the JSON usually arrives wrapped in a
+` ```json ` fence and may be preceded by reasoning prose or log preamble.
+Feeding that raw text straight to `jq --slurpfile` aborts the whole audit
+cycle with `jq: Bad JSON ... Invalid numeric literal`, discarding the seek and
+validation work already done (#820).
+
+Before merging, the step normalizes each validator's raw output to a single
+JSON object using the tolerant `amplihack orch helper extract-json` helper —
+the same normalizer `smart-orchestrator` uses. It recovers JSON from, in
+priority order: ` ```json ` fenced blocks, untagged ` ``` ` blocks, then a
+balanced-brace scan over raw prose (correctly handling braces inside string
+values). The normalized objects are what `jq --slurpfile` consumes.
+
+Degradation is explicit, never silent:
+
+- A validator that did not run (empty output) normalizes to `{}` and simply
+  contributes zero votes — no warning.
+- A validator that produced **non-empty** output containing **no parseable
+  JSON object** triggers a targeted diagnostic on stderr that names the
+  validator and preserves its raw output as an artifact under `output_dir`:
+
+  ```
+  [merge-validations] WARNING: validation_agent_2 produced no parseable JSON
+  object; counting zero votes from it. Raw output preserved at:
+  ./eval_results/quality_audit/merge-validations-validation_agent_2-cycle3-raw.txt
+  ```
+
+  The merge then proceeds with the remaining validators instead of crashing,
+  so a single malformed validator can no longer take down the entire cycle.
+
+The deterministic majority-vote merge (`group_by` on `finding_id`, confirm when
+`≥ validation_threshold` validators agree) is unchanged — only the inputs are
+normalized.
+
 ### verify-fixes: Git Diff Cross-Check (#646)
 
 The `verify-fixes` step performs a two-layer verification:

--- a/tests/gadugi/run-merge-validations-scenario.sh
+++ b/tests/gadugi/run-merge-validations-scenario.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Self-asserting gadugi-test scenario body for issue #820.
+#
+# Drives the SHIPPED `merge-validations` recipe logic (via run-merge-validations.sh)
+# through mixed validator-output cases and exits non-zero if any case regresses.
+# Designed to be launched by the gadugi `execute` action with no arguments, then
+# checked with `validate_exit_code` + an `ALL_CASES_PASSED` output assertion.
+#
+# Before the #820 fix, mixed validator output (JSON inside a ```json fence, or
+# with log preamble) crashed `jq --slurpfile` with "Bad JSON" and aborted the
+# whole audit cycle. After the fix, output is normalized via the tolerant
+# `extract-json` helper, unparseable output yields a targeted diagnostic, and the
+# merge always produces valid JSON.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN="$SCRIPT_DIR/run-merge-validations.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fail=0
+
+pass() { echo "PASS: $1"; }
+fl()   { echo "FAIL: $1"; fail=1; }
+
+confirmed_count() { printf '%s' "$1" | jq -r '.confirmed_count' 2>/dev/null; }
+first_verdict()   { printf '%s' "$1" | jq -r '.validated[0].verdict' 2>/dev/null; }
+
+# ---------------------------------------------------------------------------
+# Case 1: mixed output — prose+```json fence, bare JSON, and log-only garbage.
+# This is the exact shape that used to crash jq with "Bad JSON".
+# ---------------------------------------------------------------------------
+cat > "$WORK/v1.txt" <<'EOF'
+Let me validate the findings now.
+I read src/foo.rs:42 — this is a genuine silent fallback.
+
+```json
+{"validator":"agent-1","cycle":1,"validated":[{"finding_id":1,"verdict":"confirmed","new_severity":"high","reasoning":"swallows error"}]}
+```
+EOF
+cat > "$WORK/v2.txt" <<'EOF'
+{"validator":"agent-2","cycle":1,"validated":[{"finding_id":1,"verdict":"confirmed","new_severity":"medium","reasoning":"agrees"}]}
+EOF
+cat > "$WORK/v3.txt" <<'EOF'
+ERROR: agent timed out before producing structured output
+[trace] partial log line with a stray { brace but no closing object
+done.
+EOF
+
+out="$("$RUN" "$WORK/v1.txt" "$WORK/v2.txt" "$WORK/v3.txt" 2 1 "$WORK/out1" 2>"$WORK/err1.txt")"
+rc=$?
+[ "$rc" = "0" ] && pass "mixed output does not crash (exit 0)" || fl "mixed output exited $rc"
+if grep -q "Bad JSON" "$WORK/err1.txt"; then
+  fl "jq 'Bad JSON' leaked on mixed output"
+else
+  pass "no jq 'Bad JSON' on mixed output"
+fi
+cc="$(confirmed_count "$out")"
+[ "$cc" = "1" ] && pass "two well-formed validators confirm the finding (confirmed_count=1)" \
+  || fl "confirmed_count expected 1, got '$cc'"
+v="$(first_verdict "$out")"
+[ "$v" = "confirmed" ] && pass "finding verdict is confirmed" || fl "verdict expected confirmed, got '$v'"
+if grep -q "no parseable JSON object" "$WORK/err1.txt"; then
+  pass "log-only validator triggers targeted diagnostic"
+else
+  fl "log-only validator did not trigger a diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: all three validators emit bare JSON objects (no fences) — must merge.
+# ---------------------------------------------------------------------------
+printf '%s\n' '{"validated":[{"finding_id":7,"verdict":"confirmed","new_severity":"high"}]}' > "$WORK/p1.txt"
+printf '%s\n' '{"validated":[{"finding_id":7,"verdict":"confirmed","new_severity":"low"}]}'  > "$WORK/p2.txt"
+printf '%s\n' '{"validated":[{"finding_id":7,"verdict":"false_positive"}]}'                  > "$WORK/p3.txt"
+out2="$("$RUN" "$WORK/p1.txt" "$WORK/p2.txt" "$WORK/p3.txt" 2 1 "$WORK/out2" 2>"$WORK/err2.txt")"
+rc2=$?
+[ "$rc2" = "0" ] && pass "bare-JSON output does not crash (exit 0)" || fl "bare-JSON output exited $rc2"
+cc2="$(confirmed_count "$out2")"
+[ "$cc2" = "1" ] && pass "majority confirms finding 7 (confirmed_count=1)" \
+  || fl "confirmed_count expected 1 for finding 7, got '$cc2'"
+
+# ---------------------------------------------------------------------------
+# Case 3: every validator produced unparseable output — degrade, do not crash.
+# ---------------------------------------------------------------------------
+printf '%s\n' 'no json here, just a log line' > "$WORK/g1.txt"
+printf '%s\n' 'another { stray brace only'    > "$WORK/g2.txt"
+printf '%s\n' 'timed out'                      > "$WORK/g3.txt"
+out3="$("$RUN" "$WORK/g1.txt" "$WORK/g2.txt" "$WORK/g3.txt" 2 1 "$WORK/out3" 2>"$WORK/err3.txt")"
+rc3=$?
+[ "$rc3" = "0" ] && pass "all-garbage output degrades gracefully (exit 0)" || fl "all-garbage output exited $rc3"
+if grep -q "Bad JSON" "$WORK/err3.txt"; then fl "jq 'Bad JSON' leaked on all-garbage output"; else pass "no jq 'Bad JSON' on all-garbage output"; fi
+cc3="$(confirmed_count "$out3")"
+[ "$cc3" = "0" ] && pass "no confirmed findings from garbage (confirmed_count=0)" \
+  || fl "confirmed_count expected 0 for garbage, got '$cc3'"
+
+if [ "$fail" -eq 0 ]; then
+  echo "ALL_CASES_PASSED"
+  exit 0
+fi
+echo "SCENARIO_FAILED"
+exit 1

--- a/tests/gadugi/run-merge-validations.sh
+++ b/tests/gadugi/run-merge-validations.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Self-locating harness that runs the SHIPPED `merge-validations` bash body from
+# amplifier-bundle/recipes/quality-audit-cycle.yaml against three validator
+# payloads. Used by the gadugi-test scenario for issue #820 so the scenario
+# exercises the REAL recipe logic (not a copy).
+#
+# Usage:
+#   run-merge-validations.sh <v1_file> <v2_file> <v3_file> [threshold] [cycle] [output_dir]
+#
+# Writes the merged JSON to stdout, the step's diagnostics to stderr, and exits
+# with the step's exit code.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECIPE="$SCRIPT_DIR/../../amplifier-bundle/recipes/quality-audit-cycle.yaml"
+[ -f "$RECIPE" ] || { echo "ERROR: recipe not found: $RECIPE" >&2; exit 2; }
+
+V1_FILE="${1:?usage: run-merge-validations.sh <v1_file> <v2_file> <v3_file> [threshold] [cycle] [output_dir]}"
+V2_FILE="${2:?need v2_file}"
+V3_FILE="${3:?need v3_file}"
+THRESHOLD="${4:-2}"
+CYCLE="${5:-1}"
+OUTPUT_DIR="${6:-$(mktemp -d)}"
+
+# The merge step calls `amplihack orch helper extract-json`. Make sure that
+# binary is resolvable even when this runs outside an activated shell (CI),
+# preferring an already-on-PATH amplihack, then a locally built one.
+if ! command -v amplihack >/dev/null 2>&1; then
+  for _cand in \
+    "$SCRIPT_DIR/../../target/debug/amplihack" \
+    "$SCRIPT_DIR/../../target/release/amplihack" \
+    "${CARGO_TARGET_DIR:-}/debug/amplihack" \
+    "${CARGO_TARGET_DIR:-}/release/amplihack" \
+    "$HOME/.local/bin/amplihack" \
+    "$HOME/.cargo/bin/amplihack"; do
+    if [ -n "$_cand" ] && [ -x "$_cand" ]; then
+      PATH="$(dirname "$_cand"):$PATH"
+      export PATH
+      break
+    fi
+  done
+fi
+
+# Substitute the {{...}} placeholders exactly as recipe-runner-rs would, then
+# run the resulting bash. Python keeps multi-line payloads byte-exact.
+SCRIPT_BODY="$(
+  RECIPE_PATH="$RECIPE" V1="$V1_FILE" V2="$V2_FILE" V3="$V3_FILE" \
+  THRESHOLD_VAL="$THRESHOLD" CYCLE_VAL="$CYCLE" OUTPUT_DIR_VAL="$OUTPUT_DIR" python3 - <<'PY'
+import os, yaml
+with open(os.environ["RECIPE_PATH"]) as fh:
+    recipe = yaml.safe_load(fh)
+for step in recipe["steps"]:
+    if step.get("id") == "merge-validations":
+        cmd = step["command"]
+        break
+else:
+    raise SystemExit("merge-validations step not found")
+
+def read(path):
+    with open(path) as fh:
+        return fh.read()
+
+subs = {
+    "validation_agent_1": read(os.environ["V1"]),
+    "validation_agent_2": read(os.environ["V2"]),
+    "validation_agent_3": read(os.environ["V3"]),
+    "validation_threshold": os.environ["THRESHOLD_VAL"],
+    "cycle_number": os.environ["CYCLE_VAL"],
+    "output_dir": os.environ["OUTPUT_DIR_VAL"],
+}
+for key, val in subs.items():
+    cmd = cmd.replace("{{" + key + "}}", val)
+print(cmd, end="")
+PY
+)"
+
+bash -c "$SCRIPT_BODY"

--- a/tests/gadugi/scenarios/issue-820-merge-validations-mixed-output.yaml
+++ b/tests/gadugi/scenarios/issue-820-merge-validations-mixed-output.yaml
@@ -1,0 +1,47 @@
+name: issue-820-merge-validations-mixed-output
+description: >
+  Regression scenario for amplihack issue #820. The quality-audit-cycle
+  merge-validations step used to feed each validator agent's RAW output straight
+  to `jq --slurpfile`, so any validator that wrapped its JSON verdict in a
+  ```json fence or emitted log preamble crashed jq with "Bad JSON" and aborted
+  the whole audit cycle before fix/verify/summary. This scenario drives the
+  SHIPPED merge-validations bash (via tests/gadugi/run-merge-validations-scenario.sh)
+  through mixed validator output: a fenced verdict, a bare-JSON verdict, and
+  log-only garbage. It asserts the step never emits "Bad JSON", normalizes the
+  well-formed verdicts (correct vote counting), and emits a targeted diagnostic
+  for the unparseable validator instead of crashing.
+version: "1.0"
+config:
+  timeout: 60000
+environment:
+  requires: []
+agents:
+  - name: cli-agent
+    type: cli
+    config: {}
+metadata:
+  tags: [cli, regression, quality-audit, workflow]
+  priority: high
+steps:
+  - name: run-merge-validations-regression-cases
+    agent: cli-agent
+    action: execute
+    params:
+      command: tests/gadugi/run-merge-validations-scenario.sh
+    timeout: 45000
+  - name: all-regression-cases-pass
+    agent: cli-agent
+    action: validate_exit_code
+    params:
+      expected: 0
+  - name: no-bad-json-crash
+    agent: cli-agent
+    action: validate_output
+    params:
+      expected: "no jq 'Bad JSON' on mixed output"
+assertions:
+  - name: all-cases-passed
+    type: output_contains
+    params:
+      target: stdout
+      expected: ALL_CASES_PASSED


### PR DESCRIPTION
## Summary

Closes #820.

`quality-audit-cycle`'s `merge-validations` step wrote each validator agent's
**raw** output to a temp file and fed it straight to `jq -n --slurpfile`.
Validators emit their JSON verdict wrapped in markdown/prose (typically a
` ```json ` fence) and sometimes with log preamble, so `jq` aborted the **entire
audit cycle** with `Bad JSON ... Invalid numeric literal` — after the expensive
seek + 3 validation agents had already run, and before fix/verify/summary.

### Root-cause fix (not symptom masking)

Normalize each validator's output through the existing tolerant
`amplihack orch helper extract-json` helper (the same normalizer
`smart-orchestrator` uses) **before** `jq --slurpfile`. It recovers a single
JSON object from ` ```json ` fences, untagged fences, or a balanced-brace scan
over raw prose. If a validator produced **non-empty** output with **no parseable
JSON object**, the step now emits a targeted diagnostic naming the validator and
preserving its raw output as an artifact under `output_dir`, then falls back to
`{}` so the merge degrades to zero votes instead of crashing. The deterministic
majority-vote merge is unchanged — only the inputs are normalized.

### Reproduction (before → after)

```
# BEFORE (origin/main), raw fenced validator output → whole cycle dies:
jq: Bad JSON in --slurpfile v1 /tmp/...: Invalid numeric literal at line 2, column 0   (exit 2)

# AFTER: extract-json normalizes → jq succeeds, votes counted, exit 0
```

---

## Merge-ready evidence

### 1. QA-team scenarios (gadugi-test)
- Scenario: `tests/gadugi/scenarios/issue-820-merge-validations-mixed-output.yaml`
  driving the **shipped** step via `tests/gadugi/run-merge-validations-scenario.sh`
  (cases: fenced verdict, bare-JSON verdict, log-only garbage).
- `gadugi-test validate -f …` → `✓ Scenario "issue-820-merge-validations-mixed-output" is valid`
- `gadugi-test run -d tests/gadugi/scenarios -s issue-820-…` → `✓ Passed: 1  ✗ Failed: 0  ✓ All tests passed!`

### 2. Docs (user-facing surface)
- `docs/reference/quality-audit-cycle-recipe.md` — new **"merge-validations:
  Validator-Output Normalization (#820)"** section documenting the normalization,
  the explicit (non-silent) degradation, and the diagnostic/artifact behavior.

### 3. quality-audit — ≥3 SEEK→VALIDATE→FIX cycles (clean final)
- **Cycle 1 (correctness/security):** found the helper's shell vars leaked as
  globals → fixed with `local` declarations. Confirmed validator content flows
  through a parser (no shell injection); single-quoted heredocs preserved.
- **Cycle 2 (robustness/CI):** recipe landed exactly at the #646 brick ceiling →
  bumped ceiling 850→880 with justification; hardened the e2e test's binary
  discovery (`current_exe()`-based) so it runs rather than silently skips.
- **Cycle 3 (final — clean):** structural + behavioral + e2e + gadugi all green;
  docs updated; `cargo fmt` clean; no clippy warnings in changed files; focused
  diff. Zero critical/high and zero medium correctness/security findings.

### 4. CI / tests
- `cargo build -p amplihack-cli` → Finished, no warnings.
- `cargo test -p amplihack-cli --test issue_820_merge_validations_mixed_output` → **12 passed**
  (structural recipe assertions, pure-Rust behavioral normalizer tests, and a
  real end-to-end run of the bash step on mixed output).
- `cargo test -p amplihack-cli --test issue_646_quality_audit_cycle_bugs` → **19 passed**
  (step inventory, YAML validity, and brick limit preserved).
- `cargo test -p amplihack-cli --test issue_439_no_per_step_timeout` → **9 passed**.
- Awaiting full CI on this PR for the 100%-green confirmation.

### 6. Focused diff
7 files, all directly related:
- `amplifier-bundle/recipes/quality-audit-cycle.yaml` — the fix (+ ~35 lines in `merge-validations`).
- `docs/reference/quality-audit-cycle-recipe.md` — behavior docs.
- `crates/amplihack-cli/tests/issue_820_merge_validations_mixed_output.rs` — regression tests.
- `crates/amplihack-cli/tests/issue_646_quality_audit_cycle_bugs.rs` — brick-ceiling bump only.
- `tests/gadugi/run-merge-validations.sh`, `tests/gadugi/run-merge-validations-scenario.sh`,
  `tests/gadugi/scenarios/issue-820-merge-validations-mixed-output.yaml` — QA scenario.