### PR TITLE
fix(install): make binary self-deploy resilient to self-updated source (#885)

### DIFF
--- a/crates/amplihack-blarify/src/tools/grep.rs
+++ b/crates/amplihack-blarify/src/tools/grep.rs
@@ -89,7 +89,7 @@ pub fn grep_code(db_manager: &dyn DbManager, input: &GrepCodeInput) -> Result<se
     let regex_pattern = if input.case_sensitive {
         Regex::new(&input.pattern)?
     } else {
-        Regex::new(&format!("(?i){}", &input.pattern))?
+        Regex::new(&format!("(?i){}", input.pattern))?
     };
 
     let file_regex = input

--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -3,7 +3,7 @@
 use super::paths::{find_binary, home_dir, is_executable};
 use anyhow::{Context, Result, bail};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Resolve the amplihack-hooks binary through a 5-step chain.
 ///
@@ -111,40 +111,21 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
 
     let mut deployed = vec![hooks_dst.clone()];
 
-    // Also copy self (the amplihack binary) if it differs from the destination.
-    // Uses atomic rename-then-replace (issue #304) so it succeeds even when the
-    // destination is the currently-running binary.
-    if let Ok(self_exe) = std::env::current_exe() {
-        let self_dst = local_bin.join("amplihack");
-        if self_exe != self_dst {
-            deploy_binary(&self_exe, &self_dst).with_context(|| {
-                format!(
-                    "failed to deploy amplihack binary to {}",
-                    self_dst.display()
-                )
-            })?;
-            deployed.push(self_dst);
-        }
-
-        let resolver_src = self_exe
-            .parent()
-            .map(|dir| dir.join("amplihack-asset-resolver"))
-            .filter(|candidate| is_executable(candidate))
-            .or_else(|| find_binary("amplihack-asset-resolver"));
-        if let Some(resolver_src) = resolver_src {
-            let resolver_dst = local_bin.join("amplihack-asset-resolver");
-            if resolver_src != resolver_dst {
-                deploy_binary(&resolver_src, &resolver_dst).with_context(|| {
-                    format!(
-                        "failed to deploy {} to {}",
-                        resolver_src.display(),
-                        resolver_dst.display()
-                    )
-                })?;
-                deployed.push(resolver_dst);
-            }
-        }
-    }
+    // Also deploy the amplihack binary itself plus its asset-resolver sidecar.
+    //
+    // Issue #885: `amplihack update` self-updates the on-disk binary and then
+    // re-runs `install` to refresh framework assets. On Linux, replacing the
+    // running binary's file leaves `std::env::current_exe()` pointing at a
+    // now-unlinked inode — the kernel reports the path with a literal
+    // " (deleted)" suffix (e.g. `~/.cargo/bin/amplihack (deleted)`). Copying
+    // from that path fails with ENOENT and used to abort the entire asset
+    // refresh before agents/skills/context were staged.
+    //
+    // `resolve_self_source` recovers the freshly-written binary (or a PATH
+    // copy), and `deploy_self_and_resolver` is tolerant: a self-copy failure is
+    // logged and skipped, never propagated, so the framework-asset staging that
+    // follows in `run_install` always proceeds.
+    deployed.extend(deploy_self_and_resolver(&local_bin, resolve_self_source()));
 
     // PATH advisory + auto-persist
     let path_var = std::env::var_os("PATH").unwrap_or_default();
@@ -168,6 +149,109 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
     }
 
     Ok(deployed)
