### PR TITLE
fix(#1084): remove unsafe env mutation from signal capacity tests

### DIFF
--- a/crates/amplihack-signal/src/signal_channel.rs
+++ b/crates/amplihack-signal/src/signal_channel.rs
@@ -87,19 +87,28 @@ impl SignalChannel {
     /// `AMPLIHACK_SIGNAL_INBOX_CAPACITY` is absent or invalid.
     pub const DEFAULT_CAPACITY: usize = 32;
 
-    /// The effective default bounded turn-queue capacity.
-    ///
-    /// Operator-configurable via `AMPLIHACK_SIGNAL_INBOX_CAPACITY`. Whitespace,
-    /// non-numeric, negative, or zero values fall back to [`Self::DEFAULT_CAPACITY`]
-    /// — never unbounded, never disabled. This is the sole surviving piece of
-    /// the deleted `session_channel` module's capacity policy, preserved verbatim.
+    /// Resolve the effective bounded turn-queue capacity from a raw operator
+    /// value (the parsed content of `AMPLIHACK_SIGNAL_INBOX_CAPACITY`). Pure and
+    /// env-free so it can be unit-tested without mutating process-global state:
+    /// whitespace, non-numeric, negative, or zero values fall back to
+    /// [`Self::DEFAULT_CAPACITY`] — never unbounded, never disabled.
     #[must_use]
-    pub fn default_capacity() -> usize {
-        std::env::var(CAPACITY_ENV)
-            .ok()
-            .and_then(|raw| raw.trim().parse::<usize>().ok())
+    fn resolve_capacity(raw: Option<&str>) -> usize {
+        raw.and_then(|r| r.trim().parse::<usize>().ok())
             .filter(|capacity| *capacity > 0)
             .unwrap_or(Self::DEFAULT_CAPACITY)
+    }
+
+    /// The effective default bounded turn-queue capacity.
+    ///
+    /// Operator-configurable via `AMPLIHACK_SIGNAL_INBOX_CAPACITY`; the parsing /
+    /// validation policy lives in [`Self::resolve_capacity`]. Whitespace,
+    /// non-numeric, negative, or zero values fall back to [`Self::DEFAULT_CAPACITY`]
+    /// — never unbounded, never disabled.
+    #[must_use]
+    pub fn default_capacity() -> usize {
+        let raw = std::env::var(CAPACITY_ENV).ok();
+        Self::resolve_capacity(raw.as_deref())
     }
 
     /// Bind an already-connected `transport` to a per-session operator-only
@@ -424,61 +433,22 @@ fn audit_accepted(session_label: &str, env: &Envelope, prompt: &str) {
 mod tests {
     use super::*;
 
-    /// Serializes the capacity tests: cargo runs tests as parallel threads in
-    /// one process and env vars are process-global, so without this lock the
-    /// `default_capacity_*` tests race on `CAPACITY_ENV` and flake.
-    static CAPACITY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn lock_capacity_env() -> std::sync::MutexGuard<'static, ()> {
-        CAPACITY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
-
-    struct EnvGuard {
-        key: &'static str,
-        prev: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let prev = std::env::var(key).ok();
-            // SAFETY: single-threaded within this test; restored on drop.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, prev }
-        }
-        fn unset(key: &'static str) -> Self {
-            let prev = std::env::var(key).ok();
-            // SAFETY: single-threaded within this test; restored on drop.
-            unsafe { std::env::remove_var(key) };
-            Self { key, prev }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.prev {
-                // SAFETY: restoring the pre-test value on the same thread.
-                Some(v) => unsafe { std::env::set_var(self.key, v) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
-
     #[test]
     fn default_capacity_honours_valid_operator_value() {
-        let _serial = lock_capacity_env();
-        let _guard = EnvGuard::set(CAPACITY_ENV, "7");
-        assert_eq!(SignalChannel::default_capacity(), 7);
+        assert_eq!(
+            SignalChannel::resolve_capacity(Some("7")),
+            7,
+            "a valid operator capacity must be honoured"
+        );
     }
 
     #[test]
     fn default_capacity_falls_back_on_invalid_values() {
-        let _serial = lock_capacity_env();
         for bad in ["0", "-1", "   ", "not-a-number", "3.5", ""] {
-            let _guard = EnvGuard::set(CAPACITY_ENV, bad);
             assert_eq!(
-                SignalChannel::default_capacity(),
+                SignalChannel::resolve_capacity(Some(bad)),
                 SignalChannel::DEFAULT_CAPACITY,
-                "invalid env value {bad:?} must fall back to DEFAULT_CAPACITY"
+                "invalid value {bad:?} must fall back to DEFAULT_CAPACITY"
             );
         }
         assert_eq!(SignalChannel::DEFAULT_CAPACITY, 32);
@@ -486,11 +456,10 @@ mod tests {
 
     #[test]
     fn default_capacity_falls_back_when_absent() {
-        let _serial = lock_capacity_env();
-        let _guard = EnvGuard::unset(CAPACITY_ENV);
         assert_eq!(
-            SignalChannel::default_capacity(),
-            SignalChannel::DEFAULT_CAPACITY
+            SignalChannel::resolve_capacity(None),
+            SignalChannel::DEFAULT_CAPACITY,
+            "an absent value must fall back to DEFAULT_CAPACITY"
         );
     }
 }

--- a/crates/amplihack-signal/tests/signal_channel_it.rs
+++ b/crates/amplihack-signal/tests/signal_channel_it.rs
@@ -2,9 +2,7 @@
 //!
 //! Written **first**: these FAIL to compile until PR-3 adds
 //! `crates/amplihack-signal/src/signal_channel.rs` with a `SignalChannel` that
-//! implements `amplihack_turn::Channel` and the relocated capacity policy
-//! (`SignalChannel::default_capacity` / `DEFAULT_CAPACITY`, the sole surviving
-//! piece of the deleted `session_channel` module). See
+//! implements `amplihack_turn::Channel`. See
 //! `docs/signal-channel-turn-loop.md`.
 //!
 //! Behaviour these lock (must be identical to today's hand-rolled
@@ -595,103 +593,5 @@ async fn id_is_the_group_id() {
         channel.id().to_string(),
         "grp-id==",
         "the channel id must be the resolved operator-only group id"
-    );
-}
-
-// =============================================================================
-// Relocated capacity policy (migrated INV-4 from the deleted session_channel)
-// =============================================================================
-
-/// Save/restore guard for the single process-global capacity env var so these
-/// tests never leak state to their neighbours.
-struct EnvGuard {
-    key: &'static str,
-    prev: Option<String>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let prev = std::env::var(key).ok();
-        // SAFETY: single-threaded within this test; restored on drop.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, prev }
-    }
-    fn unset(key: &'static str) -> Self {
-        let prev = std::env::var(key).ok();
-        // SAFETY: single-threaded within this test; restored on drop.
-        unsafe { std::env::remove_var(key) };
-        Self { key, prev }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.prev {
-            // SAFETY: restoring the pre-test value on the same thread.
-            Some(v) => unsafe { std::env::set_var(self.key, v) },
-            None => unsafe { std::env::remove_var(self.key) },
-        }
-    }
-}
-
-const CAPACITY_ENV: &str = "AMPLIHACK_SIGNAL_INBOX_CAPACITY";
-
-/// Serializes the capacity tests below. Cargo runs tests as parallel threads in
-/// a single process and env vars are process-global, so without this lock the
-/// three `default_capacity_*` tests race on `CAPACITY_ENV` and flake. Holding
-/// this guard for a test's whole body makes each env mutation observe-and-read
-/// atomically with respect to its siblings.
-static CAPACITY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Acquire the capacity-env serialization lock, tolerating poisoning from an
-/// unrelated panicking test (the guarded data is `()`, so a poisoned lock is
-/// still safe to use).
-fn lock_capacity_env() -> std::sync::MutexGuard<'static, ()> {
-    CAPACITY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-}
-
-// INV-4 (migrated): the bounded turn-queue capacity is operator-configurable via
-// AMPLIHACK_SIGNAL_INBOX_CAPACITY, resolved through the relocated
-// `SignalChannel::default_capacity()`. A valid value is honoured; invalid / zero
-// / negative / whitespace / non-numeric / absent values fall back to
-// `SignalChannel::DEFAULT_CAPACITY` (32) — never unbounded, never disabled. This
-// preserves the exact policy previously on `Inbox::default_capacity()`.
-#[test]
-fn default_capacity_honours_valid_operator_value() {
-    let _serial = lock_capacity_env();
-    let _guard = EnvGuard::set(CAPACITY_ENV, "3");
-    assert_eq!(
-        SignalChannel::default_capacity(),
-        3,
-        "a valid operator capacity must be honoured"
-    );
-}
-
-#[test]
-fn default_capacity_falls_back_on_invalid_values() {
-    let _serial = lock_capacity_env();
-    for bad in ["0", "-1", "   ", "not-a-number", "3.5", ""] {
-        let _guard = EnvGuard::set(CAPACITY_ENV, bad);
-        assert_eq!(
-            SignalChannel::default_capacity(),
-            SignalChannel::DEFAULT_CAPACITY,
-            "invalid env value {bad:?} must fall back to DEFAULT_CAPACITY, never unbounded/disabled"
-        );
-    }
-    assert_eq!(
-        SignalChannel::DEFAULT_CAPACITY,
-        32,
-        "the default fallback capacity must remain 32 (unchanged policy)"
-    );
-}
-
-#[test]
-fn default_capacity_falls_back_when_absent() {
-    let _serial = lock_capacity_env();
-    let _guard = EnvGuard::unset(CAPACITY_ENV);
-    assert_eq!(
-        SignalChannel::default_capacity(),
-        SignalChannel::DEFAULT_CAPACITY,
-        "an absent env value must fall back to DEFAULT_CAPACITY"
     );
 }


### PR DESCRIPTION
## Summary

Hardens the Signal channel bounded turn-queue capacity tests by removing all `unsafe` env mutation.

- Extracted the pure parse/validation policy into a private, env-free helper `SignalChannel::resolve_capacity(raw: Option<&str>) -> usize` (trim → `parse::<usize>` → filter `> 0` → fallback to `DEFAULT_CAPACITY`).
- `default_capacity()` is now a thin wrapper that reads `AMPLIHACK_SIGNAL_INBOX_CAPACITY` and delegates to `resolve_capacity`. Its observable behavior is byte-for-byte identical to before (same env var, trim, `usize` parse, `> 0` filter, fallback `32`). Public signature and `DEFAULT_CAPACITY`/`CAPACITY_ENV` are unchanged.
- The capacity tests now assert on **literal inputs** via `resolve_capacity` instead of mutating process-global env through `unsafe { set_var }`.
- Deleted the duplicated `EnvGuard` + `CAPACITY_ENV_LOCK`/`lock_capacity_env` mutex machinery from **both** the inline unit tests (`src/signal_channel.rs`) and the integration test file's "Relocated capacity policy" section (`tests/signal_channel_it.rs`), along with the now-stale module-doc reference.

No new dependencies (no `serial_test`). `resolve_capacity` stays private. Tests are fully parallel-safe — no `--test-threads=1`.

## Validation

- `cargo fmt --all --check` ✅
- `cargo clippy -p amplihack-signal --all-targets --features signal -- -D warnings` ✅
- `cargo test -p amplihack-signal --features signal` ✅ (lib unit tests + `signal_channel_it` green under parallel execution)

Closes #1084