### PR TITLE
fix(install): register Copilot hooks against deployed binary, not transient target/debug path (#911)

### DIFF
--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -346,3 +346,91 @@ fn is_python_script(path: &std::path::Path) -> bool {
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    //! TDD regression tests for issue #911.
+    //!
+    //! Root cause: the Copilot plugin `hooks.json` baked the TRANSIENT source
+    //! build path (`<cwd>/target/debug/amplihack-hooks`, returned by
+    //! [`find_hooks_binary`] via the sibling-of-exe step when installing from a
+    //! worktree) instead of the STABLE deployed path
+    //! (`~/.local/bin/amplihack-hooks`, i.e. the first entry of
+    //! [`deploy_binaries`]). When the build/worktree dir is later cleaned, every
+    //! hook command exits 127 and Copilot CLI 1.0.71 fails CLOSED — denying every
+    //! tool call in nested recipe sub-agents.
+    //!
+    //! The fix threads the DEPLOYED path through to the Copilot plugin
+    //! registration. [`deployed_hooks_binary`] is the pure selection seam that
+    //! encodes the invariant "pick the stable deployed `amplihack-hooks`, never a
+    //! build artifact". These tests define its contract and MUST fail until it
+    //! exists.
+    use super::*;
+
+    #[test]
+    fn deployed_hooks_binary_selects_stable_deployed_amplihack_hooks() {
+        // Mirrors the shape of deploy_binaries()'s return value: the deployed
+        // amplihack-hooks under the user bin dir is the FIRST entry, followed by
+        // the amplihack self-binary and the asset-resolver.
+        let deployed = vec![
+            PathBuf::from("/home/u/.local/bin/amplihack-hooks"),
+            PathBuf::from("/home/u/.local/bin/amplihack"),
+            PathBuf::from("/home/u/.local/bin/amplihack-asset-resolver"),
+        ];
+
+        let selected =
+            deployed_hooks_binary(&deployed).expect("should select the deployed hooks bin");
+
+        assert_eq!(
+            selected,
+            Path::new("/home/u/.local/bin/amplihack-hooks"),
+            "must select the stable deployed amplihack-hooks path"
+        );
+        let s = selected.to_string_lossy();
+        assert!(
+            !s.contains("target/debug") && !s.contains("target/release"),
+            "selected hooks binary must NEVER be a transient build artifact, got: {s}"
+        );
+        assert!(
+            s.ends_with(".local/bin/amplihack-hooks"),
+            "selected hooks binary must be the deployed ~/.local/bin copy, got: {s}"
+        );
+    }
+
+    #[test]
+    fn deployed_hooks_binary_ignores_non_hooks_entries() {
+        // Even if ordering changes, selection must key on the amplihack-hooks
+        // file name — never accidentally return the amplihack self-binary or a
+        // stray transient path that happens to be present.
+        let deployed = vec![
+            PathBuf::from("/home/u/.local/bin/amplihack"),
+            PathBuf::from("/tmp/build/target/debug/amplihack-hooks-scratch"),
+            PathBuf::from("/home/u/.local/bin/amplihack-hooks"),
+        ];
+
+        let selected =
+            deployed_hooks_binary(&deployed).expect("should find the deployed hooks bin");
+
+        assert_eq!(
+            selected,
+            Path::new("/home/u/.local/bin/amplihack-hooks"),
+            "must pick the file named exactly amplihack-hooks under the deployed bin dir"
+        );
+        assert!(
+            !selected.to_string_lossy().contains("target/debug"),
+            "must never select a target/debug build artifact"
+        );
+    }
+
+    #[test]
+    fn deployed_hooks_binary_errs_when_absent() {
+        // A deployment vector with no amplihack-hooks entry is a hard error:
+        // baking a bogus/guessed path would reintroduce the 127 outage.
+        let deployed = vec![PathBuf::from("/home/u/.local/bin/amplihack")];
+
+        assert!(
+            deployed_hooks_binary(&deployed).is_err(),
+            "absent amplihack-hooks in deployed set must be an error, not a silent guess"
+        );
+    }
+}

--- a/crates/amplihack-cli/src/commands/install/binary.rs
+++ b/crates/amplihack-cli/src/commands/install/binary.rs
@@ -88,6 +88,24 @@ pub(super) fn validate_hook_command_string(cmd: &str) -> Result<()> {
     Ok(())
 }
 
+/// Select the STABLE deployed `amplihack-hooks` path from a deployment set.
+///
+/// This is the pure selection seam for issue #911: Copilot hook registration
+/// must bake the deployed `~/.local/bin/amplihack-hooks` path (returned by
+/// [`deploy_binaries`]) rather than the transient source build artifact
+/// (`<cwd>/target/debug/amplihack-hooks`) that [`find_hooks_binary`] can
+/// resolve when installing from a worktree. Selection keys strictly on the
+/// exact `amplihack-hooks` file name so ordering changes or stray build paths
+/// can never be chosen. An absent entry is a hard error — baking a guessed
+/// path would reintroduce the exit-127 outage.
+pub(super) fn deployed_hooks_binary(deployed: &[PathBuf]) -> Result<PathBuf> {
+    deployed
+        .iter()
+        .find(|p| p.file_name().is_some_and(|name| name == "amplihack-hooks"))
+        .cloned()
+        .context("no amplihack-hooks entry found in the deployed binary set")
+}
+
 /// Copy the Rust binaries to `~/.local/bin` with 0o755 perms.
 /// Emits a PATH advisory if `~/.local/bin` is not in `$PATH`.
 /// Returns the list of deployed paths for the manifest.

--- a/crates/amplihack-cli/src/commands/install/copilot_plugin.rs
+++ b/crates/amplihack-cli/src/commands/install/copilot_plugin.rs
@@ -953,4 +953,83 @@ mod tests {
             result.err()
         );
     }
