### PR TITLE
fix(hooks): redirect Skill calls naming an agent to the agent interface (#838)

### DIFF
--- a/crates/amplihack-hooks/src/known_agents.rs
+++ b/crates/amplihack-hooks/src/known_agents.rs
@@ -1,0 +1,206 @@
+//! Known amplihack agent names.
+//!
+//! Provides a compile-time set of all built-in agent names and a fast
+//! membership check via `is_amplihack_agent()`.
+//!
+//! This registry mirrors `known_skills.rs` but tracks *agents* — the
+//! `amplifier-bundle/agents/**/*.md` definitions that are invoked via the
+//! agent/Task runtime interface rather than the Skill tool. It exists so the
+//! pre-tool-use hook can detect when a `Skill` invocation names something that
+//! is actually an agent (e.g. `prompt-writer`) and redirect the model to the
+//! correct interface instead of letting the copilot runtime hard-fail with
+//! "Skill not found" (issue #838).
+
+/// All built-in amplihack agent names. Keep sorted for `binary_search`.
+///
+/// Derived from the unique `.md` basenames under `amplifier-bundle/agents/`
+/// (the `guide` basename appears under both `agents/` and `agents/core/` and is
+/// deduped to a single entry). The `registry_matches_bundled_agent_files` test
+/// fails the build if this list drifts from the bundled agent definitions.
+static AMPLIHACK_AGENTS: &[&str] = &[
+    "ambiguity",
+    "amplifier-cli-architect",
+    "amplihack-improvement-workflow",
+    "analyzer",
+    "api-designer",
+    "architect",
+    "azure-kubernetes-expert",
+    "builder",
+    "ci-diagnostic-workflow",
+    "cleanup",
+    "concept-extractor",
+    "database",
+    "documentation-writer",
+    "fallback-cascade",
+    "fix-agent",
+    "gherkin-expert",
+    "guide",
+    "iac-planner",
+    "insight-synthesizer",
+    "integration",
+    "knowledge-archaeologist",
+    "mcp-server-builder",
+    "multi-agent-debate",
+    "n-version-validator",
+    "openapi-scaffolder",
+    "optimizer",
+    "patterns",
+    "philosophy-guardian",
+    "pre-commit-diagnostic",
+    "preference-reviewer",
+    "prompt-review-workflow",
+    "prompt-writer",
+    "reviewer",
+    "rust-programming-expert",
+    "security",
+    "socratic-reviewer",
+    "tester",
+    "tla-plus-expert",
+    "visualization-architect",
+    "worktree-manager",
+    "xpia-defense",
+];
+
+/// Check whether `name` is a known amplihack agent.
+pub fn is_amplihack_agent(name: &str) -> bool {
+    AMPLIHACK_AGENTS.binary_search(&name).is_ok()
+}
+
+/// Return the total number of known agents.
+pub fn agent_count() -> usize {
+    AMPLIHACK_AGENTS.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_agent_is_recognised() {
+        // The agent at the heart of issue #838.
+        assert!(is_amplihack_agent("prompt-writer"));
+        // A handful of other agents drawn from the three subdirectories.
+        assert!(is_amplihack_agent("architect"));
+        assert!(is_amplihack_agent("builder"));
+        assert!(is_amplihack_agent("ambiguity"));
+        assert!(is_amplihack_agent("amplihack-improvement-workflow"));
+    }
+
+    #[test]
+    fn unknown_agent_is_rejected() {
+        assert!(!is_amplihack_agent("nonexistent-agent"));
+        assert!(!is_amplihack_agent(""));
+        assert!(!is_amplihack_agent("PROMPT-WRITER")); // case-sensitive
+    }
+
+    #[test]
+    fn agent_only_names_are_not_confused_with_skill_only_names() {
+        // `prompt-writer` and `guide` exist *only* as agents (no SKILL.md),
+        // so they must be present in this registry.
+        assert!(is_amplihack_agent("prompt-writer"));
+        assert!(is_amplihack_agent("guide"));
+
+        // `default-workflow` is a skill, not an agent, so it must be absent.
+        assert!(!is_amplihack_agent("default-workflow"));
+        assert!(!is_amplihack_agent("pdf"));
+    }
+
+    #[test]
+    fn dual_skill_and_agent_names_are_present() {
+        // `gherkin-expert` and `tla-plus-expert` exist as BOTH a skill and an
+        // agent. They must still appear in the agent registry; the redirect
+        // guard in `pre_tool_use` resolves the overlap by giving skills
+        // precedence.
+        assert!(is_amplihack_agent("gherkin-expert"));
+        assert!(is_amplihack_agent("tla-plus-expert"));
+    }
+
+    #[test]
+    fn agent_count_matches_unique_bundled_agents() {
+        // 42 agent `.md` files, but `guide` is duplicated across
+        // `agents/` and `agents/core/`, leaving 41 unique names.
+        assert_eq!(agent_count(), 41);
+    }
+
+    #[test]
+    fn all_agents_are_kebab_case() {
+        for agent in AMPLIHACK_AGENTS.iter() {
+            assert!(
+                agent
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c == '-' || c.is_ascii_digit()),
+                "unexpected characters in agent name: {agent}"
+            );
+        }
+    }
+
+    #[test]
+    fn agents_are_sorted_for_binary_search() {
+        for pair in AMPLIHACK_AGENTS.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "agent list must stay sorted: {} before {}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn no_duplicate_agent_names() {
+        use std::collections::BTreeSet;
+        let unique: BTreeSet<_> = AMPLIHACK_AGENTS.iter().collect();
+        assert_eq!(
+            unique.len(),
+            AMPLIHACK_AGENTS.len(),
+            "agent registry must not contain duplicates"
+        );
+    }
+
+    /// Compile-time-style consistency check: the registry must exactly match
+    /// the set of unique agent `.md` basenames bundled under
+    /// `amplifier-bundle/agents/`. This fails the build when an agent is added,
+    /// removed, or renamed without updating the registry (registry drift).
+    #[test]
+    fn registry_matches_bundled_agent_files() {
+        use std::collections::BTreeSet;
+        use std::fs;
+        use std::path::{Path, PathBuf};
+
+        fn collect_agent_files(dir: &Path, files: &mut Vec<PathBuf>) {
+            for entry in fs::read_dir(dir).expect("read bundled agents dir") {
+                let path = entry.expect("read bundled agents entry").path();
+                if path.is_dir() {
+                    collect_agent_files(&path, files);
+                } else if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+                    files.push(path);
+                }
+            }
+        }
+
+        let agents_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("amplifier-bundle/agents");
+        let mut agent_files = Vec::new();
+        collect_agent_files(&agents_dir, &mut agent_files);
+
+        let bundled: BTreeSet<_> = agent_files
+            .iter()
+            .map(|path| {
+                path.file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .expect("agent file basename")
+                    .to_string()
+            })
+            .collect();
+        let registered: BTreeSet<_> = AMPLIHACK_AGENTS
+            .iter()
+            .map(|agent| (*agent).to_string())
+            .collect();
+
+        assert_eq!(
+            bundled, registered,
+            "known agent registry must match bundled agent .md basenames"
+        );
+    }
+}

