### PR TITLE
fix(#1110): update stale gadugi merge-validations scenario to current FATAL-on-all-unparseable contract

### DIFF
--- a/docs/bugfixes/bugfix-1110-gadugi-merge-validations-scenario-fatal-recharacterization.md
+++ b/docs/bugfixes/bugfix-1110-gadugi-merge-validations-scenario-fatal-recharacterization.md
@@ -1,0 +1,128 @@
+# Bug Fix #1110 — realign the stale gadugi `merge-validations` characterization scenario
+
+> **Issue:** [#1110](https://github.com/rysweet/amplihack-rs/issues/1110)
+
+---
+
+## Summary
+
+The gadugi characterization scenario `issue-820-merge-validations-mixed-output`
+had drifted away from the shipped `merge-validations` behavior and was failing
+against the current contract. This fix **re-characterizes the scenario driver**
+so it once again asserts the behavior the recipe actually ships today.
+
+This is a **test-drift fix only**. No shipped/production code changed. The single
+edited file is the self-asserting scenario driver
+`tests/gadugi/run-merge-validations-scenario.sh`. The shipped logic
+(`amplifier-bundle/recipes/quality-audit-cycle.yaml`), the byte-exact harness
+(`tests/gadugi/run-merge-validations.sh`), and the scenario YAML
+(`tests/gadugi/scenarios/issue-820-merge-validations-mixed-output.yaml`) are
+unchanged.
+
+## The two drifts
+
+The driver asserted two behaviors that the shipped `merge-validations` step no
+longer exhibits:
+
+| # | Drift | Old (stale) driver expectation | Current shipped behavior |
+| --- | --- | --- | --- |
+| 1 | Per-unparseable-validator diagnostic wording | grep for an earlier diagnostic substring no longer emitted by the step | grep for `output unparseable; counting zero votes from it` |
+| 2 | All validators unparseable | exit `0`, `confirmed_count == 0` (graceful degrade) | **FATAL**: exit `1`, no JSON on stdout, `FATAL: all validators produced unparseable output; cannot merge any verdicts` on stderr |
+
+### Drift 1 — diagnostic wording
+
+When a validator's output cannot be parsed, the step emits a single-line
+`WARNING` to stderr:
+
+```text
+[merge-validations] WARNING: validator <label> output unparseable; counting zero votes from it. Raw output preserved at: <path>
+```
+
+The old driver grepped for an earlier diagnostic substring that the shipped
+`merge-validations` step no longer emits. (The exact retired wording is not
+recoverable from the current recipe body — the pre-drift diagnostic message has
+been fully replaced, so only the historical fact of the change is documented
+here, not the literal old string.) The driver now greps the current, shipped
+substring `output unparseable; counting zero votes from it`, which is emitted
+verbatim by the recipe.
+
+### Drift 2 — all-unparseable is now FATAL
+
+When **every** validator is unparseable (`parsed_count == 0` and
+`unparseable_count >= 1`), the step now **fails closed** rather than silently
+"merging" zero verdicts. It:
+
+- prints `[merge-validations] FATAL: all validators produced unparseable output;
+  cannot merge any verdicts. Raw outputs preserved at: <paths>` to stderr,
+- preserves each validator's raw output as a per-cycle artifact,
+- writes **no** JSON to stdout, and
+- exits `1`.
+
+This fail-closed gate is the intended hardening documented in
+[bugfix #899](./bugfix-899-merge-validations-unparseable-abstention.md); the
+scenario is now locked onto it.
+
+## Scenario contract (after this fix)
+
+The driver runs three cases against the real recipe body via
+`tests/gadugi/run-merge-validations.sh` and prints `ALL_CASES_PASSED` (exit `0`)
+when all hold.
+
+### Case 1 — mixed output (fenced + bare + log-only)
+
+`v1` wraps its verdict in a ```` ```json ```` fence, `v2` is bare JSON, and `v3`
+is log-only garbage. Two validators parse, so the merge proceeds.
+
+- exit `0`;
+- no `jq` `Bad JSON` leak on stderr (PASS line `no jq 'Bad JSON' on mixed output`
+  — asserted verbatim by the scenario YAML);
+- `confirmed_count == 1`, first verdict `confirmed`;
+- the log-only validator triggers the current unparseable diagnostic
+  (`output unparseable; counting zero votes from it`).
+
+### Case 2 — all bare JSON
+
+All three validators emit bare JSON objects. Unchanged: exit `0`,
+`confirmed_count == 1` for finding 7.
+
+### Case 3 — all validators unparseable (now FATAL)
+
+Three garbage inputs (`g1`/`g2`/`g3`), passed with `OUTPUT_DIR = out3` and
+`cycle = 1`:
+
+- exit `1` (FATAL);
+- stderr contains `FATAL: all validators produced unparseable output; cannot
+  merge any verdicts`;
+- no `jq` `Bad JSON` leak;
+- the raw output artifact is preserved at
+  `out3/cycle_1/validator_v1_raw.txt`.
+
+The obsolete `confirmed_count == 0` assertion is removed — the FATAL path writes
+no JSON to stdout, so a vote-count check is meaningless.
+
+## Validation
+
+```bash
+# Authoritative check: the driver self-asserts all three cases.
+bash tests/gadugi/run-merge-validations-scenario.sh; echo "rc=$?"
+# → prints ALL_CASES_PASSED and rc=0
+
+# Syntax check.
+bash -n tests/gadugi/run-merge-validations-scenario.sh
+
+# Optional, if the gadugi-test runner is installed.
+gadugi-test run -s issue-820-merge-validations-mixed-output
+# → 0 failures
+```
+
+If the `gadugi-test` runner is not installed, the direct `bash` run is the
+authoritative check.
+
+## Scope
+
+Test re-characterization only. The scenario driver was updated to describe the
+current shipped `merge-validations` contract; the voting math, verdict
+extraction, validator classification, the `jq` merge, diagnostics, and the
+fail-closed gate are all unchanged shipped behavior. The scenario YAML's
+`assertions` (`ALL_CASES_PASSED`, exit `0`, `no jq 'Bad JSON' on mixed output`)
+remain valid and were not modified.

--- a/tests/gadugi/run-merge-validations-scenario.sh
+++ b/tests/gadugi/run-merge-validations-scenario.sh
@@ -59,10 +59,10 @@ cc="$(confirmed_count "$out")"
   || fl "confirmed_count expected 1, got '$cc'"
 v="$(first_verdict "$out")"
 [ "$v" = "confirmed" ] && pass "finding verdict is confirmed" || fl "verdict expected confirmed, got '$v'"
-if grep -q "no parseable JSON object" "$WORK/err1.txt"; then
-  pass "log-only validator triggers targeted diagnostic"
+if grep -q "output unparseable; counting zero votes from it" "$WORK/err1.txt"; then
+  pass "log-only validator triggers targeted unparseable diagnostic"
 else
-  fl "log-only validator did not trigger a diagnostic"
+  fl "log-only validator did not trigger the unparseable diagnostic"
 fi
 
 # ---------------------------------------------------------------------------
@@ -79,18 +79,28 @@ cc2="$(confirmed_count "$out2")"
   || fl "confirmed_count expected 1 for finding 7, got '$cc2'"
 
 # ---------------------------------------------------------------------------
-# Case 3: every validator produced unparseable output — degrade, do not crash.
+# Case 3: every validator produced unparseable output — now FATAL (exit 1).
+# When no validator parses and at least one is unparseable, the step refuses to
+# "merge" zero verdicts: it prints a FATAL diagnostic, preserves the raw outputs,
+# writes NO JSON to stdout, and exits 1.
 # ---------------------------------------------------------------------------
 printf '%s\n' 'no json here, just a log line' > "$WORK/g1.txt"
 printf '%s\n' 'another { stray brace only'    > "$WORK/g2.txt"
 printf '%s\n' 'timed out'                      > "$WORK/g3.txt"
-out3="$("$RUN" "$WORK/g1.txt" "$WORK/g2.txt" "$WORK/g3.txt" 2 1 "$WORK/out3" 2>"$WORK/err3.txt")"
+"$RUN" "$WORK/g1.txt" "$WORK/g2.txt" "$WORK/g3.txt" 2 1 "$WORK/out3" >/dev/null 2>"$WORK/err3.txt"
 rc3=$?
-[ "$rc3" = "0" ] && pass "all-garbage output degrades gracefully (exit 0)" || fl "all-garbage output exited $rc3"
-if grep -q "Bad JSON" "$WORK/err3.txt"; then fl "jq 'Bad JSON' leaked on all-garbage output"; else pass "no jq 'Bad JSON' on all-garbage output"; fi
-cc3="$(confirmed_count "$out3")"
-[ "$cc3" = "0" ] && pass "no confirmed findings from garbage (confirmed_count=0)" \
-  || fl "confirmed_count expected 0 for garbage, got '$cc3'"
+[ "$rc3" = "1" ] && pass "all-unparseable output is FATAL (exit 1)" || fl "all-unparseable output exited $rc3, expected 1"
+if grep -q "FATAL: all validators produced unparseable output; cannot merge any verdicts" "$WORK/err3.txt"; then
+  pass "all-unparseable output triggers FATAL diagnostic"
+else
+  fl "all-unparseable output did not print the FATAL diagnostic"
+fi
+if grep -q "Bad JSON" "$WORK/err3.txt"; then fl "jq 'Bad JSON' leaked on all-unparseable output"; else pass "no jq 'Bad JSON' on all-unparseable output"; fi
+if [ -f "$WORK/out3/cycle_1/validator_v1_raw.txt" ]; then
+  pass "unparseable validator raw output preserved"
+else
+  fl "expected preserved raw artifact validator_v1_raw.txt under out3/cycle_1"
+fi
 
 if [ "$fail" -eq 0 ]; then
   echo "ALL_CASES_PASSED"


### PR DESCRIPTION
## Summary

GitHub issue #1110: the gadugi characterization scenario
`issue-820-merge-validations` was **STALE** and failed against current shipped
behavior. This is a **test-drift fix** — only the gadugi scenario **driver**
(`tests/gadugi/run-merge-validations-scenario.sh`) was updated to
re-characterize current shipped behavior. **No production/shipped code changed.**

## The two drifts

The shipped `merge-validations` step in
`amplifier-bundle/recipes/quality-audit-cycle.yaml` (exercised via
`tests/gadugi/run-merge-validations.sh`) had moved on from the driver:

1. **Diagnostic wording.** The per-unparseable-validator warning is now:
   `output unparseable; counting zero votes from it`
   (full: `[merge-validations] WARNING: validator <label> output unparseable;
   counting zero votes from it. Raw output preserved at: <path>`). The driver
   still grepped the old string `no parseable JSON object`, which no longer
   exists.

2. **All-unparseable is now FATAL.** When every validator is unparseable
   (`parsed_count == 0` and `unparseable_count >= 1`) the step now prints
   `[merge-validations] FATAL: all validators produced unparseable output;
   cannot merge any verdicts. Raw outputs preserved at: <paths>` to stderr and
   exits **1**, writing **no** JSON to stdout. The driver's "all garbage" case
   still expected the old graceful-degrade contract (exit 0, `confirmed_count 0`).
   This FATAL hardening is the intended behavior (do not silently "merge" zero
   verdicts), so the scenario is locked onto it.

## Changes (driver only)

- **Case 1 (mixed):** replaced the stale grep `no parseable JSON object` →
  `output unparseable; counting zero votes from it`. All other Case 1
  assertions unchanged; the `no jq 'Bad JSON' on mixed output` PASS line
  (asserted by the scenario YAML) is preserved verbatim.
- **Case 3 (all unparseable):** rewritten from graceful-degrade to the FATAL
  contract — asserts `rc == 1`, the FATAL stderr message, no `Bad JSON` leak,
  and preserved raw artifact `out3/cycle_1/validator_v1_raw.txt`. Removed the
  now-meaningless `confirmed_count == 0` assertion (FATAL path writes no JSON).
  Comment header updated to state all-unparseable is now FATAL (exit 1).
- **Case 2:** untouched.

Not modified: the harness (`run-merge-validations.sh`), the shipped recipe
(`quality-audit-cycle.yaml`), or the scenario YAML assertions.

## Validation

Direct driver run (authoritative):
```
$ bash tests/gadugi/run-merge-validations-scenario.sh; echo "rc=$?"
PASS: mixed output does not crash (exit 0)
PASS: no jq 'Bad JSON' on mixed output
PASS: two well-formed validators confirm the finding (confirmed_count=1)
PASS: finding verdict is confirmed
PASS: log-only validator triggers targeted unparseable diagnostic
PASS: bare-JSON output does not crash (exit 0)
PASS: majority confirms finding 7 (confirmed_count=1)
PASS: all-unparseable output is FATAL (exit 1)
PASS: all-unparseable output triggers FATAL diagnostic
PASS: no jq 'Bad JSON' on all-unparseable output
PASS: unparseable validator raw output preserved
ALL_CASES_PASSED
rc=0
```

- `bash -n tests/gadugi/run-merge-validations-scenario.sh` → OK
- `shellcheck` → no new warnings introduced (removed the one SC2034 I would
  have added; remaining SC2015 infos are pre-existing style on untouched lines)
- `gadugi-test run -d tests/gadugi/scenarios -s issue-820-merge-validations-mixed-output`
  → **Passed: 1, Failed: 0**

Closes #1110
