### PR TITLE
fix(artifact-guard): exempt the entire .claude/runtime/ subtree

### DIFF
--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -247,11 +247,6 @@ const DEFAULT_RULES: &[ArtifactRule] = &[
         remediation: REMEDIATION,
     },
     ArtifactRule {
-        id: "claude-runtime",
-        description: "Claude runtime state",
-        remediation: REMEDIATION,
-    },
-    ArtifactRule {
         id: "nested-worktree",
         description: "Nested worktree under parent repository",
         remediation: REMEDIATION,
@@ -556,33 +551,31 @@ fn add_violation_if_prohibited(
     }
 }
 
-/// Runtime bookkeeping files that the amplihack launcher and session tracker
-/// write into `<repo>/.claude/runtime/` as a normal, unavoidable part of
-/// launching an agent. They live under the path the `claude-runtime` rule
-/// otherwise blocks, but they are the launcher's OWN state — not leftover agent
-/// pollution — so the guard must never flag them. Treating them as violations
-/// turned a clean end-of-run guard step into a hard failure (issue #807), which
-/// in turn left `recipe-runner-rs` and its child agents hung after the work was
-/// already committed and pushed.
+/// The `<repo>/.claude/runtime/` subtree holds runtime bookkeeping that the
+/// amplihack launcher, session tracker, and *every* agent's PostToolUse metrics
+/// hook write continuously as a normal, unavoidable part of launching and
+/// running an agent: launcher context, session logs, metrics
+/// (`metrics/post_tool_use_metrics.jsonl`), locks, and power-steering state all
+/// land here while a recipe runs. The entire subtree is `.gitignore`d,
+/// tool-generated, and outside the author's control.
 ///
