### PR TITLE
refactor(recipes): rename step-17a compliance gate to testing-evidence gate

### DIFF
--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -1,5 +1,5 @@
 name: "workflow-pr-review"
-description: "Phase 7: PR review cycle — compliance, reviewer, gates (17a-19d)"
+description: "Phase 7: PR review cycle — testing-evidence, reviewer, gates (17a-19d)"
 version: "1.0.0"
 author: "Amplihack Team"
 tags: ["development", "review", "pr"]
@@ -13,15 +13,15 @@ context:
   worktree_setup: ""
   allow_no_op: false
 steps:
-  - id: "step-17a-compliance-verification"
+  - id: "step-17a-testing-evidence-gate"
     type: "bash"
     condition: "terminal_state.terminal_success != 'true'"
     command: |
-      echo "=== Step 17a: Step 13 Compliance Verification ===" && \
+      echo "=== Step 17a: Step 13 Testing-Evidence Gate ===" && \
       echo "" && \
       GATE_OUTPUT="$LOCAL_TESTING_GATE" && \
       if [ -z "$GATE_OUTPUT" ] || [ "$GATE_OUTPUT" = "''" ]; then \
-        echo "COMPLIANCE FAILURE: Step 13 (outside-in testing) produced no output." && \
+        echo "TESTING-EVIDENCE GATE FAILURE: Step 13 (outside-in testing) produced no output." && \
         echo "" && \
         echo "The outside-in testing step (step-13-local-testing) must be completed" && \
         echo "before the PR review phase can begin." && \
@@ -31,13 +31,13 @@ steps:
         echo "PR description under 'Step 13: Local Testing Results'." && \
         exit 1 ; \
       fi && \
-      echo "Compliance check: local_testing_gate is populated." && \
+      echo "Testing-evidence check: local_testing_gate is populated." && \
       echo "" && \
       echo "Verify PR description contains 'Step 13: Local Testing Results' section" && \
       echo "with detected toolchains, chosen strategy, and actual test execution evidence (not just planning)." && \
       echo "" && \
-      echo "=== Compliance Check PASSED ==="
-    output: "step_13_compliance_check"
+      echo "=== Testing-Evidence Gate PASSED ==="
+    output: "step_13_testing_evidence_check"
   - id: "step-17b-reviewer-agent"
     agent: "amplihack:reviewer"
     condition: "terminal_state.terminal_success != 'true'"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -41,7 +41,7 @@ steps:
       echo "  Step 15: Commit and Push"
       echo "  Step 16: Open PR as Draft"
       echo "  Step 17: Review the PR (MANDATORY - 6 sub-steps with verification gate)"
-      echo "    17a: Step 13 Compliance Verification"
+      echo "    17a: Step 13 Testing-Evidence Gate"
       echo "    17b: Comprehensive Code Review (reviewer agent)"
       echo "    17c: Security Review (security agent)"
       echo "    17d: Philosophy Guardian Review (philosophy-guardian agent)"

--- a/amplifier-bundle/skills/default-workflow/SKILL.md
+++ b/amplifier-bundle/skills/default-workflow/SKILL.md
@@ -86,7 +86,7 @@ flowchart TD
     end
 
     subgraph P6["Phase 6: PR Review - MANDATORY"]
-        S17a[Step 17a: Compliance Verification] --> S17b[Step 17b: Reviewer Agent]
+        S17a[Step 17a: Testing-Evidence Gate] --> S17b[Step 17b: Reviewer Agent]
         S17b --> S17c[Step 17c: Security Review]
         S17c --> S17d[Step 17d: Philosophy Guardian]
         S17d --> S17e{Blocking issues?}

--- a/docs/audits/recipe-runner-quality-robustness-audit.md
+++ b/docs/audits/recipe-runner-quality-robustness-audit.md
@@ -174,7 +174,7 @@ The default-workflow has exactly **3 git-based checkpoints** across 23 steps:
 #### F-ERR-2: Step 13 "CANNOT BE SKIPPED" label has no enforcement mechanism (🟠 High)
 
 - **File**: `amplifier-bundle/recipes/default-workflow.yaml:961`
-- **Issue**: Step 13 (outside-in testing) is labeled "CANNOT BE SKIPPED" in the prompt text, but has no `condition` or `depends_on` field enforcing this. The label is advisory only. Step 17a (compliance gate) validates `local_testing_gate` output and fails if step 13 produced no output — creating an implicit but fragile coupling.
+- **Issue**: Step 13 (outside-in testing) is labeled "CANNOT BE SKIPPED" in the prompt text, but has no `condition` or `depends_on` field enforcing this. The label is advisory only. Step 17a (testing-evidence gate) validates `local_testing_gate` output and fails if step 13 produced no output — creating an implicit but fragile coupling.
 - **Fix**: Add explicit `required: true` metadata or a validation step that halts the workflow if step 13 is skipped.
 
 #### F-ERR-3: Only 40% of workflow has checkpoint coverage (🟠 High)

--- a/docs/claude/skills/default-workflow/SKILL.md
+++ b/docs/claude/skills/default-workflow/SKILL.md
@@ -86,7 +86,7 @@ flowchart TD
     end
 
     subgraph P6["Phase 6: PR Review - MANDATORY"]
