### PR TITLE
fix(#1110): update stale gadugi merge-validations scenario to current FATAL-on-all-unparseable contract

### DIFF
--- a/tests/gadugi/run-merge-validations-scenario.sh
+++ b/tests/gadugi/run-merge-validations-scenario.sh
@@ -59,10 +59,10 @@ cc="$(confirmed_count "$out")"
   || fl "confirmed_count expected 1, got '$cc'"
 v="$(first_verdict "$out")"
 [ "$v" = "confirmed" ] && pass "finding verdict is confirmed" || fl "verdict expected confirmed, got '$v'"
-if grep -q "no parseable JSON object" "$WORK/err1.txt"; then
-  pass "log-only validator triggers targeted diagnostic"
+if grep -q "output unparseable; counting zero votes from it" "$WORK/err1.txt"; then
+  pass "log-only validator triggers targeted unparseable diagnostic"
 else
-  fl "log-only validator did not trigger a diagnostic"
+  fl "log-only validator did not trigger the unparseable diagnostic"
 fi
 
 # ---------------------------------------------------------------------------
@@ -79,18 +79,29 @@ cc2="$(confirmed_count "$out2")"
   || fl "confirmed_count expected 1 for finding 7, got '$cc2'"
 
 # ---------------------------------------------------------------------------
-# Case 3: every validator produced unparseable output — degrade, do not crash.
+# Case 3: every validator produced unparseable output — now FATAL (exit 1).
+# When nothing parses and >=1 validator is unparseable the step refuses to
+# "merge" zero verdicts: it prints a FATAL diagnostic, preserves the raw
+# outputs, writes no JSON to stdout, and exits 1.
 # ---------------------------------------------------------------------------
 printf '%s\n' 'no json here, just a log line' > "$WORK/g1.txt"
 printf '%s\n' 'another { stray brace only'    > "$WORK/g2.txt"
 printf '%s\n' 'timed out'                      > "$WORK/g3.txt"
 out3="$("$RUN" "$WORK/g1.txt" "$WORK/g2.txt" "$WORK/g3.txt" 2 1 "$WORK/out3" 2>"$WORK/err3.txt")"
 rc3=$?
-[ "$rc3" = "0" ] && pass "all-garbage output degrades gracefully (exit 0)" || fl "all-garbage output exited $rc3"
-if grep -q "Bad JSON" "$WORK/err3.txt"; then fl "jq 'Bad JSON' leaked on all-garbage output"; else pass "no jq 'Bad JSON' on all-garbage output"; fi
-cc3="$(confirmed_count "$out3")"
-[ "$cc3" = "0" ] && pass "no confirmed findings from garbage (confirmed_count=0)" \
-  || fl "confirmed_count expected 0 for garbage, got '$cc3'"
+[ "$rc3" = "1" ] && pass "all-unparseable output is FATAL (exit 1)" || fl "all-unparseable output exited $rc3, expected 1"
+if grep -q "FATAL: all validators produced unparseable output; cannot merge any verdicts" "$WORK/err3.txt"; then
+  pass "all-unparseable output triggers FATAL diagnostic"
+else
+  fl "all-unparseable output did not trigger the FATAL diagnostic"
+fi
+if grep -q "Bad JSON" "$WORK/err3.txt"; then fl "jq 'Bad JSON' leaked on all-unparseable output"; else pass "no jq 'Bad JSON' on all-unparseable output"; fi
+[ -z "$out3" ] && pass "FATAL path writes no JSON to stdout" || fl "expected empty stdout on FATAL, got '$out3'"
+if [ -f "$WORK/out3/cycle_1/validator_v1_raw.txt" ]; then
+  pass "unparseable validator raw output preserved"
+else
+  fl "expected preserved raw artifact validator_v1_raw.txt under out3/cycle_1"
+fi
 
 if [ "$fail" -eq 0 ]; then
   echo "ALL_CASES_PASSED"


### PR DESCRIPTION
## Summary

Resolves #1110. The gadugi characterization scenario `issue-820-merge-validations` was STALE and failed against current shipped behavior. This is a **test-drift fix**: only the gadugi scenario **driver** (`tests/gadugi/run-merge-validations-scenario.sh`) is updated to re-characterize current shipped behavior. **No production/shipped code changed** — `run-merge-validations.sh` (harness) and `amplifier-bundle/recipes/quality-audit-cycle.yaml` (shipped logic) are untouched.

## The two drifts

1. **Diagnostic wording.** The per-unparseable-validator warning is now:
   > `[merge-validations] WARNING: validator <label> output unparseable; counting zero votes from it. Raw output preserved at: <path>`

   Case 1's grep still matched the OLD string `no parseable JSON object`, which no longer exists. Updated to grep the current substring `output unparseable; counting zero votes from it`.

2. **All-unparseable is now FATAL.** When every validator is unparseable (`parsed_count == 0` and `unparseable_count >= 1`) the step now prints:
   > `[merge-validations] FATAL: all validators produced unparseable output; cannot merge any verdicts. Raw outputs preserved at: <paths>`

   to stderr and exits `1`, writing **no JSON** to stdout. The driver's Case 3 still expected the old graceful-degrade contract (exit 0 + `confirmed_count 0`). Case 3 is rewritten to assert:
   - `rc3 == 1` (FATAL)
   - stderr contains the FATAL message
   - no `Bad JSON` leak
   - empty stdout (FATAL path writes no JSON)
   - preserved raw artifact exists at `out3/cycle_1/validator_v1_raw.txt`
   - the obsolete `confirmed_count == 0` assertion is removed

Case 1's `exit 0` / `confirmed_count 1` / `verdict confirmed` / `no jq 'Bad JSON' on mixed output` assertions are unchanged. Case 2 is untouched. The scenario still exits 0 and prints `ALL_CASES_PASSED`.

## Validation

- `bash tests/gadugi/run-merge-validations-scenario.sh` → prints `ALL_CASES_PASSED`, `rc=0`.
- `bash -n tests/gadugi/run-merge-validations-scenario.sh` → syntax OK.
- `shellcheck` → no new warnings introduced (only pre-existing SC2015 info notes remain, consistent with the file's existing style; the new `out3` is used by an emptiness assertion so no SC2034).
- `gadugi-test run -s issue-820-merge-validations-mixed-output -d tests/gadugi/scenarios` → **1 passed / 0 failed**.
- No `--no-verify`; all pre-commit hooks passed.

Closes #1110