### PR TITLE
feat: add NPE hunting workflow skill

### DIFF
--- a/amplifier-bundle/agents/core/guide.md
+++ b/amplifier-bundle/agents/core/guide.md
@@ -60,11 +60,11 @@ Introduce users to the 35 available agents:
 
 ### 3. Skills Library
 
-Guide users through the 74 available skills:
+Guide users through the 75 available skills:
 
 **Domain Analysts** (23): Expert perspectives (economist, historian, psychologist, etc.)
 **Workflow Skills** (11): Workflow execution knowledge
-**Technical Skills** (19): Coding patterns, debugging, testing
+**Technical Skills** (20): Coding patterns, debugging, testing
 **Document Processing** (4): PDF, DOCX, XLSX, PPTX handling
 **Meta Skills** (11): PR review, backlog curation, roadmaps
 

--- a/amplifier-bundle/bundle.md
+++ b/amplifier-bundle/bundle.md
@@ -69,7 +69,7 @@ skills:
   quality-audit-workflow: { path: skills/quality-audit-workflow/SKILL.md }
   ultrathink-orchestrator: { path: skills/ultrathink-orchestrator/SKILL.md }
 
-  # Technical skills (19)
+  # Technical skills (20)
   agent-sdk: { path: skills/claude-agent-sdk/SKILL.md }
   azure-admin: { path: skills/azure-admin/SKILL.md }
   azure-devops: { path: skills/azure-devops/SKILL.md }
@@ -84,6 +84,7 @@ skills:
   mermaid-diagram-generator: { path: skills/mermaid-diagram-generator/SKILL.md }
   microsoft-agent-framework: { path: skills/microsoft-agent-framework/SKILL.md }
   module-spec-generator: { path: skills/module-spec-generator/SKILL.md }
+  npe-hunting-workflow: { path: skills/npe-hunting-workflow/SKILL.md }
   outside-in-testing: { path: skills/outside-in-testing/SKILL.md }
   qa-team: { path: skills/qa-team/SKILL.md }
   remote-work: { path: skills/remote-work/SKILL.md }
@@ -288,7 +289,7 @@ agents:
         |----------|-------|----------|
         | Domain Analysts | 23 | economist, historian, psychologist |
         | Workflow Skills | 11 | default-workflow, debate, consensus |
-        | Technical Skills | 19 | design-patterns, debugging, testing |
+        | Technical Skills | 20 | design-patterns, debugging, testing |
         | Document Processing | 4 | PDF, DOCX, XLSX, PPTX |
         | Meta Skills | 11 | PR review, backlog, roadmaps |
 

