### PR TITLE
fix(#1062): replace brittle recipe parsing with structured orch-helper + parse_json signals

### DIFF
--- a/amplifier-bundle/recipes/smart-classify-route.yaml
+++ b/amplifier-bundle/recipes/smart-classify-route.yaml
@@ -78,6 +78,12 @@ steps:
            e.g. "build webui + api" -> 2 workstreams
                 "investigate X then implement Y" -> 2 workstreams
          - recipe: "default-workflow" (dev) | "investigation-workflow" (research)
+      5. no_merge: true | false — set `true` when the request asks NOT to merge
+         or to keep the PR open (issue #929/#1062). This replaces the old bash
+         prose-regex; you understand intent, so catch ALL phrasings, including
+         unusual ones like "hold off merging", "keep it as a draft", "wait for
+         my review", "leave it open", "don't merge", "no admin merge". Default
+         to `false` when the request says nothing about merging.
 
       **Classification rules — read carefully (#269)**:
       - **Operations** is ONLY for one-shot read-only or trivial mutating
@@ -102,6 +108,7 @@ steps:
         "task_type": "Development",
         "goal": "One sentence goal",
         "success_criteria": ["Criterion 1", "Criterion 2"],
+        "no_merge": false,
         "workstreams": [
           {"name": "slug", "description": "full task", "recipe": "default-workflow"}
         ]
@@ -253,11 +260,19 @@ steps:
       # #283: replace scripted uuid with /proc/sys/kernel/random/uuid (POSIX)
       SESSION_ID=$(tr -d '-' < /proc/sys/kernel/random/uuid | head -c 8)
 
-      # #248: native Rust subcommand for session tree registration
-      if OUTPUT=$(amplihack session-tree register "$SESSION_ID" 2>&1); then
-        # Output: "TREE_ID=abc123 DEPTH=0"
-        TREE_ID=$(echo "$OUTPUT" | grep -oE 'TREE_ID=[A-Za-z0-9_-]+' | head -1 | cut -d= -f2)
-        DEPTH_STR=$(echo "$OUTPUT" | grep -oE 'DEPTH=[0-9]+' | head -1 | cut -d= -f2)
+      # #248: native Rust subcommand for session tree registration.
+      # Issue #1062 (finding D2): request structured JSON via the additive
+      # `--json` flag and read tree_id/depth through the tested
+      # `orch helper extract-field` pipeline instead of grep-scraping the
+      # `TREE_ID=.. DEPTH=..` text line.
+      if OUTPUT=$(amplihack session-tree register "$SESSION_ID" --json 2>&1); then
+        # Output: {"tree_id":"abc123","depth":0}
+        TREE_ID=$(printf '%s' "$OUTPUT" \
+          | amplihack orch helper extract-json \
+          | amplihack orch helper extract-field --field tree_id --default '')
+        DEPTH_STR=$(printf '%s' "$OUTPUT" \
+          | amplihack orch helper extract-json \
+          | amplihack orch helper extract-field --field depth --default 0)
         DEPTH_VAL=${DEPTH_STR:-0}
         # Validate extracted values
         if ! echo "$TREE_ID" | grep -qE '^[A-Za-z0-9_-]+$'; then

--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -77,12 +77,18 @@ steps:
     command: |
       # FIX (#469/#311): Use env var — safe against injection and word-splitting.
       SESSION_JSON="$SESSION_INFO"
-      # Extract status using shell grep — no external subprocess needed
-      if echo "$SESSION_JSON" | grep -qE '"status" *: *"ok"'; then
+      # Issue #1062 (finding D1): read `status` through the tested
+      # `orch helper extract-json | extract-field` pipeline instead of
+      # regex-scanning the JSON. An unparseable blob or absent field yields
+      # STATUS=unknown, which falls through to the BLOCKED:unknown fail-safe.
+      STATUS=$(printf '%s' "$SESSION_JSON" \
+        | amplihack orch helper extract-json \
+        | amplihack orch helper extract-field --field status --default unknown)
+      if [ "$STATUS" = "ok" ]; then
         echo "ALLOWED"
-      elif echo "$SESSION_JSON" | grep -qE '"status" *: *"no_tree_script"'; then
+      elif [ "$STATUS" = "no_tree_script" ]; then
         echo "ALLOWED"
-      elif echo "$SESSION_JSON" | grep -qE '"status" *: *"registration_failed"'; then
+      elif [ "$STATUS" = "registration_failed" ]; then
         echo "NOTE: Session tree registration was skipped — depth and capacity limits inactive." >&2
         echo "BLOCKED:registration_failed"
       else

--- a/amplifier-bundle/recipes/smart-execute-routing.yaml
+++ b/amplifier-bundle/recipes/smart-execute-routing.yaml
@@ -78,15 +78,11 @@ steps:
       # FIX (#469/#311): Use env var — safe against injection and word-splitting.
       SESSION_JSON="$SESSION_INFO"
       # Issue #1062 (finding D1): read `status` through the tested
-      # `orch helper extract-json | extract-field` pipeline instead of
-      # regex-scanning the JSON. An unparseable blob or absent field yields
-      # STATUS=unknown, which falls through to the BLOCKED:unknown fail-safe.
+      # extract-json|extract-field pipeline; unknown -> BLOCKED:unknown fail-safe.
       STATUS=$(printf '%s' "$SESSION_JSON" \
         | amplihack orch helper extract-json \
         | amplihack orch helper extract-field --field status --default unknown)
-      if [ "$STATUS" = "ok" ]; then
-        echo "ALLOWED"
-      elif [ "$STATUS" = "no_tree_script" ]; then
+      if [ "$STATUS" = "ok" ] || [ "$STATUS" = "no_tree_script" ]; then
         echo "ALLOWED"
       elif [ "$STATUS" = "registration_failed" ]; then
         echo "NOTE: Session tree registration was skipped — depth and capacity limits inactive." >&2

--- a/amplifier-bundle/recipes/smart-reflect-loop.yaml
+++ b/amplifier-bundle/recipes/smart-reflect-loop.yaml
@@ -99,24 +99,34 @@ steps:
         normally (prefer continuing the loop). Fail toward continuing, never
         toward a premature ACHIEVED.
 
-      End with EXACTLY one of:
-      - `GOAL_STATUS: ACHIEVED` -- all criteria met with verifiable evidence
-      - `GOAL_STATUS: PARTIAL -- [what's missing]` -- needs another round
-      - `GOAL_STATUS: NOT_ACHIEVED -- [reason]` -- needs another round
-      - `GOAL_STATUS: HOLLOW -- [what was empty]` -- agents ran but produced no real work
+      Output EXACTLY one JSON object as your final line (issue #1062 finding C:
+      the loop condition now reads a structured `goal_status` field instead of
+      substring-matching this prose, so a stray "partial" in your narrative can
+      no longer false-trigger a round):
+
+      ```json
+      {"goal_status": "ACHIEVED", "summary": "what was verified or what is missing"}
+      ```
+
+      `goal_status` MUST be EXACTLY one of:
+      - `ACHIEVED` -- all criteria met with verifiable evidence
+      - `PARTIAL` -- some criteria met, needs another round; put the gaps in `summary`
+      - `NOT_ACHIEVED` -- criteria not met, needs another round; reason in `summary`
+      - `HOLLOW` -- agents ran but produced no real work; what was empty in `summary`
     output: "reflection_1"
+    parse_json: true
 
   - id: "execute-round-2"
     type: "agent"
     condition: |
-      reflection_1 and ('PARTIAL' in reflection_1 or 'NOT_ACHIEVED' in reflection_1 or 'HOLLOW' in reflection_1)
+      reflection_1 and (reflection_1.goal_status == 'PARTIAL' or reflection_1.goal_status == 'NOT_ACHIEVED' or reflection_1.goal_status == 'HOLLOW')
     agent: "amplihack:core:builder"
     prompt: |
       Round 1 was incomplete. Continue from where it left off.
 
       **Original Goal**: {{decomposition_json}}
       **Round 1 Result**: {{round_1_result}}
-      **What's Missing**: {{reflection_1}}
+      **What's Missing**: {{reflection_1.summary}}
 
       Address only what's missing. Do not redo completed work.
       Create PRs for new changes. Report PR URLs.
@@ -126,7 +136,7 @@ steps:
   - id: "reflect-round-2"
     type: "agent"
     condition: |
-      round_2_result and ('PARTIAL' in reflection_1 or 'NOT_ACHIEVED' in reflection_1)
+      round_2_result and (reflection_1.goal_status == 'PARTIAL' or reflection_1.goal_status == 'NOT_ACHIEVED')
     agent: "amplihack:core:reviewer"
     prompt: |
       Evaluate goal achievement after round 2.
@@ -148,23 +158,30 @@ steps:
       pending/failing/closed/draft/no-PR/empty-required-check-set or unknown
       states — in those cases evaluate normally and prefer continuing.
 
-      End with:
-      - `GOAL_STATUS: ACHIEVED`
-      - `GOAL_STATUS: PARTIAL -- [gaps]`
-      - `GOAL_STATUS: NOT_ACHIEVED -- [reason]`
+      End with EXACTLY one JSON object as your final line (issue #1062 finding
+      C: the loop reads a structured `goal_status` field, not substring-matched
+      prose):
+
+      ```json
+      {"goal_status": "ACHIEVED", "summary": "gaps or reason, if any"}
+      ```
+
+      `goal_status` MUST be EXACTLY one of `ACHIEVED`, `PARTIAL`, or
+      `NOT_ACHIEVED`.
     output: "reflection_2"
+    parse_json: true
 
   - id: "execute-round-3"
     type: "agent"
     condition: |
-      reflection_2 and ('PARTIAL' in reflection_2 or 'NOT_ACHIEVED' in reflection_2)
+      reflection_2 and (reflection_2.goal_status == 'PARTIAL' or reflection_2.goal_status == 'NOT_ACHIEVED')
     agent: "amplihack:core:builder"
     prompt: |
       Final round. Complete as much remaining work as possible.
 
       **Original Goal**: {{decomposition_json}}
       **Round 2 Result**: {{round_2_result}}
-      **Round 2 Gaps**: {{reflection_2}}
+      **Round 2 Gaps**: {{reflection_2.summary}}
 
       Prioritize the most critical missing items. This is the last round.
       Report what was and was not completed.

--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -193,7 +193,6 @@ assert_runtime_artifact_helper_contracts() {
 
     local case_dir="${WORK}/runtime-artifacts"
     local repo="${case_dir}/repo"
-    local nongit="${case_dir}/not-a-git-worktree"
 
     mkdir -p "${case_dir}"
     git init -b main "${repo}" >/dev/null
@@ -232,12 +231,25 @@ assert_runtime_artifact_helper_contracts() {
     [[ -f "${repo}/worktrees/tracked-source/source.txt" ]] \
         || fail "cleanup must not delete tracked worktrees/ source"
 
+    # The non-git fixture MUST live outside every git repository. Placing it
+    # under ${WORK} is unsafe: ${WORK} is rooted at ${REPO_ROOT}/.. and, when
+    # this suite runs from a *linked* worktree (REPO_ROOT = <main>/worktrees/
+    # <branch>/...), that parent still resolves inside the main repository's
+    # work tree. `git rev-parse --is-inside-work-tree` walks upward and reports
+    # true, so is_git_worktree() would pass and the fail-closed guard would
+    # never be exercised. mktemp -d yields a path under $TMPDIR that is
+    # genuinely outside any repo, making this assertion valid regardless of the
+    # checkout layout (plain clone or nested worktree).
+    local nongit
+    nongit="$(mktemp -d)"
     mkdir -p "${nongit}/.claude/runtime"
     if cleanup_known_workflow_runtime_artifacts "${nongit}"; then
+        rm -rf "${nongit}"
         fail "cleanup must reject non-git directories instead of deleting by path shape alone"
     fi
     [[ -d "${nongit}/.claude/runtime" ]] \
-        || fail "cleanup must not delete anything when the target is not a git worktree"
+        || { rm -rf "${nongit}"; fail "cleanup must not delete anything when the target is not a git worktree"; }
+    rm -rf "${nongit}"
 }
 
 assert_terminal_recipe_uses_final_status_tool() {

--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -1035,11 +1035,14 @@ assert_scoped_pr_helper_contracts
 #       *.lock, package-lock.json, go.sum, ...) whenever any non-generated file
 #       is present. Only a genuinely lockfile-only diff may fall back to the
 #       lockfile scope. CHANGED_COUNT and the PR body still enumerate all files.
-#   R2  workflow-terminal-state.yaml must detect an explicit no-merge directive
-#       in TASK_DESCRIPTION ("do not merge", "don't merge", "no admin merge",
-#       "no-merge", "leave ... open") and force should_merge="false" on the
-#       active emit path, while leaving should_merge="true" when no directive is
-#       present (default behavior unchanged).
+#   R2  workflow-terminal-state.yaml must honor a STRUCTURED no-merge flag
+#       (issue #1062 finding B): the classifier emits `no_merge`, threaded to
+#       the terminal-state probe via the NO_MERGE env / no_merge context var.
+#       A truthy flag forces should_merge="false" on the active emit path, while
+#       its absence leaves should_merge="true" (default behavior unchanged). The
+#       old bash prose-regex over TASK_DESCRIPTION has been removed because
+#       unusual phrasings ("hold off merging", "keep as draft") silently slipped
+#       through it.
 #
 # These assertions SHOULD FAIL before the issue #929 fixes land and MUST PASS
 # afterwards.
@@ -1233,6 +1236,7 @@ run_nomerge_probe_case() {
     local task_description="$2"
     local out="$3"
     local err="$4"
+    local no_merge_flag="${5:-}"
 
     (
         cd "${repo}"
@@ -1244,6 +1248,14 @@ run_nomerge_probe_case() {
         export ISSUE_NUMBER="929"
         export AMPLIHACK_HOME="${REPO_ROOT}"
         export TASK_DESCRIPTION="${task_description}"
+        # Issue #1062 (finding B): no-merge intent is now a STRUCTURED flag
+        # emitted by the classifier, not prose scraped from TASK_DESCRIPTION.
+        # The probe consumes it via the NO_MERGE env / no_merge context var.
+        if [ -n "${no_merge_flag}" ]; then
+            export NO_MERGE="${no_merge_flag}"
+        else
+            unset NO_MERGE
+        fi
         unset PR_URL PR_NUMBER GOAL_ALREADY_MET
         bash "${PROBE_TERMINAL_STEP}"
     ) >"${out}" 2>"${err}"
@@ -1270,25 +1282,27 @@ assert_no_merge_directive_suppresses_auto_merge() {
     grep -q '"should_merge":"true"' "${WORK}/nomerge-control.out" \
         || { cat "${WORK}/nomerge-control.out" >&2; fail "issue #929: default (no directive) active state must keep should_merge=true"; }
 
-    # Directive present -> should_merge must be forced to "false".
-    local directive
-    for directive in \
-        "Fix issue 929. Do NOT merge the PR; leave it open." \
-        "Please don't merge this, no admin merge." \
-        "Implement the change but this is a no-merge task"; do
+    # Directive present -> should_merge must be forced to "false". Issue #1062
+    # (finding B): the directive is now the STRUCTURED `no_merge` flag emitted by
+    # the classifier (truthy tokens), not prose scraped from the task text. The
+    # accompanying task_description prose is intentionally varied to prove the
+    # decision is driven by the flag, NOT by the wording.
+    local directive_flag
+    for directive_flag in "true" "1" "yes"; do
         local case_repo
-        case_repo="${WORK}/nomerge-probe-$(printf '%s' "${directive}" | tr -c 'A-Za-z0-9' '_' | cut -c1-24)"
+        case_repo="${WORK}/nomerge-probe-flag-${directive_flag}"
         setup_nomerge_probe_repo "${case_repo}"
-        if ! run_nomerge_probe_case "${case_repo}" "${directive}" \
-            "${WORK}/nomerge-dir.out" "${WORK}/nomerge-dir.err"; then
+        if ! run_nomerge_probe_case "${case_repo}" \
+            "Implement the change (unusual phrasing: hold off merging, keep as draft)" \
+            "${WORK}/nomerge-dir.out" "${WORK}/nomerge-dir.err" "${directive_flag}"; then
             echo "--- nomerge directive stdout ---" >&2
             cat "${WORK}/nomerge-dir.out" >&2
             echo "--- nomerge directive stderr ---" >&2
             cat "${WORK}/nomerge-dir.err" >&2
-            fail "workflow-terminal-state probe must succeed on an active branch when a no-merge directive is present"
+            fail "workflow-terminal-state probe must succeed on an active branch when a no-merge flag is present"
         fi
         grep -q '"should_merge":"false"' "${WORK}/nomerge-dir.out" \
-            || { echo "directive was: ${directive}" >&2; cat "${WORK}/nomerge-dir.out" >&2; fail "issue #929: no-merge directive must force should_merge=false"; }
+            || { echo "no_merge flag was: ${directive_flag}" >&2; cat "${WORK}/nomerge-dir.out" >&2; fail "issue #929/#1062: structured no_merge flag must force should_merge=false"; }
     done
 }
 

--- a/amplifier-bundle/recipes/workflow-design.yaml
+++ b/amplifier-bundle/recipes/workflow-design.yaml
@@ -198,8 +198,7 @@ steps:
     # step-06b-checkpoint-doc-review reports the degraded state (see its header).
     continue_on_error: true
     # Issue #1062 (finding A3): emit a structured `status` field so the checkpoint
-    # reads a machine-readable outcome via the tested helper toolchain instead of
-    # English-keyword NLU grep over free-text prose.
+    # reads a machine-readable outcome via the tested helper toolchain, not grep.
     parse_json: true
     prompt: |
       # Step 6b: Documentation Review
@@ -279,16 +278,12 @@ steps:
       COMMIT_REF="${COMMIT_SHA:-${HEAD_SHA:-}}"
       REVIEW_THREAD_REF="${REVIEW_THREAD_ID:-${REVIEW_COMMENT_ID:-}}"
 
-      # Classify the review outcome. Issue #1062 (finding A3): STATUS now comes
-      # from the doc-review agent's structured `status` field (emitted via
-      # parse_json), extracted with the tested `orch helper extract-field`
-      # pipeline — NOT English-keyword NLU over free-text feedback. The
-      # untrusted feedback is still consumed strictly as DATA: piped through
-      # `printf '%s'` into the helper, never interpolated into a command
-      # (issue #834 S2). Failure/empty is checked conservatively so mixed or
-      # missing feedback becomes a follow-up item. Empty feedback means the
-      # review produced no notes (the agent step likely errored out under
-      # continue_on_error) — still flag it for attention.
+      # Classify the review outcome. Issue #1062 (finding A3): STATUS comes from
+      # the doc-review agent's structured `status` field (emitted via parse_json)
+      # via the tested `orch helper` pipeline — not English-keyword NLU over
+      # free-text. Untrusted feedback stays DATA: piped through `printf '%s'` into
+      # the helper, never interpolated into a command (issue #834 S2). Empty or
+      # non-OK status is treated conservatively as a follow-up item.
       DOC_STATUS_RAW=$(printf '%s' "$DOC_FEEDBACK" \
         | amplihack orch helper extract-json \
         | amplihack orch helper extract-field --field status --default "")
@@ -298,12 +293,7 @@ steps:
       if [ -z "$DOC_FEEDBACK" ]; then
         STATUS="NEEDS_ATTENTION"
         REASON="documentation-review produced no feedback (step may have failed)"
-      elif [ "$DOC_STATUS_NORM" = "OK" ]; then
-        STATUS="OK"
-        REASON="documentation-review passed"
-      else
-        # Any non-OK structured status (NEEDS_ATTENTION, or an absent/unknown
-        # field) is treated conservatively as a follow-up item.
+      elif [ "$DOC_STATUS_NORM" != "OK" ]; then
         STATUS="NEEDS_ATTENTION"
         REASON="documentation-review reported issues requiring follow-up"
       fi

--- a/amplifier-bundle/recipes/workflow-design.yaml
+++ b/amplifier-bundle/recipes/workflow-design.yaml
@@ -197,6 +197,10 @@ steps:
     # failed/empty review never discards durable upstream work. The follow-on
     # step-06b-checkpoint-doc-review reports the degraded state (see its header).
     continue_on_error: true
+    # Issue #1062 (finding A3): emit a structured `status` field so the checkpoint
+    # reads a machine-readable outcome via the tested helper toolchain instead of
+    # English-keyword NLU grep over free-text prose.
+    parse_json: true
     prompt: |
       # Step 6b: Documentation Review
 
@@ -209,6 +213,19 @@ steps:
       3. Highlights any changes needed to the design
 
       Provide feedback for documentation refinement.
+
+      Output EXACTLY one JSON object as your final line (issue #1062 finding A3:
+      the checkpoint reads the structured `status` field, not substring-matched
+      prose):
+
+      ```json
+      {"status": "OK", "feedback": "concise review notes / refinement guidance"}
+      ```
+
+      `status` MUST be EXACTLY one of:
+      - `OK` -- documentation aligns and is accurate; no follow-up required
+      - `NEEDS_ATTENTION` -- gaps, inaccuracies, or design mismatches remain;
+        put the specifics in `feedback`
     output: "doc_review_feedback"
 
   - id: "step-06c-documentation-refinement"
@@ -238,10 +255,11 @@ steps:
   # doc-review follow-up item — instead of a generic 'failed'.
   #
   # Security: the untrusted agent feedback is consumed strictly as DATA. It is
-  # piped through `printf '%s'` into grep and is NEVER interpolated into the
-  # summary or used to build a command. Only fixed markers + allow-listed,
-  # non-sensitive metadata refs are printed. No eval/source/indirect expansion,
-  # no env/secret dumps. `set -uo pipefail` without `-e`; structurally exits 0.
+  # piped through `printf '%s'` into the `orch helper` extractor and is NEVER
+  # interpolated into the summary or used to build a command. Only fixed markers
+  # + allow-listed, non-sensitive metadata refs are printed. No eval/source/
+  # indirect expansion, no env/secret dumps. `set -uo pipefail` without `-e`;
+  # structurally exits 0.
   - id: "step-06b-checkpoint-doc-review"
     type: "bash"
     command: |
@@ -261,16 +279,31 @@ steps:
       COMMIT_REF="${COMMIT_SHA:-${HEAD_SHA:-}}"
       REVIEW_THREAD_REF="${REVIEW_THREAD_ID:-${REVIEW_COMMENT_ID:-}}"
 
-      # Classify the review outcome. Failure/empty is checked first so mixed or
-      # missing feedback is treated conservatively as a follow-up item. Empty
-      # feedback means the review produced no notes (the agent step likely
-      # errored out under continue_on_error) — still flag it for attention.
+      # Classify the review outcome. Issue #1062 (finding A3): STATUS now comes
+      # from the doc-review agent's structured `status` field (emitted via
+      # parse_json), extracted with the tested `orch helper extract-field`
+      # pipeline — NOT English-keyword NLU over free-text feedback. The
+      # untrusted feedback is still consumed strictly as DATA: piped through
+      # `printf '%s'` into the helper, never interpolated into a command
+      # (issue #834 S2). Failure/empty is checked conservatively so mixed or
+      # missing feedback becomes a follow-up item. Empty feedback means the
+      # review produced no notes (the agent step likely errored out under
+      # continue_on_error) — still flag it for attention.
+      DOC_STATUS_RAW=$(printf '%s' "$DOC_FEEDBACK" \
+        | amplihack orch helper extract-json \
+        | amplihack orch helper extract-field --field status --default "")
+      DOC_STATUS_NORM=$(printf '%s' "$DOC_STATUS_RAW" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')
       STATUS="OK"
       REASON="documentation-review passed"
       if [ -z "$DOC_FEEDBACK" ]; then
         STATUS="NEEDS_ATTENTION"
         REASON="documentation-review produced no feedback (step may have failed)"
-      elif printf '%s' "$DOC_FEEDBACK" | grep -qiE 'fail|error|cannot|could not|unable|missing|incomplete|does not|blocker'; then
+      elif [ "$DOC_STATUS_NORM" = "OK" ]; then
+        STATUS="OK"
+        REASON="documentation-review passed"
+      else
+        # Any non-OK structured status (NEEDS_ATTENTION, or an absent/unknown
+        # field) is treated conservatively as a follow-up item.
         STATUS="NEEDS_ATTENTION"
         REASON="documentation-review reported issues requiring follow-up"
       fi

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -29,7 +29,21 @@ steps:
       # failing tests are independently caught fatally by step-08c-enforce-verdict
       # and step-19c-zero-bs-verification; this presence-gate only needs to honor
       # an explicit failure verdict. A bookkeeping degrade must NEVER mask one.
-      if printf '%s' "$GATE_OUTPUT" | grep -qiE 'VERDICT:[[:space:]]*FAILED|"verdict"[[:space:]]*:[[:space:]]*"[^"]*(FAILED|NOT_VERIFIED)'; then
+      # Issue #1062 (finding A2): the structured JSON verdict now flows through
+      # the tested `orch helper` toolchain (extract-json | extract-field |
+      # normalise-verdict); only the narrow prose "VERDICT: FAILED" fail-safe
+      # token (issue #962) is still matched with a literal grep. The removed
+      # mechanism was the ad-hoc combined dual-format regex — NOT this
+      # documented defensive prose token. normalise-verdict maps FAILED/FAIL/
+      # EMPTY/... to HOLLOW_SUCCESS via exact-token equality, so a benign
+      # summary like "0 tests failed, 19 passed" (no JSON verdict, no prose
+      # "VERDICT: FAILED") is never misread as a failure.
+      JSON_VERDICT=$(printf '%s' "$GATE_OUTPUT" \
+        | amplihack orch helper extract-json \
+        | amplihack orch helper extract-field --field verdict --default '' \
+        | amplihack orch helper normalise-verdict)
+      if [ "$JSON_VERDICT" = "HOLLOW_SUCCESS" ] \
+         || printf '%s' "$GATE_OUTPUT" | grep -qiE 'VERDICT:[[:space:]]*FAILED'; then
         echo "TESTING-EVIDENCE GATE FAILURE: Step 13 evidence records an explicit test/verification FAILURE." >&2
         echo "This is a genuine code-verification failure and stays fatal (not a bookkeeping-absence degrade)." >&2
         exit 1

--- a/amplifier-bundle/recipes/workflow-pr-review.yaml
+++ b/amplifier-bundle/recipes/workflow-pr-review.yaml
@@ -21,23 +21,13 @@ steps:
       echo ""
       GATE_OUTPUT="${LOCAL_TESTING_GATE:-}"
       # Outcome 3 (FATAL — code-verification failure): a genuine test/verification
-      # failure EXPLICITLY recorded as a verdict in the evidence stays fatal. We
-      # match only verdict-style failure tokens (prose "VERDICT: FAILED" or a JSON
-      # "verdict":"...FAILED/NOT_VERIFIED") — NOT a loose "tests failed", which
-      # would false-positive on benign summaries like "0 tests failed, 19 passed"
-      # and re-introduce the very work-discarding abort #962 removes. Actual
-      # failing tests are independently caught fatally by step-08c-enforce-verdict
-      # and step-19c-zero-bs-verification; this presence-gate only needs to honor
-      # an explicit failure verdict. A bookkeeping degrade must NEVER mask one.
-      # Issue #1062 (finding A2): the structured JSON verdict now flows through
-      # the tested `orch helper` toolchain (extract-json | extract-field |
-      # normalise-verdict); only the narrow prose "VERDICT: FAILED" fail-safe
-      # token (issue #962) is still matched with a literal grep. The removed
-      # mechanism was the ad-hoc combined dual-format regex — NOT this
-      # documented defensive prose token. normalise-verdict maps FAILED/FAIL/
-      # EMPTY/... to HOLLOW_SUCCESS via exact-token equality, so a benign
-      # summary like "0 tests failed, 19 passed" (no JSON verdict, no prose
-      # "VERDICT: FAILED") is never misread as a failure.
+      # failure EXPLICITLY recorded as a verdict stays fatal. Issue #1062 (finding
+      # A2): the structured JSON verdict flows through the tested `orch helper`
+      # toolchain (extract-json | extract-field | normalise-verdict, mapping
+      # FAILED/FAIL/EMPTY/... to HOLLOW_SUCCESS); only the prose "VERDICT: FAILED"
+      # fail-safe token (#962) still uses a literal grep. Matching only verdict
+      # tokens avoids false-positives on benign summaries ("0 tests failed, 19
+      # passed"); real failures are caught by step-08c and step-19c.
       JSON_VERDICT=$(printf '%s' "$GATE_OUTPUT" \
         | amplihack orch helper extract-json \
         | amplihack orch helper extract-field --field verdict --default '' \
@@ -49,11 +39,8 @@ steps:
         exit 1
       fi
       # Outcome 2 (VISIBLE DEGRADE / N-A): no local-testing evidence was produced
-      # (e.g. a change with no external-service integration that legitimately
-      # needs none). Per the #962 NO-DISCARD invariant this MUST NOT abort and
-      # cascade (workflow-pr-review -> default-workflow -> whole recipe FAILED),
-      # discarding already-implemented, tested, committed work. It degrades
-      # VISIBLY (loud WARNING) and lets the workflow proceed.
+      # (e.g. a change that legitimately needs none). Per the #962 NO-DISCARD
+      # invariant this MUST NOT abort/cascade; it degrades VISIBLY and continues.
       if [ -z "$GATE_OUTPUT" ] || [ "$GATE_OUTPUT" = "''" ]; then
         echo "WARNING: Step 13 testing-evidence gate is empty / not applicable — no local-testing evidence was recorded for this change." >&2
         echo "WARNING: This is a bookkeeping/evidence gate, not a code-verification gate; degrading VISIBLY and continuing so validated, committed work is NOT discarded (no-discard invariant, issue #962)." >&2
@@ -217,9 +204,8 @@ steps:
       # Pre-publish artifact-provenance gate: runs BEFORE pushing review-feedback
       # commits, so per the landed #829 contract it stays fail-visible (exit 2) if
       # the helper is unresolvable. Uses the git-toplevel variant (NOT REPO_PATH)
-      # to honor the #684 invariant that step-18c requires the worktree; the
-      # AMPLIHACK_HOME/git-toplevel/cwd/~/.copilot/~/.amplihack ladder (issue #962)
-      # still finds it at the install root even for a gitignored worktree bundle.
+      # to honor the #684 worktree invariant; the resolution ladder (#962) still
+      # finds it at the install root even for a gitignored worktree bundle.
       [ -f "$RUNTIME_ARTIFACT_HELPER" ] || { echo "ERROR: workflow runtime artifact helper not found (searched AMPLIHACK_HOME, worktree, cwd, ~/.copilot, ~/.amplihack): $RUNTIME_ARTIFACT_HELPER" >&2; exit 2; }
       # shellcheck source=/dev/null
       . "$RUNTIME_ARTIFACT_HELPER"

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -266,7 +266,7 @@ steps:
           exit 0
           ;;
         INSUFFICIENT_EVIDENCE)
-          echo "WARN: step-08c work-verifier returned INSUFFICIENT_EVIDENCE — letting workflow continue with a loud warning (issue #615)." >&2
+          echo "WARN: step-08c work-verifier returned INSUFFICIENT_EVIDENCE — fail-safe: letting workflow continue with a loud warning (issue #615/#624). An unknown/novel verdict normalises here too, so a recipe with real artifacts is never hard-failed." >&2
           printf '%s\n' "$VERDICT_LINE" | jq . >&2 || printf '%s\n' "$VERDICT_LINE" >&2
           exit 0
           ;;
@@ -277,10 +277,12 @@ steps:
           exit 1
           ;;
         *)
-          # Issue #624: Unknown verdicts fail-safe to INSUFFICIENT_EVIDENCE.
-          # An LLM producing novel verdict strings should never hard-fail a
-          # recipe that already has real artifacts (e.g. an open PR).
-          echo "WARN: step-08c unknown verdict '$VERDICT' — fail-safe to INSUFFICIENT_EVIDENCE (issue #624)." >&2
+          # Defensive fallback (issue #624/#1062): `normalise-verdict` already
+          # collapses unknown/novel verdict strings to INSUFFICIENT_EVIDENCE
+          # upstream, so this branch is normally unreachable. It stays as a
+          # belt-and-suspenders fail-safe: an unexpected token must never
+          # hard-fail a recipe that already has real artifacts (e.g. an open PR).
+          echo "WARN: step-08c unexpected verdict '$VERDICT' — fail-safe to INSUFFICIENT_EVIDENCE (issue #624)." >&2
           printf '%s\n' "$VERDICT_LINE" | jq . >&2 || printf '%s\n' "$VERDICT_LINE" >&2
           exit 0
           ;;

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -243,30 +243,21 @@ steps:
         exit 0
       fi
 
-      # Extract the last line that looks like a JSON object. Tolerates the
-      # verifier mixing prose with the final JSON line.
-      VERDICT_LINE=$(printf '%s\n' "$VERDICT_RAW" | grep -E '^[[:space:]]*\{.*"verdict"' | awk 'NF {line=$0} END {print line}' || true)
-      if [ -z "$VERDICT_LINE" ]; then
-        # Fall back to scanning the entire blob with jq for the first valid
-        # JSON object containing a "verdict" key.
-        VERDICT_LINE=$(printf '%s' "$VERDICT_RAW" | jq -c 'select(type=="object" and has("verdict"))' 2>/dev/null | awk 'NF {line=$0} END {print line}' || true)
-      fi
-      if [ -z "$VERDICT_LINE" ]; then
-        echo "WARN: step-08c-work-verifier output did not contain a parseable JSON verdict. Treating as INSUFFICIENT_EVIDENCE (issue #615)." >&2
-        echo "--- verifier stdout (truncated to 4000 bytes) ---" >&2
-        printf '%s\n' "${VERDICT_RAW:0:4000}" >&2
-        echo "--- end ---" >&2
-        exit 0
-      fi
-
-      VERDICT=$(printf '%s' "$VERDICT_LINE" | jq -r '.verdict // "INSUFFICIENT_EVIDENCE"' 2>/dev/null || echo "INSUFFICIENT_EVIDENCE")
-
-      # Issue #624: Normalize common LLM synonym verdicts before the case gate.
-      case "$VERDICT" in
-        VERIFIED|SUCCESS|APPROVED|PASS|PASSED) VERDICT="WORK_VERIFIED" ;;
-        FAILED|NO_WORK|EMPTY|NO_ARTIFACTS)     VERDICT="HOLLOW_SUCCESS" ;;
-        INCONCLUSIVE|UNKNOWN|UNCLEAR|PARTIAL)  VERDICT="INSUFFICIENT_EVIDENCE" ;;
-      esac
+      # Issue #1062 (finding A1): route the verifier's JSON verdict through the
+      # tested `orch helper` toolchain instead of grep/awk/jq/case text-scraping.
+      #   extract-json      -> first complete JSON object ({} if none parseable)
+      #   extract-field     -> .verdict, or INSUFFICIENT_EVIDENCE if absent
+      #   normalise-verdict -> collapse LLM synonyms via exact-token equality
+      #                        (preserves the #624 synonym mapping and the #615
+      #                        fail-safe default; UNVERIFIED/NOT_APPROVED never
+      #                        collide with a pass token).
+      # A non-parseable blob yields VERDICT_LINE="{}" and
+      # VERDICT="INSUFFICIENT_EVIDENCE", which the gate below degrades safely
+      # (loud WARNING + exit 0), preserving the prior behaviour.
+      VERDICT_LINE=$(printf '%s' "$VERDICT_RAW" | amplihack orch helper extract-json)
+      VERDICT=$(printf '%s' "$VERDICT_LINE" \
+        | amplihack orch helper extract-field --field verdict --default INSUFFICIENT_EVIDENCE \
+        | amplihack orch helper normalise-verdict)
 
       case "$VERDICT" in
         WORK_VERIFIED)

--- a/amplifier-bundle/recipes/workflow-terminal-state.yaml
+++ b/amplifier-bundle/recipes/workflow-terminal-state.yaml
@@ -26,9 +26,9 @@ inputs:
   - name: terminal_fail_mode
     description: "Failure behavior for terminal probe blockers. `exit` preserves standalone fail-closed behavior; `report` emits blocker JSON with exit 0 so workflow-finalize can classify and validate it agentically."
   - name: task_description
-    description: "Original task description. Scanned for an explicit no-merge directive (e.g. 'do not merge', 'no admin merge', 'leave it open') so the workflow never auto-merges when told not to (issue #929)."
+    description: "Original task description. Retained for context/plumbing; no-merge intent is no longer scraped from this prose (issue #1062 finding B) — see the structured `no_merge` flag emitted by the classifier."
   - name: no_merge
-    description: "Optional explicit flag ('true'/'1'/'yes') that forces should_merge='false' regardless of task_description wording."
+    description: "Structured no-merge flag ('true'/'1'/'yes') emitted by the classifier (smart-classify-route `no_merge` field, issue #929/#1062). When truthy it forces should_merge='false'; absent it preserves the auto-merge default."
 
 context:
   repo_path: "."
@@ -250,35 +250,28 @@ steps:
       case "$PR_URL_INPUT" in "{{pr_url}}"|"''") PR_URL_INPUT="" ;; esac
       case "$GOAL_ALREADY_MET_INPUT" in "{{goal_already_met}}"|"''") GOAL_ALREADY_MET_INPUT="false" ;; esac
 
-      # Issue #929: honor an explicit no-merge directive so the workflow never
-      # auto-merges when told not to. Read the task description and optional
-      # explicit flag, then detect intent with static, quoted pattern matching.
-      # Additive gate: a detected directive can only *suppress* auto-merge; when
-      # no directive is found (or detection cannot match) the merge decision
-      # stays at the prior default ("true"), preserving existing behavior.
-      TASK_DESCRIPTION_INPUT="${TASK_DESCRIPTION:-}"
-      [ -n "$TASK_DESCRIPTION_INPUT" ] || TASK_DESCRIPTION_INPUT="${RECIPE_VAR_task_description:-}"
-      [ -n "$TASK_DESCRIPTION_INPUT" ] || TASK_DESCRIPTION_INPUT="{{task_description}}"
-      case "$TASK_DESCRIPTION_INPUT" in "{{task_description}}"|"''") TASK_DESCRIPTION_INPUT="" ;; esac
+      # Issue #929 + #1062 (finding B): honor a no-merge directive so the
+      # workflow never auto-merges when told not to. The intent is now a
+      # *structured* flag emitted by the classifier (smart-classify-route's
+      # `no_merge` parse_json field), NOT a bash regex guessing intent from the
+      # user's prose (unusual phrasings silently auto-merged before). We read
+      # the flag from the explicit `no_merge` context var / `NO_MERGE` env.
+      # Additive gate: a truthy flag can only *suppress* auto-merge; when the
+      # flag is absent the merge decision stays at the prior default ("true"),
+      # preserving existing behavior.
       NO_MERGE_FLAG_INPUT="${NO_MERGE:-}"
       [ -n "$NO_MERGE_FLAG_INPUT" ] || NO_MERGE_FLAG_INPUT="${RECIPE_VAR_no_merge:-}"
       [ -n "$NO_MERGE_FLAG_INPUT" ] || NO_MERGE_FLAG_INPUT="{{no_merge}}"
       case "$NO_MERGE_FLAG_INPUT" in "{{no_merge}}"|"''") NO_MERGE_FLAG_INPUT="" ;; esac
 
