### PR TITLE
test(gadugi): reconcile issue-820 merge-validations scenario with shipped contract (#1110)

### DIFF
--- a/tests/gadugi/run-merge-validations-scenario.sh
+++ b/tests/gadugi/run-merge-validations-scenario.sh
@@ -59,7 +59,7 @@ cc="$(confirmed_count "$out")"
   || fl "confirmed_count expected 1, got '$cc'"
 v="$(first_verdict "$out")"
 [ "$v" = "confirmed" ] && pass "finding verdict is confirmed" || fl "verdict expected confirmed, got '$v'"
-if grep -q "no parseable JSON object" "$WORK/err1.txt"; then
+if grep -q "output unparseable" "$WORK/err1.txt"; then
   pass "log-only validator triggers targeted diagnostic"
 else
   fl "log-only validator did not trigger a diagnostic"
@@ -79,18 +79,31 @@ cc2="$(confirmed_count "$out2")"
   || fl "confirmed_count expected 1 for finding 7, got '$cc2'"
 
 # ---------------------------------------------------------------------------
-# Case 3: every validator produced unparseable output — degrade, do not crash.
+# Case 3: every validator produced unparseable output. All-unparseable is a
+# FATAL condition (hardening #1110): rather than silently "merging" zero
+# verdicts, the step exits 1, writes no merged JSON, and preserves each
+# validator's raw output for triage. Assert that contract (not the old
+# graceful exit-0 / confirmed_count=0 behavior the scenario used to expect).
 # ---------------------------------------------------------------------------
 printf '%s\n' 'no json here, just a log line' > "$WORK/g1.txt"
 printf '%s\n' 'another { stray brace only'    > "$WORK/g2.txt"
 printf '%s\n' 'timed out'                      > "$WORK/g3.txt"
 out3="$("$RUN" "$WORK/g1.txt" "$WORK/g2.txt" "$WORK/g3.txt" 2 1 "$WORK/out3" 2>"$WORK/err3.txt")"
 rc3=$?
-[ "$rc3" = "0" ] && pass "all-garbage output degrades gracefully (exit 0)" || fl "all-garbage output exited $rc3"
+[ "$rc3" = "1" ] && pass "all-unparseable output is FATAL (exit 1)" || fl "all-unparseable output exited $rc3, expected 1"
 if grep -q "Bad JSON" "$WORK/err3.txt"; then fl "jq 'Bad JSON' leaked on all-garbage output"; else pass "no jq 'Bad JSON' on all-garbage output"; fi
-cc3="$(confirmed_count "$out3")"
-[ "$cc3" = "0" ] && pass "no confirmed findings from garbage (confirmed_count=0)" \
-  || fl "confirmed_count expected 0 for garbage, got '$cc3'"
+if grep -q "FATAL: all validators produced unparseable output" "$WORK/err3.txt"; then
+  pass "all-unparseable prints the FATAL diagnostic"
+else
+  fl "all-unparseable did not print the FATAL diagnostic"
+fi
+[ -z "$out3" ] && pass "all-unparseable writes no merged JSON to stdout" \
+  || fl "all-unparseable unexpectedly emitted JSON: '$out3'"
+if ls "$WORK/out3"/cycle_*/validator_*_raw.txt >/dev/null 2>&1; then
+  pass "all-unparseable preserves validator_*_raw.txt artifacts"
+else
+  fl "all-unparseable did not preserve validator_*_raw.txt artifacts"
+fi
 
 if [ "$fail" -eq 0 ]; then
   echo "ALL_CASES_PASSED"

--- a/tests/gadugi/test-merge-validations-scenario-contract.sh
+++ b/tests/gadugi/test-merge-validations-scenario-contract.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# TDD spec (Problem 3 / issue #1110): the issue-820 gadugi scenario driver is
+# STALE and must be updated to assert the SHIPPED merge-validations contract:
+#
+#   1. Diagnostic wording drift: shipped emits
+#        "validator <label> output unparseable; counting zero votes from it"
+#      (driver still greps the old "no parseable JSON object").
+#   2. All-unparseable is now FATAL, not graceful: shipped prints
+#        "FATAL: all validators produced unparseable output; cannot merge any verdicts"
+#      and exits 1 (writes no output JSON, preserving validator_*_raw.txt).
+#
+# Two layers:
+#   PART A — pins the shipped run-merge-validations.sh contract by RUNNING it
+#            (source of truth the driver must match). Guards against code regressions.
+#   PART B — asserts the driver SOURCE has been retconned to that contract, and
+#            that running the driver yields ALL_CASES_PASSED / exit 0.
+#
+# FAILING-FIRST: Part B fails against the current stale driver; passes once the
+# driver's Case-1 grep + Case-3 assertions are updated to the FATAL contract.
+# Run:  bash tests/gadugi/test-merge-validations-scenario-contract.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN="$SCRIPT_DIR/run-merge-validations.sh"
+DRIVER="$SCRIPT_DIR/run-merge-validations-scenario.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+pass() { echo "PASS: $1"; }
+fl()   { echo "FAIL: $1"; fail=1; }
+
+[ -f "$RUN" ]    || { fl "missing harness: $RUN"; echo "SCENARIO_FAILED"; exit 1; }
+[ -f "$DRIVER" ] || { fl "missing driver: $DRIVER"; echo "SCENARIO_FAILED"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# PART A — shipped contract (source of truth). These pin current behavior.
+# ---------------------------------------------------------------------------
+
+# A1: mixed output emits the "output unparseable" WARNING for the garbage validator.
+cat > "$WORK/m1.txt" <<'EOF'
+```json
+{"validated":[{"finding_id":1,"verdict":"confirmed","new_severity":"high"}]}
+```
+EOF
+printf '%s\n' '{"validated":[{"finding_id":1,"verdict":"confirmed","new_severity":"low"}]}' > "$WORK/m2.txt"
+printf '%s\n' 'ERROR: agent timed out, no structured output' > "$WORK/m3.txt"
+"$RUN" "$WORK/m1.txt" "$WORK/m2.txt" "$WORK/m3.txt" 2 1 "$WORK/mout" >/dev/null 2>"$WORK/merr.txt" || true
+if grep -q "output unparseable" "$WORK/merr.txt"; then
+  pass "shipped: mixed output emits 'output unparseable' WARNING"
+else
+  fl "shipped: expected 'output unparseable' WARNING not found (contract changed?)"
+fi
+
+# A2: all-unparseable is FATAL — exit 1, FATAL message, no output JSON,
+#     and preserved validator_*_raw.txt artifacts.
+printf '%s\n' 'no json here, just a log line' > "$WORK/g1.txt"
+printf '%s\n' 'another { stray brace only'    > "$WORK/g2.txt"
+printf '%s\n' 'timed out'                      > "$WORK/g3.txt"
+gout="$("$RUN" "$WORK/g1.txt" "$WORK/g2.txt" "$WORK/g3.txt" 2 1 "$WORK/gdir" 2>"$WORK/gerr.txt")"
+grc=$?
+[ "$grc" = "1" ] \
+  && pass "shipped: all-unparseable exits 1 (FATAL, not graceful)" \
+  || fl  "shipped: all-unparseable exited $grc, expected 1"
+if grep -q "FATAL: all validators produced unparseable output" "$WORK/gerr.txt"; then
+  pass "shipped: all-unparseable prints the FATAL diagnostic"
+else
+  fl "shipped: FATAL diagnostic not found for all-unparseable"
+fi
+[ -z "$gout" ] \
+  && pass "shipped: all-unparseable writes no merged JSON to stdout" \
+  || fl  "shipped: all-unparseable unexpectedly emitted JSON: '$gout'"
+if ls "$WORK/gdir"/cycle_*/validator_*_raw.txt >/dev/null 2>&1; then
+  pass "shipped: all-unparseable preserves validator_*_raw.txt artifacts"
+else
+  fl "shipped: validator_*_raw.txt artifacts not preserved"
+fi
+
+# ---------------------------------------------------------------------------
+# PART B — driver must be retconned to the shipped contract (FAILS on stale driver).
+# ---------------------------------------------------------------------------
+
+# B1: Case-1 greps the CURRENT wording, not the stale "no parseable JSON object".
+grep -q "output unparseable" "$DRIVER" \
+  && pass "driver greps current 'output unparseable' wording" \
+  || fl  "driver does not grep 'output unparseable' (stale Case-1 diagnostic)"
+grep -q "no parseable JSON object" "$DRIVER" \
+  && fl  "driver still greps stale 'no parseable JSON object' string" \
+  || pass "driver no longer greps stale 'no parseable JSON object'"
+
+# B2: Case-3 asserts the FATAL exit-1 contract, not graceful exit 0 / confirmed_count=0.
+grep -q "confirmed_count expected 0 for garbage" "$DRIVER" \
+  && fl  "driver still asserts graceful 'confirmed_count=0 for garbage' (stale Case-3)" \
+  || pass "driver dropped the stale graceful-degrade Case-3 assertion"
+grep -q "FATAL: all validators produced unparseable output" "$DRIVER" \
+  && pass "driver asserts the shipped FATAL message in Case-3" \
+  || fl  "driver does not assert the FATAL message for all-unparseable"
+grep -Eq "validator_.*_raw\.txt" "$DRIVER" \
+  && pass "driver asserts preserved validator_*_raw.txt artifacts in Case-3" \
+  || fl  "driver does not assert preserved validator_*_raw.txt artifacts"
+
+# B3 (the acceptance gate): running the driver passes cleanly.
+if bash "$DRIVER" >"$WORK/driver.out" 2>&1; then drc=0; else drc=$?; fi
+if grep -q "ALL_CASES_PASSED" "$WORK/driver.out" && [ "$drc" = "0" ]; then
+  pass "driver run: ALL_CASES_PASSED and exit 0"
+else
+  fl "driver run failed (exit $drc); see output below:"
+  sed 's/^/    driver| /' "$WORK/driver.out"
+fi
+
+if [ "$fail" -eq 0 ]; then echo "ALL_CASES_PASSED"; exit 0; fi
+echo "SCENARIO_FAILED"; exit 1


### PR DESCRIPTION
## Problem (Observed Problem #4 — issue #1110)

The gadugi scenario `issue-820-merge-validations` was stale and failed deterministically against the current merge-validation behavior:

```
FAIL: log-only validator did not trigger a diagnostic
FAIL: all-garbage output exited 1
FAIL: confirmed_count expected 0 for garbage, got ''
SCENARIO_FAILED
```

## Root cause — characterization drift (two)

The `run-merge-validations` step was hardened after the scenario was written; the scenario's assertions were not updated:

1. **Diagnostic wording.** The step now emits `validator <label> output unparseable; counting zero votes from it`, but Case 1 still grepped the old `no parseable JSON object`.
2. **All-unparseable is now FATAL** (intentional hardening — don't silently "merge" zero verdicts). The step prints `FATAL: all validators produced unparseable output; cannot merge any verdicts`, exits **1**, writes no merged JSON, and preserves `validator_*_raw.txt`. Case 3 still asserted graceful exit 0 / `confirmed_count=0`.

This is stale-test drift, not a shipped-code regression.

## Fix

- `run-merge-validations-scenario.sh`: Case 1 greps the current `output unparseable` wording; Case 3 asserts the FATAL exit-1 contract (FATAL message + no stdout JSON + preserved `validator_*_raw.txt`).
- Add `test-merge-validations-scenario-contract.sh`: a two-part guard that (A) pins the shipped `run-merge-validations.sh` behavior as the source of truth and (B) asserts the driver matches it and yields `ALL_CASES_PASSED` / exit 0 — preventing drift in either direction.

## Verification

```
$ bash tests/gadugi/run-merge-validations-scenario.sh        # ALL_CASES_PASSED, exit 0
$ bash tests/gadugi/test-merge-validations-scenario-contract.sh  # ALL_CASES_PASSED, exit 0
```

Characterization-test update only — no shipped-code change.

Closes #1110