### PR TITLE
fix(cli): resolve --all-targets clippy blocker and add gate (#884)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       # --locked: fail fast on Cargo.lock drift here in the first job (rather than
       # only downstream in test/build), closing a dependency-substitution gap so
       # clippy can never silently resolve unpinned deps (#744 supply-chain).
-      - run: cargo clippy --locked -- -D warnings
+      - run: cargo clippy --locked --all-targets -- -D warnings
 
   test:
     name: Test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,8 @@ repos:
         files: '(\.rs|Cargo\.toml|Cargo\.lock)$'
 
       - id: cargo-clippy
-        name: cargo clippy -- -D warnings
-        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo clippy --locked -- -D warnings'
+        name: cargo clippy --all-targets -- -D warnings
+        entry: bash -c 'CARGO_TARGET_DIR="${TMPDIR:-/tmp}/amplihack-precommit-target" cargo clippy --locked --all-targets -- -D warnings'
         language: system
         pass_filenames: false
         files: '(\.rs|Cargo\.toml|Cargo\.lock)$'

--- a/crates/amplihack-cli/tests/issue_899_merge_validations_abstention.rs
+++ b/crates/amplihack-cli/tests/issue_899_merge_validations_abstention.rs
@@ -33,6 +33,7 @@
 //!   5. the malformed raw output is preserved at
 //!      `cycle_<N>/validator_<label>_raw.txt`
 //!   6. the preserved raw output is byte-for-byte the malformed payload
+//!
 //! Plus:
 //!   * all-unparseable → still exit `1` (FATAL gate keyed on
 //!     `parsed_count == 0`) — the fail-closed floor is preserved.


### PR DESCRIPTION
## Summary

Fixes #884.

The repro command `cargo clippy -p amplihack-cli --all-targets -- -D warnings` exited non-zero. Investigation showed the originally reported **13 `unnecessary_get_then_check` errors were already fixed on `main`** by #878 (they rewrote `.get(k).is_none()` → `!contains_key(k)`). The remaining blocker to the repro command exiting 0 was a single latent `doc_lazy_continuation` error in a test doc-comment — latent because the CI/pre-commit clippy gate ran **without** `--all-targets` (green in CI, red under `--all-targets`), exactly the root cause described in the issue.

## Changes

- **`crates/amplihack-cli/tests/issue_899_merge_validations_abstention.rs`**: add a blank doc line before `Plus:` so it forms its own paragraph rather than an unindented list continuation of item 6 (semantically what the doc intended). Clears the sole `--all-targets` blocker.
- **`.github/workflows/ci.yml`** and **`.pre-commit-config.yaml`**: add `--all-targets` to the clippy gate to prevent this test-only lint class from regressing latently (the issue's suggested regression-prevention).

## Verification

- `cargo clippy -p amplihack-cli --all-targets -- -D warnings` → exits **0**
- `cargo clippy --locked --all-targets -- -D warnings` (full workspace) → exits **0**
- `cargo test -p amplihack-cli --test issue_899_merge_validations_abstention` → **7 passed**
- `pre-commit run --all-files` → **all hooks Passed** (unbypassed)

## Scope / notes

- Zero behavioral change: both the doc-comment indentation and the gate config are semantically inert, so no new tests are required (existing tests cover behavior).
- Diff limited to one test file + two gate configs. No unrelated changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd