### PR TITLE
fix(#1091): deterministic az boards work-item url capture + REST-url parsing in workflow-prep

### DIFF
--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -44,6 +44,7 @@ TERMINAL_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-terminal-state.y
 DEFAULT_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/default-workflow.yaml"
 SMART_EXECUTE_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/smart-execute-routing.yaml"
 SMART_ORCHESTRATOR_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/smart-orchestrator.yaml"
+PREP_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-prep.yaml"
 FINAL_STATUS_TOOL="${REPO_ROOT}/amplifier-bundle/tools/workflow_final_status.sh"
 PR_SCOPE_HELPER="${REPO_ROOT}/amplifier-bundle/tools/workflow_pr_scope.sh"
 
@@ -1466,9 +1467,27 @@ SHIMD
     echo "  PASS[gh-retry:d]: generic 5xx keeps short-backoff 3-attempt behavior"
 }
 
+assert_azdo_work_item_url_parsing() {
+    # issue #1091: step-03-create-issue must project ONLY the url scalar (single line,
+    # no read-splitting) and must NOT fold create stderr into the parsed value; step-03b
+    # must extract the id from the AzDO REST url form the create/reuse paths actually emit.
+    grep -qF -- '--query "url" -o tsv' "${PREP_RECIPE}" \
+        || fail "issue #1091: step-03 must project the url scalar via --query \"url\" -o tsv"
+    if grep -qF -- '--query "[id,url]" -o tsv' "${PREP_RECIPE}"; then
+        fail "issue #1091: step-03 must not use the brittle --query \"[id,url]\" -o tsv projection"
+    fi
+    if grep -qE 'az boards work-item create .*-o tsv 2>&1' "${PREP_RECIPE}"; then
+        fail "issue #1091: step-03 must not fold create-command stderr with 2>&1 into the parsed result"
+    fi
+    grep -qF -- '_apis/wit/workItems/' "${PREP_RECIPE}" \
+        || fail "issue #1091: step-03b must extract the id from the _apis/wit/workItems/ REST url form"
+    echo "  PASS[azdo-wi]: step-03 url projection + step-03b REST-url extraction contracts hold"
+}
+
 assert_pr_title_ignores_lockfiles
 assert_no_merge_directive_suppresses_auto_merge
 assert_gh_rate_limit_backoff_contracts
 assert_stanza_cleanup_guidance
+assert_azdo_work_item_url_parsing
 
 echo "PASS: default workflow reliability contracts are covered."

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -351,15 +351,14 @@ steps:
             [ -z "$AZDO_WI_ASSIGNEE" ] && AZDO_WI_ASSIGNEE=$(timeout 60 az ad signed-in-user show --query "userPrincipalName" -o tsv 2>/dev/null || echo "")
             [ -z "$AZDO_WI_ASSIGNEE" ] && { echo "WARN: could not resolve the caller's identity for work-item assignment ('az account show' and 'az ad signed-in-user show' both failed). Set AZDO_ASSIGNED_TO to a UPN or re-run 'az login'; refusing to create an unassigned work item — using local tracking instead." >&2; emit_local_metadata; exit 0; }
           fi
-          WI_CREATE_RC=0
-          WI_RESULT=$(timeout 60 az boards work-item create --title "$ISSUE_TITLE" --type "$AZDO_WI_TYPE" --assigned-to "$AZDO_WI_ASSIGNEE" --org "$AZDO_ORG_URL" --project "$AZDO_PROJECT" --query "[id,url]" -o tsv 2>&1) || WI_CREATE_RC=$?
+          WI_CREATE_RC=0; AZ_ERR=$(mktemp)
+          WI_URL=$(timeout 60 az boards work-item create --title "$ISSUE_TITLE" --type "$AZDO_WI_TYPE" --assigned-to "$AZDO_WI_ASSIGNEE" --org "$AZDO_ORG_URL" --project "$AZDO_PROJECT" --query "url" -o tsv 2>"$AZ_ERR") || WI_CREATE_RC=$?
           if [ "$WI_CREATE_RC" -eq 0 ]; then
