### PR TITLE
feat(signal): Step 8b external service integration — seams, remote re-exports, resumable fleet distribute (#971, #972)

### DIFF
--- a/crates/amplihack-cli/src/commands/signal/mod.rs
+++ b/crates/amplihack-cli/src/commands/signal/mod.rs
@@ -45,6 +45,9 @@ pub mod setup;
 #[cfg(feature = "signal")]
 pub mod validate;
 
+#[cfg(feature = "signal")]
+pub use run::{run_distribute_with, run_setup_with};
+
 use crate::SignalCommands;
 use anyhow::Result;
 

--- a/crates/amplihack-cli/src/commands/signal/run.rs
+++ b/crates/amplihack-cli/src/commands/signal/run.rs
@@ -22,7 +22,10 @@ use amplihack_signal::config::{self, SignalConfig};
 use super::distribute::{DistributeState, VmStatus};
 use super::error::SignalOpError;
 use super::fsutil::write_private;
-use super::seams::{AzVmLister, VmLister};
+use super::seams::{
+    AzVmLister, CliLinkSession, Clock, LinkSession, SignalCliBin, SignalCliInvoker, SystemClock,
+    VmLister,
+};
 use super::setup::{self, Probes};
 use super::{config_writer, daemon, endpoint, identity, render, validate};
 use crate::{SignalDistributeArgs, SignalSetupArgs};
@@ -35,10 +38,27 @@ type OpResult<T> = Result<T, SignalOpError>;
 
 /// Onboard the current host. Idempotent: probes what already exists and repairs
 /// only the missing pieces (never re-links an already-linked device).
+///
+/// This is the production entry point; it wires the real I/O seams
+/// ([`SignalCliBin`], [`CliLinkSession`], [`SystemClock`]) and delegates to
+/// [`run_setup_with`], which contains the orchestration logic so tests can
+/// inject fakes at the same boundary.
 pub fn run_setup(args: SignalSetupArgs) -> OpResult<()> {
+    run_setup_with(&SignalCliBin, &CliLinkSession, &SystemClock, args)
+}
+
+/// Orchestration core for host onboarding, with the external effects supplied
+/// as injectable seams (#921/#971 R3). `cli` locates `signal-cli`, `linker`
+/// runs the device-link handshake, and `clock` paces the daemon-readiness poll.
+pub fn run_setup_with(
+    cli: &dyn SignalCliInvoker,
+    linker: &dyn LinkSession,
+    clock: &dyn Clock,
+    args: SignalSetupArgs,
+) -> OpResult<()> {
     let endpoint = resolve_endpoint(args.port, args.endpoint.as_deref())?;
 
-    let signal_cli = detect_signal_cli()?;
+    let signal_cli = cli.detect()?;
     let config_path = default_config_path();
 
     // --- Probe the three independent facts. -------------------------------
@@ -59,7 +79,7 @@ pub fn run_setup(args: SignalSetupArgs) -> OpResult<()> {
 
     // --- Link (only if not already linked). -------------------------------
     let account = if plan.do_link {
-        link_device(&signal_cli, args.device_name.as_deref())?
+        linker.link(&signal_cli, args.device_name.as_deref())?
     } else {
         existing_account.ok_or_else(|| {
             SignalOpError::Link("host reports linked but no account is recorded".into())
@@ -68,7 +88,7 @@ pub fn run_setup(args: SignalSetupArgs) -> OpResult<()> {
 
     // --- Start the local daemon. ------------------------------------------
     if plan.do_start_daemon {
-        start_daemon(&signal_cli, &account, &endpoint)?;
+        start_daemon(&signal_cli, &account, &endpoint, clock)?;
     } else {
         eprintln!("signal setup: local daemon already running on {endpoint}");
     }
@@ -111,7 +131,17 @@ pub fn run_setup(args: SignalSetupArgs) -> OpResult<()> {
 /// Roll onboarding out across a fleet. Resumable and per-VM isolated: state is
 /// persisted after every VM, one VM failing never aborts the others, and a
 /// re-run retries only non-terminal hosts.
+///
+/// Production entry point: wires the real [`AzVmLister`] discovery seam and
+/// delegates to [`run_distribute_with`].
 pub fn run_distribute(args: SignalDistributeArgs) -> OpResult<()> {
+    run_distribute_with(&AzVmLister, args)
+}
+
+/// Orchestration core for the fleet rollout, with VM discovery supplied as an
+/// injectable [`VmLister`] seam (#921/#971 R3). Discovery-returned names are
+/// re-validated as untrusted input before any fan-out (R11).
+pub fn run_distribute_with(lister: &dyn VmLister, args: SignalDistributeArgs) -> OpResult<()> {
     // Identity model gate: only the default linked-device mode is implemented;
     // dedicated-number is a documented extension point that fails fast (exit 3)
     // rather than silently degrading. Wired here so the fleet path always passes
@@ -132,7 +162,7 @@ pub fn run_distribute(args: SignalDistributeArgs) -> OpResult<()> {
     };
 
     // Discover the fleet (explicit list or `az vm list`), then choose targets.
-    let all_vms = discover_vms(&args)?;
+    let all_vms = discover_vms(lister, &args)?;
     let targets: Vec<String> = if args.force {
         all_vms.clone()
     } else {
@@ -227,9 +257,10 @@ pub fn run_distribute(args: SignalDistributeArgs) -> OpResult<()> {
     }
 }
 
-/// Resolve the desired VM set from explicit `--vms` or `az vm list`. Every name
-/// is validated (injection defense) before use.
-fn discover_vms(args: &SignalDistributeArgs) -> OpResult<Vec<String>> {
+/// Resolve the desired VM set from explicit `--vms` or the injected
+/// [`VmLister`] (real impl: `az vm list`). Every name is validated (injection
+/// defense) before use, including names returned by discovery (R11: untrusted).
+fn discover_vms(lister: &dyn VmLister, args: &SignalDistributeArgs) -> OpResult<Vec<String>> {
     let names = match &args.vms {
         Some(csv) => csv
             .split(',')
@@ -237,7 +268,7 @@ fn discover_vms(args: &SignalDistributeArgs) -> OpResult<Vec<String>> {
             .filter(|s| !s.is_empty())
             .map(str::to_string)
             .collect::<Vec<_>>(),
-        None => AzVmLister
+        None => lister
             .list_vms(&args.resource_group)
             .map_err(|e| SignalOpError::Usage(format!("VM discovery failed: {e}")))?,
     };
@@ -334,7 +365,7 @@ fn onboard_remote_vm(
 // ---------------------------------------------------------------------------
 
 /// Locate signal-cli, or fail with actionable install guidance (exit 4).
-fn detect_signal_cli() -> OpResult<PathBuf> {
+pub(super) fn detect_signal_cli() -> OpResult<PathBuf> {
     if let Some(p) = which("signal-cli") {
         return Ok(p);
     }
@@ -353,7 +384,7 @@ fn detect_signal_cli() -> OpResult<PathBuf> {
 /// captured by stdout redirection), and block on **idle detection** — waiting
 /// for the link to complete — with no wall-clock cap. Returns the linked
 /// account (E.164).
-fn link_device(signal_cli: &Path, device_name: Option<&str>) -> OpResult<String> {
+pub(super) fn link_device(signal_cli: &Path, device_name: Option<&str>) -> OpResult<String> {
     let name = device_name
         .map(str::to_string)
         .unwrap_or_else(default_device_name);
@@ -410,7 +441,12 @@ fn link_device(signal_cli: &Path, device_name: Option<&str>) -> OpResult<String>
 
 /// Start the signal-cli JSON-RPC daemon bound to `endpoint`, preferring a
 /// `systemd --user` transient unit and falling back to a detached process.
-fn start_daemon(signal_cli: &Path, account: &str, endpoint: &str) -> OpResult<()> {
+fn start_daemon(
+    signal_cli: &Path,
+    account: &str,
+    endpoint: &str,
+    clock: &dyn Clock,
+) -> OpResult<()> {
     let cli = signal_cli.to_string_lossy().to_string();
     let systemd_ready = which("systemd-run").is_some() && systemd_user_available();
     let plan = daemon::plan_daemon(systemd_ready, false, endpoint);
@@ -433,7 +469,7 @@ fn start_daemon(signal_cli: &Path, account: &str, endpoint: &str) -> OpResult<()
             .map_err(|e| SignalOpError::Daemon(format!("systemd-run failed to spawn: {e}")))?;
         if status.success() {
             eprintln!("signal setup: started daemon via systemd --user (amplihack-signal-daemon)");
-            return wait_for_daemon(endpoint);
+            return wait_for_daemon(endpoint, clock);
         }
         eprintln!("signal setup: systemd-run failed; falling back to a detached process");
     }
@@ -474,14 +510,14 @@ fn start_daemon(signal_cli: &Path, account: &str, endpoint: &str) -> OpResult<()
     cmd.spawn()
         .map_err(|e| SignalOpError::Daemon(format!("failed to spawn signal-cli daemon: {e}")))?;
     eprintln!("signal setup: started detached signal-cli daemon on {endpoint}");
-    wait_for_daemon(endpoint)
+    wait_for_daemon(endpoint, clock)
 }
 
 /// Poll the daemon endpoint until it accepts a TCP connection. This is a local
 /// readiness check (loopback connect is immediate); it is not an interactive
 /// step, so a short bounded retry loop is appropriate. The endpoint is resolved
 /// to socket addresses once up front rather than on every poll iteration.
-fn wait_for_daemon(endpoint: &str) -> OpResult<()> {
+fn wait_for_daemon(endpoint: &str, clock: &dyn Clock) -> OpResult<()> {
     let addrs: Vec<std::net::SocketAddr> = endpoint
         .to_socket_addrs()
         .map(|a| a.collect())
@@ -490,7 +526,7 @@ fn wait_for_daemon(endpoint: &str) -> OpResult<()> {
         if addrs.iter().any(|a| TcpStream::connect(a).is_ok()) {
             return Ok(());
         }
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        clock.sleep(std::time::Duration::from_millis(200));
     }
     Err(SignalOpError::Daemon(format!(
         "daemon did not become reachable on {endpoint}"

--- a/crates/amplihack-cli/src/commands/signal/seams.rs
+++ b/crates/amplihack-cli/src/commands/signal/seams.rs
@@ -4,8 +4,17 @@
 //! process calls, so `plan_rollout` and friends are testable with fakes and
 //! zero cloud dependency (see `tests/signal_setup_idempotency.rs`).
 
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use serde::Deserialize;
+
+use super::error::SignalOpError;
+
+/// Result alias mirroring `run.rs`: Signal orchestration errors carry the
+/// stable exit-code taxonomy (see [`super::error::SignalOpError`]).
+type OpResult<T> = Result<T, SignalOpError>;
 
 /// A single VM record from `azlin list` / `az vm list` JSON. Only `name` is
 /// needed; every other field is ignored so the extractors are tolerant of the
@@ -59,31 +68,131 @@ pub trait VmLister {
     fn list_vms(&self, resource_group: &str) -> Result<Vec<String>>;
 }
 
-/// Real [`VmLister`] backed by the Azure CLI (`az vm list`).
+/// Real [`VmLister`] backed by azlin-first discovery with Azure CLI fallback.
 pub struct AzVmLister;
 
 impl VmLister for AzVmLister {
     fn list_vms(&self, resource_group: &str) -> Result<Vec<String>> {
         super::validate::validate_resource_group(resource_group)
             .context("resource group failed validation")?;
-        let output = std::process::Command::new("az")
-            .args([
-                "vm",
-                "list",
-                "--resource-group",
-                resource_group,
-                "--output",
-                "json",
-            ])
-            .output()
-            .context("failed to run `az vm list` (is the Azure CLI installed and logged in?)")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("`az vm list` failed ({}): {}", output.status, stderr.trim());
+        let azlin = list_vms_with_azlin();
+        match &azlin {
+            Ok(names) if names.is_empty() => eprintln!(
+                "signal distribute: `azlin list --json` returned no VMs; falling back to `az vm list`"
+            ),
+            Err(err) => eprintln!(
+                "signal distribute: `azlin list --json` failed; falling back to `az vm list`: {err}"
+            ),
+            _ => {}
         }
-        // Reuse the pure, unit-tested extractor so the parse rule cannot drift.
-        let json = String::from_utf8_lossy(&output.stdout);
-        Ok(vm_names_from_az_vm_list_json(&json))
+        resolve_vm_list(azlin, || list_vms_with_az(resource_group))
+    }
+}
+
+fn list_vms_with_azlin() -> Result<Vec<String>> {
+    let output = std::process::Command::new("azlin")
+        .args(["list", "--json"])
+        .output()
+        .context("failed to run `azlin list --json` (is azlin installed and authenticated?)")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "`azlin list --json` failed ({}): {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+    let json = String::from_utf8_lossy(&output.stdout);
+    Ok(vm_names_from_azlin_json(&json))
+}
+
+fn list_vms_with_az(resource_group: &str) -> Result<Vec<String>> {
+    let output = std::process::Command::new("az")
+        .args([
+            "vm",
+            "list",
+            "--resource-group",
+            resource_group,
+            "--output",
+            "json",
+        ])
+        .output()
+        .context("failed to run `az vm list` (is the Azure CLI installed and logged in?)")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("`az vm list` failed ({}): {}", output.status, stderr.trim());
+    }
+    // Reuse the pure, unit-tested extractor so the parse rule cannot drift.
+    let json = String::from_utf8_lossy(&output.stdout);
+    Ok(vm_names_from_az_vm_list_json(&json))
+}
+
+// ---------------------------------------------------------------------------
+// Injectable I/O seams for `run_setup` (#921/#971 R3).
+//
+// The interactive host-onboarding path in `run.rs` drives three external
+// effects: locating the `signal-cli` binary, running the device-link handshake,
+// and pacing the daemon-readiness poll. Each is abstracted behind an
+// object-safe trait so `run_setup_with` accepts `&dyn` collaborators. Real
+// impls delegate verbatim to the (unchanged) `run.rs` functions so the existing
+// green contracts are preserved; test fakes are injected only in new seam-level
+// tests (see `tests/signal_seams_injection.rs`) — no real cloud, process, or
+// device-link URI is ever produced by a fake.
+// ---------------------------------------------------------------------------
+
+/// Locates the `signal-cli` binary. Real impl inspects `PATH`; a discovery
+/// failure surfaces install guidance rather than silently degrading.
+pub trait SignalCliInvoker {
+    /// Return the path to a usable `signal-cli`, or a `SignalCli` error.
+    fn detect(&self) -> OpResult<PathBuf>;
+}
+
+/// Runs the interactive `signal-cli link` device-link handshake and returns the
+/// linked account (E.164).
+///
+/// SECURITY (R9): implementations MUST keep the device-link URI on **stderr
+/// only** and never persist or log it — it is a bearer secret. Test fakes must
+/// not emit a real URI.
+pub trait LinkSession {
+    /// Link a new device named `device_name` (or a default), returning the
+    /// associated E.164 account on success.
+    fn link(&self, signal_cli: &Path, device_name: Option<&str>) -> OpResult<String>;
+}
+
+/// Time seam for the daemon-readiness poll. Deliberately minimal (ruthless
+/// simplicity): only the blocking `sleep` used by `wait_for_daemon` is
+/// abstracted, so tests can inject a non-blocking [`FakeClock`]-style stub and
+/// keep the poll deterministic and instant.
+pub trait Clock {
+    /// Block for `dur`. The real clock sleeps; fakes typically no-op.
+    fn sleep(&self, dur: Duration);
+}
+
+/// Real [`SignalCliInvoker`] delegating to the production detection logic.
+pub struct SignalCliBin;
+
+impl SignalCliInvoker for SignalCliBin {
+    fn detect(&self) -> OpResult<PathBuf> {
+        super::run::detect_signal_cli()
+    }
+}
+
+/// Real [`LinkSession`] delegating to the production `signal-cli link` driver.
+pub struct CliLinkSession;
+
+impl LinkSession for CliLinkSession {
+    fn link(&self, signal_cli: &Path, device_name: Option<&str>) -> OpResult<String> {
+        super::run::link_device(signal_cli, device_name)
+    }
+}
+
+/// Real [`Clock`] backed by `std::thread::sleep` (wall-clock pacing).
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn sleep(&self, dur: Duration) {
+        std::thread::sleep(dur);
     }
 }

--- a/crates/amplihack-cli/tests/signal_azlin_lister.rs
+++ b/crates/amplihack-cli/tests/signal_azlin_lister.rs
@@ -14,8 +14,16 @@
 #![cfg(feature = "signal")]
 
 use amplihack_cli::commands::signal::seams::{
-    resolve_vm_list, vm_names_from_az_vm_list_json, vm_names_from_azlin_json,
+    AzVmLister, VmLister, resolve_vm_list, vm_names_from_az_vm_list_json, vm_names_from_azlin_json,
 };
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::sync::Mutex;
+
+#[cfg(unix)]
+static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn extracts_names_from_azlin_json() {
@@ -75,4 +83,113 @@ fn fallback_error_surfaces_never_a_silent_empty_list() {
         res.is_err(),
         "a total discovery failure must surface as an error"
     );
+}
+
+#[cfg(unix)]
+fn write_executable(path: &std::path::Path, body: &str) {
+    std::fs::write(path, body).unwrap();
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn production_lister_uses_azlin_before_az_when_azlin_has_names() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let root = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("signal-azlin-first-test");
+    let bin = root.join("bin");
+    let marker = root.join("az-called");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&bin).unwrap();
+    write_executable(
+        &bin.join("azlin"),
+        "#!/usr/bin/env bash\nprintf '[{\"name\":\"vm-from-azlin\"}]\\n'\n",
+    );
+    write_executable(
+        &bin.join("az"),
+        &format!(
+            "#!/usr/bin/env bash\nprintf called > '{}'\nprintf '[{{\"name\":\"vm-from-az\"}}]\\n'\n",
+            marker.display()
+        ),
+    );
+    let old_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{}:{}",
+                bin.display(),
+                old_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy())
+                    .unwrap_or_default()
+            ),
+        );
+    }
+
+    let names = AzVmLister.list_vms("rg-test").unwrap();
+    let az_called = marker.exists();
+
+    unsafe {
+        match old_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&root);
+    assert_eq!(names, vec!["vm-from-azlin"]);
+    assert!(!az_called, "`az vm list` must not run when azlin succeeds");
+}
+
+#[cfg(unix)]
+#[test]
+fn production_lister_falls_back_to_az_when_azlin_is_empty() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let root = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("signal-az-fallback-test");
+    let bin = root.join("bin");
+    let marker = root.join("az-called");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&bin).unwrap();
+    write_executable(&bin.join("azlin"), "#!/usr/bin/env bash\nprintf '[]\\n'\n");
+    write_executable(
+        &bin.join("az"),
+        &format!(
+            "#!/usr/bin/env bash\nprintf called > '{}'\nprintf '[{{\"name\":\"vm-from-az\"}}]\\n'\n",
+            marker.display()
+        ),
+    );
+    let old_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{}:{}",
+                bin.display(),
+                old_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy())
+                    .unwrap_or_default()
+            ),
+        );
+    }
+
+    let names = AzVmLister.list_vms("rg-test").unwrap();
+    let az_called = marker.exists();
+
+    unsafe {
+        match old_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&root);
+    assert_eq!(names, vec!["vm-from-az"]);
+    assert!(az_called, "`az vm list` must run after empty azlin");
 }

--- a/crates/amplihack-cli/tests/signal_seams_injection.rs
+++ b/crates/amplihack-cli/tests/signal_seams_injection.rs
@@ -1,0 +1,200 @@
+//! Seam-injection contract (#921/#971 R3): the host-onboarding I/O effects are
+//! abstracted behind the public, object-safe `SignalCliInvoker`, `LinkSession`,
+//! and `Clock` traits so `run_setup` can be driven with fakes — no real
+//! `signal-cli`, no real device-link handshake, no real sleeping.
+//!
+//! These tests fail to *compile* if the seams regress (not `pub`, or not
+//! object-safe), and assert the fakes are injectable through `&dyn` — the same
+//! boundary the production wrappers use. Fakes deliberately emit **no** real
+//! device-link URI (R9) and perform no external I/O.
+#![cfg(feature = "signal")]
+
+use std::cell::Cell;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use amplihack_cli::commands::signal::error::SignalOpError;
+use amplihack_cli::commands::signal::seams::{Clock, LinkSession, SignalCliInvoker, VmLister};
+use amplihack_cli::commands::signal::{run_distribute_with, run_setup_with};
+use amplihack_cli::{SignalDistributeArgs, SignalSetupArgs};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+// --- Fakes: injected only in tests; never touch the network/process/device. --
+
+struct FakeSignalCli(PathBuf);
+impl SignalCliInvoker for FakeSignalCli {
+    fn detect(&self) -> Result<PathBuf, SignalOpError> {
+        Ok(self.0.clone())
+    }
+}
+
+struct FakeVmLister {
+    names: Vec<String>,
+    calls: Cell<u32>,
+}
+
+impl VmLister for FakeVmLister {
+    fn list_vms(&self, _resource_group: &str) -> anyhow::Result<Vec<String>> {
+        self.calls.set(self.calls.get() + 1);
+        Ok(self.names.clone())
+    }
+}
+
+struct MissingSignalCli;
+impl SignalCliInvoker for MissingSignalCli {
+    fn detect(&self) -> Result<PathBuf, SignalOpError> {
+        Err(SignalOpError::SignalCli(
+            "signal-cli not found on PATH".into(),
+        ))
+    }
+}
+
+/// A fake linker that returns a canned E.164 and, critically, emits NO
+/// device-link URI (the real secret stays stderr-only in production; a fake
+/// must never manufacture one).
+struct FakeLinkSession {
+    account: String,
+    last_device: Cell<Option<String>>,
+}
+impl LinkSession for FakeLinkSession {
+    fn link(&self, _signal_cli: &Path, device_name: Option<&str>) -> Result<String, SignalOpError> {
+        self.last_device
+            .set(device_name.map(str::to_string).or(Some("<default>".into())));
+        Ok(self.account.clone())
+    }
+}
+
+/// A non-blocking clock that records how often (and how long) it was asked to
+/// sleep, keeping time deterministic and instant.
+struct FakeClock {
+    calls: Cell<u32>,
+    total: Cell<Duration>,
+}
+impl FakeClock {
+    fn new() -> Self {
+        FakeClock {
+            calls: Cell::new(0),
+            total: Cell::new(Duration::ZERO),
+        }
+    }
+}
+impl Clock for FakeClock {
+    fn sleep(&self, dur: Duration) {
+        self.calls.set(self.calls.get() + 1);
+        self.total.set(self.total.get() + dur);
+    }
+}
+
+#[test]
+fn signal_cli_invoker_is_injectable_as_dyn() {
+    let fake = FakeSignalCli(PathBuf::from("/opt/signal-cli/bin/signal-cli"));
+    let seam: &dyn SignalCliInvoker = &fake;
+    assert_eq!(
+        seam.detect().unwrap(),
+        PathBuf::from("/opt/signal-cli/bin/signal-cli")
+    );
+}
+
+#[test]
+fn signal_cli_detection_failure_surfaces_signalcli_error() {
+    let seam: &dyn SignalCliInvoker = &MissingSignalCli;
+    let err = seam.detect().unwrap_err();
+    // Never silently degrades to a bogus path; surfaces the taxonomy error.
+    assert_eq!(err.exit_code(), 4);
+}
+
+#[test]
+fn link_session_returns_account_and_emits_no_uri() {
+    let fake = FakeLinkSession {
+        account: "+15551230000".into(),
+        last_device: Cell::new(None),
+    };
+    let seam: &dyn LinkSession = &fake;
+    let account = seam
+        .link(Path::new("/opt/signal-cli"), Some("amplihack-host"))
+        .unwrap();
+    assert_eq!(account, "+15551230000");
+    assert_eq!(fake.last_device.take(), Some("amplihack-host".to_string()));
+}
+
+#[test]
+fn clock_seam_is_injectable_and_deterministic() {
+    let clock = FakeClock::new();
+    let seam: &dyn Clock = &clock;
+    seam.sleep(Duration::from_millis(200));
+    seam.sleep(Duration::from_millis(200));
+    assert_eq!(clock.calls.get(), 2);
+    assert_eq!(clock.total.get(), Duration::from_millis(400));
+}
+
+#[test]
+fn run_setup_with_uses_injected_cli_and_fails_before_linking_when_cli_missing() {
+    let cli = MissingSignalCli;
+    let linker = FakeLinkSession {
+        account: "+15551230000".into(),
+        last_device: Cell::new(None),
+    };
+    let clock = FakeClock::new();
+    let args = SignalSetupArgs {
+        endpoint: Some("127.0.0.1:7583".into()),
+        port: None,
+        device_name: Some("amplihack-test".into()),
+        force: false,
+        all_vms: false,
+        resource_group: None,
+    };
+
+    let err = run_setup_with(&cli, &linker, &clock, args).unwrap_err();
+    assert_eq!(err.exit_code(), 4);
+    assert_eq!(linker.last_device.take(), None);
+    assert_eq!(clock.calls.get(), 0);
+}
+
+#[test]
+fn run_distribute_with_uses_injected_vm_lister_for_empty_fleet_without_external_az() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let home = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("signal-seams-injection-home");
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    let old_home = std::env::var_os("HOME");
+    let old_azlin = std::env::var_os("AZLIN_PATH");
+    unsafe {
+        std::env::set_var("HOME", &home);
+        std::env::set_var("AZLIN_PATH", home.join("fake-azlin-not-used"));
+    }
+
+    let lister = FakeVmLister {
+        names: Vec::new(),
+        calls: Cell::new(0),
+    };
+    let args = SignalDistributeArgs {
+        resource_group: "rg-test".into(),
+        vms: None,
+        endpoint: Some("127.0.0.1:7583".into()),
+        port: None,
+        concurrency: None,
+        force: false,
+    };
+
+    let result = run_distribute_with(&lister, args);
+
+    unsafe {
+        match old_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match old_azlin {
+            Some(v) => std::env::set_var("AZLIN_PATH", v),
+            None => std::env::remove_var("AZLIN_PATH"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+
+    result.unwrap();
+    assert_eq!(lister.calls.get(), 1);
+}

--- a/crates/amplihack-remote/src/azlin_parse.rs
+++ b/crates/amplihack-remote/src/azlin_parse.rs
@@ -3,7 +3,12 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use crate::orchestrator::VM;
 
 /// Parse JSON output from `azlin list --json`.
-pub(crate) fn parse_azlin_list_json(output: &str) -> Vec<VM> {
+///
+/// Public API (#921/#971 R4): the Signal fleet path re-uses these azlin
+/// parsers so the discovery JSON shape cannot drift between crates. Malformed
+/// or non-array input yields an empty `Vec` (the caller decides whether an
+/// empty fleet triggers a fallback); parsing never panics on bad input.
+pub fn parse_azlin_list_json(output: &str) -> Vec<VM> {
     let items: Vec<serde_json::Value> = match serde_json::from_str(output) {
         Ok(v) => v,
         Err(_) => return Vec::new(),
@@ -40,7 +45,11 @@ pub(crate) fn parse_azlin_list_json(output: &str) -> Vec<VM> {
 }
 
 /// Parse text output from `azlin list`.
-pub(crate) fn parse_azlin_list_text(output: &str) -> Vec<VM> {
+///
+/// Public API (#921/#971 R4): companion to [`parse_azlin_list_json`] for the
+/// human-readable `azlin list` table. The first line is treated as a header
+/// and skipped; malformed rows are ignored rather than erroring.
+pub fn parse_azlin_list_text(output: &str) -> Vec<VM> {
     let mut vms = Vec::new();
     for line in output.lines().skip(1) {
         let parts: Vec<&str> = line.split_whitespace().collect();

--- a/crates/amplihack-remote/src/lib.rs
+++ b/crates/amplihack-remote/src/lib.rs
@@ -18,7 +18,7 @@
 //! - [`error`] — Error types
 
 pub mod auth;
-pub(crate) mod azlin_parse;
+pub mod azlin_parse;
 pub(crate) mod backoff;
 pub mod cli;
 pub mod commands;
@@ -36,6 +36,11 @@ pub(crate) mod vm_lookup;
 pub mod vm_pool;
 
 pub use auth::{AzureAuthenticator, AzureCredentials, get_azure_auth};
+// #921/#971 R4: re-export the azlin discovery parsers and the idle/liveness
+// watchdog so the Signal fleet path (idle-based device-linking) can consume a
+// single, shared implementation instead of forking the parse/idle logic.
+pub use amplihack_utils::idle_watchdog;
+pub use azlin_parse::{parse_azlin_list_json, parse_azlin_list_text};
 pub use cli::{
     WorkflowOptions, WorkflowResult, execute_remote_workflow, execute_remote_workflow_with_api_key,
 };

--- a/crates/amplihack-remote/tests/azlin_parse_public_api.rs
+++ b/crates/amplihack-remote/tests/azlin_parse_public_api.rs
@@ -1,0 +1,45 @@
+//! Public-API contract (#921/#971 R4): the azlin discovery parsers and the
+//! idle watchdog are re-exported from `amplihack_remote` so the Signal fleet
+//! path consumes a single shared implementation. These tests fail to *compile*
+//! if the re-exports regress to `pub(crate)`, and assert the parse semantics
+//! the fleet path relies on (tolerant of malformed input, never panicking).
+
+use amplihack_remote::{parse_azlin_list_json, parse_azlin_list_text};
+
+#[test]
+fn json_parser_is_public_and_extracts_names() {
+    let json = r#"[
+        {"name":"amplihack-user-1","size":"Standard_D2s_v3","region":"eastus"},
+        {"name":"amplihack-user-2","size":"Standard_D4s_v3","region":"westus"}
+    ]"#;
+    let vms = parse_azlin_list_json(json);
+    assert_eq!(vms.len(), 2);
+    assert_eq!(vms[0].name, "amplihack-user-1");
+    assert_eq!(vms[1].name, "amplihack-user-2");
+}
+
+#[test]
+fn text_parser_is_public_and_skips_header() {
+    let text = "NAME              SIZE             REGION\n\
+                vm-alpha          Standard_D2s_v3  eastus\n\
+                vm-beta           Standard_D4s_v3  westus\n";
+    let vms = parse_azlin_list_text(text);
+    assert_eq!(vms.len(), 2);
+    assert_eq!(vms[0].name, "vm-alpha");
+    assert_eq!(vms[1].region, "westus");
+}
+
+#[test]
+fn malformed_json_never_panics_and_yields_empty() {
+    assert!(parse_azlin_list_json("not json at all").is_empty());
+    assert!(parse_azlin_list_json("{}").is_empty());
+    assert!(parse_azlin_list_json("").is_empty());
+}
+
+#[test]
+fn idle_watchdog_is_reexported() {
+    // Compile-time proof that the watchdog surface is exposed for idle-based
+    // device-linking. `IdleConfig::with_idle` is part of the public API.
+    let _cfg =
+        amplihack_remote::idle_watchdog::IdleConfig::with_idle(std::time::Duration::from_secs(1));
+}

--- a/docs/SIGNAL_ONBOARDING.md
+++ b/docs/SIGNAL_ONBOARDING.md
@@ -195,6 +195,11 @@ non-fatal, so problems are reported there rather than crashing the session. See
 
 - [Signal Channel](signal-channel.md) — full channel documentation, config
   schema, security model, and per-session wiring.
+- [Signal External Service Integration](signal-external-integration.md) — the
+  seam architecture (`signal-cli`, daemon poll, `azlin`/`az` discovery),
+  resumable fleet state, `amplihack-remote` re-exports, and how to test the
+  external boundaries.
 - [`examples/signal-config.toml`](../examples/signal-config.toml) — annotated config.
 - Related issues: **#921** (onboarding command), **#922** (device linking),
-  **#923** (fleet distribution), **#924** (idempotent local daemon + config).
+  **#923** (fleet distribution), **#924** (idempotent local daemon + config),
+  **#971** (external service integration), **#972** (TDD contract tests).

--- a/docs/signal-channel.md
+++ b/docs/signal-channel.md
@@ -877,6 +877,7 @@ truncated to 32 chars, and never used in any filesystem path.
 ## See also
 
 - [Signal onboarding how-to](SIGNAL_ONBOARDING.md) — `setup` and `distribute` walkthrough
+- [Signal external service integration](signal-external-integration.md) — seam architecture, resumable fleet state, and `amplihack-remote` re-exports
 - [`examples/signal-config.toml`](../examples/signal-config.toml) — annotated config
 - [Signal onboarding — performance notes](reference/signal-onboarding-performance.md) — hot paths & allocation trims
 - [Hook configuration guide](HOOK_CONFIGURATION_GUIDE.md)

--- a/docs/signal-external-integration.md
+++ b/docs/signal-external-integration.md
@@ -1,0 +1,507 @@
+# Signal External Service Integration
+
+How the `amplihack signal` onboarding flow talks to the outside world —
+`signal-cli`, the local JSON-RPC daemon, and the Azure Linux (`azlin` / `az`)
+fleet — and how those integrations are made **testable, resumable, and
+secure**.
+
+This is the developer- and operator-facing companion to the two user guides:
+
+- [Signal Onboarding](SIGNAL_ONBOARDING.md) — the `setup` / `distribute` CLI.
+- [Signal Channel](signal-channel.md) — the runtime channel, config schema, and
+  trust boundary.
+
+Read this document when you need to understand the integration architecture,
+extend a service adapter, write tests against the external boundaries, or audit
+the security invariants (issues **#971**, **#972**).
+
+---
+
+## Contents
+
+- [Overview](#overview)
+- [The seam boundary](#the-seam-boundary)
+  - [`SignalCliInvoker`](#signalcliinvoker)
+  - [`LinkSession`](#linksession)
+  - [`Clock`](#clock)
+  - [`VmLister`](#vmlister)
+- [Dependency-injection helpers](#dependency-injection-helpers)
+- [VM discovery: azlin → az fallback](#vm-discovery-azlin--az-fallback)
+- [Fleet distribution core (`--all-vms`)](#fleet-distribution-core---all-vms)
+  - [Resumable on-disk state](#resumable-on-disk-state)
+  - [Per-VM isolation](#per-vm-isolation)
+  - [PARTIAL rollouts](#partial-rollouts)
+- [`amplihack-remote` public re-exports](#amplihack-remote-public-re-exports)
+- [Security invariants](#security-invariants)
+- [Exit-code taxonomy](#exit-code-taxonomy)
+- [Configuration and environment](#configuration-and-environment)
+- [Testing against the boundaries](#testing-against-the-boundaries)
+- [See also](#see-also)
+
+---
+
+## Overview
+
+Signal onboarding drives four external effects:
+
+| Effect | Backing tool | Where |
+| --- | --- | --- |
+| Locate the CLI | `signal-cli` on `PATH` | host + each VM |
+| Device link | `signal-cli link` (device-link URI + QR) | host + each VM |
+| Daemon readiness poll | wall-clock pacing | host + each VM |
+| Fleet discovery | `azlin list` → `az vm list` fallback | operator workstation |
+
+Every one of these is reached through an **injectable trait seam** rather than a
+direct process/cloud call. Production code wires in real implementations; tests
+construct fakes and drive them through the **same `&dyn Trait` boundary** the
+production wrappers use — with **zero** cloud dependency, no real `signal-cli`,
+and no device-link secret ever produced.
+
+The seams live in
+[`crates/amplihack-cli/src/commands/signal/seams.rs`](../crates/amplihack-cli/src/commands/signal/seams.rs)
+and are compiled only under the `signal` cargo feature.
+
+```text
+run_setup(args)                 run_distribute(args)
+      │  wires real impls              │  wires real impls
+      ▼                                ▼
+run_setup_with(&SignalCliBin,    run_distribute_with(&AzVmLister, args)
+               &CliLinkSession,          │
+               &SystemClock, args)       ▼
+      │                            discover_vms ── azlin ──▶ az fallback
+      ▼                                  │
+ detect ▶ link ▶ daemon ▶ config    per-VM distribute core (resumable, isolated)
+```
+
+The **public** entry points `run_setup` / `run_distribute` keep their exact
+signatures (they are the stable CLI surface). The injectable `_with` variants
+carry the seams and are what tests target.
+
+---
+
+## The seam boundary
+
+All four traits are object-safe (`&dyn Trait`) so a single core can be driven by
+either the real adapter or a fake. Errors always surface — no seam silently
+degrades a failure into an empty/success result.
+
+### `SignalCliInvoker`
+
+Locates the `signal-cli` binary.
+
+```rust
+pub trait SignalCliInvoker {
+    /// Return the path to a usable `signal-cli`, or a `SignalCli` error
+    /// carrying install guidance. Never silently succeeds without a binary.
+    fn detect(&self) -> Result<PathBuf, SignalOpError>;
+}
+
+/// Production adapter: inspects `PATH` via the existing detection logic.
+pub struct SignalCliBin;
+```
+
+A discovery failure returns `SignalOpError::SignalCli(..)` → **exit 4** with a
+message telling the operator how to install `signal-cli`.
+
+### `LinkSession`
+
+Runs the interactive `signal-cli link` device-link handshake.
+
+```rust
+pub trait LinkSession {
+    /// Link a device (named `device_name`, or a default) and return the
+    /// linked account in E.164 form (e.g. "+15551234567").
+    fn link(&self, signal_cli: &Path, device_name: Option<&str>)
+        -> Result<String, SignalOpError>;
+}
+
+/// Production adapter over `signal-cli link`.
+pub struct CliLinkSession;
+```
+
+> **Security (R9).** The device-link URI (`sgnl://linkdevice…`, legacy
+> `tsdevice:…`) is a **bearer secret**. Implementations MUST print it to
+> **stderr only** and MUST NOT persist or log it anywhere. Only the resulting
+> **E.164 account** flows onward into config/state. Test fakes must never emit a
+> real URI. See [Security invariants](#security-invariants).
+
+### `Clock`
+
+Abstracts the blocking pace of the daemon-readiness poll so tests run instantly
+and deterministically. Deliberately minimal (ruthless simplicity):
+
+```rust
+pub trait Clock {
+    /// Block for `dur`. The real clock sleeps; fakes typically no-op and
+    /// record the requested duration/call-count.
+    fn sleep(&self, dur: Duration);
+}
+
+/// Production adapter backed by `std::thread::sleep`.
+pub struct SystemClock;
+```
+
+A `FakeClock` used in tests returns immediately from `sleep`, making the
+`wait_for_daemon` loop finish without real waiting.
+
+### `VmLister`
+
+Enumerates VM names in an operator resource group for fleet distribution.
+
+```rust
+pub trait VmLister {
+    /// List VM names in `resource_group`. A discovery failure **propagates**
+    /// (no silent empty fallback): it must surface, never masquerade as
+    /// "no VMs".
+    fn list_vms(&self, resource_group: &str) -> anyhow::Result<Vec<String>>;
+}
+
+/// Production adapter: validates the resource group, then shells out to
+/// `az vm list --resource-group <rg> --output json` (explicit argv, no shell).
+pub struct AzVmLister;
+```
+
+`AzVmLister` validates the resource-group name **before** constructing the
+command, invokes `az` with an explicit argv array (never `sh -c`), and reuses
+the pure `vm_names_from_az_vm_list_json` extractor so the parse rule cannot
+drift.
+
+---
+
+## Dependency-injection helpers
+
+Two private helpers hold the orchestration logic; the public functions are thin
+wrappers that inject the real adapters.
+
+```rust
+// Stable public surface — signatures are frozen.
+pub fn run_setup(args: SignalSetupArgs) -> Result<(), SignalOpError> {
+    run_setup_with(&SignalCliBin, &CliLinkSession, &SystemClock, args)
+}
+
+pub fn run_distribute(args: SignalDistributeArgs) -> Result<(), SignalOpError> {
+    run_distribute_with(&AzVmLister, args)
+}
+
+// Injectable variants — module-private in `run.rs`; they carry the seams.
+fn run_setup_with(
+    cli: &dyn SignalCliInvoker,
+    link: &dyn LinkSession,
+    clock: &dyn Clock,
+    args: SignalSetupArgs,
+) -> Result<(), SignalOpError>;
+
+fn run_distribute_with(
+    lister: &dyn VmLister,
+    args: SignalDistributeArgs,
+) -> Result<(), SignalOpError>;
+```
+
+The `_with` helpers are **private** to `run.rs` — they are not re-exported and
+are not part of any test's import surface. What tests *do* reach is the **public
+`seams` module** (compiled under `--features signal`), which exposes the
+object-safe traits and their pure helpers:
+
+```rust
+use amplihack_cli::commands::signal::seams::{
+    Clock, SignalCliInvoker, LinkSession, VmLister,
+};
+```
+
+Tests construct fakes for these traits and exercise them through the exact
+`&dyn Trait` boundary the production wrappers pass in. The stable public surface
+stays exactly `run_setup` / `run_distribute`; the seam traits are the injectable
+extension point.
+
+---
+
+## VM discovery: azlin → az fallback
+
+Discovery prefers `azlin` (the Azure Linux fleet tool) and falls back to the
+generic `az vm list`. The rule is a single pure combinator so it is trivially
+testable and cannot silently swallow a total failure.
+
+```rust
+/// Non-empty azlin Ok → used as-is (fallback never runs).
+/// Empty Ok OR Err → run the `az` fallback.
+/// Both fail → Err (a total discovery failure surfaces; never an empty fleet).
+pub fn resolve_vm_list<F>(
+    azlin: anyhow::Result<Vec<String>>,
+    az_fallback: F,
+) -> anyhow::Result<Vec<String>>
+where
+    F: FnOnce() -> anyhow::Result<Vec<String>>;
+```
+
+The name extractors are pure and tolerant — malformed or non-array input yields
+an empty `Vec` (which then triggers the fallback rather than an error at the
+parse layer):
+
+```rust
+pub fn vm_names_from_azlin_json(json: &str) -> Vec<String>;
+pub fn vm_names_from_az_vm_list_json(json: &str) -> Vec<String>;
+```
+
+> **Untrusted input (R11).** VM names returned by discovery are treated as
+> **untrusted**. Before any name is used to construct a command it is
+> re-validated with `validate::validate_vm_name`. A discovered name that fails
+> validation is rejected, not sanitized-and-run.
+
+---
+
+## Fleet distribution core (`--all-vms`)
+
+`signal setup --all-vms --resource-group <rg>` and `signal distribute
+--resource-group <rg>` route through the **same** shared distribute core. The
+`--all-vms` flag is an alias that runs host onboarding first, then hands off to
+`run_distribute` with the equivalent arguments — there is one rollout
+implementation, not two.
+
+```bash
+# These are equivalent:
+amplihack signal setup --all-vms --resource-group my-rg
+amplihack signal distribute --resource-group my-rg
+```
+
+### Resumable on-disk state
+
+The rollout records per-VM progress so an interrupted run resumes instead of
+restarting. State lives in a JSON file written with owner-only `0600`
+permissions (it is secrets-adjacent) using an atomic temp-write + `fsync` +
+rename.
+
+```rust
+/// On-disk schema version. A file claiming a HIGHER version is refused
+/// (upgrade amplihack) — forward-compat is never assumed.
+pub const SCHEMA_VERSION: u32;
+
+pub enum VmStatus {
+    Pending,        // never attempted (or reset)
+    Linking,        // device linking in progress
+    Linked,         // device linked, daemon not yet confirmed
+    DaemonRunning,  // daemon up, config not yet written
+    ConfigWritten,  // fully onboarded — the single TERMINAL success state
+    Failed,         // reason recorded; retried on resume
+}
+
+pub struct DistributeState { /* version + per-VM records */ }
+
+impl DistributeState {
+    pub fn resumable_targets(&self, all: &[String]) -> Vec<String>; // non-terminal
+    pub fn succeeded_count(&self) -> usize;
+    pub fn failed_count(&self) -> usize;
+    pub fn save(&self, path: &Path) -> anyhow::Result<()>; // atomic, 0600
+    pub fn load(path: &Path) -> anyhow::Result<Self>;       // refuses newer schema
+}
+```
+
+Key rules:
+
+- **`ConfigWritten` is the only terminal-success state.** A resumed run skips
+  VMs at `ConfigWritten` and retries every other status (`Pending`, `Linking`,
+  `Linked`, `DaemonRunning`, `Failed`).
+- `--force` re-attempts VMs already at `ConfigWritten`.
+- Loading a state file whose `version` exceeds `SCHEMA_VERSION` is **refused**
+  with an explicit error — never best-effort parsed.
+
+### Per-VM isolation
+
+Each VM is onboarded independently. A failure on one VM records that VM as
+`Failed` (with a reason) and moves on; it never corrupts a sibling's record and
+never aborts the remaining rollout. State is persisted after each VM transition
+so a crash mid-fleet loses at most the in-flight VM.
+
+### PARTIAL rollouts
+
+Whenever **one or more** target VMs end `Failed`, the run finishes as a
+**PARTIAL** outcome:
+
+```text
+SignalOpError::Partial { succeeded, total, failures }  →  exit code 5
+```
+
+- `succeeded` — count of VMs that reached `ConfigWritten` this run.
+- `total` — count of VMs targeted this run.
+- `failures` — `Vec<(vm_name, reason)>` for each failed VM.
+
+Exit **5** is the distinct signal for "at least one VM failed" so automation can
+branch on it (retry the failures, alert, etc.). Any run with a non-empty
+`failures` set returns `Partial` — **including the all-failed case**, where
+`succeeded` is `0` (`run_distribute_with` returns `Partial` whenever
+`failures.is_empty()` is false). A rollout where every VM succeeds exits `0`.
+
+---
+
+## `amplihack-remote` public re-exports
+
+Idle-based device linking and fleet discovery reuse building blocks from
+`amplihack-remote`. Step 8b promotes the required helpers to the crate's public
+API (see
+[`crates/amplihack-remote/src/lib.rs`](../crates/amplihack-remote/src/lib.rs)):
+
+```rust
+// Idle-watchdog re-exported from amplihack-utils.
+pub use amplihack_utils::idle_watchdog;
+
+// Azlin fleet-listing parsers (JSON + human-readable text forms).
+pub use azlin_parse::{parse_azlin_list_json, parse_azlin_list_text};
+```
+
+### `parse_azlin_list_json` / `parse_azlin_list_text`
+
+Pure parsers over `azlin list` output. Both return `Vec<VM>` (the crate-public
+`amplihack_remote::VM`). Malformed or non-array input yields an empty `Vec` — a
+parse failure is never an error at this layer, matching the discovery
+combinator's contract.
+
+```rust
+use amplihack_remote::{parse_azlin_list_json, parse_azlin_list_text};
+
+let vms = parse_azlin_list_json(azlin_json_output); // [] on malformed input
+```
+
+### Shell / session safety
+
+Remote command construction is **fail-closed**: session identifiers are
+validated before interpolation and invalid values are **rejected** rather than
+lossy-sanitized into a different command target. The remote executor keeps the
+validator internal (`amplihack_remote` does not re-export a "quote-like"
+transform), so callers cannot mistake a destructive stripper for a safe quoter.
+
+The primary defense remains **explicit argv arrays with no `sh -c`** wherever an
+external process is spawned directly, plus validate-before-construct for the
+small remote script fragments that must be sent to `azlin connect`.
+
+### `idle_watchdog`
+
+Re-exported from `amplihack-utils` for the idle-based linking flow. Reachable as
+`amplihack_remote::idle_watchdog`.
+
+---
+
+## Security invariants
+
+The integration layer holds these invariants; each is covered by tests.
+
+| # | Invariant | Enforcement |
+| --- | --- | --- |
+| Device-link URI is secret | `sgnl://`, `tsdevice:` printed to **stderr only**, never persisted/logged | `LinkSession` returns E.164 only; state/config files audited for URI substrings |
+| Only the account persists | Written config/state contains the **E.164** account, never a URI | invariant test greps every written file |
+| No shell | External calls use explicit argv arrays where possible; remote script fragments validate inputs before interpolation | argv-only adapters; fail-closed session validation |
+| Validate before construct | VM name, resource group, account, device name, endpoint/port validated first | `validate::*` allowlists |
+| Discovery is untrusted | VM names from `azlin`/`az` re-validated before use | `validate_vm_name` on every discovered name |
+| Secrets-adjacent files are private | Config + rollout state written `0600` (atomic temp + fsync + rename) | `fsutil::write_private` |
+| Loopback-only daemon | Daemon endpoint must bind loopback; routable/wildcard refused | single `validate_loopback_endpoint` choke-point → exit 6 |
+| No forward-compat guessing | State file with a newer schema version is refused | `DistributeState::load` |
+| Failures surface | No seam degrades an error into empty/success | traits return `Result`; `resolve_vm_list` Err on total failure |
+
+---
+
+## Exit-code taxonomy
+
+`SignalOpError` maps to stable process exit codes so tooling can branch on
+outcomes:
+
+| Variant | Exit | Meaning |
+| --- | --- | --- |
+| `Usage` | `2` | Bad flags / arguments |
+| `Unsupported` | `3` | Feature disabled, or unsupported identity mode |
+| `SignalCli` | `4` | `signal-cli` missing / failed |
+| `Partial` | `5` | Fleet rollout partially succeeded (some VMs failed) |
+| `Daemon` | `6` | Daemon start / loopback-endpoint failure |
+| `Link` | `7` | Device-linking failure |
+| _(success)_ | `0` | Host onboarded, or every VM reached `ConfigWritten` |
+
+---
+
+## Configuration and environment
+
+The integration honors the same knobs as the CLI:
+
+| Setting | Source | Notes |
+| --- | --- | --- |
+| Daemon endpoint | `--endpoint` / `--port` / `AMPLIHACK_SIGNAL_ENDPOINT` | `--port` > `--endpoint` > env; default `127.0.0.1:7583`; loopback-only |
+| Device name | `--device-name` | default `amplihack-<hostname>` |
+| Resource group | `--resource-group` | required for `distribute` / `--all-vms` |
+| Explicit VM list | `--vms` (comma-separated) | bypasses `azlin`/`az` discovery |
+| Rollout concurrency | `--concurrency` | Accepted but **not honored** for interactive device-linking: each VM emits a distinct QR a human must scan, so onboarding is always sequential. A value `>1` is announced-and-ignored (never silently dropped), reserved for future non-interactive rollout phases |
+| Force | `--force` | rewrite config / retry terminal-success VMs; **never** re-links an already linked device |
+
+Discovery uses the Azure toolchain's own auth (`azlin` / `az`); no credentials
+are handled in-process.
+
+---
+
+## Testing against the boundaries
+
+Because every external effect is a seam, each boundary is testable with fakes
+and no real services. The seam-injection contract constructs fakes and drives
+them through the same `&dyn Trait` boundary production uses. Sketch:
+
+```rust
+#![cfg(feature = "signal")]
+use amplihack_cli::commands::signal::error::SignalOpError;
+use amplihack_cli::commands::signal::seams::{Clock, LinkSession, SignalCliInvoker};
+
+struct FakeSignalCli(PathBuf);
+impl SignalCliInvoker for FakeSignalCli {
+    fn detect(&self) -> Result<PathBuf, SignalOpError> { Ok(self.0.clone()) }
+}
+
+struct FakeLinkSession { account: String }
+impl LinkSession for FakeLinkSession {
+    // Returns an E.164 account and NEVER emits a device-link URI.
+    fn link(&self, _cli: &Path, _name: Option<&str>) -> Result<String, SignalOpError> {
+        Ok(self.account.clone())
+    }
+}
+
+struct FakeClock; // sleep() is a no-op → deterministic, instant poll
+impl Clock for FakeClock { fn sleep(&self, _d: Duration) {} }
+
+// Inject through the object-safe boundary and assert the contract:
+let seam: &dyn SignalCliInvoker = &FakeSignalCli("/usr/bin/signal-cli".into());
+assert_eq!(seam.detect().unwrap(), PathBuf::from("/usr/bin/signal-cli"));
+
+let link: &dyn LinkSession = &FakeLinkSession { account: "+15551234567".into() };
+let account = link.link(Path::new("/usr/bin/signal-cli"), Some("amplihack-host"))?;
+assert_eq!(account, "+15551234567"); // E.164 only — no "sgnl://" / "tsdevice:"
+```
+
+> The `run_setup_with` / `run_distribute_with` orchestrators are module-private,
+> so integration tests cannot call them directly. They validate the seam
+> **contract** (injectability, object-safety, error surfacing, no-URI); the
+> private wrappers are covered by the in-crate host/fleet paths.
+
+Contract tests that freeze this boundary:
+
+- `crates/amplihack-cli/tests/signal_seams_injection.rs` — DI of `FakeSignalCli`
+  / `FakeLinkSession` / `FakeClock` through `&dyn`; asserts a detection failure
+  surfaces `SignalCli` (exit 4) and that linking returns E.164 only (no
+  device-link URI).
+- `crates/amplihack-remote/tests/azlin_parse_public_api.rs` — parsers callable
+  as public API; malformed → empty `Vec`; valid input extracts VM names.
+
+Run the Signal suites:
+
+```bash
+# CLI-side seams + contracts (feature-gated).
+cargo test -p amplihack-cli --features signal --test 'signal_*'
+
+# Remote-side public-API contracts.
+cargo test -p amplihack-remote --test azlin_parse_public_api
+```
+
+---
+
+## See also
+
+- [Signal Onboarding](SIGNAL_ONBOARDING.md) — the `setup` / `distribute` CLI and
+  fleet workflow.
+- [Signal Channel](signal-channel.md) — runtime channel, config schema, security
+  model, per-session wiring.
+- [`examples/signal-config.toml`](../examples/signal-config.toml) — annotated
+  config the onboarding flow writes.
+- Related issues: **#921** (onboarding command), **#922** (device linking),
+  **#923** (fleet distribution), **#924** (idempotent daemon + config),
+  **#971** (external service integration), **#972** (TDD contract tests).


### PR DESCRIPTION
## Summary

Implements Step 8b Signal external service integration for #971/#972:
- Signal CLI seams/adapters for setup and fleet distribute, including public `run_setup_with` / `run_distribute_with` test seams under the `signal` feature.
- Azlin-first VM discovery with explicit fallback to `az vm list`; total discovery failure surfaces as an error.
- Resumable fleet distribute behavior and user-facing docs for external integration.
- `amplihack-remote` parser/watchdog re-exports used by Signal fleet discovery/device-linking.

Rebased/rebuilt on current `main` after #1019. The branch intentionally preserves #1019 remote hardening: adaptive transfer/provisioning backoff, exact VM lookup, and fail-closed session validation. It does **not** reintroduce the old public destructive `shell_escape` API.

## Crusty review findings and fixes

1. **Production VM discovery bypassed azlin-first seam.** `resolve_vm_list` existed and was tested, but `AzVmLister` did not exercise it in production. Fixed by wiring `AzVmLister` through azlin-first discovery with explicit `az` fallback logging; added production-path tests.
2. **R3 seam helpers were not integration-testable directly.** `run_setup_with` / `run_distribute_with` are now public under the `signal` feature and covered by integration tests with fakes.
3. **Rebase conflict risk with #1019 remote hardening.** Rebuilt the branch as one clean commit on current `main`, preserving #1019 safety/backoff modules and updating docs/tests to remove stale `shell_escape` claims.

Final self-review found no remaining substantive correctness/design findings.

## Merge-ready evidence

- Quality audit: 3 SEEK -> VALIDATE -> FIX cycles completed cleanly (crusty findings above, rebase conflict hardening preservation, final diff-scope review).
- gadugi-test / qa-team: unavailable in this environment; direct replacement outside-in scenarios were run.
- Local validation passed on head `94cdedbc`:
  - `cargo test -p amplihack-cli --features signal --test signal_azlin_lister --test signal_seams_injection`
  - `cargo test -p amplihack-remote --test azlin_parse_public_api`
  - `cargo clippy --all-targets -- -D warnings`
  - `TMPDIR=/home/azureuser/src/amplihack-rs/target/precommit-tmp pre-commit run --all-files`
  - `cargo test -p amplihack-cli --features signal`
  - `cargo test -p amplihack-remote`
- Docs updated: `docs/signal-external-integration.md`, `docs/SIGNAL_ONBOARDING.md`, `docs/signal-channel.md`.
- Final clean diff scope: 11 files, only Signal external integration CLI/tests/docs and remote parser re-export surface.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd