### PR TITLE
test(#910): characterization safety net for turn-driver loops (PR-1)

### DIFF
--- a/crates/amplihack-launcher/src/auto_mode_exec.rs
+++ b/crates/amplihack-launcher/src/auto_mode_exec.rs
@@ -360,4 +360,65 @@ mod tests {
         assert!(!append.join("extra.md").exists());
         assert!(dir.path().join(".amplihack/appended/extra.md").exists());
     }
+
+    // -------------------------------------------------------------------------
+    // INV-7 — auto-mode continuation: a continuation prompt is produced each
+    // turn until the loop's stop condition, and the stop condition is honored.
+    //
+    // The pre-existing `should_continue_*` tests check individual stop
+    // conditions in isolation. This characterization locks the LOOP behavior:
+    // replaying `AutoMode::run`'s execute-phase decision sequence with the real,
+    // in-crate `should_continue()` and `build_execution_prompt()` (no process is
+    // spawned), it asserts that exactly one continuation prompt is emitted per
+    // turn — each carrying the correct 1-based `[Turn {turn+1}/{max_turns}]`
+    // marker — until `turn >= max_turns`, at which point the loop stops. A later
+    // shared-Session extraction MUST preserve this loop arithmetic.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn characterization_inv7_automode_continues_until_stop_condition() {
+        const MAX_TURNS: u32 = 3;
+        let mut am = AutoMode::new(AutoModeConfig {
+            max_turns: MAX_TURNS,
+            ..Default::default()
+        });
+
+        // Replay the `while self.should_continue()` execute loop from run(),
+        // substituting execute_turn's side effect (turn += 1) for the real
+        // process spawn.
+        let mut prompts = Vec::new();
+        while am.should_continue() {
+            let prompt = am.build_execution_prompt();
+            // Each turn emits its 1-based marker before the turn counter advances.
+            let expected_marker = format!("[Turn {}/{}]", am.turn + 1, MAX_TURNS);
+            assert!(
+                prompt.contains(&expected_marker),
+                "continuation prompt for turn index {} must carry {expected_marker}; got: {prompt}",
+                am.turn
+            );
+            prompts.push(prompt);
+            // execute_turn increments the turn counter.
+            am.turn += 1;
+        }
+
+        // Exactly max_turns continuation prompts were produced.
+        assert_eq!(
+            prompts.len() as u32,
+            MAX_TURNS,
+            "the loop must emit exactly max_turns continuation prompts"
+        );
+        // Markers are the full, ordered 1..=max_turns sequence.
+        for (i, prompt) in prompts.iter().enumerate() {
+            let marker = format!("[Turn {}/{}]", i + 1, MAX_TURNS);
+            assert!(
+                prompt.contains(&marker),
+                "prompt {i} must carry {marker}; got: {prompt}"
+            );
+        }
+        // Stop condition honored: once turn >= max_turns the loop stops.
+        assert_eq!(am.turn, MAX_TURNS, "loop halts exactly at max_turns");
+        assert!(
+            !am.should_continue(),
+            "should_continue() must be false once turn >= max_turns"
+        );
+    }
 }

--- a/crates/amplihack-signal/tests/chat_it.rs
+++ b/crates/amplihack-signal/tests/chat_it.rs
@@ -540,6 +540,313 @@ mod turn {
             "no stale trigger may linger after the turn completes"
         );
     }
