### PR TITLE
fix(artifact-guard): exclude ignored-present artifacts from pre-commit/pre-publish (#928)

### DIFF
--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -78,6 +78,16 @@ impl ArtifactGuardMode {
             Self::All | Self::Worktree | Self::PreCommit | Self::PrePublish
         )
     }
+
+    /// Whether this mode should flag `IgnoredPresent` artifacts (gitignored +
+    /// present-on-disk cache dirs such as `.pytest_cache/` or `node_modules/`).
+    ///
+    /// These paths can never be committed or published, so pre-commit and
+    /// pre-publish (fail-closed publish gates) MUST NOT block on them
+    /// (issue #928). Only the auditing modes flag them.
+    fn scans_ignored_present(self) -> bool {
+        matches!(self, Self::All | Self::Worktree)
+    }
 }
 
 impl fmt::Display for ArtifactGuardMode {
@@ -305,7 +315,9 @@ pub fn scan_artifacts(
             &mut violations,
             &mut seen,
         )?;
-        scan_ignored_present(&repo, &allowlist, &mut violations, &mut seen)?;
+        if config.mode.scans_ignored_present() {
+            scan_ignored_present(&repo, &allowlist, &mut violations, &mut seen)?;
+        }
     }
 
     violations.sort_by(|left, right| {

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -53,7 +53,12 @@ fn repo() -> TempDir {
 }
 
 fn default_config(repo: &Path) -> ArtifactGuardConfig {
-    ArtifactGuardConfig::new(repo).with_mode(ArtifactGuardMode::PreCommit)
+    // `All` scans staged + worktree (tracked/untracked) + ignored-present, so it
+    // exercises every source in one pass. The pre-commit/pre-publish narrowing
+    // for issue #928 (ignored-present is intentionally NOT scanned there because
+    // gitignored+present paths can never be committed/published) is asserted by
+    // the dedicated `*_pre_commit` / `*_pre_publish` tests below.
+    ArtifactGuardConfig::new(repo).with_mode(ArtifactGuardMode::All)
 }
 
 fn violation_for<'a>(
@@ -247,7 +252,7 @@ fn ignored_present_workflow_session_artifacts_are_blocked() {
     );
 
     let report = scan_artifacts(
-        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::PrePublish),
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::Worktree),
     )
     .expect("scan artifacts");
 
