### PR TITLE
feat(publish): best-effort PR labels via WORKFLOW_PR_LABELS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Recipes — PR always opens after successful push (issue #495)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-pr-always-opens.sh
+      - name: Recipes — best-effort PR labels from WORKFLOW_PR_LABELS
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-pr-labels-best-effort.sh
       - name: Recipes — static guard validation scope (issue #495)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-static-guard-validation-scope.sh

--- a/amplifier-bundle/recipes/tests/test-pr-labels-best-effort.sh
+++ b/amplifier-bundle/recipes/tests/test-pr-labels-best-effort.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# test-pr-labels-best-effort.sh — unit test for apply_pr_labels_best_effort()
+# in tools/workflow_publish_pr.sh.
+#
+# Contract under test:
+#   1. When WORKFLOW_PR_LABELS is set, the host is GitHub, a numeric PR number
+#      was resolved, and `gh` is present, EACH comma-separated label is applied
+#      via `gh pr edit <number> --add-label <label>` (whitespace trimmed).
+#   2. When WORKFLOW_PR_LABELS is empty/unset, NO `gh pr edit` runs.
+#   3. When the host is not GitHub, NO `gh pr edit` runs.
+#   4. When the PR number is not numeric, NO `gh pr edit` runs.
+#   5. A failing `gh pr edit` (e.g. label missing in repo) is best-effort: the
+#      function still returns 0 and never aborts the publish.
+#
+# The helper is sourced in isolation via the WORKFLOW_PUBLISH_PR_LIB_ONLY seam,
+# so this test needs neither a git remote nor the wider publish machinery.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-pr-labels-best-effort.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+PUBLISH_LIB="${REPO_ROOT}/amplifier-bundle/tools/workflow_publish_pr.sh"
+
+if [[ ! -f "${PUBLISH_LIB}" ]]; then
+    echo "HARNESS-ERROR: ${PUBLISH_LIB} not found" >&2
+    exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "HARNESS-ERROR: jq required" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d -t pr-labels-XXXXXX)"
+trap 'rm -rf "${WORK}"' EXIT
+
+mkdir -p "${WORK}/bin"
+GH_LOG="${WORK}/gh-invocations.log"
+export GH_INVOCATIONS_LOG="${GH_LOG}"
+
+# Fake `gh` shim — records every invocation. Fails `pr edit --add-label` when
+# the label is the sentinel "does-not-exist" (to exercise best-effort), else
+# succeeds. Never contacts the network.
+cat > "${WORK}/bin/gh" <<'SHIM'
+#!/usr/bin/env bash
+log="${GH_INVOCATIONS_LOG:?GH_INVOCATIONS_LOG must be set}"
+printf '%s\n' "$*" >> "$log"
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "edit" ]; then
+    for a in "$@"; do
+        if [ "$a" = "does-not-exist" ]; then
+            echo "could not add label: 'does-not-exist' not found" >&2
+            exit 1
+        fi
+    done
+fi
+exit 0
+SHIM
+chmod +x "${WORK}/bin/gh"
+
+fail() { echo "FAIL[$1]: $2" >&2; echo "--- gh-invocations.log ---" >&2; cat "${GH_LOG}" 2>/dev/null >&2 || true; exit 1; }
+
+# Reset the invocation log and run apply_pr_labels_best_effort in a subshell
+# with the given environment. Emits the function's return code on stdout.
+# Args: HOST_TYPE PR_NUMBER_RESULT WORKFLOW_PR_LABELS with_gh(1|0)
+run_case() {
+    local host="$1" prnum="$2" labels="$3" with_gh="$4"
+    : > "${GH_LOG}"
+    local path_prefix=""
+    [ "$with_gh" = "1" ] && path_prefix="${WORK}/bin:"
+    (
+        set -euo pipefail
+        export PATH="${path_prefix}/usr/bin:/bin"
+        export GH_INVOCATIONS_LOG="${GH_LOG}"
+        export WORKFLOW_PUBLISH_PR_LIB_ONLY=1
+        export WORKFLOW_PR_LABELS="${labels}"
+        # shellcheck source=/dev/null
+        . "${PUBLISH_LIB}"
+        # shellcheck disable=SC2034  # consumed by the sourced apply_pr_labels_best_effort
+        HOST_TYPE="${host}"
+        # shellcheck disable=SC2034  # consumed by the sourced apply_pr_labels_best_effort
+        PR_NUMBER_RESULT="${prnum}"
+        apply_pr_labels_best_effort
+        echo "rc=$?"
+    )
+}
+
+edit_calls() { grep -cE '^pr edit ' "${GH_LOG}" 2>/dev/null || true; }
+
+# --- Case 1: happy path, two labels (one padded with whitespace) -----------
+out="$(run_case github 4321 'simard-autonomous, needs-attention ' 1)"
+[[ "${out##*rc=}" == "0" ]] || fail 1 "function did not return 0 on happy path (got '${out}')"
+grep -qE '^pr edit 4321 --add-label simard-autonomous$' "${GH_LOG}" \
+    || fail 1 "expected 'pr edit 4321 --add-label simard-autonomous' not recorded"
+grep -qE '^pr edit 4321 --add-label needs-attention$' "${GH_LOG}" \
+    || fail 1 "second label not trimmed/applied ('needs-attention' expected)"
+[[ "$(edit_calls)" == "2" ]] || fail 1 "expected exactly 2 pr-edit calls, got $(edit_calls)"
+
+# --- Case 2: no labels configured → no edits -------------------------------
+run_case github 4321 '' 1 >/dev/null
+[[ "$(edit_calls)" == "0" ]] || fail 2 "pr edit invoked despite empty WORKFLOW_PR_LABELS"
+
+# --- Case 3: non-GitHub host → no edits ------------------------------------
+run_case azdo 4321 'simard-autonomous' 1 >/dev/null
+[[ "$(edit_calls)" == "0" ]] || fail 3 "pr edit invoked on non-GitHub host"
+
+# --- Case 4: non-numeric PR number → no edits ------------------------------
+run_case github 'not-a-number' 'simard-autonomous' 1 >/dev/null
+[[ "$(edit_calls)" == "0" ]] || fail 4 "pr edit invoked with non-numeric PR number"
+
+# --- Case 4b: empty PR number → no edits -----------------------------------
+run_case github '' 'simard-autonomous' 1 >/dev/null
+[[ "$(edit_calls)" == "0" ]] || fail 4b "pr edit invoked with empty PR number"
+
+# --- Case 5: failing label edit is best-effort (function still returns 0) ---
+out="$(run_case github 4321 'does-not-exist' 1)"
+[[ "${out##*rc=}" == "0" ]] || fail 5 "function did not return 0 when gh pr edit failed"
+grep -qE '^pr edit 4321 --add-label does-not-exist$' "${GH_LOG}" \
+    || fail 5 "failing label edit was not attempted"
+
+echo "PASS: apply_pr_labels_best_effort applies WORKFLOW_PR_LABELS best-effort on GitHub PRs only."
+exit 0

