### PR TITLE
fix(recipes): gracefully degrade missing runtime-artifact helper at post-side-effect checkpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Recipes — static guard validation scope (issue #495)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-static-guard-validation-scope.sh
+      - name: Recipes — graceful degradation for missing runtime-artifact helper (issue #829)
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-bug-829-graceful-degradation.sh
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,23 @@ Unreleased changes appear at the top under `[Unreleased]`.
   failures. New "Known Failure Points" section in `amplihack-expert/SKILL.md`
   documents rate-limit resilience patterns.
 
+- **Recipes hard-fail at post-side-effect checkpoints when the
+  runtime-artifact helper is missing (#829)** — The path-resolution fix in
+  #818/v0.11.42 corrected helper lookup upstream, but downstream consumers that
+  have not yet run `amplihack update` could still hit a missing
+  `workflow_runtime_artifacts.sh` at four *post-side-effect* bookkeeping
+  checkpoints (one in `workflow-tdd.yaml`, three in `workflow-finalize.yaml`).
+  These sites now **gracefully degrade**: when the helper cannot be resolved
+  they emit a `WARNING` to stderr (fail-visible — the searched roots, resolved
+  path, and `cwd` are reported) and continue, instead of `exit 2`. The
+  unconditional `artifact-guard --mode pre-publish` gate after each block is
+  preserved, and all genuine pre-publish gates (the four runtime-artifact
+  `exit 2` gates in `workflow-publish`/`workflow-refactor-review`/
+  `workflow-pr-review`, git-identity `exit 2`, and final-status `exit 1`) remain
+  hard failures. Covered by `test-bug-829-graceful-degradation.sh` (32
+  assertions across the four softened sites and the retained hard gates), wired
+  into CI.
+
 ### Added
 
 - **Copilot `--remote` by default** — `amplihack copilot` now injects

--- a/amplifier-bundle/recipes/tests/test-bug-829-graceful-degradation.sh
+++ b/amplifier-bundle/recipes/tests/test-bug-829-graceful-degradation.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# test-bug-829-graceful-degradation.sh — regression test for issue #829.
+#
+# Bug (residual after #818): the runtime-artifact-helper preflight at
+# checkpoints that run AFTER durable side effects (implementation commit/push,
+# PR creation, push cleanup, final status) does `exit 2` when the helper is
+# missing from ALL search paths. This turns already-successful work
+# (implementation + verification + branch push + PR) into an apparent failure
+# requiring manual reconciliation.
+#
+# #818 (path-resolution hardening) is NOT re-done here. This fix only softens
+# the *missing-helper* case at post-durable-side-effect checkpoints from a hard
+# `exit 2` into a WARNING + degraded-continue that names the searched paths and
+# the current working directory (cwd=).
+#
+# Contracts under test:
+#   A. Softened sites (post-durable-side-effect) MUST, in the missing-helper
+#      branch, emit a WARNING (not ERROR), include `cwd=`, and NOT `exit 2`:
+#        - workflow-tdd.yaml      :: checkpoint-after-implementation
+#        - workflow-finalize.yaml :: step-20a-artifact-guard
+#        - workflow-finalize.yaml :: step-20b-push-cleanup
+#        - workflow-finalize.yaml :: step-22b-final-status
+#   B. Each softened site MUST still source + run the preflight enrichment in
+#      the helper-PRESENT branch (degrade only the missing case).
+#   C. Pre-publish GATE sites (run BEFORE durable side effects) MUST retain the
+#      hard `exit 2` on missing helper:
+#        - workflow-publish.yaml       (2 sites)
+#        - workflow-refactor-review.yaml (1 site)
+#        - workflow-pr-review.yaml     (1 site)
+#      => exactly 4 retained runtime-artifact `exit 2` gates.
+#   D. Durable-work guards MUST remain intact at the softened sites:
+#        - `amplihack hygiene artifact-guard` call preserved (tdd checkpoint,
+#          finalize 20a, finalize 20b).
+#        - git-identity helper retains its own `exit 2`.
+#        - final-status helper retains its own `exit 1`.
+#
+# This test SHOULD FAIL before the #829 fix lands (sites still `exit 2`).
+# It MUST PASS once the four sites are softened.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-bug-829-graceful-degradation.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+RECIPES="${REPO_ROOT}/amplifier-bundle/recipes"
+
+TDD="${RECIPES}/workflow-tdd.yaml"
+FINALIZE="${RECIPES}/workflow-finalize.yaml"
+PUBLISH="${RECIPES}/workflow-publish.yaml"
+REFACTOR_REVIEW="${RECIPES}/workflow-refactor-review.yaml"
+PR_REVIEW="${RECIPES}/workflow-pr-review.yaml"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo "  PASS[$1]: $2"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  FAIL[$1]: $2" >&2; }
+
+for f in "${TDD}" "${FINALIZE}" "${PUBLISH}" "${REFACTOR_REVIEW}" "${PR_REVIEW}"; do
+    if [[ ! -f "${f}" ]]; then
+        echo "HARNESS-ERROR: required recipe not found: ${f}" >&2
+        exit 2
+    fi
+done
+
+# extract_step <file> <step-id>
+# Prints the contiguous block from the matching `- id: "<step-id>"` line up to
+# (but not including) the next top-level `  - id:` step marker.
+extract_step() {
+    local file="$1" step_id="$2"
+    awk -v target="${step_id}" '
+        BEGIN { inblk = 0 }
+        /^[[:space:]]*-[[:space:]]+id:[[:space:]]*"/ {
+            line = $0
+            sub(/^[[:space:]]*-[[:space:]]+id:[[:space:]]*"/, "", line)
+            sub(/".*$/, "", line)
+            if (line == target) { inblk = 1; print; next }
+            else if (inblk) { inblk = 0 }
+        }
+        inblk { print }
+    ' "${file}"
+}
+
+echo "=== Bug #829: graceful degradation for missing runtime-artifact helper ==="
+
+# ---------------------------------------------------------------------------
+# Contract A + B: softened sites.
+# For each (file, step), the helper-not-found line MUST be a WARNING with cwd=,
+# MUST NOT carry `exit 2`, AND the present-branch MUST still source + preflight.
+# ---------------------------------------------------------------------------
+assert_softened() {
+    local label="$1" file="$2" step="$3"
+    local block
+    block="$(extract_step "${file}" "${step}")"
+
+    if [[ -z "${block}" ]]; then
+        fail "${label}:block" "could not extract step '${step}' from $(basename "${file}")"
+        return
+    fi
+
+    # The line that announces the missing helper.
+    local helper_line
+    helper_line="$(printf '%s\n' "${block}" \
+        | grep -E 'workflow runtime artifact helper not found' || true)"
+
+    if [[ -z "${helper_line}" ]]; then
+        fail "${label}:present" "step '${step}' no longer references the runtime-artifact helper at all"
+        return
+    fi
+
+    # A1: WARNING, not ERROR, on the missing-helper line.
+    if printf '%s\n' "${helper_line}" | grep -qE 'WARNING' \
+       && ! printf '%s\n' "${helper_line}" | grep -qE 'ERROR'; then
+        pass "${label}:warn" "missing-helper branch warns (not errors)"
+    else
+        fail "${label}:warn" "missing-helper branch still ERRORs instead of WARNING: ${helper_line}"
+    fi
+
+    # A2: includes cwd= (issue #829 explicit ask: report cwd).
+    if printf '%s\n' "${helper_line}" | grep -qE 'cwd='; then
+        pass "${label}:cwd" "missing-helper WARNING reports cwd="
+    else
+        fail "${label}:cwd" "missing-helper WARNING does not report cwd=: ${helper_line}"
+    fi
+
+    # A3: names the searched paths (diagnosis aid).
+    if printf '%s\n' "${helper_line}" | grep -qE 'searched'; then
+        pass "${label}:paths" "missing-helper WARNING names searched paths"
+    else
+        fail "${label}:paths" "missing-helper WARNING does not name searched paths: ${helper_line}"
+    fi
+
+    # A4: the missing-helper branch MUST NOT abort with `exit 2`.
+    if printf '%s\n' "${helper_line}" | grep -qE 'exit[[:space:]]+2'; then
+        fail "${label}:no-exit2" "missing-helper branch still hard-aborts with exit 2"
+    else
+        pass "${label}:no-exit2" "missing-helper branch does not exit 2"
+    fi
+
+    # B: present branch still sources + runs preflight enrichment.
+    if printf '%s\n' "${block}" | grep -qE 'preflight_known_workflow_runtime_artifacts'; then
+        pass "${label}:preflight" "present branch still runs preflight enrichment"
+    else
+        fail "${label}:preflight" "present branch dropped preflight enrichment"
+    fi
+}
+
+assert_softened "A-tdd"        "${TDD}"      "checkpoint-after-implementation"
+assert_softened "A-fin20a"     "${FINALIZE}" "step-20a-artifact-guard"
+assert_softened "A-fin20b"     "${FINALIZE}" "step-20b-push-cleanup"
+assert_softened "A-fin22b"     "${FINALIZE}" "step-22b-final-status"
+
+# ---------------------------------------------------------------------------
+# Contract C: pre-publish GATE sites retain exit 2 on missing helper.
+# Count runtime-artifact helper-not-found `exit 2` gates across gate recipes.
+# Expected: publish(2) + refactor-review(1) + pr-review(1) = 4.
+# ---------------------------------------------------------------------------
+count_gate_exit2() {
+    # Count lines that both reference the missing helper AND `exit 2`.
+    grep -E 'workflow runtime artifact helper not found' "$1" 2>/dev/null \
+        | grep -cE 'exit[[:space:]]+2' || true
+}
+
+publish_gates=$(count_gate_exit2 "${PUBLISH}")
+refactor_gates=$(count_gate_exit2 "${REFACTOR_REVIEW}")
+prreview_gates=$(count_gate_exit2 "${PR_REVIEW}")
+total_gates=$((publish_gates + refactor_gates + prreview_gates))
+
+if [[ "${publish_gates}" -eq 2 ]]; then
+    pass "C-publish" "workflow-publish.yaml retains 2 pre-publish exit-2 gates"
+else
+    fail "C-publish" "workflow-publish.yaml has ${publish_gates} exit-2 gates (expected 2)"
+fi
+if [[ "${refactor_gates}" -eq 1 ]]; then
+    pass "C-refactor" "workflow-refactor-review.yaml retains 1 pre-publish exit-2 gate"
+else
+    fail "C-refactor" "workflow-refactor-review.yaml has ${refactor_gates} exit-2 gates (expected 1)"
+fi
+if [[ "${prreview_gates}" -eq 1 ]]; then
+    pass "C-prreview" "workflow-pr-review.yaml retains 1 pre-publish exit-2 gate"
+else
+    fail "C-prreview" "workflow-pr-review.yaml has ${prreview_gates} exit-2 gates (expected 1)"
+fi
+if [[ "${total_gates}" -eq 4 ]]; then
+    pass "C-total" "exactly 4 pre-publish runtime-artifact exit-2 gates retained"
+else
+    fail "C-total" "found ${total_gates} pre-publish exit-2 gates (expected 4) — a gate may have been softened by mistake"
+fi
+
+# ---------------------------------------------------------------------------
+# Contract C2: softened files MUST have ZERO runtime-artifact exit-2 gates left.
+# ---------------------------------------------------------------------------
+tdd_gates=$(count_gate_exit2 "${TDD}")
+fin_gates=$(count_gate_exit2 "${FINALIZE}")
+if [[ "${tdd_gates}" -eq 0 ]]; then
+    pass "C2-tdd" "workflow-tdd.yaml has no runtime-artifact exit-2 gate"
+else
+    fail "C2-tdd" "workflow-tdd.yaml still has ${tdd_gates} runtime-artifact exit-2 gate(s)"
+fi
+if [[ "${fin_gates}" -eq 0 ]]; then
+    pass "C2-fin" "workflow-finalize.yaml has no runtime-artifact exit-2 gate"
+else
+    fail "C2-fin" "workflow-finalize.yaml still has ${fin_gates} runtime-artifact exit-2 gate(s)"
+fi
+
+# ---------------------------------------------------------------------------
+# Contract D: durable-work guards remain intact at softened sites.
+# ---------------------------------------------------------------------------
+assert_contains() {
+    local label="$1" file="$2" step="$3" pattern="$4" desc="$5"
+    local block
+    block="$(extract_step "${file}" "${step}")"
+    if printf '%s\n' "${block}" | grep -qE "${pattern}"; then
+        pass "${label}" "${desc}"
+    else
+        fail "${label}" "${desc} — MISSING in ${step}"
+    fi
+}
+
+# D1: artifact-guard call preserved where it was present.
+assert_contains "D-guard-tdd"  "${TDD}"      "checkpoint-after-implementation" \
+    'amplihack hygiene artifact-guard' "tdd checkpoint keeps artifact-guard call"
+assert_contains "D-guard-20a"  "${FINALIZE}" "step-20a-artifact-guard" \
+    'amplihack hygiene artifact-guard' "finalize 20a keeps artifact-guard call"
+assert_contains "D-guard-20b"  "${FINALIZE}" "step-20b-push-cleanup" \
+    'amplihack hygiene artifact-guard' "finalize 20b keeps artifact-guard call"
+
+# D2: git-identity helper retains its own exit 2.
+assert_contains "D-gitid-tdd"  "${TDD}"      "checkpoint-after-implementation" \
+    'git identity helper not found.*exit[[:space:]]+2' "tdd checkpoint keeps git-identity exit-2"
+assert_contains "D-gitid-20b"  "${FINALIZE}" "step-20b-push-cleanup" \
+    'git identity helper not found.*exit[[:space:]]+2' "finalize 20b keeps git-identity exit-2"
+
+# D3: final-status helper retains its own exit 1.
+assert_contains "D-final-22b"  "${FINALIZE}" "step-22b-final-status" \
+    'final-status helper not found.*exit[[:space:]]+1' "finalize 22b keeps final-status exit-1"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ---"
+
+if [[ ${FAIL_COUNT} -gt 0 ]]; then
+    exit 1
+fi
+
+echo "PASS: Bug #829 — missing runtime-artifact helper degrades gracefully at post-side-effect checkpoints."
+exit 0

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -80,7 +80,7 @@ steps:
         cd "$REPO_PATH"
       fi
       RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }; . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .
+      if [ -f "$RUNTIME_ARTIFACT_HELPER" ]; then . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .; else echo "WARNING: workflow runtime artifact helper not found; skipping artifact preflight enrichment and continuing in degraded mode (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER; cwd=$(pwd)" >&2; fi
       amplihack hygiene artifact-guard --repo . --mode pre-publish
 
   - id: "step-20b-push-cleanup"
@@ -114,7 +114,7 @@ steps:
         exit 1
       fi
       RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }; . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .
+      if [ -f "$RUNTIME_ARTIFACT_HELPER" ]; then . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .; else echo "WARNING: workflow runtime artifact helper not found; skipping artifact preflight enrichment and continuing in degraded mode (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER; cwd=$(pwd)" >&2; fi
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)
@@ -258,7 +258,7 @@ steps:
       PR_URL="${PR_URL:-${PR_PUBLISH_RESULT_PR_URL:-${RECIPE_VAR_pr_publish_result__pr_url:-}}}"
       if [ -z "$PR_URL" ]; then : "N/A"; fi
       RUNTIME_ARTIFACT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/workflow_runtime_artifacts.sh"; [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }; . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .
+      if [ -f "$RUNTIME_ARTIFACT_HELPER" ]; then . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .; else echo "WARNING: workflow runtime artifact helper not found; skipping artifact preflight enrichment and continuing in degraded mode (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER; cwd=$(pwd)" >&2; fi
       # Helper contract: git diff --quiet identifies no-diff; terminal_status accepts no-diff, already-merged, and closed-after-merge; GitHub-only status uses gh pr view.
       # Terminal-state contract: FAILED_CLOSED_UNMERGED, FAILED_MEANINGFUL_DIFF, BLOCKED_CI, MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED.
       FINAL_STATUS_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_final_status.sh"

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -344,7 +344,7 @@ steps:
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] || RUNTIME_ARTIFACT_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/workflow_runtime_artifacts.sh"
-      [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }; . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .
+      if [ -f "$RUNTIME_ARTIFACT_HELPER" ]; then . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .; else echo "WARNING: workflow runtime artifact helper not found; skipping artifact preflight enrichment and continuing in degraded mode (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER; cwd=$(pwd)" >&2; fi
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       STAGED=$(git diff --cached --name-only)


