### PR TITLE
fix(workflow): make gh/az helper scripts tolerant of GitHub API rate limits

### DIFF
--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -80,7 +80,9 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 2
 fi
 
-WORK="$(mktemp -d -t default-workflow-reliability-XXXXXX)"
+WORK="${REPO_ROOT}/../.default-workflow-reliability-test-${$}"
+rm -rf "$WORK"
+mkdir -p "$WORK"
 trap 'rm -rf "${WORK}"' EXIT
 STEP04="${WORK}/step-04-setup-worktree.sh"
 STEP_TDD_CHECKPOINT="${WORK}/checkpoint-after-implementation.sh"
@@ -285,7 +287,7 @@ assert_terminal_status_case() {
         unset IMPLEMENTATION_COMPLETED VERIFICATION_COMPLETED PUBLISH_STATE_REACHED TERMINAL_NO_OP TERMINAL_FAILURE
         unset TERMINAL_STATE TERMINAL_REASON OBSERVED_PHASES ALLOW_NO_OP
         for assignment in "$@"; do
-            export "${assignment}"
+            export "${assignment?}"
         done
         bash "${FINAL_STATUS_TOOL}"
     ) >"${stdout_file}" 2>"${stderr_file}" || status=$?
@@ -1274,7 +1276,8 @@ assert_no_merge_directive_suppresses_auto_merge() {
         "Fix issue 929. Do NOT merge the PR; leave it open." \
         "Please don't merge this, no admin merge." \
         "Implement the change but this is a no-merge task"; do
-        local case_repo="${WORK}/nomerge-probe-$(printf '%s' "${directive}" | tr -c 'A-Za-z0-9' '_' | cut -c1-24)"
+        local case_repo
+        case_repo="${WORK}/nomerge-probe-$(printf '%s' "${directive}" | tr -c 'A-Za-z0-9' '_' | cut -c1-24)"
         setup_nomerge_probe_repo "${case_repo}"
         if ! run_nomerge_probe_case "${case_repo}" "${directive}" \
             "${WORK}/nomerge-dir.out" "${WORK}/nomerge-dir.err"; then

--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -1289,7 +1289,133 @@ assert_no_merge_directive_suppresses_auto_merge() {
     done
 }
 
+assert_gh_rate_limit_backoff_contracts() {
+    # Regression coverage for the shared rate-limit-aware retry driver
+    # (workflow_gh_retry.sh) used by the publish/scope/final/ready helpers.
+    local lib="${REPO_ROOT}/amplifier-bundle/tools/workflow_gh_retry.sh"
+    [ -f "$lib" ] || fail "workflow_gh_retry.sh shared retry helper is missing"
+
+    local base="${WORK}/gh-rate-limit"
+    mkdir -p "$base"
+
+    # --- (a) a rate-limit stderr triggers wait-for-reset (mock gh api rate_limit)
+    local a="${base}/a"; mkdir -p "${a}/bin"
+    cat > "${a}/bin/gh" <<'SHIMA'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${GH_LOG:?}"; printf 'call %s\n' "$*" >> "$log"
+case "${1:-}-${2:-}" in
+  api-rate_limit)
+    now="$(date +%s)"
+    # graphql exhausted, core also exhausted -> forces wait (no REST), reset now.
+    printf '{"resources":{"graphql":{"remaining":0,"reset":%s},"core":{"remaining":0,"reset":%s}}}\n' "$now" "$now" ;;
+  pr-list)
+    n="$(grep -c '^call pr list' "$log")"
+    if [ "$n" -le 1 ]; then echo "GraphQL: API rate limit already exceeded for user ID 1" >&2; exit 1; fi
+    printf '[]\n' ;;
+  *) echo "unexpected $*" >&2; exit 1 ;;
+esac
+SHIMA
+    chmod +x "${a}/bin/gh"
+    (
+        set +e
+        export PATH="${a}/bin:${PATH}" GH_LOG="${a}/log"; : > "$GH_LOG"
+        # shellcheck source=/dev/null
+        . "$lib"
+        rc=0
+        out="$(GH_RETRY_REST_FALLBACK="" GH_RETRY_RESOURCE="graphql" _gh_retry_core "pr list" pr list --repo example/repo --head feat/x)" || rc=$?
+        [ "$rc" -eq 0 ] || { echo "case-a rc=$rc" >&2; cat "$GH_LOG" >&2; exit 1; }
+        grep -q '^call api rate_limit' "$GH_LOG" || { echo "case-a: gh api rate_limit was not consulted for reset" >&2; exit 1; }
+        [ "$(grep -c '^call pr list' "$GH_LOG")" -eq 2 ] || { echo "case-a: expected exactly 2 pr list attempts (fail+retry-after-reset)" >&2; cat "$GH_LOG" >&2; exit 1; }
+    ) || fail "rate-limit stderr must wait for the authoritative reset (gh api rate_limit) then retry"
+    echo "  PASS[gh-retry:a]: rate-limit waits for authoritative reset (gh api rate_limit) then retries"
+
+    # --- (b) REST fallback used for pr-existence when GraphQL fails but core ok
+    local b="${base}/b"; mkdir -p "${b}/bin"
+    cat > "${b}/bin/gh" <<'SHIMB'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${GH_LOG:?}"; printf 'call %s\n' "$*" >> "$log"
+case "${1:-}-${2:-}" in
+  api-rate_limit)
+    now="$(date +%s)"
+    # graphql exhausted (reset far out), but core still has budget -> REST now.
+    printf '{"resources":{"graphql":{"remaining":0,"reset":%s},"core":{"remaining":4000,"reset":%s}}}\n' "$((now+3600))" "$now" ;;
+  api-*)
+    case "$2" in
+      repos/example/repo/pulls\?*)
+        printf '[{"number":77,"title":"Update x","body":"b","state":"open","created_at":"2026-01-01T00:00:00Z","merged_at":null,"html_url":"https://github.com/example/repo/pull/77","head":{"ref":"feat/x","sha":"deadbeef","repo":{"name":"repo","full_name":"example/repo","owner":{"login":"example"}}},"base":{"ref":"main","repo":{"full_name":"example/repo"}}}]\n' ;;
+      *) printf '[]\n' ;;
+    esac ;;
+  pr-list) echo "GraphQL: API rate limit exceeded" >&2; exit 1 ;;
+  *) echo "unexpected $*" >&2; exit 1 ;;
+esac
+SHIMB
+    chmod +x "${b}/bin/gh"
+    (
+        set +e
+        export PATH="${b}/bin:${PATH}" GH_LOG="${b}/log"; : > "$GH_LOG"
+        # shellcheck source=/dev/null
+        . "$lib"
+        _case_b_fallback() { gh_pr_exists_rest example/repo feat/x; }
+        rc=0
+        out="$(GH_RETRY_REST_FALLBACK=_case_b_fallback _gh_retry_core "pr list" pr list --repo example/repo --head feat/x 2>"${b}/err")" || rc=$?
+        [ "$rc" -eq 0 ] || { echo "case-b rc=$rc" >&2; cat "$GH_LOG" "${b}/err" >&2; exit 1; }
+        printf '%s' "$out" | jq -e '.[0].number == 77' >/dev/null 2>&1 || { echo "case-b: REST fallback did not return the existing PR" >&2; echo "$out" >&2; exit 1; }
+        grep -qi 'REST /pulls fallback' "${b}/err" || { echo "case-b: REST fallback must be logged as an explicit WARNING" >&2; cat "${b}/err" >&2; exit 1; }
+        [ "$(grep -c '^call pr list' "$GH_LOG")" -eq 1 ] || { echo "case-b: must not block on GraphQL when core budget serves REST" >&2; cat "$GH_LOG" >&2; exit 1; }
+    ) || fail "GraphQL rate-limit with available core budget must serve PR-existence via REST fallback"
+    echo "  PASS[gh-retry:b]: REST fallback serves PR-existence when GraphQL exhausted but core has budget"
+
+    # --- (c) auth error is NOT retried
+    local c="${base}/c"; mkdir -p "${c}/bin"
+    cat > "${c}/bin/gh" <<'SHIMC'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${GH_LOG:?}"; printf 'call %s\n' "$*" >> "$log"
+echo "HTTP 401: Bad credentials" >&2
+exit 1
+SHIMC
+    chmod +x "${c}/bin/gh"
+    (
+        set +e
+        export PATH="${c}/bin:${PATH}" GH_LOG="${c}/log"; : > "$GH_LOG"
+        # shellcheck source=/dev/null
+        . "$lib"
+        rc=0
+        _gh_retry_core "pr view" pr view 1 >/dev/null 2>&1 || rc=$?
+        [ "$rc" -ne 0 ] || { echo "case-c: auth failure must return non-zero" >&2; exit 1; }
+        [ "$(grep -c '^call ' "$GH_LOG")" -eq 1 ] || { echo "case-c: auth error must NOT be retried" >&2; cat "$GH_LOG" >&2; exit 1; }
+    ) || fail "authentication errors (401 / Bad credentials) must never be retried"
+    echo "  PASS[gh-retry:c]: authentication errors are terminal (no retry)"
+
+    # --- (d) generic 5xx keeps the short-backoff 3-attempt behavior
+    local d="${base}/d"; mkdir -p "${d}/bin"
+    cat > "${d}/bin/gh" <<'SHIMD'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${GH_LOG:?}"; printf 'call %s\n' "$*" >> "$log"
+echo "HTTP 503 temporary GitHub API failure" >&2
+exit 1
+SHIMD
+    chmod +x "${d}/bin/gh"
+    (
+        set +e
+        export PATH="${d}/bin:${PATH}" GH_LOG="${d}/log"; : > "$GH_LOG"
+        # shellcheck source=/dev/null
+        . "$lib"
+        rc=0
+        _gh_retry_core "pr list" pr list --repo example/repo --head feat/x >/dev/null 2>&1 || rc=$?
+        [ "$rc" -ne 0 ] || { echo "case-d: persistent 5xx must fail closed" >&2; exit 1; }
+        [ "$(grep -c '^call pr list' "$GH_LOG")" -eq 3 ] || { echo "case-d: generic transient must keep exactly 3 attempts" >&2; cat "$GH_LOG" >&2; exit 1; }
+        grep -q '^call api rate_limit' "$GH_LOG" && { echo "case-d: transient path must NOT consult rate_limit reset" >&2; exit 1; }
+        true
+    ) || fail "generic 5xx/network errors must keep the short-backoff 3-attempt behavior"
+    echo "  PASS[gh-retry:d]: generic 5xx keeps short-backoff 3-attempt behavior"
+}
+
 assert_pr_title_ignores_lockfiles
 assert_no_merge_directive_suppresses_auto_merge
+assert_gh_rate_limit_backoff_contracts
 
 echo "PASS: default workflow reliability contracts are covered."

--- a/amplifier-bundle/recipes/tests/test-gh-rate-limit-backoff.sh
+++ b/amplifier-bundle/recipes/tests/test-gh-rate-limit-backoff.sh
@@ -30,7 +30,10 @@ LIB="${REPO_ROOT}/amplifier-bundle/tools/workflow_gh_retry.sh"
 [ -f "$LIB" ] || { echo "HARNESS ERROR: missing $LIB" >&2; exit 2; }
 command -v jq >/dev/null 2>&1 || { echo "HARNESS ERROR: jq is required" >&2; exit 2; }
 
-WORK="$(mktemp -d -t gh-rate-limit-backoff-XXXXXX)"
+WORK="${REPO_ROOT}/.gh-rate-limit-backoff-test-${$}"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+export GH_RETRY_TMPDIR="$WORK"
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
 
@@ -42,7 +45,7 @@ ok() { PASS_COUNT=$((PASS_COUNT + 1)); echo "  PASS: $*"; }
 . "$LIB"
 
 # --- 1. classifier ---------------------------------------------------------