+}
+
+/// Deploy the `amplihack` binary and its `amplihack-asset-resolver` sidecar
+/// from `self_source` into `local_bin`.
+///
+/// Tolerant by design (issue #885): a failure to copy either binary is logged
+/// to stderr and skipped, never propagated. The framework-asset refresh that
+/// follows `deploy_binaries` in `run_install` must not be aborted just because
+/// the self-copy could not complete — most notably when `amplihack update`
+/// swapped the running binary out from under us and the source could not be
+/// recovered. Returns the paths that were successfully deployed (for the
+/// uninstall manifest).
+///
+/// When `self_source` is `None` (no real amplihack source could be located)
+/// the self/resolver deploy is skipped entirely and an empty vector is
+/// returned — the running binary is already installed somewhere on PATH, so
+/// this is a safe no-op rather than an error.
+pub(super) fn deploy_self_and_resolver(
+    local_bin: &Path,
+    self_source: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    use super::filesystem::deploy_binary;
+
+    let mut deployed = Vec::new();
+    let Some(self_exe) = self_source else {
+        return deployed;
+    };
+
+    let self_dst = local_bin.join("amplihack");
+    if self_exe != self_dst {
+        match deploy_binary(&self_exe, &self_dst) {
+            Ok(()) => deployed.push(self_dst),
+            Err(err) => eprintln!(
+                "  ⚠️  Skipping amplihack self-copy to {}: {err:#}",
+                self_dst.display()
+            ),
+        }
+    }
+
+    let resolver_src = self_exe
+        .parent()
+        .map(|dir| dir.join("amplihack-asset-resolver"))
+        .filter(|candidate| is_executable(candidate))
+        .or_else(|| find_binary("amplihack-asset-resolver"));
+    if let Some(resolver_src) = resolver_src {
+        let resolver_dst = local_bin.join("amplihack-asset-resolver");
+        if resolver_src != resolver_dst {
+            match deploy_binary(&resolver_src, &resolver_dst) {
+                Ok(()) => deployed.push(resolver_dst),
+                Err(err) => eprintln!(
+                    "  ⚠️  Skipping amplihack-asset-resolver copy to {}: {err:#}",
+                    resolver_dst.display()
+                ),
+            }
+        }
+    }
+
+    deployed
+}
+
+/// Resolve a real, copyable source for the running `amplihack` binary,
+/// starting from `std::env::current_exe()`.
+///
+/// Delegates to [`resolve_self_source_from`]; see it for the resolution order.
+/// Returns `None` when `current_exe()` itself cannot be determined or no real
+/// source can be located.
+fn resolve_self_source() -> Option<PathBuf> {
+    resolve_self_source_from(&std::env::current_exe().ok()?)
+}
+
+/// Resolve a real, copyable `amplihack` source from a possibly-stale
+/// `current_exe()` path.
+///
+/// Resolution order:
+/// 1. `raw_exe` as-is, when it points at an existing file.
+/// 2. `raw_exe` with a trailing " (deleted)" marker stripped, when that path
+///    exists — after an in-place `amplihack update`, the freshly-written
+///    replacement binary lives at the original location while the running
+///    process still reports the unlinked inode (issue #885).
+/// 3. `amplihack` found on `$PATH`.
+///
+/// Returns `None` when none of these locate a real file.
+pub(super) fn resolve_self_source_from(raw_exe: &Path) -> Option<PathBuf> {
+    if raw_exe.exists() {
+        return Some(raw_exe.to_path_buf());
+    }
+    if let Some(stripped) = strip_deleted_suffix(raw_exe)
+        && stripped.exists()
+    {
+        return Some(stripped);
+    }
+    find_binary("amplihack")
+}
+
+/// Strip the literal " (deleted)" marker that Linux appends to
+/// `/proc/self/exe` when the running executable's file has been unlinked
+/// (e.g. by an in-place `amplihack update`). Returns `None` when the path has
+/// no such suffix.
+pub(super) fn strip_deleted_suffix(path: &Path) -> Option<PathBuf> {
+    const DELETED_MARKER: &str = " (deleted)";
+    path.to_str()?
+        .strip_suffix(DELETED_MARKER)
+        .map(PathBuf::from)
 }
 
 pub(super) fn path_conflict_warning_after_install(

--- a/crates/amplihack-cli/src/commands/install/tests/binary_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/binary_tests.rs
@@ -1,6 +1,7 @@
 use super::helpers::create_exe_stub;
 use super::*;
 use std::fs;
+use std::path::{Path, PathBuf};
 
 // ─── TDD: Group 5 — find_hooks_binary resolution ─────────────────────────
 
@@ -195,6 +196,193 @@ fn deploy_binaries_succeeds_when_local_bin_not_in_path() {
     assert!(
         result.is_ok(),
         "deploy_binaries must exit 0 (warning only) even when ~/.local/bin absent from PATH"
+    );
+}
+
+// ─── Issue #885 — self-source resolution & tolerant self-deploy ───────────
+
+#[test]
+fn strip_deleted_suffix_strips_linux_marker() {
+    // Linux reports a swapped-out running binary as "<path> (deleted)".
+    let stripped =
+        binary::strip_deleted_suffix(Path::new("/home/u/.cargo/bin/amplihack (deleted)"));
+    assert_eq!(
+        stripped,
+        Some(PathBuf::from("/home/u/.cargo/bin/amplihack")),
+        "must strip the trailing ' (deleted)' marker"
+    );
+}
+
+#[test]
+fn strip_deleted_suffix_returns_none_without_marker() {
+    assert!(
+        binary::strip_deleted_suffix(Path::new("/home/u/.cargo/bin/amplihack")).is_none(),
+        "a normal path has no ' (deleted)' marker to strip"
+    );
+}
+
+#[test]
+fn resolve_self_source_from_returns_existing_path_directly() {
+    let tmp = tempfile::tempdir().unwrap();
+    let exe = create_exe_stub(tmp.path(), "amplihack");
+
+    let resolved = binary::resolve_self_source_from(&exe);
+    assert_eq!(
+        resolved,
+        Some(exe),
+        "an existing current_exe() must be used as-is"
+    );
+}
+
+#[test]
+fn resolve_self_source_from_recovers_deleted_suffix_binary() {
+    // Issue #885: after `amplihack update` swaps the binary in place, the
+    // running process reports "<path> (deleted)" while the freshly-written
+    // replacement binary is at "<path>". Resolution must recover the real file.
+    let tmp = tempfile::tempdir().unwrap();
+    let real = create_exe_stub(tmp.path(), "amplihack");
+    let deleted = PathBuf::from(format!("{} (deleted)", real.display()));
+
+    let resolved = binary::resolve_self_source_from(&deleted);
+    assert_eq!(
+        resolved,
+        Some(real),
+        "must strip ' (deleted)' and resolve the freshly-written binary"
+    );
+}
+
+#[test]
+fn resolve_self_source_from_falls_back_to_path_when_unrecoverable() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    // amplihack is on PATH but NOT at the (deleted) location.
+    let path_bin = tmp.path().join("path_bin");
+    let path_stub = create_exe_stub(&path_bin, "amplihack");
+    let unrecoverable = tmp.path().join("gone").join("amplihack (deleted)");
+
+    let prev_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var("PATH", &path_bin);
+    }
+
+    let resolved = binary::resolve_self_source_from(&unrecoverable);
+
+    if let Some(v) = prev_path {
+        unsafe { std::env::set_var("PATH", v) };
+    }
+
+    assert_eq!(
+        resolved,
+        Some(path_stub),
+        "must fall back to the amplihack binary found on $PATH"
+    );
+}
+
+#[test]
+fn resolve_self_source_from_returns_none_when_nothing_found() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let unrecoverable = tmp.path().join("gone").join("amplihack (deleted)");
+
+    let prev_path = std::env::var_os("PATH");
+    unsafe {
+        // Point PATH at an empty dir so find_binary("amplihack") misses.
+        std::env::set_var("PATH", tmp.path().join("empty_bin"));
+    }
+
+    let resolved = binary::resolve_self_source_from(&unrecoverable);
+
+    if let Some(v) = prev_path {
+        unsafe { std::env::set_var("PATH", v) };
+    }
+
+    assert!(
+        resolved.is_none(),
+        "no existing file, no recoverable (deleted) path, and no PATH copy → None"
+    );
+}
+
+#[test]
+fn deploy_self_and_resolver_skips_when_source_none() {
+    // When no real amplihack source can be located, the self/resolver deploy
+    // is a no-op — the running binary is already installed on PATH. Returning
+    // an empty vec (not an error) lets framework-asset staging proceed (#885).
+    let tmp = tempfile::tempdir().unwrap();
+    let local_bin = tmp.path().join(".local/bin");
+    fs::create_dir_all(&local_bin).unwrap();
+
+    let deployed = binary::deploy_self_and_resolver(&local_bin, None);
+
+    assert!(
+        deployed.is_empty(),
+        "None source must skip the self-copy entirely"
+    );
+    assert!(
+        !local_bin.join("amplihack").exists(),
+        "no amplihack binary should be written when the source is unresolvable"
+    );
+}
+
+#[test]
+fn deploy_self_and_resolver_tolerates_missing_source_without_erroring() {
+    // A source that does not exist (and whose destination is also absent) makes
+    // the underlying copy fail. `deploy_self_and_resolver` must swallow that
+    // failure and return an empty vec so the caller (`deploy_binaries` →
+    // `run_install`) continues on to stage framework assets (#885).
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let local_bin = tmp.path().join(".local/bin");
+    fs::create_dir_all(&local_bin).unwrap();
+    let bogus_source = tmp.path().join("nonexistent-amplihack");
+
+    // Point PATH at an empty dir so the resolver PATH-fallback also misses —
+    // otherwise a host-installed amplihack-asset-resolver would be deployed.
+    let prev_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var("PATH", tmp.path().join("empty_bin"));
+    }
+
+    // No panic, no error — just a skipped copy.
+    let deployed = binary::deploy_self_and_resolver(&local_bin, Some(bogus_source));
+
+    if let Some(v) = prev_path {
+        unsafe { std::env::set_var("PATH", v) };
+    }
+
+    assert!(
+        deployed.is_empty(),
+        "a failed self-copy must be skipped, not recorded as deployed"
+    );
+    assert!(
+        !local_bin.join("amplihack").exists(),
+        "the failed copy must not leave a partial destination binary"
+    );
+}
+
+#[test]
+fn deploy_self_and_resolver_copies_valid_source_to_local_bin() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let src_dir = tmp.path().join("cargo_bin");
+    let source = create_exe_stub(&src_dir, "amplihack");
+    let local_bin = tmp.path().join(".local/bin");
+    fs::create_dir_all(&local_bin).unwrap();
+
+    let deployed = binary::deploy_self_and_resolver(&local_bin, Some(source));
+
+    let dst = local_bin.join("amplihack");
+    assert!(dst.exists(), "amplihack must be copied into ~/.local/bin");
+    assert!(
+        deployed.contains(&dst),
+        "the deployed amplihack path must be reported for the manifest, got {deployed:?}"
     );
 }
 

