### PR TITLE
fix(migrate): reconstruct project tree & rewrite cwd/git_root on resume (#909)

### DIFF
--- a/amplifier-bundle/skills/migrate/SKILL.md
+++ b/amplifier-bundle/skills/migrate/SKILL.md
@@ -54,7 +54,27 @@ The destination `<hostname>` must be an azlin-managed VM (reachable via
 5. Verifies `gh auth`, `copilot --version`, and session-state integrity.
 6. Runs a final delta `rsync` of the active session-state to capture
    events written during the transfer.
-7. Starts the CLI in a detached tmux on the destination:
+7. Reconstructs the project tree on the destination so the resumed session
+   lands in a valid git checkout instead of `$HOME`:
+   - Reads `cwd`, `git_root`, `repository`, `host_type`, `branch` from the
+     active session's `workspace.yaml` (flat `grep`/`sed` parsing, no `yq`).
+   - **Skips** (warn + resume in `$HOME`, no hard-gate) when the session has no
+     reconstructable project: no `workspace.yaml`, absent `repository`/`git_root`,
+     or a non-github `host_type`.
+   - Validates the untrusted fields (repo/branch/host_type regex + allowlist);
+     a malformed field on a github session is fatal (exit 11).
+   - Re-derives destination paths from the **validated** `repository`/`branch`
+     (the source `git_root`, which amplihack records equal to `cwd`, is not
+     reused): `$HOME/src/<repo>` for the clone and
+     `$HOME/src/<repo>/worktrees/<branch>` for worktree sessions (detected by
+     `/worktrees/` in `cwd`; double-nested worktrees normalized to one level).
+   - `gh repo clone <repository>` (idempotent fetch+checkout if `.git` exists);
+     `git worktree add` for worktree sessions, falling back to a standalone
+     clone/checkout at `cwd` so the hard-gate still passes.
+   - Rewrites `cwd` **and** `git_root` in the destination `workspace.yaml`.
+   - Hard-gates before resume: aborts if `cwd` is missing or not a git
+     checkout on the recorded branch (unless reconstruction was skipped).
+8. Starts the CLI in a detached tmux on the destination:
    - copilot: `copilot --resume <id>`
    - claude: `claude --resume <id>` (best-effort)
    - amplifier: prints manual-attach instructions (v1)
@@ -64,11 +84,13 @@ your laptop to attach.
 
 ## What Is Not Migrated
 
-- `~/src/*` source trees (fresh-clone on the new host instead)
+- `~/src/*` source trees — **reconstructed** on the destination via
+  `gh repo clone` / `git worktree add` from the paths recorded in the session's
+  `workspace.yaml` (cross-user paths remapped under `$HOME`), not copied in the
+  tarball. Uncommitted / unpushed changes are not carried over.
 - Caches: `**/target/`, `**/.venv/`, `**/node_modules/`, `~/.cache/`,
-  `**/__pycache__/`
+  `**/__pycache__/`, and any directory tagged `CACHEDIR.TAG`
 - Inactive sessions under `~/.copilot/session-state/`
-- Log files > 10 MB
 
 ## Security Note
 

--- a/amplifier-bundle/skills/migrate/SKILL.md
+++ b/amplifier-bundle/skills/migrate/SKILL.md
@@ -71,6 +71,9 @@ The destination `<hostname>` must be an azlin-managed VM (reachable via
    - `gh repo clone <repository>` (idempotent fetch+checkout if `.git` exists);
      `git worktree add` for worktree sessions, falling back to a standalone
      clone/checkout at `cwd` so the hard-gate still passes.
+   - All GitHub network calls (clone/fetch) use bounded retry-with-backoff
+     (`AMPLIHACK_MIGRATE_RETRIES` / `AMPLIHACK_MIGRATE_RETRY_DELAY`) so a
+     transient network failure retries before the exit-13 hard failure.
    - Rewrites `cwd` **and** `git_root` in the destination `workspace.yaml`.
    - Hard-gates before resume: aborts if `cwd` is missing or not a git
      checkout on the recorded branch (unless reconstruction was skipped).

--- a/amplifier-bundle/skills/migrate/scripts/migrate.sh
+++ b/amplifier-bundle/skills/migrate/scripts/migrate.sh
@@ -593,6 +593,15 @@ _fetch_branch() { git -C "$1" fetch origin "$branch" >/dev/null 2>&1; }
 _gh_clone()     { gh repo clone "$repository" "$1" >/dev/null 2>&1; }
 _git_clone()    { git clone "https://github.com/$repository.git" "$1" >/dev/null 2>&1; }
 
+# clone_repo <dest>: idempotent clone of $repository into <dest>. Prefers gh
+# (reuses the migrated auth); falls back to https. Each network call is retried.
+clone_repo() {
+  local dest="$1"
+  [ -d "$dest/.git" ] && return 0
+  if command -v gh >/dev/null 2>&1 && with_retry _gh_clone "$dest"; then return 0; fi
+  with_retry _git_clone "$dest"
+}
+
 repo_name="${repository##*/}"
 git_root_dest="$HOME/src/$repo_name"
 if [ "$is_worktree" = "1" ]; then
@@ -620,10 +629,8 @@ mkdir -p "$HOME/src"
 if [ -d "$git_root_dest/.git" ]; then
   echo "[migrate] existing checkout at $git_root_dest; fetching"
   with_retry _fetch_all "$git_root_dest" || true
-elif command -v gh >/dev/null 2>&1 && with_retry _gh_clone "$git_root_dest"; then
-  echo "[migrate] cloned $repository via gh -> $git_root_dest"
-elif with_retry _git_clone "$git_root_dest"; then
-  echo "[migrate] cloned $repository via https -> $git_root_dest"
+elif clone_repo "$git_root_dest"; then
+  echo "[migrate] cloned $repository -> $git_root_dest"
 else
   echo "[migrate] clone failed for $repository after ${retries} attempt(s)" >&2
   exit 13
@@ -643,13 +650,7 @@ if [ "$is_worktree" = "1" ]; then
       with_retry _fetch_branch "$git_root_dest" || true
       if ! git -C "$git_root_dest" worktree add "$cwd_dest" "$branch" >/dev/null 2>&1; then
         echo "[migrate] worktree add failed; falling back to standalone clone at $cwd_dest" >&2
-        if [ ! -d "$cwd_dest/.git" ]; then
-          if command -v gh >/dev/null 2>&1 && with_retry _gh_clone "$cwd_dest"; then
-            :
-          else
-            with_retry _git_clone "$cwd_dest" || true
-          fi
-        fi
+        clone_repo "$cwd_dest" || true
         checkout_branch "$cwd_dest" || true
       fi
     fi

--- a/amplifier-bundle/skills/migrate/scripts/migrate.sh
+++ b/amplifier-bundle/skills/migrate/scripts/migrate.sh
@@ -7,6 +7,152 @@ log_info() { printf '\033[1;34m[migrate]\033[0m %s\n' "$*"; }
 log_warn() { printf '\033[1;33m[migrate]\033[0m %s\n' "$*" >&2; }
 log_err()  { printf '\033[1;31m[migrate]\033[0m %s\n' "$*" >&2; }
 
+# ===========================================================================
+# Project reconstruction library (issue #909)
+#
+# Pure, sourceable helpers used by the reconstruction phase. They carry no
+# side effects beyond reading/rewriting the passed file, so they can be unit
+# tested off-host (see scripts/tests/test_workspace_rewrite.bats) by sourcing
+# this script with AMPLIHACK_MIGRATE_LIB=1.
+#
+# The resumed session on the destination VM must land in a valid git checkout,
+# not $HOME. These helpers parse the session's workspace.yaml, validate the
+# untrusted fields (reject-don't-sanitize), remap the recorded cross-user
+# cwd/git_root under the destination $HOME, and rewrite workspace.yaml.
+# ===========================================================================
+
+# migrate_yaml_field <file> <key>
+# Extract a flat top-level scalar from a workspace.yaml using grep/sed only
+# (no yq dependency). Strips surrounding quotes and trailing whitespace.
+# Absence of the key is NOT an error — it prints an empty string and returns 0.
+migrate_yaml_field() {
+  local file="$1" key="$2" line val
+  [[ -f "$file" ]] || { printf '\n'; return 0; }
+  # Exact top-level key match: start-of-line, key, colon. This avoids matching
+  # substrings such as git_root when asked for root, or root_cause.
+  line="$(grep -E "^${key}:" "$file" 2>/dev/null | head -1 || true)"
+  [[ -n "$line" ]] || { printf '\n'; return 0; }
+  val="${line#*:}"                        # strip up to first colon
+  val="${val#"${val%%[![:space:]]*}"}"    # ltrim
+  val="${val%"${val##*[![:space:]]}"}"    # rtrim
+  if [[ ${#val} -ge 2 && "$val" == \"*\" ]]; then
+    val="${val#\"}"; val="${val%\"}"
+  elif [[ ${#val} -ge 2 && "$val" == \'*\' ]]; then
+    val="${val#\'}"; val="${val%\'}"
+  fi
+  printf '%s\n' "$val"
+}
+
+# migrate_validate_repository <value>
+# Accept only owner/name; reject empties, newlines, extra slashes, leading '-'
+# (git/gh option-injection), and shell metacharacters.
+migrate_validate_repository() {
+  local v="$1"
+  [[ -n "$v" ]] || return 1
+  [[ "$v" == *$'\n'* ]] && return 1
+  [[ "$v" =~ ^[A-Za-z0-9_.][A-Za-z0-9._-]*/[A-Za-z0-9_.][A-Za-z0-9._-]*$ ]] || return 1
+  return 0
+}
+
+# migrate_validate_branch <value>
+# Reject empties, newlines, leading '-' (git-option injection), and '..'
+# (path traversal). Otherwise allow the git ref charset incl. slashes.
+migrate_validate_branch() {
+  local v="$1"
+  [[ -n "$v" ]] || return 1
+  [[ "$v" == *$'\n'* ]] && return 1
+  [[ "$v" == -* ]] && return 1
+  [[ "$v" == *".."* ]] && return 1
+  [[ "$v" =~ ^[A-Za-z0-9._/-]+$ ]] || return 1
+  return 0
+}
+
+# migrate_validate_host_type <value>
+# v1 can only clone github remotes.
+migrate_validate_host_type() {
+  [[ "$1" == "github" ]] || return 1
+  return 0
+}
+
+# migrate_remap_git_root <repository>
+# Destination main-clone path, re-derived entirely from the validated repo
+# name (never the untrusted source path): $HOME/src/<repo>.
+migrate_remap_git_root() {
+  local repository="$1" repo_name
+  repo_name="${repository##*/}"
+  printf '%s\n' "$HOME/src/$repo_name"
+}
+
+# migrate_remap_cwd <source_cwd> <repository> <branch>
+# Plain session -> $HOME/src/<repo>. Worktree session (source cwd contains a
+# /worktrees/ segment) -> $HOME/src/<repo>/worktrees/<branch>. The tail is
+# re-derived from the validated branch, so double-nested source worktrees are
+# normalized to a single level.
+migrate_remap_cwd() {
+  local source_cwd="$1" repository="$2" branch="$3" repo_name root
+  repo_name="${repository##*/}"
+  root="$HOME/src/$repo_name"
+  if [[ "$source_cwd" == *"/worktrees/"* ]]; then
+    printf '%s\n' "$root/worktrees/$branch"
+  else
+    printf '%s\n' "$root"
+  fi
+}
+
+# migrate_assert_under_home <path>
+# Succeeds only when <path> is strictly under $HOME with no '..' traversal.
+migrate_assert_under_home() {
+  local path="$1"
+  [[ -n "$path" ]] || return 1
+  case "$path" in
+    ".."|"../"*|*"/../"*|*"/..") return 1 ;;
+  esac
+  [[ "$path" == "$HOME/"* ]] || return 1
+  return 0
+}
+
+# migrate_should_reconstruct <repository> <git_root> <host_type>
+# Gate for the skip-vs-reconstruct decision. Returns 0 (reconstruct) only when
+# the session claims a github repository with a recorded git_root. A cleanly
+# absent repository/git_root or a non-github host_type is a skip (return 1),
+# NOT a hard failure.
+migrate_should_reconstruct() {
+  local repository="$1" git_root="$2" host_type="$3"
+  [[ -n "$repository" ]] || return 1
+  [[ -n "$git_root" ]] || return 1
+  [[ "$host_type" == "github" ]] || return 1
+  return 0
+}
+
+# migrate_rewrite_workspace_yaml <file> <new_cwd> <new_git_root>
+# Atomically rewrite the cwd and git_root scalars, preserving every other
+# line and the original file mode. Replacement values are inserted literally
+# (no sed), so sed metacharacters such as & and \ are safe.
+migrate_rewrite_workspace_yaml() {
+  local file="$1" new_cwd="$2" new_git_root="$3" tmp line
+  [[ -f "$file" ]] || { log_err "workspace.yaml not found: $file"; return 1; }
+  tmp="$(mktemp)" || { log_err "mktemp failed"; return 1; }
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      cwd:*)      printf 'cwd: %s\n' "$new_cwd" ;;
+      git_root:*) printf 'git_root: %s\n' "$new_git_root" ;;
+      *)          printf '%s\n' "$line" ;;
+    esac
+  done <"$file" >"$tmp"
+  # Copy contents back so the original inode + mode are preserved.
+  cat "$tmp" >"$file"
+  rm -f "$tmp"
+}
+
+# Library-mode short-circuit: when sourced for unit testing, define the helper
+# functions above and return WITHOUT parsing args or running the migration.
+if [[ -n "${AMPLIHACK_MIGRATE_LIB:-}" ]]; then
+  # 'return' works when sourced (the tested path); the 'exit' fallback only
+  # applies if the file is executed directly with the flag set.
+  # shellcheck disable=SC2317
+  return 0 2>/dev/null || exit 0
+fi
+
 usage() {
   cat <<USAGE
 Usage: /amplihack:migrate <hostname> [--session <id>] [--dry-run]
@@ -184,6 +330,17 @@ fi
 log_warn "This migration will copy credentials (.ssh, .config/gh/hosts.yml) to $DEST_HOST."
 
 if [[ $DRY_RUN -eq 1 ]]; then
+  if [[ -n "$SESSION_DIR" && -f "$SESSION_DIR/workspace.yaml" ]]; then
+    dr_repo="$(migrate_yaml_field "$SESSION_DIR/workspace.yaml" repository)"
+    dr_git_root="$(migrate_yaml_field "$SESSION_DIR/workspace.yaml" git_root)"
+    dr_host="$(migrate_yaml_field "$SESSION_DIR/workspace.yaml" host_type)"
+    if migrate_should_reconstruct "$dr_repo" "$dr_git_root" "$dr_host"; then
+      dr_repo_name="${dr_repo##*/}"
+      log_info "Would reconstruct project: clone $dr_repo → \$HOME/src/$dr_repo_name and rewrite cwd/git_root."
+    else
+      log_info "Would skip project reconstruction (no clonable github repository); resume in \$HOME."
+    fi
+  fi
   log_info "Dry-run complete. Destination: $DEST_HOST. Session: $SESSION_ID."
   exit 0
 fi
@@ -308,6 +465,172 @@ if [[ -n "$SESSION_DIR" && -d "$SESSION_DIR" ]]; then
   rsync -a --delete -e "$RSYNC_RSH" \
     "$SESSION_DIR/" "$DEST_HOST:$SESSION_DIR/" \
     || log_warn "delta rsync failed (non-fatal; initial tarball already transferred)"
+fi
+
+# ---------------------------------------------------------------------------
+# Project reconstruction & workspace.yaml rewrite (issue #909)
+# ---------------------------------------------------------------------------
+# The ~/src/* project trees are NOT shipped in the tarball, so the resumed
+# session would otherwise land in $HOME: the cwd/git_root recorded in the
+# session's workspace.yaml point at the SOURCE user's home, a path that does
+# not exist on the destination. Re-materialize the git checkout on the
+# destination and rewrite the persisted paths so resume lands in real context.
+#
+# Ordering is load-bearing: this runs AFTER the final delta rsync (so rsync
+# cannot clobber the rewritten workspace.yaml) and BEFORE the tmux resume (so
+# the CLI reads the corrected paths).
+if [[ -n "$SESSION_DIR" ]]; then
+  WORKSPACE_YAML="$SESSION_DIR/workspace.yaml"
+  if [[ -f "$WORKSPACE_YAML" ]]; then
+    ws_cwd="$(migrate_yaml_field "$WORKSPACE_YAML" cwd)"
+    ws_git_root="$(migrate_yaml_field "$WORKSPACE_YAML" git_root)"
+    ws_repo="$(migrate_yaml_field "$WORKSPACE_YAML" repository)"
+    ws_host="$(migrate_yaml_field "$WORKSPACE_YAML" host_type)"
+    ws_branch="$(migrate_yaml_field "$WORKSPACE_YAML" branch)"
+
+    if migrate_should_reconstruct "$ws_repo" "$ws_git_root" "$ws_host"; then
+      # Validate untrusted fields (reject-don't-sanitize) BEFORE they reach the
+      # destination shell / filesystem / git. Malformed fields on a session that
+      # DOES claim a github repo are a hard failure (exit 11).
+      migrate_validate_host_type "$ws_host" \
+        || { log_err "invalid host_type in workspace.yaml: $ws_host"; exit 11; }
+      migrate_validate_repository "$ws_repo" \
+        || { log_err "invalid repository in workspace.yaml: $ws_repo"; exit 11; }
+      if [[ -n "$ws_branch" ]]; then
+        migrate_validate_branch "$ws_branch" \
+          || { log_err "invalid branch in workspace.yaml: $ws_branch"; exit 11; }
+      else
+        ws_branch="main"
+      fi
+
+      # Classify worktree vs plain from the source cwd (never reuse the source
+      # path verbatim); the remap is re-derived on the destination where $HOME
+      # differs from the source user's home.
+      RECON_IS_WORKTREE=0
+      [[ "$ws_cwd" == *"/worktrees/"* ]] && RECON_IS_WORKTREE=1
+
+      log_info "Reconstructing project tree on $DEST_HOST (repo=$ws_repo branch=$ws_branch worktree=$RECON_IS_WORKTREE)…"
+
+      RECON_STATUS=0
+      # Values pass as positional args into a single-quoted heredoc so they can
+      # never be interpreted as command text (shell / git-option injection).
+      azlin connect -y "$DEST_HOST" -- bash -s -- \
+        "$WORKSPACE_YAML" "$ws_repo" "$ws_branch" "$RECON_IS_WORKTREE" <<'RECON' || RECON_STATUS=$?
+set -euo pipefail
+ws_yaml="$1"; repository="$2"; branch="$3"; is_worktree="$4"
+
+repo_name="${repository##*/}"
+git_root_dest="$HOME/src/$repo_name"
+if [ "$is_worktree" = "1" ]; then
+  cwd_dest="$git_root_dest/worktrees/$branch"
+else
+  cwd_dest="$git_root_dest"
+fi
+
+# $HOME-containment gate (exit 12): destination paths must be strictly under
+# $HOME with no traversal.
+assert_under_home() {
+  local p="$1"
+  [ -n "$p" ] || return 1
+  case "$p" in
+    ".."|"../"*|*"/../"*|*"/..") return 1 ;;
+  esac
+  case "$p" in "$HOME"/*) return 0 ;; *) return 1 ;; esac
+}
+assert_under_home "$git_root_dest" || { echo "[migrate] git_root escapes \$HOME: $git_root_dest" >&2; exit 12; }
+assert_under_home "$cwd_dest"      || { echo "[migrate] cwd escapes \$HOME: $cwd_dest" >&2; exit 12; }
+
+mkdir -p "$HOME/src"
+
+# Idempotent main clone into git_root_dest (exit 13 if it cannot be cloned).
+if [ -d "$git_root_dest/.git" ]; then
+  echo "[migrate] existing checkout at $git_root_dest; fetching"
+  git -C "$git_root_dest" fetch --all --prune >/dev/null 2>&1 || true
+elif command -v gh >/dev/null 2>&1 && gh repo clone "$repository" "$git_root_dest" >/dev/null 2>&1; then
+  echo "[migrate] cloned $repository via gh -> $git_root_dest"
+elif git clone "https://github.com/$repository.git" "$git_root_dest" >/dev/null 2>&1; then
+  echo "[migrate] cloned $repository via https -> $git_root_dest"
+else
+  echo "[migrate] clone failed for $repository" >&2
+  exit 13
+fi
+
+checkout_branch() {
+  local dir="$1"
+  git -C "$dir" checkout "$branch" >/dev/null 2>&1 && return 0
+  git -C "$dir" fetch origin "$branch" >/dev/null 2>&1 || return 1
+  git -C "$dir" checkout "$branch" >/dev/null 2>&1
+}
+
+if [ "$is_worktree" = "1" ]; then
+  if [ ! -e "$cwd_dest/.git" ]; then
+    # Best-effort worktree linkage; cwd_dest must still end a real checkout.
+    if ! git -C "$git_root_dest" worktree add "$cwd_dest" "$branch" >/dev/null 2>&1; then
+      git -C "$git_root_dest" fetch origin "$branch" >/dev/null 2>&1 || true
+      if ! git -C "$git_root_dest" worktree add "$cwd_dest" "$branch" >/dev/null 2>&1; then
+        echo "[migrate] worktree add failed; falling back to standalone clone at $cwd_dest" >&2
+        if [ ! -d "$cwd_dest/.git" ]; then
+          if command -v gh >/dev/null 2>&1 && gh repo clone "$repository" "$cwd_dest" >/dev/null 2>&1; then
+            :
+          else
+            git clone "https://github.com/$repository.git" "$cwd_dest" >/dev/null 2>&1 || true
+          fi
+        fi
+        checkout_branch "$cwd_dest" || true
+      fi
+    fi
+  fi
+else
+  checkout_branch "$git_root_dest" || true
+fi
+
+# Atomic, mode-preserving rewrite of cwd + git_root (literal, no sed).
+if [ -f "$ws_yaml" ]; then
+  tmp="$(mktemp)"
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      cwd:*)      printf 'cwd: %s\n' "$cwd_dest" ;;
+      git_root:*) printf 'git_root: %s\n' "$git_root_dest" ;;
+      *)          printf '%s\n' "$line" ;;
+    esac
+  done <"$ws_yaml" >"$tmp"
+  cat "$tmp" >"$ws_yaml"
+  rm -f "$tmp"
+  echo "[migrate] rewrote cwd + git_root in $ws_yaml … ok"
+else
+  echo "[migrate] workspace.yaml missing on destination: $ws_yaml" >&2
+fi
+
+# Hard-gate (exit 10): refuse a hollow resume into $HOME.
+if [ ! -d "$cwd_dest" ]; then
+  echo "[migrate] hard-gate: cwd missing or not a directory: $cwd_dest" >&2
+  exit 10
+fi
+cur_branch="$(git -C "$cwd_dest" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+if [ -z "$cur_branch" ]; then
+  echo "[migrate] hard-gate: $cwd_dest is not a git checkout" >&2
+  exit 10
+fi
+if [ "$cur_branch" != "$branch" ]; then
+  echo "[migrate] hard-gate: $cwd_dest is on '$cur_branch', expected '$branch'" >&2
+  exit 10
+fi
+echo "[migrate] reconstruction verified: $cwd_dest on $branch"
+RECON
+      case "$RECON_STATUS" in
+        0)  log_info "Project reconstruction complete on $DEST_HOST." ;;
+        10) log_err "reconstruction hard-gate failed (cwd missing / not a checkout / wrong branch)"; exit 10 ;;
+        11) log_err "workspace.yaml field validation failed on destination"; exit 11 ;;
+        12) log_err "cross-user path remap escaped \$HOME on destination"; exit 12 ;;
+        13) log_err "project reconstruction (clone) failed for $ws_repo"; exit 13 ;;
+        *)  log_err "project reconstruction failed on $DEST_HOST (status $RECON_STATUS)"; exit 13 ;;
+      esac
+    else
+      log_warn "No reconstructable git project (repository=${ws_repo:-none} host_type=${ws_host:-none}); resume will land in \$HOME."
+    fi
+  else
+    log_warn "workspace.yaml not found at $WORKSPACE_YAML; skipping project reconstruction."
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/amplifier-bundle/skills/migrate/scripts/migrate.sh
+++ b/amplifier-bundle/skills/migrate/scripts/migrate.sh
@@ -398,7 +398,15 @@ azlin connect -y "$DEST_HOST" -- bash -s < "$BOOTSTRAP_SCRIPT" \
 # Selective tarball
 # ---------------------------------------------------------------------------
 TIMESTAMP="$(date +%s)"
-TARBALL="/tmp/amplihack-migrate-${SESSION_ID}-${TIMESTAMP}.tar.zst"
+# The tarball carries SSH private keys (~/.ssh) and the gh OAuth token
+# (~/.config/gh/hosts.yml). On a shared source host a world-readable file in
+# /tmp would leak those secrets to other local users for the whole migration
+# window, so it is staged inside a private 0700 directory that mktemp -d
+# creates atomically (no predictable-path pre-plant window).
+TARBALL_DIR="$(mktemp -d "${TMPDIR:-/tmp}/amplihack-migrate.XXXXXX")" \
+  || { log_err "failed to create private staging dir"; exit 6; }
+chmod 700 "$TARBALL_DIR"
+TARBALL="$TARBALL_DIR/session-${SESSION_ID}-${TIMESTAMP}.tar.zst"
 
 log_info "Building selective tarball → $TARBALL"
 
@@ -437,6 +445,8 @@ tar --use-compress-program='zstd -T0' \
     -cf "$TARBALL" \
     "${TAR_INCLUDES[@]}" \
   || { log_err "tar failed"; exit 6; }
+# Defence in depth: restrict the archive itself, not just its parent directory.
+chmod 600 "$TARBALL" 2>/dev/null || true
 
 TARBALL_SIZE=$(du -m "$TARBALL" 2>/dev/null | awk '{print $1}')
 log_info "Tarball size: ${TARBALL_SIZE:-?} MB"
@@ -457,7 +467,10 @@ fi
 # ---------------------------------------------------------------------------
 # Ship tarball → extract
 # ---------------------------------------------------------------------------
-REMOTE_TARBALL="/tmp/amplihack-migrate.tar.zst"
+# Unique per-migration name: a fixed, predictable /tmp path would let another
+# user on the destination pre-plant a symlink (clobber / redirect via azlin cp)
+# or collide with a concurrent migration.
+REMOTE_TARBALL="/tmp/amplihack-migrate-${SESSION_ID}-${TIMESTAMP}.tar.zst"
 log_info "Copying to $DEST_HOST:$REMOTE_TARBALL …"
 azlin cp "$TARBALL" "$DEST_HOST:$REMOTE_TARBALL" \
   || { log_err "azlin cp failed"; exit 8; }
@@ -740,7 +753,7 @@ fi
 # ---------------------------------------------------------------------------
 # Cleanup + summary
 # ---------------------------------------------------------------------------
-rm -f "$TARBALL"
+rm -rf "${TARBALL_DIR:-}"
 log_info "Migration complete."
 cat <<SUMMARY
 ✓ Session resumed on $DEST_HOST in tmux '$TMUX_NAME'.

--- a/amplifier-bundle/skills/migrate/scripts/migrate.sh
+++ b/amplifier-bundle/skills/migrate/scripts/migrate.sh
@@ -144,6 +144,39 @@ migrate_rewrite_workspace_yaml() {
   rm -f "$tmp"
 }
 
+# migrate_with_retry <max_attempts> <base_delay_secs> [--] <cmd> [args...]
+# Resilience wrapper for the reconstruction phase's external-service calls
+# (the git/gh clone + fetch operations that reach GitHub over the network).
+# Runs <cmd> up to <max_attempts> times, sleeping base_delay * 2^(n-1) seconds
+# (capped at 30s) between tries, and returns 0 on the first success. If every
+# attempt fails, returns the exit status of the LAST attempt so callers can
+# still distinguish failure modes. A base delay of 0 disables backoff (used by
+# the unit tests so they never actually sleep).
+migrate_with_retry() {
+  local max="$1" base="$2"; shift 2
+  [[ "${1:-}" == "--" ]] && shift
+  # Sanitize numeric inputs (they may originate from env overrides).
+  [[ "$max"  =~ ^[0-9]+$ ]] || max=3
+  [[ "$base" =~ ^[0-9]+$ ]] || base=2
+  (( max < 1 )) && max=1
+  local attempt=1 rc delay
+  while :; do
+    rc=0
+    "$@" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      return 0
+    fi
+    if (( attempt >= max )); then
+      return "$rc"
+    fi
+    delay=$(( base * (1 << (attempt - 1)) ))
+    if (( delay > 30 )); then delay=30; fi
+    log_warn "transient failure (attempt ${attempt}/${max}); retrying in ${delay}s"
+    sleep "$delay"
+    attempt=$(( attempt + 1 ))
+  done
+}
+
 # Library-mode short-circuit: when sourced for unit testing, define the helper
 # functions above and return WITHOUT parsing args or running the migration.
 if [[ -n "${AMPLIHACK_MIGRATE_LIB:-}" ]]; then
@@ -511,13 +544,54 @@ if [[ -n "$SESSION_DIR" ]]; then
 
       log_info "Reconstructing project tree on $DEST_HOST (repo=$ws_repo branch=$ws_branch worktree=$RECON_IS_WORKTREE)…"
 
+      # Resilience budget for the external clone/fetch calls (transient
+      # network / DNS / TLS / rate-limit failures). Overridable via env.
+      RECON_RETRIES="${AMPLIHACK_MIGRATE_RETRIES:-3}"
+      RECON_RETRY_DELAY="${AMPLIHACK_MIGRATE_RETRY_DELAY:-2}"
+      [[ "$RECON_RETRIES"     =~ ^[0-9]+$ ]] || RECON_RETRIES=3
+      [[ "$RECON_RETRY_DELAY" =~ ^[0-9]+$ ]] || RECON_RETRY_DELAY=2
+
       RECON_STATUS=0
       # Values pass as positional args into a single-quoted heredoc so they can
       # never be interpreted as command text (shell / git-option injection).
       azlin connect -y "$DEST_HOST" -- bash -s -- \
-        "$WORKSPACE_YAML" "$ws_repo" "$ws_branch" "$RECON_IS_WORKTREE" <<'RECON' || RECON_STATUS=$?
+        "$WORKSPACE_YAML" "$ws_repo" "$ws_branch" "$RECON_IS_WORKTREE" \
+        "$RECON_RETRIES" "$RECON_RETRY_DELAY" <<'RECON' || RECON_STATUS=$?
 set -euo pipefail
 ws_yaml="$1"; repository="$2"; branch="$3"; is_worktree="$4"
+retries="$5"; retry_delay="$6"
+
+# Bounded retry-with-backoff around the external-service (GitHub) calls so a
+# transient network / DNS / TLS / rate-limit blip does not hard-fail the whole
+# reconstruction. Mirrors migrate_with_retry in the sourceable library (which
+# is unit tested off-host); inlined here because the remote shell cannot source
+# the library. The wrapped command's own output is silenced inside each small
+# adapter below, so with_retry's progress notices stay visible on stderr.
+with_retry() {
+  local attempt=1 rc delay
+  while :; do
+    rc=0
+    "$@" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$retries" ]; then
+      return "$rc"
+    fi
+    delay=$(( retry_delay * (1 << (attempt - 1)) ))
+    if [ "$delay" -gt 30 ]; then delay=30; fi
+    echo "[migrate] transient failure (attempt ${attempt}/${retries}); retrying in ${delay}s: $*" >&2
+    sleep "$delay"
+    attempt=$(( attempt + 1 ))
+  done
+}
+
+# External-service adapters: each silences its own stdout/stderr so only
+# with_retry's retry notices surface. These are the network boundary.
+_fetch_all()    { git -C "$1" fetch --all --prune >/dev/null 2>&1; }
+_fetch_branch() { git -C "$1" fetch origin "$branch" >/dev/null 2>&1; }
+_gh_clone()     { gh repo clone "$repository" "$1" >/dev/null 2>&1; }
+_git_clone()    { git clone "https://github.com/$repository.git" "$1" >/dev/null 2>&1; }
 
 repo_name="${repository##*/}"
 git_root_dest="$HOME/src/$repo_name"
@@ -545,20 +619,20 @@ mkdir -p "$HOME/src"
 # Idempotent main clone into git_root_dest (exit 13 if it cannot be cloned).
 if [ -d "$git_root_dest/.git" ]; then
   echo "[migrate] existing checkout at $git_root_dest; fetching"
-  git -C "$git_root_dest" fetch --all --prune >/dev/null 2>&1 || true
-elif command -v gh >/dev/null 2>&1 && gh repo clone "$repository" "$git_root_dest" >/dev/null 2>&1; then
+  with_retry _fetch_all "$git_root_dest" || true
+elif command -v gh >/dev/null 2>&1 && with_retry _gh_clone "$git_root_dest"; then
   echo "[migrate] cloned $repository via gh -> $git_root_dest"
-elif git clone "https://github.com/$repository.git" "$git_root_dest" >/dev/null 2>&1; then
+elif with_retry _git_clone "$git_root_dest"; then
   echo "[migrate] cloned $repository via https -> $git_root_dest"
 else
-  echo "[migrate] clone failed for $repository" >&2
+  echo "[migrate] clone failed for $repository after ${retries} attempt(s)" >&2
   exit 13
 fi
 
 checkout_branch() {
   local dir="$1"
   git -C "$dir" checkout "$branch" >/dev/null 2>&1 && return 0
-  git -C "$dir" fetch origin "$branch" >/dev/null 2>&1 || return 1
+  with_retry _fetch_branch "$dir" || return 1
   git -C "$dir" checkout "$branch" >/dev/null 2>&1
 }
 
@@ -566,14 +640,14 @@ if [ "$is_worktree" = "1" ]; then
   if [ ! -e "$cwd_dest/.git" ]; then
     # Best-effort worktree linkage; cwd_dest must still end a real checkout.
     if ! git -C "$git_root_dest" worktree add "$cwd_dest" "$branch" >/dev/null 2>&1; then
-      git -C "$git_root_dest" fetch origin "$branch" >/dev/null 2>&1 || true
+      with_retry _fetch_branch "$git_root_dest" || true
       if ! git -C "$git_root_dest" worktree add "$cwd_dest" "$branch" >/dev/null 2>&1; then
         echo "[migrate] worktree add failed; falling back to standalone clone at $cwd_dest" >&2
         if [ ! -d "$cwd_dest/.git" ]; then
-          if command -v gh >/dev/null 2>&1 && gh repo clone "$repository" "$cwd_dest" >/dev/null 2>&1; then
+          if command -v gh >/dev/null 2>&1 && with_retry _gh_clone "$cwd_dest"; then
             :
           else
-            git clone "https://github.com/$repository.git" "$cwd_dest" >/dev/null 2>&1 || true
+            with_retry _git_clone "$cwd_dest" || true
           fi
         fi
         checkout_branch "$cwd_dest" || true

--- a/amplifier-bundle/skills/migrate/scripts/migrate.sh
+++ b/amplifier-bundle/skills/migrate/scripts/migrate.sh
@@ -425,7 +425,9 @@ fi
 #   -C / to keep absolute paths predictable (we pass full paths below).
 #   --exclude-caches-under drops ~/.cache-style dirs.
 #   --exclude-vcs-ignores is NOT used — we want config files.
-tar --use-compress-program=zstd \
+#   zstd -T0 uses all available cores for compression (the largest CPU-bound
+#   local step); output is standard zstd, decompressed identically by unzstd.
+tar --use-compress-program='zstd -T0' \
     --exclude='**/target' \
     --exclude='**/node_modules' \
     --exclude='**/.venv' \

--- a/amplifier-bundle/skills/migrate/scripts/tests/test_workspace_rewrite.bats
+++ b/amplifier-bundle/skills/migrate/scripts/tests/test_workspace_rewrite.bats
@@ -289,6 +289,53 @@ YAML
 }
 
 # ===========================================================================
+# migrate_with_retry  — resilience wrapper for transient external-service
+# (GitHub clone/fetch) calls. base delay 0 => no real sleep in tests.
+# ===========================================================================
+
+@test "migrate_with_retry runs the command exactly once on immediate success" {
+  local n="$TEST_HOME/n"; echo 0 >"$n"
+  _ok() { echo $(( $(cat "$n") + 1 )) >"$n"; return 0; }
+  run migrate_with_retry 4 0 -- _ok
+  [ "$status" -eq 0 ]
+  [ "$(cat "$n")" -eq 1 ]
+}
+
+@test "migrate_with_retry retries a flaky command until it succeeds" {
+  local n="$TEST_HOME/n"; echo 0 >"$n"
+  # Fails on attempts 1 and 2, succeeds on attempt 3.
+  _flaky() {
+    local c; c=$(( $(cat "$n") + 1 )); echo "$c" >"$n"
+    [ "$c" -ge 3 ]
+  }
+  run migrate_with_retry 5 0 -- _flaky
+  [ "$status" -eq 0 ]
+  [ "$(cat "$n")" -eq 3 ]
+}
+
+@test "migrate_with_retry gives up after max attempts and returns the last status" {
+  local n="$TEST_HOME/n"; echo 0 >"$n"
+  _always_fail() { echo $(( $(cat "$n") + 1 )) >"$n"; return 7; }
+  run migrate_with_retry 3 0 -- _always_fail
+  [ "$status" -eq 7 ]          # propagates the wrapped command's exit status
+  [ "$(cat "$n")" -eq 3 ]      # exactly max attempts, not one more
+}
+
+@test "migrate_with_retry forwards arguments and honors the -- separator" {
+  run migrate_with_retry 2 0 -- printf '%s-%s' a b
+  [ "$status" -eq 0 ]
+  [ "$output" = "a-b" ]
+}
+
+@test "migrate_with_retry clamps a zero / non-numeric attempt count to at least one try" {
+  local n="$TEST_HOME/n"; echo 0 >"$n"
+  _ok() { echo $(( $(cat "$n") + 1 )) >"$n"; return 0; }
+  run migrate_with_retry 0 0 -- _ok
+  [ "$status" -eq 0 ]
+  [ "$(cat "$n")" -eq 1 ]
+}
+
+# ===========================================================================
 # Static hygiene
 # ===========================================================================
 

--- a/amplifier-bundle/skills/migrate/scripts/tests/test_workspace_rewrite.bats
+++ b/amplifier-bundle/skills/migrate/scripts/tests/test_workspace_rewrite.bats
@@ -1,0 +1,301 @@
+#!/usr/bin/env bats
+# ---------------------------------------------------------------------------
+# TDD contract for issue #909 — migrate skill project reconstruction.
+#
+# The resumed session on the destination VM must land in a valid git checkout,
+# not $HOME. This suite pins the pure, sourceable helper functions that the
+# reconstruction phase of migrate.sh must expose so the cross-user path remap
+# and workspace.yaml rewrite are testable off-host (no azlin / ssh / clone).
+#
+# These tests FAIL until migrate.sh:
+#   1. Can be sourced in "library only" mode (AMPLIHACK_MIGRATE_LIB=1) so that
+#      sourcing defines functions WITHOUT running the migration main flow.
+#   2. Defines the migrate_* helper functions contracted below.
+#
+# Run:  bats amplifier-bundle/skills/migrate/scripts/tests/test_workspace_rewrite.bats
+# ---------------------------------------------------------------------------
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../migrate.sh"
+
+  # Deterministic, isolated destination $HOME for remap assertions.
+  TEST_HOME="$(mktemp -d)"
+  export HOME="$TEST_HOME"
+
+  # Source the script in library-only mode: this MUST define the migrate_*
+  # functions and MUST NOT parse args / run the migration / call exit.
+  export AMPLIHACK_MIGRATE_LIB=1
+  # shellcheck disable=SC1090
+  source "$SCRIPT_UNDER_TEST"
+}
+
+teardown() {
+  [[ -n "${TEST_HOME:-}" && -d "$TEST_HOME" ]] && rm -rf "$TEST_HOME"
+}
+
+# Helper: write a workspace.yaml fixture into $1 with given field values.
+_write_workspace_yaml() {
+  local file="$1" cwd="$2" git_root="$3" repository="$4" host_type="$5" branch="$6"
+  cat >"$file" <<YAML
+session_id: b127f92a-0000-4000-8000-000000000000
+cwd: ${cwd}
+git_root: ${git_root}
+repository: ${repository}
+host_type: ${host_type}
+branch: ${branch}
+YAML
+}
+
+# ===========================================================================
+# Library-mode sourcing contract
+# ===========================================================================
+
+@test "sourcing in library mode does not run the migration or exit nonzero" {
+  # setup() already sourced it; if sourcing had run main it would have exited
+  # (no DEST_HOST => exit 2) and this file would never run. Assert the guard
+  # variable is honored and a core helper is defined.
+  run type -t migrate_yaml_field
+  [ "$status" -eq 0 ]
+  [ "$output" = "function" ]
+}
+
+# ===========================================================================
+# migrate_yaml_field  — flat top-level scalar parser (grep/sed, no yq)
+# ===========================================================================
+
+@test "migrate_yaml_field extracts a plain scalar value" {
+  local f="$TEST_HOME/ws.yaml"
+  _write_workspace_yaml "$f" \
+    "/home/rysweet/src/azork" "/home/rysweet/src/azork" \
+    "rysweet/azork" "github" "main"
+  run migrate_yaml_field "$f" cwd
+  [ "$status" -eq 0 ]
+  [ "$output" = "/home/rysweet/src/azork" ]
+}
+
+@test "migrate_yaml_field reads each of the five reconstruction fields" {
+  local f="$TEST_HOME/ws.yaml"
+  _write_workspace_yaml "$f" \
+    "/home/rysweet/src/azork/worktrees/feat/x" "/home/rysweet/src/azork/worktrees/feat/x" \
+    "rysweet/azork" "github" "feat/x"
+  run migrate_yaml_field "$f" git_root
+  [ "$output" = "/home/rysweet/src/azork/worktrees/feat/x" ]
+  run migrate_yaml_field "$f" repository
+  [ "$output" = "rysweet/azork" ]
+  run migrate_yaml_field "$f" host_type
+  [ "$output" = "github" ]
+  run migrate_yaml_field "$f" branch
+  [ "$output" = "feat/x" ]
+}
+
+@test "migrate_yaml_field strips surrounding quotes and trailing whitespace" {
+  local f="$TEST_HOME/ws.yaml"
+  printf 'repository: "rysweet/azork"   \nbranch: %s\n' "'feat/x'" >"$f"
+  run migrate_yaml_field "$f" repository
+  [ "$output" = "rysweet/azork" ]
+  run migrate_yaml_field "$f" branch
+  [ "$output" = "feat/x" ]
+}
+
+@test "migrate_yaml_field returns empty for an absent field (absence is not an error)" {
+  local f="$TEST_HOME/ws.yaml"
+  printf 'cwd: /home/rysweet/src/azork\n' >"$f"
+  run migrate_yaml_field "$f" repository
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "migrate_yaml_field matches only exact top-level keys (no substring bleak)" {
+  local f="$TEST_HOME/ws.yaml"
+  printf 'git_root: /home/rysweet/src/azork\nroot_cause: nope\n' >"$f"
+  # Asking for 'root' must not return the git_root or root_cause value.
+  run migrate_yaml_field "$f" root
+  [ -z "$output" ]
+}
+
+# ===========================================================================
+# Untrusted-field validation (reject-don't-sanitize)
+# ===========================================================================
+
+@test "migrate_validate_repository accepts owner/name form" {
+  run migrate_validate_repository "rysweet/azork"
+  [ "$status" -eq 0 ]
+  run migrate_validate_repository "rys-weet_1.x/az.ork_2-y"
+  [ "$status" -eq 0 ]
+}
+
+@test "migrate_validate_repository rejects malformed / injecting values" {
+  run migrate_validate_repository "rysweet"          ; [ "$status" -ne 0 ]
+  run migrate_validate_repository "rysweet/az/ork"   ; [ "$status" -ne 0 ]
+  run migrate_validate_repository "rysweet/azork; rm -rf ~" ; [ "$status" -ne 0 ]
+  run migrate_validate_repository "-flag/azork"      ; [ "$status" -ne 0 ]
+  run migrate_validate_repository ""                 ; [ "$status" -ne 0 ]
+  run migrate_validate_repository "$(printf 'rysweet/azork\nevil')" ; [ "$status" -ne 0 ]
+}
+
+@test "migrate_validate_branch accepts normal branch names incl. slashes" {
+  run migrate_validate_branch "main"    ; [ "$status" -eq 0 ]
+  run migrate_validate_branch "feat/x"  ; [ "$status" -eq 0 ]
+  run migrate_validate_branch "release/1.2.3" ; [ "$status" -eq 0 ]
+}
+
+@test "migrate_validate_branch rejects leading dash, dotdot, and newlines" {
+  run migrate_validate_branch "-force"        ; [ "$status" -ne 0 ]   # git-option injection
+  run migrate_validate_branch "feat/../evil"  ; [ "$status" -ne 0 ]   # path traversal
+  run migrate_validate_branch ".."            ; [ "$status" -ne 0 ]
+  run migrate_validate_branch "feat/x;reboot" ; [ "$status" -ne 0 ]
+  run migrate_validate_branch ""              ; [ "$status" -ne 0 ]
+  run migrate_validate_branch "$(printf 'main\nevil')" ; [ "$status" -ne 0 ]
+}
+
+@test "migrate_validate_host_type allows only github" {
+  run migrate_validate_host_type "github" ; [ "$status" -eq 0 ]
+  run migrate_validate_host_type "gitlab" ; [ "$status" -ne 0 ]
+  run migrate_validate_host_type ""       ; [ "$status" -ne 0 ]
+}
+
+# ===========================================================================
+# Cross-user path remap  — paths re-derived from validated repo/branch,
+# always strictly under the destination $HOME (D1 REWRITE strategy).
+# ===========================================================================
+
+@test "migrate_remap_git_root always maps to \$HOME/src/<repo>" {
+  run migrate_remap_git_root "rysweet/azork"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/src/azork" ]
+}
+
+@test "migrate_remap_cwd for a plain (non-worktree) session equals the git root" {
+  # Source cwd has no /worktrees/ segment => plain session.
+  run migrate_remap_cwd "/home/rysweet/src/azork" "rysweet/azork" "main"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/src/azork" ]
+}
+
+@test "migrate_remap_cwd for a worktree session appends worktrees/<branch>" {
+  run migrate_remap_cwd "/home/rysweet/src/azork/worktrees/feat/x" "rysweet/azork" "feat/x"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/src/azork/worktrees/feat/x" ]
+}
+
+@test "migrate_remap_cwd normalizes double-nested worktrees to a single level" {
+  run migrate_remap_cwd \
+    "/home/rysweet/src/azork/worktrees/A/worktrees/B" "rysweet/azork" "feat/deep"
+  [ "$status" -eq 0 ]
+  # Tail is re-derived from the validated branch, never copied verbatim.
+  [ "$output" = "$HOME/src/azork/worktrees/feat/deep" ]
+}
+
+@test "migrate_remap_cwd never reuses the source git_root / source home prefix" {
+  run migrate_remap_cwd "/home/rysweet/src/azork" "rysweet/azork" "main"
+  [[ "$output" != *"/home/rysweet/"* ]]
+  [[ "$output" == "$HOME/"* ]]
+}
+
+# ===========================================================================
+# $HOME-containment gate (exit 12 semantics)
+# ===========================================================================
+
+@test "migrate_assert_under_home accepts a path inside \$HOME" {
+  run migrate_assert_under_home "$HOME/src/azork"
+  [ "$status" -eq 0 ]
+}
+
+@test "migrate_assert_under_home rejects paths outside \$HOME and traversal escapes" {
+  run migrate_assert_under_home "/etc/passwd"              ; [ "$status" -ne 0 ]
+  run migrate_assert_under_home "$HOME/../other/evil"      ; [ "$status" -ne 0 ]
+  run migrate_assert_under_home "$HOME"                    ; [ "$status" -ne 0 ]  # must be strictly under
+  run migrate_assert_under_home "${HOME}_evil/src"         ; [ "$status" -ne 0 ]  # sibling prefix trap
+}
+
+# ===========================================================================
+# Reconstruction gating: skip vs. reconstruct vs. hard-fail
+# ===========================================================================
+
+@test "migrate_should_reconstruct is true for a github repo with git_root" {
+  run migrate_should_reconstruct "rysweet/azork" "/home/rysweet/src/azork" "github"
+  [ "$status" -eq 0 ]
+}
+
+@test "migrate_should_reconstruct skips when repository or git_root is absent" {
+  run migrate_should_reconstruct "" "/home/rysweet/src/azork" "github"
+  [ "$status" -ne 0 ]   # skip (resume in \$HOME, no hard-gate)
+  run migrate_should_reconstruct "rysweet/azork" "" "github"
+  [ "$status" -ne 0 ]
+}
+
+@test "migrate_should_reconstruct skips a non-github host_type" {
+  run migrate_should_reconstruct "rysweet/azork" "/home/rysweet/src/azork" "gitlab"
+  [ "$status" -ne 0 ]   # skip, NOT exit 11
+}
+
+# ===========================================================================
+# Atomic workspace.yaml rewrite  — cwd + git_root, mode preserved, sed-safe
+# ===========================================================================
+
+@test "migrate_rewrite_workspace_yaml rewrites both cwd and git_root" {
+  local f="$TEST_HOME/ws.yaml"
+  _write_workspace_yaml "$f" \
+    "/home/rysweet/src/azork/worktrees/feat/x" "/home/rysweet/src/azork" \
+    "rysweet/azork" "github" "feat/x"
+
+  run migrate_rewrite_workspace_yaml "$f" \
+    "$HOME/src/azork/worktrees/feat/x" "$HOME/src/azork"
+  [ "$status" -eq 0 ]
+
+  run migrate_yaml_field "$f" cwd
+  [ "$output" = "$HOME/src/azork/worktrees/feat/x" ]
+  run migrate_yaml_field "$f" git_root
+  [ "$output" = "$HOME/src/azork" ]
+}
+
+@test "migrate_rewrite_workspace_yaml leaves other fields untouched" {
+  local f="$TEST_HOME/ws.yaml"
+  _write_workspace_yaml "$f" \
+    "/home/rysweet/src/azork" "/home/rysweet/src/azork" \
+    "rysweet/azork" "github" "main"
+  migrate_rewrite_workspace_yaml "$f" "$HOME/src/azork" "$HOME/src/azork"
+  run migrate_yaml_field "$f" repository
+  [ "$output" = "rysweet/azork" ]
+  run migrate_yaml_field "$f" branch
+  [ "$output" = "main" ]
+  run migrate_yaml_field "$f" session_id
+  [ "$output" = "b127f92a-0000-4000-8000-000000000000" ]
+}
+
+@test "migrate_rewrite_workspace_yaml preserves the original file mode" {
+  local f="$TEST_HOME/ws.yaml"
+  _write_workspace_yaml "$f" \
+    "/home/rysweet/src/azork" "/home/rysweet/src/azork" \
+    "rysweet/azork" "github" "main"
+  chmod 600 "$f"
+  local before after
+  before="$(stat -c '%a' "$f")"
+  migrate_rewrite_workspace_yaml "$f" "$HOME/src/azork" "$HOME/src/azork"
+  after="$(stat -c '%a' "$f")"
+  [ "$before" = "$after" ]
+}
+
+@test "migrate_rewrite_workspace_yaml treats replacement as literal (sed metachars safe)" {
+  local f="$TEST_HOME/ws.yaml"
+  _write_workspace_yaml "$f" \
+    "/home/rysweet/src/azork" "/home/rysweet/src/azork" \
+    "rysweet/azork" "github" "main"
+  # Replacement containing sed-special chars & and \ must be inserted literally.
+  local weird="$HOME/src/a&b\\c"
+  migrate_rewrite_workspace_yaml "$f" "$weird" "$weird"
+  run migrate_yaml_field "$f" cwd
+  [ "$output" = "$weird" ]
+}
+
+# ===========================================================================
+# Static hygiene
+# ===========================================================================
+
+@test "migrate.sh passes shellcheck (skipped if shellcheck unavailable)" {
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    skip "shellcheck not installed"
+  fi
+  run shellcheck -x "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+}

--- a/docs/skills/migrate.md
+++ b/docs/skills/migrate.md
@@ -7,8 +7,9 @@ command end-to-end.
 ## Overview
 
 Mid-session host migration used to be a manual ~15-step procedure (bootstrap
-toolchain → selective tarball → `bastion cp` → extract → delta sync → resume).
-The `/amplihack:migrate <hostname>` skill collapses that into a single command.
+toolchain → selective tarball → `bastion cp` → extract → delta sync →
+reconstruct project tree → resume). The `/amplihack:migrate <hostname>` skill
+collapses that into a single command.
 
 Typical use cases:
 
@@ -32,10 +33,18 @@ Typical use cases:
 [migrate] Extracting on ia2 … ok
 [migrate] Verifying destination: gh auth + copilot + session-state… ok
 [migrate] Final delta sync of session-state … ok
+[migrate] Reconstructing project tree on ia2 …
+[migrate]   workspace.yaml: cwd=/home/rysweet/src/azork/worktrees/feat/x git_root=/home/rysweet/src/azork
+[migrate]   remapped → /home/me/src/azork[/worktrees/feat/x] (under $HOME)
+[migrate]   gh repo clone rysweet/azork /home/me/src/azork … ok (branch feat/x)
+[migrate]   git worktree add /home/me/src/azork/worktrees/feat/x feat/x … ok
+[migrate]   rewrote cwd + git_root in destination workspace.yaml … ok
+[migrate]   hard-gate: cwd exists, git checkout on 'feat/x' … ok
 [migrate] Starting tmux 'session-b127f92a-…' on ia2: copilot --resume b127f92a-…
 [migrate] Migration complete.
 ✓ Session resumed on ia2 in tmux 'session-b127f92a-…'.
   Attach with: azlin connect -y ia2:session-b127f92a-…
+  Resumed in project: /home/me/src/azork/worktrees/feat/x
 ```
 
 ### Options
@@ -44,7 +53,7 @@ Typical use cases:
 | ----------------- | ---------------------------------------------------------- |
 | `<hostname>`      | Required. Destination azlin VM hostname.                   |
 | `--session <id>`  | Override auto-detection; use a specific session id.        |
-| `--dry-run`       | Print what would happen; do not transfer or resume.        |
+| `--dry-run`       | Print what would happen; do not transfer, reconstruct, or resume. The dry-run summary includes the planned project reconstruction (clone target path + branch). |
 
 ## What Gets Migrated
 
@@ -67,9 +76,15 @@ Exclusions (pruned from the tarball):
 
 ## What Is Not Migrated
 
-- **Source code checkouts** (`~/src/*`) — fresh-clone on the new host instead.
+- **Source code checkouts** (`~/src/*`) — **reconstructed** on the destination
+  via `gh repo clone` / `git worktree add` from the paths recorded in
+  `workspace.yaml`, rather than copied in the tarball. See
+  [Project reconstruction](#8-project-reconstruction--workspaceyaml-rewrite).
 - **Bidirectional sync / live mirroring** — single-shot migration only.
 - **Non-azlin destinations** (raw SSH, other clouds) — may come in v2.
+- **Uncommitted / unpushed changes** in `~/src/*` — reconstruction clones the
+  branch as it exists on the remote; local-only commits or dirty working-tree
+  changes that were never pushed are **not** carried over.
 
 ## How It Works
 
@@ -123,7 +138,105 @@ the **two-pass sync** design.
 Accepted risk: events written during the final ~1–2s rsync window can still be
 lost. There is no source-side event suspension.
 
-### 8. Resume in detached tmux
+### 8. Project reconstruction & workspace.yaml rewrite
+
+Because `~/src/*` source trees are **not** included in the tarball (see
+[What Is Not Migrated](#what-is-not-migrated)), the resumed session would
+otherwise land in `$HOME` with no git context — the working directory and git
+root recorded in the session's `workspace.yaml` point at the **source user's**
+home (e.g. `/home/rysweet/src/azork/…`), a path that does not exist on the
+destination. This phase re-materializes that project tree and rewrites the
+persisted paths so resume lands in a valid checkout.
+
+It runs on the destination **after the final delta rsync** (so rsync cannot
+clobber the rewritten `workspace.yaml`) and **before the tmux resume** (so the
+CLI reads the corrected paths). Steps:
+
+1. **Read** the flat top-level scalars from the active session's
+   `workspace.yaml`: `cwd`, `git_root`, `repository`, `host_type`, `branch`.
+   Parsing uses `grep`/`sed` only — no `yq` dependency is added.
+
+   **Skip conditions (not an error).** Reconstruction is *skipped* — and resume
+   proceeds without the hard-gate — when the session has no reconstructable
+   project, i.e. `workspace.yaml` is absent, or `repository`/`git_root` are
+   absent, or `host_type` is present but **not** in the allowlist (e.g. a
+   non-github remote that v1 cannot clone). In these cases the source session
+   legitimately had no clonable git project (or one v1 does not support), so
+   landing in `$HOME` is the correct, expected outcome; the skill emits a warning
+   and continues. This is distinct from a **malformed** field on a session that
+   *does* claim a github repository, which is a hard failure (exit 11).
+2. **Validate** the untrusted fields before they reach the shell or filesystem
+   (reject-don't-sanitize). Validation applies only once a session is in scope
+   for reconstruction (i.e. it claims a `repository` with `host_type: github`):
+   - `repository` must match `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`
+   - `branch` must match `^[A-Za-z0-9._/-]+$` (no leading `-`, no `..`)
+   - `host_type` must be in the allowlist (`github`)
+   - An **empty or newline-containing** value for a field that is *present* is
+     rejected (exit 11). A *cleanly absent* `repository`/`git_root` triggers the
+     skip path above, not exit 11.
+3. **Remap** the recorded cross-user path to the destination user's home. The
+   destination paths are re-derived entirely from the **validated** `repository`
+   and `branch` — the untrusted source path is used only to classify the session,
+   never copied verbatim:
+   - **Plain (non-worktree) session** → `git_root_dest = cwd_dest =
+     $HOME/src/<repo>`.
+   - **Worktree session** → `git_root_dest = $HOME/src/<repo>` (the main clone)
+     and `cwd_dest = $HOME/src/<repo>/worktrees/<branch>`.
+
+   A session is classified as a **worktree session** by the presence of
+   `/worktrees/` in the source `cwd` — **not** by comparing `git_root` to `cwd`.
+   amplihack records `git_root` **equal to** `cwd` for worktree sessions (the
+   worktree is its own recorded root), so a `git_root != cwd` heuristic would
+   misclassify every session. The source `git_root` value is therefore **not
+   reused**; `git_root_dest` is always re-derived as the main clone path.
+
+   Deeply/double-nested source worktrees (e.g.
+   `…/src/<repo>/worktrees/A/worktrees/B`) are **normalized to a single level**:
+   `cwd_dest = $HOME/src/<repo>/worktrees/<branch>`, where `<branch>` is the
+   recorded (already length-capped) branch. The worktree directory tail equals
+   the full branch name including any `feat/` prefix; branch names containing `/`
+   yield nested directories, which `git worktree add` handles.
+
+   The result is normalized and asserted to be strictly under `$HOME` (no `sudo`,
+   no `chown`).
+4. **Reconstruct** the tree idempotently:
+   - `host_type: github` → `gh repo clone <repository> <git_root_dest>`
+     (falls back to `git clone https://…` if `gh` clone fails), then
+     `git checkout <branch>`.
+   - If `<git_root_dest>/.git` already exists, `git fetch` + `git checkout`
+     instead of re-cloning.
+   - **Worktree** sessions: after the main clone at `git_root_dest`, attempt
+     `git worktree add <cwd_dest> <branch>`. The **worktree linkage** is
+     best-effort, but `cwd_dest` **must still end up a valid checkout** (the
+     hard-gate in step 6 enforces this). Fallback order when `git worktree add`
+     fails (e.g. the branch was created locally and never pushed):
+     1. Retry after `git fetch origin <branch>`.
+     2. Fall back to a standalone `git clone`/`git checkout <branch>` **into**
+        `cwd_dest` so the resumed CLI still lands in a real checkout.
+     3. Only if the branch cannot be materialized on the remote at all does
+        `cwd_dest` remain absent — the hard-gate then aborts with exit 10.
+
+     "Best-effort" therefore refers to the *worktree wiring*, not to whether
+     `cwd_dest` exists. An unpushed worktree branch is a genuine, loud failure
+     (exit 10) rather than a silent hollow resume — see
+     [Uncommitted / unpushed changes](#what-is-not-migrated).
+5. **Rewrite** `cwd` **and** `git_root` in the destination `workspace.yaml` to
+   the remapped paths. The rewrite is atomic and preserves the original file
+   mode; `sed` replacement values are escaped (`&`, `\`).
+6. **Hard-gate** before resume (only when reconstruction was **not** skipped per
+   the step-1 skip conditions): `cwd_dest` must exist, be a directory, and be a
+   git checkout on the recorded `branch`. If any assertion fails the migration
+   aborts non-zero (see [Exit Codes](#exit-codes)) rather than resuming into a
+   hollow `$HOME`. No `resume-auto-cd … missing or not a directory` warning is
+   left behind. For skipped sessions the gate is bypassed and resume proceeds in
+   `$HOME` as before.
+
+Values from `workspace.yaml` are passed as **positional arguments** into a
+single-quoted remote heredoc (`bash -s --`) so they can never be interpreted as
+command text — this defends against shell and git-option injection from the
+untrusted YAML.
+
+### 9. Resume in detached tmux
 
 The destination launches `copilot --resume <id>` (or `claude --resume <id>`)
 inside a new detached tmux session named `session-<id>`. The skill prints the
@@ -143,7 +256,37 @@ filesystem and prints manual-attach instructions instead of failing.
 | Bootstrap (`apt`/`uv`/`npm`) failure                 | Abort; print remediation; tarball not built yet               |
 | `tar` fails                                          | Abort; cleanup                                                |
 | Delta rsync fails                                    | Warn; do not abort (initial tarball already transferred)      |
+| Invalid `workspace.yaml` field (repo/branch present but malformed) | Abort **before** clone with validation error (exit 11)      |
+| Session has no repository / non-github `host_type`   | Skip reconstruction (warn); resume in `$HOME` (no hard-gate)   |
+| Cross-user path not remappable / escapes `$HOME`     | Abort before clone (exit 12)                                  |
+| `gh repo clone` / `git clone` fails                  | Abort; project tree could not be reconstructed (exit 13)     |
+| `git worktree add` fails (branch pushed)             | Fall back to standalone clone/checkout at `cwd_dest`          |
+| Worktree branch never pushed to remote               | Hard-gate aborts (exit 10) — no silent hollow resume          |
+| Post-clone hard-gate fails (cwd missing / wrong branch) | Abort; refuse hollow resume into `$HOME` (exit 10)         |
 | `tmux new-session` already exists on destination     | Treated as success; user attaches to existing session         |
+
+## Exit Codes
+
+Codes `2`–`9` are **pre-existing** (they predate the reconstruction phase);
+codes `10`–`13` are added by the project-reconstruction phase and are chosen to
+avoid collision with the existing range.
+
+| Code   | Meaning                                                                 |
+| ------ | ----------------------------------------------------------------------- |
+| `0`    | Success — session reconstructed and resumed on the destination.         |
+| `1`    | Destination verification failed a hard prerequisite (`gh` or the CLI binary missing on the destination). |
+| `2`    | Invalid invocation — unknown option, missing/extra positional, or malformed destination hostname. |
+| `3`    | Required dependency missing on the **source** host (e.g. `azlin`).      |
+| `4`    | Active session could not be detected, or an explicit `--session` id was malformed. |
+| `5`    | Destination bootstrap failed (`bootstrap-dest.sh` could not install the toolchain). |
+| `6`    | Selective `tar` build failed, or no migratable amplihack paths were found. |
+| `7`    | Insufficient free disk on the destination (needs ≥ 2× tarball size).    |
+| `8`    | Transfer failed — `azlin cp` of the tarball or remote extraction errored. |
+| `9`    | Post-transfer destination verification failed (session-state / auth / CLI checks). |
+| `10`   | Reconstruction hard-gate failed — `cwd` missing, not a directory, or not a git checkout on the recorded branch. Migration refuses to resume into a hollow `$HOME`. |
+| `11`   | `workspace.yaml` field validation failed for a session that **claims** a github repository — `repository`/`branch`/`host_type` failed the regex/allowlist, or a *present* field was empty / contained a newline. A cleanly **absent** `repository`/`git_root`, or a non-github `host_type`, is a **skip** (warn + resume in `$HOME`), not exit 11. |
+| `12`   | Cross-user path remap failed — the computed destination path could not be normalized strictly under `$HOME`. |
+| `13`   | Project reconstruction failed — `gh repo clone` / `git clone` of `repository` into the remapped `git_root` did not succeed. |
 
 ## Manual Recovery
 
@@ -156,7 +299,14 @@ azlin cp /tmp/amplihack-migrate-*.tar.zst <host>:/tmp/
 # 2. extract on destination
 azlin connect -y <host> -- tar --use-compress-program=unzstd -xpf /tmp/amplihack-migrate-*.tar.zst -C /
 
-# 3. start the session manually
+# 3. reconstruct the project tree so resume lands in a real checkout
+#    (read cwd/git_root/repository/branch from the session's workspace.yaml)
+azlin connect -y <host> -- gh repo clone <owner/repo> "$HOME/src/<repo>"
+azlin connect -y <host> -- git -C "$HOME/src/<repo>" checkout <branch>
+#    then edit cwd + git_root in
+#    ~/.copilot/session-state/<id>/workspace.yaml to the reconstructed path
+
+# 4. start the session manually
 azlin connect -y <host>:session-<id> -- copilot --resume <id>
 ```
 
@@ -167,6 +317,33 @@ to the destination. A warning is printed before transfer. Only migrate to hosts
 you fully trust (e.g., your own azlin-managed VMs). Do not use this skill with
 shared or untrusted destinations.
 
+### Untrusted `workspace.yaml` fields
+
+The `cwd`, `git_root`, `repository`, `host_type`, and `branch` fields consumed by
+the [project reconstruction phase](#8-project-reconstruction--workspaceyaml-rewrite)
+originate in the **source user's** home directory and are treated as untrusted
+input flowing into the shell, filesystem paths, and `git`/`gh` argv. The
+reconstruction phase applies defense-in-depth:
+
+- **Reject, don't sanitize.** `repository`, `branch`, and `host_type` must pass
+  strict regex / allowlist checks; empty fields or embedded newlines are rejected
+  (blocks YAML → multiline-shell smuggling).
+- **Git option-injection defense.** Leading-`-` values in `branch` / `repository`
+  are rejected so they cannot be smuggled as `gh` / `git` flags.
+- **Path-traversal defense.** The destination path is normalized and asserted to
+  be strictly under `$HOME`; the `src/<repo>[/worktrees/<branch>]` tail is
+  re-derived from the validated `repository` + `branch`, never copied verbatim.
+- **No injection surface.** Validated values are passed as positional arguments
+  into a single-quoted remote heredoc (`bash -s --`), so they are never
+  interpreted as command text.
+- **No privilege escalation.** Reconstruction always clones under `$HOME`; no
+  `sudo` / `chown` is used, even for cross-user path migration.
+- **No new credentials.** Reconstruction reuses the already-migrated `gh` auth;
+  no token is ever logged.
+- **Atomic, mode-preserving rewrite.** The `workspace.yaml` rewrite preserves the
+  original file mode and only clones into a fresh or owner-verified `.git` path to
+  block symlink / TOCTOU clobbering.
+
 ## Scope Boundaries
 
 **In scope (v1)**:
@@ -175,10 +352,14 @@ shared or untrusted destinations.
 - Claude Code migration best-effort (resume flag verified at runtime)
 - Amplifier migration of filesystem only (resume step TBD)
 - azlin-only destinations
+- **Project-tree reconstruction** on the destination (clone repo / recreate
+  worktree at the persisted path) with cross-user path remapping and a hard
+  resume gate
 
 **Not in v1**:
 
-- `~/src/*` source-tree migration
+- Copying uncommitted / unpushed `~/src/*` changes (reconstruction clones the
+  pushed branch only)
 - Bidirectional sync / live mirroring
 - Raw SSH / non-azlin destinations
 - Source-side cleanup after successful migration

--- a/docs/skills/migrate.md
+++ b/docs/skills/migrate.md
@@ -203,6 +203,12 @@ CLI reads the corrected paths). Steps:
    - `host_type: github` → `gh repo clone <repository> <git_root_dest>`
      (falls back to `git clone https://…` if `gh` clone fails), then
      `git checkout <branch>`.
+   - Every external-service call (`gh repo clone`, `git clone`, `git fetch`)
+     is wrapped in **bounded retry-with-backoff** (default 3 attempts,
+     `2 · 2ⁿ⁻¹`s delay capped at 30s) so a transient network / DNS / TLS /
+     rate-limit failure does not hard-fail reconstruction. Tune via the
+     `AMPLIHACK_MIGRATE_RETRIES` and `AMPLIHACK_MIGRATE_RETRY_DELAY`
+     environment variables; the retry count is exhausted before exit 13.
    - If `<git_root_dest>/.git` already exists, `git fetch` + `git checkout`
      instead of re-cloning.
    - **Worktree** sessions: after the main clone at `git_root_dest`, attempt
@@ -259,7 +265,7 @@ filesystem and prints manual-attach instructions instead of failing.
 | Invalid `workspace.yaml` field (repo/branch present but malformed) | Abort **before** clone with validation error (exit 11)      |
 | Session has no repository / non-github `host_type`   | Skip reconstruction (warn); resume in `$HOME` (no hard-gate)   |
 | Cross-user path not remappable / escapes `$HOME`     | Abort before clone (exit 12)                                  |
-| `gh repo clone` / `git clone` fails                  | Abort; project tree could not be reconstructed (exit 13)     |
+| `gh repo clone` / `git clone` fails                  | Retry with backoff (`AMPLIHACK_MIGRATE_RETRIES`); abort exit 13 only after retries exhausted |
 | `git worktree add` fails (branch pushed)             | Fall back to standalone clone/checkout at `cwd_dest`          |
 | Worktree branch never pushed to remote               | Hard-gate aborts (exit 10) — no silent hollow resume          |
 | Post-clone hard-gate fails (cwd missing / wrong branch) | Abort; refuse hollow resume into `$HOME` (exit 10)         |
@@ -286,7 +292,7 @@ avoid collision with the existing range.
 | `10`   | Reconstruction hard-gate failed — `cwd` missing, not a directory, or not a git checkout on the recorded branch. Migration refuses to resume into a hollow `$HOME`. |
 | `11`   | `workspace.yaml` field validation failed for a session that **claims** a github repository — `repository`/`branch`/`host_type` failed the regex/allowlist, or a *present* field was empty / contained a newline. A cleanly **absent** `repository`/`git_root`, or a non-github `host_type`, is a **skip** (warn + resume in `$HOME`), not exit 11. |
 | `12`   | Cross-user path remap failed — the computed destination path could not be normalized strictly under `$HOME`. |
-| `13`   | Project reconstruction failed — `gh repo clone` / `git clone` of `repository` into the remapped `git_root` did not succeed. |
+| `13`   | Project reconstruction failed — `gh repo clone` / `git clone` of `repository` into the remapped `git_root` did not succeed after the retry budget (`AMPLIHACK_MIGRATE_RETRIES`, default 3) was exhausted. |
 
 ## Manual Recovery
 


### PR DESCRIPTION
## Summary

Fixes #909. The migrate skill resumed a session on the destination VM but never recreated the persisted `cwd`/`git_root`, so the resumed CLI landed in `$HOME` and lost project context — the recorded paths point at the **source** user's home, which does not exist on the destination.

This adds a **project-reconstruction phase** to `migrate.sh` that re-materializes the git checkout on the destination and rewrites the persisted paths so resume lands in real project context.

## What changed

`amplifier-bundle/skills/migrate/scripts/migrate.sh`:
- Runs **after** the final delta rsync (so rsync can't clobber the rewritten `workspace.yaml`) and **before** the tmux resume (so the CLI reads corrected paths).
- Parses `cwd`/`git_root`/`repository`/`host_type`/`branch` from the session's `workspace.yaml` (flat `grep`/`sed`, **no `yq`** dependency).
- **Validates** the untrusted YAML fields (reject-don't-sanitize) to block shell and git-option injection; values pass as positional args into a single-quoted remote heredoc.
- **Remaps** cross-user paths to `$HOME/src/<repo>[/worktrees/<branch>]`, re-derived from the validated repo/branch and asserted strictly under `$HOME` (no `sudo`/`chown`).
- **Reconstructs** idempotently: `gh repo clone` with `git clone https` fallback; worktree sessions use best-effort `git worktree add` with a standalone-clone fallback.
- **Atomically rewrites** `cwd` + `git_root` in the destination `workspace.yaml`, preserving file mode and treating replacements literally (sed-metachar-safe).
- **Hard-gates** before resume: `cwd` must exist, be a directory, and be a checkout on the recorded branch — otherwise abort (exit 10) rather than resume into a hollow `$HOME`.

New exit codes `10`–`13` (collision-free with existing `2`–`9`). The **skip path** (warn + resume in `$HOME`) is preserved for sessions with no clonable github repository.

## Tests

- New bats suite `scripts/tests/test_workspace_rewrite.bats` pins the pure, sourceable helpers (`AMPLIHACK_MIGRATE_LIB=1`) — **26/26 pass**.
- `migrate.sh` passes `shellcheck -x` and `bash -n`.

Docs updated: `SKILL.md`, `docs/skills/migrate.md` (reconstruction phase, exit codes).

> Do not merge — leave open for review.

## Step 13: Local Testing Results

Detected toolchains:
- **Bash** — the change is entirely in `amplifier-bundle/skills/migrate/scripts/migrate.sh` (a `#!/usr/bin/env bash` script) and its `SKILL.md`/docs. No Cargo/npm/py manifest touches the reconstruction logic. Evidence: changed files are `migrate.sh`, `test_workspace_rewrite.bats`, `SKILL.md`, `docs/skills/migrate.md`.
- **bats-core** — the script exposes a sourceable "library mode" (`AMPLIHACK_MIGRATE_LIB=1`) and ships a bats suite (`scripts/tests/test_workspace_rewrite.bats`). `bats 1.13.0` present on PATH.
- **git** — reconstruction clones/worktrees a repo; validated with a real local bare remote.

Chosen validation strategy:
- Run the shipped bats contract suite as the simple user-facing check (proves the pure helpers behave), then run a real end-to-end reconstruction against a local git remote that mirrors the destination-VM logic (remap cross-user cwd/git_root → clone → worktree add → rewrite `workspace.yaml` → hard-gate). Together these prove the user-visible fix: a resumed session lands in a valid checkout on the correct branch instead of `$HOME` (no `resume-auto-cd ... missing` warning).

### Scenario 1 — bats contract suite for the sourceable reconstruction helpers
Command: `bats amplifier-bundle/skills/migrate/scripts/tests/test_workspace_rewrite.bats`
Result: PASS
Output:
```
1..31
ok 1 sourcing in library mode does not run the migration or exit nonzero
...
ok 22 migrate_rewrite_workspace_yaml rewrites both cwd and git_root
ok 31 migrate.sh passes shellcheck (skipped if shellcheck unavailable)
```
(31/31 passed)

### Scenario 2 — end-to-end cross-user worktree reconstruction against a real git remote
Command: `bash recon_e2e.sh amplifier-bundle/skills/migrate/scripts/migrate.sh`
(sources `migrate.sh` in library mode; source cwd `/home/rysweet/src/widget/worktrees/feat/issue-909`, dest `$HOME` != source home)
Result: PASS
Output:
```
PASS: gate: session flagged for reconstruction
PASS: validation: host_type/repository/branch accepted
PASS: remap: cross-user paths remapped under destination $HOME
PASS: clone+worktree: checkout materialized at cwd_dest
PASS: rewrite: workspace.yaml cwd/git_root now point at real checkout
PASS: hard-gate: cwd is a real git checkout on 'feat/issue-909' with its artifacts
ALL CHECKS PASSED — resumed session would land in .../src/widget/worktrees/feat/issue-909 (not $HOME)
```
