### PR TITLE
chore(tools): remove dead sanitize_gh_stderr helpers

### DIFF
--- a/amplifier-bundle/tools/workflow_final_status.sh
+++ b/amplifier-bundle/tools/workflow_final_status.sh
@@ -34,10 +34,6 @@ GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}
 # shellcheck source=/dev/null
 . "$GH_RETRY_HELPER"
 
-sanitize_gh_stderr() {
-  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
-}
-
 # Best-effort final PR status read. This is a display-only read that the caller
 # already tolerates failing (`|| true`); it must NOT stall the workflow's final
 # reporting step waiting on a rate-limit reset (which can be up to an hour out).

--- a/amplifier-bundle/tools/workflow_pr_ready.sh
+++ b/amplifier-bundle/tools/workflow_pr_ready.sh
@@ -22,10 +22,6 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 127
 fi
 
-sanitize_gh_stderr() {
-  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
-}
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}"
 if [ ! -f "$GH_RETRY_HELPER" ]; then

--- a/amplifier-bundle/tools/workflow_pr_scope.sh
+++ b/amplifier-bundle/tools/workflow_pr_scope.sh
@@ -78,10 +78,6 @@ emit_failure() {
   exit 1
 }
 
-sanitize_gh_stderr() {
-  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | awk '{print substr($0, 1, 500)}'
-}
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GH_RETRY_HELPER="${WORKFLOW_GH_RETRY_HELPER:-${SCRIPT_DIR}/workflow_gh_retry.sh}"
 if [ ! -f "$GH_RETRY_HELPER" ]; then

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -131,10 +131,6 @@ parse_github_repo_identity() {
   printf '%s/%s\n' "$owner" "$repo"
 }
 
-sanitize_gh_stderr() {
-  sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | head -c 500
-}
-
 # Rate-limit-aware retry wrappers. Retry logic is centralised in the shared
 # workflow_gh_retry.sh driver: a genuine rate limit waits for the authoritative
 # reset (adaptive, bounded by the reset window) instead of burning three

--- a/tests/integration/workflow_finalize_resilience.rs
+++ b/tests/integration/workflow_finalize_resilience.rs
@@ -134,7 +134,6 @@ fn final_status_uses_resilient_github_status_lookup() {
     let command = helper_text("workflow_final_status.sh");
 
     for required in [
-        "sanitize_gh_stderr",
         "workflow_gh_retry.sh",
         "_gh_retry_core",
         "gh_pr_view_with_retry",
@@ -152,7 +151,6 @@ fn pr_ready_helper_retries_github_lookup_ready_and_comment_calls() {
     let command = helper_text("workflow_pr_ready.sh");
 
     for required in [
-        "sanitize_gh_stderr",
         "workflow_gh_retry.sh",
         "_gh_retry_core",
         "gh_with_retry",

--- a/tests/integration/workflow_publish_resilience.rs
+++ b/tests/integration/workflow_publish_resilience.rs
@@ -165,7 +165,6 @@ fn publish_retries_all_github_pr_metadata_and_mutation_calls() {
     let command = helper_text("workflow_publish_pr.sh");
 
     for required in [
-        "sanitize_gh_stderr",
         "workflow_gh_retry.sh",
         "_gh_retry_core",
         "classify_gh_error",


### PR DESCRIPTION
## Summary
Follow-up cleanup from the review of #1003. Removes four dead
`sanitize_gh_stderr()` functions from the workflow helper scripts — each had
**zero call sites** after retry logic was centralised in `workflow_gh_retry.sh`.

The live redaction path is the shared driver's `gh_sanitize_stderr` (full
URL-credential + token redaction), reached via the `gh_*_with_retry` wrappers.
The dead functions did weaker **URL-only** redaction, a false-assurance risk if
a future maintainer wired one up (flagged as a Zero-BS / ruthless-simplicity
violation in the review).

## Changed files
- `amplifier-bundle/tools/workflow_pr_scope.sh` — delete dead function
- `amplifier-bundle/tools/workflow_final_status.sh` — delete dead function
- `amplifier-bundle/tools/workflow_pr_ready.sh` — delete dead function
- `amplifier-bundle/tools/workflow_publish_pr.sh` — delete dead function
- `tests/integration/workflow_publish_resilience.rs` — drop stale assertion
- `tests/integration/workflow_finalize_resilience.rs` — drop stale assertions (x2)

## Not touched (intentional)
- `workflow_gh_retry.sh` — the live `gh_sanitize_stderr` driver (5 call sites)
- `amplifier-bundle/recipes/workflow-terminal-state.yaml` — its inline
  `sanitize_gh_stderr` has **real call sites** and stays, along with its
  matching assertion in `default_workflow_terminal_state.rs`.

## Validation
- `shellcheck` clean on all 5 tool scripts (no new warnings; pre-existing
  SC2016 info count unchanged at 3)
- `bash -n` syntax OK on all scripts
- `cargo test` on the affected suites: **9 + 27 + terminal-state probe all pass**
- pre-commit (fmt, clippy `-D warnings`) passed

Pure deletion of unreachable code + stale test assertions. No behavior change;
the resilience tests still assert the sourced driver (`workflow_gh_retry.sh` /
`_gh_retry_core`) that provides the real sanitization.