--- a/amplifier-bundle/skills/npe-hunting-workflow/SKILL.md
+++ b/amplifier-bundle/skills/npe-hunting-workflow/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: npe-hunting-workflow
+description: Investigates and remediates NullPointerException (NPE) and null-dereference failures from a real stack trace. Use when tracing an NPE, finding structurally similar null bugs, filtering false positives, deciding whether TLA+ applies, or coordinating validated fixes.
+metadata:
+  version: "1.0"
+  author: amplihack
+---
+
+# NPE Hunting Workflow
+
+## Purpose
+
+Turns one observed null failure into an evidence-driven search for related bugs.
+It separates candidate generation, skeptical falsification, validation, formal
+analysis, and remediation so plausible static matches are never treated as
+confirmed defects.
+
+## Required Outcomes
+
+- Anchor the investigation to an observed stack trace and repository revision.
+- Explain the complete lifecycle that can produce the null value.
+- Record every candidate, including rejected and inconclusive candidates.
+- Invoke `crusty-old-engineer` to falsify every candidate before validation.
+- Assess formal methods for every surviving lifecycle or interleaving defect.
+- Add a characterization test before changing production behavior.
+- Fix only validated bugs through `default-workflow`.
+- Run parallel fixes only when file and interface ownership is disjoint.
+
+## Workflow
+
+### 1. Initialize evidence tracking
+
+Create a process journal and candidate ledger before searching. Use the formats
+in [reference.md](reference.md). Record commands, hypotheses, failed approaches,
+and decisions, not just successful findings.
+
+Candidate states are:
+
+`provisional -> skeptical-review -> reproduce -> validated -> fixed`
+
+Terminal states are `rejected-false-positive`, `rejected-wrong-bug-class`, and
+`blocked-insufficient-evidence`.
+
+### 2. Anchor the seed failure
+
+Start from a real stack trace or reproduce one before broad scanning.
+
+If the trace text is absent, stop and obtain or reproduce it; never synthesize a trace.
+If the failing revision is unknown, record the current checkout and mark line
+mappings as conditional until history or build metadata identifies it.
+
+1. Pin the source revision and map every stack frame to that revision.
+2. Identify the exact null object. Do not infer field ownership from the JVM
+   variable name.
+3. Trace backward to the null producer and forward to the dereference.
+4. Separate the immediate null path from the lifecycle transition that made the
+   value absent.
+5. State confirmed facts and hypotheses separately.
+
+Do not widen the search until the immediate seed path is source-confirmed.
+
+### 3. Trace the nullable lifecycle
+
+For the seed object, enumerate:
+
+- creation and initialization
+- attachment or registration
+- lookup and caching
+- replacement and generation changes
+- detachment, release, and clearing
+- callbacks, animations, listeners, executors, and render traversals
+- guards at scheduling time and guards at use time
+
+Express the seed as a structural signature, for example:
+
+`lifecycle-owned nullable resource + stale readiness check + deferred use + unguarded dereference`
+
+### 4. Generate candidates structurally
+
+Search for the signature, not for every nullable value. Partition large
+codebases by subsystem so scans do not duplicate work.
+
+Each provisional candidate must identify:
+
+1. a concrete null producer
+2. a reachable consumer path
+3. the exact unguarded dereference
+4. the lifecycle transition between producer and consumer
+5. existing guards and tests
+6. a concrete false-positive condition
+
+Independently re-derive these facts from production source. Do not accept a
+candidate writeup, scanner result, or test-double path as evidence by itself.
+
+Stop broad searching when new regions yield only duplicate signatures or
+rejected patterns. More matches are not progress by themselves.
+
+### 5. Falsify every candidate
+
+Invoke `crusty-old-engineer` with the complete ledger, or deterministic batches
+when the ledger is too large. Require one verdict per candidate:
+
+- `VALIDATED`: observed trace or characterization test proves the failure.
+- `RETAIN_FOR_REPRODUCTION`: source-reachable, but runtime ordering is unproven.
+- `REJECT_FALSE_POSITIVE`: a contract, guard, or unreachable transition blocks it.
+
+The review must challenge the null producer, reachability, actual exception
+type, short-circuit behavior, lazy recreation, call-order invariants, and
+production teardown paths. Record the evidence behind every verdict.
+
+No candidate may enter remediation directly from static analysis.
+
+### 6. Validate and assess formal methods
+
+Write the smallest targeted characterization test for each retained candidate.
+The test must exercise the production method rather than a fixture override that
+bypasses the suspect path.
+
+Invoke `tla-plus-expert` when all of these are true:
+
+- correctness depends on lifecycle state or operation ordering
+- the relevant state and transitions can be finitely abstracted
+- a safety invariant can distinguish the current design from a proposed fix
+- testing would sample interleavings rather than cover them
+
+For TLA+ work, require:
+
+1. a counterexample for the current design
+2. a check of the tempting minimal fix, such as a null check alone
+3. a passing model for the proposed fix invariant
+4. explicit abstraction, bound, atomicity, liveness, and memory-model limits
+
+Model replacement as a new resource identity and in-place mutation as the same
+identity. State which callbacks or operations are atomic in the model.
+
+Skip formal modeling for a direct sequential missing guard when a focused test
+proves the bug more clearly. Record that decision in the ledger.
+
+### 7. Characterize before fixing
+
+A bug is eligible for a fix only when:
+
+- skeptical review retained it
+- a trace, focused failing test, or formal counterexample validates it
+- a characterization test captures current behavior
+- the intended safe behavior is explicit
+
+Preserve the characterization test, then change it or add a paired regression
+test that asserts the corrected behavior.
+
+### 8. Partition and fix
+
+Create an ownership matrix for validated bugs. Group candidates by files and
+tightly coupled interfaces.
+
+- Launch parallel `default-workflow` workstreams only for disjoint groups.
+- Run overlapping groups sequentially.
+- Give each workstream its characterization tests, evidence, formal invariants,
+  owned files, and excluded files.
+- Integrate only after targeted tests and independent review pass.
+
+Do not weaken formal invariants during implementation. A null check is not a
+complete fix when acquisition and cleanup must use the same resource identity.
+
+### 9. Close the investigation
+
+Update every ledger entry with its final disposition, validation evidence,
+formal-method decision, fix workstream, and test result. Record workflow
+failures and fallbacks in the journal; infrastructure failure is process
+evidence too.
+
+## Supporting Material
+
+- [reference.md](reference.md): ledger, journal, evidence gates, and formal checklist
+- [examples.md](examples.md): representative activation and decision examples

