### PR TITLE
test(#860): regression guard for pr-guide skill Copilot discoverability

### DIFF
--- a/crates/amplihack-cli/src/copilot_setup/staging.rs
+++ b/crates/amplihack-cli/src/copilot_setup/staging.rs
@@ -241,6 +241,116 @@ pub(super) fn register_plugin(source_commands: &Path, copilot_home: &Path) -> Re
 mod tests {
     use super::*;
 
+    /// Issue #860: staging must copy the `pr-guide` skill into the Copilot
+    /// skills tree so Copilot CLI lists it. This exercises the production
+    /// `stage_skills` against a pr-guide-shaped source (a canonical `SKILL.md`
+    /// with valid `name: pr-guide` frontmatter, a sibling `reference.md`, and a
+    /// nested `tests/` dir with a non-markdown file) alongside other skills, and
+    /// asserts the discoverable `skills/pr-guide/SKILL.md` lands intact with no
+    /// co-located skill dropped.
+    #[test]
+    fn stage_skills_makes_pr_guide_discoverable_for_copilot() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_skills = temp.path().join("source-skills");
+        let copilot_home = temp.path().join(".copilot");
+
+        // pr-guide, shaped like the real bundled skill.
+        let pr_guide = source_skills.join("pr-guide");
+        fs::create_dir_all(pr_guide.join("tests")).unwrap();
+        fs::write(
+            pr_guide.join("SKILL.md"),
+            "---\nname: pr-guide\ndescription: Illustrated PR walkthrough.\n---\n\n# PR Guide\n",
+        )
+        .unwrap();
+        fs::write(pr_guide.join("reference.md"), "# Reference\n").unwrap();
+        fs::write(
+            pr_guide.join("tests").join("test_skill_structure.sh"),
+            "#!/usr/bin/env bash\n",
+        )
+        .unwrap();
+
+        // A co-located skill, to prove staging pr-guide does not drop siblings.
+        let other = source_skills.join("pr-review-assistant");
+        fs::create_dir_all(&other).unwrap();
+        fs::write(
+            other.join("SKILL.md"),
+            "---\nname: pr-review-assistant\ndescription: Review helper.\n---\n\n# Review\n",
+        )
+        .unwrap();
+
+        let count = stage_skills(&source_skills, &copilot_home).unwrap();
+
+        let staged_pr_guide = copilot_home
+            .join("skills")
+            .join("pr-guide")
+            .join("SKILL.md");
+        assert!(
+            staged_pr_guide.is_file(),
+            "pr-guide/SKILL.md must be staged to {} so Copilot CLI lists the skill",
+            staged_pr_guide.display()
+        );
+
+        let staged_body = fs::read_to_string(&staged_pr_guide).unwrap();
+        assert!(
+            staged_body.starts_with("---\n") && staged_body.contains("name: pr-guide"),
+            "staged pr-guide/SKILL.md must preserve valid `name: pr-guide` frontmatter"
+        );
+        assert!(
+            copilot_home
+                .join("skills")
+                .join("pr-guide")
+                .join("reference.md")
+                .is_file(),
+            "pr-guide supporting markdown must be staged alongside SKILL.md"
+        );
+        assert!(
+            copilot_home
+                .join("skills")
+                .join("pr-review-assistant")
+                .join("SKILL.md")
+                .is_file(),
+            "staging pr-guide must not drop co-located skills"
+        );
+        assert!(
+            count >= 3,
+            "expected at least 3 staged markdown files (pr-guide SKILL.md + \
+             reference.md + pr-review-assistant SKILL.md), got {count}"
+        );
+    }
+
+    /// Issue #860: re-staging must not duplicate or lose the `pr-guide` skill —
+    /// `reset_markdown_dir` clears stale markdown before each copy, so a second
+    /// stage yields exactly the same discoverable SKILL.md.
+    #[test]
+    fn stage_skills_is_idempotent_for_pr_guide() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_skills = temp.path().join("source-skills");
+        let copilot_home = temp.path().join(".copilot");
+
+        let pr_guide = source_skills.join("pr-guide");
+        fs::create_dir_all(&pr_guide).unwrap();
+        fs::write(
+            pr_guide.join("SKILL.md"),
+            "---\nname: pr-guide\ndescription: Illustrated PR walkthrough.\n---\n",
+        )
+        .unwrap();
+
+        stage_skills(&source_skills, &copilot_home).unwrap();
+        stage_skills(&source_skills, &copilot_home).unwrap();
+
+        let staged_dir = copilot_home.join("skills").join("pr-guide");
+        let markdown: Vec<_> = fs::read_dir(&staged_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .filter(|name| Path::new(name).extension().is_some_and(|ext| ext == "md"))
+            .collect();
+        assert_eq!(
+            markdown,
+            vec![std::ffi::OsString::from("SKILL.md")],
+            "re-staging pr-guide must leave exactly one discoverable SKILL.md"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn legacy_cli_skill_cleanup_rejects_unsupported_file_type() {

--- a/crates/amplihack-cli/tests/issue_860_pr_guide_present.rs
+++ b/crates/amplihack-cli/tests/issue_860_pr_guide_present.rs
@@ -1,0 +1,156 @@
+//! Regression guard for issue #860: the `pr-guide` skill must remain present
+//! and valid in the bundled skill corpus so Copilot CLI keeps listing it.
+//!
+//! # Background
+//!
+//! `pr-guide` previously disappeared from the Copilot CLI skills list because a
+//! hardcoded skill registry (`crates/amplihack-hooks/src/known_skills.rs`)
+//! gated which skills were exposed and did not include it. That registry was
+//! patched (#821) and then removed entirely (#865: "skills directory is the
+//! single source of truth"), so the Copilot path is now filesystem-driven.
+//!
+//! Nothing, however, pinned `pr-guide` specifically. This guard fails loudly
+//! the moment the `pr-guide` skill definition is removed, renamed, or given
+//! malformed metadata — the concrete failure modes that make a skill vanish
+//! from Copilot's list.
+//!
+//! # Read-only invariant
+//!
+//! This test only reads the bundled source files. It never writes or stages.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use serde_yaml::Value;
+
+/// Walk up from the crate manifest dir until we find the workspace root
+/// (the directory that owns both `amplifier-bundle/` and `Cargo.toml`).
+fn workspace_root() -> &'static Path {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        let mut cur = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        loop {
+            if cur.join("amplifier-bundle").is_dir() && cur.join("Cargo.toml").is_file() {
+                return cur;
+            }
+            assert!(
+                cur.pop(),
+                "walked above filesystem root looking for workspace root"
+            );
+        }
+    })
+    .as_path()
+}
+
+fn pr_guide_dir() -> PathBuf {
+    workspace_root().join("amplifier-bundle/skills/pr-guide")
+}
+
+fn pr_guide_skill_md() -> PathBuf {
+    pr_guide_dir().join("SKILL.md")
+}
+
+/// Extract the YAML frontmatter block (between the opening `---\n` at byte 0 and
+/// the next `\n---`). Returns `None` when frontmatter is absent.
+fn extract_frontmatter(content: &str) -> Option<&str> {
+    let after_open = content.strip_prefix("---\n")?;
+    let close_idx = after_open.find("\n---")?;
+    Some(&after_open[..close_idx])
+}
+
+/// TC-860-01: The `pr-guide` skill directory and its canonical `SKILL.md`
+/// entrypoint must exist. A missing/moved/renamed definition is the most direct
+/// way the skill drops out of Copilot's list.
+#[test]
+fn tc_860_01_pr_guide_skill_definition_exists() {
+    let dir = pr_guide_dir();
+    assert!(
+        dir.is_dir(),
+        "pr-guide skill directory is missing at {} — the skill will not be \
+         staged to ~/.copilot/skills and disappears from Copilot CLI",
+        dir.display()
+    );
+
+    let skill_md = pr_guide_skill_md();
+    assert!(
+        skill_md.is_file(),
+        "pr-guide/SKILL.md is missing at {} — Copilot skill discovery requires a \
+         canonical uppercase SKILL.md entrypoint",
+        skill_md.display()
+    );
+}
+
+/// TC-860-02: `pr-guide/SKILL.md` frontmatter must start at byte 0. A Markdown
+/// title or comment before the opening `---` prevents Copilot from parsing the
+/// metadata and silently hides the skill.
+#[test]
+fn tc_860_02_pr_guide_frontmatter_starts_at_first_byte() {
+    let content = fs::read_to_string(pr_guide_skill_md()).expect("read pr-guide SKILL.md");
+    assert!(
+        content.starts_with("---\n"),
+        "pr-guide/SKILL.md frontmatter must start at the first byte"
+    );
+}
+
+/// TC-860-03: `pr-guide/SKILL.md` frontmatter must be valid YAML declaring a
+/// string `name: pr-guide` and a string `description`. Non-string scalar fields
+/// (list/map) are exactly what Copilot CLI rejects (issue #890), and a wrong
+/// name breaks the directory/name match Copilot relies on.
+#[test]
+fn tc_860_03_pr_guide_frontmatter_metadata_is_valid() {
+    let content = fs::read_to_string(pr_guide_skill_md()).expect("read pr-guide SKILL.md");
+    let frontmatter =
+        extract_frontmatter(&content).expect("pr-guide/SKILL.md must have YAML frontmatter");
+
+    let mapping = match serde_yaml::from_str::<Value>(frontmatter) {
+        Ok(Value::Mapping(map)) => map,
+        Ok(other) => panic!("pr-guide frontmatter must be a YAML mapping, found {other:?}"),
+        Err(err) => panic!("pr-guide frontmatter is not valid YAML: {err}"),
+    };
+
+    let name = mapping
+        .get("name")
+        .expect("pr-guide/SKILL.md must declare a `name` field");
+    assert_eq!(
+        name.as_str(),
+        Some("pr-guide"),
+        "pr-guide/SKILL.md `name` must be the string \"pr-guide\" (must also \
+         match the containing directory name for Copilot discovery)"
+    );
+
+    let description = mapping
+        .get("description")
+        .expect("pr-guide/SKILL.md must declare a `description` field");
+    assert!(
+        matches!(description, Value::String(_)),
+        "pr-guide/SKILL.md `description` must be a string scalar — Copilot CLI \
+         rejects list/map scalar fields"
+    );
+}
+
+/// TC-860-04: The `pr-guide` skill name must match its containing directory.
+/// Copilot stages each skill into `~/.copilot/skills/<dir>/` and lists it under
+/// that directory; a name/dir mismatch makes the listing inconsistent.
+#[test]
+fn tc_860_04_pr_guide_name_matches_directory() {
+    let content = fs::read_to_string(pr_guide_skill_md()).expect("read pr-guide SKILL.md");
+    let frontmatter =
+        extract_frontmatter(&content).expect("pr-guide/SKILL.md must have YAML frontmatter");
+    let name = frontmatter
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("name:"))
+        .map(str::trim)
+        .expect("pr-guide/SKILL.md must declare a `name` field");
+
+    let dir_name = pr_guide_dir()
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("pr-guide directory has a name")
+        .to_string();
+
+    assert_eq!(
+        name, dir_name,
+        "pr-guide skill `name` ({name}) must match its directory ({dir_name})"
+    );
+}

--- a/docs/bugfixes/bugfix-860-pr-guide-skill-listing.md
+++ b/docs/bugfixes/bugfix-860-pr-guide-skill-listing.md
@@ -1,0 +1,164 @@
+# Bug Fix #860 — `pr-guide` skill missing from the Copilot CLI skills list
+
+> **Issue:** [#860](https://github.com/rysweet/amplihack-rs/issues/860)
+
+---
+
+## Summary
+
+The `pr-guide` skill stopped appearing in the Copilot CLI skills list even
+though its definition still existed in the bundled skill corpus. Skill exposure
+to Copilot CLI was gated by a hardcoded registry that did not include
+`pr-guide`, so the skill was silently dropped from what Copilot could list and
+invoke.
+
+Copilot skill discovery is now **filesystem-driven**: a skill is listed if — and
+only if — its `SKILL.md` exists under `amplifier-bundle/skills/<name>/` and is
+staged into the Copilot home. No allow-list gates which skills are exposed. This
+bug fix pins `pr-guide` with dedicated regression coverage so that the concrete
+failure modes that make a skill vanish (removed, renamed, or malformed metadata)
+fail loudly instead of silently.
+
+## Root cause
+
+`pr-guide` disappeared because a hardcoded skill registry —
+`crates/amplihack-hooks/src/known_skills.rs` — enumerated which skills were
+exposed to Copilot CLI and did not include `pr-guide`. The skill definition on
+disk was correct; the registry was the single point of omission.
+
+That registry was:
+
+1. Patched to add missing entries (#821), then
+2. **Removed entirely** (#865: _"the skills directory is the single source of
+   truth"_), making Copilot skill discovery purely filesystem-driven.
+
+After #865 the production code path is correct: any skill directory containing a
+valid `SKILL.md` is staged and listed. What remained missing was a guard that
+pins `pr-guide` specifically, so a future removal, rename, or metadata
+regression could once again silently drop it from Copilot's list without any
+test failing.
+
+This was **not** a missing-file defect in the current tree. The `pr-guide`
+directory, its `SKILL.md`, and supporting markdown are all present and valid.
+The fix does **not** restore `known_skills.rs`, which is intentionally gone.
+
+## Fix
+
+Skill discovery for Copilot CLI is filesystem-driven in `stage_skills`:
+
+```text
+crates/amplihack-cli/src/copilot_setup/staging.rs
+```
+
+`stage_skills(source_skills, copilot_home)` walks every subdirectory of
+`amplifier-bundle/skills/`, flattens each skill's markdown tree, and writes it to
+`<copilot_home>/skills/<name>/`. There is no registry, allow-list, or manifest
+that a skill must additionally appear in. A skill is listed by Copilot CLI when:
+
+| Requirement | Detail |
+| --- | --- |
+| Directory exists | `amplifier-bundle/skills/<name>/` is a directory |
+| `SKILL.md` present | `<name>/SKILL.md` exists at the directory root |
+| Frontmatter at byte 0 | The file starts with a `---` YAML frontmatter block |
+| `name` matches directory | Frontmatter `name:` equals `<name>` (kebab-case) |
+| `description` is a string | Frontmatter `description:` is a scalar string |
+
+`pr-guide` satisfies every requirement, so it is staged and listed like any
+other skill.
+
+## `pr-guide` skill
+
+`pr-guide` generates an illustrated, plain-language walkthrough document for a
+pull request — problem statement, approach overview, a step-by-step code tour
+with mermaid diagrams and deep diff links, key decisions, and a testing summary.
+It works with GitHub and Azure DevOps and deliberately skips trivial PRs.
+
+Skill definition:
+
+```text
+amplifier-bundle/skills/pr-guide/
+├── SKILL.md                    # frontmatter (name: pr-guide) + instructions
+├── reference.md                # supporting reference material
+└── tests/test_skill_structure.sh
+```
+
+`SKILL.md` frontmatter:
+
+```yaml
+---
+name: pr-guide
+description: Generates an illustrated, plain-language walkthrough document for a
+  pull request — problem statement, approach overview, step-by-step code tour
+  with mermaid diagrams, deep diff links, key decisions, and testing summary.
+  Use when explaining, documenting, or summarizing a PR, creating a
+  reviewer-friendly illustrated guide, or producing walkthrough notes at the end
+  of default-workflow. Works with GitHub and Azure DevOps.
+---
+```
+
+## Verifying the fix
+
+After installing or updating, confirm the skill is staged into the Copilot home:
+
+```sh
+amplihack install
+ls ~/.copilot/skills/pr-guide/SKILL.md
+```
+
+Then confirm Copilot CLI lists it:
+
+```sh
+copilot
+> /skills
+```
+
+`pr-guide` appears in the skills list. Invoking it produces the illustrated PR
+walkthrough document.
+
+## Regression coverage
+
+Two layers of tests pin `pr-guide` so it cannot silently vanish again.
+
+**Staging unit tests** (`crates/amplihack-cli/src/copilot_setup/staging.rs`)
+exercise the real `stage_skills` function against a `pr-guide`-shaped source:
+
+| Test | Proves |
+| --- | --- |
+| `stage_skills_makes_pr_guide_discoverable_for_copilot` | `skills/pr-guide/SKILL.md` lands intact with valid `name: pr-guide` frontmatter and its supporting markdown, with no sibling skill dropped |
+| `stage_skills_is_idempotent_for_pr_guide` | Re-staging leaves exactly one discoverable `SKILL.md` (no duplication or loss) |
+
+**Integration invariants**
+(`crates/amplihack-cli/tests/issue_860_pr_guide_present.rs`) are read-only and
+fail loudly the moment the skill definition regresses:
+
+| Case | Invariant |
+| --- | --- |
+| TC-860-01 | `amplifier-bundle/skills/pr-guide/` and its `SKILL.md` exist |
+| TC-860-02 | Frontmatter block starts at byte 0 of `SKILL.md` |
+| TC-860-03 | Frontmatter parses as a YAML mapping whose `name` and `description` are `serde_yaml::Value::String` scalars (guards against list/mapping metadata regressions — see [frontmatter type guard](../testing/SKILL_FRONTMATTER_TYPE_GUARD.md)) |
+| TC-860-04 | Frontmatter `name` equals the directory name `pr-guide` |
+
+These tests read only the bundled source files; they never write or stage. Any
+removal, rename, or malformed-metadata change to `pr-guide` fails a test rather
+than silently dropping the skill from Copilot's list.
+
+Focused checks:
+
+```sh
+cargo test -p amplihack-cli --test issue_860_pr_guide_present
+cargo test -p amplihack-cli --lib stage_skills
+```
+
+Broader checks:
+
+```sh
+cargo test -p amplihack-cli
+cargo check --workspace
+```
+
+## Related
+
+- [Staging API reference](../reference/staging-api.md)
+- [Copilot installation implementation](../reference/copilot-installation-implementation.md)
+- [Skill catalog](../skills/SKILL_CATALOG.md)
+- [Skill frontmatter type guard](../testing/SKILL_FRONTMATTER_TYPE_GUARD.md)


### PR DESCRIPTION
## Summary

Fixes #860 — the `pr-guide` skill no longer showing up in the Copilot CLI skills list.

### Root cause (investigation)

`pr-guide` disappeared from the Copilot CLI list because a **hardcoded skill registry** (`crates/amplihack-hooks/src/known_skills.rs`) gated which skills were exposed and did not include it. That registry was:

- patched to add `pr-guide` in #821, then
- **removed entirely** in #865 (*"skills directory is the single source of truth"*).

On current `main` the Copilot path is now purely filesystem-driven (`amplifier-bundle/skills/` → install copy → `~/.amplihack/.claude/skills/` → `copilot_setup::staging::stage_skills` → `~/.copilot/skills/`), and `pr-guide` is present, valid, and staged correctly. Verified end-to-end on a live install (`~/.copilot/skills/pr-guide/SKILL.md` present; skill appears in the Copilot available-skills list).

**Gap:** nothing pinned `pr-guide` specifically, so it could silently drop out again (definition removed/renamed, malformed frontmatter, or a staging change).

### Change

Focused, behavior-pinning regression guards — no production behavior change, since the causal defect (the registry) is already gone:

- **`crates/amplihack-cli/tests/issue_860_pr_guide_present.rs`** — asserts the bundled `pr-guide/SKILL.md` exists, frontmatter starts at byte 0, is valid YAML with a string `name: pr-guide` and string `description`, and `name` matches the directory. These are the exact failure modes that hide a skill from Copilot.
- **`copilot_setup/staging.rs` tests** — exercise the production `stage_skills` and assert a `pr-guide`-shaped skill lands as `skills/pr-guide/SKILL.md` with intact frontmatter, co-located skills are not dropped, and re-staging is idempotent (exactly one discoverable `SKILL.md`).

### Testing

- `cargo test -p amplihack-cli --test issue_860_pr_guide_present` — 4 passed
- `cargo test -p amplihack-cli copilot_setup::staging` — 3 passed
- Adjacent guards green: `skill_frontmatter_name` (11), `skill_frontmatter_type` (4)
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and `pre-commit run` all pass

No `--no-verify`, no admin merge. Not merging — review only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd

---

**Docs:** `docs/bugfixes/bugfix-860-pr-guide-skill-listing.md` records the root cause (the removed `known_skills.rs` registry), the filesystem-driven Copilot discovery contract, and the regression guards — following the repo's `docs/bugfixes/` convention.