### PR TITLE
fix: bugfix branches no longer bump version in workflow-publish (#944)

### DIFF
--- a/amplifier-bundle/recipes/tests/test-issue-944-bugfix-no-version-bump.sh
+++ b/amplifier-bundle/recipes/tests/test-issue-944-bugfix-no-version-bump.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# test-issue-944-bugfix-no-version-bump.sh
+#
+# TDD contract for GitHub issue #944.
+#
+# Problem: the default-workflow/publish implementation commit hardcodes a
+# `feat:` conventional-commit prefix (workflow-publish.yaml step-15,
+# historically `printf 'feat: %.72s'`). Because step-14-bump-version treats any
+# feature-signalling commit as license to bump `[workspace.package].version`,
+# pure bugfix branches spuriously bump the workspace version (observed on #920
+# and #943, requiring manual reverts).
+#
+# Contract under test:
+#   R1 (behavioural) — The step-15 commit TITLE prefix is derived from the real
+#       change type reported by step-14 via the env var
+#       `RECIPE_VAR_version_bump__change_classification`:
+#           PATCH -> "fix: "
+#           MINOR -> "feat: "
+#           MAJOR -> "feat!: "
+#       When the classification is unset/empty, a deterministic fallback scans
+#       $TASK_DESCRIPTION for bugfix intent (bug/bugfix/fix) -> "fix: ",
+#       otherwise defaults to "feat: " (legacy behaviour preserved).
+#   R1 (static) — The hardcoded `printf 'feat: %.72s'` literal is GONE; the
+#       step-15 title logic references the classification signal and can emit
+#       both `fix:` and `feat!:` prefixes.
+#   R1 (safety) — Injection/word-splitting hardening from #469/#311 is
+#       preserved: the task description is consumed via env var, sanitized with
+#       `tr '\n\r'`, truncated with `%.72s`, and the block contains no `eval`.
+#   R2 (static) — step-14-bump-version's prompt instructs that PATCH is a
+#       NO-OP on the workspace version line (leave version unchanged /
+#       new_version == current_version), while MINOR/MAJOR still bump.
+#
+# Expected BEFORE the fix: several assertions FAIL (hardcoded feat: prefix).
+# Expected AFTER  the fix: all assertions PASS.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-issue-944-bugfix-no-version-bump.sh
+# Exit codes: 0 = all pass, 1 = one or more failures, 2 = harness error.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-publish.yaml"
+
+if [[ ! -f "${RECIPE}" ]]; then
+    echo "HARNESS-ERROR: recipe not found: ${RECIPE}" >&2
+    exit 2
+fi
+for tool in python3 jq; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "HARNESS-ERROR: $tool required" >&2; exit 2; }
+done
+
+WORK="$(mktemp -d -t issue944-XXXXXX)"
+trap 'rm -rf "${WORK}"' EXIT
+
+pass=0
+fail=0
+record_pass() { echo "PASS: $1"; pass=$((pass + 1)); }
+record_fail() {
+    echo "FAIL: $1" >&2
+    [[ $# -gt 1 && -n "${2:-}" ]] && printf '      %s\n' "$2" >&2
+    fail=$((fail + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Extract the two recipe fragments we exercise:
+#   * step-15 commit TITLE-computation region (bounded by stable anchors)
+#   * step-14-bump-version prompt text
+# ---------------------------------------------------------------------------
+STEP15_TITLE_SLICE="${WORK}/step15_title_slice.sh"
+STEP14_PROMPT="${WORK}/step14_prompt.txt"
+STEP15_FULL="${WORK}/step15_full.sh"
+
+python3 - "$RECIPE" "$STEP15_TITLE_SLICE" "$STEP14_PROMPT" "$STEP15_FULL" <<'PY'
+import sys, yaml
+
+recipe_path, slice_out, prompt_out, full_out = sys.argv[1:5]
+with open(recipe_path) as fh:
+    doc = yaml.safe_load(fh)
+
+steps = doc.get("steps") or doc.get("recipe", {}).get("steps") or []
+by_id = {s.get("id"): s for s in steps if isinstance(s, dict)}
+
+step15 = by_id.get("step-15-commit-push")
+step14 = by_id.get("step-14-bump-version")
+if step15 is None:
+    sys.stderr.write("HARNESS-ERROR: step-15-commit-push not found\n"); sys.exit(2)
+if step14 is None:
+    sys.stderr.write("HARNESS-ERROR: step-14-bump-version not found\n"); sys.exit(2)
+
+cmd = step15.get("command", "")
+with open(full_out, "w") as fh:
+    fh.write(cmd)
+
+lines = cmd.splitlines()
+
+def find(pred, default=None):
+    for i, ln in enumerate(lines):
+        if pred(ln):
+            return i
+    return default
+
+# Start: just after the "Creating Commit" banner, else first TASK_DESC= line.
+start = find(lambda l: "Creating Commit" in l)
+if start is None:
+    start = find(lambda l: "TASK_DESC=" in l)
+    if start is None:
+        sys.stderr.write("HARNESS-ERROR: could not locate commit-title region start\n"); sys.exit(2)
+else:
+    start += 1
+
+# End: first Host-aware marker, else HOST_TYPE= assignment, else COMMIT_MSG=.
+end = find(lambda l: "Host-aware commit references" in l)
+if end is None:
+    end = find(lambda l: "HOST_TYPE=" in l)
+if end is None:
+    end = find(lambda l: "COMMIT_MSG=" in l)
+if end is None or end <= start:
+    sys.stderr.write("HARNESS-ERROR: could not locate commit-title region end\n"); sys.exit(2)
+
+with open(slice_out, "w") as fh:
+    fh.write("\n".join(lines[start:end]) + "\n")
+
+with open(prompt_out, "w") as fh:
+    fh.write(step14.get("prompt", ""))
+PY
+rc=$?
+[[ $rc -eq 0 ]] || { echo "HARNESS-ERROR: fragment extraction failed (rc=$rc)" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Behavioural harness: run the real recipe title-computation slice in isolation
+# and report the resulting COMMIT_TITLE for a given classification / task desc.
+# Runs under `set -euo pipefail` to prove set-u safety (step-15's real shell).
+# ---------------------------------------------------------------------------
+compute_title() {
+    # $1 = classification (empty string = unset), $2 = task description
+    local class="$1" desc="$2"
+    local runner="${WORK}/runner.sh"
+    {
+        echo 'set -euo pipefail'
+        printf 'export TASK_DESCRIPTION=%q\n' "$desc"
+        printf 'export ISSUE_NUMBER=%q\n' "944"
+        cat "$STEP15_TITLE_SLICE"
+        echo 'printf "COMMIT_TITLE=%s\\n" "$COMMIT_TITLE"'
+    } > "$runner"
+
+    if [[ -n "$class" ]]; then
+        RECIPE_VAR_version_bump__change_classification="$class" \
+            bash "$runner" 2>/dev/null | sed -n 's/^COMMIT_TITLE=//p'
+    else
+        env -u RECIPE_VAR_version_bump__change_classification \
+            bash "$runner" 2>/dev/null | sed -n 's/^COMMIT_TITLE=//p'
+    fi
+}
+
+assert_prefix() {
+    # $1 desc, $2 classification, $3 task, $4 expected prefix
+    local title
+    title="$(compute_title "$2" "$3")"
+    if [[ -z "$title" ]]; then
+        record_fail "$1" "slice produced no COMMIT_TITLE (likely set -u abort on unset classification var)"
+    elif [[ "$title" == "$4"* ]]; then
+        record_pass "$1"
+    else
+        record_fail "$1" "expected prefix '$4', got title: '$title'"
+    fi
+}
+
+BUG_TASK="Fix GitHub issue #944: bugfix so bugfix branches do not bump version"
+FEAT_TASK="Add a new publish dashboard command to the CLI"
+
+# R1 behavioural — classification-driven prefix mapping.
+assert_prefix "R1: PATCH classification -> 'fix:' prefix"   "PATCH" "$BUG_TASK"  "fix: "
+assert_prefix "R1: MINOR classification -> 'feat:' prefix"  "MINOR" "$FEAT_TASK" "feat: "
+assert_prefix "R1: MAJOR classification -> 'feat!:' prefix" "MAJOR" "$FEAT_TASK" "feat!: "
+
+# R1 behavioural — deterministic fallback when classification is unset/empty.
+assert_prefix "R1: unset classification + bug task -> 'fix:' (heuristic)"     "" "$BUG_TASK"  "fix: "
+assert_prefix "R1: unset classification + feature task -> 'feat:' (default)"  "" "$FEAT_TASK" "feat: "
+
+# R1 behavioural — the fix: prefix must NOT double-emit for MINOR (guard the
+# mapping is a real switch, not "always fix:").
+minor_title="$(compute_title "MINOR" "$BUG_TASK")"
+if [[ "$minor_title" == feat:* ]]; then
+    record_pass "R1: MINOR overrides bug-word heuristic (classification wins)"
+else
+    record_fail "R1: MINOR overrides bug-word heuristic (classification wins)" \
+        "expected 'feat:' prefix from MINOR classification, got: '$minor_title'"
+fi
+
+# R1 safety — the `%.72s` truncation of the description is preserved. Assert
+# on the description payload directly (prefix-agnostic): at most 72 of the
+# repeated marker characters survive.
+LONG_DESC="$(printf 'q%.0s' {1..200}) trailing"
+long_title="$(compute_title "PATCH" "$LONG_DESC")"
+q_count="$(printf '%s' "$long_title" | tr -cd 'q' | wc -c | tr -d ' ')"
+if [[ -n "$long_title" && "$q_count" -le 72 ]]; then
+    record_pass "R1-safety: description truncated to <=72 chars (%.72s preserved)"
+else
+    record_fail "R1-safety: description truncated to <=72 chars (%.72s preserved)" \
+        "surviving payload chars=$q_count title='$long_title'"
+fi
+
+# R1 safety — raw newlines in the task description must be flattened so the
+# commit TITLE is a single physical line (injection hardening from #469/#311).
+MULTILINE_DESC=$'fix newline handling\nSECOND LINE INJECTED'
+ml_title="$(compute_title "PATCH" "$MULTILINE_DESC")"
+if [[ -n "$ml_title" && "$ml_title" != *$'\n'* ]]; then
+    record_pass "R1-safety: newlines flattened -> single-line commit title"
+else
+    record_fail "R1-safety: newlines flattened -> single-line commit title" \
+        "title spans multiple lines: '$ml_title'"
+fi
+
+# ---------------------------------------------------------------------------
+# Static assertions on the recipe source.
+# ---------------------------------------------------------------------------
+
+# R1 static — the hardcoded feat: prefix literal must be gone.
+if grep -qF "printf 'feat: %.72s'" "$RECIPE"; then
+    record_fail "R1-static: hardcoded \"printf 'feat: %.72s'\" removed" \
+        "still present in $RECIPE (step-15)"
+else
+    record_pass "R1-static: hardcoded \"printf 'feat: %.72s'\" removed"
+fi
+
+# R1 static — step-15 must reference the classification signal.
+if grep -qE 'version_bump__change_classification|VERSION_BUMP__?CHANGE_CLASSIFICATION' "$STEP15_FULL"; then
+    record_pass "R1-static: step-15 reads version_bump change classification"
+else
+    record_fail "R1-static: step-15 reads version_bump change classification" \
+        "no classification env var reference in step-15 command"
+fi
+
+# R1 static — step-15 must be able to emit fix: and feat!: prefixes.
+if grep -qE '(^|[^a-z])fix:' "$STEP15_FULL" && grep -qE 'feat!:' "$STEP15_FULL"; then
+    record_pass "R1-static: step-15 defines both 'fix:' and 'feat!:' prefixes"
+else
+    record_fail "R1-static: step-15 defines both 'fix:' and 'feat!:' prefixes" \
+        "missing fix: and/or feat!: mapping in step-15 command"
+fi
+
+# R1 safety static — env-var + sanitize + truncate preserved, no eval.
+if grep -qF 'TASK_DESC="$TASK_DESCRIPTION"' "$STEP15_FULL" \
+   && grep -qE "tr '\\\\n\\\\r'" "$STEP15_FULL" \
+   && grep -qE '%\.72s' "$STEP15_FULL"; then
+    record_pass "R1-safety-static: env-var + tr sanitize + %.72s truncation preserved"
+else
+    record_fail "R1-safety-static: env-var + tr sanitize + %.72s truncation preserved" \
+        "one of: TASK_DESC env assignment / tr '\\n\\r' / %.72s missing"
+fi
+if grep -qE '(^|[^_[:alnum:]])eval([[:space:]]|$)' "$STEP15_FULL"; then
+    record_fail "R1-safety-static: no eval in commit block" "eval found in step-15"
+else
+    record_pass "R1-safety-static: no eval in commit block"
+fi
+
+# R2 static — step-14 prompt makes PATCH a no-op on the workspace version.
+prompt_lc="$(tr '[:upper:]' '[:lower:]' < "$STEP14_PROMPT")"
+if grep -q 'patch' <<<"$prompt_lc" \
+   && grep -Eq 'do not (modify|change|bump|edit)|leave .*version .*unchanged|unchanged|no-op|new_version *(==|=) *current_version|same version' <<<"$prompt_lc"; then
+    record_pass "R2-static: step-14 prompt instructs PATCH is a no-op on version"
+else
+    record_fail "R2-static: step-14 prompt instructs PATCH is a no-op on version" \
+        "prompt must tell the agent NOT to bump [workspace.package].version for PATCH"
+fi
+
+# R2 static — MINOR/MAJOR must still bump (guard against over-correction).
+if grep -Eq 'minor' <<<"$prompt_lc" && grep -Eq 'major' <<<"$prompt_lc"; then
+    record_pass "R2-static: step-14 prompt still distinguishes MINOR/MAJOR bumps"
+else
+    record_fail "R2-static: step-14 prompt still distinguishes MINOR/MAJOR bumps" \
+        "prompt lost MINOR/MAJOR bump semantics"
+fi
+
+# ---------------------------------------------------------------------------
+echo "---------------------------------------------"
+echo "issue-944 TDD: ${pass} passed, ${fail} failed"
+[[ $fail -eq 0 ]] || exit 1
+exit 0

--- a/amplifier-bundle/recipes/tests/test-issue-944-bugfix-no-version-bump.sh
+++ b/amplifier-bundle/recipes/tests/test-issue-944-bugfix-no-version-bump.sh
@@ -188,6 +188,28 @@ else
         "expected 'feat:' prefix from MINOR classification, got: '$minor_title'"
 fi
 
+# R1 behavioural — the uppercased alias VERSION_BUMP_CHANGE_CLASSIFICATION
+# (dot -> single '_') must also drive the prefix. Guards the regression where
+# a double-underscore uppercase name was used and silently never matched.
+upper_title="$(
+    {
+        echo 'set -euo pipefail'
+        printf 'export TASK_DESCRIPTION=%q\n' "$FEAT_TASK"
+        printf 'export ISSUE_NUMBER=%q\n' "944"
+        cat "$STEP15_TITLE_SLICE"
+        echo 'printf "COMMIT_TITLE=%s\\n" "$COMMIT_TITLE"'
+    } > "${WORK}/runner_upper.sh"
+    env -u RECIPE_VAR_version_bump__change_classification \
+        VERSION_BUMP_CHANGE_CLASSIFICATION="PATCH" \
+        bash "${WORK}/runner_upper.sh" 2>/dev/null | sed -n 's/^COMMIT_TITLE=//p'
+)"
+if [[ "$upper_title" == fix:* ]]; then
+    record_pass "R1: uppercase alias VERSION_BUMP_CHANGE_CLASSIFICATION drives prefix"
+else
+    record_fail "R1: uppercase alias VERSION_BUMP_CHANGE_CLASSIFICATION drives prefix" \
+        "expected 'fix:' prefix from uppercase alias, got: '$upper_title'"
+fi
+
 # R1 safety — the `%.72s` truncation of the description is preserved. Assert
 # on the description payload directly (prefix-agnostic): at most 72 of the
 # repeated marker characters survive.

--- a/amplifier-bundle/recipes/tests/test-issue-944-bugfix-no-version-bump.sh
+++ b/amplifier-bundle/recipes/tests/test-issue-944-bugfix-no-version-bump.sh
@@ -263,7 +263,7 @@ else
 fi
 
 # R1 safety static — env-var + sanitize + truncate preserved, no eval.
-if grep -qF 'TASK_DESC="$TASK_DESCRIPTION"' "$STEP15_FULL" \
+if grep -qE 'TASK_DESC="\$\{?TASK_DESCRIPTION(:-\})?"?' "$STEP15_FULL" \
    && grep -qE "tr '\\\\n\\\\r'" "$STEP15_FULL" \
    && grep -qE '%\.72s' "$STEP15_FULL"; then
     record_pass "R1-safety-static: env-var + tr sanitize + %.72s truncation preserved"

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -224,8 +224,10 @@ steps:
       git add -A
       echo "--- Creating Commit ---" >&2
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
-      TASK_DESC="$TASK_DESCRIPTION"
-      ISSUE_NUMBER="$ISSUE_NUMBER"
+      # nounset-safe reads (${VAR:-}) so an unset value cannot abort the step
+      # before the #944 fallback heuristic (below) can classify from TASK_DESC.
+      TASK_DESC="${TASK_DESCRIPTION:-}"
+      ISSUE_NUMBER="${ISSUE_NUMBER:-}"
       # FIX (#944): Derive the conventional-commit prefix from the real change
       # type reported by step-14-bump-version instead of hardcoding 'feat:'. A
       # hardcoded 'feat:' made pure bugfix branches trip the version-bump gate

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -47,8 +47,14 @@ steps:
        Required:
        1. Review `git diff main...HEAD`.
        2. Classify as PATCH (fix/docs/refactor), MINOR (backward-compatible feature/API), or MAJOR (breaking).
-       3. Read and update the current `version = "X.Y.Z"` line in the workspace Cargo.toml.
-       4. Verify the new version.
+       3. Update the `[workspace.package].version` line ONLY when the change type warrants it:
+          - **PATCH (fix/docs/refactor): DO NOT modify the `version = "X.Y.Z"` line.**
+            Leave `[workspace.package].version` exactly as-is and set
+            `new_version` equal to `current_version` in the output JSON.
+            A bugfix/docs/refactor branch MUST NOT bump the workspace version.
+          - **MINOR (backward-compatible feature/API): bump the minor** (X.Y.Z → X.(Y+1).0).
+          - **MAJOR (breaking): bump the major** (X.Y.Z → (X+1).0.0).
+       4. Verify the resulting version matches the classification (unchanged for PATCH).
 
        Useful commands:
        ```bash
@@ -56,6 +62,8 @@ steps:
        git diff main...HEAD --stat
        CURRENT_VERSION=$(grep -E '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)
        echo "Current version: $CURRENT_VERSION"
+       # PATCH: leave the version line untouched (no sed).
+       # MINOR/MAJOR only:
        # sed -i 's/version = "X.Y.Z"/version = "NEW.VERSION"/' Cargo.toml
        grep -E '^version = ' Cargo.toml | head -1
        ```
@@ -218,7 +226,29 @@ steps:
       # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
       TASK_DESC="$TASK_DESCRIPTION"
       ISSUE_NUMBER="$ISSUE_NUMBER"
-      COMMIT_TITLE=$(printf 'feat: %.72s' "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
+      # FIX (#944): Derive the conventional-commit prefix from the real change
+      # type reported by step-14-bump-version instead of hardcoding 'feat:'. A
+      # hardcoded 'feat:' made pure bugfix branches trip the version-bump gate
+      # (observed on #920/#943, requiring manual reverts).
+      #   PATCH -> fix:   MINOR -> feat:   MAJOR -> feat!:
+      # The classification is read from the step-14 output (surfaced by the
+      # recipe runner as RECIPE_VAR_version_bump__change_classification; the
+      # VERSION_BUMP__CHANGE_CLASSIFICATION uppercase form is a defensive
+      # fallback). When unset/unknown, fall back to a bugfix-intent heuristic on
+      # the task description, defaulting to feat: to preserve legacy behavior.
+      CHANGE_CLASS="${RECIPE_VAR_version_bump__change_classification:-${VERSION_BUMP__CHANGE_CLASSIFICATION:-}}"
+      case "$(printf '%s' "$CHANGE_CLASS" | tr '[:lower:]' '[:upper:]')" in
+        PATCH) COMMIT_PREFIX="fix: " ;;
+        MINOR) COMMIT_PREFIX="feat: " ;;
+        MAJOR) COMMIT_PREFIX="feat!: " ;;
+        *)
+          case "$(printf '%s' "$TASK_DESC" | tr '[:upper:]' '[:lower:]')" in
+            *bug*|*bugfix*|*fix*) COMMIT_PREFIX="fix: " ;;
+            *)                    COMMIT_PREFIX="feat: " ;;
+          esac
+          ;;
+      esac
+      COMMIT_TITLE=$(printf '%s%.72s' "$COMMIT_PREFIX" "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
       # FIX #684: Host-aware commit references
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
       case "$HOST_TYPE" in

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -47,14 +47,11 @@ steps:
        Required:
        1. Review `git diff main...HEAD`.
        2. Classify as PATCH (fix/docs/refactor), MINOR (backward-compatible feature/API), or MAJOR (breaking).
-       3. Update the `[workspace.package].version` line ONLY when the change type warrants it:
-          - **PATCH (fix/docs/refactor): DO NOT modify the `version = "X.Y.Z"` line.**
-            Leave `[workspace.package].version` exactly as-is and set
-            `new_version` equal to `current_version` in the output JSON.
-            A bugfix/docs/refactor branch MUST NOT bump the workspace version.
-          - **MINOR (backward-compatible feature/API): bump the minor** (X.Y.Z → X.(Y+1).0).
-          - **MAJOR (breaking): bump the major** (X.Y.Z → (X+1).0.0).
-       4. Verify the resulting version matches the classification (unchanged for PATCH).
+       3. Update `[workspace.package].version` ONLY when warranted:
+          - **PATCH (fix/docs/refactor): DO NOT modify the `version` line.** Set
+            `new_version` = `current_version` in the output JSON — no bump.
+          - **MINOR: bump minor** (X.Y.Z → X.(Y+1).0). **MAJOR: bump major** (→ (X+1).0.0).
+       4. Verify the version matches the classification (unchanged for PATCH).
 
        Useful commands:
        ```bash
@@ -62,9 +59,7 @@ steps:
        git diff main...HEAD --stat
        CURRENT_VERSION=$(grep -E '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)
        echo "Current version: $CURRENT_VERSION"
-       # PATCH: leave the version line untouched (no sed).
-       # MINOR/MAJOR only:
-       # sed -i 's/version = "X.Y.Z"/version = "NEW.VERSION"/' Cargo.toml
+       # MINOR/MAJOR only (PATCH: no sed): sed -i 's/version = "X.Y.Z"/version = "NEW.VERSION"/' Cargo.toml
        grep -E '^version = ' Cargo.toml | head -1
        ```
 
@@ -223,23 +218,12 @@ steps:
       amplihack hygiene artifact-guard --repo . --mode pre-publish
       git add -A
       echo "--- Creating Commit ---" >&2
-      # FIX (#469/#311): Use env vars — safe against injection and word-splitting.
-      # nounset-safe reads (${VAR:-}) so an unset value cannot abort the step
-      # before the #944 fallback heuristic (below) can classify from TASK_DESC.
+      # FIX (#469/#311): env vars are injection-safe; ${VAR:-} nounset reads so an unset value can't abort before the #944 fallback below.
       TASK_DESC="${TASK_DESCRIPTION:-}"
       ISSUE_NUMBER="${ISSUE_NUMBER:-}"
-      # FIX (#944): Derive the conventional-commit prefix from the real change
-      # type reported by step-14-bump-version instead of hardcoding 'feat:'. A
-      # hardcoded 'feat:' made pure bugfix branches trip the version-bump gate
-      # (observed on #920/#943, requiring manual reverts).
-      #   PATCH -> fix:   MINOR -> feat:   MAJOR -> feat!:
-      # The classification comes from the step-14 output. The recipe runner
-      # surfaces each dotted output under two names (see the worktree_path reads
-      # above for the same idiom): the uppercased form VERSION_BUMP_CHANGE_
-      # CLASSIFICATION (dot -> single '_') and the RECIPE_VAR_ form
-      # RECIPE_VAR_version_bump__change_classification (dot -> double '__').
-      # When unset/unknown, fall back to a bugfix-intent heuristic on the task
-      # description, defaulting to feat: to preserve legacy behavior.
+      # FIX (#944): commit prefix from step-14's real change type (PATCH->fix:
+      # MINOR->feat: MAJOR->feat!:), not a hardcoded 'feat:' that bumped the
+      # version on bugfix branches (#920/#943). Unknown/unset -> bugfix heuristic.
       CHANGE_CLASS="${VERSION_BUMP_CHANGE_CLASSIFICATION:-${RECIPE_VAR_version_bump__change_classification:-}}"
       case "$(printf '%s' "$CHANGE_CLASS" | tr '[:lower:]' '[:upper:]')" in
         PATCH) COMMIT_PREFIX="fix: " ;;
