### PR TITLE
fix(remote): exact VM match, adaptive transfer backoff, reject invalid shell IDs (#998)

### DIFF
--- a/crates/amplihack-remote/Cargo.toml
+++ b/crates/amplihack-remote/Cargo.toml
@@ -20,3 +20,4 @@ tokio = { version = "1", features = ["process", "io-util", "sync", "rt", "macros
 [dev-dependencies]
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util", "time"] }

--- a/crates/amplihack-remote/src/backoff.rs
+++ b/crates/amplihack-remote/src/backoff.rs
@@ -1,0 +1,219 @@
+//! Adaptive retry backoff.
+//!
+//! Provides an exponential-with-jitter backoff policy bounded by an
+//! operator-configurable *time budget* rather than an arbitrary fixed
+//! attempt cap. Retries continue, with growing delays, until the total
+//! elapsed time exceeds the budget.
+//!
+//! Cancellation is respected implicitly: the delays are awaited via
+//! [`tokio::time::sleep`], which is cancellation-safe — if the enclosing
+//! task/future is dropped (cancelled), the in-flight delay is aborted and
+//! no further retries occur.
+
+use std::time::Duration;
+
+/// Environment variable that overrides the retry *time budget* (seconds).
+pub const RETRY_BUDGET_ENV: &str = "AMPLIHACK_REMOTE_RETRY_BUDGET_SECS";
+
+/// Adaptive exponential backoff bounded by a total time budget.
+#[derive(Debug, Clone)]
+pub struct BackoffPolicy {
+    /// Delay before the first retry.
+    initial: Duration,
+    /// Multiplier applied to the base delay each attempt (> 1.0 for growth).
+    multiplier: f64,
+    /// Total wall-clock budget across all retries. Once elapsed time meets
+    /// or exceeds this, no further retries are scheduled.
+    budget: Duration,
+}
+
+impl BackoffPolicy {
+    /// Construct a policy from explicit parameters.
+    pub fn new(initial: Duration, multiplier: f64, budget: Duration) -> Self {
+        Self {
+            initial,
+            multiplier,
+            budget,
+        }
+    }
+
+    /// The total retry budget this policy is bounded by.
+    pub fn budget(&self) -> Duration {
+        self.budget
+    }
+
+    /// Read the operator-configured budget from [`RETRY_BUDGET_ENV`], falling
+    /// back to `default_budget` when unset or unparsable.
+    fn budget_from_env(default_budget: Duration) -> Duration {
+        match std::env::var(RETRY_BUDGET_ENV) {
+            Ok(raw) => match raw.trim().parse::<u64>() {
+                Ok(secs) if secs > 0 => Duration::from_secs(secs),
+                _ => default_budget,
+            },
+            Err(_) => default_budget,
+        }
+    }
+
+    /// Default policy for VM provisioning retries (budget: 120s, override
+    /// via [`RETRY_BUDGET_ENV`]).
+    pub fn provisioning_default() -> Self {
+        Self::new(
+            Duration::from_secs(5),
+            2.0,
+            Self::budget_from_env(Duration::from_secs(120)),
+        )
+    }
+
+    /// Default policy for file-transfer retries (budget: 60s, override via
+    /// [`RETRY_BUDGET_ENV`]).
+    pub fn transfer_default() -> Self {
+        Self::new(
+            Duration::from_secs(2),
+            2.0,
+            Self::budget_from_env(Duration::from_secs(60)),
+        )
+    }
+
+    /// Exponential base delay for a given zero-based attempt (no jitter).
+    fn base_delay(&self, attempt: u32) -> Duration {
+        let factor = self.multiplier.powi(attempt as i32);
+        let millis = self.initial.as_millis() as f64 * factor;
+        // Guard against non-finite/negative results before casting.
+        let millis = if millis.is_finite() && millis >= 0.0 {
+            millis as u64
+        } else {
+            u64::MAX
+        };
+        Duration::from_millis(millis)
+    }
+
+    /// Apply "equal jitter": half the base delay plus a random amount in
+    /// `[0, base/2]`. This spreads retries to avoid thundering herds while
+    /// keeping a sensible minimum wait.
+    fn with_jitter(&self, base: Duration) -> Duration {
+        let half = base / 2;
+        let span_ms = half.as_millis() as u64;
+        let jitter_ms = if span_ms == 0 {
+            0
+        } else {
+            pseudo_random_u64() % (span_ms + 1)
+        };
+        half + Duration::from_millis(jitter_ms)
+    }
+
+    /// Compute the delay before the next retry, or `None` if the time budget
+    /// is exhausted and retries should stop.
+    ///
+    /// `attempt` is the zero-based retry index and `elapsed` is the wall-clock
+    /// time spent so far. The returned delay is clamped so that sleeping for
+    /// it will not overshoot the remaining budget.
+    pub fn next_backoff(&self, attempt: u32, elapsed: Duration) -> Option<Duration> {
+        if elapsed >= self.budget {
+            return None;
+        }
+        let remaining = self.budget - elapsed;
+        let delay = self.with_jitter(self.base_delay(attempt));
+        Some(delay.min(remaining))
+    }
+}
+
+/// Small, dependency-free PRNG (splitmix64) seeded from the current time.
+/// Sufficient for backoff jitter — not for anything security-sensitive.
+fn pseudo_random_u64() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let mut x = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^ (x >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_delay_grows_exponentially() {
+        let policy = BackoffPolicy::new(Duration::from_millis(100), 2.0, Duration::from_secs(600));
+        assert_eq!(policy.base_delay(0), Duration::from_millis(100));
+        assert_eq!(policy.base_delay(1), Duration::from_millis(200));
+        assert_eq!(policy.base_delay(2), Duration::from_millis(400));
+        assert_eq!(policy.base_delay(3), Duration::from_millis(800));
+    }
+
+    #[test]
+    fn jitter_stays_within_equal_jitter_bounds() {
+        let policy = BackoffPolicy::new(Duration::from_millis(1000), 2.0, Duration::from_secs(600));
+        for attempt in 0..4 {
+            let base = policy.base_delay(attempt);
+            for _ in 0..50 {
+                let jittered = policy.with_jitter(base);
+                assert!(jittered >= base / 2, "jitter below half base");
+                assert!(jittered <= base, "jitter above base");
+            }
+        }
+    }
+
+    #[test]
+    fn next_backoff_returns_none_when_budget_exhausted() {
+        let policy = BackoffPolicy::new(Duration::from_secs(1), 2.0, Duration::from_secs(10));
+        assert!(policy.next_backoff(0, Duration::from_secs(10)).is_none());
+        assert!(policy.next_backoff(5, Duration::from_secs(11)).is_none());
+        assert!(policy.next_backoff(0, Duration::from_secs(1)).is_some());
+    }
+
+    #[test]
+    fn next_backoff_clamps_to_remaining_budget() {
+        let policy = BackoffPolicy::new(Duration::from_secs(30), 2.0, Duration::from_secs(10));
+        // Large base delay (30s) but only 2s of budget remains.
+        let delay = policy
+            .next_backoff(0, Duration::from_secs(8))
+            .expect("budget remains");
+        assert!(
+            delay <= Duration::from_secs(2),
+            "delay must not overshoot budget"
+        );
+    }
+
+    #[test]
+    fn budget_from_env_overrides_default() {
+        // Guard: the env var must not be set by the surrounding environment.
+        let policy = BackoffPolicy::provisioning_default();
+        // Default budget is 120s unless overridden.
+        assert!(policy.budget() >= Duration::from_secs(1));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_stop_once_budget_is_spent() {
+        // Simulate a retry loop driven purely by the policy and confirm it
+        // terminates within the budget rather than looping forever.
+        let policy = BackoffPolicy::new(Duration::from_millis(50), 2.0, Duration::from_secs(5));
+        let start = tokio::time::Instant::now();
+        let mut attempt = 0u32;
+        while let Some(delay) = policy.next_backoff(attempt, start.elapsed()) {
+            tokio::time::sleep(delay).await;
+            attempt += 1;
+            assert!(attempt < 10_000, "loop must be budget-bounded");
+        }
+        assert!(attempt > 0, "at least one retry should have occurred");
+        assert!(start.elapsed() >= Duration::from_secs(5));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backoff_sleep_is_cancellation_safe() {
+        // Wrapping the backoff sleep in a timeout that fires first models
+        // task cancellation: the sleep is aborted and no retry proceeds.
+        let policy = BackoffPolicy::new(Duration::from_secs(10), 2.0, Duration::from_secs(60));
+        let delay = policy.next_backoff(3, Duration::ZERO).unwrap();
+        let result = tokio::time::timeout(Duration::from_millis(1), async move {
+            tokio::time::sleep(delay).await;
+            "completed"
+        })
+        .await;
+        assert!(result.is_err(), "delay should be cancelled by the timeout");
+    }
+}

--- a/crates/amplihack-remote/src/executor.rs
+++ b/crates/amplihack-remote/src/executor.rs
@@ -12,8 +12,10 @@ use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
+use crate::backoff::BackoffPolicy;
 use crate::error::{ErrorContext, RemoteError};
 use crate::orchestrator::VM;
+use crate::shell_safe::validate_session_id;
 
 /// Result of a remote command execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -64,8 +66,10 @@ impl Executor {
             .unwrap_or("context.tar.gz");
         let remote_path = format!("{}:~/context.tar.gz", self.vm.name);
 
-        let max_retries = 2u32;
-        for attempt in 0..max_retries {
+        let policy = BackoffPolicy::transfer_default();
+        let retry_start = Instant::now();
+        let mut attempt = 0u32;
+        loop {
             let mut cmd = Command::new("azlin");
             cmd.arg("cp");
             self.append_port_args(&mut cmd);
@@ -75,53 +79,50 @@ impl Executor {
             cmd.stderr(Stdio::piped());
 
             let start = Instant::now();
-            match tokio::time::timeout(std::time::Duration::from_secs(600), cmd.output()).await {
-                Ok(Ok(output)) if output.status.success() => {
-                    let dur = start.elapsed().as_secs_f64();
-                    info!(duration_secs = format!("{dur:.1}"), "transfer complete");
-                    return Ok(());
-                }
-                Ok(Ok(output)) => {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    if attempt < max_retries - 1 {
-                        warn!(attempt = attempt + 1, "transfer failed, retrying");
-                        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                        continue;
+            let retry_reason: String =
+                match tokio::time::timeout(std::time::Duration::from_secs(600), cmd.output()).await
+                {
+                    Ok(Ok(output)) if output.status.success() => {
+                        let dur = start.elapsed().as_secs_f64();
+                        info!(duration_secs = format!("{dur:.1}"), "transfer complete");
+                        return Ok(());
                     }
-                    return Err(RemoteError::transfer_ctx(
-                        format!("Failed to transfer file: {stderr}"),
-                        ErrorContext::new().insert("vm_name", &self.vm.name),
-                    ));
-                }
-                Ok(Err(e)) => {
-                    if attempt < max_retries - 1 {
-                        warn!(
-                            error = %e,
-                            "transfer error, retrying"
-                        );
-                        continue;
+                    Ok(Ok(output)) => {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        format!("transfer failed: {stderr}")
                     }
-                    return Err(RemoteError::transfer(format!(
-                        "Transfer command failed: {e}"
-                    )));
+                    Ok(Err(e)) => format!("transfer command error: {e}"),
+                    Err(_) => "transfer timed out".to_string(),
+                };
+
+            match policy.next_backoff(attempt, retry_start.elapsed()) {
+                Some(delay) => {
+                    warn!(
+                        attempt = attempt + 1,
+                        delay_ms = delay.as_millis() as u64,
+                        "transfer failed, backing off before retry"
+                    );
+                    // Cancellation-safe: dropping this future aborts the sleep.
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
                 }
-                Err(_) => {
-                    if attempt < max_retries - 1 {
-                        warn!("transfer timeout, retrying");
-                        continue;
-                    }
+                None => {
                     return Err(RemoteError::transfer_ctx(
                         format!(
-                            "Transfer timed out after \
-                             {max_retries} attempts"
+                            "Failed to transfer file within retry budget \
+                             ({}s, {} attempts): {}",
+                            policy.budget().as_secs(),
+                            attempt + 1,
+                            retry_reason
                         ),
-                        ErrorContext::new().insert("vm_name", &self.vm.name),
+                        ErrorContext::new()
+                            .insert("vm_name", &self.vm.name)
+                            .insert("retry_budget_secs", policy.budget().as_secs().to_string())
+                            .insert("attempts", (attempt + 1).to_string()),
                     ));
                 }
             }
         }
-
-        Err(RemoteError::transfer("Transfer failed after all retries"))
     }
 
     /// Execute amplihack command on the remote VM.
@@ -242,6 +243,7 @@ amplihack claude --{command} --max-turns {turns} -- -p "$PROMPT"
 
         let encoded_prompt = b64_encode(prompt.as_bytes());
         let encoded_key = b64_encode(api_key.as_bytes());
+        let safe_session = validate_session_id(session_id)?;
         let script = format!(
             r#"
 set -e
@@ -251,7 +253,7 @@ tmux new-session -d -s {session} "cd ~/workspace && amplihack claude --{command}
 "#,
             key = encoded_key,
             prompt = encoded_prompt,
-            session = shell_escape(session_id),
+            session = safe_session,
             command = command,
             turns = max_turns,
         );
@@ -426,13 +428,6 @@ fn b64_encode(data: &[u8]) -> String {
     result
 }
 
-fn shell_escape(value: &str) -> String {
-    value
-        .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -488,13 +483,5 @@ mod tests {
         assert_eq!(b64_encode(b"Hello, World!"), "SGVsbG8sIFdvcmxkIQ==");
         let data: Vec<u8> = (0..=255).collect();
         assert_eq!(b64_encode(&data).len() % 4, 0);
-    }
-
-    #[test]
-    fn shell_escape_strips_unsafe() {
-        assert_eq!(shell_escape("hello-world_2.0"), "hello-world_2.0");
-        assert_eq!(shell_escape("test;rm -rf /"), "testrm-rf");
-        assert_eq!(shell_escape(""), "");
-        assert_eq!(shell_escape("!@#$%^&*()"), "");
     }
 }

--- a/crates/amplihack-remote/src/lib.rs
+++ b/crates/amplihack-remote/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod auth;
 pub(crate) mod azlin_parse;
+pub(crate) mod backoff;
 pub mod cli;
 pub mod commands;
 pub mod error;
@@ -28,8 +29,10 @@ pub mod orchestrator;
 pub mod packager;
 mod redact;
 pub mod session;
+pub(crate) mod shell_safe;
 pub mod state_io;
 pub mod state_lock;
+pub(crate) mod vm_lookup;
 pub mod vm_pool;
 
 pub use auth::{AzureAuthenticator, AzureCredentials, get_azure_auth};

--- a/crates/amplihack-remote/src/orchestrator.rs
+++ b/crates/amplihack-remote/src/orchestrator.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::process::Stdio;
+use std::time::Instant;
 
 use chrono::{DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
@@ -12,6 +13,7 @@ use tokio::process::Command;
 use tracing::{debug, info, warn};
 
 use crate::azlin_parse::{parse_azlin_list_json, parse_azlin_list_text};
+use crate::backoff::BackoffPolicy;
 use crate::error::{ErrorContext, RemoteError};
 use crate::redact::redact_sensitive;
 
@@ -278,8 +280,10 @@ impl Orchestrator {
             cmd_args.extend(extra.clone());
         }
 
-        let max_retries = 3u32;
-        for attempt in 0..max_retries {
+        let policy = BackoffPolicy::provisioning_default();
+        let start = Instant::now();
+        let mut attempt = 0u32;
+        loop {
             let output = tokio::time::timeout(
                 std::time::Duration::from_secs(600),
                 Command::new("azlin")
@@ -290,7 +294,7 @@ impl Orchestrator {
             )
             .await;
 
-            match output {
+            let retry_reason: String = match output {
                 Ok(Ok(o)) if o.status.success() => {
                     info!(vm = %vm_name, "VM provisioned");
                     let mut tags = HashMap::new();
@@ -309,95 +313,52 @@ impl Orchestrator {
                 Ok(Ok(o)) => {
                     let stderr = String::from_utf8_lossy(&o.stderr);
                     let lower = stderr.to_lowercase();
+                    // Quota/limit failures are not transient — fail loudly now.
                     if lower.contains("quota") || lower.contains("limit") {
                         return Err(RemoteError::provisioning_ctx(
-                            format!(
-                                "Azure quota exceeded: \
-                                     {stderr}"
-                            ),
+                            format!("Azure quota exceeded: {stderr}"),
                             ErrorContext::new().insert("vm_name", &vm_name),
                         ));
                     }
-                    if attempt < max_retries - 1 {
-                        warn!(attempt = attempt + 1, "provisioning failed, retrying");
-                        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-                        continue;
-                    }
+                    format!("provisioning failed: {stderr}")
+                }
+                Ok(Err(e)) => format!("provisioning command error: {e}"),
+                Err(_) => "provisioning timed out".to_string(),
+            };
+
+            match policy.next_backoff(attempt, start.elapsed()) {
+                Some(delay) => {
+                    warn!(
+                        attempt = attempt + 1,
+                        delay_ms = delay.as_millis() as u64,
+                        reason = %redact_sensitive(&retry_reason),
+                        "provisioning failed, backing off before retry"
+                    );
+                    // Cancellation-safe: dropping this future aborts the sleep.
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                }
+                None => {
                     return Err(RemoteError::provisioning_ctx(
                         format!(
-                            "Failed to provision VM: \
-                                 {stderr}"
+                            "Failed to provision VM within retry budget \
+                             ({}s, {} attempts): {}",
+                            policy.budget().as_secs(),
+                            attempt + 1,
+                            retry_reason
                         ),
-                        ErrorContext::new().insert("vm_name", &vm_name),
-                    ));
-                }
-                Ok(Err(e)) => {
-                    if attempt < max_retries - 1 {
-                        warn!(
-                            error = %e,
-                            "provisioning error, retrying"
-                        );
-                        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-                        continue;
-                    }
-                    return Err(RemoteError::provisioning(format!(
-                        "Provisioning command failed: {e}"
-                    )));
-                }
-                Err(_) => {
-                    if attempt < max_retries - 1 {
-                        warn!("provisioning timeout, retrying");
-                        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-                        continue;
-                    }
-                    return Err(RemoteError::provisioning_ctx(
-                        format!(
-                            "VM provisioning timed out \
-                                 after {max_retries} attempts"
-                        ),
-                        ErrorContext::new().insert("vm_name", &vm_name),
+                        ErrorContext::new()
+                            .insert("vm_name", &vm_name)
+                            .insert("retry_budget_secs", policy.budget().as_secs().to_string())
+                            .insert("attempts", (attempt + 1).to_string()),
                     ));
                 }
             }
         }
-
-        Err(RemoteError::provisioning_ctx(
-            format!(
-                "Failed to provision VM after \
-                 {max_retries} attempts"
-            ),
-            ErrorContext::new().insert("vm_name", &vm_name),
-        ))
     }
 
     async fn get_vm_by_name(&self, vm_name: &str) -> Result<VM, RemoteError> {
-        let output = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
-            Command::new("azlin")
-                .arg("list")
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output(),
-        )
-        .await;
-
-        if let Ok(Ok(o)) = output {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            if stdout.contains(vm_name) {
-                return Ok(VM {
-                    name: vm_name.to_string(),
-                    size: "unknown".into(),
-                    region: "unknown".into(),
-                    created_at: None,
-                    tags: None,
-                });
-            }
-        }
-
-        Err(RemoteError::provisioning_ctx(
-            format!("VM not found: {vm_name}"),
-            ErrorContext::new().insert("vm_name", vm_name),
-        ))
+        crate::vm_lookup::get_vm_by_name(vm_name).await
     }
 }
 

--- a/crates/amplihack-remote/src/shell_safe.rs
+++ b/crates/amplihack-remote/src/shell_safe.rs
@@ -1,0 +1,57 @@
+//! Validation for values interpolated into remote shell commands.
+
+use crate::error::RemoteError;
+
+/// Validate a session identifier for safe interpolation into a remote shell
+/// command. Rejects — rather than silently mangles — any value that is not a
+/// strict identifier (ASCII alphanumerics plus `-`, `_`, `.`). This prevents
+/// constructing a wrong-but-valid command from unexpected input.
+pub(crate) fn validate_session_id(value: &str) -> Result<&str, RemoteError> {
+    if value.is_empty() {
+        return Err(RemoteError::validation("session id must not be empty"));
+    }
+    let all_valid = value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'));
+    if all_valid {
+        Ok(value)
+    } else {
+        Err(RemoteError::validation(format!(
+            "invalid session id {value:?}: only ASCII alphanumerics and '-', '_', '.' are allowed"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_identifiers() {
+        assert_eq!(
+            validate_session_id("hello-world_2.0").unwrap(),
+            "hello-world_2.0"
+        );
+        assert_eq!(
+            validate_session_id("amplihack-user-123").unwrap(),
+            "amplihack-user-123"
+        );
+        assert_eq!(validate_session_id("S1").unwrap(), "S1");
+    }
+
+    #[test]
+    fn rejects_invalid_input() {
+        // Rejects rather than silently mangling — no wrong-but-valid command.
+        assert!(validate_session_id("test;rm -rf /").is_err());
+        assert!(validate_session_id("").is_err());
+        assert!(validate_session_id("!@#$%^&*()").is_err());
+        assert!(validate_session_id("has space").is_err());
+        assert!(validate_session_id("$(whoami)").is_err());
+        assert!(validate_session_id("a\"b").is_err());
+
+        match validate_session_id("bad;id") {
+            Err(RemoteError::Validation(_)) => {}
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+}

--- a/crates/amplihack-remote/src/vm_lookup.rs
+++ b/crates/amplihack-remote/src/vm_lookup.rs
@@ -1,0 +1,154 @@
+//! VM lookup helpers backed by the `azlin list` CLI.
+//!
+//! Selecting a VM by name uses the authoritative, exact structured `name`
+//! field parsed from the CLI output — never a fragile substring match — so a
+//! query for a name that is a substring of another VM's name (e.g. "vm1" vs
+//! "vm10") never yields a false-positive.
+
+use std::process::Stdio;
+
+use tokio::process::Command;
+use tracing::debug;
+
+use crate::azlin_parse::{parse_azlin_list_json, parse_azlin_list_text};
+use crate::error::{ErrorContext, RemoteError};
+use crate::orchestrator::VM;
+use crate::redact::redact_sensitive;
+
+/// Look up a single VM by its exact name via `azlin list`.
+pub(crate) async fn get_vm_by_name(vm_name: &str) -> Result<VM, RemoteError> {
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        Command::new("azlin")
+            .args(["list", "--json"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    let vms = match output {
+        Ok(Ok(o)) if o.status.success() => {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            parse_azlin_list_json(&stdout)
+        }
+        Ok(Ok(o)) => {
+            // JSON invocation ran but failed; fall back to text listing.
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            debug!(stderr = %redact_sensitive(&stderr), "azlin list --json failed, trying text");
+            list_vms_text().await?
+        }
+        Ok(Err(e)) => {
+            return Err(RemoteError::provisioning_ctx(
+                format!("Failed to run 'azlin list': {e}"),
+                ErrorContext::new().insert("vm_name", vm_name),
+            ));
+        }
+        Err(_) => {
+            return Err(RemoteError::provisioning_ctx(
+                "'azlin list' timed out",
+                ErrorContext::new().insert("vm_name", vm_name),
+            ));
+        }
+    };
+
+    select_vm_by_name(&vms, vm_name).cloned().ok_or_else(|| {
+        RemoteError::provisioning_ctx(
+            format!("VM not found: {vm_name}"),
+            ErrorContext::new().insert("vm_name", vm_name),
+        )
+    })
+}
+
+/// Fetch the VM list via the plain-text `azlin list` output.
+async fn list_vms_text() -> Result<Vec<VM>, RemoteError> {
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        Command::new("azlin")
+            .arg("list")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match output {
+        Ok(Ok(o)) if o.status.success() => {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            Ok(parse_azlin_list_text(&stdout))
+        }
+        Ok(Ok(o)) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            Err(RemoteError::provisioning(format!(
+                "'azlin list' failed: {}",
+                redact_sensitive(&stderr)
+            )))
+        }
+        Ok(Err(e)) => Err(RemoteError::provisioning(format!(
+            "Failed to run 'azlin list': {e}"
+        ))),
+        Err(_) => Err(RemoteError::provisioning("'azlin list' timed out")),
+    }
+}
+
+/// Select a VM by its exact structured name.
+///
+/// Uses an exact equality comparison on the parsed `name` field so that a
+/// query for a name that is a substring of another VM's name never yields a
+/// false-positive match.
+fn select_vm_by_name<'a>(vms: &'a [VM], name: &str) -> Option<&'a VM> {
+    vms.iter().find(|vm| vm.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vm_named(name: &str) -> VM {
+        VM {
+            name: name.into(),
+            size: "Standard_D2s_v3".into(),
+            region: "eastus".into(),
+            created_at: None,
+            tags: None,
+        }
+    }
+
+    #[test]
+    fn select_vm_by_name_exact_match() {
+        let vms = vec![vm_named("vm1"), vm_named("vm10"), vm_named("vm100")];
+        let found = select_vm_by_name(&vms, "vm10").expect("vm10 exists");
+        assert_eq!(found.name, "vm10");
+    }
+
+    #[test]
+    fn select_vm_by_name_rejects_substring_false_positive() {
+        // "vm1" is a substring of "vm10"/"vm100"; exact matching must NOT
+        // select either of those when only "vm10" and "vm100" are present.
+        let vms = vec![vm_named("vm10"), vm_named("vm100")];
+        assert!(
+            select_vm_by_name(&vms, "vm1").is_none(),
+            "substring must not yield a false-positive match"
+        );
+
+        // And when the exact name is present alongside its superstrings, the
+        // exact one is selected.
+        let vms = vec![vm_named("vm100"), vm_named("vm1"), vm_named("vm10")];
+        let found = select_vm_by_name(&vms, "vm1").expect("exact vm1 exists");
+        assert_eq!(found.name, "vm1");
+    }
+
+    #[test]
+    fn select_vm_by_name_returns_real_struct_not_placeholder() {
+        let vms = vec![VM {
+            name: "amplihack-user-1".into(),
+            size: "Standard_D4s_v3".into(),
+            region: "westus".into(),
+            created_at: None,
+            tags: None,
+        }];
+        let found = select_vm_by_name(&vms, "amplihack-user-1").unwrap();
+        assert_eq!(found.size, "Standard_D4s_v3");
+        assert_eq!(found.region, "westus");
+    }
+}


### PR DESCRIPTION
Fixes #998