### PR TITLE
Update workflow recipes with 3 changed files (#1075)

### DIFF
--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -179,6 +179,29 @@ assert_yaml_step_not_fatal_false() {
     ' "${recipe}" || fail "${label} must not mark '${step_id}' as fatal: false"
 }
 
+# Regression guard for issue #1075: deleting a test/bin/bench source file must be
+# paired with removing the corresponding [[test]]/[[bin]]/[[bench]] stanza in the
+# owning crate's Cargo.toml, otherwise the checkpoint-after-implementation gate
+# (`cargo fmt --all`) hard-fails with `couldn't read .../tests/*.rs: No such file`.
+# The fix is prompt guidance in the recipe files; these assertions lock that
+# guidance in so it cannot silently regress.
+assert_stanza_cleanup_guidance() {
+    # Shared anchor phrase that MUST appear verbatim in both recipe prompts.
+    local anchor="[[test]]\` / \`[[bin]]\` / \`[[bench]]\` stanza in the owning crate's Cargo.toml"
+
+    grep -qF "${anchor}" "${TDD_RECIPE}" \
+        || fail "workflow-tdd.yaml step-08-implement must instruct the builder to remove the ${anchor} when a test/bin/bench source file is deleted or renamed (issue #1075)"
+
+    grep -qF "${anchor}" "${REFACTOR_REVIEW_RECIPE}" \
+        || fail "workflow-refactor-review.yaml step-09-refactor must instruct cleanup to remove the ${anchor} when a test/bin/bench source file is deleted or renamed (issue #1075)"
+
+    # Defensive diagnostic comment at the checkpoint gate must explain the failure mode.
+    grep -qF 'dangling [[test]] stanza' "${TDD_RECIPE}" \
+        || fail "workflow-tdd.yaml checkpoint-after-implementation must document that a 'No such file or directory' cargo error means a deleted test file left a dangling [[test]] stanza (issue #1075)"
+
+    echo "  PASS[stanza-cleanup]: recipe prompts require Cargo.toml stanza cleanup on file deletion (issue #1075)"
+}
+
 assert_runtime_artifact_helper_contracts() {
     [[ -f "${RUNTIME_ARTIFACT_HELPER}" ]] \
         || fail "workflow_runtime_artifacts.sh must exist for narrow runtime artifact cleanup"
@@ -1446,5 +1469,6 @@ SHIMD
 assert_pr_title_ignores_lockfiles
 assert_no_merge_directive_suppresses_auto_merge
 assert_gh_rate_limit_backoff_contracts
+assert_stanza_cleanup_guidance
 
 echo "PASS: default workflow reliability contracts are covered."

--- a/amplifier-bundle/recipes/workflow-refactor-review.yaml
+++ b/amplifier-bundle/recipes/workflow-refactor-review.yaml
@@ -50,6 +50,7 @@ steps:
       3. Simplify complex logic (without violating specs)
       4. Ensure single responsibility principle
       5. Verify no placeholders remain
+      6. When refactoring DELETES or RENAMES a test/bin/bench source file, you MUST also remove or update the corresponding `[[test]]` / `[[bin]]` / `[[bench]]` stanza in the owning crate's Cargo.toml in the SAME change, so `cargo build --all-targets` / `cargo fmt --all` still resolve all targets. Leaving a stanza that points at a deleted file is a workflow failure.
 
       **Zero-BS Checklist:**
       - [ ] No stubs

--- a/amplifier-bundle/recipes/workflow-tdd.yaml
+++ b/amplifier-bundle/recipes/workflow-tdd.yaml
@@ -83,6 +83,7 @@ steps:
       6. NO faked APIs or data.
       7. Clear error messages.
       8. Appropriate logging.
+      9. When you DELETE or RENAME a test/bin/bench source file, you MUST also remove or update the corresponding `[[test]]` / `[[bin]]` / `[[bench]]` stanza in the owning crate's Cargo.toml in the SAME change, so `cargo build --all-targets` / `cargo fmt --all` still resolve all targets. Leaving a stanza that points at a deleted file is a workflow failure.
 
       **Self-verification before declaring done:**
       - Run `git status` and `git diff --stat` in your working directory.
@@ -326,6 +327,11 @@ steps:
         exit 1
       fi
       echo "=== Checkpoint: Staging Implementation ==="
+      # NOTE (#1075): if `cargo fmt --all` below fails with
+      # `couldn't read .../tests/*.rs: No such file or directory`, a prior step
+      # almost certainly deleted a test source file but left a
+      # dangling [[test]] stanza in the owning crate's Cargo.toml. Fix = remove
+      # that stanza (see step-08-implement Rule 9). Do NOT auto-parse Cargo.toml here.
       if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
         cargo fmt --all
       fi


### PR DESCRIPTION
## Summary
Concise workflow-generated PR for workflow recipes.

## Issue
Closes #1075

## Changed files
- amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
- amplifier-bundle/recipes/workflow-refactor-review.yaml
- amplifier-bundle/recipes/workflow-tdd.yaml

## Diff stat
```text
 .../tests/test-default-workflow-reliability.sh     | 24 ++++++++++++++++++++++
 .../recipes/workflow-refactor-review.yaml          |  1 +
 amplifier-bundle/recipes/workflow-tdd.yaml         |  6 ++++++
 3 files changed, 31 insertions(+)
```

## Behavior
Implemented behavior through these branch commits:
35e132d8 fix(#1075): guide sub-recipe cleanup to prevent dangling Cargo target stanzas

## Validation
ℹ NODE_OPTIONS=--max-old-space-size=32768 (saved preference). To change: /home/azureuser/.amplihack/config
I'll start by checking the current state of the repository and understanding what's been done.

● Check branch, status, recent commits (shell)
  │ cd /tmp/wt-1075-base/worktrees/fix/issue-1075-fix-github-issue-1075-default-workflow-hard-fails
  │ && git branch --show-current && echo "---STATUS---" && git --no-pager status && echo "---LOG---"
  │ && git --no-pager log --oneline -5
  └ 14 lines…

The fix is already committed. Let me review the change to verify it's complete before testing.

● Show files changed in fix commit (shell)

## Risk
Workflow behavior changed; review recipe gates and regression coverage carefully.

## Checklist
- [x] Branch has 1 commit(s) ahead of main
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*

## Step 16b: Outside-In Testing Results

**Detected toolchain:** Rust Cargo workspace (`Cargo.toml` at root, 30+ member crates). Integration tests registered as explicit `[[test]]` targets in `bins/amplihack/Cargo.toml`. Recipe reliability suite is a Bash harness (`amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh`).

**Chosen strategy:** Per the qa-team skill's Rust-CLI guidance, validate at the user/consumer boundary with native `cargo test` and the repo's own Bash reliability harness (no gadugi framework required). Changed files are prompt-side YAML + a Bash assertion, so the relevant boundaries are: (a) the reliability harness that a maintainer runs, and (b) the `every_phase_subrecipe_under_400_lines` brick-budget gate that would break if the added prompt lines pushed a phase file over the 400-line limit.

| # | Scenario | Command | Result | Key output |
|---|----------|---------|--------|------------|
| 1 (simple) | Reliability harness locks in the new stanza-cleanup guidance | `bash amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh` | ✅ PASS | `PASS[stanza-cleanup]: recipe prompts require Cargo.toml stanza cleanup on file deletion (issue #1075)` … `PASS: default workflow reliability contracts are covered.` |
| 2 (edge/integration) | Added prompt lines must not push any phase sub-recipe over the 400-line brick budget | `cargo test -p amplihack --test default_workflow_decomposition every_phase_subrecipe_under_400_lines --locked` | ✅ PASS | `test every_phase_subrecipe_under_400_lines ... ok` (workflow-tdd.yaml = 397 lines, under 400) |
| 3 (regression sweep) | Full decomposition contract suite | `cargo test -p amplihack --test default_workflow_decomposition --locked` | ✅ PASS | `test result: ok. 35 passed; 0 failed` |

**Supporting checks:** `workflow-tdd.yaml` and `workflow-refactor-review.yaml` both parse as valid YAML (verified via `yaml.safe_load`).

**Fix count:** 0 — all scenarios passed on the first run; no diagnose/fix/retry iterations were required.

**Acceptance confirmed:**
- `step-08-implement` Rule 9 contains the explicit delete-test-file → remove-`[[test]]`-stanza rule.
- `workflow-refactor-review.yaml` step-09-refactor carries matching Rule 6.
- Diagnostic comment added at `checkpoint-after-implementation` (comment-only, no auto-parsing bash).
- Reliability harness `assert_stanza_cleanup_guidance` locks the guidance so it cannot silently regress.
- No brittle Cargo.toml string/line parsing introduced.
