### PR TITLE
fix(install): register Copilot hooks against stable deployed binary (#911)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/copilot_plugin.rs
+++ b/crates/amplihack-cli/src/commands/install/copilot_plugin.rs
@@ -532,6 +532,67 @@ mod tests {
     }
 
     #[test]
+    fn hooks_json_never_references_transient_build_path() {
+        // Regression for #911: the generated hooks.json (and every generated
+        // hook command string) must point at the stable deployed binary and
+        // must NEVER embed a transient `target/debug` / `target/release` build
+        // path. Such a path lives in a build/worktree dir that later gets
+        // cleaned, making every hook exit 127; Copilot CLI fails closed on hook
+        // errors, denying every tool call in nested sessions.
+        let td = TempDir::new().unwrap();
+        let copilot_home = fake_copilot_home(&td);
+        let repo = fake_repo(&td, false);
+
+        // Simulate the stable deployed location: ~/.local/bin/amplihack-hooks.
+        let deployed_bin = td.path().join(".local").join("bin").join("amplihack-hooks");
+        fs::create_dir_all(deployed_bin.parent().unwrap()).unwrap();
+        fs::write(&deployed_bin, b"#!/bin/sh\nexit 0\n").unwrap();
+
+        let res = run_with_copilot_home(&copilot_home, &repo, &deployed_bin);
+        assert!(res, "registration should succeed when ~/.copilot exists");
+
+        let hooks_path = copilot_home
+            .join("installed-plugins")
+            .join("amplihack@local")
+            .join("hooks.json");
+        let raw = fs::read_to_string(&hooks_path).unwrap();
+
+        assert!(
+            !raw.contains("target/debug") && !raw.contains("target/release"),
+            "hooks.json must never embed a transient build path, got:\n{raw}"
+        );
+        assert!(
+            raw.contains(&deployed_bin.display().to_string()),
+            "hooks.json should reference the deployed stable binary path {}",
+            deployed_bin.display()
+        );
+
+        // Assert on every individual generated command string too, not just the
+        // raw JSON blob, so a future format change can't hide a bad path.
+        let body: Value = serde_json::from_str(&raw).unwrap();
+        let hooks = body.get("hooks").and_then(|h| h.as_object()).unwrap();
+        let mut command_count = 0;
+        for entries in hooks.values() {
+            for entry in entries.as_array().unwrap() {
+                let cmd = entry.get("bash").and_then(|c| c.as_str()).unwrap();
+                command_count += 1;
+                assert!(
+                    !cmd.contains("target/debug") && !cmd.contains("target/release"),
+                    "hook command must not embed a transient build path: {cmd}"
+                );
+                assert!(
+                    cmd.contains(&deployed_bin.display().to_string()),
+                    "hook command should reference the deployed stable path: {cmd}"
+                );
+            }
+        }
+        assert_eq!(
+            command_count, 6,
+            "expected all 6 hook commands to be generated"
+        );
+    }
+
+    #[test]
     fn rejects_shell_metacharacters_in_hooks_binary_path() {
         let td = TempDir::new().unwrap();
         let copilot_home = fake_copilot_home(&td);

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -362,7 +362,17 @@ fn local_install(
         }
     }
 
-    match copilot_plugin::register_copilot_plugin(repo_root, &hooks_bin)
+    // Register the Copilot plugin against the STABLE DEPLOYED hooks binary
+    // (~/.local/bin/amplihack-hooks, the first entry from deploy_binaries()),
+    // NEVER the transient `find_hooks_binary()` source path (e.g.
+    // target/debug/amplihack-hooks). The source path lives in a build/worktree
+    // dir that gets cleaned, making every hook exit 127; Copilot CLI fails
+    // closed on hook errors, denying every tool call in nested sessions (#911).
+    let deployed_hooks_bin = deployed_binaries
+        .first()
+        .cloned()
+        .unwrap_or_else(|| hooks_bin.clone());
+    match copilot_plugin::register_copilot_plugin(repo_root, &deployed_hooks_bin)
         .context("failed to register Copilot CLI plugin")?
     {
         true => {


### PR DESCRIPTION
## Summary

Fixes #911.

The amplihack Copilot plugin `hooks.json` embedded an **absolute path to the transient build artifact** (`<cwd-at-install-time>/target/debug/amplihack-hooks`) returned by `find_hooks_binary()`, instead of the stable deployed binary at `~/.local/bin/amplihack-hooks`.

When that build/worktree dir is later removed or cleaned, every hook command exits `127` (command not found). Copilot CLI 1.0.71 **fails closed** on a hook error, denying **every** tool call in nested/recipe Copilot sub-agents — completely breaking `amplihack recipe run` / default-workflow under Copilot (full outage).

## Root cause

`local_install()` derived two paths:
- `deploy_binaries()[0]` → the **stable** deployed path (`~/.local/bin/amplihack-hooks`)
- `find_hooks_binary()` → the **transient source** build path

`register_copilot_plugin()` was called with the transient path, which `write_hooks_json` / `copilot_hook_command` baked verbatim into all 6 hook command strings.

## Fix

- Thread the deployed path (`deploy_binaries()[0]`, equal to `preferred_user_bin_dir().join("amplihack-hooks")`) through to `register_copilot_plugin()` instead of the `find_hooks_binary()` source path.
- Claude Code `settings.json` still uses `find_hooks_binary()` — inspected and left unchanged: the fail-closed behavior that causes the outage is Copilot-specific, so the fix is kept focused per the issue scope.

## Regression test

`hooks_json_never_references_transient_build_path` asserts the generated `hooks.json` **and each of the 6 generated hook command strings** never contain `target/debug` or `target/release`, and **do** point at the deployed stable location.

## Validation

- `cargo test -p amplihack-cli` — 16 install/copilot_plugin tests pass (including the new one)
- `cargo fmt --check` — clean
- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` — clean

No arbitrary caps/timeouts introduced. Scoped to #911 only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>