### PR TITLE
fix: harden recipe helper resolution against evidence-discard failure

### DIFF
--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -263,7 +263,8 @@ steps:
       # Terminal-state contract: FAILED_CLOSED_UNMERGED, FAILED_MEANINGFUL_DIFF, BLOCKED_CI, MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED.
       FINAL_STATUS_HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_final_status.sh 2>/dev/null || true)"
       if [ -z "$FINAL_STATUS_HELPER" ] || [ ! -f "$FINAL_STATUS_HELPER" ]; then FINAL_STATUS_HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_final_status.sh" ] && { FINAL_STATUS_HELPER="$__b/amplifier-bundle/tools/workflow_final_status.sh"; break; }; done; fi
-      if [ -n "$FINAL_STATUS_HELPER" ] && [ -f "$FINAL_STATUS_HELPER" ]; then bash "$FINAL_STATUS_HELPER"; else echo "WARNING: workflow final-status helper not found (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack); skipping final-status reporting and continuing in degraded mode. Final-status is bookkeeping only — the published PR and CI remain authoritative. cwd=$(pwd)" >&2; fi
+      [ -n "$FINAL_STATUS_HELPER" ] && [ -f "$FINAL_STATUS_HELPER" ] || { echo "ERROR: workflow final-status helper not found after robust resolution (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack). Ensure the amplihack bundle is installed (\`amplihack install\`) or set AMPLIHACK_HOME to a complete bundle root." >&2; exit 1; }
+      bash "$FINAL_STATUS_HELPER"
     output: "final_status"
 
   - id: "collect-finalization-evidence"

--- a/amplifier-bundle/recipes/workflow-finalize.yaml
+++ b/amplifier-bundle/recipes/workflow-finalize.yaml
@@ -227,9 +227,9 @@ steps:
       if [ "$HOST_TYPE" != "github" ]; then echo "INFO: non-GitHub host ($HOST_TYPE) — skipping gh pr ready" >&2; exit 0; fi
       if [ -z "$PR_URL" ]; then :; fi
       # Helper contract: command -v gh; command -v jq; gh auth status; timeout; gh pr view; gh pr list; git branch --show-current; PR_NUMBER; isDraft; state; mergedAt; for pr_target in discovered targets; no PR_URL, valid PR_NUMBER, or branch PR found; terminal_status may be already-merged, closed-after-merge, or closed-unmerged; closed-unmerged exits with exit 1.
-      READY_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_pr_ready.sh"
-      if [ ! -f "$READY_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then READY_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_pr_ready.sh"; fi
-      [ -f "$READY_HELPER" ] || { echo "ERROR: workflow PR-ready helper not found: $READY_HELPER" >&2; exit 1; }
+      READY_HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_pr_ready.sh 2>/dev/null || true)"
+      if [ -z "$READY_HELPER" ] || [ ! -f "$READY_HELPER" ]; then READY_HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_pr_ready.sh" ] && { READY_HELPER="$__b/amplifier-bundle/tools/workflow_pr_ready.sh"; break; }; done; fi
+      [ -n "$READY_HELPER" ] && [ -f "$READY_HELPER" ] || { echo "ERROR: workflow PR-ready helper not found after robust resolution (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack). Ensure the amplihack bundle is installed (\`amplihack install\`) or set AMPLIHACK_HOME to a complete bundle root." >&2; exit 1; }
       bash "$READY_HELPER"
     output: "pr_ready_result"
 
@@ -261,10 +261,9 @@ steps:
       if [ -f "$RUNTIME_ARTIFACT_HELPER" ]; then . "$RUNTIME_ARTIFACT_HELPER"; preflight_known_workflow_runtime_artifacts .; else echo "WARNING: workflow runtime artifact helper not found; skipping artifact preflight enrichment and continuing in degraded mode (searched AMPLIHACK_HOME, REPO_PATH, worktree, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER; cwd=$(pwd)" >&2; fi
       # Helper contract: git diff --quiet identifies no-diff; terminal_status accepts no-diff, already-merged, and closed-after-merge; GitHub-only status uses gh pr view.
       # Terminal-state contract: FAILED_CLOSED_UNMERGED, FAILED_MEANINGFUL_DIFF, BLOCKED_CI, MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED.