--- a/crates/amplihack-hooks/src/pre_tool_use/cwd/mod.rs
+++ b/crates/amplihack-hooks/src/pre_tool_use/cwd/mod.rs
@@ -158,16 +158,16 @@ fn check_glob_cwd_match(pattern: &str, cwd: &Path) -> Option<Value> {
     }
 
     let prefix_path = Path::new(prefix);
-    let glob_dir = match prefix_path.parent() {
-        Some(d) => match d.canonicalize() {
+    let glob_dir = {
+        let d = prefix_path.parent()?;
+        match d.canonicalize() {
             Ok(c) => c,
             Err(_) => return None,
-        },
-        None => return None,
+        }
     };
-    let basename_prefix = match prefix_path.file_name() {
-        Some(n) => n.to_string_lossy().to_string(),
-        None => return None,
+    let basename_prefix = {
+        let n = prefix_path.file_name()?;
+        n.to_string_lossy().to_string()
     };
 
     let mut current = Some(cwd.to_path_buf());


### PR DESCRIPTION
## Summary

Fixes #885. On a cargo-installed host, `amplihack update` self-updates the binary but then its **inline `install` step fails to refresh framework assets**, emitting:

```
🦀 Deploying binaries:
⚠️  Binary updated but framework asset refresh failed: failed to deploy amplihack binary to
   /home/.../.local/bin/amplihack: failed to copy /home/.../.cargo/bin/amplihack (deleted)
   to /home/.../.local/bin/.amplihack.new.NNN: No such file or directory (os error 2)
```

### Root cause
When `amplihack update` replaces the running `~/.cargo/bin/amplihack` in place, the still-running process's `std::env::current_exe()` points at a now-unlinked inode. On Linux the kernel reports that path with a literal `" (deleted)"` suffix. The install step's binary-deploy sub-step then copied from that non-existent path, failed with `ENOENT`, and aborted the whole asset refresh **before** agents/skills/context were staged. Net effect: the binary updated but framework assets went stale (a standalone `amplihack install` afterward worked fine).

## Fix (`crates/amplihack-cli/src/commands/install/binary.rs`)

- **`resolve_self_source` / `resolve_self_source_from`** — source the self-deploy from a real, copyable binary:
  1. the running exe if it exists, else
  2. the same path with the `" (deleted)"` marker stripped (the freshly-written replacement binary lives at the original location), else
  3. `amplihack` found on `$PATH`.
- **`deploy_self_and_resolver`** — the amplihack/asset-resolver copy is now **tolerant**: a failure (or an unresolvable source) is logged and skipped, never propagated. This guarantees the framework-asset staging that follows in `run_install` always proceeds. The hooks-binary deploy remains fatal (genuinely required).

The result: a single `amplihack update` on a cargo-installed host refreshes **both** the binary and framework assets with no "asset refresh failed" warning.

## Tests

Added unit tests in `tests/binary_tests.rs`:
- `strip_deleted_suffix` strips the Linux marker / returns `None` otherwise.
- `resolve_self_source_from` for existing / `(deleted)`-recovered / `$PATH`-fallback / unresolvable cases.
- `deploy_self_and_resolver` skips on `None`, tolerates a missing source without erroring (assets proceed), and copies a valid source.

## Verification

- `cargo build` ✔
- `cargo fmt --all --check` ✔
- `cargo clippy -- -D warnings` ✔ (workspace clean)
- `cargo test --workspace` ✔ (0 failures)
- pre-commit hooks pass (no `--no-verify`)

## Note on incidental changes

The just-released **Rust 1.97.0 stable** toolchain (which CI's `dtolnay/rust-toolchain@stable` now resolves to) surfaces 3 pre-existing `clippy` findings in `amplihack-blarify` and `amplihack-hooks` that would fail the required `cargo clippy -- -D warnings` check for *any* PR. They are fixed here (mechanical, `clippy --fix`-generated, behavior-preserving) so this PR's CI stays green.

Closes #885