--- a/crates/amplihack-hooks/src/lib.rs
+++ b/crates/amplihack-hooks/src/lib.rs
@@ -37,6 +37,8 @@ pub mod issue_dedup;
 pub mod copilot_stop_handler;
 /// Hook file installation verification.
 pub mod hook_verification;
+/// Known amplihack agent name registry.
+pub mod known_agents;
 /// Known amplihack skill name registry.
 pub mod known_skills;
 /// Host-specific hook strategies (Claude, Copilot).

--- a/crates/amplihack-hooks/src/pre_tool_use/mod.rs
+++ b/crates/amplihack-hooks/src/pre_tool_use/mod.rs
@@ -74,6 +74,56 @@ For true emergencies, ask a human to override this protection.\n\
 \n\
 🔒 This protection cannot be disabled programmatically.";
 
+/// Guidance returned when a `Skill` invocation names an amplihack *agent*
+/// (e.g. `prompt-writer`) rather than a skill. Without this redirect the
+/// copilot runtime hard-fails with "Skill not found: <name>", silently
+/// skipping the step (issue #838). The `{name}` placeholder is replaced with
+/// the requested (sanitized) agent name.
+const SKILL_IS_AGENT_REDIRECT: &str = "\
+🔁 WRONG INTERFACE - '{name}' is an amplihack AGENT, not a skill.\n\
+\n\
+You invoked the Skill tool with name '{name}', but '{name}' is provided as an\n\
+agent, not a skill. Invoking it as a skill fails with \"Skill not found\" and\n\
+silently skips this step.\n\
+\n\
+✅ Instead, run '{name}' through the agent interface (the Task/agent tool),\n\
+e.g. reference it as an agent such as \"amplihack:{name}\".\n\
+\n\
+This redirect prevents the requirements-clarification phase from being skipped.";
+
+/// Detect a `Skill` invocation that names an agent rather than a skill and, if
+/// so, return a non-fatal block instructing the model to use the agent
+/// interface instead. Returns `None` (pass-through) for every other case:
+/// genuine skills, names that are both skill and agent (skills take
+/// precedence), unknown names, and malformed payloads.
+///
+/// Parsing is total and panic-free: a missing/non-string/null name simply
+/// passes through.
+fn check_skill_redirect(tool_name: &str, tool_input: &Value) -> Option<Value> {
+    if tool_name != "Skill" {
+        return None;
+    }
+
+    // Host payloads use either the `skill` key or the `name` key.
+    let name = tool_input
+        .get("skill")
+        .and_then(Value::as_str)
+        .or_else(|| tool_input.get("name").and_then(Value::as_str))?;
+
+    // Skills take precedence: only redirect agent-only names. This keeps
+    // overlapping names (e.g. gherkin-expert) resolving as skills.
+    if crate::known_skills::is_amplihack_skill(name)
+        || !crate::known_agents::is_amplihack_agent(name)
+    {
+        return None;
+    }
+
+    Some(serde_json::json!({
+        "block": true,
+        "message": SKILL_IS_AGENT_REDIRECT.replace("{name}", name)
+    }))
+}
+
 /// Strip leading env-variable assignments (`VAR=value ...`) and an optional
 /// `env` prefix so that `GIT_DIR=/x git commit` is normalized to `git commit`.
 fn normalize_command(command: &str) -> String {
@@ -157,6 +207,14 @@ impl Hook for PreToolUseHook {
 
         // XPIA security validation for all tools.
         if let Some(block) = xpia::check_xpia(&tool_name, &tool_input) {
+            return Ok(block);
+        }
+
+        // Issue #838: a Skill invocation that names an amplihack *agent* (not a
+        // skill) must be redirected to the agent interface rather than letting
+        // the runtime hard-fail with "Skill not found", which silently skips
+        // the step (e.g. the requirements-clarification phase).
+        if let Some(block) = check_skill_redirect(&tool_name, &tool_input) {
             return Ok(block);
         }
 

--- a/crates/amplihack-hooks/src/pre_tool_use/tests/pre_tool_use_tests.rs
+++ b/crates/amplihack-hooks/src/pre_tool_use/tests/pre_tool_use_tests.rs
@@ -186,3 +186,149 @@ fn normalize_strips_multiple_env_vars() {
 fn normalize_passthrough_plain_command() {
     assert_eq!(normalize_command("git commit -m 'x'"), "git commit -m 'x'");
 }
+
+// ---------------------------------------------------------------------------
+// Issue #838: Skill-tool invocation that names an *agent* must be redirected
+// to agent execution rather than letting the copilot runtime hard-fail with
+// "Skill not found: <agent>" (which silently skips the requirements
+// clarification phase of default-workflow).
+//
+// Behavior contract (verified through the public `process()` interface):
+//   * Skill(name) where name is an AGENT but NOT a skill  -> block + redirect.
+//   * Skill(name) where name is a real skill              -> pass-through.
+//   * Skill(name) where name is in BOTH (overlap)         -> pass-through
+//                                                            (skill precedence).
+//   * Skill(name) where name is unknown                   -> pass-through.
+//   * Malformed Skill payloads                            -> pass-through, no panic.
+// ---------------------------------------------------------------------------
+
+/// Build a `Skill` PreToolUse input using the primary `skill` key.
+fn make_skill_input(name: &str) -> HookInput {
+    HookInput::PreToolUse {
+        tool_name: "Skill".to_string(),
+        tool_input: serde_json::json!({"skill": name}),
+        session_id: None,
+    }
+}
+
+/// Build a `Skill` PreToolUse input using the alternate `name` key, which some
+/// host payloads use instead of `skill`.
+fn make_skill_input_name_key(name: &str) -> HookInput {
+    HookInput::PreToolUse {
+        tool_name: "Skill".to_string(),
+        tool_input: serde_json::json!({"name": name}),
+        session_id: None,
+    }
+}
+
+#[test]
+fn redirects_skill_call_naming_prompt_writer_agent() {
+    let hook = PreToolUseHook;
+    let result = hook.process(make_skill_input("prompt-writer")).unwrap();
+
+    // Must be a non-fatal block carrying a redirect message — NOT an empty
+    // pass-through (which would let the runtime emit "Skill not found").
+    assert_eq!(
+        result["block"], true,
+        "Skill(prompt-writer) must be blocked and redirected, got: {result}"
+    );
+    let message = result["message"]
+        .as_str()
+        .expect("redirect block must carry a message");
+    assert!(
+        message.contains("prompt-writer"),
+        "redirect message must name the agent: {message}"
+    );
+    assert!(
+        message.to_lowercase().contains("agent"),
+        "redirect message must point the model at the agent interface: {message}"
+    );
+}
+
+#[test]
+fn redirects_skill_call_using_name_key_payload() {
+    let hook = PreToolUseHook;
+    let result = hook
+        .process(make_skill_input_name_key("prompt-writer"))
+        .unwrap();
+    assert_eq!(
+        result["block"], true,
+        "Skill payload using the `name` key must also redirect: {result}"
+    );
+}
+
+#[test]
+fn redirects_skill_call_naming_guide_agent_only() {
+    // `guide` exists only as an agent (no SKILL.md), so it must redirect.
+    let hook = PreToolUseHook;
+    let result = hook.process(make_skill_input("guide")).unwrap();
+    assert_eq!(
+        result["block"], true,
+        "Skill(guide) must redirect because guide is agent-only: {result}"
+    );
+}
+
+#[test]
+fn does_not_redirect_real_skill() {
+    let hook = PreToolUseHook;
+    let result = hook.process(make_skill_input("default-workflow")).unwrap();
+    assert!(
+        result.as_object().unwrap().is_empty(),
+        "a genuine skill must pass through untouched: {result}"
+    );
+}
+
+#[test]
+fn does_not_redirect_overlapping_skill_and_agent_names() {
+    // gherkin-expert and tla-plus-expert are BOTH a skill and an agent.
+    // Skills take precedence, so these must pass through (resolve as skills).
+    let hook = PreToolUseHook;
+    for name in ["gherkin-expert", "tla-plus-expert"] {
+        let result = hook.process(make_skill_input(name)).unwrap();
+        assert!(
+            result.as_object().unwrap().is_empty(),
+            "overlapping name {name} must resolve as a skill (no redirect): {result}"
+        );
+    }
+}
+
+#[test]
+fn does_not_redirect_unknown_skill_name() {
+    // Unknown names are neither skill nor agent — let the runtime handle them
+    // normally rather than over-blocking.
+    let hook = PreToolUseHook;
+    let result = hook
+        .process(make_skill_input("totally-unknown-thing"))
+        .unwrap();
+    assert!(
+        result.as_object().unwrap().is_empty(),
+        "unknown names must pass through: {result}"
+    );
+}
+
+#[test]
+fn malformed_skill_payloads_pass_through_without_panic() {
+    let hook = PreToolUseHook;
+
+    let malformed = [
+        serde_json::json!({}),                     // missing key
+        serde_json::json!({"skill": 123}),         // non-string
+        serde_json::json!({"skill": null}),        // null
+        serde_json::json!({"name": ["nested"]}),   // array
+        serde_json::json!({"unrelated": "value"}), // wrong key
+        serde_json::json!({"skill": {"x": "y"}}),  // object value
+    ];
+
+    for payload in malformed {
+        let input = HookInput::PreToolUse {
+            tool_name: "Skill".to_string(),
+            tool_input: payload.clone(),
+            session_id: None,
+        };
+        let result = hook.process(input).unwrap();
+        assert!(
+            result.as_object().unwrap().is_empty(),
+            "malformed Skill payload must pass through: {payload}"
+        );
+    }
+}

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -41,6 +41,10 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 
 - [Best-Effort Mermaid CLI Provisioning](mermaid-cli-best-effort-install.md) — `amplihack install` provisions the Mermaid CLI (`mmdc`, npm `@mermaid-js/mermaid-cli`) on a best-effort basis so the `pr-guide` skill can render mermaid diagrams to images locally for Azure DevOps instead of relying on the third-party `mermaid.ink` service. A failed or skipped install warns and continues (never blocks install); disable entirely with `AMPLIHACK_SKIP_MMDC=1` (issue [#828](https://github.com/rysweet/amplihack-rs/issues/828)).
 
+## Workflow Guardrails
+
+- [Skill-to-Agent Redirect](skill-to-agent-redirect.md) — the `PreToolUse` hook intercepts a `Skill` call naming an agent-only target (for example `prompt-writer`), blocks it with a non-fatal redirect to agent execution, and prevents the copilot runtime's `Skill not found` abort from silently skipping the requirements-clarification phase (issue [#838](https://github.com/rysweet/amplihack-rs/issues/838)). See the [API reference](../reference/skill-agent-redirect-api.md).
+
 ## GitHub Distribution
 
 - [GitHub Distribution](github-distribution.md) — publish agent bundles to GitHub repositories via the `gh` CLI, with idempotent uploads, visibility control, and tagged releases.

--- a/docs/features/skill-to-agent-redirect.md
+++ b/docs/features/skill-to-agent-redirect.md
@@ -1,0 +1,122 @@
+# Skill-to-Agent Redirect
+
+**A PreToolUse guardrail that intercepts `Skill` invocations naming an agent-only target and redirects the model to agent execution instead of letting the runtime abort with `Skill not found`.**
+
+> [Home](../index.md) > [Features](README.md) > Skill-to-Agent Redirect
+
+## Quick Navigation
+
+- [Skill-to-Agent Redirect API reference](../reference/skill-agent-redirect-api.md)
+- [Hook specifications reference](../reference/hook-specifications.md)
+- [How to troubleshoot hooks](../howto/troubleshoot-hooks.md)
+
+---
+
+## What This Feature Does
+
+Some amplihack capabilities exist **only as agents** (for example `prompt-writer`), never as skills. During recipe-driven runs the model is sometimes nudged — by injected USER_PREFERENCES, the auto-intent-router reminder, or an agent system prompt — to reach a capability through the `Skill` tool. When the named target is not a registered skill, the copilot runtime's skill dispatcher logs:
+
+```
+skill(prompt-writer) Skill not found: prompt-writer
+```
+
+and the step is aborted. For `default-workflow` this silently degrades the **requirements-clarification phase**, which is supposed to run `prompt-writer` as an agent.
+
+The Skill-to-Agent Redirect closes that gap. The `PreToolUse` hook inspects every `Skill` call **before** the runtime can fail it. When the named target:
+
+- is **not** a known amplihack skill, **and**
+- **is** a known amplihack agent,
+
+the hook blocks the call and returns a clear, non-fatal redirect message instructing the model to invoke the capability through the agent/`Task` tool. The model self-corrects on the next turn, the requirements-clarification phase runs `prompt-writer` as an agent, and the workflow is never silently skipped or aborted.
+
+This is a general defense: it protects against *any* agent-only name being called as a skill, not just `prompt-writer`.
+
+---
+
+## How It Works
+
+```
+Skill(name="prompt-writer")
+        │
+        ▼
+┌─────────────────────────────────────────────┐
+│ PreToolUse hook                              │
+│  1. Launcher context injection (side effect) │
+│  2. XPIA security check                      │
+│  3. check_skill_redirect()  ◀── this feature │
+│        is_amplihack_skill(name)? ── yes ─▶ pass through (resolve as skill)
+│        is_amplihack_agent(name)? ── yes ─▶ BLOCK + redirect message
+│        otherwise ──────────────────────▶ pass through
+│  4. Bash-only checks (cwd, branch, ...)      │
+└─────────────────────────────────────────────┘
+        │
+        ▼ (block)
+{ "block": true, "message": "<redirect guidance>" }
+```
+
+Key properties:
+
+- **Skill precedence.** The redirect fires only when `!is_amplihack_skill(name) && is_amplihack_agent(name)`. Names that exist as **both** a skill and an agent (for example `gherkin-expert` and `tla-plus-expert`, which ship both a `SKILL.md` and an agent file) keep resolving as skills with no behavior change.
+- **Non-fatal.** The hook returns a `block` with guidance — it never panics, never aborts the run, and never deletes work. The model is told what to do instead.
+- **Compile-time registry.** Agent names are baked into the binary at build time via a sorted static slice; no filesystem access happens at runtime.
+- **Fail-open.** Consistent with the rest of `PreToolUse`, any parse or lookup failure passes the tool call through unchanged (`FailurePolicy::Open`).
+
+---
+
+## What the Model Sees
+
+When the redirect fires, the model receives a `block` response whose `message` is static guidance plus the sanitized target name. For example, a `Skill(name="prompt-writer")` call returns:
+
+```text
+"prompt-writer" is an amplihack agent, not a skill. The Skill tool cannot
+run it. Invoke it as an agent instead (use the Task/agent tool with
+agent type "prompt-writer"), or reference it from a recipe step as
+`agent: "amplihack:prompt-writer"`. Do not retry this as a Skill call.
+```
+
+The message intentionally echoes **only** the sanitized target name (`[A-Za-z0-9-]`), never the full tool input, so surrounding prompt content is not leaked into logs or transcripts.
+
+---
+
+## Behavior Matrix
+
+| `Skill` target            | Known skill? | Known agent? | Result                          |
+| ------------------------- | ------------ | ------------ | ------------------------------- |
+| `prompt-writer`           | no           | yes          | **Blocked + redirect to agent** |
+| `architect`               | no           | yes          | **Blocked + redirect to agent** |
+| `builder`                 | no           | yes          | **Blocked + redirect to agent** |
+| `default-workflow`        | yes          | no           | Pass through (runs as skill)    |
+| `pdf`                     | yes          | no           | Pass through (runs as skill)    |
+| `gherkin-expert`          | yes          | yes          | Pass through (skill precedence) |
+| `tla-plus-expert`         | yes          | yes          | Pass through (skill precedence) |
+| `guide`                   | no           | yes          | **Blocked + redirect to agent** |
+| `totally-unknown-name`    | no           | no           | Pass through (no opinion)       |
+| malformed input (`{}`, …) | n/a          | n/a          | Pass through (no panic)         |
+
+---
+
+## Operational Guarantees
+
+| Guarantee                          | Behavior                                                                                          | Why it matters                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| No silent skip                     | An agent-only `Skill` call is blocked with guidance instead of aborting the step.                | The requirements-clarification phase reliably runs `prompt-writer`.   |
+| No false blocks                    | Overlapping names resolve as skills; unknown names pass through untouched.                        | Genuine skills and unrelated tools are never disrupted.               |
+| Panic-free                         | Total, panic-free parsing of the `Skill` payload (`skill` key with `name` fallback).             | Malformed or hostile JSON cannot crash the hook (DoS resistance).     |
+| Fail-open                          | Any internal failure passes the original call through.                                           | The guardrail never becomes a new failure mode.                       |
+| No prompt leakage                  | The redirect echoes only the sanitized target name, never the full tool input.                   | Surrounding prompt content stays out of logs and transcripts.         |
+
+---
+
+## Affected Workflows
+
+The redirect applies to **every** `PreToolUse` event, so it protects all recipes. It was introduced to fix the `default-workflow` requirements-clarification regression where `prompt-writer` was called as a skill (issue [#838](https://github.com/rysweet/amplihack-rs/issues/838)).
+
+No configuration is required and there are no new flags or environment variables — the guardrail is always on.
+
+---
+
+## Related
+
+- [Skill-to-Agent Redirect API reference](../reference/skill-agent-redirect-api.md) — `known_agents` registry and `check_skill_redirect()` developer API.
+- [Hook specifications reference](../reference/hook-specifications.md) — where the `PreToolUse` hook sits in the hook table.
+- [Workflow execution guardrails](workflow-execution-guardrails.md) — companion safety guardrails for recipe-driven runs.

--- a/docs/reference/skill-agent-redirect-api.md
+++ b/docs/reference/skill-agent-redirect-api.md
@@ -1,0 +1,199 @@
+# Skill-to-Agent Redirect API Reference
+
+Developer reference for the Skill-to-Agent Redirect guardrail in the `amplihack-hooks` crate. It documents the `known_agents` registry and the `PreToolUse` redirect helper that intercepts `Skill` calls naming an agent-only target.
+
+> [Home](../index.md) > [Reference](../index.md) > Skill-to-Agent Redirect API
+
+See the [feature overview](../features/skill-to-agent-redirect.md) for the conceptual model and behavior matrix.
+
+## Module Layout
+
+| File                                            | Role                                                                                  |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `crates/amplihack-hooks/src/known_agents.rs`    | Compile-time registry of amplihack agent names + membership API.                      |
+| `crates/amplihack-hooks/src/known_skills.rs`    | Existing compile-time registry of skill names (companion; used for precedence).       |
+| `crates/amplihack-hooks/src/pre_tool_use/mod.rs`| `check_skill_redirect()` helper wired into the `PreToolUse` `process()` flow.          |
+| `crates/amplihack-hooks/src/lib.rs`             | Registers `pub mod known_agents;`.                                                     |
+
+---
+
+## `known_agents` Module
+
+A filesystem-free, compile-time registry mirroring `known_skills`.
+
+### Data
+
+```rust
+/// All built-in amplihack agent names. Keep sorted for `binary_search`.
+static AMPLIHACK_AGENTS: &[&str] = &[
+    "ambiguity",
+    "amplifier-cli-architect",
+    "amplihack-improvement-workflow",
+    "analyzer",
+    "api-designer",
+    "architect",
+    // ... 41 unique names total, sorted ...
+    "worktree-manager",
+    "xpia-defense",
+];
+```
+
+The registry contains the **41 unique** agent names sourced from `amplifier-bundle/agents/**/*.md`. The duplicate `guide.md` basename is deduplicated so the slice stays unique and sorted.
+
+### Functions
+
+```rust
+/// Returns true if `name` is a known amplihack agent (case-sensitive, exact).
+pub fn is_amplihack_agent(name: &str) -> bool;
+
+/// Returns the number of registered agent names.
+pub fn agent_count() -> usize;
+```
+
+- `is_amplihack_agent` is a `binary_search` over the static slice — O(log n), no allocation, no regex, no path or shell use.
+- Matching is **exact and case-sensitive**. `"prompt-writer"` matches; `"PROMPT-WRITER"` and `"specialized/prompt-writer"` do not.
+
+#### Example
+
+```rust
+use amplihack_hooks::known_agents::{agent_count, is_amplihack_agent};
+
+assert!(is_amplihack_agent("prompt-writer"));
+assert!(is_amplihack_agent("architect"));
+assert!(!is_amplihack_agent("default-workflow")); // that's a skill
+assert!(!is_amplihack_agent(""));
+assert_eq!(agent_count(), 41);
+```
+
+### Registry Consistency Test
+
+A `#[cfg(test)]` consistency test globs `amplifier-bundle/agents/**/*.md`, collects the deduplicated basenames, and asserts they exactly match `AMPLIHACK_AGENTS`. If an agent is added, renamed, or removed without updating the registry, the build fails. This is the guard against registry drift.
+
+---
+
+## `PreToolUse` Redirect
+
+### Constant
+
+```rust
+/// Static guidance template for an agent-only Skill invocation.
+const SKILL_IS_AGENT_REDIRECT: &str = "\
+\"{name}\" is an amplihack agent, not a skill. The Skill tool cannot run it. \
+Invoke it as an agent instead (use the Task/agent tool with agent type \
+\"{name}\"), or reference it from a recipe step as `agent: \"amplihack:{name}\"`. \
+Do not retry this as a Skill call.";
+```
+
+Only the sanitized target name is substituted into the template. The full tool input is never echoed.
+
+### Helper
+
+```rust
+/// Returns `Some(block_response)` when `tool_name == "Skill"` and the named
+/// target is an agent but not a skill; otherwise `None` (pass through).
+fn check_skill_redirect(tool_name: &str, input: &serde_json::Value) -> Option<serde_json::Value>;
+```
+
+Semantics:
+
+1. Return `None` immediately unless `tool_name == "Skill"`.
+2. Extract the target name with total, panic-free accessors:
+   ```rust
+   let name = input
+       .get("skill")
+       .or_else(|| input.get("name"))
+       .and_then(serde_json::Value::as_str)?;
+   ```
+   The copilot `Skill` payload uses the `skill` key; `name` is accepted as a fallback. A missing, non-string, or null value yields `None` (pass through).
+3. Apply the predicate:
+   ```rust
+   if !is_amplihack_skill(name) && is_amplihack_agent(name) {
+       // build redirect
+   }
+   ```
+4. On match, return:
+   ```json
+   { "block": true, "message": "<SKILL_IS_AGENT_REDIRECT with name substituted>" }
+   ```
+   where `name` is sanitized to `[A-Za-z0-9-]` before substitution.
+
+### Wiring
+
+`check_skill_redirect()` is called inside `PreToolUseHook::process()` **after** the XPIA security check and **before** the `if tool_name != "Bash"` early return:
+
+```rust
+fn process(&self, input: HookInput) -> anyhow::Result<Value> {
+    let (tool_name, tool_input) = /* ... */;
+
+    // Launcher context injection (side effect only).
+    // XPIA security validation.
+    if let Some(block) = xpia::check_xpia(&tool_name, &tool_input) {
+        return Ok(block);
+    }
+
+    // Skill-to-agent redirect (this feature).
+    if let Some(block) = check_skill_redirect(&tool_name, &tool_input) {
+        return Ok(block);
+    }
+
+    if tool_name != "Bash" {
+        return Ok(Value::Object(serde_json::Map::new()));
+    }
+    // ... Bash-only checks ...
+}
+```
+
+Placing the check before the `Bash` gate is required because `Skill` is not `Bash`; the existing early return (`Value::Object(serde_json::Map::new())`, which serializes to `{}`) would otherwise pass every non-Bash tool through untouched.
+
+### Failure Policy
+
+`PreToolUseHook` returns `FailurePolicy::Open`. The redirect is advisory UX: any parse or lookup failure passes the original tool call through. The hook never fails closed and never aborts a run.
+
+---
+
+## Output Contract
+
+A matched redirect produces a standard `PreToolUse` block response:
+
+```json
+{
+  "block": true,
+  "message": "\"prompt-writer\" is an amplihack agent, not a skill. ..."
+}
+```
+
+A non-match produces an empty object (`{}`), identical to any other allowed non-Bash tool call.
+
+---
+
+## Security Considerations
+
+- **Total parsing.** Name extraction uses `Option` accessors only — no `unwrap`, `expect`, or indexing. Missing/non-string/null inputs pass through.
+- **Pure lookup.** `is_amplihack_agent` is a `binary_search` over a static `&[&str]`. No regex, path traversal, format-string, or shell evaluation — no injection vector.
+- **No runtime filesystem access.** Agent names are compile-time constants; filesystem globbing is confined to the `#[cfg(test)]` consistency test.
+- **Non-reflective message.** The redirect emits a static template plus the bare sanitized name (`[A-Za-z0-9-]`), never the full tool input, to avoid leaking surrounding prompt content into logs or transcripts.
+- **No persistence.** The registry holds public agent names only; the hook performs no disk or database writes and adds no new log sinks beyond existing `tracing`.
+
+---
+
+## Tests
+
+| Location                                  | Coverage                                                                                                    |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `known_agents.rs` (`#[cfg(test)]`)        | Membership (`prompt-writer` → true, unknown → false), slice-is-sorted assertion, `agent_count` value, and the filesystem consistency test against `amplifier-bundle/agents/**/*.md`. |
+| `pre_tool_use/mod.rs` (`#[cfg(test)]`)    | `Skill(prompt-writer)` → blocked + redirect; `gherkin-expert` / `tla-plus-expert` / `default-workflow` → pass (skill precedence); `totally-unknown` → pass; malformed inputs (`{}`, `{"skill":123}`, `{"skill":null}`, nested junk) → pass-through with no panic. |
+
+Run them with:
+
+```bash
+cargo test -p amplihack-hooks known_agents
+cargo test -p amplihack-hooks skill_redirect
+```
+
+---
+
+## Related
+
+- [Skill-to-Agent Redirect feature overview](../features/skill-to-agent-redirect.md)
+- [Hook specifications reference](hook-specifications.md)
+- [UserPromptSubmit hook API reference](user-prompt-submit-hook-api.md)


### PR DESCRIPTION
## Summary

Fixes #838. During `amplihack recipe run default-workflow`, an agent invokes the **Skill** tool with name `prompt-writer`, and the amplihack copilot binary logs `Skill not found: prompt-writer`, silently skipping the requirements-clarification phase.

## Root cause

`prompt-writer` is bundled **only as an agent** (`amplifier-bundle/agents/**/*.md`), never as a skill. The recipes are already correct (they reference it as `agent: "amplihack:prompt-writer"`) and the external recipe runner correctly resolves `agent:` references — neither is the cause.

The spurious `Skill(prompt-writer)` call is initiated by the **model at runtime** (driven by injected amplihack instructions that tell the model to invoke skills). The copilot skill-dispatch path then hard-fails with "Skill not found", and the step is silently skipped/degraded.

## Fix

A pre-tool-use guardrail in `amplihack-hooks`. When a `Skill` invocation names something that is a known amplihack **agent** but **not** a skill, the `PreToolUse` hook returns a non-fatal block with a redirect message instructing the model to use the agent interface (e.g. `amplihack:prompt-writer`). This intercepts the call **before** the copilot runtime can emit "Skill not found", so the phase is never silently skipped.

- **`crates/amplihack-hooks/src/known_agents.rs`** (new) — compile-time registry of the 41 unique agent names (sorted for `binary_search`), mirroring `known_skills.rs`. Includes a consistency test that fails the build if the registry drifts from `amplifier-bundle/agents/**/*.md`.
- **`pre_tool_use/mod.rs`** — `check_skill_redirect()` wired in after the XPIA check and before the `Bash` early-return. Predicate `!is_amplihack_skill(name) && is_amplihack_agent(name)` gives **skills precedence**, so overlapping names (`gherkin-expert`, `tla-plus-expert`) still resolve as skills. Parsing is total and panic-free; `FailurePolicy::Open` means any parse failure passes through.
- **`lib.rs`** — registers `pub mod known_agents;`.

## Tests (regression)

- `Skill(prompt-writer)` / `Skill(guide)` / `name`-key payload → **blocked + redirect** (no silent abort).
- Real skill (`default-workflow`), overlapping names, unknown names, and malformed payloads (`{}`, non-string, null, nested) → **pass-through, no panic**.
- `known_agents.rs` unit + filesystem-consistency tests.

`cargo test -p amplihack-hooks` → **421 passed**. `cargo fmt`, `cargo clippy -- -D warnings`, and full `cargo build` are green.

Closes #838