-        S17a[Step 17a: Compliance Verification] --> S17b[Step 17b: Reviewer Agent]
+        S17a[Step 17a: Testing-Evidence Gate] --> S17b[Step 17b: Reviewer Agent]
         S17b --> S17c[Step 17c: Security Review]
         S17c --> S17d[Step 17d: Philosophy Guardian]
         S17d --> S17e{Blocking issues?}

--- a/docs/reference/recipe-runner-audit.md
+++ b/docs/reference/recipe-runner-audit.md
@@ -183,7 +183,7 @@ The default-workflow has exactly **3 git-based checkpoints** across 23 steps:
 #### F-ERR-2: Step 13 "CANNOT BE SKIPPED" label has no enforcement mechanism (High)
 
 - **File**: `amplifier-bundle/recipes/default-workflow.yaml:961`
-- **Issue**: Step 13 (outside-in testing) is labeled "CANNOT BE SKIPPED" in the prompt text, but has no `condition` or `depends_on` field enforcing this. The label is advisory only. Step 17a (compliance gate) validates `local_testing_gate` output and fails if step 13 produced no output — creating an implicit but fragile coupling.
+- **Issue**: Step 13 (outside-in testing) is labeled "CANNOT BE SKIPPED" in the prompt text, but has no `condition` or `depends_on` field enforcing this. The label is advisory only. Step 17a (testing-evidence gate) validates `local_testing_gate` output and fails if step 13 produced no output — creating an implicit but fragile coupling.
 - **Fix**: Add explicit `required: true` metadata or a validation step that halts the workflow if step 13 is skipped.
 
 #### F-ERR-3: Only 40% of workflow has checkpoint coverage (High)

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -254,7 +254,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "step-16-create-draft-pr",
     "step-16b-outside-in-fix-loop",
     // Phase 7: workflow-pr-review (steps 17a-19d)
-    "step-17a-compliance-verification",
+    "step-17a-testing-evidence-gate",
     "step-17b-reviewer-agent",
     "step-17c-security-review",
     "step-17d-philosophy-guardian",
@@ -297,7 +297,7 @@ const PHASE_RECIPES: &[&str] = &[
 ];
 
 const PR_REVIEW_STEP_INVENTORY: &[&str] = &[
-    "step-17a-compliance-verification",
+    "step-17a-testing-evidence-gate",
     "step-17b-reviewer-agent",
     "step-17c-security-review",
     "step-17d-philosophy-guardian",
@@ -800,7 +800,7 @@ fn mandatory_steps_still_present() {
     for required in [
         "step-00-workflow-preparation",
         "step-14-bump-version",
-        "step-17a-compliance-verification",
+        "step-17a-testing-evidence-gate",
         "step-18a-analyze-feedback",
     ] {
         assert!(


### PR DESCRIPTION
## Summary

Renames the misleadingly-named **step-17a-compliance-verification** gate in the amplihack default-workflow PR-review recipe to accurate **testing-evidence-gate** terminology.

Operator feedback: "compliance" wrongly implies *regulatory* compliance. This step is **not** about regulatory compliance — it merely verifies that Step 13 (outside-in / local testing) produced testing **evidence** (i.e. the `LOCAL_TESTING_GATE` variable is populated).

This is a **pure rename with no behavior change**.

## Changes

`amplifier-bundle/recipes/workflow-pr-review.yaml`:
- Step id: `step-17a-compliance-verification` → `step-17a-testing-evidence-gate`
- Output var: `step_13_compliance_check` → `step_13_testing_evidence_check`
- Echo text updates:
  - "Step 17a: Step 13 Compliance Verification" → "Step 17a: Step 13 Testing-Evidence Gate"
  - "COMPLIANCE FAILURE: ..." → "TESTING-EVIDENCE GATE FAILURE: ..."
  - "Compliance check: local_testing_gate is populated." → "Testing-evidence check: local_testing_gate is populated."
  - "=== Compliance Check PASSED ===" → "=== Testing-Evidence Gate PASSED ==="
- Recipe description: "Phase 7: PR review cycle — compliance, reviewer, gates (17a-19d)" → "Phase 7: PR review cycle — testing-evidence, reviewer, gates (17a-19d)"

Consistent references updated in:
- `amplifier-bundle/recipes/workflow-prep.yaml` (step listing)
- `amplifier-bundle/skills/default-workflow/SKILL.md` + `docs/claude/skills/default-workflow/SKILL.md` (mermaid diagrams)
- `docs/audits/recipe-runner-quality-robustness-audit.md`, `docs/reference/recipe-runner-audit.md`
- `tests/integration/default_workflow_decomposition_test.rs` (step-id assertions)

## Scope preservation

Legitimate **"philosophy compliance"** and **"pattern compliance"** references (step-19a/19b and elsewhere) are intentionally **untouched** — those are meaningful and remain.

## Verification

- `grep -rn 'step-17a-compliance-verification\|step_13_compliance_check'` returns nothing in source.
- YAML still parses.
- `cargo test --test default_workflow_decomposition` → 35 passed, 0 failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>