### PR TITLE
fix(recipe): reject caller checkout reuse for task worktrees

### DIFF
--- a/amplifier-bundle/recipes/consensus-issue-worktree.yaml
+++ b/amplifier-bundle/recipes/consensus-issue-worktree.yaml
@@ -140,9 +140,24 @@ steps:
           $1=="branch" && $2==b { print wt; exit }
         ')"
         if [ -n "$EXISTING_WT" ]; then
+          REPO_REAL="$(pwd -P)"
+          if ! EXISTING_WT_REAL="$(cd "$EXISTING_WT" 2>/dev/null && pwd -P)"; then
+            echo "ERROR: git reports an existing worktree for branch '$BRANCH_NAME' at '$EXISTING_WT', but that path is not accessible." >&2
+            echo "ERROR: run 'git worktree prune' or remove the stale registration before retrying; refusing to guess a fallback worktree (issue #858)." >&2
+            exit 1
+          fi
+          if [ "$EXISTING_WT_REAL" = "$REPO_REAL" ]; then
+            echo "ERROR: existing branch '$BRANCH_NAME' is checked out in the caller repository '$REPO_PATH'." >&2
+            echo "ERROR: refusing to use the caller checkout as a recipe task worktree because it may contain unrelated local commits or uncommitted files (issue #858)." >&2
+            echo "ERROR: run the recipe from a clean base checkout or detach/switch the caller checkout before targeting this branch." >&2
+            exit 1
+          fi
           WORKTREE_PATH="$EXISTING_WT"
         elif [ "$(git symbolic-ref --short HEAD 2>/dev/null || true)" = "$BRANCH_NAME" ]; then
-          WORKTREE_PATH="$(pwd)"
+          echo "ERROR: existing branch '$BRANCH_NAME' is checked out in the caller repository '$REPO_PATH'." >&2
+          echo "ERROR: refusing to use the caller checkout as a recipe task worktree because it may contain unrelated local commits or uncommitted files (issue #858)." >&2
+          echo "ERROR: run the recipe from a clean base checkout or detach/switch the caller checkout before targeting this branch." >&2
+          exit 1
         elif git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
           git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
         elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -121,7 +121,8 @@ steps:
 
         # Resolve worktree path:
         #   (a) reuse if a worktree already exists for the branch
-        #   (b) else use REPO_PATH if it is itself checked out on the branch
+        #   (b) else refuse if the caller checkout already has the branch
+        #       checked out (#858: never use caller state as a task worktree)
         #   (c) else attach a new worktree at REPO_PATH/worktrees/<branch>
         WORKTREE_PATH=""
         EXISTING_WT="$(git worktree list --porcelain | awk -v b="refs/heads/$BRANCH_NAME" '
@@ -129,43 +130,57 @@ steps:
           $1=="branch" && $2==b { print wt; exit }
         ')"
         if [ -n "$EXISTING_WT" ]; then
+          REPO_REAL="$(cd "$REPO_PATH" && pwd -P)"
+          if ! EXISTING_WT_REAL="$(cd "$EXISTING_WT" 2>/dev/null && pwd -P)"; then
+            echo "ERROR: git reports an existing worktree for branch '$BRANCH_NAME' at '$EXISTING_WT', but that path is not accessible." >&2
+            echo "ERROR: run 'git worktree prune' or remove the stale registration before retrying; refusing to guess a fallback worktree (issue #858)." >&2
+            exit 1
+          fi
+          if [ "$EXISTING_WT_REAL" = "$REPO_REAL" ]; then
+            echo "ERROR: existing branch '$BRANCH_NAME' is checked out in the caller repository '$REPO_PATH'." >&2
+            echo "ERROR: refusing to use the caller checkout as a recipe task worktree because it may contain unrelated local commits or uncommitted files (issue #858)." >&2
+            echo "ERROR: run the recipe from a clean base checkout or detach/switch the caller checkout before targeting this branch." >&2
+            exit 1
+          fi
           WORKTREE_PATH="$EXISTING_WT"
           echo "INFO: Reusing existing worktree at '$WORKTREE_PATH'." >&2
         else
           HEAD_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
           if [ "$HEAD_BRANCH" = "$BRANCH_NAME" ]; then
