### PR TITLE
chore(build): cut debuginfo on dev/test profiles to shrink target/

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,19 @@ amplihack-domain-agents = { path = "crates/amplihack-domain-agents" }
 amplihack-hive = { path = "crates/amplihack-hive" }
 amplihack-agent-generator = { path = "crates/amplihack-agent-generator" }
 
+# Shrink local/dev/CI debug builds. This workspace has 26 crates and ~155
+# integration-test binaries; the default `debug = true` emits full DWARF
+# debuginfo into every rlib and every statically-linked test binary, which
+# balloons `target/` to tens of GB (each worktree gets its own copy).
+# `line-tables-only` keeps file:line in panic backtraces while dropping the
+# bulk of the debuginfo, cutting target size roughly in half with no loss of
+# usable backtraces.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"
+
 [profile.release]
 lto = true
 strip = true


### PR DESCRIPTION
## Problem

This workspace has **26 crates and ~155 integration-test binaries**. The default `dev`/`test` profile emits **full DWARF debuginfo** into every rlib and every statically-linked test binary, ballooning `target/` to **~29 GB**. Because each `default-workflow` run creates its own worktree with its own `target/`, this repeatedly exhausted disk during parallel/iterative runs.

## Change

Set `dev`/`test` `debug = "line-tables-only"`:

```toml
[profile.dev]
debug = "line-tables-only"

[profile.test]
debug = "line-tables-only"
```

`line-tables-only` keeps **file:line in panic backtraces** while dropping the bulk of the debuginfo — roughly halves `target/` size with no loss of usable backtraces. The `release` profile is unchanged.

## Validation

- `cargo metadata` parses the new profiles.
- Pre-commit `cargo fmt --check` + `cargo clippy -- -D warnings` pass (compiles cleanly under the new profile).

## Follow-up (not in this PR)

The structural multiplier is N worktrees × one `target/` each. Options for a future change: a shared `CARGO_TARGET_DIR` for worktrees (cargo's build lock serializes safely), and/or running `amplihack hygiene cleanup --cargo-targets` to reap stale worktree targets after merge.