### PR TITLE
fix(signal): fail-closed config hardening (follow-up to #995)

### DIFF
--- a/crates/amplihack-hooks/src/signal_integration/imp.rs
+++ b/crates/amplihack-hooks/src/signal_integration/imp.rs
@@ -203,7 +203,13 @@ pub fn drain_into_context(session_id: Option<&str>) -> Option<String> {
     if inbox.is_empty().unwrap_or(true) {
         return None;
     }
-    let items = inbox.drain().ok()?;
+    let items = match inbox.drain() {
+        Ok(items) => items,
+        Err(err) => {
+            tracing::warn!("signal: failed to drain non-empty inbox: {err}");
+            return None;
+        }
+    };
     if items.is_empty() {
         return None;
     }
@@ -250,7 +256,15 @@ fn stop(session_id: &str) -> anyhow::Result<()> {
     let dirs = ProjectDirs::from_cwd();
     let root = signal_root(&dirs);
     let state_file = AtomicJsonFile::new(state_path(&root, session_id));
-    let state: SignalState = state_file.read().ok().flatten().unwrap_or_default();
+    let state: SignalState = match state_file.read() {
+        Ok(Some(state)) => state,
+        Ok(None) => SignalState::default(),
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "failed to read signal state for session {session_id}: {err}"
+            ));
+        }
+    };
 
     // Stop the subscriber first so it stops touching the inbox.
     if let Some(pid) = state.subscriber_pid {

--- a/crates/amplihack-hooks/src/signal_integration/imp.rs
+++ b/crates/amplihack-hooks/src/signal_integration/imp.rs
@@ -124,8 +124,7 @@ fn start(session_id: &str) -> anyhow::Result<()> {
             with_timeout("connect", SignalTransport::connect(&config.endpoint)).await?;
 
         // Reuse a pinned rolling group when configured; otherwise create a
-        // fresh per-session group (rolling mode without a pinned id also
-        // creates one on first use).
+        // fresh per-session group.
         let group_id = match (config.reuse_rolling_group, &config.rolling_group_id) {
             (true, Some(existing)) => GroupId(existing.clone()),
             _ => with_timeout("create_group", transport.create_group(&group_name)).await?,

--- a/crates/amplihack-signal/src/config.rs
+++ b/crates/amplihack-signal/src/config.rs
@@ -185,7 +185,12 @@ impl SignalConfig {
                 .unwrap_or(false),
         };
 
-        let rolling_group_id = get_str(ENV_ROLLING_GROUP_ID, "rolling_group_id");
+        let rolling_group_id = get_str(ENV_ROLLING_GROUP_ID, "rolling_group_id")
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        if reuse_rolling_group && rolling_group_id.is_none() {
+            return Err(ConfigError::MissingRequired("rolling_group_id"));
+        }
 
         Ok(SignalConfig {
             endpoint,
@@ -534,6 +539,39 @@ mod tests {
         let cfg = SignalConfig::from_sources(&HashMap::new(), Some(toml)).unwrap();
         assert!(cfg.reuse_rolling_group);
         assert_eq!(cfg.rolling_group_id.as_deref(), Some("grp-shared=="));
+    }
+
+    #[test]
+    fn reuse_rolling_group_requires_rolling_group_id() {
+        // Without a pinned group id, "rolling" mode cannot actually roll
+        // across sessions; it would create a fresh group and skip quitGroup.
+        let e = env(&[
+            (ENV_ENDPOINT, "127.0.0.1:7583"),
+            (ENV_ACCOUNT, "+15551230000"),
+            (ENV_ALLOWLIST, "+15551230001"),
+            (ENV_REUSE_ROLLING_GROUP, "1"),
+        ]);
+        let err = SignalConfig::from_sources(&e, None).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::MissingRequired("rolling_group_id")
+        ));
+    }
+
+    #[test]
+    fn empty_rolling_group_id_does_not_enable_reuse() {
+        let e = env(&[
+            (ENV_ENDPOINT, "127.0.0.1:7583"),
+            (ENV_ACCOUNT, "+15551230000"),
+            (ENV_ALLOWLIST, "+15551230001"),
+            (ENV_REUSE_ROLLING_GROUP, "true"),
+            (ENV_ROLLING_GROUP_ID, "  "),
+        ]);
+        let err = SignalConfig::from_sources(&e, None).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::MissingRequired("rolling_group_id")
+        ));
     }
 
     #[test]

--- a/crates/amplihack-signal/src/config.rs
+++ b/crates/amplihack-signal/src/config.rs
@@ -131,20 +131,26 @@ impl SignalConfig {
             parse_allowlist_csv(csv)?
         } else {
             let mut out = Vec::new();
-            if let Some(arr) = toml_table
-                .and_then(|t| t.get("allowlist"))
-                .and_then(toml::Value::as_array)
-            {
-                for item in arr {
-                    if let Some(s) = item.as_str() {
-                        let s = s.trim();
-                        if s.is_empty() {
-                            continue;
-                        }
-                        validate_e164(s)?;
-                        out.push(s.to_string());
-                    }
+            let Some(raw_allowlist) = toml_table.and_then(|t| t.get("allowlist")) else {
+                return Err(ConfigError::MissingRequired("allowlist"));
+            };
+            let arr = raw_allowlist.as_array().ok_or_else(|| {
+                ConfigError::Toml(format!(
+                    "invalid allowlist: expected array, got {raw_allowlist}"
+                ))
+            })?;
+            for item in arr {
+                let s = item.as_str().ok_or_else(|| {
+                    ConfigError::Toml(format!(
+                        "invalid allowlist entry: expected string, got {item}"
+                    ))
+                })?;
+                let s = s.trim();
+                if s.is_empty() {
+                    continue;
                 }
+                validate_e164(s)?;
+                out.push(s.to_string());
             }
             out
         };
@@ -158,10 +164,19 @@ impl SignalConfig {
                         value: v.clone(),
                     })?,
             ),
-            None => toml_table
-                .and_then(|t| t.get("own_device_id"))
-                .and_then(toml::Value::as_integer)
-                .map(|i| i as u32),
+            None => match toml_table.and_then(|t| t.get("own_device_id")) {
+                Some(v) => {
+                    let i = v.as_integer().ok_or_else(|| ConfigError::InvalidNumber {
+                        key: ENV_OWN_DEVICE_ID,
+                        value: v.to_string(),
+                    })?;
+                    Some(u32::try_from(i).map_err(|_| ConfigError::InvalidNumber {
+                        key: ENV_OWN_DEVICE_ID,
+                        value: i.to_string(),
+                    })?)
+                }
+                None => None,
+            },
         };
 
         // signal-cli's own linked-device id, when configured, must be a real