-            WORKTREE_PATH="$REPO_PATH"
-            echo "INFO: Caller already on branch '$BRANCH_NAME'; using REPO_PATH as worktree." >&2
-          else
-            # SECURITY: WORKTREE_PATH construction is safe because BRANCH_NAME
-            # has passed git check-ref-format above (rejects .., leading -, etc.).
-            WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
-            if [ -d "$WORKTREE_PATH" ]; then
-              # Issue #642: worktree dir exists from a prior run. If it's a
-              # valid git worktree on the right branch, reuse it. Otherwise
-              # remove the stale directory and re-create.
-              WT_BRANCH="$(git -C "$WORKTREE_PATH" symbolic-ref --short HEAD 2>/dev/null || true)"
-              if [ "$WT_BRANCH" = "$BRANCH_NAME" ]; then
-                echo "INFO: Reusing existing worktree directory at '$WORKTREE_PATH' (branch matches)." >&2
-              else
-                echo "INFO: Removing stale worktree at '$WORKTREE_PATH' (was '$WT_BRANCH', need '$BRANCH_NAME')." >&2
-                git worktree remove --force "$WORKTREE_PATH" >&2 2>/dev/null || rm -rf "$WORKTREE_PATH"
-                if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-                  git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
-                elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
-                  git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
-                fi
-              fi
-            elif git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-              # Local branch exists: attach without -b (safe re-attach).
-              git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
-            elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
-              # Remote-only: create local tracking branch on attach.
-              git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+            echo "ERROR: existing branch '$BRANCH_NAME' is checked out in the caller repository '$REPO_PATH'." >&2
+            echo "ERROR: refusing to use the caller checkout as a recipe task worktree because it may contain unrelated local commits or uncommitted files (issue #858)." >&2
+            echo "ERROR: run the recipe from a clean base checkout or detach/switch the caller checkout before targeting this branch." >&2
+            exit 1
+          fi
+
+          # SECURITY: WORKTREE_PATH construction is safe because BRANCH_NAME
+          # has passed git check-ref-format above (rejects .., leading -, etc.).
+          WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+          if [ -d "$WORKTREE_PATH" ]; then
+            # Issue #642: worktree dir exists from a prior run. If it's a
+            # valid git worktree on the right branch, reuse it. Otherwise
+            # remove the stale directory and re-create.
+            WT_BRANCH="$(git -C "$WORKTREE_PATH" symbolic-ref --short HEAD 2>/dev/null || true)"
+            if [ "$WT_BRANCH" = "$BRANCH_NAME" ]; then
+              echo "INFO: Reusing existing worktree directory at '$WORKTREE_PATH' (branch matches)." >&2
             else
-              echo "ERROR: branch '$BRANCH_NAME' not found locally or on origin." >&2
-              exit 1
+              echo "INFO: Removing stale worktree at '$WORKTREE_PATH' (was '$WT_BRANCH', need '$BRANCH_NAME')." >&2
+              git worktree remove --force "$WORKTREE_PATH" >&2 2>/dev/null || rm -rf "$WORKTREE_PATH"
+              if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+                git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+              elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+                git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+              fi
             fi
+          elif git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+            # Local branch exists: attach without -b (safe re-attach).
+            git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+          elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+            # Remote-only: create local tracking branch on attach.
+            git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+          else
+            echo "ERROR: branch '$BRANCH_NAME' not found locally or on origin." >&2
+            exit 1
           fi
         fi
 

--- a/tests/integration/existing_branch_context_test.rs
+++ b/tests/integration/existing_branch_context_test.rs
@@ -164,6 +164,20 @@ impl GitFixture {
         git(&self.repo_path, &["branch", name, "main"]);
     }
 
+    fn checkout(&self, name: &str) {
+        git(&self.repo_path, &["checkout", name]);
+    }
+
+    fn commit_file(&self, path: &str, contents: &str, message: &str) {
+        let file_path = self.repo_path.join(path);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&file_path, contents).unwrap();
+        git(&self.repo_path, &["add", path]);
+        git(&self.repo_path, &["commit", "-m", message]);
+    }
+
     fn create_remote_only_branch(&self, name: &str) {
         // Create on origin without leaving a local ref behind.
         git(&self.repo_path, &["branch", name, "main"]);
@@ -346,6 +360,15 @@ fn step04_body() -> String {
     )
 }
 
