### PR TITLE
security(remote): keep API key out of argv & validate executor command (#997)

### DIFF
--- a/crates/amplihack-remote/src/executor.rs
+++ b/crates/amplihack-remote/src/executor.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, warn};
 use crate::backoff::BackoffPolicy;
 use crate::error::{ErrorContext, RemoteError};
 use crate::orchestrator::VM;
-use crate::shell_safe::validate_session_id;
+use crate::script::{build_remote_script, build_tmux_script, validate_command};
 
 /// Result of a remote command execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -132,6 +132,9 @@ impl Executor {
         prompt: &str,
         max_turns: u32,
     ) -> Result<ExecutionResult, RemoteError> {
+        // Issue #997 (F2): validate at the entry boundary too, so callers get a
+        // clear rejection before an env lookup or delegation occurs.
+        validate_command(command)?;
         let api_key = std::env::var("ANTHROPIC_API_KEY")
             .map_err(|_| RemoteError::execution("ANTHROPIC_API_KEY not found in environment"))?;
         self.execute_remote_with_api_key(command, prompt, max_turns, &api_key)
@@ -146,36 +149,19 @@ impl Executor {
         max_turns: u32,
         api_key: &str,
     ) -> Result<ExecutionResult, RemoteError> {
+        // Issue #997 (F2): reject untrusted command tokens before building any script.
+        validate_command(command)?;
         if api_key.trim().is_empty() {
             return Err(RemoteError::execution(
                 "ANTHROPIC_API_KEY not found in environment",
             ));
         }
-        let encoded_prompt = b64_encode(prompt.as_bytes());
-        let encoded_key = b64_encode(api_key.as_bytes());
 
         info!(command, "executing remote command");
 
-        let setup_script = format!(
-            r#"
-set -e
-cd ~
-tar xzf context.tar.gz
-rm -rf {workspace}
-mkdir -p {workspace}
-cd {workspace}
-git clone ~/repo.bundle .
-rm -rf .claude && cp -r ~/.claude .
-export ANTHROPIC_API_KEY=$(echo '{key}' | base64 -d)
-PROMPT=$(echo '{prompt}' | base64 -d)
-amplihack claude --{command} --max-turns {turns} -- -p "$PROMPT"
-"#,
-            workspace = self.remote_workspace,
-            key = encoded_key,
-            prompt = encoded_prompt,
-            command = command,
-            turns = max_turns,
-        );
+        // Issue #997 (F1): the script is key-free by construction; the secret is
+        // transported over the child's stdin (never argv, disk, or logs).
+        let setup_script = build_remote_script(&self.remote_workspace, command, prompt, max_turns)?;
 
         let mut cmd = Command::new("azlin");
         cmd.arg("connect");
@@ -183,8 +169,10 @@ amplihack claude --{command} --max-turns {turns} -- -p "$PROMPT"
         cmd.args([&self.vm.name, &setup_script]);
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
-        // Issue #867: null stdin so the spawned child can't steal the orchestrator's input.
-        cmd.stdin(Stdio::null());
+        // Issue #997 (F1): pipe stdin so we can hand the API key to the remote
+        // `read`. Issue #867 is preserved: we write the key once, flush, and
+        // close the handle immediately, so the child never holds a live TTY.
+        cmd.stdin(Stdio::piped());
 
         let start = Instant::now();
         // Issue #867: supervise via idle watchdog, not a wall-clock cap. A run
@@ -192,6 +180,26 @@ amplihack claude --{command} --max-turns {turns} -- -p "$PROMPT"
         let mut child = cmd
             .spawn()
             .map_err(|e| RemoteError::execution(format!("Failed to spawn remote command: {e}")))?;
+
+        // Issue #997 (F1): deliver the API key via stdin, then close it (EOF).
+        // Surface any write failure explicitly — no silent fallback.
+        {
+            use tokio::io::AsyncWriteExt;
+            let mut stdin = child.stdin.take().ok_or_else(|| {
+                RemoteError::execution("failed to capture remote command stdin for key transport")
+            })?;
+            stdin
+                .write_all(format!("{api_key}\n").as_bytes())
+                .await
+                .map_err(|e| {
+                    RemoteError::execution(format!("failed to write API key to remote stdin: {e}"))
+                })?;
+            stdin.flush().await.map_err(|e| {
+                RemoteError::execution(format!("failed to flush API key to remote stdin: {e}"))
+            })?;
+            // Drop closes the pipe, signalling EOF to the remote shell.
+        }
+
         let child_stdout = child.stdout.take();
         let child_stderr = child.stderr.take();
         let cfg = IdleConfig::with_idle(std::time::Duration::from_secs(self.timeout_seconds));
@@ -235,40 +243,54 @@ amplihack claude --{command} --max-turns {turns} -- -p "$PROMPT"
         max_turns: u32,
         api_key: &str,
     ) -> Result<(), RemoteError> {
+        // Issue #997 (F2): reject untrusted command tokens before building any script.
+        validate_command(command)?;
         if api_key.trim().is_empty() {
             return Err(RemoteError::execution(
                 "ANTHROPIC_API_KEY not found in environment",
             ));
         }
 
-        let encoded_prompt = b64_encode(prompt.as_bytes());
-        let encoded_key = b64_encode(api_key.as_bytes());
-        let safe_session = validate_session_id(session_id)?;
-        let script = format!(
-            r#"
-set -e
-export ANTHROPIC_API_KEY=$(echo '{key}' | base64 -d)
-PROMPT=$(echo '{prompt}' | base64 -d)
-tmux new-session -d -s {session} "cd ~/workspace && amplihack claude --{command} --max-turns {turns} -- -p \"$PROMPT\""
-"#,
-            key = encoded_key,
-            prompt = encoded_prompt,
-            session = safe_session,
-            command = command,
-            turns = max_turns,
-        );
+        // Issue #997 (F1): key-free script; the secret arrives over stdin.
+        // Issue #998: build_tmux_script rejects (not strips) invalid session ids.
+        let script = build_tmux_script(session_id, command, prompt, max_turns)?;
 
         let mut cmd = Command::new("azlin");
         cmd.arg("connect");
         self.append_port_args(&mut cmd);
         cmd.args([&self.vm.name, &script]);
+        cmd.stdin(Stdio::piped());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-        let output = tokio::time::timeout(std::time::Duration::from_secs(60), cmd.output())
-            .await
-            .map_err(|_| RemoteError::execution("tmux launch timed out"))?
-            .map_err(|e| RemoteError::execution(format!("tmux launch failed: {e}")))?;
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| RemoteError::execution(format!("tmux launch failed to spawn: {e}")))?;
+
+        // Issue #997 (F1): deliver the API key via stdin, then close it (EOF).
+        // Drop the handle before awaiting output so the remote shell sees EOF
+        // and cannot deadlock waiting for more input.
+        {
+            use tokio::io::AsyncWriteExt;
+            let mut stdin = child.stdin.take().ok_or_else(|| {
+                RemoteError::execution("failed to capture tmux stdin for key transport")
+            })?;
+            stdin
+                .write_all(format!("{api_key}\n").as_bytes())
+                .await
+                .map_err(|e| {
+                    RemoteError::execution(format!("failed to write API key to tmux stdin: {e}"))
+                })?;
+            stdin.flush().await.map_err(|e| {
+                RemoteError::execution(format!("failed to flush API key to tmux stdin: {e}"))
+            })?;
+        }
+
+        let output =
+            tokio::time::timeout(std::time::Duration::from_secs(60), child.wait_with_output())
+                .await
+                .map_err(|_| RemoteError::execution("tmux launch timed out"))?
+                .map_err(|e| RemoteError::execution(format!("tmux launch failed: {e}")))?;
 
         if output.status.success() {
             Ok(())
@@ -403,31 +425,6 @@ fi
     }
 }
 
