### PR TITLE
feat(#1095): infra guardrail detecting silently-disabled strict branch protection

### DIFF
--- a/.github/workflows/branch-protection-guard.yml
+++ b/.github/workflows/branch-protection-guard.yml
@@ -1,0 +1,46 @@
+# Branch Protection Guard (issue #1095)
+#
+# WHAT THIS DOES
+#   Runs scripts/check-branch-protection.sh, which fails if strict up-to-date
+#   merges (required_status_checks.strict) on main have been turned off.
+#
+# THIS IS DETECTION, NOT PREVENTION
+#   This workflow catches the setting being turned off within one CI cycle: it
+#   runs once a day on a schedule, on every push to main, and on manual
+#   dispatch. It cannot stop an admin from turning strict off in the first
+#   place. The durable way to PREVENT that is an organization- or
+#   enterprise-level ruleset (an org-admin action). This workflow is the
+#   in-repo detection layer.
+#
+# DO NOT MAKE THIS A REQUIRED PR STATUS CHECK
+#   It depends on the BRANCH_PROTECTION_READ_TOKEN secret, which is not
+#   available to pull requests from forks. As a required check it would fail
+#   closed and block every such PR. Keep it as a standalone scheduled/push
+#   guard only.
+#
+# SETUP: this needs a repository Actions secret named
+# BRANCH_PROTECTION_READ_TOKEN — a fine-grained PAT scoped to this repo only
+# with administration: read. See scripts/check-branch-protection.sh for the
+# step-by-step token creation instructions.
+name: Branch Protection Guard
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  strict-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Check main branch protection strict setting
+        run: scripts/check-branch-protection.sh
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}