-      detect_no_merge_directive() {
-        # $1 explicit flag, $2 free-text task description. User text is only ever
-        # the grep subject, never the pattern, so there is no ReDoS/injection risk.
-        local flag text
+      normalise_no_merge_flag() {
+        # $1 structured flag value. Truthy tokens suppress auto-merge; anything
+        # else (including empty/false) preserves the default merge behavior.
+        local flag
         flag="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
-        case "$flag" in true|1|yes|on) printf 'true\n'; return 0 ;; esac
-        text="$(printf '%s' "${2:-}" | tr '[:upper:]' '[:lower:]')"
-        if printf '%s' "$text" | grep -Eq "do[[:space:]]+not[[:space:]]+merge|don'?t[[:space:]]+merge|no[[:space:]_-]*merge|no[[:space:]]+admin[[:space:]]+merge|leave[[:space:]][^.]*open"; then
-          printf 'true\n'
-          return 0
-        fi
-        printf 'false\n'
+        case "$flag" in true|1|yes|on) printf 'true\n' ;; *) printf 'false\n' ;; esac
       }
-      NO_MERGE_DIRECTIVE="$(detect_no_merge_directive "$NO_MERGE_FLAG_INPUT" "$TASK_DESCRIPTION_INPUT")"
+      NO_MERGE_DIRECTIVE="$(normalise_no_merge_flag "$NO_MERGE_FLAG_INPUT")"
       if [ "$NO_MERGE_DIRECTIVE" = "true" ]; then
         echo "INFO: workflow-terminal-state: explicit no-merge directive detected; auto-merge will be suppressed (should_merge=false)" >&2
       fi

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -140,6 +140,15 @@ path = "../../tests/integration/default_workflow_decomposition_test.rs"
 name = "issue_615_work_verifier"
 path = "../../tests/integration/issue_615_work_verifier_test.rs"
 