--- a/amplifier-bundle/recipes/tests/test-pr-labels-best-effort.sh
+++ b/amplifier-bundle/recipes/tests/test-pr-labels-best-effort.sh
@@ -63,9 +63,9 @@ fail() { echo "FAIL[$1]: $2" >&2; echo "--- gh-invocations.log ---" >&2; cat "${
 
 # Reset the invocation log and run apply_pr_labels_best_effort in a subshell
 # with the given environment. Emits the function's return code on stdout.
-# Args: HOST_TYPE PR_NUMBER_RESULT WORKFLOW_PR_LABELS with_gh(1|0)
+# Args: HOST_TYPE PR_NUMBER_RESULT WORKFLOW_PR_LABELS with_gh(1|0) [PR_STATE]
 run_case() {
-    local host="$1" prnum="$2" labels="$3" with_gh="$4"
+    local host="$1" prnum="$2" labels="$3" with_gh="$4" pr_state="${5:-}"
     : > "${GH_LOG}"
     local path_prefix=""
     [ "$with_gh" = "1" ] && path_prefix="${WORK}/bin:"
@@ -81,6 +81,8 @@ run_case() {
         HOST_TYPE="${host}"
         # shellcheck disable=SC2034  # consumed by the sourced apply_pr_labels_best_effort
         PR_NUMBER_RESULT="${prnum}"
+        # shellcheck disable=SC2034  # consumed by the sourced apply_pr_labels_best_effort
+        PR_STATE="${pr_state}"
         apply_pr_labels_best_effort
         echo "rc=$?"
     )
@@ -112,6 +114,16 @@ run_case github 'not-a-number' 'simard-autonomous' 1 >/dev/null
 # --- Case 4b: empty PR number → no edits -----------------------------------
 run_case github '' 'simard-autonomous' 1 >/dev/null
 [[ "$(edit_calls)" == "0" ]] || fail 4b "pr edit invoked with empty PR number"
+
+# --- Case 4c: MERGED / CLOSED PR state → no edits (nothing to gate) ---------
+run_case github 4321 'simard-autonomous' 1 MERGED >/dev/null
+[[ "$(edit_calls)" == "0" ]] || fail 4c "pr edit invoked on a MERGED PR"
+run_case github 4321 'simard-autonomous' 1 CLOSED >/dev/null
+[[ "$(edit_calls)" == "0" ]] || fail 4c "pr edit invoked on a CLOSED PR"
+
+# --- Case 4d: OPEN PR state still labels -----------------------------------
+run_case github 4321 'simard-autonomous' 1 OPEN >/dev/null
+[[ "$(edit_calls)" == "1" ]] || fail 4d "OPEN PR was not labeled (got $(edit_calls) edits)"
 
 # --- Case 5: failing label edit is best-effort (function still returns 0) ---
 out="$(run_case github 4321 'does-not-exist' 1)"

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -30,6 +30,37 @@ emit_publish_result() {
     '{state:$state,legacy_state:$legacy_state,terminal_status:$terminal_status,pr_url:$pr_url,pr_number:$pr_number,branch_diff_status:$branch_diff_status,message:$message}'
 }
 
+# Best-effort: apply caller-configured labels to the GitHub PR that was just
+# published (created OR matched as an existing open PR for this branch). The
+# labels come from the comma-separated `WORKFLOW_PR_LABELS` env var, so the
+# generic bundle stays policy-free — the caller (e.g. an autonomous agent that
+# needs a durable "eligible for gated self-merge" marker) decides what to apply.
+#
+# This NEVER fails the publish: a label that does not exist in the repo, a
+# transient GitHub API error, or a missing `gh` must not block the PR flow, so
+# every failure is warn-and-continue and the function always returns 0. It is a
+# no-op unless the host is GitHub, a numeric PR number was resolved, and at
+# least one label was requested.
+apply_pr_labels_best_effort() {
+  local labels_csv="${WORKFLOW_PR_LABELS:-}"
+  [ -n "$labels_csv" ] || return 0
+  [ "${HOST_TYPE:-}" = "github" ] || return 0
+  case "${PR_NUMBER_RESULT:-}" in '' | *[!0-9]*) return 0 ;; esac
+  command -v gh >/dev/null 2>&1 || return 0
+
+  local label
+  # Split on commas without word-splitting globs or leaking IFS: read each
+  # comma-separated entry as a line, then trim surrounding whitespace.
+  while IFS= read -r label || [ -n "$label" ]; do
+    label="$(printf '%s' "$label" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -n "$label" ] || continue
+    if ! gh pr edit "$PR_NUMBER_RESULT" --add-label "$label" >/dev/null 2>&1; then
+      echo "WARNING: workflow_publish_pr.sh: best-effort label '${label}' not applied to PR #${PR_NUMBER_RESULT} (label may not exist in this repo, or GitHub API unavailable)" >&2
+    fi
+  done < <(printf '%s' "$labels_csv" | tr ',' '\n')
+  return 0
+}
+
 finish_publish() {
   local state="$1"
   local legacy_state="$2"
@@ -41,6 +72,9 @@ finish_publish() {
   LEGACY_PUBLISH_STATE="$legacy_state"
   TERMINAL_STATUS="$terminal_status"
   MESSAGE="$message"
+  if [ "$terminal_status" = "success" ]; then
+    apply_pr_labels_best_effort
+  fi
   emit_publish_result
   exit "$exit_code"
 }
@@ -270,6 +304,15 @@ scoped_pr_lookup() {
   fi
   finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "scoped PR lookup failed: ${reason:-unknown}" 1
 }
+
+# Test seam: when sourced with WORKFLOW_PUBLISH_PR_LIB_ONLY set, return after
+# defining the helper functions above so unit tests can exercise pure helpers
+# (e.g. apply_pr_labels_best_effort) without running the full publish flow.
+# Never set in production, so the publish path below always executes normally.
+if [ -n "${WORKFLOW_PUBLISH_PR_LIB_ONLY:-}" ]; then
+  # shellcheck disable=SC2317  # exit 0 is reached only when executed, not sourced
+  return 0 2>/dev/null || exit 0
+fi
 
 HOST_TYPE="${REMOTE_HOST_TYPE:-other}"
 CURRENT_BRANCH=$(git branch --show-current)

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -46,6 +46,12 @@ apply_pr_labels_best_effort() {
   [ -n "$labels_csv" ] || return 0
   [ "${HOST_TYPE:-}" = "github" ] || return 0
   case "${PR_NUMBER_RESULT:-}" in '' | *[!0-9]*) return 0 ;; esac
+  # Only label PRs that are newly created or currently OPEN. A MERGED/CLOSED
+  # terminal is a no-op success (nothing to gate for the merge queue), and
+  # labeling a closed PR would be pointless churn. PR_STATE is empty on the
+  # create-new path (no pre-existing PR was found), so this still labels
+  # freshly created PRs.
+  case "${PR_STATE:-}" in MERGED | CLOSED) return 0 ;; esac
   command -v gh >/dev/null 2>&1 || return 0
 
   local label
@@ -54,8 +60,10 @@ apply_pr_labels_best_effort() {
   while IFS= read -r label || [ -n "$label" ]; do
     label="$(printf '%s' "$label" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
     [ -n "$label" ] || continue
-    if ! gh pr edit "$PR_NUMBER_RESULT" --add-label "$label" >/dev/null 2>&1; then
-      echo "WARNING: workflow_publish_pr.sh: best-effort label '${label}' not applied to PR #${PR_NUMBER_RESULT} (label may not exist in this repo, or GitHub API unavailable)" >&2
+    # `timeout 60` mirrors every other gh call in this script: a hung
+    # `gh pr edit` must never block finish_publish from emitting its JSON.
+    if ! timeout 60 gh pr edit "$PR_NUMBER_RESULT" --add-label "$label" >/dev/null 2>&1; then
+      echo "WARNING: workflow_publish_pr.sh: best-effort label '${label}' not applied to PR #${PR_NUMBER_RESULT} (label may not exist in this repo, GitHub API unavailable, or timed out)" >&2
     fi
   done < <(printf '%s' "$labels_csv" | tr ',' '\n')
   return 0
@@ -305,13 +313,13 @@ scoped_pr_lookup() {
   finish_publish "FAILED_PR_IDENTITY" "invalid-pr-identity" "failure" "scoped PR lookup failed: ${reason:-unknown}" 1
 }
 
-# Test seam: when sourced with WORKFLOW_PUBLISH_PR_LIB_ONLY set, return after
-# defining the helper functions above so unit tests can exercise pure helpers
-# (e.g. apply_pr_labels_best_effort) without running the full publish flow.
-# Never set in production, so the publish path below always executes normally.
-if [ -n "${WORKFLOW_PUBLISH_PR_LIB_ONLY:-}" ]; then
-  # shellcheck disable=SC2317  # exit 0 is reached only when executed, not sourced
-  return 0 2>/dev/null || exit 0
+# Test seam: when this file is *sourced* with WORKFLOW_PUBLISH_PR_LIB_ONLY set,
+# return after defining the helper functions above so unit tests can exercise
+# pure helpers (e.g. apply_pr_labels_best_effort) without running the publish
+# flow. Guarded by `BASH_SOURCE[0] != $0` so it can ONLY short-circuit when
+# sourced — a leaked env var can never abort a directly-executed production run.
+if [ -n "${WORKFLOW_PUBLISH_PR_LIB_ONLY:-}" ] && [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+  return 0
 fi
 
 HOST_TYPE="${REMOTE_HOST_TYPE:-other}"


### PR DESCRIPTION
## Problem

Simard's autonomous engineers publish their PRs through this bundle's `workflow_publish_pr.sh`. Those PRs land on `feat/*`/`fix/*` branches and are authored by the same GitHub account as the operator's own manual PRs. Simard's merge-queue candidate filter therefore cannot tell agent PRs from human PRs by author or branch, and the intended primary discriminator — a `simard-autonomous` label — was **never applied at PR creation**. Net effect: green, mergeable engineer PRs were invisible to the self-merge queue and piled up unmerged.

The publish script had **no** way to label a PR at creation.

## Change

`workflow_publish_pr.sh` gains a best-effort `apply_pr_labels_best_effort()` that applies the comma-separated labels in the `WORKFLOW_PR_LABELS` env var to the GitHub PR it just published — both the *create-new* and *existing-open* paths, via the single common `finish_publish` success terminal.

- **Policy-free:** the bundle applies whatever the caller configures and **nothing by default**. The caller (Simard) decides to set `WORKFLOW_PR_LABELS=simard-autonomous`; the generic bundle carries no Simard-specific policy.
- **Best-effort by construction:** a label missing from the repo, a GitHub API error, a missing `gh`, a non-GitHub host, or a non-numeric/empty PR number is a no-op / warn-and-continue that **never** changes the publish exit code or the emitted result JSON. Warnings go to stderr so they can't corrupt the JSON the recipe parses on stdout.
- **No brittle parsing:** discrimination is a durable label marker, not title/body scraping.

This is **inert until a caller sets `WORKFLOW_PR_LABELS`** — safe to land independently. The Simard side (setting that env in the engineer spawn) is a separate PR.

## Tests

New `amplifier-bundle/recipes/tests/test-pr-labels-best-effort.sh` (wired into CI) sources the helper in isolation via a new `WORKFLOW_PUBLISH_PR_LIB_ONLY` seam and asserts:
1. happy path applies each comma-separated label (whitespace trimmed);
2. empty `WORKFLOW_PR_LABELS` → no `gh pr edit`;
3. non-GitHub host → no `gh pr edit`;
4. non-numeric / empty PR number → no `gh pr edit`;
5. a failing `gh pr edit` (label missing) is best-effort — function still returns 0.

Existing `test-pr-always-opens.sh` still passes; `bash -n` + shellcheck clean on the new lines.