### PR TITLE
fix(signal): never block session exit reading a non-regular transcript (follow-up to #1007)

### DIFF
--- a/crates/amplihack-hooks/src/stop/mod.rs
+++ b/crates/amplihack-hooks/src/stop/mod.rs
@@ -88,14 +88,20 @@ impl Hook for StopHook {
     }
 }
 
+/// Cap on how many trailing bytes we read from a transcript when locating the
+/// last assistant message for outbound mirroring. Bounds memory for
+/// pathologically large (or unbounded) files.
+#[cfg(feature = "signal")]
+const OUTBOUND_TRANSCRIPT_READ_CAP: u64 = 8 * 1024 * 1024;
+
 /// Best-effort extraction of the **last** assistant message text from a
 /// transcript JSONL file, for outbound mirroring. Tolerant of the several
 /// transcript shapes across hosts (Copilot `assistant.message`, Claude
 /// `role: assistant`, nested `message.role`). Returns `None` on any failure so
-/// mirroring never blocks session exit.
+/// mirroring never blocks or fails session exit.
 #[cfg(feature = "signal")]
 fn last_assistant_message_from_transcript(transcript_path: &std::path::Path) -> Option<String> {
-    let contents = std::fs::read_to_string(transcript_path).ok()?;
+    let contents = read_transcript_tail_bounded(transcript_path)?;
     contents.lines().rev().find_map(|line| {
         let line = line.trim();
         if line.is_empty() {
@@ -104,6 +110,40 @@ fn last_assistant_message_from_transcript(transcript_path: &std::path::Path) -> 
         let entry = serde_json::from_str::<Value>(line).ok()?;
         extract_assistant_text_from_entry(&entry)
     })
+}
+
+/// Bounded, non-blocking read of a transcript for outbound mirroring.
+///
+/// Only **regular files** are read. A non-regular path — a FIFO, socket,
+/// character/block device, or a `/proc/self/fd/*` handle onto this process's
+/// own pipe (a symlink/`fd` transcript path is enough) — would otherwise make a
+/// plain `read_to_string` block indefinitely and wedge session exit, or stream
+/// unbounded data. Reading is capped to the trailing
+/// [`OUTBOUND_TRANSCRIPT_READ_CAP`] bytes so the last assistant message is still
+/// found without unbounded allocation. Returns `None` on any error so mirroring
+/// never blocks or fails session exit.
+#[cfg(feature = "signal")]
+fn read_transcript_tail_bounded(transcript_path: &std::path::Path) -> Option<String> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    // `metadata` follows symlinks and does not read file contents, so it is
+    // safe (non-blocking) even for a `/proc/self/fd/*` pipe handle.
+    let metadata = std::fs::metadata(transcript_path).ok()?;
+    if !metadata.file_type().is_file() {
+        return None;
+    }
+
+    let len = metadata.len();
+    let mut file = std::fs::File::open(transcript_path).ok()?;
+    if len > OUTBOUND_TRANSCRIPT_READ_CAP {
+        file.seek(SeekFrom::Start(len - OUTBOUND_TRANSCRIPT_READ_CAP))
+            .ok()?;
+    }
+    let mut buf = Vec::new();
+    file.take(OUTBOUND_TRANSCRIPT_READ_CAP)
+        .read_to_end(&mut buf)
+        .ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
 }
 
 /// Pull assistant text out of a single transcript entry across host shapes.
