### PR TITLE
feat: add agentic-workflow-first skill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplihack"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-cli",
  "amplihack-hooks",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-memory",
  "amplihack-utils",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-eval"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "serde",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-agent-generator"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "serde",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-asset-resolver-bin"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-cli",
  "tracing",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-blarify"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-builders"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-builders",
  "amplihack-hive",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-context"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-delegation"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "globset",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-domain-agents"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-fleet"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hive"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-agent-core",
  "amplihack-memory",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-memory",
  "amplihack-security",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-hooks-bin"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-hooks",
  "amplihack-state",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-launcher"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-types",
  "amplihack-utils",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-memory"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-multilspy"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-orchestration"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-state",
  "amplihack-utils",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-recovery"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-reflection"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-remote"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-utils",
  "anyhow",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-safety"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-security"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "once_cell",
  "regex",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-session"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "filetime",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-signal"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-turn",
  "amplihack-types",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-state"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-types",
  "libc",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-turn"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-utils"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-types",
  "anyhow",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "amplihack-workflows"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "amplihack-utils",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rysweet/amplihack-rs"

--- a/amplifier-bundle/context/PATTERNS.md
+++ b/amplifier-bundle/context/PATTERNS.md
@@ -1070,6 +1070,24 @@ Congratulations! You executed all 22 steps systematically.
 
 ---
 
+## Pattern: Agentic-Workflow-First
+
+**Problem:** New work defaults to imperative code, burying judgment in Rust functions.
+
+**Solution:** Invoke the **`agentic-workflow-first`** skill — the canonical decision
+procedure for structuring work as a recipe of agentic steps (prompts) + tools + a thin
+rail. It names the four anti-patterns to reject (stdout scraping, imperative judgment,
+wall-clock kills, argv/env payloads) and ships copy-ready recipe/prompt/typed-record
+templates.
+
+**Related:** `TOOL_VS_SKILL_CLASSIFICATION.md` (deciding tool vs skill boundaries).
+
+> **Origin (illustrative):** motivated by prior agentic-workflow efforts that
+> skewed toward bespoke code over recipes; this skill makes "can this be a recipe
+> + prompts + tools?" the mandatory first question.
+
+---
+
 ## Remember
 
 These patterns represent proven solutions from real development challenges:

--- a/amplifier-bundle/context/PHILOSOPHY.md
+++ b/amplifier-bundle/context/PHILOSOPHY.md
@@ -233,4 +233,12 @@ Push for extreme simplicity in:
 - **Trust AI to handle the details while you guide the vision**
 - **Modules should be bricks: self-contained and regeneratable**
 
+## Starting New Work
+
+Before writing imperative code, run the **`agentic-workflow-first`** skill
+(`amplifier-bundle/skills/agentic-workflow-first/`). It gives an ordered procedure that
+pushes new functionality toward deterministic workflows of agentic steps + prompts +
+tools, with code reduced to a thin rail. Judgment → prompt; side effects → tool; glue →
+minimal rail.
+
 This philosophy serves as the foundational guide for all development decisions in the project.