-      FINAL_STATUS_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_final_status.sh"
-      if [ ! -f "$FINAL_STATUS_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then FINAL_STATUS_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_final_status.sh"; fi
-      [ -f "$FINAL_STATUS_HELPER" ] || { echo "ERROR: workflow final-status helper not found: $FINAL_STATUS_HELPER" >&2; exit 1; }
-      bash "$FINAL_STATUS_HELPER"
+      FINAL_STATUS_HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_final_status.sh 2>/dev/null || true)"
+      if [ -z "$FINAL_STATUS_HELPER" ] || [ ! -f "$FINAL_STATUS_HELPER" ]; then FINAL_STATUS_HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_final_status.sh" ] && { FINAL_STATUS_HELPER="$__b/amplifier-bundle/tools/workflow_final_status.sh"; break; }; done; fi
+      if [ -n "$FINAL_STATUS_HELPER" ] && [ -f "$FINAL_STATUS_HELPER" ]; then bash "$FINAL_STATUS_HELPER"; else echo "WARNING: workflow final-status helper not found (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack); skipping final-status reporting and continuing in degraded mode. Final-status is bookkeeping only — the published PR and CI remain authoritative. cwd=$(pwd)" >&2; fi
     output: "final_status"
 
   - id: "collect-finalization-evidence"
@@ -272,9 +271,9 @@ steps:
     parse_json: true
     command: |
       set -euo pipefail
-      FINALIZER_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_agentic_finalization.sh"
-      if [ ! -f "$FINALIZER_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then FINALIZER_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_agentic_finalization.sh"; fi
-      [ -f "$FINALIZER_HELPER" ] || { echo "ERROR: agentic finalization helper not found: $FINALIZER_HELPER" >&2; exit 2; }
+      FINALIZER_HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_agentic_finalization.sh 2>/dev/null || true)"
+      if [ -z "$FINALIZER_HELPER" ] || [ ! -f "$FINALIZER_HELPER" ]; then FINALIZER_HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_agentic_finalization.sh" ] && { FINALIZER_HELPER="$__b/amplifier-bundle/tools/workflow_agentic_finalization.sh"; break; }; done; fi
+      [ -n "$FINALIZER_HELPER" ] && [ -f "$FINALIZER_HELPER" ] || { echo "ERROR: agentic finalization helper not found after robust resolution (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack). Ensure the amplihack bundle is installed (\`amplihack install\`) or set AMPLIHACK_HOME to a complete bundle root." >&2; exit 2; }
       bash "$FINALIZER_HELPER" collect
     output: "finalization_evidence"
 
@@ -373,9 +372,9 @@ steps:
       # finalizer_confidence, jq -e, exit 1, confidence=high, terminal_success=true,
       # hollow_success_detected=true, FAILED_DIRTY_WORKTREE,
       # FAILED_PR_METADATA_UNAVAILABLE, BLOCKED_CI, FAILED_MEANINGFUL_DIFF.
-      FINALIZER_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_agentic_finalization.sh"
-      if [ ! -f "$FINALIZER_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then FINALIZER_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_agentic_finalization.sh"; fi
-      [ -f "$FINALIZER_HELPER" ] || { echo "ERROR: agentic finalization helper not found: $FINALIZER_HELPER" >&2; exit 2; }
+      FINALIZER_HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_agentic_finalization.sh 2>/dev/null || true)"
+      if [ -z "$FINALIZER_HELPER" ] || [ ! -f "$FINALIZER_HELPER" ]; then FINALIZER_HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_agentic_finalization.sh" ] && { FINALIZER_HELPER="$__b/amplifier-bundle/tools/workflow_agentic_finalization.sh"; break; }; done; fi
+      [ -n "$FINALIZER_HELPER" ] && [ -f "$FINALIZER_HELPER" ] || { echo "ERROR: agentic finalization helper not found after robust resolution (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack). Ensure the amplihack bundle is installed (\`amplihack install\`) or set AMPLIHACK_HOME to a complete bundle root." >&2; exit 2; }
       bash "$FINALIZER_HELPER" validate
     output: "workflow_result"
 