@@ -208,5 +248,84 @@ mod tests {
         let hook = StopHook;
         let result = hook.process(HookInput::Unknown).unwrap();
         assert_eq!(result["decision"], "approve");
+    }
+
+    // Regression tests for the outbound-mirroring transcript reader. A
+    // non-regular transcript path (FIFO/socket/`/proc/self/fd/*` pipe) must
+    // never be read, otherwise mirroring blocks session exit indefinitely.
+    #[cfg(feature = "signal")]
+    mod transcript_read {
+        use super::super::{OUTBOUND_TRANSCRIPT_READ_CAP, read_transcript_tail_bounded};
+        use std::fs;
+        use std::io::Write;
+        use std::path::PathBuf;
+
+        fn unique_dir(tag: &str) -> PathBuf {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let dir = std::env::temp_dir().join(format!(
+                "amplihack-stop-transcript-{tag}-{}-{nanos}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&dir).unwrap();
+            dir
+        }
+
+        #[test]
+        fn reads_regular_file() {
+            let dir = unique_dir("regular");
+            let path = dir.join("t.jsonl");
+            fs::write(&path, "{\"role\":\"assistant\",\"content\":\"hi\"}\n").unwrap();
+            let contents = read_transcript_tail_bounded(&path).expect("regular file read");
+            assert!(contents.contains("hi"));
+            let _ = fs::remove_dir_all(&dir);
+        }
+
+        #[test]
+        fn non_regular_path_returns_none_without_blocking() {
+            // A directory is a simple, portable non-regular file. The guard
+            // that rejects it is the same guard that rejects a FIFO/pipe
+            // (e.g. `/proc/self/fd/1`) whose read would block forever.
+            let dir = unique_dir("dir");
+            assert!(read_transcript_tail_bounded(&dir).is_none());
+            let _ = fs::remove_dir_all(&dir);
+        }
+
+        #[test]
+        fn missing_path_returns_none() {
+            let dir = unique_dir("missing");
+            let path = dir.join("does-not-exist.jsonl");
+            assert!(read_transcript_tail_bounded(&path).is_none());
+            let _ = fs::remove_dir_all(&dir);
+        }
+
+        #[test]
+        fn oversized_file_reads_bounded_tail_and_finds_last_message() {
+            let dir = unique_dir("oversized");
+            let path = dir.join("big.jsonl");
+            let mut file = fs::File::create(&path).unwrap();
+            // Write filler beyond the cap, then the real last message at the end.
+            let filler = "x".repeat(1024 * 1024);
+            let mut written: u64 = 0;
+            while written <= OUTBOUND_TRANSCRIPT_READ_CAP {
+                writeln!(file, "{filler}").unwrap();
+                written += filler.len() as u64 + 1;
+            }
+            writeln!(file, "{{\"role\":\"assistant\",\"content\":\"tail-msg\"}}").unwrap();
+            file.flush().unwrap();
+
+            let contents = read_transcript_tail_bounded(&path).expect("bounded tail read");
+            assert!(
+                (contents.len() as u64) <= OUTBOUND_TRANSCRIPT_READ_CAP,
+                "read must be bounded by the cap"
+            );
+            assert!(
+                contents.contains("tail-msg"),
+                "tail read must still contain the last assistant message"
+            );
+            let _ = fs::remove_dir_all(&dir);
+        }
     }
 }

--- a/crates/amplihack-hooks/src/stop/mod.rs
+++ b/crates/amplihack-hooks/src/stop/mod.rs
@@ -122,19 +122,26 @@ fn last_assistant_message_from_transcript(transcript_path: &std::path::Path) -> 
 /// [`OUTBOUND_TRANSCRIPT_READ_CAP`] bytes so the last assistant message is still
 /// found without unbounded allocation. Returns `None` on any error so mirroring
 /// never blocks or fails session exit.
+///
+/// The file is opened first and then classified via `fstat` on the **opened
+/// descriptor** (not a separate path-based `metadata()` call), which closes the
+/// TOCTOU window where a regular file could be swapped for a FIFO between the
+/// check and the open. On Unix the open uses `O_NONBLOCK`, so opening a
+/// FIFO/socket/device returns immediately instead of blocking; `O_NONBLOCK` is
+/// ignored for reads on regular files, so real transcripts read normally.
 #[cfg(feature = "signal")]
 fn read_transcript_tail_bounded(transcript_path: &std::path::Path) -> Option<String> {
     use std::io::{Read, Seek, SeekFrom};
 
-    // `metadata` follows symlinks and does not read file contents, so it is
-    // safe (non-blocking) even for a `/proc/self/fd/*` pipe handle.
-    let metadata = std::fs::metadata(transcript_path).ok()?;
+    let mut file = open_transcript_nonblocking(transcript_path)?;
+    // fstat on the opened fd — never blocks, and reflects the actual object we
+    // hold open (no path re-resolution, so no TOCTOU with the open above).
+    let metadata = file.metadata().ok()?;
     if !metadata.file_type().is_file() {
         return None;
     }
 
     let len = metadata.len();
-    let mut file = std::fs::File::open(transcript_path).ok()?;
     if len > OUTBOUND_TRANSCRIPT_READ_CAP {
         file.seek(SeekFrom::Start(len - OUTBOUND_TRANSCRIPT_READ_CAP))
             .ok()?;
@@ -144,6 +151,28 @@ fn read_transcript_tail_bounded(transcript_path: &std::path::Path) -> Option<Str
         .read_to_end(&mut buf)
         .ok()?;
     Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Open a transcript for reading without ever blocking on a non-regular path.
+///
+/// On Unix, `O_NONBLOCK` makes opening a FIFO with no writer (or a slow device)
+/// return immediately rather than hang; the caller then rejects any non-regular
+/// descriptor via `fstat`. Regular files ignore `O_NONBLOCK` for reads.
+#[cfg(all(feature = "signal", unix))]
+fn open_transcript_nonblocking(path: &std::path::Path) -> Option<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(path)
+        .ok()
+}
+
+/// Non-Unix fallback: the FIFO/proc-fd hang classes do not apply the same way,
+/// and the caller still rejects non-regular descriptors via `fstat`.
+#[cfg(all(feature = "signal", not(unix)))]
+fn open_transcript_nonblocking(path: &std::path::Path) -> Option<std::fs::File> {
+    std::fs::File::open(path).ok()
 }
 
 /// Pull assistant text out of a single transcript entry across host shapes.
@@ -290,6 +319,40 @@ mod tests {
             // (e.g. `/proc/self/fd/1`) whose read would block forever.
             let dir = unique_dir("dir");
             assert!(read_transcript_tail_bounded(&dir).is_none());
+            let _ = fs::remove_dir_all(&dir);
+        }
+
+        // A real FIFO with no writer: a plain blocking open (or read) would hang
+        // session exit forever. The `O_NONBLOCK`-open + `fstat`-classify path
+        // must return `None` promptly. We run it on a worker thread and require
+        // it to finish well within a generous bound to prove it never blocks.
+        #[cfg(unix)]
+        #[test]
+        fn real_fifo_with_no_writer_returns_none_without_blocking() {
+            use std::ffi::CString;
+            use std::sync::mpsc;
+            use std::time::Duration;
+
+            let dir = unique_dir("fifo");
+            let path = dir.join("t.jsonl");
+            let c_path = CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+            // 0o600 FIFO; if mkfifo is unsupported the assert below is skipped.
+            let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+            assert_eq!(rc, 0, "mkfifo failed (errno {})", unsafe {
+                *libc::__errno_location()
+            });
+
+            let (tx, rx) = mpsc::channel();
+            let probe_path = path.clone();
+            let handle = std::thread::spawn(move || {
+                let r = read_transcript_tail_bounded(&probe_path);
+                let _ = tx.send(r.is_none());
+            });
+            let got_none = rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("reading a FIFO transcript must not block session exit");
+            assert!(got_none, "a FIFO transcript must be rejected (None)");
+            handle.join().unwrap();
             let _ = fs::remove_dir_all(&dir);
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #1007 (per-session Signal channel). Outside-in ("Step 16b") testing of the
merged #1007 work uncovered a **latent denial-of-service in the Stop hook** that shipped to
`main`. This PR fixes it. Net diff is a single file: `crates/amplihack-hooks/src/stop/mod.rs`.

## The bug (found via outside-in testing)

With the `signal` feature enabled, the Stop hook mirrors the last assistant message outbound.
It read the transcript with an **unbounded, blocking** call:

```rust
let contents = std::fs::read_to_string(transcript_path).ok()?;
```

When `transcript_path` points at a **non-regular file** (a FIFO, socket, or a
`/proc/self/fd/*` handle to the process's own stdout pipe/TTY), `read_to_string` blocks
**forever** waiting for EOF that never comes — wedging session exit. This is a
session-exit DoS.

The repo already ships a fixture that triggers it:
`tests/golden/hooks/stop/84_transcript_symlink_path.input.json` sets
`transcript_path: "/proc/self/fd/1"`. It passes in CI only because CI stdout is a regular
file (instant EOF); on a pipe/TTY it hangs indefinitely. During Step 16b the
`hooks_golden` suite hung on `golden_stop` for ~28 min until killed — that was this bug.

## The fix

Replace the unbounded read with `read_transcript_tail_bounded()`:

- **Regular-file guard**: `fs::metadata(path).file_type().is_file()` (a non-blocking stat
  that follows symlinks) rejects FIFOs/sockets/pipes before any blocking open, returning
  `None` instead of hanging.
- **Bounded read**: reads at most the trailing `OUTBOUND_TRANSCRIPT_READ_CAP` (8 MiB) so a
  pathological transcript can't cause unbounded memory/latency; decoded with
  `String::from_utf8_lossy`.
- New signal-gated regression tests (`mod transcript_read`): reads a regular file, returns
  `None` without blocking for a non-regular path, returns `None` for a missing path, and
  reads the bounded tail of an oversized file to still find the last message.

## Step 16b: Outside-In Testing Results

- **Detected toolchain**: Rust workspace (`Cargo.toml` / `Cargo.lock`), edition 2024,
  pinned toolchain 1.97.0. Feature flag under test: `signal`. Affected crates:
  `amplihack-signal`, `amplihack-hooks`, `bins/amplihack-hooks`.
- **Strategy**: Built the test binaries and ran them from the CLI/hook consumer boundary
  under a `timeout` wrapper (per-crate), with and without `--features signal`, to detect
  hangs (exit 124) that a normal `cargo test` masks. Project-local `CARGO_TARGET_DIR`
  (never `/tmp`).
- **Simple scenario** (no-signal): `amplihack-hooks` default tests + golden contract
  → **18/18 PASS**.
- **Edge/integration scenario** (`--features signal`): `amplihack-signal` all pass;
  `amplihack-hooks` lib(signal) 449 pass; signal integration tests pass; golden
  `golden_stop` **HUNG** on fixture 84 → root-caused to the transcript read above.
- **After fix**: `golden_stop` 0.01s; full golden **18/18**; new regression tests **4/4**;
  `cargo clippy` (default **and** `--features signal`, `-D warnings`) clean; `cargo fmt --check` clean.
- **Fix count**: **1**.

## Reconciliation note

PR #1007 (the substantive Signal channel work) merged to `main` as `59a9f701` while Step 16b
was running, so "prepare and stop before merge" is moot for #1007 — it is already merged.
This branch is `origin/main` + the single transcript-hang fix, delivered as a follow-up so
the DoS does not remain latent in `main`. It intentionally does **not** revert any #971/#992
external-integration work.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## CI status & co-driven hardening

- Required checks reached **full green** on the fix at head `12594b73` (run `30186224079`):
  Build ×4 targets, Test, Lint & Format, Install Smoke Test, GitGuardian — all pass.
- A concurrent agent (`wt-1029-harden`) is layering a TOCTOU hardening commit
  (`O_NONBLOCK` open + `fstat`) and periodic `main` syncs onto this same branch. Those pushes
  restart CI; each new head re-runs the same required-checks matrix. The branch remains
  `MERGEABLE` throughout and the net diff stays confined to
  `crates/amplihack-hooks/src/stop/mod.rs`. `cargo clippy --features signal -D warnings` passes
  locally on the hardened head as well.
