### PR TITLE
fix(#1123): collapse settings.json check-then-read into a single atomic read (TOCTOU S2)

### DIFF
--- a/crates/amplihack-cli/src/commands/doctor/checks.rs
+++ b/crates/amplihack-cli/src/commands/doctor/checks.rs
@@ -65,12 +65,9 @@ pub fn check_hooks_installed() -> (bool, String) {
 /// read/parse error whose message is truncated and never includes file
 /// contents.
 fn settings_has_amplihack_hooks(path: &std::path::Path) -> Option<Result<bool, String>> {
-    if !path.exists() {
-        return None;
-    }
-
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
         Err(e) => {
             let msg = e.to_string();
             return Some(Err(format!(
@@ -104,12 +101,11 @@ pub fn check_settings_valid_json() -> (bool, String) {
         Some(p) => p,
     };
 
-    if !path.exists() {
-        return (false, "settings.json: file not found".to_string());
-    }
-
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return (false, "settings.json: file not found".to_string());
+        }
         Err(e) => {
             let msg = e.to_string();
             return (
@@ -222,4 +218,32 @@ fn sanitized_single_line(bytes: &[u8]) -> String {
 pub fn check_amplihack_version() -> (bool, String) {
     let version = crate::VERSION;
     (true, format!("amplihack v{version}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::settings_has_amplihack_hooks;
+
+    /// #1123: after collapsing the `exists()` probe into the read, an absent
+    /// path must still map to `None` (nothing to report for this location).
+    #[test]
+    fn settings_has_amplihack_hooks_absent_path_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist/settings.json");
+        assert!(settings_has_amplihack_hooks(&missing).is_none());
+    }
+
+    /// #1123: a present-but-unreadable path (a directory at the file path) must
+    /// map to `Some(Err(_))`, preserving the absent-vs-error distinction.
+    #[test]
+    fn settings_has_amplihack_hooks_unreadable_present_is_some_err() {
+        let dir = tempfile::tempdir().unwrap();
+        // The path exists but is a directory, so read_to_string fails with a
+        // non-NotFound error.
+        let result = settings_has_amplihack_hooks(dir.path());
+        assert!(
+            matches!(result, Some(Err(_))),
+            "present-but-unreadable path must yield Some(Err(_)), got {result:?}"
+        );
+    }
 }

--- a/crates/amplihack-hooks/src/session_start/migration.rs
+++ b/crates/amplihack-hooks/src/session_start/migration.rs
@@ -8,9 +8,6 @@ use std::path::PathBuf;
 
 pub(super) fn migrate_global_hooks(dirs: &ProjectDirs) -> Option<String> {
     let global_settings = ProjectDirs::global_settings()?;
-    if !global_settings.exists() {
-        return None;
-    }
 
     let settings_file = AtomicJsonFile::new(&global_settings);
     let settings: Value = match settings_file.read() {
@@ -68,9 +65,6 @@ pub(super) fn migrate_global_hooks(dirs: &ProjectDirs) -> Option<String> {
 /// whether the global hooks are redundant; it never writes.
 fn repo_local_contains_amplihack_hooks(dirs: &ProjectDirs) -> bool {
     let repo_local = dirs.claude.join("settings.json");
-    if !repo_local.exists() {
-        return false;
-    }
     match AtomicJsonFile::new(&repo_local).read() {
         Ok(Some(value)) => contains_amplihack_hooks(&value),
         Ok(None) => false,
@@ -401,6 +395,34 @@ mod tests {
             updated["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
             Some("/usr/local/bin/third-party-hook"),
             "third-party global entries must be preserved"
+        );
+    }
+
+    /// Absent-global guard (#1123): with no global `~/.claude/settings.json`,
+    /// the collapsed atomic read must yield `None` (nothing to migrate).
+    #[test]
+    fn migrate_global_hooks_returns_none_when_global_absent() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let home = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        // No global settings.json is written under HOME.
+        let dirs = ProjectDirs::new(repo.path());
+        let result = migrate_global_hooks(&dirs);
+
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert!(
+            result.is_none(),
+            "must return None when global settings file is absent"
         );
     }
 }


### PR DESCRIPTION
## Summary

Resolves #1123 (S2). Removes the check-then-read TOCTOU pattern on
`settings.json` reads by collapsing each `exists()` probe + subsequent read into
a single atomic read that treats a missing file as the existing "not present"
outcome. This is **behavior-preserving hardening** — no observable change except
that presence and read now happen in one operation, so a file removed/swapped
between the two steps can no longer produce an inconsistent result.

## The four collapsed sites

1. **`crates/amplihack-hooks/src/session_start/migration.rs` — `migrate_global_hooks`**
   Deleted the redundant `if !global_settings.exists() { return None; }` block.
   `AtomicJsonFile::read()` already returns `Ok(None)` for a missing file, which
   the existing `Ok(None) => return None` arm handles identically.

2. **`migration.rs` — `repo_local_contains_amplihack_hooks`**
   Deleted the redundant `if !repo_local.exists() { return false; }` block. The
   existing `Ok(None) => false` arm already covers a missing file.

3. **`crates/amplihack-cli/src/commands/doctor/checks.rs` — `settings_has_amplihack_hooks`**
   Removed the `exists()` probe; `read_to_string` `NotFound` now maps to the same
   absent outcome (`None`). All other read errors keep the exact same
   `Some(Err("hooks: cannot read settings.json: ..."))` message.

4. **`checks.rs` — `check_settings_valid_json`**
   Removed the `exists()` probe; `NotFound` maps to the same
   `(false, "settings.json: file not found")` outcome. All other read errors keep
   the same `(false, "settings.json: cannot read: ...")` message.

## Behavior preservation

Every existing outcome is byte-for-byte identical: absent → same result, valid →
same, corrupt/unreadable → same message. Only the atomicity of presence+read
changes. No function signature, message string, or return type was altered, and
the `Err(e)` warn arms / JSON-parse arms are untouched.

## S3 (symlink following) — deliberate no-op, not a deferral

No `symlink_metadata` / `O_NOFOLLOW` / symlink-refusal was added to these reads.
Rationale: the targets stay within the user's own trust domain (`$HOME` / the
repo), only presence/validity is ever reported (file contents are never
surfaced), and refusing symlinked config would break legitimate
dotfile-management setups where `~/.claude/settings.json` is a symlink. There is
no security benefit to refusing symlinks here, so S3 is intentionally left as-is.

## Tests

- `checks.rs`: `settings_has_amplihack_hooks` returns `None` for a nonexistent
  path and `Some(Err(_))` for an unreadable-but-present path (a directory at the
  path) — asserting the collapse did not change the absent-vs-error distinction.
- `migration.rs`: `migrate_global_hooks` returns `None` when the global settings
  file is absent.
- #1088 regression tests remain green
  (`test_check_hooks_installed_corrupt_global_does_not_mask_repo_local`).

## Validation

- `cargo fmt --all --check` ✅
- `cargo clippy -p amplihack-cli -p amplihack-hooks --all-targets -- -D warnings` ✅
- `cargo test -p amplihack-cli -p amplihack-hooks` ✅ (new + #1088 regression tests pass)

Closes #1123
