### PR TITLE
feat(signal): make per-session Signal groups the discoverable default; rolling reuse strictly opt-in

### DIFF
--- a/crates/amplihack-cli/src/commands/signal/config_writer.rs
+++ b/crates/amplihack-cli/src/commands/signal/config_writer.rs
@@ -17,6 +17,13 @@
 /// own allowlist (the single-number linked-device rule). Values are TOML
 /// basic-string escaped defensively; callers should still validate inputs via
 /// [`super::validate`] before writing.
+///
+/// Per-session isolation is the default: the generator explicitly emits
+/// `reuse_rolling_group = false` so each amplihack session creates its own
+/// fresh Signal group (`amplihack-<session-id>-<ts>`). Reusing a single shared
+/// rolling group is strictly opt-in — set `reuse_rolling_group = true` and
+/// provide a `rolling_group_id`. The generator never pre-writes
+/// `rolling_group_id`; the operator adds it only when opting in.
 pub fn to_toml(endpoint: &str, account: &str) -> String {
     format!(
         "# amplihack Signal channel configuration.\n\
@@ -28,7 +35,13 @@ pub fn to_toml(endpoint: &str, account: &str) -> String {
          # own synced messages and must be accepted.\n\
          endpoint = \"{endpoint}\"\n\
          account = \"{account}\"\n\
-         allowlist = [\"{account}\"]\n",
+         allowlist = [\"{account}\"]\n\
+         \n\
+         # Per-session groups are the default: each session creates its own\n\
+         # fresh Signal group so messages are never disclosed across sessions.\n\
+         # To reuse a single shared \"rolling\" group instead, set this to true\n\
+         # AND add a rolling-group-id line below (opt-in only).\n\
+         reuse_rolling_group = false\n",
         endpoint = escape_basic(endpoint),
         account = escape_basic(account),
     )
@@ -38,4 +51,57 @@ pub fn to_toml(endpoint: &str, account: &str) -> String {
 /// only — inputs are otherwise constrained to E.164 / `host:port` shapes.
 fn escape_basic(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use amplihack_signal::config::SignalConfig;
+    use std::collections::HashMap;
+
+    const ENDPOINT: &str = "127.0.0.1:7583";
+    const ACCOUNT: &str = "+15551230000";
+
+    /// The generated config must make per-session isolation the discoverable,
+    /// documented default by explicitly emitting `reuse_rolling_group = false`.
+    #[test]
+    fn generated_config_emits_reuse_rolling_group_false() {
+        let out = to_toml(ENDPOINT, ACCOUNT);
+        assert!(
+            out.contains("reuse_rolling_group = false"),
+            "generated config must explicitly pin per-session default, got:\n{out}"
+        );
+    }
+
+    /// `rolling_group_id` is strictly opt-in — the generator must never
+    /// pre-write it (a value there would bind the config to a shared group).
+    #[test]
+    fn generated_config_omits_rolling_group_id() {
+        let out = to_toml(ENDPOINT, ACCOUNT);
+        assert!(
+            !out.contains("rolling_group_id"),
+            "generator must NOT pre-write rolling_group_id (opt-in only), got:\n{out}"
+        );
+    }
+
+    /// The generated TOML must round-trip through the REAL per-session channel
+    /// resolver to `reuse_rolling_group == false` and `rolling_group_id == None`
+    /// with an empty environment — proving onboarding output yields per-session
+    /// isolation by default without divergence from the loader.
+    #[test]
+    fn generated_config_round_trips_to_per_session_default() {
+        let out = to_toml(ENDPOINT, ACCOUNT);
+        let cfg = SignalConfig::from_sources(&HashMap::new(), Some(&out))
+            .expect("generated TOML must resolve through the real loader");
+        assert_eq!(cfg.endpoint, ENDPOINT);
+        assert_eq!(cfg.account, ACCOUNT);
+        assert!(
+            !cfg.reuse_rolling_group,
+            "generated config must resolve to per-session (reuse=false)"
+        );
+        assert_eq!(
+            cfg.rolling_group_id, None,
+            "generated config must not bind a rolling group id"
+        );
+    }
 }

--- a/crates/amplihack-signal/src/config.rs
+++ b/crates/amplihack-signal/src/config.rs
@@ -479,6 +479,64 @@ mod tests {
     }
 
     #[test]
+    fn reuse_rolling_group_falsy_env_values_are_per_session() {
+        // Fail-closed: any non-truthy env token (including explicit "false",
+        // "0", and empty) must resolve to per-session isolation, never shared.
+        for v in ["0", "false", "no", "off", "", "  "] {
+            let e = env(&[
+                (ENV_ENDPOINT, "127.0.0.1:7583"),
+                (ENV_ACCOUNT, "+15551230000"),
+                (ENV_ALLOWLIST, "+15551230001"),
+                (ENV_REUSE_ROLLING_GROUP, v),
+            ]);
+            let cfg = SignalConfig::from_sources(&e, None).unwrap();
+            assert!(
+                !cfg.reuse_rolling_group,
+                "value {v:?} must resolve to per-session (reuse=false)"
+            );
+        }
+    }
+
+    #[test]
+    fn absent_reuse_setting_defaults_to_per_session() {
+        // With neither env nor TOML specifying the flag, the default MUST be
+        // per-session (reuse=false) with no bound rolling group id.
+        let e = env(&[
+            (ENV_ENDPOINT, "127.0.0.1:7583"),
+            (ENV_ACCOUNT, "+15551230000"),
+            (ENV_ALLOWLIST, "+15551230001"),
+        ]);
+        let cfg = SignalConfig::from_sources(&e, None).unwrap();
+        assert!(!cfg.reuse_rolling_group);
+        assert_eq!(cfg.rolling_group_id, None);
+
+        // Same via a TOML file that omits the key entirely.
+        let toml = r#"
+            endpoint = "127.0.0.1:7583"
+            account  = "+15551230000"
+            allowlist = ["+15551230001"]
+        "#;
+        let cfg = SignalConfig::from_sources(&HashMap::new(), Some(toml)).unwrap();
+        assert!(!cfg.reuse_rolling_group);
+        assert_eq!(cfg.rolling_group_id, None);
+    }
+
+    #[test]
+    fn reuse_rolling_group_opt_in_via_toml() {
+        // Opt-in path: explicit reuse=true + a bound group id in TOML is honored.
+        let toml = r#"
+            endpoint = "127.0.0.1:7583"
+            account  = "+15551230000"
+            allowlist = ["+15551230001"]
+            reuse_rolling_group = true
+            rolling_group_id = "grp-shared=="
+        "#;
+        let cfg = SignalConfig::from_sources(&HashMap::new(), Some(toml)).unwrap();
+        assert!(cfg.reuse_rolling_group);
+        assert_eq!(cfg.rolling_group_id.as_deref(), Some("grp-shared=="));
+    }
+
+    #[test]
     fn malformed_toml_is_error() {
         let err = SignalConfig::from_sources(&HashMap::new(), Some("this = = broken")).unwrap_err();
         assert!(matches!(err, ConfigError::Toml(_)));

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -45,6 +45,9 @@ All environment variables read or written by `amplihack` during a launch (`ampli
   - [AMPLIHACK_TEST_FAKE_LATEST_VERSION](#amplihack_test_fake_latest_version)
   - [CI](#ci)
   - [UV_TOOL_BIN_DIR](#uv_tool_bin_dir)
+- [Signal channel variables](#signal-channel-variables)
+  - [AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP](#amplihack_signal_reuse_rolling_group)
+  - [AMPLIHACK_SIGNAL_ROLLING_GROUP_ID](#amplihack_signal_rolling_group_id)
 
 ---
 
@@ -1132,12 +1135,59 @@ Override the directory where `uv tool install` places the `amplifier` binary. De
 
 ---
 
+## Signal channel variables
+
+These variables control the optional Signal channel (feature `signal`). They are
+read only when the channel is active and, unlike the launcher variables above,
+are documented authoritatively — with their TOML equivalents — in the
+[Signal channel reference](../signal-channel.md#settings). The two variables
+below govern **group strategy**. The channel's default is **per-session
+groups**: every amplihack session creates its own fresh Signal group
+(`amplihack-<session-id>-<unix-ts>`) and leaves it at Stop, so no session can see
+another session's messages. Reusing a single shared "rolling" group is strictly
+**opt-in**.
+
+---
+
+### AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP
+
+**Type:** boolean (truthy: `1`, `true`, `yes`, `on`)
+**TOML key:** `reuse_rolling_group`
+**Default:** `false` (per-session groups)
+**Read by:** `amplihack_signal::config::SignalConfig`
+
+Opt-in switch for sharing one long-lived group across every session. When truthy,
+amplihack reuses a single "rolling" group and does **not** quit it at Stop,
+giving one persistent operator thread. When unset, empty, or any non-truthy
+value, the channel resolves **fail-closed to the per-session default** — never to
+shared visibility. Pair it with `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` to bind to an
+existing group. Like every Signal setting, the environment variable overrides the
+TOML key of the same name.
+
+---
+
+### AMPLIHACK_SIGNAL_ROLLING_GROUP_ID
+
+**Type:** string (signal-cli group id)
+**TOML key:** `rolling_group_id`
+**Default:** unset
+**Read by:** `amplihack_signal::config::SignalConfig`
+
+Binds rolling reuse to an **existing** group id instead of creating a new one on
+first use. Only consulted when `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` is truthy;
+it is ignored while the per-session default is in effect. Setting this alone does
+**not** enable sharing — both the opt-in flag and this id are required for a
+shared rolling group.
+
+---
+
 ## Related
 
 - [Agent Binary Routing](../concepts/agent-binary-routing.md) — Why `AMPLIHACK_AGENT_BINARY` exists and how recipe runner uses it
 - [Run amplihack in Non-interactive Mode](../howto/run-in-noninteractive-mode.md) — CI and pipe usage guide
 - [Bootstrap Parity](../concepts/bootstrap-parity.md) — How the Rust CLI matches the Python launcher's environment contract
 - [Memory Backend Reference](./memory-backend.md) — `AMPLIHACK_MEMORY_BACKEND` values, storage paths, schema, and security
+- [Signal Channel](../signal-channel.md) — Full reference for the Signal channel, including the per-session-default group strategy and the opt-in rolling-group variables
 - [Recipe Runner Logging](./recipe-runner-logging.md) — Progress, heartbeat, snippet, and JSONL configuration
 - [amplihack install](./install-command.md) — Variables read during installation
 - [Startup Self-Update Prompt — Subprocess-Safe Skip](../features/startup-update-prompt-subprocess-safe.md) — How `CI`, `AMPLIHACK_AGENT_BINARY`, `AMPLIHACK_NONINTERACTIVE`, `--subprocess-safe`, and non-TTY stdin each suppress the `Update now? [y/N] (5s timeout):` prompt

--- a/docs/signal-channel.md
+++ b/docs/signal-channel.md
@@ -395,7 +395,7 @@ the channel stays off; there are **no other silent defaults**.
 | Account | `AMPLIHACK_SIGNAL_ACCOUNT` | `account` | ✅ | E.164 (`+` then digits) — the number amplihack sends **as** |
 | Allowlist | `AMPLIHACK_SIGNAL_ALLOWLIST` | `allowlist` | ✅ | Operator numbers allowed to send inbound. Env = comma-separated E.164. **Empty ⇒ fail-closed (deny all inbound).** |
 | Own device id | `AMPLIHACK_SIGNAL_OWN_DEVICE_ID` | `own_device_id` | optional | signal-cli's **own** linked-device id (must be `>= 2`). Only used to reject the bot's own synced-back echoes explicitly; the primary-phone (device `1`) gate is the main loop guard and needs no configuration. Leave unset unless you know your signal-cli device id |
-| Reuse rolling group | `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` | `reuse_rolling_group` | optional | **Default `false` (per-session groups).** Opt-in only: `true`/`1` reuses one long-lived shared group across every session instead of creating a fresh per-session group. Any absent, empty, or non-truthy value resolves fail-closed to per-session isolation |
+| Reuse rolling group | `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` | `reuse_rolling_group` | optional | **Default `false` (per-session groups).** Opt-in only: a truthy value (`1`/`true`/`yes`/`on`, case-insensitive) reuses one long-lived shared group across every session instead of creating a fresh per-session group. Any absent, empty, or non-truthy value resolves fail-closed to per-session isolation |
 | Rolling group id | `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` | `rolling_group_id` | optional | Existing group id to bind to when — and only when — rolling reuse is opted into. Ignored while the per-session default is in effect |
 | Config file path | `AMPLIHACK_SIGNAL_CONFIG` | — | optional | Explicit path to the TOML file below. When unset, the loader falls back to the onboarding default `~/.amplihack/signal-config.toml` |
 
@@ -582,6 +582,13 @@ Concretely:
   network sockets.
 - **No silent config defaults.** Missing required config is an explicit error,
   never a guessed value.
+- **Per-session group isolation by default.** `reuse_rolling_group` defaults to
+  `false`, so each session gets its own group that is closed with `quitGroup`
+  at Stop — no operator thread outlives the session that created it. Sharing one
+  long-lived group across sessions is a deliberate opt-in
+  (`reuse_rolling_group = true` / `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`);
+  only non-empty truthy values enable it, so a malformed or empty setting stays
+  fail-closed on the isolated per-session default.
 - **Path safety.** Every per-session file path is run through
   `sanitize_session_id`; inbox/PID files are written atomically with
   restrictive permissions.

--- a/docs/signal-channel.md
+++ b/docs/signal-channel.md
@@ -165,12 +165,21 @@ amplihack signal setup
    requires.
 4. **Writes the config.** It writes `~/.amplihack/signal-config.toml` (mode
    `0600`) using the **exact existing [`SignalConfig`](#configuration) schema**,
-   with `endpoint`, `account`, and `allowlist = [account]`. See
+   with `endpoint`, `account`, and `allowlist = [account]`. It also emits an
+   explicit `reuse_rolling_group = false` line (with a short opt-in caveat
+   comment) so the **per-session default is discoverable in the file itself**:
+   each session gets its own fresh group and the file documents that reusing a
+   single shared group is an explicit opt-in. The generator writes **only** that
+   `reuse_rolling_group = false` line — it never pre-writes a `rolling_group_id`;
+   you add that yourself only when opting in (set `reuse_rolling_group = true`
+   together with a `rolling_group_id`). See
    [the single-number rule](#configuration) for why the account's own number is
-   allowlisted. Environment variables and an explicit `AMPLIHACK_SIGNAL_CONFIG`
-   still override this file; onboarding relies on the loader's default-path
-   fallback to `~/.amplihack/signal-config.toml` (see
-   [Configuration](#configuration) and [Per-session wiring](#per-session-wiring)).
+   allowlisted, and [Group naming and lifecycle](#group-naming-and-lifecycle)
+   for the per-session-vs-rolling behavior. Environment variables and an
+   explicit `AMPLIHACK_SIGNAL_CONFIG` still override this file; onboarding relies
+   on the loader's default-path fallback to `~/.amplihack/signal-config.toml`
+   (see [Configuration](#configuration) and
+   [Per-session wiring](#per-session-wiring)).
 
 That is the whole onboarding. The next amplihack session on this host will pick
 up the config automatically — no further steps (see
@@ -386,8 +395,8 @@ the channel stays off; there are **no other silent defaults**.
 | Account | `AMPLIHACK_SIGNAL_ACCOUNT` | `account` | ✅ | E.164 (`+` then digits) — the number amplihack sends **as** |
 | Allowlist | `AMPLIHACK_SIGNAL_ALLOWLIST` | `allowlist` | ✅ | Operator numbers allowed to send inbound. Env = comma-separated E.164. **Empty ⇒ fail-closed (deny all inbound).** |
 | Own device id | `AMPLIHACK_SIGNAL_OWN_DEVICE_ID` | `own_device_id` | optional | signal-cli's **own** linked-device id (must be `>= 2`). Only used to reject the bot's own synced-back echoes explicitly; the primary-phone (device `1`) gate is the main loop guard and needs no configuration. Leave unset unless you know your signal-cli device id |
-| Reuse rolling group | `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` | `reuse_rolling_group` | optional | `true`/`1` reuses one long-lived group instead of per-session groups |
-| Rolling group id | `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` | `rolling_group_id` | optional | Existing group id to reuse when rolling mode is on |
+| Reuse rolling group | `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` | `reuse_rolling_group` | optional | **Default `false` (per-session groups).** Opt-in only: `true`/`1` reuses one long-lived shared group across every session instead of creating a fresh per-session group. Any absent, empty, or non-truthy value resolves fail-closed to per-session isolation |
+| Rolling group id | `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` | `rolling_group_id` | optional | Existing group id to bind to when — and only when — rolling reuse is opted into. Ignored while the per-session default is in effect |
 | Config file path | `AMPLIHACK_SIGNAL_CONFIG` | — | optional | Explicit path to the TOML file below. When unset, the loader falls back to the onboarding default `~/.amplihack/signal-config.toml` |
 
 > **Fail-closed allowlist.** An **empty** allowlist is a valid, deliberate
@@ -416,8 +425,12 @@ endpoint = "127.0.0.1:7583"
 account  = "+15551230000"
 allowlist = ["+15551230001", "+15551230002"]
 # own_device_id = 2
-# reuse_rolling_group = false
-# rolling_group_id = "group.aBcDeF0123456789=="
+# Per-session groups are the default. `amplihack signal setup` writes exactly
+# this line (and nothing about `rolling_group_id`) so the isolation guarantee is
+# visible in the generated file. Flip it to `true` AND uncomment/set
+# `rolling_group_id` below to opt into one shared rolling group.
+reuse_rolling_group = false
+# rolling_group_id = "group.aBcDeF0123456789=="  # only used when reuse_rolling_group = true
 ```
 
 Any value present in the environment overrides the same key in the file.
@@ -435,11 +448,14 @@ amplihack-<session-id>-<unix-timestamp>
 The `groupId` returned by signal-cli is persisted in session state. On Stop the
 group is closed with `quitGroup`.
 
-**Rolling group (opt-in).** Set `reuse_rolling_group = true` (or
-`AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`) to reuse a **single** long-lived
-group across all sessions. In this mode the group is **not** quit at Stop, so
-you keep one persistent operator thread. Supply `rolling_group_id` to bind to
-an existing group instead of creating a new one on first use.
+**Rolling group (opt-in).** Per-session groups are the default; nothing needs
+to be set to get them. To instead reuse a **single** long-lived group across all
+sessions, explicitly opt in by setting `reuse_rolling_group = true` (or
+`AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`). In this mode the group is **not** quit
+at Stop, so you keep one persistent operator thread. Supply `rolling_group_id`
+to bind to an existing group instead of creating a new one on first use. Because
+this trades per-session isolation for a shared thread, it must be requested
+deliberately — any absent or non-truthy value keeps the per-session default.
 
 | Phase | Per-session | Rolling |
 |---|---|---|
@@ -626,8 +642,8 @@ assert!(cfg.allowlist.iter().all(|n| n.starts_with('+')));
 | `account` | `String` | E.164 sending account |
 | `allowlist` | `Vec<String>` | Permitted E.164 senders (empty ⇒ deny all inbound) |
 | `own_device_id` | `Option<u32>` | signal-cli's own linked-device id (`>= 2`) for explicit echo rejection |
-| `reuse_rolling_group` | `bool` | Use one rolling group |
-| `rolling_group_id` | `Option<String>` | Bind rolling mode to an existing group |
+| `reuse_rolling_group` | `bool` | Opt-in: reuse one shared rolling group. Defaults to `false` (per-session groups) |
+| `rolling_group_id` | `Option<String>` | Existing group id to bind rolling reuse to (only consulted when `reuse_rolling_group` is `true`) |
 
 ### `transport`
 
@@ -752,9 +768,12 @@ No. Inbound text is delivered only as `additionalContext`. The agent decides
 whether to act, and all normal safety hooks still apply.
 
 **Per-session vs rolling group — which should I use?**
-Per-session (default) gives clean isolation and auto-cleanup via `quitGroup`.
-Rolling keeps one persistent operator thread across runs; set
-`reuse_rolling_group = true`.
+Per-session is the **default** and needs no configuration: each session creates
+its own fresh group and cleans it up at Stop via `quitGroup`, giving clean
+isolation and no cross-session message disclosure. Rolling is a deliberate
+opt-in that keeps one persistent operator thread across runs; enable it by
+setting `reuse_rolling_group = true` (optionally with a `rolling_group_id`).
+Prefer the per-session default unless you specifically want one shared thread.
 
 **Where do inbound instructions get stored?**
 In a per-session, atomically-written JSON inbox whose path is derived through

--- a/examples/signal-config.toml
+++ b/examples/signal-config.toml
@@ -59,17 +59,24 @@ allowlist = [
 # ---------------------------------------------------------------------------
 # Group strategy (optional).
 #
-# By default amplihack creates ONE group PER session, named
-# "amplihack-<session-id>-<unix-ts>", and calls quitGroup at Stop.
+# DEFAULT: amplihack creates ONE group PER session, named
+# "amplihack-<session-id>-<unix-ts>", and calls quitGroup at Stop. This is the
+# confidentiality default — no session can see another session's messages.
+# `amplihack signal setup` writes `reuse_rolling_group = false` explicitly so
+# this guarantee is visible in the generated file. The generator emits only that
+# line — it leaves `rolling_group_id` unset (you add it yourself when opting in).
 #
-# Set `reuse_rolling_group = true` to instead reuse a single long-lived
-# "rolling" group across every session (it is NOT quit at Stop). Useful when
-# you want one persistent operator thread instead of a fresh group each run.
+# OPT-IN: set `reuse_rolling_group = true` to instead reuse a single long-lived
+# "rolling" group across every session (it is NOT quit at Stop). Useful when you
+# want one persistent operator thread instead of a fresh group each run. Any
+# absent, empty, or non-truthy value keeps the per-session default (fail-closed
+# to isolation).
 # ENV override: AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1
 # ---------------------------------------------------------------------------
-# reuse_rolling_group = false
+reuse_rolling_group = false
 
-# When `reuse_rolling_group = true`, an existing group id may be supplied so
-# amplihack posts into it instead of creating a new one on first use.
+# Only used when `reuse_rolling_group = true`: an existing group id to bind to so
+# amplihack posts into it instead of creating a new one on first use. Ignored
+# while the per-session default is in effect.
 # ENV override: AMPLIHACK_SIGNAL_ROLLING_GROUP_ID
 # rolling_group_id = "group.aBcDeF0123456789=="


### PR DESCRIPTION
## Summary

Makes **per-session Signal groups the default** everywhere the code/config/docs express a default, and keeps rolling-group reuse **strictly opt-in**. Closes #994.

The runtime already resolved `reuse_rolling_group` fail-closed to `false` (`config.rs`) and `imp.rs` already creates a fresh `amplihack-<session-id>-<ts>` group per session and quits it at Stop. The real gap was that the **generated onboarding config** and parts of the **docs** did not make per-session isolation explicit/discoverable. This PR closes that gap — code + docs + tests only.

## Changes

- **`config_writer::to_toml`** (only functional change): now emits an explicit `reuse_rolling_group = false` line with a short opt-in caveat comment. It never pre-writes `rolling_group_id` (opt-in only).
- **`docs/signal-channel.md`**: sharpen settings-table rows, group-lifecycle prose, example TOML, API table, and FAQ to frame per-session as the confidentiality default and rolling reuse as deliberate opt-in.
- **`docs/reference/environment-variables.md`**: document `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` and `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` as opt-in sharing knobs (default `false`, fail-closed).
- **`examples/signal-config.toml`**: mirror the generator — explicit `reuse_rolling_group = false`, `rolling_group_id` left unset.
- **Tests** (all `--features signal`):
  - `config.rs`: absent setting ⇒ per-session (reuse=false, id=None); falsy/empty env tokens ⇒ per-session (fail-closed); opt-in via TOML honored. Existing truthy-env opt-in test retained.
  - `config_writer.rs`: generator emits `reuse_rolling_group = false`, omits `rolling_group_id`, and round-trips through the real `SignalConfig::from_sources` to reuse=false/id=None.

**No functional change to `imp.rs`** — per-session creation and Stop cleanup verified by review/tests.

## Verification

- `cargo test -p amplihack-signal -p amplihack-cli --features signal` — green (the one `issue_538_install_completeness` failure is environmental: it requires a built `target/debug/amplihack`; it fails identically on unmodified HEAD and passes once the binary is built).
- `cargo fmt --check` and `cargo clippy -- -D warnings` — clean on touched crates (pre-existing unrelated clippy warning in `issue_899_merge_validations_abstention` untouched).
- Pre-commit hooks passed without `--no-verify`.

## Out of scope

Runtime-deployed config files on fleet hosts (operational, handled separately).

---

## Merge-ready evidence (autonomous post-merge run, 2026-07-25)

- **Crusty-old-engineer review:** found one substantive design/correctness issue in the PR surface: rolling mode could be enabled without a pinned `rolling_group_id`, causing a fresh group to be created and then not quit at Stop. Fixed locally/branch-side by requiring `rolling_group_id` when `reuse_rolling_group=true` and aligning docs/examples. Additional quality-audit findings fixed locally/branch-side: strict malformed TOML allowlist/device-id handling, explicit logging/errors for Signal state/inbox read failures, stricter endpoint validation, strict unknown rolling-group env tokens, and unreadable config-source tests. **Blocker:** PR #995 was already merged by `rysweet` at `e82866a87effde5c1fd275f7a7ff95797c7f1e0f` before these post-review commits could become part of the merged PR.
- **QA-team / outside-in:** qa-team skill says Rust CLI repos substitute native `cargo test` for `gadugi-test`; `gadugi-test` was also unavailable (`npx gadugi-test` returned npm 404). Native outside-in/user-facing validation run: `cargo test -p amplihack-signal --features signal`, `cargo test -p amplihack-cli --features signal`, and `cargo clippy --all-targets -- -D warnings` passed after building `target/debug/amplihack` for the install-completeness tests.
- **Quality-audit:** quality-audit-cycle was invoked with 3-cycle intent. The recipe repeatedly failed at recursive cycle timeout (`exit 124`) before a formal clean final summary, but completed seek/validate cycles found real issues that were fixed locally/branch-side. Supplemental validation commands above passed. Blocker recorded: quality-audit recipe timeout prevented formal clean-cycle certification.
- **Docs:** `docs/signal-channel.md`, `docs/reference/environment-variables.md`, and `examples/signal-config.toml` were reviewed/updated for per-session default and rolling opt-in semantics.
- **Scope:** original merged PR scope was 5 files: `config_writer.rs`, `config.rs`, env-var docs, Signal docs, example TOML. Post-review local fixes also touched tightly coupled Signal config tests and hook error handling; no unrelated product area was intentionally changed.
- **Checks/merge:** merge commit `e82866a87effde5c1fd275f7a7ff95797c7f1e0f` has required checks green via REST: Lint & Format, Test, Install Smoke Test, and Build x86_64/aarch64 Linux/macOS all `completed/success`. PR state is `closed`, `merged=true`.