@@ -179,10 +194,12 @@ impl SignalConfig {
 
         let reuse_rolling_group = match env.get(ENV_REUSE_ROLLING_GROUP) {
             Some(v) => is_truthy(v),
-            None => toml_table
-                .and_then(|t| t.get("reuse_rolling_group"))
-                .and_then(toml::Value::as_bool)
-                .unwrap_or(false),
+            None => match toml_table.and_then(|t| t.get("reuse_rolling_group")) {
+                Some(v) => v.as_bool().ok_or_else(|| {
+                    ConfigError::Toml(format!("invalid boolean setting reuse_rolling_group: {v}"))
+                })?,
+                None => false,
+            },
         };
 
         let rolling_group_id = get_str(ENV_ROLLING_GROUP_ID, "rolling_group_id")
@@ -280,12 +297,24 @@ fn validate_e164(s: &str) -> Result<(), ConfigError> {
     }
 }
 
-/// Validate a `host:port` endpoint: non-empty host and a parseable `u16` port.
+/// Validate a `host:port` endpoint: non-empty host and non-zero `u16` port.
+/// IPv6 literals must use the standard bracket form (`[::1]:7583`) so the host
+/// boundary is unambiguous.
 fn validate_endpoint(s: &str) -> Result<(), ConfigError> {
-    if let Some((host, port)) = s.rsplit_once(':')
-        && !host.is_empty()
-        && port.parse::<u16>().is_ok()
-    {
+    let (host, port) = if let Some(rest) = s.strip_prefix('[') {
+        let (host, rest) = rest
+            .split_once("]:")
+            .ok_or_else(|| ConfigError::InvalidEndpoint(s.to_string()))?;
+        (host, rest)
+    } else if let Some((host, port)) = s.rsplit_once(':') {
+        if host.contains(':') {
+            return Err(ConfigError::InvalidEndpoint(s.to_string()));
+        }
+        (host, port)
+    } else {
+        return Err(ConfigError::InvalidEndpoint(s.to_string()));
+    };
+    if !host.is_empty() && port.parse::<u16>().is_ok_and(|p| p != 0) {
         return Ok(());
     }
     Err(ConfigError::InvalidEndpoint(s.to_string()))
@@ -347,6 +376,21 @@ mod tests {
             (ENV_OWN_DEVICE_ID, "1"),
         ]);
         let err = SignalConfig::from_sources(&e, None).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidNumber { key, .. } if key == ENV_OWN_DEVICE_ID),
