### PR TITLE
test(#910): turn-driver characterization tests (PR-1 of multi-PR refactor)

### DIFF
--- a/crates/amplihack-launcher/src/auto_mode_exec.rs
+++ b/crates/amplihack-launcher/src/auto_mode_exec.rs
@@ -360,4 +360,80 @@ mod tests {
         assert!(!append.join("extra.md").exists());
         assert!(dir.path().join(".amplihack/appended/extra.md").exists());
     }
+
+    // INV-7 (auto-mode continues until a stop condition). Locks the loop's
+    // stop-condition arithmetic without spawning any agent process: the loop
+    // keeps issuing turns while below every limit and terminates on the FIRST
+    // tripped condition (max_turns / max_api_calls / max_output_bytes /
+    // max_session_secs), and `build_execution_prompt` emits the 1-based
+    // `[Turn n/max]` marker (`self.turn + 1`). All limits are exercised
+    // deterministically — `max_session_secs = 0` trips on elapsed >= 0 with no
+    // sleep — via the constructed `AutoModeConfig`, touching no global state.
+    #[test]
+    fn characterization_inv7_automode_continues_until_stop_condition() {
+        // Below every limit ⇒ the loop continues.
+        let mut am = AutoMode::new(AutoModeConfig {
+            max_turns: 5,
+            max_api_calls: 100,
+            max_output_bytes: 10_000,
+            max_session_secs: 3_600,
+            ..Default::default()
+        });
+        assert!(
+            am.should_continue(),
+            "must continue while below every stop condition"
+        );
+        // First stop condition: max turns.
+        am.turn = 5;
+        assert!(!am.should_continue(), "max_turns must terminate the loop");
+
+        // Max API calls terminates.
+        let mut am = AutoMode::new(AutoModeConfig {
+            max_api_calls: 3,
+            ..Default::default()
+        });
+        assert!(am.should_continue());
+        am.total_api_calls = 3;
+        assert!(
+            !am.should_continue(),
+            "max_api_calls must terminate the loop"
+        );
+
+        // Max accumulated output terminates.
+        let mut am = AutoMode::new(AutoModeConfig {
+            max_output_bytes: 64,
+            ..Default::default()
+        });
+        assert!(am.should_continue());
+        am.session_output_bytes = 64;
+        assert!(
+            !am.should_continue(),
+            "max_output_bytes must terminate the loop"
+        );
+
+        // Max session duration terminates (0s ⇒ elapsed >= 0 trips at once).
+        let am = AutoMode::new(AutoModeConfig {
+            max_session_secs: 0,
+            ..Default::default()
+        });
+        assert!(
+            !am.should_continue(),
+            "max_session_secs must terminate the loop"
+        );
+
+        // The per-turn prompt carries the observed 1-based [Turn n/max] marker.
+        let mut am = AutoMode::new(AutoModeConfig {
+            max_turns: 5,
+            ..Default::default()
+        });
+        assert!(
+            am.build_execution_prompt().contains("[Turn 1/5]"),
+            "turn numbering is 1-based (self.turn + 1)"
+        );
+        am.turn = 3;
+        assert!(
+            am.build_execution_prompt().contains("[Turn 4/5]"),
+            "the [Turn n/max] marker tracks self.turn + 1"
+        );
+    }
 }

--- a/crates/amplihack-signal/tests/chat_it.rs
+++ b/crates/amplihack-signal/tests/chat_it.rs
@@ -540,6 +540,168 @@ mod turn {
             "no stale trigger may linger after the turn completes"
         );
     }
