### PR TITLE
fix: repair stale amplihack install shadowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,9 @@ Custom workflows:
   validation and troubleshooting
 - **[Workflow Customization](https://rysweet.github.io/amplihack-rs/WORKFLOW_COMPLETION/)** -
   Modify development process
+- **[Install/Update Repair](docs/howto/repair-install-update-path-conflicts.md)** -
+  Quarantine stale Python/uvx wrappers, keep the Rust user-level binary first,
+  and refresh stale framework assets
 - **[Artifact Guard](docs/artifact-guard.md)** - Guard for blocking
   generated/runtime artifacts before broad staging, pre-commit, and workflow
   publication

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -325,6 +325,11 @@ path = "../../tests/integration/multitask_orchestrator_spec_test.rs"
 name = "orch_workflow_log_inventory"
 path = "../../tests/integration/orch_workflow_log_inventory_test.rs"
 
+# Issue #891: smart-orchestrator active execution must not require orch_helper.py.
+[[test]]
+name = "active_recipe_guard"
+path = "../../tests/integration/active_recipe_guard.rs"
+
 # Issue #801: generated workflow requirements must omit saved preference notices.
 [[test]]
 name = "workflow_prep_requirements_sanitizer"

--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -148,7 +148,9 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
         }
     }
 
-    // PATH advisory + auto-persist
+    // PATH advisory + auto-persist. Always ensure the managed profile block is
+    // present so future shells prefer the user-level Rust binary, even when the
+    // current PATH already mentions ~/.local/bin later.
     let path_var = std::env::var_os("PATH").unwrap_or_default();
     let in_path = std::env::split_paths(&path_var).any(|dir| dir == local_bin);
     if !in_path {
@@ -156,9 +158,9 @@ pub(super) fn deploy_binaries() -> Result<Vec<PathBuf>> {
             "  ⚠️  ~/.local/bin is not in $PATH. Add it to your shell profile:\n   \
              export PATH=\"$HOME/.local/bin:$PATH\""
         );
-        if let Err(e) = super::paths::ensure_local_bin_on_shell_path() {
-            tracing::warn!("failed to auto-persist PATH: {e}");
-        }
+    }
+    if let Err(e) = super::paths::ensure_local_bin_on_shell_path() {
+        tracing::warn!("failed to auto-persist PATH: {e}");
     }
 
     if let Ok(current_exe) = std::env::current_exe()

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -301,10 +301,14 @@ fn local_install(
         )
         .context("failed to neutralize stale Python/uvx amplihack PATH wrappers")?;
         if !repair.neutralized.is_empty() {
+            let manifest_path = repair
+                .manifest_path
+                .as_ref()
+                .context("stale wrapper repair quarantined files without writing a manifest")?;
             println!(
                 "  ✅ Quarantined {} stale amplihack wrapper(s); manifest: {}",
                 repair.neutralized.len(),
-                repair.manifest_path.display()
+                manifest_path.display()
             );
         }
     }

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -284,7 +284,9 @@ fn local_install(
     let preferred_amplihack =
         paths::preferred_user_bin_dir()?.join(crate::path_conflicts::binary_filename("amplihack"));
     if preferred_amplihack.is_file() {
-        let path_dirs = std::env::var_os("PATH")
+        let stale_wrapper_path =
+            std::env::var_os("AMPLIHACK_REPAIR_ORIGINAL_PATH").or_else(|| std::env::var_os("PATH"));
+        let path_dirs = stale_wrapper_path
             .map(|value| std::env::split_paths(&value).collect())
             .unwrap_or_default();
         let repair = stale_wrappers::neutralize_shadowing_stale_wrappers(

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -13,6 +13,7 @@ mod mermaid_cli;
 pub(crate) mod paths;
 mod recipe_runner;
 mod settings;
+mod stale_wrappers;
 mod types;
 mod uninstall;
 mod verification;
@@ -279,6 +280,31 @@ fn local_install(
     let hooks_bin = find_hooks_binary()?;
     for p in &deployed_binaries {
         println!("  ✅ Deployed {}", p.display());
+    }
+    let preferred_amplihack =
+        paths::preferred_user_bin_dir()?.join(crate::path_conflicts::binary_filename("amplihack"));
+    if preferred_amplihack.is_file() {
+        let path_dirs = std::env::var_os("PATH")
+            .map(|value| std::env::split_paths(&value).collect())
+            .unwrap_or_default();
+        let repair = stale_wrappers::neutralize_shadowing_stale_wrappers(
+            stale_wrappers::StaleWrapperNeutralizerConfig {
+                home_dir: paths::home_dir()?,
+                current_exe: std::env::current_exe()
+                    .unwrap_or_else(|_| preferred_amplihack.to_path_buf()),
+                preferred_rust_binary: preferred_amplihack,
+                path_dirs,
+                binary_name: crate::path_conflicts::binary_filename("amplihack"),
+            },
+        )
+        .context("failed to neutralize stale Python/uvx amplihack PATH wrappers")?;
+        if !repair.neutralized.is_empty() {
+            println!(
+                "  ✅ Quarantined {} stale amplihack wrapper(s); manifest: {}",
+                repair.neutralized.len(),
+                repair.manifest_path.display()
+            );
+        }
     }
 
     ensure_dirs(&claude_dir)?;

--- a/crates/amplihack-cli/src/commands/install/paths.rs
+++ b/crates/amplihack-cli/src/commands/install/paths.rs
@@ -1,6 +1,7 @@
 //! Common path helpers and binary lookup utilities.
 
 use anyhow::{Context, Result};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -108,11 +109,14 @@ pub(crate) fn shell_profile_path() -> Option<PathBuf> {
     Some(home.join(rc))
 }
 
-/// Ensure `~/.local/bin` is exported in the user's shell profile.
+const PATH_BLOCK_START: &str = "# >>> amplihack managed PATH >>>";
+const PATH_BLOCK_END: &str = "# <<< amplihack managed PATH <<<";
+
+/// Ensure `~/.local/bin` is prepended in the user's shell profile.
 ///
-/// If `~/.local/bin` is already mentioned in the rc file (via literal
-/// `.local/bin` substring), this is a no-op.  Otherwise it appends an
-/// `export PATH` line with a timestamped comment.
+/// A later PATH mention is not sufficient: stale Python/uvx wrappers earlier
+/// on PATH can still win. The managed block is idempotent and always prepends
+/// `$HOME/.local/bin` for future shells.
 pub(crate) fn ensure_local_bin_on_shell_path() -> Result<()> {
     let profile = match shell_profile_path() {
         Some(p) => p,
@@ -123,23 +127,45 @@ pub(crate) fn ensure_local_bin_on_shell_path() -> Result<()> {
     };
 
     let existing = std::fs::read_to_string(&profile).unwrap_or_default();
-    if existing.contains(".local/bin") {
+    let without_old_block = remove_managed_path_block(&existing);
+    let next_content = format!("{}{}", without_old_block.trim_end(), managed_path_block());
+    if existing == next_content {
         return Ok(());
     }
 
-    let line = format!(
-        "\n# Added by amplihack install ({})\nexport PATH=\"$HOME/.local/bin:$PATH\"\n",
-        chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC"),
-    );
-
-    use std::io::Write;
-    let mut file = std::fs::OpenOptions::new()
+    std::fs::OpenOptions::new()
         .create(true)
-        .append(true)
+        .write(true)
+        .truncate(true)
         .open(&profile)
-        .with_context(|| format!("failed to open {} for appending", profile.display()))?;
-    file.write_all(line.as_bytes())
+        .with_context(|| format!("failed to open {} for writing", profile.display()))?
+        .write_all(next_content.as_bytes())
         .with_context(|| format!("failed to write PATH export to {}", profile.display()))?;
-    println!("  ✅ Added ~/.local/bin to PATH in {}", profile.display());
+    println!(
+        "  ✅ Ensured ~/.local/bin is prepended to PATH in {}",
+        profile.display()
+    );
     Ok(())
+}
+
+fn managed_path_block() -> String {
+    format!(
+        "\n{}\n# Added by amplihack install\nexport PATH=\"$HOME/.local/bin:$PATH\"\n{}\n",
+        PATH_BLOCK_START, PATH_BLOCK_END
+    )
+}
+
+fn remove_managed_path_block(input: &str) -> String {
+    let Some(start) = input.find(PATH_BLOCK_START) else {
+        return input.to_string();
+    };
+    let Some(end_relative) = input[start..].find(PATH_BLOCK_END) else {
+        return input.to_string();
+    };
+    let end = start + end_relative + PATH_BLOCK_END.len();
+    let mut output = String::with_capacity(input.len());
+    output.push_str(input[..start].trim_end());
+    output.push('\n');
+    output.push_str(input[end..].trim_start_matches(['\r', '\n']));
+    output
 }

--- a/crates/amplihack-cli/src/commands/install/paths.rs
+++ b/crates/amplihack-cli/src/commands/install/paths.rs
@@ -1,7 +1,6 @@
 //! Common path helpers and binary lookup utilities.
 
 use anyhow::{Context, Result};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -133,14 +132,7 @@ pub(crate) fn ensure_local_bin_on_shell_path() -> Result<()> {
         return Ok(());
     }
 
-    std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(&profile)
-        .with_context(|| format!("failed to open {} for writing", profile.display()))?
-        .write_all(next_content.as_bytes())
-        .with_context(|| format!("failed to write PATH export to {}", profile.display()))?;
+    atomic_write(&profile, next_content.as_bytes())?;
     println!(
         "  ✅ Ensured ~/.local/bin is prepended to PATH in {}",
         profile.display()
@@ -168,4 +160,21 @@ fn remove_managed_path_block(input: &str) -> String {
     output.push('\n');
     output.push_str(input[end..].trim_start_matches(['\r', '\n']));
     output
+}
+
+fn atomic_write(path: &Path, body: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let mut tmp_name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_default();
+    tmp_name.push(".tmp");
+    let tmp = path.with_file_name(tmp_name);
+    std::fs::write(&tmp, body).with_context(|| format!("failed to write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("failed to rename {} to {}", tmp.display(), path.display()))?;
+    Ok(())
 }

--- a/crates/amplihack-cli/src/commands/install/stale_wrappers.rs
+++ b/crates/amplihack-cli/src/commands/install/stale_wrappers.rs
@@ -1,0 +1,405 @@
+use anyhow::Result;
+use serde::Serialize;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StaleWrapperNeutralizerConfig {
+    pub(crate) home_dir: PathBuf,
+    pub(crate) current_exe: PathBuf,
+    pub(crate) preferred_rust_binary: PathBuf,
+    pub(crate) path_dirs: Vec<PathBuf>,
+    pub(crate) binary_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StaleWrapperNeutralizerReport {
+    pub(crate) neutralized: Vec<NeutralizedWrapper>,
+    pub(crate) manifest_path: PathBuf,
+    pub(crate) resolved_after: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NeutralizedWrapper {
+    pub(crate) original_path: PathBuf,
+    pub(crate) quarantine_path: PathBuf,
+    pub(crate) kind: NeutralizedWrapperKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum NeutralizedWrapperKind {
+    StalePythonWrapper,
+    StaleUvxWrapper,
+}
+
+impl NeutralizedWrapperKind {
+    fn as_manifest_kind(self) -> &'static str {
+        match self {
+            Self::StalePythonWrapper => "stale-python-wrapper",
+            Self::StaleUvxWrapper => "stale-uvx-wrapper",
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum StaleWrapperRepairError {
+    #[error(
+        "unknown executable {path} shadows the Rust amplihack binary at {preferred}; leaving it untouched"
+    )]
+    UnknownShadowingExecutable { path: PathBuf, preferred: PathBuf },
+    #[error(
+        "inaccessible executable {path} shadows the Rust amplihack binary at {preferred}: {source}"
+    )]
+    InaccessibleShadowingExecutable {
+        path: PathBuf,
+        preferred: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error(
+        "stale wrapper repair failed: {resolved_after} still resolves before the Rust amplihack binary at {preferred}"
+    )]
+    RustBinaryStillShadowed {
+        resolved_after: PathBuf,
+        preferred: PathBuf,
+    },
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathCandidateKind {
+    CurrentRustBinary,
+    PreferredRustBinary,
+    StalePythonWrapper,
+    StaleUvxWrapper,
+    UnknownExecutable,
+    Inaccessible(String),
+}
+
+#[derive(Debug, Serialize)]
+struct Manifest {
+    generated_at_unix_secs: u64,
+    entries: Vec<ManifestEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct ManifestEntry {
+    original_path: String,
+    quarantine_path: String,
+    kind: String,
+    size: u64,
+    modified_unix_secs: Option<u64>,
+    action: &'static str,
+}
+
+pub(crate) fn neutralize_shadowing_stale_wrappers(
+    config: StaleWrapperNeutralizerConfig,
+) -> Result<StaleWrapperNeutralizerReport, StaleWrapperRepairError> {
+    let preferred = config
+        .preferred_rust_binary
+        .canonicalize()
+        .unwrap_or_else(|_| config.preferred_rust_binary.clone());
+    let current = config
+        .current_exe
+        .canonicalize()
+        .unwrap_or_else(|_| config.current_exe.clone());
+    let candidates = executable_path_candidates(&config);
+    let preferred_index = candidates.iter().position(|candidate| {
+        same_path(candidate, &config.preferred_rust_binary) || same_path(candidate, &preferred)
+    });
+    let preferred_on_path = preferred_index.is_some();
+    let shadowing_candidates = match preferred_index {
+        Some(index) => &candidates[..index],
+        None => candidates.as_slice(),
+    };
+
+    let run_dir = quarantine_run_dir(&config.home_dir)?;
+    let mut neutralized = Vec::new();
+    let mut manifest_entries = Vec::new();
+
+    for (counter, candidate) in shadowing_candidates.iter().enumerate() {
+        let kind = classify_path_candidate(candidate, &preferred, &current, &config.home_dir)
+            .map_err(
+                |source| StaleWrapperRepairError::InaccessibleShadowingExecutable {
+                    path: candidate.clone(),
+                    preferred: config.preferred_rust_binary.clone(),
+                    source,
+                },
+            )?;
+        match kind {
+            PathCandidateKind::PreferredRustBinary | PathCandidateKind::CurrentRustBinary => {}
+            PathCandidateKind::StalePythonWrapper | PathCandidateKind::StaleUvxWrapper => {
+                let wrapper_kind = match kind {
+                    PathCandidateKind::StalePythonWrapper => {
+                        NeutralizedWrapperKind::StalePythonWrapper
+                    }
+                    PathCandidateKind::StaleUvxWrapper => NeutralizedWrapperKind::StaleUvxWrapper,
+                    _ => unreachable!("matched stale wrapper kinds only"),
+                };
+                let quarantine_path = quarantine_path_for(&run_dir, candidate, counter);
+                if let Some(parent) = quarantine_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let metadata = fs::symlink_metadata(candidate)?;
+                quarantine_file(candidate, &quarantine_path)?;
+                manifest_entries.push(ManifestEntry {
+                    original_path: candidate.display().to_string(),
+                    quarantine_path: quarantine_path.display().to_string(),
+                    kind: wrapper_kind.as_manifest_kind().to_string(),
+                    size: metadata.len(),
+                    modified_unix_secs: metadata.modified().ok().and_then(system_time_secs),
+                    action: "quarantined",
+                });
+                neutralized.push(NeutralizedWrapper {
+                    original_path: candidate.clone(),
+                    quarantine_path,
+                    kind: wrapper_kind,
+                });
+            }
+            PathCandidateKind::UnknownExecutable => {
+                if preferred_on_path {
+                    return Err(StaleWrapperRepairError::UnknownShadowingExecutable {
+                        path: candidate.clone(),
+                        preferred: config.preferred_rust_binary.clone(),
+                    });
+                }
+            }
+            PathCandidateKind::Inaccessible(reason) => {
+                if preferred_on_path {
+                    return Err(StaleWrapperRepairError::InaccessibleShadowingExecutable {
+                        path: candidate.clone(),
+                        preferred: config.preferred_rust_binary.clone(),
+                        source: io::Error::other(reason),
+                    });
+                }
+            }
+        }
+    }
+
+    let manifest_path = run_dir.join("manifest.json");
+    fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&Manifest {
+            generated_at_unix_secs: now_secs(),
+            entries: manifest_entries,
+        })?,
+    )?;
+
+    let resolved_after = if preferred_on_path {
+        resolve_binary_on_path(&config).unwrap_or_else(|| config.preferred_rust_binary.clone())
+    } else {
+        config.preferred_rust_binary.clone()
+    };
+    if preferred_on_path && !same_path(&resolved_after, &config.preferred_rust_binary) {
+        let resolved_kind =
+            classify_path_candidate(&resolved_after, &preferred, &current, &config.home_dir)
+                .map_err(
+                    |source| StaleWrapperRepairError::InaccessibleShadowingExecutable {
+                        path: resolved_after.clone(),
+                        preferred: config.preferred_rust_binary.clone(),
+                        source,
+                    },
+                )?;
+        if !matches!(
+            resolved_kind,
+            PathCandidateKind::PreferredRustBinary | PathCandidateKind::CurrentRustBinary
+        ) {
+            return Err(StaleWrapperRepairError::RustBinaryStillShadowed {
+                resolved_after,
+                preferred: config.preferred_rust_binary,
+            });
+        }
+    }
+
+    Ok(StaleWrapperNeutralizerReport {
+        neutralized,
+        manifest_path,
+        resolved_after,
+    })
+}
+
+fn executable_path_candidates(config: &StaleWrapperNeutralizerConfig) -> Vec<PathBuf> {
+    config
+        .path_dirs
+        .iter()
+        .map(|dir| dir.join(&config.binary_name))
+        .filter(|path| is_executable_file(path))
+        .collect()
+}
+
+fn resolve_binary_on_path(config: &StaleWrapperNeutralizerConfig) -> Option<PathBuf> {
+    executable_path_candidates(config).into_iter().next()
+}
+
+fn classify_path_candidate(
+    path: &Path,
+    preferred: &Path,
+    current: &Path,
+    home: &Path,
+) -> io::Result<PathCandidateKind> {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if canonical == *preferred || same_path(path, preferred) {
+        return Ok(PathCandidateKind::PreferredRustBinary);
+    }
+    if canonical == *current || same_path(path, current) {
+        return Ok(PathCandidateKind::CurrentRustBinary);
+    }
+
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        if !is_safe_wrapper_location(&canonical, home) {
+            return Ok(PathCandidateKind::UnknownExecutable);
+        }
+    } else if !is_safe_wrapper_location(path, home) {
+        return Ok(PathCandidateKind::UnknownExecutable);
+    }
+
+    let content = match read_prefix(path) {
+        Ok(content) => content,
+        Err(err) => return Ok(PathCandidateKind::Inaccessible(err.to_string())),
+    };
+    if is_stale_uvx_wrapper(&content) {
+        return Ok(PathCandidateKind::StaleUvxWrapper);
+    }
+    if is_stale_python_wrapper(&content) {
+        return Ok(PathCandidateKind::StalePythonWrapper);
+    }
+    Ok(PathCandidateKind::UnknownExecutable)
+}
+
+fn is_safe_wrapper_location(path: &Path, home: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(home) else {
+        return false;
+    };
+    let rel = relative.to_string_lossy().replace('\\', "/");
+    rel.starts_with(".local/share/uv/")
+        || rel.starts_with(".cache/uv/")
+        || rel.starts_with(".amplihack/")
+}
+
+fn read_prefix(path: &Path) -> io::Result<String> {
+    let mut file = fs::File::open(path)?;
+    let mut bytes = Vec::new();
+    file.by_ref().take(64 * 1024).read_to_end(&mut bytes)?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn is_stale_python_wrapper(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+    (lower.starts_with("#!")
+        && lower
+            .lines()
+            .next()
+            .is_some_and(|line| line.contains("python")))
+        && (content.contains("from amplihack")
+            || content.contains("import amplihack")
+            || content.contains("load_entry_point")
+            || content.contains("amplihack.cli"))
+}
+
+fn is_stale_uvx_wrapper(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+    ((lower.contains("uvx") || lower.contains("uv tool"))
+        && lower.contains("amplihack")
+        && (lower.starts_with("#!") || lower.contains("generated")))
+        || (lower.starts_with("#!")
+            && lower.contains("exec")
+            && lower.contains(".local/bin/amplihack"))
+}
+
+fn quarantine_run_dir(home: &Path) -> io::Result<PathBuf> {
+    let dir = home
+        .join(".amplihack")
+        .join("quarantine")
+        .join("stale-wrappers")
+        .join(format!("{}-{}", now_secs(), std::process::id()));
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn quarantine_path_for(run_dir: &Path, original: &Path, counter: usize) -> PathBuf {
+    let sanitized = original
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(value) => Some(value.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("__");
+    run_dir.join(format!(
+        "{counter:03}-{}",
+        sanitize_path_segment(if sanitized.is_empty() {
+            "amplihack".into()
+        } else {
+            sanitized
+        })
+    ))
+}
+
+fn sanitize_path_segment(segment: String) -> String {
+    segment
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn quarantine_file(source: &Path, destination: &Path) -> io::Result<()> {
+    match fs::rename(source, destination) {
+        Ok(()) => Ok(()),
+        Err(err) if err.raw_os_error() == Some(libc::EXDEV) => {
+            fs::copy(source, destination)?;
+            fs::remove_file(source)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        path.metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn system_time_secs(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|value| value.as_secs())
+}
+
+fn now_secs() -> u64 {
+    system_time_secs(SystemTime::now()).unwrap_or(0)
+}

--- a/crates/amplihack-cli/src/commands/install/stale_wrappers.rs
+++ b/crates/amplihack-cli/src/commands/install/stale_wrappers.rs
@@ -18,7 +18,7 @@ pub(crate) struct StaleWrapperNeutralizerConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StaleWrapperNeutralizerReport {
     pub(crate) neutralized: Vec<NeutralizedWrapper>,
-    pub(crate) manifest_path: PathBuf,
+    pub(crate) manifest_path: Option<PathBuf>,
     pub(crate) resolved_after: PathBuf,
 }
 
@@ -120,9 +120,9 @@ pub(crate) fn neutralize_shadowing_stale_wrappers(
         None => candidates.as_slice(),
     };
 
-    let run_dir = quarantine_run_dir(&config.home_dir)?;
     let mut neutralized = Vec::new();
     let mut manifest_entries = Vec::new();
+    let mut run_dir = None;
 
     for (counter, candidate) in shadowing_candidates.iter().enumerate() {
         let kind = classify_path_candidate(candidate, &preferred, &current, &config.home_dir)
@@ -143,7 +143,13 @@ pub(crate) fn neutralize_shadowing_stale_wrappers(
                     PathCandidateKind::StaleUvxWrapper => NeutralizedWrapperKind::StaleUvxWrapper,
                     _ => unreachable!("matched stale wrapper kinds only"),
                 };
-                let quarantine_path = quarantine_path_for(&run_dir, candidate, counter);
+                if run_dir.is_none() {
+                    run_dir = Some(quarantine_run_dir(&config.home_dir)?);
+                }
+                let Some(quarantine_root) = run_dir.as_ref() else {
+                    return Err(io::Error::other("quarantine run dir was not initialized").into());
+                };
+                let quarantine_path = quarantine_path_for(quarantine_root, candidate, counter);
                 if let Some(parent) = quarantine_path.parent() {
                     fs::create_dir_all(parent)?;
                 }
@@ -183,14 +189,20 @@ pub(crate) fn neutralize_shadowing_stale_wrappers(
         }
     }
 
-    let manifest_path = run_dir.join("manifest.json");
-    fs::write(
-        &manifest_path,
-        serde_json::to_vec_pretty(&Manifest {
-            generated_at_unix_secs: now_secs(),
-            entries: manifest_entries,
-        })?,
-    )?;
+    let manifest_path = match run_dir {
+        Some(run_dir) => {
+            let manifest_path = run_dir.join("manifest.json");
+            fs::write(
+                &manifest_path,
+                serde_json::to_vec_pretty(&Manifest {
+                    generated_at_unix_secs: now_secs(),
+                    entries: manifest_entries,
+                })?,
+            )?;
+            Some(manifest_path)
+        }
+        None => None,
+    };
 
     let resolved_after = if preferred_on_path {
         resolve_binary_on_path(&config).unwrap_or_else(|| config.preferred_rust_binary.clone())

--- a/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/install_flow.rs
@@ -748,6 +748,42 @@ fn copy_amplifier_bundle_replaces_existing_atomically() {
     );
 }
 
+#[test]
+fn copy_amplifier_bundle_replaces_stale_installed_assets_instead_of_merging() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo_root = temp.path().join("repo");
+    let claude_dir = temp.path().join(".amplihack/.claude");
+    let staged = temp.path().join(".amplihack/amplifier-bundle");
+    fs::create_dir_all(staged.join("recipes")).unwrap();
+    fs::create_dir_all(staged.join("tools")).unwrap();
+    fs::write(
+        staged.join("recipes/old-smart-orchestrator.yaml"),
+        "stale\n",
+    )
+    .unwrap();
+    fs::write(
+        staged.join("tools/orch_helper.py"),
+        "print('stale helper')\n",
+    )
+    .unwrap();
+
+    issue_734_create_bundle_repo(&repo_root, issue_734_compatible_smart_orchestrator());
+    directories::copy_amplifier_bundle(&repo_root, &claude_dir).unwrap();
+
+    assert!(
+        !staged.join("recipes/old-smart-orchestrator.yaml").exists(),
+        "bundle refresh must replace the installed bundle wholesale; stale recipes must not survive"
+    );
+    assert!(
+        !staged.join("tools/orch_helper.py").exists(),
+        "bundle refresh must not merge over old assets that can resurrect orch_helper.py behavior"
+    );
+    assert!(
+        staged.join("recipes/smart-orchestrator.yaml").is_file(),
+        "current distribution recipes must be activated after replacing stale installed assets"
+    );
+}
+
 fn issue_734_compatible_smart_orchestrator() -> &'static str {
     r#"name: "smart-orchestrator"
 description: "Composable smart task orchestrator"

--- a/crates/amplihack-cli/src/commands/install/tests/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/mod.rs
@@ -10,8 +10,10 @@ mod issue_527_tests;
 mod mermaid_cli_tests;
 mod output_regression_tests;
 mod path_conflict_tests;
+mod path_precedence_tests;
 mod same_path_tests;
 mod settings_tests;
+mod stale_wrapper_repair;
 mod uninstall_tests;
 mod wrapper_tests;
 

--- a/crates/amplihack-cli/src/commands/install/tests/path_precedence_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/path_precedence_tests.rs
@@ -1,0 +1,107 @@
+use super::paths::ensure_local_bin_on_shell_path;
+use std::fs;
+
+#[test]
+fn shell_profile_gets_managed_prepend_even_when_local_bin_already_appears_later() {
+    let _lock = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::HomeGuard::set(temp.path());
+    let previous_shell = std::env::var_os("SHELL");
+    unsafe {
+        std::env::set_var("SHELL", "/bin/bash");
+    }
+    let bashrc = temp.path().join(".bashrc");
+    fs::write(
+        &bashrc,
+        "export PATH=\"/opt/stale-python:$PATH:$HOME/.local/bin\"\n",
+    )
+    .unwrap();
+
+    ensure_local_bin_on_shell_path().unwrap();
+
+    let content = fs::read_to_string(&bashrc).unwrap();
+    match previous_shell {
+        Some(value) => unsafe { std::env::set_var("SHELL", value) },
+        None => unsafe { std::env::remove_var("SHELL") },
+    }
+    assert!(
+        content.contains("# >>> amplihack managed PATH >>>")
+            && content.contains("# <<< amplihack managed PATH <<<"),
+        "future-shell PATH repair must use an idempotent managed block, got:\n{content}"
+    );
+    assert!(
+        content.contains("export PATH=\"$HOME/.local/bin:$PATH\""),
+        "managed block must prepend ~/.local/bin rather than treating a later mention as sufficient:\n{content}"
+    );
+}
+
+#[test]
+fn shell_profile_managed_prepend_is_idempotent() {
+    let _lock = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::HomeGuard::set(temp.path());
+    let previous_shell = std::env::var_os("SHELL");
+    unsafe {
+        std::env::set_var("SHELL", "/bin/bash");
+    }
+
+    ensure_local_bin_on_shell_path().unwrap();
+    ensure_local_bin_on_shell_path().unwrap();
+
+    let content = fs::read_to_string(temp.path().join(".bashrc")).unwrap();
+    match previous_shell {
+        Some(value) => unsafe { std::env::set_var("SHELL", value) },
+        None => unsafe { std::env::remove_var("SHELL") },
+    }
+    assert_eq!(
+        content.matches("# >>> amplihack managed PATH >>>").count(),
+        1,
+        "managed PATH block must not be duplicated:\n{content}"
+    );
+}
+
+#[test]
+fn shell_profile_existing_managed_block_is_moved_after_later_path_mutations() {
+    let _lock = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::HomeGuard::set(temp.path());
+    let previous_shell = std::env::var_os("SHELL");
+    unsafe {
+        std::env::set_var("SHELL", "/bin/bash");
+    }
+    let bashrc = temp.path().join(".bashrc");
+    fs::write(
+        &bashrc,
+        "# >>> amplihack managed PATH >>>\nexport PATH=\"$HOME/.local/bin:$PATH\"\n# <<< amplihack managed PATH <<<\nexport PATH=\"/opt/stale-python:$PATH\"\n",
+    )
+    .unwrap();
+
+    ensure_local_bin_on_shell_path().unwrap();
+
+    let content = fs::read_to_string(&bashrc).unwrap();
+    match previous_shell {
+        Some(value) => unsafe { std::env::set_var("SHELL", value) },
+        None => unsafe { std::env::remove_var("SHELL") },
+    }
+    let stale_pos = content
+        .find("/opt/stale-python")
+        .expect("test fixture must keep stale PATH mutation");
+    let managed_pos = content
+        .rfind("# >>> amplihack managed PATH >>>")
+        .expect("managed PATH block must remain");
+    assert!(
+        managed_pos > stale_pos,
+        "managed PATH block must be moved after later PATH mutations so it wins in future shells:\n{content}"
+    );
+    assert_eq!(
+        content.matches("# >>> amplihack managed PATH >>>").count(),
+        1,
+        "managed PATH block must still be singular after move:\n{content}"
+    );
+}

--- a/crates/amplihack-cli/src/commands/install/tests/stale_wrapper_repair.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/stale_wrapper_repair.rs
@@ -197,3 +197,31 @@ fn quarantines_uv_cache_shim_that_delegates_to_user_local_amplihack() {
     );
     assert_eq!(report.resolved_after, preferred_rust);
 }
+
+#[test]
+fn update_repair_uses_preserved_parent_path_even_when_runtime_path_is_repaired() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let preferred_bin = home.join(".local/bin");
+    let uvx_bin = home.join(".cache/uv/archive-v0/bin");
+    let preferred_rust = create_exe_stub(&preferred_bin, "amplihack");
+    let stale_wrapper = uvx_bin.join("amplihack");
+    write_executable(
+        &stale_wrapper,
+        "#!/bin/sh\n# uvx generated shim\nexec uvx --from amplihack amplihack \"$@\"\n",
+    );
+
+    let parent_path = std::env::join_paths([uvx_bin.clone(), preferred_bin.clone()]).unwrap();
+    let path_dirs = std::env::split_paths(&parent_path).collect();
+    let report = neutralize_shadowing_stale_wrappers(repair_config(
+        &home,
+        &preferred_rust,
+        &preferred_rust,
+        path_dirs,
+    ))
+    .expect("update repair must inspect the parent PATH that had stale wrappers before PATH was repaired for subprocess execution");
+
+    assert!(!stale_wrapper.exists());
+    assert_eq!(report.neutralized.len(), 1);
+    assert_eq!(report.resolved_after, preferred_rust);
+}

--- a/crates/amplihack-cli/src/commands/install/tests/stale_wrapper_repair.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/stale_wrapper_repair.rs
@@ -72,7 +72,13 @@ fn quarantines_shadowing_python_entrypoint_wrapper_and_records_manifest() {
         "quarantine path must remain under ~/.amplihack/quarantine/stale-wrappers, got {}",
         report.neutralized[0].quarantine_path.display()
     );
-    let manifest = fs::read_to_string(&report.manifest_path).unwrap();
+    let manifest = fs::read_to_string(
+        report
+            .manifest_path
+            .as_ref()
+            .expect("quarantining wrappers must write a manifest"),
+    )
+    .unwrap();
     assert!(manifest.contains(&stale_wrapper.display().to_string()));
     assert!(manifest.contains("stale-python-wrapper"));
     assert!(manifest.contains("quarantined"));
@@ -167,6 +173,32 @@ fn quarantines_stale_uvx_wrapper_even_before_local_bin_is_on_current_path() {
     assert!(!stale_wrapper.exists());
     assert_eq!(report.resolved_after, preferred_rust);
     assert_eq!(report.neutralized.len(), 1);
+}
+
+#[test]
+fn no_shadowing_wrapper_does_not_create_empty_quarantine_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let preferred_bin = home.join(".local/bin");
+    let preferred_rust = create_exe_stub(&preferred_bin, "amplihack");
+
+    let report = neutralize_shadowing_stale_wrappers(repair_config(
+        &home,
+        &preferred_rust,
+        &preferred_rust,
+        vec![preferred_bin],
+    ))
+    .expect("already Rust-first PATH should need no repair");
+
+    assert!(report.neutralized.is_empty());
+    assert!(
+        report.manifest_path.is_none(),
+        "no-op repair should not leave empty quarantine manifests behind"
+    );
+    assert!(
+        !home.join(".amplihack/quarantine/stale-wrappers").exists(),
+        "no-op repair should not create quarantine directories"
+    );
 }
 
 #[test]

--- a/crates/amplihack-cli/src/commands/install/tests/stale_wrapper_repair.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/stale_wrapper_repair.rs
@@ -1,0 +1,199 @@
+use super::super::stale_wrappers::{
+    NeutralizedWrapperKind, StaleWrapperNeutralizerConfig, StaleWrapperRepairError,
+    neutralize_shadowing_stale_wrappers,
+};
+use super::helpers::create_exe_stub;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn write_executable(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+fn repair_config(
+    home: &Path,
+    current_rust: &Path,
+    preferred_rust: &Path,
+    path_dirs: Vec<PathBuf>,
+) -> StaleWrapperNeutralizerConfig {
+    StaleWrapperNeutralizerConfig {
+        home_dir: home.to_path_buf(),
+        current_exe: current_rust.to_path_buf(),
+        preferred_rust_binary: preferred_rust.to_path_buf(),
+        path_dirs,
+        binary_name: "amplihack".to_string(),
+    }
+}
+
+#[test]
+fn quarantines_shadowing_python_entrypoint_wrapper_and_records_manifest() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let preferred_bin = home.join(".local/bin");
+    let uv_tools_bin = home.join(".local/share/uv/tools/amplihack/bin");
+    let preferred_rust = create_exe_stub(&preferred_bin, "amplihack");
+    let stale_wrapper = uv_tools_bin.join("amplihack");
+    write_executable(
+        &stale_wrapper,
+        "#!/usr/bin/env python3\n# -*- coding: utf-8 -*-\nimport sys\nfrom amplihack.cli import main\nsys.exit(main())\n",
+    );
+
+    let report = neutralize_shadowing_stale_wrappers(repair_config(
+        &home,
+        &preferred_rust,
+        &preferred_rust,
+        vec![uv_tools_bin.clone(), preferred_bin.clone()],
+    ))
+    .expect("positively identified stale Python wrappers in user-controlled uv locations should be quarantined");
+
+    assert!(
+        !stale_wrapper.exists(),
+        "shadowing stale wrapper must no longer exist at its original PATH location"
+    );
+    assert_eq!(report.resolved_after, preferred_rust);
+    assert_eq!(report.neutralized.len(), 1);
+    assert_eq!(
+        report.neutralized[0].kind,
+        NeutralizedWrapperKind::StalePythonWrapper
+    );
+    assert!(report.neutralized[0].quarantine_path.is_file());
+    assert!(
+        report.neutralized[0]
+            .quarantine_path
+            .starts_with(home.join(".amplihack/quarantine/stale-wrappers")),
+        "quarantine path must remain under ~/.amplihack/quarantine/stale-wrappers, got {}",
+        report.neutralized[0].quarantine_path.display()
+    );
+    let manifest = fs::read_to_string(&report.manifest_path).unwrap();
+    assert!(manifest.contains(&stale_wrapper.display().to_string()));
+    assert!(manifest.contains("stale-python-wrapper"));
+    assert!(manifest.contains("quarantined"));
+}
+
+#[test]
+fn quarantines_shadowing_uvx_script_wrapper_without_touching_rust_binary() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let preferred_bin = home.join(".local/bin");
+    let uvx_bin = home.join(".cache/uv/archive-v0/bin");
+    let preferred_rust = create_exe_stub(&preferred_bin, "amplihack");
+    let stale_wrapper = uvx_bin.join("amplihack");
+    write_executable(
+        &stale_wrapper,
+        "#!/bin/sh\n# uvx generated shim\nexec uvx --from amplihack amplihack \"$@\"\n",
+    );
+
+    let report = neutralize_shadowing_stale_wrappers(repair_config(
+        &home,
+        &preferred_rust,
+        &preferred_rust,
+        vec![uvx_bin, preferred_bin.clone()],
+    ))
+    .expect("positively identified stale uvx wrappers should be quarantined");
+
+    assert!(!stale_wrapper.exists());
+    assert!(
+        preferred_rust.exists(),
+        "neutralizing stale wrappers must never move the preferred Rust binary"
+    );
+    assert_eq!(report.neutralized.len(), 1);
+    assert_eq!(
+        report.neutralized[0].kind,
+        NeutralizedWrapperKind::StaleUvxWrapper
+    );
+}
+
+#[test]
+fn unknown_shadowing_executable_is_reported_and_not_modified() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let preferred_bin = home.join(".local/bin");
+    let other_bin = home.join("bin");
+    let preferred_rust = create_exe_stub(&preferred_bin, "amplihack");
+    let unknown = other_bin.join("amplihack");
+    write_executable(&unknown, "#!/bin/sh\necho unrelated-user-tool\n");
+    let before = fs::read(&unknown).unwrap();
+
+    let err = neutralize_shadowing_stale_wrappers(repair_config(
+        &home,
+        &preferred_rust,
+        &preferred_rust,
+        vec![other_bin, preferred_bin],
+    ))
+    .expect_err("unknown shadowing executables must block repair instead of being deleted");
+
+    match err {
+        StaleWrapperRepairError::UnknownShadowingExecutable { path, .. } => {
+            assert_eq!(path, unknown);
+        }
+        other => panic!("expected UnknownShadowingExecutable, got {other:?}"),
+    }
+    assert_eq!(
+        fs::read(&unknown).unwrap(),
+        before,
+        "unknown executables must be left byte-for-byte untouched"
+    );
+}
+
+#[test]
+fn quarantines_stale_uvx_wrapper_even_before_local_bin_is_on_current_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let preferred_bin = home.join(".local/bin");
+    let uvx_bin = home.join(".cache/uv/archive-v0/bin");
+    let preferred_rust = create_exe_stub(&preferred_bin, "amplihack");
+    let stale_wrapper = uvx_bin.join("amplihack");
+    write_executable(
+        &stale_wrapper,
+        "#!/bin/sh\n# uvx generated shim\nexec uvx --from amplihack amplihack \"$@\"\n",
+    );
+
+    let report = neutralize_shadowing_stale_wrappers(repair_config(
+        &home,
+        &preferred_rust,
+        &preferred_rust,
+        vec![uvx_bin],
+    ))
+    .expect("safe stale uvx wrappers should be quarantined even before profile changes affect the current PATH");
+
+    assert!(!stale_wrapper.exists());
+    assert_eq!(report.resolved_after, preferred_rust);
+    assert_eq!(report.neutralized.len(), 1);
+}
+
+#[test]
+fn quarantines_uv_cache_shim_that_delegates_to_user_local_amplihack() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let preferred_bin = home.join(".local/bin");
+    let uv_cache_bin = home.join(".cache/uv/archive-v0/hash/bin");
+    let preferred_rust = create_exe_stub(&preferred_bin, "amplihack");
+    let stale_wrapper = uv_cache_bin.join("amplihack");
+    write_executable(
+        &stale_wrapper,
+        "#!/usr/bin/env bash\nexec \"$HOME/.local/bin/amplihack\" \"$@\"\n",
+    );
+
+    let report = neutralize_shadowing_stale_wrappers(repair_config(
+        &home,
+        &preferred_rust,
+        &preferred_rust,
+        vec![uv_cache_bin, preferred_bin.clone()],
+    ))
+    .expect("uv-cache shim that shadows the preferred Rust binary should be quarantined");
+
+    assert!(!stale_wrapper.exists());
+    assert_eq!(
+        report.neutralized[0].kind,
+        NeutralizedWrapperKind::StaleUvxWrapper
+    );
+    assert_eq!(report.resolved_after, preferred_rust);
+}

--- a/crates/amplihack-cli/src/path_conflicts/target.rs
+++ b/crates/amplihack-cli/src/path_conflicts/target.rs
@@ -115,8 +115,10 @@ pub(crate) fn decide_update_install_target(
         .get(&input.report.current_exe)
         .map(|probe| probe.writable)
         .unwrap_or_else(|| path_is_writable(&input.report.current_exe));
+    let preferred_user_bin_writable = path_is_writable(&input.report.preferred_user_bin);
 
     if !is_under_denied_prefix(&input.report.preferred_user_bin, &denied_system_prefixes)
+        && preferred_user_bin_writable
         && (current_exe_denied || report_has_shadowing(&input.report))
     {
         return Ok(InstallTargetDecision::PreferredUserBin {
@@ -266,13 +268,7 @@ fn is_under_denied_prefix(path: &Path, prefixes: &[(PathBuf, PathBuf)]) -> bool 
 fn path_is_writable(path: &Path) -> bool {
     #[cfg(unix)]
     {
-        let target = if path.exists() {
-            path
-        } else if let Some(parent) = path.parent() {
-            parent
-        } else {
-            return false;
-        };
+        let target = nearest_existing_path(path);
         return is_writable_by_current_user(target);
     }
 
@@ -297,5 +293,17 @@ fn path_is_writable(path: &Path) -> bool {
         // SAFETY: libc::access only reads the NUL-terminated path pointer for the
         // duration of the call; `c_path` is alive and immutable for that duration.
         unsafe { libc::access(c_path.as_ptr(), libc::W_OK) == 0 }
+    }
+
+    #[cfg(unix)]
+    fn nearest_existing_path(path: &Path) -> &Path {
+        let mut target = path;
+        while !target.exists() {
+            let Some(parent) = target.parent() else {
+                break;
+            };
+            target = parent;
+        }
+        target
     }
 }

--- a/crates/amplihack-cli/src/path_conflicts/target.rs
+++ b/crates/amplihack-cli/src/path_conflicts/target.rs
@@ -116,18 +116,13 @@ pub(crate) fn decide_update_install_target(
         .map(|probe| probe.writable)
         .unwrap_or_else(|| path_is_writable(&input.report.current_exe));
 
-    if input.report.preferred_user_bin.exists()
-        && user_bin_pair_exists_and_is_writable(
-            &input.report.preferred_user_bin,
-            &input.candidate_probes,
-        )
+    if !is_under_denied_prefix(&input.report.preferred_user_bin, &denied_system_prefixes)
         && (current_exe_denied || report_has_shadowing(&input.report))
     {
         return Ok(InstallTargetDecision::PreferredUserBin {
             install_dir: input.report.preferred_user_bin,
-            reason:
-                "writable user-level binaries are preferred over unsafe or shadowed PATH candidates"
-                    .to_string(),
+            reason: "user-level binaries are preferred over unsafe or shadowed PATH candidates"
+                .to_string(),
         });
     }
 
@@ -195,22 +190,6 @@ pub(crate) fn probe_candidates_without_exec(
             .or_insert_with(|| binary_probe_without_exec(&path));
     }
     probes
-}
-
-fn user_bin_pair_exists_and_is_writable(
-    user_bin: &Path,
-    probes: &BTreeMap<PathBuf, BinaryProbe>,
-) -> bool {
-    ["amplihack", "amplihack-hooks"].into_iter().all(|name| {
-        let path = user_bin.join(binary_filename(name));
-        if !path.is_file() {
-            return false;
-        }
-        probes
-            .get(&path)
-            .map(|probe| probe.writable)
-            .unwrap_or_else(|| path_is_writable(&path))
-    })
 }
 
 fn report_has_shadowing(report: &PathConflictReport) -> bool {

--- a/crates/amplihack-cli/src/path_conflicts/tests.rs
+++ b/crates/amplihack-cli/src/path_conflicts/tests.rs
@@ -366,6 +366,44 @@ fn denied_system_prefix_is_never_selected_even_when_probe_says_writable() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn unwritable_user_bin_requires_manual_repair_for_denied_system_install() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    let user_bin = home.join(".local/bin");
+    let usr_local_bin = temp.path().join("usr/local/bin");
+    fs::create_dir_all(&user_bin).unwrap();
+    let system_amplihack = write_executable(&usr_local_bin, "amplihack");
+    write_executable(&usr_local_bin, "amplihack-hooks");
+
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(&user_bin, fs::Permissions::from_mode(0o555)).unwrap();
+
+    let report = analyze_path_conflicts(&analysis_input(
+        &home,
+        &system_amplihack,
+        vec![usr_local_bin.clone()],
+    ))
+    .unwrap();
+    let mut probes = BTreeMap::new();
+    probes.insert(system_amplihack, BinaryProbe { writable: false });
+
+    let decision = decide_update_install_target(TargetDecisionInput {
+        report,
+        candidate_probes: probes,
+        denied_system_prefixes: vec![temp.path().join("usr/local")],
+    })
+    .unwrap();
+
+    fs::set_permissions(&user_bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(
+        matches!(decision, InstallTargetDecision::ManualRepairRequired { .. }),
+        "update must not target an unwritable user bin dir: {decision:?}"
+    );
+}
+
 #[test]
 fn update_notice_reports_shadowed_user_local_repair_without_permission_noise() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/amplihack-cli/src/path_conflicts/tests.rs
+++ b/crates/amplihack-cli/src/path_conflicts/tests.rs
@@ -221,9 +221,8 @@ fn update_prefers_current_writable_user_bin_with_production_probes_over_shadowin
         decision,
         InstallTargetDecision::PreferredUserBin {
             install_dir: user_bin,
-            reason:
-                "writable user-level binaries are preferred over unsafe or shadowed PATH candidates"
-                    .into(),
+            reason: "user-level binaries are preferred over unsafe or shadowed PATH candidates"
+                .into(),
         }
     );
 }
@@ -258,17 +257,17 @@ fn update_prefers_writable_user_bin_not_on_path_when_current_exe_is_denied() {
         decision,
         InstallTargetDecision::PreferredUserBin {
             install_dir: user_bin,
-            reason:
-                "writable user-level binaries are preferred over unsafe or shadowed PATH candidates"
-                    .into(),
+            reason: "user-level binaries are preferred over unsafe or shadowed PATH candidates"
+                .into(),
         }
     );
 }
 
 #[test]
-fn root_owned_system_candidate_requires_manual_repair_without_privileged_copy_attempt() {
+fn denied_system_candidate_repairs_to_user_bin_without_privileged_copy_attempt() {
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path().join("home");
+    let user_bin = home.join(".local/bin");
     let usr_local_bin = temp.path().join("usr/local/bin");
     let system_amplihack = write_executable(&usr_local_bin, "amplihack");
     write_executable(&usr_local_bin, "amplihack-hooks");
@@ -287,22 +286,21 @@ fn root_owned_system_candidate_requires_manual_repair_without_privileged_copy_at
         candidate_probes: probes,
         denied_system_prefixes: vec![temp.path().join("usr/local")],
     })
-    .expect("manual repair is a valid decision, not an IO error");
+    .expect("target selection should be pure");
 
-    let InstallTargetDecision::ManualRepairRequired { guidance, .. } = decision else {
-        panic!("unwritable denied system install must require manual repair, got {decision:?}");
-    };
-    assert!(guidance.contains("sudo"));
-    assert!(guidance.contains("/usr/local/bin") || guidance.contains("usr/local/bin"));
-    assert!(guidance.contains("~/.local/bin") || guidance.contains(".local/bin"));
-    assert!(
-        !guidance.contains("Permission denied copying"),
-        "guidance must avoid the old misleading temp-copy failure wording: {guidance}"
+    assert_eq!(
+        decision,
+        InstallTargetDecision::PreferredUserBin {
+            install_dir: user_bin,
+            reason: "user-level binaries are preferred over unsafe or shadowed PATH candidates"
+                .into(),
+        },
+        "denied system installs must repair by writing the user-level target, not by copying into /usr/local"
     );
 }
 
 #[test]
-fn writable_empty_user_bin_does_not_silently_repair_denied_system_install() {
+fn empty_user_bin_is_valid_repair_target_for_denied_system_install() {
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path().join("home");
     let user_bin = home.join(".local/bin");
@@ -327,9 +325,14 @@ fn writable_empty_user_bin_does_not_silently_repair_denied_system_install() {
     })
     .unwrap();
 
-    assert!(
-        matches!(decision, InstallTargetDecision::ManualRepairRequired { .. }),
-        "a writable user-bin directory without existing user-level binaries is not enough to redirect updates away from a denied system install: {decision:?}"
+    assert_eq!(
+        decision,
+        InstallTargetDecision::PreferredUserBin {
+            install_dir: user_bin,
+            reason: "user-level binaries are preferred over unsafe or shadowed PATH candidates"
+                .into(),
+        },
+        "a user-bin directory without existing binaries must be enough to redirect updates away from a denied system install"
     );
 }
 
@@ -358,8 +361,8 @@ fn denied_system_prefix_is_never_selected_even_when_probe_says_writable() {
     .unwrap();
 
     assert!(
-        matches!(decision, InstallTargetDecision::ManualRepairRequired { .. }),
-        "automatic updates must not target denied system prefixes even when the current process can write there: {decision:?}"
+        matches!(decision, InstallTargetDecision::PreferredUserBin { .. }),
+        "automatic updates must target user-level repair, not denied system prefixes, even when the current process can write there: {decision:?}"
     );
 }
 

--- a/crates/amplihack-cli/src/update/check.rs
+++ b/crates/amplihack-cli/src/update/check.rs
@@ -370,5 +370,32 @@ pub(super) fn build_install_command(installed_exe: &Path) -> std::process::Comma
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit());
+    if let Some(path) = repair_subprocess_path(installed_exe) {
+        cmd.env("PATH", path);
+    }
     cmd
+}
+
+fn repair_subprocess_path(installed_exe: &Path) -> Option<std::ffi::OsString> {
+    let user_bin = std::env::var_os("HOME")
+        .map(|home| crate::path_conflicts::preferred_user_bin(Path::new(&home)))
+        .or_else(|| installed_exe.parent().map(Path::to_path_buf))?;
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![user_bin.clone()];
+    paths.extend(
+        std::env::split_paths(&existing)
+            .filter(|path| !paths_equal(path, &user_bin))
+            .collect::<Vec<_>>(),
+    );
+    std::env::join_paths(paths).ok()
+}
+
+fn paths_equal(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
 }

--- a/crates/amplihack-cli/src/update/check.rs
+++ b/crates/amplihack-cli/src/update/check.rs
@@ -367,6 +367,10 @@ pub(super) fn build_install_command(installed_exe: &Path) -> std::process::Comma
         .env("AMPLIHACK_NO_UPDATE_CHECK", "1")
         .env("AMPLIHACK_NONINTERACTIVE", "1")
         .env("AMPLIHACK_POST_UPDATE_INSTALL", "1")
+        .env(
+            "AMPLIHACK_REPAIR_ORIGINAL_PATH",
+            std::env::var_os("PATH").unwrap_or_default(),
+        )
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit());

--- a/crates/amplihack-cli/src/update/install.rs
+++ b/crates/amplihack-cli/src/update/install.rs
@@ -37,6 +37,12 @@ pub(super) fn download_and_replace(release: &UpdateRelease) -> Result<PathBuf> {
         .amplihack_destination
         .parent()
         .context("selected amplihack destination has no parent directory")?;
+    fs::create_dir_all(install_dir).with_context(|| {
+        format!(
+            "failed to create update install dir {}",
+            install_dir.display()
+        )
+    })?;
     let hooks_dest = plan.hooks_destination.clone();
     let amplihack_dest = plan.amplihack_destination.clone();
 

--- a/crates/amplihack-cli/src/update/tests/build_install_command.rs
+++ b/crates/amplihack-cli/src/update/tests/build_install_command.rs
@@ -176,3 +176,41 @@ fn sets_post_update_install_env() {
         "post-update installs must set AMPLIHACK_POST_UPDATE_INSTALL=1 so known transitional XPIA asset gaps can be reported as self-healing instead of hard ❌ errors, got envs: {envs:?}"
     );
 }
+
+/// The repair subprocess must execute with the user-level Rust install first
+/// on PATH, so stale uvx/Python wrappers that existed earlier in the parent
+/// process cannot shadow the freshly installed Rust binary during repair.
+#[test]
+fn prepends_user_local_bin_to_repair_subprocess_path() {
+    let _lock = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::HomeGuard::set(temp.path());
+    let previous_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var("PATH", "/tmp/stale-uvx:/usr/bin");
+    }
+
+    let fake_path = temp.path().join(".local/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    let path_env = cmd
+        .get_envs()
+        .find_map(|(key, value)| {
+            (key == std::ffi::OsStr::new("PATH")).then(|| value.map(|v| v.to_os_string()))
+        })
+        .flatten()
+        .expect("post-update repair subprocess must set PATH explicitly");
+
+    match previous_path {
+        Some(value) => unsafe { std::env::set_var("PATH", value) },
+        None => unsafe { std::env::remove_var("PATH") },
+    }
+
+    let path_env = path_env.to_string_lossy();
+    let expected_prefix = temp.path().join(".local/bin").display().to_string();
+    assert!(
+        path_env.starts_with(&expected_prefix),
+        "post-update repair PATH must start with the Rust user-level bin dir {expected_prefix}, got {path_env}"
+    );
+}

--- a/crates/amplihack-cli/src/update/tests/build_install_command.rs
+++ b/crates/amplihack-cli/src/update/tests/build_install_command.rs
@@ -214,3 +214,38 @@ fn prepends_user_local_bin_to_repair_subprocess_path() {
         "post-update repair PATH must start with the Rust user-level bin dir {expected_prefix}, got {path_env}"
     );
 }
+
+#[test]
+fn preserves_parent_path_for_stale_wrapper_discovery() {
+    let _lock = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::HomeGuard::set(temp.path());
+    let previous_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var("PATH", "/tmp/stale-uvx:/usr/bin");
+    }
+
+    let fake_path = temp.path().join(".local/bin/amplihack");
+    let cmd = build_install_command(&fake_path);
+    let original_path = cmd
+        .get_envs()
+        .find_map(|(key, value)| {
+            (key == std::ffi::OsStr::new("AMPLIHACK_REPAIR_ORIGINAL_PATH"))
+                .then(|| value.map(|v| v.to_os_string()))
+        })
+        .flatten()
+        .expect("post-update install must preserve the parent PATH for stale-wrapper discovery");
+
+    match previous_path {
+        Some(value) => unsafe { std::env::set_var("PATH", value) },
+        None => unsafe { std::env::remove_var("PATH") },
+    }
+
+    assert_eq!(
+        original_path.to_string_lossy(),
+        "/tmp/stale-uvx:/usr/bin",
+        "the install subprocess needs the original shadowing PATH, not only the repaired PATH"
+    );
+}

--- a/crates/amplihack-cli/src/update/tests/install_target.rs
+++ b/crates/amplihack-cli/src/update/tests/install_target.rs
@@ -69,9 +69,10 @@ fn downloaded_update_plan_uses_preferred_user_bin_when_system_binary_shadows_cur
 }
 
 #[test]
-fn downloaded_update_plan_returns_manual_repair_before_copying_into_denied_system_dir() {
+fn downloaded_update_plan_uses_user_bin_instead_of_copying_into_denied_system_dir() {
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path().join("home");
+    let user_bin = home.join(".local/bin");
     let usr_local_bin = temp.path().join("usr/local/bin");
     let archive = temp.path().join("archive");
 
@@ -95,20 +96,21 @@ fn downloaded_update_plan_returns_manual_repair_before_copying_into_denied_syste
         denied_system_prefixes: vec![temp.path().join("usr/local")],
     });
 
-    let err = plan_downloaded_binary_install(
+    let plan = plan_downloaded_binary_install(
         InstallArchiveLayout {
             amplihack: new_amplihack,
             hooks: new_hooks,
         },
         decision,
     )
-    .expect_err("denied system target must not produce a copy plan");
+    .expect("denied system target must repair into user-level bin");
 
-    let message = err.to_string();
-    assert!(message.contains("manual repair"));
-    assert!(message.contains("sudo"));
-    assert!(
-        !message.contains(".tmp") && !message.contains("Permission denied"),
-        "update must fail before temp-copying into /usr/local/bin, got: {message}"
+    assert_eq!(
+        plan,
+        BinaryInstallPlan {
+            amplihack_destination: user_bin.join("amplihack"),
+            hooks_destination: user_bin.join("amplihack-hooks"),
+        },
+        "update must avoid temp-copying into /usr/local/bin and target ~/.local/bin instead"
     );
 }

--- a/docs/features/update-reexec-new-binary.md
+++ b/docs/features/update-reexec-new-binary.md
@@ -2,20 +2,21 @@
 
 > [Home](../index.md) > [Features](README.md) > Post-Update Install Re-exec
 
-When `amplihack update` downloads a new binary, the post-update install step
-spawns the **new** binary as a subprocess rather than running the old binary's
-compiled-in install code. This ensures that fixes, asset changes, and
-configuration migrations shipped in the new version take effect immediately —
-without requiring the user to manually run `amplihack install` a second time.
+When `amplihack update` installs a new Rust binary, the post-update install
+step spawns the **new** binary as a subprocess rather than running the old
+binary's compiled-in install code. This ensures that binary precedence repair,
+stale wrapper quarantine, asset refresh, and configuration migrations shipped
+in the new version take effect immediately.
 
 ## Problem
 
 Issue [#683](https://github.com/rysweet/amplihack-rs/issues/683).
 
-`amplihack update` performs two steps:
+`amplihack update` performs two major steps:
 
 1. **Binary swap** — downloads and atomically replaces the on-disk binary.
-2. **Post-update install** — re-stages framework assets in `~/.amplihack`.
+2. **Post-update repair install** — runs the new binary's
+   `amplihack install --force-refresh` path.
 
 Prior to this fix, step 2 called `crate::commands::install::run_install`
 **in-process**. Because the old binary was still the running process image,
@@ -26,9 +27,14 @@ hook file verification) would not take effect until the user manually ran
 `amplihack install` with the new binary.
 
 The result was a class of "phantom failures": users ran `amplihack update`,
-saw a success message, but the old install code — with its old bugs — had
+saw a success message, but the pre-update install logic — with its old bugs — had
 just re-staged assets. The new binary's fixes were present on disk but had
 never executed.
+
+The durable repair also prevents stale Python/uvx wrappers and stale installed
+`amplifier-bundle` assets from regaining control after update. Update must end
+with the Rust user-level binary selected and the installed bundle replaced from
+the current Rust distribution.
 
 ### Why `current_exe()` is unreliable after binary replacement
 
@@ -49,9 +55,9 @@ binary as a child process instead of calling `run_install` in-process:
 amplihack update
   │
   ├─ analyze PATH conflicts
-  │    → inspect ordered candidates for amplihack + amplihack-hooks
-  │    → prefer ~/.local/bin when a safe user-level target exists
-  │    → stop with manual repair guidance for system-managed targets
+  │    -> inspect ordered candidates for amplihack + amplihack-hooks
+  │    -> select ~/.local/bin as the preferred user-level target
+  │    -> classify stale wrappers, unknown executables, and inaccessible paths
   │
   ├─ download_and_replace(&release)
   │    → downloads, verifies SHA-256, atomic rename
@@ -61,18 +67,18 @@ amplihack update
   │
   └─ run_post_update_install(skip_install, || { ... })
        │
-       ├─ skip_install = true  → skip, return Ok(())
+       ├─ skip_install = true  → intentional bypass: skip durable repair
        │
        └─ skip_install = false →
             build_install_command(&installed_exe)
-              → Command::new(installed_exe)
-              → args: ["install", "--force-refresh"]
-              → env: AMPLIHACK_NO_UPDATE_CHECK=1
-              → env: AMPLIHACK_NONINTERACTIVE=1
+              -> Command::new(installed_exe)
+              -> args: ["install", "--force-refresh"]
+              -> env: AMPLIHACK_NO_UPDATE_CHECK=1
+              -> env: AMPLIHACK_NONINTERACTIVE=1
             cmd.status()?
-              → spawns NEW binary as subprocess
-              → inherits stdin/stdout/stderr
-              → non-zero exit → bail with path + status
+              -> spawns NEW binary as subprocess
+              -> inherits stdin/stdout/stderr
+              -> non-zero exit -> bail with path + status
 ```
 
 ### Key design decisions
@@ -84,14 +90,13 @@ amplihack update
    `current_exe()` (which would point to a deleted inode on Linux). This path
    is passed directly to `Command::new()`.
 
-2. **`--force-refresh` hidden flag** — The subprocess runs with
-   `amplihack install --force-refresh`, a hidden CLI flag that forces a fresh
-   network download of `amplifier-bundle/` assets instead of reusing stale
-   local copies. This flag is not shown in `--help` output; it exists solely
-   for the update→install subprocess path. The downloaded source and staged
-   destination are still validated by the framework bundle compatibility
-   checker, including the composable smart-orchestrator contract added for
-   issue [#734](https://github.com/rysweet/amplihack-rs/issues/734).
+2. **`--force-refresh` hidden flag** - The subprocess runs with
+   `amplihack install --force-refresh`, a hidden CLI flag that bypasses the
+   installed `~/.amplihack/amplifier-bundle` as a source and refreshes assets
+   from the current Rust distribution. This flag is not shown in `--help`
+   output; it exists for the update-to-install repair path and direct
+   stale-bundle repair. The source and staged destination are validated by the
+   framework bundle compatibility checker.
 
 3. **Recursion prevention** — The subprocess environment includes
    `AMPLIHACK_NO_UPDATE_CHECK=1`, which prevents the child `amplihack install`
@@ -107,27 +112,39 @@ amplihack update
    user sees install progress in real time. The subprocess behaves as if the
    user ran `amplihack install` directly.
 
-6. **Safe target selection** — Before replacing a binary, update analyzes
-   ordered `PATH` candidates for `amplihack` and `amplihack-hooks`. If stale
-   system-managed entries such as `/usr/local/bin`, `/usr/bin`, `/bin`, or
-   `/opt` shadow current user-local binaries, update prefers the writable
-   `~/.local/bin` target when available and prints repair guidance. It never
-   writes automatically into system-managed prefixes, even when those
-   directories are writable.
+6. **Rust-first repair** - Before replacement, update analyzes ordered `PATH`
+   candidates for `amplihack` and `amplihack-hooks`. The repair install then
+   deploys to `~/.local/bin`, quarantines positively identified stale Python/uvx
+  wrappers only when they shadow Rust and are in safe locations, writes the
+  managed PATH profile block, and fails if an unknown or inaccessible
+  executable still shadows the Rust binary.
+
+7. **Staged bundle activation** - The repair install stages and validates
+   `~/.amplihack/amplifier-bundle` from the current Rust distribution, then
+   activates the staged bundle as the installed bundle. It does not merge
+   source files over the old installed bundle.
 
 ### `--skip-install` bypass
 
 The existing `--skip-install` (alias `--no-install`) flag on
-`amplihack update` continues to work. When set, the entire post-update
-install step is skipped — no subprocess is spawned. The binary is updated
-on disk but framework assets are not re-staged:
+`amplihack update` continues to work as an intentional bypass. When set, the
+entire post-update install step is skipped — no subprocess is spawned. The
+binary is updated on disk, but durable repair is not performed: stale wrappers
+are not quarantined, PATH precedence is not persisted, and framework assets are
+not re-staged:
 
 ```sh
 # Update binary only, skip post-update install
 amplihack update --skip-install
 ```
 
-Users can then run `amplihack install` manually at a time of their choosing.
+Use this flag only when you intentionally want a binary-only update. Complete
+the skipped repair later with:
+
+```sh
+amplihack install --force-refresh
+```
+
 The [self-heal](self-heal-asset-restage.md) mechanism will also catch the
 version mismatch on the next launch and trigger an automatic re-install when
 the version stamp still indicates the framework was not staged successfully.
@@ -154,16 +171,25 @@ execute permission, `Command::new().status()` returns an I/O error that
 propagates with full context. This should not happen in practice because
 `download_and_replace()` sets `0o755` permissions and uses atomic rename.
 
-### System binary shadows user-local binary
+### Unknown executable shadows the Rust binary
 
-If `/usr/local/bin/amplihack` appears before `~/.local/bin/amplihack` on
-`PATH`, update reports the conflict. When `~/.local/bin` is writable, the
-user-local binary is updated and the warning explains how to make the shell run
-it first. When no safe user-level target exists, update stops before replacement
-and prints sudo/manual repair guidance.
+If an executable named `amplihack` appears before `~/.local/bin/amplihack` and
+cannot be classified as the current Rust binary, preferred Rust binary, or stale
+Python/uvx wrapper, update reports the conflict. The file is not modified.
+
+When the managed PATH block and wrapper quarantine still cannot make the Rust
+binary resolve first, update exits non-zero with the conflicting path and manual
+repair guidance.
 
 See [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md)
-for the target-selection rules.
+for the candidate classification and neutralization rules.
+
+### Stale wrapper quarantine fails
+
+If a shadowing stale wrapper is positively identified but cannot be moved into
+quarantine, the post-update install fails when that wrapper would continue to
+shadow the Rust binary. The failure includes the source path and quarantine
+destination.
 
 ### Old binary without `--force-refresh`
 
@@ -177,15 +203,16 @@ include the unrecognized flag name.
 
 | File | Role |
 |------|------|
-| `crates/amplihack-cli/src/path_conflicts.rs` | Shared side-effect-free PATH analysis, canonical duplicate handling, warning formatting, and install target decision logic. |
+| `crates/amplihack-cli/src/path_conflicts.rs` | Shared side-effect-free PATH analysis, candidate classification, warning formatting, and install target decision logic. |
 | `crates/amplihack-cli/src/update/mod.rs` | Exposes update submodules so resolver-backed target selection is part of the update flow without leaking file layout. |
 | `crates/amplihack-cli/src/update/install.rs` | `download_and_replace()` returns `Result<PathBuf>` with the installed binary path (captured before atomic rename). |
 | `crates/amplihack-cli/src/update/check.rs` | `run_update()` captures the returned path, passes it to `build_install_command()`. The closure given to `run_post_update_install` spawns the subprocess and checks its exit status. |
 | `crates/amplihack-cli/src/update/check.rs` | `build_install_command(installed_exe: &Path) -> Command` — constructs the subprocess command with args and env vars. Visibility: `pub(super)` for testability. |
-| `crates/amplihack-cli/src/commands/install/binary.rs` | Deploys user-local binaries and invokes PATH conflict analysis for install-time warnings. |
-| `crates/amplihack-cli/src/commands/install/paths.rs` | Owns user-local path construction and safe path helpers reused by install/update target selection. |
+| `crates/amplihack-cli/src/commands/install/binary.rs` | Deploys user-local binaries and invokes PATH conflict analysis. |
+| `crates/amplihack-cli/src/commands/install/stale_wrappers.rs` | Quarantines positively identified shadowing stale Python/uvx wrappers and writes manifests. |
+| `crates/amplihack-cli/src/commands/install/paths.rs` | Owns user-local path construction, safe path helpers, and managed PATH profile blocks. |
 | `crates/amplihack-cli/src/commands/install/settings.rs` | Keeps hook registrations aligned with the selected `amplihack-hooks` binary path. |
-| `crates/amplihack-cli/src/commands/install/bundle_compat.rs` | Validates source and staged framework bundles so stale smart-orchestrator assets cannot be accepted or remain installed. |
+| `crates/amplihack-cli/src/commands/install/bundle_compat.rs` | Validates source and staged framework bundles, rejects active `orch_helper.py` dependencies, and supports staged installed-bundle activation. |
 | `crates/amplihack-cli/src/cli_commands.rs` | `Commands::Install` gains a hidden `--force-refresh` flag (`#[arg(long = "force-refresh", hide = true)]`). |
 | `crates/amplihack-cli/src/commands/mod.rs` | Destructures and passes `force_refresh` through to `run_install`. |
 | `crates/amplihack-cli/src/update/post_install.rs` | Unchanged. The closure injection pattern continues to work — the closure now spawns a subprocess instead of calling `run_install`. |
@@ -201,10 +228,12 @@ No new crate dependencies introduced.
 | `build_install_command_sets_no_update_check_env` | `update/tests/build_install_command.rs` | `AMPLIHACK_NO_UPDATE_CHECK=1` is set |
 | `build_install_command_sets_noninteractive_env` | `update/tests/build_install_command.rs` | `AMPLIHACK_NONINTERACTIVE=1` is set |
 | `update_check_source_includes_framework_restage` | `tests/bugfix_install_tests.rs` | Source-level assertion that `run_update` uses `build_install_command` (not `run_install` in-process) |
-| Existing `run_post_update_install` tests | `update/post_install.rs` | Skip-install bypass, closure invocation, error propagation — all still pass unchanged |
-| PATH conflict resolver tests | `path_conflicts.rs` | User-bin first, system-bin shadowing, duplicate candidates, safe user-bin preference, and manual repair decisions |
+| Existing `run_post_update_install` tests | `update/post_install.rs` | Skip-install intentional bypass, closure invocation, error propagation — all still pass unchanged |
+| PATH conflict resolver tests | `path_conflicts.rs` | User-bin first, candidate classification, unknown conflict reporting, inaccessible path handling, and manual repair decisions |
+| Stale wrapper repair tests | `tests/install_stale_wrapper_repair.rs` | Python wrapper quarantine, uvx wrapper quarantine, safe symlink handling, and no mutation of unknown executables |
+| Update repair flow tests | `tests/update_repair_flow.rs` | Update invokes the new binary's install repair path and ends with Rust-first resolution |
 | Install/update smoke output assertions | install/update tests | Normal output excludes stale hook-file `❌` lines, `profile_management` warnings, and literal `Skipping symlink` noise |
-| Bundle compatibility tests | `commands/install/bundle_compat.rs` and install-flow tests | Stale monolithic smart-orchestrator bundles are rejected; missing companion recipes fail; stale `AMPLIHACK_HOME` is skipped; staged repair cannot leave stale `smart-orchestrator.yaml` behind |
+| Bundle compatibility tests | `commands/install/bundle_compat.rs` and `tests/active_recipe_guard.rs` | Stale monolithic smart-orchestrator bundles are rejected; active `orch_helper.py` dependencies fail; stale installed bundles are atomically replaced |
 
 ## Interaction with related features
 
@@ -222,8 +251,8 @@ scan. When it re-runs install, that install run uses the same source and staged
 bundle compatibility validation as an explicit `amplihack install`.
 
 The post-update install subprocess still passes `--force-refresh`, so update
-continues to bypass local bundle reuse and validate the downloaded source and
-staged destination.
+continues to bypass installed-bundle reuse and validate the current-distribution
+source and staged destination.
 
 ### Startup self-update prompt
 
@@ -237,9 +266,11 @@ own update prompt. The `AMPLIHACK_NO_UPDATE_CHECK=1` env var set by
 - [Install Command Reference](../reference/install-command.md) — the install
   procedure invoked by the subprocess.
 - [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md) —
-  safe target selection, PATH shadowing warnings, and manual repair guidance.
+  shadowing stale wrapper quarantine, PATH precedence, and manual repair guidance.
+- [Framework bundle compatibility reference](../reference/framework-bundle-compatibility.md) -
+  active smart-orchestrator guard and staged bundle activation.
 - [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md) —
-  user-facing repair steps for stale `/usr/local/bin` binaries.
+  user-facing repair steps for stale Python/uvx wrappers and unknown conflicts.
 - [Self-Heal Asset Re-Stage](self-heal-asset-restage.md) — the startup-time
   safety net that catches missed post-update installs.
 - [Startup Self-Update Prompt — Subprocess-Safe Skip](startup-update-prompt-subprocess-safe.md) —

--- a/docs/howto/repair-install-update-path-conflicts.md
+++ b/docs/howto/repair-install-update-path-conflicts.md
@@ -1,202 +1,217 @@
 ---
-title: Repair install/update PATH conflicts
-description: Diagnose and repair stale system-wide amplihack binaries that shadow current user-local binaries.
-last_updated: 2026-06-05
+title: Repair stale amplihack wrappers and PATH conflicts
+description: Use install/update to quarantine stale Python or uvx wrappers that shadow Rust, put the Rust binary first, and report unknown command conflicts.
+last_updated: 2026-07-10
 review_schedule: as-needed
 owner: amplihack-maintainers
 doc_type: howto
 ---
 
-# Repair install/update PATH conflicts
+# Repair stale amplihack wrappers and PATH conflicts
 
-Use this guide when `amplihack update` or `amplihack install` reports that a
-stale system-wide binary, usually `/usr/local/bin/amplihack` or
-`/usr/local/bin/amplihack-hooks`, is shadowing the current user-local binary in
-`~/.local/bin`.
+Use this guide when `amplihack` resolves to an old Python or uvx wrapper, or
+when `amplihack install` or `amplihack update` reports that an earlier `PATH`
+entry shadows the Rust binary in `~/.local/bin`.
 
-`amplihack` never runs `sudo`, deletes system files, or writes to
-system-managed locations automatically. It repairs only user-level writable
-install targets and gives explicit commands when system files need
-administrator action.
+Current install/update is the repair path. It deploys the Rust binaries to
+`~/.local/bin`, writes a managed profile block that makes future shells resolve
+that directory first, quarantines only positively identified stale wrappers
+that shadow Rust, and
+refreshes framework assets before final verification that the selected
+`amplihack` is the Rust binary.
 
-## Check command resolution order
+## Repair with install
 
-Show every `amplihack` and `amplihack-hooks` candidate on `PATH`:
-
-```bash
-which -a amplihack
-which -a amplihack-hooks
-```
-
-A healthy user-local install resolves `~/.local/bin` first:
-
-```text
-/home/alice/.local/bin/amplihack
-/home/alice/.local/bin/amplihack-hooks
-```
-
-A conflicting install has an earlier system candidate:
-
-```text
-/usr/local/bin/amplihack
-/home/alice/.local/bin/amplihack
-/usr/local/bin/amplihack-hooks
-/home/alice/.local/bin/amplihack-hooks
-```
-
-In that case the shell runs `/usr/local/bin/amplihack` even though the current
-user-level binaries are present.
-
-## Prefer `~/.local/bin`
-
-Put `~/.local/bin` before `/usr/local/bin` in your shell profile:
+Run:
 
 ```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
-hash -r
-```
-
-For zsh, use `~/.zshrc`:
-
-```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
-hash -r
-```
-
-Verify the result:
-
-```bash
-which -a amplihack
-which -a amplihack-hooks
-amplihack --version
-amplihack-hooks --version
-```
-
-The first result for both binaries should be under `~/.local/bin`.
-
-## Remove stale system binaries
-
-If `/usr/local/bin` still appears first, remove the stale system copies with
-administrator privileges:
-
-```bash
-sudo rm /usr/local/bin/amplihack /usr/local/bin/amplihack-hooks
-hash -r
-```
-
-Then reinstall or update using the user-local binaries:
-
-```bash
-amplihack update
 amplihack install
 ```
 
-Only remove the files when they are stale amplihack binaries. If your team
-intentionally manages `/usr/local/bin/amplihack` through a package manager,
-update that package or change `PATH` order instead.
+Expected successful behavior:
 
-## Run a safe update
+```text
+Deployed amplihack -> /home/alice/.local/bin/amplihack
+Deployed amplihack-hooks -> /home/alice/.local/bin/amplihack-hooks
+Updated shell PATH profile block
+Quarantined stale amplihack wrapper -> /home/alice/.amplihack/quarantine/stale-wrappers/...
+Refreshed amplifier-bundle from current distribution
+Verified Rust amplihack resolves first
+```
 
-When `~/.local/bin/amplihack` and `~/.local/bin/amplihack-hooks` already exist
-and are writable, `amplihack update` uses them as the preferred replacement
-target even if stale copies also exist in system-managed prefixes such as
-`/usr/local/bin`, `/usr/bin`, `/bin`, or `/opt`.
+Open a new shell and verify:
+
+```bash
+command -v amplihack
+amplihack --version
+```
+
+The first command should print:
+
+```text
+/home/alice/.local/bin/amplihack
+```
+
+## Repair with update
+
+Run:
 
 ```bash
 amplihack update
 ```
 
-If a system-managed binary blocks automatic repair, the command fails before
-attempting a temporary copy into that location and prints manual guidance:
+After replacing the binary, update runs the new binary's install repair path:
 
-```text
-Cannot update /usr/local/bin/amplihack automatically.
-
-/usr/local/bin/amplihack appears before /home/alice/.local/bin/amplihack on PATH
-and is not writable by the current user.
-
-Run one of:
-  sudo rm /usr/local/bin/amplihack /usr/local/bin/amplihack-hooks
-  export PATH="$HOME/.local/bin:$PATH"
-
-Then run:
-  hash -r
-  amplihack update
+```bash
+amplihack install --force-refresh
 ```
 
-This is intentional. The updater avoids misleading errors such as:
+`--force-refresh` is an internal flag. It bypasses stale installed bundle
+contents and refreshes `~/.amplihack/amplifier-bundle` from the current Rust
+distribution.
 
-```text
-Permission denied (os error 13)
+## Inspect command resolution
+
+Show every candidate on `PATH`:
+
+```bash
+which -a amplihack
+which -a amplihack-hooks
 ```
 
-from trying to copy temporary replacement files into system-managed prefixes.
-
-## Expected clean install/update output
-
-Successful install and update output should not contain stale hook-file or
-profile warnings. Treat these strings as regressions:
+Healthy output starts with user-local Rust binaries:
 
 ```text
-session_start.sh ❌
-post_tool_use.sh ❌
-pre_tool_use.sh ❌
-profile_management
-Skipping symlink
+/home/alice/.local/bin/amplihack
+/home/alice/.local/bin/amplihack-hooks
 ```
 
-Known-safe bundled symlinks are skipped silently or reported only when
-diagnostic verbosity explicitly asks for file-copy details. Normal user-facing
-install/update output remains focused on actionable results.
+If an earlier candidate exists, install/update classifies it before taking any
+action.
+
+| Candidate | Behavior |
+| --- | --- |
+| Current Rust binary | Accepted. |
+| Preferred Rust binary in `~/.local/bin` | Accepted and made first for future shells. |
+| Stale Python wrapper | Quarantined only when it shadows Rust, is clearly identified, and is in a safe location. |
+| Stale uvx wrapper | Quarantined only when it shadows Rust, is clearly identified, and is in a safe location. |
+| Unknown executable | Not modified; reported as a conflict. |
+| Inaccessible path | Not modified; reported with the filesystem error. |
+
+## Review quarantined wrappers
+
+Quarantined wrappers are stored under:
+
+```text
+~/.amplihack/quarantine/stale-wrappers/<timestamp>/
+```
+
+Each quarantine directory includes a manifest:
+
+```bash
+find ~/.amplihack/quarantine/stale-wrappers -name manifest.tsv -print
+```
+
+The manifest records the original path, quarantined path, wrapper kind, file
+size, modification time, action, and reason. It does not copy full file
+contents into logs.
+
+To restore a quarantined file, move it out manually after confirming that doing
+so will not shadow the Rust binary. Do not restore it to an earlier `PATH`
+directory named `amplihack`.
+
+## Handle unknown conflicts
+
+Install/update does not delete or quarantine unknown executables named
+`amplihack`.
+
+If the unknown executable is yours and obsolete, remove or rename it manually:
+
+```bash
+mv /path/to/old/amplihack /path/to/old/amplihack.disabled
+hash -r
+amplihack install
+```
+
+If the unknown executable is intentionally managed by a package manager, either
+update that package or put `~/.local/bin` before the package-manager directory
+for shells that should use the Rust user-level install.
+
+## Verify future shells
+
+The managed profile block is idempotent and bounded by markers:
+
+```bash
+grep -n "amplihack path" ~/.bashrc ~/.zshrc 2>/dev/null || true
+```
+
+The block prepends `$HOME/.local/bin` only when it is not already first. It
+does not remove unrelated `PATH` entries.
+
+Open a new terminal and check:
+
+```bash
+command -v amplihack
+amplihack --version
+```
 
 ## Troubleshooting
 
-### `amplihack update` still runs the old binary
+### Install reports an unknown executable
 
-Clear your shell's command lookup cache:
+**Symptom**:
+
+```text
+Unknown executable shadows Rust amplihack:
+  /home/alice/bin/amplihack
+```
+
+**Fix**: Inspect that file yourself. If it is not the current Rust binary and
+is not needed, rename or remove it, then run `amplihack install` again.
+
+### A system path shadows the Rust binary
+
+Install/update never mutates system-managed locations such as `/usr/bin`,
+`/usr/local/bin`, `/opt`, or package-manager directories outside `$HOME`.
+
+**No sudo repair:** install/update will not request elevated privileges and
+will not delete system files. Do not fix this with a privileged delete; use your
+normal package-manager or administrative process.
+
+Use your normal administrative process to update or remove the system copy, or
+keep the user-level install first through the managed profile block.
+
+### The shell still runs the old command
+
+Clear the shell command cache:
 
 ```bash
 hash -r
 ```
 
-Open a new terminal and check again:
+Then open a new shell. The persistent repair applies to future shells, not only
+the process that ran install.
+
+### smart-orchestrator still mentions `orch_helper.py`
+
+Run:
 
 ```bash
-which -a amplihack
-amplihack --version
+amplihack install --force-refresh
 ```
 
-### Hooks still point at an old binary
-
-Re-run install after fixing `PATH`:
+Then verify:
 
 ```bash
-amplihack install
+grep -R "orch_helper.py" ~/.amplihack/amplifier-bundle/recipes || true
 ```
 
-Hook registrations use the compiled `amplihack-hooks` binary. They do not call
-Python hook scripts and do not require `session_start.sh`,
-`post_tool_use.sh`, or `pre_tool_use.sh` files.
-
-### You need a system-wide install
-
-Install both binaries consistently in the same system-managed location and keep
-them writable only by the administrator:
-
-```bash
-sudo install -m 0755 amplihack /usr/local/bin/amplihack
-sudo install -m 0755 amplihack-hooks /usr/local/bin/amplihack-hooks
-```
-
-After that, keep `/usr/local/bin` first on `PATH` and update the system copy
-through the same administrative process. Do not mix a system-wide `amplihack`
-with a user-local `amplihack-hooks`.
+Active recipes should not contain an executable `orch_helper.py` dependency.
+Mentions in docs, tests, or compatibility rejection logic are allowed.
 
 ## See also
 
 - [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md)
+- [Framework bundle compatibility reference](../reference/framework-bundle-compatibility.md)
+- [Repair a stale framework bundle](repair-stale-framework-bundle.md)
 - [amplihack install reference](../reference/install-command.md)
-- [Post-update install re-exec](../features/update-reexec-new-binary.md)
-- [First-time install](first-install.md)

--- a/docs/howto/repair-stale-framework-bundle.md
+++ b/docs/howto/repair-stale-framework-bundle.md
@@ -218,4 +218,5 @@ the installer is designed to reject.
 - [Stale smart-orchestrator asset bugfix note](../bugfixes/stale-smart-orchestrator-assets.md)
 - [Install completeness verification](../reference/install-completeness.md)
 - [Post-update install re-exec](../features/update-reexec-new-binary.md)
+- [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md)
 - [resolve-bundle-asset command reference](../reference/resolve-bundle-asset-command.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,9 +90,9 @@ Centralized plugin system that works across all your projects:
 - [Prerequisites](PREREQUISITES.md) - System requirements and dependencies
 - [Interactive Installation](INTERACTIVE_INSTALLATION.md) - Step-by-step setup wizard
 - [Quick Start](../README.md) - Basic usage and first commands
-- [PATH Conflict Tutorial](tutorials/repair-install-update-path-conflicts.md) - Learn why stale system binaries can shadow current user-local installs
-- [Repair Install/Update PATH Conflicts](howto/repair-install-update-path-conflicts.md) - Fix stale `/usr/local/bin` binaries that shadow current `~/.local/bin` installs
-- [Repair a Stale Framework Bundle](howto/repair-stale-framework-bundle.md) - Fix installs where the binary is current but smart-orchestrator recipes are stale
+- [Stale Wrapper Repair Tutorial](tutorials/repair-install-update-path-conflicts.md) - Learn how install/update keeps the Rust binary first and refreshes stale assets
+- [Repair Stale Wrappers and PATH Conflicts](howto/repair-install-update-path-conflicts.md) - Quarantine stale Python/uvx wrappers and make `~/.local/bin/amplihack` resolve first
+- [Repair a Stale Framework Bundle](howto/repair-stale-framework-bundle.md) - Replace stale installed `amplifier-bundle` assets from the current Rust distribution
 
 ### Configuration
 
@@ -151,8 +151,8 @@ amplihack copilot
 
 - [Release Installation](howto/first-install.md) - Install from published binaries or source
 - [Install Manifest](reference/install-manifest.md) - Understand installed files and uninstall state
-- [Install/Update PATH Conflict Reference](reference/install-update-path-conflicts.md) - Target selection, PATH analysis, and output regression guarantees
-- [Framework Bundle Compatibility](reference/framework-bundle-compatibility.md) - Smart-orchestrator compatibility contract and stale bundle repair behavior
+- [Install/Update PATH Conflict Reference](reference/install-update-path-conflicts.md) - Rust binary precedence, stale wrapper neutralization, and PATH profile persistence
+- [Framework Bundle Compatibility](reference/framework-bundle-compatibility.md) - Atomic bundle refresh and active `orch_helper.py` rejection
 - [Azure Integration](AZURE_INTEGRATION.md) - Deploy to Azure cloud
 
 ---

--- a/docs/reference/framework-bundle-compatibility.md
+++ b/docs/reference/framework-bundle-compatibility.md
@@ -1,7 +1,7 @@
 ---
 title: Framework bundle compatibility reference
-description: Compatibility contract for install/update framework bundles, smart-orchestrator recipes, and stale bundle repair.
-last_updated: 2026-06-10
+description: Compatibility contract for staged amplifier-bundle activation, smart-orchestrator recipes, and active orch_helper.py rejection.
+last_updated: 2026-07-10
 review_schedule: as-needed
 owner: amplihack-maintainers
 doc_type: reference
@@ -9,36 +9,29 @@ doc_type: reference
 
 # Framework bundle compatibility reference
 
-`amplihack install` and `amplihack update` validate the framework bundle before
-accepting it as an install source and after staging it under `AMPLIHACK_HOME`.
-Startup self-heal does not run a separate compatibility scan; when the
-version-stamp safety net re-runs install, that install path inherits the same
-validation.
+`amplihack install` and the post-update repair path refresh
+`~/.amplihack/amplifier-bundle` from the current Rust distribution and validate
+the result before reporting success.
 
-The validator protects users from mixed-version installs where the binary is
-current but `~/.amplihack/amplifier-bundle/` still contains stale recipes from an
-older release. This specifically covers issue
-[#734](https://github.com/rysweet/amplihack-rs/issues/734), where a stale
-monolithic `smart-orchestrator.yaml` remained installed after v0.11.0 and failed
-during `parse-decomposition`.
+The validator prevents mixed-version installs where the Rust binary is current
+but installed recipes are stale. In particular, active smart-orchestrator paths
+must not reference or require `orch_helper.py`.
 
 ## Compatibility contract
 
-A framework bundle is compatible only when its `amplifier-bundle/` tree satisfies
-the current smart-orchestrator contract.
-
-Required files:
+A compatible installed bundle contains the current composable
+smart-orchestrator recipe and all required companion recipes.
 
 | Path | Required role |
 | --- | --- |
-| `amplifier-bundle/recipes/smart-orchestrator.yaml` | Composable parent recipe |
-| `amplifier-bundle/recipes/smart-classify-route.yaml` | Classification, preflight, decomposition, activation, and session setup |
-| `amplifier-bundle/recipes/smart-execute-routing.yaml` | Q&A, operations, development, investigation, parallel, fallback, and adaptive routing |
-| `amplifier-bundle/recipes/smart-reflect-loop.yaml` | Goal-seeking reflection loop |
-| `amplifier-bundle/recipes/smart-validate-summarize.yaml` | Outside-in validation, summary, and completion |
-| `amplifier-bundle/recipes/_recipe_manifest.json` | Recipe manifest containing non-empty hash entries for `smart-orchestrator` and all four companion recipes |
+| `amplifier-bundle/recipes/smart-orchestrator.yaml` | Composable parent recipe. |
+| `amplifier-bundle/recipes/smart-classify-route.yaml` | Classification, preflight, decomposition, activation, and session setup. |
+| `amplifier-bundle/recipes/smart-execute-routing.yaml` | Q&A, operations, development, investigation, parallel, fallback, and adaptive routing. |
+| `amplifier-bundle/recipes/smart-reflect-loop.yaml` | Goal-seeking reflection loop. |
+| `amplifier-bundle/recipes/smart-validate-summarize.yaml` | Outside-in validation, summary, and completion. |
+| `amplifier-bundle/recipes/_recipe_manifest.json` | Manifest entries for the parent and companion recipes. |
 
-The parent recipe must be the composable smart-orchestrator:
+The parent recipe delegates to the companion recipes:
 
 ```yaml
 name: "smart-orchestrator"
@@ -57,121 +50,98 @@ steps:
     recipe: "smart-validate-summarize"
 ```
 
-The validator checks structure and required references, not line count. Future
-valid changes may add comments, context keys, or metadata without breaking
-compatibility, as long as the parent recipe still delegates to the four required
-sub-recipes.
+The validator checks structure and active execution references. It does not pin
+one exact YAML hash, so harmless comments or metadata changes do not break
+compatibility.
 
-The recipe manifest must also contain entries for:
+## Active `orch_helper.py` rejection
 
-```text
-smart-orchestrator
-smart-classify-route
-smart-execute-routing
-smart-reflect-loop
-smart-validate-summarize
-```
+No active smart-orchestrator execution path may depend on `orch_helper.py`.
 
-Each entry must have a non-empty hash value. The validator uses this as a
-bundle-manifest sanity check; it does not require one exact recipe file hash.
-
-This is also not an exact content-hash pin. The install path still uses
-source-derived manifest verification to prove required directories were copied,
-but smart-orchestrator compatibility is a structural/content contract. A bundle
-may pass file-presence manifest checks and still fail this validator when the
-recipe content is stale.
-
-## Rejected stale patterns
-
-The installer rejects any candidate or staged bundle whose
-`smart-orchestrator.yaml` matches known incompatible monolithic behavior.
-
-Rejected examples include:
+Rejected active patterns include:
 
 | Pattern | Why it is rejected |
 | --- | --- |
-| A single large monolithic `smart-orchestrator.yaml` that does not delegate to the four sub-recipes | It bypasses the v0.11.0 composable smart-orchestrator contract. |
-| `resolve-bundle-asset helper-path` inside `smart-orchestrator.yaml` as part of old orchestration-helper execution | This belongs to the stale monolithic recipe path and must not remain installed. |
-| Python `importlib` orchestration in `smart-orchestrator.yaml` | The recipe is stale and predates the Rust-native/composable workflow split. |
-| References to `orch_helper.py` as a current smart-orchestrator dependency | `orch_helper.py` no longer exists and must not be restored. |
+| `orch_helper.py` in `smart-orchestrator.yaml` command, script, env, arg, helper, or asset-resolution fields | The active recipe would require a removed Python helper. |
+| Python `importlib` orchestration in `smart-orchestrator.yaml` | The recipe predates the Rust/composable orchestration path. |
+| `resolve-bundle-asset helper-path` used by the stale monolithic smart-orchestrator helper flow | It reintroduces old helper dispatch behavior. |
+| A monolithic smart-orchestrator that does not delegate to the companion recipes | It bypasses the composable contract. |
 
-These stale-marker checks are scoped to
-`amplifier-bundle/recipes/smart-orchestrator.yaml`. Historical documentation,
-tests, or bugfix notes may still mention `orch_helper.py`, `importlib`, or old
-helper-path behavior as examples of stale failures; those references do not
-make the bundle incompatible.
+Allowed references:
 
-`helper-path` remains a valid named bundle asset, but it resolves to the native
-multitask wrapper:
+| Location | Allowed use |
+| --- | --- |
+| Tests | Regression fixtures proving stale recipes are rejected. |
+| Documentation | Historical explanation or troubleshooting. |
+| Compatibility rejection logic | Marker strings used to identify stale active recipes. |
+
+The named asset `helper-path` remains valid outside stale smart-orchestrator
+helper dispatch. It resolves to:
 
 ```text
-helper-path -> amplifier-bundle/bin/multitask-orchestrator.sh
+amplifier-bundle/bin/multitask-orchestrator.sh
 ```
 
-Do not remap `helper-path` to `orch_helper.py`. Do not reintroduce
-`orch_helper.py` to make stale recipes pass validation.
+Do not restore `orch_helper.py` or remap `helper-path` to a Python file.
 
-## Source selection behavior
+## Staged bundle activation
 
-Every local framework source candidate is validated before use.
+Install/update replaces the installed bundle; it does not merge over the
+existing directory.
 
-Default source resolution for `amplihack install`:
+Refresh order:
 
-| Priority | Candidate | Compatibility behavior |
-| --- | --- | --- |
-| 1 | `AMPLIHACK_HOME` | Explicit user-configured source. Skipped when stale or incompatible. |
-| 2 | Current-working-directory walk-up | Finds the checkout the user is installing from. Used only when compatible. |
-| 3 | Executable-path walk-up | Finds in-tree development binaries under `target/`. Used only when compatible. |
-| 4 | Compile-time workspace root | Fallback for `cargo run`-style invocations. Used only when compatible. |
-| 5 | `~/.amplihack` | Prior staged install location. Skipped when stale or incompatible. |
-| 6 | Network download | Used when no compatible local bundle is available or `--force-refresh` is active. |
+1. Resolve the current Rust distribution's authoritative `amplifier-bundle`.
+2. Validate the source bundle.
+3. Copy the source bundle into a temporary staging directory under the install
+   root.
+4. Validate the staged bundle, including smart-orchestrator compatibility.
+5. Activate the staged bundle with a same-install-root swap/rename strategy so
+   the selected installed bundle changes as one final activation step.
+6. Re-run post-activation compatibility checks against
+   `~/.amplihack/amplifier-bundle`.
+7. Verify install completeness and write install metadata only after the
+   replacement is valid.
 
-An incompatible local candidate does not win the resolution race merely because
-it exists. The installer reports the skipped candidate and continues to the next
-source. If no compatible source can be found or downloaded, install fails.
+The atomic guarantee is scoped to the final activation step after staging and
+validation. The installer must not delete the active bundle and then copy files
+into place, and must not merge new files over old files. If the platform cannot
+perform the activation without a merge/delete window, install/update fails
+closed instead of reporting success.
 
-`amplihack update` runs the new binary as:
+If validation fails before activation, the previous installed bundle remains
+selected. If staging or post-activation validation fails, install/update exits
+non-zero and does not write success metadata.
 
-```sh
-amplihack install --force-refresh
-```
+Because activation is whole-directory, stale files that existed only in the old
+installed bundle cannot survive a successful refresh.
 
-The hidden `--force-refresh` flag bypasses local source selection and downloads
-fresh framework assets. The downloaded source is still validated before staging,
-and the staged destination is validated after copy.
+## Source selection
 
-## Staging behavior
+`amplihack install` uses compatible assets from the current Rust distribution.
+For a development checkout, that is the checkout's `amplifier-bundle/`. For a
+packaged release, that is the bundle shipped with the release distribution.
 
-Framework staging is fail-closed:
+Source behavior:
 
-1. Validate the selected source bundle.
-2. Copy the bundle into the install staging area.
-3. Validate the staged `AMPLIHACK_HOME/amplifier-bundle/`.
-4. Run source-derived install completeness verification.
-5. Persist uninstall manifest and version-success metadata only after the bundle
-   and mapped assets are valid.
+| Invocation | Bundle source behavior |
+| --- | --- |
+| `amplihack install` | Uses compatible current-distribution assets and validates before staging. |
+| `amplihack install --local <PATH>` | Uses the explicit local source only if it passes compatibility validation. |
+| `amplihack install --force-refresh` | Bypasses the installed bundle as a source and refreshes from the current Rust distribution. |
+| `amplihack update` | Installs the new Rust binary, then runs that binary's `install --force-refresh` repair path. |
 
-If a stale monolithic `smart-orchestrator.yaml` exists at the destination before
-install, a successful install replaces it with the canonical composable recipe.
-The stale file cannot remain staged after a successful install/update repair.
+The installed `~/.amplihack/amplifier-bundle` is never trusted as an
+authoritative source for `--force-refresh`.
 
 ## User-facing diagnostics
 
-When a local candidate is skipped:
+When a stale active recipe is rejected:
 
 ```text
-⚠️  Skipping incompatible framework bundle at /home/alice/.amplihack:
-    recipes/smart-orchestrator.yaml is stale: expected composable sub-recipes
-    smart-classify-route, smart-execute-routing, smart-reflect-loop,
-    smart-validate-summarize
-```
-
-When the staged destination fails validation:
-
-```text
-install failed: staged framework bundle is incompatible:
-  /home/alice/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml
-  contains stale monolithic smart-orchestrator behavior
+install failed: framework bundle is incompatible:
+  amplifier-bundle/recipes/smart-orchestrator.yaml
+  contains active orch_helper.py dependency
 ```
 
 When a companion recipe is missing:
@@ -182,47 +152,26 @@ install failed: framework bundle is incompatible:
   amplifier-bundle/recipes/smart-reflect-loop.yaml
 ```
 
-Diagnostics include the path and the failed contract. They do not dump full
-recipe contents or environment variables.
+When an installed stale bundle is replaced:
 
-## Security model
+```text
+Refreshed amplifier-bundle from current distribution
+Verified smart-orchestrator compatibility
+Verified no active orch_helper.py dependency
+```
 
-Framework bundle candidates are treated as untrusted until validation succeeds,
-whether they come from `AMPLIHACK_HOME`, a local checkout, the executable path,
-the compile-time workspace root, `~/.amplihack`, `--local`, or a download.
-
-The compatibility validator only reads files. It does not execute YAML, shell,
-Python, helper scripts, or bundle assets while deciding whether a source can be
-used. Unreadable files, missing companion recipes, and incomplete bundle roots
-fail closed with an explicit error instead of falling back to success-shaped
-defaults.
-
-## Manifest and checksum policy
-
-Framework compatibility validation complements install completeness verification;
-it does not replace it.
-
-| Check | Purpose | Failure mode |
-| --- | --- | --- |
-| Source-derived completeness manifest | Confirms required source directories, child directories, skills, and staged bundle paths were copied. | Missing or partial files/directories fail install. |
-| Smart-orchestrator compatibility validator | Confirms the copied recipes satisfy the current composable contract. | Stale monolithic or incomplete smart-orchestrator assets fail install. |
-| Release archive checksum | Confirms downloaded binaries or archives match the expected remote artifact when that download path provides checksums. | Download/update fails before install staging. |
-
-Do not use a hard-coded SHA-256 of `smart-orchestrator.yaml` as the primary
-compatibility gate. Exact hashes are too strict for harmless comments or
-metadata changes and too weak as the only staged-state check because a matching
-parent file does not prove the required companion recipes were staged. Use the
-structural contract and companion-recipe presence checks instead.
+Diagnostics include paths and failed contracts. They do not dump full recipe
+contents or environment variables.
 
 ## Configuration
 
-No new configuration is required.
+No new user configuration is required.
 
 | Input | Effect |
 | --- | --- |
-| `AMPLIHACK_HOME` | Selects the install/staging root. A bundle under this root is validated before it can be reused. |
-| `--local <PATH>` | Uses a caller-provided source path. The path is still validated and fails if incompatible. |
-| `--force-refresh` | Hidden install flag used by post-update install. Bypasses local source candidates, downloads a fresh bundle, then validates source and staged destination. |
+| `AMPLIHACK_HOME` | Selects the install root. Defaults to `~/.amplihack`. |
+| `--local <PATH>` | Uses a caller-provided source path after compatibility validation. |
+| `--force-refresh` | Hidden install flag used by update repair and direct stale-bundle repair; bypasses the installed bundle as a source. |
 | `AMPLIHACK_SKIP_AUTO_INSTALL` | Suppresses startup self-heal. It does not disable explicit install/update compatibility validation. |
 
 ## Contributor API
@@ -233,9 +182,6 @@ The install compatibility validator lives in
 ### `validate_framework_bundle_compatibility(root: &Path) -> Result<()>`
 
 Validates a candidate framework source before install accepts it.
-
-Use this before returning a path from source discovery or before copying from a
-user-provided `--local` path.
 
 The `root` may be either:
 
@@ -249,9 +195,8 @@ smart-orchestrator contract is not satisfied.
 
 ### `validate_staged_framework_bundle(root: &Path) -> Result<()>`
 
-Validates the staged bundle after copy and atomic replacement.
-
-Use this against the installed Amplihack home, normally:
+Validates the staged installed bundle after copy and before final replacement.
+Use this against:
 
 ```text
 ~/.amplihack/amplifier-bundle/
@@ -260,71 +205,71 @@ Use this against the installed Amplihack home, normally:
 This check is a hard install failure. It prevents copy bugs, stale destination
 files, or partial staging from being reported as success.
 
+### `replace_installed_bundle_atomically(source: &Path, install_root: &Path) -> Result<()>`
+
+Stages a validated source bundle in a temporary directory, validates the staged
+copy, and atomically activates it as `install_root/amplifier-bundle`.
+
+Callers must not copy files directly into the installed bundle or merge source
+files over the destination.
+
+### `reject_active_orch_helper_dependency(bundle_root: &Path) -> Result<()>`
+
+Scans active recipe/runtime dispatch paths for stale `orch_helper.py`
+dependencies. The scan is scoped to executable recipe behavior and compatibility
+rules; it does not reject documentation, tests, or rejection fixtures that
+mention the string.
+
 ### `is_compatible_framework_bundle(root: &Path) -> bool`
 
-Boolean helper for source discovery.
-
-Use this when scanning optional local candidates such as `AMPLIHACK_HOME` or an
-executable walk-up path. A `false` result means "do not select this candidate";
-the caller may continue to the next candidate or fall back to network download.
-
-Do not use this helper for final staging verification. Final verification should
-call `validate_staged_framework_bundle()` so the user receives the actionable
-error.
+Boolean helper for optional source discovery. A `false` result means "do not
+select this candidate"; the caller may continue to another source. Final
+staging verification should call `validate_staged_framework_bundle()` so the
+user receives an actionable error.
 
 ### `BundleCompatibilityError`
 
-Structured error used by the validator. Error messages are stable enough for
-diagnostics and tests, but callers should branch on variants rather than parsing
-human text.
-
-Expected variants:
+Structured error used by the validator. Callers should branch on variants
+rather than parsing human text.
 
 | Variant | Meaning |
 | --- | --- |
 | `MissingBundleRoot` | No `amplifier-bundle/` directory was found from the provided root. |
 | `MissingSmartOrchestrator` | `recipes/smart-orchestrator.yaml` is absent. |
-| `MissingCompanionRecipe` | One of the four required `smart-*` companion recipes is absent. |
+| `MissingCompanionRecipe` | One of the four required companion recipes is absent. |
 | `IncompatibleSmartOrchestrator` | The parent recipe does not delegate to the required companion recipes. |
-| `StaleSmartOrchestrator` | Known stale monolithic, Python/importlib, `orch_helper.py`, or old `helper-path` orchestration behavior was detected. |
+| `ActiveOrchHelperDependency` | An executable smart-orchestrator path references or requires `orch_helper.py`. |
+| `StaleSmartOrchestrator` | Known stale monolithic, Python/importlib, or old helper-path orchestration behavior was detected. |
 | `UnreadableRecipe` | A required recipe file exists but cannot be read. |
 
 ## Regression coverage
 
 Tests cover:
 
-1. The repository's canonical `amplifier-bundle/recipes/smart-orchestrator.yaml`
-   is accepted.
-2. A stale monolithic smart-orchestrator using old Python/importlib behavior is
-   rejected.
-3. A stale smart-orchestrator that references `resolve-bundle-asset helper-path`
-   as an orchestration helper is rejected.
-4. A bundle missing any required companion recipe is rejected.
-5. Source discovery skips a stale `AMPLIHACK_HOME` bundle and continues to a
-   compatible source.
-6. Install/update repair replaces a staged stale monolithic
-   `smart-orchestrator.yaml`; it cannot remain staged after success.
-7. `helper-path` continues to resolve to
+1. The repository's canonical `smart-orchestrator.yaml` is accepted.
+2. A stale monolithic smart-orchestrator is rejected.
+3. Active `orch_helper.py` dependencies are rejected.
+4. Documentation, tests, and compatibility rejection fixtures may mention
+   `orch_helper.py`.
+5. A bundle missing any companion recipe is rejected.
+6. `--force-refresh` replaces the installed bundle instead of merging over it.
+7. Stale installed smart-orchestrator files cannot remain after successful
+   install/update repair.
+8. `helper-path` continues to resolve to
    `amplifier-bundle/bin/multitask-orchestrator.sh`.
 
 Focused validation:
 
-```sh
+```bash
 cargo test -p amplihack-cli bundle_compat
+cargo test -p amplihack-cli active_recipe_guard
 cargo test -p amplihack-cli install_flow
-```
-
-Workspace validation:
-
-```sh
-cargo test -p amplihack-cli
-cargo check --workspace
 ```
 
 ## See also
 
-- [amplihack install / uninstall command reference](install-command.md)
+- [Repair a stale framework bundle](../howto/repair-stale-framework-bundle.md)
+- [Install/update PATH conflict reference](install-update-path-conflicts.md)
 - [Install completeness verification](install-completeness.md)
 - [Post-update install re-exec](../features/update-reexec-new-binary.md)
-- [Repair a stale framework bundle](../howto/repair-stale-framework-bundle.md)
 - [resolve-bundle-asset command reference](resolve-bundle-asset-command.md)

--- a/docs/reference/install-command.md
+++ b/docs/reference/install-command.md
@@ -9,13 +9,20 @@ amplihack uninstall
 
 ## amplihack install
 
-Bootstraps the amplihack environment on the current machine. On first run, it performs full setup: locates the bundled framework source (or falls back to network download), deploys native binaries, stages framework assets, and registers Claude Code hooks. Subsequent runs are idempotent — they update existing registrations in place without duplication.
+Bootstraps or repairs the amplihack environment on the current machine. On
+first run, it deploys the Rust binaries to `~/.local/bin`, makes that directory
+resolve first for future shells, refreshes framework assets from the current
+Rust distribution, registers hooks, and finally verifies the selected
+`amplihack` is the Rust binary.
 
-Since issue #254, framework assets are bundled in the amplihack-rs source tree. The installer resolves the framework source in this order: (1) `AMPLIHACK_HOME`, (2) current-working-directory walk-up, (3) executable-path walk-up, (4) compile-time workspace root, (5) `~/.amplihack`, (6) network download from upstream (legacy fallback).
+Subsequent runs are idempotent. They update existing registrations and managed
+profile blocks in place, quarantine newly discovered shadowing stale wrappers,
+and replace the installed `amplifier-bundle` instead of merging over it.
 
-Since issue #675, the post-update installer bypasses local source selection and always downloads a fresh bundle from the network. This prevents stale `amplifier-bundle/` assets at `~/.amplihack/` from being re-staged after a binary update.
-
-Since issue #734, every local framework source candidate is also checked for smart-orchestrator compatibility before it can be selected. Standalone `amplihack install` still uses the resolver order above, but stale or incompatible local bundles are skipped instead of being reused. See [Framework bundle compatibility](./framework-bundle-compatibility.md).
+The installer treats the current Rust distribution as authoritative. The
+installed `~/.amplihack/amplifier-bundle` is not reused by
+`--force-refresh`, and stale smart-orchestrator assets are rejected before they
+can become active. See [Framework bundle compatibility](./framework-bundle-compatibility.md).
 
 You can invoke the same command through the npm wrapper package when desired:
 
@@ -38,9 +45,9 @@ fall back to a source build.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--interactive` | `bool` | `false` | Launch a guided setup wizard that prompts for default tool, hook scope, and update-check preference. Requires a TTY; falls back to defaults with a warning if stdin is not a terminal. See [Interactive Install](../howto/interactive-install.md). |
-| `--local <PATH>` | `PathBuf` | absent | Install from a specific local directory instead of using the bundled source. The path must exist, be a directory, contain a framework root marker, and pass framework bundle compatibility validation. Without `--local`, the installer uses compatible bundled framework assets from the amplihack-rs source tree or falls back to download. |
+| `--local <PATH>` | `PathBuf` | absent | Install from a specific local directory instead of using the current distribution's default source. The path must exist, be a directory, contain a framework root marker, and pass framework bundle compatibility validation. Without `--local`, the installer uses compatible assets shipped with the current Rust distribution. |
 | `--verbose` | `bool` | `false` | Accepted for diagnostic scripts. The install command already emits phase-level diagnostics by default. |
-| `--force-refresh` | `bool` | `false` | **Hidden.** Forces a fresh network download of `amplifier-bundle/` assets, bypassing local source resolution. Used internally by `amplihack update` when spawning the new binary as a post-update install subprocess. Not shown in `--help` output. See [Post-Update Install — Re-exec New Binary](../features/update-reexec-new-binary.md). |
+| `--force-refresh` | `bool` | `false` | **Hidden.** Refreshes `amplifier-bundle/` from the current Rust distribution while bypassing the installed bundle as a source. Used internally by `amplihack update` when spawning the new binary as a post-update install subprocess. Not shown in `--help` output. See [Post-Update Install - Re-exec New Binary](../features/update-reexec-new-binary.md). |
 
 The `--interactive` and `--local` flags compose: `--interactive` controls configuration preferences while `--local` controls the framework source path.
 
@@ -53,6 +60,8 @@ The `--interactive` and `--local` flags compose: `--interactive` controls config
 | `1` | `--local` path does not exist or is not a directory |
 | `1` | `--local` path does not contain a framework root marker |
 | `1` | selected framework bundle is stale or incompatible |
+| `1` | unknown or inaccessible executable still shadows the Rust `~/.local/bin/amplihack` after repair |
+| `1` | stale wrapper quarantine failed and the wrapper still shadows the Rust binary |
 | `1` | Framework archive download or extraction failed (non-local mode only) |
 
 Note: A Node.js version below v24 does **not** cause a non-zero exit from `amplihack install`. It produces a warning at the Copilot plugin step. By contrast, `amplihack copilot` exits with code 1 if Node.js < v24. See [Node.js Version Checking](./node-version-checking.md).
@@ -63,21 +72,24 @@ Note: A Node.js version below v24 does **not** cause a non-zero exit from `ampli
 amplihack install [--interactive]
 │
 ├── 0. maybe_run_wizard()         — if --interactive, prompt for tool/scope/update prefs (skipped otherwise)
-├── 1. Bundled source, --local path, OR GitHub fallback — obtain compatible framework source
+├── 1. Current distribution or --local path — obtain compatible framework source
 ├── 2. deploy_binaries()          — copy amplihack + amplihack-hooks (+ asset resolver when present) to ~/.local/bin
-├── 2b. analyze PATH conflicts    — warn if stale earlier PATH entries shadow ~/.local/bin
-├── 3. copy framework assets      — validate source, stage mapped framework assets, validate staged bundle
-├── 4. create_runtime_dirs()      — create runtime/ subdirs with 0o755 permissions
-├── 5. ensure_settings_json()     — backup settings.json, register hooks, set permissions
-├── 6. verify_framework_assets()  — confirm required staged framework assets exist
-├── 7. apply_config()             — if wizard ran, write preferences to manifest and settings
-├── 8. write_manifest()           — write amplihack-manifest.json for uninstall
-└── 9. ensure_mermaid_cli()       — best-effort: provision mmdc (npm @mermaid-js/mermaid-cli); warn-and-continue on failure
+├── 2b. analyze PATH candidates   — classify Rust binaries, stale wrappers, unknowns, and inaccessible paths
+├── 2c. neutralize stale wrappers — quarantine only shadowing, positively identified Python/uvx wrappers in safe locations
+├── 2d. persist PATH precedence   — write/update managed shell profile block so ~/.local/bin resolves first
+├── 3. refresh framework assets   — validate source, stage full bundle, atomically activate installed bundle, validate staged bundle
+├── 4. verify Rust selection      — confirm selected amplihack is the Rust binary after PATH and bundle repair
+├── 5. create_runtime_dirs()      — create runtime/ subdirs with 0o755 permissions
+├── 6. ensure_settings_json()     — backup settings.json, register hooks, set permissions
+├── 7. verify_framework_assets()  — confirm required staged framework assets exist
+├── 8. apply_config()             — if wizard ran, write preferences to manifest and settings
+├── 9. write_manifest()           — write amplihack-manifest.json for uninstall
+└── 10. ensure_mermaid_cli()      — best-effort: provision mmdc (npm @mermaid-js/mermaid-cli); warn-and-continue on failure
 ```
 
 Phase 0 runs only when `--interactive` is passed **and** stdin is a TTY. If `--interactive` is set but no TTY is available, the wizard is skipped with a warning to stderr. Phase 7 applies wizard results (default tool, update-check preference) to the manifest and writes hooks to the selected settings.json scope.
 
-Phase 9 runs **after** the version stamp, manifest, and Copilot-home staging, so an `mmdc` failure can never leave required install state unwritten. It is **optional and best-effort**: it attempts `npm install -g @mermaid-js/mermaid-cli` only when npm is available and `mmdc` is missing, and it always continues — a failed or skipped install emits a warning/info line and never fails the install. See [Best-Effort Mermaid CLI Provisioning](../features/mermaid-cli-best-effort-install.md).
+Phase 10 runs **after** the version stamp, manifest, and Copilot-home staging, so an `mmdc` failure can never leave required install state unwritten. It is **optional and best-effort**: it attempts `npm install -g @mermaid-js/mermaid-cli` only when npm is available and `mmdc` is missing, and it always continues — a failed or skipped install emits a warning/info line and never fails the install. See [Best-Effort Mermaid CLI Provisioning](../features/mermaid-cli-best-effort-install.md).
 
 ### Environment Variables
 
@@ -109,7 +121,9 @@ Successful install prints a phase-by-phase progress summary:
 ✓ Deployed amplihack → ~/.local/bin/amplihack
 ✓ Deployed amplihack-hooks → ~/.local/bin/amplihack-hooks
 ✓ Deployed amplihack-asset-resolver → ~/.local/bin/amplihack-asset-resolver
-✓ Staged framework assets (47 files, 12 directories)
+✓ Updated shell PATH profile block
+✓ Refreshed amplifier-bundle from current distribution
+✓ Verified Rust amplihack resolves first
 ✓ Created runtime directories
 ✓ Backed up ~/.claude/settings.json → settings.json.backup.1741651200
 ✓ Registered 7 Claude Code hooks
@@ -135,24 +149,30 @@ instead, and install still succeeds:
   ℹ npm not available; skipping mermaid CLI install (pr-guide will fall back to mermaid.ink)
 ```
 
-If `~/.local/bin` is not in `$PATH`, an advisory is printed (install still succeeds):
-
-```
-⚠️  ~/.local/bin is not in $PATH
-    Add: export PATH="$HOME/.local/bin:$PATH"
-```
-
-If another candidate appears earlier on `$PATH`, install prints an advisory
-after deploying the user-local binaries:
+If `~/.local/bin` is not first on `PATH`, install updates the managed profile
+block:
 
 ```text
-⚠️  PATH conflict: /usr/local/bin/amplihack appears before /home/alice/.local/bin/amplihack
-    Your shell may continue to run the stale system binary.
-    Fix: export PATH="$HOME/.local/bin:$PATH" or remove the stale system copy with sudo.
+Updated shell PATH profile block:
+  /home/alice/.bashrc
 ```
 
-This warning does not mean install failed. It means the shell may still resolve
-`amplihack` or `amplihack-hooks` to an older candidate until `PATH` is repaired.
+If a stale Python or uvx wrapper is safely neutralized:
+
+```text
+Quarantined stale amplihack wrapper:
+  /home/alice/.local/share/uv/tools/amplihack/bin/amplihack
+  -> /home/alice/.amplihack/quarantine/stale-wrappers/20260710T183440Z/...
+```
+
+If an unknown executable still shadows the Rust binary, install fails instead
+of pretending the repair succeeded:
+
+```text
+Cannot select Rust amplihack because an unknown executable shadows it:
+  /home/alice/bin/amplihack
+```
+
 See [Install/update PATH conflict reference](./install-update-path-conflicts.md).
 
 ---
@@ -208,14 +228,14 @@ The functions below are in `crates/amplihack-cli/src/commands/install/mod.rs`.
 
 ### `run_install(local: Option<PathBuf>, interactive: bool, force_refresh: bool) -> Result<()>`
 
-Entry point called by the command dispatcher. When `interactive` is true and stdin is a TTY, runs the interactive wizard before proceeding. Canonicalizes and validates `--local` path when provided.
+Entry point called by the command dispatcher. When `interactive` is true and stdin is a TTY, runs the interactive wizard before proceeding. Canonicalizes and validates `--local` path when provided. The install path deploys user-level Rust binaries, neutralizes eligible shadowing stale wrappers, persists PATH precedence, refreshes the framework bundle, and then verifies Rust-first command resolution.
 
 The `force_refresh` parameter controls framework source resolution:
 
 | `force_refresh` | Behavior |
 |-----------------|----------|
-| `false` | **Default.** Resolves a compatible bundled framework root by checking `AMPLIHACK_HOME`, walking up from the current working directory, walking up from the executable path, checking the compile-time workspace root, then checking `~/.amplihack`. Incompatible local candidates are skipped. Falls back to network download only when no compatible local source is found. This is the behavior for standalone `amplihack install` and install runs triggered by self-heal. |
-| `true` | **Skips local bundle resolution entirely.** Goes directly to `download_and_extract_framework_repo()` to fetch a fresh `amplifier-bundle/` from the upstream archive (`REPO_ARCHIVE_URL`). Used by the post-update installer to ensure that `amplihack update` always refreshes stale framework assets rather than re-staging the old bundle that was already present at `~/.amplihack/amplifier-bundle/`. The downloaded source and staged destination are still validated for compatibility. |
+| `false` | **Default.** Resolves compatible current-distribution framework assets, honoring `--local` when supplied and validating every candidate before staging. |
+| `true` | **Bypasses the installed bundle as a source.** Refreshes from the current Rust distribution so `amplihack update` cannot re-stage stale assets already present at `~/.amplihack/amplifier-bundle/`. The source and staged destination are still validated for compatibility. |
 
 **Priority rule:** When `local` is `Some(path)`, it takes precedence over `force_refresh` for source selection, but not for compatibility. The user-specified path must still pass framework bundle validation. This is correct by design: `--local` is an explicit source override, not permission to stage stale smart-orchestrator assets.
 
@@ -224,7 +244,7 @@ The `force_refresh` parameter controls framework source resolution:
 | Caller | `force_refresh` | Rationale |
 |--------|-----------------|-----------|
 | `amplihack install` (command dispatcher) | `false` | Standalone install prefers compatible local sources |
-| `amplihack update` (post-update closure) | `true` | **Root cause fix for issue #675** — forces fresh download |
+| `amplihack update` (post-update closure) | `true` | Forces current-distribution bundle refresh and repair after binary replacement |
 | Self-heal (startup version-stamp check) | `false` | Re-runs install when the version stamp is stale; it benefits from install compatibility validation but does not perform a separate startup compatibility scan |
 | `ensure_framework_installed()` (bootstrap) | `false` | Bootstrap prefers compatible local sources |
 
@@ -259,9 +279,8 @@ Located in `crates/amplihack-cli/src/commands/install/bundle_compat.rs`.
 
 ### `is_compatible_framework_bundle(root: &Path) -> bool`
 
-Boolean helper for local source discovery. Use it to skip optional stale
-candidates such as `AMPLIHACK_HOME` while continuing to the next candidate or
-network fallback. Final staging verification should use
+Boolean helper for source discovery. Use it to reject optional stale candidates
+while continuing to the next current-distribution candidate. Final staging verification should use
 `validate_staged_framework_bundle()` for actionable diagnostics.
 
 Located in `crates/amplihack-cli/src/commands/install/bundle_compat.rs`.
@@ -290,13 +309,37 @@ Returns an actionable error if none of the five locations yield an executable.
 
 ### `deploy_binaries() -> Result<Vec<PathBuf>>`
 
-Copies `amplihack` (current executable) and `amplihack-hooks` (resolved by `find_hooks_binary`) to `~/.local/bin` with `0o755` permissions. When a sibling `amplihack-asset-resolver` binary is present, it is deployed too so launched tools and recipe runs can resolve bundle assets without falling back to Python. Returns the list of deployed paths for inclusion in the manifest.
+Copies `amplihack` (current executable) and `amplihack-hooks` (resolved by
+`find_hooks_binary`) to `~/.local/bin` with `0o755` permissions. When a sibling
+`amplihack-asset-resolver` binary is present, it is deployed too so launched
+tools and recipe runs can resolve bundle assets without falling back to Python.
+Returns the list of deployed paths for inclusion in the manifest.
 
 After deployment, install analyzes ordered `PATH` candidates for `amplihack` and
-`amplihack-hooks`. It warns when a system-managed candidate such as
-`/usr/local/bin/amplihack` shadows the freshly deployed `~/.local/bin` binary or
-when the two binaries resolve from different install roots. The analysis is
-side-effect free; install never removes or rewrites system-managed binaries.
+`amplihack-hooks`, quarantines eligible stale Python/uvx wrappers that shadow
+Rust, persists `~/.local/bin` precedence, refreshes the framework bundle, and
+then verifies the selected `amplihack` is the Rust binary. Unknown or
+inaccessible shadowing candidates are reported and fail the repair if
+Rust-first resolution cannot be guaranteed.
+
+### `neutralize_stale_wrappers(report: &PathConflictReport) -> Result<NeutralizationReport>`
+
+Moves positively identified shadowing stale Python/uvx `amplihack` wrappers into
+`~/.amplihack/quarantine/stale-wrappers/<timestamp>/`. The function re-checks
+basename, safe location, ownership, metadata, and symlink boundaries before
+moving any file. It never mutates system-managed prefixes or unknown
+executables.
+
+Located in `crates/amplihack-cli/src/commands/install/stale_wrappers.rs`.
+
+### `ensure_user_bin_precedence() -> Result<PathPrecedenceReport>`
+
+Writes or updates the managed shell profile block that prepends
+`$HOME/.local/bin` when it is not already first. The detected profile is
+`~/.bashrc` for bash and `~/.zshrc` for zsh. Preserves unrelated profile
+content and returns the file changed.
+
+Located in `crates/amplihack-cli/src/commands/install/paths.rs`.
 
 > **macOS note:** On macOS with System Integrity Protection (SIP) active, copying the running executable to `~/.local/bin` may produce a quarantined binary. See the [First-time install how-to](../howto/first-install.md#macos-sip-note) for the resolution step.
 
@@ -335,7 +378,7 @@ Best-effort provisioning of the Mermaid CLI (`mmdc`, npm `@mermaid-js/mermaid-cl
 - [Best-Effort Mermaid CLI Provisioning](../features/mermaid-cli-best-effort-install.md) — optional `mmdc` install for local mermaid rendering in `pr-guide`
 
 - [Interactive Install](../howto/interactive-install.md) — guided setup wizard walkthrough
-- [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md) — repair stale system binaries that shadow `~/.local/bin`
+- [Repair stale amplihack wrappers and PATH conflicts](../howto/repair-install-update-path-conflicts.md) — quarantine shadowing stale Python/uvx wrappers and keep Rust `amplihack` first
 - [Install/update PATH conflict reference](./install-update-path-conflicts.md) — target selection and resolver API
 - [Hook Specifications](./hook-specifications.md) — the 7 hooks registered by amplihack install
 - [Install Manifest](./install-manifest.md) — manifest schema

--- a/docs/reference/install-update-path-conflicts.md
+++ b/docs/reference/install-update-path-conflicts.md
@@ -1,7 +1,7 @@
 ---
 title: Install/update PATH conflict reference
-description: Reference for amplihack install/update target selection, PATH conflict detection, safe repair behavior, and output regression guarantees.
-last_updated: 2026-06-05
+description: Reference for Rust binary precedence, stale Python/uvx wrapper neutralization, PATH persistence, and install/update repair APIs.
+last_updated: 2026-07-10
 review_schedule: as-needed
 owner: amplihack-maintainers
 doc_type: reference
@@ -9,205 +9,181 @@ doc_type: reference
 
 # Install/update PATH conflict reference
 
-`amplihack install` and `amplihack update` analyze command resolution order
-before reporting binary deployment status or replacing an existing binary. The
-analysis is deterministic, side-effect free, and based on `PATH` order rather
-than only `std::env::current_exe()`.
+`amplihack install` and `amplihack update` make the Rust `amplihack` binary in
+`~/.local/bin` the selected user-level command. They do this by deploying the
+Rust binaries, persistently prepending `$HOME/.local/bin` for future shells,
+neutralizing only positively identified stale Python/uvx wrappers that shadow
+the Rust binary, and failing visibly when an unknown executable would still
+shadow the Rust binary.
+
+The resolver never executes discovered candidates while classifying them.
 
 ## Scope
 
-The conflict detector covers these binary names:
+The repair covers:
 
-| Binary | Purpose |
+| Name | Purpose |
 | --- | --- |
-| `amplihack` | Main CLI and update target |
-| `amplihack-hooks` | Rust-native hook dispatcher used by registered hooks |
+| `amplihack` | Main Rust CLI and update target. |
+| `amplihack-hooks` | Rust hook dispatcher registered in settings files. |
 
-It does not execute discovered binaries. It inspects candidate paths, metadata,
-canonical forms when available, and safe user-level target locations.
+Stale-wrapper neutralization applies only to a file whose basename is exactly
+`amplihack` and that appears before the preferred Rust binary in ordered
+`PATH` resolution. Later stale wrappers are left in place because they do not
+control the command. The installer does not rewrite arbitrary `PATH` entries or
+delete unrelated binaries.
 
-## Preferred install target
+## Install/update order
 
-`~/.local/bin` is the preferred user-local target when it already contains
-current or writable `amplihack` and `amplihack-hooks` binaries.
+Both install and the post-update repair path use the same order:
 
-Target selection uses this priority:
+1. Deploy Rust binaries to `~/.local/bin`.
+2. Analyze ordered `PATH` candidates.
+3. Quarantine stale Python/uvx `amplihack` wrappers only when they shadow the
+   Rust binary, are clearly identified, and are safe to move.
+4. Persist the managed PATH profile block so future shells resolve
+   `$HOME/.local/bin` first.
+5. Refresh `~/.amplihack/amplifier-bundle` from the current Rust distribution.
+6. Verify the selected `amplihack` is the Rust binary.
 
-| Priority | Target | Used when |
+If any required repair cannot be completed and an earlier candidate would still
+shadow the Rust binary, install/update exits non-zero with the conflicting path
+and manual repair guidance.
+
+## Candidate classifications
+
+| Classification | Meaning | Automatic action |
 | --- | --- | --- |
-| 1 | Existing current executable directory | The running binary directory is user-level, user-writable, and not under a denied system prefix. |
-| 2 | `~/.local/bin` | User-local binaries are present or the directory is creatable/writable. |
-| 3 | Manual repair required | The only viable target is under a denied system prefix, system-owned, root-owned, or otherwise unsafe. |
+| `CurrentRustBinary` | The running Rust binary or a binary with the current Rust identity. | Accepted. |
+| `PreferredRustBinary` | The Rust binary deployed to `~/.local/bin/amplihack`. | Accepted and made first for future shells. |
+| `StalePythonWrapper` | A user-controlled wrapper whose content positively identifies old Python amplihack launch behavior. | Quarantined when safe and shadowing Rust. |
+| `StaleUvxWrapper` | A user-controlled wrapper whose content positively identifies uvx/uv wrapper launch behavior for amplihack. | Quarantined when safe and shadowing Rust. |
+| `UnknownExecutable` | An executable named `amplihack` that is not positively identified as Rust or stale wrapper. | Not modified; reported as a conflict if it shadows Rust. |
+| `Inaccessible` | Metadata, ownership, canonicalization, or content could not be inspected. | Not modified; reported with the underlying error. |
 
-A target is **safe for automatic replacement** only when it is under the current
-user's home directory and neither its raw nor canonical path is under a denied
-system prefix. Denied system prefixes include `/usr/local/bin`, `/usr/bin`,
-`/bin`, `/usr/sbin`, `/sbin`, and `/opt`. These prefixes are never written
-automatically, even when filesystem permissions would allow the current user to
-write there.
+## Safe wrapper neutralization
 
-The updater does not invoke `sudo`, change ownership, delete files, or attempt
-privileged temporary-file copies.
+A stale wrapper is eligible for quarantine only when all conditions hold:
 
-## PATH conflict categories
+1. The basename is exactly `amplihack`.
+2. The candidate appears before the preferred Rust `~/.local/bin/amplihack` in
+   the current ordered `PATH`, or is otherwise the command that would be
+   selected before repair.
+3. The path is under a user-controlled or amplihack-managed location, such as
+   `$HOME/.local/bin`, `$HOME/bin`, `$HOME/.cargo/bin`, `$HOME/.local/share`,
+   or `$AMPLIHACK_HOME`.
+4. The file is not under a denied system prefix such as `/usr/bin`,
+   `/usr/local/bin`, `/bin`, `/usr/sbin`, `/sbin`, `/opt`, or a package-manager
+   directory outside `$HOME`.
+5. The file is owned by the current user or otherwise safely movable by the
+   current user.
+6. File content contains positive stale-wrapper evidence, such as a Python
+   shebang plus old amplihack wrapper markers, uvx/uv launch markers, or known
+   package-wrapper boilerplate for the Python amplihack distribution.
+7. Symlinks resolve to a safe target. Ambiguous or escaping symlinks are skipped
+   and reported instead of followed destructively.
 
-| Category | Detection | User-facing behavior |
-| --- | --- | --- |
-| User-local first | `~/.local/bin/<binary>` is the first candidate for both binaries. | No warning. Install/update proceeds normally. |
-| System shadowing user-local | A candidate such as `/usr/local/bin/<binary>` appears before `~/.local/bin/<binary>`. | Warn with the shadowing path and the preferred user-local path. |
-| Duplicate candidates | More than one distinct binary identity exists for a binary after canonical de-duplication. | Warn when the order is ambiguous or could run a stale binary. |
-| System-managed stale candidate | Earlier candidate is under a denied system prefix and a user-local candidate exists. | Prefer safe user-local update when possible; otherwise fail with manual repair guidance. |
-| Mixed binary locations | `amplihack` and `amplihack-hooks` resolve from different install roots. | Warn because hooks may be updated independently from the CLI. |
-
-Canonicalization is best effort. If a path cannot be canonicalized because it
-does not exist or metadata cannot be read, the raw path is still included in the
-report and filesystem errors from later install operations are preserved.
-
-## Duplicate and canonical path handling
-
-The resolver keeps raw `PATH` candidates in shell resolution order for messages,
-then computes a stable identity for duplicate detection:
-
-1. Use the canonical path when both the candidate and its target can be
-   canonicalized.
-2. Otherwise use the normalized raw absolute path.
-
-Candidates with the same canonical identity are treated as aliases of the same
-binary and do not produce duplicate or stale-shadowing warnings by themselves.
-For example, `/usr/local/bin/amplihack` symlinked to
-`/home/alice/.local/bin/amplihack` is not reported as a stale duplicate solely
-because both raw paths appear on `PATH`.
-
-Warnings are emitted when ordered candidates resolve to distinct identities and
-an earlier candidate either creates ambiguous command resolution or is under a
-denied system prefix that shadows a safe user-local target.
-
-## Update behavior
-
-`amplihack update` downloads the new release, verifies it, and replaces only the
-selected safe target.
-
-If the current executable is `/usr/local/bin/amplihack` but
-`~/.local/bin/amplihack` is present and writable, the updater selects the
-user-local target and reports the system conflict instead of trying to write a
-temporary file into `/usr/local/bin`.
-
-Example:
+The neutralizer moves eligible wrappers to:
 
 ```text
-⚠️  PATH conflict: /usr/local/bin/amplihack appears before /home/alice/.local/bin/amplihack
-    Updating user-local target: /home/alice/.local/bin/amplihack
-    To run the updated binary first, move ~/.local/bin earlier in PATH or remove the stale system copy.
+~/.amplihack/quarantine/stale-wrappers/<timestamp>/
 ```
 
-When no safe user-level target exists, update exits non-zero before
-replacement:
+Each quarantine directory includes `manifest.tsv` with:
+
+| Field | Description |
+| --- | --- |
+| `original_path` | Absolute original path. |
+| `quarantined_path` | Sanitized path below the quarantine directory. |
+| `kind` | `StalePythonWrapper` or `StaleUvxWrapper`. |
+| `size` | File size in bytes. |
+| `mtime` | Source file modification time. |
+| `action` | `quarantined`, `skipped`, or `failed`. |
+| `reason` | Classification or failure reason. |
+
+The manifest records metadata only. It does not copy full wrapper contents into
+logs.
+
+## Unknown and system-managed conflicts
+
+Unknown executables are never deleted or quarantined automatically. If an
+unknown executable remains before `~/.local/bin/amplihack` after the managed
+PATH repair, install/update fails with guidance.
+
+System-managed paths are never mutated automatically, even if they are writable:
 
 ```text
-Cannot update amplihack automatically because the resolved target is system-managed:
+/usr/bin
+/usr/local/bin
+/bin
+/usr/sbin
+/sbin
+/opt
+```
+
+Example diagnostic:
+
+```text
+Cannot select Rust amplihack because an unknown executable shadows it:
   /usr/local/bin/amplihack
 
-amplihack does not write system-managed prefixes automatically.
-
-Repair options:
-  1. Move ~/.local/bin before /usr/local/bin in PATH.
-  2. Remove stale system binaries with sudo:
-     sudo rm /usr/local/bin/amplihack /usr/local/bin/amplihack-hooks
-  3. Re-run:
-     hash -r
-     amplihack update
+amplihack did not modify this file. Move ~/.local/bin before /usr/local/bin,
+update the system package, or remove the stale system copy through your normal
+administrative process, then run amplihack install again.
 ```
 
-The error is explicit and actionable. It replaces generic permission-denied
-failures caused by blind temporary-file copies into system-managed directories.
+## PATH persistence
 
-## Install behavior
+Install writes an idempotent managed block to the detected user shell profile:
+`~/.bashrc` for bash and `~/.zshrc` for zsh. If the shell cannot be detected or
+is not supported, install leaves profiles unchanged and prints manual PATH
+guidance instead.
 
-`amplihack install` deploys native binaries to `~/.local/bin` and then analyzes
-`PATH` resolution.
+The block prepends `$HOME/.local/bin` when it is not already first:
 
-When a system binary shadows the deployed user-local binary, install succeeds
-but prints a warning:
-
-```text
-✓ Deployed amplihack → /home/alice/.local/bin/amplihack
-✓ Deployed amplihack-hooks → /home/alice/.local/bin/amplihack-hooks
-⚠️  PATH conflict: /usr/local/bin/amplihack appears before /home/alice/.local/bin/amplihack
-    Your shell may continue to run the stale system binary.
-    Fix: export PATH="$HOME/.local/bin:$PATH" or remove the stale system copy with sudo.
+```bash
+# >>> amplihack path >>>
+case "$PATH" in
+  "$HOME/.local/bin"|"$HOME/.local/bin":*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+# <<< amplihack path <<<
 ```
 
-This is an advisory because the install completed successfully and the repair
-requires either a shell profile change or administrator action.
-
-## Hook behavior
-
-Hook registrations use Rust-native binary subcommands:
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "/home/alice/.local/bin/amplihack-hooks post-tool-use"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-The installer does not deploy or verify Python hook files. The following missing
-file lines are not valid install/update diagnostics:
-
-```text
-session_start.sh ❌
-post_tool_use.sh ❌
-pre_tool_use.sh ❌
-```
-
-Their presence in install/update output is a regression.
+The block is bounded by markers so subsequent installs update it in place. It
+does not remove unrelated `PATH` entries. A later duplicate of
+`$HOME/.local/bin` is harmless because the first occurrence wins.
 
 ## Configuration
 
-No new configuration file is required.
+No new user configuration is required.
 
 | Input | Role |
 | --- | --- |
-| `PATH` | Source of ordered command candidates. |
-| `HOME` | Used to resolve `~/.local/bin`. |
-| Current executable path | Used as a candidate replacement target, not as the sole source of truth. |
-| Filesystem metadata | Used for existence, file type, ownership, and writability checks. |
-| `AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH` | Still applies to `amplihack-hooks` lookup during install. It does not override PATH conflict reporting. |
-
-Recommended shell configuration:
-
-```bash
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-## Implementation surfaces
-
-The feature is intentionally split so install and update share one resolver
-instead of duplicating PATH policy.
-
-| File | Planned role |
-| --- | --- |
-| `crates/amplihack-cli/src/path_conflicts.rs` | Shared side-effect-free resolver, warning formatter, and install target decision API. |
-| `crates/amplihack-cli/src/update/mod.rs` | Exposes update submodules and keeps the resolver available to update orchestration without coupling callers to file layout. |
-| `crates/amplihack-cli/src/update/check.rs` | Calls the resolver before binary replacement, handles `ManualRepairRequired`, and passes the chosen safe target to download/replacement code. |
-| `crates/amplihack-cli/src/update/install.rs` | Replaces only the selected safe target and returns the installed binary path used by post-update install re-exec. |
-| `crates/amplihack-cli/src/commands/install/binary.rs` | Deploys user-local binaries, then invokes PATH analysis for install-time warnings. |
-| `crates/amplihack-cli/src/commands/install/paths.rs` | Owns user-local path construction and safe path helpers reused by the resolver. |
-| `crates/amplihack-cli/src/commands/install/settings.rs` | Ensures hook registrations point at the selected `amplihack-hooks` binary path after install/update repair. |
+| `HOME` | Used to resolve the preferred user bin directory, expected as `~/.local/bin`. |
+| `PATH` | Ordered command candidates for conflict analysis. |
+| `AMPLIHACK_HOME` | Install root for bundle staging and stale-wrapper quarantine; defaults to `~/.amplihack`. |
+| `AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH` | Optional test/CI hint for locating `amplihack-hooks`; does not bypass PATH conflict reporting. |
+| Shell profile file | Installer updates the managed block in `~/.bashrc` for bash or `~/.zshrc` for zsh when the file is writable. |
 
 ## Contributor API
 
 The shared resolver lives in `crates/amplihack-cli/src/path_conflicts.rs`.
+The stale wrapper neutralizer lives in
+`crates/amplihack-cli/src/commands/install/stale_wrappers.rs`.
+
+### `PathCandidateKind`
+
+Classifies an executable candidate.
+
+| Variant | Meaning |
+| --- | --- |
+| `CurrentRustBinary` | Candidate is the running/current Rust binary. |
+| `PreferredRustBinary` | Candidate is the Rust binary in the preferred user bin directory. |
+| `StalePythonWrapper` | Candidate is a positively identified stale Python wrapper. |
+| `StaleUvxWrapper` | Candidate is a positively identified stale uvx wrapper. |
+| `UnknownExecutable` | Candidate is executable but not safely classifiable. |
+| `Inaccessible` | Candidate could not be inspected. |
 
 ### `PathAnalysisInput`
 
@@ -215,15 +191,12 @@ Inputs supplied by install/update callers and tests.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `path_env` | string | Raw `PATH` value to scan in order. |
-| `home_dir` | `PathBuf` | Home directory used to derive preferred user bin. |
+| `path_env` | `String` | Raw `PATH` value to scan in order. |
+| `home_dir` | `PathBuf` | Home directory used to derive `~/.local/bin`. |
+| `amplihack_home` | `PathBuf` | Install root used for quarantine and bundle paths. |
 | `current_exe` | `PathBuf` | Running executable path. |
-| `binary_names` | list | Fixed set: `amplihack`, `amplihack-hooks`. |
-| `filesystem` | trait-backed adapter | Metadata, canonicalization, and writability checks. |
-
-Tests inject temporary directories and filesystem adapters so transition
-coverage is deterministic and does not depend on host `/usr/local/bin`
-permissions.
+| `binary_names` | `Vec<String>` | Normally `amplihack` and `amplihack-hooks`. |
+| `filesystem` | trait-backed adapter | Metadata, canonicalization, ownership, writability, and content inspection. |
 
 ### `BinaryResolution`
 
@@ -232,21 +205,32 @@ Ordered candidate list for one binary.
 | Field | Description |
 | --- | --- |
 | `name` | Binary name. |
-| `candidates` | Existing executable candidates in PATH order. |
-| `first` | First candidate that the shell resolves. |
-| `preferred_user_bin` | Expected `~/.local/bin/<name>` path. |
+| `candidates` | Existing executable candidates in shell resolution order. |
+| `first` | First executable candidate. |
+| `preferred_user_bin` | Expected user-local target. |
 | `shadowed_user_bin` | User-local candidate when another path appears earlier. |
 
 ### `PathConflictReport`
 
-Side-effect-free analysis result consumed by install and update.
+Side-effect-free analysis consumed by install and update.
 
 | Field | Description |
 | --- | --- |
 | `resolutions` | Per-binary command resolution details. |
-| `warnings` | User-facing advisory messages for shadowing, duplicates, and mixed roots. |
-| `has_shadowing` | True when user-local binaries are shadowed by earlier candidates. |
-| `has_ambiguity` | True when multiple candidates create an ambiguous command resolution. |
+| `warnings` | User-facing advisory messages. |
+| `stale_wrappers` | Eligible shadowing stale wrappers, already classified but not moved. |
+| `unknown_conflicts` | Unknown candidates that would shadow the Rust binary. |
+| `inaccessible_conflicts` | Candidates that could not be inspected. |
+| `rust_first_after_repair` | Whether the Rust binary will resolve first after PATH repair and shadowing wrapper quarantine. |
+
+### `StaleWrapperNeutralizer`
+
+Moves eligible shadowing stale wrappers into quarantine and returns a manifest
+summary.
+
+Callers must pass only candidates already classified by the resolver. The
+neutralizer re-checks safe location, basename, metadata, and symlink boundaries
+before moving a file.
 
 ### `InstallTargetDecision`
 
@@ -254,32 +238,43 @@ Decision used by update replacement logic.
 
 | Variant | Meaning |
 | --- | --- |
-| `CurrentExeDir { target }` | Replace the current executable path only when it is a safe user-level target. |
-| `PreferredUserBin { target, warnings }` | Replace the safe user-local target and report conflicts. |
+| `PreferredUserBin { target, warnings }` | Install or replace `~/.local/bin/amplihack`. |
+| `CurrentExeDir { target }` | Reuse the current executable directory only when it is the safe user-level bin directory. |
 | `ManualRepairRequired { attempted_target, guidance }` | Do not replace anything; return actionable guidance. |
 
 Callers must propagate `ManualRepairRequired` as a user-visible error and must
-not fall back to privileged writes.
+not fall back to privileged writes or broad `PATH` cleanup.
 
-## Regression output contract
+### `PathPrecedenceManager`
 
-Install/update smoke tests assert that normal user-facing output does not
-contain:
+Owns profile-file updates. It writes or updates the managed block in the
+detected shell profile and reports which file changed. It must preserve all
+unrelated profile content.
 
-| Forbidden output | Reason |
-| --- | --- |
-| `session_start.sh ❌` | Obsolete Python/shell hook verification. |
-| `post_tool_use.sh ❌` | Obsolete Python/shell hook verification. |
-| `pre_tool_use.sh ❌` | Obsolete Python/shell hook verification. |
-| `profile_management` warning | Old noisy profile-management staging warning. |
-| `Skipping symlink` | Non-actionable copy noise for known-safe bundled symlinks during normal install/update. |
+## Regression coverage
 
-Diagnostic modes may include explicit file-copy details, but normal
-install/update output must stay free of these known regressions.
+Automated tests cover:
+
+1. stale Python wrapper quarantine
+2. stale uvx wrapper quarantine
+3. unknown executable conflict reporting without mutation
+4. safe symlink handling
+5. `$HOME/.local/bin` managed-block prepend idempotence
+6. install selecting the Rust user-level binary after stale wrapper repair
+7. update invoking the new binary's install repair path
+8. no mutation of system-managed paths
+
+Focused validation:
+
+```bash
+cargo test -p amplihack-cli stale_wrapper
+cargo test -p amplihack-cli path_conflicts
+cargo test -p amplihack-cli update_repair
+```
 
 ## See also
 
-- [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md)
+- [Repair stale amplihack wrappers and PATH conflicts](../howto/repair-install-update-path-conflicts.md)
+- [Framework bundle compatibility reference](framework-bundle-compatibility.md)
 - [amplihack install reference](install-command.md)
-- [Binary resolution reference](binary-resolution.md)
 - [Post-update install re-exec](../features/update-reexec-new-binary.md)

--- a/docs/tutorials/repair-install-update-path-conflicts.md
+++ b/docs/tutorials/repair-install-update-path-conflicts.md
@@ -1,156 +1,208 @@
 ---
-title: Tutorial: understand install/update PATH conflicts
-description: Learn how stale system-wide amplihack binaries shadow current user-local binaries and how the repair guidance works.
-last_updated: 2026-06-05
+title: Tutorial: repair stale amplihack wrappers and assets
+description: Learn how install/update keeps the Rust amplihack binary first and refreshes stale framework assets.
+last_updated: 2026-07-10
 review_schedule: as-needed
 owner: amplihack-maintainers
 doc_type: tutorial
 ---
 
-# Tutorial: understand install/update PATH conflicts
+# Tutorial: repair stale amplihack wrappers and assets
 
-This tutorial uses temporary fixture binaries to show how `PATH` order affects
-`amplihack install` and `amplihack update`. It does not modify your real
-`/usr/local/bin` or `~/.local/bin`.
+This tutorial shows the finished install/update behavior using temporary files.
+It does not modify your real shell profile, `~/.local/bin`, or
+`~/.amplihack`.
 
-## What you will learn
+You will create:
 
-You will create two fake install roots:
+1. a stale Python-style `amplihack` wrapper
+2. a user-local Rust-style `amplihack` binary
+3. a stale installed `amplifier-bundle`
+4. the shell profile block that makes future shells resolve the Rust binary first
 
-- a stale system-style root that appears first on `PATH`
-- a current user-style root that appears later on `PATH`
+## Prerequisites
 
-Then you will change `PATH` order and see why `amplihack` prefers safe
-user-local repair instead of writing to system-managed directories.
+- A POSIX shell
+- `mktemp`, `mkdir`, `chmod`, `grep`, and `find`
 
-## 1. Create temporary fake binaries
+## 1. Create a fake stale wrapper and Rust binary
 
 ```bash
 tmpdir="$(mktemp -d)"
-mkdir -p "$tmpdir/system-bin" "$tmpdir/user-bin"
+mkdir -p "$tmpdir/stale-bin" "$tmpdir/home/.local/bin" "$tmpdir/home/.amplihack"
 
-printf '#!/bin/sh\necho stale-system-amplihack\n' > "$tmpdir/system-bin/amplihack"
-printf '#!/bin/sh\necho stale-system-hooks\n' > "$tmpdir/system-bin/amplihack-hooks"
+cat > "$tmpdir/stale-bin/amplihack" <<'SH'
+#!/usr/bin/env python3
+# stale amplihack uvx wrapper
+import sys
+print("stale-python-wrapper")
+SH
 
-printf '#!/bin/sh\necho current-user-amplihack\n' > "$tmpdir/user-bin/amplihack"
-printf '#!/bin/sh\necho current-user-hooks\n' > "$tmpdir/user-bin/amplihack-hooks"
+cat > "$tmpdir/home/.local/bin/amplihack" <<'SH'
+#!/bin/sh
+echo "rust-amplihack"
+SH
 
-chmod +x "$tmpdir/system-bin/amplihack" \
-  "$tmpdir/system-bin/amplihack-hooks" \
-  "$tmpdir/user-bin/amplihack" \
-  "$tmpdir/user-bin/amplihack-hooks"
+chmod +x "$tmpdir/stale-bin/amplihack" "$tmpdir/home/.local/bin/amplihack"
 ```
 
-## 2. Put the stale system root first
+Put the stale wrapper first:
 
 ```bash
-PATH="$tmpdir/system-bin:$tmpdir/user-bin:$PATH" which -a amplihack
-PATH="$tmpdir/system-bin:$tmpdir/user-bin:$PATH" which -a amplihack-hooks
-```
-
-You should see the system-style root before the user-style root:
-
-```text
-/tmp/.../system-bin/amplihack
-/tmp/.../user-bin/amplihack
-/tmp/.../system-bin/amplihack-hooks
-/tmp/.../user-bin/amplihack-hooks
-```
-
-That is the same shape as a real machine where `/usr/local/bin/amplihack`
-appears before `/home/alice/.local/bin/amplihack`.
-
-Run the fake command:
-
-```bash
-PATH="$tmpdir/system-bin:$tmpdir/user-bin:$PATH" amplihack
+PATH="$tmpdir/stale-bin:$tmpdir/home/.local/bin:$PATH" amplihack
 ```
 
 Expected output:
 
 ```text
-stale-system-amplihack
+stale-python-wrapper
 ```
 
-The shell ran the first candidate, even though a newer user-local candidate
-also exists.
+That is the failure shape the installer repairs: a Python or uvx wrapper named
+exactly `amplihack` appears earlier on `PATH` than the Rust binary in
+`~/.local/bin`.
 
-## 3. Put the user root first
+## 2. See the persistent PATH repair
+
+`amplihack install` writes an idempotent managed block to the user's shell
+profile so future shells put `$HOME/.local/bin` first:
 
 ```bash
-PATH="$tmpdir/user-bin:$tmpdir/system-bin:$PATH" which -a amplihack
-PATH="$tmpdir/user-bin:$tmpdir/system-bin:$PATH" amplihack
+cat > "$tmpdir/home/.bashrc" <<'SH'
+# >>> amplihack path >>>
+case "$PATH" in
+  "$HOME/.local/bin"|"$HOME/.local/bin":*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+# <<< amplihack path <<<
+SH
+```
+
+Source the profile with the temporary home:
+
+```bash
+HOME="$tmpdir/home" PATH="$tmpdir/stale-bin:$tmpdir/home/.local/bin:$PATH" \
+  sh -c '. "$HOME/.bashrc"; command -v amplihack; amplihack'
 ```
 
 Expected output:
 
 ```text
-current-user-amplihack
+/tmp/.../home/.local/bin/amplihack
+rust-amplihack
 ```
 
-This is the preferred real configuration:
+The block checks only whether `$HOME/.local/bin` is already first. If it is not
+first, it prepends it. A later duplicate is harmless because shells resolve the
+first matching executable.
+
+## 3. See how stale wrappers are quarantined
+
+When install/update positively identifies a stale Python or uvx wrapper that
+shadows the Rust binary and is in a user-controlled or amplihack-managed
+location, it moves the wrapper under:
+
+```text
+~/.amplihack/quarantine/stale-wrappers/<timestamp>/
+```
+
+The quarantine uses sanitized path names and a manifest instead of deleting the
+file. Simulate the result:
 
 ```bash
-export PATH="$HOME/.local/bin:$PATH"
+stamp="20260710T183440Z"
+quarantine="$tmpdir/home/.amplihack/quarantine/stale-wrappers/$stamp"
+mkdir -p "$quarantine"
+quarantined="$quarantine/stale-bin__amplihack"
+mv "$tmpdir/stale-bin/amplihack" "$quarantined"
+
+cat > "$quarantine/manifest.tsv" <<EOF
+original_path	quarantined_path	kind	size	mtime	action	reason
+$tmpdir/stale-bin/amplihack	$quarantined	StalePythonWrapper	91	2026-07-10T18:34:40Z	quarantined	shadows preferred Rust binary
+EOF
 ```
 
-With that order, `amplihack update` can update the user-local binary and your
-shell will run the updated binary first.
-
-## 4. Map the tutorial to the real repair
-
-In a real conflict, inspect your actual command resolution:
+Check that only the Rust binary remains on the fake `PATH`:
 
 ```bash
-which -a amplihack
-which -a amplihack-hooks
+PATH="$tmpdir/stale-bin:$tmpdir/home/.local/bin:$PATH" command -v amplihack
+PATH="$tmpdir/stale-bin:$tmpdir/home/.local/bin:$PATH" amplihack
 ```
 
-If `/usr/local/bin` appears before `~/.local/bin`, repair it by reordering
-`PATH`:
+Expected output:
+
+```text
+/tmp/.../home/.local/bin/amplihack
+rust-amplihack
+```
+
+Unknown executables are not quarantined. If a file named `amplihack` cannot be
+classified as the current Rust binary, the preferred Rust binary, or a stale
+Python/uvx wrapper, install/update reports it as an unknown conflict and fails
+if it would still shadow the Rust binary.
+
+## 4. See whole-bundle replacement
+
+Create a stale installed bundle:
 
 ```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
-hash -r
+mkdir -p "$tmpdir/home/.amplihack/amplifier-bundle/recipes"
+cat > "$tmpdir/home/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml" <<'YAML'
+name: smart-orchestrator
+steps:
+  - run: python orch_helper.py
+YAML
 ```
 
-Or remove stale system copies when they are not managed by a package manager:
+Create a current distribution bundle:
 
 ```bash
-sudo rm /usr/local/bin/amplihack /usr/local/bin/amplihack-hooks
-hash -r
+mkdir -p "$tmpdir/current/amplifier-bundle/recipes"
+cat > "$tmpdir/current/amplifier-bundle/recipes/smart-orchestrator.yaml" <<'YAML'
+name: "smart-orchestrator"
+steps:
+  - id: "smart-classify-route"
+    type: "recipe"
+    recipe: "smart-classify-route"
+  - id: "smart-execute-routing"
+    type: "recipe"
+    recipe: "smart-execute-routing"
+  - id: "smart-reflect-loop"
+    type: "recipe"
+    recipe: "smart-reflect-loop"
+  - id: "smart-validate-summarize"
+    type: "recipe"
+    recipe: "smart-validate-summarize"
+YAML
 ```
 
-After repair:
+Install/update validates a staged copy from the current Rust distribution and
+then activates the staged bundle as the installed bundle. The real installer
+uses a same-install-root activation step; the temporary commands below only
+build the expected post-repair tree so you can inspect the result. They are not
+the installer algorithm.
 
 ```bash
-amplihack update
-amplihack install
+cp -R "$tmpdir/current/amplifier-bundle" \
+  "$tmpdir/home/.amplihack/amplifier-bundle.after"
 ```
 
-## 5. Clean up the fixture
+Verify the stale active dependency is gone:
+
+```bash
+grep -R "orch_helper.py" "$tmpdir/home/.amplihack/amplifier-bundle.after" || true
+```
+
+Expected output: no matches.
+
+## 5. Clean up
 
 ```bash
 rm -rf "$tmpdir"
 ```
 
-## What clean output means
-
-Clean install/update output contains phase summaries and actionable warnings. It
-does not contain stale hook-file checks such as:
-
-```text
-session_start.sh ❌
-post_tool_use.sh ❌
-pre_tool_use.sh ❌
-```
-
-Those files are not part of the Rust-native hook path. Hook registrations call
-`amplihack-hooks` binary subcommands.
-
 ## See also
 
 - [Repair install/update PATH conflicts](../howto/repair-install-update-path-conflicts.md)
 - [Install/update PATH conflict reference](../reference/install-update-path-conflicts.md)
-- [amplihack install reference](../reference/install-command.md)
+- [Framework bundle compatibility reference](../reference/framework-bundle-compatibility.md)

--- a/tests/integration/active_recipe_guard.rs
+++ b/tests/integration/active_recipe_guard.rs
@@ -1,0 +1,53 @@
+use serde_yaml::Value;
+use std::fs;
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.pop();
+    root.pop();
+    root
+}
+
+#[test]
+fn smart_orchestrator_active_steps_do_not_reference_orch_helper_py_or_helper_path() {
+    let path = workspace_root().join("amplifier-bundle/recipes/smart-orchestrator.yaml");
+    let raw =
+        fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+    let yaml: Value =
+        serde_yaml::from_str(&raw).unwrap_or_else(|err| panic!("parse {}: {err}", path.display()));
+    let steps = yaml
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("smart-orchestrator must have a steps sequence");
+
+    let mut violations = Vec::new();
+    for step in steps {
+        let Some(mapping) = step.as_mapping() else {
+            continue;
+        };
+        let id = mapping
+            .get(Value::String("id".to_string()))
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        for field in ["command", "script", "run"] {
+            let Some(value) = mapping
+                .get(Value::String(field.to_string()))
+                .and_then(Value::as_str)
+            else {
+                continue;
+            };
+            if value.contains("orch_helper.py")
+                || value.contains("resolve-bundle-asset helper-path")
+            {
+                violations.push(format!("{id}.{field}: {value}"));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "active smart-orchestrator executable fields must not depend on orch_helper.py/helper-path:\n{}",
+        violations.join("\n")
+    );
+}

--- a/tests/integration/artifact_guard_workflow_tests.rs
+++ b/tests/integration/artifact_guard_workflow_tests.rs
@@ -187,7 +187,7 @@ fn every_recipe_with_git_add_all_invokes_guard_first() {
 
         let guard_position = text.find("amplihack hygiene artifact-guard");
         for add_position in broad_add_positions {
-            if !guard_position.is_some_and(|guard| guard < add_position) {
+            if guard_position.is_none_or(|guard| guard >= add_position) {
                 missing.push(format!(
                     "{}: missing artifact guard before broad staging at byte {add_position}",
                     path.strip_prefix(workspace_root())


### PR DESCRIPTION
## Root cause

Install/update previously trusted the current PATH and staged framework assets too softly. A stale Python/uvx `amplihack` wrapper earlier on PATH could continue to win after the Rust binary was installed, and stale `~/.amplihack/amplifier-bundle` contents could preserve old smart-orchestrator behavior that still depended on `orch_helper.py`. That made update appear successful while subsequent shells or recipe execution still used stale code/assets.

## Fix

- Always deploy the Rust `amplihack` and companion binaries to the preferred user bin dir (`~/.local/bin`).
- Persist an idempotent managed shell-profile block that prepends `$HOME/.local/bin` for future shells, even when a later PATH entry already mentioned it.
- Quarantine only positively identified stale Python/uvx `amplihack` wrappers in user-controlled or amplihack-managed locations, leaving unknown executables untouched and failing visibly instead of deleting them.
- Preserve the parent PATH for post-update stale-wrapper discovery while running the repair subprocess with user-local Rust bin first.
- Atomically replace `~/.amplihack/amplifier-bundle` from the current distribution and reject stale active smart-orchestrator executable paths.
- Refactor: no-op repairs no longer create empty quarantine directories/manifests; manifests are written only when wrappers are actually quarantined.

## Test evidence

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p amplihack-cli stale_wrapper --quiet`
- `cargo test -p amplihack-cli path_precedence --quiet`
- `cargo test -p amplihack-cli build_install_command --quiet`
- `cargo test --test active_recipe_guard --quiet`
- `cargo test -p amplihack-utils --lib artifact_guard --quiet`
- `cargo test --workspace`

Crusty-old-engineer review returned **HAPPY**.

Note: the first full workspace test run hit a transient artifact-guard tempdir failure; the failed artifact-guard tests passed in isolation and the final full workspace run passed.