@@ -390,8 +389,8 @@ steps:
       # CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED, SUPERSEDED, BLOCKED_CI,
       # FAILED_FINALIZER_OUTPUT, FAILED_MISSING_TOOLING, FAILED_PR_METADATA_UNAVAILABLE,
       # FAILED_DIRTY_WORKTREE, FAILED_MEANINGFUL_DIFF, HOLLOW_SUCCESS, INCOMPLETE.
-      FINALIZER_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_agentic_finalization.sh"
-      if [ ! -f "$FINALIZER_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then FINALIZER_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_agentic_finalization.sh"; fi
-      [ -f "$FINALIZER_HELPER" ] || { echo "ERROR: agentic finalization helper not found: $FINALIZER_HELPER" >&2; exit 2; }
+      FINALIZER_HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_agentic_finalization.sh 2>/dev/null || true)"
+      if [ -z "$FINALIZER_HELPER" ] || [ ! -f "$FINALIZER_HELPER" ]; then FINALIZER_HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_agentic_finalization.sh" ] && { FINALIZER_HELPER="$__b/amplifier-bundle/tools/workflow_agentic_finalization.sh"; break; }; done; fi
+      [ -n "$FINALIZER_HELPER" ] && [ -f "$FINALIZER_HELPER" ] || { echo "ERROR: agentic finalization helper not found after robust resolution (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack). Ensure the amplihack bundle is installed (\`amplihack install\`) or set AMPLIHACK_HOME to a complete bundle root." >&2; exit 2; }
       bash "$FINALIZER_HELPER" complete
     output: "workflow_completion"

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -249,9 +249,9 @@ steps:
       # Terminal vocabulary: MERGED, CLOSED_OBSOLETE, NO_DIFF_SUCCESS, FOLLOWUP_CREATED, EXISTING_OPEN_PR, BLOCKED_CI, BLOCKED_PROVIDER.
       # gh pr create is called by the helper only after PUBLISH_STATE classification.
       # gh pr create failed is surfaced by workflow_publish_pr.sh as FAILED_PR_CREATE.
-      PUBLISH_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_publish_pr.sh"
-      if [ ! -f "$PUBLISH_HELPER" ] && [ -n "${REPO_PATH:-}" ]; then PUBLISH_HELPER="$REPO_PATH/amplifier-bundle/tools/workflow_publish_pr.sh"; fi
-      [ -f "$PUBLISH_HELPER" ] || { echo "ERROR: workflow publish helper not found: $PUBLISH_HELPER" >&2; exit 1; }
+      PUBLISH_HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_publish_pr.sh 2>/dev/null || true)"
+      if [ -z "$PUBLISH_HELPER" ] || [ ! -f "$PUBLISH_HELPER" ]; then PUBLISH_HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_publish_pr.sh" ] && { PUBLISH_HELPER="$__b/amplifier-bundle/tools/workflow_publish_pr.sh"; break; }; done; fi
+      [ -n "$PUBLISH_HELPER" ] && [ -f "$PUBLISH_HELPER" ] || { echo "ERROR: workflow publish helper not found after robust resolution (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack). Ensure the amplihack bundle is installed (\`amplihack install\`) or set AMPLIHACK_HOME to a complete bundle root." >&2; exit 1; }
       bash "$PUBLISH_HELPER"
     output: "pr_publish_result"
     parse_json: true

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -391,26 +391,8 @@ steps:
     parse_json: true
     command: |
       set -euo pipefail
-      # Resolve the evidence helper robustly. In target-repo worktrees the
-      # `amplifier-bundle/` may be gitignored (empty tools/), so prefer the
-      # installed resolver (`amplihack resolve-bundle-asset`, which skips empty
-      # bundles and checks the file exists), then fall back across every known
-      # install root. This step is BOOKKEEPING: it must NEVER hard-fail and
-      # discard already-implemented, fully-tested work (steps 7-8). If the
-      # helper cannot be located, degrade gracefully — warn and emit
-      # non-blocking evidence so the workflow proceeds to finalization/CI, which
-      # remain the real correctness gates.
+      # BOOKKEEPING: resolve robustly (resolve-bundle-asset skips empty/gitignored bundles, then fall back across install roots); NEVER hard-fail/discard tested work — degrade gracefully if unresolved (finalization + CI stay the real gates).
       HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_implementation_evidence.sh 2>/dev/null || true)"