+            "expected InvalidNumber for own_device_id, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn toml_own_device_id_below_two_is_error() {
+        let toml = r#"
+            endpoint = "127.0.0.1:7583"
+            account  = "+15551230000"
+            allowlist = ["+15551230001"]
+            own_device_id = -1
+        "#;
+        let err = SignalConfig::from_sources(&HashMap::new(), Some(toml)).unwrap_err();
         assert!(
             matches!(err, ConfigError::InvalidNumber { key, .. } if key == ENV_OWN_DEVICE_ID),
             "expected InvalidNumber for own_device_id, got {err:?}"
@@ -431,6 +475,33 @@ mod tests {
     }
 
     #[test]
+    fn endpoint_rejects_unbracketed_ipv6_and_port_zero() {
+        for endpoint in ["::1", "fe80::1", "127.0.0.1:0"] {
+            let e = env(&[
+                (ENV_ENDPOINT, endpoint),
+                (ENV_ACCOUNT, "+15551230000"),
+                (ENV_ALLOWLIST, "+15551230001"),
+            ]);
+            let err = SignalConfig::from_sources(&e, None).unwrap_err();
+            assert!(
+                matches!(err, ConfigError::InvalidEndpoint(_)),
+                "{endpoint} should be rejected, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn endpoint_accepts_bracketed_ipv6() {
+        let e = env(&[
+            (ENV_ENDPOINT, "[::1]:7583"),
+            (ENV_ACCOUNT, "+15551230000"),
+            (ENV_ALLOWLIST, "+15551230001"),
+        ]);
+        let cfg = SignalConfig::from_sources(&e, None).expect("bracketed IPv6 endpoint is valid");
+        assert_eq!(cfg.endpoint, "[::1]:7583");
+    }
+
+    #[test]
     fn toml_supplies_values_when_env_absent() {
         let toml = r#"
             endpoint = "10.0.0.5:7583"
@@ -447,6 +518,28 @@ mod tests {
         assert_eq!(cfg.own_device_id, Some(2));
         assert!(cfg.reuse_rolling_group);
         assert_eq!(cfg.rolling_group_id.as_deref(), Some("grp-rolling=="));
+    }
+
+    #[test]
+    fn toml_allowlist_must_be_an_array() {
+        let toml = r#"
+            endpoint = "127.0.0.1:7583"
+            account  = "+15551230000"
+            allowlist = "+15551230001"
+        "#;
+        let err = SignalConfig::from_sources(&HashMap::new(), Some(toml)).unwrap_err();
+        assert!(matches!(err, ConfigError::Toml(_)));
+    }
+
+    #[test]
+    fn toml_allowlist_entries_must_be_strings() {
+        let toml = r#"
+            endpoint = "127.0.0.1:7583"
+            account  = "+15551230000"
+            allowlist = ["+15551230001", 123]
+        "#;
+        let err = SignalConfig::from_sources(&HashMap::new(), Some(toml)).unwrap_err();
+        assert!(matches!(err, ConfigError::Toml(_)));
     }
 
     #[test]
@@ -500,6 +593,18 @@ mod tests {
                 "value {v:?} must resolve to per-session (reuse=false)"
             );
         }
+    }
+
+    #[test]
+    fn non_boolean_toml_reuse_rolling_group_is_error() {
+        let toml = r#"
+            endpoint = "127.0.0.1:7583"
+            account  = "+15551230000"
+            allowlist = ["+15551230001"]
+            reuse_rolling_group = "tru"
+        "#;
+        let err = SignalConfig::from_sources(&HashMap::new(), Some(toml)).unwrap_err();
+        assert!(matches!(err, ConfigError::Toml(_)));
     }
 
     #[test]

--- a/crates/amplihack-signal/src/config.rs
+++ b/crates/amplihack-signal/src/config.rs
@@ -193,7 +193,7 @@ impl SignalConfig {
         }
 
         let reuse_rolling_group = match env.get(ENV_REUSE_ROLLING_GROUP) {
-            Some(v) => is_truthy(v),
+            Some(v) => parse_bool_env(ENV_REUSE_ROLLING_GROUP, v)?,
             None => match toml_table.and_then(|t| t.get("reuse_rolling_group")) {
                 Some(v) => v.as_bool().ok_or_else(|| {
                     ConfigError::Toml(format!("invalid boolean setting reuse_rolling_group: {v}"))
@@ -320,12 +320,16 @@ fn validate_endpoint(s: &str) -> Result<(), ConfigError> {
     Err(ConfigError::InvalidEndpoint(s.to_string()))
 }
 
-/// Interpret common truthy string values (`1`, `true`, `yes`, `on`).
-fn is_truthy(v: &str) -> bool {
-    matches!(
-        v.trim().to_ascii_lowercase().as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+/// Parse common boolean env tokens. Empty is retained as a safe explicit false
+/// for the isolation default; unknown non-empty tokens are configuration errors.
+fn parse_bool_env(key: &'static str, v: &str) -> Result<bool, ConfigError> {
+    match v.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" | "" => Ok(false),
+        _ => Err(ConfigError::Toml(format!(
+            "invalid boolean setting {key}: {v}"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -578,8 +582,8 @@ mod tests {
 
     #[test]
     fn reuse_rolling_group_falsy_env_values_are_per_session() {
-        // Fail-closed: any non-truthy env token (including explicit "false",
-        // "0", and empty) must resolve to per-session isolation, never shared.
+        // Fail-closed: explicit false tokens and empty values must resolve to
+        // per-session isolation, never shared.
         for v in ["0", "false", "no", "off", "", "  "] {
             let e = env(&[
                 (ENV_ENDPOINT, "127.0.0.1:7583"),
@@ -593,6 +597,18 @@ mod tests {
                 "value {v:?} must resolve to per-session (reuse=false)"
             );
         }
+    }
+
+    #[test]
+    fn unknown_reuse_rolling_group_env_value_is_error() {
+        let e = env(&[
+            (ENV_ENDPOINT, "127.0.0.1:7583"),
+            (ENV_ACCOUNT, "+15551230000"),
+            (ENV_ALLOWLIST, "+15551230001"),
+            (ENV_REUSE_ROLLING_GROUP, "treu"),
+        ]);
+        let err = SignalConfig::from_sources(&e, None).unwrap_err();
+        assert!(matches!(err, ConfigError::Toml(_)));
     }
 
     #[test]

--- a/crates/amplihack-signal/tests/default_config_path_it.rs
+++ b/crates/amplihack-signal/tests/default_config_path_it.rs
@@ -16,7 +16,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use amplihack_signal::config::{self, SignalConfig};
+use amplihack_signal::config::{self, ConfigError, SignalConfig};
 
 const SAMPLE_TOML: &str = r#"
 endpoint = "127.0.0.1:7583"
@@ -60,6 +60,28 @@ fn resolve_source_prefers_env_config_path_over_default() {
 }
 
 #[test]
+fn resolve_source_errors_when_env_config_path_is_unreadable() {
+    let dir = tempfile::tempdir().unwrap();
+    let env_file = dir.path().join("explicit-dir");
+    let default_file = dir.path().join(".amplihack/signal-config.toml");
+    std::fs::create_dir_all(&env_file).unwrap();
+    std::fs::create_dir_all(default_file.parent().unwrap()).unwrap();
+    std::fs::write(&default_file, SAMPLE_TOML).unwrap();
+
+    let mut env: HashMap<String, String> = HashMap::new();
+    env.insert(
+        config::ENV_CONFIG_PATH.to_string(),
+        env_file.display().to_string(),
+    );
+
+    let err = config::resolve_config_source(&env, &default_file).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::Io { .. }),
+        "unreadable explicit config must error instead of falling back, got {err:?}"
+    );
+}
+
+#[test]
 fn resolve_source_falls_back_to_default_path_when_env_unset() {
     let dir = tempfile::tempdir().unwrap();
     let default_file = dir.path().join(".amplihack/signal-config.toml");
@@ -88,5 +110,19 @@ fn resolve_source_is_none_when_neither_env_nor_default_exists() {
     assert!(
         src.is_none(),
         "with no env var and no default file, resolution yields None (disabled)"
+    );
+}
+
+#[test]
+fn resolve_source_errors_when_default_path_exists_but_is_unreadable() {
+    let dir = tempfile::tempdir().unwrap();
+    let default_file = dir.path().join(".amplihack/signal-config.toml");
+    std::fs::create_dir_all(&default_file).unwrap();
+    let env: HashMap<String, String> = HashMap::new();
+
+    let err = config::resolve_config_source(&env, &default_file).unwrap_err();
+    assert!(
+        matches!(err, ConfigError::Io { .. }),
+        "unreadable default config must error instead of disabling the channel, got {err:?}"
     );
 }

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1157,12 +1157,13 @@ another session's messages. Reusing a single shared "rolling" group is strictly
 **Read by:** `amplihack_signal::config::SignalConfig`
 
 Opt-in switch for sharing one long-lived group across every session. When truthy,
-amplihack reuses a single "rolling" group and does **not** quit it at Stop,
-giving one persistent operator thread. When unset, empty, or any non-truthy
-value, the channel resolves **fail-closed to the per-session default** — never to
-shared visibility. Pair it with `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` to bind to an
-existing group. Like every Signal setting, the environment variable overrides the
-TOML key of the same name.
+amplihack reuses the group named by `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` and does
+**not** quit it at Stop, giving one persistent operator thread. When unset,
+empty, or any non-truthy value, the channel resolves **fail-closed to the
+per-session default** — never to shared visibility. A truthy value without a
+non-empty `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` is rejected so rolling mode cannot
+create an untracked group. Like every Signal setting, the environment variable
+overrides the TOML key of the same name.
 
 ---
 
@@ -1173,11 +1174,10 @@ TOML key of the same name.
 **Default:** unset
 **Read by:** `amplihack_signal::config::SignalConfig`
 
-Binds rolling reuse to an **existing** group id instead of creating a new one on
-first use. Only consulted when `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` is truthy;
-it is ignored while the per-session default is in effect. Setting this alone does
-**not** enable sharing — both the opt-in flag and this id are required for a
-shared rolling group.
+Binds rolling reuse to an **existing** group id. Only consulted when
+`AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` is truthy; it is ignored while the
+per-session default is in effect. Setting this alone does **not** enable sharing
+— both the opt-in flag and this id are required for a shared rolling group.
 
 ---
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1159,11 +1159,12 @@ another session's messages. Reusing a single shared "rolling" group is strictly
 Opt-in switch for sharing one long-lived group across every session. When truthy,
 amplihack reuses the group named by `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` and does
 **not** quit it at Stop, giving one persistent operator thread. When unset,
-empty, or any non-truthy value, the channel resolves **fail-closed to the
-per-session default** — never to shared visibility. A truthy value without a
-non-empty `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` is rejected so rolling mode cannot
-create an untracked group. Like every Signal setting, the environment variable
-overrides the TOML key of the same name.
+empty, or an explicit false value (`0`, `false`, `no`, `off`), the channel
+resolves **fail-closed to the per-session default** — never to shared
+visibility. Unknown non-empty tokens are rejected so typos are visible. A truthy
+value without a non-empty `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` is rejected so
+rolling mode cannot create an untracked group. Like every Signal setting, the
+environment variable overrides the TOML key of the same name.
 
 ---
 

--- a/docs/signal-channel.md
+++ b/docs/signal-channel.md
@@ -396,7 +396,7 @@ the channel stays off; there are **no other silent defaults**.
 | Allowlist | `AMPLIHACK_SIGNAL_ALLOWLIST` | `allowlist` | ✅ | Operator numbers allowed to send inbound. Env = comma-separated E.164. **Empty ⇒ fail-closed (deny all inbound).** |
 | Own device id | `AMPLIHACK_SIGNAL_OWN_DEVICE_ID` | `own_device_id` | optional | signal-cli's **own** linked-device id (must be `>= 2`). Only used to reject the bot's own synced-back echoes explicitly; the primary-phone (device `1`) gate is the main loop guard and needs no configuration. Leave unset unless you know your signal-cli device id |
 | Reuse rolling group | `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` | `reuse_rolling_group` | optional | **Default `false` (per-session groups).** Opt-in only: a truthy value (`1`/`true`/`yes`/`on`, case-insensitive) reuses one long-lived shared group across every session instead of creating a fresh per-session group. Any absent, empty, or non-truthy value resolves fail-closed to per-session isolation |
-| Rolling group id | `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` | `rolling_group_id` | optional | Existing group id to bind to when — and only when — rolling reuse is opted into. Ignored while the per-session default is in effect |
+| Rolling group id | `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` | `rolling_group_id` | required when rolling reuse is enabled | Existing group id to bind to when — and only when — rolling reuse is opted into. Ignored while the per-session default is in effect |
 | Config file path | `AMPLIHACK_SIGNAL_CONFIG` | — | optional | Explicit path to the TOML file below. When unset, the loader falls back to the onboarding default `~/.amplihack/signal-config.toml` |
 
 > **Fail-closed allowlist.** An **empty** allowlist is a valid, deliberate
@@ -451,11 +451,11 @@ group is closed with `quitGroup`.
 **Rolling group (opt-in).** Per-session groups are the default; nothing needs
 to be set to get them. To instead reuse a **single** long-lived group across all
 sessions, explicitly opt in by setting `reuse_rolling_group = true` (or
-`AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`). In this mode the group is **not** quit
-at Stop, so you keep one persistent operator thread. Supply `rolling_group_id`
-to bind to an existing group instead of creating a new one on first use. Because
-this trades per-session isolation for a shared thread, it must be requested
-deliberately — any absent or non-truthy value keeps the per-session default.
+`AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`) **and** supplying `rolling_group_id`.
+In this mode the group is **not** quit at Stop, so you keep one persistent
+operator thread. Because this trades per-session isolation for a shared thread,
+it must be requested deliberately — any absent or non-truthy reuse flag keeps
+the per-session default, and a truthy reuse flag without a group id is rejected.
 
 | Phase | Per-session | Rolling |
 |---|---|---|
@@ -586,9 +586,9 @@ Concretely:
   `false`, so each session gets its own group that is closed with `quitGroup`
   at Stop — no operator thread outlives the session that created it. Sharing one
   long-lived group across sessions is a deliberate opt-in
-  (`reuse_rolling_group = true` / `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`);
-  only non-empty truthy values enable it, so a malformed or empty setting stays
-  fail-closed on the isolated per-session default.
+  (`reuse_rolling_group = true` / `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`) plus
+  a `rolling_group_id`; only non-empty truthy values enable it, and a missing
+  group id is rejected instead of creating an untracked shared thread.
 - **Path safety.** Every per-session file path is run through
   `sanitize_session_id`; inbox/PID files are written atomically with
   restrictive permissions.
@@ -650,7 +650,7 @@ assert!(cfg.allowlist.iter().all(|n| n.starts_with('+')));
 | `allowlist` | `Vec<String>` | Permitted E.164 senders (empty ⇒ deny all inbound) |
 | `own_device_id` | `Option<u32>` | signal-cli's own linked-device id (`>= 2`) for explicit echo rejection |
 | `reuse_rolling_group` | `bool` | Opt-in: reuse one shared rolling group. Defaults to `false` (per-session groups) |
-| `rolling_group_id` | `Option<String>` | Existing group id to bind rolling reuse to (only consulted when `reuse_rolling_group` is `true`) |
+| `rolling_group_id` | `Option<String>` | Existing group id to bind rolling reuse to (required when `reuse_rolling_group` is `true`) |
 
 ### `transport`
 
@@ -779,7 +779,7 @@ Per-session is the **default** and needs no configuration: each session creates
 its own fresh group and cleans it up at Stop via `quitGroup`, giving clean
 isolation and no cross-session message disclosure. Rolling is a deliberate
 opt-in that keeps one persistent operator thread across runs; enable it by
-setting `reuse_rolling_group = true` (optionally with a `rolling_group_id`).
+setting `reuse_rolling_group = true` with a `rolling_group_id`.
 Prefer the per-session default unless you specifically want one shared thread.
 
 **Where do inbound instructions get stored?**

--- a/docs/signal-channel.md
+++ b/docs/signal-channel.md
@@ -395,7 +395,7 @@ the channel stays off; there are **no other silent defaults**.
 | Account | `AMPLIHACK_SIGNAL_ACCOUNT` | `account` | ✅ | E.164 (`+` then digits) — the number amplihack sends **as** |
 | Allowlist | `AMPLIHACK_SIGNAL_ALLOWLIST` | `allowlist` | ✅ | Operator numbers allowed to send inbound. Env = comma-separated E.164. **Empty ⇒ fail-closed (deny all inbound).** |
 | Own device id | `AMPLIHACK_SIGNAL_OWN_DEVICE_ID` | `own_device_id` | optional | signal-cli's **own** linked-device id (must be `>= 2`). Only used to reject the bot's own synced-back echoes explicitly; the primary-phone (device `1`) gate is the main loop guard and needs no configuration. Leave unset unless you know your signal-cli device id |
-| Reuse rolling group | `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` | `reuse_rolling_group` | optional | **Default `false` (per-session groups).** Opt-in only: a truthy value (`1`/`true`/`yes`/`on`, case-insensitive) reuses one long-lived shared group across every session instead of creating a fresh per-session group. Any absent, empty, or non-truthy value resolves fail-closed to per-session isolation |
+| Reuse rolling group | `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` | `reuse_rolling_group` | optional | **Default `false` (per-session groups).** Opt-in only: a truthy value (`1`/`true`/`yes`/`on`, case-insensitive) reuses one long-lived shared group across every session instead of creating a fresh per-session group. Absent, empty, or explicit false values (`0`/`false`/`no`/`off`) resolve to per-session isolation; unknown tokens are rejected |
 | Rolling group id | `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` | `rolling_group_id` | required when rolling reuse is enabled | Existing group id to bind to when — and only when — rolling reuse is opted into. Ignored while the per-session default is in effect |
 | Config file path | `AMPLIHACK_SIGNAL_CONFIG` | — | optional | Explicit path to the TOML file below. When unset, the loader falls back to the onboarding default `~/.amplihack/signal-config.toml` |
 
@@ -454,8 +454,9 @@ sessions, explicitly opt in by setting `reuse_rolling_group = true` (or
 `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`) **and** supplying `rolling_group_id`.
 In this mode the group is **not** quit at Stop, so you keep one persistent
 operator thread. Because this trades per-session isolation for a shared thread,
-it must be requested deliberately — any absent or non-truthy reuse flag keeps
-the per-session default, and a truthy reuse flag without a group id is rejected.
+it must be requested deliberately — any absent, empty, or explicit false reuse
+flag keeps the per-session default, unknown tokens are rejected, and a truthy
+reuse flag without a group id is rejected.
 
 | Phase | Per-session | Rolling |
 |---|---|---|

--- a/examples/signal-config.toml
+++ b/examples/signal-config.toml
@@ -69,8 +69,8 @@ allowlist = [
 # OPT-IN: set `reuse_rolling_group = true` to instead reuse a single long-lived
 # "rolling" group across every session (it is NOT quit at Stop). Useful when you
 # want one persistent operator thread instead of a fresh group each run. Any
-# absent, empty, or non-truthy value keeps the per-session default (fail-closed
-# to isolation).
+# absent, empty, or explicit false value keeps the per-session default
+# (fail-closed to isolation); unknown non-empty env tokens are rejected.
 # ENV override: AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1
 # ---------------------------------------------------------------------------
 reuse_rolling_group = false

--- a/examples/signal-config.toml
+++ b/examples/signal-config.toml
@@ -75,8 +75,8 @@ allowlist = [
 # ---------------------------------------------------------------------------
 reuse_rolling_group = false
 
-# Only used when `reuse_rolling_group = true`: an existing group id to bind to so
-# amplihack posts into it instead of creating a new one on first use. Ignored
-# while the per-session default is in effect.
+# Required when `reuse_rolling_group = true`: an existing group id to bind to so
+# amplihack posts into the intended shared thread. Ignored while the per-session
+# default is in effect.
 # ENV override: AMPLIHACK_SIGNAL_ROLLING_GROUP_ID
 # rolling_group_id = "group.aBcDeF0123456789=="


### PR DESCRIPTION
## Summary

Follow-up hardening for the per-session Signal work merged in #995. PR #995 was
already merged into `main` (merge commit `e82866a`) before these commits were
pushed, so they are delivered here as a continuation rather than by reopening a
closed PR.

This PR contains **three** commits at HEAD (`a88c4ae2`), all tightening
fail-closed behavior for the Signal channel:

- **`f76556d1` — `fix(signal): require group id for rolling reuse`** — rolling
  reuse without a pinned `rolling_group_id` could create a fresh group and skip
  teardown, which is neither rolling nor isolated. That configuration is now
  rejected and the docs/examples match the real contract.
- **`97aede61` — `fix(signal): fail loudly on malformed signal config`** — reject
  non-array allowlists, non-string allowlist entries, non-boolean
  `reuse_rolling_group`, and out-of-range `own_device_id` instead of silently
  defaulting. Endpoints are validated strictly (bracketed IPv6 literals required,
  port `0` rejected). Inbox-drain and signal-state read failures are surfaced
  instead of swallowed.
- **`a88c4ae2` — `test(signal): lock fail-loud config edge cases`** — regression
  coverage locking in each new fail-loud edge case so the hardened contract
  cannot silently regress.

## Scope

Signal config parsing (`crates/amplihack-signal/src/config.rs`), hook signal
integration error propagation (`crates/amplihack-hooks/src/signal_integration/imp.rs`),
and the corresponding docs/examples. No behavior change for already-valid
per-session configurations.

## Local Testing Results

Detected toolchains:
- **Rust / Cargo** — workspace `Cargo.toml`; changed files are `.rs` in
  `crates/amplihack-signal` and `crates/amplihack-hooks`; the `signal` feature
  is defined in `crates/amplihack-signal/Cargo.toml` and consumed by
  `crates/amplihack-cli` and `bins/amplihack`. The consumer boundary for the
  changed config code is `SignalConfig::from_sources`, exercised by the CLI and
  hooks.

### Gate summary (all pass locally)
- `cargo test -p amplihack-signal --features signal` → all pass (unit + integration)
- `cargo test -p amplihack-cli --features signal` → all pass
- `cargo clippy --all-targets -- -D warnings` → clean, no warnings

These prove the user-visible behavior: valid per-session configs still parse and
default to isolation, malformed configs now fail loudly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd
