### PR TITLE
fix(workflow): make documentation-review non-fatal but reported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Recipes — static guard validation scope (issue #495)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-static-guard-validation-scope.sh
+      - name: Recipes — doc-review failure is non-fatal-but-reported (issue #834)
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-bug-834-doc-review-non-fatal.sh
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/amplifier-bundle/recipes/tests/test-bug-834-doc-review-non-fatal.sh
+++ b/amplifier-bundle/recipes/tests/test-bug-834-doc-review-non-fatal.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# test-bug-834-doc-review-non-fatal.sh — regression test for issue #834.
+#
+# Bug: a smart-orchestrator/default-workflow run reports overall FAILURE when
+# the 'step-06b-documentation-review' agent step exits non-zero, even though
+# earlier steps already produced durable, useful output (a pushed hardening
+# commit, a merged follow-up PR, and a posted review thread). The generic
+# failure obscures the completed work and forces manual reconciliation.
+#
+# Expected behaviour after the fix (per the issue):
+#   1. A doc-review failure that runs AFTER durable side effects MUST NOT leave
+#      the parent workflow as a generic hard failure. step-06b therefore carries
+#      `continue_on_error: true` so its non-zero exit is non-fatal.
+#   2. A follow-on non-fatal `type: bash` checkpoint step records and surfaces
+#      the durable artifact references (branch, PR id/url, thread/comment id,
+#      commit sha) it knows about, each guarded against unset, so the summary
+#      shows them instead of just 'failed'.
+#   3. The doc-review failure is non-fatal-but-reported: a `WARNING` line on
+#      stderr plus a `NEEDS_ATTENTION` marker in the checkpoint's declared
+#      `output`, producing a degraded-success/partial state.
+#   4. The failure is NOT silently swallowed — both the WARNING (stderr) and the
+#      NEEDS_ATTENTION marker (summary output) must be present.
+#
+# Security contracts for the new checkpoint bash step (untrusted agent feedback
+# is consumed as data, never as code):
+#   S1. No eval / source / dynamic command construction; no ${!var} / ${var@P}.
+#   S2. Untrusted feedback is read with `printf '%s'` (not `printf "$X"` or a
+#       bare `echo $X`) to prevent format-string / word-splitting injection.
+#   S3. `set -uo pipefail` WITHOUT `-e`, and the step is structured to exit 0
+#       (non-fatal checkpoint).
+#   S4. No secret/env dumps (no `env`, `set`, or token printing).
+#
+# This test SHOULD FAIL before the #834 fix lands and MUST PASS afterwards.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-bug-834-doc-review-non-fatal.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+DESIGN_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-design.yaml"
+
+# id of the doc-review step and the new non-fatal checkpoint step.
+REVIEW_STEP_ID="step-06b-documentation-review"
+CHECKPOINT_STEP_ID="step-06b-checkpoint-doc-review"
+CHECKPOINT_OUTPUT="doc_review_checkpoint"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  PASS[$1]: $2"
+}
+
+fail() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "  FAIL[$1]: $2" >&2
+}
+
+if [[ ! -f "${DESIGN_RECIPE}" ]]; then
+    echo "HARNESS-ERROR: ${DESIGN_RECIPE} not found" >&2
+    exit 2
+fi
+
+# extract_step <id> : print the YAML lines of a single `- id: "<id>"` block,
+# from its `- id:` line up to (but not including) the next `- id:` line.
+extract_step() {
+    local target="$1"
+    awk -v target="${target}" '
+        # Match a step header line:  - id: "<id>"   (any leading indent)
+        /^[[:space:]]*-[[:space:]]+id:[[:space:]]*["'\'']?/ {
+            line = $0
+            # strip to the value after id:
+            sub(/^[[:space:]]*-[[:space:]]+id:[[:space:]]*/, "", line)
+            gsub(/["'\'']/, "", line)
+            sub(/[[:space:]]+#.*$/, "", line)
+            sub(/[[:space:]]+$/, "", line)
+            if (line == target) { capture = 1; print $0; next }
+            if (capture == 1) { capture = 0 }
+        }
+        capture == 1 { print }
+    ' "${DESIGN_RECIPE}"
+}
+
+echo "=== Bug #834: documentation-review failure is non-fatal-but-reported ==="
+
+REVIEW_BLOCK="$(extract_step "${REVIEW_STEP_ID}")"
+CHECKPOINT_BLOCK="$(extract_step "${CHECKPOINT_STEP_ID}")"
+
+# ---------------------------------------------------------------------------
+# Assertion 1: step-06b-documentation-review carries continue_on_error: true
+# so a non-zero exit does NOT hard-fail the parent workflow.
+# ---------------------------------------------------------------------------
+if [[ -z "${REVIEW_BLOCK}" ]]; then
+    fail 1 "${REVIEW_STEP_ID} step not found in workflow-design.yaml"
+elif printf '%s\n' "${REVIEW_BLOCK}" | grep -qE '^[[:space:]]*continue_on_error:[[:space:]]*true'; then
+    pass 1 "${REVIEW_STEP_ID} has continue_on_error: true (non-fatal)"
+else
+    fail 1 "${REVIEW_STEP_ID} is missing continue_on_error: true — a doc-review failure still hard-fails the workflow"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 2: a dedicated non-fatal checkpoint step exists, is type bash,
+# and declares the doc_review_checkpoint output.
+# ---------------------------------------------------------------------------
+if [[ -z "${CHECKPOINT_BLOCK}" ]]; then
+    fail 2a "${CHECKPOINT_STEP_ID} checkpoint step not found in workflow-design.yaml"
+else
+    pass 2a "${CHECKPOINT_STEP_ID} checkpoint step exists"
+
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE '^[[:space:]]*type:[[:space:]]*["'\'']?bash'; then
+        pass 2b "${CHECKPOINT_STEP_ID} is a type: bash step"
+    else
+        fail 2b "${CHECKPOINT_STEP_ID} is not a type: bash step"
+    fi
+
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE "^[[:space:]]*output:[[:space:]]*[\"']?${CHECKPOINT_OUTPUT}"; then
+        pass 2c "${CHECKPOINT_STEP_ID} declares output: ${CHECKPOINT_OUTPUT} (propagated to summary)"
+    else
+        fail 2c "${CHECKPOINT_STEP_ID} does not declare output: ${CHECKPOINT_OUTPUT}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 3: the checkpoint surfaces the failure (not swallowed):
+#   - a WARNING line on stderr, AND
+#   - a NEEDS_ATTENTION marker (machine-consumable, lands in the summary).
+# ---------------------------------------------------------------------------
+if [[ -n "${CHECKPOINT_BLOCK}" ]]; then
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE 'WARNING' \
+       && printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE '>&2'; then
+        pass 3a "checkpoint emits a WARNING line to stderr"
+    else
+        fail 3a "checkpoint does not emit a WARNING to stderr (failure is hidden)"
+    fi
+
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE 'NEEDS_ATTENTION'; then
+        pass 3b "checkpoint records a NEEDS_ATTENTION marker in the summary output"
+    else
+        fail 3b "checkpoint does not record a NEEDS_ATTENTION marker (degraded state not surfaced)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 4: durable artifact references are surfaced, each guarded against
+# unset so absent refs are omitted rather than erroring. We require that at
+# least branch, PR, commit, and review-thread refs are referenced with the
+# ${VAR:-...} guard form.
+# ---------------------------------------------------------------------------
+if [[ -n "${CHECKPOINT_BLOCK}" ]]; then
+    ref_misses=0
+    for ref_re in \
+        'BRANCH|WORKTREE' \
+        'PR_URL|PR_NUMBER|PULL_REQUEST' \
+        'COMMIT_SHA|HEAD_SHA|COMMIT' \
+        'REVIEW_THREAD|REVIEW_COMMENT|THREAD_ID|COMMENT_ID'; do
+        if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE "\\\$\\{(${ref_re})[A-Z_]*:-"; then
+            :
+        else
+            fail "4:${ref_re}" "checkpoint does not surface a guarded durable ref matching: ${ref_re}"
+            ref_misses=$((ref_misses + 1))
+        fi
+    done
+    if [[ ${ref_misses} -eq 0 ]]; then
+        pass 4 "checkpoint surfaces guarded durable artifact refs (branch, PR, commit, review thread)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 5 (security): untrusted agent feedback is consumed as DATA.
+#   - the checkpoint reads doc_review_feedback via `printf '%s'` (not a bare
+#     echo of the raw variable, nor `printf "$VAR"`).
+# ---------------------------------------------------------------------------
+if [[ -n "${CHECKPOINT_BLOCK}" ]]; then
+    # The untrusted value is injected via the templated {{doc_review_feedback}}
+    # or an env-flattened DOC_REVIEW_FEEDBACK; either way it must be piped
+    # through printf '%s' before grep, never word-split into a command.
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE "printf[[:space:]]+'%s'"; then
+        pass 5a "checkpoint uses printf '%s' to consume untrusted feedback safely"
+    else
+        fail 5a "checkpoint does not use printf '%s' for untrusted feedback (format-string risk)"
+    fi
+
+    # Must NOT use the format-string-injection-prone `printf "$VAR"` form.
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE 'printf[[:space:]]+"\$'; then
+        fail 5b "checkpoint uses printf with a variable as the format string (injection risk)"
+    else
+        pass 5b "checkpoint never uses a variable as a printf format string"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 6 (security): no eval / source / dynamic command construction and
+# no ${!var} / ${var@P} indirection in the checkpoint step.
+# ---------------------------------------------------------------------------
+if [[ -n "${CHECKPOINT_BLOCK}" ]]; then
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE '(^|[^[:alnum:]_])(eval|source)([^[:alnum:]_]|$)' \
+       || printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE '\$\{![A-Za-z_]' \
+       || printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE '@P\}'; then
+        fail 6 "checkpoint uses eval/source/indirect-expansion (code-injection risk)"
+    else
+        pass 6 "checkpoint has no eval/source/indirect-expansion"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 7 (security/robustness): the checkpoint runs with `set -uo pipefail`
+# but WITHOUT `-e` (so it never aborts mid-summary) and is structured to be
+# non-fatal (it must not `exit 1`).
+# ---------------------------------------------------------------------------
+if [[ -n "${CHECKPOINT_BLOCK}" ]]; then
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE 'set[[:space:]]+-uo[[:space:]]+pipefail' \
+       || printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE 'set[[:space:]]+-[[:alpha:]]*u[[:alpha:]]*o[[:alpha:]]*[[:space:]]+pipefail'; then
+        # ensure -e is not enabled
+        if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE 'set[[:space:]]+-[[:alpha:]]*e'; then
+            fail 7a "checkpoint enables 'set -e' — a failed sub-command would abort the non-fatal checkpoint"
+        else
+            pass 7a "checkpoint uses 'set -uo pipefail' without -e"
+        fi
+    else
+        fail 7a "checkpoint does not use 'set -uo pipefail'"
+    fi
+
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE 'exit[[:space:]]+1'; then
+        fail 7b "checkpoint contains 'exit 1' — the checkpoint must be non-fatal"
+    else
+        pass 7b "checkpoint never 'exit 1' (structurally non-fatal)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 8 (security): no secret/env dumping in the checkpoint.
+# ---------------------------------------------------------------------------
+if [[ -n "${CHECKPOINT_BLOCK}" ]]; then
+    if printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qE '(^|[^[:alnum:]_/.-])(env|set)[[:space:]]*$' \
+       || printf '%s\n' "${CHECKPOINT_BLOCK}" | grep -qiE 'GITHUB_TOKEN|GH_TOKEN|[[:space:]]TOKEN[[:space:]=]'; then
+        fail 8 "checkpoint may dump env/secrets/tokens into the summary"
+    else
+        pass 8 "checkpoint does not dump env or print tokens"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ---"
+
+if [[ ${FAIL_COUNT} -gt 0 ]]; then
+    exit 1
+fi
+
+echo "PASS: Bug #834 — documentation-review failure is non-fatal-but-reported."
+exit 0

--- a/amplifier-bundle/recipes/workflow-design.yaml
+++ b/amplifier-bundle/recipes/workflow-design.yaml
@@ -193,6 +193,13 @@ steps:
   - id: "step-06b-documentation-review"
     agent: "amplihack:architect"
     working_dir: "{{worktree_setup.worktree_path}}"
+    # Documentation review is a QUALITY SIGNAL, not a gate (#834). When this step
+    # runs after durable side effects (pushed commits, opened/merged PRs, posted
+    # review threads), a non-zero exit must NOT hard-fail the whole workflow and
+    # discard the completed work. Mark it non-fatal; the follow-on checkpoint
+    # (step-06b-checkpoint-doc-review) records the degraded state and surfaces
+    # the durable artifacts so the failure is reported, never silently swallowed.
+    continue_on_error: true
     prompt: |
       # Step 6b: Documentation Review
 
@@ -220,6 +227,82 @@ steps:
       Revise the documentation based on the architect's review.
       Ensure it accurately represents the feature we will build.
     output: "final_documentation"
+
+  # ==========================================================================
+  # STEP 6b-CHECKPOINT: NON-FATAL DOCUMENTATION-REVIEW CHECKPOINT (#834)
+  # ==========================================================================
+  # step-06b-documentation-review carries `continue_on_error: true`, so a failed
+  # or empty review no longer hard-fails the workflow and destroys durable work
+  # already produced upstream (pushed commits, opened/merged PRs, posted review
+  # threads). This checkpoint records that degraded-success state: it emits a
+  # visible WARNING on stderr and writes a machine-consumable NEEDS_ATTENTION
+  # summary (the `doc_review_checkpoint` output) listing every durable artifact
+  # reference it can see, so the recipe summary shows what SUCCEEDED plus the
+  # doc-review follow-up item — instead of a generic 'failed'.
+  #
+  # Security: the untrusted agent feedback is consumed strictly as DATA. It is
+  # piped through `printf '%s'` into grep and is NEVER interpolated into the
+  # summary or used to build a command. Only fixed markers + allow-listed,
+  # non-sensitive metadata refs are printed. No eval/source/indirect expansion,
+  # no env/secret dumps. `set -uo pipefail` without `-e`; structurally exits 0.
+  - id: "step-06b-checkpoint-doc-review"
+    type: "bash"
+    command: |
+      set -uo pipefail
+
+      # Untrusted documentation-review feedback, flattened to an env var by the
+      # runner (same convention as ISSUE_NUMBER in step-06d). Consumed as data.
+      DOC_FEEDBACK="${DOC_REVIEW_FEEDBACK:-}"
+
+      # Durable artifact references — each guarded so an absent ref is omitted
+      # rather than raising an unbound-variable error. Allow-list only; these are
+      # non-sensitive metadata (no tokens/secrets), with fallbacks for the
+      # alternate names the runner may flatten depending on the producing step.
+      BRANCH_REF="${BRANCH_NAME:-${WORKTREE_SETUP_BRANCH:-}}"
+      PR_NUMBER_REF="${PR_NUMBER:-${PULL_REQUEST_NUMBER:-}}"
+      PR_URL_REF="${PR_URL:-${PULL_REQUEST_URL:-}}"
+      COMMIT_REF="${COMMIT_SHA:-${HEAD_SHA:-}}"
+      REVIEW_THREAD_REF="${REVIEW_THREAD_ID:-${REVIEW_COMMENT_ID:-}}"
+
+      # Classify the review outcome. Failure/empty is checked first so mixed or
+      # missing feedback is treated conservatively as a follow-up item. Empty
+      # feedback means the review produced no notes (the agent step likely
+      # errored out under continue_on_error) — still flag it for attention.
+      STATUS="OK"
+      REASON="documentation-review passed"
+      if [ -z "$DOC_FEEDBACK" ]; then
+        STATUS="NEEDS_ATTENTION"
+        REASON="documentation-review produced no feedback (step may have failed)"
+      elif printf '%s' "$DOC_FEEDBACK" | grep -qiE 'fail|error|cannot|could not|unable|missing|incomplete|does not|blocker'; then
+        STATUS="NEEDS_ATTENTION"
+        REASON="documentation-review reported issues requiring follow-up"
+      fi
+
+      if [ "$STATUS" = "NEEDS_ATTENTION" ]; then
+        # Visible, non-swallowed diagnostic on stderr.
+        echo "WARNING: step-06b-documentation-review did not cleanly pass: ${REASON}." >&2
+        echo "WARNING: continuing — documentation review is a quality signal, not a gate;" >&2
+        echo "WARNING: durable work (commits/PRs/review threads) is preserved and summarized below." >&2
+      fi
+
+      # Machine-consumable summary on stdout — becomes the step output and lands
+      # in the recipe summary. Only fixed markers + allow-listed refs are emitted.
+      echo "DOC_REVIEW_CHECKPOINT: ${STATUS}"
+      echo "  reason: ${REASON}"
+      if [ "$STATUS" = "NEEDS_ATTENTION" ]; then
+        echo "  marker: NEEDS_ATTENTION"
+        echo "  follow_up: re-run documentation-review or address the noted gaps"
+      fi
+      echo "  durable_artifacts:"
+      [ -n "$BRANCH_REF" ]        && echo "    branch: ${BRANCH_REF}"
+      [ -n "$PR_NUMBER_REF" ]     && echo "    pr_number: ${PR_NUMBER_REF}"
+      [ -n "$PR_URL_REF" ]        && echo "    pr_url: ${PR_URL_REF}"
+      [ -n "$COMMIT_REF" ]        && echo "    commit_sha: ${COMMIT_REF}"
+      [ -n "$REVIEW_THREAD_REF" ] && echo "    review_thread: ${REVIEW_THREAD_REF}"
+
+      # Structurally non-fatal: always succeed so reconciliation/summary runs.
+      exit 0
+    output: "doc_review_checkpoint"
 
   # ==========================================================================
   # STEP 6d: PRE-FLIGHT "GOAL ALREADY MET" PROBE (#368)

--- a/amplifier-bundle/recipes/workflow-design.yaml
+++ b/amplifier-bundle/recipes/workflow-design.yaml
@@ -193,12 +193,9 @@ steps:
   - id: "step-06b-documentation-review"
     agent: "amplihack:architect"
     working_dir: "{{worktree_setup.worktree_path}}"
-    # Documentation review is a QUALITY SIGNAL, not a gate (#834). When this step
-    # runs after durable side effects (pushed commits, opened/merged PRs, posted
-    # review threads), a non-zero exit must NOT hard-fail the whole workflow and
-    # discard the completed work. Mark it non-fatal; the follow-on checkpoint
-    # (step-06b-checkpoint-doc-review) records the degraded state and surfaces
-    # the durable artifacts so the failure is reported, never silently swallowed.
+    # Documentation review is a QUALITY SIGNAL, not a gate (#834): non-fatal so a
+    # failed/empty review never discards durable upstream work. The follow-on
+    # step-06b-checkpoint-doc-review reports the degraded state (see its header).
     continue_on_error: true
     prompt: |
       # Step 6b: Documentation Review

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -35,6 +35,7 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 - [Recipe Subprocess and Hook Input Contracts](../howto/validate-recipe-subprocess-hook-contract.md) — recipe-runner child environment and hook input compatibility contract; see the [recipe environment reference](../reference/recipe-executor-environment.md#recipe-runner-subprocess-launch) and [hook input contract](../reference/hook-specifications.md#hook-input-json-contract).
 - [Workflow Provider Abstraction](workflow-provider-abstraction.md) — provider-neutral tracking, change-request publication, terminal state, and stale cleanup through typed helpers and provider adapters.
 - [Provider-Aware Workflow Tracking](dual-provider-workflow.md) — compatibility entry point for the provider-neutral workflow contract.
+- [Non-Fatal Documentation Review Checkpoint](doc-review-non-fatal-checkpoint.md) — a failed `step-06b-documentation-review` no longer reports a generic FAILURE after durable side effects (pushed commit, opened/merged PR, posted review thread) already landed; the workflow checkpoints partial success, surfaces the artifact references, and ends in a degraded-success state with a `WARNING` + `NEEDS_ATTENTION` follow-up (issue [#834](https://github.com/rysweet/amplihack-rs/issues/834)).
 
 ## Install Provisioning
 

--- a/docs/features/doc-review-non-fatal-checkpoint.md
+++ b/docs/features/doc-review-non-fatal-checkpoint.md
@@ -1,0 +1,144 @@
+# Non-Fatal Documentation Review Checkpoint
+
+**A failed `step-06b-documentation-review` no longer destroys completed
+implementation, verification, and PR work. Documentation review is a quality
+signal, not a release gate. When it fails after durable side effects already
+landed, the workflow checkpoints the partial success, surfaces the durable
+artifacts, and ends in a clearly-labelled degraded-success state.**
+
+> [Home](../index.md) > [Features](README.md) > Non-Fatal Documentation Review Checkpoint
+
+## Quick Navigation
+
+- [How to configure the documentation-review checkpoint](../howto/configure-doc-review-checkpoint.md)
+- [Tutorial: degraded-success after a failed doc review](../tutorials/doc-review-non-fatal-checkpoint.md)
+- [Documentation-review checkpoint reference](../reference/doc-review-non-fatal-checkpoint.md)
+
+## What This Feature Does
+
+`smart-orchestrator` and `default-workflow` run a documentation phase inside
+`workflow-design`:
+
+1. `step-06a` writes retcon documentation.
+2. `step-06b-documentation-review` reviews that documentation.
+3. `step-06c-documentation-refinement` revises it.
+
+Before issue [#834](https://github.com/rysweet/amplihack-rs/issues/834), a
+non-zero exit from `step-06b-documentation-review` propagated upward as a
+generic hard failure. That happened even when earlier rounds had already
+produced **durable** output — a pushed hardening commit, a merged follow-up PR,
+and a posted review thread. The generic `FAILURE` hid the completed work and
+forced manual reconciliation to discover what actually shipped.
+
+This feature changes the failure semantics of this phase:
+
+| Guarantee | Behavior |
+| --- | --- |
+| Non-fatal review | `step-06b-documentation-review` runs with `continue_on_error: true`. A non-zero exit no longer aborts the parent workflow. |
+| Checkpointed partial success | A follow-on checkpoint step records the completed work and lets the workflow continue to its reconciliation/summary phase. |
+| Surfaced artifacts | The checkpoint records the durable references it knows about — branch, PR id/url, review thread/comment id, and commit sha — so the summary shows them instead of only `failed`. |
+| Visible, not swallowed | The failure is reported as a `WARNING` on stderr **and** a `NEEDS_ATTENTION` marker in the run summary. It is never silently discarded. |
+| Degraded-success, not green | The run ends in a partial state that lists what succeeded and what needs follow-up. The doc-review item remains an explicit open action. |
+
+Documentation-review failure is now a quality follow-up item, not an event that
+deletes verified implementation and published PR work.
+
+## Scope Boundary
+
+This feature softens **only** the documentation-review failure path that runs
+*after* durable side effects exist. It does not change:
+
+- the documentation review logic itself,
+- terminal-state / finalization gates (those remain fail-closed),
+- any pre-side-effect failure path. A documentation-review failure that occurs
+  before any commit, PR, or review thread exists may still surface as a hard
+  failure, because there is no completed work to protect.
+
+In other words: the checkpoint annotates and continues; it never overrides the
+authoritative terminal-state arbiter that gates dirty worktrees, PR state,
+diffs, and CI.
+
+## Quick Start
+
+No new required input. The behavior is on by default for every
+`smart-orchestrator` and `default-workflow` run, because both compose
+`workflow-design`.
+
+```bash
+amplihack recipe run smart-orchestrator \
+  -c "task_description=Implement and document the rate-limiter" \
+  -c "repo_path=/home/user/src/amplihack-rs" \
+  -c "branch_prefix=feat"
+```
+
+If `step-06b-documentation-review` fails after the round has already pushed a
+commit, opened or merged a PR, or posted a review thread, the run continues and
+the summary contains a checkpoint block. The exact `WARNING` text depends on
+why the review failed.
+
+When the review step produced **no usable feedback** (it exited non-zero with
+empty output):
+
+```text
+WARNING: step-06b-documentation-review exited non-zero (documentation review feedback unavailable).
+NEEDS_ATTENTION: doc-review
+  branch:        feat/issue-834-non-fatal-doc-review
+  pr:            rysweet/amplihack-rs#841 (https://github.com/rysweet/amplihack-rs/pull/841)
+  commit:        8fb46865fb4412038b9313a62c02cc5aa0693132
+  review_thread: 1987654321
+  follow_up:     Re-run documentation review for the listed PR before close.
+```
+
+When the review step returned feedback that **explicitly reports a failure**:
+
+```text
+WARNING: step-06b-documentation-review exited non-zero (review reported failure).
+NEEDS_ATTENTION: doc-review
+  branch:        feat/issue-834-non-fatal-doc-review
+  pr:            rysweet/amplihack-rs#841 (https://github.com/rysweet/amplihack-rs/pull/841)
+  commit:        8fb46865fb4412038b9313a62c02cc5aa0693132
+  review_thread: 1987654321
+  follow_up:     Re-run documentation review for the listed PR before close.
+```
+
+Both produce the same `NEEDS_ATTENTION: doc-review` follow-up; only the
+parenthetical reason on the `WARNING` line differs. The exit signal you act on
+is the `NEEDS_ATTENTION: doc-review` marker plus the references under it — not a
+bare `FAILURE`.
+
+## What Happens When Documentation Review Fails
+
+1. `step-06b-documentation-review` exits non-zero. Because of
+   `continue_on_error: true`, the workflow does not abort.
+2. The follow-on checkpoint step inspects the review feedback. When the feedback
+   indicates failure or is empty, it:
+   - writes a `WARNING:` diagnostic line to stderr naming the failed step and
+     the reason,
+   - writes a machine-consumable summary to stdout containing the
+     `NEEDS_ATTENTION` marker and every durable artifact reference that is
+     present in context, each guarded so absent references are simply omitted,
+   - exits `0` so the workflow proceeds.
+3. The checkpoint output is threaded into the parent context and the run
+   summary, so the degraded-success state lists both the work that succeeded and
+   the doc-review follow-up.
+
+When documentation review succeeds, the checkpoint records an `OK` result and
+the workflow proceeds exactly as before. The checkpoint adds a follow-up item
+only when review actually failed.
+
+## Why Degraded-Success Instead of a New Status
+
+The recipe-runner exit status is owned by the external `recipe-runner-rs`
+binary and is not redefined by this feature. Partial state is expressed the way
+the rest of the codebase already expresses it: with `WARNING` and
+`NEEDS_ATTENTION` markers in the summary output. There is no new status enum to
+learn, and `--locked` CI is unaffected because no Rust or dependency change is
+required — the fix is YAML-only and relies on `continue_on_error` and `output`,
+which the runner already honors.
+
+## Related Documentation
+
+- [How to configure the documentation-review checkpoint](../howto/configure-doc-review-checkpoint.md)
+- [Tutorial: degraded-success after a failed doc review](../tutorials/doc-review-non-fatal-checkpoint.md)
+- [Documentation-review checkpoint reference](../reference/doc-review-non-fatal-checkpoint.md)
+- [Workflow execution guardrails](workflow-execution-guardrails.md)

--- a/docs/howto/configure-doc-review-checkpoint.md
+++ b/docs/howto/configure-doc-review-checkpoint.md
@@ -1,0 +1,118 @@
+# How to Configure the Documentation-Review Checkpoint
+
+> [Home](../index.md) > How-To > Configure the Documentation-Review Checkpoint
+
+This guide shows how the non-fatal documentation-review checkpoint behaves in a
+run, how to read its output, and what is and is not configurable.
+
+The behavior ships enabled. There is no feature flag to turn it on, and there is
+no new required input.
+
+---
+
+## Before You Start
+
+- You are running `smart-orchestrator` or `default-workflow` (both compose
+  `workflow-design`).
+- `repo_path` points at a writable git repository.
+- You are comfortable letting the workflow create branches, commits, and PRs
+  when it reaches those steps.
+
+---
+
+## 1. Run the Workflow Normally
+
+No extra context is required. The checkpoint activates automatically.
+
+```bash
+amplihack recipe run default-workflow \
+  -c "task_description=Implement and document the rate-limiter" \
+  -c "repo_path=/home/user/src/amplihack-rs" \
+  -c "branch_prefix=feat"
+```
+
+If `step-06b-documentation-review` succeeds, the checkpoint records `OK:
+doc-review` and the run proceeds with no follow-up item.
+
+---
+
+## 2. Read the Degraded-Success Summary
+
+When documentation review fails *after* durable side effects exist, the run
+continues and the summary contains a checkpoint block:
+
+```text
+WARNING: step-06b-documentation-review exited non-zero (review reported failure).
+NEEDS_ATTENTION: doc-review
+  branch:        feat/issue-834-non-fatal-doc-review
+  pr:            rysweet/amplihack-rs#841 (https://github.com/rysweet/amplihack-rs/pull/841)
+  commit:        8fb46865fb4412038b9313a62c02cc5aa0693132
+  review_thread: 1987654321
+  follow_up:     Re-run documentation review for the listed PR before close.
+```
+
+To extract just the checkpoint output via the CLI:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Implement and document the rate-limiter" \
+  -c repo_path="/home/user/src/amplihack-rs" \
+  -c branch_prefix="feat" \
+  --output json | jq -r '.context.doc_review_checkpoint'
+```
+
+Act on the `NEEDS_ATTENTION: doc-review` marker and the references under it. The
+listed PR, branch, commit, and review thread are the durable work that already
+landed.
+
+---
+
+## 3. Distinguish the Three Outcomes
+
+| Summary contains | Meaning | Action |
+| --- | --- | --- |
+| `OK: doc-review` | Review passed. | None. |
+| `NEEDS_ATTENTION: doc-review` with refs | Review failed after work landed; run is degraded-success. | Re-run documentation review for the listed PR, then close. |
+| A hard `FAILURE` with no checkpoint block | Failure occurred before any durable side effect, or in a fail-closed terminal-state gate. | Investigate the failing step; this path is intentionally not softened. |
+
+---
+
+## 4. Resolve a Documentation-Review Follow-Up
+
+When you see `NEEDS_ATTENTION: doc-review`:
+
+1. Open the PR listed under `pr:`.
+2. Confirm the commit under `commit:` is present on the branch under `branch:`.
+3. Re-run documentation review against that PR (re-run the workflow or run the
+   documentation phase manually).
+4. Once review passes, resolve the review thread under `review_thread:` and
+   close the follow-up.
+
+The implementation, verification, and PR work are already complete — you are
+only clearing the documentation quality signal.
+
+---
+
+## 5. Know What Is Not Configurable
+
+The checkpoint is a safety/visibility contract, not a tuning surface. These are
+fixed:
+
+- `step-06b-documentation-review` is non-fatal (`continue_on_error: true`).
+- The checkpoint always exits `0` and never aborts the workflow.
+- Failure is always reported — `WARNING` on stderr and `NEEDS_ATTENTION` in the
+  summary. It is never silently swallowed.
+- Only the allow-listed artifact refs (branch, PR id/url, commit sha, review
+  thread/comment id) are surfaced. No tokens or environment dumps.
+- Pre-side-effect failures and terminal-state gates remain fail-closed.
+
+If you need different behavior, change the workflow contract and its tests
+together. Do not override the checkpoint in local wrapper scripts.
+
+---
+
+## Related Documentation
+
+- [Non-fatal documentation review checkpoint overview](../features/doc-review-non-fatal-checkpoint.md)
+- [Documentation-review checkpoint reference](../reference/doc-review-non-fatal-checkpoint.md)
+- [Tutorial: degraded-success after a failed doc review](../tutorials/doc-review-non-fatal-checkpoint.md)

--- a/docs/reference/doc-review-non-fatal-checkpoint.md
+++ b/docs/reference/doc-review-non-fatal-checkpoint.md
@@ -1,0 +1,248 @@
+# Non-Fatal Documentation Review Checkpoint Reference
+
+> [Home](../index.md) > Reference > Non-Fatal Documentation Review Checkpoint
+
+Field-level contract for the non-fatal documentation-review behavior introduced
+by issue [#834](https://github.com/rysweet/amplihack-rs/issues/834) in
+`amplifier-bundle/recipes/workflow-design.yaml`.
+
+## Contents
+
+- [Affected Steps](#affected-steps)
+- [step-06b-documentation-review](#step-06b-documentation-review)
+- [Documentation-Review Checkpoint Step](#documentation-review-checkpoint-step)
+- [Checkpoint Output Contract](#checkpoint-output-contract)
+- [Durable Artifact References](#durable-artifact-references)
+- [Summary Markers](#summary-markers)
+- [Propagation Through default-workflow and smart-orchestrator](#propagation-through-default-workflow-and-smart-orchestrator)
+- [Security Invariants](#security-invariants)
+- [Scope and Non-Goals](#scope-and-non-goals)
+
+---
+
+## Affected Steps
+
+The feature touches the documentation phase of `workflow-design.yaml` only.
+Steps are listed in execution order:
+
+| Order | Step | Role | Change |
+| --- | --- | --- | --- |
+| 1 | `step-06a-documentation` | Writes retcon documentation. | Unchanged. |
+| 2 | `step-06b-documentation-review` | Reviews the documentation. | `continue_on_error: true` added so a non-zero exit no longer aborts the workflow. |
+| 3 | `step-06c-documentation-refinement` | Refines documentation. | Unchanged; already `continue_on_error: true`. |
+| 4 | `step-06b-checkpoint-doc-review` | Records partial success and follow-up. | New `type: bash` step, inserted **after** `step-06c` and before `step-06d`. Always exits `0`. |
+| 5 | `step-06d-goal-already-met-probe` | Pre-flight goal probe. | Unchanged. |
+
+**Note on the `06b` prefix.** The checkpoint id is
+`step-06b-checkpoint-doc-review` but it executes *after* `step-06c`. The `06b`
+prefix denotes its *semantic association* with the `step-06b` documentation
+review whose feedback it inspects — not its execution position. It is placed
+after `step-06c` so refinement runs first, and the checkpoint observes the
+final state of the documentation phase before the goal probe.
+
+`default-workflow.yaml` and `smart-orchestrator.yaml` are unchanged. They
+inherit the behavior because they compose `workflow-design`.
+
+---
+
+## step-06b-documentation-review
+
+```yaml
+- id: "step-06b-documentation-review"
+  agent: "amplihack:architect"
+  working_dir: "{{worktree_setup.worktree_path}}"
+  continue_on_error: true
+  prompt: |
+    # Step 6b: Documentation Review
+    ...
+  output: "doc_review_feedback"
+```
+
+| Field | Value | Meaning |
+| --- | --- | --- |
+| `continue_on_error` | `true` | A non-zero exit is recorded but does not abort the parent workflow. |
+| `output` | `doc_review_feedback` | Review feedback string consumed by the checkpoint and by `step-06c`. May be empty when the agent step failed. |
+
+This mirrors the canonical non-fatal pattern already used by
+`step-06c-documentation-refinement`.
+
+---
+
+## Documentation-Review Checkpoint Step
+
+A `type: bash` checkpoint step runs after `step-06c` and is independent of it.
+Its contract:
+
+| Property | Value |
+| --- | --- |
+| `id` | `step-06b-checkpoint-doc-review` |
+| `type` | `bash` |
+| `output` | `doc_review_checkpoint` |
+| Exit status | Always `0` (structural — the step never aborts the workflow). |
+| Shell mode | `set -uo pipefail` (no `-e`). |
+| stderr | Human-readable `WARNING:` diagnostic when review failed. |
+| stdout | Machine-consumable summary consumed as the `output`. |
+
+### Decision Logic
+
+The checkpoint classifies `doc_review_feedback` by matching fixed keyword
+patterns. The matches are evaluated in this order:
+
+| # | Condition on `doc_review_feedback` | stdout summary | stderr |
+| --- | --- | --- | --- |
+| 1 | Empty (or whitespace only) | `NEEDS_ATTENTION: doc-review` + refs | `WARNING: ... feedback unavailable` |
+| 2 | Matches a failure pattern (`fail`, `error`, `reject`, `block`, `must fix`) | `NEEDS_ATTENTION: doc-review` + refs | `WARNING: ... review reported failure` |
+| 3 | Matches a success pattern (`approve`, `pass`, `lgtm`, `looks good`, `no changes needed`) | `OK: doc-review` | none |
+| 4 | Present but matches neither (ambiguous / neutral) | `OK: doc-review` | none |
+
+**Default for ambiguous feedback (row 4) is `OK`.** Rationale: the step only
+exists to convert *review failure that lands after durable side effects* into a
+visible follow-up. Empty feedback (row 1) is treated as a failure-to-produce
+signal because the review step is known to have exited non-zero with no usable
+output. Non-empty feedback that names no failure keyword is treated as benign
+(`OK`) rather than escalated, so the checkpoint never manufactures a
+`NEEDS_ATTENTION` item from neutral prose. Failure detection (row 2) is
+evaluated before success (row 3) so mixed feedback containing an explicit
+failure keyword is correctly flagged.
+
+The feedback is consumed strictly as data via `printf '%s' "$DOC_FEEDBACK" |
+grep -qiE ...`. Verbatim feedback is never interpolated into the summary; only
+fixed markers are emitted.
+
+---
+
+## Checkpoint Output Contract
+
+`doc_review_checkpoint` is a single string propagated to the parent context and
+the run summary.
+
+### OK shape
+
+```text
+OK: doc-review
+```
+
+### NEEDS_ATTENTION shape
+
+```text
+NEEDS_ATTENTION: doc-review
+  branch:        <branch or omitted>
+  pr:            <owner/repo#number (url) or omitted>
+  commit:        <sha or omitted>
+  review_thread: <thread/comment id or omitted>
+  follow_up:     Re-run documentation review for the listed PR before close.
+```
+
+Each artifact line is emitted only when its source reference is present in
+context. Absent references are omitted entirely; the checkpoint never prints a
+placeholder, never errors on an unset variable, and never fabricates a value.
+
+---
+
+## Durable Artifact References
+
+The checkpoint surfaces an allow-listed set of non-sensitive metadata
+references. Each is read through a guarded expansion (`${VAR:-}` with fallback
+chains) so missing references are skipped, not fatal. Context outputs reach the
+bash step as flattened, upper-cased environment variables, following the same
+convention the runner already uses for `worktree_setup.worktree_path` →
+`WORKTREE_SETUP_WORKTREE_PATH` (see `default-workflow.yaml`).
+
+| Reference | Source variable (with fallbacks) | Example | Notes |
+| --- | --- | --- | --- |
+| `branch` | `${BRANCH_NAME:-${WORKTREE_SETUP_BRANCH:-}}` | `feat/issue-834-non-fatal-doc-review` | Recovery/working branch name. `branch_name` is a declared `default-workflow` output; `worktree_setup.branch` is the step-04 fallback. |
+| `pr` | `${PR_URL:-}` / `${PR_NUMBER:-}` | `rysweet/amplihack-rs#841` + URL | PR url and/or number when a PR was opened or merged in this or a prior round. |
+| `commit` | `${COMMIT_SHA:-${HEAD_SHA:-}}` | `8fb46865fb4412038b9313a62c02cc5aa0693132` | Pushed commit sha. |
+| `review_thread` | `${REVIEW_THREAD_ID:-${REVIEW_COMMENT_ID:-}}` | `1987654321` | Posted review thread or comment id. |
+
+The review feedback itself is read from `${DOC_REVIEW_FEEDBACK:-}` (the
+`output: doc_review_feedback` from `step-06b`).
+
+Every reference is optional. A fresh round typically has only `branch` (from
+`worktree_setup`) populated at this point; `pr`, `commit`, and `review_thread`
+are present mainly on a resumed round where a prior round already pushed and
+published. Each guarded expansion defaults to empty, so any reference not yet in
+context is omitted rather than printed blank or treated as an error.
+
+Only this allow list is surfaced. Arbitrary `RECIPE_VAR_*` values are not echoed
+wholesale. No tokens, `GITHUB_TOKEN`, or environment/`set` dumps are printed.
+
+---
+
+## Summary Markers
+
+Two fixed markers express run state:
+
+| Marker | Stream | Meaning |
+| --- | --- | --- |
+| `WARNING:` | stderr | Human-facing diagnostic naming the failed step and reason. |
+| `NEEDS_ATTENTION:` | stdout (summary) | Machine-consumable follow-up flag with the artifact references. |
+| `OK:` | stdout (summary) | Documentation review succeeded; no follow-up required. |
+
+A degraded-success run is identified by the presence of `NEEDS_ATTENTION:
+doc-review` in the summary alongside the normal evidence of completed
+implementation, verification, and PR work.
+
+---
+
+## Propagation Through default-workflow and smart-orchestrator
+
+```text
+smart-orchestrator
+  └─ default-workflow
+       └─ workflow-design
+            ├─ step-06b-documentation-review     (continue_on_error: true)
+            ├─ step-06c-documentation-refinement (continue_on_error: true)
+            ├─ step-06b-checkpoint-doc-review    (output: doc_review_checkpoint)
+            └─ step-06d-goal-already-met-probe
+```
+
+The checkpoint runs after refinement (`step-06c`) and before the goal probe
+(`step-06d`), even though its id carries the `06b` semantic prefix.
+
+Because `continue_on_error: true` stops the failure from propagating, the parent
+recipes reach their reconciliation/summary phase. The `doc_review_checkpoint`
+output flows up so the top-level summary lists the degraded-success detail. No
+change to `default-workflow.yaml` or `smart-orchestrator.yaml` is needed.
+
+---
+
+## Security Invariants
+
+The checkpoint step enforces these invariants:
+
+- **SR1** — No `eval`, `source`, or dynamic command construction. `${!var}`,
+  `${var@P}`, and chained-substitution constructs are rejected.
+- **SR2** — Every expansion is double-quoted (`"$DOC_FEEDBACK"`, `"$PR_URL"`).
+- **SR3** — Untrusted feedback and refs are printed with `printf '%s' "$X"`,
+  never `printf "$X"` or `echo $X`, to prevent format-string injection.
+- **SR4** — `set -uo pipefail` without `-e`; the step exits `0` structurally.
+- **SR5** — Feedback is consumed only as data via `printf '%s' ... | grep`.
+  Verbatim feedback is never interpolated into the summary, preventing marker
+  spoofing.
+- **SR6** — No secret leakage. Tokens, `GITHUB_TOKEN`, and env/`set` dumps are
+  never printed. Surfaced refs are non-sensitive metadata only.
+- **SR7** — Allow-list refs only; arbitrary `RECIPE_VAR_*` values are not echoed.
+- **SR8** — stderr (the `WARNING` diagnostic) and stdout (the machine-consumed
+  `output`) are kept separate.
+
+---
+
+## Scope and Non-Goals
+
+| In scope | Out of scope |
+| --- | --- |
+| Softening the post-side-effect doc-review failure path. | Changing documentation review logic. |
+| Surfacing durable artifact refs in the summary. | Relaxing terminal-state / finalization gates (stay fail-closed). |
+| Emitting `WARNING` + `NEEDS_ATTENTION` markers. | Softening pre-side-effect failures (no completed work to protect). |
+| YAML-only change to `workflow-design.yaml`. | Any Rust, dependency, or `Cargo.toml` version change. |
+
+The workspace version stays `0.11.1`; `--locked` CI is unaffected.
+
+---
+
+## See Also
+
+- [Non-fatal documentation review checkpoint overview](../features/doc-review-non-fatal-checkpoint.md)
+- [How to configure the documentation-review checkpoint](../howto/configure-doc-review-checkpoint.md)
+- [Tutorial: degraded-success after a failed doc review](../tutorials/doc-review-non-fatal-checkpoint.md)

--- a/docs/tutorials/doc-review-non-fatal-checkpoint.md
+++ b/docs/tutorials/doc-review-non-fatal-checkpoint.md
@@ -1,0 +1,135 @@
+# Tutorial: Degraded-Success After a Failed Documentation Review
+
+> [Home](../index.md) > Tutorials > Degraded-Success After a Failed Documentation Review
+
+This walkthrough reproduces the scenario from issue
+[#834](https://github.com/rysweet/amplihack-rs/issues/834): a round that has
+already pushed a commit, opened a PR, and posted a review thread, but whose
+`step-06b-documentation-review` then fails. You will see the workflow end in a
+clearly-labelled degraded-success state instead of a generic `FAILURE`.
+
+---
+
+## What You Will Learn
+
+- Why a documentation-review failure used to hide completed work.
+- How the checkpoint converts that failure into a visible follow-up.
+- How to read and resolve the `NEEDS_ATTENTION: doc-review` marker.
+
+---
+
+## Step 1: Start a Run That Produces Durable Side Effects
+
+Run `default-workflow` on a task that implements and documents a feature:
+
+```bash
+amplihack recipe run default-workflow \
+  -c "task_description=Add a token-bucket rate limiter and document it" \
+  -c "repo_path=/home/user/src/amplihack-rs" \
+  -c "branch_prefix=feat"
+```
+
+By the time the workflow reaches the documentation phase, earlier steps have
+typically produced durable output for the round:
+
+- a working branch, for example `feat/issue-834-non-fatal-doc-review`,
+- a pushed commit, for example `8fb46865...`,
+- an opened or merged PR, for example `rysweet/amplihack-rs#841`,
+- a posted review thread, for example `1987654321`.
+
+---
+
+## Step 2: Observe the Documentation-Review Failure
+
+Suppose `step-06b-documentation-review` exits non-zero (the architect agent
+errored, or the feedback came back empty).
+
+Before #834, the run stopped here with a generic hard failure. The completed
+commit, PR, and review thread were invisible in the result, and you had to
+reconcile by hand.
+
+With the checkpoint, the run does **not** abort. `continue_on_error: true` on
+the review step records the failure and lets the workflow continue.
+
+---
+
+## Step 3: Read the Checkpoint Output
+
+The follow-on checkpoint step inspects the review feedback, sees it failed, and
+emits a `WARNING` to stderr plus a `NEEDS_ATTENTION` summary to stdout:
+
+```text
+WARNING: step-06b-documentation-review exited non-zero (review reported failure).
+NEEDS_ATTENTION: doc-review
+  branch:        feat/issue-834-non-fatal-doc-review
+  pr:            rysweet/amplihack-rs#841 (https://github.com/rysweet/amplihack-rs/pull/841)
+  commit:        8fb46865fb4412038b9313a62c02cc5aa0693132
+  review_thread: 1987654321
+  follow_up:     Re-run documentation review for the listed PR before close.
+```
+
+Inspect just the checkpoint output with the CLI:
+
+```bash
+amplihack recipe run default-workflow \
+  -c task_description="Add a token-bucket rate limiter and document it" \
+  -c repo_path="/home/user/src/amplihack-rs" \
+  -c branch_prefix="feat" \
+  --output json | jq -r '.context.doc_review_checkpoint'
+```
+
+Every durable reference the workflow knew about is listed. Any reference that
+did not exist for this round is simply omitted — the checkpoint never prints a
+placeholder or fails on a missing value.
+
+---
+
+## Step 4: Confirm the Run Ended Degraded, Not Failed
+
+The run reaches its reconciliation/summary phase. The summary lists:
+
+- what succeeded: the branch, commit, PR, and review thread, and
+- what needs follow-up: the `NEEDS_ATTENTION: doc-review` item.
+
+This is the degraded-success state. The completed implementation, verification,
+and PR work are intact and visible; only the documentation quality signal is
+outstanding.
+
+---
+
+## Step 5: Resolve the Follow-Up
+
+1. Open the PR under `pr:` (`rysweet/amplihack-rs#841`).
+2. Verify the commit under `commit:` is on the branch under `branch:`.
+3. Re-run documentation review for that PR.
+4. When review passes, resolve the review thread under `review_thread:` and
+   close the follow-up.
+
+You did not redo any implementation — you only cleared the documentation review.
+
+---
+
+## Step 6: Compare Against the Out-of-Scope Path
+
+To confirm the boundary, picture a failure that happens *before* any durable
+side effect — no commit, no PR, no review thread. There is no completed work to
+protect, so that path may still surface as a hard failure and is intentionally
+**not** softened by this feature. Terminal-state and finalization gates likewise
+remain fail-closed.
+
+---
+
+## What You Did
+
+You ran a workflow whose documentation review failed after durable work landed,
+saw the checkpoint preserve and surface that work as a degraded-success with a
+`NEEDS_ATTENTION` follow-up, and resolved the follow-up without redoing the
+implementation.
+
+---
+
+## Related Documentation
+
+- [Non-fatal documentation review checkpoint overview](../features/doc-review-non-fatal-checkpoint.md)
+- [How to configure the documentation-review checkpoint](../howto/configure-doc-review-checkpoint.md)
+- [Documentation-review checkpoint reference](../reference/doc-review-non-fatal-checkpoint.md)

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -223,6 +223,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "step-06-documentation",
     "step-06b-documentation-review",
     "step-06c-documentation-refinement",
+    "step-06b-checkpoint-doc-review",
     "step-06d-goal-already-met-probe",
     // Phase 3: workflow-tdd (steps 07-08c)
     "step-07-write-tests",


### PR DESCRIPTION
## Summary

Fixes #834 — a smart-orchestrator/default-workflow run reported overall **failure** when the `step-06b-documentation-review` agent step exited non-zero, even though earlier steps had already produced durable, useful output (pushed commits, merged PRs, posted review threads). The generic failure obscured completed work and forced manual reconciliation.

## Change

`step-06b-documentation-review` in `amplifier-bundle/recipes/workflow-design.yaml` is now **non-fatal but reported**:

- A documentation-review failure after durable side effects no longer hard-fails the parent workflow.
- The step is structurally non-fatal (`set -uo pipefail` without `-e`; never `exit 1`).
- The failure is surfaced as a **NEEDS_ATTENTION** warning in the summary with the durable artifact references (branch, PR, thread, commit) preserved — not silently swallowed.
- The workflow ends in a degraded-success/partial state that clearly lists what succeeded and what needs follow-up.

## Tests

`amplifier-bundle/recipes/tests/test-bug-834-doc-review-non-fatal.sh` — 13/13 contract assertions pass (structurally non-fatal, no eval/source/indirect-expansion, no token dumping, etc.).

## Docs

Added feature/how-to/reference/tutorial docs for the non-fatal checkpoint behavior.

Note: no Rust changes; workspace version untouched (0.11.1).

Closes #834