+# Issue #1062: brittle-parsing findings from the default-workflow audit. Pins
+# the migration of free-text agent-output scraping to the tested
+# `amplihack orch helper extract-json | extract-field | normalise-verdict`
+# path, plus the additive `session-tree register --json` mode and the
+# structured no_merge/goal_status control signals.
+[[test]]
+name = "issue_1062_brittle_parsing"
+path = "../../tests/integration/issue_1062_brittle_parsing_test.rs"
+
 [[test]]
 name = "workflow_prep_git_recovery"
 path = "../../tests/integration/workflow_prep_git_recovery_test.rs"

--- a/crates/amplihack-cli/src/commands/orch.rs
+++ b/crates/amplihack-cli/src/commands/orch.rs
@@ -58,6 +58,18 @@ pub enum OrchHelperCommands {
     /// `Q&A`, `Operations`, `Investigation`, `Development` (the default).
     NormaliseType,
 
+    /// Read one already-extracted verdict token from stdin, print the
+    /// canonical verdict token.
+    ///
+    /// Output is one of `WORK_VERIFIED`, `HOLLOW_SUCCESS`, or
+    /// `INSUFFICIENT_EVIDENCE` (the default for unknown/empty input).
+    /// Unlike `normalise-type`, matching is **exact-token equality**
+    /// (case-insensitive), not substring — so negation-adjacent labels
+    /// (`UNVERIFIED`, `NOT_APPROVED`, `NOT_ACHIEVED`) never collide with a
+    /// pass token and fall through to `INSUFFICIENT_EVIDENCE`. Used by the
+    /// verdict-gate recipes (issue #1062, finding A).
+    NormaliseVerdict,
+
     /// Read decomposition JSON from stdin, print the workstream count.
     ///
     /// Equivalent to `max(1, len(extract_json(stdin)["workstreams"]))`.
@@ -226,7 +238,50 @@ pub fn normalise_type(raw: &str) -> &'static str {
     "Development"
 }
 
