### PR TITLE
Harden turn failure error: bound output tail, gate full output behind debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,8 @@ dependencies = [
  "async-trait",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/amplihack-turn/Cargo.toml
+++ b/crates/amplihack-turn/Cargo.toml
@@ -21,10 +21,15 @@ tokio = { version = "1", default-features = false, features = [
 ] }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
+# Lightweight logging facade only (no net, negligible transitive cost). Used to
+# emit failed-turn full output at debug level and warn on bad env config.
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time"] }
 async-trait = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 # Hermetic mock-session / mock-channel driver-loop contract tests (no network,
 # no real copilot). Registered as an explicit [[test]] target per repo convention.
@@ -36,3 +41,9 @@ path = "tests/driver_loop_it.rs"
 [[test]]
 name = "agent_session_it"
 path = "tests/agent_session_it.rs"
+
+# Turn-failure error hygiene (#1092): bounded tail, char-boundary safety,
+# env-configurable budget, debug-gated full output.
+[[test]]
+name = "turn_error_it"
+path = "tests/turn_error_it.rs"

--- a/crates/amplihack-turn/src/turn.rs
+++ b/crates/amplihack-turn/src/turn.rs
@@ -332,9 +332,14 @@ impl TurnRunner for CopilotTurnRunner {
                 // Do NOT embed the full child output in the surfaced error: it
                 // can carry secrets or megabytes of log text (see module docs).
                 // Preserve the historical stdout-then-stderr ordering when
-                // building the combined text.
-                let mut combined = String::from_utf8_lossy(&stdout_buf).into_owned();
-                combined.push_str(&String::from_utf8_lossy(&stderr_buf));
+                // building the combined text. Pre-size the buffer to the exact
+                // final length so the stderr append cannot trigger a realloc +
+                // recopy of the (potentially large) stdout portion.
+                let stdout_lossy = String::from_utf8_lossy(&stdout_buf);
+                let stderr_lossy = String::from_utf8_lossy(&stderr_buf);
+                let mut combined = String::with_capacity(stdout_lossy.len() + stderr_lossy.len());
+                combined.push_str(&stdout_lossy);
+                combined.push_str(&stderr_lossy);
 
                 // Full output goes only to debug logging, for operators who
                 // opt in. Report each stream's byte length as structured fields.

--- a/crates/amplihack-turn/src/turn.rs
+++ b/crates/amplihack-turn/src/turn.rs
@@ -16,6 +16,19 @@
 //! `copilot` process, publishes a child-bound pre-empt trigger into a shared
 //! [`PreemptSlot`] (so an out-of-band `stop` can pre-empt an in-flight turn
 //! without any PID-reuse race), and captures clean stdout.
+//!
+//! # Turn-failure error hygiene
+//!
+//! When a turn's child process exits non-zero, the returned error must NOT
+//! embed the child's full stdout/stderr: that output can contain secrets,
+//! tokens echoed by tools, absolute paths, or many megabytes of log text, and
+//! this error string is surfaced to logs and relayed onward. So by default the
+//! returned error contains only the exit status plus a bounded tail (the last
+//! few bytes) of the combined output. The full output is still emitted at
+//! `tracing::debug!` for operators who opt into debug logging.
+//!
+//! The size of that tail is controlled by the `AMPLIHACK_TURN_ERROR_TAIL_BYTES`
+//! environment variable (see [`DEFAULT_TURN_ERROR_TAIL_BYTES`]).
 
 use std::future::Future;
 use std::io;
@@ -25,6 +38,61 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 
 use crate::allowlist::ToolAllowlist;
+
+/// Default number of trailing bytes of a failed turn's combined stdout+stderr
+/// to include in the surfaced error when `AMPLIHACK_TURN_ERROR_TAIL_BYTES` is
+/// unset or cannot be parsed as an unsigned integer.
+///
+/// This is a deliberate, documented default rather than an arbitrary hard cap:
+/// operators can raise or lower it via the environment variable to trade error
+/// verbosity against the risk of leaking sensitive output into logs/relays.
+pub const DEFAULT_TURN_ERROR_TAIL_BYTES: usize = 2048;
+
+/// Environment variable that sets how many trailing bytes of a failed turn's
+/// combined output appear in the surfaced error string.
+const TURN_ERROR_TAIL_BYTES_ENV: &str = "AMPLIHACK_TURN_ERROR_TAIL_BYTES";
+
+/// Resolve the configured tail byte budget for turn-failure errors.
+///
+/// Reads [`TURN_ERROR_TAIL_BYTES_ENV`]. An unset variable uses
+/// [`DEFAULT_TURN_ERROR_TAIL_BYTES`]. A value that cannot be parsed as an
+/// unsigned integer is NOT silently ignored: it falls back to the default and
+/// emits a `tracing::warn!` naming the bad value, so misconfiguration is
+/// visible. A parseable `0` is honoured literally (an empty tail).
+fn turn_error_tail_bytes() -> usize {
+    match std::env::var(TURN_ERROR_TAIL_BYTES_ENV) {
+        Ok(raw) => match raw.parse::<usize>() {
+            Ok(n) => n,
+            Err(_) => {
+                tracing::warn!(
+                    env = TURN_ERROR_TAIL_BYTES_ENV,
+                    value = %raw,
+                    default = DEFAULT_TURN_ERROR_TAIL_BYTES,
+                    "ignoring unparseable turn-error tail byte budget; using default"
+                );
+                DEFAULT_TURN_ERROR_TAIL_BYTES
+            }
+        },
+        Err(_) => DEFAULT_TURN_ERROR_TAIL_BYTES,
+    }
+}
+
+/// Take the last `budget` bytes of `s`, snapping the start index FORWARD to the
+/// nearest UTF-8 char boundary so the slice never splits a multibyte character
+/// (which would panic). Snapping forward means the returned tail is always
+/// `<= budget` bytes. If `s` is already `<= budget` bytes, the whole string is
+/// returned.
+fn char_boundary_tail(s: &str, budget: usize) -> &str {
+    let len = s.len();
+    if len <= budget {
+        return s;
+    }
+    let mut start = len - budget;
+    while start < len && !s.is_char_boundary(start) {
+        start += 1;
+    }
+    &s[start..]
+}
 
 /// Shared pre-emption seam: holds a one-shot trigger bound to the in-flight
 /// child, or `None` when no turn is running.
@@ -155,10 +223,10 @@ impl<R: TurnRunner> crate::AgentSession for SerialTurnDriver<R> {
 /// turn. Pre-emption fires the trigger; this runner reacts by killing its
 /// **owned** [`tokio::process::Child`] handle (via `start_kill`), so the kill is
 /// bound to the exact process and is immune to PID reuse. A pre-empted turn
-/// surfaces as [`io::ErrorKind::Interrupted`]. On a non-zero exit the combined
-/// stderr/stdout is surfaced as an error so the chat can post the failure to
-/// the group and keep going (the next turn resumes the same session, context
-/// intact).
+/// surfaces as [`io::ErrorKind::Interrupted`]. On a non-zero exit the error
+/// carries the exit status plus a bounded tail of the combined output (the full
+/// output is emitted at debug level only); see the crate module docs on
+/// turn-failure error hygiene.
 pub struct CopilotTurnRunner {
     program: String,
     preempt: PreemptSlot,
@@ -261,10 +329,28 @@ impl TurnRunner for CopilotTurnRunner {
                     Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
                 })
             } else {
-                let stderr = String::from_utf8_lossy(&stderr_buf);
-                let stdout = String::from_utf8_lossy(&stdout_buf);
+                // Do NOT embed the full child output in the surfaced error: it
+                // can carry secrets or megabytes of log text (see module docs).
+                // Preserve the historical stdout-then-stderr ordering when
+                // building the combined text.
+                let mut combined = String::from_utf8_lossy(&stdout_buf).into_owned();
+                combined.push_str(&String::from_utf8_lossy(&stderr_buf));
+
+                // Full output goes only to debug logging, for operators who
+                // opt in. Report each stream's byte length as structured fields.
+                tracing::debug!(
+                    status = %status,
+                    stdout_len = stdout_buf.len(),
+                    stderr_len = stderr_buf.len(),
+                    output = %combined,
+                    "copilot turn failed; full combined output at debug"
+                );
+
+                let budget = turn_error_tail_bytes();
+                let tail = char_boundary_tail(&combined, budget);
+                let n = tail.len();
                 Err(io::Error::other(format!(
-                    "copilot turn failed ({status}): {stdout}{stderr}"
+                    "copilot turn failed ({status}); last {n} bytes of output: {tail}"
                 )))
             }
         })