-classify_str() { local f; f="$(mktemp -t classify-XXXXXX)"; printf '%s' "$1" > "$f"; classify_gh_error "$f"; rm -f "$f"; }
+classify_str() { local f="${WORK}/classify-${PASS_COUNT}-${RANDOM}.stderr"; printf '%s' "$1" > "$f"; classify_gh_error "$f"; rm -f "$f"; }
 
 expect_class() {
   local got; got="$(classify_str "$2")"
@@ -64,7 +67,7 @@ expect_class "empty"                ""                                          
 expect_class "unrelated"            "some other unrelated failure"                            "other"
 
 # --- 2. reset epoch from headers ------------------------------------------
-hdr="$(mktemp -t hdr-XXXXXX)"
+hdr="${WORK}/headers.stderr"
 printf 'X-RateLimit-Reset: 2000000000\n' > "$hdr"
 [ "$(gh_reset_epoch_from_stderr "$hdr")" = "2000000000" ] || fail "X-RateLimit-Reset epoch not parsed"
 ok "reset epoch parsed from X-RateLimit-Reset header"

--- a/amplifier-bundle/recipes/tests/test-gh-rate-limit-backoff.sh
+++ b/amplifier-bundle/recipes/tests/test-gh-rate-limit-backoff.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# test-gh-rate-limit-backoff.sh — focused unit tests for the shared
+# GitHub/az rate-limit-aware retry helper (amplifier-bundle/tools/workflow_gh_retry.sh).
+#
+# Covers the motivating production failures where an exhausted GraphQL quota
+# (0/5000, reset up to ~1h later) made `gh` calls fail the workflow closed:
+#   * workflow_publish_pr.sh  — `gh pr list` retried 3x then refused.
+#   * workflow_pr_scope.sh    — scoped `gh pr list` -> pr_metadata_unavailable.
+#   * workflow-prep step-03   — `gh issue create` aborted on rate limit.
+#
+# Contracts under test:
+#   1. classify_gh_error distinguishes auth | rate_limit | transient | other.
+#   2. Reset epoch is read from `gh api rate_limit` (non-budget-consuming) and,
+#      as a fallback, from Retry-After / X-RateLimit-Reset headers.
+#   3. gh_pr_exists_rest maps the REST /pulls payload into the `gh --json` shape.
+#   4. The retry driver: (a) waits for the authoritative reset on a rate limit,
+#      (b) serves READ existence via REST when GraphQL is exhausted but core has
+#      budget, (c) never retries auth errors, (d) keeps the generic transient
+#      short-backoff at exactly 3 attempts.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-gh-rate-limit-backoff.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+LIB="${REPO_ROOT}/amplifier-bundle/tools/workflow_gh_retry.sh"
+
+[ -f "$LIB" ] || { echo "HARNESS ERROR: missing $LIB" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "HARNESS ERROR: jq is required" >&2; exit 2; }
+
+WORK="$(mktemp -d -t gh-rate-limit-backoff-XXXXXX)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+PASS_COUNT=0
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { PASS_COUNT=$((PASS_COUNT + 1)); echo "  PASS: $*"; }
+
+# shellcheck source=/dev/null
+. "$LIB"
+
+# --- 1. classifier ---------------------------------------------------------
+classify_str() { local f; f="$(mktemp -t classify-XXXXXX)"; printf '%s' "$1" > "$f"; classify_gh_error "$f"; rm -f "$f"; }
+
+expect_class() {
+  local got; got="$(classify_str "$2")"
+  [ "$got" = "$3" ] || fail "classify '$1': expected '$3' got '$got'"
+  ok "classify $1 -> $3"
+}
+
+expect_class "rate-limit-primary"   "GraphQL: API rate limit already exceeded for user ID 1." "rate_limit"
+expect_class "rate-limit-secondary" "You have exceeded a secondary rate limit. Please wait."  "rate_limit"
+expect_class "rate-limit-429"       "HTTP 429 Too Many Requests"                              "rate_limit"
+expect_class "rate-limit-403-bare"  "HTTP 403: Forbidden"                                     "rate_limit"
+expect_class "permission-403"       "HTTP 403: Resource not accessible by integration"        "other"
+expect_class "auth-bad-credentials" "HTTP 401: Bad credentials"                               "auth"
+expect_class "auth-requires"        "gh: authentication failed - requires authentication"     "auth"
+expect_class "transient-503"        "HTTP 503 temporary GitHub API failure"                   "transient"
+expect_class "transient-502"        "HTTP 502 temporary GitHub API failure"                   "transient"
+expect_class "transient-network"    "connection reset by peer"                                "transient"
+expect_class "empty"                ""                                                        "other"
+expect_class "unrelated"            "some other unrelated failure"                            "other"
+
+# --- 2. reset epoch from headers ------------------------------------------
+hdr="$(mktemp -t hdr-XXXXXX)"
+printf 'X-RateLimit-Reset: 2000000000\n' > "$hdr"
+[ "$(gh_reset_epoch_from_stderr "$hdr")" = "2000000000" ] || fail "X-RateLimit-Reset epoch not parsed"
+ok "reset epoch parsed from X-RateLimit-Reset header"
+now="$(date +%s)"; printf 'Retry-After: 30\n' > "$hdr"
+ra="$(gh_reset_epoch_from_stderr "$hdr")"
+[ "$ra" -ge "$((now + 29))" ] && [ "$ra" -le "$((now + 35))" ] || fail "Retry-After not converted to epoch (got $ra)"
+ok "reset epoch derived from Retry-After header"
+rm -f "$hdr"
+
+# --- mock gh helper --------------------------------------------------------
+# make_gh <dir> <<'BODY' ... BODY   installs a PATH-shim gh; logs to $GH_LOG.
+make_gh() {
+  local dir="$1"; mkdir -p "${dir}/bin"
+  cat > "${dir}/bin/gh"
+  chmod +x "${dir}/bin/gh"
+}
+
+# --- 3. gh_pr_exists_rest shape -------------------------------------------
+d3="${WORK}/rest"; make_gh "$d3" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'call %s\n' "$*" >> "${GH_LOG:?}"
+case "$2" in
+  repos/example/repo/pulls\?*)
+    printf '[{"number":42,"title":"t","body":"issue #7","state":"open","created_at":"2026-01-01T00:00:00Z","merged_at":null,"html_url":"https://github.com/example/repo/pull/42","head":{"ref":"feat/x","sha":"abc","repo":{"name":"repo","full_name":"example/repo","owner":{"login":"example"}}},"base":{"ref":"main","repo":{"full_name":"example/repo"}}}]\n' ;;
+  *) printf '[]\n' ;;
+esac
+SHIM
+(
+  export PATH="${d3}/bin:${PATH}" GH_LOG="${d3}/log"; : > "$GH_LOG"
+  out="$(gh_pr_exists_rest example/repo feat/x)"
+  printf '%s' "$out" | jq -e '.[0].number == 42 and .[0].state == "OPEN" and .[0].headRefName == "feat/x" and .[0].baseRefName == "main" and .[0].isCrossRepository == false' >/dev/null \
+    || { echo "REST shape mismatch: $out" >&2; exit 1; }
+) || fail "gh_pr_exists_rest must map REST /pulls into the gh --json shape"
+ok "gh_pr_exists_rest maps REST /pulls into gh --json shape"
+
+# --- 4a. rate-limit waits for authoritative reset then retries -------------
+d4a="${WORK}/wait"; make_gh "$d4a" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${GH_LOG:?}"; printf 'call %s\n' "$*" >> "$log"
+case "${1:-}-${2:-}" in
+  api-rate_limit)
+    now="$(date +%s)"
+    printf '{"resources":{"graphql":{"remaining":0,"reset":%s},"core":{"remaining":0,"reset":%s}}}\n' "$now" "$now" ;;
+  pr-list)
+    n="$(grep -c '^call pr list' "$log")"
+    if [ "$n" -le 1 ]; then echo "GraphQL: API rate limit already exceeded" >&2; exit 1; fi
+    printf '[]\n' ;;
+  *) exit 1 ;;
+esac
+SHIM
+(
+  set +e
+  export PATH="${d4a}/bin:${PATH}" GH_LOG="${d4a}/log"; : > "$GH_LOG"
+  rc=0
+  GH_RETRY_REST_FALLBACK="" _gh_retry_core "pr list" pr list --repo example/repo --head feat/x >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || { echo "rc=$rc" >&2; cat "$GH_LOG" >&2; exit 1; }
+  grep -q '^call api rate_limit' "$GH_LOG" || { echo "rate_limit endpoint not consulted" >&2; exit 1; }
+  [ "$(grep -c '^call pr list' "$GH_LOG")" -eq 2 ] || { echo "expected 2 pr list attempts" >&2; cat "$GH_LOG" >&2; exit 1; }
+) || fail "rate-limit must wait for the authoritative reset (gh api rate_limit) then retry"
+ok "rate-limit waits for authoritative reset then retries"
+
+# --- 4b. REST fallback when GraphQL exhausted but core has budget ----------
+d4b="${WORK}/restfb"; make_gh "$d4b" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${GH_LOG:?}"; printf 'call %s\n' "$*" >> "$log"
+case "${1:-}-${2:-}" in
+  api-rate_limit)
+    now="$(date +%s)"
+    printf '{"resources":{"graphql":{"remaining":0,"reset":%s},"core":{"remaining":4000,"reset":%s}}}\n' "$((now+3600))" "$now" ;;
+  api-*)
+    case "$2" in
+      repos/example/repo/pulls\?*)
+        printf '[{"number":88,"title":"t","body":"b","state":"open","created_at":"2026-01-01T00:00:00Z","merged_at":null,"html_url":"https://github.com/example/repo/pull/88","head":{"ref":"feat/x","sha":"abc","repo":{"name":"repo","full_name":"example/repo","owner":{"login":"example"}}},"base":{"ref":"main","repo":{"full_name":"example/repo"}}}]\n' ;;
+      *) printf '[]\n' ;;
+    esac ;;
+  pr-list) echo "GraphQL: API rate limit exceeded" >&2; exit 1 ;;
+  *) exit 1 ;;
+esac
+SHIM
+(
+  set +e
+  export PATH="${d4b}/bin:${PATH}" GH_LOG="${d4b}/log"; : > "$GH_LOG"
+  _fb() { gh_pr_exists_rest example/repo feat/x; }
+  rc=0
+  out="$(GH_RETRY_REST_FALLBACK=_fb _gh_retry_core "pr list" pr list --repo example/repo --head feat/x 2>"${d4b}/err")" || rc=$?
+  [ "$rc" -eq 0 ] || { echo "rc=$rc" >&2; cat "$GH_LOG" "${d4b}/err" >&2; exit 1; }
+  printf '%s' "$out" | jq -e '.[0].number == 88' >/dev/null || { echo "REST fallback output missing: $out" >&2; exit 1; }
+  grep -qi 'REST /pulls fallback' "${d4b}/err" || { echo "REST fallback not logged as WARNING" >&2; cat "${d4b}/err" >&2; exit 1; }
+  [ "$(grep -c '^call pr list' "$GH_LOG")" -eq 1 ] || { echo "should not block on GraphQL when REST serves" >&2; cat "$GH_LOG" >&2; exit 1; }
+) || fail "REST fallback must serve PR-existence when GraphQL exhausted but core has budget"
+ok "REST fallback serves PR-existence when GraphQL exhausted but core has budget"
+
+# --- 4c. auth errors are never retried ------------------------------------
+d4c="${WORK}/auth"; make_gh "$d4c" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'call %s\n' "$*" >> "${GH_LOG:?}"
+echo "HTTP 401: Bad credentials" >&2
+exit 1
+SHIM
+(
+  set +e
+  export PATH="${d4c}/bin:${PATH}" GH_LOG="${d4c}/log"; : > "$GH_LOG"
+  rc=0
+  _gh_retry_core "pr view" pr view 1 >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || { echo "auth must be non-zero" >&2; exit 1; }
+  [ "$(grep -c '^call ' "$GH_LOG")" -eq 1 ] || { echo "auth must not retry" >&2; cat "$GH_LOG" >&2; exit 1; }
+) || fail "auth errors (401 / Bad credentials) must never be retried"
+ok "auth errors are terminal (no retry)"
+
+# --- 4d. generic 5xx keeps the short-backoff 3-attempt behavior ------------
+d4d="${WORK}/transient"; make_gh "$d4d" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'call %s\n' "$*" >> "${GH_LOG:?}"
+echo "HTTP 503 temporary GitHub API failure" >&2
+exit 1
+SHIM
+(
+  set +e
+  export PATH="${d4d}/bin:${PATH}" GH_LOG="${d4d}/log"; : > "$GH_LOG"
+  rc=0
+  _gh_retry_core "pr list" pr list --repo example/repo --head feat/x >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || { echo "persistent 5xx must fail closed" >&2; exit 1; }
+  [ "$(grep -c '^call pr list' "$GH_LOG")" -eq 3 ] || { echo "transient must keep 3 attempts" >&2; cat "$GH_LOG" >&2; exit 1; }
+  grep -q '^call api rate_limit' "$GH_LOG" && { echo "transient must not consult rate_limit reset" >&2; exit 1; }
+  true
+) || fail "generic 5xx/network errors must keep the short-backoff 3-attempt behavior"
+ok "generic 5xx keeps short-backoff 3-attempt behavior"
+
+echo "PASS: gh rate-limit backoff helper contracts are covered (${PASS_COUNT} checks)."

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -251,11 +251,7 @@ steps:
       ISSUE_TITLE="${TASK_DESC//$'\n'/ }"; ISSUE_TITLE="${ISSUE_TITLE//$'\r'/ }"; ISSUE_TITLE="${ISSUE_TITLE:0:200}"
       SANITIZED_ISSUE_REQS="$(printf '%s\n' "$FINAL_REQUIREMENTS" | awk '/^ℹ NODE_OPTIONS=--max-old-space-size=[0-9]+ \(saved preference\)(\. To change: .+)?$/ { next } { print }')"  # sanitize only launcher "ℹ NODE_OPTIONS=--max-old-space-size=N (saved preference). To change: ~/.amplihack/config" notices; preserve legitimate NODE_OPTIONS task text such as "Ensure the workflow rejects unsafe NODE_OPTIONS values"
       HOST_TYPE="${REMOTE_HOST_TYPE:-other}"; EXISTING_ISSUE_NUMBER="${ISSUE_NUMBER:-}"
