### PR TITLE
fix(amplihack-hooks): isolate graph DB env vars in context_loaders tests (#907)

### DIFF
--- a/crates/amplihack-hooks/src/session_start/context_loaders.rs
+++ b/crates/amplihack-hooks/src/session_start/context_loaders.rs
@@ -301,16 +301,13 @@ mod tests {
         let _guard = env_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let saved = std::env::var_os("AMPLIHACK_GRAPH_DB_PATH");
-        unsafe { std::env::remove_var("AMPLIHACK_GRAPH_DB_PATH") };
+        let _graph_db = EnvVarGuard::unset("AMPLIHACK_GRAPH_DB_PATH");
+        let _kuzu_db = EnvVarGuard::unset("AMPLIHACK_KUZU_DB_PATH");
 
         let dir = tempfile::tempdir().unwrap();
         let dirs = ProjectDirs::new(dir.path());
         let result = load_code_graph_context(&dirs);
 
-        if let Some(val) = saved {
-            unsafe { std::env::set_var("AMPLIHACK_GRAPH_DB_PATH", val) };
-        }
         assert!(result.unwrap().is_none());
     }
 
@@ -319,6 +316,8 @@ mod tests {
         let _guard = env_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _graph_db = EnvVarGuard::unset("AMPLIHACK_GRAPH_DB_PATH");
+        let _kuzu_db = EnvVarGuard::unset("AMPLIHACK_KUZU_DB_PATH");
         let dir = tempfile::tempdir().unwrap();
         let dirs = ProjectDirs::new(dir.path());
         let input = dir.path().join("blarify.json");


### PR DESCRIPTION
## Summary
Fixes #907 — test isolation for the code-graph context loader tests.

`load_code_graph_context_describes_native_graph` did **not** clear
`AMPLIHACK_GRAPH_DB_PATH` / `AMPLIHACK_KUZU_DB_PATH`. When an operator's
shell exports `AMPLIHACK_GRAPH_DB_PATH` (e.g. `.../.amplihack/graph_db`),
the test honored that global path instead of its own temp dir, causing a
single-writer kuzu/ladybug DB **lock collision** under parallel
`cargo nextest`.

Its sibling `load_code_graph_context_missing_db_returns_none` only handled
the GRAPH var (via a manual save/restore that leaks on panic) and ignored
the KUZU var.

## Changes (test-only)
- `load_code_graph_context_describes_native_graph`: add panic-safe
  `EnvVarGuard::unset` for **both** `AMPLIHACK_GRAPH_DB_PATH` and
  `AMPLIHACK_KUZU_DB_PATH` (save + remove on setup, restore on drop).
- `load_code_graph_context_missing_db_returns_none`: replace the manual
  GRAPH-only save/restore with `EnvVarGuard::unset` and also guard the
  KUZU var.
- Reuses the existing `crate::test_support::EnvVarGuard`; the `env_lock()`
  mutex is retained to serialize env mutation. No production code changed.

## Verification
- Repro: with `AMPLIHACK_GRAPH_DB_PATH` exported the test previously honored
  the global path (root cause of the parallel lock collision).
- `cargo test -p amplihack-hooks --lib session_start::context_loaders` — **8 passed**, both with the env vars set and unset.
- `cargo fmt -p amplihack-hooks -- --check` — clean.
- `cargo clippy -p amplihack-hooks --tests` — no new warnings.

Scope is limited to this single test-isolation fix for #907.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>