--- a/amplifier-bundle/skills/agentic-workflow-first/SKILL.md
+++ b/amplifier-bundle/skills/agentic-workflow-first/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: agentic-workflow-first
+description: Start new work as a deterministic workflow of agentic steps, prompts, and tools instead of code. Use when designing a feature, deciding how to build something, choosing code vs recipe, or asking "how should I structure this".
+metadata:
+  version: "1.0"
+  author: amplihack
+---
+
+# Agentic-Workflow-First
+
+## Purpose
+
+Steer new work toward **deterministic workflows made of agentic steps (prompts) +
+tool calls + a thin deterministic rail**, and away from imperative code. Judgment
+belongs in prompts; side effects belong in tools; code is only glue.
+
+## When I Activate
+
+I load when you mention: designing or structuring a feature, "how should I build
+this", "should this be code or a recipe", starting new work, "make this agentic",
+or "reduce the code".
+
+## The Rule (why this skill exists)
+
+> Most core functionality should be a collection of deterministic workflows with
+> agentic steps, prompts, and access to tools — NOT code. Rust is only a thin
+> deterministic rail.
+
+Default behavior is to write code. This skill forces the opposite default: prove a
+step *cannot* be a prompt or a tool before you write imperative logic for it.
+
+## The 6-Step Decision Procedure
+
+Follow these in order for any new piece of work.
+
+### Step 1 — Restate as goal + observable success criteria
+Write the desired behavior as a single goal sentence and a numbered list of
+*observable, verifiable* success criteria (what a passing run produces). If you
+cannot state how to observe success, you are not ready to design.
+
+### Step 2 — Decompose into a deterministic workflow
+Break the goal into an ordered (or branching) sequence of steps. Each step has one
+responsibility and a named output. This ordered set IS the workflow.
+
+### Step 3 — Classify every step (the core test)
+Tag each step as exactly one of:
+
+- **(a) Agentic step** — an LLM/agent reasoning step driven by a prompt. Choose this
+  whenever the step requires *judgment, classification, prioritization, interpretation,
+  or open-ended decision*.
+- **(b) Tool call** — a deterministic capability with a side effect: CLI, API, file
+  IO, `git`, `gh`. Choose this for anything with an external effect or a single
+  correct deterministic result.
+- **(c) Thin rail** — minimal glue code: typed-record IO, guardrails, attempt caps,
+  fail-closed reads. Choose this ONLY for plumbing that is neither judgment nor an
+  external capability.
+
+**Classification test — apply literally:**
+- Does the step *decide something* a reasonable person could disagree on? → **(a)**.
+- Does the step *change the world or read one true value* (write a file, call `gh`,
+  run a command)? → **(b)**.
+- Is it *pure plumbing* moving typed data between (a) and (b) with guardrails? → **(c)**.
+- If tempted to write a Rust `classify()` / `orient()` / `decide()` / `prioritize()`
+  function → it is judgment → it MUST be **(a)** behind a prompt.
+
+### Step 4 — Express the workflow as a recipe
+Write the workflow as a recipe YAML (repo format — see `templates.md`). Agentic steps
+use `type: "agent"` with a `prompt:` block; tools use `type: "bash"`. Data flows
+between steps as **typed records** (a file/JSON schema written by one step, read
+fail-closed by the next) — NEVER by scraping/parsing another step's stdout prose.
+
+### Step 5 — Write code only for the thin rail
+Write imperative code ONLY for step-type (c), and only for what genuinely cannot be a
+recipe/prompt/tool. For every line of imperative *judgment*, write a one-line
+justification of why it is not an agentic step. If you cannot justify it, convert it.
+
+### Step 6 — Enable + verify end-to-end
+The workflow must be runnable and observable. Run it, confirm each success criterion
+from Step 1 is produced, and confirm the typed-record handoffs (not stdout scraping)
+carry the data.
+
+## Anti-Patterns to Reject
+
+See `reference.md` for the four named anti-patterns and their replacements:
+1. Brittle stdout / JSON scraping of agent output → typed, owner-only (`0o600`),
+   freshness-checked records read **fail-CLOSED**.
+2. Imperative heuristics standing in for judgment (`classify_signal`, `orient`,
+   `decide`) → an agentic step behind a prompt.
+3. Wall-clock timeouts that kill working agentic steps → idle/liveness detection.
+4. Passing large payloads via argv/env (E2BIG) → route via stdin or a file the tool
+   reads.
+
+## Templates & Example
+
+- `templates.md` — copy-ready recipe, prompt, typed-record, and fail-closed-reader
+  skeletons matching the repo's real shapes.
+- `worked-example.md` — one behavior (classify + route a signal) built as recipe +
+  prompt + typed record + ~10-line rail, contrasted with a naive hardcoded function.
+
+## §7 — Honest note on reflexive irony
+
+Some shipped recipes in this repo still hand data between steps by having a later step
+parse an earlier step's stdout (e.g. `parse_json` over agent output). That works, and
+this skill does not claim those recipes are broken. The **recipe step is the agentic
+unit** either way. What this skill teaches is the *improved handoff*: a step writes a
+**typed record** (owner-only, freshness-checked) and the next step reads it fail-closed.
+Model new work on the typed-record handoff; treat stdout-scraping as legacy, not as the
+target pattern.

--- a/amplifier-bundle/skills/agentic-workflow-first/reference.md
+++ b/amplifier-bundle/skills/agentic-workflow-first/reference.md
@@ -1,0 +1,62 @@
+# Anti-Patterns & Typed-Record Replacements
+
+Four anti-patterns drawn from recurring agentic-workflow history. Each is
+paired with the pattern that replaces it.
+
+## AP-1 — Brittle stdout / JSON scraping
+
+**Symptom:** a step recovers data by parsing another step's printed prose or by
+scraping JSON out of an agent's free-text output (`extract_and_parse_json`,
+`from_recipe_envelope`). Fragile to formatting drift; fails open on partial output.
+
+**Reject because:** the contract is implicit and unvalidated; a reworded agent reply
+silently breaks the handoff, and a partial parse can proceed on default/garbage data.
+
+**Replace with — the typed-record handoff (THE way data flows agent→agent / agent→rail):**
+- The producing step writes a **typed record**: a small file with an explicit schema
+  (versioned, with a nonce/timestamp).
+- Create it **owner-only** (`0o600`) **atomically at creation** (open with mode; never
+  `chmod` after write — that is a TOCTOU window).
+- The consuming step reads it **fail-CLOSED**: missing file, wrong permissions, parse
+  failure, schema mismatch, or a stale record → **abort the step**. Never proceed on
+  partial or default data.
+- Include a **freshness / nonce** check so a stale record from a previous run cannot be
+  replayed by a concurrent run.
+
+## AP-2 — Imperative heuristics standing in for judgment
+
+**Symptom:** a Rust function (`orient`, `classify_signal`, `decide`, `prioritize`)
+hardcodes priority/classification logic that is really a judgment call.
+
+**Reject because:** judgment encoded as branches rots, cannot explain itself, and
+cannot adapt to phrasing it did not anticipate.
+
+**Replace with:** an **agentic step** (Step 3a) behind a prompt. The prompt states the
+classes/priorities and the decision rules; the agent classifies and emits a typed
+record. The rail only routes on the record's typed field.
+
+## AP-3 — Wall-clock timeouts that kill working agentic steps
+
+**Symptom:** a per-step wall-clock `timeout:` aborts an agentic step mid-thought.
+
+**Reject because:** agentic steps have highly variable, non-linear runtimes; a wall
+clock kills correct in-progress work. (This repo's workflows adopt a NO-TIMEOUT policy
+for agent steps for exactly this reason.)
+
+**Replace with:** **idle / liveness detection** — abort only on lack of progress
+(no output / no heartbeat), not on elapsed wall-clock time. Shell `timeout` may still
+guard *external network commands* (`gh`, `curl`, `git remote`) inside bash tool steps,
+because those are not mid-thought abort gates.
+
+## AP-4 — Large payloads via argv / env (E2BIG)
+
+**Symptom:** passing a big blob (a diff, a corpus, a record) as a command-line argument
+or environment variable. Hits the OS `E2BIG` limit and leaks contents through
+`ps` / `/proc/<pid>/environ`.
+
+**Reject because:** it breaks on size AND exposes payloads/secrets to any process that
+can read the process table.
+
+**Replace with:** route the payload via **stdin** or a **file the tool reads**. The
+producing step writes the file (owner-only if sensitive); the consuming tool reads it
+by path or from stdin. argv/env carry only small, non-secret identifiers.

--- a/amplifier-bundle/skills/agentic-workflow-first/templates.md
+++ b/amplifier-bundle/skills/agentic-workflow-first/templates.md
@@ -117,7 +117,7 @@ REC="${1:?record path required}"
 
 # WHY each guard: any failure => abort the step; never proceed on default data.
 [ -f "$REC" ]                        || { echo "record missing: $REC" >&2; exit 1; }
-perms=$(stat -c '%a' "$REC")
+perms=$(stat -c '%a' "$REC" 2>/dev/null || stat -f '%Lp' "$REC")  # GNU || BSD/macOS
 [ "$perms" = "600" ]                 || { echo "record not 0o600 (got $perms)" >&2; exit 1; }
 jq -e . "$REC" >/dev/null            || { echo "record not valid JSON" >&2; exit 1; }
 ver=$(jq -r '.schema_version' "$REC")
@@ -126,6 +126,14 @@ ver=$(jq -r '.schema_version' "$REC")
                                      || { echo "stale/replayed record (nonce mismatch)" >&2; exit 1; }
 
 decision=$(jq -r '.decision' "$REC")   # route ONLY on the typed field
