### PR TITLE
fix(#1084): remove unsafe env mutation from signal capacity tests

### DIFF
--- a/crates/amplihack-signal/src/signal_channel.rs
+++ b/crates/amplihack-signal/src/signal_channel.rs
@@ -101,9 +101,10 @@ impl SignalChannel {
 
     /// The effective default bounded turn-queue capacity.
     ///
-    /// Operator-configurable via [`CAPACITY_ENV`]
-    /// (`AMPLIHACK_SIGNAL_INBOX_CAPACITY`); the parsing / validation policy lives
-    /// in [`Self::resolve_capacity`].
+    /// Operator-configurable via `AMPLIHACK_SIGNAL_INBOX_CAPACITY`; the parsing /
+    /// validation policy lives in [`Self::resolve_capacity`]. Whitespace,
+    /// non-numeric, negative, or zero values fall back to [`Self::DEFAULT_CAPACITY`]
+    /// — never unbounded, never disabled.
     #[must_use]
     pub fn default_capacity() -> usize {
         let raw = std::env::var(CAPACITY_ENV).ok();
@@ -434,7 +435,11 @@ mod tests {
 
     #[test]
     fn default_capacity_honours_valid_operator_value() {
-        assert_eq!(SignalChannel::resolve_capacity(Some("7")), 7);
+        assert_eq!(
+            SignalChannel::resolve_capacity(Some("7")),
+            7,
+            "a valid operator capacity must be honoured"
+        );
     }
 
     #[test]
@@ -453,7 +458,8 @@ mod tests {
     fn default_capacity_falls_back_when_absent() {
         assert_eq!(
             SignalChannel::resolve_capacity(None),
-            SignalChannel::DEFAULT_CAPACITY
+            SignalChannel::DEFAULT_CAPACITY,
+            "an absent value must fall back to DEFAULT_CAPACITY"
         );
     }
 }

--- a/crates/amplihack-signal/src/signal_channel.rs
+++ b/crates/amplihack-signal/src/signal_channel.rs
@@ -87,19 +87,27 @@ impl SignalChannel {
     /// `AMPLIHACK_SIGNAL_INBOX_CAPACITY` is absent or invalid.
     pub const DEFAULT_CAPACITY: usize = 32;
 
-    /// The effective default bounded turn-queue capacity.
-    ///
-    /// Operator-configurable via `AMPLIHACK_SIGNAL_INBOX_CAPACITY`. Whitespace,
-    /// non-numeric, negative, or zero values fall back to [`Self::DEFAULT_CAPACITY`]
-    /// — never unbounded, never disabled. This is the sole surviving piece of
-    /// the deleted `session_channel` module's capacity policy, preserved verbatim.
+    /// Resolve the effective bounded turn-queue capacity from a raw operator
+    /// value (the parsed content of `AMPLIHACK_SIGNAL_INBOX_CAPACITY`). Pure and
+    /// env-free so it can be unit-tested without mutating process-global state:
+    /// whitespace, non-numeric, negative, or zero values fall back to
+    /// [`Self::DEFAULT_CAPACITY`] — never unbounded, never disabled.
     #[must_use]
-    pub fn default_capacity() -> usize {
-        std::env::var(CAPACITY_ENV)
-            .ok()
-            .and_then(|raw| raw.trim().parse::<usize>().ok())
+    fn resolve_capacity(raw: Option<&str>) -> usize {
+        raw.and_then(|r| r.trim().parse::<usize>().ok())
             .filter(|capacity| *capacity > 0)
             .unwrap_or(Self::DEFAULT_CAPACITY)
+    }
+
+    /// The effective default bounded turn-queue capacity.
+    ///
+    /// Operator-configurable via [`CAPACITY_ENV`]
+    /// (`AMPLIHACK_SIGNAL_INBOX_CAPACITY`); the parsing / validation policy lives
+    /// in [`Self::resolve_capacity`].
+    #[must_use]
+    pub fn default_capacity() -> usize {
+        let raw = std::env::var(CAPACITY_ENV).ok();
+        Self::resolve_capacity(raw.as_deref())
     }
 
     /// Bind an already-connected `transport` to a per-session operator-only
@@ -424,61 +432,18 @@ fn audit_accepted(session_label: &str, env: &Envelope, prompt: &str) {
 mod tests {
     use super::*;
 
-    /// Serializes the capacity tests: cargo runs tests as parallel threads in
-    /// one process and env vars are process-global, so without this lock the
-    /// `default_capacity_*` tests race on `CAPACITY_ENV` and flake.
-    static CAPACITY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn lock_capacity_env() -> std::sync::MutexGuard<'static, ()> {
-        CAPACITY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
-
-    struct EnvGuard {
-        key: &'static str,
-        prev: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let prev = std::env::var(key).ok();
-            // SAFETY: single-threaded within this test; restored on drop.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, prev }
-        }
-        fn unset(key: &'static str) -> Self {
-            let prev = std::env::var(key).ok();
-            // SAFETY: single-threaded within this test; restored on drop.
-            unsafe { std::env::remove_var(key) };
-            Self { key, prev }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.prev {
-                // SAFETY: restoring the pre-test value on the same thread.
-                Some(v) => unsafe { std::env::set_var(self.key, v) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
-
     #[test]
     fn default_capacity_honours_valid_operator_value() {
-        let _serial = lock_capacity_env();
-        let _guard = EnvGuard::set(CAPACITY_ENV, "7");
-        assert_eq!(SignalChannel::default_capacity(), 7);
+        assert_eq!(SignalChannel::resolve_capacity(Some("7")), 7);
     }
 
     #[test]
     fn default_capacity_falls_back_on_invalid_values() {
-        let _serial = lock_capacity_env();
         for bad in ["0", "-1", "   ", "not-a-number", "3.5", ""] {
-            let _guard = EnvGuard::set(CAPACITY_ENV, bad);
             assert_eq!(
-                SignalChannel::default_capacity(),
+                SignalChannel::resolve_capacity(Some(bad)),
                 SignalChannel::DEFAULT_CAPACITY,
-                "invalid env value {bad:?} must fall back to DEFAULT_CAPACITY"
+                "invalid value {bad:?} must fall back to DEFAULT_CAPACITY"
             );
         }
         assert_eq!(SignalChannel::DEFAULT_CAPACITY, 32);
@@ -486,10 +451,8 @@ mod tests {
 
     #[test]
     fn default_capacity_falls_back_when_absent() {
-        let _serial = lock_capacity_env();
-        let _guard = EnvGuard::unset(CAPACITY_ENV);
         assert_eq!(
-            SignalChannel::default_capacity(),
+            SignalChannel::resolve_capacity(None),
             SignalChannel::DEFAULT_CAPACITY
         );
     }

--- a/crates/amplihack-signal/tests/signal_channel_it.rs
+++ b/crates/amplihack-signal/tests/signal_channel_it.rs
@@ -2,9 +2,7 @@
 //!
 //! Written **first**: these FAIL to compile until PR-3 adds
 //! `crates/amplihack-signal/src/signal_channel.rs` with a `SignalChannel` that
-//! implements `amplihack_turn::Channel` and the relocated capacity policy
-//! (`SignalChannel::default_capacity` / `DEFAULT_CAPACITY`, the sole surviving
-//! piece of the deleted `session_channel` module). See
+//! implements `amplihack_turn::Channel`. See
 //! `docs/signal-channel-turn-loop.md`.
 //!
 //! Behaviour these lock (must be identical to today's hand-rolled
@@ -595,103 +593,5 @@ async fn id_is_the_group_id() {
         channel.id().to_string(),
         "grp-id==",
         "the channel id must be the resolved operator-only group id"
-    );
-}
-
-// =============================================================================
-// Relocated capacity policy (migrated INV-4 from the deleted session_channel)
-// =============================================================================
-
-/// Save/restore guard for the single process-global capacity env var so these
-/// tests never leak state to their neighbours.
-struct EnvGuard {
-    key: &'static str,
-    prev: Option<String>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let prev = std::env::var(key).ok();
-        // SAFETY: single-threaded within this test; restored on drop.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, prev }
-    }
-    fn unset(key: &'static str) -> Self {
-        let prev = std::env::var(key).ok();
-        // SAFETY: single-threaded within this test; restored on drop.
-        unsafe { std::env::remove_var(key) };
-        Self { key, prev }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.prev {
-            // SAFETY: restoring the pre-test value on the same thread.
-            Some(v) => unsafe { std::env::set_var(self.key, v) },
-            None => unsafe { std::env::remove_var(self.key) },
-        }
-    }
-}
-
-const CAPACITY_ENV: &str = "AMPLIHACK_SIGNAL_INBOX_CAPACITY";
-
-/// Serializes the capacity tests below. Cargo runs tests as parallel threads in
-/// a single process and env vars are process-global, so without this lock the
-/// three `default_capacity_*` tests race on `CAPACITY_ENV` and flake. Holding
-/// this guard for a test's whole body makes each env mutation observe-and-read
-/// atomically with respect to its siblings.
-static CAPACITY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Acquire the capacity-env serialization lock, tolerating poisoning from an
-/// unrelated panicking test (the guarded data is `()`, so a poisoned lock is
-/// still safe to use).
-fn lock_capacity_env() -> std::sync::MutexGuard<'static, ()> {
-    CAPACITY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-}
-
-// INV-4 (migrated): the bounded turn-queue capacity is operator-configurable via
-// AMPLIHACK_SIGNAL_INBOX_CAPACITY, resolved through the relocated
-// `SignalChannel::default_capacity()`. A valid value is honoured; invalid / zero
-// / negative / whitespace / non-numeric / absent values fall back to
-// `SignalChannel::DEFAULT_CAPACITY` (32) — never unbounded, never disabled. This
-// preserves the exact policy previously on `Inbox::default_capacity()`.
-#[test]
-fn default_capacity_honours_valid_operator_value() {
-    let _serial = lock_capacity_env();
-    let _guard = EnvGuard::set(CAPACITY_ENV, "3");
-    assert_eq!(
-        SignalChannel::default_capacity(),
-        3,
-        "a valid operator capacity must be honoured"
-    );
-}
-
-#[test]
-fn default_capacity_falls_back_on_invalid_values() {
-    let _serial = lock_capacity_env();
-    for bad in ["0", "-1", "   ", "not-a-number", "3.5", ""] {
-        let _guard = EnvGuard::set(CAPACITY_ENV, bad);
-        assert_eq!(
-            SignalChannel::default_capacity(),
-            SignalChannel::DEFAULT_CAPACITY,
-            "invalid env value {bad:?} must fall back to DEFAULT_CAPACITY, never unbounded/disabled"
-        );
-    }
-    assert_eq!(
-        SignalChannel::DEFAULT_CAPACITY,
-        32,
-        "the default fallback capacity must remain 32 (unchanged policy)"
-    );
-}
-
-#[test]
-fn default_capacity_falls_back_when_absent() {
-    let _serial = lock_capacity_env();
-    let _guard = EnvGuard::unset(CAPACITY_ENV);
-    assert_eq!(
-        SignalChannel::default_capacity(),
-        SignalChannel::DEFAULT_CAPACITY,
-        "an absent env value must fall back to DEFAULT_CAPACITY"
     );
 }

--- a/docs/signal-channel-turn-loop.md
+++ b/docs/signal-channel-turn-loop.md
@@ -29,7 +29,7 @@ This feature is compiled only under the `signal` cargo feature (default
   - [`next_prompt` — LISTEN](#next_prompt--listen)
   - [`publish_output` — REPLAY](#publish_output--replay)
   - [The background Signal I/O actor](#the-background-signal-io-actor)
-  - [Queue capacity policy (`default_capacity`)](#queue-capacity-policy-default_capacity)
+  - [Queue capacity policy (`default_capacity` / `resolve_capacity`)](#queue-capacity-policy-default_capacity--resolve_capacity)
 - [`AgentSession` for the Copilot turn driver](#agentsession-for-the-copilot-turn-driver)
 - [`run_chat_async` wiring](#run_chat_async-wiring)
 - [Configuration](#configuration)
@@ -198,7 +198,7 @@ The background **Signal I/O actor** (single spawned task) exclusively owns:
 | Signal `transport` | signal-cli JSON-RPC client — the **only** holder of `&mut transport` (both `receive()` and outbound `send_group`). |
 | `Gate` | Fail-closed inbound decision + outbound echo record (`crates/amplihack-signal/src/gating.rs` — **untouched**). The **only** holder of `&mut gate`. |
 | expected-member allowlist | `chat::membership::expected_members(cfg)`, re-checked before every post. |
-| bounded turn queue (sender) | A `VecDeque<String>`/mpsc whose capacity comes from `--inbox-capacity` / [`default_capacity`](#queue-capacity-policy-default_capacity). Evict-oldest at capacity. |
+| bounded turn queue (sender) | A `VecDeque<String>`/mpsc whose capacity comes from `--inbox-capacity` / [`default_capacity`](#queue-capacity-policy-default_capacity--resolve_capacity). Evict-oldest at capacity. |
 
 ```rust
 impl amplihack_turn::Channel for SignalChannel {
@@ -330,35 +330,95 @@ both `transport` and `gate`, there is never a second holder of `&mut transport`
 or `&mut gate`; the echo-suppression window and the fail-closed membership
 checks stay coherent by construction.
 
-### Queue capacity policy (`default_capacity`)
+### Queue capacity policy (`default_capacity` / `resolve_capacity`)
 
-The only surviving piece of the deleted `session_channel` module is its
-bounded-queue capacity policy, relocated onto `SignalChannel`:
+The bounded-queue capacity policy lives on `SignalChannel` and is split into two
+pieces: a pure, env-free **parse/validation helper** (`resolve_capacity`) and a
+thin **env-reading wrapper** (`default_capacity`). The split keeps the exact same
+operator-facing behavior while making the policy unit-testable without touching
+process-global state:
 
 ```rust
+/// Env var carrying the operator-configured inbox capacity. Defined once as a
+/// module const so the wrapper and any diagnostics stay in sync.
+const CAPACITY_ENV: &str = "AMPLIHACK_SIGNAL_INBOX_CAPACITY";
+
 impl SignalChannel {
     /// Fallback capacity when AMPLIHACK_SIGNAL_INBOX_CAPACITY is absent/invalid.
     pub const DEFAULT_CAPACITY: usize = 32;
 
+    /// Resolve the effective bounded turn-queue capacity from a raw operator
+    /// value (the parsed content of `AMPLIHACK_SIGNAL_INBOX_CAPACITY`). Pure and
+    /// env-free so it can be unit-tested without mutating process-global state:
+    /// whitespace, non-numeric, negative, or zero values fall back to
+    /// `DEFAULT_CAPACITY` — never unbounded, never disabled.
+    #[must_use]
+    fn resolve_capacity(raw: Option<&str>) -> usize {
+        raw.and_then(|r| r.trim().parse::<usize>().ok())
+            .filter(|capacity| *capacity > 0)
+            .unwrap_or(Self::DEFAULT_CAPACITY)
+    }
+
     /// Capacity for a new channel's turn queue.
     ///
-    /// Operator-configurable via AMPLIHACK_SIGNAL_INBOX_CAPACITY. Whitespace-only,
-    /// non-numeric, or zero values fall back to DEFAULT_CAPACITY — never
-    /// unbounded, never disabled.
+    /// Operator-configurable via `CAPACITY_ENV`; the parsing / validation policy
+    /// lives in `resolve_capacity`.
     #[must_use]
     pub fn default_capacity() -> usize {
-        std::env::var("AMPLIHACK_SIGNAL_INBOX_CAPACITY")
-            .ok()
-            .and_then(|raw| raw.trim().parse::<usize>().ok())
-            .filter(|c| *c > 0)
-            .unwrap_or(Self::DEFAULT_CAPACITY)
+        let raw = std::env::var(CAPACITY_ENV).ok();
+        Self::resolve_capacity(raw.as_deref())
     }
 }
 ```
 
-This preserves the previous `Inbox::default_capacity()` semantics exactly (env
-override → trimmed → parsed → must be `> 0` → else `32`). `chat.rs` resolves the
-effective capacity as `args.inbox_capacity.unwrap_or_else(SignalChannel::default_capacity)`.
+`resolve_capacity` is **private** — it is an internal seam used only by
+`default_capacity` and the in-module unit tests. It does not widen the public
+API; the operator-facing surface remains `DEFAULT_CAPACITY`, `default_capacity()`,
+and the `AMPLIHACK_SIGNAL_INBOX_CAPACITY` env var / `--inbox-capacity` flag.
+
+`default_capacity()`'s observable behavior is byte-for-byte identical to the
+previous single-function form (env override → trimmed → parsed as `usize` → must
+be `> 0` → else `32`). `chat.rs` resolves the effective capacity as
+`args.inbox_capacity.unwrap_or_else(SignalChannel::default_capacity)`.
+
+#### Testing the policy without touching process env
+
+Because the policy is a pure function of its input, the capacity tests assert on
+**literal inputs** and never mutate the environment. There is no `unsafe`
+`std::env::set_var`/`remove_var`, no `EnvGuard`, and no shared mutex serializing
+capacity tests — so they run fully parallel with the rest of the suite and carry
+no data-race hazard under the Rust 2024 `unsafe`-env semantics. The single
+remaining environment read in the whole capacity path is the one inside
+`default_capacity()`.
+
+Coverage is expressed directly against `resolve_capacity`:
+
+```rust
+// Valid operator value is honoured verbatim.
+assert_eq!(SignalChannel::resolve_capacity(Some("7")), 7);
+
+// Malformed / out-of-range values fall back to DEFAULT_CAPACITY (32),
+// never unbounded and never disabled.
+assert_eq!(SignalChannel::DEFAULT_CAPACITY, 32);
+for bad in ["0", "-1", "   ", "not-a-number", "3.5", ""] {
+    assert_eq!(
+        SignalChannel::resolve_capacity(Some(bad)),
+        SignalChannel::DEFAULT_CAPACITY,
+    );
+}
+
+// Absent env (None) falls back to DEFAULT_CAPACITY.
+assert_eq!(
+    SignalChannel::resolve_capacity(None),
+    SignalChannel::DEFAULT_CAPACITY,
+);
+```
+
+These live in the inline `#[cfg(test)] mod tests` block of `signal_channel.rs`.
+The capacity policy is deliberately **not** duplicated in the
+`signal_channel_it` integration binary: env-mutating integration copies were
+removed in favor of this env-free unit coverage, so the policy is asserted in
+exactly one place.
 
 ---
 
@@ -495,8 +555,11 @@ PR-3 removes it entirely:
 - **Deleted**: `session_channel.rs`, its `pub mod session_channel;` declaration
   in `lib.rs`, and its in-crate unit tests.
 - **Relocated (only)**: the `default_capacity()` queue-size policy constant,
-  now [`SignalChannel::default_capacity`](#queue-capacity-policy-default_capacity).
-  It remains operator-configurable; no new fixed cap.
+  now [`SignalChannel::default_capacity`](#queue-capacity-policy-default_capacity--resolve_capacity).
+  It remains operator-configurable; no new fixed cap. The parse/validation
+  policy is factored into a private, env-free `resolve_capacity` helper so the
+  capacity tests assert on literal inputs instead of mutating process-global env
+  via `unsafe set_var` (no `EnvGuard`, no mutex, no duplicated integration copy).
 - **Dependency dropped**: `amplihack-state` (the `AtomicJsonFile` backing store)
   is no longer a dependency of `amplihack-signal` — it was used only by the
   file-backed inbox. `amplihack-types` stays (used elsewhere).


### PR DESCRIPTION
## Summary

Hardens the Signal bounded turn-queue capacity tests so they no longer mutate
process-global environment via `unsafe { std::env::set_var(...) }`.

- Extracted the pure parse/validation policy into a private, env-free helper
  `SignalChannel::resolve_capacity(raw: Option<&str>) -> usize`. `default_capacity()`
  is now a thin wrapper that reads `AMPLIHACK_SIGNAL_INBOX_CAPACITY` and delegates.
  Observable behavior is unchanged: same trim, same `usize` parse, same `> 0`
  filter, same fallback to `DEFAULT_CAPACITY` (32) — never unbounded, never disabled.
- Rewrote the three inline `default_capacity_*` unit tests to assert on literal
  inputs through `resolve_capacity(...)` — no env, no `unsafe`, no mutex, fully
  parallel-safe.
- Deleted the duplicated `EnvGuard`/`CAPACITY_ENV_LOCK`/`lock_capacity_env` machinery
  and the "Relocated capacity policy" tests from both the inline unit tests and the
  `tests/signal_channel_it.rs` integration file. No `serial_test` dependency added.

No change to `default_capacity()`'s public signature/behavior, the `DEFAULT_CAPACITY`
constant, the `CAPACITY_ENV` name, or `SignalChannel::new`. `resolve_capacity` stays
private.

Closes #1084

## Step 13: Local Testing Results

Detected toolchains:
- Rust / Cargo workspace (`Cargo.toml` at root; crate `amplihack-signal` with a
  feature-gated `signal` feature). Changed files: `crates/amplihack-signal/src/signal_channel.rs`,
  `crates/amplihack-signal/tests/signal_channel_it.rs`, `docs/signal-channel-turn-loop.md`.
  The capacity policy is consumed via `SignalChannel::default_capacity()` (public API)
  which delegates to the new private `resolve_capacity` helper.

Chosen validation strategy:
- Rust CLI repo → use `cargo test` as the outside-in harness (per qa-team repo-type
  detection). Scenario 1 exercises the pure policy through the unit boundary;
  Scenario 2 exercises the full integration binary (including the behavioral
  evict-oldest-at-capacity path) under default parallel execution. Also ran
  `cargo fmt --all --check` and `cargo clippy -p amplihack-signal --features signal
  --all-targets -- -D warnings`, and grep-verified zero `unsafe`/env-mutation remnants.

### Scenario 1 — pure capacity policy unit tests (no env mutation)
Command: `cargo test -p amplihack-signal --features signal --lib default_capacity`
Result: PASS
Output:
```
running 3 tests
test signal_channel::tests::default_capacity_falls_back_on_invalid_values ... ok
test signal_channel::tests::default_capacity_honours_valid_operator_value ... ok
test signal_channel::tests::default_capacity_falls_back_when_absent ... ok
test result: ok. 3 passed; 0 failed; 58 filtered out
```

### Scenario 2 — full integration binary incl. evict-oldest-at-capacity (parallel)
Command: `cargo test -p amplihack-signal --features signal --test signal_channel_it`
Result: PASS
Output:
```
running 14 tests
test queue_evicts_oldest_at_capacity ... ok
test result: ok. 14 passed; 0 failed; 0 ignored; 0 filtered out
```

Additional gates:
- `cargo fmt --all --check` → PASS
- `cargo clippy -p amplihack-signal --features signal --all-targets -- -D warnings` → PASS
- Hard-constraint grep for `unsafe|set_var|remove_var|EnvGuard|CAPACITY_ENV_LOCK|lock_capacity_env`
  across both files → NO MATCHES.

Note: the pre-existing test `transport_cancel_safe_it::fragmented_inbound_frame_survives_cancellation_and_interleaved_request`
is flaky (passes ~2/3 runs) and is unrelated to this change (transport frame
fragmentation/cancellation, not capacity). All capacity tests pass reliably.


---

## Step 16b: Outside-In Testing Results

Tested from the PR branch (`fix/issue-1084-resolve-github-issue-1084-harden-signal-inbox-capa`) as a consumer of the crate's public/test boundary.

**Detected toolchain:** Rust workspace (`Cargo.toml` at root; `crates/amplihack-signal` with `Cargo.toml`, workspace `Cargo.lock`). Package manager: `cargo`. The capacity tests are gated behind the `signal` feature (`#![cfg(feature = "signal")]`), so validation was run both without and with `--features signal`.

**Chosen strategy:** Native `cargo` outside-in validation (per qa-team Rust CLI guidance — substitute `cargo test` for the gadugi harness). Exercised the pure `resolve_capacity` policy via the crate's lib unit tests plus the full `signal_channel_it` integration binary, under default parallel execution (no `--test-threads=1`).

| # | Scenario | Command | Result | Key output |
|---|----------|---------|--------|------------|
| 1 | Format compliance | `cargo fmt --all --check` | ✅ PASS | no diffs |
| 2 | Lint gate (default) | `cargo clippy -p amplihack-signal --all-targets -- -D warnings` | ✅ PASS | `Finished` (0 warnings) |
| 3 | Lint gate (signal feature) | `cargo clippy -p amplihack-signal --all-targets --features signal -- -D warnings` | ✅ PASS | `Finished` (0 warnings) |
| 4 | Simple: valid + absent capacity policy | `cargo test -p amplihack-signal --features signal` | ✅ PASS | `default_capacity_honours_valid_operator_value ... ok`, `default_capacity_falls_back_when_absent ... ok` |
| 5 | Edge: invalid capacity inputs (`"0","-1","   ","not-a-number","3.5",""`) | `cargo test -p amplihack-signal --features signal` | ✅ PASS | `default_capacity_falls_back_on_invalid_values ... ok` |
| 6 | Integration: full Signal channel behavior binary | `cargo test -p amplihack-signal --features signal` (`signal_channel_it`) | ✅ PASS | `signal_channel_it ... 14 passed; 0 failed` |
| 7 | Whole-crate regression (parallel) | `cargo test -p amplihack-signal --features signal` | ✅ PASS | lib `61 passed; 0 failed`; all integration binaries green |

**Hard-constraint verification:**
`grep -rnE "unsafe|set_var|remove_var|EnvGuard|CAPACITY_ENV_LOCK|lock_capacity_env" crates/amplihack-signal/tests/signal_channel_it.rs crates/amplihack-signal/src/signal_channel.rs` → **NO MATCHES**. The only remaining environment access is the single `std::env::var(CAPACITY_ENV)` read inside `default_capacity()`. No `serial_test` dependency added; `resolve_capacity` remains private.

**Fix count:** 0 — all scenarios passed on the first iteration; no diagnose/fix/push cycles were required.