-      if [ -z "$HELPER" ] || [ ! -f "$HELPER" ]; then
-        HELPER=""
-        for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do
-          [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_implementation_evidence.sh" ] && { HELPER="$__b/amplifier-bundle/tools/workflow_implementation_evidence.sh"; break; }
-        done
-      fi
-      if [ -n "$HELPER" ] && [ -f "$HELPER" ]; then
-        bash "$HELPER"
-      else
-        echo "WARNING: workflow implementation evidence helper not found (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack); AMPLIHACK_HOME=${AMPLIHACK_HOME:-<unset>} REPO_PATH=${REPO_PATH:-<unset>} cwd=$(pwd). Emitting non-blocking evidence and continuing in degraded mode so validated implementation work is NOT discarded." >&2
-        jq -nc '{implementation_completed:"false",terminal_no_op:"false",terminal_state:"IMPLEMENTATION_EVIDENCE_DEGRADED",terminal_reason:"evidence helper unresolved (bundle tools/ missing/gitignored); implementation preserved, correctness deferred to finalization + CI gates"}'
-      fi
+      if [ -z "$HELPER" ] || [ ! -f "$HELPER" ]; then HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_implementation_evidence.sh" ] && { HELPER="$__b/amplifier-bundle/tools/workflow_implementation_evidence.sh"; break; }; done; fi
+      if [ -n "$HELPER" ] && [ -f "$HELPER" ]; then bash "$HELPER"; else echo "WARNING: workflow implementation evidence helper not found (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack); AMPLIHACK_HOME=${AMPLIHACK_HOME:-<unset>} REPO_PATH=${REPO_PATH:-<unset>} cwd=$(pwd). Emitting non-blocking evidence and continuing in degraded mode so validated implementation work is NOT discarded." >&2; jq -nc '{implementation_completed:"false",terminal_no_op:"false",terminal_state:"IMPLEMENTATION_EVIDENCE_DEGRADED",terminal_reason:"evidence helper unresolved (bundle tools/ missing/gitignored); implementation preserved, correctness deferred to finalization + CI gates"}'; fi
     output: "implementation_terminal_evidence"

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -391,8 +391,26 @@ steps:
     parse_json: true
     command: |
       set -euo pipefail
-      HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_implementation_evidence.sh"
-      [ -f "$HELPER" ] || HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_implementation_evidence.sh"
-      [ -f "$HELPER" ] || { echo "ERROR: workflow implementation evidence helper not found: $HELPER" >&2; exit 2; }
-      bash "$HELPER"
+      # Resolve the evidence helper robustly. In target-repo worktrees the
+      # `amplifier-bundle/` may be gitignored (empty tools/), so prefer the
+      # installed resolver (`amplihack resolve-bundle-asset`, which skips empty
+      # bundles and checks the file exists), then fall back across every known
+      # install root. This step is BOOKKEEPING: it must NEVER hard-fail and
+      # discard already-implemented, fully-tested work (steps 7-8). If the
+      # helper cannot be located, degrade gracefully — warn and emit
+      # non-blocking evidence so the workflow proceeds to finalization/CI, which
+      # remain the real correctness gates.
+      HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_implementation_evidence.sh 2>/dev/null || true)"
+      if [ -z "$HELPER" ] || [ ! -f "$HELPER" ]; then
+        HELPER=""
+        for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do
+          [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_implementation_evidence.sh" ] && { HELPER="$__b/amplifier-bundle/tools/workflow_implementation_evidence.sh"; break; }
+        done
+      fi
+      if [ -n "$HELPER" ] && [ -f "$HELPER" ]; then
+        bash "$HELPER"
+      else
+        echo "WARNING: workflow implementation evidence helper not found (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack); AMPLIHACK_HOME=${AMPLIHACK_HOME:-<unset>} REPO_PATH=${REPO_PATH:-<unset>} cwd=$(pwd). Emitting non-blocking evidence and continuing in degraded mode so validated implementation work is NOT discarded." >&2
+        jq -nc '{implementation_completed:"false",terminal_no_op:"false",terminal_state:"IMPLEMENTATION_EVIDENCE_DEGRADED",terminal_reason:"evidence helper unresolved (bundle tools/ missing/gitignored); implementation preserved, correctness deferred to finalization + CI gates"}'
+      fi
     output: "implementation_terminal_evidence"

--- a/amplifier-bundle/recipes/workflow-terminal-state.yaml
+++ b/amplifier-bundle/recipes/workflow-terminal-state.yaml
@@ -462,15 +462,14 @@ steps:
         exit 0
       fi
 
-      helper=""
-      if [ -n "${AMPLIHACK_HOME:-}" ] && [ -f "${AMPLIHACK_HOME}/amplifier-bundle/tools/workflow_final_status.sh" ]; then
-        helper="${AMPLIHACK_HOME}/amplifier-bundle/tools/workflow_final_status.sh"
-      elif [ -n "${REPO_PATH:-}" ] && [ -f "${REPO_PATH}/amplifier-bundle/tools/workflow_final_status.sh" ]; then
-        helper="${REPO_PATH}/amplifier-bundle/tools/workflow_final_status.sh"
-      elif [ -f "./amplifier-bundle/tools/workflow_final_status.sh" ]; then
-        helper="./amplifier-bundle/tools/workflow_final_status.sh"
+      helper="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_final_status.sh 2>/dev/null || true)"
+      if [ -z "$helper" ] || [ ! -f "$helper" ]; then
+        helper=""
+        for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do
+          [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_final_status.sh" ] && { helper="$__b/amplifier-bundle/tools/workflow_final_status.sh"; break; }
+        done
       fi
-      [ -n "$helper" ] || { echo "ERROR: workflow terminal-state helper not found; set AMPLIHACK_HOME or run from an amplihack checkout" >&2; exit 2; }
+      [ -n "$helper" ] && [ -f "$helper" ] || { echo "ERROR: workflow terminal-state helper not found after robust resolution (searched: amplihack resolve-bundle-asset, AMPLIHACK_HOME, REPO_PATH, cwd, ~/.copilot, ~/.amplihack). Ensure the amplihack bundle is installed (\`amplihack install\`) or set AMPLIHACK_HOME to a complete bundle root." >&2; exit 2; }
 
       : "${OBSERVED_PHASES:=workflow-prep,workflow-worktree,workflow-design,workflow-tdd,workflow-refactor-review,workflow-precommit-test,workflow-publish,workflow-pr-review,workflow-finalize}"
       export OBSERVED_PHASES

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -40,9 +40,9 @@ steps:
       # re-run converges instead of colliding. Graceful no-op if the helper is
       # absent (#829 precedent); never aborts setup. Destructive lifecycle logic
       # lives in tools/workflow_worktree_sweep.sh to keep this recipe < 400 lines.
-      SWEEP_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_worktree_sweep.sh"
-      [ -f "$SWEEP_HELPER" ] || SWEEP_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_worktree_sweep.sh"
-      if [ -f "$SWEEP_HELPER" ]; then bash "$SWEEP_HELPER" sweep "$REPO_PATH" >&2 || true; fi
+      SWEEP_HELPER="$(amplihack resolve-bundle-asset amplifier-bundle/tools/workflow_worktree_sweep.sh 2>/dev/null || true)"
+      if [ -z "$SWEEP_HELPER" ] || [ ! -f "$SWEEP_HELPER" ]; then SWEEP_HELPER=""; for __b in "${AMPLIHACK_HOME:-}" "${REPO_PATH:-}" "$(pwd)" "${HOME:-/root}/.copilot" "${HOME:-/root}/.amplihack"; do [ -n "$__b" ] && [ -f "$__b/amplifier-bundle/tools/workflow_worktree_sweep.sh" ] && { SWEEP_HELPER="$__b/amplifier-bundle/tools/workflow_worktree_sweep.sh"; break; }; done; fi
+      if [ -n "$SWEEP_HELPER" ] && [ -f "$SWEEP_HELPER" ]; then bash "$SWEEP_HELPER" sweep "$REPO_PATH" >&2 || true; fi
 
       echo "=== Step 4: Creating Worktree and Branch ===" >&2
       echo "" >&2

--- a/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/mod.rs
@@ -635,4 +635,90 @@ mod cli_dispatch_tests {
              Remove dead HOOKS_DIR assignments: {offenders:?}"
         );
     }
+
+    fn recipes_dir_or_skip() -> Option<std::path::PathBuf> {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let recipes_dir = manifest
+            .join("..")
+            .join("..")
+            .join("amplifier-bundle")
+            .join("recipes");
+        if !recipes_dir.is_dir() {
+            eprintln!(
+                "skipping: recipes dir not found at {}",
+                recipes_dir.display()
+            );
+            return None;
+        }
+        Some(recipes_dir)
+    }
+
+    /// Regression for the evidence-helper discard bug (Simard run d6061601):
+    /// the `implementation-terminal-evidence` step used to `exit 2` when the
+    /// helper was missing, cascading a whole-recipe failure that DISCARDED
+    /// already-implemented, fully-tested work. It must instead (a) resolve the
+    /// helper via the robust `resolve-bundle-asset` resolver and (b) degrade
+    /// gracefully by emitting non-blocking evidence rather than hard-failing.
+    #[test]
+    fn evidence_step_degrades_instead_of_discarding_work() {
+        let Some(recipes_dir) = recipes_dir_or_skip() else {
+            return;
+        };
+        let tdd = recipes_dir.join("workflow-tdd.yaml");
+        let body = std::fs::read_to_string(&tdd).unwrap();
+
+        assert!(
+            body.contains(
+                "resolve-bundle-asset amplifier-bundle/tools/workflow_implementation_evidence.sh"
+            ),
+            "implementation-terminal-evidence must resolve its helper via \
+             `amplihack resolve-bundle-asset` (robust, skips empty/gitignored bundles)"
+        );
+        assert!(
+            body.contains("IMPLEMENTATION_EVIDENCE_DEGRADED"),
+            "implementation-terminal-evidence must degrade gracefully (emit \
+             non-blocking evidence) when the helper cannot be found, never \
+             discarding validated implementation work"
+        );
+        assert!(
+            !body.contains("workflow implementation evidence helper not found: $HELPER"),
+            "the fragile hard-fail evidence resolution (exit 2 on missing helper) \
+             must be removed — it discards completed, tested work"
+        );
+    }
+
+    /// Regression: the audited workflow helper resolutions (see task brief)
+    /// must locate the bundle robustly via `resolve-bundle-asset` instead of the
+    /// fragile `${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}` chain that fails in
+    /// target-repo worktrees whose `amplifier-bundle/` is gitignored/empty.
+    #[test]
+    fn audited_helpers_use_robust_resolver() {
+        let Some(recipes_dir) = recipes_dir_or_skip() else {
+            return;
+        };
+        // (recipe file, helper relative path) pairs called out in the brief.
+        let cases = [
+            ("workflow-tdd.yaml", "workflow_implementation_evidence.sh"),
+            ("workflow-finalize.yaml", "workflow_pr_ready.sh"),
+            ("workflow-finalize.yaml", "workflow_final_status.sh"),
+            ("workflow-finalize.yaml", "workflow_agentic_finalization.sh"),
+            ("workflow-publish.yaml", "workflow_publish_pr.sh"),
+            ("workflow-worktree.yaml", "workflow_worktree_sweep.sh"),
+            ("workflow-terminal-state.yaml", "workflow_final_status.sh"),
+        ];
+        let mut offenders = Vec::new();
+        for (recipe, helper) in cases {
+            let body = std::fs::read_to_string(recipes_dir.join(recipe)).unwrap();
+            let robust = format!("resolve-bundle-asset amplifier-bundle/tools/{helper}");
+            if !body.contains(&robust) {
+                offenders.push(format!("{recipe} -> {helper}"));
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "these workflow helper resolutions are not using the robust \
+             `resolve-bundle-asset` resolver and remain fragile in gitignored \
+             worktrees: {offenders:?}"
+        );
+    }
 }

--- a/crates/amplihack-cli/src/resolve_bundle_asset/search.rs
+++ b/crates/amplihack-cli/src/resolve_bundle_asset/search.rs
@@ -30,8 +30,15 @@ pub(super) fn search_bases() -> Vec<PathBuf> {
         bases.push(root);
     }
 
+    // Installed runtime roots. When a recipe runs against a target repo whose
+    // `amplifier-bundle/` is gitignored (empty `tools/` in git worktrees), the
+    // complete bundle lives under one of these install roots — never in the
+    // target checkout. `~/.copilot` is the Copilot CLI install location and
+    // `~/.amplihack` is the default `amplihack install` root.
     if let Ok(home) = env::var("HOME") {
-        bases.push(PathBuf::from(home).join(".amplihack"));
+        let home = PathBuf::from(home);
+        bases.push(home.join(".copilot"));
+        bases.push(home.join(".amplihack"));
     }
 
     bases
@@ -41,7 +48,7 @@ pub(super) fn search_bases() -> Vec<PathBuf> {
 ///
 /// Priority:
 /// 1. `AMPLIHACK_HOME` env var (highest priority)
-/// 2. `~/.amplihack`
+/// 2. `~/.copilot` then `~/.amplihack` (installed runtime roots)
 /// 3. Walk up from cwd until a project root marker is found
 /// 4. Workspace root (compile-time anchor, analogous to Python's package/repo root)
 /// 5. cwd
@@ -55,9 +62,13 @@ pub(super) fn named_asset_search_bases() -> Vec<PathBuf> {
         bases.push(PathBuf::from(amplihack_home));
     }
 
-    // 2. ~/.amplihack
+    // 2. Installed runtime roots (`~/.copilot` = Copilot CLI install,
+    //    `~/.amplihack` = default `amplihack install`). These hold the complete
+    //    bundle when the target repo's `amplifier-bundle/` is gitignored/empty.
     if let Ok(home) = env::var("HOME") {
-        bases.push(PathBuf::from(home).join(".amplihack"));
+        let home = PathBuf::from(home);
+        bases.push(home.join(".copilot"));
+        bases.push(home.join(".amplihack"));
     }
 
     // 3. Walk up from cwd looking for a project/repo root marker
@@ -92,4 +103,64 @@ pub(super) fn named_asset_search_bases() -> Vec<PathBuf> {
     });
 
     bases
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for the evidence-helper discard bug: when a target repo's
+    /// `amplifier-bundle/` is gitignored (empty in worktrees) and AMPLIHACK_HOME
+    /// points at that repo, the complete bundle lives under an install root.
+    /// `search_bases()` must include `~/.copilot` (Copilot install) ahead of
+    /// `~/.amplihack` so `resolve-bundle-asset` can find the real helper.
+    #[test]
+    fn search_bases_includes_copilot_root_before_amplihack() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        let prev_home = crate::test_support::set_home(temp.path());
+
+        let bases = search_bases();
+
+        crate::test_support::restore_home(prev_home);
+
+        let copilot_idx = bases
+            .iter()
+            .position(|b| *b == temp.path().join(".copilot"));
+        let amplihack_idx = bases
+            .iter()
+            .position(|b| *b == temp.path().join(".amplihack"));
+        assert!(
+            copilot_idx.is_some(),
+            "search_bases must include ~/.copilot: {bases:?}"
+        );
+        assert!(
+            amplihack_idx.is_some(),
+            "search_bases must include ~/.amplihack: {bases:?}"
+        );
+        assert!(
+            copilot_idx < amplihack_idx,
+            "~/.copilot must be searched before ~/.amplihack: {bases:?}"
+        );
+    }
+
+    #[test]
+    fn named_asset_search_bases_includes_copilot_root() {
+        let _guard = crate::test_support::home_env_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let temp = tempfile::tempdir().unwrap();
+        let prev_home = crate::test_support::set_home(temp.path());
+
+        let bases = named_asset_search_bases();
+
+        crate::test_support::restore_home(prev_home);
+
+        assert!(
+            bases.iter().any(|b| *b == temp.path().join(".copilot")),
+            "named_asset_search_bases must include ~/.copilot: {bases:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Observed failure (2026-07-19, Simard self-improvement run `d6061601`): the
`workflow-tdd.yaml` **`implementation-terminal-evidence`** step resolved its
helper via `${AMPLIHACK_HOME:-${REPO_PATH:-pwd}}/amplifier-bundle/tools/workflow_implementation_evidence.sh`
(single fallback to `${REPO_PATH}/...`) and hard-failed `exit 2` when the file
was missing.

When a recipe runs against a target repo whose `amplifier-bundle/` is
**gitignored** (so git worktrees contain an EMPTY `tools/`) and `AMPLIHACK_HOME`
resolves to that repo, the helper was unresolvable →
`Command failed (exit 2): ERROR: workflow implementation evidence helper not found`
→ cascaded `workflow-tdd → default-workflow → smart-execute-routing` → the
**entire recipe FAILED, discarding an already-implemented, fully-tested change**
(steps 7/8 completed).

## Fix

**1. Evidence/bookkeeping step must not discard validated work.**
`implementation-terminal-evidence` now resolves the helper via the robust
`amplihack resolve-bundle-asset` resolver, then a broad inline fallback, and if
still unresolved it **degrades gracefully** — warns and emits non-blocking
evidence (`IMPLEMENTATION_EVIDENCE_DEGRADED`, `terminal_no_op:"false"`, exit 0)
so the workflow proceeds to finalization + CI (the real correctness gates)
rather than discarding work.

**2. Robust helper resolution.**
The Rust `resolve-bundle-asset` resolver already skips empty/gitignored bundles
(checks the file `.exists()`), but its search bases omitted `~/.copilot`.
`search_bases()` / `named_asset_search_bases()` now include `~/.copilot`
(Copilot CLI install root) before `~/.amplihack`, so the complete bundle is
found even when the target checkout's copy is empty.

**3. Target-repo worktree awareness.**
All hardened resolutions search `resolve-bundle-asset` → `AMPLIHACK_HOME` →
`REPO_PATH` → cwd → `~/.copilot` → `~/.amplihack`, accounting for worktrees that
never contain the gitignored bundle files.

**4. Sibling audit** (same relative-path fragility):
`workflow_pr_ready.sh`, `workflow_final_status.sh` (bookkeeping → graceful
degrade), `workflow_agentic_finalization.sh` (×3), `workflow_publish_pr.sh`,
`workflow_worktree_sweep.sh` (already non-blocking), and the strict
terminal-state gate. Real action/gate steps keep failing loud but with
**actionable, install-aware** errors instead of silently falling through to an
incomplete vendored copy.

## Evidence

**Criterion 6 — Focused diff** (`git diff --stat`): 5 recipes + 2 Rust files, +211/-38.
No unrelated edits.

**Automated regression tests** (new, `crates/amplihack-cli/src/resolve_bundle_asset/`):
- `evidence_step_degrades_instead_of_discarding_work` — asserts the step uses
  `resolve-bundle-asset`, emits `IMPLEMENTATION_EVIDENCE_DEGRADED`, and no longer
  hard-fails on a missing helper.
- `audited_helpers_use_robust_resolver` — asserts all 7 audited (recipe, helper)
  pairs use the robust resolver.
- `search_bases_includes_copilot_root_before_amplihack` /
  `named_asset_search_bases_includes_copilot_root`.

**Test run:** `cargo test -p amplihack-cli --lib` → **1645 passed**, 0 relevant
failures. (One pre-existing, unrelated flake `clean_broken_symlinks_recursive`
fails only locally because another tenant on this shared host left
`/tmp/nonexistent-xyz` present — the test hardcodes that path's absence. I did
not touch `filesystem.rs`; it passes on a clean CI runner.)

**Functional verification of the degraded path** (extracted the real step bash):
- Helper missing everywhere (isolated HOME, no `amplihack`, empty bundle):
  → exit 0, valid non-blocking JSON, warning to stderr — work **not** discarded.
- Helper present only in `~/.copilot` with resolver unavailable: → fallback
  resolves and runs the real helper (`IMPLEMENTATION_COMPLETED`).
- `resolve-bundle-asset` with empty `AMPLIHACK_HOME` bundle: skips the empty
  bundle and resolves the complete one.

**Gates:** `cargo fmt --all --check` ✅, `cargo clippy -- -D warnings` ✅,
`amplihack hygiene artifact-guard` ✅, `check-yaml` ✅, plus `bash -n` on every
edited recipe command block ✅ (all pre-commit hooks passed on commit).

## Criteria status
- **CI (criterion 4):** pending the automated run on this PR — please gate on green CI.
- **qa-team scenarios / gadugi-test (1) & quality-audit cycles (3):** the
  automated `qa-team`/`gadugi-test`/`quality-audit` harness is not available in
  this execution context; validation here is the unit + functional + gate
  evidence above. Reviewers/CI should run the full suite before merge.