### PR TITLE
feat(signal): Phase A — /signal topic-scoped bidirectional Signal bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ version = "0.11.1"
 dependencies = [
  "amplihack-state",
  "amplihack-types",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",

--- a/amplifier-bundle/skills/signal/SKILL.md
+++ b/amplifier-bundle/skills/signal/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: signal
+version: 1.0.0
+description: Drive an agent session from a Signal group chat. Opens an operator-only Signal group for a topic and turns every operator message into a real agent prompt with full session context.
+activation_keywords:
+  - "/signal"
+  - "signal bridge"
+  - "drive from signal"
+  - "run this in signal"
+  - "review over signal"
+  - "signal group review"
+  - "control from my phone"
+---
+
+# Signal Bridge Skill
+
+## Purpose
+
+Hand an agent task off to a **Signal group chat** and drive the whole session
+from your phone. The skill starts a **topic-scoped, bidirectional Signal
+bridge**: all agent output is posted to a fresh operator-only group, and every
+message you send in that group becomes the **next agent prompt** — with full
+prior session context preserved across turns.
+
+It is a thin wrapper: the skill simply shells out to
+`amplihack signal bridge "<topic>"`. All logic, security, and failure handling
+live in that subcommand (see [docs/SIGNAL_BRIDGE.md](../../../docs/SIGNAL_BRIDGE.md)).
+
+## When This Skill Activates
+
+- User wants to run/monitor/steer an agent task **from Signal** ("do this over
+  Signal", "let me drive this from my phone").
+- User wants an agent **review or investigation** delivered to a Signal group
+  they can reply into.
+- User types `/signal <topic>`.
+
+## How It Works
+
+The skill runs one command:
+
+```bash
+amplihack signal bridge "<topic>"
+```
+
+That command:
+
+1. Verifies the local signal-cli daemon is on `127.0.0.1` and the account is
+   linked (reusing `amplihack signal setup`; guides you to link via QR if not).
+2. Creates a fresh group `amplihack-<host>[-<tmux>]-<slug(topic)>`.
+3. Posts a first message announcing the **topic**, the **effective tool
+   allowlist** (blast radius), and the **control phrases** (`stop`/`kill`/`status`).
+4. Runs the first turn with the topic as the prompt and posts the reply.
+5. Loops: each accepted group message → one `copilot --session-id <uuid>` turn
+   (serialized, one at a time) → redacted, chunked output posted back.
+
+## Usage
+
+```text
+/signal start a crusty-old-engineer review of PR 3967
+```
+
+expands to:
+
+```bash
+amplihack signal bridge "start a crusty-old-engineer review of PR 3967"
+```
+
+### Scoped write access (explicit)
+
+Only investigation is allowed by default. To let the driven agent edit or run a
+specific command, add scoped tools:
+
+```bash
+amplihack signal bridge "fix the failing lint" \
+  --allow-tool view --allow-tool grep --allow-tool glob \
+  --allow-tool edit --allow-tool 'shell(cargo fmt)'
+```
+
+### Full tools (dangerous, explicit opt-in)
+
+```bash
+amplihack signal bridge "do whatever it takes" --dangerous-all-tools
+```
+
+## Control Phrases (in the group)
+
+| Phrase   | Effect |
+| -------- | ------ |
+| `status` | Post session id, current turn, allowlist, queue depth, membership status. |
+| `stop`   | Terminate the child agent immediately (even mid-turn), close the group, exit. |
+| `kill`   | Synonym for `stop`. |
+
+Control phrases are parsed **before** a message is treated as a prompt and
+always pre-empt an in-flight turn.
+
+## Security Notes
+
+- **An accepted message == typing into the agent.** The bridge is
+  **least-privilege by default** (read-only tools) and **fails closed**:
+  membership is verified before every outbound post, the daemon must be
+  loopback-only, and every accepted prompt is audit-logged (redacted). Do not
+  pass `--dangerous-all-tools` unless you fully trust the group membership.
+
+## Prerequisites
+
+- amplihack built with `--features signal`.
+- A linked signal-cli daemon on this host (`amplihack signal setup`).
+- `copilot` (GitHub Copilot CLI) on `PATH`.
+
+## Related
+
+- [docs/SIGNAL_BRIDGE.md](../../../docs/SIGNAL_BRIDGE.md) — full usage, security
+  contract, configuration, and failure modes.
+- [docs/SIGNAL_ONBOARDING.md](../../../docs/SIGNAL_ONBOARDING.md) — linking and
+  the local daemon.

--- a/crates/amplihack-cli/src/cli_subcommands.rs
+++ b/crates/amplihack-cli/src/cli_subcommands.rs
@@ -612,6 +612,12 @@ pub enum SignalCommands {
     /// with its OWN local signal-cli daemon + config. Resumable and per-VM
     /// isolated (one VM failing never aborts the rest).
     Distribute(SignalDistributeArgs),
+    /// Drive an agent session from a fresh, operator-only Signal group for a
+    /// topic. All agent output is posted to the group; every operator message
+    /// becomes the next `copilot --session-id` turn with full session context.
+    /// Least-privilege by default (read-only tools), fail-closed membership
+    /// verification, loopback-only daemon.
+    Bridge(SignalBridgeArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -676,4 +682,51 @@ pub struct SignalDistributeArgs {
     /// Retry VMs already recorded as terminal-success (otherwise skipped).
     #[arg(long)]
     pub force: bool,
+}
+
+/// `amplihack signal bridge <topic>` — drive an agent session from a Signal
+/// group. See `docs/SIGNAL_BRIDGE.md` for the full security and failure
+/// contract. Least-privilege by default: with no `--allow-tool` the driven
+/// agent gets only read-only investigation tools.
+#[derive(Args, Debug, Clone)]
+pub struct SignalBridgeArgs {
+    /// Free-text topic for the session. Used as the first turn's prompt and to
+    /// derive the group name `amplihack-<host>[-<tmux>]-<slug(topic)>`.
+    pub topic: String,
+
+    /// Add one tool to the scoped Copilot allowlist. Repeatable, order-preserving
+    /// (maps to `copilot --allow-tool <TOOL>`). With none given the agent gets
+    /// the read-only default (`view`/`grep`/`glob`).
+    #[arg(long = "allow-tool")]
+    pub allow_tool: Vec<String>,
+
+    /// Explicit opt-in to grant **all** Copilot tools (`--allow-all-tools`, not
+    /// the wider `--allow-all`). Overrides `--allow-tool`. Dangerous: an accepted
+    /// group message can then invoke any tool.
+    #[arg(long = "dangerous-all-tools")]
+    pub dangerous_all_tools: bool,
+
+    /// Override the generated group name entirely.
+    #[arg(long = "group-name")]
+    pub group_name: Option<String>,
+
+    /// Override the `<host>` token used in the generated group name (default:
+    /// system hostname).
+    #[arg(long)]
+    pub host: Option<String>,
+
+    /// Max reconnect attempts (bounded exponential backoff) before a clean
+    /// shutdown when the daemon is down. Defaults to 10.
+    #[arg(long = "retry-budget")]
+    pub retry_budget: Option<u32>,
+
+    /// Bounded turn-queue capacity (also settable via
+    /// `AMPLIHACK_SIGNAL_INBOX_CAPACITY`). Defaults to 32.
+    #[arg(long = "inbox-capacity")]
+    pub inbox_capacity: Option<usize>,
+
+    /// Explicit, documented opt-in to allow a **non-loopback** signal-cli daemon
+    /// endpoint. Without it, a non-`127.0.0.1` endpoint fails closed (exit 2).
+    #[arg(long = "unsafe-remote-endpoint")]
+    pub unsafe_remote_endpoint: bool,
 }

--- a/crates/amplihack-cli/src/commands/signal/bridge.rs
+++ b/crates/amplihack-cli/src/commands/signal/bridge.rs
@@ -1,0 +1,365 @@
+//! `amplihack signal bridge <topic>` — runtime orchestration (gated I/O shell).
+//!
+//! This drives a Copilot session from a fresh, operator-only Signal group. All
+//! decision logic lives in the reusable, unit-tested cores in
+//! `amplihack_signal::bridge`; this file performs the effects: config/link
+//! check, loopback validation, resume probe, daemon connect, group create, the
+//! announcement, the first turn, and the subscriber loop.
+//!
+//! Security posture (see `docs/SIGNAL_BRIDGE.md`): least-privilege tools by
+//! default, **fail-closed** outbound membership verification before every post,
+//! loopback-only daemon unless an explicit opt-in, an audit log of every
+//! accepted prompt, and outbound secret redaction before chunking. No silent
+//! fallbacks — every fatal condition maps to a stable [`BridgeError`] exit code.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use amplihack_signal::bridge::allowlist::ToolAllowlist;
+use amplihack_signal::bridge::control::{Control, parse_control};
+use amplihack_signal::bridge::membership::{Membership, classify};
+use amplihack_signal::bridge::outbound::redact_and_chunk;
+use amplihack_signal::bridge::turn::{CopilotTurnRunner, SerialTurnDriver};
+use amplihack_signal::bridge::{BridgeError, connect_daemon, validate_endpoint};
+use amplihack_signal::config::SignalConfig;
+use amplihack_signal::gating::Gate;
+use amplihack_signal::session_channel::Inbox;
+use amplihack_signal::transport::{GroupId, SignalTransport};
+
+use crate::SignalBridgeArgs;
+
+/// Default reconnect attempts before a clean daemon-down shutdown.
+const DEFAULT_RETRY_BUDGET: u32 = 10;
+
+/// The `copilot` binary the bridge drives (turn-based `--session-id` resume).
+const COPILOT_BIN: &str = "copilot";
+
+/// Entry point for `amplihack signal bridge`. Blocks on an async runtime and
+/// returns the stable [`BridgeError`] taxonomy on failure.
+pub fn run_bridge(args: SignalBridgeArgs) -> Result<(), BridgeError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| {
+            eprintln!("error: failed to start async runtime: {e}");
+            BridgeError::NotLinked
+        })?;
+    runtime.block_on(run_bridge_async(args))
+}
+
+/// Best-effort system hostname for the group-name `<host>` token.
+fn hostname() -> String {
+    std::fs::read_to_string("/etc/hostname")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("HOSTNAME").ok())
+        .unwrap_or_else(|| "host".to_string())
+}
+
+/// The current tmux session name, if the bridge is running inside tmux.
+fn tmux_session() -> Option<String> {
+    std::env::var_os("TMUX")?;
+    let out = std::process::Command::new("tmux")
+        .args(["display-message", "-p", "#S"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if name.is_empty() { None } else { Some(name) }
+}
+
+/// Probe that the installed `copilot` accepts `--session-id` resume. Without it,
+/// turn continuity cannot be guaranteed, so the bridge refuses to start.
+fn probe_copilot_resume() -> Result<(), BridgeError> {
+    let out = std::process::Command::new(COPILOT_BIN)
+        .arg("--help")
+        .output()
+        .map_err(|_| BridgeError::ResumeProbeFailed)?;
+    let help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    if help.contains("--session-id") {
+        Ok(())
+    } else {
+        Err(BridgeError::ResumeProbeFailed)
+    }
+}
+
+/// The expected operator-only member set: the allowlisted senders plus the
+/// account amplihack itself sends as.
+fn expected_members(cfg: &SignalConfig) -> Vec<String> {
+    let mut set = cfg.allowlist.clone();
+    if !set.contains(&cfg.account) {
+        set.push(cfg.account.clone());
+    }
+    set
+}
+
+/// Verify group membership, then relay `body` (redacted + chunked) — FAIL
+/// CLOSED. If membership cannot be positively verified, alert the local
+/// terminal and skip the relay (never assume "probably fine").
+async fn verify_and_post(
+    transport: &mut SignalTransport,
+    group_id: &GroupId,
+    expected: &[String],
+    gate: &mut Gate,
+    body: &str,
+) {
+    let actual = transport.group_members(group_id).await.ok();
+    let membership = classify(expected, actual.as_deref());
+    if let Membership::Unverified(reason) = &membership {
+        eprintln!(
+            "signal bridge: WITHHOLDING outbound relay — group membership unverified: {reason}"
+        );
+        return;
+    }
+    for chunk in redact_and_chunk(body) {
+        if let Err(e) = transport.send_group(group_id, &chunk).await {
+            eprintln!("signal bridge: failed to post to group: {e}");
+            return;
+        }
+        gate.record_outbound(&chunk);
+    }
+}
+
+/// Audit-log an accepted prompt (redacted) to the local terminal.
+fn audit_accepted(session_id: &str, sender: &str, device: Option<u32>, prompt: &str) {
+    let redacted = amplihack_signal::bridge::outbound::redact_for_relay(prompt);
+    let preview: String = redacted.chars().take(120).collect();
+    tracing::info!(
+        session_id,
+        sender,
+        device = device.unwrap_or(0),
+        "signal bridge accepted prompt: {preview}"
+    );
+    eprintln!("signal bridge: accepted prompt from {sender} (device {device:?}): {preview}");
+}
+
+async fn run_bridge_async(args: SignalBridgeArgs) -> Result<(), BridgeError> {
+    // 1. Load config (also our linked/configured check). A missing/invalid
+    //    config means the host is not onboarded → guide the operator.
+    let cfg = SignalConfig::load().map_err(|e| {
+        eprintln!(
+            "error: signal is not configured on this host ({e}).\n\
+             Run `amplihack signal setup` to link a device and start the daemon."
+        );
+        BridgeError::NotLinked
+    })?;
+
+    // 2. Loopback safety (fail closed unless explicit opt-in).
+    validate_endpoint(&cfg.endpoint, args.unsafe_remote_endpoint).inspect_err(|_| {
+        eprintln!(
+            "error: signal-cli endpoint {} is not loopback. Pass --unsafe-remote-endpoint to \
+             override (never across an untrusted network).",
+            cfg.endpoint
+        );
+    })?;
+
+    // 3. Copilot resume probe (turn continuity precondition).
+    probe_copilot_resume().inspect_err(|_| {
+        eprintln!(
+            "error: the installed `copilot` did not accept `--session-id` resume; turn \
+             continuity cannot be guaranteed."
+        );
+    })?;
+
+    // 4. Connect to the daemon with a bounded retry budget.
+    let retry_budget = args.retry_budget.unwrap_or(DEFAULT_RETRY_BUDGET);
+    let mut transport = connect_daemon(&cfg.endpoint, retry_budget)
+        .await
+        .inspect_err(|_| {
+            eprintln!(
+                "error: signal-cli daemon at {} was unreachable after {retry_budget} attempts; \
+                 shutting down cleanly.",
+                cfg.endpoint
+            );
+        })?;
+
+    // 5. Derive the group name and create a fresh operator-only group.
+    let host = args.host.clone().unwrap_or_else(hostname);
+    let tmux = tmux_session();
+    let group_name = args.group_name.clone().unwrap_or_else(|| {
+        amplihack_signal::bridge::naming::group_name(&host, tmux.as_deref(), &args.topic)
+    });
+    let group_id = transport.create_group(&group_name).await.map_err(|e| {
+        eprintln!("error: failed to create Signal group '{group_name}': {e}");
+        BridgeError::GroupCreateFailed
+    })?;
+    eprintln!(
+        "signal bridge: created group '{group_name}' ({})",
+        group_id.as_str()
+    );
+
+    // 6. Fresh pinned session id + effective allowlist.
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let allowlist = ToolAllowlist::from_flags(&args.allow_tool, args.dangerous_all_tools);
+    let expected = expected_members(&cfg);
+    let mut gate = Gate::new(&cfg, group_id.as_str());
+
+    // Shared child-PID slot so a control `stop`/`kill` can pre-empt an in-flight
+    // turn even mid-execution.
+    let current_pid = Arc::new(Mutex::new(None::<u32>));
+    let driver = Arc::new(SerialTurnDriver::new(
+        CopilotTurnRunner::new(COPILOT_BIN, current_pid.clone()),
+        &session_id,
+        allowlist.clone(),
+    ));
+
+    // 7. Announce topic, blast radius, and control phrases.
+    let announcement = format!(
+        "amplihack signal bridge started.\n\
+         topic: {}\n\
+         session: {}\n\
+         tools ({}): {}\n\
+         controls: `status`, `stop`, `kill` (exact word).",
+        args.topic,
+        session_id,
+        if allowlist.is_dangerous() {
+            "DANGEROUS"
+        } else {
+            "least-privilege"
+        },
+        allowlist.describe(),
+    );
+    verify_and_post(
+        &mut transport,
+        &group_id,
+        &expected,
+        &mut gate,
+        &announcement,
+    )
+    .await;
+
+    // Bounded turn queue (operator-configurable), mirroring the session inbox.
+    let capacity = args.inbox_capacity.unwrap_or_else(Inbox::default_capacity);
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    // 8. First turn: the topic itself is the opening prompt.
+    let (turn_tx, mut turn_rx) = tokio::sync::mpsc::unbounded_channel::<TurnResult>();
+    let mut turn_in_flight = spawn_turn(&driver, &turn_tx, args.topic.clone());
+
+    // 9. Subscriber loop.
+    loop {
+        tokio::select! {
+            biased;
+            // Post completed turn output promptly, then start the next queued turn.
+            Some(result) = turn_rx.recv() => {
+                turn_in_flight = false;
+                match result.output {
+                    Ok(body) if !body.trim().is_empty() => {
+                        verify_and_post(&mut transport, &group_id, &expected, &mut gate, &body).await;
+                    }
+                    Ok(_) => {
+                        verify_and_post(&mut transport, &group_id, &expected, &mut gate,
+                            "(turn produced no output)").await;
+                    }
+                    Err(e) => {
+                        // Surface the failure but keep the bridge alive; the next
+                        // turn resumes the SAME session (context preserved).
+                        verify_and_post(&mut transport, &group_id, &expected, &mut gate,
+                            &format!("turn failed: {e}")).await;
+                    }
+                }
+                if !turn_in_flight {
+                    let next = queue.pop_front();
+                    if let Some(next) = next {
+                        turn_in_flight = spawn_turn(&driver, &turn_tx, next);
+                    }
+                }
+            }
+            // Inbound Signal frames.
+            recv = transport.receive() => {
+                let env = match recv {
+                    Ok(Some(env)) => env,
+                    Ok(None) => {
+                        eprintln!("signal bridge: receive stream closed; shutting down.");
+                        break;
+                    }
+                    Err(e) => {
+                        eprintln!("signal bridge: receive error: {e}");
+                        continue;
+                    }
+                };
+                let sender = env.source.clone().unwrap_or_default();
+                let device = env.source_device;
+                let Some(body) = gate.evaluate(&env) else { continue };
+                if body.is_empty() {
+                    continue;
+                }
+                // Control phrases are parsed BEFORE a body becomes a prompt.
+                match parse_control(&body) {
+                    Control::Status => {
+                        let status = format!(
+                            "status: session {} | {} | queue depth {} | membership: verifying before each post",
+                            session_id,
+                            if turn_in_flight { "turn in flight" } else { "idle" },
+                            queue.len(),
+                        );
+                        verify_and_post(&mut transport, &group_id, &expected, &mut gate, &status).await;
+                    }
+                    Control::Stop => {
+                        eprintln!("signal bridge: stop received; terminating child and closing group.");
+                        preempt_child(&current_pid);
+                        let _ = transport.quit_group(&group_id).await;
+                        break;
+                    }
+                    Control::Prompt(prompt) => {
+                        audit_accepted(&session_id, &sender, device, &prompt);
+                        if turn_in_flight {
+                            queue.push_back(prompt);
+                            while queue.len() > capacity {
+                                queue.pop_front();
+                                eprintln!(
+                                    "signal bridge: turn queue at capacity ({capacity}); dropped oldest pending prompt."
+                                );
+                            }
+                        } else {
+                            turn_in_flight = spawn_turn(&driver, &turn_tx, prompt);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// The result of one background turn task.
+struct TurnResult {
+    output: std::io::Result<String>,
+}
+
+/// Spawn one serialized turn on the driver, delivering its result over `tx`.
+/// Returns `true` (a turn is now in flight).
+fn spawn_turn(
+    driver: &Arc<SerialTurnDriver<CopilotTurnRunner>>,
+    tx: &tokio::sync::mpsc::UnboundedSender<TurnResult>,
+    prompt: String,
+) -> bool {
+    let driver = driver.clone();
+    let tx = tx.clone();
+    tokio::spawn(async move {
+        let output = driver.run_turn(&prompt).await;
+        let _ = tx.send(TurnResult { output });
+    });
+    true
+}
+
+/// Terminate the currently-tracked child `copilot` PID, if any, pre-empting an
+/// in-flight turn. Best-effort; uses `SIGKILL` via the `kill` syscall.
+fn preempt_child(current_pid: &Arc<Mutex<Option<u32>>>) {
+    let pid = *current_pid.lock().expect("pid mutex not poisoned");
+    if let Some(pid) = pid {
+        // SAFETY: `kill(2)` with a real PID and SIGKILL (9). A stale PID simply
+        // returns ESRCH, which we ignore.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        }
+    }
+}

--- a/crates/amplihack-cli/src/commands/signal/mod.rs
+++ b/crates/amplihack-cli/src/commands/signal/mod.rs
@@ -21,6 +21,8 @@
 //! - `run` — the runtime orchestration (signal-cli, daemon, azlin), gated.
 
 #[cfg(feature = "signal")]
+pub mod bridge;
+#[cfg(feature = "signal")]
 pub mod config_writer;
 #[cfg(feature = "signal")]
 pub mod daemon;
@@ -54,9 +56,22 @@ use anyhow::Result;
 /// Dispatch a `signal` subcommand (feature build).
 #[cfg(feature = "signal")]
 pub fn dispatch(command: SignalCommands) -> Result<()> {
+    // The bridge uses its own `BridgeError` exit-code taxonomy; the onboarding
+    // subcommands use `SignalOpError`. Both funnel through the stable exit-code
+    // helper so tooling can branch on outcomes.
+    if let SignalCommands::Bridge(args) = command {
+        return match bridge::run_bridge(args) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                eprintln!("error: {err}");
+                Err(crate::command_error::exit_error(err.exit_code()))
+            }
+        };
+    }
     let outcome = match command {
         SignalCommands::Setup(args) => run::run_setup(args),
         SignalCommands::Distribute(args) => run::run_distribute(args),
+        SignalCommands::Bridge(_) => unreachable!("bridge handled above"),
     };
     match outcome {
         Ok(()) => Ok(()),

--- a/crates/amplihack-cli/src/lib.rs
+++ b/crates/amplihack-cli/src/lib.rs
@@ -88,7 +88,8 @@ pub use cli_subcommands::{
     BuilderCommands, HygieneArtifactGuardArgs, HygieneCleanupArgs, HygieneCommands,
     MIN_CLEANUP_APPLY_OLDER_THAN_HOURS, MIN_CLEANUP_APPLY_OLDER_THAN_SECS, MemoryCommands,
     ModeCommands, MultitaskCommands, PluginCommands, QueryCodeCommands, RecipeCommands,
-    ReflectCommands, RemoteCommands, SignalCommands, SignalDistributeArgs, SignalSetupArgs,
+    ReflectCommands, RemoteCommands, SignalBridgeArgs, SignalCommands, SignalDistributeArgs,
+    SignalSetupArgs,
 };
 
 fn graph_db_backend_value_parser() -> PossibleValuesParser {

--- a/crates/amplihack-cli/tests/signal_bridge_it.rs
+++ b/crates/amplihack-cli/tests/signal_bridge_it.rs
@@ -1,0 +1,122 @@
+//! TDD contract tests for the `amplihack signal bridge <topic>` subcommand
+//! (CLI glue). Written **first**; expected to FAIL to compile until the
+//! `Bridge(SignalBridgeArgs)` clap variant and the `commands::signal::bridge`
+//! module exist.
+//!
+//! Run: `cargo test -p amplihack-cli --features signal --test signal_bridge_it`.
+//!
+//! Gated on the `signal` feature so a default build compiles it away (the
+//! subcommand's implementation only exists behind `--features signal`).
+#![cfg(feature = "signal")]
+
+use amplihack_cli::{SignalBridgeArgs, SignalCommands};
+use clap::Parser;
+
+/// Minimal wrapper so the `SignalCommands` subcommand tree can be parsed in
+/// isolation, exactly as it will be reached under `amplihack signal ...`.
+#[derive(Parser, Debug)]
+struct Wrapper {
+    #[command(subcommand)]
+    cmd: SignalCommands,
+}
+
+fn parse_bridge(args: &[&str]) -> SignalBridgeArgs {
+    let mut argv = vec!["amplihack-signal-test"];
+    argv.extend_from_slice(args);
+    match Wrapper::try_parse_from(argv)
+        .expect("bridge args must parse")
+        .cmd
+    {
+        SignalCommands::Bridge(a) => a,
+        other => panic!("expected Bridge subcommand, got {other:?}"),
+    }
+}
+
+#[test]
+fn topic_is_a_required_positional() {
+    let a = parse_bridge(&["bridge", "review PR 3967"]);
+    assert_eq!(a.topic, "review PR 3967");
+    // Sensible least-privilege defaults when nothing else is passed.
+    assert!(
+        a.allow_tool.is_empty(),
+        "no --allow-tool ⇒ read-only default later"
+    );
+    assert!(!a.dangerous_all_tools);
+    assert!(!a.unsafe_remote_endpoint);
+}
+
+#[test]
+fn missing_topic_is_a_parse_error() {
+    let err = Wrapper::try_parse_from(["amplihack-signal-test", "bridge"]);
+    assert!(
+        err.is_err(),
+        "topic is required; omitting it must fail to parse"
+    );
+}
+
+#[test]
+fn allow_tool_is_repeatable_and_ordered() {
+    let a = parse_bridge(&[
+        "bridge",
+        "topic",
+        "--allow-tool",
+        "edit",
+        "--allow-tool",
+        "shell(git commit)",
+    ]);
+    assert_eq!(a.allow_tool, vec!["edit", "shell(git commit)"]);
+    assert!(!a.dangerous_all_tools);
+}
+
+#[test]
+fn dangerous_all_tools_is_an_explicit_opt_in_flag() {
+    let a = parse_bridge(&["bridge", "topic", "--dangerous-all-tools"]);
+    assert!(a.dangerous_all_tools);
+}
+
+#[test]
+fn retry_budget_and_inbox_capacity_are_overridable() {
+    let a = parse_bridge(&[
+        "bridge",
+        "topic",
+        "--retry-budget",
+        "5",
+        "--inbox-capacity",
+        "64",
+    ]);
+    assert_eq!(a.retry_budget, Some(5));
+    assert_eq!(a.inbox_capacity, Some(64));
+}
+
+#[test]
+fn group_and_host_naming_overrides_are_accepted() {
+    let a = parse_bridge(&[
+        "bridge",
+        "topic",
+        "--group-name",
+        "amplihack-custom",
+        "--host",
+        "myhost",
+    ]);
+    assert_eq!(a.group_name.as_deref(), Some("amplihack-custom"));
+    assert_eq!(a.host.as_deref(), Some("myhost"));
+}
+
+#[test]
+fn unsafe_remote_endpoint_is_an_explicit_opt_in_flag() {
+    let a = parse_bridge(&["bridge", "topic", "--unsafe-remote-endpoint"]);
+    assert!(
+        a.unsafe_remote_endpoint,
+        "non-loopback endpoints require an explicit documented opt-in"
+    );
+}
+
+#[test]
+fn bridge_variant_reuses_the_shared_six_code_exit_contract() {
+    // The CLI maps bridge failures through amplihack-signal's BridgeError so the
+    // documented 6-code exit contract has a single source of truth.
+    use amplihack_signal::bridge::BridgeError;
+    assert_eq!(BridgeError::RemoteEndpointRejected.exit_code(), 2);
+    assert_eq!(BridgeError::DaemonUnavailable.exit_code(), 4);
+    assert_eq!(BridgeError::ResumeProbeFailed.exit_code(), 5);
+}

--- a/crates/amplihack-signal/Cargo.toml
+++ b/crates/amplihack-signal/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 # lib, pulls in no tokio-net stack, and costs nothing at runtime.
 default = []
 # Enables the whole channel (pure core + gated tokio TCP transport).
-signal = ["dep:tokio", "dep:tokio-stream"]
+signal = ["dep:tokio", "dep:tokio-stream", "dep:regex"]
 
 [dependencies]
 serde = { workspace = true }
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 toml = "0.8"
+regex = { version = "1", optional = true }
 amplihack-state = { workspace = true }
 amplihack-types = { workspace = true }
 tokio = { workspace = true, optional = true, features = [
@@ -28,6 +29,7 @@ tokio = { workspace = true, optional = true, features = [
     "macros",
     "time",
     "sync",
+    "process",
 ] }
 tokio-stream = { version = "0.1", optional = true }
 
@@ -40,6 +42,7 @@ tokio = { version = "1", features = [
     "io-util",
     "time",
     "sync",
+    "process",
 ] }
 
 # Fixture-driven envelope tests (pure wire parsing, no I/O).
@@ -51,3 +54,8 @@ path = "tests/envelope_fixtures.rs"
 [[test]]
 name = "session_channel_it"
 path = "tests/session_channel_it.rs"
+
+# Phase A `/signal` topic bridge contract tests (feature-gated).
+[[test]]
+name = "bridge_it"
+path = "tests/bridge_it.rs"

--- a/crates/amplihack-signal/src/bridge/allowlist.rs
+++ b/crates/amplihack-signal/src/bridge/allowlist.rs
@@ -1,0 +1,96 @@
+//! Scoped Copilot tool allowlist for the driven agent.
+//!
+//! An accepted inbound Signal message is equivalent to typing into the agent,
+//! so the bridge is **least-privilege by default**: with no explicit
+//! `--allow-tool`, the driven `copilot` gets only read-only investigation tools
+//! ([`ToolAllowlist::read_only_default`]). Broader access is granted only when
+//! the operator lists specific tools, and blanket access
+//! (`--allow-all-tools`) requires the explicit `--dangerous-all-tools` opt-in.
+//!
+//! Crucially, "dangerous" mode maps to Copilot's tools-only escape hatch
+//! `--allow-all-tools`, **never** the wider `--allow-all` (which would also
+//! grant unrestricted paths/URLs).
+
+/// The read-only investigation tools granted by default.
+const READ_ONLY_TOOLS: &[&str] = &["view", "grep", "glob"];
+
+/// An effective Copilot tool allowlist for one bridge session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolAllowlist {
+    /// When `true`, render `--allow-all-tools` and ignore `tools`.
+    dangerous: bool,
+    /// The scoped tool list (only meaningful when not `dangerous`).
+    tools: Vec<String>,
+}
+
+impl ToolAllowlist {
+    /// The least-privilege default: read-only `view` / `grep` / `glob`.
+    #[must_use]
+    pub fn read_only_default() -> Self {
+        Self {
+            dangerous: false,
+            tools: READ_ONLY_TOOLS.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    /// Resolve an allowlist from CLI flags.
+    ///
+    /// Precedence:
+    /// - `dangerous == true` ⇒ blanket [`--allow-all-tools`], regardless of
+    ///   `flags`.
+    /// - non-empty `flags` ⇒ exactly those scoped tools, in order.
+    /// - empty `flags` ⇒ the least-privilege [`read_only_default`].
+    ///
+    /// [`--allow-all-tools`]: ToolAllowlist::to_copilot_args
+    /// [`read_only_default`]: ToolAllowlist::read_only_default
+    #[must_use]
+    pub fn from_flags(flags: &[String], dangerous: bool) -> Self {
+        if dangerous {
+            Self {
+                dangerous: true,
+                tools: Vec::new(),
+            }
+        } else if flags.is_empty() {
+            Self::read_only_default()
+        } else {
+            Self {
+                dangerous: false,
+                tools: flags.to_vec(),
+            }
+        }
+    }
+
+    /// Whether this allowlist grants blanket tool access.
+    #[must_use]
+    pub fn is_dangerous(&self) -> bool {
+        self.dangerous
+    }
+
+    /// Render the allowlist as Copilot CLI arguments.
+    ///
+    /// Dangerous mode is a single `--allow-all-tools`; otherwise each tool is a
+    /// repeated `--allow-tool <TOOL>` pair, preserving order.
+    #[must_use]
+    pub fn to_copilot_args(&self) -> Vec<String> {
+        if self.dangerous {
+            return vec!["--allow-all-tools".to_string()];
+        }
+        let mut args = Vec::with_capacity(self.tools.len() * 2);
+        for tool in &self.tools {
+            args.push("--allow-tool".to_string());
+            args.push(tool.clone());
+        }
+        args
+    }
+
+    /// A human-readable, single-line description of the effective blast radius,
+    /// posted in the group's first announcement message.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        if self.dangerous {
+            "ALL TOOLS (dangerous: --allow-all-tools)".to_string()
+        } else {
+            format!("read-only/scoped tools: {}", self.tools.join(", "))
+        }
+    }
+}

--- a/crates/amplihack-signal/src/bridge/chunk.rs
+++ b/crates/amplihack-signal/src/bridge/chunk.rs
@@ -1,0 +1,42 @@
+//! Outbound message chunking sized to Signal's per-message limit.
+//!
+//! Agent turns can be far larger than a single Signal message. Before posting a
+//! (already-redacted) body to the group it is split into [`SIGNAL_MAX_BYTES`]
+//! chunks that reassemble losslessly. This bound is **distinct** from the
+//! inbound JSON-RPC frame bound (`transport::MAX_FRAME_BYTES`, 256 KiB): that
+//! caps a single wire frame, whereas this caps what one Signal message can
+//! usefully carry.
+
+/// Maximum size, in bytes, of a single outbound Signal message body.
+///
+/// Deliberately conservative and well under any JSON-RPC frame bound so a large
+/// agent turn is delivered as several readable messages rather than one giant
+/// (or rejected) one.
+pub const SIGNAL_MAX_BYTES: usize = 2000;
+
+/// Split `body` into chunks each at most [`SIGNAL_MAX_BYTES`] bytes.
+///
+/// Never splits a UTF-8 code point (each chunk is valid UTF-8), and the chunks
+/// reassemble to exactly `body` (`chunk(b).concat() == b`). A body already
+/// within the cap is returned as a single chunk; an empty body yields no
+/// chunks.
+#[must_use]
+pub fn chunk(body: &str) -> Vec<String> {
+    if body.is_empty() {
+        return Vec::new();
+    }
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < body.len() {
+        let mut end = (start + SIGNAL_MAX_BYTES).min(body.len());
+        // Back off to the nearest char boundary so no multibyte code point is
+        // cut. A single code point is at most 4 bytes, far below the cap, so
+        // `end` can never fall back all the way to `start`.
+        while end > start && !body.is_char_boundary(end) {
+            end -= 1;
+        }
+        chunks.push(body[start..end].to_string());
+        start = end;
+    }
+    chunks
+}

--- a/crates/amplihack-signal/src/bridge/control.rs
+++ b/crates/amplihack-signal/src/bridge/control.rs
@@ -1,0 +1,37 @@
+//! Control-phrase parsing for inbound bridge messages.
+//!
+//! Every accepted group message is first classified by [`parse_control`]
+//! **before** it is treated as an agent prompt. Reserved control words
+//! (`status`, `stop`, `kill`) are matched **only** as the entire message body
+//! (after trimming). Any other text — including a sentence that merely *contains*
+//! a reserved word — is a normal [`Control::Prompt`].
+//!
+//! This precedence is a safety property: `stop`/`kill` must always be able to
+//! pre-empt an in-flight turn, but the operator must equally be able to *talk*
+//! about stopping ("please stop the review") without accidentally killing the
+//! bridge.
+
+/// The classification of one inbound message body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Control {
+    /// Report bridge state to the group (session id, turn, allowlist, queue).
+    Status,
+    /// Pre-empt: terminate the child agent, close the group, and exit.
+    Stop,
+    /// Ordinary text to be run as the next agent prompt (verbatim, trimmed).
+    Prompt(String),
+}
+
+/// Classify one inbound message body.
+///
+/// Total function: never errors. Leading/trailing whitespace is ignored for the
+/// control-word comparison and stripped from the resulting prompt.
+#[must_use]
+pub fn parse_control(body: &str) -> Control {
+    let trimmed = body.trim();
+    match trimmed.to_ascii_lowercase().as_str() {
+        "status" => Control::Status,
+        "stop" | "kill" => Control::Stop,
+        _ => Control::Prompt(trimmed.to_string()),
+    }
+}

--- a/crates/amplihack-signal/src/bridge/membership.rs
+++ b/crates/amplihack-signal/src/bridge/membership.rs
@@ -1,0 +1,53 @@
+//! Outbound group-membership verification — **fail closed**.
+//!
+//! Because relaying agent output to the group leaks whatever the agent produced
+//! to every member, the bridge verifies the group's member set matches the
+//! expected operator-only set **before every outbound post**. Verification is
+//! positive-only: anything other than an exact match — an RPC error, a timeout,
+//! an ambiguous response, an unexpected extra member, or a missing expected
+//! member — is treated as [`Membership::Unverified`] and **refuses** the relay.
+//! The bridge never assumes "probably fine".
+
+use std::collections::BTreeSet;
+
+/// The result of comparing an actual group member set to the expected set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Membership {
+    /// The actual member set exactly equals the expected operator-only set.
+    Verified,
+    /// Membership could not be positively verified; relay must be withheld. The
+    /// string explains why (for the local terminal alert / audit log).
+    Unverified(String),
+}
+
+impl Membership {
+    /// Whether outbound relay is permitted. Only [`Membership::Verified`] is.
+    #[must_use]
+    pub fn may_relay(&self) -> bool {
+        matches!(self, Membership::Verified)
+    }
+}
+
+/// Classify group membership by comparing `actual` to `expected`.
+///
+/// `actual == None` models an RPC error / timeout / ambiguous response and is
+/// always [`Membership::Unverified`]. A `Some` set must equal `expected` as a
+/// set (order- and duplicate-insensitive) to be [`Membership::Verified`].
+#[must_use]
+pub fn classify(expected: &[String], actual: Option<&[String]>) -> Membership {
+    let Some(actual) = actual else {
+        return Membership::Unverified(
+            "group membership query failed or was ambiguous (no member set)".to_string(),
+        );
+    };
+    let expected_set: BTreeSet<&String> = expected.iter().collect();
+    let actual_set: BTreeSet<&String> = actual.iter().collect();
+    if expected_set == actual_set {
+        return Membership::Verified;
+    }
+    let unexpected: Vec<&&String> = actual_set.difference(&expected_set).collect();
+    let missing: Vec<&&String> = expected_set.difference(&actual_set).collect();
+    Membership::Unverified(format!(
+        "group membership mismatch (unexpected: {unexpected:?}, missing: {missing:?})"
+    ))
+}

--- a/crates/amplihack-signal/src/bridge/mod.rs
+++ b/crates/amplihack-signal/src/bridge/mod.rs
@@ -1,0 +1,124 @@
+//! The `/signal` topic bridge: reusable core for driving a Copilot session from
+//! a Signal group.
+//!
+//! This module tree is the crate-side, reusable half of the bridge (the CLI
+//! subcommand glue lives in `amplihack-cli`). It holds the pure, unit-tested
+//! pieces — [`naming`], [`control`], [`allowlist`], [`chunk`], [`membership`],
+//! [`outbound`] redaction, and the [`turn`] driver — plus the small set of
+//! fail-closed I/O helpers below ([`validate_endpoint`], [`connect_daemon`])
+//! and the shared [`BridgeError`] exit-code taxonomy.
+//!
+//! Security posture (see `docs/SIGNAL_BRIDGE.md`): least-privilege tools by
+//! default, fail-closed outbound membership verification, loopback-only daemon
+//! unless an explicit unsafe opt-in, and no silent fallbacks — every failure is
+//! surfaced with a stable exit code.
+
+pub mod allowlist;
+pub mod chunk;
+pub mod control;
+pub mod membership;
+pub mod naming;
+pub mod outbound;
+pub mod turn;
+
+use std::time::Duration;
+
+/// The bridge's stable exit-code taxonomy.
+///
+/// Together with a `0` (clean shutdown / normal end) this is the documented
+/// **6-code exit contract** operators script against. Each variant maps to
+/// exactly one non-zero code via [`BridgeError::exit_code`].
+#[derive(Debug, thiserror::Error)]
+pub enum BridgeError {
+    /// The account is not linked (or the feature/setup prerequisites are
+    /// missing). Exit `1`.
+    #[error("signal account not linked or bridge prerequisites missing")]
+    NotLinked,
+    /// A non-loopback daemon endpoint was rejected without the explicit
+    /// `--unsafe-remote-endpoint` opt-in. Exit `2`.
+    #[error("non-loopback signal-cli endpoint rejected (loopback safety)")]
+    RemoteEndpointRejected,
+    /// The operator-only group could not be created/joined. Exit `3`.
+    #[error("failed to create the operator-only Signal group")]
+    GroupCreateFailed,
+    /// The signal-cli daemon was not reachable within the retry budget. Exit `4`.
+    #[error("signal-cli daemon unavailable after exhausting the retry budget")]
+    DaemonUnavailable,
+    /// The installed `copilot` did not accept `--session-id` resume, so turn
+    /// continuity cannot be guaranteed. Exit `5`.
+    #[error("copilot session-resume probe failed (--session-id unsupported)")]
+    ResumeProbeFailed,
+}
+
+impl BridgeError {
+    /// The stable process exit code for this error.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            BridgeError::NotLinked => 1,
+            BridgeError::RemoteEndpointRejected => 2,
+            BridgeError::GroupCreateFailed => 3,
+            BridgeError::DaemonUnavailable => 4,
+            BridgeError::ResumeProbeFailed => 5,
+        }
+    }
+}
+
+/// Whether `host` is a loopback address (or `localhost`).
+fn is_loopback_host(host: &str) -> bool {
+    let host = host.trim();
+    // Strip IPv6 brackets, e.g. `[::1]`.
+    let host = host.strip_prefix('[').unwrap_or(host);
+    let host = host.strip_suffix(']').unwrap_or(host);
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    match host.parse::<std::net::IpAddr>() {
+        Ok(ip) => ip.is_loopback(),
+        Err(_) => false,
+    }
+}
+
+/// Validate a signal-cli daemon `endpoint` (`host:port`) for loopback safety.
+///
+/// A loopback endpoint is always accepted. A non-loopback endpoint is accepted
+/// **only** when `unsafe_remote` is `true` (the explicit, documented
+/// opt-in); otherwise it **fails closed** with
+/// [`BridgeError::RemoteEndpointRejected`].
+pub fn validate_endpoint(endpoint: &str, unsafe_remote: bool) -> Result<(), BridgeError> {
+    if unsafe_remote {
+        return Ok(());
+    }
+    // Split off the port from the right so IPv6 hosts (which contain colons)
+    // are handled: `[::1]:7583` → host `[::1]`.
+    let host = match endpoint.rsplit_once(':') {
+        Some((host, _port)) => host,
+        None => endpoint,
+    };
+    if is_loopback_host(host) {
+        Ok(())
+    } else {
+        Err(BridgeError::RemoteEndpointRejected)
+    }
+}
+
+/// Connect to the signal-cli JSON-RPC daemon with a bounded retry budget.
+///
+/// Uses capped exponential backoff via
+/// [`crate::transport::SignalTransport::connect_with_retry`]. If every attempt
+/// fails, the transient I/O error is surfaced as the stable
+/// [`BridgeError::DaemonUnavailable`] (exit `4`) rather than hanging or
+/// silently disabling the bridge.
+pub async fn connect_daemon(
+    endpoint: &str,
+    retry_budget: u32,
+) -> Result<crate::transport::SignalTransport, BridgeError> {
+    crate::transport::SignalTransport::connect_with_retry(
+        endpoint,
+        retry_budget,
+        Duration::from_millis(100),
+        Duration::from_secs(5),
+    )
+    .await
+    .map_err(|_| BridgeError::DaemonUnavailable)
+}

--- a/crates/amplihack-signal/src/bridge/naming.rs
+++ b/crates/amplihack-signal/src/bridge/naming.rs
@@ -1,0 +1,63 @@
+//! Deterministic Signal group naming for the `/signal` bridge.
+//!
+//! A bridge group is named `amplihack-<host>[-<tmux>]-<slug(topic)>` so an
+//! operator can tell at a glance which host, tmux session, and topic a group
+//! drives. Naming is a **pure function** — the same inputs always yield the
+//! same name — which keeps it unit-testable and free of hidden state.
+
+/// Maximum length of a slugified topic segment.
+///
+/// Signal imposes a limit on group names; the topic is the only unbounded
+/// segment (host and tmux tokens are short), so the cap is applied to it. The
+/// cap never leaves a dangling `-` (see [`slug`]).
+pub const MAX_TOPIC_SLUG: usize = 40;
+
+/// Slugify arbitrary free text into a lowercase, `-`-delimited token.
+///
+/// Rules (all applied):
+/// - lowercase,
+/// - every run of non-alphanumeric characters collapses to a single `-`,
+/// - leading/trailing `-` are trimmed,
+/// - the result is capped to [`MAX_TOPIC_SLUG`] bytes without leaving a
+///   trailing `-`.
+///
+/// Slugs are ASCII by construction (only `[a-z0-9-]`), so the byte cap is also
+/// a char cap and never splits a code point.
+#[must_use]
+pub fn slug(text: &str) -> String {
+    let mut out = String::with_capacity(text.len().min(MAX_TOPIC_SLUG));
+    let mut prev_dash = false;
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    // Trim to the cap, then strip any leading/trailing '-' (a trailing '-' can
+    // appear either from the input's edges or from truncation mid-separator).
+    let trimmed_len = out.len().min(MAX_TOPIC_SLUG);
+    out.truncate(trimmed_len);
+    out.trim_matches('-').to_string()
+}
+
+/// Build the deterministic bridge group name from its parts.
+///
+/// `tmux` is included only when present and non-empty (a bridge started outside
+/// tmux omits that segment). All parts are slugified so an odd hostname or
+/// session name cannot produce an invalid group name.
+#[must_use]
+pub fn group_name(host: &str, tmux: Option<&str>, topic: &str) -> String {
+    let mut parts = vec!["amplihack".to_string(), slug(host)];
+    if let Some(session) = tmux {
+        let s = slug(session);
+        if !s.is_empty() {
+            parts.push(s);
+        }
+    }
+    parts.push(slug(topic));
+    parts.retain(|p| !p.is_empty());
+    parts.join("-")
+}

--- a/crates/amplihack-signal/src/bridge/outbound.rs
+++ b/crates/amplihack-signal/src/bridge/outbound.rs
@@ -1,0 +1,101 @@
+//! Outbound secret redaction, applied **before** chunking.
+//!
+//! An accepted agent turn is captured verbatim from `copilot` stdout and can
+//! contain pasted or echoed credentials. Because the group may have more than
+//! one member, secrets must be scrubbed before any byte leaves the machine.
+//! [`redact_for_relay`] scrubs the high-frequency secret shapes; the bridge
+//! always pipes through [`redact_and_chunk`] so redaction happens over the
+//! **whole** body first and a secret can never straddle (and survive in) a
+//! chunk boundary.
+//!
+//! The pattern set mirrors the proven full-conversation mirroring redactor in
+//! `amplihack-hooks::signal_integration::outbound`; it is deliberately
+//! conservative and deterministic (idempotent) so benign prose is preserved.
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use super::chunk::chunk;
+
+/// Secret shapes scrubbed from a body before it is relayed to Signal, applied
+/// in order. The whole `key = value` form is redacted first so its placeholder
+/// cannot re-expose a value a later, narrower pattern would leave intact.
+static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    let specs: &[(&str, &str)] = &[
+        // PEM private-key blocks (multi-line): drop the whole armored body.
+        (
+            r"(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+            "[REDACTED-PRIVATE-KEY]",
+        ),
+        // Signal device-link URIs (linking a device would hijack the account).
+        (
+            r"(?i)\b(?:sgnl://linkdevice|tsdevice:/)\?[^\s<>'\x22]+",
+            "[REDACTED-SIGNAL-LINK]",
+        ),
+        // `name: value` / `name = value` credential assignments. An optional
+        // HTTP auth scheme word (Bearer/Basic/Token) is consumed as part of the
+        // value so the credential is fully redacted.
+        (
+            r#"(?i)\b(api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|credential|authorization)\b['"]?\s*[:=]\s*['"]?(?:(?:bearer|basic|token)\s+)?[A-Za-z0-9._~+/=:-]{6,}['"]?"#,
+            "$1=[REDACTED]",
+        ),
+        // GitHub tokens (PAT, OAuth, user-to-server, server-to-server, refresh).
+        (
+            r"\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b",
+            "[REDACTED-GITHUB-TOKEN]",
+        ),
+        // AWS access-key IDs.
+        (r"\bAKIA[0-9A-Z]{16}\b", "[REDACTED-AWS-KEY]"),
+        // Google API keys (fixed `AIza` prefix + 35 url-safe chars).
+        (r"\bAIza[0-9A-Za-z_-]{35}\b", "[REDACTED-GOOGLE-KEY]"),
+        // Credentials embedded in a URL's userinfo: keep scheme + username,
+        // drop the password so pasted connection strings do not leak.
+        (
+            r"(?i)\b([a-z][a-z0-9+.-]*://[^\s:@/]+):[^\s@/]+@",
+            "$1:[REDACTED]@",
+        ),
+        // Slack tokens.
+        (
+            r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
+            "[REDACTED-SLACK-TOKEN]",
+        ),
+        // HTTP bearer credentials (JWTs and opaque tokens alike).
+        (
+            r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}",
+            "[REDACTED-BEARER]",
+        ),
+    ];
+    specs
+        .iter()
+        .map(|(pattern, replacement)| {
+            (
+                Regex::new(pattern).expect("static relay redaction regex is valid"),
+                *replacement,
+            )
+        })
+        .collect()
+});
+
+/// Scrub high-frequency secret shapes out of `body`. Pure, idempotent, and
+/// allocation-light (only adopts a new buffer on a real match).
+#[must_use]
+pub fn redact_for_relay(body: &str) -> String {
+    let mut out = Cow::Borrowed(body);
+    for (re, replacement) in REDACTION_PATTERNS.iter() {
+        if let Cow::Owned(replaced) = re.replace_all(&out, *replacement) {
+            out = Cow::Owned(replaced);
+        }
+    }
+    out.into_owned()
+}
+
+/// Redact secrets over the whole body, **then** split into Signal-sized chunks.
+///
+/// Redacting before chunking guarantees no individual outbound message can leak
+/// a secret that would otherwise straddle a chunk boundary.
+#[must_use]
+pub fn redact_and_chunk(body: &str) -> Vec<String> {
+    chunk(&redact_for_relay(body))
+}

--- a/crates/amplihack-signal/src/bridge/turn.rs
+++ b/crates/amplihack-signal/src/bridge/turn.rs
@@ -1,0 +1,167 @@
+//! Copilot turn driver: build the pinned resume argv and serialize turns.
+//!
+//! The bridge drives the agent one **turn at a time** by resuming the same
+//! Copilot session: `copilot --session-id <uuid> --no-color -s -p "<msg>"
+//! <allowlist>`. Each turn is a fresh `copilot` process that resumes the SAME
+//! session id, so full prior context is preserved without any PTY, ANSI
+//! parsing, or streaming.
+//!
+//! Two seams live here:
+//! - [`build_turn_argv`] — the pure argv builder (injection-safe: the prompt is
+//!   always exactly one argv element, never concatenated into a shell string).
+//! - [`SerialTurnDriver`] — serializes turns so at most one turn per session
+//!   runs at a time, over an injectable [`TurnRunner`].
+//!
+//! [`CopilotTurnRunner`] is the production [`TurnRunner`]: it spawns the real
+//! `copilot` process, tracks its PID (so an out-of-band `stop` can pre-empt an
+//! in-flight turn), and captures clean stdout.
+
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use super::allowlist::ToolAllowlist;
+
+/// Build the Copilot resume argv for one turn.
+///
+/// Layout: `--session-id <SID> --no-color -s -p <PROMPT> <allowlist...>`.
+///
+/// - `--session-id <SID>` pins turn continuity (resume the same session).
+/// - `--no-color` guarantees ANSI-free stdout before redaction/chunking.
+/// - `-s` (silent) captures the response only.
+/// - `-p <PROMPT>` passes the (attacker-influenced) prompt as **exactly one**
+///   argv element, verbatim — never a shell string — so metacharacters cannot
+///   inject a command.
+///
+/// The returned vector is the *argument* list (the program, `copilot`, is
+/// supplied by the runner).
+#[must_use]
+pub fn build_turn_argv(session_id: &str, prompt: &str, allowlist: &ToolAllowlist) -> Vec<String> {
+    let mut argv = vec![
+        "--session-id".to_string(),
+        session_id.to_string(),
+        "--no-color".to_string(),
+        "-s".to_string(),
+        "-p".to_string(),
+        prompt.to_string(),
+    ];
+    argv.extend(allowlist.to_copilot_args());
+    argv
+}
+
+/// An injectable executor of one Copilot turn given its argv.
+///
+/// Returns the captured stdout on success. Implemented for real by
+/// [`CopilotTurnRunner`] and by mocks in tests.
+pub trait TurnRunner: Send + Sync {
+    /// Run `copilot` with `argv` and resolve to its captured stdout.
+    fn run_argv(
+        &self,
+        argv: Vec<String>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<String>> + Send>>;
+}
+
+/// Serializes turns for one pinned session so at most one turn runs at a time.
+///
+/// Turn continuity requires that two `copilot --session-id <same>` processes are
+/// never in flight concurrently (they would race the same session state). An
+/// async mutex enforces one-at-a-time execution even when `run_turn` is called
+/// from multiple tasks.
+pub struct SerialTurnDriver<R: TurnRunner> {
+    runner: R,
+    session_id: String,
+    allowlist: ToolAllowlist,
+    lock: tokio::sync::Mutex<()>,
+}
+
+impl<R: TurnRunner> SerialTurnDriver<R> {
+    /// Create a driver bound to `session_id` and `allowlist`.
+    #[must_use]
+    pub fn new(runner: R, session_id: &str, allowlist: ToolAllowlist) -> Self {
+        Self {
+            runner,
+            session_id: session_id.to_string(),
+            allowlist,
+            lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    /// The pinned session id this driver resumes.
+    #[must_use]
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Run one turn with `prompt`, serialized against any other turn.
+    pub async fn run_turn(&self, prompt: &str) -> io::Result<String> {
+        let argv = build_turn_argv(&self.session_id, prompt, &self.allowlist);
+        // Hold the lock across the whole child lifetime so turns never overlap.
+        let _guard = self.lock.lock().await;
+        self.runner.run_argv(argv).await
+    }
+}
+
+/// Production [`TurnRunner`]: spawns the real `copilot` binary.
+///
+/// The currently-running child's PID is published into a shared slot so an
+/// out-of-band control message (`stop`/`kill`) can terminate an in-flight turn.
+/// On a non-zero exit the combined stderr/stdout is surfaced as an error so the
+/// bridge can post the failure to the group and keep going (the next turn
+/// resumes the same session, context intact).
+pub struct CopilotTurnRunner {
+    program: String,
+    current_pid: Arc<Mutex<Option<u32>>>,
+}
+
+impl CopilotTurnRunner {
+    /// Create a runner for `program` (typically `copilot`) sharing `current_pid`
+    /// so the bridge can pre-empt the in-flight child.
+    #[must_use]
+    pub fn new(program: impl Into<String>, current_pid: Arc<Mutex<Option<u32>>>) -> Self {
+        Self {
+            program: program.into(),
+            current_pid,
+        }
+    }
+}
+
+impl TurnRunner for CopilotTurnRunner {
+    fn run_argv(
+        &self,
+        argv: Vec<String>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<String>> + Send>> {
+        let program = self.program.clone();
+        let current_pid = self.current_pid.clone();
+        Box::pin(async move {
+            use tokio::process::Command;
+
+            let child = Command::new(&program)
+                .args(&argv)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()?;
+
+            if let Some(pid) = child.id() {
+                *current_pid.lock().expect("pid mutex not poisoned") = Some(pid);
+            }
+
+            let output = child.wait_with_output().await;
+            // Clear the published PID regardless of outcome.
+            *current_pid.lock().expect("pid mutex not poisoned") = None;
+            let output = output?;
+
+            if output.status.success() {
+                Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                Err(io::Error::other(format!(
+                    "copilot turn failed ({}): {}{}",
+                    output.status, stdout, stderr
+                )))
+            }
+        })
+    }
+}

--- a/crates/amplihack-signal/src/lib.rs
+++ b/crates/amplihack-signal/src/lib.rs
@@ -13,10 +13,16 @@
 //!   echo suppression).
 //! - [`session_channel`] — [`session_channel::SignalSession`] and the
 //!   file-backed [`session_channel::Inbox`].
+//! - [`bridge`] — the `/signal` topic bridge core (deterministic group naming,
+//!   control-phrase parsing, scoped tool allowlist, outbound redaction +
+//!   Signal-sized chunking, fail-closed membership verification, and the
+//!   serialized Copilot turn driver).
 //!
 //! Trust model: inbound Signal text is **data, never commands**. It is only
 //! ever surfaced to the agent as `additionalContext`; it is never executed.
 
+#[cfg(feature = "signal")]
+pub mod bridge;
 #[cfg(feature = "signal")]
 pub mod config;
 #[cfg(feature = "signal")]

--- a/crates/amplihack-signal/src/transport.rs
+++ b/crates/amplihack-signal/src/transport.rs
@@ -69,6 +69,10 @@ pub enum WireError {
     /// The input line was not valid JSON.
     #[error("invalid JSON frame: {0}")]
     Json(String),
+    /// Group membership could not be positively determined from a JSON-RPC
+    /// result (fail-closed: absent / empty / wrong-group / malformed).
+    #[error("group membership unavailable: {0}")]
+    Membership(String),
 }
 
 /// Build a JSON-RPC 2.0 `send` request frame for an outbound group message.
@@ -152,10 +156,50 @@ pub fn parse_incoming(line: &str) -> Result<Envelope, WireError> {
     })
 }
 
+/// Extract the E.164 member numbers of `group_id` from a signal-cli
+/// `listGroups` result, **failing closed**.
+///
+/// The result is expected to be an array of group objects, each with an `id`
+/// and a `members` array of `{ "number": "+E164" }` entries. This returns
+/// [`WireError::Membership`] — never `Ok` of an empty set — whenever membership
+/// cannot be positively determined: a non-array/malformed value, the target
+/// group not being present, an absent `members` field, or an empty member set.
+/// Fail-closed is essential: the caller uses the returned set to decide whether
+/// it is safe to relay agent output to the group.
+pub fn parse_group_members(value: &Value, group_id: &str) -> Result<Vec<String>, WireError> {
+    let groups = value
+        .as_array()
+        .ok_or_else(|| WireError::Membership("listGroups result is not an array".to_string()))?;
+    let group = groups
+        .iter()
+        .find(|g| g.get("id").and_then(Value::as_str) == Some(group_id))
+        .ok_or_else(|| WireError::Membership(format!("group {group_id} not present in result")))?;
+    let members = group
+        .get("members")
+        .and_then(Value::as_array)
+        .ok_or_else(|| WireError::Membership("group has no members field".to_string()))?;
+    if members.is_empty() {
+        return Err(WireError::Membership(
+            "group member set is empty".to_string(),
+        ));
+    }
+    let numbers: Vec<String> = members
+        .iter()
+        .filter_map(|m| m.get("number").and_then(Value::as_str).map(str::to_string))
+        .collect();
+    if numbers.is_empty() {
+        return Err(WireError::Membership(
+            "group members carry no E.164 numbers".to_string(),
+        ));
+    }
+    Ok(numbers)
+}
+
 /// Newline-delimited JSON-RPC 2.0 client over a `tokio` TCP connection.
 ///
 /// Owns the socket; all methods perform network I/O. The pure helpers above
 /// are used internally and are what the unit tests exercise.
+#[derive(Debug)]
 pub struct SignalTransport {
     reader: tokio::io::BufReader<tokio::net::tcp::OwnedReadHalf>,
     writer: tokio::net::tcp::OwnedWriteHalf,
@@ -398,6 +442,16 @@ impl SignalTransport {
         )
         .await
         .map(|_| ())
+    }
+
+    /// Query the current E.164 member set of `group_id` (wraps `listGroups`).
+    ///
+    /// Fails closed via [`parse_group_members`]: any ambiguity (missing group,
+    /// absent/empty members, malformed result) is an error, never an empty set.
+    pub async fn group_members(&mut self, group_id: &GroupId) -> std::io::Result<Vec<String>> {
+        let result = self.request("listGroups", serde_json::json!({})).await?;
+        parse_group_members(&result, group_id.as_str())
+            .map_err(|e| std::io::Error::other(e.to_string()))
     }
 
     /// Read and parse the next inbound envelope from the receive stream.

--- a/crates/amplihack-signal/tests/bridge_it.rs
+++ b/crates/amplihack-signal/tests/bridge_it.rs
@@ -1,0 +1,546 @@
+//! TDD contract tests for the Phase A `/signal` topic bridge (amplihack-signal
+//! reusable core). These are written **first** and are expected to FAIL to
+//! compile until the `bridge` module tree and the `transport::parse_group_members`
+//! helper are implemented.
+//!
+//! Run: `cargo test -p amplihack-signal --features signal --test bridge_it`.
+//!
+//! The whole file is gated on the `signal` feature so a default (feature-off)
+//! build compiles it away to nothing (matching the crate's empty-shim policy).
+#![cfg(feature = "signal")]
+
+// =============================================================================
+// Group naming — bridge::naming  (host + tmux slug, deterministic, 40-char cap)
+// =============================================================================
+mod naming {
+    use amplihack_signal::bridge::naming::{group_name, slug};
+
+    #[test]
+    fn slug_lowercases_collapses_and_trims() {
+        // Non-alphanumeric runs collapse to a single '-'; leading/trailing '-'
+        // trimmed; result lowercased.
+        assert_eq!(slug("review PR 3967!"), "review-pr-3967");
+        assert_eq!(slug("  Hello___World  "), "hello-world");
+        assert_eq!(slug("!!!edges!!!"), "edges");
+    }
+
+    #[test]
+    fn slug_is_length_capped_to_40() {
+        let long = "a very long topic ".repeat(20); // >> 40 chars
+        let s = slug(&long);
+        assert!(
+            s.len() <= 40,
+            "slug must be capped at ~40 chars, got {} ({s:?})",
+            s.len()
+        );
+        // Cap must not leave a dangling trailing '-'.
+        assert!(
+            !s.ends_with('-'),
+            "capped slug must not end with '-': {s:?}"
+        );
+    }
+
+    #[test]
+    fn group_name_without_tmux() {
+        assert_eq!(
+            group_name("azlin-07", None, "review PR 3967!"),
+            "amplihack-azlin-07-review-pr-3967"
+        );
+    }
+
+    #[test]
+    fn group_name_with_tmux_includes_session() {
+        // Documented example: host azlin-07, tmux session "ops".
+        assert_eq!(
+            group_name("azlin-07", Some("ops"), "review PR 3967!"),
+            "amplihack-azlin-07-ops-review-pr-3967"
+        );
+    }
+
+    #[test]
+    fn group_name_is_deterministic() {
+        let a = group_name("h", Some("t"), "same topic");
+        let b = group_name("h", Some("t"), "same topic");
+        assert_eq!(a, b, "naming must be a pure deterministic function");
+    }
+}
+
+// =============================================================================
+// Control phrases — bridge::control  (parsed BEFORE a body becomes a prompt)
+// =============================================================================
+mod control {
+    use amplihack_signal::bridge::control::{Control, parse_control};
+
+    #[test]
+    fn status_is_a_control_command() {
+        assert!(matches!(parse_control("status"), Control::Status));
+        assert!(matches!(parse_control("  STATUS  "), Control::Status));
+    }
+
+    #[test]
+    fn stop_and_kill_map_to_stop() {
+        assert!(matches!(parse_control("stop"), Control::Stop));
+        assert!(matches!(parse_control("kill"), Control::Stop));
+        assert!(matches!(parse_control("  Stop\n"), Control::Stop));
+        assert!(matches!(parse_control("KILL"), Control::Stop));
+    }
+
+    #[test]
+    fn control_takes_precedence_but_only_on_exact_word() {
+        // A sentence containing "stop" is a normal prompt, NOT a control phrase.
+        match parse_control("please stop the review") {
+            Control::Prompt(p) => assert_eq!(p, "please stop the review"),
+            other => panic!("expected Prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ordinary_text_is_a_prompt() {
+        match parse_control("run the tests again") {
+            Control::Prompt(p) => assert_eq!(p, "run the tests again"),
+            other => panic!("expected Prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_control_never_errors_unknown_is_prompt() {
+        // Total function: any non-control body is preserved verbatim as a Prompt.
+        assert!(matches!(parse_control("stopwatch"), Control::Prompt(_)));
+    }
+}
+
+// =============================================================================
+// Tool allowlist — bridge::allowlist  (default read-only, NOT allow-all)
+// =============================================================================
+mod allowlist {
+    use amplihack_signal::bridge::allowlist::ToolAllowlist;
+
+    #[test]
+    fn default_is_read_only_view_grep_glob() {
+        let al = ToolAllowlist::read_only_default();
+        assert!(!al.is_dangerous(), "default must never be dangerous");
+        assert_eq!(
+            al.to_copilot_args(),
+            vec![
+                "--allow-tool",
+                "view",
+                "--allow-tool",
+                "grep",
+                "--allow-tool",
+                "glob",
+            ]
+        );
+    }
+
+    #[test]
+    fn default_never_emits_allow_all() {
+        let args = ToolAllowlist::read_only_default().to_copilot_args();
+        assert!(
+            !args
+                .iter()
+                .any(|a| a == "--allow-all" || a == "--allow-all-tools"),
+            "read-only default must not grant blanket tool access: {args:?}"
+        );
+    }
+
+    #[test]
+    fn scoped_flags_render_repeated_allow_tool_in_order() {
+        let al = ToolAllowlist::from_flags(
+            &["edit".to_string(), "shell(git commit)".to_string()],
+            false,
+        );
+        assert!(!al.is_dangerous());
+        assert_eq!(
+            al.to_copilot_args(),
+            vec!["--allow-tool", "edit", "--allow-tool", "shell(git commit)",]
+        );
+    }
+
+    #[test]
+    fn empty_flags_without_dangerous_falls_back_to_read_only_default() {
+        let al = ToolAllowlist::from_flags(&[], false);
+        assert!(!al.is_dangerous());
+        assert_eq!(
+            al.to_copilot_args(),
+            ToolAllowlist::read_only_default().to_copilot_args(),
+            "no --allow-tool + no dangerous ⇒ least-privilege read-only default"
+        );
+    }
+
+    #[test]
+    fn dangerous_maps_to_allow_all_tools_not_allow_all() {
+        let al = ToolAllowlist::from_flags(&[], true);
+        assert!(al.is_dangerous());
+        let args = al.to_copilot_args();
+        assert!(
+            args.iter().any(|a| a == "--allow-all-tools"),
+            "dangerous mode must emit --allow-all-tools: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--allow-all"),
+            "must use tools-only escape hatch, never the wider --allow-all: {args:?}"
+        );
+    }
+
+    #[test]
+    fn describe_lists_blast_radius_for_announcement() {
+        // The first group message prints the effective allowlist verbatim.
+        let d = ToolAllowlist::read_only_default().describe();
+        for tool in ["view", "grep", "glob"] {
+            assert!(d.contains(tool), "describe() must name {tool}: {d:?}");
+        }
+    }
+}
+
+// =============================================================================
+// Outbound chunking — bridge::chunk  (Signal per-message limit, char-safe)
+// =============================================================================
+mod chunk {
+    use amplihack_signal::bridge::chunk::{SIGNAL_MAX_BYTES, chunk};
+
+    #[test]
+    fn max_bytes_is_signal_sized_not_frame_sized() {
+        // Distinct from the inbound JSON-RPC MAX_FRAME_BYTES (256 KiB).
+        assert_eq!(SIGNAL_MAX_BYTES, 2000);
+    }
+
+    #[test]
+    fn short_body_is_a_single_chunk() {
+        assert_eq!(chunk("hello"), vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn large_ascii_body_splits_under_the_cap_and_reassembles() {
+        let body = "x".repeat(5000);
+        let chunks = chunk(&body);
+        assert!(chunks.len() >= 3, "5000 bytes must split into >=3 chunks");
+        for c in &chunks {
+            assert!(
+                c.len() <= SIGNAL_MAX_BYTES,
+                "chunk of {} bytes exceeds cap {SIGNAL_MAX_BYTES}",
+                c.len()
+            );
+        }
+        assert_eq!(chunks.concat(), body, "chunks must reassemble losslessly");
+    }
+
+    #[test]
+    fn never_splits_a_multibyte_codepoint() {
+        // '€' is 3 bytes; a run whose byte-length straddles the cap must still
+        // never cut a codepoint (every chunk is valid UTF-8 by construction and
+        // reassembles exactly).
+        let body = "€".repeat(2000); // 6000 bytes
+        let chunks = chunk(&body);
+        for c in &chunks {
+            assert!(c.len() <= SIGNAL_MAX_BYTES);
+        }
+        assert_eq!(chunks.concat(), body);
+    }
+}
+
+// =============================================================================
+// Outbound membership verification — bridge::membership  (FAIL CLOSED)
+// =============================================================================
+mod membership {
+    use amplihack_signal::bridge::membership::{Membership, classify};
+
+    fn expected() -> Vec<String> {
+        vec!["+15551230000".to_string(), "+15551230001".to_string()]
+    }
+
+    #[test]
+    fn exact_expected_set_is_verified_and_may_relay() {
+        let actual = expected();
+        let m = classify(&expected(), Some(&actual));
+        assert!(matches!(m, Membership::Verified));
+        assert!(m.may_relay(), "verified membership permits outbound relay");
+    }
+
+    #[test]
+    fn query_error_is_unverified_and_refuses_relay() {
+        // `None` models an RPC error / timeout / ambiguous response.
+        let m = classify(&expected(), None);
+        assert!(matches!(m, Membership::Unverified(_)));
+        assert!(!m.may_relay(), "unverified membership must FAIL CLOSED");
+    }
+
+    #[test]
+    fn unexpected_extra_member_refuses_relay() {
+        let actual = vec![
+            "+15551230000".to_string(),
+            "+15551230001".to_string(),
+            "+15559999999".to_string(), // intruder
+        ];
+        let m = classify(&expected(), Some(&actual));
+        assert!(matches!(m, Membership::Unverified(_)));
+        assert!(!m.may_relay());
+    }
+
+    #[test]
+    fn missing_expected_member_refuses_relay() {
+        let actual = vec!["+15551230000".to_string()];
+        let m = classify(&expected(), Some(&actual));
+        assert!(matches!(m, Membership::Unverified(_)));
+        assert!(!m.may_relay());
+    }
+}
+
+// =============================================================================
+// Copilot turn driver — bridge::turn  (pinned argv + serialized single-turn)
+// =============================================================================
+mod turn {
+    use amplihack_signal::bridge::allowlist::ToolAllowlist;
+    use amplihack_signal::bridge::turn::{SerialTurnDriver, TurnRunner, build_turn_argv};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    const SID: &str = "11111111-2222-3333-4444-555555555555";
+
+    #[test]
+    fn argv_pins_session_id_silent_and_no_color() {
+        let argv = build_turn_argv(SID, "hello world", &ToolAllowlist::read_only_default());
+
+        // --session-id is immediately followed by the pinned uuid.
+        let sid_pos = argv
+            .iter()
+            .position(|a| a == "--session-id")
+            .expect("argv must pin --session-id");
+        assert_eq!(argv.get(sid_pos + 1).map(String::as_str), Some(SID));
+
+        // Clean, ANSI-free, response-only capture.
+        assert!(
+            argv.iter().any(|a| a == "-s" || a == "--silent"),
+            "argv must request silent (response-only) output: {argv:?}"
+        );
+        assert!(
+            argv.iter().any(|a| a == "--no-color"),
+            "argv must disable color for clean stdout: {argv:?}"
+        );
+
+        // Allowlist rendered into the same argv.
+        assert!(argv.windows(2).any(|w| w == ["--allow-tool", "view"]));
+    }
+
+    #[test]
+    fn prompt_is_a_single_argv_element_never_a_shell_string() {
+        // IV-2 injection contract: the prompt (attacker-influenced) is passed as
+        // ONE argv element, verbatim, and is never concatenated into a shell
+        // command line. Metacharacters must survive unchanged and unsplit.
+        let evil = "; rm -rf / # $(whoami) `id`";
+        let argv = build_turn_argv(SID, evil, &ToolAllowlist::read_only_default());
+
+        let p_pos = argv
+            .iter()
+            .position(|a| a == "-p" || a == "--prompt")
+            .expect("argv must carry a prompt flag");
+        assert_eq!(
+            argv.get(p_pos + 1).map(String::as_str),
+            Some(evil),
+            "prompt must be exactly one argv element, unmodified"
+        );
+    }
+
+    #[test]
+    fn read_only_argv_never_grants_allow_all() {
+        let argv = build_turn_argv(SID, "topic", &ToolAllowlist::read_only_default());
+        assert!(
+            !argv
+                .iter()
+                .any(|a| a == "--allow-all" || a == "--allow-all-tools")
+        );
+    }
+
+    // A mock runner that records the maximum number of turns running at once and
+    // the argv it received, to prove the driver serializes execution.
+    struct MockRunner {
+        active: Arc<AtomicUsize>,
+        max_active: Arc<AtomicUsize>,
+        seen: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    impl TurnRunner for MockRunner {
+        fn run_argv(
+            &self,
+            argv: Vec<String>,
+        ) -> Pin<Box<dyn Future<Output = std::io::Result<String>> + Send>> {
+            let active = self.active.clone();
+            let max_active = self.max_active.clone();
+            let seen = self.seen.clone();
+            Box::pin(async move {
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active.fetch_max(now, Ordering::SeqCst);
+                seen.lock().unwrap().push(argv);
+                tokio::time::sleep(Duration::from_millis(40)).await;
+                active.fetch_sub(1, Ordering::SeqCst);
+                Ok(String::from("ok"))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn turns_execute_one_at_a_time_per_session() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let runner = MockRunner {
+            active: active.clone(),
+            max_active: max_active.clone(),
+            seen: seen.clone(),
+        };
+
+        let driver = Arc::new(SerialTurnDriver::new(
+            runner,
+            SID,
+            ToolAllowlist::read_only_default(),
+        ));
+
+        let d1 = driver.clone();
+        let d2 = driver.clone();
+        let t1 = tokio::spawn(async move { d1.run_turn("first").await });
+        let t2 = tokio::spawn(async move { d2.run_turn("second").await });
+        t1.await.unwrap().unwrap();
+        t2.await.unwrap().unwrap();
+
+        assert_eq!(
+            max_active.load(Ordering::SeqCst),
+            1,
+            "the driver MUST serialize turns (one concurrent turn per session)"
+        );
+        assert_eq!(seen.lock().unwrap().len(), 2, "both turns must run");
+    }
+}
+
+// =============================================================================
+// Transport — parse_group_members  (fail-closed JSON-RPC parse for membership)
+// =============================================================================
+mod transport_members {
+    use amplihack_signal::transport::parse_group_members;
+    use serde_json::json;
+
+    #[test]
+    fn parses_expected_member_numbers() {
+        // Assumed signal-cli `listGroups` shape (adjust in impl if OI-2 resolves
+        // to `getGroup`): an array of groups, each with an `id` and `members`.
+        let v = json!([{
+            "id": "grp-abc==",
+            "members": [
+                {"number": "+15551230000"},
+                {"number": "+15551230001"},
+            ],
+        }]);
+        let members = parse_group_members(&v, "grp-abc==").expect("well-formed members parse");
+        assert_eq!(members, vec!["+15551230000", "+15551230001"]);
+    }
+
+    #[test]
+    fn missing_members_field_is_err_fail_closed() {
+        let v = json!([{ "id": "grp-abc==" }]);
+        assert!(
+            parse_group_members(&v, "grp-abc==").is_err(),
+            "absent member set must fail closed, never Ok(empty)"
+        );
+    }
+
+    #[test]
+    fn empty_members_is_err_fail_closed() {
+        let v = json!([{ "id": "grp-abc==", "members": [] }]);
+        assert!(parse_group_members(&v, "grp-abc==").is_err());
+    }
+
+    #[test]
+    fn group_not_present_is_err_fail_closed() {
+        let v = json!([{ "id": "some-other-group==", "members": [{"number": "+1"}] }]);
+        assert!(parse_group_members(&v, "grp-abc==").is_err());
+    }
+
+    #[test]
+    fn null_or_malformed_result_is_err() {
+        assert!(parse_group_members(&serde_json::Value::Null, "grp-abc==").is_err());
+        assert!(parse_group_members(&json!("nonsense"), "grp-abc==").is_err());
+    }
+}
+
+// =============================================================================
+// Outbound redaction reuse — bridge::outbound  (redact BEFORE chunk)
+// =============================================================================
+mod outbound {
+    use amplihack_signal::bridge::chunk::SIGNAL_MAX_BYTES;
+    use amplihack_signal::bridge::outbound::{redact_and_chunk, redact_for_relay};
+
+    const SECRET: &str = "sk-supersecrettoken1234567890";
+
+    #[test]
+    fn redact_for_relay_removes_bearer_secret() {
+        let red = redact_for_relay(&format!("Authorization: Bearer {SECRET}"));
+        assert!(
+            red.contains("[REDACTED]"),
+            "expected redaction marker: {red:?}"
+        );
+        assert!(!red.contains(SECRET), "secret must not survive redaction");
+    }
+
+    #[test]
+    fn redaction_happens_before_chunking_so_no_chunk_leaks_a_secret() {
+        // DP-1: redaction is applied to the whole body BEFORE it is chunked, so a
+        // secret can never leak in any individual outbound Signal message.
+        let body = format!("{}\nAuthorization: Bearer {SECRET}", "x".repeat(2500));
+        let chunks = redact_and_chunk(&body);
+        assert!(chunks.len() >= 2, "body larger than the cap must chunk");
+        for c in &chunks {
+            assert!(c.len() <= SIGNAL_MAX_BYTES, "each chunk respects the cap");
+            assert!(!c.contains(SECRET), "no chunk may contain the raw secret");
+        }
+    }
+}
+
+// =============================================================================
+// Bridge error taxonomy — bridge::BridgeError  (6-code exit contract) +
+// real daemon-down and loopback failure modes
+// =============================================================================
+mod failure_modes {
+    use amplihack_signal::bridge::{BridgeError, validate_endpoint};
+
+    #[test]
+    fn exit_code_contract_is_stable() {
+        assert_eq!(BridgeError::NotLinked.exit_code(), 1);
+        assert_eq!(BridgeError::RemoteEndpointRejected.exit_code(), 2);
+        assert_eq!(BridgeError::GroupCreateFailed.exit_code(), 3);
+        assert_eq!(BridgeError::DaemonUnavailable.exit_code(), 4);
+        assert_eq!(BridgeError::ResumeProbeFailed.exit_code(), 5);
+    }
+
+    #[test]
+    fn non_loopback_endpoint_fails_closed_with_exit_2() {
+        let err = validate_endpoint("10.0.0.5:7583", false).expect_err("routable host rejected");
+        assert!(matches!(err, BridgeError::RemoteEndpointRejected));
+        assert_eq!(err.exit_code(), 2);
+    }
+
+    #[test]
+    fn loopback_endpoint_is_accepted() {
+        assert!(validate_endpoint("127.0.0.1:7583", false).is_ok());
+    }
+
+    #[test]
+    fn remote_endpoint_allowed_only_with_explicit_unsafe_opt_in() {
+        assert!(
+            validate_endpoint("10.0.0.5:7583", true).is_ok(),
+            "explicit --unsafe-remote-endpoint opt-in permits a non-loopback endpoint"
+        );
+    }
+
+    #[tokio::test]
+    async fn daemon_down_shuts_down_cleanly_with_exit_4_after_retry_budget() {
+        // Port 9 (discard) is closed on a normal host ⇒ connection refused. The
+        // bridge must exhaust its bounded retry budget and surface a clean
+        // DaemonUnavailable (exit 4), never hang or silently disable itself.
+        let err = amplihack_signal::bridge::connect_daemon("127.0.0.1:9", 2)
+            .await
+            .expect_err("connecting to a closed port must fail");
+        assert!(matches!(err, BridgeError::DaemonUnavailable));
+        assert_eq!(err.exit_code(), 4);
+    }
+}

--- a/docs/SIGNAL_BRIDGE.md
+++ b/docs/SIGNAL_BRIDGE.md
@@ -1,0 +1,390 @@
+# Signal Bridge (`amplihack signal bridge`)
+
+Drive a **whole agent session from a Signal group chat**. The bridge opens a
+fresh, operator-only Signal group for one *topic*, runs the first agent turn,
+posts the agent's output back to the group, and then treats **every operator
+message in that group as the next agent prompt** — with full prior session
+context preserved across turns.
+
+- **Crate (reusable logic):** `amplihack-signal`
+- **Subcommand (CLI glue):** `amplihack signal bridge`
+- **Cargo feature:** `signal` (default **OFF**)
+- **Model:** turn-based **resume** of one pinned Copilot session UUID — one
+  operator message → one `copilot --session-id <uuid> …` invocation → one
+  redacted, chunked reply posted to the group. **No PTY, no ANSI parsing, no
+  streaming.**
+- **Trust model:** an accepted inbound message is **equivalent to typing into
+  the agent**. The bridge is therefore **least-privilege by default** and
+  **fails closed** on every ambiguity.
+
+> **Status.** The bridge is a **new, opt-in** feature. It **replaces** the old
+> auto-per-session mirroring (which produced empty groups). It is compiled out
+> entirely unless you build with `--features signal`; with the feature off the
+> subcommand still registers and exits with a clean
+> "rebuild with `--features signal`" error (never a silent no-op). The bridge
+> does **not** touch or remove the legacy per-session hooks — that retirement is
+> a separate change.
+
+---
+
+## Contents
+
+- [How it works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Quick start](#quick-start)
+- [Command reference](#command-reference)
+- [Tool allowlist (blast radius)](#tool-allowlist-blast-radius)
+- [Control phrases](#control-phrases)
+- [Group naming](#group-naming)
+- [Security contract](#security-contract)
+- [Configuration](#configuration)
+- [Failure modes](#failure-modes)
+- [The `/signal` skill](#the-signal-skill)
+- [Tutorial: a PR review from your phone](#tutorial-a-pr-review-from-your-phone)
+- [Exit codes](#exit-codes)
+- [Reference](#reference)
+
+---
+
+## How it works
+
+```
+operator (Signal app on phone)
+        │  message in group
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│ amplihack signal bridge "<topic>"                            │
+│                                                              │
+│  signal-cli JSON-RPC (127.0.0.1) ── inbound gating ──┐       │
+│                                                       ▼       │
+│                                          control-phrase parse │
+│                                    (stop / kill / status)     │
+│                                                       │       │
+│                                         normal prompt │       │
+│                                                       ▼       │
+│                                        bounded turn queue     │
+│                                                       │       │
+│                                    serialized turn driver     │
+│                                                       ▼       │
+│   copilot --session-id <uuid> --no-color -s \                │
+│           -p "<msg>" --allow-tool <t1> --allow-tool <t2> …    │
+│                                                       │stdout │
+│                                     redact → chunk → post ────┤
+└──────────────────────────────────────────────────────────────┘
+        │  membership verified (fail closed) before every post
+        ▼
+operator (Signal group)
+```
+
+1. **One pinned session UUID.** The bridge generates a fresh v4 UUID once. Every
+   turn resumes the **same** session with `copilot --session-id <uuid>`, so the
+   agent keeps full context across the whole conversation.
+2. **One turn at a time.** Turns are **serialized** — exactly one child
+   `copilot` process runs per session at any moment. New messages queue.
+3. **Copilot invocation.** Each turn runs:
+
+   ```bash
+   copilot --session-id <uuid> --no-color -s -p "<message>" \
+           --allow-tool <t1> --allow-tool <t2> …
+   ```
+
+   - `-s`/`--silent` → the agent **response only** on stdout (clean to capture).
+   - `--no-color` → guarantees ANSI-free stdout before redaction/chunking.
+   - `--allow-tool` (repeated) → the scoped allowlist (see below).
+4. **Output relay.** stdout is **redacted for secrets first**, then **chunked**
+   to Signal's per-message limit, then posted to the group — but only after the
+   group's membership is **positively verified** as the expected operator-only
+   set.
+
+---
+
+## Prerequisites
+
+- **amplihack built with the `signal` feature:**
+
+  ```bash
+  cargo build --release --features signal
+  ```
+
+- **A linked, running signal-cli JSON-RPC daemon on `127.0.0.1`.** If you have
+  not onboarded this host yet, run `amplihack signal setup` first (it installs
+  signal-cli, links a device via QR, starts the local daemon, and writes the
+  config). See [Signal Onboarding](SIGNAL_ONBOARDING.md). The bridge **reuses**
+  that onboarding/link path — it never reimplements linking. If the account is
+  not linked, the bridge guides you to link and exits.
+- **`copilot` on `PATH`** (GitHub Copilot CLI) — the agent that each turn drives.
+- **Your phone with Signal**, on the same account, to send/receive in the group.
+
+---
+
+## Quick start
+
+```bash
+# Least-privilege (read-only investigation tools) by default:
+amplihack signal bridge "review PR 3967 with a crusty-old-engineer eye"
+```
+
+The bridge will:
+
+1. Validate the daemon endpoint is loopback and the account is linked.
+2. Create a fresh group named `amplihack-<host>-<slug(topic)>`.
+3. Post a first message announcing the **topic**, the **effective tool
+   allowlist** (your blast radius), and the **control phrases**.
+4. Run the first turn (`-p "<topic>"`) and post the reply.
+5. Wait for your next message in the group and treat it as the next prompt.
+
+Grant a scoped write/exec capability explicitly:
+
+```bash
+amplihack signal bridge "fix the failing lint in crates/amplihack-signal" \
+  --allow-tool view --allow-tool grep --allow-tool glob \
+  --allow-tool edit --allow-tool 'shell(cargo fmt)'
+```
+
+Full-tools escape hatch (explicit opt-in — widest blast radius):
+
+```bash
+amplihack signal bridge "do whatever it takes" --dangerous-all-tools
+```
+
+---
+
+## Command reference
+
+```text
+amplihack signal bridge <TOPIC> [OPTIONS]
+```
+
+| Argument / Option        | Kind                  | Default              | Description |
+| ------------------------ | --------------------- | -------------------- | ----------- |
+| `<TOPIC>`                | positional (required) | —                    | Free-text topic. Becomes the **first prompt** and seeds the group name. |
+| `--allow-tool <TOOL>`    | repeatable            | read-only set        | Add one tool to the scoped Copilot allowlist. Repeat for multiple. Maps to `copilot --allow-tool`. |
+| `--dangerous-all-tools`  | flag                  | off                  | Opt in to `copilot --allow-all-tools` (all **tools**, not paths/URLs). Overrides `--allow-tool`. |
+| `--group-name <NAME>`    | override              | derived (see naming) | Override the generated group name. |
+| `--host <NAME>`          | override              | system hostname      | Override the `<host>` token used in the group name. |
+| `--retry-budget <N>`     | override              | `10`                 | Max reconnect attempts (bounded exponential backoff) before clean shutdown when the daemon is down. |
+| `--inbox-capacity <N>`   | override              | `32`                 | Bounded turn-queue capacity (also settable via `AMPLIHACK_SIGNAL_INBOX_CAPACITY`). |
+| `--unsafe-remote-endpoint` | flag                | off                  | Explicit, documented opt-in to allow a **non-loopback** signal-cli daemon endpoint. Without it, a non-`127.0.0.1` endpoint **fails closed** (exit `2`). Never use across an untrusted network. |
+
+> **Note on `-s`.** The `-s` you see in the underlying `copilot` invocation is
+> Copilot's `--silent` flag (response-only stdout), **not** an allowlist. The
+> allowlist is always expressed with repeated `--allow-tool`. You never pass
+> `copilot` flags to `amplihack signal bridge` directly.
+
+> **Note on allowlist form.** The bridge always emits the allowlist as
+> **repeated** `--allow-tool <TOOL>` arguments (one per tool), e.g.
+> `--allow-tool view --allow-tool grep`. Scoped shell commands are quoted using
+> Copilot's convention, e.g. `--allow-tool 'shell(cargo fmt)'`.
+
+---
+
+## Tool allowlist (blast radius)
+
+The driven agent runs with a **scoped allowlist**, never `--allow-all`, unless
+you explicitly opt in. The effective list is **printed verbatim in the group's
+first message** so the blast radius is always visible.
+
+| Mode                      | How to select                         | Copilot flags emitted                           |
+| ------------------------- | ------------------------------------- | ----------------------------------------------- |
+| **Read-only (default)**   | pass no `--allow-tool`                | `--allow-tool view --allow-tool grep --allow-tool glob` plus read-only shell (`git status`, `git log`, `cat`, …) |
+| **Scoped**                | one or more `--allow-tool <TOOL>`     | exactly the tools you listed                    |
+| **Dangerous (all tools)** | `--dangerous-all-tools`               | `--allow-all-tools`                             |
+
+- **Least-privilege by default.** With no `--allow-tool`, the agent gets only
+  read-only investigation tools. Anything not on the allowlist (writes, exec,
+  network) is **denied** in non-interactive mode rather than auto-approved.
+- **`--dangerous-all-tools` maps to `--allow-all-tools`**, not `--allow-all`.
+  `--allow-all` would additionally open arbitrary paths and URLs (a wider blast
+  radius); the bridge deliberately uses the tools-only escape hatch.
+
+---
+
+## Control phrases
+
+Each accepted inbound message is parsed for a **control phrase first**, before it
+is ever queued as a prompt. Matching is case-insensitive, trimmed, exact-word.
+
+| Phrase   | Effect |
+| -------- | ------ |
+| `status` | Post current state to the group: session id, current turn, effective allowlist, queue depth, membership-verification status. Does **not** enqueue a prompt. |
+| `stop`   | **Pre-empt**: terminate the tracked child `copilot` PID immediately (even mid-turn), leave/close the group, and exit. |
+| `kill`   | Synonym for `stop`. |
+
+Control phrases **always** take precedence over normal prompts and always
+pre-empt an in-flight turn. A message like `please stop the review` is treated as
+a normal prompt (no exact-word `stop`), whereas `stop` on its own line is a
+control command.
+
+---
+
+## Group naming
+
+```
+amplihack-<host>-<slug(topic)>                 # no tmux
+amplihack-<host>-<tmux>-<slug(topic)>          # inside a tmux session
+```
+
+- `<host>` — short system hostname (or `--host` override).
+- `<tmux>` — the tmux session name, included when the bridge runs inside tmux
+  (from `$TMUX` / `tmux display-message -p '#S'`).
+- `slug(topic)` — lowercase; every run of non-alphanumeric characters collapses
+  to a single `-`; leading/trailing `-` trimmed; length-capped (≈40 chars) to
+  respect signal-cli group-name limits.
+
+Example: topic `"review PR 3967!"` on host `azlin-07` inside tmux session `ops`
+→ `amplihack-azlin-07-ops-review-pr-3967`.
+
+Override entirely with `--group-name`.
+
+---
+
+## Security contract
+
+An accepted inbound message == typing into the agent. The bridge enforces:
+
+1. **Least-privilege by default** — scoped `--allow-tool`, never `--allow-all`
+   unless `--dangerous-all-tools`. Effective allowlist printed in the first
+   group message.
+2. **Inbound gating** (existing `Gate`): group-id match, non-empty body, echo
+   suppression, allowlist check (an **empty allowlist denies all**), and
+   sync-message acceptance only from **your own account on primary device 1**.
+3. **Outbound membership verification — FAIL CLOSED.** Before every post (and on
+   any membership change), the bridge verifies the group's member set is the
+   expected operator-only set. If it cannot be **positively** verified
+   (error / timeout / ambiguous / unexpected member), the bridge does **not**
+   relay output — it alerts on the local terminal and **pauses relaying** until
+   re-verified. It never assumes "probably fine."
+4. **Local-only daemon** — the JSON-RPC endpoint must be `127.0.0.1`. A remote
+   endpoint requires the explicit `--unsafe-remote-endpoint` opt-in; without it a
+   non-loopback endpoint **fails closed** and exits `2`.
+5. **Audit log** — every accepted prompt is logged with
+   sender / device / timestamp / session id, **redacted**.
+6. **Outbound secret redaction** — the existing `redact_for_relay` helper is
+   **reused** and runs **before** chunking, so secrets never leak across a chunk
+   boundary. Only redaction is reused; multi-message **chunking** to
+   `SIGNAL_MAX_BYTES` is new bridge logic (`bridge/chunk.rs`) — replies larger
+   than the limit are **chunked, never truncated**.
+7. **Adaptive backpressure** — the bounded inbox (operator-configurable) coalesces
+   bursts and applies backpressure; drops happen **only** under genuine resource
+   pressure and are announced with an explicit in-group notice (**never silent**).
+8. **Argv-only spawn** — the operator's message is passed to `copilot` as a
+   single `-p <arg>` argument vector (no shell interpolation), closing the
+   command-injection sink.
+
+---
+
+## Configuration
+
+The bridge reuses the shared Signal config (`crates/amplihack-signal/config.rs`)
+loaded by `amplihack signal setup`. Bridge-relevant knobs:
+
+| Setting                          | Source                                   | Default     | Meaning |
+| -------------------------------- | ---------------------------------------- | ----------- | ------- |
+| daemon endpoint                  | signal config TOML                       | `127.0.0.1` | JSON-RPC host:port; must be loopback unless `--unsafe-remote-endpoint` is passed (else fail closed, exit `2`). |
+| account / linked device          | signal config TOML                       | —           | The linked signal-cli account used to create the group and gate sync messages. |
+| inbound allowlist                | signal config TOML                       | —           | Which senders are accepted; **empty = deny all**. |
+| `AMPLIHACK_SIGNAL_INBOX_CAPACITY`| env / `--inbox-capacity`                 | `32`        | Bounded turn-queue capacity. |
+| retry budget                     | `--retry-budget`                         | `10`        | Reconnect attempts before clean shutdown. |
+| outbound chunk size              | `SIGNAL_MAX_BYTES` constant              | `2000` B    | UTF-8-boundary-safe per-message size for the group (distinct from the JSON-RPC frame bound). |
+
+---
+
+## Failure modes
+
+Errors are **surfaced, never silently swallowed**.
+
+| Failure                    | Behavior |
+| -------------------------- | -------- |
+| signal-cli daemon down     | Reconnect with **bounded exponential backoff**, surfacing status to the **local terminal**. If not restored within `--retry-budget`, shut down cleanly: stop accepting turns, print a clear terminal error, tear down the child PID, exit **`4`**. |
+| non-loopback endpoint      | Rejected at startup unless `--unsafe-remote-endpoint` is passed; exit **`2`**. |
+| account not linked / feature off | Clear terminal guidance (run `amplihack signal setup`, or rebuild with `--features signal`); exit **`1`**. |
+| copilot resume unsupported | If the `copilot` session-resume probe fails, refuse to start (turn continuity cannot be guaranteed); exit **`5`**. |
+| group create failure       | Abort immediately with a clear error; exit **`3`**. |
+| child `copilot` hang       | **Idle/liveness detection** with **no wall-clock cap** on the turn (repo no-agent-timeout policy) + periodic local heartbeat. The operator `stop`/`kill` phrase always pre-empts. |
+| child `copilot` non-zero / crash | Post the failure to the group **and** log it; keep the bridge alive. The next turn resumes the **same** session id, so context is preserved. |
+| membership unverifiable     | Pause outbound relay, alert locally, retry verification until positive. |
+| orphaned bridge/subprocess | The child `copilot` PID is tracked and torn down on stop / session-end. |
+
+---
+
+## The `/signal` skill
+
+The `/signal` skill (`amplifier-bundle/skills/signal/`) is a thin wrapper that
+shells out to the subcommand. Invoke it when you want to hand an agent task off
+to a Signal group and drive it from your phone.
+
+```text
+/signal start a crusty-old-engineer review of PR 3967
+```
+
+expands to:
+
+```bash
+amplihack signal bridge "start a crusty-old-engineer review of PR 3967"
+```
+
+See [`amplifier-bundle/skills/signal/SKILL.md`](../amplifier-bundle/skills/signal/SKILL.md).
+
+---
+
+## Tutorial: a PR review from your phone
+
+1. **Onboard the host once** (if not already linked):
+
+   ```bash
+   amplihack signal setup
+   ```
+
+   Scan the QR with **Signal → Settings → Linked devices → Link new device**.
+
+2. **Start the bridge** for the review topic (read-only is plenty for a review):
+
+   ```bash
+   amplihack signal bridge "review PR 3967 as a crusty old engineer"
+   ```
+
+3. **Watch your phone.** A new group `amplihack-<host>-review-pr-3967` appears
+   with a first message listing the topic, the read-only allowlist, and the
+   control phrases. Moments later the agent's first review turn arrives.
+
+4. **Drive the conversation.** Reply in the group:
+
+   > *"Focus on the error-handling in the turn driver — any silent fallbacks?"*
+
+   The bridge runs one more turn on the **same** session (full context) and posts
+   the answer.
+
+5. **Check state any time:** send `status` → you get session id, current turn,
+   allowlist, queue depth, and membership status.
+
+6. **Finish:** send `stop` → the child `copilot` is terminated, the group is
+   closed, and the bridge exits.
+
+---
+
+## Exit codes
+
+The bridge exposes a **6-code exit contract** so operators can script it
+reliably. Every non-zero exit is also accompanied by a clear terminal message.
+
+| Code | Meaning |
+| ---- | ------- |
+| `0`  | Clean shutdown via `stop`/`kill` or normal session end. |
+| `1`  | Generic fatal error — feature not built (`--features signal` off), account not linked, or unexpected internal error during setup. |
+| `2`  | Non-loopback daemon endpoint rejected (loopback safety) without `--unsafe-remote-endpoint`. |
+| `3`  | Group create/setup failure (could not create or join the operator-only group). |
+| `4`  | signal-cli daemon not restored within `--retry-budget`; clean shutdown after exhausting reconnect attempts. |
+| `5`  | Copilot session-resume probe failed — the installed `copilot` did not accept `--session-id` resume, so turn continuity cannot be guaranteed. |
+
+---
+
+## Reference
+
+- [Signal Channel](signal-channel.md) — the per-session channel this bridge
+  complements.
+- [Signal Onboarding](SIGNAL_ONBOARDING.md) — `signal setup` / `distribute`,
+  linking, and the local daemon the bridge depends on.
+- [Copilot CLI](COPILOT_CLI.md) — the agent the bridge drives via
+  `--session-id` resume.
+- Crate: `crates/amplihack-signal` (reusable bridge logic, feature `signal`).
+- Subcommand: `crates/amplihack-cli/src/commands/signal/bridge.rs`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -691,6 +691,7 @@ Robust handling of conversation compaction in long sessions:
 
 - [MCP Evaluation](mcp_evaluation/README.md) - Model Context Protocol evaluation
 - [Signal Onboarding](SIGNAL_ONBOARDING.md) / [Signal Channel](signal-channel.md) / [Signal Release Builds](SIGNAL_RELEASE_BUILD.md) - Per-session Signal notifications with advisory reply-to-agent, configured via `amplihack signal setup`
+- [Signal Bridge](SIGNAL_BRIDGE.md) - Drive a whole agent session from a topic-scoped Signal group chat via `amplihack signal bridge "<topic>"` (the `/signal` skill)
 
 ---
 


### PR DESCRIPTION
## Phase A — `/signal` topic-scoped bidirectional Signal bridge

Implements a NEW, opt-in feature that lets an operator drive an agent session entirely from a Signal group chat. All agent output is posted to the group; every accepted operator message becomes a real agent prompt with full session context via turn-based `copilot --session-id <uuid>` resume (no PTY, no ANSI parsing, no streaming). Replaces the broken auto-per-session mirroring.

**Phase A only.** Does NOT touch or remove the legacy hooks — that retirement (Phase B) is a separate later PR.

### What's included
- **New subcommand** `amplihack signal bridge <topic>` (crates/amplihack-cli, behind the existing `signal` feature). Flags: `--allow-tool` (repeatable), `--dangerous-all-tools`, `--group-name`, `--host`, `--retry-budget`, `--inbox-capacity`, `--unsafe-remote-endpoint`.
- **Reusable core** in `crates/amplihack-signal/src/bridge/`:
  - `naming` — `amplihack-<host>[-<tmux>]-<slug(topic)>` group naming
  - `control` — stop/kill/status control-phrase parsing (precedence over prompts)
  - `allowlist` — read-only default (view/grep/glob); `--allow-all-tools` only with `--dangerous-all-tools`
  - `chunk` — Signal-sized (2000-byte), UTF-8-safe outbound chunker
  - `membership` — fail-closed operator-only membership classification
  - `outbound` — secret redaction applied before chunking
  - `turn` — injection-safe argv builder, serialized single-turn driver, real subprocess runner with PID tracking for pre-emption
  - `mod` — BridgeError taxonomy (exit 1–5, 0 = clean), loopback endpoint validation, bounded-backoff daemon connect
- **Transport**: `group_members` RPC + fail-closed `parse_group_members`.
- **`/signal` skill** (amplifier-bundle/skills/signal/SKILL.md) shelling out to `amplihack signal bridge`.
- **Docs**: docs/SIGNAL_BRIDGE.md.

### Security contract
- Least-privilege by default (read-only allowlist); `--allow-all` only via explicit `--dangerous-all-tools`; effective allowlist posted in the group's first message.
- Outbound membership verification, **fail closed** — pause relaying if the operator-only member set can't be positively verified.
- Adaptive backpressure via the existing bounded inbox (`AMPLIHACK_SIGNAL_INBOX_CAPACITY`, default 32).
- Local-only daemon (127.0.0.1); remote requires explicit `--unsafe-remote-endpoint`.
- Audit log of every accepted prompt (sender/device/timestamp/session id, redacted).
- Secret redaction before chunking.

### Failure modes (surface, never silent)
- Daemon down → bounded exponential backoff with terminal status; clean non-zero shutdown after retry budget.
- Group create failure → abort with clear error.
- Child hang → idle/liveness detection, no wall-clock cap; stop phrase always pre-empts.
- Orphaned subprocess → child PID tracked, cleaned up on stop/session-end.

### Tests
- 40 signal contract tests + 8 CLI contract tests (naming, control precedence, read-only default, membership fail-closed, serialized turns, daemon-down clean shutdown).
- `cargo test -p amplihack-signal --features signal` and `-p amplihack-cli --features signal` green.
- Pre-commit passed: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings --locked`.

Closes #1054

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo workspace** — `Cargo.toml` at repo root; changed code lives in `crates/amplihack-signal` (reusable cores) and `crates/amplihack-cli` (subcommand glue) behind the `signal` cargo feature. `Cargo.lock` present (built with `--locked` in CI). Entry point exercised: the `amplihack` binary's `signal bridge <topic>` subcommand.
- Evidence: new/changed `*.rs` under `crates/amplihack-*/src/bridge/**` and `crates/amplihack-cli/src/commands/signal/bridge.rs`, plus feature-gated integration tests `crates/amplihack-signal/tests/bridge_it.rs` and `crates/amplihack-cli/tests/signal_bridge_it.rs`.

Chosen validation strategy:
- Run the feature-gated suites (`cargo test -p amplihack-signal --features signal`, `cargo test -p amplihack-cli --features signal`) to prove the required unit/integration behaviors (naming, control precedence, read-only default allowlist, fail-closed membership, serialized single-turn, daemon-down clean shutdown).
- Then drive the **actual built CLI binary at the process boundary** for the two user-visible scenarios below, because Phase A's contract is exposed to operators through `amplihack signal bridge`. This proves help/UX and the fail-closed startup + stable exit-code taxonomy exactly as an operator experiences them.

Test suite totals: `amplihack-signal --features signal` = all tests passing incl. **40/40** in `bridge_it.rs`; `amplihack-cli --features signal` bridge glue = **8/8** in `signal_bridge_it.rs`. (Three `commands::multitask::launcher_tests` failures are pre-existing environmental flakiness — a 2s `bash -n` timeout under full-parallel load in files untouched by this PR; they pass in isolation / with `--test-threads=1`.)

### Scenario 1 — Simple: `signal bridge --help` exposes the documented interface
Command: `amplihack signal bridge --help`
Result: PASS
Output: exit 0. Help shows required `<TOPIC>` positional and documents `--allow-tool` ("With none given the agent gets the read-only default (`view`/`grep`/`glob`)"), `--dangerous-all-tools` ("`--allow-all-tools`, not the wider `--allow-all`"), `--group-name`, `--host`, `--retry-budget` (default 10), `--inbox-capacity` (default 32, `AMPLIHACK_SIGNAL_INBOX_CAPACITY`), and `--unsafe-remote-endpoint` ("a non-`127.0.0.1` endpoint fails closed (exit 2)").

### Scenario 2 — Complex/integration: daemon-down path → bounded retry → clean exit 4
Command: `AMPLIHACK_SIGNAL_ENDPOINT=127.0.0.1:59991 AMPLIHACK_SIGNAL_ACCOUNT=+15551230000 AMPLIHACK_SIGNAL_ALLOWLIST=+15559990000 amplihack signal bridge "daemon-down smoke test" --retry-budget 2`
Result: PASS
Output:
```
error: signal-cli daemon at 127.0.0.1:59991 was unreachable after 2 attempts; shutting down cleanly.
error: signal-cli daemon unavailable after exhausting the retry budget
exit=4
```
This drives the real orchestration entry point end-to-end through the process boundary: env-var config load → loopback endpoint validation → `copilot --session-id` resume probe (copilot present on PATH, `--session-id` supported) → bounded exponential-backoff reconnect → **clean shutdown with the stable `DaemonUnavailable` exit code 4**. No silent fallback; the failure is surfaced to the local terminal.

Supporting evidence (fail-closed startup on an unconfigured host): `HOME=<empty> amplihack signal bridge "start a crusty-old-engineer review of PR 3967"` exits **1** with the actionable message `signal is not configured on this host (missing required Signal setting: endpoint). Run \`amplihack signal setup\` to link a device and start the daemon.` — least-privilege, fail-closed, no partial bridge.
