### PR TITLE
Update Cargo.lock with 6 changed files (#860)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplihack"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-memory",
  "async-trait",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-eval"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "serde",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-generator"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "serde",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-asset-resolver-bin"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-cli",
  "tracing",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-blarify"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-builders"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-builders",
  "amplihack-hive",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-context"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-delegation"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "globset",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-domain-agents"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-fleet"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hive"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-cli",
  "amplihack-security",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-launcher"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-types",
  "amplihack-utils",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-memory"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-multilspy"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-orchestration"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-utils",
  "async-trait",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recovery"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-reflection"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-remote"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-safety"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-security"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "once_cell",
  "regex",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-session"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "chrono",
  "filetime",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-utils"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "base64",
  "chrono",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-workflows"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "amplihack-utils",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -36,6 +36,10 @@ Ahoy, matey! Hit a snag? This be yer map to fix common issues and get back on co
 
 - [Startup Conflict Prompt](startup-conflict-prompt.md) - Fix "Uncommitted changes detected in .claude/" prompt on every startup
 
+### Skills
+
+- [`pr-guide` Skill Missing](pr-guide-skill-missing.md) - A bundled skill disappears from the Copilot CLI listing (filesystem-driven staging + registry drift, issue #860)
+
 ### Configuration Problems
 
 - [Hook Configuration](../HOOK_CONFIGURATION_GUIDE.md) - Customize framework behavior

--- a/docs/troubleshooting/pr-guide-skill-missing.md
+++ b/docs/troubleshooting/pr-guide-skill-missing.md
@@ -65,18 +65,26 @@ Then re-run `amplihack install` (or `amplihack update`) to re-stage skills.
 
 ## Regression Guards
 
-To prevent any skill from silently disappearing again, two guard tests were
-added in `tests/integration/skill_frontmatter_name_test.rs` (test binary
+Two layers prevent a skill from silently disappearing again:
+
+**1. Registry ↔ bundle set-equality** — the existing
+`registry_matches_bundled_skill_frontmatter_names` unit test in
+`crates/amplihack-hooks/src/known_skills.rs` asserts the set of bundled
+`SKILL.md` frontmatter names equals the `AMPLIHACK_SKILLS` registry, catching
+any *one-sided* drift (a bundled skill missing from the registry, or a registry
+entry with no matching bundled `SKILL.md`).
+
+**2. `pr-guide` two-sided pin** — a guard test added in
+`tests/integration/skill_frontmatter_name_test.rs` (test binary
 `skill_frontmatter_name`):
 
 | Test | Guards against |
 | --- | --- |
-| `tc_skill_12_registry_matches_bundle` | One-sided drift — a bundled skill missing from the `AMPLIHACK_SKILLS` registry, or a registry entry with no matching bundled `SKILL.md` (count desync). With unique names on both sides this is set-equality between the two sources of truth. |
-| `tc_skill_13_pr_guide_pinned_in_registry_and_bundle` | Wholesale two-sided removal of `pr-guide` (the exact #860 failure). |
+| `tc_skill_13_pr_guide_pinned_in_registry_and_bundle` | Wholesale two-sided removal of `pr-guide` (the exact #860 failure) — a skill dropped from *both* the bundle and the registry at once. |
 
-TC-SKILL-13 pins `pr-guide` concretely on each side so a simultaneous removal
-from *both* the bundle and the registry — which the TC-SKILL-12 drift check
-cannot catch (an empty ⊆ empty comparison stays green) — turns the suite red.
+The set-equality check in layer 1 stays green under a two-sided removal (both
+sets lose the same element), so TC-SKILL-13 pins `pr-guide` concretely on each
+side to turn the suite red for that case.
 
 ## Verifying the Fix
 

--- a/docs/troubleshooting/pr-guide-skill-missing.md
+++ b/docs/troubleshooting/pr-guide-skill-missing.md
@@ -65,20 +65,18 @@ Then re-run `amplihack install` (or `amplihack update`) to re-stage skills.
 
 ## Regression Guards
 
-To prevent any skill from silently disappearing again, four guard tests were
+To prevent any skill from silently disappearing again, two guard tests were
 added in `tests/integration/skill_frontmatter_name_test.rs` (test binary
 `skill_frontmatter_name`):
 
 | Test | Guards against |
 | --- | --- |
-| `tc_skill_12_every_bundled_skill_is_registered` | A bundled skill missing from the `AMPLIHACK_SKILLS` registry. |
-| `tc_skill_13_registry_count_matches_bundle_count` | Count desync between the registry and the on-disk bundle. |
-| `tc_skill_14_pr_guide_pinned_in_registry_and_bundle` | Wholesale two-sided removal of `pr-guide` (the exact #860 failure). |
-| `tc_skill_15_no_registry_bundle_drift` | Any bidirectional drift between bundle frontmatter names and the registry. |
+| `tc_skill_12_registry_matches_bundle` | One-sided drift — a bundled skill missing from the `AMPLIHACK_SKILLS` registry, or a registry entry with no matching bundled `SKILL.md` (count desync). With unique names on both sides this is set-equality between the two sources of truth. |
+| `tc_skill_13_pr_guide_pinned_in_registry_and_bundle` | Wholesale two-sided removal of `pr-guide` (the exact #860 failure). |
 
-TC-SKILL-14 pins `pr-guide` concretely on each side so a simultaneous removal
-from *both* the bundle and the registry — which a plain set-equality check
-cannot catch — turns the suite red.
+TC-SKILL-13 pins `pr-guide` concretely on each side so a simultaneous removal
+from *both* the bundle and the registry — which the TC-SKILL-12 drift check
+cannot catch (an empty ⊆ empty comparison stays green) — turns the suite red.
 
 ## Verifying the Fix
 

--- a/docs/troubleshooting/pr-guide-skill-missing.md
+++ b/docs/troubleshooting/pr-guide-skill-missing.md
@@ -1,0 +1,103 @@
+# `pr-guide` Skill Missing from Copilot CLI - Troubleshooting
+
+> [Home](../index.md) > [Troubleshooting](README.md) > pr-guide skill missing
+
+## Problem
+
+The `pr-guide` skill was previously available in the Copilot CLI skills list but
+no longer appears. It is absent from the skills listing and cannot be invoked,
+even though other skills work as expected.
+
+This is tracked as issue #860. The same failure mode can affect **any** bundled
+skill, not just `pr-guide`.
+
+## Cause
+
+Copilot CLI skill staging is **filesystem-driven**. During install/update,
+`stage_skills` (in `crates/amplihack-cli/src/copilot_setup/staging.rs`) simply
+iterates the directories under `amplifier-bundle/skills/`:
+
+```rust
+for entry in fs::read_dir(source_skills)? {
+    // ... copies each skill directory into ~/.copilot/skills/
+}
+```
+
+A skill is listed in Copilot CLI **if and only if** its bundle directory exists
+on disk at stage time. There is no separate manifest — the directory *is* the
+source of truth for staging.
+
+The skill also has a second source of truth: the compile-time registry
+`AMPLIHACK_SKILLS` in `crates/amplihack-hooks/src/known_skills.rs`, which hook
+and classification code use to recognise skill names.
+
+The root cause of #860 was a **stale-tree checkout** that predated the commit
+adding `pr-guide`. On that tree, `pr-guide` was absent from **both** sources of
+truth at once:
+
+1. `amplifier-bundle/skills/pr-guide/` did not exist → staging never copied it
+   into `~/.copilot/skills/`, so it vanished from the Copilot CLI listing.
+2. `"pr-guide"` was missing from `AMPLIHACK_SKILLS` → hooks did not recognise it.
+
+Because both sides were removed together, a naive set-equality check between the
+two would still have passed (empty ⊆ empty), which is why the drop went silent.
+
+## Solution
+
+Restore `pr-guide` in **both** sources of truth (already present on `main`):
+
+1. Bundle directory `amplifier-bundle/skills/pr-guide/` with a valid
+   `SKILL.md` whose frontmatter is `name: pr-guide`.
+2. The `"pr-guide"` entry in `AMPLIHACK_SKILLS`
+   (`crates/amplihack-hooks/src/known_skills.rs`), kept in sorted order (the
+   registry is queried with `binary_search`), with `skill_count()` matching the
+   on-disk bundle count.
+
+If you are on a stale branch that is missing the skill, do a **surgical**
+restore of only these paths rather than merging or rebasing an old `main`:
+
+```bash
+git checkout origin/main -- amplifier-bundle/skills/pr-guide
+git checkout origin/main -- crates/amplihack-hooks/src/known_skills.rs
+```
+
+Then re-run `amplihack install` (or `amplihack update`) to re-stage skills.
+
+## Regression Guards
+
+To prevent any skill from silently disappearing again, four guard tests were
+added in `tests/integration/skill_frontmatter_name_test.rs` (test binary
+`skill_frontmatter_name`):
+
+| Test | Guards against |
+| --- | --- |
+| `tc_skill_12_every_bundled_skill_is_registered` | A bundled skill missing from the `AMPLIHACK_SKILLS` registry. |
+| `tc_skill_13_registry_count_matches_bundle_count` | Count desync between the registry and the on-disk bundle. |
+| `tc_skill_14_pr_guide_pinned_in_registry_and_bundle` | Wholesale two-sided removal of `pr-guide` (the exact #860 failure). |
+| `tc_skill_15_no_registry_bundle_drift` | Any bidirectional drift between bundle frontmatter names and the registry. |
+
+TC-SKILL-14 pins `pr-guide` concretely on each side so a simultaneous removal
+from *both* the bundle and the registry — which a plain set-equality check
+cannot catch — turns the suite red.
+
+## Verifying the Fix
+
+Confirm the skill is present in both sources of truth and staged for Copilot:
+
+```bash
+# 1. Bundle directory exists with valid frontmatter
+cat amplifier-bundle/skills/pr-guide/SKILL.md | head -5   # expect: name: pr-guide
+
+# 2. Registry entry present
+grep '"pr-guide"' crates/amplihack-hooks/src/known_skills.rs
+
+# 3. Regression guards pass
+cargo test -p amplihack --test skill_frontmatter_name
+
+# 4. After install/update, the skill is staged for Copilot CLI
+ls ~/.copilot/skills/pr-guide/SKILL.md
+```
+
+All four checks should succeed. If step 4 is missing the file, re-run
+`amplihack install` and confirm the bundle directory from step 1 exists at
+stage time.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {

--- a/tests/integration/skill_frontmatter_name_test.rs
+++ b/tests/integration/skill_frontmatter_name_test.rs
@@ -13,18 +13,25 @@
 //! TC-SKILL-03 validates that `activation_keywords` also comply.
 //! TC-SKILL-04 verifies the SKILL_CATALOG.md references `amplihack-migrate`.
 //!
+//! TC-SKILL-12..15 are the issue #860 regression guards: they pin the
+//! `pr-guide` skill and enforce registry ↔ bundle consistency so a skill can
+//! never silently disappear from the Copilot CLI listing again (see
+//! `docs/troubleshooting/pr-guide-skill-missing.md`).
+//!
 //! # Running
 //!
 //! ```bash
 //! cargo test --test skill_frontmatter_name -- --nocapture
 //! ```
 
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+use amplihack_hooks::known_skills::{is_amplihack_skill, skill_count};
 use regex::Regex;
 use serde_yaml::Value;
 
@@ -533,5 +540,215 @@ fn tc_skill_11_frontmatter_is_valid_yaml() {
         violations.is_empty(),
         "SKILL.md frontmatter must be valid YAML:\n{}",
         violations.join("\n")
+    );
+}
+
+// ── Issue #860 regression guards: registry ↔ bundle consistency ─────────────────
+//
+// Root cause of #860: a stale-tree checkout dropped the `pr-guide` skill from
+// *both* the bundle (`amplifier-bundle/skills/pr-guide/`) and the compile-time
+// registry (`crates/amplihack-hooks/src/known_skills.rs`). Copilot CLI staging
+// is filesystem-driven, so once the bundle directory was gone the skill
+// disappeared from the listing. These guards pin the fix and detect drift:
+//
+//   * TC-SKILL-12 — every bundled skill is registered. Catches one-sided drift
+//     where a bundle skill is missing from the registry.
+//   * TC-SKILL-13 — the registry count equals the on-disk bundle SKILL.md
+//     count. Catches count desync between the two sources of truth.
+//   * TC-SKILL-14 — `pr-guide` is pinned in *both* the registry and the bundle.
+//     This is the explicit #860 backstop: it goes red on the two-sided
+//     wholesale removal that a plain set-equality check cannot catch (an empty
+//     ⊆ empty comparison stays green).
+//   * TC-SKILL-15 — no bidirectional drift between the bundle frontmatter-name
+//     set and the registry, with per-skill diagnostics.
+//
+// These tests reuse the file's existing helpers (`skills_dir`, `skill_files`,
+// `extract_frontmatter_name`, `relative_path`) plus the public
+// `amplihack_hooks::known_skills` API. No production code change is required on
+// this branch — `pr-guide` is already present in both sources.
+
+/// TC-SKILL-12: Every bundled skill's frontmatter `name:` must appear in the
+/// `AMPLIHACK_SKILLS` registry (`is_amplihack_skill(name) == true`).
+///
+/// A bundle skill missing from the registry is the one-sided drift that leaves
+/// the skill on disk but unrecognised by hook/classification code.
+#[test]
+fn tc_skill_12_every_bundled_skill_is_registered() {
+    let skills = skills_dir();
+    if !skills.is_dir() {
+        eprintln!(
+            "SKIP: amplifier-bundle/skills/ not found at {}",
+            skills.display()
+        );
+        return;
+    }
+
+    let files = skill_files();
+    assert!(
+        !files.is_empty(),
+        "Expected to find SKILL.md files under {}",
+        skills.display()
+    );
+
+    let mut unregistered = Vec::new();
+    for path in files {
+        let content = fs::read_to_string(path).expect("read SKILL.md");
+        let name = extract_frontmatter_name(&content).unwrap_or_else(|| {
+            panic!(
+                "SKILL.md must have a frontmatter name: field: {}",
+                relative_path(path)
+            )
+        });
+        if !is_amplihack_skill(&name) {
+            unregistered.push(format!(
+                "  {} → name: \"{}\" is not in the AMPLIHACK_SKILLS registry",
+                relative_path(path),
+                name
+            ));
+        }
+    }
+
+    assert!(
+        unregistered.is_empty(),
+        "Every bundled skill must be registered in known_skills.rs \
+         (Copilot CLI recognition depends on it):\n{}",
+        unregistered.join("\n")
+    );
+}
+
+/// TC-SKILL-13: The registry `skill_count()` must equal the number of bundled
+/// `SKILL.md` files on disk.
+///
+/// A mismatch means the registry array and the bundle directory have drifted
+/// out of sync — exactly the class of failure that hid `pr-guide`.
+#[test]
+fn tc_skill_13_registry_count_matches_bundle_count() {
+    let skills = skills_dir();
+    if !skills.is_dir() {
+        eprintln!(
+            "SKIP: amplifier-bundle/skills/ not found at {}",
+            skills.display()
+        );
+        return;
+    }
+
+    let bundle_count = skill_files().len();
+    assert!(
+        bundle_count > 0,
+        "Expected to find bundled SKILL.md files under {}",
+        skills.display()
+    );
+
+    assert_eq!(
+        skill_count(),
+        bundle_count,
+        "Registry skill_count() ({}) must equal the bundled SKILL.md count ({}); \
+         the registry and bundle have drifted",
+        skill_count(),
+        bundle_count
+    );
+}
+
+/// TC-SKILL-14: `pr-guide` must be pinned in *both* the registry and the
+/// bundle. Direct regression guard for issue #860.
+///
+/// This is the backstop for the wholesale two-sided removal: unlike a plain
+/// set-equality check (which stays green when a skill vanishes from both
+/// sides), this test asserts the skill's concrete presence on each side.
+#[test]
+fn tc_skill_14_pr_guide_pinned_in_registry_and_bundle() {
+    // Registry side — enforced unconditionally.
+    assert!(
+        is_amplihack_skill("pr-guide"),
+        "pr-guide must be registered in known_skills.rs (regression guard for issue #860)"
+    );
+
+    // Bundle side — a SKILL.md whose frontmatter name is exactly `pr-guide`.
+    let skills = skills_dir();
+    if !skills.is_dir() {
+        eprintln!(
+            "SKIP: amplifier-bundle/skills/ not found at {} (registry check still enforced)",
+            skills.display()
+        );
+        return;
+    }
+
+    let bundled_pr_guide = skill_files().iter().find(|path| {
+        let content = fs::read_to_string(path).expect("read SKILL.md");
+        extract_frontmatter_name(&content).as_deref() == Some("pr-guide")
+    });
+
+    assert!(
+        bundled_pr_guide.is_some(),
+        "A bundled SKILL.md with frontmatter name \"pr-guide\" must exist under {} \
+         (regression guard for issue #860)",
+        skills.display()
+    );
+}
+
+/// TC-SKILL-15: No bidirectional drift between the bundle frontmatter-name set
+/// and the registry.
+///
+/// Because bundled skill names are unique (TC-SKILL-08) and registry entries
+/// are strictly sorted/unique (`skills_are_sorted_for_binary_search`), the
+/// conjunction of "every bundled name is registered" and "counts are equal"
+/// is equivalent to set-equality between the two sources of truth.
+#[test]
+fn tc_skill_15_no_registry_bundle_drift() {
+    let skills = skills_dir();
+    if !skills.is_dir() {
+        eprintln!(
+            "SKIP: amplifier-bundle/skills/ not found at {}",
+            skills.display()
+        );
+        return;
+    }
+
+    let files = skill_files();
+    assert!(
+        !files.is_empty(),
+        "Expected to find SKILL.md files under {}",
+        skills.display()
+    );
+
+    let bundled: BTreeSet<String> = files
+        .iter()
+        .map(|path| {
+            let content = fs::read_to_string(path).expect("read SKILL.md");
+            extract_frontmatter_name(&content).unwrap_or_else(|| {
+                panic!(
+                    "SKILL.md must have a frontmatter name: field: {}",
+                    relative_path(path)
+                )
+            })
+        })
+        .collect();
+
+    // Direction 1: every bundled name must be registered.
+    let missing_from_registry: Vec<&String> = bundled
+        .iter()
+        .filter(|name| !is_amplihack_skill(name))
+        .collect();
+    assert!(
+        missing_from_registry.is_empty(),
+        "Bundled skills missing from the known_skills.rs registry:\n{}",
+        missing_from_registry
+            .iter()
+            .map(|name| format!("  {name}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    // Direction 2: the registry must not carry entries without a bundle file.
+    // With direction 1 holding and both sides unique, equal cardinality proves
+    // the registry has no extra (unbundled) skill names.
+    assert_eq!(
+        skill_count(),
+        bundled.len(),
+        "Registry has {} entrie(s) with no matching bundled SKILL.md \
+         (registry_count={}, bundle_count={})",
+        skill_count() as i64 - bundled.len() as i64,
+        skill_count(),
+        bundled.len()
     );
 }

--- a/tests/integration/skill_frontmatter_name_test.rs
+++ b/tests/integration/skill_frontmatter_name_test.rs
@@ -13,10 +13,12 @@
 //! TC-SKILL-03 validates that `activation_keywords` also comply.
 //! TC-SKILL-04 verifies the SKILL_CATALOG.md references `amplihack-migrate`.
 //!
-//! TC-SKILL-12..13 are the issue #860 regression guards: TC-SKILL-12 enforces
-//! registry ↔ bundle consistency (no one-sided drift) and TC-SKILL-13 pins the
-//! `pr-guide` skill on both sides, so a skill can never silently disappear from
-//! the Copilot CLI listing again (see
+//! TC-SKILL-13 is the issue #860 regression guard: it pins the `pr-guide`
+//! skill on *both* sources of truth (bundle + registry) so a skill can never
+//! silently disappear from the Copilot CLI listing again. It complements the
+//! existing `registry_matches_bundled_skill_frontmatter_names` unit test in
+//! `crates/amplihack-hooks/src/known_skills.rs`, which already asserts full
+//! set-equality between the bundle and the registry (see
 //! `docs/troubleshooting/pr-guide-skill-missing.md`).
 //!
 //! # Running
@@ -31,7 +33,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
-use amplihack_hooks::known_skills::{is_amplihack_skill, skill_count};
+use amplihack_hooks::known_skills::is_amplihack_skill;
 use regex::Regex;
 use serde_yaml::Value;
 
@@ -543,102 +545,34 @@ fn tc_skill_11_frontmatter_is_valid_yaml() {
     );
 }
 
-// ── Issue #860 regression guards: registry ↔ bundle consistency ─────────────────
+// ── Issue #860 regression guard: `pr-guide` pinned on both sources of truth ──────
 //
 // Root cause of #860: a stale-tree checkout dropped the `pr-guide` skill from
 // *both* the bundle (`amplifier-bundle/skills/pr-guide/`) and the compile-time
 // registry (`crates/amplihack-hooks/src/known_skills.rs`). Copilot CLI staging
 // is filesystem-driven, so once the bundle directory was gone the skill
-// disappeared from the listing. Two guards pin the fix:
+// disappeared from the listing.
 //
-//   * TC-SKILL-12 — no one-sided drift: every bundled skill is registered and
-//     the registry count equals the on-disk bundle count. Given unique names on
-//     both sides this is set-equality between the two sources of truth.
-//   * TC-SKILL-13 — `pr-guide` is pinned concretely on *both* sides. This is the
-//     #860 backstop for the wholesale two-sided removal, which TC-SKILL-12
-//     cannot catch (dropping a skill from both sides keeps the counts equal and
-//     leaves no bundled name unregistered).
+// Registry ↔ bundle set-equality (no one-sided drift) is already enforced by the
+// `registry_matches_bundled_skill_frontmatter_names` unit test in known_skills.rs.
+// Like any set-equality check it has a single blind spot: a *two-sided* removal
+// that drops a skill from the bundle and the registry together keeps the two sets
+// equal and stays green. TC-SKILL-13 is the backstop for exactly that case — it
+// pins `pr-guide` concretely on each side.
 //
-// These tests reuse the file's existing helpers (`skills_dir`, `skill_files`,
+// This test reuses the file's existing helpers (`skills_dir`,
 // `extract_frontmatter_name`, `relative_path`) plus the public
 // `amplihack_hooks::known_skills` API. No production code change is required on
 // this branch — `pr-guide` is already present in both sources.
 
-/// TC-SKILL-12: No drift between the bundle and the `AMPLIHACK_SKILLS` registry.
-///
-/// Guards both one-sided drift directions that can hide a skill:
-///   * a bundled skill whose frontmatter `name:` is missing from the registry
-///     (on disk but unrecognised by hook/classification code), and
-///   * a registry entry with no matching bundled `SKILL.md` (recognised by name
-///     but never staged for Copilot CLI).
-///
-/// Because bundled names are unique (TC-SKILL-08) and registry entries are
-/// strictly sorted/unique (`skills_are_sorted_for_binary_search`), "every
-/// bundled name is registered" plus "equal counts" is exactly set-equality
-/// between the two sources of truth.
-#[test]
-fn tc_skill_12_registry_matches_bundle() {
-    let skills = skills_dir();
-    if !skills.is_dir() {
-        eprintln!(
-            "SKIP: amplifier-bundle/skills/ not found at {}",
-            skills.display()
-        );
-        return;
-    }
-
-    let files = skill_files();
-    assert!(
-        !files.is_empty(),
-        "Expected to find SKILL.md files under {}",
-        skills.display()
-    );
-
-    // Direction 1: every bundled skill's frontmatter name is registered.
-    let mut unregistered = Vec::new();
-    for path in files {
-        let content = fs::read_to_string(path).expect("read SKILL.md");
-        let name = extract_frontmatter_name(&content).unwrap_or_else(|| {
-            panic!(
-                "SKILL.md must have a frontmatter name: field: {}",
-                relative_path(path)
-            )
-        });
-        if !is_amplihack_skill(&name) {
-            unregistered.push(format!(
-                "  {} → name: \"{}\" is not in the AMPLIHACK_SKILLS registry",
-                relative_path(path),
-                name
-            ));
-        }
-    }
-    assert!(
-        unregistered.is_empty(),
-        "Every bundled skill must be registered in known_skills.rs \
-         (Copilot CLI recognition depends on it):\n{}",
-        unregistered.join("\n")
-    );
-
-    // Direction 2: the registry count equals the on-disk bundle count. With
-    // direction 1 holding and both sides unique, equal cardinality proves the
-    // registry carries no extra (unbundled) entries.
-    assert_eq!(
-        skill_count(),
-        files.len(),
-        "Registry skill_count() ({}) must equal the bundled SKILL.md count ({}); \
-         the registry and bundle have drifted",
-        skill_count(),
-        files.len()
-    );
-}
-
 /// TC-SKILL-13: `pr-guide` must be pinned in *both* the registry and the
 /// bundle. Direct regression guard for issue #860.
 ///
-/// This is the backstop for the wholesale two-sided removal: unlike the drift
-/// check in TC-SKILL-12 (which stays green when a skill vanishes from *both*
-/// sides — counts still match and no bundled name is left unregistered), this
-/// test asserts the skill's concrete presence on each side.
+/// This is the backstop for the wholesale two-sided removal: the
+/// `registry_matches_bundled_skill_frontmatter_names` set-equality check in
+/// known_skills.rs stays green when a skill vanishes from *both* sides (both
+/// sets lose the same element), so this test asserts the skill's concrete
+/// presence on each side instead.
 #[test]
 fn tc_skill_13_pr_guide_pinned_in_registry_and_bundle() {
     // Registry side — enforced unconditionally.

--- a/tests/integration/skill_frontmatter_name_test.rs
+++ b/tests/integration/skill_frontmatter_name_test.rs
@@ -13,9 +13,10 @@
 //! TC-SKILL-03 validates that `activation_keywords` also comply.
 //! TC-SKILL-04 verifies the SKILL_CATALOG.md references `amplihack-migrate`.
 //!
-//! TC-SKILL-12..15 are the issue #860 regression guards: they pin the
-//! `pr-guide` skill and enforce registry ↔ bundle consistency so a skill can
-//! never silently disappear from the Copilot CLI listing again (see
+//! TC-SKILL-12..13 are the issue #860 regression guards: TC-SKILL-12 enforces
+//! registry ↔ bundle consistency (no one-sided drift) and TC-SKILL-13 pins the
+//! `pr-guide` skill on both sides, so a skill can never silently disappear from
+//! the Copilot CLI listing again (see
 //! `docs/troubleshooting/pr-guide-skill-missing.md`).
 //!
 //! # Running
@@ -24,7 +25,6 @@
 //! cargo test --test skill_frontmatter_name -- --nocapture
 //! ```
 
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
@@ -549,31 +549,35 @@ fn tc_skill_11_frontmatter_is_valid_yaml() {
 // *both* the bundle (`amplifier-bundle/skills/pr-guide/`) and the compile-time
 // registry (`crates/amplihack-hooks/src/known_skills.rs`). Copilot CLI staging
 // is filesystem-driven, so once the bundle directory was gone the skill
-// disappeared from the listing. These guards pin the fix and detect drift:
+// disappeared from the listing. Two guards pin the fix:
 //
-//   * TC-SKILL-12 — every bundled skill is registered. Catches one-sided drift
-//     where a bundle skill is missing from the registry.
-//   * TC-SKILL-13 — the registry count equals the on-disk bundle SKILL.md
-//     count. Catches count desync between the two sources of truth.
-//   * TC-SKILL-14 — `pr-guide` is pinned in *both* the registry and the bundle.
-//     This is the explicit #860 backstop: it goes red on the two-sided
-//     wholesale removal that a plain set-equality check cannot catch (an empty
-//     ⊆ empty comparison stays green).
-//   * TC-SKILL-15 — no bidirectional drift between the bundle frontmatter-name
-//     set and the registry, with per-skill diagnostics.
+//   * TC-SKILL-12 — no one-sided drift: every bundled skill is registered and
+//     the registry count equals the on-disk bundle count. Given unique names on
+//     both sides this is set-equality between the two sources of truth.
+//   * TC-SKILL-13 — `pr-guide` is pinned concretely on *both* sides. This is the
+//     #860 backstop for the wholesale two-sided removal, which TC-SKILL-12
+//     cannot catch (dropping a skill from both sides keeps the counts equal and
+//     leaves no bundled name unregistered).
 //
 // These tests reuse the file's existing helpers (`skills_dir`, `skill_files`,
 // `extract_frontmatter_name`, `relative_path`) plus the public
 // `amplihack_hooks::known_skills` API. No production code change is required on
 // this branch — `pr-guide` is already present in both sources.
 
-/// TC-SKILL-12: Every bundled skill's frontmatter `name:` must appear in the
-/// `AMPLIHACK_SKILLS` registry (`is_amplihack_skill(name) == true`).
+/// TC-SKILL-12: No drift between the bundle and the `AMPLIHACK_SKILLS` registry.
 ///
-/// A bundle skill missing from the registry is the one-sided drift that leaves
-/// the skill on disk but unrecognised by hook/classification code.
+/// Guards both one-sided drift directions that can hide a skill:
+///   * a bundled skill whose frontmatter `name:` is missing from the registry
+///     (on disk but unrecognised by hook/classification code), and
+///   * a registry entry with no matching bundled `SKILL.md` (recognised by name
+///     but never staged for Copilot CLI).
+///
+/// Because bundled names are unique (TC-SKILL-08) and registry entries are
+/// strictly sorted/unique (`skills_are_sorted_for_binary_search`), "every
+/// bundled name is registered" plus "equal counts" is exactly set-equality
+/// between the two sources of truth.
 #[test]
-fn tc_skill_12_every_bundled_skill_is_registered() {
+fn tc_skill_12_registry_matches_bundle() {
     let skills = skills_dir();
     if !skills.is_dir() {
         eprintln!(
@@ -590,6 +594,7 @@ fn tc_skill_12_every_bundled_skill_is_registered() {
         skills.display()
     );
 
+    // Direction 1: every bundled skill's frontmatter name is registered.
     let mut unregistered = Vec::new();
     for path in files {
         let content = fs::read_to_string(path).expect("read SKILL.md");
@@ -607,56 +612,35 @@ fn tc_skill_12_every_bundled_skill_is_registered() {
             ));
         }
     }
-
     assert!(
         unregistered.is_empty(),
         "Every bundled skill must be registered in known_skills.rs \
          (Copilot CLI recognition depends on it):\n{}",
         unregistered.join("\n")
     );
-}
 
-/// TC-SKILL-13: The registry `skill_count()` must equal the number of bundled
-/// `SKILL.md` files on disk.
-///
-/// A mismatch means the registry array and the bundle directory have drifted
-/// out of sync — exactly the class of failure that hid `pr-guide`.
-#[test]
-fn tc_skill_13_registry_count_matches_bundle_count() {
-    let skills = skills_dir();
-    if !skills.is_dir() {
-        eprintln!(
-            "SKIP: amplifier-bundle/skills/ not found at {}",
-            skills.display()
-        );
-        return;
-    }
-
-    let bundle_count = skill_files().len();
-    assert!(
-        bundle_count > 0,
-        "Expected to find bundled SKILL.md files under {}",
-        skills.display()
-    );
-
+    // Direction 2: the registry count equals the on-disk bundle count. With
+    // direction 1 holding and both sides unique, equal cardinality proves the
+    // registry carries no extra (unbundled) entries.
     assert_eq!(
         skill_count(),
-        bundle_count,
+        files.len(),
         "Registry skill_count() ({}) must equal the bundled SKILL.md count ({}); \
          the registry and bundle have drifted",
         skill_count(),
-        bundle_count
+        files.len()
     );
 }
 
-/// TC-SKILL-14: `pr-guide` must be pinned in *both* the registry and the
+/// TC-SKILL-13: `pr-guide` must be pinned in *both* the registry and the
 /// bundle. Direct regression guard for issue #860.
 ///
-/// This is the backstop for the wholesale two-sided removal: unlike a plain
-/// set-equality check (which stays green when a skill vanishes from both
-/// sides), this test asserts the skill's concrete presence on each side.
+/// This is the backstop for the wholesale two-sided removal: unlike the drift
+/// check in TC-SKILL-12 (which stays green when a skill vanishes from *both*
+/// sides — counts still match and no bundled name is left unregistered), this
+/// test asserts the skill's concrete presence on each side.
 #[test]
-fn tc_skill_14_pr_guide_pinned_in_registry_and_bundle() {
+fn tc_skill_13_pr_guide_pinned_in_registry_and_bundle() {
     // Registry side — enforced unconditionally.
     assert!(
         is_amplihack_skill("pr-guide"),
@@ -683,72 +667,5 @@ fn tc_skill_14_pr_guide_pinned_in_registry_and_bundle() {
         "A bundled SKILL.md with frontmatter name \"pr-guide\" must exist under {} \
          (regression guard for issue #860)",
         skills.display()
-    );
-}
-
-/// TC-SKILL-15: No bidirectional drift between the bundle frontmatter-name set
-/// and the registry.
-///
-/// Because bundled skill names are unique (TC-SKILL-08) and registry entries
-/// are strictly sorted/unique (`skills_are_sorted_for_binary_search`), the
-/// conjunction of "every bundled name is registered" and "counts are equal"
-/// is equivalent to set-equality between the two sources of truth.
-#[test]
-fn tc_skill_15_no_registry_bundle_drift() {
-    let skills = skills_dir();
-    if !skills.is_dir() {
-        eprintln!(
-            "SKIP: amplifier-bundle/skills/ not found at {}",
-            skills.display()
-        );
-        return;
-    }
-
-    let files = skill_files();
-    assert!(
-        !files.is_empty(),
-        "Expected to find SKILL.md files under {}",
-        skills.display()
-    );
-
-    let bundled: BTreeSet<String> = files
-        .iter()
-        .map(|path| {
-            let content = fs::read_to_string(path).expect("read SKILL.md");
-            extract_frontmatter_name(&content).unwrap_or_else(|| {
-                panic!(
-                    "SKILL.md must have a frontmatter name: field: {}",
-                    relative_path(path)
-                )
-            })
-        })
-        .collect();
-
-    // Direction 1: every bundled name must be registered.
-    let missing_from_registry: Vec<&String> = bundled
-        .iter()
-        .filter(|name| !is_amplihack_skill(name))
-        .collect();
-    assert!(
-        missing_from_registry.is_empty(),
-        "Bundled skills missing from the known_skills.rs registry:\n{}",
-        missing_from_registry
-            .iter()
-            .map(|name| format!("  {name}"))
-            .collect::<Vec<_>>()
-            .join("\n")
-    );
-
-    // Direction 2: the registry must not carry entries without a bundle file.
-    // With direction 1 holding and both sides unique, equal cardinality proves
-    // the registry has no extra (unbundled) skill names.
-    assert_eq!(
-        skill_count(),
-        bundled.len(),
-        "Registry has {} entrie(s) with no matching bundled SKILL.md \
-         (registry_count={}, bundle_count={})",
-        skill_count() as i64 - bundled.len() as i64,
-        skill_count(),
-        bundled.len()
     );
 }

--- a/tests/integration/skill_frontmatter_name_test.rs
+++ b/tests/integration/skill_frontmatter_name_test.rs
@@ -647,7 +647,11 @@ fn tc_skill_13_pr_guide_pinned_in_registry_and_bundle() {
         "pr-guide must be registered in known_skills.rs (regression guard for issue #860)"
     );
 
-    // Bundle side — a SKILL.md whose frontmatter name is exactly `pr-guide`.
+    // Bundle side — read the canonical `pr-guide/SKILL.md` that Copilot CLI
+    // staging walks by directory. The #860 root cause was this directory being
+    // dropped, so we probe the exact loader-expected path (one file read, no
+    // full-tree scan) rather than searching every SKILL.md for a matching name;
+    // TC-SKILL-09 already pins frontmatter name == directory name.
     let skills = skills_dir();
     if !skills.is_dir() {
         eprintln!(
@@ -657,15 +661,20 @@ fn tc_skill_13_pr_guide_pinned_in_registry_and_bundle() {
         return;
     }
 
-    let bundled_pr_guide = skill_files().iter().find(|path| {
-        let content = fs::read_to_string(path).expect("read SKILL.md");
-        extract_frontmatter_name(&content).as_deref() == Some("pr-guide")
-    });
-
+    let skill_md = skills.join("pr-guide/SKILL.md");
     assert!(
-        bundled_pr_guide.is_some(),
-        "A bundled SKILL.md with frontmatter name \"pr-guide\" must exist under {} \
+        skill_md.is_file(),
+        "The canonical pr-guide SKILL.md must exist at {} \
          (regression guard for issue #860)",
-        skills.display()
+        relative_path(&skill_md)
+    );
+
+    let content = fs::read_to_string(&skill_md).expect("read pr-guide SKILL.md");
+    assert_eq!(
+        extract_frontmatter_name(&content).as_deref(),
+        Some("pr-guide"),
+        "pr-guide SKILL.md frontmatter name must be \"pr-guide\" at {} \
+         (regression guard for issue #860)",
+        relative_path(&skill_md)
     );
 }


### PR DESCRIPTION
## Summary
Concise workflow-generated PR for Cargo.lock.

## Issue
Closes #860

## Changed files
- Cargo.lock
- Cargo.toml
- docs/troubleshooting/README.md
- docs/troubleshooting/pr-guide-skill-missing.md
- package.json
- tests/integration/skill_frontmatter_name_test.rs

## Diff stat
```text
 Cargo.lock                                       |  58 ++++++------
 Cargo.toml                                       |   2 +-
 docs/troubleshooting/README.md                   |   4 +
 docs/troubleshooting/pr-guide-skill-missing.md   | 109 +++++++++++++++++++++++
 package.json                                     |   2 +-
 tests/integration/skill_frontmatter_name_test.rs |  77 ++++++++++++++++
 6 files changed, 221 insertions(+), 31 deletions(-)
```

## Behavior
Implemented behavior through these branch commits:
e6c8638 feat: Investigate why the 'pr-guide' skill is no longer showing up / being lis
3aaf605 test(skills): drop redundant TC-SKILL-12; existing set-equality guard covers it (#860)
a21bd6f perf(tests): pin pr-guide guard to canonical SKILL.md path (#860)
c746d67 refactor(tests): consolidate #860 skill-drift guards from 4 tests to 2
506d943 test(skills): guard against silent skill drops from Copilot CLI (#860)

## Validation
ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config
I'll start by understanding the current state of the repository and the changes that have been made.

● Get branch, status, and recent commits (shell)
  │ cd /home/azureuser/src/amplihack-rs/worktrees/feat/issue-860-investigate-why-the-pr-guide-skill-
  │ is-no-longer-sh && echo "=== BRANCH ===" && git branch --show-current && echo "=== STATUS ==="
  │ && git --no-pager status && echo "=== RECENT COMMITS ===" && git --no-pager log --oneline -15
  └ 25 lines…

The fix appears to already be committed (4 commits ahead). Let me examine what was changed for issue #860.

● See files changed in the 4 commits (shell)

## Risk
No high-risk subsystem pattern detected from changed paths.

## Checklist
- [x] Branch has 5 commit(s) ahead of main
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*