--- a/crates/amplihack-turn/tests/turn_error_it.rs
+++ b/crates/amplihack-turn/tests/turn_error_it.rs
@@ -1,0 +1,222 @@
+//! Contract tests for turn-failure error hygiene (issue #1092).
+//!
+//! When a turn's child process exits non-zero, the surfaced error must NOT
+//! embed the child's full stdout/stderr. Instead it carries the exit status
+//! plus a BOUNDED TAIL of the combined output; the full output is emitted only
+//! at `tracing::debug!`. The tail budget is configurable via
+//! `AMPLIHACK_TURN_ERROR_TAIL_BYTES` (default 2048).
+//!
+//! These drive the real [`CopilotTurnRunner`] over a tiny `sh -c` program that
+//! writes to stdout/stderr and exits non-zero, so we exercise the actual
+//! non-zero-exit branch (not a mock).
+//!
+//! The tests are plain `#[test]` functions (not `#[tokio::test]`): each builds
+//! its own current-thread runtime and drives it via `block_on` INSIDE the env
+//! guard, so the env var is set for the whole failing run and env-mutating
+//! tests never race (a nested `#[tokio::test]` + `block_on` would panic).
+//!
+//! Run: `cargo test -p amplihack-turn --test turn_error_it`.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use amplihack_turn::{CopilotTurnRunner, PreemptSlot, TurnRunner};
+
+const TAIL_ENV: &str = "AMPLIHACK_TURN_ERROR_TAIL_BYTES";
+const DEFAULT_TAIL_BYTES: usize = 2048;
+
+/// Process-wide lock so env-mutating tests never race each other (the env is
+/// global). Mirrors the workspace's env-test serialization pattern.
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Set `AMPLIHACK_TURN_ERROR_TAIL_BYTES` for the duration of a closure, then
+/// restore the prior value. Edition 2024 requires `unsafe` around
+/// `set_var`/`remove_var`.
+fn with_tail_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+    let _guard = env_lock().lock().expect("env lock not poisoned");
+    let prev = std::env::var(TAIL_ENV).ok();
+    unsafe {
+        match value {
+            Some(v) => std::env::set_var(TAIL_ENV, v),
+            None => std::env::remove_var(TAIL_ENV),
+        }
+    }
+    let out = f();
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(TAIL_ENV, v),
+            None => std::env::remove_var(TAIL_ENV),
+        }
+    }
+    out
+}
+
+fn new_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build current-thread runtime")
+}
+
+/// Run a `sh -c` script and return the `Err` message from a non-zero exit.
+/// Builds and drives its own runtime so it can be called from a sync `#[test]`
+/// inside the env guard.
+fn run_failing(script: &str) -> String {
+    let preempt: PreemptSlot = Arc::new(Mutex::new(None));
+    // `sh` is the "program"; the argv is a `-c` script. The real production
+    // program is `copilot`, but the runner just spawns whatever program it was
+    // built with, so this exercises the identical non-zero-exit code path.
+    let runner = CopilotTurnRunner::new("sh", preempt);
+    let argv = vec!["-c".to_string(), script.to_string()];
+    let err = new_runtime()
+        .block_on(runner.run_argv(argv))
+        .expect_err("non-zero exit must surface as an error");
+    err.to_string()
+}
+
+/// The tail portion follows the documented marker; extract it so tests can
+/// assert on the bounded segment specifically.
+fn tail_of(msg: &str) -> &str {
+    let marker = "bytes of output: ";
+    let idx = msg
+        .find(marker)
+        .expect("error message must contain the tail marker");
+    &msg[idx + marker.len()..]
+}
+
+#[test]
+fn prefix_is_preserved() {
+    let msg = with_tail_env(None, || run_failing("echo hi; exit 1"));
+    assert!(
+        msg.contains("copilot turn failed"),
+        "prefix must be preserved for downstream consumers; got: {msg}"
+    );
+    assert!(
+        msg.contains("copilot turn failed (exit status:"),
+        "the ({{status}}) content must be preserved; got: {msg}"
+    );
+}
+
+#[test]
+fn multibyte_tail_does_not_panic_and_is_bounded() {
+    // Emit far more than the budget, ending in 4-byte characters so a naive
+    // byte slice would split a char and panic.
+    let budget = 16usize;
+    let script = "yes '😀' | head -n 2000 | tr -d '\\n'; exit 1";
+    let msg = with_tail_env(Some(&budget.to_string()), || run_failing(script));
+    let tail = tail_of(&msg);
+    assert!(
+        tail.len() <= budget,
+        "tail ({} bytes) must be <= budget ({budget}); got tail: {tail:?}",
+        tail.len()
+    );
+    // A valid &str here already proves no char boundary was split (would panic).
+    assert!(
+        !tail.is_empty(),
+        "tail should contain some trailing content"
+    );
+}
+
+#[test]
+fn bound_is_honored_for_large_ascii_output() {
+    let budget = 32usize;
+    let script = "printf '%0.sA' $(seq 1 5000); exit 3";
+    let msg = with_tail_env(Some(&budget.to_string()), || run_failing(script));
+    let tail = tail_of(&msg);
+    assert!(
+        tail.len() <= budget,
+        "tail ({} bytes) must not exceed configured budget ({budget})",
+        tail.len()
+    );
+}
+
+#[test]
+fn env_override_shrinks_tail() {
+    let script = "printf '%0.sB' $(seq 1 5000); exit 1";
+    let small = with_tail_env(Some("8"), || run_failing(script));
+    let large = with_tail_env(Some("64"), || run_failing(script));
+    assert!(
+        tail_of(&small).len() < tail_of(&large).len(),
+        "a smaller AMPLIHACK_TURN_ERROR_TAIL_BYTES must produce a shorter tail"
+    );
+    assert!(tail_of(&small).len() <= 8);
+    assert!(tail_of(&large).len() <= 64);
+}
+
+#[test]
+fn unparseable_env_falls_back_to_default() {
+    // 5000 ASCII bytes exceeds the 2048 default, so the tail is capped at it.
+    let script = "printf '%0.sC' $(seq 1 5000); exit 1";
+    let msg = with_tail_env(Some("not-a-number"), || run_failing(script));
+    let tail = tail_of(&msg);
+    assert!(
+        tail.len() <= DEFAULT_TAIL_BYTES,
+        "unparseable env must fall back to the default budget ({DEFAULT_TAIL_BYTES}); tail was {} bytes",
+        tail.len()
+    );
+    // With 5000 ASCII bytes of output and a 2048 default, the tail is trimmed
+    // to exactly the default (ASCII => no boundary snapping needed).
+    assert_eq!(
+        tail.len(),
+        DEFAULT_TAIL_BYTES,
+        "5000 ASCII bytes must be trimmed to the default tail budget"
+    );
+}
+
+#[test]
+fn full_output_only_at_debug_and_not_in_error_string() {
+    use std::io::Write;
+    use tracing::Level;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    // A MakeWriter that appends everything into a shared buffer, so we can
+    // inspect what was logged at DEBUG level.
+    #[derive(Clone)]
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+    impl Write for BufWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> MakeWriter<'a> for BufWriter {
+        type Writer = BufWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(Level::DEBUG)
+        .with_writer(BufWriter(buf.clone()))
+        .without_time()
+        .finish();
+
+    // A unique marker at the START of the output that must NOT appear in the
+    // returned error (it's beyond the small tail) but MUST appear in the debug
+    // log (which carries the full combined output).
+    let marker = "SECRET_TOKEN_ABCDEF";
+    let budget = 8usize;
+    let script = format!("printf '{marker}'; printf '%0.sZ' $(seq 1 4000); exit 1");
+
+    let msg = with_tail_env(Some(&budget.to_string()), || {
+        tracing::subscriber::with_default(subscriber, || run_failing(&script))
+    });
+
+    assert!(
+        !msg.contains(marker),
+        "full output must NOT leak into the surfaced error string; got: {msg}"
+    );
+
+    let logged = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert!(
+        logged.contains(marker),
+        "full combined output must be emitted at DEBUG level; log was: {logged}"
+    );
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -761,6 +761,7 @@ Security guidelines, context preservation, and best practices.
 - [Security Recommendations](SECURITY_RECOMMENDATIONS.md) - Essential security practices
 - [Security Context Preservation](SECURITY_CONTEXT_PRESERVATION.md) - Maintain security through sessions
 - [Security Guides](security/README.md) - Comprehensive security documentation
+- [Turn-Failure Error Hygiene](turn-error-hygiene.md) - Bounded, debug-gated turn-failure errors that avoid embedding child output (issue #1092)
 
 ### Safe Operations
 

--- a/docs/turn-error-hygiene.md
+++ b/docs/turn-error-hygiene.md
@@ -1,0 +1,299 @@
+# Turn-Failure Error Hygiene
+
+When a Copilot turn's child process exits non-zero, the driver in
+[`crates/amplihack-turn`](../crates/amplihack-turn) returns an error that
+describes the failure **without** dumping the child's full stdout/stderr into
+the surfaced message. By default the error carries only the exit status and a
+short, size-bounded tail of the combined output. The full output is still
+available to operators who opt into debug-level logging.
+
+This closes the information-disclosure and log-hygiene concern in issue #1092:
+raw child output can contain secrets, tokens echoed by tools, absolute paths,
+or many megabytes of log text, and this error string is both written to logs
+and relayed onward through the Signal chat layer.
+
+Read this document when you need to:
+
+- understand what a failed turn's error message contains and why,
+- configure how much trailing output that message includes,
+- retrieve the full child output while diagnosing a failure,
+- write or read tests that assert the failure-error contract.
+
+---
+
+## Contents
+
+- [Overview](#overview)
+- [What the error contains](#what-the-error-contains)
+- [Configuration: `AMPLIHACK_TURN_ERROR_TAIL_BYTES`](#configuration-amplihack_turn_error_tail_bytes)
+- [Retrieving the full output at debug level](#retrieving-the-full-output-at-debug-level)
+- [API reference](#api-reference)
+- [Examples](#examples)
+- [Design notes](#design-notes)
+- [Security invariants](#security-invariants)
+- [Testing](#testing)
+- [See also](#see-also)
+
+---
+
+## Overview
+
+The production turn runner, `CopilotTurnRunner`, spawns each `copilot` turn as a
+child process and captures its stdout and stderr. There are two outcomes:
+
+- **Success (zero exit).** The runner returns the child's captured stdout
+  verbatim as the turn output. This path is unchanged — full stdout is the
+  turn result, exactly as before.
+- **Failure (non-zero exit).** The runner returns an `io::Error` whose message
+  is a **summary**: the exact prefix `copilot turn failed ({status})` followed
+  by only a bounded tail of the combined stdout+stderr. The complete combined
+  output is emitted separately at `tracing::debug!`.
+
+Only the non-zero-exit path changed. The failure error still begins with the
+stable prefix `copilot turn failed`, so existing log parsing and the chat
+layer's `turn failed: {e}` relay message keep working.
+
+---
+
+## What the error contains
+
+On a non-zero exit the returned error string has the form:
+
+```text
+copilot turn failed ({status}); last {n} bytes of output: {tail}
+```
+
+- `{status}` — the child's exit status, e.g. `exit status: 3`. The
+  `copilot turn failed ({status})` prefix is preserved exactly and is stable
+  for downstream parsing.
+- `{n}` — the **actual** number of bytes in `{tail}` after the char-boundary
+  snap (see below). This is the truthful length of what follows, not the
+  configured budget.
+- `{tail}` — the last `n` bytes of the combined output, built as the child's
+  stdout followed by its stderr (preserving the historical ordering), decoded
+  losslessly (`from_utf8_lossy`).
+
+Behavioral details:
+
+- **Bounded.** `{tail}` is at most the configured budget in bytes (see
+  [configuration](#configuration-amplihack_turn_error_tail_bytes)). The error
+  message length no longer scales with child output size, so a chatty or
+  runaway child cannot flood logs or relayed messages.
+- **Short output.** If the combined output is already within the budget, the
+  whole output is included and `{n}` equals its full length.
+- **Multibyte-safe.** The tail start index is snapped **forward** to the
+  nearest UTF-8 character boundary, so the tail never splits a multibyte
+  character and never panics. Because the snap moves forward, the tail is
+  always `<= budget` bytes.
+- **Not redacted here.** The tail is bounded, not scrubbed. Redaction of
+  relayed message bodies is the responsibility of the relay layer
+  (`redact_for_relay` in `amplihack-signal`), which is the correct place to
+  apply it. The turn driver deliberately does not add a second redactor.
+
+---
+
+## Configuration: `AMPLIHACK_TURN_ERROR_TAIL_BYTES`
+
+The tail size is an explicit operator policy, not a fixed hardcoded cap.
+
+| | |
+| --- | --- |
+| **Environment variable** | `AMPLIHACK_TURN_ERROR_TAIL_BYTES` |
+| **Meaning** | Maximum number of trailing bytes of a failed turn's combined output to include in the surfaced error string. |
+| **Type** | Unsigned integer (bytes). |
+| **Default** | `2048` (the `DEFAULT_TURN_ERROR_TAIL_BYTES` constant) when the variable is unset. |
+| **Value `0`** | Honored literally — the error carries no tail, only the exit-status summary. |
+| **Unparseable value** | Any value that does not parse as an unsigned integer — including negative numbers and values that overflow `usize` — falls back to the default **and** emits a `tracing::warn!` naming the bad value. Misconfiguration is never silent. |
+
+Raise the budget when you want more failure context inline; lower it (or set it
+to `0`) to further reduce the amount of child output that can reach logs and
+relays. There is no upper limit imposed by the driver — the value you set is
+the value used — so choose it against your own log-hygiene policy.
+
+### Examples
+
+```bash
+# Default behavior: up to 2048 bytes of tail in the error.
+unset AMPLIHACK_TURN_ERROR_TAIL_BYTES
+
+# Tighten to a 256-byte tail.
+export AMPLIHACK_TURN_ERROR_TAIL_BYTES=256
+
+# Emit only the exit-status summary, no child output at all.
+export AMPLIHACK_TURN_ERROR_TAIL_BYTES=0
+
+# Bad value -> falls back to 2048 and logs a warning naming "banana".
+export AMPLIHACK_TURN_ERROR_TAIL_BYTES=banana
+```
+
+---
+
+## Retrieving the full output at debug level
+
+The complete combined output is never discarded — it is emitted at
+`tracing::debug!` with structured fields, so operators keep full diagnosability
+without exposing that output in the default error surface.
+
+The debug event carries:
+
+| Field | Meaning |
+| --- | --- |
+| `status` | The child's exit status. |
+| `stdout_len` | Length of the captured stdout, in bytes. |
+| `stderr_len` | Length of the captured stderr, in bytes. |
+| `output` | The full combined stdout+stderr text. |
+
+Message: `copilot turn failed; full combined output at debug`.
+
+Enable it by configuring your `tracing` subscriber to allow `DEBUG` for the
+`amplihack_turn` target, for example:
+
+```bash
+# With tracing-subscriber's EnvFilter:
+export RUST_LOG=amplihack_turn=debug
+```
+
+> **Operational note.** The full `output` field is intended for opt-in
+> diagnosis. Do not run production relays at `DEBUG` for `amplihack_turn` as a
+> default, since that reintroduces the full child output into your log sink.
+
+---
+
+## API reference
+
+Public surface (module `amplihack_turn::turn`):
+
+### `DEFAULT_TURN_ERROR_TAIL_BYTES`
+
+```rust
+/// Default number of trailing bytes of a failed turn's combined stdout+stderr
+/// to include in the surfaced error when `AMPLIHACK_TURN_ERROR_TAIL_BYTES` is
+/// unset or cannot be parsed as an unsigned integer.
+pub const DEFAULT_TURN_ERROR_TAIL_BYTES: usize = 2048;
+```
+
+The documented default budget. Exposed so callers and tests can reference the
+same value the runner uses.
+
+### `CopilotTurnRunner` (behavioral contract)
+
+`CopilotTurnRunner` implements the `TurnRunner` trait. Its `run_argv` future
+resolves to:
+
+- `Ok(String)` — the child's full captured stdout, on a zero exit.
+- `Err(io::Error)` — on a non-zero exit, an `io::Error::other(..)` whose
+  message is `copilot turn failed ({status}); last {n} bytes of output: {tail}`
+  as described in [What the error contains](#what-the-error-contains). Other
+  error kinds (e.g. `Interrupted` for a pre-empted turn) are unaffected by this
+  feature.
+
+The tail budget and the char-boundary snapping are internal helpers; only the
+default constant and the environment variable are part of the public contract.
+
+---
+
+## Examples
+
+### Reading a failed-turn error in the chat layer
+
+The Signal chat layer surfaces the error unchanged apart from a prefix:
+
+```text
+turn failed: copilot turn failed (exit status: 2); last 137 bytes of output: ...trailing output...
+```
+
+Because the `copilot turn failed` prefix is preserved, any code that matches on
+it (including the existing integration test asserting
+`msg.contains("copilot turn failed")`) continues to work.
+
+### Diagnosing a failure with full output
+
+```bash
+# Reproduce the failure with full child output visible.
+RUST_LOG=amplihack_turn=debug amplihack signal chat ...
+
+# In the logs, find:
+#   DEBUG amplihack_turn: copilot turn failed; full combined output at debug
+#       status=exit status: 2 stdout_len=41231 stderr_len=88 output=<full text>
+```
+
+---
+
+## Design notes
+
+- **Only the failure branch changed.** The success path still returns the full
+  captured stdout as the turn output. Nothing about a successful turn's output
+  is bounded or truncated.
+- **Forward char-boundary snap.** Taking the last `budget` bytes can land in the
+  middle of a multibyte UTF-8 sequence. Snapping the start index forward to the
+  next boundary guarantees a valid `&str` slice and keeps the result within the
+  budget. This mirrors the char-boundary-safe truncation used elsewhere for
+  prompt injection handling.
+- **No heavy dependencies.** The only new dependency is the lightweight
+  `tracing` logging facade (no networking, negligible transitive cost). The
+  `amplihack-turn` crate is always compiled and intentionally lean, so no
+  regex engine, redactor, or `tokio` `net` feature was added.
+- **No silent fallbacks.** An unparseable budget falls back to the default and
+  warns; it is never quietly ignored.
+
+---
+
+## Security invariants
+
+- **Bounded by default.** With no configuration, at most
+  `DEFAULT_TURN_ERROR_TAIL_BYTES` (2048) bytes of child output can appear in the
+  surfaced/relayed error. Full output is never embedded in full by default.
+- **Operator-gated full output.** The complete stdout+stderr is available only
+  at `tracing::debug!`, which is opt-in.
+- **Panic-free on hostile input.** Lossy UTF-8 decode plus a forward
+  char-boundary snap mean arbitrary child bytes cannot panic the tail
+  computation.
+- **Log-flood resistance.** The error-message size is independent of child
+  output size, so a runaway child cannot inflate logs or relayed messages
+  through this path.
+- **Stable prefix.** `copilot turn failed ({status})` is preserved for
+  downstream parsing and for the chat relay message.
+- **Redaction stays at the relay layer.** The tail is bounded but not scrubbed;
+  scrubbing of relayed bodies remains the responsibility of `redact_for_relay`
+  in `amplihack-signal`, avoiding a duplicated, misplaced redactor here.
+
+---
+
+## Testing
+
+Validation gate:
+
+```bash
+cargo fmt --all
+cargo clippy -p amplihack-turn --all-targets -- -D warnings
+cargo test  -p amplihack-turn                      # incl. turn_error_it
+cargo build -p amplihack-turn
+```
+
+Coverage in `crates/amplihack-turn/tests/turn_error_it.rs`:
+
+- **Multibyte safety.** A failing turn whose combined output ends in multibyte
+  UTF-8 characters longer than the tail budget produces a bounded tail and does
+  not panic.
+- **Bound honored.** The returned error's tail portion is `<= budget` bytes
+  (allowing for the forward char-boundary snap).
+- **Env override respected.** Setting `AMPLIHACK_TURN_ERROR_TAIL_BYTES` to a
+  small value shrinks the tail; an unparseable value falls back to
+  `DEFAULT_TURN_ERROR_TAIL_BYTES`.
+- **Prefix preserved.** The error still contains `copilot turn failed`.
+- **Full output at debug only.** A captured `tracing` subscriber observes the
+  full combined output at `DEBUG`, and that full output is **not** present in
+  the returned error string when it exceeds the tail budget.
+
+> **Test hygiene.** Environment-mutating tests are serialized through a
+> process-wide mutex and wrap `std::env::set_var`/`remove_var` in `unsafe`
+> (edition 2024) to avoid cross-test races, matching the pattern used elsewhere
+> in the workspace.
+
+---
+
+## See also
+
+- [Signal Chat Hardening](signal-chat-hardening.md)
+- [Signal Channel Turn Loop](signal-channel-turn-loop.md)
+- [`crates/amplihack-turn`](../crates/amplihack-turn)


### PR DESCRIPTION
## Summary

Resolves the info-disclosure / log-hygiene defect in the Copilot turn runner. On a non-zero child exit, `CopilotTurnRunner::run_argv` (`crates/amplihack-turn/src/turn.rs`) previously embedded the **full, unbounded** child stdout+stderr into the returned error string. That error is logged and relayed onward, so it could leak secrets, tokens echoed by tools, absolute paths, and megabytes of log text.

## What changed

The non-zero-exit branch now:

- Emits the **full** combined output only at `tracing::debug!` (structured fields: `status`, `stdout_len`, `stderr_len`, `output`) — full diagnosability stays available to operators who enable debug logging.
- Returns a **summary** error: the preserved prefix `copilot turn failed ({status})` plus a **bounded, char-boundary-safe tail** of the combined output: `copilot turn failed ({status}); last {n} bytes of output: {tail}`.

The tail budget is **operator-configurable** via `AMPLIHACK_TURN_ERROR_TAIL_BYTES` (documented default `2048`). Unset uses the default; an unparseable value falls back to the default **and** emits `tracing::warn!` naming the bad value (no silent misconfiguration). A parseable `0` is honoured literally.

The tail is computed char-boundary-safe (start index snapped **forward** to the nearest UTF-8 char boundary), so multibyte content never panics and the tail is always `<= budget` bytes.

## Scope / non-goals

- Surgical: only the non-zero-exit branch + a documented constant/env helper + `tracing` dep + tests + doc comments. The success path is untouched (still returns full captured stdout).
- **No redaction added here** — relay-body redaction remains `redact_for_relay`'s responsibility in `amplihack-signal` (hardened separately). Adding a second redactor would be the wrong layer.
- `tracing` is a lightweight facade (no net); the crate stays lean per its always-compiled constraint.

## Tests

New registered `[[test]]` `tests/turn_error_it.rs`, driving the real runner over `sh -c`:
- multibyte tail does not panic and is bounded,
- bound honored (`<=` configured budget),
- env override shrinks the tail,
- unparseable env falls back to the default,
- `copilot turn failed` prefix preserved,
- full output emitted at DEBUG only and absent from the returned error string (captured `tracing` subscriber).

`cargo test -p amplihack-turn`, `cargo clippy --all-targets -- -D warnings`, and `pre-commit run` all pass.

Closes #1092

---

## Step 16b: Outside-In Testing Results

**Detected toolchain:** Rust workspace (`Cargo.toml` at root, `Cargo.lock` present). Package manager: Cargo. Affected crate: `amplihack-turn` (changed files: `src/turn.rs`, `Cargo.toml`, new `tests/turn_error_it.rs`). Downstream consumer: `amplihack-cli` (`src/commands/signal/chat.rs` relays `"turn failed: {e}"`).

**Chosen strategy:** Per the qa-team skill's Rust-CLI guidance, use native `cargo test` at the real consumer boundary. The new integration test drives the **actual** `CopilotTurnRunner::run_argv` over a real `sh -c` child that writes output and exits non-zero — exercising the true non-zero-exit code path a user hits (not a mock).

**Branch:** `fix/issue-1092-resolve-github-issue-1092-harden-turn-failure-erro`

### Scenarios

| # | Type | Scenario | Command | Result |
|---|------|----------|---------|--------|
| 1 | Simple | Failing turn preserves `copilot turn failed (...)` prefix; downstream relay contract intact | `cargo test -p amplihack-turn --test turn_error_it` | ✅ 6/6 passed |
| 2 | Edge | Multibyte (4-byte `😀`) output longer than budget → bounded, char-boundary-safe tail, no panic | (same target) | ✅ pass |
| 3 | Edge | Env override `AMPLIHACK_TURN_ERROR_TAIL_BYTES` shrinks tail; unparseable value falls back to default 2048 | (same target) | ✅ pass |
| 4 | Edge | Full output emitted at DEBUG only; secret marker absent from returned error string | (same target) | ✅ pass |
| 5 | Integration | Full crate suite (14 lib + 6 turn_error + 7 exit_code + agent_session) | `cargo test -p amplihack-turn` | ✅ 33/33 passed |
| 6 | Integration | Downstream consumer still compiles with new error shape | `cargo build -p amplihack-cli` | ✅ built clean |
| 7 | Lint | Clippy on all targets | `cargo clippy -p amplihack-turn --all-targets` | ✅ no warnings |

**Key output:**
```
test result: ok. 6 passed; 0 failed  (turn_error_it.rs)
test result: ok. 14 passed; 0 failed (lib)
test result: ok. 7 passed; 0 failed  (turn_output_exit_code_it.rs)
```

**Fix count:** 0 — all scenarios passed on the first iteration. No code changes required during outside-in testing.