### PR TITLE
fix(#955): broaden git-identity helper resolution with robust fallback chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Recipes — graceful degradation for missing runtime-artifact helper (issue #829)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-bug-829-graceful-degradation.sh
+      - name: Recipes — git-identity helper fallback resolution (issue #955)
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh
       - name: Recipes — doc-review failure is non-fatal-but-reported (issue #834)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-bug-834-doc-review-non-fatal.sh

--- a/amplifier-bundle/recipes/consensus-pr-feedback.yaml
+++ b/amplifier-bundle/recipes/consensus-pr-feedback.yaml
@@ -38,7 +38,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         git commit -m "Address PR review feedback"
       else

--- a/amplifier-bundle/recipes/consensus-publish.yaml
+++ b/amplifier-bundle/recipes/consensus-publish.yaml
@@ -61,7 +61,7 @@ steps:
 
       COMMITTED=false
       if [ -n "$(git diff --cached --name-only)" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         if git commit -m "$COMMIT_MSG"; then
           COMMITTED=true

--- a/amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh
+++ b/amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# test-issue-955-git-identity-fallback.sh — regression test for issue #955.
+#
+# Bug: the recipe git-identity.sh helper was resolved with only TWO candidate
+# paths and then hard-failed with `exit 2` when neither existed. This killed
+# every commit/checkpoint step whenever AMPLIHACK_HOME pointed at a downstream
+# repo checkout lacking `amplifier-bundle/` (e.g. the Simard project), even
+# though the helper WAS installed at ${HOME}/.amplihack/amplifier-bundle/tools/
+# git-identity.sh. Observed impact: default-workflow runs completed
+# design+TDD+implement+verify but produced NO commit and NO PR because the
+# checkpoint step exited 2.
+#
+# Fix: mirror the sibling RUNTIME_ARTIFACT_HELPER resolution — append three
+# fallbacks BEFORE the terminal `exit 2`, in this order:
+#   $(pwd)/...
+#   ${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh
+#   ${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh
+# The final `exit 2` is retained ONLY after ALL candidates are exhausted
+# (fail-visible, never silent-degrade).
+#
+# Contracts under test:
+#   A. BEHAVIOURAL — with AMPLIHACK_HOME and the repo top-level both lacking
+#      `amplifier-bundle/`, the extracted chain resolves the helper via the
+#      ${HOME}/.amplihack fallback and exits 0 (no `exit 2`).
+#   B. BEHAVIOURAL — when NONE of the candidate paths exist, the chain still
+#      hard-fails with `exit 2` and emits the ERROR (fail-visible preserved).
+#   C. STATIC — every recipe that resolves git-identity contains the
+#      ${HOME}/.amplihack fallback candidate; the 7 single-line gate sites also
+#      retain their terminal `exit 2`.
+#
+# This test SHOULD FAIL before the #955 fix lands (chain has only 2 paths).
+# It MUST PASS once the three fallbacks are appended.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+RECIPES="${REPO_ROOT}/amplifier-bundle/recipes"
+
+TDD="${RECIPES}/workflow-tdd.yaml"
+
+SINGLE_LINE_RECIPES=(
+    "consensus-pr-feedback.yaml"
+    "workflow-tdd.yaml"
+    "workflow-refactor-review.yaml"
+    "workflow-publish.yaml"
+    "workflow-finalize.yaml"
+    "consensus-publish.yaml"
+    "workflow-pr-review.yaml"
+)
+
+FALLBACK_CANDIDATE='${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo "  PASS[$1]: $2"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  FAIL[$1]: $2" >&2; }
+
+for f in "${SINGLE_LINE_RECIPES[@]}"; do
+    if [[ ! -f "${RECIPES}/${f}" ]]; then
+        echo "HARNESS-ERROR: required recipe not found: ${RECIPES}/${f}" >&2
+        exit 2
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Extract the real single-line git-identity resolution chain from workflow-tdd
+# and swap the final `. "$HELPER"` sourcing for an echo so we can observe the
+# resolved path without actually sourcing the helper under test.
+# ---------------------------------------------------------------------------
+CHAIN="$(grep -m1 -E 'GIT_IDENTITY_HELPER="\$\{AMPLIHACK_HOME' "${TDD}" | sed -E 's/^[[:space:]]+//')"
+if [[ -z "${CHAIN}" ]]; then
+    echo "HARNESS-ERROR: could not extract git-identity chain from ${TDD}" >&2
+    exit 2
+fi
+CHAIN_PROBE="$(printf '%s' "${CHAIN}" | sed -E 's/; \. "\$GIT_IDENTITY_HELPER"$/; echo "RESOLVED=$GIT_IDENTITY_HELPER"/')"
+
+WORK="$(mktemp -d -t issue-955-XXXXXX)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# A git repo sandbox that deliberately LACKS amplifier-bundle/.
+SANDBOX_REPO="${WORK}/downstream-repo"
+mkdir -p "${SANDBOX_REPO}"
+git -C "${SANDBOX_REPO}" init -q
+# AMPLIHACK_HOME that also lacks amplifier-bundle/.
+EMPTY_HOME="${WORK}/amplihack-home-empty"
+mkdir -p "${EMPTY_HOME}"
+
+# ---------------------------------------------------------------------------
+# A. Positive: ${HOME}/.amplihack fallback resolves; exit 0, no `exit 2`.
+# ---------------------------------------------------------------------------
+FAKE_HOME="${WORK}/fake-home"
+mkdir -p "${FAKE_HOME}/.amplihack/amplifier-bundle/tools"
+printf '#!/usr/bin/env bash\n: # stub git-identity helper\n' \
+    >"${FAKE_HOME}/.amplihack/amplifier-bundle/tools/git-identity.sh"
+
+set +e
+OUT_A="$(cd "${SANDBOX_REPO}" && env -u REPO_PATH HOME="${FAKE_HOME}" \
+    AMPLIHACK_HOME="${EMPTY_HOME}" bash -c "${CHAIN_PROBE}" 2>"${WORK}/err_a")"
+RC_A=$?
+set -e
+
+EXPECTED_A="${FAKE_HOME}/.amplihack/amplifier-bundle/tools/git-identity.sh"
+if [[ ${RC_A} -eq 0 && "${OUT_A}" == "RESOLVED=${EXPECTED_A}" ]]; then
+    pass "A-fallback-resolves" "helper resolved via \${HOME}/.amplihack fallback (rc=0)"
+else
+    fail "A-fallback-resolves" \
+        "expected rc=0 + RESOLVED=${EXPECTED_A}; got rc=${RC_A}, out='${OUT_A}'"
+fi
+
+# ---------------------------------------------------------------------------
+# B. Negative: no candidate exists anywhere -> still hard-fails exit 2.
+# ---------------------------------------------------------------------------
+BARE_HOME="${WORK}/bare-home"
+mkdir -p "${BARE_HOME}"
+set +e
+cd "${SANDBOX_REPO}" && env -u REPO_PATH HOME="${BARE_HOME}" \
+    AMPLIHACK_HOME="${EMPTY_HOME}" bash -c "${CHAIN_PROBE}" >/dev/null 2>"${WORK}/err_b"
+RC_B=$?
+set -e
+
+if [[ ${RC_B} -eq 2 ]] && grep -q "git identity helper not found" "${WORK}/err_b"; then
+    pass "B-all-missing-exit2" "all candidates missing -> exit 2 + ERROR (fail-visible)"
+else
+    fail "B-all-missing-exit2" \
+        "expected rc=2 + ERROR; got rc=${RC_B}, err='$(cat "${WORK}/err_b")'"
+fi
+
+# ---------------------------------------------------------------------------
+# C. Static: every recipe carries the .amplihack fallback; the 7 single-line
+#    gate sites retain their terminal exit 2.
+# ---------------------------------------------------------------------------
+for f in "${SINGLE_LINE_RECIPES[@]}"; do
+    p="${RECIPES}/${f}"
+    if grep -Fq "${FALLBACK_CANDIDATE}" "${p}"; then
+        pass "C-fallback-${f}" "${f} contains \${HOME}/.amplihack git-identity fallback"
+    else
+        fail "C-fallback-${f}" "${f} missing \${HOME}/.amplihack git-identity fallback"
+    fi
+    if grep -Eq 'git identity helper not found.*exit[[:space:]]+2' "${p}"; then
+        pass "C-exit2-${f}" "${f} retains terminal git-identity exit 2"
+    else
+        fail "C-exit2-${f}" "${f} lost terminal git-identity exit 2"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ---"
+[[ ${FAIL_COUNT} -eq 0 ]] || exit 1
+exit 0

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -119,7 +119,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -195,7 +195,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel)}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-$(git rev-parse --show-toplevel)}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_output_file=$(mktemp -t step18c-review-feedback-commit-XXXXXX)
         commit_with_pre_commit_guard() {
           local pre_commit_hook

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -246,7 +246,7 @@ steps:
       COMMIT_MSG=$(printf '%s\n\nImplements %s\n\nChanges:\n- Implementation as per design specification\n- Tests added for new functionality\n- Documentation updated\n\n%s' "$COMMIT_TITLE" "$ISSUE_IMPL" "$ISSUE_REF")
       # PERF: --quiet short-circuits on the first staged change.
       if ! git diff --cached --quiet; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         amplihack_prepare_git_commit_identity
         git commit -m "$COMMIT_MSG"
       else
@@ -385,6 +385,9 @@ steps:
           ```bash
           GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"
           [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"
+          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"
+          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"
+          [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"
           . "$GIT_IDENTITY_HELPER"
           amplihack hygiene artifact-guard --repo . --mode pre-publish && git add -A
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -229,7 +229,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -349,7 +349,7 @@ steps:
       git add -A
       STAGED=$(git diff --cached --name-only)
       if [ -n "$STAGED" ]; then
-        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
+        GIT_IDENTITY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(git rev-parse --show-toplevel)}}/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(git rev-parse --show-toplevel)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"; [ -f "$GIT_IDENTITY_HELPER" ] || { echo "ERROR: git identity helper not found: $GIT_IDENTITY_HELPER" >&2; exit 2; }; . "$GIT_IDENTITY_HELPER"
         commit_with_pre_commit_guard() {
           local pre_commit_hook
           amplihack_prepare_git_commit_identity


### PR DESCRIPTION
## Summary
Fixes #955. The recipe `git-identity.sh` helper resolved only **two** candidate paths and then hard-failed with `exit 2` when neither existed. This killed every commit/checkpoint step whenever `AMPLIHACK_HOME` pointed at a downstream repo checkout lacking `amplifier-bundle/` (e.g. the Simard project), even though the helper **was** installed at `${HOME}/.amplihack/amplifier-bundle/tools/git-identity.sh`. Observed impact: `default-workflow` runs completed design+TDD+implement+verify but produced **no commit and no PR** because the checkpoint step exited 2.

## Fix
Mirror the sibling `RUNTIME_ARTIFACT_HELPER` resolution (which already uses five fallbacks). Append the three missing fallbacks **before** the terminal `exit 2`, in the same order and style:

```
[ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="$(pwd)/amplifier-bundle/tools/git-identity.sh"
[ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.copilot/amplifier-bundle/tools/git-identity.sh"
[ -f "$GIT_IDENTITY_HELPER" ] || GIT_IDENTITY_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/git-identity.sh"
```

Applied consistently to all **7 single-line gate sites** and the **multi-line block** in `workflow-publish.yaml`:

- `consensus-pr-feedback.yaml:41`
- `workflow-tdd.yaml:352`
- `workflow-refactor-review.yaml:232`
- `workflow-publish.yaml:249` (single-line) + `:386-388` (multi-line block)
- `workflow-finalize.yaml:122`
- `consensus-publish.yaml:64`
- `workflow-pr-review.yaml:198`

## Constraints honored
- **Additive / non-breaking:** existing leading candidates preserved verbatim (including `workflow-pr-review`'s intentionally `REPO_PATH`-less base). Found-path behavior unchanged.
- **Fail-visible, never silent-degrade:** the terminal `exit 2` is retained only after **all five** candidates are exhausted. The publish multi-line block keeps its original fail-open-to-source shape (no `exit 2` introduced there — it never had one).
- Plain `[ -f "$X" ] || X="..."` chain mirroring `RUNTIME_ARTIFACT_HELPER` — no functions, loops, or code-parsing.
- No Bridge naming; no stray `print!`/`println!` (shell/YAML-only change).

## Tests
- **New:** `amplifier-bundle/recipes/tests/test-issue-955-git-identity-fallback.sh` (registered in `.github/workflows/ci.yml`). Covers:
  - **A (behavioural):** with `AMPLIHACK_HOME` and repo top-level both lacking `amplifier-bundle/`, the extracted chain resolves via the `${HOME}/.amplihack` fallback and exits 0.
  - **B (behavioural):** when no candidate exists anywhere, the chain still hard-fails `exit 2` with the ERROR (fail-visible preserved).
  - **C (static):** every recipe carries the `.amplihack` fallback; the 7 single-line gate sites retain their terminal `exit 2`.
  - Result: **16 passed, 0 failed**. Shellcheck clean.
- **Regression:** `test-bug-829-graceful-degradation.sh` still passes (**32 passed**) — its `git identity helper not found.*exit 2` assertions remain satisfied.
- All edited YAML files parse; `scripts/check-recipes-no-python.sh` and `scripts/check-toolchain-refs.sh` pass.

## Notes
Do not squash-merge with a message that drops the `#955` reference. This closes #955.