+
+    // -------------------------------------------------------------------------
+    // INV-5 — Resume continuity + injection safety, across TWO successive turns.
+    //
+    // The pre-existing `argv_*` tests characterize the shape of a SINGLE argv
+    // build. This characterization locks the refactor-critical property that two
+    // SEQUENTIAL turns driven by the SAME `SerialTurnDriver` both resume the
+    // SAME pinned `--session-id` (context continuity), and that the
+    // attacker-influenced prompt is exactly ONE argv element on BOTH turns
+    // (never shell-concatenated). A later shared-Session extraction MUST preserve
+    // both properties or this test fails.
+    // -------------------------------------------------------------------------
+
+    /// Records the exact argv of every `run_turn` so the test can assert
+    /// cross-turn session-id identity and single-element prompts.
+    struct RecordingRunner {
+        seen: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    impl TurnRunner for RecordingRunner {
+        fn run_argv(
+            &self,
+            argv: Vec<String>,
+        ) -> Pin<Box<dyn Future<Output = std::io::Result<String>> + Send>> {
+            let seen = self.seen.clone();
+            Box::pin(async move {
+                seen.lock().unwrap().push(argv);
+                Ok(String::from("ok"))
+            })
+        }
+    }
+
+    fn session_id_of(argv: &[String]) -> &str {
+        let pos = argv
+            .iter()
+            .position(|a| a == "--session-id")
+            .expect("every turn must pin --session-id");
+        argv.get(pos + 1)
+            .map(String::as_str)
+            .expect("--session-id must be followed by the pinned uuid")
+    }
+
+    fn prompt_of(argv: &[String]) -> &str {
+        let pos = argv
+            .iter()
+            .position(|a| a == "-p" || a == "--prompt")
+            .expect("every turn must carry a prompt flag");
+        argv.get(pos + 1)
+            .map(String::as_str)
+            .expect("prompt flag must be followed by exactly one prompt element")
+    }
+
+    #[tokio::test]
+    async fn characterization_inv5_successive_turns_reuse_same_session_id() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let runner = RecordingRunner { seen: seen.clone() };
+        let driver = SerialTurnDriver::new(runner, SID, ToolAllowlist::read_only_default());
+
+        // Two SEQUENTIAL turns with distinct, attacker-shaped prompts.
+        let first = "first turn prompt";
+        // Metacharacters must survive verbatim as a single argv element.
+        let second = "second; rm -rf / # $(whoami) `id`";
+        driver.run_turn(first).await.expect("turn 1 ok");
+        driver.run_turn(second).await.expect("turn 2 ok");
+
+        let calls = seen.lock().unwrap().clone();
+        assert_eq!(calls.len(), 2, "exactly two turns must have run");
+
+        // Continuity: both turns resume the SAME pinned session id.
+        assert_eq!(session_id_of(&calls[0]), SID, "turn 1 resumes pinned SID");
+        assert_eq!(session_id_of(&calls[1]), SID, "turn 2 resumes pinned SID");
+        assert_eq!(
+            session_id_of(&calls[0]),
+            session_id_of(&calls[1]),
+            "successive turns MUST reuse the identical session id (context continuity)"
+        );
+
+        // Injection safety: each prompt is exactly ONE argv element, verbatim,
+        // on BOTH turns — never split or shell-concatenated.
+        assert_eq!(
+            prompt_of(&calls[0]),
+            first,
+            "turn 1 prompt must be one verbatim argv element"
+        );
+        assert_eq!(
+            prompt_of(&calls[1]),
+            second,
+            "turn 2 prompt must be one verbatim argv element (metacharacters intact)"
+        );
+        // The prompt occupies a single slot: the flag's successor equals the
+        // whole prompt, so nothing leaked into an adjacent argv element.
+        for argv in &calls {
+            let p_pos = argv
+                .iter()
+                .position(|a| a == "-p" || a == "--prompt")
+                .unwrap();
+            let count = argv
+                .iter()
+                .filter(|a| *a == "-p" || *a == "--prompt")
+                .count();
+            assert_eq!(count, 1, "exactly one prompt flag per turn: {argv:?}");
+            assert!(p_pos + 1 < argv.len(), "prompt flag must have a value");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // INV-6 — No per-turn wall-clock timeout: a turn runs to natural completion.
+    //
+    // The driver imposes NO wall-clock cap on a turn; completion is gated ONLY
+    // by the runner finishing. A channel-gated mock blocks inside `run_argv`
+    // until the test explicitly releases it. Fully deterministic (no sleeps as
+    // synchronization): the mock signals entry, the test proves the turn is
+    // still in-flight (not finished) while blocked, then releases and observes
+    // completion. If a future refactor injected a loop-level timeout, the turn
+    // would resolve (to a timeout error) BEFORE release and this test fails.
+    // -------------------------------------------------------------------------
+
+    /// Blocks inside `run_argv` on a test-controlled release channel, signalling
+    /// once it has entered so the test can synchronize without sleeping.
+    struct GatedRunner {
+        entered: Mutex<Option<oneshot_std::Sender<()>>>,
+        release: Mutex<Option<oneshot_std::Receiver<()>>>,
+    }
+
+    // Use std's oneshot analogue via tokio to keep the runner `Send`; alias for
+    // readability.
+    use tokio::sync::oneshot as oneshot_std;
+
+    impl TurnRunner for GatedRunner {
+        fn run_argv(
+            &self,
+            _argv: Vec<String>,
+        ) -> Pin<Box<dyn Future<Output = std::io::Result<String>> + Send>> {
+            let entered = self.entered.lock().unwrap().take();
+            let release = self.release.lock().unwrap().take();
+            Box::pin(async move {
+                if let Some(tx) = entered {
+                    let _ = tx.send(());
+                }
+                if let Some(rx) = release {
+                    // Block until the test releases the turn — no wall-clock cap.
+                    let _ = rx.await;
+                }
+                Ok(String::from("released"))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn characterization_inv6_turn_runs_to_completion_no_wallclock_cap() {
+        let (entered_tx, entered_rx) = oneshot_std::channel::<()>();
+        let (release_tx, release_rx) = oneshot_std::channel::<()>();
+        let runner = GatedRunner {
+            entered: Mutex::new(Some(entered_tx)),
+            release: Mutex::new(Some(release_rx)),
+        };
+        let driver = Arc::new(SerialTurnDriver::new(
+            runner,
+            SID,
+            ToolAllowlist::read_only_default(),
+        ));
+
+        let d = driver.clone();
+        let handle = tokio::spawn(async move { d.run_turn("long-running turn").await });
+
+        // Deterministic sync: the turn is now executing inside the runner and
+        // blocked on `release_rx` — no timer, no cap.
+        entered_rx.await.expect("runner must enter the turn");
+        assert!(
+            !handle.is_finished(),
+            "the turn MUST NOT complete on its own: the loop imposes no wall-clock cap"
+        );
+
+        // Release: only now does the turn complete — proving completion is gated
+        // solely by the runner's natural finish.
+        release_tx.send(()).expect("release the in-flight turn");
+        let out = handle
+            .await
+            .expect("turn task must not panic")
+            .expect("released turn must succeed");
+        assert_eq!(
+            out, "released",
+            "turn ran to natural completion after release"
+        );
+    }
+}
+
+// =============================================================================
+// INV-3 — Inbound gating (fail-closed), consolidated end-to-end anchor.
+//
+// `Gate::evaluate` is exhaustively unit-tested in `src/gating.rs`, and the
+// accept/echo-drop paths are exercised in `session_relay_it.rs`. This anchor
+// consolidates the fail-closed contract through the REAL inbound loop
+// (`SignalSession::pump_once`) over the in-process `FakeSignalEndpoint`, so a
+// future Session/Channel extraction that accidentally fails OPEN on any one
+// rejection reason breaks a single, clearly-named test.
+//
+// Deny-by-default is asserted positively: exactly one accepted operator
+// instruction survives; wrong-group, wrong-sender, empty-body, and
+// echo-within-TTL are each dropped.
+// =============================================================================
+mod gating {
+    use amplihack_signal::config::{ENV_ACCOUNT, ENV_ALLOWLIST, ENV_ENDPOINT, SignalConfig};
+    use amplihack_signal::fake_endpoint::FakeSignalEndpoint;
+    use amplihack_signal::session_channel::{Inbox, SignalSession};
+    use amplihack_signal::transport::{GroupId, SignalTransport};
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    const GID: &str = "grp-inv3==";
+    const ACCOUNT: &str = "+15551230000";
+    const STRANGER: &str = "+15559999999";
+
+    fn config_for(addr: &str) -> SignalConfig {
+        let mut env = HashMap::new();
+        env.insert(ENV_ENDPOINT.to_string(), addr.to_string());
+        env.insert(ENV_ACCOUNT.to_string(), ACCOUNT.to_string());
+        // Operator commands from their own primary phone (device 1) as the
+        // account's synced transcript; allowlist the account number only.
+        env.insert(ENV_ALLOWLIST.to_string(), ACCOUNT.to_string());
+        SignalConfig::from_sources(&env, None).expect("valid config")
+    }
+
+    #[tokio::test]
+    async fn characterization_inv3_inbound_gate_failclosed() {
+        let fake = FakeSignalEndpoint::start()
+            .await
+            .unwrap()
+            .with_group_id(GID)
+            // Operator-only membership so the pre-echo `post` verifies and
+            // records the outbound body into the echo-suppression window.
+            .with_group_members_script(vec![vec![ACCOUNT.to_string()]]);
+        let transport = SignalTransport::connect(fake.addr()).await.unwrap();
+        let dir = TempDir::new().unwrap();
+        let inbox = Inbox::new(dir.path().join("inbox.json"), 16);
+        let cfg = config_for(fake.addr());
+        let mut session = SignalSession::new(transport, &cfg, GroupId(GID.to_string()), inbox);
+
+        // Post an outbound line first so its synced-back copy is a suppressible
+        // echo (records the body into the gate's echo window).
+        let echoed = "session update mirrored";
+        session.post(echoed).await.unwrap();
+
+        // (a) ACCEPTED — allowlisted operator, primary device (1), this group.
+        fake.enqueue_inbound(&format!(
+            r#"{{"jsonrpc":"2.0","method":"receive","params":{{"envelope":{{
+                "source":"{ACCOUNT}","sourceDevice":1,
+                "syncMessage":{{"sentMessage":{{"message":"run the tests again",
+                    "groupInfo":{{"groupId":"{GID}"}}}}}}
+            }}}}}}"#
+        ));
+        // (b) REJECTED — wrong group.
+        fake.enqueue_inbound(&format!(
+            r#"{{"jsonrpc":"2.0","method":"receive","params":{{"envelope":{{
+                "source":"{ACCOUNT}","sourceDevice":1,
+                "syncMessage":{{"sentMessage":{{"message":"for another group",
+                    "groupInfo":{{"groupId":"grp-OTHER=="}}}}}}
+            }}}}}}"#
+        ));
+        // (c) REJECTED — sender not on the allowlist (dataMessage from a stranger).
+        fake.enqueue_inbound(&format!(
+            r#"{{"jsonrpc":"2.0","method":"receive","params":{{"envelope":{{
+                "source":"{STRANGER}","sourceDevice":1,
+                "dataMessage":{{"message":"malicious injection",
+                    "groupInfo":{{"groupId":"{GID}"}}}}
+            }}}}}}"#
+        ));
+        // (d) REJECTED — empty body.
+        fake.enqueue_inbound(&format!(
+            r#"{{"jsonrpc":"2.0","method":"receive","params":{{"envelope":{{
+                "source":"{ACCOUNT}","sourceDevice":1,
+                "syncMessage":{{"sentMessage":{{"message":"",
+                    "groupInfo":{{"groupId":"{GID}"}}}}}}
+            }}}}}}"#
+        ));
+        // (e) REJECTED — echo of our own outbound within the TTL window.
+        fake.enqueue_inbound(&format!(
+            r#"{{"jsonrpc":"2.0","method":"receive","params":{{"envelope":{{
+                "source":"{ACCOUNT}","sourceDevice":1,
+                "syncMessage":{{"sentMessage":{{"message":"{echoed}",
+                    "groupInfo":{{"groupId":"{GID}"}}}}}}
+            }}}}}}"#
+        ));
+
+        // Pump all five envelopes; collect the non-empty accepted instructions.
+        let mut accepted = Vec::new();
+        for _ in 0..5 {
+            if let Some(instr) = session.pump_once().await.expect("pump ok")
+                && !instr.is_empty()
+            {
+                accepted.push(instr);
+            }
+        }
+
+        // Deny-by-default: exactly the one legitimate instruction is accepted.
+        assert_eq!(
+            accepted,
+            vec!["run the tests again".to_string()],
+            "only the allowlisted, correct-group, non-empty, non-echo message may be accepted"
+        );
+        // And only that one instruction is queued for injection into the agent.
+        assert_eq!(
+            session.drain().unwrap(),
+            vec!["run the tests again".to_string()],
+            "fail-closed: wrong-group / wrong-sender / empty / echo must never be queued"
+        );
+    }
 }
 
 // =============================================================================

