### PR TITLE
test(ci): bound [profile.release] slice to next section header (#1033 S1)

### DIFF
--- a/tests/integration/ci_wallclock_parallelize_test.rs
+++ b/tests/integration/ci_wallclock_parallelize_test.rs
@@ -296,10 +296,18 @@ fn release_workflow_has_no_profile_overrides() {
 #[test]
 fn workspace_release_profile_keeps_full_optimization() {
     let content = read_root_cargo_toml();
+    let header = "[profile.release]";
     let start = content
-        .find("[profile.release]")
+        .find(header)
         .unwrap_or_else(|| panic!("FAIL: no [profile.release] in root Cargo.toml"));
-    let section = &content[start..];
+    // Bound the slice to the next TOML section header (`\n[`) instead of EOF so
+    // a future profile/section added after `[profile.release]` cannot satisfy
+    // the assertion on the wrong section's content and mask a regression.
+    let body = &content[start + header.len()..];
+    let end = body
+        .find("\n[")
+        .map_or(content.len(), |off| start + header.len() + off);
+    let section = &content[start..end];
     let lto = Regex::new(r"lto\s*=\s*true").unwrap();
     let cgu = Regex::new(r"codegen-units\s*=\s*1\b").unwrap();
     assert!(


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1033 addressing the single non-blocking review suggestion (**S1**), raised independently by both the Code Review (17b) and Philosophy Review (17d) gates.

## Problem

`workspace_release_profile_keeps_full_optimization` sliced `[profile.release]` to **EOF** (`&content[start..]`). This is airtight *today* because `[profile.release]` is the last profile section in the root `Cargo.toml` — but a future profile/section added after it could satisfy the `lto = true` / `codegen-units = 1` assertion on the **wrong** section's content and silently mask a regression.

## Change

Bound the slice to the next TOML section header (`\n[`) after `[profile.release]`, falling back to EOF when it is the last section:

```rust
let body = &content[start + header.len()..];
let end = body
    .find("\n[")
    .map_or(content.len(), |off| start + header.len() + off);
let section = &content[start..end];
```

## Validation

- `cargo test -p amplihack --test ci_wallclock_parallelize` → **12/12 passed**
- `cargo clippy --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean

Docs/behavior unchanged; this is a test-robustness hardening only.