@@ -249,8 +233,7 @@ steps:
           case "$(printf '%s' "$TASK_DESC" | tr '[:upper:]' '[:lower:]')" in
             *bug*|*bugfix*|*fix*) COMMIT_PREFIX="fix: " ;;
             *)                    COMMIT_PREFIX="feat: " ;;
-          esac
-          ;;
+          esac ;;
       esac
       COMMIT_TITLE=$(printf '%s%.72s' "$COMMIT_PREFIX" "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
       # FIX #684: Host-aware commit references
@@ -261,8 +244,7 @@ steps:
         *)      ISSUE_REF="Ref #${ISSUE_NUMBER}"; ISSUE_IMPL="issue #${ISSUE_NUMBER}" ;;
       esac
       COMMIT_MSG=$(printf '%s\n\nImplements %s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\n%s' "$COMMIT_TITLE" "$ISSUE_IMPL" "$ISSUE_REF")
-      # PERF: --quiet short-circuits on the first staged change and avoids
-      # buffering the full name list into a command substitution.
+      # PERF: --quiet short-circuits on the first staged change.
       if ! git diff --cached --quiet; then
         GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -231,12 +231,14 @@ steps:
       # hardcoded 'feat:' made pure bugfix branches trip the version-bump gate
       # (observed on #920/#943, requiring manual reverts).
       #   PATCH -> fix:   MINOR -> feat:   MAJOR -> feat!:
