### PR TITLE
docs: reconcile default-workflow SKILL mirror and fix stale step-17a gate citations (#849 follow-up)

### DIFF
--- a/amplifier-bundle/skills/default-workflow/SKILL.md
+++ b/amplifier-bundle/skills/default-workflow/SKILL.md
@@ -134,6 +134,13 @@ compliance throughout.
 The skill and recipe are the authoritative representation. Legacy
 `DEFAULT_WORKFLOW.md` files are deprecated compatibility references only.
 
+The two copies of this file — `docs/claude/skills/default-workflow/SKILL.md` and
+`amplifier-bundle/skills/default-workflow/SKILL.md` — are mirrored byte-for-byte.
+Because they live at different directory depths, cross-references to other
+repository docs must use a repo-relative inline-code path (for example
+`docs/reference/foo.md`) rather than a relative `../` markdown link, so the
+reference stays valid from both locations.
+
 ## Execution Instructions
 
 ### Normal path (via dev-orchestrator)
@@ -216,7 +223,7 @@ their own local consumer-facing validation pattern. Python `uvx` is only a
 Python/uv-specific option when that project shape warrants it.
 
 For the full evidence contract and examples, see
-[`docs/reference/default-workflow-step-13-validation.md`](../../../reference/default-workflow-step-13-validation.md).
+`docs/reference/default-workflow-step-13-validation.md`.
 
 ## Configuration
 

--- a/amplifier-bundle/skills/default-workflow/SKILL.md
+++ b/amplifier-bundle/skills/default-workflow/SKILL.md
@@ -203,6 +203,21 @@ Agent runtimes that support skills should enter through
 `Skill(skill="default-workflow")` activation is for explicit standalone use or
 orchestrator-unavailable compatibility.
 
+## Step 13 Local Validation Contract
+
+Step 13 is a mandatory outside-in local validation gate. It is agentic and
+toolchain-aware: the acting agent detects affected languages, manifests,
+lockfiles, package managers, entry points, changed files, and documented project
+commands before selecting validation commands.
+
+The step must not require one global validation mechanism across all projects.
+Rust/Cargo, Node/npm, Python/uv, Go, .NET, and other detected toolchains each use
+their own local consumer-facing validation pattern. Python `uvx` is only a
+Python/uv-specific option when that project shape warrants it.
+
+For the full evidence contract and examples, see
+[`docs/reference/default-workflow-step-13-validation.md`](../../../reference/default-workflow-step-13-validation.md).
+
 ## Configuration
 
 Generated preferences and session context name the canonical skill/recipe, not a
@@ -238,15 +253,33 @@ In most cases, it will activate first and invoke this workflow as a sub-recipe.
 Steps that commonly fail during workflow execution. Agents executing this workflow
 MUST apply the documented resilience patterns when encountering these steps.
 
+### Step 1 — Git Fetch (credential failure)
+
+**Failure**: `git fetch --all` fails with exit 128 when the remote requires credentials
+that are not configured — most commonly Azure DevOps remotes where only the GitHub
+credential helper (`gh auth git-credential`) is wired up.
+**Resilience**: Fetch failure is caught and downgraded to a WARNING. The step continues
+with local branch state. ADO remotes (`dev.azure.com`, `visualstudio.com`) receive
+specific remediation guidance (`az login`, GCM install, PAT setup). The remote URL is
+never echoed to avoid leaking embedded credentials. See
+`docs/recipes/issue-655-656-skill-invocation-and-fetch-resilience.md` for details.
+
 ### Step 3 — Issue Creation (label missing)
 
 **Failure**: `gh label create` fails silently when labels cannot be created (permission denied, API timeout).
 **Resilience**: Label attachment is best-effort. If `gh issue create --label` fails, retry without `--label`. The issue itself is the critical artifact, not its labels.
 
-### Step 4 — Worktree Setup (no remote / no origin/main)
+### Step 4 — Worktree Setup (non-main default branch)
 
-**Failure**: `git fetch origin main` aborts when the repo has no remotes or `origin/main` does not exist.
-**Resilience**: Topology detection runs first. If no remote exists, use `HEAD` as base ref and skip push/upstream setup. The `bootstrap` flag in worktree output signals downstream steps to skip remote operations.
+**Failure**: Worktree setup aborts when a repository does not have `origin/main`,
+even though its remote default branch is `master` or `develop`.
+**Resilience**: Remote base detection runs before worktree creation. Prefer
+Git-verified `origin/HEAD`, then fall back to `origin/master`, then
+`origin/develop`. `origin/HEAD` may target `origin/main`, `origin/master`,
+`origin/develop`, or another remote default branch as long as Git verifies it as
+a remote-tracking ref under `refs/remotes/origin/`. If no supported remote base
+source exists, fail closed with a clear error; do not bootstrap from local
+`HEAD` or silently skip push/upstream setup.
 
 ### Step 4 — Initial Push (network transient)
 

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -376,3 +376,11 @@ path = "../../tests/integration/merge_ready_platform_contract_test.rs"
 [[test]]
 name = "code_philosophy_audit_recipe"
 path = "../../tests/integration/code_philosophy_audit_recipe_test.rs"
+
+# Issue #849: default-workflow SKILL mirror parity + F-ERR-2 stale-citation guard.
+# Pins byte-for-byte mirror equality, the extracted Step 17a gate node, absence of
+# the stale `default-workflow.yaml:961` reference, and that the audit citations
+# resolve to a live `step-17a-testing-evidence-gate` step in workflow-pr-review.yaml.
+[[test]]
+name = "issue_849_skill_mirror_citation"
+path = "../../tests/integration/issue_849_skill_mirror_citation_test.rs"

--- a/docs/audits/recipe-runner-quality-robustness-audit.md
+++ b/docs/audits/recipe-runner-quality-robustness-audit.md
@@ -173,7 +173,8 @@ The default-workflow has exactly **3 git-based checkpoints** across 23 steps:
 
 #### F-ERR-2: Step 13 "CANNOT BE SKIPPED" label has no enforcement mechanism (🟠 High)
 
-- **File**: `amplifier-bundle/recipes/default-workflow.yaml:961`
+- **File**: `amplifier-bundle/recipes/workflow-pr-review.yaml` — step `step-17a-testing-evidence-gate` (~L16–40; the gate `echo`/`exit 1` block emitting `step_13_testing_evidence_check`)
+- **Note**: This file/line reference is a point-in-time snapshot. The Step 17a testing-evidence gate was extracted from `default-workflow.yaml` into `workflow-pr-review.yaml`; locate it by step id (`step-17a-testing-evidence-gate`) rather than a fixed line number.
 - **Issue**: Step 13 (outside-in testing) is labeled "CANNOT BE SKIPPED" in the prompt text, but has no `condition` or `depends_on` field enforcing this. The label is advisory only. Step 17a (testing-evidence gate) validates `local_testing_gate` output and fails if step 13 produced no output — creating an implicit but fragile coupling.
 - **Fix**: Add explicit `required: true` metadata or a validation step that halts the workflow if step 13 is skipped.
 

--- a/docs/claude/skills/default-workflow/SKILL.md
+++ b/docs/claude/skills/default-workflow/SKILL.md
@@ -134,6 +134,13 @@ compliance throughout.
 The skill and recipe are the authoritative representation. Legacy
 `DEFAULT_WORKFLOW.md` files are deprecated compatibility references only.
 
+The two copies of this file — `docs/claude/skills/default-workflow/SKILL.md` and
+`amplifier-bundle/skills/default-workflow/SKILL.md` — are mirrored byte-for-byte.
+Because they live at different directory depths, cross-references to other
+repository docs must use a repo-relative inline-code path (for example
+`docs/reference/foo.md`) rather than a relative `../` markdown link, so the
+reference stays valid from both locations.
+
 ## Execution Instructions
 
 ### Normal path (via dev-orchestrator)
@@ -216,7 +223,7 @@ their own local consumer-facing validation pattern. Python `uvx` is only a
 Python/uv-specific option when that project shape warrants it.
 
 For the full evidence contract and examples, see
-[`docs/reference/default-workflow-step-13-validation.md`](../../../reference/default-workflow-step-13-validation.md).
+`docs/reference/default-workflow-step-13-validation.md`.
 
 ## Configuration
 

--- a/docs/reference/recipe-runner-audit.md
+++ b/docs/reference/recipe-runner-audit.md
@@ -182,7 +182,8 @@ The default-workflow has exactly **3 git-based checkpoints** across 23 steps:
 
 #### F-ERR-2: Step 13 "CANNOT BE SKIPPED" label has no enforcement mechanism (High)
 
-- **File**: `amplifier-bundle/recipes/default-workflow.yaml:961`
+- **File**: `amplifier-bundle/recipes/workflow-pr-review.yaml` — step `step-17a-testing-evidence-gate` (~L16–40; the gate `echo`/`exit 1` block emitting `step_13_testing_evidence_check`)
+- **Note**: This file/line reference is a point-in-time snapshot. The Step 17a testing-evidence gate was extracted from `default-workflow.yaml` into `workflow-pr-review.yaml`; locate it by step id (`step-17a-testing-evidence-gate`) rather than a fixed line number.
 - **Issue**: Step 13 (outside-in testing) is labeled "CANNOT BE SKIPPED" in the prompt text, but has no `condition` or `depends_on` field enforcing this. The label is advisory only. Step 17a (testing-evidence gate) validates `local_testing_gate` output and fails if step 13 produced no output — creating an implicit but fragile coupling.
 - **Fix**: Add explicit `required: true` metadata or a validation step that halts the workflow if step 13 is skipped.
 

--- a/tests/integration/issue_849_skill_mirror_citation_test.rs
+++ b/tests/integration/issue_849_skill_mirror_citation_test.rs
@@ -1,0 +1,162 @@
+//! Issue #849 regression contract: SKILL.md mirror parity + stale-citation guard.
+//!
+//! Commit #849 reconciled the bundle `default-workflow` SKILL mirror with the
+//! authoritative docs copy and repointed the stale F-ERR-2 audit citations after
+//! the Step 17a testing-evidence gate was extracted from `default-workflow.yaml`
+//! into `workflow-pr-review.yaml`.
+//!
+//! These invariants regress silently (an edit to one SKILL copy, a rename of the
+//! gate step, or a reintroduced `:961` line number would each go unnoticed), so
+//! this test pins them:
+//!   - the two SKILL.md copies stay byte-for-byte identical,
+//!   - the extracted gate node survives in the mirror,
+//!   - no doc reintroduces the stale `default-workflow.yaml:961` reference,
+//!   - both audit files cite `workflow-pr-review.yaml` by step id with the
+//!     point-in-time-snapshot note,
+//!   - `workflow-pr-review.yaml` still defines that gate step and its output, so
+//!     the audit citations cannot go stale without failing loudly,
+//!   - the Step 13 validation reference doc linked from the mirror exists.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop(); // bins/amplihack -> bins
+    path.pop(); // bins -> workspace root
+    path
+}
+
+fn read(relative: &str) -> String {
+    let path = workspace_root().join(relative);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+const DOCS_SKILL: &str = "docs/claude/skills/default-workflow/SKILL.md";
+const BUNDLE_SKILL: &str = "amplifier-bundle/skills/default-workflow/SKILL.md";
+const AUDIT_FILES: &[&str] = &[
+    "docs/audits/recipe-runner-quality-robustness-audit.md",
+    "docs/reference/recipe-runner-audit.md",
+];
+const PR_REVIEW_RECIPE: &str = "amplifier-bundle/recipes/workflow-pr-review.yaml";
+const STEP13_REFERENCE_DOC: &str = "docs/reference/default-workflow-step-13-validation.md";
+const GATE_STEP_ID: &str = "step-17a-testing-evidence-gate";
+
+/// The bundle mirror must remain byte-for-byte identical to the authoritative
+/// docs copy — this is the core invariant #849 established.
+#[test]
+fn skill_mirror_is_byte_for_byte_identical() {
+    let docs = read(DOCS_SKILL);
+    let bundle = read(BUNDLE_SKILL);
+    assert_eq!(
+        docs, bundle,
+        "{BUNDLE_SKILL} must be byte-for-byte identical to {DOCS_SKILL}; the bundle \
+         copy is a mirror of the authoritative docs copy (issue #849)."
+    );
+}
+
+/// The extracted Step 17a testing-evidence gate node must survive in the mirror.
+#[test]
+fn skill_retains_testing_evidence_gate_node() {
+    for f in [DOCS_SKILL, BUNDLE_SKILL] {
+        assert!(
+            read(f).contains("Step 17a: Testing-Evidence Gate"),
+            "{f} must retain the 'Step 17a: Testing-Evidence Gate' node (issue #849)."
+        );
+    }
+}
+
+/// No documentation file may reintroduce the stale line-number citation that
+/// pointed F-ERR-2 at `default-workflow.yaml:961` before the gate was extracted.
+#[test]
+fn no_stale_961_citation_in_docs() {
+    let mut offenders = Vec::new();
+    let docs_root = workspace_root().join("docs");
+    let files = markdown_files(&docs_root);
+    assert!(
+        !files.is_empty(),
+        "no markdown files found under {}; the stale-citation scan would pass \
+         vacuously (issue #849).",
+        docs_root.display()
+    );
+    for path in files {
+        let body =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        if body.contains("default-workflow.yaml:961") {
+            offenders.push(path.display().to_string());
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "stale 'default-workflow.yaml:961' citation reintroduced in: {offenders:?} \
+         (the Step 17a gate now lives in {PR_REVIEW_RECIPE}; cite it by step id)."
+    );
+}
+
+/// Both audit files must cite the extracted gate by recipe file + step id and
+/// carry the point-in-time-snapshot note so the reference survives future moves.
+#[test]
+fn audit_files_cite_extracted_gate_by_step_id() {
+    for f in AUDIT_FILES {
+        let body = read(f);
+        assert!(
+            body.contains("workflow-pr-review.yaml"),
+            "{f} must cite `workflow-pr-review.yaml` for F-ERR-2 (issue #849)."
+        );
+        assert!(
+            body.contains(GATE_STEP_ID),
+            "{f} must locate F-ERR-2 by step id `{GATE_STEP_ID}` (issue #849)."
+        );
+        assert!(
+            body.contains("point-in-time snapshot"),
+            "{f} must keep the point-in-time-snapshot note so the citation is \
+             located by step id rather than a fixed line number (issue #849)."
+        );
+    }
+}
+
+/// The cited recipe must actually define the gate step and emit its output, so
+/// the audit citation cannot go stale without this test failing.
+#[test]
+fn pr_review_recipe_defines_cited_gate() {
+    let recipe = read(PR_REVIEW_RECIPE);
+    assert!(
+        recipe.contains(GATE_STEP_ID),
+        "{PR_REVIEW_RECIPE} must define the `{GATE_STEP_ID}` step referenced by \
+         the F-ERR-2 audit citations (issue #849)."
+    );
+    assert!(
+        recipe.contains("step_13_testing_evidence_check"),
+        "{PR_REVIEW_RECIPE} must emit `step_13_testing_evidence_check`, the gate \
+         output named by the F-ERR-2 audit citations (issue #849)."
+    );
+}
+
+/// The Step 13 validation reference doc linked from the mirror must exist.
+#[test]
+fn step13_validation_reference_doc_exists() {
+    let path = workspace_root().join(STEP13_REFERENCE_DOC);
+    assert!(
+        path.exists(),
+        "{STEP13_REFERENCE_DOC} must exist; it is linked from the Step 13 Local \
+         Validation Contract block in the SKILL mirror (issue #849)."
+    );
+}
+
+/// Collect every `.md` file under `dir`, recursively.
+fn markdown_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(markdown_files(&path));
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            out.push(path);
+        }
+    }
+    out
+}