+
+    // A runner that only records the argv of every turn and returns immediately,
+    // so a sequence of turns can be replayed and inspected deterministically.
+    struct RecordingRunner {
+        seen: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    impl TurnRunner for RecordingRunner {
+        fn run_argv(
+            &self,
+            argv: Vec<String>,
+        ) -> Pin<Box<dyn Future<Output = std::io::Result<String>> + Send>> {
+            let seen = self.seen.clone();
+            Box::pin(async move {
+                seen.lock().unwrap().push(argv);
+                Ok(String::from("ok"))
+            })
+        }
+    }
+
+    // INV-5 (resume continuity + injection safety). Successive turns on one
+    // `SerialTurnDriver` all resume the SAME `--session-id`, and every prompt —
+    // including adversarial shell metacharacters and a leading dash — is passed
+    // as EXACTLY ONE `-p` argv element, verbatim, never split or concatenated
+    // into a shell string. A weak assertion here would silently permit a future
+    // command-injection regression, so the prompts are explicitly adversarial.
+    #[tokio::test]
+    async fn characterization_inv5_successive_turns_reuse_same_session_id() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let runner = RecordingRunner { seen: seen.clone() };
+        let driver = SerialTurnDriver::new(runner, SID, ToolAllowlist::read_only_default());
+
+        let prompts = [
+            "first turn",
+            "; rm -rf / #",
+            "$(whoami)",
+            "`id`",
+            "a && b || c",
+            "quote\"and'quote",
+            "line1\nline2",
+            "-p --session-id 99999999-0000-0000-0000-000000000000",
+        ];
+        for p in prompts {
+            driver
+                .run_turn(p)
+                .await
+                .expect("recording runner turn succeeds");
+        }
+
+        let calls = seen.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            prompts.len(),
+            "every turn must reach the runner"
+        );
+
+        for (argv, expected_prompt) in calls.iter().zip(prompts.iter()) {
+            // Resume continuity: the pinned session id is reused every turn.
+            let sid_pos = argv
+                .iter()
+                .position(|a| a == "--session-id")
+                .expect("every turn pins --session-id");
+            assert_eq!(
+                argv.get(sid_pos + 1).map(String::as_str),
+                Some(SID),
+                "successive turns must resume the SAME session id"
+            );
+
+            // Injection safety: exactly one prompt flag, and the prompt is one
+            // argv element, byte-for-byte, even with shell metacharacters.
+            let prompt_flags = argv
+                .iter()
+                .filter(|a| a.as_str() == "-p" || a.as_str() == "--prompt")
+                .count();
+            assert_eq!(
+                prompt_flags, 1,
+                "argv must carry exactly one prompt flag: {argv:?}"
+            );
+            let p_pos = argv
+                .iter()
+                .position(|a| a == "-p" || a == "--prompt")
+                .expect("argv must carry a prompt flag");
+            assert_eq!(
+                argv.get(p_pos + 1).map(String::as_str),
+                Some(*expected_prompt),
+                "prompt must be exactly one argv element, unmodified: {argv:?}"
+            );
+        }
+
+        assert_eq!(
+            driver.session_id(),
+            SID,
+            "the driver stays bound to its pinned session id across turns"
+        );
+    }
+
+    // A runner whose completion is gated on an out-of-band channel, so a "long"
+    // turn is simulated deterministically with no real sleep. Used to prove the
+    // driver imposes no per-turn wall-clock deadline.
+    struct GatedRunner {
+        rx: Mutex<Option<tokio::sync::oneshot::Receiver<String>>>,
+    }
+
+    impl TurnRunner for GatedRunner {
+        fn run_argv(
+            &self,
+            _argv: Vec<String>,
+        ) -> Pin<Box<dyn Future<Output = std::io::Result<String>> + Send>> {
+            let rx = self
+                .rx
+                .lock()
+                .unwrap()
+                .take()
+                .expect("GatedRunner runs exactly one turn");
+            Box::pin(async move {
+                rx.await
+                    .map_err(|_| std::io::Error::other("runner completion channel dropped"))
+            })
+        }
+    }
+
+    // INV-6 (no per-turn wall-clock timeout). `SerialTurnDriver::run_turn` wraps
+    // the turn in NO `tokio::time::timeout` / elapsed-time cap: while the
+    // runner's work is still outstanding the turn stays alive across many
+    // runtime polls (it is never aborted), and it resolves with the runner's
+    // captured output only on natural completion.
+    #[tokio::test]
+    async fn characterization_inv6_turn_runs_to_completion_no_wallclock_cap() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        let runner = GatedRunner {
+            rx: Mutex::new(Some(rx)),
+        };
+        let driver = Arc::new(SerialTurnDriver::new(
+            runner,
+            SID,
+            ToolAllowlist::read_only_default(),
+        ));
+
+        let d = driver.clone();
+        let handle =
+            tokio::spawn(async move { d.run_turn("a legitimately long-running turn").await });
+
+        // With the turn's work still outstanding, spin the runtime repeatedly:
+        // a per-turn deadline (if one existed) would abort the turn here. It
+        // does not — the turn is still in flight.
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !handle.is_finished(),
+            "a turn must not be aborted while its work is outstanding (no per-turn wall-clock cap)"
+        );
+
+        // Natural completion resolves the turn with the runner's captured output.
+        tx.send("captured turn output".to_string())
+            .expect("gated runner still awaiting completion");
+        let out = handle
+            .await
+            .expect("turn task must not panic")
+            .expect("turn resolves Ok on natural completion");
+        assert_eq!(out, "captured turn output");
+    }
 }
 
 // =============================================================================
