### PR TITLE
ci: SHA-pin all GitHub Actions refs repo-wide (supply-chain hardening)

### DIFF
--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install Graphviz
         run: sudo apt-get update && sudo apt-get install -y graphviz
@@ -35,7 +35,7 @@ jobs:
           done
 
       - name: Upload atlas artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: code-atlas
           path: docs/atlas/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Verify cxx-build pin
         run: |
           version=$(grep -A1 'name = "cxx-build"' Cargo.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/')
@@ -90,10 +90,10 @@ jobs:
             sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
             shellcheck -S warning amplifier-bundle/tools/workflow_worktree_sweep.sh
           fi
-      - uses: dtolnay/rust-toolchain@1.97.0
+      - uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-targets: false
           cache-on-failure: true
@@ -115,7 +115,7 @@ jobs:
       # and lower peak disk. The suite asserts behavior, not backtraces (#744).
       CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Free disk space
         # Deterministic reclaim of tens of GB, replacing the fragile hand-rolled
         # `rm -rf`. tool-cache:false keeps the Rust toolchain cache we rely on.
@@ -128,13 +128,13 @@ jobs:
           docker-images: true
           large-packages: false
           swap-storage: false
-      - uses: dtolnay/rust-toolchain@1.97.0
+      - uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
       - name: Install cargo-nextest
         # Prebuilt binary (no slow `cargo install`); SHA-pinned for supply chain.
         uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2.83.1
         with:
           tool: nextest
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # The full workspace test profile links large native artifacts. Restoring
           # target/ can exhaust GitHub-hosted runner disk before tests start.
@@ -162,9 +162,9 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: "false"
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.97.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # Reuse the dependency-source cache namespace the native x86_64-linux
           # build in cross-compile populates. With cache-targets disabled only
@@ -208,11 +208,11 @@ jobs:
             cross: false
             gnu_cross_toolchain: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.97.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
           cache-targets: false
@@ -250,7 +250,7 @@ jobs:
         run: cross build --release --locked --target ${{ matrix.target }}
 
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: amplihack-${{ matrix.target }}
           path: |
@@ -267,8 +267,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
@@ -285,7 +285,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: amplihack-*.tar.gz
           generate_release_notes: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Build docs
         run: docker run --rm -v "$PWD:/docs" squidfunk/mkdocs-material build --strict
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
@@ -46,4 +46,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/invisible-char-scan.yml
+++ b/.github/workflows/invisible-char-scan.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout base (safe — not PR head)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
@@ -35,9 +35,9 @@ jobs:
       - name: Fetch PR head
         run: git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-targets: false
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -47,11 +47,11 @@ jobs:
             cross: false
             gnu_cross_toolchain: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.97.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: snapshot-${{ matrix.target }}
           cache-targets: false
@@ -114,7 +114,7 @@ jobs:
             amplihack amplihack-hooks
 
       - name: Upload packaged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: snapshot-${{ matrix.target }}
           path: dist/amplihack-${{ matrix.target }}.tar.gz
@@ -126,13 +126,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Create GitHub snapshot release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: snapshot-${{ github.sha }}
           name: snapshot-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       version: ${{ steps.bump.outputs.version }}
       sha: ${{ steps.bump.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -131,13 +131,13 @@ jobs:
             gnu_cross_toolchain: false
             exe_suffix: ".exe"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.version-bump.outputs.sha }}
-      - uses: dtolnay/rust-toolchain@1.97.0
+      - uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}
           cache-targets: false
@@ -182,7 +182,7 @@ jobs:
           cd dist && tar czf ../amplihack-${{ matrix.target }}.tar.gz *
           cd .. && sha256sum amplihack-${{ matrix.target }}.tar.gz > amplihack-${{ matrix.target }}.tar.gz.sha256
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: amplihack-${{ matrix.target }}
           path: |
@@ -197,11 +197,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.version-bump.outputs.sha }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
@@ -223,7 +223,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ needs.version-bump.outputs.version }}
           name: "amplihack-rs v${{ needs.version-bump.outputs.version }}"