+
+    /// Regression guard for issue #911.
+    ///
+    /// The generated Copilot `hooks.json` — and every individual `bash` hook
+    /// command string inside it — must reference the STABLE deployed hooks
+    /// binary (`.../.local/bin/amplihack-hooks`) and must NEVER contain a
+    /// transient `target/debug` or `target/release` build path. A build-artifact
+    /// path vanishes when the worktree/target dir is cleaned, making every hook
+    /// exit 127; Copilot CLI 1.0.71 then fails CLOSED and denies every tool call
+    /// in nested recipe sub-agents.
+    #[test]
+    fn hooks_json_never_references_transient_build_path() {
+        let td = TempDir::new().unwrap();
+        let copilot_home = fake_copilot_home(&td);
+        let repo = fake_repo(&td, false);
+
+        // Simulate the STABLE deployed location: ~/.local/bin/amplihack-hooks.
+        let deployed_bin_dir = td.path().join(".local").join("bin");
+        fs::create_dir_all(&deployed_bin_dir).unwrap();
+        let deployed_hooks_bin = deployed_bin_dir.join("amplihack-hooks");
+        fs::write(&deployed_hooks_bin, b"#!/bin/sh\nexit 0\n").unwrap();
+
+        let res = run_with_copilot_home(&copilot_home, &repo, &deployed_hooks_bin);
+        assert!(res, "registration should succeed when ~/.copilot exists");
+
+        let hooks_path = copilot_home
+            .join("installed-plugins")
+            .join("amplihack@local")
+            .join("hooks.json");
+        let raw = fs::read_to_string(&hooks_path).expect("hooks.json should be written");
+
+        // Negative: no transient build-artifact path anywhere in the file.
+        assert!(
+            !raw.contains("target/debug"),
+            "hooks.json must never reference a target/debug build artifact:\n{raw}"
+        );
+        assert!(
+            !raw.contains("target/release"),
+            "hooks.json must never reference a target/release build artifact:\n{raw}"
+        );
+
+        // Positive: it points at the deployed stable location.
+        let deployed_str = deployed_hooks_bin.display().to_string();
+        assert!(
+            raw.contains(&deployed_str),
+            "hooks.json must point at the deployed stable binary {deployed_str}:\n{raw}"
+        );
+
+        // Per-command assertions: every one of the 6 bash hook command strings
+        // must reference the deployed binary and contain no build path.
+        let body: Value = serde_json::from_str(&raw).unwrap();
+        let hooks = body.get("hooks").and_then(|h| h.as_object()).unwrap();
+        let mut command_count = 0_usize;
+        for (event, entries) in hooks {
+            for entry in entries.as_array().unwrap() {
+                let cmd = entry
+                    .get("bash")
+                    .and_then(|b| b.as_str())
+                    .unwrap_or_else(|| panic!("event {event} entry missing bash command"));
+                command_count += 1;
+                assert!(
+                    !cmd.contains("target/debug") && !cmd.contains("target/release"),
+                    "hook command for {event} must not reference a build artifact: {cmd}"
+                );
+                assert!(
+                    cmd.contains(&deployed_str),
+                    "hook command for {event} must invoke the deployed binary {deployed_str}: {cmd}"
+                );
+                assert!(
+                    cmd.contains("amplihack-hooks"),
+                    "hook command for {event} must invoke amplihack-hooks: {cmd}"
+                );
+            }
+        }
+        assert_eq!(
+            command_count, 6,
+            "expected 6 Copilot hook command strings, found {command_count}"
+        );
+    }
 }

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod version_stamp;
 #[cfg(test)]
 mod tests;
 
