### PR TITLE
fix(remote): redact azlin stderr before logging in Orchestrator::cleanup

### DIFF
--- a/crates/amplihack-remote/src/orchestrator.rs
+++ b/crates/amplihack-remote/src/orchestrator.rs
@@ -5,14 +5,49 @@
 
 use std::collections::HashMap;
 use std::process::Stdio;
+use std::sync::LazyLock;
 
 use chrono::{DateTime, Local, Utc};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
 use crate::azlin_parse::{parse_azlin_list_json, parse_azlin_list_text};
 use crate::error::{ErrorContext, RemoteError};
+
+/// Placeholder substituted for any redacted sensitive segment.
+const REDACTION_PLACEHOLDER: &str = "[REDACTED]";
+
+/// GUIDs (subscription IDs, tenant IDs, resource GUIDs) in canonical
+/// `8-4-4-4-12` hex form.
+static GUID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+        .expect("valid GUID regex")
+});
+
+/// Azure Storage SAS query parameters (`sig`, `se`, `sp`, `sv`, `st`, `sr`,
+/// `ss`, `srt`, `skoid`, `sktid`, ...). Redacts the *value* while keeping the
+/// parameter name so the error stays diagnosable.
+static SAS_PARAM_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)([?&](?:sig|se|sp|sv|st|sr|ss|srt|spr|skoid|sktid|skt|ske|sks|skv)=)[^&\s]+")
+        .expect("valid SAS param regex")
+});
+
+/// Scrub known-sensitive Azure identifiers from arbitrary text (typically
+/// `azlin`/Azure CLI stderr) before it is folded into a log line or
+/// [`RemoteError`]. Redacts SAS token query parameters and canonical GUIDs
+/// (subscription/tenant/resource IDs), replacing each with
+/// [`REDACTION_PLACEHOLDER`]. Benign error text is preserved verbatim.
+fn redact_sensitive(input: &str) -> String {
+    // SAS params first so the placeholder does not disturb GUID matching.
+    let sas_scrubbed = SAS_PARAM_RE.replace_all(input, |caps: &regex::Captures<'_>| {
+        format!("{}{REDACTION_PLACEHOLDER}", &caps[1])
+    });
+    GUID_RE
+        .replace_all(&sas_scrubbed, REDACTION_PLACEHOLDER)
+        .into_owned()
+}
 
 /// Represents an Azure VM managed by azlin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -132,7 +167,7 @@ impl Orchestrator {
             }
             Ok(Ok(o)) => {
                 let stderr = String::from_utf8_lossy(&o.stderr);
-                let msg = format!("VM cleanup failed: {stderr}");
+                let msg = format!("VM cleanup failed: {}", redact_sensitive(&stderr));
                 if force {
                     warn!("{msg}");
                     Ok(false)
@@ -144,7 +179,10 @@ impl Orchestrator {
                 }
             }
             Ok(Err(e)) => {
-                let msg = format!("VM cleanup command failed: {e}");
+                let msg = format!(
+                    "VM cleanup command failed: {}",
+                    redact_sensitive(&e.to_string())
+                );
                 if force {
                     warn!("{msg}");
                     Ok(false)
@@ -491,5 +529,54 @@ mod tests {
         let opts2: VMOptions = serde_json::from_str(&json).unwrap();
         assert!(opts2.no_reuse);
         assert_eq!(opts2.region.as_deref(), Some("eastus"));
+    }
+
+    #[test]
+    fn redact_sensitive_scrubs_subscription_guid() {
+        let stderr = "ERROR: Subscription 12345678-90ab-cdef-1234-567890abcdef not found";
+        let out = redact_sensitive(stderr);
+        assert!(
+            !out.contains("12345678-90ab-cdef-1234-567890abcdef"),
+            "GUID leaked: {out}"
+        );
+        assert!(out.contains(REDACTION_PLACEHOLDER));
+        // Benign surrounding text is preserved.
+        assert!(out.contains("Subscription"));
+        assert!(out.contains("not found"));
+    }
+
+    #[test]
+    fn redact_sensitive_scrubs_sas_query_params() {
+        let stderr = "failed to reach https://acct.blob.core.windows.net/c/b?sv=2021-08-06&se=2025-01-01T00:00:00Z&sr=b&sp=r&sig=abc123DEF456secretsignature%3D";
+        let out = redact_sensitive(stderr);
+        assert!(
+            !out.contains("abc123DEF456secretsignature"),
+            "SAS sig leaked: {out}"
+        );
+        assert!(!out.contains("2021-08-06"), "SAS sv value leaked: {out}");
+        // Parameter names are retained for diagnosability.
+        assert!(out.contains("sig="));
+        assert!(out.contains("sv="));
+        assert!(out.contains(REDACTION_PLACEHOLDER));
+        // Host/path (non-secret) is preserved.
+        assert!(out.contains("acct.blob.core.windows.net"));
+    }
+
+    #[test]
+    fn redact_sensitive_preserves_benign_text() {
+        let stderr = "azlin kill: VM 'sess-vm-1' is already deleted (no-op)";
+        let out = redact_sensitive(stderr);
+        assert_eq!(out, stderr);
+        assert!(!out.contains(REDACTION_PLACEHOLDER));
+    }
+
+    #[test]
+    fn redact_sensitive_handles_multiple_secrets() {
+        let stderr = "sub 11111111-2222-3333-4444-555555555555 sas ?sig=topsecret&sp=racwd";
+        let out = redact_sensitive(stderr);
+        assert!(!out.contains("11111111-2222-3333-4444-555555555555"));
+        assert!(!out.contains("topsecret"));
+        assert!(!out.contains("racwd"));
+        assert_eq!(out.matches(REDACTION_PLACEHOLDER).count(), 3);
     }
 }

--- a/crates/amplihack-remote/src/orchestrator.rs
+++ b/crates/amplihack-remote/src/orchestrator.rs
@@ -5,10 +5,8 @@
 
 use std::collections::HashMap;
 use std::process::Stdio;
-use std::sync::LazyLock;
 
 use chrono::{DateTime, Local, Utc};
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
@@ -16,38 +14,8 @@ use tracing::{debug, info, warn};
 use crate::azlin_parse::{parse_azlin_list_json, parse_azlin_list_text};
 use crate::error::{ErrorContext, RemoteError};
 
-/// Placeholder substituted for any redacted sensitive segment.
-const REDACTION_PLACEHOLDER: &str = "[REDACTED]";
-
-/// GUIDs (subscription IDs, tenant IDs, resource GUIDs) in canonical
-/// `8-4-4-4-12` hex form.
-static GUID_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
-        .expect("valid GUID regex")
-});
-
-/// Azure Storage SAS query parameters (`sig`, `se`, `sp`, `sv`, `st`, `sr`,
-/// `ss`, `srt`, `skoid`, `sktid`, ...). Redacts the *value* while keeping the
-/// parameter name so the error stays diagnosable.
-static SAS_PARAM_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)([?&](?:sig|se|sp|sv|st|sr|ss|srt|spr|skoid|sktid|skt|ske|sks|skv)=)[^&\s]+")
-        .expect("valid SAS param regex")
-});
-
-/// Scrub known-sensitive Azure identifiers from arbitrary text (typically
-/// `azlin`/Azure CLI stderr) before it is folded into a log line or
-/// [`RemoteError`]. Redacts SAS token query parameters and canonical GUIDs
-/// (subscription/tenant/resource IDs), replacing each with
-/// [`REDACTION_PLACEHOLDER`]. Benign error text is preserved verbatim.
-fn redact_sensitive(input: &str) -> String {
-    // SAS params first so the placeholder does not disturb GUID matching.
-    let sas_scrubbed = SAS_PARAM_RE.replace_all(input, |caps: &regex::Captures<'_>| {
-        format!("{}{REDACTION_PLACEHOLDER}", &caps[1])
-    });
-    GUID_RE
-        .replace_all(&sas_scrubbed, REDACTION_PLACEHOLDER)
-        .into_owned()
-}
+mod redact;
+use redact::redact_sensitive;
 
 /// Represents an Azure VM managed by azlin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -179,10 +147,8 @@ impl Orchestrator {
                 }
             }
             Ok(Err(e)) => {
-                let msg = format!(
-                    "VM cleanup command failed: {}",
-                    redact_sensitive(&e.to_string())
-                );
+                let detail = redact_sensitive(&e.to_string());
+                let msg = format!("VM cleanup command failed: {detail}");
                 if force {
                     warn!("{msg}");
                     Ok(false)
@@ -529,54 +495,5 @@ mod tests {
         let opts2: VMOptions = serde_json::from_str(&json).unwrap();
         assert!(opts2.no_reuse);
         assert_eq!(opts2.region.as_deref(), Some("eastus"));
-    }
-
-    #[test]
-    fn redact_sensitive_scrubs_subscription_guid() {
-        let stderr = "ERROR: Subscription 12345678-90ab-cdef-1234-567890abcdef not found";
-        let out = redact_sensitive(stderr);
-        assert!(
-            !out.contains("12345678-90ab-cdef-1234-567890abcdef"),
-            "GUID leaked: {out}"
-        );
-        assert!(out.contains(REDACTION_PLACEHOLDER));
-        // Benign surrounding text is preserved.
-        assert!(out.contains("Subscription"));
-        assert!(out.contains("not found"));
-    }
-
-    #[test]
-    fn redact_sensitive_scrubs_sas_query_params() {
-        let stderr = "failed to reach https://acct.blob.core.windows.net/c/b?sv=2021-08-06&se=2025-01-01T00:00:00Z&sr=b&sp=r&sig=abc123DEF456secretsignature%3D";
-        let out = redact_sensitive(stderr);
-        assert!(
-            !out.contains("abc123DEF456secretsignature"),
-            "SAS sig leaked: {out}"
-        );
-        assert!(!out.contains("2021-08-06"), "SAS sv value leaked: {out}");
-        // Parameter names are retained for diagnosability.
-        assert!(out.contains("sig="));
-        assert!(out.contains("sv="));
-        assert!(out.contains(REDACTION_PLACEHOLDER));
-        // Host/path (non-secret) is preserved.
-        assert!(out.contains("acct.blob.core.windows.net"));
-    }
-
-    #[test]
-    fn redact_sensitive_preserves_benign_text() {
-        let stderr = "azlin kill: VM 'sess-vm-1' is already deleted (no-op)";
-        let out = redact_sensitive(stderr);
-        assert_eq!(out, stderr);
-        assert!(!out.contains(REDACTION_PLACEHOLDER));
-    }
-
-    #[test]
-    fn redact_sensitive_handles_multiple_secrets() {
-        let stderr = "sub 11111111-2222-3333-4444-555555555555 sas ?sig=topsecret&sp=racwd";
-        let out = redact_sensitive(stderr);
-        assert!(!out.contains("11111111-2222-3333-4444-555555555555"));
-        assert!(!out.contains("topsecret"));
-        assert!(!out.contains("racwd"));
-        assert_eq!(out.matches(REDACTION_PLACEHOLDER).count(), 3);
     }
 }

--- a/crates/amplihack-remote/src/orchestrator/redact.rs
+++ b/crates/amplihack-remote/src/orchestrator/redact.rs
@@ -1,0 +1,97 @@
+//! Sensitive-value redaction for azlin/Azure CLI diagnostics.
+//!
+//! Kept in its own submodule so `orchestrator` stays within the
+//! `amplihack-remote` module-size budget (issue #536). Scrubs Azure secrets
+//! (SAS token values, canonical GUIDs) from arbitrary text before it is folded
+//! into a log line or [`crate::error::RemoteError`].
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Placeholder substituted for any redacted sensitive segment.
+const REDACTION_PLACEHOLDER: &str = "[REDACTED]";
+
+/// GUIDs (subscription IDs, tenant IDs, resource GUIDs) in canonical
+/// `8-4-4-4-12` hex form.
+static GUID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+        .expect("valid GUID regex")
+});
+
+/// Azure Storage SAS query parameters (`sig`, `se`, `sp`, `sv`, `st`, `sr`,
+/// `ss`, `srt`, `skoid`, `sktid`, ...). Redacts the *value* while keeping the
+/// parameter name so the error stays diagnosable.
+static SAS_PARAM_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)([?&](?:sig|se|sp|sv|st|sr|ss|srt|spr|skoid|sktid|skt|ske|sks|skv)=)[^&\s]+")
+        .expect("valid SAS param regex")
+});
+
+/// Scrub known-sensitive Azure identifiers from arbitrary text (typically
+/// `azlin`/Azure CLI stderr) before it is folded into a log line or
+/// [`crate::error::RemoteError`]. Redacts SAS token query parameters and
+/// canonical GUIDs (subscription/tenant/resource IDs), replacing each with
+/// [`REDACTION_PLACEHOLDER`]. Benign error text is preserved verbatim.
+pub(super) fn redact_sensitive(input: &str) -> String {
+    // SAS params first so the placeholder does not disturb GUID matching.
+    let sas_scrubbed = SAS_PARAM_RE.replace_all(input, |caps: &regex::Captures<'_>| {
+        format!("{}{REDACTION_PLACEHOLDER}", &caps[1])
+    });
+    GUID_RE
+        .replace_all(&sas_scrubbed, REDACTION_PLACEHOLDER)
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_sensitive_scrubs_subscription_guid() {
+        let stderr = "ERROR: Subscription 12345678-90ab-cdef-1234-567890abcdef not found";
+        let out = redact_sensitive(stderr);
+        assert!(
+            !out.contains("12345678-90ab-cdef-1234-567890abcdef"),
+            "GUID leaked: {out}"
+        );
+        assert!(out.contains(REDACTION_PLACEHOLDER));
+        // Benign surrounding text is preserved.
+        assert!(out.contains("Subscription"));
+        assert!(out.contains("not found"));
+    }
+
+    #[test]
+    fn redact_sensitive_scrubs_sas_query_params() {
+        let stderr = "failed to reach https://acct.blob.core.windows.net/c/b?sv=2021-08-06&se=2025-01-01T00:00:00Z&sr=b&sp=r&sig=abc123DEF456secretsignature%3D";
+        let out = redact_sensitive(stderr);
+        assert!(
+            !out.contains("abc123DEF456secretsignature"),
+            "SAS sig leaked: {out}"
+        );
+        assert!(!out.contains("2021-08-06"), "SAS sv value leaked: {out}");
+        // Parameter names are retained for diagnosability.
+        assert!(out.contains("sig="));
+        assert!(out.contains("sv="));
+        assert!(out.contains(REDACTION_PLACEHOLDER));
+        // Host/path (non-secret) is preserved.
+        assert!(out.contains("acct.blob.core.windows.net"));
+    }
+
+    #[test]
+    fn redact_sensitive_preserves_benign_text() {
+        let stderr = "azlin kill: VM 'sess-vm-1' is already deleted (no-op)";
+        let out = redact_sensitive(stderr);
+        assert_eq!(out, stderr);
+        assert!(!out.contains(REDACTION_PLACEHOLDER));
+    }
+
+    #[test]
+    fn redact_sensitive_handles_multiple_secrets() {
+        let stderr = "sub 11111111-2222-3333-4444-555555555555 sas ?sig=topsecret&sp=racwd";
+        let out = redact_sensitive(stderr);
+        assert!(!out.contains("11111111-2222-3333-4444-555555555555"));
+        assert!(!out.contains("topsecret"));
+        assert!(!out.contains("racwd"));
+        assert_eq!(out.matches(REDACTION_PLACEHOLDER).count(), 3);
+    }
+}


### PR DESCRIPTION
## Summary

`Orchestrator::cleanup` in `crates/amplihack-remote/src/orchestrator.rs` embedded **raw azlin (Azure CLI) stderr** directly into `warn!` log lines and `RemoteError` cleanup messages. Azure CLI stderr can contain sensitive identifiers — subscription/tenant GUIDs and SAS token query strings (`sig`, `se`, `sp`, `sv`, `st`, `sr`, ...) — so logging it verbatim risks disclosing secrets to log sinks.

## Changes

- Add a small regex-based `redact_sensitive()` helper (module-local, using the existing `regex` dependency and `LazyLock`, matching the `packager.rs`/`session.rs` convention) that scrubs:
  - Canonical `8-4-4-4-12` **GUIDs** (subscription/tenant/resource IDs) → `[REDACTED]`
  - **SAS query parameter values** (`sig`, `se`, `sp`, `sv`, `st`, `sr`, `ss`, `srt`, `skoid`, `sktid`, ...) → param name kept, value replaced with `[REDACTED]` for diagnosability
- Apply it to both fallible cleanup paths: the non-zero-exit `stderr` path (`warn!` + `RemoteError::cleanup_ctx`) and the command-spawn error path.

The failure is **still surfaced unchanged** — `Err` when `!force`, `warn!` when `force`; only sensitive substrings are replaced. Benign error text is preserved verbatim. No control-flow, timeout, or `force` semantics changed.

## Tests

Added 4 unit tests: subscription-GUID scrub, SAS query-param scrub, benign-text preservation, and multi-secret redaction. `cargo test -p amplihack-remote`, `cargo fmt --check`, and `cargo clippy -- -D warnings` all pass; pre-commit hooks pass without bypass.

Scope limited to issue #882 only (per the #870/#881 scope-discipline note).

Fixes #882