--- a/crates/amplihack-signal/tests/session_channel_it.rs
+++ b/crates/amplihack-signal/tests/session_channel_it.rs
@@ -64,3 +64,86 @@ fn at_session_derives_stable_sanitized_path() {
     let c = Inbox::at_session("session-456", dir.path());
     assert_ne!(a.path(), c.path(), "different ids → different paths");
 }
+
+// -----------------------------------------------------------------------------
+// INV-4 — Bounded turn queue, capacity from OPERATOR CONFIG, evict-oldest.
+//
+// The pre-existing tests bound the inbox via an explicit `Inbox::new(_, N)`.
+// This characterization locks the refactor-critical binding that the
+// operator-configurable capacity flows from `AMPLIHACK_SIGNAL_INBOX_CAPACITY`
+// through `Inbox::default_capacity()` into `Inbox::at_session`, and that a flood
+// evicts the OLDEST pending prompt (FIFO backpressure). A later shared-Session
+// extraction MUST preserve this operator control and eviction order.
+//
+// Env mutation is process-global, so a save/restore guard serializes it against
+// any sibling test that reads the same variable.
+// -----------------------------------------------------------------------------
+
+use std::sync::Mutex as StdMutex;
+
+// Serializes AMPLIHACK_SIGNAL_INBOX_CAPACITY mutation across parallel tests.
+static ENV_GUARD: StdMutex<()> = StdMutex::new(());
+
+#[test]
+fn characterization_inv4_capacity_from_operator_config_evicts_oldest() {
+    const KEY: &str = "AMPLIHACK_SIGNAL_INBOX_CAPACITY";
+    // A small, unlikely-to-collide operator-chosen capacity.
+    const CAP: usize = 3;
+
+    let _guard = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+    let previous = std::env::var(KEY).ok();
+
+    // SAFETY: mutation is serialized by ENV_GUARD and restored below.
+    unsafe {
+        std::env::set_var(KEY, CAP.to_string());
+    }
+
+    // Confirm the operator config is honored by the default-capacity path.
+    assert_eq!(
+        Inbox::default_capacity(),
+        CAP,
+        "operator-set AMPLIHACK_SIGNAL_INBOX_CAPACITY must drive default_capacity()"
+    );
+
+    let dir = TempDir::new().unwrap();
+    // Construct through the OPERATOR-CONFIG path (at_session → default_capacity),
+    // not an explicit new(_, N).
+    let inbox = Inbox::at_session("inv4-session", dir.path());
+
+    // Push exactly capacity prompts: all queued, no eviction.
+    for i in 0..CAP {
+        assert_eq!(
+            inbox.push(&format!("prompt-{i}")).unwrap(),
+            PushOutcome::Queued,
+            "prompt within capacity must queue without eviction"
+        );
+    }
+    // One more overflows: the OLDEST is evicted (backpressure).
+    assert_eq!(
+        inbox.push(&format!("prompt-{CAP}")).unwrap(),
+        PushOutcome::EvictedOldest,
+        "exceeding operator-configured capacity must evict the oldest prompt"
+    );
+
+    // Restore the environment before asserting (so a panic can't leak state).
+    // SAFETY: still under ENV_GUARD.
+    unsafe {
+        match &previous {
+            Some(v) => std::env::set_var(KEY, v),
+            None => std::env::remove_var(KEY),
+        }
+    }
+
+    // The surviving queue is the newest CAP prompts, oldest-first (FIFO): the
+    // very first prompt ("prompt-0") was the one evicted.
+    let remaining = inbox.drain().unwrap();
+    assert_eq!(
+        remaining,
+        vec![
+            "prompt-1".to_string(),
+            "prompt-2".to_string(),
+            "prompt-3".to_string()
+        ],
+        "bounded queue keeps the newest {CAP} prompts in FIFO order; the oldest is evicted"
+    );
+}