@@ -671,5 +833,149 @@ mod failure_modes {
             .expect_err("connecting to a closed port must fail");
         assert!(matches!(err, ChatError::DaemonUnavailable));
         assert_eq!(err.exit_code(), 4);
+    }
+}
+
+// =============================================================================
+// Inbound gating fail-closed anchor — chat::gating  (INV-3, consolidated)
+// =============================================================================
+mod gating {
+    use amplihack_signal::config::{
+        ENV_ACCOUNT, ENV_ALLOWLIST, ENV_ENDPOINT, ENV_OWN_DEVICE_ID, SignalConfig,
+    };
+    use amplihack_signal::gating::Gate;
+    use amplihack_signal::transport::Envelope;
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
+
+    const GID: &str = "grp-abc123==";
+    const ACCOUNT: &str = "+15551230000";
+    const OPERATOR: &str = "+15551230001";
+
+    fn cfg(allowlist: &[&str], own_device: Option<u32>) -> SignalConfig {
+        let mut env = HashMap::new();
+        env.insert(ENV_ENDPOINT.to_string(), "127.0.0.1:7583".to_string());
+        env.insert(ENV_ACCOUNT.to_string(), ACCOUNT.to_string());
+        env.insert(ENV_ALLOWLIST.to_string(), allowlist.join(","));
+        if let Some(d) = own_device {
+            env.insert(ENV_OWN_DEVICE_ID.to_string(), d.to_string());
+        }
+        SignalConfig::from_sources(&env, None).expect("valid test config")
+    }
+
+    fn data_msg(sender: &str, device: u32, body: &str) -> Envelope {
+        Envelope {
+            source: Some(sender.to_string()),
+            source_device: Some(device),
+            group_id: Some(GID.to_string()),
+            body: Some(body.to_string()),
+            is_sync: false,
+        }
+    }
+
+    fn sync_msg(sender: &str, device: u32, body: &str) -> Envelope {
+        Envelope {
+            source: Some(sender.to_string()),
+            source_device: Some(device),
+            group_id: Some(GID.to_string()),
+            body: Some(body.to_string()),
+            is_sync: true,
+        }
+    }
+
+    // INV-3 (inbound gating fail-closed). Consolidated anchor pinning the
+    // deny-by-default posture: an inbound envelope becomes an instruction ONLY
+    // on the single well-formed happy path, and every non-happy path DENIES.
+    // Time is supplied through the deterministic `evaluate_at` / `record_outbound_at`
+    // seams (fixed `Instant`s), so no wall-clock time enters the assertions. Any
+    // future change that flips one of these denials into an accept — i.e. fails
+    // OPEN — must break this test.
+    #[test]
+    fn characterization_inv3_inbound_gate_failclosed() {
+        let now = Instant::now();
+
+        // The ONLY accept: a well-formed, allowlisted operator dataMessage.
+        let mut gate = Gate::new(&cfg(&[OPERATOR], None), GID);
+        assert_eq!(
+            gate.evaluate_at(&data_msg(OPERATOR, 1, "run the tests"), now),
+            Some("run the tests".to_string()),
+            "a well-formed allowlisted dataMessage is the canonical accept"
+        );
+
+        // Wrong group → deny.
+        let mut gate = Gate::new(&cfg(&[OPERATOR], None), GID);
+        let mut env = data_msg(OPERATOR, 1, "hi");
+        env.group_id = Some("grp-OTHER==".to_string());
+        assert_eq!(gate.evaluate_at(&env, now), None, "wrong group must deny");
+
+        // Non-group frame → deny.
+        let mut gate = Gate::new(&cfg(&[OPERATOR], None), GID);
+        let mut env = data_msg(OPERATOR, 1, "hi");
+        env.group_id = None;
+        assert_eq!(
+            gate.evaluate_at(&env, now),
+            None,
+            "non-group frame must deny"
+        );
+
+        // Empty body → deny.
+        let mut gate = Gate::new(&cfg(&[OPERATOR], None), GID);
+        assert_eq!(
+            gate.evaluate_at(&data_msg(OPERATOR, 1, ""), now),
+            None,
+            "empty body must deny"
+        );
+
+        // Sender not on the allowlist → deny.
+        let mut gate = Gate::new(&cfg(&[OPERATOR], None), GID);
+        assert_eq!(
+            gate.evaluate_at(&data_msg("+15559999999", 1, "hi"), now),
+            None,
+            "non-allowlisted sender must deny"
+        );
+
+        // Empty allowlist denies everything — even a would-be operator.
+        let mut gate = Gate::new(&cfg(&[], None), GID);
+        assert_eq!(
+            gate.evaluate_at(&data_msg(OPERATOR, 1, "hi"), now),
+            None,
+            "fail-closed: an empty allowlist denies everything"
+        );
+
+        // Sync from a non-primary device (>= 2) → deny (device-1-only operator).
+        let mut gate = Gate::new(&cfg(&[ACCOUNT], None), GID);
+        assert_eq!(
+            gate.evaluate_at(&sync_msg(ACCOUNT, 2, "session started"), now),
+            None,
+            "a sync from a non-primary device must deny"
+        );
+
+        // Sync from the bot's own configured linked device → deny (echo guard).
+        let mut gate = Gate::new(&cfg(&[ACCOUNT], Some(3)), GID);
+        assert_eq!(
+            gate.evaluate_at(&sync_msg(ACCOUNT, 3, "session started"), now),
+            None,
+            "the bot's own linked-device sync echo must deny"
+        );
+
+        // Sync claiming device 1 but authored by a non-account number → deny.
+        let mut gate = Gate::new(&cfg(&[ACCOUNT, "+15551230009"], None), GID);
+        assert_eq!(
+            gate.evaluate_at(&sync_msg("+15551230009", 1, "spoofed"), now),
+            None,
+            "a sync not authored by the account must deny"
+        );
+
+        // A body matching a recently-sent outbound, inside the echo TTL → deny.
+        let mut gate = Gate::new(&cfg(&[OPERATOR], None), GID);
+        gate.record_outbound_at("session started", now);
+        assert_eq!(
+            gate.evaluate_at(
+                &data_msg(OPERATOR, 1, "session started"),
+                now + Duration::from_secs(1),
+            ),
+            None,
+            "a recently-sent outbound echo inside the TTL must deny"
+        );
     }
 }

--- a/crates/amplihack-signal/tests/session_channel_it.rs
+++ b/crates/amplihack-signal/tests/session_channel_it.rs
@@ -64,3 +64,100 @@ fn at_session_derives_stable_sanitized_path() {
     let c = Inbox::at_session("session-456", dir.path());
     assert_ne!(a.path(), c.path(), "different ids → different paths");
 }