-use binary::{deploy_binaries, find_hooks_binary};
+use binary::{deploy_binaries, deployed_hooks_binary, find_hooks_binary};
 use bundle_compat::validate_framework_bundle_compatibility;
 use clone::{download_and_extract_framework_repo, find_bundled_framework_root};
 use directories::*;
@@ -362,7 +362,13 @@ fn local_install(
         }
     }
 
-    match copilot_plugin::register_copilot_plugin(repo_root, &hooks_bin)
+    // Issue #911: Copilot hooks must reference the STABLE deployed binary
+    // (~/.local/bin/amplihack-hooks), not the transient source build path that
+    // find_hooks_binary() can resolve from a worktree. Claude's settings.json
+    // (above) keeps hooks_bin because Copilot 1.0.71's fail-closed behavior is
+    // the outage trigger; scope the change to the Copilot call site.
+    let deployed_hooks_bin = deployed_hooks_binary(&deployed_binaries)?;
+    match copilot_plugin::register_copilot_plugin(repo_root, &deployed_hooks_bin)
         .context("failed to register Copilot CLI plugin")?
     {
         true => {

--- a/docs/COPILOT_CLI.md
+++ b/docs/COPILOT_CLI.md
@@ -204,6 +204,19 @@ pytest .claude/tools/amplihack/hooks/tests/test_power_steering_copilot_cli.py
    refreshes the `amplihack` plugin entry without duplicating it or removing
    unrelated `~/.copilot/config.json` fields.
 
+   **Stable binary path (important):** Every hook command in the generated
+   `hooks.json` invokes the binary at its **deployed, stable location** —
+   `~/.local/bin/amplihack-hooks` (the value of `preferred_user_bin_dir()`) —
+   never a transient build artifact such as `target/debug/amplihack-hooks` or
+   `target/release/amplihack-hooks` inside the source checkout you happened to
+   run `amplihack install` from. `amplihack install` copies (`deploy_binaries`)
+   the hooks binary into `~/.local/bin/` and registers the plugin against that
+   copy. This means the hooks keep working after the source repository,
+   worktree, or `target/` directory is moved, cleaned (`cargo clean`), or
+   deleted. See [Every tool call denied in Copilot
+   sessions](#every-tool-call-denied-in-copilot-sessions-hooks-survive-source-tree-cleanup)
+   for why this matters under Copilot CLI's fail-closed hook policy.
+
 3. **Verify Integration**:
 
    ```bash
@@ -500,6 +513,57 @@ subcommands:
 
 `PreCompact` remains Claude Code-only because Copilot CLI has no documented
 equivalent lifecycle event.
+
+#### Stable Deployed Binary Path
+
+Every command string in the Copilot `hooks.json` points at the **stable,
+deployed** hooks binary — the path returned as the first element of
+`deploy_binaries()`, which is `preferred_user_bin_dir().join("amplihack-hooks")`
+(normally `~/.local/bin/amplihack-hooks`).
+
+The registration flow guarantees this:
+
+1. `deploy_binaries()` copies the freshly built `amplihack-hooks` from wherever
+   the install is reading it (e.g. `target/debug/amplihack-hooks` in a dev
+   checkout, or the packaged binary in a release) into `~/.local/bin/`.
+2. That deployed path is threaded directly into `register_copilot_plugin()`,
+   which bakes it into each of the six hook command strings in `hooks.json`.
+
+The install **never** writes a build-artifact path (`target/debug/…` or
+`target/release/…`) into `hooks.json`. A regression test
+(`hooks_json_never_references_transient_build_path`) asserts that the generated
+JSON and every generated hook command string contain no `target/debug` or
+`target/release` segment and do reference the deployed `~/.local/bin` location.
+
+Why this matters: Copilot CLI (1.0.71+) **fails closed** on a hook error — if a
+hook command exits non-zero (for example exit `127`, "command not found",
+because the binary path no longer exists), Copilot denies the tool call that
+triggered the hook. Because hooks fire on `preToolUse`, a broken hook path
+denies **every** tool call in a Copilot session, including nested
+`amplihack recipe run` / default-workflow sub-agents. Registering against the
+stable `~/.local/bin/amplihack-hooks` copy — instead of a transient build
+artifact that disappears on `cargo clean` or worktree removal — keeps hooks
+resolvable for the life of the install.
+
+An example generated `~/.copilot/installed-plugins/amplihack@local/hooks.json`
+entry:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "'/home/you/.local/bin/amplihack-hooks' pre-tool-use"
+      }
+    ]
+  }
+}
+```
+
+Note the absolute path resolves to `~/.local/bin/`, not into any `target/`
+build directory.
 
 #### Platform Detection
 
@@ -1288,6 +1352,45 @@ file .github/agents/skills/[skill-name]
 # Verify Copilot can read files
 gh copilot explain .github/agents/README.md
 ```
+
+#### Every Tool Call Denied in Copilot Sessions (Hooks Survive Source-Tree Cleanup)
+
+**Problem**: A Copilot CLI session — often a nested `amplihack recipe run` /
+default-workflow sub-agent — denies **every** tool call. Symptoms include a
+hook command exiting `127` ("command not found") and Copilot refusing to run
+any tool because it fails closed on hook errors. This typically appears after
+the source repository, git worktree, or `target/` directory used at install
+time was moved, cleaned (`cargo clean`), or deleted.
+
+**Cause**: A stale `hooks.json` pointing at a transient build artifact
+(`target/debug/amplihack-hooks`) that no longer exists.
+
+**Fix**: Current `amplihack install` always registers hooks against the stable
+deployed path `~/.local/bin/amplihack-hooks`, so a fresh install resolves this
+permanently. To confirm and repair:
+
+```bash
+# 1. Inspect the generated Copilot hooks — commands must point at ~/.local/bin,
+#    NOT at any target/debug or target/release path.
+cat ~/.copilot/installed-plugins/amplihack@local/hooks.json
+
+# Quick check: this should print NOTHING. Any match means a stale hooks.json.
+grep -E 'target/(debug|release)' \
+  ~/.copilot/installed-plugins/amplihack@local/hooks.json && \
+  echo "STALE: re-run 'amplihack install'"
+
+# 2. Confirm the deployed binary exists and is executable.
+ls -l ~/.local/bin/amplihack-hooks
+~/.local/bin/amplihack-hooks --help
+
+# 3. Re-run install to regenerate hooks.json against the stable path.
+amplihack install
+```
+
+After re-installing, every command string in `hooks.json` resolves to
+`~/.local/bin/amplihack-hooks`, which persists independently of any source
+checkout, so hooks — and therefore Copilot tool calls — keep working even after
+`cargo clean` or worktree removal.
 
 ### Debug Mode
 

--- a/docs/reference/binary-resolution.md
+++ b/docs/reference/binary-resolution.md
@@ -71,6 +71,35 @@ Fix: build the binary first:
   cargo build --release --bin amplihack-hooks
 ```
 
+## Copilot Registration: Selecting the Deployed Path
+
+`find_hooks_binary()` locates a **source** binary to copy during install. When
+installing from a worktree it can legitimately resolve a transient build
+artifact such as `<cwd>/target/debug/amplihack-hooks` (via Step 2,
+sibling-of-exe). That path is fine as a *copy source*, but it must never be
+baked into a persisted hook command string — the `target/` directory is
+worktree- and cwd-relative and disappears on `cargo clean` or when the worktree
+is removed, producing an exit-127 fail-closed outage at hook execution time.
+
+To avoid this, Copilot hook registration does **not** use the raw
+`find_hooks_binary()` result. Instead, `deployed_hooks_binary()` selects the
+stable, already-deployed `~/.local/bin/amplihack-hooks` path from the set
+returned by `deploy_binaries()`:
+
+```
+find_hooks_binary()  →  copy source (may be target/debug)
+deploy_binaries()    →  copies to ~/.local/bin/amplihack-hooks
+deployed_hooks_binary(&deployed)  →  ~/.local/bin/amplihack-hooks  ← registered
+```
+
+Selection keys strictly on the exact `amplihack-hooks` file name, so it is
+independent of ordering in the deployed set and can never pick up a stray build
+path. An absent entry is a **hard error** — the installer refuses to bake a
+guessed path rather than reintroduce the outage.
+
+Note: Claude's `~/.claude/settings.json` continues to use `find_hooks_binary()`
+directly; the deployed-path selection is Copilot-specific (see issue #911).
+
 ## Using in Tests
 
 The parity test scenario for install sets `AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH` to a stub executable:


### PR DESCRIPTION
Fixes #911

## Problem

The amplihack Copilot plugin `hooks.json` baked an **absolute path to the
transient build artifact** `<cwd-at-install-time>/target/debug/amplihack-hooks`
instead of the stable deployed binary at `~/.local/bin/amplihack-hooks`.

When that build/worktree dir was later cleaned or removed, every hook command
exited 127 (command not found). Copilot CLI 1.0.71 fails **closed** on a hook
error, denying **every** tool call in nested/recipe Copilot sub-agents —
completely breaking `amplihack recipe run` / default-workflow under Copilot.

## Root Cause

`local_install()` derived the hooks path via `find_hooks_binary()`, which can
resolve the source build artifact (`target/debug/amplihack-hooks`) from the
current worktree, and passed it to `register_copilot_plugin()`.
`write_hooks_json` / `copilot_hook_command` then baked that path verbatim into
all 6 hook command strings.

## Fix

- Added `deployed_hooks_binary()` helper that selects the STABLE deployed
  `~/.local/bin/amplihack-hooks` path (keyed on the exact `amplihack-hooks`
  file name) from the set returned by `deploy_binaries()`.
- Thread the **deployed** path through to `register_copilot_plugin()` instead
  of re-deriving via `find_hooks_binary()`. Claude's `settings.json` is
  intentionally left unchanged (Copilot's fail-closed behavior is the outage
  trigger); the change is scoped to the Copilot call site.
- Verified the other hook path (`~/.copilot/.github/hooks/*` in
  `copilot_setup/hooks.rs`) does NOT share the bug: it uses runtime PATH
  resolution wrapper scripts (`command -v amplihack-hooks` with stable
  `~/.amplihack` fallbacks), not a baked worktree build path. No change needed.

## Tests

- New regression test `hooks_json_never_references_transient_build_path`
  asserts the generated `hooks.json` (and each of the 6 hook command strings)
  never contains `target/debug` / `target/release` and DOES point at the
  deployed stable location.
- New `deployed_hooks_binary` unit tests (selects stable path, ignores
  non-hooks entries, errors when absent).

## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo** — `Cargo.toml` workspace at root; changed files are
  `crates/amplihack-cli/src/commands/install/{binary,copilot_plugin,mod}.rs`.
  The user-visible boundary is the `amplihack install` CLI command and the
  `hooks.json` it generates for Copilot.

Chosen validation strategy:
- Run the Rust regression + helper unit tests (fast, deterministic assertion
  of the invariant), plus a real end-to-end `amplihack install` into an
  isolated fake `HOME` **from within the worktree** (where
  `target/debug/amplihack-hooks` exists) to prove the generated `hooks.json`
  bakes the deployed stable path, not the transient build path. This
  reproduces the exact outage condition.

### Scenario 1 — Regression + helper unit tests (invariant)
Command: `cargo test -p amplihack-cli --lib -- --exact commands::install::copilot_plugin::tests::hooks_json_never_references_transient_build_path commands::install::binary::tests::deployed_hooks_binary_selects_stable_deployed_amplihack_hooks commands::install::binary::tests::deployed_hooks_binary_ignores_non_hooks_entries commands::install::binary::tests::deployed_hooks_binary_errs_when_absent`
Result: PASS
Output:
```
test commands::install::binary::tests::deployed_hooks_binary_ignores_non_hooks_entries ... ok
test commands::install::binary::tests::deployed_hooks_binary_selects_stable_deployed_amplihack_hooks ... ok
test commands::install::binary::tests::deployed_hooks_binary_errs_when_absent ... ok
test commands::install::copilot_plugin::tests::hooks_json_never_references_transient_build_path ... ok
test result: ok. 4 passed; 0 failed
```
(Full install module suite: `cargo test -p amplihack-cli --lib install::` → 259 passed; 0 failed.)

### Scenario 2 — Real `amplihack install` from worktree, inspect generated hooks.json
Command: `HOME=$FAKEHOME ./target/debug/amplihack install` then inspect `$FAKEHOME/.copilot/installed-plugins/amplihack@local/hooks.json`
Result: PASS
Output:
```
✅ Deployed <FAKEHOME>/.local/bin/amplihack-hooks
✅ Copilot CLI plugin hooks.json written to <FAKEHOME>/.copilot/installed-plugins/amplihack@local/hooks.json
--- checking for transient build paths ---
PASS: no target/debug or target/release path in hooks.json
--- deployed path referenced? ---
<FAKEHOME>/.local/bin/amplihack-hooks
PASS: points at deployed ~/.local/bin/amplihack-hooks
--- sample hook command ---
postToolUse -> "<FAKEHOME>/.local/bin/amplihack-hooks" post-tool-use
```

Additional gates: `cargo fmt -p amplihack-cli -- --check` (clean),
`cargo clippy -p amplihack-cli --all-targets -- -D warnings` (exit 0, 0 warnings).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