--- a/.github/workflows/branch-protection-guard.yml
+++ b/.github/workflows/branch-protection-guard.yml
@@ -34,6 +34,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   strict-guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
         run: scripts/check-skills-no-missing-helpers.sh
       - name: Toolchain refs — cross-target steps pinned to channel (issue #935)
         run: scripts/check-toolchain-refs.sh
+      - name: Branch-protection guard — strict-mode script logic (issue #1095)
+        shell: bash
+        run: bash tests/issue_1095_branch_protection_guard_test.sh
       - name: Recipes — PR always opens after successful push (issue #495)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-pr-always-opens.sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -286,6 +286,7 @@ Code-enforced workflow execution engine with declarative YAML recipes.
 - [CI Pipeline Reference](reference/ci-pipeline.md) - Pinned toolchain, cargo-nextest test job, disk freeing, caching, and required checks
 - [CI Wall-Clock Parallelization Reference](reference/ci-wallclock-parallelization.md) - Parallel fan-out job graph (no `needs: check`) and tag-conditional release optimization keeping shipped artifacts fully optimized
 - [Merge Flow Reference](reference/merge-flow.md) - How `main` merges: strict up-to-date branch protection with all 7 required checks stays on, why a GitHub merge queue is unavailable on a user-owned repo, and the serial green-and-up-to-date squash-merge flow
+- [Branch Protection Guard Reference](reference/branch-protection-guard.md) - In-repo detection that fails a check within one CI cycle when the strict up-to-date policy on `main` is turned off; the script, workflow, `BRANCH_PROTECTION_READ_TOKEN` setup, and why it is detection (not prevention)
 - [Validate Recipe Subprocess and Hook Input Contracts](howto/validate-recipe-subprocess-hook-contract.md) - Validate recipe child env handling and hook JSON compatibility
 - [Workflow Execution Guardrails](features/workflow-execution-guardrails.md) - Canonical execution roots, exact GitHub identity checks, and observer-only stall detection
 - [How to Configure Workflow Execution Guardrails](howto/configure-workflow-execution-guardrails.md) - Supply `expected_gh_account`, inspect `execution_root`, and troubleshoot failures

--- a/docs/reference/branch-protection-guard.md
+++ b/docs/reference/branch-protection-guard.md
@@ -1,0 +1,198 @@
+# Branch Protection Guard Reference
+
+> [Home](../index.md) > Reference > Branch Protection Guard
+
+The branch protection guard is an in-repo check that notices when the strict
+up-to-date merge policy on `main` gets turned off, and fails a check so the team
+finds out and turns it back on. It is the automated follow-up to the prose-only
+merge policy described in the [Merge Flow Reference](merge-flow.md).
+
+## What "strict" means and why it matters
+
+`main` is protected so a pull request can only merge after its branch has been
+brought up to date with the latest `main`. GitHub calls this "Require branches to
+be up to date before merging" and stores it as
+`required_status_checks.strict = true`. This is what makes merges serial and
+keeps every merge preceded by an up-to-date CI run. The
+[Merge Flow Reference](merge-flow.md) explains why this must stay on.
+
+Before this guard existed, that requirement lived only in documentation. If
+someone turned strict off, nothing noticed. This guard closes that gap: it reads
+the live setting and fails if it is anything other than `true`.
+
+## Detection, not prevention
+
+This guard **detects** the setting being turned off; it does **not prevent** it.
+A repository admin can still turn strict off from inside the repository. What
+this guard guarantees is that the change becomes loud — a check goes red within
+one CI cycle.
+
+The durable way to **prevent** the setting from being changed is an
+organization- or enterprise-level ruleset, which only an org admin can set up.
+That is out of scope for this guard; the guard is the in-repo detection layer
+that catches drift until (or unless) such a ruleset exists.
+
+| Layer | Who controls it | Effect |
+| --- | --- | --- |
+| This guard (workflow + script) | Repo maintainers | Detects drift, fails a check within one CI cycle |
+| Org / enterprise ruleset | Org admin | Prevents the setting from being changed at all |
+
+## Components
+
+| File | Role |
+| --- | --- |
+| `scripts/check-branch-protection.sh` | Reads `required_status_checks.strict` and exits non-zero unless it is exactly `true`. |
+| `.github/workflows/branch-protection-guard.yml` | Runs the script on a daily schedule, on every push to `main`, and on manual dispatch. |
+| `tests/issue_1095_branch_protection_guard_test.sh` | Offline unit test of the script's logic (runs in CI, needs no secret). |
+
+## Required setup: the `BRANCH_PROTECTION_READ_TOKEN` secret
+
+Reading a branch's protection settings needs admin-level read access. The token
+GitHub Actions gives a workflow by default (`GITHUB_TOKEN`) does **not** have
+that access and gets a `403`, even if the workflow requests
+`administration: read`. So the guard runs with a dedicated fine-grained Personal
+Access Token instead, supplied through the `GH_TOKEN` environment variable (the
+`gh` CLI reads `GH_TOKEN` automatically).
+
+Create the token once:
+
+1. GitHub → Settings → Developer settings → Personal access tokens →
+   Fine-grained tokens → **Generate new token**.
+2. **Resource owner:** this repository's owner. **Repository access:** only
+   **this** repository (not all repositories).
+3. **Permissions:** Repository permissions → **Administration → Read-only**.
+   Grant nothing else.
+4. Generate the token and copy it.
+5. In this repository: Settings → Secrets and variables → Actions →
+   **New repository secret**. Name it exactly `BRANCH_PROTECTION_READ_TOKEN` and
+   paste the token as the value.
+
+If the secret is absent, the scheduled guard fails loudly rather than passing
+silently — a silent pass would recreate the exact gap this guard exists to
+close.
+
+## The script: `scripts/check-branch-protection.sh`
+
+### Behavior
+
+The script reads the strict setting using structured extraction only
+(`gh api ... --jq`); it never parses JSON with `grep`, `sed`, or `awk`.
+
+```bash
+strict="$(gh api "repos/${REPO}/branches/${BRANCH}/protection" \
+  --jq '.required_status_checks.strict')"
+```
+
+It exits `0` only when `strict` is exactly `true`. Every other outcome — strict
+off, a missing token, or a failed API call — exits `1` and prints a GitHub
+Actions `::error::` annotation.
+
+### Environment variables
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `GH_TOKEN` | Yes | Fine-grained PAT with `administration: read`. If empty/unset, the script fails with a "not configured" error. |
+| `GITHUB_REPOSITORY` | No | `owner/repo` slug. Set automatically inside Actions; falls back to `gh repo view --json nameWithOwner -q .nameWithOwner` when unset. |
+| `PROTECTED_BRANCH` | No | Branch to check. Defaults to `main`. |
+
+### Exit status
+
+| Exit | Condition |
+| --- | --- |
+| `0` | `required_status_checks.strict` is exactly `true`. |
+| `1` | Strict is off, the token is missing, or the `gh api` call failed. |
+
+### Example output
+
+Healthy:
+
+```text
+OK: branch protection on main: required_status_checks.strict is 'true' (strict up-to-date merges enabled).
+```
+
+Strict turned off (exit 1):
+
+```text
+::error::branch protection on main: required_status_checks.strict is 'false', expected 'true'. Someone disabled strict up-to-date merges — re-enable immediately.
+```
+
+Token missing (exit 1):
+
+```text
+::error::branch-protection guard not configured: missing BRANCH_PROTECTION_READ_TOKEN (fine-grained PAT, this-repo-only, administration:read)
+```
+
+### Running it locally
+
+```bash
+GH_TOKEN=<fine-grained PAT> scripts/check-branch-protection.sh
+```
+
+Check a different branch:
+
+```bash
+GH_TOKEN=<fine-grained PAT> PROTECTED_BRANCH=release scripts/check-branch-protection.sh
+```
+
+## The workflow: `.github/workflows/branch-protection-guard.yml`
+
+### Triggers
+
+| Trigger | Purpose |
+| --- | --- |
+| `schedule` (`cron: "17 6 * * *"`) | Daily catch-all so drift is detected within one CI cycle. |
+| `push` to `main` | Fast feedback right after changes land on `main`. |
+| `workflow_dispatch` | On-demand manual run from the Actions tab. |
+
+### Permissions and shape
+
+- Top-level `permissions: contents: read` (least privilege). The admin read
+  comes from the PAT, not from `GITHUB_TOKEN`.
+- A `concurrency` group scoped to workflow and ref, `cancel-in-progress: true`.
+- A single job `strict-guard` on `ubuntu-latest`, `timeout-minutes: 5`, with a
+  SHA-pinned `actions/checkout`, that runs the script with
+  `GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}`.
+
+### Do not make this a required PR status check
+
+The guard depends on the `BRANCH_PROTECTION_READ_TOKEN` secret, which is not
+available to pull requests from forks. As a required check it would fail closed
+and block every such PR. Keep it as a standalone scheduled / push / dispatch
+guard only.
+
+## The test: `tests/issue_1095_branch_protection_guard_test.sh`
+
+The test is self-contained and never touches the real GitHub API. It puts a fake
+`gh` executable early on `PATH` and drives it with a `FAKE_STRICT` control
+variable, asserting:
+
+| Scenario | Expected result |
+| --- | --- |
+| Guard script present | `check-branch-protection.sh` exists and is executable. |
+| `GH_TOKEN=x FAKE_STRICT=true` | Exit `0`. |
+| `FAKE_STRICT=false` | Exit non-zero; stderr contains "expected 'true'". |
+| `GH_TOKEN` unset/empty | Exit non-zero; stderr contains "not configured". |
+| `FAKE_STRICT=apierror` | Exit non-zero. |
+
+It runs in CI as a step in the `check` (Lint & Format) job of
+`.github/workflows/ci.yml`, alongside the other `scripts/check-*.sh` checks, and
+needs no secret because it exercises only the script's logic.
+
+## Responding to a red guard
+
+1. Open the failed run and read the `::error::` annotation.
+2. If it says strict is not `true`, go to Settings → Branches (or the ruleset)
+   for `main` and re-enable "Require branches to be up to date before merging".
+3. Re-run the guard (`workflow_dispatch`) to confirm it is green.
+4. If it says the token is missing or the API call failed, check that the
+   `BRANCH_PROTECTION_READ_TOKEN` secret exists and still has
+   `administration: read` on this repository.
+
+## See also
+
+- [Merge Flow Reference](merge-flow.md) - The serial, strict, up-to-date merge
+  policy this guard protects.
+- [CI Pipeline Reference](ci-pipeline.md) - Required checks and the `check` job
+  the unit test runs in.
+- [CI Resource Discipline Reference](ci-resource-discipline.md) - Concurrency and
+  timeout conventions the guard workflow follows.

--- a/docs/reference/branch-protection-guard.md
+++ b/docs/reference/branch-protection-guard.md
@@ -173,6 +173,7 @@ variable, asserting:
 | `FAKE_STRICT=false` | Exit non-zero; stderr contains "expected 'true'". |
 | `GH_TOKEN` unset/empty | Exit non-zero; stderr contains "not configured". |
 | `FAKE_STRICT=apierror` | Exit non-zero. |
+| `GITHUB_REPOSITORY` unset | Resolves the slug via `gh repo view`, then exits `0` when strict is `true`. |
 
 It runs in CI as a step in the `check` (Lint & Format) job of
 `.github/workflows/ci.yml`, alongside the other `scripts/check-*.sh` checks, and

--- a/docs/reference/merge-flow.md
+++ b/docs/reference/merge-flow.md
@@ -43,3 +43,12 @@ PR is merged only after it is both green and up to date with `main`:
 
 Do **not** use `gh pr merge --admin`, and do **not** use `--no-verify`. Every PR
 goes through the same required checks with the strict up-to-date policy in place.
+
+## Keeping the strict policy on
+
+The strict up-to-date policy above is enforced automatically by the
+[Branch Protection Guard](branch-protection-guard.md): an in-repo check that
+reads the live `required_status_checks.strict` setting and fails within one CI
+cycle if it is ever turned off. That guard is detection, not prevention — it
+makes the change loud so it can be reverted; only an org- or enterprise-level
+ruleset can prevent the change outright.

--- a/scripts/check-branch-protection.sh
+++ b/scripts/check-branch-protection.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# check-branch-protection.sh — detect if strict up-to-date merges got turned off.
+#
+# WHAT THIS CHECKS
+#   The `main` branch is protected so that a pull request can only be merged
+#   after it has been brought up to date with the latest `main` (GitHub calls
+#   this "Require branches to be up to date before merging", stored as
+#   required_status_checks.strict = true). This script reads that setting and
+#   fails if it is anything other than true. If someone turns it off, this
+#   check goes red so the team notices and can turn it back on.
+#
+# WHY THE NORMAL WORKFLOW TOKEN CANNOT BE USED
+#   Reading a branch's protection settings needs admin-level read access. The
+#   token GitHub Actions hands to a workflow by default (GITHUB_TOKEN) does not
+#   have that access and gets a 403, even if the workflow asks for
+#   administration: read. So this script must run with a dedicated
+#   fine-grained Personal Access Token instead. The workflow passes that token
+#   in through the GH_TOKEN environment variable (the gh CLI reads GH_TOKEN
+#   automatically).
+#
+# HOW TO CREATE THE TOKEN SECRET (one-time setup)
+#   1. GitHub -> Settings -> Developer settings -> Personal access tokens ->
+#      Fine-grained tokens -> Generate new token.
+#   2. Resource owner: this repository's owner. Repository access: only THIS
+#      repository (not all repositories).
+#   3. Permissions: Repository permissions -> Administration -> Read-only.
+#      Grant nothing else.
+#   4. Generate the token, copy it.
+#   5. In this repository: Settings -> Secrets and variables -> Actions ->
+#      New repository secret. Name it exactly BRANCH_PROTECTION_READ_TOKEN and
+#      paste the token as the value.
+#
+# WHAT THIS IS AND IS NOT
+#   This is a DETECTION control, not prevention. A repository admin can still
+#   turn strict off from inside the repository; this script just makes that
+#   loud by failing a check within one CI cycle (the guard runs daily on a
+#   schedule, on every push to main, and on manual dispatch). The durable way
+#   to PREVENT the setting from being turned off is an organization- or
+#   enterprise-level ruleset, which only an org admin can set up. This script
+#   is the in-repo detection layer that catches drift until/if that exists.
+#
+# Usage:
+#   GH_TOKEN=<fine-grained PAT> scripts/check-branch-protection.sh
+#
+# Exit status:
+#   0  required_status_checks.strict is exactly true
+#   1  strict is off, the token is missing, or the API call failed
+#
+# Environment:
+#   GH_TOKEN            required; fine-grained PAT with administration: read
+#   GITHUB_REPOSITORY   owner/repo slug (set automatically in Actions); falls
+#                       back to `gh repo view` when unset
+#   PROTECTED_BRANCH    branch to check (defaults to main)
+
+set -euo pipefail
+
+BRANCH="${PROTECTED_BRANCH:-main}"
+
+# Require the admin-read token. Absence is a loud failure, never a silent pass:
+# a silent pass here would recreate the exact gap this guard exists to close.
+if [ -z "${GH_TOKEN:-}" ]; then
+    echo "::error::branch-protection guard not configured: missing BRANCH_PROTECTION_READ_TOKEN (fine-grained PAT, this-repo-only, administration:read)" >&2
+    exit 1
+fi
+
+# Resolve the owner/repo slug: prefer the value Actions provides, else ask gh.
+REPO="${GITHUB_REPOSITORY:-}"
+if [ -z "$REPO" ]; then
+    if ! REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"; then
+        echo "::error::could not determine repository slug (set GITHUB_REPOSITORY or run inside a gh-authenticated checkout)" >&2
+        exit 1
+    fi
+fi
+
+ERRFILE="$(mktemp)"
+cleanup() { rm -f "$ERRFILE"; }
+trap cleanup EXIT
+
+# Read the setting with structured extraction only (gh --jq). No grep/sed/awk
+# on JSON — brittle text parsing of API responses is not allowed here.
+if ! strict="$(gh api "repos/${REPO}/branches/${BRANCH}/protection" --jq '.required_status_checks.strict' 2>"$ERRFILE")"; then
+    echo "::error::branch-protection guard: 'gh api repos/${REPO}/branches/${BRANCH}/protection' failed (token likely lacks administration:read, or the repo/branch is wrong). gh output: $(tr '\n' ' ' <"$ERRFILE")" >&2
+    exit 1
+fi
+
+if [ "$strict" = "true" ]; then
+    echo "OK: branch protection on ${BRANCH}: required_status_checks.strict is 'true' (strict up-to-date merges enabled)."
+    exit 0
+fi
+
+echo "::error::branch protection on ${BRANCH}: required_status_checks.strict is '${strict}', expected 'true'. Someone disabled strict up-to-date merges — re-enable immediately." >&2
+exit 1

--- a/tests/issue_1095_branch_protection_guard_test.sh
+++ b/tests/issue_1095_branch_protection_guard_test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# TDD tests for issue #1095 — branch-protection strict-mode detection guard.
+#
+# Contract:
+#   scripts/check-branch-protection.sh reads required_status_checks.strict for
+#   the protected branch (via `gh api --jq`, structured extraction only) and:
+#     - exits 0 only when strict is exactly "true";
+#     - exits 1 when strict is "false" (or empty/other), printing an error that
+#       says it expected 'true';
+#     - exits 1 with a "not configured" error when the GH_TOKEN secret is
+#       absent (loud fail, never a silent pass);
+#     - exits 1 when the underlying `gh api` call fails.
+#
+# These tests are fully self-contained: a fake `gh` is placed early on PATH so
+# the script never contacts the real GitHub API. The fake is driven by the
+# FAKE_STRICT environment variable.
+#
+# Run: bash tests/issue_1095_branch_protection_guard_test.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GUARD="$REPO_ROOT/scripts/check-branch-protection.sh"
+
+pass=0
+fail=0
+TMPROOT=""
+
+cleanup() { [ -n "$TMPROOT" ] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+record_pass() {
+    echo "PASS: $1"
+    pass=$((pass + 1))
+}
+
+record_fail() {
+    echo "FAIL: $1"
+    fail=$((fail + 1))
+}
+
+TMPROOT="$(mktemp -d)"
+BINDIR="$TMPROOT/bin"
+mkdir -p "$BINDIR"
+
+# Fake `gh`: handles both the protection query and the repo-view fallback.
+# FAKE_STRICT drives behaviour:
+#   true|false|<other>  -> echoed as the strict value for the api call
+#   apierror            -> the api call exits non-zero (simulates 403 / bad repo)
+cat >"$BINDIR/gh" <<'FAKE'
+#!/usr/bin/env bash
+set -uo pipefail
+if [ "${1:-}" = "api" ]; then
+    if [ "${FAKE_STRICT:-}" = "apierror" ]; then
+        echo "HTTP 403: Must have admin rights to Repository." >&2
+        exit 1
+    fi
+    echo "${FAKE_STRICT:-}"
+    exit 0
+fi
+if [ "${1:-}" = "repo" ] && [ "${2:-}" = "view" ]; then
+    echo "octo/example"
+    exit 0
+fi
+echo "fake gh: unhandled args: $*" >&2
+exit 2
+FAKE
+chmod +x "$BINDIR/gh"
+
+# Common environment for invoking the guard with the fake gh on PATH.
+run_guard() {
+    # Args are passed as VAR=value env assignments plus stderr capture path.
+    local errfile="$1"
+    shift
+    PATH="$BINDIR:$PATH" GITHUB_REPOSITORY="octo/example" \
+        env "$@" bash "$GUARD" 2>"$errfile"
+}
+
+test_guard_exists() {
+    if [ -x "$GUARD" ]; then
+        record_pass "check-branch-protection.sh exists and is executable"
+    else
+        record_fail "check-branch-protection.sh missing or not executable at $GUARD"
+    fi
+}
+
+test_strict_true_passes() {
+    local err="$TMPROOT/err_true"
+    if run_guard "$err" GH_TOKEN=x FAKE_STRICT=true; then
+        record_pass "strict=true -> exit 0"
+    else
+        record_fail "strict=true should exit 0 (stderr: $(cat "$err"))"
+    fi
+}
+
+test_strict_false_fails() {
+    local err="$TMPROOT/err_false"
+    if run_guard "$err" GH_TOKEN=x FAKE_STRICT=false; then
+        record_fail "strict=false should exit non-zero but exited 0"
+    else
+        if grep -q "expected 'true'" "$err"; then
+            record_pass "strict=false -> non-zero and stderr mentions expected 'true'"
+        else
+            record_fail "strict=false: stderr missing \"expected 'true'\" (got: $(cat "$err"))"
+        fi
+    fi
+}
+
+test_missing_token_fails() {
+    local err="$TMPROOT/err_token"
+    # GH_TOKEN explicitly empty; FAKE_STRICT=true proves it fails on token, not value.
+    if run_guard "$err" GH_TOKEN= FAKE_STRICT=true; then
+        record_fail "missing GH_TOKEN should exit non-zero but exited 0"
+    else
+        if grep -q "not configured" "$err"; then
+            record_pass "missing token -> non-zero and stderr mentions 'not configured'"
+        else
+            record_fail "missing token: stderr missing 'not configured' (got: $(cat "$err"))"
+        fi
+    fi
+}
+
+test_api_error_fails() {
+    local err="$TMPROOT/err_api"
+    if run_guard "$err" GH_TOKEN=x FAKE_STRICT=apierror; then
+        record_fail "api error should exit non-zero but exited 0"
+    else
+        record_pass "api error -> non-zero exit"
+    fi
+}
+
+test_guard_exists
+test_strict_true_passes
+test_strict_false_fails
+test_missing_token_fails
+test_api_error_fails
+
+echo "=== Results: $pass passed, $fail failed ==="
+[ "$fail" -eq 0 ] || exit 1

--- a/tests/issue_1095_branch_protection_guard_test.sh
+++ b/tests/issue_1095_branch_protection_guard_test.sh
@@ -9,7 +9,9 @@
 #       says it expected 'true';
 #     - exits 1 with a "not configured" error when the GH_TOKEN secret is
 #       absent (loud fail, never a silent pass);
-#     - exits 1 when the underlying `gh api` call fails.
+#     - exits 1 when the underlying `gh api` call fails;
+#     - resolves the repo slug via `gh repo view` when GITHUB_REPOSITORY is
+#       unset (local / manual runs), then applies the same strict check.
 #
 # These tests are fully self-contained: a fake `gh` is placed early on PATH so
 # the script never contacts the real GitHub API. The fake is driven by the
@@ -76,6 +78,15 @@ run_guard() {
         env "$@" bash "$GUARD" 2>"$errfile"
 }
 
+# Variant that runs the guard with GITHUB_REPOSITORY unset, forcing the script
+# down the `gh repo view` slug-resolution fallback.
+run_guard_no_repo() {
+    local errfile="$1"
+    shift
+    PATH="$BINDIR:$PATH" \
+        env -u GITHUB_REPOSITORY "$@" bash "$GUARD" 2>"$errfile"
+}
+
 test_guard_exists() {
     if [ -x "$GUARD" ]; then
         record_pass "check-branch-protection.sh exists and is executable"
@@ -129,11 +140,23 @@ test_api_error_fails() {
     fi
 }
 
+test_slug_fallback_resolves_and_passes() {
+    local err="$TMPROOT/err_slug"
+    # GITHUB_REPOSITORY unset -> script must call `gh repo view` (fake returns
+    # octo/example) and then honour the strict value like any other run.
+    if run_guard_no_repo "$err" GH_TOKEN=x FAKE_STRICT=true; then
+        record_pass "GITHUB_REPOSITORY unset -> gh repo view fallback -> exit 0"
+    else
+        record_fail "slug fallback with strict=true should exit 0 (stderr: $(cat "$err"))"
+    fi
+}
+
 test_guard_exists
 test_strict_true_passes
 test_strict_false_fails
 test_missing_token_fails
 test_api_error_fails
+test_slug_fallback_resolves_and_passes
 
 echo "=== Results: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Adds an in-repo **detection** control so that turning off strict up-to-date merges (`required_status_checks.strict`) on `main` becomes a loud, failing check within one CI cycle. This closes the prose-only gap identified as a follow-up to #1089/#1094: previously nothing but documentation kept `strict` on.

This is honest about its limits: it **detects** drift, it does not **prevent** it. A repo admin can still disable `strict` from inside the repo; only an org/enterprise-level ruleset (an org-admin action) can truly prevent that. This workflow is the in-repo detection layer that catches drift daily until/if such a ruleset exists.

## What changed

- **`scripts/check-branch-protection.sh`** (new, executable): reads `required_status_checks.strict` via `gh api --jq` (structured extraction only — no grep/sed/awk on JSON). Fails loudly with a `::error::` annotation when the admin-read token is missing (no silent fail-open), when the API call fails, or when `strict` is anything other than `true`. Captures gh stderr via `mktemp` with `trap` cleanup.
- **`.github/workflows/branch-protection-guard.yml`** (new): daily schedule (`17 6 * * *`) + push to `main` + manual dispatch. Least-privilege `permissions: contents: read`. Runs the script with `GH_TOKEN` from the `BRANCH_PROTECTION_READ_TOKEN` secret.
- **`tests/issue_1095_branch_protection_guard_test.sh`** (new, executable): self-contained unit test with a fake `gh` on `PATH` (driven by `FAKE_STRICT`), covering `strict=true` (exit 0), `strict=false` (fails, "expected 'true'"), missing token ("not configured"), and API-error paths. No network access.
- **`.github/workflows/ci.yml`**: wires the unit test into the `check` job beside the other `scripts/check-*.sh` steps.

## Required one-time setup

The guard workflow needs a repository Actions secret **`BRANCH_PROTECTION_READ_TOKEN`** — a fine-grained PAT scoped to **this repo only** with **`administration: read`** and nothing else. The default `GITHUB_TOKEN` cannot read branch protection (403), even with `administration: read`. Step-by-step token instructions are in the header of `scripts/check-branch-protection.sh`.

> **Note:** This guard must **not** be added as a required PR status check — it depends on a secret unavailable to fork PRs and would otherwise fail closed and block every such PR.

## Test plan

- `bash tests/issue_1095_branch_protection_guard_test.sh` → 5/5 pass.
- `bash -n` clean; both workflow YAML files parse.
- The unit test now runs in CI's `check` job (needs no secret).

## Acceptance criteria

- ✅ Disabling `strict` on `main` triggers a failing check within one CI cycle (daily scheduled guard).
- ✅ The guard is independent of `docs/reference/merge-flow.md` — it is a workflow + script + test, not prose.

Closes #1095