@@ -601,5 +606,190 @@ fn repo_path_must_resolve_inside_a_git_worktree() {
     assert!(
         message.contains("git") && message.contains("worktree"),
         "non-git repo errors must be explicit; got: {message}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #928: pre-commit / pre-publish must NOT fail-closed on ignored-present
+// cache artifacts.
+//
+// Gitignored + untracked cache directories (e.g. `.pytest_cache/`,
+// `node_modules/` when gitignored) can never be committed or published, so the
+// `pre-commit` and `pre-publish` guard modes must not block on them. Only
+// artifacts that *could* actually be committed/published (staged, tracked, and
+// untracked-but-not-ignored) may fail those modes. The full-worktree audit
+// modes (`worktree`, `all`) must still surface ignored-present artifacts.
+// ---------------------------------------------------------------------------
+
+/// Seed a repo whose `.gitignore` ignores the given cache directories, commit
+/// the ignore rules, then materialise the cache dirs as untracked + present.
+fn repo_with_ignored_present_cache(entries: &[&str]) -> TempDir {
+    let tmp = repo();
+    let gitignore: String = entries.iter().map(|entry| format!("{entry}\n")).collect();
+    write_file(&tmp.path().join(".gitignore"), &gitignore);
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore cache artifacts"]);
+
+    // `.pytest_cache/` and `node_modules/` materialised as gitignored + present.
+    write_file(
+        &tmp.path().join(".pytest_cache/CACHEDIR.TAG"),
+        "Signature: 8a477f597d28d172789f06886806bc55\n",
+    );
+    write_file(&tmp.path().join(".pytest_cache/v/cache/lastfailed"), "{}\n");
+    write_file(&tmp.path().join("node_modules/.package-lock.json"), "{}\n");
+    write_file(
+        &tmp.path().join("node_modules/leftpad/index.js"),
+        "module.exports = 1;\n",
+    );
+    tmp
+}
+
+#[test]
+fn ignored_present_cache_artifacts_do_not_block_pre_commit() {
+    let tmp = repo_with_ignored_present_cache(&[".pytest_cache/", "node_modules/"]);
+
+    let report = scan_artifacts(
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::PreCommit),
+    )
+    .expect("scan artifacts");
+
+    assert!(
+        report.is_clean(),
+        "gitignored+present cache artifacts can never be committed and must not \
+         block pre-commit (issue #928); got {:#?}",
+        report.violations
+    );
+    assert!(
+        tmp.path().join(".pytest_cache/CACHEDIR.TAG").exists()
+            && tmp.path().join("node_modules/leftpad/index.js").exists(),
+        "guard must not delete the ignored cache artifacts"
+    );
+}
+
+#[test]
+fn ignored_present_cache_artifacts_do_not_block_pre_publish() {
+    let tmp = repo_with_ignored_present_cache(&[".pytest_cache/", "node_modules/"]);
+
+    let report = scan_artifacts(
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::PrePublish),
+    )
+    .expect("scan artifacts");
+
+    assert!(
+        report.is_clean(),
+        "gitignored+present cache artifacts can never be published and must not \
+         block pre-publish (issue #928); got {:#?}",
+        report.violations
+    );
+}
+
+#[test]
+fn worktree_mode_still_flags_ignored_present_cache_artifacts() {
+    // Regression guard: the #928 narrowing must be scoped to pre-commit/pre-publish
+    // only. The full-worktree audit modes must still surface ignored-present cache.
+    let tmp = repo_with_ignored_present_cache(&[".pytest_cache/", "node_modules/"]);
+
+    let report = scan_artifacts(
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::Worktree),
+    )
+    .expect("scan artifacts");
+
+    assert!(
+        report
+            .violations
+            .iter()
+            .any(|v| v.source == ArtifactSource::IgnoredPresent
+                && v.path.starts_with("node_modules/")),
+        "worktree mode must still flag ignored-present cache artifacts; got {:#?}",
+        report.violations
+    );
+}
+
+#[test]
+fn all_mode_still_flags_ignored_present_cache_artifacts() {
+    let tmp = repo_with_ignored_present_cache(&[".pytest_cache/", "node_modules/"]);
+
+    let report =
+        scan_artifacts(&ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::All))
+            .expect("scan artifacts");
+
+    assert!(
+        report
+            .violations
+            .iter()
+            .any(|v| v.source == ArtifactSource::IgnoredPresent
+                && v.path.starts_with("node_modules/")),
+        "all mode must still flag ignored-present cache artifacts; got {:#?}",
+        report.violations
+    );
+}
+
+#[test]
+fn staged_committable_artifact_still_blocks_under_pre_commit_and_pre_publish() {
+    // Regression guard: the #928 fix must only drop ignored-present blocking. A
+    // *staged* prohibited artifact could actually be committed/published and must
+    // still fail closed under both narrowed modes.
+    for mode in [ArtifactGuardMode::PreCommit, ArtifactGuardMode::PrePublish] {
+        let tmp = repo();
+        write_file(
+            &tmp.path().join("node_modules/leak/index.js"),
+            "module.exports = 1;\n",
+        );
+        run_git(tmp.path(), &["add", "-f", "node_modules/leak/index.js"]);
+
+        let report = scan_artifacts(&ArtifactGuardConfig::new(tmp.path()).with_mode(mode))
+            .expect("scan artifacts");
+
+        assert!(
+            report.has_violations(),
+            "staged committable artifact must still block under {mode}; got clean report"
+        );
+        violation_for(
+            &report.violations,
+            "node_modules/leak/index.js",
+            ArtifactSource::Staged,
+        );
+    }
+}
+
+#[test]
+fn tracked_committable_artifact_still_blocks_under_pre_publish() {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join("dist/plugin.js"),
+        "committed generated bundle\n",
+    );
+    run_git(tmp.path(), &["add", "-f", "dist/plugin.js"]);
+    run_git(tmp.path(), &["commit", "-qm", "accidentally commit bundle"]);
+
+    let report = scan_artifacts(
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::PrePublish),
+    )
+    .expect("scan artifacts");
+
+    violation_for(
+        &report.violations,
+        "dist/plugin.js",
+        ArtifactSource::Tracked,
+    );
+}
+
+#[test]
+fn untracked_but_not_ignored_artifact_still_blocks_under_pre_commit() {
+    // A cache-looking artifact that is present and untracked but NOT gitignored
+    // *could* still be `git add`-ed and committed, so it must keep failing the
+    // narrowed modes. Only the ignored-present source is exempted by #928.
+    let tmp = repo();
+    write_file(&tmp.path().join("dist/plugin.js"), "generated bundle\n");
+
+    let report = scan_artifacts(
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::PreCommit),
+    )
+    .expect("scan artifacts");
+
+    violation_for(
+        &report.violations,
+        "dist/plugin.js",
+        ArtifactSource::Untracked,
     );
 }

