### PR TITLE
Surface save_state() persistence errors in vm_pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/amplihack-remote/Cargo.toml
+++ b/crates/amplihack-remote/Cargo.toml
@@ -19,3 +19,4 @@ tokio = { version = "1", features = ["process", "io-util", "sync", "rt", "macros
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/amplihack-remote/src/vm_pool.rs
+++ b/crates/amplihack-remote/src/vm_pool.rs
@@ -187,7 +187,14 @@ impl VMPoolManager {
                     vm = %entry.vm.name,
                     "session released"
                 );
-                let _ = self.save_state();
+                if let Err(e) = self.save_state() {
+                    warn!(
+                        session = session_id,
+                        error = %e,
+                        "failed to persist pool state after releasing session; \
+                         in-memory and on-disk state may diverge"
+                    );
+                }
                 return;
             }
         }
@@ -243,7 +250,14 @@ impl VMPoolManager {
 
         if !removed.is_empty() {
             info!(count = removed.len(), "cleaned up idle VMs");
-            let _ = self.save_state();
+            if let Err(e) = self.save_state() {
+                warn!(
+                    count = removed.len(),
+                    error = %e,
+                    "failed to persist pool state after idle-VM cleanup; \
+                     in-memory and on-disk state may diverge"
+                );
+            }
         }
 
         removed

--- a/crates/amplihack-remote/src/vm_pool_tests.rs
+++ b/crates/amplihack-remote/src/vm_pool_tests.rs
@@ -289,6 +289,41 @@ fn apply_cleanup_result_err_retains() {
 // test without a live cloud backend; asserting on it here would require a real
 // azlin and would not exercise anything the shared path does not already cover.
 
+/// A `MakeWriter` that appends every emitted line into a shared buffer so a
+/// test can assert on captured `tracing` output.
+#[derive(Clone, Default)]
+struct BufferWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for BufferWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufferWriter {
+    type Writer = BufferWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Run `f` with a `tracing` subscriber that captures WARN+ events, returning
+/// the captured log text so callers can assert an error was surfaced.
+fn capture_logs(f: impl FnOnce()) -> String {
+    let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::WARN)
+        .with_writer(BufferWriter(buffer.clone()))
+        .without_time()
+        .finish();
+    tracing::subscriber::with_default(subscriber, f);
+    String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+}
+
 fn manager_with_unwritable_state() -> VMPoolManager {
     let dir = tempfile::tempdir().unwrap();
     // A regular file standing where a directory would need to be.
@@ -314,15 +349,31 @@ fn release_session_surfaces_save_state_failure_without_losing_mutation() {
     entry.active_sessions.push("sess-1".to_string());
     mgr.pool.insert("vm-release".to_string(), entry);
 
-    // save_state() will fail here; the method must not panic and must still
-    // apply the in-memory mutation (session removed).
-    mgr.release_session("sess-1");
-
     // Sanity: the persistence path really does fail with this setup, so the
     // test is exercising the surfaced-error branch (not a silent success).
     assert!(
         mgr.save_state().is_err(),
         "test setup must make save_state() fail to exercise the error branch"
+    );
+
+    // save_state() will fail here; the method must not panic, must still apply
+    // the in-memory mutation, and must SURFACE the failure via a WARN log
+    // rather than swallowing it (the issue #883 contract). Capturing the log
+    // is what distinguishes the fixed behaviour from the old
+    // `let _ = self.save_state();` which produced no diagnostic at all.
+    let logs = capture_logs(|| mgr.release_session("sess-1"));
+
+    assert!(
+        logs.contains("WARN"),
+        "persistence failure must be surfaced at WARN level, got logs: {logs:?}"
+    );
+    assert!(
+        logs.contains("in-memory and on-disk state may diverge"),
+        "surfaced warning must explain the divergence, got logs: {logs:?}"
+    );
+    assert!(
+        logs.contains("sess-1"),
+        "surfaced warning must include the session id for diagnosis, got logs: {logs:?}"
     );
 
     let entry = mgr

--- a/crates/amplihack-remote/src/vm_pool_tests.rs
+++ b/crates/amplihack-remote/src/vm_pool_tests.rs
@@ -264,3 +264,73 @@ fn apply_cleanup_result_err_retains() {
         "failed cleanup must not be reported as removed"
     );
 }
+
+// ---- issue #883: save_state() persistence errors must be surfaced, not swallowed ----
+//
+// `release_session` and `cleanup_idle_vms` previously discarded a failed
+// on-disk persistence write via `let _ = self.save_state();`. If the write
+// fails after an in-memory mutation, on-disk state silently diverges from
+// memory. The contract now is log-and-continue: the in-memory mutation still
+// takes effect (the method stays infallible / keeps its return contract) and
+// the persistence failure is surfaced via `warn!` rather than panicking or
+// being swallowed.
+//
+// To drive the shared save_state() error path deterministically without a
+// real cloud/azlin dependency, we point the state file at a location whose
+// parent is a *regular file*. `load_state()` still succeeds (the file does
+// not exist -> Ok(None)), but `save_state()` -> `merge_key_into_state` ->
+// `create_dir_all(parent)` fails because the parent is not a directory.
+//
+// Both sites call the identical `save_state()` with the identical
+// `if let Err(e) => warn!(...)` handling, so the `release_session` test below
+// pins the surfaced-error contract for the shared code path. `cleanup_idle_vms`
+// only reaches its `save_state()` after a *confirmed* VM reclaim (an actual
+// `azlin` deallocation returning `Ok(true)`), which is unavailable in a unit
+// test without a live cloud backend; asserting on it here would require a real
+// azlin and would not exercise anything the shared path does not already cover.
+
+fn manager_with_unwritable_state() -> VMPoolManager {
+    let dir = tempfile::tempdir().unwrap();
+    // A regular file standing where a directory would need to be.
+    let blocker = dir.path().join("blocker");
+    std::fs::write(&blocker, b"not a directory").unwrap();
+    // Parent of `state_file` is `blocker` (a file) -> create_dir_all fails on save.
+    let state_file = blocker.join("state.json");
+
+    let mgr = VMPoolManager::new(Some(state_file), Orchestrator::with_username("test"))
+        .expect("load_state succeeds for a missing state file");
+
+    // Keep the tempdir alive for the lifetime of the manager by leaking it;
+    // the process-scoped test tempdir is cleaned up by the OS afterwards.
+    std::mem::forget(dir);
+    mgr
+}
+
+#[test]
+fn release_session_surfaces_save_state_failure_without_losing_mutation() {
+    let mut mgr = manager_with_unwritable_state();
+
+    let mut entry = make_entry("vm-release");
+    entry.active_sessions.push("sess-1".to_string());
+    mgr.pool.insert("vm-release".to_string(), entry);
+
+    // save_state() will fail here; the method must not panic and must still
+    // apply the in-memory mutation (session removed).
+    mgr.release_session("sess-1");
+
+    // Sanity: the persistence path really does fail with this setup, so the
+    // test is exercising the surfaced-error branch (not a silent success).
+    assert!(
+        mgr.save_state().is_err(),
+        "test setup must make save_state() fail to exercise the error branch"
+    );
+
+    let entry = mgr
+        .pool
+        .get("vm-release")
+        .expect("VM entry must remain in the pool");
+    assert!(
+        !entry.active_sessions.contains(&"sess-1".to_string()),
+        "in-memory mutation must persist even when save_state() fails"
+    );
+}

--- a/docs/remote-sessions/CLI_REFERENCE.md
+++ b/docs/remote-sessions/CLI_REFERENCE.md
@@ -449,6 +449,47 @@ record `32768`, matching the 32 GB Node heap set with
 State writes use an advisory lock so concurrent `remote` commands do not corrupt
 the JSON file.
 
+### Pool persistence and error visibility
+
+The VM pool keeps an in-memory view of every VM and its active sessions, and
+persists that view to the [state file](#state-file) after each mutation so the
+on-disk record stays in step with memory. How a failed persistence write is
+handled depends on whether the operation can report an error to its caller:
+
+| Operation | When it writes | On persistence failure |
+| --------- | -------------- | ---------------------- |
+| Acquiring a session (reuse or provision) | After a VM is assigned to a session | Error is **returned** to the caller (the acquire call fails) |
+| Releasing a session | After a session is removed from its VM's `active_sessions` | `WARN` log with `session` id + `error`; call still succeeds |
+| Idle-VM cleanup | After one or more idle VMs are removed from the pool | `WARN` log with `count` of removed VMs + `error`; call still succeeds |
+
+Acquisition is fallible and propagates a write failure up the stack. Releasing a
+session and idle-VM cleanup are infallible by contract, so they cannot return the
+error. Rather than silently discarding it, they emit a `WARN`-level log that names
+the affected operation and the underlying cause, so the divergence between
+in-memory and on-disk state is observable rather than hidden:
+
+```text
+WARN failed to persist pool state after releasing session;
+     in-memory and on-disk state may diverge session="sess-20260502-203014-4f2a" error="..."
+
+WARN failed to persist pool state after idle-VM cleanup;
+     in-memory and on-disk state may diverge count=2 error="..."
+```
+
+These operations remain non-fatal by design: the in-memory mutation is already
+applied and correct, so the release and cleanup calls continue to succeed and
+return their normal result. The `WARN` log is the signal that the persisted
+state file is stale and may need to be rebuilt (see
+[State file is stale after a persistence warning](#state-file-is-stale-after-a-persistence-warning)).
+
+To surface these warnings, run `remote` commands with tracing at `warn` level or
+lower (the default). Increase verbosity with `RUST_LOG` when diagnosing
+persistence problems:
+
+```bash
+RUST_LOG=amplihack_remote=debug amplihack remote kill sess-20260502-203014-4f2a
+```
+
 ## Exit codes
 
 | Code | Meaning |
@@ -518,3 +559,38 @@ amplihack remote status
 
 Detached sessions already running on VMs continue running, but untracked sessions
 will not appear in `amplihack remote list` until recreated in state.
+
+### State file is stale after a persistence warning
+
+When releasing a session or cleaning up idle VMs, the pool persists its updated
+state to disk. If that write fails, the operation still succeeds in memory but
+emits a `WARN` log so the failure is visible instead of silently swallowed:
+
+```text
+WARN failed to persist pool state after releasing session;
+     in-memory and on-disk state may diverge session="sess-..." error="..."
+```
+
+This means the running process has the correct pool state, but the on-disk
+`remote-state.json` is now behind. Resolve it by fixing the underlying write
+problem and forcing a fresh persist:
+
+1. Check that the state directory is writable and has free space:
+
+   ```bash
+   ls -ld ~/.amplihack
+   df -h ~/.amplihack
+   ```
+
+2. Trigger a fresh persist by running a command that mutates pool state (for
+   example, another `kill`, or an idle-VM cleanup cycle). Each `remote`
+   invocation is a separate process, so a read-only command such as
+   `amplihack remote status` reports the current on-disk view but does not by
+   itself rewrite a stale file — a mutating operation is what re-persists:
+
+   ```bash
+   amplihack remote kill <session-id>
+   ```
+
+If the `error` in the warning points to invalid JSON, follow
+[State file is invalid JSON](#state-file-is-invalid-json) to rebuild the file.


### PR DESCRIPTION
## Summary

`crates/amplihack-remote/src/vm_pool.rs` swallowed failed persistence writes at two sites via `let _ = self.save_state();`:

- `release_session` (L190)
- `cleanup_idle_vms` (L246)

If the on-disk write failed after an in-memory pool mutation, the state file silently diverged from memory (Zero-BS smell — a real error path discarded).

## Change

Both sites now surface the failure with an explicit `warn!` including diagnostic context, instead of discarding the `Result`:

- `release_session` → logs `session` id + `error`.
- `cleanup_idle_vms` → logs `count` of removed VMs + `error`.

Log-and-continue is used because both methods are infallible by contract (release returns `()`, cleanup must return its `Vec<String>` of removed VMs). The in-memory mutation is already applied and correct; the `WARN` makes the memory-vs-disk divergence observable rather than hidden — consistent with the fail-closed logging convention introduced by #870. Acquisition remains fallible and still propagates write failures via `?`.

## Tests

Added `release_session_surfaces_save_state_failure_without_losing_mutation`, which drives the shared `save_state()` error path (state-file parent is a regular file → `create_dir_all` fails) and **captures `tracing` output** to assert a `WARN` naming the session id and the divergence is emitted. This is a true regression test: it **fails** against the old `let _ = self.save_state();` (no log emitted) and **passes** with the fix. `cleanup_idle_vms` shares the identical `save_state()` + `if let Err(e) => warn!` handling; its site is only reachable after a confirmed `azlin` reclaim (no mock seam), so the shared path is pinned via `release_session`.

Adds `tracing-subscriber` as a dev-dependency (already a workspace dependency) for in-test log capture.

## Docs

Documents the pool persistence error-visibility contract in `docs/remote-sessions/CLI_REFERENCE.md` (fallible acquisition vs. infallible release/cleanup that log-and-continue), including the recovery note that only a mutating `remote` command re-persists a stale state file.

## Validation

- `cargo test -p amplihack-remote` — all green (incl. the <500-line module budget contract)
- `cargo clippy -p amplihack-remote --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- pre-commit (fmt, clippy, artifact guard) — all pass; no `--no-verify`, no admin merge

## Scope

Diff limited to `vm_pool.rs`, `vm_pool_tests.rs`, `Cargo.toml`/`Cargo.lock` (dev-dep), and the CLI reference doc. No unrelated changes. Supersedes and consolidates the duplicate #986 (now closed).

Fixes #883