### PR TITLE
fix(#955): give recipe git-identity resolution the full 5-path fallback chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Recipes — graceful degradation for missing runtime-artifact helper (issue #829)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-bug-829-graceful-degradation.sh
+      - name: Recipes — git-identity helper fallback resolution (issue #955)
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh
       - name: Recipes — doc-review failure is non-fatal-but-reported (issue #834)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-bug-834-doc-review-non-fatal.sh

--- a/amplifier-bundle/recipes/consensus-pr-feedback.yaml
+++ b/amplifier-bundle/recipes/consensus-pr-feedback.yaml
@@ -38,7 +38,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         git commit -m "Address PR review feedback"
       else

--- a/amplifier-bundle/recipes/consensus-publish.yaml
+++ b/amplifier-bundle/recipes/consensus-publish.yaml
@@ -61,7 +61,7 @@ steps:
 
       COMMITTED=false
       if [ -n "$(git diff --cached --name-only)" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         if git commit -m "$COMMIT_MSG"; then
           COMMITTED=true

--- a/amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh
+++ b/amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# test-issue-955-git-identity-fallback.sh — regression test for issue #955.
+#
+# Bug: the git-identity.sh helper is resolved with only TWO candidate paths and
+# then hard-fails with `exit 2` if neither exists:
+#     GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+#     [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+#     [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+# This kills EVERY commit/checkpoint step whenever AMPLIHACK_HOME points at a
+# downstream repo checkout that lacks amplifier-bundle/ — even though the helper
+# IS installed at ${HOME}/.amplihack/amplifier-bundle/tools/git-identity.sh.
+#
+# Fix: mirror the sibling RUNTIME_ARTIFACT_HELPER resolution — append THREE more
+# guarded fallbacks before the terminal exit 2:
+#     ... || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"
+#     ... || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"
+#     ... || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"
+# The terminal `exit 2` stays LAST (fail-visible, never silent-degrade).
+#
+# Contracts under test:
+#   POS: When AMPLIHACK_HOME and the repo top-level both LACK amplifier-bundle/,
+#        the chain MUST still resolve the helper via the ${HOME}/.amplihack
+#        fallback, source it, and NOT exit 2.
+#   POS2: The ${HOME}/.copilot fallback also resolves.
+#   NEG: When the helper is absent from ALL candidate paths, the chain MUST
+#        still fail visibly with exit 2 + "git identity helper not found"
+#        (fail-visible control — never silent-degrade).
+#   STATIC: Every recipe that emits "git identity helper not found" MUST carry
+#        the three canonical tail fallbacks in its git-identity chain.
+#   STATIC2: workflow-publish.yaml multi-line block MUST also gain the three
+#        fallbacks while remaining exit-2-free (it never had an exit 2).
+#   GUARD: Exactly 7 single-line sites retain their terminal git-identity
+#        `exit 2`; the multi-line publish block stays exit-2-free.
+#
+# This test SHOULD FAIL before the #955 fix lands (only 2 candidates present).
+# It MUST PASS once the three tail fallbacks are appended everywhere.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+RECIPES="${REPO_ROOT}/amplifier-bundle/recipes"
+
+# Every recipe that emits "git identity helper not found" (7 single-line sites).
+RECIPE_FILES=(
+    "workflow-finalize.yaml"
+    "workflow-refactor-review.yaml"
+    "workflow-pr-review.yaml"
+    "workflow-tdd.yaml"
+    "workflow-publish.yaml"
+    "consensus-publish.yaml"
+    "consensus-pr-feedback.yaml"
+)
+
+# The three canonical tail fallbacks that MUST be appended (mirrors the sibling
+# RUNTIME_ARTIFACT_HELPER chain, retargeted at git-identity.sh).
+FALLBACK_PWD='$(pwd)/amplifier-bundle/tools/git-identity.sh'
+FALLBACK_COPILOT='${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh'
+FALLBACK_AMPLIHACK='${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo "  PASS[$1]: $2"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  FAIL[$1]: $2" >&2; }
+
+for f in "${RECIPE_FILES[@]}"; do
+    if [[ ! -f "${RECIPES}/${f}" ]]; then
+        echo "HARNESS-ERROR: required recipe not found: ${RECIPES}/${f}" >&2
+        exit 2
+    fi
+done
+
+echo "=== Issue #955: git-identity helper resolution robustness ==="
+
+# ---------------------------------------------------------------------------
+# Dynamic fixture: an isolated environment where NEITHER AMPLIHACK_HOME NOR the
+# repo top-level contains amplifier-bundle/, reproducing the downstream-checkout
+# scenario (e.g. the Simard project) from the bug report.
+# ---------------------------------------------------------------------------
+TMP_ROOT="$(mktemp -d)"
+cleanup() { rm -rf "${TMP_ROOT}"; }
+trap cleanup EXIT
+
+TMP_REPO="${TMP_ROOT}/repo"                 # git top-level, NO amplifier-bundle/
+TMP_AH="${TMP_ROOT}/downstream"             # AMPLIHACK_HOME, NO amplifier-bundle/
+HOME_AMPLIHACK="${TMP_ROOT}/home_amplihack" # has ~/.amplihack/.../git-identity.sh
+HOME_COPILOT="${TMP_ROOT}/home_copilot"     # has ~/.copilot/.../git-identity.sh
+HOME_EMPTY="${TMP_ROOT}/home_empty"         # nothing installed anywhere
+
+mkdir -p "${TMP_REPO}" "${TMP_AH}" "${HOME_EMPTY}"
+git -C "${TMP_REPO}" init -q
+
+# Install stub helpers only under the "home" trees (NOT under AMPLIHACK_HOME or
+# the repo top-level) so resolution must reach the appended tail fallbacks.
+install_stub() {
+    local dir="$1"
+    mkdir -p "${dir}"
+    cat > "${dir}/git-identity.sh" <<'STUB'
+#!/usr/bin/env bash
+# Test stub sourced in place of the real git-identity helper.
+echo "STUB_GITID_SOURCED"
+amplihack_prepare_git_commit_identity() { :; }
+STUB
+}
+install_stub "${HOME_AMPLIHACK}/.amplihack/amplifier-bundle/tools"
+install_stub "${HOME_COPILOT}/.copilot/amplifier-bundle/tools"
+
+# extract_gitid_chain <recipe> — print the single-line git-identity resolution
+# chain (the one that ends in the terminal `exit 2`), leading whitespace removed.
+extract_gitid_chain() {
+    local recipe="$1" line
+    line="$(grep -E 'GIT_IDENTITY_HELPER="[^"]*git rev-parse --show-toplevel' "${recipe}" \
+            | grep -F 'exit 2' | head -1)"
+    line="${line#"${line%%[![:space:]]*}"}"
+    printf '%s' "${line}"
+}
+
+# run_gitid_chain <recipe> <home> — evaluate a recipe's git-identity chain inside
+# the isolated fixture and echo the resolved path. Runs in a subshell so a
+# terminal `exit 2` surfaces as the subshell exit code.
+run_gitid_chain() {
+    local recipe="$1" home="$2" chain
+    chain="$(extract_gitid_chain "${RECIPES}/${recipe}")"
+    if [[ -z "${chain}" ]]; then
+        echo "HARNESS: no git-identity chain found in ${recipe}" >&2
+        return 3
+    fi
+    (
+        cd "${TMP_REPO}" || exit 3
+        export HOME="${home}"
+        export AMPLIHACK_HOME="${TMP_AH}"
+        unset REPO_PATH
+        eval "${chain}"
+        printf 'RESOLVED=%s\n' "${GIT_IDENTITY_HELPER}"
+    )
+}
+
+# ---------------------------------------------------------------------------
+# POS: ${HOME}/.amplihack fallback resolves for every recipe.
+# ---------------------------------------------------------------------------
+for f in "${RECIPE_FILES[@]}"; do
+    set +e
+    out="$(run_gitid_chain "${f}" "${HOME_AMPLIHACK}" 2>&1)"
+    rc=$?
+    set -e
+    if [[ ${rc} -eq 0 ]] \
+       && printf '%s\n' "${out}" | grep -q 'STUB_GITID_SOURCED' \
+       && printf '%s\n' "${out}" | grep -qF "${HOME_AMPLIHACK}/.amplihack/amplifier-bundle/tools/git-identity.sh"; then
+        pass "POS-amplihack:${f}" "resolves via \${HOME}/.amplihack fallback and sources helper"
+    else
+        fail "POS-amplihack:${f}" "did not resolve via \${HOME}/.amplihack fallback (rc=${rc}): ${out}"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# POS2: ${HOME}/.copilot fallback resolves for every recipe.
+# ---------------------------------------------------------------------------
+for f in "${RECIPE_FILES[@]}"; do
+    set +e
+    out="$(run_gitid_chain "${f}" "${HOME_COPILOT}" 2>&1)"
+    rc=$?
+    set -e
+    if [[ ${rc} -eq 0 ]] \
+       && printf '%s\n' "${out}" | grep -q 'STUB_GITID_SOURCED' \
+       && printf '%s\n' "${out}" | grep -qF "${HOME_COPILOT}/.copilot/amplifier-bundle/tools/git-identity.sh"; then
+        pass "POS-copilot:${f}" "resolves via \${HOME}/.copilot fallback and sources helper"
+    else
+        fail "POS-copilot:${f}" "did not resolve via \${HOME}/.copilot fallback (rc=${rc}): ${out}"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# NEG: fail-visible control — helper truly absent everywhere MUST still exit 2.
+# ---------------------------------------------------------------------------
+for f in "${RECIPE_FILES[@]}"; do
+    set +e
+    out="$(run_gitid_chain "${f}" "${HOME_EMPTY}" 2>&1)"
+    rc=$?
+    set -e
+    if [[ ${rc} -eq 2 ]] \
+       && printf '%s\n' "${out}" | grep -q 'git identity helper not found'; then
+        pass "NEG-failvisible:${f}" "absent helper still exits 2 with ERROR (fail-visible)"
+    else
+        fail "NEG-failvisible:${f}" "did not fail visibly with exit 2 (rc=${rc}): ${out}"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# STATIC: each recipe's git-identity chain carries all three tail fallbacks.
+# ---------------------------------------------------------------------------
+count_fallback() {
+    # Literal-substring occurrence count within a file.
+    grep -Fc "$2" "$1" 2>/dev/null || true
+}
+
+for f in "${RECIPE_FILES[@]}"; do
+    file="${RECIPES}/${f}"
+    # workflow-publish.yaml carries TWO git-identity chains (single-line + the
+    # multi-line block), so each fallback must appear at least twice there.
+    min=1
+    [[ "${f}" == "workflow-publish.yaml" ]] && min=2
+
+    for cand_name in PWD COPILOT AMPLIHACK; do
+        case "${cand_name}" in
+            PWD) cand="${FALLBACK_PWD}" ;;
+            COPILOT) cand="${FALLBACK_COPILOT}" ;;
+            AMPLIHACK) cand="${FALLBACK_AMPLIHACK}" ;;
+        esac
+        n="$(count_fallback "${file}" "${cand}")"
+        if [[ "${n}" -ge "${min}" ]]; then
+            pass "STATIC-${cand_name}:${f}" "carries ${cand_name} fallback (>= ${min})"
+        else
+            fail "STATIC-${cand_name}:${f}" "missing ${cand_name} fallback '${cand}' (found ${n}, need >= ${min})"
+        fi
+    done
+done
+
+# ---------------------------------------------------------------------------
+# STATIC2 + GUARD: exactly 7 single-line git-identity `exit 2` sites; the
+# workflow-publish.yaml multi-line block stays exit-2-free (only one file
+# references the ERROR text more than once? No — each file has exactly one
+# single-line ERROR site; publish's multi-line block never emits the ERROR).
+# ---------------------------------------------------------------------------
+total_exit2=0
+for f in "${RECIPE_FILES[@]}"; do
+    n="$(grep -E 'git identity helper not found' "${RECIPES}/${f}" 2>/dev/null \
+         | grep -cE 'exit[[:space:]]+2' || true)"
+    total_exit2=$((total_exit2 + n))
+done
+if [[ "${total_exit2}" -eq 7 ]]; then
+    pass "GUARD-exit2-total" "exactly 7 single-line git-identity exit-2 sites retained"
+else
+    fail "GUARD-exit2-total" "found ${total_exit2} git-identity exit-2 sites (expected 7)"
+fi
+
+# The publish multi-line block must NOT gain an exit 2: the file references the
+# ERROR text exactly once (its single-line site only).
+publish_err="$(grep -cE 'git identity helper not found' "${RECIPES}/workflow-publish.yaml" 2>/dev/null || true)"
+if [[ "${publish_err}" -eq 1 ]]; then
+    pass "GUARD-publish-noexit2" "workflow-publish.yaml multi-line block stays exit-2-free"
+else
+    fail "GUARD-publish-noexit2" "workflow-publish.yaml has ${publish_err} git-identity ERROR sites (expected 1)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ---"
+
+if [[ ${FAIL_COUNT} -gt 0 ]]; then
+    exit 1
+fi
+
+echo "PASS: Issue #955 — git-identity helper resolves via the full fallback chain (fail-visible only when truly absent)."
+exit 0

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -119,7 +119,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -195,7 +195,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel)}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel)}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_output_file=$(mktemp -t step18c-review-feedback-commit-XXXXXX)
         commit_with_pre_commit_guard() {
           local pre_commit_hook

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -383,11 +383,7 @@ steps:
           distribution validation when that project shape warrants it.
        5. If a test fails, diagnose, fix, commit, push, and retry up to 3 times:
           ```bash
-          GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
-          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
-          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"
-          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"
-          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"
+          GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"
           . "$GIT_IDENTITY_HELPER"
           amplihack hygiene artifact-guard --repo . --mode pre-publish && git add -A
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -246,7 +246,7 @@ steps:
       COMMIT_MSG=$(printf '%s\n\nImplements %s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\n%s' "$COMMIT_TITLE" "$ISSUE_IMPL" "$ISSUE_REF")
       # PERF: --quiet short-circuits on the first staged change.
       if ! git diff --cached --quiet; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         git commit -m "$COMMIT_MSG"
       else
@@ -385,6 +385,9 @@ steps:
           ```bash
           GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
           [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"
+          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"
+          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"
           . "$GIT_IDENTITY_HELPER"
           amplihack hygiene artifact-guard --repo . --mode pre-publish && git add -A
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -229,7 +229,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -349,7 +349,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity

--- a/docs/howto/configure-workflow-commit-identity.md
+++ b/docs/howto/configure-workflow-commit-identity.md
@@ -178,6 +178,45 @@ Do not fix the failure by setting `git config --global` on the VM. A global VM
 identity can leak into unrelated repositories and does not prove the intended
 attribution for the current workflow.
 
+## Fix a "git identity helper not found" failure
+
+A commit or checkpoint step can stop with:
+
+```text
+ERROR: git identity helper not found: <path>
+```
+
+This means the recipe step could not locate `git-identity.sh` on disk before
+sourcing it. Commit steps search five locations in order and only fail after all
+of them are absent:
+
+1. `${AMPLIHACK_HOME:-${REPO_PATH:-<repo top level>}}/amplifier-bundle/tools/git-identity.sh`
+2. `<repo top level>/amplifier-bundle/tools/git-identity.sh`
+3. `$(pwd)/amplifier-bundle/tools/git-identity.sh`
+4. `${HOME}/.copilot/amplifier-bundle/tools/git-identity.sh`
+5. `${HOME}/.amplihack/amplifier-bundle/tools/git-identity.sh`
+
+In a downstream project checkout that does not vendor `amplifier-bundle/`, the
+helper resolves automatically from the installed home locations
+(`~/.copilot/...` or `~/.amplihack/...`), so no action is needed. If the failure
+still occurs, the bundle is genuinely missing from every location. Reinstall the
+bundle or point `AMPLIHACK_HOME` at a directory that contains
+`amplifier-bundle/`:
+
+```bash
+export AMPLIHACK_HOME="$HOME/.amplihack"
+ls "$AMPLIHACK_HOME/amplifier-bundle/tools/git-identity.sh"
+
+amplihack recipe run default-workflow \
+  -c repo_path=. \
+  -c task_description="Continue after restoring the amplihack bundle"
+```
+
+The `exit 2` is fail-visible by design: the workflow stops loudly rather than
+silently skipping the commit, so a truly missing bundle is never masked. See the
+[Helper script location resolution](../reference/workflow-commit-identity.md#helper-script-location-resolution)
+reference for the full candidate chain.
+
 ## Check the resulting commit identity
 
 After the workflow creates a commit, inspect the latest commit:

--- a/docs/reference/workflow-commit-identity.md
+++ b/docs/reference/workflow-commit-identity.md
@@ -12,6 +12,7 @@ invoking `git commit`.
 - [Validation rules](#validation-rules)
 - [Provider inference](#provider-inference)
 - [Shell helper API](#shell-helper-api)
+- [Helper script location resolution](#helper-script-location-resolution)
 - [Recipe contract](#recipe-contract)
 - [Failures](#failures)
 
@@ -208,6 +209,109 @@ Classifies the repository remote as `github`, `azdo`, or `unknown`.
 Provider inference uses this value to decide whether `gh` or Azure CLI identity
 lookup is allowed.
 
+## Helper script location resolution
+
+Before a recipe can source `git-identity.sh`, it must first *find* the file on
+disk. The installed bundle layout differs across execution contexts, so every
+commit-producing recipe step resolves the helper path with the same ordered
+fallback chain rather than assuming a single location. This makes commit and
+checkpoint steps robust when `AMPLIHACK_HOME` points at a downstream repository
+checkout that does not itself contain an `amplifier-bundle/` tree (for example,
+a project consuming an installed amplihack), while the helper is present under
+`${HOME}/.amplihack/` or `${HOME}/.copilot/`.
+
+### Resolution order
+
+Each recipe step assigns `GIT_IDENTITY_HELPER` to the first candidate path that
+exists, checked in this exact order. The chain adopts the same home-directory
+fallback tail (`$(pwd)`, then `~/.copilot`, then `~/.amplihack`) and
+last-resort ordering as the sibling `RUNTIME_ARTIFACT_HELPER` chain used for
+`workflow_runtime_artifacts.sh`. The leading candidates differ intentionally:
+git-identity resolution uses `git rev-parse --show-toplevel` for the repository
+top level, whereas the runtime-artifact helper uses `${REPO_PATH:-$(pwd)}`:
+
+| # | Candidate path | Resolves when |
+| --- | --- | --- |
+| 1 | `${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh` | `AMPLIHACK_HOME` (or `REPO_PATH`, or the repo top level) contains the bundle. |
+| 2 | `$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh` | The current repository root contains the bundle. |
+| 3 | `$(pwd)/amplifier-bundle/tools/git-identity.sh` | The working directory contains the bundle (worktrees where `pwd` differs from the top level). |
+| 4 | `${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh` | The bundle is installed under the Copilot home. |
+| 5 | `${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh` | The bundle is installed under the amplihack home. |
+
+Higher-trust, workflow-scoped locations (`AMPLIHACK_HOME`, `REPO_PATH`, repo top
+level) are always tried first. The user-home install locations are tried last so
+they never shadow an explicitly configured bundle path.
+
+Candidate #1 is preserved verbatim per recipe and is not universal:
+`workflow-pr-review.yaml` intentionally uses `${AMPLIHACK_HOME:-$(git rev-parse
+--show-toplevel)}` (no `REPO_PATH`) as its base. Only the three home-based
+fallbacks (#3–#5) are appended identically across every recipe; see
+[Coverage](#coverage).
+
+The single-line form used in the commit steps is:
+
+```bash
+GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
+[ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+[ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"
+[ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"
+[ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"
+[ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
+. "$GIT_IDENTITY_HELPER"
+```
+
+All candidate assignments and every `[ -f "$GIT_IDENTITY_HELPER" ]` guard are
+double-quoted to prevent word-splitting and glob expansion. The chain performs
+no `eval`, adds no command substitution beyond the existing `$(pwd)` and
+`$(git rev-parse --show-toplevel)`, and never parses the contents of the helper
+during resolution.
+
+### Fail-visible behavior
+
+Resolution is fail-visible, never silent-degrade. When *every* candidate is
+absent, the step prints
+`ERROR: git identity helper not found: <path>` to stderr and exits `2`. The
+terminal `exit 2` runs only after the full chain is exhausted, so a genuinely
+missing helper still stops the workflow loudly instead of producing an
+unattributed or skipped commit.
+
+`workflow-publish.yaml` additionally documents a multi-line commit example in an
+inline retry block. That block uses the same five candidate paths to locate the
+helper before sourcing it, and by design it does not add an `exit 2` guard — it
+retains its original fail-open-to-source shape and only benefits from the added
+resolution paths.
+
+### Coverage
+
+The five-candidate chain is applied consistently in every recipe step that
+sources `git-identity.sh`:
+
+| Recipe | Step context |
+| --- | --- |
+| `workflow-finalize.yaml` | Finalization and cleanup commit step. |
+| `workflow-refactor-review.yaml` | Review-feedback checkpoint commit step. |
+| `workflow-pr-review.yaml` | PR review remediation commit step (base candidate omits `REPO_PATH` by design). |
+| `workflow-tdd.yaml` | Implementation checkpoint commit step. |
+| `workflow-publish.yaml` | Publish commit step and the multi-line outside-in retry example. |
+| `consensus-publish.yaml` | Consensus result publication commit step. |
+| `consensus-pr-feedback.yaml` | PR feedback publication commit step. |
+
+Leading candidates are preserved verbatim per recipe: `workflow-pr-review.yaml`
+intentionally starts from `${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel)}`
+without `REPO_PATH`, and the three home-based fallbacks are appended without
+rewriting it.
+
+### Regression contract
+
+A regression test asserts that the helper is located via the
+`${HOME}/.amplihack/amplifier-bundle/tools/git-identity.sh` fallback when both
+`AMPLIHACK_HOME` and the repository top level lack an `amplifier-bundle/` tree.
+The test also keeps a negative control proving that a fully missing helper still
+exits `2` (fail-visible), and static assertions that every recipe listed above
+carries the complete five-candidate chain. The test uses a temporary `HOME` and
+a disposable repository with `trap ... EXIT` cleanup and never writes to the
+real `~/.amplihack` or `~/.copilot`.
+
 ## Recipe contract
 
 Every Amplihack recipe path that creates a commit calls
@@ -267,3 +371,16 @@ git config --local user.email "mona@example.com"
 Do not fix this by setting global Git config on a shared VM. Global VM config can
 affect unrelated repositories and does not prove the identity was intended for
 the current workflow commit.
+
+A commit step can also stop earlier, before identity resolution runs, when the
+helper script itself cannot be located on disk:
+
+```text
+ERROR: git identity helper not found: <path>
+```
+
+This is the separate, fail-visible `exit 2` described under
+[Helper script location resolution](#helper-script-location-resolution). It
+means every candidate path was absent, not that the identity was unsafe.
+Remediation for that case is covered in the how-to guide's
+"Fix a 'git identity helper not found' failure" section.


### PR DESCRIPTION
## Problem

The `git-identity.sh` helper in the workflow/consensus recipes was resolved with only **two** candidate paths, then hard `exit 2` if neither existed:

```sh
GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
[ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
[ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }
```

This silently killed **every commit/checkpoint step** whenever `AMPLIHACK_HOME` pointed at a downstream repo checkout that lacks `amplifier-bundle/` (e.g. a Simard worktree) — even though the helper **is** installed at `${HOME}/.amplihack/amplifier-bundle/tools/git-identity.sh`. Root cause of default-workflow finalize failures in downstream repos.

## Fix

The sibling `RUNTIME_ARTIFACT_HELPER` in the same steps already had a 5-path fallback chain. This mirrors it: appends three guarded fallbacks — `$(pwd)/...`, `${HOME}/.copilot/...`, `${HOME}/.amplihack/...` — **before** the terminal `exit 2`, which stays **last** so a genuinely-missing helper still fails visibly (never silent-degrades).

Applied consistently across all 7 single-line git-identity sites + the `workflow-publish.yaml` multi-line block.

## Tests

Adds `tests/test-issue-955-git-identity-fallback.sh` (44 assertions): positive fallback resolution, negative fail-visible `exit 2`, and static guards proving every site carries the three tail fallbacks. Updates the workflow-commit-identity how-to + reference docs.

Fixes #955