### PR TITLE
fix(hooks): stop session-start from silently self-uninstalling amplihack

### DIFF
--- a/crates/amplihack-cli/src/commands/doctor/checks.rs
+++ b/crates/amplihack-cli/src/commands/doctor/checks.rs
@@ -20,28 +20,21 @@ const DOCTOR_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 /// File contents are never printed; only presence/validity is reported and
 /// error strings are truncated (SEC-WS2-04).
 pub fn check_hooks_installed() -> (bool, String) {
-    let global_path = settings_json_path();
-    let repo_local_path = std::env::current_dir()
-        .ok()
-        .map(|cwd| settings_json_path_for(&cwd));
+    // Global settings take precedence, then the project-local copy. A missing
+    // file (`None`) or one without amplihack hooks (`Some(Ok(false))`) simply
+    // falls through to the next candidate; a read/parse error short-circuits.
+    let candidates = [
+        settings_json_path(),
+        std::env::current_dir()
+            .ok()
+            .map(|cwd| settings_json_path_for(&cwd)),
+    ];
 
-    if let Some(path) = global_path.as_ref()
-        && let Some(result) = settings_has_amplihack_hooks(path)
-    {
-        match result {
-            Ok(true) => return (true, "amplihack hooks installed".to_string()),
-            Ok(false) => {}
-            Err(msg) => return (false, msg),
-        }
-    }
-
-    if let Some(path) = repo_local_path.as_ref()
-        && let Some(result) = settings_has_amplihack_hooks(path)
-    {
-        match result {
-            Ok(true) => return (true, "amplihack hooks installed".to_string()),
-            Ok(false) => {}
-            Err(msg) => return (false, msg),
+    for path in candidates.into_iter().flatten() {
+        match settings_has_amplihack_hooks(&path) {
+            Some(Ok(true)) => return (true, "amplihack hooks installed".to_string()),
+            Some(Err(msg)) => return (false, msg),
+            Some(Ok(false)) | None => {}
         }
     }
 

--- a/crates/amplihack-cli/src/commands/doctor/checks.rs
+++ b/crates/amplihack-cli/src/commands/doctor/checks.rs
@@ -20,9 +20,12 @@ const DOCTOR_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 /// File contents are never printed; only presence/validity is reported and
 /// error strings are truncated (SEC-WS2-04).
 pub fn check_hooks_installed() -> (bool, String) {
-    // Global settings take precedence, then the project-local copy. A missing
-    // file (`None`) or one without amplihack hooks (`Some(Ok(false))`) simply
-    // falls through to the next candidate; a read/parse error short-circuits.
+    // Global settings take precedence, then the project-local copy. Pass if
+    // EITHER location has amplihack hooks. A missing file (`None`) or one
+    // without amplihack hooks (`Some(Ok(false))`) falls through to the next
+    // candidate. A read/parse error on one candidate must NOT mask a valid
+    // install in the other, so errors are remembered and only surfaced when no
+    // candidate yields amplihack hooks.
     let candidates = [
         settings_json_path(),
         std::env::current_dir()
@@ -30,12 +33,21 @@ pub fn check_hooks_installed() -> (bool, String) {
             .map(|cwd| settings_json_path_for(&cwd)),
     ];
 
+    let mut first_error: Option<String> = None;
     for path in candidates.into_iter().flatten() {
         match settings_has_amplihack_hooks(&path) {
             Some(Ok(true)) => return (true, "amplihack hooks installed".to_string()),
-            Some(Err(msg)) => return (false, msg),
+            Some(Err(msg)) => {
+                if first_error.is_none() {
+                    first_error = Some(msg);
+                }
+            }
             Some(Ok(false)) | None => {}
         }
+    }
+
+    if let Some(msg) = first_error {
+        return (false, msg);
     }
 
     (

--- a/crates/amplihack-cli/src/commands/doctor/checks.rs
+++ b/crates/amplihack-cli/src/commands/doctor/checks.rs
@@ -1,6 +1,9 @@
 //! Individual health check implementations for `amplihack doctor`.
 
-use super::{MAX_ERROR_LEN, MAX_VERSION_LEN, json_contains_amplihack, settings_json_path};
+use super::{
+    MAX_ERROR_LEN, MAX_VERSION_LEN, json_contains_amplihack, settings_json_path,
+    settings_json_path_for,
+};
 use crate::util::{run_output_with_timeout, strip_ansi, truncate_chars_with_notice};
 use std::process::Command;
 use std::time::Duration;
@@ -9,44 +12,79 @@ const DOCTOR_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Check 1 — amplihack hooks installed.
 ///
-/// Reads `$HOME/.claude/settings.json` and verifies that the `hooks` section
-/// contains at least one entry whose value contains the substring
-/// `"amplihack"`.
+/// Passes if EITHER the global `$HOME/.claude/settings.json` OR the
+/// project-local `<cwd>/.claude/settings.json` has a `hooks` section that
+/// contains the substring `"amplihack"`. Project-local installs are valid, so
+/// a working install must not be reported as missing (issue #1088).
+///
+/// File contents are never printed; only presence/validity is reported and
+/// error strings are truncated (SEC-WS2-04).
 pub fn check_hooks_installed() -> (bool, String) {
-    let path = match settings_json_path() {
-        None => return (false, "hooks: $HOME not set".to_string()),
-        Some(p) => p,
-    };
+    let global_path = settings_json_path();
+    let repo_local_path = std::env::current_dir()
+        .ok()
+        .map(|cwd| settings_json_path_for(&cwd));
 
-    let content = match std::fs::read_to_string(&path) {
+    if let Some(path) = global_path.as_ref()
+        && let Some(result) = settings_has_amplihack_hooks(path)
+    {
+        match result {
+            Ok(true) => return (true, "amplihack hooks installed".to_string()),
+            Ok(false) => {}
+            Err(msg) => return (false, msg),
+        }
+    }
+
+    if let Some(path) = repo_local_path.as_ref()
+        && let Some(result) = settings_has_amplihack_hooks(path)
+    {
+        match result {
+            Ok(true) => return (true, "amplihack hooks installed".to_string()),
+            Ok(false) => {}
+            Err(msg) => return (false, msg),
+        }
+    }
+
+    (
+        false,
+        "amplihack hooks not found in settings.json (checked global \
+         ~/.claude/settings.json and project-local .claude/settings.json)"
+            .to_string(),
+    )
+}
+
+/// Read `path` and report whether its `hooks` section references amplihack.
+///
+/// Returns `None` when the file is absent (nothing to report for this
+/// location), `Some(Ok(bool))` when it parses, and `Some(Err(msg))` for a
+/// read/parse error whose message is truncated and never includes file
+/// contents.
+fn settings_has_amplihack_hooks(path: &std::path::Path) -> Option<Result<bool, String>> {
+    if !path.exists() {
+        return None;
+    }
+
+    let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) => {
             let msg = e.to_string();
-            return (
-                false,
-                format!(
-                    "hooks: cannot read settings.json: {}",
-                    truncate_chars_with_notice(&msg, MAX_ERROR_LEN)
-                ),
-            );
+            return Some(Err(format!(
+                "hooks: cannot read settings.json: {}",
+                truncate_chars_with_notice(&msg, MAX_ERROR_LEN)
+            )));
         }
     };
 
     let json: serde_json::Value = match serde_json::from_str(&content) {
         Ok(v) => v,
-        Err(_) => return (false, "hooks: settings.json is not valid JSON".to_string()),
+        Err(_) => return Some(Err("hooks: settings.json is not valid JSON".to_string())),
     };
 
-    if let Some(hooks) = json.get("hooks")
-        && json_contains_amplihack(hooks)
-    {
-        return (true, "amplihack hooks installed".to_string());
-    }
-
-    (
-        false,
-        "amplihack hooks not found in settings.json".to_string(),
-    )
+    let has_hooks = json
+        .get("hooks")
+        .map(json_contains_amplihack)
+        .unwrap_or(false);
+    Some(Ok(has_hooks))
 }
 
 /// Check 2 — settings.json valid JSON.

--- a/crates/amplihack-cli/src/commands/doctor/mod.rs
+++ b/crates/amplihack-cli/src/commands/doctor/mod.rs
@@ -338,4 +338,62 @@ mod tests {
             "run_doctor should return Ok on healthy machine"
         );
     }
+
+    #[test]
+    fn test_check_hooks_installed_passes_with_repo_local_hooks_only() {
+        use crate::test_support::{CwdGuard, HomeGuard, env_lock};
+
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        // Global HOME has no settings.json; hooks live only in the repo-local
+        // <cwd>/.claude/settings.json — a valid project-local install.
+        let home = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let _home_guard = HomeGuard::set(home.path());
+
+        let repo_settings = repo.path().join(".claude").join("settings.json");
+        std::fs::create_dir_all(repo_settings.parent().unwrap()).unwrap();
+        std::fs::write(
+            &repo_settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "hooks": {
+                    "SessionStart": [
+                        { "hooks": [{"type": "command", "command": "/home/user/.local/bin/amplihack-hooks session-start"}] }
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let _cwd_guard = CwdGuard::set(repo.path()).unwrap();
+        let (passed, msg) = check_hooks_installed();
+        assert!(
+            passed,
+            "project-local hooks must satisfy the doctor check; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_check_hooks_installed_fails_when_no_hooks_anywhere() {
+        use crate::test_support::{CwdGuard, HomeGuard, env_lock};
+
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let home = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let _home_guard = HomeGuard::set(home.path());
+        let _cwd_guard = CwdGuard::set(repo.path()).unwrap();
+
+        let (passed, msg) = check_hooks_installed();
+        assert!(!passed, "no hooks anywhere should fail");
+        assert!(
+            msg.contains("global") && msg.contains("project-local"),
+            "failure message should mention both checked locations; got: {msg}"
+        );
+    }
 }

--- a/crates/amplihack-cli/src/commands/doctor/mod.rs
+++ b/crates/amplihack-cli/src/commands/doctor/mod.rs
@@ -396,4 +396,47 @@ mod tests {
             "failure message should mention both checked locations; got: {msg}"
         );
     }
+
+    #[test]
+    fn test_check_hooks_installed_corrupt_global_does_not_mask_repo_local() {
+        use crate::test_support::{CwdGuard, HomeGuard, env_lock};
+
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        // Global settings.json is present but corrupt (invalid JSON), while a
+        // valid project-local install exists. A read/parse error on the global
+        // candidate must not short-circuit and mask the working repo-local
+        // hooks — otherwise we reintroduce the #1088 false-negative.
+        let home = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let _home_guard = HomeGuard::set(home.path());
+
+        let global_settings = home.path().join(".claude").join("settings.json");
+        std::fs::create_dir_all(global_settings.parent().unwrap()).unwrap();
+        std::fs::write(&global_settings, "{ this is not valid json ").unwrap();
+
+        let repo_settings = repo.path().join(".claude").join("settings.json");
+        std::fs::create_dir_all(repo_settings.parent().unwrap()).unwrap();
+        std::fs::write(
+            &repo_settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "hooks": {
+                    "SessionStart": [
+                        { "hooks": [{"type": "command", "command": "/home/user/.local/bin/amplihack-hooks session-start"}] }
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let _cwd_guard = CwdGuard::set(repo.path()).unwrap();
+        let (passed, msg) = check_hooks_installed();
+        assert!(
+            passed,
+            "a corrupt global settings.json must not mask valid repo-local hooks; got: {msg}"
+        );
+    }
 }

--- a/crates/amplihack-hooks/src/session_start/migration.rs
+++ b/crates/amplihack-hooks/src/session_start/migration.rs
@@ -6,7 +6,7 @@ use amplihack_types::ProjectDirs;
 use serde_json::Value;
 use std::path::PathBuf;
 
-pub(super) fn migrate_global_hooks() -> Option<String> {
+pub(super) fn migrate_global_hooks(dirs: &ProjectDirs) -> Option<String> {
     let global_settings = ProjectDirs::global_settings()?;
     if !global_settings.exists() {
         return None;
@@ -30,23 +30,53 @@ pub(super) fn migrate_global_hooks() -> Option<String> {
         return None;
     }
 
+    // The global hooks are only redundant once project-local hooks exist. If the
+    // repo-local `.claude/settings.json` does not (yet) contain amplihack hooks,
+    // the global copy is the ONLY working copy — deleting it here would silently
+    // uninstall the framework (issue #1088). In that case do nothing and stay
+    // quiet: no deletion, no bogus "migrated" message.
+    if !repo_local_contains_amplihack_hooks(dirs) {
+        return None;
+    }
+
+    // Project-local hooks are present, so the global copy is now redundant and
+    // safe to remove. This is a pure cleanup — never claim a "migration/move".
     match settings_file.update(|settings: &mut Value| remove_amplihack_hooks(settings)) {
         Ok(updated) if !contains_amplihack_hooks(&updated) => Some(
-            "✅ Migrated amplihack hooks from global ~/.claude/settings.json to project-local hooks."
+            "Removed redundant global amplihack hooks from ~/.claude/settings.json; \
+             project-local hooks in .claude/settings.json remain active."
                 .to_string(),
         ),
         Ok(_) => Some(
-            "⚠️ Global amplihack hooks detected in ~/.claude/settings.json. \
-             These should be migrated to project-local hooks."
+            "⚠️ Redundant global amplihack hooks detected in ~/.claude/settings.json. \
+             Automatic cleanup did not remove them — please remove them manually."
                 .to_string(),
         ),
         Err(e) => {
-            tracing::warn!("Hook migration failed: {}", e);
+            tracing::warn!("Hook cleanup failed: {}", e);
             Some(
-                "⚠️ Global amplihack hooks detected in ~/.claude/settings.json. \
-                 Migration failed — please remove them manually."
+                "⚠️ Redundant global amplihack hooks detected in ~/.claude/settings.json. \
+                 Cleanup failed — please remove them manually."
                     .to_string(),
             )
+        }
+    }
+}
+
+/// Return `true` if the repo-local `<project-root>/.claude/settings.json`
+/// already contains amplihack hooks. This is a read-only probe used to decide
+/// whether the global hooks are redundant; it never writes.
+fn repo_local_contains_amplihack_hooks(dirs: &ProjectDirs) -> bool {
+    let repo_local = dirs.claude.join("settings.json");
+    if !repo_local.exists() {
+        return false;
+    }
+    match AtomicJsonFile::new(&repo_local).read() {
+        Ok(Some(value)) => contains_amplihack_hooks(&value),
+        Ok(None) => false,
+        Err(e) => {
+            tracing::warn!("Failed to read repo-local settings: {}", e);
+            false
         }
     }
 }
@@ -81,7 +111,10 @@ fn wrapper_references_amplihack(wrapper: &Value) -> bool {
 
 fn remove_amplihack_hooks(settings: &mut Value) {
     let Some(root) = settings.as_object_mut() else {
-        *settings = serde_json::json!({});
+        // The settings file did not parse to a JSON object (e.g. a truncated
+        // write left an array/string/null). Removing "our" hooks must never
+        // zero out a user's entire config, so leave the value untouched.
+        tracing::warn!("Global settings.json was not a JSON object; left unchanged");
         return;
     };
     let Some(hooks) = root.get_mut("hooks").and_then(Value::as_object_mut) else {
@@ -217,53 +250,157 @@ mod tests {
         assert!(settings["hooks"].get("UserPromptSubmit").is_none());
     }
 
+    /// (d) Data-loss guard: a non-object settings value must be left UNCHANGED
+    /// and must never be replaced with `{}`.
     #[test]
-    fn migrate_global_hooks_updates_settings_atomically() {
+    fn remove_amplihack_hooks_leaves_non_object_values_untouched() {
+        for input in [
+            serde_json::json!([]),
+            serde_json::json!("x"),
+            serde_json::json!(42),
+            Value::Null,
+        ] {
+            let mut value = input.clone();
+            remove_amplihack_hooks(&mut value);
+            assert_eq!(
+                value, input,
+                "non-object settings value must be left untouched"
+            );
+            assert_ne!(
+                value,
+                serde_json::json!({}),
+                "non-object value must not be replaced with an empty object"
+            );
+        }
+    }
+
+    fn amplihack_hooks_json() -> serde_json::Value {
+        serde_json::json!({
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "hooks": [
+                            {"type": "command", "command": "/home/user/.local/bin/amplihack-hooks session-start"}
+                        ]
+                    },
+                    {
+                        "hooks": [
+                            {"type": "command", "command": "/usr/local/bin/third-party-hook"}
+                        ]
+                    }
+                ]
+            }
+        })
+    }
+
+    fn write_json(path: &std::path::Path, value: &serde_json::Value) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, serde_json::to_string_pretty(value).unwrap()).unwrap();
+    }
+
+    /// (a) Self-uninstall guard (regression test for #1088): global has
+    /// amplihack hooks but the repo-local `.claude/settings.json` does NOT, so
+    /// the global copy is the only working copy and MUST be left untouched.
+    #[test]
+    fn migrate_global_hooks_does_not_delete_when_no_repo_local_hooks() {
         let _guard = env_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let dir = tempfile::tempdir().unwrap();
-        let prev_home = std::env::var_os("HOME");
-        unsafe { std::env::set_var("HOME", dir.path()) };
 
-        let settings_path = dir.path().join(".claude/settings.json");
-        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
-        fs::write(
-            &settings_path,
-            serde_json::to_string_pretty(&serde_json::json!({
+        let home = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let global_path = home.path().join(".claude/settings.json");
+        let global_value = amplihack_hooks_json();
+        write_json(&global_path, &global_value);
+
+        let dirs = ProjectDirs::new(repo.path());
+
+        // Case 1: repo-local settings.json absent entirely.
+        let result_absent = migrate_global_hooks(&dirs);
+
+        // Case 2: repo-local settings.json present but WITHOUT amplihack hooks.
+        write_json(
+            &dirs.claude.join("settings.json"),
+            &serde_json::json!({
                 "hooks": {
                     "SessionStart": [
-                        {
-                            "hooks": [
-                                {"type": "command", "command": "/home/user/.local/bin/amplihack-hooks session-start"}
-                            ]
-                        },
-                        {
-                            "hooks": [
-                                {"type": "command", "command": "/usr/local/bin/third-party-hook"}
-                            ]
-                        }
+                        { "hooks": [{"type": "command", "command": "/usr/local/bin/third-party-hook"}] }
                     ]
                 }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-
-        let message = migrate_global_hooks().expect("migration message expected");
+            }),
+        );
+        let result_no_amplihack = migrate_global_hooks(&dirs);
 
         match prev_home {
             Some(value) => unsafe { std::env::set_var("HOME", value) },
             None => unsafe { std::env::remove_var("HOME") },
         }
 
-        assert!(message.contains("Migrated amplihack hooks"));
+        assert!(
+            result_absent.is_none(),
+            "must not act when repo-local settings absent"
+        );
+        assert!(
+            result_no_amplihack.is_none(),
+            "must not act when repo-local lacks amplihack hooks"
+        );
+
+        // The global file must be completely UNCHANGED (still has amplihack hooks).
+        let after: Value =
+            serde_json::from_str(&fs::read_to_string(&global_path).unwrap()).unwrap();
+        assert_eq!(after, global_value, "global settings must be untouched");
+        assert!(contains_amplihack_hooks(&after));
+    }
+
+    /// (b)/(c) Redundant-cleanup path: global AND repo-local both have amplihack
+    /// hooks -> the global copy is removed, third-party global entries are
+    /// preserved, and the message does NOT falsely claim a move/migration.
+    #[test]
+    fn migrate_global_hooks_removes_redundant_global_when_repo_local_present() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let home = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let global_path = home.path().join(".claude/settings.json");
+        write_json(&global_path, &amplihack_hooks_json());
+
+        let dirs = ProjectDirs::new(repo.path());
+        write_json(&dirs.claude.join("settings.json"), &amplihack_hooks_json());
+
+        let message = migrate_global_hooks(&dirs).expect("cleanup message expected");
+
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert!(
+            !message.to_lowercase().contains("migrated"),
+            "message must not claim a migration/move; got: {message}"
+        );
+        assert!(
+            message.contains("Removed redundant global amplihack hooks"),
+            "message should state redundant global hooks were removed; got: {message}"
+        );
+
         let updated: Value =
-            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
-        assert!(!contains_amplihack_hooks(&updated));
+            serde_json::from_str(&fs::read_to_string(&global_path).unwrap()).unwrap();
+        assert!(
+            !contains_amplihack_hooks(&updated),
+            "global amplihack hooks should be removed"
+        );
         assert_eq!(
             updated["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
-            Some("/usr/local/bin/third-party-hook")
+            Some("/usr/local/bin/third-party-hook"),
+            "third-party global entries must be preserved"
         );
     }
 }

--- a/crates/amplihack-hooks/src/session_start/mod.rs
+++ b/crates/amplihack-hooks/src/session_start/mod.rs
@@ -87,7 +87,7 @@ impl Hook for SessionStartHook {
         }
 
         // Migrate global hooks if needed.
-        if let Some(migration_notice) = migrate_global_hooks() {
+        if let Some(migration_notice) = migrate_global_hooks(&dirs) {
             context_parts.push(migration_notice);
         }
 

--- a/docs/HOOK_MIGRATION_AND_DOCTOR.md
+++ b/docs/HOOK_MIGRATION_AND_DOCTOR.md
@@ -1,0 +1,160 @@
+# Global Hook Cleanup & `amplihack doctor` Hook Detection
+
+This guide explains how amplihack manages the relationship between **global**
+hooks (`~/.claude/settings.json`) and **project-local** hooks
+(`<project-root>/.claude/settings.json`) on session start, and how
+`amplihack doctor` reports whether hooks are installed.
+
+It documents the safety guarantees that prevent amplihack from ever
+uninstalling itself, and the conditions under which `amplihack doctor` reports
+a healthy install.
+
+> Related: [Hook Configuration Guide](HOOK_CONFIGURATION_GUIDE.md),
+> [Hook Payload Compatibility](HOOK_PAYLOAD_COMPATIBILITY.md).
+
+## Background: two places hooks can live
+
+Claude Code (and amplihack's native hook runner) resolves hooks from two
+locations:
+
+| Location        | Path                                      | Scope                         |
+| --------------- | ----------------------------------------- | ----------------------------- |
+| Global          | `~/.claude/settings.json`                 | Applies to every project      |
+| Project-local   | `<project-root>/.claude/settings.json`    | Applies to one repository     |
+
+Amplihack hooks are identified inside a `settings.json` `hooks` section by a
+hook `command` string that references `amplihack-hooks` or
+`tools/amplihack/`. Either location is a **valid, fully working** install.
+
+## Session-start global hook cleanup
+
+On every session start, amplihack runs a small compatibility step that decides
+whether the **global** amplihack hooks are still needed. The governing
+invariant is:
+
+> **Never delete the only working copy of amplihack's hooks, and never report
+> success for a pure deletion.**
+
+### Decision table
+
+The step reads global settings and probes the project-local
+`.claude/settings.json` (read-only — it never writes hooks). It then behaves as
+follows:
+
+| Global has amplihack hooks | Project-local has amplihack hooks | Action                                            | Notice shown                                                                                                                        |
+| :------------------------: | :-------------------------------: | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| No (or file absent)        | —                                 | **Nothing.**                                      | *(none)*                                                                                                                            |
+| Yes                        | **No** (or file absent)           | **Nothing — global copy is preserved.**           | *(none)*                                                                                                                            |
+| Yes                        | Yes                               | Remove the now-redundant global amplihack hooks.  | `Removed redundant global amplihack hooks from ~/.claude/settings.json; project-local hooks in .claude/settings.json remain active.` |
+
+Key points:
+
+- **The global hooks are removed only when a project-local copy already exists.**
+  If there is no project-local copy, the global hooks are left completely
+  untouched. This is what prevents the framework from silently uninstalling
+  itself once per session.
+- **No false "migration" message is ever printed.** A notice appears only after
+  a redundant global copy is confirmed removed, and the wording describes a
+  cleanup — not a move. If nothing was deleted, nothing is claimed.
+- Third-party (non-amplihack) hooks in the global file are always preserved.
+  Only amplihack's own hook entries are removed, and empty hook groups left
+  behind by the removal are pruned.
+- If the global `~/.claude/settings.json` **exists but cannot be read or
+  parsed**, the step makes no changes and surfaces a cautionary notice
+  (`⚠️ Global amplihack hooks may exist in ~/.claude/settings.json. Failed to
+  read the file for migration.`) rather than silently proceeding. Likewise, if
+  a confirmed-redundant cleanup fails to remove the hooks, a `⚠️` notice asks
+  you to remove them manually instead of falsely reporting success.
+
+### What you will (and won't) see
+
+Fresh install with only global hooks — session start is silent about hooks and
+your global hooks keep working:
+
+```text
+$ amplihack   # start a session
+# (no hook migration/cleanup notice; global hooks remain active)
+```
+
+Once a project also has project-local hooks, the next session start reports the
+one-time cleanup of the redundant global copy:
+
+```text
+Removed redundant global amplihack hooks from ~/.claude/settings.json;
+project-local hooks in .claude/settings.json remain active.
+```
+
+## Data-loss protection for malformed settings
+
+Cleanup of amplihack's hooks is defensive about malformed configuration files.
+If `~/.claude/settings.json` does not parse to a JSON **object** — for example a
+truncated write left an array, a bare string, a number, or `null` — the cleanup
+routine **leaves the value untouched** and logs a warning:
+
+```text
+WARN  Global settings.json was not a JSON object; left unchanged
+```
+
+A cleanup of amplihack's own hooks will **never** overwrite an unexpected value
+with an empty object (`{}`), so a partially written or hand-edited settings file
+is never zeroed out.
+
+All reads and writes use amplihack's atomic JSON file mechanism (temp-write +
+atomic rename with a consistent backup), so a crash or a concurrent writer
+cannot leave `settings.json` half-written by this step.
+
+## `amplihack doctor`: hook detection
+
+`amplihack doctor` includes a **hooks installed** health check. It passes when
+**either** location contains amplihack hooks:
+
+- global `~/.claude/settings.json`, **or**
+- project-local `<cwd>/.claude/settings.json`
+
+This means a project that is installed **only** project-locally is correctly
+reported as healthy.
+
+### Passing output
+
+Run from a directory whose `.claude/settings.json` (or your global settings)
+contains amplihack hooks:
+
+```text
+$ amplihack doctor
+✓ amplihack hooks installed
+...
+```
+
+### Failing output
+
+If **neither** location contains amplihack hooks, the check fails and names both
+places it looked:
+
+```text
+$ amplihack doctor
+✗ amplihack hooks not found in settings.json (checked global
+  ~/.claude/settings.json and project-local .claude/settings.json)
+```
+
+### Secret hygiene
+
+The hooks check never prints the contents of any `settings.json`. It reports
+only presence/validity, and any read/parse error messages are truncated. This
+preserves the doctor command's existing secret-hygiene behavior.
+
+## Frequently asked questions
+
+**Will amplihack delete my global hooks if I only ever install globally?**
+No. Global hooks are removed only when a project-local copy already exists. A
+global-only install is never touched and `amplihack doctor` reports it as
+healthy.
+
+**I have a project-local install but `doctor` used to say hooks were missing.**
+`amplihack doctor` now checks the project-local
+`<cwd>/.claude/settings.json` in addition to the global file, so a
+project-local install passes the check.
+
+**Does this step write project-local hooks for me?**
+No. This compatibility step only **reads** the project-local file to decide
+whether the global copy is redundant. Writing project-local hooks (for example
+choosing an install scope during the install wizard) is a separate feature.

--- a/docs/index.md
+++ b/docs/index.md
@@ -713,6 +713,7 @@ Advanced configuration, deployment patterns, and environment management.
 - [Profile Management](PROFILE_MANAGEMENT.md) - Multiple environment configurations
 - [Hook Configuration](HOOK_CONFIGURATION_GUIDE.md) - Customize framework behavior
 - [Hook Payload Compatibility](HOOK_PAYLOAD_COMPATIBILITY.md) - Claude Code, Amplifier, and Copilot CLI tool-input payload shapes and normalization
+- [Global Hook Cleanup & Doctor Hook Detection](HOOK_MIGRATION_AND_DOCTOR.md) - Safe global-vs-project-local hook cleanup on session start and how `amplihack doctor` detects installed hooks
 - [Shell Command Hook](SHELL_COMMAND_HOOK.md) - Custom shell integrations
 
 ### Deployment


### PR DESCRIPTION
## Summary

The session-start hook "migration" deleted amplihack's global hooks from `~/.claude/settings.json` on every session start whenever they were present, while **nothing ever wrote project-local hooks**. The framework silently uninstalled itself once per session, and `amplihack doctor` could never pass. This PR fixes the self-uninstall, a whole-config data-loss defect, the false "success" message, and the doctor false-negative.

**Governing invariant:** never delete the SOURCE side of a "migration" before the DESTINATION side is durable, and never report success for a pure deletion.

## Changes (3 files + tests)

### `crates/amplihack-hooks/src/session_start/migration.rs`
- `migrate_global_hooks` now takes `&ProjectDirs` and reads the repo-local `.claude/settings.json` to decide whether deletion is safe:
  - global has hooks but **repo-local lacks them** → the global copy is the only working copy → **do nothing, no message** (stops the self-uninstall, #1088).
  - global has hooks **and** repo-local also has them → the global copy is redundant → remove it, returning a plain-language notice that does **not** claim a move/migration.
- **Data-loss fix:** `remove_amplihack_hooks` no longer replaces a non-object settings value with `{}` (which wiped the entire config); it leaves the value untouched and warns.

### `crates/amplihack-hooks/src/session_start/mod.rs`
- Caller updated to `migrate_global_hooks(&dirs)`.

### `crates/amplihack-cli/src/commands/doctor/checks.rs`
- `check_hooks_installed` now passes if **either** the global `~/.claude/settings.json` **or** the project-local `<cwd>/.claude/settings.json` contains amplihack hooks. Secret-hygiene/truncation preserved; failure message names both checked locations.

## Scope guardrails
- amplihack-hooks does **not** gain any install/writer dependency — it only *reads* the repo-local settings file to decide whether deletion is safe. Building the repo-local install writer / wizard scope choice is out of scope (follow-up #1119).

## Tests
- Self-uninstall regression guard (global hooks preserved when repo-local absent/hookless).
- Redundant-cleanup path (both present → global removed, third-party entries preserved, no false "migrated" text).
- Data-loss guard (non-object value left unchanged, never `{}`).
- Doctor passes with repo-local-only hooks; fails naming both locations when none exist.

## Validation
- `cargo test -p amplihack-hooks` ✅
- `cargo test -p amplihack-cli --lib commands::doctor` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --all --check` ✅

Closes #1088

---

## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo** (workspace `Cargo.toml`, edition 2024). Changed files are `.rs` in `crates/amplihack-hooks` and `crates/amplihack-cli`. User-facing surfaces are two binaries: `bins/amplihack` (the `amplihack doctor` CLI) and `bins/amplihack-hooks` (the `session-start` hook run by the host). Both were built with `cargo build -p amplihack -p amplihack-hooks`.

Chosen validation strategy:
- Native `cargo test` for unit/branch coverage, **plus** true outside-in execution of the built binaries in isolated `HOME`/`CWD` sandboxes — exactly how the host launcher invokes them. This proves the user-visible behavior (self-uninstall guard, honest messaging, data-loss guard, doctor pass) end-to-end rather than at the function level.

### Scenario 1 — `amplihack doctor` passes with repo-local-only hooks (doctor false-negative fix)
Command: `cd <repo-sandbox> && HOME=<home-sandbox> amplihack doctor` (global `~/.claude/settings.json` = `{}`, project-local `.claude/settings.json` contains amplihack hooks)
Result: PASS
Output:
```
✓ amplihack hooks installed
```
Negative control (no hooks anywhere):
```
✗ amplihack hooks not found in settings.json (checked global ~/.claude/settings.json and project-local .claude/settings.json)
```

### Scenario 2 — `session-start` self-uninstall regression + redundant cleanup + data-loss guard
Command: `echo '{"hook_event_name":"SessionStart","session_id":"..."}' | (cd <repo-sandbox> && HOME=<home-sandbox> amplihack-hooks session-start)`
Result: PASS (7/7 assertions)
Output (harness summary):
```
2a: global hooks present, NO repo-local hooks -> global MUST be preserved
  PASS: global amplihack hooks NOT deleted (self-uninstall guard)
  PASS: global settings.json byte-identical (unchanged)
2b: global hooks present AND repo-local hooks present -> global cleaned up, honest msg
  PASS: redundant global amplihack hooks removed
  PASS: third-party global hook preserved
  PASS: output does NOT falsely claim 'Migrated amplihack hooks'
  PASS: output uses honest 'redundant global amplihack hooks' language
2c: corrupt (non-object) global settings
  PASS: non-object global settings left UNCHANGED (not wiped to {})

==================== SUMMARY: PASS=9 FAIL=0 ====================
```

Cargo suites (run in addition to outside-in):
- `cargo test -p amplihack-hooks` → ok (all migration branch tests incl. `migrate_global_hooks_does_not_delete_when_no_repo_local_hooks`, `migrate_global_hooks_removes_redundant_global_when_repo_local_present`, `remove_amplihack_hooks_leaves_non_object_values_untouched`, `remove_amplihack_hooks_preserves_third_party_entries`).
- `cargo test -p amplihack-cli --lib commands::doctor` → ok (incl. `test_check_hooks_installed_passes_with_repo_local_hooks_only`, `test_check_hooks_installed_fails_when_no_hooks_anywhere`).
- `cargo clippy -p amplihack-hooks -p amplihack-cli --all-targets -- -D warnings` → clean.
- `cargo fmt --all --check` → clean.

Both scenarios passed.


## Step 16b: Outside-In Testing Results

**Detected toolchain:** Rust workspace (Cargo). Root `Cargo.toml`, `rust-toolchain.toml`. Changed crates: `amplihack-hooks`, `amplihack-cli`. Entry-point binaries: `amplihack` (CLI) and `amplihack-hooks` (hook runner).

**Chosen strategy:** Native `cargo test` for the changed crates plus real-binary, end-to-end scenarios exercising the two user/consumer boundaries this fix touches: the `amplihack doctor` CLI and the `amplihack-hooks session-start` hook. Ran against isolated sandbox `HOME`/repo dirs. Also ran `cargo fmt --all --check` and `cargo clippy --all-targets -D warnings`.

| # | Scenario | Command | Result | Key output |
|---|----------|---------|--------|------------|
| unit-hooks | `amplihack-hooks` unit + golden suite (incl. all 4 migration branches: self-uninstall guard, redundant cleanup, data-loss guard, third-party preserve) | `cargo test -p amplihack-hooks` | ✅ PASS | 18 passed; 0 failed. Migration tests: 4/4 ok |
| unit-doctor | doctor lib tests incl. new repo-local pass + no-hooks-anywhere fail | `cargo test -p amplihack-cli --lib commands::doctor` | ✅ PASS | 11 passed; 0 failed; 1 ignored (needs live tmux/recipe-runner) |
| S1 (simple) | `amplihack doctor` with hooks ONLY in project-local `.claude/settings.json` (global empty) | `amplihack doctor` | ✅ PASS | `✓ amplihack hooks installed` |
| S2 (edge/#1088 regression) | `session-start` hook when global has amplihack hooks but repo-local has none | `echo '{}' \| amplihack-hooks session-start` | ✅ PASS | No "Migrated" message; global `settings.json` byte-for-byte UNCHANGED; amplihack hooks + unrelated user setting both preserved |
| S3 (edge) | `session-start` redundant cleanup: global AND repo-local both have hooks | `echo '{}' \| amplihack-hooks session-start` | ✅ PASS | Global amplihack hook removed; third-party global entry `/usr/local/bin/third-party-hook` preserved |
| S4 (edge) | `amplihack doctor` with no hooks in either location | `amplihack doctor` | ✅ PASS | `✗ amplihack hooks not found in settings.json (checked global ~/.claude/settings.json and project-local .claude/settings.json)` |
| lint | Formatting + lints | `cargo fmt --all --check` && `cargo clippy --all-targets -- -D warnings` | ✅ PASS | fmt exit 0; clippy exit 0 (no warnings) |

**Fix count during Step 16b: 0.** All scenarios passed on first run; the branch implementation already satisfies every acceptance criterion (self-uninstall prevented, no false "migrated" message, whole-config data-loss guarded, doctor recognizes project-local installs). No code changes were required.

Closes #1088
