### PR TITLE
security(signal-setup): follow-up hardening from PR #993 review (S1/S2/C1)

### DIFF
--- a/amplifier-bundle/skills/signal-setup/SECURITY.md
+++ b/amplifier-bundle/skills/signal-setup/SECURITY.md
@@ -126,10 +126,14 @@ secrets and written under a hardened regime:
 - **Trap-based cleanup.** A `trap cleanup_secrets EXIT INT TERM` guarantees the
   URI file is removed on any exit path — normal completion, `Ctrl-C`, or
   termination. The `sgnl://` link secret (`URI_FILE`) is **always** purged. The
-  `-vv` trace log and the local daemon log — which hold identity material but
-  **not** the link secret — are purged on **success** and deliberately
+  `-vv` trace log and the local daemon-launch log — which hold identity material
+  but **not** the link secret — are purged on **success** and deliberately
   **retained (still `0600`) on failure**, with their paths printed, so a
-  hard-to-reproduce link failure inside the ~60s window stays debuggable. For
+  hard-to-reproduce link failure inside the ~60s window stays debuggable. The
+  local daemon itself runs under a transient `systemd-run` unit, so its own
+  runtime output is journald-captured under `$DAEMON_UNIT` (the failure path
+  prints the `journalctl -u` command); `DAEMON_LOG` holds only the launcher
+  message. For
   remote hosts, cleanup also removes the URI (always) and the trace (on success)
   on the VM via `run-command`.
 - **Unlink-after-render.** The URI copy is deleted **immediately after the QR is

--- a/amplifier-bundle/skills/signal-setup/SECURITY.md
+++ b/amplifier-bundle/skills/signal-setup/SECURITY.md
@@ -37,7 +37,7 @@ injection** — not authentication or web auth.
 | # | Threat | Vector | Severity | Mitigation (this script) |
 |---|--------|--------|----------|--------------------------|
 | T1 | Command / argument injection | Malicious `--host`, `--resource-group`, `--group`, `--phone` flowing into shell command lines, the root-executed `az run-command` payload, or JSON-RPC strings | **High** | Strict allowlist validation (fail closed) — §3 |
-| T2 | Link-secret disclosure via predictable `/tmp` | Another local user reads or pre-creates `/tmp/slink-*` / `/tmp/scli-*` | **Medium** | Unguessable per-run path, `0600` via `systemd-run --property=UMask=0077`, unlink-after-render — §4 |
+| T2 | Link-secret disclosure via predictable `/tmp` | Another local user reads or pre-creates `/tmp/slink-*` / `/tmp/scli-*` | **Medium** | 128-bit CSPRNG per-run path, `0600` via `systemd-run --property=UMask=0077`, unlink-after-render — §4 |
 | T3 | Root `rm -f` on an attacker-planted symlink | Cleanup deletes/overwrites a file a symlink points at | **Medium** | Unguessable per-run paths so the target name can't be pre-created — §4 |
 | T4 | JSON / argument injection into the daemon | `--phone` / `--group` / `groupId` embedded raw into a JSON-RPC request | **Medium** | `json_escape()` on every interpolated value — §5 |
 | T5 | Unauthenticated daemon reachable off-box | Daemon bound to `0.0.0.0` | **Low** | Bound to `127.0.0.1` only; never `0.0.0.0` — §6. `SIGNAL_SETUP_DAEMON_TCP` is loopback-allowlist validated (fail-closed) |
@@ -59,6 +59,9 @@ downstream command, `az` payload, or JSON-RPC request is built.
 | `--resource-group` | `^[A-Za-z0-9._()-]+$` | Azure resource-group naming charset (allows `()`). Flows into `az vm run-command -g`. |
 | `--group` | `^[A-Za-z0-9._ -]+$` | Self-group display name. Printable, spaces allowed, but no shell/JSON metacharacters. |
 | `--phone` | `^\+[1-9][0-9]{7,14}$` | Strict E.164. Validated only when provided. Flows into `signal-cli -a`, daemon args, and JSON-RPC. |