-            read -r _ WI_URL <<< "$WI_RESULT"
-            [ -n "$WI_URL" ] && { printf '%s\n' "$WI_URL"; exit 0; }
-            echo "ERROR: az boards work-item create reported success but no work item URL could be parsed from its output." >&2; sanitize_cli_output "$WI_RESULT" >&2; exit 1
+            [ -n "$WI_URL" ] && { rm -f "$AZ_ERR"; printf '%s\n' "$WI_URL"; exit 0; }
+            echo "ERROR: az boards work-item create reported success but no work item URL could be parsed from its output." >&2; sanitize_cli_output "$(cat "$AZ_ERR")" >&2; rm -f "$AZ_ERR"; exit 1
           fi
           # A genuine AzDO API failure (auth, permissions, invalid type) must surface loudly, not silently degrade to local tracking — the silent fallback is what produced orphaned/unassigned work items (#983).
-          echo "ERROR: az boards work-item create failed (type='$AZDO_WI_TYPE', assigned-to='$AZDO_WI_ASSIGNEE'). Resolve the AzDO failure (check az login, project permissions, or set AZDO_WORK_ITEM_TYPE if the type is invalid); not falling back to local tracking." >&2; sanitize_cli_output "$WI_RESULT" >&2; exit 1
+          echo "ERROR: az boards work-item create failed (type='$AZDO_WI_TYPE', assigned-to='$AZDO_WI_ASSIGNEE'). Resolve the AzDO failure (check az login, project permissions, or set AZDO_WORK_ITEM_TYPE if the type is invalid); not falling back to local tracking." >&2; sanitize_cli_output "$(cat "$AZ_ERR")" >&2; rm -f "$AZ_ERR"; exit 1
         else
           echo "WARN: 'az' CLI not found or org/project empty — using local tracking for AzDO remote" >&2
         fi
@@ -383,6 +382,7 @@ steps:
         command -v gh >/dev/null 2>&1 && EXTRACTED=$(timeout 60 gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[0].number // ""' 2>/dev/null || echo '')
         [ -z "$EXTRACTED" ] && EXTRACTED="$PR_NUMBER"
       elif [[ "$ISSUE_CREATION" =~ _workitems/edit/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
+      elif [[ "$ISSUE_CREATION" =~ _apis/wit/workItems/([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$ISSUE_CREATION" =~ issue_number=([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC_RAW" =~ AB#([0-9]+) ]]; then EXTRACTED="${BASH_REMATCH[1]}"


### PR DESCRIPTION
## Summary
Fixes the AzDO path of `workflow-prep` `step-03-create-issue`, which screen-scraped `az boards work-item create` text output and **failed the whole workflow after successfully creating a work item** — orphaning work items (AB#3502, AB#3515) and aborting `default-workflow` before any development step ran.

## Changes
- **step-03-create-issue**: capture only the `url` scalar via `--query "url" -o tsv` (a single field → a single line → no `read`-splitting, no multi-line ambiguity), and redirect the create command's stderr to a temp file instead of folding it into the parsed value with `2>&1`. All exit paths clean up the temp file and surface captured stderr loudly on failure (no silent fallback to local tracking, preserving #983). No `jq` dependency added — this mirrors the existing working reuse path `az boards work-item show ... --query "url" -o tsv`.
- **step-03b-extract-issue-number**: add a branch that extracts the id from the AzDO REST url form `.../_apis/wit/workItems/<id>` that the create/reuse paths actually emit (the extractor previously only matched the `_workitems/edit/` browser form, so the id would not have been parsed end-to-end).
- **Regression lock**: new `assert_azdo_work_item_url_parsing` in `test-default-workflow-reliability.sh` pins the url-scalar projection, the absence of the brittle `[id,url]` projection, the absence of `2>&1`-folding on the create command, and the presence of the REST-url extraction branch.

## Validation
- `bash amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh` passes (incl. the new assertion).
- `workflow-prep.yaml` stays 398 lines (< 400 phase-recipe brick limit).

Closes #1091
Closes #1102