### PR DESCRIPTION
## Summary

Residual fix for #829. The **path-resolution** half was already fixed by #818 (shipped in v0.11.42) — environments hitting the *old* error just need `amplihack update`. This PR adds the missing **graceful-degradation** safety net.

## Problem

When `workflow_runtime_artifacts.sh` is genuinely absent from *all* search paths (`AMPLIHACK_HOME`, `REPO_PATH`, cwd, `~/.copilot`, `~/.amplihack`), the `checkpoint-after-implementation` step did `exit 2` — hard-failing the whole workflow **after** implementation, verification, branch push, and PR creation had already completed. That turned successful work into an apparent failure requiring manual reconciliation.

## Change

At post-durable-side-effect checkpoints (`workflow-tdd.yaml`, `workflow-finalize.yaml`), a missing runtime-artifact helper now:

- emits a clear **WARNING** that names the searched paths **and the current cwd** (the issue explicitly asked for this: "report the resolved bundle path and cwd"),
- **continues** the checkpoint in degraded mode (git add/commit/push + PR bookkeeping still run),
- only the artifact-preflight enrichment is skipped.

Required behavior is preserved: the `amplihack hygiene artifact-guard` pre-publish call and the git-identity helper still hard-fail when genuinely broken (verified by tests).

## Tests

`amplifier-bundle/recipes/tests/test-bug-829-graceful-degradation.sh` — 32/32 assertions pass, including guards that the artifact-guard and git-identity exit codes are unchanged.

Note: no Rust changes; workspace version untouched (0.11.1).

Closes #829