### PR TITLE
fix(recipe): deconflict foreign-worktree branch ownership in worktree setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Recipes — ADO work items assigned + typed + fail-loud (issue #983)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-issue-983-azdo-work-item-assignment.sh
+      - name: Recipes — foreign-worktree branch deconfliction (concurrency)
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh
       - name: Recipes — shellcheck worktree sweep helper (issue #840)
         shell: bash
         run: |
@@ -101,6 +104,15 @@ jobs:
           else
             sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
             shellcheck -S warning amplifier-bundle/tools/workflow_worktree_sweep.sh
+          fi
+      - name: Recipes — shellcheck worktree deconflict helper (concurrency)
+        shell: bash
+        run: |
+          if command -v shellcheck >/dev/null 2>&1; then
+            shellcheck -S warning amplifier-bundle/tools/workflow_worktree_deconflict.sh
+          else
+            sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+            shellcheck -S warning amplifier-bundle/tools/workflow_worktree_deconflict.sh
           fi
       - uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
         with:

--- a/amplifier-bundle/recipes/consensus-issue-worktree.yaml
+++ b/amplifier-bundle/recipes/consensus-issue-worktree.yaml
@@ -273,10 +273,18 @@ steps:
       [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
       [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
       if [ -f "$DECONFLICT_HELPER" ]; then
-        RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_DIR/$BRANCH_NAME" "$(pwd)" 2>/dev/null || echo "$BRANCH_NAME")"
-        if [ -n "$RESOLVED_BRANCH" ] && [ "$RESOLVED_BRANCH" != "$BRANCH_NAME" ]; then
-          echo "INFO: branch '$BRANCH_NAME' is owned by a foreign worktree — deconflicting to '$RESOLVED_BRANCH'." >&2
-          BRANCH_NAME="$RESOLVED_BRANCH"
+        # Let helper diagnostics (stderr) surface; branch on EXIT CODE so a clean
+        # resolution (exit 0) is distinguished from exhaustion/misconfig (non-zero).
+        # On failure, fail loud instead of silently reusing the CONFLICTING name
+        # (which would re-abort at the idempotency guard's `git branch -D`).
+        if RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_DIR/$BRANCH_NAME" "$(pwd)")"; then
+          if [ -n "$RESOLVED_BRANCH" ] && [ "$RESOLVED_BRANCH" != "$BRANCH_NAME" ]; then
+            echo "INFO: branch '$BRANCH_NAME' is owned by a foreign worktree — deconflicting to '$RESOLVED_BRANCH'." >&2
+            BRANCH_NAME="$RESOLVED_BRANCH"
+          fi
+        else
+          echo "ERROR: worktree branch deconfliction failed for '$BRANCH_NAME' (helper exhausted its bounded retries or hit a misconfiguration; see stderr above). Aborting to avoid clobbering a concurrent foreign worktree." >&2
+          exit 1
         fi
       fi
 

--- a/amplifier-bundle/recipes/consensus-issue-worktree.yaml
+++ b/amplifier-bundle/recipes/consensus-issue-worktree.yaml
@@ -261,6 +261,25 @@ steps:
 
       # Create worktree (base ref already resolved to a remote ref above; #858).
 
+      # --- Foreign-worktree deconfliction (concurrency-safety) ---
+      # MIRROR of workflow-worktree.yaml step-04-setup-worktree. Before the
+      # idempotency guard's `git branch -D`, check whether BRANCH_NAME is held by
+      # a FOREIGN worktree at a DIFFERENT path (a concurrent recipe that derived
+      # the same slug). If so the helper returns a NEW provably-free branch name
+      # (recompute WORKTREE_PATH) instead of deleting the foreign branch; else it
+      # returns the candidate unchanged. Best-effort (#829/#840): a missing helper
+      # is a graceful no-op. Keep this mirror in sync with the executable recipe.
+      DECONFLICT_HELPER="${AMPLIHACK_HOME:-$(pwd)}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+      [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+      [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="${HOME:-/root}/.amplihack/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+      if [ -f "$DECONFLICT_HELPER" ]; then
+        RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_DIR/$BRANCH_NAME" "$(pwd)" 2>/dev/null || echo "$BRANCH_NAME")"
+        if [ -n "$RESOLVED_BRANCH" ] && [ "$RESOLVED_BRANCH" != "$BRANCH_NAME" ]; then
+          echo "INFO: branch '$BRANCH_NAME' is owned by a foreign worktree — deconflicting to '$RESOLVED_BRANCH'." >&2
+          BRANCH_NAME="$RESOLVED_BRANCH"
+        fi
+      fi
+
       # Idempotency guard (mirrors default-workflow three-state check)
       WORKTREE_PATH="$WORKTREE_DIR/$BRANCH_NAME"
       BRANCH_EXISTS=$(git branch --list "$BRANCH_NAME")

--- a/amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh
+++ b/amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# test-foreign-worktree-deconflict.sh — TDD spec for the foreign-worktree
+# branch-deconfliction fix (concurrency bug in workflow-worktree.yaml).
+#
+# ROOT CAUSE (issue #200 family / concurrency): in step-04-setup-worktree's
+# State-2 idempotency path (branch exists, worktree missing at THIS recipe's
+# WORKTREE_PATH, COMMITS_AHEAD>0) the script runs `git branch -D "${BRANCH_NAME}"`
+# (~L334). When that same BRANCH_NAME is currently checked out by a DIFFERENT,
+# concurrently-running recipe's worktree (a FOREIGN worktree at another path),
+# `git branch -D` fails with "cannot delete branch used by worktree" and the
+# whole recipe aborts. WORKTREE_EXISTS (~L308, `grep -Fx`) only matches this
+# recipe's EXACT path, so a foreign worktree owning the branch elsewhere is
+# invisible to the state machine.
+#
+# FIX (approved design): a self-contained, NON-DESTRUCTIVE shell brick
+# `amplifier-bundle/tools/workflow_worktree_deconflict.sh` parses
+# `git worktree list --porcelain`, detects when the candidate branch is owned by
+# a FOREIGN worktree (checked out at a normalized path != the intended one), and
+# returns a fresh, provably-free branch name via a bounded (<=5) retry loop.
+# step-04-setup-worktree invokes it best-effort (graceful no-op if absent, #829/
+# #840 precedent) BEFORE the idempotency state machine, reassigning
+# BRANCH_NAME/WORKTREE_PATH so the deconflicted name flows into the JSON output.
+# The consensus recipe (`consensus-issue-worktree.yaml` step3-setup-worktree)
+# carries the equivalent guidance in its worktree-manager prompt (verified by
+# static parity, since recipe-runner does not execute prompt bash).
+#
+# Helper CLI contract (defined here, TDD-first):
+#   workflow_worktree_deconflict.sh resolve <candidate_branch> <intended_worktree_path> [repo_path]
+#     stdout: exactly one line — the resolved branch (unchanged, or deconflicted)
+#     stderr: human diagnostics
+#     exit 0: a usable branch name was resolved
+#     exit 1: bad args, or all bounded retries (<=5) exhausted without a free name
+# Env knob:
+#   AMPLIHACK_DECONFLICT_MAX_RETRIES  upper bound on suffix retries; validated
+#                                     ^[0-9]+$ AND clamped to a hard ceiling of 5
+#                                     (override may only LOWER the bound).
+#
+# This test SHOULD FAIL before the fix lands (helper missing, YAML not wired,
+# consensus not mirrored) and MUST PASS once helper + step-04 call-site +
+# consensus mirror exist.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+RECIPES="${REPO_ROOT}/amplifier-bundle/recipes"
+TOOLS="${REPO_ROOT}/amplifier-bundle/tools"
+
+WORKTREE_YAML="${RECIPES}/workflow-worktree.yaml"
+CONSENSUS_YAML="${RECIPES}/consensus-issue-worktree.yaml"
+HELPER="${TOOLS}/workflow_worktree_deconflict.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo "  PASS[$1]: $2"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  FAIL[$1]: $2" >&2; }
+
+if [[ ! -f "${WORKTREE_YAML}" ]]; then
+    echo "HARNESS-ERROR: required recipe not found: ${WORKTREE_YAML}" >&2
+    exit 2
+fi
+if [[ ! -f "${CONSENSUS_YAML}" ]]; then
+    echo "HARNESS-ERROR: required recipe not found: ${CONSENSUS_YAML}" >&2
+    exit 2
+fi
+
+# Scratch workspace; cleaned on exit.
+TEST_TMP="$(mktemp -d)"
+cleanup() { rm -rf "${TEST_TMP}"; }
+trap cleanup EXIT
+
+# extract_step <file> <step-id>
+# Prints the contiguous block from the matching `- id: "<step-id>"` line up to
+# (but not including) the next top-level `  - id:` step marker.
+extract_step() {
+    local file="$1" step_id="$2"
+    awk -v target="${step_id}" '
+        BEGIN { inblk = 0 }
+        /^[[:space:]]*-[[:space:]]+id:[[:space:]]*"/ {
+            line = $0
+            sub(/^[[:space:]]*-[[:space:]]+id:[[:space:]]*"/, "", line)
+            sub(/".*$/, "", line)
+            if (line == target) { inblk = 1; print; next }
+            else if (inblk) { inblk = 0 }
+        }
+        inblk { print }
+    ' "${file}"
+}
+
+echo "=== Foreign-worktree branch deconfliction (concurrency-safety) ==="
+
+STEP04="$(extract_step "${WORKTREE_YAML}" "step-04-setup-worktree")"
+
+# ===========================================================================
+# Part A — Static / contract checks (helper + YAML integration + parity).
+# ===========================================================================
+
+# A1: helper exists.
+if [[ -f "${HELPER}" ]]; then
+    pass "A1-exists" "deconflict helper present at tools/workflow_worktree_deconflict.sh"
+else
+    fail "A1-exists" "missing helper: ${HELPER}"
+fi
+
+# A2: helper hardened — set -euo pipefail.
+if [[ -f "${HELPER}" ]] && grep -qE 'set -euo pipefail' "${HELPER}"; then
+    pass "A2-strict" "helper uses 'set -euo pipefail'"
+else
+    fail "A2-strict" "helper missing 'set -euo pipefail'"
+fi
+
+# A3: helper advertises the 'resolve' operation.
+if [[ -f "${HELPER}" ]] && grep -qE '\bresolve\b' "${HELPER}"; then
+    pass "A3-resolve" "helper implements the 'resolve' operation"
+else
+    fail "A3-resolve" "helper does not implement a 'resolve' operation"
+fi
+
+# A4: ownership detection parses worktrees via porcelain (never fragile scraping).
+if [[ -f "${HELPER}" ]] && grep -qE 'git worktree list --porcelain' "${HELPER}"; then
+    pass "A4-porcelain" "helper enumerates worktrees via 'git worktree list --porcelain'"
+else
+    fail "A4-porcelain" "helper does not use 'git worktree list --porcelain'"
+fi
+
+# A5: every candidate is validated with the authoritative git ref checker.
+if [[ -f "${HELPER}" ]] && grep -qE 'git check-ref-format' "${HELPER}"; then
+    pass "A5-checkref" "helper validates candidates via 'git check-ref-format'"
+else
+    fail "A5-checkref" "helper does not validate candidates via 'git check-ref-format'"
+fi
+
+# A6: HARD non-destructive invariant — the helper must contain ZERO destructive
+# commands. It renames THIS run's branch; it must never delete/reset/force the
+# foreign run's branch or worktree.
+if [[ -f "${HELPER}" ]]; then
+    if grep -qE 'git[[:space:]]+branch[[:space:]]+-[dD]' "${HELPER}" \
+       || grep -qE 'git[[:space:]]+worktree[[:space:]]+remove' "${HELPER}" \
+       || grep -qE 'reset[[:space:]]+--hard' "${HELPER}" \
+       || grep -qE 'checkout[[:space:]]+-f' "${HELPER}" \
+       || grep -qE 'push[[:space:]].*(--force|--delete|-f\b)' "${HELPER}" \
+       || grep -qE 'rm[[:space:]]+-[rRfial]*[rf]' "${HELPER}"; then
+        fail "A6-nondestructive" "helper contains a DESTRUCTIVE command (must be read-only introspection)"
+    else
+        pass "A6-nondestructive" "helper contains no destructive git/fs commands (non-destructive invariant holds)"
+    fi
+else
+    fail "A6-nondestructive" "helper missing — cannot verify non-destructive invariant"
+fi
+
+# A7: bounded retry — the helper honors AMPLIHACK_DECONFLICT_MAX_RETRIES and
+# encodes a hard ceiling of 5 (DoS bound; override may only lower it).
+if [[ -f "${HELPER}" ]] && grep -qE 'AMPLIHACK_DECONFLICT_MAX_RETRIES' "${HELPER}" \
+   && grep -qE '\b5\b' "${HELPER}"; then
+    pass "A7-bounded" "helper honors AMPLIHACK_DECONFLICT_MAX_RETRIES with a hard ceiling of 5"
+else
+    fail "A7-bounded" "helper missing bounded-retry knob / hard ceiling of 5"
+fi
+
+# A8: chosen name is provably free on ALL THREE axes — local ref, remote ref,
+# and not checked out by ANY worktree.
+if [[ -f "${HELPER}" ]] \
+   && grep -qE 'refs/heads' "${HELPER}" \
+   && grep -qE 'refs/remotes/origin' "${HELPER}"; then
+    pass "A8-freshness" "helper checks local + remote refs (freshness axes referenced)"
+else
+    fail "A8-freshness" "helper does not check both refs/heads and refs/remotes/origin"
+fi
+
+# A9: helper normalizes paths (pwd -P) so a symlinked/'..'-laden intended path
+# cannot masquerade as same-path or foreign.
+if [[ -f "${HELPER}" ]] && grep -qE 'pwd -P' "${HELPER}"; then
+    pass "A9-normalize" "helper normalizes paths via 'pwd -P' before comparison"
+else
+    fail "A9-normalize" "helper does not normalize paths via 'pwd -P'"
+fi
+
+# A10: helper shellcheck-clean (only when shellcheck is installed).
+if command -v shellcheck >/dev/null 2>&1; then
+    if [[ -f "${HELPER}" ]] && shellcheck -S warning "${HELPER}" >/dev/null 2>&1; then
+        pass "A10-shellcheck" "helper passes shellcheck -S warning"
+    else
+        fail "A10-shellcheck" "helper fails shellcheck (or is missing)"
+    fi
+else
+    echo "  SKIP[A10-shellcheck]: shellcheck not installed"
+fi
+
+# A11: step-04-setup-worktree invokes the deconflict helper.
+if [[ -z "${STEP04}" ]]; then
+    fail "A11-invoke" "could not extract step-04-setup-worktree from workflow-worktree.yaml"
+elif printf '%s\n' "${STEP04}" | grep -qE 'workflow_worktree_deconflict\.sh'; then
+    pass "A11-invoke" "step-04 invokes workflow_worktree_deconflict.sh"
+else
+    fail "A11-invoke" "step-04 does not invoke workflow_worktree_deconflict.sh"
+fi
+
+# A12: the inline call is best-effort (graceful no-op): guarded by a file-
+# existence test and/or `|| true`/`|| echo` so a missing helper never aborts.
+if printf '%s\n' "${STEP04}" | grep -E 'workflow_worktree_deconflict\.sh' \
+       | grep -qE '(\|\||-f )'; then
+    pass "A12-best-effort" "step-04 deconflict call is best-effort (guarded / '|| ...')"
+else
+    fail "A12-best-effort" "step-04 deconflict call is not guarded best-effort"
+fi
+
+# A13: CALL-SITE ORDERING — the deconflict invocation must run BEFORE the
+# idempotency state machine (BRANCH_EXISTS probe) and BEFORE the State-2
+# `git branch -D`. This is the core of the fix: detect foreign ownership before
+# any destructive/reuse decision.
+if [[ -n "${STEP04}" ]]; then
+    DECON_LINE="$(printf '%s\n' "${STEP04}" | grep -nE 'workflow_worktree_deconflict\.sh' | head -1 | cut -d: -f1 || true)"
+    BEXISTS_LINE="$(printf '%s\n' "${STEP04}" | grep -nE '^[[:space:]]*BRANCH_EXISTS=' | head -1 | cut -d: -f1 || true)"
+    BRANCHD_LINE="$(printf '%s\n' "${STEP04}" | grep -nE 'git branch -D' | head -1 | cut -d: -f1 || true)"
+    if [[ -n "${DECON_LINE}" && -n "${BEXISTS_LINE}" && "${DECON_LINE}" -lt "${BEXISTS_LINE}" ]] \
+       && { [[ -z "${BRANCHD_LINE}" ]] || [[ "${DECON_LINE}" -lt "${BRANCHD_LINE}" ]]; }; then
+        pass "A13-ordering" "deconflict runs before BRANCH_EXISTS probe and State-2 'git branch -D'"
+    else
+        fail "A13-ordering" "deconflict is not positioned before the state machine (decon=${DECON_LINE:-none}, branch_exists=${BEXISTS_LINE:-none}, branch-D=${BRANCHD_LINE:-none})"
+    fi
+else
+    fail "A13-ordering" "step-04 not extracted — cannot verify call-site ordering"
+fi
+
+# A14: deconflicted name reassigns BRANCH_NAME so it flows into the JSON output.
+if printf '%s\n' "${STEP04}" | grep -qE 'BRANCH_NAME=.*RESOLVED|BRANCH_NAME="\$RESOLVED_BRANCH"|RESOLVED_BRANCH'; then
+    pass "A14-surfaced" "step-04 reassigns BRANCH_NAME from the resolved value (surfaces in JSON output)"
+else
+    fail "A14-surfaced" "step-04 does not reassign BRANCH_NAME from the deconflict result"
+fi
+
+# A15: HARD CONSTRAINT — workflow-worktree.yaml strictly < 400 lines (brick budget).
+YAML_LINES=$(wc -l < "${WORKTREE_YAML}")
+if [[ "${YAML_LINES}" -lt 400 ]]; then
+    pass "A15-400" "workflow-worktree.yaml is ${YAML_LINES} lines (< 400)"
+else
+    fail "A15-400" "workflow-worktree.yaml is ${YAML_LINES} lines (>= 400 — brick limit breached)"
+fi
+
+# A16: CONSENSUS PARITY — the consensus recipe's step3-setup-worktree prompt
+# carries the equivalent deconfliction guidance (mirror in the same commit).
+STEP3="$(extract_step "${CONSENSUS_YAML}" "step3-setup-worktree")"
+if [[ -z "${STEP3}" ]]; then
+    fail "A16-parity" "could not extract step3-setup-worktree from consensus-issue-worktree.yaml"
+elif printf '%s\n' "${STEP3}" | grep -qE 'workflow_worktree_deconflict\.sh' \
+     && printf '%s\n' "${STEP3}" | grep -qiE 'foreign|deconflict'; then
+    pass "A16-parity" "consensus step3 prompt mirrors the deconfliction guidance"
+else
+    fail "A16-parity" "consensus step3 prompt is missing the deconfliction mirror"
+fi
+
+# ===========================================================================
+# Part B — Behavioral checks against real temp git repos.
+# These exercise the helper's runtime contract. They require the helper to
+# exist; before the fix lands they fail at the guard below (expected, TDD).
+# ===========================================================================
+
+# build_repo <name> -> echoes path to a fresh repo with origin + main commit.
+build_repo() {
+    local name="$1"
+    local remote="${TEST_TMP}/${name}-remote.git"
+    local work="${TEST_TMP}/${name}"
+    git init --quiet --bare "${remote}"
+    git clone --quiet "${remote}" "${work}" 2>/dev/null
+    git -C "${work}" config user.email "t@example.com"
+    git -C "${work}" config user.name "Test"
+    git -C "${work}" checkout -q -b main 2>/dev/null || git -C "${work}" checkout -q main
+    echo "base" > "${work}/README.md"
+    git -C "${work}" add README.md
+    git -C "${work}" commit -q -m "base commit"
+    git -C "${work}" push -q -u origin main 2>/dev/null || true
+    git -C "${work}" remote set-head origin main 2>/dev/null || true
+    printf '%s\n' "${work}"
+}
+
+# resolve <candidate> <intended_path> <repo> -> prints stdout (branch) only.
+resolve() {
+    bash "${HELPER}" resolve "$1" "$2" "$3" 2>/dev/null
+}
+
+# branch_checked_out_anywhere <repo> <branch> -> 0 if some worktree owns it.
+branch_checked_out_anywhere() {
+    git -C "$1" worktree list --porcelain \
+        | grep -qxF "branch refs/heads/$2"
+}
+
+if [[ ! -f "${HELPER}" ]]; then
+    echo ""
+    echo "--- Scenario checks SKIPPED: helper not yet implemented (TDD red) ---"
+    for s in B1-badargs B2-absent B3-same-path B4-normalized-same B5-leftover-branch \
+             B6-foreign-new B7-foreign-nondestructive B8-provably-free B9-converges; do
+        fail "${s}" "scenario requires ${HELPER} (not implemented)"
+    done
+else
+    # --- B1: bad args → exit 1 (contract). ---
+    REPO="$(build_repo b1)"
+    if bash "${HELPER}" resolve "feat/x" >/dev/null 2>&1; then
+        fail "B1-badargs" "missing intended-path arg should exit non-zero"
+    else
+        pass "B1-badargs" "bad/insufficient args exit non-zero"
+    fi
+
+    # --- B2: branch ABSENT → candidate returned unchanged, exit 0. ---
+    REPO="$(build_repo b2)"
+    OUT="$(resolve "feat/issue-1-brand-new" "${REPO}/worktrees/feat/issue-1-brand-new" "${REPO}")"
+    if [[ "${OUT}" == "feat/issue-1-brand-new" ]]; then
+        pass "B2-absent" "absent branch returns candidate unchanged"
+    else
+        fail "B2-absent" "absent branch should return unchanged, got '${OUT}'"
+    fi
+
+    # --- B3: SAME-PATH resume → unchanged (State-1 reuse preserved). ---
+    REPO="$(build_repo b3)"
+    git -C "${REPO}" worktree add -q "${REPO}/worktrees/feat/mine" -b feat/mine origin/main
+    OUT="$(resolve "feat/mine" "${REPO}/worktrees/feat/mine" "${REPO}")"
+    if [[ "${OUT}" == "feat/mine" ]]; then
+        pass "B3-same-path" "branch checked out at intended path is same-path resume (unchanged)"
+    else
+        fail "B3-same-path" "same-path resume should return unchanged, got '${OUT}'"
+    fi
+
+    # --- B4: NORMALIZED same-path — non-canonical intended path (./, ..) that
+    #         resolves to the checkout path is still same-path (unchanged). ---
+    REPO="$(build_repo b4)"
+    git -C "${REPO}" worktree add -q "${REPO}/worktrees/feat/norm" -b feat/norm origin/main
+    OUT="$(resolve "feat/norm" "${REPO}/worktrees/feat/./norm" "${REPO}")"
+    if [[ "${OUT}" == "feat/norm" ]]; then
+        pass "B4-normalized-same" "non-canonical intended path normalizes to same-path (unchanged)"
+    else
+        fail "B4-normalized-same" "normalized same-path should return unchanged, got '${OUT}'"
+    fi
+
+    # --- B5: branch EXISTS but NO worktree owns it → unchanged (normal State-2;
+    #         this recipe may safely manage its own leftover branch). ---
+    REPO="$(build_repo b5)"
+    git -C "${REPO}" branch feat/leftover origin/main
+    OUT="$(resolve "feat/leftover" "${REPO}/worktrees/feat/leftover" "${REPO}")"
+    if [[ "${OUT}" == "feat/leftover" ]]; then
+        pass "B5-leftover-branch" "branch with no owning worktree returns unchanged (State-2 preserved)"
+    else
+        fail "B5-leftover-branch" "unowned leftover branch should return unchanged, got '${OUT}'"
+    fi
+
+    # --- B6: FOREIGN ownership → a NEW, distinct, valid branch is returned. ---
+    #     Reproduce the exact bug: BRANCH is checked out by a FOREIGN worktree
+    #     at a DIFFERENT path than this recipe's intended path, and the foreign
+    #     branch is AHEAD of base (the State-2 `git branch -D` trigger).
+    REPO="$(build_repo b6)"
+    FOREIGN_WT="${REPO}/worktrees/foreign-holder"
+    INTENDED="${REPO}/worktrees/feat/issue-200-fix-bug"
+    git -C "${REPO}" worktree add -q "${FOREIGN_WT}" -b feat/issue-200-fix-bug origin/main
+    echo "foreign work" > "${FOREIGN_WT}/w.txt"
+    git -C "${FOREIGN_WT}" add w.txt
+    git -C "${FOREIGN_WT}" commit -q -m "foreign unique commit"
+    FOREIGN_SHA="$(git -C "${FOREIGN_WT}" rev-parse HEAD)"
+    NEW_BRANCH="$(resolve "feat/issue-200-fix-bug" "${INTENDED}" "${REPO}")"
+    if [[ -n "${NEW_BRANCH}" && "${NEW_BRANCH}" != "feat/issue-200-fix-bug" ]] \
+       && git -C "${REPO}" check-ref-format --branch "${NEW_BRANCH}" >/dev/null 2>&1; then
+        pass "B6-foreign-new" "foreign-owned branch deconflicts to a NEW valid branch ('${NEW_BRANCH}')"
+    else
+        fail "B6-foreign-new" "foreign ownership should yield a new valid branch, got '${NEW_BRANCH}'"
+    fi
+
+    # --- B7: NON-DESTRUCTIVE — resolving a foreign branch must leave the foreign
+    #         branch, its worktree, and its unique commit fully intact. The bug's
+    #         `git branch -D` on the foreign branch must NEVER happen. ---
+    if [[ -d "${FOREIGN_WT}" ]] \
+       && [[ -n "$(git -C "${REPO}" branch --list feat/issue-200-fix-bug)" ]] \
+       && git -C "${REPO}" cat-file -e "${FOREIGN_SHA}^{commit}" 2>/dev/null \
+       && branch_checked_out_anywhere "${REPO}" "feat/issue-200-fix-bug"; then
+        pass "B7-foreign-nondestructive" "foreign branch + worktree + commit preserved (no 'git branch -D')"
+    else
+        fail "B7-foreign-nondestructive" "foreign branch/worktree/commit was disturbed by resolve (DATA LOSS)"
+    fi
+
+    # --- B8: the deconflicted name is PROVABLY FREE on all three axes. ---
+    if [[ -n "${NEW_BRANCH}" && "${NEW_BRANCH}" != "feat/issue-200-fix-bug" ]]; then
+        free=yes
+        git -C "${REPO}" show-ref --verify --quiet "refs/heads/${NEW_BRANCH}" && free=no
+        git -C "${REPO}" show-ref --verify --quiet "refs/remotes/origin/${NEW_BRANCH}" && free=no
+        branch_checked_out_anywhere "${REPO}" "${NEW_BRANCH}" && free=no
+        if [[ "${free}" == "yes" ]]; then
+            pass "B8-provably-free" "deconflicted name has no local ref, no remote ref, no worktree"
+        else
+            fail "B8-provably-free" "deconflicted name '${NEW_BRANCH}' is not free on some axis"
+        fi
+    else
+        fail "B8-provably-free" "no deconflicted name produced to verify freshness"
+    fi
+
+    # --- B9: CONVERGENCE — the recipe's normal create path works on the new
+    #         name. Recompute WORKTREE_PATH and `git worktree add` at it, exactly
+    #         as step-04 would. It must succeed with NO collision and NO need to
+    #         touch the foreign branch. ---
+    if [[ -n "${NEW_BRANCH}" && "${NEW_BRANCH}" != "feat/issue-200-fix-bug" ]]; then
+        NEW_PATH="${REPO}/worktrees/${NEW_BRANCH}"
+        if git -C "${REPO}" worktree add -q "${NEW_PATH}" -b "${NEW_BRANCH}" origin/main 2>/dev/null \
+           && [[ -d "${NEW_PATH}" ]] \
+           && [[ -d "${FOREIGN_WT}" ]]; then
+            pass "B9-converges" "create path on deconflicted branch succeeds; foreign run untouched"
+        else
+            fail "B9-converges" "create path on deconflicted branch failed (no convergence)"
+        fi
+    else
+        fail "B9-converges" "no deconflicted name produced to exercise the create path"
+    fi
+fi
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo ""
+echo "--- Summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ---"
+
+if [[ ${FAIL_COUNT} -gt 0 ]]; then
+    exit 1
+fi
+
+echo "PASS: foreign-worktree deconfliction is non-destructive, bounded, and concurrency-safe."
+exit 0

--- a/amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh
+++ b/amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh
@@ -253,6 +253,30 @@ else
     fail "A16-parity" "consensus step3 prompt is missing the deconfliction mirror"
 fi
 
+# A17: FAIL-LOUD CALL-SITE (review S1+S2) — the deconflict call must branch on
+# the helper's exit code and abort ('deconfliction failed' + exit 1) instead of
+# silently falling back to the CONFLICTING name via '2>/dev/null || echo "$BRANCH_NAME"'.
+A17_OK=1
+if ! printf '%s\n' "${STEP04}" | grep -qE 'deconfliction failed'; then
+    A17_OK=0
+fi
+if printf '%s\n' "${STEP04}" | grep -qE '\|\|[[:space:]]*echo[[:space:]]+"\$\{?BRANCH_NAME\}?"'; then
+    A17_OK=0
+fi
+if [[ -n "${STEP3}" ]]; then
+    if ! printf '%s\n' "${STEP3}" | grep -qE 'deconfliction failed'; then
+        A17_OK=0
+    fi
+    if printf '%s\n' "${STEP3}" | grep -qE '\|\|[[:space:]]*echo[[:space:]]+"\$\{?BRANCH_NAME\}?"'; then
+        A17_OK=0
+    fi
+fi
+if [[ "${A17_OK}" -eq 1 ]]; then
+    pass "A17-fail-loud" "both call-sites branch on helper exit code and fail loud (no silent fallback to the conflicting name)"
+else
+    fail "A17-fail-loud" "a call-site still silences the helper and/or falls back to the conflicting BRANCH_NAME on failure"
+fi
+
 # ===========================================================================
 # Part B — Behavioral checks against real temp git repos.
 # These exercise the helper's runtime contract. They require the helper to
@@ -292,7 +316,8 @@ if [[ ! -f "${HELPER}" ]]; then
     echo ""
     echo "--- Scenario checks SKIPPED: helper not yet implemented (TDD red) ---"
     for s in B1-badargs B2-absent B3-same-path B4-normalized-same B5-leftover-branch \
-             B6-foreign-new B7-foreign-nondestructive B8-provably-free B9-converges; do
+             B6-foreign-new B7-foreign-nondestructive B8-provably-free B9-converges \
+             B10-length-cap; do
         fail "${s}" "scenario requires ${HELPER} (not implemented)"
     done
 else
@@ -407,6 +432,23 @@ else
         fi
     else
         fail "B9-converges" "no deconflicted name produced to exercise the create path"
+    fi
+
+    # --- B10: LENGTH CAP on the rename path (review S4). A very long foreign
+    #          candidate must deconflict to a name bounded by DECONFLICT_MAX_BRANCH_LEN
+    #          (80) while staying valid and distinct — the suffix is preserved, the
+    #          base is truncated. ---
+    REPO="$(build_repo b10)"
+    LONG_SLUG="$(printf 'a%.0s' $(seq 1 70))"
+    LONG_BRANCH="feat/issue-200-${LONG_SLUG}"
+    git -C "${REPO}" worktree add -q "${REPO}/worktrees/foreign-long" -b "${LONG_BRANCH}" origin/main
+    LONG_OUT="$(resolve "${LONG_BRANCH}" "${REPO}/worktrees/feat/issue-200-mine" "${REPO}")"
+    if [[ -n "${LONG_OUT}" && "${LONG_OUT}" != "${LONG_BRANCH}" ]] \
+       && [[ "${#LONG_OUT}" -le 80 ]] \
+       && git -C "${REPO}" check-ref-format --branch "${LONG_OUT}" >/dev/null 2>&1; then
+        pass "B10-length-cap" "long foreign candidate deconflicts to a bounded (<=80) valid name (len=${#LONG_OUT})"
+    else
+        fail "B10-length-cap" "rename path did not cap length or produced invalid name: '${LONG_OUT}' (len=${#LONG_OUT})"
     fi
 fi
 

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -290,6 +290,20 @@ steps:
         fi
       fi
       WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+      # --- Foreign-worktree deconfliction (concurrency-safety) ---
+      # If BRANCH_NAME is held by a FOREIGN worktree at a DIFFERENT path, the helper
+      # returns a NEW provably-free name; else unchanged (State-1/2 kept). #829/#840.
+      DECONFLICT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+      [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+      [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+      if [ -f "$DECONFLICT_HELPER" ]; then
+        RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_PATH" "$REPO_PATH" 2>/dev/null || echo "$BRANCH_NAME")"
+        if [ -n "$RESOLVED_BRANCH" ] && [ "$RESOLVED_BRANCH" != "$BRANCH_NAME" ]; then
+          echo "INFO: branch '${BRANCH_NAME}' is owned by a foreign worktree — deconflicting to '${RESOLVED_BRANCH}'." >&2
+          BRANCH_NAME="$RESOLVED_BRANCH"
+          WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+        fi
+      fi
 
       echo "Branch: ${BRANCH_NAME}" >&2
       echo "Worktree: ${WORKTREE_PATH}" >&2

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -263,11 +263,8 @@ steps:
       BASE_REF="$(resolve_base_ref)"
       BASE_BRANCH="${BASE_REF#origin/}"
 
-      # NOTE: This slug pipeline is duplicated in consensus-workflow.yaml step3-setup-worktree
-      # with a 30-char limit instead of 50. If you update this pipeline (e.g. security patch),
-      # update consensus-workflow.yaml in the same commit. See Issue #2952 for context.
-      #
-      # Generate branch name from task description.
+      # NOTE: slug pipeline mirrored in consensus-issue-worktree.yaml step3 (30-char cap
+      # vs 50); update both in the same commit on security patches. See Issue #2952.
       # FIX (#469/#311): Use env var — safe against injection and word-splitting.
       # Sanitization pipeline (tr -cd 'a-z0-9-') strips all shell metacharacters.
       TASK_DESC="$TASK_DESCRIPTION"
@@ -276,10 +273,8 @@ steps:
       # git check-ref-format accepts as valid but is undesirable. Catch it explicitly first.
       if [ -z "$TASK_SLUG" ]; then
         echo "WARNING: task_description produced an empty slug — falling back to task-unnamed" >&2
-        # FIX (issue #3023 / BL-002 fallback hardening): Use hardcoded 'feat/' prefix rather
-        # than $BRANCH_PREFIX to prevent injection via an invalid or malicious branch_prefix
-        # value (e.g. '; rm -rf /' or '../../etc'). The prefix is not user-configurable in
-        # the fallback path; configurable prefix only applies when a valid slug exists.
+        # FIX (#3023/BL-002): hardcode 'feat/' (not $BRANCH_PREFIX) so an invalid or
+        # malicious branch_prefix (e.g. '; rm -rf /', '../../etc') can't inject via fallback.
         BRANCH_NAME="feat/task-unnamed-$(date +%s)"
       else
         BRANCH_NAME="${BRANCH_PREFIX}/issue-${ISSUE_NUMBER}-${TASK_SLUG}"
@@ -290,14 +285,18 @@ steps:
         fi
       fi
       WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
-      # --- Foreign-worktree deconfliction (concurrency-safety) ---
-      # If BRANCH_NAME is held by a FOREIGN worktree at a DIFFERENT path, the helper
-      # returns a NEW provably-free name; else unchanged (State-1/2 kept). #829/#840.
+      # --- Foreign-worktree deconfliction (#829/#840): if BRANCH_NAME is held by a
+      # FOREIGN worktree, get a NEW free name (else unchanged); missing helper = no-op.
       DECONFLICT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
       [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
       [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
       if [ -f "$DECONFLICT_HELPER" ]; then
-        RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_PATH" "$REPO_PATH" 2>/dev/null || echo "$BRANCH_NAME")"
+        # Fail loud on non-zero exit (retries exhausted / misconfig); let stderr surface.
+        # Never reuse the conflicting name — that would re-abort at `git branch -D`. #200 S1/S2.
+        if ! RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_PATH" "$REPO_PATH")"; then
+          echo "ERROR: worktree branch deconfliction failed for '${BRANCH_NAME}' (retries exhausted or helper misconfig; see stderr). Aborting to avoid clobbering a concurrent foreign worktree." >&2
+          exit 1
+        fi
         if [ -n "$RESOLVED_BRANCH" ] && [ "$RESOLVED_BRANCH" != "$BRANCH_NAME" ]; then
           echo "INFO: branch '${BRANCH_NAME}' is owned by a foreign worktree — deconflicting to '${RESOLVED_BRANCH}'." >&2
           BRANCH_NAME="$RESOLVED_BRANCH"

--- a/amplifier-bundle/tools/workflow_worktree_deconflict.md
+++ b/amplifier-bundle/tools/workflow_worktree_deconflict.md
@@ -1,0 +1,354 @@
+# Worktree Branch Deconfliction
+
+**Non-destructive helper that keeps two concurrently-running recipes from
+fighting over the same branch name.**
+
+`workflow_worktree_deconflict.sh` is a self-contained shell brick used by the
+worktree/branch setup steps of `workflow-worktree.yaml` (step
+`step-04-setup-worktree`) and mirrored as guidance in
+`consensus-issue-worktree.yaml` (step `step3-setup-worktree`). It inspects the
+live `git worktree` topology and, when the branch a recipe wants is already
+checked out by a **different** recipe's worktree, hands back a fresh, distinct,
+provably-free branch name instead of destroying the other recipe's work.
+
+- [Why this exists](#why-this-exists)
+- [What it guarantees](#what-it-guarantees)
+- [Command-line usage](#command-line-usage)
+- [Contract / API](#contract--api)
+- [Ownership classification](#ownership-classification)
+- [Deconfliction algorithm](#deconfliction-algorithm)
+- [Configuration](#configuration)
+- [Integration in the recipes](#integration-in-the-recipes)
+- [Examples](#examples)
+- [Preserved behaviors](#preserved-behaviors)
+- [Security model](#security-model)
+- [Testing](#testing)
+
+---
+
+## Why this exists
+
+`smart-orchestrator` derives a branch name deterministically from the target
+issue number and a slug of the task description
+(`feat/issue-<N>-<slug>`). When two orchestrator runs start from the **same
+issue number and the same task-description file**, they derive the **identical
+branch slug**. Each run computes its own worktree path
+(`<repo>/worktrees/<branch>`).
+
+Previously, the setup step's idempotency state machine assumed that a branch it
+found was one of its *own* prior runs. In the "State-2" path (branch exists,
+worktree missing at *this* recipe's path, and the branch has commits ahead of
+base) it ran:
+
+```bash
+git branch -D "${BRANCH_NAME}"
+```
+
+If that branch was, at that very moment, checked out by a **foreign** worktree
+belonging to a concurrently-running recipe at a *different* path, git refused:
+
+```
+error: cannot delete branch 'feat/issue-200-fix-bug' used by worktree at
+'/repo/worktrees/feat/issue-200-fix-bug'
+```
+
+...and the whole recipe aborted. The existing worktree-existence probe only
+matched *this* recipe's exact path via `grep -Fx`, so a foreign worktree owning
+the branch elsewhere was invisible to the state machine.
+
+A foreign-owned branch actually breaks the State-2 path at **two** points, both
+resolved by renaming this run's branch upstream of the state machine:
+
+- when the branch is **ahead of base**, `git branch -D` fails as shown above; and
+- even when the branch is **clean** (no commits ahead), the fallback
+  `git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}"` (attach without `-b`)
+  fails with `fatal: '<branch>' is already used by worktree at '<foreign path>'`,
+  because git will not check out one branch in two worktrees.
+
+This helper detects that foreign ownership **before** any destructive or reuse
+decision is made, and resolves it by *renaming this run's branch* rather than
+by destroying the other run's branch or worktree.
+
+## What it guarantees
+
+- **Never destructive to foreign work.** The helper contains **zero**
+  destructive commands — no `git branch -D`, no `git worktree remove`, no
+  `rm -rf`, no `reset --hard`, no `checkout -f`. It only reads git state and
+  prints a branch name.
+- **Foreign-owned branches are left untouched.** When the desired branch is
+  checked out by any worktree at a path other than the intended one, the
+  original branch and its worktree are neither deleted nor reused.
+- **The chosen name is provably free.** Every returned name passes
+  `git check-ref-format --branch`, has **no** local ref (`refs/heads/*`), **no**
+  matching remote ref (`refs/remotes/origin/*`), and is **not** checked out by
+  **any** worktree.
+- **Bounded and loud.** At most `5` candidate suffixes are tried (a hard ceiling
+  that `AMPLIHACK_DECONFLICT_MAX_RETRIES` may only *lower*, never raise); on
+  exhaustion the helper exits non-zero with a diagnostic rather than looping or
+  silently degrading.
+- **Same-path resume is preserved.** If the branch is checked out at *this*
+  recipe's own intended path, that is a genuine resume — the helper returns the
+  branch unchanged so the recipe's State-1 reuse path (`created=false`) still
+  runs.
+
+## Command-line usage
+
+```bash
+workflow_worktree_deconflict.sh resolve <candidate_branch> <intended_worktree_path> [repo_path]
+```
+
+| Argument                  | Meaning                                                              |
+| ------------------------- | ------------------------------------------------------------------- |
+| `candidate_branch`        | The branch name the recipe derived (e.g. `feat/issue-200-fix-bug`). |
+| `intended_worktree_path`  | The path this recipe intends to attach the worktree to.             |
+| `repo_path` (optional)    | Repository root. Defaults to the current working directory.         |
+
+`stdout` carries **only** the resolved branch name (one line, no
+decoration) so it is safe to capture with command substitution. All human
+diagnostics go to `stderr`.
+
+```bash
+NEW_BRANCH="$(bash workflow_worktree_deconflict.sh resolve \
+  "feat/issue-200-fix-bug" \
+  "/repo/worktrees/feat/issue-200-fix-bug")"
+```
+
+### Exit codes
+
+| Code | Meaning                                                                            |
+| ---- | ---------------------------------------------------------------------------------- |
+| `0`  | A usable branch name was resolved and printed to stdout.                            |
+| `1`  | Bad arguments, or all bounded retries (`≤ 5`) were exhausted without a free name.   |
+
+## Contract / API
+
+The helper exposes a single logical operation, `resolve`, with this contract:
+
+**Input:** a candidate branch, the intended worktree path, and (optionally) the
+repo root.
+
+**Output (stdout):** exactly one branch name that is guaranteed to satisfy all
+freshness invariants at the moment of return. It is either:
+
+1. the **unchanged** candidate — when the branch is absent, or is checked out at
+   the intended path (genuine same-path resume), or exists but is **not**
+   checked out by any worktree (a normal State-2 branch this recipe may safely
+   manage); or
+2. a **new** deconflicted name — when the candidate is foreign-owned.
+
+**Side effects:** none. The helper only reads git state.
+
+The caller is responsible for recomputing `WORKTREE_PATH` from the returned
+branch and proceeding through its normal create path.
+
+## Ownership classification
+
+The helper parses `git worktree list --porcelain` (the stable, machine-readable
+form — never the human `git worktree list` output) and pairs each
+`worktree <path>` record with its `branch refs/heads/<name>` record. Both the
+live worktree path and the intended path are normalized (symlinks and `..`
+resolved, `pwd -P`-style, matching the existing issue #858 caller-checkout
+logic) before comparison.
+
+| Situation                                                        | Classification | Action                                  |
+| ---------------------------------------------------------------- | -------------- | --------------------------------------- |
+| Branch is checked out by no worktree                             | **candidate**  | return unchanged                        |
+| Branch is checked out at the **intended** path (after normalize) | **same-path**  | return unchanged (State-1 resume)       |
+| Branch is checked out at a **different** normalized path         | **foreign**    | deconflict → return a new distinct name |
+
+## Deconfliction algorithm
+
+When a branch is classified **foreign**, the helper generates a new name with a
+bounded, deterministic-enough loop:
+
+1. Build a short unique suffix from `date +%s` and the process id, then sanitize
+   it through `tr -cd 'a-z0-9-'` so it can never introduce shell or ref
+   metacharacters.
+2. Form a candidate: `<candidate_branch>-<suffix>`.
+3. Validate the candidate with `git check-ref-format --branch`.
+4. Reject the candidate unless it is **free** on every axis:
+   - no `refs/heads/<name>` (local branch),
+   - no `refs/remotes/origin/<name>` (remote branch),
+   - not checked out by **any** worktree.
+5. On the first candidate that passes all checks, print it to stdout and exit
+   `0`.
+6. Repeat up to the configured bound (default and hard ceiling **5**; see
+   [Configuration](#configuration)). If every attempt is exhausted, print a
+   diagnostic to stderr and exit `1` (fail loud — never loop unbounded, never
+   fall back to a colliding name).
+
+Because every pass re-validates freshness, the astronomically-rare case of two
+runs generating the same suffix in the same second is caught on the next
+iteration.
+
+## Configuration
+
+The helper is intentionally low-configuration. Its behavior is governed by a
+single optional environment variable:
+
+| Variable                            | Purpose                                             | Default |
+| ----------------------------------- | --------------------------------------------------- | ------- |
+| `AMPLIHACK_DECONFLICT_MAX_RETRIES`  | Upper bound on suffix retries. Validated `^[0-9]+$` **and clamped to a hard ceiling of `5`** so the override can only *lower* the bound, never weaken the DoS guarantee. Any invalid value falls back to the default. | `5`     |
+
+Resolution of the helper path in the recipe follows the same **best-effort
+ladder** modeled on `workflow_worktree_sweep.sh` (issue #829/#840 precedent). As
+wired in `workflow-worktree.yaml`, the call site probes, in order,
+`$AMPLIHACK_HOME`, `$REPO_PATH`, and the current directory for
+`amplifier-bundle/tools/workflow_worktree_deconflict.sh` (see the snippet under
+[Integration in the recipes](#integration-in-the-recipes)). If the helper is not
+found the call site is a graceful no-op guarded by `-f` and `|| true`, and the
+recipe proceeds with its legacy state machine (degraded but never aborting).
+
+## Integration in the recipes
+
+### `workflow-worktree.yaml` — executable path (primary fix)
+
+The call site sits immediately after `WORKTREE_PATH` is computed
+(~L292) and **before** the idempotency state machine's
+`BRANCH_EXISTS`/`WORKTREE_EXISTS` probes and the State-2 `git branch -D`
+(~L308–334):
+
+```bash
+# --- Foreign-worktree deconfliction (concurrency-safety) ---
+# Before the idempotency state machine touches this branch, ask the helper
+# whether the branch is owned by a FOREIGN worktree at a different path. If so
+# it returns a NEW distinct branch name; otherwise it returns the candidate
+# unchanged (preserving same-path State-1 resume). Best-effort: a missing
+# helper is a graceful no-op (#829/#840 precedent).
+DECONFLICT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+[ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+[ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
+if [ -f "$DECONFLICT_HELPER" ]; then
+  RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_PATH" "$REPO_PATH" 2>/dev/null || echo "$BRANCH_NAME")"
+  if [ -n "$RESOLVED_BRANCH" ] && [ "$RESOLVED_BRANCH" != "$BRANCH_NAME" ]; then
+    echo "INFO: branch '${BRANCH_NAME}' is owned by a foreign worktree — deconflicting to '${RESOLVED_BRANCH}'." >&2
+    BRANCH_NAME="$RESOLVED_BRANCH"
+    WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
+  fi
+fi
+```
+
+Because `BRANCH_NAME` is reassigned before the state machine runs and before the
+JSON is printed, the final (possibly deconflicted) name flows automatically into
+the step's structured output:
+
+```json
+{
+  "worktree_path": "/repo/worktrees/feat/issue-200-fix-bug-9f3c1a2b",
+  "branch_name": "feat/issue-200-fix-bug-9f3c1a2b",
+  "base_ref": "origin/main",
+  "base_branch": "main",
+  "runtime_root": "/tmp/amplihack-runtime/feat/issue-200-fix-bug-9f3c1a2b",
+  "created": true
+}
+```
+
+Downstream steps (PR creation, runtime-artifact laddering, etc.) consume
+`branch_name` from this object, so they target the deconflicted branch with no
+further changes.
+
+### `consensus-issue-worktree.yaml` — mirror (guidance)
+
+The consensus setup step is an `agent:` step (`amplihack:worktree-manager`)
+whose bash lives inside a natural-language `prompt:` block. The equivalent
+deconfliction guidance and helper-invocation snippet are inserted into that
+prompt **before** its own `git branch -D` (~L286). This mirror is verified by a
+**static parity assertion** (grep-based) rather than a behavioral test, because
+the recipe-runner does not execute prompt bash directly.
+
+## Examples
+
+### Two concurrent runs, same slug
+
+```console
+$ # Run A already holds feat/issue-200-fix-bug at /repo/worktrees/feat/issue-200-fix-bug
+$ bash workflow_worktree_deconflict.sh resolve \
+    feat/issue-200-fix-bug /repo-B/worktrees/feat/issue-200-fix-bug /repo-B
+INFO: branch 'feat/issue-200-fix-bug' is owned by a foreign worktree at
+      /repo/worktrees/feat/issue-200-fix-bug (intended: /repo-B/worktrees/...) — deconflicting.
+feat/issue-200-fix-bug-9f3c1a2b
+```
+
+Run B proceeds on `feat/issue-200-fix-bug-9f3c1a2b`; Run A is untouched and never
+sees `git branch -D`.
+
+### Genuine same-path resume (no rename)
+
+```console
+$ # This recipe's own worktree already holds the branch at the intended path
+$ bash workflow_worktree_deconflict.sh resolve \
+    feat/issue-200-fix-bug /repo/worktrees/feat/issue-200-fix-bug /repo
+feat/issue-200-fix-bug
+```
+
+Unchanged output → the recipe's State-1 reuse path runs and emits
+`created=false`.
+
+### Branch exists but no worktree owns it (normal State-2)
+
+```console
+$ bash workflow_worktree_deconflict.sh resolve \
+    feat/issue-200-fix-bug /repo/worktrees/feat/issue-200-fix-bug /repo
+feat/issue-200-fix-bug
+```
+
+Unchanged output → the recipe safely manages its own leftover branch exactly as
+before.
+
+## Preserved behaviors
+
+The deconfliction gate is purely additive. Every existing behavior remains
+intact:
+
+- **State-1 same-path resume** — reuse with `created=false`.
+- **Issue #200 dirty-branch reset** — a dirty/ahead branch owned by *this*
+  recipe is still reset to base.
+- **Issue #342 `existing_branch` / `PR_NUMBER` targeting** — explicit
+  branch/PR targeting is honored.
+- **Issue #858 caller-checkout refusal** — refusing to hijack a branch the
+  caller has checked out.
+- **Issue #3023 empty-slug hardened fallback** — `feat/task-unnamed-<ts>`.
+- **The sanitized slug pipeline** — `tr -cd 'a-z0-9-'`, `git check-ref-format`,
+  and the hardcoded `feat/` fallback prefix.
+
+## Security model
+
+- **Command injection:** all expansions are quoted; there is no `eval` or
+  backtick re-execution; porcelain output is parsed as data via `awk`; and every
+  candidate must clear `git check-ref-format --branch` before use.
+- **Non-destructive invariant (hard):** the helper contains no branch/worktree
+  deletion, no `rm`, no `reset --hard`, and no `checkout -f`. This is enforced
+  by a static test assertion.
+- **Path spoofing / traversal:** both the intended and live worktree paths are
+  `pwd -P`-normalized (symlinks and `..` resolved) before equality comparison,
+  so a symlinked path cannot masquerade as same-path.
+- **Denial of service:** retries are bounded (`≤ 5`) and the helper fails loud
+  on exhaustion — it never loops unbounded.
+- **No network / auth / secret surface:** read-only local git introspection
+  only; no fetch/push/pull and no credential handling.
+- **Data minimization:** stdout carries the resolved branch name only;
+  worktree-list detail stays on stderr.
+- The helper is **shellcheck-gated in CI** to catch unquoted-expansion and
+  injection classes automatically.
+
+## Testing
+
+Behavioral and static coverage lives in
+`amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh`, wired as a
+named step in `.github/workflows/ci.yml` alongside the other per-recipe tests
+(and a shellcheck step for the helper). It follows the issue #840 harness
+template (`set -euo pipefail`, `extract_step()` awk, `mktemp -d` fixtures,
+`trap cleanup EXIT`, pass/fail counters).
+
+It asserts:
+
+1. **Foreign ownership → new branch.** With a foreign worktree holding
+   `BRANCH_NAME` at a different path, the step selects a **new**, valid branch,
+   succeeds, and **never** calls `git branch -D` on the foreign branch.
+2. **Same-path resume still reuses.** A genuine same-path worktree yields
+   `created=false` and no new branch.
+3. **Consensus parity.** The `consensus-issue-worktree.yaml` prompt carries the
+   equivalent deconfliction guidance.
+4. **Static invariants.** Non-destructive command absence, porcelain +
+   `check-ref-format` usage, bounded-retry, call-site ordering before the state
+   machine, and the `< 400`-line budget on `workflow-worktree.yaml`.

--- a/amplifier-bundle/tools/workflow_worktree_deconflict.md
+++ b/amplifier-bundle/tools/workflow_worktree_deconflict.md
@@ -56,14 +56,14 @@ error: cannot delete branch 'feat/issue-200-fix-bug' used by worktree at
 matched *this* recipe's exact path via `grep -Fx`, so a foreign worktree owning
 the branch elsewhere was invisible to the state machine.
 
-A foreign-owned branch actually breaks the State-2 path at **two** points, both
-resolved by renaming this run's branch upstream of the state machine:
+A foreign-owned branch breaks the State-2 path at **two** points, both resolved
+by renaming this run's branch upstream of the state machine:
 
 - when the branch is **ahead of base**, `git branch -D` fails as shown above; and
-- even when the branch is **clean** (no commits ahead), the fallback
-  `git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}"` (attach without `-b`)
-  fails with `fatal: '<branch>' is already used by worktree at '<foreign path>'`,
-  because git will not check out one branch in two worktrees.
+- even when it is **clean**, the fallback `git worktree add "${WORKTREE_PATH}"
+  "${BRANCH_NAME}"` (attach without `-b`) fails with `fatal: '<branch>' is
+  already used by worktree at '<foreign path>'` — git will not check out one
+  branch in two worktrees.
 
 This helper detects that foreign ownership **before** any destructive or reuse
 decision is made, and resolves it by *renaming this run's branch* rather than
@@ -164,7 +164,10 @@ bounded, deterministic-enough loop:
 1. Build a short unique suffix from `date +%s` and the process id, then sanitize
    it through `tr -cd 'a-z0-9-'` so it can never introduce shell or ref
    metacharacters.
-2. Form a candidate: `<candidate_branch>-<suffix>`.
+2. Form a candidate: `<candidate_branch>-<suffix>`, then cap the total length at
+   `DECONFLICT_MAX_BRANCH_LEN` (80) by truncating only the **base** — the
+   uniqueness-bearing suffix is preserved intact and any resulting trailing
+   hyphen is stripped.
 3. Validate the candidate with `git check-ref-format --branch`.
 4. Reject the candidate unless it is **free** on every axis:
    - no `refs/heads/<name>` (local branch),
@@ -184,20 +187,25 @@ iteration.
 ## Configuration
 
 The helper is intentionally low-configuration. Its behavior is governed by a
-single optional environment variable:
+single optional environment variable, plus one internal constant:
 
 | Variable                            | Purpose                                             | Default |
 | ----------------------------------- | --------------------------------------------------- | ------- |
 | `AMPLIHACK_DECONFLICT_MAX_RETRIES`  | Upper bound on suffix retries. Validated `^[0-9]+$` **and clamped to a hard ceiling of `5`** so the override can only *lower* the bound, never weaken the DoS guarantee. Any invalid value falls back to the default. | `5`     |
+
+The internal `readonly DECONFLICT_MAX_BRANCH_LEN` (80) caps the length of a
+renamed branch on the deconfliction path — see the [algorithm](#deconfliction-algorithm),
+step 2. It is a constant, not an environment knob.
 
 Resolution of the helper path in the recipe follows the same **best-effort
 ladder** modeled on `workflow_worktree_sweep.sh` (issue #829/#840 precedent). As
 wired in `workflow-worktree.yaml`, the call site probes, in order,
 `$AMPLIHACK_HOME`, `$REPO_PATH`, and the current directory for
 `amplifier-bundle/tools/workflow_worktree_deconflict.sh` (see the snippet under
-[Integration in the recipes](#integration-in-the-recipes)). If the helper is not
-found the call site is a graceful no-op guarded by `-f` and `|| true`, and the
-recipe proceeds with its legacy state machine (degraded but never aborting).
+[Integration in the recipes](#integration-in-the-recipes)). A **missing** helper
+is a graceful no-op guarded by `-f`, and the recipe proceeds with its legacy
+state machine. A helper that **runs but exits non-zero** (retries exhausted /
+misconfig) fails loud (`exit 1`) instead of falling back to the conflicting name.
 
 ## Integration in the recipes
 
@@ -213,13 +221,20 @@ The call site sits immediately after `WORKTREE_PATH` is computed
 # Before the idempotency state machine touches this branch, ask the helper
 # whether the branch is owned by a FOREIGN worktree at a different path. If so
 # it returns a NEW distinct branch name; otherwise it returns the candidate
-# unchanged (preserving same-path State-1 resume). Best-effort: a missing
-# helper is a graceful no-op (#829/#840 precedent).
+# unchanged (preserving same-path State-1 resume). A missing helper is a
+# graceful no-op (#829/#840 precedent); a helper that runs but FAILS (retries
+# exhausted / misconfig) aborts loud rather than reusing the conflicting name.
 DECONFLICT_HELPER="${AMPLIHACK_HOME:-${REPO_PATH:-$(pwd)}}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
 [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="${REPO_PATH:-$(pwd)}/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
 [ -f "$DECONFLICT_HELPER" ] || DECONFLICT_HELPER="$(pwd)/amplifier-bundle/tools/workflow_worktree_deconflict.sh"
 if [ -f "$DECONFLICT_HELPER" ]; then
-  RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_PATH" "$REPO_PATH" 2>/dev/null || echo "$BRANCH_NAME")"
+  # Branch on the helper's EXIT CODE and let its stderr surface — never
+  # '2>/dev/null || echo "$BRANCH_NAME"', which would silently reuse the
+  # conflicting name and re-abort at the State-2 `git branch -D`.
+  if ! RESOLVED_BRANCH="$(bash "$DECONFLICT_HELPER" resolve "$BRANCH_NAME" "$WORKTREE_PATH" "$REPO_PATH")"; then
+    echo "ERROR: worktree branch deconfliction failed for '${BRANCH_NAME}' ..." >&2
+    exit 1
+  fi
   if [ -n "$RESOLVED_BRANCH" ] && [ "$RESOLVED_BRANCH" != "$BRANCH_NAME" ]; then
     echo "INFO: branch '${BRANCH_NAME}' is owned by a foreign worktree — deconflicting to '${RESOLVED_BRANCH}'." >&2
     BRANCH_NAME="$RESOLVED_BRANCH"

--- a/amplifier-bundle/tools/workflow_worktree_deconflict.sh
+++ b/amplifier-bundle/tools/workflow_worktree_deconflict.sh
@@ -40,6 +40,13 @@ set -euo pipefail
 # Hard ceiling on retries — an override may only lower this, never raise it.
 readonly DECONFLICT_HARD_CEILING=5
 
+# Overall cap on a deconflicted branch name produced by the rename path. The
+# caller's slug pipeline already caps the BASE (50 chars in workflow-worktree.yaml,
+# 30 in consensus-issue-worktree.yaml), but appending a uniqueness suffix on the
+# rename path can exceed that budget (issue #200 review, item S4). This bounds the
+# result; it is generous by design and only trims pathologically long names.
+readonly DECONFLICT_MAX_BRANCH_LEN=80
+
 log() { printf '%s\n' "$*" >&2; }
 
 usage() {
@@ -170,7 +177,7 @@ cmd_resolve() {
   log "INFO: branch '${candidate}' is owned by a foreign worktree at '${owner_norm}'"
   log "INFO: (intended path is '${intended_norm}') — deconflicting to a new branch."
 
-  local max attempt suffix candidate_new
+  local max attempt suffix candidate_new base_max base_trunc
   max="$(resolve_max_retries)"
   attempt=0
   while [ "$attempt" -lt "$max" ]; do
@@ -179,7 +186,14 @@ cmd_resolve() {
     # introduce shell or ref metacharacters. Attempt + RANDOM disambiguate the
     # astronomically-rare same-second collision.
     suffix="$(printf '%s' "$(date +%s)-${attempt}-$$-${RANDOM:-0}" | tr -cd 'a-z0-9-')"
-    candidate_new="${candidate}-${suffix}"
+    # Re-apply an overall length cap on the rename path (review item S4). Truncate
+    # only the BASE so the uniqueness-bearing suffix is preserved intact; strip any
+    # resulting trailing hyphen so we never emit 'base--suffix' or a trailing '-'.
+    base_max=$(( DECONFLICT_MAX_BRANCH_LEN - ${#suffix} - 1 ))
+    [ "$base_max" -lt 1 ] && base_max=1
+    base_trunc="${candidate:0:base_max}"
+    base_trunc="${base_trunc%-}"
+    candidate_new="${base_trunc}-${suffix}"
     if ! git check-ref-format --branch "$candidate_new" >/dev/null 2>&1; then
       continue
     fi

--- a/amplifier-bundle/tools/workflow_worktree_deconflict.sh
+++ b/amplifier-bundle/tools/workflow_worktree_deconflict.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# workflow_worktree_deconflict.sh — non-destructive worktree/branch deconfliction.
+#
+# See amplifier-bundle/tools/workflow_worktree_deconflict.md for the full design.
+#
+# PURPOSE
+#   Two concurrently-running smart-orchestrator recipes can derive the SAME
+#   branch slug (same issue number + same task-description). The setup step's
+#   idempotency state machine (workflow-worktree.yaml step-04-setup-worktree,
+#   consensus-issue-worktree.yaml step3-setup-worktree) assumed any branch it
+#   found was one of its OWN prior runs. In the State-2 path it ran
+#   `git branch` deletion (or `git worktree add` without -b) which
+#   FAILS — and aborts the whole recipe — when that branch is currently checked
+#   out by a DIFFERENT recipe's worktree at another path.
+#
+#   This helper detects that FOREIGN ownership BEFORE any destructive/reuse
+#   decision is made and resolves it by renaming THIS run's branch (never by
+#   destroying the other run's branch or worktree).
+#
+# CONTRACT
+#   workflow_worktree_deconflict.sh resolve <candidate_branch> <intended_worktree_path> [repo_path]
+#     stdout : exactly one line — the resolved branch name (unchanged, or a new
+#              deconflicted name). Safe to capture with command substitution.
+#     stderr : human-readable diagnostics.
+#     exit 0 : a usable branch name was resolved and printed.
+#     exit 1 : bad/insufficient arguments, or all bounded retries (<=5) were
+#              exhausted without finding a provably-free name.
+#
+# NON-DESTRUCTIVE INVARIANT (hard): this helper only READS git state. It
+#   performs no branch deletion, no worktree removal, no hard reset, no forced
+#   checkout, no force/delete push, and no filesystem removal.
+#
+# ENV
+#   AMPLIHACK_DECONFLICT_MAX_RETRIES  upper bound on suffix retries; validated
+#     against ^[0-9]+$ and clamped to a HARD ceiling of 5 (override may only
+#     LOWER the bound, never weaken the DoS guarantee).
+
+set -euo pipefail
+
+# Hard ceiling on retries — an override may only lower this, never raise it.
+readonly DECONFLICT_HARD_CEILING=5
+
+log() { printf '%s\n' "$*" >&2; }
+
+usage() {
+  log "usage: workflow_worktree_deconflict.sh resolve <candidate_branch> <intended_worktree_path> [repo_path]"
+}
+
+# normalize_path <path>
+# Resolve symlinks and '.'/'..' segments (pwd -P semantics) even when the path
+# does not exist yet. Walks up to the deepest existing ancestor, canonicalizes
+# it, then re-appends the missing tail. Matches the issue #858 caller-checkout
+# normalization so a symlinked/non-canonical intended path cannot masquerade as
+# same-path or foreign.
+normalize_path() {
+  local p="$1"
+  if [ -d "$p" ]; then
+    (cd "$p" 2>/dev/null && pwd -P) || printf '%s' "$p"
+    return 0
+  fi
+  local dir="$p" rest="" base
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ] && [ "$dir" != "." ]; do
+    base="$(basename -- "$dir")"
+    if [ -n "$rest" ]; then
+      rest="$base/$rest"
+    else
+      rest="$base"
+    fi
+    dir="$(dirname -- "$dir")"
+  done
+  local realdir
+  realdir="$(cd "$dir" 2>/dev/null && pwd -P)" || realdir="$dir"
+  if [ -n "$rest" ]; then
+    printf '%s/%s' "$realdir" "$rest"
+  else
+    printf '%s' "$realdir"
+  fi
+}
+
+# branch_worktree_path <branch>
+# Print the (raw) worktree path that has <branch> checked out, or nothing.
+# Parses the stable machine-readable porcelain form, never the human output.
+branch_worktree_path() {
+  local branch="$1"
+  git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/${branch}" '
+    $1 == "worktree" { wt = substr($0, 10) }
+    $1 == "branch" && $2 == b { print wt; exit }
+  '
+}
+
+# branch_is_checked_out_anywhere <branch> -> 0 if any worktree owns it.
+branch_is_checked_out_anywhere() {
+  local branch="$1"
+  git worktree list --porcelain 2>/dev/null \
+    | grep -qxF "branch refs/heads/${branch}"
+}
+
+# name_is_free <branch> -> 0 when the name has no local ref, no remote ref, and
+# is not checked out by ANY worktree.
+name_is_free() {
+  local branch="$1"
+  if git show-ref --verify --quiet "refs/heads/${branch}"; then
+    return 1
+  fi
+  if git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+    return 1
+  fi
+  if branch_is_checked_out_anywhere "$branch"; then
+    return 1
+  fi
+  return 0
+}
+
+# resolve_max_retries -> echo the effective, clamped retry bound.
+resolve_max_retries() {
+  local max="$DECONFLICT_HARD_CEILING"
+  local override="${AMPLIHACK_DECONFLICT_MAX_RETRIES:-}"
+  if [ -n "$override" ] && printf '%s' "$override" | grep -qE '^[0-9]+$'; then
+    if [ "$override" -lt "$max" ]; then
+      max="$override"
+    fi
+  fi
+  printf '%s' "$max"
+}
+
+cmd_resolve() {
+  local candidate="${1:-}"
+  local intended="${2:-}"
+  local repo="${3:-$(pwd)}"
+
+  if [ -z "$candidate" ] || [ -z "$intended" ]; then
+    log "ERROR: resolve requires <candidate_branch> and <intended_worktree_path>."
+    usage
+    return 1
+  fi
+
+  if ! cd "$repo" 2>/dev/null; then
+    log "ERROR: repo_path '$repo' is not accessible."
+    return 1
+  fi
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # Not a git repo — nothing to introspect. Return the candidate untouched so
+    # the caller proceeds with its legacy behaviour (graceful, non-fatal).
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  local owner
+  owner="$(branch_worktree_path "$candidate" || true)"
+
+  if [ -z "$owner" ]; then
+    # Branch not checked out by any worktree: absent, or a leftover branch this
+    # recipe may safely manage itself (normal State-2). Return unchanged.
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  local owner_norm intended_norm
+  owner_norm="$(normalize_path "$owner")"
+  intended_norm="$(normalize_path "$intended")"
+
+  if [ "$owner_norm" = "$intended_norm" ]; then
+    # Same-path resume (State-1): this is our own worktree. Return unchanged.
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  # Foreign ownership: a DIFFERENT worktree holds this branch. Do NOT touch it.
+  # Rename THIS run's branch to a fresh, provably-free name.
+  log "INFO: branch '${candidate}' is owned by a foreign worktree at '${owner_norm}'"
+  log "INFO: (intended path is '${intended_norm}') — deconflicting to a new branch."
+
+  local max attempt suffix candidate_new
+  max="$(resolve_max_retries)"
+  attempt=0
+  while [ "$attempt" -lt "$max" ]; do
+    attempt=$((attempt + 1))
+    # Short unique suffix. Sanitized through tr -cd 'a-z0-9-' so it can never
+    # introduce shell or ref metacharacters. Attempt + RANDOM disambiguate the
+    # astronomically-rare same-second collision.
+    suffix="$(printf '%s' "$(date +%s)-${attempt}-$$-${RANDOM:-0}" | tr -cd 'a-z0-9-')"
+    candidate_new="${candidate}-${suffix}"
+    if ! git check-ref-format --branch "$candidate_new" >/dev/null 2>&1; then
+      continue
+    fi
+    if name_is_free "$candidate_new"; then
+      printf '%s\n' "$candidate_new"
+      return 0
+    fi
+  done
+
+  log "ERROR: exhausted ${max} deconfliction attempts without a free branch name for '${candidate}'."
+  return 1
+}
+
+main() {
+  local op="${1:-}"
+  case "$op" in
+    resolve)
+      shift
+      cmd_resolve "$@"
+      ;;
+    ""|-h|--help|help)
+      usage
+      [ -z "$op" ] && return 1 || return 0
+      ;;
+    *)
+      log "ERROR: unknown operation '$op'."
+      usage
+      return 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Fixes a **concurrency bug** in worktree setup. When two `smart-orchestrator`
recipes derive the **same branch slug** (same issue + same task description),
the step-04 idempotency state machine assumed any branch it found was one of
its own prior runs. In the State-2 path it ran `git branch -D` (or `git worktree
add` without `-b`), which **fails and aborts the whole recipe** when that branch
is currently checked out by a *different* recipe's worktree at another path.

## Approach

A self-contained, **non-destructive** shell brick
`amplifier-bundle/tools/workflow_worktree_deconflict.sh`:

- Parses `git worktree list --porcelain` (machine-readable form, never human output).
- Detects **foreign ownership**: the candidate branch is checked out by a worktree
  whose normalized path differs from this recipe's intended path.
- Same-path ⇒ State-1 resume (unchanged). No owning worktree ⇒ State-2 leftover
  (unchanged). Foreign ⇒ returns a fresh, **provably-free** branch name via a
  **bounded** (≤5, hard-ceiled) retry loop, each candidate re-validated with
  `git check-ref-format --branch` + no local ref + no remote ref + not in any worktree.
- Hard invariant: the helper only **reads** git state — no deletion, reset, or
  forced checkout of the foreign run's branch/worktree.

`workflow-worktree.yaml` step-04 invokes it **before** the idempotency state
machine (best-effort; graceful no-op if the helper is absent, #829/#840
precedent), reassigning `BRANCH_NAME`/`WORKTREE_PATH` so the deconflicted name
flows into the step's JSON output. `consensus-issue-worktree.yaml` step3 carries
the equivalent guidance in its worktree-manager prompt (verified by static parity).

## Tests

`amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh` — 25 checks:
16 static parity/wiring assertions + 9 behavioral tests on real git fixtures
(same-path resume, normalized same-path, unowned leftover, foreign→new-name,
non-destructive preservation, provably-free, convergence). Wired into CI plus a
shellcheck gate on the helper.

## Files
- `amplifier-bundle/tools/workflow_worktree_deconflict.sh` (+215) — helper
- `amplifier-bundle/tools/workflow_worktree_deconflict.md` (+354) — design doc
- `amplifier-bundle/recipes/workflow-worktree.yaml` (+14) — executable call site
- `amplifier-bundle/recipes/consensus-issue-worktree.yaml` (+19) — prompt mirror
- `amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh` (+424) — TDD spec
- `.github/workflows/ci.yml` (+12) — CI wiring + shellcheck gate

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
