### PR TITLE
fix(#1103): redact AzDO PATs and Bearer tokens in sanitize_cli_output

### DIFF
--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -1558,7 +1558,36 @@ assert_sanitize_cli_output_redacts_secrets() {
     [ "${out}" = "${benign}" ] \
         || fail "issue #1103: benign non-secret content must pass through unchanged (got: '${out}')"
 
-    echo "  PASS[sanitize]: sanitize_cli_output redacts Bearer + 52-char AzDO PAT, stays idempotent, preserves gh_*/github_pat_ clauses and benign passthrough"
+    # 6. Divergence guard (issue #1103 follow-up): the recipe carries two secret-
+    #    scrubbing sed chains that CANNOT share a function because they live in
+    #    separate recipe steps (separate shells): the canonical sanitize_cli_output
+    #    and an inline chain on the GitHub issue-creation error path. They drifted
+    #    once (the inline copy lacked the Bearer + 52-char AzDO-PAT clauses), so pin
+    #    that every "<redacted-token>" sed chain carries the SAME clause count and
+    #    the same hardened clauses. Any future clause added to one chain but not the
+    #    other fails here instead of silently leaking a token on the divergent path.
+    local -a redaction_lines
+    mapfile -t redaction_lines < <(grep -nE 'sed -E .*<redacted-token>' "${PREP_RECIPE}")
+    [ "${#redaction_lines[@]}" -ge 2 ] \
+        || fail "issue #1103: expected >=2 <redacted-token> sed chains in ${PREP_RECIPE}, found ${#redaction_lines[@]}"
+    local ref_count="" line clause_count
+    for line in "${redaction_lines[@]}"; do
+        clause_count="$(printf '%s' "${line}" | grep -oE 's#[^#]*#[^#]*#g' | wc -l | tr -d ' ')"
+        [ "${clause_count}" -ge 5 ] \
+            || fail "issue #1103: a <redacted-token> sed chain has ${clause_count} clauses (<5), divergence detected on line ${line%%:*}"
+        printf '%s' "${line}" | grep -q 'Bearer' \
+            || fail "issue #1103: a <redacted-token> sed chain is missing the Bearer clause (divergence) on line ${line%%:*}"
+        printf '%s' "${line}" | grep -q '{52}' \
+            || fail "issue #1103: a <redacted-token> sed chain is missing the 52-char AzDO-PAT clause (divergence) on line ${line%%:*}"
+        if [ -z "${ref_count}" ]; then
+            ref_count="${clause_count}"
+        else
+            [ "${clause_count}" -eq "${ref_count}" ] \
+                || fail "issue #1103: <redacted-token> sed chains have differing clause counts (${ref_count} vs ${clause_count}) - chains diverged"
+        fi
+    done
+
+    echo "  PASS[sanitize]: sanitize_cli_output redacts Bearer + 52-char AzDO PAT, stays idempotent, preserves gh_*/github_pat_ clauses, benign passthrough, and both scrub chains stay in parity"
 }
 
 assert_pr_title_ignores_lockfiles

--- a/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
+++ b/amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh
@@ -1484,10 +1484,88 @@ assert_azdo_work_item_url_parsing() {
     echo "  PASS[azdo-wi]: step-03 url projection + step-03b REST-url extraction contracts hold"
 }
 
+assert_sanitize_cli_output_redacts_secrets() {
+    # issue #1103: harden the sanitize_cli_output shell filter in workflow-prep.yaml
+    # so it ALSO redacts Azure DevOps Personal Access Tokens (classic 52-char
+    # alphanumeric) and generic "Authorization: Bearer <token>" values, on top of
+    # the existing basic-auth-URL / gh[pousr]_ / github_pat_ clauses.
+    #
+    # This pins the anti-regression, idempotency, and anti-silent-degradation
+    # (#983) invariants so a future edit cannot weaken existing clauses, break
+    # double-run stability, or start dropping benign output.
+    #
+    # All token literals below are OBVIOUSLY-FAKE (embedded example/NotReal
+    # markers, low-entropy padding) so the GitGuardian CI secret scanner does not
+    # flag them, mirroring the fake-constant convention in
+    # crates/amplihack-signal/tests/chat_it.rs.
+    local fn_def
+    fn_def="$(grep -F 'sanitize_cli_output() {' "${PREP_RECIPE}" | head -n1)" \
+        || fail "issue #1103: could not locate sanitize_cli_output definition in ${PREP_RECIPE}"
+    [ -n "${fn_def}" ] \
+        || fail "issue #1103: extracted sanitize_cli_output definition was empty"
+    # Load the recipe's REAL function into this test shell (single source of truth).
+    eval "${fn_def}" \
+        || fail "issue #1103: failed to eval extracted sanitize_cli_output definition"
+
+    local bearer_token="examplenotrealbearertokenvalue0000000000"
+    local gh_token="ghp_exampleNotRealToken0123456789abcd"
+    local gh_pat="github_pat_exampleNotReal0123456789"
+    local azdo_pat
+    azdo_pat="exampleNotRealAzdoPat$(printf '0%.0s' {1..31})"
+    [ "${#azdo_pat}" -eq 52 ] \
+        || fail "issue #1103: test fixture azdo_pat must be 52 chars, got ${#azdo_pat}"
+
+    local out
+
+    # 1. Generic Authorization: Bearer <token> is redacted: the raw token must NOT
+    #    survive, while the literal "Bearer" scheme keyword may remain.
+    out="$(sanitize_cli_output "Authorization: Bearer ${bearer_token}")"
+    if printf '%s' "${out}" | grep -qF "${bearer_token}"; then
+        fail "issue #1103: Bearer token value was not redacted (raw token survived output)"
+    fi
+    printf '%s' "${out}" | grep -qi 'bearer' \
+        || fail "issue #1103: Bearer redaction must preserve the literal Bearer keyword"
+
+    # 2. A 52-char AzDO-PAT-shaped value is redacted (raw value must NOT survive).
+    out="$(sanitize_cli_output "az repos error token=${azdo_pat} (auth failed)")"
+    if printf '%s' "${out}" | grep -qF "${azdo_pat}"; then
+        fail "issue #1103: 52-char AzDO PAT value was not redacted (raw value survived output)"
+    fi
+
+    # 3. Idempotency: sanitizing already-sanitized output must be a no-op, so the
+    #    <redacted-token> / Bearer <redacted-token> markers can never re-match.
+    local combined once twice
+    combined="Authorization: Bearer ${bearer_token} pat=${azdo_pat} tok=${gh_token} ${gh_pat}"
+    once="$(sanitize_cli_output "${combined}")"
+    twice="$(sanitize_cli_output "${once}")"
+    [ "${once}" = "${twice}" ] \
+        || fail "issue #1103: sanitize_cli_output must be idempotent (double-run differs from single-run)"
+
+    # 4. Regression: pre-existing gh[pousr]_ and github_pat_ clauses still redact.
+    out="$(sanitize_cli_output "creds ${gh_token} and ${gh_pat} end")"
+    if printf '%s' "${out}" | grep -qF "${gh_token}"; then
+        fail "issue #1103: regression - existing ghp_ token clause no longer redacts"
+    fi
+    if printf '%s' "${out}" | grep -qF "${gh_pat}"; then
+        fail "issue #1103: regression - existing github_pat_ token clause no longer redacts"
+    fi
+
+    # 5. Anti-silent-degradation (#983): benign non-secret content passes through
+    #    unchanged - the sanitizer must redact, never swallow or drop safe output.
+    local benign
+    benign="Successfully created work item 12345 in project Contoso"
+    out="$(sanitize_cli_output "${benign}")"
+    [ "${out}" = "${benign}" ] \
+        || fail "issue #1103: benign non-secret content must pass through unchanged (got: '${out}')"
+
+    echo "  PASS[sanitize]: sanitize_cli_output redacts Bearer + 52-char AzDO PAT, stays idempotent, preserves gh_*/github_pat_ clauses and benign passthrough"
+}
+
 assert_pr_title_ignores_lockfiles
 assert_no_merge_directive_suppresses_auto_merge
 assert_gh_rate_limit_backoff_contracts
 assert_stanza_cleanup_guidance
 assert_azdo_work_item_url_parsing
+assert_sanitize_cli_output_redacts_secrets
 
 echo "PASS: default workflow reliability contracts are covered."

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -390,7 +390,7 @@ steps:
       fi
       if [ -z "$EXTRACTED" ]; then
         echo "ERROR: step-03b failed to extract issue number from issue_creation output." >&2
-        printf '%s\n' "$ISSUE_CREATION" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g' >&2
+        printf '%s\n' "$ISSUE_CREATION" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g; s#[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]{20,}#Bearer <redacted-token>#g; s#[A-Za-z0-9]{52}#<redacted-token>#g' >&2
         exit 1
       fi
       printf '%s' "$EXTRACTED"

--- a/amplifier-bundle/recipes/workflow-prep.yaml
+++ b/amplifier-bundle/recipes/workflow-prep.yaml
@@ -264,7 +264,7 @@ steps:
         fi
       }
       emit_local_metadata() { LOCAL_REF="$(derive_local_tracking_id)"; LOCAL_NUM=""; [[ "$LOCAL_REF" =~ local-(issue|ab)-([0-9]+)$ ]] && LOCAL_NUM="${BASH_REMATCH[2]}"; printf 'tracking_system=local\ntracking_reference=%s\ntracking_issue=%s\nissue_creation=local-tracking\n' "$LOCAL_REF" "$LOCAL_REF"; [ -n "$LOCAL_NUM" ] && printf 'issue_number=%s\n' "$LOCAL_NUM"; return 0; }
