### PR TITLE
fix(workflow): auto-initialize workspace in non-git dirs (#900)

### DIFF
--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -129,10 +129,11 @@ context:
   verification_terminal_evidence: ""
 
 steps:
-  # Git precondition handling lives in workflow-prep/step-01: when <cwd> is not
-  # a git work tree it auto-initializes a fresh repo (issue #900) so repo-
-  # creation tasks proceed. Set auto_init_repo="false" for a fail-closed opt-out
-  # that restores the historical hard-fail.
+  # Git precondition handling lives in workflow-prep/step-01: default-workflow
+  # requires a git repo at <cwd>. When <cwd> is not a git work tree it
+  # auto-initializes a fresh repo (issue #900) so repo-creation tasks proceed;
+  # set auto_init_repo="false" for a fail-closed opt-out that restores the
+  # historical hard-fail (`git init` or rerun from a checkout).
   - id: "workflow-prep"
     type: "recipe"
     recipe: "workflow-prep"

--- a/amplifier-bundle/recipes/default-workflow.yaml
+++ b/amplifier-bundle/recipes/default-workflow.yaml
@@ -94,6 +94,8 @@ context:
   allow_no_op: false
   # Skip pre-agent project validation (npm test, build) — default true to avoid blocking on large codebases (see #453)
   skip_pre_agent_validation: "true"
+  # Auto-initialize a git repo when repo_path is not a work tree — default true so repo-creation tasks proceed; set "false" for a fail-closed opt-out (see #900)
+  auto_init_repo: "true"
   design_spec: ""
   documentation: ""
   test_spec: ""
@@ -127,9 +129,10 @@ context:
   verification_terminal_evidence: ""
 
 steps:
-  # Git precondition is enforced in workflow-prep/step-01 before the first
-  # direct git operation: default-workflow requires a git repo at <cwd>; either
-  # `git init` or rerun from a checkout.
+  # Git precondition handling lives in workflow-prep/step-01: when <cwd> is not
+  # a git work tree it auto-initializes a fresh repo (issue #900) so repo-
+  # creation tasks proceed. Set auto_init_repo="false" for a fail-closed opt-out
+  # that restores the historical hard-fail.
   - id: "workflow-prep"
     type: "recipe"
     recipe: "workflow-prep"

--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -121,6 +121,7 @@ steps:
       worktree_setup: "{{worktree_setup}}"
       allow_no_op: "{{allow_no_op}}"
       skip_pre_agent_validation: "{{skip_pre_agent_validation}}"
+      auto_init_repo: "{{auto_init_repo}}"
     output: "round_1_result"
 
   - id: "execute-single-round-1-investigation"
@@ -233,6 +234,7 @@ steps:
       worktree_setup: "{{worktree_setup}}"
       allow_no_op: "{{allow_no_op}}"
       skip_pre_agent_validation: "{{skip_pre_agent_validation}}"
+      auto_init_repo: "{{auto_init_repo}}"
     output: "round_1_result"
 
   - id: "execute-single-fallback-blocked-investigation"
@@ -369,6 +371,7 @@ steps:
       worktree_setup: "{{worktree_setup}}"
       allow_no_op: "{{allow_no_op}}"
       skip_pre_agent_validation: "{{skip_pre_agent_validation}}"
+      auto_init_repo: "{{auto_init_repo}}"
     output: "round_1_result"
 
   - id: "adaptive-execute-investigation"

--- a/amplifier-bundle/recipes/smart-orchestrator.yaml
+++ b/amplifier-bundle/recipes/smart-orchestrator.yaml
@@ -52,6 +52,8 @@ context:
   ops_modified_files: "" # set by ops-file-change-check when Operations modifies files
   # Skip pre-agent project validation (npm test, build) — default true to avoid blocking on large codebases (see #453)
   skip_pre_agent_validation: "true"
+  # Auto-initialize a git repo when repo_path is not a work tree — default true so repo-creation tasks proceed; set "false" for a fail-closed opt-out (see #900)
+  auto_init_repo: "true"
 
 context_validation:
   task_description: "nonempty"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -73,7 +73,10 @@ steps:
   - id: "step-01-prepare-workspace"
     type: "bash"
     command: |
-      cd "$REPO_PATH"
+      # Fail closed: a failed `cd` must NOT fall through to the auto-init path
+      # (issue #900), or `git init` would run in the recipe runner's actual cwd
+      # instead of $REPO_PATH.
+      cd "$REPO_PATH" || { echo "ERROR: step-01-prepare-workspace cannot enter REPO_PATH='$REPO_PATH'" >&2; exit 1; }
       echo "=== Step 1: Preparing Workspace ==="
       echo ""
       echo "Current directory: $(pwd)"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -79,8 +79,20 @@ steps:
       echo "Current directory: $(pwd)"
       echo ""
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        echo "ERROR: step-01-prepare-workspace requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
-        exit 1
+        # Non-git workspace. By default (AUTO_INIT_REPO != "false") we initialize
+        # a fresh repository so repo-creation tasks can proceed. Set
+        # AUTO_INIT_REPO="false" to restore the strict hard-fail behavior for
+        # locked-down/CI contexts (fail-closed opt-out).
+        if [ "${AUTO_INIT_REPO:-true}" = "false" ]; then
+          echo "ERROR: step-01-prepare-workspace requires a git repo at $(pwd) and AUTO_INIT_REPO=false; either \`git init\` or rerun from a checkout" >&2
+          exit 1
+        fi
+        echo "[init] no git repo found — initialized a new one for repo-creation task"
+        # `git init -b main` needs git >= 2.28; fall back for older gits.
+        if ! git init -b main >/dev/null 2>&1; then
+          git init >/dev/null 2>&1
+          git checkout -b main >/dev/null 2>&1 || git symbolic-ref HEAD refs/heads/main >/dev/null 2>&1
+        fi
       fi
       echo "--- Git Status ---"; STATUS_RC=0
       git status || STATUS_RC=$?

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -16,7 +16,6 @@ steps:
   # STEP 0: WORKFLOW PREPARATION (MANDATORY - DO NOT SKIP)
   # Creates tracking structure. Must complete before ANY implementation work.
   # Prevents "completion bias" - ensures mandatory review steps not skipped.
-  # ==========================================================================
   - id: "step-00-workflow-preparation"
     type: "bash"
     command: |
@@ -40,24 +39,9 @@ steps:
       echo "  Step 14: Bump Version (MANDATORY)"
       echo "  Step 15: Commit and Push"
       echo "  Step 16: Open PR as Draft"
-      echo "  Step 17: Review the PR (MANDATORY - 6 sub-steps with verification gate)"
-      echo "    17a: Step 13 Testing-Evidence Gate"
-      echo "    17b: Comprehensive Code Review (reviewer agent)"
-      echo "    17c: Security Review (security agent)"
-      echo "    17d: Philosophy Guardian Review (philosophy-guardian agent)"
-      echo "    17e: Address Blocking Issues (builder agent)"
-      echo "    17f: Verification Gate"
-      echo "  Step 18: Implement Review Feedback (MANDATORY - 5 sub-steps with verification gate)"
-      echo "    18a: Analyze Feedback"
-      echo "    18b: Implement Feedback (builder agent)"
-      echo "    18c: Push Changes"
-      echo "    18d: Respond to Comments"
-      echo "    18e: Verification Gate"
-      echo "  Step 19: Philosophy Compliance Check (4 sub-steps with verification gate)"
-      echo "    19a: Philosophy Review (reviewer agent)"
-      echo "    19b: Pattern Check (patterns agent)"
-      echo "    19c: Zero-BS Verification"
-      echo "    19d: Verification Gate"
+      echo "  Step 17: Review the PR (MANDATORY - 6 sub-steps 17a-17f with verification gate)"
+      echo "  Step 18: Implement Review Feedback (MANDATORY - 5 sub-steps 18a-18e with verification gate)"
+      echo "  Step 19: Philosophy Compliance Check (4 sub-steps 19a-19d with verification gate)"
       echo "  Step 20: Final Cleanup"
       echo "  Step 20c: Quality Audit Loop (3+ cycles, multi-agent validation)"
       echo "  Step 21: Convert PR to Ready"

--- a/docs/howto/create-a-new-repository.md
+++ b/docs/howto/create-a-new-repository.md
@@ -1,0 +1,142 @@
+# Create a New Repository from a Workflow Task
+
+How to run `smart-orchestrator` or `default-workflow` against an empty (non-git)
+directory so the workflow scaffolds a brand-new repository instead of failing at
+the first step.
+
+## Before you start
+
+- `amplihack` is installed (`amplihack --version`)
+- You have a recipe to run (`smart-orchestrator.yaml` or `default-workflow.yaml`)
+- Your task goal is to **create** a new repository — the target directory does
+  not yet contain a `.git` directory
+
+---
+
+## The short version
+
+Auto-init is **on by default**. Point the recipe at any directory — empty or
+not — and step-01 initializes a git repository on the `main` branch when one
+does not already exist. No action needed:
+
+```sh
+amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+  -c task_description="scaffold a new Rust CLI project called widgetron" \
+  -c repo_path="./widgetron"
+```
+
+When step-01 runs against the non-git directory it prints:
+
+```
+[init] no git repo found — initialized a new one for repo-creation task
+```
+
+and continues through the rest of the workflow.
+
+---
+
+## Why this exists
+
+Previously, `workflow-prep` step-01 (`step-01-prepare-workspace`) hard-failed
+with `exit 1` whenever `repo_path` was not inside a git work tree. That guard
+protected real development tasks from running against a stray directory — but it
+also made it impossible to use the workflow for its second major use case:
+creating a repository that does not exist yet (issue #900).
+
+The `auto_init_repo` context variable resolves the conflict. It defaults to
+`"true"`, so:
+
+- **Repo-creation tasks** (empty/non-git dir) → step-01 runs `git init -b main`
+  and proceeds.
+- **Normal development tasks** (existing checkout) → step-01 behavior is
+  unchanged: full status, fetch, and branch diagnostics run exactly as before.
+
+Auto-init never touches an existing `.git` directory. It only fires when there
+is no repository to begin with.
+
+---
+
+## Verify the initialized repository
+
+After the workflow runs (or after step-01 alone), confirm the repo exists on the
+`main` branch:
+
+```sh
+cd ./widgetron
+git rev-parse --is-inside-work-tree   # -> true
+git branch --show-current             # -> main   (unborn until first commit)
+git rev-parse --abbrev-ref HEAD       # -> main
+```
+
+To watch the auto-init happen at runtime, run with `--verbose` and look for the
+`[init]` line in step-01's output:
+
+```sh
+amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+  -c task_description="scaffold a new project" \
+  -c repo_path="./widgetron" \
+  --verbose
+```
+
+---
+
+## Disable auto-init (fail-closed)
+
+In locked-down or CI contexts that must **never** create a repository
+implicitly, set `auto_init_repo="false"` to restore the pre-#900 behavior.
+step-01 then hard-fails on a non-git directory:
+
+```sh
+amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+  -c task_description="refactor auth module" \
+  -c repo_path="." \
+  -c auto_init_repo="false"
+```
+
+With the flag disabled, running against a non-git directory prints:
+
+```
+ERROR: step-01-prepare-workspace requires a git repo at <path>; either `git init` or rerun from a checkout (set auto_init_repo=true to auto-initialize)
+```
+
+and exits `1`.
+
+---
+
+## Permanent override in recipe YAML
+
+To change the default for a specific project, edit the recipe's context block:
+
+```yaml
+# In amplifier-bundle/recipes/smart-orchestrator.yaml
+context:
+  auto_init_repo: "false"   # was "true" — never auto-create repos for this project
+```
+
+Apply the same change in `default-workflow.yaml` if you run that recipe
+directly.
+
+**Trade-off:** With `auto_init_repo="false"`, any task pointed at a directory
+without a `.git` will fail at step-01. Only set this when implicit repo creation
+is genuinely undesirable.
+
+---
+
+## Older git versions
+
+`git init -b main` requires git **2.28+**. step-01 falls back automatically on
+older git (`git init` + `git checkout -b main`, then a `git symbolic-ref HEAD`
+last resort), so the initialized repo always lands on `main` regardless of host
+git version. No configuration is required.
+
+---
+
+## Related
+
+- [auto_init_repo Reference](../reference/auto-init-repo.md) — Type, default,
+  propagation chain, fallback chain, and bash consumption details
+- [Skip Pre-Agent Validation on Large Codebases](./skip-pre-agent-validation.md)
+  — Sibling step-01 context variable
+- [Run a Recipe End-to-End](./run-a-recipe.md) — General recipe execution guide
+- [Troubleshoot Recipe Execution](./troubleshoot-recipe-execution.md) —
+  Diagnosing recipe failures

--- a/docs/reference/auto-init-repo.md
+++ b/docs/reference/auto-init-repo.md
@@ -1,0 +1,264 @@
+# auto_init_repo — Reference
+
+Recipe context variable that controls whether `workflow-prep` step-01
+(`step-01-prepare-workspace`) initializes a new git repository when `repo_path`
+is **not** inside a git work tree. This enables repo-creation tasks — where the
+goal is to produce a brand-new repository — to proceed through the workflow
+instead of hard-failing at the first step (issue #900).
+
+## Contents
+
+- [Motivation](#motivation)
+- [Declaration sites](#declaration-sites)
+- [Type and default](#type-and-default)
+- [Propagation chain](#propagation-chain)
+- [Implementation checklist](#implementation-checklist)
+- [Bash consumption](#bash-consumption)
+- [Auto-init behavior](#auto-init-behavior)
+- [Interaction with other context variables](#interaction-with-other-context-variables)
+- [Override at invocation](#override-at-invocation)
+- [Source](#source)
+
+---
+
+## Motivation
+
+Before this feature, `step-01-prepare-workspace` ran an unconditional guard:
+
+```bash
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "ERROR: step-01-prepare-workspace requires a git repo ..." >&2
+  exit 1
+fi
+```
+
+This hard-fail broke any task whose goal was to **create** a repository: the
+workspace does not yet contain a `.git` directory, so step-01 exited `1` before
+the agent could do any work. The later steps in `workflow-prep.yaml` (the guards
+near the metadata and local-tracking sections) already degrade gracefully for
+non-git directories, so only step-01 needed to change.
+
+`auto_init_repo` replaces the hard-fail with a gated auto-initialization: when
+the workspace is not a git work tree and the flag is enabled (the default),
+step-01 runs `git init -b main`, prints an informational line, and continues.
+
+---
+
+## Declaration sites
+
+The variable is declared in the recipe context blocks that flow into
+`workflow-prep`:
+
+| Recipe | File | Purpose |
+|--------|------|---------|
+| `smart-orchestrator` | `amplifier-bundle/recipes/smart-orchestrator.yaml` | Top-level entry point for `/dev` tasks |
+| `default-workflow` | `amplifier-bundle/recipes/default-workflow.yaml` | 23-step development workflow |
+
+Both declare it identically:
+
+```yaml
+context:
+  auto_init_repo: "true"
+```
+
+---
+
+## Type and default
+
+**Type:** string
+**Default:** `"true"` (auto-init enabled)
+**Valid values:** `"true"` (auto-init a new repo on non-git dirs), `"false"` (restore the pre-#900 hard-fail)
+
+The value is a quoted YAML string, not a native boolean. This matches the
+pattern used by `skip_pre_agent_validation` and `force_single_workstream:
+"false"` and avoids YAML 1.1 boolean parsing quirks (`yes`/`no`/`on`/`off`).
+
+The recipe runner exposes context variables as environment variables, which are
+always strings. Using string type is explicit and prevents type-mismatch
+surprises.
+
+**The default MUST allow repo-creation tasks to proceed.** `"true"` is the
+default so that the common case — an agent asked to scaffold a new project —
+works without any extra flags. Setting the flag to `"false"` is a fail-closed
+opt-out intended for locked-down or CI contexts that must never create a
+repository implicitly.
+
+---
+
+## Propagation chain
+
+The variable flows through the recipe hierarchy the same way
+`skip_pre_agent_validation` does:
+
+```
+smart-orchestrator.yaml          (declares auto_init_repo: "true")
+  └─ smart-execute-routing.yaml  (explicitly forwards in context blocks)
+       └─ default-workflow.yaml  (declares auto_init_repo: "true")
+            └─ workflow-prep.yaml  (consumes as $AUTO_INIT_REPO)
+```
+
+`smart-execute-routing.yaml` explicitly forwards the variable in every
+`context:` block that also forwards `worktree_setup`, `allow_no_op`, and
+`skip_pre_agent_validation`. This defensive pattern ensures the value reaches
+`default-workflow` even if automatic context-merging semantics change.
+
+**This forwarding is load-bearing, not cosmetic.** Auto-init's happy path works
+even without it (an unset `$AUTO_INIT_REPO` is empty → default-allow → auto-init
+fires). But the documented fail-closed opt-out `-c auto_init_repo="false"` only
+takes effect if the value is forwarded end-to-end; without the declaration and
+forwarding, the `"false"` never reaches step-01 and the security control is
+silently inert. See [Implementation checklist](#implementation-checklist).
+
+Intermediate routing recipes (`smart-classify-route.yaml`) pass context through
+without consuming it. If such a recipe introduces a `context:` block that would
+shadow this variable, add explicit forwarding there too.
+
+---
+
+## Implementation checklist
+
+`auto_init_repo` is **not** a single-file change. Because the fail-closed
+opt-out (`-c auto_init_repo="false"`) must reach `workflow-prep` from the CLI
+invocation, the variable has to be declared **and** forwarded through the whole
+recipe chain — exactly like `skip_pre_agent_validation`. Editing only
+`workflow-prep.yaml` leaves the happy path working (empty value → default-allow)
+but makes the documented `"false"` opt-out silently non-functional.
+
+The complete change set is:
+
+| File | Edit | Anchor |
+|------|------|--------|
+| `smart-orchestrator.yaml` | Declare `auto_init_repo: "true"` in the top-level `context:` block | Next to `skip_pre_agent_validation: "true"` (~line 54) |
+| `default-workflow.yaml` | Declare `auto_init_repo: "true"` in the `context:` block | Next to `skip_pre_agent_validation: "true"` (~line 96) |
+| `smart-execute-routing.yaml` | Forward `auto_init_repo: "{{auto_init_repo}}"` in each context block that forwards `skip_pre_agent_validation` | 3 blocks (~lines 123, 235, 371) |
+| `workflow-prep.yaml` | Consume `$AUTO_INIT_REPO` in the step-01 work-tree guard | `step-01-prepare-workspace` |
+
+Regression coverage lives in
+`tests/integration/workflow_prep_git_recovery_test.rs` (auto-init path,
+disabled-flag hard-fail, unchanged existing-checkout path).
+
+---
+
+## Bash consumption
+
+`workflow-prep.yaml` step-01 (`step-01-prepare-workspace`) reads the variable as
+`$AUTO_INIT_REPO` inside the work-tree guard, after `cd "$REPO_PATH"`:
+
+```bash
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if [ "$AUTO_INIT_REPO" = "false" ]; then
+    echo "ERROR: step-01-prepare-workspace requires a git repo at $(pwd); either \`git init\` or rerun from a checkout (set auto_init_repo=true to auto-initialize)" >&2
+    exit 1
+  fi
+  echo "[init] no git repo found — initialized a new one for repo-creation task"
+  git init -b main >/dev/null 2>&1 \
+    || { git init >/dev/null 2>&1 && git checkout -b main >/dev/null 2>&1; } \
+    || git symbolic-ref HEAD refs/heads/main
+fi
+# ... existing status / fetch / branch diagnostics run unchanged ...
+```
+
+**Default-allow semantics:** Auto-init runs unless it is explicitly disabled via
+`"false"`. Empty, unset, or any other value — including the default `"true"` —
+enables auto-init. This is intentional: repo-creation tasks are a first-class
+use case and must proceed without extra flags.
+
+**Idempotent and non-destructive:** The auto-init block only runs when
+`git rev-parse --is-inside-work-tree` fails — i.e., there is no existing repo.
+It never re-initializes or clobbers a `.git` directory in a real checkout. For
+real checkouts, step-01 behavior is byte-for-byte unchanged: status, fetch (with
+the ADO-remote remediation hints), and current-branch diagnostics all run as
+before.
+
+**Security:** `$REPO_PATH` and `$AUTO_INIT_REPO` are always double-quoted in
+bash to prevent word splitting on empty or malformed values. Only strict string
+equality `= "false"` is used — never `eval`, pattern matching, or unquoted
+comparison. The initial branch name is a hard-coded literal `main` and is never
+derived from an environment variable.
+
+---
+
+## Auto-init behavior
+
+When auto-init fires, step-01:
+
+1. Prints the informational line
+   `[init] no git repo found — initialized a new one for repo-creation task`
+   to stdout (not stderr — this is normal, expected behavior, not a warning).
+2. Creates a new repository on the `main` branch in `$REPO_PATH`.
+3. Continues into the existing status / fetch / branch diagnostics, which now
+   operate against the freshly-initialized repo (empty status, no remote to
+   fetch — both handled gracefully by the existing `|| WARNING` guards).
+
+### Initial-branch fallback chain
+
+`git init -b <branch>` requires git **2.28+**. To remain portable on older git,
+step-01 uses a three-tier fallback:
+
+| Tier | Command | Applies to |
+|------|---------|-----------|
+| 1 | `git init -b main` | git ≥ 2.28 |
+| 2 | `git init` then `git checkout -b main` | older git, no commits yet |
+| 3 | `git symbolic-ref HEAD refs/heads/main` | last-resort HEAD retarget |
+
+All three converge on an unborn `main` branch, so downstream steps see a
+consistent default branch regardless of the host git version.
+
+---
+
+## Interaction with other context variables
+
+| Variable | Relationship |
+|----------|-------------|
+| `skip_pre_agent_validation` | Independent. Uses the same string-as-boolean pattern. `auto_init_repo` gates the work-tree guard at the top of step-01; `skip_pre_agent_validation` gates the validation block at the bottom of step-01. |
+| `force_single_workstream` | Independent. Same string-as-boolean pattern. |
+| `allow_no_op` | Independent. `allow_no_op` opts out of the step-08c work-verifier; `auto_init_repo` controls step-01 repo initialization. |
+| `worktree_setup` | Independent. Both are explicitly forwarded in `smart-execute-routing.yaml`. When `worktree_setup` provisions a worktree, that worktree is already a git work tree, so auto-init does not fire. |
+
+---
+
+## Override at invocation
+
+Auto-init is enabled by default, so repo-creation tasks need no extra flags:
+
+```sh
+amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+  -c task_description="scaffold a new Rust CLI project" \
+  -c repo_path="./my-new-project"
+```
+
+To disable auto-init and restore the pre-#900 hard-fail (fail-closed for
+locked-down or CI contexts that must never create a repository):
+
+```sh
+amplihack recipe run amplifier-bundle/recipes/smart-orchestrator.yaml \
+  -c task_description="refactor auth module" \
+  -c repo_path="." \
+  -c auto_init_repo="false"
+```
+
+To restore the default (auto-init enabled), omit the flag or set it explicitly:
+
+```sh
+-c auto_init_repo="true"
+```
+
+---
+
+## Source
+
+- `amplifier-bundle/recipes/smart-orchestrator.yaml` — context declaration
+- `amplifier-bundle/recipes/default-workflow.yaml` — context declaration
+- `amplifier-bundle/recipes/smart-execute-routing.yaml` — explicit forwarding
+- `amplifier-bundle/recipes/workflow-prep.yaml` — bash consumption in step-01
+- `tests/integration/workflow_prep_git_recovery_test.rs` — regression tests for
+  the auto-init path, the disabled-flag hard-fail, and the unchanged
+  existing-checkout path
+
+## Related
+
+- [Create a New Repository from a Workflow Task](../howto/create-a-new-repository.md) — Step-by-step guide for repo-creation tasks
+- [skip_pre_agent_validation Reference](./skip-pre-agent-validation.md) — Sibling step-01 context variable using the same pattern
+- [Recipe Executor Environment](./recipe-executor-environment.md) — How context variables become environment variables in shell steps
+- [Environment Variables](./environment-variables.md) — All variables read or injected by `amplihack`
+- [Troubleshoot Recipe Execution](../howto/troubleshoot-recipe-execution.md) — Common recipe failure modes

--- a/tests/integration/workflow_prep_git_recovery_test.rs
+++ b/tests/integration/workflow_prep_git_recovery_test.rs
@@ -242,6 +242,32 @@ fn prepare_workspace_preserves_existing_checkout_diagnostics() {
     );
 }
 
+#[test]
+fn prepare_workspace_fails_closed_when_repo_path_is_invalid() {
+    // A failed `cd` must fail closed: otherwise the #900 auto-init path would
+    // run `git init` in the recipe runner's actual cwd instead of REPO_PATH.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let missing = temp.path().join("does-not-exist");
+
+    let output = run_prepare_workspace_real_git(&missing, None);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "invalid REPO_PATH must fail closed, not silently continue; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("cannot enter REPO_PATH"),
+        "failed cd must emit an explicit error; stderr:\n{stderr}"
+    );
+    assert!(
+        !missing.join(".git").exists() && !temp.path().join(".git").exists(),
+        "failed cd must not leak a .git into REPO_PATH or its parent; stderr:\n{stderr}"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Issue #582: recoverable-diagnostic contract (unchanged)
 // ─────────────────────────────────────────────────────────────────────────

--- a/tests/integration/workflow_prep_git_recovery_test.rs
+++ b/tests/integration/workflow_prep_git_recovery_test.rs
@@ -1,5 +1,12 @@
 //! Issue #582: workspace preparation must distinguish hard repository
 //! validation from recoverable git probes.
+//!
+//! Issue #900: `step-01-prepare-workspace` must NOT hard-fail on non-git
+//! workspaces. When `REPO_PATH` is not inside a git work tree it must
+//! initialize a fresh repo (`git init -b main`), print a clear informational
+//! line, and CONTINUE — so repo-creation tasks can proceed. The auto-init is
+//! gated by `AUTO_INIT_REPO` (default enabled); `AUTO_INIT_REPO=false`
+//! restores the historical hard-fail for locked-down contexts.
 
 use serde::Deserialize;
 use std::io::Write;
@@ -58,6 +65,8 @@ fn write_executable(path: &Path, content: &str) {
     std::fs::set_permissions(path, perms).expect("chmod executable");
 }
 
+/// Run step-01 with a *fake* `git` on PATH, driven by the provided shell
+/// script. Used to model recoverable diagnostic failures deterministically.
 fn run_prepare_workspace(fake_git: &str) -> Output {
     let temp = tempfile::tempdir().expect("tempdir");
     let bin_dir = temp.path().join("bin");
@@ -86,6 +95,157 @@ fn run_prepare_workspace(fake_git: &str) -> Output {
         .expect("run workflow-prep step")
 }
 
+/// Run step-01 with the *real* `git` in `repo_path`. `auto_init` controls the
+/// `AUTO_INIT_REPO` env var (`None` leaves it unset to exercise the default).
+fn run_prepare_workspace_real_git(repo_path: &Path, auto_init: Option<&str>) -> Output {
+    let command = step_command("workflow-prep", "step-01-prepare-workspace");
+
+    let mut cmd = Command::new("bash");
+    cmd.arg("-c")
+        .arg(command)
+        .env("REPO_PATH", repo_path)
+        .env("TASK_DESCRIPTION", "issue #900 repo-creation task")
+        .env("SKIP_PRE_AGENT_VALIDATION", "true")
+        // Keep git deterministic/offline regardless of host config.
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    match auto_init {
+        Some(value) => {
+            cmd.env("AUTO_INIT_REPO", value);
+        }
+        None => {
+            cmd.env_remove("AUTO_INIT_REPO");
+        }
+    }
+
+    cmd.output().expect("run workflow-prep step (real git)")
+}
+
+/// Create a real git checkout on `main` with one commit, to model an existing
+/// repository for the "preserve existing behavior" contract.
+fn init_real_checkout(dir: &Path) {
+    let ok = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("run git setup");
+        assert!(status.success(), "git {args:?} failed setting up checkout");
+    };
+    ok(&["init", "-b", "main"]);
+    ok(&["config", "user.email", "test@example.com"]);
+    ok(&["config", "user.name", "Test"]);
+    ok(&["commit", "--allow-empty", "-m", "seed"]);
+}
+
+fn current_branch(dir: &Path) -> String {
+    // Use symbolic-ref so this resolves correctly on an *unborn* branch
+    // (freshly `git init`ed repo with no commits yet), where
+    // `rev-parse --abbrev-ref HEAD` would report "HEAD".
+    let out = Command::new("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .expect("git symbolic-ref");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Issue #900: auto-init contract
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn prepare_workspace_auto_inits_repo_in_non_git_dir() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path();
+
+    let output = run_prepare_workspace_real_git(repo, None); // default enabled
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "non-git workspace must auto-init and continue (issue #900); stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        repo.join(".git").exists(),
+        "step-01 must initialize a real .git directory in a non-git workspace; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        current_branch(repo),
+        "main",
+        "auto-initialized repo must be on the `main` branch"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("[init]") && combined.contains("no git repo found"),
+        "auto-init must print a clear informational line about initializing a new repo; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn prepare_workspace_hard_fails_when_auto_init_disabled() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path();
+
+    let output = run_prepare_workspace_real_git(repo, Some("false"));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "AUTO_INIT_REPO=false must restore the historical hard-fail for non-git paths; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !repo.join(".git").exists(),
+        "disabled auto-init must NOT create a .git directory; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("requires a git repo"),
+        "disabled auto-init failure should stay explicit; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn prepare_workspace_preserves_existing_checkout_diagnostics() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path();
+    init_real_checkout(repo);
+
+    let output = run_prepare_workspace_real_git(repo, None);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "existing checkout must continue to succeed; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        !combined.contains("[init]"),
+        "existing checkout must NOT trigger the auto-init path; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("--- Git Status ---") && stdout.contains("--- Current Branch ---"),
+        "existing checkout must preserve the status/branch diagnostics; stdout:\n{stdout}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Issue #582: recoverable-diagnostic contract (unchanged)
+// ─────────────────────────────────────────────────────────────────────────
+
 #[test]
 fn prepare_workspace_continues_when_git_status_exits_128_after_repo_validation() {
     let output = run_prepare_workspace(
@@ -110,30 +270,6 @@ esac
     assert!(
         stderr.contains("git status failed") && stderr.contains("continuing"),
         "recoverable status failure must emit clear degraded-diagnostics warning; stderr:\n{stderr}"
-    );
-}
-
-#[test]
-fn prepare_workspace_still_fails_for_non_git_paths() {
-    let output = run_prepare_workspace(
-        r#"#!/bin/sh
-if [ "$1:$2" = "rev-parse:--is-inside-work-tree" ]; then
-  echo "fatal: not a git repository" >&2
-  exit 128
-fi
-echo "unexpected git invocation: $*" >&2
-exit 2
-"#,
-    );
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        !output.status.success(),
-        "hard repo validation must still fail for non-git paths"
-    );
-    assert!(
-        stderr.contains("requires a git repo"),
-        "non-git failure should stay explicit; stderr:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #900. `step-01-prepare-workspace` now auto-initializes a git repository when invoked in a non-git directory, instead of failing. The behavior is opt-out via `-c auto_init_repo=false`, wired through the full recipe chain (mirrors `skip_pre_agent_validation`).

## Changes

| Commit | Fix |
|--------|-----|
| `8f5a38db` | Auto-init workspace in non-git dirs (step-01) |
| `8e3be635` | Wire `auto_init_repo` through recipe chain so `-c auto_init_repo=false` opt-out reaches step-01 |
| `b7adea77` | Fail closed on invalid `REPO_PATH` (prevents `git init` in the wrong dir) + regression test |

## Review feedback addressed

- **High** — inert security opt-out: fixed, forwarding mirrors `skip_pre_agent_validation`.
- **Medium** — swallowed `cd` failure (Zero-BS violation): fixed with a fail-closed guard + test.

## Testing

`cargo test -p amplihack --test workflow_prep_git_recovery` — **6 passed, 0 failed**.

- `prepare_workspace_auto_inits_repo_in_non_git_dir`
- `prepare_workspace_hard_fails_when_auto_init_disabled`
- `prepare_workspace_fails_closed_when_repo_path_is_invalid`
- `prepare_workspace_continues_when_git_status_exits_128_after_repo_validation`
- `prepare_workspace_preserves_existing_checkout_diagnostics`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>