### PR TITLE
Update Cargo.lock with 20 changed files (#903)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ version = "0.11.1"
 dependencies = [
  "amplihack-cli",
  "amplihack-security",
+ "amplihack-signal",
  "amplihack-state",
  "amplihack-types",
  "amplihack-utils",
@@ -271,10 +272,12 @@ name = "amplihack-hooks-bin"
 version = "0.11.1"
 dependencies = [
  "amplihack-hooks",
+ "amplihack-signal",
  "amplihack-state",
  "amplihack-types",
  "anyhow",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]
@@ -426,6 +429,20 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "amplihack-signal"
+version = "0.11.1"
+dependencies = [
+ "amplihack-state",
+ "amplihack-types",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 
@@ -2167,6 +2184,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sqlite-wasm-rs"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2379,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/amplihack-remote",
     "crates/amplihack-orchestration",
     "crates/amplihack-session",
+    "crates/amplihack-signal",
     "bins/amplihack",
     "bins/amplihack-asset-resolver",
     "bins/amplihack-hooks",
@@ -82,6 +83,7 @@ amplihack-agent-core = { path = "crates/amplihack-agent-core" }
 amplihack-domain-agents = { path = "crates/amplihack-domain-agents" }
 amplihack-hive = { path = "crates/amplihack-hive" }
 amplihack-agent-generator = { path = "crates/amplihack-agent-generator" }
+amplihack-signal = { path = "crates/amplihack-signal" }
 
 # Shrink local/dev/CI debug builds. This workspace has 26 crates and ~155
 # integration-test binaries; the default `debug = true` emits full DWARF

--- a/bins/amplihack-hooks/Cargo.toml
+++ b/bins/amplihack-hooks/Cargo.toml
@@ -13,13 +13,22 @@ path = "src/main.rs"
 amplihack-types = { workspace = true }
 amplihack-state = { workspace = true }
 amplihack-hooks = { workspace = true }
+amplihack-signal = { workspace = true, optional = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+[features]
+default = []
+# Forwards to amplihack-hooks/signal so the `signal-subscriber` subcommand and
+# per-session Signal channel are compiled into the multicall binary.
+signal = ["amplihack-hooks/signal", "dep:amplihack-signal", "amplihack-signal/signal"]
+
 [dev-dependencies]
 serde_json = { workspace = true }
+tempfile = { workspace = true }
+amplihack-signal = { workspace = true }
 
 [[test]]
 name = "hook_dispatch"
@@ -28,3 +37,11 @@ path = "../../tests/integration/hook_dispatch_test.rs"
 [[test]]
 name = "hook_aliases"
 path = "../../tests/integration/hook_aliases_test.rs"
+
+# Subscriber integration test: spawns the real `amplihack-hooks signal-subscriber`
+# subcommand (resolved via CARGO_BIN_EXE) against a mock signal-cli daemon and
+# asserts a gate-accepted operator message lands in the file inbox. Gated: the
+# file compiles to nothing without `--features signal`.
+[[test]]
+name = "signal_subscriber_it"
+path = "tests/signal_subscriber_it.rs"

--- a/bins/amplihack-hooks/tests/signal_subscriber_it.rs
+++ b/bins/amplihack-hooks/tests/signal_subscriber_it.rs
@@ -1,0 +1,115 @@
+//! Integration test for the `amplihack-hooks signal-subscriber` subcommand.
+//!
+//! Spawns the real multicall binary (resolved via `CARGO_BIN_EXE_amplihack-hooks`)
+//! pointed at a mock signal-cli JSON-RPC daemon, and asserts that a gate-accepted
+//! operator message (device 1, allowlisted sender, matching group id) is appended
+//! to the per-session file inbox. Only compiled with `--features signal`.
+#![cfg(feature = "signal")]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use amplihack_signal::session_channel::Inbox;
+
+const OPERATOR: &str = "+15551239999";
+const ACCOUNT: &str = "+15551230000";
+const GROUP_ID: &str = "SESSION_GROUP_ID_AAA==";
+
+/// A blocking, single-connection mock signal-cli daemon.
+///
+/// On connect it immediately pushes one inbound group message (device 1), then
+/// replies `{}` to any client request until the client disconnects. Returns the
+/// bound `host:port`.
+fn spawn_mock_daemon() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((stream, _)) = listener.accept() {
+            let mut writer = stream.try_clone().unwrap();
+            // Push a realistic inbound group message from the operator's phone.
+            let notification = serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "receive",
+                "params": {
+                    "envelope": {
+                        "source": OPERATOR,
+                        "sourceNumber": OPERATOR,
+                        "sourceDevice": 1,
+                        "timestamp": 1720000000000i64,
+                        "dataMessage": {
+                            "message": "deploy the staging branch",
+                            "groupInfo": { "groupId": GROUP_ID }
+                        }
+                    }
+                }
+            });
+            let mut line = serde_json::to_vec(&notification).unwrap();
+            line.push(b'\n');
+            let _ = writer.write_all(&line);
+            let _ = writer.flush();
+
+            // Drain and ack any requests the subscriber sends (e.g. subscribe).
+            let reader = BufReader::new(stream);
+            for req_line in reader.lines() {
+                let Ok(req_line) = req_line else { break };
+                if req_line.trim().is_empty() {
+                    continue;
+                }
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&req_line) {
+                    let id = v.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let resp = serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": {} });
+                    let mut bytes = serde_json::to_vec(&resp).unwrap();
+                    bytes.push(b'\n');
+                    let _ = writer.write_all(&bytes);
+                    let _ = writer.flush();
+                }
+            }
+        }
+    });
+    format!("{}:{}", addr.ip(), addr.port())
+}
+
+#[test]
+fn accepted_operator_message_lands_in_inbox() {
+    let endpoint = spawn_mock_daemon();
+    let tmp = tempfile::tempdir().unwrap();
+    let inbox_path = tmp.path().join("inbox.json");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_amplihack-hooks"))
+        .arg("signal-subscriber")
+        .arg("--session-id")
+        .arg("it-session")
+        .arg("--group-id")
+        .arg(GROUP_ID)
+        .arg("--inbox")
+        .arg(&inbox_path)
+        .env("AMPLIHACK_SIGNAL_ENDPOINT", &endpoint)
+        .env("AMPLIHACK_SIGNAL_ACCOUNT", ACCOUNT)
+        .env("AMPLIHACK_SIGNAL_ALLOWLIST", OPERATOR)
+        .spawn()
+        .expect("spawn signal-subscriber subcommand");
+
+    // Poll the inbox until the message is delivered or we time out.
+    let inbox = Inbox::new(&inbox_path);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut delivered = Vec::new();
+    while Instant::now() < deadline {
+        if let Ok(entries) = inbox.peek() {
+            if !entries.is_empty() {
+                delivered = entries;
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert_eq!(delivered.len(), 1, "exactly one accepted message expected");
+    assert_eq!(delivered[0].source, OPERATOR);
+    assert_eq!(delivered[0].body, "deploy the staging branch");
+}

--- a/crates/amplihack-hooks/Cargo.toml
+++ b/crates/amplihack-hooks/Cargo.toml
@@ -12,6 +12,7 @@ amplihack-cli = { workspace = true }
 amplihack-security = { workspace = true }
 amplihack-workflows = { workspace = true }
 amplihack-utils = { workspace = true }
+amplihack-signal = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
@@ -20,6 +21,12 @@ tracing = { workspace = true }
 shell-words = { workspace = true }
 regex = "1"
 sha2 = { workspace = true }
+
+[features]
+default = []
+# Enables the per-session Signal channel wiring (SessionStart create+announce+
+# spawn subscriber, inbox drain into additionalContext, Stop quit+kill).
+signal = ["dep:amplihack-signal", "amplihack-signal/signal"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/amplihack-signal/Cargo.toml
+++ b/crates/amplihack-signal/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "amplihack-signal"
+description = "Feature-gated per-session Signal channel for amplihack (config, transport, gating, session channel)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+amplihack-types = { workspace = true }
+amplihack-state = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+# tokio is pulled in ONLY under the `signal` feature so default builds add no
+# async runtime and no signal-cli transport dependency.
+tokio = { workspace = true, features = ["net", "io-util", "time", "rt", "rt-multi-thread", "macros"], optional = true }
+
+[features]
+default = []
+signal = ["dep:tokio"]
+
+[dev-dependencies]
+tempfile = { workspace = true }
+serde_json = { workspace = true }
+
+# Integration test exercising the async TCP JSON-RPC client + file inbox against
+# a mock signal-cli server. Only meaningful with the `signal` feature; compiles
+# to an empty binary otherwise (file is guarded by `#![cfg(feature = "signal")]`).
+[[test]]
+name = "session_channel_it"
+path = "tests/session_channel_it.rs"

--- a/crates/amplihack-signal/src/config.rs
+++ b/crates/amplihack-signal/src/config.rs
@@ -1,0 +1,281 @@
+//! Env-first Signal configuration resolver.
+//!
+//! Precedence is **env > file > explicit error**. A missing *required* value is
+//! always a hard [`ConfigError`], never a silent default. An *empty* allowlist
+//! parses successfully to the empty set — that is the fail-closed default
+//! (nobody is trusted) and is deliberately NOT an error.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Env var: `host:port` of the signal-cli JSON-RPC daemon. Required.
+pub const ENV_ENDPOINT: &str = "AMPLIHACK_SIGNAL_ENDPOINT";
+/// Env var: operator's own E.164 account. Required.
+pub const ENV_ACCOUNT: &str = "AMPLIHACK_SIGNAL_ACCOUNT";
+/// Env var: comma-separated E.164 allowlist. Empty string => fail-closed set.
+pub const ENV_ALLOWLIST: &str = "AMPLIHACK_SIGNAL_ALLOWLIST";
+/// Env var: optional bot own device id (>= 2) for defence-in-depth loop guard.
+pub const ENV_OWN_DEVICE_ID: &str = "AMPLIHACK_SIGNAL_OWN_DEVICE_ID";
+/// Env var: echo-suppression TTL in seconds. Optional (default 30).
+pub const ENV_ECHO_TTL_SECS: &str = "AMPLIHACK_SIGNAL_ECHO_TTL_SECS";
+/// Env var: group mode, `per-session` (default) or `rolling`.
+pub const ENV_GROUP_MODE: &str = "AMPLIHACK_SIGNAL_GROUP_MODE";
+/// Env var: rolling group id. Required only when group mode = rolling.
+pub const ENV_ROLLING_GROUP_ID: &str = "AMPLIHACK_SIGNAL_ROLLING_GROUP_ID";
+/// Env var: max inbound frame size in bytes. Optional (default 1 MiB).
+pub const ENV_MAX_FRAME_BYTES: &str = "AMPLIHACK_SIGNAL_MAX_FRAME_BYTES";
+
+/// Default echo-suppression TTL (seconds) when unset.
+pub const DEFAULT_ECHO_TTL_SECS: u64 = 30;
+/// Default maximum inbound frame size (1 MiB) when unset.
+pub const DEFAULT_MAX_FRAME_BYTES: usize = 1024 * 1024;
+
+/// How per-session Signal groups are managed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupMode {
+    /// Create a fresh group per session and `quitGroup` on Stop.
+    PerSession,
+    /// Reuse a single rolling group; never create, never quit.
+    Rolling,
+}
+
+/// Fully resolved, validated Signal configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignalConfig {
+    /// `host:port` of the signal-cli JSON-RPC daemon.
+    pub endpoint: String,
+    /// Operator's own E.164 account.
+    pub account: String,
+    /// Trusted E.164 senders. Empty = fail-closed (nobody trusted).
+    pub allowlist: Vec<String>,
+    /// Optional bot own device id (>= 2) for the loop guard.
+    pub own_device_id: Option<u32>,
+    /// Echo-suppression TTL window.
+    pub echo_ttl: Duration,
+    /// Group management mode.
+    pub group_mode: GroupMode,
+    /// Rolling group id (present iff `group_mode == Rolling`).
+    pub rolling_group_id: Option<String>,
+    /// Max inbound frame size accepted by the transport parser.
+    pub max_frame_bytes: usize,
+}
+
+/// Configuration resolution failure. Surfaced explicitly — never swallowed.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ConfigError {
+    /// A required variable was not set in env or file.
+    #[error("required signal config var {0} is not set")]
+    MissingRequired(String),
+    /// A value was present but failed validation.
+    #[error("invalid value for {var}: {reason}")]
+    Invalid {
+        /// The offending variable name.
+        var: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+}
+
+impl SignalConfig {
+    /// Resolve from the process environment.
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let vars: HashMap<String, String> = std::env::vars().collect();
+        Self::resolve_from(&vars)
+    }
+
+    /// Resolve from an explicit variable map (env layer already merged over the
+    /// optional file layer by the caller). This is the pure, test-friendly seam.
+    pub fn resolve_from(_vars: &HashMap<String, String>) -> Result<Self, ConfigError> {
+        todo!("implement env>file>error resolution (P1)")
+    }
+}
+
+/// Validate an E.164 phone number (`+` followed by 7-15 digits).
+pub fn is_valid_e164(_value: &str) -> bool {
+    todo!("implement E.164 validation (P1)")
+}
+
+/// Parse a comma-separated allowlist. Empty/whitespace => empty (fail-closed).
+/// Every entry must be valid E.164 or the whole parse fails.
+pub fn parse_allowlist(_raw: &str) -> Result<Vec<String>, ConfigError> {
+    todo!("implement allowlist parsing (P1)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_vars() -> HashMap<String, String> {
+        let mut v = HashMap::new();
+        v.insert(ENV_ENDPOINT.into(), "127.0.0.1:7583".into());
+        v.insert(ENV_ACCOUNT.into(), "+15551230000".into());
+        v.insert(ENV_ALLOWLIST.into(), "+15551239999".into());
+        v
+    }
+
+    #[test]
+    fn resolves_minimal_valid_config() {
+        let cfg = SignalConfig::resolve_from(&base_vars()).expect("valid config");
+        assert_eq!(cfg.endpoint, "127.0.0.1:7583");
+        assert_eq!(cfg.account, "+15551230000");
+        assert_eq!(cfg.allowlist, vec!["+15551239999".to_string()]);
+        assert_eq!(cfg.group_mode, GroupMode::PerSession);
+        assert_eq!(cfg.echo_ttl, Duration::from_secs(DEFAULT_ECHO_TTL_SECS));
+        assert_eq!(cfg.max_frame_bytes, DEFAULT_MAX_FRAME_BYTES);
+        assert_eq!(cfg.own_device_id, None);
+        assert_eq!(cfg.rolling_group_id, None);
+    }
+
+    #[test]
+    fn missing_account_is_hard_error() {
+        let mut vars = base_vars();
+        vars.remove(ENV_ACCOUNT);
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert_eq!(err, ConfigError::MissingRequired(ENV_ACCOUNT.to_string()));
+    }
+
+    #[test]
+    fn missing_endpoint_is_hard_error() {
+        let mut vars = base_vars();
+        vars.remove(ENV_ENDPOINT);
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert_eq!(err, ConfigError::MissingRequired(ENV_ENDPOINT.to_string()));
+    }
+
+    #[test]
+    fn missing_allowlist_var_is_hard_error() {
+        // The allowlist var must be *present* (even if empty) so an operator
+        // never accidentally runs with an unset => undefined trust set.
+        let mut vars = base_vars();
+        vars.remove(ENV_ALLOWLIST);
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert_eq!(err, ConfigError::MissingRequired(ENV_ALLOWLIST.to_string()));
+    }
+
+    #[test]
+    fn empty_allowlist_is_fail_closed_not_error() {
+        let mut vars = base_vars();
+        vars.insert(ENV_ALLOWLIST.into(), "".into());
+        let cfg = SignalConfig::resolve_from(&vars).expect("empty allowlist is valid");
+        assert!(
+            cfg.allowlist.is_empty(),
+            "empty allowlist must parse to the empty (fail-closed) set"
+        );
+    }
+
+    #[test]
+    fn allowlist_parses_multiple_trimmed_entries() {
+        let mut vars = base_vars();
+        vars.insert(ENV_ALLOWLIST.into(), " +15551230001 , +15551230002 ".into());
+        let cfg = SignalConfig::resolve_from(&vars).unwrap();
+        assert_eq!(
+            cfg.allowlist,
+            vec!["+15551230001".to_string(), "+15551230002".to_string()]
+        );
+    }
+
+    #[test]
+    fn invalid_e164_account_is_rejected() {
+        let mut vars = base_vars();
+        vars.insert(ENV_ACCOUNT.into(), "5551230000".into()); // missing +
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Invalid { ref var, .. } if var == ENV_ACCOUNT),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_e164_in_allowlist_is_rejected() {
+        let mut vars = base_vars();
+        vars.insert(ENV_ALLOWLIST.into(), "+15551230001,not-a-number".into());
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert!(matches!(err, ConfigError::Invalid { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn rolling_mode_without_group_id_is_error() {
+        let mut vars = base_vars();
+        vars.insert(ENV_GROUP_MODE.into(), "rolling".into());
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert_eq!(
+            err,
+            ConfigError::MissingRequired(ENV_ROLLING_GROUP_ID.to_string())
+        );
+    }
+
+    #[test]
+    fn rolling_mode_with_group_id_resolves() {
+        let mut vars = base_vars();
+        vars.insert(ENV_GROUP_MODE.into(), "rolling".into());
+        vars.insert(ENV_ROLLING_GROUP_ID.into(), "GROUP_ABC==".into());
+        let cfg = SignalConfig::resolve_from(&vars).unwrap();
+        assert_eq!(cfg.group_mode, GroupMode::Rolling);
+        assert_eq!(cfg.rolling_group_id.as_deref(), Some("GROUP_ABC=="));
+    }
+
+    #[test]
+    fn unknown_group_mode_is_error() {
+        let mut vars = base_vars();
+        vars.insert(ENV_GROUP_MODE.into(), "banana".into());
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Invalid { ref var, .. } if var == ENV_GROUP_MODE),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn echo_ttl_parses_from_env() {
+        let mut vars = base_vars();
+        vars.insert(ENV_ECHO_TTL_SECS.into(), "90".into());
+        let cfg = SignalConfig::resolve_from(&vars).unwrap();
+        assert_eq!(cfg.echo_ttl, Duration::from_secs(90));
+    }
+
+    #[test]
+    fn invalid_echo_ttl_is_error() {
+        let mut vars = base_vars();
+        vars.insert(ENV_ECHO_TTL_SECS.into(), "-5".into());
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Invalid { ref var, .. } if var == ENV_ECHO_TTL_SECS),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn max_frame_bytes_parses_from_env() {
+        let mut vars = base_vars();
+        vars.insert(ENV_MAX_FRAME_BYTES.into(), "2048".into());
+        let cfg = SignalConfig::resolve_from(&vars).unwrap();
+        assert_eq!(cfg.max_frame_bytes, 2048);
+    }
+
+    #[test]
+    fn own_device_id_must_be_at_least_two() {
+        let mut vars = base_vars();
+        vars.insert(ENV_OWN_DEVICE_ID.into(), "1".into());
+        let err = SignalConfig::resolve_from(&vars).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Invalid { ref var, .. } if var == ENV_OWN_DEVICE_ID),
+            "device id 1 is the primary phone and must not be the bot; got {err:?}"
+        );
+    }
+
+    #[test]
+    fn own_device_id_valid_when_ge_two() {
+        let mut vars = base_vars();
+        vars.insert(ENV_OWN_DEVICE_ID.into(), "3".into());
+        let cfg = SignalConfig::resolve_from(&vars).unwrap();
+        assert_eq!(cfg.own_device_id, Some(3));
+    }
+
+    #[test]
+    fn e164_validator_accepts_and_rejects() {
+        assert!(is_valid_e164("+15551230000"));
+        assert!(!is_valid_e164("15551230000"));
+        assert!(!is_valid_e164("+"));
+        assert!(!is_valid_e164("+1555abc0000"));
+    }
+}

--- a/crates/amplihack-signal/src/gating.rs
+++ b/crates/amplihack-signal/src/gating.rs
@@ -1,0 +1,170 @@
+//! Trust boundary for inbound Signal messages.
+//!
+//! Inbound text becomes agent instructions, so the gate is the security-critical
+//! seam. It is **infallible** — it returns a [`GateDecision`], never an error —
+//! and it is fail-closed by construction: acceptance requires ALL of:
+//! 1. sender in the (non-empty) allowlist,
+//! 2. `sourceDevice == 1` (operator's primary phone),
+//! 3. the message's group id matches this session's group,
+//! 4. the body is not a recently-sent outbound (TTL echo suppression).
+//!
+//! An empty allowlist therefore rejects everything. The echo window is bounded
+//! by a TTL (evicted on insert/lookup), never an arbitrary fixed message cap.
+
+use crate::transport::IncomingMessage;
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+/// The primary-device id: the operator's phone. Only device 1 is trusted.
+pub const PRIMARY_DEVICE_ID: u32 = 1;
+
+/// Why a message was rejected. Distinct variants aid redacted logging/metrics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejectReason {
+    /// Sender not in the allowlist (includes the empty-allowlist case).
+    NotInAllowlist,
+    /// Not from the operator's primary device (device != 1).
+    NotPrimaryDevice,
+    /// Group id did not match this session's group.
+    GroupMismatch,
+    /// Body matched a recently-sent outbound within the TTL window (loop guard).
+    EchoSuppressed,
+}
+
+/// The gate's verdict for a single inbound message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateDecision {
+    /// Accept and inject as an operator instruction.
+    Accept,
+    /// Reject, with reason.
+    Reject(RejectReason),
+}
+
+/// Fail-closed inbound gate bound to one session group.
+#[allow(dead_code)] // fields are consumed by the P3 implementation of the stubbed methods
+pub struct Gate {
+    allowlist: HashSet<String>,
+    group_id: String,
+    echo_ttl: Duration,
+    recent_outbound: HashMap<String, Instant>,
+}
+
+impl Gate {
+    /// Create a gate for `group_id` trusting exactly `allowlist`.
+    pub fn new(
+        _allowlist: impl IntoIterator<Item = String>,
+        _group_id: impl Into<String>,
+        _echo_ttl: Duration,
+    ) -> Self {
+        todo!("construct gate (P3)")
+    }
+
+    /// Record an outbound body just posted by the bot, so its synced-back copy
+    /// is suppressed for the TTL window. Evicts expired entries.
+    pub fn record_outbound(&mut self, _body: &str, _now: Instant) {
+        todo!("record outbound for echo suppression (P3)")
+    }
+
+    /// Evaluate an inbound message. Infallible.
+    pub fn evaluate(&mut self, _msg: &IncomingMessage, _now: Instant) -> GateDecision {
+        todo!("evaluate allowlist AND device AND group AND echo (P3)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(source: &str, device: u32, group: &str, body: &str) -> IncomingMessage {
+        IncomingMessage {
+            source_number: source.into(),
+            source_device: device,
+            group_id: Some(group.into()),
+            body: body.into(),
+        }
+    }
+
+    const GID: &str = "SESSION_GROUP_ID_AAA==";
+    const OP: &str = "+15551239999";
+
+    fn gate_with(allow: &[&str]) -> Gate {
+        Gate::new(
+            allow.iter().map(|s| s.to_string()),
+            GID,
+            Duration::from_secs(30),
+        )
+    }
+
+    #[test]
+    fn happy_path_accepts_primary_device_allowlisted_matching_group() {
+        let mut g = gate_with(&[OP]);
+        let d = g.evaluate(&msg(OP, 1, GID, "do the thing"), Instant::now());
+        assert_eq!(d, GateDecision::Accept);
+    }
+
+    #[test]
+    fn empty_allowlist_rejects_everything() {
+        let mut g = gate_with(&[]);
+        let d = g.evaluate(&msg(OP, 1, GID, "do the thing"), Instant::now());
+        assert_eq!(d, GateDecision::Reject(RejectReason::NotInAllowlist));
+    }
+
+    #[test]
+    fn sender_not_in_allowlist_rejected() {
+        let mut g = gate_with(&[OP]);
+        let d = g.evaluate(&msg("+15550000001", 1, GID, "do the thing"), Instant::now());
+        assert_eq!(d, GateDecision::Reject(RejectReason::NotInAllowlist));
+    }
+
+    #[test]
+    fn non_primary_device_rejected() {
+        let mut g = gate_with(&[OP]);
+        let d = g.evaluate(&msg(OP, 2, GID, "synced-back bot echo"), Instant::now());
+        assert_eq!(d, GateDecision::Reject(RejectReason::NotPrimaryDevice));
+    }
+
+    #[test]
+    fn group_mismatch_rejected() {
+        let mut g = gate_with(&[OP]);
+        let d = g.evaluate(&msg(OP, 1, "OTHER_GROUP==", "hi"), Instant::now());
+        assert_eq!(d, GateDecision::Reject(RejectReason::GroupMismatch));
+    }
+
+    #[test]
+    fn missing_group_id_rejected_as_mismatch() {
+        let mut g = gate_with(&[OP]);
+        let mut m = msg(OP, 1, GID, "hi");
+        m.group_id = None;
+        let d = g.evaluate(&m, Instant::now());
+        assert_eq!(d, GateDecision::Reject(RejectReason::GroupMismatch));
+    }
+
+    #[test]
+    fn recent_outbound_is_echo_suppressed_within_ttl() {
+        let mut g = gate_with(&[OP]);
+        let t0 = Instant::now();
+        g.record_outbound("session started", t0);
+        let d = g.evaluate(&msg(OP, 1, GID, "session started"), t0);
+        assert_eq!(d, GateDecision::Reject(RejectReason::EchoSuppressed));
+    }
+
+    #[test]
+    fn outbound_accepted_after_ttl_expires() {
+        let mut g = Gate::new([OP.to_string()], GID, Duration::from_secs(30));
+        let t0 = Instant::now();
+        g.record_outbound("session started", t0);
+        // Same body arriving after the TTL window is no longer suppressed.
+        let later = t0 + Duration::from_secs(31);
+        let d = g.evaluate(&msg(OP, 1, GID, "session started"), later);
+        assert_eq!(d, GateDecision::Accept);
+    }
+
+    #[test]
+    fn allowlist_check_precedes_device_check() {
+        // A non-allowlisted, non-primary-device message reports NotInAllowlist:
+        // the cheapest/outermost authz check wins, keeping ordering deterministic.
+        let mut g = gate_with(&[OP]);
+        let d = g.evaluate(&msg("+15550000002", 5, GID, "x"), Instant::now());
+        assert_eq!(d, GateDecision::Reject(RejectReason::NotInAllowlist));
+    }
+}

--- a/crates/amplihack-signal/src/lib.rs
+++ b/crates/amplihack-signal/src/lib.rs
@@ -1,0 +1,28 @@
+//! Feature-gated per-session Signal channel for amplihack.
+//!
+//! This crate is compiled into default builds (so its pure logic — config
+//! parsing, wire-format helpers, the trust-boundary gate, and the file-backed
+//! inbox — is always testable), but all async TCP I/O against a `signal-cli`
+//! JSON-RPC daemon is gated behind the `signal` cargo feature so default builds
+//! pull in no async runtime and no signal transport dependency.
+//!
+//! Module map:
+//! - [`config`]   — env > file > explicit-error resolver (fail-loud, never a
+//!   silent default). Empty allowlist parses successfully to the empty set =
+//!   fail-closed.
+//! - [`transport`] — pure `build_*_request` / `parse_incoming` wire helpers
+//!   (no I/O, dual inbound envelope shapes) plus the gated tokio client.
+//! - [`gating`]   — infallible trust boundary: allowlist AND primary-device
+//!   AND groupId-match AND TTL echo-suppression.
+//! - [`session_channel`] — file-backed [`session_channel::Inbox`] +
+//!   injection-context formatting + the gated per-session `SignalSession`.
+
+pub mod config;
+pub mod gating;
+pub mod session_channel;
+pub mod transport;
+
+pub use config::{ConfigError, GroupMode, SignalConfig};
+pub use gating::{Gate, GateDecision, RejectReason};
+pub use session_channel::{Inbox, InboxEntry, InboxError, format_injection_context};
+pub use transport::{IncomingMessage, ParseError, parse_incoming};

--- a/crates/amplihack-signal/src/session_channel.rs
+++ b/crates/amplihack-signal/src/session_channel.rs
@@ -1,0 +1,203 @@
+//! Per-session Signal channel: a crash-safe file-backed [`Inbox`] for accepted
+//! operator instructions, the [`format_injection_context`] helper that renders
+//! drained entries into a labeled-untrusted, length-capped block for the hook
+//! `additionalContext` seam, and the gated [`SignalSession`] that owns the
+//! session's group over the async transport.
+
+use amplihack_state::AtomicJsonFile;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Maximum bytes of injected context emitted per drain. Bounds prompt-injection
+/// surface; longer drains are truncated with a marker.
+pub const MAX_INJECTION_BYTES: usize = 4096;
+
+/// One accepted, gate-approved operator instruction awaiting injection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InboxEntry {
+    /// Monotonic per-session id (assigned on append).
+    pub id: u64,
+    /// Sender E.164 (already allowlist-checked).
+    pub source: String,
+    /// The instruction body.
+    pub body: String,
+}
+
+/// Inbox persistence error.
+#[derive(Debug, thiserror::Error)]
+pub enum InboxError {
+    /// Underlying atomic-file failure.
+    #[error("inbox storage error: {0}")]
+    Storage(String),
+}
+
+/// A crash-safe, append/drain file inbox backed by [`AtomicJsonFile`].
+///
+/// Appends assign a monotonically increasing id. `drain` returns all pending
+/// entries in id order and atomically clears them; a concurrent append never
+/// loses or reorders entries.
+pub struct Inbox {
+    #[allow(dead_code)] // consumed by the P4 implementation of the stubbed methods
+    file: AtomicJsonFile,
+}
+
+impl Inbox {
+    /// Open (or lazily create) an inbox at `path`.
+    pub fn new(_path: impl Into<PathBuf>) -> Self {
+        todo!("open atomic-json-backed inbox (P4)")
+    }
+
+    /// Append a gate-accepted instruction, returning the stored entry.
+    pub fn append(&self, _source: &str, _body: &str) -> Result<InboxEntry, InboxError> {
+        todo!("append with monotonic id (P4)")
+    }
+
+    /// Return pending entries in id order WITHOUT removing them.
+    pub fn peek(&self) -> Result<Vec<InboxEntry>, InboxError> {
+        todo!("peek pending (P4)")
+    }
+
+    /// Return all pending entries in id order and atomically clear them.
+    pub fn drain(&self) -> Result<Vec<InboxEntry>, InboxError> {
+        todo!("drain + atomic clear (P4)")
+    }
+}
+
+/// Render drained entries into an `additionalContext` block.
+///
+/// Returns `None` for an empty slice (so the hook emits byte-identical output
+/// when there is nothing to inject). Output is explicitly labeled as untrusted
+/// operator input and truncated to [`MAX_INJECTION_BYTES`].
+pub fn format_injection_context(_entries: &[InboxEntry]) -> Option<String> {
+    todo!("format labeled-untrusted, capped context (P4/P6)")
+}
+
+/// Async per-session Signal channel over the signal-cli JSON-RPC transport.
+#[cfg(feature = "signal")]
+pub use gated::SignalSession;
+
+#[cfg(feature = "signal")]
+mod gated {
+    use crate::config::SignalConfig;
+
+    /// Owns one per-session Signal group over a live JSON-RPC TCP connection.
+    pub struct SignalSession {
+        #[allow(dead_code)]
+        config: SignalConfig,
+        #[allow(dead_code)]
+        group_id: Option<String>,
+    }
+
+    impl SignalSession {
+        /// Connect to the configured signal-cli daemon.
+        pub async fn connect(_config: SignalConfig) -> std::io::Result<Self> {
+            todo!("connect TCP JSON-RPC (P4)")
+        }
+
+        /// Create (per-session) or resolve (rolling) this session's group and
+        /// return its group id. Posts nothing.
+        pub async fn announce(&mut self, _name: &str) -> std::io::Result<String> {
+            todo!("create/resolve group (P4)")
+        }
+
+        /// Post an update to the session group.
+        pub async fn post(&self, _update: &str) -> std::io::Result<()> {
+            todo!("send to group (P4)")
+        }
+
+        /// Leave the session group (per-session mode only).
+        pub async fn quit(&self) -> std::io::Result<()> {
+            todo!("quit group (P4)")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: u64, body: &str) -> InboxEntry {
+        InboxEntry {
+            id,
+            source: "+15551239999".into(),
+            body: body.into(),
+        }
+    }
+
+    #[test]
+    fn append_then_drain_roundtrips_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = Inbox::new(dir.path().join("inbox.json"));
+        inbox.append("+15551239999", "first").unwrap();
+        inbox.append("+15551239999", "second").unwrap();
+        let drained = inbox.drain().unwrap();
+        let bodies: Vec<&str> = drained.iter().map(|e| e.body.as_str()).collect();
+        assert_eq!(bodies, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn append_assigns_monotonic_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = Inbox::new(dir.path().join("inbox.json"));
+        let a = inbox.append("+15551239999", "a").unwrap();
+        let b = inbox.append("+15551239999", "b").unwrap();
+        assert!(b.id > a.id, "ids must be monotonically increasing");
+    }
+
+    #[test]
+    fn drain_clears_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = Inbox::new(dir.path().join("inbox.json"));
+        inbox.append("+15551239999", "only").unwrap();
+        let first = inbox.drain().unwrap();
+        assert_eq!(first.len(), 1);
+        let second = inbox.drain().unwrap();
+        assert!(second.is_empty(), "second drain must be empty");
+    }
+
+    #[test]
+    fn peek_does_not_remove() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = Inbox::new(dir.path().join("inbox.json"));
+        inbox.append("+15551239999", "keep").unwrap();
+        assert_eq!(inbox.peek().unwrap().len(), 1);
+        assert_eq!(
+            inbox.peek().unwrap().len(),
+            1,
+            "peek must be non-destructive"
+        );
+    }
+
+    #[test]
+    fn drain_on_missing_inbox_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = Inbox::new(dir.path().join("nonexistent.json"));
+        assert!(inbox.drain().unwrap().is_empty());
+    }
+
+    #[test]
+    fn format_empty_entries_returns_none() {
+        assert_eq!(format_injection_context(&[]), None);
+    }
+
+    #[test]
+    fn format_labels_content_untrusted() {
+        let ctx = format_injection_context(&[entry(1, "restart the build")]).expect("some context");
+        assert!(
+            ctx.to_lowercase().contains("untrusted"),
+            "injected context must flag untrusted operator input, got: {ctx}"
+        );
+        assert!(ctx.contains("restart the build"));
+    }
+
+    #[test]
+    fn format_caps_length() {
+        let huge = "A".repeat(MAX_INJECTION_BYTES * 4);
+        let ctx = format_injection_context(&[entry(1, &huge)]).expect("some context");
+        assert!(
+            ctx.len() <= MAX_INJECTION_BYTES + 256,
+            "context must be capped near MAX_INJECTION_BYTES, was {}",
+            ctx.len()
+        );
+    }
+}

--- a/crates/amplihack-signal/src/transport.rs
+++ b/crates/amplihack-signal/src/transport.rs
@@ -1,0 +1,181 @@
+//! signal-cli JSON-RPC 2.0 wire format: pure request builders and an inbound
+//! envelope parser (no I/O), plus the gated async TCP client.
+//!
+//! signal-cli speaks newline-delimited JSON-RPC 2.0. Only the pure helpers are
+//! compiled on default builds and unit-tested with no sockets, exactly like the
+//! Simard reference `transport.rs`.
+
+use serde_json::Value;
+
+/// Default maximum inbound frame size (1 MiB). Mirrors [`crate::config`].
+pub const DEFAULT_MAX_FRAME_BYTES: usize = 1024 * 1024;
+
+/// A parsed, relevant inbound group message. Only messages carrying a group id
+/// and body are surfaced; everything else parses to `Ok(None)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncomingMessage {
+    /// Sender E.164 (from `envelope.source` / `sourceNumber`).
+    pub source_number: String,
+    /// Sending device id. Operator's primary phone is device 1.
+    pub source_device: u32,
+    /// Group id the message was sent to, if any.
+    pub group_id: Option<String>,
+    /// The message body text.
+    pub body: String,
+}
+
+/// Inbound parse failure. A *malformed* frame is an error; an *irrelevant* but
+/// well-formed frame is `Ok(None)` — the two are deliberately distinct so the
+/// receive loop can log-and-continue on noise but surface real corruption.
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    /// The frame exceeded the configured maximum size and was not buffered.
+    #[error("inbound frame too large: {size} > {max} bytes")]
+    FrameTooLarge {
+        /// Observed size.
+        size: usize,
+        /// Configured maximum.
+        max: usize,
+    },
+    /// The frame was not valid JSON.
+    #[error("malformed inbound JSON: {0}")]
+    Json(String),
+}
+
+/// Build a `send` request that posts `body` to `group_id`.
+///
+/// Shape: `{"jsonrpc":"2.0","id":<id>,"method":"send","params":{"groupId":..,"message":..}}`.
+pub fn build_send_request(_group_id: &str, _body: &str, _id: u64) -> Value {
+    todo!("build send request (P2)")
+}
+
+/// Build an `updateGroup` request that creates a group named `name` containing
+/// exactly `members` (for the self-only group, the single operator account).
+///
+/// Shape: `{"jsonrpc":"2.0","id":<id>,"method":"updateGroup","params":{"name":..,"members":[..]}}`.
+pub fn build_create_group_request(_name: &str, _members: &[String], _id: u64) -> Value {
+    todo!("build updateGroup request (P2)")
+}
+
+/// Build a `quitGroup` request that leaves `group_id`.
+pub fn build_quit_group_request(_group_id: &str, _id: u64) -> Value {
+    todo!("build quitGroup request (P2)")
+}
+
+/// Parse one NDJSON line using the default max frame size.
+pub fn parse_incoming(line: &str) -> Result<Option<IncomingMessage>, ParseError> {
+    parse_incoming_bounded(line, DEFAULT_MAX_FRAME_BYTES)
+}
+
+/// Parse one NDJSON line, rejecting frames larger than `max_frame_bytes`.
+///
+/// Tolerant by contract: unknown/irrelevant well-formed envelopes return
+/// `Ok(None)`; only oversized or non-JSON input returns `Err`. Never panics.
+/// Handles both inbound group shapes:
+/// - `params.envelope.dataMessage.groupInfo.groupId`
+/// - `params.envelope.syncMessage.sentMessage.groupInfo.groupId`
+pub fn parse_incoming_bounded(
+    _line: &str,
+    _max_frame_bytes: usize,
+) -> Result<Option<IncomingMessage>, ParseError> {
+    todo!("parse inbound envelope, dual-shape, tolerant (P2)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const F_DATA: &str = include_str!("../tests/fixtures/inbound_data_message.json");
+    const F_SYNC: &str = include_str!("../tests/fixtures/inbound_sync_sent_message.json");
+    const F_RECEIPT: &str = include_str!("../tests/fixtures/inbound_irrelevant_receipt.json");
+    const F_BOT: &str = include_str!("../tests/fixtures/inbound_sync_from_bot_device.json");
+    const F_MALFORMED: &str = include_str!("../tests/fixtures/inbound_malformed.json");
+
+    #[test]
+    fn send_request_has_expected_shape() {
+        let req = build_send_request("GID==", "hello", 7);
+        assert_eq!(req["jsonrpc"], "2.0");
+        assert_eq!(req["id"], 7);
+        assert_eq!(req["method"], "send");
+        assert_eq!(req["params"]["groupId"], "GID==");
+        assert_eq!(req["params"]["message"], "hello");
+    }
+
+    #[test]
+    fn create_group_request_uses_update_group_method() {
+        let req = build_create_group_request("amplihack-sess-1", &["+15551230000".into()], 1);
+        assert_eq!(req["jsonrpc"], "2.0");
+        assert_eq!(req["id"], 1);
+        assert_eq!(req["method"], "updateGroup");
+        assert_eq!(req["params"]["name"], "amplihack-sess-1");
+        assert_eq!(req["params"]["members"][0], "+15551230000");
+    }
+
+    #[test]
+    fn quit_group_request_uses_quit_group_method() {
+        let req = build_quit_group_request("GID==", 5);
+        assert_eq!(req["method"], "quitGroup");
+        assert_eq!(req["params"]["groupId"], "GID==");
+        assert_eq!(req["id"], 5);
+    }
+
+    #[test]
+    fn parses_data_message_shape() {
+        let msg = parse_incoming(F_DATA).unwrap().expect("relevant message");
+        assert_eq!(msg.source_number, "+15551239999");
+        assert_eq!(msg.source_device, 1);
+        assert_eq!(msg.group_id.as_deref(), Some("SESSION_GROUP_ID_AAA=="));
+        assert_eq!(msg.body, "deploy the staging branch");
+    }
+
+    #[test]
+    fn parses_sync_sent_message_shape() {
+        let msg = parse_incoming(F_SYNC).unwrap().expect("relevant message");
+        assert_eq!(msg.source_number, "+15551239999");
+        assert_eq!(msg.source_device, 1);
+        assert_eq!(msg.group_id.as_deref(), Some("SESSION_GROUP_ID_AAA=="));
+        assert_eq!(msg.body, "run the tests again");
+    }
+
+    #[test]
+    fn sync_from_bot_device_still_parses_with_its_device_id() {
+        // Parsing must faithfully report sourceDevice >= 2; the *gate* (not the
+        // parser) is responsible for rejecting the bot's own synced-back echo.
+        let msg = parse_incoming(F_BOT).unwrap().expect("relevant message");
+        assert_eq!(msg.source_device, 2);
+        assert_eq!(msg.body, "session started for task #903");
+    }
+
+    #[test]
+    fn irrelevant_envelope_returns_none() {
+        assert_eq!(parse_incoming(F_RECEIPT).unwrap(), None);
+    }
+
+    #[test]
+    fn non_group_data_message_returns_none() {
+        // A direct (non-group) message has no groupInfo — not for us.
+        let line = r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{"source":"+15551239999","sourceDevice":1,"dataMessage":{"message":"hi"}}}}"#;
+        assert_eq!(parse_incoming(line).unwrap(), None);
+    }
+
+    #[test]
+    fn malformed_json_is_error() {
+        let err = parse_incoming(F_MALFORMED).unwrap_err();
+        assert!(matches!(err, ParseError::Json(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn oversized_frame_is_rejected_without_buffering() {
+        let big = "x".repeat(64);
+        let err = parse_incoming_bounded(&big, 16).unwrap_err();
+        assert!(
+            matches!(err, ParseError::FrameTooLarge { size: 64, max: 16 }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn empty_line_is_none() {
+        assert_eq!(parse_incoming("").unwrap(), None);
+    }
+}

--- a/crates/amplihack-signal/tests/fixtures/inbound_data_message.json
+++ b/crates/amplihack-signal/tests/fixtures/inbound_data_message.json
@@ -1,0 +1,19 @@
+{
+  "jsonrpc": "2.0",
+  "method": "receive",
+  "params": {
+    "envelope": {
+      "source": "+15551239999",
+      "sourceNumber": "+15551239999",
+      "sourceDevice": 1,
+      "timestamp": 1720000000000,
+      "dataMessage": {
+        "timestamp": 1720000000000,
+        "message": "deploy the staging branch",
+        "groupInfo": {
+          "groupId": "SESSION_GROUP_ID_AAA=="
+        }
+      }
+    }
+  }
+}

--- a/crates/amplihack-signal/tests/fixtures/inbound_irrelevant_receipt.json
+++ b/crates/amplihack-signal/tests/fixtures/inbound_irrelevant_receipt.json
@@ -1,0 +1,17 @@
+{
+  "jsonrpc": "2.0",
+  "method": "receive",
+  "params": {
+    "envelope": {
+      "source": "+15551239999",
+      "sourceDevice": 1,
+      "timestamp": 1720000000002,
+      "receiptMessage": {
+        "when": 1720000000002,
+        "isDelivery": true,
+        "isRead": false,
+        "timestamps": [1720000000000]
+      }
+    }
+  }
+}

--- a/crates/amplihack-signal/tests/fixtures/inbound_malformed.json
+++ b/crates/amplihack-signal/tests/fixtures/inbound_malformed.json
@@ -1,0 +1,1 @@
+{ "jsonrpc": "2.0", "method": "receive", "params": { "envelope": { "source":

--- a/crates/amplihack-signal/tests/fixtures/inbound_sync_from_bot_device.json
+++ b/crates/amplihack-signal/tests/fixtures/inbound_sync_from_bot_device.json
@@ -1,0 +1,20 @@
+{
+  "jsonrpc": "2.0",
+  "method": "receive",
+  "params": {
+    "envelope": {
+      "source": "+15551239999",
+      "sourceDevice": 2,
+      "timestamp": 1720000000003,
+      "syncMessage": {
+        "sentMessage": {
+          "timestamp": 1720000000003,
+          "message": "session started for task #903",
+          "groupInfo": {
+            "groupId": "SESSION_GROUP_ID_AAA=="
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/amplihack-signal/tests/fixtures/inbound_sync_sent_message.json
+++ b/crates/amplihack-signal/tests/fixtures/inbound_sync_sent_message.json
@@ -1,0 +1,21 @@
+{
+  "jsonrpc": "2.0",
+  "method": "receive",
+  "params": {
+    "envelope": {
+      "source": "+15551239999",
+      "sourceNumber": "+15551239999",
+      "sourceDevice": 1,
+      "timestamp": 1720000000001,
+      "syncMessage": {
+        "sentMessage": {
+          "timestamp": 1720000000001,
+          "message": "run the tests again",
+          "groupInfo": {
+            "groupId": "SESSION_GROUP_ID_AAA=="
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/amplihack-signal/tests/session_channel_it.rs
+++ b/crates/amplihack-signal/tests/session_channel_it.rs
@@ -1,0 +1,96 @@
+//! Integration test: `SignalSession` against a mock signal-cli JSON-RPC daemon.
+//!
+//! Only compiled with `--features signal`; otherwise this file is empty.
+#![cfg(feature = "signal")]
+
+use std::time::Duration;
+
+use amplihack_signal::config::{GroupMode, SignalConfig};
+use amplihack_signal::session_channel::SignalSession;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Minimal NDJSON JSON-RPC mock. Replies to `updateGroup`/`send`/`quitGroup`.
+/// Returns the bound `host:port` and a join handle.
+async fn spawn_mock() -> (String, tokio::task::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        handle_conn(stream).await
+    });
+    (format!("{}:{}", addr.ip(), addr.port()), handle)
+}
+
+/// Reads NDJSON requests until EOF, replies to each, and records the methods.
+async fn handle_conn(stream: TcpStream) -> Vec<String> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut lines = BufReader::new(read_half).lines();
+    let mut seen_methods = Vec::new();
+    while let Ok(Some(line)) = lines.next_line().await {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let req: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let id = req.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let method = req
+            .get("method")
+            .and_then(|m| m.as_str())
+            .unwrap_or("")
+            .to_string();
+        let result = match method.as_str() {
+            "updateGroup" => serde_json::json!({ "groupId": "MOCK_GROUP_ID==" }),
+            _ => serde_json::json!({ "timestamp": 1720000000000i64 }),
+        };
+        let resp = serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result });
+        let mut bytes = serde_json::to_vec(&resp).unwrap();
+        bytes.push(b'\n');
+        write_half.write_all(&bytes).await.unwrap();
+        write_half.flush().await.unwrap();
+        seen_methods.push(method);
+    }
+    seen_methods
+}
+
+fn config_for(endpoint: &str) -> SignalConfig {
+    SignalConfig {
+        endpoint: endpoint.to_string(),
+        account: "+15551230000".into(),
+        allowlist: vec!["+15551239999".into()],
+        own_device_id: None,
+        echo_ttl: Duration::from_secs(30),
+        group_mode: GroupMode::PerSession,
+        rolling_group_id: None,
+        max_frame_bytes: 1024 * 1024,
+    }
+}
+
+#[tokio::test]
+async fn announce_post_quit_roundtrip() {
+    let (endpoint, server) = spawn_mock().await;
+    let mut session = SignalSession::connect(config_for(&endpoint))
+        .await
+        .expect("connect to mock daemon");
+
+    let group_id = session
+        .announce("amplihack-session-test")
+        .await
+        .expect("announce returns a group id");
+    assert_eq!(group_id, "MOCK_GROUP_ID==");
+
+    session
+        .post("session started for task #903")
+        .await
+        .expect("post to group");
+
+    session.quit().await.expect("quit group");
+
+    drop(session);
+    let methods = server.await.unwrap();
+    assert!(methods.contains(&"updateGroup".to_string()));
+    assert!(methods.contains(&"send".to_string()));
+    assert!(methods.contains(&"quitGroup".to_string()));
+}

--- a/docs/signal-channel.md
+++ b/docs/signal-channel.md
@@ -1,0 +1,351 @@
+# Signal Channel
+
+The **Signal channel** gives every amplihack session a private, two-way bridge to
+the operator's Signal account. When enabled, each session opens a fresh Signal
+group containing only the operator's own linked account, posts meaningful session
+updates to that group, and watches the group for replies from the operator's
+primary phone. Accepted replies are injected into the running session as
+additional agent context.
+
+This lets you supervise and steer a long-running amplihack session from your
+phone: read what the agent is doing and reply with a nudge, correction, or new
+instruction — all without touching the terminal.
+
+!!! info "Feature-gated, off by default"
+    The Signal channel is compiled only when the `signal` cargo feature is
+    enabled. Default builds pull **zero** additional runtime dependencies and
+    behave exactly as before. See [Enabling the feature](#enabling-the-feature).
+
+---
+
+## At a glance
+
+| Property | Value |
+| --- | --- |
+| Cargo feature | `signal` (default **off**) |
+| Transport | signal-cli JSON-RPC 2.0 over newline-delimited TCP |
+| Group membership | Operator's own Signal account only (self-group) |
+| Inbound trust model | Fail-closed allowlist **AND** primary-device (`sourceDevice == 1`) **AND** group-id match **AND** echo suppression |
+| Injection seam | `hookSpecificOutput.additionalContext` on `UserPromptSubmit` / `PostToolUse` |
+| Posting cadence | Meaningful transitions only (start, checkpoints, key results, stop) |
+| Group lifecycle | Created on `SessionStart`, left (`quitGroup`) on `Stop` — or a single rolling group |
+
+---
+
+## How it works
+
+```mermaid
+sequenceDiagram
+    participant Phone as Operator phone (device 1)
+    participant Signal as signal-cli daemon
+    participant Session as amplihack session (hooks)
+    participant Sub as signal-subscriber
+
+    Note over Session: SessionStart hook
+    Session->>Signal: updateGroup {name} → groupId
+    Session->>Signal: send {groupId, "session started …"}
+    Signal-->>Phone: session started …
+    Session->>Sub: spawn detached subscriber (groupId)
+
+    loop while session runs
+        Phone->>Signal: reply "focus on the auth module"
+        Signal-->>Sub: syncMessage.sentMessage (device 1)
+        Sub->>Sub: gate: allowlist ∧ device==1 ∧ groupId ∧ not-echo
+        Sub->>Session: append to file inbox
+        Note over Session: UserPromptSubmit / PostToolUse hook
+        Session->>Session: drain inbox → additionalContext
+    end
+
+    Note over Session: Stop hook
+    Session->>Signal: send {groupId, "session summary …"}
+    Session->>Signal: quitGroup {groupId}
+    Session->>Sub: terminate subscriber
+```
+
+1. **Session start.** If the `signal` feature is built and configuration
+   resolves, the `SessionStart` hook creates a per-session Signal group, persists
+   the group id to session state, posts a short "session started" announcement,
+   and spawns a long-lived `signal-subscriber` process.
+2. **Inbound monitoring.** The subscriber holds one JSON-RPC connection open,
+   filters messages to this session's group, applies the trust gate, and appends
+   accepted messages to a crash-safe file inbox in session state. Because the
+   group holds only the operator's own account, replies arrive as
+   `syncMessage.sentMessage` envelopes; the parser tolerantly accepts both that
+   shape and the ordinary `dataMessage` shape, treats irrelevant frames as a
+   no-op, and rejects malformed frames without panicking.
+3. **Injection.** On each `UserPromptSubmit` (and opportunistically on
+   `PostToolUse`), the hook drains the inbox and emits the queued operator
+   instructions through `hookSpecificOutput.additionalContext`, clearly labeled
+   as untrusted operator input. The prompt itself is never mutated.
+4. **Session stop.** The `Stop` hook posts a session summary, leaves the group
+   (`quitGroup`), and terminates the subscriber so groups do not pile up on the
+   operator's phone.
+
+---
+
+## Prerequisites
+
+- A working [`signal-cli`](https://github.com/AsamK/signal-cli) installation,
+  registered and linked to the operator's Signal account, running in
+  **JSON-RPC daemon mode** over TCP. For example:
+
+  ```bash
+  signal-cli -a "+15551234567" daemon --tcp 127.0.0.1:7583
+  ```
+
+- The operator's **primary phone** (the registered number, `device 1`) available
+  to send and receive messages in the session group.
+
+!!! warning "amplihack owns its own account"
+    Do **not** point amplihack at a signal-cli daemon/account that another
+    service is already consuming. A second receive-consumer on the same account
+    races and double-processes inbound messages. Give amplihack a dedicated
+    account (or at minimum a dedicated daemon that nothing else reads).
+
+---
+
+## Enabling the feature
+
+Build (or install) amplihack with the `signal` feature:
+
+```bash
+# Build the hooks binary with Signal support
+cargo build --release --features signal -p amplihack-hooks
+
+# Or run tests across the feature
+cargo test --features signal
+```
+
+Default builds omit the feature entirely:
+
+```bash
+cargo build            # no signal-cli, no tokio net, no behavior change
+cargo test             # default gate still passes
+```
+
+The feature must be present **and** configuration must resolve for the channel to
+activate. If the feature is built but configuration is incomplete, the session
+proceeds normally and records a warning — the Signal channel is always
+**fail-open** with respect to session availability.
+
+---
+
+## Configuration
+
+Configuration is resolved **env → file → explicit error**. Environment variables
+always win. A missing *required* value is a hard, explicit error (never a silent
+default). An empty allowlist is a valid configuration that means **nobody** —
+fail-closed.
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `AMPLIHACK_SIGNAL_ENDPOINT` | Yes | — | signal-cli daemon address, `host:port` (e.g. `127.0.0.1:7583`). |
+| `AMPLIHACK_SIGNAL_ACCOUNT` | Yes | — | Operator's registered account in E.164 form (e.g. `+15551234567`). |
+| `AMPLIHACK_SIGNAL_ALLOWLIST` | Yes | — | Comma-separated E.164 numbers allowed to inject. **Empty = fail-closed (nobody).** |
+| `AMPLIHACK_SIGNAL_GROUP_MODE` | No | `per-session` | `per-session` (new group each session, left on stop) or `rolling` (reuse one group). |
+| `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` | Only if `rolling` | — | Existing group id to reuse. Required, with explicit error, when mode is `rolling`. |
+| `AMPLIHACK_SIGNAL_ECHO_TTL_SECS` | No | `30` | TTL (seconds) for the echo-suppression window that prevents re-ingesting the bot's own messages. |
+| `AMPLIHACK_SIGNAL_OWN_DEVICE_ID` | No | — | Defence-in-depth: the bot's own linked device id (`>= 2`). Used as an extra loop guard. |
+| `AMPLIHACK_SIGNAL_MAX_FRAME_BYTES` | No | `1048576` | Hard cap on a single inbound JSON-RPC frame. Frames larger than this are rejected without buffering, bounding subscriber memory against a hostile or runaway daemon. |
+| `AMPLIHACK_SIGNAL_CONFIG` | No | platform default | Path to an optional TOML config file (see below). |
+
+### Config file
+
+When present, a TOML config file provides a lower-priority layer beneath the
+environment. Its path comes from `AMPLIHACK_SIGNAL_CONFIG`, or a platform default
+under the amplihack project directories. Any value set in the environment
+overrides the file; required values absent from *both* layers produce an
+explicit error.
+
+```toml
+# examples/signal-config.toml
+endpoint = "127.0.0.1:7583"
+account  = "+15551234567"
+
+# Comma is not needed in TOML; use a real array.
+# An empty array means fail-closed (nobody may inject).
+allowlist = ["+15551234567"]
+
+group_mode = "per-session"        # or "rolling"
+# rolling_group_id = "group.abc123=="   # required only when group_mode = "rolling"
+
+echo_ttl_secs = 30
+# own_device_id = 2               # optional loop-guard, must be >= 2
+# max_frame_bytes = 1048576       # reject inbound frames larger than this (1 MiB default)
+```
+
+!!! note "E.164 format"
+    All phone numbers — `account` and every allowlist entry — must be valid
+    E.164 (leading `+`, country code, digits only). Invalid numbers are rejected
+    at config load time with an explicit error.
+
+### Group modes
+
+- **`per-session`** (default): each session creates its own group named with the
+  session id and a timestamp, and leaves it on `Stop`. Cleanest supervision, but
+  produces one (auto-left) group per session.
+- **`rolling`**: all sessions post to a single pre-existing group
+  (`AMPLIHACK_SIGNAL_ROLLING_GROUP_ID`). The group is neither created nor left by
+  amplihack. Use this to avoid group churn on the operator's phone.
+
+!!! tip "Signal cannot delete groups for everyone"
+    Signal has no delete-for-everyone for groups. `per-session` mode
+    auto-**leaves** each group on stop (it still lingers in your group list until
+    you clear it manually). If group litter bothers you, prefer `rolling` mode.
+
+---
+
+## The trust boundary
+
+Inbound Signal text becomes agent context, so the gate is deliberately strict and
+**fail-closed**. A message is accepted **only** when *all* of the following hold:
+
+1. **Allowlist** — the sender's E.164 number is in `AMPLIHACK_SIGNAL_ALLOWLIST`.
+   An empty allowlist rejects everything.
+2. **Primary device** — the message originates from `sourceDevice == 1` (the
+   operator's registered primary phone), not a linked device or the bot itself.
+3. **Group match** — the message's group id equals this session's group id.
+4. **Not an echo** — the message body does not match a recently-sent outbound
+   body within the TTL window (prevents the bot re-ingesting its own
+   synced-back messages and looping).
+
+The gate is infallible: it returns an accept/reject decision, never an error.
+Injected content is length-capped and explicitly labeled as untrusted operator
+input. **Injection is context-only** — operator text never bypasses amplihack's
+existing approval gates and never auto-executes a mutating action.
+
+---
+
+## Usage tutorial
+
+This walkthrough assumes signal-cli is registered to `+15551234567` and running
+as a TCP daemon on `127.0.0.1:7583`.
+
+### 1. Start the daemon
+
+```bash
+signal-cli -a "+15551234567" daemon --tcp 127.0.0.1:7583
+```
+
+### 2. Configure amplihack
+
+```bash
+export AMPLIHACK_SIGNAL_ENDPOINT="127.0.0.1:7583"
+export AMPLIHACK_SIGNAL_ACCOUNT="+15551234567"
+export AMPLIHACK_SIGNAL_ALLOWLIST="+15551234567"   # only your own phone
+```
+
+### 3. Run a session with the feature enabled
+
+Use an amplihack build that includes the `signal` feature. On session start you
+will receive a Signal message like:
+
+```
+amplihack session started
+session: 91988bcc • 2026-07-15T02:44Z
+task: Implement the feature-gated Signal channel
+```
+
+### 4. Steer from your phone
+
+Reply in the group from your primary phone:
+
+```
+please add a unit test for the empty-allowlist case
+```
+
+On the next prompt boundary, the agent sees an additional context block:
+
+```
+[untrusted operator input via Signal]
+please add a unit test for the empty-allowlist case
+```
+
+The agent treats it as guidance, subject to the usual approval gates.
+
+### 5. End the session
+
+On `Stop` you receive a summary and the group is left:
+
+```
+amplihack session complete
+session: 91988bcc
+result: PR opened, 12 files changed, tests green
+```
+
+---
+
+## Session state layout
+
+The channel stores runtime state under the amplihack project directories, keyed
+by a sanitized session id (only `[A-Za-z0-9_-]`, everything else mapped to `_`):
+
+| File | Purpose |
+| --- | --- |
+| `signal/<session-id>/state.json` | Resolved group id and mode for the session. |
+| `signal/<session-id>/inbox.json` | Crash-safe append log of gate-accepted operator messages awaiting injection. |
+| `signal/<session-id>/subscriber.json` | Subscriber PID, so `Stop` can terminate it. |
+
+State files are written via the crash-safe, locked `AtomicJsonFile`. On shared
+hosts the signal state directory is created `0o700` and files `0o600`; message
+bodies are **never** logged, and phone numbers are redacted in warnings.
+
+---
+
+## The `signal-subscriber` process
+
+The persistent subscriber is a subcommand on the hooks binary:
+
+```bash
+amplihack-hooks signal-subscriber --session-id <session-id>
+```
+
+It is spawned detached by `SessionStart` and should not normally be run by hand.
+It maintains one long-lived JSON-RPC connection, retries with backoff if the
+daemon is unavailable, and appends only gate-accepted messages to the inbox. It
+exists as a separate long-lived process because hooks are short-lived CLI
+invocations and would otherwise drop inbound messages between runs.
+
+Reads are bounded by `AMPLIHACK_SIGNAL_MAX_FRAME_BYTES` (default 1 MiB): a frame
+that exceeds the cap is rejected and the read buffer reset rather than grown
+without limit, so a hostile or malfunctioning daemon cannot exhaust subscriber
+memory. Oversized and malformed frames are dropped as no-ops; the connection is
+retained.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| No "session started" message | Feature not built, or config unresolved | Build with `--features signal`; check required env vars; look for `warnings[]` in hook output. |
+| Replies never reach the agent | Number not in allowlist, or sent from a linked device (not device 1) | Add the number to `AMPLIHACK_SIGNAL_ALLOWLIST`; send from the primary registered phone. |
+| Duplicate/looping messages | Two consumers on one account | Give amplihack a dedicated account/daemon. |
+| Groups piling up | `per-session` mode | Switch to `AMPLIHACK_SIGNAL_GROUP_MODE=rolling`. |
+| `config error: AMPLIHACK_SIGNAL_ACCOUNT is required` | Missing required var | Set it in the environment or config file — there is no silent default. |
+
+---
+
+## Scope and limitations (v1)
+
+**In scope:** per-session group create + post; env-first config with file layer;
+feature flag; fail-closed allowlist + device-1 gate + echo suppression; file
+inbox with hook-driven `additionalContext` injection; `SessionStart` /
+`UserPromptSubmit` / `PostToolUse` / `Stop` wiring.
+
+**Out of scope (v1):**
+
+- Mid-turn interruption of a running agent turn (injection happens at prompt
+  boundaries only).
+- Multi-operator groups (the group holds only the operator's own account).
+- amplihack installing or managing its own signal-cli daemon.
+
+---
+
+## See also
+
+- [Hooks Configuration](HOOK_CONFIGURATION_GUIDE.md)
+- [Trust & Anti-Sycophancy](claude/context/TRUST.md)
+- Example config: [`examples/signal-config.toml`](https://github.com/rysweet/amplihack-rs/blob/main/examples/signal-config.toml)

--- a/examples/signal-config.toml
+++ b/examples/signal-config.toml
@@ -1,0 +1,56 @@
+# Example configuration for the amplihack Signal channel.
+#
+# The Signal channel is compiled only under the `signal` cargo feature
+# (default OFF). This file is the OPTIONAL lower-priority config layer:
+# environment variables always override anything set here. Any required
+# value that is missing from BOTH the environment and this file produces
+# an explicit error at load time — there are no silent defaults.
+#
+# Point amplihack at this file with:
+#   export AMPLIHACK_SIGNAL_CONFIG=/path/to/signal-config.toml
+#
+# Prerequisite: a registered signal-cli running in JSON-RPC daemon mode, e.g.
+#   signal-cli -a "+15551234567" daemon --tcp 127.0.0.1:7583
+
+# --- Required -------------------------------------------------------------
+
+# signal-cli JSON-RPC daemon address, "host:port".
+# Env override: AMPLIHACK_SIGNAL_ENDPOINT
+endpoint = "127.0.0.1:7583"
+
+# Operator's registered Signal account, E.164 format.
+# Env override: AMPLIHACK_SIGNAL_ACCOUNT
+account = "+15551234567"
+
+# Numbers permitted to inject instructions into the session.
+# E.164 only. An EMPTY array is valid and means "nobody" (fail-closed).
+# Env override: AMPLIHACK_SIGNAL_ALLOWLIST (comma-separated)
+allowlist = ["+15551234567"]
+
+# --- Optional -------------------------------------------------------------
+
+# "per-session" (default): create a fresh group per session, leave it on Stop.
+# "rolling": reuse a single existing group; do not create or leave it.
+# Env override: AMPLIHACK_SIGNAL_GROUP_MODE
+group_mode = "per-session"
+
+# Required ONLY when group_mode = "rolling". Explicit error if missing.
+# Env override: AMPLIHACK_SIGNAL_ROLLING_GROUP_ID
+# rolling_group_id = "group.AbCdEf0123456789=="
+
+# Echo-suppression window (seconds). Recently-sent outbound bodies are
+# ignored on inbound within this TTL, preventing the bot from re-ingesting
+# its own synced-back messages and looping. Default: 30.
+# Env override: AMPLIHACK_SIGNAL_ECHO_TTL_SECS
+echo_ttl_secs = 30
+
+# Defence-in-depth loop guard: the bot's own linked device id (must be >= 2).
+# Optional; the primary-device gate (sourceDevice == 1) is the main control.
+# Env override: AMPLIHACK_SIGNAL_OWN_DEVICE_ID
+# own_device_id = 2
+
+# Hard cap on a single inbound JSON-RPC frame (bytes). Frames larger than this
+# are rejected without buffering, bounding subscriber memory against a hostile
+# or runaway daemon. Default: 1048576 (1 MiB).
+# Env override: AMPLIHACK_SIGNAL_MAX_FRAME_BYTES
+# max_frame_bytes = 1048576

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
       - Scenarios Overview: claude/scenarios/README.md
       - Creating Tools: CREATE_YOUR_OWN_TOOLS.md
       - Hooks Configuration: HOOK_CONFIGURATION_GUIDE.md
+      - Signal Channel: signal-channel.md
       - GitHub Copilot CLI:
           - Overview: COPILOT_CLI.md
           - Tutorial: tutorials/copilot-parity-control-plane.md


### PR DESCRIPTION
## Summary
Concise workflow-generated PR for Cargo.lock.

## Issue
Closes #903

## Changed files
- Cargo.lock
- Cargo.toml
- bins/amplihack-hooks/Cargo.toml
- bins/amplihack-hooks/tests/signal_subscriber_it.rs
- crates/amplihack-hooks/Cargo.toml
- crates/amplihack-signal/Cargo.toml
- crates/amplihack-signal/src/config.rs
- crates/amplihack-signal/src/gating.rs
- crates/amplihack-signal/src/lib.rs
- crates/amplihack-signal/src/session_channel.rs
- crates/amplihack-signal/src/transport.rs
- crates/amplihack-signal/tests/fixtures/inbound_data_message.json
- crates/amplihack-signal/tests/fixtures/inbound_irrelevant_receipt.json
- crates/amplihack-signal/tests/fixtures/inbound_malformed.json
- crates/amplihack-signal/tests/fixtures/inbound_sync_from_bot_device.json
- crates/amplihack-signal/tests/fixtures/inbound_sync_sent_message.json
- crates/amplihack-signal/tests/session_channel_it.rs
- docs/signal-channel.md
- examples/signal-config.toml
- mkdocs.yml

## Diff stat
```text
 Cargo.toml                                         |   2 +
 bins/amplihack-hooks/Cargo.toml                    |  17 +
 bins/amplihack-hooks/tests/signal_subscriber_it.rs | 115 +++++++
 crates/amplihack-hooks/Cargo.toml                  |   7 +
 crates/amplihack-signal/Cargo.toml                 |  32 ++
 crates/amplihack-signal/src/config.rs              | 281 +++++++++++++++++
 crates/amplihack-signal/src/gating.rs              | 170 ++++++++++
 crates/amplihack-signal/src/lib.rs                 |  28 ++
 crates/amplihack-signal/src/session_channel.rs     | 203 ++++++++++++
 crates/amplihack-signal/src/transport.rs           | 181 +++++++++++
 .../tests/fixtures/inbound_data_message.json       |  19 ++
 .../tests/fixtures/inbound_irrelevant_receipt.json |  17 +
 .../tests/fixtures/inbound_malformed.json          |   1 +
 .../fixtures/inbound_sync_from_bot_device.json     |  20 ++
 .../tests/fixtures/inbound_sync_sent_message.json  |  21 ++
 .../amplihack-signal/tests/session_channel_it.rs   |  96 ++++++
 docs/signal-channel.md                             | 351 +++++++++++++++++++++
 examples/signal-config.toml                        |  56 ++++
 mkdocs.yml                                         |   1 +
 20 files changed, 1646 insertions(+)
```

## Behavior
Implemented behavior through these branch commits:
dc50c7ce wip: checkpoint after implementation (steps 7-8)

## Validation
ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config
I'll start by checking the current branch and what's been implemented.

✗ Get branch and changed files (shell)
  │ cd /home/azureuser/src/amplihack-rs/worktrees/feat/issue-903-implement-a-feature-gated-per-sessi
  │ on-signal-chann && git branch --show-current && echo "---CHANGED---" && git status --short &&
  │ echo "---DIFF STAT vs main---" && git --no-pager diff --stat main...HEAD 2>/dev/null | tail -40
  └ Denied by preToolUse hook from "amplihack@local" (hook errored)

✗ Get current branch name (shell)
  │ cd /home/azureuser/src/amplihack-rs/worktrees/feat/issue-903-implement-a-feature-gated-per-sessi
  │ on-signal-chann && git branch --show-current

## Risk
No high-risk subsystem pattern detected from changed paths.

## Checklist
- [x] Branch has 1 commit(s) ahead of main
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*