+| `SIGNAL_SETUP_DAEMON_TCP` | loopback host + `^[1-9][0-9]{0,4}$` port (≤65535) | Loopback-only allowlist; the port flows into `daemon --tcp`, `/dev/tcp` probes, and `nc`. See §6. |
+| `SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS` | `^[1-9][0-9]{0,3}$` | Positive integer only. Interpolated unquoted into the root-executed remote payload (`seq 1 …`); numeric allowlist closes the self-injection path. |
+| `SIGNAL_SETUP_RPC_TIMEOUT_SECONDS` | `^[1-9][0-9]{0,3}$` | Positive integer only. Interpolated unquoted into the root-executed remote payload (`timeout … nc`); numeric allowlist closes the self-injection path. |
 
 Examples that are **rejected** (fail closed, non-zero exit, no side effects):
 
@@ -107,18 +110,19 @@ secrets and written under a hardened regime:
     the process-level `umask 077` alone cannot reach files written inside the
     unit.
 - **Unguessable, per-run paths.** File names embed a per-invocation
-  `RUN_TOKEN` composed of the epoch seconds, the PID, and two `$RANDOM`
-  draws:
+  `RUN_TOKEN`. It is drawn from `/dev/urandom` as 32 hex characters (**128 bits**
+  of entropy), falling back to an `<epoch>-<pid>-<RANDOM><RANDOM><RANDOM>`
+  composite only if `/dev/urandom` is unreadable:
 
   ```text
-  RUN_TOKEN = "<epoch>-<pid>-<RANDOM><RANDOM>"
+  RUN_TOKEN = "<32 hex chars from /dev/urandom>"   # fallback: "<epoch>-<pid>-<RANDOM>..."
   URI_FILE  = /tmp/slink-<host>-<RUN_TOKEN>.out
   LOG_FILE  = /tmp/scli-<host>-<RUN_TOKEN>.log
   ```
 
-  Because the suffix cannot be predicted, another local user cannot
-  **pre-create** the path as a symlink (defeating the classic `/tmp` symlink
-  attack, T3) nor **poll** a known path to read the secret (T2).
+  Because the suffix cannot be predicted (128-bit CSPRNG space), another local
+  user cannot **pre-create** the path as a symlink (defeating the classic
+  `/tmp` symlink attack, T3) nor **poll** a known path to read the secret (T2).
 - **Trap-based cleanup.** A `trap cleanup_secrets EXIT INT TERM` guarantees the
   URI file is removed on any exit path — normal completion, `Ctrl-C`, or
   termination. The `sgnl://` link secret (`URI_FILE`) is **always** purged. The

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -154,6 +154,12 @@ esac
 validate "SIGNAL_SETUP_DAEMON_TCP port" "$DAEMON_TCP_PORT" '^[1-9][0-9]{0,4}$'
 [ "$DAEMON_TCP_PORT" -le 65535 ] \
   || die "SIGNAL_SETUP_DAEMON_TCP port out of range (1-65535): $DAEMON_TCP_PORT"
+# Numeric loop/timeout tunables: these flow UNQUOTED into the root-executed
+# remote payload (`seq 1 $DAEMON_WAIT_ATTEMPTS`, `timeout $RPC_TIMEOUT_SECONDS`),
+# so constrain them to a bare positive integer for parity with the port rule
+# and to close the self-injection path (SECURITY.md T4/§5, defense-in-depth).
+validate "SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS" "$DAEMON_WAIT_ATTEMPTS" '^[1-9][0-9]{0,3}$'
+validate "SIGNAL_SETUP_RPC_TIMEOUT_SECONDS" "$RPC_TIMEOUT_SECONDS" '^[1-9][0-9]{0,3}$'
 # Auto-detect mode if not forced.
 if [ -z "$MODE" ]; then
   if [ "$HOST" = "local" ] || [ "$HOST" = "localhost" ] || [ "$HOST" = "$(hostname)" ]; then
@@ -167,7 +173,12 @@ UNIT="sig-link-$HOST"
 DAEMON_UNIT="sig-daemon-$HOST"
 # Secret paths use an unguessable per-run token; systemd units pin UMask=0077.
 umask 077
-RUN_TOKEN="${EPOCHSECONDS}-$$-${RANDOM}${RANDOM}"
+# Prefer a 128-bit CSPRNG token from /dev/urandom so the /tmp path is not merely
+# hard-to-guess but computationally infeasible to pre-create (defeats the classic
+# symlink pre-plant on BOTH the local and remote paths — SECURITY.md T2). Falls
+# back to the epoch/PID/$RANDOM composite only if /dev/urandom is unreadable.
+RUN_TOKEN="$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom 2>/dev/null | head -c 32)"
+[ "${#RUN_TOKEN}" -ge 32 ] || RUN_TOKEN="${EPOCHSECONDS}-$$-${RANDOM}${RANDOM}${RANDOM}"
 URI_FILE="/tmp/slink-${HOST}-${RUN_TOKEN}.out"
 LOG_FILE="/tmp/scli-${HOST}-${RUN_TOKEN}.log"
 DAEMON_LOG="/tmp/signal-daemon-${HOST}-${RUN_TOKEN}.log"
@@ -380,6 +391,7 @@ daemon_up() { (exec 3<>/dev/tcp/$DAEMON_TCP_HOST/$DAEMON_TCP_PORT) 2>/dev/null; 
 if ! daemon_up; then
   systemctl reset-failed $DAEMON_UNIT 2>/dev/null
   systemd-run --unit=$DAEMON_UNIT --uid=azureuser --gid=azureuser \
+    --property=UMask=0077 \
     --setenv=HOME=/home/azureuser \
     --setenv=PATH=/home/azureuser/.local/bin:/usr/bin:/bin \
     $sigcli -a '$acct_j' daemon --tcp $DAEMON_TCP_HOST:$DAEMON_TCP_PORT >/dev/null 2>&1
@@ -410,7 +422,23 @@ REMOTE
 local_daemon_group_posttest() {
   local sigcli="$1"
   if ! daemon_up; then
-    "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >"$DAEMON_LOG" 2>&1 &
+    # Parity with the remote daemon path: supervise the daemon under a transient
+    # systemd unit (reset-failed + UMask=0077) instead of a bare `&` background
+    # job, so the local and remote paths get identical lifecycle handling and
+    # owner-only isolation for any state the daemon writes. systemd-run's own
+    # launch output is captured to DAEMON_LOG for the failure diagnostic below;
+    # the daemon's runtime output goes to journald under $DAEMON_UNIT.
+    systemctl --user reset-failed "$DAEMON_UNIT" 2>/dev/null
+    sudo systemctl reset-failed "$DAEMON_UNIT" 2>/dev/null
+    # SC2024: the redirect is intentionally the caller's, not root's — DAEMON_LOG
+    # captures systemd-run's launch message as an owner-only (umask 077) file;
+    # the daemon's own runtime output is journald-captured under $DAEMON_UNIT.
+    # shellcheck disable=SC2024
+    sudo systemd-run --unit="$DAEMON_UNIT" --uid="$(id -u)" --gid="$(id -g)" \
+      --property=UMask=0077 \
+      --setenv=HOME="$HOME" \
+      --setenv=PATH="$HOME/.local/bin:/usr/bin:/bin" \
+      "$sigcli" -a "$PHONE" daemon --tcp "$DAEMON_TCP" >"$DAEMON_LOG" 2>&1
     local _i
     for ((_i = 1; _i <= DAEMON_WAIT_ATTEMPTS; _i++)); do
       daemon_up && break

--- a/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
+++ b/amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh
@@ -428,7 +428,6 @@ local_daemon_group_posttest() {
     # owner-only isolation for any state the daemon writes. systemd-run's own
     # launch output is captured to DAEMON_LOG for the failure diagnostic below;
     # the daemon's runtime output goes to journald under $DAEMON_UNIT.
-    systemctl --user reset-failed "$DAEMON_UNIT" 2>/dev/null
     sudo systemctl reset-failed "$DAEMON_UNIT" 2>/dev/null
     # SC2024: the redirect is intentionally the caller's, not root's — DAEMON_LOG
     # captures systemd-run's launch message as an owner-only (umask 077) file;
@@ -448,8 +447,13 @@ local_daemon_group_posttest() {
   daemon_up \
     || { warn "  Daemon did not come up on $DAEMON_TCP.";
          if [ -s "$DAEMON_LOG" ]; then
-           warn "  Last daemon-log lines ($DAEMON_LOG):"; tail -n 20 "$DAEMON_LOG" >&2
+           warn "  systemd-run launch log ($DAEMON_LOG):"; tail -n 20 "$DAEMON_LOG" >&2
          fi
+         # The daemon runs under a transient systemd unit, so its own runtime
+         # output is journald-captured (not in DAEMON_LOG). Point the operator at
+         # it so a link/daemon failure inside the ~60s window stays debuggable.
+         warn "  Daemon runtime output is journald-captured; inspect with:";
+         warn "    sudo journalctl -u $DAEMON_UNIT -n 50 --no-pager";
          return 1; }
   ok "  Daemon reachable on $DAEMON_TCP"
   command -v nc >/dev/null 2>&1 || { warn "  'nc' not available; cannot run JSON-RPC self-group post-test."; return 1; }

--- a/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
@@ -186,6 +186,8 @@ run_ss() {
     MOCK_LINK_AFTER_MINT_FILE="$SANDBOX/linked-after-mint" \
     SIGNAL_SETUP_TEST_DAEMON_UP="${SIGNAL_SETUP_TEST_DAEMON_UP:-}" \
     SIGNAL_SETUP_DAEMON_TCP="${SIGNAL_SETUP_DAEMON_TCP:-}" \
+    SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS="${SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS:-}" \
+    SIGNAL_SETUP_RPC_TIMEOUT_SECONDS="${SIGNAL_SETUP_RPC_TIMEOUT_SECONDS:-}" \
     /bin/bash "$IMPL" "$@" 2>&1)"
   RC=$?
 }
@@ -382,6 +384,49 @@ if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "already linked"; then
   pass "valid loopback endpoint (localhost:7600) accepted"
 else
   fail "a valid loopback daemon endpoint must be accepted (rc=$RC): $OUT"
+fi
+
+# ─── Test 4c: numeric env tunables fail closed on non-integer values ────────
+# DAEMON_WAIT_ATTEMPTS / RPC_TIMEOUT_SECONDS are interpolated UNQUOTED into the
+# root-executed remote payload (`seq 1 $DAEMON_WAIT_ATTEMPTS`, `timeout
+# $RPC_TIMEOUT_SECONDS nc`). A non-numeric value is an injection vector into that
+# payload, so validation must reject it before any mint/daemon side effect.
+echo ""
+echo "Test 4c: numeric env tunables fail closed (self-injection guard)"
+
+reset_logs
+SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS='5; reboot' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then
+  pass "non-numeric SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS rejected"
+else
+  fail "non-numeric DAEMON_WAIT_ATTEMPTS must be rejected (rc=$RC): $OUT"
+fi
+if [[ ! -s "$QR_LOG" ]]; then
+  pass "no QR rendered for a rejected wait-attempts value"
+else
+  fail "a rejected wait-attempts value must not reach QR rendering"
+fi
+
+reset_logs
+SIGNAL_SETUP_RPC_TIMEOUT_SECONDS='$(touch /tmp/pwn)' MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then
+  pass "non-numeric SIGNAL_SETUP_RPC_TIMEOUT_SECONDS rejected"
+else
+  fail "non-numeric RPC_TIMEOUT_SECONDS must be rejected (rc=$RC): $OUT"
+fi
+
+# POSITIVE: valid integer tunables pass validation (paired with already-linked
+# + --no-daemon so we exit cleanly, proving acceptance not a skipped step).
+reset_logs
+SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS='30' SIGNAL_SETUP_RPC_TIMEOUT_SECONDS='20' \
+  MOCK_LINKED_NUMBER="+15551234567" \
+  run_ss --host local --phone +15551234567 --no-daemon -y
+if [[ "$RC" -eq 0 ]] && echo "$OUT" | grep -qi "already linked"; then
+  pass "valid integer env tunables accepted"
+else
+  fail "valid integer env tunables must be accepted (rc=$RC): $OUT"
 fi
 
 # ─── Test 5: valid inputs pass validation (reach prereqs/idempotency) ───────

--- a/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_script_behavior.sh
@@ -409,6 +409,7 @@ else
 fi
 
 reset_logs
+# shellcheck disable=SC2016  # literal $(...) is the injection payload under test — must NOT expand
 SIGNAL_SETUP_RPC_TIMEOUT_SECONDS='$(touch /tmp/pwn)' MOCK_LINKED_NUMBER="+15551234567" \
   run_ss --host local --phone +15551234567 --no-daemon -y
 if [[ "$RC" -ne 0 ]] && echo "$OUT" | grep -qi "invalid"; then


### PR DESCRIPTION
Follow-up to merged #993. Implements the three highest-value non-blocking suggestions from the Step-16 Code/Security/Philosophy reviews.

## Changes
| Item | Finding | Fix |
|------|---------|-----|
| **S1** (Security, LOW) | Predictable `/tmp` paths rest on token unpredictability (~epoch+PID+2×$RANDOM) | `RUN_TOKEN` now a **128-bit CSPRNG** value (32 hex from `/dev/urandom`), fallback to old composite if unreadable. Structurally defeats the symlink pre-plant class (T2/T3), local + remote. |
| **S2** (Security, LOW) | `DAEMON_WAIT_ATTEMPTS`/`RPC_TIMEOUT_SECONDS` interpolated **unquoted** into the root remote payload without a numeric allowlist | Added `validate … '^[1-9][0-9]{0,3}$'` for both, matching the existing port validation. Closes the self-injection parity gap. |
| **C1** (Code, minor) | Local daemon used a bare `&` while remote used `systemd-run --unit=$DAEMON_UNIT`; `DAEMON_UNIT` unused locally | Local daemon now supervised under a transient systemd unit (reset-failed + `UMask=0077`) via `$DAEMON_UNIT`; added `UMask=0077` to the remote daemon unit too for full parity. |

Not addressed (documented as lower priority in the Step-18a analysis): C2 (verify budget tuning) and C3 (idempotency parse test) — logged for a later touch; neither is a defect.

## Docs
SECURITY.md T2 row, the per-run-path section, and the input-validation table updated to match.

## Verification
- Full suite: **103 assertions pass / 0 fail** (was 99; +4 covering S2 reject + accept paths)
- `shellcheck -S warning` clean; `bash -n` OK
- Local-daemon launch block is skipped in tests via `SIGNAL_SETUP_TEST_DAEMON_UP=1`, so C1 changes no tested behavior; UMask-count structure test still passes (≥2)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

## Final Verification Evidence (Step 20)

### CI Checks — all required green (mergeState=`CLEAN`)
| Check | Result |
|-------|--------|
| Lint & Format | ✅ pass |
| Test (`cargo nextest` + doctests) | ✅ pass |
| Build x86_64-unknown-linux-gnu | ✅ pass |
| Build aarch64-unknown-linux-gnu | ✅ pass |
| Build x86_64-apple-darwin | ✅ pass |
| Build aarch64-apple-darwin | ✅ pass |
| Install Smoke Test | ✅ pass |
| GitGuardian Security Checks | ✅ pass |
| scan / Release | ⏭️ conditionally skipped (not required) |

### Outside-in / bundled TDD evidence
`tests/run_all_tests.sh` (hermetic, mocked signal-cli / az / qrencode): **103 assertions pass, 0 fail**. Covers idempotency (local + remote), QR mint/verify paths, prerequisite aborts, multi-account guards, and the +4 new S2 numeric-allowlist reject/accept assertions. No harness blockers.

### Static guards (repo policy gates) — all pass
- `check-skills-no-missing-helpers.sh` ✅
- `check-no-python-assets.sh` ✅
- `check-toolchain-refs.sh` ✅
- `shellcheck -S warning scripts/signal-setup.sh` ✅ · `bash -n` ✅

### Quality-audit cycles
3 consecutive SEEK→VALIDATE→FIX cycles produced zero substantive findings; only the pre-documented lower-priority items C2/C3 remain (logged, not defects).

### Diff scope (rebased on current `origin/main`, 1 commit ahead)
```
SECURITY.md                          | 18 +++++----
scripts/signal-setup.sh              | 32 +++++++++++++-
tests/test_script_behavior.sh        | 45 ++++++++++++++++++
3 files changed, 86 insertions(+), 9 deletions(-)
```

**Status: READY_TO_MERGE** — not merged per instructions.