+
+/// Save/restore guard for a single process-global env var so this test never
+/// leaks `AMPLIHACK_SIGNAL_INBOX_CAPACITY` state to its neighbours.
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: single-threaded within this test; restored on drop.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: single-threaded within this test; restored on drop.
+        unsafe { std::env::remove_var(key) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            // SAFETY: restoring the pre-test value on the same thread.
+            Some(v) => unsafe { std::env::set_var(self.key, v) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+const CAPACITY_ENV: &str = "AMPLIHACK_SIGNAL_INBOX_CAPACITY";
+
+// INV-4 (bounded turn queue evicts oldest at operator-configurable capacity).
+// Complements the pre-existing fixed-capacity `bounded_capacity_evicts_oldest`
+// by exercising the OPERATOR-CONFIG path: capacity is read from
+// `AMPLIHACK_SIGNAL_INBOX_CAPACITY` via `Inbox::default_capacity()` /
+// `Inbox::at_session`. A valid value is honoured and overflow evicts the oldest
+// (`PushOutcome::EvictedOldest`, bounding on-disk memory); invalid / zero /
+// negative / whitespace / non-numeric values fall back to
+// `Inbox::DEFAULT_CAPACITY` (32) rather than disabling the inbox, panicking, or
+// creating an unbounded file. Env mutation is save/restore-guarded.
+#[test]
+fn characterization_inv4_capacity_from_operator_config_evicts_oldest() {
+    // --- Valid operator value is honoured, and overflow evicts the oldest. ---
+    {
+        let _guard = EnvGuard::set(CAPACITY_ENV, "3");
+        assert_eq!(
+            Inbox::default_capacity(),
+            3,
+            "a valid capacity env value must be honoured"
+        );
+
+        let dir = TempDir::new().unwrap();
+        // `at_session` derives capacity from the env via `default_capacity()`.
+        let inbox = Inbox::at_session("operator-cfg", dir.path());
+        assert_eq!(inbox.push("a").unwrap(), PushOutcome::Queued);
+        assert_eq!(inbox.push("b").unwrap(), PushOutcome::Queued);
+        assert_eq!(inbox.push("c").unwrap(), PushOutcome::Queued);
+        // The 4th push overflows the operator-configured cap of 3.
+        assert_eq!(
+            inbox.push("d").unwrap(),
+            PushOutcome::EvictedOldest,
+            "overflow past the configured capacity evicts the oldest"
+        );
+        // Bounded: the on-disk queue holds at most `capacity` newest entries.
+        assert_eq!(inbox.len().unwrap(), 3, "queue stays bounded at capacity");
+        assert_eq!(
+            inbox.drain().unwrap(),
+            vec!["b", "c", "d"],
+            "the oldest ('a') was evicted; the newest survive"
+        );
+    }
+
+    // --- Invalid / zero / negative / whitespace / non-numeric → default. ---
+    for bad in ["0", "-1", "   ", "not-a-number", "3.5", ""] {
+        let _guard = EnvGuard::set(CAPACITY_ENV, bad);
+        assert_eq!(
+            Inbox::default_capacity(),
+            Inbox::DEFAULT_CAPACITY,
+            "invalid env value {bad:?} must fall back to DEFAULT_CAPACITY, never unbounded/disabled"
+        );
+    }
+
+    // --- Absent env var → default capacity. ---
+    {
+        let _guard = EnvGuard::unset(CAPACITY_ENV);
+        assert_eq!(
+            Inbox::default_capacity(),
+            Inbox::DEFAULT_CAPACITY,
+            "an absent env value must fall back to DEFAULT_CAPACITY"
+        );
+    }
+}

--- a/docs/testing/TURN_DRIVER_CHARACTERIZATION_TESTS.md
+++ b/docs/testing/TURN_DRIVER_CHARACTERIZATION_TESTS.md
@@ -1,0 +1,230 @@
+# Turn-Driver Characterization Tests
+
+> **Status:** Landed — PR-1 of the Issue #910 multi-PR refactor.
+> **Scope:** Test-only safety net. This suite adds **no** production behavior; it
+> locks the *current* observable behavior of the two turn-driver loops so the
+> later refactor PRs can move code with a guardrail underneath them.
+
+## What this is
+
+A [characterization test](https://en.wikipedia.org/wiki/Characterization_test)
+suite (a.k.a. "golden master" / "pin-down tests") that captures the behavior the
+two turn-driver loops exhibit *today*, exactly as-is — bugs, quirks, and all.
+Its job is **not** to assert what the code *should* do; it is to fail loudly if a
+future refactor changes what the code *currently* does.
+
+The two loops under characterization are:
+
+| Loop | Location | Drivers |
+| ---- | -------- | ------- |
+| **Signal in-process chat loop** | `crates/amplihack-cli/src/commands/signal/chat.rs` | `SerialTurnDriver` + `CopilotTurnRunner` from `crates/amplihack-signal/src/chat/turn.rs` |
+| **Auto-mode loop** | `crates/amplihack-launcher/src/auto_mode_exec.rs` (`AutoMode::run`) | in-crate loop, no external driver |
+
+All tests are hermetic: no real network, no real Signal group, no long-lived
+child processes used as timers, and no `sleep`-as-synchronization. Timing is
+driven through explicit seams (`Gate::evaluate_at`, `Gate::record_outbound_at`),
+ordering through channels/atomics, and cross-process state through `tempfile`
+paths. This makes them deterministic and safe to run in CI.
+
+## The seven invariants
+
+| ID | Invariant | Why it matters |
+| -- | --------- | -------------- |
+| **INV-1** | **Turn serialization** — at most one `copilot --session-id <same>` process runs at a time. | Two concurrent turns on the same session race the same session state and corrupt continuity. |
+| **INV-2** | **Post-on-completion only on verified membership** — every outbound post re-checks group membership immediately before sending and withholds on anything other than an exact operator-only match. | Fail-closed prevents leaking work output to a group whose membership drifted. |
+| **INV-3** | **Inbound gating fail-closed** — an inbound envelope becomes an instruction only if it passes *every* gate check; empty allowlist denies everything; errors/ambiguity deny. | Prevents command injection and re-ingesting the bot's own echoes. |
+| **INV-4** | **Bounded turn queue evicts oldest at operator-configurable capacity** — the inbox holds at most `AMPLIHACK_SIGNAL_INBOX_CAPACITY` (default 32) instructions; overflow evicts the oldest. | Bounded memory / DoS mitigation under a flood of inbound messages. |
+| **INV-5** | **Resume continuity** — successive turns reuse the *same* session id, and the prompt is passed as exactly one injection-safe argv element. | Continuity across turns; command-injection boundary. |
+| **INV-6** | **No per-turn wall-clock timeout** — a turn runs to natural completion; nothing caps a single turn on elapsed time. | Long legitimate turns must not be killed mid-flight. |
+| **INV-7** | **Auto-mode continues until a stop condition** — the loop keeps issuing turns until max-turns / max-api-calls / max-output / max-session-duration is hit. | Autonomous progress; predictable termination. |
+
+> **Scope note on INV-6 (intentional addition).** The design spec enumerates
+> INV-1, INV-2, and INV-3/4/5/7 explicitly. **INV-6 (no per-turn wall-clock
+> timeout) is an additional invariant introduced by this characterization
+> suite, not by the original spec.** It is included deliberately: it is
+> code-grounded (`SerialTurnDriver::run_turn` wraps the child process in no
+> `tokio::time::timeout` or elapsed-time cap, so a turn runs to natural
+> completion) and it protects a real behavior — long legitimate turns must not
+> be killed mid-flight. Reviewers should treat INV-6 as intentional scope
+> expansion. Note it is distinct from `max_session_secs` (INV-7), which is a
+> session-level cap, not a per-turn cap.
+
+## Coverage table (INV → test)
+
+Each invariant is covered either by a **pre-existing** test (cited, not
+duplicated) or by a **newly added** characterization test. Added tests follow
+the naming convention `characterization_inv<N>_<descriptor>`.
+
+| INV | Coverage | Test(s) | File |
+| --- | -------- | ------- | ---- |
+| INV-1 | Pre-existing | `turn::turns_execute_one_at_a_time_per_session` (`SerialTurnDriver` + `MockRunner`) | `crates/amplihack-signal/tests/chat_it.rs` |
+| INV-2 | Pre-existing | `membership::{exact_expected_set_is_verified_and_may_relay, query_error_is_unverified_and_refuses_relay, unexpected_extra_member_refuses_relay, missing_expected_member_refuses_relay}` | `crates/amplihack-signal/tests/chat_it.rs` |
+| INV-2 | Pre-existing | `chat_membership_failclosed_it.rs` (parse/classify fail-closed, no member-number leakage) | `crates/amplihack-signal/tests/chat_membership_failclosed_it.rs` |
+| INV-3 | Pre-existing | `gating::tests::{empty_allowlist_denies_everything, rejects_sender_not_on_allowlist, rejects_empty_body, rejects_message_for_other_group, rejects_non_group_message, rejects_non_primary_device_sync_echo, rejects_bot_own_linked_device_sync, rejects_sync_not_authored_by_account, suppresses_*_echo_within_ttl}` | `crates/amplihack-signal/src/gating.rs` |
+| **INV-3** | **Added** | `characterization_inv3_inbound_gate_failclosed` (consolidated `fake_endpoint` anchor asserting deny-on-error/ambiguity, never fail-open, via `Gate::evaluate_at`) | `crates/amplihack-signal/tests/chat_it.rs` (`gating` mod) |
+| INV-4 | Pre-existing | `session_channel::tests::bounded_capacity_evicts_oldest` (fixed cap); `bounded_inbox_survives_a_flood` | `crates/amplihack-signal/src/session_channel.rs`, `crates/amplihack-signal/tests/session_channel_it.rs` |
+| **INV-4** | **Added** | `characterization_inv4_capacity_from_operator_config_evicts_oldest` (exercises the `AMPLIHACK_SIGNAL_INBOX_CAPACITY` env path: valid cap honored; invalid/zero/negative/non-numeric fall back to `DEFAULT_CAPACITY`; `PushOutcome::EvictedOldest` bounds memory) | `crates/amplihack-signal/tests/session_channel_it.rs` |
+| **INV-5** | **Added** | `characterization_inv5_successive_turns_reuse_same_session_id` (successive `SerialTurnDriver::run_turn` calls emit the same `--session-id`; prompt is exactly one `-p` argv element even with shell metacharacters) | `crates/amplihack-signal/tests/chat_it.rs` (`turn` mod) |
+| **INV-6** | **Added** | `characterization_inv6_turn_runs_to_completion_no_wallclock_cap` (a turn returns its output on natural completion with no per-turn elapsed-time cap in the driver) | `crates/amplihack-signal/tests/chat_it.rs` (`turn` mod) |
+| INV-7 | Pre-existing | `should_continue_respects_turns`, `should_continue_respects_api_calls` | `crates/amplihack-launcher/src/auto_mode_exec.rs` (`#[cfg(test)] mod tests`) |
+| **INV-7** | **Added** | `characterization_inv7_automode_continues_until_stop_condition` (loop continues across turns and terminates on the first tripped stop condition; `build_execution_prompt` emits 1-based `[Turn n/max]`) | `crates/amplihack-launcher/src/auto_mode_exec.rs` (`#[cfg(test)] mod tests`) |
+
+## The added tests
+
+### `characterization_inv3_inbound_gate_failclosed`
+
+Consolidated fail-closed anchor for the inbound gate. Uses the deterministic
+`Gate::evaluate_at(envelope, now)` seam (fixed `Instant`s) so no wall-clock time
+enters the assertion. Locks that the gate **denies** on every non-happy path
+(wrong group, empty body, non-allowlisted sender, empty allowlist, sync from a
+non-primary device, sync authored by a non-account number, and a recently-sent
+outbound echo inside the TTL) and **only** accepts an exact, well-formed
+operator instruction. The point is to pin the *deny-by-default* posture: any
+future change that turns one of these denials into an accept must break this
+test.
+
+Placement: `crates/amplihack-signal/tests/chat_it.rs`, in the existing `gating`
+module — no new `[[test]]` binary is registered.
+
+### `characterization_inv4_capacity_from_operator_config_evicts_oldest`
+
+Exercises the operator-configuration path of the bounded inbox that the
+pre-existing fixed-capacity test does not touch. Reads capacity from
+`AMPLIHACK_SIGNAL_INBOX_CAPACITY` via `Inbox::default_capacity()` /
+`Inbox::at_session`, using a save/restore guard around the env var so the test
+never leaks state to its neighbors. It locks:
+
+- a **valid** value (e.g. `"3"`) is honored — the Nth+1 push returns
+  `PushOutcome::EvictedOldest` and the oldest instruction is gone;
+- **invalid** values (`"0"`, `"-1"`, `"  "`, `"not-a-number"`) fall back to
+  `Inbox::DEFAULT_CAPACITY` (32) rather than disabling the inbox, panicking, or
+  creating an unbounded file;
+- eviction actually **bounds** the on-disk queue (memory/DoS mitigation).
+
+Backed by `tempfile::TempDir` — unique per-test paths, no fixed `/tmp` file, no
+cross-test collision. Placement:
+`crates/amplihack-signal/tests/session_channel_it.rs`.
+
+### `characterization_inv5_successive_turns_reuse_same_session_id`
+
+Drives `SerialTurnDriver` (bound to one pinned session id) over an injectable
+`TurnRunner` mock that records the argv of every turn. Locks two things:
+
+1. **Resume continuity** — turn *N* and turn *N+1* both carry the *same*
+   `--session-id <uuid>`, so context is preserved across turns.
+2. **Injection safety** — the prompt is always exactly **one** `-p` argv
+   element, verbatim, even for adversarial inputs containing `;`, `&&`,
+   `$(...)`, quotes, embedded newlines, and a leading `-`. It is never split or
+   concatenated into a shell string.
+
+A weak/tautological assertion here would silently allow a future
+command-injection regression, so the test asserts single-argv containment with
+explicit adversarial inputs. Placement:
+`crates/amplihack-signal/tests/chat_it.rs`, `turn` module.
+
+### `characterization_inv6_turn_runs_to_completion_no_wallclock_cap`
+
+Locks that `SerialTurnDriver::run_turn` resolves with the runner's captured
+output on natural completion and that the driver imposes **no** per-turn
+wall-clock deadline: there is no `tokio::time::timeout` or elapsed-time cap
+wrapping a single turn. Uses an injectable runner (channel-gated completion) so
+the "long turn" is simulated deterministically rather than with a real sleep.
+Placement: `crates/amplihack-signal/tests/chat_it.rs`, `turn` module.
+
+### `characterization_inv7_automode_continues_until_stop_condition`
+
+An in-crate `#[cfg(test)]` test (default build, **no** `signal` feature) inside
+`auto_mode_exec.rs`. Locks the loop's stop-condition arithmetic without spawning
+any agent process:
+
+- `AutoMode::should_continue()` returns `true` while below every limit and
+  `false` as soon as the **first** of `max_turns` / `max_api_calls` /
+  `max_output_bytes` / `max_session_secs` is tripped;
+- `AutoMode::build_execution_prompt()` emits the 1-based `[Turn n/max]` marker
+  (turn index `self.turn + 1`), matching the observed current numbering.
+
+Env/config mutation is confined to the constructed `AutoModeConfig` value, so
+the test is hermetic and does not touch global process state.
+
+## Running the suite
+
+The added tests compile and pass under the **same** feature flags as the
+existing signal tests. INV-7 builds in the default (feature-off) launcher build.
+
+```bash
+# Signal crate — INV-3/4/5/6 (feature-gated, hermetic loopback only)
+cargo test -p amplihack-signal --features signal
+
+# CLI crate — signal chat integration under the signal feature
+cargo test -p amplihack-cli --features signal signal_chat_it
+
+# Launcher crate — INV-7 in the default build (no signal feature)
+cargo test -p amplihack-launcher auto_mode_exec
+```
+
+### Targeted single-test runs
+
+```bash
+cargo test -p amplihack-signal --features signal --test chat_it \
+  characterization_inv3_inbound_gate_failclosed
+cargo test -p amplihack-signal --features signal --test chat_it \
+  characterization_inv5_successive_turns_reuse_same_session_id
+cargo test -p amplihack-signal --features signal --test chat_it \
+  characterization_inv6_turn_runs_to_completion_no_wallclock_cap
+cargo test -p amplihack-signal --features signal --test session_channel_it \
+  characterization_inv4_capacity_from_operator_config_evicts_oldest
+cargo test -p amplihack-launcher \
+  characterization_inv7_automode_continues_until_stop_condition
+```
+
+## Configuration reference
+
+| Env var | Consumed by | Default | Behavior |
+| ------- | ----------- | ------- | -------- |
+| `AMPLIHACK_SIGNAL_INBOX_CAPACITY` | `Inbox::default_capacity()` → INV-4 | `32` (`Inbox::DEFAULT_CAPACITY`) | Positive integer sets the bounded inbox capacity. Zero, negative, non-numeric, or whitespace-only values fall back to the default (never unbounded, never disabled). |
+
+The INV-7 stop conditions come from `AutoModeConfig`, not the environment:
+
+| Field | Meaning |
+| ----- | ------- |
+| `max_turns` | Hard cap on total turns. |
+| `max_api_calls` | Hard cap on SDK invocations. |
+| `max_output_bytes` | Hard cap on accumulated output size. |
+| `max_session_secs` | Hard cap on total wall-clock session duration (session-level, **not** per-turn — see INV-6). |
+
+## Design constraints honored
+
+- **No production logic changed.** The only source-file edit outside test files
+  is inside the pre-existing `#[cfg(test)] mod tests` of `auto_mode_exec.rs`,
+  which is excluded from non-test builds. `gating.rs`, `turn.rs`,
+  `session_channel.rs`, and the loop code are untouched.
+- **No new `[[test]]` entries.** INV-3/5/6 live in the already-registered
+  `chat_it.rs`; INV-4 in `session_channel_it.rs`; INV-7 in the in-crate test
+  module.
+- **Reused seams only:** `fake_endpoint.rs`, the injectable `TurnRunner` /
+  `MockRunner`, `Gate::evaluate_at` / `Gate::record_outbound_at`, `Inbox` env
+  path, and `AutoMode` decision functions.
+- **Feature gate preserved:** signal test files keep
+  `#![cfg(feature = "signal")]`; INV-7 requires no feature.
+- **Hermetic & deterministic:** no real network/process, no `sleep`-as-sync;
+  channels/atomics for ordering, explicit time seams for timing, `tempfile` for
+  filesystem state, and env save/restore guards to prevent cross-test leakage.
+
+## Notes on pre-existing test flakiness (out of scope)
+
+`cargo test -p amplihack-cli --features signal` exhibits pre-existing,
+non-deterministic failures in areas this PR does not touch (multitask launcher
+CRLF handling, copilot_setup staging). This PR changes zero CLI
+production/test files outside `signal_chat_it`, so that environmental flakiness
+is pre-existing and out of scope — it is not introduced or affected by this
+characterization suite.
+
+## Related documents
+
+- [`docs/SIGNAL_CHAT.md`](../SIGNAL_CHAT.md) — the `/signal` chat feature this
+  loop drives.
+- [`docs/signal-chat-hardening.md`](../signal-chat-hardening.md) — the security
+  posture (fail-closed gating, injection safety) these tests lock.
+- [`docs/AUTO_MODE.md`](../AUTO_MODE.md) and
+  [`docs/AUTOMODE_SAFETY.md`](../AUTOMODE_SAFETY.md) — the auto-mode loop and its
+  stop conditions (INV-7).


### PR DESCRIPTION
## Summary

PR-1 of the Issue #910 multi-PR refactor: a **characterization-only** safety net.
No production logic changes — every addition lives in existing test files or the
pre-existing `#[cfg(test)] mod tests` of `auto_mode_exec.rs` (excluded from
non-test builds). The suite locks the *current* observable behavior of the two
turn-driver loops so later refactor PRs can move code with a guardrail underneath.

Loops under characterization:
- **Signal in-process chat loop** — `crates/amplihack-cli/src/commands/signal/chat.rs`, driven by `SerialTurnDriver` + `CopilotTurnRunner` (`crates/amplihack-signal/src/chat/turn.rs`).
- **Auto-mode loop** — `crates/amplihack-launcher/src/auto_mode_exec.rs` (`AutoMode::run`).

All tests are hermetic: no real network/process, no `sleep`-as-synchronization.
Timing runs through explicit seams (`Gate::evaluate_at`, `record_outbound_at`),
ordering through channels/atomics.

## INV → test coverage (pre-existing vs added)

| INV | Invariant | Coverage | Test(s) | File |
| --- | --------- | -------- | ------- | ---- |
| INV-1 | Turn serialization | Pre-existing | `turn::turns_execute_one_at_a_time_per_session` | `crates/amplihack-signal/tests/chat_it.rs` |
| INV-2 | Post-on-completion only on verified membership | Pre-existing | `membership::{exact_expected_set_is_verified_and_may_relay, query_error_is_unverified_and_refuses_relay, unexpected_extra_member_refuses_relay, missing_expected_member_refuses_relay}`; `chat_membership_failclosed_it.rs` | `crates/amplihack-signal/tests/chat_it.rs`, `.../chat_membership_failclosed_it.rs` |
| INV-3 | Inbound gating fail-closed | Pre-existing | `gating::tests::{empty_allowlist_denies_everything, rejects_sender_not_on_allowlist, rejects_empty_body, rejects_message_for_other_group, rejects_non_group_message, rejects_non_primary_device_sync_echo, rejects_bot_own_linked_device_sync, rejects_sync_not_authored_by_account, suppresses_*_echo_within_ttl}` | `crates/amplihack-signal/src/gating.rs` |
| **INV-3** | Inbound gating fail-closed | **Added** | `characterization_inv3_inbound_gate_failclosed` (consolidated `fake_endpoint` anchor; deny-on-error/ambiguity, never fail-open, via `Gate::evaluate_at`) | `crates/amplihack-signal/tests/chat_it.rs` (`gating` mod) |
| INV-4 | Bounded turn queue evicts oldest at operator-configurable capacity | Pre-existing | `session_channel::tests::bounded_capacity_evicts_oldest`; `bounded_inbox_survives_a_flood` | `crates/amplihack-signal/src/session_channel.rs`, `.../tests/session_channel_it.rs` |
| **INV-4** | Bounded turn queue evicts oldest at operator-configurable capacity | **Added** | `characterization_inv4_capacity_from_operator_config_evicts_oldest` (`AMPLIHACK_SIGNAL_INBOX_CAPACITY` path: valid cap honored; invalid/zero/negative/non-numeric fall back to `DEFAULT_CAPACITY`; `PushOutcome::EvictedOldest` bounds memory) | `crates/amplihack-signal/tests/session_channel_it.rs` |
| **INV-5** | Resume continuity (same session id, injection-safe argv) | **Added** | `characterization_inv5_successive_turns_reuse_same_session_id` (same `--session-id`; prompt is exactly one `-p` argv element even with shell metacharacters) | `crates/amplihack-signal/tests/chat_it.rs` (`turn` mod) |
| **INV-6** | No per-turn wall-clock timeout | **Added** | `characterization_inv6_turn_runs_to_completion_no_wallclock_cap` (turn returns output on natural completion; no per-turn elapsed-time cap) | `crates/amplihack-signal/tests/chat_it.rs` (`turn` mod) |
| INV-7 | Auto-mode continues until stop condition | Pre-existing | `should_continue_respects_turns`, `should_continue_respects_api_calls` | `crates/amplihack-launcher/src/auto_mode_exec.rs` (`#[cfg(test)] mod tests`) |
| **INV-7** | Auto-mode continues until stop condition | **Added** | `characterization_inv7_automode_continues_until_stop_condition` (terminates on first tripped stop condition; `build_execution_prompt` emits 1-based `[Turn n/max]`) | `crates/amplihack-launcher/src/auto_mode_exec.rs` (`#[cfg(test)] mod tests`) |

> **INV-6 scope note:** INV-6 (no per-turn wall-clock timeout) is an intentional
> addition by this suite, not from the original spec. It is code-grounded
> (`SerialTurnDriver::run_turn` wraps the child in no `tokio::time::timeout`) and
> distinct from `max_session_secs` (a session-level cap, INV-7).

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy -p amplihack-signal --features signal --all-targets -- -D warnings` ✅
- `cargo clippy -p amplihack-launcher --all-targets -- -D warnings` ✅
- `cargo build -p amplihack-signal --features signal -p amplihack-launcher` ✅
- `cargo test -p amplihack-signal --features signal` ✅ (all 5 signal characterization tests + full suite pass)
- `cargo test -p amplihack-launcher characterization_inv7` ✅ (default build, no signal feature)

`git diff` shows only test files + `cfg(test)` helpers — no production logic change.

## Out of scope / notes

- Pre-existing, non-deterministic CLI test flakiness in unrelated files
  (multitask launcher CRLF, copilot_setup staging) is *not* touched by this PR and
  does not gate this characterization-only change.

Full write-up: `docs/testing/TURN_DRIVER_CHARACTERIZATION_TESTS.md`.

Closes part of #910.


## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo** (workspace). Evidence: root `Cargo.toml` workspace; changed files are all Rust test code — `crates/amplihack-signal/tests/{chat_it.rs,session_channel_it.rs}` (integration tests, `#![cfg(feature = "signal")]`) and a `#[cfg(test)] mod tests` block in `crates/amplihack-launcher/src/auto_mode_exec.rs`, plus a Markdown doc. The signal turn-driver is feature-gated (`--features signal`); auto-mode is in the default build.

Chosen validation strategy:
- Outside-in consumer boundary for a Rust CLI = the crate test suites exercising the public seams (`SerialTurnDriver`, injectable `TurnRunner`/`MockRunner`, `Gate::evaluate_at`, `Inbox` env path, `AutoMode` decision fns). Ran the five added `characterization_inv<N>_*` tests under the same feature flags as existing signal tests, plus the four cargo gates. This proves the observable turn-driver behavior is locked without touching production logic.

### Scenario 1 — simple: auto-mode INV-7 in the default build (no signal feature)
Command: `cargo test -p amplihack-launcher characterization_inv7_automode_continues_until_stop_condition`
Result: PASS
Output:
```
test auto_mode_exec::tests::characterization_inv7_automode_continues_until_stop_condition ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 299 filtered out
```

### Scenario 2 — complex: feature-gated signal turn-driver characterization suite (INV-3/4/5/6)
Command: `cargo test -p amplihack-signal --features signal characterization`
Result: PASS
Output:
```
gating::characterization_inv3_inbound_gate_failclosed ... ok
turn::characterization_inv5_successive_turns_reuse_same_session_id ... ok
turn::characterization_inv6_turn_runs_to_completion_no_wallclock_cap ... ok
characterization_inv4_capacity_from_operator_config_evicts_oldest ... ok
test result: ok. 3 passed (chat_it) + 1 passed (session_channel_it); 0 failed
```

### Cargo gates (all green)
- `cargo fmt --check` ✅
- `cargo clippy -p amplihack-signal -p amplihack-launcher --features signal --tests` ✅ (no warnings)
- `cargo build -p amplihack-signal -p amplihack-launcher --features signal` ✅
- `cargo test -p amplihack-signal --features signal` ✅ / `cargo test -p amplihack-cli --features signal signal_chat_it` ✅ (0 failed) / `cargo test -p amplihack-launcher` ✅

### Regression / no-production-change check
`git diff --name-only origin/main...HEAD` = only test files, one `#[cfg(test)] mod tests` block, and a doc. Production files `gating.rs`, `chat/turn.rs`, `session_channel.rs` confirmed **untouched**; the sole `auto_mode_exec.rs` hunk (`@@ -360,4 +360,80 @@ mod tests {`) is inside the pre-existing test module (excluded from non-test builds).


## Step 16b: Outside-In Testing Results

Re-validated the branch from the consumer (`cargo`) boundary as an external user of these test suites. **0 fixes required** — the characterization suite was already green.

**Detected toolchain**
- Language: Rust (workspace `Cargo.toml`, resolver 2). Toolchain: `cargo 1.97.0` / `rustc 1.97.0`.
- Changed files (`origin/main...HEAD`): `crates/amplihack-signal/tests/chat_it.rs`, `crates/amplihack-signal/tests/session_channel_it.rs` (test binaries), `crates/amplihack-launcher/src/auto_mode_exec.rs` (additions confined to the existing `#[cfg(test)] mod tests`), `docs/testing/TURN_DRIVER_CHARACTERIZATION_TESTS.md` (docs). No production logic touched.
- Package manager / boundary: native `cargo` (Rust CLI repo — no gadugi framework required per qa-team skill).

**Chosen strategy**: run the added characterization tests through the same `cargo` invocations a downstream user/CI would use, under the same feature flags as the existing signal tests, plus the four cargo quality gates. Hermetic, no network/process.

**Scenarios**

| # | Scenario | Command | Result | Key output |
|---|----------|---------|--------|------------|
| 1 (simple) | INV-7 auto-mode stop-condition, default build (no `signal` feature) | `cargo test -p amplihack-launcher characterization_inv7_automode_continues_until_stop_condition` | PASS | `characterization_inv7_automode_continues_until_stop_condition ... ok` — 1 passed |
| 2 (edge/integration) | INV-3/4/5/6 feature-gated signal turn-driver suite | `cargo test -p amplihack-signal --features signal` | PASS | `characterization_inv3_inbound_gate_failclosed ... ok`, `..._inv4_capacity_from_operator_config_evicts_oldest ... ok`, `..._inv5_successive_turns_reuse_same_session_id ... ok`, `..._inv6_turn_runs_to_completion_no_wallclock_cap ... ok` (all suite tests ok) |
| 3 | CLI signal feature integration builds/passes | `cargo test -p amplihack-cli --features signal signal_chat_it` | PASS | all matched binaries ok (no CLI production/test files changed by this PR) |

**Cargo gates (all four green)**

| Gate | Command | Result |
|------|---------|--------|
| Format | `cargo fmt --check` | clean |
| Lint | `cargo clippy -p amplihack-signal -p amplihack-launcher -p amplihack-cli --features amplihack-signal/signal,amplihack-cli/signal --all-targets` | no warnings |
| Build | `cargo build -p amplihack-signal -p amplihack-launcher -p amplihack-cli --features amplihack-signal/signal,amplihack-cli/signal` | Finished |
| Test | scenarios 1-3 above | all passed |

**No-production-change check**: `git diff origin/main...HEAD` limited to two test files, a docs file, and `#[cfg(test)]`-only additions in `auto_mode_exec.rs`; `gating.rs`, `turn.rs`, and `session_channel.rs` are untouched.

**Fix count**: 0 (all scenarios and gates passed on first run at commit 94ee1cfb).