--- a/docs/testing/TURN_DRIVER_CHARACTERIZATION_TESTS.md
+++ b/docs/testing/TURN_DRIVER_CHARACTERIZATION_TESTS.md
@@ -1,0 +1,212 @@
+# Turn-Driver Characterization Tests (Issue #910, PR-1)
+
+A safety net that locks the **current observable behavior** of the two
+turn-driver loops before a later, multi-PR refactor extracts a shared
+`Session`/`Channel` abstraction. These are **characterization tests only** — they
+describe existing behavior, they do not change production code, and every later
+PR must keep them green **unchanged**.
+
+- **Signal loop**: `crates/amplihack-cli/src/commands/signal/chat.rs`
+  (`run_chat_async`), driven by `SerialTurnDriver` + `CopilotTurnRunner` from
+  `crates/amplihack-signal/src/chat/turn.rs`.
+- **auto-mode loop**: `crates/amplihack-launcher/src/auto_mode_exec.rs`
+  (`AutoMode::run`, `should_continue`, `build_execution_prompt`).
+
+> These tests are a *retcon* specification: they assert what the code already
+> does today. If a change makes one fail, the change altered observable
+> behavior — that is the signal the safety net exists to raise.
+
+---
+
+## The seven locked invariants
+
+| ID    | Invariant | Locked by | Status |
+| ----- | --------- | --------- | ------ |
+| INV-1 | **Turn serialization** — at most one turn per session runs at a time (`SerialTurnDriver`). | `chat_it.rs::turn::turns_execute_one_at_a_time_per_session` | pre-existing (cited) |
+| INV-2 | **Post-on-completion** — a completed turn's output is posted outward exactly once, only on verified operator-only membership; withheld when membership is unverified. | `verified_send_it.rs`, `session_relay_it.rs` (outbound), `chat_membership_failclosed_it.rs` | pre-existing (cited) |
+| INV-3 | **Inbound gating (fail-closed)** — an inbound message is accepted as a next-turn prompt only if `Gate::evaluate` accepts it (wrong sender/device/group/echo/empty ⇒ rejected). | `gating.rs` unit tests + `session_relay_it.rs`; consolidated end-to-end anchor **added**: `chat_it.rs::gating::characterization_inv3_inbound_gate_failclosed` | pre-existing + **added anchor** |
+| INV-4 | **Bounded turn queue** — when operator-configurable capacity is exceeded, the **oldest** pending prompt is evicted (backpressure), matching `Inbox` semantics. | `session_channel_it.rs::characterization_inv4_capacity_from_operator_config_evicts_oldest` | **added** |
+| INV-5 | **Resume continuity** — each turn resumes the **same** session id (`build_turn_argv`), preserving context; the prompt is exactly one argv element (injection-safe), verified across **two successive** turns. | `chat_it.rs::turn::characterization_inv5_successive_turns_reuse_same_session_id` | **added** |
+| INV-6 | **No per-turn wall-clock timeout** — a turn runs to natural completion; the loop injects no wall-clock cap. | `chat_it.rs::turn::characterization_inv6_turn_runs_to_completion_no_wallclock_cap` | **added** |
+| INV-7 | **auto-mode continuation** — continuation prompts are produced each turn until the loop's stop condition, and the stop condition is honored. | `auto_mode_exec.rs::tests::characterization_inv7_automode_continues_until_stop_condition` | **added** |
+
+All seven invariants are covered: INV-1, INV-2 by citation only; INV-3 by
+citation **plus** a new consolidated anchor; INV-4, INV-5, INV-6, INV-7 by new
+characterization tests.
+
+---
+
+## How to run
+
+The Signal-side tests are gated on the `signal` cargo feature (matching every
+existing Signal test file, which begins with `#![cfg(feature = "signal")]`). A
+default, feature-off build compiles them away to nothing.
+
+```bash
+# Signal turn-driver + inbox invariants (INV-1..INV-6)
+cargo test -p amplihack-signal --features signal
+
+# Narrower: a single characterization test file
+cargo test -p amplihack-signal --features signal --test chat_it
+cargo test -p amplihack-signal --features signal --test session_channel_it
+
+# CLI-side signal loop coverage (INV-2 membership / outbound)
+cargo test -p amplihack-cli --features signal
+
+# auto-mode continuation loop (INV-7) — runs in the DEFAULT build, no feature flag
+cargo test -p amplihack-launcher auto_mode_exec
+```
+
+### The four cargo gates
+
+This is a Rust change and follows the default workflow; all four gates pass with
+and without `--features signal` as appropriate:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --features signal -- -D warnings
+cargo build --workspace --features signal
+cargo test  --workspace --features signal
+```
+
+---
+
+## Test seams (reused, never re-invented)
+
+These tests are deterministic and hermetic: **no** real network, **no** real
+`copilot`/`signal-cli` process, and **no** `sleep`-as-synchronization. They ride
+the seams that already exist in the crates.
+
+### `fake_endpoint` — in-process signal-cli loopback
+
+`crates/amplihack-signal/src/fake_endpoint.rs` is an in-process loopback fake of
+the `signal-cli` JSON-RPC daemon. Tests script inbound envelopes and observe
+outbound sends without touching a socket. Used by the INV-3 anchor to drive
+accepted vs. rejected inbound messages end-to-end.
+
+### `TurnRunner` — injectable turn executor (`turn.rs`)
+
+```rust
+pub trait TurnRunner: Send + Sync {
+    fn run_argv(&self, argv: Vec<String>)
+        -> Pin<Box<dyn Future<Output = io::Result<String>> + Send>>;
+}
+```
+
+`CopilotTurnRunner` is the production implementation (spawns real `copilot`).
+Characterization tests inject a **mock** instead:
+
+- **Recording mock** (INV-5): captures the exact `argv` of every `run_turn`
+  call so the test can assert `--session-id <same-uuid>` on turn 1 and turn 2,
+  and that the prompt occupies exactly one argv slot (verbatim, never
+  shell-concatenated).
+- **Channel-gated mock** (INV-6): blocks inside `run_argv` on a test-controlled
+  `oneshot`/`Notify` until the test releases it. The test asserts the turn is
+  *not* complete before release and completes *after* release — proving the loop
+  imposes no wall-clock cap (fully deterministic, no timing races).
+
+`SerialTurnDriver::run_turn` holds an async mutex across the whole child
+lifetime, which is what INV-1 (pre-existing) and INV-5 (successive turns) rely on.
+
+### `Inbox` — bounded, operator-configurable queue (`session_channel.rs`)
+
+INV-4 drives the **operator-config** path rather than an explicit `new(_, N)`:
+
+```rust
+// Operators tune capacity via the environment; invalid/zero/absent → DEFAULT_CAPACITY (32).
+pub fn default_capacity() -> usize; // reads AMPLIHACK_SIGNAL_INBOX_CAPACITY
+```
+
+The test sets `AMPLIHACK_SIGNAL_INBOX_CAPACITY`, constructs the inbox through
+`default_capacity()`, pushes `capacity + 1` prompts, and asserts:
+
+- the final push returns `PushOutcome::EvictedOldest`, and
+- the surviving queue is the newest `capacity` prompts in FIFO order (the
+  **oldest** was evicted).
+
+Environment mutation is serialized with a save/restore guard and a unique
+capacity value so the test cannot contaminate sibling tests.
+
+### `AutoModeRunner` mock seam — auto-mode loop (`auto_mode_exec.rs`)
+
+INV-7 characterizes the loop **arithmetic** using the real, in-crate decision
+functions — no process is spawned:
+
+- `should_continue()` — honors `max_turns`, `max_api_calls`, `max_output_bytes`,
+  and `max_session_secs`.
+- `build_execution_prompt()` — emits a per-turn `[Turn {turn+1}/{max_turns}]`
+  marker (1-based; the internal `turn` index is 0-based).
+
+With `max_turns = 3`, the test replays the loop's decision sequence and asserts a
+continuation prompt is produced for turns 1..=3, each carrying the correct
+`[Turn {turn+1}/{max_turns}]` marker, and that `should_continue()` returns `false` once
+`turn >= max_turns` (the stop condition is honored). This runs in the default
+build; it does **not** require the `signal` feature.
+
+---
+
+## Naming convention
+
+Every added test is named after the invariant it locks:
+
+```
+characterization_inv3_inbound_gate_failclosed
+characterization_inv4_capacity_from_operator_config_evicts_oldest
+characterization_inv5_successive_turns_reuse_same_session_id
+characterization_inv6_turn_runs_to_completion_no_wallclock_cap
+characterization_inv7_automode_continues_until_stop_condition
+```
+
+The `characterization_inv<N>_` prefix makes it trivial to grep the whole safety
+net and to spot, in a later refactor PR's diff, exactly which invariant a change
+touched.
+
+---
+
+## File placement (no new `[[test]]` entries)
+
+Added tests live inside **already-registered** test files/modules so the refactor
+does not introduce Cargo `[[test]]` drift:
+
+| Invariant | File | Module / location |
+| --------- | ---- | ----------------- |
+| INV-3 anchor | `crates/amplihack-signal/tests/chat_it.rs` | `mod gating` |
+| INV-5, INV-6 | `crates/amplihack-signal/tests/chat_it.rs` | `mod turn` |
+| INV-4 | `crates/amplihack-signal/tests/session_channel_it.rs` | file scope |
+| INV-7 | `crates/amplihack-launcher/src/auto_mode_exec.rs` | `#[cfg(test)] mod tests` |
+
+---
+
+## Guarantees (what these tests promise the refactor)
+
+1. **Tests only.** `git diff --stat` for this PR lists only the three files
+   above (plus any `cfg(test)`-gated test-support helpers). No production logic —
+   including `gating.rs` and every turn-driver path — is modified or weakened.
+2. **Deny-by-default is asserted positively.** Each INV-3 rejection reason (wrong
+   sender, wrong group, wrong device, empty body, echo-within-TTL) gets an
+   explicit negative assertion, so a future *fail-open* regression breaks a test
+   rather than silently passing.
+3. **Injection safety is a security control.** INV-5 asserts the prompt is a
+   single argv element on **both** turns; a future change that shell-concatenates
+   the prompt fails the test.
+4. **Hermetic and deterministic.** Loopback fake + injected mock runner; no
+   network egress, no real `signal-cli`/`copilot` spawn, no sleep-based
+   synchronization. Env mutation is serialized and restored.
+5. **Feature-gate preserved.** Signal-side tests are inert without
+   `--features signal`, consistent with the existing test files; auto-mode tests
+   pass in the default build.
+
+---
+
+## For the next PR in the series
+
+When you extract the shared `Session`/`Channel` abstraction:
+
+- **Do not edit these tests.** They must pass unchanged. If one fails, you
+  changed observable behavior — reconcile the change or the invariant, don't
+  relax the test.
+- Keep the same seams (`fake_endpoint`, `TurnRunner`, `Inbox`,
+  `AutoMode::should_continue`/`build_execution_prompt`) available to the tests,
+  even if their internals move behind the new abstraction.
+- If the new abstraction renames a type the tests reference, update the
+  **reference**, not the **assertion**.


### PR DESCRIPTION
## Issue #910 — PR-1 of a multi-PR refactor: characterization tests only

A **safety net** that locks the current observable behavior of the two turn-driver
loops **before** later PRs extract a shared `Session`/`Channel` abstraction. These
are characterization tests only — **no production code is changed**, and later PRs
must keep these tests green **unchanged**.

- **Signal loop:** `crates/amplihack-cli/src/commands/signal/chat.rs` (`run_chat_async`),
  driven by `SerialTurnDriver` + `CopilotTurnRunner` in `crates/amplihack-signal/src/chat/turn.rs`.
- **auto-mode loop:** `crates/amplihack-launcher/src/auto_mode_exec.rs`
  (`AutoMode::run`, `should_continue`, `build_execution_prompt`).

Full narrative: `docs/testing/TURN_DRIVER_CHARACTERIZATION_TESTS.md`.

### INV → test coverage table

| ID | Invariant | Locked by | Status |
| -- | --------- | --------- | ------ |
| INV-1 | **Turn serialization** — at most one turn per session runs at a time (`SerialTurnDriver`). | `chat_it.rs::turn::turns_execute_one_at_a_time_per_session` | pre-existing (cited) |
| INV-2 | **Post-on-completion** — a completed turn's output is posted outward exactly once, only on verified operator-only membership; withheld when membership is unverified. | `verified_send_it.rs`, `session_relay_it.rs` (outbound), `chat_membership_failclosed_it.rs` | pre-existing (cited) |
| INV-3 | **Inbound gating (fail-closed)** — an inbound message is accepted as a next-turn prompt only if `Gate::evaluate` accepts it (wrong sender/device/group/echo/empty ⇒ rejected). | `gating.rs` unit tests + `session_relay_it.rs`; consolidated end-to-end anchor **added**: `chat_it.rs::gating::characterization_inv3_inbound_gate_failclosed` | pre-existing + **added anchor** |
| INV-4 | **Bounded turn queue** — when operator-configurable capacity is exceeded, the **oldest** pending prompt is evicted (backpressure), matching `Inbox` semantics. | `session_channel_it.rs::characterization_inv4_capacity_from_operator_config_evicts_oldest` | **added** |
| INV-5 | **Resume continuity** — each turn resumes the **same** session id (`build_turn_argv`), preserving context; prompt is exactly one argv element (injection-safe), verified across two successive turns. | `chat_it.rs::turn::characterization_inv5_successive_turns_reuse_same_session_id` | **added** |
| INV-6 | **No per-turn wall-clock timeout** — a turn runs to natural completion; the loop injects no wall-clock cap. | `chat_it.rs::turn::characterization_inv6_turn_runs_to_completion_no_wallclock_cap` | **added** |
| INV-7 | **auto-mode continuation** — continuation prompts are produced each turn until the loop's stop condition, and the stop condition is honored. | `auto_mode_exec.rs::tests::characterization_inv7_automode_continues_until_stop_condition` | **added** |

All seven invariants are covered: INV-1, INV-2 by citation; INV-3 by citation **plus** a
new consolidated anchor; INV-4/5/6/7 by new characterization tests. Tests reuse the
existing hermetic seams (`fake_endpoint` loopback, injectable `TurnRunner`, `Inbox`,
`AutoMode` decision fns) — no real network, no real `signal-cli`/`copilot` process, no
sleep-based synchronization.

### Changed files (tests + docs only)

- `crates/amplihack-signal/tests/chat_it.rs` — INV-3 anchor (`mod gating`), INV-5/INV-6 (`mod turn`)
- `crates/amplihack-signal/tests/session_channel_it.rs` — INV-4
- `crates/amplihack-launcher/src/auto_mode_exec.rs` — INV-7 (inside `#[cfg(test)] mod tests`)
- `docs/testing/TURN_DRIVER_CHARACTERIZATION_TESTS.md` — narrative + invariant map

`git diff --stat origin/main...HEAD` lists only these four files; no production logic
(including `gating.rs` and every turn-driver path) is modified or weakened.

---

## Step 16b: Outside-In Testing Results

**Detected toolchains:** Rust workspace (Cargo). Signal-side tests gated behind the
`signal` cargo feature (`#![cfg(feature = "signal")]`); auto-mode tests run in the
default build. No Node/Python/Go manifests relevant to the change.

**Chosen strategy (qa-team, Rust CLI):** substitute `cargo test` for the gadugi harness
per the qa-team repo-type rules. The characterization tests **are** the outside-in
boundary: they drive the turn-driver loops through the same public seams a user/consumer
exercises (loopback `fake_endpoint` daemon + injectable `TurnRunner`/`AutoMode` decision
functions), rather than internal implementation details. Ran one simple scenario
(auto-mode continuation loop, default build) and edge/integration scenarios (fail-closed
inbound gating end-to-end over the loopback daemon; oldest-eviction backpressure at
operator-configured capacity; resume-continuity + injection-safety across two turns;
no-wall-clock-cap via a channel-gated mock runner).

| # | Scenario | Command | Result | Key output |
| - | -------- | ------- | ------ | ---------- |
| 1 (simple) | auto-mode continuation loop honors stop condition (INV-7) | `cargo test -p amplihack-launcher characterization_inv7` | PASS | `test result: ok. 1 passed` |
| 2 (edge) | inbound gate fail-closed end-to-end + INV-5/INV-6 turn-driver invariants over loopback daemon | `cargo test -p amplihack-signal --features signal --test chat_it` | PASS | `test result: ok. 48 passed; 0 failed` |
| 3 (integration) | bounded inbox evicts oldest at operator capacity (INV-4) | `cargo test -p amplihack-signal --features signal --test session_channel_it` | PASS | `test result: ok. 4 passed; 0 failed` |

**Four cargo gates (default-workflow):**

| Gate | Command | Result |
| ---- | ------- | ------ |
| fmt | `cargo fmt --all --check` | PASS |
| clippy | `cargo clippy -p amplihack-signal --features signal --tests -- -D warnings` and `cargo clippy -p amplihack-launcher --tests -- -D warnings` | PASS (no warnings) |
| test | targeted characterization scenarios above | PASS (all) |
| build | `cargo build --workspace` | PASS |

**Fix count:** 0 — all scenarios and gates passed on the first outside-in run; no fixes
were required.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
