### PR TITLE
Fix #939: pin release.yml cross-build toolchain to 1.97.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.version-bump.outputs.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/docs/reference/ci-pipeline.md
+++ b/docs/reference/ci-pipeline.md
@@ -106,7 +106,7 @@ Bump deliberately, in its own PR:
 
 1. Edit `channel` in `rust-toolchain.toml`.
 2. Update every `dtolnay/rust-toolchain@<version>` ref in the build workflows to
-   match —    the four refs in `ci.yml`, the ref in `publish-snapshot.yml`, and the
+   match — the four refs in `ci.yml`, the ref in `publish-snapshot.yml`, and the
    cross-build ref in `release.yml`.
 3. Run `cargo clippy -- -D warnings && cargo fmt --check && cargo nextest run
    --workspace --locked` locally, fix any new lints, and open the PR.

--- a/docs/reference/ci-pipeline.md
+++ b/docs/reference/ci-pipeline.md
@@ -42,8 +42,9 @@ components = ["rustfmt", "clippy"]
 
 Every job in **every** build workflow installs the toolchain with a
 version-pinned `dtolnay/rust-toolchain@1.97.0` action that matches the file.
-This includes `ci.yml` (build, test, clippy, and the cross-compile matrix) and
-the `publish-snapshot.yml` release matrix. Cross-compile legs add
+This includes `ci.yml` (build, test, clippy, and the cross-compile matrix), the
+`publish-snapshot.yml` release matrix, and the **Auto Release**
+(`release.yml`) cross-build matrix. Cross-compile legs add
 `targets: ${{ matrix.target }}` on top so the target's `rust-std` is installed
 into the pinned toolchain.
 
@@ -69,6 +70,35 @@ The rule: any `dtolnay/rust-toolchain@<ref>` that supplies `targets:` for a
 cross build **must** equal the `rust-toolchain.toml` channel. Prefer keeping
 _all_ build-job refs pinned to the file's channel so target `rust-std` always
 lands in the resolved toolchain.
+
+### Auto Release cross-build legs (`release.yml`)
+
+The **Auto Release** workflow (`.github/workflows/release.yml`) builds a
+per-target artifact matrix. Its native-arch legs run on a host whose
+architecture already matches the target, but two legs cross-build:
+
+| Target                       | Runner          | Kind        |
+| ---------------------------- | --------------- | ----------- |
+| `aarch64-unknown-linux-gnu`  | `ubuntu-latest` | cross-arch  |
+| `x86_64-apple-darwin`        | `macos-latest`  | cross-arch  |
+
+Both cross legs install the toolchain with `dtolnay/rust-toolchain@1.97.0` and
+`targets: ${{ matrix.target }}`, matching `rust-toolchain.toml`:
+
+```yaml
+# .github/workflows/release.yml (cross-build matrix step)
+- uses: dtolnay/rust-toolchain@1.97.0
+  with:
+    targets: ${{ matrix.target }}
+```
+
+Because the action ref equals the file's channel, the target's `rust-std` is
+added to the **same** `1.97.0` toolchain that `rust-toolchain.toml` resolves to
+at build time. This is exactly what fixed the every-`main`-push failure in which
+both cross legs aborted with `error[E0463]: can't find crate for std` while the
+native legs passed (issue #939). It is the same drift class first resolved for
+`publish-snapshot.yml` in #935/#948; `release.yml` is now pinned and fully
+covered by the regression guard below — there is no remaining tracked drift.
 
 ### Bumping the pinned toolchain
 
@@ -103,6 +133,19 @@ runs on `@stable` by design) do not install per-target `rust-std`, are not
 exposed to the `E0463` drift, and are outside the invariant. Run the guard locally before pushing; it is also wired
 into CI and pre-commit, so a mismatched or floating ref fails fast instead of
 surfacing as an `E0463` in a release build.
