### PR TITLE
fix(workflow): ancestry-aware Step 15 publish, no blind rebase onto unrelated upstream (#978)

### DIFF
--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -275,19 +275,46 @@ steps:
       fi
       COMMITS_AHEAD=$(git rev-list --count @{u}..HEAD)
       if [ "$COMMITS_AHEAD" -ne 0 ]; then
-        pull_output_file=$(mktemp -t step15-pull-XXXXXX)
-        if git pull --rebase >"$pull_output_file" 2>&1; then
-          redact_sensitive_file "$pull_output_file" >&2
-          rm -f "$pull_output_file"
+        # FIX (#978): ancestry-aware integration. Step 15 must NOT blindly
+        # `git pull --rebase` onto the configured upstream. When a temporary
+        # workstream branch tracks an unrelated/stale upstream, rebasing replays
+        # already-integrated commits and produces add/add conflicts. Refresh the
+        # upstream ref, then decide by ancestry:
+        #   • upstream is an ancestor of HEAD (behind==0) -> fast-forward push,
+        #     preserving the tested commit identities (no history rewrite).
+        #   • histories diverged (behind>0) -> fail closed with structured
+        #     merge-base/ahead/behind evidence and require an explicit
+        #     merge/rebase decision. Never auto-replay already-integrated history.
+        UPSTREAM_REF=$(git rev-parse --abbrev-ref '@{u}' 2>/dev/null || echo "unknown")
+        fetch_output_file=$(mktemp -t step15-fetch-XXXXXX)
+        if git fetch origin >"$fetch_output_file" 2>&1; then
+          redact_sensitive_file "$fetch_output_file" >&2
         else
-          pull_rc=$?
-          sanitized=$(redact_sensitive_file "$pull_output_file" | tr '\n' ' ' | head -c 500)
-          reason="pull-failed: ${sanitized}"
-          echo "ERROR: git pull --rebase failed (exit $pull_rc)" >&2
-          redact_sensitive_file "$pull_output_file" >&2
-          rm -f "$pull_output_file"
-          exit "$pull_rc"
+          echo "WARNING: git fetch origin failed before ancestry check; using cached upstream state" >&2
+          redact_sensitive_file "$fetch_output_file" >&2
         fi
+        rm -f "$fetch_output_file"
+        COMMITS_AHEAD=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+        COMMITS_BEHIND=$(git rev-list --count 'HEAD..@{u}' 2>/dev/null || echo 0)
+        if [ "$COMMITS_AHEAD" -eq 0 ]; then
+          echo "INFO: HEAD no longer ahead of upstream '$UPSTREAM_REF' after fetch — nothing to push" >&2
+          raw_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
+          if printf '%s' "$raw_sha" | grep -qE '^[0-9a-f]{40}$'; then sha="$raw_sha"; fi
+          pushed="true"; reason="already-pushed"
+          echo "=== Commit and Push Complete ===" >&2
+          exit 0
+        fi
+        if [ "$COMMITS_BEHIND" -ne 0 ]; then
+          MERGE_BASE=$(git merge-base HEAD '@{u}' 2>/dev/null || echo "none")
+          HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+          echo "ERROR: step-15 refuses to rebase divergent history onto upstream '$UPSTREAM_REF' (issue #978)." >&2
+          echo "  ancestry: ahead=$COMMITS_AHEAD behind=$COMMITS_BEHIND merge_base=$MERGE_BASE head=$HEAD_SHA upstream=$UPSTREAM_REF" >&2
+          echo "  Auto-rebasing would replay already-integrated commits and create add/add conflicts." >&2
+          echo "  Point the branch at its intended PR base and fast-forward, or make an explicit rebase decision." >&2
+          reason="diverged-upstream: ahead=$COMMITS_AHEAD behind=$COMMITS_BEHIND merge_base=$MERGE_BASE upstream=$UPSTREAM_REF"
+          exit 1
+        fi
+        echo "INFO: upstream '$UPSTREAM_REF' is an ancestor of HEAD — fast-forward push, no rebase (#978)" >&2
         # FIX (#495): capture push stderr, redact tokens before reason emission.
         push_stderr_file=$(mktemp -t step15-push-XXXXXX)
         # shellcheck disable=SC2064

--- a/amplifier-bundle/recipes/workflow-publish.yaml
+++ b/amplifier-bundle/recipes/workflow-publish.yaml
@@ -4,8 +4,8 @@ version: "1.0.0"
 author: "Amplihack Team"
 tags: ["development", "version", "pr"]
 # workflow-publish: default-workflow phase brick. Parent context is merged by
-# recipe-runner and declared outputs propagate to later phase recipes.
-# Pager safety: recipe-runner-rs sets GIT_PAGER=cat/PAGER=cat for subprocesses.
+# recipe-runner; declared outputs propagate to later phase recipes. Pager safety:
+# recipe-runner-rs sets GIT_PAGER=cat/PAGER=cat for subprocesses.
 recursion:
   max_depth: 6
   max_total_steps: 80
@@ -85,12 +85,9 @@ steps:
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-14b requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
-      # Issue #915: step-14 bumps the workspace version in Cargo.toml but leaves
-      # Cargo.lock stale. Every pre-commit gate (artifact-guard, cargo-clippy,
-      # cargo-test) runs with --locked, so step-15 fails deterministically with
-      # "cannot update the lock file ... because --locked was passed". Keep the
-      # lock IN SYNC (do NOT weaken --locked) using an offline, network-free
-      # update. Skip gracefully on non-Rust workspaces.
+      # Issue #915: step-14's version bump leaves Cargo.lock stale, so --locked
+      # pre-commit gates fail deterministically. Keep the lock IN SYNC (do NOT
+      # weaken --locked) via an offline update; skip gracefully on non-Rust workspaces.
       if [ -f Cargo.toml ] && [ -f Cargo.lock ]; then
         echo "step-14b: syncing Cargo.lock to bumped version (offline)"
         cargo update --workspace --offline
@@ -105,15 +102,10 @@ steps:
       set -euo pipefail
       : "${WORKTREE_SETUP_WORKTREE_PATH:=${RECIPE_VAR_worktree_setup__worktree_path:-${REPO_PATH:-}}}"
       cd "${WORKTREE_SETUP_WORKTREE_PATH:?step-14c requires worktree_setup.worktree_path from step-04 (workflow-worktree); ensure parent recipe ran worktree-setup and propagated outputs}"
-      # Issue #925: step-14 bumps [workspace.package].version in Cargo.toml and
-      # step-14b keeps Cargo.lock in sync, but NOTHING syncs the root
-      # package.json "version". The contract test
-      # `package_json_version_matches_root_workspace_version` then fails in CI
-      # (exit 100) because package.json is left stale, and no pre-commit gate
-      # catches it. Sync package.json.version to the workspace version with a
-      # ROBUST read (scoped [workspace.package] parse, offline) and a ROBUST
-      # JSON edit (jq, falling back to python3 json) — never brittle text
-      # munging. Skip gracefully when package.json is absent (non-JS workspace).
+      # Issue #925: nothing syncs root package.json "version" after the workspace
+      # bump, so `package_json_version_matches_root_workspace_version` fails in CI.
+      # Sync package.json.version via a ROBUST scoped read + ROBUST JSON edit (jq,
+      # python3 fallback); skip gracefully when package.json is absent (non-JS workspace).
       if [ ! -f package.json ]; then
         echo "step-14c: no package.json present; skipping npm version sync (non-JS workspace)"
         exit 0
@@ -122,33 +114,27 @@ steps:
         echo "step-14c: no Cargo.toml present; cannot determine workspace version; skipping"
         exit 0
       fi
-      # Read [workspace.package].version robustly: a SCOPED parse of only the
-      # [workspace.package] table (offline, network-free). This is NOT an
-      # unscoped grep of the first `version =` line, which would pick up an
-      # unrelated table. As a defensive fallback, prefer `cargo metadata
-      # --offline` if the scoped parse yields nothing.
+      # Read [workspace.package].version via a SCOPED offline parse (NOT an unscoped
+      # grep that could match an unrelated table); fall back to `cargo metadata --offline`.
       WS_VERSION="$(awk -F'"' '
         /^\[workspace\.package\]/ { in_ws = 1; next }
         /^\[/ { in_ws = 0 }
         in_ws && /^[[:space:]]*version[[:space:]]*=/ { print $2; exit }
       ' Cargo.toml)"
-      # Fallback: resolve the workspace ROOT package by its resolved id
-      # (.resolve.root) — NOT `select(.source == null)`, which matches ALL local
-      # members and is nondeterministic when members declare divergent versions.
+      # Fallback: resolve the workspace ROOT package by its resolved id (.resolve.root),
+      # NOT `select(.source == null)` which matches ALL local members nondeterministically.
       if [ -z "${WS_VERSION:-}" ] && command -v cargo >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
         WS_VERSION="$(cargo metadata --no-deps --format-version=1 --offline 2>/dev/null \
           | jq -r '.resolve.root as $r | (.packages[] | select(.id == $r) | .version) // empty' 2>/dev/null || true)"
       fi
       if [ -z "${WS_VERSION:-}" ]; then
-        # Non-standard layout or unreadable version: skip cleanly (mirror-only
-        # step; never a hard failure). Matches requirement R4 and the reference doc.
+        # Non-standard layout or unreadable version: skip cleanly (mirror-only step; never a hard failure).
         echo "step-14c: could not read [workspace.package].version; skipping package.json sync"
         exit 0
       fi
       echo "step-14c: syncing package.json version to workspace version ${WS_VERSION}"
       if command -v jq >/dev/null 2>&1; then
-        # Write to a temp file IN THE SAME DIRECTORY so `mv` is an atomic,
-        # same-filesystem rename, and preserve the original file permissions.
+        # Same-directory temp file so `mv` is an atomic rename; preserve permissions.
         _tmp="$(mktemp ./package.json.XXXXXX)"
         trap 'rm -f "$_tmp"' EXIT
         chmod --reference=package.json "$_tmp" 2>/dev/null || true
@@ -156,9 +142,7 @@ steps:
         mv "$_tmp" package.json
         trap - EXIT
       else
-        # Same atomic contract as the jq path: write a temp file IN THE SAME
-        # DIRECTORY (so os.replace is an atomic same-filesystem rename) and copy
-        # the original file mode so permissions (e.g. 0644) are preserved.
+        # Same atomic contract as the jq path: same-directory temp + os.replace, mode preserved.
         WS_VERSION="$WS_VERSION" python3 -c 'import json, os, tempfile; p = "package.json"; d = json.load(open(p, encoding="utf-8")); d["version"] = os.environ["WS_VERSION"]; _dir = os.path.dirname(os.path.abspath(p)); _fd, _tmp = tempfile.mkstemp(dir=_dir, prefix="package.json."); os.write(_fd, (json.dumps(d, indent=2) + "\n").encode("utf-8")); os.close(_fd); os.chmod(_tmp, os.stat(p).st_mode & 0o7777); os.replace(_tmp, p)'
       fi
 
@@ -221,9 +205,8 @@ steps:
       # FIX (#469/#311): env vars are injection-safe; ${VAR:-} nounset reads so an unset value can't abort before the #944 fallback below.
       TASK_DESC="${TASK_DESCRIPTION:-}"
       ISSUE_NUMBER="${ISSUE_NUMBER:-}"
-      # FIX (#944): commit prefix from step-14's real change type (PATCH->fix:
-      # MINOR->feat: MAJOR->feat!:), not a hardcoded 'feat:' that bumped the
-      # version on bugfix branches (#920/#943). Unknown/unset -> bugfix heuristic.
+      # FIX (#944): commit prefix from step-14's real change type (PATCH->fix:,
+      # MINOR->feat:, MAJOR->feat!:), not a hardcoded 'feat:'. Unknown -> bugfix heuristic.
       CHANGE_CLASS="${VERSION_BUMP_CHANGE_CLASSIFICATION:-${RECIPE_VAR_version_bump__change_classification:-}}"
       case "$(printf '%s' "$CHANGE_CLASS" | tr '[:lower:]' '[:upper:]')" in
         PATCH) COMMIT_PREFIX="fix: " ;;
@@ -250,9 +233,8 @@ steps:
         amplihack_prepare_git_commit_identity
         git commit -m "$COMMIT_MSG"
       else
-        # FIX (#282): hollow-success false-positive when agent worked in an
-        # alternate worktree. Check if the current branch has new commits
-        # in any other worktree before declaring hollow success.
+        # FIX (#282): avoid hollow-success false-positive — check the current branch
+        # for new commits (in any worktree) before declaring nothing was done.
         CURRENT_BRANCH=$(git branch --show-current)
         ALT_WORKTREE_COMMITS=0
         if [ -n "$CURRENT_BRANCH" ] && git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
@@ -275,16 +257,10 @@ steps:
       fi
       COMMITS_AHEAD=$(git rev-list --count @{u}..HEAD)
       if [ "$COMMITS_AHEAD" -ne 0 ]; then
-        # FIX (#978): ancestry-aware integration. Step 15 must NOT blindly
-        # `git pull --rebase` onto the configured upstream. When a temporary
-        # workstream branch tracks an unrelated/stale upstream, rebasing replays
-        # already-integrated commits and produces add/add conflicts. Refresh the
-        # upstream ref, then decide by ancestry:
-        #   • upstream is an ancestor of HEAD (behind==0) -> fast-forward push,
-        #     preserving the tested commit identities (no history rewrite).
-        #   • histories diverged (behind>0) -> fail closed with structured
-        #     merge-base/ahead/behind evidence and require an explicit
-        #     merge/rebase decision. Never auto-replay already-integrated history.
+        # FIX (#978): ancestry-aware integration — never blind `git pull --rebase`.
+        # Refresh upstream, then decide by ancestry: behind==0 -> fast-forward push
+        # (preserve tested commit identities); behind>0 -> fail closed with structured
+        # merge-base/ahead/behind evidence. Never auto-replay already-integrated history.
         UPSTREAM_REF=$(git rev-parse --abbrev-ref '@{u}' 2>/dev/null || echo "unknown")
         fetch_output_file=$(mktemp -t step15-fetch-XXXXXX)
         if git fetch origin >"$fetch_output_file" 2>&1; then

--- a/amplifier-bundle/skills/default-workflow/SKILL.md
+++ b/amplifier-bundle/skills/default-workflow/SKILL.md
@@ -298,10 +298,15 @@ source exists, fail closed with a clear error; do not bootstrap from local
 **Failure**: Agent output file not written or corrupted, causing downstream steps to fail with empty input.
 **Resilience**: If an agent step produces empty output, the recipe runner should surface the error visibly. Checkpoints after design (step 5e) and after implementation (step 8b) preserve partial work so the workflow can resume from the nearest safe point.
 
-### Step 15 — Push to Remote (upstream tracking)
+### Step 15 — Push to Remote (upstream tracking, ancestry-aware)
 
 **Failure**: `git rev-list --count @{u}..HEAD` fails when upstream is not set (first push scenario).
 **Resilience**: Detect missing upstream explicitly. If `@{u}` fails, push unconditionally instead of silently skipping. Retry push with backoff on transient network errors.
+
+**Failure (#978)**: A temporary workstream branch tracks an unrelated/stale upstream; a blind `git pull --rebase` replays already-integrated historical commits and produces add/add conflicts.
+**Resilience**: Step 15 is ancestry-aware. After fetching, it compares HEAD to `@{u}`:
+- upstream is an ancestor of HEAD (behind == 0) → fast-forward push, preserving the tested commit identities (no history rewrite, no rebase);
+- histories diverged (behind > 0) → **fail closed** with structured `merge-base / ahead / behind` evidence and require an explicit merge/rebase decision. Step 15 never auto-rebases divergent history onto a possibly-unrelated upstream.
 
 ### Step 16 — PR Creation (already exists / no commits)
 

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -142,6 +142,10 @@ name = "workflow_publish_resilience"
 path = "../../tests/integration/workflow_publish_resilience.rs"
 
 [[test]]
+name = "issue_978_step15_rebase_base"
+path = "../../tests/integration/issue_978_step15_rebase_base_test.rs"
+
+[[test]]
 name = "workflow_publish_azdo_contract"
 path = "../../tests/integration/workflow_publish_azdo_contract_test.rs"
 

--- a/docs/claude/skills/default-workflow/SKILL.md
+++ b/docs/claude/skills/default-workflow/SKILL.md
@@ -298,10 +298,15 @@ source exists, fail closed with a clear error; do not bootstrap from local
 **Failure**: Agent output file not written or corrupted, causing downstream steps to fail with empty input.
 **Resilience**: If an agent step produces empty output, the recipe runner should surface the error visibly. Checkpoints after design (step 5e) and after implementation (step 8b) preserve partial work so the workflow can resume from the nearest safe point.
 
-### Step 15 — Push to Remote (upstream tracking)
+### Step 15 — Push to Remote (upstream tracking, ancestry-aware)
 
 **Failure**: `git rev-list --count @{u}..HEAD` fails when upstream is not set (first push scenario).
 **Resilience**: Detect missing upstream explicitly. If `@{u}` fails, push unconditionally instead of silently skipping. Retry push with backoff on transient network errors.
+
+**Failure (#978)**: A temporary workstream branch tracks an unrelated/stale upstream; a blind `git pull --rebase` replays already-integrated historical commits and produces add/add conflicts.
+**Resilience**: Step 15 is ancestry-aware. After fetching, it compares HEAD to `@{u}`:
+- upstream is an ancestor of HEAD (behind == 0) → fast-forward push, preserving the tested commit identities (no history rewrite, no rebase);
+- histories diverged (behind > 0) → **fail closed** with structured `merge-base / ahead / behind` evidence and require an explicit merge/rebase decision. Step 15 never auto-rebases divergent history onto a possibly-unrelated upstream.
 
 ### Step 16 — PR Creation (already exists / no commits)
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -29,6 +29,7 @@ Intelligent guidance system that prevents common mistakes and ensures work compl
 ## Workflow Recovery
 
 - [Workflow-Owned PR Recovery Readiness](pr-recovery-readiness.md) — recover existing pull requests through `default-workflow`, reuse the PR branch, verify hook and additive-copy readiness, and finalize only through workflow-owned steps.
+- [Ancestry-Aware Step 15 Publish](workflow-publish-ancestry-aware-step15.md) — `workflow-publish` step 15 integrates with its upstream by branch ancestry: fast-forward when `behind == 0`, fail closed with structured `ahead=`/`behind=`/`merge_base=` evidence when histories diverge, and never blind-rebase already-integrated commits. Includes the PR #980 brick-rule cleanup that trims `workflow-publish.yaml` back under the 400-line limit (issue [#978](https://github.com/rysweet/amplihack-rs/issues/978)).
 - [Existing Branch Finalization Runbook](post-v0977-finalization.md) — inspect,
   preserve, validate, publish, and merge an already-implemented branch; includes
   the post-v0.9.77 issue-658 branch as the concrete example.

--- a/docs/features/workflow-publish-ancestry-aware-step15.md
+++ b/docs/features/workflow-publish-ancestry-aware-step15.md
@@ -1,0 +1,189 @@
+# Ancestry-Aware Step 15 Publish
+
+**`workflow-publish` step 15 integrates with its upstream by branch ancestry — fast-forward when it can, fail closed when histories diverge — and never blind-rebases already-integrated commits.**
+
+> [Home](../index.md) > [Features](README.md) > Ancestry-Aware Step 15 Publish
+
+## Quick Navigation
+
+- [What This Feature Does](#what-this-feature-does)
+- [Behavior](#behavior)
+- [Structured Divergence Evidence](#structured-divergence-evidence)
+- [Brick-Rule Compliance](#brick-rule-compliance)
+- [Verification](#verification)
+- [Related Docs](#related-docs)
+
+---
+
+## What This Feature Does
+
+`step-15-commit-push` in `amplifier-bundle/recipes/workflow-publish.yaml` is the
+publish phase's commit-and-push step. Before this feature, when a temporary
+workstream branch tracked an unrelated or stale upstream, the step ran a blind
+`git pull --rebase` before pushing. Rebasing onto a diverged upstream replays
+commits that were **already integrated**, producing add/add conflicts and, in the
+worst case, silently rewriting tested commit identities.
+
+This feature makes step 15 **ancestry-aware**. It refreshes the upstream ref and
+then decides what to do by comparing histories, never replaying already-integrated
+history:
+
+- **Fast-forwardable** (`behind == 0`, `ahead > 0`) → push directly, preserving the
+  exact tested commit identities. No history rewrite.
+- **Already published** (`ahead == 0`) → report `already-pushed` and exit cleanly.
+- **Diverged** (`ahead > 0` **and** `behind > 0`) → **fail closed** with structured
+  merge-base / ahead / behind evidence and require an explicit merge or rebase
+  decision. The step never auto-rebases divergent history.
+
+This closes issue
+[#978](https://github.com/rysweet/amplihack-rs/issues/978).
+
+---
+
+## Behavior
+
+Step 15 evaluates the branch against its configured upstream (`@{u}`) and selects
+exactly one outcome:
+
+| Condition (relative to `@{u}`) | Outcome | Exit | Emitted marker |
+| ------------------------------ | ------- | ---- | -------------- |
+| No upstream tracking branch configured | Skip push | `0` | `reason="no-upstream"` |
+| `ahead == 0` after fetch | Nothing to push | `0` | `reason="already-pushed"` |
+| `behind == 0`, `ahead > 0` | Fast-forward push | `0` | `"pushed":"true"` |
+| `ahead > 0` **and** `behind > 0` | Fail closed (no rebase) | `1` | `reason="diverged-upstream: …"` |
+
+Key invariants:
+
+- **Commit identity is preserved on the fast-forward path.** `HEAD` is unchanged
+  before and after the push, and `origin/<branch>` fast-forwards to the local
+  `HEAD`. No `git rebase` is ever run for a fast-forwardable branch.
+- **Divergence fails closed.** On divergence the working tree and `HEAD` are left
+  untouched — no rewrite, no conflict markers, no partial push. The operator must
+  point the branch at its intended PR base and fast-forward, or make an explicit
+  rebase decision.
+- **Fetch failures are non-fatal.** If `git fetch origin` fails before the ancestry
+  check, the step warns and proceeds using cached upstream state rather than
+  aborting the publish.
+- **Push and fetch output is redacted.** Fetch and push stderr pass through
+  `redact_sensitive_file` before being emitted, so tokens never leak into the
+  publish log.
+
+---
+
+## Structured Divergence Evidence
+
+When step 15 refuses to rebase a divergent history it emits machine-parseable
+ancestry evidence to **stderr** so operators and reviewers can diagnose the base
+mismatch without re-deriving it:
+
+```text
+ERROR: step-15 refuses to rebase divergent history onto upstream 'origin/feature' (issue #978).
+  ancestry: ahead=1 behind=1 merge_base=<sha> head=<sha> upstream=origin/feature
+  Auto-rebasing would replay already-integrated commits and create add/add conflicts.
+  Point the branch at its intended PR base and fast-forward, or make an explicit rebase decision.
+```
+
+The result record on stdout reports the non-success outcome. It is emitted by
+`_emit_commit_result` via `jq -nc`, so every field is always present in the
+order `pushed, sha, branch, reason`:
+
+```json
+{"pushed":"false","sha":"","branch":"feature","reason":"diverged-upstream: ahead=1 behind=1 merge_base=<sha> upstream=origin/feature"}
+```
+
+These markers are contract strings. The following substrings are guaranteed and
+must not change without updating the regression tests that pin them:
+
+- `issue #978`
+- `refuses to rebase divergent history`
+- `ahead=`, `behind=`, `merge_base=`
+- `"pushed":"true"` on the fast-forward path
+- `"reason":"diverged-upstream"` (or `"pushed":"false"`) on divergence
+
+---
+
+## Brick-Rule Compliance
+
+Every phase sub-recipe in `default-workflow` is a **brick**: it must stay under
+**400 physical lines**. This limit is enforced by the
+`every_phase_subrecipe_under_400_lines` integration test, which counts the lines
+of each recipe in `PHASE_RECIPES` plus `default-workflow` and fails any whose
+`lines >= BRICK_LIMIT` (`BRICK_LIMIT = 400`). `workflow-publish` is one of the
+guarded `PHASE_RECIPES`, so a compliant recipe is at most **399 lines**.
+
+### Current state and the required cleanup
+
+Adding the ancestry-aware logic grew `workflow-publish.yaml` to **423 lines**,
+which **exceeds** the 400-line brick limit — the guard is red until the recipe is
+trimmed. Bringing it back under the limit is part of this work and is tracked by
+[PR #980](https://github.com/rysweet/amplihack-rs/pull/980). PR #980 is
+behavior-neutral: it must reduce the physical line count **without changing any of
+the contract strings, markers, or fail-closed behavior** described above.
+
+The trim must be a genuine reduction, not a weakening of the guard. Apply, in
+order of preference:
+
+1. **Collapse comment banners.** The multi-line `# FIX (#978)` rationale block is
+   the primary target — condense it to a one-line pointer to this document. The
+   exhaustive narrative lives here, not inline in the recipe.
+2. **Keep load-bearing diagnostics executable.** All ancestry markers
+   (`issue #978`, `refuses to rebase divergent history`, `ahead=`/`behind=`/
+   `merge_base=`, the `_emit_commit_result` fields) must remain in executable
+   `echo`/`printf`/`git`/`jq` statements — never move them into comments to save
+   lines, because the regression tests assert them at runtime.
+3. **Extract, don't inflate.** If condensing comments is not enough, extract
+   reusable shell into `amplifier-bundle/tools/` rather than growing the recipe
+   body.
+
+Do **not** weaken `BRICK_LIMIT`, delete the guard test, or drop a pinned marker to
+get under the limit. Once the trim lands, `workflow-publish.yaml` must be **≤ 399
+lines** and the brick guard green.
+
+---
+
+## Verification
+
+Run the size guard and both ancestry regression pins:
+
+```bash
+# Brick-rule guard — every phase recipe (incl. workflow-publish) < 400 lines
+cargo nextest run -p amplihack every_phase_subrecipe_under_400_lines
+
+# Ancestry behavior pins for issue #978
+cargo nextest run -p amplihack \
+  step15_fast_forwards_ahead_branch_without_rebase \
+  step15_fails_closed_on_divergent_upstream_instead_of_rebasing
+```
+
+Expected once the PR #980 trim has landed (see [Brick-Rule
+Compliance](#brick-rule-compliance)):
+
+- `every_phase_subrecipe_under_400_lines` — passes; `workflow-publish.yaml` is
+  ≤ 399 lines. **Until the trim lands this guard fails** with a
+  `brick rule violation` reporting `workflow-publish` at 423 lines, which is the
+  expected pre-cleanup state.
+- `step15_fast_forwards_ahead_branch_without_rebase` — the branch publishes,
+  `"pushed":"true"` is emitted, `HEAD` is unchanged, `origin/<branch>` matches the
+  local `HEAD`, and no `Rebasing` appears in stderr.
+- `step15_fails_closed_on_divergent_upstream_instead_of_rebasing` — the step exits
+  non-zero, emits the `issue #978` / `refuses to rebase divergent history` message
+  with `ahead=`/`behind=`/`merge_base=` evidence, reports no successful push, and
+  leaves `HEAD` and the working tree untouched.
+
+Confirm CI is green on the pull request:
+
+```bash
+gh pr checks 980 --repo rysweet/amplihack-rs
+```
+
+The `Test` check must be `SUCCESS` — a `FAILURE` there indicates either an
+ancestry regression or that `workflow-publish.yaml` has crossed the 400-line brick
+limit.
+
+---
+
+## Related Docs
+
+- [Publish Workflow: Classification-Driven Commit Prefix & Version Bump](../WORKFLOW_PUBLISH_VERSIONING.md) — how the publish phase derives commit prefix and version bump.
+- [Workflow Execution Guardrails](workflow-execution-guardrails.md) — canonical execution roots and GitHub identity checks for recipe-driven runs.
+- [Workflow-Owned PR Recovery Readiness](pr-recovery-readiness.md) — recovering and finalizing existing PRs through `default-workflow`.

--- a/tests/integration/issue_978_step15_rebase_base_test.rs
+++ b/tests/integration/issue_978_step15_rebase_base_test.rs
@@ -1,0 +1,244 @@
+//! tests/integration/issue_978_step15_rebase_base_test.rs
+//!
+//! Regression coverage for issue #978: default-workflow Step 15 must be
+//! ancestry-aware. It must NOT blindly `git pull --rebase` a temporary
+//! workstream branch onto its configured upstream — when that upstream has
+//! diverged (unrelated/stale), rebasing replays already-integrated commits and
+//! produces add/add conflicts. Step 15 must instead:
+//!   1. fast-forward push when HEAD is strictly ahead of upstream (behind == 0),
+//!      preserving the tested commit identities (no rebase / no history rewrite);
+//!   2. fail closed with structured merge-base/ahead/behind evidence when the
+//!      histories genuinely diverge (behind > 0), instead of silently rebasing.
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_yaml::Value;
+use tempfile::TempDir;
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn load_publish_recipe() -> Value {
+    let path = workspace_root()
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join("workflow-publish.yaml");
+    let text = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn step_command(recipe: &Value, id: &str) -> String {
+    recipe
+        .get("steps")
+        .and_then(|s| s.as_sequence())
+        .and_then(|steps| {
+            steps
+                .iter()
+                .find(|step| step.get("id").and_then(|v| v.as_str()) == Some(id))
+        })
+        .and_then(|step| step.get("command"))
+        .and_then(|c| c.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| panic!("step {id} must be a bash command step"))
+}
+
+fn workspace_helper_path(name: &str) -> PathBuf {
+    workspace_root()
+        .join("amplifier-bundle")
+        .join("tools")
+        .join(name)
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| panic!("create {}: {e}", parent.display()));
+    }
+    fs::write(path, content).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("run git {args:?} in {}: {e}", dir.display()));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+        dir.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("run git {args:?} in {}: {e}", dir.display()));
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn run_step15(repo: &Path, command: &str) -> std::process::Output {
+    Command::new("bash")
+        .arg("-c")
+        .arg(command)
+        .current_dir(repo)
+        .env("WORKTREE_SETUP_WORKTREE_PATH", repo)
+        .env(
+            "WORKFLOW_RUNTIME_ARTIFACT_HELPER",
+            workspace_helper_path("workflow_runtime_artifacts.sh"),
+        )
+        .env("TASK_DESCRIPTION", "publish workstream branch (issue #978)")
+        .env("ISSUE_NUMBER", "978")
+        .env("REMOTE_HOST_TYPE", "github")
+        .output()
+        .expect("run step-15 commit-push command")
+}
+
+/// Build a clone whose `feature` branch is `ahead` of `origin/feature`. Returns
+/// the working repo path (inside `tmp`).
+fn init_repo_with_feature_branch(tmp: &Path) -> (PathBuf, PathBuf) {
+    let origin = tmp.join("origin.git");
+    let repo = tmp.join("repo");
+    git(tmp, &["init", "--bare", origin.to_str().unwrap()]);
+    git(
+        tmp,
+        &["clone", origin.to_str().unwrap(), repo.to_str().unwrap()],
+    );
+    git(&repo, &["switch", "-c", "main"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "user.name", "Workflow Test"]);
+    write_file(&repo.join("README.md"), "base\n");
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "base"]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+    // Workstream branch, published so it has an upstream.
+    git(&repo, &["switch", "-c", "feature"]);
+    write_file(&repo.join("feature.txt"), "f1\n");
+    git(&repo, &["add", "feature.txt"]);
+    git(&repo, &["commit", "-m", "feature commit 1"]);
+    git(&repo, &["push", "-u", "origin", "feature"]);
+    (origin, repo)
+}
+
+#[test]
+fn step15_fast_forwards_ahead_branch_without_rebase() {
+    let recipe = load_publish_recipe();
+    let command = step_command(&recipe, "step-15-commit-push");
+    let tmp = TempDir::new().expect("tempdir");
+    let (_origin, repo) = init_repo_with_feature_branch(tmp.path());
+
+    // Local-only descendant commit: strictly ahead of origin/feature (behind == 0).
+    write_file(&repo.join("feature.txt"), "f1\nf2\n");
+    git(&repo, &["add", "feature.txt"]);
+    git(&repo, &["commit", "-m", "feature commit 2"]);
+    let head_before = git_stdout(&repo, &["rev-parse", "HEAD"]);
+
+    let output = run_step15(&repo, &command);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "fast-forwardable branch must publish successfully\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains(r#""pushed":"true""#),
+        "step-15 must push the fast-forward commit, stdout:\n{stdout}"
+    );
+    // Commit identity preserved (no rebase/rewrite): HEAD unchanged and remote matches.
+    let head_after = git_stdout(&repo, &["rev-parse", "HEAD"]);
+    assert_eq!(
+        head_before, head_after,
+        "step-15 must not rewrite commit identities during a fast-forward publish"
+    );
+    let remote_feature = git_stdout(&repo, &["rev-parse", "origin/feature"]);
+    assert_eq!(
+        head_after, remote_feature,
+        "origin/feature must fast-forward to the local HEAD"
+    );
+    assert!(
+        !stderr.contains("Rebasing"),
+        "step-15 must not run a rebase for a fast-forward publish, stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn step15_fails_closed_on_divergent_upstream_instead_of_rebasing() {
+    let recipe = load_publish_recipe();
+    let command = step_command(&recipe, "step-15-commit-push");
+    let tmp = TempDir::new().expect("tempdir");
+    let (origin, repo) = init_repo_with_feature_branch(tmp.path());
+
+    // Simulate an unrelated/diverged upstream: a second clone pushes a
+    // *conflicting* commit onto origin/feature touching the same file.
+    let other = tmp.path().join("other");
+    git(
+        tmp.path(),
+        &["clone", origin.to_str().unwrap(), other.to_str().unwrap()],
+    );
+    git(&other, &["config", "user.email", "other@example.com"]);
+    git(&other, &["config", "user.name", "Other Worker"]);
+    git(&other, &["switch", "feature"]);
+    write_file(&other.join("feature.txt"), "f1\nUPSTREAM-CONFLICT\n");
+    git(&other, &["add", "feature.txt"]);
+    git(&other, &["commit", "-m", "conflicting upstream commit"]);
+    git(&other, &["push", "origin", "feature"]);
+
+    // Meanwhile the workstream repo makes its own descendant commit: now ahead>0
+    // AND behind>0 relative to the (diverged) upstream.
+    write_file(&repo.join("feature.txt"), "f1\nLOCAL-WORK\n");
+    git(&repo, &["add", "feature.txt"]);
+    git(&repo, &["commit", "-m", "local workstream commit 2"]);
+    let head_before = git_stdout(&repo, &["rev-parse", "HEAD"]);
+    let file_before = fs::read_to_string(repo.join("feature.txt")).unwrap();
+
+    let output = run_step15(&repo, &command);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "divergent upstream must fail closed, not rebase\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("issue #978") && stderr.contains("refuses to rebase divergent history"),
+        "step-15 must fail with an explicit #978 divergence message, stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("ahead=") && stderr.contains("behind=") && stderr.contains("merge_base="),
+        "step-15 must emit structured ancestry evidence, stderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains(r#""reason":"diverged-upstream"#) || stdout.contains(r#""pushed":"false""#),
+        "step-15 must not report a successful push on divergence, stdout:\n{stdout}"
+    );
+    // No history rewrite and no rebase conflict markers left behind.
+    let head_after = git_stdout(&repo, &["rev-parse", "HEAD"]);
+    assert_eq!(
+        head_before, head_after,
+        "step-15 must not rewrite HEAD when it refuses a divergent rebase"
+    );
+    let file_after = fs::read_to_string(repo.join("feature.txt")).unwrap();
+    assert_eq!(
+        file_before, file_after,
+        "step-15 must leave the working tree untouched on a refused divergent rebase"
+    );
+    assert!(
+        !file_after.contains("<<<<<<<") && !file_after.contains(">>>>>>>"),
+        "step-15 must not leave add/add conflict markers, file:\n{file_after}"
+    );
+    assert!(
+        !repo.join(".git/rebase-merge").exists() && !repo.join(".git/rebase-apply").exists(),
+        "step-15 must not leave an in-progress rebase behind"
+    );
+}

--- a/tests/integration/workflow_publish_resilience.rs
+++ b/tests/integration/workflow_publish_resilience.rs
@@ -247,8 +247,8 @@ fn publish_commit_push_redacts_pull_and_push_failure_output() {
         "publish commit/push step must use a shared redaction helper"
     );
     assert!(
-        command.contains("git pull --rebase >\"$pull_output_file\" 2>&1"),
-        "publish commit/push step must capture pull output before logging"
+        command.contains("git fetch origin >\"$fetch_output_file\" 2>&1"),
+        "publish commit/push step must capture fetch output before logging (issue #978)"
     );
     assert!(
         !command.contains("cat \"$push_stderr_file\""),


### PR DESCRIPTION
## Problem

`default-workflow` **Step 15** ran `git pull --rebase` before publishing whenever the branch was ahead of its configured upstream. When a temporary workstream branch tracked an **unrelated/stale upstream**, this replayed 40–50 already-integrated commits and produced repeated add/add conflicts (issue #978), even though the new commits formed a clean fast-forward of the intended target PR branch.

## Fix

Step 15 (`amplifier-bundle/recipes/workflow-publish.yaml`, `step-15-commit-push`) is now **ancestry-aware**. After fetching it compares `HEAD` to `@{u}`:

- **upstream is an ancestor of HEAD (`behind == 0`)** → fast-forward push, preserving the tested commit identities (no rebase, no history rewrite).
- **histories diverged (`behind > 0`)** → **fail closed** with structured `merge-base / ahead / behind` evidence and require an explicit merge/rebase decision. Step 15 never auto-replays already-integrated history onto a possibly-unrelated upstream.

This satisfies the issue's acceptance criteria: fast-forward the intended branch, never rebase a temp branch onto its stale configured upstream, never replay integrated commits, fail closed with ancestry evidence on genuine divergence, and never rewrite tested commit identities during publish.

## Tests

New `tests/integration/issue_978_step15_rebase_base_test.rs`:
- `step15_fast_forwards_ahead_branch_without_rebase` — ahead-only branch publishes via fast-forward; HEAD identity preserved, no rebase.
- `step15_fails_closed_on_divergent_upstream_instead_of_rebasing` — diverged upstream fails closed with `issue #978` + `ahead/behind/merge_base` evidence; working tree untouched, no conflict markers, no in-progress rebase.

Existing `workflow_publish_resilience.rs` redaction contract updated for the new fetch-based capture. All publish/resilience integration tests pass locally.

## Notes
- Additive / non-breaking; existing first-push and already-pushed paths preserved.
- Structured tracing/stderr diagnostics only — no `print!`/`println!`, no Bridge naming.
- Docs updated in `default-workflow` SKILL (and `docs/claude` mirror).

Closes #978

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>