### PR TITLE
fix(workflow-publish): sync Cargo.lock after version bump (#915)

### DIFF
--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -91,7 +91,6 @@ steps:
       if [ -f Cargo.toml ] && [ -f Cargo.lock ]; then
         echo "step-14b: syncing Cargo.lock to bumped version (offline)"
         cargo update --workspace --offline
-        git diff --stat -- Cargo.lock || true
       else
         echo "step-14b: no Cargo.toml/Cargo.lock present; skipping lockfile sync (non-Rust workspace)"
       fi

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -75,6 +75,27 @@ steps:
     output: "version_bump"
     parse_json: true
 
+  - id: "step-14b-sync-lockfile"
+    type: "bash"
+    condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"
+    command: |
+      set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-14b requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+      # Issue #915: step-14 bumps the workspace version in Cargo.toml but leaves
+      # Cargo.lock stale. Every pre-commit gate (artifact-guard, cargo-clippy,
+      # cargo-test) runs with --locked, so step-15 fails deterministically with
+      # "cannot update the lock file ... because --locked was passed". Keep the
+      # lock IN SYNC (do NOT weaken --locked) using an offline, network-free
+      # update. Skip gracefully on non-Rust workspaces.
+      if [ -f Cargo.toml ] && [ -f Cargo.lock ]; then
+        echo "step-14b: syncing Cargo.lock to bumped version (offline)"
+        cargo update --workspace --offline
+        git diff --stat -- Cargo.lock || true
+      else
+        echo "step-14b: no Cargo.toml/Cargo.lock present; skipping lockfile sync (non-Rust workspace)"
+      fi
+
   - id: "step-14g-artifact-guard"
     type: "bash"
     condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"

--- a/docs/index.md
+++ b/docs/index.md
@@ -289,6 +289,7 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [How to Configure Workflow Commit Identity](howto/configure-workflow-commit-identity.md) - Setup for `AMPLIHACK_GIT_*`, repo-local Git identity, and provider-safe fallbacks
 - [Tutorial: Verify Workflow Commit Identity](tutorials/workflow-commit-identity.md) - Disposable-repository walkthrough for explicit, repo-local, GitHub, and Azure DevOps commit attribution
 - [Default Workflow Step 13 Validation Reference](reference/default-workflow-step-13-validation.md) - Toolchain-aware outside-in local validation contract for Step 13
+- [Workflow Publish Lockfile Sync Reference](reference/workflow-publish-lockfile-sync.md) - Offline `Cargo.lock` sync after the version bump so `--locked` pre-commit gates pass (issue #915)
 - [Workflow Terminal-State Reference](reference/workflow-terminal-state.md) - Target contract for development completion evidence, no-op states, failure semantics, and shell helper API
 - [Default Workflow Agentic Finalization](reference/default-workflow-agentic-finalization.md) - Structured finalizer schema, terminal-state vocabulary, configuration, and examples for robust workflow closure
 - [How to Diagnose Workflow Terminal-State Failures](howto/diagnose-workflow-terminal-state.md) - Investigate missing evidence after planning, analysis, design, or worktree-only runs

--- a/docs/reference/workflow-publish-lockfile-sync.md
+++ b/docs/reference/workflow-publish-lockfile-sync.md
@@ -1,0 +1,154 @@
+---
+title: "Workflow Publish Lockfile Sync Reference"
+description: "Contract for the offline Cargo.lock sync step that keeps the lockfile in sync with the bumped workspace version so --locked pre-commit gates pass."
+last_updated: 2026-07-15
+review_schedule: quarterly
+owner: amplihack
+doc_type: reference
+---
+
+# Workflow Publish Lockfile Sync Reference
+
+> [Home](../index.md) > Reference > Workflow Publish Lockfile Sync
+
+The publish phase of `default-workflow` (recipe
+`amplifier-bundle/recipes/workflow-publish.yaml`) bumps the workspace version in
+`Cargo.toml` before it commits, pushes, and opens a pull request. Step
+`step-14b-sync-lockfile` runs immediately after the version bump and
+regenerates `Cargo.lock` from that new version using an offline, network-free
+command. This keeps the lockfile in sync so the `--locked` pre-commit gates
+pass deterministically instead of aborting the run.
+
+## Problem it solves
+
+`step-14-bump-version` rewrites the `version = "X.Y.Z"` line in the workspace
+`Cargo.toml`. Without a matching lockfile update, `Cargo.lock` still records the
+old version for every `amplihack-*` workspace crate. Every pre-commit gate in
+`.pre-commit-config.yaml` — `artifact-guard`, `cargo-clippy`, and `cargo-test` —
+runs Cargo with `--locked`. Cargo refuses to reconcile the drift and fails:
+
+```text
+error: cannot update the lock file ... because --locked was passed to prevent this
+```
+
+`step-15-commit-push` triggers those `--locked` gates through the pre-commit
+hook that fires on `git commit`, so the mismatch made `step-15` fail on every
+run, blocking pull-request creation for all workflows — not only Rust changes
+that touched dependencies. See
+[issue #915](https://github.com/rysweet/amplihack-rs/issues/915).
+
+The fix keeps the lock **in sync**. It does not weaken or remove `--locked`, so
+reproducible builds are preserved.
+
+## Step contract
+
+`step-14b-sync-lockfile` is a `bash` step positioned between
+`step-14-bump-version` and `step-14g-artifact-guard`. It must satisfy the
+following invariants:
+
+| Invariant | Requirement |
+| --- | --- |
+| Ordering | `step-14-bump-version` < `step-14b-sync-lockfile` < `step-14g-artifact-guard` < `step-15-commit-push`. |
+| Offline | Sync uses `cargo update --workspace --offline`. No network access is permitted. |
+| Guarded | Runs only when both `Cargo.toml` and `Cargo.lock` exist; non-Rust workspaces are skipped, not errored. |
+| Worktree resolution | Resolves the target tree with the same `WORKTREE_SETUP_WORKTREE_PATH` fallback chain as the sibling `step-14g-artifact-guard`. |
+| No double-staging | The step does not `git add` the lockfile. `step-15-commit-push` stages it via `git add -A`. |
+| Condition guard | Shares the same `condition` as its sibling steps so it only runs when publishing. |
+
+### Command
+
+```bash
+set -euo pipefail
+: "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
+cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-14b requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+if [ -f Cargo.toml ] && [ -f Cargo.lock ]; then
+  echo "step-14b: syncing Cargo.lock to bumped version (offline)"
+  cargo update --workspace --offline
+  git diff --stat -- Cargo.lock || true
+else
+  echo "step-14b: no Cargo.toml/Cargo.lock present; skipping lockfile sync (non-Rust workspace)"
+fi
+```
+
+### Why `--offline`
+
+`cargo update --workspace --offline` re-resolves only the workspace members and
+writes their bumped versions into `Cargo.lock` using packages already present in
+the local Cargo cache. `--offline` forbids any network fetch, so the step cannot
+silently upgrade transitive dependencies or reach out to a registry. This is the
+primary supply-chain control: the lockfile diff is limited to the
+`amplihack-*` workspace crate versions and remains reviewable in the pull
+request.
+
+`--workspace` scopes the resolution to the workspace so the lockfile rewrite
+surface stays minimal. No `--precise` or unpinned upgrade flags are used, so
+existing dependency pins are not disturbed.
+
+## Configuration
+
+The step needs no feature-specific flag. It uses the standard publish context:
+
+| Context key / variable | Required | How the step uses it |
+| --- | --- | --- |
+| `worktree_setup.worktree_path` (via `WORKTREE_SETUP_WORKTREE_PATH`) | Yes | Directory to `cd` into before running the offline update. Populated by the `workflow-worktree` sub-recipe (step-04). |
+| `RECIPE_VAR_worktree_setup__worktree_path` | Fallback | Secondary source for the worktree path. |
+| `REPO_PATH` | Fallback | Final fallback if the worktree path is unavailable. |
+| `condition` (`goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'`) | Yes | Gates the step to publish-only runs, matching its sibling steps verbatim. |
+
+## Behavior on non-Rust workspaces
+
+If either `Cargo.toml` or `Cargo.lock` is absent, the step prints a skip message
+and exits `0`. Repositories that are not Cargo workspaces continue through the
+publish phase unchanged.
+
+## Examples
+
+### Rust workspace (lockfile synced)
+
+```text
+step-14b: syncing Cargo.lock to bumped version (offline)
+ Cargo.lock | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+```
+
+`step-15-commit-push` then runs `git add -A`, staging the updated `Cargo.lock`
+alongside the bumped `Cargo.toml`, and the `--locked` gates pass.
+
+### Non-Rust workspace (skipped)
+
+```text
+step-14b: no Cargo.toml/Cargo.lock present; skipping lockfile sync (non-Rust workspace)
+```
+
+## Non-goals
+
+- The step does not weaken, remove, or bypass any `--locked` flag in
+  `.pre-commit-config.yaml`. Reproducible builds remain enforced.
+- The step does not fetch from the network. Offline resolution failures must
+  surface loudly rather than fall back to an online update.
+- The step does not stage `Cargo.lock` itself; staging is owned by
+  `step-15-commit-push` via `git add -A`.
+- The step does not upgrade transitive dependencies; `--workspace --offline`
+  limits the rewrite to workspace crate versions.
+
+## Regression expectations
+
+Tests covering this step should assert the semantic contract, not exact prose:
+
+- `step-14b-sync-lockfile` exists in `workflow-publish.yaml`.
+- Step ordering holds:
+  `step-14-bump-version` < `step-14b-sync-lockfile` < `step-14g-artifact-guard`.
+- The recipe text contains `cargo update --workspace --offline`.
+- The lockfile-existence guard (`[ -f Cargo.toml ] && [ -f Cargo.lock ]`) is
+  present so non-Rust workspaces are skipped.
+- No `--locked` flag is removed from `.pre-commit-config.yaml`.
+
+The integration test
+`tests/integration/workflow_publish_terminal_gate.rs` encodes these assertions
+using the shared `load_publish_recipe()` and `step_index()` helpers.
+
+## See also
+
+- [Default Workflow Step 13 Validation Reference](default-workflow-step-13-validation.md)
+- [Workflow Terminal-State Reference](workflow-terminal-state.md)
+- [Worktree Setup Propagation Reference](worktree-setup-propagation.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
           - Tutorial: tutorials/pr-recovery-readiness.md
           - Reference: reference/pr-recovery-readiness.md
       - Terminal-State Provider Safety: reference/workflow-terminal-state-provider-safety.md
+      - Publish Lockfile Sync: reference/workflow-publish-lockfile-sync.md
       - Local Tracking Issue-Number Extraction: recipes/issue-815-804-local-tracking-issue-number.md
   - Agents:
       - Overview: claude/agents/README.md

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -249,6 +249,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     // Phase 6: workflow-publish (terminal gate + steps 14-16b)
     "publish-terminal-state",
     "step-14-bump-version",
+    "step-14b-sync-lockfile",
     "step-14g-artifact-guard",
     "step-15-commit-push",
     "step-16-create-draft-pr",

--- a/tests/integration/workflow_publish_terminal_gate.rs
+++ b/tests/integration/workflow_publish_terminal_gate.rs
@@ -100,6 +100,46 @@ fn publish_mutation_steps_are_suppressed_when_terminal_success_is_true() {
 }
 
 #[test]
+fn publish_syncs_cargo_lock_after_version_bump_before_locked_gates() {
+    // Issue #915: step-14 bumps the workspace version in Cargo.toml but the
+    // lockfile stayed stale, so every --locked pre-commit gate failed. The
+    // fix inserts step-14b-sync-lockfile between the bump and the guard/commit
+    // steps and syncs the lock offline. Assert ordering and the offline command.
+    let recipe = load_publish_recipe();
+
+    let bump = step_index(&recipe, "step-14-bump-version");
+    let sync = step_index(&recipe, "step-14b-sync-lockfile");
+    let guard = step_index(&recipe, "step-14g-artifact-guard");
+    let commit = step_index(&recipe, "step-15-commit-push");
+
+    assert!(
+        bump < sync,
+        "step-14b-sync-lockfile must run AFTER step-14-bump-version"
+    );
+    assert!(
+        sync < guard,
+        "step-14b-sync-lockfile must run BEFORE step-14g-artifact-guard (which runs --locked)"
+    );
+    assert!(
+        sync < commit,
+        "step-14b-sync-lockfile must run BEFORE step-15-commit-push"
+    );
+
+    let text = recipe_text(&recipe);
+    assert!(
+        text.contains("cargo update --workspace --offline"),
+        "step-14b must sync the lockfile with an offline, network-free command"
+    );
+
+    let condition = step_condition(&recipe, "step-14b-sync-lockfile");
+    assert!(
+        condition.contains("terminal_state.should_publish == 'true'")
+            || condition.contains("should_publish == 'true'"),
+        "step-14b must share the publish gate of its sibling mutation steps; condition was `{condition}`"
+    );
+}
+
+#[test]
 fn publish_uses_required_terminal_and_followup_status_vocabulary() {
     let recipe = load_publish_recipe();
     let text = recipe_text(&recipe);


### PR DESCRIPTION
## Summary

Fixes #915.

`default-workflow`'s publish phase bumps the workspace version in `Cargo.toml`
(`step-14-bump-version`) but never regenerated `Cargo.lock`. Every pre-commit
gate (`artifact-guard`, `cargo-clippy`, `cargo-test`) runs with `--locked`, so
the stale lock made `step-15-commit-push` fail deterministically with:

```
error: cannot update the lock file ... because --locked was passed to prevent this
```

This blocked **every** workflow run from opening a PR.

## Change

- Add `step-14b-sync-lockfile` in `amplifier-bundle/recipes/workflow-publish.yaml`,
  positioned immediately **after** `step-14-bump-version` and **before**
  `step-14g-artifact-guard`.
- It runs `cargo update --workspace --offline` (network-free) to sync
  `Cargo.lock` to the bumped version. Verified offline: updates all
  `amplihack-*` workspace crate versions with no network access.
- Guarded with `[ -f Cargo.toml ] && [ -f Cargo.lock ]` so non-Rust
  workspaces are skipped, not errored.
- Uses the same `WORKTREE_SETUP_WORKTREE_PATH` fallback chain as the sibling
  `step-14g-artifact-guard`, and shares the identical publish condition guard.
- `step-15-commit-push` already does `git add -A`, so the synced lock is staged
  automatically — **no double-staging** (the new step only prints `git diff --stat`).

## What is intentionally NOT changed

- The `--locked` flags in `.pre-commit-config.yaml` are left intact. The fix
  keeps the lock **in sync**, it does not weaken reproducible builds.

## Tests

Added `publish_syncs_cargo_lock_after_version_bump_before_locked_gates` to
`tests/integration/workflow_publish_terminal_gate.rs`, asserting:

- `step-14-bump-version < step-14b-sync-lockfile < step-14g-artifact-guard`
  and `< step-15-commit-push`
- the recipe contains `cargo update --workspace --offline`
- the new step shares the sibling publish gate condition

All 5 tests in the `workflow_publish_terminal_gate` target pass. YAML parses
cleanly. Pre-commit (fmt/clippy/yaml/artifact-guard) passes.

Scope is limited to #915 only; no #911/#912 or unrelated changes bundled.

---

## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo workspace** — root `Cargo.toml` + `Cargo.lock`, workspace version `0.11.1` under `[workspace.package]`; 30 `amplihack-*` member crates. The change edits a YAML recipe (`amplifier-bundle/recipes/workflow-publish.yaml`) consumed by the `amplihack` Rust CLI, and the fix's runtime behavior is a Cargo command (`cargo update --workspace --offline`). Evidence: `bins/amplihack/Cargo.toml` registers the integration test `workflow_publish_terminal_gate` at `tests/integration/workflow_publish_terminal_gate.rs`; pre-commit gates in `.pre-commit-config.yaml` invoke cargo with `--locked`.

Chosen validation strategy:
- Two boundaries, both user/consumer-facing: (1) the recipe-parsing integration test that asserts YAML validity and step ordering (`cargo test`), and (2) a faithful reproduction of the real publish flow using cargo itself — bump `[workspace.package].version`, run the stale-lock `--locked` gate to reproduce the deterministic failure from #915, then run the exact fix command `cargo update --workspace --offline` and re-run the `--locked` gate. This proves the user-visible outcome: publish no longer dies on a stale lock, and the offline command needs no network.

### Scenario 1 — Recipe parses and step-14b ordering is correct
Command: `cargo test -p amplihack --test workflow_publish_terminal_gate --locked`
Result: PASS
Output:
```
running 5 tests
test publish_syncs_cargo_lock_after_version_bump_before_locked_gates ... ok
test publish_mutation_steps_are_suppressed_when_terminal_success_is_true ... ok
test publish_runs_terminal_state_probe_before_any_mutation_or_publish_step ... ok
test publish_terminal_success_does_not_wait_for_ci_or_attempt_merge ... ok
test publish_uses_required_terminal_and_followup_status_vocabulary ... ok
test result: ok. 5 passed; 0 failed; 0 ignored
```
(Asserts workflow-publish.yaml is valid YAML, that `step-14-bump-version < step-14b-sync-lockfile < step-14g-artifact-guard < step-15-commit-push`, that the sync step uses `cargo update --workspace --offline`, and that it shares the publish gate condition.)

### Scenario 2 — Reproduce the stale-lock failure, then prove the offline fix resolves it
Command:
```
# simulate step-14-bump-version
sed -i '0,/^version = "0.11.1"/s//version = "0.11.3"/' Cargo.toml
cargo check --locked --offline -p amplihack        # gate BEFORE sync
cargo update --workspace --offline                 # step-14b fix command
cargo check --locked --offline -p amplihack        # gate AFTER sync
```
Result: PASS
Output:
```
step-A gate FAIL (bug reproduced)
  error: cannot update the lock file ... because --locked was passed to prevent this
sync exit=0            # cargo update --workspace --offline: 30 amplihack-* crates 0.11.1 -> 0.11.3, no network
lock entries @0.11.3: 31
step-B gate PASS (fix works)
```
Confirmed idempotent/deterministic across repeated bump→sync→gate cycles. Working tree restored to clean HEAD after testing (`git checkout -- Cargo.toml Cargo.lock`).

**Regression check:** all 5 integration tests in the suite pass; the `--locked` pre-commit gates remain intact (not weakened) — the lock is kept in sync rather than the gate relaxed.
