### PR TITLE
fix(#1123): collapse settings.json check-then-read into a single atomic read (TOCTOU S2)

### DIFF
--- a/crates/amplihack-cli/src/commands/doctor/checks.rs
+++ b/crates/amplihack-cli/src/commands/doctor/checks.rs
@@ -65,12 +65,9 @@ pub fn check_hooks_installed() -> (bool, String) {
 /// read/parse error whose message is truncated and never includes file
 /// contents.
 fn settings_has_amplihack_hooks(path: &std::path::Path) -> Option<Result<bool, String>> {
-    if !path.exists() {
-        return None;
-    }
-
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
         Err(e) => {
             let msg = e.to_string();
             return Some(Err(format!(
@@ -104,12 +101,11 @@ pub fn check_settings_valid_json() -> (bool, String) {
         Some(p) => p,
     };
 
-    if !path.exists() {
-        return (false, "settings.json: file not found".to_string());
-    }
-
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return (false, "settings.json: file not found".to_string());
+        }
         Err(e) => {
             let msg = e.to_string();
             return (
@@ -222,4 +218,34 @@ fn sanitized_single_line(bytes: &[u8]) -> String {
 pub fn check_amplihack_version() -> (bool, String) {
     let version = crate::VERSION;
     (true, format!("amplihack v{version}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// TOCTOU S2 (issue #1123): collapsing the `exists()` probe + read into a
+    /// single read must preserve the absent-vs-error distinction —
+    /// `NotFound` maps to absent (`None`), while a present-but-unreadable path
+    /// still yields `Some(Err(_))`.
+    #[test]
+    fn settings_has_amplihack_hooks_distinguishes_absent_from_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Absent file → None.
+        let missing = dir.path().join("does-not-exist.json");
+        assert!(
+            settings_has_amplihack_hooks(&missing).is_none(),
+            "a nonexistent path must map to None (absent)"
+        );
+
+        // Present-but-unreadable (a directory at the path) → Some(Err(_)),
+        // because read_to_string fails with a non-NotFound error.
+        let dir_at_path = dir.path().join("settings.json");
+        std::fs::create_dir(&dir_at_path).unwrap();
+        assert!(
+            matches!(settings_has_amplihack_hooks(&dir_at_path), Some(Err(_))),
+            "a present-but-unreadable path must map to Some(Err(_))"
+        );
+    }
 }

--- a/crates/amplihack-hooks/src/session_start/migration.rs
+++ b/crates/amplihack-hooks/src/session_start/migration.rs
@@ -8,9 +8,6 @@ use std::path::PathBuf;
 
 pub(super) fn migrate_global_hooks(dirs: &ProjectDirs) -> Option<String> {
     let global_settings = ProjectDirs::global_settings()?;
-    if !global_settings.exists() {
-        return None;
-    }
 
     let settings_file = AtomicJsonFile::new(&global_settings);
     let settings: Value = match settings_file.read() {
@@ -68,9 +65,6 @@ pub(super) fn migrate_global_hooks(dirs: &ProjectDirs) -> Option<String> {
 /// whether the global hooks are redundant; it never writes.
 fn repo_local_contains_amplihack_hooks(dirs: &ProjectDirs) -> bool {
     let repo_local = dirs.claude.join("settings.json");
-    if !repo_local.exists() {
-        return false;
-    }
     match AtomicJsonFile::new(&repo_local).read() {
         Ok(Some(value)) => contains_amplihack_hooks(&value),
         Ok(None) => false,
@@ -401,6 +395,35 @@ mod tests {
             updated["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
             Some("/usr/local/bin/third-party-hook"),
             "third-party global entries must be preserved"
+        );
+    }
+
+    /// TOCTOU S2 (issue #1123): with the redundant `exists()` probe removed, an
+    /// absent global settings file must still yield `None` (the atomic
+    /// `read()`'s `Ok(None)` arm is now the single source of truth).
+    #[test]
+    fn migrate_global_hooks_returns_none_when_global_absent() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let home = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        // No ~/.claude/settings.json is created — the global file is absent.
+        let dirs = ProjectDirs::new(repo.path());
+        let result = migrate_global_hooks(&dirs);
+
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert!(
+            result.is_none(),
+            "absent global settings must yield None; got: {result:?}"
         );
     }
 }

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -25,6 +25,10 @@ Ahoy! This be where ye learn to keep yer ship secure from digital pirates.
 
 - [Executor Secret Transport & Command Validation](./EXECUTOR_SECRET_AND_COMMAND_HARDENING.md) - Keep the API key off argv/disk (stdin transport) and allowlist-validate the executor command before spawn
 
+**New in Issue #1123 (S2 hardening):**
+
+- [Atomic `settings.json` Reads — TOCTOU Hardening](./SETTINGS_ATOMIC_READ_TOCTOU.md) - Collapse each `exists()` probe + read into a single atomic read so presence and content can never disagree (behavior-preserving)
+
 ---
 
 ## Security Features Overview

--- a/docs/security/SETTINGS_ATOMIC_READ_TOCTOU.md
+++ b/docs/security/SETTINGS_ATOMIC_READ_TOCTOU.md
@@ -1,0 +1,163 @@
+# Atomic `settings.json` Reads — TOCTOU Hardening (S2)
+
+Status: **Implemented** · Issue: [#1123](https://github.com/rysweet/amplihack-rs/issues/1123) · Scope item: **S2**
+
+## Overview
+
+Every place where amplihack inspects a `settings.json` file performs the
+presence check and the read as a **single atomic operation**. A file that is
+absent is treated as the ordinary "not present" outcome by the read itself —
+there is no separate `exists()` probe that precedes the read.
+
+This eliminates a class of *time-of-check-to-time-of-use* (TOCTOU) races: with a
+separate `exists()` check followed by a read, a file could be removed, created,
+or swapped in the window between the two steps, producing an inconsistent
+result (for example, `exists()` returns `true` but the subsequent read fails, or
+vice versa). Collapsing the two steps means presence and content are decided by
+one operation and can never disagree.
+
+The change is **behavior-preserving hardening**. There is no observable change
+in output for any input:
+
+| Input state                        | Reported outcome (unchanged)                         |
+| ---------------------------------- | ---------------------------------------------------- |
+| File absent                        | Same "not present" result as before                  |
+| File present and valid             | Same parsed result as before                         |
+| File present but corrupt/invalid   | Same error/message as before                         |
+| File present but unreadable        | Same read-error message as before                    |
+
+Only the **atomicity** of "presence + read" changed.
+
+## Where it applies
+
+Four read sites were collapsed from `exists()`-then-read into a single atomic
+read:
+
+### `amplihack-hooks` — `session_start::migration`
+
+- **`migrate_global_hooks`** — reads the global settings file
+  (`~/.claude/settings.json`) via `AtomicJsonFile::read()`. A missing file
+  returns `Ok(None)`, which maps to `None` ("nothing to migrate"). No
+  standalone `exists()` probe is used.
+- **`repo_local_contains_amplihack_hooks`** — reads the repo-local
+  `<project-root>/.claude/settings.json` via `AtomicJsonFile::read()`. A missing
+  file returns `Ok(None)`, which maps to `false` ("no repo-local hooks"). No
+  standalone `exists()` probe is used.
+
+In both cases a genuine read error (not "absent") is surfaced through the
+existing `Err(e)` arms via `tracing::warn!`, and for `migrate_global_hooks` the
+same user-facing warning string as before.
+
+Note the one intentional exception to the "error ≠ absent" rule:
+`repo_local_contains_amplihack_hooks` returns a `bool`, so its `Err(e)` arm
+degrades to `false` — the *same value* it returns for an absent file — after
+emitting a `tracing::warn!`. This is a deliberate fail-safe: an unreadable
+repo-local settings file must not be treated as "amplihack hooks are present,"
+so it is degraded to `false`-with-warning rather than propagating an error.
+This single site is the exception to the byte-for-byte error-propagation
+guarantee described in [Semantics](#semantics-absent-vs-error) below; the other
+three sites preserve a distinct error outcome.
+
+### `amplihack-cli` — `commands::doctor::checks`
+
+- **`settings_has_amplihack_hooks`** — a single `std::fs::read_to_string`. A
+  `NotFound` error maps to `None` (location absent → nothing to report). Every
+  other error keeps the identical message:
+  `hooks: cannot read settings.json: <truncated error>`.
+- **`check_settings_valid_json`** — a single `std::fs::read_to_string`. A
+  `NotFound` error maps to the same `(false, "settings.json: file not found")`
+  outcome as before. Every other error keeps the identical message:
+  `settings.json: cannot read: <truncated error>`.
+
+## Semantics: "absent" vs. "error"
+
+The hardening preserves the critical distinction between *absent* and
+*unreadable*:
+
+- **Absent** (`std::io::ErrorKind::NotFound`, or `AtomicJsonFile::read()`
+  returning `Ok(None)`) → the "not present" outcome (`None` / `false` /
+  `file not found`). This is a normal, expected state.
+- **Present but unreadable** (permissions, a directory in the file's place, I/O
+  error, etc.) → an *error* outcome with the original diagnostic message. These
+  are never silently downgraded to "absent".
+
+Only `NotFound` is mapped to the absent branch. All other `io::Error` kinds
+propagate with byte-for-byte identical messages. This means a permission or
+corruption failure is never masked as a missing file.
+
+**One deliberate exception:** `repo_local_contains_amplihack_hooks` returns a
+`bool` and therefore has no error channel to propagate through. On a read error
+it emits a `tracing::warn!` and returns `false` — which happens to equal its
+absent value. This is an intentional fail-safe (an unreadable repo-local file
+must never be reported as "hooks present"), not a silent downgrade: the failure
+is always logged. The distinction preserved here is behavioral safety, not the
+absent-vs-error value distinction, which cannot be expressed in a `bool` return.
+The other three sites (`migrate_global_hooks`, `settings_has_amplihack_hooks`,
+`check_settings_valid_json`) keep a fully distinct error outcome.
+
+## Error-message contract (unchanged)
+
+The following strings are part of the observable contract and are preserved
+exactly:
+
+- `hooks: cannot read settings.json: <truncated>` (non-NotFound read error in
+  `settings_has_amplihack_hooks`)
+- `hooks: settings.json is not valid JSON` (parse error)
+- `settings.json: file not found` (NotFound in `check_settings_valid_json`)
+- `settings.json: cannot read: <truncated>` (non-NotFound read error in
+  `check_settings_valid_json`)
+- `settings.json is valid JSON` / `settings.json: invalid JSON`
+
+Read-error messages are passed through `truncate_chars_with_notice(.., MAX_ERROR_LEN)`
+and never include file contents.
+
+## Relationship to `doctor`
+
+`amplihack doctor` surfaces these checks to users:
+
+- **Check "hooks installed"** aggregates the two-location probe
+  (`settings_has_amplihack_hooks` over global and repo-local settings). An
+  unreadable or corrupt file at one location no longer masks a valid result at
+  the other (see regression coverage below).
+- **Check "settings.json valid JSON"** uses `check_settings_valid_json`.
+
+No `doctor` output changed as a result of this hardening.
+
+## Symlink following (S3) — intentionally NOT changed
+
+These reads deliberately **do not** refuse symlinked targets. No
+`symlink_metadata`, `O_NOFOLLOW`, or symlink-refusal logic was added. This is a
+conscious no-op, not a deferral:
+
+- The targets stay within the user's own trust domain (`$HOME` and the current
+  repository).
+- Only *presence* and *validity* are ever reported — file **contents are never
+  surfaced** to the user or logs.
+- Refusing symlinked config would break legitimate dotfile-management setups
+  where `~/.claude/settings.json` is a symlink into a managed dotfiles
+  repository.
+
+There is no security benefit to refusing symlinks at these read sites, so S3 is
+a deliberate no-op.
+
+## Regression coverage
+
+The following behaviors are covered by tests and must remain green:
+
+- `settings_has_amplihack_hooks` returns `None` for a path that does not exist
+  (NotFound → absent), and `Some(Err(_))` for a present-but-unreadable path
+  (e.g. a directory at the path, or a Unix file with read permission removed) —
+  proving the collapse did not blur the absent-vs-error distinction.
+- `migrate_global_hooks` returns `None` when the global settings file is absent.
+- `test_check_hooks_installed_corrupt_global_does_not_mask_repo_local` (#1088):
+  a corrupt global settings file does not hide valid repo-local hooks.
+- The two-location `doctor` hooks checks report consistently regardless of which
+  location is absent, valid, or corrupt.
+
+## Rationale
+
+Config-inspection code paths are attractive TOCTOU targets because they run at
+session start and during `doctor`, often against files under user-writable
+directories. Collapsing check-then-read removes the race window at essentially
+zero cost and with no behavioral change, making the presence/validity report a
+single, self-consistent decision.


### PR DESCRIPTION
## Summary

Resolves #1123 (S2). Removes the check-then-read TOCTOU pattern on
`settings.json` reads by collapsing each `exists()` probe + subsequent read
into a **single atomic read** that treats a missing file as the existing
"not present" outcome. This is behavior-preserving hardening — no observable
change except that presence and read now happen in one operation, so a file
removed/swapped between the two steps can no longer produce an inconsistent
result.

## The four collapsed `exists()` + read sites

1. **`amplihack-hooks/.../migration.rs::migrate_global_hooks`** — deleted the
   redundant `if !global_settings.exists() { return None; }` block.
   `AtomicJsonFile::read()` already returns `Ok(None)` for a missing file, which
   the existing `Ok(None) => return None` arm handles identically.
2. **`migration.rs::repo_local_contains_amplihack_hooks`** — deleted the
   redundant `if !repo_local.exists() { return false; }` block; the existing
   `Ok(None) => false` arm already covers absence.
3. **`amplihack-cli/.../doctor/checks.rs::settings_has_amplihack_hooks`** —
   replaced the `exists()` probe + read with a single read whose `NotFound`
   error maps to the same absent outcome (`None`); all other read errors keep
   the identical `"hooks: cannot read settings.json: ..."` message.
4. **`checks.rs::check_settings_valid_json`** — collapsed to a single read:
   `NotFound` yields the identical `(false, "settings.json: file not found")`;
   all other read errors keep the identical `"settings.json: cannot read: ..."`
   message.

## Behavior unchanged (only atomicity)

Every existing outcome is byte-for-byte identical: absent → same result, valid
→ same, corrupt/unreadable → same message. No function signature, message
string, or return type changed. The `Err(e)` warn arms in `migration.rs` and
the JSON-parse arms are untouched.

## S3 (symlink following) — deliberate no-op, not a deferral

This PR does **not** add `symlink_metadata` / `O_NOFOLLOW` or any symlink
refusal to these reads. Rationale: the targets stay within the user's own trust
domain (`$HOME` / the repo), only presence/validity is ever reported (file
contents are never surfaced), and refusing symlinked config would break
legitimate dotfile-management setups where `~/.claude/settings.json` is a
symlink. There is no security benefit to refusing symlinks here.

## Tests added

- `settings_has_amplihack_hooks_distinguishes_absent_from_unreadable` — asserts
  the collapse preserved the absent-vs-error distinction: a nonexistent path →
  `None` (NotFound = absent), a present-but-unreadable path (directory at the
  path) → `Some(Err(_))`.
- `migrate_global_hooks_returns_none_when_global_absent` — with the redundant
  probe removed, an absent global settings file still yields `None`.

## Validation

- `cargo fmt --all --check` ✅
- `cargo clippy -p amplihack-cli -p amplihack-hooks --all-targets -- -D warnings` ✅
- `cargo test -p amplihack-cli -p amplihack-hooks` — new tests + the #1088
  regression (`test_check_hooks_installed_corrupt_global_does_not_mask_repo_local`)
  green. The only failures (`issue_538_install_completeness::install_*`) are
  pre-existing and environmental — they require a prebuilt `amplihack` binary in
  the worktree and fail identically on the pristine baseline; they are unrelated
  to this change.

Closes #1123