-/// The exemption is intentionally narrow: only these specific launcher-owned
-/// files are exempt. Everything else under `.claude/runtime/` (session logs,
-/// metrics, locks, power-steering state, stray runtime output) is still blocked
-/// so the guard keeps catching genuine runtime pollution. Paths mirror
-/// `amplihack_types::ProjectDirs::launcher_context_file` and `sessions_log_file`.
-const LAUNCHER_OWNED_RUNTIME_FILES: &[&str] = &[
-    ".claude/runtime/launcher_context.json",
-    ".claude/runtime/sessions.jsonl",
-];
-
-/// Whether `path` is a launcher-owned runtime bookkeeping file that the guard
-/// must never treat as a prohibited artifact. See [`LAUNCHER_OWNED_RUNTIME_FILES`].
-fn is_launcher_owned_runtime_file(path: &str) -> bool {
-    LAUNCHER_OWNED_RUNTIME_FILES.contains(&path)
+/// The guard must never treat anything under `.claude/runtime/` as a prohibited
+/// artifact. Flagging it turned a clean end-of-run guard step into a hard
+/// failure (issue #807 — and again when it blocked the metrics file that agents
+/// append to on every tool call), which left `recipe-runner-rs` and its child
+/// agents hung *after* the work was already committed and pushed, discarding
+/// completed recipe work. Because the subtree is gitignored, an
+/// `.amplihack-artifact-allowlist` entry cannot rescue it either
+/// (`.claude/runtime` is a root-prohibited broad exemption; see
+/// [`is_root_prohibited_exemption`]), so the whole tree is exempted here at the
+/// source. Genuine runtime pollution outside `.claude/runtime/` (node_modules,
+/// build artifacts, nested worktrees, caches) is still blocked.
+fn is_exempt_claude_runtime_path(path: &str) -> bool {
+    path == ".claude/runtime" || path.starts_with(".claude/runtime/")
 }
 
 fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static ArtifactRule> {
-    if is_launcher_owned_runtime_file(path) {
+    if is_exempt_claude_runtime_path(path) {
         return None;
     }
     if path_has_component(path, "node_modules") {
@@ -590,9 +583,6 @@ fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static Artifact
     }
     if path == "dist/plugin.js" || path.ends_with("/dist/plugin.js") {
         return rule("plugin-bundle");
-    }
-    if path == ".claude/runtime" || path.starts_with(".claude/runtime/") {
-        return rule("claude-runtime");
     }
     if path == "worktrees" || path.starts_with("worktrees/") {
         return rule("nested-worktree");

--- a/crates/amplihack-utils/src/artifact_guard.rs
+++ b/crates/amplihack-utils/src/artifact_guard.rs
@@ -247,6 +247,11 @@ const DEFAULT_RULES: &[ArtifactRule] = &[
         remediation: REMEDIATION,
     },
     ArtifactRule {
+        id: "claude-runtime",
+        description: "Claude runtime state",
+        remediation: REMEDIATION,
+    },
+    ArtifactRule {
         id: "nested-worktree",
         description: "Nested worktree under parent repository",
         remediation: REMEDIATION,
@@ -551,31 +556,63 @@ fn add_violation_if_prohibited(
     }
 }
 
-/// The `<repo>/.claude/runtime/` subtree holds runtime bookkeeping that the
-/// amplihack launcher, session tracker, and *every* agent's PostToolUse metrics
-/// hook write continuously as a normal, unavoidable part of launching and
-/// running an agent: launcher context, session logs, metrics
-/// (`metrics/post_tool_use_metrics.jsonl`), locks, and power-steering state all
-/// land here while a recipe runs. The entire subtree is `.gitignore`d,
-/// tool-generated, and outside the author's control.
+/// The two runtime bookkeeping files the amplihack launcher and session tracker
+/// force into `<repo>/.claude/runtime/` as part of every launch. These are the
+/// launcher's OWN state and are exempt in *every* git source (including staged),
+/// because the launcher itself may stage them and flagging them turned the
+/// end-of-run guard into a hang (issue #807). The rest of the runtime tree is
+/// handled by [`is_claude_runtime_path`], which is exempt only for the
+/// untracked/ignored-present output that recipes unavoidably produce.
+const LAUNCHER_OWNED_RUNTIME_FILES: &[&str] = &[
+    ".claude/runtime/launcher_context.json",
+    ".claude/runtime/sessions.jsonl",
+];
+
+/// Whether `path` is one of the launcher-owned bookkeeping files exempt in all
+/// git sources. See [`LAUNCHER_OWNED_RUNTIME_FILES`].
+fn is_launcher_owned_runtime_file(path: &str) -> bool {
+    LAUNCHER_OWNED_RUNTIME_FILES.contains(&path)
+}
+
+/// Whether `path` is the `.claude/runtime` directory or anything beneath it.
 ///
-/// The guard must never treat anything under `.claude/runtime/` as a prohibited
-/// artifact. Flagging it turned a clean end-of-run guard step into a hard
-/// failure (issue #807 — and again when it blocked the metrics file that agents
-/// append to on every tool call), which left `recipe-runner-rs` and its child
-/// agents hung *after* the work was already committed and pushed, discarding
-/// completed recipe work. Because the subtree is gitignored, an
+/// The whole `<repo>/.claude/runtime/` subtree is runtime bookkeeping that the
+/// launcher, session tracker, and *every* agent's PostToolUse metrics hook write
+/// continuously as a normal, unavoidable part of running an agent: session logs,
+/// metrics (`metrics/post_tool_use_metrics.jsonl`, appended on every tool call),
+/// locks, and power-steering state. This tree is `.gitignore`d and tool-generated.
+///
+/// The guard exempts it — but only when it appears as **untracked or
+/// ignored-present** output (see [`rule_for_path`]). Flagging that output turned
+/// the clean end-of-run guard step into a hard failure (issue #807 — and again
+/// when it blocked the metrics file), which left `recipe-runner-rs` and its
+/// child agents hung *after* the work was already committed and pushed,
+/// discarding completed recipe work. Because the subtree is gitignored, an
 /// `.amplihack-artifact-allowlist` entry cannot rescue it either
 /// (`.claude/runtime` is a root-prohibited broad exemption; see
-/// [`is_root_prohibited_exemption`]), so the whole tree is exempted here at the
-/// source. Genuine runtime pollution outside `.claude/runtime/` (node_modules,
-/// build artifacts, nested worktrees, caches) is still blocked.
-fn is_exempt_claude_runtime_path(path: &str) -> bool {
+/// [`is_root_prohibited_exemption`]).
+///
+/// A **staged or tracked** `.claude/runtime/` path is not covered by this
+/// exemption: deliberately committing runtime state into the published tree is
+/// genuine pollution and is still blocked as `claude-runtime`.
+fn is_claude_runtime_path(path: &str) -> bool {
     path == ".claude/runtime" || path.starts_with(".claude/runtime/")
 }
 
 fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static ArtifactRule> {
-    if is_exempt_claude_runtime_path(path) {
+    // Launcher-owned bookkeeping is exempt regardless of git source.
+    if is_launcher_owned_runtime_file(path) {
+        return None;
+    }
+    // The rest of the runtime tree is exempt only as the untracked/ignored
+    // output every recipe unavoidably produces; staged/tracked runtime state
+    // still falls through to the `claude-runtime` block below.
+    if is_claude_runtime_path(path)
+        && matches!(
+            source,
+            ArtifactSource::Untracked | ArtifactSource::IgnoredPresent
+        )
+    {
         return None;
     }
     if path_has_component(path, "node_modules") {
@@ -583,6 +620,9 @@ fn rule_for_path(path: &str, source: ArtifactSource) -> Option<&'static Artifact
     }
     if path == "dist/plugin.js" || path.ends_with("/dist/plugin.js") {
         return rule("plugin-bundle");
+    }
+    if is_claude_runtime_path(path) {
+        return rule("claude-runtime");
     }
     if path == "worktrees" || path.starts_with("worktrees/") {
         return rule("nested-worktree");

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -148,14 +148,15 @@ fn ignored_present_dist_plugin_runtime_and_cache_artifacts_are_blocked() {
 }
 
 #[test]
-fn entire_claude_runtime_subtree_is_exempt() {
+fn claude_runtime_subtree_is_exempt_when_untracked_or_ignored() {
     // Regression for issue #807 and the recurrence that blocked
     // `.claude/runtime/metrics/post_tool_use_metrics.jsonl`: the amplihack
     // launcher, session tracker, and every agent's PostToolUse metrics hook
     // write bookkeeping into `<repo>/.claude/runtime/` continuously while a
-    // recipe runs. The whole subtree is gitignored, tool-generated, and outside
-    // the author's control, so the guard must never flag any of it — otherwise
-    // the end-of-run guard step hard-fails and discards already-committed work.
+    // recipe runs. That output is unavoidable, gitignored, tool-generated
+    // runtime state, so the guard must never flag it as untracked or
+    // ignored-present — otherwise the end-of-run guard step hard-fails and
+    // discards already-committed work.
     let tmp = repo();
     write_file(&tmp.path().join(".gitignore"), ".claude/runtime/\n");
     run_git(tmp.path(), &["add", ".gitignore"]);
@@ -178,10 +179,69 @@ fn entire_claude_runtime_subtree_is_exempt() {
     for rel in runtime_paths {
         assert!(
             !report.violations.iter().any(|v| v.path == rel),
-            "{rel} under .claude/runtime/ must be exempt; got {:#?}",
+            "{rel} under .claude/runtime/ must be exempt when untracked/ignored; got {:#?}",
             report.violations
         );
     }
+}
+
+#[test]
+fn staged_or_tracked_claude_runtime_state_is_still_blocked() {
+    // The subtree exemption covers only the untracked/ignored output recipes
+    // unavoidably produce. Deliberately committing runtime state into the
+    // published tree is genuine pollution and must still fail the guard — except
+    // the two launcher-owned bookkeeping files, which are exempt in all sources.
+    let tmp = repo();
+    write_file(&tmp.path().join(".gitignore"), ".claude/runtime/\n");
+    run_git(tmp.path(), &["add", ".gitignore"]);
+    run_git(tmp.path(), &["commit", "-qm", "ignore claude runtime"]);
+
+    // Force-stage a non-launcher runtime file past .gitignore.
+    write_file(
+        &tmp.path()
+            .join(".claude/runtime/metrics/post_tool_use_metrics.jsonl"),
+        "{}\n",
+    );
+    run_git(
+        tmp.path(),
+        &[
+            "add",
+            "-f",
+            ".claude/runtime/metrics/post_tool_use_metrics.jsonl",
+        ],
+    );
+    // Launcher-owned file, also force-staged: exempt in all sources.
+    write_file(
+        &tmp.path().join(".claude/runtime/launcher_context.json"),
+        "{}\n",
+    );
+    run_git(
+        tmp.path(),
+        &["add", "-f", ".claude/runtime/launcher_context.json"],
+    );
+
+    let report = scan_artifacts(
+        &ArtifactGuardConfig::new(tmp.path()).with_mode(ArtifactGuardMode::PrePublish),
+    )
+    .expect("scan artifacts");
+
+    let blocked = violation_for(
+        &report.violations,
+        ".claude/runtime/metrics/post_tool_use_metrics.jsonl",
+        ArtifactSource::Staged,
+    );
+    assert_eq!(
+        blocked.rule_id, "claude-runtime",
+        "staged runtime state must still be blocked as claude-runtime"
+    );
+    assert!(
+        !report
+            .violations
+            .iter()
+            .any(|v| v.path == ".claude/runtime/launcher_context.json"),
+        "launcher-owned bookkeeping must stay exempt even when staged; got {:#?}",
+        report.violations
+    );
 }
 
 #[test]

--- a/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
+++ b/crates/amplihack-utils/src/tests/artifact_guard_tests.rs
@@ -127,7 +127,6 @@ fn ignored_present_dist_plugin_runtime_and_cache_artifacts_are_blocked() {
 
     for (path, rule_id) in [
         ("dist/plugin.js", "plugin-bundle"),
-        (".claude/runtime/session.json", "claude-runtime"),
         (".next/cache/webpack/index.bin", "cache-artifact"),
     ] {
         let violation = violation_for(&report.violations, path, ArtifactSource::IgnoredPresent);
@@ -136,53 +135,51 @@ fn ignored_present_dist_plugin_runtime_and_cache_artifacts_are_blocked() {
             "{path} must be classified by the expected rule"
         );
     }
+    // The entire `.claude/runtime/` subtree is tool-generated launcher/agent
+    // bookkeeping and must never be flagged, even when ignored-but-present.
+    assert!(
+        !report
+            .violations
+            .iter()
+            .any(|v| v.path == ".claude/runtime/session.json"),
+        ".claude/runtime/session.json must be exempt; got {:#?}",
+        report.violations
+    );
 }
 
 #[test]
-fn launcher_owned_runtime_files_are_exempt_while_other_runtime_state_is_blocked() {
-    // Regression for issue #807: the amplihack launcher writes its own
-    // bookkeeping into `<repo>/.claude/runtime/` as part of every launch. The
-    // guard must not flag those launcher-owned files (which turned the
-    // end-of-run guard step into a hang), but must still block genuine runtime
-    // pollution under the same directory.
+fn entire_claude_runtime_subtree_is_exempt() {
+    // Regression for issue #807 and the recurrence that blocked
+    // `.claude/runtime/metrics/post_tool_use_metrics.jsonl`: the amplihack
+    // launcher, session tracker, and every agent's PostToolUse metrics hook
+    // write bookkeeping into `<repo>/.claude/runtime/` continuously while a
+    // recipe runs. The whole subtree is gitignored, tool-generated, and outside
+    // the author's control, so the guard must never flag any of it — otherwise
+    // the end-of-run guard step hard-fails and discards already-committed work.
     let tmp = repo();
     write_file(&tmp.path().join(".gitignore"), ".claude/runtime/\n");
     run_git(tmp.path(), &["add", ".gitignore"]);
     run_git(tmp.path(), &["commit", "-qm", "ignore claude runtime"]);
 
-    // Launcher-owned bookkeeping (exempt).
-    write_file(
-        &tmp.path().join(".claude/runtime/launcher_context.json"),
-        "{}\n",
-    );
-    write_file(&tmp.path().join(".claude/runtime/sessions.jsonl"), "{}\n");
-    // Genuine runtime pollution under the same directory (still blocked).
-    write_file(&tmp.path().join(".claude/runtime/session.json"), "{}\n");
-    write_file(
-        &tmp.path().join(".claude/runtime/metrics/tool.json"),
-        "{}\n",
-    );
+    let runtime_paths = [
+        ".claude/runtime/launcher_context.json",
+        ".claude/runtime/sessions.jsonl",
+        ".claude/runtime/session.json",
+        ".claude/runtime/metrics/tool.json",
+        ".claude/runtime/metrics/post_tool_use_metrics.jsonl",
+        ".claude/runtime/locks/power_steering.lock",
+    ];
+    for rel in runtime_paths {
+        write_file(&tmp.path().join(rel), "{}\n");
+    }
 
     let report = scan_artifacts(&default_config(tmp.path())).expect("scan artifacts");
 
-    for exempt in [
-        ".claude/runtime/launcher_context.json",
-        ".claude/runtime/sessions.jsonl",
-    ] {
+    for rel in runtime_paths {
         assert!(
-            !report.violations.iter().any(|v| v.path == exempt),
-            "launcher-owned runtime file {exempt} must be exempt; got {:#?}",
+            !report.violations.iter().any(|v| v.path == rel),
+            "{rel} under .claude/runtime/ must be exempt; got {:#?}",
             report.violations
-        );
-    }
-    for blocked in [
-        ".claude/runtime/session.json",
-        ".claude/runtime/metrics/tool.json",
-    ] {
-        let violation = violation_for(&report.violations, blocked, ArtifactSource::IgnoredPresent);
-        assert_eq!(
-            violation.rule_id, "claude-runtime",
-            "{blocked} must still be blocked as claude-runtime"
         );
     }
 }

--- a/docs/artifact-guard.md
+++ b/docs/artifact-guard.md
@@ -144,7 +144,7 @@ Artifact Guard blocked 3 prohibited artifact paths.
 source           path                  rule
 staged           dist/plugin.js        plugin-bundle
 ignored-present  node_modules/         dependency-tree
-untracked        .claude/runtime/      claude-runtime
+untracked        .cache/               cache-artifact
 
 Remediation:
   - Move generated, plugin, cache, and runtime output into an isolated directory.
@@ -171,7 +171,7 @@ repository worktree:
 | --- | --- | --- |
 | Dependency trees | `node_modules/`, `packages/*/node_modules/` | Blocked in `worktree`/`all` only |
 | Plugin bundles | `dist/plugin.js`, `*/dist/plugin.js` | Blocked in `worktree`/`all` only |
-| Claude runtime | `.claude/runtime/` | Blocked in `worktree`/`all` only (except launcher-owned bookkeeping — see below) |
+| Claude runtime | `.claude/runtime/` | Exempt as untracked/ignored-present; blocked only when **staged or tracked** (except the launcher-owned files — see below) |
 | Nested worktrees | `worktrees/` | Blocked in `worktree`/`all` only |
 | Cache directories | `.cache/`, `.npm/`, `.pnpm-store/`, `.yarn/cache/`, `.turbo/`, `.parcel-cache/`, `.pytest_cache/` | Blocked in `worktree`/`all` only |
 | Build output | `dist/`, `build/`, `coverage/`, `.next/`, `out/`, `logs/`, `outputs/`, `index.scip` | Blocked in `worktree`/`all` only |
@@ -190,26 +190,43 @@ Rules match normalized repo-relative paths using `/` separators. The guard does
 not need to read artifact file contents; path-level scanning is the intended
 contract.
 
-### Built-in launcher exemptions
+### Built-in `.claude/runtime/` exemption
 
-The amplihack launcher and session tracker write a small set of bookkeeping
-files into `<repo>/.claude/runtime/` as a normal, unavoidable part of launching
-an agent. These files are the launcher's own state, not leftover agent
-pollution, so the guard never flags them even though they sit under the
-otherwise-blocked `.claude/runtime/` tree:
+The amplihack launcher, session tracker, and every agent's PostToolUse metrics
+hook write bookkeeping into `<repo>/.claude/runtime/` continuously as a normal,
+unavoidable part of launching and running an agent: launcher context, session
+logs, metrics (`metrics/post_tool_use_metrics.jsonl`, appended on every tool
+call), locks, and power-steering state all land here while a recipe runs. This
+subtree is `.gitignore`d, tool-generated runtime state.
 
-| Exempt path | Writer |
-| --- | --- |
-| `.claude/runtime/launcher_context.json` | Launcher / hooks (adaptive launcher detection) |
-| `.claude/runtime/sessions.jsonl` | Session tracker (nesting detection) |
+The guard exempts the whole `.claude/runtime/` subtree **when it appears as
+untracked or ignored-present output** — the form this unavoidable runtime state
+always takes. This holds in every mode, including the fail-closed `pre-commit`
+and `pre-publish` gates:
 
-This is a built-in implicit exemption, not a `.amplihack-artifact-allowlist`
-entry, and it is intentionally narrow. Every other path under
-`.claude/runtime/` (session logs, metrics, locks, power-steering state, and any
-stray runtime output) is still blocked. Before this exemption, the launcher's
-own `launcher_context.json` failed the end-of-run `pre-publish` guard, which in
-turn left `recipe-runner-rs` and its child agents hung after the work was
-already committed and pushed (issue #807).
+| Path | Untracked / ignored-present | Staged or tracked |
+| --- | --- | --- |
+| `.claude/runtime/` (whole subtree) | Exempt | Blocked as `claude-runtime` |
+| `.claude/runtime/launcher_context.json` | Exempt | Exempt (launcher-owned) |
+| `.claude/runtime/sessions.jsonl` | Exempt | Exempt (launcher-owned) |
+
+Deliberately committing runtime state into the published tree (a *staged* or
+*tracked* `.claude/runtime/` path) is genuine pollution and is still blocked —
+except the two launcher-owned bookkeeping files, which are exempt in all git
+sources because the launcher itself may stage them.
+
+These are built-in implicit exemptions, not `.amplihack-artifact-allowlist`
+entries (and `.claude/runtime` cannot be broadly allowlisted anyway — it is a
+root-prohibited exemption). Because the untracked/ignored exemption lives in
+`rule_for_path`, it also removes that runtime output from the `worktree`/`all`
+audit modes; that is intentional, since always-present regenerated runtime state
+is not actionable pollution.
+
+Before this exemption, files under
+`.claude/runtime/` (originally the launcher's own `launcher_context.json`, and
+later the metrics file that agents append to on every tool call) failed the
+end-of-run `pre-publish` guard, which left `recipe-runner-rs` and its child
+agents hung after the work was already committed and pushed (issue #807).
 
 ## Allowlist configuration
 
@@ -384,7 +401,6 @@ Avoid writing generated output directly to:
 ```text
 <repo>/node_modules/
 <repo>/dist/plugin.js
-<repo>/.claude/runtime/
 <repo>/worktrees/
 <repo>/build/
 ```
@@ -402,7 +418,7 @@ gates. The preflight is intentionally narrower than Artifact Guard:
 
 | Path | Preflight behavior | Artifact Guard behavior if still present |
 | --- | --- | --- |
-| `.claude/runtime` | Remove when it is exactly under the active task worktree. | Block as `claude-runtime`. |
+| `.claude/runtime` | Remove when it is exactly under the active task worktree. | Exempt when untracked/ignored; blocked as `claude-runtime` only if staged or tracked. |
 | `worktrees/` | Remove when it is exactly under the active task worktree and not tracked source. | Block as `nested-worktrees`. |
 | `.claude/settings.json` | Preserve. | Not blocked by the runtime rule. |
 | Unrelated untracked files | Preserve. | Block when they match prohibited artifact rules or dirty-worktree gates. |
@@ -511,7 +527,7 @@ amplihack hygiene artifact-guard --repo . --mode all
 Use `--mode all` (or `--mode worktree`) to surface ignored-present leftovers.
 The `pre-commit` and `pre-publish` gates deliberately do not report them,
 because gitignored, untracked paths cannot be committed or published. If the
-guard reports `node_modules/`, `.pytest_cache/`, `.claude/runtime/`, or another
+guard reports `node_modules/`, `.pytest_cache/`, `.cache/`, or another
 ignored-present artifact under those hygiene modes, relocate or remove the local
 output. Do not treat `.gitignore` as approval to keep parent-worktree pollution
 — clean it up locally even though it will not block a commit or a publish.

--- a/tests/integration/artifact_guard_cli_tests.rs
+++ b/tests/integration/artifact_guard_cli_tests.rs
@@ -204,15 +204,20 @@ fn cli_exits_0_when_only_launcher_owned_runtime_files_are_present() {
 }
 
 #[test]
-fn cli_exits_1_cleanly_for_genuine_runtime_pollution_next_to_launcher_files() {
-    // The exemption is narrow: a real leftover under `.claude/runtime/` still
-    // produces a clean non-zero exit (not a hang), even when the launcher's own
-    // exempt files sit beside it.
+fn cli_exempts_ignored_present_claude_runtime_but_blocks_when_staged() {
+    // Source-conditional contract for the whole `.claude/runtime/` subtree:
     //
-    // Uses `--mode worktree` because issue #928 narrowed `pre-publish` so that it
-    // no longer scans ignored-present paths (they can never be committed or
-    // published). The narrow-launcher-exemption contract is therefore asserted
-    // against a mode that still audits ignored-present state.
+    //   * Ignored-present (or untracked) runtime output can NEVER enter the
+    //     deliverable, so it must not block a publish — this is the exact
+    //     false-positive that previously hung recipe-runner on gitignored
+    //     runtime metrics/session files.
+    //   * A *staged* `.claude/runtime/` file could actually be committed, so it
+    //     must still fail closed as genuine pollution entering the deliverable.
+    //
+    // Uses `--mode worktree` for the ignored-present half because issue #928
+    // narrowed `pre-publish` so it no longer scans ignored-present paths at all;
+    // worktree is the mode that still audits ignored-present state, so it is the
+    // strongest place to prove the exemption.
     let tmp = repo();
     write_file(&tmp.path().join(".gitignore"), ".claude/runtime/\n");
     run_git(tmp.path(), &["add", ".gitignore"]);
@@ -223,28 +228,39 @@ fn cli_exits_1_cleanly_for_genuine_runtime_pollution_next_to_launcher_files() {
     );
     write_file(&tmp.path().join(".claude/runtime/session.json"), "{}\n");
 
-    let output = Command::new(bin())
-        .args(["hygiene", "artifact-guard", "--mode", "worktree", "--repo"])
-        .arg(tmp.path())
-        .env("AMPLIHACK_SKIP_AUTO_INSTALL", "1")
-        .output()
-        .expect("run artifact guard");
+    let output = run_guard(tmp.path(), "worktree");
 
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "genuine runtime pollution must exit 1\nstdout:\n{}\nstderr:\n{}",
+        Some(0),
+        "ignored-present .claude/runtime/ output must not block (it can never \
+         enter the deliverable)\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Second half: force-stage the same runtime file so it becomes committable.
+    // A staged `.claude/runtime/` path is deliberate pollution entering the
+    // deliverable and must still fail closed under pre-commit.
+    run_git(tmp.path(), &["add", "-f", ".claude/runtime/session.json"]);
+
+    let staged = run_guard(tmp.path(), "pre-commit");
+
+    assert_eq!(
+        staged.status.code(),
+        Some(1),
+        "staged .claude/runtime/ file must still block pre-commit\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&staged.stdout),
+        String::from_utf8_lossy(&staged.stderr)
     );
     let combined = format!(
         "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+        String::from_utf8_lossy(&staged.stdout),
+        String::from_utf8_lossy(&staged.stderr)
     );
     assert!(
         combined.contains(".claude/runtime/session.json"),
-        "must report the genuine runtime leftover; got:\n{combined}"
+        "must report the staged runtime pollution; got:\n{combined}"
     );
     assert!(
         !combined.contains("launcher_context.json"),


### PR DESCRIPTION
## Problem

The pre-publish artifact guard (`amplihack hygiene artifact-guard --mode pre-publish`, run as `step-14g-artifact-guard` in `workflow-publish`) blocked **every** path under `.claude/runtime/` except two launcher-owned files.

That subtree is `.gitignore`d, tool-generated bookkeeping written **continuously** while a recipe runs — most notably `.claude/runtime/metrics/post_tool_use_metrics.jsonl`, which every agent's PostToolUse metrics hook appends to on **every tool call**.

**Observed failure** (bake-principle recipe, real log):
```
Artifact Guard blocked 1 prohibited artifact path(s) ... (mode: pre-publish).
ignored-present .claude/runtime/metrics/post_tool_use_metrics.jsonl claude-runtime
```
`step-14g` hard-failed **after** the recipe's work was already committed and pushed — discarding completed recipe work and leaving `recipe-runner-rs` and its child agents hung. This is a recurrence of issue #807 that the guard's own doc-comment warned about.

`.claude/runtime` is a **root-prohibited broad exemption** (`is_root_prohibited_exemption`), so an `.amplihack-artifact-allowlist` entry cannot rescue it either — the fix must live at the source.

### Relationship to #928
Issue #928 stopped the fail-closed gates from scanning **ignored-present** paths, covering the *gitignored* case for those gates. This change complements it and also closes the **untracked-not-ignored** gap (repos that do not gitignore `.claude/runtime/`), which #928 does not cover, and cleans the path out of the `worktree`/`all` audit modes.

## Change

The `.claude/runtime/` subtree is exempt **only for the `Untracked` and `IgnoredPresent` sources** — the form its unavoidable agent-written runtime output always takes. A **staged or tracked** `.claude/runtime/` path is deliberate pollution entering the published tree and is **still blocked** as `claude-runtime`. The two launcher-owned bookkeeping files (`launcher_context.json`, `sessions.jsonl`) keep their pre-existing all-source exemption.

- Add `is_claude_runtime_path` and a source-guarded exemption in `rule_for_path`; keep `is_launcher_owned_runtime_file` (all-source) and the `claude-runtime` rule + blocking branch (staged/tracked).
- Tests: `claude_runtime_subtree_is_exempt_when_untracked_or_ignored` (incl. the real culprit metrics path, locks, session state) and `staged_or_tracked_claude_runtime_state_is_still_blocked` (force-staged metrics file blocked; force-staged launcher file exempt).
- Update `docs/artifact-guard.md` to document the source-conditional behavior.

The exemption boundary is tight — `starts_with(".claude/runtime/")` requires the trailing slash, so siblings like `.claude/runtime-backup/` are not falsely exempted.

## Scope (criterion 13)

Source/target: `fix/exempt-claude-runtime-artifact-guard` -> `main`. 3 files, all on-topic:
- `crates/amplihack-utils/src/artifact_guard.rs` (the fix)
- `crates/amplihack-utils/src/tests/artifact_guard_tests.rs` (tests)
- `docs/artifact-guard.md` (docs)

No unrelated changes.

## Validation / evidence

- **Unit tests:** `cargo test -p amplihack-utils` — 496 lib + integration tests pass; 26 `artifact_guard` tests pass incl. the two new regression tests.
- **Clippy:** `cargo clippy -p amplihack-utils --all-targets` — clean.
- **QA:** No end-user gadigu scenario exists for an internal path-classification guard; the behavioral contract is covered by the crate's 26 artifact_guard unit tests (substitute for gadigu here — internal hygiene primitive, not a user-facing runtime surface).
- **Docs:** `docs/artifact-guard.md` updated (user-facing guard behavior surface).
- **Review:** crusty-old-engineer — APPROVE. Independent rubber-duck review raised one Major (unconditional exemption also freed staged/tracked pollution); **addressed** by scoping the exemption to Untracked/IgnoredPresent and restoring the staged/tracked block, with a dedicated regression test.
- **Pre-push gates:** fmt, clippy `-D warnings`, artifact-guard — all passed.
- **CI:** re-running on head; will not merge until required checks are green.

Once merged and the host `amplihack` CLI is redeployed, this unblocks all future recipe publishes (including parked actor-binding and agentic-recipes-principle workstreams whose code was complete but blocked at publish).