-/// Simple base64 encoder (standard alphabet, with padding).
-fn b64_encode(data: &[u8]) -> String {
-    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut result = String::with_capacity(data.len().div_ceil(3) * 4);
-    for chunk in data.chunks(3) {
-        let b0 = chunk[0] as u32;
-        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
-        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
-        let n = (b0 << 16) | (b1 << 8) | b2;
-        result.push(ALPHABET[((n >> 18) & 0x3F) as usize] as char);
-        result.push(ALPHABET[((n >> 12) & 0x3F) as usize] as char);
-        if chunk.len() > 1 {
-            result.push(ALPHABET[((n >> 6) & 0x3F) as usize] as char);
-        } else {
-            result.push('=');
-        }
-        if chunk.len() > 2 {
-            result.push(ALPHABET[(n & 0x3F) as usize] as char);
-        } else {
-            result.push('=');
-        }
-    }
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -472,16 +469,5 @@ mod tests {
         };
         let exec = Executor::new(vm, 10, None);
         assert!(exec.tunnel_port.is_none());
-    }
-
-    #[test]
-    fn b64_encode_vectors() {
-        assert_eq!(b64_encode(b""), "");
-        assert_eq!(b64_encode(b"A"), "QQ==");
-        assert_eq!(b64_encode(b"AB"), "QUI=");
-        assert_eq!(b64_encode(b"ABC"), "QUJD");
-        assert_eq!(b64_encode(b"Hello, World!"), "SGVsbG8sIFdvcmxkIQ==");
-        let data: Vec<u8> = (0..=255).collect();
-        assert_eq!(b64_encode(&data).len() % 4, 0);
     }
 }