-      # The classification is read from the step-14 output (surfaced by the
-      # recipe runner as RECIPE_VAR_version_bump__change_classification; the
-      # VERSION_BUMP__CHANGE_CLASSIFICATION uppercase form is a defensive
-      # fallback). When unset/unknown, fall back to a bugfix-intent heuristic on
-      # the task description, defaulting to feat: to preserve legacy behavior.
-      CHANGE_CLASS="${RECIPE_VAR_version_bump__change_classification:-${VERSION_BUMP__CHANGE_CLASSIFICATION:-}}"
+      # The classification comes from the step-14 output. The recipe runner
+      # surfaces each dotted output under two names (see the worktree_path reads
+      # above for the same idiom): the uppercased form VERSION_BUMP_CHANGE_
+      # CLASSIFICATION (dot -> single '_') and the RECIPE_VAR_ form
+      # RECIPE_VAR_version_bump__change_classification (dot -> double '__').
+      # When unset/unknown, fall back to a bugfix-intent heuristic on the task
+      # description, defaulting to feat: to preserve legacy behavior.
+      CHANGE_CLASS="${VERSION_BUMP_CHANGE_CLASSIFICATION:-${RECIPE_VAR_version_bump__change_classification:-}}"
       case "$(printf '%s' "$CHANGE_CLASS" | tr '[:lower:]' '[:upper:]')" in
         PATCH) COMMIT_PREFIX="fix: " ;;
         MINOR) COMMIT_PREFIX="feat: " ;;