--- a/crates/amplihack-cli/src/ci_resource_discipline_tests.rs
+++ b/crates/amplihack-cli/src/ci_resource_discipline_tests.rs
@@ -91,7 +91,16 @@ fn ci_rust_cache_entries_do_not_cache_workspace_targets_by_default() {
                 continue;
             };
             for (index, step) in steps.iter().enumerate() {
-                if step.get("uses").and_then(Value::as_str) != Some("Swatinem/rust-cache@v2") {
+                // Match rust-cache by action prefix so the check keeps working
+                // whether the ref floats (`@v2`) or is SHA-pinned with a
+                // trailing version comment (`@<sha> # v2`, issue #951). YAML
+                // strips the comment, leaving the SHA, so an exact `@v2` match
+                // would silently skip every pinned step and void this test.
+                let is_rust_cache = step
+                    .get("uses")
+                    .and_then(Value::as_str)
+                    .is_some_and(|u| u.starts_with("Swatinem/rust-cache@"));
+                if !is_rust_cache {
                     continue;
                 }
                 let cache_targets = step

--- a/scripts/check-toolchain-refs.sh
+++ b/scripts/check-toolchain-refs.sh
@@ -59,13 +59,31 @@ toolchain_channel() {
 # Emit "lineno:ref" for every dtolnay/rust-toolchain step in $1 that declares a
 # `targets:` key within the few lines following the step (before the next step
 # or toolchain action).
+#
+# SHA-pinned refs (issue #951): a ref may be a 40-hex commit SHA followed by a
+# trailing `# <version>` comment (supply-chain hardening). In that case the
+# EFFECTIVE toolchain channel is the commented version — dtolnay/rust-toolchain
+# bakes the channel into each branch's action.yml — so the comment is what must
+# match rust-toolchain.toml. A SHA with NO version comment cannot be verified,
+# so it is emitted verbatim and treated as drift (fails loudly, never silently
+# assumed correct).
 targets_bearing_refs() {
     local file="$1"
     awk '
         /dtolnay\/rust-toolchain@/ {
-            ref = $0
+            raw = $0
+            ref = raw
             sub(/.*dtolnay\/rust-toolchain@/, "", ref)
             sub(/[[:space:]].*/, "", ref)
+            eff = ref
+            if (ref ~ /^[0-9a-f]{40}$/) {
+                if (raw ~ /#/) {
+                    cmt = raw
+                    sub(/.*#[[:space:]]*/, "", cmt)
+                    sub(/[[:space:]].*/, "", cmt)
+                    eff = cmt
+                }
+            }
             ln = FNR
             hit = 0
             for (i = 1; i <= 6; i++) {
@@ -73,7 +91,7 @@ targets_bearing_refs() {
                 if (line ~ /^[[:space:]]*targets:/) { hit = 1; break }
                 if (line ~ /dtolnay\/rust-toolchain@/) break
             }
-            if (hit) print ln ":" ref
+            if (hit) print ln ":" eff
         }
     ' "$file"
 }

--- a/tests/integration/ci_speedup_optimization_test.rs
+++ b/tests/integration/ci_speedup_optimization_test.rs
@@ -146,9 +146,16 @@ fn ci_has_no_unpinned_stable_toolchain() {
 #[test]
 fn ci_pins_dtolnay_toolchain_to_1_97_0() {
     let content = read_ci_yml();
+    // Accept either the plain channel ref (`@1.97.0`) or a SHA-pinned ref with a
+    // trailing `# 1.97.0` version comment (issue #951 supply-chain hardening).
+    // In both forms the effective toolchain channel is 1.97.0, matching
+    // rust-toolchain.toml and the last known-good run.
+    let re =
+        Regex::new(r"dtolnay/rust-toolchain@(?:1\.97\.0|[0-9a-f]{40}\s*#\s*1\.97\.0)\b").unwrap();
     assert!(
-        content.contains("dtolnay/rust-toolchain@1.97.0"),
-        "FAIL: ci.yml must pin the toolchain action to `dtolnay/rust-toolchain@1.97.0`.\n\
+        re.is_match(&content),
+        "FAIL: ci.yml must pin the toolchain action to the 1.97.0 channel, either as\n\
+         `dtolnay/rust-toolchain@1.97.0` or a SHA-pin `dtolnay/rust-toolchain@<sha> # 1.97.0`.\n\
          This matches rust-toolchain.toml and the last known-good run."
     );
 }

--- a/tests/issue_935_toolchain_ref_pin_test.sh
+++ b/tests/issue_935_toolchain_ref_pin_test.sh
@@ -71,15 +71,28 @@ toolchain_channel() {
     sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TOOLCHAIN_TOML" | head -n1
 }
 
-# Return the @ref for every dtolnay/rust-toolchain step in a file that also
-# declares a `targets:` key within the following few lines of the step.
+# Return the EFFECTIVE channel for every dtolnay/rust-toolchain step in a file
+# that also declares a `targets:` key within the following few lines of the
+# step. SHA-pinned refs (issue #951) carry the effective channel in a trailing
+# `# <version>` comment; a SHA without a comment is returned verbatim so it is
+# treated as drift.
 targets_bearing_refs() {
     local file="$1"
     awk '
         /dtolnay\/rust-toolchain@/ {
-            ref = $0
+            raw = $0
+            ref = raw
             sub(/.*dtolnay\/rust-toolchain@/, "", ref)
             sub(/[[:space:]].*/, "", ref)
+            eff = ref
+            if (ref ~ /^[0-9a-f]{40}$/) {
+                if (raw ~ /#/) {
+                    cmt = raw
+                    sub(/.*#[[:space:]]*/, "", cmt)
+                    sub(/[[:space:]].*/, "", cmt)
+                    eff = cmt
+                }
+            }
             window = 6
             hit = 0
             for (i = 1; i <= window; i++) {
@@ -87,7 +100,7 @@ targets_bearing_refs() {
                 if (line ~ /^[[:space:]]*targets:/) { hit = 1; break }
                 if (line ~ /dtolnay\/rust-toolchain@/) break
             }
-            if (hit) print ref
+            if (hit) print eff
         }
     ' "$file"
 }
@@ -109,7 +122,7 @@ echo
 assert "publish-snapshot.yml exists" "[ -f '$SNAPSHOT' ]"
 
 assert "publish-snapshot.yml pins dtolnay/rust-toolchain to the toml channel ($CHANNEL)" \
-    "grep -q 'dtolnay/rust-toolchain@$CHANNEL' '$SNAPSHOT'"
+    "grep -Eq 'dtolnay/rust-toolchain@($CHANNEL([[:space:]]|\$)|[0-9a-f]{40}[[:space:]]+#[[:space:]]*$CHANNEL([[:space:]]|\$))' '$SNAPSHOT'"
 
 assert "publish-snapshot.yml no longer uses dtolnay/rust-toolchain@stable" \
     "! grep -q 'dtolnay/rust-toolchain@stable' '$SNAPSHOT'"

--- a/tests/issue_939_release_toolchain_pin_test.sh
+++ b/tests/issue_939_release_toolchain_pin_test.sh
@@ -76,15 +76,28 @@ toolchain_channel() {
     sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TOOLCHAIN_TOML" | head -n1
 }
 
-# Return the @ref for every dtolnay/rust-toolchain step in a file that also
-# declares a `targets:` key within the following few lines of the step.
+# Return the EFFECTIVE channel for every dtolnay/rust-toolchain step in a file
+# that also declares a `targets:` key within the following few lines of the
+# step. SHA-pinned refs (issue #951) carry the effective channel in a trailing
+# `# <version>` comment; a SHA without a comment is returned verbatim so it is
+# treated as drift.
 targets_bearing_refs() {
     local file="$1"
     awk '
         /dtolnay\/rust-toolchain@/ {
-            ref = $0
+            raw = $0
+            ref = raw
             sub(/.*dtolnay\/rust-toolchain@/, "", ref)
             sub(/[[:space:]].*/, "", ref)
+            eff = ref
+            if (ref ~ /^[0-9a-f]{40}$/) {
+                if (raw ~ /#/) {
+                    cmt = raw
+                    sub(/.*#[[:space:]]*/, "", cmt)
+                    sub(/[[:space:]].*/, "", cmt)
+                    eff = cmt
+                }
+            }
             window = 6
             hit = 0
             for (i = 1; i <= window; i++) {
@@ -92,7 +105,7 @@ targets_bearing_refs() {
                 if (line ~ /^[[:space:]]*targets:/) { hit = 1; break }
                 if (line ~ /dtolnay\/rust-toolchain@/) break
             }
-            if (hit) print ref
+            if (hit) print eff
         }
     ' "$file"
 }
@@ -115,7 +128,7 @@ echo
 assert "release.yml exists" "[ -f '$RELEASE' ]"
 
 assert "release.yml pins dtolnay/rust-toolchain to the toml channel ($CHANNEL)" \
-    "grep -q 'dtolnay/rust-toolchain@$CHANNEL' '$RELEASE'"
+    "grep -Eq 'dtolnay/rust-toolchain@($CHANNEL([[:space:]]|\$)|[0-9a-f]{40}[[:space:]]+#[[:space:]]*$CHANNEL([[:space:]]|\$))' '$RELEASE'"
 
 assert "release.yml no longer uses dtolnay/rust-toolchain@stable" \
     "! grep -q 'dtolnay/rust-toolchain@stable' '$RELEASE'"


### PR DESCRIPTION
Fixes #951

## Summary
Repo-wide supply-chain hardening: every GitHub Actions ref in all six workflows is now pinned to a full 40-char commit SHA with a trailing human-readable version comment, replacing floating tags/branches. A repointed upstream tag can no longer change what executes in CI.

## Changes
Pinned refs (resolved from each upstream repo's authentic tag/branch head):

| Action | SHA | Comment |
|---|---|---|
| actions/checkout | `11d5960a326750d5838078e36cf38b85af677262` | `# v4` |
| actions/upload-artifact | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `# v4` |
| actions/download-artifact | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | `# v4` |
| actions/upload-pages-artifact | `56afc609e74202658d3ffba0e8f6dda462b719fa` | `# v3` |
| actions/deploy-pages | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | `# v4` |
| Swatinem/rust-cache | `e18b497796c12c097a38f9edb9d0641fb99eee32` | `# v2` |
| dtolnay/rust-toolchain | `35a842e360814583e976785eeda0bd0655cb8e83` | `# 1.97.0` |
| dtolnay/rust-toolchain | `4cda84d5c5c54efe2404f9d843567869ab1699d4` | `# stable` |
| softprops/action-gh-release | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | `# v2` |

The two refs already pinned in #939/#950 (`jlumbroso/free-disk-space`, `taiki-e/install-action`) are left untouched.

## Behavior preservation (dtolnay/rust-toolchain)
`dtolnay/rust-toolchain@1.97.0` and `@stable` are **branches**, not tags. Each branch bakes the toolchain version into its own `action.yml` (`toolchain: 1.97.0` / `default: stable`), so pinning to the current branch-head SHA installs the identical toolchain — no functional change.

## #935/#939 invariant kept intact
`scripts/check-toolchain-refs.sh` (and its `issue_935` / `issue_939` tests) enforce that every `targets:`-bearing `dtolnay/rust-toolchain` step matches the `rust-toolchain.toml` channel. The guard + tests are now **SHA-aware**: for a 40-hex ref the effective channel is read from the trailing `# <version>` comment. A SHA with **no** version comment is treated as drift and fails loudly — no silent fallback (per repo error-handling convention).

## Testing
- `scripts/check-toolchain-refs.sh` default scan: green (effective channel `1.97.0`).
- `tests/issue_935_toolchain_ref_pin_test.sh`: 15/15 pass.
- `tests/issue_939_release_toolchain_pin_test.sh`: 22/22 pass.
- All pre-commit hooks pass locally (no `--no-verify`).

## Scope
Only `uses:` ref pinning + the tightly-coupled toolchain guard/tests. No workflow logic, job, or step changes. No new automation (Dependabot/Renovate) and no non-Actions dependency pinning — out of scope for #951.