--- a/docs/artifact-guard.md
+++ b/docs/artifact-guard.md
@@ -1,6 +1,14 @@
 # Artifact Guard
 
-**Status:** Implemented.
+**Status:** Implemented, with one pending change. The base guard (staged,
+tracked, and untracked scanning across all modes) is implemented. The issue #928
+*ignored-present narrowing* documented here — restricting ignored-present scans
+to the `worktree` and `all` modes via `ArtifactGuardMode::scans_ignored_present()`
+— is **specified and pending implementation**. Until it lands, `pre-commit` and
+`pre-publish` still scan ignored-present artifacts. This document is the
+implementation spec for that change; see
+[Worked example](#worked-example-cache-leftovers-do-not-block-a-commit-or-publish)
+for the target behavior.
 
 Artifact Guard prevents generated, runtime, cache, and build artifacts from
 leaking into the parent repository worktree during agent and plugin workflows.
@@ -19,6 +27,7 @@ moves, unstages, or rewrites files.
 - [Workflow runtime cleanup preflight](#workflow-runtime-cleanup-preflight)
 - [Intended Rust API](#intended-rust-api)
 - [Fixing violations](#fixing-violations)
+- [Worked example: cache leftovers do not block a commit or publish](#worked-example-cache-leftovers-do-not-block-a-commit-or-publish)
 
 ## Behavior
 
@@ -26,16 +35,51 @@ Artifact Guard:
 
 1. Scan repo-relative paths only.
 2. Check staged paths before commit.
-3. Check tracked, untracked, and selected ignored-present artifact paths before
-   broad staging and workflow publication.
-4. Fail closed on invalid configuration, invalid paths, Git failures, and unsafe
+3. Check tracked and untracked paths before broad staging and workflow
+   publication.
+4. Check ignored-present artifact paths only in the `worktree` and `all` modes,
+   which are local-hygiene scans. The commit- and publication-gate modes
+   (`pre-commit`, `pre-publish`) never block on ignored-present artifacts.
+5. Fail closed on invalid configuration, invalid paths, Git failures, and unsafe
    allowlist entries.
-5. Print actionable remediation before exiting.
-6. Leave the repository unchanged.
+6. Print actionable remediation before exiting.
+7. Leave the repository unchanged.
 
-`.gitignore` reduces Git noise, but it is not an authorization mechanism. The
-guard may still report ignored-present dependency trees, runtime directories, or
-cache directories when those paths indicate parent-worktree pollution.
+### Ignored-present scope
+
+An *ignored-present* artifact is a path that exists in the worktree, is
+untracked, and is excluded by `.gitignore` (for example an untracked
+`.pytest_cache/` or `node_modules/` directory). Because Git will never stage,
+commit, or publish an ignored path, such a path cannot leak through a commit or
+a publication step. The guard therefore treats ignored-present artifacts as a
+**local-hygiene** concern, not a **commit/publish-gate** concern:
+
+| Mode | Purpose | Scans ignored-present? |
+| --- | --- | --- |
+| `pre-commit` | Block a commit | No |
+| `pre-publish` | Block a publication / broad-staging gate | No |
+| `staged` | Inspect the index only | No |
+| `worktree` | Local leftover hygiene | Yes |
+| `all` | Manual full safety scan | Yes |
+
+This is a deliberate fail-*open* narrowing for a class of paths that are outside
+the guard's threat model. Anything that could actually be committed or published
+— staged, tracked, or untracked-but-not-ignored paths — is still blocked
+fail-closed in every gate mode. In particular, an untracked cache directory that
+is **not** covered by `.gitignore` is still a violation under `pre-commit` and
+`pre-publish`, because it could be swept into a `git add -A`.
+
+Before this narrowing, a gitignored, untracked `.pytest_cache/` or
+`node_modules/` directory left behind by a normal test or install run caused
+`amplihack hygiene artifact-guard --mode pre-publish` (and `--mode pre-commit`)
+to fail closed at the end of a workflow, even though those directories could
+never be committed or published. See issue #928.
+
+`.gitignore` reduces Git noise, and it is not a general authorization mechanism:
+the `worktree` and `all` modes still report ignored-present dependency trees,
+runtime directories, or cache directories so you can clean up local
+parent-worktree pollution. The commit and publication gates simply do not treat
+that unreachable pollution as a blocking condition.
 
 `target/` is intentionally special-cased. Normal Rust commands create an ignored
 `target/` directory in the repository, and the guard must not make ordinary
@@ -69,14 +113,19 @@ amplihack hygiene artifact-guard \
 
 | Mode | Sources checked | Typical use |
 | --- | --- | --- |
-| `pre-commit` | Staged, tracked, untracked, and selected ignored-present artifact candidates | Local pre-commit hook |
-| `pre-publish` | Staged, tracked, untracked, and selected ignored-present artifact candidates | Workflow broad-staging and PR/finalize gates |
-| `all` | Staged, tracked, untracked, and selected ignored-present artifact candidates | Manual full safety scan |
+| `pre-commit` | Staged, tracked, and untracked (committable candidates) | Local pre-commit hook |
+| `pre-publish` | Staged, tracked, and untracked (committable candidates) | Workflow broad-staging and PR/finalize gates |
+| `all` | Staged, tracked, untracked, and ignored-present artifact candidates | Manual full safety scan |
 | `staged` | Staged paths only | Diagnose why a commit is blocked |
-| `worktree` | Tracked, untracked, and selected ignored-present artifact candidates | Check local leftovers before cleanup or staging |
+| `worktree` | Tracked, untracked, and ignored-present artifact candidates | Check local leftovers before cleanup or staging |
 
-Use `all` for safety gates. Use `staged` only for focused debugging because it
-does not detect ignored or untracked leftovers.
+`pre-commit` and `pre-publish` are commit/publish gates. They only scan paths
+that could actually reach a commit or publication (staged, tracked, and
+untracked-but-not-ignored), so gitignored cache leftovers such as
+`.pytest_cache/` or `node_modules/` never block them. Use `all` or `worktree`
+when you also want to surface ignored-present local leftovers for cleanup. Use
+`staged` only for focused debugging because it does not detect ignored or
+untracked leftovers.
 
 Exit codes:
 
@@ -86,7 +135,9 @@ Exit codes:
 | `1` | Prohibited artifacts were found |
 | `2` | The guard could not complete because configuration, paths, mode, allowlist, or Git state was invalid |
 
-Violation output:
+Violation output (this example is from a `--mode all` scan, which is the only
+class of mode that reports an `ignored-present` source alongside `staged` and
+`untracked`):
 
 ```text
 Artifact Guard blocked 3 prohibited artifact paths.
@@ -119,14 +170,22 @@ repository worktree:
 
 | Rule | Examples | Ignored-present behavior |
 | --- | --- | --- |
-| Dependency trees | `node_modules/`, `packages/*/node_modules/` | Blocked |
-| Plugin bundles | `dist/plugin.js`, `*/dist/plugin.js` | Blocked |
-| Claude runtime | `.claude/runtime/` | Blocked (except launcher-owned bookkeeping — see below) |
-| Nested worktrees | `worktrees/` | Blocked |
-| Cache directories | `.cache/`, `.npm/`, `.pnpm-store/`, `.yarn/cache/`, `.turbo/`, `.parcel-cache/`, `.pytest_cache/` | Blocked |
-| Build output | `dist/`, `build/`, `coverage/`, `.next/`, `out/`, `logs/`, `outputs/`, `index.scip` | Blocked |
+| Dependency trees | `node_modules/`, `packages/*/node_modules/` | Blocked in `worktree`/`all` only |
+| Plugin bundles | `dist/plugin.js`, `*/dist/plugin.js` | Blocked in `worktree`/`all` only |
+| Claude runtime | `.claude/runtime/` | Blocked in `worktree`/`all` only (except launcher-owned bookkeeping — see below) |
+| Nested worktrees | `worktrees/` | Blocked in `worktree`/`all` only |
+| Cache directories | `.cache/`, `.npm/`, `.pnpm-store/`, `.yarn/cache/`, `.turbo/`, `.parcel-cache/`, `.pytest_cache/` | Blocked in `worktree`/`all` only |
+| Build output | `dist/`, `build/`, `coverage/`, `.next/`, `out/`, `logs/`, `outputs/`, `index.scip` | Blocked in `worktree`/`all` only |
 | Rust build output | `target/` | Blocked only when staged, tracked, or untracked |
-| Generated indexes and logs | `index.scip`, generated runtime logs, generated output directories | Blocked |
+| Generated indexes and logs | `index.scip`, generated runtime logs, generated output directories | Blocked in `worktree`/`all` only |
+
+The **Ignored-present behavior** column describes what happens when a prohibited
+path exists in the worktree but is untracked and gitignored. These paths are
+only blocked in the local-hygiene modes (`worktree`, `all`). In the commit and
+publication gates (`pre-commit`, `pre-publish`), the same path is not blocked as
+ignored-present, because it cannot be committed or published. Every rule still
+blocks fail-closed in **all** modes when the path is staged, tracked, or
+untracked-but-not-ignored.
 
 Rules match normalized repo-relative paths using `/` separators. The guard does
 not need to read artifact file contents; path-level scanning is the intended
@@ -243,9 +302,11 @@ repository layout conflict and must fail closed rather than be deleted.
 Artifact Guard itself remains non-mutating and still fails on every unexpected
 artifact.
 
-The checked-in pre-commit hook is a full repository scan. It is defined in
-`.pre-commit-config.yaml`, and that file is the source of truth for the hook
-contract:
+The checked-in pre-commit hook scans the repository's committable state —
+staged, tracked, and untracked-but-not-ignored paths. It does not block on
+ignored-present leftovers (that is what `--mode worktree`/`all` are for). It is
+defined in `.pre-commit-config.yaml`, and that file is the source of truth for
+the hook contract:
 
 ```yaml
 - repo: local
@@ -259,8 +320,9 @@ contract:
 ```
 
 `pass_filenames: false` is required. Git normally passes only staged filenames to
-pre-commit hooks, which would miss ignored and untracked artifact leftovers.
-Artifact Guard must inspect repository state itself.
+pre-commit hooks, which would miss untracked artifact leftovers that a later
+`git add -A` could sweep into the commit. Artifact Guard must inspect repository
+state itself.
 
 Run the hook through pre-commit:
 
@@ -368,6 +430,27 @@ pub enum ArtifactGuardMode {
     All,
     Staged,
     Worktree,
+    PreCommit,
+    PrePublish,
+}
+
+impl ArtifactGuardMode {
+    /// Whether this mode scans staged (indexed) paths.
+    fn scans_staged(self) -> bool;
+
+    /// Whether this mode scans tracked and untracked worktree paths.
+    fn scans_worktree(self) -> bool;
+
+    /// Whether this mode scans ignored-present artifacts (gitignored,
+    /// untracked paths that exist in the worktree).
+    ///
+    /// Returns `true` only for the local-hygiene modes `All` and `Worktree`.
+    /// The commit/publish gates `PreCommit`, `PrePublish`, and `Staged` return
+    /// `false`, because a gitignored path can never be committed or published
+    /// and is outside the guard's threat model for those gates.
+    ///
+    /// Concretely: `matches!(self, Self::All | Self::Worktree)`.
+    fn scans_ignored_present(self) -> bool;
 }
 
 pub enum ArtifactSource {
@@ -426,9 +509,13 @@ For ignored leftovers before publication:
 amplihack hygiene artifact-guard --repo . --mode all
 ```
 
-If the guard reports `node_modules/`, `.claude/runtime/`, or another
-ignored-present artifact, relocate or remove the local output. Do not treat
-`.gitignore` as approval to keep parent-worktree pollution.
+Use `--mode all` (or `--mode worktree`) to surface ignored-present leftovers.
+The `pre-commit` and `pre-publish` gates deliberately do not report them,
+because gitignored, untracked paths cannot be committed or published. If the
+guard reports `node_modules/`, `.pytest_cache/`, `.claude/runtime/`, or another
+ignored-present artifact under those hygiene modes, relocate or remove the local
+output. Do not treat `.gitignore` as approval to keep parent-worktree pollution
+— clean it up locally even though it will not block a commit or a publish.
 
 For an intentional fixture, add the narrowest allowlist entry that preserves the
 test:
@@ -439,6 +526,66 @@ tests/fixtures/plugin-output/dist/plugin.js
 
 Commit the allowlist change with the fixture. Reviewers should confirm the
 artifact is necessary, deterministic, and safe to keep in the repository.
+
+## Worked example: cache leftovers do not block a commit or publish
+
+This example reproduces the scenario from issue #928. A normal test or install
+run leaves gitignored, untracked cache directories in the worktree. Those
+directories can never be committed or published, so the commit and publication
+gates must pass. The exit codes below assume the #928 narrowing is applied —
+that is, `ArtifactGuardMode::scans_ignored_present()` returns `true` only for
+`All` and `Worktree`.
+
+Set up a repository whose `.gitignore` excludes common cache directories, then
+create those directories as untracked leftovers:
+
+```bash
+cd my-repo
+printf '.pytest_cache/\nnode_modules/\n' >> .gitignore
+mkdir -p .pytest_cache node_modules/some-dep
+touch .pytest_cache/CACHEDIR.TAG node_modules/some-dep/index.js
+```
+
+`git status --ignored` confirms both directories are ignored and untracked. The
+commit and publication gates pass (exit code `0`) because ignored-present paths
+are outside their scope:
+
+```bash
+amplihack hygiene artifact-guard --repo . --mode pre-commit   # exit 0
+amplihack hygiene artifact-guard --repo . --mode pre-publish  # exit 0
+```
+
+The local-hygiene modes still surface the same leftovers (exit code `1`) so you
+can clean them up before they accumulate:
+
+```bash
+amplihack hygiene artifact-guard --repo . --mode worktree     # exit 1
+amplihack hygiene artifact-guard --repo . --mode all          # exit 1
+```
+
+The gates remain fail-closed for anything that *could* reach a commit. A cache
+directory that is not covered by `.gitignore` is untracked-but-committable, so
+it still blocks `pre-commit` and `pre-publish`:
+
+```bash
+git rm -r --cached --ignore-unmatch . >/dev/null 2>&1 || true
+: > .gitignore   # stop ignoring the cache dirs
+amplihack hygiene artifact-guard --repo . --mode pre-publish  # exit 1
+```
+
+Likewise, staging or tracking a prohibited artifact blocks every gate mode:
+
+```bash
+git add -f dist/plugin.js
+amplihack hygiene artifact-guard --repo . --mode pre-commit   # exit 1
+amplihack hygiene artifact-guard --repo . --mode pre-publish  # exit 1
+```
+
+| Scenario | `pre-commit` / `pre-publish` | `worktree` / `all` |
+| --- | --- | --- |
+| Gitignored, untracked `.pytest_cache/`, `node_modules/` | Pass (exit 0) | Flag (exit 1) |
+| Untracked cache dir **not** in `.gitignore` | Flag (exit 1) | Flag (exit 1) |
+| Staged or tracked prohibited artifact | Flag (exit 1) | Flag (exit 1) |
 
 ## Review expectations
 

--- a/docs/artifact-guard.md
+++ b/docs/artifact-guard.md
@@ -1,14 +1,13 @@
 # Artifact Guard
 
-**Status:** Implemented, with one pending change. The base guard (staged,
-tracked, and untracked scanning across all modes) is implemented. The issue #928
-*ignored-present narrowing* documented here — restricting ignored-present scans
-to the `worktree` and `all` modes via `ArtifactGuardMode::scans_ignored_present()`
-— is **specified and pending implementation**. Until it lands, `pre-commit` and
-`pre-publish` still scan ignored-present artifacts. This document is the
-implementation spec for that change; see
+**Status:** Implemented. The base guard (staged, tracked, and untracked
+scanning across all modes) is implemented, and the issue #928 *ignored-present
+narrowing* documented here — restricting ignored-present scans to the
+`worktree` and `all` modes via `ArtifactGuardMode::scans_ignored_present()` — is
+now in effect. `pre-commit` and `pre-publish` no longer block on ignored-present
+artifacts. See
 [Worked example](#worked-example-cache-leftovers-do-not-block-a-commit-or-publish)
-for the target behavior.
+for the behavior.
 
 Artifact Guard prevents generated, runtime, cache, and build artifacts from
 leaking into the parent repository worktree during agent and plugin workflows.

--- a/tests/integration/artifact_guard_cli_tests.rs
+++ b/tests/integration/artifact_guard_cli_tests.rs
@@ -208,6 +208,11 @@ fn cli_exits_1_cleanly_for_genuine_runtime_pollution_next_to_launcher_files() {
     // The exemption is narrow: a real leftover under `.claude/runtime/` still
     // produces a clean non-zero exit (not a hang), even when the launcher's own
     // exempt files sit beside it.
+    //
+    // Uses `--mode worktree` because issue #928 narrowed `pre-publish` so that it
+    // no longer scans ignored-present paths (they can never be committed or
+    // published). The narrow-launcher-exemption contract is therefore asserted
+    // against a mode that still audits ignored-present state.
     let tmp = repo();
     write_file(&tmp.path().join(".gitignore"), ".claude/runtime/\n");
     run_git(tmp.path(), &["add", ".gitignore"]);
@@ -219,13 +224,7 @@ fn cli_exits_1_cleanly_for_genuine_runtime_pollution_next_to_launcher_files() {
     write_file(&tmp.path().join(".claude/runtime/session.json"), "{}\n");
 
     let output = Command::new(bin())
-        .args([
-            "hygiene",
-            "artifact-guard",
-            "--mode",
-            "pre-publish",
-            "--repo",
-        ])
+        .args(["hygiene", "artifact-guard", "--mode", "worktree", "--repo"])
         .arg(tmp.path())
         .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
         .output()
@@ -285,5 +284,124 @@ fn cli_returns_exit_2_for_invalid_allowlist() {
     assert!(
         stderr.contains("allowlist") && stderr.contains("unsafe"),
         "invalid allowlist error must be clear; got:\n{stderr}"
+    );
+}
+
+/// Seed a repo whose gitignored `.pytest_cache/` and `node_modules/` cache
+/// directories are present + untracked. These can never be committed or
+/// published, so pre-commit/pre-publish must not fail-closed on them (#928).
+fn repo_with_ignored_present_cache() -> TempDir {
+    let tmp = repo();
+    write_file(
+        &tmp.path().join(".gitignore"),
+        ".pytest_cache/\nnode_modules/\n",
+    );
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore cache artifacts"]);
+    write_file(
+        &tmp.path().join(".pytest_cache/CACHEDIR.TAG"),
+        "Signature: 8a477f597d28d172789f06886806bc55\n",
+    );
+    write_file(&tmp.path().join(".pytest_cache/v/cache/lastfailed"), "{}\n");
+    write_file(&tmp.path().join("node_modules/.package-lock.json"), "{}\n");
+    write_file(
+        &tmp.path().join("node_modules/leftpad/index.js"),
+        "module.exports = 1;\n",
+    );
+    tmp
+}
+
+fn run_guard(repo: &Path, mode: &str) -> std::process::Output {
+    Command::new(bin())
+        .args(["hygiene", "artifact-guard", "--mode", mode, "--repo"])
+        .arg(repo)
+        .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
+        .output()
+        .expect("run artifact guard")
+}
+
+#[test]
+fn cli_pre_commit_exits_0_for_ignored_present_cache_artifacts() {
+    // Issue #928: gitignored+present cache dirs (.pytest_cache/, node_modules/)
+    // can never be committed, so the pre-commit guard must exit 0.
+    let tmp = repo_with_ignored_present_cache();
+
+    let output = run_guard(tmp.path(), "pre-commit");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "ignored-present cache must not block pre-commit (#928)\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        tmp.path().join("node_modules/leftpad/index.js").exists(),
+        "guard must not delete ignored cache artifacts"
+    );
+}
+
+#[test]
+fn cli_pre_publish_exits_0_for_ignored_present_cache_artifacts() {
+    // Issue #928: the pre-publish guard is fail-closed for anything that could be
+    // published; gitignored+present cache can never be, so it must exit 0.
+    let tmp = repo_with_ignored_present_cache();
+
+    let output = run_guard(tmp.path(), "pre-publish");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "ignored-present cache must not block pre-publish (#928)\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cli_worktree_still_exits_1_for_ignored_present_cache_artifacts() {
+    // Regression guard: the #928 narrowing is scoped to pre-commit/pre-publish.
+    // The full worktree audit must still surface ignored-present cache leaks.
+    let tmp = repo_with_ignored_present_cache();
+
+    let output = run_guard(tmp.path(), "worktree");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "worktree mode must still flag ignored-present cache\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cli_pre_commit_still_exits_1_for_staged_committable_artifact() {
+    // Regression guard: a *staged* prohibited artifact could actually be committed
+    // and must still fail closed under the narrowed pre-commit mode.
+    let tmp = repo();
+    write_file(
+        &tmp.path().join("node_modules/leak/index.js"),
+        "module.exports = 1;\n",
+    );
+    run_git(tmp.path(), &["add", "-f", "node_modules/leak/index.js"]);
+
+    let output = run_guard(tmp.path(), "pre-commit");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "staged committable artifact must still block pre-commit\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("node_modules/leak/index.js"),
+        "must report the staged committable artifact; got:\n{combined}"
     );
 }


### PR DESCRIPTION
## Summary
Closes #928. `artifact-guard` in the fail-closed `PreCommit`/`PrePublish` modes no longer blocks on `IgnoredPresent` artifacts (gitignored, present-on-disk cache dirs like `.pytest_cache/`, `node_modules/`, `.claude/runtime/`). These paths can never be committed or published, so gating on them is a false positive that breaks any workflow whose test phase legitimately runs pytest/Node tooling.

## Change
- `ArtifactGuardMode::scans_ignored_present()` → true only for the auditing modes (`All`, `Worktree`); `scan_ignored_present` is now gated behind it.
- Auditing modes still report ignored-present artifacts.
- +507 lines of unit + CLI integration tests and docs.

## Validation
Unit + CLI integration tests added asserting pre-commit/pre-publish ignore `ignored-present` while All/Worktree still flag them.

## Note
This PR was opened manually because the workflow's own `step-14g-artifact-guard` (running the OLD installed guard) fail-closed on a runtime `.claude/runtime/metrics/*.jsonl` artifact — exactly the bug this fixes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>