### PR TITLE
fix(recipe): early-exit reflection loop when deliverable PR is open and green (#1025)

### DIFF
--- a/amplifier-bundle/recipes/smart-reflect-loop.yaml
+++ b/amplifier-bundle/recipes/smart-reflect-loop.yaml
@@ -70,6 +70,31 @@ steps:
       Factor this into your evaluation — if the task ran via adaptive strategy
       due to a routing failure, note this in your assessment.
 
+      ## Deliverable PR early-exit (issue #1025)
+
+      Before choosing a GOAL_STATUS, determine whether this workstream has
+      already produced its deliverable pull request. If a PR exists for the
+      branch/changes created during the execution rounds, check its CI status:
+
+          gh pr view --json state,isDraft,statusCheckRollup
+          # or, for a specific branch: gh pr checks <branch>
+
+      Apply this rule UNLESS the environment variable
+      AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT is set to a truthy value
+      (`1`/`true`), in which case skip this rule entirely and evaluate normally:
+      - If the PR is definitively OPEN (not draft, not closed/merged) and ALL
+        required checks have COMPLETED SUCCESSFULLY (green), the deliverable is
+        met: end with `GOAL_STATUS: ACHIEVED` and STOP. Do NOT request another
+        round or any further heavy re-validation (e.g. local full-reactor
+        builds) — CI on the clean checkout is authoritative, and a local-only
+        failure (such as a test scanning sibling `./worktrees/` copies) must not
+        override a green PR.
+      - NEVER short-circuit to ACHIEVED on any other state. If checks are
+        pending/queued/in-progress, any check is failing, the PR is
+        closed/merged/draft, no PR exists yet, or the status is unknown or
+        ambiguous, IGNORE this rule and evaluate normally (prefer continuing the
+        loop). Fail toward continuing, never toward a premature ACHIEVED.
+
       End with EXACTLY one of:
       - `GOAL_STATUS: ACHIEVED` -- all criteria met with verifiable evidence
       - `GOAL_STATUS: PARTIAL -- [what's missing]` -- needs another round
@@ -105,6 +130,18 @@ steps:
       **Goal**: {{decomposition_json}}
       **Round 1**: {{round_1_result}}
       **Round 2**: {{round_2_result}}
+
+      ## Deliverable PR early-exit (issue #1025)
+
+      If a deliverable pull request now exists for this workstream, check its
+      CI status (`gh pr view --json state,isDraft,statusCheckRollup` or
+      `gh pr checks <branch>`). Unless AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT
+      is truthy: when the PR is definitively OPEN (not draft) and ALL required
+      checks are green, end with `GOAL_STATUS: ACHIEVED` and STOP — do not
+      trigger another round or heavy re-validation; CI on the clean checkout is
+      authoritative. NEVER short-circuit on pending/failing/closed/draft/no-PR
+      or unknown states — in those cases evaluate normally and prefer
+      continuing.
 
       End with:
       - `GOAL_STATUS: ACHIEVED`
@@ -144,6 +181,17 @@ steps:
       - Round 3 (if any): {{round_3_result}}
 
       Note: empty strings above mean that round was not needed.
+
+      ## Deliverable PR early-exit (issue #1025)
+
+      If a deliverable pull request exists for this workstream, check its CI
+      status (`gh pr view --json state,isDraft,statusCheckRollup` or
+      `gh pr checks <branch>`). Unless AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT
+      is truthy: when the PR is definitively OPEN (not draft) and ALL required
+      checks are green, conclude `GOAL_STATUS: ACHIEVED` — CI on the clean
+      checkout is authoritative and a local-only failure must not override it.
+      NEVER conclude ACHIEVED via this rule on pending/failing/closed/draft/
+      no-PR or unknown states; evaluate normally in those cases.
 
       Was the overall goal achieved? Summarize what was done.
       End with `GOAL_STATUS: ACHIEVED`, `GOAL_STATUS: PARTIAL -- [gaps]`,

--- a/amplifier-bundle/recipes/smart-reflect-loop.yaml
+++ b/amplifier-bundle/recipes/smart-reflect-loop.yaml
@@ -74,26 +74,30 @@ steps:
 
       Before choosing a GOAL_STATUS, determine whether this workstream has
       already produced its deliverable pull request. If a PR exists for the
-      branch/changes created during the execution rounds, check its CI status:
+      branch/changes created during the execution rounds, check PR state/draft
+      status separately from required checks:
 
-          gh pr view --json state,isDraft,statusCheckRollup
-          # or, for a specific branch: gh pr checks <branch>
+          gh pr view --json state,isDraft
+          gh pr checks --required
+          # or, for a specific branch: gh pr checks --required <branch>
 
       Apply this rule UNLESS the environment variable
       AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT is set to a truthy value
       (`1`/`true`), in which case skip this rule entirely and evaluate normally:
-      - If the PR is definitively OPEN (not draft, not closed/merged) and ALL
-        required checks have COMPLETED SUCCESSFULLY (green), the deliverable is
-        met: end with `GOAL_STATUS: ACHIEVED` and STOP. Do NOT request another
-        round or any further heavy re-validation (e.g. local full-reactor
-        builds) — CI on the clean checkout is authoritative, and a local-only
-        failure (such as a test scanning sibling `./worktrees/` copies) must not
-        override a green PR.
+      - If the PR is definitively OPEN (not draft, not closed/merged), the
+        repository reports a concrete required-check set, and EVERY required
+        check has COMPLETED SUCCESSFULLY (green), the deliverable is met: end
+        with `GOAL_STATUS: ACHIEVED` and STOP. Do NOT request another round or
+        any further heavy re-validation (e.g. local full-reactor builds) — CI on
+        the clean checkout is authoritative, and a local-only failure (such as a
+        test scanning sibling `./worktrees/` copies) must not override a green
+        PR.
       - NEVER short-circuit to ACHIEVED on any other state. If checks are
-        pending/queued/in-progress, any check is failing, the PR is
-        closed/merged/draft, no PR exists yet, or the status is unknown or
-        ambiguous, IGNORE this rule and evaluate normally (prefer continuing the
-        loop). Fail toward continuing, never toward a premature ACHIEVED.
+        pending/queued/in-progress, any required check is failing, the PR is
+        closed/merged/draft, no PR exists yet, the required-check set is empty,
+        or the status is unknown or ambiguous, IGNORE this rule and evaluate
+        normally (prefer continuing the loop). Fail toward continuing, never
+        toward a premature ACHIEVED.
 
       End with EXACTLY one of:
       - `GOAL_STATUS: ACHIEVED` -- all criteria met with verifiable evidence
@@ -134,14 +138,15 @@ steps:
       ## Deliverable PR early-exit (issue #1025)
 
       If a deliverable pull request now exists for this workstream, check its
-      CI status (`gh pr view --json state,isDraft,statusCheckRollup` or
-      `gh pr checks <branch>`). Unless AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT
-      is truthy: when the PR is definitively OPEN (not draft) and ALL required
-      checks are green, end with `GOAL_STATUS: ACHIEVED` and STOP — do not
-      trigger another round or heavy re-validation; CI on the clean checkout is
-      authoritative. NEVER short-circuit on pending/failing/closed/draft/no-PR
-      or unknown states — in those cases evaluate normally and prefer
-      continuing.
+      CI status (`gh pr view --json state,isDraft` plus
+      `gh pr checks --required`, or `gh pr checks --required <branch>`). Unless
+      AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT is truthy: when the PR is
+      definitively OPEN (not draft), the required-check set is concrete/nonempty,
+      and ALL required checks are green, end with `GOAL_STATUS: ACHIEVED` and
+      STOP — do not trigger another round or heavy re-validation; CI on the
+      clean checkout is authoritative. NEVER short-circuit on
+      pending/failing/closed/draft/no-PR/empty-required-check-set or unknown
+      states — in those cases evaluate normally and prefer continuing.
 
       End with:
       - `GOAL_STATUS: ACHIEVED`
@@ -185,13 +190,15 @@ steps:
       ## Deliverable PR early-exit (issue #1025)
 
       If a deliverable pull request exists for this workstream, check its CI
-      status (`gh pr view --json state,isDraft,statusCheckRollup` or
-      `gh pr checks <branch>`). Unless AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT
-      is truthy: when the PR is definitively OPEN (not draft) and ALL required
-      checks are green, conclude `GOAL_STATUS: ACHIEVED` — CI on the clean
-      checkout is authoritative and a local-only failure must not override it.
-      NEVER conclude ACHIEVED via this rule on pending/failing/closed/draft/
-      no-PR or unknown states; evaluate normally in those cases.
+      status (`gh pr view --json state,isDraft` plus `gh pr checks --required`,
+      or `gh pr checks --required <branch>`). Unless
+      AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT is truthy: when the PR is
+      definitively OPEN (not draft), the required-check set is concrete/nonempty,
+      and ALL required checks are green, conclude `GOAL_STATUS: ACHIEVED` — CI
+      on the clean checkout is authoritative and a local-only failure must not
+      override it. NEVER conclude ACHIEVED via this rule on
+      pending/failing/closed/draft/no-PR/empty-required-check-set or unknown
+      states; evaluate normally in those cases.
 
       Was the overall goal achieved? Summarize what was done.
       End with `GOAL_STATUS: ACHIEVED`, `GOAL_STATUS: PARTIAL -- [gaps]`,

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -50,6 +50,10 @@ name = "smart_orchestrator_decomposition"
 path = "../../tests/integration/smart_orchestrator_decomposition_test.rs"
 
 [[test]]
+name = "issue_1025_pr_green_shortcircuit"
+path = "../../tests/integration/issue_1025_pr_green_shortcircuit_test.rs"
+
+[[test]]
 name = "automated_action_failure_investigation_contract"
 path = "../../tests/integration/automated_action_failure_investigation_contract_test.rs"
 

--- a/docs/reference/recipe-executor-environment.md
+++ b/docs/reference/recipe-executor-environment.md
@@ -139,12 +139,14 @@ The goal-seeking reflection loop in `smart-reflect-loop.yaml` instructs the
 reviewer agent (`amplihack:core:reviewer`) to conclude `GOAL_STATUS: ACHIEVED`
 and stop once the workstream's deliverable pull request is definitively **open
 (not draft) and all required checks are green** (verified with `gh pr view` /
-`gh pr checks`). This prevents the loop from running further heavy re-validation
-rounds after CI on the clean checkout has already proven the deliverable — a
-local-only failure (for example a test scanning sibling `./worktrees/` copies)
-must not override a green PR. The reviewer **never** short-circuits on
-pending/failing/closed/draft/no-PR or unknown states; it fails toward continuing
-the loop.
+`gh pr checks --required`). The reviewer checks PR state/draft status separately
+from required-check status and must not infer success from broad optional
+rollups or an empty required-check set. This prevents the loop from running
+further heavy re-validation rounds after CI on the clean checkout has already
+proven the deliverable — a local-only failure (for example a test scanning
+sibling `./worktrees/` copies) must not override a green PR. The reviewer
+**never** short-circuits on pending/failing/closed/draft/no-PR/empty-required-
+check-set or unknown states; it fails toward continuing the loop.
 
 | Variable | Default | Behavior |
 |----------|---------|----------|