+# Optional allowlist (defense-in-depth): when ALLOWED_DECISIONS is set (space-separated),
+# reject any decision outside it — fail CLOSED here, before the caller ever routes on it.
+if [ -n "${ALLOWED_DECISIONS:-}" ]; then
+  case " $ALLOWED_DECISIONS " in
+    *" $decision "*) : ;;
+    *) echo "decision not in allowlist: $decision" >&2; exit 1 ;;
+  esac
+fi
 echo "$decision"
 ```
 

--- a/amplifier-bundle/skills/agentic-workflow-first/templates.md
+++ b/amplifier-bundle/skills/agentic-workflow-first/templates.md
@@ -1,0 +1,136 @@
+# Copy-Ready Templates
+
+These match the repo's ACTUAL recipe shape (see `amplifier-bundle/recipes/
+default-workflow.yaml` and `smart-classify-route.yaml`). Each protection is annotated
+with its "why" so copiers do not strip it as boilerplate. Use `{{placeholders}}` —
+never hardcode host-specific paths.
+
+## Template A — Recipe skeleton (agentic step → tool writes typed record → thin-rail read)
+
+```yaml
+name: "{{workflow_name}}"
+description: "{{one-line goal}}"
+version: "1.0.0"
+author: "{{author}}"
+tags: ["{{tag}}"]
+
+# NO-TIMEOUT POLICY: no per-step wall-clock `timeout:` on agent steps (AP-3).
+# Idle/liveness detection guards agentic steps; shell `timeout` only guards
+# external network commands inside bash steps.
+
+recursion:
+  max_depth: 6
+  max_total_steps: 80
+
+context:
+  # Small, non-secret inputs only (AP-4: no large payloads via env/argv).
+  repo_path: "."
+  input_ref: ""          # path/id to a file the steps read; not the payload itself
+  record_path: ""        # where the typed record is written/read
+
+steps:
+  # (a) AGENTIC STEP — judgment behind a prompt (Step 3a)
+  - id: "decide"
+    type: "agent"
+    agent: "amplihack:core:architect"
+    prompt: |
+      === [RECIPE PROGRESS] Step: decide ===
+      {{See Template B for the prompt body}}
+      Emit ONLY the typed record described in Template C. Do not print prose.
+    output: "decision_record"
+
+  # (b) TOOL STEP — deterministic side effect: write the typed record 0o600 (AP-1)
+  - id: "persist-record"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      REC="${RECORD_PATH:?record_path required}"
+      # WHY 0o600 at creation (not chmod-after): closes the TOCTOU window (AP-1).
+      ( umask 177; : > "$REC" )          # create owner-only, atomically empty
+      # WHY here-doc/stdin, not argv: avoids E2BIG + /proc leak (AP-4).
+      cat > "$REC" <<'RECORD'
+      {{typed record JSON — see Template C}}
+      RECORD
+    output: "record_written"
+
+  # (c) THIN RAIL — read the record fail-CLOSED, then route (Step 3c / Template D)
+  - id: "route"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      "{{repo_path}}/scripts/read_record.sh" "${RECORD_PATH:?}"   # fail-closed reader
+    output: "route_result"
+```
+
+## Template B — Inline prompt skeleton
+
+The repo's canonical prompt shape is an **inline `prompt: |` block** inside the recipe
+step (as in `smart-classify-route.yaml`). There is no separate `prompts/*.yaml` asset
+format in this repo; keep prompts inline.
+
+```yaml
+    prompt: |
+      === [RECIPE PROGRESS] Step: {{step_id}} ===
+
+      You are performing ONE judgment step. Do NOT implement, build, or run tools.
+
+      **INPUT**: {{input_ref}} (read the file at this path; it is not inlined here — AP-4)
+
+      **TASK**: {{state the single decision — classify / prioritize / interpret}}
+
+      **CLASSES / RULES**:
+      - {{class or rule 1}}
+      - {{class or rule 2}}
+
+      **OUTPUT**: Emit ONLY a typed record matching this schema (no prose, no fences):
+      {{Template C schema}}
+```
+
+> Aside: Simard sometimes stores prompts as separate asset files
+> (`operator-liaison.yaml`, `merge-readiness-judge.yaml`). That variant is fine there,
+> but this repo verifies only the inline form — use inline here.
+
+## Template C — Typed-record schema
+
+```json
+{
+  "schema": "{{workflow_name}}.decision",
+  "schema_version": 1,
+  "nonce": "{{run-unique nonce — freshness/replay guard, AP-1}}",
+  "created_at": "{{RFC3339 timestamp}}",
+  "decision": "{{one of the enumerated classes}}",
+  "confidence": "{{low|medium|high}}",
+  "rationale": "{{short, for observability only — never parsed for control flow}}"
+}
+```
+
+Control flow reads ONLY typed fields (`decision`, `schema_version`, `nonce`). `rationale`
+is human-facing and must never drive routing (that would re-introduce AP-1).
+
+## Template D — Fail-CLOSED reader (`scripts/read_record.sh`, the thin rail)
+
+```bash
+#!/usr/bin/env bash
+# Thin rail: read a typed record fail-CLOSED. Aborts on ANY doubt (AP-1).
+set -euo pipefail
+REC="${1:?record path required}"
+
+# WHY each guard: any failure => abort the step; never proceed on default data.
+[ -f "$REC" ]                        || { echo "record missing: $REC" >&2; exit 1; }
+perms=$(stat -c '%a' "$REC")
+[ "$perms" = "600" ]                 || { echo "record not 0o600 (got $perms)" >&2; exit 1; }
+jq -e . "$REC" >/dev/null            || { echo "record not valid JSON" >&2; exit 1; }
+ver=$(jq -r '.schema_version' "$REC")
+[ "$ver" = "1" ]                     || { echo "unexpected schema_version: $ver" >&2; exit 1; }
+[ "$(jq -r '.nonce' "$REC")" = "${EXPECTED_NONCE:?}" ] \
+                                     || { echo "stale/replayed record (nonce mismatch)" >&2; exit 1; }
+
+decision=$(jq -r '.decision' "$REC")   # route ONLY on the typed field
+echo "$decision"
+```
+
+**PR-review checklist (paste into the PR):**
+- [ ] No example shows a fail-OPEN handoff (proceeding on missing/partial record).
+- [ ] No example uses `chmod` after write (must be `0o600` at creation).
+- [ ] No large/sensitive payload passed via argv or env (stdin/file only).
+- [ ] No control flow keys off `rationale`/free-text (only typed fields).

--- a/amplifier-bundle/skills/agentic-workflow-first/worked-example.md
+++ b/amplifier-bundle/skills/agentic-workflow-first/worked-example.md
@@ -1,0 +1,81 @@
+# Worked Example — Classify & route a signal
+
+Behavior: given an inbound signal, classify it as `urgent | normal | ignore` and route
+accordingly. Below: the naive "just write a function" version vs. the agentic-first
+version.
+
+## Naive version (rejected — AP-2)
+
+```rust
+// Hardcoded judgment in Rust: brittle, cannot explain itself, rots on new phrasings.
+fn classify_signal(text: &str) -> Signal {
+    if text.contains("URGENT") || text.contains("down") { Signal::Urgent }
+    else if text.contains("fyi") { Signal::Ignore }
+    else { Signal::Normal }
+}
+```
+
+Problems: keyword branches are judgment masquerading as code (AP-2); adding a class
+means editing/recompiling code; it cannot handle "the site is unreachable" (no keyword
+match) and cannot explain its call.
+
+## Agentic-first version
+
+**Step 1 — goal + success criteria:** "Route each signal by urgency." Success: every
+signal produces a typed record with `decision ∈ {urgent,normal,ignore}` and the router
+takes the matching branch.
+
+**Step 2 — workflow:** `classify` (judgment) → `persist-record` (write typed record) →
+`route` (rail reads fail-closed, branches).
+
+**Step 3 — classify:** `classify` = **(a) agentic** (judgment). `persist-record` =
+**(b) tool**. `route` = **(c) thin rail**.
+
+**Step 4 — recipe** (uses Templates A–C):
+
+```yaml
+steps:
+  - id: "classify"
+    type: "agent"
+    agent: "amplihack:core:architect"
+    prompt: |
+      === [RECIPE PROGRESS] Step: classify ===
+      Read the signal at {{input_ref}}. Classify urgency as one of:
+      urgent (service impact / time-critical), normal (routine), ignore (FYI/noise).
+      Judge intent, not keywords. Emit ONLY this typed record (no prose):
+      {"schema":"signal.decision","schema_version":1,"nonce":"{{nonce}}",
+       "created_at":"{{now}}","decision":"<urgent|normal|ignore>",
+       "confidence":"<low|medium|high>","rationale":"<one line>"}
+    output: "signal_record"
+
+  - id: "persist-record"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      ( umask 177; : > "$RECORD_PATH" )        # 0o600 at creation (AP-1)
+      cat > "$RECORD_PATH"                       # payload via stdin, not argv (AP-4)
+    output: "record_written"
+
+  - id: "route"
+    type: "bash"
+    command: |
+      set -euo pipefail
+      decision=$("{{repo_path}}/scripts/read_record.sh" "$RECORD_PATH")  # fail-closed
+      case "$decision" in
+        urgent) gh issue create --label urgent --title "signal: urgent" ;;
+        normal) echo "queued: normal" ;;
+        ignore) echo "dropped: ignore" ;;
+        *)      echo "unknown decision: $decision" >&2; exit 1 ;;   # fail-closed
+      esac
+    output: "route_result"
+```
+
+**Step 5 — thin rail:** only `scripts/read_record.sh` (Template D, ~10 lines). No
+imperative *judgment* — the `case` merely routes on a typed field.
+
+**Step 6 — verify:** run the recipe; confirm a record with a valid `decision` is
+written `0o600`, the router branches correctly, and no stdout scraping is involved.
+
+**Contrast:** judgment moved from brittle Rust branches into an explainable prompt;
+adding a class is a prompt edit, not a recompile; the rail shrank to a fail-closed
+reader plus a `case`.

--- a/amplifier-bundle/skills/agentic-workflow-first/worked-example.md
+++ b/amplifier-bundle/skills/agentic-workflow-first/worked-example.md
@@ -60,6 +60,8 @@ steps:
     type: "bash"
     command: |
       set -euo pipefail
+      export EXPECTED_NONCE="{{nonce}}"                 # complete the freshness handshake the reader requires (AP-1)
+      export ALLOWED_DECISIONS="urgent normal ignore"   # allowlist the reader enforces before we route (defense-in-depth)
       decision=$("{{repo_path}}/scripts/read_record.sh" "$RECORD_PATH")  # fail-closed
       case "$decision" in
         urgent) gh issue create --label urgent --title "signal: urgent" ;;

--- a/crates/amplihack-cli/tests/agentic_workflow_first_present.rs
+++ b/crates/amplihack-cli/tests/agentic_workflow_first_present.rs
@@ -62,6 +62,25 @@ fn extract_frontmatter(content: &str) -> Option<&str> {
     Some(&after_open[..close_idx])
 }
 
+/// Parse `SKILL.md`, extract its YAML frontmatter, and return the `name` field as
+/// a `String`. Uses `serde_yaml` (like TC-AWF-03) so the name is read from parsed
+/// YAML rather than by brittle line scanning, which would mishandle quoting,
+/// inline comments, or block scalars.
+fn frontmatter_name() -> String {
+    let content = fs::read_to_string(skill_md()).expect("read agentic-workflow-first SKILL.md");
+    let frontmatter = extract_frontmatter(&content).expect("SKILL.md must have YAML frontmatter");
+    let mapping = match serde_yaml::from_str::<Value>(frontmatter) {
+        Ok(Value::Mapping(map)) => map,
+        Ok(other) => panic!("{SKILL_NAME} frontmatter must be a YAML mapping, found {other:?}"),
+        Err(err) => panic!("{SKILL_NAME} frontmatter is not valid YAML: {err}"),
+    };
+    mapping
+        .get("name")
+        .and_then(Value::as_str)
+        .expect("SKILL.md must declare a string `name` field")
+        .to_string()
+}
+
 /// TC-AWF-01: The `agentic-workflow-first` skill directory and its canonical
 /// `SKILL.md` entrypoint must exist. A missing/moved/renamed definition is the
 /// most direct way the skill drops out of Copilot's list.
@@ -141,13 +160,7 @@ fn tc_awf_03_frontmatter_metadata_is_valid() {
 /// a name/dir mismatch makes the listing inconsistent (#860).
 #[test]
 fn tc_awf_04_name_matches_directory() {
-    let content = fs::read_to_string(skill_md()).expect("read agentic-workflow-first SKILL.md");
-    let frontmatter = extract_frontmatter(&content).expect("SKILL.md must have YAML frontmatter");
-    let name = frontmatter
-        .lines()
-        .find_map(|line| line.trim().strip_prefix("name:"))
-        .map(str::trim)
-        .expect("SKILL.md must declare a `name` field");
+    let name = frontmatter_name();
 
     let dir_name = skill_dir()
         .file_name()
@@ -165,13 +178,7 @@ fn tc_awf_04_name_matches_directory() {
 /// (case-insensitive) — an explicit naming constraint for this skill.
 #[test]
 fn tc_awf_05_name_has_no_forbidden_token() {
-    let content = fs::read_to_string(skill_md()).expect("read agentic-workflow-first SKILL.md");
-    let frontmatter = extract_frontmatter(&content).expect("SKILL.md must have YAML frontmatter");
-    let name = frontmatter
-        .lines()
-        .find_map(|line| line.trim().strip_prefix("name:"))
-        .map(str::trim)
-        .expect("SKILL.md must declare a `name` field");
+    let name = frontmatter_name();
 
     assert!(
         !name.to_lowercase().contains("bridge"),

--- a/crates/amplihack-cli/tests/agentic_workflow_first_present.rs
+++ b/crates/amplihack-cli/tests/agentic_workflow_first_present.rs
@@ -1,0 +1,180 @@
+//! Regression + validation guard for the `agentic-workflow-first` skill: it must
+//! remain present and valid in the bundled skill corpus so Copilot CLI keeps
+//! listing it and surfacing it on design / "how should I build this" questions.
+//!
+//! # Background
+//!
+//! `agentic-workflow-first` is an overwhelmingly-markdown skill that teaches the
+//! ordered decision procedure for classifying each step of new work as agentic
+//! (judgment → prompt), tool (side-effect → bash), or thin rail (glue → code).
+//! Because the skills directory is the single source of truth for Copilot
+//! discovery (#865), a skill silently vanishes from the list if its definition
+//! is removed, renamed, has frontmatter that does not start at byte 0, carries a
+//! non-string scalar field (#890), or has a `name` that no longer matches its
+//! directory (#860).
+//!
+//! This guard fails loudly the moment any of those failure modes appears.
+//!
+//! # Read-only invariant
+//!
+//! This test only reads the bundled source files. It never writes or stages.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use serde_yaml::Value;
+
+const SKILL_NAME: &str = "agentic-workflow-first";
+
+/// Walk up from the crate manifest dir until we find the workspace root
+/// (the directory that owns both `amplifier-bundle/` and `Cargo.toml`).
+fn workspace_root() -> &'static Path {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        let mut cur = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        loop {
+            if cur.join("amplifier-bundle").is_dir() && cur.join("Cargo.toml").is_file() {
+                return cur;
+            }
+            assert!(
+                cur.pop(),
+                "walked above filesystem root looking for workspace root"
+            );
+        }
+    })
+    .as_path()
+}
+
+fn skill_dir() -> PathBuf {
+    workspace_root().join(format!("amplifier-bundle/skills/{SKILL_NAME}"))
+}
+
+fn skill_md() -> PathBuf {
+    skill_dir().join("SKILL.md")
+}
+
+/// Extract the YAML frontmatter block (between the opening `---\n` at byte 0 and
+/// the next `\n---`). Returns `None` when frontmatter is absent.
+fn extract_frontmatter(content: &str) -> Option<&str> {
+    let after_open = content.strip_prefix("---\n")?;
+    let close_idx = after_open.find("\n---")?;
+    Some(&after_open[..close_idx])
+}
+
+/// TC-AWF-01: The `agentic-workflow-first` skill directory and its canonical
+/// `SKILL.md` entrypoint must exist. A missing/moved/renamed definition is the
+/// most direct way the skill drops out of Copilot's list.
+#[test]
+fn tc_awf_01_skill_definition_exists() {
+    let dir = skill_dir();
+    assert!(
+        dir.is_dir(),
+        "{SKILL_NAME} skill directory is missing at {} — the skill will not be \
+         staged to ~/.copilot/skills and disappears from Copilot CLI",
+        dir.display()
+    );
+
+    let md = skill_md();
+    assert!(
+        md.is_file(),
+        "{SKILL_NAME}/SKILL.md is missing at {} — Copilot skill discovery requires \
+         a canonical uppercase SKILL.md entrypoint",
+        md.display()
+    );
+}
+
+/// TC-AWF-02: `SKILL.md` frontmatter must start at byte 0. A Markdown title or
+/// comment before the opening `---` prevents Copilot from parsing the metadata
+/// and silently hides the skill.
+#[test]
+fn tc_awf_02_frontmatter_starts_at_first_byte() {
+    let content = fs::read_to_string(skill_md()).expect("read agentic-workflow-first SKILL.md");
+    assert!(
+        content.starts_with("---\n"),
+        "{SKILL_NAME}/SKILL.md frontmatter must start at the first byte"
+    );
+}
+
+/// TC-AWF-03: `SKILL.md` frontmatter must be valid YAML declaring a string
+/// `name: agentic-workflow-first` and a non-empty string `description`.
+/// Non-string scalar fields (list/map) are exactly what Copilot CLI rejects
+/// (#890), and a wrong name breaks the directory/name match Copilot relies on.
+#[test]
+fn tc_awf_03_frontmatter_metadata_is_valid() {
+    let content = fs::read_to_string(skill_md()).expect("read agentic-workflow-first SKILL.md");
+    let frontmatter = extract_frontmatter(&content).expect("SKILL.md must have YAML frontmatter");
+
+    let mapping = match serde_yaml::from_str::<Value>(frontmatter) {
+        Ok(Value::Mapping(map)) => map,
+        Ok(other) => panic!("{SKILL_NAME} frontmatter must be a YAML mapping, found {other:?}"),
+        Err(err) => panic!("{SKILL_NAME} frontmatter is not valid YAML: {err}"),
+    };
+
+    let name = mapping
+        .get("name")
+        .expect("SKILL.md must declare a `name` field");
+    assert_eq!(
+        name.as_str(),
+        Some(SKILL_NAME),
+        "{SKILL_NAME}/SKILL.md `name` must be the string \"{SKILL_NAME}\" (must also \
+         match the containing directory name for Copilot discovery)"
+    );
+
+    let description = mapping
+        .get("description")
+        .expect("SKILL.md must declare a `description` field");
+    match description {
+        Value::String(s) => assert!(
+            !s.trim().is_empty(),
+            "{SKILL_NAME}/SKILL.md `description` must be a non-empty string scalar"
+        ),
+        other => panic!(
+            "{SKILL_NAME}/SKILL.md `description` must be a string scalar — Copilot CLI \
+             rejects list/map scalar fields, found {other:?}"
+        ),
+    }
+}
+
+/// TC-AWF-04: The skill name must match its containing directory. Copilot stages
+/// each skill into `~/.copilot/skills/<dir>/` and lists it under that directory;
+/// a name/dir mismatch makes the listing inconsistent (#860).
+#[test]
+fn tc_awf_04_name_matches_directory() {
+    let content = fs::read_to_string(skill_md()).expect("read agentic-workflow-first SKILL.md");
+    let frontmatter = extract_frontmatter(&content).expect("SKILL.md must have YAML frontmatter");
+    let name = frontmatter
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("name:"))
+        .map(str::trim)
+        .expect("SKILL.md must declare a `name` field");
+
+    let dir_name = skill_dir()
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("skill directory has a name")
+        .to_string();
+
+    assert_eq!(
+        name, dir_name,
+        "{SKILL_NAME} skill `name` ({name}) must match its directory ({dir_name})"
+    );
+}
+
+/// TC-AWF-05: The skill `name` must not contain the forbidden token "Bridge"
+/// (case-insensitive) — an explicit naming constraint for this skill.
+#[test]
+fn tc_awf_05_name_has_no_forbidden_token() {
+    let content = fs::read_to_string(skill_md()).expect("read agentic-workflow-first SKILL.md");
+    let frontmatter = extract_frontmatter(&content).expect("SKILL.md must have YAML frontmatter");
+    let name = frontmatter
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("name:"))
+        .map(str::trim)
+        .expect("SKILL.md must declare a `name` field");
+
+    assert!(
+        !name.to_lowercase().contains("bridge"),
+        "{SKILL_NAME} skill `name` ({name}) must not contain the token \"Bridge\""
+    );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rysweet/amplihack-rs",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "npm/npx wrapper for the amplihack Rust CLI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Adds a bundled amplihack **skill** `agentic-workflow-first` that encodes one architectural rule as an actionable, ordered decision procedure:

> Most core functionality should be a collection of deterministic workflows made of agentic steps (prompts) + tool calls + a thin deterministic rail — not imperative code. Start new work by asking "can this be a recipe + prompts + tools?" before writing Rust.

The skill loads via the filesystem skill scan (no registry edit needed) for both amplihack-rs and Simard.

## What's included

- `amplifier-bundle/skills/agentic-workflow-first/SKILL.md` — front-matter (`name` + string `description` + `metadata`, Copilot-CLI-safe per #890/#860) and the **6-step decision procedure** that classifies each step as agentic (judgment→prompt), tool (side-effect→bash), or thin rail (glue→code).
- `reference.md` — the four named anti-patterns and their typed-record replacements: brittle stdout/JSON scraping → typed owner-only `0o600` freshness-checked fail-CLOSED records; imperative heuristics-as-judgment → agentic step; wall-clock kills → idle/liveness detection; argv/env E2BIG payloads → stdin/file routing.
- `templates.md` — copy-ready recipe / inline-prompt / typed-record / fail-closed-reader skeletons matching the repo's real YAML shapes, each protection annotated with its "why".
- `worked-example.md` — one behavior (classify + route a signal) built end-to-end, contrasted with the naive hardcoded-function version.
- Cross-links appended to `context/PHILOSOPHY.md` and `context/PATTERNS.md` for start-of-work discoverability.

## Tests

- `crates/amplihack-cli/tests/agentic_workflow_first_present.rs` — read-only presence/validation guard cloned from `issue_860_pr_guide_present.rs`: asserts the skill dir + `SKILL.md` exist, front-matter starts at byte 0, parses as a YAML mapping with `name == "agentic-workflow-first"` (== dir name) and a non-empty string `description`, and that the name contains no forbidden token. 5 tests, all pass.
- Existing `skill_catalog::catalog_load_from_bundle` still passes (`catalog.len() >= 70` lower bound; adding a skill only increases the count).

## Review checklist

- [ ] No example shows a fail-OPEN handoff (proceeding on missing/partial record).
- [ ] No example uses `chmod` after write (must be `0o600` at creation).
- [ ] No large/sensitive payload passed via argv or env (stdin/file only).
- [ ] No control flow keys off `rationale`/free-text (only typed fields).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Step 16b: Outside-In Testing Results

Tested from this PR branch (`feat/issue-1114-homeazureusercopilotsession-state465c3cbf-6e73-43e`) as a consumer would, via the qa-team skill.

**Detected toolchains / strategy**
- Root manifests: `Cargo.toml` + `Cargo.lock` (Rust workspace, 28 crates) and `package.json` (npm/npx wrapper). rust-toolchain.toml pins the channel; `cargo 1.97.0`, `node v24.16.0`.
- Changed surface is overwhelmingly markdown (the new `agentic-workflow-first` skill) plus one read-only Rust guard test and version bumps. Per qa-team repo-type detection, a **Rust CLI** repo → substitute `cargo test` / native binary runs for gadugi. Chosen outside-in boundaries: (1) the CLI's skill-discovery guard test, and (2) the real `amplihack install` staging path that makes the skill discoverable to Copilot CLI under `~/.copilot/skills/`.

| # | Scenario | Command | Result | Key output |
|---|----------|---------|--------|-----------|
| 1 (simple) | Skill-discovery guard: skill dir/`SKILL.md` present, front-matter at byte 0, valid YAML mapping, `name == dir == "agentic-workflow-first"`, non-empty string `description`, no forbidden token | `cargo test -p amplihack-cli --test agentic_workflow_first_present --locked` | ✅ PASS | `test result: ok. 5 passed; 0 failed` (tc_awf_01…05) |
| 2 (edge/integration) | Real user path — install the bundle into an **isolated `HOME`** and confirm the new skill is staged intact for Copilot discovery | `HOME=$(mktemp -d) ./target/debug/amplihack install --local .` then inspect `$HOME/.copilot/skills/agentic-workflow-first/` | ✅ PASS | exit 0; `Copilot home staged (~/.copilot/)`; staged `SKILL.md`, `reference.md`, `templates.md`, `worked-example.md`; 126 skill dirs total |

**Supporting PR-gate checks** (all green, no fixes needed):
- `cargo fmt -p amplihack-cli -- --check …/agentic_workflow_first_present.rs` → exit 0
- `cargo clippy -p amplihack-cli --tests --locked -- -D warnings` → exit 0
- `bash scripts/check-skills-no-missing-helpers.sh` → `PASS: live bundled skills do not reference missing legacy Python helpers.`

**Fix count: 0.** Both scenarios passed on the first run; no diagnose/fix/commit iterations were required. Isolated temp `HOME` was removed after the run (no host pollution).
