### PR TITLE
Fix stale smart-orchestrator installed asset shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Unreleased changes appear at the top under `[Unreleased]`.
 
 ### Fixed
 
+- **Stale installed smart-orchestrator assets can shadow fresh bundles (#3698)** —
+  Startup self-heal now validates `~/.amplihack/amplifier-bundle` even when
+  `.installed-version` matches the binary, forcing the normal install repair
+  path when the installed top-level bundle still contains legacy
+  `orch_helper.py` / `importlib` / `parse-decomposition` markers. Recipe
+  resolution also skips stale smart-orchestrator candidates when a compatible
+  fallback exists and fails loudly with repair guidance when every candidate is
+  stale. Install/update compatibility validation remains centralized in
+  `bundle_compat.rs` and validates staged destination assets after copy.
+
 - **default-workflow leaves stray fallback branches + nested worktrees when
   force-push is denied (#808)** — `default-workflow` finalization now runs a
   deterministic, idempotent cleanup. On a denied force-push the run-created

--- a/crates/amplihack-cli/src/auto_update.rs
+++ b/crates/amplihack-cli/src/auto_update.rs
@@ -8,12 +8,16 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 use tracing::{debug, info, warn};
+
+use crate::util::run_with_timeout;
 
 const GITHUB_REPO: &str = "rysweet/amplihack-rs";
 const CACHE_FILE_NAME: &str = "update_cache.json";
 const DEFAULT_CHECK_INTERVAL_HOURS: u64 = 24;
 const DEFAULT_TIMEOUT_SECONDS: u64 = 10;
+const UPGRADE_COMMAND_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Result of comparing the current version against the latest release.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -220,7 +224,9 @@ fn _save_cache(cache_dir: &Path, cache: &UpdateCache) {
 
 /// Run an upgrade subprocess and return its exit code.
 fn _run_upgrade(binary: &Path, args: &[&str]) -> i32 {
-    match Command::new(binary).args(args).status() {
+    let mut command = Command::new(binary);
+    command.args(args);
+    match run_with_timeout(command, UPGRADE_COMMAND_TIMEOUT) {
         Ok(status) => status.code().unwrap_or(1),
         Err(e) => {
             warn!(error = %e, binary = %binary.display(), "Failed to run upgrade command");
@@ -249,7 +255,7 @@ fn _restart_cli(args: &[String]) {
         }
         #[cfg(not(unix))]
         {
-            let _ = cmd.status();
+            let _ = run_with_timeout(cmd, UPGRADE_COMMAND_TIMEOUT);
         }
     }
 }

--- a/crates/amplihack-cli/src/binary_finder.rs
+++ b/crates/amplihack-cli/src/binary_finder.rs
@@ -3,12 +3,13 @@
 //! Uses `which`-style lookup with version verification. No fallbacks:
 //! if the binary isn't found, we error out.
 
-use crate::util::strip_ansi;
+use crate::util::{run_output_with_timeout, strip_ansi, truncate_chars_with_notice};
 use anyhow::{Result, bail};
 use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 /// Metadata about a discovered binary.
 #[derive(Debug, Clone)]
@@ -174,10 +175,13 @@ fn install_fallback_dirs() -> Vec<PathBuf> {
 
 /// Maximum number of characters to retain from a detected version string.
 const MAX_VERSION_LEN: usize = 200;
+const VERSION_DETECTION_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Run `binary --version` and extract a version string.
 fn detect_version(path: &Path) -> Option<String> {
-    let output = Command::new(path).arg("--version").output().ok()?;
+    let mut cmd = Command::new(path);
+    cmd.arg("--version");
+    let output = run_output_with_timeout(cmd, VERSION_DETECTION_TIMEOUT).ok()?;
 
     if !output.status.success() {
         return None;
@@ -188,11 +192,7 @@ fn detect_version(path: &Path) -> Option<String> {
     let first_line = stdout.lines().next()?.trim();
     let version = strip_ansi(first_line);
     // Truncate to avoid unbounded strings from malicious or misbehaving binaries.
-    if version.len() > MAX_VERSION_LEN {
-        Some(version[..MAX_VERSION_LEN].to_string())
-    } else {
-        Some(version)
-    }
+    Some(truncate_chars_with_notice(&version, MAX_VERSION_LEN))
 }
 
 /// Check if a path is executable (Unix: has execute bit).
@@ -335,5 +335,57 @@ mod tests {
         unsafe { env::remove_var("AMPLIHACK_BADTOOL_BINARY_PATH") };
 
         assert!(result.is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detect_version_truncates_without_panicking_on_utf8_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let fake_tool = temp.path().join("version-tool");
+        std::fs::write(
+            &fake_tool,
+            "#!/bin/sh\n\
+             i=0\n\
+             while [ \"$i\" -lt 80 ]; do printf '\\342\\202\\254'; i=$((i + 1)); done\n\
+             printf '\\n'\n",
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&fake_tool).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&fake_tool, perms).unwrap();
+
+        let result = std::panic::catch_unwind(|| detect_version(&fake_tool));
+
+        assert!(
+            result.is_ok(),
+            "detect_version must truncate on UTF-8 boundaries"
+        );
+        assert!(
+            result.unwrap().is_some(),
+            "valid lossy UTF-8 version output should still be detected"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detect_version_is_bounded_for_hanging_binaries() {
+        let temp = tempfile::tempdir().unwrap();
+        let fake_tool = temp.path().join("hanging-version-tool");
+        std::fs::write(&fake_tool, "#!/bin/sh\n/bin/sleep 2\nprintf 'v9.9.9\\n'\n").unwrap();
+        let mut perms = std::fs::metadata(&fake_tool).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&fake_tool, perms).unwrap();
+
+        let started = std::time::Instant::now();
+        let version = detect_version(&fake_tool);
+
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "version detection must not wait for an unbounded child process"
+        );
+        assert!(
+            version.is_none(),
+            "timed-out version probes should not report a stale version"
+        );
     }
 }

--- a/crates/amplihack-cli/src/bootstrap.rs
+++ b/crates/amplihack-cli/src/bootstrap.rs
@@ -6,9 +6,12 @@ use crate::commands::install;
 use crate::copilot_setup;
 use crate::freshness;
 use crate::tool_update_check::{get_installed_version, get_latest_version, sanitize_version};
-use crate::util::{is_noninteractive, run_with_timeout};
+use crate::util::{
+    format_output_diagnostics, is_noninteractive, run_output_with_timeout, run_with_timeout,
+};
 use anyhow::{Context, Result, anyhow, bail};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -18,6 +21,7 @@ use std::time::Duration;
 /// These involve network downloads and can be legitimately slow, so we allow
 /// 5 minutes before treating them as hung.
 const INSTALL_TIMEOUT: Duration = Duration::from_secs(300);
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(300);
 
 pub fn prepare_launcher(tool: &str) -> Result<()> {
     // SEC-WS2-02: Non-interactive mode (CI, pipes, AMPLIHACK_NONINTERACTIVE=1)
@@ -140,6 +144,9 @@ fn ensure_node_for_copilot() -> Result<Option<PathBuf>> {
     let ext = "tar.xz";
     let filename = format!("node-{NODE_AUTO_INSTALL_VERSION}-{os_name}-{arch_name}.{ext}");
     let url = format!("https://nodejs.org/dist/{NODE_AUTO_INSTALL_VERSION}/{filename}");
+    let checksum_filename = "SHASUMS256.txt";
+    let checksum_url =
+        format!("https://nodejs.org/dist/{NODE_AUTO_INSTALL_VERSION}/{checksum_filename}");
 
     println!("  ⬇️  Downloading Node.js {NODE_AUTO_INSTALL_VERSION} ({os_name}-{arch_name})...");
     tracing::info!(%url, "downloading Node.js");
@@ -148,22 +155,24 @@ fn ensure_node_for_copilot() -> Result<Option<PathBuf>> {
         .with_context(|| format!("failed to create {}", runtimes_dir.display()))?;
 
     let tmp_path = runtimes_dir.join(&filename);
+    let checksum_path = runtimes_dir.join(format!("{filename}.{checksum_filename}"));
 
-    let status = Command::new("curl")
-        .args(["-fsSL", "-o"])
-        .arg(&tmp_path)
-        .arg(&url)
-        .status()
-        .context("failed to run curl")?;
-
-    if !status.success() {
+    if let Err(err) = download_with_curl(&url, &tmp_path, "Node.js archive") {
         let _ = fs::remove_file(&tmp_path);
-        bail!(
-            "failed to download Node.js from {url} (exit {})\n\
-             Install Node.js manually: https://nodejs.org/",
-            status.code().unwrap_or(-1)
-        );
+        bail!("{err:#}\nInstall Node.js manually: https://nodejs.org/");
     }
+    if let Err(err) = download_with_curl(&checksum_url, &checksum_path, "Node.js checksum manifest")
+    {
+        let _ = fs::remove_file(&tmp_path);
+        let _ = fs::remove_file(&checksum_path);
+        bail!("{err:#}\nInstall Node.js manually: https://nodejs.org/");
+    }
+    if let Err(err) = verify_node_archive_sha256(&tmp_path, &checksum_path, &filename) {
+        let _ = fs::remove_file(&tmp_path);
+        let _ = fs::remove_file(&checksum_path);
+        bail!("{err:#}\nInstall Node.js manually: https://nodejs.org/");
+    }
+    let _ = fs::remove_file(&checksum_path);
 
     println!("  📦 Installing Node.js {NODE_AUTO_INSTALL_VERSION}...");
 
@@ -177,13 +186,14 @@ fn ensure_node_for_copilot() -> Result<Option<PathBuf>> {
     fs::create_dir_all(&temp_dir)
         .with_context(|| format!("failed to create temp dir {}", temp_dir.display()))?;
 
-    let extract_status = Command::new("tar")
+    let mut extract_cmd = Command::new("tar");
+    extract_cmd
         .args(["--strip-components=1", "-xJf"])
         .arg(&tmp_path)
         .arg("-C")
-        .arg(&temp_dir)
-        .status()
-        .context("failed to run tar")?;
+        .arg(&temp_dir);
+    let extract_status =
+        run_with_timeout(extract_cmd, INSTALL_TIMEOUT).context("failed to run tar")?;
 
     let _ = fs::remove_file(&tmp_path);
 
@@ -217,6 +227,65 @@ fn ensure_node_for_copilot() -> Result<Option<PathBuf>> {
         install_dir.display()
     );
     Ok(Some(bin_dir))
+}
+
+fn download_with_curl(url: &str, destination: &Path, label: &str) -> Result<()> {
+    let mut cmd = Command::new("curl");
+    cmd.args(["-fsSL", "-o"]).arg(destination).arg(url);
+    let output = run_output_with_timeout(cmd, DOWNLOAD_TIMEOUT)
+        .with_context(|| format!("{label} download timed out or failed to execute: {url}"))?;
+    if !output.status.success() {
+        bail!(
+            "{label} download failed from {url}: {}",
+            format_output_diagnostics(&output, 400)
+        );
+    }
+    Ok(())
+}
+
+fn verify_node_archive_sha256(
+    archive_path: &Path,
+    checksum_path: &Path,
+    archive_filename: &str,
+) -> Result<()> {
+    let manifest = fs::read_to_string(checksum_path).with_context(|| {
+        format!(
+            "failed to read Node.js checksum manifest {}",
+            checksum_path.display()
+        )
+    })?;
+    let expected = find_sha256_for_archive(&manifest, archive_filename)?;
+    let mut archive = fs::File::open(archive_path)
+        .with_context(|| format!("failed to read Node.js archive {}", archive_path.display()))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut archive, &mut hasher)
+        .with_context(|| format!("failed to hash Node.js archive {}", archive_path.display()))?;
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected {
+        bail!(
+            "Node.js archive SHA-256 verification failed for {archive_filename}: expected {expected}, got {actual}"
+        );
+    }
+    Ok(())
+}
+
+fn find_sha256_for_archive(manifest: &str, archive_filename: &str) -> Result<String> {
+    let mut matches = manifest.lines().filter_map(|line| {
+        let mut parts = line.split_whitespace();
+        let digest = parts.next()?;
+        let filename = parts.next()?;
+        (filename == archive_filename).then(|| digest.to_ascii_lowercase())
+    });
+    let digest = matches
+        .next()
+        .ok_or_else(|| anyhow!("Node.js checksum manifest does not list {archive_filename}"))?;
+    if matches.next().is_some() {
+        bail!("Node.js checksum manifest lists {archive_filename} more than once");
+    }
+    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("Node.js checksum manifest has an invalid SHA-256 digest for {archive_filename}");
+    }
+    Ok(digest)
 }
 
 pub fn ensure_tool_available(tool: &str) -> Result<BinaryInfo> {
@@ -534,15 +603,29 @@ fn configure_codex() -> Result<()> {
         .with_context(|| format!("failed to create {}", config_dir.display()))?;
     let config_path = config_dir.join("config.json");
 
-    // Load existing config, falling back to an empty object for any error
-    // (missing file, parse error, or non-object JSON value).
-    let mut value = config_path
-        .exists()
-        .then(|| fs::read_to_string(&config_path).ok())
-        .flatten()
-        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
-        .filter(Value::is_object)
-        .unwrap_or_else(|| json!({}));
+    let mut value = if config_path.exists() {
+        let raw = fs::read_to_string(&config_path).with_context(|| {
+            format!(
+                "refusing to overwrite unreadable existing Codex config {}",
+                config_path.display()
+            )
+        })?;
+        let parsed: Value = serde_json::from_str(&raw).with_context(|| {
+            format!(
+                "refusing to overwrite malformed existing Codex config {}",
+                config_path.display()
+            )
+        })?;
+        if !parsed.is_object() {
+            bail!(
+                "refusing to overwrite existing Codex config {} because it is not an object",
+                config_path.display()
+            );
+        }
+        parsed
+    } else {
+        json!({})
+    };
 
     let object = value
         .as_object_mut()
@@ -645,6 +728,116 @@ mod tests {
         assert_eq!(value["approval_mode"], "auto");
 
         crate::test_support::restore_home(previous_home);
+    }
+
+    #[test]
+    fn configure_codex_refuses_malformed_existing_config_without_overwriting() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        let previous_home = crate::test_support::set_home(temp.path());
+        let config_dir = temp.path().join(".openai/codex");
+        fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("config.json");
+        let original = "{ this is not json";
+        fs::write(&config_path, original).unwrap();
+
+        let error = configure_codex().expect_err("malformed config must be preserved");
+
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), original);
+        assert!(
+            error.to_string().contains("malformed")
+                || error.to_string().contains("refusing to overwrite"),
+            "error should clearly explain malformed config preservation; got {error:#}"
+        );
+
+        crate::test_support::restore_home(previous_home);
+    }
+
+    #[test]
+    fn configure_codex_refuses_non_object_existing_config_without_overwriting() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        let previous_home = crate::test_support::set_home(temp.path());
+        let config_dir = temp.path().join(".openai/codex");
+        fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("config.json");
+        let original = "[\"not\", \"an\", \"object\"]\n";
+        fs::write(&config_path, original).unwrap();
+
+        let error = configure_codex().expect_err("non-object config must be preserved");
+
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), original);
+        assert!(
+            error.to_string().contains("not an object")
+                || error.to_string().contains("refusing to overwrite"),
+            "error should clearly explain non-object config preservation; got {error:#}"
+        );
+
+        crate::test_support::restore_home(previous_home);
+    }
+
+    #[test]
+    fn managed_node_bootstrap_requires_checksum_validation_before_extraction() {
+        let source = include_str!("bootstrap.rs");
+
+        assert!(
+            source.contains("SHASUMS256.txt"),
+            "managed Node bootstrap must download the official checksum manifest"
+        );
+        assert!(
+            source.contains("SHA-256") || source.contains("sha256"),
+            "managed Node bootstrap must verify a SHA-256 digest before extraction"
+        );
+        let checksum_index = source
+            .find("SHASUMS256.txt")
+            .expect("checksum manifest should be referenced");
+        let extraction_index = source
+            .find("Command::new(\"tar\")")
+            .expect("tar extraction should remain explicit");
+        assert!(
+            checksum_index < extraction_index,
+            "checksum verification must happen before tar extraction"
+        );
+    }
+
+    #[test]
+    fn node_checksum_manifest_requires_exact_archive_entry() {
+        let manifest = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v1-linux-x64.tar.xz\n\
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  other.tar.xz\n";
+
+        let digest = find_sha256_for_archive(manifest, "node-v1-linux-x64.tar.xz").unwrap();
+
+        assert_eq!(
+            digest,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert!(find_sha256_for_archive(manifest, "missing.tar.xz").is_err());
+    }
+
+    #[test]
+    fn node_archive_sha256_mismatch_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp.path().join("node-test.tar.xz");
+        let checksum = temp.path().join("SHASUMS256.txt");
+        fs::write(&archive, b"not the expected archive").unwrap();
+        fs::write(
+            &checksum,
+            "0000000000000000000000000000000000000000000000000000000000000000  node-test.tar.xz\n",
+        )
+        .unwrap();
+
+        let error = verify_node_archive_sha256(&archive, &checksum, "node-test.tar.xz")
+            .expect_err("checksum mismatch must fail closed");
+
+        assert!(
+            error.to_string().contains("SHA-256 verification failed"),
+            "checksum mismatch should be explicit; got {error:#}"
+        );
     }
 
     // ========================================================================

--- a/crates/amplihack-cli/src/bootstrap.rs
+++ b/crates/amplihack-cli/src/bootstrap.rs
@@ -781,30 +781,6 @@ mod tests {
     }
 
     #[test]
-    fn managed_node_bootstrap_requires_checksum_validation_before_extraction() {
-        let source = include_str!("bootstrap.rs");
-
-        assert!(
-            source.contains("SHASUMS256.txt"),
-            "managed Node bootstrap must download the official checksum manifest"
-        );
-        assert!(
-            source.contains("SHA-256") || source.contains("sha256"),
-            "managed Node bootstrap must verify a SHA-256 digest before extraction"
-        );
-        let checksum_index = source
-            .find("SHASUMS256.txt")
-            .expect("checksum manifest should be referenced");
-        let extraction_index = source
-            .find("Command::new(\"tar\")")
-            .expect("tar extraction should remain explicit");
-        assert!(
-            checksum_index < extraction_index,
-            "checksum verification must happen before tar extraction"
-        );
-    }
-
-    #[test]
     fn node_checksum_manifest_requires_exact_archive_entry() {
         let manifest = "\
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v1-linux-x64.tar.xz\n\
@@ -938,6 +914,7 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  other.tar.xz\n
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let temp = tempfile::tempdir().unwrap();
         let previous_home = crate::test_support::set_home(temp.path());
+        let previous_shell = std::env::var_os("SHELL");
         // SAFETY: Test-only shell override.
         unsafe {
             std::env::set_var("SHELL", "/bin/bash");
@@ -951,6 +928,10 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  other.tar.xz\n
         let profile = fs::read_to_string(temp.path().join(".bashrc")).unwrap();
         assert_eq!(profile.matches("Added by amplihack").count(), 1);
 
+        match previous_shell {
+            Some(value) => unsafe { std::env::set_var("SHELL", value) },
+            None => unsafe { std::env::remove_var("SHELL") },
+        }
         crate::test_support::restore_home(previous_home);
     }
 }

--- a/crates/amplihack-cli/src/bootstrap.rs
+++ b/crates/amplihack-cli/src/bootstrap.rs
@@ -782,17 +782,14 @@ mod tests {
 
     #[test]
     fn node_checksum_manifest_requires_exact_archive_entry() {
-        let manifest = "\
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v1-linux-x64.tar.xz\n\
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  other.tar.xz\n";
+        let expected = "a".repeat(64);
+        let other = "b".repeat(64);
+        let manifest = format!("{expected}  node-v1-linux-x64.tar.xz\n{other}  other.tar.xz\n");
 
-        let digest = find_sha256_for_archive(manifest, "node-v1-linux-x64.tar.xz").unwrap();
+        let digest = find_sha256_for_archive(&manifest, "node-v1-linux-x64.tar.xz").unwrap();
 
-        assert_eq!(
-            digest,
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-        assert!(find_sha256_for_archive(manifest, "missing.tar.xz").is_err());
+        assert_eq!(digest, expected);
+        assert!(find_sha256_for_archive(&manifest, "missing.tar.xz").is_err());
     }
 
     #[test]
@@ -801,11 +798,7 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  other.tar.xz\n
         let archive = temp.path().join("node-test.tar.xz");
         let checksum = temp.path().join("SHASUMS256.txt");
         fs::write(&archive, b"not the expected archive").unwrap();
-        fs::write(
-            &checksum,
-            "0000000000000000000000000000000000000000000000000000000000000000  node-test.tar.xz\n",
-        )
-        .unwrap();
+        fs::write(&checksum, format!("{}  node-test.tar.xz\n", "0".repeat(64))).unwrap();
 
         let error = verify_node_archive_sha256(&archive, &checksum, "node-test.tar.xz")
             .expect_err("checksum mismatch must fail closed");

--- a/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/helpers.rs
@@ -5,6 +5,8 @@ use amplihack_launcher::prompt_delivery::{
 };
 use amplihack_utils::prompt_delivery::PromptDelivery;
 use std::ffi::OsString;
+#[cfg(test)]
+use std::process::Command;
 
 pub(super) fn philosophy_context() -> &'static str {
     "AUTONOMOUS MODE: You are in auto mode. Do NOT ask questions. Make decisions using:\n1. Explicit user requirements (highest priority)\n2. @.claude/context/USER_PREFERENCES.md guidance\n3. @.claude/context/PHILOSOPHY.md principles\n4. The `default-workflow` skill/recipe routed through `dev-orchestrator` and `amplihack recipe run smart-orchestrator`\n5. @.claude/context/USER_REQUIREMENT_PRIORITY.md for conflicts\n\nDecision Authority:\n- YOU DECIDE implementation details and architecture\n- YOU PRESERVE explicit user requirements and hard constraints\n- WHEN AMBIGUOUS choose the simplest modular option"

--- a/crates/amplihack-cli/src/commands/auto_mode/mod.rs
+++ b/crates/amplihack-cli/src/commands/auto_mode/mod.rs
@@ -18,7 +18,6 @@ use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -181,11 +180,10 @@ fn run_delivered_output_with_timeout(
         Err(_elapsed) => {
             #[cfg(unix)]
             {
-                let kill_result = Command::new("kill")
-                    .args(["-TERM", &pid.to_string()])
-                    .status();
-                if let Err(e) = kill_result {
-                    tracing::warn!(pid, error = %e, "failed to terminate timed-out subprocess");
+                let result = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+                if result != 0 {
+                    let error = std::io::Error::last_os_error();
+                    tracing::warn!(pid, %error, "failed to terminate timed-out subprocess");
                 }
             }
             bail!(

--- a/crates/amplihack-cli/src/commands/cs_validate/build.rs
+++ b/crates/amplihack-cli/src/commands/cs_validate/build.rs
@@ -1,23 +1,26 @@
 //! Level 2-4 validation: shell out to `dotnet` for build, analyzers, and format checks.
 
 use super::{CsValidatorConfig, Diagnostic, DiagnosticSeverity, EXIT_MISSING_DEPENDENCY};
+use crate::util::{run_output_with_timeout, run_with_timeout};
 use anyhow::{Result, bail};
 use std::path::Path;
 use std::process::Command;
 use std::sync::OnceLock;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Cached result of `dotnet --version` availability check.
 static DOTNET_AVAILABLE: OnceLock<bool> = OnceLock::new();
+const DOTNET_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Check if `dotnet` is available on PATH (cached after first call).
 pub fn dotnet_available() -> bool {
     *DOTNET_AVAILABLE.get_or_init(|| {
-        Command::new("dotnet")
+        let mut command = Command::new("dotnet");
+        command
             .arg("--version")
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
+            .stderr(std::process::Stdio::null());
+        run_with_timeout(command, DOTNET_PROBE_TIMEOUT)
             .map(|s| s.success())
             .unwrap_or(false)
     })
@@ -46,29 +49,9 @@ fn run_dotnet_command(
     }
 
     let timeout = Duration::from_secs(config.timeout_seconds.into());
-    let start = Instant::now();
-
-    let mut child = Command::new("dotnet")
-        .args(args)
-        .current_dir(project_dir(path))
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()?;
-
-    let output = loop {
-        match child.try_wait()? {
-            Some(_status) => break child.wait_with_output()?,
-            None => {
-                if start.elapsed() >= timeout {
-                    // Kill the child on timeout
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    bail!("dotnet command timed out after {}s", config.timeout_seconds);
-                }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-        }
-    };
+    let mut command = Command::new("dotnet");
+    command.args(args).current_dir(project_dir(path));
+    let output = run_output_with_timeout(command, timeout)?;
 
     if output.status.success() {
         return Ok(Vec::new());

--- a/crates/amplihack-cli/src/commands/doctor/checks.rs
+++ b/crates/amplihack-cli/src/commands/doctor/checks.rs
@@ -1,9 +1,11 @@
 //! Individual health check implementations for `amplihack doctor`.
 
-use super::{
-    MAX_ERROR_LEN, MAX_VERSION_LEN, json_contains_amplihack, settings_json_path, truncate,
-};
-use crate::util::strip_ansi;
+use super::{MAX_ERROR_LEN, MAX_VERSION_LEN, json_contains_amplihack, settings_json_path};
+use crate::util::{run_output_with_timeout, strip_ansi, truncate_chars_with_notice};
+use std::process::Command;
+use std::time::Duration;
+
+const DOCTOR_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Check 1 — amplihack hooks installed.
 ///
@@ -24,7 +26,7 @@ pub fn check_hooks_installed() -> (bool, String) {
                 false,
                 format!(
                     "hooks: cannot read settings.json: {}",
-                    truncate(&msg, MAX_ERROR_LEN)
+                    truncate_chars_with_notice(&msg, MAX_ERROR_LEN)
                 ),
             );
         }
@@ -71,7 +73,7 @@ pub fn check_settings_valid_json() -> (bool, String) {
                 false,
                 format!(
                     "settings.json: cannot read: {}",
-                    truncate(&msg, MAX_ERROR_LEN)
+                    truncate_chars_with_notice(&msg, MAX_ERROR_LEN)
                 ),
             );
         }
@@ -92,25 +94,24 @@ pub fn check_settings_valid_json() -> (bool, String) {
 /// no user input is passed to the subprocess.
 pub fn check_recipe_runner_available() -> (bool, String) {
     // SAFETY: all arguments are compile-time literals — no user input.
-    let output = std::process::Command::new("recipe-runner-rs")
-        .arg("--version")
-        .output();
+    let mut command = Command::new("recipe-runner-rs");
+    command.arg("--version");
+    let output = run_output_with_timeout(command, DOCTOR_COMMAND_TIMEOUT);
 
     match output {
         Ok(out) if out.status.success() => {
-            let raw = String::from_utf8_lossy(&out.stdout);
-            let first_line = raw.lines().next().unwrap_or("").trim();
-            let stripped = strip_ansi(first_line);
-            let version = truncate(&stripped, MAX_VERSION_LEN).to_string();
+            let stripped = sanitized_single_line(&out.stdout);
+            let version = truncate_chars_with_notice(&stripped, MAX_VERSION_LEN);
             (true, format!("recipe-runner-rs {version}"))
         }
         Ok(out) => {
-            let err = String::from_utf8_lossy(&out.stderr);
-            let first_line = err.lines().next().unwrap_or("").trim().to_string();
-            let msg = strip_ansi(&first_line);
+            let msg = sanitized_single_line(&out.stderr);
             (
                 false,
-                format!("recipe-runner-rs: {}", truncate(&msg, MAX_ERROR_LEN)),
+                format!(
+                    "recipe-runner-rs: {}",
+                    truncate_chars_with_notice(&msg, MAX_ERROR_LEN)
+                ),
             )
         }
         Err(e) => {
@@ -119,7 +120,7 @@ pub fn check_recipe_runner_available() -> (bool, String) {
                 false,
                 format!(
                     "recipe-runner-rs not found on PATH: {}",
-                    truncate(&msg, MAX_ERROR_LEN)
+                    truncate_chars_with_notice(&msg, MAX_ERROR_LEN)
                 ),
             )
         }
@@ -134,30 +135,39 @@ pub fn check_recipe_runner_available() -> (bool, String) {
 /// SAFETY: `"tmux"` and `"-V"` are compile-time literals.
 pub fn check_tmux_installed() -> (bool, String) {
     // SAFETY: all arguments are compile-time literals — no user input.
-    let output = std::process::Command::new("tmux").arg("-V").output();
+    let mut command = Command::new("tmux");
+    command.arg("-V");
+    let output = run_output_with_timeout(command, DOCTOR_COMMAND_TIMEOUT);
 
     match output {
         Ok(out) if out.status.success() => {
-            let raw = String::from_utf8_lossy(&out.stdout);
-            let first_line = raw.lines().next().unwrap_or("").trim();
-            let stripped = strip_ansi(first_line);
-            let version = truncate(&stripped, MAX_VERSION_LEN).to_string();
+            let stripped = sanitized_single_line(&out.stdout);
+            let version = truncate_chars_with_notice(&stripped, MAX_VERSION_LEN);
             (true, version)
         }
         Ok(out) => {
-            let err = String::from_utf8_lossy(&out.stderr);
-            let first_line = err.lines().next().unwrap_or("").trim().to_string();
-            let msg = strip_ansi(&first_line);
-            (false, format!("tmux: {}", truncate(&msg, MAX_ERROR_LEN)))
+            let msg = sanitized_single_line(&out.stderr);
+            (
+                false,
+                format!("tmux: {}", truncate_chars_with_notice(&msg, MAX_ERROR_LEN)),
+            )
         }
         Err(e) => {
             let msg = e.to_string();
             (
                 false,
-                format!("tmux not found: {}", truncate(&msg, MAX_ERROR_LEN)),
+                format!(
+                    "tmux not found: {}",
+                    truncate_chars_with_notice(&msg, MAX_ERROR_LEN)
+                ),
             )
         }
     }
+}
+
+fn sanitized_single_line(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes).replace(['\r', '\n'], " ");
+    strip_ansi(text.trim())
 }
 
 /// Check 6 — amplihack binary version (compile-time constant).

--- a/crates/amplihack-cli/src/commands/doctor/mod.rs
+++ b/crates/amplihack-cli/src/commands/doctor/mod.rs
@@ -73,14 +73,6 @@ fn json_contains_amplihack(v: &serde_json::Value) -> bool {
     }
 }
 
-/// Truncate `s` to at most `max_chars` characters (character boundary safe).
-fn truncate(s: &str, max_chars: usize) -> &str {
-    match s.char_indices().nth(max_chars) {
-        Some((byte_idx, _)) => &s[..byte_idx],
-        None => s,
-    }
-}
-
 // ── Summary printer ───────────────────────────────────────────────────────────
 
 /// Print a formatted summary of `results` to stdout and return `(passed,

--- a/crates/amplihack-cli/src/commands/fleet/commands.rs
+++ b/crates/amplihack-cli/src/commands/fleet/commands.rs
@@ -325,11 +325,9 @@ fn extract_amplihack_version(output: &str) -> Option<String> {
 }
 
 fn verify_host_version(host: &str, expected: Option<&str>) -> FleetVersionResult {
-    let output = Command::new("ssh")
-        .arg(host)
-        .arg("amplihack")
-        .arg("--version")
-        .output();
+    let mut command = Command::new("ssh");
+    command.arg(host).arg("amplihack").arg("--version");
+    let output = run_output_with_timeout(command, SUBPROCESS_TIMEOUT);
     match output {
         Ok(out) if out.status.success() => {
             let stdout = String::from_utf8_lossy(&out.stdout);
@@ -372,7 +370,7 @@ fn verify_host_version(host: &str, expected: Option<&str>) -> FleetVersionResult
             status: "error".to_string(),
             version: None,
             expected: expected.map(str::to_string),
-            message: err.to_string(),
+            message: format!("{err:#}"),
         },
     }
 }
@@ -445,7 +443,7 @@ pub(super) fn run_update_hosts(
         if expected.is_some() {
             command.arg("--skip-install");
         }
-        match command.output() {
+        match run_output_with_timeout(command, SUBPROCESS_TIMEOUT) {
             Ok(out) if out.status.success() => {
                 if verify {
                     results.push(verify_host_version(&host, expected));
@@ -478,7 +476,7 @@ pub(super) fn run_update_hosts(
                 status: "error".to_string(),
                 version: None,
                 expected: expected.map(str::to_string),
-                message: err.to_string(),
+                message: format!("{err:#}"),
             }),
         }
     }

--- a/crates/amplihack-cli/src/commands/fleet/commands.rs
+++ b/crates/amplihack-cli/src/commands/fleet/commands.rs
@@ -351,20 +351,13 @@ fn verify_host_version(host: &str, expected: Option<&str>) -> FleetVersionResult
                 message,
             }
         }
-        Ok(out) => {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            FleetVersionResult {
-                host: host.to_string(),
-                status: "unreachable".to_string(),
-                version: None,
-                expected: expected.map(str::to_string),
-                message: stderr
-                    .lines()
-                    .next()
-                    .unwrap_or("ssh command failed")
-                    .to_string(),
-            }
-        }
+        Ok(out) => FleetVersionResult {
+            host: host.to_string(),
+            status: "unreachable".to_string(),
+            version: None,
+            expected: expected.map(str::to_string),
+            message: render_diagnostic_bytes(&out.stderr, 400),
+        },
         Err(err) => FleetVersionResult {
             host: host.to_string(),
             status: "error".to_string(),
@@ -458,17 +451,12 @@ pub(super) fn run_update_hosts(
                 }
             }
             Ok(out) => {
-                let stderr = String::from_utf8_lossy(&out.stderr);
                 results.push(FleetVersionResult {
                     host,
                     status: "failed".to_string(),
                     version: None,
                     expected: expected.map(str::to_string),
-                    message: stderr
-                        .lines()
-                        .next()
-                        .unwrap_or("amplihack update failed")
-                        .to_string(),
+                    message: render_diagnostic_bytes(&out.stderr, 400),
                 });
             }
             Err(err) => results.push(FleetVersionResult {

--- a/crates/amplihack-cli/src/commands/fleet/helpers.rs
+++ b/crates/amplihack-cli/src/commands/fleet/helpers.rs
@@ -82,7 +82,15 @@ pub(super) fn claude_project_dir() -> PathBuf {
 }
 
 pub(super) fn truncate_chars(value: &str, limit: usize) -> String {
-    value.chars().take(limit).collect()
+    let total = value.chars().count();
+    if total <= limit {
+        return value.to_string();
+    }
+    let prefix: String = value.chars().take(limit).collect();
+    format!(
+        "{prefix}\n[truncated: discarded {} chars]",
+        total.saturating_sub(limit)
+    )
 }
 
 pub(super) fn shell_single_quote(value: &str) -> String {
@@ -299,4 +307,39 @@ pub(super) fn render_advance_report(
     }
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_chars_reports_discarded_diagnostics() {
+        let rendered = truncate_chars("abcdef", 3);
+
+        assert!(
+            rendered.contains("abc"),
+            "truncated output should retain the prefix"
+        );
+        assert!(
+            rendered.contains("truncated") && rendered.contains("discarded"),
+            "truncated output must report discarded diagnostics; got {rendered}"
+        );
+    }
+
+    #[test]
+    fn sanitize_external_error_detail_reports_discarded_diagnostics() {
+        let token = format!("ghp_{}", "A".repeat(36));
+        let detail = format!("failure at /home/alice/project with token {token} extra context");
+        let rendered = sanitize_external_error_detail(&detail, 20);
+
+        assert!(
+            !rendered.contains("ghp_") && !rendered.contains("/home/alice"),
+            "sanitization must still redact tokens and paths"
+        );
+        assert!(
+            rendered.contains("truncated") && rendered.contains("discarded"),
+            "sanitized truncation must report discarded diagnostics; got {rendered}"
+        );
+    }
 }

--- a/crates/amplihack-cli/src/commands/fleet/mod.rs
+++ b/crates/amplihack-cli/src/commands/fleet/mod.rs
@@ -10,7 +10,7 @@
 use crate::binary_finder::BinaryFinder;
 use crate::command_error::exit_error;
 use crate::env_builder::EnvBuilder;
-use crate::util::run_output_with_timeout;
+use crate::util::{render_diagnostic_bytes, run_output_with_timeout};
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Local};
 use clap::{CommandFactory, Parser};

--- a/crates/amplihack-cli/src/commands/hygiene/cleanup.rs
+++ b/crates/amplihack-cli/src/commands/hygiene/cleanup.rs
@@ -11,7 +11,10 @@ use serde::Serialize;
 
 use crate::{
     HygieneCleanupArgs, MIN_CLEANUP_APPLY_OLDER_THAN_HOURS, MIN_CLEANUP_APPLY_OLDER_THAN_SECS,
+    util::{run_output_with_timeout, truncate_chars_with_notice},
 };
+
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug, Serialize)]
 struct CleanupItem {
@@ -573,13 +576,14 @@ fn print_report(report: &CleanupReport, config: &CleanupConfig) -> Result<()> {
 }
 
 fn active_worktrees(repo: &Path) -> Result<BTreeSet<PathBuf>> {
-    let output = Command::new("git")
+    let mut command = Command::new("git");
+    command
         .arg("-C")
         .arg(repo)
         .arg("worktree")
         .arg("list")
-        .arg("--porcelain")
-        .output()
+        .arg("--porcelain");
+    let output = run_output_with_timeout(command, GIT_COMMAND_TIMEOUT)
         .with_context(|| format!("run git worktree list for {}", repo.display()))?;
     if !output.status.success() {
         bail!(
@@ -615,17 +619,14 @@ fn sanitized_stderr(stderr: &[u8]) -> String {
     if sanitized.is_empty() {
         "no stderr".to_string()
     } else {
-        sanitized.chars().take(500).collect()
+        truncate_chars_with_notice(&sanitized, 500)
     }
 }
 
 fn git_has_dirty_state(path: &Path) -> bool {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(path)
-        .arg("status")
-        .arg("--porcelain")
-        .output();
+    let mut command = Command::new("git");
+    command.arg("-C").arg(path).arg("status").arg("--porcelain");
+    let output = run_output_with_timeout(command, GIT_COMMAND_TIMEOUT);
     match output {
         Ok(output) if output.status.success() => !output.stdout.is_empty(),
         _ => true,
@@ -633,13 +634,14 @@ fn git_has_dirty_state(path: &Path) -> bool {
 }
 
 fn git_has_unpushed_commits(path: &Path) -> bool {
-    let upstream = Command::new("git")
+    let mut upstream_command = Command::new("git");
+    upstream_command
         .arg("-C")
         .arg(path)
         .arg("rev-parse")
         .arg("--abbrev-ref")
-        .arg("@{u}")
-        .output();
+        .arg("@{u}");
+    let upstream = run_output_with_timeout(upstream_command, GIT_COMMAND_TIMEOUT);
     let Ok(upstream) = upstream else {
         return true;
     };
@@ -647,13 +649,14 @@ fn git_has_unpushed_commits(path: &Path) -> bool {
         return true;
     }
 
-    let count = Command::new("git")
+    let mut count_command = Command::new("git");
+    count_command
         .arg("-C")
         .arg(path)
         .arg("rev-list")
         .arg("--count")
-        .arg("@{u}..HEAD")
-        .output();
+        .arg("@{u}..HEAD");
+    let count = run_output_with_timeout(count_command, GIT_COMMAND_TIMEOUT);
     match count {
         Ok(output) if output.status.success() => {
             String::from_utf8_lossy(&output.stdout).trim() != "0"

--- a/crates/amplihack-cli/src/commands/install/bundle_compat.rs
+++ b/crates/amplihack-cli/src/commands/install/bundle_compat.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-pub(super) const REQUIRED_SMART_RECIPES: &[&str] = &[
+pub(crate) const REQUIRED_SMART_RECIPES: &[&str] = &[
     "smart-classify-route",
     "smart-execute-routing",
     "smart-reflect-loop",
@@ -12,16 +12,15 @@ pub(super) const REQUIRED_SMART_RECIPES: &[&str] = &[
 ];
 
 const STALE_SMART_ORCHESTRATOR_MARKERS: &[&str] = &[
-    "resolve-bundle-asset helper-path",
+    "orch_helper.py",
+    "orch_helper",
     "importlib",
     "parse-decomposition",
-    "orch_helper.py",
+    "resolve-bundle-asset helper-path",
 ];
 
-const EXECUTABLE_STEP_FIELDS: &[&str] = &["command", "script", "run"];
-
 #[derive(Debug, Error)]
-pub(super) enum BundleCompatibilityError {
+pub(crate) enum BundleCompatibilityError {
     #[error(
         "framework bundle compatibility check failed: no amplifier-bundle recipes directory found under {0}"
     )]
@@ -92,7 +91,7 @@ pub(super) enum BundleCompatibilityError {
     InvalidManifestEntry { path: PathBuf, recipe: String },
 }
 
-pub(super) fn validate_framework_bundle_compatibility(
+pub(crate) fn validate_framework_bundle_compatibility(
     root_or_bundle: &Path,
 ) -> Result<(), BundleCompatibilityError> {
     let bundle = resolve_bundle_root(root_or_bundle)?;
@@ -104,7 +103,7 @@ pub(super) fn validate_framework_bundle_compatibility(
     require_recipe_file(&recipes, "smart-orchestrator")?;
     let smart = read_file(&smart_path)?;
     let smart_yaml = parse_yaml(&smart_path, &smart)?;
-    reject_stale_smart_orchestrator(&smart_path, &smart_yaml)?;
+    reject_stale_smart_orchestrator(&smart_path, &smart)?;
     let smart_recipe_refs = top_level_recipe_steps(&smart_yaml);
 
     for &recipe in REQUIRED_SMART_RECIPES {
@@ -124,10 +123,33 @@ pub(super) fn validate_framework_bundle_compatibility(
     Ok(())
 }
 
-pub(super) fn validate_staged_framework_bundle(
+pub(crate) fn validate_staged_framework_bundle(
     bundle: &Path,
 ) -> Result<(), BundleCompatibilityError> {
     validate_framework_bundle_compatibility(bundle)
+}
+
+pub(crate) fn validate_recipe_compatibility(path: &Path) -> Result<(), BundleCompatibilityError> {
+    if path.file_stem().and_then(|value| value.to_str()) != Some("smart-orchestrator") {
+        return Ok(());
+    }
+
+    let raw = read_file(path)?;
+    reject_stale_smart_orchestrator(path, &raw)
+}
+
+pub(crate) fn is_incompatible_smart_orchestrator(
+    path: &Path,
+) -> Result<bool, BundleCompatibilityError> {
+    if path.file_stem().and_then(|value| value.to_str()) != Some("smart-orchestrator") {
+        return Ok(false);
+    }
+
+    match validate_recipe_compatibility(path) {
+        Ok(()) => Ok(false),
+        Err(BundleCompatibilityError::StaleSmartOrchestrator { .. }) => Ok(true),
+        Err(err) => Err(err),
+    }
 }
 
 #[cfg(test)]
@@ -192,30 +214,13 @@ fn parse_yaml(path: &Path, raw: &str) -> Result<Value, BundleCompatibilityError>
     })
 }
 
-fn reject_stale_smart_orchestrator(
-    path: &Path,
-    yaml: &Value,
-) -> Result<(), BundleCompatibilityError> {
-    let Some(Value::Sequence(steps)) = mapping_value(yaml, "steps") else {
-        return Ok(());
-    };
-
-    for step in steps {
-        let Value::Mapping(mapping) = step else {
-            continue;
-        };
-        for field in EXECUTABLE_STEP_FIELDS {
-            let Some(executable) = mapping_string(mapping, field) else {
-                continue;
-            };
-            for marker in STALE_SMART_ORCHESTRATOR_MARKERS {
-                if executable.contains(marker) {
-                    return Err(BundleCompatibilityError::StaleSmartOrchestrator {
-                        path: path.to_path_buf(),
-                        marker: (*marker).to_string(),
-                    });
-                }
-            }
+fn reject_stale_smart_orchestrator(path: &Path, raw: &str) -> Result<(), BundleCompatibilityError> {
+    for marker in STALE_SMART_ORCHESTRATOR_MARKERS {
+        if raw.contains(marker) {
+            return Err(BundleCompatibilityError::StaleSmartOrchestrator {
+                path: path.to_path_buf(),
+                marker: (*marker).to_string(),
+            });
         }
     }
     Ok(())
@@ -477,6 +482,32 @@ steps:
     }
 
     #[test]
+    fn rejects_stale_marker_anywhere_in_smart_orchestrator_body() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("amplifier-bundle");
+        write_compatible_bundle(&bundle);
+        fs::write(
+            bundle.join("recipes/smart-orchestrator.yaml"),
+            compatible_smart().replace(
+                "Composable smart task orchestrator",
+                "Composable smart task orchestrator that still mentions orch_helper.py",
+            ),
+        )
+        .unwrap();
+
+        let err = validate_framework_bundle_compatibility(&bundle).expect_err(
+            "any live smart-orchestrator recipe containing stale legacy markers must be rejected",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("smart-orchestrator")
+                && msg.contains("stale")
+                && msg.contains("orch_helper.py"),
+            "error must identify the stale marker and recipe path, got: {msg}"
+        );
+    }
+
+    #[test]
     fn rejects_missing_required_companion_recipe() {
         let temp = tempfile::tempdir().unwrap();
         let bundle = temp.path().join("amplifier-bundle");
@@ -591,7 +622,7 @@ steps:
     }
 
     #[test]
-    fn accepts_stale_marker_text_in_comments_and_metadata() {
+    fn rejects_stale_marker_text_in_comments_and_metadata() {
         let temp = tempfile::tempdir().unwrap();
         let bundle = temp.path().join("amplifier-bundle");
         write_compatible_bundle(&bundle);
@@ -608,8 +639,13 @@ metadata:
         )
         .unwrap();
 
-        validate_framework_bundle_compatibility(&bundle)
-            .expect("comments and inert metadata must not trip stale executable marker checks");
+        let err = validate_framework_bundle_compatibility(&bundle)
+            .expect_err("live smart-orchestrator recipes must not contain stale markers anywhere");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("smart-orchestrator") && msg.contains("orch_helper.py"),
+            "error must identify the stale marker in the live recipe body, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/amplihack-cli/src/commands/install/clone.rs
+++ b/crates/amplihack-cli/src/commands/install/clone.rs
@@ -28,6 +28,8 @@
 use super::bundle_compat::validate_framework_bundle_compatibility;
 use super::types::{REPO_ARCHIVE_URL, REPO_GIT_URL};
 use crate::update::{extract_archive, http_get_with_retry, validate_download_url};
+#[cfg(windows)]
+use crate::util::run_with_timeout;
 use anyhow::{Context, Result, bail};
 use std::collections::VecDeque;
 use std::fs;
@@ -35,7 +37,7 @@ use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -44,6 +46,8 @@ const GIT_CLONE_TIMEOUT: Duration = Duration::from_secs(300);
 #[cfg(test)]
 const GIT_CLONE_TIMEOUT: Duration = Duration::from_millis(250);
 const GIT_CLONE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+#[cfg(windows)]
+const TERMINATE_PROCESS_TREE_TIMEOUT: Duration = Duration::from_secs(5);
 const CAPTURE_LIMIT: usize = 8192;
 
 /// Locate the bundled framework source from the amplihack-rs source tree.
@@ -156,28 +160,36 @@ pub(super) fn download_and_extract_framework_repo(destination: &Path) -> Result<
 
 /// Resolve the `git` binary path from PATH.
 fn which_git() -> Result<PathBuf> {
-    let output = std::process::Command::new("which")
-        .arg("git")
-        .output()
-        .or_else(|_| {
-            // `which` may not be available on all platforms; fall back to `command -v git`
-            std::process::Command::new("sh")
-                .args(["-c", "command -v git"])
-                .output()
-        })
-        .context("failed to locate git binary")?;
-    if output.status.success() {
-        let path_str = std::str::from_utf8(&output.stdout)
-            .context("git path is not valid UTF-8")?
-            .trim()
-            .to_string();
-        if path_str.is_empty() {
-            bail!("git not found on PATH");
-        }
-        Ok(PathBuf::from(path_str))
+    let Some(paths) = std::env::var_os("PATH") else {
+        bail!("git not found on PATH");
+    };
+    let candidates: &[&str] = if cfg!(windows) {
+        &["git.exe", "git"]
     } else {
-        bail!("git not found on PATH")
+        &["git"]
+    };
+    for dir in std::env::split_paths(&paths) {
+        for candidate in candidates {
+            let path = dir.join(candidate);
+            if is_executable_file(&path) {
+                return Ok(path);
+            }
+        }
     }
+    bail!("git not found on PATH")
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 /// Run `git clone --depth 1 <REPO_GIT_URL> <destination>`.
@@ -186,7 +198,7 @@ fn git_clone_framework_repo(git_path: &Path, destination: &Path) -> Result<()> {
         .context("failed to create temporary stdout file for git clone")?;
     let stderr_file = tempfile::NamedTempFile::new()
         .context("failed to create temporary stderr file for git clone")?;
-    let mut command = std::process::Command::new(git_path);
+    let mut command = Command::new(git_path);
     command
         .args([
             "clone",
@@ -271,12 +283,13 @@ fn terminate_git_clone(child: &mut std::process::Child) {
     #[cfg(windows)]
     {
         let pid = child.id().to_string();
-        let _ = std::process::Command::new("taskkill")
+        let mut command = Command::new("taskkill");
+        command
             .args(["/PID", &pid, "/T", "/F"])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
+            .stderr(Stdio::null());
+        let _ = run_with_timeout(command, TERMINATE_PROCESS_TREE_TIMEOUT);
     }
     let _ = child.kill();
     let _ = child.wait();
@@ -285,16 +298,19 @@ fn terminate_git_clone(child: &mut std::process::Child) {
 fn read_limited(path: &Path) -> Result<String> {
     let mut file = fs::File::open(path)
         .with_context(|| format!("failed to open captured output {}", path.display()))?;
+    let total_bytes = file
+        .metadata()
+        .with_context(|| format!("failed to inspect captured output {}", path.display()))?
+        .len() as usize;
     let mut bytes = Vec::new();
     file.by_ref()
-        .take((CAPTURE_LIMIT + 1) as u64)
+        .take(CAPTURE_LIMIT as u64)
         .read_to_end(&mut bytes)
         .with_context(|| format!("failed to read captured output {}", path.display()))?;
-    let truncated = bytes.len() > CAPTURE_LIMIT;
-    bytes.truncate(CAPTURE_LIMIT);
     let mut text = String::from_utf8_lossy(&bytes).into_owned();
-    if truncated {
-        text.push_str("\n...<truncated>");
+    if total_bytes > CAPTURE_LIMIT {
+        let discarded = total_bytes - CAPTURE_LIMIT;
+        text.push_str(&format!("\n[truncated: discarded {discarded} bytes]"));
     }
     Ok(text)
 }
@@ -375,6 +391,20 @@ mod tests {
         assert!(
             msg.contains("stdout-marker") && msg.contains("stderr-marker"),
             "error must include captured stdout/stderr: {msg}"
+        );
+    }
+
+    #[test]
+    fn read_limited_reports_discarded_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let output = temp.path().join("captured.log");
+        fs::write(&output, vec![b'x'; CAPTURE_LIMIT + 7]).unwrap();
+
+        let rendered = read_limited(&output).unwrap();
+
+        assert!(
+            rendered.contains("[truncated: discarded 7 bytes]"),
+            "truncated output must report discarded bytes: {rendered}"
         );
     }
 

--- a/crates/amplihack-cli/src/commands/install/mermaid_cli.rs
+++ b/crates/amplihack-cli/src/commands/install/mermaid_cli.rs
@@ -25,12 +25,16 @@
 //! 5. Re-probe `mmdc`. Present → `Installed`. Still absent (e.g. npm prefix
 //!    not on PATH) → warn-and-continue → `Failed`.
 
+use crate::util::run_with_timeout;
 use anyhow::Result;
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 /// The scoped npm package that provides the `mmdc` binary. Hardcoded exactly;
 /// never constructed from env/config/user input (no command-injection surface).
 const MERMAID_CLI_PACKAGE: &str = "@mermaid-js/mermaid-cli";
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+const NPM_INSTALL_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// User-facing line shown when mmdc could not be provisioned. Shared by the
 /// `Failed` and the defense-in-depth `Err(_)` arms in `mod.rs` so the message
@@ -62,11 +66,11 @@ pub(super) enum Outcome {
 /// child's stdout/stderr are discarded via `Stdio::null()` — this both keeps
 /// the install console quiet and avoids allocating/reading capture pipes.
 fn version_probe_succeeds(bin: &str) -> bool {
-    Command::new(bin)
-        .arg("--version")
+    let mut cmd = Command::new(bin);
+    cmd.arg("--version")
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+        .stderr(Stdio::null());
+    run_with_timeout(cmd, VERSION_PROBE_TIMEOUT)
         .map(|status| status.success())
         .unwrap_or(false)
 }
@@ -95,11 +99,11 @@ pub(super) fn ensure_mermaid_cli() -> Result<Outcome> {
     }
 
     // (4) Install. Arg-vector form only (no shell): prevents injection. No
-    // sudo / no privilege escalation; no hard timeout (the Chromium download
-    // is legitimately slow and is bounded by npm's own network timeouts).
-    let install_result = Command::new("npm")
-        .args(["install", "-g", MERMAID_CLI_PACKAGE])
-        .status();
+    // sudo / no privilege escalation; bounded so a wedged npm/Chromium download
+    // cannot hang install indefinitely.
+    let mut install_cmd = Command::new("npm");
+    install_cmd.args(["install", "-g", MERMAID_CLI_PACKAGE]);
+    let install_result = run_with_timeout(install_cmd, NPM_INSTALL_TIMEOUT);
 
     match install_result {
         Ok(status) if status.success() => {
@@ -123,8 +127,46 @@ pub(super) fn ensure_mermaid_cli() -> Result<Outcome> {
             Ok(Outcome::Failed)
         }
         Err(err) => {
-            tracing::warn!(%err, "failed to spawn npm install -g {MERMAID_CLI_PACKAGE}");
+            tracing::warn!(%err, "npm install -g {MERMAID_CLI_PACKAGE} failed or timed out");
             Ok(Outcome::Failed)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn version_probe_is_bounded_for_hanging_binaries() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        let fake_bin = temp.path().join("mmdc");
+        std::fs::write(&fake_bin, "#!/bin/sh\n/bin/sleep 2\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(&fake_bin).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&fake_bin, perms).unwrap();
+
+        let previous_path = std::env::var_os("PATH");
+        unsafe {
+            std::env::set_var("PATH", temp.path());
+        }
+
+        let started = std::time::Instant::now();
+        let result = version_probe_succeeds("mmdc");
+
+        match previous_path {
+            Some(value) => unsafe { std::env::set_var("PATH", value) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "version probes must not hang on a stuck binary"
+        );
+        assert!(!result, "timed-out version probes must fail closed");
     }
 }

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -1,7 +1,7 @@
 //! Native install and uninstall commands.
 
 mod binary;
-mod bundle_compat;
+pub(crate) mod bundle_compat;
 mod clone;
 mod copilot_plugin;
 mod directories;

--- a/crates/amplihack-cli/src/commands/launch/checkout.rs
+++ b/crates/amplihack-cli/src/commands/launch/checkout.rs
@@ -4,6 +4,11 @@ use anyhow::{Context, Result, bail};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use crate::util::{format_output_diagnostics, run_output_with_timeout};
+
+const GIT_CLONE_TIMEOUT: Duration = Duration::from_secs(300);
 
 pub(crate) fn resolve_checkout_repo(repo_uri: Option<&str>) -> Result<Option<PathBuf>> {
     let Some(repo_uri) = repo_uri else {
@@ -30,20 +35,18 @@ pub(super) fn resolve_checkout_repo_in(repo_uri: &str, base_dir: &Path) -> Resul
     }
 
     let clone_url = format!("https://github.com/{owner}/{repo}.git");
-    let output = Command::new("git")
-        .args(["clone", &clone_url, &target_dir.to_string_lossy()])
-        .stdin(Stdio::null())
-        .output()
-        .context("failed to spawn git clone")?;
+    let target_dir_arg = target_dir.to_string_lossy();
+    let mut command = Command::new("git");
+    command
+        .args(["clone", &clone_url, target_dir_arg.as_ref()])
+        .stdin(Stdio::null());
+    let output = run_output_with_timeout(command, GIT_CLONE_TIMEOUT)
+        .context("git clone timed out or failed to execute")?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stderr = stderr.trim();
-        let detail = if stderr.is_empty() {
-            "git clone failed"
-        } else {
-            stderr
-        };
-        bail!("failed to checkout repository {repo_uri}: {detail}");
+        bail!(
+            "failed to checkout repository {repo_uri}: {}",
+            format_output_diagnostics(&output, 400)
+        );
     }
 
     println!("Cloned repository to: {}", target_dir.display());

--- a/crates/amplihack-cli/src/commands/memory/scip_indexing/indexer.rs
+++ b/crates/amplihack-cli/src/commands/memory/scip_indexing/indexer.rs
@@ -1,10 +1,13 @@
 use super::helpers::augmented_path;
 use super::types::ScipIndexResult;
+use crate::util::run_output_with_timeout;
 use anyhow::{Context, Result, bail};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+
+const SCIP_INDEXER_TIMEOUT: Duration = Duration::from_secs(600);
 
 pub(super) fn run_indexer_for_language(
     language: &str,
@@ -32,11 +35,12 @@ pub(super) fn run_indexer_for_language(
     };
 
     let started = Instant::now();
-    let output = Command::new(&command[0])
+    let mut indexer = Command::new(&command[0]);
+    indexer
         .args(&command[1..])
         .current_dir(project_path)
-        .env("PATH", augmented_path())
-        .output();
+        .env("PATH", augmented_path());
+    let output = run_output_with_timeout(indexer, SCIP_INDEXER_TIMEOUT);
     let elapsed = started.elapsed().as_secs_f64();
 
     if let Some(cleanup) = cleanup {

--- a/crates/amplihack-cli/src/commands/multitask/cleanup.rs
+++ b/crates/amplihack-cli/src/commands/multitask/cleanup.rs
@@ -1,0 +1,78 @@
+use super::models::{WorkstreamConfig, sanitize_id};
+use super::utils::dir_size_bytes;
+use crate::util::run_output_with_timeout;
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+const GH_PR_VIEW_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(super) fn cleanup_merged(
+    base_dir: &Path,
+    state_dir: &Path,
+    config_path: &str,
+    dry_run: bool,
+) -> Result<()> {
+    let config_text = fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read config: {config_path}"))?;
+    let items: Vec<WorkstreamConfig> = serde_json::from_str(&config_text)?;
+    let mut deleted_count = 0u32;
+    let mut freed_bytes = 0u64;
+
+    for item in &items {
+        let issue = item.issue_id();
+        let safe_id = sanitize_id(&issue.to_string());
+        let work_dir = base_dir.join(format!("ws-{issue}"));
+        let state_file = state_dir.join(format!("ws-{safe_id}.json"));
+
+        let mut gh_cmd = Command::new("gh");
+        gh_cmd.args([
+            "pr",
+            "view",
+            &item.branch,
+            "--json",
+            "state",
+            "-q",
+            ".state",
+        ]);
+        let is_merged = run_output_with_timeout(gh_cmd, GH_PR_VIEW_TIMEOUT)
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .is_some_and(|s| s.trim() == "MERGED");
+        if !is_merged || !work_dir.exists() {
+            continue;
+        }
+
+        let dir_size = dir_size_bytes(&work_dir);
+        if dry_run {
+            println!(
+                "[{issue}] Would delete work dir ({:.0}MB)",
+                dir_size as f64 / (1024.0 * 1024.0)
+            );
+        } else {
+            let _ = fs::remove_dir_all(&work_dir);
+            let _ = fs::remove_file(&state_file);
+            println!(
+                "[{issue}] Deleted work dir ({:.0}MB freed)",
+                dir_size as f64 / (1024.0 * 1024.0)
+            );
+        }
+        freed_bytes += dir_size;
+        deleted_count += 1;
+    }
+
+    let freed_gb = freed_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    let prefix = if dry_run { "DRY RUN " } else { "" };
+    let modal = if dry_run { "would be " } else { "" };
+    println!(
+        "\n{prefix}Summary:\n  Workstreams {modal}deleted: {deleted_count}\n  Disk space {modal}freed: {freed_gb:.2}GB"
+    );
+
+    if dry_run && deleted_count > 0 {
+        println!("\nRun without --dry-run to actually delete these workstreams.");
+    }
+    Ok(())
+}

--- a/crates/amplihack-cli/src/commands/multitask/default_branch.rs
+++ b/crates/amplihack-cli/src/commands/multitask/default_branch.rs
@@ -1,0 +1,10 @@
+pub(super) fn parse_from_ls_remote(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .find(|line| line.starts_with("ref: refs/heads/"))
+        .and_then(|line| line.strip_prefix("ref: refs/heads/"))
+        .and_then(|line| line.split('\t').next())
+        .map(str::trim)
+        .filter(|branch| !branch.is_empty())
+        .map(ToOwned::to_owned)
+}

--- a/crates/amplihack-cli/src/commands/multitask/launcher_tests.rs
+++ b/crates/amplihack-cli/src/commands/multitask/launcher_tests.rs
@@ -2,9 +2,11 @@ use super::launcher::{
     VALID_DELEGATES, write_classic_launcher, write_executable_script, write_recipe_launcher,
 };
 use super::models::Workstream;
+use crate::util::run_output_with_timeout;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
 
 #[test]
 fn test_valid_delegates() {
@@ -81,10 +83,9 @@ fn assert_script_is_lf_only_and_bash_valid(script: &Path) {
         script.display()
     );
 
-    let output = Command::new("bash")
-        .arg("-n")
-        .arg(script)
-        .output()
+    let mut command = Command::new("bash");
+    command.arg("-n").arg(script);
+    let output = run_output_with_timeout(command, Duration::from_secs(2))
         .unwrap_or_else(|err| panic!("failed to run bash -n for {}: {err}", script.display()));
 
     assert!(

--- a/crates/amplihack-cli/src/commands/multitask/mod.rs
+++ b/crates/amplihack-cli/src/commands/multitask/mod.rs
@@ -16,8 +16,13 @@ mod process_scope;
 mod state;
 mod utils;
 
+use crate::util::run_output_with_timeout;
 use anyhow::{Context, Result};
 use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+const REPO_URL_DETECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Run parallel workstreams from a JSON config file.
 pub fn run_multitask(
@@ -143,9 +148,9 @@ pub fn run_status(base_dir: Option<&str>) -> Result<()> {
 }
 
 fn detect_repo_url() -> String {
-    std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .output()
+    let mut cmd = Command::new("git");
+    cmd.args(["remote", "get-url", "origin"]);
+    run_output_with_timeout(cmd, REPO_URL_DETECTION_TIMEOUT)
         .ok()
         .filter(|o| o.status.success())
         .and_then(|o| String::from_utf8(o.stdout).ok())

--- a/crates/amplihack-cli/src/commands/multitask/mod.rs
+++ b/crates/amplihack-cli/src/commands/multitask/mod.rs
@@ -5,7 +5,9 @@
 //! and classic execution modes, per-workstream timeout budgets, state
 //! persistence for resumption, and automatic cleanup of completed workstreams.
 
+mod cleanup;
 mod command_builder;
+mod default_branch;
 mod launcher;
 #[cfg(test)]
 mod launcher_tests;

--- a/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
+++ b/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
@@ -5,6 +5,7 @@
 
 use super::models::*;
 use super::{launcher, state, utils};
+use crate::util::{format_output_diagnostics, run_output_with_timeout};
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
 use std::collections::HashMap;
@@ -16,6 +17,8 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 use tracing::warn;
+
+const DEFAULT_BRANCH_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct ParallelOrchestrator {
     repo_url: String,
@@ -348,24 +351,51 @@ impl ParallelOrchestrator {
             return branch.clone();
         }
 
-        let branch = Command::new("git")
-            .args(["ls-remote", "--symref", &self.repo_url, "HEAD"])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .and_then(|out| {
-                out.lines()
-                    .find(|l| l.starts_with("ref: refs/heads/"))
-                    .and_then(|l| l.strip_prefix("ref: refs/heads/"))
-                    .and_then(|l| l.split('\t').next())
-                    .map(|s| s.trim().to_string())
-            })
-            .unwrap_or_else(|| "main".to_string());
+        let mut cmd = Command::new("git");
+        cmd.args(["ls-remote", "--symref", &self.repo_url, "HEAD"]);
+        let branch = match run_output_with_timeout(cmd, DEFAULT_BRANCH_RESOLUTION_TIMEOUT) {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                parse_default_branch_from_ls_remote(&stdout).unwrap_or_else(|| {
+                    eprintln!(
+                        "WARNING: git ls-remote did not return a usable HEAD symref for {}; falling back to main. stdout/stderr diagnostic: {}",
+                        self.repo_url,
+                        format_output_diagnostics(&output, 400)
+                    );
+                    "main".to_string()
+                })
+            }
+            Ok(output) => {
+                eprintln!(
+                    "WARNING: git ls-remote failed for {}; falling back to main. stdout/stderr diagnostic: {}",
+                    self.repo_url,
+                    format_output_diagnostics(&output, 400)
+                );
+                "main".to_string()
+            }
+            Err(err) => {
+                eprintln!(
+                    "WARNING: git ls-remote timed out or failed for {}; falling back to main. diagnostic: {err:#}",
+                    self.repo_url
+                );
+                "main".to_string()
+            }
+        };
 
         self.default_branch = Some(branch.clone());
         branch
     }
+}
+
+fn parse_default_branch_from_ls_remote(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .find(|line| line.starts_with("ref: refs/heads/"))
+        .and_then(|line| line.strip_prefix("ref: refs/heads/"))
+        .and_then(|line| line.split('\t').next())
+        .map(str::trim)
+        .filter(|branch| !branch.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 #[cfg(test)]
@@ -389,5 +419,23 @@ mod tests {
         // Invalid policy should be rejected
         orch.set_default_timeout_policy("invalid-policy");
         assert_eq!(orch.default_timeout_policy, "continue-preserve");
+    }
+
+    #[test]
+    fn default_branch_fallback_is_bounded_and_diagnostic() {
+        let source = include_str!("orchestrator.rs");
+
+        assert!(
+            source.contains("run_output_with_timeout") || source.contains("run_with_timeout"),
+            "git ls-remote default branch resolution must use an explicit timeout helper"
+        );
+        assert!(
+            source.contains("falling back to main") || source.contains("fallback to main"),
+            "fallback to main must be observable in diagnostics"
+        );
+        assert!(
+            source.contains("stderr") || source.contains("stdout") || source.contains("diagnostic"),
+            "default branch fallback diagnostics should include failure context"
+        );
     }
 }

--- a/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
+++ b/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -19,6 +19,7 @@ use std::time::{Duration, Instant};
 use tracing::warn;
 
 const DEFAULT_BRANCH_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(30);
+const GIT_CLONE_TIMEOUT: Duration = Duration::from_secs(300);
 
 pub struct ParallelOrchestrator {
     repo_url: String,
@@ -126,21 +127,24 @@ impl ParallelOrchestrator {
             );
         } else {
             println!("[{issue}] Cloning default branch '{default_branch}' from remote...");
-            let status = Command::new("git")
-                .args([
-                    "clone",
-                    "--depth=1",
-                    &format!("--branch={default_branch}"),
-                    &self.repo_url,
-                    &ws.work_dir.to_string_lossy(),
-                ])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-                .with_context(|| format!("[{issue}] Failed to spawn git clone"))?;
+            let branch_arg = format!("--branch={default_branch}");
+            let work_dir_arg = ws.work_dir.to_string_lossy();
+            let mut clone_cmd = Command::new("git");
+            clone_cmd.args([
+                "clone",
+                "--depth=1",
+                &branch_arg,
+                &self.repo_url,
+                work_dir_arg.as_ref(),
+            ]);
+            let output = run_output_with_timeout(clone_cmd, GIT_CLONE_TIMEOUT)
+                .with_context(|| format!("[{issue}] git clone timed out or failed to execute"))?;
 
-            if !status.success() {
-                bail!("[{issue}] git clone failed with exit code {status}");
+            if !output.status.success() {
+                bail!(
+                    "[{issue}] git clone failed: {}",
+                    format_output_diagnostics(&output, 400)
+                );
             }
         }
 

--- a/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
+++ b/crates/amplihack-cli/src/commands/multitask/orchestrator.rs
@@ -4,7 +4,7 @@
 //! live in sibling modules (`launcher`, `state`, `utils`).
 
 use super::models::*;
-use super::{launcher, state, utils};
+use super::{cleanup, default_branch, launcher, state, utils};
 use crate::util::{format_output_diagnostics, run_output_with_timeout};
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
@@ -20,6 +20,10 @@ use tracing::warn;
 
 const DEFAULT_BRANCH_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(30);
 const GIT_CLONE_TIMEOUT: Duration = Duration::from_secs(300);
+
+#[cfg(test)]
+#[path = "orchestrator_tests.rs"]
+mod orchestrator_tests;
 
 pub struct ParallelOrchestrator {
     repo_url: String,
@@ -333,7 +337,7 @@ impl ParallelOrchestrator {
     }
 
     pub fn cleanup_merged(&self, config_path: &str, dry_run: bool) -> Result<()> {
-        state::cleanup_merged(&self.base_dir, &self.state_dir, config_path, dry_run)
+        cleanup::cleanup_merged(&self.base_dir, &self.state_dir, config_path, dry_run)
     }
 
     fn cleanup_workstream_dir(&self, ws: &Workstream) {
@@ -360,7 +364,7 @@ impl ParallelOrchestrator {
         let branch = match run_output_with_timeout(cmd, DEFAULT_BRANCH_RESOLUTION_TIMEOUT) {
             Ok(output) if output.status.success() => {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                parse_default_branch_from_ls_remote(&stdout).unwrap_or_else(|| {
+                default_branch::parse_from_ls_remote(&stdout).unwrap_or_else(|| {
                     eprintln!(
                         "WARNING: git ls-remote did not return a usable HEAD symref for {}; falling back to main. stdout/stderr diagnostic: {}",
                         self.repo_url,
@@ -388,58 +392,5 @@ impl ParallelOrchestrator {
 
         self.default_branch = Some(branch.clone());
         branch
-    }
-}
-
-fn parse_default_branch_from_ls_remote(stdout: &str) -> Option<String> {
-    stdout
-        .lines()
-        .find(|line| line.starts_with("ref: refs/heads/"))
-        .and_then(|line| line.strip_prefix("ref: refs/heads/"))
-        .and_then(|line| line.split('\t').next())
-        .map(str::trim)
-        .filter(|branch| !branch.is_empty())
-        .map(ToOwned::to_owned)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_orchestrator_construction() {
-        let orch = ParallelOrchestrator::new("https://github.com/test/repo", "recipe");
-        assert_eq!(orch.mode, "recipe");
-        assert_eq!(orch.default_max_runtime, DEFAULT_MAX_RUNTIME);
-        assert!(orch.workstreams.is_empty());
-    }
-
-    #[test]
-    fn test_set_timeout_policy() {
-        let mut orch = ParallelOrchestrator::new(".", "recipe");
-        orch.set_default_timeout_policy("continue-preserve");
-        assert_eq!(orch.default_timeout_policy, "continue-preserve");
-
-        // Invalid policy should be rejected
-        orch.set_default_timeout_policy("invalid-policy");
-        assert_eq!(orch.default_timeout_policy, "continue-preserve");
-    }
-
-    #[test]
-    fn default_branch_fallback_is_bounded_and_diagnostic() {
-        let source = include_str!("orchestrator.rs");
-
-        assert!(
-            source.contains("run_output_with_timeout") || source.contains("run_with_timeout"),
-            "git ls-remote default branch resolution must use an explicit timeout helper"
-        );
-        assert!(
-            source.contains("falling back to main") || source.contains("fallback to main"),
-            "fallback to main must be observable in diagnostics"
-        );
-        assert!(
-            source.contains("stderr") || source.contains("stdout") || source.contains("diagnostic"),
-            "default branch fallback diagnostics should include failure context"
-        );
     }
 }

--- a/crates/amplihack-cli/src/commands/multitask/orchestrator_tests.rs
+++ b/crates/amplihack-cli/src/commands/multitask/orchestrator_tests.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+#[test]
+fn test_orchestrator_construction() {
+    let orch = ParallelOrchestrator::new("https://github.com/test/repo", "recipe");
+    assert_eq!(orch.mode, "recipe");
+    assert_eq!(orch.default_max_runtime, DEFAULT_MAX_RUNTIME);
+    assert!(orch.workstreams.is_empty());
+}
+
+#[test]
+fn test_set_timeout_policy() {
+    let mut orch = ParallelOrchestrator::new(".", "recipe");
+    orch.set_default_timeout_policy("continue-preserve");
+    assert_eq!(orch.default_timeout_policy, "continue-preserve");
+
+    orch.set_default_timeout_policy("invalid-policy");
+    assert_eq!(orch.default_timeout_policy, "continue-preserve");
+}
+
+#[test]
+fn default_branch_fallback_is_bounded_and_diagnostic() {
+    let source = include_str!("orchestrator.rs");
+
+    assert!(
+        source.contains("run_output_with_timeout") || source.contains("run_with_timeout"),
+        "git ls-remote default branch resolution must use an explicit timeout helper"
+    );
+    assert!(
+        source.contains("falling back to main") || source.contains("fallback to main"),
+        "fallback to main must be observable in diagnostics"
+    );
+    assert!(
+        source.contains("stderr") || source.contains("stdout") || source.contains("diagnostic"),
+        "default branch fallback diagnostics should include failure context"
+    );
+}

--- a/crates/amplihack-cli/src/commands/multitask/state.rs
+++ b/crates/amplihack-cli/src/commands/multitask/state.rs
@@ -6,6 +6,7 @@ use super::process_scope::{
     snapshot_for_pid, validate_process_scope,
 };
 use super::utils::{atomic_write, dir_size_bytes};
+use crate::util::run_output_with_timeout;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use std::collections::HashMap;
@@ -13,8 +14,11 @@ use std::fs;
 use std::path::Path;
 use std::process::{Child, Command};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use std::time::Instant;
 use tracing::warn;
+
+const GH_PR_VIEW_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Status snapshot for all workstreams.
 #[derive(Default)]
@@ -342,17 +346,17 @@ pub(super) fn cleanup_merged(
         let state_file = state_dir.join(format!("ws-{safe_id}.json"));
 
         // Check if PR is merged via gh CLI
-        let is_merged = Command::new("gh")
-            .args([
-                "pr",
-                "view",
-                &item.branch,
-                "--json",
-                "state",
-                "-q",
-                ".state",
-            ])
-            .output()
+        let mut gh_cmd = Command::new("gh");
+        gh_cmd.args([
+            "pr",
+            "view",
+            &item.branch,
+            "--json",
+            "state",
+            "-q",
+            ".state",
+        ]);
+        let is_merged = run_output_with_timeout(gh_cmd, GH_PR_VIEW_TIMEOUT)
             .ok()
             .filter(|o| o.status.success())
             .and_then(|o| String::from_utf8(o.stdout).ok())

--- a/crates/amplihack-cli/src/commands/multitask/state.rs
+++ b/crates/amplihack-cli/src/commands/multitask/state.rs
@@ -5,20 +5,16 @@ use super::process_scope::{
     CurrentWorkflowScope, ProcessScopeConfig, ProcessScopeValidation, normalize_path,
     snapshot_for_pid, validate_process_scope,
 };
-use super::utils::{atomic_write, dir_size_bytes};
-use crate::util::run_output_with_timeout;
-use anyhow::{Context, Result};
+use super::utils::atomic_write;
+use anyhow::Result;
 use chrono::Utc;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::process::{Child, Command};
+use std::process::Child;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 use std::time::Instant;
 use tracing::warn;
-
-const GH_PR_VIEW_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Status snapshot for all workstreams.
 #[derive(Default)]
@@ -324,79 +320,4 @@ pub(super) fn get_status(
     }
 
     status
-}
-
-pub(super) fn cleanup_merged(
-    base_dir: &Path,
-    state_dir: &Path,
-    config_path: &str,
-    dry_run: bool,
-) -> Result<()> {
-    let config_text = fs::read_to_string(config_path)
-        .with_context(|| format!("Failed to read config: {config_path}"))?;
-    let items: Vec<WorkstreamConfig> = serde_json::from_str(&config_text)?;
-
-    let mut deleted_count = 0u32;
-    let mut freed_bytes = 0u64;
-
-    for item in &items {
-        let issue = item.issue_id();
-        let safe_id = sanitize_id(&issue.to_string());
-        let work_dir = base_dir.join(format!("ws-{issue}"));
-        let state_file = state_dir.join(format!("ws-{safe_id}.json"));
-
-        // Check if PR is merged via gh CLI
-        let mut gh_cmd = Command::new("gh");
-        gh_cmd.args([
-            "pr",
-            "view",
-            &item.branch,
-            "--json",
-            "state",
-            "-q",
-            ".state",
-        ]);
-        let is_merged = run_output_with_timeout(gh_cmd, GH_PR_VIEW_TIMEOUT)
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .is_some_and(|s| s.trim() == "MERGED");
-
-        if !is_merged {
-            continue;
-        }
-
-        if work_dir.exists() {
-            let dir_size = dir_size_bytes(&work_dir);
-            if dry_run {
-                println!(
-                    "[{issue}] Would delete work dir ({:.0}MB)",
-                    dir_size as f64 / (1024.0 * 1024.0)
-                );
-            } else {
-                let _ = fs::remove_dir_all(&work_dir);
-                let _ = fs::remove_file(&state_file);
-                println!(
-                    "[{issue}] Deleted work dir ({:.0}MB freed)",
-                    dir_size as f64 / (1024.0 * 1024.0)
-                );
-            }
-            freed_bytes += dir_size;
-            deleted_count += 1;
-        }
-    }
-
-    let freed_gb = freed_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
-    println!(
-        "\n{}Summary:\n  Workstreams {}deleted: {deleted_count}\n  Disk space {}freed: {freed_gb:.2}GB",
-        if dry_run { "DRY RUN " } else { "" },
-        if dry_run { "would be " } else { "" },
-        if dry_run { "would be " } else { "" },
-    );
-
-    if dry_run && deleted_count > 0 {
-        println!("\nRun without --dry-run to actually delete these workstreams.");
-    }
-
-    Ok(())
 }

--- a/crates/amplihack-cli/src/commands/multitask/utils.rs
+++ b/crates/amplihack-cli/src/commands/multitask/utils.rs
@@ -25,6 +25,7 @@ pub(super) fn tail_output(
 ) {
     let reader = BufReader::new(stdout);
     let mut log_bytes_written: u64 = 0;
+    let mut discarded_log_bytes: u64 = 0;
 
     // Open log file with 0o600 permissions on Unix, default permissions on Windows.
     let log_fd = {
@@ -47,10 +48,22 @@ pub(super) fn tail_output(
                 let _ = w.flush();
             }
             log_bytes_written += line_bytes;
+        } else {
+            discarded_log_bytes = discarded_log_bytes.saturating_add(line_bytes);
         }
 
         // Prefix output to stdout
         println!("[ws:{issue_id}] {line}");
+    }
+
+    if discarded_log_bytes > 0
+        && let Some(ref mut w) = log_writer
+    {
+        let _ = writeln!(
+            w,
+            "[truncated: discarded {discarded_log_bytes} bytes after log capture limit]"
+        );
+        let _ = w.flush();
     }
 }
 
@@ -157,5 +170,20 @@ mod tests {
         atomic_write(&file, b"hello world").unwrap();
         assert_eq!(fs::read_to_string(&file).unwrap(), "hello world");
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn tail_output_reports_when_log_bytes_are_discarded() {
+        let temp = tempfile::tempdir().unwrap();
+        let log_file = temp.path().join("workstream.log");
+        let input = std::io::Cursor::new(b"abcdef\nsecond line\n".to_vec());
+
+        tail_output(input, &log_file, 42, 4);
+
+        let log = fs::read_to_string(&log_file).unwrap_or_default();
+        assert!(
+            log.contains("truncated") && log.contains("discarded"),
+            "log truncation must report discarded diagnostics; got {log:?}"
+        );
     }
 }

--- a/crates/amplihack-cli/src/commands/new_agent/distributor.rs
+++ b/crates/amplihack-cli/src/commands/new_agent/distributor.rs
@@ -6,12 +6,15 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::time::Instant;
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
 
 use super::error::BundleError;
 use super::models::{DistributionPlatform, DistributionResult, PackagedBundle};
 use super::packager::sha256_file;
+use crate::util::run_output_with_timeout;
+
+const GH_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Options for a distribution operation.
 #[derive(Debug, Clone, Default)]
@@ -153,32 +156,24 @@ impl Distributor {
 
     /// Check whether `gh` CLI is available.
     fn has_gh_cli() -> bool {
-        Command::new("gh")
-            .arg("--version")
-            .output()
+        run_gh(&["--version"])
             .map(|o| o.status.success())
             .unwrap_or(false)
     }
 
     /// Ensure the repository exists, create it if not.
     fn ensure_repo(&self, full_repo: &str) -> Result<(), BundleError> {
-        let status = Command::new("gh")
-            .args(["repo", "view", full_repo, "--json", "name"])
-            .output()
-            .map_err(|e| BundleError::distribution(format!("gh repo view failed: {e}")))?;
+        let status = run_gh(&["repo", "view", full_repo, "--json", "name"])?;
 
         if !status.status.success() {
-            let out = Command::new("gh")
-                .args([
-                    "repo",
-                    "create",
-                    full_repo,
-                    "--public",
-                    "--description",
-                    "Amplihack agent bundle",
-                ])
-                .output()
-                .map_err(|e| BundleError::distribution(format!("gh repo create failed: {e}")))?;
+            let out = run_gh(&[
+                "repo",
+                "create",
+                full_repo,
+                "--public",
+                "--description",
+                "Amplihack agent bundle",
+            ])?;
             if !out.status.success() {
                 let stderr = String::from_utf8_lossy(&out.stderr);
                 return Err(BundleError::distribution(format!(
@@ -202,10 +197,8 @@ impl Distributor {
             .join(".dist-work");
         let _ = fs::remove_dir_all(&work);
 
-        let clone_out = Command::new("gh")
-            .args(["repo", "clone", full_repo, work.to_string_lossy().as_ref()])
-            .output()
-            .map_err(|e| BundleError::distribution(format!("clone failed: {e}")))?;
+        let work_arg = work.to_string_lossy();
+        let clone_out = run_gh(&["repo", "clone", full_repo, work_arg.as_ref()])?;
 
         if !clone_out.status.success() {
             let stderr = String::from_utf8_lossy(&clone_out.stderr);
@@ -256,21 +249,20 @@ impl Distributor {
         notes: &str,
         asset: &Path,
     ) -> Result<String, BundleError> {
-        let out = Command::new("gh")
-            .args([
-                "release",
-                "create",
-                tag,
-                "--repo",
-                full_repo,
-                "--title",
-                &format!("Release {tag}"),
-                "--notes",
-                notes,
-                asset.to_string_lossy().as_ref(),
-            ])
-            .output()
-            .map_err(|e| BundleError::distribution(format!("gh release create: {e}")))?;
+        let title = format!("Release {tag}");
+        let asset_arg = asset.to_string_lossy();
+        let out = run_gh(&[
+            "release",
+            "create",
+            tag,
+            "--repo",
+            full_repo,
+            "--title",
+            &title,
+            "--notes",
+            notes,
+            asset_arg.as_ref(),
+        ])?;
 
         if !out.status.success() {
             let stderr = String::from_utf8_lossy(&out.stderr);
@@ -346,6 +338,18 @@ impl Distributor {
 
         Ok(dest)
     }
+}
+
+fn run_gh(args: &[&str]) -> Result<Output, BundleError> {
+    let mut cmd = Command::new("gh");
+    cmd.args(args);
+    run_output_with_timeout(cmd, GH_COMMAND_TIMEOUT).map_err(|err| {
+        BundleError::distribution(format!(
+            "gh {} failed or timed out after {}s: {err:#}",
+            args.first().copied().unwrap_or("<no-arg>"),
+            GH_COMMAND_TIMEOUT.as_secs()
+        ))
+    })
 }
 
 /// Verify the integrity of a distributed package against its recorded checksum.

--- a/crates/amplihack-cli/src/commands/new_agent/distributor.rs
+++ b/crates/amplihack-cli/src/commands/new_agent/distributor.rs
@@ -12,9 +12,10 @@ use std::time::{Duration, Instant};
 use super::error::BundleError;
 use super::models::{DistributionPlatform, DistributionResult, PackagedBundle};
 use super::packager::sha256_file;
-use crate::util::run_output_with_timeout;
+use crate::util::{format_output_diagnostics, run_output_with_timeout};
 
 const GH_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Options for a distribution operation.
 #[derive(Debug, Clone, Default)]
@@ -216,16 +217,20 @@ impl Distributor {
 
         // Git add + commit + push.
         let run_git = |args: &[&str]| -> Result<(), BundleError> {
-            let out = Command::new("git")
-                .args(args)
-                .current_dir(&work)
-                .output()
-                .map_err(|e| BundleError::distribution(format!("git {}: {e}", args[0])))?;
+            let mut cmd = Command::new("git");
+            cmd.args(args).current_dir(&work);
+            let out = run_output_with_timeout(cmd, GIT_COMMAND_TIMEOUT).map_err(|err| {
+                BundleError::distribution(format!(
+                    "git {} failed or timed out after {}s: {err:#}",
+                    args.first().copied().unwrap_or("<no-arg>"),
+                    GIT_COMMAND_TIMEOUT.as_secs()
+                ))
+            })?;
             if !out.status.success() {
-                let stderr = String::from_utf8_lossy(&out.stderr);
                 return Err(BundleError::distribution(format!(
-                    "git {} failed: {stderr}",
-                    args[0]
+                    "git {} failed: {}",
+                    args.first().copied().unwrap_or("<no-arg>"),
+                    format_output_diagnostics(&out, 400)
                 )));
             }
             Ok(())

--- a/crates/amplihack-cli/src/commands/new_agent/update_manager.rs
+++ b/crates/amplihack-cli/src/commands/new_agent/update_manager.rs
@@ -12,6 +12,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::error::BundleError;
+use crate::util::run_output_with_timeout;
+
+const GIT_COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Information about an available update.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -239,11 +242,16 @@ impl UpdateManager {
             }
         };
 
-        let output = Command::new("git")
+        let mut command = Command::new("git");
+        command
             .args(["rev-parse", "--short", "HEAD"])
-            .current_dir(&repo)
-            .output()
-            .map_err(|e| BundleError::repo(format!("git rev-parse failed: {e}")))?;
+            .current_dir(&repo);
+        let output = run_output_with_timeout(command, GIT_COMMAND_TIMEOUT).map_err(|err| {
+            BundleError::repo(format!(
+                "git rev-parse failed or timed out after {}s: {err:#}",
+                GIT_COMMAND_TIMEOUT.as_secs()
+            ))
+        })?;
 
         if !output.status.success() {
             return Err(BundleError::repo("failed to get framework version"));
@@ -258,15 +266,16 @@ impl UpdateManager {
             None => return Vec::new(),
         };
 
-        let output = Command::new("git")
+        let mut command = Command::new("git");
+        command
             .args([
                 "log",
                 "--oneline",
                 "--max-count=10",
                 &format!("{old}..{new}"),
             ])
-            .current_dir(repo)
-            .output();
+            .current_dir(repo);
+        let output = run_output_with_timeout(command, GIT_COMMAND_TIMEOUT);
 
         match output {
             Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)

--- a/crates/amplihack-cli/src/commands/node.rs
+++ b/crates/amplihack-cli/src/commands/node.rs
@@ -1,12 +1,18 @@
 //! Node.js diagnostics and conservative remediation for Copilot CLI support.
 
 use crate::command_error::exit_error;
+use crate::util::{render_diagnostic_bytes, run_output_with_timeout};
 use amplihack_utils::prerequisites::{NODE_MINIMUM_MAJOR, parse_node_major_version};
 use anyhow::Result;
 use std::process::Command;
+use std::time::Duration;
+
+const NODE_VERSION_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub(crate) fn run_node_diagnostic(ensure: bool) -> Result<()> {
-    let output = Command::new("node").arg("--version").output();
+    let mut command = Command::new("node");
+    command.arg("--version");
+    let output = run_output_with_timeout(command, NODE_VERSION_TIMEOUT);
     match output {
         Ok(out) if out.status.success() => {
             let version = String::from_utf8_lossy(&out.stdout);
@@ -28,19 +34,17 @@ pub(crate) fn run_node_diagnostic(ensure: bool) -> Result<()> {
                 ),
             }
         }
-        Ok(out) => {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            fail_with_remediation(
-                ensure,
-                &format!(
-                    "Node.js version check failed: {}",
-                    stderr
-                        .lines()
-                        .next()
-                        .unwrap_or("node --version exited non-zero")
-                ),
-            )
-        }
+        Ok(out) => fail_with_remediation(
+            ensure,
+            &format!(
+                "Node.js version check failed: {}",
+                if out.stderr.is_empty() {
+                    "node --version exited non-zero".to_string()
+                } else {
+                    render_diagnostic_bytes(&out.stderr, 500)
+                }
+            ),
+        ),
         Err(err) => fail_with_remediation(ensure, &format!("Node.js is missing: {err}")),
     }
 }

--- a/crates/amplihack-cli/src/commands/pr/mod.rs
+++ b/crates/amplihack-cli/src/commands/pr/mod.rs
@@ -9,11 +9,14 @@
 #[cfg(test)]
 mod tests;
 
+use crate::util::run_output_with_timeout;
 use anyhow::{Context, Result, bail};
 use clap::Subcommand;
 use serde::Deserialize;
 use std::thread;
 use std::time::Duration;
+
+const GH_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
 
 // ── Public types ────────────────────────────────────────────────────
 
@@ -68,10 +71,10 @@ pub struct RealGhRunner;
 
 impl GhRunner for RealGhRunner {
     fn run_gh(&self, args: &[&str]) -> Result<GhOutput> {
-        let output = std::process::Command::new("gh")
-            .args(args)
-            .output()
-            .context("failed to execute `gh` — is it installed?")?;
+        let mut cmd = std::process::Command::new("gh");
+        cmd.args(args);
+        let output = run_output_with_timeout(cmd, GH_COMMAND_TIMEOUT)
+            .context("failed to execute `gh` within the 60s timeout — is it installed?")?;
         Ok(GhOutput {
             stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),

--- a/crates/amplihack-cli/src/commands/recipe/recipe_tests.rs
+++ b/crates/amplihack-cli/src/commands/recipe/recipe_tests.rs
@@ -485,6 +485,24 @@ fn resolve_recipe_path_fails_loudly_when_all_smart_orchestrator_candidates_are_s
 }
 
 #[test]
+fn resolve_recipe_path_fails_loudly_for_absolute_stale_smart_orchestrator() {
+    let temp = tempdir().unwrap();
+    let stale = temp.path().join("smart-orchestrator.yaml");
+    write_recipe(&stale, stale_smart_orchestrator_recipe());
+
+    let err = resolve_recipe_path(stale.to_str().unwrap(), temp.path())
+        .expect_err("absolute stale smart-orchestrator path must not bypass compatibility checks");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("smart-orchestrator")
+            && msg.contains("stale")
+            && msg.contains("orch_helper")
+            && msg.contains("amplihack install"),
+        "error must identify stale absolute smart-orchestrator and repair guidance, got: {msg}"
+    );
+}
+
+#[test]
 fn amplihack_home_recipe_dir_warns_for_non_directory_root_with_resolved_path() {
     let _home_guard = crate::test_support::home_env_lock()
         .lock()

--- a/crates/amplihack-cli/src/commands/recipe/recipe_tests.rs
+++ b/crates/amplihack-cli/src/commands/recipe/recipe_tests.rs
@@ -103,6 +103,39 @@ fn capture_warn_logs<T>(operation: impl FnOnce() -> T) -> (T, Vec<String>) {
     (result, captured)
 }
 
+fn compatible_smart_orchestrator_recipe(label: &str) -> String {
+    format!(
+        r#"name: smart-orchestrator
+description: compatible {label}
+steps:
+  - id: route
+    type: bash
+    command: echo compatible {label}
+"#
+    )
+}
+
+fn stale_smart_orchestrator_recipe() -> &'static str {
+    r#"name: smart-orchestrator
+description: stale v1.5.1 helper-based orchestrator
+steps:
+  - id: parse-decomposition
+    type: shell
+    command: |
+      HELPER="$(amplihack resolve-bundle-asset helper-path)"
+      python3 - <<'PY'
+      import importlib
+      helper = importlib.import_module("orch_helper")
+      helper.parse_decomposition()
+      PY
+"#
+}
+
+fn write_recipe(path: &Path, body: impl AsRef<str>) {
+    fs::create_dir_all(path.parent().expect("recipe path has parent")).unwrap();
+    fs::write(path, body.as_ref()).unwrap();
+}
+
 #[test]
 fn parse_recipe_validates_required_fields() {
     let err = parse_recipe_text("description: nope\nsteps: []").unwrap_err();
@@ -371,6 +404,84 @@ fn resolve_recipe_path_searches_amplihack_home_bundle_dir() {
     }
 
     assert_eq!(resolved, recipe_path);
+}
+
+#[test]
+fn resolve_recipe_path_skips_stale_smart_orchestrator_when_compatible_fallback_exists() {
+    let _env_guard = crate::test_support::env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempdir().unwrap();
+    let home = temp.path().join("home");
+    let amplihack_home = temp.path().join("amplihack-home");
+    let working_dir = temp.path().join("project");
+    fs::create_dir_all(&working_dir).unwrap();
+
+    let stale = amplihack_home
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join("smart-orchestrator.yaml");
+    write_recipe(&stale, stale_smart_orchestrator_recipe());
+
+    let fallback = home
+        .join(".amplihack")
+        .join(".claude")
+        .join("recipes")
+        .join("smart-orchestrator.yaml");
+    write_recipe(
+        &fallback,
+        compatible_smart_orchestrator_recipe("claude fallback"),
+    );
+
+    let _home = EnvVarGuard::set_path("HOME", &home);
+    let _amplihack_home = EnvVarGuard::set_path("AMPLIHACK_HOME", &amplihack_home);
+
+    let resolved = resolve_recipe_path("smart-orchestrator", &working_dir)
+        .expect("compatible fallback should be selected when the top-level bundle is stale");
+
+    assert_eq!(
+        resolved, fallback,
+        "stale AMPLIHACK_HOME/amplifier-bundle smart-orchestrator must not shadow a compatible .claude/recipes fallback"
+    );
+}
+
+#[test]
+fn resolve_recipe_path_fails_loudly_when_all_smart_orchestrator_candidates_are_stale() {
+    let _env_guard = crate::test_support::env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempdir().unwrap();
+    let home = temp.path().join("home");
+    let amplihack_home = temp.path().join("amplihack-home");
+    let working_dir = temp.path().join("project");
+    fs::create_dir_all(&working_dir).unwrap();
+
+    let top_level_stale = amplihack_home
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join("smart-orchestrator.yaml");
+    write_recipe(&top_level_stale, stale_smart_orchestrator_recipe());
+
+    let claude_stale = home
+        .join(".amplihack")
+        .join(".claude")
+        .join("recipes")
+        .join("smart-orchestrator.yaml");
+    write_recipe(&claude_stale, stale_smart_orchestrator_recipe());
+
+    let _home = EnvVarGuard::set_path("HOME", &home);
+    let _amplihack_home = EnvVarGuard::set_path("AMPLIHACK_HOME", &amplihack_home);
+
+    let err = resolve_recipe_path("smart-orchestrator", &working_dir)
+        .expect_err("all stale smart-orchestrator candidates must fail, not resolve silently");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("smart-orchestrator")
+            && (msg.contains("stale") || msg.contains("incompatible"))
+            && msg.contains("orch_helper")
+            && (msg.contains("install") || msg.contains("repair")),
+        "error must identify stale candidates and give repair guidance, got: {msg}"
+    );
 }
 
 #[test]

--- a/crates/amplihack-cli/src/commands/recipe/resolve.rs
+++ b/crates/amplihack-cli/src/commands/recipe/resolve.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::commands::install::bundle_compat::is_incompatible_smart_orchestrator;
 
 pub(super) fn resolve_path_from(base_dir: &Path, path: impl AsRef<Path>) -> Result<PathBuf> {
     let path = path.as_ref();
@@ -163,6 +164,70 @@ pub(crate) fn find_recipe_path(name: &str, search_dirs: &[PathBuf]) -> Option<Pa
     None
 }
 
+fn find_compatible_recipe_path(name: &str, search_dirs: &[PathBuf]) -> Result<Option<PathBuf>> {
+    if !is_smart_orchestrator_input(name) {
+        return Ok(find_recipe_path(name, search_dirs));
+    }
+
+    let mut stale_candidates = Vec::new();
+    for search_dir in search_dirs {
+        for extension in RECIPE_FILE_EXTENSIONS {
+            let candidate = search_dir.join(format!("{name}.{extension}"));
+            if !candidate.is_file() {
+                continue;
+            }
+            if is_incompatible_smart_orchestrator(&candidate)? {
+                stale_candidates.push(candidate);
+                continue;
+            }
+            warn_if_stale_smart_orchestrator_was_bypassed(&stale_candidates);
+            return Ok(Some(candidate));
+        }
+    }
+
+    fail_if_only_stale_smart_orchestrators(name, &stale_candidates)?;
+    Ok(None)
+}
+
+fn is_smart_orchestrator_input(input: &str) -> bool {
+    Path::new(input)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        == Some("smart-orchestrator")
+}
+
+fn warn_if_stale_smart_orchestrator_was_bypassed(stale_candidates: &[PathBuf]) {
+    if stale_candidates.is_empty() {
+        return;
+    }
+
+    tracing::warn!(
+        stale_candidates = %stale_candidates
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        "skipping stale smart-orchestrator recipe candidates because a compatible fallback exists"
+    );
+}
+
+fn fail_if_only_stale_smart_orchestrators(input: &str, stale_candidates: &[PathBuf]) -> Result<()> {
+    if stale_candidates.is_empty() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "Recipe {input} resolved only to stale or incompatible smart-orchestrator candidates: {}. \
+         These recipes contain legacy markers such as orch_helper/importlib/parse-decomposition. \
+         Run `amplihack install` to refresh installed assets, or `amplihack update` to install a current bundle.",
+        stale_candidates
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
 fn looks_like_recipe_path(input: &str) -> bool {
     let candidate = Path::new(input);
     candidate.components().count() > 1
@@ -189,13 +254,22 @@ pub(crate) fn resolve_recipe_path(input: &str, working_dir: impl AsRef<Path>) ->
         // repo root rather than the current working directory.
         let roots = relative_recipe_path_search_roots(&cwd, &working_dir);
         let mut tried = Vec::with_capacity(roots.len());
+        let mut stale_candidates = Vec::new();
         for root in &roots {
             let resolved = root.join(candidate);
             if resolved.is_file() {
+                if is_smart_orchestrator_input(input)
+                    && is_incompatible_smart_orchestrator(&resolved)?
+                {
+                    stale_candidates.push(resolved);
+                    continue;
+                }
+                warn_if_stale_smart_orchestrator_was_bypassed(&stale_candidates);
                 return Ok(resolved);
             }
             tried.push(resolved);
         }
+        fail_if_only_stale_smart_orchestrators(input, &stale_candidates)?;
 
         // Preserve prior fallback behavior: if no root contains the file, return
         // the working_dir-relative path so downstream parsing emits the
@@ -211,7 +285,7 @@ pub(crate) fn resolve_recipe_path(input: &str, working_dir: impl AsRef<Path>) ->
     }
 
     let search_dirs = recipe_search_dirs(None, &working_dir)?;
-    if let Some(resolved) = find_recipe_path(input, &search_dirs) {
+    if let Some(resolved) = find_compatible_recipe_path(input, &search_dirs)? {
         return Ok(resolved);
     }
 

--- a/crates/amplihack-cli/src/commands/recipe/resolve.rs
+++ b/crates/amplihack-cli/src/commands/recipe/resolve.rs
@@ -243,6 +243,12 @@ pub(crate) fn resolve_recipe_path(input: &str, working_dir: impl AsRef<Path>) ->
     let candidate = Path::new(input);
 
     if candidate.is_absolute() {
+        if is_smart_orchestrator_input(input)
+            && candidate.is_file()
+            && is_incompatible_smart_orchestrator(candidate)?
+        {
+            fail_if_only_stale_smart_orchestrators(input, &[candidate.to_path_buf()])?;
+        }
         return Ok(candidate.to_path_buf());
     }
 

--- a/crates/amplihack-cli/src/commands/recipe/run/correlation.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/correlation.rs
@@ -1,17 +1,20 @@
 use super::super::{RecipeLogPointerSummary, RecipeRunResult};
+use crate::util::run_output_with_timeout;
 use chrono::{SecondsFormat, Utc};
 use serde::Serialize;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
+use std::time::Duration;
 use uuid::Uuid;
 
 pub(super) const LOG_POINTER_PREFIX: &str = "amplihack.recipe.log_pointer ";
 
 const SCHEMA_VERSION: u8 = 1;
 const MAX_POINTER_VALUE_BYTES: usize = 1024;
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone)]
 pub(super) struct RecipeRunCorrelation {
@@ -91,6 +94,10 @@ impl RecipeRunCorrelation {
 
     pub(super) fn run_id(&self) -> &str {
         &self.run_id
+    }
+
+    pub(super) fn cwd(&self) -> &str {
+        &self.cwd
     }
 
     pub(super) fn emit_early(&self) {
@@ -307,14 +314,9 @@ fn path_to_string(path: &Path) -> String {
 }
 
 fn git_output(working_dir: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(working_dir)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .output()
-        .ok()?;
+    let mut command = Command::new("git");
+    command.arg("-C").arg(working_dir).args(args);
+    let output = run_output_with_timeout(command, GIT_COMMAND_TIMEOUT).ok()?;
     if !output.status.success() {
         return None;
     }

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -1,14 +1,24 @@
 use super::correlation::{RecipeRunCorrelation, RecipeRunFinalStatus, known_log_paths};
 use super::*;
 use crate::env_builder::{EnvBuilder, active_agent_binary};
+#[cfg(windows)]
+use crate::util::run_with_timeout;
+use crate::util::truncate_chars_with_notice;
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Write as IoWrite};
-use std::process::Stdio;
-use std::sync::{Arc, Mutex};
+use std::process::{Child, ExitStatus, Stdio};
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
+use std::time::{Duration, Instant};
 
 const STDERR_TAIL_LINES: usize = 5;
 const CAPTURED_STDERR_LINES: usize = 200;
+const RECIPE_RUNNER_DEFAULT_TIMEOUT: Duration = Duration::from_secs(6 * 60 * 60);
+const RECIPE_RUNNER_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const RECIPE_RUNNER_PIPE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(windows)]
+const RECIPE_RUNNER_TERMINATE_TIMEOUT: Duration = Duration::from_secs(5);
+const RECIPE_RUNNER_TIMEOUT_ENV: &str = "AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS";
 
 /// Threshold in bytes for total `--set` argument size before we switch
 /// to passing context via a temp file. Well under the typical Linux
@@ -187,7 +197,7 @@ pub(super) fn execute_recipe_via_rust(
     }
 
     // Pass context as a file when the total size would risk E2BIG (os error 7).
-    // The temp file is kept alive until command.output() completes.
+    // The temp file is kept alive until the recipe runner child completes.
     let _context_file = pass_context(&mut command, context)?;
 
     // Issue #784 / #4583: export recipe context as environment variables so
@@ -236,7 +246,7 @@ pub(super) fn execute_recipe_via_rust(
     command.env("AMPLIHACK_WORKFLOW_ARTIFACT_DIR", &artifact_dir);
     command.env("TMPDIR", &tmp_dir);
 
-    spawn_with_streaming_stderr(command, correlation)
+    spawn_with_streaming_stderr(command, correlation, recipe_path, recipe_runner_timeout())
 }
 
 /// Spawn the runner with stdout captured (we need to parse JSON from it)
@@ -246,8 +256,24 @@ pub(super) fn execute_recipe_via_rust(
 fn spawn_with_streaming_stderr(
     mut command: Command,
     correlation: RecipeRunCorrelation,
+    recipe_path: &Path,
+    timeout: Duration,
 ) -> Result<RecipeRunResult> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: `pre_exec` runs after fork and before exec. `setsid` is
+        // async-signal-safe and lets timeout cleanup terminate the recipe tree.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
     correlation.emit_early();
     let mut child = match command.spawn() {
         Ok(child) => child,
@@ -264,9 +290,12 @@ fn spawn_with_streaming_stderr(
     let child_pid = Some(child.id());
 
     let captured_stderr: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(VecDeque::new()));
+    let dropped_stderr_lines: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
     let stderr_handle = child.stderr.take().expect("piped stderr");
     let captured_clone = Arc::clone(&captured_stderr);
-    let pump = thread::spawn(move || {
+    let dropped_clone = Arc::clone(&dropped_stderr_lines);
+    let (stderr_done_tx, stderr_done_rx) = mpsc::channel();
+    thread::spawn(move || {
         // Read RAW BYTES, not str-typed lines(): an Err(InvalidData) from
         // non-UTF-8 stderr would otherwise terminate the pump silently and
         // the child can then block on a full pipe (#366 / COE feedback).
@@ -281,7 +310,7 @@ fn spawn_with_streaming_stderr(
                     let line = String::from_utf8_lossy(&buf);
                     let trimmed = line.trim_end_matches(['\r', '\n']);
                     let _ = writeln!(stderr.lock(), "{trimmed}");
-                    push_bounded_stderr_line(&captured_clone, trimmed.to_string());
+                    push_bounded_stderr_line(&captured_clone, &dropped_clone, trimmed.to_string());
                 }
                 // I/O error reading from the pipe: log and stop pumping —
                 // we MUST NOT spin or leak the thread, but the child will
@@ -289,23 +318,65 @@ fn spawn_with_streaming_stderr(
                 Err(_) => break,
             }
         }
+        let _ = stderr_done_tx.send(());
     });
 
-    let mut stdout_buf = String::new();
     let mut stdout_handle = child.stdout.take().expect("piped stdout");
     use std::io::Read;
-    stdout_handle
-        .read_to_string(&mut stdout_buf)
-        .context("failed to read recipe-runner-rs stdout")?;
+    let (stdout_tx, stdout_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut stdout_buf = String::new();
+        let result = stdout_handle
+            .read_to_string(&mut stdout_buf)
+            .map(|_| stdout_buf);
+        let _ = stdout_tx.send(result);
+    });
 
-    let status = child
-        .wait()
-        .context("failed to wait for recipe-runner-rs")?;
-    pump.join().expect("stderr pump thread panicked");
+    let status = match wait_for_recipe_runner(&mut child, timeout)
+        .context("failed to wait for recipe-runner-rs")?
+    {
+        Some(status) => status,
+        None => {
+            let pid = child.id();
+            terminate_recipe_runner(&mut child)?;
+            let _summary = correlation.emit_final(
+                RecipeRunFinalStatus::Failure,
+                child_pid,
+                None,
+                known_log_paths(None),
+            );
+            anyhow::bail!(
+                "recipe-runner-rs timed out after {:?} (pid {}, recipe {}, working dir {})",
+                timeout,
+                pid,
+                recipe_path.display(),
+                correlation.cwd()
+            );
+        }
+    };
+
+    let stdout_buf = stdout_rx
+        .recv_timeout(RECIPE_RUNNER_PIPE_DRAIN_TIMEOUT)
+        .with_context(|| {
+            format!(
+                "recipe-runner-rs stdout did not close within {:?} after process exit",
+                RECIPE_RUNNER_PIPE_DRAIN_TIMEOUT
+            )
+        })?
+        .context("failed to read recipe-runner-rs stdout")?;
+    let _ = stderr_done_rx.recv_timeout(RECIPE_RUNNER_PIPE_DRAIN_TIMEOUT);
 
     let captured = captured_stderr.lock().expect("stderr mutex");
+    let dropped = *dropped_stderr_lines
+        .lock()
+        .expect("stderr drop-count mutex");
     let stderr_joined = captured.iter().cloned().collect::<Vec<_>>().join("\n");
-    match parse_recipe_output(&stdout_buf, &stderr_joined, status.success()) {
+    match parse_recipe_output_with_stderr_drops(
+        &stdout_buf,
+        &stderr_joined,
+        status.success(),
+        dropped,
+    ) {
         Ok(mut result) => {
             let final_status = if status.success() && result.success {
                 RecipeRunFinalStatus::Success
@@ -364,10 +435,15 @@ fn recipe_name_for_correlation(recipe_path: &Path) -> String {
         .unwrap_or_else(|| recipe_path.display().to_string())
 }
 
-fn push_bounded_stderr_line(captured: &Arc<Mutex<VecDeque<String>>>, line: String) {
+fn push_bounded_stderr_line(
+    captured: &Arc<Mutex<VecDeque<String>>>,
+    dropped: &Arc<Mutex<usize>>,
+    line: String,
+) {
     let mut captured = captured.lock().expect("stderr mutex");
     if captured.len() == CAPTURED_STDERR_LINES {
         captured.pop_front();
+        *dropped.lock().expect("stderr drop-count mutex") += 1;
     }
     captured.push_back(line);
 }
@@ -381,14 +457,24 @@ fn push_bounded_stderr_line(captured: &Arc<Mutex<VecDeque<String>>>, line: Strin
 /// - Empty/whitespace-only stdout + failure: errors with the meaningful stderr
 ///   tail surfaced so callers see the upstream cause.
 /// - Non-empty stdout: parses as JSON; on failure, errors with a bounded stdout
-///   preview (first 200 chars) and stderr tail in the `anyhow::Context`.
+///   preview that reports discarded chars and stderr tail in the `anyhow::Context`.
 ///
 /// `RecipeRunResult` does not use `deny_unknown_fields`, so future
 /// recipe-runner-rs versions may add fields without breaking us.
+#[cfg(test)]
 pub(super) fn parse_recipe_output(
     stdout: &str,
     stderr: &str,
     exit_success: bool,
+) -> Result<RecipeRunResult> {
+    parse_recipe_output_with_stderr_drops(stdout, stderr, exit_success, 0)
+}
+
+fn parse_recipe_output_with_stderr_drops(
+    stdout: &str,
+    stderr: &str,
+    exit_success: bool,
+    prior_discarded_stderr_lines: usize,
 ) -> Result<RecipeRunResult> {
     let trimmed = stdout.trim();
     if trimmed.is_empty() {
@@ -413,16 +499,16 @@ pub(super) fn parse_recipe_output(
         }
         anyhow::bail!(
             "recipe-runner-rs produced no output and exited with failure\nstderr tail:\n{}",
-            meaningful_stderr_tail(stderr)
+            meaningful_stderr_tail_with_prior_drops(stderr, prior_discarded_stderr_lines)
         );
     }
 
     serde_json::from_str::<RecipeRunResult>(trimmed).with_context(|| {
-        let preview: String = trimmed.chars().take(200).collect();
+        let preview = truncate_chars_with_notice(trimmed, 200);
         format!(
-            "recipe-runner-rs produced non-JSON stdout (first 200 chars): {}\nstderr tail:\n{}",
+            "recipe-runner-rs produced non-JSON stdout preview:\n{}\nstderr tail:\n{}",
             preview,
-            meaningful_stderr_tail(stderr)
+            meaningful_stderr_tail_with_prior_drops(stderr, prior_discarded_stderr_lines)
         )
     })
 }
@@ -493,7 +579,15 @@ fn signal_name(signal: i32) -> &'static str {
     }
 }
 
+#[cfg(test)]
 pub(super) fn meaningful_stderr_tail(stderr: &str) -> String {
+    meaningful_stderr_tail_with_prior_drops(stderr, 0)
+}
+
+pub(super) fn meaningful_stderr_tail_with_prior_drops(
+    stderr: &str,
+    prior_discarded_stderr_lines: usize,
+) -> String {
     let lines = stderr
         .lines()
         .map(str::trim)
@@ -508,19 +602,95 @@ pub(super) fn meaningful_stderr_tail(stderr: &str) -> String {
         })
         .collect::<Vec<_>>();
 
-    let selected = if meaningful.is_empty() {
-        lines
-            .into_iter()
-            .rev()
-            .take(STDERR_TAIL_LINES)
-            .collect::<Vec<_>>()
+    let (selected, discarded) = if meaningful.is_empty() {
+        let discarded = lines.len().saturating_sub(STDERR_TAIL_LINES);
+        (
+            lines
+                .into_iter()
+                .rev()
+                .take(STDERR_TAIL_LINES)
+                .collect::<Vec<_>>(),
+            discarded,
+        )
     } else {
-        meaningful
-            .into_iter()
-            .rev()
-            .take(STDERR_TAIL_LINES)
-            .collect::<Vec<_>>()
+        let discarded = meaningful.len().saturating_sub(STDERR_TAIL_LINES);
+        (
+            meaningful
+                .into_iter()
+                .rev()
+                .take(STDERR_TAIL_LINES)
+                .collect::<Vec<_>>(),
+            discarded,
+        )
     };
 
-    selected.into_iter().rev().collect::<Vec<_>>().join("\n")
+    let mut tail = selected.into_iter().rev().collect::<Vec<_>>().join("\n");
+    let discarded = discarded + prior_discarded_stderr_lines;
+    if discarded > 0 {
+        if !tail.is_empty() {
+            tail.push('\n');
+        }
+        tail.push_str(&format!("[truncated: discarded {discarded} stderr lines]"));
+    }
+    tail
+}
+
+fn recipe_runner_timeout() -> Duration {
+    std::env::var(RECIPE_RUNNER_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(RECIPE_RUNNER_DEFAULT_TIMEOUT)
+}
+
+fn wait_for_recipe_runner(
+    child: &mut Child,
+    timeout: Duration,
+) -> std::io::Result<Option<ExitStatus>> {
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(Some(status));
+        }
+        if started.elapsed() >= timeout {
+            return Ok(None);
+        }
+        thread::sleep(RECIPE_RUNNER_POLL_INTERVAL.min(timeout.saturating_sub(started.elapsed())));
+    }
+}
+
+fn terminate_recipe_runner(child: &mut Child) -> Result<()> {
+    let pid = child.id();
+    #[cfg(unix)]
+    {
+        let process_group = -(pid as libc::pid_t);
+        let result = unsafe { libc::kill(process_group, libc::SIGKILL) };
+        if result != 0 {
+            let error = std::io::Error::last_os_error();
+            tracing::warn!(pid, %error, "failed to terminate timed-out recipe-runner process group");
+        }
+    }
+    #[cfg(windows)]
+    {
+        let mut command = Command::new("taskkill");
+        command
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let _ = run_with_timeout(command, RECIPE_RUNNER_TERMINATE_TIMEOUT);
+    }
+    child
+        .kill()
+        .or_else(|kill_error| match child.try_wait() {
+            Ok(Some(_)) => Ok(()),
+            Ok(None) => Err(kill_error),
+            Err(wait_error) => Err(wait_error),
+        })
+        .with_context(|| format!("failed to terminate timed-out recipe-runner-rs pid {pid}"))?;
+    child
+        .wait()
+        .with_context(|| format!("failed to wait for timed-out recipe-runner-rs pid {pid}"))?;
+    Ok(())
 }

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_execute.rs
@@ -1887,6 +1887,123 @@ fn test_execute_recipe_via_rust_verbose_survives_non_utf8_stderr() {
     );
 }
 
+#[test]
+#[cfg(unix)]
+fn test_execute_recipe_via_rust_times_out_hung_runner() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    std::fs::write(&runner, "#!/bin/sh\n/bin/sleep 5\n").expect("failed to write runner stub");
+
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&runner, std::fs::Permissions::from_mode(0o755))
+        .expect("failed to chmod runner");
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: timeout-probe\nsteps: []\n").expect("failed to write recipe");
+
+    let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+    let prev_timeout = std::env::var_os("AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS");
+    unsafe {
+        std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+        std::env::set_var("AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS", "1");
+    }
+
+    let start = std::time::Instant::now();
+    let result = execute::execute_recipe_via_rust(
+        &recipe,
+        &BTreeMap::new(),
+        false,
+        true,
+        temp.path(),
+        &[],
+        None,
+    );
+    let elapsed = start.elapsed();
+
+    match prev_runner {
+        Some(value) => unsafe { std::env::set_var("RECIPE_RUNNER_RS_PATH", value) },
+        None => unsafe { std::env::remove_var("RECIPE_RUNNER_RS_PATH") },
+    }
+    match prev_timeout {
+        Some(value) => unsafe { std::env::set_var("AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS", value) },
+        None => unsafe { std::env::remove_var("AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS") },
+    }
+
+    let err = result.expect_err("hung recipe-runner must time out");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("timed out"),
+        "error should report timeout: {msg}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "parent timeout should bound hung runner, elapsed {elapsed:?}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_execute_recipe_via_rust_timeout_kills_runner_process_tree() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    let marker = temp.path().join("orphan-marker");
+    std::fs::write(
+        &runner,
+        format!(
+            "#!/bin/sh\n(/bin/sleep 2; echo orphan > '{}') &\n/bin/sleep 5\n",
+            marker.display()
+        ),
+    )
+    .expect("failed to write runner stub");
+
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&runner, std::fs::Permissions::from_mode(0o755))
+        .expect("failed to chmod runner");
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: timeout-tree-probe\nsteps: []\n")
+        .expect("failed to write recipe");
+
+    let prev_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
+    let prev_timeout = std::env::var_os("AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS");
+    unsafe {
+        std::env::set_var("RECIPE_RUNNER_RS_PATH", &runner);
+        std::env::set_var("AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS", "1");
+    }
+
+    let result = execute::execute_recipe_via_rust(
+        &recipe,
+        &BTreeMap::new(),
+        false,
+        true,
+        temp.path(),
+        &[],
+        None,
+    );
+
+    match prev_runner {
+        Some(value) => unsafe { std::env::set_var("RECIPE_RUNNER_RS_PATH", value) },
+        None => unsafe { std::env::remove_var("RECIPE_RUNNER_RS_PATH") },
+    }
+    match prev_timeout {
+        Some(value) => unsafe { std::env::set_var("AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS", value) },
+        None => unsafe { std::env::remove_var("AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS") },
+    }
+
+    result.expect_err("hung recipe-runner must time out");
+    std::thread::sleep(std::time::Duration::from_millis(2_300));
+    assert!(
+        !marker.exists(),
+        "timeout cleanup must terminate recipe-runner descendants"
+    );
+}
+
 // -------------------------------------------------------------------------
 // Issue #494 — sub-recipe discovery: pass -R search dirs to recipe-runner-rs
 // -------------------------------------------------------------------------

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_format.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_format.rs
@@ -246,12 +246,17 @@ fn test_format_recipe_run_result_yaml_preserves_run_id_and_log_pointer_fields() 
 /// error message directing the user to install the binary.
 #[test]
 fn test_find_recipe_runner_binary_error_message_is_actionable() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     if which_recipe_runner_available() {
         return;
     }
+    let previous_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
     unsafe { std::env::remove_var("RECIPE_RUNNER_RS_PATH") };
 
     let result = binary::find_recipe_runner_binary();
+    restore_recipe_runner_path(previous_runner);
     assert!(
         result.is_err(),
         "find_recipe_runner_binary must fail when binary is not installed. Got: {:?}",
@@ -272,6 +277,10 @@ fn test_find_recipe_runner_binary_error_message_is_actionable() {
 /// must be ignored and discovery falls through to the standard locations.
 #[test]
 fn test_find_recipe_runner_binary_ignores_nonexistent_env_path() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let previous_runner = std::env::var_os("RECIPE_RUNNER_RS_PATH");
     unsafe {
         std::env::set_var(
             "RECIPE_RUNNER_RS_PATH",
@@ -281,7 +290,7 @@ fn test_find_recipe_runner_binary_ignores_nonexistent_env_path() {
 
     let result = binary::find_recipe_runner_binary();
 
-    unsafe { std::env::remove_var("RECIPE_RUNNER_RS_PATH") };
+    restore_recipe_runner_path(previous_runner);
 
     match result {
         Ok(path) => {
@@ -301,6 +310,13 @@ fn test_find_recipe_runner_binary_ignores_nonexistent_env_path() {
                 "Error must mention the binary name. Got: {e}"
             );
         }
+    }
+}
+
+fn restore_recipe_runner_path(previous_runner: Option<std::ffi::OsString>) {
+    match previous_runner {
+        Some(value) => unsafe { std::env::set_var("RECIPE_RUNNER_RS_PATH", value) },
+        None => unsafe { std::env::remove_var("RECIPE_RUNNER_RS_PATH") },
     }
 }
 

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_format.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_format.rs
@@ -329,6 +329,35 @@ fn test_meaningful_stderr_tail_skips_progress_noise() {
     assert_eq!(tail, "real error one\nreal error two");
 }
 
+#[test]
+fn test_meaningful_stderr_tail_reports_discarded_lines() {
+    let tail = execute::meaningful_stderr_tail(
+        "error one\nerror two\nerror three\nerror four\nerror five\nerror six\n",
+    );
+
+    assert!(
+        tail.contains("error two"),
+        "tail should retain recent lines: {tail}"
+    );
+    assert!(
+        tail.contains("[truncated: discarded 1 stderr lines]"),
+        "tail should report omitted diagnostics: {tail}"
+    );
+}
+
+#[test]
+fn test_meaningful_stderr_tail_includes_prior_buffer_drops() {
+    let tail = execute::meaningful_stderr_tail_with_prior_drops(
+        "error one\nerror two\nerror three\nerror four\nerror five\nerror six\n",
+        300,
+    );
+
+    assert!(
+        tail.contains("[truncated: discarded 301 stderr lines]"),
+        "tail should include lines discarded before bounded tail capture: {tail}"
+    );
+}
+
 /// Returns true if recipe-runner-rs appears to be available on this system.
 fn which_recipe_runner_available() -> bool {
     if let Ok(p) = std::env::var("RECIPE_RUNNER_RS_PATH")

--- a/crates/amplihack-cli/src/commands/workflow.rs
+++ b/crates/amplihack-cli/src/commands/workflow.rs
@@ -1,3 +1,4 @@
+use crate::util::{format_output_diagnostics, run_output_with_timeout, truncate_chars_with_notice};
 use amplihack_workflows::simulation::{RecipeSimulation, RecipeSimulationScenario};
 use amplihack_workflows::stale_cleanup::{
     CleanupAction, CleanupMode, CleanupPlan, CleanupPolicy, StaleChangeRequest,
@@ -11,12 +12,17 @@ use amplihack_workflows::workflow_contract::{
 use anyhow::{Context, Result};
 use clap::{ArgGroup, Args, Subcommand, ValueEnum};
 use serde_json::json;
+use std::io;
 use std::path::PathBuf;
 use std::process::{Command, Output};
+use std::time::Duration;
 
 mod provider_detection;
 
 use provider_detection::detect_provider_from_repo;
+
+const PROVIDER_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
+const PROVIDER_DIAGNOSTIC_CHARS: usize = 600;
 
 #[derive(Subcommand, Debug)]
 pub enum WorkflowCommands {
@@ -380,14 +386,24 @@ fn publish_github_change_request(
         ],
     ) {
         Ok(output) if output.status.success() => output,
-        Ok(_) => {
-            return provider_command_failed(provider, capabilities, "GitHub PR lookup failed.");
+        Ok(output) => {
+            return provider_command_failed_with_output(
+                provider,
+                capabilities,
+                "GitHub PR lookup failed.",
+                &output,
+            );
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return provider_cli_missing(provider, capabilities, "gh");
         }
-        Err(_) => {
-            return provider_command_failed(provider, capabilities, "GitHub PR lookup failed.");
+        Err(error) => {
+            return provider_command_failed_with_error(
+                provider,
+                capabilities,
+                "GitHub PR lookup failed.",
+                &error,
+            );
         }
     };
 
@@ -421,14 +437,24 @@ fn publish_github_change_request(
         ],
     ) {
         Ok(output) if output.status.success() => output,
-        Ok(_) => {
-            return provider_command_failed(provider, capabilities, "GitHub PR creation failed.");
+        Ok(output) => {
+            return provider_command_failed_with_output(
+                provider,
+                capabilities,
+                "GitHub PR creation failed.",
+                &output,
+            );
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return provider_cli_missing(provider, capabilities, "gh");
         }
-        Err(_) => {
-            return provider_command_failed(provider, capabilities, "GitHub PR creation failed.");
+        Err(error) => {
+            return provider_command_failed_with_error(
+                provider,
+                capabilities,
+                "GitHub PR creation failed.",
+                &error,
+            );
         }
     };
     let url = String::from_utf8_lossy(&create.stdout).trim().to_string();
@@ -451,21 +477,26 @@ fn publish_github_change_request(
         ],
     ) {
         Ok(output) if output.status.success() => output,
-        Ok(_) => {
-            return provider_command_failed(
+        Ok(output) => {
+            return provider_command_failed_with_detail(
                 provider,
                 capabilities,
                 "GitHub PR verification failed.",
+                Some(format_output_diagnostics(
+                    &output,
+                    PROVIDER_DIAGNOSTIC_CHARS,
+                )),
             );
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return provider_cli_missing(provider, capabilities, "gh");
         }
-        Err(_) => {
-            return provider_command_failed(
+        Err(error) => {
+            return provider_command_failed_with_detail(
                 provider,
                 capabilities,
                 "GitHub PR verification failed.",
+                Some(provider_error_diagnostic(&error)),
             );
         }
     };
@@ -513,21 +544,26 @@ fn publish_azdo_change_request(
         ],
     ) {
         Ok(output) if output.status.success() => output,
-        Ok(_) => {
-            return provider_command_failed(
+        Ok(output) => {
+            return provider_command_failed_with_detail(
                 provider,
                 capabilities,
                 "Azure Repos PR lookup failed.",
+                Some(format_output_diagnostics(
+                    &output,
+                    PROVIDER_DIAGNOSTIC_CHARS,
+                )),
             );
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return provider_cli_missing(provider, capabilities, "az");
         }
-        Err(_) => {
-            return provider_command_failed(
+        Err(error) => {
+            return provider_command_failed_with_detail(
                 provider,
                 capabilities,
                 "Azure Repos PR lookup failed.",
+                Some(provider_error_diagnostic(&error)),
             );
         }
     };
@@ -567,21 +603,26 @@ fn publish_azdo_change_request(
         ],
     ) {
         Ok(output) if output.status.success() => output,
-        Ok(_) => {
-            return provider_command_failed(
+        Ok(output) => {
+            return provider_command_failed_with_detail(
                 provider,
                 capabilities,
                 "Azure Repos PR creation failed.",
+                Some(format_output_diagnostics(
+                    &output,
+                    PROVIDER_DIAGNOSTIC_CHARS,
+                )),
             );
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return provider_cli_missing(provider, capabilities, "az");
         }
-        Err(_) => {
-            return provider_command_failed(
+        Err(error) => {
+            return provider_command_failed_with_detail(
                 provider,
                 capabilities,
                 "Azure Repos PR creation failed.",
+                Some(provider_error_diagnostic(&error)),
             );
         }
     };
@@ -606,7 +647,31 @@ fn publish_azdo_change_request(
 }
 
 fn run_provider_command(binary: &str, args: &[&str]) -> std::io::Result<Output> {
-    Command::new(binary).args(args).output()
+    let mut cmd = Command::new(binary);
+    cmd.args(args);
+    run_output_with_timeout(cmd, provider_command_timeout()).map_err(|err| {
+        let kind = err
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<io::Error>().map(io::Error::kind))
+            .unwrap_or_else(|| {
+                if err.to_string().contains("timed out") {
+                    io::ErrorKind::TimedOut
+                } else {
+                    io::ErrorKind::Other
+                }
+            });
+        io::Error::new(kind, err.to_string())
+    })
+}
+
+fn provider_command_timeout() -> Duration {
+    #[cfg(test)]
+    if let Ok(ms) = std::env::var("AMPLIHACK_TEST_PROVIDER_TIMEOUT_MS")
+        && let Ok(ms) = ms.parse::<u64>()
+    {
+        return Duration::from_millis(ms);
+    }
+    PROVIDER_COMMAND_TIMEOUT
 }
 
 fn provider_cli_missing(
@@ -632,17 +697,69 @@ fn provider_command_failed(
     capabilities: ProviderCapabilities,
     message: &str,
 ) -> HelperEnvelope {
+    provider_command_failed_with_detail(provider, capabilities, message, None)
+}
+
+fn provider_command_failed_with_output(
+    provider: RepositoryProvider,
+    capabilities: ProviderCapabilities,
+    message: &str,
+    output: &Output,
+) -> HelperEnvelope {
+    provider_command_failed_with_detail(
+        provider,
+        capabilities,
+        message,
+        Some(format_output_diagnostics(output, PROVIDER_DIAGNOSTIC_CHARS)),
+    )
+}
+
+fn provider_command_failed_with_error(
+    provider: RepositoryProvider,
+    capabilities: ProviderCapabilities,
+    message: &str,
+    error: &io::Error,
+) -> HelperEnvelope {
+    provider_command_failed_with_detail(
+        provider,
+        capabilities,
+        message,
+        Some(provider_error_diagnostic(error)),
+    )
+}
+
+fn provider_command_failed_with_detail(
+    provider: RepositoryProvider,
+    capabilities: ProviderCapabilities,
+    message: &str,
+    diagnostic: Option<String>,
+) -> HelperEnvelope {
+    let diagnostic = diagnostic
+        .filter(|detail| !detail.trim().is_empty())
+        .map(|detail| {
+            format!(
+                " Bounded stdout/stderr diagnostic: {}",
+                truncate_chars_with_notice(&detail, PROVIDER_DIAGNOSTIC_CHARS)
+            )
+        })
+        .unwrap_or_else(|| " Bounded stdout/stderr diagnostic unavailable.".to_string());
     helper_envelope(
         provider,
         HelperOperation::PublishChangeRequest,
         ProviderOperationStatus::Failed,
-        format!("{message} Inspect provider CLI authentication/output and rerun publication."),
+        format!(
+            "{message}{diagnostic} Inspect provider CLI authentication/output and rerun publication."
+        ),
         json!({
             "change_request": null,
             "manual_action": null,
             "capabilities": capabilities
         }),
     )
+}
+
+fn provider_error_diagnostic(error: &io::Error) -> String {
+    format!("provider command error ({}): {error}", error.kind())
 }
 
 fn parse_github_pr_list(stdout: &[u8]) -> Option<ChangeRequest> {
@@ -859,6 +976,63 @@ mod tests {
         assert_eq!(
             provider_status(RepositoryProvider::AzureDevOps),
             ProviderOperationStatus::Succeeded
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn provider_command_execution_is_bounded() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        let fake_provider = temp.path().join("fake-gh");
+        std::fs::write(
+            &fake_provider,
+            "#!/bin/sh\n/bin/sleep 2\nprintf 'done\\n'\n",
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&fake_provider).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&fake_provider, perms).unwrap();
+
+        let previous_timeout = std::env::var_os("AMPLIHACK_TEST_PROVIDER_TIMEOUT_MS");
+        unsafe {
+            std::env::set_var("AMPLIHACK_TEST_PROVIDER_TIMEOUT_MS", "50");
+        }
+        let started = std::time::Instant::now();
+        let result = run_provider_command(fake_provider.to_str().unwrap(), &[]);
+        match previous_timeout {
+            Some(value) => unsafe {
+                std::env::set_var("AMPLIHACK_TEST_PROVIDER_TIMEOUT_MS", value)
+            },
+            None => unsafe { std::env::remove_var("AMPLIHACK_TEST_PROVIDER_TIMEOUT_MS") },
+        }
+
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "provider command helper must enforce an explicit timeout"
+        );
+        assert!(
+            result.is_err(),
+            "timed-out provider command should return an error with timeout context"
+        );
+    }
+
+    #[test]
+    fn provider_failure_guidance_mentions_bounded_stdout_stderr_diagnostics() {
+        let envelope = provider_command_failed(
+            RepositoryProvider::GitHub,
+            provider_capabilities(RepositoryProvider::GitHub),
+            "GitHub PR lookup failed.",
+        );
+
+        assert!(
+            envelope.next_action.contains("stderr")
+                || envelope.next_action.contains("stdout")
+                || envelope.next_action.contains("diagnostic"),
+            "provider failures must surface bounded stdout/stderr diagnostics; got {}",
+            envelope.next_action
         );
     }
 }

--- a/crates/amplihack-cli/src/copilot_setup/hooks.rs
+++ b/crates/amplihack-cli/src/copilot_setup/hooks.rs
@@ -331,7 +331,9 @@ pub(super) fn set_executable(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::run_output_with_timeout;
     use std::process::Command;
+    use std::time::Duration;
 
     #[test]
     fn wrapper_script_generation_uses_lf_only_line_endings() {
@@ -427,10 +429,9 @@ mod tests {
     }
 
     fn assert_bash_accepts_script(script: &Path) {
-        let output = Command::new("bash")
-            .arg("-n")
-            .arg(script)
-            .output()
+        let mut command = Command::new("bash");
+        command.arg("-n").arg(script);
+        let output = run_output_with_timeout(command, Duration::from_secs(2))
             .unwrap_or_else(|err| panic!("failed to run bash -n for {}: {err}", script.display()));
 
         assert!(

--- a/crates/amplihack-cli/src/docker/manager.rs
+++ b/crates/amplihack-cli/src/docker/manager.rs
@@ -5,8 +5,13 @@ use std::env;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use super::{DEFAULT_IMAGE_NAME, DockerDetector, helpers::forwarded_env_vars};
+use crate::util::run_with_timeout;
+
+const DOCKER_BUILD_TIMEOUT: Duration = Duration::from_secs(600);
+const DOCKER_RUN_TIMEOUT: Duration = Duration::from_secs(3600);
 
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -67,9 +72,9 @@ impl DockerManager {
         }
 
         let run_args = self.build_run_args(cwd, amplihack_args, env::vars_os());
-        let status = Command::new("docker")
-            .args(&run_args)
-            .status()
+        let mut command = Command::new("docker");
+        command.args(&run_args);
+        let status = run_with_timeout(command, DOCKER_RUN_TIMEOUT)
             .context("failed to execute docker run")?;
         Ok(status.code().unwrap_or(1))
     }
@@ -86,9 +91,9 @@ impl DockerManager {
         }
 
         println!("Building Docker image: {}", self.image_name);
-        let status = Command::new("docker")
-            .args(self.build_image_args(&dockerfile))
-            .status()
+        let mut command = Command::new("docker");
+        command.args(self.build_image_args(&dockerfile));
+        let status = run_with_timeout(command, DOCKER_BUILD_TIMEOUT)
             .context("failed to execute docker build")?;
         if !status.success() {
             eprintln!("Docker build failed.");

--- a/crates/amplihack-cli/src/docker/mod.rs
+++ b/crates/amplihack-cli/src/docker/mod.rs
@@ -7,8 +7,12 @@ pub(crate) use manager::DockerManager;
 
 use std::env;
 use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use crate::util::{run_output_with_timeout, run_with_timeout};
 
 pub(crate) const DEFAULT_IMAGE_NAME: &str = "amplihack:latest";
+const DOCKER_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DockerActivation {
@@ -51,12 +55,13 @@ impl DockerDetector {
             return false;
         }
 
-        Command::new("docker")
+        let mut command = Command::new("docker");
+        command
             .arg("info")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
+            .stderr(Stdio::null());
+        run_with_timeout(command, DOCKER_PROBE_TIMEOUT)
             .map(|status| status.success())
             .unwrap_or(false)
     }
@@ -83,10 +88,11 @@ impl DockerDetector {
             return false;
         }
 
-        Command::new("docker")
+        let mut command = Command::new("docker");
+        command
             .args(["images", "-q", image_name])
-            .stdin(Stdio::null())
-            .output()
+            .stdin(Stdio::null());
+        run_output_with_timeout(command, DOCKER_PROBE_TIMEOUT)
             .map(|output| !String::from_utf8_lossy(&output.stdout).trim().is_empty())
             .unwrap_or(false)
     }

--- a/crates/amplihack-cli/src/fleet_local/cache.rs
+++ b/crates/amplihack-cli/src/fleet_local/cache.rs
@@ -2,7 +2,9 @@
 
 use std::collections::VecDeque;
 
-use super::{CAPTURE_CACHE_CAPACITY, CAPTURE_CACHE_ENTRY_MAX_BYTES};
+#[cfg(test)]
+use super::CAPTURE_CACHE_ENTRY_MAX_BYTES;
+use super::{CAPTURE_CACHE_CAPACITY, truncate_to_capture_cache_limit};
 
 // ── FleetCaptureCache ─────────────────────────────────────────────────────────
 
@@ -49,16 +51,7 @@ impl FleetCaptureCache {
     /// - Evicts the **oldest** entry when capacity is reached.
     pub fn insert(&mut self, session_id: String, output: String) {
         // SEC-10: cap at 64 KiB, truncating at a UTF-8 boundary.
-        let output = if output.len() > CAPTURE_CACHE_ENTRY_MAX_BYTES {
-            // Find the last valid UTF-8 boundary at or before the limit.
-            let mut boundary = CAPTURE_CACHE_ENTRY_MAX_BYTES;
-            while !output.is_char_boundary(boundary) {
-                boundary -= 1;
-            }
-            output[..boundary].to_string()
-        } else {
-            output
-        };
+        let output = truncate_to_capture_cache_limit(output);
 
         // Remove any existing entry for this session.
         self.inner.retain(|(k, _)| k != &session_id);
@@ -155,6 +148,17 @@ mod tests {
             "stored entry ({} bytes) must not exceed 64 KiB cap",
             stored.len()
         );
+    }
+
+    #[test]
+    fn fleet_capture_cache_caps_entry_at_utf8_boundary() {
+        let mut cache = FleetCaptureCache::new();
+        let oversized = format!("{}é", "x".repeat(CAPTURE_CACHE_ENTRY_MAX_BYTES - 1));
+        cache.insert("utf8-session".to_string(), oversized);
+
+        let stored = cache.get("utf8-session").expect("entry must be stored");
+        assert_eq!(stored.len(), CAPTURE_CACHE_ENTRY_MAX_BYTES - 1);
+        assert!(stored.ends_with('x'));
     }
 
     #[test]

--- a/crates/amplihack-cli/src/fleet_local/dashboard.rs
+++ b/crates/amplihack-cli/src/fleet_local/dashboard.rs
@@ -6,10 +6,7 @@ use super::tmux::{
     capture_local_tmux_pane, is_tmux_available, list_local_tmux_sessions,
     sanitize_tmux_session_name,
 };
-use super::{
-    CAPTURE_CACHE_ENTRY_MAX_BYTES, FleetLocalError, RefreshMsg, collect_observed_fleet_state,
-    strip_osc_sequences,
-};
+use super::{FleetLocalError, RefreshMsg, collect_observed_fleet_state, strip_osc_sequences};
 
 // ── run_fleet_dashboard ───────────────────────────────────────────────────────
 
@@ -96,21 +93,9 @@ pub fn run_fleet_dashboard(bg_tx: Option<Sender<RefreshMsg>>) -> Result<(), Flee
                         // Capture pane output for this session.
                         let raw_output = capture_local_tmux_pane(&session_id);
 
-                        // Strip OSC escape sequences (SEC-06).
-                        let clean = strip_osc_sequences(&raw_output);
-
-                        // Cap at 64 KiB before sending over the channel (SEC-10).
-                        // Truncate at a valid UTF-8 boundary — a naive byte-index
-                        // slice would panic on multi-byte characters (e.g. emoji).
-                        let output = if clean.len() > CAPTURE_CACHE_ENTRY_MAX_BYTES {
-                            let mut boundary = CAPTURE_CACHE_ENTRY_MAX_BYTES;
-                            while !clean.is_char_boundary(boundary) {
-                                boundary -= 1;
-                            }
-                            clean[..boundary].to_string()
-                        } else {
-                            clean
-                        };
+                        // Strip OSC escape sequences (SEC-06). Capture is already
+                        // bounded before allocation grows in the tmux helper.
+                        let output = strip_osc_sequences(&raw_output);
 
                         let msg = RefreshMsg::CaptureUpdate { session_id, output };
                         if tx_slow.send(msg).is_err() {

--- a/crates/amplihack-cli/src/fleet_local/mod.rs
+++ b/crates/amplihack-cli/src/fleet_local/mod.rs
@@ -49,6 +49,19 @@ pub const CAPTURE_CACHE_CAPACITY: usize = 64;
 /// Maximum bytes stored per capture cache entry (64 KiB).
 pub const CAPTURE_CACHE_ENTRY_MAX_BYTES: usize = 64 * 1024;
 
+pub(super) fn truncate_to_capture_cache_limit(mut value: String) -> String {
+    if value.len() <= CAPTURE_CACHE_ENTRY_MAX_BYTES {
+        return value;
+    }
+
+    let mut boundary = CAPTURE_CACHE_ENTRY_MAX_BYTES;
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value.truncate(boundary);
+    value
+}
+
 /// Maximum number of lines in the multiline editor.
 pub const EDITOR_MAX_LINES: usize = 200;
 

--- a/crates/amplihack-cli/src/fleet_local/tmux.rs
+++ b/crates/amplihack-cli/src/fleet_local/tmux.rs
@@ -1,37 +1,27 @@
 //! Tmux helper functions for the slow refresh thread (T5).
 
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use super::{CAPTURE_CACHE_ENTRY_MAX_BYTES, truncate_to_capture_cache_limit};
+use crate::util::{run_output_with_timeout, run_output_with_timeout_limited, run_with_timeout};
+
+const TMUX_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+const CAPTURE_PANE_BACKSCROLL_LINES: &str = "-4096";
+
 /// Check whether a local `tmux` binary is available.
 ///
 /// Runs `tmux -V` with a 2-second timeout.  Returns `false` if the binary
 /// cannot be found or returns a non-zero exit code (RISK-07).
 pub(super) fn is_tmux_available() -> bool {
-    use std::process::{Command, Stdio};
-    use std::time::Duration;
-
-    // Use a child process with a timeout so we don't block the slow thread.
-    let mut child = match Command::new("tmux")
+    let mut command = Command::new("tmux");
+    command
         .args(["-V"])
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(_) => return false, // binary not found
-    };
-
-    let deadline = std::time::Instant::now() + Duration::from_secs(2);
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return status.success(),
-            Ok(None) if std::time::Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return false;
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
-            Err(_) => return false,
-        }
-    }
+        .stderr(Stdio::null());
+    run_with_timeout(command, TMUX_COMMAND_TIMEOUT)
+        .map(|status| status.success())
+        .unwrap_or(false)
 }
 
 /// List active local tmux session names via `tmux list-sessions -F "#{session_name}"`.
@@ -39,14 +29,12 @@ pub(super) fn is_tmux_available() -> bool {
 /// Returns an empty `Vec` if tmux is absent, returns no sessions, or any
 /// command error occurs (RISK-07: graceful skip when tmux is unavailable).
 pub(super) fn list_local_tmux_sessions() -> Vec<String> {
-    use std::process::{Command, Stdio};
-
-    let output = match Command::new("tmux")
+    let mut command = Command::new("tmux");
+    command
         .args(["list-sessions", "-F", "#{session_name}"])
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .output()
-    {
+        .stderr(Stdio::null());
+    let output = match run_output_with_timeout(command, TMUX_COMMAND_TIMEOUT) {
         Ok(o) => o,
         Err(_) => return vec![],
     };
@@ -63,17 +51,14 @@ pub(super) fn list_local_tmux_sessions() -> Vec<String> {
         .collect()
 }
 
-/// Capture the most recent output from a local tmux pane.
+/// Capture recent output from a local tmux pane.
 ///
-/// Runs `tmux capture-pane -t {session_id} -p -S -` and returns the raw
-/// stdout.  Returns an empty string on any error (non-zero exit, binary
-/// absence, timeout, etc.).
+/// Runs `tmux capture-pane` against a bounded recent backscroll window and
+/// returns capped raw stdout.  Returns an empty string on any error (non-zero
+/// exit, binary absence, timeout, etc.).
 ///
-/// The caller is responsible for stripping OSC sequences and capping at
-/// [`CAPTURE_CACHE_ENTRY_MAX_BYTES`].
+/// The caller is responsible for stripping OSC sequences.
 pub(super) fn capture_local_tmux_pane(session_id: &str) -> String {
-    use std::process::{Command, Stdio};
-
     // SEC-01: session_id must already be sanitized before calling this.
     // We additionally reject any session_id containing shell-special characters
     // to prevent command injection.  Only [a-zA-Z0-9_.-] are allowed.
@@ -84,18 +69,29 @@ pub(super) fn capture_local_tmux_pane(session_id: &str) -> String {
         return String::new();
     }
 
-    let output = match Command::new("tmux")
-        .args(["capture-pane", "-t", session_id, "-p", "-S", "-"])
+    let mut command = Command::new("tmux");
+    command
+        .args([
+            "capture-pane",
+            "-t",
+            session_id,
+            "-p",
+            "-S",
+            CAPTURE_PANE_BACKSCROLL_LINES,
+        ])
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .output()
-    {
+        .stderr(Stdio::null());
+    let output = match run_output_with_timeout_limited(
+        command,
+        TMUX_COMMAND_TIMEOUT,
+        CAPTURE_CACHE_ENTRY_MAX_BYTES,
+    ) {
         Ok(o) => o,
         Err(_) => return String::new(),
     };
 
     if output.status.success() {
-        String::from_utf8_lossy(&output.stdout).into_owned()
+        truncate_to_capture_cache_limit(String::from_utf8_lossy(&output.stdout).into_owned())
     } else {
         String::new()
     }
@@ -117,8 +113,6 @@ pub(super) fn sanitize_tmux_session_name(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fleet_local::CAPTURE_CACHE_ENTRY_MAX_BYTES;
-
     #[test]
     fn sanitize_tmux_session_name_keeps_alphanumeric_hyphen_underscore() {
         assert_eq!(sanitize_tmux_session_name("my-session_01"), "my-session_01");
@@ -171,11 +165,7 @@ mod tests {
     #[test]
     fn capture_output_capped_at_64kib_in_slow_thread_logic() {
         let oversized = "x".repeat(CAPTURE_CACHE_ENTRY_MAX_BYTES + 512);
-        let capped = if oversized.len() > CAPTURE_CACHE_ENTRY_MAX_BYTES {
-            oversized[..CAPTURE_CACHE_ENTRY_MAX_BYTES].to_string()
-        } else {
-            oversized.clone()
-        };
+        let capped = truncate_to_capture_cache_limit(oversized);
         assert_eq!(
             capped.len(),
             CAPTURE_CACHE_ENTRY_MAX_BYTES,

--- a/crates/amplihack-cli/src/health_check.rs
+++ b/crates/amplihack-cli/src/health_check.rs
@@ -6,7 +6,13 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
 use tracing::{debug, warn};
+
+use crate::util::run_with_timeout;
+
+const DEPENDENCY_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Overall health status.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -128,12 +134,12 @@ pub fn check_health() -> HealthReport {
 
 /// Check whether a CLI dependency is available on PATH.
 fn _check_dependency(name: &str, args: &[&str]) -> CheckDetail {
-    match std::process::Command::new(name)
+    let mut command = Command::new(name);
+    command
         .args(args)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .status()
-    {
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    match run_with_timeout(command, DEPENDENCY_CHECK_TIMEOUT) {
         Ok(status) if status.success() => {
             debug!(dep = name, "Dependency available");
             CheckDetail {

--- a/crates/amplihack-cli/src/memory_config.rs
+++ b/crates/amplihack-cli/src/memory_config.rs
@@ -1,6 +1,6 @@
 //! Smart NODE_OPTIONS memory configuration for launcher startup.
 
-use crate::util::{is_noninteractive, read_user_input_with_timeout};
+use crate::util::{is_noninteractive, read_user_input_with_timeout, run_output_with_timeout};
 use anyhow::Result;
 use serde_json::{Map, Value};
 use std::env;
@@ -12,6 +12,7 @@ use std::time::Duration;
 const MIN_MEMORY_MB: u64 = 8192;
 const MAX_MEMORY_MB: u64 = 32768;
 const MEMORY_PROMPT_TIMEOUT: Duration = Duration::from_secs(30);
+const RAM_DETECTION_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryConfig {
@@ -108,10 +109,9 @@ fn detect_ram_linux() -> Option<u64> {
 }
 
 fn detect_ram_macos() -> Option<u64> {
-    let output = Command::new("sysctl")
-        .args(["-n", "hw.memsize"])
-        .output()
-        .ok()?;
+    let mut command = Command::new("sysctl");
+    command.args(["-n", "hw.memsize"]);
+    let output = run_output_with_timeout(command, RAM_DETECTION_TIMEOUT).ok()?;
     if !output.status.success() {
         return None;
     }
@@ -124,10 +124,9 @@ fn detect_ram_macos() -> Option<u64> {
 }
 
 fn detect_ram_windows() -> Option<u64> {
-    let output = Command::new("wmic")
-        .args(["ComputerSystem", "get", "TotalPhysicalMemory"])
-        .output()
-        .ok()?;
+    let mut command = Command::new("wmic");
+    command.args(["ComputerSystem", "get", "TotalPhysicalMemory"]);
+    let output = run_output_with_timeout(command, RAM_DETECTION_TIMEOUT).ok()?;
     if !output.status.success() {
         return None;
     }

--- a/crates/amplihack-cli/src/rust_trial.rs
+++ b/crates/amplihack-cli/src/rust_trial.rs
@@ -6,9 +6,15 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
+
+use crate::util::run_with_timeout;
+
+const RUST_TRIAL_TIMEOUT: Duration = Duration::from_secs(3600);
 
 /// Options for installing the Rust CLI binary.
 #[derive(Debug, Clone)]
@@ -228,10 +234,9 @@ pub fn run_rust_trial(rust_args: &[String], trial_home: &Path) -> i32 {
         "running rust trial"
     );
 
-    let status = std::process::Command::new(&binary)
-        .args(rust_args)
-        .envs(&env)
-        .status();
+    let mut command = Command::new(&binary);
+    command.args(rust_args).envs(&env);
+    let status = run_with_timeout(command, RUST_TRIAL_TIMEOUT);
 
     match status {
         Ok(s) => s.code().unwrap_or(1),

--- a/crates/amplihack-cli/src/self_heal.rs
+++ b/crates/amplihack-cli/src/self_heal.rs
@@ -31,6 +31,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use fs4::fs_std::FileExt;
 
+use crate::commands::install::bundle_compat::validate_framework_bundle_compatibility;
 use crate::commands::install::version_stamp;
 
 /// Env var that fully disables the auto-restage check.
@@ -164,14 +165,18 @@ where
     // single-line stderr diagnostic so CI logs surface the drift. Both
     // values are constant or regex-validated semver, so plain formatting
     // is safe (no control-char injection surface).
+    let installed_bundle_issue = installed_bundle_compatibility_issue()
+        .context("checking installed framework bundle compatibility")?;
+    let stamp_match = stamp.as_deref() == Some(expected);
+
     if env_bypass_set() {
-        let stamp_match = stamp.as_deref() == Some(expected);
-        if !stamp_match {
+        if !stamp_match || installed_bundle_issue.is_some() {
             let stamp_str = stamp.as_deref().unwrap_or("<missing>");
+            let bundle_status = installed_bundle_issue.as_deref().unwrap_or("compatible");
             writeln!(
                 notice,
                 "amplihack: AMPLIHACK_SKIP_AUTO_INSTALL set; skipping re-stage \
-                 (stamp={stamp_str} current={expected})"
+                 (stamp={stamp_str} current={expected}; installed_bundle={bundle_status:?})"
             )
             .context("emitting bypass diagnostic")?;
         }
@@ -179,19 +184,26 @@ where
         return Ok(());
     }
 
-    if stamp.as_deref() == Some(expected) {
+    if stamp_match && installed_bundle_issue.is_none() {
         tracing::debug!("self_heal: stamp matches binary version {expected}");
         return Ok(());
     }
 
-    match stamp.as_deref() {
-        Some(prior) => {
-            tracing::info!(
-                "self_heal: install stamp {prior} != binary {expected}; re-staging assets"
-            );
-        }
-        None => {
-            tracing::info!("self_heal: install stamp missing; staging assets for {expected}");
+    if let Some(issue) = &installed_bundle_issue {
+        tracing::info!(
+            "self_heal: installed framework bundle incompatible despite stamp={:?}; re-staging assets: {issue}",
+            stamp.as_deref()
+        );
+    } else {
+        match stamp.as_deref() {
+            Some(prior) => {
+                tracing::info!(
+                    "self_heal: install stamp {prior} != binary {expected}; re-staging assets"
+                );
+            }
+            None => {
+                tracing::info!("self_heal: install stamp missing; staging assets for {expected}");
+            }
         }
     }
 
@@ -205,9 +217,11 @@ where
         // have already brought the stamp current.
         let stamp_now = version_stamp::read_installed_version()
             .context("re-reading install stamp under lock")?;
-        if stamp_now.as_deref() == Some(expected) {
+        let installed_bundle_issue_now = installed_bundle_compatibility_issue()
+            .context("re-checking installed framework bundle compatibility under lock")?;
+        if stamp_now.as_deref() == Some(expected) && installed_bundle_issue_now.is_none() {
             tracing::debug!(
-                "self_heal: stamp brought current by concurrent installer; nothing to do"
+                "self_heal: stamp and installed bundle brought current by concurrent installer; nothing to do"
             );
             return Ok(());
         }
@@ -220,6 +234,19 @@ where
         )
         .context("emitting self-heal notice")?;
         Ok(())
+    })
+}
+
+fn installed_bundle_compatibility_issue() -> Result<Option<String>> {
+    let stamp_path = version_stamp::installed_version_path()?;
+    let install_root = stamp_path
+        .parent()
+        .context("install version stamp path has no parent directory")?;
+    let bundle = install_root.join("amplifier-bundle");
+
+    Ok(match validate_framework_bundle_compatibility(&bundle) {
+        Ok(()) => None,
+        Err(err) => Some(err.to_string()),
     })
 }
 
@@ -291,6 +318,8 @@ fn args_should_skip(args: &[OsString]) -> bool {
 mod tests {
     use super::*;
     use std::cell::Cell;
+    use std::fs;
+    use std::path::Path;
     use tempfile::TempDir;
 
     /// Save/restore guard for `HOME` and `AMPLIHACK_SKIP_AUTO_INSTALL`.
@@ -359,6 +388,78 @@ mod tests {
         }
     }
 
+    fn stale_smart_orchestrator() -> &'static str {
+        r#"name: "smart-orchestrator"
+description: "stale v1.5.1 smart task orchestrator"
+steps:
+  - id: "parse-decomposition"
+    type: "shell"
+    command: |
+      HELPER="$(amplihack resolve-bundle-asset helper-path)"
+      python3 - <<'PY'
+      import importlib
+      helper = importlib.import_module("orch_helper")
+      helper.parse_decomposition()
+      PY
+"#
+    }
+
+    fn write_stale_installed_smart_orchestrator(home: &Path) {
+        let recipes = home.join(".amplihack/amplifier-bundle/recipes");
+        fs::create_dir_all(&recipes).unwrap();
+        fs::write(
+            recipes.join("smart-orchestrator.yaml"),
+            stale_smart_orchestrator(),
+        )
+        .unwrap();
+    }
+
+    fn write_compatible_installed_bundle(home: &Path) {
+        let recipes = home.join(".amplihack/amplifier-bundle/recipes");
+        fs::create_dir_all(&recipes).unwrap();
+        fs::write(
+            recipes.join("smart-orchestrator.yaml"),
+            r#"name: "smart-orchestrator"
+description: "Composable smart task orchestrator"
+steps:
+  - id: "smart-classify-route"
+    type: "recipe"
+    recipe: "smart-classify-route"
+  - id: "smart-execute-routing"
+    type: "recipe"
+    recipe: "smart-execute-routing"
+  - id: "smart-reflect-loop"
+    type: "recipe"
+    recipe: "smart-reflect-loop"
+  - id: "smart-validate-summarize"
+    type: "recipe"
+    recipe: "smart-validate-summarize"
+"#,
+        )
+        .unwrap();
+        for recipe in crate::commands::install::bundle_compat::REQUIRED_SMART_RECIPES {
+            fs::write(
+                recipes.join(format!("{recipe}.yaml")),
+                format!(
+                    "name: \"{recipe}\"\nsteps:\n  - id: smoke\n    type: bash\n    command: 'true'\n"
+                ),
+            )
+            .unwrap();
+        }
+        fs::write(
+            recipes.join("_recipe_manifest.json"),
+            r#"{
+  "smart-classify-route": "250c8da0ee348745",
+  "smart-execute-routing": "11612506ae846a47",
+  "smart-orchestrator": "8d55ee4817dbc815",
+  "smart-reflect-loop": "7b8101dfce096480",
+  "smart-validate-summarize": "007548c49e9654fb"
+}
+"#,
+        )
+        .unwrap();
+    }
+
     #[test]
     fn stamp_mismatch_triggers_install() {
         let tmp = TempDir::new().unwrap();
@@ -395,6 +496,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let _g = EnvGuard::new(tmp.path(), None);
         version_stamp::write_installed_version(crate::VERSION).unwrap();
+        write_compatible_installed_bundle(tmp.path());
 
         let calls = Cell::new(0u32);
         let mut buf = Vec::new();
@@ -407,6 +509,34 @@ mod tests {
 
         assert_eq!(calls.get(), 0, "installer must not run when stamp matches");
         assert!(buf.is_empty(), "no notice when stamp matches");
+    }
+
+    #[test]
+    fn stamp_match_with_stale_installed_smart_orchestrator_triggers_repair() {
+        let tmp = TempDir::new().unwrap();
+        let _g = EnvGuard::new(tmp.path(), None);
+        version_stamp::write_installed_version(crate::VERSION).unwrap();
+        write_stale_installed_smart_orchestrator(tmp.path());
+
+        let calls = Cell::new(0u32);
+        let mut buf = Vec::new();
+        ensure_assets_match_binary_version_with(
+            &args(&["amplihack", "launch"]),
+            &mut buf,
+            counting_installer(&calls, crate::VERSION),
+        )
+        .expect("stale installed smart-orchestrator should be repairable");
+
+        assert_eq!(
+            calls.get(),
+            1,
+            "matching .installed-version is not sufficient: stale installed smart-orchestrator assets must trigger install repair"
+        );
+        let notice = String::from_utf8(buf).unwrap();
+        assert!(
+            notice.contains("re-staged"),
+            "repair must emit the normal self-heal notice; got: {notice}"
+        );
     }
 
     #[test]
@@ -681,6 +811,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let _g = EnvGuard::new(tmp.path(), Some("1"));
         version_stamp::write_installed_version(crate::VERSION).unwrap();
+        write_compatible_installed_bundle(tmp.path());
 
         let calls = Cell::new(0u32);
         let mut buf = Vec::new();

--- a/crates/amplihack-cli/src/tool_update_check/version.rs
+++ b/crates/amplihack-cli/src/tool_update_check/version.rs
@@ -1,8 +1,7 @@
 //! Version querying, sanitization, and npm subprocess execution.
 
-use crate::util::strip_ansi;
-use std::sync::mpsc;
-use std::thread;
+use crate::util::{run_output_with_timeout, strip_ansi};
+use std::process::Command;
 use std::time::Duration;
 
 /// Subprocess timeout for each npm command.
@@ -91,9 +90,8 @@ pub fn sanitize_version(s: &str) -> String {
 
 /// Run `npm <args>` with a hard timeout, returning stdout on success.
 ///
-/// Uses a background thread + `mpsc::channel` + `recv_timeout` to enforce
-/// the timeout without requiring an async runtime.  This is a security
-/// control against a hung or malicious npm binary on PATH.
+/// Uses the shared child-killing timeout helper so a hung or malicious npm
+/// binary on PATH cannot keep running after this function returns.
 ///
 /// Returns `None` if:
 /// - `npm` is not found on PATH
@@ -101,26 +99,63 @@ pub fn sanitize_version(s: &str) -> String {
 /// - The process exits with a non-zero status
 /// - stdout is not valid UTF-8
 pub fn run_npm_with_timeout(args: &[&str], timeout: Duration) -> Option<String> {
-    // Convert to owned Strings so the thread can take ownership.
-    let args_owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let mut cmd = Command::new("npm");
+    cmd.args(args);
+    let output = run_output_with_timeout(cmd, timeout).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
 
-    let (tx, rx) = mpsc::channel::<Option<String>>();
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    thread::spawn(move || {
-        let result = std::process::Command::new("npm")
-            .args(&args_owned)
-            .output()
-            .ok()
-            .and_then(|out| {
-                if out.status.success() {
-                    String::from_utf8(out.stdout).ok()
-                } else {
-                    None
-                }
-            });
-        // Ignore send errors — receiver may have timed out.
-        let _ = tx.send(result);
-    });
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn run_npm_with_timeout_terminates_child_after_timeout() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        let sentinel = temp.path().join("npm-still-ran");
+        let fake_npm = temp.path().join("npm");
+        std::fs::write(
+            &fake_npm,
+            "#!/bin/sh\n\
+             /bin/sleep 0.2\n\
+             printf 'late' > \"$AMPLIHACK_NPM_SENTINEL\"\n\
+             printf '1.2.3\\n'\n",
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&fake_npm).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&fake_npm, perms).unwrap();
 
-    rx.recv_timeout(timeout).ok().flatten()
+        let previous_path = std::env::var_os("PATH");
+        let previous_sentinel = std::env::var_os("AMPLIHACK_NPM_SENTINEL");
+        unsafe {
+            std::env::set_var("PATH", temp.path());
+            std::env::set_var("AMPLIHACK_NPM_SENTINEL", &sentinel);
+        }
+
+        let result = run_npm_with_timeout(&["--version"], Duration::from_millis(10));
+        std::thread::sleep(Duration::from_millis(350));
+
+        match previous_path {
+            Some(value) => unsafe { std::env::set_var("PATH", value) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+        match previous_sentinel {
+            Some(value) => unsafe { std::env::set_var("AMPLIHACK_NPM_SENTINEL", value) },
+            None => unsafe { std::env::remove_var("AMPLIHACK_NPM_SENTINEL") },
+        }
+
+        assert!(result.is_none(), "timeout should return no npm output");
+        assert!(
+            !sentinel.exists(),
+            "timed-out npm subprocess must be terminated, not left running in a background thread"
+        );
+    }
 }

--- a/crates/amplihack-cli/src/update/check.rs
+++ b/crates/amplihack-cli/src/update/check.rs
@@ -12,6 +12,7 @@ pub enum StartupUpdateOutcome {
 }
 
 const STARTUP_UPDATE_PROMPT_TIMEOUT_SECS: u64 = 5;
+const POST_UPDATE_INSTALL_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// The literal skip-line emitted to stderr when the version-check prompt is
 /// suppressed by a subprocess-safe signal (env, argv flag, or non-TTY stdin).
@@ -101,13 +102,14 @@ pub fn run_update(skip_install: bool) -> Result<()> {
     // execute the OLD binary's compiled-in code. Instead we spawn the NEW
     // binary as a subprocess so the freshly-installed code runs.
     super::post_install::run_post_update_install(skip_install, || {
-        let mut cmd = build_install_command(&installed_exe);
-        let status = cmd.status().with_context(|| {
-            format!(
-                "failed to spawn post-update install subprocess {}",
-                installed_exe.display()
-            )
-        })?;
+        let cmd = build_install_command(&installed_exe);
+        let status =
+            crate::util::run_with_timeout(cmd, POST_UPDATE_INSTALL_TIMEOUT).with_context(|| {
+                format!(
+                    "failed to spawn post-update install subprocess {}",
+                    installed_exe.display()
+                )
+            })?;
         if !status.success() {
             bail!(
                 "post-update install subprocess {} exited with {status}",

--- a/crates/amplihack-cli/src/util.rs
+++ b/crates/amplihack-cli/src/util.rs
@@ -113,6 +113,7 @@ const SUBPROCESS_SPAWN_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 /// On timeout, terminates the child through the process handle, waits for
 /// cleanup to finish, and returns an error. Returns the `ExitStatus` on success.
 pub fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExitStatus> {
+    let command_context = format!("{cmd:?}");
     let mut child = spawn_subprocess(&mut cmd).context("failed to spawn subprocess")?;
     let pid = child.id();
 
@@ -124,14 +125,16 @@ pub fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExitStatu
 
     terminate_timed_out_child(&mut child)?;
     bail!(
-        "subprocess timed out after {} seconds (pid {})",
-        timeout.as_secs(),
+        "subprocess `{}` timed out after {:?} (pid {})",
+        command_context,
+        timeout,
         pid
     )
 }
 
 /// Run a pre-built `Command` with stdout/stderr capture and a hard timeout.
 pub fn run_output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Output> {
+    let command_context = format!("{cmd:?}");
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
     let mut child = spawn_subprocess(&mut cmd).context("failed to spawn subprocess")?;
@@ -163,9 +166,43 @@ pub fn run_output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Ou
     // Do not join pipe readers after timeout: descendants may keep inherited
     // pipe fds open, and this helper must preserve a hard wall-clock timeout.
     bail!(
-        "subprocess timed out after {} seconds (pid {})",
-        timeout.as_secs(),
+        "subprocess `{}` timed out after {:?} (pid {})",
+        command_context,
+        timeout,
         pid
+    )
+}
+
+/// Truncate UTF-8 text on character boundaries and report discarded characters.
+pub fn truncate_chars_with_notice(value: &str, max_chars: usize) -> String {
+    let total_chars = value.chars().count();
+    if total_chars <= max_chars {
+        return value.to_string();
+    }
+
+    let prefix: String = value.chars().take(max_chars).collect();
+    let discarded = total_chars.saturating_sub(max_chars);
+    format!("{prefix}\n[truncated: discarded {discarded} chars]")
+}
+
+/// Decode bytes lossily, truncate on UTF-8 character boundaries, and report loss.
+pub fn render_diagnostic_bytes(bytes: &[u8], max_chars: usize) -> String {
+    if bytes.is_empty() {
+        return "<empty>".to_string();
+    }
+    truncate_chars_with_notice(&String::from_utf8_lossy(bytes), max_chars)
+}
+
+/// Render bounded stdout/stderr details for a completed subprocess.
+pub fn format_output_diagnostics(output: &Output, max_chars: usize) -> String {
+    format!(
+        "exit={}; stdout={}; stderr={}",
+        output
+            .status
+            .code()
+            .map_or_else(|| "signal".to_string(), |code| code.to_string()),
+        render_diagnostic_bytes(&output.stdout, max_chars),
+        render_diagnostic_bytes(&output.stderr, max_chars)
     )
 }
 
@@ -433,6 +470,26 @@ mod tests {
         assert!(
             exited,
             "timed-out subprocess must be terminated even when PATH cannot resolve kill"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn run_output_with_timeout_reports_command_and_precise_timeout_context() {
+        let mut cmd = std::process::Command::new("/bin/sh");
+        cmd.args(["-c", "sleep 5"]);
+
+        let error = run_output_with_timeout(cmd, Duration::from_millis(50))
+            .expect_err("sleeping subprocess should time out");
+        let rendered = error.to_string();
+
+        assert!(
+            rendered.contains("/bin/sh") || rendered.contains("sleep"),
+            "timeout error must include command context; got {rendered:#}"
+        );
+        assert!(
+            rendered.contains("50ms") || rendered.contains("0.05"),
+            "timeout error must report the configured timeout precisely; got {rendered:#}"
         );
     }
 

--- a/crates/amplihack-cli/src/util.rs
+++ b/crates/amplihack-cli/src/util.rs
@@ -113,7 +113,6 @@ const SUBPROCESS_SPAWN_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 /// On timeout, terminates the child through the process handle, waits for
 /// cleanup to finish, and returns an error. Returns the `ExitStatus` on success.
 pub fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExitStatus> {
-    let command_context = format!("{cmd:?}");
     let mut child = spawn_subprocess(&mut cmd).context("failed to spawn subprocess")?;
     let pid = child.id();
 
@@ -124,6 +123,7 @@ pub fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExitStatu
     }
 
     terminate_timed_out_child(&mut child)?;
+    let command_context = format!("{cmd:?}");
     bail!(
         "subprocess `{}` timed out after {:?} (pid {})",
         command_context,
@@ -134,10 +134,29 @@ pub fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExitStatu
 
 /// Run a pre-built `Command` with stdout/stderr capture and a hard timeout.
 pub fn run_output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Output> {
-    let command_context = format!("{cmd:?}");
+    run_output_with_timeout_inner(&mut cmd, timeout, None)
+}
+
+/// Run a pre-built `Command` with stdout/stderr capture capped per stream.
+///
+/// The subprocess pipes are still fully drained so successful commands do not
+/// fail with a broken pipe once the retained bytes reach `max_bytes_per_stream`.
+pub fn run_output_with_timeout_limited(
+    mut cmd: Command,
+    timeout: Duration,
+    max_bytes_per_stream: usize,
+) -> Result<Output> {
+    run_output_with_timeout_inner(&mut cmd, timeout, Some(max_bytes_per_stream))
+}
+
+fn run_output_with_timeout_inner(
+    cmd: &mut Command,
+    timeout: Duration,
+    max_bytes_per_stream: Option<usize>,
+) -> Result<Output> {
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    let mut child = spawn_subprocess(&mut cmd).context("failed to spawn subprocess")?;
+    let mut child = spawn_subprocess(cmd).context("failed to spawn subprocess")?;
     let pid = child.id();
     let stdout = child
         .stdout
@@ -147,8 +166,8 @@ pub fn run_output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Ou
         .stderr
         .take()
         .context("failed to capture subprocess stderr")?;
-    let stdout_reader = spawn_pipe_reader(stdout);
-    let stderr_reader = spawn_pipe_reader(stderr);
+    let stdout_reader = spawn_pipe_reader(stdout, max_bytes_per_stream);
+    let stderr_reader = spawn_pipe_reader(stderr, max_bytes_per_stream);
 
     if let Some(status) =
         wait_for_child_exit(&mut child, timeout).context("failed to wait for subprocess output")?
@@ -165,6 +184,7 @@ pub fn run_output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Ou
     terminate_timed_out_child(&mut child)?;
     // Do not join pipe readers after timeout: descendants may keep inherited
     // pipe fds open, and this helper must preserve a hard wall-clock timeout.
+    let command_context = format!("{cmd:?}");
     bail!(
         "subprocess `{}` timed out after {:?} (pid {})",
         command_context,
@@ -175,13 +195,25 @@ pub fn run_output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Ou
 
 /// Truncate UTF-8 text on character boundaries and report discarded characters.
 pub fn truncate_chars_with_notice(value: &str, max_chars: usize) -> String {
-    let total_chars = value.chars().count();
+    if value.len() <= max_chars {
+        return value.to_string();
+    }
+
+    let mut total_chars = 0usize;
+    let mut end_byte = value.len();
+    for (idx, _) in value.char_indices() {
+        if total_chars == max_chars {
+            end_byte = idx;
+        }
+        total_chars += 1;
+    }
+
     if total_chars <= max_chars {
         return value.to_string();
     }
 
-    let prefix: String = value.chars().take(max_chars).collect();
-    let discarded = total_chars.saturating_sub(max_chars);
+    let prefix = &value[..end_byte];
+    let discarded = total_chars - max_chars;
     format!("{prefix}\n[truncated: discarded {discarded} chars]")
 }
 
@@ -262,13 +294,33 @@ fn terminate_timed_out_child(child: &mut Child) -> Result<()> {
     Ok(())
 }
 
-fn spawn_pipe_reader<R>(mut pipe: R) -> thread::JoinHandle<io::Result<Vec<u8>>>
+fn spawn_pipe_reader<R>(
+    mut pipe: R,
+    max_retained_bytes: Option<usize>,
+) -> thread::JoinHandle<io::Result<Vec<u8>>>
 where
     R: Read + Send + 'static,
 {
     thread::spawn(move || {
         let mut buffer = Vec::new();
-        pipe.read_to_end(&mut buffer)?;
+        match max_retained_bytes {
+            Some(max_retained_bytes) => {
+                let mut chunk = [0u8; 8192];
+                loop {
+                    let read = pipe.read(&mut chunk)?;
+                    if read == 0 {
+                        break;
+                    }
+                    let remaining = max_retained_bytes.saturating_sub(buffer.len());
+                    if remaining > 0 {
+                        buffer.extend_from_slice(&chunk[..read.min(remaining)]);
+                    }
+                }
+            }
+            None => {
+                pipe.read_to_end(&mut buffer)?;
+            }
+        }
         Ok(buffer)
     })
 }
@@ -421,6 +473,19 @@ mod tests {
         assert_eq!(strip_ansi(input), "green bold");
     }
 
+    #[test]
+    fn truncate_chars_with_notice_keeps_short_multibyte_text() {
+        assert_eq!(truncate_chars_with_notice("é", 1), "é");
+    }
+
+    #[test]
+    fn truncate_chars_with_notice_truncates_on_character_boundary() {
+        assert_eq!(
+            truncate_chars_with_notice("aébc", 2),
+            "aé\n[truncated: discarded 2 chars]"
+        );
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn run_output_with_timeout_terminates_child_without_path() {
@@ -491,6 +556,18 @@ mod tests {
             rendered.contains("50ms") || rendered.contains("0.05"),
             "timeout error must report the configured timeout precisely; got {rendered:#}"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn run_output_with_timeout_limited_caps_retained_stdout() {
+        let mut cmd = std::process::Command::new("/bin/sh");
+        cmd.args(["-c", "head -c 70000 /dev/zero"]);
+
+        let output = run_output_with_timeout_limited(cmd, Duration::from_secs(2), 1024).unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout.len(), 1024);
     }
 
     #[cfg(target_os = "linux")]

--- a/docs/bugfixes/stale-smart-orchestrator-assets.md
+++ b/docs/bugfixes/stale-smart-orchestrator-assets.md
@@ -1,0 +1,62 @@
+---
+title: Stale smart-orchestrator installed assets
+description: Root cause and durable fix for stale orch_helper.py smart-orchestrator regressions.
+last_updated: 2026-07-10
+review_schedule: as-needed
+owner: amplihack-maintainers
+doc_type: bugfix
+---
+
+# Stale smart-orchestrator installed assets
+
+## Root cause
+
+The `orch_helper.py` regression came from stale installed assets shadowing fresh
+assets. The current `amplihack-rs` source bundle is clean, but an installed
+top-level bundle can remain stale at:
+
+```text
+~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
+```
+
+The stale v1.5.1 recipe references legacy markers such as `orch_helper.py`,
+`importlib`, `parse-decomposition`, and
+`resolve-bundle-asset helper-path`. Before the fix, startup self-heal skipped
+asset refresh whenever `.installed-version` matched the binary, and recipe
+resolution could select `AMPLIHACK_HOME/amplifier-bundle/recipes` before a
+fresh compatible `.claude/recipes` fallback.
+
+## Fix
+
+Current builds centralize smart-orchestrator compatibility checks and apply
+them in three places:
+
+1. Install/update validates source and staged `amplifier-bundle` assets and
+   atomically replaces the top-level installed bundle.
+2. Startup self-heal requires both a matching `.installed-version` and a
+   compatible `~/.amplihack/amplifier-bundle`; stale installed assets trigger
+   the normal install repair path even when the stamp matches.
+3. Recipe resolution skips stale smart-orchestrator candidates when a compatible
+   fallback exists, and fails loudly with repair guidance when every candidate is
+   stale.
+
+## Validation
+
+After install or update, the resolved smart-orchestrator recipe must not contain
+any legacy marker:
+
+```sh
+AMPGREP='orch_helper\.py|importlib|parse-decomposition|resolve-bundle-asset helper-path'
+amplihack recipe show smart-orchestrator | grep -E "$AMPGREP" && exit 1 || echo "ok: no stale markers"
+```
+
+The canonical parent recipe should delegate to these companion recipes:
+
+```text
+smart-classify-route
+smart-execute-routing
+smart-reflect-loop
+smart-validate-summarize
+```
+
+See also: [Repair a stale framework bundle](../howto/repair-stale-framework-bundle.md).

--- a/docs/howto/repair-stale-framework-bundle.md
+++ b/docs/howto/repair-stale-framework-bundle.md
@@ -1,7 +1,7 @@
 ---
 title: Repair a stale framework bundle
 description: Diagnose and repair an install where the binary is current but smart-orchestrator recipes are stale.
-last_updated: 2026-06-10
+last_updated: 2026-07-10
 review_schedule: as-needed
 owner: amplihack-maintainers
 doc_type: howto
@@ -17,6 +17,23 @@ Current installs validate and repair this automatically. A successful
 `amplihack install` or post-update install replaces stale
 `smart-orchestrator.yaml` assets with the canonical composable recipe and its
 four companion recipes.
+
+## Root cause fixed in current builds
+
+The regression came from stale installed assets, not from the current
+`amplihack-rs` source bundle. The stale path was:
+
+```text
+~/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
+```
+
+Older installs could leave that top-level bundle at the old v1.5.1 monolithic
+recipe while `.installed-version` still matched the binary. Startup self-heal
+trusted the version stamp alone, and recipe resolution could prefer
+`AMPLIHACK_HOME/amplifier-bundle/recipes` before a fresh compatible fallback.
+Current builds validate the installed top-level bundle even when the version
+stamp matches, refresh incompatible assets, and refuse stale smart-orchestrator
+resolution when no compatible fallback exists.
 
 ## Symptoms
 
@@ -84,6 +101,20 @@ the source bundle, stages it, then validates the staged destination. If the
 post-update install fails, the binary update has still completed; run
 `amplihack install` manually to retry the asset repair.
 
+## Automatic startup repair
+
+Current binaries also check the installed bundle during normal startup. The
+no-op condition is now:
+
+```text
+.installed-version matches the binary AND ~/.amplihack/amplifier-bundle is compatible
+```
+
+If either side fails, self-heal re-runs the install path and emits the normal
+`framework assets re-staged` notice. Setting `AMPLIHACK_SKIP_AUTO_INSTALL`
+still skips repair, but the diagnostic includes the incompatible bundle status
+instead of silently trusting stale assets.
+
 ## Repair from a local checkout
 
 Use `--local` when you intentionally want to install from a checkout:
@@ -123,6 +154,13 @@ for recipe in smart-classify-route smart-execute-routing smart-reflect-loop smar
   test -f "$HOME/.amplihack/amplifier-bundle/recipes/${recipe}.yaml" \
     && echo "ok: ${recipe}"
 done
+```
+
+Confirm the resolved recipe contains none of the legacy markers:
+
+```sh
+AMPGREP='orch_helper\.py|importlib|parse-decomposition|resolve-bundle-asset helper-path'
+amplihack recipe show smart-orchestrator | grep -E "$AMPGREP" && exit 1 || echo "ok: no stale markers"
 ```
 
 Confirm `helper-path` still resolves to the multitask wrapper:
@@ -177,6 +215,7 @@ the installer is designed to reject.
 ## See also
 
 - [Framework bundle compatibility reference](../reference/framework-bundle-compatibility.md)
+- [Stale smart-orchestrator asset bugfix note](../bugfixes/stale-smart-orchestrator-assets.md)
 - [Install completeness verification](../reference/install-completeness.md)
 - [Post-update install re-exec](../features/update-reexec-new-binary.md)
 - [resolve-bundle-asset command reference](../reference/resolve-bundle-asset-command.md)


### PR DESCRIPTION
## Summary

Fixes stale installed `smart-orchestrator` asset shadowing so legacy helper-based recipes containing `orch_helper.py` cannot silently run from installed bundles. Also fixes the merge-blocking quality-audit findings that surfaced while making the PR merge-ready.

## Changes

- Centralized stale smart-orchestrator marker detection.
- Startup/install repair now rejects stale top-level bundle state instead of trusting only the version stamp.
- Recipe resolution skips stale smart-orchestrator candidates when compatible fallbacks exist and fails loudly when all candidates are stale.
- Absolute stale `smart-orchestrator.yaml` paths cannot bypass compatibility checks.
- Hardened audit-blocking subprocess paths and diagnostics.
- Split multitask bricks back under the 400-line structural limit.
- Avoided high-entropy checksum literals in source tests.
- Updated durable stale-bundle repair docs.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p amplihack-cli commands::recipe::recipe_tests -- --test-threads=1`
- `cargo test -p amplihack-cli commands::install -- --test-threads=1`
- `cargo test -p amplihack --test multitask_orchestrator_spec every_multitask_module_under_brick_limit -- --nocapture`
- `cargo test -p amplihack --test security_hygiene tc_sec_20_no_hardcoded_high_entropy_secrets_in_fleet_source -- --nocapture`
- `cargo test -p amplihack-cli --lib commands::multitask -- --test-threads=1`
- `cargo test -p amplihack-cli --lib node_checksum_manifest_requires_exact_archive_entry -- --test-threads=1`
- `cargo test -p amplihack-cli --lib node_archive_sha256_mismatch_fails_closed -- --test-threads=1`
- `cargo clippy -p amplihack-cli --lib -- -D warnings`
- Pre-commit hooks passed during commits; no `--no-verify` used.
- GitHub checks on head `880553e9f657020ccada31e82dc6feae2cfa1384`: Lint & Format, build, Test, Install Smoke Test, all platform builds, GitGuardian green; skipped Release/deploy are conditional.

## Review / merge readiness

- Crusty review blocker about absolute stale recipe paths fixed and re-reviewed with no remaining blocker.
- Quality-audit findings that blocked merge-readiness were addressed in follow-up hardening commits; subsequent CI is green.
- Platform: GitHub.
- PR: #888 https://github.com/rysweet/amplihack-rs/pull/888
- Source -> target: `fix/stale-smart-orchestrator-assets-tests` -> `main`
- Current head revision: `880553e9f657020ccada31e82dc6feae2cfa1384`
- QA-team evidence: Rust CLI repo; native cargo tests substituted per qa-team guidance.
- Docs: updated durable docs under `docs/bugfixes/` and `docs/howto/`.
- Checks/build validation: all required GitHub checks green.
- Metadata: title/body complete, not draft.
- Merge conflicts: CLEAN/MERGEABLE.
- Scope: focused on stale smart-orchestrator asset resolution plus merge-readiness audit hardening discovered on this PR.

No `--admin` merge. No `--no-verify`.