### PR DESCRIPTION
## Summary

Documentation follow-up to the #848 rename (step-17a compliance gate → testing-evidence gate). Reconciles the bundle `SKILL.md` mirror with the authoritative docs copy, corrects stale audit citations that pointed at a line/file that no longer hosts the gate, and adds a contract test that guards these invariants against future drift.

Issue #849 (the rename itself) shipped via #848; this PR cleans up the documentation drift the extraction left behind, per an architect review of the docs.

## Changes

- **SKILL mirror sync**: `amplifier-bundle/skills/default-workflow/SKILL.md` is now byte-for-byte identical to `docs/claude/skills/default-workflow/SKILL.md`. This adopts blocks that had only landed on the docs copy:
  - "Step 13 Local Validation Contract" (toolchain-aware validation, from #768)
  - "Step 1 — Git Fetch (credential failure)" resilience note (from #657)
  - Fail-closed "Step 4 — Worktree Setup" wording (`origin/HEAD` → `origin/master` → `origin/develop`, matching `workflow-worktree.yaml`)
  - The `Step 17a: Testing-Evidence Gate` mermaid node is preserved.
- **Citation fix**: F-ERR-2 in `docs/reference/recipe-runner-audit.md` and `docs/audits/recipe-runner-quality-robustness-audit.md` repointed from the stale `amplifier-bundle/recipes/default-workflow.yaml:961` to `amplifier-bundle/recipes/workflow-pr-review.yaml` (step `step-17a-testing-evidence-gate`, ~L16–40), with a point-in-time-snapshot note so readers locate the gate by step id rather than a fixed line number. F-ERR-2 substance (enforcement gap, `required: true` fix) is unchanged.
- **Robust reference link**: the Step 13 validation reference uses a repo-relative inline-code path (`docs/reference/default-workflow-step-13-validation.md`) rather than a depth-sensitive `../` markdown link that 404s from the bundle mirror. A restored Canonical Sources note documents the byte-for-byte mirror convention so future edits don't reintroduce a relative link.
- **Regression guard**: `tests/integration/issue_849_skill_mirror_citation_test.rs` (registered in `bins/amplihack/Cargo.toml`) asserts mirror byte-parity, survival of the testing-evidence gate node, the corrected F-ERR-2 citations, and existence of the referenced validation doc.

## Consolidation

Supersedes and replaces closed PR #851, which implemented the same reconciliation on a misleadingly-named `feat/issue-848-…` branch and dragged in unrelated `0.11.1 → 0.11.2` version bumps (Cargo.lock/Cargo.toml/package.json). This PR keeps the change scoped to documentation + its guarding test, with no version churn.

## Verification

- `diff docs/.../SKILL.md amplifier-bundle/.../SKILL.md` → exit 0 (byte-identical)
- Both `SKILL.md` still contain `Step 17a: Testing-Evidence Gate`
- No `../` markdown link to the validation doc; reference is repo-relative inline code
- `grep -rn 'default-workflow.yaml:961' docs/` → zero matches
- Both audit files cite `workflow-pr-review.yaml` with a snapshot note
- `cargo test -p amplihack --test issue_849_skill_mirror_citation` → 6 passed
- pre-commit hooks pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>