### PR TITLE
test(qa-team): add gadugi PR-ownership lease scenario (#1051, #1058)

### DIFF
--- a/tests/gadugi/run-pr-lease-scenario.sh
+++ b/tests/gadugi/run-pr-lease-scenario.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Self-asserting gadugi-test scenario body for the PR-ownership lease (issue #1051, PR #1058).
+#
+# Exercises the SHIPPED pr-lease behavioral contract end-to-end as a black box:
+#   - the lease integration suite (crates/amplihack-orchestration/tests/pr_lease_behavior.rs)
+#   - the CLI merge-gate tests (crates/amplihack-cli, pr::tests)
+# and asserts the observable contract that #1051 requires: a second session cannot
+# acquire a held lease, expired/corrupt leases are reclaimable, the TTL cannot
+# overflow into a permanent lease, drop releases the lease, and the merge gate
+# vetoes a merge unless the lease is owned.
+#
+# Launched by the gadugi `execute` action with no arguments, then checked with
+# `validate_exit_code` + an `ALL_CASES_PASSED` output assertion.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+fail=0
+pass() { echo "PASS: $1"; }
+fl()   { echo "FAIL: $1"; fail=1; }
+
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+
+# ---------------------------------------------------------------------------
+# Case 1: the shipped lease behavior contract (orchestration integration tests).
+# These treat the on-disk lease store as a black box via its public API and
+# assert acquire/stand-down/expiry/renew/release/CAS/traversal/corrupt/overflow.
+# ---------------------------------------------------------------------------
+if cargo test -p amplihack-orchestration --test pr_lease_behavior -- --nocapture >"$LOG" 2>&1; then
+  pass "pr_lease_behavior integration contract passes"
+else
+  fl "pr_lease_behavior integration contract FAILED"
+  tail -40 "$LOG"
+fi
+
+# Assert the specific safety-critical behaviors are actually present and green,
+# not merely that some tests ran.
+for t in \
+  cas_rejects_concurrent_second_writer \
+  file_slug_is_traversal_safe \
+  corrupt_record_is_reclaimable \
+  lease_record_expiry_does_not_overflow \
+  drop_releases_on_session_end \
+  contended_acquire_stands_down \
+  ; do
+  if grep -Eq "test .*${t} .* ok" "$LOG"; then
+    pass "safety behavior present and green: ${t}"
+  else
+    fl "safety behavior missing or not green: ${t}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Case 2: the CLI merge-gate contract — a merge is vetoed unless the lease is
+# owned, and the lease is released after a successful merge.
+# ---------------------------------------------------------------------------
+if cargo test -p amplihack-cli pr::tests -- --nocapture >"$LOG" 2>&1; then
+  pass "CLI merge-gate tests pass"
+else
+  fl "CLI merge-gate tests FAILED"
+  tail -40 "$LOG"
+fi
+for t in \
+  test_gated_merge_vetoes_when_lease_not_owned \
+  test_gated_merge_asserts_then_releases_on_success \
+  ; do
+  if grep -Eq "test .*${t} .* ok" "$LOG"; then
+    pass "gate behavior present and green: ${t}"
+  else
+    fl "gate behavior missing or not green: ${t}"
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "ALL_CASES_PASSED"
+  exit 0
+fi
+echo "SCENARIO_FAILED"
+exit 1

--- a/tests/gadugi/scenarios/pr-ownership-lease.yaml
+++ b/tests/gadugi/scenarios/pr-ownership-lease.yaml
@@ -1,0 +1,70 @@
+name: pr-ownership-lease
+description: >
+  QA-team scenario for the PR-ownership lease (issue #1051, shipped in PR #1058).
+  The lease prevents two concurrent orchestrator sessions from co-driving the same
+  pull request into a merge live-lock: a session acquires an advisory, TTL-bounded,
+  filesystem-backed lease before merging, and the CLI merge gate vetoes any merge
+  the session does not own. This scenario drives the SHIPPED lease contract end to
+  end (via tests/gadugi/run-pr-lease-scenario.sh) as a black box and asserts the
+  safety-critical behaviors: a contended second acquirer stands down, expired and
+  corrupt records are reclaimable (a crashed session cannot block a PR forever),
+  the TTL cannot overflow into a permanent lease, drop releases on session end, a
+  concurrent compare-and-set second writer is rejected, lease keys are
+  path-traversal-safe, and the merge gate vetoes a merge unless the lease is owned.
+version: "1.0"
+config:
+  timeout: 180000
+environment:
+  requires: []
+agents:
+  - name: cli-agent
+    type: cli
+    config: {}
+metadata:
+  tags: [cli, qa-team, pr-lease, orchestration, concurrency]
+  priority: high
+  issues: ["1051"]
+  pr: "1058"
+steps:
+  - name: run-pr-lease-contract
+    agent: cli-agent
+    action: execute
+    params:
+      command: tests/gadugi/run-pr-lease-scenario.sh
+    timeout: 170000
+  - name: contract-exits-clean
+    agent: cli-agent
+    action: validate_exit_code
+    params:
+      expected: 0
+  - name: all-lease-behaviors-pass
+    agent: cli-agent
+    action: validate_output
+    params:
+      expected: "shipped lease + merge-gate contract green"
+assertions:
+  - name: all-cases-passed
+    type: output_contains
+    params:
+      target: stdout
+      expected: ALL_CASES_PASSED
+  - name: contended-acquirer-stands-down
+    type: output_contains
+    params:
+      target: stdout
+      expected: "contended_acquire_stands_down"
+  - name: concurrent-cas-rejected
+    type: output_contains
+    params:
+      target: stdout
+      expected: "cas_rejects_concurrent_second_writer"
+  - name: expiry-cannot-overflow
+    type: output_contains
+    params:
+      target: stdout
+      expected: "lease_record_expiry_does_not_overflow"
+  - name: merge-gate-vetoes-unowned
+    type: output_contains
+    params:
+      target: stdout
+      expected: "test_gated_merge_vetoes_when_lease_not_owned"


### PR DESCRIPTION
## Summary

Adds the **qa-team outside-in scenario** that was skipped when PR #1058 (the PR-ownership lease from issue #1051) was merged.

During the retroactive merge-ready audit of #1058, I incorrectly claimed the qa-team criterion was "environment-blocked because `gadugi-test` is not installed." That was wrong — `gadugi-test` builds from `rysweet/gadugi-agentic-test` and I am responsible for this host. This PR corrects that by actually installing gadugi and adding + running the scenario.

## What this adds

- `tests/gadugi/run-pr-lease-scenario.sh` — self-asserting driver (10 assertions) that drives the **shipped lease contract** end to end as a black box.
- `tests/gadugi/scenarios/pr-ownership-lease.yaml` — the gadugi scenario (validated `--strict`).

It asserts the safety-critical lease behaviors from #1051:
- contended second acquirer **stands down** (no two sessions co-drive one PR)
- **expired and corrupt** records are reclaimable (a crashed session can't block a PR forever)
- TTL **cannot overflow** into a permanent lease
- **drop releases** on session end
- concurrent **compare-and-set** second writer is rejected
- lease keys are **path-traversal-safe**
- the CLI **merge gate vetoes** any merge the session does not own

## Evidence

```
$ gadugi-test validate -f tests/gadugi/scenarios/pr-ownership-lease.yaml --strict
✓ 1 scenario(s) valid: "pr-ownership-lease"

$ gadugi-test run -s pr-ownership-lease
✓ Command completed with exit code 0
Test Execution Results:
✓ Passed: 1
✗ Failed: 0
✓ All tests passed!
```

Driver output (all 10 assertions): `ALL_CASES_PASSED`.

Refs #1051. Follow-up to #1058.