+fn consensus_step3_body() -> String {
+    extract_step_body(
+        &load_recipe(
+            &workspace_root().join("amplifier-bundle/recipes/consensus-issue-worktree.yaml"),
+        ),
+        "step3-setup-worktree",
+    )
+}
+
 fn base_env(fix: &GitFixture) -> HashMap<&'static str, String> {
     let mut env = HashMap::new();
     env.insert("REPO_PATH", fix.repo_path.to_string_lossy().into_owned());
@@ -511,6 +534,116 @@ fn case6_both_set_existing_branch_wins_with_warning() {
         warn_lc.contains("warning") && warn_lc.contains("existing_branch"),
         "must emit a precedence WARNING on stderr; got:\n{}",
         r.stderr
+    );
+}
+
+/// Issue #858: a normal new task branch must be created from the resolved
+/// remote base ref, not from the caller checkout's current dirty branch.
+#[test]
+fn issue858_new_task_worktree_ignores_dirty_caller_branch() {
+    let fix = GitFixture::new();
+    fix.create_local_branch("feat/caller-dirty");
+    fix.checkout("feat/caller-dirty");
+    fix.commit_file(
+        "caller_only.txt",
+        "caller-only commit must not leak\n",
+        "caller-only commit",
+    );
+    fs::write(fix.repo_path.join("untracked-caller.txt"), "dirty caller\n").unwrap();
+
+    let body = step04_body();
+    let env = base_env(&fix);
+    let r = run_bash(&body, &env, &fix.repo_path);
+
+    assert_eq!(
+        r.status, 0,
+        "step exited {} stdout=\n{}\nstderr=\n{}",
+        r.status, r.stdout, r.stderr
+    );
+    let json = parse_json(&r.stdout);
+    let worktree_path = PathBuf::from(json["worktree_path"].as_str().unwrap());
+    let base_ref = json["base_ref"].as_str().unwrap();
+
+    assert_ne!(
+        worktree_path, fix.repo_path,
+        "task worktree must be isolated from caller checkout"
+    );
+    assert!(
+        worktree_path.is_dir(),
+        "task worktree path should exist: {}",
+        worktree_path.display()
+    );
+    assert_eq!(
+        git(
+            &worktree_path,
+            &["rev-list", "--count", &format!("{base_ref}..HEAD")]
+        )
+        .stdout,
+        b"0\n",
+        "new task worktree must start exactly at the resolved base ref"
+    );
+    assert!(
+        !worktree_path.join("caller_only.txt").exists(),
+        "caller-only committed file leaked into task worktree"
+    );
+    assert!(
+        !worktree_path.join("untracked-caller.txt").exists(),
+        "caller untracked file leaked into task worktree"
+    );
+    assert!(
+        git(&worktree_path, &["status", "--porcelain"])
+            .stdout
+            .is_empty(),
+        "new task worktree must be clean at creation"
+    );
+}
+
+/// Issue #858's sharp edge: the existing-branch path used to silently set
+/// `WORKTREE_PATH=$REPO_PATH` when the caller checkout was already on the
+/// target branch. That made salvage unsafe because unrelated caller commits
+/// and dirty files became the recipe task worktree.
+#[test]
+fn issue858_existing_branch_checked_out_in_caller_is_rejected() {
+    let fix = GitFixture::new();
+    fix.create_local_branch("feat/caller-target");
+    fix.checkout("feat/caller-target");
+    fix.commit_file(
+        "caller_only.txt",
+        "caller-only commit must not become task state\n",
+        "caller-only target commit",
+    );
+    fs::write(fix.repo_path.join("untracked-caller.txt"), "dirty caller\n").unwrap();
+
+    let body = step04_body();
+    let mut env = base_env(&fix);
+    env.insert("EXISTING_BRANCH", "feat/caller-target".to_owned());
+    let r = run_bash(&body, &env, &fix.repo_path);
+
+    assert_ne!(
+        r.status, 0,
+        "existing-branch path must not succeed by reusing dirty REPO_PATH; stdout=\n{}",
+        r.stdout
+    );
+    assert!(
+        r.stderr.contains("refusing to use the caller checkout") && r.stderr.contains("issue #858"),
+        "failure must explain the salvage-safety reason; stderr=\n{}",
+        r.stderr
+    );
+    assert!(
+        r.stdout.trim().is_empty(),
+        "failing path must not emit a worktree_setup JSON object that downstream steps could trust; stdout=\n{}",
+        r.stdout
+    );
+}
+
+#[test]
+fn issue858_consensus_recipe_also_refuses_caller_checkout_reuse() {
+    let body = consensus_step3_body();
+    assert!(
+        body.contains("refusing to use the caller checkout")
+            && body.contains("issue #858")
+            && !body.contains("WORKTREE_PATH=\"$(pwd)\""),
+        "consensus-issue-worktree must mirror the #858 caller-checkout refusal"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #858 by making recipe task worktree setup fail loudly instead of reusing the caller checkout when an existing target branch is already checked out in the caller repository. This prevents concurrent recipes from inheriting unrelated caller commits or dirty files and keeps salvage safe.

## Changes

- Default workflow worktree setup now refuses caller-checkout reuse for existing branches discovered via `git worktree list` or the current `HEAD_BRANCH` path.
- Consensus issue workflow mirrors the same safety rule.
- Stale/inaccessible registered worktree paths now produce an explicit error instead of an implicit fallback/ambiguous failure.
- Regression coverage proves dirty caller branch commits and untracked files do not leak into new task worktrees, and existing caller checkout reuse is rejected.

## Crusty review findings + fixes

1. **High: existing-branch path could use the caller checkout as the task worktree.** Fixed by detecting when the registered worktree or current branch path resolves to `REPO_PATH` and exiting with an issue #858 diagnostic.
2. **High: consensus worktree setup had the same reuse pattern.** Fixed the consensus recipe to refuse caller checkout reuse too.
3. **Medium: stale `git worktree list` registrations could fail unclearly.** Fixed with an explicit stale-registration error telling the operator to prune/remove it.

Final crusty self-review: no remaining substantive findings in the clean diff.

## Merge-ready evidence

Quality-audit SEEK -> VALIDATE -> FIX cycles:

1. SEEK dirty caller branch leakage on new task branches -> VALIDATE regression test `issue858_new_task_worktree_ignores_dirty_caller_branch` -> FIX confirmed new task worktree starts exactly at resolved base ref and is clean.
2. SEEK existing target branch/caller checkout reuse -> VALIDATE regression test `issue858_existing_branch_checked_out_in_caller_is_rejected` -> FIX fail-loud refusal with no downstream JSON emitted.
3. SEEK mirrored recipe paths and silent stale-worktree degradation -> VALIDATE `issue858_consensus_recipe_also_refuses_caller_checkout_reuse`, YAML/pre-commit checks -> FIX consensus recipe and explicit stale-registration diagnostic.

Validation run locally with cargo artifacts outside `/home`:

- `cargo test -p amplihack --test existing_branch_context` — 21 passed
- `cargo test -p amplihack --test default_workflow_decomposition` — 35 passed
- `cargo test -p amplihack --test consensus_workflow_decomposition` — 6 passed
- `cargo fmt --all --check` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `pre-commit run --all-files` — passed

Docs: no user-facing documented surface changed; behavior is an internal safety/error-path fix.

gadugi-test/qa-team CLI: not available in this worktree/session (`command -v gadugi-test` and `command -v qa-team` returned no path); direct affected Rust/recipe tests were run instead.

## Diff scope

Focused only on:

- `amplifier-bundle/recipes/workflow-worktree.yaml`
- `amplifier-bundle/recipes/consensus-issue-worktree.yaml`
- `tests/integration/existing_branch_context_test.rs`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd

## Final CI status

Rebased head `266d12ce810c6f87b15f8494d487f38c3ce4582a`: required checks passed:

- Lint & Format — SUCCESS
- Test — SUCCESS
- Install Smoke Test — SUCCESS
- Build x86_64-unknown-linux-gnu — SUCCESS
- Build aarch64-unknown-linux-gnu — SUCCESS
- Build x86_64-apple-darwin — SUCCESS
- Build aarch64-apple-darwin — SUCCESS