### PR TITLE
fix(workflow): scope PRs by (head,base,repo) primary key + collision-tolerant publish (#1017)

### DIFF
--- a/amplifier-bundle/tools/workflow_pr_scope.sh
+++ b/amplifier-bundle/tools/workflow_pr_scope.sh
@@ -78,6 +78,7 @@ emit_failure() {
   exit 1
 }
 
+# shellcheck disable=SC2317  # invoked indirectly on the gh error path
 sanitize_gh_stderr() {
   sed -E 's#(https?://)[^@[:space:]]+@#\1REDACTED@#g' "$1" | tr '\n' ' ' | awk '{print substr($0, 1, 500)}'
 }
@@ -150,8 +151,11 @@ raw_json=""
 # but core still has budget, the shared driver serves the existence/inspection
 # lookup via these instead of failing the scope probe closed. Each fallback
 # echoes JSON in the same shape the matching `gh` command would return.
+# shellcheck disable=SC2317  # invoked indirectly via GH_RETRY_REST_FALLBACK
 _scope_rest_list() { gh_pr_exists_rest "$REPO" "$HEAD_REF"; }
+# shellcheck disable=SC2317  # invoked indirectly via GH_RETRY_REST_FALLBACK
 _scope_rest_view_number() { gh_pr_view_rest "$REPO" "$PR_NUMBER"; }
+# shellcheck disable=SC2317  # invoked indirectly via GH_RETRY_REST_FALLBACK
 _scope_rest_view_url() {
   local n
   n="$(gh_pr_number_from_url "$PR_URL")" || return 1

--- a/amplifier-bundle/tools/workflow_pr_scope.sh
+++ b/amplifier-bundle/tools/workflow_pr_scope.sh
@@ -259,6 +259,18 @@ emit_scoped_match() {
   exit 0
 }
 
+# Discovery-mode fallback. Prefer a single OPEN candidate over failing closed on
+# the recipe's own PR; a genuine >=2-OPEN set (GitHub's one-open-PR-per-head->base
+# invariant broken) is a real anomaly and fails loud. Always terminates.
+prefer_single_open_or_fail() {
+  local open
+  open="$(open_candidates "$1")"
+  if [ "$(array_length "$open")" -eq 1 ]; then
+    emit_scoped_match "$open"
+  fi
+  emit_multiple_scoped_prs "$1"
+}
+
 primary="$(match_by_primary_key "$raw_json")"
 primary_count="$(array_length "$primary")"
 
@@ -295,22 +307,12 @@ if [ "$tie_count" -eq 1 ]; then
   emit_scoped_match "$tie"
 fi
 
+# tie_count > 1: discriminators narrowed but did not resolve -> prefer OPEN.
 if [ "$tie_count" -gt 1 ]; then
-  # Prefer a single OPEN candidate; only a genuine >=2-OPEN anomaly fails loud.
-  tie_open="$(open_candidates "$tie")"
-  if [ "$(array_length "$tie_open")" -eq 1 ]; then
-    emit_scoped_match "$tie_open"
-  fi
-  emit_multiple_scoped_prs "$tie"
+  prefer_single_open_or_fail "$tie"
 fi
 
-# Discriminators eliminated every candidate. Rather than fail closed on the
-# recipe's own PR, prefer the single OPEN candidate under the primary key.
-primary_open="$(open_candidates "$primary")"
-if [ "$(array_length "$primary_open")" -eq 1 ]; then
-  emit_scoped_match "$primary_open"
-fi
-
-# Two or more OPEN PRs share the same head+base: a real GitHub anomaly worth
-# surfacing loudly instead of silently guessing.
-emit_multiple_scoped_prs "$primary"
+# tie_count == 0: discriminators eliminated the recipe's own PR (stale issue
+# token or advanced head-sha). Fall back to the primary key and prefer OPEN
+# rather than failing closed on a PR that is genuinely ours.
+prefer_single_open_or_fail "$primary"

--- a/amplifier-bundle/tools/workflow_pr_scope.sh
+++ b/amplifier-bundle/tools/workflow_pr_scope.sh
@@ -178,14 +178,44 @@ if ! printf '%s' "$raw_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
   emit_failure "invalid_pr_metadata" "GitHub PR metadata was not a JSON array"
 fi
 
-matches="$(
-  printf '%s' "$raw_json" | jq -c \
+# PRIMARY KEY: (headRefName, baseRefName, same-repo, non-cross-repository).
+# GitHub forbids a second OPEN PR for the same head->base in the same repo, so
+# this tuple is already a reliable unique key for the recipe's own PR. Issue
+# tokens / head-sha / title-prefix are NOT primary discriminators: layering them
+# as hard rejections (a stale local tracking issue, or a remote head that has
+# advanced past the captured sha) makes the lookup fail closed, then collide on
+# `gh pr create` and hard-fail the recipe (issue #1017, PR #1015). When
+# --pr-number/--pr-url is given the primary key also enforces that explicit
+# identity so an authoritative lookup still targets exactly the named PR.
+match_by_primary_key() {
+  printf '%s' "$1" | jq -c \
     --arg repo "$REPO" \
     --arg headRefName "$HEAD_REF" \
     --arg baseRefName "$BASE_REF" \
-    --arg headRefOid "$HEAD_SHA" \
     --arg prNumber "$PR_NUMBER" \
-    --arg prUrl "$PR_URL" \
+    --arg prUrl "$PR_URL" '
+      def owner_name:
+        (.headRepositoryOwner.login // .headRepositoryOwner.name // .headRepositoryOwner // "");
+      def repo_name:
+        (.headRepository.name // ((.headRepository.nameWithOwner // "") | split("/") | .[-1]) // "");
+      [
+        .[]
+        | select((.headRefName // "") == $headRefName)
+        | select((.baseRefName // "") == $baseRefName)
+        | select((.isCrossRepository // false) == false)
+        | select(((owner_name + "/" + repo_name) == $repo))
+        | select(($prNumber == "") or (((.number // "") | tostring) == $prNumber))
+        | select(($prUrl == "") or ((.url // "") == $prUrl))
+      ]'
+}
+
+# Secondary discriminators. Applied as HARD filters only in authoritative
+# (--pr-number/--pr-url) mode — where a stale explicitly-named PR must fail
+# closed — and as TIE-BREAKERS in discovery mode only when >1 candidate shares
+# the same head+base (rare open/closed variants).
+apply_discriminators() {
+  printf '%s' "$1" | jq -c \
+    --arg headRefOid "$HEAD_SHA" \
     --arg issueId "$ISSUE_ID" \
     --arg workItemId "$WORK_ITEM_ID" \
     --arg recipeRunId "$RECIPE_RUN_ID" \
@@ -193,23 +223,13 @@ matches="$(
     --arg workstreamId "$WORKSTREAM_ID" \
     --arg expected_pr_title_prefix "$EXPECTED_PR_TITLE_PREFIX" \
     --arg created_after "$CREATED_AFTER" '
-      def owner_name:
-        (.headRepositoryOwner.login // .headRepositoryOwner.name // .headRepositoryOwner // "");
-      def repo_name:
-        (.headRepository.name // ((.headRepository.nameWithOwner // "") | split("/") | .[-1]) // "");
       def text:
         ((.title // "") + " " + (.body // ""));
       def has_token($token):
         ($token == "") or (text | contains($token));
       [
         .[]
-        | select((.headRefName // "") == $headRefName)
-        | select((.baseRefName // "") == $baseRefName)
         | select(($headRefOid == "") or ((.headRefOid // "") == $headRefOid))
-        | select(($prNumber == "") or (((.number // "") | tostring) == $prNumber))
-        | select(($prUrl == "") or ((.url // "") == $prUrl))
-        | select((.isCrossRepository // false) == false)
-        | select(((owner_name + "/" + repo_name) == $repo))
         | select(($expected_pr_title_prefix == "") or ((.title // "") | startswith($expected_pr_title_prefix)))
         | select(($created_after == "") or ((.createdAt // "") >= $created_after))
         | select(($issueId == "") or (((.number // "") | tostring) == $issueId) or has_token("#" + $issueId) or has_token("issue-" + $issueId))
@@ -218,16 +238,79 @@ matches="$(
         | select(($treeId == "") or has_token($treeId))
         | select(($workstreamId == "") or has_token($workstreamId))
       ]'
-)"
+}
 
-match_count="$(printf '%s' "$matches" | jq 'length')"
-if [ "$match_count" -eq 0 ]; then
-  emit_failure "no_scoped_pr" "no PR matched the explicit workflow scope"
-fi
-if [ "$match_count" -gt 1 ]; then
-  jq -nc --arg reason "multiple_scoped_prs" --argjson candidates "$matches" '{ok:false,reason:$reason,candidates:$candidates}'
+open_candidates() {
+  printf '%s' "$1" | jq -c '[ .[] | select(((.state // "") | ascii_upcase) == "OPEN") ]'
+}
+
+array_length() {
+  printf '%s' "$1" | jq 'length'
+}
+
+emit_multiple_scoped_prs() {
+  jq -nc --arg reason "multiple_scoped_prs" --argjson candidates "$1" '{ok:false,reason:$reason,candidates:$candidates}'
   echo "ERROR: workflow_pr_scope.sh: multiple_scoped_prs: more than one PR matched the explicit workflow scope" >&2
   exit 1
+}
+
+emit_scoped_match() {
+  printf '%s' "$1" | jq -c '.[0] + {ok:true, scoped:true}'
+  exit 0
+}
+
+primary="$(match_by_primary_key "$raw_json")"
+primary_count="$(array_length "$primary")"
+
+if [ "$primary_count" -eq 0 ]; then
+  emit_failure "no_scoped_pr" "no PR matched the explicit workflow scope"
 fi
 
-printf '%s' "$matches" | jq -c '.[0] + {ok:true, scoped:true}'
+if [ -n "$PR_NUMBER" ] || [ -n "$PR_URL" ]; then
+  # Authoritative mode: the explicitly named PR must still satisfy every
+  # historical metadata guard (stale head-sha, title-prefix, issue token, ...).
+  # This preserves the fail-closed contract for a caller-supplied PR identity.
+  matches="$(apply_discriminators "$primary")"
+  match_count="$(array_length "$matches")"
+  if [ "$match_count" -eq 0 ]; then
+    emit_failure "no_scoped_pr" "no PR matched the explicit workflow scope"
+  fi
+  if [ "$match_count" -gt 1 ]; then
+    emit_multiple_scoped_prs "$matches"
+  fi
+  emit_scoped_match "$matches"
+fi
+
+# Discovery mode: (head, base, same-repo, non-cross) is authoritative on its own.
+if [ "$primary_count" -eq 1 ]; then
+  emit_scoped_match "$primary"
+fi
+
+# More than one candidate shares the same head+base (rare open/closed variants).
+# Use the discriminators only to break the tie.
+tie="$(apply_discriminators "$primary")"
+tie_count="$(array_length "$tie")"
+
+if [ "$tie_count" -eq 1 ]; then
+  emit_scoped_match "$tie"
+fi
+
+if [ "$tie_count" -gt 1 ]; then
+  # Prefer a single OPEN candidate; only a genuine >=2-OPEN anomaly fails loud.
+  tie_open="$(open_candidates "$tie")"
+  if [ "$(array_length "$tie_open")" -eq 1 ]; then
+    emit_scoped_match "$tie_open"
+  fi
+  emit_multiple_scoped_prs "$tie"
+fi
+
+# Discriminators eliminated every candidate. Rather than fail closed on the
+# recipe's own PR, prefer the single OPEN candidate under the primary key.
+primary_open="$(open_candidates "$primary")"
+if [ "$(array_length "$primary_open")" -eq 1 ]; then
+  emit_scoped_match "$primary_open"
+fi
+
+# Two or more OPEN PRs share the same head+base: a real GitHub anomaly worth
+# surfacing loudly instead of silently guessing.
+emit_multiple_scoped_prs "$primary"

--- a/amplifier-bundle/tools/workflow_publish_pr.sh
+++ b/amplifier-bundle/tools/workflow_publish_pr.sh
@@ -492,7 +492,18 @@ PR_BODY=$(printf '## Summary\nConcise workflow-generated PR for %s.\n\n## Issue\
 PUBLISH_STATE="FOLLOWUP_CREATED"
 LEGACY_PUBLISH_STATE="create-new-pr"
 if ! PR_URL_RESULT="$(gh_pr_create_with_retry)"; then
-  finish_publish "FAILED_PR_CREATE" "create-pr-failed" "failure" "draft PR creation failed; GitHub API state is ambiguous" 1
+  # Create-collision tolerance (issue #1017): `gh pr create` most often fails
+  # because an OPEN PR for this head->base already exists ("a pull request for
+  # branch already exists"). A TOCTOU window between the initial scoped lookup
+  # and create can hide it. Re-run the (now primary-key) scoped lookup: if an
+  # OPEN PR is now visible, adopt it as existing-open-pr success instead of
+  # hard-failing the whole recipe. Only a genuinely absent PR stays FAILED.
+  RECOVERY_JSON="$(scoped_pr_lookup)"
+  load_pr_fields "$RECOVERY_JSON"
+  if [ -n "$PR_URL_RESULT" ] && [ "$PR_STATE" = "OPEN" ]; then
+    finish_publish "existing-open-pr" "existing-open-pr" "success" "adopted existing open PR after create collision"
+  fi
+  finish_publish "FAILED_PR_CREATE" "create-pr-failed" "failure" "draft PR creation failed and no existing open PR was found for the branch; GitHub API state is ambiguous" 1
 fi
 PR_NUMBER_RESULT="$(printf '%s\n' "$PR_URL_RESULT" | awk -F/ '/\/pull\/[0-9]+/ {print $NF; exit}')"
 finish_publish "$PUBLISH_STATE" "$LEGACY_PUBLISH_STATE" "success" "draft PR created"

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -404,6 +404,13 @@ path = "../../tests/integration/issue_815_804_local_tracking_extract_test.rs"
 name = "issue_815_804_local_tracking_scope_args"
 path = "../../tests/integration/issue_815_804_local_tracking_scope_args_test.rs"
 
+# Issue #1017: PR-scope must match on the (head,base,same-repo) primary key so
+# the recipe adopts its own unique-by-branch PR (stale --issue/--head-sha), and
+# publish must be collision-tolerant (adopt an existing OPEN PR on create fail).
+[[test]]
+name = "pr_scope_primary_key"
+path = "../../tests/integration/pr_scope_primary_key_test.rs"
+
 # Issue #778: merge-ready must be platform-neutral, with explicit GitHub and
 # Azure DevOps/AzDO guidance for every merge-readiness aspect.
 [[test]]

--- a/docs/concepts/scoped-workflow-closure.md
+++ b/docs/concepts/scoped-workflow-closure.md
@@ -28,46 +28,76 @@ the current work against first-class identifiers.
 Current-work identity is never inferred from recency, authorship, broad text
 matching, or a same-user PR list.
 
-The workflow accepts a PR, process, or workstream as current only when it
-matches the persisted scope for the run:
+The workflow's own pull request is identified by a **primary key**: the exact
+`repository + head branch + base branch` tuple, restricted to same-repository
+(non-fork, non-cross-repository) PRs. GitHub allows only one OPEN pull request
+per `head → base` within a repository, so this tuple is already unique for the
+workflow's PR:
 
 ```text
-repository + head branch + base branch + PR/tracking item + recipe/workstream + start time
+repository + head branch + base branch  (same-repository, not cross-repo)
 ```
 
-Missing scope is not a soft match. It is display-only history.
+Tracking discriminators — PR/issue/work-item token, recipe/workstream id, title
+prefix, start time, and head SHA — are **tie-breakers**. They resolve the rare
+case of multiple candidates (for example, an OPEN and a previously CLOSED PR on
+the same head and base). A stale or drifted discriminator never rejects the
+unique primary-key PR.
+
+For processes and workstreams the persisted scope still requires the full
+identity tuple:
+
+```text
+repository + workdir + branch + recipe/workstream + start time + process marker
+```
+
+Missing primary-key scope is not a soft match. It is display-only history.
 
 ## PR Scope
 
-PR scope identifies the pull request owned by the current workflow. The
-authoritative fields are:
+PR scope identifies the pull request owned by the current workflow. The fields
+divide into the primary key and the tie-breakers:
 
-| Scope field | Purpose |
-| --- | --- |
-| `repository` | Exact GitHub repository owner/name. |
-| `head_ref` | Exact PR branch expected for the workflow. |
-| `base_ref` | Exact target branch. |
-| `pr_number` or `pr_url` | Concrete PR identity when already known. |
-| `issue_number` or `work_item_id` | Tracking item that the PR is expected to close or reference. |
-| `expected_pr_title_prefix` | Deterministic title prefix when the PR has not been persisted yet. |
-| `created_after` | Run start time; older PRs are rejected. |
-| `head_sha` | Exact head SHA required for readiness, final status, and no-op success paths. |
+| Scope field | Role | Purpose |
+| --- | --- | --- |
+| `repository` | Primary key | Exact GitHub repository owner/name (same-repo only). |
+| `head_ref` | Primary key | Exact PR branch expected for the workflow. |
+| `base_ref` | Primary key | Exact target branch. |
+| `pr_number` or `pr_url` | Authoritative override | Concrete PR identity when already known; bypasses primary-key and tie-breaker resolution. |
+| `issue_number` or `work_item_id` | Tie-breaker | Tracking item the PR is expected to close or reference. |
+| `expected_pr_title_prefix` | Tie-breaker | Deterministic title prefix. |
+| `created_after` | Tie-breaker | Run start time; used to discard older candidates. |
+| `head_sha` | Tie-breaker | Exact head SHA for exact-head operations. |
 
 The shell helper `workflow_pr_scope.sh` is the single authority for current-work
 PR ownership. `workflow_publish_pr.sh`, `workflow_pr_ready.sh`, and
 `workflow_final_status.sh` call it before mutating or reporting PR state.
 
-Persisted PR identity has priority. If the workflow already knows `pr_number` or
-`pr_url`, the helper validates that concrete PR first and rejects any mismatch.
-Scoped lookup is allowed only when concrete PR identity has not been persisted,
-and it must use exact repository, head branch, base branch, start time, and a
-tracking discriminator such as issue, work item, or title prefix. The helper
-never falls back to recent PRs, PR author, or broad title/body search.
+Persisted PR identity has priority: a known `pr_number` or `pr_url` is
+authoritative and validated directly. Otherwise the helper resolves the primary
+key. A single primary-key candidate is adopted as-is — no issue token, head SHA,
+or title prefix is additionally required. Tie-breakers apply only when more than
+one candidate shares the same head and base; if they eliminate everything but one
+OPEN candidate remains, that candidate is adopted. OPEN is always preferred over
+closed. The helper never falls back to recent PRs, PR author, or broad
+title/body search.
+
+This is why the workflow reliably adopts its own PR even when the branch bakes in
+a local tracking issue (`feat/issue-1014-...`) while the PR body references a
+different upstream issue (`#4610`), or when the remote head advances past the
+locally captured SHA. The unique `(head, base, same-repo)` PR is matched;
+the stale discriminators are ignored rather than treated as hard rejections.
 
 Cross-repository and fork PRs are rejected by default. A workflow that starts in
 `rysweet/amplihack-rs` may close only a PR whose base repository and head
 repository both match `rysweet/amplihack-rs`, unless a future recipe explicitly
 opts into a narrower fork policy.
+
+When publishing, `workflow_publish_pr.sh` is collision-tolerant: if
+`gh pr create` fails because a PR already exists for the branch, the helper
+re-runs the scoped lookup and adopts the existing OPEN PR as an `existing-open-pr`
+success instead of hard-failing the recipe. Only a genuinely absent PR combined
+with a failed create is reported as `FAILED_PR_CREATE`.
 
 ## Process Scope
 
@@ -102,8 +132,8 @@ Common invalid reasons:
 | Reason | Meaning |
 | --- | --- |
 | `missing_scope` | The persisted state predates scoped closure fields. |
-| `no_scoped_pr` | No PR matches the explicit workflow scope. |
-| `multiple_scoped_prs` | The scope is not specific enough to identify one PR. |
+| `no_scoped_pr` | No PR matches the primary key (repository, head, base). This is an empty result, not a stale-discriminator rejection. |
+| `multiple_scoped_prs` | Two or more OPEN candidates share the same head and base and survive tie-breaking. |
 | `repo_mismatch` | Repository differs from the current workflow. |
 | `workdir_mismatch` | Work directory differs from persisted process scope. |
 | `branch_mismatch` | Branch or head ref differs from scope. |

--- a/docs/howto/configure-scoped-workflow-closure.md
+++ b/docs/howto/configure-scoped-workflow-closure.md
@@ -12,7 +12,8 @@ You need:
 - a writable checkout of the target repository
 - the branch that the workflow owns
 - the target base branch
-- the issue number or work item id for the task
+- optionally, the issue number or work item id for the task (used as a
+  tie-breaker and for PR body linkage, not required to match a unique PR)
 - `gh auth status` working when the repository is hosted on GitHub
 - `amplihack` and the bundled `amplifier-bundle/tools/` files available
 
@@ -89,9 +90,28 @@ amplifier-bundle/tools/workflow_pr_scope.sh \
 The command prints a `valid` JSON object only when the PR belongs to this exact
 workflow scope.
 
-Known PR identity takes precedence after it is persisted. If `PR_NUMBER` or
-`PR_URL` conflicts with the repository, head branch, base branch, issue, or head
-SHA, scoped validation fails instead of searching for another PR.
+Known PR identity takes precedence after it is persisted. A supplied
+`PR_NUMBER` or `PR_URL` is authoritative: the helper inspects that exact PR and
+short-circuits the primary-key and tie-breaker passes. Validation fails only if
+the PR disagrees on repository, head branch, or base branch. A stale `--issue`
+or `--head-sha` does not reject an otherwise-matching PR — those are tie-breakers,
+not part of the authoritative match.
+
+If no PR identity is persisted yet, you can omit `--pr-number`/`--pr-url` and let
+the primary key `--repo` + `--head` + `--base` resolve the workflow's unique PR:
+
+```bash
+amplifier-bundle/tools/workflow_pr_scope.sh \
+  --repo "$REPOSITORY" \
+  --head "$BRANCH" \
+  --base "$BASE_REF" \
+  --created-after "$STARTED_AT" \
+  --issue "$ISSUE_NUMBER"
+```
+
+The `--issue` value is used only to break ties if more than one candidate shares
+the head and base. A single primary-key candidate is adopted even when the branch
+tracking issue differs from the issue referenced in the PR body.
 
 ## 4. Check Readiness
 
@@ -155,11 +175,12 @@ and head repository must both match `REPOSITORY`.
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `no_scoped_pr` | No PR matches the exact repository, branch, base, and start time. | Pass the known `pr_number` or correct the branch/base/start time. |
-| `multiple_scoped_prs` | Scope is not specific enough. | Add `pr_number`, `pr_url`, `issue_number`, `work_item_id`, or `expected_pr_title_prefix`. |
+| `no_scoped_pr` | No PR matches the primary key (repository, head, base). | Verify the branch was pushed and a PR exists for `head → base`; correct the `--head`/`--base` values. A stale `--issue`/`--head-sha` is not the cause — those no longer reject a unique PR. |
+| `multiple_scoped_prs` | Two or more OPEN PRs share the same head and base. | Add `pr_number` or `pr_url`, or make a tie-breaker (`issue_number`, `work_item_id`, `expected_pr_title_prefix`) distinguish them. |
 | `branch_mismatch` | The PR head ref differs from the workflow branch. | Use the branch attached to the PR or block the workflow until branch ownership is resolved. |
 | `invalid_pr_url` | The provided PR URL is not a GitHub pull request URL. | Correct the persisted PR URL before readiness/final-status steps. |
 | `invalid_pr_number` | The provided PR number is not positive numeric text. | Correct the persisted PR number. |
+| `FAILED_PR_CREATE` on publish | `gh pr create` failed and no OPEN PR exists for the branch. | Inspect the redacted GitHub error; a genuine create failure (auth, protected branch) must be resolved. A create collision with an existing OPEN PR is handled automatically as `existing-open-pr`. |
 | `missing_scope` | Persisted multitask state predates scoped fields. | Treat the record as display-only; relaunch the workstream to capture scope. |
 | `pid_reused` | The PID exists but start metadata differs. | Ignore the old record; relaunch the workstream if work is still needed. |
 | `repo_mismatch` or `workdir_mismatch` | State belongs to another checkout or worktree. | Run the monitor from the owning worktree or discard stale state. |

--- a/docs/operations/workflow-resilience.md
+++ b/docs/operations/workflow-resilience.md
@@ -55,6 +55,13 @@ The recipe must check branch diff and PR state before publishing. It never creat
 empty PR and never creates a second PR for the same live branch when an open or
 merged PR already exists.
 
+Publishing is also collision-tolerant at create time. If `gh pr create` fails
+because a pull request already exists for the branch (a race with the pre-create
+check, or a stale local view), `workflow-publish` re-runs the scoped PR lookup;
+when an OPEN PR now exists it returns `state=existing-open-pr` success rather than
+`FAILED_PR_CREATE`. Only a genuinely absent PR combined with a failed create is a
+hard failure.
+
 Closed-unmerged PRs with remaining branch diff are a hard failure. The workflow
 must not silently republish, mark them complete, or hide the fact that user
 action is required.

--- a/docs/recipes/issue-815-804-local-tracking-issue-number.md
+++ b/docs/recipes/issue-815-804-local-tracking-issue-number.md
@@ -60,9 +60,12 @@ valid tracking identifier without numeric parsing."*
 Because `issue_number` can now legitimately carry a non-numeric local
 reference, `workflow-terminal-state` coerces a non-numeric value to empty
 before passing `--issue` / `--work-item` to `workflow_pr_scope.sh`. PR-scope
-matching only understands numeric GitHub issue / AzDO work-item ids, so a local
-reference must never filter out the legitimate current-work PR (which would
-otherwise surface as `no_scoped_pr`).
+matching resolves the current-work PR by its primary key
+(`repository + head + base`, same-repo), and `--issue` / `--work-item` act only
+as tie-breakers among multiple candidates — so a local reference can never
+filter out the legitimate current-work PR. Coercing the non-numeric value to
+empty keeps the tie-breaker inputs clean and avoids passing a value the matcher
+does not interpret as a GitHub issue / AzDO work-item id.
 
 ## Behavior summary
 

--- a/docs/reference/scoped-workflow-closure.md
+++ b/docs/reference/scoped-workflow-closure.md
@@ -36,7 +36,7 @@ publish, readiness, final-status, and multitask monitor steps.
 | `issue_number` | integer or numeric string | Required when the workflow is issue-backed | GitHub issue expected in PR metadata or closing references. |
 | `work_item_id` | string | Required when the workflow is work-item-backed | Non-GitHub work item expected in PR metadata. |
 | `expected_pr_title_prefix` | string | Required for title-based candidate lookup | Prefix that newly created workflow PRs must use. |
-| `created_after` | RFC 3339 timestamp | Yes | Workflow start time. Older PRs are rejected. |
+| `created_after` | RFC 3339 timestamp | Recorded for tie-breaking | Workflow start time. Discards older candidates only when disambiguating multiple primary-key matches; never rejects the sole primary-key PR. |
 | `head_sha` | full Git SHA | Required for readiness, final status, and exact-head no-op paths | PR head SHA that must match before scoped success is reported. |
 | `recipe_run_id` | string | Required for multitask monitor authority | Unique recipe run id. |
 | `tree_id` | string | Required for nested recipe authority | Recipe execution tree id. |
@@ -44,11 +44,22 @@ publish, readiness, final-status, and multitask monitor steps.
 
 Known PR identity is authoritative when present. If `pr_number` or `pr_url` is
 known, validators check that concrete PR first and fail closed on mismatch.
-Scoped lookup without a known PR requires the exact tuple
-`repository + head_ref + base_ref + created_after` plus at least one tracking
-discriminator: `issue_number`, `work_item_id`, or `expected_pr_title_prefix`.
-`head_sha` narrows the candidate for exact-head operations; it never
-broadens a match.
+
+Scoped lookup without a known PR resolves against a **primary key** — the exact
+tuple `repository + head_ref + base_ref` restricted to same-repository,
+non-cross-repository PRs. GitHub permits only one OPEN pull request per
+`head → base` within a repository, so this tuple already uniquely identifies the
+workflow's own PR. When the primary key yields exactly one candidate, it is
+adopted as current work without requiring any additional discriminator.
+
+`issue_number`, `work_item_id`, `expected_pr_title_prefix`, `created_after`, and
+`head_sha` are **tie-breakers**. They are applied only when the primary key
+returns more than one candidate (for example, when open and closed PRs share the
+same head and base). A tie-breaker narrows an ambiguous candidate set; it never
+hard-rejects the sole primary-key candidate. If tie-breakers eliminate every
+candidate but exactly one OPEN candidate exists, that OPEN candidate is adopted
+rather than returning `no_scoped_pr`. OPEN candidates are always preferred over
+closed candidates when state varies at any resolution step.
 
 ## Environment Inputs
 
@@ -68,16 +79,20 @@ validation.
 
 | Operation | Required identity |
 | --- | --- |
-| Publish a new PR | `repository`, `head_ref`, `base_ref`, `created_after`, and `issue_number`, `work_item_id`, or `expected_pr_title_prefix`. |
+| Publish a new PR | `repository`, `head_ref`, `base_ref`, and `created_after`. `issue_number`, `work_item_id`, or `expected_pr_title_prefix` are recorded for tie-breaking and PR body linkage. |
 | Update or resume a known PR | `pr_number` or `pr_url`, plus `repository`, `head_ref`, `base_ref`, and `created_after`. |
-| Lookup a PR before identity is persisted | `repository`, `head_ref`, `base_ref`, `created_after`, and at least one of `issue_number`, `work_item_id`, or `expected_pr_title_prefix`. |
+| Lookup a PR before identity is persisted | `repository`, `head_ref`, and `base_ref` (the primary key). Tracking discriminators are optional and used only to break ties. |
 | Check readiness | Known PR identity plus `repository`, `head_ref`, `base_ref`, `created_after`, and `head_sha`. |
 | Report final status | Known PR identity plus `repository`, `head_ref`, `base_ref`, `created_after`, and `head_sha`. |
 | Validate a workstream process | `repo_path`, `workdir`, `branch`, `base_ref`, `recipe_run_id`, `tree_id`, `workstream_id`, `started_at`, `pid`, and process start metadata. |
 
-Issue and work-item fields are mandatory when the workflow was launched from
-that tracking system. Title-prefix lookup is a bootstrap path for newly created
-PRs; it is not a replacement for persisted PR identity after publish succeeds.
+The primary-key lookup (`repository + head_ref + base_ref`, same-repository) is
+sufficient to identify the workflow's own PR because GitHub allows only one OPEN
+PR per `head → base`. Tracking discriminators (`issue_number`, `work_item_id`,
+`expected_pr_title_prefix`) and `head_sha` are tie-breakers for the rare case of
+multiple candidates on the same head and base; they are not required to adopt a
+unique candidate, and a stale or mismatched discriminator never rejects the sole
+primary-key candidate.
 
 ## PR Scope Persistence
 
@@ -104,12 +119,19 @@ recipes validate a persisted `pr_number` or `pr_url` first when either exists.
 
 Precedence:
 
-1. Validate persisted `number` and `url` when either exists.
-2. If no concrete PR identity exists, perform scoped lookup using repository,
-   head branch, base branch, start time, and tracking discriminator.
-3. Reject mismatches; do not replace persisted identity with a recent, same-author,
-   or broad-text candidate.
-4. Persist the concrete PR identity immediately after publish succeeds.
+1. Validate persisted `number` and `url` when either exists (authoritative
+   override — this short-circuits above the primary key).
+2. If no concrete PR identity exists, resolve the primary key
+   `repository + head_ref + base_ref` (same-repository, non-cross-repository).
+   A single primary-key candidate is adopted directly.
+3. If more than one primary-key candidate exists, apply tracking discriminators
+   and `head_sha` as tie-breakers, preferring OPEN over closed. If tie-breakers
+   eliminate all candidates but one OPEN candidate remains, adopt it.
+4. Reject only genuine mismatches (different head branch, cross-repository, or an
+   authoritative `pr_number`/`pr_url` that disagrees). Do not reject the sole
+   primary-key candidate because a stale `issue_number` or `head_sha` no longer
+   matches.
+5. Persist the concrete PR identity immediately after publish succeeds.
 
 ## PR Scope Helper
 
@@ -142,17 +164,28 @@ amplifier-bundle/tools/workflow_pr_scope.sh \
 
 Rules:
 
-1. `--repo`, `--head`, `--base`, and `--created-after` are exact match
-   fields.
-2. `--pr-number` and `--pr-url` must identify the same repository and PR.
-3. `--expected-pr-title-prefix` is a prefix check, not a substring search.
-4. `--issue` and `--work-item` match structured closing/reference
-   fields or exact workflow metadata. They do not run broad text grep.
-5. `--head-sha` must equal the PR head SHA when supplied.
+1. `--repo`, `--head`, and `--base` form the **primary key**. Combined with the
+   same-repository / non-cross-repository guard, they are exact-match fields.
+2. `--pr-number` and `--pr-url` are an authoritative override: when supplied they
+   identify the PR directly and short-circuit the primary-key and tie-breaker
+   passes. They must identify the same repository and PR.
+3. When the primary key returns exactly one candidate, the helper returns it
+   without consulting any tie-breaker.
+4. `--issue`, `--work-item`, `--expected-pr-title-prefix`, `--created-after`, and
+   `--head-sha` are **tie-breakers**. They are consulted only when the primary
+   key returns more than one candidate. `--expected-pr-title-prefix` is a prefix
+   check; `--issue` and `--work-item` match structured closing/reference fields
+   or exact workflow metadata (never a broad text grep); `--head-sha` compares
+   the PR head SHA; `--created-after` rejects candidates created before the run.
+5. A stale or mismatched tie-breaker never rejects the sole primary-key
+   candidate. When tie-breakers eliminate every candidate but exactly one OPEN
+   candidate exists, that OPEN candidate is returned. OPEN candidates are
+   preferred over closed candidates at every step.
 6. The PR base repository and head repository must match `--repo` by default;
-   fork and cross-repository PRs exit with `cross_repo_pr`.
-7. Zero candidates, multiple candidates, stale candidates, and mismatches exit
-   non-zero with structured JSON.
+   fork and cross-repository PRs are rejected during the primary-key pass.
+7. A PR on a different head branch is never matched. Zero primary-key candidates
+   exit non-zero with `no_scoped_pr`; two or more OPEN candidates that survive
+   tie-breaking exit non-zero with `multiple_scoped_prs`.
 8. The helper never falls back to `gh pr list --author @me`, recent PR ordering,
    or broad title/body grep.
 
@@ -186,7 +219,28 @@ Invalid validation prints JSON and exits non-zero:
 The `reason` value is stable and intended for recipes, shell tests, and monitor
 checks. Human-readable `message` text is diagnostic only.
 
-## Multitask State Fields
+## PR Scope Resolution Passes
+
+`workflow_pr_scope.sh` resolves the current-work PR through ordered passes. The
+first pass that produces a single result wins.
+
+| Pass | Condition | Behavior |
+| --- | --- | --- |
+| Authoritative override | `--pr-number` or `--pr-url` supplied | Inspect that exact PR. Return it on match; fail closed on mismatch. Skips the remaining passes. |
+| Primary key | No authoritative override | Filter to `headRefName == --head AND baseRefName == --base AND isCrossRepository == false AND owner/name == --repo`. |
+| Single primary-key candidate | Primary key returns exactly one | Return it as `ok: true`. No tie-breaker is consulted. |
+| Tie-breakers | Primary key returns two or more | Apply `--issue`, `--work-item`, `--expected-pr-title-prefix`, `--created-after`, `--head-sha`, preferring OPEN over closed. |
+| Single-OPEN fallback | Tie-breakers eliminate all, one OPEN remains | Return that OPEN candidate rather than `no_scoped_pr`. |
+| Loud ambiguity | Two or more OPEN candidates survive | Exit non-zero with `multiple_scoped_prs`. |
+| Empty | Primary key returns zero | Exit non-zero with `no_scoped_pr`. |
+
+Safety invariants that hold across all passes:
+
+- A PR on a different `headRefName` is never matched.
+- `isCrossRepository == true` and fork PRs are rejected in the primary-key pass.
+- The head/base equality check is part of the primary key, never a tie-breaker.
+- All GitHub stderr is routed through URL-credential redaction and length-capped
+  before it appears in any diagnostic output.
 
 `WorkstreamState` persists logical workflow scope and concrete process scope.
 Missing fields deserialize successfully so old state files remain readable.
@@ -309,7 +363,7 @@ Rust enum names are internal. CLI and JSON output serializes validation reasons
 as snake_case.
 
 | Rust outcome | Serialized reason | Authoritative | Meaning |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `Valid` | `valid` | Yes | Persisted state, current workflow scope, and runtime snapshot match. |
 | `MissingScope` | `missing_scope` | No | Old state lacks required scope fields. |
 | `Dead` | `dead` | No | PID is not running. |
@@ -328,7 +382,7 @@ These bundled tools and recipes use scoped validation:
 
 | Component | Contract |
 | --- | --- |
-| `workflow_publish_pr.sh` | Persists PR identity after creation and validates known PR identity before updating an existing PR. |
+| `workflow_publish_pr.sh` | Persists PR identity after creation and validates known PR identity before updating an existing PR. On `gh pr create` collision, re-runs the scoped lookup and adopts an existing OPEN PR as `existing-open-pr` success instead of failing the recipe. |
 | `workflow_pr_ready.sh` | Refuses readiness checks until `workflow_pr_scope.sh` returns `ok: true`. |
 | `workflow_final_status.sh` | Requires validated PR metadata before reporting terminal PR status. |
 | `workflow-terminal-state.yaml` | Uses persisted PR URL or number, then scoped lookup; no recent-PR fallback. |
@@ -339,12 +393,19 @@ These bundled tools and recipes use scoped validation:
 
 ## Failure Semantics
 
-Scoped closure fails closed:
+Scoped closure fails closed, but a stale tracking discriminator is not a
+failure:
 
-- missing PR scope blocks publish/readiness/final-status current-work claims
+- missing primary-key scope (repository, head, base) blocks
+  publish/readiness/final-status current-work claims
 - unrelated PRs are ignored even when newer or authored by the same account
+- a PR on a different head branch is never adopted
 - cross-repository and fork PRs are rejected by default
-- multiple scoped PR candidates block until scope is made more specific
+- two or more OPEN candidates on the same head and base block with
+  `multiple_scoped_prs` until scope is made more specific
+- a stale `issue_number` or `head_sha` does **not** reject the unique
+  primary-key PR; those fields only break ties among multiple candidates
+- `no_scoped_pr` is reserved for a genuinely empty primary-key result
 - stale process records are display-only
 - PID reuse is rejected when runtime start metadata differs
 - missing runtime start metadata is rejected as incomplete process scope
@@ -360,6 +421,7 @@ The regression suite covers these contracts:
 
 ```bash
 cargo test -p amplihack-cli --test issue_754_scoped_monitor_contracts
+cargo test -p amplihack-cli --test pr_scope_primary_key_test
 
 amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh \
   scoped-pr-identity
@@ -369,10 +431,14 @@ Representative checks:
 
 | Check | Expected result |
 | --- | --- |
+| unique branch/base PR with a stale `--issue` and `--head-sha` | helper adopts it with `ok: true` |
+| PR body references a different upstream issue than the branch tracking issue | helper still adopts it (`ok: true`) |
 | newer unrelated PR exists for same author | scoped helper rejects it |
-| zero matching PRs | helper exits non-zero with `no_scoped_pr` |
-| two matching branch/base candidates | helper exits non-zero with `multiple_scoped_prs` |
-| fork or cross-repository PR candidate | helper rejects it during scoped filtering |
+| PR on a different head branch | helper never matches it |
+| zero primary-key candidates | helper exits non-zero with `no_scoped_pr` |
+| two or more OPEN candidates on the same head and base | helper exits non-zero with `multiple_scoped_prs` |
+| fork or cross-repository PR candidate | helper rejects it during the primary-key pass |
+| `gh pr create` collides with an existing OPEN PR | publish returns `existing-open-pr` success (exit 0), not `FAILED_PR_CREATE` |
 | persisted legacy workstream lacks scope | monitor marks display-only and does not notify |
 | persisted PID is dead | validation returns `dead` |
 | PID exists with different start marker | validation returns `pid_reused` |

--- a/docs/tutorials/scoped-workflow-closure.md
+++ b/docs/tutorials/scoped-workflow-closure.md
@@ -100,9 +100,29 @@ Valid output looks like this:
 If PR 813 is newer but uses `feat/unrelated-work`, the helper rejects it as
 `branch_mismatch`. The newer PR is not current work.
 
-If the persisted `PR_NUMBER` or `PR_URL` points at a different repository,
-branch, base, issue, or head SHA, validation fails. It does not search for a
-different same-author or recent PR.
+A supplied `PR_NUMBER` or `PR_URL` is authoritative: the helper inspects that
+exact PR and fails only if it disagrees on repository, head branch, or base
+branch. A stale `--issue` or `--head-sha` does not cause a rejection — they are
+tie-breakers, not part of the authoritative match. This is what lets the workflow
+adopt its own PR when the branch tracking issue (`feat/issue-754-...`) differs
+from the upstream issue referenced in the PR body, or when the remote head has
+advanced past the locally captured SHA.
+
+Before PR identity is persisted, the primary key alone resolves the PR:
+
+```bash
+amplifier-bundle/tools/workflow_pr_scope.sh \
+  --repo "$REPOSITORY" \
+  --head "$BRANCH" \
+  --base "$BASE_REF" \
+  --issue "$ISSUE_NUMBER" \
+  --head-sha "$STALE_LOCAL_SHA"
+```
+
+Because `(repository, head, base)` is unique for an OPEN PR, the helper returns
+`ok: true` for the workflow's PR even though `--head-sha` no longer matches the
+advanced remote head. `--issue` and `--head-sha` would only be consulted if two
+candidates shared the same head and base.
 
 ## Step 4: Observe Stale Process Rejection
 
@@ -167,6 +187,7 @@ Scoped closure produces one of these outcomes:
 | Outcome | Meaning |
 | --- | --- |
 | `valid` | The PR or process belongs to the current workflow. |
+| `existing-open-pr` | Publish found the workflow's PR already open (create collision) and adopted it as success instead of failing. |
 | `blocked` | Required current-work scope is missing or mismatched. |
 | `display-only` | State is readable for diagnostics but cannot notify or close. |
 | `not_authoritative` | A candidate exists but fails one or more scope checks. |

--- a/tests/integration/pr_scope_primary_key_test.rs
+++ b/tests/integration/pr_scope_primary_key_test.rs
@@ -1,0 +1,529 @@
+//! TDD (red) contracts for the PR-scope primary-key fix (default-workflow
+//! finalize false-failure, issue #1017).
+//!
+//! `workflow_pr_scope.sh` currently AND-joins every scope discriminator
+//! (`--issue`, `--head-sha`, `--expected-pr-title-prefix`, ...) on top of the
+//! head/base identity. That converts a reliable lookup into one that fails
+//! closed: the recipe's OWN unique-by-branch PR (e.g. #1015) is rejected with
+//! `no_scoped_pr` whenever the PR body references the UPSTREAM issue instead of
+//! the branch's LOCAL tracking issue, or whenever the remote head advanced past
+//! the captured `--head-sha`. The publish step then falls through to
+//! `gh pr create`, collides ("a pull request for branch already exists"), and
+//! hard-fails the whole recipe.
+//!
+//! These tests specify the required behavior BEFORE implementation:
+//!   * `(headRefName, baseRefName, same-repo, non-cross-repo)` is the PRIMARY
+//!     key. A single primary candidate is adopted even when `--issue` /
+//!     `--head-sha` / `--expected-pr-title-prefix` do NOT match.
+//!   * discriminators act only as TIE-BREAKERS when >1 candidate shares the
+//!     same head+base; if they zero out but >=2 OPEN candidates remain, the
+//!     loud `multiple_scoped_prs` failure is preserved.
+//!   * a PR on a DIFFERENT head branch is NEVER matched (safety invariant).
+//!   * `workflow_publish_pr.sh` is collision-tolerant: when `gh pr create`
+//!     fails but an OPEN PR now exists for the branch, publish adopts it as
+//!     `existing-open-pr` / success (exit 0) instead of `FAILED_PR_CREATE`.
+//!
+//! All harnesses inject a stub `gh` on PATH (mirroring
+//! `issue_815_804_local_tracking_scope_args_test.rs` and
+//! `workflow_publish_resilience.rs`) so no real GitHub token is required.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // bins/amplihack -> bins
+    p.pop(); // bins -> workspace root
+    p
+}
+
+fn helper_path(name: &str) -> PathBuf {
+    workspace_root().join("amplifier-bundle/tools").join(name)
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .status()
+        .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+    assert!(status.success(), "git {args:?} failed");
+}
+
+/// The PR-scope helper only needs `command -v gh` to succeed plus a JSON array
+/// on stdout for `gh pr list`. This stub emits the canned candidate list from
+/// `$STUB_PR_LIST_JSON` and is a no-op for anything else.
+fn write_list_stub_gh(bin_dir: &Path, list_json: &Path) {
+    fs::create_dir_all(bin_dir).expect("create bin dir");
+    let gh = bin_dir.join("gh");
+    fs::write(
+        &gh,
+        format!(
+            "#!/usr/bin/env bash\nset -uo pipefail\nsub=\"${{1:-}} ${{2:-}}\"\ncase \"$sub\" in\n  \"pr list\") cat {list:?} ;;\n  *) exit 0 ;;\nesac\n",
+            list = list_json.display().to_string()
+        ),
+    )
+    .expect("write gh stub");
+    make_executable(&gh);
+}
+
+/// Run `workflow_pr_scope.sh` with the stub `gh` on PATH. Returns (stdout,
+/// success). No git repo is required: `--repo/--head/--base/--head-sha` are all
+/// passed explicitly.
+fn run_scope(dir: &Path, bin_dir: &Path, args: &[&str]) -> (String, bool) {
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let output = Command::new("bash")
+        .arg(helper_path("workflow_pr_scope.sh"))
+        .args(args)
+        .current_dir(dir)
+        .env("PATH", format!("{}:{old_path}", bin_dir.display()))
+        .output()
+        .expect("run workflow_pr_scope.sh");
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        output.status.success(),
+    )
+}
+
+/// The stale local head-sha the recipe captured before the remote branch
+/// advanced. Deliberately different from every candidate's `headRefOid`.
+const STALE_HEAD_SHA: &str = "2222222222222222222222222222222222222222";
+
+// ---------------------------------------------------------------------------
+// Case (a): #1015 adoption despite stale --issue + --head-sha + title-prefix.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adopts_own_unique_branch_pr_despite_stale_issue_head_sha_and_title_prefix() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = tmp.path().join("bin");
+
+    // The #1015 shape: OPEN, unique by (head,base), title does NOT start with
+    // the default "Update" prefix, body references only the UPSTREAM issue
+    // (#4610), and headRefOid differs from the recipe's captured --head-sha.
+    let list = tmp.path().join("candidates.json");
+    fs::write(
+        &list,
+        r#"[
+          {
+            "number": 1015,
+            "title": "Verus Phase-1 proof scaffolding",
+            "body": "Closes #4610\nRelates to #4610\nUpstream tracking: #4610",
+            "state": "OPEN",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "mergedAt": null,
+            "url": "https://github.com/owner/repo/pull/1015",
+            "headRefName": "feat/issue-1014-verus-phase1",
+            "baseRefName": "main",
+            "headRefOid": "1111111111111111111111111111111111111111",
+            "headRepositoryOwner": {"login": "owner"},
+            "headRepository": {"name": "repo"},
+            "isCrossRepository": false,
+            "isDraft": true
+          }
+        ]"#,
+    )
+    .expect("write candidates");
+    write_list_stub_gh(&bin_dir, &list);
+
+    let (stdout, ok) = run_scope(
+        tmp.path(),
+        &bin_dir,
+        &[
+            "--repo",
+            "owner/repo",
+            "--head",
+            "feat/issue-1014-verus-phase1",
+            "--base",
+            "main",
+            "--issue",
+            "1014",
+            "--work-item",
+            "1014",
+            "--expected-pr-title-prefix",
+            "Update",
+            "--head-sha",
+            STALE_HEAD_SHA,
+        ],
+    );
+
+    assert!(
+        ok,
+        "scope must exit 0 when a single primary (head,base,same-repo) candidate exists; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"ok\":true") && stdout.contains("\"scoped\":true"),
+        "the recipe's own unique-by-branch PR must be adopted (ok:true) even when --issue/--head-sha/--expected-pr-title-prefix do not match; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"number\":1015"),
+        "the adopted PR must be #1015, not a re-derived candidate; stdout:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case (b): regression — body references a DIFFERENT upstream issue than the
+// branch tracking issue, AND the remote head-sha differs. Still adopted.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adopts_pr_whose_body_references_a_different_upstream_issue() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = tmp.path().join("bin");
+
+    let list = tmp.path().join("candidates.json");
+    fs::write(
+        &list,
+        r#"[
+          {
+            "number": 4242,
+            "title": "Update workflow recipes with 3 changed files (#4610)",
+            "body": "Closes #4610\nThis addresses upstream issue #4610 only.",
+            "state": "OPEN",
+            "createdAt": "2024-02-02T00:00:00Z",
+            "mergedAt": null,
+            "url": "https://github.com/owner/repo/pull/4242",
+            "headRefName": "feat/issue-1014-tracking",
+            "baseRefName": "main",
+            "headRefOid": "1111111111111111111111111111111111111111",
+            "headRepositoryOwner": {"login": "owner"},
+            "headRepository": {"name": "repo"},
+            "isCrossRepository": false,
+            "isDraft": true
+          }
+        ]"#,
+    )
+    .expect("write candidates");
+    write_list_stub_gh(&bin_dir, &list);
+
+    let (stdout, ok) = run_scope(
+        tmp.path(),
+        &bin_dir,
+        &[
+            "--repo",
+            "owner/repo",
+            "--head",
+            "feat/issue-1014-tracking",
+            "--base",
+            "main",
+            // Local tracking issue 1014 appears NOWHERE in the PR text.
+            "--issue",
+            "1014",
+            "--work-item",
+            "1014",
+            // Remote head advanced past the captured sha.
+            "--head-sha",
+            STALE_HEAD_SHA,
+        ],
+    );
+
+    assert!(
+        ok,
+        "scope must adopt the sole primary candidate even when the branch's local tracking issue (#1014) is absent from PR text and the head-sha is stale; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"ok\":true") && stdout.contains("\"number\":4242"),
+        "the #1015-class PR (upstream-only issue reference + stale head) must remain adopted; stdout:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case (d): NEGATIVE safety invariant — a PR on a DIFFERENT head branch must
+// NEVER be matched, no matter what discriminators are supplied.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn never_matches_a_pr_on_a_different_head_branch() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = tmp.path().join("bin");
+
+    // Candidate is OPEN, same base/repo, and its body even contains the issue
+    // token — but it lives on an UNRELATED head branch.
+    let list = tmp.path().join("candidates.json");
+    fs::write(
+        &list,
+        r#"[
+          {
+            "number": 9001,
+            "title": "Update something (#1014)",
+            "body": "Closes #1014\nissue-1014",
+            "state": "OPEN",
+            "createdAt": "2024-03-03T00:00:00Z",
+            "mergedAt": null,
+            "url": "https://github.com/owner/repo/pull/9001",
+            "headRefName": "some-other-unrelated-branch",
+            "baseRefName": "main",
+            "headRefOid": "1111111111111111111111111111111111111111",
+            "headRepositoryOwner": {"login": "owner"},
+            "headRepository": {"name": "repo"},
+            "isCrossRepository": false,
+            "isDraft": true
+          }
+        ]"#,
+    )
+    .expect("write candidates");
+    write_list_stub_gh(&bin_dir, &list);
+
+    let (stdout, ok) = run_scope(
+        tmp.path(),
+        &bin_dir,
+        &[
+            "--repo",
+            "owner/repo",
+            "--head",
+            "feat/issue-1014-verus-phase1",
+            "--base",
+            "main",
+            "--issue",
+            "1014",
+        ],
+    );
+
+    assert!(
+        !ok,
+        "a PR on a different head branch must never be adopted; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"reason\":\"no_scoped_pr\""),
+        "different-head candidate must yield no_scoped_pr, never a match; stdout:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case (e): >=2 OPEN candidates on the same head+base, discriminators zero out
+// -> the loud `multiple_scoped_prs` failure is preserved (genuine ambiguity).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn preserves_multiple_scoped_prs_when_two_open_candidates_remain() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = tmp.path().join("bin");
+
+    // Two OPEN PRs share the same head+base+repo (a GitHub anomaly). Neither
+    // body carries the local issue token, both head-shas are stale, and neither
+    // title starts with "Update" — so every discriminator zeroes out. With >=2
+    // OPEN candidates remaining, the resolver must fail loudly, not guess.
+    let list = tmp.path().join("candidates.json");
+    fs::write(
+        &list,
+        r#"[
+          {
+            "number": 5001,
+            "title": "Verus phase-1 A",
+            "body": "Closes #4610",
+            "state": "OPEN",
+            "createdAt": "2024-04-04T00:00:00Z",
+            "mergedAt": null,
+            "url": "https://github.com/owner/repo/pull/5001",
+            "headRefName": "feat/issue-1014-verus-phase1",
+            "baseRefName": "main",
+            "headRefOid": "1111111111111111111111111111111111111111",
+            "headRepositoryOwner": {"login": "owner"},
+            "headRepository": {"name": "repo"},
+            "isCrossRepository": false,
+            "isDraft": true
+          },
+          {
+            "number": 5002,
+            "title": "Verus phase-1 B",
+            "body": "Closes #4610",
+            "state": "OPEN",
+            "createdAt": "2024-04-05T00:00:00Z",
+            "mergedAt": null,
+            "url": "https://github.com/owner/repo/pull/5002",
+            "headRefName": "feat/issue-1014-verus-phase1",
+            "baseRefName": "main",
+            "headRefOid": "3333333333333333333333333333333333333333",
+            "headRepositoryOwner": {"login": "owner"},
+            "headRepository": {"name": "repo"},
+            "isCrossRepository": false,
+            "isDraft": true
+          }
+        ]"#,
+    )
+    .expect("write candidates");
+    write_list_stub_gh(&bin_dir, &list);
+
+    let (stdout, ok) = run_scope(
+        tmp.path(),
+        &bin_dir,
+        &[
+            "--repo",
+            "owner/repo",
+            "--head",
+            "feat/issue-1014-verus-phase1",
+            "--base",
+            "main",
+            "--issue",
+            "1014",
+            "--expected-pr-title-prefix",
+            "Update",
+            "--head-sha",
+            STALE_HEAD_SHA,
+        ],
+    );
+
+    assert!(
+        !ok,
+        "two OPEN candidates sharing head+base is a genuine ambiguity and must fail; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"reason\":\"multiple_scoped_prs\""),
+        "the loud multiple_scoped_prs failure must be preserved for >=2 OPEN candidates; stdout:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case (c): create-collision recovery in workflow_publish_pr.sh. The first
+// scoped lookup finds nothing (TOCTOU), `gh pr create` collides, and a
+// re-query then finds the OPEN PR -> publish must succeed as existing-open-pr.
+// ---------------------------------------------------------------------------
+
+/// A stateful stub `gh` for the publish create-collision path:
+///   * `pr list` call #1 -> `[]` (nothing found yet)
+///   * `pr create`       -> fails with the branch-already-exists collision
+///   * `pr list` call #2 -> the now-visible OPEN PR (adopted via re-lookup)
+///   * anything else     -> no-op success (labels, view, etc.)
+fn write_collision_stub_gh(bin_dir: &Path, state_dir: &Path, open_pr_json: &Path) {
+    fs::create_dir_all(bin_dir).expect("create bin dir");
+    fs::create_dir_all(state_dir).expect("create state dir");
+    let gh = bin_dir.join("gh");
+    fs::write(
+        &gh,
+        format!(
+            r#"#!/usr/bin/env bash
+set -uo pipefail
+state_dir={state:?}
+open_pr={open:?}
+sub="${{1:-}} ${{2:-}}"
+case "$sub" in
+  "pr list")
+    count_file="$state_dir/list_count"
+    n=0
+    [ -f "$count_file" ] && n="$(cat "$count_file")"
+    printf '%s' "$((n + 1))" > "$count_file"
+    if [ "$n" -eq 0 ]; then
+      printf '[]\n'
+    else
+      cat "$open_pr"
+    fi
+    ;;
+  "pr create")
+    echo "a pull request for branch already exists" >&2
+    exit 1
+    ;;
+  "pr view")
+    cat "$open_pr"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+"#,
+            state = state_dir.display().to_string(),
+            open = open_pr_json.display().to_string()
+        ),
+    )
+    .expect("write collision gh stub");
+    make_executable(&gh);
+}
+
+#[test]
+fn publish_adopts_existing_open_pr_on_create_collision_instead_of_failing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+
+    // Real git repo on a feature branch with a committed diff over origin/main.
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "user.name", "Workflow Test"]);
+    fs::write(repo.join("README.md"), "base\n").expect("write readme");
+    git(&repo, &["add", "README.md"]);
+    git(&repo, &["commit", "-m", "base"]);
+    git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ],
+    );
+    git(&repo, &["update-ref", "refs/remotes/origin/main", "main"]);
+    git(&repo, &["switch", "-c", "feat/issue-1014-collide"]);
+    fs::write(repo.join("feature.txt"), "feature\n").expect("write feature");
+    git(&repo, &["add", "feature.txt"]);
+    git(&repo, &["commit", "-m", "feature work"]);
+
+    // The OPEN PR that becomes visible on the re-query. Its title is NOT
+    // "Update"-prefixed and its body references only the upstream issue, so it
+    // is adopted purely via the (head,base,same-repo) primary key.
+    let open_pr = tmp.path().join("open_pr.json");
+    fs::write(
+        &open_pr,
+        r#"[
+          {
+            "number": 1015,
+            "title": "Verus Phase-1 proof scaffolding",
+            "body": "Closes #4610",
+            "state": "OPEN",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "mergedAt": null,
+            "url": "https://github.com/owner/repo/pull/1015",
+            "headRefName": "feat/issue-1014-collide",
+            "baseRefName": "main",
+            "headRefOid": "1111111111111111111111111111111111111111",
+            "headRepositoryOwner": {"login": "owner"},
+            "headRepository": {"name": "repo"},
+            "isCrossRepository": false,
+            "isDraft": true
+          }
+        ]"#,
+    )
+    .expect("write open pr");
+
+    let bin_dir = tmp.path().join("bin");
+    let state_dir = tmp.path().join("gh-state");
+    write_collision_stub_gh(&bin_dir, &state_dir, &open_pr);
+
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let output = Command::new("bash")
+        .arg(helper_path("workflow_publish_pr.sh"))
+        .current_dir(&repo)
+        .env("PATH", format!("{}:{old_path}", bin_dir.display()))
+        .env("REMOTE_HOST_TYPE", "github")
+        .env("ISSUE_NUMBER", "1014")
+        .env(
+            "WORKFLOW_RUNTIME_ARTIFACT_HELPER",
+            helper_path("workflow_runtime_artifacts.sh"),
+        )
+        .output()
+        .expect("run workflow_publish_pr.sh");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "a create collision whose branch already has an OPEN PR must end in SUCCESS, not a recipe failure\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("\"legacy_state\":\"existing-open-pr\"")
+            && stdout.contains("\"terminal_status\":\"success\""),
+        "publish must adopt the already-open PR as existing-open-pr success on create collision\nstdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("FAILED_PR_CREATE"),
+        "create collision recovered by an existing OPEN PR must NOT report FAILED_PR_CREATE\nstdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Problem (issue #1017)

`workflow_pr_scope.sh` layered `--issue` / `--head-sha` / `--title-prefix` as
hard-AND rejections on top of the already-unique `(headRefName, baseRefName,
same-repo)` key. When a branch's PR body referenced a different upstream issue
than its local tracking issue (e.g. PR #1015 body cites #4610, tracks #1014),
or the remote head advanced past the captured sha, the lookup failed closed,
`gh pr create` then collided, and the whole recipe hard-failed — also emitting
the "Update X with N changed files" orphan PR titles.

## Fix

- **Primary key = `(head, base, same-repo, non-cross-repository)`.** A single
  candidate is adopted immediately. `--issue`/`--head-sha`/`--title-prefix` are
  now tie-breakers ONLY when >1 candidate shares head+base (discovery mode), and
  hard filters ONLY in authoritative `--pr-number`/`--pr-url` mode.
- **Collision-tolerant publish.** On `gh pr create` failure, re-run the scoped
  lookup; if an OPEN PR is now visible, adopt it as `existing-open-pr` success
  instead of hard-failing.
- Same-repo / non-cross-repository guardrails and stderr redaction preserved.

## Tests (`tests/integration/pr_scope_primary_key_test.rs`)

- `adopts_pr_whose_body_references_a_different_upstream_issue` — the #1015 case.
- `publish_adopts_existing_open_pr_on_create_collision_instead_of_failing`.
- `never_matches_a_pr_on_a_different_head_branch` (safety invariant).
- `preserves_multiple_scoped_prs_when_two_open_candidates_remain` (loud-fail).

Closes #1017.

_Recovered from a default-workflow run whose finalize step hit an unrelated
`Argument list too long` crash (filed separately); the code + review gates
completed clean. Original auto-generated title/body replaced._