+
+The guard's allowlist (`ALLOWLIST`) is **empty**: every targets-bearing ref —
+across `ci.yml`, `publish-snapshot.yml`, and `release.yml` — must pin to the
+`rust-toolchain.toml` channel, with no tracked exceptions. A clean run reports:
+
+```text
+check-toolchain-refs: OK — all targets-bearing toolchain refs pinned to @1.97.0
+```
+
+and exits `0`. Add an entry to `ALLOWLIST` only to track a genuinely
+out-of-scope, in-progress pinning follow-up; allowlisted drift is surfaced as a
+visible `WARNING` (never silently ignored) and must be removed once the target
+workflow is pinned.
 
 ## Test execution
 

--- a/docs/reference/ci-pipeline.md
+++ b/docs/reference/ci-pipeline.md
@@ -76,8 +76,8 @@ Bump deliberately, in its own PR:
 
 1. Edit `channel` in `rust-toolchain.toml`.
 2. Update every `dtolnay/rust-toolchain@<version>` ref in the build workflows to
-   match — the four refs in `ci.yml`, the ref in `publish-snapshot.yml`, **and**
-   the cross-build ref in `release.yml` (see the known-drift note below).
+   match —    the four refs in `ci.yml`, the ref in `publish-snapshot.yml`, and the
+   cross-build ref in `release.yml`.
 3. Run `cargo clippy -- -D warnings && cargo fmt --check && cargo nextest run
    --workspace --locked` locally, fix any new lints, and open the PR.
 
@@ -103,18 +103,6 @@ runs on `@stable` by design) do not install per-target `rust-std`, are not
 exposed to the `E0463` drift, and are outside the invariant. Run the guard locally before pushing; it is also wired
 into CI and pre-commit, so a mismatched or floating ref fails fast instead of
 surfacing as an `E0463` in a release build.
-
-> **Known remaining drift — `release.yml` cross-build (tracked follow-up).**
-> The tag-triggered release matrix in `release.yml` builds the shipped binaries
-> with `dtolnay/rust-toolchain@stable` **and** `targets: ${{ matrix.target }}`,
-> including `aarch64-unknown-linux-gnu` on `ubuntu-latest`. That is the exact
-> #935 configuration, still present in release builds: because it supplies
-> `targets:`, it is **in scope** for the invariant and `check-toolchain-refs.sh`
-> flags it. Fixing #935 pinned only the snapshot workflow, so the guard will
-> report `release.yml` as a mismatch until its ref is pinned to the file's
-> channel too. Pin it in a dedicated follow-up PR (same one-line change as the
-> snapshot fix); until then, treat the guard's `release.yml` finding as the
-> expected signal for that tracked work, not a false positive.
 
 ## Test execution
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,10 +2,11 @@
 # same compiler and lint set. This stops `@stable` drift from introducing
 # surprise clippy/fmt failures between deliberate bumps (issue #744; cf. the
 # emergency lint fix in PR #878). Bump this file and the matching
-# `dtolnay/rust-toolchain@<version>` refs in .github/workflows/ci.yml and
-# .github/workflows/publish-snapshot.yml together, in a dedicated PR. Keeping
-# the snapshot workflow pinned (not `@stable`) is what keeps cross-target
-# `rust-std` in the resolved toolchain and prevents E0463 (issue #935).
+# `dtolnay/rust-toolchain@<version>` refs in .github/workflows/ci.yml,
+# .github/workflows/publish-snapshot.yml, and .github/workflows/release.yml
+# together, in a dedicated PR. Keeping the snapshot and release workflows pinned
+# (not `@stable`) is what keeps cross-target `rust-std` in the resolved
+# toolchain and prevents E0463 (issues #935, #939).
 # See docs/reference/ci-pipeline.md.
 [toolchain]
 channel = "1.97.0"

--- a/scripts/check-toolchain-refs.sh
+++ b/scripts/check-toolchain-refs.sh
@@ -41,12 +41,11 @@ TOOLCHAIN_TOML="${TOOLCHAIN_TOML:-$REPO_ROOT/rust-toolchain.toml}"
 # an entry once the underlying workflow is pinned so stale allowlist entries are
 # surfaced too.
 #