-/// Read all of stdin into a `String`. Errors out cleanly if stdin is
+/// Normalise an already-extracted verdict token to one canonical token:
+/// `WORK_VERIFIED`, `HOLLOW_SUCCESS`, or `INSUFFICIENT_EVIDENCE` (the default
+/// for any unrecognised or empty input).
+///
+/// Matching is **case-insensitive exact-token equality**, deliberately NOT the
+/// substring/`contains` strategy used by [`normalise_type`]. Verdict labels
+/// have negation-adjacent tokens (`UNVERIFIED` vs `VERIFIED`,
+/// `NOT_APPROVED` vs `APPROVED`, `NOT_ACHIEVED` vs `ACHIEVED`); a `contains`
+/// implementation would fail **open** by matching the pass token inside its
+/// own negation. Equality guarantees `PASS ⊄ PASSED` and
+/// `ACHIEVED ⊄ NOT_ACHIEVED` (issue #1062 R2, preserving #615 work-verifier
+/// behaviour).
+///
+/// The input is expected to be one already-extracted token (the output of
+/// `extract-field --field verdict`), not raw agent prose.
+pub fn normalise_verdict(raw: &str) -> &'static str {
+    let t = raw.trim().to_ascii_uppercase();
+    const PASS: &[&str] = &[
+        "VERIFIED",
+        "WORK_VERIFIED",
+        "SUCCESS",
+        "APPROVED",
+        "PASS",
+        "PASSED",
+    ];
+    const HOLLOW: &[&str] = &[
+        "HOLLOW",
+        "HOLLOW_SUCCESS",
+        "FAILED",
+        "FAIL",
+        "NO_WORK",
+        "NO_ARTIFACTS",
+        "EMPTY",
+    ];
+    if PASS.contains(&t.as_str()) {
+        return "WORK_VERIFIED";
+    }
+    if HOLLOW.contains(&t.as_str()) {
+        return "HOLLOW_SUCCESS";
+    }
+    // `INSUFFICIENT`, `INCONCLUSIVE`, `PARTIAL`, `UNKNOWN`, `UNCLEAR`, `NEEDS`,
+    // and everything else (including empty and negation-adjacent labels).
+    "INSUFFICIENT_EVIDENCE"
+}
 /// not valid UTF-8 (recipe shell pipes always produce UTF-8 in practice).
 fn read_stdin() -> Result<String> {
     let mut buf = String::new();
@@ -248,6 +303,11 @@ pub fn run(command: OrchHelperCommands) -> Result<()> {
         OrchHelperCommands::NormaliseType => {
             let input = read_stdin()?;
             println!("{}", normalise_type(input.trim()));
+            Ok(())
+        }
+        OrchHelperCommands::NormaliseVerdict => {
+            let input = read_stdin()?;
+            println!("{}", normalise_verdict(&input));
             Ok(())
         }
         OrchHelperCommands::CountWorkstreams { force_single } => {
@@ -724,6 +784,87 @@ mod tests {
         // "qa" appears before "command" in keyword order — first match wins,
         // matching the Python's short-circuit `any()` evaluation.
         assert_eq!(normalise_type("qa command"), "Q&A");
+    }
+
+    // --- normalise_verdict ---------------------------------------------------
+
+    #[test]
+    fn normalise_verdict_pass_synonyms() {
+        for s in [
+            "VERIFIED",
+            "WORK_VERIFIED",
+            "SUCCESS",
+            "APPROVED",
+            "PASS",
+            "PASSED",
+            "approved",
+            "  pass  ",
+        ] {
+            assert_eq!(normalise_verdict(s), "WORK_VERIFIED", "{s:?}");
+        }
+    }
+
+    #[test]
+    fn normalise_verdict_hollow_synonyms() {
+        for s in [
+            "HOLLOW",
+            "HOLLOW_SUCCESS",
+            "FAILED",
+            "FAIL",
+            "NO_WORK",
+            "NO_ARTIFACTS",
+            "EMPTY",
+            "failed",
+        ] {
+            assert_eq!(normalise_verdict(s), "HOLLOW_SUCCESS", "{s:?}");
+        }
+    }
+
+    #[test]
+    fn normalise_verdict_canonical_tokens_pass_through() {
+        // The three canonical outputs must be idempotent so a value that has
+        // already been normalised once survives a second pass unchanged.
+        for s in ["WORK_VERIFIED", "HOLLOW_SUCCESS", "INSUFFICIENT_EVIDENCE"] {
+            assert_eq!(normalise_verdict(s), s, "{s:?} must pass through unchanged");
+        }
+    }
+
+    #[test]
+    fn normalise_verdict_insufficient_and_unknown_default() {
+        for s in [
+            "INSUFFICIENT",
+            "INCONCLUSIVE",
+            "PARTIAL",
+            "UNKNOWN",
+            "UNCLEAR",
+            "NEEDS",
+            "",
+            "   ",
+            "banana",
+        ] {
+            assert_eq!(normalise_verdict(s), "INSUFFICIENT_EVIDENCE", "{s:?}");
+        }
+    }
+
+    #[test]
+    fn normalise_verdict_negation_adjacent_never_collides_with_pass() {
+        // R2 regression (issue #1062): exact-token equality, not `contains`.
+        // A substring implementation would match VERIFIED inside UNVERIFIED
+        // (or APPROVED inside NOT_APPROVED) and fail OPEN. These must all
+        // resolve to the fail-safe default, never WORK_VERIFIED.
+        for s in [
+            "UNVERIFIED",
+            "NOT_APPROVED",
+            "NOT_ACHIEVED",
+            "NOT_VERIFIED",
+            "UNSUCCESSFUL",
+        ] {
+            assert_eq!(
+                normalise_verdict(s),
+                "INSUFFICIENT_EVIDENCE",
+                "{s:?} must NOT collide with a pass token"
+            );
+        }
     }
 
     #[test]

--- a/crates/amplihack-cli/src/commands/orch.rs
+++ b/crates/amplihack-cli/src/commands/orch.rs
@@ -161,11 +161,12 @@ fn scan_fenced_blocks(text: &str, tagged_only: bool) -> Option<serde_json::Value
             // For untagged blocks, skip any block that is actually ```json —
             // those were already considered (and failed) in the tagged pass.
             let after = &text[body_start_search..];
-            let lang = after
-                .chars()
-                .take_while(|c| c.is_alphanumeric())
-                .collect::<String>();
-            if lang.eq_ignore_ascii_case("json") {
+            let lang_len = after
+                .char_indices()
+                .find(|(_, c)| !c.is_alphanumeric())
+                .map(|(i, _)| i)
+                .unwrap_or(after.len());
+            if after[..lang_len].eq_ignore_ascii_case("json") {
                 search_from = body_start_search;
                 continue;
             }

--- a/crates/amplihack-cli/src/commands/orch.rs
+++ b/crates/amplihack-cli/src/commands/orch.rs
@@ -282,6 +282,8 @@ pub fn normalise_verdict(raw: &str) -> &'static str {
     // and everything else (including empty and negation-adjacent labels).
     "INSUFFICIENT_EVIDENCE"
 }
+
+/// Read all of stdin into a `String`. Errors if reading fails or the input is
 /// not valid UTF-8 (recipe shell pipes always produce UTF-8 in practice).
 fn read_stdin() -> Result<String> {
     let mut buf = String::new();

--- a/crates/amplihack-cli/src/commands/session_tree/mod.rs
+++ b/crates/amplihack-cli/src/commands/session_tree/mod.rs
@@ -36,6 +36,12 @@ pub enum SessionTreeCommands {
         session_id: Option<String>,
         /// Optional parent session ID.
         parent_id: Option<String>,
+        /// Emit a single-line JSON object `{"tree_id":..,"depth":..}` instead
+        /// of the default `TREE_ID=.. DEPTH=..` text line. Additive/opt-in;
+        /// lets consumers reuse the `orch helper extract-field` pipeline
+        /// (issue #1062, finding D2).
+        #[arg(long)]
+        json: bool,
     },
     /// Mark a session as completed.
     Complete {
@@ -103,7 +109,8 @@ pub fn run(cmd: SessionTreeCommands) -> Result<()> {
         SessionTreeCommands::Register {
             session_id,
             parent_id,
-        } => run_register(ctx, session_id, parent_id),
+            json,
+        } => run_register(ctx, session_id, parent_id, json),
         SessionTreeCommands::Complete { session_id } => run_complete(ctx, &session_id),
         SessionTreeCommands::Status { tree_id } => run_status(ctx, tree_id),
         SessionTreeCommands::Check => run_check(ctx),
@@ -114,6 +121,7 @@ fn run_register(
     ctx: TreeContext,
     session_id: Option<String>,
     parent_id: Option<String>,
+    as_json: bool,
 ) -> Result<()> {
     let session_id = session_id.unwrap_or_else(random_id);
     validate_tree_id(&session_id).context("invalid session_id")?;
@@ -164,8 +172,13 @@ fn run_register(
 
     match outcome {
         Ok(()) => {
-            // Byte-exact stdout contract consumed by smart-orchestrator.yaml.
-            println!("TREE_ID={tree_id} DEPTH={depth}");
+            if as_json {
+                // Opt-in single-line JSON; reuses the extract-field pipeline.
+                println!("{}", json!({ "tree_id": tree_id, "depth": depth }));
+            } else {
+                // Byte-exact stdout contract consumed by smart-orchestrator.yaml.
+                println!("TREE_ID={tree_id} DEPTH={depth}");
+            }
             Ok(())
         }
         Err(err) => {

--- a/crates/amplihack-cli/src/self_heal.rs
+++ b/crates/amplihack-cli/src/self_heal.rs
@@ -290,10 +290,14 @@ fn args_should_skip(args: &[OsString]) -> bool {
     if matches!(positionals.as_slice(), ["hygiene", "artifact-guard", ..]) {
         return true;
     }
-    if matches!(
-        positionals.as_slice(),
-        ["orch", "helper", "workflow-log-inventory", ..]
-    ) {
+    // `orch helper <sub>` commands are pure stdin->stdout text-transform
+    // primitives (extract-json, extract-field, normalise-type,
+    // normalise-verdict, reclassify-task-type, workflow-log-inventory, ...).
+    // They are invoked *inside* recipe bash pipelines whose output is parsed
+    // downstream (issue #1062). A self-heal install would emit its banner onto
+    // stdout and corrupt the very pipe these helpers exist to make robust, so
+    // none of them may trigger auto-install.
+    if matches!(positionals.as_slice(), ["orch", "helper", ..]) {
         return true;
     }
 
@@ -689,6 +693,38 @@ steps:
             1,
             "only hygiene artifact-guard should bypass startup self-heal"
         );
+    }
+
+    #[test]
+    fn orch_helper_commands_skip_startup_self_heal() {
+        // Every `orch helper <sub>` is a pipe primitive (issue #1062); a
+        // self-heal install banner on stdout would corrupt recipe pipelines.
+        for sub in [
+            "normalise-verdict",
+            "extract-json",
+            "extract-field",
+            "normalise-type",
+            "reclassify-task-type",
+            "workflow-log-inventory",
+        ] {
+            let tmp = TempDir::new().unwrap();
+            let _g = EnvGuard::new(tmp.path(), None);
+
+            let calls = Cell::new(0u32);
+            let mut buf = Vec::new();
+            ensure_assets_match_binary_version_with(
+                &args(&["amplihack", "orch", "helper", sub]),
+                &mut buf,
+                counting_installer(&calls, crate::VERSION),
+            )
+            .expect("ok");
+
+            assert_eq!(
+                calls.get(),
+                0,
+                "`orch helper {sub}` is a pipe primitive and must not self-heal (would pollute stdout)"
+            );
+        }
     }
 
     #[test]

--- a/docs/howto/parse-agent-verdicts-with-orch-helper.md
+++ b/docs/howto/parse-agent-verdicts-with-orch-helper.md
@@ -1,0 +1,141 @@
+---
+title: Read Agent Verdicts with orch helper
+last_updated: 2026-07-26
+review_schedule: quarterly
+owner: workflow-team
+---
+
+# Read Agent Verdicts with `orch helper`
+
+How to read a verdict, intent, or outcome signal from agent output in a recipe
+step without brittle bash text-scraping. Use this when adding a new gate,
+migrating an old grep/awk/jq step, or debugging a gate that degrades to its
+safe default.
+
+## Before you start
+
+- `amplihack` is installed (`amplihack --version` to confirm).
+- Your agent step captures output with `output:` and, ideally, `parse_json: true`.
+- See the [Structured Verdict & Intent Parsing Reference](../reference/structured-verdict-parsing.md)
+  for the full contract.
+
+## The rule
+
+Never `grep`, `awk`, `jq`, or `case` over agent prose to derive a control
+signal. Route every agent-emitted field through:
+
+```bash
+amplihack orch helper extract-json | amplihack orch helper extract-field --field FIELD --default SAFE_DEFAULT
+```
+
+For verdicts, add `| amplihack orch helper normalise-verdict`.
+
+## Read a verdict from agent output
+
+```bash
+VERDICT=$(printf '%s' "$RAW_AGENT_OUTPUT" \
+  | amplihack orch helper extract-json \
+  | amplihack orch helper extract-field --field verdict --default INSUFFICIENT_EVIDENCE \
+  | amplihack orch helper normalise-verdict)
+
+case "$VERDICT" in
+  WORK_VERIFIED)        echo "gate passed" ;;
+  HOLLOW_SUCCESS)       echo "gate failed (no real work)"; exit 1 ;;
+  *)                    echo "insufficient evidence — degrading safely" ;;
+esac
+```
+
+`normalise-verdict` collapses exact synonym tokens (`APPROVED`, `PASS`,
+`SUCCESS` → `WORK_VERIFIED`; `FAILED`, `EMPTY` → `HOLLOW_SUCCESS`) and maps
+anything else — including negation-adjacent labels like `UNVERIFIED` or
+`NOT_APPROVED` — to `INSUFFICIENT_EVIDENCE`. Matching is exact-token equality,
+not substring, so a failure label can never collide with a pass token. See the
+[canonical mapping](../reference/structured-verdict-parsing.md#canonical-mapping).
+
+## Read a non-verdict field (status, tree_id, etc.)
+
+Drop the normaliser and pick your own safe default:
+
+```bash
+STATUS=$(printf '%s' "$SESSION_INFO" \
+  | amplihack orch helper extract-json \
+  | amplihack orch helper extract-field --field status --default unknown)
+[ "$STATUS" = "ok" ] && echo "allowed"
+```
+
+## Move intent into a structured field
+
+When a signal reflects *intent* (should we merge? is the goal met?), do not
+guess it from prose with a regex. Have the upstream agent emit it as a
+`parse_json` field and read it in an engine condition.
+
+1. Extend the agent's JSON contract, e.g. the classifier emits:
+
+   ```json
+   { "task_type": "Development", "no_merge": true }
+   ```
+
+2. Read it with a `condition:` instead of a bash regex:
+
+   ```yaml
+   condition: "no_merge == true"
+   ```
+
+For loop control on a status field:
+
+```yaml
+condition: "reflection_1.goal_status == 'PARTIAL' or reflection_1.goal_status == 'NOT_ACHIEVED'"
+```
+
+Use `==` equality, never substring `in`, so a stray word in narrative prose
+cannot false-trigger the branch.
+
+## Emit JSON from `session-tree register`
+
+If you need `tree_id` / `depth` in a script, request JSON and reuse the same
+pipeline instead of scraping the text line:
+
+```bash
+INFO=$(amplihack session-tree register --json)
+TREE_ID=$(printf '%s' "$INFO" | amplihack orch helper extract-field --field tree_id --default "")
+DEPTH=$(printf '%s'  "$INFO" | amplihack orch helper extract-field --field depth   --default 0)
+```
+
+The default text output (`TREE_ID=… DEPTH=…`) is unchanged for existing
+consumers; `--json` is opt-in.
+
+## Verify your change
+
+Run the CLI helper tests and the recipe's own test after each migration:
+
+```bash
+cargo test -p amplihack-cli
+# then the recipe's shell/integration test, e.g.
+amplifier-bundle/recipes/tests/test-issue-962-step17a-testing-evidence-gate.sh
+```
+
+## Keep fail-safes intact
+
+Migrating the parsing mechanism must not change behaviour:
+
+- Keep the same safe default the old code used (`INSUFFICIENT_EVIDENCE`,
+  `NEEDS_ATTENTION`, `unknown`, `no_merge=false`).
+- Keep every `WARNING` stderr message and `# issue #NNN` defensive branch.
+- Keep documented prose fail-safe tokens where a test requires them (for
+  example the prose `VERDICT: FAILED` fatal token in
+  `workflow-pr-review.yaml`, issue #962).
+
+## Do NOT convert these
+
+These are correct already — leave them alone:
+
+- `jq` over `gh --json` output.
+- SHA / ref-format / charset validation regex.
+- Greps of `gh` / `git` **stderr** for rate-limit / auth / transient errors.
+- Token-redaction `sed`, slug-building `tr`, the `grep -qF` sentinel.
+
+## Related
+
+- [Structured Verdict & Intent Parsing Reference](../reference/structured-verdict-parsing.md)
+- [`amplihack orch run` and helpers](../reference/orch-run-command.md)
+- [Run a Recipe End-to-End](run-a-recipe.md)

--- a/docs/howto/parse-agent-verdicts-with-orch-helper.md
+++ b/docs/howto/parse-agent-verdicts-with-orch-helper.md
@@ -30,6 +30,10 @@ amplihack orch helper extract-json | amplihack orch helper extract-field --field
 
 For verdicts, add `| amplihack orch helper normalise-verdict`.
 
+> **Security:** agent output is untrusted. Pipe it in as data with
+> `printf '%s' "$RAW"` and branch on the canonical token the helper returns.
+> Never `eval`/`source` agent output or expand it into a command position.
+
 ## Read a verdict from agent output
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -271,6 +271,8 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [Verify Dev-Orchestrator Routing](howto/verify-dev-orchestrator-routing.md) - Check deterministic Development-to-default-workflow routing from the CLI
 - [Correlate Recipe Runs with Logs](howto/correlate-recipe-runs.md) - Match terminal output, final JSON, child process IDs, and runner log paths by run ID
 - [Recipe Executor Environment](reference/recipe-executor-environment.md) - Step-level variables plus subprocess environment contract for forced non-interactive recipe execution
+- [Structured Verdict & Intent Parsing Reference](reference/structured-verdict-parsing.md) - `normalise-verdict` helper, `session-tree register --json`, and the `verdict`/`no_merge`/`goal_status`/`status` fields that replace brittle agent-prose scraping
+- [Read Agent Verdicts with orch helper](howto/parse-agent-verdicts-with-orch-helper.md) - Migrate grep/awk/jq gates to `orch helper extract-json | extract-field | normalise-verdict` and structured `parse_json` conditions
 - [Recipe Context Environment Export](reference/recipe-context-environment.md) - Export recipe context variables to bash steps (`$TASK_DESCRIPTION`, `$REPO_PATH`), uppercasing, reserved-name denylist, and precedence
 - [Tutorial: Propagate Recipe Context to Bash Steps](tutorials/recipe-context-env-propagation.md) - Read context from the environment under `set -u`, including nested sub-recipes and skipped keys
 - [Workflow Provider Abstraction](features/workflow-provider-abstraction.md) - Provider-neutral tracking, change-request publication, terminal state, and stale cleanup through typed helpers and adapters

--- a/docs/reference/structured-verdict-parsing.md
+++ b/docs/reference/structured-verdict-parsing.md
@@ -75,6 +75,20 @@ VERDICT=$(printf '%s' "$RAW" \
   | amplihack orch helper normalise-verdict)
 ```
 
+### Security: agent output is untrusted data, never code
+
+Agent output is attacker-influenceable text. Route it through the pipeline
+above as **data only**:
+
+- Always feed the raw output to the helper via stdin with `printf '%s' "$RAW"`
+  (never string-interpolate it into the command line).
+- Never `eval`, `source`, or `bash -c` agent output, and never expand it into a
+  command position or an indirect/`${!var}` reference.
+- Branch on the *canonical token* the helper returns (a fixed allow-list such as
+  `WORK_VERIFIED` / `HOLLOW_SUCCESS` / `INSUFFICIENT_EVIDENCE`), not on the raw
+  prose. Any unrecognised input already collapses to the safe default, so a
+  crafted verdict string cannot smuggle a shell metacharacter into a decision.
+
 ## `amplihack orch helper normalise-verdict`
 
 Collapses a free-text or synonym verdict label into one canonical token. It

--- a/docs/reference/structured-verdict-parsing.md
+++ b/docs/reference/structured-verdict-parsing.md
@@ -1,0 +1,334 @@
+---
+title: Structured Verdict & Intent Parsing Reference
+last_updated: 2026-07-26
+review_schedule: quarterly
+owner: workflow-team
+---
+
+# Structured Verdict & Intent Parsing Reference
+
+The default-workflow recipe family reads every agent verdict, intent, and
+outcome signal through the tested `amplihack orch helper` toolchain and through
+agent-emitted `parse_json` fields evaluated by engine conditions. There is no
+bash text-scraping of agent prose in the control path.
+
+This reference documents the contract that recipe steps and the backing Rust
+CLI honour: the `normalise-verdict` helper, the `session-tree register --json`
+flag, and the structured fields (`verdict`, `no_merge`, `goal_status`,
+`status`, `tree_id`, `depth`) that drive workflow control flow.
+
+## Contents
+
+- [Why this exists](#why-this-exists)
+- [The canonical extraction pipeline](#the-canonical-extraction-pipeline)
+- [`amplihack orch helper normalise-verdict`](#amplihack-orch-helper-normalise-verdict)
+- [`amplihack session-tree register --json`](#amplihack-session-tree-register---json)
+- [Structured fields by recipe](#structured-fields-by-recipe)
+- [Fail-safe guarantees](#fail-safe-guarantees)
+- [What is intentionally NOT parsed this way](#what-is-intentionally-not-parsed-this-way)
+- [Related references](#related-references)
+
+## Why this exists
+
+Agent output is free text. Three problems used to be solved three different
+brittle ways:
+
+- A verdict was read with line-anchored `grep -E '^{.*"verdict"'`, an `awk`
+  "last line" heuristic, a `jq` fallback, and an inline `case` synonym block.
+- A no-merge directive was guessed from user prose with a regex.
+- A goal status was matched by substring `'PARTIAL' in reflection_1` on prose.
+
+Each degraded silently when an agent emitted a slightly different shape or
+phrasing. The fix routes every one of these signals through one tested tool
+(`orch helper extract-json | extract-field`) plus a small centralised
+normaliser, and moves intent/outcome signals into agent-emitted `parse_json`
+fields that engine `condition:` expressions read directly.
+
+The parsing mechanism changed. The fail-safe defaults, loud `WARNING` stderr
+messages, and issue-referenced defensive branches did not.
+
+## The canonical extraction pipeline
+
+Every recipe step that reads a field from agent output uses this one pattern
+(the template lives at `smart-classify-route.yaml`):
+
+```bash
+VALUE=$(printf '%s' "$RAW" \
+  | amplihack orch helper extract-json \
+  | amplihack orch helper extract-field --field FIELD --default SAFE_DEFAULT)
+```
+
+- `extract-json` reads stdin and prints the first complete JSON object it finds,
+  trying ` ```json ` fenced blocks, untagged ` ``` ` blocks, then a
+  balanced-brace scan over raw prose. It prints `{}` when nothing parseable is
+  found.
+- `extract-field --field FIELD --default SAFE_DEFAULT` reads that JSON object
+  and prints the string value of `FIELD`, or `SAFE_DEFAULT` if the field is
+  absent or the input is not a JSON object.
+
+Verdicts add a normalisation stage to collapse LLM synonyms:
+
+```bash
+VERDICT=$(printf '%s' "$RAW" \
+  | amplihack orch helper extract-json \
+  | amplihack orch helper extract-field --field verdict --default INSUFFICIENT_EVIDENCE \
+  | amplihack orch helper normalise-verdict)
+```
+
+## `amplihack orch helper normalise-verdict`
+
+Collapses a free-text or synonym verdict label into one canonical token. It
+mirrors the existing [`normalise-type`](#related-references) helper: reads the
+label from stdin, prints the canonical token to stdout, exits `0`.
+
+### Synopsis
+
+```
+amplihack orch helper normalise-verdict
+```
+
+Reads one already-extracted verdict token from stdin (the output of
+`extract-field`, not raw agent prose). Matching is case-insensitive **exact-token
+equality**: the label must equal one of the tokens below. Anything else —
+including negation-adjacent labels and empty input — resolves to the
+`INSUFFICIENT_EVIDENCE` default.
+
+### Canonical mapping
+
+| Input token (case-insensitive, exact match)                | Canonical output        |
+| ---------------------------------------------------------- | ----------------------- |
+| `VERIFIED`, `WORK_VERIFIED`, `SUCCESS`, `APPROVED`, `PASS`, `PASSED` | `WORK_VERIFIED`         |
+| `HOLLOW`, `FAILED`, `FAIL`, `NO_WORK`, `NO_ARTIFACTS`, `EMPTY`       | `HOLLOW_SUCCESS`        |
+| `INSUFFICIENT`, `INCONCLUSIVE`, `PARTIAL`, `UNKNOWN`, `UNCLEAR`, `NEEDS` | `INSUFFICIENT_EVIDENCE` |
+| _(anything else, including empty input)_                   | `INSUFFICIENT_EVIDENCE` |
+
+The default is `INSUFFICIENT_EVIDENCE`: a malformed or unrecognised verdict
+neither auto-passes nor hard-aborts a gate. Because matching is exact-token
+equality (not containment), negation-adjacent labels such as `UNVERIFIED`,
+`NOT_APPROVED`, or `NOT_ACHIEVED` never collide with a pass token — they fall to
+the `INSUFFICIENT_EVIDENCE` default. This is the security-critical property from
+the design (R2: equality, not containment — `PASS ⊄ PASSED`, `ACHIEVED ⊄
+NOT_ACHIEVED`); a `str::contains` implementation would fail **open**.
+
+The mapping reproduces the bash `case` block that previously lived inline in
+`workflow-tdd.yaml` (lines 265–268), whose patterns
+(`VERIFIED|SUCCESS|APPROVED|PASS|PASSED)` …) are **exact globs** — token
+equality, not substring. Implement with an exact-match comparison, **not**
+`str::contains`, even though the sibling `normalise_type` uses `contains`:
+task-type labels have no negation-adjacent tokens, verdict labels do. The added
+synonyms (`FAIL`, `HOLLOW`, `INSUFFICIENT`, `NEEDS`, …) are additive exact tokens
+and remain safe under equality. Issue #615 work-verifier behaviour is preserved.
+
+### Examples
+
+```bash
+echo "APPROVED" | amplihack orch helper normalise-verdict
+# WORK_VERIFIED
+
+echo "FAILED" | amplihack orch helper normalise-verdict
+# HOLLOW_SUCCESS
+# (input is the extracted token from `extract-field --field verdict`, not a prose sentence)
+
+echo "PARTIAL" | amplihack orch helper normalise-verdict
+# INSUFFICIENT_EVIDENCE
+
+echo "UNVERIFIED" | amplihack orch helper normalise-verdict
+# INSUFFICIENT_EVIDENCE  (exact-match: does NOT collide with VERIFIED)
+
+printf '' | amplihack orch helper normalise-verdict
+# INSUFFICIENT_EVIDENCE
+```
+
+### Behaviour contract
+
+- Input: one line on stdin (trailing whitespace trimmed).
+- Output: exactly one canonical token followed by a newline.
+- Exit code: `0` in all cases; there is no error path for an unrecognised
+  verdict — that resolves to the default.
+- Unit tests live next to `normalise_type`'s tests in
+  `crates/amplihack-cli/src/commands/orch.rs` and cover each synonym cluster,
+  the default, and the R2 equality regression: negation-adjacent tokens
+  (`UNVERIFIED`, `NOT_APPROVED`, `NOT_ACHIEVED`) must resolve to
+  `INSUFFICIENT_EVIDENCE`, never `WORK_VERIFIED` (a substring match would fail
+  open).
+
+## `amplihack session-tree register --json`
+
+`session-tree register` records a session in the session tree and reports the
+assigned `tree_id` and `depth`. It supports two output formats:
+
+### Default (text) output — unchanged
+
+```bash
+amplihack session-tree register
+# TREE_ID=a1b2c3d4 DEPTH=0
+```
+
+The `TREE_ID=… DEPTH=…` line is byte-for-byte the historical contract. Both
+`smart-classify-route.yaml` and `smart-orchestrator.yaml` still read it, so it
+is never removed or reordered.
+
+### Opt-in JSON output
+
+```bash
+amplihack session-tree register --json
+# {"tree_id":"a1b2c3d4","depth":0}
+```
+
+`--json` is additive. When present, `register` emits a single-line JSON object
+instead of the text line, letting consumers use the same `extract-field`
+pipeline as everywhere else:
+
+```bash
+INFO=$(amplihack session-tree register --json)
+TREE_ID=$(printf '%s' "$INFO" | amplihack orch helper extract-field --field tree_id --default "")
+DEPTH=$(printf '%s' "$INFO" | amplihack orch helper extract-field --field depth --default 0)
+```
+
+The `tree_id` charset validation and the `registration_failed` fallback print
+are unchanged; only the success-line format is selectable.
+
+## Structured fields by recipe
+
+Each control signal below is either extracted with the pipeline above or
+emitted by an agent step as a `parse_json` field and read by an engine
+`condition:`.
+
+| Finding | Recipe / step                                   | Signal                | Source                                                                 |
+| ------- | ----------------------------------------------- | --------------------- | --------------------------------------------------------------------- |
+| A1      | `workflow-tdd.yaml` step-08c work-verifier gate | `verdict`             | `extract-json \| extract-field --field verdict \| normalise-verdict`  |
+| A2      | `workflow-pr-review.yaml` step-17a testing gate | `verdict` (+ fail-safe) | JSON verdict via helper; prose `VERDICT: FAILED` retained as fatal token |
+| A3      | `workflow-design.yaml` doc-review checkpoint    | `verdict` / `status`  | agent `parse_json`, read via `extract-field` + `normalise-verdict`    |
+| B       | `workflow-terminal-state.yaml`                  | `no_merge`            | classifier `parse_json` boolean → `NO_MERGE` env → engine condition   |
+| C       | `smart-reflect-loop.yaml`                       | `goal_status`         | reviewer `parse_json` field, `reflection_N.goal_status == '…'`        |
+| D1      | `smart-execute-routing.yaml`                    | `status`              | `extract-json \| extract-field --field status --default unknown`      |
+| D2      | `smart-classify-route.yaml`                     | `tree_id`, `depth`    | `session-tree register --json` → `extract-field`                      |
+
+### A1 — TDD work-verifier gate (`verdict`)
+
+The verifier's JSON verdict flows through the canonical verdict pipeline. The
+opt-out guard, the empty-input guard, and the four verdict branches
+(`WORK_VERIFIED`, `HOLLOW_SUCCESS`, `INSUFFICIENT_EVIDENCE`, and the fail-safe
+default) are unchanged — only the extraction mechanism moved from
+grep/awk/jq/case to the helper toolchain.
+
+### A2 — PR-review testing-evidence gate (`verdict` + prose fail-safe)
+
+The testing-evidence gate reads semi-structured prose that may embed **either**
+a JSON `"verdict"` **or** a bare prose `VERDICT: FAILED` token:
+
+- **JSON verdict**: extracted via `extract-json | extract-field --field verdict`
+  then normalised; `HOLLOW_SUCCESS` / failure is fatal.
+- **Prose `VERDICT: FAILED`**: a narrow literal match is **retained** as a
+  documented defensive fatal branch (issue #962). This is not the brittle
+  mechanism — the removed mechanism was the ad-hoc combined dual-format regex.
+  The structured JSON path now goes through the helper; only the prose-failure
+  fail-safe token remains.
+
+Contract preserved: prose `VERDICT: FAILED` → exit 1; empty evidence → exit 0
+with a visible `WARNING` degrade; populated benign evidence → exit 0.
+
+### A3 — Design doc-review checkpoint (`verdict` / `status`)
+
+The doc-review agent emits `parse_json` `{"verdict": …}` (or `{"status": …}`),
+read via `extract-field --field verdict --default NEEDS_ATTENTION` and
+normalised. The English-keyword `grep -qiE 'fail|error|cannot|…'` NLU is gone.
+Empty output still defaults to `NEEDS_ATTENTION`, the `WARNING` stderr and the
+stdout markers are unchanged, and the checkpoint remains non-fatal (issue #834).
+
+> **Note:** `normalise-verdict` has no `NEEDS_ATTENTION` output — an empty or
+> unknown doc-review verdict normalises to `INSUFFICIENT_EVIDENCE`. The
+> `NEEDS_ATTENTION` marker asserted by `test-bug-834-doc-review-non-fatal.sh`
+> must therefore be emitted from the checkpoint's own status/marker path (the
+> preserved lines 287–298), independently of the normalised control token. Keep
+> the two concerns separate: the marker is presentation, the normalised token is
+> control flow.
+
+### B — Terminal-state no-merge intent (`no_merge`)
+
+The classifier (`smart-classify-route.yaml`) emits a `no_merge` boolean in its
+`parse_json` output, derived from the task description it already reads. It
+threads down as the context var `no_merge` / env `NO_MERGE` that
+`workflow-terminal-state.yaml` already reads. Terminal-state consumes the
+structured flag via an engine `condition:` (or `[ "$NO_MERGE" = … ]` on the
+exported env), never a prose regex. The "only suppress merge, never fabricate"
+semantics and the explicit-flag path are unchanged.
+
+Because intent is now a structured field, previously unmatched phrasings — "hold
+off merging", "keep it as a draft", "wait for my review" — are honoured by the
+classifier instead of silently auto-merging.
+
+### C — Reflect-loop goal status (`goal_status`)
+
+The reviewer steps that produce `reflection_1` / `reflection_2` emit
+`parse_json` `{"goal_status": "ACHIEVED|PARTIAL|NOT_ACHIEVED"}`. Loop-control
+conditions test the field for equality:
+
+```yaml
+condition: "reflection_1.goal_status == 'PARTIAL' or reflection_1.goal_status == 'NOT_ACHIEVED'"
+```
+
+Equality on a structured field replaces substring `'PARTIAL' in reflection_1`,
+so a stray "partial" in a reviewer's narrative can no longer false-trigger the
+loop. The `GOAL_STATUS:` prose lines remain in the prompts as documentation. A
+`normalise-goal-status` helper is optional and only added if a reviewer emits
+synonyms; equality on the field is the baseline.
+
+### D1 — Execute-routing recursion guard (`status`)
+
+The recursion guard reads `session_info` with the helper instead of
+`grep -qE '"status" *: *"ok"'`:
+
+```bash
+STATUS=$(printf '%s' "$SESSION_INFO" \
+  | amplihack orch helper extract-json \
+  | amplihack orch helper extract-field --field status --default unknown)
+[ "$STATUS" = "ok" ] && ...   # ALLOWED / BLOCKED branches unchanged
+```
+
+### D2 — Classify-route session tree (`tree_id`, `depth`)
+
+`smart-classify-route.yaml` calls `session-tree register --json` and reads
+`tree_id` / `depth` with `extract-field`, replacing
+`grep -oE 'TREE_ID=…' / 'DEPTH=…'`. See
+[`session-tree register --json`](#amplihack-session-tree-register---json).
+
+## Fail-safe guarantees
+
+Every gate remains fail-closed. The parsing change never weakens these:
+
+- Missing / malformed JSON → the step's documented safe default
+  (`INSUFFICIENT_EVIDENCE`, `NEEDS_ATTENTION`, `unknown`, `no_merge=false`).
+- `extract-json` on non-JSON prints `{}`; `extract-field` then returns the
+  supplied `--default`.
+- `normalise-verdict` resolves any unrecognised or empty verdict to
+  `INSUFFICIENT_EVIDENCE`.
+- The `WARNING` stderr messages, `continue_on_error` settings, additive
+  "suppress-only" gate semantics, and `# issue #NNN` defensive branches are
+  preserved byte-for-behaviour.
+
+## What is intentionally NOT parsed this way
+
+These are correct structured-tool usages or format validation, not brittle
+agent-prose scraping, and are left unchanged:
+
+- `jq` over `gh --json` output.
+- SHA validation (`^[0-9a-f]{40}$`), `git check-ref-format`, and `tree_id`
+  charset checks.
+- Error-classification greps of `gh` / `git` **stderr** for rate-limit / auth /
+  5xx / transient failures.
+- Token-redaction `sed` and slug-building `tr`.
+- The exact `grep -qF` orchestration sentinel.
+
+## Related references
+
+- [`amplihack orch run`](orch-run-command.md) — native workstream orchestrator
+  and the `orch helper` subcommand family (`extract-json`, `extract-field`,
+  `normalise-type`, `count-workstreams`, `reclassify-task-type`).
+- [Recipe Executor Environment](recipe-executor-environment.md) — how context
+  vars and `parse_json` outputs reach bash steps and engine conditions.
+- [Doc-Review Non-Fatal Checkpoint](doc-review-non-fatal-checkpoint.md) — the
+  non-fatal semantics preserved by finding A3.
+- [Workflow Terminal State](workflow-terminal-state.md) — no-merge and
+  auto-merge semantics consumed by finding B.
+- How-to: [Read agent verdicts with `orch helper`](../howto/parse-agent-verdicts-with-orch-helper.md).

--- a/tests/integration/issue_1062_brittle_parsing_test.rs
+++ b/tests/integration/issue_1062_brittle_parsing_test.rs
@@ -1,0 +1,786 @@
+//! Issue #1062: fix the brittle-parsing findings from the default-workflow
+//! recipe brittleness audit.
+//!
+//! These tests are written **first** (TDD, step 7) and MUST FAIL against the
+//! current, un-migrated code. They pin the target contract for each finding:
+//!
+//!   A4 (Rust helper): `amplihack orch helper normalise-verdict` centralises
+//!       LLM verdict-synonym handling (mirrors the existing `normalise-type`),
+//!       using EQUALITY not containment (so `NOT_VERIFIED`/`NOT_ACHIEVED` never
+//!       collapse to `WORK_VERIFIED`).
+//!   A1 (workflow-tdd step-08c-enforce-verdict): the free-text verdict scrape
+//!       (`grep -E '^{.*"verdict"'` + `awk` last-line + `jq` fallback + bash
+//!       `case` synonym block) is replaced by
+//!       `orch helper extract-json | extract-field --field verdict | normalise-verdict`.
+//!       Fail-safe branches (#615/#624/#425) are PRESERVED.
+//!   A2 (workflow-pr-review step-17a): the hand-rolled JSON-form regex is
+//!       replaced by the helper; the narrow prose `VERDICT: FAILED` fail-safe
+//!       token stays (issue #962), and the three-outcome contract holds.
+//!   A3 (workflow-design step-06b-checkpoint-doc-review): the English-keyword
+//!       NLU grep (`fail|error|cannot|...`) is removed; STATUS derives from an
+//!       agent-emitted structured field. Non-fatal contract (#834) preserved.
+//!   B  (workflow-terminal-state): no-merge intent stops being guessed from
+//!       user prose via `detect_no_merge_directive` regex; it reads a
+//!       structured classifier-emitted field, while keeping the explicit
+//!       `NO_MERGE` flag plumbing.
+//!   C  (smart-reflect-loop): goal-status loop control stops using substring
+//!       `'PARTIAL' in reflection_1`; the reviewer emits a structured
+//!       `goal_status` (parse_json) tested with equality.
+//!   D1 (smart-execute-routing derive-recursion-guard): `grep -qE '"status" *: *"ok"'`
+//!       over `session_info` JSON is replaced by
+//!       `orch helper extract-field --field status`.
+//!   D2 (session-tree register + smart-classify-route setup-session): `register`
+//!       gains an additive `--json` mode; the default `TREE_ID=.. DEPTH=..`
+//!       line stays byte-exact; the consumer reads it via `extract-field`
+//!       instead of `grep -oE 'TREE_ID=...'`.
+//!
+//! Findings explicitly OUT OF SCOPE (must remain untouched): jq over `gh --json`
+//! output, SHA/charset/ref-format validation regex, gh/git stderr
+//! error-classification greps, token-redaction sed.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Absolute path to the freshly-built `amplihack` binary under test.
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_amplihack")
+}
+
+/// A `PATH` value that includes the built binary's directory, so recipe bash
+/// bodies that call the bare command `amplihack ...` resolve to THIS build.
+fn path_with_bin() -> String {
+    let dir = Path::new(bin())
+        .parent()
+        .expect("binary has a parent dir")
+        .to_string_lossy()
+        .to_string();
+    match std::env::var("PATH") {
+        Ok(p) => format!("{dir}:{p}"),
+        Err(_) => dir,
+    }
+}
+
+/// `amplifier-bundle/recipes/<name>.yaml` relative to the test crate.
+fn recipe_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("amplifier-bundle")
+        .join("recipes")
+        .join(format!("{name}.yaml"))
+}
+
+fn read_recipe(name: &str) -> String {
+    let p = recipe_path(name);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+/// Return the raw `command:` block string of a step by id, from `<recipe>.yaml`.
+fn step_command(recipe: &str, step_id: &str) -> String {
+    step_field(recipe, step_id, "command")
+        .unwrap_or_else(|| panic!("{recipe}: step `{step_id}` has no `command:` block"))
+}
+
+/// Return the raw string value of a scalar/block field of a step by id.
+fn step_field(recipe: &str, step_id: &str, field: &str) -> Option<String> {
+    let text = read_recipe(recipe);
+    let value: serde_yaml::Value = serde_yaml::from_str(&text)
+        .unwrap_or_else(|e| panic!("parse {recipe}.yaml: {e}"));
+    let steps = value
+        .get("steps")
+        .and_then(|s| s.as_sequence())
+        .unwrap_or_else(|| panic!("{recipe}.yaml: top-level `steps:` missing"));
+    for step in steps {
+        let id = step.get("id").and_then(|v| v.as_str()).unwrap_or_default();
+        if id == step_id {
+            return step
+                .get(field)
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+        }
+    }
+    panic!("{recipe}.yaml: step `{step_id}` not found");
+}
+
+/// Is `parse_json: true` set on the step?
+fn step_parse_json(recipe: &str, step_id: &str) -> bool {
+    let text = read_recipe(recipe);
+    let value: serde_yaml::Value = serde_yaml::from_str(&text).unwrap();
+    let steps = value.get("steps").and_then(|s| s.as_sequence()).unwrap();
+    for step in steps {
+        let id = step.get("id").and_then(|v| v.as_str()).unwrap_or_default();
+        if id == step_id {
+            return step
+                .get("parse_json")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        }
+    }
+    panic!("{recipe}.yaml: step `{step_id}` not found");
+}
+
+struct Run {
+    code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+/// Run `amplihack <args>` feeding `stdin`, with an optional extra env map and
+/// the built binary already on PATH.
+fn run_cli(args: &[&str], stdin: &str, extra_env: &[(&str, &str)]) -> Run {
+    let mut cmd = Command::new(bin());
+    cmd.args(args)
+        .env("PATH", path_with_bin())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("spawn amplihack");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait amplihack");
+    Run {
+        code: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+    }
+}
+
+/// Execute a recipe bash body with `amplihack` on PATH and the supplied env.
+fn run_bash_body(body: &str, envs: &[(&str, &str)]) -> Run {
+    let mut script = tempfile::NamedTempFile::new().expect("tempfile");
+    script.write_all(body.as_bytes()).expect("write body");
+    let path = script.path().to_path_buf();
+
+    let mut cmd = Command::new("bash");
+    cmd.arg(&path)
+        .env_clear()
+        .env("PATH", path_with_bin())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("spawn bash");
+    Run {
+        code: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+    }
+}
+
+fn normalise_verdict(input: &str) -> Run {
+    run_cli(&["orch", "helper", "normalise-verdict"], input, &[])
+}
+
+// ===========================================================================
+// A4 — `amplihack orch helper normalise-verdict`
+// ===========================================================================
+
+#[test]
+fn a4_normalise_verdict_subcommand_is_wired() {
+    let run = run_cli(&["orch", "helper", "normalise-verdict", "--help"], "", &[]);
+    assert_eq!(
+        run.code, 0,
+        "`orch helper normalise-verdict --help` must exit 0 (subcommand wired into clap); stderr={}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a4_positive_synonyms_map_to_work_verified() {
+    for raw in ["VERIFIED", "SUCCESS", "APPROVED", "PASS", "PASSED"] {
+        let run = normalise_verdict(raw);
+        assert_eq!(run.code, 0, "normalise-verdict({raw:?}) must exit 0");
+        assert_eq!(
+            run.stdout.trim(),
+            "WORK_VERIFIED",
+            "positive synonym {raw:?} must normalise to WORK_VERIFIED (mirror the tdd `case` block)"
+        );
+    }
+}
+
+#[test]
+fn a4_failure_synonyms_map_to_hollow_success() {
+    for raw in ["FAILED", "NO_WORK", "EMPTY", "NO_ARTIFACTS"] {
+        let run = normalise_verdict(raw);
+        assert_eq!(
+            run.stdout.trim(),
+            "HOLLOW_SUCCESS",
+            "failure synonym {raw:?} must normalise to HOLLOW_SUCCESS"
+        );
+    }
+}
+
+#[test]
+fn a4_inconclusive_synonyms_map_to_insufficient_evidence() {
+    for raw in ["INCONCLUSIVE", "UNKNOWN", "UNCLEAR", "PARTIAL"] {
+        let run = normalise_verdict(raw);
+        assert_eq!(
+            run.stdout.trim(),
+            "INSUFFICIENT_EVIDENCE",
+            "inconclusive synonym {raw:?} must normalise to INSUFFICIENT_EVIDENCE"
+        );
+    }
+}
+
+#[test]
+fn a4_canonical_verdicts_pass_through_unchanged() {
+    for raw in ["WORK_VERIFIED", "HOLLOW_SUCCESS", "INSUFFICIENT_EVIDENCE"] {
+        let run = normalise_verdict(raw);
+        assert_eq!(
+            run.stdout.trim(),
+            raw,
+            "canonical verdict {raw:?} must pass through unchanged"
+        );
+    }
+}
+
+#[test]
+fn a4_unknown_verdict_fail_safes_to_insufficient_evidence() {
+    // Issue #624 philosophy: an LLM producing a novel verdict string must never
+    // hard-fail a recipe that already has real artifacts.
+    for raw in ["WHATEVER", "totally-made-up", ""] {
+        let run = normalise_verdict(raw);
+        assert_eq!(
+            run.stdout.trim(),
+            "INSUFFICIENT_EVIDENCE",
+            "unknown verdict {raw:?} must fail-safe to INSUFFICIENT_EVIDENCE"
+        );
+    }
+}
+
+#[test]
+fn a4_is_case_insensitive_and_trims_whitespace() {
+    for (raw, expected) in [
+        ("verified", "WORK_VERIFIED"),
+        ("  Pass \n", "WORK_VERIFIED"),
+        ("failed", "HOLLOW_SUCCESS"),
+        ("Partial", "INSUFFICIENT_EVIDENCE"),
+    ] {
+        let run = normalise_verdict(raw);
+        assert_eq!(
+            run.stdout.trim(),
+            expected,
+            "normalise-verdict must be case-insensitive and whitespace-trimming: {raw:?}"
+        );
+    }
+}
+
+#[test]
+fn a4_uses_equality_not_containment_regression() {
+    // SECURITY / correctness (design R2): substring matching would collapse
+    // `NOT_VERIFIED` and `NOT_ACHIEVED` into WORK_VERIFIED because they *contain*
+    // "VERIFIED"/"ACHIEVED". Equality-based mapping must NOT do that.
+    for raw in ["NOT_VERIFIED", "NOT_ACHIEVED", "UNVERIFIED"] {
+        let run = normalise_verdict(raw);
+        assert_ne!(
+            run.stdout.trim(),
+            "WORK_VERIFIED",
+            "{raw:?} must NEVER normalise to WORK_VERIFIED (equality, not containment)"
+        );
+    }
+}
+
+// ===========================================================================
+// A1 — workflow-tdd step-08c-enforce-verdict
+// ===========================================================================
+
+const TDD_GATE: &str = "step-08c-enforce-verdict";
+
+#[test]
+fn a1_tdd_gate_uses_orch_helper_extractor() {
+    let cmd = step_command("workflow-tdd", TDD_GATE);
+    assert!(
+        cmd.contains("orch helper extract-json"),
+        "{TDD_GATE} must extract the verdict via `orch helper extract-json`"
+    );
+    assert!(
+        cmd.contains("extract-field") && cmd.contains("verdict"),
+        "{TDD_GATE} must read the verdict with `extract-field --field verdict`"
+    );
+    assert!(
+        cmd.contains("normalise-verdict"),
+        "{TDD_GATE} must centralise synonym handling via `normalise-verdict`"
+    );
+}
+
+#[test]
+fn a1_tdd_gate_drops_brittle_line_scrape() {
+    let cmd = step_command("workflow-tdd", TDD_GATE);
+    // The line-based grep for a JSON object and the awk "last line" scrape are
+    // exactly what multiline verifier JSON defeats — they must be gone.
+    assert!(
+        !cmd.contains(r#"grep -E '^[[:space:]]*\{.*"verdict"'"#),
+        "{TDD_GATE} must not line-grep for a JSON object (multiline JSON defeats it)"
+    );
+    assert!(
+        !cmd.contains("awk 'NF {line=$0} END {print line}'"),
+        "{TDD_GATE} must not use the awk last-JSON-line scrape"
+    );
+    // The scattered bash synonym `case` is replaced by `normalise-verdict`.
+    assert!(
+        !cmd.contains("VERIFIED|SUCCESS|APPROVED|PASS"),
+        "{TDD_GATE} must not carry an inline bash synonym `case` block (moved to normalise-verdict)"
+    );
+}
+
+#[test]
+fn a1_tdd_gate_preserves_failsafe_branches() {
+    let cmd = step_command("workflow-tdd", TDD_GATE);
+    // Do NOT tear down existing fail-safe/opt-out branches or issue-referenced
+    // defensive comments — only replace the brittle parsing mechanism.
+    for needle in [
+        "set -euo pipefail",
+        "INSUFFICIENT_EVIDENCE",
+        "HOLLOW_SUCCESS",
+        "ALLOW_NO_OP",
+        "orchestration",       // #425 sentinel opt-out
+        "issue #615",
+    ] {
+        assert!(
+            cmd.contains(needle),
+            "{TDD_GATE} must preserve fail-safe branch/comment containing {needle:?}"
+        );
+    }
+    assert!(
+        cmd.contains("exit 1"),
+        "{TDD_GATE} must keep the fatal HOLLOW_SUCCESS `exit 1` (issue #962 fatal allowlist)"
+    );
+}
+
+/// Run the migrated tdd gate body with the given inputs.
+fn run_tdd_gate(verdict_json: &str, implementation: &str, allow_no_op: &str) -> Run {
+    let body = step_command("workflow-tdd", TDD_GATE);
+    run_bash_body(
+        &body,
+        &[
+            ("VERDICT_JSON", verdict_json),
+            ("IMPLEMENTATION", implementation),
+            ("ALLOW_NO_OP", allow_no_op),
+        ],
+    )
+}
+
+#[test]
+fn a1_tdd_gate_work_verified_synonym_exits_zero() {
+    // `VERIFIED` is a synonym the old bash `case` handled; normalise-verdict
+    // must handle it after migration.
+    let run = run_tdd_gate(r#"{"verdict": "VERIFIED"}"#, "src/foo.rs changed", "false");
+    assert_eq!(
+        run.code, 0,
+        "WORK_VERIFIED synonym must exit 0; stderr={}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a1_tdd_gate_parses_multiline_json_the_old_scrape_missed() {
+    // The whole point of finding A1: pretty-printed multiline JSON defeated the
+    // line-based grep. extract-json handles it.
+    let verdict = "Here is my verdict:\n{\n  \"verdict\": \"HOLLOW_SUCCESS\",\n  \"rationale\": \"no artifacts\"\n}\n";
+    let run = run_tdd_gate(verdict, "anything", "false");
+    assert_eq!(
+        run.code, 1,
+        "multiline HOLLOW_SUCCESS JSON must be parsed and stay fatal (exit 1); stderr={}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a1_tdd_gate_failed_synonym_is_fatal() {
+    let run = run_tdd_gate(r#"{"verdict": "FAILED"}"#, "anything", "false");
+    assert_eq!(
+        run.code, 1,
+        "FAILED synonym -> HOLLOW_SUCCESS must be fatal (exit 1); stderr={}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a1_tdd_gate_unknown_verdict_fail_safes_to_zero() {
+    let run = run_tdd_gate(r#"{"verdict": "WHATEVER"}"#, "anything", "false");
+    assert_eq!(
+        run.code, 0,
+        "unknown verdict must fail-safe to exit 0 (issue #624); stderr={}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a1_tdd_gate_empty_input_fail_safes_to_zero_with_warning() {
+    let run = run_tdd_gate("", "anything", "false");
+    assert_eq!(run.code, 0, "empty verdict must fail-safe to exit 0");
+    assert!(
+        run.stderr.contains("WARN"),
+        "empty verdict must warn loudly on stderr; stderr={}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a1_tdd_gate_allow_no_op_short_circuits() {
+    // #425 fast-path must still short-circuit BEFORE verdict parsing.
+    let run = run_tdd_gate(r#"{"verdict": "HOLLOW_SUCCESS"}"#, "no diff", "true");
+    assert_eq!(
+        run.code, 0,
+        "ALLOW_NO_OP=true must short-circuit to exit 0 before parsing; stderr={}",
+        run.stderr
+    );
+}
+
+// ===========================================================================
+// A2 — workflow-pr-review step-17a-testing-evidence-gate
+// ===========================================================================
+
+const PR_GATE: &str = "step-17a-testing-evidence-gate";
+
+#[test]
+fn a2_pr_gate_replaces_json_regex_with_helper() {
+    let cmd = step_command("workflow-pr-review", PR_GATE);
+    // The hand-rolled JSON-form regex half must be gone...
+    assert!(
+        !cmd.contains(r#""verdict"[[:space:]]*:[[:space:]]*"[^"]*(FAILED|NOT_VERIFIED)"#),
+        "{PR_GATE} must not hand-roll a JSON `verdict` regex; route JSON through the helper"
+    );
+    // ...replaced by the tested extractor.
+    assert!(
+        cmd.contains("orch helper extract-json") && cmd.contains("extract-field"),
+        "{PR_GATE} must extract an embedded JSON verdict via `orch helper extract-json | extract-field`"
+    );
+}
+
+#[test]
+fn a2_pr_gate_retains_prose_failure_failsafe() {
+    let cmd = step_command("workflow-pr-review", PR_GATE);
+    // The narrow prose token is a documented fail-safe (issue #962), NOT the
+    // brittle mechanism — it must be retained.
+    assert!(
+        cmd.contains("VERDICT:") && cmd.to_uppercase().contains("FAILED"),
+        "{PR_GATE} must keep the prose `VERDICT: FAILED` fail-safe token (issue #962)"
+    );
+    assert!(
+        cmd.contains("issue #962") || cmd.contains("#962"),
+        "{PR_GATE} must keep its issue #962 defensive rationale"
+    );
+}
+
+fn run_pr_gate(gate_value: &str) -> Run {
+    let body = step_command("workflow-pr-review", PR_GATE);
+    run_bash_body(&body, &[("LOCAL_TESTING_GATE", gate_value)])
+}
+
+#[test]
+fn a2_pr_gate_prose_failure_stays_fatal() {
+    // Existing #962 three-outcome contract (FAIL-VISIBLE).
+    let gate = "Step 13: Local Testing Results\nExecuted: cargo test. VERDICT: FAILED — 3 of 19 tests failing.";
+    let run = run_pr_gate(gate);
+    assert_ne!(run.code, 0, "explicit prose failure verdict must stay fatal");
+}
+
+#[test]
+fn a2_pr_gate_embedded_json_failure_is_fatal() {
+    // NEW: a machine-readable JSON verdict embedded in the evidence is now read
+    // via the helper (not a regex) and a FAILED verdict stays fatal.
+    let gate = "Step 13: Local Testing Results\nverifier said: {\"verdict\": \"FAILED\", \"rationale\": \"3 failing\"}";
+    let run = run_pr_gate(gate);
+    assert_ne!(
+        run.code, 0,
+        "embedded JSON FAILED verdict must be fatal via the helper; stderr={}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a2_pr_gate_empty_degrades_visibly() {
+    // #962: empty gate must NOT abort/discard work — degrade with WARNING+exit0.
+    let run = run_pr_gate("");
+    assert_eq!(run.code, 0, "empty gate must degrade, not abort (issue #962)");
+    assert!(
+        run.stdout.to_uppercase().contains("WARNING") || run.stderr.contains("WARNING"),
+        "empty gate must degrade VISIBLY with a WARNING"
+    );
+}
+
+#[test]
+fn a2_pr_gate_benign_failword_is_not_fatal() {
+    // #962: "0 tests failed, 19 passed" must not be misread as a failure verdict.
+    let gate = "Step 13: Local Testing Results\nExecuted: cargo test. Summary: 0 tests failed, 19 passed.";
+    let run = run_pr_gate(gate);
+    assert_eq!(
+        run.code, 0,
+        "benign 'N tests failed, M passed' must not be misread as fatal; stderr={}",
+        run.stderr
+    );
+}
+
+// ===========================================================================
+// A3 — workflow-design step-06b-checkpoint-doc-review
+// ===========================================================================
+
+const DOC_CHECKPOINT: &str = "step-06b-checkpoint-doc-review";
+const DOC_REVIEW: &str = "step-06b-documentation-review";
+
+#[test]
+fn a3_doc_review_emits_structured_status() {
+    // The doc-review agent must emit a machine-readable status field rather than
+    // relying on downstream English-keyword NLU.
+    assert!(
+        step_parse_json("workflow-design", DOC_REVIEW),
+        "{DOC_REVIEW} must set `parse_json: true` so its status/verdict is structured"
+    );
+    let prompt = step_field("workflow-design", DOC_REVIEW, "prompt")
+        .unwrap_or_else(|| panic!("{DOC_REVIEW} must declare a prompt"));
+    assert!(
+        prompt.contains("status"),
+        "{DOC_REVIEW} prompt must instruct the agent to emit a structured `status` field"
+    );
+}
+
+#[test]
+fn a3_doc_checkpoint_drops_keyword_nlu_grep() {
+    let cmd = step_command("workflow-design", DOC_CHECKPOINT);
+    // Pure English-keyword NLU in bash is the brittle mechanism to remove.
+    assert!(
+        !cmd.contains("fail|error|cannot|could not|unable|missing|incomplete|does not|blocker"),
+        "{DOC_CHECKPOINT} must not derive STATUS by keyword-matching free-text feedback"
+    );
+    // STATUS must instead come from the structured agent field.
+    assert!(
+        cmd.contains("extract-field") || cmd.contains("DOC_REVIEW_STATUS") || cmd.contains("doc_review_status"),
+        "{DOC_CHECKPOINT} must derive STATUS from the agent-emitted structured field"
+    );
+}
+
+#[test]
+fn a3_doc_checkpoint_stays_non_fatal_and_safe() {
+    // Preserve the issue #834 contract: non-fatal, WARNING+NEEDS_ATTENTION,
+    // untrusted feedback consumed as data (printf '%s'), no exit 1.
+    let cmd = step_command("workflow-design", DOC_CHECKPOINT);
+    assert!(!cmd.contains("exit 1"), "{DOC_CHECKPOINT} must remain non-fatal (no exit 1)");
+    assert!(cmd.contains("NEEDS_ATTENTION"), "{DOC_CHECKPOINT} must keep the NEEDS_ATTENTION marker");
+    assert!(cmd.contains("WARNING"), "{DOC_CHECKPOINT} must keep a WARNING on stderr");
+    assert!(
+        cmd.contains("printf '%s'"),
+        "{DOC_CHECKPOINT} must keep consuming untrusted feedback safely via printf '%s' (issue #834 S2)"
+    );
+}
+
+// ===========================================================================
+// B — workflow-terminal-state no-merge intent
+// ===========================================================================
+
+#[test]
+fn b_terminal_state_drops_prose_intent_regex() {
+    let text = read_recipe("workflow-terminal-state");
+    // The prose-guessing regex over the user's task description is the failure
+    // mode (unusual phrasings silently auto-merge). It must be gone.
+    assert!(
+        !text.contains("detect_no_merge_directive"),
+        "workflow-terminal-state must not guess no-merge intent from user prose via detect_no_merge_directive"
+    );
+    assert!(
+        !text.contains("leave[[:space:]][^.]*open"),
+        "workflow-terminal-state must not carry the brittle prose no-merge regex"
+    );
+}
+
+#[test]
+fn b_terminal_state_keeps_explicit_flag_plumbing() {
+    let text = read_recipe("workflow-terminal-state");
+    // The structured flag path is retained; only the prose-regex SOURCE is
+    // removed. The decision still reads the explicit no_merge flag.
+    assert!(
+        text.contains("NO_MERGE") || text.contains("no_merge"),
+        "workflow-terminal-state must keep the explicit structured no_merge flag plumbing"
+    );
+}
+
+#[test]
+fn b_classifier_emits_structured_no_merge() {
+    // The classifier already reads task_description; it must emit a structured
+    // no_merge/intent field the engine consumes, instead of a bash regex.
+    let text = read_recipe("smart-classify-route");
+    assert!(
+        text.contains("no_merge"),
+        "smart-classify-route classifier must emit a structured `no_merge` intent field"
+    );
+}
+
+// ===========================================================================
+// C — smart-reflect-loop goal-status control
+// ===========================================================================
+
+#[test]
+fn c_reflect_loop_replaces_substring_conditions_with_equality() {
+    let text = read_recipe("smart-reflect-loop");
+    // Substring matching free-text prose can false-trigger on a stray "partial"
+    // in a reviewer narrative.
+    for brittle in [
+        "'PARTIAL' in reflection_1",
+        "'NOT_ACHIEVED' in reflection_1",
+        "'HOLLOW' in reflection_1",
+        "'PARTIAL' in reflection_2",
+        "'NOT_ACHIEVED' in reflection_2",
+    ] {
+        assert!(
+            !text.contains(brittle),
+            "smart-reflect-loop must not gate the loop on substring match `{brittle}`"
+        );
+    }
+    assert!(
+        text.contains("goal_status"),
+        "smart-reflect-loop conditions must test a structured `goal_status` field"
+    );
+    assert!(
+        text.contains("goal_status ==") || text.contains("goal_status=="),
+        "smart-reflect-loop must use equality (==) against goal_status, not containment"
+    );
+}
+
+#[test]
+fn c_reflect_steps_emit_structured_goal_status() {
+    // The reviewer/reflection steps must emit parse_json so goal_status is a
+    // real field, not scraped from prose.
+    for step in ["reflect-round-1", "reflect-round-2"] {
+        // reflect-round-1 may be named differently; tolerate absence by checking
+        // any step whose output feeds a loop condition. We assert at least the
+        // canonical reviewer step carries parse_json.
+        if step_field("smart-reflect-loop", step, "output").is_some() {
+            assert!(
+                step_parse_json("smart-reflect-loop", step),
+                "{step} must set parse_json:true so goal_status is structured"
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// D1 — smart-execute-routing derive-recursion-guard
+// ===========================================================================
+
+const GUARD_STEP: &str = "derive-recursion-guard";
+
+#[test]
+fn d1_guard_uses_extract_field_over_json() {
+    let cmd = step_command("smart-execute-routing", GUARD_STEP);
+    assert!(
+        !cmd.contains(r#"grep -qE '"status" *: *"ok"'"#),
+        "{GUARD_STEP} must not regex-scan session_info JSON for status"
+    );
+    assert!(
+        cmd.contains("extract-field") && cmd.contains("status"),
+        "{GUARD_STEP} must derive status via `orch helper extract-field --field status`"
+    );
+}
+
+fn run_guard(session_info: &str) -> Run {
+    let body = step_command("smart-execute-routing", GUARD_STEP);
+    run_bash_body(&body, &[("SESSION_INFO", session_info)])
+}
+
+#[test]
+fn d1_guard_allows_ok_status() {
+    let run = run_guard(r#"{"session_id":"a","tree_id":"t","depth":0,"status":"ok"}"#);
+    assert!(
+        run.stdout.contains("ALLOWED"),
+        "status=ok must yield ALLOWED; stdout={} stderr={}",
+        run.stdout,
+        run.stderr
+    );
+}
+
+#[test]
+fn d1_guard_blocks_registration_failed() {
+    let run = run_guard(r#"{"session_id":"none","tree_id":"none","depth":0,"status":"registration_failed"}"#);
+    assert!(
+        run.stdout.contains("BLOCKED"),
+        "status=registration_failed must yield BLOCKED; stdout={} stderr={}",
+        run.stdout,
+        run.stderr
+    );
+}
+
+// ===========================================================================
+// D2 — session-tree register --json + smart-classify-route consumer
+// ===========================================================================
+
+#[test]
+fn d2_register_default_line_is_byte_exact() {
+    // The additive --json flag must NOT disturb the byte-exact default contract
+    // consumed by smart-orchestrator.yaml: `TREE_ID=<id> DEPTH=<n>\n`.
+    let tmp = tempfile::TempDir::new_in("/tmp").unwrap();
+    let run = run_cli(
+        &["session-tree", "register", "sess1234"],
+        "",
+        &[
+            ("AMPLIHACK_SESSION_TREE_DIR", tmp.path().to_str().unwrap()),
+            ("AMPLIHACK_TREE_ID", "treeabc"),
+            ("AMPLIHACK_SESSION_DEPTH", "0"),
+        ],
+    );
+    assert_eq!(run.code, 0, "register must exit 0; stderr={}", run.stderr);
+    assert_eq!(
+        run.stdout, "TREE_ID=treeabc DEPTH=0\n",
+        "default register stdout must remain byte-exact"
+    );
+}
+
+#[test]
+fn d2_register_json_flag_emits_structured_status() {
+    let tmp = tempfile::TempDir::new_in("/tmp").unwrap();
+    let run = run_cli(
+        &["session-tree", "register", "sess5678", "--json"],
+        "",
+        &[
+            ("AMPLIHACK_SESSION_TREE_DIR", tmp.path().to_str().unwrap()),
+            ("AMPLIHACK_TREE_ID", "treexyz"),
+            ("AMPLIHACK_SESSION_DEPTH", "0"),
+        ],
+    );
+    assert_eq!(run.code, 0, "register --json must exit 0; stderr={}", run.stderr);
+    let v: serde_json::Value = serde_json::from_str(run.stdout.trim())
+        .unwrap_or_else(|e| panic!("register --json must emit valid single-line JSON: {e}; got {:?}", run.stdout));
+    // The JSON must carry the same tree_id/depth as the byte-exact text line so
+    // the consumer (setup-session) can read them via `extract-field` instead of
+    // `grep -oE 'TREE_ID=...'`. setup-session wraps this with session_id/status.
+    assert_eq!(
+        v.get("tree_id").and_then(|x| x.as_str()),
+        Some("treexyz"),
+        "register --json must expose tree_id for extract-field"
+    );
+    assert_eq!(
+        v.get("depth").and_then(|x| x.as_u64()),
+        Some(0),
+        "register --json must expose depth for extract-field"
+    );
+}
+
+#[test]
+fn d2_classify_route_consumer_uses_json_not_text_grep() {
+    let cmd = step_command("smart-classify-route", "setup-session");
+    assert!(
+        !cmd.contains("grep -oE 'TREE_ID="),
+        "setup-session must not grep TREE_ID out of `register` text output"
+    );
+    assert!(
+        cmd.contains("register") && cmd.contains("--json"),
+        "setup-session must call `session-tree register ... --json`"
+    );
+    assert!(
+        cmd.contains("extract-field"),
+        "setup-session must read tree_id/depth via `orch helper extract-field`"
+    );
+}

--- a/tests/integration/issue_1062_brittle_parsing_test.rs
+++ b/tests/integration/issue_1062_brittle_parsing_test.rs
@@ -89,8 +89,8 @@ fn step_command(recipe: &str, step_id: &str) -> String {
 /// Return the raw string value of a scalar/block field of a step by id.
 fn step_field(recipe: &str, step_id: &str, field: &str) -> Option<String> {
     let text = read_recipe(recipe);
-    let value: serde_yaml::Value = serde_yaml::from_str(&text)
-        .unwrap_or_else(|e| panic!("parse {recipe}.yaml: {e}"));
+    let value: serde_yaml::Value =
+        serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {recipe}.yaml: {e}"));
     let steps = value
         .get("steps")
         .and_then(|s| s.as_sequence())
@@ -98,10 +98,7 @@ fn step_field(recipe: &str, step_id: &str, field: &str) -> Option<String> {
     for step in steps {
         let id = step.get("id").and_then(|v| v.as_str()).unwrap_or_default();
         if id == step_id {
-            return step
-                .get(field)
-                .and_then(|v| v.as_str())
-                .map(str::to_string);
+            return step.get(field).and_then(|v| v.as_str()).map(str::to_string);
         }
     }
     panic!("{recipe}.yaml: step `{step_id}` not found");
@@ -347,7 +344,7 @@ fn a1_tdd_gate_preserves_failsafe_branches() {
         "INSUFFICIENT_EVIDENCE",
         "HOLLOW_SUCCESS",
         "ALLOW_NO_OP",
-        "orchestration",       // #425 sentinel opt-out
+        "orchestration", // #425 sentinel opt-out
         "issue #615",
     ] {
         assert!(
@@ -487,7 +484,10 @@ fn a2_pr_gate_prose_failure_stays_fatal() {
     // Existing #962 three-outcome contract (FAIL-VISIBLE).
     let gate = "Step 13: Local Testing Results\nExecuted: cargo test. VERDICT: FAILED — 3 of 19 tests failing.";
     let run = run_pr_gate(gate);
-    assert_ne!(run.code, 0, "explicit prose failure verdict must stay fatal");
+    assert_ne!(
+        run.code, 0,
+        "explicit prose failure verdict must stay fatal"
+    );
 }
 
 #[test]
@@ -507,7 +507,10 @@ fn a2_pr_gate_embedded_json_failure_is_fatal() {
 fn a2_pr_gate_empty_degrades_visibly() {
     // #962: empty gate must NOT abort/discard work — degrade with WARNING+exit0.
     let run = run_pr_gate("");
-    assert_eq!(run.code, 0, "empty gate must degrade, not abort (issue #962)");
+    assert_eq!(
+        run.code, 0,
+        "empty gate must degrade, not abort (issue #962)"
+    );
     assert!(
         run.stdout.to_uppercase().contains("WARNING") || run.stderr.contains("WARNING"),
         "empty gate must degrade VISIBLY with a WARNING"
@@ -517,7 +520,8 @@ fn a2_pr_gate_empty_degrades_visibly() {
 #[test]
 fn a2_pr_gate_benign_failword_is_not_fatal() {
     // #962: "0 tests failed, 19 passed" must not be misread as a failure verdict.
-    let gate = "Step 13: Local Testing Results\nExecuted: cargo test. Summary: 0 tests failed, 19 passed.";
+    let gate =
+        "Step 13: Local Testing Results\nExecuted: cargo test. Summary: 0 tests failed, 19 passed.";
     let run = run_pr_gate(gate);
     assert_eq!(
         run.code, 0,
@@ -559,7 +563,9 @@ fn a3_doc_checkpoint_drops_keyword_nlu_grep() {
     );
     // STATUS must instead come from the structured agent field.
     assert!(
-        cmd.contains("extract-field") || cmd.contains("DOC_REVIEW_STATUS") || cmd.contains("doc_review_status"),
+        cmd.contains("extract-field")
+            || cmd.contains("DOC_REVIEW_STATUS")
+            || cmd.contains("doc_review_status"),
         "{DOC_CHECKPOINT} must derive STATUS from the agent-emitted structured field"
     );
 }
@@ -569,9 +575,18 @@ fn a3_doc_checkpoint_stays_non_fatal_and_safe() {
     // Preserve the issue #834 contract: non-fatal, WARNING+NEEDS_ATTENTION,
     // untrusted feedback consumed as data (printf '%s'), no exit 1.
     let cmd = step_command("workflow-design", DOC_CHECKPOINT);
-    assert!(!cmd.contains("exit 1"), "{DOC_CHECKPOINT} must remain non-fatal (no exit 1)");
-    assert!(cmd.contains("NEEDS_ATTENTION"), "{DOC_CHECKPOINT} must keep the NEEDS_ATTENTION marker");
-    assert!(cmd.contains("WARNING"), "{DOC_CHECKPOINT} must keep a WARNING on stderr");
+    assert!(
+        !cmd.contains("exit 1"),
+        "{DOC_CHECKPOINT} must remain non-fatal (no exit 1)"
+    );
+    assert!(
+        cmd.contains("NEEDS_ATTENTION"),
+        "{DOC_CHECKPOINT} must keep the NEEDS_ATTENTION marker"
+    );
+    assert!(
+        cmd.contains("WARNING"),
+        "{DOC_CHECKPOINT} must keep a WARNING on stderr"
+    );
     assert!(
         cmd.contains("printf '%s'"),
         "{DOC_CHECKPOINT} must keep consuming untrusted feedback safely via printf '%s' (issue #834 S2)"
@@ -704,7 +719,9 @@ fn d1_guard_allows_ok_status() {
 
 #[test]
 fn d1_guard_blocks_registration_failed() {
-    let run = run_guard(r#"{"session_id":"none","tree_id":"none","depth":0,"status":"registration_failed"}"#);
+    let run = run_guard(
+        r#"{"session_id":"none","tree_id":"none","depth":0,"status":"registration_failed"}"#,
+    );
     assert!(
         run.stdout.contains("BLOCKED"),
         "status=registration_failed must yield BLOCKED; stdout={} stderr={}",
@@ -750,9 +767,17 @@ fn d2_register_json_flag_emits_structured_status() {
             ("AMPLIHACK_SESSION_DEPTH", "0"),
         ],
     );
-    assert_eq!(run.code, 0, "register --json must exit 0; stderr={}", run.stderr);
-    let v: serde_json::Value = serde_json::from_str(run.stdout.trim())
-        .unwrap_or_else(|e| panic!("register --json must emit valid single-line JSON: {e}; got {:?}", run.stdout));
+    assert_eq!(
+        run.code, 0,
+        "register --json must exit 0; stderr={}",
+        run.stderr
+    );
+    let v: serde_json::Value = serde_json::from_str(run.stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "register --json must emit valid single-line JSON: {e}; got {:?}",
+            run.stdout
+        )
+    });
     // The JSON must carry the same tree_id/depth as the byte-exact text line so
     // the consumer (setup-session) can read them via `extract-field` instead of
     // `grep -oE 'TREE_ID=...'`. setup-session wraps this with session_id/status.

--- a/tests/integration/p1_workflow_reliability_test.rs
+++ b/tests/integration/p1_workflow_reliability_test.rs
@@ -112,21 +112,25 @@ fn run_gate(verdict_json: &str, implementation: &str, allow_no_op: &str) -> Gate
 mod ws1_synonym_mapping {
     use super::*;
 
-    /// The enforce-verdict bash command must contain the synonym mapping block.
+    /// The enforce-verdict bash command must route the verifier's verdict through
+    /// the tested `orch helper` parsing toolchain (issue #1062, finding A1),
+    /// rather than an inline grep/awk/jq + `case` synonym block. The synonym
+    /// mapping itself now lives in `normalise-verdict` and is covered by that
+    /// helper's Rust unit tests plus the runtime `synonym_*` tests below.
     #[test]
-    fn enforce_verdict_command_contains_synonym_case_block() {
+    fn enforce_verdict_command_routes_through_orch_helper_toolchain() {
         let cmd = enforce_verdict_command();
         assert!(
-            cmd.contains("VERIFIED") && cmd.contains("WORK_VERIFIED"),
-            "enforce-verdict must contain synonym mapping from VERIFIED to WORK_VERIFIED"
+            cmd.contains("orch helper extract-json"),
+            "enforce-verdict must extract the JSON verdict via `orch helper extract-json`"
         );
         assert!(
-            cmd.contains("NO_WORK") && cmd.contains("HOLLOW_SUCCESS"),
-            "enforce-verdict must map NO_WORK to HOLLOW_SUCCESS"
+            cmd.contains("orch helper extract-field") && cmd.contains("--field verdict"),
+            "enforce-verdict must read the verdict via `orch helper extract-field --field verdict`"
         );
         assert!(
-            cmd.contains("INCONCLUSIVE") && cmd.contains("INSUFFICIENT_EVIDENCE"),
-            "enforce-verdict must map INCONCLUSIVE to INSUFFICIENT_EVIDENCE"
+            cmd.contains("orch helper normalise-verdict"),
+            "enforce-verdict must collapse synonyms via `orch helper normalise-verdict`"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the brittle-parsing findings from the default-workflow recipe brittleness audit (issue #1062). Replaces fragile bash text-scraping of agent output with the tested Rust `amplihack orch helper extract-json | extract-field | normalise-verdict` tooling, and moves intent/outcome control signals to agent-emitted `parse_json` fields read by engine conditions.

**Guiding principle:** only the *parsing mechanism* changed. All existing fail-safe branches, safe defaults, loud stderr warnings, and issue-referenced defensive comments are preserved.

## Findings addressed

- **A — agent verdict parsed from free text (3 inconsistent sites).** `workflow-tdd.yaml`, `workflow-pr-review.yaml`, and `workflow-design.yaml` now read the verdict via the `orch helper extract-json | extract-field --field verdict` pipeline. Added a new tested Rust `normalise-verdict` helper that uses **exact-token equality** (not `str::contains`) so `PASS ⊄ PASSED` and `UNVERIFIED ⊄ VERIFIED` — closing a fail-open hole the naive `normalise_type` mirror would have introduced. `A2` keeps its narrow prose `VERDICT: FAILED` fatal token (#962).
- **B — no-merge intent regex over user prose** (`workflow-terminal-state.yaml`): replaced by a structured classifier-emitted `no_merge` field read by an engine condition.
- **C — goal-status substring matching** (`smart-reflect-loop.yaml`): reviewer now emits a `parse_json` `goal_status` field; loop control uses `==` equality instead of `'PARTIAL' in ...` substring tests.
- **D — regex over structured JSON** (`smart-execute-routing.yaml`, `smart-classify-route.yaml`): use `extract-field`; `session-tree register` gained an additive `--json` output.

## Notable bug found & fixed during implementation

The `orch helper` pipe primitives could have their stdout polluted by the startup self-heal banner — which would corrupt the very pipelines this change introduces. Generalized the self-heal carve-out to exempt **all** `orch helper` subcommands, with a regression test.

## Verification

- New `issue_1062_brittle_parsing` integration suite: 37/37 pass
- `issue_615_work_verifier` regression: 19/19 pass
- Full workspace at bounded parallelism: 264 test-result groups, **zero failures** (failures seen only under a ~1500-test fork storm were `EAGAIN`, environmental)
- clippy clean; recipe files kept under the 400-line brick limit
- Docs: new `docs/reference/structured-verdict-parsing.md` + `docs/howto/parse-agent-verdicts-with-orch-helper.md`, linked from `docs/index.md`

Closes #1062

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
