### PR TITLE
perf(ci): parallelize CI jobs + skip LTO on PR build-verification (wall-clock spike)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,14 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: check
+    # No `needs: check` — the lint/format job compiles the whole workspace for
+    # clippy (~15 min under the no-artifact-cache policy), and gating the
+    # expensive Test job behind it serialized the critical path to
+    # check(~15m) -> test(~35m) ≈ 50 min. Under strict "up-to-date" branch
+    # protection a fast-moving main then re-queued the branch before it could
+    # merge. Running Test concurrently with Lint & Format drops the critical
+    # path to ~35 min. `concurrency: cancel-in-progress` still supersedes stale
+    # runs; a lint failure only costs redundant Test compute, not correctness.
     timeout-minutes: 45
     env:
       # Drop debug info from the workspace's large test-binary surface (60+
@@ -152,7 +159,7 @@ jobs:
   install-smoke:
     name: Install Smoke Test
     runs-on: ubuntu-latest
-    needs: check
+    # No `needs: check` — parallelize with Lint & Format (see Test job note).
     timeout-minutes: 30
     env:
       # This job only asserts that `cargo install` succeeds and the binary
@@ -188,8 +195,17 @@ jobs:
   cross-compile:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    needs: check
+    # No `needs: check` — parallelize with Lint & Format (see Test job note).
     timeout-minutes: 45
+    env:
+      # PR/branch runs only *verify* that each target compiles; the optimized
+      # binaries are shipped exclusively by the `release` job on tag pushes.
+      # Full-optimization release builds (lto = true, codegen-units = 1) are the
+      # slowest configuration to compile, so disable them for non-tag runs to
+      # cut build wall-clock substantially. Tag builds keep full optimization so
+      # shipped artifacts are unchanged.
+      CARGO_PROFILE_RELEASE_LTO: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '16' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Spike: cut CI wall-clock time

**Problem.** Under strict `up-to-date` branch protection, main advances (~every 45 min) faster than a PR's checks complete (~50 min), so PRs keep falling `behind` and can never hit the `green + current` window needed to merge.

**Where the ~50 min goes.** Every job runs `cache-targets: false` (no compiled-artifact cache), so each recompiles all deps from scratch. `Test`, `Install Smoke`, and the 4 `Build` jobs all declare `needs: check`, so they wait ~15 min for `Lint & Format` (which compiles the workspace for clippy) before starting. Critical path: `check (~15m) -> test (~35m) ≈ 50m`.

## Changes
1. **Parallelize:** remove `needs: check` from `Test`, `Install Smoke`, and the four `Build` jobs so they run concurrently with `Lint & Format`. Critical path -> ~35 min. `concurrency: cancel-in-progress` still supersedes stale runs; a lint failure only wastes redundant compute, not correctness.
2. **Skip LTO on build-verification:** `cross-compile` builds fully-optimized `--release` (`lto=true`, `codegen-units=1`) only to verify each target compiles; those artifacts ship solely from the tag-only `release` job. Non-tag runs now build with LTO off / `codegen-units=16` (big compile speedup); **tag builds keep full optimization**, so shipped binaries are unchanged.

All **seven required check names are unchanged**, so no branch-protection update is needed.

## Expected impact
- Time-to-all-required-green: **~50 min -> ~30-35 min** (measurable on this PR's own run).

## Recommended follow-up (not in this PR)
The CI already has a `merge_group:` trigger. **Enabling the GitHub merge queue** in branch protection is the real structural fix for the up-to-date race: it batch-validates approved PRs onto a queue branch and merges them without each PR serially racing main. Recommend enabling it (I have not, as it is a repo-wide policy change).

## Risk
Low. No production build/artifact behavior changes on tags. Worst case on non-tag runs is redundant compute when lint fails.