### PR TITLE
feat(recipe-runner): first-class clean agent-result channel off the noisy stdout (#854)

### DIFF
--- a/crates/amplihack-orchestration/src/claude_process.rs
+++ b/crates/amplihack-orchestration/src/claude_process.rs
@@ -118,6 +118,12 @@ pub struct ProcessResult {
     pub stderr: String,
     pub duration: Duration,
     pub process_id: String,
+    /// The **clean result channel** contents, captured verbatim from the
+    /// child's result sink. `None` when the caller did not opt in, the child
+    /// did not write the sink, or the contents were unrecoverable (empty,
+    /// oversize, or non-UTF-8). Agent->agent handoffs should read this via
+    /// [`ProcessResult::answer`] instead of scraping `output`.
+    pub result: Option<String>,
 }
 
 impl ProcessResult {
@@ -129,6 +135,7 @@ impl ProcessResult {
             stderr: String::new(),
             duration,
             process_id,
+            result: None,
         }
     }
 
@@ -141,11 +148,23 @@ impl ProcessResult {
             stderr,
             duration,
             process_id,
+            result: None,
         }
     }
 
     pub fn is_success(&self) -> bool {
         self.exit_code == 0
+    }
+
+    /// The agent's clean semantic answer: the result channel when present,
+    /// falling back to captured stdout otherwise.
+    ///
+    /// Consumers performing agent->agent handoffs should use this instead of
+    /// scraping `output`. When the clean channel is off (the default) this is
+    /// byte-identical to `output`, so callers get zero behaviour change until a
+    /// step opts in.
+    pub fn answer(&self) -> &str {
+        self.result.as_deref().unwrap_or(&self.output)
     }
 }
 
@@ -158,6 +177,11 @@ pub struct RunOptions {
     pub timeout: Option<Duration>,
     pub model: Option<String>,
     pub working_dir: Option<PathBuf>,
+    /// Opt-in **clean result channel**. When `Some(path)`, the runner exports
+    /// `AMPLIHACK_RESULT_SINK=<path>` to the child and captures whatever the
+    /// child writes there verbatim into `ProcessResult.result`. `None` (the
+    /// default) preserves legacy stdout-only capture exactly.
+    pub result_sink: Option<PathBuf>,
 }
 
 impl RunOptions {
@@ -168,7 +192,15 @@ impl RunOptions {
             timeout: None,
             model: None,
             working_dir: None,
+            result_sink: None,
         }
+    }
+
+    /// Enable the clean result channel for this run, capturing the child's
+    /// verbatim answer from `sink` into `ProcessResult.result`.
+    pub fn with_result_sink(mut self, sink: PathBuf) -> Self {
+        self.result_sink = Some(sink);
+        self
     }
 }
 
@@ -221,7 +253,14 @@ impl TokioProcessRunner {
         if let Some(dir) = &opts.working_dir {
             delivered.command.current_dir(dir);
         }
-        run_delivered_command(delivered, opts.timeout, opts.process_id, start).await
+        run_delivered_command(
+            delivered,
+            opts.timeout,
+            opts.result_sink,
+            opts.process_id,
+            start,
+        )
+        .await
     }
 }
 
@@ -262,13 +301,21 @@ impl ProcessRunner for TokioProcessRunner {
             delivered.command.current_dir(dir);
         }
 