--- a/docs/reference/recipe-executor-environment.md
+++ b/docs/reference/recipe-executor-environment.md
@@ -8,6 +8,7 @@ Complete reference for the environment variables, prerequisite checks, and conte
 - [Recipe context environment export](#recipe-context-environment-export)
 - [Shell step environment injection](#shell-step-environment-injection)
 - [Agent step context augmentation](#agent-step-context-augmentation)
+- [Reviewer reflection early-exit (issue #1025)](#reviewer-reflection-early-exit-issue-1025)
 - [Prerequisite validation](#prerequisite-validation)
 - [Interaction with AMPLIHACK_NONINTERACTIVE](#interaction-with-amplihack_noninteractive)
 
@@ -129,6 +130,34 @@ Every agent step receives an augmented context map before the agent backend is i
 - The `working_directory` value tells the agent where to locate and write files. Without it, agents may operate in an unexpected directory.
 
 **Source:** `crates/amplihack-recipe/src/executor.rs`, `execute_agent_step()`.
+
+---
+
+## Reviewer reflection early-exit (issue #1025)
+
+The goal-seeking reflection loop in `smart-reflect-loop.yaml` instructs the
+reviewer agent (`amplihack:core:reviewer`) to conclude `GOAL_STATUS: ACHIEVED`
+and stop once the workstream's deliverable pull request is definitively **open
+(not draft) and all required checks are green** (verified with `gh pr view` /
+`gh pr checks`). This prevents the loop from running further heavy re-validation
+rounds after CI on the clean checkout has already proven the deliverable — a
+local-only failure (for example a test scanning sibling `./worktrees/` copies)
+must not override a green PR. The reviewer **never** short-circuits on
+pending/failing/closed/draft/no-PR or unknown states; it fails toward continuing
+the loop.
+
+| Variable | Default | Behavior |
+|----------|---------|----------|
+| `AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT` | *(unset)* | When set to a truthy value (`1`/`true`), the reviewer skips the PR-green early-exit rule entirely and evaluates goal status normally. |
+
+**Scope / nature:** This is a **recipe-prompt-level, reviewer-honored** control,
+not an executor-enforced variable — the reviewer agent runs inside the recipe
+subprocess (where the flag is visible) and applies the rule. A **deterministic,
+engine-enforced** bound (and graceful cancellation) is tracked separately in the
+recipe engine repository: `rysweet/amplihack-recipe-runner#132`.
+
+**Source:** `amplifier-bundle/recipes/smart-reflect-loop.yaml`, reviewer steps
+`reflect-round-1`, `reflect-round-2`, `reflect-final`.
 
 ---
 

--- a/tests/integration/issue_1025_pr_green_shortcircuit_test.rs
+++ b/tests/integration/issue_1025_pr_green_shortcircuit_test.rs
@@ -101,11 +101,15 @@ fn every_reviewer_step_has_the_pr_green_early_exit_guard() {
             p.contains("ACHIEVED") && p.to_lowercase().contains("green"),
             "{id} guard must map an open+green PR to GOAL_STATUS: ACHIEVED"
         );
-        // The guard must tell the reviewer HOW to check (authoritative CI, not
-        // a local re-build).
+        // The guard must tell the reviewer HOW to check authoritative required
+        // checks, not broad optional status rollups or a local re-build.
         assert!(
-            p.contains("gh pr"),
-            "{id} guard must query PR CI status via gh pr view/checks"
+            p.contains("gh pr checks --required"),
+            "{id} guard must query required PR CI status via gh pr checks --required"
+        );
+        assert!(
+            p.contains("gh pr view --json state,isDraft"),
+            "{id} guard must query PR open/draft state separately"
         );
         // Kill switch so the behavior can be disabled without a code change.
         assert!(
@@ -134,6 +138,10 @@ fn round_one_guard_enumerates_all_four_decision_cases() {
     assert!(p.contains("pending"), "case (b) pending-checks missing");
     assert!(p.contains("failing"), "case (c) failing-checks missing");
     assert!(p.contains("no pr"), "case (d) no-PR-yet missing");
+    assert!(
+        p.contains("empty"),
+        "guard must not treat an empty required-check set as green"
+    );
     assert!(
         p.contains("fail toward continuing"),
         "guard must state the fail-safe default of continuing the loop"

--- a/tests/integration/issue_1025_pr_green_shortcircuit_test.rs
+++ b/tests/integration/issue_1025_pr_green_shortcircuit_test.rs
@@ -1,0 +1,156 @@
+//! Issue #1025 — the goal-seeking reflection loop kept running expensive
+//! reflection/re-validation rounds long after the workstream's deliverable PR
+//! was already open and green, because the reviewer (`amplihack:core:reviewer`)
+//! reflect steps had no authoritative "PR is green -> done" short-circuit and
+//! relied only on local validation (which can false-fail, e.g. a test scanning
+//! sibling `./worktrees/` copies).
+//!
+//! The recipe-level fix adds a config-guarded, safety-first early-exit
+//! instruction to every reviewer/reflect step in `smart-reflect-loop.yaml`:
+//! when the deliverable PR is definitively OPEN and all required checks are
+//! green, conclude `GOAL_STATUS: ACHIEVED` and stop; otherwise
+//! (pending / failing / closed / draft / no PR / unknown) evaluate normally
+//! and prefer continuing.
+//!
+//! These tests lock that guard — and its four decision cases — into CI so a
+//! future prompt edit cannot silently drop the short-circuit or, worse,
+//! short-circuit on a non-green state.
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct Recipe {
+    steps: Vec<Step>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Step {
+    id: String,
+    #[serde(default)]
+    agent: String,
+    #[serde(default)]
+    prompt: String,
+}
+
+/// The reviewer/reflect steps that emit `GOAL_STATUS` and therefore gate
+/// whether another round runs.
+const REVIEWER_STEPS: &[&str] = &["reflect-round-1", "reflect-round-2", "reflect-final"];
+
+/// The full 5-step inventory of the reflect loop. The #1025 fix must be a
+/// prompt-only change: it must NOT add, remove, or rename steps (the
+/// smart_orchestrator_decomposition contract test locks the global inventory).
+const EXPECTED_STEPS: &[&str] = &[
+    "reflect-round-1",
+    "execute-round-2",
+    "reflect-round-2",
+    "execute-round-3",
+    "reflect-final",
+];
+
+/// Env flag that disables the early-exit (fail-safe kill switch).
+const DISABLE_FLAG: &str = "AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT";
+
+fn load_reflect_loop() -> Recipe {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut dir = crate_dir.clone();
+    while !dir.join("amplifier-bundle").exists() {
+        if !dir.pop() {
+            panic!("could not find amplifier-bundle from {crate_dir:?}");
+        }
+    }
+    let path = dir.join("amplifier-bundle/recipes/smart-reflect-loop.yaml");
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    serde_yaml::from_str(&raw).unwrap_or_else(|e| panic!("parse {path:?}: {e}"))
+}
+
+fn step<'a>(recipe: &'a Recipe, id: &str) -> &'a Step {
+    recipe
+        .steps
+        .iter()
+        .find(|s| s.id == id)
+        .unwrap_or_else(|| panic!("step {id} not found in smart-reflect-loop.yaml"))
+}
+
+#[test]
+fn reflect_loop_step_inventory_is_unchanged_by_the_fix() {
+    let recipe = load_reflect_loop();
+    let ids: Vec<&str> = recipe.steps.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(
+        ids, EXPECTED_STEPS,
+        "#1025 must be a prompt-only change: reflect-loop step inventory changed"
+    );
+}
+
+#[test]
+fn every_reviewer_step_has_the_pr_green_early_exit_guard() {
+    let recipe = load_reflect_loop();
+    for id in REVIEWER_STEPS {
+        let s = step(&recipe, id);
+        assert_eq!(
+            s.agent, "amplihack:core:reviewer",
+            "{id} is expected to be the GOAL_STATUS-emitting reviewer step"
+        );
+        let p = &s.prompt;
+        assert!(
+            p.contains("issue #1025"),
+            "{id} is missing the #1025 early-exit guard marker"
+        );
+        // Case (a): PR open + all checks green -> ACHIEVED (stop).
+        assert!(
+            p.contains("ACHIEVED") && p.to_lowercase().contains("green"),
+            "{id} guard must map an open+green PR to GOAL_STATUS: ACHIEVED"
+        );
+        // The guard must tell the reviewer HOW to check (authoritative CI, not
+        // a local re-build).
+        assert!(
+            p.contains("gh pr"),
+            "{id} guard must query PR CI status via gh pr view/checks"
+        );
+        // Kill switch so the behavior can be disabled without a code change.
+        assert!(
+            p.contains(DISABLE_FLAG),
+            "{id} guard must be gated by {DISABLE_FLAG}"
+        );
+        // Safety: never short-circuit on a non-green state.
+        assert!(
+            p.contains("NEVER"),
+            "{id} guard must forbid short-circuiting on non-green states"
+        );
+    }
+}
+
+/// The most detailed guard (round 1) must explicitly enumerate all four
+/// decision cases so the "fail toward continuing" contract is unambiguous:
+///   (a) green    -> ACHIEVED / stop
+///   (b) pending  -> continue
+///   (c) failing  -> continue
+///   (d) no PR    -> continue
+#[test]
+fn round_one_guard_enumerates_all_four_decision_cases() {
+    let recipe = load_reflect_loop();
+    let p = step(&recipe, "reflect-round-1").prompt.to_lowercase();
+    assert!(p.contains("green"), "case (a) open+green missing");
+    assert!(p.contains("pending"), "case (b) pending-checks missing");
+    assert!(p.contains("failing"), "case (c) failing-checks missing");
+    assert!(p.contains("no pr"), "case (d) no-PR-yet missing");
+    assert!(
+        p.contains("fail toward continuing"),
+        "guard must state the fail-safe default of continuing the loop"
+    );
+}
+
+/// The short-circuit must live only in the reviewer/reflect steps — the
+/// builder `execute-round-*` steps must not carry it (they do work; they do
+/// not decide goal status).
+#[test]
+fn executor_steps_do_not_carry_the_early_exit_guard() {
+    let recipe = load_reflect_loop();
+    for id in ["execute-round-2", "execute-round-3"] {
+        let s = step(&recipe, id);
+        assert!(
+            !s.prompt.contains("issue #1025"),
+            "{id} (a builder step) must not carry the reviewer early-exit guard"
+        );
+    }
+}


### PR DESCRIPTION
## Problem (issue #1025)
The `smart-reflect-loop` goal-seeking loop keeps running reflection and **heavy re-validation rounds long after a workstream's deliverable PR is already open and all required checks are green** — observed **55+ minutes** of extra Maven-build rounds after a PR was 7/7 green. The reviewer reflect steps emit `GOAL_STATUS` purely from *local* validation, which can false-fail (e.g. `SystemExitBoundaryTest` scanning sibling `./worktrees/` copies, RabbitHole #998) and never converge even though CI on the clean checkout is green.

## Fix (recipe-level early-exit — issue's proposed change #1)
Add a **config-guarded, safety-first** "deliverable PR early-exit" instruction to every reviewer/reflect step (`reflect-round-1`, `reflect-round-2`, `reflect-final`) in `amplifier-bundle/recipes/smart-reflect-loop.yaml`:

- When the deliverable PR is **definitively OPEN (not draft) and ALL required checks are green** (checked via `gh pr view --json state,isDraft,statusCheckRollup` / `gh pr checks <branch>`), conclude `GOAL_STATUS: ACHIEVED` and **stop** — CI on the clean checkout is authoritative; a local-only failure must not override it.
- **NEVER** short-circuit on any other state: pending / queued / in-progress, failing, closed / merged / draft, no PR yet, or unknown/ambiguous → evaluate normally and **prefer continuing** (fail toward continuing, never toward a premature ACHIEVED).
- Kill switch: set `AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT` to disable the rule entirely.

This is a **prompt-only** change — the reflect-loop step inventory is unchanged (the `smart_orchestrator_decomposition` contract still passes).

## Tests
New contract test `tests/integration/issue_1025_pr_green_shortcircuit_test.rs` locking the guard and its four decision cases:
- (a) open + all checks green → `ACHIEVED`/stop;
- (b) pending → continue; (c) failing → continue; (d) no PR → continue;
- guard present in all three reviewer steps, gated by the kill-switch env, absent from builder `execute-round-*` steps, and inventory unchanged.

```
cargo test -p amplihack --test issue_1025_pr_green_shortcircuit   # 4 passed
cargo test -p amplihack --test smart_orchestrator_decomposition   # 6 passed (unchanged)
```
Pre-commit: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, artifact-guard — all green.

## Scope / split-out (issue's secondary items)
The **deterministic engine-side bound** ("bound post-success reflection") and **graceful cancellation** (SIGTERM teardown without respawn) live in the *separate* recipe engine repo **`rysweet/amplihack-recipe-runner`** (`recipe-runner-rs`, installed via `cargo install`), not in this repo. They are intentionally **not** forced into this focused PR; they should be followed up there. This PR delivers the recipe-level early-exit that is fixable within `amplihack-rs`.

Closes #1025

---
## Merge-ready evidence (crusty review + merge-ready gate)

**Crusty review.** This is deliberately a *recipe-prompt-level* change — the deterministic loop-control engine lives in a separate repo (`rysweet/amplihack-recipe-runner`), so the only lever available in this repo is the reviewer reflect-step guidance (exactly what issue #1025 proposes as change #1). The guard is **fail-safe**: it only concludes `ACHIEVED` on a definitively open + all-green PR and explicitly refuses to short-circuit on pending/failing/closed/draft/no-PR/unknown. The `AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT` control is honestly documented as reviewer-honored (not engine-enforced); deterministic enforcement + graceful cancellation are split to `rysweet/amplihack-recipe-runner#132`.

1. **QA / tests:** New contract test `issue_1025_pr_green_shortcircuit` (4 tests) locks the guard and all four decision cases; the pre-existing `smart_orchestrator_decomposition` contract (6 tests) still passes, proving the 29-step inventory and ≤400-LOC brick rule are unaffected. Outside-in gadugi scenarios are N/A: the change is reviewer-prompt guidance with no new runtime CLI/service surface.
2. **Docs:** Updated — `docs/reference/recipe-executor-environment.md` gains a "Reviewer reflection early-exit (issue #1025)" section documenting the behavior and the `AMPLIHACK_DISABLE_PR_GREEN_SHORTCIRCUIT` control and its exact (advisory) nature.
3. **Review:** Direct crusty review performed; no critical/high findings remain.
4. **Checks:** Full CI matrix required to be green on the head revision (Lint & Format, 4-platform builds, Test, Install Smoke Test) before merge.
5–11. **Metadata / reviews / conflicts / policy / linked issue / threads:** `Closes #1025`; base `main` (0 required reviews, strict up-to-date); rebased onto `origin/main` (was BEHIND); no unresolved threads; both commits carry the required trailers.
12–13. **Description / scope:** This evidence block; diff limited to the reflect-loop recipe, its contract test + `[[test]]` registration, and the reference doc — no unrelated changes, no build artifacts.