--- a/amplifier-bundle/skills/npe-hunting-workflow/examples.md
+++ b/amplifier-bundle/skills/npe-hunting-workflow/examples.md
@@ -1,0 +1,58 @@
+# NPE Hunting Examples
+
+## Example 1: Activate from an observed stack trace
+
+Prompt:
+
+```text
+Start from this NullPointerException stack trace, identify the exact null
+producer, and then search for structurally similar bugs.
+```
+
+Expected behavior:
+
+1. Anchor source lines to the reported revision.
+2. Confirm the immediate null path before searching broadly.
+3. Create the journal and candidate ledger.
+4. Derive a lifecycle signature from the seed.
+5. Keep causal hypotheses separate from confirmed facts.
+
+The skill must not begin with a repository-wide search for `null`.
+
+## Example 2: Reject plausible static matches
+
+Prompt:
+
+```text
+I have twenty possible NPE sites. Review them before we fix anything.
+```
+
+Expected behavior:
+
+1. Require producer, reachability, dereference, transition, and safe condition
+   for every candidate.
+2. Invoke `crusty-old-engineer` for every ledger entry.
+3. Reject lazy recreation, short-circuited access, wrong bug classes, and
+   teardown paths with no production caller.
+4. Route source-reachable but unproven entries to targeted reproduction.
+5. Start no fix workstream from static evidence alone.
+
+## Example 3: Model lifecycle ordering and fix in parallel
+
+Prompt:
+
+```text
+The validated NPE depends on a resource being replaced between animation open
+and close. Prove the fix, then repair all validated bugs in parallel.
+```
+
+Expected behavior:
+
+1. Invoke `tla-plus-expert` because resource identity and ordering are finite
+   and modelable.
+2. Produce a current-design counterexample.
+3. Check whether a null-only guard leaves an acquisition/cleanup asymmetry.
+4. Prove the proposed safety invariants within explicit model bounds.
+5. Add characterization tests before production edits.
+6. Partition validated bugs by files and shared interfaces.
+7. Launch parallel `default-workflow` workstreams only for disjoint groups.

--- a/amplifier-bundle/skills/npe-hunting-workflow/reference.md
+++ b/amplifier-bundle/skills/npe-hunting-workflow/reference.md
@@ -1,0 +1,193 @@
+# NPE Hunting Reference
+
+## Candidate Ledger
+
+Use one row per dereference site. Shared lifecycle defects may link several rows.
+
+| Field | Required content |
+| --- | --- |
+| ID | Stable identifier |
+| Region | Subsystem or module |
+| File and symbol | Exact source location |
+| Null producer | Operation that can return or assign null |
+| Consumer path | Entry point through dereference |
+| Lifecycle transition | Initialization, replacement, teardown, or callback ordering |
+| Guards | Checks and the exact property each establishes |
+| Tests | Existing coverage and bypassing fixtures |
+| False-positive case | Concrete condition that makes the path safe or unreachable |
+| Skeptical verdict | Validated, reproduce, or reject with evidence |
+| Formal decision | Required, useful, or inapplicable with reason |
+| Validation | Trace, failing test, or model counterexample |
+| Ownership | Files and interfaces assigned to a fix workstream |
+| Final disposition | Fixed, rejected, or blocked |
+
+## Process Journal Entry
+
+Record each meaningful step:
+
+```text
+Context:
+Evidence examined:
+Hypothesis:
+Probe or command:
+Result:
+Decision:
+Next step:
+Reusable heuristic:
+Failure mode or dead end:
+Verification:
+```
+
+The journal is chronological. The ledger is state-oriented. Keep both.
+
+## Lifecycle Trace Checklist
+
+For each nullable resource, answer:
+
+1. Who creates it?
+2. Can creation legitimately return null?
+3. Who stores or discovers it?
+4. What establishes readiness?
+5. Can it be replaced while work is queued?
+6. Who detaches, clears, releases, or invalidates it?
+7. Which lists, listeners, queues, caches, or parents retain reachability?
+8. Which thread or callback performs the dereference?
+9. Is the guard checking the same value and generation that is later used?
+10. Does cleanup use the identical resource acquired during setup?
+
+## Evidence Gates
+
+### Provisional candidate
+
+All must be present:
+
+- concrete null producer
+- complete source-level path
+- exact dereference
+- plausible lifecycle transition
+- falsifiable safe condition
+
+### Retained after skeptical review
+
+All must be present:
+
+- `crusty-old-engineer` verdict
+- contracts and guards challenged
+- actual failure class identified
+- smallest decisive reproduction described
+
+### Validated bug
+
+At least one:
+
+- observed production stack trace at the site
+- focused characterization test reproducing the failure
+- executable formal counterexample for a modelable lifecycle violation
+
+Source plausibility alone is not validation.
+
+### Fix eligible
+
+All must be present:
+
+- validated bug
+- characterization test in the affected repository
+- intended behavior stated
+- formal applicability decision recorded
+- owned files identified
+
+## False-Positive Filters
+
+Reject or reclassify candidates when evidence shows:
+
+- a lazy getter recreates the object instead of returning null
+- short-circuit evaluation prevents the dereference
+- the value is stale but non-null, producing a different bug class
+- the null-producing teardown operation has no production caller
+- release also unlinks the object before traversal can reach it
+- a synchronous call-order invariant initializes the value first
+- an earlier guard establishes the exact value and generation later used
+- a test double bypasses the production path under investigation
+- an assertion changes the exception only in assertion-enabled builds
+
+Assertions do not count as production null guards. Adjacent readiness checks do
+not establish the real precondition.
+
+## Formal-Method Decision
+
+### TLA+ is useful
+
+Use it when a finite lifecycle model can expose ordering defects such as:
+
+- schedule, detach, callback
+- acquire on generation A, replace with B, cleanup
+- register, release, retained listener
+- stop, restart, queued work observes another generation
+
+Model:
+
+- lifecycle states and resource identity
+- actions that add, remove, replace, schedule, and consume
+- the current design
+- the tempting minimal fix
+- the proposed invariant-preserving fix
+
+Typical safety invariants:
+
+- no null dereference
+- cleanup uses the resource acquired by setup
+- closed or released state has no residual attachment
+- queued work cannot observe another generation's resource
+
+### TLA+ is inapplicable
+
+Prefer a focused test when the defect is a direct sequential dereference with no
+meaningful state machine. Formal syntax adds no confidence to `nullable lookup ->
+unguarded call`.
+
+### Proof reporting
+
+Always report:
+
+- TLC command and result
+- counterexample trace
+- state-space bound
+- abstraction mapping to code
+- atomicity assumptions
+- safety versus liveness scope
+- memory-model limitations
+
+Do not call a bounded model check an unbounded proof.
+
+## Parallel Fix Ownership
+
+Before launching fixes, build this matrix:
+
+| Workstream | Candidates | Owned files | Shared interfaces | Dependencies |
+| --- | --- | --- | --- | --- |
+
+Two workstreams are disjoint only if they do not edit the same files and do not
+change a shared contract consumed by the other. If ownership is unclear, run
+them sequentially.
+
+Each `default-workflow` prompt must include:
+
+- validated candidate IDs
+- characterization tests
+- intended behavior
+- formal invariants and limits
+- owned and excluded files
+- targeted validation command
+
+## Completion Checklist
+
+- [ ] Seed stack trace and revision recorded
+- [ ] Immediate null path confirmed
+- [ ] Lifecycle transition explained or explicitly unresolved
+- [ ] Structural signature documented
+- [ ] Every candidate has a skeptical verdict
+- [ ] Every retained candidate has a targeted reproduction
+- [ ] Formal applicability recorded
+- [ ] Every fixed bug has a characterization and regression test
+- [ ] Parallel workstreams have disjoint ownership
+- [ ] Final ledger and journal are complete

--- a/bins/amplihack/Cargo.toml
+++ b/bins/amplihack/Cargo.toml
@@ -361,6 +361,10 @@ path = "../../tests/integration/skill_frontmatter_name_test.rs"
 name = "skill_frontmatter_type"
 path = "../../tests/integration/skill_frontmatter_type_test.rs"
 
+[[test]]
+name = "npe_hunting_skill"
+path = "../../tests/integration/npe_hunting_skill_test.rs"
+
 # QA-022: Formal specification for multitask orchestrator refactoring.
 [[test]]
 name = "multitask_orchestrator_spec"

--- a/docs/skills/SKILL_CATALOG.md
+++ b/docs/skills/SKILL_CATALOG.md
@@ -87,6 +87,7 @@ Those bundled `SKILL.md` files are the install-time source of truth.
 | `multi-repo` | `multi-repo/SKILL.md` |
 | `multitask` | `multitask/SKILL.md` |
 | `n-version-workflow` | `n-version-workflow/SKILL.md` |
+| `npe-hunting-workflow` | `npe-hunting-workflow/SKILL.md` |
 | `novelist-analyst` | `novelist-analyst/SKILL.md` |
 | `outside-in-testing` | `outside-in-testing/SKILL.md` |
 | `oxidizer-workflow` | `oxidizer-workflow/SKILL.md` |

--- a/tests/integration/npe_hunting_skill_test.rs
+++ b/tests/integration/npe_hunting_skill_test.rs
@@ -1,0 +1,156 @@
+//! Contract tests for the NPE hunting workflow skill.
+
+use std::fs;
+use std::path::PathBuf;
+
+const SKILL: &str = "amplifier-bundle/skills/npe-hunting-workflow/SKILL.md";
+const REFERENCE: &str = "amplifier-bundle/skills/npe-hunting-workflow/reference.md";
+const EXAMPLES: &str = "amplifier-bundle/skills/npe-hunting-workflow/examples.md";
+const BUNDLE: &str = "amplifier-bundle/bundle.md";
+const CATALOG: &str = "docs/skills/SKILL_CATALOG.md";
+const GUIDE: &str = "amplifier-bundle/agents/core/guide.md";
+
+fn workspace_root() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.pop();
+    path
+}
+
+fn read(relative: &str) -> String {
+    let path = workspace_root().join(relative);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn skill_is_registered_with_activation_terms() {
+    let skill = read(SKILL);
+    assert!(skill.starts_with("---\n"));
+    assert!(skill.contains("name: npe-hunting-workflow"));
+    assert!(skill.contains("NullPointerException (NPE)"));
+    assert!(skill.contains("null-dereference"));
+    assert!(read(BUNDLE).contains("npe-hunting-workflow:"));
+    assert!(read(CATALOG).contains("`npe-hunting-workflow`"));
+    assert!(read(GUIDE).contains("Guide users through the 75 available skills"));
+    assert!(read(GUIDE).contains("**Technical Skills** (20)"));
+}
+
+#[test]
+fn workflow_starts_from_evidence_and_tracks_candidates() {
+    let skill = read(SKILL);
+    for required in [
+        "Start from a real stack trace",
+        "Anchor the seed failure",
+        "Trace the nullable lifecycle",
+        "candidate ledger",
+        "false-positive condition",
+        "Do not widen the search until the immediate seed path is source-confirmed",
+        "never synthesize a trace",
+        "Independently re-derive these facts from production source",
+    ] {
+        assert!(
+            skill.contains(required),
+            "{SKILL} must contain `{required}`"
+        );
+    }
+}
+
+#[test]
+fn skeptical_review_is_a_blocking_gate_for_every_candidate() {
+    let skill = read(SKILL);
+    assert!(skill.contains("Invoke `crusty-old-engineer`"));
+    assert!(skill.contains("Require one verdict per candidate"));
+    assert!(skill.contains("No candidate may enter remediation directly from static analysis"));
+    for verdict in [
+        "VALIDATED",
+        "RETAIN_FOR_REPRODUCTION",
+        "REJECT_FALSE_POSITIVE",
+    ] {
+        assert!(skill.contains(verdict));
+    }
+}
+
+#[test]
+fn formal_gate_checks_current_minimal_and_proposed_designs() {
+    let skill = read(SKILL);
+    for required in [
+        "Invoke `tla-plus-expert`",
+        "a counterexample for the current design",
+        "the tempting minimal fix",
+        "a passing model for the proposed fix invariant",
+        "atomicity, liveness, and memory-model limits",
+        "Skip formal modeling for a direct sequential missing guard",
+        "Model replacement as a new resource identity",
+    ] {
+        assert!(
+            skill.contains(required),
+            "{SKILL} must contain `{required}`"
+        );
+    }
+}
+
+#[test]
+fn characterization_and_validation_precede_fixes() {
+    let skill = read(SKILL);
+    assert!(skill.contains("Characterize before fixing"));
+    assert!(skill.contains("skeptical review retained it"));
+    assert!(skill.contains("a characterization test captures current behavior"));
+    assert!(skill.contains("Fix only validated bugs through `default-workflow`"));
+}
+
+#[test]
+fn parallel_fixes_require_disjoint_ownership() {
+    let skill = read(SKILL);
+    assert!(skill.contains("Create an ownership matrix"));
+    assert!(skill.contains("parallel `default-workflow` workstreams only for disjoint groups"));
+    assert!(skill.contains("Run overlapping groups sequentially"));
+    assert!(read(REFERENCE).contains("Two workstreams are disjoint only if"));
+}
+
+#[test]
+fn references_capture_false_positive_and_proof_limits() {
+    let reference = read(REFERENCE);
+    for required in [
+        "a lazy getter recreates the object instead of returning null",
+        "the value is stale but non-null",
+        "the null-producing teardown operation has no production caller",
+        "Do not call a bounded model check an unbounded proof",
+        "Assertions do not count as production null guards",
+    ] {
+        assert!(
+            reference.contains(required),
+            "{REFERENCE} must contain `{required}`"
+        );
+    }
+}
+
+#[test]
+fn examples_cover_activation_falsification_and_remediation() {
+    let examples = read(EXAMPLES);
+    for section in [
+        "Example 1: Activate from an observed stack trace",
+        "Example 2: Reject plausible static matches",
+        "Example 3: Model lifecycle ordering and fix in parallel",
+    ] {
+        assert!(
+            examples.contains(section),
+            "{EXAMPLES} must contain `{section}`"
+        );
+    }
+}
+
+#[test]
+fn skill_artifacts_are_ascii_and_progressively_disclosed() {
+    let skill = read(SKILL);
+    assert!(skill.lines().count() < 500);
+    assert!(skill.contains("[reference.md](reference.md)"));
+    assert!(skill.contains("[examples.md](examples.md)"));
+
+    for artifact in [SKILL, REFERENCE, EXAMPLES] {
+        let body = read(artifact);
+        assert!(
+            body.is_ascii(),
+            "{artifact} must remain ASCII-clean for the invisible-character gate"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `npe-hunting-workflow` Agent Skill, extracted from a completed lifecycle-driven NPE investigation in `rysweet/RabbitHole`.

The skill starts from a real stack trace, derives structural nullability patterns, requires skeptical falsification of every candidate, applies formal methods when lifecycle interleavings are modelable, and permits fixes only after characterization.

## Changes

- Add specification-compliant `npe-hunting-workflow/SKILL.md`
- Add one-level `reference.md` with ledger, journal, evidence, false-positive, TLA+, and ownership templates
- Add three representative prompt examples
- Register the skill in the amplifier bundle, guide, and skill catalog
- Add nine Rust contract tests for activation and behavior gates

## Key workflow gates

- No broad search before the seed's immediate null path is confirmed
- No candidate accepted from scanner output or static plausibility alone
- `crusty-old-engineer` must return one evidence-backed verdict per candidate
- TLA+ must check current, tempting-minimal, and proposed designs when applicable
- Characterization tests precede production edits
- Parallel `default-workflow` fixes require disjoint file and shared-interface ownership
- Missing traces are reproduced or requested, never synthesized

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p amplihack --test npe_hunting_skill --test skill_frontmatter_name --test skill_frontmatter_type`
- `uvx --from skills-ref agentskills validate ./amplifier-bundle/skills/npe-hunting-workflow`

Results:

- 9 NPE skill behavior contracts passed
- 11 bundled skill-name/frontmatter contracts passed
- 4 bundled frontmatter-type contracts passed
- official Agent Skills validator accepted the skill

## Related

- `rysweet/RabbitHole#1031`

