### PR TITLE
fix(#1121): make step-04 worktree setup relative-repo_path safe and idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Recipes — foreign-worktree branch deconfliction (concurrency)
         shell: bash
         run: bash amplifier-bundle/recipes/tests/test-foreign-worktree-deconflict.sh
+      - name: Recipes — relative repo_path idempotent worktree setup (issue #1121)
+        shell: bash
+        run: bash amplifier-bundle/recipes/tests/test-issue-1121-relative-repo-path.sh
       - name: Recipes — shellcheck worktree sweep helper (issue #840)
         shell: bash
         run: |

--- a/amplifier-bundle/recipes/tests/test-issue-1121-relative-repo-path.sh
+++ b/amplifier-bundle/recipes/tests/test-issue-1121-relative-repo-path.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# test-issue-1121-relative-repo-path.sh — TDD spec for issue #1121.
+#
+# Issue #1121: workflow-worktree.yaml step-04-setup-worktree spuriously
+# HARD-FAILS with `git worktree add ... already exists` (exit 128) — taking the
+# whole recipe run to status: failure — when invoked with a RELATIVE repo_path
+# (e.g. `-c repo_path="."`) and a worktree for the target branch is already
+# registered and present on disk.
+#
+# ROOT CAUSE (two combining defects in the new-branch three-state idempotency
+# guard, ~lines 287-358 of workflow-worktree.yaml):
+#   A. NON-CANONICAL PATH: with repo_path=".", WORKTREE_PATH becomes
+#      "./worktrees/<branch>", but `git worktree list --porcelain` emits ABSOLUTE
+#      canonical paths ("/abs/repo/worktrees/<branch>"). The `grep -Fx` exact
+#      match therefore NEVER matches a registered worktree, so a present+
+#      registered worktree is misclassified as "missing" (State 2 instead of
+#      State 1 reuse).
+#   B. NO EXISTING-DIRECTORY / PRUNE GUARD in the State-2 and State-3
+#      `git worktree add` branches, so the misclassification (or any leftover
+#      dir on disk) becomes a hard exit-128 instead of converging.
+#
+# REQUIRED FIXES (both):
+#   1. Canonicalize repo_path once, right after the `cd "$REPO_PATH"` +
+#      is-inside-work-tree validation:  REPO_PATH="$(pwd -P)".
+#   2. Route every `git worktree add` through a guarded, idempotent helper
+#      (prune + reuse-if-branch-matches else remove+re-add) so setup converges
+#      to exit 0 instead of exit 128. Never `git worktree add --force`.
+#
+# This test SHOULD FAIL before #1121 lands (scenarios exit 128; the canonicalize
+# static check is absent) and MUST PASS once both fixes are in place.
+#
+# Usage: bash amplifier-bundle/recipes/tests/test-issue-1121-relative-repo-path.sh
+# Exit codes: 0 = pass, 1 = fail, 2 = test harness error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+RECIPES="${REPO_ROOT}/amplifier-bundle/recipes"
+
+WORKTREE_YAML="${RECIPES}/workflow-worktree.yaml"
+
+# Branch that the step derives from the fixed context vars below. Kept explicit
+# (rather than re-deriving the slug pipeline) so the scenarios are readable.
+#   BRANCH_PREFIX=fix  ISSUE_NUMBER=1121  TASK_DESCRIPTION="reuse me" -> slug "reuse-me"
+TARGET_BRANCH="fix/issue-1121-reuse-me"
+STEP_TASK_DESC="reuse me"
+STEP_BRANCH_PREFIX="fix"
+STEP_ISSUE_NUMBER="1121"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo "  PASS[$1]: $2"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  FAIL[$1]: $2" >&2; }
+
+if [[ ! -f "${WORKTREE_YAML}" ]]; then
+    echo "HARNESS-ERROR: required recipe not found: ${WORKTREE_YAML}" >&2
+    exit 2
+fi
+
+# Scratch workspace; cleaned on exit. HOME is repointed here when running the
+# extracted step body so the best-effort sweep/deconflict helper lookups under
+# ~/.amplihack and ~/.copilot reliably miss (hermetic no-op, per #829).
+TEST_TMP="$(mktemp -d)"
+cleanup() { rm -rf "${TEST_TMP}"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# extract_step <file> <step-id>
+# Prints the contiguous block from `- id: "<step-id>"` up to (but excluding) the
+# next top-level `  - id:` marker. Same idiom as test-issue-840.
+# ---------------------------------------------------------------------------
+extract_step() {
+    local file="$1" step_id="$2"
+    awk -v target="${step_id}" '
+        BEGIN { inblk = 0 }
+        /^[[:space:]]*-[[:space:]]+id:[[:space:]]*"/ {
+            line = $0
+            sub(/^[[:space:]]*-[[:space:]]+id:[[:space:]]*"/, "", line)
+            sub(/".*$/, "", line)
+            if (line == target) { inblk = 1; print; next }
+            else if (inblk) { inblk = 0 }
+        }
+        inblk { print }
+    ' "${file}"
+}
+
+# ---------------------------------------------------------------------------
+# extract_step_body <file> <step-id>
+# Prints the executable bash body of a `command: |` block, dedented (the block
+# is indented 6 spaces under the 4-space `command:` key). Stops at the next
+# 4-space YAML key (e.g. `    output:`). This lets us run the REAL step logic
+# against a temp repo instead of brittle string-matching runtime output.
+# ---------------------------------------------------------------------------
+extract_step_body() {
+    local file="$1" step_id="$2"
+    extract_step "${file}" "${step_id}" | awk '
+        /^    command:[[:space:]]*\|/ { grab = 1; next }
+        grab && /^    [A-Za-z_-]+:/  { grab = 0 }
+        grab { line = $0; sub(/^      /, "", line); print line }
+    '
+}
+
+# ---------------------------------------------------------------------------
+# build_repo <name> -> echoes path to a fresh repo with origin + main commit.
+# Mirrors test-issue-840's build_repo.
+# ---------------------------------------------------------------------------
+build_repo() {
+    local name="$1"
+    local remote="${TEST_TMP}/${name}-remote.git"
+    local work="${TEST_TMP}/${name}"
+    git init --quiet --bare "${remote}"
+    git clone --quiet "${remote}" "${work}" 2>/dev/null
+    git -C "${work}" config user.email "t@example.com"
+    git -C "${work}" config user.name "Test"
+    git -C "${work}" checkout -q -b main 2>/dev/null || git -C "${work}" checkout -q main
+    echo "base" > "${work}/README.md"
+    git -C "${work}" add README.md
+    git -C "${work}" commit -q -m "base commit"
+    git -C "${work}" push -q -u origin main 2>/dev/null || true
+    git -C "${work}" remote set-head origin main 2>/dev/null || true
+    printf '%s\n' "${work}"
+}
+
+# ---------------------------------------------------------------------------
+# run_step_body <repo> -> runs the extracted step body inside <repo> with a
+# RELATIVE repo_path ("."). Captures combined output in RUN_OUT and exit code
+# in RUN_RC. Never aborts the harness (RC captured under set -e via `if`).
+# ---------------------------------------------------------------------------
+STEP_SCRIPT="${TEST_TMP}/step-04-body.sh"
+
+run_step_body() {
+    local repo="$1"
+    if RUN_OUT="$(
+        cd "${repo}" && env -i \
+            PATH="${PATH}" \
+            HOME="${TEST_TMP}" \
+            REPO_PATH="." \
+            TASK_DESCRIPTION="${STEP_TASK_DESC}" \
+            BRANCH_PREFIX="${STEP_BRANCH_PREFIX}" \
+            ISSUE_NUMBER="${STEP_ISSUE_NUMBER}" \
+            bash "${STEP_SCRIPT}" 2>&1
+    )"; then
+        RUN_RC=0
+    else
+        RUN_RC=$?
+    fi
+}
+
+echo "=== Issue #1121: relative repo_path must not spuriously exit-128 ==="
+
+STEP04="$(extract_step "${WORKTREE_YAML}" "step-04-setup-worktree")"
+if [[ -z "${STEP04}" ]]; then
+    echo "HARNESS-ERROR: could not extract step-04-setup-worktree from ${WORKTREE_YAML}" >&2
+    exit 2
+fi
+
+extract_step_body "${WORKTREE_YAML}" "step-04-setup-worktree" > "${STEP_SCRIPT}"
+if [[ ! -s "${STEP_SCRIPT}" ]]; then
+    echo "HARNESS-ERROR: extracted step body is empty (command block extraction failed)" >&2
+    exit 2
+fi
+
+# ===========================================================================
+# Part A — Static / contract checks.
+# ===========================================================================
+
+# A1: FIX #1 — step-04 canonicalizes repo_path via `pwd -P` after the cd, so the
+# grep -Fx registration check matches git's absolute porcelain output.
+if printf '%s\n' "${STEP04}" \
+       | grep -qE 'REPO_PATH="\$\(pwd -P\)"'; then
+    pass "A1-canonicalize" "step-04 canonicalizes repo_path with pwd -P after cd"
+else
+    fail "A1-canonicalize" "step-04 does not canonicalize repo_path (REPO_PATH=\"\$(pwd -P)\" missing)"
+fi
+
+# A2: FIX #2 — every `git worktree add` is routed through the mandated guarded,
+# idempotent helper (prune + reuse-if-branch-matches else remove+re-add). Accept
+# the inline helper function or the externalized tools/ add-helper script. An
+# ACTUAL executed `git worktree prune` line (not a comment/echo advising it) also
+# satisfies the guard. Comment/error-string mentions of "git worktree prune"
+# (issue #858 advice) must NOT count — hence the leading-whitespace/`;` anchor.
+if printf '%s\n' "${STEP04}" \
+       | grep -qE '(\bwt_add_idempotent\b|workflow_worktree_add|^[[:space:]]*git worktree prune\b)'; then
+    pass "A2-add-guard" "new-branch add path routes through a guarded idempotent-add helper"
+else
+    fail "A2-add-guard" "new-branch add path lacks a guarded idempotent-add helper (still bare 'git worktree add')"
+fi
+
+# A3: HARD CONSTRAINT (brick limit) — workflow-worktree.yaml strictly < 400 lines.
+YAML_LINES=$(wc -l < "${WORKTREE_YAML}")
+if [[ "${YAML_LINES}" -lt 400 ]]; then
+    pass "A3-400" "workflow-worktree.yaml is ${YAML_LINES} lines (< 400)"
+else
+    fail "A3-400" "workflow-worktree.yaml is ${YAML_LINES} lines (>= 400 — brick limit breached)"
+fi
+
+# A4: guard must NOT reach for the unconditional `git worktree add --force`,
+# which can silently clobber a legitimately-populated directory.
+if printf '%s\n' "${STEP04}" | grep -qE 'git worktree add --force'; then
+    fail "A4-no-force-add" "step-04 uses 'git worktree add --force' (can clobber populated dir)"
+else
+    pass "A4-no-force-add" "step-04 avoids unconditional 'git worktree add --force'"
+fi
+
+# ===========================================================================
+# Part B — Real-repo scenarios (the faithful reproduction of #1121).
+# ===========================================================================
+
+# --- B1: registered + present worktree for the branch, run with repo_path="."
+#         MUST be reused (State 1), exit 0, and never print "already exists". ---
+REPO="$(build_repo s1)"
+git -C "${REPO}" worktree add -q "${REPO}/worktrees/${TARGET_BRANCH}" \
+    -b "${TARGET_BRANCH}" origin/main
+run_step_body "${REPO}"
+if [[ "${RUN_RC}" -ne 0 ]]; then
+    fail "B1-exit0" "step exited ${RUN_RC} (expected 0) for a registered+present worktree with repo_path=. (this is the #1121 exit-128 bug)"
+elif printf '%s\n' "${RUN_OUT}" | grep -qiF "already exists"; then
+    fail "B1-exit0" "step printed 'already exists' (spurious worktree-add collision)"
+else
+    pass "B1-exit0" "registered+present worktree with repo_path=. exits 0, no 'already exists'"
+fi
+# B1b: it must be classified State 1 (reuse) -> created=false in the JSON output.
+if printf '%s\n' "${RUN_OUT}" | grep -qE '"created":[[:space:]]*false'; then
+    pass "B1-reuse" "registered worktree REUSED (created=false, State 1)"
+else
+    fail "B1-reuse" "registered worktree was NOT reused (expected \"created\": false in JSON output)"
+fi
+
+# --- B2: directory present on disk for the target branch but WITHOUT a
+#         registration (stale/partial state or manually-created dir). The guard
+#         must still converge to exit 0 (remove+re-add), never exit 128. ---
+REPO="$(build_repo s2)"
+mkdir -p "${REPO}/worktrees/${TARGET_BRANCH}"
+echo "leftover from a partially-pruned prior run" \
+    > "${REPO}/worktrees/${TARGET_BRANCH}/stale.txt"
+run_step_body "${REPO}"
+if [[ "${RUN_RC}" -ne 0 ]]; then
+    fail "B2-converge" "step exited ${RUN_RC} (expected 0) for a present-but-unregistered dir (must converge, not exit 128)"
+elif printf '%s\n' "${RUN_OUT}" | grep -qiF "already exists"; then
+    fail "B2-converge" "step printed 'already exists' for a present-but-unregistered dir"
+else
+    pass "B2-converge" "present-but-unregistered dir converges to exit 0 (no 128)"
+fi
+# B2b: after convergence the path is a real, registered worktree on the branch.
+if git -C "${REPO}" worktree list --porcelain \
+       | grep -qFx "worktree ${REPO}/worktrees/${TARGET_BRANCH}"; then
+    pass "B2-registered" "converged worktree is registered on ${TARGET_BRANCH}"
+else
+    fail "B2-registered" "converged path is not a registered worktree"
+fi
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo ""
+echo "--- Summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ---"
+
+if [[ ${FAIL_COUNT} -gt 0 ]]; then
+    exit 1
+fi
+
+echo "PASS: Issue #1121 — relative repo_path setup is canonical, idempotent, and exit-0 convergent."
+exit 0

--- a/amplifier-bundle/recipes/workflow-worktree.yaml
+++ b/amplifier-bundle/recipes/workflow-worktree.yaml
@@ -34,6 +34,8 @@ steps:
         echo "ERROR: step-04-setup-worktree requires a git repo at $(pwd); either \`git init\` or rerun from a checkout" >&2
         exit 1
       fi
+      # Canonicalize repo_path so WORKTREE_PATH matches git porcelain (issue #1121).
+      REPO_PATH="$(pwd -P)"
 
       # --- Self-healing orphan sweep (issue #840) ---
       # Best-effort: prune leaked worktrees/branches from prior FAILED runs so a
@@ -60,6 +62,27 @@ steps:
         s=${s//$'\r'/\\r}
         s=${s//$'\t'/\\t}
         printf '%s' "$s"
+      }
+
+      # wt_add_idempotent MODE WT BRANCH [REF] (issue #1121/#642): prune stale regs,
+      # reuse dir if it's a worktree on BRANCH else remove+re-add. No add --force.
+      wt_add_idempotent() {
+        local mode="$1" wt="$2" branch="$3" ref="${4:-}" cur
+        git worktree prune >/dev/null 2>&1 || true
+        if [ -d "$wt" ]; then
+          cur="$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null || true)"
+          if [ "$cur" = "$branch" ]; then
+            echo "INFO: Reusing existing worktree directory at '$wt' (branch matches)." >&2
+            return 0
+          fi
+          echo "INFO: Removing stale worktree at '$wt' (was '${cur:-none}', need '$branch')." >&2
+          git worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+        fi
+        case "$mode" in
+          attach) git worktree add -- "$wt" "$branch" >&2 ;;
+          create) git worktree add -b "$branch" -- "$wt" "$ref" >&2 ;;
+          track)  git worktree add --track -b "$branch" -- "$wt" "$ref" >&2 ;;
+        esac
       }
 
       # ========================================================================
@@ -156,31 +179,11 @@ steps:
             echo "ERROR: run the recipe from a clean base checkout or detach/switch the caller checkout before targeting this branch." >&2
             exit 1
           else
-            # SECURITY: WORKTREE_PATH construction is safe because BRANCH_NAME
-            # has passed git check-ref-format above (rejects .., leading -, etc.).
             WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"
-            if [ -d "$WORKTREE_PATH" ]; then
-              # Issue #642: worktree dir exists from a prior run. If it's a
-              # valid git worktree on the right branch, reuse it. Otherwise
-              # remove the stale directory and re-create.
-              WT_BRANCH="$(git -C "$WORKTREE_PATH" symbolic-ref --short HEAD 2>/dev/null || true)"
-              if [ "$WT_BRANCH" = "$BRANCH_NAME" ]; then
-                echo "INFO: Reusing existing worktree directory at '$WORKTREE_PATH' (branch matches)." >&2
-              else
-                echo "INFO: Removing stale worktree at '$WORKTREE_PATH' (was '$WT_BRANCH', need '$BRANCH_NAME')." >&2
-                git worktree remove --force "$WORKTREE_PATH" >&2 2>/dev/null || rm -rf "$WORKTREE_PATH"
-                if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-                  git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
-                elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
-                  git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
-                fi
-              fi
-            elif git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-              # Local branch exists: attach without -b (safe re-attach).
-              git worktree add -- "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+            if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+              wt_add_idempotent attach "$WORKTREE_PATH" "$BRANCH_NAME"
             elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
-              # Remote-only: create local tracking branch on attach.
-              git worktree add --track -b "$BRANCH_NAME" -- "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
+              wt_add_idempotent track "$WORKTREE_PATH" "$BRANCH_NAME" "origin/$BRANCH_NAME"
             else
               echo "ERROR: branch '$BRANCH_NAME' not found locally or on origin." >&2
               exit 1
@@ -311,12 +314,10 @@ steps:
 
       # --- Idempotency: detect existing branch and/or worktree ---
       # FIX (issue #3023 / BL-002): Three-state guard makes re-runs safe.
-      # State 1: branch + worktree both exist → reuse silently, emit created=false
-      # State 2: branch exists but worktree missing → add worktree without -b
-      # State 3: neither exists → full create path (original behaviour)
-      #
-      # Security note: grep -F is required (not -E/-P) so that filesystem path
-      # characters (., +, *) in WORKTREE_PATH are not interpreted as regex metacharacters.
+      # State 1: branch + worktree both exist → reuse; State 2: branch only → add;
+      # State 3: neither → create. grep -Fx: literal exact match. (issue #1121)
+      # WORKTREE_PATH is now canonical/absolute so this matches git porcelain;
+      # every add routes through wt_add_idempotent.
       BRANCH_EXISTS=$(git branch --list "${BRANCH_NAME}")
       WORKTREE_EXISTS=$(git worktree list --porcelain | grep -Fx "worktree ${WORKTREE_PATH}" || true)
 
@@ -345,15 +346,15 @@ steps:
         if [ "$COMMITS_AHEAD" -gt 0 ]; then
           echo "WARNING: Existing branch '${BRANCH_NAME}' has ${COMMITS_AHEAD} unmerged commit(s) — resetting to ${BASE_REF}." >&2
           git branch -D "${BRANCH_NAME}" >&2
-          git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" "${BASE_REF}" >&2
+          wt_add_idempotent create "${WORKTREE_PATH}" "${BRANCH_NAME}" "${BASE_REF}"
         else
           echo "INFO: Branch '${BRANCH_NAME}' exists (clean) but worktree is missing — adding worktree without -b." >&2
-          git worktree add "${WORKTREE_PATH}" "${BRANCH_NAME}" >&2
+          wt_add_idempotent attach "${WORKTREE_PATH}" "${BRANCH_NAME}"
         fi
         CREATED=true
       else
         echo "INFO: Creating new branch and worktree." >&2
-        git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" "${BASE_REF}" >&2
+        wt_add_idempotent create "${WORKTREE_PATH}" "${BRANCH_NAME}" "${BASE_REF}"
         CREATED=true
       fi
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -84,6 +84,7 @@ Complete documentation for using the Recipe Runner:
 - **[Tutorial: Workflow Terminal-State Closure](../tutorials/workflow-terminal-state-closure.md)** - Walk through successful evidence, planning-only failure, and rerun behavior
 - **[Scoped Workflow Closure](../reference/scoped-workflow-closure.md)** - Persisted PR, process, and workstream ownership contract for default-workflow closure
 - **[Leak-Proof, Self-Healing Worktree Setup (#840)](issue-840-leak-proof-worktree.md)** - Orphan-worktree sweep and cleanup-on-failure for `step-04-setup-worktree`, with the `workflow_worktree_sweep.sh` helper API, the data-loss safety gate, and `AMPLIHACK_WORKTREE_STALE_SECS` configuration
+- **[Relative-Path-Safe, Idempotent Worktree Setup (#1121)](issue-1121-relative-repo-path.md)** - Canonicalizes `repo_path` (`pwd -P`) and routes every `git worktree add` through a guarded `wt_add_idempotent` helper so `step-04-setup-worktree` reuses an already-present worktree instead of hard-failing with `already exists` (exit 128) under a relative `repo_path`
 
 ## Why It Exists
 

--- a/docs/recipes/issue-1121-relative-repo-path.md
+++ b/docs/recipes/issue-1121-relative-repo-path.md
@@ -1,0 +1,271 @@
+# Relative-Path-Safe, Idempotent Worktree Setup (Issue #1121)
+
+`step-04-setup-worktree` now works reliably when the recipe is invoked with a
+**relative** `repo_path` (for example `-c repo_path="."`). Re-running against a
+worktree that is already registered **and** present on disk no longer aborts the
+whole recipe with `git worktree add ... already exists` (exit 128). Setup now
+**converges**: an existing, matching worktree is silently **reused**, and a
+directory left behind on disk is repaired in place instead of crashing the run.
+
+**Affects:**
+- `amplifier-bundle/recipes/workflow-worktree.yaml` — `step-04-setup-worktree`
+
+**Closes:** #1121
+
+---
+
+## Quick Start
+
+No configuration is required. Both absolute and relative `repo_path` values are
+now handled identically. The following invocations are equivalent and both
+succeed on first run and on every re-run:
+
+```bash
+# Absolute repo_path (worked before)
+amplihack recipe run default-workflow \
+  -c task_description="Fix issue #1234" \
+  -c repo_path="$(pwd)"
+
+# Relative repo_path (now equally safe)
+amplihack recipe run default-workflow \
+  -c task_description="Fix issue #1234" \
+  -c repo_path="."
+```
+
+Running the setup step a second time when the worktree already exists prints:
+
+```
+INFO: Branch 'feat-issue-1234' and worktree '/abs/repo/worktrees/feat-issue-1234' already exist and are clean — reusing.
+```
+
+and the step exits `0` with `created=false`. It **never** prints
+`fatal: '...' already exists` and **never** exits `128` for an already-present,
+matching worktree.
+
+---
+
+## Problem
+
+Each workflow run creates an isolated git worktree under
+`${REPO_PATH}/worktrees/<branch>` (see
+[Worktree Support](../worktree-support.md)). `step-04-setup-worktree` uses a
+three-state idempotency guard to make re-runs safe:
+
+| State | Condition | Action |
+| ----- | --------- | ------ |
+| 1 | branch **and** worktree both registered | reuse silently (`created=false`) |
+| 2 | branch registered, worktree missing | attach a worktree for the branch |
+| 3 | neither exists | create branch + worktree |
+
+Two defects combined to break this guard when `repo_path` was relative.
+
+### Defect A — non-canonical path defeats the registration check
+
+The guard derives the target path as
+`WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"` and tests whether that
+worktree is already registered with an **exact** match:
+
+```bash
+WORKTREE_EXISTS=$(git worktree list --porcelain \
+  | grep -Fx "worktree ${WORKTREE_PATH}" || true)
+```
+
+`git worktree list --porcelain` always emits **absolute, canonical** paths
+(e.g. `/abs/repo/worktrees/feat-issue-1234`). But with `repo_path="."`,
+`WORKTREE_PATH` was `./worktrees/feat-issue-1234`. The `grep -Fx` exact-line
+match therefore **never matched** a registered worktree, so a worktree that was
+in fact present got misclassified as *missing* (State 2). The same breakage
+occurred for any `repo_path` containing `/./`, a trailing slash, or a
+symlinked / otherwise non-canonical prefix.
+
+### Defect B — the add path had no existing-directory guard
+
+Once misclassified as State 2 (or State 3), the guard ran a bare
+`git worktree add "${WORKTREE_PATH}" ...`. Because the directory was actually
+present on disk, git aborted:
+
+```
+fatal: '/abs/repo/worktrees/feat-issue-1234' already exists
+```
+
+with exit code `128`, which propagated up and marked the **entire recipe run**
+as `status: failure`. The existing-branch / PR code path (issue #342) already
+guarded its adds against a present-on-disk directory (issue #642); the
+three-state guard had regressed that robustness.
+
+---
+
+## Fix
+
+Two changes, both in `step-04-setup-worktree`.
+
+### 1. Canonicalize `repo_path` once, early
+
+Immediately after the step validates it is inside a work tree and `cd`s into
+`repo_path`, it now canonicalizes the path:
+
+```bash
+cd "$REPO_PATH"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { ... }
+# Canonicalize so every derived WORKTREE_PATH is absolute and matches
+# `git worktree list --porcelain` output (fixes issue #1121 Defect A).
+REPO_PATH="$(pwd -P)"
+```
+
+Because the step has already `cd`'d into the repo, `pwd -P` yields the absolute,
+symlink-resolved canonical path. Every downstream
+`WORKTREE_PATH="${REPO_PATH}/worktrees/${BRANCH_NAME}"` is therefore absolute
+and canonical, so the `grep -Fx` registration check matches git's porcelain
+output. This alone fixes the exact reported failure: a registered **and**
+present worktree is now correctly classified as **State 1 (reuse)**.
+
+### 2. Idempotent, guarded `git worktree add`
+
+Every `git worktree add` in the step is now routed through a single shared
+helper, `wt_add_idempotent`, defined once near the top of the step. Before
+adding, it prunes stale registrations and repairs a present-on-disk directory
+instead of crashing:
+
+```bash
+# wt_add_idempotent MODE WORKTREE_PATH BRANCH_NAME [REF]
+#   MODE ∈ attach | track | create
+wt_add_idempotent() {
+  local mode="$1" wt="$2" branch="$3" ref="${4:-}"
+  git worktree prune 2>/dev/null || true          # drop stale registrations
+  if [ -d "$wt" ]; then
+    local cur
+    cur="$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null || true)"
+    if [ "$cur" = "$branch" ]; then
+      return 0                                     # already correct — reuse
+    fi
+    git worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+  fi
+  case "$mode" in
+    attach) git worktree add -- "$wt" "$branch" ;;
+    track)  git worktree add --track -b "$branch" -- "$wt" "origin/$branch" ;;
+    create) git worktree add -b "$branch" -- "$wt" "$ref" ;;
+  esac
+}
+```
+
+> **`--` placement matters.** Git stops parsing options at `--`, so every
+> option (`-b`, `--track`) must appear **before** the separator. `create`
+> therefore uses `add -b "$branch" -- "$wt" "$ref"` (not `add -- "$wt" -b …`,
+> which git rejects because `-b` after `--` is read as a pathspec). This
+> mirrors the existing `--track` form and preserves the flag-injection guard
+> the `--` separator provides.
+
+Key guarantees:
+
+- **Never `git worktree add --force` unconditionally.** A blind `--force` can
+  silently clobber a legitimately populated directory. The helper only removes a
+  directory *after* confirming its checked-out branch does **not** match the
+  target.
+- **Reuse when the branch already matches.** A present directory whose `HEAD`
+  is the target branch is reused as-is (`return 0`), so no data is lost.
+- **Repair when it does not match.** A stale / mismatched directory is removed
+  (`git worktree remove --force`, falling back to `rm -rf`) and re-added.
+- **Prune first.** `git worktree prune` clears registrations left dangling by a
+  partial prior run, so a present-but-unregistered directory still converges.
+- **Validation preserved.** The helper is only ever reached after branch names
+  pass `git check-ref-format`, and it always uses the `--` end-of-options
+  separator, so path/branch values can never be interpreted as flags.
+
+The three-state guard's State 2 and State 3 adds, and the existing-branch /
+PR (#342) adds, all call this one helper. Because the several previously
+duplicated `git worktree add` invocations collapse into a single function, the
+change **adds the guard while net-reducing line count**, keeping
+`workflow-worktree.yaml` strictly **under 400 lines** (enforced by check A10 in
+`test-issue-840-worktree-leak-proof.sh`).
+
+> **Line-budget watch-item.** `workflow-worktree.yaml` is already **398/400**
+> lines, so the guarantee above is tight. The net reduction is only real if the
+> helper genuinely collapses the duplicated State-2, State-3, and #342 add-sites
+> into single-line calls; a helper that is *added alongside* the existing
+> invocations would blow the budget. If collapsing alone does not clear 400
+> lines, the documented contingencies are, in order: (1) trim redundant inline
+> comments in the step, then (2) externalize the helper to a
+> `tools/`-hosted script sourced by the step. Check A10 remains the hard gate
+> either way.
+
+---
+
+## Behavior Matrix
+
+With both fixes, `step-04-setup-worktree` converges for every combination of
+registration state, on-disk presence, and `repo_path` form:
+
+| `repo_path` | Worktree registered? | Directory on disk? | Branch matches? | Result |
+| ----------- | -------------------- | ------------------ | --------------- | ------ |
+| `.` or absolute | yes | yes | yes | **State 1** — reuse, exit 0, `created=false` |
+| `.` or absolute | yes | yes | no (dirty/ahead) | reset to `BASE_REF`, exit 0 |
+| `.` or absolute | yes | no | — | **State 2** — attach, exit 0 |
+| `.` or absolute | no | yes | yes | prune + reuse, exit 0 |
+| `.` or absolute | no | yes | no | prune + remove + re-add, exit 0 |
+| `.` or absolute | no | no | — | **State 3** — create, exit 0 |
+
+No combination results in exit 128 or an `already exists` abort.
+
+---
+
+## Preserved Behavior
+
+This fix is surgical. It does **not** change:
+
+- The **#858 caller-checkout refusal** — a run never reuses the caller's own
+  repository as its task worktree.
+- The **#200 cleanliness resets** — a dirty worktree or a branch with commits
+  ahead of `BASE_REF` is still `reset --hard "${BASE_REF}"` before reuse.
+- The **#829 / #840 foreign-worktree deconfliction** and the orphan
+  [sweep helper](./issue-840-leak-proof-worktree.md).
+- The **#342** existing-branch / PR matching (`git worktree list --porcelain`
+  awk on the branch ref) and its **#642** existing-directory guard semantics.
+- The `created=` / `CREATED` output contract and the step's JSON output.
+- Branch-name validation via `git check-ref-format` before any path use.
+
+---
+
+## Regression Test
+
+`amplifier-bundle/recipes/tests/test-issue-1121-relative-repo-path.sh` guards
+this behavior. It follows the same idioms as
+`test-issue-840-worktree-leak-proof.sh` (repo-root discovery, pass/fail
+counters, `set -euo pipefail`, `mktemp -d` + trap cleanup, a `build_repo`
+helper, and exit codes `0` pass / `1` fail / `2` harness error). It exercises
+the real step body extracted from the recipe (via the same `extract_step` awk
+idiom as the #840 test) against a temporary git repo:
+
+**Dynamic scenarios**
+
+1. **Registered + present.** Pre-register and leave on disk a worktree for the
+   target branch, then run the step with `repo_path="."`. Asserts the step
+   exits `0`, does **not** print `already exists`, and **reuses** the worktree
+   (State 1, `created=false`).
+2. **Present but unregistered.** Leave a directory on disk for the target
+   branch with **no** registration (a stale/partial state). Asserts the guard
+   still converges to exit `0` (reuse-if-branch-matches, else remove + re-add),
+   never exit `128`.
+
+**Static contract checks**
+
+- (a) step-04 canonicalizes `repo_path` with `pwd -P` after the `cd`.
+- (b) the new-branch add path has a prune / existing-directory guard.
+- (c) `workflow-worktree.yaml` is still **< 400 lines** (check A10).
+
+Run it directly:
+
+```bash
+bash amplifier-bundle/recipes/tests/test-issue-1121-relative-repo-path.sh
+# -> exit 0
+```
+
+The test is registered in CI (`.github/workflows/ci.yml`) alongside the other
+`recipes/tests/*.sh` worktree tests.
+
+---
+
+## Related
+
+- [Leak-Proof, Self-Healing Worktree Setup (Issue #840)](./issue-840-leak-proof-worktree.md)
+- [Worktree Support](../worktree-support.md)
+- [step-03 Idempotency](./step-03-idempotency.md)


### PR DESCRIPTION
## Summary

Fixes #1121: `workflow-worktree.yaml` step-04-setup-worktree spuriously failed
with `git worktree add ... already exists` (exit 128) — taking the whole recipe
run down to `status: failure` — whenever it was invoked with a **relative**
`repo_path` (e.g. `-c repo_path="."`, the documented default) and a worktree for
the target branch was already registered and present on disk.

## Root cause

Two defects combined in the new-branch three-state guard:

1. **Non-canonical path.** `WORKTREE_PATH="${REPO_PATH}/worktrees/<branch>"` was
   built from the raw relative `repo_path`, but `git worktree list --porcelain`
   emits **absolute canonical** paths. The `grep -Fx` registration check
   therefore never matched a registered worktree, so it was misclassified as
   "missing" and a bare `git worktree add` was attempted on a directory that was
   really there → exit 128.
2. **No existing-directory guard** on the State-2/State-3 `git worktree add`
   branches, so the misclassification became a hard failure. The existing-branch
   (#342) path already handled this correctly (#642); the three-state guard had
   regressed it.

## Fix

- **Canonicalize** `repo_path` once, right after the `cd` + git validation:
  `REPO_PATH="$(pwd -P)"`. Every downstream `WORKTREE_PATH` is now absolute and
  canonical, so the porcelain registration check matches. This resolves `.`,
  trailing slashes, `/./`, and symlinked prefixes.
- **Add an existing-directory / stale-registration guard** via a single shared
  shell function `wt_add_idempotent()` (prune stale registrations, reuse the
  directory when it is a worktree on the right branch, otherwise
  `git worktree remove --force`/`rm -rf` then re-add). All worktree-add sites —
  both the #342 path and the three-state State-2/State-3 branches — now route
  through it. It never uses `git worktree add --force` unconditionally.

Factoring the repeated add logic into one function de-duplicated the step, so
`workflow-worktree.yaml` stays **399 lines** (< 400 brick limit enforced by the
#840 test).

## Tests

- New `amplifier-bundle/recipes/tests/test-issue-1121-relative-repo-path.sh`
  (wired into CI): static contract checks plus two real temp-repo scenarios — a
  registered+present worktree under `repo_path=.` exits 0 and is reused (State
  1); a present-but-unregistered directory converges to exit 0 (no 128). 8/8 pass.
- No regressions: `test-issue-840-worktree-leak-proof.sh` 17/17,
  `test-foreign-worktree-deconflict.sh` 27/27.

Closes #1121

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 29147940-80a3-4c99-9db5-8b796a13cfcd
