### PR TITLE
feat(skills): add property-based / metamorphic testing skill (#1048)

### DIFF
--- a/amplifier-bundle/skills/gherkin-expert/SKILL.md
+++ b/amplifier-bundle/skills/gherkin-expert/SKILL.md
@@ -65,3 +65,12 @@ Scenario: Login
 4. **Giant Background** — keep shared setup minimal
 5. **Scenario Outline abuse** — use only when examples vary by data
 6. **Inconsistent domain language** — align with ubiquitous language
+
+## Related Skills
+
+- **property-based-testing**: Generalizes concrete Gherkin examples into
+  universally-quantified properties (invariant, round-trip, metamorphic).
+  Reach for it when a `Scenario Outline`'s example table is really trying to
+  express "for all inputs" rather than a handful of cases.
+- **tla-plus-expert**: Formal design-level verification; together these form
+  the specification-and-verification triad.

--- a/amplifier-bundle/skills/property-based-testing/README.md
+++ b/amplifier-bundle/skills/property-based-testing/README.md
@@ -1,0 +1,150 @@
+# Property-Based Testing Skill
+
+Expert guidance for **property-based** and **metamorphic** testing. Instead of
+asserting one hand-picked example, you state a rule that must hold for *every*
+input, and the library generates hundreds of inputs to try to break it. This
+skill is the third leg of amplihack's formal-methods triad, alongside
+`tla-plus-expert` (model checking) and `gherkin-expert` (BDD acceptance specs).
+
+## Quick Start
+
+```
+User: I want to test that our redaction function can't leak a secret. How?
+
+Claude: That's a property-based testing job — you can't enumerate every secret,
+but you can state a rule. Use proptest (Rust), inside `cargo test`:
+
+  proptest! {
+      #[test]
+      fn redacted_output_has_no_secret(
+          secret in "[A-Za-z0-9]{8,32}", prefix in ".*", suffix in ".*"
+      ) {
+          let input = format!("{prefix}{secret}{suffix}");
+          prop_assert!(!redact_secret(&input, &secret).contains(&secret));
+      }
+  }
+
+This is a "no-secret-leak" safety invariant. Pair it with an idempotence
+property, redact(redact(x)) == redact(x), for full coverage.
+```
+
+## When to Use
+
+Reach for this skill when:
+
+- Example tests keep missing edge cases (empty input, huge input, unicode,
+  boundary numbers, duplicates, reordering).
+- You can state a **rule** the code must obey but can't enumerate every input.
+- You have a **reference implementation** (an older version, a slow-but-correct
+  oracle, or a sibling implementation in another language) to compare against.
+
+Prefer `tla-plus-expert` instead when the property is about concurrency,
+ordering, or temporal/liveness behavior of a *design you can model*. Prefer
+`gherkin-expert` when the value is a shared, human-readable acceptance spec.
+These complement rather than replace each other — a mature component often has
+all three.
+
+## Features
+
+- **Library selection per stack**: proptest/quickcheck (Rust), Hypothesis
+  (Python), FsCheck/CsCheck (.NET), fast-check (JS/TS), jqwik (Java).
+- **Property discovery**: invariants, round-trips, idempotence, commutativity,
+  oracle/differential (incl. cross-language conformance), and metamorphic
+  relations.
+- **Shrinking & seeding guidance**: turn a failure into the smallest
+  reproducible counterexample and pin it as a regression test.
+- **Existing-runner integration**: property tests are ordinary tests — no
+  separate harness.
+
+## Activation
+
+| Method   | Trigger                                                                                                   |
+| -------- | --------------------------------------------------------------------------------------------------------- |
+| Auto     | Phrases like "property-based testing", "metamorphic testing", "generative testing", "shrinking", "fuzz property", or a library name (proptest, quickcheck, hypothesis, fast-check, fscheck, jqwik). |
+| Explicit | `/property-based-testing` or `/amplihack:property-based-testing`                                           |
+
+No confirmation is required; explicit triggers skip confirmation entirely
+(`confirmation_required: false`, `skip_confirmation_if_explicit: true`). The
+skill's token budget is 3000.
+
+## Library Selection
+
+| Stack  | Library                                        | Runner it plugs into        |
+| ------ | ---------------------------------------------- | --------------------------- |
+| Rust   | **proptest** (preferred) or **quickcheck**     | `cargo test`                |
+| Python | **Hypothesis**                                 | `pytest` / `unittest`       |
+| .NET   | **FsCheck** (F#-friendly) / **CsCheck** (C#)   | `xunit` / `nunit`           |
+| JS/TS  | **fast-check**                                 | `jest` / `vitest` / `mocha` |
+| Java   | **jqwik**                                      | JUnit 5 platform            |
+
+Every library above runs *inside* your existing test runner as ordinary test
+cases. Do not build a separate harness.
+
+## Property Families
+
+| Family                | Rule                                   | Typical targets                       |
+| --------------------- | -------------------------------------- | ------------------------------------- |
+| Invariant             | Something always true of the output    | length bounds, permutation-preserving |
+| Round-trip            | `decode(encode(x)) == x`               | serializers, parsers, config load/save|
+| Idempotence           | `f(f(x)) == f(x)`                      | redaction, normalization, dedup       |
+| Commutativity         | `merge(a, b) == merge(b, a)`           | set/CRDT merges, aggregation          |
+| Oracle / differential | Matches a trusted reference            | old release, cross-language conformance|
+| Metamorphic relation  | How output must *change* with input    | search, ranking, scaling              |
+
+When you can't state an exact expected value, a metamorphic relation is usually
+still available — that is the whole point of metamorphic testing.
+
+## Worked Examples
+
+The skill ships one worked example per stack, all drawn from amplihack's own
+invariants:
+
+- **Rust / proptest** — redaction idempotence and the no-secret-leak invariant.
+- **Python / Hypothesis** — config bounds: `shard_jobs_max <= effective <= jobs_max`.
+- **.NET / FsCheck** — coverage tally: `bundle >= in_scope` and
+  `scanned + excluded == in_scope`.
+- **JS/TS / fast-check** — telemetry totality/safety: `recordTelemetry` never
+  throws and always returns a well-formed event.
+- **Java / jqwik** — config encode/decode round-trip plus a differential oracle
+  comparing a fast parser to a reference parser.
+
+See [SKILL.md](./SKILL.md) for the full, runnable snippets.
+
+## Cross-Language Conformance
+
+For amplihack's multi-runtime components, run the *same* seeded corpus through
+each language implementation and assert identical outputs. Generate the corpus
+once with a fixed seed, feed it to every implementation, and diff the results.
+Any divergence is a conformance bug — shrink it to the minimal input.
+
+## Shrinking, Seeding, Reproducibility
+
+- **Shrinking** reduces a failing input to the smallest counterexample. Never
+  disable it — the minimal case *is* the bug report.
+- **Seeding**: every run records a seed; re-run with it to reproduce
+  deterministically. Commit the seed or the reduced counterexample as a
+  regression example test so the bug stays fixed.
+- **Budget**: start with the default case count (100–1000). Raise it in CI for
+  critical invariants; keep it low locally for fast feedback.
+- **Security note**: redact and seed shrink counterexamples so generative tests
+  never leak sensitive data into CI logs.
+
+## Workflow Integration
+
+- **Step 11 (Write Tests)**: add properties for invariants example tests can't
+  enumerate.
+- **Step 12–13 (Run/Local Testing)**: property tests run in the existing runner
+  via `smart-test` tiers — no separate harness.
+- **After a failure**: pin the shrunk counterexample as a regression test.
+
+## Related Skills
+
+- `tla-plus-expert` — exhaustive model checking of designs (the high-cost leg).
+- `gherkin-expert` — human-readable BDD acceptance scenarios.
+- `test-gap-analyzer` — find *which* code lacks coverage; then add properties here.
+- `smart-test` — run the resulting property tests through the existing runner.
+
+---
+
+See [SKILL.md](./SKILL.md) for complete documentation, runnable per-language
+examples, and the built-in quiz.

--- a/amplifier-bundle/skills/property-based-testing/SKILL.md
+++ b/amplifier-bundle/skills/property-based-testing/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: property-based-testing
+version: 1.0.0
+description: Property-based and metamorphic testing expert for choosing a library, finding good properties (invariants, round-trips, idempotence, oracle/differential, metamorphic relations), and wiring generative tests into the existing test runner.
+auto_activates:
+  - "property-based testing"
+  - "property based test"
+  - "metamorphic testing"
+  - "generative testing"
+  - "fuzz property"
+  - "proptest"
+  - "quickcheck"
+  - "hypothesis testing library"
+  - "fast-check"
+  - "fscheck"
+  - "jqwik"
+  - "shrinking"
+explicit_triggers:
+  - /property-based-testing
+  - /amplihack:property-based-testing
+confirmation_required: false
+skip_confirmation_if_explicit: true
+token_budget: 3000
+---
+
+# Property-Based Testing Skill
+
+Expert guidance for **property-based** and **metamorphic** testing: instead of
+asserting one hand-picked example, you state a rule that must hold for *every*
+input, and the library generates hundreds of inputs to try to break it.
+
+## Where This Fits — the third leg of the formal-methods triad
+
+amplihack ships two other formal-methods skills. Property-based testing is the
+practical middle ground between them:
+
+| Approach | Skill | What it checks | Cost |
+| --- | --- | --- | --- |
+| Example tests | (unit tests) | Behavior on inputs you thought of | Low |
+| **Property-based / metamorphic** | **property-based-testing** | Invariants over *generated* inputs, at runtime, against real code | Medium |
+| BDD acceptance | `gherkin-expert` | Human-readable behavior scenarios | Low–medium |
+| Model checking / proof | `tla-plus-expert` | Exhaustive state-space or temporal properties of a *model* | High |
+
+Reach for property-based testing when:
+
+- Example tests keep missing edge cases (empty input, huge input, unicode,
+  boundary numbers, duplicates, reordering).
+- You can state a **rule** the code must obey but can't enumerate every input.
+- You have a **reference implementation** (an old version, a slow-but-correct
+  oracle, or a sibling implementation in another language) to compare against.
+
+Prefer TLA+ instead when the property is about *concurrency, ordering, or
+temporal/liveness* behavior of a design you can model. Prefer Gherkin when the
+value is a shared, human-readable acceptance spec. These are complements, not
+substitutes — a mature component often has all three.
+
+## Pick the library for your stack
+
+| Stack | Library | Runner it plugs into |
+| --- | --- | --- |
+| Rust | **proptest** (preferred) or **quickcheck** | `cargo test` |
+| Python | **Hypothesis** | `pytest` / `unittest` |
+| .NET | **FsCheck** (F#-friendly) or **CsCheck** (C#-friendly) | `xunit` / `nunit` |
+| JS/TS | **fast-check** | `jest` / `vitest` / `mocha` |
+| Java | **jqwik** | JUnit 5 platform |
+
+**Do not build a separate harness.** Every library above runs *inside* your
+existing test runner as ordinary test cases. A property test is just a test
+that loops over generated inputs.
+
+## Finding good properties
+
+A "property" is a rule that holds for all valid inputs. The reliable families:
+
+- **Invariant** — something always true of the output (e.g. output length ≤
+  input length; a sorted list is still a permutation of the input).
+- **Round-trip** — `decode(encode(x)) == x`. Great for serializers, parsers,
+  compressors, config load/save.
+- **Idempotence** — applying twice equals applying once: `f(f(x)) == f(x)`.
+  Redaction, normalization, dedup, formatting.
+- **Commutativity / associativity** — order of operations doesn't change the
+  result: `merge(a, b) == merge(b, a)`.
+- **Oracle / differential** — compare against a trusted reference: a naive
+  slow implementation, the previous release, or **a sibling implementation in
+  another language** (cross-language conformance).
+- **Metamorphic relation** — you don't know the exact output, but you know how
+  the output must *change* when the input changes. E.g. adding an item to a set
+  can never shrink its size; re-scaling all weights by k scales the total by k;
+  searching a superset returns at least as many hits.
+
+When you can't state an exact expected value, a metamorphic relation is usually
+still available. That is the whole point of metamorphic testing.
+
+## Shrinking, seeding, reproducibility
+
+- **Shrinking**: when a property fails, the library automatically reduces the
+  failing input to the *smallest* counterexample (e.g. from a 400-char string
+  to `"a"`). Never disable shrinking — the minimal case is the bug report.
+- **Seeding**: every run prints/records a seed. On failure, re-run with the
+  same seed to reproduce deterministically. Commit the seed (or the reduced
+  counterexample as a regression example test) so the bug stays fixed.
+- **Budget**: start with the default case count (usually 100–1000). Raise it in
+  CI for critical invariants; keep it low locally for fast feedback.
+
+## Worked examples (concrete property families)
+
+The snippets below use amplihack's own invariants as worked examples.
+
+### Rust — proptest (redaction idempotence + no-secret-leak)
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    // redact(redact(x)) == redact(x)
+    #[test]
+    fn redact_is_idempotent(s in ".*") {
+        let once = redact(&s);
+        let twice = redact(&once);
+        prop_assert_eq!(once, twice);
+    }
+
+    // output never contains the secret
+    #[test]
+    fn redacted_output_has_no_secret(secret in "[A-Za-z0-9]{8,32}", prefix in ".*", suffix in ".*") {
+        let input = format!("{prefix}{secret}{suffix}");
+        let out = redact_secret(&input, &secret);
+        prop_assert!(!out.contains(&secret));
+    }
+}
+```
+
+### Python — Hypothesis (config bounds invariant)
+
+```python
+from hypothesis import given, strategies as st
+
+# shard_jobs_max <= effective <= jobs_max
+@given(
+    jobs_max=st.integers(min_value=1, max_value=256),
+    shard_jobs_max=st.integers(min_value=1, max_value=256),
+    requested=st.integers(min_value=0, max_value=512),
+)
+def test_effective_jobs_respects_bounds(jobs_max, shard_jobs_max, requested):
+    shard_jobs_max = min(shard_jobs_max, jobs_max)
+    effective = compute_effective_jobs(requested, shard_jobs_max, jobs_max)
+    assert shard_jobs_max <= effective <= jobs_max
+```
+
+### .NET — FsCheck (coverage tally invariants)
+
+```csharp
+using FsCheck;
+using FsCheck.Xunit;
+
+public class CoverageProperties
+{
+    // bundle >= in_scope  AND  scanned + excluded == in_scope
+    [Property]
+    public Property CoverageTallyHolds(PositiveInt inScope, PositiveInt extra, NonNegativeInt excluded)
+    {
+        int in_scope = inScope.Get;
+        int bundle   = in_scope + extra.Get;              // bundle is a superset
+        int exc      = Math.Min(excluded.Get, in_scope);
+        int scanned  = in_scope - exc;
+
+        bool bundleSuperset = bundle >= in_scope;
+        bool tallyBalances  = scanned + exc == in_scope;
+        return (bundleSuperset && tallyBalances).ToProperty();
+    }
+}
+```
+
+### JS/TS — fast-check (telemetry totality / safety)
+
+```ts
+import fc from "fast-check";
+import { recordTelemetry } from "../src/telemetry";
+
+// totality: recordTelemetry never throws and always returns a well-formed event
+test("telemetry is total and safe", () => {
+  fc.assert(
+    fc.property(fc.anything(), fc.string(), (payload, name) => {
+      const event = recordTelemetry(name, payload); // must not throw
+      expect(event.name).toBe(name);
+      expect(typeof event.timestamp).toBe("number");
+      expect(typeof event.dropped).toBe("boolean"); // always a boolean, never undefined
+    }),
+  );
+});
+```
+
+### Java — jqwik (encode/decode round-trip + differential oracle)
+
+```java
+import net.jqwik.api.*;
+
+class ConfigRoundTripProperties {
+
+    // decode(encode(x)) == x  (round-trip)
+    @Property
+    boolean encodeDecodeRoundTrips(@ForAll("configs") Config c) {
+        return Config.decode(Config.encode(c)).equals(c);
+    }
+
+    // oracle/differential: fast parser agrees with reference parser
+    @Property
+    boolean parsersAgree(@ForAll("configText") String text) {
+        return FastParser.parse(text).equals(ReferenceParser.parse(text));
+    }
+
+    @Provide Arbitrary<Config> configs() { return Arbitraries.of(Config.defaults()); }
+    @Provide Arbitrary<String> configText() { return Arbitraries.strings().ofMaxLength(64); }
+}
+```
+
+## Cross-language conformance (oracle in practice)
+
+For amplihack's multi-runtime components, run the *same* generated inputs
+through each language implementation and assert identical outputs. Generate the
+corpus once (with a fixed seed), feed it to every implementation, and diff the
+results. Any divergence is a conformance bug — shrink it to the minimal input.
+
+## Quick quiz
+
+Check your understanding (answers below).
+
+1. A function `normalize_path` is claimed to be safe to call more than once.
+   Which property family proves that, and how do you write it?
+2. You are testing a JSON serializer in TypeScript and want to catch encoding
+   bugs. Which library and which property family fit best?
+3. You can't predict the exact ranking a search function returns, but you know
+   adding a matching document must never *reduce* the number of results. What
+   kind of property is this?
+4. Which stack does **jqwik** target, and which runner does it plug into?
+5. A redaction function must satisfy two rules. Name them and classify each.
+
+<details>
+<summary>Answers</summary>
+
+1. **Idempotence**: assert `normalize_path(normalize_path(p)) == normalize_path(p)`
+   over generated paths.
+2. **fast-check**, using a **round-trip** property: `decode(encode(x)) == x`.
+3. A **metamorphic relation** — you constrain how the output must change, not
+   its exact value.
+4. **Java**, plugged into the **JUnit 5** platform.
+5. **Idempotence** (`redact(redact(x)) == redact(x)`) and a **no-secret-leak
+   invariant** (the output never matches the secret). The first is an
+   idempotence property; the second is a safety invariant.
+
+</details>
+
+## Related Skills
+
+- `tla-plus-expert` — exhaustive model checking of designs (the high-cost leg).
+- `gherkin-expert` — human-readable BDD acceptance scenarios.
+- `test-gap-analyzer` — find *which* code lacks coverage; then add properties here.
+- `smart-test` — run the resulting property tests through the existing runner.

--- a/amplifier-bundle/skills/property-based-testing/tests/run_all_tests.sh
+++ b/amplifier-bundle/skills/property-based-testing/tests/run_all_tests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Run all property-based-testing skill tests
+# Usage: bash amplifier-bundle/skills/property-based-testing/tests/run_all_tests.sh
+#
+# Returns 0 only if ALL test suites pass.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOTAL_FAIL=0
+SUITE_RESULTS=()
+
+run_suite() {
+  local name="$1"
+  local script="$2"
+  echo ""
+  echo "╔═══════════════════════════════════════════════════════╗"
+  echo "  Running: $name"
+  echo "╚═══════════════════════════════════════════════════════╝"
+  echo ""
+
+  if bash "$script" 2>&1; then
+    SUITE_RESULTS+=("  ✅ $name")
+  else
+    SUITE_RESULTS+=("  ❌ $name")
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+  fi
+}
+
+run_suite "Skill Structure" "$SCRIPT_DIR/test_skill_structure.sh"
+
+echo ""
+echo "╔═══════════════════════════════════════════════════════╗"
+echo "  OVERALL RESULTS"
+echo "╠═══════════════════════════════════════════════════════╣"
+for result in "${SUITE_RESULTS[@]}"; do
+  echo "$result"
+done
+echo "╚═══════════════════════════════════════════════════════╝"
+
+if [[ "$TOTAL_FAIL" -gt 0 ]]; then
+  echo ""
+  echo "❌ $TOTAL_FAIL suite(s) FAILED"
+  exit 1
+else
+  echo ""
+  echo "✅ All suites passed"
+  exit 0
+fi

--- a/amplifier-bundle/skills/property-based-testing/tests/test_skill_structure.sh
+++ b/amplifier-bundle/skills/property-based-testing/tests/test_skill_structure.sh
@@ -61,7 +61,7 @@ else
   fail "frontmatter: first line should be '---', got '$FIRST_LINE'"
 fi
 
-DELIM_COUNT=$(grep -c "^---$" "$SKILL_FILE" || true)
+DELIM_COUNT=$(grep -c "^---$" "$SKILL_FILE" || echo 0)
 if [[ "$DELIM_COUNT" -ge 2 ]]; then
   pass "frontmatter has closing --- delimiter ($DELIM_COUNT found)"
 else
@@ -175,7 +175,7 @@ for issue_prop in "redact(redact" "no-secret-leak" "shard_jobs_max" "coverage ta
 done
 
 # Fenced code blocks must exist for examples (need >= 5, one per stack).
-FENCE_COUNT=$(grep -c '^```' "$SKILL_FILE" || true)
+FENCE_COUNT=$(grep -c '^```' "$SKILL_FILE" || echo 0)
 if [[ "$FENCE_COUNT" -ge 10 ]]; then
   pass "has >=5 fenced code blocks ($((FENCE_COUNT/2)) blocks)"
 else
@@ -193,7 +193,7 @@ else
   fail "missing quiz/self-test section"
 fi
 
-QUIZ_QUESTIONS=$(grep -cE "^[0-9]+\." "$SKILL_FILE" || true)
+QUIZ_QUESTIONS=$(grep -cE "^[0-9]+\." "$SKILL_FILE" || echo 0)
 if [[ "$QUIZ_QUESTIONS" -ge 3 ]]; then
   pass "quiz has >=3 numbered questions ($QUIZ_QUESTIONS numbered items)"
 else

--- a/amplifier-bundle/skills/property-based-testing/tests/test_skill_structure.sh
+++ b/amplifier-bundle/skills/property-based-testing/tests/test_skill_structure.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Tests for property-based-testing skill — structural validation
+# Run: bash amplifier-bundle/skills/property-based-testing/tests/test_skill_structure.sh
+#
+# Validates SKILL.md frontmatter, required sections, per-language examples,
+# quiz, no-secret-leak, and reciprocal cross-references from sibling skills.
+# Follows the code-philosophy test pattern. Self-contained; no deps beyond
+# coreutils + grep. These tests define the contract for the skill deliverable
+# and MUST fail before the skill is authored (TDD).
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+SKILL_FILE="$SKILL_DIR/SKILL.md"
+SKILLS_ROOT="$(cd "$SKILL_DIR/.." && pwd)"
+
+echo "═══════════════════════════════════════════════════════"
+echo "  Test Suite: property-based-testing skill — Structure"
+echo "═══════════════════════════════════════════════════════"
+
+# ─── Test 1: Required files exist ────────────────────────────────────────────
+
+echo ""
+echo "Test 1: Required files exist"
+
+if [[ -f "$SKILL_FILE" ]]; then
+  pass "SKILL.md exists"
+else
+  fail "SKILL.md not found at $SKILL_FILE"
+  echo "  (Cannot run remaining tests without SKILL.md)"
+  echo ""
+  echo "═══════════════════════════"
+  echo "Results: $PASS passed, $FAIL failed"
+  echo "═══════════════════════════"
+  exit 1
+fi
+
+# ─── Test 2: YAML frontmatter — required fields ─────────────────────────────
+
+echo ""
+echo "Test 2: YAML frontmatter — required fields"
+
+FIRST_LINE=$(head -1 "$SKILL_FILE")
+if [[ "$FIRST_LINE" == "---" ]]; then
+  pass "frontmatter starts with --- delimiter"
+else
+  fail "frontmatter: first line should be '---', got '$FIRST_LINE'"
+fi
+
+DELIM_COUNT=$(grep -c "^---$" "$SKILL_FILE" || true)
+if [[ "$DELIM_COUNT" -ge 2 ]]; then
+  pass "frontmatter has closing --- delimiter ($DELIM_COUNT found)"
+else
+  fail "frontmatter missing closing --- delimiter (only $DELIM_COUNT found)"
+fi
+
+FRONTMATTER=$(sed -n '/^---$/,/^---$/p' "$SKILL_FILE")
+
+if echo "$FRONTMATTER" | grep -q "^name: property-based-testing"; then
+  pass "frontmatter name is 'property-based-testing'"
+else
+  fail "frontmatter name must be exactly 'property-based-testing'"
+fi
+
+if echo "$FRONTMATTER" | grep -q "^version:"; then
+  pass "frontmatter has version field"
+else
+  fail "frontmatter missing version field"
+fi
+
+if echo "$FRONTMATTER" | grep -q "^description:"; then
+  pass "frontmatter has description field"
+else
+  fail "frontmatter missing description field"
+fi
+
+if echo "$FRONTMATTER" | grep -qE "^auto_activates:"; then
+  pass "frontmatter has auto_activates field"
+else
+  fail "frontmatter missing auto_activates field"
+fi
+
+# ─── Test 3: Positioning vs the formal-methods triad ────────────────────────
+
+echo ""
+echo "Test 3: Positions PBT vs example tests, Gherkin, TLA+"
+
+for term in "example" "Gherkin" "TLA+"; do
+  if grep -qi -- "$term" "$SKILL_FILE"; then
+    pass "mentions '$term' for positioning"
+  else
+    fail "should position PBT relative to '$term'"
+  fi
+done
+
+# ─── Test 4: Per-stack library selection ────────────────────────────────────
+
+echo ""
+echo "Test 4: Per-stack library selection table"
+
+for lib in "proptest" "quickcheck" "Hypothesis" "FsCheck" "CsCheck" "fast-check" "jqwik"; do
+  if grep -qi -- "$lib" "$SKILL_FILE"; then
+    pass "recommends library '$lib'"
+  else
+    fail "missing library recommendation '$lib'"
+  fi
+done
+
+# ─── Test 5: Property families are enumerated ───────────────────────────────
+
+echo ""
+echo "Test 5: Property families enumerated"
+
+for family in "invariant" "round-trip" "idempoten" "commutativ" "oracle" "differential" "metamorphic"; do
+  if grep -qi -- "$family" "$SKILL_FILE"; then
+    pass "covers property family matching '$family'"
+  else
+    fail "missing property family '$family'"
+  fi
+done
+
+# ─── Test 6: Shrinking, seeding, runner integration ─────────────────────────
+
+echo ""
+echo "Test 6: Shrinking, seeding, existing-runner integration"
+
+for concept in "shrink" "seed" "runner"; do
+  if grep -qi -- "$concept" "$SKILL_FILE"; then
+    pass "discusses '$concept'"
+  else
+    fail "should discuss '$concept'"
+  fi
+done
+
+# ─── Test 7: Per-language worked examples present ───────────────────────────
+
+echo ""
+echo "Test 7: Worked examples for all five stacks"
+
+for lang in "Rust" "Python" ".NET" "JS/TS" "Java"; do
+  if grep -qi -- "$lang" "$SKILL_FILE"; then
+    pass "has example section for '$lang'"
+  else
+    fail "missing example section for '$lang'"
+  fi
+done
+
+# Concrete property families from the issue must appear as worked examples.
+for issue_prop in "redact(redact" "no-secret-leak" "shard_jobs_max" "coverage tally" "telemetry"; do
+  if grep -qi -- "$issue_prop" "$SKILL_FILE"; then
+    pass "worked example references issue property '$issue_prop'"
+  else
+    fail "missing issue property example '$issue_prop'"
+  fi
+done
+
+# Fenced code blocks must exist for examples (need >= 5, one per stack).
+FENCE_COUNT=$(grep -c '^```' "$SKILL_FILE" || true)
+if [[ "$FENCE_COUNT" -ge 10 ]]; then
+  pass "has >=5 fenced code blocks ($((FENCE_COUNT/2)) blocks)"
+else
+  fail "expected >=5 fenced code blocks, found $((FENCE_COUNT/2))"
+fi
+
+# ─── Test 8: Quiz present ────────────────────────────────────────────────────
+
+echo ""
+echo "Test 8: Short quiz/tests section"
+
+if grep -qiE "^#{2,3} .*(quiz|check your understanding|self-test)" "$SKILL_FILE"; then
+  pass "has a quiz section"
+else
+  fail "missing quiz/self-test section"
+fi
+
+QUIZ_QUESTIONS=$(grep -cE "^[0-9]+\." "$SKILL_FILE" || true)
+if [[ "$QUIZ_QUESTIONS" -ge 3 ]]; then
+  pass "quiz has >=3 numbered questions ($QUIZ_QUESTIONS numbered items)"
+else
+  fail "quiz should have >=3 numbered questions (found $QUIZ_QUESTIONS)"
+fi
+
+# ─── Test 9: Reciprocal cross-references ────────────────────────────────────
+
+echo ""
+echo "Test 9: Cross-references wired both directions"
+
+# This skill references the four sibling skills.
+for sib in "tla-plus-expert" "gherkin-expert" "smart-test" "test-gap-analyzer"; do
+  if grep -q -- "$sib" "$SKILL_FILE"; then
+    pass "SKILL.md references sibling '$sib'"
+  else
+    fail "SKILL.md should reference sibling '$sib'"
+  fi
+done
+
+# The four sibling skills reference this skill back.
+for sib in "tla-plus-expert" "gherkin-expert" "smart-test" "test-gap-analyzer"; do
+  sib_file="$SKILLS_ROOT/$sib/SKILL.md"
+  if [[ -f "$sib_file" ]] && grep -q "property-based-testing" "$sib_file"; then
+    pass "'$sib' reciprocally references property-based-testing"
+  else
+    fail "'$sib' must reference property-based-testing"
+  fi
+done
+
+# ─── Test 10: No leaked secrets ─────────────────────────────────────────────
+
+echo ""
+echo "Test 10: No leaked secrets in skill content"
+
+# Guard against real credential-looking tokens. Synthetic placeholders used in
+# the redaction example (e.g. a literal 'SECRET-1234' fixture) are fine; real
+# AWS-style keys or PEM blocks are not.
+if grep -qE "AKIA[0-9A-Z]{16}" "$SKILL_FILE"; then
+  fail "contains an AWS-access-key-shaped token"
+else
+  pass "no AWS-access-key-shaped tokens"
+fi
+
+if grep -q "BEGIN RSA PRIVATE KEY" "$SKILL_FILE"; then
+  fail "contains a PEM private key block"
+else
+  pass "no PEM private key blocks"
+fi
+
+# ─── Results ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "═══════════════════════════════════════════════════════"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/amplifier-bundle/skills/property-based-testing/tests/test_skill_structure.sh
+++ b/amplifier-bundle/skills/property-based-testing/tests/test_skill_structure.sh
@@ -42,6 +42,13 @@ else
   exit 1
 fi
 
+README_FILE="$SKILL_DIR/README.md"
+if [[ -f "$README_FILE" ]]; then
+  pass "README.md exists"
+else
+  fail "README.md not found at $README_FILE"
+fi
+
 # ─── Test 2: YAML frontmatter — required fields ─────────────────────────────
 
 echo ""
@@ -85,6 +92,12 @@ if echo "$FRONTMATTER" | grep -qE "^auto_activates:"; then
   pass "frontmatter has auto_activates field"
 else
   fail "frontmatter missing auto_activates field"
+fi
+
+if echo "$FRONTMATTER" | grep -qE "^explicit_triggers:"; then
+  pass "frontmatter has explicit_triggers field"
+else
+  fail "frontmatter missing explicit_triggers field (required by convention)"
 fi
 
 # ─── Test 3: Positioning vs the formal-methods triad ────────────────────────
@@ -229,6 +242,40 @@ if grep -q "BEGIN RSA PRIVATE KEY" "$SKILL_FILE"; then
   fail "contains a PEM private key block"
 else
   pass "no PEM private key blocks"
+fi
+
+# ─── Test 11: README consistency with SKILL.md ──────────────────────────────
+
+echo ""
+echo "Test 11: README.md stays consistent with SKILL.md"
+
+if [[ -f "$README_FILE" ]]; then
+  # README must link to the canonical SKILL.md so readers reach runnable snippets.
+  if grep -q "SKILL.md" "$README_FILE"; then
+    pass "README links to SKILL.md"
+  else
+    fail "README should link to SKILL.md"
+  fi
+
+  # README must list every stack's library so its table can't drift from SKILL.md.
+  for lib in "proptest" "quickcheck" "Hypothesis" "FsCheck" "CsCheck" "fast-check" "jqwik"; do
+    if grep -qi -- "$lib" "$README_FILE"; then
+      pass "README mentions library '$lib'"
+    else
+      fail "README missing library '$lib' (drift from SKILL.md)"
+    fi
+  done
+
+  # README must reciprocally reference all four sibling skills, like SKILL.md.
+  for sib in "tla-plus-expert" "gherkin-expert" "smart-test" "test-gap-analyzer"; do
+    if grep -q -- "$sib" "$README_FILE"; then
+      pass "README references sibling '$sib'"
+    else
+      fail "README should reference sibling '$sib'"
+    fi
+  done
+else
+  fail "README.md not found; cannot check consistency"
 fi
 
 # ─── Results ─────────────────────────────────────────────────────────────────

--- a/amplifier-bundle/skills/smart-test/SKILL.md
+++ b/amplifier-bundle/skills/smart-test/SKILL.md
@@ -359,6 +359,7 @@ Works with existing pytest markers from pyproject.toml:
 ## Complementary Skills
 
 - **test-gap-analyzer**: Identifies missing tests
+- **property-based-testing**: Generates property/invariant tests (proptest, Hypothesis, fast-check, jqwik) whose commands plug into the tiers selected here
 - **qa-team**: Creates E2E and parity test scenarios (`outside-in-testing` alias supported)
 - **tester agent**: Writes new tests for gaps
 - **pre-commit-diagnostic**: Fixes pre-commit failures

--- a/amplifier-bundle/skills/test-gap-analyzer/SKILL.md
+++ b/amplifier-bundle/skills/test-gap-analyzer/SKILL.md
@@ -560,6 +560,12 @@ Result after implementing:
 - Improved confidence in refactoring
 ```
 
+## Complementary Skills
+
+- **property-based-testing**: Once gaps are found, cover them with generative
+  property/metamorphic tests (invariants, round-trips) rather than only examples.
+- **smart-test**: Runs the resulting tests through the existing test runner.
+
 ## Next Steps
 
 After gap analysis:

--- a/amplifier-bundle/skills/tla-plus-expert/SKILL.md
+++ b/amplifier-bundle/skills/tla-plus-expert/SKILL.md
@@ -83,3 +83,13 @@ TLA+ specs live in `experiments/hive_mind/tla_prompt_language/specs/`.
 - Experiment runner: `crates/amplihack-eval/src/tla_prompt_experiment.rs`
 - TLC binary: `/usr/local/bin/tlc` (if installed)
 - Issue #3939: TLA+ integration roadmap
+
+## Related Skills
+
+- **property-based-testing**: The executable counterpart in the formal-methods
+  triad. Where TLA+ model-checks an abstract design, property-based-testing
+  exercises the concrete implementation against invariants/round-trip/oracle
+  properties. Use TLA+ to prove the design; use property-based-testing to check
+  the code matches it.
+- **gherkin-expert**: Specifies example-driven behavior; complements the
+  exhaustive design coverage TLA+ provides.


### PR DESCRIPTION
Closes #1048.

Adds a language-agnostic `property-based-testing` skill — the third leg of the formal-methods triad alongside `tla-plus-expert` (model checking) and `gherkin-expert` (BDD).

## What's included
- `amplifier-bundle/skills/property-based-testing/SKILL.md` — frontmatter + guidance: where it fits, picking the library per stack (proptest/quickcheck for Rust, Hypothesis for Python, FsCheck/CsCheck for .NET, fast-check for JS/TS, jqwik for Java), finding good properties (invariants, round-trips, idempotence, commutativity, oracle/differential, metamorphic), shrinking/seeding/reproducibility, wiring into the existing test runner.
- Worked examples in all five languages, using the concrete property families from the issue: redaction idempotence + no-secret-leak, config bounds, coverage tally invariants, telemetry totality/safety, encode/decode round-trip + differential oracle.
- A short quiz with answers, plus a README and a self-test suite (`tests/`, 64 checks, all passing).
- Cross-references added from the formal-methods skills (tla-plus-expert, gherkin-expert) and the testing skills (smart-test, test-gap-analyzer).

## Notes
- Documentation/skill only — no Rust code, no registry entry (skill listing is derived from the directory).
- Acceptance criteria (#1048): new skill dir with SKILL.md + per-language examples + quiz; cross-referenced from formal-methods and testing skills. ✓

Skill self-tests: `bash amplifier-bundle/skills/property-based-testing/tests/run_all_tests.sh` → 64 passed, 0 failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd