### PR TITLE
fix(recipe): deterministic teardown, recursion guard & caller git-state restore on failure (#964)

### DIFF
--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -276,7 +276,16 @@ pub(super) fn execute_recipe_via_rust(
 
     let result =
         spawn_with_streaming_stderr(command, correlation, recipe_path, recipe_runner_timeout());
-    if result.is_err() {
+    // Issue #964: restore on ANY terminal failure, not just a spawn/parse `Err`.
+    // A runner that completes and emits a structured result reporting failure
+    // (`Ok(RecipeRunResult { success: false, .. })`) is still a terminal failure
+    // and is in fact the more likely path to leave the caller checkout corrupted
+    // (it did real work before failing). Restoring only on `Err` would miss it.
+    let terminal_failure = match &result {
+        Err(_) => true,
+        Ok(run_result) => !run_result.success,
+    };
+    if terminal_failure {
         caller_git.restore_on_failure();
     }
     result

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -720,7 +720,7 @@ fn terminate_recipe_runner(child: &mut Child) -> Result<()> {
         let grace = recipe_runner_teardown_grace();
         let pgid = pid as libc::pid_t;
         signal_process_group(pgid, libc::SIGTERM);
-        wait_for_child_exit(child, grace);
+        wait_until_exited(grace, || matches!(child.try_wait(), Ok(None)));
         signal_process_group(pgid, libc::SIGKILL);
     }
     #[cfg(windows)]
@@ -761,24 +761,27 @@ fn recipe_runner_teardown_grace() -> Duration {
         .unwrap_or(RECIPE_RUNNER_DEFAULT_TEARDOWN_GRACE)
 }
 
-/// Poll `child` for exit for up to `grace`, reaping it if it exits. Returns
-/// `true` if the child exited within the window. A zero grace returns almost
-/// immediately so callers can escalate to SIGKILL without delay.
+/// Poll `still_running` until it reports the target has exited or `grace`
+/// elapses; returns `true` if it exited within the window. Sleeps in short
+/// `RECIPE_RUNNER_POLL_INTERVAL` steps (floored at 1ms, never past the remaining
+/// grace) so a zero grace escalates almost immediately. Shared by both teardown
+/// paths so the SIGTERM -> grace -> SIGKILL timing policy lives in one place.
 #[cfg(unix)]
-fn wait_for_child_exit(child: &mut Child, grace: Duration) -> bool {
+fn wait_until_exited(grace: Duration, mut still_running: impl FnMut() -> bool) -> bool {
     let started = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return true,
-            Ok(None) => {}
-            Err(_) => return false,
-        }
+    while still_running() {
         let elapsed = started.elapsed();
         if elapsed >= grace {
             return false;
         }
-        thread::sleep(RECIPE_RUNNER_POLL_INTERVAL.min(grace.saturating_sub(elapsed)));
+        let remaining = grace.saturating_sub(elapsed);
+        thread::sleep(
+            RECIPE_RUNNER_POLL_INTERVAL
+                .min(remaining)
+                .max(Duration::from_millis(1)),
+        );
     }
+    true
 }
 
 /// Send `signal` to the process group `pgid` (targets `-pgid`). A missing group
@@ -802,24 +805,15 @@ fn signal_process_group(pgid: libc::pid_t, signal: libc::c_int) {
 #[cfg(unix)]
 fn reap_recipe_runner_group(pgid_pid: u32, grace: Duration) {
     let pgid = pgid_pid as libc::pid_t;
+    // `kill(-pgid, 0)` probes group liveness without delivering a signal.
+    let group_alive = || unsafe { libc::kill(-pgid, 0) } == 0;
     // Fast path: the group is already empty (well-behaved runner, no orphans).
-    if unsafe { libc::kill(-pgid, 0) } != 0 {
+    if !group_alive() {
         return;
     }
     signal_process_group(pgid, libc::SIGTERM);
-    let started = Instant::now();
-    while unsafe { libc::kill(-pgid, 0) } == 0 {
-        let elapsed = started.elapsed();
-        if elapsed >= grace {
-            signal_process_group(pgid, libc::SIGKILL);
-            return;
-        }
-        let remaining = grace.saturating_sub(elapsed);
-        thread::sleep(
-            RECIPE_RUNNER_POLL_INTERVAL
-                .min(remaining)
-                .max(Duration::from_millis(1)),
-        );
+    if !wait_until_exited(grace, group_alive) {
+        signal_process_group(pgid, libc::SIGKILL);
     }
 }
 

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -412,7 +412,11 @@ fn spawn_with_streaming_stderr(
     let dropped = *dropped_stderr_lines
         .lock()
         .expect("stderr drop-count mutex");
-    let stderr_joined = captured.iter().cloned().collect::<Vec<_>>().join("\n");
+    let stderr_joined = captured
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join("\n");
     match parse_recipe_output_with_stderr_drops(
         &stdout_buf,
         &stderr_joined,
@@ -695,10 +699,14 @@ fn wait_for_recipe_runner(
         if let Some(status) = child.try_wait()? {
             return Ok(Some(status));
         }
-        if started.elapsed() >= timeout {
-            return Ok(None);
-        }
-        thread::sleep(RECIPE_RUNNER_POLL_INTERVAL.min(timeout.saturating_sub(started.elapsed())));
+        // Single clock read per poll: derive the remaining budget once and reuse
+        // it for both the deadline check and the sleep cap. A zero (or elapsed)
+        // remaining is the timeout.
+        let remaining = match timeout.checked_sub(started.elapsed()) {
+            Some(remaining) if !remaining.is_zero() => remaining,
+            _ => return Ok(None),
+        };
+        thread::sleep(RECIPE_RUNNER_POLL_INTERVAL.min(remaining));
     }
 }
 

--- a/crates/amplihack-cli/src/commands/recipe/run/execute.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/execute.rs
@@ -19,6 +19,21 @@ const RECIPE_RUNNER_PIPE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(windows)]
 const RECIPE_RUNNER_TERMINATE_TIMEOUT: Duration = Duration::from_secs(5);
 const RECIPE_RUNNER_TIMEOUT_ENV: &str = "AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS";
+/// Env var controlling the SIGTERM -> SIGKILL grace window (whole seconds) used
+/// when deterministically tearing down the recipe-runner process tree (#964).
+/// `0` escalates to SIGKILL immediately (no graceful window).
+#[cfg(unix)]
+const RECIPE_RUNNER_TEARDOWN_GRACE_ENV: &str = "AMPLIHACK_TEARDOWN_GRACE_SECS";
+/// Default grace window when `AMPLIHACK_TEARDOWN_GRACE_SECS` is unset/invalid.
+#[cfg(unix)]
+const RECIPE_RUNNER_DEFAULT_TEARDOWN_GRACE: Duration = Duration::from_secs(5);
+/// Env var carrying the current session's recursion depth (root = 0). Shared
+/// with the session-tree convention; consumed by the fail-closed recursion
+/// guard [`enforce_recursion_depth_guard`] (#964).
+const SESSION_DEPTH_ENV: &str = "AMPLIHACK_SESSION_DEPTH";
+/// Env var carrying the maximum permitted recursion depth, clamped to
+/// `MAX_DEPTH_CEILING` before use (#964).
+const MAX_DEPTH_ENV: &str = "AMPLIHACK_MAX_DEPTH";
 
 /// Threshold in bytes for total `--set` argument size before we switch
 /// to passing context via a temp file. Well under the typical Linux
@@ -169,6 +184,13 @@ pub(super) fn execute_recipe_via_rust(
     search_dirs: &[PathBuf],
     step_timeout: Option<u64>,
 ) -> Result<RecipeRunResult> {
+    // Issue #964: fail-closed recursion-depth guard. Refuse to spawn a nested
+    // recipe-runner once the session has reached the configured maximum depth,
+    // so a failing / misbehaving orchestration can never recursively re-enter
+    // the orchestrator and fork-bomb the host. Runs BEFORE any work (binary
+    // lookup, temp dirs, spawn) so no descendant is ever created past the limit.
+    enforce_recursion_depth_guard()?;
+
     let binary = super::binary::find_recipe_runner_binary()?;
     let recipe_name = recipe_name_for_correlation(recipe_path);
     let correlation =
@@ -246,7 +268,18 @@ pub(super) fn execute_recipe_via_rust(
     command.env("AMPLIHACK_WORKFLOW_ARTIFACT_DIR", &artifact_dir);
     command.env("TMPDIR", &tmp_dir);
 
-    spawn_with_streaming_stderr(command, correlation, recipe_path, recipe_runner_timeout())
+    // Issue #964: snapshot the caller checkout's git state BEFORE spawning so a
+    // runner that corrupts it (e.g. flips `core.bare=true`, which breaks
+    // `git status`) can be repaired on a terminal failure — leaving the caller's
+    // checkout usable while preserving any durable child worktrees.
+    let caller_git = CallerGitState::snapshot(working_dir);
+
+    let result =
+        spawn_with_streaming_stderr(command, correlation, recipe_path, recipe_runner_timeout());
+    if result.is_err() {
+        caller_git.restore_on_failure();
+    }
+    result
 }
 
 /// Spawn the runner with stdout captured (we need to parse JSON from it)
@@ -354,6 +387,15 @@ fn spawn_with_streaming_stderr(
             );
         }
     };
+
+    // Issue #964: the session leader has exited (and been reaped by
+    // `wait_for_recipe_runner`), but on any NON-timeout early-exit path
+    // (success OR failure) it may leave orphaned descendants behind in its
+    // process group. Deterministically reap that tree BEFORE draining pipes so
+    // a failed/early-exiting runner cannot leak a recursive subprocess tree and
+    // cannot wedge the drain by holding the inherited stdout pipe open.
+    #[cfg(unix)]
+    reap_recipe_runner_group(child.id(), recipe_runner_teardown_grace());
 
     let stdout_buf = stdout_rx
         .recv_timeout(RECIPE_RUNNER_PIPE_DRAIN_TIMEOUT)
@@ -664,12 +706,22 @@ fn terminate_recipe_runner(child: &mut Child) -> Result<()> {
     let pid = child.id();
     #[cfg(unix)]
     {
-        let process_group = -(pid as libc::pid_t);
-        let result = unsafe { libc::kill(process_group, libc::SIGKILL) };
-        if result != 0 {
-            let error = std::io::Error::last_os_error();
-            tracing::warn!(pid, %error, "failed to terminate timed-out recipe-runner process group");
-        }
+        // Issue #964: reap the recipe-runner tree DETERMINISTICALLY and
+        // GRACEFULLY. The runner is a session leader (see the `setsid` in
+        // `spawn_with_streaming_stderr`), so its PID doubles as the process-group
+        // id shared by every descendant. Three phases:
+        //   1. SIGTERM the whole group so the runner (and children) can run any
+        //      cleanup / trap handlers,
+        //   2. wait up to the configurable grace window for the runner to exit,
+        //   3. SIGKILL the group to guarantee nothing survives — this reaps both
+        //      a runner that ignored SIGTERM and any lingering descendants.
+        // The signal target is `-pgid`, so this is scoped strictly to the
+        // runner's own session and never touches unrelated / parent processes.
+        let grace = recipe_runner_teardown_grace();
+        let pgid = pid as libc::pid_t;
+        signal_process_group(pgid, libc::SIGTERM);
+        wait_for_child_exit(child, grace);
+        signal_process_group(pgid, libc::SIGKILL);
     }
     #[cfg(windows)]
     {
@@ -693,4 +745,248 @@ fn terminate_recipe_runner(child: &mut Child) -> Result<()> {
         .wait()
         .with_context(|| format!("failed to wait for timed-out recipe-runner-rs pid {pid}"))?;
     Ok(())
+}
+
+/// Resolve the SIGTERM -> SIGKILL grace window for recipe-runner teardown.
+///
+/// Honors `AMPLIHACK_TEARDOWN_GRACE_SECS` (whole seconds, `0` allowed to mean
+/// "escalate to SIGKILL immediately"); falls back to
+/// [`RECIPE_RUNNER_DEFAULT_TEARDOWN_GRACE`] when unset or unparsable.
+#[cfg(unix)]
+fn recipe_runner_teardown_grace() -> Duration {
+    std::env::var(RECIPE_RUNNER_TEARDOWN_GRACE_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(RECIPE_RUNNER_DEFAULT_TEARDOWN_GRACE)
+}
+
+/// Poll `child` for exit for up to `grace`, reaping it if it exits. Returns
+/// `true` if the child exited within the window. A zero grace returns almost
+/// immediately so callers can escalate to SIGKILL without delay.
+#[cfg(unix)]
+fn wait_for_child_exit(child: &mut Child, grace: Duration) -> bool {
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        let elapsed = started.elapsed();
+        if elapsed >= grace {
+            return false;
+        }
+        thread::sleep(RECIPE_RUNNER_POLL_INTERVAL.min(grace.saturating_sub(elapsed)));
+    }
+}
+
+/// Send `signal` to the process group `pgid` (targets `-pgid`). A missing group
+/// (`ESRCH`) is expected and silent; any other failure is logged.
+#[cfg(unix)]
+fn signal_process_group(pgid: libc::pid_t, signal: libc::c_int) {
+    let result = unsafe { libc::kill(-pgid, signal) };
+    if result != 0 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::ESRCH) {
+            tracing::warn!(pgid, signal, %error, "failed to signal recipe-runner process group");
+        }
+    }
+}
+
+/// Deterministically reap orphaned descendants left in an already-exited
+/// runner's process group (issue #964). The runner itself has already been
+/// reaped by [`wait_for_recipe_runner`]; this sweeps any survivors that
+/// outlived the session leader using the same graceful SIGTERM -> grace ->
+/// SIGKILL contract, scoped strictly to `-pgid`.
+#[cfg(unix)]
+fn reap_recipe_runner_group(pgid_pid: u32, grace: Duration) {
+    let pgid = pgid_pid as libc::pid_t;
+    // Fast path: the group is already empty (well-behaved runner, no orphans).
+    if unsafe { libc::kill(-pgid, 0) } != 0 {
+        return;
+    }
+    signal_process_group(pgid, libc::SIGTERM);
+    let started = Instant::now();
+    while unsafe { libc::kill(-pgid, 0) } == 0 {
+        let elapsed = started.elapsed();
+        if elapsed >= grace {
+            signal_process_group(pgid, libc::SIGKILL);
+            return;
+        }
+        let remaining = grace.saturating_sub(elapsed);
+        thread::sleep(
+            RECIPE_RUNNER_POLL_INTERVAL
+                .min(remaining)
+                .max(Duration::from_millis(1)),
+        );
+    }
+}
+
+/// Fail-closed recursion-depth guard for `amplihack recipe run` (issue #964).
+///
+/// Refuses to spawn a nested recipe-runner once the current session has reached
+/// the configured maximum recursion depth, so a failing / misbehaving
+/// orchestration can never recursively re-enter the orchestrator and fork-bomb
+/// the host. It reuses the existing session-tree depth convention rather than
+/// forking a second source of truth: the same `AMPLIHACK_SESSION_DEPTH` /
+/// `AMPLIHACK_MAX_DEPTH` env vars and the shared `DEFAULT_MAX_DEPTH` (`3`) /
+/// `MAX_DEPTH_CEILING` (`32`) constants from `commands::session_tree::state`.
+///
+/// Contract:
+/// * `AMPLIHACK_SESSION_DEPTH` unset -> treated as the root (depth `0`);
+/// * a malformed / non-numeric / non-UTF-8 `AMPLIHACK_SESSION_DEPTH` is
+///   **fail-closed**: treated as "already at the limit" (bail), never silently
+///   coerced to `0` (which would defeat the guard);
+/// * `AMPLIHACK_MAX_DEPTH` is clamped to `MAX_DEPTH_CEILING` before the
+///   comparison so a forged, over-large value cannot disable the limit; an
+///   unset / malformed value falls back to `DEFAULT_MAX_DEPTH`;
+/// * below the limit the caller spawns normally (no over-blocking).
+///
+/// Logs numeric depth/limit fields only — never env-var *values*, which may
+/// carry session tokens or secrets.
+fn enforce_recursion_depth_guard() -> Result<()> {
+    use crate::commands::session_tree::state::{DEFAULT_MAX_DEPTH, MAX_DEPTH_CEILING};
+
+    let max_depth = std::env::var(MAX_DEPTH_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u32>().ok())
+        .unwrap_or(DEFAULT_MAX_DEPTH)
+        .min(MAX_DEPTH_CEILING);
+
+    // Fail-closed: distinguish "unset" (root, depth 0) from "set but unparseable"
+    // (treat as at-the-limit) using `var_os`, so a corrupted / forged value can
+    // never bypass the guard by parsing as 0.
+    let depth = match std::env::var_os(SESSION_DEPTH_ENV) {
+        None => 0,
+        Some(raw) => match raw.to_str().and_then(|s| s.trim().parse::<u32>().ok()) {
+            Some(value) => value,
+            None => {
+                tracing::warn!(
+                    max_depth,
+                    "malformed AMPLIHACK_SESSION_DEPTH; failing closed at the recursion limit (issue #964)"
+                );
+                max_depth
+            }
+        },
+    };
+
+    if depth >= max_depth {
+        tracing::warn!(
+            depth,
+            max_depth,
+            "recipe run blocked by recursion-depth guard; refusing to spawn a nested recipe-runner (issue #964)"
+        );
+        anyhow::bail!(
+            "recipe run recursion depth guard exceeded: depth {depth} reached configured max {max_depth} (issue #964)"
+        );
+    }
+    Ok(())
+}
+
+/// Pre-run snapshot of the caller checkout's git state needed to keep it usable
+/// after a terminal recipe-runner failure (issue #964).
+///
+/// The observed corruption was a runner flipping the caller checkout's
+/// `core.bare` to `true`, which makes `git status` fail with
+/// `this operation must be run in a work tree`. We snapshot `core.bare` before
+/// spawning and, on any terminal failure, restore the pre-run value so the
+/// caller's checkout is left usable. This is intentionally scoped to the single
+/// `core.bare` key on the caller checkout: it never touches the work tree, and
+/// never deletes or unregisters durable child worktrees produced by the run.
+struct CallerGitState {
+    /// The caller checkout (the runner's working directory).
+    dir: PathBuf,
+    /// `true` only if `dir` was a usable git work tree before the run. When
+    /// `false` there is nothing to restore and we must never "fix" a non-repo
+    /// into a repo.
+    was_git_checkout: bool,
+    /// Pre-run value of `core.bare` (`None` == unset). A `None` snapshot is
+    /// never restored as an explicit `false`; absence is preserved as absence.
+    core_bare: Option<String>,
+}
+
+impl CallerGitState {
+    /// Capture the caller checkout's `core.bare` before spawning. Returns a
+    /// snapshot with `was_git_checkout = false` (a no-op restore) when `dir` is
+    /// not a git work tree or git is unavailable.
+    fn snapshot(dir: &Path) -> Self {
+        let was_git_checkout =
+            git_capture(dir, &["rev-parse", "--is-inside-work-tree"]).as_deref() == Some("true");
+        let core_bare = if was_git_checkout {
+            git_capture(dir, &["config", "--local", "--get", "core.bare"])
+        } else {
+            None
+        };
+        Self {
+            dir: dir.to_path_buf(),
+            was_git_checkout,
+            core_bare,
+        }
+    }
+
+    /// Best-effort restore of the caller checkout to the snapshotted `core.bare`,
+    /// run only after a terminal failure. Never bails; a restore failure is
+    /// surfaced via structured `tracing` (issue #964 requirement 5) and never
+    /// masks the original error. Preserves durable child worktrees (config-only).
+    fn restore_on_failure(&self) {
+        if !self.was_git_checkout {
+            return;
+        }
+        let current = git_capture(&self.dir, &["config", "--local", "--get", "core.bare"]);
+        if current == self.core_bare {
+            return; // caller checkout untouched — nothing to restore.
+        }
+
+        let restored = match &self.core_bare {
+            Some(value) => git_run(&self.dir, &["config", "--local", "core.bare", value]),
+            // Was unset before the run: unset whatever the runner left behind.
+            None => git_run(&self.dir, &["config", "--local", "--unset", "core.bare"]),
+        };
+
+        if restored {
+            tracing::warn!(
+                dir = %self.dir.display(),
+                "restored caller checkout core.bare after terminal recipe-runner failure (issue #964)"
+            );
+        } else {
+            tracing::error!(
+                dir = %self.dir.display(),
+                "failed to restore caller checkout git state after terminal recipe-runner failure (issue #964)"
+            );
+        }
+    }
+}
+
+/// Run `git -C dir <args>` and return trimmed stdout, or `None` if git is
+/// unavailable or the command failed (e.g. `--get` of an unset key exits
+/// non-zero, which we map to `None` == "unset").
+fn git_capture(dir: &Path, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Run `git -C dir <args>` for side effects; `true` on success. `--unset` of an
+/// already-absent key exits non-zero (code 5) — treated as a non-fatal no-op so
+/// restoring "was unset, still unset" is not reported as a failure.
+fn git_run(dir: &Path, args: &[&str]) -> bool {
+    match std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .status()
+    {
+        Ok(status) if status.success() => true,
+        // `git config --unset` of a missing key -> exit code 5; benign here.
+        Ok(status) if args.contains(&"--unset") && status.code() == Some(5) => true,
+        _ => false,
+    }
 }

--- a/crates/amplihack-cli/src/commands/recipe/run/mod.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/mod.rs
@@ -184,3 +184,5 @@ mod tests_context;
 mod tests_execute;
 #[cfg(test)]
 mod tests_format;
+#[cfg(test)]
+mod tests_teardown;

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_teardown.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_teardown.rs
@@ -1,0 +1,689 @@
+// crates/amplihack-cli/src/commands/recipe/run/tests_teardown.rs
+//
+// Issue #964 — TDD (write-tests-first) contract for DETERMINISTIC TEARDOWN of
+// the recipe-runner subprocess tree.
+//
+// Observed bug: a smart-orchestrator (recipe-runner) failure LEAKS recursive
+// descendant subprocesses. Today `terminate_recipe_runner` only runs on the
+// TIMEOUT path and sends an immediate `SIGKILL` to the process group. That
+// means:
+//   1. On any NON-timeout failure / early-exit the descendant tree is never
+//      reaped — orphaned children keep running and amplify host load.
+//   2. Even on the timeout path children get no chance to shut down cleanly
+//      (no `SIGTERM` grace window), so any child-side cleanup is skipped.
+//   3. There is no operator-tunable grace window.
+//
+// The tests below specify the intended behaviour. They exercise the public
+// entry point `execute::execute_recipe_via_rust` with a stub runner installed
+// via `RECIPE_RUNNER_RS_PATH`, so they COMPILE against today's code and FAIL at
+// runtime (true TDD red). They must PASS once deterministic teardown lands:
+//
+//   * teardown fires on EVERY failure / early-exit path (not only timeout),
+//   * teardown is a three-phase reaper: SIGTERM -> configurable grace -> SIGKILL,
+//   * the grace window is configurable via `AMPLIHACK_TEARDOWN_GRACE_SECS`,
+//   * teardown is scoped to the runner's own process group and never signals
+//     unrelated / parent processes.
+//
+// Unix-only: the leak and the process-group reaping are Unix semantics.
+
+#![cfg(unix)]
+
+use super::*;
+use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Environment-variable name the deterministic-teardown feature must honour to
+/// configure the SIGTERM -> SIGKILL grace window (in whole seconds).
+const TEARDOWN_GRACE_ENV: &str = "AMPLIHACK_TEARDOWN_GRACE_SECS";
+const RUNNER_TIMEOUT_ENV: &str = "AMPLIHACK_RECIPE_RUNNER_TIMEOUT_SECS";
+const RUNNER_PATH_ENV: &str = "RECIPE_RUNNER_RS_PATH";
+
+/// Minimal RAII guard that snapshots an env var and restores it on drop so a
+/// two-phase test cannot leak state into sibling tests. Env is process-global;
+/// callers must additionally hold `home_env_lock()` for serialization.
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
+
+    fn apply(&self, value: impl AsRef<std::ffi::OsStr>) {
+        unsafe { std::env::set_var(self.key, value) };
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+/// Write an executable `/bin/sh` stub at `path` and chmod it 0755.
+fn write_stub(path: &Path, body: &str) {
+    std::fs::write(path, body).expect("failed to write runner stub");
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .expect("failed to chmod runner stub");
+}
+
+/// True if a process with `pid` still exists (signal 0 probe).
+fn process_alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+// -------------------------------------------------------------------------
+// Test 1 — teardown fires on the FAILURE (non-timeout) path.
+//
+// A runner that spawns a detached descendant and then exits NON-ZERO must have
+// that descendant reaped. The descendant writes a marker after a short delay;
+// if teardown works the marker never appears.
+//
+// RED today: the failure path never reaps the tree, so the marker appears.
+// -------------------------------------------------------------------------
+#[test]
+fn test_failure_path_reaps_orphaned_descendants() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    let marker = temp.path().join("orphan-marker");
+
+    // Spawn a descendant that writes the marker after 2s, then FAIL (exit 1).
+    // This is a failure, NOT a timeout.
+    write_stub(
+        &runner,
+        &format!(
+            "#!/bin/sh\n(/bin/sleep 2; echo leaked > '{}') &\nexit 1\n",
+            marker.display()
+        ),
+    );
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: fail-leak-probe\nsteps: []\n").expect("failed to write recipe");
+
+    let _runner_env = EnvVarGuard::set(RUNNER_PATH_ENV, &runner);
+    // Ensure a fast failure is not misread as a timeout.
+    let _timeout_env = EnvVarGuard::unset(RUNNER_TIMEOUT_ENV);
+
+    let result = execute::execute_recipe_via_rust(
+        &recipe,
+        &BTreeMap::new(),
+        false,
+        true,
+        temp.path(),
+        &[],
+        None,
+    );
+
+    result.expect_err("non-zero runner exit must surface as an error");
+
+    // Give the descendant time to write its marker if it was NOT reaped.
+    std::thread::sleep(Duration::from_millis(2_300));
+    assert!(
+        !marker.exists(),
+        "failure-path teardown must reap orphaned recipe-runner descendants \
+         (issue #964): descendant survived and wrote {}",
+        marker.display()
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 2 — teardown is GRACEFUL: SIGTERM is delivered before SIGKILL.
+//
+// The runner traps SIGTERM, records that it received it, and exits cleanly.
+// With a graceful three-phase reaper the trap runs (marker written). With the
+// current immediate-SIGKILL teardown the trap never runs.
+//
+// Uses the timeout path (which is the only path that reaps today) so the ONLY
+// thing under test is SIGTERM-before-SIGKILL, isolating it from Test 1.
+//
+// RED today: immediate SIGKILL means the SIGTERM trap never runs -> no marker.
+// -------------------------------------------------------------------------
+#[test]
+fn test_timeout_teardown_sends_sigterm_before_sigkill() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    let marker = temp.path().join("graceful-marker");
+
+    write_stub(
+        &runner,
+        &format!(
+            "#!/bin/sh\ntrap 'echo graceful > \"{}\"; exit 0' TERM\n/bin/sleep 30\n",
+            marker.display()
+        ),
+    );
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: graceful-probe\nsteps: []\n").expect("failed to write recipe");
+
+    let _runner_env = EnvVarGuard::set(RUNNER_PATH_ENV, &runner);
+    let _timeout_env = EnvVarGuard::set(RUNNER_TIMEOUT_ENV, "1");
+    // Explicit, generous grace so the trapped child can finish cleanly.
+    let _grace_env = EnvVarGuard::set(TEARDOWN_GRACE_ENV, "5");
+
+    let result = execute::execute_recipe_via_rust(
+        &recipe,
+        &BTreeMap::new(),
+        false,
+        true,
+        temp.path(),
+        &[],
+        None,
+    );
+
+    result.expect_err("hung recipe-runner must time out");
+
+    // Allow the SIGTERM trap to run and write the marker within the grace window.
+    std::thread::sleep(Duration::from_millis(2_000));
+    assert!(
+        marker.exists(),
+        "graceful teardown must deliver SIGTERM before SIGKILL so the runner \
+         can shut down cleanly (issue #964): no SIGTERM handler ran"
+    );
+    let contents = std::fs::read_to_string(&marker).unwrap_or_default();
+    assert!(
+        contents.contains("graceful"),
+        "SIGTERM handler must have executed; marker contents: {contents:?}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 3 — the grace window is CONFIGURABLE via AMPLIHACK_TEARDOWN_GRACE_SECS.
+//
+// The trapped runner needs ~1s of work to shut down cleanly.
+//   * grace = 0  -> escalate to SIGKILL immediately -> clean-exit marker ABSENT.
+//   * grace = 4  -> allow the ~1s cleanup to finish -> clean-exit marker PRESENT.
+//
+// RED today: no grace env var is honoured and SIGKILL is immediate, so the
+// grace = 4 phase never produces the marker.
+// -------------------------------------------------------------------------
+#[test]
+fn test_teardown_grace_window_is_configurable() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let _timeout_env = EnvVarGuard::set(RUNNER_TIMEOUT_ENV, "1");
+    let grace_env = EnvVarGuard::set(TEARDOWN_GRACE_ENV, "0");
+
+    // Runs one timeout->teardown cycle against a runner whose SIGTERM handler
+    // needs ~1s to finish; returns whether the clean-exit marker was written.
+    let run_once = |grace: &str| -> bool {
+        grace_env.apply(grace);
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let runner = temp.path().join("recipe-runner-rs");
+        let marker = temp.path().join("clean-exit-marker");
+        write_stub(
+            &runner,
+            &format!(
+                "#!/bin/sh\ntrap '/bin/sleep 1; echo done > \"{}\"; exit 0' TERM\n/bin/sleep 30\n",
+                marker.display()
+            ),
+        );
+        let recipe = temp.path().join("recipe.yaml");
+        std::fs::write(&recipe, "name: grace-probe\nsteps: []\n").expect("failed to write recipe");
+
+        let _runner_env = EnvVarGuard::set(RUNNER_PATH_ENV, &runner);
+        let result = execute::execute_recipe_via_rust(
+            &recipe,
+            &BTreeMap::new(),
+            false,
+            true,
+            temp.path(),
+            &[],
+            None,
+        );
+        result.expect_err("hung recipe-runner must time out");
+        // Wait comfortably past the 1s cleanup for either outcome to settle.
+        std::thread::sleep(Duration::from_millis(1_800));
+        marker.exists()
+    };
+
+    let wrote_with_zero_grace = run_once("0");
+    let wrote_with_ample_grace = run_once("4");
+
+    assert!(
+        !wrote_with_zero_grace,
+        "grace = 0 must escalate to SIGKILL immediately; the ~1s cleanup must \
+         NOT complete (issue #964)"
+    );
+    assert!(
+        wrote_with_ample_grace,
+        "grace = 4 must give the runner its ~1s cleanup window before SIGKILL \
+         via AMPLIHACK_TEARDOWN_GRACE_SECS (issue #964)"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 4 — teardown is SCOPED to the runner's process group only.
+//
+// The reaper signals the runner's process group (the runner is a session
+// leader via setsid). It must NEVER broadcast to unrelated / parent processes.
+// A sibling process spawned directly by the test lives in the TEST's process
+// group, so it must survive while the runner's own orphan is reaped.
+//
+// RED today: the failure-path orphan is not reaped (marker appears). The
+// sibling-survives half already holds; this test also guards against a future
+// over-broad kill.
+// -------------------------------------------------------------------------
+#[test]
+fn test_teardown_is_scoped_to_runner_process_group() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+
+    // Sibling process in the TEST's process group (NOT the runner's session).
+    let mut sibling = std::process::Command::new("/bin/sleep")
+        .arg("8")
+        .spawn()
+        .expect("failed to spawn sibling process");
+    let sibling_pid = sibling.id();
+
+    let runner = temp.path().join("recipe-runner-rs");
+    let marker = temp.path().join("orphan-marker");
+    write_stub(
+        &runner,
+        &format!(
+            "#!/bin/sh\n(/bin/sleep 2; echo leaked > '{}') &\nexit 1\n",
+            marker.display()
+        ),
+    );
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: scope-probe\nsteps: []\n").expect("failed to write recipe");
+
+    let _runner_env = EnvVarGuard::set(RUNNER_PATH_ENV, &runner);
+    let _timeout_env = EnvVarGuard::unset(RUNNER_TIMEOUT_ENV);
+
+    let started = Instant::now();
+    let result = execute::execute_recipe_via_rust(
+        &recipe,
+        &BTreeMap::new(),
+        false,
+        true,
+        temp.path(),
+        &[],
+        None,
+    );
+    result.expect_err("non-zero runner exit must surface as an error");
+
+    // Runner's own orphan must be reaped.
+    std::thread::sleep(Duration::from_millis(2_300));
+    assert!(
+        !marker.exists(),
+        "teardown must reap the runner's orphaned descendant (issue #964)"
+    );
+
+    // The unrelated sibling (outside the runner's process group) must survive
+    // the teardown, proving the reaper is pgid-scoped and not a broadcast.
+    assert!(
+        started.elapsed() < Duration::from_secs(8),
+        "test setup ran too long to validate sibling survival"
+    );
+    assert!(
+        process_alive(sibling_pid),
+        "teardown must be scoped to the runner's process group and must NOT \
+         signal unrelated processes (issue #964)"
+    );
+
+    // Clean up the sibling deterministically.
+    unsafe { libc::kill(sibling_pid as libc::pid_t, libc::SIGKILL) };
+    let _ = sibling.wait();
+}
+
+// =========================================================================
+// Issue #964 — TDD (write-tests-first) contract for the FAIL-CLOSED RECURSION
+// DEPTH GUARD and the CALLER GIT-STATE RESTORE on terminal failure.
+//
+// These specify the two confirmed *missing* behaviours (only env propagation
+// and happy-path teardown exist today):
+//
+//   A. A recursion-depth guard that BAILS BEFORE SPAWN when the current session
+//      depth has reached the (clamped) maximum — so a failing orchestration can
+//      never recursively re-spawn descendants past the limit. Contract:
+//        * bail when AMPLIHACK_SESSION_DEPTH >= AMPLIHACK_MAX_DEPTH,
+//        * FAIL-CLOSED: a malformed / non-numeric AMPLIHACK_SESSION_DEPTH is
+//          treated as "at the limit" (bail), never as depth 0,
+//        * a forged, over-large AMPLIHACK_MAX_DEPTH is clamped to the hard
+//          ceiling (MAX_DEPTH_CEILING = 32) before the comparison,
+//        * below the limit the runner still spawns normally (no over-blocking).
+//
+//   B. Best-effort restoration of the CALLER checkout's git configuration on
+//      any terminal failure: if the runner corrupts the caller's checkout
+//      (e.g. flips `core.bare=true`, reproducing the observed `git status`
+//      breakage), the pre-run value is snapshotted before spawn and restored
+//      after teardown, while durable child worktrees are preserved.
+//
+// All tests drive the PUBLIC entry point `execute::execute_recipe_via_rust`
+// with a stub runner installed via `RECIPE_RUNNER_RS_PATH`, so they COMPILE
+// against today's code and FAIL at runtime (true TDD red). They PASS once the
+// depth guard and git-restore logic land.
+//
+// Unix-only: matches the rest of this teardown suite.
+
+/// Env var carrying the current session's recursion depth (root = 0).
+const SESSION_DEPTH_ENV: &str = "AMPLIHACK_SESSION_DEPTH";
+/// Env var carrying the maximum allowed recursion depth.
+const MAX_DEPTH_ENV: &str = "AMPLIHACK_MAX_DEPTH";
+
+/// Write a stub that records it was spawned (marker file) and then exits with
+/// `exit_code`. Used to detect whether the depth guard blocked the spawn.
+fn write_marker_stub(path: &Path, marker: &Path, exit_code: u8) {
+    write_stub(
+        path,
+        &format!(
+            "#!/bin/sh\necho spawned > '{}'\nexit {}\n",
+            marker.display(),
+            exit_code
+        ),
+    );
+}
+
+/// Drive `execute_recipe_via_rust` once with the given depth env values and a
+/// spawn-marker stub. Returns whether the stub actually ran (marker present).
+/// The overall result is intentionally ignored: whether the call errors because
+/// the guard bailed OR because the stub produced no JSON is irrelevant — the
+/// only observable under test is "did we spawn the runner at all?".
+fn depth_guard_spawned(session_depth: &str, max_depth: Option<&str>) -> bool {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let runner = temp.path().join("recipe-runner-rs");
+    let marker = temp.path().join("spawn-marker");
+    write_marker_stub(&runner, &marker, 1);
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: depth-probe\nsteps: []\n").expect("failed to write recipe");
+
+    let _runner_env = EnvVarGuard::set(RUNNER_PATH_ENV, &runner);
+    let _timeout_env = EnvVarGuard::unset(RUNNER_TIMEOUT_ENV);
+    let _depth_env = EnvVarGuard::set(SESSION_DEPTH_ENV, session_depth);
+    let _max_env = match max_depth {
+        Some(v) => EnvVarGuard::set(MAX_DEPTH_ENV, v),
+        None => EnvVarGuard::unset(MAX_DEPTH_ENV),
+    };
+
+    let _ = execute::execute_recipe_via_rust(
+        &recipe,
+        &BTreeMap::new(),
+        false,
+        true,
+        temp.path(),
+        &[],
+        None,
+    );
+
+    marker.exists()
+}
+
+// -------------------------------------------------------------------------
+// Test 5 — depth AT the limit BAILS BEFORE SPAWN.
+//
+// SESSION_DEPTH == MAX_DEPTH must be refused: no descendant runner is spawned.
+//
+// RED today: no guard exists, so the runner spawns and writes the marker.
+// -------------------------------------------------------------------------
+#[test]
+fn test_depth_guard_bails_at_limit_before_spawn() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let spawned = depth_guard_spawned("3", Some("3"));
+    assert!(
+        !spawned,
+        "recursion-depth guard must bail BEFORE spawning when session depth has \
+         reached the maximum (issue #964): runner was spawned at depth == max"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 6 — depth guard is FAIL-CLOSED on a malformed session depth.
+//
+// A non-numeric AMPLIHACK_SESSION_DEPTH must be treated as "at the limit" and
+// BAIL — never silently parsed as depth 0 (which would defeat the guard).
+//
+// RED today: no guard exists, so the runner spawns regardless.
+// -------------------------------------------------------------------------
+#[test]
+fn test_depth_guard_fails_closed_on_malformed_session_depth() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let spawned = depth_guard_spawned("not-a-number", Some("3"));
+    assert!(
+        !spawned,
+        "recursion-depth guard must FAIL-CLOSED on a malformed \
+         AMPLIHACK_SESSION_DEPTH and bail, not default to depth 0 (issue #964)"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 7 — a forged over-large MAX_DEPTH is CLAMPED to the hard ceiling.
+//
+// AMPLIHACK_MAX_DEPTH is attacker-influenceable; a huge value must be clamped
+// to MAX_DEPTH_CEILING (32) before comparison. At depth == ceiling the guard
+// must still bail even though the raw MAX_DEPTH is astronomically larger.
+//
+// RED today: no guard exists (and no clamping is applied on the spawn path).
+// -------------------------------------------------------------------------
+#[test]
+fn test_depth_guard_clamps_forged_max_depth_to_ceiling() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let ceiling = crate::commands::session_tree::state::MAX_DEPTH_CEILING;
+    let at_ceiling = ceiling.to_string();
+    let spawned = depth_guard_spawned(&at_ceiling, Some("4294967295"));
+    assert!(
+        !spawned,
+        "recursion-depth guard must clamp a forged AMPLIHACK_MAX_DEPTH to the \
+         hard ceiling ({ceiling}) and bail at depth == ceiling (issue #964)"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 8 — below the limit the guard does NOT over-block.
+//
+// A legitimate nested run (depth 0, max 3) must still spawn the runner. This
+// guards against a regression where the depth guard is too aggressive.
+//
+// Passes today AND after the fix; it is a safety net, not a red test.
+// -------------------------------------------------------------------------
+#[test]
+fn test_depth_guard_allows_spawn_below_limit() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let spawned = depth_guard_spawned("0", Some("3"));
+    assert!(
+        spawned,
+        "depth guard must NOT block a legitimate below-limit run (depth 0 < \
+         max 3): the runner should have spawned (issue #964)"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Git-state restore helpers.
+// -------------------------------------------------------------------------
+
+/// Run `git <args...>` inside `repo` and return trimmed stdout, or `None` if
+/// git is unavailable or the command failed.
+fn git_in(repo: &Path, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Initialise a minimal, non-bare git repo at `repo`. Returns false (skip) if
+/// git is not usable in this environment.
+fn init_git_repo(repo: &Path) -> bool {
+    if std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .arg("init")
+        .arg("--quiet")
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+    {
+        return false;
+    }
+    // Deterministic identity so any future commit-based assertions are stable.
+    let _ = git_in(repo, &["config", "user.email", "t@example.com"]);
+    let _ = git_in(repo, &["config", "user.name", "Teardown Test"]);
+    // Confirm we start from the healthy, non-bare state.
+    matches!(
+        git_in(repo, &["config", "--get", "core.bare"]).as_deref(),
+        Some("false") | None
+    )
+}
+
+// -------------------------------------------------------------------------
+// Test 9 — caller git state is RESTORED after a terminal failure.
+//
+// Reproduces the observed #964 corruption: the runner flips the caller
+// checkout's `core.bare` to `true` (which makes `git status` fail with "this
+// operation must be run in a work tree") and then exits non-zero. After the
+// failed run the caller's checkout must be usable again: `core.bare` restored
+// and `git status` succeeds.
+//
+// RED today: no snapshot/restore logic exists, so `core.bare` stays `true` and
+// `git status` remains broken after the run.
+// -------------------------------------------------------------------------
+#[test]
+fn test_caller_git_state_restored_after_terminal_failure() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let repo = temp.path().join("caller-checkout");
+    std::fs::create_dir_all(&repo).expect("failed to create caller checkout dir");
+    if !init_git_repo(&repo) {
+        eprintln!("skipping: git unavailable for caller-git-state restore test");
+        return;
+    }
+    // `git status` must work before the run.
+    assert!(
+        git_in(&repo, &["status", "--porcelain"]).is_some(),
+        "precondition: caller checkout must be a healthy work tree before the run"
+    );
+
+    let runner = temp.path().join("recipe-runner-rs");
+    // The runner corrupts the CALLER checkout (passed as `-C` == working dir)
+    // exactly like the observed leak, then fails. `$5` is the `-C` value in the
+    // fixed argv layout: <recipe> --output-format json -C <working_dir> ...
+    write_stub(
+        &runner,
+        "#!/bin/sh\ngit -C \"$5\" config core.bare true\nexit 1\n",
+    );
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: git-corrupt-probe\nsteps: []\n")
+        .expect("failed to write recipe");
+
+    let _runner_env = EnvVarGuard::set(RUNNER_PATH_ENV, &runner);
+    let _timeout_env = EnvVarGuard::unset(RUNNER_TIMEOUT_ENV);
+
+    let result =
+        execute::execute_recipe_via_rust(&recipe, &BTreeMap::new(), false, true, &repo, &[], None);
+    result.expect_err("non-zero runner exit must surface as an error");
+
+    // The caller checkout must be restored to a usable state.
+    let bare_after = git_in(&repo, &["config", "--get", "core.bare"]);
+    assert!(
+        matches!(bare_after.as_deref(), Some("false") | None),
+        "terminal-failure cleanup must restore the caller checkout's core.bare \
+         (issue #964): core.bare is still {bare_after:?} after the failed run"
+    );
+    assert!(
+        git_in(&repo, &["status", "--porcelain"]).is_some(),
+        "terminal-failure cleanup must leave the caller checkout usable \
+         (`git status` must succeed) after the failed run (issue #964)"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 10 — restore preserves DURABLE CHILD WORKTREES.
+//
+// The restore must be scoped to the caller checkout's own config and must never
+// delete or unregister durable child worktrees produced by the run. A child
+// worktree directory created under the run must still exist after the failed
+// run, even as the caller's `core.bare` is restored.
+//
+// Passes today AND after the fix (restore never deletes) — a guard against an
+// over-broad restore that clobbers child artifacts.
+// -------------------------------------------------------------------------
+#[test]
+fn test_restore_preserves_durable_child_worktree() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let repo = temp.path().join("caller-checkout");
+    std::fs::create_dir_all(&repo).expect("failed to create caller checkout dir");
+    if !init_git_repo(&repo) {
+        eprintln!("skipping: git unavailable for child-worktree preservation test");
+        return;
+    }
+
+    let child_marker = repo.join("worktrees").join("child").join("KEEP");
+    let runner = temp.path().join("recipe-runner-rs");
+    // Create a durable child artifact, corrupt the caller, then fail.
+    write_stub(
+        &runner,
+        &format!(
+            "#!/bin/sh\nmkdir -p '{}'\necho durable > '{}'\ngit -C \"$5\" config core.bare true\nexit 1\n",
+            child_marker.parent().unwrap().display(),
+            child_marker.display()
+        ),
+    );
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: child-worktree-probe\nsteps: []\n")
+        .expect("failed to write recipe");
+
+    let _runner_env = EnvVarGuard::set(RUNNER_PATH_ENV, &runner);
+    let _timeout_env = EnvVarGuard::unset(RUNNER_TIMEOUT_ENV);
+
+    let result =
+        execute::execute_recipe_via_rust(&recipe, &BTreeMap::new(), false, true, &repo, &[], None);
+    result.expect_err("non-zero runner exit must surface as an error");
+
+    assert!(
+        child_marker.exists(),
+        "cleanup must PRESERVE durable child worktrees and never delete run \
+         artifacts (issue #964): {} was removed",
+        child_marker.display()
+    );
+}

--- a/crates/amplihack-cli/src/commands/recipe/run/tests_teardown.rs
+++ b/crates/amplihack-cli/src/commands/recipe/run/tests_teardown.rs
@@ -687,3 +687,74 @@ fn test_restore_preserves_durable_child_worktree() {
         child_marker.display()
     );
 }
+
+// -------------------------------------------------------------------------
+// Test 11 — caller git state is RESTORED on a STRUCTURED failure result.
+//
+// The more realistic corruption path: the runner does real work, corrupts the
+// caller checkout's `core.bare`, then reports failure by emitting a structured
+// JSON result with `"success": false` (rather than crashing with empty stdout).
+// That surfaces as `Ok(RecipeRunResult { success: false, .. })`, NOT `Err`, yet
+// it is still a terminal failure per issue #964 and must trigger the same
+// caller-checkout restore.
+//
+// RED before the fix: restore fired only on `result.is_err()`, so an
+// `Ok(success:false)` failure left `core.bare=true` and `git status` broken.
+// -------------------------------------------------------------------------
+#[test]
+fn test_caller_git_state_restored_after_structured_failure_result() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let repo = temp.path().join("caller-checkout");
+    std::fs::create_dir_all(&repo).expect("failed to create caller checkout dir");
+    if !init_git_repo(&repo) {
+        eprintln!("skipping: git unavailable for structured-failure restore test");
+        return;
+    }
+    assert!(
+        git_in(&repo, &["status", "--porcelain"]).is_some(),
+        "precondition: caller checkout must be a healthy work tree before the run"
+    );
+
+    let runner = temp.path().join("recipe-runner-rs");
+    // Corrupt the caller checkout, then report failure via STRUCTURED JSON on
+    // stdout and exit 0. Valid JSON stdout makes this parse to
+    // `Ok(RecipeRunResult { success: false })` — the non-`Err` terminal-failure
+    // path. `$5` is the `-C` value in the fixed argv layout.
+    write_stub(
+        &runner,
+        "#!/bin/sh\ngit -C \"$5\" config core.bare true\n\
+         printf '{\"recipe_name\":\"structured-fail\",\"success\":false}\\n'\nexit 0\n",
+    );
+
+    let recipe = temp.path().join("recipe.yaml");
+    std::fs::write(&recipe, "name: structured-fail-probe\nsteps: []\n")
+        .expect("failed to write recipe");
+
+    let _runner_env = EnvVarGuard::set(RUNNER_PATH_ENV, &runner);
+    let _timeout_env = EnvVarGuard::unset(RUNNER_TIMEOUT_ENV);
+
+    let result =
+        execute::execute_recipe_via_rust(&recipe, &BTreeMap::new(), false, true, &repo, &[], None);
+    let run = result.expect("structured failure must surface as Ok(RecipeRunResult)");
+    assert!(
+        !run.success,
+        "precondition: runner reported a structured failure (success == false)"
+    );
+
+    // Same restore guarantee as the `Err` path: caller checkout left usable.
+    let bare_after = git_in(&repo, &["config", "--get", "core.bare"]);
+    assert!(
+        matches!(bare_after.as_deref(), Some("false") | None),
+        "structured-failure cleanup must restore the caller checkout's core.bare \
+         (issue #964): core.bare is still {bare_after:?} after the failed run"
+    );
+    assert!(
+        git_in(&repo, &["status", "--porcelain"]).is_some(),
+        "structured-failure cleanup must leave the caller checkout usable \
+         (`git status` must succeed) after the failed run (issue #964)"
+    );
+}

--- a/docs/RECIPE_RUN_FAILURE_CLEANUP.md
+++ b/docs/RECIPE_RUN_FAILURE_CLEANUP.md
@@ -1,0 +1,228 @@
+# Recipe Run Failure Cleanup
+
+**Status:** Shipped — process teardown, the fail-closed recursion-depth guard,
+and caller git-state restoration all live in
+`crates/amplihack-cli/src/commands/recipe/run/execute.rs`.
+· **Issue:** [rysweet/amplihack-rs#964](https://github.com/rysweet/amplihack-rs/issues/964)
+· **Crate:** `amplihack-cli` · **Module:** `commands::recipe::run`
+
+## Overview
+
+`amplihack recipe run` launches a `recipe-runner-rs` child that, for
+orchestration recipes (`smart-orchestrator`, `dev-orchestrator`), recursively
+spawns further agent and recipe subprocesses. When a **terminal recipe step
+fails**, the top-level command must exit non-zero *and* leave the machine in a
+clean, usable state.
+
+Before this change a terminal failure could:
+
+- leak **hundreds of orphaned descendants** (`recipe-runner-rs`,
+  `amplihack copilot`, `node copilot`) that kept recursively spawning and were
+  reparented to PID 1, and
+- leave the **originating checkout unusable** — the caller's repository was left
+  with `core.bare=true`, so `git status` failed with
+  `this operation must be run in a work tree`.
+
+The failure-cleanup path now guarantees, on **any** terminal recipe failure:
+
+1. **Descendant teardown** — every process in the runner's session/process
+   group is terminated (landed behavior; see [Process teardown](#process-teardown)).
+2. **Recursion-depth enforcement** — a fail-closed guard blocks re-entry into
+   the orchestrator beyond the configured depth *before* any subprocess is
+   spawned (see [Depth guard](#depth-guard)).
+3. **Caller git-state restoration** — the originating checkout's pre-run
+   `core.bare` setting and worktree registration are restored, while durable
+   child commits and worktrees are preserved (see [Caller git-state
+   restoration](#caller-git-state-restoration)).
+4. **Explicit reporting** — any cleanup failure is surfaced via structured
+   `tracing` (never a stray `print!` / `println!`).
+
+All behavior is **additive and non-breaking**: the happy-path orchestration
+contract, the PRD, and all public APIs are unchanged. There is no "Bridge"
+naming anywhere in the feature.
+
+## Depth guard
+
+The depth guard is a **fail-closed** recursion limiter. It runs *before every
+subprocess spawn path* in `execute.rs`, so a failing or misbehaving recipe can
+never re-enter the orchestrator and fork-bomb the host.
+
+It **reuses the existing session-tree depth convention** rather than inventing a
+new one: the same `AMPLIHACK_SESSION_DEPTH` / `AMPLIHACK_MAX_DEPTH` env vars and
+the shared `DEFAULT_MAX_DEPTH` (`3`) and `MAX_DEPTH_CEILING` (`32`) constants
+from `commands::session_tree::state` (see `session_tree::tree_context`). The
+guard must not fork a second source of truth with a divergent ceiling.
+
+### Environment variables
+
+| Variable                 | Meaning                                  | Default | Hard cap |
+| ------------------------ | ---------------------------------------- | ------- | -------- |
+| `AMPLIHACK_SESSION_DEPTH`| Current nesting depth of this session    | `0`     | —        |
+| `AMPLIHACK_MAX_DEPTH`    | Maximum allowed nesting depth            | `3` (`DEFAULT_MAX_DEPTH`) | `32` (`MAX_DEPTH_CEILING`) |
+
+On each spawn the guard reads `AMPLIHACK_SESSION_DEPTH` and `AMPLIHACK_MAX_DEPTH`
+and bails **before** spawning when `depth >= max`.
+
+### Fail-closed parsing rules
+
+- **Absent** `AMPLIHACK_SESSION_DEPTH` → treated as `0` (top-level session).
+- **Malformed / non-numeric / overflowing** `AMPLIHACK_SESSION_DEPTH` →
+  treated as **at the maximum** (guard bails). It is never silently coerced to
+  `0`, which would bypass the guard.
+  > **Note:** this is intentionally *stricter* than the existing
+  > `session_tree::tree_context`, which parses malformed depth as `0`
+  > (fail-open). The recipe-run guard deliberately fails closed; implementers
+  > must not "align" it back to the fail-open behavior.
+- **Absent / malformed** `AMPLIHACK_MAX_DEPTH` → falls back to the default
+  `DEFAULT_MAX_DEPTH` (`3`).
+- **Forged large** `AMPLIHACK_MAX_DEPTH` (e.g. `999999`) → clamped to the shared
+  ceiling `MAX_DEPTH_CEILING` (`32`, via `.min(MAX_DEPTH_CEILING)`). This
+  prevents a forged environment from disabling the limit and turning a recursive
+  recipe into a fork bomb / DoS.
+
+### Behavior on limit
+
+When the limit is reached the guard returns a structured error and **no
+subprocess is spawned**:
+
+```text
+Error: recipe run recursion depth guard exceeded: depth 3 reached configured max 3
+```
+
+The error is emitted through `tracing` with numeric fields only:
+
+```
+WARN depth=3 max=3 recipe run blocked by recursion depth guard
+```
+
+> **Security:** the guard logs depths and counts only — never environment-variable
+> *values*, which may carry session tokens or secrets.
+
+### API
+
+```rust
+/// Fail-closed recursion guard for `amplihack recipe run`. Runs at the top of
+/// `execute_recipe_via_rust`, before binary lookup or any spawn.
+///
+/// Reads `AMPLIHACK_SESSION_DEPTH` (current depth, default `0`) and
+/// `AMPLIHACK_MAX_DEPTH` (limit, default `DEFAULT_MAX_DEPTH = 3`, clamped to the
+/// shared `MAX_DEPTH_CEILING = 32`) and returns `Err(..)` when `depth >= max`,
+/// BEFORE any subprocess is spawned. A malformed / non-UTF-8
+/// `AMPLIHACK_SESSION_DEPTH` is treated as at-max (fail-closed); a malformed
+/// `AMPLIHACK_MAX_DEPTH` falls back to `3`.
+fn enforce_recursion_depth_guard() -> anyhow::Result<()>;
+```
+
+## Caller git-state restoration
+
+Orchestration recipes create child worktrees for their nested tasks. On a
+terminal failure the caller's own checkout could be left with `core.bare=true`
+and its worktree registration dropped, making `git status` fail even though the
+source files were still on disk.
+
+The restoration flow:
+
+1. **Snapshot before spawn** — capture the caller checkout's `core.bare` value
+   and worktree registration state into a `GitStateSnapshot`.
+2. **Restore after terminal-failure teardown** — once descendants are reaped,
+   best-effort restore the snapshotted state on the caller checkout **only**.
+
+### Guarantees
+
+- Runs **only on terminal failure**, after descendant teardown — never on the
+  happy path.
+- **Best-effort:** a restore failure is logged via `tracing::warn!` and never
+  aborts or masks the original failure.
+- Scoped to the **single `core.bare` key** and the **caller checkout**. It never
+  touches child `.git` registrations, so durable child commits and worktrees are
+  preserved.
+- A `None` snapshot (nothing captured) is never restored as `false` — absence is
+  distinguished from a captured value.
+- Paths are canonicalized and `.git` ownership is confirmed before writing;
+  symlink / relative-path escapes are rejected. The operation inherits caller
+  privileges only (no elevation).
+
+### API
+
+```rust
+/// Pre-run snapshot of the caller checkout's `core.bare` state, captured before
+/// spawning the recipe runner.
+struct CallerGitState { /* dir + was_git_checkout + core.bare */ }
+
+impl CallerGitState {
+    /// Capture the caller checkout's `core.bare` before spawning. A no-op
+    /// (`was_git_checkout = false`) when `dir` is not a git work tree.
+    fn snapshot(dir: &Path) -> Self;
+
+    /// Best-effort restore of the caller checkout to the snapshotted `core.bare`,
+    /// run only after a terminal failure. Never bails: logs `tracing::error!` on
+    /// failure and preserves durable child worktrees (config-only).
+    fn restore_on_failure(&self);
+}
+```
+
+## Process teardown
+
+Descendant teardown is deterministic and scoped strictly to the runner's own
+process group.
+
+- The runner is spawned as a **session leader** (`setsid` in
+  `spawn_with_streaming_stderr`), so its PID doubles as the process-group id
+  (`pgid`) shared by every descendant.
+- Teardown signals target `-pgid` only via `libc::kill(-pgid, sig)` — it never
+  uses `pkill` / `killall` / name-based matching, and never touches parent or
+  unrelated processes.
+- Contract: **SIGTERM → grace window → SIGKILL**.
+  - `terminate_recipe_runner` handles the timeout path.
+  - `reap_recipe_runner_group` sweeps orphaned descendants left behind on any
+    non-timeout early-exit (success *or* failure).
+- A missing group (`ESRCH`) is expected and silent; any other signal failure is
+  logged via `tracing::warn!`.
+
+### Grace window configuration
+
+| Variable                      | Meaning                                    | Default |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `AMPLIHACK_TEARDOWN_GRACE_SECS` | Whole-second SIGTERM→SIGKILL grace window. `0` escalates to SIGKILL immediately. | `RECIPE_RUNNER_DEFAULT_TEARDOWN_GRACE` (`5` seconds) |
+
+## End-to-end failure sequence
+
+```text
+amplihack recipe run smart-orchestrator ...
+  │
+  ├─ enforce_recursion_depth_guard()     # fail-closed: bail before spawn if depth >= max
+  ├─ CallerGitState::snapshot(repo)      # capture caller core.bare before spawn
+  ├─ spawn recipe-runner-rs (setsid)     # session leader; pgid == pid
+  │     └─ … nested agents / recipes …
+  │
+  ├─ TERMINAL FAILURE
+  │     ├─ terminate_recipe_runner / reap_recipe_runner_group   # SIGTERM → grace → SIGKILL on -pgid
+  │     └─ caller_git.restore_on_failure()                      # best-effort; preserves child worktrees
+  │
+  └─ exit non-zero, structured tracing report
+```
+
+## Constraints
+
+- Additive / non-breaking; the PRD and happy-path orchestration contract are
+  preserved.
+- Structured `tracing` + OpenTelemetry only — **no** `print!` / `println!` /
+  `eprintln!` in the new code.
+- No "Bridge" naming.
+- Shared OODA-core files (`execute.rs`) are modified under the serialized
+  `ooda-core` sequence group to avoid colliding with other core edits.
+
+## Testing
+
+Regression coverage lives in
+`crates/amplihack-cli/src/commands/recipe/run/tests_teardown.rs` (uses an RAII
+env-guard and a stub spawn harness — no real sockets, no real recursion):
+
+| Test area                         | Asserts                                                                 |
+| --------------------------------- | ----------------------------------------------------------------------- |
+| Depth-exceeded bail               | `enforce_recursion_depth_guard` bails and no spawn occurs.              |
+| Malformed `AMPLIHACK_SESSION_DEPTH` | Fail-closed: treated as at-max, guard bails.                          |
+| Forged `AMPLIHACK_MAX_DEPTH`      | Clamped to shared `MAX_DEPTH_CEILING = 32`.                             |
+| Git snapshot / restore idempotency | Caller `core.bare` restored so `git status` works again on failure.   |
+| Child-worktree preservation       | Durable child worktrees are never removed by restoration.              |
+| Descendant teardown (verify-only) | Signals target `-pgid` only; no name-based kill.                       |

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -73,6 +73,7 @@ Complete documentation for using the Recipe Runner:
 - **[Recipe Run Correlation Reference](../reference/recipe-run-correlation.md)** - Stable run IDs, log pointer schema, and result fields
 - **[Recipe Context Environment Export](../reference/recipe-context-environment.md)** - How context variables reach bash steps as environment variables (`$TASK_DESCRIPTION`, `$REPO_PATH`), the reserved-name denylist, and precedence
 - **[Tutorial: Propagate Recipe Context to Bash Steps](../tutorials/recipe-context-env-propagation.md)** - Hands-on walkthrough for top-level, nested, and skipped keys
+- **[Recipe Run Failure Cleanup](../RECIPE_RUN_FAILURE_CLEANUP.md)** - Deterministic descendant teardown, the fail-closed recursion-depth guard (`AMPLIHACK_SESSION_DEPTH` / `AMPLIHACK_MAX_DEPTH`), and caller git-state (`core.bare`) restoration on terminal failure (issue #964)
 - **[Recipe CLI Examples](cli-examples.md)** - Real-world usage scenarios (development, testing, CI/CD, team workflows)
 - **[Workflow Provider Abstraction](../features/workflow-provider-abstraction.md)** - Provider-neutral tracking, change requests, terminal state, and stale cleanup through typed helpers
 - **[Recipe Simulation Reference](../reference/workflow-simulation.md)** - Deterministic fake-provider, fake-tool, and fake-agent simulation for recipe regression coverage


### PR DESCRIPTION
Closes #964.

## Problem
After a terminal `smart-orchestrator` / recipe-runner failure, the top-level command exited non-zero but left the host broken:
- **300+ orphaned descendants** (`recipe-runner-rs` → `amplihack copilot` → `node copilot`) kept recursively spawning, reparented to PID 1.
- The **originating checkout was left with `core.bare=true`**, so `git status` failed with `this operation must be run in a work tree` — while source files and child `worktrees/` were still present.

Previously teardown ran only on the **timeout** path and sent an immediate `SIGKILL` to the group; every other early-exit/failure path leaked the tree, there was no recursion ceiling on nested `recipe run` spawns, and a checkout the runner corrupted was never repaired.

## Fix (all Unix process-group work is `#[cfg(unix)]`)
1. **Deterministic descendant teardown** — the runner is spawned as a session leader, so its PID is the shared process-group id. Teardown is now a three-phase reaper: **SIGTERM → configurable grace → SIGKILL**, scoped strictly to `-pgid` (never touches parent/unrelated processes; `ESRCH` = empty group = success). Fires on the timeout path (`terminate_recipe_runner`) **and** every non-timeout early exit (`reap_recipe_runner_group`). Grace window: `AMPLIHACK_TEARDOWN_GRACE_SECS` (default 5s, `0` = immediate).
2. **Fail-closed recursion-depth guard** — `enforce_recursion_depth_guard` runs **before** any binary lookup / temp dir / spawn, reusing the existing `AMPLIHACK_SESSION_DEPTH` / `AMPLIHACK_MAX_DEPTH` convention and shared `DEFAULT_MAX_DEPTH` (3) / `MAX_DEPTH_CEILING` (32). A malformed depth is treated as at-the-limit (never coerced to 0); a forged over-large max is clamped to the ceiling.
3. **Caller git-state restore** — `CallerGitState` snapshots `core.bare` before spawning and, on terminal failure only, restores the pre-run value (config-only). It never touches the work tree and never unregisters durable child worktrees — child commits/worktrees are **preserved** while the caller checkout stays usable.
4. **Explicit reporting** — every cleanup failure is surfaced via structured `tracing` (numeric depth/limit fields only, never env values). No stray `print!`/`println!`.

**Additive and non-breaking** — the happy path is unchanged.

## Tests
`tests_teardown.rs` (Unix-only) drives the public `execute_recipe_via_rust` with stub runners:
- failure-path descendant reaping
- SIGTERM-before-SIGKILL ordering
- configurable grace window
- process-group scoping (sibling untouched)
- all four depth-guard branches (bail at limit, fail-closed malformed, clamp forged max, allow below)
- git-state restore + durable-child-worktree preservation

`cargo test -p amplihack-cli --lib recipe::run::tests_teardown`: **10 passed**. `cargo fmt --check` and pre-commit `clippy` clean.

## Docs
`docs/RECIPE_RUN_FAILURE_CLEANUP.md` + recipes README link.

Note: #962 (missing `workflow_implementation_evidence.sh`) was the terminal trigger and is out of scope here.