### PR TITLE
ci: speed up PR lint by dropping --all-targets on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,19 @@ jobs:
       # --locked: fail fast on Cargo.lock drift here in the first job (rather than
       # only downstream in test/build), closing a dependency-substitution gap so
       # clippy can never silently resolve unpinned deps (#744 supply-chain).
-      - run: cargo clippy --locked --all-targets -- -D warnings
+      #
+      # Scope is conditional to keep PR feedback fast without losing coverage:
+      #   - PRs: lint lib+bins only (no --all-targets). This skips compiling the
+      #     60+ integration test binaries, the dominant cost of the ~16 min step.
+      #     Test-code *compile* breakage is still caught on PRs by the Test job.
+      #   - push to main + merge_group: full --all-targets so clippy lints test
+      #     code too before anything actually lands.
+      - name: Clippy (PR — lib/bins only, fast)
+        if: github.event_name == 'pull_request'
+        run: cargo clippy --locked --workspace -- -D warnings
+      - name: Clippy (main/merge_group — all targets, full)
+        if: github.event_name != 'pull_request'
+        run: cargo clippy --locked --all-targets -- -D warnings
 
   test:
     name: Test


### PR DESCRIPTION
## What
Part A of the CI lint-cost reduction. Makes clippy's target scope conditional on the CI event.

- **Pull requests:** `cargo clippy --locked --workspace -- -D warnings` (lib + bins only).
- **push to main + merge_group:** unchanged `cargo clippy --locked --all-targets -- -D warnings`.

## Why
The Lint & Format job is ~17 min, almost entirely the clippy step (~16.6 min / 997 s). `--all-targets` compiles the whole ~30-crate workspace **plus 60+ integration test binaries** from scratch (`cache-targets: false`, disabled to avoid runner disk exhaustion). Skipping the test-binary compiles on PRs gives faster lint feedback at no disk risk.

## Coverage trade-off
On PRs, clippy no longer lints test-code *style/lints* — but:
- Test-code *compile* breakage is still caught on PRs by the **Test** job.
- Full `--all-targets` clippy still runs on **push to main** and in the **merge queue**, so test code is fully linted before anything lands.

## Safety
- `cargo fmt --check`, all script checks, and the **"Lint & Format"** required-check name are unchanged → branch protection unaffected.
- Fully reversible (single conditional step).

## Follow-up (separate PR)
Part B: an artifact-caching spike (sccache GHA backend) to cut overall wall-clock across lint+test+builds — the shared root cause. Tracked separately.