### PR TITLE
feat(skills): add signal-setup skill for end-to-end Signal linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplihack"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-core"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-memory",
  "amplihack-utils",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-eval"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "serde",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-generator"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "serde",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-asset-resolver-bin"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-cli",
  "tracing",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-blarify"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-builders"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-builders",
  "amplihack-hive",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-context"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-delegation"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "globset",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-domain-agents"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-fleet"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hive"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-cli",
  "amplihack-security",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-launcher"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-types",
  "amplihack-utils",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-memory"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-multilspy"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-orchestration"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-utils",
  "async-trait",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recovery"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-reflection"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-remote"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-utils",
  "anyhow",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-safety"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-security"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "once_cell",
  "regex",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-session"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "filetime",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-signal"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-state",
  "amplihack-types",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-utils"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "base64",
  "chrono",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-workflows"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "amplihack-utils",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/amplifier-bundle/skills/signal-setup/README.md
+++ b/amplifier-bundle/skills/signal-setup/README.md
@@ -1,0 +1,49 @@
+# Signal Setup Skill
+
+Link a host — local machine or a remote **azlin** Azure VM — to **Signal** as a
+linked device, END-TO-END, and wire it into amplihack's Signal channel. The
+whole manual device-linking loop becomes one idempotent command.
+
+See [`SKILL.md`](./SKILL.md) for the full flow and the critical facts. The
+executable lives at [`scripts/signal-setup.sh`](./scripts/signal-setup.sh).
+
+## Quick start
+
+```bash
+# Link the local host
+scripts/signal-setup.sh --host "$(hostname -s)"
+
+# Link a remote azlin VM (auto-detected; links via `az vm run-command`)
+scripts/signal-setup.sh --host deva2
+
+# Skip the interactive prompt (scan screen already open)
+scripts/signal-setup.sh --host dev -y
+
+# Link only, skip the daemon + self-group + post-test phase
+scripts/signal-setup.sh --host dev --no-daemon
+```
+
+## What it does
+
+1. **Prereqs** — `signal-cli` (0.14.5, `~/.local/bin/signal-cli`), `qrencode`,
+   and `az` (remote hosts only).
+2. **Prompt** to open Signal → Linked Devices → Link New Device.
+3. **Mint** the link under `systemd-run` (local, or remote via
+   `az vm run-command` + `systemd-run --uid=azureuser`).
+4. **Render** the QR in-terminal with `qrencode -t ANSIUTF8i` (zero latency,
+   dark-terminal-safe).
+5. **Verify** linkage via `signal-cli listAccounts`.
+6. **Channel** (optional) — start the JSON-RPC daemon on `127.0.0.1:7583`,
+   ensure a self-only group, and post-test.
+
+## The three facts that make it work
+
+- **60-second window**: Signal's provisioning socket closes (code 1001) 60s
+  after the QR is minted. Be on the scan screen first; scan immediately.
+- **`ANSIUTF8i`** (inverted): required so the QR is visible/scannable on dark
+  terminals. Never deliver the QR through Signal itself.
+- **`systemd-run`**: keeps the link process alive the full window; remote runs
+  need `--uid=azureuser` because `az vm run-command` runs as root.
+
+Idempotent: re-running an already-linked host skips linking and just (re)ensures
+the daemon/group.

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: signal-setup
+version: 1.0.0
+description: |
+  Link a host (local or a remote azlin Azure VM) to Signal as a linked device
+  END-TO-END and wire it into amplihack's Signal channel — the entire manual
+  device-linking loop collapsed into one idempotent command. Encodes the
+  hard-won facts about Signal's 60-second provisioning window, dark-terminal-safe
+  in-terminal QR rendering, systemd-run link persistence, and the remote
+  az-run-command path. Use when onboarding a machine to Signal notifications.
+auto_activates:
+  - "Set up Signal"
+  - "Link Signal device"
+  - "Link a host to Signal"
+  - "Onboard host to Signal"
+  - "Signal setup for a VM"
+  - "Configure Signal notifications for a host"
+priority_score: 34.0
+---
+
+# signal-setup
+
+Links a host to **Signal** as a linked device and wires it into amplihack's
+Signal channel in one idempotent invocation. Works for the **local** host or a
+**remote azlin Azure VM**.
+
+## When to use
+
+- Onboarding a new machine (local or an azlin VM) so amplihack can post to
+  Signal.
+- Re-establishing a Signal link after a device was removed.
+- You previously did the manual device-linking dance by hand and want it
+  reduced to a single command.
+
+## Invoke
+
+```bash
+# Local host
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh --host "$(hostname -s)"
+
+# Remote azlin VM (auto-detected as remote; links via az vm run-command)
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh --host deva2
+
+# Non-interactive (you confirm the scan screen is already open)
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh --host dev -y
+```
+
+Key options: `--remote/--local` (force the path), `--group <name>` (default
+`amplihack`), `--endpoint 127.0.0.1:7583`, `--resource-group <rg>`,
+`--no-daemon`, `--skip-prereqs`, `-y/--yes`. Run with `--help` for all flags.
+
+## End-to-end flow
+
+1. **Prereqs** — verify/install `signal-cli` (0.14.5 known-good, expected at
+   `~/.local/bin/signal-cli`), `qrencode`, and (for remote hosts) the `az` CLI.
+2. **Idempotency** — if the host already shows a `Number: +…` in
+   `signal-cli listAccounts`, the link step is **skipped**.
+3. **Prompt** — tell the user to open
+   **Signal → Settings → Linked Devices → "Link New Device"** and wait for
+   confirmation that the scan screen is open (skipped with `-y`).
+4. **Mint** — start `signal-cli link -n amplihack-<host>` under `systemd-run`
+   (transient unit `sig-link-<host>`) so the process survives the shell and
+   stays connected the full window. Remote hosts mint via
+   `az vm run-command … RunShellScript` calling `systemd-run --uid=azureuser …`.
+5. **Render** — capture the `sgnl://…` URI and render it **directly in this
+   terminal** with `qrencode -t ANSIUTF8i` (zero delivery latency).
+6. **Verify** — poll `signal-cli listAccounts` for `Number: +<phone>`; the
+   transient unit exits (inactive) on success; the trace log shows
+   `Associated with: +<phone>` → `Finishing new device registration`.
+7. **Channel** (optional, `--no-daemon` to skip) — start the JSON-RPC daemon
+   (`signal-cli -a +<phone> daemon --tcp 127.0.0.1:7583`), ensure a self-only
+   group via `updateGroup{name}` → `groupId`, and post-test with
+   `send{groupId,message}`. An empty `{"results":[],"timestamp":…}` is the
+   **expected success** for a self-group. For remote hosts this phase hands off
+   to `amplihack signal setup` on the VM.
+
+## ⚠ Critical facts (do NOT lose these)
+
+### 1. The 60-second window (root cause of hours of failure)
+Signal's device-link provisioning websocket to `chat.signal.org` closes with
+**server code 1001 EXACTLY 60 seconds after it opens** (verified in
+`signal-cli -vv` trace: `onOpen → onClosing(1001)` at +60s). A link QR is valid
+for only **~60s from mint**. Any delivery path slower than a few seconds expires
+it and the phone shows *"invalid response from server"*. Routing the QR through
+a remote Signal daemon (azlin/bastion round-trip = 40–60s) is exactly what
+caused the failures. **Get to the scan screen first; scan the instant the QR
+prints.**
+
+### 2. ANSIUTF8i — required for dark terminals
+Render with `qrencode -t ANSIUTF8i`. The trailing **`i` (inverted) is
+required**: plain `ANSIUTF8` is dark-on-dark and **invisible/unscannable** on
+dark terminal backgrounds.
+
+### 3. Never route the QR through Signal
+**NEVER** deliver the link QR as a Signal message/attachment during linking —
+that is the deprecated slow path (relay/daemon delivery) that blows the 60s
+window. Always render in-terminal, locally.
+
+### 4. systemd-run persistence
+The link process runs under `systemd-run` (unit `sig-link-<host>`) so it
+survives the launching shell and stays connected the full window. For **remote**
+hosts, `az vm run-command` runs as **root**, so `systemd-run` must pass
+`--uid=azureuser --gid=azureuser --setenv=HOME=/home/azureuser` so the account
+lands under `azureuser`, not root.
+
+## Operational gotchas (documented, avoided by the script)
+
+- **azlin SIGPIPE core-dump** — azlin is a Rust binary that ABORTS
+  (SIGABRT/core-dump) on a broken pipe. **Never** pipe azlin into `grep -q`,
+  `head`, or any early-closing consumer — capture full output first, then
+  filter. The script always uses command substitution before grepping.
+- **One bastion session per host** — concurrent azlin/bastion sessions to the
+  same VM core-dump. Run one host at a time.
+- **azlin form** —
+  `azlin connect <host> --resource-group rysweet-linux-vm-pool --no-tmux -y -- "<cmd>"`.
+
+## Verifying / troubleshooting
+
+- `signal-cli listAccounts` → shows `Number: +<phone>` when linked.
+- Transient unit: `systemctl is-active sig-link-<host>` → `inactive` on success.
+- Trace log: `/tmp/scli-<host>.log` (search for `Associated with:`).
+- Link URI capture: `/tmp/slink-<host>.out`.
+- If linkage times out, the 60s window almost certainly expired — re-run and
+  scan faster.
+
+## Integration with amplihack's Signal channel
+
+The daemon endpoint (`127.0.0.1:7583`), device-name convention
+(`amplihack-<host>`), and self-group model match the existing
+`amplihack signal setup` command (crate `amplihack-signal`,
+`crates/amplihack-cli/src/commands/signal/`). Remote onboarding defers the
+daemon+config write to `amplihack signal setup` on the VM.

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+#
+# signal-setup.sh — link a host as a Signal linked device END-TO-END and wire it
+# into amplihack's Signal channel, collapsing the whole manual device-linking
+# loop into a single idempotent command.
+#
+# Supported hosts:
+#   --host <name>       local host name  (linked LOCALLY via systemd-run)
+#   --host <azlin-vm>   remote Azure VM  (linked via `az vm run-command` +
+#                       systemd-run on the VM, QR relayed back and rendered
+#                       LOCALLY in this terminal)
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# HARD-WON FACTS THIS SCRIPT ENCODES (do not "optimise" any of these away):
+#
+#  1. THE 60-SECOND WINDOW  (critical root cause)
+#     Signal's device-link provisioning websocket to chat.signal.org closes
+#     with server code 1001 EXACTLY 60s after it opens (verified in
+#     `signal-cli -vv` trace: onOpen → onClosing(1001) at +60s). A link QR is
+#     therefore valid for only ~60s from mint. Any delivery path slower than a
+#     few seconds expires it and the phone shows "invalid response from
+#     server". Routing the QR through a remote Signal daemon (azlin/bastion
+#     round-trip = 40-60s) is what caused hours of failures. We mint and render
+#     with essentially zero delivery latency instead.
+#
+#  2. ZERO-LATENCY, DARK-TERMINAL-SAFE QR DELIVERY
+#     Render the QR DIRECTLY in this terminal with `qrencode -t ANSIUTF8i`.
+#     The trailing "i" = INVERTED and is REQUIRED: plain ANSIUTF8 is
+#     dark-on-dark and invisible/unscannable on dark terminal backgrounds.
+#     NEVER deliver the QR as a Signal message/attachment during linking.
+#
+#  3. PERSISTENT LINK PROCESS
+#     Run `signal-cli link` under `systemd-run` (transient unit sig-link-<host>)
+#     so it survives the launching shell and stays connected the full window.
+#     For REMOTE hosts, `az vm run-command` runs as ROOT, so systemd-run needs
+#     --uid=azureuser --gid=azureuser --setenv=HOME=/home/azureuser to land the
+#     account under the azureuser user (not root).
+#
+#  4. OPERATIONAL GOTCHAS
+#     (a) azlin is a Rust binary that ABORTS (SIGABRT/core-dump) on a broken
+#         pipe (SIGPIPE). NEVER pipe azlin into `grep -q`/`head` or any
+#         early-closing consumer — capture full output first, then filter.
+#     (b) Only ONE bastion session per host at a time — concurrent
+#         azlin/bastion sessions to the same VM core-dump.
+#     (c) azlin form:
+#         azlin connect <host> --resource-group <rg> --no-tmux -y -- "<cmd>"
+#
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+# ── Defaults / configuration ────────────────────────────────────────────────
+SIGNAL_CLI_VERSION="0.14.5"                      # known-good pin
+SIGNAL_CLI_BIN="${SIGNAL_CLI_BIN:-$HOME/.local/bin/signal-cli}"
+RG="${AMPLIHACK_SIGNAL_RG:-rysweet-linux-vm-pool}"
+ENDPOINT="${AMPLIHACK_SIGNAL_ENDPOINT:-127.0.0.1:7583}"
+GROUP_NAME="${AMPLIHACK_SIGNAL_GROUP:-amplihack}"
+LINK_TIMEOUT="${AMPLIHACK_SIGNAL_LINK_TIMEOUT:-75}" # >60s so we outlive the window
+
+HOST=""
+REMOTE=0
+DO_DAEMON=1
+DO_PREREQS=1
+ASSUME_YES=0
+
+usage() {
+  cat <<'USAGE'
+signal-setup.sh — link a host to Signal and wire it into amplihack (idempotent)
+
+Usage:
+  signal-setup.sh --host <name> [options]
+
+Options:
+  --host <name>       Host to link. A local hostname links LOCALLY; an Azure VM
+                      name links REMOTELY via `az vm run-command` (auto-detected,
+                      or force with --remote / --local).
+  --remote            Force remote (azlin VM) linking path.
+  --local             Force local linking path.
+  --group <name>      amplihack Signal group name (default: amplihack).
+  --endpoint <h:port> Loopback JSON-RPC endpoint (default: 127.0.0.1:7583).
+  --resource-group <rg>  Azure RG for remote hosts (default: rysweet-linux-vm-pool).
+  --no-daemon         Skip the daemon + self-group + post-test phase.
+  --skip-prereqs      Skip prerequisite verification/installation.
+  -y, --yes           Non-interactive: assume the scan screen is open.
+  -h, --help          Show this help.
+
+Flow: prereqs → prompt to open scan screen → mint under systemd-run →
+      print ANSIUTF8i QR in-terminal → verify linkage →
+      (optional) start daemon + ensure self-group + post-test.
+USAGE
+}
+
+log()  { printf '\033[1;36m[signal-setup]\033[0m %s\n' "$*" >&2; }
+warn() { printf '\033[1;33m[signal-setup] WARN:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[signal-setup] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+FORCE_REMOTE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host)           HOST="${2:-}"; shift 2 ;;
+    --host=*)         HOST="${1#*=}"; shift ;;
+    --remote)         FORCE_REMOTE=1; shift ;;
+    --local)          FORCE_REMOTE=0; shift ;;
+    --group)          GROUP_NAME="${2:-}"; shift 2 ;;
+    --group=*)        GROUP_NAME="${1#*=}"; shift ;;
+    --endpoint)       ENDPOINT="${2:-}"; shift 2 ;;
+    --endpoint=*)     ENDPOINT="${1#*=}"; shift ;;
+    --resource-group) RG="${2:-}"; shift 2 ;;
+    --resource-group=*) RG="${1#*=}"; shift ;;
+    --no-daemon)      DO_DAEMON=0; shift ;;
+    --skip-prereqs)   DO_PREREQS=0; shift ;;
+    -y|--yes)         ASSUME_YES=1; shift ;;
+    -h|--help)        usage; exit 0 ;;
+    *) die "unknown argument: $1 (see --help)" ;;
+  esac
+done
+
+[ -n "$HOST" ] || { usage; die "--host is required"; }
+
+DEVICE_NAME="amplihack-$HOST"
+UNIT="sig-link-$HOST"
+URI_FILE="/tmp/slink-$HOST.out"
+TRACE_LOG="/tmp/scli-$HOST.log"
+LOCAL_HOST="$(hostname -s 2>/dev/null || hostname)"
+
+# ── Decide local vs remote ───────────────────────────────────────────────────
+detect_remote() {
+  if [ -n "$FORCE_REMOTE" ]; then REMOTE="$FORCE_REMOTE"; return; fi
+  # Local if the requested host matches this machine's short hostname.
+  if [ "$HOST" = "$LOCAL_HOST" ] || [ "$HOST" = "localhost" ] || [ "$HOST" = "local" ]; then
+    REMOTE=0
+  else
+    REMOTE=1
+  fi
+}
+detect_remote
+log "host=$HOST  mode=$([ "$REMOTE" -eq 1 ] && echo REMOTE || echo LOCAL)  device=$DEVICE_NAME  unit=$UNIT"
+
+# azlin invocation (form c): capture output FULLY (gotcha a: never pipe azlin
+# into an early-closing consumer or the Rust binary SIGABRTs on the broken pipe).
+azlin_run() {
+  local h="$1" cmd="$2"
+  timeout 180 azlin connect "$h" --resource-group "$RG" --no-tmux -y -- "$cmd" 2>&1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PHASE 1 — PREREQUISITES
+# ─────────────────────────────────────────────────────────────────────────────
+have() { command -v "$1" >/dev/null 2>&1; }
+
+install_qrencode() {
+  have qrencode && return 0
+  log "installing qrencode…"
+  if have apt-get; then sudo apt-get update -qq && sudo apt-get install -y -qq qrencode
+  elif have dnf; then sudo dnf install -y -q qrencode
+  elif have brew; then brew install qrencode
+  else die "qrencode missing and no known package manager (apt/dnf/brew)"; fi
+}
+
+check_signal_cli_local() {
+  if [ -x "$SIGNAL_CLI_BIN" ]; then
+    local v; v="$("$SIGNAL_CLI_BIN" --version 2>/dev/null | awk '{print $NF}')"
+    log "signal-cli present: ${v:-unknown} ($SIGNAL_CLI_BIN)"
+    [ "$v" = "$SIGNAL_CLI_VERSION" ] || warn "signal-cli $v != known-good $SIGNAL_CLI_VERSION (continuing)"
+    return 0
+  fi
+  if have signal-cli; then SIGNAL_CLI_BIN="$(command -v signal-cli)"; log "signal-cli on PATH: $SIGNAL_CLI_BIN"; return 0; fi
+  die "signal-cli not found at $SIGNAL_CLI_BIN or on PATH. Install signal-cli $SIGNAL_CLI_VERSION\n\
+  e.g. unpack to ~/.local/opt/signal-cli-$SIGNAL_CLI_VERSION and symlink its bin/signal-cli into ~/.local/bin."
+}
+
+prereqs_local() {
+  export PATH="$HOME/.local/bin:$PATH"
+  check_signal_cli_local
+  install_qrencode
+  have systemd-run || die "systemd-run not available (needed for a persistent link process)"
+}
+
+prereqs_remote() {
+  # qrencode is needed LOCALLY (we render here); az CLI is needed for run-command.
+  install_qrencode
+  have az || die "az CLI not found — required to reach remote host '$HOST'. Install the Azure CLI."
+  log "verifying signal-cli + systemd-run on remote host '$HOST' (single azlin round-trip)…"
+  local probe; probe="$(azlin_run "$HOST" \
+    "test -x $SIGNAL_CLI_BIN && echo HAVE_CLI; command -v systemd-run >/dev/null && echo HAVE_SYSTEMD; $SIGNAL_CLI_BIN --version 2>/dev/null")" || true
+  printf '%s\n' "$probe" | grep -qa HAVE_CLI     || die "remote host '$HOST' missing signal-cli at $SIGNAL_CLI_BIN"
+  printf '%s\n' "$probe" | grep -qa HAVE_SYSTEMD || die "remote host '$HOST' missing systemd-run"
+  local rv; rv="$(printf '%s\n' "$probe" | grep -ao "$SIGNAL_CLI_VERSION" | head -1)"
+  if [ -n "$rv" ]; then log "remote signal-cli $SIGNAL_CLI_VERSION OK"; else warn "remote signal-cli version != $SIGNAL_CLI_VERSION (continuing)"; fi
+}
+
+if [ "$DO_PREREQS" -eq 1 ]; then
+  log "── Phase 1: prerequisites ──"
+  if [ "$REMOTE" -eq 1 ]; then prereqs_remote; else prereqs_local; fi
+else
+  [ "$REMOTE" -eq 1 ] || { export PATH="$HOME/.local/bin:$PATH"; }
+  warn "skipping prerequisite checks (--skip-prereqs)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# IDEMPOTENCY — bail out early if this host is already linked.
+# ─────────────────────────────────────────────────────────────────────────────
+list_accounts_local()  { "$SIGNAL_CLI_BIN" listAccounts 2>/dev/null; }
+list_accounts_remote() { azlin_run "$HOST" "$SIGNAL_CLI_BIN listAccounts 2>/dev/null"; }
+
+get_linked_number() {
+  local out
+  if [ "$REMOTE" -eq 1 ]; then out="$(list_accounts_remote)"; else out="$(list_accounts_local)"; fi
+  printf '%s\n' "$out" | sed -n 's/.*Number: *\(+[0-9][0-9]*\).*/\1/p' | head -1
+}
+
+EXISTING="$(get_linked_number)"
+if [ -n "$EXISTING" ]; then
+  log "host '$HOST' is ALREADY linked as $EXISTING — skipping the link step (idempotent)."
+  PHONE="$EXISTING"
+  ALREADY_LINKED=1
+else
+  ALREADY_LINKED=0
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PHASE 2 — PROMPT: open the scan screen BEFORE we mint (60s window!)
+# ─────────────────────────────────────────────────────────────────────────────
+if [ "$ALREADY_LINKED" -eq 0 ]; then
+  cat >&2 <<'BANNER'
+
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  ⚠  60-SECOND WINDOW — get ready to scan BEFORE the QR is minted.      │
+  │                                                                        │
+  │  On your phone, open:                                                  │
+  │      Signal → Settings → Linked Devices → "Link New Device"           │
+  │  and get to the camera / scan screen NOW.                             │
+  │                                                                        │
+  │  The QR expires ~60s after it is minted (Signal closes the            │
+  │  provisioning socket with code 1001). Scan it the instant it prints.  │
+  └──────────────────────────────────────────────────────────────────────┘
+
+BANNER
+  if [ "$ASSUME_YES" -eq 0 ]; then
+    if [ -t 0 ]; then
+      printf '\033[1;32m[signal-setup]\033[0m Press ENTER once you are on the scan screen (Ctrl-C to abort)… ' >&2
+      read -r _ || die "aborted"
+    else
+      warn "no TTY and no -y/--yes; proceeding immediately — make sure the scan screen is open."
+    fi
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PHASE 3 — MINT the link under systemd-run (persistent process)
+# ─────────────────────────────────────────────────────────────────────────────
+mint_local() {
+  sudo systemctl reset-failed "$UNIT" 2>/dev/null
+  sudo systemctl stop "$UNIT" 2>/dev/null
+  sudo rm -f "$URI_FILE" "$TRACE_LOG"
+  sudo systemd-run --unit="$UNIT" --uid="$USER" --gid="$USER" \
+    --setenv=HOME="$HOME" --setenv=PATH="$HOME/.local/bin:/usr/bin:/bin" \
+    /bin/bash -c "'$SIGNAL_CLI_BIN' -vv --log-file '$TRACE_LOG' link -n '$DEVICE_NAME' > '$URI_FILE' 2>&1" \
+    >/dev/null 2>&1
+  local _i
+  for _i in $(seq 1 40); do
+    sudo grep -qa '^sgnl://' "$URI_FILE" 2>/dev/null && break
+    sleep 0.5
+  done
+  sudo grep -m1 -a '^sgnl://' "$URI_FILE" 2>/dev/null
+}
+
+mint_remote() {
+  # ONE azlin round-trip: start the link under systemd-run (as azureuser — see
+  # fact #3), poll the URI file on the VM, echo the URI back between markers.
+  local script
+  script=$(cat <<REMOTE
+systemctl reset-failed $UNIT 2>/dev/null
+systemctl stop $UNIT 2>/dev/null
+rm -f $URI_FILE $TRACE_LOG
+systemd-run --unit=$UNIT --uid=azureuser --gid=azureuser \
+  --setenv=HOME=/home/azureuser --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
+  /bin/bash -c '$SIGNAL_CLI_BIN -vv --log-file $TRACE_LOG link -n $DEVICE_NAME > $URI_FILE 2>&1' >/dev/null 2>&1
+for i in \$(seq 1 40); do grep -qa '^sgnl://' $URI_FILE 2>/dev/null && break; sleep 0.5; done
+echo URI_START; grep -m1 -a '^sgnl://' $URI_FILE 2>/dev/null; echo URI_END
+REMOTE
+)
+  local out
+  out="$(az vm run-command invoke -g "$RG" -n "$HOST" --command-id RunShellScript \
+        --scripts "$script" --query 'value[0].message' -o tsv 2>/dev/null)"
+  printf '%s\n' "$out" | sed -n 's/.*URI_START//p' | grep -m1 -a '^sgnl://'
+}
+
+if [ "$ALREADY_LINKED" -eq 0 ]; then
+  log "── Phase 3: minting device-link (unit=$UNIT) ──"
+  if [ "$REMOTE" -eq 1 ]; then URI="$(mint_remote)"; else URI="$(mint_local)"; fi
+  [ -n "${URI:-}" ] || die "failed to obtain an sgnl:// link URI for '$HOST'. Check signal-cli/systemd-run (trace: $TRACE_LOG)."
+  MINT_TS="$(date -u +%H:%M:%SZ)"
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # PHASE 4 — RENDER the QR IN-TERMINAL (zero latency, dark-terminal-safe)
+  # ───────────────────────────────────────────────────────────────────────────
+  cat >&2 <<BANNER
+
+############################################################
+#  SCAN NOW — you have ~55 seconds (Signal closes at 60s)  #
+#  Signal > Linked Devices > Link New Device > scan below  #
+############################################################
+BANNER
+  # ANSIUTF8i — the trailing "i" (inverted) is REQUIRED for dark terminals.
+  qrencode -t ANSIUTF8i -m 2 "$URI"
+  echo >&2
+  log "minted at $MINT_TS  (host=$HOST unit=$UNIT). If it will not scan, paste this URI into Link New Device:"
+  printf '%s\n' "$URI" >&2
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # PHASE 5 — VERIFY linkage (poll until listAccounts shows the number, or the
+  # transient unit goes inactive; trace log confirms "Associated with").
+  # ───────────────────────────────────────────────────────────────────────────
+  log "── Phase 5: waiting for you to scan (up to ${LINK_TIMEOUT}s) ──"
+  PHONE=""
+  DEADLINE=$(( $(date +%s) + LINK_TIMEOUT ))
+  while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    PHONE="$(get_linked_number)"
+    [ -n "$PHONE" ] && break
+    sleep 3
+  done
+  if [ -z "$PHONE" ]; then
+    warn "no linked account detected within ${LINK_TIMEOUT}s."
+    warn "The 60s window likely expired — re-run signal-setup.sh and scan faster. Trace: $TRACE_LOG"
+    die "linkage not confirmed for '$HOST'"
+  fi
+  log "✅ LINKED: '$HOST' is now Signal account $PHONE  (device: $DEVICE_NAME)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PHASE 6 — DAEMON + SELF-GROUP + POST-TEST (the amplihack Signal channel)
+# For LOCAL hosts we can drive the JSON-RPC daemon directly. For remote hosts we
+# report the linked account and hand off to `amplihack signal setup` / the
+# fleet distribute path, which manage the remote daemon + config.
+# ─────────────────────────────────────────────────────────────────────────────
+json_rpc() {
+  # json_rpc <host:port> <json-request-line>  → prints the first response line.
+  local hp="$1" req="$2" host port
+  host="${hp%:*}"; port="${hp##*:}"
+  if have python3; then
+    HP_HOST="$host" HP_PORT="$port" REQ="$req" python3 - <<'PY'
+import os, socket, sys, time
+host=os.environ["HP_HOST"]; port=int(os.environ["HP_PORT"]); req=os.environ["REQ"]
+try:
+    s=socket.create_connection((host,port),timeout=10); s.settimeout(20)
+except OSError as e:
+    print(f'{{"error":"connect: {e}"}}'); sys.exit(0)
+s.sendall((req+"\n").encode())
+buf=b""; end=time.time()+20
+while time.time()<end:
+    try: c=s.recv(65536)
+    except socket.timeout: break
+    if not c: break
+    buf+=c
+    if b"\n" in buf: break
+line=buf.split(b"\n",1)[0].decode(errors="replace")
+print(line)
+PY
+  else
+    warn "python3 unavailable; cannot drive JSON-RPC directly"; return 1
+  fi
+}
+
+daemon_running() {
+  local hp="$1" host port
+  host="${hp%:*}"; port="${hp##*:}"
+  (exec 3<>"/dev/tcp/$host/$port") 2>/dev/null && { exec 3>&- 3<&-; return 0; } || return 1
+}
+
+setup_channel_local() {
+  log "── Phase 6: daemon + self-group + post-test ──"
+  if daemon_running "$ENDPOINT"; then
+    log "JSON-RPC daemon already running on $ENDPOINT (idempotent)"
+  else
+    log "starting JSON-RPC daemon on $ENDPOINT under systemd-run…"
+    local dunit="sig-daemon-$HOST"
+    sudo systemctl reset-failed "$dunit" 2>/dev/null
+    sudo systemctl stop "$dunit" 2>/dev/null
+    sudo systemd-run --unit="$dunit" --uid="$USER" --gid="$USER" \
+      --setenv=HOME="$HOME" --setenv=PATH="$HOME/.local/bin:/usr/bin:/bin" \
+      "$SIGNAL_CLI_BIN" -a "$PHONE" daemon --tcp "$ENDPOINT" >/dev/null 2>&1
+    local _i
+    for _i in $(seq 1 20); do daemon_running "$ENDPOINT" && break; sleep 0.5; done
+    daemon_running "$ENDPOINT" || { warn "daemon did not come up on $ENDPOINT"; return 1; }
+    log "daemon up on $ENDPOINT (unit=$dunit)"
+  fi
+
+  # Ensure a self-only amplihack group exists → capture groupId.
+  log "ensuring self-only group '$GROUP_NAME' exists…"
+  local resp gid
+  resp="$(json_rpc "$ENDPOINT" "{\"jsonrpc\":\"2.0\",\"id\":\"grp\",\"method\":\"updateGroup\",\"params\":{\"name\":\"$GROUP_NAME\"}}")"
+  gid="$(printf '%s' "$resp" | sed -n 's/.*"groupId":"\([^"]*\)".*/\1/p')"
+  if [ -z "$gid" ]; then
+    warn "updateGroup did not return a groupId. Response: $resp"
+    return 1
+  fi
+  log "group '$GROUP_NAME' groupId=$gid"
+
+  # Post-test: send to the self-group. Empty results is NORMAL/success for a
+  # self-only group ({"results":[],"timestamp":...}).
+  log "post-test: sending a confirmation message to the self-group…"
+  local msg send
+  msg="amplihack signal-setup: '$HOST' linked as $PHONE at $(date -u +%FT%TZ)"
+  send="$(json_rpc "$ENDPOINT" "{\"jsonrpc\":\"2.0\",\"id\":\"snd\",\"method\":\"send\",\"params\":{\"groupId\":\"$gid\",\"message\":\"$msg\"}}")"
+  if printf '%s' "$send" | grep -q '"timestamp"'; then
+    log "✅ post-test OK (self-group send returned a timestamp; empty \"results\" is expected)."
+  else
+    warn "post-test send did not return a timestamp. Response: $send"
+    return 1
+  fi
+}
+
+if [ "$DO_DAEMON" -eq 1 ]; then
+  if [ "$REMOTE" -eq 1 ]; then
+    log "── Phase 6 (remote) ──"
+    log "Remote host '$HOST' is linked as $PHONE."
+    if have amplihack; then
+      log "Handing daemon+config off to amplihack's Signal channel on the VM (via azlin)…"
+      azlin_run "$HOST" "amplihack signal setup --endpoint $ENDPOINT --device-name $DEVICE_NAME 2>&1 || true" \
+        | sed 's/^/[remote amplihack signal setup] /' >&2 || true
+    else
+      warn "amplihack CLI not found locally; run on the VM to finish the channel:"
+      warn "    amplihack signal setup --endpoint $ENDPOINT --device-name $DEVICE_NAME"
+    fi
+  else
+    setup_channel_local || warn "channel phase incomplete — host is LINKED ($PHONE); re-run to finish daemon/group setup."
+  fi
+else
+  log "skipping daemon/self-group/post-test (--no-daemon)."
+fi
+
+echo >&2
+log "DONE. host='$HOST' account=$PHONE mode=$([ "$REMOTE" -eq 1 ] && echo remote || echo local)."
+[ "$REMOTE" -eq 1 ] || log "Verify any time with:  $SIGNAL_CLI_BIN listAccounts"

--- a/docs/skills/SKILL_CATALOG.md
+++ b/docs/skills/SKILL_CATALOG.md
@@ -5,8 +5,8 @@ Those bundled `SKILL.md` files are the install-time source of truth.
 
 ## Summary
 
-- **Unique bundled skill names:** 121
-- **Skill definition files:** 121
+- **Unique bundled skill names:** 122
+- **Skill definition files:** 122
 
 ## Bundled Skills
 
@@ -113,6 +113,7 @@ Those bundled `SKILL.md` files are the install-time source of truth.
 | `session-to-agent` | `session-to-agent/SKILL.md` |
 | `setting-up-projects` | `development/setting-up-projects/SKILL.md` |
 | `shadow-testing` | `shadow-testing/SKILL.md` |
+| `signal-setup` | `signal-setup/SKILL.md` |
 | `silent-degradation-audit` | `silent-degradation-audit/SKILL.md` |
 | `skill-builder` | `skill-builder/SKILL.md` |
 | `smart-test` | `smart-test/SKILL.md` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Adds a new reusable, idempotent amplihack skill — **`signal-setup`** — that
collapses the entire manual Signal device-linking loop into a single invocable
command, for a **local host** or a **remote azlin Azure VM**. Closes #996.

Generalizes the proven `link_now.sh` into a real skill:
- `amplifier-bundle/skills/signal-setup/SKILL.md` — when/how to invoke + full e2e flow + the critical facts.
- `amplifier-bundle/skills/signal-setup/README.md` — quick start.
- `amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh` — executable, idempotent, `--host` (local or remote).
- `docs/skills/SKILL_CATALOG.md` — registers the new skill.

## What running it does

`signal-setup.sh --host <name>` performs:
1. **Prereqs** — verify/install `signal-cli` (0.14.5 known-good, `~/.local/bin/signal-cli`), `qrencode`, and `az` (remote hosts).
2. **Idempotency** — skip linking if the host already shows `Number: +…`.
3. **Prompt** the user to open Signal → Linked Devices → Link New Device.
4. **Mint** the link under `systemd-run` (remote via `az vm run-command` + `systemd-run --uid=azureuser`).
5. **Render** the QR in-terminal with `qrencode -t ANSIUTF8i` (zero latency).
6. **Verify** linkage via `signal-cli listAccounts`.
7. **Channel** (optional) — start the JSON-RPC daemon on `127.0.0.1:7583`, ensure a self-only group, post-test.

## Hard-won facts encoded & documented prominently in SKILL.md

- **60-second window** — Signal's provisioning websocket closes with server code 1001 exactly 60s after opening; the QR is only valid ~60s from mint. Slow delivery (e.g. remote daemon relay = 40–60s) expires it → "invalid response from server".
- **`ANSIUTF8i` for dark terminals** — the inverted variant is required; plain `ANSIUTF8` is dark-on-dark and invisible. Never route the QR through Signal.
- **`systemd-run` persistence** — keeps the link process alive the full window; remote runs need `--uid=azureuser` because `az vm run-command` runs as root.
- **Operational gotchas** — azlin SIGPIPE core-dump (never pipe into early-closing consumers), one bastion session per host, canonical azlin invocation form.

## Testing

- `shellcheck` clean; `bash -n` syntax OK; `--help` works.
- `cargo test -p amplihack --test skill_frontmatter_name` — 11/11 pass (name/kebab/uniqueness/dir-match/valid-YAML).
- `scripts/check-skills-no-missing-helpers.sh` passes.
- `pre-commit run` on all changed files passes (artifact-guard, whitespace, EOF, large-files).

No production Rust changed; the skill reuses the existing `amplihack signal setup` command / `amplihack-signal` crate for remote daemon+config handoff.

## Step 13: Local Testing Results

Detected toolchains:
- **Bash CLI skill** — the change set is a shell script + Markdown (`amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh`, `SKILL.md`, `README.md`) plus a `docs/skills/SKILL_CATALOG.md` row. The script has a `#!/usr/bin/env bash` shebang, mode `100755`, and `set -uo pipefail`; `shellcheck` is available and clean.
- **Rust workspace guardrails** — root `Cargo.toml`; the repo enforces skill correctness via `bins/amplihack` integration test targets `skill_frontmatter_name` (11 tests) and `skill_frontmatter_type` (4 tests), which scan every bundled `SKILL.md`. These are the CI gates a new skill must satisfy.

Chosen validation strategy:
- Exercise the script's real user-facing CLI boundary (help, argument validation, idempotency, QR rendering) directly — a phone-in-the-loop link cannot be automated, so I drive every path that does not require Signal's servers and stub `signal-cli` for the idempotency path.
- Run the repo's own skill-frontmatter guard tests so the new skill is proven to pass the same checks CI runs. Also ran `shellcheck`, `bash -n`, and `scripts/check-toolchain-refs.sh`.

### Scenario 1 — Simple: help + argument validation
Command: `signal-setup.sh --help` ; `signal-setup.sh` (no args) ; `signal-setup.sh --host foo --bogus`
Result: PASS
Output:
- `--help` prints full usage and the e2e flow, exits `0`.
- No `--host` → prints usage + `ERROR: --host is required`, exits `1`.
- Unknown flag → `ERROR: unknown argument: --bogus (see --help)`, exits `1`.

### Scenario 2 — Complex: idempotent re-run detection (integration point)
Command: `SIGNAL_CLI_BIN=<stub> signal-setup.sh --host $(hostname -s) --skip-prereqs --no-daemon -y`
Result: PASS
Output:
- Detected `host=deva mode=LOCAL device=amplihack-deva`, then `host 'deva' is ALREADY linked as +15551230000 — skipping the link step (idempotent).`
- Correctly skipped the mint/prompt/verify and the daemon phase; exited `0`. Confirms the documented idempotency guarantee (re-running a linked host is a safe no-op).

### Supporting checks (all PASS)
- `shellcheck signal-setup.sh` → exit 0 (clean); `bash -n` → SYNTAX OK.
- `qrencode -t ANSIUTF8i` renders a scannable inverted QR in-terminal (the dark-terminal-critical delivery path).
- `cargo test -p amplihack --test skill_frontmatter_name --test skill_frontmatter_type --locked` → **15/15 pass** (kebab name == directory name `signal-setup`, frontmatter at byte 0, `name`/`description` are string scalars, unique name, valid YAML).
- `scripts/check-toolchain-refs.sh` → OK.
- `docs/skills/SKILL_CATALOG.md` contains the `signal-setup` row.

Both required scenarios passed; no failures.
