### PR TITLE
fix(artifact-guard): exempt registered sibling worktrees from ignored-present scan (#857)

### DIFF
--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -443,11 +443,22 @@ fn scan_ignored_present(
         });
     }
 
+    // Files inside legitimately-registered sibling task worktrees (concurrent
+    // recipe runs nested under `<repo>/worktrees/`) are NOT leaked pollution and
+    // must not be flagged as `nested-worktree` violations (issue #857). Genuine
+    // leaked directories under `worktrees/` (not registered git worktrees) are
+    // still flagged. `git ls-files --others --ignored` recurses into these
+    // gitignored nested worktrees, so we filter their paths out explicitly.
+    let registered_nested = registered_nested_worktree_prefixes(repo);
+
     for raw in output.stdout.split(|byte| *byte == 0) {
         if raw.is_empty() {
             continue;
         }
         let path = String::from_utf8_lossy(raw);
+        if is_inside_registered_nested_worktree(&path, &registered_nested) {
+            continue;
+        }
         add_violation_if_prohibited(
             &path,
             ArtifactSource::IgnoredPresent,
@@ -457,6 +468,56 @@ fn scan_ignored_present(
         );
     }
     Ok(())
+}
+
+/// Repo-relative path prefixes (each ending in `/`) of git worktrees that are
+/// registered under `<repo>/worktrees/`. These are legitimate concurrent task
+/// worktrees created by other recipe runs — not leaked scratch — so the artifact
+/// guard must never flag their contents (issue #857). Best-effort: returns empty
+/// on any git error so the guard fails safe (keeps scanning).
+fn registered_nested_worktree_prefixes(repo: &Path) -> Vec<String> {
+    let Ok(output) = Command::new("git")
+        .args(["-C"])
+        .arg(repo)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let repo_canon = repo.canonicalize().unwrap_or_else(|_| repo.to_path_buf());
+    let mut prefixes = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Some(raw) = line.strip_prefix("worktree ") else {
+            continue;
+        };
+        let wt = Path::new(raw);
+        let wt_canon = wt.canonicalize().unwrap_or_else(|_| wt.to_path_buf());
+        let Ok(rel) = wt_canon.strip_prefix(&repo_canon) else {
+            continue;
+        };
+        let rel = normalize_slashes(rel.to_string_lossy().trim_end_matches('/'));
+        // Only worktrees nested under `<repo>/worktrees/` — never the repo root
+        // itself (rel == "") nor unrelated paths.
+        if rel.starts_with("worktrees/") {
+            prefixes.push(format!("{rel}/"));
+        }
+    }
+    prefixes
+}
+
+/// Whether `raw_path` (a repo-relative scan path) lies inside one of the
+/// `registered` nested-worktree prefixes. See [`registered_nested_worktree_prefixes`].
+fn is_inside_registered_nested_worktree(raw_path: &str, registered: &[String]) -> bool {
+    if registered.is_empty() {
+        return false;
+    }
+    let path = normalize_slashes(raw_path.trim_end_matches('/'));
+    registered
+        .iter()
+        .any(|prefix| path == prefix.trim_end_matches('/') || path.starts_with(prefix.as_str()))
 }
 
 fn add_violation_if_prohibited(

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -355,6 +355,66 @@ fn untracked_nested_worktrees_and_build_artifacts_are_blocked() {
 }
 
 #[test]
+fn ignored_present_inside_registered_sibling_worktree_is_not_flagged() {
+    // Issue #857: concurrent recipe runs create dedicated task worktrees under
+    // `<repo>/worktrees/`. When `worktrees/` is gitignored (as in Simard), each
+    // sibling's ignored files (target/, .pytest_cache, .claude/runtime) surface
+    // via `git ls-files --others --ignored` and were wrongly flagged as
+    // `nested-worktree` leaks, failing every concurrent recipe's finalize.
+    let tmp = repo();
+    write_file(&tmp.path().join(".gitignore"), "worktrees/\n");
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore worktrees"]);
+
+    // A legitimately-registered sibling task worktree.
+    run_git(
+        tmp.path(),
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "worktrees/sibling",
+            "-b",
+            "sibling",
+        ],
+    );
+    // Ignored-present artifacts INSIDE the registered sibling — must be exempt.
+    write_file(
+        &tmp.path()
+            .join("worktrees/sibling/.pytest_cache/CACHEDIR.TAG"),
+        "x\n",
+    );
+    write_file(
+        &tmp.path().join("worktrees/sibling/target/.rustc_info.json"),
+        "{}\n",
+    );
+    // A genuinely-leaked (UNregistered) directory under worktrees/ — still flagged.
+    write_file(
+        &tmp.path().join("worktrees/leaked/target/.rustc_info.json"),
+        "{}\n",
+    );
+
+    let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
+
+    assert!(
+        !report
+            .violations
+            .iter()
+            .any(|v| v.path.starts_with("worktrees/sibling")),
+        "registered sibling worktree wrongly flagged (issue #857): {:?}",
+        report.violations
+    );
+    assert!(
+        report
+            .violations
+            .iter()
+            .any(|v| v.path.starts_with("worktrees/leaked")),
+        "leaked unregistered worktree must still be flagged: {:?}",
+        report.violations
+    );
+}
+
+#[test]
 fn normal_source_files_and_ignored_rust_target_do_not_block_local_development() {
     let tmp = repo();
     write_file(&tmp.path().join("src/lib.rs"), "pub fn ok() {}\n");


### PR DESCRIPTION
Fixes #857.

## Problem
Concurrent default-workflow recipes each create a dedicated task worktree under `<repo>/worktrees/`. When `worktrees/` is gitignored (as in Simard), every sibling worktree's ignored files (`target/`, `.pytest_cache`, `.claude/runtime`) surface via `git ls-files --others --ignored` and were flagged by the guard as `nested-worktree` leaks — failing **every** concurrent recipe at the finalize artifact gate even though its work was clean and CI-green (forced manual per-recipe salvage across ~8 Simard recipes on 2026-07-07).

The destructive nested-worktree *cleanup* already skips `worktrees/` on the main checkout; the *detection* scan (`scan_ignored_present`) had no such exemption.

## Fix
`scan_ignored_present` skips paths inside **registered** git worktrees nested under `worktrees/` (legitimate concurrent runs), while still flagging genuinely-leaked **unregistered** dirs. Registration read from `git worktree list --porcelain`; best-effort (empty on git error → fails safe).

## Test
`ignored_present_inside_registered_sibling_worktree_is_not_flagged`: registered sibling exempt, leaked unregistered still caught. All 18 artifact_guard tests pass; fmt + clippy clean.

Related: #858 (recipe worktrees inheriting caller's dirty branch).