-      case "$HOST_TYPE" in
-        github|azdo|other) ;;
-        azure-devops) HOST_TYPE="azdo" ;;
-        *) echo "WARN: Unexpected REMOTE_HOST_TYPE — using local tracking" >&2; HOST_TYPE="other" ;;
-      esac
+      case "$HOST_TYPE" in github|azdo|other) ;; azure-devops) HOST_TYPE="azdo" ;; *) echo "WARN: Unexpected REMOTE_HOST_TYPE — using local tracking" >&2; HOST_TYPE="other" ;; esac
       derive_local_tracking_id() {
         if [[ "$EXISTING_ISSUE_NUMBER" =~ ^#?([0-9]+)$ ]]; then
           printf 'local-issue-%s' "${BASH_REMATCH[1]}"
@@ -285,46 +281,24 @@ steps:
       if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then echo "[skip] not a git repo — using local tracking" >&2; emit_local_metadata; exit 0; fi
       case "$HOST_TYPE" in
       github)
-        if [ -n "$REF_ISSUE_NUM" ]; then
-          EXISTING_URL=$(timeout 60 gh issue view "$REF_ISSUE_NUM" --json url --jq '.url // ""' 2>/dev/null || echo '')
-          [ -n "$EXISTING_URL" ] && { printf '%s\n' "$EXISTING_URL"; exit 0; }
-        fi
+        if [ -n "$REF_ISSUE_NUM" ]; then EXISTING_URL=$(timeout 60 gh issue view "$REF_ISSUE_NUM" --json url --jq '.url // ""' 2>/dev/null || echo ''); [ -n "$EXISTING_URL" ] && { printf '%s\n' "$EXISTING_URL"; exit 0; }; fi
         SEARCH_Q="${ISSUE_TITLE:0:100}"
-        if [ -n "$SEARCH_Q" ]; then
-          FOUND_URL=$(timeout 60 gh issue list --state open --search "$SEARCH_Q" --json url --jq '.[0].url // ""' 2>/dev/null || echo '')
-          [ -n "$FOUND_URL" ] && { printf '%s\n' "$FOUND_URL"; exit 0; }
-        fi
+        if [ -n "$SEARCH_Q" ]; then FOUND_URL=$(timeout 60 gh issue list --state open --search "$SEARCH_Q" --json url --jq '.[0].url // ""' 2>/dev/null || echo ''); [ -n "$FOUND_URL" ] && { printf '%s\n' "$FOUND_URL"; exit 0; }; fi
         ISSUE_BODY=$(printf '## Task Description\n%s\n\n## Requirements\n%s\n\n## Acceptance Criteria\n- [ ] All explicit requirements met\n- [ ] Tests passing\n- [ ] Philosophy compliant\n- [ ] Documentation updated\n\n## Classification\nGenerated via default-workflow recipe\n' "$TASK_DESC" "$SANITIZED_ISSUE_REQS")
         LABEL_NAME="workflow:default"
         timeout 30 gh label create "$LABEL_NAME" --color "0366d6" --description "Created by default-workflow recipe" 2>/dev/null || true
         gh_create_issue() { timeout 60 gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" "$@" 2>&1; }
         try_gh_create() { GH_ISSUE_RC=0; GH_ISSUE_OUTPUT=$(gh_create_issue --label "$LABEL_NAME") || GH_ISSUE_OUTPUT=$(gh_create_issue) || GH_ISSUE_RC=$?; }
-        # Rate-limit-aware issue creation. A temporarily-exhausted GraphQL quota
-        # ("API rate limit already exceeded") must not abort the whole run. When
-        # the failure is a rate limit (and not a permanent auth error), wait for
-        # the AUTHORITATIVE reset — read via `gh api rate_limit`, which does not
-        # itself consume the core/graphql budget — and retry. The wait is
-        # adaptive (bounded by the observed reset window, not a fixed cap), up to
-        # two reset windows. A clear error is only surfaced if still failing.
+        # Rate-limit-aware issue creation: a temporarily-exhausted GraphQL quota must not abort the run.
+        # On a rate limit (not a permanent auth error) wait for the AUTHORITATIVE reset read via
+        # `gh api rate_limit` (which does not itself consume the core/graphql budget) — adaptive, bounded
+        # by the observed reset window (not a fixed cap), up to two windows — then retry; a clear error is
+        # only surfaced if still failing. Auth errors (401 / Bad credentials) are never retried.
         _issue_is_rate_limit() { printf '%s' "$1" | grep -Eiq 'api rate limit|rate limit already exceeded|secondary rate limit|abuse detection|(^|[^0-9])429([^0-9]|$)|retry-after|x-ratelimit-reset|rate limit'; }
         _issue_is_auth() { printf '%s' "$1" | grep -Eiq 'bad credentials|HTTP 401|(^|[^0-9])401([^0-9]|$)|requires authentication|not logged in'; }
-        _issue_wait_for_reset() {
-          local now epoch waitfor floor=5 buffer=3
-          now=$(date +%s)
-          epoch=$(timeout 30 gh api rate_limit 2>/dev/null | jq -r '.resources.graphql.reset // empty' 2>/dev/null || true)
-          case "$epoch" in ''|*[!0-9]*) epoch="" ;; esac
-          if [ -z "$epoch" ]; then waitfor=$floor; else waitfor=$((epoch - now + buffer)); [ "$waitfor" -lt "$floor" ] && waitfor=$floor; fi
-          echo "WARNING: GitHub GraphQL rate limit hit during issue creation; waiting ${waitfor}s for authoritative reset (adaptive, bounded by reset window)." >&2
-          sleep "$waitfor"
-        }
-        try_gh_create
-        RL_WINDOWS=0
-        while [ "$GH_ISSUE_RC" -ne 0 ] && _issue_is_rate_limit "$GH_ISSUE_OUTPUT" && ! _issue_is_auth "$GH_ISSUE_OUTPUT" && [ "$RL_WINDOWS" -lt 2 ]; do
-          RL_WINDOWS=$((RL_WINDOWS + 1))
-          echo "WARNING: gh issue create hit a GitHub rate limit (reset window ${RL_WINDOWS}/2); waiting for reset before retrying." >&2
-          _issue_wait_for_reset
-          try_gh_create
-        done
+        _issue_wait_for_reset() { local now epoch waitfor floor=5 buffer=3; now=$(date +%s); epoch=$(timeout 30 gh api rate_limit 2>/dev/null | jq -r '.resources.graphql.reset // empty' 2>/dev/null || true); case "$epoch" in ''|*[!0-9]*) epoch="" ;; esac; if [ -z "$epoch" ]; then waitfor=$floor; else waitfor=$((epoch - now + buffer)); [ "$waitfor" -lt "$floor" ] && waitfor=$floor; fi; echo "WARNING: GitHub GraphQL rate limit hit during issue creation; waiting ${waitfor}s for authoritative reset (adaptive, bounded by reset window)." >&2; sleep "$waitfor"; }
+        try_gh_create; RL_WINDOWS=0
+        while [ "$GH_ISSUE_RC" -ne 0 ] && _issue_is_rate_limit "$GH_ISSUE_OUTPUT" && ! _issue_is_auth "$GH_ISSUE_OUTPUT" && [ "$RL_WINDOWS" -lt 2 ]; do RL_WINDOWS=$((RL_WINDOWS + 1)); echo "WARNING: gh issue create hit a GitHub rate limit (reset window ${RL_WINDOWS}/2); waiting for reset before retrying." >&2; _issue_wait_for_reset; try_gh_create; done
         [ "$GH_ISSUE_RC" -eq 0 ] && { printf '%s\n' "$GH_ISSUE_OUTPUT"; exit 0; }
         if [[ "$GH_ISSUE_OUTPUT" =~ Could\ not\ resolve\ to\ a\ Repository|[Rr]epository\ not\ found|[Rr]epository.*inaccessible|HTTP\ 404 ]]; then
           echo "WARNING: GitHub issue creation failed because the repository could not be resolved or accessed; using local tracking metadata instead." >&2

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -294,12 +294,12 @@ steps:
         # purpose (this embedded step runs before any tool script is sourced; keep the two in sync). On a
         # rate limit (not a permanent auth error) wait for the AUTHORITATIVE reset read via `gh api
         # rate_limit` (does not consume the core/graphql budget) — adaptive, bounded by the observed reset
-        # window, up to two windows — then retry. Auth errors (401 / Bad credentials) are never retried.
+        # window with no arbitrary fixed cap — then retry. Auth errors (401 / Bad credentials) are never retried.
         _issue_is_rate_limit() { printf '%s' "$1" | grep -Eiq 'api rate limit|rate limit already exceeded|secondary rate limit|abuse detection|(^|[^0-9])429([^0-9]|$)|retry-after|x-ratelimit-reset|rate limit'; }
         _issue_is_auth() { printf '%s' "$1" | grep -Eiq 'bad credentials|HTTP 401|(^|[^0-9])401([^0-9]|$)|requires authentication|not logged in'; }
         _issue_wait_for_reset() { local now epoch waitfor floor=5 buffer=3; now=$(date +%s); epoch=$(timeout 30 gh api rate_limit 2>/dev/null | jq -r '.resources.graphql.reset // empty' 2>/dev/null || true); case "$epoch" in ''|*[!0-9]*) epoch="" ;; esac; if [ -z "$epoch" ]; then waitfor=$floor; else waitfor=$((epoch - now + buffer)); [ "$waitfor" -lt "$floor" ] && waitfor=$floor; fi; echo "WARNING: GitHub GraphQL rate limit hit during issue creation; waiting ${waitfor}s for authoritative reset (adaptive, bounded by reset window)." >&2; sleep "$waitfor"; }
         try_gh_create; RL_WINDOWS=0
-        while [ "$GH_ISSUE_RC" -ne 0 ] && _issue_is_rate_limit "$GH_ISSUE_OUTPUT" && ! _issue_is_auth "$GH_ISSUE_OUTPUT" && [ "$RL_WINDOWS" -lt 2 ]; do RL_WINDOWS=$((RL_WINDOWS + 1)); echo "WARNING: gh issue create hit a GitHub rate limit (reset window ${RL_WINDOWS}/2); waiting for reset before retrying." >&2; _issue_wait_for_reset; try_gh_create; done
+        while [ "$GH_ISSUE_RC" -ne 0 ] && _issue_is_rate_limit "$GH_ISSUE_OUTPUT" && ! _issue_is_auth "$GH_ISSUE_OUTPUT"; do RL_WINDOWS=$((RL_WINDOWS + 1)); echo "WARNING: gh issue create hit a GitHub rate limit (reset window ${RL_WINDOWS}, no arbitrary cap); waiting for reset before retrying." >&2; _issue_wait_for_reset; try_gh_create; done
         [ "$GH_ISSUE_RC" -eq 0 ] && { printf '%s\n' "$GH_ISSUE_OUTPUT"; exit 0; }
         if [[ "$GH_ISSUE_OUTPUT" =~ Could\ not\ resolve\ to\ a\ Repository|[Rr]epository\ not\ found|[Rr]epository.*inaccessible|HTTP\ 404 ]]; then
           echo "WARNING: GitHub issue creation failed because the repository could not be resolved or accessed; using local tracking metadata instead." >&2

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -299,7 +299,33 @@ steps:
         timeout 30 gh label create "$LABEL_NAME" --color "0366d6" --description "Created by default-workflow recipe" 2>/dev/null || true
         gh_create_issue() { timeout 60 gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" "$@" 2>&1; }
         try_gh_create() { GH_ISSUE_RC=0; GH_ISSUE_OUTPUT=$(gh_create_issue --label "$LABEL_NAME") || GH_ISSUE_OUTPUT=$(gh_create_issue) || GH_ISSUE_RC=$?; }
-        try_gh_create; [ "$GH_ISSUE_RC" -eq 0 ] && { printf '%s\n' "$GH_ISSUE_OUTPUT"; exit 0; }
+        # Rate-limit-aware issue creation. A temporarily-exhausted GraphQL quota
+        # ("API rate limit already exceeded") must not abort the whole run. When
+        # the failure is a rate limit (and not a permanent auth error), wait for
+        # the AUTHORITATIVE reset — read via `gh api rate_limit`, which does not
+        # itself consume the core/graphql budget — and retry. The wait is
+        # adaptive (bounded by the observed reset window, not a fixed cap), up to
+        # two reset windows. A clear error is only surfaced if still failing.
+        _issue_is_rate_limit() { printf '%s' "$1" | grep -Eiq 'api rate limit|rate limit already exceeded|secondary rate limit|abuse detection|(^|[^0-9])429([^0-9]|$)|retry-after|x-ratelimit-reset|rate limit'; }
+        _issue_is_auth() { printf '%s' "$1" | grep -Eiq 'bad credentials|HTTP 401|(^|[^0-9])401([^0-9]|$)|requires authentication|not logged in'; }
+        _issue_wait_for_reset() {
+          local now epoch waitfor floor=5 buffer=3
+          now=$(date +%s)
+          epoch=$(timeout 30 gh api rate_limit 2>/dev/null | jq -r '.resources.graphql.reset // empty' 2>/dev/null || true)
+          case "$epoch" in ''|*[!0-9]*) epoch="" ;; esac
+          if [ -z "$epoch" ]; then waitfor=$floor; else waitfor=$((epoch - now + buffer)); [ "$waitfor" -lt "$floor" ] && waitfor=$floor; fi
+          echo "WARNING: GitHub GraphQL rate limit hit during issue creation; waiting ${waitfor}s for authoritative reset (adaptive, bounded by reset window)." >&2
+          sleep "$waitfor"
+        }
+        try_gh_create
+        RL_WINDOWS=0
+        while [ "$GH_ISSUE_RC" -ne 0 ] && _issue_is_rate_limit "$GH_ISSUE_OUTPUT" && ! _issue_is_auth "$GH_ISSUE_OUTPUT" && [ "$RL_WINDOWS" -lt 2 ]; do
+          RL_WINDOWS=$((RL_WINDOWS + 1))
+          echo "WARNING: gh issue create hit a GitHub rate limit (reset window ${RL_WINDOWS}/2); waiting for reset before retrying." >&2
+          _issue_wait_for_reset
+          try_gh_create
+        done
+        [ "$GH_ISSUE_RC" -eq 0 ] && { printf '%s\n' "$GH_ISSUE_OUTPUT"; exit 0; }
         if [[ "$GH_ISSUE_OUTPUT" =~ Could\ not\ resolve\ to\ a\ Repository|[Rr]epository\ not\ found|[Rr]epository.*inaccessible|HTTP\ 404 ]]; then
           echo "WARNING: GitHub issue creation failed because the repository could not be resolved or accessed; using local tracking metadata instead." >&2
           echo "WARNING: gh reported repository access/resolution failure." >&2

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -290,10 +290,11 @@ steps:
         gh_create_issue() { timeout 60 gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" "$@" 2>&1; }
         try_gh_create() { GH_ISSUE_RC=0; GH_ISSUE_OUTPUT=$(gh_create_issue --label "$LABEL_NAME") || GH_ISSUE_OUTPUT=$(gh_create_issue) || GH_ISSUE_RC=$?; }
         # Rate-limit-aware issue creation: a temporarily-exhausted GraphQL quota must not abort the run.
-        # On a rate limit (not a permanent auth error) wait for the AUTHORITATIVE reset read via
-        # `gh api rate_limit` (which does not itself consume the core/graphql budget) — adaptive, bounded
-        # by the observed reset window (not a fixed cap), up to two windows — then retry; a clear error is
-        # only surfaced if still failing. Auth errors (401 / Bad credentials) are never retried.
+        # Mirrors the classifier/wait-for-reset policy in tools/workflow_gh_retry.sh but kept inline on
+        # purpose (this embedded step runs before any tool script is sourced; keep the two in sync). On a
+        # rate limit (not a permanent auth error) wait for the AUTHORITATIVE reset read via `gh api
+        # rate_limit` (does not consume the core/graphql budget) — adaptive, bounded by the observed reset
+        # window, up to two windows — then retry. Auth errors (401 / Bad credentials) are never retried.
         _issue_is_rate_limit() { printf '%s' "$1" | grep -Eiq 'api rate limit|rate limit already exceeded|secondary rate limit|abuse detection|(^|[^0-9])429([^0-9]|$)|retry-after|x-ratelimit-reset|rate limit'; }
         _issue_is_auth() { printf '%s' "$1" | grep -Eiq 'bad credentials|HTTP 401|(^|[^0-9])401([^0-9]|$)|requires authentication|not logged in'; }
         _issue_wait_for_reset() { local now epoch waitfor floor=5 buffer=3; now=$(date +%s); epoch=$(timeout 30 gh api rate_limit 2>/dev/null | jq -r '.resources.graphql.reset // empty' 2>/dev/null || true); case "$epoch" in ''|*[!0-9]*) epoch="" ;; esac; if [ -z "$epoch" ]; then waitfor=$floor; else waitfor=$((epoch - now + buffer)); [ "$waitfor" -lt "$floor" ] && waitfor=$floor; fi; echo "WARNING: GitHub GraphQL rate limit hit during issue creation; waiting ${waitfor}s for authoritative reset (adaptive, bounded by reset window)." >&2; sleep "$waitfor"; }

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -28,6 +28,10 @@ terminal_status="${PUBLISH_STATE:-active-pr}"
 final_status_rc=0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PR_SCOPE_HELPER="${WORKFLOW_PR_SCOPE_HELPER:-${SCRIPT_DIR}/workflow_pr_scope.sh}"
+GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}"
+[ -f "$GH_RETRY_HELPER" ] || { echo "ERROR: workflow_final_status.sh requires the shared retry helper at $GH_RETRY_HELPER" >&2; exit 2; }
+# shellcheck source=/dev/null
+. "$GH_RETRY_HELPER"
 # workflow_pr_scope.sh validates headRefName, baseRefName, headRefOid,
 # isCrossRepository, expected_pr_title_prefix, and created_after.
 
@@ -35,33 +39,12 @@ sanitize_gh_stderr() {
   sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
 }
 
-is_transient_gh_error() {
-  [ -s "$1" ] && grep -Eiq 'HTTP 5[0-9][0-9]|(^|[^0-9])(502|503|504)([^0-9]|$)|rate limit|timed out|timeout|temporar|connection reset|connection refused|TLS handshake|network|server error' "$1"
-}
-
+# Best-effort final PR status read. Rate limits now wait for the authoritative
+# reset (via the shared driver) instead of burning three immediate retries; the
+# caller already tolerates failure (`|| true`) and continues with the
+# terminal-state result. No REST fallback here: this is a display-only read.
 gh_pr_view_with_retry() {
-  local stderr_file output status attempt delay=1
-  for attempt in 1 2 3; do
-    stderr_file=$(mktemp -t step22b-gh-pr-view-XXXXXX)
-    if output=$(timeout 60 gh pr view "$@" 2>"$stderr_file"); then
-      rm -f "$stderr_file"
-      printf '%s\n' "$output"
-      return 0
-    else
-      status=$?
-    fi
-    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
-      echo "WARNING: final PR status lookup failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
-      rm -f "$stderr_file"
-      sleep "$delay"
-      delay=$((delay * 2))
-      continue
-    fi
-    echo "WARNING: final PR status lookup failed (exit ${status}); continuing with terminal-state result" >&2
-    [ ! -s "$stderr_file" ] || echo "gh pr view stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
-    rm -f "$stderr_file"
-    return "$status"
-  done
+  _gh_retry_core "final PR status pr view" pr view "$@"
 }
 
 normalize_bool() {

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -39,12 +39,14 @@ sanitize_gh_stderr() {
   sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
 }
 
-# Best-effort final PR status read. Rate limits now wait for the authoritative
-# reset (via the shared driver) instead of burning three immediate retries; the
-# caller already tolerates failure (`|| true`) and continues with the
-# terminal-state result. No REST fallback here: this is a display-only read.
+# Best-effort final PR status read. This is a display-only read that the caller
+# already tolerates failing (`|| true`); it must NOT stall the workflow's final
+# reporting step waiting on a rate-limit reset (which can be up to an hour out).
+# Pin GH_RETRY_MAX_RL_WINDOWS=0 so a rate-limit fails fast instead of sleeping
+# through reset windows. Transient errors still get the short bounded retries.
+# No REST fallback here: this is a display-only read.
 gh_pr_view_with_retry() {
-  _gh_retry_core "final PR status pr view" pr view "$@"
+  GH_RETRY_MAX_RL_WINDOWS=0 _gh_retry_core "final PR status pr view" pr view "$@"
 }
 
 normalize_bool() {

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -28,12 +28,12 @@ terminal_status="${PUBLISH_STATE:-active-pr}"
 final_status_rc=0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PR_SCOPE_HELPER="${WORKFLOW_PR_SCOPE_HELPER:-${SCRIPT_DIR}/workflow_pr_scope.sh}"
+# workflow_pr_scope.sh validates headRefName, baseRefName, headRefOid,
+# isCrossRepository, expected_pr_title_prefix, and created_after.
 GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}"
 [ -f "$GH_RETRY_HELPER" ] || { echo "ERROR: workflow_final_status.sh requires the shared retry helper at $GH_RETRY_HELPER" >&2; exit 2; }
 # shellcheck source=/dev/null
 . "$GH_RETRY_HELPER"
-# workflow_pr_scope.sh validates headRefName, baseRefName, headRefOid,
-# isCrossRepository, expected_pr_title_prefix, and created_after.
 
 sanitize_gh_stderr() {
   sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500

--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -24,7 +24,6 @@ terminal_no_op="false"
 missing_evidence=""
 invalid_evidence=""
 normalized_bool="false"
-terminal_status="${PUBLISH_STATE:-active-pr}"
 final_status_rc=0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PR_SCOPE_HELPER="${WORKFLOW_PR_SCOPE_HELPER:-${SCRIPT_DIR}/workflow_pr_scope.sh}"

--- a/amplifier-bundle/tools/workflow_gh_retry.sh
+++ b/amplifier-bundle/tools/workflow_gh_retry.sh
@@ -237,8 +237,10 @@ gh_pr_number_from_url() {
 #                           consult for reset epoch on a rate-limit.
 #   GH_RETRY_MAX_TRANSIENT  integer            (default: 3) — attempts for the
 #                           generic transient path (preserves legacy behaviour).
-#   GH_RETRY_MAX_RL_WINDOWS integer            (default: 2) — number of reset
-#                           windows to wait through on a persistent rate-limit.
+#   GH_RETRY_MAX_RL_WINDOWS integer            (default: unset) — optional
+#                           safety valve for callers that explicitly want to
+#                           cap reset windows. Unset means no arbitrary cap:
+#                           keep honoring the authoritative reset window.
 #   GH_RETRY_REST_FALLBACK  function name      (default: unset) — when set, a
 #                           READ path: on rate-limit the driver serves the
 #                           request via this REST fallback (core budget) instead
@@ -251,7 +253,7 @@ _gh_retry_core() {
   local label="${1:-gh}"; shift
   local resource="${GH_RETRY_RESOURCE:-graphql}"
   local max_transient="${GH_RETRY_MAX_TRANSIENT:-3}"
-  local max_windows="${GH_RETRY_MAX_RL_WINDOWS:-2}"
+  local max_windows="${GH_RETRY_MAX_RL_WINDOWS:-}"
   local rest_fallback="${GH_RETRY_REST_FALLBACK:-}"
   local attempt=0 rl_windows=0 delay=1
   local stderr_file output status class fb_out
@@ -259,7 +261,8 @@ _gh_retry_core() {
 
   while :; do
     attempt=$((attempt + 1))
-    stderr_file="$(mktemp -t workflow-gh-retry-XXXXXX)"
+    stderr_file="${GH_RETRY_TMPDIR:-.}/.workflow-gh-retry-${$}-${attempt}-${RANDOM}.stderr"
+    : >"$stderr_file" || return 1
     if output="$(timeout 60 gh "$@" 2>"$stderr_file")"; then
       rm -f "$stderr_file"
       printf '%s\n' "$output"
@@ -292,9 +295,13 @@ _gh_retry_core() {
         fi
         # Write path, or core also exhausted: wait for the authoritative reset
         # (bounded by the observed reset window) and retry.
-        if [ "$rl_windows" -lt "$max_windows" ]; then
+        if [ -z "$max_windows" ] || [ "$rl_windows" -lt "$max_windows" ]; then
           rl_windows=$((rl_windows + 1))
-          echo "WARNING: gh ${label} hit a GitHub rate limit (exit ${status}); waiting for reset (window ${rl_windows}/${max_windows}): $(gh_sanitize_stderr "$stderr_file")" >&2
+          if [ -n "$max_windows" ]; then
+            echo "WARNING: gh ${label} hit a GitHub rate limit (exit ${status}); waiting for reset (window ${rl_windows}/${max_windows}): $(gh_sanitize_stderr "$stderr_file")" >&2
+          else
+            echo "WARNING: gh ${label} hit a GitHub rate limit (exit ${status}); waiting for reset (window ${rl_windows}, no arbitrary cap): $(gh_sanitize_stderr "$stderr_file")" >&2
+          fi
           gh_wait_for_rate_limit "$resource" "$stderr_file"
           rm -f "$stderr_file"
           continue

--- a/amplifier-bundle/tools/workflow_gh_retry.sh
+++ b/amplifier-bundle/tools/workflow_gh_retry.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# workflow_gh_retry.sh — shared GitHub/az rate-limit-aware retry helpers.
+#
+# Sourced by the default-workflow helper scripts (workflow_publish_pr.sh,
+# workflow_pr_scope.sh, workflow_final_status.sh, workflow_pr_ready.sh) so a
+# temporarily-exhausted GitHub API quota does not fail the workflow closed.
+#
+# Motivation (observed in production): when the GraphQL quota is exhausted
+# (0/5000, reset up to ~1h later) the previous helpers classified "rate limit"
+# as a generic transient error and retried ~3x with an immediate/short backoff.
+# All retries hit the still-exhausted quota and the step failed closed. This
+# library distinguishes three error classes and handles them differently:
+#
+#   * auth        -> permanent (401 / Bad credentials): NEVER retried.
+#   * rate_limit  -> wait for the AUTHORITATIVE reset (adaptive, bounded by the
+#                    observed reset window, not an arbitrary fixed cap) and/or
+#                    fall back to a REST read on the core budget.
+#   * transient   -> generic 5xx/network: existing short-backoff, 3 attempts.
+#
+# Error-handling convention (see amplifier-bundle/context/PHILOSOPHY.md):
+# no silent fallbacks. Every fallback is logged (WARNING) and the caller still
+# fails closed when both GraphQL and REST are exhausted.
+#
+# This file only DEFINES functions; sourcing it has no side effects.
+
+# GH_RETRY_LAST_CLASS is a deliberate cross-script global read by sourcing
+# helpers (e.g. to branch on rate_limit_rest); shellcheck cannot see that use.
+# shellcheck disable=SC2034
+
+# --- stderr sanitiser (redacts embedded credentials) -----------------------
+gh_sanitize_stderr() {
+  [ -n "${1:-}" ] && [ -s "$1" ] || return 0
+  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
+}
+
+# --- classifier ------------------------------------------------------------
+# classify_gh_error <stderr_file> -> echoes: auth | rate_limit | transient | other
+#
+# Order matters: permanent auth errors are checked first (never retried), then
+# rate-limit signals (wait-for-reset), then generic transient signals.
+classify_gh_error() {
+  local f="${1:-}"
+  [ -n "$f" ] && [ -s "$f" ] || { printf 'other\n'; return 0; }
+
+  # Permanent authentication/authorisation failures — must NOT be retried.
+  if grep -Eiq 'bad credentials|HTTP 401|(^|[^0-9])401([^0-9]|$)|unauthorized|authentication failed|requires authentication|gh auth login|not logged in|token .*(expired|invalid)|invalid .*token' "$f"; then
+    printf 'auth\n'; return 0
+  fi
+
+  # Explicit rate-limit signals (primary + secondary + abuse detection).
+  if grep -Eiq 'api rate limit exceeded|rate limit already exceeded|secondary rate limit|abuse detection|retry-after|x-ratelimit-reset|rate limit|HTTP 429|(^|[^0-9])429([^0-9]|$)' "$f"; then
+    printf 'rate_limit\n'; return 0
+  fi
+
+  # A bare 403 is treated as a (secondary) rate-limit signal UNLESS it clearly
+  # reads as a permission error, in which case it is not retryable.
+  if grep -Eiq 'HTTP 403|(^|[^0-9])403([^0-9]|$)' "$f"; then
+    if grep -Eiq 'resource not accessible|must have admin|not authorized|insufficient|permission' "$f"; then
+      printf 'other\n'; return 0
+    fi
+    printf 'rate_limit\n'; return 0
+  fi
+
+  # Generic transient server/network errors — short-backoff retry.
+  if grep -Eiq 'HTTP 5[0-9][0-9]|(^|[^0-9])(500|502|503|504)([^0-9]|$)|timed out|timeout|temporar|connection reset|connection refused|TLS handshake|network|server error|i/o timeout|no such host|EOF' "$f"; then
+    printf 'transient\n'; return 0
+  fi
+
+  printf 'other\n'
+}
+
+# --- authoritative reset lookup -------------------------------------------
+# gh_rate_limit_reset_epoch <resource> -> echoes epoch seconds, or returns 1.
+#
+# Uses the `gh api rate_limit` endpoint, which does NOT itself consume the
+# core/graphql budget.
+gh_rate_limit_reset_epoch() {
+  local resource="${1:-graphql}" json reset
+  command -v gh >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  json="$(gh api rate_limit 2>/dev/null)" || return 1
+  [ -n "$json" ] || return 1
+  reset="$(printf '%s' "$json" | jq -r --arg r "$resource" '.resources[$r].reset // empty' 2>/dev/null)" || return 1
+  case "$reset" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$reset"
+}
+
+# gh_rate_limit_remaining <resource> -> echoes remaining count, or returns 1.
+gh_rate_limit_remaining() {
+  local resource="${1:-core}" json remaining
+  command -v gh >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  json="$(gh api rate_limit 2>/dev/null)" || return 1
+  [ -n "$json" ] || return 1
+  remaining="$(printf '%s' "$json" | jq -r --arg r "$resource" '.resources[$r].remaining // empty' 2>/dev/null)" || return 1
+  case "$remaining" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$remaining"
+}
+
+# _gh_core_has_budget -> returns 0 when the REST/core budget still has requests.
+_gh_core_has_budget() {
+  local remaining
+  remaining="$(gh_rate_limit_remaining core 2>/dev/null)" || return 1
+  [ "$remaining" -gt 0 ]
+}
+
+# --- reset epoch from response headers (fallback) --------------------------
+# gh_reset_epoch_from_stderr <stderr_file> -> echoes epoch seconds, or returns 1.
+# Honors a `Retry-After: <seconds>` or `X-RateLimit-Reset: <epoch>` header when
+# `gh api rate_limit` is unavailable.
+gh_reset_epoch_from_stderr() {
+  local f="${1:-}" now retry reset
+  [ -n "$f" ] && [ -s "$f" ] || return 1
+  now="$(date +%s)"
+  retry="$(grep -Eio 'retry-after:[[:space:]]*[0-9]+' "$f" | grep -Eo '[0-9]+' | head -n1 || true)"
+  if [ -n "$retry" ]; then
+    printf '%s\n' "$((now + retry))"; return 0
+  fi
+  reset="$(grep -Eio 'x-ratelimit-reset:[[:space:]]*[0-9]+' "$f" | grep -Eo '[0-9]+' | head -n1 || true)"
+  if [ -n "$reset" ]; then
+    printf '%s\n' "$reset"; return 0
+  fi
+  return 1
+}
+
+# --- adaptive wait ---------------------------------------------------------
+# gh_wait_for_rate_limit <resource> <stderr_file>
+#
+# Sleeps until just after the authoritative reset for <resource>. There is NO
+# arbitrary fixed cap: the wait is bounded by the observed reset window. A small
+# floor (5s) and buffer (3s) guard against negative/absent values and clock
+# skew. NO-TIMEOUT policy: this is a liveness-bounded sleep, not a wall clock.
+gh_wait_for_rate_limit() {
+  local resource="${1:-graphql}" stderr_file="${2:-}"
+  local now epoch wait floor=5 buffer=3
+  now="$(date +%s)"
+  epoch="$(gh_rate_limit_reset_epoch "$resource" 2>/dev/null || true)"
+  if [ -z "$epoch" ] && [ -n "$stderr_file" ]; then
+    epoch="$(gh_reset_epoch_from_stderr "$stderr_file" 2>/dev/null || true)"
+  fi
+  if [ -z "$epoch" ]; then
+    wait="$floor"
+    echo "WARNING: GitHub ${resource} rate limit hit; reset time unknown, waiting ${wait}s (floor) before re-probing." >&2
+  else
+    wait=$(( epoch - now + buffer ))
+    [ "$wait" -lt "$floor" ] && wait="$floor"
+    echo "WARNING: GitHub ${resource} rate limit hit; waiting ${wait}s for authoritative reset (adaptive, bounded by reset window)." >&2
+  fi
+  sleep "$wait"
+}
+
+# --- REST existence fallback ----------------------------------------------
+# gh_pr_exists_rest <OWNER/REPO> <branch> -> echoes a JSON array shaped like
+# `gh pr list --json ...` output so callers can consume it identically.
+#
+# Uses the REST /pulls endpoint (core budget) so a GraphQL-only outage does not
+# block PR-existence checks. Returns 1 when the REST call itself fails.
+gh_pr_exists_rest() {
+  local repo="${1:-}" branch="${2:-}" owner rest
+  [ -n "$repo" ] && [ -n "$branch" ] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  owner="${repo%%/*}"
+  rest="$(gh api "repos/${repo}/pulls?head=${owner}:${branch}&state=all&per_page=100" 2>/dev/null)" || return 1
+  [ -n "$rest" ] || return 1
+  printf '%s' "$rest" | jq -c '
+    (if type == "array" then . else [] end)
+    | map({
+        number: .number,
+        title: (.title // ""),
+        body: (.body // ""),
+        state: (if (.merged_at // null) != null then "MERGED"
+                elif ((.state // "") | ascii_downcase) == "open" then "OPEN"
+                else "CLOSED" end),
+        createdAt: (.created_at // ""),
+        mergedAt: (.merged_at // ""),
+        url: (.html_url // ""),
+        headRefName: (.head.ref // ""),
+        baseRefName: (.base.ref // ""),
+        headRefOid: (.head.sha // ""),
+        headRepositoryOwner: { login: (.head.repo.owner.login // "") },
+        headRepository: { name: (.head.repo.name // "") },
+        isCrossRepository: (((.head.repo.full_name // "") != (.base.repo.full_name // "")))
+      })' 2>/dev/null || return 1
+}
+
+# gh_pr_view_rest <OWNER/REPO> <pr_number> -> echoes a single JSON object shaped
+# like `gh pr view --json ...` output (core budget). Returns 1 on failure.
+gh_pr_view_rest() {
+  local repo="${1:-}" number="${2:-}" rest
+  [ -n "$repo" ] || return 1
+  case "$number" in ''|*[!0-9]*) return 1 ;; esac
+  command -v gh >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  rest="$(gh api "repos/${repo}/pulls/${number}" 2>/dev/null)" || return 1
+  [ -n "$rest" ] || return 1
+  printf '%s' "$rest" | jq -c '{
+      number: .number,
+      title: (.title // ""),
+      body: (.body // ""),
+      state: (if (.merged_at // null) != null then "MERGED"
+              elif ((.state // "") | ascii_downcase) == "open" then "OPEN"
+              else "CLOSED" end),
+      createdAt: (.created_at // ""),
+      mergedAt: (.merged_at // ""),
+      url: (.html_url // ""),
+      headRefName: (.head.ref // ""),
+      baseRefName: (.base.ref // ""),
+      headRefOid: (.head.sha // ""),
+      headRepositoryOwner: { login: (.head.repo.owner.login // "") },
+      headRepository: { name: (.head.repo.name // "") },
+      isCrossRepository: (((.head.repo.full_name // "") != (.base.repo.full_name // "")))
+    }' 2>/dev/null || return 1
+}
+
+# gh_pr_number_from_url <url> -> echoes the trailing pull-request number, or 1.
+gh_pr_number_from_url() {
+  local url="${1:-}" num
+  num="${url##*/pull/}"
+  num="${num%%[!0-9]*}"
+  case "$num" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$num"
+}
+
+# --- retry driver ----------------------------------------------------------
+# _gh_retry_core <label> <gh-arg>...
+#
+#   stdout : command output on success (or REST fallback output).
+#   return : 0 on success; otherwise the last gh exit status.
+#
+# Behaviour is tuned via environment variables (all optional):
+#   GH_RETRY_RESOURCE       graphql|core       (default: graphql) — resource to
+#                           consult for reset epoch on a rate-limit.
+#   GH_RETRY_MAX_TRANSIENT  integer            (default: 3) — attempts for the
+#                           generic transient path (preserves legacy behaviour).
+#   GH_RETRY_MAX_RL_WINDOWS integer            (default: 2) — number of reset
+#                           windows to wait through on a persistent rate-limit.
+#   GH_RETRY_REST_FALLBACK  function name      (default: unset) — when set, a
+#                           READ path: on rate-limit the driver serves the
+#                           request via this REST fallback (core budget) instead
+#                           of blocking, logging a WARNING. Leave UNSET for write
+#                           paths so they wait-for-reset with no REST fallback.
+#
+# Sets GH_RETRY_LAST_CLASS to the class of the final failure (or
+# `success`/`rate_limit_rest`) for callers that need to branch on it.
+_gh_retry_core() {
+  local label="${1:-gh}"; shift
+  local resource="${GH_RETRY_RESOURCE:-graphql}"
+  local max_transient="${GH_RETRY_MAX_TRANSIENT:-3}"
+  local max_windows="${GH_RETRY_MAX_RL_WINDOWS:-2}"
+  local rest_fallback="${GH_RETRY_REST_FALLBACK:-}"
+  local attempt=0 rl_windows=0 delay=1
+  local stderr_file output status class fb_out
+  GH_RETRY_LAST_CLASS=""
+
+  while :; do
+    attempt=$((attempt + 1))
+    stderr_file="$(mktemp -t workflow-gh-retry-XXXXXX)"
+    if output="$(timeout 60 gh "$@" 2>"$stderr_file")"; then
+      rm -f "$stderr_file"
+      printf '%s\n' "$output"
+      GH_RETRY_LAST_CLASS="success"
+      return 0
+    else
+      status=$?
+    fi
+    class="$(classify_gh_error "$stderr_file")"
+    GH_RETRY_LAST_CLASS="$class"
+
+    case "$class" in
+      auth)
+        echo "ERROR: gh ${label} failed with an authentication error (exit ${status}); not retrying: $(gh_sanitize_stderr "$stderr_file")" >&2
+        rm -f "$stderr_file"
+        return "$status"
+        ;;
+      rate_limit)
+        # READ path: prefer an immediate REST fallback when the core budget is
+        # still available, rather than blocking for the GraphQL reset.
+        if [ -n "$rest_fallback" ] && _gh_core_has_budget; then
+          if fb_out="$("$rest_fallback")"; then
+            echo "WARNING: gh ${label}: GraphQL rate-limited; served via REST /pulls fallback on the core budget (explicit fallback)." >&2
+            rm -f "$stderr_file"
+            printf '%s\n' "$fb_out"
+            GH_RETRY_LAST_CLASS="rate_limit_rest"
+            return 0
+          fi
+          echo "WARNING: gh ${label}: REST fallback attempt failed; will wait for the authoritative reset instead." >&2
+        fi
+        # Write path, or core also exhausted: wait for the authoritative reset
+        # (bounded by the observed reset window) and retry.
+        if [ "$rl_windows" -lt "$max_windows" ]; then
+          rl_windows=$((rl_windows + 1))
+          echo "WARNING: gh ${label} hit a GitHub rate limit (exit ${status}); waiting for reset (window ${rl_windows}/${max_windows}): $(gh_sanitize_stderr "$stderr_file")" >&2
+          gh_wait_for_rate_limit "$resource" "$stderr_file"
+          rm -f "$stderr_file"
+          continue
+        fi
+        # Windows exhausted: last-ditch REST for reads before failing closed.
+        if [ -n "$rest_fallback" ] && _gh_core_has_budget; then
+          if fb_out="$("$rest_fallback")"; then
+            echo "WARNING: gh ${label}: GraphQL still exhausted after ${rl_windows} reset window(s); served via REST fallback." >&2
+            rm -f "$stderr_file"
+            printf '%s\n' "$fb_out"
+            GH_RETRY_LAST_CLASS="rate_limit_rest"
+            return 0
+          fi
+        fi
+        rm -f "$stderr_file"
+        return "$status"
+        ;;
+      transient)
+        if [ "$attempt" -lt "$max_transient" ]; then
+          echo "WARNING: gh ${label} failed transiently (exit ${status}); retrying (${attempt}/${max_transient}): $(gh_sanitize_stderr "$stderr_file")" >&2
+          rm -f "$stderr_file"
+          sleep "$delay"
+          delay=$((delay * 2))
+          continue
+        fi
+        rm -f "$stderr_file"
+        return "$status"
+        ;;
+      *)
+        rm -f "$stderr_file"
+        return "$status"
+        ;;
+    esac
+  done
+}

--- a/amplifier-bundle/tools/workflow_gh_retry.sh
+++ b/amplifier-bundle/tools/workflow_gh_retry.sh
@@ -30,7 +30,11 @@
 # --- stderr sanitiser (redacts embedded credentials) -----------------------
 gh_sanitize_stderr() {
   [ -n "${1:-}" ] && [ -s "$1" ] || return 0
-  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
+  sed -E \
+    -e 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' \
+    -e 's#gh[pousr]_[A-Za-z0-9]{16,}#REDACTED_TOKEN#g' \
+    -e 's#github_pat_[A-Za-z0-9_]{16,}#REDACTED_TOKEN#g' \
+    "$1" | tr '\n' ' ' | head -c 500
 }
 
 # --- classifier ------------------------------------------------------------

--- a/amplifier-bundle/tools/workflow_pr_ready.sh
+++ b/amplifier-bundle/tools/workflow_pr_ready.sh
@@ -199,54 +199,56 @@ pr_target="$(printf '%s' "$scoped_pr_json" | jq -r '.url // .number // empty')"
 
 terminal_status="active-pr"
 closed_unmerged_seen="false"
-for pr_target in "$pr_target"; do
-  if ! pr_json="$(gh_with_retry "pr view" pr view "$pr_target" --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,headRefOid,headRepositoryOwner,headRepository,isCrossRepository)"; then
-    echo "ERROR: unable to inspect PR '$pr_target' with gh; refusing to mutate ambiguous PR state" >&2
-    exit 1
-  fi
-  pr_url=$(printf '%s' "$pr_json" | jq -r '.url // ""')
-  pr_state=$(printf '%s' "$pr_json" | jq -r '.state // ""')
-  pr_is_draft=$(printf '%s' "$pr_json" | jq -r '.isDraft // false')
-  pr_merged_at=$(printf '%s' "$pr_json" | jq -r '.mergedAt // ""')
+if ! pr_json="$(gh_with_retry "pr view" pr view "$pr_target" --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,headRefOid,headRepositoryOwner,headRepository,isCrossRepository)"; then
+  echo "ERROR: unable to inspect PR '$pr_target' with gh; refusing to mutate ambiguous PR state" >&2
+  exit 1
+fi
+pr_url=$(printf '%s' "$pr_json" | jq -r '.url // ""')
+pr_state=$(printf '%s' "$pr_json" | jq -r '.state // ""')
+pr_is_draft=$(printf '%s' "$pr_json" | jq -r '.isDraft // false')
+pr_merged_at=$(printf '%s' "$pr_json" | jq -r '.mergedAt // ""')
 
-  if [ "$pr_state" = "MERGED" ] || [ -n "$pr_merged_at" ]; then
-    terminal_status="already-merged"
-    [ "$pr_state" = "CLOSED" ] && terminal_status="closed-after-merge"
-    echo "INFO: terminal_status=$terminal_status; PR is already merged — no ready-for-review action needed"
-    continue
-  fi
-  if [ "$pr_state" = "CLOSED" ]; then
-    terminal_status="closed-unmerged"
-    closed_unmerged_seen="true"
-    echo "ERROR: terminal_status=closed-unmerged; PR is closed without merge — reopen it or create a new branch intentionally" >&2
-    continue
-  fi
+if [ "$pr_state" = "MERGED" ] || [ -n "$pr_merged_at" ]; then
+  terminal_status="already-merged"
+  [ "$pr_state" = "CLOSED" ] && terminal_status="closed-after-merge"
+  echo "INFO: terminal_status=$terminal_status; PR is already merged — no ready-for-review action needed"
+  echo "=== PR Ready Step Complete (terminal_status=$terminal_status) ==="
+  exit 0
+fi
+if [ "$pr_state" = "CLOSED" ]; then
+  terminal_status="closed-unmerged"
+  closed_unmerged_seen="true"
+  echo "ERROR: terminal_status=closed-unmerged; PR is closed without merge — reopen it or create a new branch intentionally" >&2
+fi
 
-  validate_pr_identity_before_mutation "$pr_json" "$pr_url" || exit 1
+if [ "$closed_unmerged_seen" = "true" ]; then
+  exit 1
+fi
 
-  if [ "$pr_is_draft" = "true" ]; then
-    if ready_output="$(gh_with_retry "pr ready" pr ready "$pr_url")"; then
-      printf '%s\n' "$ready_output"
-    else
-      ready_rc=$?
-      echo "ERROR: gh pr ready failed for '$pr_url' (exit ${ready_rc}); refusing to report successful finalization after mutation failure" >&2
-      exit "$ready_rc"
-    fi
+validate_pr_identity_before_mutation "$pr_json" "$pr_url" || exit 1
+
+if [ "$pr_is_draft" = "true" ]; then
+  if ready_output="$(gh_with_retry "pr ready" pr ready "$pr_url")"; then
+    printf '%s\n' "$ready_output"
   else
-    echo "INFO: PR is already ready for review"
+    ready_rc=$?
+    echo "ERROR: gh pr ready failed for '$pr_url' (exit ${ready_rc}); refusing to report successful finalization after mutation failure" >&2
+    exit "$ready_rc"
   fi
+else
+  echo "INFO: PR is already ready for review"
+fi
 
-  ready_body="## Ready for Final Review
+ready_body="## Ready for Final Review
 
 Workflow steps completed: requirements, design, implementation, tests, code review, philosophy compliance, cleanup, and quality audit.
 
 Ready for merge approval."
-  if comment_output="$(gh_with_retry "pr comment" pr comment "$pr_url" --body "$ready_body")"; then
-    printf '%s\n' "$comment_output"
-  else
-    echo "WARNING: gh pr comment failed for '$pr_url'; PR ready state was still evaluated" >&2
-  fi
-done
+if comment_output="$(gh_with_retry "pr comment" pr comment "$pr_url" --body "$ready_body")"; then
+  printf '%s\n' "$comment_output"
+else
+  echo "WARNING: gh pr comment failed for '$pr_url'; PR ready state was still evaluated" >&2
+fi
 
 if [ "$closed_unmerged_seen" = "true" ]; then
   exit 1

--- a/amplifier-bundle/tools/workflow_pr_ready.sh
+++ b/amplifier-bundle/tools/workflow_pr_ready.sh
@@ -26,34 +26,23 @@ sanitize_gh_stderr() {
   sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
 }
 
-is_transient_gh_error() {
-  [ -s "$1" ] && grep -Eiq 'HTTP 5[0-9][0-9]|(^|[^0-9])(502|503|504)([^0-9]|$)|rate limit|timed out|timeout|temporar|connection reset|connection refused|TLS handshake|network|server error' "$1"
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}"
+if [ ! -f "$GH_RETRY_HELPER" ]; then
+  echo "ERROR: workflow_pr_ready.sh requires the shared retry helper at $GH_RETRY_HELPER" >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
+. "$GH_RETRY_HELPER"
 
+# Rate-limit-aware retry. This helper both reads (pr view) and MUTATES (pr ready,
+# pr comment); per the workflow contract mutation paths must never fall back to
+# REST, so no REST fallback is configured here — a genuine rate limit waits for
+# the authoritative reset and then retries. Auth errors are never retried.
 gh_with_retry() {
-  local label="$1" stderr_file output status attempt delay=1
+  local label="$1"
   shift
-  for attempt in 1 2 3; do
-    stderr_file=$(mktemp -t step21-gh-XXXXXX)
-    if output=$(timeout 60 gh "$@" 2>"$stderr_file"); then
-      rm -f "$stderr_file"
-      printf '%s\n' "$output"
-      return 0
-    else
-      status=$?
-    fi
-    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
-      echo "WARNING: gh $label failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
-      rm -f "$stderr_file"
-      sleep "$delay"
-      delay=$((delay * 2))
-      continue
-    fi
-    echo "WARNING: gh $label failed (exit ${status})" >&2
-    [ ! -s "$stderr_file" ] || echo "gh $label stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
-    rm -f "$stderr_file"
-    return "$status"
-  done
+  _gh_retry_core "$label" "$@"
 }
 
 parse_github_repo_identity() {

--- a/amplifier-bundle/tools/workflow_pr_ready.sh
+++ b/amplifier-bundle/tools/workflow_pr_ready.sh
@@ -228,8 +228,9 @@ for pr_target in "$pr_target"; do
     if ready_output="$(gh_with_retry "pr ready" pr ready "$pr_url")"; then
       printf '%s\n' "$ready_output"
     else
-      echo "ERROR: gh pr ready failed for '$pr_url'; refusing to report successful finalization after mutation failure" >&2
-      exit 1
+      ready_rc=$?
+      echo "ERROR: gh pr ready failed for '$pr_url' (exit ${ready_rc}); refusing to report successful finalization after mutation failure" >&2
+      exit "$ready_rc"
     fi
   else
     echo "INFO: PR is already ready for review"

--- a/amplifier-bundle/tools/workflow_pr_scope.sh
+++ b/amplifier-bundle/tools/workflow_pr_scope.sh
@@ -82,34 +82,25 @@ sanitize_gh_stderr() {
   sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | awk '{print substr($0, 1, 500)}'
 }
 
-is_transient_gh_error() {
-  [ -s "$1" ] && grep -Eiq 'HTTP 5[0-9][0-9]|(^|[^0-9])(502|503|504)([^0-9]|$)|rate limit|timed out|timeout|temporar|connection reset|connection refused|TLS handshake|network|server error' "$1"
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}"
+if [ ! -f "$GH_RETRY_HELPER" ]; then
+  echo '{"ok":false,"reason":"missing_gh_retry_helper"}'
+  echo "ERROR: workflow_pr_scope.sh requires the shared retry helper at $GH_RETRY_HELPER" >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
+. "$GH_RETRY_HELPER"
 
+# Thin wrapper over the shared rate-limit-aware retry driver. A rate-limit is no
+# longer treated as a fast 3x transient: the driver waits for the authoritative
+# reset and, when a REST fallback is provided (read paths), serves the request
+# on the core budget instead of blocking. GH_RETRY_REST_FALLBACK is set by the
+# caller only for READ existence lookups.
 gh_with_retry() {
-  local label="$1" stderr_file output status attempt delay=1
+  local label="$1"
   shift
-  for attempt in 1 2 3; do
-    stderr_file=$(mktemp -t workflow-pr-scope-gh-XXXXXX)
-    if output=$(timeout 60 gh "$@" 2>"$stderr_file"); then
-      rm -f "$stderr_file"
-      printf '%s\n' "$output"
-      return 0
-    else
-      status=$?
-    fi
-    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
-      echo "WARNING: gh $label failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
-      rm -f "$stderr_file"
-      sleep "$delay"
-      delay=$((delay * 2))
-      continue
-    fi
-    echo "ERROR: gh $label failed (exit ${status})" >&2
-    [ ! -s "$stderr_file" ] || echo "gh $label stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
-    rm -f "$stderr_file"
-    return "$status"
-  done
+  _gh_retry_core "$label" "$@"
 }
 
 parse_github_repo_identity() {
@@ -154,16 +145,29 @@ fi
 
 fields="number,title,body,state,createdAt,mergedAt,url,headRefName,baseRefName,headRefOid,headRepositoryOwner,headRepository,isCrossRepository,statusCheckRollup,isDraft,mergeable,reviews"
 raw_json=""
+
+# REST (core-budget) fallbacks for the read paths. When GraphQL is rate-limited
+# but core still has budget, the shared driver serves the existence/inspection
+# lookup via these instead of failing the scope probe closed. Each fallback
+# echoes JSON in the same shape the matching `gh` command would return.
+_scope_rest_list() { gh_pr_exists_rest "$REPO" "$HEAD_REF"; }
+_scope_rest_view_number() { gh_pr_view_rest "$REPO" "$PR_NUMBER"; }
+_scope_rest_view_url() {
+  local n
+  n="$(gh_pr_number_from_url "$PR_URL")" || return 1
+  gh_pr_view_rest "$REPO" "$n"
+}
+
 if [ -n "$PR_URL" ]; then
-  raw_json="$(gh_with_retry "pr view" pr view "$PR_URL" --repo "$REPO" --json "$fields")" \
+  raw_json="$(GH_RETRY_REST_FALLBACK=_scope_rest_view_url gh_with_retry "pr view" pr view "$PR_URL" --repo "$REPO" --json "$fields")" \
     || emit_failure "pr_metadata_unavailable" "unable to inspect explicit PR URL"
   raw_json="$(jq -nc --argjson pr "$raw_json" '[$pr]')"
 elif [ -n "$PR_NUMBER" ]; then
-  raw_json="$(gh_with_retry "pr view" pr view "$PR_NUMBER" --repo "$REPO" --json "$fields")" \
+  raw_json="$(GH_RETRY_REST_FALLBACK=_scope_rest_view_number gh_with_retry "pr view" pr view "$PR_NUMBER" --repo "$REPO" --json "$fields")" \
     || emit_failure "pr_metadata_unavailable" "unable to inspect explicit PR number"
   raw_json="$(jq -nc --argjson pr "$raw_json" '[$pr]')"
 else
-  raw_json="$(gh_with_retry "pr list" pr list --repo "$REPO" --head "$HEAD_REF" --state all --json "$fields")" \
+  raw_json="$(GH_RETRY_REST_FALLBACK=_scope_rest_list gh_with_retry "pr list" pr list --repo "$REPO" --head "$HEAD_REF" --state all --json "$fields")" \
     || emit_failure "pr_metadata_unavailable" "unable to list scoped PR candidates"
   if [ -z "${raw_json//[[:space:]]/}" ]; then
     raw_json="[]"

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -88,18 +88,12 @@ finish_publish() {
 load_pr_fields() {
   local pr_json="$1"
   mapfile -t PR_FIELDS < <(
-    printf '%s' "$pr_json" | jq -r '.url // "", ((.number // "") | tostring), .state // "", .mergedAt // "", .headRefName // "", .baseRefName // "", .headRefOid // "", (.headRepositoryOwner.login // .headRepositoryOwner.name // .headRepositoryOwner // ""), (.headRepository.name // ((.headRepository.nameWithOwner // "") | split("/") | .[-1]) // ""), (.isCrossRepository // false | tostring)'
+    printf '%s' "$pr_json" | jq -r '.url // "", ((.number // "") | tostring), .state // "", .mergedAt // ""'
   )
   PR_URL_RESULT="${PR_FIELDS[0]:-}"
   PR_NUMBER_RESULT="${PR_FIELDS[1]:-}"
   PR_STATE="${PR_FIELDS[2]:-}"
   PR_MERGED_AT="${PR_FIELDS[3]:-}"
-  PR_HEAD_REF="${PR_FIELDS[4]:-}"
-  PR_BASE_REF="${PR_FIELDS[5]:-}"
-  PR_HEAD_OID="${PR_FIELDS[6]:-}"
-  PR_HEAD_OWNER="${PR_FIELDS[7]:-}"
-  PR_HEAD_REPO="${PR_FIELDS[8]:-}"
-  PR_IS_CROSS_REPO="${PR_FIELDS[9]:-false}"
 }
 
 resolve_pr_base_ref() {
@@ -195,6 +189,13 @@ sanitize_provider_stderr() {
     "$1" | tr '\n' ' ' | head -c 500
 }
 
+provider_stderr_file() {
+  local prefix="${1:-workflow-provider}"
+  local file="${GH_RETRY_TMPDIR:-.}/.${prefix}-${$}-${RANDOM}.stderr"
+  : >"$file" || return 1
+  printf '%s\n' "$file"
+}
+
 azdo_common_args=()
 configure_azdo_args() {
   local org_url project_name
@@ -228,7 +229,7 @@ az_repos_pr_list_with_retry() {
   local stderr_file output status attempt delay=1 class
   configure_azdo_args
   for attempt in 1 2 3; do
-    stderr_file=$(mktemp -t step16-az-pr-list-XXXXXX)
+    stderr_file="$(provider_stderr_file step16-az-pr-list)" || return 1
     if output=$(timeout 60 az repos pr list "${azdo_common_args[@]}" --status active --source-branch "$CURRENT_BRANCH" --target-branch "$BASE_BRANCH" --output json 2>"$stderr_file"); then
       rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
     else
@@ -259,7 +260,7 @@ az_repos_pr_create_with_retry() {
   local stderr_file output status attempt delay=1 class
   configure_azdo_args
   for attempt in 1 2 3; do
-    stderr_file=$(mktemp -t step16-az-pr-create-XXXXXX)
+    stderr_file="$(provider_stderr_file step16-az-pr-create)" || return 1
     if output=$(timeout 60 az repos pr create "${azdo_common_args[@]}" --source-branch "$CURRENT_BRANCH" --target-branch "$BASE_BRANCH" --title "$PR_TITLE" --description "$PR_BODY" --output json 2>"$stderr_file"); then
       rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
     else
@@ -455,7 +456,7 @@ RECENT_COMMITS=$(git log --oneline --no-decorate "${BASE_REF}..HEAD" -6 2>/dev/n
 # data: quoted expansions, basename matched via a static case, never eval'd.
 is_generated_scope_file() {
   case "$(basename -- "$1")" in
-    Cargo.lock|*.lock|package-lock.json|npm-shrinkwrap.json|yarn.lock|pnpm-lock.yaml|go.sum|Pipfile.lock|poetry.lock|composer.lock|Gemfile.lock|flake.lock) return 0 ;;
+    *.lock|package-lock.json|npm-shrinkwrap.json|pnpm-lock.yaml|go.sum) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -205,6 +205,25 @@ configure_azdo_args() {
   [ -n "$project_name" ] && azdo_common_args+=(--project "$project_name")
 }
 
+# Azure DevOps rate-limit wait. ADO throttling is unrelated to GitHub's API
+# budget, so we must NOT consult `gh api rate_limit` here. Derive the wait from
+# the provider's own Retry-After / reset header (provider-neutral parse) with a
+# short floor; fall back to a small fixed backoff when no header is present.
+az_wait_for_rate_limit() {
+  local stderr_file="${1:-}" now epoch wait floor=5 buffer=3
+  now="$(date +%s)"
+  epoch="$(gh_reset_epoch_from_stderr "$stderr_file" 2>/dev/null || true)"
+  if [ -z "$epoch" ]; then
+    wait="$floor"
+    echo "WARNING: Azure DevOps rate limit; no reset header present, waiting ${wait}s (floor) before retrying." >&2
+  else
+    wait=$(( epoch - now + buffer ))
+    [ "$wait" -lt "$floor" ] && wait="$floor"
+    echo "WARNING: Azure DevOps rate limit; waiting ${wait}s for the provider reset (header-derived; GitHub API not consulted)." >&2
+  fi
+  sleep "$wait"
+}
+
 az_repos_pr_list_with_retry() {
   local stderr_file output status attempt delay=1 class
   configure_azdo_args
@@ -222,7 +241,7 @@ az_repos_pr_list_with_retry() {
     fi
     if [ "$attempt" -lt 3 ] && [ "$class" = "rate_limit" ]; then
       echo "WARNING: az repos pr list hit a rate limit (exit ${status}); waiting for reset (${attempt}/3): $(sanitize_provider_stderr "$stderr_file")" >&2
-      gh_wait_for_rate_limit "" "$stderr_file"
+      az_wait_for_rate_limit "$stderr_file"
       rm -f "$stderr_file"; continue
     fi
     if [ "$attempt" -lt 3 ] && [ "$class" = "transient" ]; then
@@ -253,7 +272,7 @@ az_repos_pr_create_with_retry() {
     fi
     if [ "$attempt" -lt 3 ] && [ "$class" = "rate_limit" ]; then
       echo "WARNING: az repos pr create hit a rate limit (exit ${status}); waiting for reset (${attempt}/3): $(sanitize_provider_stderr "$stderr_file")" >&2
-      gh_wait_for_rate_limit "" "$stderr_file"
+      az_wait_for_rate_limit "$stderr_file"
       rm -f "$stderr_file"; continue
     fi
     if [ "$attempt" -lt 3 ] && [ "$class" = "transient" ]; then

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -15,12 +15,12 @@ BRANCH_DIFF_STATUS="unknown"
 MESSAGE="not classified"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PR_SCOPE_HELPER="${WORKFLOW_PR_SCOPE_HELPER:-${SCRIPT_DIR}/workflow_pr_scope.sh}"
+# workflow_pr_scope.sh validates headRefName, baseRefName, headRefOid,
+# isCrossRepository, expected_pr_title_prefix, and created_after.
 GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}"
 [ -f "$GH_RETRY_HELPER" ] || { echo "ERROR: workflow_publish_pr.sh requires the shared retry helper at $GH_RETRY_HELPER" >&2; exit 2; }
 # shellcheck source=/dev/null
 . "$GH_RETRY_HELPER"
-# workflow_pr_scope.sh validates headRefName, baseRefName, headRefOid,
-# isCrossRepository, expected_pr_title_prefix, and created_after.
 
 emit_publish_result() {
   jq -nc \

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -15,6 +15,10 @@ BRANCH_DIFF_STATUS="unknown"
 MESSAGE="not classified"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PR_SCOPE_HELPER="${WORKFLOW_PR_SCOPE_HELPER:-${SCRIPT_DIR}/workflow_pr_scope.sh}"
+GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}"
+[ -f "$GH_RETRY_HELPER" ] || { echo "ERROR: workflow_publish_pr.sh requires the shared retry helper at $GH_RETRY_HELPER" >&2; exit 2; }
+# shellcheck source=/dev/null
+. "$GH_RETRY_HELPER"
 # workflow_pr_scope.sh validates headRefName, baseRefName, headRefOid,
 # isCrossRepository, expected_pr_title_prefix, and created_after.
 
@@ -137,68 +141,50 @@ sanitize_gh_stderr() {
   sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
 }
 
-is_transient_gh_error() {
-  [ -s "$1" ] && grep -Eiq 'HTTP 5[0-9][0-9]|(^|[^0-9])(502|503|504)([^0-9]|$)|rate limit|timed out|timeout|temporar|connection reset|connection refused|TLS handshake|network|server error' "$1"
+# Rate-limit-aware retry wrappers. Retry logic is centralised in the shared
+# workflow_gh_retry.sh driver: a genuine rate limit waits for the authoritative
+# reset (adaptive, bounded by the reset window) instead of burning three
+# immediate retries against a still-exhausted quota, and READ existence lookups
+# fall back to the REST/core budget when GraphQL is exhausted. Auth errors are
+# never retried. Each wrapper keeps its tailored fail-closed message so the
+# duplicate-PR safety and diagnostics are preserved verbatim.
+
+# REST (core-budget) fallback for the existing-PR view read path.
+_publish_rest_view() {
+  local n
+  n="$(gh_pr_number_from_url "${PR_URL_RESULT:-}")" || return 1
+  gh_pr_view_rest "$REPO_IDENTITY" "$n"
 }
 
+# REST (core-budget) fallback for the branch existence list read path.
+_publish_rest_list() { gh_pr_exists_rest "${REPO_IDENTITY:-}" "${CURRENT_BRANCH:-}"; }
+
 gh_pr_list_with_retry() {
-  local stderr_file output status attempt delay=1
-  for attempt in 1 2 3; do
-    stderr_file=$(mktemp -t step16-gh-pr-list-XXXXXX)
-    if output=$(timeout 60 gh pr list "$@" 2>"$stderr_file"); then
-      rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
-    else
-      status=$?
-    fi
-    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
-      echo "WARNING: gh pr list failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
-      rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
-    fi
-    echo "ERROR: gh pr list failed (exit ${status}); refusing to risk duplicate PR creation." >&2
-    [ ! -s "$stderr_file" ] || echo "gh pr list stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
-    rm -f "$stderr_file"
-    return "$status"
-  done
+  local status
+  # READ path: existence lookup may fall back to REST on the core budget.
+  GH_RETRY_REST_FALLBACK=_publish_rest_list \
+    _gh_retry_core "pr list" pr list "$@" && return 0
+  status=$?
+  echo "ERROR: gh pr list failed (exit ${status}); refusing to risk duplicate PR creation." >&2
+  return "$status"
 }
 
 gh_pr_view_with_retry() {
-  local stderr_file output status attempt delay=1
-  for attempt in 1 2 3; do
-    stderr_file=$(mktemp -t step16-gh-pr-view-XXXXXX)
-    if output=$(timeout 60 gh pr view "$@" 2>"$stderr_file"); then
-      rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
-    else
-      status=$?
-    fi
-    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
-      echo "WARNING: gh pr view failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
-      rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
-    fi
-    echo "ERROR: gh pr view failed (exit ${status}); existing PR state is ambiguous." >&2
-    [ ! -s "$stderr_file" ] || echo "gh pr view stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
-    rm -f "$stderr_file"
-    return "$status"
-  done
+  local status
+  GH_RETRY_REST_FALLBACK=_publish_rest_view \
+    _gh_retry_core "pr view" pr view "$@" && return 0
+  status=$?
+  echo "ERROR: gh pr view failed (exit ${status}); existing PR state is ambiguous." >&2
+  return "$status"
 }
 
 gh_pr_create_with_retry() {
-  local stderr_file output status attempt delay=1
-  for attempt in 1 2 3; do
-    stderr_file=$(mktemp -t step16-gh-pr-create-XXXXXX)
-    if output=$(timeout 60 gh pr create --draft --title "$PR_TITLE" --body "$PR_BODY" 2>"$stderr_file"); then
-      rm -f "$stderr_file"; printf '%s\n' "$output"; return 0
-    else
-      status=$?
-    fi
-    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
-      echo "WARNING: gh pr create failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_gh_stderr "$stderr_file")" >&2
-      rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
-    fi
-    echo "ERROR: gh pr create failed (exit $status) — PR may already exist for this branch or GitHub API is unavailable" >&2
-    [ ! -s "$stderr_file" ] || echo "gh pr create stderr: $(sanitize_gh_stderr "$stderr_file")" >&2
-    rm -f "$stderr_file"
-    return "$status"
-  done
+  local status
+  # WRITE path: no REST fallback (never blind-create); rate limits wait for reset.
+  _gh_retry_core "pr create" pr create --draft --title "$PR_TITLE" --body "$PR_BODY" && return 0
+  status=$?
+  echo "ERROR: gh pr create failed (exit $status) — PR may already exist for this branch or GitHub API is unavailable" >&2
+  return "$status"
 }
 
 sanitize_provider_stderr() {
@@ -216,7 +202,7 @@ configure_azdo_args() {
 }
 
 az_repos_pr_list_with_retry() {
-  local stderr_file output status attempt delay=1
+  local stderr_file output status attempt delay=1 class
   configure_azdo_args
   for attempt in 1 2 3; do
     stderr_file=$(mktemp -t step16-az-pr-list-XXXXXX)
@@ -225,7 +211,17 @@ az_repos_pr_list_with_retry() {
     else
       status=$?
     fi
-    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
+    class="$(classify_gh_error "$stderr_file")"
+    if [ "$class" = "auth" ]; then
+      echo "ERROR: az repos pr list failed with an authentication error (exit ${status}); not retrying: $(sanitize_provider_stderr "$stderr_file")" >&2
+      rm -f "$stderr_file"; return "$status"
+    fi
+    if [ "$attempt" -lt 3 ] && [ "$class" = "rate_limit" ]; then
+      echo "WARNING: az repos pr list hit a rate limit (exit ${status}); waiting for reset (${attempt}/3): $(sanitize_provider_stderr "$stderr_file")" >&2
+      gh_wait_for_rate_limit "" "$stderr_file"
+      rm -f "$stderr_file"; continue
+    fi
+    if [ "$attempt" -lt 3 ] && [ "$class" = "transient" ]; then
       echo "WARNING: az repos pr list failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_provider_stderr "$stderr_file")" >&2
       rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
     fi
@@ -237,7 +233,7 @@ az_repos_pr_list_with_retry() {
 }
 
 az_repos_pr_create_with_retry() {
-  local stderr_file output status attempt delay=1
+  local stderr_file output status attempt delay=1 class
   configure_azdo_args
   for attempt in 1 2 3; do
     stderr_file=$(mktemp -t step16-az-pr-create-XXXXXX)
@@ -246,7 +242,17 @@ az_repos_pr_create_with_retry() {
     else
       status=$?
     fi
-    if [ "$attempt" -lt 3 ] && is_transient_gh_error "$stderr_file"; then
+    class="$(classify_gh_error "$stderr_file")"
+    if [ "$class" = "auth" ]; then
+      echo "ERROR: az repos pr create failed with an authentication error (exit ${status}); not retrying: $(sanitize_provider_stderr "$stderr_file")" >&2
+      rm -f "$stderr_file"; return "$status"
+    fi
+    if [ "$attempt" -lt 3 ] && [ "$class" = "rate_limit" ]; then
+      echo "WARNING: az repos pr create hit a rate limit (exit ${status}); waiting for reset (${attempt}/3): $(sanitize_provider_stderr "$stderr_file")" >&2
+      gh_wait_for_rate_limit "" "$stderr_file"
+      rm -f "$stderr_file"; continue
+    fi
+    if [ "$attempt" -lt 3 ] && [ "$class" = "transient" ]; then
       echo "WARNING: az repos pr create failed transiently (exit ${status}); retrying (${attempt}/3): $(sanitize_provider_stderr "$stderr_file")" >&2
       rm -f "$stderr_file"; sleep "$delay"; delay=$((delay * 2)); continue
     fi

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -188,7 +188,11 @@ gh_pr_create_with_retry() {
 }
 
 sanitize_provider_stderr() {
-  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
+  sed -E \
+    -e 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' \
+    -e 's#gh[pousr]_[A-Za-z0-9]{16,}#REDACTED_TOKEN#g' \
+    -e 's#github_pat_[A-Za-z0-9_]{16,}#REDACTED_TOKEN#g' \
+    "$1" | tr '\n' ' ' | head -c 500
 }
 
 azdo_common_args=()

--- a/tests/integration/issue_684_host_aware_workflow_test.rs
+++ b/tests/integration/issue_684_host_aware_workflow_test.rs
@@ -1139,7 +1139,7 @@ fn step_03_github_unexpected_create_failure_remains_error() {
         &[
             (
                 "GH_CREATE_OUTPUT",
-                "GraphQL: rate limit exceeded for https://token:ghp_secret123@github.com/example-org/example-repo",
+                "GraphQL: unexpected create failure for https://token:ghp_secret123@github.com/example-org/example-repo",
             ),
             ("GH_CREATE_STATUS", "1"),
         ],
@@ -1153,7 +1153,7 @@ fn step_03_github_unexpected_create_failure_remains_error() {
     );
     assert!(
         stderr.contains("ERROR: GitHub issue creation failed.")
-            && stderr.contains("GraphQL: rate limit exceeded")
+            && stderr.contains("GraphQL: unexpected create failure")
             && stderr.contains("https://<redacted>@github.com/example-org/example-repo"),
         "unexpected GitHub failures must remain visible; stdout:\n{stdout}\nstderr:\n{stderr}"
     );

--- a/tests/integration/workflow_finalize_resilience.rs
+++ b/tests/integration/workflow_finalize_resilience.rs
@@ -135,12 +135,10 @@ fn final_status_uses_resilient_github_status_lookup() {
 
     for required in [
         "sanitize_gh_stderr",
-        "is_transient_gh_error",
+        "workflow_gh_retry.sh",
+        "_gh_retry_core",
         "gh_pr_view_with_retry",
-        "timeout 60 gh pr view",
-        "for attempt in 1 2 3",
-        "retrying (${attempt}/3)",
-        "final PR status lookup failed",
+        "final PR status",
     ] {
         assert!(
             command.contains(required),
@@ -155,15 +153,14 @@ fn pr_ready_helper_retries_github_lookup_ready_and_comment_calls() {
 
     for required in [
         "sanitize_gh_stderr",
-        "is_transient_gh_error",
+        "workflow_gh_retry.sh",
+        "_gh_retry_core",
         "gh_with_retry",
-        "timeout 60 gh",
-        "for attempt in 1 2 3",
-        "retrying (${attempt}/3)",
         "workflow_pr_scope.sh",
         "gh_with_retry \"pr view\"",
         "gh_with_retry \"pr ready\"",
         "gh_with_retry \"pr comment\"",
+        "refusing to report successful finalization",
         "isCrossRepository",
     ] {
         assert!(

--- a/tests/integration/workflow_publish_resilience.rs
+++ b/tests/integration/workflow_publish_resilience.rs
@@ -166,13 +166,12 @@ fn publish_retries_all_github_pr_metadata_and_mutation_calls() {
 
     for required in [
         "sanitize_gh_stderr",
-        "is_transient_gh_error",
+        "workflow_gh_retry.sh",
+        "_gh_retry_core",
+        "classify_gh_error",
         "gh_pr_list_with_retry",
         "gh_pr_view_with_retry",
         "gh_pr_create_with_retry",
-        "timeout 60 gh pr list",
-        "timeout 60 gh pr view",
-        "timeout 60 gh pr create",
         "retrying (${attempt}/3)",
         "refusing to risk duplicate PR creation",
     ] {


### PR DESCRIPTION
## Problem

When the GitHub GraphQL quota is exhausted (0/5000, resets up to ~1h later), `default-workflow` helper steps that call `gh` failed closed after short retries against the same exhausted quota.

## Fix

- Add shared `amplifier-bundle/tools/workflow_gh_retry.sh` with explicit `auth | rate_limit | transient | other` classification.
- Honor authoritative reset data from `gh api rate_limit` and `Retry-After` / `X-RateLimit-Reset`; by default there is no arbitrary fixed reset-window cap.
- Add explicit REST `/pulls` fallback for read-only PR existence/view paths when GraphQL is exhausted but core budget remains.
- Preserve duplicate-PR safety: retry/fallback only the existence read; never blind-create after ambiguous state.
- Keep write/mutation paths fail-closed: auth is terminal, rate limits wait for reset, no REST mutation fallback.
- Harden stderr redaction for embedded credentials and GitHub token patterns.
- Make edited shell shellcheck-clean at warning level.

## Crusty review loop evidence

Final crusty pass found and fixed substantive issues:

1. Default `GH_RETRY_MAX_RL_WINDOWS=2` violated the repo policy against arbitrary fixed caps. Fixed by making the cap opt-in only; default behavior keeps honoring the authoritative reset window.
2. Inline issue-creation retry in `workflow-prep.yaml` still documented/enforced a two-window cap. Fixed to match the shared helper: no default cap and explicit logging.
3. Retry/test scratch used `mktemp`/system temp paths. Fixed edited helpers/tests to use controlled repo-adjacent scratch and cleanup.
4. `workflow_pr_ready.sh` had a single-iteration quoted loop that failed shellcheck and obscured terminal-state handling. Replaced with explicit single-target logic preserving merged/closed/draft behavior.
5. Shellcheck warnings in edited files were resolved without suppressing the checker.

A final self-review verified auth errors are not retried, REST fallback is logged explicitly, PR creation remains guarded by existence lookup, and Signal files are absent from the diff.

## Merge-ready evidence

- Clean diff scope after rebase/push: 11 tightly scoped rate-limit workflow-tooling files (`workflow_gh_retry.sh`, publish/scope/ready/final-status helpers, workflow-prep, two shell tests, two Rust workflow integration tests plus the stale issue-684 unexpected-failure fixture that previously used rate-limit text and would now intentionally retry). No Signal files, `SKILL_CATALOG.md`, or signal-setup scenario deletions.
- QA/gadugi-test: `gadugi-test` and `qa-team` commands are unavailable in this worktree; direct replacement scenarios were run.
- Quality-audit cycle 1 (scope): `git diff --stat origin/main..HEAD` and `git diff --name-only origin/main..HEAD` clean and focused.
- Quality-audit cycle 2 (behavior): `bash amplifier-bundle/recipes/tests/test-gh-rate-limit-backoff.sh` PASS (19 checks); `bash amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh` PASS.
- Quality-audit cycle 3 (integration/hygiene): `cargo test --test workflow_publish_resilience --test workflow_finalize_resilience` PASS (36 tests); `shellcheck -S warning ...` PASS; `pre-commit run --all-files` PASS including `cargo clippy --all-targets -- -D warnings`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd


CI follow-up: the first post-push Test job was cancelled after an obsolete issue-684 fixture used a rate-limit string for an unrelated unexpected-failure assertion, causing the new no-cap retry policy to wait. Updated that fixture to use a non-rate-limit unexpected error and verified `cargo test --test issue_684_host_aware_workflow step_03_github_unexpected_create_failure_remains_error` PASS before force-pushing the amended head.


---

## Step 16b: Outside-In Testing Results

Validated the merged rate-limit tolerance tooling from the PR branch head (`b7e37dcb`) as a consumer would, via the repo's native toolchains.

**Detected toolchains:** Rust CLI (`cargo 1.97.0`, `Cargo.toml` workspace, package `amplihack`), Bash workflow tooling (`bash 5.3`, `shellcheck 0.11.0`). Changed files are shell helpers under `amplifier-bundle/tools/` + `recipes/` and Rust integration tests under `tests/integration/`.

**Chosen strategy:** Per the qa-team skill's Rust-CLI guidance, exercise the outside-in boundaries directly — run the shell contract test that drives the rate-limit backoff helpers, lint all changed shell scripts, and run the modified Rust integration test targets. No gadugi framework required.

| # | Scenario | Command | Result | Key output |
|---|----------|---------|--------|-----------|
| 1 (simple) | Shell rate-limit backoff helper contracts | `bash amplifier-bundle/recipes/tests/test-gh-rate-limit-backoff.sh` | PASS | `PASS: gh rate-limit backoff helper contracts are covered (19 checks).` — classifies primary/secondary/429/403 rate limits, parses reset epoch, REST fallback when GraphQL exhausted, auth errors terminal (no retry) |
| 2a (edge/lint) | Shellcheck changed workflow scripts | `shellcheck workflow_gh_retry.sh workflow_pr_ready.sh workflow_pr_scope.sh workflow_publish_pr.sh workflow_final_status.sh` | PASS | Exit 0; only info-level SC2016 on intentional `printf` format strings |
| 2b (integration) | Finalize resilience integration tests | `cargo test -p amplihack --test workflow_finalize_resilience` | PASS | `27 passed; 0 failed` (incl. `pr_ready_helper_fails_closed_when_base_branch_cannot_be_proven`) |
| 2c (integration) | Publish resilience integration tests | `cargo test -p amplihack --test workflow_publish_resilience` | PASS | `9 passed; 0 failed` |
| 2d (integration) | Host-aware workflow (rate-limit fixture) tests | `cargo test -p amplihack --test issue_684_host_aware_workflow` | PASS | `50 passed; 0 failed` |

**Fix count:** 0 — all scenarios passed on the first run; no code changes required.

**Merge status:** PR already MERGED (commit `cb915faf`) into `origin/main` with all required CI green (Build ×4, Test, Lint & Format, Install Smoke Test, GitGuardian all `pass`). Outside-in validation confirms the merged rate-limit tolerance tooling behaves correctly at the user/consumer boundary.
