### PR TITLE
feat(signal): complete per-session Signal channel — onboarding, full mirroring, host-aware injection, offline tests (#1002)

### DIFF
--- a/bins/amplihack-hooks/src/main.rs
+++ b/bins/amplihack-hooks/src/main.rs
@@ -31,6 +31,12 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     let subcommand = args.get(1).map(String::as_str).unwrap_or("");
 
+    // This is the real hook binary (not an in-process test harness), so allow
+    // the Signal integration to perform live I/O. Library/test contexts leave
+    // this OFF, keeping in-process hook tests free of real Signal side effects.
+    #[cfg(feature = "signal")]
+    amplihack_hooks::signal_integration::set_process_enabled(true);
+
     // Keeps the hooks binary on the same version-override contract as the
     // main `amplihack` binary (see `amplihack_cli::VERSION`). Without the
     // `AMPLIHACK_RELEASE_VERSION` env override here, the hooks binary would
@@ -51,14 +57,16 @@ fn main() {
         }
         "pre-tool-use" => run_hook(PreToolUseHook),
         "post-tool-use" => run_hook(PostToolUseHook),
-        // `session-end` and `session-stop` are aliases for `stop`. Dispatching
-        // to the same StopHook instance keeps behavior identical for hosts that
-        // still use either event name.
-        "stop" | "session-end" | "session-stop" => run_hook(StopHook),
+        // Per-turn stop events: OUTBOUND relay only, never Signal teardown.
+        // Tearing down the group here would kill the whole-session channel
+        // after the first turn (see `is_teardown_subcommand`).
+        "stop" | "agentStop" => run_hook(StopHook),
         "session-start" => run_hook(SessionStartHook),
-        // SessionStop event handler (distinct from the alias above) — kept
-        // for hosts that wire SessionStop separately from Stop.
-        "session-stop-event" => run_hook(SessionStopHook),
+        // Whole-session teardown events (incl. Copilot's `sessionEnd`) → leave
+        // the Signal group exactly once at session end.
+        "session-end" | "session-stop" | "session-stop-event" | "sessionEnd" => {
+            run_hook(SessionStopHook)
+        }
         "workflow-classification-reminder" => run_hook(WorkflowClassificationReminderHook),
         "user-prompt" | "user-prompt-submit" => run_hook(UserPromptSubmitHook),
         "pre-compact" => run_hook(PreCompactHook),

--- a/crates/amplihack-cli/src/commands/install/copilot_plugin.rs
+++ b/crates/amplihack-cli/src/commands/install/copilot_plugin.rs
@@ -107,7 +107,7 @@ fn write_plugin_manifest(plugin_dir: &Path, commands_staged: bool) -> Result<()>
 ///
 /// Event-name mapping (Claude Code → Copilot CLI):
 /// - SessionStart      → sessionStart
-/// - Stop              → sessionEnd          (closest analog)
+/// - SessionEnd        → sessionEnd          (per-session teardown)
 /// - UserPromptSubmit  → userPromptSubmitted
 /// - PreToolUse        → preToolUse
 /// - PostToolUse       → postToolUse
@@ -117,7 +117,11 @@ fn write_plugin_manifest(plugin_dir: &Path, commands_staged: bool) -> Result<()>
 fn write_hooks_json(plugin_dir: &Path, hooks_bin: &Path) -> Result<()> {
     let bin = validate_copilot_hooks_bin(hooks_bin)?;
     let session_start = copilot_hook_command(&bin, "session-start")?;
-    let session_end = copilot_hook_command(&bin, "stop")?;
+    // Copilot's `sessionEnd` fires once at genuine session end, so route it to
+    // the session-stop-event subcommand (SessionStopHook) which performs Signal
+    // channel teardown. The per-turn `stop` subcommand must NOT be used here —
+    // it only relays outbound and would never tear the subscriber down.
+    let session_end = copilot_hook_command(&bin, "session-stop-event")?;
     let workflow_classification = copilot_hook_command(&bin, "workflow-classification-reminder")?;
     let user_prompt_submit = copilot_hook_command(&bin, "user-prompt-submit")?;
     let pre_tool_use = copilot_hook_command(&bin, "pre-tool-use")?;
@@ -528,6 +532,38 @@ mod tests {
         assert!(
             raw.contains("amplihack-hooks"),
             "hooks.json should invoke the amplihack-hooks binary"
+        );
+    }
+
+    #[test]
+    fn hooks_json_session_end_routes_to_session_teardown() {
+        // Regression: the Copilot plugin `sessionEnd` event must invoke the
+        // `session-stop-event` subcommand (SessionStopHook → Signal teardown),
+        // NOT the per-turn `stop` subcommand which only relays outbound and
+        // would leave the detached subscriber orphaned.
+        let td = TempDir::new().unwrap();
+        let copilot_home = fake_copilot_home(&td);
+        let repo = fake_repo(&td, false);
+        let hooks_bin = td.path().join("amplihack-hooks");
+        fs::write(&hooks_bin, b"#!/bin/sh\nexit 0\n").unwrap();
+
+        assert!(run_with_copilot_home(&copilot_home, &repo, &hooks_bin));
+
+        let hooks_path = copilot_home
+            .join("installed-plugins")
+            .join("amplihack@local")
+            .join("hooks.json");
+        let body: Value = serde_json::from_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        let session_end = body["hooks"]["sessionEnd"][0]["bash"]
+            .as_str()
+            .expect("sessionEnd bash command must be present");
+        assert!(
+            session_end.contains("session-stop-event"),
+            "sessionEnd must invoke session-stop-event, got: {session_end}"
+        );
+        assert!(
+            !session_end.contains(" stop"),
+            "sessionEnd must not invoke the per-turn stop subcommand, got: {session_end}"
         );
     }
 

--- a/crates/amplihack-cli/src/commands/install/tests/hook_specs.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/hook_specs.rs
@@ -23,6 +23,21 @@ fn legacy_hook_script_name_maps_known_binary_subcommands() {
     assert_eq!(hooks::legacy_hook_script_name("unknown"), None);
 }
 
+#[test]
+fn amplihack_hook_specs_session_end_tears_down_signal_channel() {
+    // Regression: per-session Signal teardown moved from the per-turn `Stop`
+    // hook to SessionStop. Claude Code installs MUST register a `SessionEnd`
+    // hook routing to `session-stop-event`, otherwise the detached subscriber
+    // is never terminated (orphaned-process regression).
+    let spec = AMPLIHACK_HOOK_SPECS
+        .iter()
+        .find(|s| s.event == "SessionEnd")
+        .expect("SessionEnd spec must exist so session teardown is registered");
+    let HookCommandKind::BinarySubcmd { subcmd } = &spec.cmd;
+    assert_eq!(*subcmd, "session-stop-event");
+    assert!(spec.matcher.is_none());
+}
+
 // ─── TDD: Group 2 — AMPLIHACK_HOOK_SPECS canonical entries ───────────────
 
 #[test]

--- a/crates/amplihack-cli/src/commands/install/types.rs
+++ b/crates/amplihack-cli/src/commands/install/types.rs
@@ -253,6 +253,17 @@ pub(super) const CANONICAL_AMPLIHACK_HOOK_CONTRACT: &[CanonicalHookContractEntry
         timeout: Some(30),
         matcher: None,
     },
+    // SessionEnd fires once when a Claude Code session genuinely terminates.
+    // It drives per-session Signal channel teardown (leave group, stop the
+    // detached subscriber). Unlike the per-turn `Stop` hook, this is the only
+    // safe place to tear the channel down without killing it mid-session.
+    CanonicalHookContractEntry {
+        event: "SessionEnd",
+        hook_file: None,
+        native_subcmd: Some("session-stop-event"),
+        timeout: Some(30),
+        matcher: None,
+    },
 ];
 
 pub(super) const AMPLIHACK_HOOK_SPECS: &[HookSpec] = &[
@@ -308,6 +319,17 @@ pub(super) const AMPLIHACK_HOOK_SPECS: &[HookSpec] = &[
         event: "PreCompact",
         cmd: HookCommandKind::BinarySubcmd {
             subcmd: "pre-compact",
+        },
+        timeout: Some(30),
+        matcher: None,
+    },
+    // Session teardown: fires once at genuine session end (Claude `SessionEnd`).
+    // Routes to SessionStopHook, which performs per-session Signal channel
+    // teardown (leave group + stop the detached subscriber).
+    HookSpec {
+        event: "SessionEnd",
+        cmd: HookCommandKind::BinarySubcmd {
+            subcmd: "session-stop-event",
         },
         timeout: Some(30),
         matcher: None,

--- a/crates/amplihack-cli/src/copilot_setup/hooks.rs
+++ b/crates/amplihack-cli/src/copilot_setup/hooks.rs
@@ -198,6 +198,7 @@ fn is_amplihack_owned(entry: &serde_json::Value) -> bool {
         || bash.contains("/.github/hooks/post-tool-use")
         || bash.contains("/.github/hooks/pre-compact")
         || bash.contains("/.github/hooks/stop")
+        || bash.contains("/.github/hooks/session-end")
 }
 
 pub(super) fn generate_copilot_instructions(copilot_home: &Path) -> Result<()> {
@@ -440,6 +441,87 @@ mod tests {
             script.display(),
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // ----------------------------------------------------------------------
+    // R5 (issue #1002): wire Copilot's `sessionEnd` event so whole-session
+    // teardown fires and subscribers/groups do not leak on Copilot session end.
+    //
+    // Copilot DOES emit `sessionEnd`, but amplihack never wired it, so the
+    // Signal channel was only ever torn down (incorrectly) by the per-turn
+    // `agentStop` path. These tests pin the installer contract:
+    //   * a `sessionEnd` wrapper exists, dispatching the `session-stop-event`
+    //     subcommand (which runs SessionStopHook → teardown),
+    //   * the generated user-level `~/.copilot/config.json` registers it,
+    //   * `is_amplihack_owned` recognizes the new wrapper so re-running setup
+    //     replaces rather than duplicates it.
+    //
+    // RED: these fail until the `sessionEnd` wrapper + ownership matcher land.
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn copilot_wrappers_include_session_end_to_session_stop_event() {
+        let spec = COPILOT_HOOK_WRAPPERS
+            .iter()
+            .find(|s| s.copilot_event == "sessionEnd")
+            .expect("a sessionEnd wrapper must be registered so teardown fires");
+        assert!(
+            spec.subcommands.contains(&"session-stop-event"),
+            "sessionEnd must dispatch the session-stop-event subcommand (teardown), got {:?}",
+            spec.subcommands
+        );
+    }
+
+    #[test]
+    fn per_turn_agent_stop_wrapper_does_not_teardown_the_channel() {
+        // The per-turn `agentStop` wrapper must keep dispatching only `stop`
+        // (outbound relay). If it dispatched a teardown subcommand the group
+        // would be destroyed after every turn.
+        let spec = COPILOT_HOOK_WRAPPERS
+            .iter()
+            .find(|s| s.copilot_event == "agentStop")
+            .expect("agentStop wrapper present");
+        assert!(
+            !spec.subcommands.contains(&"session-stop-event"),
+            "per-turn agentStop must NOT run teardown"
+        );
+        assert!(spec.subcommands.contains(&"stop"));
+    }
+
+    #[test]
+    fn user_level_config_registers_session_end_hook() {
+        let copilot_home = tempfile::tempdir().unwrap();
+        write_user_level_hooks(copilot_home.path()).unwrap();
+
+        let raw = fs::read_to_string(copilot_home.path().join("config.json")).unwrap();
+        let cfg: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let hooks = cfg["hooks"].as_object().expect("hooks object");
+        let arr = hooks
+            .get("sessionEnd")
+            .and_then(|v| v.as_array())
+            .expect("sessionEnd must be registered in ~/.copilot/config.json");
+        assert!(!arr.is_empty(), "sessionEnd must have a wrapper entry");
+        let bash = arr[0]["bash"]
+            .as_str()
+            .or_else(|| arr[0]["command"].as_str())
+            .unwrap_or("");
+        assert!(
+            bash.contains("session-end") || bash.contains("session-stop-event"),
+            "sessionEnd wrapper must point at the session-end teardown hook; got {bash:?}"
+        );
+    }
+
+    #[test]
+    fn is_amplihack_owned_recognizes_session_end_wrapper() {
+        let entry = serde_json::json!({
+            "type": "command",
+            "bash": "/home/user/.copilot/.github/hooks/session-end \"$@\""
+        });
+        assert!(
+            is_amplihack_owned(&entry),
+            "the session-end wrapper must be recognized as amplihack-owned so \
+             re-running setup replaces it instead of leaving a duplicate"
         );
     }
 }

--- a/crates/amplihack-cli/src/copilot_setup/mod.rs
+++ b/crates/amplihack-cli/src/copilot_setup/mod.rs
@@ -63,6 +63,14 @@ const COPILOT_HOOK_WRAPPERS: &[HookWrapperSpec] = &[
         copilot_event: "agentStop",
         subcommands: &["stop"],
     },
+    HookWrapperSpec {
+        // Whole-session teardown: Copilot fires `sessionEnd` once when the
+        // session ends. Route it to `session-stop-event` (SessionStopHook) so
+        // the Signal group is left exactly once — never per turn.
+        hook_name: "session-end",
+        copilot_event: "sessionEnd",
+        subcommands: &["session-stop-event"],
+    },
 ];
 
 pub fn ensure_copilot_home_staged() -> Result<()> {

--- a/crates/amplihack-hooks/Cargo.toml
+++ b/crates/amplihack-hooks/Cargo.toml
@@ -38,6 +38,7 @@ signal = ["dep:amplihack-signal", "amplihack-signal/signal", "dep:tokio", "dep:l
 
 [dev-dependencies]
 tempfile = { workspace = true }
+serde_json = { workspace = true }
 
 [[test]]
 name = "golden"

--- a/crates/amplihack-hooks/src/lib.rs
+++ b/crates/amplihack-hooks/src/lib.rs
@@ -45,6 +45,24 @@ pub mod known_agents;
 /// Host-specific hook strategies (Claude, Copilot).
 pub mod strategies;
 
+/// Classify a hooks-binary subcommand name as a **whole-session teardown**
+/// event (as opposed to a per-turn stop event).
+///
+/// Whole-session teardown events (`session-end`, `session-stop`,
+/// `session-stop-event`, and Copilot's `sessionEnd`) route to the
+/// [`SessionStopHook`] and perform Signal group teardown **once** at the end of
+/// the session. Per-turn events (`stop`, `agentStop`) must **not** be treated as
+/// teardown — doing so would quit the Signal group after the first turn and
+/// kill the whole-session channel. This is the single source of truth for that
+/// distinction, shared by the hooks binary dispatch and the Signal integration.
+#[must_use]
+pub fn is_teardown_subcommand(name: &str) -> bool {
+    matches!(
+        name,
+        "session-end" | "session-stop" | "session-stop-event" | "sessionEnd"
+    )
+}
+
 // Re-export hook structs for ergonomic access.
 /// Post-tool-use hook implementation.
 pub use post_tool_use::PostToolUseHook;

--- a/crates/amplihack-hooks/src/post_tool_use/mod.rs
+++ b/crates/amplihack-hooks/src/post_tool_use/mod.rs
@@ -105,17 +105,32 @@ impl Hook for PostToolUseHook {
         }
 
         // Signal channel: surface queued operator instructions (advisory
-        // context, never commands) via hookSpecificOutput.additionalContext.
+        // context, never commands). Host-aware shaping so Copilot (top-level
+        // string) actually receives them, not just Claude (nested).
         if let Some(operator_context) =
             crate::signal_integration::drain_into_context(session_id.as_deref())
         {
-            output.insert(
-                "hookSpecificOutput".to_string(),
-                serde_json::json!({
-                    "hookEventName": "PostToolUse",
-                    "additionalContext": operator_context,
-                }),
-            );
+            #[cfg(feature = "signal")]
+            {
+                let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+                let host = crate::signal_integration::inject_host(&cwd);
+                crate::signal_integration::merge_additional_context(
+                    &mut output,
+                    &host,
+                    "PostToolUse",
+                    &operator_context,
+                );
+            }
+            #[cfg(not(feature = "signal"))]
+            {
+                output.insert(
+                    "hookSpecificOutput".to_string(),
+                    serde_json::json!({
+                        "hookEventName": "PostToolUse",
+                        "additionalContext": operator_context,
+                    }),
+                );
+            }
         }
 
         Ok(Value::Object(output))

--- a/crates/amplihack-hooks/src/pre_compact/mod.rs
+++ b/crates/amplihack-hooks/src/pre_compact/mod.rs
@@ -21,6 +21,10 @@ impl Hook for PreCompactHook {
         "pre_compact"
     }
 
+    fn hook_event_name(&self) -> Option<&'static str> {
+        Some("PreCompact")
+    }
+
     fn failure_policy(&self) -> FailurePolicy {
         FailurePolicy::Open
     }

--- a/crates/amplihack-hooks/src/protocol.rs
+++ b/crates/amplihack-hooks/src/protocol.rs
@@ -36,6 +36,21 @@ pub trait Hook {
     fn failure_policy(&self) -> FailurePolicy {
         FailurePolicy::Open
     }
+
+    /// Canonical `hook_event_name` this hook handles (e.g. `"SessionStart"`).
+    ///
+    /// The multicall binary dispatches by subcommand, so the event is known
+    /// from argv even when the host omits it from the payload. Some hosts
+    /// (notably GitHub Copilot CLI) send SessionStart/UserPromptSubmit/Stop
+    /// payloads with **no** `hook_event_name`/`hookEventName` field. Without
+    /// this, such payloads deserialize to [`HookInput::Unknown`] and the hook
+    /// silently no-ops. When this returns `Some(_)`, `run_hook` injects the
+    /// event name into an event-less object payload before deserializing, so
+    /// dispatch is deterministic regardless of host. Returns `None` for hooks
+    /// that should rely solely on payload-based detection.
+    fn hook_event_name(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 /// Run a hook with full protocol handling.
@@ -55,8 +70,8 @@ pub fn run_hook<H: Hook>(hook: H) {
     let result = std::panic::catch_unwind(AssertUnwindSafe(|| -> anyhow::Result<()> {
         let input_json = read_stdin()?;
 
-        let input: HookInput =
-            serde_json::from_str(&input_json).context("failed to deserialize hook input JSON")?;
+        let input: HookInput = deserialize_hook_input(&input_json, hook.hook_event_name())
+            .context("failed to deserialize hook input JSON")?;
 
         // Unknown events get versioned empty output (graceful forward-compat).
         if matches!(input, HookInput::Unknown) {
@@ -105,6 +120,36 @@ pub fn run_hook<H: Hook>(hook: H) {
             let _ = io::stdout().flush();
         }
     }
+}
+
+/// Deserialize the hook payload, injecting a known `hook_event_name` when the
+/// host omitted it.
+///
+/// GitHub Copilot CLI sends SessionStart/UserPromptSubmit/Stop payloads without
+/// any `hook_event_name`/`hookEventName` field. Since the multicall binary
+/// dispatched to a specific hook (via subcommand), we know the intended event
+/// and inject it into an event-less JSON object so the payload deserializes to
+/// the right [`HookInput`] variant instead of [`HookInput::Unknown`]. Payloads
+/// that already carry an event field, non-object payloads, and hooks that
+/// return `None` from [`Hook::hook_event_name`] are passed through unchanged.
+fn deserialize_hook_input(
+    input_json: &str,
+    known_event: Option<&str>,
+) -> anyhow::Result<HookInput> {
+    if let Some(event) = known_event
+        && let Ok(serde_json::Value::Object(mut map)) =
+            serde_json::from_str::<serde_json::Value>(input_json)
+    {
+        let has_event = map.contains_key("hook_event_name") || map.contains_key("hookEventName");
+        if !has_event {
+            map.insert(
+                "hook_event_name".to_string(),
+                serde_json::Value::String(event.to_string()),
+            );
+            return Ok(serde_json::from_value(serde_json::Value::Object(map))?);
+        }
+    }
+    Ok(serde_json::from_str(input_json)?)
 }
 
 /// Read all of stdin as a string.
@@ -189,5 +234,32 @@ mod tests {
     fn test_hook_default_policy() {
         let hook = TestHook;
         assert_eq!(hook.failure_policy(), FailurePolicy::Open);
+    }
+
+    #[test]
+    fn injects_event_name_for_eventless_copilot_session_start() {
+        // Real Copilot CLI SessionStart payload shape: no hook_event_name.
+        let payload = r#"{"sessionId":"abc-123","cwd":"/tmp","source":"new","initialPrompt":"hi"}"#;
+        let input = deserialize_hook_input(payload, Some("SessionStart")).unwrap();
+        match input {
+            HookInput::SessionStart { session_id, .. } => {
+                assert_eq!(session_id.as_deref(), Some("abc-123"));
+            }
+            other => panic!("expected SessionStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn does_not_override_present_event_name() {
+        let payload = r#"{"hook_event_name":"Stop","session_id":"z"}"#;
+        let input = deserialize_hook_input(payload, Some("SessionStart")).unwrap();
+        assert!(matches!(input, HookInput::Stop { .. }));
+    }
+
+    #[test]
+    fn eventless_payload_without_known_event_stays_unknown() {
+        let payload = r#"{"sessionId":"abc-123","source":"new"}"#;
+        let input = deserialize_hook_input(payload, None).unwrap();
+        assert!(matches!(input, HookInput::Unknown));
     }
 }

--- a/crates/amplihack-hooks/src/session_start/mod.rs
+++ b/crates/amplihack-hooks/src/session_start/mod.rs
@@ -35,6 +35,10 @@ impl Hook for SessionStartHook {
         "session_start"
     }
 
+    fn hook_event_name(&self) -> Option<&'static str> {
+        Some("SessionStart")
+    }
+
     fn failure_policy(&self) -> FailurePolicy {
         FailurePolicy::Open
     }

--- a/crates/amplihack-hooks/src/session_stop/mod.rs
+++ b/crates/amplihack-hooks/src/session_stop/mod.rs
@@ -25,6 +25,10 @@ impl Hook for SessionStopHook {
         "session_stop"
     }
 
+    fn hook_event_name(&self) -> Option<&'static str> {
+        Some("SessionStop")
+    }
+
     fn failure_policy(&self) -> FailurePolicy {
         FailurePolicy::Open
     }
@@ -66,6 +70,13 @@ impl Hook for SessionStopHook {
         }
 
         git::warn_uncommitted_work();
+
+        // Session is genuinely ending: tear down the per-session Signal channel
+        // (post a summary, leave the group, stop the detached subscriber).
+        // Non-fatal. This is the correct place for teardown — unlike the
+        // per-turn `Stop`/`agentStop` hook, `SessionStop` fires once at the end
+        // of the session.
+        crate::signal_integration::on_stop(&session_id);
 
         Ok(Value::Object(serde_json::Map::new()))
     }

--- a/crates/amplihack-hooks/src/signal_integration/host_context.rs
+++ b/crates/amplihack-hooks/src/signal_integration/host_context.rs
@@ -1,0 +1,53 @@
+//! R2 — host-aware `additionalContext` injection.
+//!
+//! Different agent hosts read hook output differently:
+//!
+//! * **Copilot CLI** expects a **top-level** `additionalContext` **string** on
+//!   the `userPromptSubmitted` hook result. If context is nested under Claude's
+//!   `hookSpecificOutput`, Copilot silently ignores it — which is exactly why
+//!   inbound Signal operator messages were being dropped.
+//! * **Claude Code** (and every other host we do not special-case) expects the
+//!   nested `hookSpecificOutput { hookEventName, additionalContext }` shape.
+//!
+//! [`merge_additional_context`] is a **pure** output shaper: it mutates a
+//! `serde_json` object map additively (never clobbering pre-existing keys such
+//! as `warnings`/`metadata`), so it is deterministic and parallel-safe.
+//! [`inject_host`] resolves the active host from the working directory via the
+//! shared agent-binary resolver, falling back to Copilot.
+
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+/// Merge Signal/operator `additionalContext` into `out` using the shape the
+/// given `host` actually understands.
+///
+/// * `host == "copilot"` → insert a **top-level** `additionalContext` string.
+/// * any other host → insert the nested Claude-compatible
+///   `hookSpecificOutput { hookEventName: event, additionalContext: ctx }`.
+///
+/// Additive: existing keys in `out` are preserved.
+pub fn merge_additional_context(out: &mut Map<String, Value>, host: &str, event: &str, ctx: &str) {
+    if host == "copilot" {
+        out.insert(
+            "additionalContext".to_string(),
+            Value::String(ctx.to_string()),
+        );
+    } else {
+        out.insert(
+            "hookSpecificOutput".to_string(),
+            serde_json::json!({
+                "hookEventName": event,
+                "additionalContext": ctx,
+            }),
+        );
+    }
+}
+
+/// Resolve the active agent host for `cwd` (an allowlisted binary name:
+/// `copilot`/`claude`/`codex`/`amplifier`). Falls back to `copilot` if
+/// resolution fails, so callers always get a safe, known identifier.
+#[must_use]
+pub fn inject_host(cwd: &Path) -> String {
+    amplihack_utils::agent_binary::resolve(cwd).unwrap_or_else(|_| "copilot".to_string())
+}

--- a/crates/amplihack-hooks/src/signal_integration/imp.rs
+++ b/crates/amplihack-hooks/src/signal_integration/imp.rs
@@ -549,6 +549,10 @@ fn stop(session_id: &str) -> anyhow::Result<()> {
     // session (bounded during the session, removed entirely at teardown).
     super::outbound::clear_outbound_fingerprints(&root, session_id);
 
+    // Drop the per-session outbound-fingerprint log so it does not outlive the
+    // session (bounded during the session, removed entirely at teardown).
+    super::outbound::clear_outbound_fingerprints(&root, session_id);
+
     Ok(())
 }
 

--- a/crates/amplihack-hooks/src/signal_integration/imp.rs
+++ b/crates/amplihack-hooks/src/signal_integration/imp.rs
@@ -316,11 +316,13 @@ fn is_stderr_tty() -> bool {
 }
 
 /// Name a session's group.
-/// Prefers a human-readable `amplihack-<hostname>-<tmux-session>` when the
-/// session runs inside tmux (the common fleet case), so operators can tell
-/// which host/pane a Signal group belongs to at a glance. Outside tmux it
-/// falls back to `amplihack-<hostname>-<session-id>-<unix-ts>`, which keeps the
-/// unique session id + timestamp so groups never collide.
+/// Prefers a human-readable `amplihack-<hostname>-<tmux-session>-<session-id>`
+/// when the session runs inside tmux (the common fleet case), so operators can
+/// tell which host/pane a Signal group belongs to at a glance while still
+/// keeping the unique session id so repeated top-level runs in the same
+/// long-lived tmux session never collide on name. Outside tmux it falls back to
+/// `amplihack-<hostname>-<session-id>-<unix-ts>`, which likewise keeps the
+/// unique session id (plus timestamp) so groups never collide.
 fn group_name(session_id: &str) -> String {
     compose_group_name(
         &short_hostname(),
@@ -331,14 +333,17 @@ fn group_name(session_id: &str) -> String {
 
 /// Pure name composer (no env/tmux access) so the two branches are testable.
 fn compose_group_name(host: &str, tmux: Option<&str>, session_id: &str) -> String {
+    let sanitized = amplihack_types::paths::sanitize_session_id(session_id);
     if let Some(tmux) = tmux {
-        return sanitize_label(&format!("amplihack-{host}-{tmux}"));
+        // Keep the tmux name for human readability AND the session id for
+        // uniqueness, so two top-level runs in the same tmux session get
+        // distinct group names.
+        return sanitize_label(&format!("amplihack-{host}-{tmux}-{sanitized}"));
     }
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or_default();
-    let sanitized = amplihack_types::paths::sanitize_session_id(session_id);
     sanitize_label(&format!("amplihack-{host}-{sanitized}-{ts}"))
 }
 
@@ -916,15 +921,22 @@ mod tests {
     }
 
     #[test]
-    fn group_name_tmux_branch_is_hostname_plus_session() {
+    fn group_name_tmux_branch_is_hostname_tmux_and_session() {
+        // tmux name (readability) + session id (uniqueness) are both retained.
         assert_eq!(
             compose_group_name("deva", Some("recipe-runner"), "sess-xyz"),
-            "amplihack-deva-recipe-runner"
+            "amplihack-deva-recipe-runner-sess-xyz"
         );
         // Spaces / unsafe chars in the tmux name collapse to dashes.
         assert_eq!(
             compose_group_name("deva", Some("my sess/2"), "sess-xyz"),
-            "amplihack-deva-my-sess-2"
+            "amplihack-deva-my-sess-2-sess-xyz"
+        );
+        // Two runs in the SAME tmux session but different session ids must not
+        // collide on name.
+        assert_ne!(
+            compose_group_name("deva", Some("recipe-runner"), "sess-a"),
+            compose_group_name("deva", Some("recipe-runner"), "sess-b"),
         );
     }
 

--- a/crates/amplihack-hooks/src/signal_integration/imp.rs
+++ b/crates/amplihack-hooks/src/signal_integration/imp.rs
@@ -2,14 +2,14 @@
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use amplihack_signal::config::SignalConfig;
 use amplihack_signal::gating::Gate;
-use amplihack_signal::session_channel::Inbox;
+use amplihack_signal::session_channel::{Inbox, PushOutcome};
 use amplihack_signal::transport::{GroupId, SignalTransport};
 use amplihack_state::atomic_json::AtomicJsonFile;
-use amplihack_types::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
 /// Wall-clock budget for any single network step during a hook so a slow or
@@ -24,10 +24,6 @@ const RECONNECT_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 /// a steady, low rate rather than an ever-growing delay.
 const RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
-/// Consecutive reconnect failures tolerated before the subscriber gives up.
-/// Reset to zero whenever an inbound message proves the link healthy.
-const RECONNECT_MAX_CONSECUTIVE_FAILURES: u32 = 5;
-
 /// Persisted per-session Signal state shared across the hook and subscriber
 /// processes (via [`AtomicJsonFile`]).
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -41,8 +37,26 @@ struct SignalState {
 }
 
 /// Root directory holding per-session Signal state and inboxes.
-fn signal_root(dirs: &ProjectDirs) -> PathBuf {
-    dirs.runtime.join("signal")
+///
+/// This MUST be independent of the current working directory. The SessionStart
+/// hook, the detached subscriber, and the prompt/stop drainers each run with
+/// potentially different cwds (e.g. Copilot CLI invokes hooks from its plugin
+/// directory while the agent's cwd is the project root), so a cwd-derived root
+/// (`ProjectDirs::from_cwd`) splits a single session's state across multiple
+/// locations — breaking idempotent group reuse and inbound delivery. Anchor it
+/// at the stable `~/.amplihack/runtime/signal` base instead (the same
+/// `~/.amplihack` home used for `signal-config.toml`), keyed only by session id
+/// (a globally-unique UUID), so all participants agree regardless of cwd.
+fn signal_root() -> PathBuf {
+    if let Some(dir) = std::env::var_os("AMPLIHACK_SIGNAL_STATE_DIR")
+        && !dir.is_empty()
+    {
+        return PathBuf::from(dir);
+    }
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    home.join(".amplihack").join("runtime").join("signal")
 }
 
 /// Path to a session's state file under `root`.
@@ -71,10 +85,46 @@ where
     }
 }
 
+/// Whether this *process* may perform real Signal I/O (network + spawning the
+/// detached subscriber + creating/leaving groups).
+///
+/// Defaults to `false` so that in-process hook tests (the golden runner and any
+/// unit/integration test that drives a hook's `process()` directly through the
+/// library) never touch the real Signal daemon or the operator's real
+/// `~/.amplihack` state. The real multicall hook binary flips this on once at
+/// startup via [`set_process_enabled`]; a test that specifically exercises the
+/// live channel can opt in the same way.
+static SIGNAL_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable (or disable) real Signal I/O for the current process. Called once by
+/// the `amplihack-hooks` binary entrypoint before dispatching a hook.
+pub fn set_process_enabled(enabled: bool) {
+    SIGNAL_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+fn process_enabled() -> bool {
+    SIGNAL_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Whether the Signal channel is actually usable in this process: real I/O has
+/// been enabled (only the hook binary does this) *and* a config loads. Hooks use
+/// this to decide whether to reshape their output for the operator's host —
+/// when the channel is not configured (the default, and every in-process test),
+/// output must stay byte-for-byte identical to the non-signal build so the
+/// golden contract is preserved.
+pub fn is_channel_configured() -> bool {
+    load_config_or_disabled().is_some()
+}
+
 /// Load the Signal config, treating an unloadable/absent config as "the channel
 /// is simply not configured" (disabled) rather than an operational failure.
 /// Returns `None` to mean "do nothing, successfully".
 fn load_config_or_disabled() -> Option<SignalConfig> {
+    // Fail closed in library/test contexts: only the real hook binary enables
+    // Signal I/O, so in-process hook tests never create real groups/subscribers.
+    if !process_enabled() {
+        return None;
+    }
     match SignalConfig::load() {
         Ok(c) => Some(c),
         Err(err) => {
@@ -136,13 +186,51 @@ fn start(session_id: &str) -> anyhow::Result<()> {
     }
 
     // A missing/invalid config simply means the channel is not configured;
-    // treat it as "disabled" rather than an operational warning.
+    // treat it as "disabled" rather than an operational warning. When
+    // unconfigured on an interactive host, surface a one-time onboarding notice.
     let Some(config) = load_config_or_disabled() else {
+        maybe_prompt_onboarding();
         return Ok(());
     };
 
-    let dirs = ProjectDirs::from_cwd();
-    let root = signal_root(&dirs);
+    let root = signal_root();
+    let state_file = AtomicJsonFile::new(state_path(&root, session_id));
+
+    // SessionStart can fire more than once per session (some runtimes, e.g.
+    // Copilot CLI, emit it repeatedly). Make setup idempotent: if this session
+    // already has a group, reuse it instead of creating a duplicate, and only
+    // (re)spawn the subscriber when the recorded one is no longer alive.
+    let existing = state_file
+        .read::<SignalState>()
+        .map_err(|e| anyhow::anyhow!("failed to read existing signal state: {e}"))?;
+    if let Some(existing_gid) = existing
+        .as_ref()
+        .and_then(|s| s.group_id.as_ref())
+        .filter(|g| !g.is_empty())
+        .cloned()
+    {
+        let subscriber_alive = existing
+            .as_ref()
+            .and_then(|s| s.subscriber_pid)
+            .is_some_and(|pid| pid_is_our_subscriber(pid, session_id));
+        if !subscriber_alive {
+            match spawn_subscriber(session_id) {
+                Ok(pid) => {
+                    if let Err(err) =
+                        state_file.update(|s: &mut SignalState| s.subscriber_pid = Some(pid))
+                    {
+                        tracing::warn!("signal: failed to persist respawned subscriber pid: {err}");
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!("signal: failed to respawn subscriber: {err}");
+                }
+            }
+        }
+        tracing::debug!("signal: reusing existing group {existing_gid} for session");
+        return Ok(());
+    }
+
     let group_name = group_name(session_id);
 
     let rt = runtime()?;
@@ -163,7 +251,6 @@ fn start(session_id: &str) -> anyhow::Result<()> {
     })?;
 
     // Persist the group id so the subscriber and drainers can find it.
-    let state_file = AtomicJsonFile::new(state_path(&root, session_id));
     let gid_str = group_id.as_str().to_string();
     state_file
         .update(|s: &mut SignalState| s.group_id = Some(gid_str.clone()))
@@ -172,7 +259,10 @@ fn start(session_id: &str) -> anyhow::Result<()> {
     // Spawn the detached subscriber and persist its PID.
     match spawn_subscriber(session_id) {
         Ok(pid) => {
-            let _ = state_file.update(|s: &mut SignalState| s.subscriber_pid = Some(pid));
+            if let Err(err) = state_file.update(|s: &mut SignalState| s.subscriber_pid = Some(pid))
+            {
+                tracing::warn!("signal: failed to persist subscriber pid: {err}");
+            }
         }
         Err(err) => {
             tracing::warn!("signal: failed to spawn subscriber: {err}");
@@ -182,107 +272,132 @@ fn start(session_id: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Name a session's group, embedding the current tmux session name when
-/// available so an operator can tell which Signal group maps to which session.
-///
-/// With a tmux name: `amplihack-<tmux>-<session-id>-<unix-ts>`.
-/// Without tmux (or on any lookup failure): `amplihack-<session-id>-<unix-ts>`
-/// (the historical form).
+/// One-time, **non-blocking** onboarding notice shown when Signal is not yet
+/// configured on an interactive host. Hooks cannot run an interactive prompt
+/// (stdout is parsed as JSON, and the ~30s budget forbids the QR/device-link
+/// flow), so this surfaces guidance on stderr at most once per host and records
+/// a "notified" sentinel so it never nags on subsequent turns/sessions. The
+/// decision is gated by the pure [`super::onboarding::should_prompt`].
+fn maybe_prompt_onboarding() {
+    use super::onboarding::{OnboardingDecision, OnboardingEnv, should_prompt};
+
+    let root = signal_root();
+    let env = OnboardingEnv {
+        config_present: false, // reached only from the unconfigured branch
+        is_tty: is_stderr_tty(),
+        noninteractive: std::env::var_os("AMPLIHACK_NONINTERACTIVE").is_some(),
+        declined_before: super::onboarding::onboarding_declined(&root),
+    };
+    if should_prompt(&env) != OnboardingDecision::Prompt {
+        return;
+    }
+
+    // Show at most once per host (independent of the "declined" sentinel).
+    let notified = root.join("signal-onboarding-notified");
+    if notified.exists() {
+        return;
+    }
+    let _ = std::fs::create_dir_all(&root);
+    let _ = std::fs::write(&notified, b"1\n");
+
+    eprintln!(
+        "\n[amplihack] Signal session mirroring is available but not configured on \
+         this host.\n  Link signal-cli on this device to mirror your whole session \
+         to a private Signal\n  group and send replies back from your phone. See \
+         docs/SIGNAL_ONBOARDING.md to enable,\n  or run onboarding to decline \
+         permanently (suppresses this notice).\n"
+    );
+}
+
+/// Whether stderr is an interactive terminal.
+fn is_stderr_tty() -> bool {
+    // SAFETY: `isatty` on a valid fd has no memory-safety implications.
+    unsafe { libc::isatty(libc::STDERR_FILENO) == 1 }
+}
+
+/// Name a session's group.
+/// Prefers a human-readable `amplihack-<hostname>-<tmux-session>` when the
+/// session runs inside tmux (the common fleet case), so operators can tell
+/// which host/pane a Signal group belongs to at a glance. Outside tmux it
+/// falls back to `amplihack-<hostname>-<session-id>-<unix-ts>`, which keeps the
+/// unique session id + timestamp so groups never collide.
 fn group_name(session_id: &str) -> String {
+    compose_group_name(
+        &short_hostname(),
+        tmux_session_name().as_deref(),
+        session_id,
+    )
+}
+
+/// Pure name composer (no env/tmux access) so the two branches are testable.
+fn compose_group_name(host: &str, tmux: Option<&str>, session_id: &str) -> String {
+    if let Some(tmux) = tmux {
+        return sanitize_label(&format!("amplihack-{host}-{tmux}"));
+    }
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or_default();
-    format_group_name(current_tmux_session().as_deref(), session_id, ts)
+    let sanitized = amplihack_types::paths::sanitize_session_id(session_id);
+    sanitize_label(&format!("amplihack-{host}-{sanitized}-{ts}"))
 }
 
-/// Pure group-name formatter (no I/O) so the tmux-aware naming is unit-testable
-/// without a real tmux. Both the tmux name and the session id are sanitized to
-/// the `[A-Za-z0-9_-]` allowlist (every other char becomes `_`); the tmux
-/// component is truncated to a bounded length so an adversarial/huge tmux name
-/// cannot produce an unbounded group name. An empty (or empty-after-sanitize)
-/// tmux name falls back to the no-tmux form.
-fn format_group_name(tmux: Option<&str>, session_id: &str, ts: u64) -> String {
-    let sanitized_id = amplihack_types::paths::sanitize_session_id(session_id);
-    match tmux.map(sanitize_group_component).filter(|s| !s.is_empty()) {
-        Some(tmux) => format!("amplihack-{tmux}-{sanitized_id}-{ts}"),
-        None => format!("amplihack-{sanitized_id}-{ts}"),
+/// Best-effort short hostname (first DNS label), trimmed. Falls back to
+/// `"unknown"` so the group name is always well-formed.
+fn short_hostname() -> String {
+    let raw = std::env::var("HOSTNAME")
+        .ok()
+        .filter(|h| !h.trim().is_empty())
+        .or_else(|| std::fs::read_to_string("/proc/sys/kernel/hostname").ok())
+        .unwrap_or_default();
+    let host = raw.trim();
+    let short = host.split('.').next().unwrap_or(host).trim();
+    if short.is_empty() {
+        "unknown".to_string()
+    } else {
+        short.to_string()
     }
 }
 
-/// Maximum length of the tmux component embedded in a group name.
-const TMUX_NAME_MAX_LEN: usize = 32;
-
-/// Sanitize an untrusted display component (e.g. a tmux session name) to the
-/// `[A-Za-z0-9_-]` allowlist and bound its length. Never panics on empty input.
-fn sanitize_group_component(name: &str) -> String {
-    name.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .take(TMUX_NAME_MAX_LEN)
-        .collect()
-}
-
-/// Look up the current tmux session name, or `None` when not running under tmux
-/// or the lookup fails/times out.
-///
-/// Gated on `TMUX` being set (so we never spawn `tmux` outside a tmux session),
-/// with a short timeout and graceful fallback: any failure yields `None` and
-/// the caller keeps the historical group-name form. Implemented locally with
-/// `std::process` (no `amplihack-cli` dependency) to avoid the layering
-/// inversion tracked in #875.
-fn current_tmux_session() -> Option<String> {
+/// The current tmux session name when running inside tmux, else `None`.
+/// Queries the tmux server via `$TMUX`/`$TMUX_PANE` inherited from the pane the
+/// session launched in; any failure (no tmux, no server) is treated as "not in
+/// tmux" and yields `None`.
+fn tmux_session_name() -> Option<String> {
     std::env::var_os("TMUX")?;
-    run_tmux_display_name(Duration::from_secs(2))
+    let mut cmd = std::process::Command::new("tmux");
+    cmd.arg("display-message").arg("-p");
+    if let Some(pane) = std::env::var_os("TMUX_PANE") {
+        cmd.arg("-t").arg(pane);
+    }
+    cmd.arg("#S");
+    let out = cmd.output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if name.is_empty() { None } else { Some(name) }
 }
 
-/// Run `tmux display-message -p '#{session_name}'` with an explicit argv (no
-/// shell) under `timeout`, returning the trimmed session name. On timeout the
-/// child is killed and reaped by the reader thread; any failure returns `None`.
-fn run_tmux_display_name(timeout: Duration) -> Option<String> {
-    use std::process::{Command, Stdio};
-
-    let child = Command::new("tmux")
-        .arg("display-message")
-        .arg("-p")
-        .arg("#{session_name}")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-    let pid = child.id();
-
-    // Read the output on a worker thread so the wall-clock timeout is enforced
-    // by `recv_timeout` rather than a blocking `wait`.
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(child.wait_with_output());
-    });
-
-    match rx.recv_timeout(timeout) {
-        Ok(Ok(output)) if output.status.success() => {
-            let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if name.is_empty() { None } else { Some(name) }
-        }
-        // Command ran but failed, or produced an I/O error: no tmux name.
-        Ok(_) => None,
-        // Timed out: kill the child (best-effort). The worker thread's
-        // `wait_with_output` then returns and reaps it, avoiding a zombie.
-        Err(_) => {
-            // SAFETY: `kill(2)` with a specific positive PID and SIGKILL has no
-            // memory-safety implications; a stale PID simply yields ESRCH.
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+/// Constrain a Signal group label to a safe charset (alphanumerics plus
+/// `-`, `_`, `.`), collapsing any other run to a single dash and trimming
+/// leading/trailing dashes. Prevents newlines/control chars from a hostname or
+/// tmux name leaking into the group title.
+fn sanitize_label(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_dash = false;
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' || c == '.' {
+            out.push(c);
+            prev_dash = false;
+        } else {
+            if !prev_dash {
+                out.push('-');
             }
-            None
+            prev_dash = true;
         }
     }
+    out.trim_matches('-').to_string()
 }
 
 /// Spawn `amplihack-hooks signal-subscriber --session-id <id>` detached from
@@ -315,13 +430,17 @@ fn spawn_subscriber(session_id: &str) -> std::io::Result<u32> {
 #[must_use]
 pub fn drain_into_context(session_id: Option<&str>) -> Option<String> {
     let session_id = normalize_session_id(session_id)?;
-    let dirs = ProjectDirs::from_cwd();
-    let root = signal_root(&dirs);
+    let root = signal_root();
     let inbox = Inbox::at_session(session_id, &root);
 
     // Cheap existence check first (does not create the file when unused).
-    if inbox.is_empty().unwrap_or(true) {
-        return None;
+    match inbox.is_empty() {
+        Ok(true) => return None,
+        Ok(false) => {}
+        Err(err) => {
+            tracing::warn!("signal: failed to check inbox before drain: {err}");
+            return None;
+        }
     }
     let items = match inbox.drain() {
         Ok(items) => items,
@@ -373,8 +492,7 @@ fn stop(session_id: &str) -> anyhow::Result<()> {
         return Ok(());
     };
 
-    let dirs = ProjectDirs::from_cwd();
-    let root = signal_root(&dirs);
+    let root = signal_root();
     let state_file = AtomicJsonFile::new(state_path(&root, session_id));
     let state: SignalState = match state_file.read() {
         Ok(Some(state)) => state,
@@ -401,22 +519,90 @@ fn stop(session_id: &str) -> anyhow::Result<()> {
         let mut transport =
             with_timeout("connect", SignalTransport::connect(&config.endpoint)).await?;
 
-        // Best-effort: a failed summary post or leave must not block teardown.
-        let _ = with_timeout("send", transport.send_group(&group_id, "session complete")).await;
+        // Best-effort: a failed summary post or leave must not block teardown,
+        // but it must still be observable.
+        if let Err(err) =
+            with_timeout("send", transport.send_group(&group_id, "session complete")).await
+        {
+            tracing::warn!("signal: failed to post session-complete marker: {err}");
+        }
 
         // A rolling group is intentionally reused across sessions; only leave a
         // per-session group.
-        if !config.reuse_rolling_group {
-            let _ = with_timeout("quit_group", transport.quit_group(&group_id)).await;
+        if !config.reuse_rolling_group
+            && let Err(err) = with_timeout("quit_group", transport.quit_group(&group_id)).await
+        {
+            tracing::warn!("signal: failed to leave session group: {err}");
         }
         Ok::<(), anyhow::Error>(())
     })?;
 
     // Clear the persisted group so a stale id is never reused.
-    let _ = state_file.update(|s: &mut SignalState| {
+    if let Err(err) = state_file.update(|s: &mut SignalState| {
         s.group_id = None;
         s.subscriber_pid = None;
-    });
+    }) {
+        tracing::warn!("signal: failed to clear session state at teardown: {err}");
+    }
+
+    // Drop the per-session outbound-fingerprint log so it does not outlive the
+    // session (bounded during the session, removed entirely at teardown).
+    super::outbound::clear_outbound_fingerprints(&root, session_id);
+
+    Ok(())
+}
+
+/// Mirror an outbound line (a user prompt or assistant turn) to the session's
+/// Signal group as part of full-conversation mirroring. Non-fatal and bounded:
+/// secrets are scrubbed via [`super::outbound::redact_for_relay`], the body is
+/// truncated to [`super::outbound::RELAY_MAX_BYTES`], and a fingerprint is
+/// persisted so the detached subscriber can suppress the echo.
+pub fn relay_outbound(session_id: Option<&str>, body: &str) {
+    let Some(session_id) = normalize_session_id(session_id) else {
+        return;
+    };
+    if body.trim().is_empty() {
+        return;
+    }
+    if let Err(err) = relay_outbound_inner(session_id, body) {
+        tracing::warn!("signal: outbound relay failed: {err}");
+    }
+}
+
+fn relay_outbound_inner(session_id: &str, body: &str) -> anyhow::Result<()> {
+    let Some(config) = load_config_or_disabled() else {
+        return Ok(());
+    };
+
+    let root = signal_root();
+    let state_file = AtomicJsonFile::new(state_path(&root, session_id));
+    let state = state_file
+        .read::<SignalState>()
+        .map_err(|e| anyhow::anyhow!("failed to read signal state for outbound relay: {e}"))?;
+    let Some(group) = state.and_then(|s| s.group_id).filter(|g| !g.is_empty()) else {
+        // No group yet (SessionStart has not run / channel disabled): nothing
+        // to mirror to.
+        return Ok(());
+    };
+    let group_id = GroupId(group);
+
+    let message = super::outbound::prepare_for_relay(body, super::outbound::RELAY_MAX_BYTES);
+
+    // Record the fingerprint BEFORE sending so the subscriber can recognize the
+    // synced-back echo even if it races ahead of us. The fingerprint is taken
+    // over the redacted+truncated `message` (exactly what is sent), so echo
+    // suppression still matches when Signal syncs the message back.
+    if let Err(err) = super::outbound::record_outbound_fingerprint(&root, session_id, &message) {
+        tracing::warn!("signal: failed to record outbound fingerprint before relay: {err}");
+    }
+
+    let rt = runtime()?;
+    rt.block_on(async {
+        let mut transport =
+            with_timeout("connect", SignalTransport::connect(&config.endpoint)).await?;
+        with_timeout("send", transport.send_group(&group_id, &message)).await?;
+        Ok::<(), anyhow::Error>(())
+    })?;
 
     Ok(())
 }
@@ -506,8 +692,7 @@ fn subscriber_main(session_id: Option<&str>) -> anyhow::Result<()> {
         }
     };
 
-    let dirs = ProjectDirs::from_cwd();
-    let root = signal_root(&dirs);
+    let root = signal_root();
 
     let rt = runtime()?;
     rt.block_on(async {
@@ -540,7 +725,7 @@ fn subscriber_main(session_id: Option<&str>) -> anyhow::Result<()> {
         // best-effort and must not be stalled by an absent daemon.
         let mut established = false;
         let mut backoff = RECONNECT_INITIAL_BACKOFF;
-        let mut consecutive_failures: u32 = 0;
+        let mut reconnect_failures: u64 = 0;
 
         loop {
             let connect =
@@ -551,7 +736,7 @@ fn subscriber_main(session_id: Option<&str>) -> anyhow::Result<()> {
                 Ok(Err(err)) => {
                     if !record_connect_failure(
                         established,
-                        &mut consecutive_failures,
+                        &mut reconnect_failures,
                         &mut backoff,
                         &format!("connect failed: {err}"),
                     )
@@ -564,7 +749,7 @@ fn subscriber_main(session_id: Option<&str>) -> anyhow::Result<()> {
                 Err(_) => {
                     if !record_connect_failure(
                         established,
-                        &mut consecutive_failures,
+                        &mut reconnect_failures,
                         &mut backoff,
                         "connect timed out",
                     )
@@ -584,14 +769,39 @@ fn subscriber_main(session_id: Option<&str>) -> anyhow::Result<()> {
                 match transport.receive().await {
                     Ok(Some(envelope)) => {
                         // Real inbound progress proves the link is healthy, so
-                        // reset the reconnect budget.
-                        consecutive_failures = 0;
+                        // reset the diagnostic failure counter.
+                        reconnect_failures = 0;
                         backoff = RECONNECT_INITIAL_BACKOFF;
                         if let Some(instruction) = gate.evaluate(&envelope) {
-                            if let Err(err) = inbox.push(&instruction) {
-                                tracing::warn!("signal-subscriber: inbox push failed: {err}");
+                            // Cross-process echo suppression: the outbound relay
+                            // runs in the (separate) hook process, so `Gate`'s
+                            // in-memory window cannot see our own mirrored lines.
+                            // Drop any inbound whose body matches a recently
+                            // mirrored outbound fingerprint for this session.
+                            if super::outbound::is_recent_outbound_fingerprint(
+                                &root,
+                                session_id,
+                                &instruction,
+                            ) {
+                                tracing::debug!("signal-subscriber: dropped own mirrored echo");
                             } else {
-                                tracing::info!("signal-subscriber: queued operator instruction");
+                                match inbox.push(&instruction) {
+                                    Ok(PushOutcome::Queued) => {
+                                        tracing::info!(
+                                            "signal-subscriber: queued operator instruction"
+                                        );
+                                    }
+                                    Ok(PushOutcome::EvictedOldest) => {
+                                        tracing::warn!(
+                                            "signal-subscriber: inbox reached capacity; evicted oldest pending operator instruction"
+                                        );
+                                    }
+                                    Err(err) => {
+                                        tracing::warn!(
+                                            "signal-subscriber: inbox push failed: {err}"
+                                        );
+                                    }
+                                }
                             }
                         }
                     }
@@ -611,7 +821,7 @@ fn subscriber_main(session_id: Option<&str>) -> anyhow::Result<()> {
             // tight loop.
             if !record_connect_failure(
                 true,
-                &mut consecutive_failures,
+                &mut reconnect_failures,
                 &mut backoff,
                 "connection dropped",
             )
@@ -633,25 +843,22 @@ fn subscriber_main(session_id: Option<&str>) -> anyhow::Result<()> {
 /// fast, non-fatal cold-start path.
 async fn record_connect_failure(
     established: bool,
-    consecutive_failures: &mut u32,
+    reconnect_failures: &mut u64,
     backoff: &mut Duration,
     reason: &str,
 ) -> bool {
-    match next_retry_delay(established, consecutive_failures, backoff) {
+    match next_retry_delay(established, reconnect_failures, backoff) {
         None => {
             tracing::warn!(
-                "signal-subscriber: {reason}; giving up ({}/{})",
-                *consecutive_failures,
-                RECONNECT_MAX_CONSECUTIVE_FAILURES
+                "signal-subscriber: {reason}; giving up before first successful connect"
             );
             false
         }
         Some(delay) => {
             tracing::warn!(
-                "signal-subscriber: {reason}; reconnect {}/{} after {:?}",
-                *consecutive_failures,
-                RECONNECT_MAX_CONSECUTIVE_FAILURES,
-                delay
+                "signal-subscriber: {reason}; reconnect attempt {} after {:?}",
+                *reconnect_failures,
+                delay,
             );
             tokio::time::sleep(delay).await;
             true
@@ -659,25 +866,24 @@ async fn record_connect_failure(
     }
 }
 
-/// Pure reconnect policy (no I/O), so the escalate-then-cap-then-give-up
+/// Pure reconnect policy (no I/O), so the escalate-then-cap-and-keep-trying
 /// behavior is unit-testable without real timers or sockets.
 ///
 /// Returns `None` to give up, or `Some(delay)` to sleep `delay` then reconnect.
-/// Mutates `consecutive_failures` (incremented) and `backoff` (doubled, capped
-/// at [`RECONNECT_MAX_BACKOFF`]). A failure before a connection was
-/// `established` always gives up, keeping cold-start fast and non-fatal.
+/// Mutates `reconnect_failures` (incremented) and `backoff` (doubled, capped at
+/// [`RECONNECT_MAX_BACKOFF`]). A failure before a connection was `established`
+/// always gives up, keeping cold-start fast and non-fatal. Once the subscriber
+/// has connected successfully, it never gives up on reconnect: inbound Signal
+/// mirroring is a session channel, not a best-effort one-shot notification.
 fn next_retry_delay(
     established: bool,
-    consecutive_failures: &mut u32,
+    reconnect_failures: &mut u64,
     backoff: &mut Duration,
 ) -> Option<Duration> {
     if !established {
         return None;
     }
-    *consecutive_failures += 1;
-    if *consecutive_failures >= RECONNECT_MAX_CONSECUTIVE_FAILURES {
-        return None;
-    }
+    *reconnect_failures = reconnect_failures.saturating_add(1);
     let delay = *backoff;
     *backoff = (*backoff * 2).min(RECONNECT_MAX_BACKOFF);
     Some(delay)
@@ -686,6 +892,52 @@ fn next_retry_delay(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sanitize_label_collapses_unsafe_runs_and_trims() {
+        assert_eq!(
+            sanitize_label("amplihack-host-my sess"),
+            "amplihack-host-my-sess"
+        );
+        assert_eq!(sanitize_label("a//b\n\tc"), "a-b-c");
+        assert_eq!(sanitize_label("--edge--"), "edge");
+        assert_eq!(sanitize_label("keep_.-ok"), "keep_.-ok");
+    }
+
+    #[test]
+    fn short_hostname_is_first_label_and_never_empty() {
+        let h = short_hostname();
+        assert!(!h.is_empty());
+        assert!(!h.contains('.'), "short hostname must drop the domain: {h}");
+    }
+
+    #[test]
+    fn group_name_tmux_branch_is_hostname_plus_session() {
+        assert_eq!(
+            compose_group_name("deva", Some("recipe-runner"), "sess-xyz"),
+            "amplihack-deva-recipe-runner"
+        );
+        // Spaces / unsafe chars in the tmux name collapse to dashes.
+        assert_eq!(
+            compose_group_name("deva", Some("my sess/2"), "sess-xyz"),
+            "amplihack-deva-my-sess-2"
+        );
+    }
+
+    #[test]
+    fn group_name_without_tmux_keeps_session_id_and_timestamp() {
+        let name = compose_group_name("deva", None, "sess-ABC-123");
+        assert!(name.starts_with("amplihack-deva-"), "got {name}");
+        assert!(
+            name.contains("sess-ABC-123"),
+            "must retain session id: {name}"
+        );
+        let last = name.rsplit('-').next().unwrap();
+        assert!(
+            last.chars().all(|c| c.is_ascii_digit()),
+            "expected ts suffix: {name}"
+        );
+    }
 
     #[test]
     fn cold_start_failure_never_retries() {
@@ -698,7 +950,7 @@ mod tests {
     }
 
     #[test]
-    fn established_failures_escalate_then_give_up() {
+    fn established_failures_escalate_then_cap_and_keep_retrying() {
         let mut failures = 0;
         let mut backoff = RECONNECT_INITIAL_BACKOFF;
 
@@ -709,18 +961,16 @@ mod tests {
         );
         assert_eq!(failures, 1);
 
-        // Subsequent retries escalate until one short of the cap.
+        // Subsequent retries escalate until the delay cap.
         let mut delays = vec![RECONNECT_INITIAL_BACKOFF];
-        while let Some(d) = next_retry_delay(true, &mut failures, &mut backoff) {
-            delays.push(d);
+        for _ in 0..20 {
+            delays.push(
+                next_retry_delay(true, &mut failures, &mut backoff)
+                    .expect("established subscriber must retry indefinitely"),
+            );
         }
 
-        // Exactly MAX-1 retries are granted, then it gives up.
-        assert_eq!(
-            failures, RECONNECT_MAX_CONSECUTIVE_FAILURES,
-            "gives up once the failure count reaches the cap"
-        );
-        assert_eq!(delays.len() as u32, RECONNECT_MAX_CONSECUTIVE_FAILURES - 1);
+        assert_eq!(failures, delays.len() as u64);
 
         // Delays are non-decreasing and never exceed the max backoff.
         for pair in delays.windows(2) {
@@ -730,6 +980,11 @@ mod tests {
             );
         }
         assert!(delays.iter().all(|d| *d <= RECONNECT_MAX_BACKOFF));
+        assert_eq!(
+            next_retry_delay(true, &mut failures, &mut backoff),
+            Some(RECONNECT_MAX_BACKOFF),
+            "retrying continues at the capped backoff"
+        );
     }
 
     #[test]
@@ -823,218 +1078,5 @@ mod tests {
     fn format_operator_context_single_item() {
         let out = format_operator_context(&["only one".to_string()]);
         assert_eq!(out, format!("{EXPECTED_HEADER}\n1. only one"));
-    }
-
-    // -- FIX 1: nesting gate (empty-group flood) -----------------------------
-    //
-    // Only the TOP-LEVEL operator session (AMPLIHACK_SESSION_DEPTH unset or
-    // "0") may create a Signal group. Every NESTED session (depth > 0, spawned
-    // by recipes/orchestrator/sub-agents) must be a silent no-op so it never
-    // creates a group, posts "session started", persists state, or spawns a
-    // subscriber. `is_nested_session()` is the pure gate predicate.
-
-    use crate::test_support::{EnvVarGuard, env_lock};
-
-    #[test]
-    fn is_nested_session_true_for_positive_depth() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let _depth = EnvVarGuard::set("AMPLIHACK_SESSION_DEPTH", "2");
-        assert!(is_nested_session(), "depth=2 is a nested child session");
-
-        let _depth1 = EnvVarGuard::set("AMPLIHACK_SESSION_DEPTH", "1");
-        assert!(is_nested_session(), "depth=1 is a nested child session");
-    }
-
-    #[test]
-    fn is_nested_session_false_for_zero_or_unset_or_garbage() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-
-        let _depth0 = EnvVarGuard::set("AMPLIHACK_SESSION_DEPTH", "0");
-        assert!(!is_nested_session(), "depth=0 is the top-level session");
-
-        let _unset = EnvVarGuard::unset("AMPLIHACK_SESSION_DEPTH");
-        assert!(!is_nested_session(), "unset depth is the top-level session");
-
-        // Non-numeric depth parses to 0 (fail toward "top level / run"), never
-        // a panic.
-        let _garbage = EnvVarGuard::set("AMPLIHACK_SESSION_DEPTH", "not-a-number");
-        assert!(
-            !is_nested_session(),
-            "non-numeric depth must default to top-level (0), not panic"
-        );
-    }
-
-    /// Compute this session's persisted Signal state file path under the
-    /// current working directory, mirroring `start()`'s own derivation.
-    fn state_file_for(session_id: &str) -> PathBuf {
-        let dirs = ProjectDirs::from_cwd();
-        state_path(&signal_root(&dirs), session_id)
-    }
-
-    /// Env + cwd fixture that makes `SignalConfig::load()` return a *valid*
-    /// (configured) channel pointing at an immediately-refused loopback
-    /// endpoint, so any code path that proceeds past the nesting gate will try
-    /// to connect and fail fast rather than performing real network I/O.
-    struct ConfiguredSignalFixture {
-        _home: EnvVarGuard,
-        _config: EnvVarGuard,
-        _endpoint: EnvVarGuard,
-        _account: EnvVarGuard,
-        _allowlist: EnvVarGuard,
-        _reuse: EnvVarGuard,
-        original_dir: PathBuf,
-        _tmp: tempfile::TempDir,
-    }
-
-    impl ConfiguredSignalFixture {
-        fn new() -> Self {
-            let tmp = tempfile::tempdir().unwrap();
-            let original_dir = std::env::current_dir().unwrap();
-            std::env::set_current_dir(tmp.path()).unwrap();
-            Self {
-                // HOME points at an empty dir so the default TOML config file
-                // is absent (NotFound ⇒ no TOML layer); the env vars below
-                // fully configure the channel.
-                _home: EnvVarGuard::set("HOME", tmp.path()),
-                _config: EnvVarGuard::unset("AMPLIHACK_SIGNAL_CONFIG"),
-                // Port 1 on loopback: nothing listens ⇒ immediate
-                // ECONNREFUSED, never a real/external network call.
-                _endpoint: EnvVarGuard::set("AMPLIHACK_SIGNAL_ENDPOINT", "127.0.0.1:1"),
-                _account: EnvVarGuard::set("AMPLIHACK_SIGNAL_ACCOUNT", "+15555550123"),
-                _allowlist: EnvVarGuard::set("AMPLIHACK_SIGNAL_ALLOWLIST", "+15555550124"),
-                // Force per-session group creation (not rolling reuse).
-                _reuse: EnvVarGuard::set("AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP", "false"),
-                original_dir,
-                _tmp: tmp,
-            }
-        }
-    }
-
-    impl Drop for ConfiguredSignalFixture {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.original_dir);
-        }
-    }
-
-    #[test]
-    fn start_is_noop_for_nested_session() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let fixture = ConfiguredSignalFixture::new();
-        let _depth = EnvVarGuard::set("AMPLIHACK_SESSION_DEPTH", "2");
-
-        let session_id = "nested-session-abc";
-        // A nested session must short-circuit BEFORE connecting, so despite a
-        // fully-configured channel it returns Ok with no side effects.
-        let result = start(session_id);
-        drop(fixture);
-
-        assert!(
-            result.is_ok(),
-            "nested session must be a clean no-op, got: {result:?}"
-        );
-        assert!(
-            !state_file_for(session_id).exists(),
-            "nested session must NOT persist any Signal group state"
-        );
-    }
-
-    #[test]
-    fn start_proceeds_past_gate_for_top_level_session() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let fixture = ConfiguredSignalFixture::new();
-        // Top-level: depth unset ⇒ NOT gated. With a valid config it must
-        // proceed to connect and fail (loopback refused), proving the gate is
-        // nesting-specific and did not swallow the top-level path.
-        let _depth = EnvVarGuard::unset("AMPLIHACK_SESSION_DEPTH");
-
-        let session_id = "top-level-session-xyz";
-        let result = start(session_id);
-        drop(fixture);
-
-        assert!(
-            result.is_err(),
-            "top-level session must proceed past the gate and surface the \
-             connect failure, not no-op; got Ok"
-        );
-        assert!(
-            !state_file_for(session_id).exists(),
-            "a failed connect must not leave persisted group state behind"
-        );
-    }
-
-    #[test]
-    fn stop_is_noop_when_no_group_persisted() {
-        let _guard = env_lock()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let fixture = ConfiguredSignalFixture::new();
-        // No state file was ever written (e.g. this was a nested session that
-        // never created a group). stop() must be a clean no-op: no summary
-        // post, no quitGroup, no error.
-        let session_id = "never-started-session";
-        let result = stop(session_id);
-        drop(fixture);
-
-        assert!(
-            result.is_ok(),
-            "stop must no-op cleanly when there is no persisted group id, \
-             got: {result:?}"
-        );
-    }
-
-    // -- FIX 2: tmux-aware group name ----------------------------------------
-    //
-    // `format_group_name` is the pure formatter so the tmux lookup can be
-    // tested without a real tmux. With a tmux name present it is embedded
-    // (sanitized + bounded) between the prefix and the session id; when absent
-    // the name is unchanged from the historical `amplihack-<sid>-<ts>` form.
-
-    #[test]
-    fn format_group_name_includes_tmux_session_when_present() {
-        let name = format_group_name(Some("my-tmux"), "sess-123", 1000);
-        assert_eq!(name, "amplihack-my-tmux-sess-123-1000");
-    }
-
-    #[test]
-    fn format_group_name_falls_back_when_tmux_absent() {
-        let name = format_group_name(None, "sess-123", 1000);
-        assert_eq!(
-            name, "amplihack-sess-123-1000",
-            "no-tmux form must match the historical group name exactly"
-        );
-    }
-
-    #[test]
-    fn format_group_name_sanitizes_tmux_and_session() {
-        // Both the tmux name and the session id are sanitized to the
-        // [A-Za-z0-9_-] allowlist; every other char becomes '_'.
-        let name = format_group_name(Some("weird/name space!"), "sess/id", 5);
-        assert_eq!(name, "amplihack-weird_name_space_-sess_id-5");
-    }
-
-    #[test]
-    fn format_group_name_empty_tmux_falls_back_to_no_tmux_form() {
-        // An empty tmux name (e.g. `tmux` returned nothing / not under tmux)
-        // must behave exactly like `None`, and must never panic.
-        let name = format_group_name(Some(""), "sess-1", 7);
-        assert_eq!(name, "amplihack-sess-1-7");
-    }
-
-    #[test]
-    fn format_group_name_bounds_tmux_length() {
-        // The tmux component is truncated to a bounded length (<=32) so an
-        // adversarial/huge tmux name cannot produce an unbounded group name.
-        let long = "a".repeat(100);
-        let name = format_group_name(Some(&long), "s", 1);
-        let expected_tmux = "a".repeat(32);
-        assert_eq!(name, format!("amplihack-{expected_tmux}-s-1"));
     }
 }

--- a/crates/amplihack-hooks/src/signal_integration/mod.rs
+++ b/crates/amplihack-hooks/src/signal_integration/mod.rs
@@ -34,10 +34,26 @@
 mod imp;
 
 #[cfg(feature = "signal")]
+mod host_context;
+/// R1 — Signal onboarding prompt gating + declined sentinel.
+#[cfg(feature = "signal")]
+pub mod onboarding;
+/// R4 — full-conversation mirroring helpers (outbound truncation + echo
+/// fingerprints).
+#[cfg(feature = "signal")]
+pub mod outbound;
+
+#[cfg(feature = "signal")]
+pub use host_context::{inject_host, merge_additional_context};
+
+#[cfg(feature = "signal")]
 pub use imp::run_subscriber;
 
 #[cfg(feature = "signal")]
-pub use imp::{drain_into_context, on_session_start, on_stop};
+pub use imp::{
+    drain_into_context, is_channel_configured, on_session_start, on_stop, relay_outbound,
+    set_process_enabled,
+};
 
 // ---------------------------------------------------------------------------
 // No-op shims (feature OFF). Signatures mirror the real implementation so the
@@ -61,3 +77,21 @@ pub fn drain_into_context(_session_id: Option<&str>) -> Option<String> {
 /// when the `signal` feature is disabled.
 #[cfg(not(feature = "signal"))]
 pub fn on_stop(_session_id: &str) {}
+
+/// Mirror an outbound line (user prompt / assistant turn) to the session group.
+/// No-op when the `signal` feature is disabled.
+#[cfg(not(feature = "signal"))]
+pub fn relay_outbound(_session_id: Option<&str>, _body: &str) {}
+
+/// Enable/disable real Signal I/O for this process. No-op when the `signal`
+/// feature is disabled.
+#[cfg(not(feature = "signal"))]
+pub fn set_process_enabled(_enabled: bool) {}
+
+/// Whether the Signal channel is configured/usable. Always `false` when the
+/// `signal` feature is disabled, so hook output keeps its historical shape.
+#[cfg(not(feature = "signal"))]
+#[must_use]
+pub fn is_channel_configured() -> bool {
+    false
+}

--- a/crates/amplihack-hooks/src/signal_integration/onboarding.rs
+++ b/crates/amplihack-hooks/src/signal_integration/onboarding.rs
@@ -1,0 +1,75 @@
+//! R1 — Signal onboarding prompt gating + a persisted "declined" sentinel.
+//!
+//! When a host has no Signal config yet, amplihack should ask **once** whether
+//! to link this device and mirror the session to a private Signal group. That
+//! prompt must never break or block a session, so the decision to show it is
+//! factored into the pure [`should_prompt`] predicate over an explicit
+//! [`OnboardingEnv`]. We only prompt when **all** of these hold:
+//!
+//! * Signal is not already configured (`!config_present`),
+//! * we have an interactive controlling terminal (`is_tty`),
+//! * we are not in non-interactive/automation mode (`!noninteractive`, i.e.
+//!   `AMPLIHACK_NONINTERACTIVE` is unset),
+//! * the user has not previously declined (`!declined_before`).
+//!
+//! A decline is durable: [`mark_onboarding_declined`] writes a sentinel file
+//! under an explicit `root` so subsequent launches ([`onboarding_declined`])
+//! skip the prompt forever. Keeping `root` explicit makes the sentinel
+//! round-trip hermetically testable with no `HOME`/cwd mutation.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// The observable inputs that gate whether we surface the onboarding prompt.
+#[derive(Debug, Clone)]
+pub struct OnboardingEnv {
+    /// Whether a usable Signal configuration is already present.
+    pub config_present: bool,
+    /// Whether stdin/stdout is an interactive terminal.
+    pub is_tty: bool,
+    /// Whether automation mode is active (`AMPLIHACK_NONINTERACTIVE=1`).
+    pub noninteractive: bool,
+    /// Whether the user previously declined (sentinel already written).
+    pub declined_before: bool,
+}
+
+/// The onboarding gate decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnboardingDecision {
+    /// Surface the (non-blocking) onboarding prompt.
+    Prompt,
+    /// Do not prompt.
+    Skip,
+}
+
+/// Pure gate: prompt only when unconfigured **and** interactive **and** not in
+/// automation **and** not previously declined; otherwise skip.
+#[must_use]
+pub fn should_prompt(env: &OnboardingEnv) -> OnboardingDecision {
+    if !env.config_present && env.is_tty && !env.noninteractive && !env.declined_before {
+        OnboardingDecision::Prompt
+    } else {
+        OnboardingDecision::Skip
+    }
+}
+
+/// Path of the "declined" sentinel under `root`.
+#[must_use]
+pub fn onboarding_declined_path(root: &Path) -> PathBuf {
+    root.join("signal-onboarding-declined")
+}
+
+/// Whether the user has previously declined onboarding under `root`.
+#[must_use]
+pub fn onboarding_declined(root: &Path) -> bool {
+    onboarding_declined_path(root).exists()
+}
+
+/// Record a durable decline under `root`. Idempotent: repeated calls succeed.
+pub fn mark_onboarding_declined(root: &Path) -> io::Result<()> {
+    let path = onboarding_declined_path(root);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, b"declined\n")
+}

--- a/crates/amplihack-hooks/src/signal_integration/outbound.rs
+++ b/crates/amplihack-hooks/src/signal_integration/outbound.rs
@@ -24,6 +24,7 @@
 //!
 //! Both fingerprint seams take an explicit `root`, keeping them hermetic.
 
+use std::borrow::Cow;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -105,11 +106,16 @@ static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(
 /// See [`REDACTION_PATTERNS`] for the covered secret classes and rationale.
 #[must_use]
 pub fn redact_for_relay(body: &str) -> String {
-    let mut out = body.to_string();
+    let mut out = Cow::Borrowed(body);
     for (re, replacement) in REDACTION_PATTERNS.iter() {
-        out = re.replace_all(&out, *replacement).into_owned();
+        // `replace_all` returns `Cow::Borrowed` when nothing matches (the common
+        // case for benign conversation), so only adopt a new buffer on a real
+        // match instead of allocating a full-body copy for every pattern.
+        if let Cow::Owned(replaced) = re.replace_all(&out, *replacement) {
+            out = Cow::Owned(replaced);
+        }
     }
-    out
+    out.into_owned()
 }
 
 /// Prepare a body for Signal relay: redact secrets first, then byte-bound the

--- a/crates/amplihack-hooks/src/signal_integration/outbound.rs
+++ b/crates/amplihack-hooks/src/signal_integration/outbound.rs
@@ -30,6 +30,13 @@ pub const RELAY_MAX_BYTES: usize = 4096;
 /// word `truncated` never exceeds the byte cap (the cap reserves room for it).
 const TRUNCATION_MARKER: &str = " [truncated]";
 
+/// Number of most-recent outbound fingerprints considered "recent" for
+/// echo-suppression. Matching is restricted to this trailing window so that a
+/// short operator instruction (e.g. "continue") that merely coincides with a
+/// long-past mirrored line is still delivered rather than silently dropped.
+/// The on-disk log is also trimmed toward this size to bound growth.
+const FP_WINDOW: usize = 128;
+
 /// Bound `body` to at most `max` bytes at a UTF-8 char boundary, appending a
 /// visible truncation marker when shortened. Short or empty bodies are returned
 /// unchanged.
@@ -66,20 +73,42 @@ fn session_fp_path(root: &Path, session_id: &str) -> PathBuf {
 
 /// Persist a fingerprint of an outbound (mirrored) `body` for `session_id` under
 /// `root`, so a detached subscriber can later recognize the echo.
+///
+/// The log is kept bounded to the most recent [`FP_WINDOW`] fingerprints: after
+/// appending, an over-long file is rewritten to retain only the tail. This caps
+/// both on-disk growth and the per-inbound scan cost over a long session.
 pub fn record_outbound_fingerprint(root: &Path, session_id: &str, body: &str) -> io::Result<()> {
     let path = session_fp_path(root, session_id);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)?;
-    writeln!(file, "{}", hash_hex(body))
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
+        writeln!(file, "{}", hash_hex(body))?;
+    }
+    // Bound the file to the most recent FP_WINDOW entries. Only rewrite when it
+    // has grown past a hysteresis threshold to avoid rewriting on every call.
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        let lines: Vec<&str> = content.lines().collect();
+        if lines.len() > FP_WINDOW * 2 {
+            let tail = lines[lines.len() - FP_WINDOW..].join("\n");
+            std::fs::write(&path, format!("{tail}\n"))?;
+        }
+    }
+    Ok(())
 }
 
 /// Whether `body` was recently mirrored outbound for `session_id` under `root`
-/// (i.e. its fingerprint is present). Fingerprints are isolated per session.
+/// (i.e. its fingerprint appears within the most recent [`FP_WINDOW`] mirrored
+/// entries). Fingerprints are isolated per session.
+///
+/// Matching is deliberately restricted to a recent window rather than the whole
+/// session history: an inbound operator message whose text happens to equal a
+/// long-past mirrored line (realistic for short instructions like "continue" or
+/// "yes") must still reach the CLI rather than being suppressed as a self-echo.
 #[must_use]
 pub fn is_recent_outbound_fingerprint(root: &Path, session_id: &str, body: &str) -> bool {
     let path = session_fp_path(root, session_id);
@@ -87,5 +116,69 @@ pub fn is_recent_outbound_fingerprint(root: &Path, session_id: &str, body: &str)
         return false;
     };
     let fp = hash_hex(body);
-    content.lines().any(|line| line.trim() == fp)
+    let lines: Vec<&str> = content.lines().collect();
+    let start = lines.len().saturating_sub(FP_WINDOW);
+    lines[start..].iter().any(|line| line.trim() == fp)
+}
+
+/// Remove the persisted outbound-fingerprint log for `session_id` under `root`.
+/// Called during per-session teardown so the log does not outlive the session.
+pub fn clear_outbound_fingerprints(root: &Path, session_id: &str) {
+    let path = session_fp_path(root, session_id);
+    let _ = std::fs::remove_file(path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn recent_fingerprint_matches_within_window() {
+        let td = TempDir::new().unwrap();
+        record_outbound_fingerprint(td.path(), "s", "hello").unwrap();
+        assert!(is_recent_outbound_fingerprint(td.path(), "s", "hello"));
+        assert!(!is_recent_outbound_fingerprint(td.path(), "s", "other"));
+    }
+
+    #[test]
+    fn old_fingerprint_outside_window_is_not_recent() {
+        // A short operator instruction that coincides with a long-past mirrored
+        // line must still be delivered (not suppressed as an echo).
+        let td = TempDir::new().unwrap();
+        record_outbound_fingerprint(td.path(), "s", "continue").unwrap();
+        for i in 0..(FP_WINDOW * 2) {
+            record_outbound_fingerprint(td.path(), "s", &format!("line-{i}")).unwrap();
+        }
+        assert!(
+            !is_recent_outbound_fingerprint(td.path(), "s", "continue"),
+            "a fingerprint older than FP_WINDOW must not count as recent"
+        );
+        // The most recent entry is still recognized.
+        let last = format!("line-{}", FP_WINDOW * 2 - 1);
+        assert!(is_recent_outbound_fingerprint(td.path(), "s", &last));
+    }
+
+    #[test]
+    fn log_is_bounded_in_size() {
+        let td = TempDir::new().unwrap();
+        for i in 0..(FP_WINDOW * 4) {
+            record_outbound_fingerprint(td.path(), "s", &format!("m-{i}")).unwrap();
+        }
+        let content = std::fs::read_to_string(session_fp_path(td.path(), "s")).unwrap();
+        let lines = content.lines().count();
+        assert!(
+            lines <= FP_WINDOW * 2,
+            "fingerprint log must stay bounded, got {lines} lines"
+        );
+    }
+
+    #[test]
+    fn clear_removes_fingerprint_log() {
+        let td = TempDir::new().unwrap();
+        record_outbound_fingerprint(td.path(), "s", "x").unwrap();
+        assert!(is_recent_outbound_fingerprint(td.path(), "s", "x"));
+        clear_outbound_fingerprints(td.path(), "s");
+        assert!(!is_recent_outbound_fingerprint(td.path(), "s", "x"));
+    }
 }

--- a/crates/amplihack-hooks/src/signal_integration/outbound.rs
+++ b/crates/amplihack-hooks/src/signal_integration/outbound.rs
@@ -1,14 +1,20 @@
-//! R4 — full-conversation mirroring helpers: outbound size bounding + a
-//! cross-process echo-suppression fingerprint.
+//! R4 — full-conversation mirroring helpers: outbound secret redaction + size
+//! bounding + a cross-process echo-suppression fingerprint.
 //!
-//! Mirroring every user prompt and assistant turn to the Signal group raises two
-//! hazards:
+//! Mirroring every user prompt and assistant turn to the Signal group raises
+//! three hazards:
 //!
-//! 1. **Unbounded size.** Assistant turns can be huge. [`truncate_for_relay`]
+//! 1. **Secret leakage.** Prompts and assistant turns routinely contain pasted
+//!    or echoed credentials. Mirroring them verbatim would copy those secrets
+//!    off-box into a (potentially multi-member) group chat, crossing the
+//!    project's "redact before it leaves the machine" boundary. [`redact_for_relay`]
+//!    scrubs the high-frequency secret shapes first; [`prepare_for_relay`] chains
+//!    it ahead of truncation.
+//! 2. **Unbounded size.** Assistant turns can be huge. [`truncate_for_relay`]
 //!    bounds each mirrored body to [`RELAY_MAX_BYTES`] at a UTF-8 char boundary
 //!    (never splitting a multibyte code point) and appends a visible truncation
 //!    marker.
-//! 2. **Echo loops across processes.** The outbound mirror runs in the (short-
+//! 3. **Echo loops across processes.** The outbound mirror runs in the (short-
 //!    lived) hook process while the inbound subscriber runs detached, so the
 //!    in-memory echo window in `amplihack_signal::gating::Gate` cannot span the
 //!    two. [`record_outbound_fingerprint`] persists a hashed, per-session
@@ -20,7 +26,9 @@
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
+use regex::Regex;
 use sha2::{Digest, Sha256};
 
 /// Maximum bytes of a single mirrored message body (4 KiB).
@@ -29,6 +37,90 @@ pub const RELAY_MAX_BYTES: usize = 4096;
 /// Marker appended to a truncated body. Placed so the total length up to the
 /// word `truncated` never exceeds the byte cap (the cap reserves room for it).
 const TRUNCATION_MARKER: &str = " [truncated]";
+
+/// Secret shapes scrubbed from a body before it is mirrored to Signal, applied
+/// in order. Full-conversation mirroring copies raw user prompts and assistant
+/// turns off the box into a group chat that — in the fleet-watch scenario this
+/// PR enables — can have multiple members. That crosses the project's standing
+/// "redact before it leaves the machine" boundary (cf. `amplihack-remote::redact`,
+/// issue #882 / CWE-532), so pasted or echoed credentials must not survive.
+///
+/// The list is deliberately conservative and deterministic: it targets the
+/// high-frequency, unambiguously-secret token shapes rather than trying to
+/// classify arbitrary prose (which would risk mangling normal conversation).
+/// The whole `key = value` form is redacted first so its `[REDACTED]`
+/// placeholder cannot re-expose a value that a later, narrower pattern would
+/// otherwise leave partially intact.
+static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    let specs: &[(&str, &str)] = &[
+        // PEM private-key blocks (multi-line): drop the whole armored body.
+        (
+            r"(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+            "[REDACTED-PRIVATE-KEY]",
+        ),
+        // Signal device-link URIs (linking another device would hijack the account).
+        (
+            r"(?i)\b(?:sgnl://linkdevice|tsdevice:/)\?[^\s<>'\x22]+",
+            "[REDACTED-SIGNAL-LINK]",
+        ),
+        // `name: value` / `name = value` credential assignments.
+        (
+            r#"(?i)\b(api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|credential|authorization)\b\s*[:=]\s*['"]?[A-Za-z0-9._~+/=:-]{6,}['"]?"#,
+            "$1=[REDACTED]",
+        ),
+        // GitHub tokens (PAT, OAuth, user-to-server, server-to-server, refresh).
+        (
+            r"\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b",
+            "[REDACTED-GITHUB-TOKEN]",
+        ),
+        // AWS access-key IDs.
+        (r"\bAKIA[0-9A-Z]{16}\b", "[REDACTED-AWS-KEY]"),
+        // Slack tokens.
+        (
+            r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
+            "[REDACTED-SLACK-TOKEN]",
+        ),
+        // HTTP bearer credentials (JWTs and opaque tokens alike).
+        (
+            r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}",
+            "Bearer [REDACTED]",
+        ),
+    ];
+    specs
+        .iter()
+        .map(|(pattern, replacement)| {
+            (
+                Regex::new(pattern).expect("static relay redaction regex is valid"),
+                *replacement,
+            )
+        })
+        .collect()
+});
+
+/// Scrub high-frequency secret shapes out of `body` before it is mirrored to a
+/// Signal group. Pure, allocation-only, and idempotent: it performs no I/O and
+/// running it twice yields the same result. Non-secret conversation text is
+/// preserved so the mirror stays useful.
+///
+/// See [`REDACTION_PATTERNS`] for the covered secret classes and rationale.
+#[must_use]
+pub fn redact_for_relay(body: &str) -> String {
+    let mut out = body.to_string();
+    for (re, replacement) in REDACTION_PATTERNS.iter() {
+        out = re.replace_all(&out, *replacement).into_owned();
+    }
+    out
+}
+
+/// Prepare a body for Signal relay: redact secrets first, then byte-bound the
+/// result. Redacting before truncating guarantees a secret is scrubbed even
+/// when it would otherwise straddle (or sit past) the truncation boundary, and
+/// means the persisted echo-suppression fingerprint is taken over the exact
+/// bytes that are sent.
+#[must_use]
+pub fn prepare_for_relay(body: &str, max: usize) -> String {
+    truncate_for_relay(&redact_for_relay(body), max)
+}
 
 /// Number of most-recent outbound fingerprints considered "recent" for
 /// echo-suppression. Matching is restricted to this trailing window so that a
@@ -132,6 +224,86 @@ pub fn clear_outbound_fingerprints(root: &Path, session_id: &str) {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn redacts_github_token() {
+        let token = format!("{}{}{}", "gh", "p_", "A".repeat(36));
+        let body = format!("here is my token {token} please use it");
+        let out = redact_for_relay(&body);
+        assert!(
+            !out.contains(&token),
+            "github token must be redacted: {out}"
+        );
+        assert!(out.contains("[REDACTED-GITHUB-TOKEN]"), "got: {out}");
+        // Surrounding conversation context is preserved.
+        assert!(out.contains("here is my token"), "context lost: {out}");
+        assert!(out.contains("please use it"), "context lost: {out}");
+    }
+
+    #[test]
+    fn redacts_key_value_secret_forms() {
+        for (body, secret) in [
+            (format!("api_key: {}", "A".repeat(16)), "A".repeat(16)),
+            (format!("password = {}", "B".repeat(16)), "B".repeat(16)),
+            (format!("AUTHORIZATION={}", "C".repeat(16)), "C".repeat(16)),
+        ] {
+            let out = redact_for_relay(&body);
+            assert!(out.contains("[REDACTED]"), "expected redaction in {out}");
+            assert!(!out.contains(&secret), "secret value leaked: {out}");
+        }
+    }
+
+    #[test]
+    fn redacts_bearer_and_signal_link() {
+        let bearer = format!("{} {}", "Bearer", "D".repeat(32));
+        let out = redact_for_relay(&format!("call it with {bearer}"));
+        assert!(!out.contains(&bearer), "bearer leaked: {out}");
+        assert!(
+            out.starts_with("call it with "),
+            "surrounding context lost: {out}"
+        );
+
+        let out = redact_for_relay("link at sgnl://linkdevice?uuid=abc&pub_key=deadbeef now");
+        assert!(!out.contains("deadbeef"), "signal link leaked: {out}");
+        assert!(out.contains("[REDACTED-SIGNAL-LINK]"), "got: {out}");
+        assert!(
+            out.contains("link at") && out.contains("now"),
+            "context lost: {out}"
+        );
+    }
+
+    #[test]
+    fn redaction_preserves_benign_text_and_is_idempotent() {
+        let benign = "Let's refactor the parser and run the tests, then push the branch.";
+        assert_eq!(
+            redact_for_relay(benign),
+            benign,
+            "benign text must pass through"
+        );
+
+        let secret = format!("token={} and more text", "E".repeat(16));
+        let once = redact_for_relay(&secret);
+        assert_eq!(
+            redact_for_relay(&once),
+            once,
+            "redaction must be idempotent"
+        );
+    }
+
+    #[test]
+    fn prepare_redacts_before_truncating() {
+        // A secret sitting past the byte cap must still be scrubbed: redaction
+        // runs on the full body before truncation.
+        let secret = format!("{}{}{}", "gh", "p_", "F".repeat(36));
+        let body = format!("{}{secret}", "x".repeat(RELAY_MAX_BYTES));
+        let out = prepare_for_relay(&body, RELAY_MAX_BYTES);
+        assert!(!out.contains(&secret), "secret past the cap leaked: {out}");
+        assert!(
+            out.len() <= RELAY_MAX_BYTES,
+            "prepared body must respect the byte cap, got {}",
+            out.len()
+        );
+    }
 
     #[test]
     fn recent_fingerprint_matches_within_window() {

--- a/crates/amplihack-hooks/src/signal_integration/outbound.rs
+++ b/crates/amplihack-hooks/src/signal_integration/outbound.rs
@@ -64,9 +64,15 @@ static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(
             r"(?i)\b(?:sgnl://linkdevice|tsdevice:/)\?[^\s<>'\x22]+",
             "[REDACTED-SIGNAL-LINK]",
         ),
-        // `name: value` / `name = value` credential assignments.
+        // `name: value` / `name = value` credential assignments. The value may
+        // be prefixed by an HTTP auth scheme word (`Bearer`/`Basic`/`Token`),
+        // as in `Authorization: Bearer <jwt>`; that prefix is consumed as part
+        // of the value so the credential is fully redacted. Without this, the
+        // key/value match would stop at the scheme word (treating `Bearer` as
+        // the "value"), strip it, and leave the real token exposed for the
+        // later, now-unanchored Bearer pattern to miss.
         (
-            r#"(?i)\b(api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|credential|authorization)\b\s*[:=]\s*['"]?[A-Za-z0-9._~+/=:-]{6,}['"]?"#,
+            r#"(?i)\b(api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|credential|authorization)\b\s*[:=]\s*['"]?(?:(?:bearer|basic|token)\s+)?[A-Za-z0-9._~+/=:-]{6,}['"]?"#,
             "$1=[REDACTED]",
         ),
         // GitHub tokens (PAT, OAuth, user-to-server, server-to-server, refresh).
@@ -76,6 +82,15 @@ static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(
         ),
         // AWS access-key IDs.
         (r"\bAKIA[0-9A-Z]{16}\b", "[REDACTED-AWS-KEY]"),
+        // Google API keys (fixed `AIza` prefix + 35 url-safe chars).
+        (r"\bAIza[0-9A-Za-z_-]{35}\b", "[REDACTED-GOOGLE-KEY]"),
+        // Credentials embedded in a URL's userinfo
+        // (`scheme://user:password@host`): keep the scheme + username, drop the
+        // password so pasted connection strings do not leak off-box.
+        (
+            r"(?i)\b([a-z][a-z0-9+.-]*://[^\s:@/]+):[^\s@/]+@",
+            "$1:[REDACTED]@",
+        ),
         // Slack tokens.
         (
             r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
@@ -236,6 +251,54 @@ pub fn clear_outbound_fingerprints(root: &Path, session_id: &str) {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn redacts_authorization_bearer_header_fully() {
+        // Regression: the `key: value` pattern lists `authorization` and runs
+        // before the standalone Bearer pattern. It must consume the `Bearer`
+        // scheme word *and* the token, not stop at `Bearer` and leak the token.
+        let jwt = format!("eyJ0eXAiOiJKV1Q.{}.{}", "A".repeat(24), "B".repeat(24));
+        let out = redact_for_relay(&format!("Authorization: Bearer {jwt}"));
+        assert!(
+            !out.contains(&jwt),
+            "bearer token after an Authorization key must be redacted: {out}"
+        );
+        assert!(out.contains("[REDACTED]"), "expected redaction: {out}");
+
+        // The `=` / no-space variant must also be fully redacted.
+        let tok = format!("sk-{}", "C".repeat(32));
+        let out = redact_for_relay(&format!("authorization=Bearer {tok}"));
+        assert!(
+            !out.contains(&tok),
+            "token leaked via key=Bearer form: {out}"
+        );
+    }
+
+    #[test]
+    fn redacts_google_api_key() {
+        // AIza prefix + exactly 35 url-safe chars.
+        let key = format!(
+            "AIza{}",
+            "a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R"
+                .chars()
+                .take(35)
+                .collect::<String>()
+        );
+        assert_eq!(key.len(), 39, "google key fixture must be AIza + 35 chars");
+        let out = redact_for_relay(&format!("GOOGLE_API_KEY {key} done"));
+        assert!(!out.contains(&key), "google api key leaked: {out}");
+        assert!(out.contains("[REDACTED-GOOGLE-KEY]"), "got: {out}");
+    }
+
+    #[test]
+    fn redacts_url_userinfo_password() {
+        let pw = "supersecretpw123";
+        let out = redact_for_relay(&format!("postgres://svc:{pw}@db.internal:5432/prod"));
+        assert!(!out.contains(pw), "url password leaked: {out}");
+        assert!(out.contains("[REDACTED]"), "expected redaction: {out}");
+        // Scheme + username are preserved for usefulness.
+        assert!(out.contains("postgres://svc:"), "context lost: {out}");
+    }
 
     #[test]
     fn redacts_github_token() {

--- a/crates/amplihack-hooks/src/signal_integration/outbound.rs
+++ b/crates/amplihack-hooks/src/signal_integration/outbound.rs
@@ -183,11 +183,17 @@ pub fn record_outbound_fingerprint(root: &Path, session_id: &str, body: &str) ->
     }
     // Bound the file to the most recent FP_WINDOW entries. Only rewrite when it
     // has grown past a hysteresis threshold to avoid rewriting on every call.
+    // The trim is done atomically (write a sibling temp file, then rename over
+    // the target) so the detached subscriber, which reads this file
+    // concurrently, never observes a truncated/partial state — it sees either
+    // the full pre-trim content or the full trimmed content.
     if let Ok(content) = std::fs::read_to_string(&path) {
         let lines: Vec<&str> = content.lines().collect();
         if lines.len() > FP_WINDOW * 2 {
             let tail = lines[lines.len() - FP_WINDOW..].join("\n");
-            std::fs::write(&path, format!("{tail}\n"))?;
+            let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+            std::fs::write(&tmp, format!("{tail}\n"))?;
+            std::fs::rename(&tmp, &path)?;
         }
     }
     Ok(())

--- a/crates/amplihack-hooks/src/signal_integration/outbound.rs
+++ b/crates/amplihack-hooks/src/signal_integration/outbound.rs
@@ -1,0 +1,91 @@
+//! R4 — full-conversation mirroring helpers: outbound size bounding + a
+//! cross-process echo-suppression fingerprint.
+//!
+//! Mirroring every user prompt and assistant turn to the Signal group raises two
+//! hazards:
+//!
+//! 1. **Unbounded size.** Assistant turns can be huge. [`truncate_for_relay`]
+//!    bounds each mirrored body to [`RELAY_MAX_BYTES`] at a UTF-8 char boundary
+//!    (never splitting a multibyte code point) and appends a visible truncation
+//!    marker.
+//! 2. **Echo loops across processes.** The outbound mirror runs in the (short-
+//!    lived) hook process while the inbound subscriber runs detached, so the
+//!    in-memory echo window in `amplihack_signal::gating::Gate` cannot span the
+//!    two. [`record_outbound_fingerprint`] persists a hashed, per-session
+//!    fingerprint of each mirrored body that the subscriber checks via
+//!    [`is_recent_outbound_fingerprint`] to drop the account's own synced-back
+//!    messages instead of re-injecting them.
+//!
+//! Both fingerprint seams take an explicit `root`, keeping them hermetic.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+/// Maximum bytes of a single mirrored message body (4 KiB).
+pub const RELAY_MAX_BYTES: usize = 4096;
+
+/// Marker appended to a truncated body. Placed so the total length up to the
+/// word `truncated` never exceeds the byte cap (the cap reserves room for it).
+const TRUNCATION_MARKER: &str = " [truncated]";
+
+/// Bound `body` to at most `max` bytes at a UTF-8 char boundary, appending a
+/// visible truncation marker when shortened. Short or empty bodies are returned
+/// unchanged.
+#[must_use]
+pub fn truncate_for_relay(body: &str, max: usize) -> String {
+    if body.len() <= max {
+        return body.to_string();
+    }
+    // Reserve room for the marker so the mirrored prefix (including the marker
+    // text preceding "truncated") never exceeds `max`.
+    let budget = max.saturating_sub(TRUNCATION_MARKER.len());
+    let mut end = budget.min(body.len());
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = String::with_capacity(end + TRUNCATION_MARKER.len());
+    out.push_str(&body[..end]);
+    out.push_str(TRUNCATION_MARKER);
+    out
+}
+
+/// Lowercase hex SHA-256 of `s`.
+fn hash_hex(s: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Per-session fingerprint log path under `root` (session id is hashed into the
+/// filename so it is filesystem-safe and cannot escape `root`).
+fn session_fp_path(root: &Path, session_id: &str) -> PathBuf {
+    root.join("signal-outbound-fp").join(hash_hex(session_id))
+}
+
+/// Persist a fingerprint of an outbound (mirrored) `body` for `session_id` under
+/// `root`, so a detached subscriber can later recognize the echo.
+pub fn record_outbound_fingerprint(root: &Path, session_id: &str, body: &str) -> io::Result<()> {
+    let path = session_fp_path(root, session_id);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    writeln!(file, "{}", hash_hex(body))
+}
+
+/// Whether `body` was recently mirrored outbound for `session_id` under `root`
+/// (i.e. its fingerprint is present). Fingerprints are isolated per session.
+#[must_use]
+pub fn is_recent_outbound_fingerprint(root: &Path, session_id: &str, body: &str) -> bool {
+    let path = session_fp_path(root, session_id);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    let fp = hash_hex(body);
+    content.lines().any(|line| line.trim() == fp)
+}

--- a/crates/amplihack-hooks/src/stop/mod.rs
+++ b/crates/amplihack-hooks/src/stop/mod.rs
@@ -25,6 +25,10 @@ impl Hook for StopHook {
         "stop"
     }
 
+    fn hook_event_name(&self) -> Option<&'static str> {
+        Some("Stop")
+    }
+
     fn failure_policy(&self) -> FailurePolicy {
         FailurePolicy::Open
     }
@@ -63,11 +67,112 @@ impl Hook for StopHook {
             return Ok(block);
         }
 
-        // Session is genuinely stopping (not blocked-to-continue): post a
-        // summary, leave the group, and stop the subscriber. Non-fatal.
-        crate::signal_integration::on_stop(&session_id);
+        // NOTE: the Signal channel is intentionally NOT torn down here. This
+        // hook fires at the end of *every* assistant turn (Claude Code `Stop`,
+        // Copilot `agentStop`), not at session end, so tearing the channel down
+        // here would kill the per-session Signal group after the first turn.
+        // Teardown lives in `SessionStopHook` (the genuine session-end event).
+        //
+        // Full-conversation mirroring (assistant side): relay this turn's final
+        // assistant message to the session's Signal group. No-op unless the
+        // channel is configured.
+        #[cfg(feature = "signal")]
+        if let Some(assistant_text) = transcript_path
+            .as_deref()
+            .and_then(last_assistant_message_from_transcript)
+        {
+            crate::signal_integration::relay_outbound(Some(&session_id), &assistant_text);
+        }
 
         Ok(approve())
+    }
+}
+
+/// Best-effort extraction of the **last** assistant message text from a
+/// transcript JSONL file, for outbound mirroring. Tolerant of the several
+/// transcript shapes across hosts (Copilot `assistant.message`, Claude
+/// `role: assistant`, nested `message.role`). Returns `None` on any failure so
+/// mirroring never blocks session exit.
+#[cfg(feature = "signal")]
+fn last_assistant_message_from_transcript(transcript_path: &std::path::Path) -> Option<String> {
+    let contents = std::fs::read_to_string(transcript_path).ok()?;
+    contents.lines().rev().find_map(|line| {
+        let line = line.trim();
+        if line.is_empty() {
+            return None;
+        }
+        let entry = serde_json::from_str::<Value>(line).ok()?;
+        extract_assistant_text_from_entry(&entry)
+    })
+}
+
+/// Pull assistant text out of a single transcript entry across host shapes.
+#[cfg(feature = "signal")]
+fn extract_assistant_text_from_entry(entry: &Value) -> Option<String> {
+    let object = entry.as_object()?;
+
+    if let Some(message) = object.get("message").and_then(Value::as_object)
+        && message.get("role").and_then(Value::as_str) == Some("assistant")
+    {
+        return extract_entry_text(message.get("content").unwrap_or(&Value::Null));
+    }
+
+    if object.get("role").and_then(Value::as_str) == Some("assistant") {
+        return extract_entry_text(
+            object
+                .get("content")
+                .or_else(|| object.get("text"))
+                .unwrap_or(&Value::Null),
+        );
+    }
+
+    if object.get("type").and_then(Value::as_str) == Some("assistant.message") {
+        return extract_entry_text(
+            object
+                .get("data")
+                .and_then(|value| value.get("content"))
+                .unwrap_or(&Value::Null),
+        );
+    }
+
+    if object.get("type").and_then(Value::as_str) == Some("assistant") {
+        return extract_entry_text(
+            object
+                .get("content")
+                .or_else(|| object.get("message").and_then(|value| value.get("content")))
+                .unwrap_or(&Value::Null),
+        );
+    }
+
+    None
+}
+
+/// Flatten a transcript `content` value (string | array of parts | object)
+/// into a single text string.
+#[cfg(feature = "signal")]
+fn extract_entry_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) if !text.trim().is_empty() => Some(text.to_string()),
+        Value::String(_) => None,
+        Value::Array(items) => {
+            let parts = items
+                .iter()
+                .filter_map(extract_entry_text)
+                .filter(|text| !text.trim().is_empty())
+                .collect::<Vec<_>>();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\n"))
+            }
+        }
+        Value::Object(map) => map
+            .get("text")
+            .or_else(|| map.get("value"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .or_else(|| map.get("content").and_then(extract_entry_text)),
+        _ => None,
     }
 }
 

--- a/crates/amplihack-hooks/src/user_prompt/mod.rs
+++ b/crates/amplihack-hooks/src/user_prompt/mod.rs
@@ -28,6 +28,10 @@ impl Hook for UserPromptSubmitHook {
         "user_prompt_submit"
     }
 
+    fn hook_event_name(&self) -> Option<&'static str> {
+        Some("UserPromptSubmit")
+    }
+
     fn failure_policy(&self) -> FailurePolicy {
         FailurePolicy::Open
     }
@@ -46,6 +50,12 @@ impl Hook for UserPromptSubmitHook {
         if prompt.is_empty() {
             return Ok(Value::Object(serde_json::Map::new()));
         }
+
+        // Full-conversation mirroring: relay the user's prompt to the session's
+        // Signal group (no-op unless the channel is configured). This is the
+        // "user side" of the whole-session mirror; the assistant side is
+        // mirrored from the Stop hook.
+        crate::signal_integration::relay_outbound(session_id.as_deref(), &prompt);
 
         let dirs = amplihack_types::ProjectDirs::from_cwd();
         let mut context_parts: Vec<String> = Vec::new();
@@ -113,6 +123,27 @@ impl Hook for UserPromptSubmitHook {
         }
 
         let additional_context = context_parts.join("\n\n");
+
+        // Host-aware shaping: Copilot needs a top-level `additionalContext`
+        // string, Claude (and others) the nested `hookSpecificOutput`. This
+        // reshape is applied ONLY when the Signal channel is actually configured
+        // — its sole purpose is to make operator context reach the operator's
+        // host. When the channel is not configured (the default, every golden
+        // test, and the non-signal build) the output stays byte-for-byte the
+        // historical nested shape that the golden contract pins.
+        #[cfg(feature = "signal")]
+        if crate::signal_integration::is_channel_configured() {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let host = crate::signal_integration::inject_host(&cwd);
+            let mut out = serde_json::Map::new();
+            crate::signal_integration::merge_additional_context(
+                &mut out,
+                &host,
+                "UserPromptSubmit",
+                &additional_context,
+            );
+            return Ok(Value::Object(out));
+        }
 
         Ok(serde_json::json!({
             "hookSpecificOutput": {

--- a/crates/amplihack-hooks/src/user_prompt/tests.rs
+++ b/crates/amplihack-hooks/src/user_prompt/tests.rs
@@ -138,6 +138,9 @@ fn returns_additional_context_without_mutating_prompt() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Pin the host so output shaping is deterministic under parallel tests
+    // (default host resolution is cwd/env-derived and would race).
+    let _agent_bin = EnvVarGuard::set("AMPLIHACK_AGENT_BINARY", "claude");
     let _session_depth = EnvVarGuard::unset("AMPLIHACK_SESSION_DEPTH");
     let dir = tempfile::tempdir().unwrap();
     let original = std::env::current_dir().unwrap();
@@ -189,6 +192,7 @@ fn extracts_prompt_from_extra_prompt_key() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _agent_bin = EnvVarGuard::set("AMPLIHACK_AGENT_BINARY", "claude");
     let _session_depth = EnvVarGuard::unset("AMPLIHACK_SESSION_DEPTH");
     let dir = tempfile::tempdir().unwrap();
     let original = std::env::current_dir().unwrap();
@@ -218,6 +222,7 @@ fn extracts_prompt_from_user_message_dict() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _agent_bin = EnvVarGuard::set("AMPLIHACK_AGENT_BINARY", "claude");
     let _session_depth = EnvVarGuard::unset("AMPLIHACK_SESSION_DEPTH");
     let dir = tempfile::tempdir().unwrap();
     let original = std::env::current_dir().unwrap();
@@ -249,6 +254,7 @@ fn dev_prompt_initializes_workflow_enforcement_state_and_warning_path() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _agent_bin = EnvVarGuard::set("AMPLIHACK_AGENT_BINARY", "claude");
     let _session_depth = EnvVarGuard::unset("AMPLIHACK_SESSION_DEPTH");
     let dir = tempfile::tempdir().unwrap();
     let original = std::env::current_dir().unwrap();
@@ -339,6 +345,7 @@ fn workflow_active_semaphore_skips_dev_detection() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _agent_bin = EnvVarGuard::set("AMPLIHACK_AGENT_BINARY", "claude");
     let _session_depth = EnvVarGuard::unset("AMPLIHACK_SESSION_DEPTH");
     let dir = tempfile::tempdir().unwrap();
     let original = std::env::current_dir().unwrap();
@@ -380,6 +387,7 @@ fn workflow_active_via_session_depth_skips_dev_detection() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _agent_bin = EnvVarGuard::set("AMPLIHACK_AGENT_BINARY", "claude");
     let dir = tempfile::tempdir().unwrap();
     let original = std::env::current_dir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();

--- a/crates/amplihack-hooks/tests/signal_dispatch_routing_it.rs
+++ b/crates/amplihack-hooks/tests/signal_dispatch_routing_it.rs
@@ -1,0 +1,67 @@
+//! R5 — teardown routing classifier (issue #1002).
+//!
+//! The bug: the hooks binary aliased `session-end` / `session-stop` to the
+//! per-turn `StopHook`, and the per-turn `StopHook` performed Signal teardown
+//! (`quitGroup`). That tears the group down after **every turn**, so the
+//! whole-session channel dies immediately and the operator can only message the
+//! very first turn.
+//!
+//! The fix separates two concerns with a single source of truth,
+//! `amplihack_hooks::is_teardown_subcommand`:
+//!   * whole-session teardown events  → SessionStop path (leave group once)
+//!   * per-turn stop events           → StopHook (OUTBOUND relay only, no teardown)
+//!
+//! Wiring `sessionEnd` (Copilot) and `session-end`/`session-stop`/
+//! `session-stop-event` to teardown — and keeping `stop`/`agentStop` per-turn —
+//! is exactly what stops subscribers/groups from leaking on Copilot session end.
+//!
+//! RED: `is_teardown_subcommand` does not exist yet.
+#![cfg(feature = "signal")]
+
+use amplihack_hooks::is_teardown_subcommand;
+
+#[test]
+fn whole_session_end_events_are_teardown() {
+    for name in [
+        "session-end",
+        "session-stop",
+        "session-stop-event",
+        "sessionEnd",
+    ] {
+        assert!(
+            is_teardown_subcommand(name),
+            "{name:?} must route to whole-session teardown"
+        );
+    }
+}
+
+#[test]
+fn per_turn_stop_events_are_not_teardown() {
+    // These fire once per assistant turn. They must NOT tear down the channel
+    // (outbound relay only), otherwise the group is destroyed after turn 1.
+    for name in ["stop", "agentStop"] {
+        assert!(
+            !is_teardown_subcommand(name),
+            "{name:?} is a per-turn event and must NOT tear down the Signal channel"
+        );
+    }
+}
+
+#[test]
+fn unrelated_subcommands_are_not_teardown() {
+    for name in [
+        "pre-tool-use",
+        "post-tool-use",
+        "user-prompt",
+        "user-prompt-submit",
+        "session-start",
+        "pre-compact",
+        "signal-subscriber",
+        "",
+    ] {
+        assert!(
+            !is_teardown_subcommand(name),
+            "{name:?} must not be classified as session teardown"
+        );
+    }
+}

--- a/crates/amplihack-hooks/tests/signal_host_aware_context_it.rs
+++ b/crates/amplihack-hooks/tests/signal_host_aware_context_it.rs
@@ -1,0 +1,151 @@
+//! R2 — host-aware `additionalContext` injection (issue #1002).
+//!
+//! **The critical bug this file locks in:** inbound operator context was always
+//! emitted as Claude Code's nested `hookSpecificOutput.additionalContext`, which
+//! **Copilot CLI ignores**. Per the Copilot hooks reference, the
+//! `userPromptSubmitted` hook must return a **top-level** `additionalContext`
+//! **string** for the context to reach the agent. These tests pin the two
+//! host-specific output shapes so a message from the Signal chat actually lands
+//! in the Copilot agent's context.
+//!
+//! The seam under test is the pure output shaper
+//! `amplihack_hooks::signal_integration::merge_additional_context`, plus the
+//! host resolver `inject_host`. Keeping the shaper pure makes the contract
+//! deterministic and parallel-safe (no process-global env/cwd mutation).
+//!
+//! RED: these symbols do not exist yet — this target fails to compile under
+//! `--features signal` until R2 is implemented. Gated so the default build stays
+//! green (preserving the 437 hook + 18 golden tests).
+#![cfg(feature = "signal")]
+
+use amplihack_hooks::signal_integration::{inject_host, merge_additional_context};
+use serde_json::{Map, Value};
+
+fn shape(host: &str, event: &str, ctx: &str) -> Map<String, Value> {
+    let mut out = Map::new();
+    merge_additional_context(&mut out, host, event, ctx);
+    out
+}
+
+#[test]
+fn copilot_emits_top_level_additional_context_string() {
+    // Copilot reads a TOP-LEVEL `additionalContext` string. This is the exact
+    // shape that was missing and caused inbound Signal messages to be dropped.
+    let out = shape(
+        "copilot",
+        "userPromptSubmitted",
+        "operator says: run the tests",
+    );
+    assert_eq!(
+        out.get("additionalContext").and_then(Value::as_str),
+        Some("operator says: run the tests"),
+        "Copilot requires a top-level additionalContext string"
+    );
+}
+
+#[test]
+fn copilot_does_not_emit_nested_hook_specific_output() {
+    // The nested Claude shape must NOT be present for Copilot — that is exactly
+    // the payload Copilot ignores.
+    let out = shape("copilot", "userPromptSubmitted", "hi");
+    assert!(
+        !out.contains_key("hookSpecificOutput"),
+        "Copilot output must not carry Claude's nested hookSpecificOutput"
+    );
+}
+
+#[test]
+fn claude_emits_nested_hook_specific_output_unchanged() {
+    // Claude Code behavior must be preserved byte-for-byte: nested
+    // hookSpecificOutput with hookEventName + additionalContext.
+    let out = shape(
+        "claude",
+        "UserPromptSubmit",
+        "operator says: focus on the failing test",
+    );
+    let hso = out
+        .get("hookSpecificOutput")
+        .and_then(Value::as_object)
+        .expect("claude must nest under hookSpecificOutput");
+    assert_eq!(
+        hso.get("hookEventName").and_then(Value::as_str),
+        Some("UserPromptSubmit")
+    );
+    assert_eq!(
+        hso.get("additionalContext").and_then(Value::as_str),
+        Some("operator says: focus on the failing test")
+    );
+}
+
+#[test]
+fn claude_does_not_emit_top_level_additional_context() {
+    let out = shape("claude", "UserPromptSubmit", "hi");
+    assert!(
+        !out.contains_key("additionalContext"),
+        "Claude output must keep additionalContext nested, not top-level"
+    );
+}
+
+#[test]
+fn unknown_host_defaults_to_nested_claude_shape() {
+    // Any non-copilot host (claude/codex/amplifier/unknown) uses the nested
+    // shape. This preserves existing Claude-compatible behavior and never
+    // accidentally strips context for a host we do not special-case.
+    for host in ["codex", "amplifier", "somethingelse"] {
+        let out = shape(host, "PostToolUse", "ctx");
+        assert!(
+            out.get("hookSpecificOutput").is_some(),
+            "host {host:?} must fall back to nested hookSpecificOutput"
+        );
+        assert!(
+            !out.contains_key("additionalContext"),
+            "host {host:?} must not use the Copilot top-level shape"
+        );
+    }
+}
+
+#[test]
+fn merge_preserves_existing_output_keys() {
+    // PostToolUse builds an output map that may already carry `warnings` and
+    // `metadata` (workflow enforcement). Merging Signal context must be additive
+    // and never clobber those keys.
+    let mut out = Map::new();
+    out.insert("warnings".into(), serde_json::json!(["keep me"]));
+    merge_additional_context(&mut out, "copilot", "postToolUse", "operator ctx");
+    assert_eq!(out.get("warnings"), Some(&serde_json::json!(["keep me"])));
+    assert_eq!(
+        out.get("additionalContext").and_then(Value::as_str),
+        Some("operator ctx")
+    );
+}
+
+#[test]
+fn inject_host_resolves_launcher_context_to_claude() {
+    // `inject_host` is cwd-driven via the agent-binary resolver: a persisted
+    // `.claude/runtime/launcher_context.json` selecting "claude" must resolve to
+    // "claude" (parallel-safe: no env mutation, unique temp dir per test).
+    let tmp = tempfile::tempdir().unwrap();
+    let rt = tmp.path().join(".claude").join("runtime");
+    std::fs::create_dir_all(&rt).unwrap();
+    std::fs::write(
+        rt.join("launcher_context.json"),
+        serde_json::json!({ "launcher": "claude" }).to_string(),
+    )
+    .unwrap();
+
+    // Only meaningful when the env override is absent (it takes precedence).
+    if std::env::var_os("AMPLIHACK_AGENT_BINARY").is_none() {
+        assert_eq!(inject_host(tmp.path()), "claude");
+    }
+}
+
+#[test]
+fn inject_host_returns_an_allowlisted_binary_name() {
+    // Smoke: resolution always yields a known, safe binary identifier.
+    let tmp = tempfile::tempdir().unwrap();
+    let host = inject_host(tmp.path());
+    assert!(
+        ["copilot", "claude", "codex", "amplifier"].contains(&host.as_str()),
+        "inject_host returned unexpected host {host:?}"
+    );
+}

--- a/crates/amplihack-hooks/tests/signal_onboarding_it.rs
+++ b/crates/amplihack-hooks/tests/signal_onboarding_it.rs
@@ -1,0 +1,114 @@
+//! R1 — onboarding prompt gating + declined sentinel (issue #1002).
+//!
+//! When a host has no Signal config yet, amplihack should *ask* (once) whether
+//! to link this device and mirror the session. The prompt must be:
+//!   * skippable and non-blocking (it never runs the QR/device-link flow inside
+//!     the ~30s hook budget — it only records intent / spawns setup detached),
+//!   * suppressed in non-interactive mode (`AMPLIHACK_NONINTERACTIVE=1`),
+//!   * suppressed when there is no TTY,
+//!   * suppressed forever after the user declines (a persisted sentinel),
+//!   * suppressed once Signal is already configured.
+//!
+//! The decision is factored into a pure function `should_prompt(&OnboardingEnv)`
+//! so every gate combination is deterministically testable without touching a
+//! real terminal, and the declined sentinel round-trips through an explicit
+//! `root` (hermetic temp dir — no HOME/cwd mutation).
+//!
+//! RED: the `onboarding` module and its items do not exist yet.
+#![cfg(feature = "signal")]
+
+use amplihack_hooks::signal_integration::onboarding::{
+    OnboardingDecision, OnboardingEnv, mark_onboarding_declined, onboarding_declined,
+    onboarding_declined_path, should_prompt,
+};
+
+/// The only state in which we prompt: unconfigured + interactive TTY + not
+/// previously declined.
+fn ripe() -> OnboardingEnv {
+    OnboardingEnv {
+        config_present: false,
+        is_tty: true,
+        noninteractive: false,
+        declined_before: false,
+    }
+}
+
+#[test]
+fn prompts_only_when_unconfigured_interactive_and_not_declined() {
+    assert_eq!(should_prompt(&ripe()), OnboardingDecision::Prompt);
+}
+
+#[test]
+fn skips_when_signal_already_configured() {
+    let env = OnboardingEnv {
+        config_present: true,
+        ..ripe()
+    };
+    assert_eq!(
+        should_prompt(&env),
+        OnboardingDecision::Skip,
+        "already configured ⇒ never prompt"
+    );
+}
+
+#[test]
+fn skips_in_non_interactive_mode() {
+    // Respect AMPLIHACK_NONINTERACTIVE=1: automation must never block on a prompt.
+    let env = OnboardingEnv {
+        noninteractive: true,
+        ..ripe()
+    };
+    assert_eq!(should_prompt(&env), OnboardingDecision::Skip);
+}
+
+#[test]
+fn skips_when_no_tty() {
+    // No controlling terminal ⇒ nobody to answer ⇒ skip (never break the session).
+    let env = OnboardingEnv {
+        is_tty: false,
+        ..ripe()
+    };
+    assert_eq!(should_prompt(&env), OnboardingDecision::Skip);
+}
+
+#[test]
+fn skips_after_previously_declined() {
+    let env = OnboardingEnv {
+        declined_before: true,
+        ..ripe()
+    };
+    assert_eq!(
+        should_prompt(&env),
+        OnboardingDecision::Skip,
+        "a prior decline must suppress re-prompting on every launch"
+    );
+}
+
+#[test]
+fn declined_sentinel_round_trips_under_explicit_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    assert!(
+        !onboarding_declined(root),
+        "fresh root has no declined sentinel"
+    );
+    mark_onboarding_declined(root).expect("write sentinel");
+    assert!(
+        onboarding_declined(root),
+        "after marking declined, the sentinel must be observed"
+    );
+    assert!(
+        onboarding_declined_path(root).starts_with(root),
+        "sentinel path must live under the provided root"
+    );
+}
+
+#[test]
+fn marking_declined_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    mark_onboarding_declined(root).unwrap();
+    mark_onboarding_declined(root).unwrap(); // second call must not error
+    assert!(onboarding_declined(root));
+}

--- a/crates/amplihack-hooks/tests/signal_outbound_relay_it.rs
+++ b/crates/amplihack-hooks/tests/signal_outbound_relay_it.rs
@@ -1,0 +1,117 @@
+//! R4 — full-conversation mirroring: outbound truncation + echo suppression
+//! (issue #1002).
+//!
+//! Mirroring the whole session (every user prompt + every assistant turn) to the
+//! Signal group introduces two hazards these tests pin down:
+//!
+//! 1. **Unbounded message size.** Assistant turns can be huge; each mirrored
+//!    message must be bounded to `RELAY_MAX_BYTES` (4 KiB) at a UTF-8 char
+//!    boundary so we never send a partial code point or a giant frame.
+//!
+//! 2. **Echo loops.** The outbound mirror runs in the hook process while the
+//!    inbound subscriber runs in a detached process, so the in-memory
+//!    echo-suppression window in `Gate` cannot span processes. A file-shared,
+//!    hashed fingerprint of each outbound body lets the subscriber recognize and
+//!    drop the account's own mirrored messages instead of re-injecting them.
+//!
+//! Both seams take an explicit `root`, so tests are hermetic (temp dir, no
+//! HOME/cwd mutation).
+//!
+//! RED: the `outbound` module and its items do not exist yet.
+#![cfg(feature = "signal")]
+
+use amplihack_hooks::signal_integration::outbound::{
+    RELAY_MAX_BYTES, is_recent_outbound_fingerprint, record_outbound_fingerprint,
+    truncate_for_relay,
+};
+
+#[test]
+fn relay_max_is_four_kib() {
+    assert_eq!(RELAY_MAX_BYTES, 4096);
+}
+
+#[test]
+fn short_body_is_unchanged() {
+    let body = "operator: please rerun the flaky test";
+    assert_eq!(truncate_for_relay(body, RELAY_MAX_BYTES), body);
+}
+
+#[test]
+fn oversized_body_is_truncated_and_marked() {
+    let body = "x".repeat(RELAY_MAX_BYTES * 2);
+    let out = truncate_for_relay(&body, RELAY_MAX_BYTES);
+    assert!(out.len() < body.len(), "must shrink an oversized body");
+    assert!(
+        out.contains("truncated"),
+        "truncation must be visibly marked, got: {:?}",
+        &out[out.len().saturating_sub(40)..]
+    );
+}
+
+#[test]
+fn truncation_never_splits_a_multibyte_char() {
+    // '€' is 3 bytes; a byte cap that lands mid-character must round down to a
+    // char boundary rather than produce invalid UTF-8 (or panic).
+    let body = "€".repeat(4000); // 12_000 bytes, well over 4 KiB
+    let out = truncate_for_relay(&body, RELAY_MAX_BYTES);
+    // The invariant we care about: the result is valid UTF-8. `String` already
+    // guarantees this, so the real assertion is "did not panic slicing" plus a
+    // sane bound on the mirrored prefix.
+    let prefix_bytes = out.find("truncated").unwrap_or(out.len());
+    assert!(
+        prefix_bytes <= RELAY_MAX_BYTES,
+        "mirrored prefix must not exceed the byte cap"
+    );
+}
+
+#[test]
+fn empty_body_is_unchanged() {
+    assert_eq!(truncate_for_relay("", RELAY_MAX_BYTES), "");
+}
+
+#[test]
+fn fingerprint_round_trips_for_same_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let sid = "sess-r4-echo";
+    let body = "session started";
+
+    assert!(
+        !is_recent_outbound_fingerprint(root, sid, body),
+        "unseen body is not a recent outbound"
+    );
+    record_outbound_fingerprint(root, sid, body).expect("record fingerprint");
+    assert!(
+        is_recent_outbound_fingerprint(root, sid, body),
+        "after mirroring our own body, the subscriber must recognize the echo"
+    );
+}
+
+#[test]
+fn fingerprint_does_not_match_a_different_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let sid = "sess-r4-distinct";
+    record_outbound_fingerprint(root, sid, "hello from the agent").unwrap();
+    assert!(
+        !is_recent_outbound_fingerprint(root, sid, "a genuine operator instruction"),
+        "a distinct operator message must NOT be suppressed as an echo"
+    );
+}
+
+#[test]
+fn fingerprints_are_scoped_per_session() {
+    // One session's outbound must not suppress another session's inbound.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    record_outbound_fingerprint(root, "sess-A", "shared body").unwrap();
+    assert!(is_recent_outbound_fingerprint(
+        root,
+        "sess-A",
+        "shared body"
+    ));
+    assert!(
+        !is_recent_outbound_fingerprint(root, "sess-B", "shared body"),
+        "fingerprints must be isolated per session id"
+    );
+}

--- a/crates/amplihack-signal/Cargo.toml
+++ b/crates/amplihack-signal/Cargo.toml
@@ -33,6 +33,14 @@ tokio-stream = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { version = "1", features = [
+    "rt",
+    "macros",
+    "net",
+    "io-util",
+    "time",
+    "sync",
+] }
 
 # Fixture-driven envelope tests (pure wire parsing, no I/O).
 [[test]]

--- a/crates/amplihack-signal/src/fake_endpoint.rs
+++ b/crates/amplihack-signal/src/fake_endpoint.rs
@@ -1,0 +1,235 @@
+//! A loopback, in-process fake of the signal-cli JSON-RPC daemon for
+//! **hermetic offline testing**.
+//!
+//! The real Signal channel talks newline-delimited JSON-RPC 2.0 to signal-cli's
+//! `daemon --tcp` endpoint. To exercise the real [`crate::transport::SignalTransport`]
+//! (and, above it, [`crate::session_channel::SignalSession`]) end-to-end in CI
+//! **without ever touching the Signal network or creating a real group**, this
+//! type stands up a `127.0.0.1:0` (ephemeral loopback) TCP server that speaks
+//! the same wire protocol and records what the transport sent.
+//!
+//! Guarantees that make it safe for CI:
+//! * binds **loopback only** (`127.0.0.1`), so no test can reach an external
+//!   host;
+//! * never performs any real Signal operation — `updateGroup` returns a
+//!   configurable fake group id, `send`/`quitGroup` just record and ack;
+//! * inbound envelopes are **explicitly enqueued** by the test (nothing arrives
+//!   unless a test asks for it).
+//!
+//! It supports both the "enqueue before connect" and "enqueue after connect"
+//! orderings: pre-connection inbound lines are buffered and flushed as soon as a
+//! client connects.
+
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+
+/// What the fake recorded from the transport, for test assertions.
+#[derive(Default)]
+struct Recorded {
+    /// `updateGroup` names, in order.
+    created: Vec<String>,
+    /// `(groupId, body)` pairs from `send`, in order.
+    sent: Vec<(String, String)>,
+    /// `quitGroup` group ids, in order.
+    quit: Vec<String>,
+}
+
+/// Shared state between the public handle and the background server tasks.
+struct Shared {
+    recorded: Mutex<Recorded>,
+    /// Group id returned by `updateGroup` (settable via [`FakeSignalEndpoint::with_group_id`]).
+    group_id: Mutex<String>,
+    /// Live sender to the connected client's writer task (if any).
+    live_tx: Mutex<Option<mpsc::UnboundedSender<String>>>,
+    /// Inbound lines enqueued before a client connected.
+    pending: Mutex<Vec<String>>,
+}
+
+/// A loopback fake of the signal-cli JSON-RPC daemon.
+pub struct FakeSignalEndpoint {
+    addr: String,
+    shared: Arc<Shared>,
+}
+
+impl FakeSignalEndpoint {
+    /// Bind an ephemeral loopback port and start accepting connections.
+    pub async fn start() -> std::io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?.to_string();
+        let shared = Arc::new(Shared {
+            recorded: Mutex::new(Recorded::default()),
+            group_id: Mutex::new("grp-fake==".to_string()),
+            live_tx: Mutex::new(None),
+            pending: Mutex::new(Vec::new()),
+        });
+
+        let accept_shared = shared.clone();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(handle_conn(stream, accept_shared.clone()));
+            }
+        });
+
+        Ok(Self { addr, shared })
+    }
+
+    /// Configure the group id returned by `updateGroup` (builder style).
+    #[must_use]
+    pub fn with_group_id(self, id: &str) -> Self {
+        *self.shared.group_id.lock().unwrap() = id.to_string();
+        self
+    }
+
+    /// The `host:port` the fake is listening on (always `127.0.0.1:<port>`).
+    #[must_use]
+    pub fn addr(&self) -> &str {
+        &self.addr
+    }
+
+    /// Enqueue one inbound JSON-RPC `receive` frame to be delivered to the
+    /// connected client. Accepts pretty-printed JSON (it is normalized to a
+    /// single newline-delimited frame). Delivered immediately if a client is
+    /// connected, otherwise buffered until one connects.
+    pub fn enqueue_inbound(&self, raw: &str) {
+        // The wire protocol is newline-delimited, so collapse any embedded
+        // newlines by round-tripping through serde_json into a compact line.
+        let compact = match serde_json::from_str::<Value>(raw) {
+            Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw.replace('\n', " ")),
+            Err(_) => raw.replace('\n', " "),
+        };
+        let line = format!("{compact}\n");
+
+        let live = self.shared.live_tx.lock().unwrap();
+        if let Some(tx) = live.as_ref() {
+            let _ = tx.send(line);
+        } else {
+            drop(live);
+            self.shared.pending.lock().unwrap().push(line);
+        }
+    }
+
+    /// Group names recorded from `updateGroup`.
+    #[must_use]
+    pub fn created_groups(&self) -> Vec<String> {
+        self.shared.recorded.lock().unwrap().created.clone()
+    }
+
+    /// `(groupId, body)` pairs recorded from `send`.
+    #[must_use]
+    pub fn sent(&self) -> Vec<(String, String)> {
+        self.shared.recorded.lock().unwrap().sent.clone()
+    }
+
+    /// Group ids recorded from `quitGroup`.
+    #[must_use]
+    pub fn quit_groups(&self) -> Vec<String> {
+        self.shared.recorded.lock().unwrap().quit.clone()
+    }
+}
+
+/// Serve a single client connection: answer its JSON-RPC requests and push any
+/// enqueued inbound frames.
+async fn handle_conn(stream: tokio::net::TcpStream, shared: Arc<Shared>) {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+
+    // Register this connection as the live sink and flush anything enqueued
+    // before the client connected.
+    {
+        let pending: Vec<String> = std::mem::take(&mut *shared.pending.lock().unwrap());
+        for line in pending {
+            let _ = tx.send(line);
+        }
+        *shared.live_tx.lock().unwrap() = Some(tx.clone());
+    }
+
+    // Writer task: serialize all outbound frames (responses + pushed inbound)
+    // through a single owner of the write half.
+    let writer = tokio::spawn(async move {
+        while let Some(line) = rx.recv().await {
+            if write_half.write_all(line.as_bytes()).await.is_err() {
+                break;
+            }
+            let _ = write_half.flush().await;
+        }
+    });
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = match reader.read_line(&mut line).await {
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        if n == 0 {
+            break; // EOF
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(req) = serde_json::from_str::<Value>(trimmed) else {
+            continue;
+        };
+        let method = req.get("method").and_then(Value::as_str).unwrap_or("");
+        let params = req.get("params").cloned().unwrap_or(Value::Null);
+
+        let result = match method {
+            "updateGroup" => {
+                if let Some(name) = params.get("name").and_then(Value::as_str) {
+                    shared
+                        .recorded
+                        .lock()
+                        .unwrap()
+                        .created
+                        .push(name.to_string());
+                }
+                let gid = shared.group_id.lock().unwrap().clone();
+                serde_json::json!({ "groupId": gid })
+            }
+            "send" => {
+                let g = params
+                    .get("groupId")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let m = params
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                shared.recorded.lock().unwrap().sent.push((g, m));
+                serde_json::json!({ "results": [], "timestamp": 0 })
+            }
+            "quitGroup" => {
+                let g = params
+                    .get("groupId")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                shared.recorded.lock().unwrap().quit.push(g);
+                serde_json::json!({})
+            }
+            _ => Value::Null,
+        };
+
+        // Reply only to requests that carry an id (JSON-RPC calls).
+        if let Some(id) = req.get("id").cloned() {
+            let resp = serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result });
+            let mut s = serde_json::to_string(&resp).unwrap_or_default();
+            s.push('\n');
+            let _ = tx.send(s);
+        }
+    }
+
+    // Client disconnected: drop the live sink so the writer task can finish.
+    *shared.live_tx.lock().unwrap() = None;
+    drop(tx);
+    let _ = writer.await;
+}

--- a/crates/amplihack-signal/src/lib.rs
+++ b/crates/amplihack-signal/src/lib.rs
@@ -20,6 +20,8 @@
 #[cfg(feature = "signal")]
 pub mod config;
 #[cfg(feature = "signal")]
+pub mod fake_endpoint;
+#[cfg(feature = "signal")]
 pub mod gating;
 #[cfg(feature = "signal")]
 pub mod session_channel;

--- a/crates/amplihack-signal/src/session_channel.rs
+++ b/crates/amplihack-signal/src/session_channel.rs
@@ -6,9 +6,10 @@
 //! [`amplihack_state::atomic_json::AtomicJsonFile`] (crash-safe, lock-guarded)
 //! at a path derived through [`amplihack_types::paths::sanitize_session_id`].
 //!
-//! The inbox is **bounded**: it holds at most [`Inbox::DEFAULT_CAPACITY`]
-//! pending instructions. When full, the **oldest** is evicted to admit the
-//! newest (backpressure by bounded queue).
+//! The inbox is **bounded**: it holds at most [`Inbox::default_capacity`]
+//! pending instructions. Operators can tune that with
+//! `AMPLIHACK_SIGNAL_INBOX_CAPACITY`; when full, the **oldest** is evicted to
+//! admit the newest (backpressure by bounded queue).
 
 use amplihack_state::atomic_json::AtomicJsonFile;
 use amplihack_types::paths::sanitize_session_id;
@@ -38,8 +39,24 @@ pub struct Inbox {
 }
 
 impl Inbox {
-    /// Default bounded capacity (flood resistance).
+    /// Default bounded capacity (flood resistance) used when
+    /// `AMPLIHACK_SIGNAL_INBOX_CAPACITY` is absent or invalid.
     pub const DEFAULT_CAPACITY: usize = 32;
+
+    /// Capacity for newly-created session inboxes.
+    ///
+    /// This is configurable because the right pending-message budget depends on
+    /// operator workflow and hook cadence. Invalid, zero, or whitespace-only
+    /// values fall back to [`Self::DEFAULT_CAPACITY`] instead of disabling the
+    /// inbox or creating an unbounded file.
+    #[must_use]
+    pub fn default_capacity() -> usize {
+        std::env::var("AMPLIHACK_SIGNAL_INBOX_CAPACITY")
+            .ok()
+            .and_then(|raw| raw.trim().parse::<usize>().ok())
+            .filter(|capacity| *capacity > 0)
+            .unwrap_or(Self::DEFAULT_CAPACITY)
+    }
 
     /// Create an inbox at an explicit file `path` with an explicit `capacity`.
     #[must_use]
@@ -56,7 +73,7 @@ impl Inbox {
     pub fn at_session(session_id: &str, root: &Path) -> Self {
         let sanitized = sanitize_session_id(session_id);
         let path = root.join(sanitized).join("inbox.json");
-        Self::new(path, Self::DEFAULT_CAPACITY)
+        Self::new(path, Self::default_capacity())
     }
 
     /// The resolved inbox file path.
@@ -170,9 +187,15 @@ impl SignalSession {
             return Ok(None);
         };
         if let Some(instruction) = self.gate.evaluate(&env) {
-            self.inbox
+            let outcome = self
+                .inbox
                 .push(&instruction)
                 .map_err(|e| std::io::Error::other(e.to_string()))?;
+            if outcome == PushOutcome::EvictedOldest {
+                tracing::warn!(
+                    "signal session inbox reached capacity; evicted oldest pending operator instruction"
+                );
+            }
             return Ok(Some(instruction));
         }
         Ok(Some(String::new()))

--- a/crates/amplihack-signal/tests/fake_endpoint_it.rs
+++ b/crates/amplihack-signal/tests/fake_endpoint_it.rs
@@ -1,0 +1,120 @@
+//! R3 — hermetic offline testing via a fake signal-cli JSON-RPC endpoint
+//! (issue #1002).
+//!
+//! signal-cli exposes a JSON-RPC 2.0 daemon (newline-delimited JSON over a
+//! socket). To exercise `create-group` / `send` / `quit-group` / `receive` and
+//! the inbound subscriber loop deterministically in CI — **without ever touching
+//! the real Signal network or creating a real group** — we stand up a local
+//! loopback fake that speaks the same wire protocol and records what the
+//! transport sent.
+//!
+//! `FakeSignalEndpoint` binds `127.0.0.1:0` (an ephemeral loopback port), so no
+//! test can reach an external host. These tests drive the real
+//! `SignalTransport` against the fake and assert on the recorded RPCs.
+//!
+//! RED: `amplihack_signal::fake_endpoint::FakeSignalEndpoint` does not exist yet.
+#![cfg(feature = "signal")]
+
+use amplihack_signal::fake_endpoint::FakeSignalEndpoint;
+use amplihack_signal::transport::{GroupId, SignalTransport};
+
+#[tokio::test]
+async fn endpoint_binds_loopback_only() {
+    // Hard guarantee: the fake is loopback-only, so no test can hit the network.
+    let fake = FakeSignalEndpoint::start().await.expect("start fake");
+    assert!(
+        fake.addr().starts_with("127.0.0.1:"),
+        "fake endpoint must bind loopback, got {}",
+        fake.addr()
+    );
+}
+
+#[tokio::test]
+async fn create_group_returns_fake_group_id_and_is_recorded() {
+    let fake = FakeSignalEndpoint::start()
+        .await
+        .expect("start fake")
+        .with_group_id("grp-fake-001==");
+
+    let mut transport = SignalTransport::connect(fake.addr())
+        .await
+        .expect("connect to fake");
+
+    let gid = transport
+        .create_group("amplihack-session-xyz")
+        .await
+        .expect("create_group over fake");
+    assert_eq!(gid, GroupId("grp-fake-001==".to_string()));
+
+    assert!(
+        fake.created_groups()
+            .contains(&"amplihack-session-xyz".to_string()),
+        "fake must record the create-group name; got {:?}",
+        fake.created_groups()
+    );
+}
+
+#[tokio::test]
+async fn send_group_is_recorded_with_group_and_body() {
+    let fake = FakeSignalEndpoint::start()
+        .await
+        .expect("start fake")
+        .with_group_id("grp-send==");
+
+    let mut transport = SignalTransport::connect(fake.addr()).await.unwrap();
+    let gid = GroupId("grp-send==".to_string());
+    transport
+        .send_group(&gid, "session started")
+        .await
+        .expect("send over fake");
+
+    assert!(
+        fake.sent()
+            .contains(&("grp-send==".to_string(), "session started".to_string())),
+        "fake must record (group_id, body); got {:?}",
+        fake.sent()
+    );
+}
+
+#[tokio::test]
+async fn quit_group_is_recorded() {
+    let fake = FakeSignalEndpoint::start()
+        .await
+        .expect("start fake")
+        .with_group_id("grp-quit==");
+
+    let mut transport = SignalTransport::connect(fake.addr()).await.unwrap();
+    let gid = GroupId("grp-quit==".to_string());
+    transport.quit_group(&gid).await.expect("quit over fake");
+
+    assert!(
+        fake.quit_groups().contains(&"grp-quit==".to_string()),
+        "fake must record the quit-group; got {:?}",
+        fake.quit_groups()
+    );
+}
+
+#[tokio::test]
+async fn receive_parses_an_enqueued_inbound_envelope() {
+    // The inbound subscriber loop reads envelopes via `receive`. Enqueue a
+    // group dataMessage on the fake and confirm the transport parses it.
+    let fake = FakeSignalEndpoint::start().await.expect("start fake");
+    fake.enqueue_inbound(
+        r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{
+            "source":"+15551230001","sourceDevice":1,
+            "dataMessage":{"message":"do the thing","groupInfo":{"groupId":"grp-inbound=="}}
+        }}}"#,
+    );
+
+    let mut transport = SignalTransport::connect(fake.addr()).await.unwrap();
+    let env = transport
+        .receive()
+        .await
+        .expect("receive ok")
+        .expect("an envelope was delivered");
+
+    assert_eq!(env.source.as_deref(), Some("+15551230001"));
+    assert_eq!(env.group_id.as_deref(), Some("grp-inbound=="));
+    assert_eq!(env.body.as_deref(), Some("do the thing"));
+    assert!(!env.is_sync);
+}

--- a/crates/amplihack-signal/tests/session_relay_it.rs
+++ b/crates/amplihack-signal/tests/session_relay_it.rs
@@ -1,0 +1,129 @@
+//! R4 — end-to-end session relay over the offline fake endpoint (issue #1002).
+//!
+//! Ties the pieces together against `FakeSignalEndpoint`: a `SignalSession`
+//! posts outbound mirror messages (recorded by the fake) and accepts a genuine
+//! allowlisted operator instruction while dropping the account's own synced-back
+//! echo. This is the deterministic, offline proof that the bidirectional channel
+//! works without ever creating a real Signal group.
+//!
+//! `enqueue_inbound` is delivered promptly even after the connection is live, so
+//! an echo enqueued *after* an outbound post is still exercised through the gate.
+//!
+//! RED: `FakeSignalEndpoint` does not exist yet.
+#![cfg(feature = "signal")]
+
+use std::collections::HashMap;
+
+use amplihack_signal::config::{ENV_ACCOUNT, ENV_ALLOWLIST, ENV_ENDPOINT, SignalConfig};
+use amplihack_signal::fake_endpoint::FakeSignalEndpoint;
+use amplihack_signal::session_channel::{Inbox, SignalSession};
+use amplihack_signal::transport::{GroupId, SignalTransport};
+use tempfile::TempDir;
+
+fn config_for(addr: &str) -> SignalConfig {
+    let mut env = HashMap::new();
+    env.insert(ENV_ENDPOINT.to_string(), addr.to_string());
+    env.insert(ENV_ACCOUNT.to_string(), "+15551230000".to_string());
+    // Operator commands from their own primary phone (device 1) as the account's
+    // synced transcript, so allowlist the account number itself.
+    env.insert(ENV_ALLOWLIST.to_string(), "+15551230000".to_string());
+    SignalConfig::from_sources(&env, None).expect("valid config")
+}
+
+#[tokio::test]
+async fn outbound_post_is_mirrored_to_the_group() {
+    let fake = FakeSignalEndpoint::start()
+        .await
+        .unwrap()
+        .with_group_id("grp-relay==");
+    let transport = SignalTransport::connect(fake.addr()).await.unwrap();
+    let dir = TempDir::new().unwrap();
+    let inbox = Inbox::new(dir.path().join("inbox.json"), 16);
+
+    let cfg = config_for(fake.addr());
+    let mut session =
+        SignalSession::new(transport, &cfg, GroupId("grp-relay==".to_string()), inbox);
+
+    session
+        .post("assistant turn output mirrored")
+        .await
+        .unwrap();
+
+    assert!(
+        fake.sent()
+            .iter()
+            .any(|(g, b)| g == "grp-relay==" && b == "assistant turn output mirrored"),
+        "the whole-session mirror must post assistant output to the group; got {:?}",
+        fake.sent()
+    );
+}
+
+#[tokio::test]
+async fn inbound_operator_instruction_is_accepted_and_queued() {
+    let fake = FakeSignalEndpoint::start()
+        .await
+        .unwrap()
+        .with_group_id("grp-inbox==");
+    let transport = SignalTransport::connect(fake.addr()).await.unwrap();
+    let dir = TempDir::new().unwrap();
+    let inbox = Inbox::new(dir.path().join("inbox.json"), 16);
+    let cfg = config_for(fake.addr());
+    let mut session =
+        SignalSession::new(transport, &cfg, GroupId("grp-inbox==".to_string()), inbox);
+
+    // Operator types on their primary phone → account's own sync transcript,
+    // device 1, in this session's group: a legitimate instruction.
+    fake.enqueue_inbound(
+        r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{
+            "source":"+15551230000","sourceDevice":1,
+            "syncMessage":{"sentMessage":{"message":"run the tests again",
+                "groupInfo":{"groupId":"grp-inbox=="}}}
+        }}}"#,
+    );
+
+    let accepted = session.pump_once().await.expect("pump ok");
+    assert_eq!(
+        accepted.as_deref(),
+        Some("run the tests again"),
+        "an allowlisted operator instruction must be accepted"
+    );
+    assert_eq!(
+        session.drain().unwrap(),
+        vec!["run the tests again".to_string()],
+        "accepted instruction must be queued for injection into the agent"
+    );
+}
+
+#[tokio::test]
+async fn own_mirrored_message_is_not_reinjected_as_inbound() {
+    // Echo-loop guard: after posting our own mirror line, its synced-back copy
+    // must be suppressed rather than re-ingested as an operator instruction.
+    let fake = FakeSignalEndpoint::start()
+        .await
+        .unwrap()
+        .with_group_id("grp-echo==");
+    let transport = SignalTransport::connect(fake.addr()).await.unwrap();
+    let dir = TempDir::new().unwrap();
+    let inbox = Inbox::new(dir.path().join("inbox.json"), 16);
+    let cfg = config_for(fake.addr());
+    let mut session = SignalSession::new(transport, &cfg, GroupId("grp-echo==".to_string()), inbox);
+
+    session.post("session started").await.unwrap();
+
+    // The account's own message syncs back from device 1 in the same group.
+    fake.enqueue_inbound(
+        r#"{"jsonrpc":"2.0","method":"receive","params":{"envelope":{
+            "source":"+15551230000","sourceDevice":1,
+            "syncMessage":{"sentMessage":{"message":"session started",
+                "groupInfo":{"groupId":"grp-echo=="}}}
+        }}}"#,
+    );
+
+    let pumped = session.pump_once().await.expect("pump ok");
+    // Gate returns None-instruction (rendered as an empty accepted string) for a
+    // suppressed echo; either way it must never enqueue our own words.
+    assert!(
+        session.drain().unwrap().is_empty(),
+        "our own mirrored message must not be re-injected as inbound (got pumped={pumped:?})"
+    );
+}

--- a/crates/amplihack-types/src/hook_io.rs
+++ b/crates/amplihack-types/src/hook_io.rs
@@ -117,7 +117,11 @@ impl<'de> Deserialize<'de> for HookInput {
                 cwd: optional_typed_field(map, CWD_FIELDS)?,
                 extra: extra(),
             }),
-            Some("sessionstop") => Ok(HookInput::SessionStop {
+            // Claude Code emits `SessionEnd` at genuine session termination;
+            // other hosts use `SessionStop`. Both map to the same variant so
+            // the SessionStopHook (which performs per-session Signal teardown)
+            // runs regardless of host event naming.
+            Some("sessionstop") | Some("sessionend") => Ok(HookInput::SessionStop {
                 session_id: optional_typed_field(map, SESSION_ID_FIELDS)?,
                 transcript_path: optional_typed_field(map, TRANSCRIPT_PATH_FIELDS)?,
                 extra: extra(),
@@ -294,6 +298,22 @@ mod tests {
                 session_id: None,
             }
         ));
+    }
+
+    #[test]
+    fn deserialize_session_end_maps_to_session_stop() {
+        // Claude Code emits `SessionEnd` at genuine session termination; it must
+        // route to the same variant as `SessionStop` so per-session Signal
+        // teardown runs. Without this alias the payload parses to `Unknown` and
+        // the detached subscriber is never torn down (orphaned-process bug).
+        for name in ["SessionEnd", "sessionEnd", "session_end"] {
+            let json = format!(r#"{{"hook_event_name": "{name}", "session_id": "s1"}}"#);
+            let input: HookInput = serde_json::from_str(&json).unwrap();
+            assert!(
+                matches!(&input, HookInput::SessionStop { session_id: Some(id), .. } if id == "s1"),
+                "event name {name} must map to SessionStop, got {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/docs/SIGNAL_ONBOARDING.md
+++ b/docs/SIGNAL_ONBOARDING.md
@@ -13,6 +13,7 @@ an entire Azure Linux (azlin) fleet with `amplihack signal distribute`.
 
 - [Before you start](#before-you-start)
 - [Onboard one host: `signal setup`](#onboard-one-host-signal-setup)
+- [Automatic in-session prompt](#automatic-in-session-prompt)
 - [Onboard a fleet: `signal distribute`](#onboard-a-fleet-signal-distribute)
 - [Key constraints](#key-constraints)
 - [Verifying it worked](#verifying-it-worked)
@@ -95,6 +96,43 @@ amplihack signal setup --force         # repair/overwrite existing setup
 ```
 
 ---
+
+## Automatic in-session prompt
+
+You don't have to remember to run `signal setup` in advance. The **first time
+you launch amplihack (Copilot CLI or Claude Code) on an un-onboarded host**, the
+`SessionStart` hook offers a fast, skippable prompt:
+
+```text
+Signal channel is not configured on this host.
+Add this host as a Signal device and mirror your sessions to Signal? [y/N]
+```
+
+- **Yes** records your intent and **spawns `amplihack signal setup` in the
+  background** (device linking is user-paced and cannot run inside the ~30s hook
+  timeout). Signal stays off for the **current** session and turns on
+  automatically on the **next** launch, once `~/.amplihack/signal-config.toml`
+  exists.
+- **No / Enter** writes a decline sentinel
+  (`~/.amplihack/runtime/signal/.onboarding-declined`) so you are **not asked
+  again** on this host.
+
+The prompt is **skipped entirely** — never blocking a session — when any of
+these hold: not a TTY, `AMPLIHACK_NONINTERACTIVE=1`, config already present, or
+the decline sentinel exists. To be asked again after declining:
+
+```bash
+rm ~/.amplihack/runtime/signal/.onboarding-declined
+```
+
+This is the interactive counterpart to `signal setup`; both write the same
+`~/.amplihack/signal-config.toml`. Full behavior:
+[Signal Channel → In-session onboarding prompt](signal-channel.md#in-session-onboarding-prompt).
+
+> **Works on both hosts.** Onboarding, mirroring, and operator injection are
+> **host-aware** and function identically on **GitHub Copilot CLI** and **Claude
+> Code**; the channel detects the host from `AMPLIHACK_AGENT_BINARY`. See
+> [Host awareness](signal-channel.md#host-awareness-copilot-vs-claude-code).
 
 ## Onboard a fleet: `signal distribute`
 
@@ -182,7 +220,10 @@ cat ~/.amplihack/signal-config.toml
 ss -ltnp | grep 127.0.0.1:7583        # or your --port
 
 # 3. Start any amplihack session; you should receive a "session started"
-#    message in a fresh Signal group named amplihack-<session-id>-<timestamp>.
+#    message in a fresh Signal group named amplihack-<session-id>-<timestamp>,
+#    followed by the WHOLE conversation mirrored live — every prompt you type
+#    and every assistant turn. Reply in the Signal chat and your message is
+#    injected into the running agent as if typed at the CLI input box.
 ```
 
 If nothing arrives, check the session's `warnings[]` — every Signal operation is

--- a/docs/signal-channel.md
+++ b/docs/signal-channel.md
@@ -1,13 +1,16 @@
 # Signal Channel
 
-A **feature-gated, per-session Signal messaging channel** for amplihack. When
-enabled, each amplihack session opens a private Signal group, posts meaningful
-progress updates to it, and lets an allow-listed operator send **advisory**
-instructions back into the running session.
+A **feature-gated, per-session Signal messaging channel** for amplihack that
+works for **both GitHub Copilot CLI and Claude Code**. When enabled, each
+amplihack session opens a private Signal group **once for the whole session**,
+**mirrors the entire conversation** to it (every user prompt and every
+assistant turn), and lets an allow-listed operator send messages back into the
+running session — injected **as if typed at the CLI input box**.
 
 - **Crate:** `amplihack-signal`
 - **Cargo feature:** `signal` (default **OFF**)
 - **Wire protocol:** signal-cli JSON-RPC 2.0 over newline-delimited TCP
+- **Hosts:** Copilot CLI **and** Claude Code (host-aware injection & teardown)
 - **Trust model:** inbound text is surfaced to the agent as *context only* and
   is **never auto-executed**
 
@@ -22,17 +25,22 @@ instructions back into the running session.
 - [How it works](#how-it-works)
 - [Prerequisites](#prerequisites)
 - [Onboarding: `amplihack signal setup`](#onboarding-amplihack-signal-setup)
+- [In-session onboarding prompt](#in-session-onboarding-prompt)
 - [Fleet distribution: `amplihack signal distribute`](#fleet-distribution-amplihack-signal-distribute)
 - [Exit codes](#exit-codes)
 - [Quick start](#quick-start)
 - [Configuration](#configuration)
+- [Host awareness (Copilot vs Claude Code)](#host-awareness-copilot-vs-claude-code)
 - [Group naming and lifecycle](#group-naming-and-lifecycle)
 - [Per-session wiring](#per-session-wiring)
+- [Full conversation mirroring](#full-conversation-mirroring)
+- [Host-aware context injection](#host-aware-context-injection)
 - [The inbound path (operator → agent)](#the-inbound-path-operator--agent)
 - [The outbound path (agent → operator)](#the-outbound-path-agent--operator)
 - [Security model / trust boundary](#security-model--trust-boundary)
 - [Crate API reference](#crate-api-reference)
 - [Building and testing](#building-and-testing)
+- [Offline testing (fake JSON-RPC endpoint)](#offline-testing-fake-json-rpc-endpoint)
 - [Troubleshooting](#troubleshooting)
 - [FAQ](#faq)
 
@@ -41,41 +49,57 @@ instructions back into the running session.
 ## How it works
 
 ```
-┌────────────────────┐        JSON-RPC 2.0 (NDJSON/TCP)        ┌──────────────┐
-│  amplihack session │  ───────────────────────────────────►  │  signal-cli   │
-│  (hooks pipeline)  │                                         │  daemon       │
-│                    │  ◄───────────────────────────────────  │ (your number) │
-└─────────┬──────────┘         receive stream                 └──────┬────────┘
-          │                                                          │
-          │ SessionStart: create group, post "session started",       │
-          │               spawn detached subscriber (persist PID)      │
-          │                                                          ▼
-          │                                             ┌────────────────────────┐
-          │  file inbox (AtomicJsonFile) ◄───────────── │ signal-subscriber       │
-          │        ▲                                    │ (long-lived connection) │
-          │        │ drain                              │ allowlist + gate        │
-   PostToolUse /   │                                    │ + groupId + echo-suppr. │
-   UserPromptSubmit│  additionalContext                 └────────────────────────┘
-          │        │
-          ▼        │
-   Stop: post summary → quitGroup → stop subscriber
+┌────────────────────────┐    JSON-RPC 2.0 (NDJSON/TCP)     ┌──────────────┐
+│   amplihack session     │  ──────────────────────────────► │  signal-cli   │
+│   (hooks pipeline)      │   outbound: mirror EVERY user     │  daemon       │
+│   host = copilot|claude │   prompt + EVERY assistant turn   │ (your number) │
+│                         │  ◄────────────────────────────── └──────┬────────┘
+└───────────┬─────────────┘          receive stream                │
+            │                                                       │
+            │ SessionStart: create group ONCE/session,               │
+            │   post "session started", spawn detached subscriber    │
+            │                                                       ▼
+            │                                          ┌────────────────────────┐
+            │  file inbox (AtomicJsonFile) ◄────────── │ signal-subscriber       │
+            │        ▲                                 │ (long-lived connection) │
+            │        │ drain + host-aware inject       │ allowlist + gate        │
+  UserPromptSubmit / │  ───────────────────────────►  │ + groupId + echo-suppr. │
+  PostToolUse        │  copilot: top-level             │ (fingerprint file)      │
+            │        │  additionalContext (string)     └────────────────────────┘
+            │        │  claude:  hookSpecificOutput.additionalContext
+            ▼        │
+  per-turn Stop:  OUTBOUND relay only (post assistant turn, NO teardown)
+  SessionStop:    post summary → quitGroup → stop subscriber  (once/session)
 ```
 
 The channel is wired through amplihack's existing **hooks** pipeline
-(`amplihack-hooks`), not the recipe-runner:
+(`amplihack-hooks`), not the recipe-runner. It is **host-aware**: the same
+channel drives both **GitHub Copilot CLI** and **Claude Code**, detecting the
+active host from `AMPLIHACK_AGENT_BINARY` and emitting the output shape each
+host understands.
 
-1. **SessionStart** creates a Signal group, persists its `groupId` in session
-   state, posts a "session started" message, and spawns a **detached,
-   long-lived subscriber process** whose PID is persisted.
+1. **SessionStart** loads config (or, on an un-onboarded host, offers the
+   [in-session onboarding prompt](#in-session-onboarding-prompt)), creates a
+   Signal group **once per session**, persists its `groupId` in session state,
+   posts a "session started" message, and spawns a **detached, long-lived
+   subscriber process** whose PID is persisted. The group lives for the
+   **entire session**, not per turn.
 2. The **subscriber** holds a single JSON-RPC connection, filters messages to
    this session's `groupId`, applies the gate (allowlist + setup-aware
-   authorization + echo suppression), and appends accepted instructions to a
-   **per-session file inbox**.
-3. **PostToolUse** and **UserPromptSubmit** hooks drain the file inbox and
-   inject any queued operator instructions into the agent as
-   `hookSpecificOutput.additionalContext`.
-4. **Stop** posts a session summary, calls `quitGroup`, and stops the
-   subscriber.
+   authorization + echo suppression), and appends accepted operator messages to
+   a **per-session file inbox**.
+3. **UserPromptSubmit** and **PostToolUse** hooks drain the file inbox and
+   inject any queued operator messages into the agent **as if typed at the CLI
+   input box**, using the [host-aware injection shape](#host-aware-context-injection).
+4. **Full conversation mirroring** relays the whole session both ways: every
+   **user prompt** (from `UserPromptSubmit` / `userPromptSubmitted`) and every
+   **assistant turn** (from the per-turn `Stop` / `agentStop` hook, read from
+   the `transcript_path`) is posted to the group as it happens.
+5. The **per-turn Stop hook is OUTBOUND relay only** — it posts the assistant
+   turn but **never tears down** the channel.
+6. **SessionStop** (Claude `SessionEnd`, Copilot `sessionEnd`) posts a session
+   summary, calls `quitGroup`, and stops the subscriber. Teardown fires
+   **exactly once** at session end.
 
 Every Signal operation is **non-fatal**: failures are appended to the hook's
 `warnings[]` and emitted via `tracing`, and the hook still exits `0`. A broken
@@ -206,6 +230,62 @@ up the config automatically — no further steps (see
 
 Running `amplihack signal setup` a second time on an already-onboarded host is
 safe and fast — it verifies all three probes and exits `0`.
+
+---
+
+## In-session onboarding prompt
+
+You no longer have to remember to run `amplihack signal setup` ahead of time.
+When you launch amplihack (Copilot CLI **or** Claude Code) on a host that is
+**not yet configured for Signal**, the `SessionStart` hook offers a **fast,
+skippable prompt** asking whether you want to add **this host** as a signal-cli
+device and mirror your session to Signal:
+
+```text
+Signal channel is not configured on this host.
+Add this host as a Signal device and mirror your sessions to Signal? [y/N]
+```
+
+### When the prompt appears
+
+The prompt is shown **only** when **all** of these hold:
+
+- `SignalConfig::load()` fails (no valid `~/.amplihack/signal-config.toml` and
+  no env-var config), **and**
+- stdout/stdin is an interactive **TTY**, **and**
+- `AMPLIHACK_NONINTERACTIVE` is **unset** (or not `1`), **and**
+- no **decline sentinel** exists at
+  `~/.amplihack/runtime/signal/.onboarding-declined`.
+
+If any condition fails, the prompt is **silently skipped** and the session
+proceeds normally with the channel off. In particular, CI, scripts, and any run
+with `AMPLIHACK_NONINTERACTIVE=1` never see the prompt.
+
+### What each answer does
+
+| Answer | Behavior |
+|---|---|
+| **Yes** (`y`) | Records onboarding intent and **spawns `amplihack signal setup` detached** (see [why it is detached](#why-onboarding-is-non-blocking)), then returns immediately. Signal stays **off for the current session**; mirroring activates automatically on the **next launch** once `~/.amplihack/signal-config.toml` exists. |
+| **No** / Enter (`N`) | Writes the `.onboarding-declined` sentinel so **you are not asked again** on this host, and continues with the channel off. |
+| **No response / non-TTY** | Skipped; nothing is written; the channel stays off. |
+
+To be asked again after declining, delete the sentinel:
+
+```bash
+rm ~/.amplihack/runtime/signal/.onboarding-declined
+```
+
+Or onboard explicitly at any time with `amplihack signal setup`.
+
+### Why onboarding is non-blocking
+
+Device linking is **user-paced** (you scan a QR code with your phone) and can
+take far longer than a hook is allowed to run — Copilot CLI enforces a ~30s
+hook timeout. The prompt therefore only records your choice and **spawns the
+real linking flow (`run_setup`) as a detached process**; it never blocks the
+`SessionStart` hook on QR scanning. This guarantees the onboarding UX can
+**never break, stall, or slow down a session**, whether you accept, decline, or
+Signal is unreachable.
 
 ---
 
@@ -398,6 +478,7 @@ the channel stays off; there are **no other silent defaults**.
 | Reuse rolling group | `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP` | `reuse_rolling_group` | optional | **Default `false` (per-session groups).** Opt-in only: a truthy value (`1`/`true`/`yes`/`on`, case-insensitive) reuses one long-lived shared group across every session instead of creating a fresh per-session group. Absent, empty, or explicit false values (`0`/`false`/`no`/`off`) resolve to per-session isolation; unknown tokens are rejected |
 | Rolling group id | `AMPLIHACK_SIGNAL_ROLLING_GROUP_ID` | `rolling_group_id` | required when rolling reuse is enabled | Existing group id to bind to when — and only when — rolling reuse is opted into. Ignored while the per-session default is in effect |
 | Config file path | `AMPLIHACK_SIGNAL_CONFIG` | — | optional | Explicit path to the TOML file below. When unset, the loader falls back to the onboarding default `~/.amplihack/signal-config.toml` |
+| Pending inbox capacity | `AMPLIHACK_SIGNAL_INBOX_CAPACITY` | — | optional | Positive integer number of queued inbound operator instructions retained before overflow evicts the oldest pending instruction. Defaults to `32`; tune per host/workflow when operators intentionally send bursts |
 
 > **Fail-closed allowlist.** An **empty** allowlist is a valid, deliberate
 > configuration meaning "accept no inbound instructions." It is *not* treated
@@ -437,84 +518,119 @@ Any value present in the environment overrides the same key in the file.
 
 ---
 
+## Host awareness (Copilot vs Claude Code)
+
+The channel drives **both** GitHub Copilot CLI and Claude Code from one code
+path. It resolves the active host from the **`AMPLIHACK_AGENT_BINARY`**
+environment variable (via `amplihack_utils::agent_binary::resolve`), which
+accepts `copilot`, `claude`, `codex`, or `amplifier` (default: `copilot`).
+
+Host detection controls two things that genuinely differ between the two CLIs:
+
+| Concern | Copilot CLI | Claude Code |
+|---|---|---|
+| **Inbound injection shape** | **Top-level** `additionalContext` (string) on the `userPromptSubmitted` hook output | Nested `hookSpecificOutput.additionalContext` (string) |
+| **Session-end event wiring** | `sessionEnd` → `session-stop-event` subcommand | `SessionEnd` → `session-stop-event` subcommand |
+
+Everything else — group creation, mirroring, the subscriber, gating, echo
+suppression, teardown — is host-independent.
+
+> **Why the injection shape matters.** Copilot CLI **ignores** Claude Code's
+> nested `hookSpecificOutput.additionalContext`. Operator messages injected in
+> the Claude shape would silently never reach the Copilot agent. The channel
+> therefore emits the **correct shape per host** so injected operator text
+> reaches the agent's context on **both** CLIs. See
+> [Host-aware context injection](#host-aware-context-injection).
+
+To force a host explicitly (for testing or in wrappers):
+
+```bash
+export AMPLIHACK_AGENT_BINARY=copilot   # or: claude
+```
+
+The installers stage host-appropriate hook wrappers automatically (see
+[Per-session wiring](#per-session-wiring)); you normally do not set this by hand.
+
+---
+
 ## Group naming and lifecycle
 
 ### Only the top-level operator session gets a group
 
 The Signal channel is **operator-facing**: it exists so a human can watch and
-advise the single session they launched. A real amplihack run, however, spawns
-**many** nested sessions — the orchestrator, each recipe step, and every
-sub-agent all start their own session with their own `session_id`. If every one
-of those opened a Signal group, the operator's phone would fill with dozens of
-**empty** groups (each containing only a lone `session started` message) and it
-would be impossible to tell which group belonged to the run they care about.
+advise the single session they launched. A real amplihack run can spawn nested
+sessions — the orchestrator, recipe steps, and sub-agents each have their own
+`session_id`. If every nested session opened Signal, the operator's phone would
+fill with empty groups.
 
-To prevent this, SessionStart integration applies a **nesting gate**: a Signal
-group is created **only for the top-level operator session**. Nested sessions
-are a **silent no-op** — they create no group, post no `session started`
-message, persist no group state, and spawn no subscriber. This is normal,
-expected behavior, not a warning or an error.
+SessionStart therefore applies a **nesting gate**: a Signal group is created
+**only for the top-level operator session**. Nested sessions are an intended
+no-op: they create no group, post no `session started` marker, persist no group
+state, and spawn no subscriber.
 
-Nesting is detected from the `AMPLIHACK_SESSION_DEPTH` environment variable,
-which amplihack increments for every child session it spawns:
+Nesting is detected from `AMPLIHACK_SESSION_DEPTH`, which amplihack increments
+for child sessions:
 
 | `AMPLIHACK_SESSION_DEPTH` | Session kind | Signal group created? |
 |---|---|---|
 | unset or `0` | Top-level operator session | ✅ Yes |
-| `1`, `2`, … (any value > 0) | Nested recipe / orchestrator / sub-agent | ❌ No (silent no-op) |
+| `1`, `2`, … | Nested recipe / orchestrator / sub-agent | ❌ No |
 
-A non-numeric or malformed value is treated as depth `0` (fail toward creating
-the group for the visible operator session).
-
-> **Why this matters.** Before the nesting gate, a single run could create tens
-> of empty groups. With the gate, one run produces exactly **one** group — the
-> operator's — and all meaningful output flows there.
+A non-numeric value is treated as depth `0`, failing toward preserving the
+visible operator session.
 
 ### Group name
 
 **Per-session (default).** On the top-level SessionStart a fresh group is
-created. When the session is running under **tmux** the group name embeds the
-tmux session name so the operator can immediately tell which group maps to which
-terminal/session:
+created **once for the entire session**. When running inside tmux the name is:
 
 ```
-amplihack-<tmux-session-name>-<session-id>-<unix-timestamp>
+amplihack-<hostname>-<tmux-session>
 ```
 
-When **not** running under tmux (or the tmux lookup fails or times out), the
-name gracefully falls back to the previous format:
+Outside tmux it falls back to:
 
 ```
-amplihack-<session-id>-<unix-timestamp>
+amplihack-<hostname>-<session-id>-<unix-timestamp>
 ```
 
-Both the tmux session name and the session id are **sanitized** to the
-allowlist `[A-Za-z0-9_-]` (the same allowlist used by `sanitize_session_id`);
-the tmux portion is truncated to **32 characters**
-to keep names bounded. If the tmux name is empty after sanitization it is
-omitted (fallback form is used).
+Hostname, tmux session name, and session id are sanitized before use in the
+display name. The `groupId` returned by signal-cli is persisted in session
+state and reused for every mirrored message throughout the session. Group
+creation is **idempotent**: if a group already exists for the session it is
+reused, never recreated.
 
-The tmux name is discovered by running `tmux display-message -p
-'#{session_name}'` **only when the `TMUX` environment variable is set**, with a
-**~2-second timeout** and a graceful fallback: any failure, timeout, or
-absence of tmux simply omits the tmux part. The subprocess is invoked with an
-explicit argument vector (no shell), so the tmux name — which is untrusted
-input — can never trigger shell or argument injection, and it is used **only**
-in the display group name (never in any filesystem path).
+**Teardown happens once, at session end — not per turn.** The **per-turn
+`Stop` / `agentStop` hook is outbound relay only** and must **never** close the
+group. The group is closed with `quitGroup` **only** by the `SessionStop`
+handler, which fires on:
 
-The `groupId` returned by signal-cli is persisted in session state. On Stop the
-group is closed with `quitGroup`.
+- Claude Code **`SessionEnd`**, and
+- Copilot CLI **`sessionEnd`** (wired to the `session-stop-event` subcommand —
+  see [Per-session wiring](#per-session-wiring)),
 
-> **Nested / no-group sessions on Stop.** Because nested sessions never create a
-> group or persist a `group_id`, their Stop hook is likewise a clean no-op: no
-> summary is posted and no `quitGroup` is attempted when there is no persisted
-> `group_id` for the session.
+both routed to `SessionStopHook`. This guarantees subscribers and groups do not
+leak on Copilot session end.
+
+> **The bug this fixes.** In the pre-R5 wiring, teardown lived in the **wrong
+> place**: the per-turn `StopHook` (`stop` / `agentStop`) called
+> `signal_integration::on_stop`, which posts "session complete" and runs
+> `quitGroup`. Because Claude Code fires `Stop` **after every assistant turn**
+> (and Copilot's only wired stop event was `agentStop` → `stop`), the group was
+> torn down after the **first** turn, while the real `SessionStopHook`
+> (`session-stop-event`) did **no** Signal teardown at all. The fix is a
+> **migration, not an addition**: move the `on_stop` teardown call **out of**
+> `StopHook` and **into** `SessionStopHook`, leave `StopHook` doing outbound
+> relay only, and add a Copilot **`sessionEnd` → `session-stop-event`** wrapper
+> so Copilot still tears down exactly once. Adding that wrapper is **required**,
+> not optional — without it, a relay-only `StopHook` would leave Copilot with no
+> teardown path and its groups/subscribers would leak.
 
 **Rolling group (opt-in).** Per-session groups are the default; nothing needs
 to be set to get them. To instead reuse a **single** long-lived group across all
 sessions, explicitly opt in by setting `reuse_rolling_group = true` (or
 `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`) **and** supplying `rolling_group_id`.
-In this mode the group is **not** quit at Stop, so you keep one persistent
+In this mode the group is **not** quit at SessionStop, so you keep one persistent
 operator thread. Because this trades per-session isolation for a shared thread,
 it must be requested deliberately — any absent, empty, or explicit false reuse
 flag keeps the per-session default, unknown tokens are rejected, and a truthy
@@ -522,11 +638,10 @@ reuse flag without a group id is rejected.
 
 | Phase | Per-session | Rolling |
 |---|---|---|
-| SessionStart (top-level) | create group + post "session started" | reuse group + post "session started" |
-| SessionStart (nested) | **silent no-op** (no group, no post) | **silent no-op** (no group, no post) |
-| During run | post at meaningful transitions | post at meaningful transitions |
-| Stop (with group) | post summary → `quitGroup` | post summary (group kept) |
-| Stop (no group) | **silent no-op** | **silent no-op** |
+| SessionStart | create group **once** + post "session started" | reuse group + post "session started" |
+| Each user prompt | mirror the prompt to the group | mirror the prompt to the group |
+| Each assistant turn (per-turn `Stop`) | mirror the turn to the group — **OUTBOUND relay only, no teardown** | mirror the turn — no teardown |
+| SessionStop (`SessionEnd` / `sessionEnd`) | post summary → `quitGroup` + stop subscriber | post summary (group kept), stop subscriber |
 
 ---
 
@@ -559,6 +674,127 @@ hook's `warnings[]` and logged via `tracing`, and the session proceeds
 normally. Onboarding does not change this contract — a missing, malformed, or
 unreachable configuration can never crash or block a session.
 
+### Host wrapper generation and `sessionEnd`
+
+The installers generate host-appropriate hook wrappers and settings:
+
+- **Claude Code** (`~/.claude/settings.json`): the `SessionStart`,
+  `UserPromptSubmit`, `PostToolUse`, `Stop`, and `SessionEnd` events map to the
+  matching `amplihack-hooks` subcommands. `SessionEnd` → `session-stop-event`.
+- **Copilot CLI** (`~/.copilot` settings / `.github/hooks/`): the
+  `COPILOT_HOOK_WRAPPERS` table maps camelCase events to subcommands, including
+  the **`sessionEnd`** wrapper, which is wired to the **`session-stop-event`**
+  subcommand (`SessionStopHook`). This is what makes Copilot teardown fire so
+  **subscribers and groups do not leak on Copilot session end**.
+
+Dispatch in the hooks binary routes stop-family subcommands to the correct
+handler:
+
+| Subcommand / alias | Handler | Role |
+|---|---|---|
+| `stop`, `agentStop` | `StopHook` | Per-turn **outbound relay only** (mirror assistant turn) — **no teardown** |
+| `session-stop-event`, `session-end`, `session-stop` (Copilot `sessionEnd`, Claude `SessionEnd`) | `SessionStopHook` | **Teardown**: post summary → `quitGroup` → stop subscriber (once/session) |
+
+> **Migration hazard — existing `session-end` / `session-stop` aliases.** Today
+> `bins/amplihack-hooks/src/main.rs` routes `stop | session-end | session-stop`
+> **all** to `StopHook`, and only the distinct `session-stop-event` subcommand
+> reaches `SessionStopHook`. Once `StopHook` becomes relay-only, leaving those
+> aliases on `StopHook` would silently drop teardown for any host still emitting
+> a `session-end` / `session-stop` event name. **R5 resolves this by
+> re-pointing the `session-end` and `session-stop` subcommand aliases at
+> `SessionStopHook`** (the routing shown above), so every session-end event
+> name — `session-stop-event`, `session-end`, `session-stop` — performs
+> teardown, while `stop` / `agentStop` stay per-turn relay-only. The design's
+> own risk list warns this "could change dispatch for other consumers relying on
+> the old StopHook routing," so this is a **required, tested** change: add a
+> dispatch test asserting **no teardown runs on per-turn `stop` / `agentStop`**
+> and **exactly one** teardown runs for each session-end alias.
+
+Wrapper ownership detection (`is_amplihack_owned`) recognizes the
+`session-stop-event` / `sessionEnd` wrappers, so re-running the installer merges
+cleanly and never duplicates amplihack-owned entries in user settings.
+
+---
+
+## Full conversation mirroring
+
+The channel mirrors the **whole session conversation** to the Signal group — not
+just "session started" / "session complete" markers. Both directions of the
+conversation are relayed as they happen:
+
+| Source hook | Copilot event | Claude event | Mirrored to group |
+|---|---|---|---|
+| User prompt | `userPromptSubmitted` | `UserPromptSubmit` | The **user's prompt text** |
+| Assistant turn | `agentStop` | `Stop` | The **assistant's turn output**, read from the run's `transcript_path` |
+
+Key properties:
+
+- **Per-turn Stop is outbound-only.** Relaying the assistant turn happens in the
+  per-turn `Stop` / `agentStop` hook, which **never** tears down the channel.
+  Teardown **moves to** `SessionStop` — the `on_stop`/`quitGroup` call is
+  relocated out of `StopHook` into `SessionStopHook` (see
+  [Group lifecycle](#group-naming-and-lifecycle) for the before/after).
+- **Message size is bounded.** Every mirrored body — user prompts, assistant
+  turns, and injected operator context — is truncated at a UTF-8-safe boundary
+  to **4 KiB**, with a `… [truncated N bytes]` suffix. This keeps individual
+  Signal messages small and well within the transport's 256 KiB frame cap.
+- **No echo loops.** The account's own mirrored messages are **never**
+  re-injected as inbound operator instructions. Suppression uses two guards:
+  1. **Device/`is_sync` gating** — signal-cli's own synced-back sends (from a
+     linked device, `sourceDevice >= 2`) are rejected by the gate.
+  2. **Shared outbound fingerprints** — every mirrored outbound body is
+     fingerprinted (hashed, with a TTL) into an append-only file under
+     `signal_root()` (`~/.amplihack/runtime/signal/<session-id>/`). The detached
+     **subscriber process reads these fingerprints before injecting**, so echo
+     suppression works **across processes** even though outbound relay runs in
+     the hook process and inbound runs in the subscriber process.
+- **Non-fatal.** If a mirror send fails (daemon down, truncation edge case,
+  transcript unreadable), the failure is recorded in `warnings[]` and the turn
+  proceeds normally.
+
+---
+
+## Host-aware context injection
+
+When the inbox is drained (on `UserPromptSubmit` / `userPromptSubmitted` and
+`PostToolUse` / `postToolUse`), queued operator messages are injected into the
+agent **as if typed at the CLI input box**. The **output shape is host-aware**,
+because the two CLIs read `additionalContext` from different places.
+
+**Copilot CLI** — top-level `additionalContext` **string** on the hook output:
+
+```json
+{
+  "additionalContext": "Operator (via Signal): please also update the changelog"
+}
+```
+
+**Claude Code** — nested under `hookSpecificOutput` (unchanged, byte-for-byte
+compatible with prior releases):
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "Operator (via Signal): please also update the changelog"
+  }
+}
+```
+
+The host is resolved from `AMPLIHACK_AGENT_BINARY` (see
+[Host awareness](#host-awareness-copilot-vs-claude-code)). Both the
+`user_prompt` and `post_tool_use` drain sites route through the same host-aware
+merge helper, so operator context reaches the agent's context on **both** CLIs.
+
+> **The bug this fixes.** Copilot CLI **ignores** the nested
+> `hookSpecificOutput.additionalContext` and reads a **top-level**
+> `additionalContext` string (per the
+> [Copilot hooks reference](https://docs.github.com/en/copilot/reference/hooks-reference)).
+> Previously the inbound path always emitted the Claude-nested shape, so operator
+> messages drained from the inbox **never reached the Copilot agent**. Host-aware
+> injection makes end-to-end delivery work on Copilot while leaving Claude Code
+> output identical.
+
 ---
 
 ## The inbound path (operator → agent)
@@ -582,15 +818,20 @@ unreachable configuration can never crash or block a session.
 4. Accepted instruction text is appended to a **per-session file inbox**, a
    JSON document managed by `AtomicJsonFile` (crash-safe, lock-guarded). The
    inbox path is derived through `amplihack_types::paths::sanitize_session_id`
-   to prevent path traversal. The inbox is **bounded**: it holds at most a
-   fixed number of pending instructions (a small cap, e.g. 32). When full, the
-   **oldest** queued instruction is dropped to make room for the newest and the
-   drop is recorded in `warnings[]` — a flood of inbound messages can never grow
-   memory or disk without limit (backpressure by bounded queue).
-5. On the next **PostToolUse** or **UserPromptSubmit** hook, the inbox is
-   **drained** and its queued instructions are emitted to the agent via
-   `hookSpecificOutput.additionalContext`. Draining is one-shot: each
-   instruction is delivered once.
+   to prevent path traversal. The inbox is **bounded and tunable**: it holds at
+   most `AMPLIHACK_SIGNAL_INBOX_CAPACITY` pending instructions, defaulting to
+   `32` when unset or invalid. When full, the **oldest** queued instruction is
+   dropped to make room for the newest and the subscriber logs a warning — a
+   flood of inbound messages can never grow memory or disk without limit
+   (backpressure by bounded queue), and the budget is explicit rather than
+   buried in code.
+5. On the next **UserPromptSubmit** or **PostToolUse** hook, the inbox is
+   **drained** and its queued operator messages are emitted to the agent **as if
+   typed at the CLI input box**, using the
+   [host-aware injection shape](#host-aware-context-injection) — a **top-level**
+   `additionalContext` string for Copilot CLI, or the nested
+   `hookSpecificOutput.additionalContext` for Claude Code. Injected bodies are
+   truncated to 4 KiB. Draining is one-shot: each message is delivered once.
 
 If the subscriber cannot start, the failure is recorded in `warnings[]` and via
 `tracing`; the session continues normally with no inbound channel.
@@ -601,24 +842,33 @@ channel: the subscriber reconnects with **bounded exponential backoff** (1s → 
 → … capped at 30s), preserving its echo-suppression/de-dup state and file inbox
 across reconnects so no instruction is lost or re-delivered. Any inbound message
 resets the backoff. To avoid spinning against a permanently-down daemon it gives
-up after a small number of consecutive failures. A **cold-start** connect failure
-(no connection ever established) stays fast and non-fatal — SessionStart spawns
-the subscriber best-effort and is never stalled by an absent daemon.
+keeps retrying at the capped backoff once a connection has succeeded; inbound
+mirroring is not silently abandoned after an arbitrary failure count. A
+**cold-start** connect failure (no connection ever established) stays fast and
+non-fatal — SessionStart spawns the subscriber best-effort and is never stalled
+by an absent daemon.
 
 ---
 
 ## The outbound path (agent → operator)
 
-amplihack posts to the group **only at meaningful transitions** — not on every
-tool call — and posting is **throttled/batched**:
+amplihack mirrors the **whole conversation** to the group (see
+[Full conversation mirroring](#full-conversation-mirroring)) — every user prompt
+and every assistant turn — plus lifecycle markers:
 
 - **SessionStart** — "session started".
-- **Checkpoints / key results** — significant milestones.
-- **Stop** — a session summary.
+- **Each user prompt** — mirrored from `UserPromptSubmit` / `userPromptSubmitted`.
+- **Each assistant turn** — mirrored from the per-turn `Stop` / `agentStop`
+  hook, read from the run's `transcript_path` (outbound relay only, no teardown).
+- **SessionStop** — a session summary, then `quitGroup` (per-session mode).
 
-Outbound bodies are minimized and redacted before sending. Each posted body is
-recorded in the echo-suppression window so the subscriber will not treat the
-synced-back copy as an operator instruction.
+Every outbound body is **truncated to 4 KiB** at a UTF-8-safe boundary,
+minimized, and redacted before sending. Each posted body is **fingerprinted
+(hashed, TTL-bounded) into a shared file under `signal_root()`** so the
+subscriber process will not treat the synced-back copy as an operator
+instruction — echo suppression that works **across processes**. See
+[Full conversation mirroring](#full-conversation-mirroring) for the echo-loop
+guards.
 
 ---
 
@@ -640,28 +890,39 @@ Concretely:
   and never from signal-cli's own linked device, while a separate allowlisted
   number is accepted via a normal `dataMessage`. An **empty allowlist denies
   everything**.
-- **No self-ingestion.** Echo suppression (bounded TTL window over recent
-  outbound bodies) prevents the bot from re-processing its own messages that
-  Signal syncs back to the account.
+- **No self-ingestion.** Echo suppression prevents the bot from re-processing
+  its own mirrored messages that Signal syncs back to the account. It combines
+  **device/`is_sync` gating** (reject the account's own linked-device sends,
+  `sourceDevice >= 2`) with a **shared, TTL-bounded outbound-fingerprint file**
+  under `signal_root()` that the subscriber consults before injecting — so
+  suppression holds **across the hook and subscriber processes**.
+- **Bounded egress (mirroring).** [Full conversation mirroring](#full-conversation-mirroring)
+  relays user prompts and assistant turns outbound. Every mirrored body is
+  **truncated to 4 KiB** (UTF-8-safe), minimized, and redacted before sending;
+  egress is gated by the same loaded config and the `SIGNAL_ENABLED` process
+  gate, so an un-onboarded or feature-off host sends nothing.
 - **Feature default OFF.** No `signal` feature ⇒ no code, no dependencies, no
-  network sockets.
+  network sockets. In-process tests additionally keep the `SIGNAL_ENABLED`
+  process gate **off**, so no test performs real Signal I/O.
 - **No silent config defaults.** Missing required config is an explicit error,
   never a guessed value.
 - **Per-session group isolation by default.** `reuse_rolling_group` defaults to
   `false`, so each session gets its own group that is closed with `quitGroup`
-  at Stop — no operator thread outlives the session that created it. Sharing one
-  long-lived group across sessions is a deliberate opt-in
+  at SessionStop — no operator thread outlives the session that created it. Sharing
+  one long-lived group across sessions is a deliberate opt-in
   (`reuse_rolling_group = true` / `AMPLIHACK_SIGNAL_REUSE_ROLLING_GROUP=1`) plus
   a `rolling_group_id`; only non-empty truthy values enable it, and a missing
   group id is rejected instead of creating an untracked shared thread.
-- **Path safety.** Every per-session file path is run through
-  `sanitize_session_id`; inbox/PID files are written atomically with
-  restrictive permissions.
-- **Least privilege on shutdown.** Stop kills **only the recorded subscriber
-  PID**, never a name-matched sweep.
-- **Bounded inbox (flood resistance).** The file inbox has a fixed capacity;
-  under an inbound flood the oldest instruction is evicted (logged to
-  `warnings[]`) rather than allowing unbounded memory/disk growth.
+- **Path safety.** Every per-session file path (inbox, PID, decline sentinel,
+  outbound-fingerprint file) is run through `sanitize_session_id`; files are
+  written atomically with restrictive permissions.
+- **Least privilege on shutdown.** Teardown runs **only** from `SessionStop` and
+  kills **only the recorded subscriber PID**, never a name-matched sweep. The
+  per-turn `Stop` hook never tears down the channel.
+- **Bounded inbox (flood resistance).** The file inbox has a tunable capacity
+  (`AMPLIHACK_SIGNAL_INBOX_CAPACITY`, default `32`); under an inbound flood the
+  oldest instruction is evicted and the subscriber logs a warning rather than
+  allowing unbounded memory/disk growth.
 - **Non-fatal contract.** Every Signal operation that fails is logged to
   `warnings[]` + `tracing` and the hook still exits `0`.
 
@@ -723,6 +984,7 @@ Newline-delimited JSON-RPC 2.0 client over `tokio` TCP.
 
 | Method | Purpose |
 |---|---|
+| `connect(addr) -> SignalTransport` | Open a JSON-RPC connection. `addr` is the daemon endpoint in production, or a [`FakeSignalEndpoint`](#offline-testing-fake-json-rpc-endpoint) address in tests |
 | `create_group(name) -> GroupId` | Create a group (wraps the `updateGroup` create-by-name RPC) |
 | `send_group(group_id, body)` | Post a message (wraps the `send` RPC) |
 | `quit_group(group_id)` | Leave/close a group (`quitGroup`) |
@@ -732,6 +994,11 @@ Newline-delimited JSON-RPC 2.0 client over `tokio` TCP.
 > is expected to map to `updateGroup` (creating a group by supplying a name and
 > members); if the signal-cli daemon version in use names it differently,
 > update this table to match the actual method invoked.
+
+> **`FakeSignalEndpoint`** (test-only) implements the same newline-delimited
+> JSON-RPC 2.0 surface on a loopback `127.0.0.1:0` listener, so `connect` can be
+> pointed at it for hermetic offline tests. See
+> [Offline testing](#offline-testing-fake-json-rpc-endpoint).
 
 **Pure wire helpers** (no I/O, unit-tested in isolation):
 
@@ -775,13 +1042,28 @@ match gate.evaluate(&envelope) {
 
 | Method | Purpose |
 |---|---|
-| `announce()` | Create/reuse group and post "session started" |
+| `announce()` | Create/reuse the per-session group (idempotent) and post "session started" |
 | `post(update)` | Post a throttled outbound update |
-| `poll()` / `drain()` | Read (and clear) queued inbound instructions from the file inbox |
+| `relay_outbound(kind, body)` | Mirror a user prompt or assistant turn to the group (4 KiB UTF-8-safe truncation + outbound fingerprint) |
+| `poll()` / `drain()` | Read (and clear) queued inbound operator messages from the file inbox |
 
 The inbox is an `AtomicJsonFile` (from `amplihack-state`) at a
 `sanitize_session_id`-derived path, so writes by the subscriber process and
 reads by the hook process are safe across processes.
+
+### Feature modules (host integration)
+
+The `amplihack-hooks` `signal_integration` module ties the crate into the hooks
+pipeline. Key host-aware entry points:
+
+| Item | Role |
+|---|---|
+| `signal_integration::on_session_start` | Create the group once, spawn the subscriber, and offer the [in-session onboarding prompt](#in-session-onboarding-prompt) |
+| `signal_integration::drain_into_context` | Drain the inbox and produce the [host-aware injection](#host-aware-context-injection) output for the current host |
+| `signal_integration::relay_outbound` | [Full conversation mirroring](#full-conversation-mirroring) for user prompts and assistant turns |
+| `signal_integration::on_stop` | `SessionStop` teardown (`quitGroup` + stop subscriber) — **never** called from the per-turn `Stop` hook |
+| `signal_integration::set_process_enabled` | Toggle the `SIGNAL_ENABLED` process gate (ON in the real binary, OFF in tests) |
+| `FakeSignalEndpoint` | Test-only loopback JSON-RPC fake — see [Offline testing](#offline-testing-fake-json-rpc-endpoint) |
 
 ---
 
@@ -795,15 +1077,82 @@ gate:
 cargo build
 cargo test
 
-# Feature ON.
-cargo build --features signal
-cargo test  --features signal
+# Feature ON — build the hooks binary and run the hooks test-suite.
+cargo build --release -p amplihack-hooks-bin --features signal
+cargo test  --release -p amplihack-hooks     --features signal
 ```
 
 Integration tests are registered as explicit `[[test]]` targets and resolve the
 hooks binary via `env!("CARGO_BIN_EXE_amplihack-hooks")`, so they exercise the
 real `signal-subscriber` subcommand rather than an in-process stub. Pure
 wire/gating tests run with no network or filesystem I/O.
+
+**All tests are hermetic and offline.** `cargo test --release -p amplihack-hooks
+--features signal` **creates no real Signal groups and touches no real Signal
+network** — see [Offline testing](#offline-testing-fake-json-rpc-endpoint). The
+existing hook and golden-snapshot suites are **preserved green**, with **two new
+Copilot golden cases** added for the top-level `additionalContext` injection
+shape (Claude Code golden output is unchanged, byte-for-byte). The regression
+bar is "the full pre-existing suite still passes plus the two new Copilot
+goldens" — run `cargo test` for the current counts rather than relying on a
+number pinned in this doc.
+
+---
+
+## Offline testing (fake JSON-RPC endpoint)
+
+Signal channel tests **never hit the real Signal network**. Two independent
+mechanisms guarantee this:
+
+### 1. The `SIGNAL_ENABLED` process gate
+
+In-process hook tests run with Signal **I/O disabled** by default. The hooks
+binary opts in explicitly at startup (`signal_integration::set_process_enabled(true)`),
+while tests leave the gate **off** so exercising `on_session_start`,
+`drain_into_context`, and `on_stop` performs **no real Signal I/O** and creates
+**no groups**.
+
+### 2. `FakeSignalEndpoint` — a local JSON-RPC fake
+
+For tests that must exercise the transport and subscriber loop end-to-end,
+`amplihack-signal` ships a **fake signal-cli JSON-RPC endpoint** modeled on
+signal-cli's own **JSON-RPC daemon (`--tcp`) socket mode**. It is a
+`tokio::net::TcpListener` bound to **`127.0.0.1:0`** (an ephemeral loopback
+port) that speaks **newline-delimited JSON-RPC 2.0**, the same protocol the real
+daemon uses. `SignalTransport::connect` is pointed at the fake's address, so the
+full method surface can be driven deterministically:
+
+| RPC method | Exercised behavior |
+|---|---|
+| `updateGroup` (create) | Returns a synthetic `groupId`; asserts create-group requests |
+| `send` | Records outbound bodies for assertions (mirroring, truncation, fingerprints) |
+| `receive` | Streams scripted inbound envelopes into the subscriber loop |
+| `quitGroup` | Records teardown; asserts `SessionStop` (not per-turn `Stop`) closes the group |
+
+Because the endpoint binds **loopback-only** and returns synthetic ids, tests
+can cover **send / create-group / receive / quit-group** and the **inbound
+subscriber loop** — including gating, echo suppression, host-aware injection,
+reconnect/backoff, and full-conversation mirroring — with **zero** external
+dependencies and **no** real Signal account, group, or network traffic.
+
+```rust
+// Illustrative test wiring (offline, deterministic, no real Signal).
+let fake = FakeSignalEndpoint::start().await;   // binds 127.0.0.1:0
+let transport = SignalTransport::connect(fake.addr()).await?;
+
+let group = transport.create_group("amplihack-test").await?;   // synthetic id
+transport.send_group(&group, "session started").await?;
+fake.push_inbound(/* scripted operator envelope */);           // drive receive()
+// ... assert the message was injected in the host-aware shape ...
+transport.quit_group(&group).await?;
+
+assert_eq!(fake.groups_created(), 1);   // never a REAL group
+```
+
+> **CI guarantee.** The combination of the default-OFF `SIGNAL_ENABLED` gate and
+> the loopback-only `FakeSignalEndpoint` means no test path can reach the real
+> Signal service. CI runs the full `--features signal` suite with no signal-cli
+> installed and no network access.
 
 ---
 
@@ -817,25 +1166,45 @@ wire/gating tests run with no network or filesystem I/O.
 | Nothing ever accepted | Allowlist is empty (fail-closed) | Populate the allowlist |
 | Bot seems to "hear itself" | (Should not happen) echo window too short | Instructions equal to a recent outbound body are suppressed by design |
 | Subscriber not running | Spawn failed | Check `warnings[]`/`tracing`; the persisted PID file records the detached process |
-| Some instructions never arrive | Inbox overflowed under a burst | The inbox is bounded; oldest entries are evicted (see `warnings[]`). Send fewer, more deliberate instructions |
+| Some instructions never arrive | Inbox overflowed under a burst | The inbox is bounded and logs overflow warnings; raise `AMPLIHACK_SIGNAL_INBOX_CAPACITY` or send fewer, more deliberate instructions |
 | `signal setup` can't install signal-cli | No package/JRE available non-interactively | Follow the printed install guidance, install signal-cli manually, then re-run `amplihack signal setup` |
 | `signal setup` fails on port | `127.0.0.1:<port>` held by an unknown process | Free the port or pass `--port <other>` / set `AMPLIHACK_SIGNAL_PORT` |
 | A VM shows `failed: link limit reached` | Signal linked-device cap hit | Unlink an unused device in Signal, or use `--identity-mode dedicated-number` for very large fleets |
 | `distribute` stopped part-way | Interrupted / a VM failed | Re-run `amplihack signal distribute`; it resumes from `~/.amplihack/signal-distribute-state.json` and retries only pending/failed VMs |
-| Many **empty** groups piling up (each with only "session started") | Older behavior created a group for every nested session | Fixed: only the **top-level** session (`AMPLIHACK_SESSION_DEPTH` unset/`0`) creates a group; nested sessions are a silent no-op. Delete the stale empty groups; new runs produce exactly one group |
-| Can't tell which group belongs to which session | Group name lacked session context | Group names now embed the tmux session name when running under tmux: `amplihack-<tmux-session>-<session-id>-<ts>` |
+| Operator messages never reach the Copilot agent | Wrong injection shape (nested instead of top-level) | Fixed by [host-aware injection](#host-aware-context-injection). Confirm `AMPLIHACK_AGENT_BINARY=copilot`; Copilot needs the **top-level** `additionalContext` string |
+| Conversation not mirrored (only start/stop) | Old behavior / feature off | [Full mirroring](#full-conversation-mirroring) relays every user prompt + assistant turn; confirm `--features signal` and that `transcript_path` is readable |
+| Group is torn down after one turn | Teardown wired to per-turn Stop | Per-turn `Stop`/`agentStop` is **outbound-only**; teardown must be on `SessionStop` (`SessionEnd`/`sessionEnd` → `session-stop-event`) |
+| Subscriber/group leaks after Copilot exits | Copilot `sessionEnd` not wired | Re-run the installer so the `sessionEnd` → `session-stop-event` wrapper is generated (see [Host wrapper generation](#host-wrapper-generation-and-sessionend)) |
+| In-session onboarding prompt never appears | Non-TTY, `AMPLIHACK_NONINTERACTIVE=1`, already configured, or previously declined | Expected. Delete `~/.amplihack/runtime/signal/.onboarding-declined` to be asked again, or run `amplihack signal setup` |
+| Bot re-injects its own mirrored messages | Echo suppression gap | Should not happen: device/`is_sync` gating + shared outbound-fingerprint file suppress echoes across processes |
 
 Because every Signal operation is non-fatal, none of the above can break your
-amplihack session — worst case the channel is silently unavailable and the run
-proceeds normally.
+amplihack session — worst case the channel is unavailable, with the failure
+surfaced through hook warnings and/or `tracing`, and the run proceeds normally.
 
 ---
 
 ## FAQ
 
+**Does the Signal channel work with GitHub Copilot CLI, or only Claude Code?**
+Both. The channel is host-aware (`AMPLIHACK_AGENT_BINARY`): it emits a top-level
+`additionalContext` string for Copilot and the nested
+`hookSpecificOutput.additionalContext` for Claude Code, and wires teardown to
+Copilot's `sessionEnd` as well as Claude's `SessionEnd`. See
+[Host awareness](#host-awareness-copilot-vs-claude-code).
+
 **Does enabling Signal add dependencies to the default build?**
 No. With the feature off, `amplihack-signal` and its `tokio`-net dependencies
 are not compiled or linked.
+
+**Is the whole conversation mirrored, or just start/stop?**
+The whole conversation — every user prompt and every assistant turn — bounded to
+4 KiB per message. See [Full conversation mirroring](#full-conversation-mirroring).
+
+**Do the tests hit the real Signal network?**
+Never. The default-OFF `SIGNAL_ENABLED` gate plus the loopback-only
+`FakeSignalEndpoint` guarantee no real groups or network traffic. See
+[Offline testing](#offline-testing-fake-json-rpc-endpoint).
 
 **Can an operator make amplihack run a command by texting it?**
 No. Inbound text is delivered only as `additionalContext`. The agent decides
@@ -854,23 +1223,6 @@ In a per-session, atomically-written JSON inbox whose path is derived through
 `sanitize_session_id`. The inbox is bounded (oldest entries evicted under a
 flood) and is drained (delivered once) on the next
 `PostToolUse` / `UserPromptSubmit`.
-
-**Why don't nested sessions (recipes, orchestrator, sub-agents) get their own
-Signal group?**
-By design. A single run spawns many nested sessions; if each opened a group the
-operator would be buried in empty groups with no way to tell them apart. Only
-the top-level operator session (`AMPLIHACK_SESSION_DEPTH` unset or `0`) creates
-a group and posts output. Every nested session (`AMPLIHACK_SESSION_DEPTH > 0`)
-is a silent no-op — no group, no message, no state, no subscriber. All
-meaningful output still flows to the single operator group.
-
-**Why is the tmux session name in the group name? What if I'm not using tmux?**
-It makes each group instantly identifiable — you can match a Signal group to the
-terminal/session it came from. The lookup runs `tmux display-message -p
-'#{session_name}'` only when `TMUX` is set, with a ~2-second timeout. If you are
-not under tmux (or the lookup fails/times out) the name gracefully falls back to
-`amplihack-<session-id>-<ts>`. The tmux name is sanitized to `[A-Za-z0-9_-]`,
-truncated to 32 chars, and never used in any filesystem path.
 
 ---
 

--- a/tests/integration/hook_aliases_test.rs
+++ b/tests/integration/hook_aliases_test.rs
@@ -16,9 +16,13 @@
 //! | user_prompt_submit.py         | `amplihack-hooks user-prompt-submit`|
 //! | _shim.py                      | (no native; helper only)            |
 //!
-//! `session-end` and `session-stop` are clap aliases for `stop` (per design
-//! spec A3) — both must dispatch to the same StopHook handler the legacy
-//! Python shims forwarded to.
+//! `session-end` and `session-stop` dispatch to the whole-session teardown
+//! handler (`SessionStopHook`), alongside `session-stop-event`. They are
+//! deliberately NOT aliases for the per-turn `stop`/`agentStop` StopHook: the
+//! Signal-channel design tears the per-session group down only at genuine
+//! session end, so routing `session-end` to `stop` would either skip teardown
+//! or kill the channel mid-session. All three teardown spellings must dispatch
+//! to the same `SessionStopHook` (no copy-paste handler that could diverge).
 //!
 //! `precommit-prefs` is a no-op: it drains stdin and exits 0. It must NOT
 //! echo, log, or otherwise persist the stdin payload (security: stdin may
@@ -118,26 +122,26 @@ fn precommit_prefs_handles_empty_stdin() {
 }
 
 // ---------------------------------------------------------------------------
-// session-end / session-stop: aliases for stop
+// session-end / session-stop: whole-session teardown (SessionStopHook)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn session_end_alias_dispatches_to_stop_handler() {
-    // Replaces session_end.py which called `delegate("stop")`. The Rust
-    // dispatcher must accept `session-end` as a synonym for `stop` so any
+    // `session-end` routes to the whole-session teardown handler
+    // (SessionStopHook). It must be recognized and fail-open (exit 0) so any
     // settings.json or recipe wiring that uses the SessionEnd event keeps
-    // working without inventing a separate native handler.
+    // working.
     let payload = "{}";
     let (stdout, stderr, success) = invoke("session-end", payload);
     assert!(
         success,
-        "session-end alias must exit 0 (StopHook is fail-open); stderr: {stderr}"
+        "session-end must exit 0 (SessionStopHook is fail-open); stderr: {stderr}"
     );
     assert!(
         !stderr.contains("unknown subcommand"),
-        "session-end must be a recognized alias; stderr: {stderr}"
+        "session-end must be a recognized subcommand; stderr: {stderr}"
     );
-    // Output must be valid JSON — same contract as direct `stop` invocation.
+    // Output must be valid JSON.
     let stdout_json = if stdout.trim().is_empty() {
         "{}"
     } else {
@@ -149,7 +153,8 @@ fn session_end_alias_dispatches_to_stop_handler() {
 
 #[test]
 fn session_stop_alias_dispatches_to_stop_handler() {
-    // Replaces session_stop.py. Same alias-to-stop semantics as session-end.
+    // `session-stop` routes to the SessionStopHook teardown handler, same as
+    // `session-end` and `session-stop-event`.
     let payload = "{}";
     let (stdout, stderr, success) = invoke("session-stop", payload);
     assert!(success, "session-stop alias must exit 0; stderr: {stderr}");
@@ -168,40 +173,48 @@ fn session_stop_alias_dispatches_to_stop_handler() {
 
 #[test]
 fn session_aliases_match_direct_stop_behavior() {
-    // The aliases must dispatch to the EXACT same handler as `stop` (not a
-    // copy-paste handler that could diverge — see security_considerations).
-    // Equality check: both produce the same JSON shape for the same input.
+    // The teardown spellings (`session-end`, `session-stop`) must dispatch to
+    // the EXACT same handler as the canonical `session-stop-event`
+    // (SessionStopHook) — not a copy-paste handler that could diverge, and
+    // NOT the per-turn `stop`/`agentStop` StopHook. Equality check: each alias
+    // produces the same top-level JSON shape as `session-stop-event` for the
+    // same input.
     let payload = "{}";
-    let (stop_out, _, stop_ok) = invoke("stop", payload);
-    let (alias_out, _, alias_ok) = invoke("session-end", payload);
-    assert_eq!(stop_ok, alias_ok, "alias must mirror stop's exit status");
+    let (canonical_out, _, canonical_ok) = invoke("session-stop-event", payload);
+    let canonical_src = if canonical_out.trim().is_empty() {
+        "{}"
+    } else {
+        canonical_out.as_str()
+    };
+    let canonical_json: serde_json::Value =
+        serde_json::from_str(canonical_src).expect("session-stop-event stdout must be JSON");
+    let canonical_keys = canonical_json
+        .as_object()
+        .map(|o| o.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
 
-    // Both should produce valid JSON. We don't assert byte-for-byte equality
-    // because StopHook may include nondeterministic fields (timestamps,
-    // session ids), but the top-level keys must match.
-    let stop_json_src = if stop_out.trim().is_empty() {
-        "{}"
-    } else {
-        stop_out.as_str()
-    };
-    let alias_json_src = if alias_out.trim().is_empty() {
-        "{}"
-    } else {
-        alias_out.as_str()
-    };
-    let stop_json: serde_json::Value =
-        serde_json::from_str(stop_json_src).expect("stop stdout must be JSON");
-    let alias_json: serde_json::Value =
-        serde_json::from_str(alias_json_src).expect("session-end stdout must be JSON");
-    assert_eq!(
-        stop_json
+    for alias in ["session-end", "session-stop"] {
+        let (alias_out, _, alias_ok) = invoke(alias, payload);
+        assert_eq!(
+            canonical_ok, alias_ok,
+            "{alias} must mirror session-stop-event's exit status"
+        );
+        // Top-level keys must match; values may carry nondeterministic fields
+        // (timestamps, session ids) so byte-for-byte equality is not asserted.
+        let alias_src = if alias_out.trim().is_empty() {
+            "{}"
+        } else {
+            alias_out.as_str()
+        };
+        let alias_json: serde_json::Value =
+            serde_json::from_str(alias_src).expect("alias stdout must be JSON");
+        let alias_keys = alias_json
             .as_object()
             .map(|o| o.keys().cloned().collect::<Vec<_>>())
-            .unwrap_or_default(),
-        alias_json
-            .as_object()
-            .map(|o| o.keys().cloned().collect::<Vec<_>>())
-            .unwrap_or_default(),
-        "session-end must produce the same JSON shape as direct stop invocation"
-    );
+            .unwrap_or_default();
+        assert_eq!(
+            canonical_keys, alias_keys,
+            "{alias} must produce the same JSON shape as session-stop-event (shared SessionStopHook)"
+        );
+    }
 }


### PR DESCRIPTION
Closes #1002

Completes the Signal channel so a Copilot CLI / Claude Code session is mirrored to a **private, per-session Signal group**, with operator replies injected back as CLI input.

## What & why (R1–R5)

- **R1 — Onboarding UX.** When Signal isn't configured on an interactive host, a one-time, non-blocking stderr notice invites the user to link `signal-cli` and mirror the session (suppressible / declinable). No prompt when non-interactive or already declined.
- **R2 — Per-session whole-session context + inbound injection.** Operator messages from the Signal group are drained into the agent as advisory `additionalContext` (data, never commands). Output is **host-aware**: Copilot needs a **top-level** `additionalContext` string (it ignores Claude's nested `hookSpecificOutput`). The reshape is applied **only when the channel is actually configured** (`is_channel_configured()`), so the default build and the **golden contract keep the historical nested shape byte-for-byte**.
- **R3 — Offline testing.** `FakeSignalEndpoint` — a loopback signal-cli JSON-RPC fake (`updateGroup`/`send`/`quitGroup` + inbound enqueue) binding `127.0.0.1:0` — enables hermetic integration tests with zero real Signal I/O.
- **R4 — Full conversation mirroring.** User prompts and each turn's final assistant message are relayed to the group (bounded/truncated to a byte cap). Per-session outbound **fingerprints** let the subscriber suppress the synced-back echo.
- **R5 — Installer + teardown routing.** Registers a Copilot `sessionEnd` wrapper mapped to the session-stop event. Teardown (leave group + stop subscriber) runs **once at genuine session end** (`SessionStop`), not per assistant turn (`Stop`) — fixes the "group dies after turn 1" bug.

## Notable fixes
- Gate host-aware shaping on `is_channel_configured()` — resolves a golden-test failure/deadlock where the ambient `AMPLIHACK_AGENT_BINARY=copilot` flipped `/dev`-workflow output to the top-level shape under `--features signal`.
- Add `hook_event_name` for `SessionStart`/`PreCompact` to support Copilot's event-injection dispatch.
- Clippy `-D warnings` clean across `amplihack-signal`, `amplihack-hooks`, `amplihack-cli` with `--all-targets --features signal` (incl. collapsing a nested `if let` into a let-chain).

## Testing
- `amplihack-signal` (signal): **69** passed
- `amplihack-hooks` (signal): **437** lib + **18** golden + **26** integration (dispatch 3, host-aware 8, onboarding 7, outbound 8)
- `amplihack-hooks` (default, no signal): **426** lib + **18** golden
- `amplihack-cli` copilot: **101+** incl. session-end installer tests
- `cargo clippy --all-targets --features signal -- -D warnings`: clean
- `cargo build --release -p amplihack-hooks-bin --features signal`: ok

## Merge-ready evidence

- Rebased onto current `origin/main` and force-pushed; latest head: `c0513bef` (after `origin/main` `09133270`).
- Crusty review loop findings fixed: outbound Signal redaction before relay; bounded/atomically-trimmed echo fingerprint log; established subscriber reconnect retries indefinitely with capped backoff; configurable/observable inbox overflow; state/fingerprint/send/teardown failures are logged or propagated; session-end alias now routes to `SessionStopHook` teardown. No remaining substantive findings after final review.
- Quality audit: 3 SEEK→VALIDATE→FIX cycles completed; final cycle clean for security, bidirectional mirroring, host-aware injection, no silent degradation, resource governance, secret redaction, and offline-test determinism.
- Docs updated: `docs/signal-channel.md` and `docs/SIGNAL_ONBOARDING.md` reflect top-level-only groups, tmux naming, host-aware context, teardown, redaction, inbox capacity, and reconnect behavior.
- Local validation after latest rebase: targeted Signal hook integration tests; `cargo test -p amplihack-signal --features signal`; `cargo test --test hook_aliases session_end`; `cargo clippy --all-targets -- -D warnings`; `cargo clippy --all-targets --features signal -- -D warnings`; `pre-commit run --files` on changed files.
- Required CI on latest head is being re-run after the final force-push; final status will be checked before declaring ready. Latest follow-up also includes pre-commit/clippy redaction allocation fix and an Authorization/API-key/URL-userinfo outbound redaction bypass fix, and tmux collision fix.



