### PR TITLE
fix(remote): redact azlin stderr before logging in Orchestrator::cleanup (#882)

### DIFF
--- a/crates/amplihack-remote/src/lib.rs
+++ b/crates/amplihack-remote/src/lib.rs
@@ -26,6 +26,7 @@ pub mod executor;
 pub mod integrator;
 pub mod orchestrator;
 pub mod packager;
+mod redact;
 pub mod session;
 pub mod state_io;
 pub mod state_lock;

--- a/crates/amplihack-remote/src/orchestrator.rs
+++ b/crates/amplihack-remote/src/orchestrator.rs
@@ -13,6 +13,7 @@ use tracing::{debug, info, warn};
 
 use crate::azlin_parse::{parse_azlin_list_json, parse_azlin_list_text};
 use crate::error::{ErrorContext, RemoteError};
+use crate::redact::redact_sensitive;
 
 /// Represents an Azure VM managed by azlin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -131,7 +132,7 @@ impl Orchestrator {
                 Ok(true)
             }
             Ok(Ok(o)) => {
-                let stderr = String::from_utf8_lossy(&o.stderr);
+                let stderr = redact_sensitive(&String::from_utf8_lossy(&o.stderr));
                 let msg = format!("VM cleanup failed: {stderr}");
                 if force {
                     warn!("{msg}");
@@ -144,7 +145,10 @@ impl Orchestrator {
                 }
             }
             Ok(Err(e)) => {
-                let msg = format!("VM cleanup command failed: {e}");
+                let msg = format!(
+                    "VM cleanup command failed: {}",
+                    redact_sensitive(&e.to_string())
+                );
                 if force {
                     warn!("{msg}");
                     Ok(false)

--- a/crates/amplihack-remote/src/redact.rs
+++ b/crates/amplihack-remote/src/redact.rs
@@ -1,0 +1,140 @@
+//! Redaction of sensitive Azure identifiers from arbitrary text.
+//!
+//! `azlin` / Azure CLI stderr can contain sensitive identifiers — subscription
+//! and tenant GUIDs, resource URIs, and SAS token query parameters (notably the
+//! `sig` bearer-capability signature). This module scrubs those values before
+//! they are folded into a [`crate::error::RemoteError`] or a log line.
+//!
+//! Addresses issue #882 (CWE-532: sensitive data written to logs).
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Canonical Azure GUID (subscription / tenant / resource IDs): 8-4-4-4-12 hex.
+static GUID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+        .expect("static GUID redaction regex is valid")
+});
+
+/// SAS query-parameter `name=value` pairs. `sig` is a true bearer credential;
+/// the remaining metadata params are conservatively redacted to avoid leaking
+/// account/container/permission context. Parameter *names* are retained so the
+/// resulting log line stays diagnosable.
+static SAS_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\b(sig|se|sp|sv|st|sr|ss|srt|spr|skoid|sktid|skt|ske|sks|skv)=([^&\s]+)")
+        .expect("static SAS redaction regex is valid")
+});
+
+/// Placeholder substituted for any redacted secret.
+const REDACTED: &str = "[REDACTED]";
+
+/// Scrub known-sensitive Azure identifiers out of arbitrary text (typically
+/// `azlin` / Azure CLI stderr) before it is folded into a `RemoteError` or a
+/// log line.
+///
+/// This is a pure, allocation-only transform: it never performs I/O, has no
+/// side effects, and is idempotent. It removes:
+///
+/// * SAS query-parameter values (`sig`, `se`, `sp`, ...), retaining the
+///   parameter name so the error remains diagnosable.
+/// * Canonical Azure GUIDs (subscription / tenant / resource IDs).
+///
+/// SAS scrubbing runs first so that its `[REDACTED]` placeholder cannot
+/// interfere with subsequent GUID matching. All non-sensitive context (hosts,
+/// paths, VM names, status text) is preserved so logs stay actionable.
+///
+/// This addresses issue #882 (CWE-532: sensitive data in logs). It is
+/// intentionally scoped to GUIDs and SAS parameters; other secret classes
+/// (connection strings, bearer/JWT tokens, account keys) are tracked as a P2
+/// follow-up.
+pub(crate) fn redact_sensitive(input: &str) -> String {
+    let sas_scrubbed = SAS_RE.replace_all(input, "${1}=[REDACTED]");
+    GUID_RE.replace_all(&sas_scrubbed, REDACTED).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_scrubs_subscription_guid() {
+        let stderr = "ERROR: subscription 00000000-0000-0000-0000-000000000000 not found";
+        let out = redact_sensitive(stderr);
+        assert!(
+            !out.contains("00000000-0000-0000-0000-000000000000"),
+            "GUID must be redacted, got: {out}"
+        );
+        assert!(
+            out.contains("[REDACTED]"),
+            "expected placeholder, got: {out}"
+        );
+        // Surrounding, non-sensitive context is preserved so the log stays
+        // actionable.
+        assert!(out.contains("subscription"), "context lost: {out}");
+        assert!(out.contains("not found"), "context lost: {out}");
+    }
+
+    #[test]
+    fn redact_scrubs_sas_token_query_params() {
+        let stderr = "failed to upload to \
+             https://acct.blob.core.windows.net/c/b?sv=2021-08-06&ss=b&srt=o&\
+             sp=rwdlac&se=2030-01-01T00:00:00Z&st=2020-01-01T00:00:00Z&spr=https&\
+             sig=EXAMPLE-fake-sas-signature-do-not-use";
+        let out = redact_sensitive(stderr);
+        // The bearer-capability signature must never survive.
+        assert!(
+            !out.contains("EXAMPLE-fake-sas-signature-do-not-use"),
+            "SAS sig value must be redacted, got: {out}"
+        );
+        // Other SAS parameter *values* are conservatively redacted too.
+        assert!(!out.contains("2021-08-06"), "sv value leaked: {out}");
+        assert!(!out.contains("rwdlac"), "sp value leaked: {out}");
+        // Parameter names are retained so the error remains diagnosable.
+        assert!(out.contains("sig="), "sig param name lost: {out}");
+        assert!(
+            out.contains("[REDACTED]"),
+            "expected placeholder, got: {out}"
+        );
+        // Non-secret host/path context is preserved.
+        assert!(
+            out.contains("acct.blob.core.windows.net"),
+            "host context lost: {out}"
+        );
+    }
+
+    #[test]
+    fn redact_preserves_benign_text() {
+        let stderr = "ERROR: VM 'ci-runner-01' is in state 'Deallocated'; retry after 30s";
+        let out = redact_sensitive(stderr);
+        assert_eq!(
+            out, stderr,
+            "benign text must pass through unchanged, got: {out}"
+        );
+        assert!(
+            !out.contains("[REDACTED]"),
+            "false-positive redaction: {out}"
+        );
+    }
+
+    #[test]
+    fn redact_handles_multiple_secrets() {
+        let stderr = "sub 00000000-0000-0000-0000-000000000000 tenant \
+             11111111-1111-1111-1111-111111111111 url ?sig=EXAMPLE-fake-sig&se=2030-01-01";
+        let out = redact_sensitive(stderr);
+        assert!(
+            !out.contains("00000000-0000-0000-0000-000000000000"),
+            "sub GUID leaked: {out}"
+        );
+        assert!(
+            !out.contains("11111111-1111-1111-1111-111111111111"),
+            "tenant GUID leaked: {out}"
+        );
+        assert!(!out.contains("EXAMPLE-fake-sig"), "sig leaked: {out}");
+        // At least three independent redactions occurred.
+        assert!(
+            out.matches("[REDACTED]").count() >= 3,
+            "expected >=3 redactions, got: {out}"
+        );
+    }
+}

--- a/crates/amplihack-remote/tests/cleanup_redaction.rs
+++ b/crates/amplihack-remote/tests/cleanup_redaction.rs
@@ -1,0 +1,142 @@
+//! Outside-in test for issue #882: `Orchestrator::cleanup` must redact
+//! sensitive Azure identifiers (subscription/tenant GUIDs, SAS query-parameter
+//! values) out of raw `azlin` stderr before it is surfaced in a `RemoteError`.
+//!
+//! These tests exercise the *real* subprocess boundary through the public API:
+//! a stub `azlin` binary is placed on `PATH`, emits secret-laden stderr, and
+//! exits non-zero. We then assert that the error returned to a CLI consumer
+//! carries `[REDACTED]` placeholders instead of the raw secrets, while keeping
+//! enough non-sensitive context to stay diagnosable.
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Mutex;
+
+use amplihack_remote::{Orchestrator, VM};
+use tempfile::TempDir;
+
+/// Serializes the `PATH`-sensitive critical section: the integration test
+/// binary runs its tests on multiple threads, but they all mutate the shared
+/// process `PATH`, so only one may drive `cleanup` at a time.
+static PATH_GUARD: Mutex<()> = Mutex::new(());
+
+/// Write an executable stub `azlin` into `dir` whose `kill` invocation prints
+/// `stderr_body` to stderr and exits non-zero.
+fn install_fake_azlin(dir: &TempDir, stderr_body: &str) {
+    let script = format!("#!/bin/sh\ncat >&2 <<'AZLIN_EOF'\n{stderr_body}\nAZLIN_EOF\nexit 1\n");
+    let path = dir.path().join("azlin");
+    let mut f = fs::File::create(&path).expect("create fake azlin");
+    f.write_all(script.as_bytes()).expect("write fake azlin");
+    let mut perms = f.metadata().unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).expect("chmod fake azlin");
+}
+
+fn sample_vm() -> VM {
+    VM {
+        name: "amplihack-tester-000".into(),
+        size: "Standard_D2s_v3".into(),
+        region: "eastus".into(),
+        created_at: None,
+        tags: None,
+    }
+}
+
+/// Run `Orchestrator::cleanup` with a fake `azlin` on `PATH` and return the
+/// resulting error message. `force = false` so the failure is surfaced as an
+/// explicit `Err` (no silent degradation).
+fn cleanup_error_message(stderr_body: &str) -> String {
+    let _guard = PATH_GUARD.lock().unwrap();
+
+    let dir = TempDir::new().expect("tempdir");
+    install_fake_azlin(&dir, stderr_body);
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let patched = format!("{}:{}", dir.path().display(), original_path);
+    // SAFETY: access to PATH is serialized by PATH_GUARD for the duration of
+    // the cleanup call, and restored before the guard is released.
+    unsafe {
+        std::env::set_var("PATH", &patched);
+    }
+
+    let orchestrator = Orchestrator::with_username("tester");
+    let vm = sample_vm();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let result = runtime.block_on(orchestrator.cleanup(&vm, false));
+
+    unsafe {
+        std::env::set_var("PATH", original_path);
+    }
+
+    match result {
+        Ok(other) => panic!("expected cleanup to fail, got Ok({other})"),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// Scenario 1 (simple): a bare subscription GUID in azlin stderr must not reach
+/// the surfaced error; the placeholder and surrounding context must remain.
+#[test]
+fn cleanup_redacts_subscription_guid_in_error() {
+    let secret_guid = "00000000-0000-0000-0000-000000000000";
+    let msg = cleanup_error_message(&format!(
+        "ERROR: The subscription '{secret_guid}' could not be found."
+    ));
+
+    assert!(
+        msg.contains("VM cleanup failed:"),
+        "unexpected error shape: {msg}"
+    );
+    assert!(
+        !msg.contains(secret_guid),
+        "subscription GUID leaked into error: {msg}"
+    );
+    assert!(
+        msg.contains("[REDACTED]"),
+        "no redaction placeholder: {msg}"
+    );
+    // Non-sensitive diagnostic context survives.
+    assert!(msg.contains("subscription"), "context lost: {msg}");
+    assert!(msg.contains("could not be found"), "context lost: {msg}");
+}
+
+/// Scenario 2 (complex / integration): a full SAS-signed blob URL *and* a
+/// tenant GUID in the same stderr line. Every secret must be scrubbed while the
+/// host/path and parameter *names* remain for debuggability.
+#[test]
+fn cleanup_redacts_sas_url_and_tenant_guid_in_error() {
+    let tenant_guid = "11111111-1111-1111-1111-111111111111";
+    let sas_sig = "EXAMPLE-fake-sas-signature-do-not-use";
+    let stderr = format!(
+        "ERROR: failed to delete blob \
+         https://acct.blob.core.windows.net/c/b?sv=2021-08-06&sig={sas_sig}&se=2030-01-01 \
+         for subscription {tenant_guid}"
+    );
+
+    let msg = cleanup_error_message(&stderr);
+
+    // Secrets are gone.
+    assert!(!msg.contains(sas_sig), "SAS sig leaked: {msg}");
+    assert!(!msg.contains(tenant_guid), "tenant GUID leaked: {msg}");
+    assert!(!msg.contains("2021-08-06"), "sv value leaked: {msg}");
+    // Placeholder present and multiple redactions happened.
+    assert!(
+        msg.contains("[REDACTED]"),
+        "no redaction placeholder: {msg}"
+    );
+    assert!(
+        msg.matches("[REDACTED]").count() >= 2,
+        "expected >=2 redactions, got: {msg}"
+    );
+    // Diagnostic context (host + parameter names) preserved.
+    assert!(
+        msg.contains("acct.blob.core.windows.net"),
+        "host context lost: {msg}"
+    );
+    assert!(msg.contains("sig="), "sig param name lost: {msg}");
+}

--- a/docs/security/AZLIN_STDERR_REDACTION.md
+++ b/docs/security/AZLIN_STDERR_REDACTION.md
@@ -1,0 +1,145 @@
+# Azlin stderr Redaction (Orchestrator Cleanup)
+
+> Status: Implemented · Severity: P2 (security hardening) · Crate: `amplihack-remote`
+> Resolves: [#882](https://github.com/rysweet/amplihack-rs/issues/882) · Follow-up from PR #881 / issue #870.
+
+## Summary
+
+The remote VM orchestrator invokes the Azure CLI wrapper (`azlin`) to provision,
+reuse, and tear down Azure VMs. When a cleanup call fails, the orchestrator
+surfaces the failure to the operator by folding the child process's **stderr**
+into a log line and/or a `RemoteError`.
+
+Raw Azure CLI stderr can contain sensitive identifiers — subscription GUIDs,
+resource URIs, and **SAS token query strings** (which are bearer credentials).
+Logging that verbatim risks disclosing secrets to log sinks (CWE-532).
+
+`Orchestrator::cleanup` now **redacts known-sensitive patterns from azlin stderr
+before** it reaches any `tracing` sink or `RemoteError`. The failure is still
+surfaced explicitly — redaction never swallows or downgrades an error.
+
+## What gets redacted
+
+Redaction is performed by a module-local, pure helper, `redact_sensitive`, in
+`crates/amplihack-remote/src/orchestrator.rs`. It applies two passes:
+
+| Pass | Pattern | Behavior |
+| --- | --- | --- |
+| 1. SAS query params | `sig`, `se`, `sp`, `sv`, `st`, `sr`, `ss`, `srt`, `spr`, `skoid`, `sktid`, `skt`, `ske`, `sks`, `skv` | The **parameter name is retained**; its value is replaced with `[REDACTED]` (e.g. `...&sig=abc123%2F...` → `...&sig=[REDACTED]`). |
+| 2. Canonical GUIDs | 8-4-4-4-12 hex (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) | The whole GUID is replaced with `[REDACTED]` (covers subscription IDs, tenant IDs, resource GUIDs). |
+
+Passes run **SAS-first, then GUID**, so the `[REDACTED]` placeholder cannot
+corrupt later matching. Benign text (VM names, error phrases, region names,
+non-secret words) is preserved so the log line stays actionable.
+
+### Properties
+
+- **Pure & idempotent** — no I/O, no side effects; `redact_sensitive(redact_sensitive(s)) == redact_sensitive(s)`.
+- **ReDoS-safe (CWE-1333)** — both patterns are linear (no nested quantifiers / catastrophic backtracking).
+- **Encoding-safe** — the stderr sink is already-valid UTF-8 from `String::from_utf8_lossy`, and the spawn-error sink is a formatted `std::io::Error`; the transform is UTF-8-boundary safe and never panics on either.
+- **Fail-safe** — applied at *both* fallible cleanup sinks, so there is no unredacted path to a log or error.
+
+## Behavioral contract (unchanged)
+
+Redaction is transparent to control flow. The existing `force` semantics are
+preserved exactly:
+
+| Condition | `force = false` | `force = true` |
+| --- | --- | --- |
+| azlin exits non-zero | `Err(RemoteError::cleanup_ctx(<redacted msg>, ctx))` | `warn!("<redacted msg>")` then `Ok(false)` |
+| azlin fails to spawn | `Err(RemoteError::cleanup(<redacted msg>))` | `warn!("<redacted msg>")` then `Ok(false)` |
+| azlin times out | `Err(RemoteError::cleanup_ctx(<static msg>, ctx))` | `warn!` then `Ok(false)` |
+
+Errors are always propagated (when not forcing) or logged (when forcing) — never
+silently degraded.
+
+> **Redaction scope:** Only the two rows that fold **external process output**
+> into the message are redacted — the non-zero-exit path (child **stderr**) and
+> the spawn-error path (the `std::io::Error`). The timeout path emits a fixed
+> `"VM cleanup timed out"` string with no external content, so redaction is a
+> no-op there; it is listed only for completeness.
+
+## API
+
+`redact_sensitive` is a private implementation detail (module-scoped, not part of
+the public crate API). No public signatures change. There is nothing new to
+import or call from outside `orchestrator.rs`; the hardening is automatic for
+every `Orchestrator::cleanup` invocation.
+
+```rust
+// Internal — not exported.
+fn redact_sensitive(input: &str) -> String;
+```
+
+## Configuration
+
+None. Redaction is **always on** and requires no flags, environment variables,
+or configuration changes. It applies to all callers of `Orchestrator::cleanup`,
+including forced/best-effort teardown paths.
+
+## Examples
+
+Input stderr (illustrative):
+
+```text
+ERROR: The Resource 'Microsoft.Compute/virtualMachines/ci-runner-7' under
+resource group 'rg-amplihack' was not found in subscription
+'00000000-0000-0000-0000-000000000000'. Upload URL:
+https://amplihackblob.blob.core.windows.net/vhds/disk.vhd?sv=2022-11-02&ss=b&srt=sco&sp=rwdlac&se=2026-01-01T00:00:00Z&st=2025-01-01T00:00:00Z&spr=https&sig=EXAMPLE-fake-sas-signature-value
+```
+
+Redacted output that reaches the log / `RemoteError`:
+
+```text
+ERROR: The Resource 'Microsoft.Compute/virtualMachines/ci-runner-7' under
+resource group 'rg-amplihack' was not found in subscription
+'[REDACTED]'. Upload URL:
+https://amplihackblob.blob.core.windows.net/vhds/disk.vhd?sv=[REDACTED]&ss=[REDACTED]&srt=[REDACTED]&sp=[REDACTED]&se=[REDACTED]&st=[REDACTED]&spr=[REDACTED]&sig=[REDACTED]
+```
+
+The VM name, resource group, error phrasing, and storage host remain intact for
+troubleshooting; the subscription GUID is gone, and the SAS **signature**
+(`sig` — the actual bearer credential) is redacted. The non-secret SAS metadata
+params (`sv`, `ss`, `sp`, `se`, `st`, …) are also scrubbed as a conservative
+over-redaction — see the note below.
+
+> **On over-redaction:** Only `sig` is a secret; the other SAS params are
+> metadata. The pass redacts the whole known-param set rather than just `sig` to
+> stay simple and fail-safe (a new credential-bearing param can't leak through a
+> too-narrow allowlist). The cost is slightly less readable URLs in logs, which
+> is an acceptable trade for cleanup diagnostics.
+
+## Testing
+
+Inline `#[cfg(test)]` unit tests in `orchestrator.rs` cover:
+
+1. Subscription/GUID redaction — a canonical GUID becomes `[REDACTED]`.
+2. SAS query-param redaction — `sig`/`se`/`sp`/… values become `[REDACTED]` while param names remain.
+3. Benign-text preservation — non-secret strings pass through unchanged.
+4. Multi-secret redaction — a message with both a GUID and a SAS string is fully scrubbed.
+
+Run:
+
+```bash
+cargo test -p amplihack-remote
+```
+
+## Known limitations (tracked as P2 follow-up)
+
+`redact_sensitive` targets the two highest-value classes for this issue. It does
+**not** yet scrub:
+
+- Storage `AccountKey=` / connection strings
+- Bearer / OAuth / JWT tokens
+- Generic `password=` / `secret=` / `token=` pairs
+
+The helper is intentionally extensible. A future refactor may centralize a single
+shared redactor across `orchestrator.rs`, `packager.rs`, and `session.rs`, plus a
+lint asserting that any remote-crate `warn!`/`error!` interpolating external
+process output routes through it.
+
+## See also
+
+- [`TOKEN_SANITIZATION_GUIDE.md`](TOKEN_SANITIZATION_GUIDE.md)
+- [`SECURITY_API_REFERENCE.md`](SECURITY_API_REFERENCE.md)
+- [`SECURITY_TESTING_GUIDE.md`](SECURITY_TESTING_GUIDE.md)

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -17,6 +17,10 @@ Ahoy! This be where ye learn to keep yer ship secure from digital pirates.
 - [Security API Reference](./SECURITY_API_REFERENCE.md) - Complete API documentation
 - [Security Testing Guide](./SECURITY_TESTING_GUIDE.md) - How to test security features
 
+**New in Issue #882 (P2 hardening):**
+
+- [Azlin stderr Redaction](./AZLIN_STDERR_REDACTION.md) - Redact subscription IDs / SAS URLs from Azure CLI stderr during VM cleanup
+
 ---
 
 ## Security Features Overview


### PR DESCRIPTION
## Summary

`Orchestrator::cleanup` in `crates/amplihack-remote/src/orchestrator.rs` folded **raw azlin (Azure CLI) stderr** verbatim into `RemoteError` messages and `warn!` log lines. Azure CLI stderr can contain sensitive identifiers — subscription/tenant GUIDs, resource URIs, and SAS token query parameters (notably the `sig` bearer-capability signature) — so logging it verbatim risked disclosing secrets to log sinks (**CWE-532**).

## Change

- Add a pure, allocation-only `redact_sensitive(&str) -> String` helper that scrubs:
  - **Canonical Azure GUIDs** (subscription / tenant / resource IDs, 8-4-4-4-12 hex) → `[REDACTED]`
  - **SAS query-parameter values** (`sig`, `se`, `sp`, `sv`, `st`, `sr`, `ss`, `srt`, `spr`, `skoid`, `sktid`, `skt`, `ske`, `sks`, `skv`) → `[REDACTED]`, **retaining parameter names** so the log stays diagnosable.
- Apply it at **both** fallible stderr sinks in `cleanup()`: the non-zero-exit path and the command-spawn-error path.
- Regexes compiled once via `LazyLock` (reusing the existing workspace `regex` dep, mirroring `packager.rs`/`session.rs`); both patterns are linear / ReDoS-safe.
- SAS scrubbing runs before GUID scrubbing so the placeholder cannot interfere with later matching.

## Error-handling contract preserved

Redaction is a pure transform — it never swallows a failure. Errors are still surfaced explicitly: `Err(RemoteError...)` when `!force`, `warn!` when `force`. No silent fallback/degradation introduced.

## Tests

4 new unit tests (`cargo test -p amplihack-remote` → 77 passed):
- `redact_scrubs_subscription_guid`
- `redact_scrubs_sas_token_query_params`
- `redact_preserves_benign_text` (no false positives)
- `redact_handles_multiple_secrets`

`cargo fmt --check`, `cargo clippy -- -D warnings`, and all pre-commit hooks pass (no bypass).

## Scope

Intentionally limited to GUIDs and SAS params per the issue (P2 hardening). Other secret classes (connection strings, bearer/JWT tokens, account keys) are noted as a P2 follow-up in the helper docs.

Fixes #882

> **Module structure:** the redaction logic (regexes + pure `redact_sensitive` transform + its unit tests) lives in a dedicated `crates/amplihack-remote/src/redact.rs` module so `orchestrator.rs` stays within the crate's 500-line-per-module budget (issue #536 contract, enforced by `migration_contract_test::remote_rust_modules_stay_under_500_lines`).

---

## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo** — `Cargo.toml` workspace at repo root; the changed code is in the `amplihack-remote` crate (`crates/amplihack-remote/src/orchestrator.rs`). `cleanup` is `async` and spawns the external `azlin` binary via `tokio::process::Command`, so the user-visible boundary is a Rust CLI consumer receiving a `RemoteError`. Per the qa-team skill's Rust-CLI guidance, `cargo test` substitutes for the gadugi harness.

Chosen validation strategy:
- Added an **outside-in integration test** (`crates/amplihack-remote/tests/cleanup_redaction.rs`) that exercises the real subprocess boundary through the **public API** (`Orchestrator::with_username(..).cleanup(&vm, false)`). A stub `azlin` is installed on `PATH`, emits secret-laden stderr, and exits non-zero — reproducing exactly what a consumer sees when Azure CLI cleanup fails. This proves redaction happens end-to-end before the error surfaces, not just in the pure helper. `force = false` asserts the failure is surfaced explicitly as `Err` (no silent degradation).

### Scenario 1 — simple: subscription GUID in cleanup error is redacted
Command: `cargo test -p amplihack-remote --test cleanup_redaction --locked`
Result: PASS
Output:
```
running 2 tests
test cleanup_redacts_subscription_guid_in_error ... ok
```
The surfaced error was `Cleanup error: VM cleanup failed: ERROR: The subscription '[REDACTED]' could not be found. (context: vm_name=amplihack-tester-000)` — raw GUID `00000000-…-000000000000` gone; `[REDACTED]` present; "subscription" / "could not be found" context retained.

### Scenario 2 — complex: full SAS-signed blob URL + tenant GUID in one stderr line
Command: `cargo test -p amplihack-remote --test cleanup_redaction --locked`
Result: PASS
Output:
```
test cleanup_redacts_sas_url_and_tenant_guid_in_error ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
The SAS `sig` value, `sv` value, and tenant GUID were all replaced with `[REDACTED]` (≥2 redactions), while `acct.blob.core.windows.net` and the `sig=` parameter name were preserved for debuggability.

### Regression check
Command: `cargo test -p amplihack-remote --lib --locked`
Result: PASS — `77 passed; 0 failed` (includes the 4 pre-existing `redact_*` unit tests).
`cargo fmt --check` and `cargo clippy --tests -- -D warnings` clean; all pre-commit hooks passed on commit (no `--no-verify`).

