### PR TITLE
fix(#1119): honor repo-local hook scope during install

### DIFF
--- a/crates/amplihack-cli/src/commands/install/interactive.rs
+++ b/crates/amplihack-cli/src/commands/install/interactive.rs
@@ -7,7 +7,6 @@
 //!   Not unit-tested (requires real TTY). Covered by manual/integration tests.
 
 use super::types::InstallManifest;
-#[cfg(test)]
 use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
@@ -66,14 +65,18 @@ impl HookScope {
         vec![Self::Global, Self::RepoLocal]
     }
 
+    /// Stable lowercase slug for manifest serialization.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::RepoLocal => "repo-local",
+        }
+    }
+
     /// Resolve the settings.json path for this scope.
     ///
     /// - `Global`: `~/.claude/settings.json` (ignores `repo_root`).
     /// - `RepoLocal`: `<repo_root>/.claude/settings.json`.
-    ///
-    /// Currently exercised by tests; will be consumed by hook-wiring
-    /// integration when repo-local scope writes land.
-    #[cfg(test)]
     pub(crate) fn settings_path_for(self, repo_root: &Path) -> PathBuf {
         match self {
             Self::Global => {
@@ -169,10 +172,6 @@ fn atty_check() -> bool {
 
 /// Resolve the effective hook scope, falling back to Global if repo-local
 /// was requested but no git repository exists at `cwd`.
-///
-/// Currently exercised by tests; will be consumed by hook-wiring
-/// integration when repo-local scope writes land.
-#[cfg(test)]
 pub(crate) fn resolve_hook_scope(scope: HookScope, cwd: &Path) -> HookScope {
     match scope {
         HookScope::Global => HookScope::Global,
@@ -216,6 +215,7 @@ pub(crate) fn maybe_run_wizard(interactive: bool) -> anyhow::Result<Option<Inter
 pub(super) fn apply_config(config: &InteractiveConfig, manifest: &mut InstallManifest) {
     manifest.default_tool = Some(config.default_tool.as_str().to_string());
     manifest.update_check_preference = Some(config.update_check.as_str().to_string());
+    manifest.hook_scope = Some(config.hook_scope.as_str().to_string());
 }
 
 // ---------------------------------------------------------------------------
@@ -284,7 +284,6 @@ fn run_wizard() -> anyhow::Result<InteractiveConfig> {
 // ---------------------------------------------------------------------------
 
 /// Resolve the user's home directory.
-#[cfg(test)]
 fn dirs_home() -> Option<PathBuf> {
     // Reuse the existing home_dir helper from the install paths module.
     super::paths::home_dir().ok()

--- a/crates/amplihack-cli/src/commands/install/mod.rs
+++ b/crates/amplihack-cli/src/commands/install/mod.rs
@@ -203,7 +203,8 @@ pub(crate) fn ensure_framework_installed() -> Result<()> {
     if !hooks_registered_in_settings(&settings_path)? {
         tracing::warn!("hooks not registered in settings.json — auto-repairing");
         let timestamp = unix_timestamp();
-        let (settings_ok, _events) = ensure_settings_json(&staging_dir, timestamp, &hooks_bin)?;
+        let (settings_ok, _events) =
+            ensure_settings_json(&settings_path, &staging_dir, timestamp, &hooks_bin)?;
         if !settings_ok {
             bail!(
                 "failed to configure ~/.claude/settings.json for amplihack hooks.\n\
@@ -378,8 +379,22 @@ fn local_install(
 
     println!();
     println!("⚙️  Configuring settings.json:");
+    // Honor the interactive hook-scope choice (issue #1119). Repo-local scope
+    // resolves against the current working directory — where `amplihack install`
+    // runs — and falls back to global if that directory is not a git repo.
+    let requested_scope = wizard_config
+        .map(|c| c.hook_scope)
+        .unwrap_or(interactive::HookScope::Global);
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let effective_scope = interactive::resolve_hook_scope(requested_scope, &cwd);
+    let settings_target = effective_scope.settings_path_for(&cwd);
+    println!(
+        "   Scope: {} → {}",
+        effective_scope.display_name(),
+        settings_target.display()
+    );
     let (settings_ok, registered_events) =
-        ensure_settings_json(&claude_dir, timestamp, &hooks_bin)?;
+        ensure_settings_json(&settings_target, &claude_dir, timestamp, &hooks_bin)?;
 
     println!();
     println!("🐙 Configuring GitHub Copilot CLI plugin (if installed):");
@@ -463,7 +478,11 @@ fn local_install(
         println!();
         println!("🧙 Interactive configuration applied:");
         println!("   • Default tool: {}", config.default_tool.display_name());
-        println!("   • Hook scope: {}", config.hook_scope.display_name());
+        println!(
+            "   • Hook scope: {} ({})",
+            effective_scope.display_name(),
+            settings_target.display()
+        );
         println!("   • Update checks: {}", config.update_check.display_name());
     }
 

--- a/crates/amplihack-cli/src/commands/install/settings.rs
+++ b/crates/amplihack-cli/src/commands/install/settings.rs
@@ -1,7 +1,7 @@
 //! Settings.json configuration, hook contract validation, and framework verification.
 
 use super::hooks::{ensure_array, ensure_object, update_hook_paths};
-use super::paths::{global_settings_path, xpia_hooks_dir};
+use super::paths::xpia_hooks_dir;
 use super::types::*;
 use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value, json};
@@ -9,26 +9,31 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
-/// Configure ~/.claude/settings.json with amplihack hook registrations.
+/// Configure the given settings.json with amplihack hook registrations.
+///
+/// The target `settings_path` is chosen by the caller (global `~/.claude` or
+/// a repo-local `<repo>/.claude`), keeping this writer scope-agnostic. Backup,
+/// parent-directory creation, and atomic-write semantics are keyed off
+/// `settings_path.parent()`.
 ///
 /// Returns `(success, registered_event_names)` where `registered_event_names`
 /// is a deduplicated list of event names that were configured.
 pub(super) fn ensure_settings_json(
+    settings_path: &Path,
     staging_dir: &Path,
     timestamp: u64,
     hooks_bin: &Path,
 ) -> Result<(bool, Vec<String>)> {
-    let settings_path = global_settings_path()?;
     if let Some(parent) = settings_path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
     let backup_path = settings_path
         .parent()
-        .context("global settings path missing parent")?
+        .context("settings path missing parent")?
         .join(format!("settings.json.backup.{timestamp}"));
     if settings_path.exists() {
-        fs::copy(&settings_path, &backup_path).with_context(|| {
+        fs::copy(settings_path, &backup_path).with_context(|| {
             format!(
                 "failed to copy {} to {}",
                 settings_path.display(),
@@ -56,11 +61,11 @@ pub(super) fn ensure_settings_json(
         println!("  💾 Backup created at {}", backup_path.display());
         println!("  📋 Found existing settings.json");
     } else {
-        fs::write(&settings_path, "{}\n")
+        fs::write(settings_path, "{}\n")
             .with_context(|| format!("failed to write {}", settings_path.display()))?;
     }
 
-    let mut settings = read_settings_json(&settings_path)?;
+    let mut settings = read_settings_json(settings_path)?;
     ensure_permissions(&mut settings);
     update_hook_paths(&mut settings, "amplihack", AMPLIHACK_HOOK_SPECS, hooks_bin);
 
@@ -70,7 +75,7 @@ pub(super) fn ensure_settings_json(
     }
 
     fs::write(
-        &settings_path,
+        settings_path,
         serde_json::to_string_pretty(&settings)? + "\n",
     )
     .with_context(|| format!("failed to write {}", settings_path.display()))?;

--- a/crates/amplihack-cli/src/commands/install/tests/interactive_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/interactive_tests.rs
@@ -264,6 +264,23 @@ fn resolve_hook_scope_preserves_global_regardless_of_git() {
     );
 }
 
+#[test]
+fn settings_path_for_repo_local_targets_repo_dot_claude() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = interactive::HookScope::RepoLocal.settings_path_for(temp.path());
+    assert_eq!(
+        path,
+        temp.path().join(".claude").join("settings.json"),
+        "repo-local settings path must be <root>/.claude/settings.json"
+    );
+}
+
+#[test]
+fn hook_scope_as_str_slugs_are_stable() {
+    assert_eq!(interactive::HookScope::Global.as_str(), "global");
+    assert_eq!(interactive::HookScope::RepoLocal.as_str(), "repo-local");
+}
+
 // ---------------------------------------------------------------------------
 // 7. Manifest integration — new optional fields
 // ---------------------------------------------------------------------------
@@ -329,6 +346,19 @@ fn apply_config_sets_manifest_fields() {
     interactive::apply_config(&config, &mut manifest);
     assert_eq!(manifest.default_tool.as_deref(), Some("codex"));
     assert_eq!(manifest.update_check_preference.as_deref(), Some("manual"));
+    assert_eq!(manifest.hook_scope.as_deref(), Some("global"));
+}
+
+#[test]
+fn apply_config_records_repo_local_hook_scope() {
+    let config = interactive::InteractiveConfig {
+        default_tool: interactive::DefaultTool::Claude,
+        hook_scope: interactive::HookScope::RepoLocal,
+        update_check: interactive::UpdateCheckPreference::Manual,
+    };
+    let mut manifest = InstallManifest::default();
+    interactive::apply_config(&config, &mut manifest);
+    assert_eq!(manifest.hook_scope.as_deref(), Some("repo-local"));
 }
 
 #[test]

--- a/crates/amplihack-cli/src/commands/install/tests/settings_tests.rs
+++ b/crates/amplihack-cli/src/commands/install/tests/settings_tests.rs
@@ -22,7 +22,8 @@ fn ensure_settings_json_returns_registered_event_names() {
         std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", &hooks_bin);
     }
 
-    let result = settings::ensure_settings_json(&staging_dir, 99999, &hooks_bin);
+    let settings_path = temp.path().join(".claude/settings.json");
+    let result = settings::ensure_settings_json(&settings_path, &staging_dir, 99999, &hooks_bin);
 
     if let Some(v) = prev_hooks {
         unsafe { std::env::set_var("AMPLIHACK_AMPLIHACK_HOOKS_BINARY_PATH", v) };
@@ -62,7 +63,8 @@ fn ensure_settings_json_succeeds_without_legacy_python_hook_files() {
     fs::create_dir_all(&staging_dir).unwrap();
     let hooks_bin = create_exe_stub(temp.path(), "amplihack-hooks");
 
-    let result = settings::ensure_settings_json(&staging_dir, 99999, &hooks_bin)
+    let settings_path = temp.path().join(".claude/settings.json");
+    let result = settings::ensure_settings_json(&settings_path, &staging_dir, 99999, &hooks_bin)
         .expect("settings setup should not depend on legacy python hook files");
 
     assert!(
@@ -88,7 +90,8 @@ fn ensure_settings_json_with_xpia_dir_keeps_unified_native_wrappers() {
     // No .py or .sh stub files — the Rust binary IS the XPIA implementation.
     let hooks_bin = create_exe_stub(temp.path(), "amplihack-hooks");
 
-    let result = settings::ensure_settings_json(&staging_dir, 99999, &hooks_bin)
+    let settings_path = temp.path().join(".claude/settings.json");
+    let result = settings::ensure_settings_json(&settings_path, &staging_dir, 99999, &hooks_bin)
         .expect("settings setup should succeed with xpia dir present (no script files needed)");
     assert!(result.0, "settings setup must succeed");
 
@@ -204,7 +207,8 @@ fn backup_metadata_is_always_valid_json() {
     let hooks_bin = create_exe_stub(temp.path(), "amplihack-hooks");
 
     let timestamp = 1_700_000_000_u64;
-    let _ = settings::ensure_settings_json(&staging_dir, timestamp, &hooks_bin);
+    let settings_path = temp.path().join(".claude/settings.json");
+    let _ = settings::ensure_settings_json(&settings_path, &staging_dir, timestamp, &hooks_bin);
 
     crate::test_support::restore_home(previous);
 
@@ -403,5 +407,76 @@ fn post_update_install_softens_known_transitional_xpia_asset_errors() {
             || settings_src.contains("self-heal")
             || settings_src.contains("self heal"),
         "post-update missing known XPIA shell assets should be reported as self-healing on next invocation rather than misleading ❌ hard errors"
+    );
+}
+
+// ─── Issue #1119: repo-local scope honors the caller-injected path ───────────
+
+#[test]
+fn ensure_settings_json_writes_to_repo_local_path_and_leaves_global_untouched() {
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    let repo = temp.path().join("project");
+    let repo_settings = repo.join(".claude").join("settings.json");
+    let staging_dir = temp.path().join(".amplihack/.claude");
+    fs::create_dir_all(&staging_dir).unwrap();
+    let hooks_bin = create_exe_stub(temp.path(), "amplihack-hooks");
+
+    let result = settings::ensure_settings_json(&repo_settings, &staging_dir, 99999, &hooks_bin)
+        .expect("repo-local settings write should succeed");
+
+    crate::test_support::restore_home(previous);
+
+    assert!(result.0, "repo-local settings setup must succeed");
+    assert!(
+        repo_settings.exists(),
+        "settings.json must be written under the repo-local .claude directory"
+    );
+    assert!(
+        !temp.path().join(".claude/settings.json").exists(),
+        "repo-local install must not create the global ~/.claude/settings.json"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_settings_json_repo_local_backup_is_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _guard = crate::test_support::home_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let previous = crate::test_support::set_home(temp.path());
+
+    let repo_claude = temp.path().join("project").join(".claude");
+    fs::create_dir_all(&repo_claude).unwrap();
+    let repo_settings = repo_claude.join("settings.json");
+    // Pre-existing settings force a backup to be created.
+    fs::write(&repo_settings, "{}").unwrap();
+
+    let staging_dir = temp.path().join(".amplihack/.claude");
+    fs::create_dir_all(&staging_dir).unwrap();
+    let hooks_bin = create_exe_stub(temp.path(), "amplihack-hooks");
+
+    let timestamp = 1_700_000_042_u64;
+    let _ = settings::ensure_settings_json(&repo_settings, &staging_dir, timestamp, &hooks_bin)
+        .expect("repo-local settings write should succeed");
+
+    crate::test_support::restore_home(previous);
+
+    let backup_path = repo_claude.join(format!("settings.json.backup.{timestamp}"));
+    assert!(
+        backup_path.exists(),
+        "a backup must be created when repo-local settings.json already exists"
+    );
+    let mode = fs::metadata(&backup_path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "repo-local backup must remain owner-read/write only (0o600), got {mode:o}"
     );
 }

--- a/crates/amplihack-cli/src/commands/install/types.rs
+++ b/crates/amplihack-cli/src/commands/install/types.rs
@@ -377,6 +377,9 @@ pub(super) struct InstallManifest {
     /// Update-check preference selected during interactive install (e.g. "auto-weekly", "disabled").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update_check_preference: Option<String>,
+    /// Hook configuration scope selected during interactive install ("global" or "repo-local").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hook_scope: Option<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Follow-up to #1088. `amplihack install` now honors the interactive **repo-local** hook scope instead of always writing to the global `~/.claude/settings.json`.

## Changes
- **`interactive.rs`**: Promote the previously `#[cfg(test)]`-gated scope machinery to production — `settings_path_for`, `resolve_hook_scope`, `dirs_home`, and the `Path`/`PathBuf` import. Add `HookScope::as_str` slug (`global` / `repo-local`) and record it in the manifest via `apply_config`.
- **`settings.rs`**: `ensure_settings_json` now takes a caller-injected `settings_path: &Path` (single seam) rather than hardcoding `global_settings_path()`. Backup / parent-creation / atomic-write / `0o600` semantics key off `settings_path.parent()`, unchanged.
- **`mod.rs`**: Main install resolves the effective `HookScope` from the wizard choice (git-fallback + warning preserved), writes settings.json to the matching location, and prints the effective scope/path. Auto-repair stays explicitly global.
- **`types.rs`**: New backward-compatible `hook_scope: Option<String>` manifest field.

## Testing
- New: repo-local write lands in `<repo>/.claude/settings.json` and leaves `~/.claude` untouched; repo-local backup is `0o600` (Unix); `settings_path_for(RepoLocal)`; `as_str` slugs; `apply_config` records `repo-local`.
- Updated existing `ensure_settings_json` tests to pass an explicit global path.
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, and 47 relevant lib tests green. (Two `issue_538_install_completeness` integration tests fail on a missing prebuilt binary — pre-existing on the base branch, unrelated to this change.)

Closes #1119