-# release.yml:137 carries the same `@stable` + `targets:` drift as #935 but the
-# release pipeline (cross-target signing/publish) is out of scope for the #935
-# bugfix and tracked as follow-up. See docs/reference/ci-pipeline.md.
-ALLOWLIST=(
-    "release.yml"
-)
+# The allowlist is currently empty: every targets-bearing toolchain ref
+# (including release.yml, pinned in #939) must match the rust-toolchain.toml
+# channel. Add an entry only to track a genuinely out-of-scope, in-progress
+# pinning follow-up. See docs/reference/ci-pipeline.md.
+ALLOWLIST=()
 
 err() { printf 'ERROR: %s\n' "$1" >&2; }
 warn() { printf 'WARNING: %s\n' "$1" >&2; }

--- a/scripts/check-toolchain-refs.sh
+++ b/scripts/check-toolchain-refs.sh
@@ -80,6 +80,10 @@ targets_bearing_refs() {
 
 is_allowlisted() {
     local base="$1" entry
+    # Expanding "${ALLOWLIST[@]}" on an empty array under `set -u` is an
+    # "unbound variable" error on bash < 4.4 (e.g. macOS system bash 3.2).
+    # Return early so an empty allowlist stays robust across bash versions.
+    [ "${#ALLOWLIST[@]}" -eq 0 ] && return 1
     for entry in "${ALLOWLIST[@]}"; do
         [ "$base" = "$entry" ] && return 0
     done

--- a/tests/issue_939_release_toolchain_pin_test.sh
+++ b/tests/issue_939_release_toolchain_pin_test.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# TDD tests for issue #939 — Auto Release cross-build E0463 fix.
+#
+# Root cause (verified): rust-toolchain.toml pins channel = "1.97.0", but
+# .github/workflows/release.yml used `dtolnay/rust-toolchain@stable` with
+# `targets: ${{ matrix.target }}` on its build matrix. dtolnay@stable adds the
+# cross target's rust-std to the STABLE toolchain, but at build time
+# rust-toolchain.toml overrides resolution back to 1.97.0 — which never had that
+# target's std added — yielding `error[E0463]: can't find crate for std` on the
+# cross-arch legs (`aarch64-unknown-linux-gnu` on ubuntu-latest and
+# `x86_64-apple-darwin` on macos-latest). The native-arch legs pass. This is the
+# SAME drift class fixed for publish-snapshot.yml in #935/#948, which introduced
+# scripts/check-toolchain-refs.sh. That guard temporarily ALLOWLISTED
+# release.yml as a tracked follow-up — this issue, #939.
+#
+# Contract:
+#   1. The fix: release.yml pins the cross-build toolchain to the exact channel
+#      in rust-toolchain.toml (@1.97.0) and keeps `targets: ${{ matrix.target }}`.
+#   2. Full enforcement: scripts/check-toolchain-refs.sh no longer allowlists
+#      release.yml. The ALLOWLIST is empty, so release.yml is fully enforced and
+#      a regression back to @stable fails the guard (never a silent WARNING).
+#   3. Invariant unchanged: every `dtolnay/rust-toolchain@<ref>` step that also
+#      declares a `targets:` key MUST pin <ref> to the rust-toolchain.toml
+#      channel; scan/native-only steps (no `targets:`) may stay on `@stable`.
+#   4. Docs: docs/reference/ci-pipeline.md documents release.yml as resolved with
+#      no remaining tracked/known drift.
+#   5. Bugfix hygiene: this change does NOT bump the workspace version.
+#
+# Expected BEFORE the fix: FAIL (release.yml @stable, allowlisted, docs note).
+# Expected AFTER the fix:  PASS (all cases).
+#
+# Run: bash tests/issue_939_release_toolchain_pin_test.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOWS="$REPO_ROOT/.github/workflows"
+TOOLCHAIN_TOML="$REPO_ROOT/rust-toolchain.toml"
+RELEASE="$WORKFLOWS/release.yml"
+CI="$WORKFLOWS/ci.yml"
+GUARD="$REPO_ROOT/scripts/check-toolchain-refs.sh"
+DOCS="$REPO_ROOT/docs/reference/ci-pipeline.md"
+
+pass=0
+fail=0
+TMPROOT=""
+
+cleanup() { [ -n "$TMPROOT" ] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+record_pass() {
+    echo "PASS: $1"
+    pass=$((pass + 1))
+}
+
+record_fail() {
+    echo "FAIL: $1"
+    if [ $# -gt 1 ] && [ -n "$2" ]; then
+        printf '      %s\n' "$2"
+    fi
+    fail=$((fail + 1))
+}
+
+assert() {
+    local desc="$1"
+    local cond="$2"
+    if eval "$cond"; then
+        record_pass "$desc"
+    else
+        record_fail "$desc" "condition: $cond"
+    fi
+}
+
+# Extract the pinned channel from rust-toolchain.toml (e.g. 1.97.0).
+toolchain_channel() {
+    sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TOOLCHAIN_TOML" | head -n1
+}
+
+# Return the @ref for every dtolnay/rust-toolchain step in a file that also
+# declares a `targets:` key within the following few lines of the step.
+targets_bearing_refs() {
+    local file="$1"
+    awk '
+        /dtolnay\/rust-toolchain@/ {
+            ref = $0
+            sub(/.*dtolnay\/rust-toolchain@/, "", ref)
+            sub(/[[:space:]].*/, "", ref)
+            window = 6
+            hit = 0
+            for (i = 1; i <= window; i++) {
+                if ((getline line) <= 0) break
+                if (line ~ /^[[:space:]]*targets:/) { hit = 1; break }
+                if (line ~ /dtolnay\/rust-toolchain@/) break
+            }
+            if (hit) print ref
+        }
+    ' "$file"
+}
+
+echo "=== issue #939 Auto Release toolchain-ref pin TDD tests ==="
+echo "Workflows: $WORKFLOWS"
+echo "Toolchain: $TOOLCHAIN_TOML"
+echo "Guard:     $GUARD"
+echo "Docs:      $DOCS"
+echo
+
+CHANNEL="$(toolchain_channel)"
+assert "rust-toolchain.toml declares a channel" "[ -n '$CHANNEL' ]"
+echo "Resolved channel: ${CHANNEL:-<none>}"
+echo
+
+# ---------------------------------------------------------------------------
+# 1. The fix: release.yml cross-build step is pinned to the toml channel.
+# ---------------------------------------------------------------------------
+assert "release.yml exists" "[ -f '$RELEASE' ]"
+
+assert "release.yml pins dtolnay/rust-toolchain to the toml channel ($CHANNEL)" \
+    "grep -q 'dtolnay/rust-toolchain@$CHANNEL' '$RELEASE'"
+
+assert "release.yml no longer uses dtolnay/rust-toolchain@stable" \
+    "! grep -q 'dtolnay/rust-toolchain@stable' '$RELEASE'"
+
+assert "release.yml preserves 'targets: \${{ matrix.target }}'" \
+    "grep -Eq 'targets:[[:space:]]*\\\$\\{\\{[[:space:]]*matrix.target[[:space:]]*\\}\\}' '$RELEASE'"
+
+# Every targets-bearing ref in the release workflow must equal the channel.
+rel_bad=""
+while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    [ "$ref" = "$CHANNEL" ] || rel_bad="$rel_bad $ref"
+done < <(targets_bearing_refs "$RELEASE")
+assert "release.yml has no drifted targets-bearing refs" "[ -z '$rel_bad' ]"
+
+# The cross-arch legs that triggered #939 must be present in the matrix so the
+# single pinned toolchain step provisions their rust-std.
+assert "release.yml matrix includes the aarch64-unknown-linux-gnu cross leg" \
+    "grep -q 'aarch64-unknown-linux-gnu' '$RELEASE'"
+assert "release.yml matrix includes the x86_64-apple-darwin cross leg" \
+    "grep -q 'x86_64-apple-darwin' '$RELEASE'"
+
+# ---------------------------------------------------------------------------
+# 2. Cross-workflow invariant: ci.yml already proves the correct pattern.
+# ---------------------------------------------------------------------------
+ci_bad=""
+while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    [ "$ref" = "$CHANNEL" ] || ci_bad="$ci_bad $ref"
+done < <(targets_bearing_refs "$CI")
+assert "ci.yml (green reference) has all targets-bearing refs pinned to channel" "[ -z '$ci_bad' ]"
+
+# ---------------------------------------------------------------------------
+# 3. Full enforcement: the guard no longer allowlists release.yml.
+# ---------------------------------------------------------------------------
+assert "guard script exists" "[ -f '$GUARD' ]"
+assert "guard script is executable" "[ -x '$GUARD' ]"
+
+# The guard must no longer carry release.yml as an allowlisted (exempt) entry;
+# an empty allowlist is what makes the invariant self-enforcing.
+assert "guard no longer allowlists release.yml" \
+    "! grep -Eq 'ALLOWLIST=\\([^)]*release\\.yml' '$GUARD'"
+
+if [ -x "$GUARD" ]; then
+    TMPROOT="$(mktemp -d)"
+    fx="$TMPROOT/fixtures"
+    mkdir -p "$fx"
+    cp "$TOOLCHAIN_TOML" "$TMPROOT/rust-toolchain.toml"
+
+    # Fixture A: a release-like file drifted back to @stable WITH targets.
+    # With the allowlist empty this MUST fail the guard (hard error, not warn).
+    cat > "$fx/release.yml" <<EOF
+jobs:
+  build:
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: \${{ matrix.target }}
+EOF
+
+    # Fixture B: correct — release-like file pinned to channel WITH targets.
+    cat > "$fx/release-pinned.yml" <<EOF
+jobs:
+  build:
+    steps:
+      - uses: dtolnay/rust-toolchain@$CHANNEL
+        with:
+          targets: \${{ matrix.target }}
+EOF
+
+    run_guard() {
+        TOOLCHAIN_TOML="$TMPROOT/rust-toolchain.toml" \
+            bash "$GUARD" "$@" >/dev/null 2>&1
+    }
+
+    # Regression guard: a drifted release.yml is now a FAILURE, not an
+    # allowlisted warning.
+    if run_guard "$fx/release.yml"; then
+        record_fail "guard fails on a drifted release.yml (no longer allowlisted)" \
+            "expected non-zero exit now that ALLOWLIST is empty"
+    else
+        record_pass "guard fails on a drifted release.yml (no longer allowlisted)"
+    fi
+
+    if run_guard "$fx/release-pinned.yml"; then
+        record_pass "guard accepts channel-pinned release.yml + targets"
+    else
+        record_fail "guard accepts channel-pinned release.yml + targets" "expected zero exit"
+    fi
+
+    # The real, fixed release workflow must pass the guard.
+    if bash "$GUARD" "$RELEASE" >/dev/null 2>&1; then
+        record_pass "guard passes on the fixed release.yml"
+    else
+        record_fail "guard passes on the fixed release.yml" "expected zero exit"
+    fi
+
+    # Default scan (no args) must be green with zero allowlisted drift, so a
+    # WARNING line for a tracked follow-up must NOT appear.
+    scan_out="$(TOOLCHAIN_TOML="$TMPROOT/rust-toolchain.toml"; bash "$GUARD" 2>&1)"
+    scan_rc=$?
+    if [ "$scan_rc" -eq 0 ]; then
+        record_pass "guard default scan is green (exit 0, CI-wireable)"
+    else
+        record_fail "guard default scan is green (exit 0, CI-wireable)" \
+            "unresolved toolchain-ref drift in .github/workflows"
+    fi
+    if printf '%s\n' "$scan_out" | grep -qi 'allowlisted'; then
+        record_fail "guard default scan reports zero allowlisted drift" \
+            "found an allowlisted (tracked follow-up) warning; allowlist should be empty"
+    else
+        record_pass "guard default scan reports zero allowlisted drift"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Docs: release.yml drift is documented as resolved (no remaining note).
+# ---------------------------------------------------------------------------
+assert "ci-pipeline.md exists" "[ -f '$DOCS' ]"
+assert "ci-pipeline.md has no 'Known remaining drift' note" \
+    "! grep -qi 'remaining drift' '$DOCS'"
+assert "ci-pipeline.md documents release.yml pinned to the channel" \
+    "grep -q 'dtolnay/rust-toolchain@$CHANNEL' '$DOCS'"
+
+# ---------------------------------------------------------------------------
+# 5. Bugfix hygiene: no workspace version bump on this change.
+# ---------------------------------------------------------------------------
+base_ref=""
+if git -C "$REPO_ROOT" rev-parse --verify -q origin/main >/dev/null 2>&1; then
+    base_ref="origin/main"
+elif git -C "$REPO_ROOT" rev-parse --verify -q main >/dev/null 2>&1; then
+    base_ref="main"
+fi
+
+if [ -n "$base_ref" ]; then
+    if git -C "$REPO_ROOT" diff "$base_ref"...HEAD -- Cargo.toml \
+        | grep -Eq '^[+-]version[[:space:]]*='; then
+        record_fail "bugfix does not bump the workspace version" \
+            "Cargo.toml version line changed vs $base_ref"
+    else
+        record_pass "bugfix does not bump the workspace version"
+    fi
+else
+    record_pass "base branch unavailable; version-bump check skipped"
+fi
+
+echo
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi

--- a/tests/issue_939_release_toolchain_pin_test.sh
+++ b/tests/issue_939_release_toolchain_pin_test.sh
@@ -192,12 +192,22 @@ EOF
     }
 
     # Regression guard: a drifted release.yml is now a FAILURE, not an
-    # allowlisted warning.
+    # allowlisted warning. Capture stderr so we can also assert the guard emits
+    # its intended drift diagnostic — not a bash "unbound variable" abort from
+    # expanding an empty ALLOWLIST under `set -u` (would mask the real message
+    # on bash < 4.4).
+    drift_err="$(TOOLCHAIN_TOML="$TMPROOT/rust-toolchain.toml" bash "$GUARD" "$fx/release.yml" 2>&1 >/dev/null)"
     if run_guard "$fx/release.yml"; then
         record_fail "guard fails on a drifted release.yml (no longer allowlisted)" \
             "expected non-zero exit now that ALLOWLIST is empty"
     else
         record_pass "guard fails on a drifted release.yml (no longer allowlisted)"
+    fi
+    if printf '%s\n' "$drift_err" | grep -q 'must pin to @'; then
+        record_pass "guard emits its drift diagnostic on empty-allowlist violation (no unbound-variable abort)"
+    else
+        record_fail "guard emits its drift diagnostic on empty-allowlist violation (no unbound-variable abort)" \
+            "stderr did not contain the expected 'must pin to @' message: $drift_err"
     fi
 
     if run_guard "$fx/release-pinned.yml"; then
@@ -215,7 +225,7 @@ EOF
 
     # Default scan (no args) must be green with zero allowlisted drift, so a
     # WARNING line for a tracked follow-up must NOT appear.
-    scan_out="$(TOOLCHAIN_TOML="$TMPROOT/rust-toolchain.toml"; bash "$GUARD" 2>&1)"
+    scan_out="$(bash "$GUARD" 2>&1)"
     scan_rc=$?
     if [ "$scan_rc" -eq 0 ]; then
         record_pass "guard default scan is green (exit 0, CI-wireable)"


### PR DESCRIPTION
## Summary
Fixes #939. The Auto Release workflow's cross-arch build legs (`aarch64-unknown-linux-gnu` on ubuntu-latest, `x86_64-apple-darwin` on macos-latest) failed on every main push with `error[E0463]: can't find crate for std`.

### Root cause
`release.yml` used `dtolnay/rust-toolchain@stable` with `targets: ${{ matrix.target }}`. That adds the cross target's std to the **stable** toolchain, but `rust-toolchain.toml` pins build resolution to **1.97.0**, which lacked the cross target's std → E0463. Same drift class fixed for `publish-snapshot.yml` in #935/#948.

### Changes
- **`.github/workflows/release.yml`**: cross-build step pinned to `dtolnay/rust-toolchain@1.97.0` (retains `targets: ${{ matrix.target }}`), matching `rust-toolchain.toml` and `ci.yml`.
- **`scripts/check-toolchain-refs.sh`**: removed `release.yml` from `ALLOWLIST` (now empty) and updated the comment — the guard now fully enforces `release.yml`.
- **`docs/reference/ci-pipeline.md`**: removed the stale 'Known remaining drift — release.yml' note and fixed the cross-reference.

### Verification
`bash scripts/check-toolchain-refs.sh` reports `OK — all targets-bearing toolchain refs pinned to @1.97.0` and exits 0.

Workspace version is unchanged (bugfix).