### PR TITLE
fix(ci): pin publish-snapshot Rust toolchain to 1.97.0 (issue #935)

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -48,7 +48,7 @@ jobs:
             gnu_cross_toolchain: false
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

Fixes #935. The **Publish Snapshot Release** workflow
(`.github/workflows/publish-snapshot.yml`) failed on every `main` push. The
cross-architecture matrix leg `aarch64-unknown-linux-gnu` (built on x86_64
`ubuntu-latest`) failed at **Build (native)** with
`error[E0463]: can't find crate for std`.

### Root cause

`rust-toolchain.toml` pins `channel = "1.97.0"`. The workflow used
`dtolnay/rust-toolchain@stable` with `targets: ${{ matrix.target }}`, which
installs the **stable** toolchain and adds the cross target's `std` to
**stable**. At build time, `rust-toolchain.toml` overrides resolution to
**1.97.0**, which never had the cross target's `std` added → E0463. The
required `ci.yml` Build job does not hit this because it uses
`dtolnay/rust-toolchain@1.97.0` (matching the pin) with the same `targets`.

### Fix

Change the toolchain action from `dtolnay/rust-toolchain@stable` to
`dtolnay/rust-toolchain@1.97.0`, keeping `targets: ${{ matrix.target }}` —
mirroring `ci.yml`'s proven pattern exactly. One-line change; no workspace
version bump (bugfix).

## Step 13: Local Testing Results

Detected toolchains:
- **Rust/Cargo** — evidence: `Cargo.toml`/`Cargo.lock` at repo root, workspace
  crates under `crates/` and `bins/`, and `rust-toolchain.toml` pinning
  `channel = "1.97.0"`. The changed file is a GitHub Actions workflow that
  drives `cargo build --release --locked --target <matrix.target>`. Local env
  mirrors CI exactly: both `stable` and `1.97.0` toolchains installed, with the
  `aarch64-unknown-linux-gnu` target absent from both (as on a fresh CI runner),
  and `rust-toolchain.toml` making `1.97.0` the active override.

Chosen validation strategy:
- Reproduce the real CI failure and prove the fix at the same consumer boundary
  CI uses: `rustup target add --toolchain <tc>` (what `dtolnay/rust-toolchain +
  targets` does) followed by the workflow's exact `cargo` build command. This
  directly proves the user-visible behavior (the snapshot build succeeds and
  produces the packaged binaries) rather than just linting YAML.

### Scenario 1 — Workflow YAML validity & toolchain-ref consistency (simple)
Command: `python3 -c "import yaml; ...parse publish-snapshot.yml..."` plus
`grep dtolnay/rust-toolchain@ across rust-toolchain.toml, ci.yml, publish-snapshot.yml`
Result: PASS
Output:
```
publish-snapshot.yml valid YAML: OK
toolchain uses in cross-compile: ['dtolnay/rust-toolchain@1.97.0']
rust-toolchain.toml channel = "1.97.0"
ci.yml toolchain refs: dtolnay/rust-toolchain@1.97.0 (x4)
publish-snapshot.yml toolchain refs: dtolnay/rust-toolchain@1.97.0
remaining @stable refs in publish-snapshot.yml: NONE
```

### Scenario 2 — Reproduce E0463, then prove the fix builds aarch64 (complex)
Commands:
```
# OLD behavior (@stable + targets): add std to STABLE, build resolves to 1.97.0
rustup target add --toolchain stable aarch64-unknown-linux-gnu
cargo check --locked --target aarch64-unknown-linux-gnu        # -> FAILS

# FIXED behavior (@1.97.0 + targets): add std to 1.97.0 (the resolved toolchain)
rustup target add --toolchain 1.97.0 aarch64-unknown-linux-gnu
# + install/configure gcc-aarch64-linux-gnu g++-aarch64-linux-gnu (workflow steps)
cargo build --release --locked --target aarch64-unknown-linux-gnu   # -> SUCCEEDS
```
Result: PASS
Output:
```
# OLD (reproduces issue #935 exactly):
error[E0463]: can't find crate for `core`
error[E0463]: can't find crate for `std`
check exit: 101

# FIXED:
E0463 occurrences: 0
    Finished `release` profile [optimized] target(s) in 4m 55s
build exit: 0

# Packaged artifacts produced (what the workflow tars):
target/aarch64-unknown-linux-gnu/release/amplihack:       ELF 64-bit ... ARM aarch64
target/aarch64-unknown-linux-gnu/release/amplihack-hooks: ELF 64-bit ... ARM aarch64
```

Regression note: the `x86_64-unknown-linux-gnu` leg and `ci.yml` already used
`@1.97.0`; this change makes `publish-snapshot.yml` consistent with them, so no
existing behavior regresses.

Both scenarios passed. The old config reproduces the exact `E0463` from #935;
the fixed config eliminates it and produces valid aarch64 release binaries.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>