### PR TITLE
fix: sync root package.json version after workspace bump (#925)

### DIFF
--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -141,6 +141,10 @@ steps:
           exit
         }
       ' Cargo.toml)
+      # Force the cargo metadata fallback when the awk yielded a non-bare-version
+      # token (e.g. a single-quoted TOML literal), rather than writing garbage
+      # into package.json.
+      case "$WS_VERSION" in ''|*[!0-9A-Za-z.+-]*) WS_VERSION="" ;; esac
       if [ -z "$WS_VERSION" ] && command -v cargo >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
         WS_VERSION=$(cargo metadata --no-deps --format-version=1 --offline 2>/dev/null \
           | jq -r '[.packages[] | select(.source == null) | .version] | unique | .[0] // empty' \

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -95,6 +95,75 @@ steps:
         echo "step-14b: no Cargo.toml/Cargo.lock present; skipping lockfile sync (non-Rust workspace)"
       fi
 
+  - id: "step-14c-sync-package-json"
+    type: "bash"
+    condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"
+    command: |
+      set -euo pipefail
+      : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
+      cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-14c requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+      # Issue #925: step-14 bumps [workspace.package].version in Cargo.toml and
+      # step-14b keeps Cargo.lock in sync, but NOTHING synced the root
+      # package.json "version". The contract test
+      # package_json_version_matches_root_workspace_version requires
+      # package.json.version == [workspace.package].version, so any bump left
+      # package.json stale and CI Test failed deterministically (exit 100).
+      # Sync it here in the worktree AFTER the bump, offline (no network, like
+      # step-14b), using a ROBUST version read + ROBUST JSON edit. This step is
+      # idempotent: safe to run even when no bump occurred. Skip gracefully when
+      # package.json is absent (non-JS workspace).
+      if [ ! -f package.json ]; then
+        echo "step-14c: no package.json present; skipping version sync (non-JS workspace)"
+        exit 0
+      fi
+      if [ ! -f Cargo.toml ]; then
+        echo "step-14c: no Cargo.toml present; cannot resolve workspace version; skipping"
+        exit 0
+      fi
+      # Read [workspace.package].version ROBUSTLY. Prefer `cargo metadata`
+      # (offline, network-free like step-14b): workspace members inherit
+      # version.workspace = true, so the local (source == null) packages share
+      # the workspace version. Fall back to a SCOPED [workspace.package] parse
+      # (awk between the section header and the next table) — never an unscoped
+      # grep of `version`, which the version-contract tests explicitly forbid.
+      WS_VERSION=""
+      if command -v cargo >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+        WS_VERSION=$(cargo metadata --no-deps --format-version=1 --offline 2>/dev/null \
+          | jq -r '[.packages[] | select(.source == null) | .version] | unique | .[0] // empty' \
+          2>/dev/null || true)
+      fi
+      if [ -z "$WS_VERSION" ]; then
+        WS_VERSION=$(awk '
+          /^\[workspace\.package\]/ { in_section = 1; next }
+          /^\[/ { in_section = 0 }
+          in_section && /^[[:space:]]*version[[:space:]]*=/ {
+            line = $0
+            sub(/^[^"]*"/, "", line)
+            sub(/".*$/, "", line)
+            print line
+            exit
+          }
+        ' Cargo.toml)
+      fi
+      if [ -z "$WS_VERSION" ]; then
+        echo "ERROR: step-14c could not resolve [workspace.package].version from Cargo.toml" >&2
+        exit 1
+      fi
+      echo "step-14c: syncing package.json version to workspace version ${WS_VERSION} (offline)"
+      # Edit package.json ROBUSTLY (never sed/grep on JSON). Prefer jq (emits a
+      # trailing newline by default, preserving 2-space indentation); fall back
+      # to python3, writing a trailing newline.
+      if command -v jq >/dev/null 2>&1; then
+        _tmp=$(mktemp)
+        jq --arg v "$WS_VERSION" '.version = $v' package.json > "$_tmp"
+        mv "$_tmp" package.json
+      elif command -v python3 >/dev/null 2>&1; then
+        WS_VERSION="$WS_VERSION" python3 -c 'import json, os; p = "package.json"; d = json.load(open(p, encoding="utf-8")); d["version"] = os.environ["WS_VERSION"]; f = open(p, "w", encoding="utf-8"); json.dump(d, f, indent=2); f.write("\n"); f.close()'
+      else
+        echo "ERROR: step-14c needs jq or python3 to edit package.json safely (no sed on JSON)" >&2
+        exit 2
+      fi
+
   - id: "step-14g-artifact-guard"
     type: "bash"
     condition: "goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'"

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -120,30 +120,31 @@ steps:
         echo "step-14c: no Cargo.toml present; cannot resolve workspace version; skipping"
         exit 0
       fi
-      # Read [workspace.package].version ROBUSTLY. Prefer `cargo metadata`
-      # (offline, network-free like step-14b): workspace members inherit
-      # version.workspace = true, so the local (source == null) packages share
-      # the workspace version. Fall back to a SCOPED [workspace.package] parse
-      # (awk between the section header and the next table) — never an unscoped
-      # grep of `version`, which the version-contract tests explicitly forbid.
-      WS_VERSION=""
-      if command -v cargo >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+      # Read [workspace.package].version ROBUSTLY, cheapest-first. step-14 bumps
+      # exactly this field, so a SCOPED [workspace.package] parse (awk between the
+      # section header and the next table) reads the authoritative value in a
+      # single ~1ms pass — never an unscoped grep of `version`, which the
+      # version-contract tests explicitly forbid. Only if that scoped parse comes
+      # up empty (e.g. a single-quoted TOML literal) do we fall back to the more
+      # expensive `cargo metadata` (offline, network-free like step-14b), which
+      # spawns cargo and resolves the whole workspace graph: workspace members
+      # inherit version.workspace = true, so the local (source == null) packages
+      # share the workspace version.
+      WS_VERSION=$(awk '
+        /^\[workspace\.package\]/ { in_section = 1; next }
+        /^\[/ { in_section = 0 }
+        in_section && /^[[:space:]]*version[[:space:]]*=/ {
+          line = $0
+          sub(/^[^"]*"/, "", line)
+          sub(/".*$/, "", line)
+          print line
+          exit
+        }
+      ' Cargo.toml)
+      if [ -z "$WS_VERSION" ] && command -v cargo >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
         WS_VERSION=$(cargo metadata --no-deps --format-version=1 --offline 2>/dev/null \
           | jq -r '[.packages[] | select(.source == null) | .version] | unique | .[0] // empty' \
           2>/dev/null || true)
-      fi
-      if [ -z "$WS_VERSION" ]; then
-        WS_VERSION=$(awk '
-          /^\[workspace\.package\]/ { in_section = 1; next }
-          /^\[/ { in_section = 0 }
-          in_section && /^[[:space:]]*version[[:space:]]*=/ {
-            line = $0
-            sub(/^[^"]*"/, "", line)
-            sub(/".*$/, "", line)
-            print line
-            exit
-          }
-        ' Cargo.toml)
       fi
       if [ -z "$WS_VERSION" ]; then
         echo "ERROR: step-14c could not resolve [workspace.package].version from Cargo.toml" >&2

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -159,7 +159,9 @@ steps:
         jq --arg v "$WS_VERSION" '.version = $v' package.json > "$_tmp"
         mv "$_tmp" package.json
       elif command -v python3 >/dev/null 2>&1; then
-        WS_VERSION="$WS_VERSION" python3 -c 'import json, os; p = "package.json"; d = json.load(open(p, encoding="utf-8")); d["version"] = os.environ["WS_VERSION"]; f = open(p, "w", encoding="utf-8"); json.dump(d, f, indent=2); f.write("\n"); f.close()'
+        # Atomic replace (temp + os.replace) to match the jq path: a crash
+        # mid-write must never truncate/corrupt package.json in a publish path.
+        WS_VERSION="$WS_VERSION" python3 -c 'import json, os, tempfile; p = "package.json"; d = json.load(open(p, encoding="utf-8")); d["version"] = os.environ["WS_VERSION"]; fd, tmp = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(p)) or ".", prefix=".package.json."); f = os.fdopen(fd, "w", encoding="utf-8"); json.dump(d, f, indent=2); f.write("\n"); f.close(); os.replace(tmp, p)'
       else
         echo "ERROR: step-14c needs jq or python3 to edit package.json safely (no sed on JSON)" >&2
         exit 2

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -155,7 +155,11 @@ steps:
       # trailing newline by default, preserving 2-space indentation); fall back
       # to python3, writing a trailing newline.
       if command -v jq >/dev/null 2>&1; then
-        _tmp=$(mktemp)
+        # Same-directory temp + mv = atomic rename on one filesystem. A bare
+        # mktemp defaults to $TMPDIR, so `mv` could cross filesystems and
+        # degrade to copy+unlink (non-atomic) — matching the python3 fallback's
+        # same-dir guarantee keeps a mid-write crash from corrupting package.json.
+        _tmp=$(mktemp ./.package.json.XXXXXX)
         jq --arg v "$WS_VERSION" '.version = $v' package.json > "$_tmp"
         mv "$_tmp" package.json
       elif command -v python3 >/dev/null 2>&1; then

--- a/docs/index.md
+++ b/docs/index.md
@@ -290,6 +290,7 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [Tutorial: Verify Workflow Commit Identity](tutorials/workflow-commit-identity.md) - Disposable-repository walkthrough for explicit, repo-local, GitHub, and Azure DevOps commit attribution
 - [Default Workflow Step 13 Validation Reference](reference/default-workflow-step-13-validation.md) - Toolchain-aware outside-in local validation contract for Step 13
 - [Workflow Publish Lockfile Sync Reference](reference/workflow-publish-lockfile-sync.md) - Offline `Cargo.lock` sync after the version bump so `--locked` pre-commit gates pass (issue #915)
+- [Workflow Publish package.json Sync Reference](reference/workflow-publish-package-json-sync.md) - Offline, atomic root `package.json` version sync after the version bump so the CI version-contract test passes (issue #925)
 - [Workflow Terminal-State Reference](reference/workflow-terminal-state.md) - Target contract for development completion evidence, no-op states, failure semantics, and shell helper API
 - [Default Workflow Agentic Finalization](reference/default-workflow-agentic-finalization.md) - Structured finalizer schema, terminal-state vocabulary, configuration, and examples for robust workflow closure
 - [How to Diagnose Workflow Terminal-State Failures](howto/diagnose-workflow-terminal-state.md) - Investigate missing evidence after planning, analysis, design, or worktree-only runs

--- a/docs/reference/workflow-publish-package-json-sync.md
+++ b/docs/reference/workflow-publish-package-json-sync.md
@@ -1,0 +1,194 @@
+---
+title: "Workflow Publish package.json Sync Reference"
+description: "Contract for the offline package.json version sync step that keeps the root package.json version in sync with the bumped workspace version so the CI version-contract test passes."
+last_updated: 2026-07-15
+review_schedule: quarterly
+owner: amplihack
+doc_type: reference
+---
+
+# Workflow Publish package.json Sync Reference
+
+> [Home](../index.md) > Reference > Workflow Publish package.json Sync
+
+The publish phase of `default-workflow` (recipe
+`amplifier-bundle/recipes/workflow-publish.yaml`) bumps the workspace version in
+`Cargo.toml` before it commits, pushes, and opens a pull request. Step
+`step-14c-sync-package-json` runs after the version bump (and after
+`step-14b-sync-lockfile`) and rewrites the root `package.json` `version` field to
+match the bumped `[workspace.package].version`. It reads the version offline and
+edits the JSON structurally so the CI version-contract test passes
+deterministically instead of failing on stale version drift.
+
+## Problem it solves
+
+`step-14-bump-version` rewrites the `version = "X.Y.Z"` line in the workspace
+`Cargo.toml`. `step-14b-sync-lockfile` keeps `Cargo.lock` in sync, but nothing
+synced the root `package.json` `version`. The contract test
+`package_json_version_matches_root_workspace_version` requires
+`package.json.version == [workspace.package].version`, so any bump left
+`package.json` stale and CI Test failed deterministically (exit 100). See
+[issue #925](https://github.com/rysweet/amplihack-rs/issues/925).
+
+The fix keeps `package.json` **in sync** with the authoritative Cargo workspace
+version. It does not change the version contract or the source of truth.
+
+## Step contract
+
+`step-14c-sync-package-json` is a `bash` step positioned between
+`step-14b-sync-lockfile` and `step-14g-artifact-guard`. It must satisfy the
+following invariants:
+
+| Invariant | Requirement |
+| --- | --- |
+| Ordering | `step-14-bump-version` < `step-14b-sync-lockfile` < `step-14c-sync-package-json` < `step-14g-artifact-guard` < `step-15-commit-push`. |
+| Offline | The version is read offline. The scoped `awk` parse touches no network; the `cargo metadata` fallback uses `--offline`. |
+| Robust read | Reads `[workspace.package].version` with a **scoped** `[workspace.package]` `awk` parse (never an unscoped `grep` of `version`, which the version-contract tests forbid), falling back to `cargo metadata --offline` only when the scoped parse is empty. |
+| Robust edit | Edits `package.json` with `jq` (or a `python3` fallback) — never `sed`/`grep` on JSON. Preserves 2-space indentation and a trailing newline. |
+| Atomic write | Both write paths write to a **same-directory** temp file and atomically replace `package.json` (`mv`/`os.replace`), so a mid-write crash cannot truncate or corrupt the file. |
+| Idempotent | Safe to run when no bump occurred; re-running produces no change. |
+| Guarded | Runs only when `package.json` and `Cargo.toml` both exist; non-JS / non-Rust workspaces are skipped (`exit 0`), not errored. |
+| Worktree resolution | Resolves the target tree with the same `WORKTREE_SETUP_WORKTREE_PATH` fallback chain as the sibling `step-14b`/`step-14g` steps. |
+| No double-staging | The step does not `git add` `package.json`. `step-15-commit-push` stages it via `git add -A`. |
+| Condition guard | Shares the same `condition` as its sibling steps so it only runs when publishing. |
+
+### Command
+
+```bash
+set -euo pipefail
+: "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
+cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-14c requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
+if [ ! -f package.json ]; then
+  echo "step-14c: no package.json present; skipping version sync (non-JS workspace)"
+  exit 0
+fi
+if [ ! -f Cargo.toml ]; then
+  echo "step-14c: no Cargo.toml present; cannot resolve workspace version; skipping"
+  exit 0
+fi
+# Scoped [workspace.package] parse (cheapest-first, ~1ms), never an unscoped grep.
+WS_VERSION=$(awk '
+  /^\[workspace\.package\]/ { in_section = 1; next }
+  /^\[/ { in_section = 0 }
+  in_section && /^[[:space:]]*version[[:space:]]*=/ {
+    line = $0; sub(/^[^"]*"/, "", line); sub(/".*$/, "", line); print line; exit
+  }
+' Cargo.toml)
+if [ -z "$WS_VERSION" ] && command -v cargo >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  WS_VERSION=$(cargo metadata --no-deps --format-version=1 --offline 2>/dev/null \
+    | jq -r '[.packages[] | select(.source == null) | .version] | unique | .[0] // empty' \
+    2>/dev/null || true)
+fi
+if [ -z "$WS_VERSION" ]; then
+  echo "ERROR: step-14c could not resolve [workspace.package].version from Cargo.toml" >&2
+  exit 1
+fi
+echo "step-14c: syncing package.json version to workspace version ${WS_VERSION} (offline)"
+if command -v jq >/dev/null 2>&1; then
+  _tmp=$(mktemp ./.package.json.XXXXXX)
+  jq --arg v "$WS_VERSION" '.version = $v' package.json > "$_tmp"
+  mv "$_tmp" package.json
+elif command -v python3 >/dev/null 2>&1; then
+  WS_VERSION="$WS_VERSION" python3 -c 'import json, os, tempfile; p = "package.json"; d = json.load(open(p, encoding="utf-8")); d["version"] = os.environ["WS_VERSION"]; fd, tmp = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(p)) or ".", prefix=".package.json."); f = os.fdopen(fd, "w", encoding="utf-8"); json.dump(d, f, indent=2); f.write("\n"); f.close(); os.replace(tmp, p)'
+else
+  echo "ERROR: step-14c needs jq or python3 to edit package.json safely (no sed on JSON)" >&2
+  exit 2
+fi
+```
+
+### Why the scoped read
+
+`step-14` bumps exactly `[workspace.package].version`, so a **scoped** parse of
+that TOML table reads the authoritative value in a single ~1ms pass. This is
+cheapest-first: the near-free `awk` parse runs before the more expensive
+`cargo metadata` subprocess (which spawns cargo and resolves the whole workspace
+graph). `cargo metadata --offline` is retained only as a fallback for edge cases
+such as single-quoted TOML literals. An unscoped `grep` of `version` is
+explicitly forbidden by the version-contract tests because it could match an
+unrelated dependency's version.
+
+### Why the atomic, structural edit
+
+`package.json` is edited with `jq` (or `python3` as a fallback), never `sed` or
+`grep`, so the JSON is always re-serialized from a parsed structure. Both write
+paths write to a **same-directory** temp file and then atomically replace
+`package.json` via `mv` (`jq` path) or `os.replace` (`python3` path). A
+same-directory temp keeps the replace on one filesystem so it is a true atomic
+rename rather than a cross-device copy+unlink; a crash mid-write therefore
+cannot truncate or corrupt `package.json` in the publish path. Both paths
+preserve 2-space indentation and a trailing newline.
+
+## Configuration
+
+The step needs no feature-specific flag. It uses the standard publish context:
+
+| Context key / variable | Required | How the step uses it |
+| --- | --- | --- |
+| `worktree_setup.worktree_path` (via `WORKTREE_SETUP_WORKTREE_PATH`) | Yes | Directory to `cd` into before reading/writing. Populated by the `workflow-worktree` sub-recipe (step-04). |
+| `RECIPE_VAR_worktree_setup__worktree_path` | Fallback | Secondary source for the worktree path. |
+| `REPO_PATH` | Fallback | Final fallback if the worktree path is unavailable. |
+| `condition` (`goal_already_met != 'true' && terminal_state.terminal_success != 'true' && terminal_state.should_publish == 'true'`) | Yes | Gates the step to publish-only runs, matching its sibling steps verbatim. |
+
+## Behavior on non-JS / non-Rust workspaces
+
+If `package.json` is absent, the step prints a skip message and exits `0`. If
+`Cargo.toml` is absent (no workspace version to resolve), it likewise skips and
+exits `0`. Repositories that are not JS-and-Cargo workspaces continue through
+the publish phase unchanged.
+
+## Examples
+
+### JS + Rust workspace (version synced)
+
+```text
+step-14c: syncing package.json version to workspace version 0.11.1 (offline)
+```
+
+`step-15-commit-push` then runs `git add -A`, staging the updated `package.json`
+alongside the bumped `Cargo.toml` and `Cargo.lock`, and the CI version-contract
+test passes.
+
+### Non-JS workspace (skipped)
+
+```text
+step-14c: no package.json present; skipping version sync (non-JS workspace)
+```
+
+## Non-goals
+
+- The step does not change the source of truth. `[workspace.package].version`
+  in `Cargo.toml` remains authoritative; `package.json` is derived from it.
+- The step does not use the network. Offline read failures surface loudly
+  (`exit 1`) rather than falling back to an online lookup.
+- The step does not edit JSON with `sed`/`grep`; structural editors (`jq` /
+  `python3`) are required.
+- The step does not stage `package.json` itself; staging is owned by
+  `step-15-commit-push` via `git add -A`.
+
+## Regression expectations
+
+Tests covering this step should assert the semantic contract, not exact prose:
+
+- `step-14c-sync-package-json` exists in `workflow-publish.yaml`.
+- Step ordering holds:
+  `step-14-bump-version` < `step-14b-sync-lockfile` <
+  `step-14c-sync-package-json` < `step-14g-artifact-guard` < `step-15-commit-push`.
+- The version read is scoped to `[workspace.package]` (no unscoped `grep` of
+  `version`) with an `--offline` `cargo metadata` fallback.
+- The JSON edit uses `jq`/`python3` (never `sed`) and writes atomically via a
+  same-directory temp file.
+- The existence guards (`package.json`, `Cargo.toml`) are present so
+  non-JS / non-Rust workspaces are skipped.
+- The step shares the publish `condition` with its sibling steps.
+
+The integration test
+`tests/integration/workflow_publish_terminal_gate.rs` encodes these assertions
+using the shared `load_publish_recipe()` and `step_index()` helpers
+(`publish_syncs_package_json_version_after_bump_before_locked_gates`).
+
+## See also
+
+- [Workflow Publish Lockfile Sync Reference](workflow-publish-lockfile-sync.md)
+- [Default Workflow Step 13 Validation Reference](default-workflow-step-13-validation.md)
+- [Workflow Terminal-State Reference](workflow-terminal-state.md)
+- [Worktree Setup Propagation Reference](worktree-setup-propagation.md)

--- a/tests/integration/default_workflow_decomposition_test.rs
+++ b/tests/integration/default_workflow_decomposition_test.rs
@@ -250,6 +250,7 @@ const EXPECTED_STEP_INVENTORY: &[&str] = &[
     "publish-terminal-state",
     "step-14-bump-version",
     "step-14b-sync-lockfile",
+    "step-14c-sync-package-json",
     "step-14g-artifact-guard",
     "step-15-commit-push",
     "step-16-create-draft-pr",

--- a/tests/integration/workflow_publish_terminal_gate.rs
+++ b/tests/integration/workflow_publish_terminal_gate.rs
@@ -140,6 +140,84 @@ fn publish_syncs_cargo_lock_after_version_bump_before_locked_gates() {
 }
 
 #[test]
+fn publish_syncs_package_json_version_after_bump_before_locked_gates() {
+    // Issue #925: step-14 bumps [workspace.package].version in Cargo.toml and
+    // step-14b keeps Cargo.lock in sync, but nothing synced root package.json's
+    // "version". The contract test package_json_version_matches_root_workspace_version
+    // then failed on CI (exit 100) because package.json stayed stale. The fix
+    // inserts step-14c-sync-package-json after the bump/lockfile sync and before
+    // the --locked gates and commit. Assert ordering, the robust offline version
+    // read, the robust JSON edit, graceful skip, and the shared publish gate.
+    let recipe = load_publish_recipe();
+
+    let bump = step_index(&recipe, "step-14-bump-version");
+    let lock_sync = step_index(&recipe, "step-14b-sync-lockfile");
+    let json_sync = step_index(&recipe, "step-14c-sync-package-json");
+    let guard = step_index(&recipe, "step-14g-artifact-guard");
+    let commit = step_index(&recipe, "step-15-commit-push");
+
+    assert!(
+        bump < json_sync,
+        "step-14c-sync-package-json must run AFTER step-14-bump-version"
+    );
+    assert!(
+        lock_sync < json_sync,
+        "step-14c-sync-package-json must run AFTER step-14b-sync-lockfile"
+    );
+    assert!(
+        json_sync < guard,
+        "step-14c-sync-package-json must run BEFORE step-14g-artifact-guard (which runs --locked)"
+    );
+    assert!(
+        json_sync < commit,
+        "step-14c-sync-package-json must run BEFORE step-15-commit-push (which stages package.json)"
+    );
+
+    let command = steps(&recipe)[json_sync]
+        .get("command")
+        .and_then(Value::as_str)
+        .expect("step-14c-sync-package-json must be a bash command step");
+
+    // Robust, offline version read: cargo metadata (offline) and/or a scoped
+    // [workspace.package] parse. Must NOT use an unscoped grep of version.
+    assert!(
+        command.contains("cargo metadata") || command.contains("[workspace.package]"),
+        "step-14c must derive the version from `cargo metadata` or a scoped [workspace.package] parse"
+    );
+    assert!(
+        command.contains("--offline"),
+        "step-14c must resolve the version offline (network-free), consistent with step-14b"
+    );
+    assert!(
+        !command.contains("grep '^version'") && !command.contains("grep \"^version\""),
+        "step-14c must not use a drift-prone unscoped grep of Cargo.toml version"
+    );
+
+    // Robust JSON edit: jq (with a python3 fallback), never sed on JSON.
+    assert!(
+        command.contains("jq "),
+        "step-14c must edit package.json with jq (robust JSON edit, not sed/grep)"
+    );
+    assert!(
+        command.contains("package.json"),
+        "step-14c must target package.json for the version sync"
+    );
+
+    // Graceful skip when package.json is absent (non-JS workspace).
+    assert!(
+        command.contains("no package.json present") || command.contains("[ ! -f package.json ]"),
+        "step-14c must skip gracefully when package.json is absent (non-JS workspace)"
+    );
+
+    let condition = step_condition(&recipe, "step-14c-sync-package-json");
+    assert!(
+        condition.contains("terminal_state.should_publish == 'true'")
+            || condition.contains("should_publish == 'true'"),
+        "step-14c must share the publish gate of its sibling mutation steps; condition was `{condition}`"
+    );
+}
+
+#[test]
 fn publish_uses_required_terminal_and_followup_status_vocabulary() {
     let recipe = load_publish_recipe();
     let text = recipe_text(&recipe);


### PR DESCRIPTION
Fixes #925.

## Problem
`default-workflow`'s `step-14-bump-version` bumps `[workspace.package].version` in `Cargo.toml`, and `step-14b-sync-lockfile` keeps `Cargo.lock` in sync — but **nothing** synced the root `package.json` `"version"`. The contract test `package_json_version_matches_root_workspace_version` (`tests/integration/version_contract_test.rs`) requires `package.json.version == [workspace.package].version`, so any bump left `package.json` stale and the CI Test job failed deterministically (exit 100). Pre-commit gates did not catch it.

## Fix
Add `step-14c-sync-package-json` immediately after `step-14b-sync-lockfile` in `amplifier-bundle/recipes/workflow-publish.yaml` (worktree, post-bump, same publish `condition`). It:

- Reads `[workspace.package].version` **robustly**: `cargo metadata --no-deps --format-version=1 --offline` (offline, network-free like 14b), falling back to a **scoped** `[workspace.package]` `awk` parse — never an unscoped `grep` of `version` (which the version-contract tests forbid).
- Edits `package.json` **robustly** via `jq` (with a `python3` fallback), preserving 2-space indentation and trailing newline — **no** `sed`/`grep` on JSON.
- Runs **offline** and is **idempotent** (safe even if no bump occurred).
- **Skips gracefully** with `exit 0` when `package.json` is absent (non-JS workspace), mirroring 14b's non-Rust skip.

No `--locked` gate is weakened; `step-14b` is untouched; **the version is not bumped by this PR**.

## Regression test
Adds `publish_syncs_package_json_version_after_bump_before_locked_gates` to `tests/integration/workflow_publish_terminal_gate.rs` (mirroring the existing 14b workflow-shape test). It asserts step-14c's ordering (after bump/lock-sync, before `--locked` guard and commit), offline version read, robust `jq` edit, graceful skip, and shared publish gate. **Verified it fails if the sync step is removed.**

## Validation
- `cargo test -p amplihack --test workflow_publish_terminal_gate --test version_contract` → all pass (including the existing contract test).
- Removed step-14c temporarily → new regression test fails as expected; restored.
- Functionally tested the sync logic (cargo-metadata read → `0.11.1`; scoped awk parse; `jq` and `python3` edits both preserve 2-space indent + trailing newline).
- `cargo fmt --all --check` clean; `cargo clippy -- -D warnings` clean.

## Scope
Single focused PR for #925 only. Only two files changed; `Cargo.toml`/`package.json` versions untouched.