@@ -257,7 +259,9 @@ steps:
         *)      ISSUE_REF="Ref #${ISSUE_NUMBER}"; ISSUE_IMPL="issue #${ISSUE_NUMBER}" ;;
       esac
       COMMIT_MSG=$(printf '%s\n\nImplements %s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\n%s' "$COMMIT_TITLE" "$ISSUE_IMPL" "$ISSUE_REF")
-      if [ -n "$(git diff --cached --name-only)" ]; then
+      # PERF: --quiet short-circuits on the first staged change and avoids
+      # buffering the full name list into a command substitution.
+      if ! git diff --cached --quiet; then
         GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         git commit -m "$COMMIT_MSG"

--- a/docs/WORKFLOW_PUBLISH_VERSIONING.md
+++ b/docs/WORKFLOW_PUBLISH_VERSIONING.md
@@ -72,9 +72,10 @@ The Step 15 commit block resolves the prefix deterministically, in priority
 order:
 
 1. **Classification signal (primary).** The step reads the environment variable
-   `RECIPE_VAR_version_bump__change_classification` (with the uppercase alias
-   `VERSION_BUMP__CHANGE_CLASSIFICATION` as a fallback), produced by
-   `step-14-bump-version`. A whitelist `case` maps it:
+   `VERSION_BUMP_CHANGE_CLASSIFICATION` (uppercased form, dot → single `_`),
+   falling back to the `RECIPE_VAR_version_bump__change_classification` alias
+   (dot → double `__`), produced by `step-14-bump-version`. A whitelist `case`
+   maps it:
    - `PATCH → fix:`
    - `MINOR → feat:`
    - `MAJOR → feat!:`

--- a/docs/WORKFLOW_PUBLISH_VERSIONING.md
+++ b/docs/WORKFLOW_PUBLISH_VERSIONING.md
@@ -1,0 +1,153 @@
+# Publish Workflow: Classification-Driven Commit Prefix & Version Bump
+
+The `workflow-publish` recipe (`amplifier-bundle/recipes/workflow-publish.yaml`)
+derives both the implementation commit's conventional-commit prefix **and** the
+`[workspace.package].version` bump from the *real change type* of the branch.
+Bugfix branches produce `fix:` commits and leave the workspace version
+untouched; feature and breaking branches bump the version as before.
+
+This closes the class of bug reported in
+[#944](https://github.com/rysweet/amplihack-rs/issues/944) (previously observed
+on #920 and #943), where every implementation commit was hardcoded to `feat:`
+and every publish run bumped `[workspace.package].version` — even on pure
+bugfix branches — requiring manual reverts.
+
+## Behavior
+
+The publish workflow classifies the branch diff and maps it to a commit prefix
+and a version-bump action:
+
+| Change classification | Commit prefix | `[workspace.package].version` |
+| --------------------- | ------------- | ----------------------------- |
+| `PATCH` (fix/docs/refactor) | `fix:`  | **unchanged** (`new_version == current_version`) |
+| `MINOR` (backward-compatible feature/API) | `feat:`  | minor bumped (`X.Y.Z → X.(Y+1).0`) |
+| `MAJOR` (breaking change) | `feat!:` | major bumped (`X.Y.Z → (X+1).0.0`) |
+
+`step-14-bump-version` collapses `docs` and `refactor` changes into the `PATCH`
+bucket (see its prompt), so all three map to a single `fix:` prefix. This is a
+deliberate lossy simplification — the workflow does **not** emit distinct
+Conventional Commits `docs:`/`refactor:` prefixes. What matters for #944 is the
+version-bump gate, and every `PATCH`-class change correctly produces `fix:` with
+no version bump.
+
+The classification comes from `step-14-bump-version`, an architect agent that
+reviews `git diff main...HEAD` and emits a `version_bump` JSON object (see
+[Classification output](#classification-output)). Both the version-bump action
+and the downstream commit prefix read from this single source of truth, so they
+can never disagree.
+
+### Examples
+
+**Bugfix branch** — a branch that only fixes a defect:
+
+```
+Classification : PATCH
+Commit title   : fix: correct off-by-one in retry backoff calculation
+Cargo.toml     : version = "0.9.4"   (unchanged)
+Cargo.lock     : re-synced to 0.9.4  (no diff)
+package.json   : re-synced to 0.9.4  (no diff)
+```
+
+The publish PR contains **no** `[workspace.package].version` diff.
+
+**Feature branch** — a backward-compatible feature:
+
+```
+Classification : MINOR
+Commit title   : feat: add --json output flag to `amplihack status`
+Cargo.toml     : version = "0.9.4" → "0.10.0"
+```
+
+**Breaking change branch**:
+
+```
+Classification : MAJOR
+Commit title   : feat!: remove deprecated `--legacy-mode` flag
+Cargo.toml     : version = "0.9.4" → "1.0.0"
+```
+
+## How the prefix is resolved
+
+The Step 15 commit block resolves the prefix deterministically, in priority
+order:
+
+1. **Classification signal (primary).** The step reads the environment variable
+   `RECIPE_VAR_version_bump__change_classification` (with the uppercase alias
+   `VERSION_BUMP__CHANGE_CLASSIFICATION` as a fallback), produced by
+   `step-14-bump-version`. A whitelist `case` maps it:
+   - `PATCH → fix:`
+   - `MINOR → feat:`
+   - `MAJOR → feat!:`
+2. **Task-description heuristic (fallback, rarely reached).** The primary signal
+   above is derived from the actual branch diff, so it is populated on virtually
+   every real publish run. Only if the classification variable is empty or unset
+   (e.g. the bump step was skipped) does the block fall back to scanning
+   `$TASK_DESCRIPTION` for bugfix intent (`bug`, `bugfix`, `fix`); a match yields
+   `fix:`. Because this fallback is text-based, a feature titled "add fix-it
+   command" could be mislabeled `fix:` — but only when the diff-derived
+   classification is unavailable, which is the exception, not the rule.
+3. **Default.** Otherwise the prefix defaults to `feat:`, preserving the
+   historical behavior for feature/release runs.
+
+The prefix is combined with the sanitized task description using the existing
+injection-safe pattern:
+
+```bash
+COMMIT_TITLE=$(printf '%s%.72s' "$PREFIX" \
+  "$(printf '%s' "$TASK_DESC" | tr '\n\r' ' ' | head -1)")
+```
+
+The classification string is only ever consumed through a whitelist `case`
+statement — it is never `eval`'d or interpolated into a command — preserving
+the injection-safety guarantees from #469/#311.
+
+## Classification output
+
+`step-14-bump-version` emits the following JSON (`output: version_bump`,
+`parse_json: true`), unchanged in schema so downstream consumers stay stable:
+
+```json
+{
+  "current_version": "0.9.4",
+  "new_version": "0.9.4",
+  "change_classification": "PATCH",
+  "rationale": "Only fixes a defect; no API surface change.",
+  "changes_summary": "Corrected off-by-one in retry backoff calculation."
+}
+```
+
+For a `PATCH` classification the agent performs **no edit** to the
+`version = "X.Y.Z"` line, and sets `new_version == current_version`. For
+`MINOR`/`MAJOR` it bumps the version as before.
+
+## Lockfile & package.json consistency
+
+`step-14b-sync-lockfile` (`cargo update --workspace --offline`) and
+`step-14c-sync-package-json` (a scoped `[workspace.package]` read that syncs the
+root `package.json` `version` via `jq`, falling back to `python3 json`) run on
+every publish, including no-bump `PATCH` runs. Both skip gracefully when their
+target file is absent (non-Rust / non-JS workspaces). On a bugfix branch they
+simply re-sync to the unchanged version, so `Cargo.lock` and `package.json`
+remain valid and produce no spurious diff.
+
+## Scope & limitations
+
+- Only `workflow-publish.yaml` implements this behavior. The
+  `consensus-publish.yaml` recipe is out of scope and unaffected.
+- The `PATCH` bucket intentionally folds `docs` and `refactor` changes into a
+  single `fix:` prefix rather than emitting distinct Conventional Commits
+  `docs:`/`refactor:` prefixes. This is a documented simplification, not a
+  defect: the goal is correct version-bump gating, not full commit-type fidelity.
+- Version bumping remains diff-gated inside the architect agent; the commit
+  prefix is a deterministic, whitelist-mapped string. A prompt-injection attempt
+  that steers the classification can at most select a fixed prefix string — it
+  cannot alter published artifacts or bypass the diff-based bump gate.
+- This change is not retroactive; it does not revert version bumps already
+  merged on #920 or #943.
+
+## Related
+
+- Issue: [#944](https://github.com/rysweet/amplihack-rs/issues/944)
+- Recipe: `amplifier-bundle/recipes/workflow-publish.yaml`
+  (`step-14-bump-version`, `step-14b-sync-lockfile`,
+  `step-14c-sync-package-json`, Step 15 commit block)

--- a/docs/index.md
+++ b/docs/index.md
@@ -226,6 +226,7 @@ Proven methodologies for consistent, high-quality results.
 - [Default Workflow](claude/skills/default-workflow/SKILL.md) - Standard multi-step development process
 - [Investigation Workflow](claude/workflow/INVESTIGATION_WORKFLOW.md) - Deep codebase analysis and understanding
 - [PR Recovery Readiness](PR_RECOVERY_READINESS.md) - Entry point for existing-PR recovery docs and the canonical readiness contract
+- [Publish Workflow Versioning](WORKFLOW_PUBLISH_VERSIONING.md) - Classification-driven commit prefix and version bump (bugfix branches stay on `fix:` and do not bump the workspace version)
 - [Document-Driven Development (DDD)](document_driven_development/README.md) - Documentation-first approach for large features
 
 ### DDD Deep Dive


### PR DESCRIPTION
Fixes #944.

## Problem
`step-15` in `workflow-publish.yaml` hardcoded a `feat:` commit prefix even for bugfixes. Combined with `step-14-bump-version`, this caused spurious `[workspace.package].version` bumps on bugfix branches (observed on #920, #943), each needing a manual revert.

## Fix
- **step-14 prompt**: PATCH (fix/docs/refactor) → DO NOT modify the version line (`new_version = current_version`). Only MINOR/MAJOR bump.
- **step-15 commit**: derive the commit prefix from step-14's real change classification (PATCH→`fix:`, MINOR→`feat:`, MAJOR→`feat!:`). Unknown/unset → keyword heuristic on the task description (bug/bugfix/fix → `fix:`).
- nounset-safe env reads (`${VAR:-}`) so an unset value can't abort before the fallback runs.

## Tests / docs
- `test-issue-944-bugfix-no-version-bump.sh` (302 lines) exercises PATCH/MINOR/MAJOR + fallback.
- `docs/WORKFLOW_PUBLISH_VERSIONING.md` documents the versioning contract.

This is a bugfix; it does not bump the version (validating itself).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>