### PR TITLE
fix(code-atlas): close SEC-10 gap with dedicated Cypher literal escaper (#961)

### DIFF
--- a/amplifier-bundle/skills/code-atlas/SECURITY.md
+++ b/amplifier-bundle/skills/code-atlas/SECURITY.md
@@ -20,7 +20,7 @@ This document defines the security controls that every implementation contributi
 | SEC-07  | MEDIUM   | Symlink attack prevention                         | Required |
 | SEC-08  | MEDIUM   | Large file DoS prevention                         | Required |
 | SEC-09  | CRITICAL | Credential redaction in bug reports + L8 output   | Required |
-| SEC-10  | HIGH     | DOT/Mermaid injection prevention (+ experiments/) | Required |
+| SEC-10  | HIGH     | DOT/Mermaid/Cypher injection prevention (+ exp/)  | Required |
 | SEC-11  | HIGH     | Layer 7 service name sanitization                 | Required |
 | SEC-12  | HIGH     | Layer 8 LSP output sanitization                   | Required |
 | SEC-13  | HIGH     | Density threshold parameter validation            | Required |
@@ -243,11 +243,12 @@ subprocess.run(f"mmdc -i {path}", shell=True)       # shell injection
 
 ### SEC-10: DOT/Mermaid Injection Prevention (HIGH)
 
-**Rule:** Code-derived strings inserted into DOT or Mermaid syntax must not allow diagram structure injection. Specifically:
+**Rule:** Code-derived strings inserted into DOT, Mermaid, **or Cypher** syntax must not allow structure/statement injection. Each target syntax has its own delimiter and therefore its own **dedicated** escaper — the DOT/Mermaid escapers MUST NOT be reused for Cypher literals, and vice versa. Specifically:
 
 - DOT labels: wrap in `"..."` and escape embedded `"` as `\"`
 - Mermaid labels: wrap node labels in `["..."]` syntax; escape `[`, `]`, `(`, `)` in content
 - Route strings (e.g. `/api/users/:id`): replace `:` with `﹕` (U+FE13) or wrap in quotes
+- **Cypher single-quote-delimited string literals** (e.g. `{name: 'STRIPE_KEY'}` in `.cypher` artifacts): escape backslash **first**, then the single quote, using the dedicated `cypher_string_literal` escaper below. The DOT/Mermaid escapers do NOT handle `'` and MUST NOT be used here.
 
 **DOT safe label:**
 
@@ -263,6 +264,22 @@ def mermaid_node(node_id: str, label: str) -> str:
     safe = label.replace('[', '&#91;').replace(']', '&#93;')
     return f'{node_id}["{safe}"]'
 ```
+
+**Cypher safe string literal** (REQUIRED for any string embedded in a `.cypher` statement):
+
+```python
+def cypher_string_literal(raw: str) -> str:
+    # Single-quote-delimited Cypher literal. Order is critical:
+    # escape backslash FIRST, then the single quote, so the
+    # backslash inserted for the quote is not itself re-escaped.
+    escaped = raw.replace('\\', '\\\\').replace("'", "\\'")
+    return "'" + escaped + "'"
+```
+
+`cypher_string_literal` — not `dot_label` / `mermaid_node` — is the control for
+every string written into a single-quote-delimited Cypher literal. An identifier
+containing `'` or `\` (e.g. `O'Brien` or `a\b`) is thereby prevented from breaking
+out of, or corrupting, the emitted literal.
 
 ---
 
@@ -566,7 +583,9 @@ All layer implementations MUST follow this pipeline order:
 14. If git push: sanitise stdout/stderr with CREDENTIAL_URL_PATTERN (SEC-19)
 15. When emitting graph artifacts (docs/atlas/cypher/) or ingesting into any backend
     (kuzu | lbug | neo4j): emit key names/structure only — EnvVar nodes carry names, never
-    values (SEC-01); all string literals in .cypher are escaped as diagram labels (SEC-10);
+    values (SEC-01); all single-quote-delimited string literals in .cypher are escaped with the
+    dedicated `cypher_string_literal` escaper — escaping `\` then `'` — not the DOT/Mermaid
+    label escaper (SEC-10);
     the recorded `graph_backend` label is non-sensitive metadata. Applies identically to every
     backend and to the portable-cypher-only outcome.
 ```
@@ -581,9 +600,11 @@ diagram output — they are a serialisation of the same node/edge model, not a n
 - **No secret values (SEC-01/SEC-15):** `EnvVar` nodes and `DataStore` nodes store key names,
   types, and non-sensitive metadata only. Env var values, credentials, and Kubernetes `data:`
   blocks are never written into `.cypher` files or passed to any backend.
-- **Injection-safe literals (SEC-10):** every string embedded in a `.cypher` statement is escaped
-  the same way diagram labels are, so a crafted route/service/symbol name cannot break query syntax
-  or inject statements.
+- **Injection-safe literals (SEC-10):** every string embedded in a single-quote-delimited `.cypher`
+  literal is escaped with the dedicated `cypher_string_literal` escaper (escape `\` first, then `'`),
+  **not** the DOT/Mermaid label escaper (which does not handle `'`), so a crafted
+  route/service/symbol name containing `'` or `\` cannot break out of the literal, corrupt it, or
+  inject statements.
 - **Backend selection is metadata:** the recorded `graph_backend`
   (`kuzu | lbug | neo4j | portable-cypher-only`) and `analyzer_mode` labels are non-sensitive and
   contain no code, paths, or secrets.
@@ -618,7 +639,8 @@ Before any layer implementation is considered complete:
 - [ ] SEC-07: Symlinks excluded from file discovery
 - [ ] SEC-08: Files >10MB skipped with SkillError logged
 - [ ] SEC-09: Bug report evidence fields (+ Layer 8 outputs + Pass 3 verdicts) scanned for credential patterns
-- [ ] SEC-10: DOT/Mermaid label strings are injection-safe (includes experiments/ output)
+- [ ] SEC-10: DOT/Mermaid label strings are injection-safe (includes experiments/ output); Cypher
+      single-quote-delimited literals escape `'` and `\` via the dedicated `cypher_string_literal` escaper
 - [ ] SEC-11: Layer 7 service names sanitised to `[a-zA-Z0-9_-]{1,64}` before path construction
 - [ ] SEC-12: Layer 8 LSP output validated (schema + SEC-03 + SEC-02 + SEC-09 applied to all fields)
 - [ ] SEC-13: `--density-threshold` values validated as integers in range 1–10,000

--- a/amplifier-bundle/skills/code-atlas/tests/test_security_controls.md
+++ b/amplifier-bundle/skills/code-atlas/tests/test_security_controls.md
@@ -177,6 +177,16 @@ nodes must carry key names only (SEC-01/SEC-15), independent of the selected `gr
 
 ---
 
+### TEST-SEC-10-C [AUTO]: Cypher single-quote literal escapes `'` and `\` and round-trips
+
+**Setup:** An identifier containing BOTH a single quote and a backslash, e.g. `O'Brien\x`, is emitted into a single-quote-delimited `.cypher` string literal (`{name: '...'}`).
+
+**Expected:** The `cypher_string_literal` escaper (escape `\` first → `\\`, then `'` → `\'`) produces `'O\'Brien\\x'`. Every interior `'` is backslash-escaped, so the delimiter is never broken out of, and decoding the literal round-trips back to the original identifier.
+
+**Pass criteria:** Feeding `O'Brien\x` through the escaper yields a literal wrapped in single quotes with no un-escaped interior quote, and unescaping returns exactly `O'Brien\x`. The DOT/Mermaid escaper is NOT used for this context.
+
+---
+
 ## Test Run Checklist
 
 Before considering security controls complete:
@@ -190,3 +200,4 @@ Before considering security controls complete:
 - [ ] TEST-SEC-09-A: Password patterns redacted in bug reports
 - [ ] TEST-SEC-10-A: Mermaid injection chars escaped in route labels
 - [ ] TEST-SEC-10-B: DOT quotes escaped in service labels
+- [ ] TEST-SEC-10-C: Cypher literal escapes `'` and `\` and round-trips without breaking the delimiter

--- a/amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh
+++ b/amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh
@@ -368,6 +368,73 @@ EOF
     rm -rf "$tmpdir"
 fi
 
+# TEST-SEC-10-C: Cypher single-quote-delimited literal escaper handles ' and \
+# An identifier containing BOTH a single quote and a backslash must be escaped
+# with the dedicated cypher_string_literal escaper (escape \ FIRST, then ')
+# so it cannot break out of / corrupt the emitted literal, and it round-trips.
+if command -v python3 >/dev/null 2>&1; then
+    sec10c_result=$(python3 - << 'PYEOF'
+def cypher_string_literal(raw: str) -> str:
+    # Order is critical: backslash first, then single quote.
+    escaped = raw.replace('\\', '\\\\').replace("'", "\\'")
+    return "'" + escaped + "'"
+
+# Identifier containing both a single quote and a backslash.
+raw = "O'Brien\\x"
+lit = cypher_string_literal(raw)
+
+# The emitted literal must be delimited by single quotes and every interior
+# quote/backslash must be backslash-escaped (no bare delimiter break-out).
+inner = lit[1:-1]
+
+# 1) Wrapped in single quotes.
+if not (lit.startswith("'") and lit.endswith("'")):
+    print("FAIL_WRAP")
+    raise SystemExit(0)
+
+# 2) Backslash escaped first: raw '\' -> '\\'; raw "'" -> "\'".
+expected_inner = "O\\'Brien\\\\x"
+if inner != expected_inner:
+    print("FAIL_ESCAPE:" + inner)
+    raise SystemExit(0)
+
+# 3) No un-escaped single quote inside (delimiter not broken out of):
+#    every ' must be immediately preceded by a backslash.
+for i, ch in enumerate(inner):
+    if ch == "'" and (i == 0 or inner[i - 1] != "\\"):
+        print("FAIL_BREAKOUT")
+        raise SystemExit(0)
+
+# 4) Round-trip: decode the literal back and confirm it equals the original.
+def cypher_unescape(literal: str) -> str:
+    body = literal[1:-1]
+    out = []
+    i = 0
+    while i < len(body):
+        if body[i] == "\\" and i + 1 < len(body):
+            out.append(body[i + 1])
+            i += 2
+        else:
+            out.append(body[i])
+            i += 1
+    return "".join(out)
+
+if cypher_unescape(lit) != raw:
+    print("FAIL_ROUNDTRIP:" + cypher_unescape(lit))
+    raise SystemExit(0)
+
+print("OK")
+PYEOF
+)
+    if [[ "$sec10c_result" == "OK" ]]; then
+        assert_pass "SEC-10-C: Cypher literal escapes ' and \\ and round-trips safely" "true"
+    else
+        assert_pass "SEC-10-C: Cypher literal escapes ' and \\ and round-trips safely" "false" "$sec10c_result"
+    fi
+else
+    echo "SKIP: SEC-10-C — python3 not available"
+fi
+
 # ============================================================================
 # SEC-04: Safe YAML Parsing (HIGH)
 # ============================================================================


### PR DESCRIPTION
Closes #961.

## Problem
The code-atlas SEC-10 control escaped the DOT/Mermaid set (`" \ [ ] ( ) :`) but did **not** escape the single-quote `'`. Emitted portable `.cypher` artifacts delimit identifier literals with single quotes (e.g. `{name: 'STRIPE_KEY'}`), so an identifier containing `'` or `\` could break out of / corrupt the emitted Cypher literal.

## Fix (option 1 — dedicated escaper)
The portable artifact format uses single-quote-delimited literals with **no** parameters map, so option 1 (dedicated escaper) applies.

- **`SECURITY.md`**: added a `cypher_string_literal` Python escaper alongside `dot_label` / `mermaid_node`. It escapes backslash **first** (`\` → `\\`) then single-quote (`'` → `\'`) — order chosen so the quote's inserted backslash is not itself re-escaped. Documented as the **REQUIRED** control for any string in a `.cypher` statement (Cypher literals use THIS escaper, not the DOT/Mermaid one). Existing DOT/Mermaid escapers are preserved unchanged.
- Updated SEC-10 section, control-table row, "Graph Artifact & Backend Security" bullet, emission-flow step 15, and the SEC-10 checklist item to state Cypher single-quote literals escape `'` and `\` via the dedicated escaper.
- **`tests/test_security_controls.sh`**: added `TEST-SEC-10-C` feeding an identifier containing both `'` and `\` (`O'Brien\x`) through the escaper, asserting the delimiter is not broken out of and the literal round-trips. Mirrored in `tests/test_security_controls.md` + checklist.

## Rust scope
`crates/amplihack-blarify` and `crates/amplihack-memory` graph_db paths use fully **parameterized** Cypher (`$param` + `GraphDbValue` bindings) — no inline single-quote literals — so no Rust changes are required.

## Verification
- `bash amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh` → `TEST-SEC-10-C` passes; suite goes from baseline 7→8 passed with **no** regressions (the 8 remaining failures are pre-existing TDD placeholders for unimplemented validator scripts).
- `run_all_tests.sh` picks up `SEC-10-C` (aggregated as Suite 3) and it passes.

## Acceptance criteria
- ✅ Emitted `.cypher` artifacts safe for identifiers with `'`, `\`, and the existing SEC-10 set.
- ✅ SEC-10 docs reflect single-quote/backslash handling via the dedicated escaper.
- ✅ Test covers an identifier with `'` and `\` round-tripping without corrupting the literal.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>