-        run_delivered_command(delivered, opts.timeout, opts.process_id, start).await
+        run_delivered_command(
+            delivered,
+            opts.timeout,
+            opts.result_sink,
+            opts.process_id,
+            start,
+        )
+        .await
     }
 }
 
 async fn run_delivered_command(
     delivered: DeliveredProcessCommand,
     timeout: Option<Duration>,
+    result_sink: Option<PathBuf>,
     process_id: String,
     start: Instant,
 ) -> ProcessResult {
@@ -283,6 +330,17 @@ async fn run_delivered_command(
     }
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
+
+    // Clean result channel: expose the sink to the child, or actively strip any
+    // inherited value so a stale ancestor sink can never redirect capture
+    // (SEC-10). Done on the std Command before the tokio conversion/spawn.
+    match &result_sink {
+        Some(sink) => crate::result_sink::inject_sink_env(&mut command, sink),
+        None => {
+            command.env_remove(crate::result_sink::RESULT_SINK_ENV);
+        }
+    }
+
     let program = command.get_program().to_string_lossy().into_owned();
     let mut command = TokioCommand::from(command);
     command.kill_on_drop(true);
@@ -350,13 +408,21 @@ async fn run_delivered_command(
     drop(delivery_handle);
     let duration = start.elapsed();
     match status {
-        Ok(s) => ProcessResult {
-            exit_code: s.code().unwrap_or(-1),
-            output: out,
-            stderr: err,
-            duration,
-            process_id,
-        },
+        Ok(s) => {
+            // Capture the clean channel verbatim (or None if unwritten /
+            // oversize / non-UTF-8). Consumers fall back to `output` on None.
+            let result = result_sink
+                .as_deref()
+                .and_then(crate::result_sink::read_sink_verbatim);
+            ProcessResult {
+                exit_code: s.code().unwrap_or(-1),
+                output: out,
+                stderr: err,
+                duration,
+                process_id,
+                result,
+            }
+        }
         Err(e) => ProcessResult::err(format!("wait failed: {e}"), process_id, duration),
     }
 }
@@ -372,6 +438,7 @@ pub async fn run_delivered_command_for_test(
     Ok(run_delivered_command(
         delivered,
         Some(timeout),
+        None,
         "prompt-delivery-test".to_string(),
         Instant::now(),
     )
@@ -571,6 +638,7 @@ mod tests {
             stderr: String::new(),
             duration: Duration::ZERO,
             process_id: "x".into(),
+            result: None,
         };
         assert!(!r.is_success());
     }
@@ -863,6 +931,7 @@ impl ClaudeProcess {
             timeout: self.timeout,
             model: self.model.clone(),
             working_dir: Some(self.working_dir.clone()),
+            result_sink: None,
         };
         let result = self.runner.run(opts).await;
         self.log(

--- a/crates/amplihack-orchestration/src/execution.rs
+++ b/crates/amplihack-orchestration/src/execution.rs
@@ -91,7 +91,7 @@ pub async fn run_sequential(
         let result = process.run().await;
         let succeeded = result.is_success();
         if pass_output {
-            accumulated.push_str(&result.output);
+            accumulated.push_str(result.answer());
         }
         results.push(result);
 
@@ -186,7 +186,7 @@ pub async fn run_batched(
                 if !joined.is_empty() {
                     joined.push_str("\n\n");
                 }
-                joined.push_str(&r.output);
+                joined.push_str(r.answer());
             }
             if !joined.is_empty() {
                 if !accumulated.is_empty() {

--- a/crates/amplihack-orchestration/src/lib.rs
+++ b/crates/amplihack-orchestration/src/lib.rs
@@ -8,6 +8,7 @@ pub mod claude_process;
 pub mod claude_process_builder;
 pub mod execution;
 pub mod patterns;
+pub mod result_sink;
 pub mod session;
 mod text_utils;
 mod time_utils;

--- a/crates/amplihack-orchestration/src/patterns/debate.rs
+++ b/crates/amplihack-orchestration/src/patterns/debate.rs
@@ -136,7 +136,10 @@ pub async fn run_debate(
 
     let mut r1_data = HashMap::new();
     for (name, result) in names_only.iter().zip(r1.iter()) {
-        history.get_mut(name).unwrap().push(result.output.clone());
+        history
+            .get_mut(name)
+            .unwrap()
+            .push(result.answer().to_string());
         r1_data.insert(name.clone(), result.clone());
     }
     all_rounds.push(RoundData {
@@ -180,7 +183,10 @@ pub async fn run_debate(
         let rn = run_parallel(processes.into_iter().map(|(_, p)| p).collect(), None).await;
         let mut rn_data = HashMap::new();
         for (name, result) in names_only.iter().zip(rn.iter()) {
-            history.get_mut(name).unwrap().push(result.output.clone());
+            history
+                .get_mut(name)
+                .unwrap()
+                .push(result.answer().to_string());
             rn_data.insert(name.clone(), result.clone());
         }
         all_rounds.push(RoundData {
@@ -282,9 +288,10 @@ fn build_transcript(all_rounds: &[RoundData], perspective_names: &[String]) -> S
                 && r.is_success()
             {
                 transcript.push_str(&format!("\n## {} PERSPECTIVE:\n", name.to_uppercase()));
-                let truncated = crate::text_utils::truncate_at_char_boundary(&r.output, 3000);
+                let body_src = r.answer();
+                let truncated = crate::text_utils::truncate_at_char_boundary(body_src, 3000);
                 transcript.push_str(truncated);
-                if truncated.len() < r.output.len() {
+                if truncated.len() < body_src.len() {
                     transcript.push_str("\n...(truncated)");
                 }
             }
@@ -320,7 +327,7 @@ fn parse_confidence(
     if !synth.is_success() {
         return Confidence::Low;
     }
-    let lower = synth.output.to_lowercase();
+    let lower = synth.answer().to_lowercase();
     let mut confidence = Confidence::Medium;
     if lower.contains("confidence level") {
         if lower.contains("high") {

--- a/crates/amplihack-orchestration/src/patterns/expert_panel/mod.rs
+++ b/crates/amplihack-orchestration/src/patterns/expert_panel/mod.rs
@@ -191,7 +191,7 @@ pub async fn run_expert_panel(
             continue;
         }
         reviews.push(parse_review(
-            &result.output,
+            result.answer(),
             &expert,
             expert_id,
             result.duration,

--- a/crates/amplihack-orchestration/src/patterns/n_version.rs
+++ b/crates/amplihack-orchestration/src/patterns/n_version.rs
@@ -160,8 +160,10 @@ pub async fn run_n_version(
         };
     }
 
-    // Step 4: parse selection.
-    let lower = comparison_result.output.to_lowercase();
+    // Step 4: parse selection. Read the reviewer's clean answer (the result
+    // channel when present, stdout otherwise) — never scrape raw noisy stdout.
+    let answer = comparison_result.answer();
+    let lower = answer.to_lowercase();
     let mut selected: Option<String> = None;
     if lower.contains("hybrid") {
         selected = Some("hybrid".to_string());
@@ -183,8 +185,7 @@ pub async fn run_n_version(
     let rationale = if let Some(idx) = lower.find("## rationale") {
         // `idx` is a valid byte boundary (from `find`), but `idx + 1000`
         // may land mid-codepoint — use UTF-8-safe truncation.
-        crate::text_utils::truncate_at_char_boundary(&comparison_result.output[idx..], 1000)
-            .to_string()
+        crate::text_utils::truncate_at_char_boundary(&answer[idx..], 1000).to_string()
     } else {
         "See comparison output for full rationale".to_string()
     };
@@ -251,7 +252,7 @@ fn build_comparison_prompt(
             p.name,
             status,
             r.duration.as_secs_f32(),
-            r.output.len(),
+            r.answer().len(),
         ));
     }
 
@@ -270,8 +271,9 @@ fn build_comparison_prompt(
     let bar = "=".repeat(80);
     for (i, r) in versions.iter().enumerate() {
         let p = profiles[i % profiles.len()];
-        let body = crate::text_utils::truncate_at_char_boundary(&r.output, 5000);
-        let truncated = if body.len() < r.output.len() {
+        let body_src = r.answer();
+        let body = crate::text_utils::truncate_at_char_boundary(body_src, 5000);
+        let truncated = if body.len() < body_src.len() {
             "...(truncated)"
         } else {
             ""

--- a/crates/amplihack-orchestration/src/result_sink.rs
+++ b/crates/amplihack-orchestration/src/result_sink.rs
@@ -92,7 +92,12 @@ pub fn inject_sink_env(command: &mut std::process::Command, sink: &Path) {
 /// observes `Some("")` and a child that "opts out" by not writing behaves
 /// identically to one that never touched the file.
 pub fn read_sink_verbatim(path: &Path) -> Option<String> {
-    let meta = std::fs::metadata(path).ok()?;
+    use std::io::Read;
+
+    // Open once and stat the handle (one syscall fewer than stat-then-read,
+    // which stats the path a second time internally to size its buffer).
+    let file = std::fs::File::open(path).ok()?;
+    let meta = file.metadata().ok()?;
     if !meta.is_file() {
         return None;
     }
@@ -101,11 +106,18 @@ pub fn read_sink_verbatim(path: &Path) -> Option<String> {
         return None;
     }
 
-    let bytes = std::fs::read(path).ok()?;
-    // Re-check on the bytes actually read: the file may have changed between the
-    // metadata probe and the read (TOCTOU). Reject if it grew past the cap or
-    // shrank to empty, so both the size bound and the empty-is-None invariant
-    // hold regardless of a concurrent write.
+    // Read through a byte-capped reader rather than slurping the whole file:
+    // this bounds the allocation to the cap even if the child grows the file
+    // between the size probe and the read (TOCTOU), so a hostile or runaway
+    // child can never force an unbounded read (SEC-3). Pre-size to the probed
+    // length for a single right-sized allocation in the common case; the extra
+    // `+ 1` byte is what lets us detect — and reject — a file that raced past
+    // the cap.
+    let mut bytes = Vec::with_capacity(len as usize);
+    file.take(MAX_SINK_BYTES + 1).read_to_end(&mut bytes).ok()?;
+    // Re-check the bytes actually read: under a concurrent write the file may
+    // have grown past the cap or shrunk to empty, so re-assert both the size
+    // bound and the empty-is-None invariant.
     if bytes.is_empty() || bytes.len() as u64 > MAX_SINK_BYTES {
         return None;
     }

--- a/crates/amplihack-orchestration/src/result_sink.rs
+++ b/crates/amplihack-orchestration/src/result_sink.rs
@@ -85,14 +85,32 @@ pub fn inject_sink_env(command: &mut std::process::Command, sink: &Path) {
 /// Returns:
 /// * `Some(contents)` when the file exists, is a regular file within the size
 ///   cap, and holds valid UTF-8.
-/// * `None` when the file is missing, empty, larger than [`MAX_SINK_BYTES`], not
-///   a regular file, or not valid UTF-8.
+/// * `None` when the file is missing, a symlink, empty, larger than
+///   [`MAX_SINK_BYTES`], not a regular file, or not valid UTF-8.
 ///
 /// Empty and unwritten collapse to the same `None` signal so a consumer never
 /// observes `Some("")` and a child that "opts out" by not writing behaves
 /// identically to one that never touched the file.
+///
+/// A symlinked sink is refused (SEC-13): `File::open` follows symlinks, so a
+/// sink swapped for a symlink could otherwise redirect the runner into reading
+/// an arbitrary file and hand it to a consumer as the "clean" answer.
 pub fn read_sink_verbatim(path: &Path) -> Option<String> {
     use std::io::Read;
+
+    // Refuse a symlinked sink before opening it (SEC-13). The read runs after
+    // the child has exited, so the only actor that could swap the file for a
+    // symlink is another process with write access to the sink's directory —
+    // which the owner-only runtime dir (SEC-6) already denies. This lstat
+    // closes the gap for a caller-supplied directory whose permissions the
+    // runner does not control, at no cost on the common (regular-file) path.
+    if std::fs::symlink_metadata(path)
+        .ok()?
+        .file_type()
+        .is_symlink()
+    {
+        return None;
+    }
 
     // Open once and stat the handle (one syscall fewer than stat-then-read,
     // which stats the path a second time internally to size its buffer).

--- a/crates/amplihack-orchestration/src/result_sink.rs
+++ b/crates/amplihack-orchestration/src/result_sink.rs
@@ -1,0 +1,112 @@
+//! The **clean result channel**: a dedicated sink an agent writes its answer to,
+//! kept OUT of the noisy human/log stdout stream.
+//!
+//! Motivation: when one agent's output feeds another agent (or a verdict
+//! decision), the handoff should be semantic and clean. Consumers must not have
+//! to strip ANSI, brace-scan, or `serde`-parse a firehose of interleaved
+//! tracing/banner/log lines to recover the agent's answer — the exact fragility
+//! that keeps breaking `extract_json_payload`-style scraping downstream.
+//!
+//! This module is the small, dependency-free surface the runner and its
+//! consumers share:
+//!
+//! * [`RESULT_SINK_ENV`] — the single env var the runner exports to the child.
+//! * [`allocate_sink_path`] — allocate a fresh, unique, runner-owned sink path.
+//! * [`inject_sink_env`] — export the sink path onto a child `Command`.
+//! * [`read_sink_verbatim`] — read a sink's bytes back **verbatim** (or `None`).
+//!
+//! The transport is deliberately minimal: one env var naming one file, captured
+//! byte-for-byte. See `docs/reference/clean-result-channel.md` for the full
+//! contract and rationale.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// The env var the runner exports to the child when the caller opts into the
+/// clean channel. The child writes its final answer to the file this names.
+/// External consumers (recipe-runner-rs, Simard) key off this exact name.
+pub const RESULT_SINK_ENV: &str = "AMPLIHACK_RESULT_SINK";
+
+/// Upper bound on a sink read (SEC-3). A sink larger than this yields `None`
+/// so a runaway or hostile child can never force an unbounded allocation;
+/// consumers simply fall back to captured stdout. Answers are semantic text,
+/// not bulk data, so 16 MiB is comfortably generous.
+const MAX_SINK_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Monotonic per-process counter guaranteeing distinct sink names even when two
+/// allocations land within the same nanosecond.
+static ALLOC_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Allocate a fresh, unique sink path under `runtime_dir`.
+///
+/// Creates `runtime_dir` (recursively) if it does not exist. On Unix the
+/// runner-created directory is owner-only (`0700`, SEC-6). The returned path
+/// does **not** exist yet — it names the file the child is expected to write.
+/// Each call returns a distinct path so parallel spawns (debate / n_version /
+/// expert_panel fan-out) never race one another's writes.
+pub fn allocate_sink_path(runtime_dir: &Path) -> std::io::Result<PathBuf> {
+    ensure_owner_only_dir(runtime_dir)?;
+
+    let counter = ALLOC_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let file_name = format!("result-{pid}-{nanos}-{counter}.sink");
+    Ok(runtime_dir.join(file_name))
+}
+
+#[cfg(unix)]
+fn ensure_owner_only_dir(dir: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+}
+
+#[cfg(not(unix))]
+fn ensure_owner_only_dir(dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)
+}
+
+/// Export `AMPLIHACK_RESULT_SINK=<path>` onto `command`'s environment so the
+/// spawned child knows where to write its answer. Call this on the
+/// `std::process::Command` before it is spawned.
+pub fn inject_sink_env(command: &mut std::process::Command, sink: &Path) {
+    command.env(RESULT_SINK_ENV, sink);
+}
+
+/// Read a sink's contents back **verbatim** — no ANSI stripping, no trimming,
+/// no newline normalization, no parsing.
+///
+/// Returns:
+/// * `Some(contents)` when the file exists, is a regular file within the size
+///   cap, and holds valid UTF-8.
+/// * `None` when the file is missing, empty, larger than [`MAX_SINK_BYTES`], not
+///   a regular file, or not valid UTF-8.
+///
+/// Empty and unwritten collapse to the same `None` signal so a consumer never
+/// observes `Some("")` and a child that "opts out" by not writing behaves
+/// identically to one that never touched the file.
+pub fn read_sink_verbatim(path: &Path) -> Option<String> {
+    let meta = std::fs::metadata(path).ok()?;
+    if !meta.is_file() {
+        return None;
+    }
+    let len = meta.len();
+    if len == 0 || len > MAX_SINK_BYTES {
+        return None;
+    }
+
+    let bytes = std::fs::read(path).ok()?;
+    // Re-check the actual read size to guard against a file that grew between
+    // the metadata probe and the read (TOCTOU): stay bounded regardless.
+    if bytes.is_empty() || bytes.len() as u64 > MAX_SINK_BYTES {
+        return None;
+    }
+
+    String::from_utf8(bytes).ok()
+}

--- a/crates/amplihack-orchestration/src/result_sink.rs
+++ b/crates/amplihack-orchestration/src/result_sink.rs
@@ -102,8 +102,10 @@ pub fn read_sink_verbatim(path: &Path) -> Option<String> {
     }
 
     let bytes = std::fs::read(path).ok()?;
-    // Re-check the actual read size to guard against a file that grew between
-    // the metadata probe and the read (TOCTOU): stay bounded regardless.
+    // Re-check on the bytes actually read: the file may have changed between the
+    // metadata probe and the read (TOCTOU). Reject if it grew past the cap or
+    // shrank to empty, so both the size bound and the empty-is-None invariant
+    // hold regardless of a concurrent write.
     if bytes.is_empty() || bytes.len() as u64 > MAX_SINK_BYTES {
         return None;
     }

--- a/crates/amplihack-orchestration/tests/prompt_delivery_lifecycle.rs
+++ b/crates/amplihack-orchestration/tests/prompt_delivery_lifecycle.rs
@@ -104,6 +104,7 @@ async fn process_runner_uses_delivery_path_for_large_delegate_prompt() {
                 timeout: Some(Duration::from_secs(5)),
                 model: None,
                 working_dir: Some(Path::new("/tmp").to_path_buf()),
+                result_sink: None,
             },
             PromptDelivery::Auto,
             DeliveryCaps {

--- a/crates/amplihack-orchestration/tests/result_sink_channel.rs
+++ b/crates/amplihack-orchestration/tests/result_sink_channel.rs
@@ -1,0 +1,208 @@
+//! TDD red-phase proving tests for the **clean result channel** end to end.
+//!
+//! This is the load-bearing evidence for the feature: a child floods **stdout**
+//! with ANSI colour, a startup banner, and tracing-style log lines that
+//! themselves contain JSON braces (a decoy `{ "verdict": "REJECT" }`), while it
+//! writes its real answer (`{ "verdict": "MERGE" }`, itself full of ANSI/braces/
+//! quotes) to the runner-provided sink named by `AMPLIHACK_RESULT_SINK`.
+//!
+//! The tests assert the answer is recovered **verbatim** from
+//! `ProcessResult.result` with ZERO stdout scraping — no `strip_ansi`, no
+//! `extract_json`, no balanced-brace scan, no `serde`. These are exactly the
+//! conditions that break `extract_json_payload` today.
+//!
+//! They fail until the feature exists (`RunOptions::with_result_sink`,
+//! `ProcessResult.result`, and the runner threading the sink env through
+//! `run_delivered_command`). See docs/reference/clean-result-channel.md.
+//!
+//! POSIX-only: the fake agent is a `sh -c` script standing in for a real
+//! claude/copilot binary that honours the invocation contract.
+
+#![cfg(unix)]
+
+use std::process::{Command as StdCommand, Stdio};
+use std::time::Duration;
+
+use amplihack_orchestration::claude_process::{ProcessResult, RunOptions, TokioProcessRunner};
+use amplihack_orchestration::result_sink;
+use amplihack_utils::prompt_delivery::{DeliveryCaps, PromptDelivery};
+
+/// A fake agent: pours a noisy human/log firehose onto stdout, then — only if
+/// the clean channel is enabled — copies its exact answer bytes (`$1`, an
+/// answer-source file path delivered via argv) to `$AMPLIHACK_RESULT_SINK`.
+///
+/// The stdout stream deliberately carries ANSI SGR escapes, a banner, tracing
+/// lines with real JSON braces, and a DECOY `{ "verdict": "REJECT" }` blob — so
+/// any consumer that brace-scans stdout would recover the WRONG verdict.
+const FAKE_AGENT_SCRIPT: &str = r#"
+printf '\033[1;33m========== STARTUP BANNER ==========\033[0m\n'
+printf '\033[31m2024-07-06T00:00:00Z INFO agent booting {"phase":"init","ok":true}\033[0m\n'
+printf '\033[36mprogress: [####------] 40%%\033[0m\n'
+printf 'noise { "verdict": "REJECT" } <- decoy brace-blob on stdout\n'
+if [ -n "${AMPLIHACK_RESULT_SINK:-}" ]; then
+  cat "$1" > "$AMPLIHACK_RESULT_SINK"
+fi
+"#;
+
+/// The child's real answer. Contains ANSI escapes, JSON braces, a stray `}`,
+/// and quotes — the payload shape that defeats stdout scraping.
+fn agent_answer() -> String {
+    "\u{1b}[32mFINAL\u{1b}[0m { \"verdict\": \"MERGE\", \"reason\": \"clean handoff; contains } and 'quotes'\" }\n"
+        .to_string()
+}
+
+/// Migration example (mirrors docs/reference/clean-result-channel.md):
+/// obtain the agent's answer from the clean channel with NO stdout scraping.
+/// No strip_ansi. No extract_json. No brace scan. No serde. No guessing.
+fn consume_answer_without_scraping(result: &ProcessResult) -> String {
+    result
+        .result
+        .clone()
+        .unwrap_or_else(|| result.output.clone())
+}
+
+/// Drive the fake agent through the real runner path. `sink` opts the run into
+/// the clean channel; `answer_src` is the file whose exact bytes the agent
+/// copies to the sink (delivered to the child as `$1` via argv).
+async fn run_fake_agent(
+    answer_src: &std::path::Path,
+    sink: Option<std::path::PathBuf>,
+) -> ProcessResult {
+    let runner = TokioProcessRunner::new();
+    let mut opts = RunOptions::new(
+        answer_src.to_string_lossy().into_owned(),
+        "clean-channel-proving".to_string(),
+    );
+    opts.timeout = Some(Duration::from_secs(10));
+    if let Some(path) = sink {
+        opts = opts.with_result_sink(path);
+    }
+
+    // args: `-c <script> sh` — after argv prompt-delivery appends the prompt,
+    // the child sees argv = [sh, -c, <script>, sh, <answer_src>] so $1 is the
+    // answer source path.
+    runner
+        .run_with_prompt_delivery_for_test(
+            opts,
+            PromptDelivery::Argv,
+            DeliveryCaps::argv_only(),
+            "sh",
+            ["-c", FAKE_AGENT_SCRIPT, "sh"],
+        )
+        .await
+}
+
+#[tokio::test]
+async fn result_recovered_verbatim_despite_ansi_log_and_banner_noise() {
+    let dir = tempfile::tempdir().unwrap();
+    let answer = agent_answer();
+    let answer_src = dir.path().join("answer.txt");
+    std::fs::write(&answer_src, answer.as_bytes()).unwrap();
+    let sink = dir.path().join("result.sink");
+
+    let result = run_fake_agent(&answer_src, Some(sink)).await;
+
+    // The clean channel carries the answer EXACTLY — braces, ANSI, quotes,
+    // trailing newline — with zero bleed from stdout.
+    assert_eq!(
+        result.result.as_deref(),
+        Some(answer.as_str()),
+        "the sink answer must be recovered byte-for-byte"
+    );
+
+    // stdout is still the full noisy firehose (capture unaffected)...
+    assert!(
+        result.output.contains("STARTUP BANNER"),
+        "stdout capture must still contain the banner"
+    );
+    assert!(
+        result.output.contains('\u{1b}'),
+        "stdout capture must still contain raw ANSI escapes"
+    );
+    // ...including the DECOY verdict a brace-scanner would wrongly latch onto.
+    assert!(
+        result.output.contains("REJECT"),
+        "stdout carries a decoy verdict; the clean channel must not"
+    );
+    assert!(
+        !result.result.as_deref().unwrap().contains("REJECT"),
+        "the clean answer must be free of stdout's decoy verdict"
+    );
+    assert_ne!(
+        result.result.as_deref(),
+        Some(result.output.as_str()),
+        "result must be the clean channel, not a copy of noisy stdout"
+    );
+}
+
+#[tokio::test]
+async fn migration_example_reads_answer_with_no_stdout_scraping() {
+    let dir = tempfile::tempdir().unwrap();
+    let answer = agent_answer();
+    let answer_src = dir.path().join("answer.txt");
+    std::fs::write(&answer_src, answer.as_bytes()).unwrap();
+    let sink = dir.path().join("result.sink");
+
+    let result = run_fake_agent(&answer_src, Some(sink)).await;
+
+    // The consumer recovers the verbatim verdict using ONLY the clean channel.
+    let recovered = consume_answer_without_scraping(&result);
+    assert_eq!(
+        recovered, answer,
+        "consumer must recover the answer verbatim via result.result alone"
+    );
+    assert!(
+        recovered.contains("MERGE") && !recovered.contains("REJECT"),
+        "consumer got the real MERGE verdict, not the stdout decoy"
+    );
+}
+
+#[tokio::test]
+async fn no_opt_in_yields_none_result_and_unchanged_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+    let answer = agent_answer();
+    let answer_src = dir.path().join("answer.txt");
+    std::fs::write(&answer_src, answer.as_bytes()).unwrap();
+
+    // No sink => legacy behaviour: the agent writes nothing to the channel.
+    let result = run_fake_agent(&answer_src, None).await;
+
+    assert!(
+        result.result.is_none(),
+        "without opt-in, result must be None (zero regression)"
+    );
+    assert!(
+        result.output.contains("STARTUP BANNER"),
+        "stdout capture is unchanged when the channel is off"
+    );
+
+    // The safe consumer idiom degrades to stdout exactly as today.
+    let recovered = consume_answer_without_scraping(&result);
+    assert_eq!(
+        recovered, result.output,
+        "with no clean channel the consumer falls back to stdout verbatim"
+    );
+}
+
+#[test]
+fn inject_sink_env_exports_the_variable_to_the_child() {
+    // The runner uses inject_sink_env on the std::process::Command before spawn.
+    let dir = tempfile::tempdir().unwrap();
+    let sink = dir.path().join("injected.sink");
+
+    let mut cmd = StdCommand::new("sh");
+    cmd.arg("-c")
+        .arg("printf '%s' \"$AMPLIHACK_RESULT_SINK\"")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    result_sink::inject_sink_env(&mut cmd, &sink);
+
+    let out = cmd.output().expect("child should run");
+    assert!(out.status.success());
+    let seen = String::from_utf8(out.stdout).unwrap();
+    assert_eq!(
+        seen,
+        sink.to_string_lossy(),
+        "inject_sink_env must export AMPLIHACK_RESULT_SINK=<path> to the child"
+    );
+}

--- a/crates/amplihack-orchestration/tests/result_sink_env_isolation.rs
+++ b/crates/amplihack-orchestration/tests/result_sink_env_isolation.rs
@@ -1,0 +1,62 @@
+//! TDD red-phase isolation test for SEC-10: no stale sink inheritance.
+//!
+//! When a run does NOT opt into the clean channel, the runner must actively
+//! remove any inherited `AMPLIHACK_RESULT_SINK` from the child's environment so
+//! a stale value from an ancestor process can never silently redirect capture.
+//!
+//! This test mutates process-global environment, so it lives in its own test
+//! binary and is the ONLY test here — no sibling tests can race the mutation.
+//!
+//! It fails until the runner env_removes the variable on the no-opt-in path
+//! (and until `ProcessResult.result` exists). See
+//! docs/reference/clean-result-channel.md (SEC-10).
+
+#![cfg(unix)]
+
+use std::time::Duration;
+
+use amplihack_orchestration::claude_process::{RunOptions, TokioProcessRunner};
+use amplihack_utils::prompt_delivery::{DeliveryCaps, PromptDelivery};
+
+/// Prints whatever `AMPLIHACK_RESULT_SINK` the child actually sees, or the
+/// literal `UNSET` when it is absent/empty.
+const REPORT_ENV_SCRIPT: &str = r#"printf '%s' "${AMPLIHACK_RESULT_SINK:-UNSET}""#;
+
+#[tokio::test]
+async fn no_opt_in_run_strips_inherited_result_sink_from_child() {
+    // Simulate a stale ancestor value in this process's environment.
+    let stale = "/tmp/stale-ancestor-result-sink-value";
+    // SAFETY: single-test binary; no other thread reads/writes env concurrently.
+    unsafe {
+        std::env::set_var("AMPLIHACK_RESULT_SINK", stale);
+    }
+
+    let runner = TokioProcessRunner::new();
+    let mut opts = RunOptions::new("unused-prompt".to_string(), "sec10".to_string());
+    opts.timeout = Some(Duration::from_secs(10));
+    // NOTE: no `with_result_sink` — this run does not opt in.
+
+    let result = runner
+        .run_with_prompt_delivery_for_test(
+            opts,
+            PromptDelivery::Argv,
+            DeliveryCaps::argv_only(),
+            "sh",
+            ["-c", REPORT_ENV_SCRIPT, "sh"],
+        )
+        .await;
+
+    unsafe {
+        std::env::remove_var("AMPLIHACK_RESULT_SINK");
+    }
+
+    assert_eq!(
+        result.output, "UNSET",
+        "SEC-10: a no-opt-in run must env_remove the inherited AMPLIHACK_RESULT_SINK \
+         so the child never sees the stale value {stale:?}"
+    );
+    assert!(
+        result.result.is_none(),
+        "no-opt-in run must yield result == None"
+    );
+}

--- a/crates/amplihack-orchestration/tests/result_sink_module.rs
+++ b/crates/amplihack-orchestration/tests/result_sink_module.rs
@@ -183,6 +183,32 @@ fn read_sink_verbatim_oversize_is_none() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn read_sink_verbatim_refuses_symlinked_sink() {
+    // SEC-13: a sink swapped for a symlink must never be followed. Otherwise a
+    // symlink pointing at a secret would let the runner read that secret and
+    // hand it to a downstream consumer as the "clean" answer. Refuse before
+    // opening so the target file's bytes are never read.
+    use std::os::unix::fs::symlink;
+
+    let dir = tempfile::tempdir().unwrap();
+    let secret = dir.path().join("secret.txt");
+    fs::write(
+        &secret,
+        b"TOP SECRET: the runner must not read this via a symlinked sink",
+    )
+    .unwrap();
+
+    let sink = dir.path().join("evil.sink");
+    symlink(&secret, &sink).unwrap();
+
+    assert!(
+        result_sink::read_sink_verbatim(&sink).is_none(),
+        "a symlinked sink must yield None; its target must never be read"
+    );
+}
+
 // ── Additive struct fields default off ────────────────────────────────
 
 #[test]

--- a/crates/amplihack-orchestration/tests/result_sink_module.rs
+++ b/crates/amplihack-orchestration/tests/result_sink_module.rs
@@ -1,0 +1,230 @@
+//! TDD red-phase contract tests for the **clean result channel** module.
+//!
+//! These tests specify the public surface of
+//! `amplihack_orchestration::result_sink` and the two additive struct fields
+//! (`RunOptions.result_sink`, `ProcessResult.result`) documented in
+//! `docs/reference/clean-result-channel.md`.
+//!
+//! They fail until the feature is implemented:
+//!   * `amplihack_orchestration::result_sink` module does not exist yet,
+//!   * `RunOptions::with_result_sink` / `RunOptions.result_sink` do not exist,
+//!   * `ProcessResult.result` does not exist.
+//!
+//! This is the expected RED state — the file defines the contract Step 8 builds.
+//!
+//! Scope of this file: pure, process-free contract checks that hold on every
+//! platform (verbatim reader semantics, path allocation, field defaults).
+//! End-to-end "verbatim under stdout noise" proving tests live in
+//! `result_sink_channel.rs`; the stale-inheritance (SEC-10) test lives in
+//! `result_sink_env_isolation.rs`.
+
+use std::fs;
+use std::time::Duration;
+
+use amplihack_orchestration::claude_process::{ProcessResult, RunOptions};
+use amplihack_orchestration::result_sink;
+
+// ── Env-var contract ──────────────────────────────────────────────────
+
+#[test]
+fn result_sink_env_const_is_amplihack_result_sink() {
+    // The single stable env var the runner exports to the child. External
+    // consumers (recipe-runner-rs, Simard) key off this exact name.
+    assert_eq!(result_sink::RESULT_SINK_ENV, "AMPLIHACK_RESULT_SINK");
+}
+
+// ── allocate_sink_path ────────────────────────────────────────────────
+
+#[test]
+fn allocate_sink_path_creates_missing_runtime_dir() {
+    let base = tempfile::tempdir().unwrap();
+    let runtime_dir = base.path().join("does-not-exist-yet");
+    assert!(!runtime_dir.exists(), "precondition: runtime dir absent");
+
+    let sink = result_sink::allocate_sink_path(&runtime_dir)
+        .expect("allocate_sink_path should create the runtime dir and return a path");
+
+    assert!(
+        runtime_dir.exists(),
+        "allocate_sink_path must create the runtime dir if needed"
+    );
+    assert!(
+        sink.starts_with(&runtime_dir),
+        "allocated sink {sink:?} must live under the runtime dir {runtime_dir:?}"
+    );
+    assert!(
+        sink.parent().is_some_and(|p| p.exists()),
+        "the parent directory of the allocated sink must exist"
+    );
+}
+
+#[test]
+fn allocate_sink_path_returns_unique_paths() {
+    // Patterns that fan out (debate / n_version / expert_panel) allocate one
+    // sink per parallel spawn; reused paths would race concurrent writes.
+    let runtime_dir = tempfile::tempdir().unwrap();
+    let a = result_sink::allocate_sink_path(runtime_dir.path()).unwrap();
+    let b = result_sink::allocate_sink_path(runtime_dir.path()).unwrap();
+    assert_ne!(a, b, "each allocation must yield a distinct sink path");
+}
+
+#[cfg(unix)]
+#[test]
+fn allocate_sink_path_creates_runtime_dir_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let base = tempfile::tempdir().unwrap();
+    let runtime_dir = base.path().join("runtime-owner-only");
+    let _sink = result_sink::allocate_sink_path(&runtime_dir).unwrap();
+
+    let mode = fs::metadata(&runtime_dir).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o700,
+        "SEC-6: a runner-created runtime dir must be owner-only (0700), got {mode:o}"
+    );
+}
+
+// ── read_sink_verbatim ────────────────────────────────────────────────
+
+#[test]
+fn read_sink_verbatim_missing_file_is_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("never-written.sink");
+    assert!(
+        result_sink::read_sink_verbatim(&path).is_none(),
+        "an unwritten sink must read back as None (consumer falls back to stdout)"
+    );
+}
+
+#[test]
+fn read_sink_verbatim_empty_file_is_none() {
+    // Empty and unwritten collapse to the same signal, so a consumer never
+    // observes Some(\"\") and need not distinguish "opted out" from "wrote nothing".
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.sink");
+    fs::write(&path, b"").unwrap();
+    assert!(
+        result_sink::read_sink_verbatim(&path).is_none(),
+        "a zero-length sink must read back as None, never Some(String::new())"
+    );
+}
+
+#[test]
+fn read_sink_verbatim_recovers_answer_byte_for_byte() {
+    // The exact conditions that break extract_json today: the answer itself
+    // contains ANSI escapes, braces, JSON, and quotes. Verbatim capture must
+    // return them unchanged — no strip, no trim, no parse.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("answer.sink");
+    let answer = "\u{1b}[32mVERDICT\u{1b}[0m: { \"verdict\": \"MERGE\", \"note\": \"has } brace and 'quotes'\" }";
+    fs::write(&path, answer.as_bytes()).unwrap();
+
+    let got = result_sink::read_sink_verbatim(&path)
+        .expect("a written, valid-UTF-8 sink must read back as Some");
+    assert_eq!(got, answer, "sink contents must be recovered byte-for-byte");
+}
+
+#[test]
+fn read_sink_verbatim_preserves_whitespace_and_newlines() {
+    // No trimming, no CRLF/LF normalization.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("whitespace.sink");
+    let answer = "  leading and trailing  \r\nmiddle\nline\n";
+    fs::write(&path, answer.as_bytes()).unwrap();
+
+    let got = result_sink::read_sink_verbatim(&path).unwrap();
+    assert_eq!(
+        got, answer,
+        "leading/trailing whitespace and CRLF/LF must be preserved verbatim"
+    );
+}
+
+#[test]
+fn read_sink_verbatim_non_utf8_is_none() {
+    // result is a String; non-UTF-8 bytes yield None rather than a lossy
+    // replacement (binary payloads are out of scope for v1).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("binary.sink");
+    fs::write(&path, [0xff, 0xfe, 0x00, 0x80]).unwrap();
+    assert!(
+        result_sink::read_sink_verbatim(&path).is_none(),
+        "invalid UTF-8 must read back as None"
+    );
+}
+
+#[test]
+fn read_sink_verbatim_accepts_reasonably_large_answer() {
+    // An answer well within any sane cap round-trips intact.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("large.sink");
+    let answer = "x".repeat(128 * 1024); // 128 KiB — comfortably below any sane cap
+    fs::write(&path, answer.as_bytes()).unwrap();
+
+    let got = result_sink::read_sink_verbatim(&path).unwrap();
+    assert_eq!(got.len(), answer.len());
+    assert_eq!(got, answer);
+}
+
+#[test]
+fn read_sink_verbatim_oversize_is_none() {
+    // SEC-3: reads are bounded. A sink far larger than any sane cap yields
+    // None (consumers fall back to output) rather than an unbounded read.
+    // A sparse file (set_len) proves a correct impl checks the size before
+    // slurping the whole thing into memory.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("oversize.sink");
+    let f = fs::File::create(&path).unwrap();
+    f.set_len(256 * 1024 * 1024).unwrap(); // 256 MiB, sparse
+    drop(f);
+
+    assert!(
+        result_sink::read_sink_verbatim(&path).is_none(),
+        "a sink beyond the bounded read cap must yield None"
+    );
+}
+
+// ── Additive struct fields default off ────────────────────────────────
+
+#[test]
+fn run_options_new_has_no_result_sink() {
+    let opts = RunOptions::new("prompt".into(), "id".into());
+    assert!(
+        opts.result_sink.is_none(),
+        "RunOptions::new must default result_sink to None so existing callers are unchanged"
+    );
+}
+
+#[test]
+fn run_options_with_result_sink_sets_the_field() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("sink");
+    let opts = RunOptions::new("prompt".into(), "id".into()).with_result_sink(path.clone());
+    assert_eq!(
+        opts.result_sink.as_deref(),
+        Some(path.as_path()),
+        "with_result_sink must enable the clean channel for this run"
+    );
+    // Other fields keep their prior defaults.
+    assert!(opts.timeout.is_none());
+    assert!(opts.model.is_none());
+    assert!(opts.working_dir.is_none());
+}
+
+#[test]
+fn process_result_ok_defaults_result_to_none() {
+    let r = ProcessResult::ok("stdout".into(), "pid".into(), Duration::ZERO);
+    assert!(
+        r.result.is_none(),
+        "ProcessResult::ok must default result to None (opt-in feature)"
+    );
+    assert_eq!(r.output, "stdout", "existing fields keep their semantics");
+}
+
+#[test]
+fn process_result_err_defaults_result_to_none() {
+    let r = ProcessResult::err("boom".into(), "pid".into(), Duration::ZERO);
+    assert!(
+        r.result.is_none(),
+        "ProcessResult::err must default result to None"
+    );
+}

--- a/docs/reference/clean-result-channel.md
+++ b/docs/reference/clean-result-channel.md
@@ -189,7 +189,7 @@ adds `result` explicitly — see [Implementation notes](#implementation-notes).
 | `RESULT_SINK_ENV`                       | const | The env-var name the runner exports to the child. Value: `"AMPLIHACK_RESULT_SINK"`.                     |
 | `allocate_sink_path(runtime_dir)`       | fn    | Allocate a fresh, unique, runner-owned sink path under `runtime_dir`. Creates the dir `0700` if needed. |
 | `inject_sink_env(cmd, path)`            | fn    | Export `AMPLIHACK_RESULT_SINK=<path>` onto a `Command`'s environment.                                    |
-| `read_sink_verbatim(path)`              | fn    | Read the sink file's bytes and return `Some(String)` verbatim, or `None` (unwritten / oversize / non-UTF-8). |
+| `read_sink_verbatim(path)`              | fn    | Read the sink file's bytes and return `Some(String)` verbatim, or `None` (unwritten / symlink / oversize / non-UTF-8). |
 
 ```rust
 /// The environment variable name the runner exports to the child process.
@@ -205,8 +205,10 @@ pub fn inject_sink_env(cmd: &mut Command, path: &Path);
 
 /// Read the sink verbatim. Returns:
 ///   - `Some(contents)` when the file exists and is valid UTF-8 within the cap,
-///   - `None` when the file is absent, empty-unwritten, oversize, or not UTF-8.
+///   - `None` when the file is absent, a symlink, empty-unwritten, oversize, or
+///     not UTF-8.
 /// Performs NO ANSI stripping, trimming, newline normalization, or JSON parsing.
+/// A symlinked sink is refused rather than followed (SEC-13).
 pub fn read_sink_verbatim(path: &Path) -> Option<String>;
 ```
 
@@ -438,6 +440,7 @@ The clean channel is designed so that opting in never widens the trust boundary.
 | SEC-6  | The runner creates the run's runtime directory owner-only (`0700` on Unix), keeping every sink inside it private to the owner. The child writes the sink file itself; the runner sets no mode on the file, relying on the owner-only directory to keep it private. |
 | SEC-10 | When the caller does not opt in, the runner `env_remove`s any inherited `AMPLIHACK_RESULT_SINK` so a stale ancestor value can never redirect capture. |
 | SEC-12 | The capability is additive and opt-in; the default path (no sink) is byte-identical to prior behaviour.     |
+| SEC-13 | The reader **refuses a symlinked sink**: `read_sink_verbatim` `lstat`s the path and returns `None` for a symlink rather than following it, so a sink swapped for a symlink can never redirect the runner into reading an arbitrary file (e.g. a secret) and handing it back as the "clean" answer. |
 
 The sink carries a *free-text answer*, not code or a command. It is data, and
 consumers must handle it as data.

--- a/docs/reference/clean-result-channel.md
+++ b/docs/reference/clean-result-channel.md
@@ -68,7 +68,7 @@ consumer.
 flowchart LR
     subgraph Runner
         A["run_delivered_command"]
-        A -->|"1. allocate sink path"| SINK["result-sink file<br/>(runtime dir, 0600)"]
+        A -->|"1. allocate sink path"| SINK["result-sink file<br/>(owner-only 0700 runtime dir)"]
         A -->|"2. export AMPLIHACK_RESULT_SINK=path"| ENV["child env"]
     end
     subgraph Child["Spawned agent / step"]
@@ -389,60 +389,40 @@ plus stray ANSI-looking bytes to `AMPLIHACK_RESULT_SINK`. The test asserts:
 
 ## Implementation notes
 
-This section records the wiring the implementation adds, written against the
-current shape of `crates/amplihack-orchestration/src/claude_process.rs`. It is
-the load-bearing plumbing behind the API above.
-
-**Thread the sink through `run_delivered_command`.** Every execution path funnels
-through one shared executor, today shaped as:
+The plumbing lives in `crates/amplihack-orchestration/src/claude_process.rs`.
+Every execution path funnels through one shared executor,
+`run_delivered_command`, which receives the opted-in sink alongside the
+delivered command:
 
 ```rust
 async fn run_delivered_command(
     delivered: DeliveredProcessCommand,
     timeout: Option<Duration>,
+    result_sink: Option<PathBuf>,
     process_id: String,
     start: Instant,
 ) -> ProcessResult
 ```
 
-It must also receive the opted-in sink (e.g. an added
-`result_sink: Option<PathBuf>` parameter). Both call sites —
-`TokioProcessRunner::run` and the `run_with_prompt_delivery_for_test` helper —
-currently pass only `(delivered, opts.timeout, opts.process_id, start)` and thus
-**drop `opts.result_sink`**. Each must forward it. This is the single biggest
-wiring change; nothing else in the feature works until the sink reaches the
-executor.
-
-**Inject before spawn.** Inside `run_delivered_command`, call
-`result_sink::inject_sink_env(&mut command, &path)` on the
-`std::process::Command` *before* it is converted via `TokioCommand::from(command)`
-and spawned. When no sink is requested, `env_remove(RESULT_SINK_ENV)` on that same
-command so an inherited ancestor value cannot leak to the child (SEC-10).
-
-**Read on the normal-exit path only.** Read the sink verbatim exactly where the
-success `ProcessResult` is constructed (the `Ok(s) => ProcessResult { .. }` arm),
-setting `result: read_sink_verbatim(&path)`. Every early return in
-`run_delivered_command` uses `ProcessResult::err`, which leaves `result = None` —
-so spawn, stdin-write, and timeout failures never touch the sink, matching the
-[error-path semantics](#how-it-works) above.
-
-**Additive struct changes.** `ProcessResult` gains `result: Option<String>` and
-`RunOptions` gains `result_sink: Option<PathBuf>`, both defaulting to `None` in
-`ProcessResult::ok`/`ProcessResult::err` and `RunOptions::new`. Existing
-constructors and pattern-matching call sites that build these structs must be
-updated to the new field, but their observable behaviour is unchanged.
-
-**Test-helper parity.** `run_delivered_command_for_test` funnels through the same
-executor and must thread the sink too, so the proving test (see
-[Migration example](#migration-example-dropping-stdout-scraping)) can point a
-child at `AMPLIHACK_RESULT_SINK` and assert verbatim recovery under a stdout
-noise storm.
-
-**Concurrency falls out naturally.** Because the sink is per invocation of
-`run_delivered_command`, each parallel `run()` in `debate` / `n_version` /
-`expert_panel` gets its own channel as long as callers allocate a distinct path
-per run (see the concurrency note under
-[`result_sink` module](#result_sink-module)).
+- **Inject before spawn.** When a sink is requested, the executor calls
+  `result_sink::inject_sink_env` on the `std::process::Command` before it is
+  converted via `TokioCommand::from(command)` and spawned. When none is
+  requested it `env_remove`s `RESULT_SINK_ENV` so an inherited ancestor value
+  cannot leak to the child (SEC-10).
+- **Read on the normal-exit path only.** The sink is read verbatim exactly where
+  the success `ProcessResult` is built. Every early return (spawn, stdin-write,
+  or timeout failure) uses `ProcessResult::err`, which leaves `result = None`, so
+  a failed run never touches the sink — matching the
+  [error-path semantics](#how-it-works) above.
+- **Additive fields.** `ProcessResult.result` and `RunOptions.result_sink` both
+  default to `None` in `ProcessResult::ok` / `ProcessResult::err` and
+  `RunOptions::new`, so existing constructors and call sites compile and behave
+  unchanged.
+- **Concurrency falls out naturally.** The sink is per invocation of
+  `run_delivered_command`, so each parallel `run()` in `debate` / `n_version` /
+  `expert_panel` gets its own channel as long as callers allocate a distinct
+  path per run (see the concurrency note under
+  [`result_sink` module](#result_sink-module)).
 
 ---
 
@@ -455,7 +435,7 @@ The clean channel is designed so that opting in never widens the trust boundary.
 | SEC-1  | The sink path is **runner-owned** — allocated by `allocate_sink_path`, never taken from untrusted recipe context. Recipe-context injection drops `AMPLIHACK_`-prefixed keys, so a recipe cannot set the sink path itself. |
 | SEC-3  | Reads are **bounded** by a size cap; an oversize sink yields `None`, never an unbounded allocation.         |
 | SEC-5  | `result` is treated as **untrusted** child output — same trust level as `output`. Consumers must not `eval`/execute it. |
-| SEC-6  | The sink lives under the run's runtime directory, created with owner-only (`0700` dir / `0600` file) permissions where the platform supports them. |
+| SEC-6  | The runner creates the run's runtime directory owner-only (`0700` on Unix), keeping every sink inside it private to the owner. The child writes the sink file itself; the runner sets no mode on the file, relying on the owner-only directory to keep it private. |
 | SEC-10 | When the caller does not opt in, the runner `env_remove`s any inherited `AMPLIHACK_RESULT_SINK` so a stale ancestor value can never redirect capture. |
 | SEC-12 | The capability is additive and opt-in; the default path (no sink) is byte-identical to prior behaviour.     |
 

--- a/docs/reference/clean-result-channel.md
+++ b/docs/reference/clean-result-channel.md
@@ -1,0 +1,503 @@
+# Clean Result Channel — Reference
+
+The **clean result channel** is a dedicated, opt-in output path that carries an
+agent or recipe step's *semantic answer* on a channel that is **separate from
+stdout**. Stdout keeps carrying tracing, banners, progress heartbeats, and ANSI
+colour — the "firehose" a human reads. The clean channel carries only what the
+child chose to write as its result, captured **verbatim**.
+
+It exists to end a recurring antipattern: downstream consumers (Simard
+distillation, merge-verdict evaluation, and the in-repo orchestration patterns)
+having to strip ANSI, brace-scan, and `serde`-parse a stream of interleaved logs
+just to recover one agent's answer. When one agent's output feeds another, the
+handoff should be semantic and clean.
+
+Structured output is **not** required. The channel carries free text. The only
+guarantee is fidelity: what the child writes is what the consumer reads, byte
+for byte.
+
+## Contents
+
+- [The problem it replaces](#the-problem-it-replaces)
+- [How it works](#how-it-works)
+- [Quick start](#quick-start)
+- [API reference](#api-reference)
+  - [`RunOptions.result_sink`](#runoptionsresult_sink)
+  - [`ProcessResult.result`](#processresultresult)
+  - [`result_sink` module](#result_sink-module)
+- [Configuration](#configuration)
+  - [`AMPLIHACK_RESULT_SINK`](#amplihack_result_sink)
+- [The invocation contract](#the-invocation-contract)
+- [Verbatim guarantee](#verbatim-guarantee)
+- [Fallback and back-compatibility](#fallback-and-back-compatibility)
+- [Migration example: dropping stdout scraping](#migration-example-dropping-stdout-scraping)
+- [Implementation notes](#implementation-notes)
+- [Security notes](#security-notes)
+- [FAQ](#faq)
+
+---
+
+## The problem it replaces
+
+Today an agent's answer is embedded in `ProcessResult.output` — the child's full
+stdout. To recover the answer, consumers reach for helpers like `extract_json`
+(`crates/amplihack-cli/src/commands/orch.rs`): try ```` ```json ```` fences,
+then untagged fences, then a left-to-right balanced-brace scan with `serde_json`.
+Pattern consumers (`patterns/debate.rs`, `patterns/n_version.rs`,
+`patterns/expert_panel/`) similarly read `result.output` and post-process it.
+
+This is brittle for well-known reasons:
+
+- **ANSI noise.** Colour escapes land in the middle of the payload.
+- **Banner / tracing bleed.** Startup banners and `tracing` lines interleave
+  with the answer and can themselves contain `{` / `}`.
+- **Ambiguous braces.** A brace-scanner can lock onto a log line's JSON-looking
+  fragment instead of the real answer.
+- **Lossy.** Any answer that is *not* JSON (plain prose, a verdict word, a diff)
+  has no reliable anchor to scrape at all.
+
+The clean result channel removes the guessing: the child writes its answer to a
+runner-provided path, and the runner hands that file's exact contents to the
+consumer.
+
+---
+
+## How it works
+
+```mermaid
+flowchart LR
+    subgraph Runner
+        A["run_delivered_command"]
+        A -->|"1. allocate sink path"| SINK["result-sink file<br/>(runtime dir, 0600)"]
+        A -->|"2. export AMPLIHACK_RESULT_SINK=path"| ENV["child env"]
+    end
+    subgraph Child["Spawned agent / step"]
+        ENV --> C["agent"]
+        C -->|"stdout: banner + tracing + ANSI"| OUT["stdout (noisy)"]
+        C -->|"final answer, verbatim"| SINK
+    end
+    OUT -->|"captured as"| RES1["ProcessResult.output"]
+    SINK -->|"read verbatim after exit"| RES2["ProcessResult.result = Some(...)"]
+```
+
+1. A caller opts in by setting `RunOptions.result_sink = Some(path)` (or by
+   letting the runner allocate one — see [`allocate_sink_path`](#result_sink-module)).
+2. Before spawning, the runner exports `AMPLIHACK_RESULT_SINK=<path>` into the
+   child's environment. When the path came from `allocate_sink_path`, its parent
+   directory already exists with owner-only permissions; a caller that supplies
+   its own path via `with_result_sink` owns that directory and its permissions.
+3. The child runs. It writes human/log output to stdout as always, and writes
+   its *final answer* to the file named by `AMPLIHACK_RESULT_SINK`.
+4. After the child exits, the runner reads that file **verbatim** into
+   `ProcessResult.result`.
+5. If the child never wrote the file (opted out, older agent, crash before
+   write), `result` is `None` and consumers fall back to `output`. The sink is
+   read only on the normal-exit path: when the runner returns early (spawn
+   failure, prompt-write failure, or timeout) it emits a `ProcessResult::err`
+   with `result == None` and never reads the sink.
+
+stdout capture is completely unchanged. `output` and `stderr` mean exactly what
+they meant before this feature existed.
+
+---
+
+## Quick start
+
+Opt in from a Rust caller that drives `ProcessRunner`:
+
+```rust
+use amplihack_orchestration::claude_process::{RunOptions, TokioProcessRunner, ProcessRunner};
+use amplihack_orchestration::result_sink;
+
+let runner = TokioProcessRunner::new();
+
+// Allocate a runner-owned sink under the run's runtime directory.
+let sink_path = result_sink::allocate_sink_path(&runtime_dir)?;
+
+let opts = RunOptions::new(prompt, process_id)
+    .with_result_sink(sink_path);
+
+let result = runner.run(opts).await;
+
+// The clean answer — no stdout scraping, no strip_ansi, no brace scan.
+let answer = result.result.as_deref().unwrap_or(&result.output);
+```
+
+From the child side (any agent honouring the contract), writing the answer is
+one line of shell:
+
+```sh
+# The runner sets this when the caller opts in. Empty/unset => legacy behavior.
+if [ -n "${AMPLIHACK_RESULT_SINK:-}" ]; then
+  printf '%s' "$FINAL_ANSWER" > "$AMPLIHACK_RESULT_SINK"
+fi
+```
+
+---
+
+## API reference
+
+The public surface lives in the `amplihack-orchestration` crate.
+
+### `RunOptions.result_sink`
+
+`RunOptions` gains one optional, additive field:
+
+| Field         | Type               | Default | Meaning                                                        |
+| ------------- | ------------------ | ------- | -------------------------------------------------------------- |
+| `result_sink` | `Option<PathBuf>`  | `None`  | When `Some(path)`, enable the clean channel for this run.      |
+
+- `RunOptions::new(prompt, process_id)` sets `result_sink: None`. **Existing
+  callers are unchanged** — the field defaults off.
+- `RunOptions::with_result_sink(path)` is a builder method that returns the
+  options with the sink enabled:
+
+  ```rust
+  let opts = RunOptions::new(prompt, id).with_result_sink(sink_path);
+  ```
+
+All previously existing fields (`prompt`, `process_id`, `timeout`, `model`,
+`working_dir`) keep their exact prior semantics.
+
+### `ProcessResult.result`
+
+`ProcessResult` gains one optional, additive field:
+
+| Field       | Type              | Default | Meaning                                                          |
+| ----------- | ----------------- | ------- | ---------------------------------------------------------------- |
+| `result`    | `Option<String>`  | `None`  | The clean channel contents, read verbatim. `None` = not written. |
+
+Semantics:
+
+- `Some(s)` — the child wrote the sink; `s` is the file's exact contents.
+- `None` — the caller did not opt in, **or** the child did not write the sink,
+  **or** the contents were not valid UTF-8 (see [Verbatim guarantee](#verbatim-guarantee)).
+
+All existing fields (`exit_code`, `output`, `stderr`, `duration`, `process_id`)
+are unchanged. The constructors `ProcessResult::ok(...)` and
+`ProcessResult::err(...)` both initialise `result` to `None`, so callers that go
+through those constructors compile without changes. Code that builds a
+`ProcessResult` via a **struct literal** (e.g. the runner's own success arm)
+adds `result` explicitly — see [Implementation notes](#implementation-notes).
+
+### `result_sink` module
+
+`amplihack_orchestration::result_sink` is the consumer-facing helper module.
+
+| Item                                    | Kind  | Description                                                                                              |
+| --------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------- |
+| `RESULT_SINK_ENV`                       | const | The env-var name the runner exports to the child. Value: `"AMPLIHACK_RESULT_SINK"`.                     |
+| `allocate_sink_path(runtime_dir)`       | fn    | Allocate a fresh, unique, runner-owned sink path under `runtime_dir`. Creates the dir `0700` if needed. |
+| `inject_sink_env(cmd, path)`            | fn    | Export `AMPLIHACK_RESULT_SINK=<path>` onto a `Command`'s environment.                                    |
+| `read_sink_verbatim(path)`              | fn    | Read the sink file's bytes and return `Some(String)` verbatim, or `None` (unwritten / oversize / non-UTF-8). |
+
+```rust
+/// The environment variable name the runner exports to the child process.
+pub const RESULT_SINK_ENV: &str = "AMPLIHACK_RESULT_SINK";
+
+/// Allocate a unique, runner-owned result-sink path under `runtime_dir`.
+/// The directory is created with owner-only permissions if it does not exist.
+pub fn allocate_sink_path(runtime_dir: &Path) -> io::Result<PathBuf>;
+
+/// Export `AMPLIHACK_RESULT_SINK=<path>` onto the environment of the command
+/// that is about to be spawned (call before spawn).
+pub fn inject_sink_env(cmd: &mut Command, path: &Path);
+
+/// Read the sink verbatim. Returns:
+///   - `Some(contents)` when the file exists and is valid UTF-8 within the cap,
+///   - `None` when the file is absent, empty-unwritten, oversize, or not UTF-8.
+/// Performs NO ANSI stripping, trimming, newline normalization, or JSON parsing.
+pub fn read_sink_verbatim(path: &Path) -> Option<String>;
+```
+
+Consumers that only need to read a captured result never call these directly —
+they read `ProcessResult.result`. The module is exposed for callers that
+allocate sinks themselves or that build child commands manually.
+
+> **Concurrency.** One sink serves exactly one run. Patterns that fan out many
+> `ProcessRunner::run` calls in parallel (`debate`, `n_version`, `expert_panel`)
+> must allocate a distinct sink per spawn — reusing one path across concurrent
+> children races their writes. `allocate_sink_path` returns a unique path on each
+> call for this reason.
+
+---
+
+## Configuration
+
+### `AMPLIHACK_RESULT_SINK`
+
+**Type:** absolute path
+**Set by:** the runner (`run_delivered_command`) when the caller opts in via
+`RunOptions.result_sink`
+**Read by:** the spawned agent / recipe step
+
+When present and non-empty, the child should write its final answer to this
+path. When absent or empty, the child behaves exactly as before (answer on
+stdout only). The runner captures the file's contents verbatim into
+`ProcessResult.result` after the child exits.
+
+Important runner behaviours:
+
+- **Opt-in only.** The variable is exported *only* when
+  `RunOptions.result_sink` is `Some`.
+- **No stale inheritance.** When `RunOptions.result_sink` is `None`, the runner
+  actively `env_remove`s `AMPLIHACK_RESULT_SINK` from the child so an inherited
+  value from an ancestor process can never silently redirect capture.
+- **Runner-owned path.** The path is chosen by the runner, not derived from
+  untrusted context, and lives under the run's runtime directory (see
+  [Security notes](#security-notes)).
+
+See also [Environment Variables — Reference](./environment-variables.md#amplihack_result_sink).
+
+---
+
+## The invocation contract
+
+The clean channel is defined as a small, stable contract so that consumers
+outside this crate — the external `recipe-runner-rs` binary and Simard — can
+honour it without linking against `amplihack-orchestration`:
+
+1. **Runner side.** If a step requests the clean channel, the runner:
+   - allocates a private path it owns,
+   - exports `AMPLIHACK_RESULT_SINK=<path>` into the child environment,
+   - after the child exits, reads that path verbatim and exposes it as the
+     step's `result`.
+   If a step does **not** request the channel, `AMPLIHACK_RESULT_SINK` is not
+   present in the child env (and any inherited value is removed).
+
+2. **Agent / step side.** A conforming agent:
+   - checks whether `AMPLIHACK_RESULT_SINK` is set and non-empty,
+   - if so, writes its final semantic answer (free text) to that path,
+   - continues to emit human/log output to stdout as usual.
+   If the variable is unset, the agent does nothing special — its answer remains
+   on stdout for legacy capture.
+
+3. **Consumer side.** A consumer reads the step's `result`. If `result` is
+   present it is authoritative and requires **no** post-processing. If `result`
+   is absent, the consumer falls back to scraping `output` exactly as it does
+   today.
+
+The contract is intentionally minimal: one env var, one file, verbatim capture.
+There is no schema, no framing, no handshake, and no dependency direction from
+the child to this crate.
+
+---
+
+## Verbatim guarantee
+
+`ProcessResult.result` is the sink file's contents **byte for byte**. The runner
+performs **none** of the following:
+
+- ANSI escape stripping
+- leading/trailing whitespace trimming
+- newline normalization (CRLF/LF)
+- JSON or any other parsing / validation
+- truncation of legitimately-sized content
+
+This is the whole point: an answer that *contains* braces, JSON, ANSI-looking
+bytes, banners, or the literal text of a log line is returned unchanged. Nothing
+in the answer can be mistaken for framing, because there is no framing.
+
+Two bounded exceptions, both of which yield `None` rather than a corrupted
+string:
+
+- **Size cap.** Reads are bounded. A sink larger than the cap yields `None`
+  (consumers fall back to `output`). This prevents a hostile or runaway child
+  from forcing an unbounded allocation.
+- **UTF-8.** `result` is a `String`; non-UTF-8 sink bytes yield `None` rather
+  than a lossy replacement. (Answers are text; binary payloads are out of
+  scope for v1.)
+
+Empty file vs. unwritten file: an existing zero-length sink is treated as "not a
+meaningful answer" and reported as `None`, so a child that opts out by simply not
+writing behaves identically to one that never touches the file. Consequently a
+consumer never observes `Some("")` — an empty answer and an unwritten answer are
+deliberately the same signal, and no consumer needs to distinguish them.
+
+---
+
+## Fallback and back-compatibility
+
+The feature is strictly additive and opt-in. The compatibility matrix:
+
+| Caller opts in? | Child writes sink? | `result`        | `output`        | Consumer behaviour                     |
+| --------------- | ------------------ | --------------- | --------------- | -------------------------------------- |
+| No              | —                  | `None`          | stdout (as before) | Legacy: scrape `output`.            |
+| Yes             | No                 | `None`          | stdout          | Falls back to scraping `output`.       |
+| Yes             | Yes                | `Some(answer)`  | stdout          | Reads `result`; no scraping needed.    |
+
+Guarantees:
+
+- Existing recipes and steps that read stdout keep working unchanged.
+- Existing `ProcessResult` / `RunOptions` constructors compile unchanged
+  (`result` and `result_sink` default off).
+- The `extract_json` / brace-scan helpers are **not** removed or deprecated;
+  they remain the fallback path for the "no clean channel" case.
+
+The recommended consumer idiom always degrades safely:
+
+```rust
+// Prefer the clean channel; fall back to stdout only if the child didn't write it.
+let answer = result.result.as_deref().unwrap_or(&result.output);
+```
+
+---
+
+## Migration example: dropping stdout scraping
+
+This is the concrete before/after a consumer follows to stop scraping. It is
+also exercised as an in-repo test proving the answer is recovered verbatim even
+when stdout is saturated with ANSI, tracing, and banner noise.
+
+**Before — scrape a noisy stdout:**
+
+```rust
+// Answer is buried in `output` alongside banners, tracing, and ANSI colour.
+// Must guess where the JSON is and strip escapes — brittle and lossy.
+let raw = result.output;
+let cleaned = strip_ansi(&raw);
+let verdict = extract_json(&cleaned)          // balanced-brace scan
+    .and_then(|v| v.get("verdict").cloned())
+    .and_then(|v| v.as_str().map(str::to_owned))
+    .unwrap_or_default();                     // silently empty on a bad scrape
+```
+
+**After — read the clean channel:**
+
+```rust
+// The step wrote its verdict to the sink. Read it verbatim. Done.
+let verdict = result
+    .result
+    .clone()
+    .expect("step opted into the clean result channel");
+// No strip_ansi. No extract_json. No brace scan. No serde. No guessing.
+```
+
+**The proving test** (shape, in `amplihack-orchestration`): a fake child emits a
+storm of ANSI SGR sequences, `tracing`-style log lines, and a startup banner to
+**stdout**, while writing an answer that itself contains `{ "verdict": "MERGE" }`
+plus stray ANSI-looking bytes to `AMPLIHACK_RESULT_SINK`. The test asserts:
+
+- `result == Some(exact_answer_string)` — byte-for-byte, including the braces
+  and ANSI-looking bytes, with **zero** bleed from stdout;
+- the assertion is reached **without** calling `strip_ansi`, `extract_json`, or
+  any `serde` helper;
+- `output` still contains the full noisy stdout (stdout capture unaffected);
+- the no-opt-in case yields `result == None` with `output` unchanged.
+
+---
+
+## Implementation notes
+
+This section records the wiring the implementation adds, written against the
+current shape of `crates/amplihack-orchestration/src/claude_process.rs`. It is
+the load-bearing plumbing behind the API above.
+
+**Thread the sink through `run_delivered_command`.** Every execution path funnels
+through one shared executor, today shaped as:
+
+```rust
+async fn run_delivered_command(
+    delivered: DeliveredProcessCommand,
+    timeout: Option<Duration>,
+    process_id: String,
+    start: Instant,
+) -> ProcessResult
+```
+
+It must also receive the opted-in sink (e.g. an added
+`result_sink: Option<PathBuf>` parameter). Both call sites —
+`TokioProcessRunner::run` and the `run_with_prompt_delivery_for_test` helper —
+currently pass only `(delivered, opts.timeout, opts.process_id, start)` and thus
+**drop `opts.result_sink`**. Each must forward it. This is the single biggest
+wiring change; nothing else in the feature works until the sink reaches the
+executor.
+
+**Inject before spawn.** Inside `run_delivered_command`, call
+`result_sink::inject_sink_env(&mut command, &path)` on the
+`std::process::Command` *before* it is converted via `TokioCommand::from(command)`
+and spawned. When no sink is requested, `env_remove(RESULT_SINK_ENV)` on that same
+command so an inherited ancestor value cannot leak to the child (SEC-10).
+
+**Read on the normal-exit path only.** Read the sink verbatim exactly where the
+success `ProcessResult` is constructed (the `Ok(s) => ProcessResult { .. }` arm),
+setting `result: read_sink_verbatim(&path)`. Every early return in
+`run_delivered_command` uses `ProcessResult::err`, which leaves `result = None` —
+so spawn, stdin-write, and timeout failures never touch the sink, matching the
+[error-path semantics](#how-it-works) above.
+
+**Additive struct changes.** `ProcessResult` gains `result: Option<String>` and
+`RunOptions` gains `result_sink: Option<PathBuf>`, both defaulting to `None` in
+`ProcessResult::ok`/`ProcessResult::err` and `RunOptions::new`. Existing
+constructors and pattern-matching call sites that build these structs must be
+updated to the new field, but their observable behaviour is unchanged.
+
+**Test-helper parity.** `run_delivered_command_for_test` funnels through the same
+executor and must thread the sink too, so the proving test (see
+[Migration example](#migration-example-dropping-stdout-scraping)) can point a
+child at `AMPLIHACK_RESULT_SINK` and assert verbatim recovery under a stdout
+noise storm.
+
+**Concurrency falls out naturally.** Because the sink is per invocation of
+`run_delivered_command`, each parallel `run()` in `debate` / `n_version` /
+`expert_panel` gets its own channel as long as callers allocate a distinct path
+per run (see the concurrency note under
+[`result_sink` module](#result_sink-module)).
+
+---
+
+## Security notes
+
+The clean channel is designed so that opting in never widens the trust boundary.
+
+| ID     | Control                                                                                                    |
+| ------ | ---------------------------------------------------------------------------------------------------------- |
+| SEC-1  | The sink path is **runner-owned** — allocated by `allocate_sink_path`, never taken from untrusted recipe context. Recipe-context injection drops `AMPLIHACK_`-prefixed keys, so a recipe cannot set the sink path itself. |
+| SEC-3  | Reads are **bounded** by a size cap; an oversize sink yields `None`, never an unbounded allocation.         |
+| SEC-5  | `result` is treated as **untrusted** child output — same trust level as `output`. Consumers must not `eval`/execute it. |
+| SEC-6  | The sink lives under the run's runtime directory, created with owner-only (`0700` dir / `0600` file) permissions where the platform supports them. |
+| SEC-10 | When the caller does not opt in, the runner `env_remove`s any inherited `AMPLIHACK_RESULT_SINK` so a stale ancestor value can never redirect capture. |
+| SEC-12 | The capability is additive and opt-in; the default path (no sink) is byte-identical to prior behaviour.     |
+
+The sink carries a *free-text answer*, not code or a command. It is data, and
+consumers must handle it as data.
+
+---
+
+## FAQ
+
+**Does my answer have to be JSON?**
+No. The channel is free text. JSON, a single verdict word, prose, or a diff are
+all fine — whatever the child writes is returned verbatim.
+
+**What if the child crashes before writing the sink?**
+`result` is `None` and the consumer falls back to `output`. No regression versus
+today.
+
+**Can I use a file descriptor instead of a path?**
+Not in v1. FDs are cross-platform-fragile and cannot be consumed by a pinned-git
+library dependency. A runner-allocated file path is the contract; FD transport is
+explicitly out of scope.
+
+**Does this change the recipe schema?**
+No. v1 requires no recipe-schema change. If a per-step opt-in flag is added
+later it will be `#[serde(default)]` and remain back-compatible.
+
+**Where does the sink file live?**
+Under the run's runtime directory (see
+[`AMPLIHACK_RUNTIME_ROOT`](./environment-variables.md#amplihack_runtime_root)),
+allocated by the runner with owner-only permissions.
+
+**Downstream consumers.** After this ships, pinned consumers (Simard
+distillation, merge-verdict evaluation) can bump their `amplihack-rs` dependency
+and read `ProcessResult.result` / the `AMPLIHACK_RESULT_SINK` contract instead of
+scraping stdout. See the PR body for the exact pinned-rev bump.
+
+---
+
+## See also
+
+- [Environment Variables — Reference](./environment-variables.md#amplihack_result_sink)
+- [RecipeResult Reference](./recipe-result.md)
+- [Rust Runner Execution](./rust-runner-execution.md)
+- [Recipe Runner Logging](./recipe-runner-logging.md)

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -22,6 +22,7 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [AMPLIHACK_NONINTERACTIVE (recipe runner subprocess)](#amplihack_noninteractive-recipe-runner-subprocess)
   - [AMPLIHACK_RECIPE_RUN_ID](#amplihack_recipe_run_id)
   - [AMPLIHACK_RUNTIME_ROOT](#amplihack_runtime_root)
+  - [AMPLIHACK_RESULT_SINK](#amplihack_result_sink)
   - [CLAUDECODE (recipe runner subprocess)](#claudecode-recipe-runner-subprocess)
   - [AMPLIHACK_RECIPE_HEARTBEAT_INTERVAL_SECONDS](#amplihack_recipe_heartbeat_interval_seconds)
   - [AMPLIHACK_RECIPE_SNIPPET_LINES](#amplihack_recipe_snippet_lines)
@@ -493,6 +494,46 @@ inside the active task worktree.
 
 See [Workflow Runtime Artifacts Reference](./workflow-runtime-artifacts.md) for
 the full runtime-root, cleanup, and lifecycle preflight contract.
+
+---
+
+### AMPLIHACK_RESULT_SINK
+
+**Type:** absolute path
+**Set by:** the orchestration runner (`run_delivered_command`) when a caller opts
+in via `RunOptions.result_sink`
+**Read by:** the spawned agent / recipe step
+
+Names the **clean result channel** file for a step. When present and non-empty,
+the child should write its final semantic answer (free text — JSON not required)
+to this path *in addition to* whatever it prints on stdout. After the child
+exits, the runner reads this file **verbatim** into `ProcessResult.result`,
+giving consumers the answer without scraping ANSI / tracing / banner noise out of
+stdout.
+
+Key behaviours:
+
+- **Opt-in only.** Exported *only* when `RunOptions.result_sink` is `Some`.
+  Absent ⇒ legacy stdout-only capture (`result == None`).
+- **No stale inheritance.** When the caller does not opt in, the runner
+  `env_remove`s any inherited `AMPLIHACK_RESULT_SINK` so an ancestor value can
+  never silently redirect capture.
+- **Runner-owned path.** The path is allocated by the runner under the run's
+  runtime directory with owner-only permissions; it is never taken from
+  untrusted recipe context.
+- **Verbatim.** The runner performs no ANSI-strip, trim, newline-normalize, or
+  JSON parse. Oversize or non-UTF-8 contents yield `result == None` (fallback to
+  stdout).
+
+```sh
+# Child-side idiom: honour the channel when the runner provides it.
+if [ -n "${AMPLIHACK_RESULT_SINK:-}" ]; then
+  printf '%s' "$FINAL_ANSWER" > "$AMPLIHACK_RESULT_SINK"
+fi
+```
+
+See the [Clean Result Channel Reference](./clean-result-channel.md) for the full
+contract, API, verbatim guarantee, and migration example.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,4 +220,3 @@ nav:
       - multitask Command: reference/multitask-command.md
       - doctor Command: reference/doctor-command.md
       - Rust Runner Execution: reference/rust-runner-execution.md
-      - Clean Result Channel: reference/clean-result-channel.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
       - Investigation Workflow: claude/workflow/INVESTIGATION_WORKFLOW.md
       - Recipe CLI Commands: howto/recipe-cli-commands.md
       - Recipe CLI Reference: reference/recipe-cli-reference.md
+      - Clean Result Channel: reference/clean-result-channel.md
       - PR Recovery Readiness:
           - Overview: features/pr-recovery-readiness.md
           - How-To: howto/recover-existing-pr-with-default-workflow.md
@@ -219,3 +220,4 @@ nav:
       - multitask Command: reference/multitask-command.md
       - doctor Command: reference/doctor-command.md
       - Rust Runner Execution: reference/rust-runner-execution.md
+      - Clean Result Channel: reference/clean-result-channel.md


### PR DESCRIPTION
Adds a dedicated clean result-sink so a recipe/agent step's answer is captured on a channel separate from the noisy human/log stdout — eliminating the need for downstream consumers to scrape ANSI/log/banner noise (the extract_json_payload / extract_verdict brittle-parsing antipattern that keeps recurring downstream in Simard). Additive/opt-in/back-compatible. Includes a symlink-refusal guard on the sink and bounded read allocation.

Closes #854

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>