### PR TITLE
docs(signal): make Signal onboarding discoverable from top-level docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ These are the features you'll use daily:
 | **Recipe Runner**    | Code-enforced workflows that models cannot skip                              |
 | **`/fix <pattern>`** | Rapid resolution of common errors (imports, CI, tests, config)               |
 | **85+ Skills**       | PDF/Excel/Word processing, Azure admin, pre-commit management, and more      |
+| **[Signal Channel](docs/SIGNAL_ONBOARDING.md)** | Per-session Signal notifications + reply-to-agent, configured via `amplihack signal setup` / distributed with `amplihack signal distribute` |
 
 ### Everything Else
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -48,6 +48,7 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 ## Signal Channel
 
 - [Signal Channel](../signal-channel.md) — feature-gated (`signal`, default OFF) per-session Signal messaging channel. Each session opens a private Signal group, posts throttled progress updates, and lets an allow-listed operator send **advisory** instructions back into the run. Inbound text is surfaced only as `hookSpecificOutput.additionalContext` and is never auto-executed; the gate is fail-closed (allowlist + `device == 1` + `groupId` match + bounded-TTL echo suppression). Wired through `amplihack-hooks` (SessionStart/PostToolUse/UserPromptSubmit/Stop) with a detached `signal-subscriber` process. Config is env-first with no silent defaults; see [`examples/signal-config.toml`](../../examples/signal-config.toml).
+- Setup / onboarding: [Signal Onboarding](../SIGNAL_ONBOARDING.md) — step-by-step how-to for configuring one host with `amplihack signal setup` and distributing the config across a fleet with `amplihack signal distribute`.
 
 ## GitHub Distribution
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -687,6 +687,7 @@ Robust handling of conversation compaction in long sessions:
 ### Third-Party Integrations
 
 - [MCP Evaluation](mcp_evaluation/README.md) - Model Context Protocol evaluation
+- [Signal Onboarding](SIGNAL_ONBOARDING.md) / [Signal Channel](signal-channel.md) - Per-session Signal notifications with advisory reply-to-agent, configured via `amplihack signal setup`
 
 ---
 


### PR DESCRIPTION
## Summary

Improves discoverability of the already-merged Signal onboarding documentation. The Signal feature (`amplihack signal setup` / `amplihack signal distribute`, per-session Signal chats) was documented in `docs/SIGNAL_ONBOARDING.md` and `docs/signal-channel.md` but not linked from top-level docs.

## Changes (documentation-only)

- **docs/features/README.md** — Under `## Signal Channel`, added a `Setup / onboarding` bullet linking `../SIGNAL_ONBOARDING.md` next to the existing `signal-channel.md` link.
- **docs/index.md** — Added a Signal entry under `### Third-Party Integrations` linking both `SIGNAL_ONBOARDING.md` and `signal-channel.md`, matching the local list style.
- **README.md** — Added a `Signal Channel` row to the Features table linking `docs/SIGNAL_ONBOARDING.md`.

## Notes

- Relative link depth verified correct per file location.
- No Rust code, Cargo files, tests, or version numbers changed.
- Pre-commit hooks pass locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Closes #975