-      sanitize_cli_output() { printf '%s\n' "$1" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g'; }
+      sanitize_cli_output() { printf '%s\n' "$1" | head -c 4000 | sed -E 's#https?://[^[:space:]]*@#https://<redacted>@#g; s#gh[pousr]_[A-Za-z0-9_]{8,}#<redacted-token>#g; s#github_pat_[A-Za-z0-9_]+#<redacted-token>#g; s#[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]{20,}#Bearer <redacted-token>#g; s#[A-Za-z0-9]{52}#<redacted-token>#g'; }
       REF_ISSUE_NUM=""
       if [[ "$TASK_DESC" =~ AB#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"
       elif [[ "$TASK_DESC" =~ \#([0-9]+) ]]; then REF_ISSUE_NUM="${BASH_REMATCH[1]}"; fi


### PR DESCRIPTION
## Summary

Hardens the `sanitize_cli_output` shell filter in
`amplifier-bundle/recipes/workflow-prep.yaml` (used on the Azure DevOps
work-item create/error output paths) so it now also redacts:

- **Generic `Authorization: Bearer <token>` values** — keyword-anchored,
  case-insensitive scheme, 20+ char token:
  `s#[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]{20,}#Bearer <redacted-token>#g`
- **Classic 52-char alphanumeric Azure DevOps Personal Access Tokens** —
  length-anchored catch-all (fails toward redaction on this error-only path;
  40-hex git SHAs are unaffected):
  `s#[A-Za-z0-9]{52}#<redacted-token>#g`

Defense-in-depth (low active exposure), not an active-leak fix.

## Constraints honored

- **Line budget:** both clauses are appended **in place** to the existing
  single-line `sed -E` chain (line 267). `workflow-prep.yaml` stays at **398
  lines**, under the 400-line cap enforced by
  `every_phase_subrecipe_under_400_lines`.
- **No existing clauses weakened, reordered, or removed** — basic-auth-URL,
  `gh[pousr]_`, and `github_pat_` redaction still work.
- **Idempotent:** the `<redacted-token>` / `Bearer <redacted-token>` markers
  never re-match, so running the sanitizer twice equals running it once.
- **Anti-silent-degradation (#983):** non-secret content passes through
  unchanged; the filter only redacts, never swallows or drops output.
- **Scope:** only the two intended files changed. No Rust code, no shared
  redaction crate, no relay/turn/redact changes.

## Tests

Adds `assert_sanitize_cli_output_redacts_secrets` to
`test-default-workflow-reliability.sh`, which extracts and `eval`s the **real**
function from the recipe (single source of truth) and asserts:

1. `Authorization: Bearer <token>` — raw token redacted, `Bearer` keyword kept
2. A 52-char AzDO-PAT-shaped value is redacted
3. Idempotency (double-run == single-run)
4. Regression: `ghp_...` / `github_pat_...` still redacted
5. Benign non-secret content passes through unchanged

All token fixtures are obviously-fake (`example`/`NotReal` markers,
low-entropy padding) so the GitGuardian scanner does not flag them.

## Verification

- `bash amplifier-bundle/recipes/tests/test-default-workflow-reliability.sh` -> exit 0
- `wc -l amplifier-bundle/recipes/workflow-prep.yaml` -> 398 (< 400)

Supersedes #1113 (equivalent work from an earlier partial run of this task;
consolidated onto the canonical worktree branch, with the corrupted
intermediate test state repaired).

Closes #1103