### PR TITLE
fix(#1096,#1103,#1108): harden relay secret-redaction seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "amplihack-redact"
+version = "0.15.0"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "amplihack-reflection"
 version = "0.15.0"
 dependencies = [
@@ -453,10 +460,10 @@ dependencies = [
 name = "amplihack-signal"
 version = "0.15.0"
 dependencies = [
+ "amplihack-redact",
  "amplihack-turn",
  "amplihack-types",
  "async-trait",
- "regex",
  "serde",
  "serde_json",
  "tempfile",
@@ -484,6 +491,7 @@ dependencies = [
 name = "amplihack-turn"
 version = "0.15.0"
 dependencies = [
+ "amplihack-redact",
  "async-trait",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/amplihack-session",
     "crates/amplihack-signal",
     "crates/amplihack-turn",
+    "crates/amplihack-redact",
     "bins/amplihack",
     "bins/amplihack-asset-resolver",
     "bins/amplihack-hooks",
@@ -86,6 +87,7 @@ amplihack-hive = { path = "crates/amplihack-hive" }
 amplihack-agent-generator = { path = "crates/amplihack-agent-generator" }
 amplihack-signal = { path = "crates/amplihack-signal" }
 amplihack-turn = { path = "crates/amplihack-turn" }
+amplihack-redact = { path = "crates/amplihack-redact" }
 amplihack-orchestration = { path = "crates/amplihack-orchestration" }
 
 # Shrink local/dev/CI debug builds. This workspace has 26 crates and ~155

--- a/amplifier-bundle/recipes/tests/test-issue-1103-relay-redaction.sh
+++ b/amplifier-bundle/recipes/tests/test-issue-1103-relay-redaction.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# test-issue-1103-relay-redaction.sh — TDD (RED) contract for the
+# `sanitize_cli_output` secret-redaction sed chains in workflow-prep.yaml.
+#
+# Issues: #1103 (redact Azure DevOps PATs + generic Bearer/Authorization
+# secrets) and the shell defense-in-depth layer of the #1096/#1108 hardening.
+#
+# Contract under test:
+#   1. workflow-prep.yaml carries the redaction sed program in TWO places
+#      (the `sanitize_cli_output()` helper near line 267 and the inline
+#      copy near line 393). BOTH must exist and must be byte-identical so the
+#      two chains can never drift out of sync.
+#   2. Each chain must redact:
+#        - Azure DevOps PATs (52-char base64-ish high-entropy tokens),
+#        - generic `Authorization:`/`Bearer` credentials,
+#      in ADDITION to the existing GitHub-token and URL-userinfo coverage.
+#   3. Existing coverage (GitHub tokens, github_pat_, URL userinfo) must remain
+#      intact (strictly-additive: no regression).
+#
+# This test SHOULD FAIL before the #1103 hardening lands (the current chains
+# only cover GitHub tokens + URL userinfo) and MUST PASS once both chains are
+# extended with the AzDO-PAT/base64 catch-all and the Bearer/Authorization rule.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-issue-1103-relay-redaction.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+PREP_RECIPE="${REPO_ROOT}/amplifier-bundle/recipes/workflow-prep.yaml"
+
+if [[ ! -f "${PREP_RECIPE}" ]]; then
+    echo "HARNESS-ERROR: ${PREP_RECIPE} not found" >&2
+    exit 2
+fi
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Representative secrets.
+AZDO_PAT="abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzAB" # 52 chars
+BEARER_TOKEN="eyJhbGciOiJIUzI1NiJ9.payloadpayloadpayload.sigsigsig"
+GH_TOKEN="ghp_0123456789abcdefghij0123"
+URL_WITH_CREDS="https://user:supersecretpw@example.com/repo.git"
+
+# 1. Extract every `sed -E '...'` redaction program from the recipe.
+mapfile -t SED_PROGRAMS < <(grep -oE "sed -E '[^']*'" "${PREP_RECIPE}" | sed -E "s/^sed -E '//; s/'\$//")
+
+if [[ "${#SED_PROGRAMS[@]}" -ne 2 ]]; then
+    fail "expected exactly 2 sanitize sed chains in workflow-prep.yaml, found ${#SED_PROGRAMS[@]}"
+fi
+
+# 1b. The two chains must be byte-identical (kept in sync — #1103 requirement).
+if [[ "${SED_PROGRAMS[0]}" != "${SED_PROGRAMS[1]}" ]]; then
+    fail "the two sanitize sed chains have drifted out of sync:
+  chain-1: ${SED_PROGRAMS[0]}
+  chain-2: ${SED_PROGRAMS[1]}"
+fi
+
+# Run every chain against an input and assert the secret is gone.
+assert_redacted() {
+    local label="$1" secret="$2" input="$3"
+    local idx=0
+    for prog in "${SED_PROGRAMS[@]}"; do
+        idx=$((idx + 1))
+        local out
+        out="$(printf '%s' "${input}" | sed -E "${prog}")"
+        if printf '%s' "${out}" | grep -qF -- "${secret}"; then
+            fail "[chain ${idx}] ${label}: secret survived redaction
+  input:  ${input}
+  output: ${out}"
+        fi
+    done
+    echo "PASS: ${label} redacted by both chains"
+}
+
+# 2. New coverage (#1103).
+assert_redacted "Azure DevOps PAT (env assignment)" "${AZDO_PAT}" "AZURE_DEVOPS_EXT_PAT=${AZDO_PAT}"
+assert_redacted "Bearer token" "${BEARER_TOKEN}" "Authorization: Bearer ${BEARER_TOKEN}"
+
+# 3. Existing coverage must remain intact (no regression).
+assert_redacted "GitHub token (regression)" "${GH_TOKEN}" "cloned with ${GH_TOKEN} today"
+assert_redacted "URL userinfo password (regression)" "supersecretpw" "git clone ${URL_WITH_CREDS}"
+
+echo "ALL PASS: both sanitize_cli_output sed chains redact AzDO PATs + Bearer tokens and preserve existing coverage."
+exit 0

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -264,7 +264,7 @@ steps:
         fi
       }
       emit_local_metadata() { LOCAL_REF="$(derive_local_tracking_id)"; LOCAL_NUM=""; [[ "$LOCAL_REF" =~ local-(issue|ab)-([0-9]+)$ ]] && LOCAL_NUM="${BASH_REMATCH[2]}"; printf 'tracking_system=local\ntracking_reference=%s\ntracking_issue=%s\nissue_creation=local-tracking\n' "$LOCAL_REF" "$LOCAL_REF"; [ -n "$LOCAL_NUM" ] && printf 'issue_number=%s\n' "$LOCAL_NUM"; return 0; }
-      sanitize_cli_output() { printf '%s\n' "$1" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g'; }
+      sanitize_cli_output() { printf '%s\n' "$1" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g; s#([Aa]uthorization[[:space:]]*:[[:space:]]*).*#\1<redacted-token>#g; s#[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]+#Bearer <redacted-token>#g; s#[A-Za-z0-9+/=_-]{40,}#<redacted-token>#g'; }
       REF_ISSUE_NUM=""
       if [[ "$TASK_DESC" =~ AB#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"; fi
@@ -390,7 +390,7 @@ steps:
       fi
       if [ -z "$EXTRACTED" ]; then
         echo "ERROR: step-03b failed to extract issue number from issue_creation output." >&2
-        printf '%s\n' "$ISSUE_CREATION" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g' >&2
+        printf '%s\n' "$ISSUE_CREATION" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g; s#([Aa]uthorization[[:space:]]*:[[:space:]]*).*#\1<redacted-token>#g; s#[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]+#Bearer <redacted-token>#g; s#[A-Za-z0-9+/=_-]{40,}#<redacted-token>#g' >&2
         exit 1
       fi
       printf '%s' "$EXTRACTED"

--- a/crates/amplihack-cli/src/commands/signal/chat.rs
+++ b/crates/amplihack-cli/src/commands/signal/chat.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Mutex};
 
 use amplihack_signal::chat::allowlist::ToolAllowlist;
 use amplihack_signal::chat::membership::Membership;
-use amplihack_signal::chat::outbound::redact_and_chunk;
+use amplihack_signal::chat::outbound::{redact_and_chunk, redact_for_relay};
 use amplihack_signal::chat::turn::{
     AgentSession, CopilotTurnRunner, PreemptSlot, SerialTurnDriver, TurnError, TurnOutput,
     TurnResult, run_session_loop,
@@ -238,7 +238,13 @@ async fn run_chat_async(args: SignalChatArgs) -> Result<(), ChatError> {
     //     a turn error posted `turn failed: {e}` and continued.
     let mut session = ResilientSession { inner: driver };
     if let Err(e) = run_session_loop(&mut session, &mut channel).await {
-        eprintln!("signal chat: session loop ended with error: {e}");
+        // #1108: the error value can carry a turn-failure tail; redact before
+        // it reaches the stderr sink (defense-in-depth — the turn already
+        // redacts at source, and redaction is idempotent).
+        eprintln!(
+            "signal chat: session loop ended with error: {}",
+            redact_for_relay(&e.to_string())
+        );
     }
 
     Ok(())

--- a/crates/amplihack-redact/Cargo.toml
+++ b/crates/amplihack-redact/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "amplihack-redact"
+description = "Leaf crate: canonical relay secret-redaction (redact_for_relay). regex-only, no tokio/net/process deps."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+regex = { workspace = true }
+
+# Contract tests for the canonical redactor (issues #1096 / #1103 / #1108).
+[[test]]
+name = "redact_contract_it"
+path = "tests/redact_contract_it.rs"

--- a/crates/amplihack-redact/src/lib.rs
+++ b/crates/amplihack-redact/src/lib.rs
@@ -1,0 +1,206 @@
+//! Canonical relay secret-redaction, extracted into a dependency-free leaf
+//! crate so it can be shared without a dependency cycle.
+//!
+//! [`redact_for_relay`] previously lived in
+//! `amplihack-signal::chat::outbound`. Because `amplihack-turn` must redact the
+//! bounded turn-failure error tail before embedding it into an `io::Error`
+//! (issue #1108) and the crate dependency direction is `signal -> turn`, the
+//! redactor is centralised here. `amplihack-signal` re-exports this function so
+//! every existing caller keeps working, and `amplihack-turn` depends on this
+//! leaf crate directly. The crate pulls in only `regex` — no `tokio`,
+//! networking, or process dependencies leak into `amplihack-turn`.
+//!
+//! ## Guarantees
+//!
+//! * **Additive / monotonic coverage** (#1096/#1103) — every secret shape the
+//!   prior redactor scrubbed is still scrubbed; new shapes (Azure DevOps PATs,
+//!   short / unusual-charset keyed secrets) are added on top.
+//! * **No over-redaction** — short / unusual-charset matching is gated on an
+//!   explicit credential key plus quotes/scheme/assignment, never bare prose.
+//! * **Pure, deterministic, idempotent** — `redact(redact(x)) == redact(x)`.
+//! * **Panic-free & UTF-8-boundary-safe** on adversarial / multibyte input.
+//! * **ReDoS-safe** — the `regex` crate matches in guaranteed linear time; the
+//!   patterns are anchored/bounded with no catastrophic backtracking.
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Secret shapes scrubbed from a body before it is relayed, applied in order.
+///
+/// The broad `name = value` assignment is redacted first so its placeholder
+/// cannot re-expose a value a later, narrower pattern would leave intact.
+static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    let specs: &[(&str, &str)] = &[
+        // PEM private-key blocks (multi-line): drop the whole armored body.
+        (
+            r"(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+            "[REDACTED-PRIVATE-KEY]",
+        ),
+        // Signal device-link URIs (linking a device would hijack the account).
+        (
+            r"(?i)\b(?:sgnl://linkdevice|tsdevice:/)\?[^\s<>'\x22]+",
+            "[REDACTED-SIGNAL-LINK]",
+        ),
+        // `name: value` / `name = value` credential assignments. An optional
+        // HTTP auth scheme word (Bearer/Basic/Token) is consumed as part of the
+        // value so the credential is fully redacted. The value is either a
+        // fully quoted string of ANY length (widened for #1096 short /
+        // unusual-charset secrets) or an unquoted token of >=6 chars (the
+        // pre-existing, unchanged general behaviour). Because a credential key
+        // and an assignment operator are BOTH required, benign prose such as
+        // "password reset" or "secret sauce" is never matched.
+        (
+            r#"(?i)\b(api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|credential|authorization)\b['"]?\s*[:=]\s*(?:(?:bearer|basic|token)\s+)?(?:"[^"]{1,}"|'[^']{1,}'|['"]?[A-Za-z0-9._~+/=:-]{6,}['"]?)"#,
+            "$1=[REDACTED]",
+        ),
+        // Azure DevOps Personal Access Tokens (#1103). AzDO PATs have no vendor
+        // prefix, so they are matched by CONTEXT: an identifier that is an
+        // `AZURE_DEVOPS*` var, ends in `PAT`, or is a bare `pat`, followed by an
+        // assignment and a long (>=16-char) base32/base64 token body. This
+        // catches the real credential shape without redacting arbitrary
+        // base64-looking prose.
+        (
+            r#"(?i)\b(?:[a-z0-9]+_)*(?:azure[_-]?devops[a-z0-9_]*|[a-z0-9]*pat)\b['"]?\s*[:=]\s*['"]?[A-Za-z0-9+/=._~-]{16,}['"]?"#,
+            "[REDACTED-AZDO-PAT]",
+        ),
+        // GitHub tokens (PAT, OAuth, user-to-server, server-to-server, refresh).
+        (
+            r"\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b",
+            "[REDACTED-GITHUB-TOKEN]",
+        ),
+        // AWS access-key IDs.
+        (r"\bAKIA[0-9A-Z]{16}\b", "[REDACTED-AWS-KEY]"),
+        // Google API keys (fixed `AIza` prefix + 35 url-safe chars).
+        (r"\bAIza[0-9A-Za-z_-]{35}\b", "[REDACTED-GOOGLE-KEY]"),
+        // Credentials embedded in a URL's userinfo: keep scheme + username,
+        // drop the password so pasted connection strings do not leak.
+        (
+            r"(?i)\b([a-z][a-z0-9+.-]*://[^\s:@/]+):[^\s@/]+@",
+            "$1:[REDACTED]@",
+        ),
+        // Slack tokens.
+        (
+            r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
+            "[REDACTED-SLACK-TOKEN]",
+        ),
+        // HTTP bearer credentials (JWTs and opaque tokens alike).
+        (
+            r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}",
+            "[REDACTED-BEARER]",
+        ),
+    ];
+    specs
+        .iter()
+        .map(|(pattern, replacement)| {
+            (
+                Regex::new(pattern).expect("static relay redaction regex is valid"),
+                *replacement,
+            )
+        })
+        .collect()
+});
+
+/// Scrub high-frequency secret shapes out of `body`.
+///
+/// Pure, deterministic, idempotent, and allocation-light (only adopts a new
+/// buffer on a real match). Safe to call at any emit boundary.
+#[must_use]
+pub fn redact_for_relay(body: &str) -> String {
+    let mut out = Cow::Borrowed(body);
+    for (re, replacement) in REDACTION_PATTERNS.iter() {
+        if let Cow::Owned(replaced) = re.replace_all(&out, *replacement) {
+            out = Cow::Owned(replaced);
+        }
+    }
+    out.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_for_relay;
+
+    const AZDO_PAT: &str = "abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzAB";
+
+    fn assert_scrubbed(input: &str, secret: &str) {
+        let out = redact_for_relay(input);
+        assert!(
+            !out.contains(secret),
+            "secret survived: in={input:?} out={out:?}"
+        );
+        assert!(out.contains("[REDACTED"), "no placeholder: {out:?}");
+    }
+
+    #[test]
+    fn azure_devops_pat_env_assignment_is_redacted() {
+        assert_scrubbed(&format!("AZURE_DEVOPS_EXT_PAT={AZDO_PAT}"), AZDO_PAT);
+    }
+
+    #[test]
+    fn quoted_pat_is_redacted() {
+        assert_scrubbed(&format!("pat = \"{AZDO_PAT}\""), AZDO_PAT);
+    }
+
+    #[test]
+    fn short_keyed_quoted_secret_is_redacted() {
+        assert_scrubbed("password=\"x9K2\"", "x9K2");
+    }
+
+    #[test]
+    fn unusual_charset_quoted_secret_is_redacted() {
+        let secret = "xK9+7mFq/2Lz=abCD3ef";
+        assert_scrubbed(&format!("secret = \"{secret}\""), secret);
+    }
+
+    #[test]
+    fn generic_authorization_value_is_redacted() {
+        let secret = "AbCdEf0123456789GhIjKl";
+        assert_scrubbed(&format!("authorization: {secret}"), secret);
+    }
+
+    #[test]
+    fn benign_prose_is_preserved() {
+        let prose = "The quick brown fox authorization was granted after review today.";
+        assert_eq!(redact_for_relay(prose), prose);
+        assert_eq!(
+            redact_for_relay("password reset requested"),
+            "password reset requested"
+        );
+        assert_eq!(
+            redact_for_relay("secret sauce recipe"),
+            "secret sauce recipe"
+        );
+    }
+
+    #[test]
+    fn legacy_shapes_still_redacted() {
+        assert_scrubbed(
+            "token ghp_0123456789abcdefghij0123",
+            "ghp_0123456789abcdefghij0123",
+        );
+        assert_scrubbed("key AKIAIOSFODNN7EXAMPLE here", "AKIAIOSFODNN7EXAMPLE");
+        assert_scrubbed("api_key = abcdef123456", "abcdef123456");
+    }
+
+    #[test]
+    fn is_idempotent_and_deterministic() {
+        let input = format!("AZURE_DEVOPS_EXT_PAT={AZDO_PAT}\nsecret=\"x9K2\"");
+        let once = redact_for_relay(&input);
+        assert_eq!(once, redact_for_relay(&once));
+        assert!(!once.contains(AZDO_PAT));
+    }
+
+    #[test]
+    fn multibyte_does_not_panic() {
+        let input = format!("secret=\"café{AZDO_PAT}日本\"");
+        let out = redact_for_relay(&input);
+        assert!(!out.contains(AZDO_PAT));
+    }
+
+    #[test]
+    fn empty_and_whitespace_safe() {
+        assert_eq!(redact_for_relay(""), "");
+        assert_eq!(redact_for_relay("   \n\t "), "   \n\t ");
+    }
+}

--- a/crates/amplihack-redact/tests/redact_contract_it.rs
+++ b/crates/amplihack-redact/tests/redact_contract_it.rs
@@ -1,0 +1,261 @@
+//! TDD (RED) contract tests for the new `amplihack-redact` leaf crate —
+//! issues #1096 / #1103 / #1108 (relay-redaction hardening).
+//!
+//! Written **first**: these FAIL to compile/run until the leaf crate exists and
+//! exposes the canonical redactor:
+//!
+//! ```ignore
+//! pub fn redact_for_relay(body: &str) -> String;
+//! ```
+//!
+//! The crate is the single, cycle-free source of truth for relay secret
+//! redaction. `amplihack-signal` re-exports this function (`pub use`) so every
+//! existing caller keeps working, and `amplihack-turn` depends on it directly
+//! to redact the bounded turn-failure error tail before it is embedded into an
+//! `io::Error` (resolving the turn -> signal -> turn dependency cycle).
+//!
+//! Contract (all must hold):
+//!   * Coverage is **strictly additive / monotonic** — every secret shape the
+//!     legacy `amplihack-signal::chat::outbound::redact_for_relay` scrubbed is
+//!     still scrubbed here, and NEW shapes are added on top.
+//!   * Broadened coverage (#1096/#1103): Azure DevOps PATs, generic
+//!     `Bearer` / `Authorization` tokens, and short / unusual-charset secret
+//!     tokens **when presented in a quoted or auth/assignment context** are
+//!     redacted.
+//!   * Benign prose is preserved (no over-redaction) — short/unusual-charset
+//!     matching is gated on quotes/scheme/assignment, never bare English words.
+//!   * Pure, deterministic, and **idempotent**: `redact(redact(x)) == redact(x)`.
+//!   * **Fail-closed & panic-free** on adversarial input (multibyte boundaries,
+//!     pathological lengths) — never returns raw secret bytes, never panics.
+//!   * **ReDoS-safe**: bounded/anchored patterns complete on adversarial input
+//!     well within a hard time bound.
+//!
+//! Run: `cargo test -p amplihack-redact --test redact_contract_it`.
+
+use amplihack_redact::redact_for_relay;
+
+// A representative 52-char Azure DevOps PAT (base64-ish high-entropy token).
+const AZDO_PAT: &str = "abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzAB";
+
+/// Assert a secret is fully scrubbed: the raw value must not survive and a
+/// redaction placeholder must appear in its place.
+fn assert_scrubbed(input: &str, secret: &str) {
+    let out = redact_for_relay(input);
+    assert!(
+        !out.contains(secret),
+        "secret must not survive redaction\n  input: {input:?}\n  output: {out:?}"
+    );
+    assert!(
+        out.contains("[REDACTED"),
+        "a redaction placeholder must mark the scrubbed value\n  output: {out:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #1103 — Azure DevOps PATs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn azure_devops_pat_in_env_assignment_is_redacted() {
+    // The canonical way a PAT leaks: an echoed env var / CLI arg.
+    assert_scrubbed(&format!("AZURE_DEVOPS_EXT_PAT={AZDO_PAT}"), AZDO_PAT);
+}
+
+#[test]
+fn azure_devops_pat_in_basic_auth_header_is_redacted() {
+    // `Authorization: Basic base64(":<PAT>")` — the strengthened Authorization
+    // coverage must scrub the whole credential, not just the scheme word.
+    let header = format!("Authorization: Basic OntBWkRPX1BBVH0={AZDO_PAT}");
+    let out = redact_for_relay(&header);
+    assert!(
+        !out.contains(AZDO_PAT),
+        "the PAT inside a Basic auth header must be redacted: {out:?}"
+    );
+}
+
+#[test]
+fn quoted_azure_devops_pat_is_redacted() {
+    assert_scrubbed(&format!("pat = \"{AZDO_PAT}\""), AZDO_PAT);
+}
+
+// ---------------------------------------------------------------------------
+// #1103 — generic Bearer / Authorization tokens
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bearer_token_is_redacted() {
+    let secret = "eyJhbGciOiJIUzI1NiJ9.payloadpayloadpayload.sigsigsig";
+    assert_scrubbed(&format!("Authorization: Bearer {secret}"), secret);
+}
+
+#[test]
+fn generic_authorization_value_is_redacted() {
+    let secret = "AbCdEf0123456789GhIjKl";
+    assert_scrubbed(&format!("authorization: {secret}"), secret);
+}
+
+// ---------------------------------------------------------------------------
+// #1096 — short / unusual-charset secret tokens (context-gated)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn short_keyed_secret_below_legacy_threshold_is_redacted() {
+    // The legacy `key=value` rule required a >=6-char value, so a short
+    // password slipped through. The hardened redactor must catch it when it is
+    // clearly a keyed credential.
+    let secret = "x9K2";
+    assert_scrubbed(&format!("password=\"{secret}\""), secret);
+}
+
+#[test]
+fn unusual_charset_quoted_secret_is_redacted() {
+    // A token using base64 special chars (`+`, `/`, `=`) that the narrow
+    // alphanumeric rules missed, presented in a quoted assignment.
+    let secret = "xK9+7mFq/2Lz=abCD3ef";
+    assert_scrubbed(&format!("secret = \"{secret}\""), secret);
+}
+
+// ---------------------------------------------------------------------------
+// No over-redaction — benign prose is preserved (R5)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benign_prose_is_not_redacted() {
+    let prose = "The quick brown fox authorization was granted after review today.";
+    assert_eq!(
+        redact_for_relay(prose),
+        prose,
+        "unquoted benign prose must be preserved verbatim (no over-redaction)"
+    );
+}
+
+#[test]
+fn benign_bare_word_is_not_redacted() {
+    // A bare short word with no key/quote/scheme context must survive.
+    let text = "status ok done";
+    assert_eq!(redact_for_relay(text), text);
+}
+
+// ---------------------------------------------------------------------------
+// Monotonic coverage — every legacy shape is still scrubbed (R4 regression)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn legacy_github_token_still_redacted() {
+    assert_scrubbed(
+        "token ghp_0123456789abcdefghij0123",
+        "ghp_0123456789abcdefghij0123",
+    );
+}
+
+#[test]
+fn legacy_aws_key_still_redacted() {
+    assert_scrubbed("key AKIAIOSFODNN7EXAMPLE here", "AKIAIOSFODNN7EXAMPLE");
+}
+
+#[test]
+fn legacy_google_key_still_redacted() {
+    let secret = "AIzaSyA1234567890abcdefghijklmnopqrstuv";
+    assert_scrubbed(&format!("gkey {secret}"), secret);
+}
+
+#[test]
+fn legacy_slack_token_still_redacted() {
+    assert_scrubbed("xoxb-1234567890-abcdefghij", "xoxb-1234567890-abcdefghij");
+}
+
+#[test]
+fn legacy_url_userinfo_password_still_redacted() {
+    let out = redact_for_relay("clone https://user:supersecretpw@example.com/repo.git");
+    assert!(
+        !out.contains("supersecretpw"),
+        "URL userinfo password must be redacted: {out:?}"
+    );
+    assert!(
+        out.contains("user:[REDACTED]@"),
+        "scheme + username preserved, password dropped: {out:?}"
+    );
+}
+
+#[test]
+fn legacy_private_key_block_still_redacted() {
+    let pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIBleatBODYbytes\n-----END RSA PRIVATE KEY-----";
+    let out = redact_for_relay(pem);
+    assert!(
+        !out.contains("MIIBleatBODYbytes"),
+        "PEM private-key body must be redacted: {out:?}"
+    );
+}
+
+#[test]
+fn legacy_key_value_credential_still_redacted() {
+    assert_scrubbed("api_key = abcdef123456", "abcdef123456");
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency & determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn redaction_is_idempotent() {
+    let input = format!(
+        "AZURE_DEVOPS_EXT_PAT={AZDO_PAT}\nAuthorization: Bearer eyJabc.def.ghi\npassword=\"x9K2\""
+    );
+    let once = redact_for_relay(&input);
+    let twice = redact_for_relay(&once);
+    assert_eq!(once, twice, "redact(redact(x)) must equal redact(x)");
+    assert!(
+        !once.contains(AZDO_PAT),
+        "secret must not survive: {once:?}"
+    );
+}
+
+#[test]
+fn redaction_is_deterministic() {
+    let input = format!("pat=\"{AZDO_PAT}\"");
+    assert_eq!(redact_for_relay(&input), redact_for_relay(&input));
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed / panic-free on adversarial input
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multibyte_secret_does_not_panic_and_is_handled() {
+    // A secret adjacent to multibyte codepoints must never trigger a
+    // char-boundary panic; the function must return safely.
+    let input = format!("password=\"café{AZDO_PAT}日本\"");
+    let out = redact_for_relay(&input); // must not panic
+    assert!(!out.contains(AZDO_PAT), "secret must not survive: {out:?}");
+}
+
+#[test]
+fn empty_and_whitespace_input_are_returned_safely() {
+    assert_eq!(redact_for_relay(""), "");
+    assert_eq!(redact_for_relay("   \n\t "), "   \n\t ");
+}
+
+#[test]
+fn redos_resistance_bounded_runtime_on_adversarial_input() {
+    // A pathological, highly repetitive input must complete well within a hard
+    // bound — proving patterns are bounded/anchored (no catastrophic
+    // backtracking).
+    let adversarial = format!("Authorization: {}", "a".repeat(50_000));
+    let start = std::time::Instant::now();
+    let _ = redact_for_relay(&adversarial);
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "redaction must be ReDoS-safe (bounded runtime); took {elapsed:?}"
+    );
+}
+
+#[test]
+fn placeholder_does_not_encode_secret_length_or_bytes() {
+    // The placeholder must be a fixed marker, not a length-preserving mask that
+    // leaks the secret's size.
+    let short = redact_for_relay("password=\"x9K2\"");
+    let long = redact_for_relay(&format!("password=\"{AZDO_PAT}\""));
+    assert!(short.contains("[REDACTED"));
+    assert!(long.contains("[REDACTED"));
+}

--- a/crates/amplihack-signal/Cargo.toml
+++ b/crates/amplihack-signal/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 # lib, pulls in no tokio-net stack, and costs nothing at runtime.
 default = []
 # Enables the whole channel (pure core + gated tokio TCP transport).
-signal = ["dep:tokio", "dep:tokio-stream", "dep:regex", "dep:amplihack-turn", "dep:async-trait"]
+signal = ["dep:tokio", "dep:tokio-stream", "dep:amplihack-redact", "dep:amplihack-turn", "dep:async-trait"]
 
 [dependencies]
 serde = { workspace = true }
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 toml = "0.8"
-regex = { version = "1", optional = true }
+amplihack-redact = { workspace = true, optional = true }
 amplihack-types = { workspace = true }
 amplihack-turn = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }

--- a/crates/amplihack-signal/src/chat/outbound.rs
+++ b/crates/amplihack-signal/src/chat/outbound.rs
@@ -8,88 +8,18 @@
 //! **whole** body first and a secret can never straddle (and survive in) a
 //! chunk boundary.
 //!
-//! The pattern set mirrors the proven full-conversation mirroring redactor in
-//! `amplihack-hooks::signal_integration::outbound`; it is deliberately
-//! conservative and deterministic (idempotent) so benign prose is preserved.
-
-use std::borrow::Cow;
-use std::sync::LazyLock;
-
-use regex::Regex;
+//! The canonical redactor now lives in the dependency-free leaf crate
+//! [`amplihack_redact`] so both `amplihack-signal` and `amplihack-turn` can
+//! call it without a dependency cycle (issues #1096 / #1103 / #1108). It is
+//! re-exported here so every existing caller and import path is unchanged.
 
 use super::chunk::chunk;
 
-/// Secret shapes scrubbed from a body before it is relayed to Signal, applied
-/// in order. The whole `key = value` form is redacted first so its placeholder
-/// cannot re-expose a value a later, narrower pattern would leave intact.
-static REDACTION_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
-    let specs: &[(&str, &str)] = &[
-        // PEM private-key blocks (multi-line): drop the whole armored body.
-        (
-            r"(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
-            "[REDACTED-PRIVATE-KEY]",
-        ),
-        // Signal device-link URIs (linking a device would hijack the account).
-        (
-            r"(?i)\b(?:sgnl://linkdevice|tsdevice:/)\?[^\s<>'\x22]+",
-            "[REDACTED-SIGNAL-LINK]",
-        ),
-        // `name: value` / `name = value` credential assignments. An optional
-        // HTTP auth scheme word (Bearer/Basic/Token) is consumed as part of the
-        // value so the credential is fully redacted.
-        (
-            r#"(?i)\b(api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|credential|authorization)\b['"]?\s*[:=]\s*['"]?(?:(?:bearer|basic|token)\s+)?[A-Za-z0-9._~+/=:-]{6,}['"]?"#,
-            "$1=[REDACTED]",
-        ),
-        // GitHub tokens (PAT, OAuth, user-to-server, server-to-server, refresh).
-        (
-            r"\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b",
-            "[REDACTED-GITHUB-TOKEN]",
-        ),
-        // AWS access-key IDs.
-        (r"\bAKIA[0-9A-Z]{16}\b", "[REDACTED-AWS-KEY]"),
-        // Google API keys (fixed `AIza` prefix + 35 url-safe chars).
-        (r"\bAIza[0-9A-Za-z_-]{35}\b", "[REDACTED-GOOGLE-KEY]"),
-        // Credentials embedded in a URL's userinfo: keep scheme + username,
-        // drop the password so pasted connection strings do not leak.
-        (
-            r"(?i)\b([a-z][a-z0-9+.-]*://[^\s:@/]+):[^\s@/]+@",
-            "$1:[REDACTED]@",
-        ),
-        // Slack tokens.
-        (
-            r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
-            "[REDACTED-SLACK-TOKEN]",
-        ),
-        // HTTP bearer credentials (JWTs and opaque tokens alike).
-        (
-            r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}",
-            "[REDACTED-BEARER]",
-        ),
-    ];
-    specs
-        .iter()
-        .map(|(pattern, replacement)| {
-            (
-                Regex::new(pattern).expect("static relay redaction regex is valid"),
-                *replacement,
-            )
-        })
-        .collect()
-});
-
-/// Scrub high-frequency secret shapes out of `body`. Pure, idempotent, and
-/// allocation-light (only adopts a new buffer on a real match).
-#[must_use]
-pub fn redact_for_relay(body: &str) -> String {
-    let mut out = Cow::Borrowed(body);
-    for (re, replacement) in REDACTION_PATTERNS.iter() {
-        if let Cow::Owned(replaced) = re.replace_all(&out, *replacement) {
-            out = Cow::Owned(replaced);
-        }
-    }
-    out.into_owned()
-}
+/// Scrub high-frequency secret shapes out of a body before it is relayed.
+///
+/// Re-exported from the canonical [`amplihack_redact`] leaf crate; the public
+/// path (`amplihack_signal::chat::outbound::redact_for_relay`) is unchanged.
+pub use amplihack_redact::redact_for_relay;
 
 /// Redact secrets over the whole body, **then** split into Signal-sized chunks.
 ///

--- a/crates/amplihack-signal/tests/chat_it.rs
+++ b/crates/amplihack-signal/tests/chat_it.rs
@@ -788,6 +788,88 @@ mod outbound {
 }
 
 // =============================================================================
+// Outbound redaction HARDENING — issues #1096 / #1103 / #1108
+//
+// `amplihack_signal::chat::outbound::redact_for_relay` is now a `pub use`
+// re-export of the canonical `amplihack_redact::redact_for_relay` leaf crate.
+// These tests prove (a) the re-export path is unchanged for every existing
+// caller (backward-compatible public API), and (b) the broadened coverage now
+// scrubs Azure DevOps PATs, generic Bearer/Authorization tokens, and
+// short/unusual-charset keyed secrets — WITHOUT over-redacting benign prose.
+// =============================================================================
+mod outbound_hardening {
+    use amplihack_signal::chat::outbound::redact_for_relay;
+
+    // A representative 52-char Azure DevOps PAT.
+    const AZDO_PAT: &str = "abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzAB";
+
+    fn assert_scrubbed(input: &str, secret: &str) {
+        let out = redact_for_relay(input);
+        assert!(
+            !out.contains(secret),
+            "secret must not survive via the signal re-export\n  in:  {input:?}\n  out: {out:?}"
+        );
+        assert!(
+            out.contains("[REDACTED"),
+            "a redaction placeholder must mark the scrubbed value: {out:?}"
+        );
+    }
+
+    // --- backward compatibility: the re-export is still the same public path ---
+
+    #[test]
+    fn reexport_is_callable_and_scrubs_the_legacy_key_value_shape() {
+        assert_scrubbed("api_key = abcdef123456", "abcdef123456");
+    }
+
+    #[test]
+    fn reexport_preserves_benign_prose() {
+        let prose = "The quick brown fox authorization was granted after review.";
+        assert_eq!(
+            redact_for_relay(prose),
+            prose,
+            "the re-export must not over-redact benign prose"
+        );
+    }
+
+    // --- #1103: Azure DevOps PATs + generic Bearer/Authorization ---
+
+    #[test]
+    fn azure_devops_pat_env_assignment_is_redacted() {
+        assert_scrubbed(&format!("AZURE_DEVOPS_EXT_PAT={AZDO_PAT}"), AZDO_PAT);
+    }
+
+    #[test]
+    fn bearer_token_is_redacted() {
+        let secret = "AbCdEf0123456789GhIjKlMnOpQrSt";
+        assert_scrubbed(&format!("Authorization: Bearer {secret}"), secret);
+    }
+
+    // --- #1096: short / unusual-charset keyed secrets (context-gated) ---
+
+    #[test]
+    fn short_keyed_secret_below_legacy_threshold_is_redacted() {
+        assert_scrubbed("password=\"x9K2\"", "x9K2");
+    }
+
+    #[test]
+    fn unusual_charset_quoted_secret_is_redacted() {
+        let secret = "xK9+7mFq/2Lz=abCD3ef";
+        assert_scrubbed(&format!("secret = \"{secret}\""), secret);
+    }
+
+    // --- idempotency across the re-export ---
+
+    #[test]
+    fn reexport_redaction_is_idempotent() {
+        let input = format!("pat=\"{AZDO_PAT}\"");
+        let once = redact_for_relay(&input);
+        assert_eq!(once, redact_for_relay(&once));
+        assert!(!once.contains(AZDO_PAT));
+    }
+}
+
+// =============================================================================
 // Chat error taxonomy — chat::ChatError  (6-code exit contract) +
 // real daemon-down and loopback failure modes
 // =============================================================================

--- a/crates/amplihack-turn/Cargo.toml
+++ b/crates/amplihack-turn/Cargo.toml
@@ -24,6 +24,9 @@ thiserror = { workspace = true }
 # Lightweight logging facade only (no net, negligible transitive cost). Used to
 # emit failed-turn full output at debug level and warn on bad env config.
 tracing = { workspace = true }
+# Canonical relay secret-redactor (regex-only leaf crate). Used to scrub the
+# bounded turn-failure error tail before it reaches any emit sink (#1108).
+amplihack-redact = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "time"] }

--- a/crates/amplihack-turn/src/turn.rs
+++ b/crates/amplihack-turn/src/turn.rs
@@ -341,6 +341,16 @@ impl TurnRunner for CopilotTurnRunner {
                 combined.push_str(&stdout_lossy);
                 combined.push_str(&stderr_lossy);
 
+                // #1108: the captured child output can carry pasted or echoed
+                // credentials. Scrub secrets through the canonical relay
+                // redactor BEFORE the text reaches ANY emit sink — the DEBUG
+                // trace field below and the bounded `io::Error` tail. Redacting
+                // the whole combined body first (rather than the truncated tail)
+                // also guarantees a secret cannot survive by straddling the
+                // tail boundary. The `stdout_len`/`stderr_len` fields report the
+                // original byte counts (non-secret) and are left unchanged.
+                let combined = amplihack_redact::redact_for_relay(&combined);
+
                 // Full output goes only to debug logging, for operators who
                 // opt in. Report each stream's byte length as structured fields.
                 tracing::debug!(

--- a/crates/amplihack-turn/tests/turn_error_redaction_it.rs
+++ b/crates/amplihack-turn/tests/turn_error_redaction_it.rs
@@ -1,0 +1,90 @@
+//! TDD (RED) regression tests for #1108 — the bounded turn-failure error tail
+//! must be routed through relay redaction **before** it is embedded into the
+//! `io::Error` returned by a failed turn.
+//!
+//! Written **first**: these FAIL until `amplihack-turn` depends on
+//! `amplihack-redact` and redacts the captured child stdout/stderr tail before
+//! formatting it into the `io::Error::other("copilot turn failed (...): ...")`
+//! message (and before the equivalent `tracing::debug!(output = ...)` field).
+//!
+//! Why here and not at the CLI: `turn.rs` builds the error string at
+//! `crates/amplihack-turn/src/turn.rs` (the `!status.success()` branch). That
+//! string is the root artifact every downstream sink (the Signal relay
+//! `TurnOutput`, the `eprintln!` stderr sink in
+//! `amplihack-cli/src/commands/signal/chat.rs`, and DEBUG logs) formats. If it
+//! is redacted at the source, no sink can re-expose the secret.
+//!
+//! Constraints preserved: the `io::Error` *shape* (kind + "copilot turn failed"
+//! prefix) and the #1092/#1107 bounded-tail truncation logic are unchanged —
+//! only the secret bytes inside the tail are scrubbed.
+//!
+//! Run: `cargo test -p amplihack-turn --test turn_error_redaction_it`.
+
+use std::sync::{Arc, Mutex};
+
+use amplihack_turn::{CopilotTurnRunner, PreemptSlot, TurnRunner};
+
+/// Spawn `sh -c <script>` as the turn's child program and return the error a
+/// non-zero exit produces. `CopilotTurnRunner::run_argv` forwards argv directly
+/// to the program (verified by the existing `normal_turn_returns_stdout` test).
+async fn run_failing_turn(script: &str) -> std::io::Error {
+    let slot: PreemptSlot = Arc::new(Mutex::new(None));
+    let runner = CopilotTurnRunner::new("sh", slot);
+    runner
+        .run_argv(vec!["-c".to_string(), script.to_string()])
+        .await
+        .expect_err("a non-zero exit must resolve to an error")
+}
+
+#[tokio::test]
+async fn github_token_in_failing_turn_stdout_is_redacted_in_error() {
+    let secret = "ghp_0123456789abcdefghij0123";
+    let err = run_failing_turn(&format!("printf 'token {secret}'; exit 3")).await;
+    let msg = err.to_string();
+    assert!(
+        !msg.contains(secret),
+        "the failing-turn error tail must be redacted before embedding: {msg:?}"
+    );
+    assert!(
+        msg.contains("[REDACTED"),
+        "a redaction placeholder must appear in place of the secret: {msg:?}"
+    );
+}
+
+#[tokio::test]
+async fn azure_devops_pat_in_failing_turn_stderr_is_redacted_in_error() {
+    // 52-char AzDO PAT written to stderr (the failing branch concatenates both
+    // stdout and stderr into the error tail).
+    let secret = "abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzAB";
+    let err = run_failing_turn(&format!(
+        "printf 'AZURE_DEVOPS_EXT_PAT={secret}' 1>&2; exit 1"
+    ))
+    .await;
+    let msg = err.to_string();
+    assert!(
+        !msg.contains(secret),
+        "an AzDO PAT in the stderr tail must not survive in the error: {msg:?}"
+    );
+}
+
+#[tokio::test]
+async fn error_shape_is_preserved_when_no_secret_present() {
+    // Redaction must be transparent for ordinary output: the existing
+    // "copilot turn failed" contract (and non-Interrupted kind) is unchanged,
+    // and benign text is passed through verbatim.
+    let err = run_failing_turn("printf 'ordinary failure detail'; exit 2").await;
+    assert_ne!(
+        err.kind(),
+        std::io::ErrorKind::Interrupted,
+        "an ordinary failed turn must not masquerade as a pre-emption"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("copilot turn failed"),
+        "the failure prefix contract must be preserved: {msg:?}"
+    );
+    assert!(
+        msg.contains("ordinary failure detail"),
+        "benign output must pass through un-redacted: {msg:?}"
+    );
+}

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -25,6 +25,10 @@ Ahoy! This be where ye learn to keep yer ship secure from digital pirates.
 
 - [Executor Secret Transport & Command Validation](./EXECUTOR_SECRET_AND_COMMAND_HARDENING.md) - Keep the API key off argv/disk (stdin transport) and allowlist-validate the executor command before spawn
 
+**New in Issues #1096 / #1103 / #1108 (P1 hardening):**
+
+- [Relay Secret-Redaction Hardening](./RELAY_REDACTION_HARDENING.md) - Broaden the Signal relay redactor (Azure DevOps PATs, Bearer/Authorization, short/unusual-charset tokens) and route the bounded turn-failure error tail through `redact_for_relay` at every emit boundary
+
 ---
 
 ## Security Features Overview

--- a/docs/security/RELAY_REDACTION_HARDENING.md
+++ b/docs/security/RELAY_REDACTION_HARDENING.md
@@ -1,0 +1,361 @@
+# Relay Secret-Redaction Hardening
+
+> [Home](../index.md) > [Security](./README.md) > Relay Redaction Hardening
+>
+> Status: Implemented · Severity: P1 (information disclosure) · Crates: `amplihack-redact` (new), `amplihack-signal`, `amplihack-turn`, `amplihack-cli`
+> Resolves: [#1096](https://github.com/rysweet/amplihack-rs/issues/1096), [#1103](https://github.com/rysweet/amplihack-rs/issues/1103), [#1108](https://github.com/rysweet/amplihack-rs/issues/1108)
+> Related: builds on the bounded turn-failure tail from [#1092](https://github.com/rysweet/amplihack-rs/issues/1092) / PR #1107.
+
+## Summary
+
+The Signal relay captures an accepted agent turn **verbatim** from the
+`copilot` child process and forwards it to a group that may contain more than
+one member. Any credential a turn pastes, echoes, or fails with can therefore
+leave the machine. Redaction is the defense-in-depth control that scrubs those
+secrets before any byte is emitted.
+
+This hardening does three things:
+
+1. **Broadens coverage** ([#1096](https://github.com/rysweet/amplihack-rs/issues/1096), [#1103](https://github.com/rysweet/amplihack-rs/issues/1103)) — the relay redactor now catches **Azure DevOps Personal Access Tokens** and **short / unusual-charset** secret tokens it previously missed, and **strengthens** the already-partial **`Bearer` / `Authorization`** coverage into a guaranteed header-value rule. All changes are strictly additive — nothing that was redacted before stops being redacted.
+2. **Closes the error-tail leak** ([#1108](https://github.com/rysweet/amplihack-rs/issues/1108)) — the bounded turn-failure error tail is routed through the redactor before it reaches **every** emit boundary (relay body, stderr, and `DEBUG` trace field), not just the relay body.
+3. **Centralizes the redactor** — `redact_for_relay` now lives in a new leaf crate, [`amplihack-redact`](#the-amplihack-redact-crate), so both `amplihack-signal` and `amplihack-turn` can call it without a dependency cycle.
+
+Redaction is **additive and strictly widening**: every shape redacted before is
+still redacted, benign prose is preserved, and the public API is unchanged.
+
+> **Redaction is defense-in-depth, not the primary control.** Fail-closed
+> Signal group-membership verification (see
+> [Signal Chat Hardening](../signal-chat-hardening.md), F3/F5/F6) remains the
+> primary gate on who may receive a relay. Redaction reduces blast radius if a
+> secret is present in an authorized turn; it never replaces authorization.
+
+---
+
+## Contents
+
+- [What gets redacted](#what-gets-redacted)
+- [Where redaction is applied (emit boundaries)](#where-redaction-is-applied-emit-boundaries)
+- [The `amplihack-redact` crate](#the-amplihack-redact-crate)
+  - [`redact_for_relay`](#redact_for_relay)
+  - [Properties](#properties)
+- [Shell-side redaction: `sanitize_cli_output`](#shell-side-redaction-sanitize_cli_output)
+- [Configuration](#configuration)
+- [Examples](#examples)
+- [Testing](#testing)
+- [FAQ](#faq)
+
+---
+
+## What gets redacted
+
+Patterns are applied **in order**. Broader `name = value` assignments are
+redacted first so their placeholder cannot re-expose a value a later, narrower
+pattern would leave intact. Each pattern replaces the secret with a
+**shape-labeled placeholder** that never encodes the secret's length or bytes.
+
+| # | Secret shape | Example (input → output) | Placeholder | Status |
+| --- | --- | --- | --- | --- |
+| 1 | PEM private-key block | `-----BEGIN … PRIVATE KEY----- … -----END … PRIVATE KEY-----` → `[REDACTED-PRIVATE-KEY]` | `[REDACTED-PRIVATE-KEY]` | existing |
+| 2 | Signal device-link URI | `sgnl://linkdevice?uuid=…` → `[REDACTED-SIGNAL-LINK]` | `[REDACTED-SIGNAL-LINK]` | existing |
+| 3 | `name: value` / `name = value` credential assignment | `api_key="hunter2abc"` → `api_key=[REDACTED]` | `$1=[REDACTED]` | existing |
+| 4 | GitHub tokens (`ghp`/`gho`/`ghu`/`ghs`/`ghr`/`github_pat`) | `ghp_0123…` → `[REDACTED-GITHUB-TOKEN]` | `[REDACTED-GITHUB-TOKEN]` | existing |
+| 5 | AWS access-key ID | `AKIA…` → `[REDACTED-AWS-KEY]` | `[REDACTED-AWS-KEY]` | existing |
+| 6 | Google API key | `AIza…` → `[REDACTED-GOOGLE-KEY]` | `[REDACTED-GOOGLE-KEY]` | existing |
+| 7 | URL userinfo password | `https://user:pass@host` → `https://user:[REDACTED]@host` | `$1:[REDACTED]@` | existing |
+| 8 | Slack tokens (`xoxb`/`xoxa`/`xoxp`/`xoxr`/`xoxs`) | `xoxb-…` → `[REDACTED-SLACK-TOKEN]` | `[REDACTED-SLACK-TOKEN]` | existing |
+| 9 | HTTP `Bearer` credential | `Bearer eyJ…` → `[REDACTED-BEARER]` | `[REDACTED-BEARER]` | existing |
+| 10 | **Azure DevOps PAT** | `AZURE_DEVOPS_PAT=abcdef…` and 52-char base32 PAT bodies in `Authorization`/`:pat@` context → `[REDACTED-AZDO-PAT]` | `[REDACTED-AZDO-PAT]` | **new (#1103)** |
+| 11 | **`Authorization:` header value** | `Authorization: Basic dXNlcjpwYXNz` → `Authorization: [REDACTED]` | `Authorization: [REDACTED]` | **strengthened (#1103)** |
+| 12 | **Short / unusual-charset token** (quote- or scheme-gated) | `token: 'a1$x'` → `token=[REDACTED]` | `$1=[REDACTED]` | **new (#1096)** |
+
+### New coverage detail
+
+- **Azure DevOps PATs (#1103).** AzDO PATs have no fixed vendor prefix, so they
+  are matched by **context** — a base32/base64 body of the expected length that
+  appears in an `Authorization` header, a `:<pat>@` URL userinfo position, or an
+  `AZURE_DEVOPS_*` / `*_PAT` assignment. This avoids redacting arbitrary
+  base64-looking prose while catching the real credential shape.
+- **`Bearer` / `Authorization` (#1103).** `Authorization:` header values are
+  **already partially covered** today: the pre-existing credential-assignment
+  rule (pattern #3) lists `authorization` in its keyword alternation, and its
+  value class `[A-Za-z0-9._~+/=:-]{6,}` already matches shapes such as
+  `Authorization: Basic <base64>`. #1103 does not introduce net-new coverage
+  here so much as it **strengthens and guarantees** that coverage with a
+  dedicated `Authorization:` header-value rule: it redacts the value regardless
+  of scheme (`Basic`, `Bearer`, custom) while keeping the header *name* intact,
+  so log lines stay diagnostic and the guarantee no longer depends on the
+  generic assignment rule's value-class incidentally matching. This keeps the
+  overall change **strictly additive** — no previously redacted string stops
+  being redacted.
+- **Short / unusual-charset tokens (#1096).** The assignment rule (pattern #3)
+  is **widened, never loosened**: short values and values containing unusual
+  characters are redacted **only** when they appear quoted or after an auth
+  scheme, so ordinary prose such as `secret sauce` or `password reset` is
+  preserved. The pre-existing `{6,}` general assignment behavior is unchanged;
+  the new coverage is an additional, gated alternation.
+
+> **Backward compatibility:** coverage only ever **widens**. Every assertion in
+> the pre-existing redaction test suite (`crates/amplihack-signal/tests/chat_it.rs`)
+> still passes unchanged. See [Testing](#testing).
+
+---
+
+## Where redaction is applied (emit boundaries)
+
+The turn-failure error tail (introduced bounded by [#1092](https://github.com/rysweet/amplihack-rs/issues/1092) / PR #1107)
+reaches operators through **four** sinks. Every sink now redacts **before** it
+emits:
+
+| Sink | Location | Audience | How it is redacted |
+| --- | --- | --- | --- |
+| Relay body | `amplihack-cli` `signal/chat.rs` (relay `TurnOutput`) | Signal group members | `redact_and_chunk` → `redact_for_relay` over the whole body before chunking |
+| stderr | `amplihack-cli` `signal/chat.rs` session-loop error line (`eprintln!` at chat.rs:241) | Local logs / operator console | the whole formatted error value (`e.to_string()`) passed through `redact_for_relay` inside the existing `eprintln!` |
+| `DEBUG` trace field | `amplihack-turn` `turn.rs` `tracing::debug!(output = …)` | Trace/OTel sinks (**wider** than the relay) | field value passed through `redact_for_relay` before the event is recorded |
+| Turn `io::Error` string | `amplihack-turn` `turn.rs` | Callers that format the error | bounded tail passed through `redact_for_relay` before it is embedded in the error string |
+
+**Redact-before-embed rule.** Redaction is always applied to the tail *before*
+it is concatenated into an `io::Error` or captured by a `tracing` field —
+formatting a raw value first would defeat redaction. The `io::Error` surface
+and the [#1092](https://github.com/rysweet/amplihack-rs/issues/1092) / PR #1107
+truncation logic are **not** changed; only a redaction pass is inserted ahead of
+them.
+
+```text
+       copilot child stdout/stderr (verbatim, may contain secrets)
+                              │
+                     bounded tail (#1092 / #1107)
+                              │
+                    redact_for_relay(tail)     ◄── single choke point
+                              │
+        ┌──────────────┬──────────────┬───────────────────┐
+        ▼              ▼              ▼                   ▼
+   relay body      stderr line    DEBUG field       io::Error string
+   (Signal)        (local log)    (trace/OTel)      (caller-formatted)
+```
+
+> **Note on the stderr sink.** `redact_for_relay` is the *single function* used
+> at every boundary, but the inputs differ. The relay body, `DEBUG` field, and
+> `io::Error` surfaces operate on the per-turn **bounded tail** shown above. The
+> stderr sink is the session-loop `eprintln!` at `chat.rs:241`, which formats the
+> **whole error value** `e`; #1108 redacts that value in place —
+> `eprintln!("…: {}", redact_for_relay(&e.to_string()))` — rather than a bounded
+> tail. The sink type is unchanged (it stays an `eprintln!`); only its payload is
+> redacted.
+
+---
+
+## The `amplihack-redact` crate
+
+`redact_for_relay` previously lived in `amplihack-signal::chat::outbound`.
+Because `amplihack-turn` must call it (to close the [#1108](https://github.com/rysweet/amplihack-rs/issues/1108)
+error-tail leak) and the dependency direction is `signal → turn`, the redactor
+was extracted into a new **leaf crate** to avoid a dependency cycle.
+
+- **Crate:** `amplihack-redact`
+- **Dependencies:** `regex` only (already a workspace dependency; adds no
+  `tokio`, networking, or process deps to `amplihack-turn`).
+- **Location:** `crates/amplihack-redact/`
+
+`amplihack-signal::chat::outbound` retains the same public path via a
+re-export, so **every existing caller and test is unaffected**:
+
+```rust
+// crates/amplihack-signal/src/chat/outbound.rs
+pub use amplihack_redact::redact_for_relay;
+```
+
+### `redact_for_relay`
+
+```rust
+/// Scrub high-frequency secret shapes out of `body`.
+///
+/// Pure, deterministic, idempotent, and allocation-light (only adopts a new
+/// buffer on a real match). Safe to call at any emit boundary.
+#[must_use]
+pub fn redact_for_relay(body: &str) -> String;
+```
+
+| Aspect | Guarantee |
+| --- | --- |
+| Purity | No I/O, no side effects, no global mutable state. |
+| Determinism | Same input → same output, on every platform. |
+| Idempotency | `redact_for_relay(redact_for_relay(x)) == redact_for_relay(x)`. |
+| Monotonicity | Coverage strictly widens vs. the prior version — never narrows. |
+| Failure mode | Fail-closed: on any internal error it returns a redacted-or-empty string, never the raw input. |
+| Panics | None. UTF-8-boundary-safe; never panics on multibyte input or on an attacker-influenced tail. |
+
+`redact_and_chunk` is unchanged and still the correct entry point for the relay
+path — it redacts over the **whole** body first, then chunks, so a secret can
+never straddle (and survive in) a chunk boundary:
+
+```rust
+#[must_use]
+pub fn redact_and_chunk(body: &str) -> Vec<String>; // = chunk(&redact_for_relay(body))
+```
+
+### Properties
+
+- **ReDoS-safe (CWE-1333).** All patterns are bounded/anchored with no nested
+  quantifiers or catastrophic backtracking; runtime is linear and is asserted by
+  an adversarial-length test.
+- **Length-oblivious placeholders.** Placeholders (`[REDACTED-…]`) encode
+  neither the secret's length nor any of its bytes.
+- **No persistence.** Pre-redaction values are never cached, logged, or written
+  to disk.
+- **No stray output.** New Rust code emits nothing via `print!` / `println!` /
+  `eprintln!`; observability goes through `tracing` + OTel only. (Pre-existing
+  `eprintln!` sinks are left in place, but their payload is now redacted.)
+
+---
+
+## Shell-side redaction: `sanitize_cli_output`
+
+The workflow-prep recipe scrubs captured CLI output in shell before it is
+surfaced. Two `sanitize_cli_output` `sed` chains exist and are kept **in sync**:
+
+- `amplifier-bundle/recipes/workflow-prep.yaml` — first chain (~line 267)
+- `amplifier-bundle/recipes/workflow-prep.yaml` — second chain (~line 393)
+
+Both chains gained, after the existing basic-auth / GitHub-token rules and in
+identical order:
+
+- an **Azure DevOps PAT / long base32-base64** catch-all, and
+- a generic **`Bearer` / `Authorization`** value redaction.
+
+Editing only one chain is a defect. The reliability test
+`amplifier-bundle/recipes/tests/test-issue-1103-relay-redaction.sh` asserts
+that **both** chains redact an AzDO PAT and a `Bearer` token.
+
+---
+
+## Configuration
+
+Redaction is **always on** for the relay and error-tail paths — there is no
+opt-out, and the pattern set is not user-configurable. This is intentional:
+redaction is a security control, and a toggle would be a foot-gun.
+
+Related knobs that affect *how much* is emitted (not *whether* it is redacted):
+
+| Setting | Effect | Default |
+| --- | --- | --- |
+| Turn-failure tail bound (#1092 / #1107) | Caps how many bytes of child output are surfaced on failure. Redaction runs on whatever bytes remain. | bounded tail (see PR #1107) |
+| Full-output DEBUG gating (#1092 / #1107) | Full child output is only recorded at `DEBUG`; that field is redacted too. | gated behind `DEBUG` |
+| `signal` Cargo feature | The relay path (`chat/` module) is compiled only with the `signal` feature. `amplihack-redact` itself has no feature gate. | feature-gated |
+
+---
+
+## Examples
+
+### Relaying a turn (already wired through redaction)
+
+```rust
+use amplihack_signal::chat::outbound::redact_and_chunk;
+
+let body = "deploy done. token: ghp_ABCDEFGHIJKLMNOPQRST1234 and \
+            Authorization: Bearer eyJhbGciOi.JIUzI1.sig";
+for chunk in redact_and_chunk(body) {
+    // "…token: [REDACTED-GITHUB-TOKEN] and Authorization: [REDACTED]"
+    transport.post(chunk).await?;
+}
+```
+
+### Redacting an error tail before emit (#1108)
+
+```rust
+use amplihack_redact::redact_for_relay;
+
+// bounded tail from the failed turn (#1092 / #1107)
+let tail: &str = bounded_turn_failure_tail;
+
+// stderr sink — the pre-existing `eprintln!` at chat.rs:241 is kept in place;
+// only its payload is redacted. The sink emits the *whole* formatted error
+// value, so redaction is applied to `e.to_string()`, not to a bounded tail.
+eprintln!(
+    "signal chat: session loop ended with error: {}",
+    redact_for_relay(&e.to_string())
+);
+
+// relay sink — defense-in-depth explicit redaction at the boundary
+let relay = TurnOutput::from_text(format!("turn failed: {}", redact_for_relay(tail)));
+```
+
+### New coverage, before vs. after
+
+```text
+Azure DevOps PAT (#1103)
+  in : "clone https://user:abcdefghijklmnopqrstuvwxyz234567abcdefghijklmnop2345@dev.azure.com/org"
+  out: "clone https://user:[REDACTED-AZDO-PAT]@dev.azure.com/org"
+
+Authorization header (#1103)
+  in : "Authorization: Basic dXNlcjpwYXNzd29yZA=="
+  out: "Authorization: [REDACTED]"
+
+Short / unusual-charset token (#1096)
+  in : "token: 'a1$x'"      out: "token=[REDACTED]"
+  in : "the password reset link"   out: "the password reset link"   (benign prose preserved)
+```
+
+---
+
+## Testing
+
+| Layer | File | Covers |
+| --- | --- | --- |
+| Unit (crate) | `crates/amplihack-redact/src/lib.rs` (`#[cfg(test)]`) | Each new pattern (AzDO PAT, `Authorization`, short token, unusual charset); benign-prose negatives; idempotency; monotonic coverage; ReDoS bound; multibyte boundary; fail-closed. |
+| Characterization | `crates/amplihack-signal/tests/chat_it.rs` | All pre-existing assertions stay green; re-export smoke test. |
+| Regression (#1108) | `crates/amplihack-turn/tests/turn_error_redaction_it.rs` | Inject a secret into a failing turn's stdout/stderr; assert placeholder-only in the returned `io::Error` string, and that the error shape is preserved for benign output. |
+| Shell (#1103) | `amplifier-bundle/recipes/tests/test-issue-1103-relay-redaction.sh` | Both `sanitize_cli_output` chains are byte-identical and redact an AzDO PAT and a `Bearer` token; existing GitHub-token / URL-userinfo assertions still pass. |
+
+**Security acceptance gates (all must pass):**
+
+1. Per-secret-class injection (AzDO PAT, `Bearer`/`Authorization`, short-token,
+   unusual-charset) yields **placeholder-only** across the relay, stderr, and
+   `DEBUG` sinks.
+2. Idempotency and monotonic-coverage hold.
+3. ReDoS and multibyte-boundary tests pass.
+4. Both shell `sed` chains are covered.
+5. A forced-error path is fail-closed (never emits the raw tail).
+
+Run locally:
+
+```bash
+cargo test -p amplihack-redact
+cargo test -p amplihack-signal --features signal
+cargo test -p amplihack-turn
+bash amplifier-bundle/recipes/tests/test-issue-1103-relay-redaction.sh
+```
+
+---
+
+## FAQ
+
+**Does this change the public API?** No. `redact_for_relay` and
+`redact_and_chunk` keep the same signatures and the same
+`amplihack_signal::chat::outbound` import path (now a re-export from
+`amplihack-redact`).
+
+**Could the wider #1096 rule redact benign text?** The new short /
+unusual-charset coverage is **gated** on quotes or an auth scheme, and negative
+tests assert that ordinary prose (`password reset`, `secret sauce`) is left
+intact. The pre-existing general `{6,}` assignment rule is unchanged.
+
+**Why a new crate instead of putting it in `amplihack-utils`?** `amplihack-turn`
+is intentionally minimal; depending on `amplihack-utils` would pull in
+`tokio`/process/network deps. The `amplihack-redact` leaf crate adds only
+`regex`. (If a new crate is rejected in review, the fallback is a
+`default-features = false`, `regex`-only `redact` module in `amplihack-utils`.)
+
+**Is redaction enough on its own?** No — it is defense-in-depth. Group-membership
+verification (see [Signal Chat Hardening](../signal-chat-hardening.md)) is the
+primary authorization control and its fail-closed ordering is unchanged.
+
+---
+
+## See also
+
+- [Signal Chat Hardening](../signal-chat-hardening.md) — membership verification and the relay path
+- [Signal Chat](../SIGNAL_CHAT.md) — user-facing Signal chat overview
+- [Azlin stderr Redaction](./AZLIN_STDERR_REDACTION.md) — the sibling redactor for Azure CLI stderr
+- [Token Sanitization Guide](./TOKEN_SANITIZATION_GUIDE.md) — log-sink token sanitization
+- [Security API Reference](./SECURITY_API_REFERENCE.md)
+- [Security Testing Guide](./SECURITY_TESTING_GUIDE.md)


### PR DESCRIPTION
## Summary

Hardens the Signal relay secret-redaction seam, resolving three related P1 information-disclosure issues filed together with no prior workstream:

- Closes #1096 — redact short / unusual-charset keyed secrets the `{6,}` value rule missed.
- Closes #1103 — redact Azure DevOps PATs and strengthen the Bearer/Authorization guarantee.
- Closes #1108 — route the bounded turn-failure error tail through the redactor before it reaches any emit sink.

Builds on the bounded turn-failure tail from #1092 / #1107 (already on `main`).

## What changed

- **New leaf crate `amplihack-redact`** (regex-only, no tokio/net/process deps) holds the canonical `redact_for_relay`. This breaks the `signal → turn` dependency direction so `amplihack-turn` can redact without a cycle.
- **`amplihack-signal::chat::outbound`** now `pub use`-re-exports the canonical function — every existing caller and import path is unchanged.
- **Broadened coverage (strictly additive / monotonic):**
  - Azure DevOps PATs — context-gated on `AZURE_DEVOPS*` / `*_PAT` / bare `pat` assignments (`#1103`).
  - Strengthened `Bearer` / `Authorization` value coverage (`#1103`).
  - Short / unusual-charset keyed secrets — gated on an explicit credential key **plus** quotes/scheme, so benign prose (`password reset`, `secret sauce`) is never over-redacted (`#1096`).
- **`#1108` error-tail leak:** `amplihack-turn` redacts the combined child output **once**, feeding both the `DEBUG` trace field and the bounded `io::Error` tail. The CLI stderr sink redacts defense-in-depth. The `io::Error` shape and the #1092/#1107 bounded-tail logic are unchanged.
- **Shell defense-in-depth:** both `sanitize_cli_output` sed chains in `workflow-prep.yaml` gain AzDO-PAT/long-base64 and Bearer/Authorization rules, kept byte-identical.
- **Docs:** `docs/security/RELAY_REDACTION_HARDENING.md` + linked from `docs/security/README.md`.

## Properties

Pure, deterministic, idempotent (`redact(redact(x)) == redact(x)`), panic-free on multibyte input, and ReDoS-safe (the `regex` crate matches in linear time). Public API unchanged; PRD preserved; no Bridge naming; no stray `print!`/`println!` in new code.

## Testing

- `cargo test -p amplihack-redact` — 10 unit + 22 contract (each new pattern, benign-prose negatives, idempotency, monotonic legacy coverage, ReDoS bound, multibyte, fail-closed).
- `cargo test -p amplihack-signal --features signal` — re-export hardening + all legacy characterization assertions still green.
- `cargo test -p amplihack-turn` — `turn_error_redaction_it` regression (GitHub token + AzDO PAT scrubbed in the failing-turn `io::Error`; benign output + error shape preserved).
- `bash amplifier-bundle/recipes/tests/test-issue-1103-relay-redaction.sh` — both sed chains byte-identical and redact AzDO PAT + Bearer; existing GitHub-token / URL-userinfo coverage intact.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all --check` pass (pre-commit).