### PR TITLE
fix(code-atlas): close SEC-10 gap with dedicated Cypher literal escaper (#961)

### DIFF
--- a/amplifier-bundle/skills/code-atlas/SECURITY.md
+++ b/amplifier-bundle/skills/code-atlas/SECURITY.md
@@ -20,7 +20,7 @@ This document defines the security controls that every implementation contributi
 | SEC-07  | MEDIUM   | Symlink attack prevention                         | Required |
 | SEC-08  | MEDIUM   | Large file DoS prevention                         | Required |
 | SEC-09  | CRITICAL | Credential redaction in bug reports + L8 output   | Required |
-| SEC-10  | HIGH     | DOT/Mermaid injection prevention (+ experiments/) | Required |
+| SEC-10  | HIGH     | DOT/Mermaid/Cypher injection prevention (+ exp/)  | Required |
 | SEC-11  | HIGH     | Layer 7 service name sanitization                 | Required |
 | SEC-12  | HIGH     | Layer 8 LSP output sanitization                   | Required |
 | SEC-13  | HIGH     | Density threshold parameter validation            | Required |
@@ -243,11 +243,14 @@ subprocess.run(f"mmdc -i {path}", shell=True)       # shell injection
 
 ### SEC-10: DOT/Mermaid Injection Prevention (HIGH)
 
-**Rule:** Code-derived strings inserted into DOT or Mermaid syntax must not allow diagram structure injection. Specifically:
+**Rule:** Code-derived strings inserted into DOT, Mermaid, or Cypher syntax must not allow diagram or query structure injection. Specifically:
 
 - DOT labels: wrap in `"..."` and escape embedded `"` as `\"`
 - Mermaid labels: wrap node labels in `["..."]` syntax; escape `[`, `]`, `(`, `)` in content
 - Route strings (e.g. `/api/users/:id`): replace `:` with `﹕` (U+FE13) or wrap in quotes
+- Cypher string literals: wrap in `'...'` and escape via the dedicated `cypher_string_literal`
+  escaper below — the DOT/Mermaid escapers do **not** handle the single-quote delimiter and
+  MUST NOT be used for `.cypher` output
 
 **DOT safe label:**
 
@@ -262,6 +265,23 @@ def dot_label(raw: str) -> str:
 def mermaid_node(node_id: str, label: str) -> str:
     safe = label.replace('[', '&#91;').replace(']', '&#93;')
     return f'{node_id}["{safe}"]'
+```
+
+**Cypher safe string literal (REQUIRED for all `.cypher` output):**
+
+The DOT/Mermaid escapers escape `"` and `[]()`, but a `.cypher` artifact delimits identifier
+literals with single quotes, e.g. `{name: 'STRIPE_KEY'}`. An identifier containing `'` or `\`
+would break out of / corrupt that literal. Every string embedded in a `.cypher` statement MUST
+be passed through this dedicated escaper — not `dot_label` / `mermaid_node`. Escape order matters:
+backslash FIRST (`\` → `\\`), then single-quote (`'` → `\'`), so an escaped backslash is never
+mistaken for the escape of a following quote (no double-escaping).
+
+```python
+def cypher_string_literal(raw: str) -> str:
+    # Escape backslash FIRST, then single-quote — order is required so that
+    # a backslash is not double-escaped against a following quote.
+    escaped = raw.replace('\\', '\\\\').replace("'", "\\'")
+    return "'" + escaped + "'"
 ```
 
 ---
@@ -566,9 +586,10 @@ All layer implementations MUST follow this pipeline order:
 14. If git push: sanitise stdout/stderr with CREDENTIAL_URL_PATTERN (SEC-19)
 15. When emitting graph artifacts (docs/atlas/cypher/) or ingesting into any backend
     (kuzu | lbug | neo4j): emit key names/structure only — EnvVar nodes carry names, never
-    values (SEC-01); all string literals in .cypher are escaped as diagram labels (SEC-10);
-    the recorded `graph_backend` label is non-sensitive metadata. Applies identically to every
-    backend and to the portable-cypher-only outcome.
+    values (SEC-01); every string literal in .cypher is single-quote-delimited and escaped with
+    the dedicated `cypher_string_literal` escaper (escapes `\` then `'`), while DOT/Mermaid labels
+    use their own escapers (SEC-10); the recorded `graph_backend` label is non-sensitive metadata.
+    Applies identically to every backend and to the portable-cypher-only outcome.
 ```
 
 ---
@@ -581,9 +602,12 @@ diagram output — they are a serialisation of the same node/edge model, not a n
 - **No secret values (SEC-01/SEC-15):** `EnvVar` nodes and `DataStore` nodes store key names,
   types, and non-sensitive metadata only. Env var values, credentials, and Kubernetes `data:`
   blocks are never written into `.cypher` files or passed to any backend.
-- **Injection-safe literals (SEC-10):** every string embedded in a `.cypher` statement is escaped
-  the same way diagram labels are, so a crafted route/service/symbol name cannot break query syntax
-  or inject statements.
+- **Injection-safe literals (SEC-10):** every string embedded in a `.cypher` statement is
+  single-quote-delimited and escaped with the dedicated `cypher_string_literal` escaper — which
+  escapes backslash (`\` → `\\`) FIRST and then the single-quote delimiter (`'` → `\'`) — so a
+  crafted route/service/symbol name containing `'` or `\` cannot break out of the literal, corrupt
+  the artifact, or inject statements. The DOT/Mermaid label escapers do not handle the single-quote
+  delimiter and MUST NOT be used for `.cypher` output.
 - **Backend selection is metadata:** the recorded `graph_backend`
   (`kuzu | lbug | neo4j | portable-cypher-only`) and `analyzer_mode` labels are non-sensitive and
   contain no code, paths, or secrets.
@@ -618,7 +642,8 @@ Before any layer implementation is considered complete:
 - [ ] SEC-07: Symlinks excluded from file discovery
 - [ ] SEC-08: Files >10MB skipped with SkillError logged
 - [ ] SEC-09: Bug report evidence fields (+ Layer 8 outputs + Pass 3 verdicts) scanned for credential patterns
-- [ ] SEC-10: DOT/Mermaid label strings are injection-safe (includes experiments/ output)
+- [ ] SEC-10: DOT/Mermaid label strings are injection-safe (includes experiments/ output); Cypher
+      single-quote-delimited literals escape `'` and `\` via the dedicated `cypher_string_literal` escaper
 - [ ] SEC-11: Layer 7 service names sanitised to `[a-zA-Z0-9_-]{1,64}` before path construction
 - [ ] SEC-12: Layer 8 LSP output validated (schema + SEC-03 + SEC-02 + SEC-09 applied to all fields)
 - [ ] SEC-13: `--density-threshold` values validated as integers in range 1–10,000

--- a/amplifier-bundle/skills/code-atlas/SECURITY.md
+++ b/amplifier-bundle/skills/code-atlas/SECURITY.md
@@ -284,6 +284,12 @@ def cypher_string_literal(raw: str) -> str:
     return "'" + escaped + "'"
 ```
 
+**Residual (accepted):** control characters — newline (`\n`), carriage return (`\r`),
+and tab (`\t`) — are intentionally **not** escaped. This is safe: Cypher permits these
+characters inside a single-quoted string literal, so they cannot terminate the literal
+or inject query structure. They pass through and are recovered verbatim in the parsed
+value. Only `\` and `'` can break out of the literal, and both are escaped above.
+
 ---
 
 ## MEDIUM Controls

--- a/amplifier-bundle/skills/code-atlas/examples.md
+++ b/amplifier-bundle/skills/code-atlas/examples.md
@@ -304,6 +304,42 @@ MATCH (r:Route {path: '/api/orders'}), (d:DTO {name: 'CreateOrderRequest'}) CREA
 MATCH (s:Service {name: 'api-service'}), (e:EnvVar {name: 'DATABASE_URL'})   CREATE (s)-[:USES_ENV]->(e);
 ```
 
+### Injection-safe string literals (SEC-10)
+
+Every string embedded in a `.cypher` statement is single-quote-delimited (`{name: 'STRIPE_KEY'}`),
+so any code-derived identifier is first passed through the dedicated `cypher_string_literal`
+escaper defined in [SECURITY.md → SEC-10](./SECURITY.md#sec-10-dotmermaid-injection-prevention-high).
+This escaper is **required** for all `.cypher` output — the DOT/Mermaid escapers do *not* handle the
+single-quote delimiter and MUST NOT be used here.
+
+The escaper escapes backslash first (`\` → `\\`), then single-quote (`'` → `\'`), then wraps the
+result in single quotes. Order matters: escaping the backslash first guarantees an escaped backslash
+is never mistaken for the escape of a following quote (no double-escaping).
+
+Given a raw identifier that contains both a single-quote and a backslash — e.g. a symbol literally
+named `O'Brien\x` — emission is safe and round-trips without breaking out of the literal:
+
+```python
+cypher_string_literal("O'Brien\\x")   # -> "'O\\'Brien\\\\x'"   (as written to the .cypher file: 'O\'Brien\\x')
+```
+
+```cypher
+// Emitted node — the delimiter is preserved; the value cannot break out of the literal
+CREATE (:Symbol {name: 'O\'Brien\\x'});
+```
+
+A parser reading the artifact recovers the original identifier exactly (`O'Brien\x`). This behaviour
+is locked by the automated regression test `TEST-SEC-10-C` in
+[`tests/test_security_controls.sh`](./tests/test_security_controls.sh), which feeds an identifier
+containing both `'` and `\` through the escaper and asserts the emitted literal is well-formed and
+round-trips.
+
+> **Residual (accepted):** control characters — newline (`\n`), carriage return (`\r`), and tab
+> (`\t`) — are intentionally not escaped. Cypher allows them inside a single-quoted literal, so they
+> cannot break out or inject query structure; they simply pass through and round-trip verbatim. Only
+> `\` and `'` can escape the literal, and both are handled above. See
+> [SECURITY.md → SEC-10](./SECURITY.md#sec-10-dotmermaid-injection-prevention-high).
+
 ### `kuzu` adapter (typed DDL)
 
 ```cypher

--- a/amplifier-bundle/skills/code-atlas/tests/test_security_controls.md
+++ b/amplifier-bundle/skills/code-atlas/tests/test_security_controls.md
@@ -188,7 +188,8 @@ delimiters. The DOT/Mermaid escapers are NOT used for Cypher output.
 
 **Pass criteria:** The emitted literal is single-quote delimited, every interior `'` and `\` is
 escaped, no bare delimiter breaks out, and decoding the literal round-trips back to the original
-identifier without corruption.
+identifier without corruption. Documented residual is also asserted: control characters
+(`\n`, `\r`, `\t`) are NOT escaped (safe inside single-quoted Cypher literals) and round-trip verbatim.
 
 ---
 

--- a/amplifier-bundle/skills/code-atlas/tests/test_security_controls.md
+++ b/amplifier-bundle/skills/code-atlas/tests/test_security_controls.md
@@ -177,6 +177,21 @@ nodes must carry key names only (SEC-01/SEC-15), independent of the selected `gr
 
 ---
 
+### TEST-SEC-10-C [AUTO]: Cypher literal with single-quote and backslash does not break out
+
+**Setup:** An identifier containing BOTH characters, e.g. `O'Brien\x' RETURN 1//`, emitted into a
+single-quote-delimited `.cypher` literal such as `{name: '...'}`.
+
+**Expected:** The dedicated `cypher_string_literal` escaper escapes backslash FIRST (`\` → `\\`) then
+the single-quote delimiter (`'` → `\'`), producing a literal whose only unescaped `'` are the outer
+delimiters. The DOT/Mermaid escapers are NOT used for Cypher output.
+
+**Pass criteria:** The emitted literal is single-quote delimited, every interior `'` and `\` is
+escaped, no bare delimiter breaks out, and decoding the literal round-trips back to the original
+identifier without corruption.
+
+---
+
 ## Test Run Checklist
 
 Before considering security controls complete:
@@ -190,3 +205,4 @@ Before considering security controls complete:
 - [ ] TEST-SEC-09-A: Password patterns redacted in bug reports
 - [ ] TEST-SEC-10-A: Mermaid injection chars escaped in route labels
 - [ ] TEST-SEC-10-B: DOT quotes escaped in service labels
+- [ ] TEST-SEC-10-C: Cypher literal escaper handles `'` and `\` without breaking out (round-trips)

--- a/amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh
+++ b/amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh
@@ -368,6 +368,78 @@ EOF
     rm -rf "$tmpdir"
 fi
 
+# TEST-SEC-10-C: Cypher single-quote-delimited literal escaper handles ' and \
+# An identifier containing BOTH a single-quote and a backslash must not break out of
+# the single-quote-delimited literal in an emitted .cypher statement. Exercise the
+# dedicated `cypher_string_literal` escaper documented in SECURITY.md and assert the
+# emitted literal round-trips back to the original identifier without corruption.
+sec10c_output=$(python3 - << 'PYEOF'
+def cypher_string_literal(raw: str) -> str:
+    # Must match SECURITY.md: escape backslash FIRST, then single-quote.
+    escaped = raw.replace('\\', '\\\\').replace("'", "\\'")
+    return "'" + escaped + "'"
+
+# Identifier containing BOTH a single-quote and a backslash (the SEC-10 gap).
+ident = "O'Brien\\x' RETURN 1//"
+literal = cypher_string_literal(ident)
+
+ok = True
+
+# 1) Result is single-quote delimited.
+if not (literal.startswith("'") and literal.endswith("'")):
+    ok = False
+
+# 2) The single interior quote and backslash are both escaped.
+if "\\'" not in literal:
+    ok = False
+if "\\\\" not in literal:
+    ok = False
+
+# 3) Escape order is correct (backslash first): the backslash-x survives as \\x,
+#    it is NOT rendered as an escaped-quote artifact.
+if "\\\\x" not in literal:
+    ok = False
+
+# 4) No unescaped delimiter breaks out: strip the outer delimiters, then every
+#    remaining single-quote must be preceded by a backslash.
+inner = literal[1:-1]
+i = 0
+while i < len(inner):
+    c = inner[i]
+    if c == '\\':
+        i += 2  # skip the escaped char
+        continue
+    if c == "'":
+        ok = False  # bare (unescaped) delimiter inside the literal
+        break
+    i += 1
+
+# 5) Round-trip: decode the Cypher literal back to the original identifier.
+def decode(lit: str) -> str:
+    body = lit[1:-1]
+    out = []
+    j = 0
+    while j < len(body):
+        if body[j] == '\\' and j + 1 < len(body):
+            out.append(body[j + 1])
+            j += 2
+        else:
+            out.append(body[j])
+            j += 1
+    return ''.join(out)
+
+if decode(literal) != ident:
+    ok = False
+
+print("PASS" if ok else "FAIL")
+PYEOF
+)
+if [[ "$sec10c_output" == "PASS" ]]; then
+    assert_pass "SEC-10-C: Cypher literal escaper safely handles ' and \\ (round-trips, no break-out)" "true"
+else
+    assert_pass "SEC-10-C: Cypher literal escaper safely handles ' and \\ (round-trips, no break-out)" "false" "escaper output: $sec10c_output"
+fi
+
 # ============================================================================
 # SEC-04: Safe YAML Parsing (HIGH)
 # ============================================================================

--- a/amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh
+++ b/amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh
@@ -431,6 +431,16 @@ def decode(lit: str) -> str:
 if decode(literal) != ident:
     ok = False
 
+# 6) Documented residual: control chars (\n, \r, \t) are intentionally NOT
+#    escaped (safe inside single-quoted Cypher literals) and must round-trip
+#    verbatim. This locks the SECURITY.md / examples.md residual note.
+ctrl = "line1\nline2\treturn\rend"
+ctrl_lit = cypher_string_literal(ctrl)
+if "\\n" in ctrl_lit or "\\t" in ctrl_lit or "\\r" in ctrl_lit:
+    ok = False  # control chars must pass through unescaped
+if decode(ctrl_lit) != ctrl:
+    ok = False
+
 print("PASS" if ok else "FAIL")
 PYEOF
 )


### PR DESCRIPTION
Closes #961.

## Problem
The code-atlas skill's SEC-10 control escaped the DOT/Mermaid character set (`" \ [ ] ( ) :`) but did **not** escape the single-quote `'`. Emitted portable `.cypher` artifacts delimit identifier literals with single quotes (e.g. `{name: 'STRIPE_KEY'}`), so an identifier containing `'` or `\` could break out of / corrupt the emitted Cypher literal.

## Fix (option 1 — dedicated escaper)
The `.cypher` format uses single-quote literals with no parameters map, so option 1 applies.

- **`SECURITY.md`**: Added a dedicated `cypher_string_literal` escaper that escapes backslash FIRST (`\` → `\\`) then single-quote (`'` → `\'`) — ordering correct to avoid double-escaping. Documented as the **REQUIRED** control for any string embedded in a `.cypher` statement (Cypher literals use THIS escaper, not the DOT/Mermaid one). The existing `dot_label` / `mermaid_node` escapers are unchanged (SEC-10 DOT/Mermaid handling preserved). Updated the SEC-10 rule, control-table row, emission-flow step 15, "Graph Artifact & Backend Security" bullet, and the checklist item.
- **`tests/test_security_controls.sh`**: Added `TEST-SEC-10-C` — feeds an identifier containing BOTH `'` and `\` (`O'Brien\x' RETURN 1//`) through the escaper and asserts single-quote delimiting, both chars escaped, correct escape order, no bare-delimiter break-out, and safe round-trip back to the original identifier.
- **`tests/test_security_controls.md`**: Mirrored TEST-SEC-10-C spec + checklist entry.

## Rust
No changes. `crates/amplihack-blarify` and `crates/amplihack-memory` graph_db paths use **parameterized** Cypher (`$param` bindings), not inline single-quote literals — nothing to escape.

## Verification
- `TEST-SEC-10-C` passes standalone and via `run_all_tests.sh`.
- Suite went 7→8 passed with **zero regressions**. Remaining 8 failures are pre-existing TDD placeholders (require unimplemented `validate_atlas_output.sh` / `safe_read.sh`), unrelated to this change.

## Acceptance criteria
- [x] Emitted `.cypher` artifacts safe for identifiers containing `'`, `\`, and the existing SEC-10 set.
- [x] SEC-10 documentation reflects single-quote/backslash handling.
- [x] Test covers an identifier with `'` and `\` round-tripping without corrupting the literal.
## Step 13: Local Testing Results

Detected toolchains:
- **Prose + shell-test skill** (no compiled Rust for this change). Evidence: change set is confined to `amplifier-bundle/skills/code-atlas/` (SECURITY.md, examples.md, tests/test_security_controls.{sh,md}); no `Cargo.toml`/manifest touched. Rust `graph_db` paths use parameterized Cypher (`$param`), so no inline single-quote literals to escape there.
- Test harness: POSIX `bash` + `python3` (the documented escaper is a Python snippet in SECURITY.md; the suite is aggregated by `tests/run_all_tests.sh`).

Chosen validation strategy:
- Outside-in at the real consumer boundary: **extract the `cypher_string_literal` escaper verbatim from SECURITY.md** (the exact control a user copies) and drive an identifier through it into an emitted `.cypher` MERGE statement, then validate the output with a single-quote Cypher-literal tokenizer (delimiter break-out + exact round-trip). This proves the documented control — not a re-typed copy — is safe. Also ran the committed automated `TEST-SEC-10-C`.

### Scenario 1 — Identifier with a single quote (`O'Brien`) emitted into `.cypher`
Command: `python3` driving the escaper extracted from SECURITY.md into `MERGE (n:Symbol {name: <lit>})`
Result: PASS
Output:
```
emitted literal  : 'O\'Brien'
emitted .cypher  : MERGE (n:Symbol {name: 'O\'Brien'})
RESULT: PASS — literal round-trips to original, no early termination
```

### Scenario 2 — Injection attempt with BOTH `'` and `\` (`x'}) DETACH DELETE n //\\'`)
Command: `python3` driving the extracted escaper into `MERGE (n:EnvVar {name: <lit>})`, then tokenizing the statement
Result: PASS
Output:
```
emitted .cypher  : MERGE (n:EnvVar {name: 'x\'}) DETACH DELETE n //\\\\\''})
tokens after literal value: '})'
RESULT: PASS — injection neutralized, delimiter intact, round-trips exactly
```
The injected `DETACH DELETE n` stayed trapped inside the string literal; the only tokens following the literal value are the map's closing `})`.

### Automated regression suite
Command: `bash amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh`
Result: PASS (new test) — `PASS: SEC-10-C: Cypher literal escaper safely handles ' and \ (round-trips, no break-out)`
Note: suite reports `8 passed, 8 failed`; **all failures are pre-existing environmental prerequisites** (`validate_atlas_output.sh`, `safe_read.sh` are staged by `amplihack install`, not present in the source bundle) and exist unchanged on base `d4bbe6aa`. No new regression. `TEST-SEC-10-C` is aggregated via `tests/run_all_tests.sh`.

---

## Step 16b: Outside-In Testing Results

**Detected toolchains:** Rust workspace (`Cargo.toml` at root, cargo 1.97.0) + prose/shell-test skill (`amplifier-bundle/skills/code-atlas/`, Python 3 + Bash for the `test_security_controls.sh` harness). The SEC-10 fix is confined to the code-atlas skill — no compiled Rust participates in `.cypher` emission (verified: no single-quote-delimited literal emission in `crates/amplihack-blarify/src/graph/` or `crates/amplihack-memory/src/graph_store.rs`), so per the task instructions the change stays skill-only and no Rust unit test / `cargo build`/`clippy` was required.

**Chosen strategy:** Run the skill's shell test suite as a consumer would (`bash test_security_controls.sh`), plus an independent adversarial round-trip verification of the documented `cypher_string_literal` escaper against identifiers a real codebase could contain.

### Scenario 1 — Simple: skill security test suite (TEST-SEC-10-C)
- **Command:** `bash amplifier-bundle/skills/code-atlas/tests/test_security_controls.sh`
- **Result:** ✅ PASS — `SEC-10-C: Cypher literal escaper safely handles ' and \ (round-trips, no break-out)`
- **Key output:** `Results: 8 passed, 8 failed`. All 8 failures are **pre-existing, unrelated to #961**: they are SEC-01/SEC-02 prerequisite checks for `scripts/validate_atlas_output.sh` and `scripts/safe_read.sh`, which do not exist in this repo. The test header explicitly documents these as "THESE TESTS WILL FAIL until the corresponding security validators are implemented." The branch's test change is verified **purely additive** (`git diff` shows no removed/modified lines in the existing suite) and TEST-SEC-10-C is wired into `run_all_tests.sh`.

### Scenario 2 — Edge/adversarial: escaper round-trip against injection & escape-order traps
- **Command:** standalone `python3` harness driving the documented `cypher_string_literal` escaper.
- **Inputs:** `STRIPE_KEY`, `O'Brien`, `path\to\file`, `x'} RETURN 1; //` (Cypher-injection attempt), `a\' b` (backslash-immediately-before-quote escape-order trap), and `line1\nline2\ttab` (control-char residual).
- **Result:** ✅ ALL PASS — every literal is single-quote delimited, contains no bare (unescaped) delimiter, decodes back to the exact original identifier (round-trips), and control chars pass through unescaped as documented. The escape-order trap (`a\' b`) confirms backslash is escaped **before** the quote, so an escaped backslash is never mis-read as an escaped delimiter.

**Fix count:** 0 — the implementation on the branch already satisfies all acceptance criteria; no diagnose/fix/commit iterations were needed. Working tree clean; branch in sync with remote.
