### PR TITLE
Harden sanitize_cli_output to redact AzDO PATs and Bearer tokens (#1103)

### DIFF
--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -1484,10 +1484,62 @@ assert_azdo_work_item_url_parsing() {
     echo "  PASS[azdo-wi]: step-03 url projection + step-03b REST-url extraction contracts hold"
 }
 
+assert_sanitize_cli_output_redacts_secrets() {
+    # Extract the single-line sanitize_cli_output definition from the recipe and eval it here.
+    local def
+    def="$(grep -F 'sanitize_cli_output() {' "${PREP_RECIPE}" | head -n 1 | sed -E 's/^[[:space:]]+//')"
+    [ -n "${def}" ] || fail "issue #1103: could not extract sanitize_cli_output definition from ${PREP_RECIPE}"
+    eval "${def}"
+
+    # Obviously-fake placeholder tokens (GitGuardian-safe: contain 'example'/'notreal' or repeated pattern).
+    local fake_bearer="example000notrealBEARERtoken000000000000"
+    local fake_pat="examplenotrealAZDOpattoken00000000000000000000000000"   # 52 chars
+    local fake_ghp="ghp_examplenotrealtoken000000"
+    local fake_gh_pat="github_pat_examplenotrealtoken000000"
+
+    # 1. Authorization: Bearer <token> is redacted (raw token must not survive; literal 'Bearer' may remain).
+    local out
+    out="$(sanitize_cli_output "Authorization: Bearer ${fake_bearer}")"
+    if printf '%s' "${out}" | grep -qF -- "${fake_bearer}"; then
+        fail "issue #1103: Bearer token was not redacted: ${out}"
+    fi
+    printf '%s' "${out}" | grep -qF -- 'Bearer <redacted-token>' \
+        || fail "issue #1103: expected 'Bearer <redacted-token>' in output: ${out}"
+
+    # 2. 52-char AzDO-PAT-shaped string is redacted.
+    out="$(sanitize_cli_output "pat=${fake_pat}")"
+    if printf '%s' "${out}" | grep -qF -- "${fake_pat}"; then
+        fail "issue #1103: 52-char AzDO PAT was not redacted: ${out}"
+    fi
+
+    # 3. Idempotency: sanitizing twice equals sanitizing once.
+    local raw="Authorization: Bearer ${fake_bearer} pat=${fake_pat} tok=${fake_ghp}"
+    local once twice
+    once="$(sanitize_cli_output "${raw}")"
+    twice="$(sanitize_cli_output "${once}")"
+    [ "${once}" = "${twice}" ] \
+        || fail "issue #1103: sanitize_cli_output not idempotent: '${once}' != '${twice}'"
+
+    # 4. Regression: existing ghp_ / github_pat_ tokens still redacted.
+    out="$(sanitize_cli_output "token ${fake_ghp} and ${fake_gh_pat}")"
+    if printf '%s' "${out}" | grep -qE -- "${fake_ghp}|${fake_gh_pat}"; then
+        fail "issue #1103: github token regression — token not redacted: ${out}"
+    fi
+
+    # 5. Benign line with no secret passes through unchanged (anti-silent-degradation, #983).
+    local benign="Created work item 4242 in project Contoso (no secrets here)"
+    out="$(sanitize_cli_output "${benign}")"
+    [ "${out}" = "${benign}" ] \
+        || fail "issue #1103: benign text was altered by sanitizer: '${out}' != '${benign}'"
+
+    echo "  PASS[sanitize]: sanitize_cli_output redacts Bearer/AzDO-PAT, stays idempotent, preserves benign text"
+}
+
 assert_pr_title_ignores_lockfiles
 assert_no_merge_directive_suppresses_auto_merge
 assert_gh_rate_limit_backoff_contracts
 assert_stanza_cleanup_guidance
 assert_azdo_work_item_url_parsing
+assert_sanitize_cli_output_redacts_secrets
 
 echo "PASS: default workflow reliability contracts are covered."

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -264,7 +264,7 @@ steps:
         fi
       }
       emit_local_metadata() { LOCAL_REF="$(derive_local_tracking_id)"; LOCAL_NUM=""; [[ "$LOCAL_REF" =~ local-(issue|ab)-([0-9]+)$ ]] && LOCAL_NUM="${BASH_REMATCH[2]}"; printf 'tracking_system=local\ntracking_reference=%s\ntracking_issue=%s\nissue_creation=local-tracking\n' "$LOCAL_REF" "$LOCAL_REF"; [ -n "$LOCAL_NUM" ] && printf 'issue_number=%s\n' "$LOCAL_NUM"; return 0; }
-      sanitize_cli_output() { printf '%s\n' "$1" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g'; }
+      sanitize_cli_output() { printf '%s\n' "$1" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g; s#[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]{20,}#Bearer <redacted-token>#g; s#[A-Za-z0-9]{52}#<redacted-token>#g'; }
       REF_ISSUE_NUM=""
       if [[ "$TASK_DESC" =~ AB#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"; fi


### PR DESCRIPTION
## Summary

Hardens the `sanitize_cli_output` shell filter in `amplifier-bundle/recipes/workflow-prep.yaml` (used on the Azure DevOps work-item create/error output paths) to also redact:

- **Generic `Authorization: Bearer <token>` secrets** — `s#[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]{20,}#Bearer <redacted-token>#g`
- **Azure DevOps 52-char PATs** — `s#[A-Za-z0-9]{52}#<redacted-token>#g` (length-anchored so 40-hex git SHAs and short benign tokens are unaffected)

This is defense-in-depth. The new clauses are appended **in place** to the existing single-line `sed -E` chain, after the github-token clauses, keeping the file at **398 lines** (under the 400-line `every_phase_subrecipe_under_400_lines` budget). No physical lines were added to `workflow-prep.yaml`.

## Invariants preserved

- **Idempotency**: `<redacted-token>` / `Bearer <redacted-token>` contain non-alphanumeric chars and are shorter than 52 alnum, so they cannot re-match. Sanitizing twice equals once.
- **Existing clauses** (basic-auth URL, `gh[pousr]_`, `github_pat_`) unchanged and still redact.
- **Anti-silent-degradation (#983)**: pure redact-and-print filter — benign text passes through unchanged.

## Tests

Added `assert_sanitize_cli_output_redacts_secrets` to `test-default-workflow-reliability.sh`. It extracts the single-line function definition from the recipe, `eval`s it, and asserts:

1. `Authorization: Bearer <token>` — raw token redacted (literal `Bearer` may remain)
2. 52-char AzDO-PAT-shaped string redacted
3. Idempotency (sanitize twice == once)
4. Regression: `ghp_` / `github_pat_` still redacted
5. Benign line passes through unchanged

Placeholder tokens are obviously fake (`example`/`notreal`, repeated `0`s) to avoid GitGuardian false positives.

## Verification

- `bash amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh` → exit 0, new `PASS[sanitize]` line
- `wc -l amplifier-bundle/recipes/workflow-prep.yaml` → 398 (< 400)
- Only the two named files changed; no Rust changes.

Closes #1103