--- a/crates/amplihack-remote/src/lib.rs
+++ b/crates/amplihack-remote/src/lib.rs
@@ -28,6 +28,7 @@ pub mod integrator;
 pub mod orchestrator;
 pub mod packager;
 mod redact;
+mod script;
 pub mod session;
 pub(crate) mod shell_safe;
 pub mod state_io;

--- a/crates/amplihack-remote/src/script.rs
+++ b/crates/amplihack-remote/src/script.rs
@@ -1,0 +1,340 @@
+//! Pure helpers for building remote shell scripts and validating executor
+//! input.
+//!
+//! Split out of `executor.rs` (issue #536: keep modules <=500 lines). These
+//! functions are deliberately side-effect free so they can be unit-tested
+//! without spawning processes — which is what lets the issue #997 security
+//! contract (secret never lands in the script; malicious commands rejected)
+//! be proven directly.
+
+use crate::error::RemoteError;
+use crate::shell_safe::validate_session_id;
+
+/// Simple base64 encoder (standard alphabet, with padding).
+pub(crate) fn b64_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        result.push(ALPHABET[((n >> 18) & 0x3F) as usize] as char);
+        result.push(ALPHABET[((n >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            result.push(ALPHABET[((n >> 6) & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            result.push(ALPHABET[(n & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+    }
+    result
+}
+
+/// Issue #997 (F2): allowlist-validate the `command` token before it is ever
+/// interpolated into a remote shell script.
+///
+/// The token must match `^[a-z][a-z0-9-]{0,31}$`: a lowercase letter followed
+/// by up to 31 lowercase-alphanumeric-or-hyphen characters (32 chars max).
+/// This admits every current [`CommandMode`](crate::orchestrator) value
+/// (`auto`, `ultrathink`, `analyze`, `fix`) and any hyphenated recipe name,
+/// while rejecting all shell metacharacters, whitespace, and the empty string.
+/// Fails closed with [`RemoteError::Validation`]; no escaping fallback.
+pub(crate) fn validate_command(command: &str) -> Result<(), RemoteError> {
+    let mut chars = command.chars();
+    let valid = match chars.next() {
+        Some(first) if first.is_ascii_lowercase() => {
+            command.len() <= 32
+                && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+        }
+        _ => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(RemoteError::validation(format!(
+            "invalid command {command:?}: must match ^[a-z][a-z0-9-]{{0,31}}$"
+        )))
+    }
+}
+
+/// Issue #997 (F1): build the remote setup script for
+/// [`crate::executor::Executor::execute_remote_with_api_key`] without ever
+/// embedding the API key. The key is transported over the child's stdin and
+/// read on the remote via `IFS= read -r ANTHROPIC_API_KEY`. The non-secret
+/// prompt continues to travel base64-encoded and is consumed only as the
+/// `$PROMPT` variable.
+pub(crate) fn build_remote_script(
+    workspace: &str,
+    command: &str,
+    prompt: &str,
+    max_turns: u32,
+) -> Result<String, RemoteError> {
+    validate_command(command)?;
+    let encoded_prompt = b64_encode(prompt.as_bytes());
+    Ok(format!(
+        r#"
+set -e
+IFS= read -r ANTHROPIC_API_KEY
+export ANTHROPIC_API_KEY
+cd ~
+tar xzf context.tar.gz
+rm -rf {workspace}
+mkdir -p {workspace}
+cd {workspace}
+git clone ~/repo.bundle .
+rm -rf .claude && cp -r ~/.claude .
+PROMPT=$(echo '{prompt}' | base64 -d)
+amplihack claude --{command} --max-turns {turns} -- -p "$PROMPT"
+"#,
+        workspace = workspace,
+        prompt = encoded_prompt,
+        command = command,
+        turns = max_turns,
+    ))
+}
+
+/// Issue #997 (F1): build the detached-tmux launch script for
+/// [`crate::executor::Executor::execute_remote_tmux`] without embedding the
+/// API key. Same stdin-read contract as [`build_remote_script`]; the session
+/// id is validated via [`validate_session_id`] (rejecting — not stripping —
+/// anything outside the strict identifier set, issue #998) and the command is
+/// allowlist-validated.
+pub(crate) fn build_tmux_script(
+    session_id: &str,
+    command: &str,
+    prompt: &str,
+    max_turns: u32,
+) -> Result<String, RemoteError> {
+    validate_command(command)?;
+    let safe_session = validate_session_id(session_id)?;
+    let encoded_prompt = b64_encode(prompt.as_bytes());
+    Ok(format!(
+        r#"
+set -e
+IFS= read -r ANTHROPIC_API_KEY
+export ANTHROPIC_API_KEY
+PROMPT=$(echo '{prompt}' | base64 -d)
+tmux new-session -d -s {session} "cd ~/workspace && amplihack claude --{command} --max-turns {turns} -- -p \"$PROMPT\""
+"#,
+        prompt = encoded_prompt,
+        session = safe_session,
+        command = command,
+        turns = max_turns,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::RemoteError;
+
+    #[test]
+    fn b64_encode_vectors() {
+        assert_eq!(b64_encode(b""), "");
+        assert_eq!(b64_encode(b"A"), "QQ==");
+        assert_eq!(b64_encode(b"AB"), "QUI=");
+        assert_eq!(b64_encode(b"ABC"), "QUJD");
+        assert_eq!(b64_encode(b"Hello, World!"), "SGVsbG8sIFdvcmxkIQ==");
+        let data: Vec<u8> = (0..=255).collect();
+        assert_eq!(b64_encode(&data).len() % 4, 0);
+    }
+
+    // ---- Issue #997: F2 — command allowlist validation ----
+
+    #[test]
+    fn validate_command_accepts_known_modes() {
+        for cmd in ["auto", "ultrathink", "analyze", "fix"] {
+            assert!(
+                validate_command(cmd).is_ok(),
+                "known mode {cmd:?} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_command_accepts_hyphenated_and_bounds() {
+        // single lowercase letter is the minimum valid token
+        assert!(validate_command("a").is_ok());
+        // hyphens are permitted between segments
+        assert!(validate_command("a-b-c").is_ok());
+        assert!(validate_command("smart-orchestrator").is_ok());
+        // 32 chars total (1 leading letter + 31 tail) is the inclusive max
+        let max_len = format!("a{}", "b".repeat(31));
+        assert_eq!(max_len.len(), 32);
+        assert!(validate_command(&max_len).is_ok());
+    }
+
+    #[test]
+    fn validate_command_rejects_shell_metacharacters() {
+        let malicious = [
+            "analyze; rm -rf ~",
+            "$(whoami)",
+            "`id`",
+            "a|b",
+            "a&&b",
+            "a>b",
+            "a<b",
+            "a\nb",
+            "a$b",
+            "a'b",
+            "a\"b",
+            "a\\b",
+        ];
+        for cmd in malicious {
+            assert!(
+                validate_command(cmd).is_err(),
+                "malicious command {cmd:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_command_rejects_whitespace_and_empty() {
+        for cmd in ["", " ", "a b", "auto ", " auto", "\t"] {
+            assert!(
+                validate_command(cmd).is_err(),
+                "command {cmd:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_command_rejects_bad_shape() {
+        // must start with a lowercase letter
+        assert!(validate_command("-auto").is_err());
+        assert!(validate_command("1auto").is_err());
+        // uppercase not allowed
+        assert!(validate_command("Auto").is_err());
+        assert!(validate_command("AUTO").is_err());
+        // underscore not allowed
+        assert!(validate_command("a_b").is_err());
+        // over the 32-char limit
+        let too_long = format!("a{}", "b".repeat(32));
+        assert_eq!(too_long.len(), 33);
+        assert!(validate_command(&too_long).is_err());
+    }
+
+    #[test]
+    fn validate_command_error_is_validation_variant() {
+        let err = validate_command("evil; rm -rf /").unwrap_err();
+        assert!(
+            matches!(err, RemoteError::Validation(_)),
+            "invalid command must fail closed with a Validation error, got {err:?}"
+        );
+    }
+
+    // ---- Issue #997: F1 — secret never lands in the generated script ----
+
+    const FAKE_KEY: &str = "sk-ant-secret-DO-NOT-LEAK-0123456789";
+
+    #[test]
+    fn build_remote_script_reads_key_from_stdin_not_argv() {
+        let script = build_remote_script("~/workspace", "auto", "do the thing", 5)
+            .expect("valid command must build a script");
+        // The key is transported via the child's stdin and read on the remote.
+        assert!(
+            script.contains("read -r ANTHROPIC_API_KEY"),
+            "script must read the API key from stdin: {script}"
+        );
+        assert!(
+            script.contains("export ANTHROPIC_API_KEY"),
+            "script must export the API key into the child env: {script}"
+        );
+    }
+
+    #[test]
+    fn build_remote_script_never_embeds_key_or_decode() {
+        // The builder takes no key at all, so the secret can never appear.
+        let script = build_remote_script("~/workspace", "auto", "prompt text", 3).unwrap();
+        assert!(
+            !script.contains(FAKE_KEY),
+            "raw key must never appear in the script body"
+        );
+        assert!(
+            !script.contains(&b64_encode(FAKE_KEY.as_bytes())),
+            "base64-encoded key must never appear in the script body"
+        );
+        // The removed leak vector: `export ANTHROPIC_API_KEY=$(echo '...' | base64 -d)`.
+        assert!(
+            !script.contains("ANTHROPIC_API_KEY=$(echo"),
+            "must not reconstruct the key inline from an embedded literal: {script}"
+        );
+    }
+
+    #[test]
+    fn build_remote_script_validates_command_before_building() {
+        let err = build_remote_script("~/workspace", "auto; curl evil.sh | sh", "p", 1)
+            .expect_err("malicious command must be rejected before any script is built");
+        assert!(matches!(err, RemoteError::Validation(_)));
+    }
+
+    #[test]
+    fn build_remote_script_interpolates_validated_command_and_prompt() {
+        let script = build_remote_script("~/ws", "ultrathink", "hello prompt", 7).unwrap();
+        assert!(
+            script.contains("--ultrathink"),
+            "validated command must be interpolated: {script}"
+        );
+        assert!(
+            script.contains("--max-turns 7"),
+            "max_turns must be interpolated: {script}"
+        );
+        // Prompt is non-secret and travels base64-encoded, consumed as a variable.
+        assert!(
+            script.contains(&b64_encode(b"hello prompt")),
+            "prompt must be base64-transported: {script}"
+        );
+        assert!(script.contains(r#"-p "$PROMPT""#));
+    }
+
+    #[test]
+    fn build_tmux_script_reads_key_from_stdin_not_argv() {
+        let script = build_tmux_script("sess-1", "auto", "the prompt", 4)
+            .expect("valid command must build a tmux script");
+        assert!(
+            script.contains("read -r ANTHROPIC_API_KEY"),
+            "tmux script must read the API key from stdin: {script}"
+        );
+        assert!(script.contains("export ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn build_tmux_script_never_embeds_key_or_decode() {
+        let script = build_tmux_script("sess-1", "fix", "prompt", 2).unwrap();
+        assert!(!script.contains(FAKE_KEY));
+        assert!(!script.contains(&b64_encode(FAKE_KEY.as_bytes())));
+        assert!(
+            !script.contains("ANTHROPIC_API_KEY=$(echo"),
+            "tmux script must not reconstruct the key from an embedded literal: {script}"
+        );
+    }
+
+    #[test]
+    fn build_tmux_script_validates_command() {
+        let err = build_tmux_script("sess-1", "fix`reboot`", "p", 1)
+            .expect_err("malicious command must be rejected");
+        assert!(matches!(err, RemoteError::Validation(_)));
+    }
+
+    #[test]
+    fn build_tmux_script_rejects_unsafe_session() {
+        // Issue #998: an unsafe session id is REJECTED, never silently stripped
+        // into a wrong-but-valid tmux session name.
+        let err = build_tmux_script("sess;rm -rf /", "analyze", "p", 9)
+            .expect_err("unsafe session id must be rejected");
+        assert!(matches!(err, RemoteError::Validation(_)));
+    }
+
+    #[test]
+    fn build_tmux_script_interpolates_valid_session_and_command() {
+        let script = build_tmux_script("sess-1.0_A", "analyze", "p", 9).unwrap();
+        assert!(script.contains("-s sess-1.0_A"));
+        assert!(script.contains("--analyze"));
+        assert!(script.contains("--max-turns 9"));
+    }
+}

--- a/docs/security/EXECUTOR_SECRET_AND_COMMAND_HARDENING.md
+++ b/docs/security/EXECUTOR_SECRET_AND_COMMAND_HARDENING.md
@@ -1,0 +1,235 @@
+# Executor Secret Transport & Command Validation Hardening
+
+> [Home](../index.md) > [Security](./README.md) > Executor Secret & Command Hardening
+
+> Status: Implemented · Severity: P1 (security hardening) · Crate: `amplihack-remote`
+> Resolves: [#997](https://github.com/rysweet/amplihack-rs/issues/997)
+
+## Summary
+
+`amplihack-remote`'s executor runs amplihack commands on remote Azure VMs by
+invoking the `azlin` SSH wrapper with a generated shell script. Two hardening
+measures close concrete leakage and injection vectors in that path:
+
+- **F1 — API key never on argv or disk.** `ANTHROPIC_API_KEY` (and related
+  secrets) are transported to the remote command exclusively through the child
+  process's **piped stdin**, read on the remote with `IFS= read -r`. The key
+  appears in **neither the local argv, nor the remote argv, nor any temp script
+  on disk, nor any log line**. The previous behavior — base64-embedding the key
+  into the generated script body (which lands in argv / process listing) — has
+  been removed. Base64 was obfuscation, not protection.
+
+- **F2 — Command token validated before execution.** The `command` token
+  (`auto`, `ultrathink`, `analyze`, `fix`, …) is validated against a strict
+  allowlist **before** any script is built or any process is spawned. Anything
+  containing shell metacharacters, whitespace, command substitution, or that is
+  empty is rejected up front, making the `--{command}` interpolation
+  injection-safe.
+
+Both measures **fail closed** and surface errors explicitly via `RemoteError`.
+There are no silent fallbacks or degraded paths, consistent with the crate's
+error-handling policy.
+
+## Threat model
+
+| ID | Threat | CWE | Before | After |
+| --- | --- | --- | --- | --- |
+| F1 | Secret disclosure via process listing / argv / temp script | CWE-214, CWE-532 | `ANTHROPIC_API_KEY` base64-embedded in script → visible in `ps`/argv | Key sent over child stdin only; never in argv, disk, or logs |
+| F2 | Command injection / RCE via raw shell interpolation | CWE-78 | `command` interpolated raw into shell string | Allowlist-validated before spawn; metacharacters rejected |
+
+The `prompt` remains **untrusted input**: it is base64-encoded and consumed only
+as a shell variable (`"$PROMPT"`), never as executable code. The `azlin`/SSH
+trust boundary continues to provide transport authentication.
+
+## F1 — Secret transport via stdin
+
+### How it works
+
+1. The executor builds a **key-free** remote script. The first meaningful line
+   reads the secret from stdin and exports it into the remote environment:
+
+   ```sh
+   IFS= read -r ANTHROPIC_API_KEY
+   export ANTHROPIC_API_KEY
+   ```
+
+   The literal key value is **never** present in the script body.
+
+2. The executor spawns `azlin connect …` with **`Stdio::piped()`** stdin,
+   writes `api_key + "\n"` to the child's stdin, **flushes**, and **drops the
+   stdin handle immediately** so the remote `read` sees EOF and execution
+   proceeds. This replaces the current transport, which embeds
+   `export ANTHROPIC_API_KEY=$(echo '<base64>' | base64 -d)` directly in the
+   generated script body (visible in argv / `ps` on both hosts).
+
+3. SSH forwards the local child's stdin to the remote command, so the key is
+   delivered into the remote process's environment without ever touching argv or
+   disk on either side.
+
+> **stdin ownership change.** `execute_remote_with_api_key` currently sets
+> `Stdio::null()` and `execute_remote_tmux` inherits the parent's stdin. Both
+> switch to `Stdio::piped()`. Because the idle-watchdog path
+> (`wait_with_idle_watchdog`) and the tmux path already take/await the child, the
+> key is written and the handle dropped **before** the wait begins; the tmux path
+> moves from `Command::output()` to spawn → write stdin → wait so it can feed the
+> key.
+
+> **Transport assumption.** Correctness relies on `azlin connect` passing the
+> local child's stdin through to the remote command's stdin (standard SSH
+> behavior for a non-interactive command). The remote `IFS= read -r` consumes
+> exactly one line — the key — before any user prompt is processed.
+
+### Regression guard (issue #867)
+
+The interactive-orchestrator TTY protection from #867 is preserved by
+construction. #867 used `Stdio::null()` to stop the child from stealing the
+orchestrator's terminal; the hardened path instead hands the child a
+**one-shot pipe** — written once, flushed, and its handle dropped — never a live
+terminal. The child still cannot read the orchestrator's interactive TTY, and it
+receives exactly one line (the key) followed by EOF.
+
+### Error handling
+
+- Writing or flushing the key to child stdin failing → propagated as
+  `RemoteError::execution(...)`. The remote failure is surfaced, never swallowed.
+- An empty or whitespace-only key is rejected **before** spawn via
+  `RemoteError::validation(...)` (fail closed). This intentionally standardizes
+  the previously `RemoteError::execution`-typed empty-key check onto the same
+  `validation` variant used by command validation, so every pre-spawn rejection
+  is reported uniformly. The message is corrected from the misleading
+  "not found in environment" to an explicit empty-key message (a
+  present-but-empty key is not a missing-env-var condition). The genuinely
+  missing-variable lookup in `execute_remote` keeps its `RemoteError::execution`
+  "not found in environment" message, since that path really is a missing env var.
+- The key and the full script body are **never logged**. Existing
+  `info!(command, …)` log lines are unchanged and log only the (validated)
+  command token, never the secret.
+
+### Applies to
+
+- `Executor::execute_remote_with_api_key` (idle-watchdog path)
+- `Executor::execute_remote_tmux` (detached tmux launch)
+- `Executor::execute_remote` inherits the transport transitively — it reads
+  `ANTHROPIC_API_KEY` from the environment and delegates to
+  `execute_remote_with_api_key`.
+
+All three public method signatures are unchanged (patch-level SemVer).
+
+## F2 — Command validation
+
+### Allowlist rule
+
+The `command` token must match:
+
+```text
+^[a-z][a-z0-9-]{0,31}$
+```
+
+- Lowercase ASCII letter first, then up to 31 more lowercase letters, digits, or
+  hyphens (32 chars total).
+- Covers every current command mode (`auto`, `ultrathink`, `analyze`, `fix`) and
+  leaves room for future hyphenated modes.
+- Rejects **all** shell metacharacters, whitespace, command substitution
+  (`$(...)`, backticks), pipes, redirects, semicolons, and the empty string.
+
+Validation is a hand-rolled check (no `regex` dependency) run at the executor
+boundary, before any script build or process spawn, in:
+
+- `Executor::execute_remote`
+- `Executor::execute_remote_with_api_key`
+- `Executor::execute_remote_tmux`
+
+### Rejection behavior
+
+Invalid input fails closed with an explicit error:
+
+```text
+RemoteError::validation("invalid command: <token>")
+```
+
+No escaping, no sanitizing-and-continuing — invalid commands are rejected, not
+transformed.
+
+### Examples
+
+| Input | Result |
+| --- | --- |
+| `auto` | ✅ accepted |
+| `ultrathink` | ✅ accepted |
+| `analyze` | ✅ accepted |
+| `fix` | ✅ accepted |
+| `analyze; rm -rf ~` | ❌ rejected (metacharacters) |
+| `$(curl evil.sh)` | ❌ rejected (substitution) |
+| `` `id` `` | ❌ rejected (backticks) |
+| `auto fix` | ❌ rejected (whitespace) |
+| `auto\|cat` | ❌ rejected (pipe) |
+| `` (empty) | ❌ rejected (empty) |
+| `Auto` | ❌ rejected (uppercase) |
+
+## Usage
+
+No API changes are required by callers. The hardening is transparent to existing
+call sites:
+
+```rust
+use amplihack_remote::executor::Executor;
+
+let executor = Executor::new(vm, timeout_minutes, tunnel_port);
+
+// `command` is validated against the allowlist before anything is spawned.
+// `api_key` is delivered to the remote over stdin — never on argv or disk.
+let result = executor
+    .execute_remote_with_api_key(
+        "auto",        // validated command token
+        prompt,        // untrusted; base64-encoded, consumed as "$PROMPT"
+        max_turns,
+        &api_key,      // transported via child stdin only
+    )
+    .await?;
+```
+
+A malicious command is rejected before any process runs:
+
+```rust
+// Returns Err(RemoteError::validation("invalid command: analyze; rm -rf ~"))
+let err = executor
+    .execute_remote_with_api_key("analyze; rm -rf ~", prompt, max_turns, &api_key)
+    .await
+    .unwrap_err();
+```
+
+## Configuration
+
+No new configuration, environment variables, or dependencies are introduced.
+Existing timeout and idle-watchdog behavior is unchanged; **no new fixed
+resource caps** were added.
+
+## Security invariants
+
+- The API key value never appears in: local argv, remote argv, on-disk temp
+  script, `tracing` output, or `RemoteError` messages.
+- The generated remote script contains `IFS= read -r ANTHROPIC_API_KEY` and does
+  **not** contain the key literal or a `base64 -d` of the key.
+- Every execution path validates `command` against the allowlist before spawn.
+- All failures (invalid command, empty key, stdin write failure) surface
+  explicitly as `RemoteError`; no path silently degrades.
+
+## Test coverage
+
+Inline `#[cfg(test)] mod tests` in `crates/amplihack-remote/src/executor.rs`
+proves the invariants:
+
+- **Allowlist matrix** — every valid mode is accepted; the injection/whitespace/
+  empty/uppercase cases above are rejected with `RemoteError::validation`.
+- **Key-free script builders** — the built script/argv contains no `api_key`
+  substring and no `base64 -d` of the key, and does contain
+  `IFS= read -r ANTHROPIC_API_KEY`.
+- **Fail-closed key** — an empty or whitespace-only key errors before spawn.
+
+Run the crate's suite and lint gates:
+
+```bash
+cargo test -p amplihack-remote
+cargo clippy --all-targets -- -D warnings
+pre-commit run --all-files
+```

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -21,6 +21,10 @@ Ahoy! This be where ye learn to keep yer ship secure from digital pirates.
 
 - [Azlin stderr Redaction](./AZLIN_STDERR_REDACTION.md) - Redact subscription IDs / SAS URLs from Azure CLI stderr during VM cleanup
 
+**New in Issue #997 (P1 hardening):**
+
+- [Executor Secret Transport & Command Validation](./EXECUTOR_SECRET_AND_COMMAND_HARDENING.md) - Keep the API key off argv/disk (stdin transport) and allowlist-validate the executor command before spawn
+
 ---
 
 ## Security Features Overview


### PR DESCRIPTION
## Summary

Security hardening in `crates/amplihack-remote` addressing issue #997. The executor previously base64-embedded `ANTHROPIC_API_KEY` directly into the subprocess argv / generated script body, and interpolated the `command` token raw into a shell with no validation.

### F1 — Keep the API key out of argv / process listing
- Removed base64-embedding of the key (`export ANTHROPIC_API_KEY=$(echo '...' | base64 -d)`) from both the remote setup script and the tmux launch script.
- The secret is now transported over the child process's **piped stdin** and read on the remote via `IFS= read -r ANTHROPIC_API_KEY`. It never appears in local argv, remote argv, on disk, or in logs.
- The one-shot stdin write is flushed and the handle dropped immediately, preserving the issue #867 guard (child cannot steal the orchestrator's TTY). stdin write/flush failures propagate explicitly — no silent fallback.

### F2 — Validate the command before execution
- New `validate_command` allowlist (`^[a-z][a-z0-9-]{0,31}$`) rejects all shell metacharacters, whitespace, and the empty string, failing closed with `RemoteError::Validation`.
- Applied at the `execute_remote` entry and inside both script builders before any interpolation.

### Refactor / tests
- Extracted pure, testable `build_remote_script` / `build_tmux_script` helpers that are key-free by construction.
- Added unit tests proving the secret never appears in the generated scripts (raw or base64) and that malicious/invalid commands are rejected before any script is built.

## Verification
- `cargo test -p amplihack-remote` — 92 passed
- `cargo clippy --all-targets -- -D warnings` — clean (workspace-wide)
- `pre-commit run --all-files` — all hooks pass

Scope limited to issue #997 only (no #998 correctness work).

Fixes #997

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd