### PR TITLE
fix(signal): close JSON-quoted-key outbound redaction bypass (PR #1007 follow-up)

### DIFF
--- a/crates/amplihack-hooks/src/signal_integration/imp.rs
+++ b/crates/amplihack-hooks/src/signal_integration/imp.rs
@@ -554,10 +554,6 @@ fn stop(session_id: &str) -> anyhow::Result<()> {
     // session (bounded during the session, removed entirely at teardown).
     super::outbound::clear_outbound_fingerprints(&root, session_id);
 
-    // Drop the per-session outbound-fingerprint log so it does not outlive the
-    // session (bounded during the session, removed entirely at teardown).
-    super::outbound::clear_outbound_fingerprints(&root, session_id);
-
     Ok(())
 }
 

--- a/crates/amplihack-hooks/src/signal_integration/outbound.rs
+++ b/crates/amplihack-hooks/src/signal_integration/outbound.rs
@@ -64,7 +64,9 @@ static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(
             r"(?i)\b(?:sgnl://linkdevice|tsdevice:/)\?[^\s<>'\x22]+",
             "[REDACTED-SIGNAL-LINK]",
         ),
-        // `name: value` / `name = value` credential assignments. The value may
+        // `name: value` / `name = value` credential assignments. An optional
+        // closing quote after the key lets the common JSON shape
+        // (`"password": "secret"`) match instead of slipping through. The value may
         // be prefixed by an HTTP auth scheme word (`Bearer`/`Basic`/`Token`),
         // as in `Authorization: Bearer <jwt>`; that prefix is consumed as part
         // of the value so the credential is fully redacted. Without this, the
@@ -72,7 +74,7 @@ static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(
         // the "value"), strip it, and leave the real token exposed for the
         // later, now-unanchored Bearer pattern to miss.
         (
-            r#"(?i)\b(api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|credential|authorization)\b\s*[:=]\s*['"]?(?:(?:bearer|basic|token)\s+)?[A-Za-z0-9._~+/=:-]{6,}['"]?"#,
+            r#"(?i)\b(api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|credential|authorization)\b['"]?\s*[:=]\s*['"]?(?:(?:bearer|basic|token)\s+)?[A-Za-z0-9._~+/=:-]{6,}['"]?"#,
             "$1=[REDACTED]",
         ),
         // GitHub tokens (PAT, OAuth, user-to-server, server-to-server, refresh).
@@ -271,6 +273,32 @@ mod tests {
         assert!(
             !out.contains(&tok),
             "token leaked via key=Bearer form: {out}"
+        );
+    }
+
+    #[test]
+    fn redacts_json_quoted_key_credentials() {
+        // Regression: the `key: value` pattern must tolerate a closing quote on
+        // the key so the extremely common JSON paste shape does not leak an
+        // opaque secret that matches no provider-specific pattern.
+        let secret = "hunter2plaintextsecret";
+        let out = redact_for_relay(&format!(r#"{{"password": "{secret}"}}"#));
+        assert!(!out.contains(secret), "json-quoted secret leaked: {out}");
+        assert!(out.contains("[REDACTED]"), "expected redaction: {out}");
+
+        // No-space, quoted `"token":"..."` variant must also be redacted.
+        let tok = "abcdef123456opaque";
+        let out = redact_for_relay(&format!(r#"{{"token":"{tok}"}}"#));
+        assert!(!out.contains(tok), "json no-space secret leaked: {out}");
+        assert!(out.contains("[REDACTED]"), "expected redaction: {out}");
+
+        // Benign prose ("token of appreciation") must NOT be redacted: the
+        // key must be immediately followed by a `:`/`=` delimiter.
+        let benign = "the token of appreciation was nice today";
+        assert_eq!(
+            redact_for_relay(benign),
+            benign,
+            "benign prose must not be redacted"
         );
     }
 


### PR DESCRIPTION
## Step 17e review remediation — follow-up to merged PR #1007

Code review of #1007 (R4 outbound Signal mirroring) surfaced a **High-severity** secret-redaction bypass plus a copy-paste bug. #1007 is already merged, so this lands the fixes on `main`.

### High (security): JSON-quoted-key redaction bypass
`crates/amplihack-hooks/src/signal_integration/outbound.rs`

The `key: value` credential pattern required the keyword to be **immediately** followed by `:`/`=`. The extremely common JSON shape therefore matched no pattern:

```
{"password": "hunter2plaintextsecret"}   -> LEAK (before)
{"token":"abcdef123456opaque"}           -> LEAK (before)
```

An opaque secret in JSON (a very common paste shape) survived unless it also matched a provider-specific shape (`ghp_`, `AKIA`, `AIza`, `xox`, `bearer`, url-userinfo). Since `redact_for_relay` mirrors raw prompts/assistant turns off-box into a (possibly multi-member) Signal group, this crosses the module's explicit "redact before it leaves the machine" boundary (cf. #882 / CWE-532).

**Fix:** allow an optional closing quote on the key before the `:`/`=` delimiter (`\b['"]?\s*[:=]`). Added regression test `redacts_json_quoted_key_credentials` covering the quoted-key and no-space JSON forms, plus a benign-prose negative case ("token of appreciation") to guard against over-redaction.

### Low: duplicated teardown call
`crates/amplihack-hooks/src/signal_integration/imp.rs`

`clear_outbound_fingerprints` was called twice back-to-back in `stop()` (copy-paste artifact; idempotent but unintended). Removed the duplicate.

### Verification
- 450 lib unit tests pass with `--features signal` (incl. 8 redaction tests, new one included)
- `cargo clippy -p amplihack-hooks --features signal` clean
- pre-commit (`cargo fmt --check`, `cargo clippy --all-targets -D warnings`) passed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>